### PR TITLE
fix(telegram): harden topic deletion authority

### DIFF
--- a/packages/coding-agent/src/sdk/bus/chat-effect-journal.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-effect-journal.ts
@@ -10,7 +10,14 @@ import {
 export const CHAT_EFFECT_JOURNAL_VERSION = 1;
 export const MAX_TERMINAL_CHAT_EFFECTS = 128;
 
-export function chatEffectJournalPath(agentDir: string, transport: "discord" | "slack"): string {
+/**
+ * Transports backed by a durable chat-effect journal. Telegram joins the union
+ * so the orphan-topic deletion claim reuses the same fsynced, generation-bound,
+ * crash-replayable durability contract as Discord/Slack provider effects.
+ */
+export type ChatEffectTransport = "discord" | "slack" | "telegram";
+
+export function chatEffectJournalPath(agentDir: string, transport: ChatEffectTransport): string {
 	return conversationStorePath(agentDir, transport, "effects.json");
 }
 
@@ -24,6 +31,12 @@ export interface ChatEffectReceipt {
 	threadId?: string;
 	timestamp?: string;
 	status?: string;
+	/**
+	 * Absolute deadline (ms epoch) a provider rate-limit (`retry_after`) backs a
+	 * nonterminal effect until. Persisted so a restart honors it before any
+	 * retried provider call instead of relying on in-memory state alone.
+	 */
+	retryAt?: number;
 }
 
 /**
@@ -33,7 +46,7 @@ export interface ChatEffectReceipt {
 export interface ChatEffect<TPayload = unknown> extends ConversationRecord {
 	id: string;
 	kind: string;
-	transport: "discord" | "slack";
+	transport: ChatEffectTransport;
 	sessionId?: string;
 	endpointGeneration: number;
 	payload: TPayload;
@@ -49,7 +62,7 @@ export interface ChatEffect<TPayload = unknown> extends ConversationRecord {
 export interface EnqueueChatEffect<TPayload> {
 	id: string;
 	kind: string;
-	transport: "discord" | "slack";
+	transport: ChatEffectTransport;
 	sessionId?: string;
 	endpointGeneration: number;
 	payload: TPayload;
@@ -123,7 +136,7 @@ export class ChatEffectJournal {
 
 	constructor(input: {
 		agentDir: string;
-		transport: "discord" | "slack";
+		transport: ChatEffectTransport;
 		fs?: ConversationStoreFs;
 		now?: () => number;
 		pid?: number;
@@ -150,7 +163,7 @@ export class ChatEffectJournal {
 		return Object.values((await this.#store.load()).conversations);
 	}
 
-	async replayable(transport: "discord" | "slack", endpointGeneration: number): Promise<ChatEffect[]> {
+	async replayable(transport: ChatEffectTransport, endpointGeneration: number): Promise<ChatEffect[]> {
 		const now = this.#now();
 		return (await this.list()).filter(
 			effect =>
@@ -339,12 +352,37 @@ export class ChatEffectJournal {
 		return terminalized;
 	}
 
+	/** Updates the receipt of an already-terminal effect without reopening it. */
+	async updateTerminalReceipt<TPayload = unknown>(
+		id: string,
+		receipt: ChatEffectReceipt,
+	): Promise<ChatEffect<TPayload> | undefined> {
+		let updated: ChatEffect<TPayload> | undefined;
+		const now = this.#now();
+		await this.#store.transact(id, current => {
+			if (current?.state !== "terminal") return current;
+			updated = {
+				...current,
+				generation: current.generation + 1,
+				receipt,
+				updatedAt: now,
+			} as ChatEffect<TPayload>;
+			return updated;
+		});
+		if (updated) await this.#pruneTerminal();
+		return updated;
+	}
+
 	async #pruneTerminal(): Promise<void> {
 		const referenced = new Set<string>();
 		for (const mapping of Object.values((await this.#mappings.load()).conversations))
 			collectEffectReferences(mapping, referenced);
 		const terminal = (await this.list())
-			.filter(effect => effect.state === "terminal")
+			.filter(
+				effect =>
+					effect.state === "terminal" &&
+					(effect.transport !== "telegram" || effect.receipt?.status?.startsWith("reconciled")),
+			)
 			.sort((left, right) => left.updatedAt - right.updatedAt);
 		for (const effect of terminal.slice(0, Math.max(0, terminal.length - MAX_TERMINAL_CHAT_EFFECTS))) {
 			if (!referenced.has(effect.id)) await this.#store.delete(effect.id, effect.generation);

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -65,7 +65,7 @@ import {
 	sessionTag,
 } from "./config";
 import { imageAttachmentsFromMessage, notificationActionPayload, summaryFromMessage } from "./helpers";
-import { ensureTelegramDaemonRunning } from "./telegram-daemon";
+import { ensureTelegramDaemonRunning, stampEndpointPublicationIdentity } from "./telegram-daemon";
 
 // ===========================================================================
 // Session lifecycle control protocol (TypeScript mirror of the Rust wire
@@ -652,29 +652,6 @@ function resolveToken(): string {
 	// `GJC_NOTIFICATIONS_TOKEN` remains an enablement compatibility flag, never
 	// a reusable endpoint credential. Every host identity gets fresh authority.
 	return crypto.randomBytes(24).toString("base64url");
-}
-
-async function stampEndpointPublicationIdentity(
-	endpointPath: string,
-	identity: { canonicalRoot: string; leaseId: string },
-): Promise<void> {
-	const raw = JSON.parse(await fs.promises.readFile(endpointPath, "utf8")) as Record<string, unknown>;
-	raw.canonicalRoot = identity.canonicalRoot;
-	raw.leaseId = identity.leaseId;
-	const tmp = `${endpointPath}.${process.pid}.${crypto.randomBytes(8).toString("hex")}.tmp`;
-	try {
-		await fs.promises.writeFile(tmp, JSON.stringify(raw), { mode: 0o600, flag: "wx" });
-		const handle = await fs.promises.open(tmp, "r");
-		try {
-			await handle.sync();
-		} finally {
-			await handle.close();
-		}
-		await fs.promises.rename(tmp, endpointPath);
-	} catch (error) {
-		await fs.promises.unlink(tmp).catch(() => undefined);
-		throw error;
-	}
 }
 
 function parseAnswer(answerJson: string): unknown {

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -654,6 +654,29 @@ function resolveToken(): string {
 	return crypto.randomBytes(24).toString("base64url");
 }
 
+async function stampEndpointPublicationIdentity(
+	endpointPath: string,
+	identity: { canonicalRoot: string; leaseId: string },
+): Promise<void> {
+	const raw = JSON.parse(await fs.promises.readFile(endpointPath, "utf8")) as Record<string, unknown>;
+	raw.canonicalRoot = identity.canonicalRoot;
+	raw.leaseId = identity.leaseId;
+	const tmp = `${endpointPath}.${process.pid}.${crypto.randomBytes(8).toString("hex")}.tmp`;
+	try {
+		await fs.promises.writeFile(tmp, JSON.stringify(raw), { mode: 0o600, flag: "wx" });
+		const handle = await fs.promises.open(tmp, "r");
+		try {
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+		await fs.promises.rename(tmp, endpointPath);
+	} catch (error) {
+		await fs.promises.unlink(tmp).catch(() => undefined);
+		throw error;
+	}
+}
+
 function parseAnswer(answerJson: string): unknown {
 	try {
 		return JSON.parse(answerJson);
@@ -2204,8 +2227,46 @@ export function createNotificationsExtension(
 		});
 
 		try {
+			// Telegram topic ownership is destructive state, so a configured session
+			// must attach its daemon and commit its registration lease before the
+			// shared SDK endpoint is published. A blocked or deferred Telegram owner
+			// fails this session start; unrelated sessions remain unaffected.
+			// Capture the exact Telegram registration identity so it can be stamped
+			// onto the endpoint file as immutable publication identity. The daemon
+			// binds this endpoint-carried identity — it never infers a lease from
+			// the registry. Declared outside the Telegram guard so the stamp runs
+			// unconditionally after the endpoint is published.
+			let registrationIdentity: { canonicalRoot: string; leaseId: string } | undefined;
+			if (notificationsEnabledForSession && settingsAvailable && settings && isTelegramConfigured(cfg)) {
+				try {
+					const telegram = await ensureTelegramDaemonRunning({
+						settings,
+						cwd: ctx.cwd,
+						sessionId: id,
+						onRegistered: identity => {
+							registrationIdentity = identity;
+						},
+					});
+					if (telegram !== "owner_spawned" && telegram !== "attached") {
+						logger.warn(`notifications: Telegram daemon registration ${telegram}; not publishing SDK endpoint`);
+						return "failed";
+					}
+				} catch (e) {
+					logger.warn(`notifications: Telegram daemon registration failed: ${String(e)}`);
+					return "failed";
+				}
+			}
 			await host.start();
 			const endpoint = await server.start();
+			// Stamp the immutable publication identity onto the just-created endpoint
+			// file BEFORE broker registration, logging, or identity frames. The native
+			// server writes the endpoint first; this read-modify-write adds
+			// canonicalRoot + leaseId so the daemon can bind and validate
+			// endpoint-carried identity (never inferring a lease from the registry).
+			if (registrationIdentity) {
+				const endpointPath = path.join(stateRoot, "sdk", `${id}.json`);
+				await stampEndpointPublicationIdentity(endpointPath, registrationIdentity);
+			}
 			const agentDir = settings?.getAgentDir?.();
 			if (agentDir) {
 				try {
@@ -2324,8 +2385,6 @@ export function createNotificationsExtension(
 
 			if (notificationsEnabledForSession && settingsAvailable && settings) {
 				try {
-					if (isTelegramConfigured(cfg))
-						await ensureTelegramDaemonRunning({ settings, cwd: ctx.cwd, sessionId: id });
 					if (isDiscordConfigured(cfg)) await ensureDiscordDaemon(settings);
 					if (isSlackConfigured(cfg)) await ensureSlackDaemon(settings);
 				} catch (e) {
@@ -2421,6 +2480,11 @@ export function createNotificationsExtension(
 			return "started";
 		} catch (e) {
 			logger.warn(`notifications: failed to start server: ${String(e)}`);
+			try {
+				server.stop();
+			} catch (stopError) {
+				logger.warn(`notifications: startup server cleanup failed: ${String(stopError)}`);
+			}
 			stopBrokerHeartbeat();
 			try {
 				await host.stop();

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -683,6 +683,33 @@ export async function registerNotificationRoot(input: {
 	// registry value later.
 	return { root, leaseId };
 }
+/**
+ * Atomically bind a just-published SDK endpoint to the exact Telegram root
+ * registration generation that authorized it. Kept in the daemon module so the
+ * production publisher and daemon tests exercise one internal implementation.
+ */
+export async function stampEndpointPublicationIdentity(
+	endpointPath: string,
+	identity: { canonicalRoot: string; leaseId: string },
+): Promise<void> {
+	const raw = JSON.parse(await fs.promises.readFile(endpointPath, "utf8")) as Record<string, unknown>;
+	raw.canonicalRoot = identity.canonicalRoot;
+	raw.leaseId = identity.leaseId;
+	const tmp = `${endpointPath}.${process.pid}.${crypto.randomBytes(8).toString("hex")}.tmp`;
+	try {
+		await fs.promises.writeFile(tmp, JSON.stringify(raw), { mode: 0o600, flag: "wx" });
+		const handle = await fs.promises.open(tmp, "r");
+		try {
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+		await fs.promises.rename(tmp, endpointPath);
+	} catch (error) {
+		await fs.promises.unlink(tmp).catch(() => undefined);
+		throw error;
+	}
+}
 
 function notificationRootForCwd(cwd: string): string {
 	return path.join(cwd, ".gjc", "state");
@@ -2193,24 +2220,38 @@ export class TelegramNotificationDaemon {
 				name: "session_closed",
 				matches: msg => msg.type === "session_closed",
 				handle: async session => {
-					this.closingSessions.add(session.sessionId);
-					this.busy.delete(session.sessionId);
-					this.closedEndpointKeys.set(session.sessionId, session.endpointKey);
+					// Waiting for an already-started topic creation is not a close
+					// mutation. Do it before admission locking, then revalidate the exact
+					// socket/root/lease/endpoint tuple under the lock.
 					await this.topicCreations.get(session.sessionId)?.catch(() => undefined);
-					// Close-path deletion authority uses ONLY the socket's BOUND
-					// admission lease (canonicalRoot, leaseId, endpoint incarnation
-					// stamped from the endpoint file at admission). NEVER re-read the
-					// current registry lease. A predecessor socket bound to an older
-					// lease cannot delete/compact under a successor lease: the durable
-					// performTopicDeletion path re-validates the bound lease against
-					// the live registry under the admission lock and short-circuits as
-					// "superseded" when they differ (no provider deletion, no
-					// compaction, no generation restoration).
 					const closeLeaseId = session.leaseId;
-					if (isNonEmptyString(closeLeaseId)) {
-						await this.deleteTopic(session.sessionId, closeLeaseId);
+					const authorized = await this.withCurrentSessionAuthorization(session, async () => {
+						// Persist a session/topic/lease-scoped deletion intent before any
+						// session-global mutation. Once the admission lock is released, a
+						// successor registration observes this unreconciled intent and
+						// cannot interleave with the destructive close path.
+						if (isNonEmptyString(closeLeaseId)) {
+							await this.enqueueTopicDeletionIntent(session.sessionId, closeLeaseId);
+						}
+						this.closingSessions.add(session.sessionId);
+						this.busy.delete(session.sessionId);
+						this.closedEndpointKeys.set(session.sessionId, session.endpointKey);
+					});
+					if (!authorized) {
+						// A predecessor close arriving after successor publication is a
+						// no-op for successor/global state: only its own socket is closed.
+						this.dropSession(session, "session_closed_superseded");
+						return;
 					}
-					this.dropSession(session, "session_closed");
+					try {
+						if (isNonEmptyString(closeLeaseId)) {
+							await this.deleteTopic(session.sessionId, closeLeaseId);
+						}
+					} finally {
+						// Local durability failures stay observable, but the fenced
+						// predecessor socket must never remain attached in memory.
+						this.dropSession(session, "session_closed");
+					}
 				},
 			});
 	}
@@ -2428,8 +2469,17 @@ export class TelegramNotificationDaemon {
 		// registry lease — a mismatch means a successor registration won.
 		const toRevoke: Array<{ sock: SessionSocket; reason: string }> = [];
 		for (const [sessionId, sock] of this.sessions) {
+			if (ambiguousSessions.has(sessionId)) {
+				// Every ambiguous endpoint classification revokes the attached
+				// current socket: missing identity, malformed/unreadable endpoint,
+				// mapped-root/lease mismatch, and duplicate conflict. (The duplicate
+				// conflict was revoked inline above and removed from the map, so only
+				// the remaining ambiguous forms reach here.) No ambiguous endpoint may
+				// keep control of a topic or its delivery — fail closed.
+				toRevoke.push({ sock, reason: "ambiguous_endpoint" });
+				continue;
+			}
 			if (this.fencedTopicGeneration.has(sessionId)) continue;
-			if (ambiguousSessions.has(sessionId)) continue; // already revoked above
 			const currentLease = view.sessionLeases.get(sessionId)?.leaseId;
 			const mappedRoot = view.sessions.get(sessionId);
 			const matchingEndpoint = liveBySession
@@ -2542,6 +2592,28 @@ export class TelegramNotificationDaemon {
 		} catch {
 			return false;
 		}
+	}
+	private async withCurrentSessionAuthorization(
+		session: SessionSocket,
+		action: () => Promise<void>,
+	): Promise<boolean> {
+		// Cheap map-identity precheck avoids acquiring the lock for a socket that
+		// is already replaced; the check is repeated inside the lock. The action
+		// runs before releasing the lock, keeping exact socket/root/lease/endpoint
+		// authority atomic with all session-global close mutations.
+		if (this.sessions.get(session.sessionId) !== session) return false;
+		let authorized = false;
+		await withFileLock(
+			telegramAdmissionLockPath(this.opts.settings.getAgentDir(), session.sessionId),
+			async () => {
+				if (this.sessions.get(session.sessionId) !== session) return;
+				if (!(await this.sessionAdmissionIsCurrent(session))) return;
+				authorized = true;
+				await action();
+			},
+			{ staleMs: 10_000 },
+		);
+		return authorized;
 	}
 
 	private async sendToCurrentSession(session: SessionSocket, frame: Record<string, unknown>): Promise<boolean> {
@@ -2670,14 +2742,14 @@ export class TelegramNotificationDaemon {
 	 * (so a delayed old close cannot delete a replacement), and best-effort closes
 	 * the socket. `scanRoots()` then reconnects the session.
 	 */
-	private dropSession(session: SessionSocket, reason: string): void {
+	private dropSession(session: SessionSocket, _reason: string): void {
 		const clearIntervalImpl = this.opts.clearIntervalImpl ?? clearInterval;
 		if (session.pingTimer) {
 			clearIntervalImpl(session.pingTimer);
 			session.pingTimer = undefined;
 		}
 		const isCurrentSession = this.sessions.get(session.sessionId) === session;
-		if (isCurrentSession || reason === "session_closed") {
+		if (isCurrentSession) {
 			this.deleteMessageRoutes(session.sessionId);
 		}
 		if (isCurrentSession) {
@@ -2956,6 +3028,20 @@ export class TelegramNotificationDaemon {
 		return next;
 	}
 
+	private async enqueueTopicDeletionIntent(sessionId: string, leaseId: string): Promise<void> {
+		const record = this.topics.get(sessionId);
+		if (!record || !isCanonicalTopicId(record.topicId)) return;
+		const generation = this.liveTopicGeneration.get(sessionId) ?? 0;
+		await this.deletionJournal.enqueue<TelegramTopicDeletePayload>({
+			id: topicDeleteEffectId(sessionId, record.topicId, leaseId),
+			kind: TELEGRAM_TOPIC_DELETE_KIND,
+			transport: "telegram",
+			sessionId,
+			endpointGeneration: generation,
+			payload: { chatId: this.opts.chatId, topicId: record.topicId, leaseId },
+		});
+	}
+
 	/**
 	 * Best-effort, crash-safe delete of a session topic. The send admission fence
 	 * is raised FIRST (no late submitThreadedFrame/continuation can target the
@@ -2997,7 +3083,16 @@ export class TelegramNotificationDaemon {
 		const outcome = await this.performTopicDeletion(sessionId, record.topicId, generation, leaseId);
 		if (outcome === "terminal") {
 			this.finalizeTopicDeletion(sessionId);
-			await this.persistTopics().catch(() => undefined);
+			// Local topic-registry removal must persist successfully BEFORE roots
+			// compaction and before the journal receipt becomes reconciled. A failed
+			// write leaves the durable claim terminal-but-not-reconciled so a
+			// restart (reconcileDeletionJournal) finishes local cleanup without
+			// another destructive provider delete.
+			try {
+				await this.persistTopics();
+			} catch {
+				return;
+			}
 			// Selective roots compaction: remove ONLY the exact matching
 			// candidate/lease/session mapping. A fresh registration whose lease
 			// differs survives (re-read durably under the roots lock).
@@ -3031,72 +3126,71 @@ export class TelegramNotificationDaemon {
 		let lease: ChatEffectLease | undefined;
 		let terminal = false;
 		let superseded = false;
-		await withFileLock(
-			telegramAdmissionLockPath(this.opts.settings.getAgentDir(), sessionId),
-			async () => {
-				const roots = await readRootsRegistry(this.fsImpl, daemonPaths(this.opts.settings.getAgentDir()).roots);
-				if (roots.sessionLeases.get(sessionId)?.leaseId !== leaseId) {
-					superseded = true;
-					return;
-				}
+		const establishClaim = async () => {
+			const roots = await readRootsRegistry(this.fsImpl, daemonPaths(this.opts.settings.getAgentDir()).roots);
+			if (roots.sessionLeases.get(sessionId)?.leaseId !== leaseId) {
+				superseded = true;
+				return;
+			}
 
-				let existing = await this.deletionJournal.read<TelegramTopicDeletePayload>(effectId);
-				if (
-					existing &&
-					(existing.transport !== "telegram" ||
-						existing.kind !== TELEGRAM_TOPIC_DELETE_KIND ||
-						existing.sessionId !== sessionId ||
-						!isTelegramTopicDeletePayload(existing.payload) ||
-						existing.payload.chatId !== payload.chatId ||
-						existing.payload.topicId !== payload.topicId ||
-						existing.payload.leaseId !== payload.leaseId)
-				) {
-					return;
-				}
-				const now = this.runtime.now();
-				const memRetryUntil = this.deletionRetryAfter.get(sessionId);
-				if (memRetryUntil !== undefined && now < memRetryUntil) return;
-				const durableRetryAt = existing?.receipt?.retryAt;
-				if (typeof durableRetryAt === "number" && Number.isFinite(durableRetryAt) && now < durableRetryAt) {
-					this.deletionRetryAfter.set(sessionId, durableRetryAt);
-					return;
-				}
-				if (existing?.state === "terminal") {
-					terminal = true;
-					return;
-				}
+			let existing = await this.deletionJournal.read<TelegramTopicDeletePayload>(effectId);
+			if (
+				existing &&
+				(existing.transport !== "telegram" ||
+					existing.kind !== TELEGRAM_TOPIC_DELETE_KIND ||
+					existing.sessionId !== sessionId ||
+					!isTelegramTopicDeletePayload(existing.payload) ||
+					existing.payload.chatId !== payload.chatId ||
+					existing.payload.topicId !== payload.topicId ||
+					existing.payload.leaseId !== payload.leaseId)
+			) {
+				return;
+			}
+			const now = this.runtime.now();
+			const memRetryUntil = this.deletionRetryAfter.get(sessionId);
+			if (memRetryUntil !== undefined && now < memRetryUntil) return;
+			const durableRetryAt = existing?.receipt?.retryAt;
+			if (typeof durableRetryAt === "number" && Number.isFinite(durableRetryAt) && now < durableRetryAt) {
+				this.deletionRetryAfter.set(sessionId, durableRetryAt);
+				return;
+			}
+			if (existing?.state === "terminal") {
+				terminal = true;
+				return;
+			}
 
-				if (!existing) {
-					const created = await this.deletionJournal.enqueueAndClaim<TelegramTopicDeletePayload>(
-						{
-							id: effectId,
-							kind: TELEGRAM_TOPIC_DELETE_KIND,
-							transport: "telegram",
-							sessionId,
-							endpointGeneration: generation,
-							payload,
-						},
-						this.opts.ownerId,
-						TELEGRAM_DELETION_LEASE_MS,
-					);
-					if (created) {
-						existing = created;
-						lease = { owner: this.opts.ownerId, epoch: created.epoch };
-					}
+			if (!existing) {
+				const created = await this.deletionJournal.enqueueAndClaim<TelegramTopicDeletePayload>(
+					{
+						id: effectId,
+						kind: TELEGRAM_TOPIC_DELETE_KIND,
+						transport: "telegram",
+						sessionId,
+						endpointGeneration: generation,
+						payload,
+					},
+					this.opts.ownerId,
+					TELEGRAM_DELETION_LEASE_MS,
+				);
+				if (created) {
+					existing = created;
+					lease = { owner: this.opts.ownerId, epoch: created.epoch };
 				}
-				if (!lease && existing) {
-					const claimed = await this.deletionJournal.claim<TelegramTopicDeletePayload>(
-						effectId,
-						this.opts.ownerId,
-						TELEGRAM_DELETION_LEASE_MS,
-					);
-					if (claimed?.state === "leased") {
-						lease = { owner: this.opts.ownerId, epoch: claimed.epoch };
-					}
+			}
+			if (!lease && existing) {
+				const claimed = await this.deletionJournal.claim<TelegramTopicDeletePayload>(
+					effectId,
+					this.opts.ownerId,
+					TELEGRAM_DELETION_LEASE_MS,
+				);
+				if (claimed?.state === "leased") {
+					lease = { owner: this.opts.ownerId, epoch: claimed.epoch };
 				}
-			},
-			{ staleMs: 10_000 },
-		);
+			}
+		};
+		await withFileLock(telegramAdmissionLockPath(this.opts.settings.getAgentDir(), sessionId), establishClaim, {
+			staleMs: 10_000,
+		});
 		if (terminal) return "terminal";
 		if (superseded) return "superseded";
 		if (!lease) return "uncertain";
@@ -3295,7 +3389,15 @@ export class TelegramNotificationDaemon {
 				this.fencedTopicIds.add(payload.topicId);
 				if (leaseMatches && record?.topicId === payload.topicId) {
 					this.finalizeTopicDeletion(sessionId);
-					await this.persistTopics().catch(() => undefined);
+					// Topic-registry removal must persist before compaction and
+					// before the receipt becomes reconciled. A failed write leaves
+					// the terminal claim non-reconciled so a later restart retries
+					// local cleanup without another provider delete.
+					try {
+						await this.persistTopics();
+					} catch {
+						continue;
+					}
 				}
 				if (leaseMatches) {
 					await this.compactRootsAfterDeletion(sessionId, payload.topicId, payload.leaseId);
@@ -3330,7 +3432,11 @@ export class TelegramNotificationDaemon {
 			);
 			if (outcome === "terminal") {
 				this.finalizeTopicDeletion(sessionId);
-				await this.persistTopics().catch(() => undefined);
+				try {
+					await this.persistTopics();
+				} catch {
+					continue;
+				}
 				await this.compactRootsAfterDeletion(sessionId, record.topicId, payload.leaseId);
 				await this.deletionJournal.updateTerminalReceipt(effect.id, {
 					provider: "telegram",

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -8,7 +8,7 @@ import { withFileLock } from "../../config/file-lock";
 import type { Settings } from "../../config/settings";
 import type { DaemonRuntimeInfo } from "../../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../../daemon/runtime";
-import { type ChatEffect, ChatEffectJournal, type ChatEffectLease } from "./chat-effect-journal";
+import { ChatEffectJournal, type ChatEffectLease } from "./chat-effect-journal";
 import { getNotificationConfig, isTelegramConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand, parseRichToggleCommand, parseTelegramControlCommand } from "./config-commands";
 import { daemonPaths, HEARTBEAT_TTL_MS } from "./daemon-paths";
@@ -594,11 +594,51 @@ const TELEGRAM_TOPIC_DELETE_KIND = "telegram.topic_delete";
 const TELEGRAM_DELETION_LEASE_MS = 60_000;
 const TELEGRAM_DELETION_RETRY_MS = 1_000;
 
-function topicDeleteEffectId(sessionId: string, topicId: string, leaseId: string): string {
+function topicDeleteEffectId(chatId: string, sessionId: string, topicId: string, leaseId: string): string {
 	// Scope terminal effects to the exact registration generation. Reusing a
 	// session or topic id under a fresh lease must never inherit an old terminal
-	// deletion record.
-	return `${TELEGRAM_TOPIC_DELETE_KIND}:${sessionId}:${topicId}:${leaseId}`;
+	// deletion record. The chat identity is embedded so a current-chat deletion
+	// can never collide with a prior-chat effect for the same session/topic/lease.
+	return `${TELEGRAM_TOPIC_DELETE_KIND}:${chatId}:${sessionId}:${topicId}:${leaseId}`;
+}
+/**
+ * Tri-state classification of durable roots-registry authority for a deletion
+ * claim. Exact current requires a successfully read, structurally valid registry
+ * with a valid session mapping and a matching lease. Superseded requires a
+ * successfully read, structurally valid registry whose valid current lease/mapping
+ * differ from the claim, positively proving a successor. A missing file, an
+ * absent session entry, malformed top-level/fields, corrupt JSON, unreadable I/O,
+ * or an ambiguous identity is UNKNOWN — fail-closed.
+ */
+type DeletionAuthorityEvidence = "exact_current" | "superseded" | "unknown";
+
+async function evaluateDeletionAuthority(
+	fsImpl: TelegramDaemonFs,
+	rootsFile: string,
+	sessionId: string,
+	leaseId: string,
+): Promise<DeletionAuthorityEvidence> {
+	let parsed: unknown;
+	try {
+		parsed = await readJson<unknown>(fsImpl, rootsFile);
+	} catch {
+		// Corrupt JSON, unreadable I/O, or any non-ENOENT read failure: UNKNOWN.
+		return "unknown";
+	}
+	// Missing file (ENOENT) is UNKNOWN: neither a successor nor the current authority can be proven.
+	if (parsed === undefined) return "unknown";
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return "unknown";
+	const raw = parsed as Record<string, unknown>;
+	const sessionLeases = parseSessionLeases(raw.sessionLeases);
+	const sessions = parseStringRecord(raw.sessions);
+	const lease = sessionLeases.get(sessionId);
+	const mappedRoot = sessions.get(sessionId);
+	// Absent session entry is UNKNOWN: cannot prove a successor or current authority.
+	if (!lease || !mappedRoot) return "unknown";
+	if (lease.leaseId === leaseId) return "exact_current";
+	// A structurally valid registry with a nonmatching current lease + mapping
+	// positively proves a successor registration.
+	return "superseded";
 }
 /** Payload of a telegram topic-delete effect. Provider identifiers only. */
 interface TelegramTopicDeletePayload {
@@ -616,6 +656,28 @@ function isTelegramTopicDeletePayload(value: unknown): value is TelegramTopicDel
 	const payload = value as Partial<TelegramTopicDeletePayload>;
 	return isNonEmptyString(payload.chatId) && isCanonicalTopicId(payload.topicId) && isNonEmptyString(payload.leaseId);
 }
+/**
+ * Result of acquiring durable deletion authority under the per-session admission
+ * lock (phase 1). `prepared` carries the exact effect id/payload/lease a caller
+ * may apply a fence and call Telegram with; `terminal` reports an already
+ * exact-current terminal claim whose local cleanup may be finished without a
+ * provider call; `quarantined` marks a malformed/prior-chat effect for a
+ * non-destructive terminal receipt (no provider/fence/topic removal/compaction);
+ * `deferred` withholds ALL successor-sensitive mutation
+ * (unknown/superseded/backoff/unclaimable). The fence, queue cancellation,
+ * drain, and provider call run ONLY after a `prepared`/`terminal` result.
+ */
+type DeletionAuthority =
+	| {
+			status: "prepared";
+			effectId: string;
+			payload: TelegramTopicDeletePayload;
+			lease: ChatEffectLease;
+			generation: number;
+	  }
+	| { status: "terminal"; effectId: string; payload: TelegramTopicDeletePayload }
+	| { status: "quarantined"; effectId: string }
+	| { status: "deferred"; reason: "unknown" | "superseded" | "backoff" | "unclaimable" };
 /** True while a topic deletion has not completed local crash reconciliation. */
 async function hasUnreconciledDeletionClaim(agentDir: string, sessionId: string): Promise<boolean> {
 	const journal = new ChatEffectJournal({ agentDir, transport: "telegram" });
@@ -705,6 +767,12 @@ export async function stampEndpointPublicationIdentity(
 			await handle.close();
 		}
 		await fs.promises.rename(tmp, endpointPath);
+		const directory = await fs.promises.open(path.dirname(endpointPath), "r");
+		try {
+			await directory.sync();
+		} finally {
+			await directory.close();
+		}
 	} catch (error) {
 		await fs.promises.unlink(tmp).catch(() => undefined);
 		throw error;
@@ -1552,7 +1620,7 @@ export class TelegramNotificationDaemon {
 	/** Per-session 429 retry_after backoff deadline (ms via opts.now). Seeded from
 	 * the DURABLY persisted deletion-effect receipt on re-entry/restart so a
 	 * crash never forgets an outstanding `retry_after` before re-calling the
-	 * provider. See {@link performTopicDeletion}. */
+	 * provider. See {@link TelegramNotificationDaemon.acquireDeletionAuthority}. */
 	private readonly deletionRetryAfter = new Map<string, number>();
 	/**
 	 * Durable, fsynced per-session topic-deletion claim journal (F003/F004).
@@ -2575,7 +2643,14 @@ export class TelegramNotificationDaemon {
 
 	private async sessionAdmissionIsCurrent(session: SessionSocket): Promise<boolean> {
 		if (!isNonEmptyString(session.canonicalRoot) || !isNonEmptyString(session.leaseId)) return false;
-		const view = await readRootsRegistry(this.fsImpl, daemonPaths(this.opts.settings.getAgentDir()).roots);
+		let view: RootsRegistryView;
+		try {
+			view = await readRootsRegistry(this.fsImpl, daemonPaths(this.opts.settings.getAgentDir()).roots);
+		} catch {
+			// Corrupt or unreadable registry authority is unknown. Fail closed
+			// without turning an expected evidence failure into an unhandled route error.
+			return false;
+		}
 		if (
 			view.sessions.get(session.sessionId) !== session.canonicalRoot ||
 			view.sessionLeases.get(session.sessionId)?.leaseId !== session.leaseId
@@ -3033,7 +3108,7 @@ export class TelegramNotificationDaemon {
 		if (!record || !isCanonicalTopicId(record.topicId)) return;
 		const generation = this.liveTopicGeneration.get(sessionId) ?? 0;
 		await this.deletionJournal.enqueue<TelegramTopicDeletePayload>({
-			id: topicDeleteEffectId(sessionId, record.topicId, leaseId),
+			id: topicDeleteEffectId(this.opts.chatId, sessionId, record.topicId, leaseId),
 			kind: TELEGRAM_TOPIC_DELETE_KIND,
 			transport: "telegram",
 			sessionId,
@@ -3043,160 +3118,207 @@ export class TelegramNotificationDaemon {
 	}
 
 	/**
-	 * Best-effort, crash-safe delete of a session topic. The send admission fence
-	 * is raised FIRST (no late submitThreadedFrame/continuation can target the
-	 * topic), queued items are cancelled, the pool is drained OUTSIDE any
-	 * registry lock, then the remote delete runs through the durable deletion
-	 * claim (fsynced intent before the call, terminal recorded before local
-	 * forgetting). `leaseId` is the persisted registration lease this deletion is
-	 * authorized under; it scopes the topic-specific effect and selective roots
-	 * compaction so a fresh registration (different lease) is never compacted. A
-	 * topic left by an uncertain/429 delete keeps its fence and is retried by the
-	 * next scan; a resumed session receives a fresh generation.
+	 * Crash-safe delete of a session topic, split into two phases so NO
+	 * successor-sensitive mutation can occur before exact durable authority is
+	 * acquired. PHASE 1 runs under the per-session admission lock: it validates
+	 * exact-current root/session/lease authority (tri-state fail-closed) and
+	 * atomically establishes/claims the durable deletion effect, returning a
+	 * typed prepared authority (effect id/payload/lease) or a terminal/quarantined
+	 * status. Only after the lock releases does PHASE 2 raise the send-admission
+	 * fence, cancel queued sends, drain in-flight operations, and call Telegram
+	 * with the prepared lease — provider I/O stays outside the lock. If authority
+	 * is unknown/superseded/backoff/unclaimable the call returns WITHOUT any
+	 * successor-sensitive mutation (no fence, no queue/ack cancellation, no
+	 * flush/drain, no provider call). `leaseId` is the persisted registration
+	 * lease this deletion is authorized under; it scopes the topic-specific effect
+	 * and selective roots compaction so a fresh registration is never compacted.
 	 */
 	private async deleteTopic(sessionId: string, leaseId: string): Promise<void> {
 		if (!isNonEmptyString(leaseId)) return;
 		const record = this.topics.get(sessionId);
 		if (!record || !isCanonicalTopicId(record.topicId)) return;
-		// FENCE: invalidate the live generation so new submits/requeues are
-		// rejected and every in-flight delivery revalidates and skips. A
-		// post-fence enqueue cannot target the old topic: admissionGeneration()
-		// is undefined while fenced, so it is stamped with a later generation.
-		this.fencedTopicGeneration.set(sessionId, this.liveTopicGeneration.get(sessionId) ?? 0);
+		const generation = this.liveTopicGeneration.get(sessionId) ?? 0;
+		// PHASE 1: acquire durable authority under the admission lock BEFORE any
+		// fence, queue removal, ack cancellation, flush, drain, or provider call.
+		const authority = await this.acquireDeletionAuthority(sessionId, record.topicId, leaseId, generation);
+		if (authority.status === "deferred") {
+			// unknown/superseded/backoff/unclaimable: NO successor-sensitive mutation.
+			return;
+		}
+		if (authority.status === "quarantined") {
+			// A malformed/prior-chat effect is terminalized with a non-destructive
+			// reconciled-quarantine receipt: NO provider call, fence, topic removal,
+			// or roots compaction, and it no longer blocks current-session registration.
+			await this.quarantineDeletionEffect(authority.effectId);
+			return;
+		}
+		// PHASE 2 (lock-free): raise the fence, cancel queued sends, drain, then
+		// call Telegram with the prepared lease. Provider I/O never holds the lock.
+		this.fencedTopicGeneration.set(sessionId, generation);
 		this.liveTopicGeneration.delete(sessionId);
 		this.fencedTopicIds.add(record.topicId);
-		// CANCEL queued sends for this session before deleting the topic;
-		// otherwise rate-limited frames can flush into a deleted topic or across
-		// resume.
 		const removed = this.pool.removeWhere(item => item.sessionId === sessionId);
 		for (const item of removed) {
 			if (item.payload.selectedAck)
 				this.finishSelectedAck(item.payload.selectedAck, { status: "failed", reason: "cancelled" });
 		}
-		// DRAIN outside registry locks: let any in-flight flush complete. Granted
-		// items revalidate against the (now-removed) live generation and skip.
 		await this.flushPool();
 		await this.drainTopicOperations(sessionId);
-		// DELETE via the durable claim. Terminal remote success is recorded before
-		// local forgetting; an uncertain/429 outcome retains the claim for retry.
-		const generation = this.fencedTopicGeneration.get(sessionId) ?? 0;
-		const outcome = await this.performTopicDeletion(sessionId, record.topicId, generation, leaseId);
-		if (outcome === "terminal") {
+		if (authority.status === "terminal") {
+			// Exact-current terminal claim: finish local cleanup WITHOUT a provider call.
 			this.finalizeTopicDeletion(sessionId);
-			// Local topic-registry removal must persist successfully BEFORE roots
-			// compaction and before the journal receipt becomes reconciled. A failed
-			// write leaves the durable claim terminal-but-not-reconciled so a
-			// restart (reconcileDeletionJournal) finishes local cleanup without
-			// another destructive provider delete.
 			try {
 				await this.persistTopics();
 			} catch {
 				return;
 			}
-			// Selective roots compaction: remove ONLY the exact matching
-			// candidate/lease/session mapping. A fresh registration whose lease
-			// differs survives (re-read durably under the roots lock).
 			await this.compactRootsAfterDeletion(sessionId, record.topicId, leaseId);
-			await this.deletionJournal.updateTerminalReceipt<TelegramTopicDeletePayload>(
-				topicDeleteEffectId(sessionId, record.topicId, leaseId),
-				{ provider: "telegram", status: "reconciled" },
-			);
-		} else if (outcome === "superseded" && this.topics.get(sessionId)?.topicId === record.topicId) {
-			this.assignTopicGeneration(sessionId);
+			await this.deletionJournal.updateTerminalReceipt(authority.effectId, {
+				provider: "telegram",
+				status: "reconciled",
+			});
+			return;
+		}
+		// authority.status === "prepared": call Telegram, then finish local cleanup.
+		const outcome = await this.executeTopicDeletion(authority, sessionId);
+		if (outcome === "terminal") {
+			this.finalizeTopicDeletion(sessionId);
+			// Local topic-registry removal must persist successfully BEFORE roots
+			// compaction and before the journal receipt becomes reconciled. A failed
+			// write leaves the durable claim terminal-but-not-reconciled so a restart
+			// (reconcileDeletionJournal) finishes local cleanup without another delete.
+			try {
+				await this.persistTopics();
+			} catch {
+				return;
+			}
+			await this.compactRootsAfterDeletion(sessionId, record.topicId, leaseId);
+			await this.deletionJournal.updateTerminalReceipt(authority.effectId, {
+				provider: "telegram",
+				status: "reconciled",
+			});
 		}
 	}
 
 	/**
-	 * Establish/reuse the durable deletion claim, call `deleteForumTopic` with
-	 * `noRetry` and a bounded AbortSignal, and record terminal/uncertain state.
-	 * Returns "terminal" when the topic is confirmed deleted (or already
-	 * deleted), "uncertain" when the call must be retried (429/abort/transport).
-	 * `leaseId` is recorded in the payload so crash replay and compaction can
-	 * validate exact session/topic/lease; the effect id is topic-scoped so a
-	 * terminal record for a superseded topic never applies here.
+	 * PHASE 1 acquisition (under the per-session admission lock). Validates exact
+	 * current root/session/lease authority via the tri-state evaluator and
+	 * atomically establishes/claims the durable deletion effect. Returns a
+	 * `prepared` authority (effect id/payload/lease) for an acquired claim, a
+	 * `terminal` status for an already exact-current terminal claim, a
+	 * `quarantined` status for a malformed/prior-chat effect, or `deferred`
+	 * (unknown/superseded/backoff/unclaimable) which withholds ALL mutation. No
+	 * provider call, fence, queue cancellation, flush, or drain is ever made here.
 	 */
-	private async performTopicDeletion(
+	private async acquireDeletionAuthority(
 		sessionId: string,
 		topicId: string,
-		generation: number,
 		leaseId: string,
-	): Promise<"terminal" | "uncertain" | "superseded"> {
-		const effectId = topicDeleteEffectId(sessionId, topicId, leaseId);
+		generation: number,
+	): Promise<DeletionAuthority> {
+		const effectId = topicDeleteEffectId(this.opts.chatId, sessionId, topicId, leaseId);
 		const payload: TelegramTopicDeletePayload = { chatId: this.opts.chatId, topicId, leaseId };
-		let lease: ChatEffectLease | undefined;
-		let terminal = false;
-		let superseded = false;
-		const establishClaim = async () => {
-			const roots = await readRootsRegistry(this.fsImpl, daemonPaths(this.opts.settings.getAgentDir()).roots);
-			if (roots.sessionLeases.get(sessionId)?.leaseId !== leaseId) {
-				superseded = true;
-				return;
-			}
-
-			let existing = await this.deletionJournal.read<TelegramTopicDeletePayload>(effectId);
-			if (
-				existing &&
-				(existing.transport !== "telegram" ||
-					existing.kind !== TELEGRAM_TOPIC_DELETE_KIND ||
-					existing.sessionId !== sessionId ||
-					!isTelegramTopicDeletePayload(existing.payload) ||
-					existing.payload.chatId !== payload.chatId ||
-					existing.payload.topicId !== payload.topicId ||
-					existing.payload.leaseId !== payload.leaseId)
-			) {
-				return;
-			}
-			const now = this.runtime.now();
-			const memRetryUntil = this.deletionRetryAfter.get(sessionId);
-			if (memRetryUntil !== undefined && now < memRetryUntil) return;
-			const durableRetryAt = existing?.receipt?.retryAt;
-			if (typeof durableRetryAt === "number" && Number.isFinite(durableRetryAt) && now < durableRetryAt) {
-				this.deletionRetryAfter.set(sessionId, durableRetryAt);
-				return;
-			}
-			if (existing?.state === "terminal") {
-				terminal = true;
-				return;
-			}
-
-			if (!existing) {
-				const created = await this.deletionJournal.enqueueAndClaim<TelegramTopicDeletePayload>(
-					{
-						id: effectId,
-						kind: TELEGRAM_TOPIC_DELETE_KIND,
-						transport: "telegram",
-						sessionId,
-						endpointGeneration: generation,
-						payload,
-					},
-					this.opts.ownerId,
-					TELEGRAM_DELETION_LEASE_MS,
-				);
-				if (created) {
-					existing = created;
-					lease = { owner: this.opts.ownerId, epoch: created.epoch };
+		let authority: DeletionAuthority = { status: "deferred", reason: "unclaimable" };
+		await withFileLock(
+			telegramAdmissionLockPath(this.opts.settings.getAgentDir(), sessionId),
+			async () => {
+				const rootsFile = daemonPaths(this.opts.settings.getAgentDir()).roots;
+				const evidence = await evaluateDeletionAuthority(this.fsImpl, rootsFile, sessionId, leaseId);
+				// UNKNOWN preserves the claim untouched; superseded is positively proven.
+				if (evidence !== "exact_current") {
+					authority = { status: "deferred", reason: evidence };
+					return;
 				}
-			}
-			if (!lease && existing) {
-				const claimed = await this.deletionJournal.claim<TelegramTopicDeletePayload>(
-					effectId,
-					this.opts.ownerId,
-					TELEGRAM_DELETION_LEASE_MS,
-				);
-				if (claimed?.state === "leased") {
-					lease = { owner: this.opts.ownerId, epoch: claimed.epoch };
+				let existing = await this.deletionJournal.read<TelegramTopicDeletePayload>(effectId);
+				// An existing effect whose immutable payload is foreign, malformed, or
+				// belongs to a different/prior chat is quarantined, never replayed/claimed.
+				if (
+					existing &&
+					(existing.transport !== "telegram" ||
+						existing.kind !== TELEGRAM_TOPIC_DELETE_KIND ||
+						existing.sessionId !== sessionId ||
+						!isTelegramTopicDeletePayload(existing.payload) ||
+						existing.payload.chatId !== payload.chatId ||
+						existing.payload.topicId !== payload.topicId ||
+						existing.payload.leaseId !== payload.leaseId)
+				) {
+					authority = { status: "quarantined", effectId };
+					return;
 				}
-			}
-		};
-		await withFileLock(telegramAdmissionLockPath(this.opts.settings.getAgentDir(), sessionId), establishClaim, {
-			staleMs: 10_000,
-		});
-		if (terminal) return "terminal";
-		if (superseded) return "superseded";
-		if (!lease) return "uncertain";
-		const result = await this.callDeleteForumTopic(topicId);
+				const now = this.runtime.now();
+				const memRetryUntil = this.deletionRetryAfter.get(sessionId);
+				if (typeof memRetryUntil === "number" && now < memRetryUntil) {
+					authority = { status: "deferred", reason: "backoff" };
+					return;
+				}
+				const durableRetryAt = existing?.receipt?.retryAt;
+				if (typeof durableRetryAt === "number" && Number.isFinite(durableRetryAt) && now < durableRetryAt) {
+					this.deletionRetryAfter.set(sessionId, durableRetryAt);
+					authority = { status: "deferred", reason: "backoff" };
+					return;
+				}
+				if (existing?.state === "terminal") {
+					authority = { status: "terminal", effectId, payload };
+					return;
+				}
+				let lease: ChatEffectLease | undefined;
+				if (!existing) {
+					const created = await this.deletionJournal.enqueueAndClaim<TelegramTopicDeletePayload>(
+						{
+							id: effectId,
+							kind: TELEGRAM_TOPIC_DELETE_KIND,
+							transport: "telegram",
+							sessionId,
+							endpointGeneration: generation,
+							payload,
+						},
+						this.opts.ownerId,
+						TELEGRAM_DELETION_LEASE_MS,
+					);
+					if (created) {
+						existing = created;
+						lease = { owner: this.opts.ownerId, epoch: created.epoch };
+					}
+				}
+				if (!lease && existing) {
+					const claimed = await this.deletionJournal.claim<TelegramTopicDeletePayload>(
+						effectId,
+						this.opts.ownerId,
+						TELEGRAM_DELETION_LEASE_MS,
+					);
+					if (claimed?.state === "leased") {
+						lease = { owner: this.opts.ownerId, epoch: claimed.epoch };
+					}
+				}
+				if (!lease) {
+					authority = { status: "deferred", reason: "unclaimable" };
+					return;
+				}
+				authority = { status: "prepared", effectId, payload, lease, generation };
+			},
+			{ staleMs: 10_000 },
+		);
+		return authority;
+	}
+
+	/**
+	 * PHASE 2 (lock-free): call `deleteForumTopic` once with the prepared lease and
+	 * record terminal/uncertain state. Returns "terminal" only when the provider
+	 * confirms the delete (`res.ok === true`); every non-OK response, throw,
+	 * abort, and timeout is "uncertain" (429 preserves retry_after).
+	 */
+	private async executeTopicDeletion(
+		authority: {
+			status: "prepared";
+			effectId: string;
+			payload: TelegramTopicDeletePayload;
+			lease: ChatEffectLease;
+		},
+		sessionId: string,
+	): Promise<"terminal" | "uncertain"> {
+		const result = await this.callDeleteForumTopic(authority.payload.topicId);
 		if (result.outcome === "deleted") {
-			await this.deletionJournal.record(effectId, lease, "terminal", {
+			await this.deletionJournal.record(authority.effectId, authority.lease, "terminal", {
 				provider: "telegram",
 				status: "deleted",
 			});
@@ -3210,7 +3332,7 @@ export class TelegramNotificationDaemon {
 				? this.runtime.now() + result.retryAfterSec * 1000
 				: this.runtime.now() + TELEGRAM_DELETION_RETRY_MS;
 		this.deletionRetryAfter.set(sessionId, retryAt);
-		await this.deletionJournal.record(effectId, lease, "uncertain", {
+		await this.deletionJournal.record(authority.effectId, authority.lease, "uncertain", {
 			provider: "telegram",
 			status: result.retryAfterSec ? `retry_after:${result.retryAfterSec}` : "uncertain",
 			retryAt,
@@ -3220,8 +3342,9 @@ export class TelegramNotificationDaemon {
 
 	/**
 	 * Call `deleteForumTopic` once with `noRetry` and a bounded AbortSignal.
-	 * Honors Telegram `parameters.retry_after` and reconciles an already-applied
-	 * delete (topic/message-thread not found) as success.
+	 * Fail-closed: `deleted` is returned ONLY for `res.ok === true`. Every non-OK
+	 * response (including not-found/already-deleted/TOPIC_CLOSED), throw, abort,
+	 * and timeout is `uncertain`; a 429 preserves the exact `retry_after`.
 	 */
 	private async callDeleteForumTopic(
 		topicId: string,
@@ -3240,15 +3363,11 @@ export class TelegramNotificationDaemon {
 				description?: string;
 				parameters?: { retry_after?: unknown };
 			};
+			// The ONLY positive deletion signal is an explicit OK. Any non-OK body —
+			// even a not-found/already-deleted/TOPIC_CLOSED description — is ambiguous:
+			// the topic id may have been reused, the chat may have changed, or the
+			// response may be a transport-level fabrication. Re-attempt later.
 			if (res?.ok === true) return { outcome: "deleted" };
-			const description = String(res?.description ?? "");
-			// Already-applied delete (topic/thread no longer exists) reconciles as success.
-			if (
-				res?.ok === false &&
-				/not found|already deleted|message thread not found|topic deleted/i.test(description)
-			) {
-				return { outcome: "deleted" };
-			}
 			// 429 rate limit: honor retry_after, retain uncertain for re-attempt.
 			if (res?.ok === false && (res.error_code === 429 || res.parameters?.retry_after !== undefined)) {
 				const retryAfter = Number(res.parameters?.retry_after);
@@ -3360,89 +3479,92 @@ export class TelegramNotificationDaemon {
 		}
 	}
 
+	private async quarantineDeletionEffect(effectId: string): Promise<void> {
+		const effect = await this.deletionJournal.read(effectId);
+		if (!effect) return;
+		const receipt = { provider: "telegram", status: "reconciled_quarantine" };
+		if (effect.state === "terminal") {
+			await this.deletionJournal.updateTerminalReceipt(effectId, receipt);
+			return;
+		}
+		const lease =
+			effect.state === "leased" && isNonEmptyString(effect.owner)
+				? { owner: effect.owner, epoch: effect.epoch }
+				: undefined;
+		await this.deletionJournal.terminalize(effectId, receipt, lease);
+	}
+
 	/**
 	 * F004 crash reconciliation of the durable deletion journal, run once at
-	 * startup after topics are loaded. It validates EXACT session/topic/lease for
-	 * every effect: a terminal claim completes local cleanup WITHOUT calling
-	 * Telegram again and compacts roots for its exact lease; a nonterminal claim
-	 * for a superseded topic/gone topic is terminalized; otherwise the remote
-	 * delete is re-attempted (honoring the durable retry_after).
+	 * startup after topics are loaded. Every effect is classified by tri-state
+	 * durable authority evidence: UNKNOWN preserves the claim untouched (no
+	 * provider call, no fence, no topic removal, no roots compaction, and it keeps
+	 * blocking registration); a positively proven SUPERSEDED claim is terminalized
+	 * with a non-destructive reconciled-superseded receipt; an EXACT-CURRENT
+	 * terminal claim finishes local cleanup WITHOUT calling Telegram again; and an
+	 * exact-current nonterminal claim is replayed through the unified deletion flow
+	 * (which re-acquires authority — and its backoff — before any fence or provider
+	 * call). A prior-chat effect is quarantined with a non-destructive
+	 * reconciled-quarantine receipt so it never blocks current-session registration.
 	 */
 	private async reconcileDeletionJournal(): Promise<void> {
 		const effects = (await this.deletionJournal.list()).filter(
-			(e): e is ChatEffect<TelegramTopicDeletePayload> =>
+			e =>
 				e.transport === "telegram" &&
 				e.kind === TELEGRAM_TOPIC_DELETE_KIND &&
-				isTelegramTopicDeletePayload(e.payload) &&
 				(e.state !== "terminal" || !e.receipt?.status?.startsWith("reconciled")),
 		);
+		const rootsFile = daemonPaths(this.opts.settings.getAgentDir()).roots;
 		for (const effect of effects) {
 			const sessionId = effect.sessionId;
-			if (!sessionId || effect.payload.chatId !== this.opts.chatId) continue;
+			if (!sessionId || !isTelegramTopicDeletePayload(effect.payload)) {
+				await this.quarantineDeletionEffect(effect.id);
+				continue;
+			}
 			const payload = effect.payload;
+			const expectedEffectId = topicDeleteEffectId(payload.chatId, sessionId, payload.topicId, payload.leaseId);
+			// Foreign chat, malformed identity, and legacy/colliding identifiers are
+			// quarantined non-destructively. None may authorize a provider call or
+			// current-chat topic/root mutation.
+			if (payload.chatId !== this.opts.chatId || effect.id !== expectedEffectId) {
+				await this.quarantineDeletionEffect(effect.id);
+				continue;
+			}
+			const evidence = await evaluateDeletionAuthority(this.fsImpl, rootsFile, sessionId, payload.leaseId);
+			// Requirement 2: UNKNOWN preserves the claim untouched and keeps blocking.
+			if (evidence === "unknown") continue;
+			if (evidence === "superseded") {
+				// Positively proven successor: terminalize non-destructively.
+				await this.deletionJournal
+					.terminalize(effect.id, { provider: "telegram", status: "reconciled_superseded" })
+					.catch(() => undefined);
+				continue;
+			}
 			const record = this.topics.get(sessionId);
-			const roots = await readRootsRegistry(this.fsImpl, daemonPaths(this.opts.settings.getAgentDir()).roots);
-			const currentLease = roots.sessionLeases.get(sessionId)?.leaseId;
-			const leaseMatches = currentLease === undefined || currentLease === payload.leaseId;
-
 			if (effect.state === "terminal") {
+				// EXACT-CURRENT terminal: finish local cleanup without a provider call.
 				this.fencedTopicIds.add(payload.topicId);
-				if (leaseMatches && record?.topicId === payload.topicId) {
+				if (record?.topicId === payload.topicId) {
 					this.finalizeTopicDeletion(sessionId);
-					// Topic-registry removal must persist before compaction and
-					// before the receipt becomes reconciled. A failed write leaves
-					// the terminal claim non-reconciled so a later restart retries
-					// local cleanup without another provider delete.
+					// Topic-registry removal must persist before compaction and before the
+					// receipt becomes reconciled. A failed write leaves the terminal claim
+					// non-reconciled so a later restart retries local cleanup without a delete.
 					try {
 						await this.persistTopics();
 					} catch {
 						continue;
 					}
 				}
-				if (leaseMatches) {
-					await this.compactRootsAfterDeletion(sessionId, payload.topicId, payload.leaseId);
-				}
-				await this.deletionJournal.updateTerminalReceipt(effect.id, {
-					provider: "telegram",
-					status: leaseMatches ? "reconciled" : "reconciled_superseded",
-				});
-				continue;
-			}
-
-			// Never replay a nonterminal delete against a different registration
-			// generation. Terminalizing it releases the admission barrier without a
-			// second provider call.
-			if (!currentLease || currentLease !== payload.leaseId || record?.topicId !== payload.topicId) {
-				await this.deletionJournal
-					.terminalize(effect.id, { provider: "telegram", status: "reconciled_superseded" })
-					.catch(() => undefined);
-				continue;
-			}
-			this.fencedTopicGeneration.set(
-				sessionId,
-				this.liveTopicGeneration.get(sessionId) ?? effect.endpointGeneration,
-			);
-			this.liveTopicGeneration.delete(sessionId);
-			this.fencedTopicIds.add(payload.topicId);
-			const outcome = await this.performTopicDeletion(
-				sessionId,
-				record.topicId,
-				effect.endpointGeneration,
-				payload.leaseId,
-			);
-			if (outcome === "terminal") {
-				this.finalizeTopicDeletion(sessionId);
-				try {
-					await this.persistTopics();
-				} catch {
-					continue;
-				}
-				await this.compactRootsAfterDeletion(sessionId, record.topicId, payload.leaseId);
+				await this.compactRootsAfterDeletion(sessionId, payload.topicId, payload.leaseId);
 				await this.deletionJournal.updateTerminalReceipt(effect.id, {
 					provider: "telegram",
 					status: "reconciled",
 				});
+				continue;
 			}
+			// EXACT-CURRENT nonterminal: replay through the unified deletion flow,
+			// which re-acquires authority (and honors backoff) before any fence/call.
+			await this.deleteTopic(sessionId, payload.leaseId);
 		}
 	}
 	/**

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -8,6 +8,7 @@ import { withFileLock } from "../../config/file-lock";
 import type { Settings } from "../../config/settings";
 import type { DaemonRuntimeInfo } from "../../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../../daemon/runtime";
+import { type ChatEffect, ChatEffectJournal, type ChatEffectLease } from "./chat-effect-journal";
 import { getNotificationConfig, isTelegramConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand, parseRichToggleCommand, parseTelegramControlCommand } from "./config-commands";
 import { daemonPaths, HEARTBEAT_TTL_MS } from "./daemon-paths";
@@ -60,7 +61,7 @@ import { decideThreadedInbound, type InboundAttachment } from "./threaded-inboun
 import { renderThreadedFrame, type ThreadedSend } from "./threaded-render";
 import { TopicRegistry, type TopicRegistryState } from "./topic-registry";
 
-export type EnsureDaemonResult = "owner_spawned" | "attached" | "disabled" | "blocked";
+export type EnsureDaemonResult = "owner_spawned" | "attached" | "disabled" | "blocked" | "deferred";
 
 export interface DaemonState {
 	pid: number;
@@ -87,9 +88,16 @@ export interface TelegramDaemonFs {
 	writeFile(path: string, data: string, opts?: fs.WriteFileOptions): Promise<void>;
 	rename(oldPath: string, newPath: string): Promise<void>;
 	unlink(path: string): Promise<void>;
-	open(path: string, flags: string, mode?: number): Promise<{ close(): Promise<void> }>;
+	open(path: string, flags: string, mode?: number): Promise<{ close(): Promise<void>; sync?(): Promise<void> }>;
 	readdir(path: string): Promise<string[]>;
 	chmod(path: string, mode: number): Promise<void>;
+	/**
+	 * Optional realpath resolver. Existing roots and the longest existing ancestor
+	 * of a missing root are canonicalized so symlink workspaces collapse to one
+	 * stable identity before and after directory creation. Every non-ENOENT
+	 * resolution failure is ambiguous and fails closed.
+	 */
+	realpath?(path: string): Promise<string>;
 }
 
 export interface SpawnResult {
@@ -176,6 +184,9 @@ const QUEUED_REACTION = "👀";
 const PENDING_TOPIC_FRAME_LIMIT = 20;
 const SEEN_UPDATE_ID_LIMIT = 1_000;
 const ORPHAN_TOPIC_GRACE_MS = 60_000;
+// Bounded AbortSignal timeout for a single deleteForumTopic call so a stalled
+// provider I/O cannot hang the daemon or hold a deletion claim indefinitely.
+const TOPIC_DELETE_TIMEOUT_MS = 15_000;
 const CONSUMED_REACTION = "✅";
 
 function splitTelegramPlainText(text: string, max = TELEGRAM_MESSAGE_LIMIT): string[] {
@@ -295,10 +306,32 @@ async function readJson<T>(fsImpl: TelegramDaemonFs, file: string): Promise<T | 
 }
 
 async function writeJsonAtomic(fsImpl: TelegramDaemonFs, file: string, data: unknown): Promise<void> {
+	const dir = path.dirname(file);
 	const tmp = `${file}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
-	await fsImpl.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
-	await fsImpl.chmod(tmp, 0o600).catch(() => undefined);
-	await fsImpl.rename(tmp, file);
+	try {
+		await fsImpl.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
+		await fsImpl.chmod(tmp, 0o600).catch(() => undefined);
+		// Fsync the temp file (data) and, after the atomic rename, the parent
+		// directory (directory entry) so a crash never leaves a half-written or
+		// unlinked file. Mirrors the ConversationStore durability contract; the
+		// optional sync() is absent only on injected test fs implementations.
+		const fileHandle = await fsImpl.open(tmp, "r");
+		try {
+			await fileHandle.sync?.();
+		} finally {
+			await fileHandle.close();
+		}
+		await fsImpl.rename(tmp, file);
+		const dirHandle = await fsImpl.open(dir, "r");
+		try {
+			await dirHandle.sync?.();
+		} finally {
+			await dirHandle.close();
+		}
+	} catch (error) {
+		await fsImpl.unlink(tmp).catch(() => undefined);
+		throw error;
+	}
 }
 
 async function tryOpenWx(fsImpl: TelegramDaemonFs, file: string): Promise<boolean> {
@@ -312,36 +345,390 @@ async function tryOpenWx(fsImpl: TelegramDaemonFs, file: string): Promise<boolea
 	}
 }
 
+/**
+ * Per-session registration lease. Refreshed with a fresh random `leaseId` on
+ * every {@link registerNotificationRoot} so a same-session re-registration
+ * invalidates any orphan candidate an older registration established. The
+ * daemon never reaps a topic whose candidate lease no longer matches the live
+ * lease — a fresh registration (session restart) cancels a stale reap.
+ */
+interface SessionLease {
+	leaseId: string;
+	refreshedAt: number;
+}
+
+/**
+ * Per-session orphan-topic deletion candidate. Recorded on the first confirmed
+ * continuous absence; a topic is reaped only once this candidate has survived
+ * {@link ORPHAN_TOPIC_GRACE_MS} from `observedAt` AND its lease still matches
+ * the live session lease (no intervening registration/publication).
+ */
+interface OrphanCandidate {
+	observedAt: number;
+	leaseId: string;
+	topicId: string;
+}
+
+/**
+ * Validated, decision-only view over the raw notification-roots registry. The
+ * raw object is carried verbatim through every read-modify-write so unknown,
+ * legacy, or unrelated fields survive; only strictly-valid entries populate the
+ * decision maps — ambiguous/malformed/legacy state never authorizes a deletion.
+ */
+interface RootsRegistryView {
+	raw: Record<string, unknown>;
+	roots: string[];
+	sessions: Map<string, string>;
+	sessionLeases: Map<string, SessionLease>;
+	orphanCandidates: Map<string, OrphanCandidate>;
+}
+/**
+ * Per-session absence evidence derived from a session's MAPPED root during a
+ * roots scan (F001). Decides whether an absence candidate may be created or
+ * continued: only `absent`/`missing` authorize it; `present` clears it, and
+ * `ambiguous` (unreadable/malformed mapped root) clears/defers it so an
+ * unreadable root can never be mistaken for confirmed absence.
+ */
+type SessionAbsenceEvidence = { kind: "present" } | { kind: "absent" } | { kind: "missing" } | { kind: "ambiguous" };
+
+/** Non-empty string scalar: every registry id (leaseId, map key) must be one. */
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0;
+}
+
+/** Non-negative safe-integer scalar: every registry timestamp must be one. */
+function isNonNegativeSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+/**
+ * Canonical positive safe-integer string scalar: every candidate topicId must
+ * be one. Rejects zero, negatives, fractions, leading zeros, whitespace,
+ * exponents, and any non-digit, so a malformed candidate id can never match a
+ * live topic record and authorize a destructive delete.
+ */
+function isCanonicalTopicId(value: unknown): value is string {
+	if (typeof value !== "string" || !/^[1-9][0-9]*$/.test(value)) return false;
+	return Number.isSafeInteger(Number(value));
+}
+/** True only for a definitive "no such file or directory" filesystem error. */
+function isENOENTError(err: unknown): boolean {
+	return err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function parseRootsList(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const roots: string[] = [];
+	for (const entry of value) if (typeof entry === "string" && entry.length > 0) roots.push(entry);
+	return roots;
+}
+
+function parseStringRecord(value: unknown): Map<string, string> {
+	const map = new Map<string, string>();
+	if (!value || typeof value !== "object" || Array.isArray(value)) return map;
+	for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+		if (isNonEmptyString(key) && typeof val === "string") map.set(key, val);
+	}
+	return map;
+}
+
+function parseSessionLeases(value: unknown): Map<string, SessionLease> {
+	const map = new Map<string, SessionLease>();
+	if (!value || typeof value !== "object" || Array.isArray(value)) return map;
+	for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+		if (!isNonEmptyString(key) || !val || typeof val !== "object" || Array.isArray(val)) continue;
+		const lease = val as { leaseId?: unknown; refreshedAt?: unknown };
+		if (!isNonEmptyString(lease.leaseId) || !isNonNegativeSafeInteger(lease.refreshedAt)) continue;
+		map.set(key, { leaseId: lease.leaseId, refreshedAt: lease.refreshedAt });
+	}
+	return map;
+}
+
+function parseOrphanCandidates(value: unknown): Map<string, OrphanCandidate> {
+	const map = new Map<string, OrphanCandidate>();
+	if (!value || typeof value !== "object" || Array.isArray(value)) return map;
+	for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+		if (!isNonEmptyString(key) || !val || typeof val !== "object" || Array.isArray(val)) continue;
+		const candidate = val as { observedAt?: unknown; leaseId?: unknown; topicId?: unknown };
+		if (
+			!isNonNegativeSafeInteger(candidate.observedAt) ||
+			!isNonEmptyString(candidate.leaseId) ||
+			!isCanonicalTopicId(candidate.topicId)
+		)
+			continue;
+		map.set(key, {
+			observedAt: candidate.observedAt,
+			leaseId: candidate.leaseId,
+			topicId: candidate.topicId,
+		});
+	}
+	return map;
+}
+
+async function readRootsRegistry(fsImpl: TelegramDaemonFs, rootsFile: string): Promise<RootsRegistryView> {
+	const parsed = await readJson<unknown>(fsImpl, rootsFile);
+	const raw: Record<string, unknown> =
+		parsed && typeof parsed === "object" && !Array.isArray(parsed) ? { ...(parsed as Record<string, unknown>) } : {};
+	return {
+		raw,
+		roots: parseRootsList(raw.roots),
+		sessions: parseStringRecord(raw.sessions),
+		sessionLeases: parseSessionLeases(raw.sessionLeases),
+		orphanCandidates: parseOrphanCandidates(raw.orphanCandidates),
+	};
+}
+
+/**
+ * Persist the raw roots registry verbatim; only the schema `version` is
+ * normalized. Every other key — known or unknown, well-formed or legacy — is
+ * carried through untouched so unknown registry fields survive every write.
+ */
+async function persistRootsRegistry(
+	fsImpl: TelegramDaemonFs,
+	rootsFile: string,
+	raw: Record<string, unknown>,
+): Promise<void> {
+	raw.version = 1;
+	await writeJsonAtomic(fsImpl, rootsFile, raw);
+}
+
+/** Return the live raw object held at `key`, or a fresh object when the field is
+ * absent or not a plain object. Callers mutate it in place and reassign it. */
+function rawObjectField(raw: Record<string, unknown>, key: string): Record<string, unknown> {
+	const existing = raw[key];
+	return existing && typeof existing === "object" && !Array.isArray(existing)
+		? (existing as Record<string, unknown>)
+		: {};
+}
+
+function addRawRoot(raw: Record<string, unknown>, root: string): void {
+	const existing = raw.roots;
+	const arr = Array.isArray(existing) ? existing : [];
+	if (arr.indexOf(root) !== -1) return;
+	const next = arr.slice();
+	next.push(root);
+	raw.roots = next;
+}
+
+function setRawSessionMapping(raw: Record<string, unknown>, sessionId: string, root: string): void {
+	const map = rawObjectField(raw, "sessions");
+	map[sessionId] = root;
+	raw.sessions = map;
+}
+
+function setRawLease(raw: Record<string, unknown>, sessionId: string, lease: SessionLease): void {
+	const map = rawObjectField(raw, "sessionLeases");
+	map[sessionId] = { leaseId: lease.leaseId, refreshedAt: lease.refreshedAt };
+	raw.sessionLeases = map;
+}
+
+function deleteRawLease(raw: Record<string, unknown>, sessionId: string): boolean {
+	const map = rawObjectField(raw, "sessionLeases");
+	if (!(sessionId in map)) return false;
+	delete map[sessionId];
+	raw.sessionLeases = map;
+	return true;
+}
+/** Remove a session→root mapping verbatim; returns whether it existed. */
+function deleteRawSessionMapping(raw: Record<string, unknown>, sessionId: string): boolean {
+	const map = rawObjectField(raw, "sessions");
+	if (!(sessionId in map)) return false;
+	delete map[sessionId];
+	raw.sessions = map;
+	return true;
+}
+
+function deleteRawRootIfUnreferenced(raw: Record<string, unknown>, root: string): boolean {
+	const sessions = raw.sessions;
+	if (!sessions || typeof sessions !== "object" || Array.isArray(sessions)) return false;
+	if (Object.values(sessions as Record<string, unknown>).some(value => value === root)) return false;
+	if (!Array.isArray(raw.roots)) return false;
+	const next = raw.roots.filter(value => value !== root);
+	if (next.length === raw.roots.length) return false;
+	raw.roots = next;
+	return true;
+}
+
+function setRawCandidate(raw: Record<string, unknown>, sessionId: string, candidate: OrphanCandidate): void {
+	const map = rawObjectField(raw, "orphanCandidates");
+	map[sessionId] = {
+		observedAt: candidate.observedAt,
+		leaseId: candidate.leaseId,
+		topicId: candidate.topicId,
+	};
+	raw.orphanCandidates = map;
+}
+
+function deleteRawCandidate(raw: Record<string, unknown>, sessionId: string): boolean {
+	const map = rawObjectField(raw, "orphanCandidates");
+	if (!(sessionId in map)) return false;
+	delete map[sessionId];
+	raw.orphanCandidates = map;
+	return true;
+}
+
+/**
+ * Run a roots-registry mutation under the bounded host-wide roots file lock. The
+ * lock is held ONLY for the read-modify-write (bounded retries); callers MUST
+ * NOT perform root inventory reads, pool flushes, or network calls inside
+ * `mutate` — those run lock-free so a stalled deletion never blocks the host.
+ */
+async function mutateRootsRegistry(
+	fsImpl: TelegramDaemonFs,
+	rootsFile: string,
+	mutate: (view: RootsRegistryView) => boolean,
+): Promise<void> {
+	await withFileLock(
+		rootsFile,
+		async () => {
+			const view = await readRootsRegistry(fsImpl, rootsFile);
+			if (mutate(view)) await persistRootsRegistry(fsImpl, rootsFile, view.raw);
+		},
+		{ staleMs: 10_000 },
+	);
+}
+
+/** Effect kind + id for a per-session telegram forum-topic deletion claim. */
+const TELEGRAM_TOPIC_DELETE_KIND = "telegram.topic_delete";
+/** Lease a deletion claim long enough for a bounded remote delete + crash window. */
+const TELEGRAM_DELETION_LEASE_MS = 60_000;
+const TELEGRAM_DELETION_RETRY_MS = 1_000;
+
+function topicDeleteEffectId(sessionId: string, topicId: string, leaseId: string): string {
+	// Scope terminal effects to the exact registration generation. Reusing a
+	// session or topic id under a fresh lease must never inherit an old terminal
+	// deletion record.
+	return `${TELEGRAM_TOPIC_DELETE_KIND}:${sessionId}:${topicId}:${leaseId}`;
+}
+/** Payload of a telegram topic-delete effect. Provider identifiers only. */
+interface TelegramTopicDeletePayload {
+	chatId: string;
+	topicId: string;
+	/**
+	 * Persisted registration lease this deletion was authorized under. Crash
+	 * replay and selective roots compaction validate it so a fresh registration
+	 * (different lease) is never compacted or short-circuited.
+	 */
+	leaseId: string;
+}
+function isTelegramTopicDeletePayload(value: unknown): value is TelegramTopicDeletePayload {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const payload = value as Partial<TelegramTopicDeletePayload>;
+	return isNonEmptyString(payload.chatId) && isCanonicalTopicId(payload.topicId) && isNonEmptyString(payload.leaseId);
+}
+/** True while a topic deletion has not completed local crash reconciliation. */
+async function hasUnreconciledDeletionClaim(agentDir: string, sessionId: string): Promise<boolean> {
+	const journal = new ChatEffectJournal({ agentDir, transport: "telegram" });
+	const effects = await journal.list();
+	return effects.some(
+		e =>
+			e.transport === "telegram" &&
+			e.kind === TELEGRAM_TOPIC_DELETE_KIND &&
+			e.sessionId === sessionId &&
+			(e.state !== "terminal" || !e.receipt?.status?.startsWith("reconciled")),
+	);
+}
+class TelegramDeletionInProgressError extends Error {}
+
+function telegramAdmissionLockPath(agentDir: string, sessionId: string): string {
+	const key = crypto.createHash("sha256").update(sessionId).digest("hex").slice(0, 32);
+	return path.join(daemonPaths(agentDir).dir, `telegram-admission-${key}`);
+}
+
 export async function registerNotificationRoot(input: {
 	settings: Settings;
 	cwd: string;
 	sessionId: string;
 	fs?: TelegramDaemonFs;
-}): Promise<string> {
+	now?: () => number;
+	randomId?: () => string;
+}): Promise<{ root: string; leaseId: string }> {
 	const fsImpl = input.fs ?? nodeFs;
 	const paths = daemonPaths(input.settings.getAgentDir());
 	await ensureDir(fsImpl, paths.dir);
-	const root = notificationRootForCwd(input.cwd);
+	// Canonicalize the workspace first so a not-yet-created state directory still
+	// inherits realpath identity from a symlinked workspace. Canonicalize the full
+	// root again when it already exists (including a symlinked state directory).
+	const root = await canonicalNotificationRoot(fsImpl, input.cwd);
+	const now = input.now ?? Date.now;
+	// A FRESH leaseId on every registration is the registration generation: it
+	// invalidates any orphan candidate an older registration established, so a
+	// session restart cancels a stale reap. Idempotent re-registrations refresh
+	// the same lease slot under the bounded roots lock.
+	const leaseId = input.randomId?.() ?? crypto.randomBytes(12).toString("base64url");
+	const refreshedAt = now();
+	if (!isNonEmptyString(leaseId) || !isNonNegativeSafeInteger(refreshedAt)) {
+		throw new Error("Telegram notification root registration requires a valid lease");
+	}
+	let deletionInProgress = false;
 	await withFileLock(
-		paths.roots,
+		telegramAdmissionLockPath(input.settings.getAgentDir(), input.sessionId),
 		async () => {
-			const current =
-				(await readJson<{ roots?: string[]; sessions?: Record<string, string> }>(fsImpl, paths.roots)) ?? {};
-			const roots = new Set(current.roots ?? []);
-			roots.add(root);
-			await writeJsonAtomic(fsImpl, paths.roots, {
-				version: 1,
-				roots: Array.from(roots).sort(),
-				sessions: { ...(current.sessions ?? {}), [input.sessionId]: root },
+			if (await hasUnreconciledDeletionClaim(input.settings.getAgentDir(), input.sessionId)) {
+				deletionInProgress = true;
+				return;
+			}
+			await mutateRootsRegistry(fsImpl, paths.roots, view => {
+				addRawRoot(view.raw, root);
+				setRawSessionMapping(view.raw, input.sessionId, root);
+				setRawLease(view.raw, input.sessionId, { leaseId, refreshedAt });
+				return true;
 			});
 		},
 		{ staleMs: 10_000 },
 	);
-	return root;
+	if (deletionInProgress) throw new TelegramDeletionInProgressError();
+	// Return the exact admission identity (canonical root + lease) so callers
+	// propagate the bound generation rather than re-reading an unbound current
+	// registry value later.
+	return { root, leaseId };
 }
 
 function notificationRootForCwd(cwd: string): string {
 	return path.join(cwd, ".gjc", "state");
+}
+/**
+ * Canonicalize an authority path through its longest existing ancestor, so a
+ * workspace/state directory that is created after registration retains the
+ * same identity (including `/var`→`/private/var`-style host aliases). Every
+ * non-ENOENT resolution failure is ambiguous and fails closed.
+ */
+async function canonicalizePath(fsImpl: TelegramDaemonFs, target: string): Promise<string> {
+	const lexical = path.resolve(target);
+	const realpath = fsImpl.realpath;
+	if (!realpath) return lexical;
+	const missingParts: string[] = [];
+	let cursor = lexical;
+	while (true) {
+		try {
+			const canonicalAncestor = await realpath(cursor);
+			return path.join(canonicalAncestor, ...missingParts);
+		} catch (error) {
+			if (!isENOENTError(error)) throw error;
+			const parent = path.dirname(cursor);
+			if (parent === cursor) return lexical;
+			missingParts.unshift(path.basename(cursor));
+			cursor = parent;
+		}
+	}
+}
+
+async function canonicalNotificationRoot(fsImpl: TelegramDaemonFs, cwd: string): Promise<string> {
+	const canonicalCwd = await canonicalizePath(fsImpl, cwd);
+	return canonicalizePath(fsImpl, notificationRootForCwd(canonicalCwd));
+}
+
+/**
+ * Admission identity bound immutably to a connected {@link SessionSocket} at
+ * connect time. The close/delete path uses these bound values and NEVER
+ * re-reads the current registry, so a predecessor socket cannot be upgraded by
+ * a successor registration's lease/root.
+ */
+interface SessionAdmissionIdentity {
+	/** Realpath-equivalent root this socket was admitted under. */
+	canonicalRoot: string;
+	/** Registration lease stamped at admission (registration generation). */
+	leaseId: string;
 }
 
 function ownerIdentityMatches(state: DaemonState, tokenFingerprint: string, chatId: string): boolean {
@@ -689,13 +1076,48 @@ export async function spawnTelegramDaemonOwner(
 }
 
 export async function ensureTelegramDaemonRunning(
-	input: { settings: Settings; cwd: string; sessionId: string },
+	input: {
+		settings: Settings;
+		cwd: string;
+		sessionId: string;
+		/**
+		 * Synchronous callback invoked with the exact registration identity
+		 * `{canonicalRoot, leaseId}` immediately after the registration lease is
+		 * committed, BEFORE this function returns. The caller uses it to stamp the
+		 * immutable publication identity onto the endpoint file so the daemon
+		 * binds endpoint-carried identity rather than inferring a lease from the
+		 * registry. Not invoked when registration is deferred/blocked/disabled.
+		 */
+		onRegistered?: (identity: { canonicalRoot: string; leaseId: string }) => void;
+	},
 	deps: TelegramDaemonDeps = {},
 ): Promise<EnsureDaemonResult> {
 	const cfg = getNotificationConfig(input.settings);
 	if (!isTelegramConfigured(cfg)) return "disabled";
-	const root = notificationRootForCwd(input.cwd);
+	const agentDir = input.settings.getAgentDir();
+	// Use the same two-step canonical state-root identity as registration.
+	const fsImpl = deps.fs ?? nodeFs;
+	const root = await canonicalNotificationRoot(fsImpl, input.cwd);
 	const fp = tokenFingerprint(cfg.botToken);
+
+	// An unresolved claim must have a daemon owner available to finish crash
+	// reconciliation, but the caller must not publish a fresh endpoint yet.
+	if (await hasUnreconciledDeletionClaim(agentDir, input.sessionId)) {
+		const recoveryOwner = await spawnTelegramDaemonOwner(
+			{ settings: input.settings, roots: [root], tokenFingerprint: fp, chatId: cfg.chatId },
+			deps,
+		);
+		if (recoveryOwner.result === "blocked") {
+			logger.warn(`notifications: failed to ensure Telegram daemon: ${recoveryOwner.warnings.join("; ")}`);
+			return "blocked";
+		}
+		if (recoveryOwner.reloadRequired) await reloadStaleGenerationOwner(input.settings, deps);
+		logger.warn(
+			`notifications: deferring Telegram daemon registration for ${input.sessionId}: topic deletion reconciliation in progress`,
+		);
+		return "deferred";
+	}
+
 	const spawned = await spawnTelegramDaemonOwner(
 		{ settings: input.settings, roots: [root], tokenFingerprint: fp, chatId: cfg.chatId },
 		deps,
@@ -704,18 +1126,25 @@ export async function ensureTelegramDaemonRunning(
 		logger.warn(`notifications: failed to ensure Telegram daemon: ${spawned.warnings.join("; ")}`);
 		return spawned.result;
 	}
+	// Commit the registration lease only after ownership/attachment succeeds and
+	// before the caller publishes its SDK endpoint. A mismatched live owner must
+	// not leave behind a root or lease that can later authorize cleanup.
+	try {
+		const registration = await registerNotificationRoot({ ...input, fs: deps.fs });
+		// Propagate the exact admission identity synchronously so the caller
+		// stamps it onto the endpoint file BEFORE any broker registration or
+		// identity frame. The daemon binds this endpoint-carried identity, never
+		// inferring a lease from the current registry.
+		input.onRegistered?.({ canonicalRoot: registration.root, leaseId: registration.leaseId });
+	} catch (error) {
+		if (error instanceof TelegramDeletionInProgressError) return "deferred";
+		throw error;
+	}
 	if (spawned.reloadRequired) {
-		// A still-live owner is running an OLDER daemon generation than this host
-		// (e.g. a pre-upgrade daemon reused in place across an in-place upgrade).
-		// Attaching would silently drop this host's newer ask-ack / control frames,
-		// so register this session's root first — so the replacement daemon serves
-		// it — then hand off through the tested SIGTERM/control reload path to bring
-		// up a fresh current-generation daemon.
-		await registerNotificationRoot({ ...input, fs: deps.fs });
+		// The replacement daemon reads the registration committed above.
 		await reloadStaleGenerationOwner(input.settings, deps);
 		return "owner_spawned";
 	}
-	await registerNotificationRoot({ ...input, fs: deps.fs });
 	return spawned.result;
 }
 
@@ -911,7 +1340,7 @@ export class TelegramUpdatePoller {
 /** Mutable dispatch state shared by session frames and inbound Telegram updates. */
 export class TelegramEventDispatchState {
 	readonly busy = new Set<string>();
-	readonly inboundReactions = new Map<number, { messageId: number }>();
+	readonly inboundReactions = new Map<number, { messageId: number; sessionId: string; generation: number }>();
 	readonly seenUpdateIds = new Set<number>();
 }
 
@@ -965,12 +1394,38 @@ export interface TelegramDaemonOptions {
 	 * built-in `{repo}/{branch} - {title}` composition and its fallbacks.
 	 */
 	topics?: { nameTemplate?: string };
+	/**
+	 * Bounded AbortSignal timeout (ms) for a single `deleteForumTopic` call.
+	 * Defaults to {@link TOPIC_DELETE_TIMEOUT_MS}. Injectable so tests drive the
+	 * deletion-timeout seam deterministically.
+	 */
+	topicDeleteTimeoutMs?: number;
+	/**
+	 * Injectable durable deletion-claim journal (per-session topic-delete state
+	 * machine). Defaults to a {@link ChatEffectJournal} rooted at the canonical
+	 * `agentDir/sdk/daemons/telegram` store. Tests inject a shared journal to
+	 * assert crash-replay and terminal compaction.
+	 */
+	deletionJournal?: ChatEffectJournal;
 }
 
 interface SessionSocket {
 	sessionId: string;
 	token: string;
+	/** Exact endpoint incarnation (`url + token`) bound at admission. */
 	endpointKey: string;
+	/**
+	 * Canonical (realpath-equivalent) root this socket was admitted under.
+	 * Bound at connect time from the session's mapped registry root; the close
+	 * path revalidates against the CURRENT mapped root and revokes on mismatch.
+	 */
+	canonicalRoot: string;
+	/**
+	 * Registration lease bound at admission. The close/delete path uses this
+	 * immutable value and never re-reads the current registry lease, so a
+	 * predecessor socket cannot delete/compact under a successor lease.
+	 */
+	leaseId: string;
 	ws: WebSocket;
 	pending: Map<string, { sessionId: string; actionId: string }>;
 	/** True once the server advertised the `client_ping_pong` capability. */
@@ -1009,6 +1464,13 @@ interface TelegramQueuePayload {
 	send: ThreadedSend;
 	topicId?: string;
 	selectedAck?: SelectedAckQueueItem;
+	/**
+	 * Per-session topic generation stamped at admission time (F002). Every
+	 * delivery revalidates this against the live generation before any provider
+	 * call; a frame whose generation no longer matches (topic fenced for
+	 * deletion or regenerated) is dropped. Absent for flat (non-topic) sends.
+	 */
+	topicGeneration?: number;
 }
 
 export class TelegramNotificationDaemon {
@@ -1024,6 +1486,11 @@ export class TelegramNotificationDaemon {
 	private running = false;
 	private readonly fsImpl: TelegramDaemonFs;
 	private readonly botApi: BotApi;
+	private readonly providerBotApi: BotApi;
+	private readonly topicOperations = new Map<string, number>();
+	private readonly topicOperationWaiters = new Map<string, Set<() => void>>();
+	private readonly closingSessions = new Set<string>();
+	private readonly topicCreations = new Map<string, Promise<string | undefined>>();
 	private readonly topics = new TopicRegistry();
 	/** Serializes registry snapshots so an older atomic write cannot overwrite newer rename state. */
 	private topicsPersistQueue: Promise<void> = Promise.resolve();
@@ -1043,6 +1510,29 @@ export class TelegramNotificationDaemon {
 	private readonly pendingThreadedFrames = new Map<string, PendingThreadedFrame[]>();
 	/** Endpoint generation tombstones for sessions that already sent session_closed. */
 	private readonly closedEndpointKeys = new Map<string, string>();
+	/**
+	 * Per-session send-admission fence state (F002). `liveTopicGeneration` holds
+	 * the generation stamped on the currently-live topic; a frame is admitted
+	 * only while its stamped generation still matches it. `fencedTopicGeneration`
+	 * records the generation being deleted so the fence is observable while a
+	 * deletion is in flight; once deletion completes both are cleared, and a
+	 * resumed topic receives a fresh generation a late enqueue can never match.
+	 */
+	private readonly liveTopicGeneration = new Map<string, number>();
+	private readonly fencedTopicGeneration = new Map<string, number>();
+	private readonly fencedTopicIds = new Set<string>();
+	private topicGenerationCounter = 0;
+	/** Per-session 429 retry_after backoff deadline (ms via opts.now). Seeded from
+	 * the DURABLY persisted deletion-effect receipt on re-entry/restart so a
+	 * crash never forgets an outstanding `retry_after` before re-calling the
+	 * provider. See {@link performTopicDeletion}. */
+	private readonly deletionRetryAfter = new Map<string, number>();
+	/**
+	 * Durable, fsynced per-session topic-deletion claim journal (F003/F004).
+	 * Defaults to the canonical `agentDir/sdk/daemons/telegram` store; injectable
+	 * for deterministic crash-replay/compaction tests.
+	 */
+	private readonly deletionJournal: ChatEffectJournal;
 	/** True once the daemon has nudged the user to enable Threaded Mode. */
 	private threadedFallbackNoticeSent = false;
 	/** Sessions whose identity header was already sent flat (Threaded Mode off). */
@@ -1056,7 +1546,7 @@ export class TelegramNotificationDaemon {
 		return this.dispatchState.busy;
 	}
 	/** Inbound update id → originating Telegram message, for delivery reactions. */
-	private get inboundReactions(): Map<number, { messageId: number }> {
+	private get inboundReactions(): Map<number, { messageId: number; sessionId: string; generation: number }> {
 		return this.dispatchState.inboundReactions;
 	}
 	/**
@@ -1429,9 +1919,12 @@ export class TelegramNotificationDaemon {
 
 	constructor(private readonly opts: TelegramDaemonOptions) {
 		this.fsImpl = opts.fs ?? nodeFs;
+		this.deletionJournal =
+			opts.deletionJournal ??
+			new ChatEffectJournal({ agentDir: opts.settings.getAgentDir(), transport: "telegram", now: opts.now });
 		this.replyStore = new ReplySentStore({ agentDir: opts.settings.getAgentDir(), fs: opts.fs });
 		this.aliasTable = createAliasTable();
-		this.botApi =
+		this.providerBotApi =
 			opts.botApi ??
 			new TelegramBotTransport({
 				botToken: opts.botToken,
@@ -1439,6 +1932,9 @@ export class TelegramNotificationDaemon {
 				fetchImpl: opts.fetchImpl,
 				setTimeoutImpl: opts.setTimeoutImpl,
 			});
+		this.botApi = {
+			call: (method, body, callOpts) => this.callGuardedBotApi(method, body, callOpts),
+		};
 		this.runtime = new NotificationOperatorRuntime({
 			now: opts.now,
 			setTimeoutImpl: opts.setTimeoutImpl,
@@ -1454,6 +1950,61 @@ export class TelegramNotificationDaemon {
 			backoff: this.pollConflictBackoff,
 			processUpdate: update => this.processTelegramUpdate(update),
 		});
+	}
+	private beginTopicOperation(sessionId: string, generation: number): (() => void) | undefined {
+		if (this.fencedTopicGeneration.has(sessionId) || this.liveTopicGeneration.get(sessionId) !== generation) {
+			return undefined;
+		}
+		this.topicOperations.set(sessionId, (this.topicOperations.get(sessionId) ?? 0) + 1);
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			const remaining = (this.topicOperations.get(sessionId) ?? 1) - 1;
+			if (remaining > 0) {
+				this.topicOperations.set(sessionId, remaining);
+				return;
+			}
+			this.topicOperations.delete(sessionId);
+			const waiters = this.topicOperationWaiters.get(sessionId);
+			this.topicOperationWaiters.delete(sessionId);
+			for (const resolve of waiters ?? []) resolve();
+		};
+	}
+
+	private async drainTopicOperations(sessionId: string): Promise<void> {
+		if ((this.topicOperations.get(sessionId) ?? 0) === 0) return;
+		await new Promise<void>(resolve => {
+			const waiters = this.topicOperationWaiters.get(sessionId) ?? new Set<() => void>();
+			waiters.add(resolve);
+			this.topicOperationWaiters.set(sessionId, waiters);
+		});
+	}
+
+	private async callGuardedBotApi(
+		method: string,
+		body: unknown,
+		callOpts?: { signal?: AbortSignal; noRetry?: boolean },
+	): Promise<unknown> {
+		const threadId =
+			body && typeof body === "object" && !Array.isArray(body)
+				? (body as { message_thread_id?: unknown }).message_thread_id
+				: undefined;
+		if (threadId === undefined) return this.providerBotApi.call(method, body, callOpts);
+		const sessionId = this.topics.sessionForTopic(String(threadId));
+		if (!sessionId) {
+			if (this.fencedTopicIds.has(String(threadId))) throw new Error("Telegram topic is fenced");
+			return this.providerBotApi.call(method, body, callOpts);
+		}
+		const generation = this.admissionGeneration(sessionId);
+		if (generation === undefined) throw new Error("Telegram topic is fenced");
+		const release = this.beginTopicOperation(sessionId, generation);
+		if (!release) throw new Error("Telegram topic is fenced");
+		try {
+			return await this.providerBotApi.call(method, body, callOpts);
+		} finally {
+			release();
+		}
 	}
 
 	private createSessionRouter(): OperatorEventRouter<SessionSocket> {
@@ -1507,6 +2058,13 @@ export class TelegramNotificationDaemon {
 						finishImmediately({ status: "failed", reason: "route_missing" });
 						return;
 					}
+					// F002: a threaded Selected ack must carry the live topic generation;
+					// a fenced (mid-delete) topic cannot receive it.
+					const topicGeneration = topicId ? this.admissionGeneration(session.sessionId) : undefined;
+					if (topicId && topicGeneration === undefined) {
+						finishImmediately({ status: "failed", reason: "route_missing" });
+						return;
+					}
 					const existing = [...new Set(this.selectedAckPending.values())].find(item => item.cacheKey === cacheKey);
 					if (existing) {
 						if (
@@ -1541,6 +2099,7 @@ export class TelegramNotificationDaemon {
 							send: { method: "sendMessage", lane: "ask", text: "Selected!" },
 							topicId,
 							selectedAck: item,
+							...(topicGeneration !== undefined ? { topicGeneration } : {}),
 						},
 					});
 					await this.flushPool();
@@ -1626,7 +2185,7 @@ export class TelegramNotificationDaemon {
 					const target = this.inboundReactions.get(msg.updateId as number);
 					if (target && msg.state === "consumed") {
 						this.inboundReactions.delete(msg.updateId as number);
-						await this.setReaction(target.messageId, CONSUMED_REACTION);
+						await this.setReaction(target.sessionId, target.messageId, CONSUMED_REACTION, target.generation);
 					}
 				},
 			})
@@ -1634,9 +2193,23 @@ export class TelegramNotificationDaemon {
 				name: "session_closed",
 				matches: msg => msg.type === "session_closed",
 				handle: async session => {
+					this.closingSessions.add(session.sessionId);
 					this.busy.delete(session.sessionId);
 					this.closedEndpointKeys.set(session.sessionId, session.endpointKey);
-					await this.deleteTopic(session.sessionId);
+					await this.topicCreations.get(session.sessionId)?.catch(() => undefined);
+					// Close-path deletion authority uses ONLY the socket's BOUND
+					// admission lease (canonicalRoot, leaseId, endpoint incarnation
+					// stamped from the endpoint file at admission). NEVER re-read the
+					// current registry lease. A predecessor socket bound to an older
+					// lease cannot delete/compact under a successor lease: the durable
+					// performTopicDeletion path re-validates the bound lease against
+					// the live registry under the admission lock and short-circuits as
+					// "superseded" when they differ (no provider deletion, no
+					// compaction, no generation restoration).
+					const closeLeaseId = session.leaseId;
+					if (isNonEmptyString(closeLeaseId)) {
+						await this.deleteTopic(session.sessionId, closeLeaseId);
+					}
 					this.dropSession(session, "session_closed");
 				},
 			});
@@ -1699,51 +2272,299 @@ export class TelegramNotificationDaemon {
 	}
 
 	async scanRoots(): Promise<void> {
+		await this.reconcileDeletionJournal();
 		const paths = daemonPaths(this.opts.settings.getAgentDir());
-		const rootState = await readJson<{ roots?: string[] }>(this.fsImpl, paths.roots);
-		const endpointSessionIds = new Set<string>();
-		let allRootsReadable = true;
-		for (const root of rootState?.roots ?? []) {
+		// F001: per-root/per-session evidence replaces the global all-roots-readable
+		// veto. Each registered root is classified independently — `readable`,
+		// `missing` (ENOENT only), or `ambiguous` (any other readdir error) — and
+		// each session's absence evidence is derived from ITS MAPPED root only, so
+		// an unrelated unreadable root never blocks another session. Malformed or
+		// unreadable matching endpoint files are tracked as protective (ambiguous)
+		// evidence so they can never be mistaken for confirmed absence.
+		const view = await readRootsRegistry(this.fsImpl, paths.roots);
+		// Canonicalize the inventory view as one identity graph before scanning.
+		// This also handles registries written by older versions: a still-live
+		// symlink root and its real path collapse in memory, and session mappings
+		// that point at the legacy alias follow the same canonical root. Resolution
+		// failures remain lexical so the later root read classifies them ambiguous.
+		const canonicalByRegisteredRoot = new Map<string, string>();
+		const canonicalRoots: string[] = [];
+		const unresolvedCanonicalRoots = new Set<string>();
+		for (const registeredRoot of view.roots) {
+			let canonicalRoot = registeredRoot;
+			try {
+				canonicalRoot = await canonicalizePath(this.fsImpl, registeredRoot);
+			} catch {
+				// Preserve unresolved authority as a distinct root, but mark it
+				// ambiguous even when its directory can still be enumerated.
+				unresolvedCanonicalRoots.add(canonicalRoot);
+			}
+			canonicalByRegisteredRoot.set(registeredRoot, canonicalRoot);
+			if (!canonicalRoots.includes(canonicalRoot)) canonicalRoots.push(canonicalRoot);
+		}
+		view.roots = canonicalRoots;
+		for (const [sessionId, mappedRoot] of view.sessions) {
+			view.sessions.set(sessionId, canonicalByRegisteredRoot.get(mappedRoot) ?? mappedRoot);
+		}
+		const pidAlive = this.opts.pidAlive ?? defaultPidAlive;
+		const rootStatus = new Map<string, "readable" | "missing" | "ambiguous">();
+		// root -> (sessionId -> endpoint classification) for readable roots only.
+		const rootSessionFiles = new Map<string, Map<string, "live" | "stale" | "malformed">>();
+		// sessionId -> live endpoint records collected across ALL readable roots.
+		// Each entry carries the immutable publication identity stamped onto the
+		// endpoint file by the session server. The daemon binds THIS identity
+		// (never inferring a lease from the registry); it only validates the
+		// carried identity against the current registry to detect stale endpoints.
+		const liveBySession = new Map<
+			string,
+			Array<{ canonicalRoot: string; leaseId: string; url: string; token: string }>
+		>();
+		const liveEndpointSessions = new Set<string>();
+		// Sessions whose endpoint identity is ambiguous (missing/malformed/mismatched
+		// carried identity, duplicate across roots, or conflicting identity). Fail-
+		// closed: never connect, never first-wins, never authorizes cleanup.
+		const ambiguousSessions = new Set<string>();
+		for (const root of view.roots) {
+			if (unresolvedCanonicalRoots.has(root)) {
+				rootStatus.set(root, "ambiguous");
+				continue;
+			}
 			const dir = path.join(root, "sdk");
 			let files: string[];
 			try {
 				files = await this.fsImpl.readdir(dir);
-			} catch {
-				allRootsReadable = false;
+			} catch (err) {
+				// Definitively missing (ENOENT) counts as confirmed absence for a
+				// mapped session; every other readdir error is ambiguous and must
+				// withhold/defer that root's sessions only.
+				rootStatus.set(root, isENOENTError(err) ? "missing" : "ambiguous");
 				continue;
 			}
+			rootStatus.set(root, "readable");
+			const fileMap = new Map<string, "live" | "stale" | "malformed">();
 			for (const file of files.filter(item => item.endsWith(".json"))) {
 				const sessionId = path.basename(file, ".json");
-				endpointSessionIds.add(sessionId);
-				if (this.sessions.has(sessionId)) continue;
+				if (this.fencedTopicGeneration.has(sessionId)) {
+					const connected = this.sessions.get(sessionId);
+					if (connected) this.dropSession(connected, "topic_deletion_pending");
+					fileMap.set(sessionId, "stale");
+					continue;
+				}
 				try {
 					const endpoint = readEndpoint(path.join(dir, file));
-					// Skip endpoint files whose owning process is gone or that are
-					// explicitly stale (e.g. a hard-closed session): reconnecting
-					// would chase a dead, token-bearing record forever. Once the
-					// associated topic is past the grace window, reap it through the
-					// same best-effort delete path as graceful session shutdown.
-					const pidAlive = this.opts.pidAlive ?? defaultPidAlive;
+					// Explicit stale/dead endpoint files are absence evidence the
+					// candidate reconciliation below may reap through the grace
+					// window; reconnecting them would chase a dead, token-bearing
+					// record forever.
 					if (endpoint.stale || (endpoint.pid !== undefined && !pidAlive(endpoint.pid))) {
-						await this.deleteOrphanedTopic(sessionId);
+						fileMap.set(sessionId, "stale");
 						continue;
 					}
-					const endpointKey = endpointGenerationKey(endpoint.url, endpoint.token);
-					if (this.closedEndpointKeys.get(sessionId) === endpointKey) continue;
-					this.closedEndpointKeys.delete(sessionId);
-					this.connectSession(sessionId, endpoint.url, endpoint.token);
-				} catch {}
+					// The endpoint MUST carry immutable publication identity
+					// (canonicalRoot + leaseId). A live endpoint missing either is
+					// malformed/ambiguous: the daemon never infers a lease from the
+					// registry. This also fails-closed for the predecessor race:
+					// an endpoint carrying a stale lease is rejected below as
+					// mismatched.
+					if (!isNonEmptyString(endpoint.canonicalRoot) || !isNonEmptyString(endpoint.leaseId)) {
+						fileMap.set(sessionId, "malformed");
+						ambiguousSessions.add(sessionId);
+						continue;
+					}
+					const mappedRoot = view.sessions.get(sessionId);
+					const currentLease = view.sessionLeases.get(sessionId)?.leaseId;
+					if (
+						mappedRoot !== root ||
+						endpoint.canonicalRoot !== root ||
+						currentLease === undefined ||
+						endpoint.leaseId !== currentLease
+					) {
+						fileMap.set(sessionId, "malformed");
+						ambiguousSessions.add(sessionId);
+						continue;
+					}
+					fileMap.set(sessionId, "live");
+					liveEndpointSessions.add(sessionId);
+					const entries = liveBySession.get(sessionId) ?? [];
+					entries.push({
+						canonicalRoot: endpoint.canonicalRoot,
+						leaseId: endpoint.leaseId,
+						url: endpoint.url,
+						token: endpoint.token,
+					});
+					liveBySession.set(sessionId, entries);
+				} catch {
+					// Malformed/unreadable matching endpoint file: protective
+					// evidence. It must NOT be treated as absence.
+					fileMap.set(sessionId, "malformed");
+					ambiguousSessions.add(sessionId);
+				}
+			}
+			rootSessionFiles.set(root, fileMap);
+		}
+		// Duplicate/conflicting identity is ambiguous and non-authorizing: a
+		// session with live endpoints carrying different publication identities
+		// (canonicalRoot + leaseId) can never prove which belongs to the fresh
+		// registration. Fail closed — disconnect/revoke any stale attached
+		// control, and never first-wins.
+		for (const [sessionId, entries] of liveBySession) {
+			const distinctIdentity = new Set(
+				entries.map(
+					entry => `${entry.canonicalRoot}\0${entry.leaseId}\0${endpointGenerationKey(entry.url, entry.token)}`,
+				),
+			);
+			if (distinctIdentity.size > 1) {
+				ambiguousSessions.add(sessionId);
+				const connected = this.sessions.get(sessionId);
+				if (connected) this.dropSession(connected, "ambiguous_duplicate_endpoint");
 			}
 		}
-		if (allRootsReadable) {
-			for (const sessionId of this.topics.sessionIds()) {
-				if (!this.sessions.has(sessionId) && !endpointSessionIds.has(sessionId))
-					await this.deleteOrphanedTopic(sessionId);
+		// Revalidation: every connected socket is checked against the CURRENT
+		// registry identity every scan. A successor registration (different
+		// lease) revokes the stale socket and any pending/session control. This
+		// is the immutable revalidation contract: current registry values cannot
+		// retroactively upgrade an old socket. The socket's BOUND lease (stamped
+		// from the endpoint file at admission) is compared against the live
+		// registry lease — a mismatch means a successor registration won.
+		const toRevoke: Array<{ sock: SessionSocket; reason: string }> = [];
+		for (const [sessionId, sock] of this.sessions) {
+			if (this.fencedTopicGeneration.has(sessionId)) continue;
+			if (ambiguousSessions.has(sessionId)) continue; // already revoked above
+			const currentLease = view.sessionLeases.get(sessionId)?.leaseId;
+			const mappedRoot = view.sessions.get(sessionId);
+			const matchingEndpoint = liveBySession
+				.get(sessionId)
+				?.some(
+					entry =>
+						entry.canonicalRoot === sock.canonicalRoot &&
+						entry.leaseId === sock.leaseId &&
+						endpointGenerationKey(entry.url, entry.token) === sock.endpointKey,
+				);
+			if (
+				!isNonEmptyString(sock.leaseId) ||
+				!isNonEmptyString(sock.canonicalRoot) ||
+				currentLease !== sock.leaseId ||
+				mappedRoot !== sock.canonicalRoot ||
+				matchingEndpoint !== true
+			) {
+				toRevoke.push({ sock, reason: "admission_identity_mismatch" });
 			}
+		}
+		for (const { sock, reason } of toRevoke) this.dropSession(sock, reason);
+		// Admission: only a live endpoint carrying immutable publication identity
+		// (canonicalRoot + leaseId) that MATCHES the current registry lease may
+		// connect/protect the topic. The daemon binds the ENDPOINT-CARRIED
+		// identity (never inferring from the registry), and validates it against
+		// the registry to reject stale predecessor endpoints whose lease no longer
+		// matches the fresh registration. This closes the predecessor race: a
+		// fresh registry lease with a predecessor endpoint file remaining is
+		// mismatched → ambiguous → never connects.
+		for (const [sessionId, entries] of liveBySession) {
+			if (ambiguousSessions.has(sessionId)) continue;
+			if (this.fencedTopicGeneration.has(sessionId)) continue;
+			if (this.sessions.has(sessionId)) continue; // already connected + revalidated
+			const entry = entries[0]!;
+			const currentLease = view.sessionLeases.get(sessionId)?.leaseId;
+			const mappedRoot = view.sessions.get(sessionId);
+			if (
+				currentLease === undefined ||
+				mappedRoot === undefined ||
+				entry.leaseId !== currentLease ||
+				entry.canonicalRoot !== mappedRoot
+			) {
+				ambiguousSessions.add(sessionId);
+				continue;
+			}
+			const endpointKey = endpointGenerationKey(entry.url, entry.token);
+			if (this.closedEndpointKeys.get(sessionId) === endpointKey) continue;
+			this.closedEndpointKeys.delete(sessionId);
+			// Bind the ENDPOINT-CARRIED identity (immutable for the socket lifetime).
+			this.connectSession(sessionId, entry.url, entry.token, {
+				canonicalRoot: entry.canonicalRoot,
+				leaseId: entry.leaseId,
+			});
+		}
+		// Derive per-session absence evidence from each session's MAPPED root.
+		const absenceEvidence = new Map<string, SessionAbsenceEvidence>();
+		for (const sessionId of this.topics.sessionIds()) {
+			// Ambiguous identity withholds/withholds cleanup: never reap.
+			if (ambiguousSessions.has(sessionId)) {
+				absenceEvidence.set(sessionId, { kind: "ambiguous" });
+				continue;
+			}
+			if (this.sessions.has(sessionId) || liveEndpointSessions.has(sessionId)) {
+				absenceEvidence.set(sessionId, { kind: "present" });
+				continue;
+			}
+			const mappedRoot = view.sessions.get(sessionId);
+			if (!mappedRoot) {
+				absenceEvidence.set(sessionId, { kind: "ambiguous" });
+				continue;
+			}
+			const status = rootStatus.get(mappedRoot);
+			if (status === "missing") {
+				absenceEvidence.set(sessionId, { kind: "missing" });
+			} else if (status !== "readable") {
+				// Unreadable (ambiguous) mapped root, or a registered root no
+				// longer present in the registry list: defer, never reap.
+				absenceEvidence.set(sessionId, { kind: "ambiguous" });
+			} else {
+				const file = rootSessionFiles.get(mappedRoot)?.get(sessionId);
+				absenceEvidence.set(
+					sessionId,
+					file === "live"
+						? { kind: "present" }
+						: file === "malformed"
+							? { kind: "ambiguous" }
+							: { kind: "absent" }, // no file, or explicit stale/dead evidence
+				);
+			}
+		}
+		await this.reconcileOrphanCandidates(view, absenceEvidence);
+	}
+
+	private async sessionAdmissionIsCurrent(session: SessionSocket): Promise<boolean> {
+		if (!isNonEmptyString(session.canonicalRoot) || !isNonEmptyString(session.leaseId)) return false;
+		const view = await readRootsRegistry(this.fsImpl, daemonPaths(this.opts.settings.getAgentDir()).roots);
+		if (
+			view.sessions.get(session.sessionId) !== session.canonicalRoot ||
+			view.sessionLeases.get(session.sessionId)?.leaseId !== session.leaseId
+		) {
+			return false;
+		}
+		try {
+			const endpoint = readEndpoint(path.join(session.canonicalRoot, "sdk", `${session.sessionId}.json`));
+			return (
+				endpoint.canonicalRoot === session.canonicalRoot &&
+				endpoint.leaseId === session.leaseId &&
+				endpointGenerationKey(endpoint.url, endpoint.token) === session.endpointKey
+			);
+		} catch {
+			return false;
 		}
 	}
 
-	connectSession(sessionId: string, url: string, token: string): void {
+	private async sendToCurrentSession(session: SessionSocket, frame: Record<string, unknown>): Promise<boolean> {
+		if (this.sessions.get(session.sessionId) !== session) return false;
+		if (!(await this.sessionAdmissionIsCurrent(session))) {
+			if (this.sessions.get(session.sessionId) === session) {
+				this.dropSession(session, "admission_identity_mismatch");
+			}
+			return false;
+		}
+		if (this.sessions.get(session.sessionId) !== session || session.ws.readyState !== WebSocket.OPEN) {
+			return false;
+		}
+		try {
+			session.ws.send(JSON.stringify(frame));
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	connectSession(sessionId: string, url: string, token: string, identity: SessionAdmissionIdentity): void {
+		this.closingSessions.delete(sessionId);
 		const WS = this.opts.WebSocketImpl ?? WebSocket;
 		const ws = new WS(`${url}/?token=${encodeURIComponent(token)}`);
 		const endpointKey = endpointGenerationKey(url, token);
@@ -1752,6 +2573,14 @@ export class TelegramNotificationDaemon {
 			sessionId,
 			token,
 			endpointKey,
+			// Bind the admission identity (canonical root + registration lease)
+			// immutably to this socket. The token IS the endpoint incarnation: it is
+			// freshly minted per endpoint publication, so (canonicalRoot, sessionId,
+			// leaseId, token) is the exact admission tuple. The close/delete path
+			// uses these bound values and never re-reads the current registry, so a
+			// predecessor socket cannot be upgraded by a successor registration.
+			canonicalRoot: identity.canonicalRoot,
+			leaseId: identity.leaseId,
 			ws,
 			pending: new Map(),
 			capable: false,
@@ -1764,31 +2593,40 @@ export class TelegramNotificationDaemon {
 		// socket is open. Sent on "open" only — a real WHATWG WebSocket cannot send
 		// while CONNECTING — and liveness starts only after a capable ServerHello.
 		ws.addEventListener("open", () => {
-			if (session.ws.readyState === WebSocket.OPEN) {
-				try {
-					session.ws.send(
-						JSON.stringify({
-							type: "hello",
-							protocolVersion: NOTIFICATION_PROTOCOL_VERSION,
-							capabilities: [CLIENT_PING_PONG_CAPABILITY, ASK_CONTROLS_CAPABILITY, ASK_SELECTED_ACK_CAPABILITY],
-						}),
-					);
-				} catch {}
-			}
-			// Eagerly create the session's Telegram topic as soon as it connects, so
-			// a thread exists the moment a notifications-enabled session is live —
-			// not lazily on the first delivered frame (which only arrives once the
-			// user sends a prompt). A provisional "GJC <id>" name is used; the
-			// identity_header frame renames it to "{repo}/{branch} - {title}" later.
-			void this.ensureTopic(sessionId, this.topicNameFor(sessionId, {})).catch(() => undefined);
+			void (async () => {
+				if (this.sessions.get(sessionId) !== session || !(await this.sessionAdmissionIsCurrent(session))) {
+					this.dropSession(session, "admission_identity_mismatch");
+					return;
+				}
+				if (session.ws.readyState === WebSocket.OPEN) {
+					try {
+						session.ws.send(
+							JSON.stringify({
+								type: "hello",
+								protocolVersion: NOTIFICATION_PROTOCOL_VERSION,
+								capabilities: [
+									CLIENT_PING_PONG_CAPABILITY,
+									ASK_CONTROLS_CAPABILITY,
+									ASK_SELECTED_ACK_CAPABILITY,
+								],
+							}),
+						);
+					} catch {}
+				}
+				void this.ensureTopic(sessionId, this.topicNameFor(sessionId, {})).catch(() => undefined);
+			})().catch(err => {
+				logger.error("notifications daemon: endpoint admission check failed", { error: String(err) });
+				this.dropSession(session, "admission_check_failed");
+			});
 		});
 		ws.addEventListener("message", ev => {
-			// Identity guard: a delayed frame from a superseded socket must not act
-			// through the replacement session.
-			if (this.sessions.get(sessionId) !== session) return;
-			void this.handleSessionMessage(session, JSON.parse(String(ev.data))).catch(err => {
-				// Surface frame-handling failures (e.g. a rejected ask sendMessage) to
-				// the daemon log instead of an invisible unhandled rejection.
+			void (async () => {
+				if (this.sessions.get(sessionId) !== session || !(await this.sessionAdmissionIsCurrent(session))) {
+					this.dropSession(session, "admission_identity_mismatch");
+					return;
+				}
+				await this.handleSessionMessage(session, JSON.parse(String(ev.data)));
+			})().catch(err => {
 				logger.error("notifications daemon: handleSessionMessage failed", { error: String(err) });
 			});
 		});
@@ -1961,11 +2799,16 @@ export class TelegramNotificationDaemon {
 	}
 
 	private async submitThreadedFrame(sessionId: string, send: ThreadedSend, topicId: string): Promise<void> {
+		// F002 admission fence: stamp the live topic generation and reject once the
+		// topic is fenced for deletion. A post-fence enqueue reads an undefined
+		// generation and returns, so it can never target the old topic.
+		const topicGeneration = this.admissionGeneration(sessionId);
+		if (topicGeneration === undefined) return;
 		this.pool.submit({
 			sessionId,
 			lane: send.lane,
 			coalesceKey: send.coalesceKey,
-			payload: { send, topicId },
+			payload: { send, topicId, topicGeneration },
 		});
 		await this.flushPool();
 	}
@@ -2027,75 +2870,497 @@ export class TelegramNotificationDaemon {
 	 * one-time nudge) or drop fail-closed for a non-private chat.
 	 */
 	private async ensureTopic(sessionId: string, name: string): Promise<string | undefined> {
+		if (this.closingSessions.has(sessionId)) return undefined;
 		if (!(await this.pairedChatIsPrivate())) return undefined;
+		if (this.closingSessions.has(sessionId) || this.fencedTopicGeneration.has(sessionId)) return undefined;
 		const existing = this.topics.get(sessionId);
-		if (existing) return existing.topicId;
-		try {
-			const rec = await this.topics.getOrCreateTopic(
-				sessionId,
-				async () => {
-					const res = (await this.botApi.call("createForumTopic", {
-						chat_id: this.opts.chatId,
-						name,
-					})) as { result?: { message_thread_id?: number } };
-					const tid = res.result?.message_thread_id;
-					if (tid === undefined || tid === null) throw new Error("createForumTopic: no message_thread_id");
-					return String(tid);
-				},
-				this.opts.now,
-				// The create winner records the name it actually used; callers that
-				// merely JOIN an in-flight create must not overwrite it locally, or a
-				// later identity rename would be wrongly skipped (topic stuck at the
-				// provisional name on Telegram).
-				name,
-			);
-			await this.persistTopics();
-			return rec.topicId;
-		} catch {
-			return undefined;
+		if (existing) {
+			this.ensureLiveTopicGeneration(sessionId);
+			return existing.topicId;
 		}
+		const pending = this.topicCreations.get(sessionId);
+		if (pending) return pending;
+
+		const creation = (async (): Promise<string | undefined> => {
+			try {
+				const rec = await this.topics.getOrCreateTopic(
+					sessionId,
+					async () => {
+						const res = (await this.botApi.call("createForumTopic", {
+							chat_id: this.opts.chatId,
+							name,
+						})) as { result?: { message_thread_id?: number } };
+						const tid = res.result?.message_thread_id;
+						if (tid === undefined || tid === null) throw new Error("createForumTopic: no message_thread_id");
+						return String(tid);
+					},
+					this.opts.now,
+					name,
+				);
+				await this.persistTopics();
+				if (!this.closingSessions.has(sessionId)) this.ensureLiveTopicGeneration(sessionId);
+				return rec.topicId;
+			} catch {
+				return undefined;
+			}
+		})();
+		this.topicCreations.set(sessionId, creation);
+		try {
+			return await creation;
+		} finally {
+			if (this.topicCreations.get(sessionId) === creation) this.topicCreations.delete(sessionId);
+		}
+	}
+
+	/** Assign a live generation for a topic that has none yet (created/resumed),
+	 * without disturbing an existing live generation or a fenced one. */
+	private ensureLiveTopicGeneration(sessionId: string): void {
+		if (this.liveTopicGeneration.has(sessionId)) return;
+		if (this.fencedTopicGeneration.has(sessionId)) return;
+		this.assignTopicGeneration(sessionId);
 	}
 
 	private topicPastOrphanGrace(sessionId: string): boolean {
 		const record = this.topics.get(sessionId);
-		return record !== undefined && this.runtime.now() - record.createdAt >= ORPHAN_TOPIC_GRACE_MS;
+		if (!record) return false;
+		// Strictly validate createdAt before it contributes to destructive grace.
+		// TopicRegistry only checks `typeof === "number"`, so it normalizes a
+		// missing/legacy value to 0 and passes through NaN/Infinity/negative/
+		// out-of-range values — any of which could make a malformed record look
+		// long-past-grace and authorize a false reap. Fail closed unless createdAt
+		// is a positive safe-integer timestamp not in the future.
+		const createdAt = record.createdAt;
+		const now = this.runtime.now();
+		if (!isNonNegativeSafeInteger(createdAt) || createdAt <= 0 || createdAt > now) return false;
+		return now - createdAt >= ORPHAN_TOPIC_GRACE_MS;
 	}
 
-	private async deleteOrphanedTopic(sessionId: string): Promise<void> {
-		if (!this.topicPastOrphanGrace(sessionId)) return;
-		await this.deleteTopic(sessionId);
+	/**
+	 * The generation a NEW send for `sessionId` would be stamped with (F002), or
+	 * `undefined` when the session has no live topic or its topic is fenced for
+	 * deletion — admission then rejects the send.
+	 */
+	private admissionGeneration(sessionId: string): number | undefined {
+		if (this.closingSessions.has(sessionId)) return undefined;
+		if (this.fencedTopicGeneration.has(sessionId)) return undefined;
+		return this.liveTopicGeneration.get(sessionId);
 	}
 
-	/** Best-effort delete of a session topic once its local notification endpoint shuts down. */
-	private async deleteTopic(sessionId: string): Promise<void> {
+	/** Assign a fresh live generation for a created/resumed topic (F002). */
+	private assignTopicGeneration(sessionId: string): number {
+		const next = ++this.topicGenerationCounter;
+		this.liveTopicGeneration.set(sessionId, next);
+		this.fencedTopicGeneration.delete(sessionId);
+		const topicId = this.topics.get(sessionId)?.topicId;
+		if (topicId) this.fencedTopicIds.delete(topicId);
+		return next;
+	}
+
+	/**
+	 * Best-effort, crash-safe delete of a session topic. The send admission fence
+	 * is raised FIRST (no late submitThreadedFrame/continuation can target the
+	 * topic), queued items are cancelled, the pool is drained OUTSIDE any
+	 * registry lock, then the remote delete runs through the durable deletion
+	 * claim (fsynced intent before the call, terminal recorded before local
+	 * forgetting). `leaseId` is the persisted registration lease this deletion is
+	 * authorized under; it scopes the topic-specific effect and selective roots
+	 * compaction so a fresh registration (different lease) is never compacted. A
+	 * topic left by an uncertain/429 delete keeps its fence and is retried by the
+	 * next scan; a resumed session receives a fresh generation.
+	 */
+	private async deleteTopic(sessionId: string, leaseId: string): Promise<void> {
+		if (!isNonEmptyString(leaseId)) return;
 		const record = this.topics.get(sessionId);
-		if (!record) return;
-		try {
-			// Drop queued sends for this session before deleting the topic; otherwise
-			// rate-limited frames can flush later into a deleted topic or across resume.
-			const removed = this.pool.removeWhere(item => item.sessionId === sessionId);
-			for (const item of removed) {
-				if (item.payload.selectedAck)
-					this.finishSelectedAck(item.payload.selectedAck, { status: "failed", reason: "cancelled" });
-			}
-			await this.flushPool();
-			const res = (await this.botApi.call("deleteForumTopic", {
-				chat_id: this.opts.chatId,
-				message_thread_id: Number(record.topicId),
-			})) as { ok?: boolean };
-			if (res?.ok === false) return;
-			this.topics.delete(sessionId);
-			for (const k of [...this.liveMessages.keys()]) {
-				if (k.startsWith(`${sessionId}:`)) this.liveMessages.delete(k);
-			}
-			this.topicOwnerByIdentity.forEach((ownerSessionId, identityKey) => {
-				if (ownerSessionId === sessionId) this.topicOwnerByIdentity.delete(identityKey);
-			});
-			this.pendingThreadedFrames.delete(sessionId);
-			await this.persistTopics();
-		} catch {
-			// Best-effort: missing Telegram topic permissions must not stop teardown.
+		if (!record || !isCanonicalTopicId(record.topicId)) return;
+		// FENCE: invalidate the live generation so new submits/requeues are
+		// rejected and every in-flight delivery revalidates and skips. A
+		// post-fence enqueue cannot target the old topic: admissionGeneration()
+		// is undefined while fenced, so it is stamped with a later generation.
+		this.fencedTopicGeneration.set(sessionId, this.liveTopicGeneration.get(sessionId) ?? 0);
+		this.liveTopicGeneration.delete(sessionId);
+		this.fencedTopicIds.add(record.topicId);
+		// CANCEL queued sends for this session before deleting the topic;
+		// otherwise rate-limited frames can flush into a deleted topic or across
+		// resume.
+		const removed = this.pool.removeWhere(item => item.sessionId === sessionId);
+		for (const item of removed) {
+			if (item.payload.selectedAck)
+				this.finishSelectedAck(item.payload.selectedAck, { status: "failed", reason: "cancelled" });
 		}
+		// DRAIN outside registry locks: let any in-flight flush complete. Granted
+		// items revalidate against the (now-removed) live generation and skip.
+		await this.flushPool();
+		await this.drainTopicOperations(sessionId);
+		// DELETE via the durable claim. Terminal remote success is recorded before
+		// local forgetting; an uncertain/429 outcome retains the claim for retry.
+		const generation = this.fencedTopicGeneration.get(sessionId) ?? 0;
+		const outcome = await this.performTopicDeletion(sessionId, record.topicId, generation, leaseId);
+		if (outcome === "terminal") {
+			this.finalizeTopicDeletion(sessionId);
+			await this.persistTopics().catch(() => undefined);
+			// Selective roots compaction: remove ONLY the exact matching
+			// candidate/lease/session mapping. A fresh registration whose lease
+			// differs survives (re-read durably under the roots lock).
+			await this.compactRootsAfterDeletion(sessionId, record.topicId, leaseId);
+			await this.deletionJournal.updateTerminalReceipt<TelegramTopicDeletePayload>(
+				topicDeleteEffectId(sessionId, record.topicId, leaseId),
+				{ provider: "telegram", status: "reconciled" },
+			);
+		} else if (outcome === "superseded" && this.topics.get(sessionId)?.topicId === record.topicId) {
+			this.assignTopicGeneration(sessionId);
+		}
+	}
+
+	/**
+	 * Establish/reuse the durable deletion claim, call `deleteForumTopic` with
+	 * `noRetry` and a bounded AbortSignal, and record terminal/uncertain state.
+	 * Returns "terminal" when the topic is confirmed deleted (or already
+	 * deleted), "uncertain" when the call must be retried (429/abort/transport).
+	 * `leaseId` is recorded in the payload so crash replay and compaction can
+	 * validate exact session/topic/lease; the effect id is topic-scoped so a
+	 * terminal record for a superseded topic never applies here.
+	 */
+	private async performTopicDeletion(
+		sessionId: string,
+		topicId: string,
+		generation: number,
+		leaseId: string,
+	): Promise<"terminal" | "uncertain" | "superseded"> {
+		const effectId = topicDeleteEffectId(sessionId, topicId, leaseId);
+		const payload: TelegramTopicDeletePayload = { chatId: this.opts.chatId, topicId, leaseId };
+		let lease: ChatEffectLease | undefined;
+		let terminal = false;
+		let superseded = false;
+		await withFileLock(
+			telegramAdmissionLockPath(this.opts.settings.getAgentDir(), sessionId),
+			async () => {
+				const roots = await readRootsRegistry(this.fsImpl, daemonPaths(this.opts.settings.getAgentDir()).roots);
+				if (roots.sessionLeases.get(sessionId)?.leaseId !== leaseId) {
+					superseded = true;
+					return;
+				}
+
+				let existing = await this.deletionJournal.read<TelegramTopicDeletePayload>(effectId);
+				if (
+					existing &&
+					(existing.transport !== "telegram" ||
+						existing.kind !== TELEGRAM_TOPIC_DELETE_KIND ||
+						existing.sessionId !== sessionId ||
+						!isTelegramTopicDeletePayload(existing.payload) ||
+						existing.payload.chatId !== payload.chatId ||
+						existing.payload.topicId !== payload.topicId ||
+						existing.payload.leaseId !== payload.leaseId)
+				) {
+					return;
+				}
+				const now = this.runtime.now();
+				const memRetryUntil = this.deletionRetryAfter.get(sessionId);
+				if (memRetryUntil !== undefined && now < memRetryUntil) return;
+				const durableRetryAt = existing?.receipt?.retryAt;
+				if (typeof durableRetryAt === "number" && Number.isFinite(durableRetryAt) && now < durableRetryAt) {
+					this.deletionRetryAfter.set(sessionId, durableRetryAt);
+					return;
+				}
+				if (existing?.state === "terminal") {
+					terminal = true;
+					return;
+				}
+
+				if (!existing) {
+					const created = await this.deletionJournal.enqueueAndClaim<TelegramTopicDeletePayload>(
+						{
+							id: effectId,
+							kind: TELEGRAM_TOPIC_DELETE_KIND,
+							transport: "telegram",
+							sessionId,
+							endpointGeneration: generation,
+							payload,
+						},
+						this.opts.ownerId,
+						TELEGRAM_DELETION_LEASE_MS,
+					);
+					if (created) {
+						existing = created;
+						lease = { owner: this.opts.ownerId, epoch: created.epoch };
+					}
+				}
+				if (!lease && existing) {
+					const claimed = await this.deletionJournal.claim<TelegramTopicDeletePayload>(
+						effectId,
+						this.opts.ownerId,
+						TELEGRAM_DELETION_LEASE_MS,
+					);
+					if (claimed?.state === "leased") {
+						lease = { owner: this.opts.ownerId, epoch: claimed.epoch };
+					}
+				}
+			},
+			{ staleMs: 10_000 },
+		);
+		if (terminal) return "terminal";
+		if (superseded) return "superseded";
+		if (!lease) return "uncertain";
+		const result = await this.callDeleteForumTopic(topicId);
+		if (result.outcome === "deleted") {
+			await this.deletionJournal.record(effectId, lease, "terminal", {
+				provider: "telegram",
+				status: "deleted",
+			});
+			this.deletionRetryAfter.delete(sessionId);
+			return "terminal";
+		}
+		// Persist retry_after DURABLY so it survives a restart: record the absolute
+		// deadline on the receipt and seed the in-memory backoff for this run.
+		const retryAt =
+			typeof result.retryAfterSec === "number" && result.retryAfterSec > 0
+				? this.runtime.now() + result.retryAfterSec * 1000
+				: this.runtime.now() + TELEGRAM_DELETION_RETRY_MS;
+		this.deletionRetryAfter.set(sessionId, retryAt);
+		await this.deletionJournal.record(effectId, lease, "uncertain", {
+			provider: "telegram",
+			status: result.retryAfterSec ? `retry_after:${result.retryAfterSec}` : "uncertain",
+			retryAt,
+		});
+		return "uncertain";
+	}
+
+	/**
+	 * Call `deleteForumTopic` once with `noRetry` and a bounded AbortSignal.
+	 * Honors Telegram `parameters.retry_after` and reconciles an already-applied
+	 * delete (topic/message-thread not found) as success.
+	 */
+	private async callDeleteForumTopic(
+		topicId: string,
+	): Promise<{ outcome: "deleted" | "uncertain"; retryAfterSec?: number }> {
+		const controller = new AbortController();
+		const timeoutMs = this.opts.topicDeleteTimeoutMs ?? TOPIC_DELETE_TIMEOUT_MS;
+		const timer = (this.opts.setTimeoutImpl ?? setTimeout)(() => controller.abort(), timeoutMs);
+		try {
+			const res = (await this.providerBotApi.call(
+				"deleteForumTopic",
+				{ chat_id: this.opts.chatId, message_thread_id: Number(topicId) },
+				{ signal: controller.signal, noRetry: true },
+			)) as {
+				ok?: boolean;
+				error_code?: number;
+				description?: string;
+				parameters?: { retry_after?: unknown };
+			};
+			if (res?.ok === true) return { outcome: "deleted" };
+			const description = String(res?.description ?? "");
+			// Already-applied delete (topic/thread no longer exists) reconciles as success.
+			if (
+				res?.ok === false &&
+				/not found|already deleted|message thread not found|topic deleted/i.test(description)
+			) {
+				return { outcome: "deleted" };
+			}
+			// 429 rate limit: honor retry_after, retain uncertain for re-attempt.
+			if (res?.ok === false && (res.error_code === 429 || res.parameters?.retry_after !== undefined)) {
+				const retryAfter = Number(res.parameters?.retry_after);
+				return {
+					outcome: "uncertain",
+					retryAfterSec: Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : undefined,
+				};
+			}
+			return { outcome: "uncertain" };
+		} catch {
+			// Abort/network/transport error: retain uncertain; a later scan retries.
+			return { outcome: "uncertain" };
+		} finally {
+			(this.opts.clearTimeoutImpl ?? clearTimeout)(timer);
+		}
+	}
+
+	/**
+	 * Local cleanup after a confirmed terminal deletion: remove the topic record,
+	 * its live-message index, identity ownership, pending frames, and generation.
+	 * Selective: only the exact session is compacted (F005). Safe to call from
+	 * crash replay for a terminal claim WITHOUT re-calling Telegram.
+	 */
+	private finalizeTopicDeletion(sessionId: string): void {
+		this.topics.delete(sessionId);
+		for (const k of [...this.liveMessages.keys()]) {
+			if (k.startsWith(`${sessionId}:`)) this.liveMessages.delete(k);
+		}
+		this.topicOwnerByIdentity.forEach((ownerSessionId, identityKey) => {
+			if (ownerSessionId === sessionId) this.topicOwnerByIdentity.delete(identityKey);
+		});
+		this.pendingThreadedFrames.delete(sessionId);
+		this.liveTopicGeneration.delete(sessionId);
+		this.fencedTopicGeneration.delete(sessionId);
+	}
+
+	/**
+	 * F001 continuous-absence reconciliation driven by per-session MAPPED-root
+	 * evidence. A `present` OR `ambiguous` session (connected, live endpoint, or
+	 * an unreadable/malformed mapped root that cannot confirm absence) clears any
+	 * candidate so a fresh grace window restarts once the ambiguity resolves; an
+	 * unrelated unreadable root only withholds ITS own sessions. Only `absent`/
+	 * `missing` evidence — under a VALID lease and a strictly-valid createdAt —
+	 * may create/continue a candidate, and a candidate is reaped only once it has
+	 * survived the grace window AND its lease still matches the live lease. The
+	 * durable reap (network call) runs OUTSIDE the roots lock.
+	 */
+	private async reconcileOrphanCandidates(
+		view: RootsRegistryView,
+		absenceEvidence: Map<string, SessionAbsenceEvidence>,
+	): Promise<void> {
+		const now = this.runtime.now();
+		const paths = daemonPaths(this.opts.settings.getAgentDir());
+		for (const sessionId of this.topics.sessionIds()) {
+			const evidence = absenceEvidence.get(sessionId);
+			const candidate = view.orphanCandidates.get(sessionId);
+			// Present OR ambiguous evidence must never authorize a reap: clear any
+			// candidate so the grace window restarts once presence/ambiguity
+			// resolves. (No evidence ⇒ unmapped session ⇒ defer fail-closed.)
+			if (!evidence || evidence.kind === "present" || evidence.kind === "ambiguous") {
+				if (candidate)
+					await mutateRootsRegistry(this.fsImpl, paths.roots, v => deleteRawCandidate(v.raw, sessionId));
+				continue;
+			}
+			// Absence confirmed (absent/missing). A valid lease is REQUIRED to
+			// create or continue a candidate: a missing/invalid lease never
+			// authorizes a reap, so clear any stale candidate instead.
+			const lease = view.sessionLeases.get(sessionId);
+			if (!lease) {
+				if (candidate)
+					await mutateRootsRegistry(this.fsImpl, paths.roots, v => deleteRawCandidate(v.raw, sessionId));
+				continue;
+			}
+			const record = this.topics.get(sessionId);
+			if (!record) continue;
+			if (!this.topicPastOrphanGrace(sessionId)) continue;
+			// Skip while a 429 retry_after backoff is in effect.
+			const retryUntil = this.deletionRetryAfter.get(sessionId);
+			if (retryUntil !== undefined && now < retryUntil) continue;
+			if (!candidate) {
+				// First confirmed continuous absence: record a candidate.
+				await mutateRootsRegistry(this.fsImpl, paths.roots, v => {
+					setRawCandidate(v.raw, sessionId, {
+						observedAt: now,
+						leaseId: lease.leaseId,
+						topicId: record.topicId,
+					});
+					return true;
+				});
+				continue;
+			}
+			if (candidate.leaseId !== lease.leaseId || candidate.topicId !== record.topicId) {
+				// A fresh registration or changed topic invalidates the prior
+				// observation. Require a complete new continuous-absence window.
+				await mutateRootsRegistry(this.fsImpl, paths.roots, v => {
+					setRawCandidate(v.raw, sessionId, {
+						observedAt: now,
+						leaseId: lease.leaseId,
+						topicId: record.topicId,
+					});
+					return true;
+				});
+				continue;
+			}
+			if (now - candidate.observedAt < ORPHAN_TOPIC_GRACE_MS) continue;
+			// Reap through the fenced, durable deletion path. The live lease
+			// authorizes the deletion and scopes selective roots compaction.
+			await this.deleteTopic(sessionId, lease.leaseId);
+		}
+	}
+
+	/**
+	 * F004 crash reconciliation of the durable deletion journal, run once at
+	 * startup after topics are loaded. It validates EXACT session/topic/lease for
+	 * every effect: a terminal claim completes local cleanup WITHOUT calling
+	 * Telegram again and compacts roots for its exact lease; a nonterminal claim
+	 * for a superseded topic/gone topic is terminalized; otherwise the remote
+	 * delete is re-attempted (honoring the durable retry_after).
+	 */
+	private async reconcileDeletionJournal(): Promise<void> {
+		const effects = (await this.deletionJournal.list()).filter(
+			(e): e is ChatEffect<TelegramTopicDeletePayload> =>
+				e.transport === "telegram" &&
+				e.kind === TELEGRAM_TOPIC_DELETE_KIND &&
+				isTelegramTopicDeletePayload(e.payload) &&
+				(e.state !== "terminal" || !e.receipt?.status?.startsWith("reconciled")),
+		);
+		for (const effect of effects) {
+			const sessionId = effect.sessionId;
+			if (!sessionId || effect.payload.chatId !== this.opts.chatId) continue;
+			const payload = effect.payload;
+			const record = this.topics.get(sessionId);
+			const roots = await readRootsRegistry(this.fsImpl, daemonPaths(this.opts.settings.getAgentDir()).roots);
+			const currentLease = roots.sessionLeases.get(sessionId)?.leaseId;
+			const leaseMatches = currentLease === undefined || currentLease === payload.leaseId;
+
+			if (effect.state === "terminal") {
+				this.fencedTopicIds.add(payload.topicId);
+				if (leaseMatches && record?.topicId === payload.topicId) {
+					this.finalizeTopicDeletion(sessionId);
+					await this.persistTopics().catch(() => undefined);
+				}
+				if (leaseMatches) {
+					await this.compactRootsAfterDeletion(sessionId, payload.topicId, payload.leaseId);
+				}
+				await this.deletionJournal.updateTerminalReceipt(effect.id, {
+					provider: "telegram",
+					status: leaseMatches ? "reconciled" : "reconciled_superseded",
+				});
+				continue;
+			}
+
+			// Never replay a nonterminal delete against a different registration
+			// generation. Terminalizing it releases the admission barrier without a
+			// second provider call.
+			if (!currentLease || currentLease !== payload.leaseId || record?.topicId !== payload.topicId) {
+				await this.deletionJournal
+					.terminalize(effect.id, { provider: "telegram", status: "reconciled_superseded" })
+					.catch(() => undefined);
+				continue;
+			}
+			this.fencedTopicGeneration.set(
+				sessionId,
+				this.liveTopicGeneration.get(sessionId) ?? effect.endpointGeneration,
+			);
+			this.liveTopicGeneration.delete(sessionId);
+			this.fencedTopicIds.add(payload.topicId);
+			const outcome = await this.performTopicDeletion(
+				sessionId,
+				record.topicId,
+				effect.endpointGeneration,
+				payload.leaseId,
+			);
+			if (outcome === "terminal") {
+				this.finalizeTopicDeletion(sessionId);
+				await this.persistTopics().catch(() => undefined);
+				await this.compactRootsAfterDeletion(sessionId, record.topicId, payload.leaseId);
+				await this.deletionJournal.updateTerminalReceipt(effect.id, {
+					provider: "telegram",
+					status: "reconciled",
+				});
+			}
+		}
+	}
+	/**
+	 * Selective local-roots compaction after a confirmed (terminal) deletion.
+	 * Removes ONLY the exact matching candidate/lease/session mapping for the
+	 * deleted topic + lease, re-read durably under the roots lock so a fresh
+	 * registration (different lease) or a different topic survives untouched.
+	 */
+	private async compactRootsAfterDeletion(sessionId: string, topicId: string, leaseId: string): Promise<void> {
+		const paths = daemonPaths(this.opts.settings.getAgentDir());
+		await mutateRootsRegistry(this.fsImpl, paths.roots, v => {
+			const candidate = v.orphanCandidates.get(sessionId);
+			if (candidate && candidate.topicId === topicId && candidate.leaseId === leaseId) {
+				deleteRawCandidate(v.raw, sessionId);
+			}
+			const lease = v.sessionLeases.get(sessionId);
+			if (leaseId && lease && lease.leaseId === leaseId) {
+				const root = v.sessions.get(sessionId);
+				deleteRawLease(v.raw, sessionId);
+				deleteRawSessionMapping(v.raw, sessionId);
+				if (root) deleteRawRootIfUnreferenced(v.raw, root);
+			}
+			return true;
+		});
 	}
 
 	private persistTopics(): Promise<void> {
@@ -2114,6 +3379,10 @@ export class TelegramNotificationDaemon {
 		// Restore the full serialized registry (topicId + identitySent + name) so a
 		// fresh daemon after reload does not resend identity headers or lose renames.
 		if (raw && typeof raw === "object") this.topics.load(raw);
+		// Assign a fresh per-session admission generation to every restored topic.
+		// The rate-limit pool is in-memory only, so a restart has no stale queued
+		// frames; each live topic starts a new generation its first send adopts.
+		for (const sessionId of this.topics.sessionIds()) this.ensureLiveTopicGeneration(sessionId);
 	}
 
 	/** Download a Telegram file by its file_path (from getFile) into memory. */
@@ -2264,6 +3533,12 @@ export class TelegramNotificationDaemon {
 			);
 		}
 		for (const item of batch) {
+			// F002: revalidate the stamped topic generation before any provider call.
+			// A frame whose generation no longer matches the live topic (fenced for
+			// deletion or regenerated) is dropped. Flat (non-topic) sends carry no
+			// generation and are never gated here.
+			const stampedGen = item.payload.topicGeneration;
+			if (typeof stampedGen === "number" && stampedGen !== this.liveTopicGeneration.get(item.sessionId)) continue;
 			const selectedAck = item.payload.selectedAck;
 			if (selectedAck) {
 				const { topicId } = item.payload;
@@ -2404,6 +3679,7 @@ export class TelegramNotificationDaemon {
 											richClass: undefined,
 										},
 										topicId,
+										topicGeneration: item.payload.topicGeneration,
 									},
 								});
 							}
@@ -2436,8 +3712,13 @@ export class TelegramNotificationDaemon {
 							// already shows this text); a missing/deleted backing message (or a
 							// transport error) resends so the first chunk is never lost.
 							let edited = false;
+							const release =
+								typeof stampedGen === "number"
+									? this.beginTopicOperation(item.sessionId, stampedGen)
+									: () => {};
+							if (!release) continue;
 							try {
-								const res = (await this.botApi.call("editMessageText", {
+								const res = (await this.providerBotApi.call("editMessageText", {
 									chat_id: this.opts.chatId,
 									message_id: existingId,
 									text: chunks[0],
@@ -2446,6 +3727,8 @@ export class TelegramNotificationDaemon {
 								edited = res?.ok !== false || /not modified/i.test(String(res?.description ?? ""));
 							} catch {
 								edited = false;
+							} finally {
+								release();
 							}
 							if (edited) {
 								firstMessageId = existingId;
@@ -2494,6 +3777,7 @@ export class TelegramNotificationDaemon {
 											richClass: undefined,
 										},
 										topicId,
+										topicGeneration: item.payload.topicGeneration,
 									},
 								});
 							}
@@ -2640,16 +3924,25 @@ export class TelegramNotificationDaemon {
 	}
 
 	/** Set a native reaction on an inbound thread message (best-effort). */
-	private async setReaction(messageId: number, emoji: string): Promise<void> {
-		if (!(await this.pairedChatIsPrivate())) return;
+	private async setReaction(
+		sessionId: string,
+		messageId: number,
+		emoji: string,
+		generation = this.admissionGeneration(sessionId),
+	): Promise<void> {
+		if (generation === undefined || !(await this.pairedChatIsPrivate())) return;
+		const release = this.beginTopicOperation(sessionId, generation);
+		if (!release) return;
 		try {
-			await this.botApi.call("setMessageReaction", {
+			await this.providerBotApi.call("setMessageReaction", {
 				chat_id: this.opts.chatId,
 				message_id: messageId,
 				reaction: [{ type: "emoji", emoji }],
 			});
 		} catch {
 			// Best-effort: reactions may be disallowed in the chat; never throw.
+		} finally {
+			release();
 		}
 	}
 
@@ -3057,7 +4350,7 @@ export class TelegramNotificationDaemon {
 			if (inbound.kind === "duplicate") return;
 			if (inbound.kind === "inject") {
 				const session = this.sessions.get(inbound.sessionId);
-				if (session?.ws.readyState === WebSocket.OPEN) {
+				if (session?.ws.readyState === WebSocket.OPEN && (await this.sessionAdmissionIsCurrent(session))) {
 					const attachmentResult = inbound.attachment
 						? await this.resolveInboundAttachment(inbound.attachment, inbound.sessionId)
 						: undefined;
@@ -3097,12 +4390,8 @@ export class TelegramNotificationDaemon {
 							await sendControlNotice(control.usage);
 							return;
 						}
-						if (session?.ws.readyState !== WebSocket.OPEN) {
-							await sendControlNotice("Session control unavailable: session is disconnected.");
-							return;
-						}
-						session.ws.send(
-							JSON.stringify({
+						if (
+							!(await this.sendToCurrentSession(session, {
 								type: "control_command",
 								sessionId: inbound.sessionId,
 								token: session.token,
@@ -3110,8 +4399,10 @@ export class TelegramNotificationDaemon {
 								updateId: inbound.updateId,
 								threadId: inbound.threadId,
 								command: control.command,
-							}),
-						);
+							}))
+						) {
+							await sendControlNotice("Session control unavailable: session is disconnected.");
+						}
 						return;
 					}
 					const cfg = hasMedia ? undefined : parseInThreadConfigCommand(inbound.text);
@@ -3121,20 +4412,25 @@ export class TelegramNotificationDaemon {
 					// to the ask's custom-input slot), so route the latest pending ask here.
 					const pendingAsk = cfg || hasMedia ? undefined : [...session.pending.values()].at(-1);
 					if (pendingAsk) {
-						session.ws.send(
-							JSON.stringify({
+						if (
+							!(await this.sendToCurrentSession(session, {
 								type: "reply",
 								id: pendingAsk.actionId,
 								answer: inbound.text,
 								token: session.token,
-							}),
-						);
+							}))
+						) {
+							return;
+						}
 						await this.rememberSeenUpdateId(inbound.updateId);
-						if (inbound.messageId !== undefined) await this.setReaction(inbound.messageId, QUEUED_REACTION);
+						if (inbound.messageId !== undefined) {
+							await this.setReaction(inbound.sessionId, inbound.messageId, QUEUED_REACTION);
+						}
 						return;
 					}
-					session.ws.send(
-						JSON.stringify(
+					if (
+						!(await this.sendToCurrentSession(
+							session,
 							cfg
 								? { type: "config_command", sessionId: inbound.sessionId, token: session.token, ...cfg }
 								: {
@@ -3146,16 +4442,27 @@ export class TelegramNotificationDaemon {
 										threadId: inbound.threadId,
 										images,
 									},
-						),
-					);
+						))
+					) {
+						return;
+					}
 					await this.rememberSeenUpdateId(inbound.updateId);
 					// User turns get a native delivery double-check: queued on receipt,
 					// flipped to consumed when the session acks the turn that picks it
 					// up. Config commands are not user turns and get no reaction.
 					if (!cfg && inbound.messageId !== undefined) {
-						this.inboundReactions.set(inbound.updateId, { messageId: inbound.messageId });
-						await this.setReaction(inbound.messageId, QUEUED_REACTION);
+						const generation = this.admissionGeneration(inbound.sessionId);
+						if (generation !== undefined) {
+							this.inboundReactions.set(inbound.updateId, {
+								messageId: inbound.messageId,
+								sessionId: inbound.sessionId,
+								generation,
+							});
+							await this.setReaction(inbound.sessionId, inbound.messageId, QUEUED_REACTION, generation);
+						}
 					}
+				} else if (session) {
+					this.dropSession(session, "admission_identity_mismatch");
 				}
 				return;
 			}
@@ -3168,13 +4475,27 @@ export class TelegramNotificationDaemon {
 		});
 		if (decision.kind === "reply") {
 			const session = this.sessions.get(decision.sessionId);
-			if (session?.ws.readyState !== WebSocket.OPEN || !session.pending.has(decision.actionId)) {
+			const admissionCurrent = session ? await this.sessionAdmissionIsCurrent(session) : false;
+			if (session && !admissionCurrent) this.dropSession(session, "admission_identity_mismatch");
+			if (
+				session?.ws.readyState !== WebSocket.OPEN ||
+				!session.pending.has(decision.actionId) ||
+				!admissionCurrent
+			) {
 				await this.sendStaleGuidance(callbackId);
 				return;
 			}
-			session.ws.send(
-				JSON.stringify({ type: "reply", id: decision.actionId, answer: decision.answer, token: session.token }),
-			);
+			if (
+				!(await this.sendToCurrentSession(session, {
+					type: "reply",
+					id: decision.actionId,
+					answer: decision.answer,
+					token: session.token,
+				}))
+			) {
+				await this.sendStaleGuidance(callbackId);
+				return;
+			}
 			await this.answerCallbackQueryBestEffort(callbackId);
 		} else if (decision.kind === "stale") {
 			await this.sendStaleGuidance(callbackId);
@@ -3219,17 +4540,21 @@ export class TelegramNotificationDaemon {
 		});
 		if (!this.running) return;
 		this.runtime.start();
-		this.startFlushTimer();
-		this.startScanTimer();
-		this.startTypingTimer();
 		try {
 			await this.refreshBotIdentity();
 			await this.registerBotCommands();
 			await this.loadAliases();
 			await this.loadTopics();
+			// F004: reconcile the durable deletion journal before scanning so a
+			// crash-completed (terminal) deletion finishes local cleanup without
+			// calling Telegram again, and a nonterminal claim is re-attempted.
+			await this.reconcileDeletionJournal();
 			await this.loadSeenUpdateIds();
 			await this.replyStore.load();
 			await this.runScan();
+			this.startFlushTimer();
+			this.startScanTimer();
+			this.startTypingTimer();
 			// Owner-only: start the session-lifecycle control server now that
 			// ownership is confirmed (singleton-safe). Best-effort; degrades.
 			await this.startLifecycleControl();

--- a/packages/coding-agent/src/sdk/bus/telegram-reference.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-reference.ts
@@ -306,22 +306,44 @@ export function routeInboundUpdate(update: unknown, ctx: RouteInboundContext): R
 	return { kind: "ignore" };
 }
 
-/** Read `{url, token, pid?, stale?}` from an endpoint discovery file. */
-export function readEndpoint(path: string): { url: string; token: string; pid?: number; stale?: boolean } {
+/** Read `{url, token, pid?, stale?, canonicalRoot?, leaseId?}` from an endpoint discovery file. */
+export function readEndpoint(path: string): {
+	url: string;
+	token: string;
+	pid?: number;
+	stale?: boolean;
+	canonicalRoot?: string;
+	leaseId?: string;
+} {
 	const raw = JSON.parse(fs.readFileSync(path, "utf8")) as {
 		url?: unknown;
 		token?: unknown;
 		pid?: unknown;
 		stale?: unknown;
+		canonicalRoot?: unknown;
+		leaseId?: unknown;
 	};
-	if (typeof raw.url !== "string" || typeof raw.token !== "string") {
+	if (
+		typeof raw.url !== "string" ||
+		raw.url.length === 0 ||
+		typeof raw.token !== "string" ||
+		raw.token.length === 0 ||
+		(raw.pid !== undefined && (typeof raw.pid !== "number" || !Number.isSafeInteger(raw.pid) || raw.pid <= 0)) ||
+		(raw.stale !== undefined && typeof raw.stale !== "boolean") ||
+		(raw.canonicalRoot !== undefined && (typeof raw.canonicalRoot !== "string" || raw.canonicalRoot.length === 0)) ||
+		(raw.leaseId !== undefined && (typeof raw.leaseId !== "string" || raw.leaseId.length === 0))
+	) {
 		throw new Error(`invalid endpoint file: ${path}`);
 	}
 	return {
 		url: raw.url,
 		token: raw.token,
-		pid: typeof raw.pid === "number" ? raw.pid : undefined,
+		...(raw.pid === undefined ? {} : { pid: raw.pid }),
 		stale: raw.stale === true,
+		...(typeof raw.canonicalRoot === "string" && raw.canonicalRoot.length > 0
+			? { canonicalRoot: raw.canonicalRoot }
+			: {}),
+		...(typeof raw.leaseId === "string" && raw.leaseId.length > 0 ? { leaseId: raw.leaseId } : {}),
 	};
 }
 

--- a/packages/coding-agent/test/notifications-telegram-daemon-crash.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon-crash.test.ts
@@ -1,0 +1,621 @@
+/**
+ * Telegram topic-deletion crash-durability matrix (PR #2173 replacement proof).
+ *
+ * These tests prove, on the PRODUCTION daemon path and against a hard SIGKILL,
+ * the persistence ordering of the per-session Telegram forum-topic deletion:
+ *
+ *   (1) durable deletion-journal claim  ──▶  provider `deleteForumTopic`
+ *   (2) provider terminal receipt       ──▶  topic-registry cleanup
+ *   (3) topic-registry cleanup          ──▶  roots compaction
+ *   (4) roots compaction                ──▶  reconciled journal receipt
+ *   (5) endpoint publication identity (canonicalRoot + leaseId) durability
+ *
+ * Each test spawns the SAME test file as an isolated child (`bun <this-file>
+ * --child <phase> <agentDir> <baseNow>`), drives the production daemon to the
+ * named cut point, writes a barrier file, and blocks. The parent observes the
+ * barrier via bounded polling, delivers SIGKILL, confirms the child exited, and
+ * asserts the exact durable state left on disk (proving the ordering at that
+ * cut survives a hard crash). It then restarts a fresh daemon in-process over
+ * the same temp agent dir and asserts the crash-replay contract:
+ *   - no duplicate provider delete after a terminal receipt (cuts 2/3/4);
+ *   - safe replay exactly once when the claim is nonterminal (cut 1);
+ *   - endpoint-carried identity drives admission on restart (cut 5).
+ *
+ * Only a fake Telegram provider is used — there are no production
+ * Telegram/network calls. Durable files come from `daemonPaths`,
+ * `registerNotificationRoot`, and the `TelegramNotificationDaemon`.
+ *
+ * Child invocation is a plain `bun <file> --child …` SCRIPT run (never the
+ * `bun test` runner), so the `describe`/`test` registrations below are guarded
+ * out of child mode and the child fixture blocks on a keepalive until SIGKILL.
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Settings } from "../src/config/settings";
+import { type ChatEffect, ChatEffectJournal, type ChatEffectReceipt } from "../src/sdk/bus/chat-effect-journal";
+import {
+	daemonPaths,
+	registerNotificationRoot,
+	stampEndpointPublicationIdentity,
+	type TelegramDaemonFs,
+	TelegramNotificationDaemon,
+} from "../src/sdk/bus/telegram-daemon";
+
+// --------------------------------------------------------------------------- //
+// Shared constants                                                            //
+// --------------------------------------------------------------------------- //
+
+const CHAT_ID = "42";
+const SESSION_ID = "S";
+const LEASE_ID = "lease-1";
+/** Deterministic forum-topic id returned by the fake provider's createForumTopic. */
+const TOPIC_ID = "777";
+const CHILD_PID = 4242;
+const CHILD_FLAG = "--child";
+const CHILD_MODE = process.argv.includes(CHILD_FLAG);
+const HERE = fileURLToPath(import.meta.url);
+const BUN = process.execPath;
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+type CrashPhase =
+	| "claim-before-provider"
+	| "provider-terminal-before-topic-registry"
+	| "topic-registry-before-roots-compaction"
+	| "roots-before-reconciled"
+	| "endpoint-publication-identity";
+
+const barrierPath = (agentDir: string, phase: CrashPhase): string => path.join(agentDir, `barrier-${phase}.json`);
+const CHILD_ERROR_FILE = "child-error.json";
+
+// --------------------------------------------------------------------------- //
+// Shared fakes + helpers (mirrors of notifications-telegram-daemon.test.ts)   //
+// --------------------------------------------------------------------------- //
+
+function tempAgentDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-telegram-crash-"));
+}
+
+function setPrivateAgentDir(s: Settings, agentDir: string): Settings {
+	return new Proxy(s, {
+		get(target, prop) {
+			if (prop === "getAgentDir") return () => agentDir;
+			const value = Reflect.get(target, prop, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	}) as Settings;
+}
+
+function settings(agentDir: string): Settings {
+	// Isolate getAgentDir() to the temp dir so daemon persistence never touches
+	// the real global ~/.gjc/agent.
+	return setPrivateAgentDir(
+		Settings.isolated({
+			"notifications.enabled": true,
+			"notifications.telegram.botToken": "123456:secret-token",
+			"notifications.telegram.chatId": CHAT_ID,
+			"notifications.daemon.idleTimeoutMs": 20,
+		}) as Settings,
+		agentDir,
+	);
+}
+
+/** Minimal WebSocket stand-in; scanRoots connects live endpoints through it. */
+class FakeWs extends EventTarget {
+	static OPEN = 1;
+	readyState = 1;
+	sent: string[] = [];
+	static instances: FakeWs[] = [];
+	constructor(public url = "") {
+		super();
+		FakeWs.instances.push(this);
+	}
+	send(data: string): void {
+		this.sent.push(data);
+	}
+	close(): void {
+		this.readyState = 3;
+		this.dispatchEvent(new Event("close"));
+	}
+}
+
+/** Fake Telegram provider: deterministic topic id; deleteForumTopic returns OK. */
+class FakeBotApi {
+	calls: Array<{ method: string; body: unknown }> = [];
+	async call(method: string, body: unknown): Promise<unknown> {
+		this.calls.push({ method, body });
+		if (method === "getUpdates") return { ok: true, result: [] };
+		if (method === "getMe") return { ok: true, result: { id: 1 } };
+		if (method === "getChat")
+			return { ok: true, result: { id: (body as { chat_id?: unknown }).chat_id, type: "private" } };
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: Number(TOPIC_ID) } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: 1 } };
+		// deleteForumTopic: the only positive signal is an explicit OK.
+		return { ok: true, result: true };
+	}
+}
+
+function rootsRegistrySnapshot(agentDir: string): {
+	roots: string[];
+	sessions: Record<string, string>;
+	sessionLeases: Record<string, { leaseId: string; refreshedAt: number }>;
+	orphanCandidates: Record<string, unknown>;
+} {
+	const file = daemonPaths(agentDir).roots;
+	if (!fs.existsSync(file)) return { roots: [], sessions: {}, sessionLeases: {}, orphanCandidates: {} };
+	return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function topicRegistrySnapshot(agentDir: string): {
+	topics: Record<string, { topicId: string; createdAt: number; [key: string]: unknown }>;
+} {
+	const file = path.join(daemonPaths(agentDir).dir, "telegram-topics.json");
+	if (!fs.existsSync(file)) return { topics: {} };
+	return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+async function telegramDeletionEffects(agentDir: string): Promise<ChatEffect[]> {
+	return new ChatEffectJournal({ agentDir, transport: "telegram" }).list();
+}
+
+function topicIdOf(effect: ChatEffect): string | undefined {
+	return (effect.payload as { topicId?: string } | undefined)?.topicId;
+}
+
+/**
+ * Register a notification root and publish a live identity-bearing endpoint file
+ * (canonicalRoot + leaseId stamped from the registration) via the production
+ * publication path.
+ */
+async function publishIdentityEndpoint(
+	s: Settings,
+	cwd: string,
+	sessionId: string,
+	url: string,
+	token: string,
+	opts?: { now?: () => number; randomId?: () => string; pid?: number },
+): Promise<{ canonicalRoot: string; leaseId: string }> {
+	const reg = await registerNotificationRoot({ settings: s, cwd, sessionId, ...(opts ?? {}) });
+	const dir = path.join(reg.root, "sdk");
+	fs.mkdirSync(dir, { recursive: true });
+	const endpointPath = path.join(dir, `${sessionId}.json`);
+	fs.writeFileSync(
+		endpointPath,
+		JSON.stringify({ url, token, ...(opts?.pid === undefined ? {} : { pid: opts.pid }) }),
+	);
+	await stampEndpointPublicationIdentity(endpointPath, {
+		canonicalRoot: reg.root,
+		leaseId: reg.leaseId,
+	});
+	return { canonicalRoot: reg.root, leaseId: reg.leaseId };
+}
+
+// --------------------------------------------------------------------------- //
+// Crash-cut gates                                                             //
+// --------------------------------------------------------------------------- //
+
+/**
+ * Write the cut-point barrier and block forever. The keepalive `setInterval`
+ * guarantees the child stays alive until the parent delivers SIGKILL — a bare
+ * pending promise alone does not keep the event loop from draining.
+ */
+function hitBarrier(agentDir: string, phase: CrashPhase): Promise<never> {
+	fs.writeFileSync(barrierPath(agentDir, phase), JSON.stringify({ phase, at: Date.now() }));
+	setInterval(() => undefined, 60_000);
+	return new Promise<never>(() => undefined);
+}
+
+/**
+ * `TelegramDaemonFs` that delegates every operation to the real fs but, once
+ * `gate.armed` is raised, blocks the durable write that follows the named cut
+ * point. Used for cuts (2) and (3); all other writes (including setup) pass
+ * through so the durable claim/registry state is exercised truthfully.
+ */
+function makeGatedFs(phase: CrashPhase, gate: { armed: boolean }, agentDir: string): TelegramDaemonFs {
+	return {
+		mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+		readFile: (file, encoding) => fs.promises.readFile(file, encoding),
+		writeFile: async (file, data, opts) => {
+			const target = String(file);
+			if (
+				gate.armed &&
+				phase === "provider-terminal-before-topic-registry" &&
+				target.includes("telegram-topics.json")
+			) {
+				// Cut (2): provider terminal receipt is already durable; block the
+				// topic-registry cleanup before it reaches disk.
+				await hitBarrier(agentDir, phase);
+			}
+			if (
+				gate.armed &&
+				phase === "topic-registry-before-roots-compaction" &&
+				target.includes("telegram-daemon.roots.json")
+			) {
+				// Cut (3): topic-registry cleanup is already durable; block the roots
+				// compaction write before it reaches disk.
+				await hitBarrier(agentDir, phase);
+			}
+			await fs.promises.writeFile(file, data, opts);
+		},
+		rename: (oldPath, newPath) => fs.promises.rename(oldPath, newPath).then(() => undefined),
+		unlink: file => fs.promises.unlink(file),
+		open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
+		readdir: file => fs.promises.readdir(file),
+		chmod: (file, mode) => fs.promises.chmod(file, mode),
+	};
+}
+
+/** FakeBotApi that blocks `deleteForumTopic` forever, gating cut (1). */
+class GatedBotApi extends FakeBotApi {
+	constructor(private readonly crashAgentDir: string) {
+		super();
+	}
+	override async call(method: string, body: unknown): Promise<unknown> {
+		if (method === "deleteForumTopic") {
+			// Cut (1): the durable claim is already recorded; block before the
+			// provider resolves (terminal receipt must never reach disk here).
+			await hitBarrier(this.crashAgentDir, "claim-before-provider");
+		}
+		return super.call(method, body);
+	}
+}
+
+/**
+ * ChatEffectJournal whose `updateTerminalReceipt` (the reconciled-receipt write)
+ * blocks forever, gating cut (4). Every other operation (enqueue/claim/record)
+ * delegates to the real durable journal.
+ */
+class GatedChatEffectJournal extends ChatEffectJournal {
+	constructor(private readonly crashAgentDir: string) {
+		super({ agentDir: crashAgentDir, transport: "telegram" });
+	}
+	override async updateTerminalReceipt<TPayload = unknown>(
+		_id: string,
+		_receipt: ChatEffectReceipt,
+	): Promise<ChatEffect<TPayload> | undefined> {
+		// Cut (4): roots compaction is already durable; block the reconciled
+		// journal receipt before it reaches disk.
+		return hitBarrier(this.crashAgentDir, "roots-before-reconciled");
+	}
+}
+
+// --------------------------------------------------------------------------- //
+// Child fixture                                                               //
+// --------------------------------------------------------------------------- //
+
+async function runChildFixture(phase: CrashPhase, agentDir: string, baseNow: number): Promise<void> {
+	// Keep the child alive from the very first tick so setup never lets the
+	// process exit before the barrier is reached.
+	const keepalive = setInterval(() => undefined, 60_000);
+	try {
+		const s = settings(agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+
+		// Production publication path: durable roots registry + stamped endpoint.
+		await publishIdentityEndpoint(s, cwd, SESSION_ID, "ws://child", "ttok", {
+			randomId: () => LEASE_ID,
+			now: () => 1000,
+			pid: CHILD_PID,
+		});
+
+		// Cut (5) crashes immediately after the identity is durably published,
+		// before any daemon work.
+		if (phase === "endpoint-publication-identity") {
+			await hitBarrier(agentDir, phase);
+		}
+
+		// Build the phase-gated production seams.
+		const gate = { armed: false };
+		const botApi = phase === "claim-before-provider" ? new GatedBotApi(agentDir) : new FakeBotApi();
+		const gatedFs =
+			phase === "provider-terminal-before-topic-registry" || phase === "topic-registry-before-roots-compaction"
+				? makeGatedFs(phase, gate, agentDir)
+				: undefined;
+		const deletionJournal = phase === "roots-before-reconciled" ? new GatedChatEffectJournal(agentDir) : undefined;
+
+		const daemonOptions: ConstructorParameters<typeof TelegramNotificationDaemon>[0] = {
+			settings: s,
+			ownerId: "owner-crash",
+			botToken: "ttok",
+			chatId: CHAT_ID,
+			botApi: botApi,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+			topicDeleteTimeoutMs: 60_000,
+			now: () => baseNow,
+		};
+		if (gatedFs) daemonOptions.fs = gatedFs;
+		if (deletionJournal) daemonOptions.deletionJournal = deletionJournal;
+
+		const daemon = new TelegramNotificationDaemon(daemonOptions);
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const session = daemon.sessions.get(SESSION_ID);
+		if (!session) throw new Error("child: session S was not admitted by scanRoots");
+
+		// Create the topic on the production path (persisted during setup).
+		await daemon.handleSessionMessage(session, {
+			type: "identity_header",
+			sessionId: SESSION_ID,
+			repo: "r",
+			branch: "b",
+		});
+
+		// Arm the durable-write gate only now, so setup writes are never blocked.
+		gate.armed = true;
+
+		// Drive the full destructive close path; the phase gate blocks at the cut.
+		await daemon.handleSessionMessage(session, { type: "session_closed", sessionId: SESSION_ID });
+		// Unreachable: the gate blocks forever and the parent delivers SIGKILL.
+		throw new Error(`child: phase ${phase} did not block at its cut point`);
+	} catch (err) {
+		clearInterval(keepalive);
+		fs.writeFileSync(
+			path.join(agentDir, CHILD_ERROR_FILE),
+			JSON.stringify({ error: String((err as Error)?.stack ?? err) }),
+		);
+		process.exit(1);
+	}
+}
+
+if (CHILD_MODE) {
+	const idx = process.argv.indexOf(CHILD_FLAG);
+	const phase = process.argv[idx + 1] as CrashPhase;
+	const agentDir = process.argv[idx + 2];
+	const baseNowRaw = Number(process.argv[idx + 3]);
+	const baseNow = Number.isFinite(baseNowRaw) ? baseNowRaw : Date.now();
+	await runChildFixture(phase, agentDir, baseNow);
+}
+
+// --------------------------------------------------------------------------- //
+// Parent orchestration                                                        //
+// --------------------------------------------------------------------------- //
+
+async function confirmExit(proc: ReturnType<typeof Bun.spawn>, timeoutMs = 5_000): Promise<void> {
+	const exited = await Promise.race([
+		proc.exited.then(
+			() => true,
+			() => true,
+		),
+		sleep(timeoutMs).then(() => false),
+	]);
+	if (!exited) throw new Error(`crash child ${proc.pid} did not exit within ${timeoutMs}ms`);
+}
+
+/**
+ * Spawn the child for `phase`, bounded-poll for its barrier, then SIGKILL it and
+ * confirm the exit. Throws with the child's recorded error if setup failed.
+ */
+async function waitForBarrierAndKill(agentDir: string, phase: CrashPhase, baseNow: number): Promise<void> {
+	const barrier = barrierPath(agentDir, phase);
+	const errFile = path.join(agentDir, CHILD_ERROR_FILE);
+	const proc = Bun.spawn([BUN, HERE, CHILD_FLAG, phase, agentDir, String(baseNow)], {
+		cwd: path.dirname(HERE),
+		stdout: "ignore",
+		stderr: "pipe",
+		env: { ...process.env },
+	});
+	const deadline = Date.now() + 20_000;
+	try {
+		while (Date.now() < deadline) {
+			if (fs.existsSync(barrier)) {
+				proc.kill("SIGKILL");
+				await confirmExit(proc);
+				return;
+			}
+			if (fs.existsSync(errFile)) {
+				throw new Error(`child setup failed: ${fs.readFileSync(errFile, "utf8")}`);
+			}
+			if (proc.exitCode !== null) {
+				const stderrText = await new Response(proc.stderr).text().catch(() => "");
+				throw new Error(`child exited early code=${proc.exitCode} stderr=${stderrText.slice(0, 800)}`);
+			}
+			await sleep(25);
+		}
+		throw new Error(`child never reached barrier for phase ${phase}`);
+	} finally {
+		try {
+			proc.kill("SIGKILL");
+		} catch {
+			// Already dead.
+		}
+		await confirmExit(proc);
+	}
+}
+
+/** Restart a fresh daemon over the crash survivor and run startup reconciliation. */
+async function reconcileAfterCrash(agentDir: string, baseNow: number): Promise<FakeBotApi> {
+	FakeWs.instances = [];
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner-restart",
+		botToken: "ttok",
+		chatId: CHAT_ID,
+		botApi: bot,
+		WebSocketImpl: FakeWs as never,
+		pidAlive: () => true,
+		// Advance the clock past the child's 60s deletion lease so a nonterminal
+		// (leased) claim is reclaimable by the restart owner for safe replay.
+		now: () => baseNow + 120_000,
+	});
+	await daemon.loadTopics();
+	await daemon.scanRoots();
+	return bot;
+}
+
+const deleteForumTopicCount = (bot: FakeBotApi): number =>
+	bot.calls.filter(c => c.method === "deleteForumTopic").length;
+
+// --------------------------------------------------------------------------- //
+// Tests (parent / test-runner mode only)                                      //
+// --------------------------------------------------------------------------- //
+
+if (!CHILD_MODE) {
+	describe("telegram daemon crash durability (subprocess SIGKILL/barrier)", () => {
+		test("cut 1: durable deletion-journal claim is recorded before provider resolution; restart replays the nonterminal claim exactly once", async () => {
+			const agentDir = tempAgentDir();
+			const baseNow = Date.now();
+			await waitForBarrierAndKill(agentDir, "claim-before-provider", baseNow);
+
+			// After SIGKILL: the claim is durable and leased (nonterminal), no
+			// terminal receipt reached disk, and no destructive mutation (topic
+			// removal / roots compaction) happened.
+			const claim = (await telegramDeletionEffects(agentDir)).find(e => topicIdOf(e) === TOPIC_ID);
+			expect(claim, "durable claim must exist after the crash").toBeDefined();
+			expect(claim!.state).toBe("leased");
+			expect(claim!.receipt?.status).toBeUndefined();
+			expect(topicRegistrySnapshot(agentDir).topics[SESSION_ID]).toBeDefined();
+			const roots = rootsRegistrySnapshot(agentDir);
+			expect(roots.sessionLeases[SESSION_ID]?.leaseId).toBe(LEASE_ID);
+			expect(roots.sessions[SESSION_ID]).toBeDefined();
+
+			// Restart: safe replay of the nonterminal claim — exactly one provider
+			// delete, then local cleanup and a reconciled receipt.
+			const restartBot = await reconcileAfterCrash(agentDir, baseNow);
+			expect(deleteForumTopicCount(restartBot)).toBe(1);
+			expect(topicRegistrySnapshot(agentDir).topics[SESSION_ID]).toBeUndefined();
+			const rootsAfter = rootsRegistrySnapshot(agentDir);
+			expect(rootsAfter.sessionLeases[SESSION_ID]).toBeUndefined();
+			expect(rootsAfter.sessions[SESSION_ID]).toBeUndefined();
+			const claimAfter = (await telegramDeletionEffects(agentDir)).find(e => topicIdOf(e) === TOPIC_ID);
+			expect(claimAfter!.state).toBe("terminal");
+			expect(claimAfter!.receipt?.status).toBe("reconciled");
+		});
+
+		test("cut 2: provider terminal receipt is durable before topic-registry cleanup; restart finishes cleanup without a duplicate provider delete", async () => {
+			const agentDir = tempAgentDir();
+			const baseNow = Date.now();
+			await waitForBarrierAndKill(agentDir, "provider-terminal-before-topic-registry", baseNow);
+
+			// After SIGKILL: terminal "deleted" receipt is durable; the topic
+			// registry still holds the topic (persistTopics had not reached disk);
+			// roots are intact.
+			const claim = (await telegramDeletionEffects(agentDir)).find(e => topicIdOf(e) === TOPIC_ID)!;
+			expect(claim.state).toBe("terminal");
+			expect(claim.receipt?.status).toBe("deleted");
+			expect(topicRegistrySnapshot(agentDir).topics[SESSION_ID]).toBeDefined();
+			const roots = rootsRegistrySnapshot(agentDir);
+			expect(roots.sessionLeases[SESSION_ID]?.leaseId).toBe(LEASE_ID);
+			expect(roots.sessions[SESSION_ID]).toBeDefined();
+
+			// Restart: exact-current terminal claim finishes local cleanup WITHOUT
+			// another provider call, then compacts and reconciles.
+			const restartBot = await reconcileAfterCrash(agentDir, baseNow);
+			expect(deleteForumTopicCount(restartBot)).toBe(0);
+			expect(topicRegistrySnapshot(agentDir).topics[SESSION_ID]).toBeUndefined();
+			const rootsAfter = rootsRegistrySnapshot(agentDir);
+			expect(rootsAfter.sessionLeases[SESSION_ID]).toBeUndefined();
+			expect(rootsAfter.sessions[SESSION_ID]).toBeUndefined();
+			const claimAfter = (await telegramDeletionEffects(agentDir)).find(e => topicIdOf(e) === TOPIC_ID)!;
+			expect(claimAfter.receipt?.status).toBe("reconciled");
+		});
+
+		test("cut 3: topic-registry cleanup is durable before roots compaction; restart compacts without a duplicate provider delete", async () => {
+			const agentDir = tempAgentDir();
+			const baseNow = Date.now();
+			await waitForBarrierAndKill(agentDir, "topic-registry-before-roots-compaction", baseNow);
+
+			// After SIGKILL: the topic is removed from the registry (persistTopics
+			// reached disk), but roots were NOT compacted (the compaction write was
+			// the blocked cut); the claim is terminal "deleted".
+			expect(topicRegistrySnapshot(agentDir).topics[SESSION_ID]).toBeUndefined();
+			const roots = rootsRegistrySnapshot(agentDir);
+			expect(roots.sessionLeases[SESSION_ID]?.leaseId).toBe(LEASE_ID);
+			expect(roots.sessions[SESSION_ID]).toBeDefined();
+			const claim = (await telegramDeletionEffects(agentDir)).find(e => topicIdOf(e) === TOPIC_ID)!;
+			expect(claim.state).toBe("terminal");
+			expect(claim.receipt?.status).toBe("deleted");
+
+			// Restart: the exact-current terminal claim compacts roots (reclaiming
+			// the stale lock the SIGKILLed child left) and reconciles without a
+			// provider call.
+			const restartBot = await reconcileAfterCrash(agentDir, baseNow);
+			expect(deleteForumTopicCount(restartBot)).toBe(0);
+			expect(topicRegistrySnapshot(agentDir).topics[SESSION_ID]).toBeUndefined();
+			const rootsAfter = rootsRegistrySnapshot(agentDir);
+			expect(rootsAfter.sessionLeases[SESSION_ID]).toBeUndefined();
+			expect(rootsAfter.sessions[SESSION_ID]).toBeUndefined();
+			const claimAfter = (await telegramDeletionEffects(agentDir)).find(e => topicIdOf(e) === TOPIC_ID)!;
+			expect(claimAfter.receipt?.status).toBe("reconciled");
+		});
+
+		test("cut 4: roots compaction is durable before the reconciled journal receipt; restart never re-deletes", async () => {
+			const agentDir = tempAgentDir();
+			const baseNow = Date.now();
+			await waitForBarrierAndKill(agentDir, "roots-before-reconciled", baseNow);
+
+			// After SIGKILL: roots are compacted (session/lease/root removed) and
+			// the topic registry is cleaned — both reached disk — but the journal
+			// receipt is still terminal "deleted" (the reconciled write was the cut).
+			expect(topicRegistrySnapshot(agentDir).topics[SESSION_ID]).toBeUndefined();
+			const roots = rootsRegistrySnapshot(agentDir);
+			expect(roots.sessionLeases[SESSION_ID]).toBeUndefined();
+			expect(roots.sessions[SESSION_ID]).toBeUndefined();
+			const claim = (await telegramDeletionEffects(agentDir)).find(e => topicIdOf(e) === TOPIC_ID)!;
+			expect(claim.state).toBe("terminal");
+			expect(claim.receipt?.status).toBe("deleted");
+
+			// Restart: the terminal claim is never re-deleted (no duplicate provider
+			// call). Compaction already removed the session's durable authority, so
+			// tri-state evidence is UNKNOWN and reconciliation leaves the terminal
+			// claim untouched rather than risk an action — it never calls Telegram.
+			const restartBot = await reconcileAfterCrash(agentDir, baseNow);
+			expect(deleteForumTopicCount(restartBot)).toBe(0);
+			expect(topicRegistrySnapshot(agentDir).topics[SESSION_ID]).toBeUndefined();
+			const rootsAfter = rootsRegistrySnapshot(agentDir);
+			expect(rootsAfter.sessionLeases[SESSION_ID]).toBeUndefined();
+			expect(rootsAfter.sessions[SESSION_ID]).toBeUndefined();
+			const claimAfter = (await telegramDeletionEffects(agentDir)).find(e => topicIdOf(e) === TOPIC_ID)!;
+			expect(claimAfter.state).toBe("terminal");
+			expect(claimAfter.receipt?.status).toBe("deleted");
+		});
+
+		test("cut 5: endpoint publication identity (canonicalRoot + leaseId) is durable across a hard crash and drives admission on restart", async () => {
+			const agentDir = tempAgentDir();
+			const baseNow = Date.now();
+			await waitForBarrierAndKill(agentDir, "endpoint-publication-identity", baseNow);
+
+			// After SIGKILL: the production stamper durably wrote BOTH the roots
+			// registry (session→canonicalRoot mapping + lease) AND the endpoint
+			// file's immutable canonicalRoot+leaseId identity.
+			const roots = rootsRegistrySnapshot(agentDir);
+			expect(roots.sessionLeases[SESSION_ID]?.leaseId).toBe(LEASE_ID);
+			const canonicalRoot = roots.sessions[SESSION_ID];
+			expect(canonicalRoot, "registered canonical root must be durable").toBeDefined();
+			const endpoint = JSON.parse(
+				fs.readFileSync(path.join(canonicalRoot!, "sdk", `${SESSION_ID}.json`), "utf8"),
+			) as Record<string, unknown>;
+			expect(endpoint).toMatchObject({
+				url: "ws://child",
+				token: "ttok",
+				pid: CHILD_PID,
+				canonicalRoot: canonicalRoot,
+				leaseId: LEASE_ID,
+			});
+
+			// Restart: a fresh daemon re-reads the stamped endpoint and admits the
+			// session under the exact endpoint-carried identity.
+			FakeWs.instances = [];
+			const daemon = new TelegramNotificationDaemon({
+				settings: settings(agentDir),
+				ownerId: "owner-restart",
+				botToken: "ttok",
+				chatId: CHAT_ID,
+				botApi: new FakeBotApi(),
+				WebSocketImpl: FakeWs as never,
+				pidAlive: () => true,
+				now: () => baseNow + 120_000,
+			});
+			await daemon.loadTopics();
+			await daemon.scanRoots();
+			const session = daemon.sessions.get(SESSION_ID);
+			expect(session, "session must be admitted from the durable stamped endpoint").toBeDefined();
+			expect(session!.leaseId).toBe(LEASE_ID);
+		});
+	});
+}

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -260,6 +260,16 @@ function topicRegistrySnapshot(agentDir: string): {
 	if (!fs.existsSync(file)) return { topics: {} };
 	return JSON.parse(fs.readFileSync(file, "utf8"));
 }
+/** Seed a telegram topic record for deletion/reconciliation tests. */
+function seedTopic(agentDir: string, sessionId: string, topicId: string): void {
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+	const file = path.join(daemonPaths(agentDir).dir, "telegram-topics.json");
+	const existing = fs.existsSync(file)
+		? (JSON.parse(fs.readFileSync(file, "utf8")) as { topics: Record<string, unknown> })
+		: { topics: {} };
+	existing.topics[sessionId] = { topicId, identitySent: true, createdAt: 1_000, name: sessionId };
+	fs.writeFileSync(file, JSON.stringify(existing));
+}
 
 /** Read the durable telegram deletion-claim effects for crash-replay/retry assertions. */
 async function telegramDeletionEffects(agentDir: string): Promise<ChatEffect[]> {
@@ -3680,25 +3690,16 @@ test("a fresh registration that wins before delete intent restores topic admissi
 	const agentDir = tempAgentDir();
 	const s = settings(agentDir);
 	const cwd = path.join(agentDir, "repo");
-	const reg = await registerNotificationRoot({
-		settings: s,
-		cwd,
-		sessionId: "S",
+	fs.mkdirSync(cwd, { recursive: true });
+	const identity = await publishIdentityEndpoint(s, cwd, "S", "ws://s", "tok", {
 		randomId: () => "lease-old",
 	});
-	const sendStarted = Promise.withResolvers<void>();
-	const releaseSend = Promise.withResolvers<void>();
 	const calls: Array<{ method: string; body: any }> = [];
 	const bot = {
 		async call(method: string, body: unknown): Promise<unknown> {
 			calls.push({ method, body });
-			const request = body as { text?: unknown };
 			if (method === "getChat") return { ok: true, result: { id: 42, type: "private" } };
 			if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 903 } };
-			if (method === "sendMessage" && String(request.text).includes("hold-delete")) {
-				sendStarted.resolve();
-				await releaseSend.promise;
-			}
 			if (method === "sendMessage") return { ok: true, result: { message_id: calls.length } };
 			return { ok: true, result: true };
 		},
@@ -3712,41 +3713,35 @@ test("a fresh registration that wins before delete intent restores topic admissi
 		WebSocketImpl: FakeWs as any,
 		rich: { enabled: false },
 	});
-	const session = {
-		sessionId: "S",
-		token: "tok",
-		endpointKey: "ws://s\0tok",
-		canonicalRoot: reg.root,
-		leaseId: reg.leaseId,
-		ws: { readyState: 1, send() {} },
-		pending: new Map(),
-	};
+	daemon.connectSession("S", "ws://s", "tok", identity);
+	const session = daemon.sessions.get("S")!;
 	await daemon.handleSessionMessage(session as any, {
 		type: "identity_header",
 		sessionId: "S",
 		repo: "r",
 		branch: "b",
 	});
+	const internals = daemon as unknown as {
+		deleteTopic(sessionId: string, leaseId: string): Promise<void>;
+		fencedTopicGeneration: Map<string, number>;
+		liveTopicGeneration: Map<string, number>;
+	};
+	const liveGen = internals.liveTopicGeneration.get("S");
 
-	const heldSend = daemon.handleSessionMessage(session as any, {
-		type: "turn_stream",
-		sessionId: "S",
-		phase: "finalized",
-		text: "hold-delete",
-	});
-	await sendStarted.promise;
-	const close = daemon.handleSessionMessage(session as any, { type: "session_closed", sessionId: "S" });
-	await Promise.resolve();
+	// The successor registers BEFORE the predecessor delete is attempted, so the
+	// predecessor's authority acquisition observes a positively SUPERSEDED registry
+	// (tri-state) and acquires NO authority — no fence, no provider call.
 	await registerNotificationRoot({
 		settings: s,
 		cwd,
 		sessionId: "S",
 		randomId: () => "lease-new",
 	});
-	releaseSend.resolve();
-	await Promise.all([heldSend, close]);
+	await internals.deleteTopic("S", "lease-old");
 
 	expect(calls.some(call => call.method === "deleteForumTopic")).toBe(false);
+	expect(internals.fencedTopicGeneration.has("S")).toBe(false);
+	expect(internals.liveTopicGeneration.get("S")).toBe(liveGen);
 	expect(rootsRegistrySnapshot(agentDir).sessionLeases.S.leaseId).toBe("lease-new");
 
 	await connectIdentitySession(daemon, "S", "ws://resumed", "tok2");
@@ -4999,7 +4994,7 @@ test("a terminal deletion record for the same session/topic under an old lease c
 	// Seed a terminal deletion record for an OLD lease (a prior completed delete
 	// that left a durable terminal marker for the same session/topic).
 	const seedJournal = new ChatEffectJournal({ agentDir, transport: "telegram", now: () => now });
-	const oldEffectId = "telegram.topic_delete:S:701:lease-old";
+	const oldEffectId = "telegram.topic_delete:42:S:701:lease-old";
 	const seeded = await seedJournal.enqueueAndClaim(
 		{
 			id: oldEffectId,
@@ -5052,7 +5047,7 @@ test("a terminal deletion record for the same session/topic under an old lease c
 	await daemon.scanRoots();
 	expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([701]);
 	const effects = await telegramDeletionEffects(agentDir);
-	expect(effects.find(e => e.id === "telegram.topic_delete:S:701:lease-new")?.state).toBe("terminal");
+	expect(effects.find(e => e.id === "telegram.topic_delete:42:S:701:lease-new")?.state).toBe("terminal");
 	expect(effects.find(e => e.id === oldEffectId)?.state).toBe("terminal");
 });
 
@@ -7342,5 +7337,685 @@ describe("telegram daemon immutable-head review (predecessor close, ambiguous re
 			effect => (effect.payload as { topicId?: string })?.topicId === topicId,
 		);
 		expect(reconciled?.receipt?.status).toBe("reconciled");
+	});
+});
+// ---------------------------------------------------------------------------
+describe("telegram daemon deletion authority (tri-state, quarantine, fail-closed provider)", () => {
+	type DeletionInternals = {
+		fencedTopicGeneration: Map<string, number>;
+		liveTopicGeneration: Map<string, number>;
+		deleteTopic(sessionId: string, leaseId: string): Promise<void>;
+		reconcileDeletionJournal(): Promise<void>;
+	};
+	const internals = (daemon: TelegramNotificationDaemon): DeletionInternals => daemon as unknown as DeletionInternals;
+
+	const CHAT = "42";
+
+	/** Seed a pending (nonterminal) telegram topic-delete effect directly in the journal. */
+	async function seedPendingDeleteEffect(
+		agentDir: string,
+		sessionId: string,
+		topicId: string,
+		leaseId: string,
+		chatId: string = CHAT,
+	): Promise<void> {
+		const journal = new ChatEffectJournal({ agentDir, transport: "telegram" });
+		await journal.enqueue({
+			id: `telegram.topic_delete:${chatId}:${sessionId}:${topicId}:${leaseId}`,
+			kind: "telegram.topic_delete",
+			transport: "telegram",
+			sessionId,
+			endpointGeneration: 0,
+			payload: { chatId, topicId, leaseId },
+		});
+	}
+
+	function deletionEffect(agentDir: string, sessionId: string, topicId: string, leaseId: string, chatId = CHAT) {
+		return (async () => {
+			const all = await telegramDeletionEffects(agentDir);
+			return all.find(
+				e =>
+					e.sessionId === sessionId &&
+					(e.payload as { topicId?: string; chatId?: string })?.topicId === topicId &&
+					(e.payload as { chatId?: string })?.chatId === chatId &&
+					(e.payload as { leaseId?: string })?.leaseId === leaseId,
+			);
+		})();
+	}
+
+	test("every non-OK deleteForumTopic response is uncertain (fail-closed, no description regex)", async () => {
+		const responses: Array<Record<string, unknown>> = [
+			{ ok: false, error_code: 400, description: "Bad Request: TOPIC_CLOSED" },
+			{ ok: false, error_code: 400, description: "Bad Request: message thread not found" },
+			{ ok: false, error_code: 400, description: "Bad Request: topic is already deleted" },
+			{ ok: false, error_code: 403, description: "Forbidden: bot was blocked by the user" },
+			{ ok: false, error_code: 500, description: "Internal Server Error" },
+			{ ok: false, error_code: 400, description: "Bad Request: chat not found" },
+		];
+		for (const resp of responses) {
+			const agentDir = tempAgentDir();
+			const s = settings(agentDir);
+			const identity = await publishIdentityEndpoint(s, path.join(agentDir, "repo"), "S", "ws://s", "tok");
+			const bot = new FakeBotApi();
+			(bot.call as (m: string, b: unknown) => Promise<unknown>) = ((method: string, body: unknown) => {
+				if (method === "deleteForumTopic") {
+					bot.calls.push({ method, body });
+					return Promise.resolve(structuredClone(resp));
+				}
+				return FakeBotApi.prototype.call.call(bot, method, body);
+			}) as never;
+			const daemon = new TelegramNotificationDaemon({
+				settings: s,
+				ownerId: "owner",
+				botToken: "tok",
+				chatId: CHAT,
+				botApi: bot,
+				WebSocketImpl: FakeWs as never,
+			});
+			daemon.connectSession("S", "ws://s", "tok", identity);
+			const session = daemon.sessions.get("S")!;
+			await daemon.handleSessionMessage(session as any, {
+				type: "identity_header",
+				sessionId: "S",
+				repo: "r",
+				branch: "b",
+			});
+			await daemon.handleSessionMessage(session as any, { type: "session_closed", sessionId: "S" });
+
+			const deletes = bot.calls.filter(c => c.method === "deleteForumTopic");
+			expect(deletes).toHaveLength(1);
+			// Topic retained (uncertain); the receipt is NEVER "deleted"/"reconciled".
+			expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+			const claim = await deletionEffect(
+				agentDir,
+				"S",
+				deletes[0]!.body.message_thread_id.toString(),
+				identity.leaseId,
+			);
+			expect(claim?.state).toBe("uncertain");
+			expect(claim?.receipt?.status).not.toBe("deleted");
+			expect(String(claim?.receipt?.status ?? "").startsWith("reconciled")).toBe(false);
+		}
+	});
+
+	test("a 429 deleteForumTopic preserves the exact retry_after in the uncertain receipt", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const identity = await publishIdentityEndpoint(s, path.join(agentDir, "repo"), "S", "ws://s", "tok");
+		const bot = new FakeBotApi();
+		(bot.call as (m: string, b: unknown) => Promise<unknown>) = ((method: string, body: unknown) => {
+			if (method === "deleteForumTopic") {
+				bot.calls.push({ method, body });
+				return Promise.resolve({
+					ok: false,
+					error_code: 429,
+					parameters: { retry_after: 17 },
+					description: "Too Many Requests",
+				});
+			}
+			return FakeBotApi.prototype.call.call(bot, method, body);
+		}) as never;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+		});
+		daemon.connectSession("S", "ws://s", "tok", identity);
+		const session = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(session as any, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		await daemon.handleSessionMessage(session as any, { type: "session_closed", sessionId: "S" });
+		const deletes = bot.calls.filter(c => c.method === "deleteForumTopic");
+		const claim = await deletionEffect(
+			agentDir,
+			"S",
+			deletes[0]!.body.message_thread_id.toString(),
+			identity.leaseId,
+		);
+		expect(claim?.receipt?.status).toBe("retry_after:17");
+		expect(claim?.state).toBe("uncertain");
+	});
+
+	test("a deleted topic only reconciles on an explicit provider OK", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const identity = await publishIdentityEndpoint(s, path.join(agentDir, "repo"), "S", "ws://s", "tok");
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+		});
+		daemon.connectSession("S", "ws://s", "tok", identity);
+		const session = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(session as any, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		await daemon.handleSessionMessage(session as any, { type: "session_closed", sessionId: "S" });
+		const deletes = bot.calls.filter(c => c.method === "deleteForumTopic");
+		expect(deletes).toHaveLength(1);
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeUndefined();
+		const claim = await deletionEffect(
+			agentDir,
+			"S",
+			deletes[0]!.body.message_thread_id.toString(),
+			identity.leaseId,
+		);
+		expect(claim?.state).toBe("terminal");
+		expect(claim?.receipt?.status).toBe("reconciled");
+	});
+
+	test("corrupt registry evidence rejects session-close authority without throwing or deleting", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const identity = await publishIdentityEndpoint(s, path.join(agentDir, "repo"), "S", "ws://s", "tok");
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+		});
+		daemon.connectSession("S", "ws://s", "tok", identity);
+		const session = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(session as any, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		fs.writeFileSync(daemonPaths(agentDir).roots, "{ corrupt registry");
+
+		await expect(
+			daemon.handleSessionMessage(session as any, { type: "session_closed", sessionId: "S" }),
+		).resolves.toBeUndefined();
+		expect(bot.calls.some(call => call.method === "deleteForumTopic")).toBe(false);
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+		expect(await telegramDeletionEffects(agentDir)).toHaveLength(0);
+	});
+	test("UNKNOWN evidence (absent session entry) preserves the claim untouched with no provider call or mutation", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", { randomId: () => "lease-1", now: () => 1000 });
+		seedTopic(agentDir, "S", "601");
+		await seedPendingDeleteEffect(agentDir, "S", "601", "lease-1");
+		// Remove the session entry from an otherwise-valid registry (absent entry ⇒ UNKNOWN).
+		const registryPath = daemonPaths(agentDir).roots;
+		const reg = JSON.parse(fs.readFileSync(registryPath, "utf8")) as Record<string, unknown>;
+		delete (reg.sessions as Record<string, unknown>).S;
+		delete (reg.sessionLeases as Record<string, unknown>).S;
+		fs.writeFileSync(registryPath, JSON.stringify(reg));
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await internals(daemon).reconcileDeletionJournal();
+
+		// No provider call, topic retained, claim still pending (preserved), registry unchanged.
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(topicRegistrySnapshot(agentDir).topics.S?.topicId).toBe("601");
+		const claim = await deletionEffect(agentDir, "S", "601", "lease-1");
+		expect(claim?.state).toBe("pending");
+		const after = rootsRegistrySnapshot(agentDir);
+		expect(after.sessionLeases.S).toBeUndefined();
+		expect(after.sessions.S).toBeUndefined();
+	});
+
+	test("UNKNOWN evidence (corrupt JSON / unreadable I/O) preserves the claim with no provider call", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", { randomId: () => "lease-1", now: () => 1000 });
+		seedTopic(agentDir, "S", "601");
+		await seedPendingDeleteEffect(agentDir, "S", "601", "lease-1");
+		// Corrupt the roots registry JSON so the read throws (non-ENOENT) ⇒ UNKNOWN.
+		fs.writeFileSync(daemonPaths(agentDir).roots, "{ this is not valid json,,,");
+		// An fs whose roots-file read always fails with EACCES (unreadable I/O ⇒ UNKNOWN).
+		const rootsFile = daemonPaths(agentDir).roots;
+		const unreadable: TelegramDaemonFs = {
+			mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+			readFile: (file, encoding) =>
+				file === rootsFile
+					? Promise.reject(Object.assign(new Error("denied"), { code: "EACCES" }))
+					: fs.promises.readFile(file, encoding),
+			writeFile: (file, data, opts) => fs.promises.writeFile(file, data, opts),
+			rename: (a, b) => fs.promises.rename(a, b).then(() => undefined),
+			unlink: file => fs.promises.unlink(file),
+			open: (file, flags, mode) => fs.promises.open(file, flags, mode),
+			readdir: file => fs.promises.readdir(file),
+			chmod: (file, mode) => fs.promises.chmod(file, mode),
+			realpath: file => fs.promises.realpath(file),
+		};
+
+		for (const fsImpl of [undefined, unreadable]) {
+			const bot = new FakeBotApi();
+			const daemon = new TelegramNotificationDaemon({
+				settings: s,
+				ownerId: "owner",
+				botToken: "tok",
+				chatId: CHAT,
+				botApi: bot,
+				WebSocketImpl: FakeWs as never,
+				pidAlive: () => true,
+				...(fsImpl ? { fs: fsImpl } : {}),
+			});
+			await daemon.loadTopics();
+			await internals(daemon).reconcileDeletionJournal();
+			expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+			expect(topicRegistrySnapshot(agentDir).topics.S?.topicId).toBe("601");
+			const claim = await deletionEffect(agentDir, "S", "601", "lease-1");
+			expect(claim?.state).toBe("pending");
+		}
+	});
+
+	test("UNKNOWN evidence keeps blocking current-session registration", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", { randomId: () => "lease-1", now: () => 1000 });
+		seedTopic(agentDir, "S", "601");
+		await seedPendingDeleteEffect(agentDir, "S", "601", "lease-1");
+		// Absent session entry ⇒ UNKNOWN.
+		const registryPath = daemonPaths(agentDir).roots;
+		const reg = JSON.parse(fs.readFileSync(registryPath, "utf8")) as Record<string, unknown>;
+		delete (reg.sessions as Record<string, unknown>).S;
+		delete (reg.sessionLeases as Record<string, unknown>).S;
+		fs.writeFileSync(registryPath, JSON.stringify(reg));
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await internals(daemon).reconcileDeletionJournal();
+		// A fresh registration is still blocked by the preserved unreconciled claim.
+		await expect(
+			registerNotificationRoot({ settings: s, cwd, sessionId: "S", randomId: () => "lease-2" }),
+		).rejects.toThrow();
+	});
+
+	test("positively proven SUPERSEDED terminalizes non-destructively with no provider call", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", { randomId: () => "lease-old", now: () => 1000 });
+		seedTopic(agentDir, "S", "601");
+		await seedPendingDeleteEffect(agentDir, "S", "601", "lease-old");
+		// Simulate the crash/race window where a successor registration became durable
+		// before this predecessor claim was observed by admission. The valid current
+		// registry lease positively proves supersession.
+		const registryPath = daemonPaths(agentDir).roots;
+		const registry = rootsRegistrySnapshot(agentDir);
+		registry.sessionLeases.S = { leaseId: "lease-new", refreshedAt: 2_000 };
+		fs.writeFileSync(registryPath, JSON.stringify(registry));
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await internals(daemon).reconcileDeletionJournal();
+
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		const claim = await deletionEffect(agentDir, "S", "601", "lease-old");
+		expect(claim?.state).toBe("terminal");
+		expect(claim?.receipt?.status).toBe("reconciled_superseded");
+		// Non-destructive: the successor lease/mapping survive untouched.
+		expect(rootsRegistrySnapshot(agentDir).sessionLeases.S.leaseId).toBe("lease-new");
+	});
+
+	test("EXACT-CURRENT nonterminal replays through the unified deletion flow", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", { randomId: () => "lease-1", now: () => 1000 });
+		seedTopic(agentDir, "S", "601");
+		await seedPendingDeleteEffect(agentDir, "S", "601", "lease-1");
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await internals(daemon).reconcileDeletionJournal();
+
+		expect(bot.calls.filter(c => c.method === "deleteForumTopic")).toHaveLength(1);
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeUndefined();
+		const claim = await deletionEffect(agentDir, "S", "601", "lease-1");
+		expect(claim?.receipt?.status).toBe("reconciled");
+	});
+
+	test("a prior-chat deletion effect is quarantined non-destructively and no longer blocks registration", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", { randomId: () => "lease-1", now: () => 1000 });
+		seedTopic(agentDir, "S", "601");
+		// A deletion effect recorded under a PRIOR chat id (collision-safe id embeds chat).
+		await seedPendingDeleteEffect(agentDir, "S", "601", "lease-1", "999");
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await internals(daemon).reconcileDeletionJournal();
+
+		// Quarantined: no provider call, no topic removal, terminal reconciled_quarantine.
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(topicRegistrySnapshot(agentDir).topics.S?.topicId).toBe("601");
+		const quarantined = (await telegramDeletionEffects(agentDir)).find(
+			e => (e.payload as { chatId?: string })?.chatId === "999",
+		);
+		expect(quarantined?.state).toBe("terminal");
+		expect(quarantined?.receipt?.status).toBe("reconciled_quarantine");
+		// No longer blocks current-session registration.
+		await expect(
+			registerNotificationRoot({ settings: s, cwd, sessionId: "S", randomId: () => "lease-2" }),
+		).resolves.toBeDefined();
+	});
+
+	test("a malformed deletion claim is quarantined without provider or topic/root mutation", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", {
+			randomId: () => "lease-1",
+			now: () => 1_000,
+		});
+		seedTopic(agentDir, "S", "601");
+		const journal = new ChatEffectJournal({ agentDir, transport: "telegram" });
+		const effectId = "telegram.topic_delete:malformed:S";
+		await journal.enqueue({
+			id: effectId,
+			kind: "telegram.topic_delete",
+			transport: "telegram",
+			sessionId: "S",
+			endpointGeneration: 0,
+			payload: { chatId: CHAT, topicId: "not-a-topic", leaseId: "" },
+		});
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await internals(daemon).reconcileDeletionJournal();
+
+		expect(bot.calls.some(call => call.method === "deleteForumTopic")).toBe(false);
+		expect(topicRegistrySnapshot(agentDir).topics.S?.topicId).toBe("601");
+		expect(rootsRegistrySnapshot(agentDir).sessionLeases.S.leaseId).toBe("lease-1");
+		const quarantined = await journal.read(effectId);
+		expect(quarantined?.state).toBe("terminal");
+		expect(quarantined?.receipt?.status).toBe("reconciled_quarantine");
+		await expect(
+			registerNotificationRoot({ settings: s, cwd, sessionId: "S", randomId: () => "lease-2" }),
+		).resolves.toBeDefined();
+	});
+
+	test("a current-chat deletion never collides with a prior-chat effect (chat-embedded effect id)", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", { randomId: () => "lease-1", now: () => 1000 });
+		seedTopic(agentDir, "S", "601");
+		// Prior-chat terminal effect for the SAME session/topic/lease under chat 999.
+		const priorJournal = new ChatEffectJournal({ agentDir, transport: "telegram" });
+		const priorId = "telegram.topic_delete:999:S:601:lease-1";
+		const seeded = await priorJournal.enqueueAndClaim(
+			{
+				id: priorId,
+				kind: "telegram.topic_delete",
+				transport: "telegram",
+				sessionId: "S",
+				endpointGeneration: 0,
+				payload: { chatId: "999", topicId: "601", leaseId: "lease-1" },
+			},
+			"owner",
+			60_000,
+		);
+		await priorJournal.record(priorId, { owner: "owner", epoch: seeded!.epoch }, "terminal", {
+			provider: "telegram",
+			status: "deleted",
+		});
+		// A current-chat (42) nonterminal effect for the same session/topic/lease: it
+		// MUST replay under its own chat-embedded id without inheriting the prior record.
+		await seedPendingDeleteEffect(agentDir, "S", "601", "lease-1", CHAT);
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await internals(daemon).reconcileDeletionJournal();
+
+		// The prior-chat effect is quarantined; the current-chat delete proceeds under its own id.
+		expect(bot.calls.filter(c => c.method === "deleteForumTopic")).toHaveLength(1);
+		const priorAfter = (await telegramDeletionEffects(agentDir)).find(e => e.id === priorId);
+		expect(priorAfter?.receipt?.status).toBe("reconciled_quarantine");
+		const current = await deletionEffect(agentDir, "S", "601", "lease-1", CHAT);
+		expect(current?.receipt?.status).toBe("reconciled");
+	});
+
+	test("a successor that wins before authority claim causes no fence, no provider call, and no live-generation mutation", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		const identity = await publishIdentityEndpoint(s, cwd, "S", "ws://s", "tok", { randomId: () => "lease-old" });
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			rich: { enabled: false },
+		});
+		daemon.connectSession("S", "ws://s", "tok", identity);
+		const session = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(session as any, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		const gen = internals(daemon).liveTopicGeneration.get("S")!;
+
+		// Successor registers before the predecessor delete attempts authority.
+		await registerNotificationRoot({ settings: s, cwd, sessionId: "S", randomId: () => "lease-new" });
+		await internals(daemon).deleteTopic("S", "lease-old");
+
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(internals(daemon).fencedTopicGeneration.has("S")).toBe(false);
+		expect(internals(daemon).liveTopicGeneration.get("S")).toBe(gen);
+		expect(rootsRegistrySnapshot(agentDir).sessionLeases.S.leaseId).toBe("lease-new");
+	});
+
+	test("platform identity: injected case-folding realpath collapses case-variant workspaces to one root", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const upper = path.join(agentDir, "Repo-WS");
+		const lower = path.join(agentDir, "repo-ws");
+		fs.mkdirSync(upper, { recursive: true });
+		// A realpath seam that case-folds (mirrors macOS default case-insensitive resolution).
+		const caseFoldingFs: TelegramDaemonFs = {
+			mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+			readFile: (file, encoding) => fs.promises.readFile(file, encoding),
+			writeFile: (file, data, opts) => fs.promises.writeFile(file, data, opts),
+			rename: (a, b) => fs.promises.rename(a, b).then(() => undefined),
+			unlink: file => fs.promises.unlink(file),
+			open: (file, flags, mode) => fs.promises.open(file, flags, mode),
+			readdir: file => fs.promises.readdir(file),
+			chmod: (file, mode) => fs.promises.chmod(file, mode),
+			realpath: file => fs.promises.realpath(file === lower ? upper : file),
+		};
+		const fromUpper = await registerNotificationRoot({
+			settings: s,
+			fs: caseFoldingFs,
+			cwd: upper,
+			sessionId: "S",
+			randomId: () => "lease-1",
+		});
+		const fromLower = await registerNotificationRoot({
+			settings: s,
+			fs: caseFoldingFs,
+			cwd: lower,
+			sessionId: "S",
+			randomId: () => "lease-2",
+		});
+		expect(fromUpper.root).toBe(fromLower.root);
+		const registry = rootsRegistrySnapshot(agentDir);
+		expect(registry.roots).toEqual([fromUpper.root]);
+		expect(registry.sessionLeases.S.leaseId).toBe("lease-2");
+	});
+
+	test("platform identity: Unicode NFC/NFD-equivalent realpath collapse keeps one canonical identity", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		// "café" in composed (NFC) vs decomposed (NFD) form.
+		const composed = path.join(agentDir, "caf\u00e9-ws");
+		const decomposed = path.join(agentDir, "cafe\u0301-ws");
+		fs.mkdirSync(composed, { recursive: true });
+		const unicodeFs: TelegramDaemonFs = {
+			mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+			readFile: (file, encoding) => fs.promises.readFile(file, encoding),
+			writeFile: (file, data, opts) => fs.promises.writeFile(file, data, opts),
+			rename: (a, b) => fs.promises.rename(a, b).then(() => undefined),
+			unlink: file => fs.promises.unlink(file),
+			open: (file, flags, mode) => fs.promises.open(file, flags, mode),
+			readdir: file => fs.promises.readdir(file),
+			chmod: (file, mode) => fs.promises.chmod(file, mode),
+			realpath: file => fs.promises.realpath(file.normalize("NFC") === composed ? composed : file),
+		};
+		const a = await registerNotificationRoot({
+			settings: s,
+			fs: unicodeFs,
+			cwd: composed,
+			sessionId: "S",
+			randomId: () => "lease-1",
+		});
+		const b = await registerNotificationRoot({
+			settings: s,
+			fs: unicodeFs,
+			cwd: decomposed,
+			sessionId: "S",
+			randomId: () => "lease-2",
+		});
+		expect(a.root).toBe(b.root);
+		expect(rootsRegistrySnapshot(agentDir).roots).toEqual([a.root]);
+	});
+
+	test("platform identity: an ancestor symlink retargeted between scans does not falsely reap a live workspace", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const realA = path.join(agentDir, "real-a");
+		const realB = path.join(agentDir, "real-b");
+		const link = path.join(agentDir, "link");
+		fs.mkdirSync(realA, { recursive: true });
+		fs.mkdirSync(realB, { recursive: true });
+		fs.symlinkSync(realA, link);
+		// Register through the link (canonicalizes to realA's state dir).
+		const identity = await publishIdentityEndpoint(s, link, "S", "ws://s", "ts", {
+			randomId: () => "lease-1",
+			now: () => 70_000,
+		});
+		seedTopic(agentDir, "S", "501");
+
+		const bot = new FakeBotApi();
+		let now = 70_000;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: CHAT,
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: () => true,
+			now: () => now,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		expect(daemon.sessions.has("S")).toBe(true);
+
+		// TOCTOU: retarget the ancestor symlink to a different target after registration.
+		fs.unlinkSync(link);
+		fs.symlinkSync(realB, link);
+
+		bot.calls = [];
+		now = 130_000;
+		await daemon.scanRoots();
+		// No false reap: the originally-registered canonical root is the durable identity.
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(rootsRegistrySnapshot(agentDir).sessions.S).toBe(identity.canonicalRoot);
 	});
 });

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "../src/config/settings";
+import { type ChatEffect, ChatEffectJournal } from "../src/sdk/bus/chat-effect-journal";
 import {
 	markdownToTelegramHtml,
 	splitTelegramHtml,
@@ -236,6 +237,130 @@ class FailingCallbackAckBotApi extends FakeBotApi {
 	}
 }
 
+/** Snapshot of the durable notification-roots registry for orphan-cleanup assertions. */
+function rootsRegistrySnapshot(agentDir: string): {
+	roots: string[];
+	sessions: Record<string, string>;
+	sessionLeases: Record<string, { leaseId: string; refreshedAt: number }>;
+	orphanCandidates: Record<string, { observedAt: number; leaseId: string; topicId: string }>;
+} {
+	const file = daemonPaths(agentDir).roots;
+	if (!fs.existsSync(file)) {
+		return { roots: [], sessions: {}, sessionLeases: {}, orphanCandidates: {} };
+	}
+	return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+/** Snapshot of the persisted telegram topic registry. */
+function topicRegistrySnapshot(agentDir: string): {
+	topics: Record<string, { topicId: string; createdAt: number; [key: string]: unknown }>;
+} {
+	const file = path.join(daemonPaths(agentDir).dir, "telegram-topics.json");
+	if (!fs.existsSync(file)) return { topics: {} };
+	return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+/** Read the durable telegram deletion-claim effects for crash-replay/retry assertions. */
+async function telegramDeletionEffects(agentDir: string): Promise<ChatEffect[]> {
+	return new ChatEffectJournal({ agentDir, transport: "telegram" }).list();
+}
+/**
+ * Register a notification root and publish a live identity-bearing endpoint file
+ * (canonicalRoot + leaseId stamped from the registration). The daemon binds this
+ * endpoint-carried identity and validates it against the registry — it never
+ * infers a lease from the registry. Returns the exact admission identity.
+ */
+async function publishIdentityEndpoint(
+	s: Settings,
+	cwd: string,
+	sessionId: string,
+	url: string,
+	token: string,
+	opts?: { now?: () => number; randomId?: () => string; pid?: number },
+): Promise<{ canonicalRoot: string; leaseId: string }> {
+	const reg = await registerNotificationRoot({ settings: s, cwd, sessionId, ...(opts ?? {}) });
+	const dir = path.join(reg.root, "sdk");
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, `${sessionId}.json`),
+		JSON.stringify({
+			url,
+			token,
+			...(opts?.pid === undefined ? {} : { pid: opts.pid }),
+			canonicalRoot: reg.root,
+			leaseId: reg.leaseId,
+		}),
+	);
+	return { canonicalRoot: reg.root, leaseId: reg.leaseId };
+}
+
+async function connectIdentitySession(
+	daemon: TelegramNotificationDaemon,
+	sessionId: string,
+	url: string,
+	token: string,
+): Promise<void> {
+	const daemonSettings = (daemon as unknown as { opts: { settings: Settings } }).opts.settings;
+	const cwd = path.join(daemonSettings.getAgentDir(), "test-workspaces", encodeURIComponent(sessionId));
+	const identity = await publishIdentityEndpoint(daemonSettings, cwd, sessionId, url, token);
+	daemon.connectSession(sessionId, url, token, identity);
+}
+
+/**
+ * TelegramDaemonFs whose `readdir` fails with a non-ENOENT error (EACCES) for one
+ * mapped root's sdk dir, so the scan classifies that root as ambiguous instead of
+ * confirmed absence. Every other operation delegates to the real fs.
+ */
+function fsWithUnreadableReaddir(withheldSdkDir: string): TelegramDaemonFs {
+	const accessError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+	return {
+		mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+		readFile: (file, encoding) => fs.promises.readFile(file, encoding),
+		writeFile: async (file, data, opts) => {
+			await fs.promises.writeFile(file, data, opts);
+		},
+		rename: (oldPath, newPath) => fs.promises.rename(oldPath, newPath).then(() => undefined),
+		unlink: file => fs.promises.unlink(file),
+		open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
+		readdir: file => (file === withheldSdkDir ? Promise.reject(accessError) : fs.promises.readdir(file)),
+		chmod: (file, mode) => fs.promises.chmod(file, mode),
+	};
+}
+
+function fsWithUnresolvableRealpath(withheldRoot: string): TelegramDaemonFs {
+	const accessError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+	return {
+		mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+		readFile: (file, encoding) => fs.promises.readFile(file, encoding),
+		writeFile: async (file, data, opts) => {
+			await fs.promises.writeFile(file, data, opts);
+		},
+		rename: (oldPath, newPath) => fs.promises.rename(oldPath, newPath).then(() => undefined),
+		unlink: file => fs.promises.unlink(file),
+		open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
+		readdir: file => fs.promises.readdir(file),
+		chmod: (file, mode) => fs.promises.chmod(file, mode),
+		realpath: file => (file === withheldRoot ? Promise.reject(accessError) : fs.promises.realpath(file)),
+	};
+}
+
+/** FakeBotApi that rate-limits (429 + retry_after) the first deleteForumTopic, then succeeds. */
+class RateLimitedDeleteBotApi extends FakeBotApi {
+	deleteAttempts = 0;
+	retryAfterSec = 30;
+	override async call(method: string, body: unknown): Promise<unknown> {
+		if (method === "deleteForumTopic") {
+			this.calls.push({ method, body });
+			this.deleteAttempts++;
+			if (this.deleteAttempts === 1) {
+				return { ok: false, error_code: 429, parameters: { retry_after: this.retryAfterSec } };
+			}
+			return { ok: true, result: true };
+		}
+		return super.call(method, body);
+	}
+}
+
 describe("telegram daemon", () => {
 	test("N concurrent ensureTelegramDaemonRunning creates exactly one owner", async () => {
 		const agentDir = tempAgentDir();
@@ -308,7 +433,7 @@ describe("telegram daemon", () => {
 		expect(registry.roots).toHaveLength(12);
 		expect(Object.keys(registry.sessions)).toHaveLength(12);
 		for (let i = 0; i < 12; i++) {
-			expect(registry.sessions[`s${i}`]).toBe(path.join(agentDir, `cwd-${i}`, ".gjc", "state"));
+			expect(registry.sessions[`s${i}`]).toBe(path.join(fs.realpathSync(agentDir), `cwd-${i}`, ".gjc", "state"));
 		}
 	});
 
@@ -407,11 +532,11 @@ describe("telegram daemon", () => {
 	test("TelegramEventDispatchState groups dispatch state without changing maps", () => {
 		const state = new TelegramEventDispatchState();
 		state.busy.add("S");
-		state.inboundReactions.set(7, { messageId: 70 });
+		state.inboundReactions.set(7, { messageId: 70, sessionId: "S", generation: 1 });
 		state.seenUpdateIds.add(99);
 
 		expect([...state.busy]).toEqual(["S"]);
-		expect(state.inboundReactions.get(7)).toEqual({ messageId: 70 });
+		expect(state.inboundReactions.get(7)).toEqual({ messageId: 70, sessionId: "S", generation: 1 });
 		expect(state.seenUpdateIds.has(99)).toBe(true);
 	});
 
@@ -647,7 +772,7 @@ describe("telegram daemon", () => {
 		expect(after.ownerId).not.toBe("old");
 		expect(after.generation).toBe(DAEMON_GENERATION);
 		// The new session's root is persisted so the replacement daemon serves it.
-		expect(after.roots).toContain(path.join(cwd, ".gjc", "state"));
+		expect(after.roots).toContain(path.join(fs.realpathSync(agentDir), "new-session", ".gjc", "state"));
 	});
 
 	test("#2028 ensureTelegramDaemonRunning reuses a current-generation live owner without a reload", async () => {
@@ -676,6 +801,40 @@ describe("telegram daemon", () => {
 		// Still the original owner; the new session's root is registered onto it.
 		expect(JSON.parse(fs.readFileSync(paths.state, "utf8")).ownerId).toBe("old");
 		expect(fs.existsSync(paths.roots)).toBe(true);
+	});
+
+	test("ensureTelegramDaemonRunning exposes the exact committed registration identity", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		writeLiveOwner(agentDir, {
+			pid: process.pid,
+			generation: DAEMON_GENERATION,
+			heartbeatAt: Date.now(),
+		});
+		const cwd = path.join(agentDir, "published-workspace");
+		let captured: { canonicalRoot: string; leaseId: string } | undefined;
+		const result = await ensureTelegramDaemonRunning(
+			{
+				settings: s,
+				cwd,
+				sessionId: "published-session",
+				onRegistered: identity => {
+					captured = identity;
+				},
+			},
+			{
+				pidAlive: () => true,
+				sleep: async () => undefined,
+			},
+		);
+		const registry = rootsRegistrySnapshot(agentDir);
+
+		expect(result).toBe("attached");
+		expect(captured?.canonicalRoot).toBe(registry.sessions["published-session"]);
+		expect(captured?.leaseId).toBe(registry.sessionLeases["published-session"].leaseId);
+		expect(captured?.canonicalRoot).toBe(
+			path.join(fs.realpathSync(agentDir), "published-workspace", ".gjc", "state"),
+		);
 	});
 
 	test("idle self-exit after timeout releases ownership", async () => {
@@ -778,8 +937,8 @@ describe("telegram daemon", () => {
 			rich: { enabled: false },
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("A", "ws://a", "ta");
-		daemon.connectSession("B", "ws://b", "tb");
+		await connectIdentitySession(daemon, "A", "ws://a", "ta");
+		await connectIdentitySession(daemon, "B", "ws://b", "tb");
 		await daemon.handleSessionMessage(daemon.sessions.get("B")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -812,7 +971,7 @@ describe("telegram daemon", () => {
 			rich: { enabled: false },
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -832,6 +991,101 @@ describe("telegram daemon", () => {
 		expect(bot.calls.some(c => c.method === "answerCallbackQuery")).toBe(true);
 	});
 
+	test("a stale ask alias does not revoke a still-current session", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			rich: { enabled: false },
+			WebSocketImpl: FakeWs as any,
+		});
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
+		const session = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(session, {
+			type: "action_needed",
+			kind: "ask",
+			id: "ask",
+			question: "Q",
+			options: ["Y"],
+		});
+		const alias = bot.calls.find(call => call.method === "sendMessage")!.body.reply_markup.inline_keyboard[0][0]
+			.callback_data;
+		session.pending.clear();
+		FakeWs.instances[0]!.sent = [];
+
+		await daemon.handleTelegramUpdate({
+			update_id: 1,
+			callback_query: { id: "cb", data: alias, message: { chat: { id: 42 } } },
+		});
+
+		expect(daemon.sessions.get("S")).toBe(session);
+		expect(FakeWs.instances[0]!.sent).toHaveLength(0);
+		expect(bot.calls.some(call => call.method === "sendMessage" && String(call.body.text).includes("stale"))).toBe(
+			true,
+		);
+	});
+	test("a socket closed during authority revalidation drops the inbound update without throwing", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+		});
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
+		const session = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(session, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		const threadId = bot.calls.find(call => call.method === "sendMessage")!.body.message_thread_id;
+		const originalAdmissionCheck = (
+			daemon as unknown as {
+				sessionAdmissionIsCurrent(target: typeof session): Promise<boolean>;
+			}
+		).sessionAdmissionIsCurrent.bind(daemon);
+		let checks = 0;
+		Object.assign(daemon, {
+			sessionAdmissionIsCurrent: async (target: typeof session) => {
+				checks++;
+				if (checks === 2) {
+					target.ws.close();
+					return true;
+				}
+				return originalAdmissionCheck(target);
+			},
+		});
+		FakeWs.instances[0]!.sent = [];
+
+		await expect(
+			daemon.handleTelegramUpdate({
+				update_id: 1,
+				message: {
+					chat: { id: 42 },
+					message_thread_id: threadId,
+					message_id: 1,
+					text: "race",
+				},
+			}),
+		).resolves.toBeUndefined();
+
+		expect(checks).toBe(2);
+		expect(FakeWs.instances[0]!.sent).toHaveLength(0);
+		expect(daemon.sessions.has("S")).toBe(false);
+	});
 	test("unknown and expired aliases are stale guidance with zero frames", async () => {
 		FakeWs.instances = [];
 		const agentDir = tempAgentDir();
@@ -845,7 +1099,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("A", "ws://a", "ta");
+		await connectIdentitySession(daemon, "A", "ws://a", "ta");
 		await daemon.handleTelegramUpdate({
 			callback_query: { id: "cb", data: "missing", message: { chat: { id: 42 } } },
 		});
@@ -875,7 +1129,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("A", "ws://a", "ta");
+		await connectIdentitySession(daemon, "A", "ws://a", "ta");
 
 		await daemon.handleTelegramUpdate({
 			callback_query: { id: "cb", data: "missing", message: { chat: { id: -10042 } } },
@@ -900,7 +1154,7 @@ describe("telegram daemon", () => {
 			rich: { enabled: false },
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -937,7 +1191,7 @@ describe("telegram daemon", () => {
 			rich: { enabled: false },
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -967,7 +1221,7 @@ describe("telegram daemon", () => {
 			rich: { enabled: false },
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -1003,9 +1257,9 @@ describe("telegram daemon", () => {
 			rich: { enabled: false },
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://old", "old-token");
+		await connectIdentitySession(daemon, "S", "ws://old", "old-token");
 		const oldSocket = FakeWs.instances[0]!;
-		daemon.connectSession("S", "ws://new", "new-token");
+		await connectIdentitySession(daemon, "S", "ws://new", "new-token");
 		const newSocket = FakeWs.instances[1]!;
 		const newSession = daemon.sessions.get("S")!;
 		await daemon.handleSessionMessage(newSession, {
@@ -1048,7 +1302,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		daemon.messageRoutes.set("55", { sessionId: "S", actionId: "A" });
 		daemon.sessions.get("S")!.pending.set("A", { sessionId: "S", actionId: "A" });
 		await daemon.handleTelegramUpdate({
@@ -1076,7 +1330,7 @@ describe("telegram daemon", () => {
 			rich: { enabled: false },
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		// Emit an ask: creates the forum topic, registers the pending ask, sends the message.
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
@@ -1135,7 +1389,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -1186,7 +1440,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		const session = daemon.sessions.get("S")!;
 		await daemon.handleSessionMessage(session, {
 			type: "action_needed",
@@ -1254,7 +1508,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		const session = daemon.sessions.get("S")!;
 		await daemon.handleSessionMessage(session, {
 			type: "action_needed",
@@ -1306,7 +1560,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		const session = daemon.sessions.get("S")!;
 		await daemon.handleSessionMessage(session, {
 			type: "action_needed",
@@ -1345,7 +1599,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		const session = daemon.sessions.get("S")!;
 		await daemon.handleSessionMessage(session, {
 			type: "action_needed",
@@ -1386,7 +1640,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		const session = daemon.sessions.get("S")!;
 		await daemon.handleSessionMessage(session, {
 			type: "action_needed",
@@ -1406,7 +1660,7 @@ describe("telegram daemon", () => {
 			WebSocketImpl: FakeWs as any,
 		});
 		await restarted.loadTopics();
-		restarted.connectSession("S", "ws://s-restarted", "ts-restarted");
+		await connectIdentitySession(restarted, "S", "ws://s-restarted", "ts-restarted");
 		const recoveredSession = restarted.sessions.get("S")!;
 		await restarted.handleSessionMessage(recoveredSession, {
 			type: "ask_selected_ack_request",
@@ -1462,7 +1716,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		const session = daemon.sessions.get("S")!;
 		await daemon.handleSessionMessage(session, {
 			type: "action_needed",
@@ -1537,7 +1791,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as never,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		const session = daemon.sessions.get("S")!;
 		await daemon.handleSessionMessage(session, {
 			type: "action_needed",
@@ -1559,7 +1813,7 @@ describe("telegram daemon", () => {
 			session,
 			"session_closed",
 		);
-		daemon.connectSession("S", "ws://replacement", "replacement-token");
+		await connectIdentitySession(daemon, "S", "ws://replacement", "replacement-token");
 		const replacement = daemon.sessions.get("S")!;
 		await daemon.handleSessionMessage(replacement, {
 			type: "ask_selected_ack_request",
@@ -1606,7 +1860,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		const session = daemon.sessions.get("S")!;
 		await daemon.handleSessionMessage(session, {
 			type: "action_needed",
@@ -1660,7 +1914,7 @@ describe("telegram daemon", () => {
 			rich: { enabled: false },
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -1693,7 +1947,7 @@ describe("telegram daemon", () => {
 			rich: { enabled: false },
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		// Create the topic + pending via an ask, then resolve it so nothing is pending.
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
@@ -1729,7 +1983,7 @@ describe("telegram daemon", () => {
 			rich: { enabled: false },
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "identity_header",
 			sessionId: "S",
@@ -1770,7 +2024,7 @@ describe("telegram daemon", () => {
 			rich: { enabled: false },
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -1808,7 +2062,7 @@ describe("telegram daemon", () => {
 			WebSocketImpl: FakeWs as any,
 		});
 		Object.assign(daemon, { botUsername: "GajaeCodeBot" });
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -1844,7 +2098,7 @@ describe("telegram daemon", () => {
 			botApi: bot,
 			WebSocketImpl: FakeWs as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "identity_header",
 			sessionId: "S",
@@ -1876,7 +2130,7 @@ describe("telegram daemon", () => {
 		});
 		await restarted.loadTopics();
 		await restarted.loadSeenUpdateIds();
-		restarted.connectSession("S", "ws://s2", "ts2");
+		await connectIdentitySession(restarted, "S", "ws://s2", "ts2");
 
 		await restarted.handleTelegramUpdate({
 			update_id: 77,
@@ -1924,10 +2178,7 @@ describe("telegram daemon", () => {
 
 		// Endpoint discovery files live at <cwd>/.gjc/state/sdk/<sessionId>.json.
 		const writeEndpoint = async (cwd: string, sessionId: string, url: string) => {
-			await registerNotificationRoot({ settings: s, cwd, sessionId });
-			const dir = path.join(cwd, ".gjc", "state", "sdk");
-			fs.mkdirSync(dir, { recursive: true });
-			fs.writeFileSync(path.join(dir, `${sessionId}.json`), JSON.stringify({ url, token: "tok" }));
+			await publishIdentityEndpoint(s, cwd, sessionId, url, "tok");
 		};
 
 		// Session A exists from the start so the run loop reaches the long-poll branch.
@@ -2069,11 +2320,7 @@ describe("telegram daemon connection-drop resilience (repro-first)", () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
 		const cwd = path.join(agentDir, "sess-cwd");
-		await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
-		const roots = JSON.parse(fs.readFileSync(daemonPaths(agentDir).roots, "utf8")) as { roots: string[] };
-		const endpointDir = path.join(roots.roots[0]!, "sdk");
-		fs.mkdirSync(endpointDir, { recursive: true });
-		fs.writeFileSync(path.join(endpointDir, "S.json"), JSON.stringify({ url: "ws://s", token: "ts" }));
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts");
 
 		let now = 0;
 		const liveness: Array<() => void> = [];
@@ -2100,6 +2347,7 @@ describe("telegram daemon connection-drop resilience (repro-first)", () => {
 		// liveness can start; then the link goes half-open (no further frames,
 		// socket never closes, no pong will arrive).
 		FakeWs.instances[0]!.emit({ type: "hello", protocolVersion: 2, capabilities: ["client_ping_pong"] });
+		await new Promise(resolve => setTimeout(resolve, 10));
 
 		// Advance past the heartbeat TTL and fire any liveness probe. Post-fix this
 		// detects the missing pong, drops the stale session, and reconnects.
@@ -2141,6 +2389,7 @@ describe("telegram daemon connection-drop resilience (repro-first)", () => {
 						// Drop the only session so the next loop iteration idle-exits
 						// once the daemon survives the rejection (post-fix path).
 						daemon.sessions.get("S")?.ws.close();
+						queueMicrotask(() => daemon.requestStop());
 						throw new Error("network down: getUpdates rejected");
 					}
 					return { ok: true, result: [] };
@@ -2149,6 +2398,7 @@ describe("telegram daemon connection-drop resilience (repro-first)", () => {
 			},
 		};
 
+		await publishIdentityEndpoint(s, path.join(agentDir, "repo"), "S", "ws://s", "ts");
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
@@ -2165,7 +2415,6 @@ describe("telegram daemon connection-drop resilience (repro-first)", () => {
 			setIntervalImpl: (() => 0) as any,
 			clearIntervalImpl: (() => {}) as any,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
 
 		await expect(daemon.run()).resolves.toBeUndefined();
 		expect(getUpdatesCalls).toBeGreaterThanOrEqual(1);
@@ -2264,7 +2513,7 @@ test("non-addressable forum lifecycle commands in known topics are dropped", asy
 			WebSocketImpl: FakeWs as any,
 		});
 		Object.assign(daemon, { lifecycleControlActive: true, botUsername });
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		const session = daemon.sessions.get("S")!;
 		await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
 		const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
@@ -2867,8 +3116,8 @@ test("live sessions with the same repo branch create distinct topics", async () 
 		botApi: bot,
 		WebSocketImpl: FakeWs as any,
 	});
-	daemon.connectSession("S1", "ws://s1", "t1");
-	daemon.connectSession("S2", "ws://s2", "t2");
+	await connectIdentitySession(daemon, "S1", "ws://s1", "t1");
+	await connectIdentitySession(daemon, "S2", "ws://s2", "t2");
 	const first = daemon.sessions.get("S1")!;
 	const second = daemon.sessions.get("S2")!;
 
@@ -3269,17 +3518,32 @@ test("activity busy frame sends a typing chat action into the session topic", as
 
 test("session_closed deletes the topic and resume creates a fresh visible topic", async () => {
 	const agentDir = tempAgentDir();
+	const s = settings(agentDir);
+	const reg = await registerNotificationRoot({
+		settings: s,
+		cwd: path.join(agentDir, "repo"),
+		sessionId: "S",
+	});
 	const bot = new FakeBotApi();
 	let now = 0;
 	const daemon = new TelegramNotificationDaemon({
-		settings: settings(agentDir),
+		settings: s,
 		ownerId: "owner",
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
+		WebSocketImpl: FakeWs as any,
 		now: () => now,
 	});
-	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	const session = {
+		sessionId: "S",
+		token: "tok",
+		endpointKey: "ws://s\0tok",
+		canonicalRoot: reg.root,
+		leaseId: reg.leaseId,
+		ws: { readyState: 1, send() {} },
+		pending: new Map(),
+	};
 
 	await daemon.handleSessionMessage(session as any, {
 		type: "identity_header",
@@ -3305,7 +3569,9 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 
 	now = 10_000;
 	bot.calls = [];
-	await daemon.handleSessionMessage(session as any, {
+	await connectIdentitySession(daemon, "S", "ws://resumed", "tok2");
+	const resumedSession = daemon.sessions.get("S")!;
+	await daemon.handleSessionMessage(resumedSession, {
 		type: "identity_header",
 		sessionId: "S",
 		repo: "r",
@@ -3324,6 +3590,197 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 	);
 });
 
+test("session_closed drains an in-flight topic creation and deletes the created topic", async () => {
+	const agentDir = tempAgentDir();
+	const s = settings(agentDir);
+	const reg = await registerNotificationRoot({ settings: s, cwd: path.join(agentDir, "repo"), sessionId: "S" });
+	const createStarted = Promise.withResolvers<void>();
+	const releaseCreate = Promise.withResolvers<void>();
+	const calls: Array<{ method: string; body: any }> = [];
+	const bot = {
+		async call(method: string, body: unknown): Promise<unknown> {
+			calls.push({ method, body });
+			if (method === "getChat") return { ok: true, result: { id: 42, type: "private" } };
+			if (method === "createForumTopic") {
+				createStarted.resolve();
+				await releaseCreate.promise;
+				return { ok: true, result: { message_thread_id: 901 } };
+			}
+			if (method === "sendMessage") return { ok: true, result: { message_id: calls.length } };
+			return { ok: true, result: true };
+		},
+	};
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = {
+		sessionId: "S",
+		token: "tok",
+		endpointKey: "ws://s\0tok",
+		canonicalRoot: reg.root,
+		leaseId: reg.leaseId,
+		ws: { readyState: 1, send() {} },
+		pending: new Map(),
+	};
+
+	const identity = daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	await createStarted.promise;
+	const close = daemon.handleSessionMessage(session as any, { type: "session_closed", sessionId: "S" });
+	await Promise.resolve();
+	expect(calls.some(call => call.method === "deleteForumTopic")).toBe(false);
+
+	releaseCreate.resolve();
+	await Promise.all([identity, close]);
+	expect(calls.filter(call => call.method === "createForumTopic")).toHaveLength(1);
+	expect(calls.filter(call => call.method === "deleteForumTopic").map(call => call.body.message_thread_id)).toEqual([
+		901,
+	]);
+	expect(topicRegistrySnapshot(agentDir).topics.S).toBeUndefined();
+});
+
+test("TOPIC_CLOSED is uncertain and retains the topic, fence, and registry for retry", async () => {
+	const agentDir = tempAgentDir();
+	const s = settings(agentDir);
+	const reg = await registerNotificationRoot({ settings: s, cwd: path.join(agentDir, "repo"), sessionId: "S" });
+	const calls: Array<{ method: string; body: any }> = [];
+	const bot = {
+		async call(method: string, body: unknown): Promise<unknown> {
+			calls.push({ method, body });
+			if (method === "getChat") return { ok: true, result: { id: 42, type: "private" } };
+			if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 902 } };
+			if (method === "sendMessage") return { ok: true, result: { message_id: calls.length } };
+			if (method === "deleteForumTopic") {
+				return { ok: false, error_code: 400, description: "Bad Request: TOPIC_CLOSED" };
+			}
+			return { ok: true, result: true };
+		},
+	};
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = {
+		sessionId: "S",
+		token: "tok",
+		endpointKey: "ws://s\0tok",
+		canonicalRoot: reg.root,
+		leaseId: reg.leaseId,
+		ws: { readyState: 1, send() {} },
+		pending: new Map(),
+	};
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	await daemon.handleSessionMessage(session as any, { type: "session_closed", sessionId: "S" });
+
+	expect(calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect(topicRegistrySnapshot(agentDir).topics.S?.topicId).toBe("902");
+	expect(rootsRegistrySnapshot(agentDir).sessions.S).toBeDefined();
+	const effect = (await telegramDeletionEffects(agentDir)).find(item => item.sessionId === "S");
+	expect(effect).toMatchObject({ state: "uncertain", receipt: { status: "uncertain" } });
+});
+
+test("a fresh registration that wins before delete intent restores topic admission without deleting", async () => {
+	const agentDir = tempAgentDir();
+	const s = settings(agentDir);
+	const cwd = path.join(agentDir, "repo");
+	const reg = await registerNotificationRoot({
+		settings: s,
+		cwd,
+		sessionId: "S",
+		randomId: () => "lease-old",
+	});
+	const sendStarted = Promise.withResolvers<void>();
+	const releaseSend = Promise.withResolvers<void>();
+	const calls: Array<{ method: string; body: any }> = [];
+	const bot = {
+		async call(method: string, body: unknown): Promise<unknown> {
+			calls.push({ method, body });
+			const request = body as { text?: unknown };
+			if (method === "getChat") return { ok: true, result: { id: 42, type: "private" } };
+			if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 903 } };
+			if (method === "sendMessage" && String(request.text).includes("hold-delete")) {
+				sendStarted.resolve();
+				await releaseSend.promise;
+			}
+			if (method === "sendMessage") return { ok: true, result: { message_id: calls.length } };
+			return { ok: true, result: true };
+		},
+	};
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+		rich: { enabled: false },
+	});
+	const session = {
+		sessionId: "S",
+		token: "tok",
+		endpointKey: "ws://s\0tok",
+		canonicalRoot: reg.root,
+		leaseId: reg.leaseId,
+		ws: { readyState: 1, send() {} },
+		pending: new Map(),
+	};
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+
+	const heldSend = daemon.handleSessionMessage(session as any, {
+		type: "turn_stream",
+		sessionId: "S",
+		phase: "finalized",
+		text: "hold-delete",
+	});
+	await sendStarted.promise;
+	const close = daemon.handleSessionMessage(session as any, { type: "session_closed", sessionId: "S" });
+	await Promise.resolve();
+	await registerNotificationRoot({
+		settings: s,
+		cwd,
+		sessionId: "S",
+		randomId: () => "lease-new",
+	});
+	releaseSend.resolve();
+	await Promise.all([heldSend, close]);
+
+	expect(calls.some(call => call.method === "deleteForumTopic")).toBe(false);
+	expect(rootsRegistrySnapshot(agentDir).sessionLeases.S.leaseId).toBe("lease-new");
+
+	await connectIdentitySession(daemon, "S", "ws://resumed", "tok2");
+	await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
+		type: "turn_stream",
+		sessionId: "S",
+		phase: "finalized",
+		text: "after-superseded-delete",
+	});
+	const resumedSend = calls.find(
+		call => call.method === "sendMessage" && String(call.body.text).includes("after-superseded-delete"),
+	);
+	expect(resumedSend?.body.message_thread_id).toBe(903);
+});
+
 test("session_closed clears reply message routes for the closed session", async () => {
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();
@@ -3337,8 +3794,8 @@ test("session_closed clears reply message routes for the closed session", async 
 		botApi: bot,
 		WebSocketImpl: FakeWs as any,
 	});
-	daemon.connectSession("S", "ws://s", "ts");
-	daemon.connectSession("T", "ws://t", "tt");
+	await connectIdentitySession(daemon, "S", "ws://s", "ts");
+	await connectIdentitySession(daemon, "T", "ws://t", "tt");
 	daemon.messageRoutes.set("s-ask", { sessionId: "S", actionId: "ask" });
 	daemon.messageRoutes.set("s-other", { sessionId: "S", actionId: "other" });
 	daemon.messageRoutes.set("t-ask", { sessionId: "T", actionId: "ask" });
@@ -3354,10 +3811,13 @@ test("session_closed tombstones its endpoint generation so scans do not recreate
 	const agentDir = tempAgentDir();
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
 	const cwd = path.join(agentDir, "repo");
-	await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
-	const endpointDir = path.join(cwd, ".gjc", "state", "sdk");
+	const reg1 = await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
+	const endpointDir = path.join(reg1.root, "sdk");
 	fs.mkdirSync(endpointDir, { recursive: true });
-	fs.writeFileSync(path.join(endpointDir, "S.json"), JSON.stringify({ url: "ws://live", token: "ts", pid: 4242 }));
+	fs.writeFileSync(
+		path.join(endpointDir, "S.json"),
+		JSON.stringify({ url: "ws://live", token: "ts", pid: 4242, canonicalRoot: reg1.root, leaseId: reg1.leaseId }),
+	);
 
 	const bot = new FakeBotApi();
 	const daemon = new TelegramNotificationDaemon({
@@ -3404,7 +3864,11 @@ test("session_closed tombstones its endpoint generation so scans do not recreate
 	expect(FakeWs.instances).toHaveLength(1);
 	expect(bot.calls.some(c => c.method === "createForumTopic")).toBe(false);
 
-	fs.writeFileSync(path.join(endpointDir, "S.json"), JSON.stringify({ url: "ws://resumed", token: "ts2", pid: 4242 }));
+	const reg2 = await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
+	fs.writeFileSync(
+		path.join(endpointDir, "S.json"),
+		JSON.stringify({ url: "ws://resumed", token: "ts2", pid: 4242, canonicalRoot: reg2.root, leaseId: reg2.leaseId }),
+	);
 	await daemon.scanRoots();
 	expect(FakeWs.instances).toHaveLength(2);
 	FakeWs.instances[1]!.dispatchEvent(new Event("open"));
@@ -3424,7 +3888,7 @@ test("inbound thread message gets a queued reaction, flipped to consumed on ack"
 		botApi: bot,
 		WebSocketImpl: FakeWs as any,
 	});
-	daemon.connectSession("S", "ws://s", "ts");
+	await connectIdentitySession(daemon, "S", "ws://s", "ts");
 	const session = daemon.sessions.get("S")!;
 	// Create the topic and learn its thread id from the pinned identity message.
 	await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
@@ -3472,7 +3936,7 @@ test("inbound photo is downloaded and forwarded as an image in the user_message"
 		fetchImpl,
 		WebSocketImpl: FakeWs as any,
 	});
-	daemon.connectSession("S", "ws://s", "ts");
+	await connectIdentitySession(daemon, "S", "ws://s", "ts");
 	const session = daemon.sessions.get("S")!;
 	await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
 	const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
@@ -3513,7 +3977,7 @@ test("inbound document is saved to a tmp file and its path injected into the tex
 		fetchImpl,
 		WebSocketImpl: FakeWs as any,
 	});
-	daemon.connectSession("S", "ws://s", "ts");
+	await connectIdentitySession(daemon, "S", "ws://s", "ts");
 	const session = daemon.sessions.get("S")!;
 	await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
 	const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
@@ -3566,7 +4030,7 @@ test("inbound document with a path-traversal filename stays sandboxed in the pri
 		fetchImpl,
 		WebSocketImpl: FakeWs as any,
 	});
-	daemon.connectSession("S", "ws://s", "ts");
+	await connectIdentitySession(daemon, "S", "ws://s", "ts");
 	const session = daemon.sessions.get("S")!;
 	await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
 	const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
@@ -3616,7 +4080,7 @@ test("daemon attachment temp dirs are removed by the shutdown cleanup path", asy
 		fetchImpl,
 		WebSocketImpl: FakeWs as any,
 	});
-	daemon.connectSession("S", "ws://s", "ts");
+	await connectIdentitySession(daemon, "S", "ws://s", "ts");
 	const session = daemon.sessions.get("S")!;
 	await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
 	const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
@@ -3652,7 +4116,7 @@ test("outbound file_attachment frame triggers a sendDocument upload to the topic
 		botApi: bot,
 		WebSocketImpl: FakeWs as any,
 	});
-	daemon.connectSession("S", "ws://s", "ts");
+	await connectIdentitySession(daemon, "S", "ws://s", "ts");
 	const session = daemon.sessions.get("S")!;
 	await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
 	bot.calls = [];
@@ -3676,14 +4140,8 @@ test("outbound file_attachment frame triggers a sendDocument upload to the topic
 });
 
 describe("telegram daemon reconnect reconciliation", () => {
-	function endpointFor(agentDir: string, cwd: string, s: Settings, sessionId: string) {
-		return (async () => {
-			await registerNotificationRoot({ settings: s, cwd, sessionId });
-			const roots = JSON.parse(fs.readFileSync(daemonPaths(agentDir).roots, "utf8")) as { roots: string[] };
-			const dir = path.join(roots.roots[0]!, "sdk");
-			fs.mkdirSync(dir, { recursive: true });
-			fs.writeFileSync(path.join(dir, `${sessionId}.json`), JSON.stringify({ url: "ws://s", token: "ts" }));
-		})();
+	function endpointFor(_agentDir: string, cwd: string, s: Settings, sessionId: string) {
+		return publishIdentityEndpoint(s, cwd, sessionId, "ws://s", "ts");
 	}
 
 	test("identity-guarded replacement survives delayed old close and old message", async () => {
@@ -3711,6 +4169,7 @@ describe("telegram daemon reconnect reconciliation", () => {
 		});
 		await daemon.scanRoots();
 		FakeWs.instances[0]!.emit({ type: "hello", protocolVersion: 2, capabilities: ["client_ping_pong"] });
+		await new Promise(resolve => setTimeout(resolve, 10));
 		now += 25_000;
 		for (const cb of liveness) cb();
 		await daemon.scanRoots();
@@ -3754,6 +4213,7 @@ describe("telegram daemon reconnect reconciliation", () => {
 		await daemon.scanRoots();
 		// Legacy server: advertises capabilities WITHOUT client_ping_pong.
 		FakeWs.instances[0]!.emit({ type: "hello", protocolVersion: 1, capabilities: ["threaded"] });
+		await new Promise(resolve => setTimeout(resolve, 10));
 		expect(liveness).toHaveLength(0);
 		now += 100_000;
 		for (const cb of liveness) cb();
@@ -3790,6 +4250,7 @@ describe("telegram daemon reconnect reconciliation", () => {
 		});
 		await daemon.scanRoots();
 		FakeWs.instances[0]!.emit({ type: "hello", protocolVersion: 2, capabilities: ["client_ping_pong"] });
+		await new Promise(resolve => setTimeout(resolve, 10));
 		now += 25_000;
 		for (const cb of liveness) cb();
 		await daemon.scanRoots();
@@ -3829,11 +4290,7 @@ describe("telegram daemon reconnect answer routing", () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
 		const cwd = path.join(agentDir, "cwd");
-		await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
-		const roots = JSON.parse(fs.readFileSync(daemonPaths(agentDir).roots, "utf8")) as { roots: string[] };
-		const dir = path.join(roots.roots[0]!, "sdk");
-		fs.mkdirSync(dir, { recursive: true });
-		fs.writeFileSync(path.join(dir, "S.json"), JSON.stringify({ url: "ws://s", token: "ts" }));
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts");
 
 		let now = 0;
 		const liveness: Array<() => void> = [];
@@ -3855,6 +4312,7 @@ describe("telegram daemon reconnect answer routing", () => {
 		});
 		await daemon.scanRoots();
 		FakeWs.instances[0]!.emit({ type: "hello", protocolVersion: 2, capabilities: ["client_ping_pong"] });
+		await new Promise(resolve => setTimeout(resolve, 10));
 		now += 25_000;
 		for (const cb of liveness) cb();
 		await daemon.scanRoots();
@@ -3980,7 +4438,7 @@ test("requestStop aborts the active long poll and run() exits, releasing ownersh
 			return 0;
 		}) as any,
 	});
-	daemon.connectSession("S", "ws://s", "t");
+	await connectIdentitySession(daemon, "S", "ws://s", "t");
 	const runPromise = daemon.run();
 	await pollStarted;
 	daemon.requestStop("signal");
@@ -4058,10 +4516,7 @@ test("a fresh daemon scanRoots reconnects an existing session endpoint", async (
 	const agentDir = tempAgentDir();
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
 	const cwd = path.join(agentDir, "repo");
-	await registerNotificationRoot({ settings: s, cwd, sessionId: "live-session" });
-	const endpointDir = path.join(cwd, ".gjc", "state", "sdk");
-	fs.mkdirSync(endpointDir, { recursive: true });
-	fs.writeFileSync(path.join(endpointDir, "live-session.json"), JSON.stringify({ url: "ws://live", token: "tok" }));
+	await publishIdentityEndpoint(s, cwd, "live-session", "ws://live", "tok");
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
@@ -4088,7 +4543,11 @@ test("connectSession eagerly creates a Telegram topic on connect (before any fra
 		botApi: bot,
 		WebSocketImpl: FakeWs as any,
 	});
-	daemon.connectSession("sess-abc123", "ws://x", "tok");
+	const registration = await publishIdentityEndpoint(s, path.join(agentDir, "repo"), "sess-abc123", "ws://x", "tok");
+	daemon.connectSession("sess-abc123", "ws://x", "tok", {
+		canonicalRoot: registration.canonicalRoot,
+		leaseId: registration.leaseId,
+	});
 	// FakeWs does not auto-dispatch "open"; fire it to exercise the connect hook.
 	FakeWs.instances[0]!.dispatchEvent(new Event("open"));
 	await new Promise(r => setTimeout(r, 10));
@@ -4126,10 +4585,14 @@ test("identity_header during an in-flight eager create still renames the topic",
 		botApi: bot,
 		WebSocketImpl: FakeWs as any,
 	});
-	daemon.connectSession("sess-xyz999", "ws://x", "tok");
+	const registration = await publishIdentityEndpoint(s, path.join(agentDir, "repo"), "sess-xyz999", "ws://x", "tok");
+	daemon.connectSession("sess-xyz999", "ws://x", "tok", {
+		canonicalRoot: registration.canonicalRoot,
+		leaseId: registration.leaseId,
+	});
 	// Eager create starts and blocks in-flight on createGate.
 	FakeWs.instances[0]!.dispatchEvent(new Event("open"));
-	await Promise.resolve();
+	await new Promise(resolve => setTimeout(resolve, 10));
 	// identity_header arrives while the create is still in flight -> joins it.
 	const session = daemon.sessions.get("sess-xyz999")!;
 	const identityP = daemon.handleSessionMessage(session as any, {
@@ -4155,12 +4618,21 @@ test("scanRoots connects only live endpoints (skips stale + dead-PID records)", 
 	const agentDir = tempAgentDir();
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
 	const cwd = path.join(agentDir, "repo");
-	await registerNotificationRoot({ settings: s, cwd, sessionId: "live" });
+	const liveReg = await registerNotificationRoot({ settings: s, cwd, sessionId: "live" });
 	await registerNotificationRoot({ settings: s, cwd, sessionId: "stale" });
 	await registerNotificationRoot({ settings: s, cwd, sessionId: "dead" });
 	const endpointDir = path.join(cwd, ".gjc", "state", "sdk");
 	fs.mkdirSync(endpointDir, { recursive: true });
-	fs.writeFileSync(path.join(endpointDir, "live.json"), JSON.stringify({ url: "ws://live", token: "t", pid: 4242 }));
+	fs.writeFileSync(
+		path.join(endpointDir, "live.json"),
+		JSON.stringify({
+			url: "ws://live",
+			token: "t",
+			pid: 4242,
+			canonicalRoot: liveReg.root,
+			leaseId: liveReg.leaseId,
+		}),
+	);
 	fs.writeFileSync(
 		path.join(endpointDir, "stale.json"),
 		JSON.stringify({ url: "ws://stale", token: "t", pid: 4242, stale: true }),
@@ -4183,13 +4655,14 @@ test("scanRoots connects only live endpoints (skips stale + dead-PID records)", 
 	expect(FakeWs.instances.every(ws => ws.url.startsWith("ws://live"))).toBe(true);
 });
 
-test("scanRoots reaps stale and dead-PID session topics after the orphan grace window", async () => {
+test("scanRoots records stale and dead-PID orphan candidates on first scan and reaps both after continuous grace", async () => {
 	FakeWs.instances = [];
+	let now = 70_000;
 	const agentDir = tempAgentDir();
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
 	const cwd = path.join(agentDir, "repo");
-	await registerNotificationRoot({ settings: s, cwd, sessionId: "stale" });
-	await registerNotificationRoot({ settings: s, cwd, sessionId: "dead" });
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "stale", now: () => now });
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "dead", now: () => now });
 	const endpointDir = path.join(cwd, ".gjc", "state", "sdk");
 	fs.mkdirSync(endpointDir, { recursive: true });
 	fs.writeFileSync(
@@ -4202,8 +4675,8 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
 		JSON.stringify({
 			topics: {
-				stale: { topicId: "101", identitySent: true, createdAt: 0, name: "stale" },
-				dead: { topicId: "102", identitySent: true, createdAt: 0, name: "dead" },
+				stale: { topicId: "101", identitySent: true, createdAt: 1_000, name: "stale" },
+				dead: { topicId: "102", identitySent: true, createdAt: 1_000, name: "dead" },
 			},
 		}),
 	);
@@ -4216,9 +4689,22 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 		botApi: bot,
 		WebSocketImpl: FakeWs as any,
 		pidAlive: () => false,
-		now: () => 120_000,
+		now: () => now,
 	});
 	await daemon.loadTopics();
+
+	// First scan: stale/dead endpoints confirm absence, but the continuous-absence
+	// candidate contract only RECORDS a candidate — no destructive delete yet.
+	await daemon.scanRoots();
+	expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	const afterFirst = rootsRegistrySnapshot(agentDir);
+	expect(Object.keys(afterFirst.orphanCandidates).sort()).toEqual(["dead", "stale"]);
+	expect(afterFirst.orphanCandidates.stale.topicId).toBe("101");
+	expect(afterFirst.orphanCandidates.dead.topicId).toBe("102");
+
+	// Second scan after the continuous grace window: both candidates survived
+	// under the same lease and are reaped through the durable deletion path.
+	now = 130_000;
 	await daemon.scanRoots();
 	expect(
 		bot.calls
@@ -4229,16 +4715,19 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 	expect(daemon.sessions.size).toBe(0);
 });
 
-test("scanRoots reaps missing endpoint topics only when all roots are readable and grace has elapsed", async () => {
+test("scanRoots records a missing-root (ENOENT) orphan candidate on first scan and reaps after continuous grace", async () => {
+	let now = 70_000;
 	const agentDir = tempAgentDir();
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
 	const cwd = path.join(agentDir, "repo");
-	await registerNotificationRoot({ settings: s, cwd, sessionId: "missing" });
-	fs.mkdirSync(path.join(cwd, ".gjc", "state", "sdk"), { recursive: true });
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "missing", now: () => now });
+	// No endpoint dir created: the mapped root's sdk dir is ENOENT (confirmed absence).
 	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
 	fs.writeFileSync(
 		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
-		JSON.stringify({ topics: { missing: { topicId: "201", identitySent: true, createdAt: 0, name: "missing" } } }),
+		JSON.stringify({
+			topics: { missing: { topicId: "201", identitySent: true, createdAt: 1_000, name: "missing" } },
+		}),
 	);
 	const bot = new FakeBotApi();
 	const daemon = new TelegramNotificationDaemon({
@@ -4247,36 +4736,395 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
-		now: () => 120_000,
+		now: () => now,
 	});
 	await daemon.loadTopics();
+
+	// First scan: ENOENT confirms absence, but only a candidate is recorded.
+	await daemon.scanRoots();
+	expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	const afterFirst = rootsRegistrySnapshot(agentDir);
+	expect(afterFirst.orphanCandidates.missing).toEqual({
+		observedAt: 70_000,
+		leaseId: afterFirst.sessionLeases.missing.leaseId,
+		topicId: "201",
+	});
+
+	// Second scan after continuous grace: the candidate is reaped.
+	now = 130_000;
 	await daemon.scanRoots();
 	expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([201]);
+});
 
-	const blockedAgentDir = tempAgentDir();
-	const blockedSettings = setPrivateAgentDir(settings(blockedAgentDir), blockedAgentDir);
-	await registerNotificationRoot({
-		settings: blockedSettings,
-		cwd: path.join(blockedAgentDir, "unreadable"),
-		sessionId: "kept",
+test("an ENOENT mapped root reaps only after continuous grace and compacts its exact root/session/lease/candidate (F001/F005)", async () => {
+	let now = 70_000;
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const cwd = path.join(agentDir, "repo");
+	const registration = await registerNotificationRoot({
+		settings: s,
+		cwd,
+		sessionId: "orphan",
+		now: () => now,
+		randomId: () => "lease-enoent",
 	});
-	fs.mkdirSync(daemonPaths(blockedAgentDir).dir, { recursive: true });
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
 	fs.writeFileSync(
-		path.join(daemonPaths(blockedAgentDir).dir, "telegram-topics.json"),
-		JSON.stringify({ topics: { kept: { topicId: "202", identitySent: true, createdAt: 0, name: "kept" } } }),
+		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+		JSON.stringify({
+			topics: { orphan: { topicId: "301", identitySent: true, createdAt: 1_000, name: "orphan" } },
+		}),
 	);
-	const blockedBot = new FakeBotApi();
-	const blockedDaemon = new TelegramNotificationDaemon({
-		settings: blockedSettings,
+	const expectedRoot = registration.root;
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
 		ownerId: "owner",
 		botToken: "tok",
 		chatId: "42",
-		botApi: blockedBot,
-		now: () => 120_000,
+		botApi: bot,
+		now: () => now,
 	});
-	await blockedDaemon.loadTopics();
-	await blockedDaemon.scanRoots();
-	expect(blockedBot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	await daemon.loadTopics();
+
+	// First scan: ENOENT mapped root => confirmed absence; a candidate is recorded
+	// but no destructive delete runs.
+	await daemon.scanRoots();
+	expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	const afterFirst = rootsRegistrySnapshot(agentDir);
+	expect(afterFirst.orphanCandidates.orphan).toEqual({
+		observedAt: 70_000,
+		leaseId: "lease-enoent",
+		topicId: "301",
+	});
+	expect(afterFirst.sessionLeases.orphan.leaseId).toBe("lease-enoent");
+	expect(afterFirst.sessions.orphan).toBe(expectedRoot);
+	expect(afterFirst.roots).toEqual([expectedRoot]);
+
+	// Second scan after continuous grace: the candidate survived under the same
+	// lease, so the topic is reaped through the durable deletion path.
+	now = 130_000;
+	await daemon.scanRoots();
+	expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([301]);
+
+	// F005 selective compaction: ONLY this session's candidate/lease/session
+	// mapping is removed, and the now-unreferenced root is pruned.
+	const afterReap = rootsRegistrySnapshot(agentDir);
+	expect(afterReap.orphanCandidates.orphan).toBeUndefined();
+	expect(afterReap.sessionLeases.orphan).toBeUndefined();
+	expect(afterReap.sessions.orphan).toBeUndefined();
+	expect(afterReap.roots).toEqual([]);
+	expect(topicRegistrySnapshot(agentDir).topics.orphan).toBeUndefined();
+	const effects = await telegramDeletionEffects(agentDir);
+	const reap = effects.find(e => e.kind === "telegram.topic_delete" && e.sessionId === "orphan");
+	expect(reap?.state).toBe("terminal");
+	expect(reap?.payload).toMatchObject({ topicId: "301", leaseId: "lease-enoent" });
+});
+
+test("a non-ENOENT readdir failure on one mapped root withholds only its sessions and never blocks an unrelated missing root (F001)", async () => {
+	let now = 70_000;
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const withheldCwd = path.join(agentDir, "withheld");
+	const missingCwd = path.join(agentDir, "missing");
+	const withheldRegistration = await registerNotificationRoot({
+		settings: s,
+		cwd: withheldCwd,
+		sessionId: "withheld",
+		now: () => now,
+	});
+	await registerNotificationRoot({ settings: s, cwd: missingCwd, sessionId: "reaped", now: () => now });
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+		JSON.stringify({
+			topics: {
+				withheld: { topicId: "401", identitySent: true, createdAt: 1_000, name: "withheld" },
+				reaped: { topicId: "402", identitySent: true, createdAt: 1_000, name: "reaped" },
+			},
+		}),
+	);
+	// The withheld root's sdk dir is unreadable (EACCES => ambiguous evidence),
+	// while the missing root's sdk dir simply does not exist (ENOENT => absence).
+	const withheldSdkDir = path.join(withheldRegistration.root, "sdk");
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		fs: fsWithUnreadableReaddir(withheldSdkDir),
+		now: () => now,
+	});
+	await daemon.loadTopics();
+
+	// First scan: "withheld" is ambiguous (no candidate), "reaped" records one.
+	await daemon.scanRoots();
+	expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	const afterFirst = rootsRegistrySnapshot(agentDir);
+	expect(afterFirst.orphanCandidates.withheld).toBeUndefined();
+	expect(afterFirst.orphanCandidates.reaped).toBeDefined();
+
+	// Second scan after grace: "reaped" is reaped while "withheld" is STILL withheld.
+	now = 130_000;
+	await daemon.scanRoots();
+	expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([402]);
+	expect(bot.calls.some(c => c.method === "deleteForumTopic" && c.body.message_thread_id === 401)).toBe(false);
+
+	// The withheld session's topic, root mapping, and lease are all preserved.
+	const afterReap = rootsRegistrySnapshot(agentDir);
+	expect(afterReap.sessions.withheld).toBeDefined();
+	expect(afterReap.sessionLeases.withheld).toBeDefined();
+	expect(topicRegistrySnapshot(agentDir).topics.withheld).toBeDefined();
+});
+
+test("a fresh same-session registration between the candidate scan and the reap scan restarts the grace window (F001 lease invalidation)", async () => {
+	let now = 70_000;
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const cwd = path.join(agentDir, "repo");
+	await registerNotificationRoot({
+		settings: s,
+		cwd,
+		sessionId: "S",
+		now: () => now,
+		randomId: () => "lease-first",
+	});
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+		JSON.stringify({ topics: { S: { topicId: "501", identitySent: true, createdAt: 1_000, name: "S" } } }),
+	);
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		now: () => now,
+	});
+	await daemon.loadTopics();
+
+	// First scan: candidate recorded under the first lease.
+	await daemon.scanRoots();
+	expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	expect(rootsRegistrySnapshot(agentDir).orphanCandidates.S.leaseId).toBe("lease-first");
+
+	// A fresh same-session registration mints a new lease generation.
+	await registerNotificationRoot({
+		settings: s,
+		cwd,
+		sessionId: "S",
+		now: () => now,
+		randomId: () => "lease-second",
+	});
+	expect(rootsRegistrySnapshot(agentDir).sessionLeases.S.leaseId).toBe("lease-second");
+
+	// Second scan after the original grace window: the candidate's lease no longer
+	// matches the live lease, so the grace window RESTARTS under the new lease
+	// instead of reaping. No deletion; registry entries survive (no compaction).
+	now = 130_000;
+	await daemon.scanRoots();
+	expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	const afterRestart = rootsRegistrySnapshot(agentDir);
+	expect(afterRestart.orphanCandidates.S).toEqual({
+		observedAt: 130_000,
+		leaseId: "lease-second",
+		topicId: "501",
+	});
+	expect(afterRestart.sessionLeases.S.leaseId).toBe("lease-second");
+	expect(afterRestart.sessions.S).toBeDefined();
+	expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+});
+
+test("a 429 deleteForumTopic retains the topic and durable retry metadata, and a fresh daemon honors retryAt (F004)", async () => {
+	let now = 70_000;
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const cwd = path.join(agentDir, "repo");
+	await registerNotificationRoot({
+		settings: s,
+		cwd,
+		sessionId: "S",
+		now: () => now,
+		randomId: () => "lease-retry",
+	});
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+		JSON.stringify({ topics: { S: { topicId: "601", identitySent: true, createdAt: 1_000, name: "S" } } }),
+	);
+	const bot = new RateLimitedDeleteBotApi();
+	bot.retryAfterSec = 30;
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		now: () => now,
+	});
+	await daemon.loadTopics();
+
+	// First scan records the candidate.
+	await daemon.scanRoots();
+	// Second scan reaps, but deleteForumTopic is rate-limited (429).
+	now = 130_000;
+	await daemon.scanRoots();
+	const attempts = bot.calls.filter(c => c.method === "deleteForumTopic");
+	expect(attempts).toHaveLength(1);
+	expect(attempts[0]!.body.message_thread_id).toBe(601);
+	// The topic is retained (uncertain outcome) and the retry deadline is durable.
+	expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+	const claim = (await telegramDeletionEffects(agentDir)).find(
+		e => e.sessionId === "S" && e.kind === "telegram.topic_delete",
+	);
+	expect(claim?.state).toBe("uncertain");
+	expect(claim?.receipt?.retryAt).toBe(160_000);
+
+	// A fresh daemon (restart) before retryAt must NOT call the provider: the
+	// durable retry deadline is honored straight from the persisted receipt.
+	const freshDaemon = new TelegramNotificationDaemon({
+		settings: setPrivateAgentDir(settings(agentDir), agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		now: () => now,
+	});
+	await freshDaemon.loadTopics();
+	now = 140_000; // before retryAt (160_000)
+	await freshDaemon.scanRoots();
+	expect(bot.calls.filter(c => c.method === "deleteForumTopic")).toHaveLength(1);
+
+	// After retryAt elapses the fresh daemon re-attempts and succeeds.
+	now = 170_000;
+	await freshDaemon.scanRoots();
+	expect(bot.calls.filter(c => c.method === "deleteForumTopic")).toHaveLength(2);
+	expect(topicRegistrySnapshot(agentDir).topics.S).toBeUndefined();
+	const finalClaim = (await telegramDeletionEffects(agentDir)).find(
+		e => e.sessionId === "S" && e.kind === "telegram.topic_delete",
+	);
+	expect(finalClaim?.state).toBe("terminal");
+});
+
+test("a terminal deletion record for the same session/topic under an old lease cannot short-circuit a new lease generation (F005)", async () => {
+	let now = 70_000;
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const cwd = path.join(agentDir, "repo");
+	// Seed a terminal deletion record for an OLD lease (a prior completed delete
+	// that left a durable terminal marker for the same session/topic).
+	const seedJournal = new ChatEffectJournal({ agentDir, transport: "telegram", now: () => now });
+	const oldEffectId = "telegram.topic_delete:S:701:lease-old";
+	const seeded = await seedJournal.enqueueAndClaim(
+		{
+			id: oldEffectId,
+			kind: "telegram.topic_delete",
+			transport: "telegram",
+			sessionId: "S",
+			endpointGeneration: 0,
+			payload: { chatId: "42", topicId: "701", leaseId: "lease-old" },
+		},
+		"owner",
+		60_000,
+	);
+	expect(seeded).toBeDefined();
+	await seedJournal.record(oldEffectId, { owner: "owner", epoch: seeded!.epoch }, "terminal", {
+		provider: "telegram",
+		status: "reconciled",
+	});
+
+	// A fresh registration mints a NEW lease for the same session/topic.
+	await registerNotificationRoot({
+		settings: s,
+		cwd,
+		sessionId: "S",
+		now: () => now,
+		randomId: () => "lease-new",
+	});
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+		JSON.stringify({ topics: { S: { topicId: "701", identitySent: true, createdAt: 1_000, name: "S" } } }),
+	);
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		now: () => now,
+	});
+	await daemon.loadTopics();
+
+	// First scan records a candidate under the NEW lease.
+	await daemon.scanRoots();
+	expect(rootsRegistrySnapshot(agentDir).orphanCandidates.S.leaseId).toBe("lease-new");
+
+	// Second scan after grace: the new lease's deletion is NOT short-circuited by
+	// the old terminal record (effect ids are lease-scoped). The provider IS called.
+	now = 130_000;
+	await daemon.scanRoots();
+	expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([701]);
+	const effects = await telegramDeletionEffects(agentDir);
+	expect(effects.find(e => e.id === "telegram.topic_delete:S:701:lease-new")?.state).toBe("terminal");
+	expect(effects.find(e => e.id === oldEffectId)?.state).toBe("terminal");
+});
+
+test("a late frame after session_closed targets a fresh topic and never the deleted thread (F002 send fence)", async () => {
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const cwd = path.join(agentDir, "repo");
+	const reg = await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts");
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	daemon.connectSession("S", "ws://s", "ts", { canonicalRoot: reg.canonicalRoot, leaseId: reg.leaseId });
+	const session = daemon.sessions.get("S")!;
+	await daemon.handleSessionMessage(session, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	const deletedThreadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
+
+	// session_closed fences and deletes the topic; queued/in-flight sends cancel.
+	await daemon.handleSessionMessage(session, { type: "session_closed", sessionId: "S" });
+	expect(bot.calls.some(c => c.method === "deleteForumTopic" && c.body.message_thread_id === deletedThreadId)).toBe(
+		true,
+	);
+
+	// A late frame arriving after the close must never reach the deleted thread.
+	// Reconnecting and sending creates a FRESH topic; the deleted id is fenced out.
+	const callsBeforeLate = bot.calls.length;
+	await connectIdentitySession(daemon, "S", "ws://s2", "ts2");
+	const resumed = daemon.sessions.get("S")!;
+	await daemon.handleSessionMessage(resumed, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+		title: "resumed",
+	});
+	await daemon.handleSessionMessage(resumed, {
+		type: "turn_stream",
+		sessionId: "S",
+		phase: "finalized",
+		text: "late-after-close",
+	});
+	const lateSends = bot.calls.slice(callsBeforeLate).filter(c => c.method === "sendMessage");
+	expect(lateSends.length).toBeGreaterThan(0);
+	expect(lateSends.some(c => c.body.message_thread_id === deletedThreadId)).toBe(false);
 });
 
 test("runDaemonInternal wires SIGTERM to the daemon stop method", async () => {
@@ -4965,7 +5813,7 @@ describe("telegram daemon rich overflow boundary (G006)", () => {
 });
 
 describe("telegram daemon action-needed rich delivery (G004)", () => {
-	function makeAskDaemon(bot: FakeBotApi, rich: { enabled: boolean }) {
+	async function makeAskDaemon(bot: FakeBotApi, rich: { enabled: boolean }) {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
 		const daemon = new TelegramNotificationDaemon({
@@ -4977,14 +5825,14 @@ describe("telegram daemon action-needed rich delivery (G004)", () => {
 			WebSocketImpl: FakeWs as any,
 			rich,
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		return daemon;
 	}
 
 	test("ask rich success: one sendRichMessage with reply_markup, route registered, callback + free-text reply route", async () => {
 		FakeWs.instances = [];
 		const bot = new RichFakeBotApi();
-		const daemon = makeAskDaemon(bot, { enabled: true });
+		const daemon = await makeAskDaemon(bot, { enabled: true });
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -5029,7 +5877,7 @@ describe("telegram daemon action-needed rich delivery (G004)", () => {
 			FakeWs.instances = [];
 			const bot = new RichFakeBotApi();
 			bot.richBehavior = behavior;
-			const daemon = makeAskDaemon(bot, { enabled: true });
+			const daemon = await makeAskDaemon(bot, { enabled: true });
 			await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 				type: "action_needed",
 				kind: "ask",
@@ -5061,7 +5909,7 @@ describe("telegram daemon action-needed rich delivery (G004)", () => {
 	test("idle rich: one sendRichMessage without reply_markup and no message route", async () => {
 		FakeWs.instances = [];
 		const bot = new RichFakeBotApi();
-		const daemon = makeAskDaemon(bot, { enabled: true });
+		const daemon = await makeAskDaemon(bot, { enabled: true });
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "idle",
@@ -5079,7 +5927,7 @@ describe("telegram daemon action-needed rich delivery (G004)", () => {
 	test("off (rich.enabled=false) ask: byte-identical HTML, zero sendRichMessage", async () => {
 		FakeWs.instances = [];
 		const bot = new RichFakeBotApi();
-		const daemon = makeAskDaemon(bot, { enabled: false });
+		const daemon = await makeAskDaemon(bot, { enabled: false });
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -5185,7 +6033,7 @@ describe("telegram daemon /rich toggle (G005)", () => {
 			WebSocketImpl: FakeWs as any,
 			rich: { enabled: true },
 		});
-		daemon.connectSession("S", "ws://s", "ts");
+		await connectIdentitySession(daemon, "S", "ws://s", "ts");
 		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
 			type: "action_needed",
 			kind: "ask",
@@ -5314,5 +6162,509 @@ describe("telegram daemon /rich toggle (G005)", () => {
 			),
 		).toBe(true);
 		expect(bot.calls.some(c => c.method === "sendMessage" && c.body.text === "Rich messages: off")).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Admission identity: canonical root (realpath/symlink collapse), bound lease,
+// duplicate-endpoint fail-closed, and predecessor/successor authority gaps.
+// Every test asserts both no destructive provider call and no stale delivery.
+// ---------------------------------------------------------------------------
+describe("telegram daemon admission identity (endpoint-carried publication identity)", () => {
+	/** Write an identity-bearing live endpoint at an explicit path. */
+	function writeIdentityEndpoint(
+		endpointDir: string,
+		sessionId: string,
+		url: string,
+		token: string,
+		canonicalRoot: string,
+		leaseId: string,
+		pid = 4242,
+	): void {
+		fs.mkdirSync(endpointDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(endpointDir, `${sessionId}.json`),
+			JSON.stringify({ url, token, pid, canonicalRoot, leaseId }),
+		);
+	}
+
+	/** Seed a telegram topic record so absence/reap evidence is exercised. */
+	function seedTopic(agentDir: string, sessionId: string, topicId: string): void {
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		const file = path.join(daemonPaths(agentDir).dir, "telegram-topics.json");
+		const existing = fs.existsSync(file)
+			? (JSON.parse(fs.readFileSync(file, "utf8")) as { topics: Record<string, unknown> })
+			: { topics: {} };
+		existing.topics[sessionId] = { topicId, identitySent: true, createdAt: 1_000, name: sessionId };
+		fs.writeFileSync(file, JSON.stringify(existing));
+	}
+
+	test("realpath symlink alias collapse: alias and real target register the same canonical root identity", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const real = path.join(agentDir, "real-workspace");
+		const alias = path.join(agentDir, "alias-workspace");
+		fs.mkdirSync(real, { recursive: true });
+		fs.symlinkSync(real, alias);
+		const canonicalRoot = path.join(fs.realpathSync(real), ".gjc", "state");
+
+		const fromAlias = await registerNotificationRoot({
+			settings: s,
+			cwd: alias,
+			sessionId: "S",
+			randomId: () => "lease-1",
+		});
+		expect(fromAlias.root).toBe(canonicalRoot);
+		expect(fromAlias.leaseId).toBe("lease-1");
+
+		await registerNotificationRoot({ settings: s, cwd: real, sessionId: "S", randomId: () => "lease-2" });
+
+		const registry = rootsRegistrySnapshot(agentDir);
+		expect(registry.roots).toEqual([canonicalRoot]);
+		expect(registry.sessions.S).toBe(canonicalRoot);
+		expect(registry.sessionLeases.S.leaseId).toBe("lease-2");
+	});
+
+	test("missing workspace keeps one canonical identity before and after directory creation", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "created-after-registration");
+		const first = await registerNotificationRoot({
+			settings: s,
+			cwd,
+			sessionId: "S",
+			randomId: () => "lease-1",
+		});
+		fs.mkdirSync(cwd, { recursive: true });
+		const second = await registerNotificationRoot({
+			settings: s,
+			cwd,
+			sessionId: "S",
+			randomId: () => "lease-2",
+		});
+
+		expect(first.root).toBe(second.root);
+		expect(second.root).toBe(path.join(fs.realpathSync(cwd), ".gjc", "state"));
+		expect(rootsRegistrySnapshot(agentDir).roots).toEqual([second.root]);
+	});
+	test("scan collapses a legacy symlink root and canonical root before endpoint admission", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const real = path.join(agentDir, "real-legacy");
+		const alias = path.join(agentDir, "alias-legacy");
+		fs.mkdirSync(real, { recursive: true });
+		fs.symlinkSync(real, alias);
+		const legacyRoot = path.join(alias, ".gjc", "state");
+		const registryPath = daemonPaths(agentDir).roots;
+		fs.mkdirSync(path.dirname(registryPath), { recursive: true });
+		fs.writeFileSync(
+			registryPath,
+			JSON.stringify({
+				version: 1,
+				roots: [legacyRoot],
+				sessions: { legacy: legacyRoot },
+				sessionLeases: { legacy: { leaseId: "legacy-lease", refreshedAt: 1 } },
+			}),
+		);
+
+		const identity = await publishIdentityEndpoint(s, alias, "S", "ws://s", "ts", {
+			randomId: () => "lease-1",
+		});
+		const persisted = rootsRegistrySnapshot(agentDir);
+		expect(persisted.roots).toContain(legacyRoot);
+		expect(persisted.roots).toContain(identity.canonicalRoot);
+
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: new FakeBotApi(),
+			WebSocketImpl: FakeWs as any,
+			pidAlive: () => true,
+		});
+		await daemon.scanRoots();
+
+		expect(daemon.sessions.get("S")?.canonicalRoot).toBe(identity.canonicalRoot);
+		expect(FakeWs.instances.filter(ws => ws.url.includes("ws://s"))).toHaveLength(1);
+	});
+	test("a non-ENOENT root canonicalization failure is ambiguous even when readdir would succeed", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "unresolvable-root");
+		const identity = await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", {
+			randomId: () => "lease-1",
+		});
+		seedTopic(agentDir, "S", "501");
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			fs: fsWithUnresolvableRealpath(identity.canonicalRoot),
+			pidAlive: () => true,
+			now: () => 130_000,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+
+		expect(daemon.sessions.has("S")).toBe(false);
+		expect(FakeWs.instances).toHaveLength(0);
+		expect(bot.calls.some(call => call.method === "deleteForumTopic")).toBe(false);
+		expect(rootsRegistrySnapshot(agentDir).orphanCandidates?.S).toBeUndefined();
+	});
+	test("daemon restart after symlink alias removal does not falsely reap a live canonical workspace", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const real = path.join(agentDir, "real-ws");
+		const alias = path.join(agentDir, "alias-ws");
+		fs.mkdirSync(real, { recursive: true });
+		fs.symlinkSync(real, alias);
+		await publishIdentityEndpoint(s, alias, "S", "ws://s", "ts", { randomId: () => "lease-1", now: () => 70_000 });
+		seedTopic(agentDir, "S", "501");
+
+		const bot = new FakeBotApi();
+		let now = 70_000;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: () => true,
+			now: () => now,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		expect(daemon.sessions.has("S")).toBe(true);
+
+		fs.unlinkSync(alias);
+
+		bot.calls = [];
+		now = 130_000;
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(daemon.sessions.has("S")).toBe(true);
+	});
+
+	test("duplicate same-session endpoints across roots are ambiguous: neither first-wins nor authorizes cleanup", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const rootA = path.join(agentDir, "root-a");
+		const rootB = path.join(agentDir, "root-b");
+		fs.mkdirSync(rootA, { recursive: true });
+		fs.mkdirSync(rootB, { recursive: true });
+		const regA = await registerNotificationRoot({
+			settings: s,
+			cwd: rootA,
+			sessionId: "S",
+			randomId: () => "lease-a",
+		});
+		const regB = await registerNotificationRoot({
+			settings: s,
+			cwd: rootB,
+			sessionId: "other",
+			randomId: () => "lease-b",
+		});
+		// Duplicate S endpoint file in BOTH distinct canonical roots with different identity.
+		writeIdentityEndpoint(path.join(regA.root, "sdk"), "S", "ws://a", "ta", regA.root, regA.leaseId);
+		writeIdentityEndpoint(path.join(regB.root, "sdk"), "S", "ws://b", "tb", regB.root, "lease-b-dup");
+		seedTopic(agentDir, "S", "501");
+
+		const bot = new FakeBotApi();
+		let now = 70_000;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: () => true,
+			now: () => now,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+
+		expect(daemon.sessions.has("S")).toBe(false);
+		expect(FakeWs.instances.some(ws => ws.url.includes("ws://a") || ws.url.includes("ws://b"))).toBe(false);
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(rootsRegistrySnapshot(agentDir).orphanCandidates?.S).toBeUndefined();
+
+		now = 130_000;
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(daemon.sessions.has("S")).toBe(false);
+	});
+
+	test("predecessor socket close after successor registration cannot delete or compact", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://old", "told", { randomId: () => "lease-old", now: () => 1000 });
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const predSession = daemon.sessions.get("S")!;
+		expect(predSession.leaseId).toBe("lease-old");
+
+		await daemon.handleSessionMessage(predSession, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
+
+		await registerNotificationRoot({
+			settings: s,
+			cwd,
+			sessionId: "S",
+			randomId: () => "lease-new",
+			now: () => 2000,
+		});
+		bot.calls = [];
+		await daemon.handleSessionMessage(predSession, { type: "session_closed", sessionId: "S" });
+
+		expect(bot.calls.some(c => c.method === "deleteForumTopic" && c.body.message_thread_id === threadId)).toBe(false);
+		const afterClose = rootsRegistrySnapshot(agentDir);
+		expect(afterClose.sessionLeases.S.leaseId).toBe("lease-new");
+		expect(afterClose.sessions.S).toBeDefined();
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+	});
+
+	test("successor registration revokes a predecessor socket: late sends are dropped and the successor connects", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://old", "told", { randomId: () => "lease-old" });
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const predSocket = FakeWs.instances[0]!;
+		expect(daemon.sessions.get("S")?.leaseId).toBe("lease-old");
+		const predecessor = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(predecessor, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "old",
+			branch: "old",
+		});
+		const threadId = bot.calls.find(call => call.method === "sendMessage")!.body.message_thread_id;
+		const predecessorSends = predSocket.sent.length;
+
+		await publishIdentityEndpoint(s, cwd, "S", "ws://new", "tnew", { randomId: () => "lease-new" });
+		await daemon.handleTelegramUpdate({
+			update_id: 99,
+			message: {
+				chat: { id: 42 },
+				message_thread_id: threadId,
+				message_id: 99,
+				text: "must not reach predecessor",
+			},
+		});
+		expect(predSocket.sent).toHaveLength(predecessorSends);
+		expect(daemon.sessions.get("S")?.ws).not.toBe(predSocket as any);
+
+		// No scan is required for revocation: Telegram-originated control and every
+		// inbound predecessor frame revalidate bound authority before acting.
+		bot.calls = [];
+		predSocket.emit({ type: "action_needed", kind: "ask", id: "stale", question: "Q", options: ["Y"] });
+		await new Promise(resolve => setTimeout(resolve, 10));
+		expect(bot.calls.some(c => c.method === "sendMessage")).toBe(false);
+		expect(daemon.sessions.get("S")?.ws).not.toBe(predSocket as any);
+
+		await daemon.scanRoots();
+		expect(daemon.sessions.get("S")?.ws).not.toBe(predSocket as any);
+		expect(daemon.sessions.get("S")?.leaseId).toBe("lease-new");
+
+		const successor = daemon.sessions.get("S")!;
+		bot.calls = [];
+		await daemon.handleSessionMessage(successor, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r2",
+			branch: "b2",
+		});
+		expect(bot.calls.some(c => c.method === "editForumTopic" || c.method === "sendMessage")).toBe(true);
+	});
+
+	test("a single valid successor connects and operates after a predecessor is gone", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", { randomId: () => "lease-1" });
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		expect(daemon.sessions.has("S")).toBe(true);
+		expect(daemon.sessions.get("S")!.leaseId).toBe("lease-1");
+
+		const session = daemon.sessions.get("S")!;
+		FakeWs.instances[0]!.dispatchEvent(new Event("open"));
+		await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
+		expect(bot.calls.some(c => c.method === "createForumTopic")).toBe(true);
+
+		const before = daemon.sessions.get("S")!;
+		await daemon.scanRoots();
+		expect(daemon.sessions.get("S")).toBe(before);
+	});
+
+	test("endpoint incarnation replacement revokes a socket even when root and lease are unchanged", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		const identity = await publishIdentityEndpoint(s, cwd, "S", "ws://old", "told", {
+			randomId: () => "lease-1",
+		});
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const predecessor = FakeWs.instances[0]!;
+		expect(daemon.sessions.get("S")?.ws).toBe(predecessor as any);
+
+		writeIdentityEndpoint(
+			path.join(identity.canonicalRoot, "sdk"),
+			"S",
+			"ws://new",
+			"tnew",
+			identity.canonicalRoot,
+			identity.leaseId,
+		);
+		bot.calls = [];
+		predecessor.emit({ type: "action_needed", kind: "ask", id: "stale", question: "Q", options: ["Y"] });
+		await new Promise(resolve => setTimeout(resolve, 10));
+
+		expect(bot.calls.some(call => call.method === "sendMessage")).toBe(false);
+		expect(daemon.sessions.get("S")?.ws).not.toBe(predecessor as any);
+
+		await daemon.scanRoots();
+		expect(daemon.sessions.get("S")?.leaseId).toBe("lease-1");
+		expect(FakeWs.instances.some(ws => ws.url.includes("ws://new"))).toBe(true);
+	});
+	test("predecessor race: fresh registry lease with predecessor endpoint file remaining never connects or deletes", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		// Predecessor registers and publishes an identity-bearing endpoint.
+		await publishIdentityEndpoint(s, cwd, "S", "ws://old", "told", { randomId: () => "lease-old" });
+		seedTopic(agentDir, "S", "501");
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+
+		// Successor registers (fresh lease) but the predecessor endpoint file is
+		// NOT yet overwritten — it still carries the OLD lease. This is the exact
+		// race window: registry has lease-new, endpoint file carries lease-old.
+		await registerNotificationRoot({ settings: s, cwd, sessionId: "S", randomId: () => "lease-new" });
+		await daemon.scanRoots();
+
+		// The predecessor endpoint (carrying lease-old) does NOT match the fresh
+		// registry lease (lease-new) → mismatched carried identity → ambiguous →
+		// NEVER connects. No topic created, no close/delete possible.
+		expect(daemon.sessions.has("S")).toBe(false);
+		expect(FakeWs.instances.some(ws => ws.url.includes("ws://old"))).toBe(false);
+		expect(bot.calls.some(c => c.method === "createForumTopic")).toBe(false);
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+
+		// Once the successor publishes its own identity-bearing endpoint (carrying
+		// lease-new), the scan connects it — the predecessor endpoint is superseded.
+		await publishIdentityEndpoint(s, cwd, "S", "ws://new", "tnew", { randomId: () => "lease-new" });
+		await daemon.scanRoots();
+		expect(daemon.sessions.has("S")).toBe(true);
+		expect(daemon.sessions.get("S")!.leaseId).toBe("lease-new");
+	});
+
+	test("endpoint missing publication identity is ambiguous and never connects", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		// Register but write a legacy endpoint WITHOUT canonicalRoot/leaseId.
+		await registerNotificationRoot({ settings: s, cwd, sessionId: "S", randomId: () => "lease-1" });
+		const endpointDir = path.join(cwd, ".gjc", "state", "sdk");
+		fs.mkdirSync(endpointDir, { recursive: true });
+		fs.writeFileSync(path.join(endpointDir, "S.json"), JSON.stringify({ url: "ws://s", token: "ts", pid: 4242 }));
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+
+		// Missing publication identity → malformed → ambiguous → never connects.
+		// The daemon never infers a lease from the registry.
+		expect(daemon.sessions.has("S")).toBe(false);
+		expect(FakeWs.instances.some(ws => ws.url.includes("ws://s"))).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -20,6 +20,7 @@ import {
 	registerNotificationRoot,
 	releaseDaemonOwnership,
 	renewDaemonHeartbeat,
+	stampEndpointPublicationIdentity,
 	TelegramBotTransport,
 	type TelegramDaemonFs,
 	TelegramEventDispatchState,
@@ -281,16 +282,19 @@ async function publishIdentityEndpoint(
 	const reg = await registerNotificationRoot({ settings: s, cwd, sessionId, ...(opts ?? {}) });
 	const dir = path.join(reg.root, "sdk");
 	fs.mkdirSync(dir, { recursive: true });
+	const endpointPath = path.join(dir, `${sessionId}.json`);
 	fs.writeFileSync(
-		path.join(dir, `${sessionId}.json`),
+		endpointPath,
 		JSON.stringify({
 			url,
 			token,
 			...(opts?.pid === undefined ? {} : { pid: opts.pid }),
-			canonicalRoot: reg.root,
-			leaseId: reg.leaseId,
 		}),
 	);
+	await stampEndpointPublicationIdentity(endpointPath, {
+		canonicalRoot: reg.root,
+		leaseId: reg.leaseId,
+	});
 	return { canonicalRoot: reg.root, leaseId: reg.leaseId };
 }
 
@@ -3519,11 +3523,7 @@ test("activity busy frame sends a typing chat action into the session topic", as
 test("session_closed deletes the topic and resume creates a fresh visible topic", async () => {
 	const agentDir = tempAgentDir();
 	const s = settings(agentDir);
-	const reg = await registerNotificationRoot({
-		settings: s,
-		cwd: path.join(agentDir, "repo"),
-		sessionId: "S",
-	});
+	const identity = await publishIdentityEndpoint(s, path.join(agentDir, "repo"), "S", "ws://s", "tok");
 	const bot = new FakeBotApi();
 	let now = 0;
 	const daemon = new TelegramNotificationDaemon({
@@ -3535,15 +3535,8 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 		WebSocketImpl: FakeWs as any,
 		now: () => now,
 	});
-	const session = {
-		sessionId: "S",
-		token: "tok",
-		endpointKey: "ws://s\0tok",
-		canonicalRoot: reg.root,
-		leaseId: reg.leaseId,
-		ws: { readyState: 1, send() {} },
-		pending: new Map(),
-	};
+	daemon.connectSession("S", "ws://s", "tok", identity);
+	const session = daemon.sessions.get("S")!;
 
 	await daemon.handleSessionMessage(session as any, {
 		type: "identity_header",
@@ -3593,7 +3586,7 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 test("session_closed drains an in-flight topic creation and deletes the created topic", async () => {
 	const agentDir = tempAgentDir();
 	const s = settings(agentDir);
-	const reg = await registerNotificationRoot({ settings: s, cwd: path.join(agentDir, "repo"), sessionId: "S" });
+	const registration = await publishIdentityEndpoint(s, path.join(agentDir, "repo"), "S", "ws://s", "tok");
 	const createStarted = Promise.withResolvers<void>();
 	const releaseCreate = Promise.withResolvers<void>();
 	const calls: Array<{ method: string; body: any }> = [];
@@ -3616,16 +3609,10 @@ test("session_closed drains an in-flight topic creation and deletes the created 
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
+		WebSocketImpl: FakeWs as never,
 	});
-	const session = {
-		sessionId: "S",
-		token: "tok",
-		endpointKey: "ws://s\0tok",
-		canonicalRoot: reg.root,
-		leaseId: reg.leaseId,
-		ws: { readyState: 1, send() {} },
-		pending: new Map(),
-	};
+	daemon.connectSession("S", "ws://s", "tok", registration);
+	const session = daemon.sessions.get("S")!;
 
 	const identity = daemon.handleSessionMessage(session as any, {
 		type: "identity_header",
@@ -3650,7 +3637,7 @@ test("session_closed drains an in-flight topic creation and deletes the created 
 test("TOPIC_CLOSED is uncertain and retains the topic, fence, and registry for retry", async () => {
 	const agentDir = tempAgentDir();
 	const s = settings(agentDir);
-	const reg = await registerNotificationRoot({ settings: s, cwd: path.join(agentDir, "repo"), sessionId: "S" });
+	const identity = await publishIdentityEndpoint(s, path.join(agentDir, "repo"), "S", "ws://s", "tok");
 	const calls: Array<{ method: string; body: any }> = [];
 	const bot = {
 		async call(method: string, body: unknown): Promise<unknown> {
@@ -3670,16 +3657,10 @@ test("TOPIC_CLOSED is uncertain and retains the topic, fence, and registry for r
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
+		WebSocketImpl: FakeWs as never,
 	});
-	const session = {
-		sessionId: "S",
-		token: "tok",
-		endpointKey: "ws://s\0tok",
-		canonicalRoot: reg.root,
-		leaseId: reg.leaseId,
-		ws: { readyState: 1, send() {} },
-		pending: new Map(),
-	};
+	daemon.connectSession("S", "ws://s", "tok", identity);
+	const session = daemon.sessions.get("S")!;
 	await daemon.handleSessionMessage(session as any, {
 		type: "identity_header",
 		sessionId: "S",
@@ -6666,5 +6647,700 @@ describe("telegram daemon admission identity (endpoint-carried publication ident
 		// The daemon never infers a lease from the registry.
 		expect(daemon.sessions.has("S")).toBe(false);
 		expect(FakeWs.instances.some(ws => ws.url.includes("ws://s"))).toBe(false);
+	});
+});
+// ---------------------------------------------------------------------------
+// Immutable-head review regressions: a late predecessor close/late frame after
+// successor publication cannot mutate successor routes/queues/topic/generation;
+// every ambiguous endpoint form revokes an attached predecessor; and a failed
+// topic-registry persist after a terminal remote delete withholds compaction
+// and reconciliation so restart finishes local cleanup without a second
+// provider delete. Every test asserts both no destructive provider call and
+// successor/global-state preservation. The real production endpoint
+// publication/stamping path (registerNotificationRoot + identity-bearing
+// endpoint file) drives admission, never hand-written registry JSON.
+// ---------------------------------------------------------------------------
+describe("telegram daemon immutable-head review (predecessor close, ambiguous revoke, deletion durability)", () => {
+	type DaemonInternals = {
+		closingSessions: Set<string>;
+		fencedTopicGeneration: Map<string, number>;
+		liveTopicGeneration: Map<string, number>;
+		closedEndpointKeys: Map<string, string>;
+		enqueueTopicDeletionIntent(sessionId: string, leaseId: string): Promise<void>;
+	};
+	const internals = (daemon: TelegramNotificationDaemon): DaemonInternals => daemon as unknown as DaemonInternals;
+
+	test("production endpoint stamper publishes the committed registration identity atomically", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "workspace");
+		fs.mkdirSync(cwd, { recursive: true });
+		const registration = await publishIdentityEndpoint(
+			s,
+			cwd,
+			"production-published-session",
+			"ws://published",
+			"published-token",
+			{ randomId: () => "published-lease", pid: 4242 },
+		);
+		const endpointPath = path.join(registration.canonicalRoot, "sdk", "production-published-session.json");
+		const endpoint = JSON.parse(fs.readFileSync(endpointPath, "utf8")) as {
+			url?: string;
+			token?: string;
+			pid?: number;
+			canonicalRoot?: string;
+			leaseId?: string;
+		};
+		const registry = rootsRegistrySnapshot(agentDir);
+		expect(endpoint).toMatchObject({
+			url: "ws://published",
+			token: "published-token",
+			pid: 4242,
+			canonicalRoot: registry.sessions["production-published-session"],
+			leaseId: registry.sessionLeases["production-published-session"].leaseId,
+		});
+		expect(endpoint.canonicalRoot).toBe(path.join(fs.realpathSync(cwd), ".gjc", "state"));
+	});
+	test("a predecessor session_closed after successor publication+connect is a no-op for successor state", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		// Predecessor registers + publishes via the real production stamping path.
+		await publishIdentityEndpoint(s, cwd, "S", "ws://old", "told", { randomId: () => "lease-old", now: () => 1000 });
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const predSocket = daemon.sessions.get("S")!;
+		const predWs = FakeWs.instances[0]!;
+		expect(predSocket.leaseId).toBe("lease-old");
+		await daemon.handleSessionMessage(predSocket, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
+
+		// Successor registers + publishes via the real production stamping path.
+		await publishIdentityEndpoint(s, cwd, "S", "ws://new", "tnew", { randomId: () => "lease-new", now: () => 2000 });
+		bot.calls = [];
+		await daemon.scanRoots(); // revokes the predecessor, connects the successor
+		const successor = daemon.sessions.get("S")!;
+		expect(successor.ws).not.toBe(predWs as never);
+		expect(successor.leaseId).toBe("lease-new");
+		await daemon.handleSessionMessage(successor, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b2",
+		});
+		const successorGen = internals(daemon).liveTopicGeneration.get("S")!;
+		expect(successorGen).toBeGreaterThan(0);
+		const successorPending = new Map(successor.pending);
+
+		// The predecessor emits session_closed AFTER successor publication+connect.
+		bot.calls = [];
+		await daemon.handleSessionMessage(predSocket, { type: "session_closed", sessionId: "S" });
+
+		// No destructive provider call.
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		// No global mutation: closingSessions empty, generation live & unchanged,
+		// no fence, no endpoint tombstone. The successor socket is untouched.
+		const after = internals(daemon);
+		expect(after.closingSessions.has("S")).toBe(false);
+		expect(after.fencedTopicGeneration.has("S")).toBe(false);
+		expect(after.liveTopicGeneration.get("S")).toBe(successorGen);
+		expect(after.closedEndpointKeys.get("S")).toBeUndefined();
+		expect(daemon.sessions.get("S")).toBe(successor);
+		expect(successor.pending).toEqual(successorPending);
+		// The predecessor socket was safely closed (its own socket only).
+		expect(predWs.readyState).toBe(3);
+		// The successor can still deliver into the topic (admission intact).
+		bot.calls = [];
+		await daemon.handleSessionMessage(successor, {
+			type: "turn_stream",
+			sessionId: "S",
+			phase: "finalized",
+			text: "successor-still-alive",
+		});
+		expect(bot.calls.some(c => c.method === "sendMessage" && c.body.message_thread_id === threadId)).toBe(true);
+	});
+	test("session_closed serializes its full destructive path against a successor registration", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://old", "told", {
+			randomId: () => "lease-old",
+		});
+
+		let releaseDelete: () => void = () => {};
+		const deleteGate = new Promise<void>(resolve => {
+			releaseDelete = resolve;
+		});
+		let signalDeleteStarted: () => void = () => {};
+		const deleteStarted = new Promise<void>(resolve => {
+			signalDeleteStarted = resolve;
+		});
+		const bot = new FakeBotApi();
+		const baseCall = bot.call.bind(bot);
+		bot.call = (async (method: string, body: unknown) => {
+			if (method === "deleteForumTopic") {
+				bot.calls.push({ method, body });
+				signalDeleteStarted();
+				await deleteGate;
+				return { ok: true, result: true };
+			}
+			return baseCall(method, body);
+		}) as never;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const predecessor = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(predecessor, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+
+		const close = daemon.handleSessionMessage(predecessor, {
+			type: "session_closed",
+			sessionId: "S",
+		});
+		await deleteStarted;
+		await expect(
+			registerNotificationRoot({
+				settings: s,
+				cwd,
+				sessionId: "S",
+				randomId: () => "lease-new",
+			}),
+		).rejects.toThrow();
+
+		releaseDelete();
+		await close;
+		const successor = await registerNotificationRoot({
+			settings: s,
+			cwd,
+			sessionId: "S",
+			randomId: () => "lease-new",
+		});
+		expect(successor.leaseId).toBe("lease-new");
+		expect(rootsRegistrySnapshot(agentDir).sessionLeases.S.leaseId).toBe("lease-new");
+		expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	});
+
+	test("a predecessor late frame after successor publication is dropped and never mutates the successor topic/generation", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://old", "told", { randomId: () => "lease-old" });
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const predSocket = daemon.sessions.get("S")!;
+		const predWs = FakeWs.instances[0]!;
+		await daemon.handleSessionMessage(predSocket, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
+
+		await publishIdentityEndpoint(s, cwd, "S", "ws://new", "tnew", { randomId: () => "lease-new" });
+		await daemon.scanRoots(); // revokes the predecessor, connects the successor
+		const successor = daemon.sessions.get("S")!;
+		expect(successor.ws).not.toBe(predWs as never);
+		await daemon.handleSessionMessage(successor, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b2",
+		});
+		const successorGen = internals(daemon).liveTopicGeneration.get("S")!;
+		expect(successorGen).toBeGreaterThan(0);
+
+		// A late frame from the PREDECESSOR socket (real ws delivery path) must be
+		// dropped before it can reach the successor topic or stamp a delivery.
+		bot.calls = [];
+		predWs.emit({ type: "turn_stream", sessionId: "S", phase: "finalized", text: "predecessor-late" });
+		await new Promise(resolve => setTimeout(resolve, 10));
+		expect(bot.calls.some(c => c.method === "sendMessage")).toBe(false);
+		// Successor topic/generation untouched; the successor remains current.
+		expect(internals(daemon).liveTopicGeneration.get("S")).toBe(successorGen);
+		expect(internals(daemon).fencedTopicGeneration.has("S")).toBe(false);
+		expect(daemon.sessions.get("S")).toBe(successor);
+		// The successor can still deliver into the same topic.
+		await daemon.handleSessionMessage(successor, {
+			type: "turn_stream",
+			sessionId: "S",
+			phase: "finalized",
+			text: "successor-ok",
+		});
+		expect(bot.calls.some(c => c.method === "sendMessage" && c.body.message_thread_id === threadId)).toBe(true);
+	});
+
+	test.each([
+		[
+			"missing publication identity",
+			(ctx: { endpointFile: string; s: Settings; cwd: string }) => {
+				fs.writeFileSync(ctx.endpointFile, JSON.stringify({ url: "ws://s", token: "ts", pid: 4242 }));
+			},
+		],
+		[
+			"malformed unreadable endpoint",
+			(ctx: { endpointFile: string; s: Settings; cwd: string }) => {
+				fs.writeFileSync(ctx.endpointFile, "{ not valid json");
+			},
+		],
+		[
+			"mapped-root/lease mismatch",
+			async (ctx: { endpointFile: string; s: Settings; cwd: string }) => {
+				// A successor registration changes the registry lease; the
+				// predecessor endpoint file still carries the old lease → mismatched
+				// carried identity → ambiguous → revokes the attached predecessor.
+				await registerNotificationRoot({
+					settings: ctx.s,
+					cwd: ctx.cwd,
+					sessionId: "S",
+					randomId: () => "lease-new",
+				});
+			},
+		],
+	] as Array<
+		[string, (ctx: { endpointFile: string; s: Settings; cwd: string }) => unknown]
+	>)("ambiguous endpoint (%s) revokes an attached predecessor without deleting or reaping", async (_name, mutate) => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		const identity = await publishIdentityEndpoint(s, cwd, "S", "ws://old", "told", { randomId: () => "lease-old" });
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const predSocket = daemon.sessions.get("S")!;
+		expect(predSocket).toBeDefined();
+		const predWs = FakeWs.instances[0]!;
+		await daemon.handleSessionMessage(predSocket, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+
+		const ctx = { endpointFile: path.join(identity.canonicalRoot, "sdk", "S.json"), s, cwd };
+		await mutate(ctx);
+
+		bot.calls = [];
+		await daemon.scanRoots();
+
+		// The attached predecessor socket is revoked (fail closed).
+		expect(daemon.sessions.has("S")).toBe(false);
+		expect(predWs.readyState).toBe(3);
+		// Ambiguity withholds cleanup: no destructive provider call.
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		// The topic + roots survive (no reap/compaction under ambiguity).
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+		const reg = rootsRegistrySnapshot(agentDir);
+		expect(reg.sessionLeases.S).toBeDefined();
+		expect(reg.orphanCandidates?.S).toBeUndefined();
+	});
+
+	test("a duplicate same-session endpoint appearing after attachment revokes the predecessor without cleanup", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const rootA = path.join(agentDir, "root-a");
+		const rootB = path.join(agentDir, "root-b");
+		fs.mkdirSync(rootA, { recursive: true });
+		fs.mkdirSync(rootB, { recursive: true });
+		await publishIdentityEndpoint(s, rootA, "S", "ws://a", "ta", {
+			randomId: () => "lease-a",
+		});
+		const other = await registerNotificationRoot({
+			settings: s,
+			cwd: rootB,
+			sessionId: "other",
+			randomId: () => "lease-b",
+		});
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const predecessor = daemon.sessions.get("S")!;
+		const predecessorWs = predecessor.ws as unknown as FakeWs;
+		await daemon.handleSessionMessage(predecessor, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+
+		const duplicateEndpoint = path.join(other.root, "sdk", "S.json");
+		fs.mkdirSync(path.dirname(duplicateEndpoint), { recursive: true });
+		fs.writeFileSync(duplicateEndpoint, JSON.stringify({ url: "ws://b", token: "tb", pid: 4242 }));
+		await stampEndpointPublicationIdentity(duplicateEndpoint, {
+			canonicalRoot: other.root,
+			leaseId: other.leaseId,
+		});
+		bot.calls = [];
+		await daemon.scanRoots();
+
+		expect(daemon.sessions.has("S")).toBe(false);
+		expect(predecessorWs.readyState).toBe(3);
+		expect(bot.calls.some(call => call.method === "deleteForumTopic")).toBe(false);
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+		const registry = rootsRegistrySnapshot(agentDir);
+		expect(registry.sessionLeases.S).toBeDefined();
+		expect(registry.orphanCandidates?.S).toBeUndefined();
+	});
+	test("a failed topic-registry persist after a terminal remote delete withholds compaction/reconciliation and restart finishes local cleanup without a second provider delete", async () => {
+		const agentDir = tempAgentDir();
+		// Test-only fs: telegram-topics.json writes can be toggled to fail, while
+		// every other operation (deletion journal, roots registry) is real so the
+		// durable claim and roots state are exercised truthfully.
+		let failTopicPersist = false;
+		const fsImpl: TelegramDaemonFs = {
+			mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+			readFile: (file, encoding) => fs.promises.readFile(file, encoding),
+			writeFile: async (file, data, opts) => {
+				if (failTopicPersist && String(file).includes("telegram-topics.json")) {
+					throw new Error("simulated topic-registry persist failure");
+				}
+				await fs.promises.writeFile(file, data, opts);
+			},
+			rename: (oldPath, newPath) => fs.promises.rename(oldPath, newPath).then(() => undefined),
+			unlink: file => fs.promises.unlink(file),
+			open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
+			readdir: file => fs.promises.readdir(file),
+			chmod: (file, mode) => fs.promises.chmod(file, mode),
+		};
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		const identity = await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", {
+			randomId: () => "lease-1",
+			now: () => 1000,
+		});
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			fs: fsImpl,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const session = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+		const topicId = topicRegistrySnapshot(agentDir).topics.S!.topicId;
+
+		// Make the topic-registry persist fail during the close-path local cleanup.
+		failTopicPersist = true;
+		bot.calls = [];
+		await daemon.handleSessionMessage(session, { type: "session_closed", sessionId: "S" });
+
+		// Remote delete happened exactly once (terminal provider success).
+		expect(bot.calls.filter(c => c.method === "deleteForumTopic")).toHaveLength(1);
+		// Roots were NOT compacted (lease/session/root survive).
+		const afterClose = rootsRegistrySnapshot(agentDir);
+		expect(afterClose.sessionLeases.S.leaseId).toBe("lease-1");
+		expect(afterClose.sessions.S).toBe(identity.canonicalRoot);
+		// The topic-registry still holds the topic on disk (persist failed).
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+		// The durable claim is terminal but NOT reconciled (status "deleted").
+		const effects = await telegramDeletionEffects(agentDir);
+		const claim = effects.find(e => (e.payload as { topicId?: string })?.topicId === topicId);
+		expect(claim).toBeDefined();
+		expect(claim!.state).toBe("terminal");
+		expect(claim!.receipt?.status).toBe("deleted");
+
+		// Restart: a fresh daemon re-runs deletion-journal reconciliation. Topic
+		// writes succeed again, so local cleanup completes without another provider call.
+		failTopicPersist = false;
+		FakeWs.instances = [];
+		const bot2 = new FakeBotApi();
+		const daemon2 = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot2,
+			WebSocketImpl: FakeWs as never,
+			fs: fsImpl,
+			pidAlive: () => true,
+		});
+		bot2.calls = [];
+		await daemon2.loadTopics();
+		await daemon2.scanRoots();
+
+		// No second provider delete (local-only reconciliation of a terminal claim).
+		expect(bot2.calls.filter(c => c.method === "deleteForumTopic")).toHaveLength(0);
+		// Local cleanup finished: topic removed, roots compacted, claim reconciled.
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeUndefined();
+		const final = rootsRegistrySnapshot(agentDir);
+		expect(final.sessionLeases.S).toBeUndefined();
+		expect(final.sessions.S).toBeUndefined();
+		const effects2 = await telegramDeletionEffects(agentDir);
+		const claim2 = effects2.find(e => (e.payload as { topicId?: string })?.topicId === topicId);
+		expect(claim2!.receipt?.status).toBe("reconciled");
+	});
+
+	test("a roots-compaction failure after terminal remote delete stays unreconciled and restart compacts without a second provider delete", async () => {
+		const agentDir = tempAgentDir();
+		let failRootsPersist = false;
+		const fsImpl: TelegramDaemonFs = {
+			mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+			readFile: (file, encoding) => fs.promises.readFile(file, encoding),
+			writeFile: async (file, data, opts) => {
+				if (failRootsPersist && String(file).includes("telegram-daemon.roots.json")) {
+					throw new Error("simulated roots compaction failure");
+				}
+				await fs.promises.writeFile(file, data, opts);
+			},
+			rename: (oldPath, newPath) => fs.promises.rename(oldPath, newPath).then(() => undefined),
+			unlink: file => fs.promises.unlink(file),
+			open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
+			readdir: file => fs.promises.readdir(file),
+			chmod: (file, mode) => fs.promises.chmod(file, mode),
+		};
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", {
+			randomId: () => "lease-1",
+			now: () => 1000,
+		});
+
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as never,
+			fs: fsImpl,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const session = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(session, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		const topicId = topicRegistrySnapshot(agentDir).topics.S!.topicId;
+
+		failRootsPersist = true;
+		bot.calls = [];
+		await expect(
+			daemon.handleSessionMessage(session, {
+				type: "session_closed",
+				sessionId: "S",
+			}),
+		).rejects.toThrow("simulated roots compaction failure");
+
+		expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeUndefined();
+		expect(rootsRegistrySnapshot(agentDir).sessionLeases.S.leaseId).toBe("lease-1");
+		const claim = (await telegramDeletionEffects(agentDir)).find(
+			effect => (effect.payload as { topicId?: string })?.topicId === topicId,
+		);
+		expect(claim?.receipt?.status).toBe("deleted");
+
+		failRootsPersist = false;
+		const bot2 = new FakeBotApi();
+		const daemon2 = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot2,
+			WebSocketImpl: FakeWs as never,
+			fs: fsImpl,
+			pidAlive: () => true,
+		});
+		await daemon2.loadTopics();
+		await daemon2.scanRoots();
+
+		expect(bot2.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+		const final = rootsRegistrySnapshot(agentDir);
+		expect(final.sessionLeases.S).toBeUndefined();
+		expect(final.sessions.S).toBeUndefined();
+		const reconciled = (await telegramDeletionEffects(agentDir)).find(
+			effect => (effect.payload as { topicId?: string })?.topicId === topicId,
+		);
+		expect(reconciled?.receipt?.status).toBe("reconciled");
+	});
+
+	test("a crash after pending close intent replays once and a failed replay persist remains unreconciled", async () => {
+		const agentDir = tempAgentDir();
+		let failTopicPersist = false;
+		const fsImpl: TelegramDaemonFs = {
+			mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+			readFile: (file, encoding) => fs.promises.readFile(file, encoding),
+			writeFile: async (file, data, opts) => {
+				if (failTopicPersist && String(file).includes("telegram-topics.json")) {
+					throw new Error("simulated replay topic persist failure");
+				}
+				await fs.promises.writeFile(file, data, opts);
+			},
+			rename: (oldPath, newPath) => fs.promises.rename(oldPath, newPath).then(() => undefined),
+			unlink: file => fs.promises.unlink(file),
+			open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
+			readdir: file => fs.promises.readdir(file),
+			chmod: (file, mode) => fs.promises.chmod(file, mode),
+		};
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		await publishIdentityEndpoint(s, cwd, "S", "ws://s", "ts", {
+			randomId: () => "lease-1",
+			now: () => 1000,
+		});
+
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner-1",
+			botToken: "tok",
+			chatId: "42",
+			botApi: new FakeBotApi(),
+			WebSocketImpl: FakeWs as never,
+			fs: fsImpl,
+			pidAlive: () => true,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		const session = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(session, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		const topicId = topicRegistrySnapshot(agentDir).topics.S!.topicId;
+
+		// Simulate a crash immediately after the close path durably enqueues its
+		// pending intent, before any provider call or in-memory close mutation.
+		await internals(daemon).enqueueTopicDeletionIntent("S", "lease-1");
+		const pending = (await telegramDeletionEffects(agentDir)).find(
+			effect => (effect.payload as { topicId?: string })?.topicId === topicId,
+		);
+		expect(pending?.state).toBe("pending");
+
+		failTopicPersist = true;
+		const replayBot = new FakeBotApi();
+		const replay = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner-2",
+			botToken: "tok",
+			chatId: "42",
+			botApi: replayBot,
+			WebSocketImpl: FakeWs as never,
+			fs: fsImpl,
+			pidAlive: () => true,
+		});
+		await replay.loadTopics();
+		await replay.scanRoots();
+
+		expect(replayBot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeDefined();
+		expect(rootsRegistrySnapshot(agentDir).sessionLeases.S.leaseId).toBe("lease-1");
+		const terminal = (await telegramDeletionEffects(agentDir)).find(
+			effect => (effect.payload as { topicId?: string })?.topicId === topicId,
+		);
+		expect(terminal?.state).toBe("terminal");
+		expect(terminal?.receipt?.status).toBe("deleted");
+
+		failTopicPersist = false;
+		const finalBot = new FakeBotApi();
+		const finalReplay = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner-3",
+			botToken: "tok",
+			chatId: "42",
+			botApi: finalBot,
+			WebSocketImpl: FakeWs as never,
+			fs: fsImpl,
+			pidAlive: () => true,
+		});
+		await finalReplay.loadTopics();
+		await finalReplay.scanRoots();
+
+		expect(finalBot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+		expect(topicRegistrySnapshot(agentDir).topics.S).toBeUndefined();
+		const finalRoots = rootsRegistrySnapshot(agentDir);
+		expect(finalRoots.sessionLeases.S).toBeUndefined();
+		expect(finalRoots.sessions.S).toBeUndefined();
+		const reconciled = (await telegramDeletionEffects(agentDir)).find(
+			effect => (effect.payload as { topicId?: string })?.topicId === topicId,
+		);
+		expect(reconciled?.receipt?.status).toBe("reconciled");
 	});
 });

--- a/packages/coding-agent/test/sdk-daemon-concurrency.test.ts
+++ b/packages/coding-agent/test/sdk-daemon-concurrency.test.ts
@@ -273,5 +273,42 @@ describe("ChatEffectJournal", () => {
 		const effects = await journal.list();
 		expect(effects.filter(effect => effect.state !== "terminal")).toHaveLength(130);
 		expect(effects.filter(effect => effect.state === "terminal")).toHaveLength(MAX_TERMINAL_CHAT_EFFECTS);
-	});
+	}, 15_000);
+
+	test("bounds Telegram terminal history only after local reconciliation completes", async () => {
+		const fs = new MemoryConversationStoreFs();
+		const journal = new ChatEffectJournal({ agentDir: "/agent", transport: "telegram", fs, now: () => 1 });
+		for (let index = 0; index < MAX_TERMINAL_CHAT_EFFECTS + 2; index++) {
+			const id = `telegram-delete-${index}`;
+			const claimed = await journal.enqueueAndClaim(
+				{
+					id,
+					kind: "telegram.topic_delete",
+					transport: "telegram",
+					sessionId: `session-${index}`,
+					endpointGeneration: 1,
+					payload: { chatId: "42", topicId: String(index + 1), leaseId: `lease-${index}` },
+				},
+				"owner",
+				10,
+			);
+			await journal.record(id, { owner: "owner", epoch: claimed!.epoch }, "terminal", {
+				provider: "telegram",
+				status: "deleted",
+			});
+		}
+		expect((await journal.list()).filter(effect => effect.state === "terminal")).toHaveLength(
+			MAX_TERMINAL_CHAT_EFFECTS + 2,
+		);
+
+		for (let index = 0; index < MAX_TERMINAL_CHAT_EFFECTS + 2; index++) {
+			await journal.updateTerminalReceipt(`telegram-delete-${index}`, {
+				provider: "telegram",
+				status: "reconciled",
+			});
+		}
+		const terminal = (await journal.list()).filter(effect => effect.state === "terminal");
+		expect(terminal).toHaveLength(MAX_TERMINAL_CHAT_EFFECTS);
+		expect(terminal.every(effect => effect.receipt?.status === "reconciled")).toBe(true);
+	}, 15_000);
 });


### PR DESCRIPTION
## Summary

Supersedes #2173 and resolves every blocker in the owner's exact-head review.

- treat only explicit Telegram `ok: true` as terminal deletion authority; every non-OK/throw/timeout remains uncertain, with durable `retry_after`
- classify roots-registry evidence as exact-current, positively superseded, or unknown; unknown preserves claims and blocks destructive cleanup
- establish and claim the durable session/topic/lease deletion effect under the admission lock before any fence, queue cancellation, flush, drain, or provider call
- quarantine malformed, legacy-id, and prior-chat effects without provider/topic/root mutation
- preserve canonical realpath identity across symlink aliases, case/Unicode platform resolution, ancestor retargets, duplicate endpoints, and predecessor/successor socket races
- add deterministic subprocess SIGKILL/barrier proof for all five durability cuts: claim→provider, terminal receipt→topic registry, topic registry→roots, roots→reconciled receipt, and endpoint publication identity

## Exact-head verification

Head: `5d2aa5b80deb57813d8fee7ddb9c3d0631ce961d`

- `bun run check`
- `bun test test/notifications-telegram-daemon.test.ts test/notifications-telegram-daemon-crash.test.ts test/sdk-daemon-concurrency.test.ts test/notifications-telegram-reference.test.ts test/tools/index.test.ts` — 254 passed, 0 failed
- `bun run ci:test:smoke`
- `git diff --check origin/dev...HEAD`
- cleanup sweep: PASS, 0 blockers
- independent architecture/product/code review: CLEAR/APPROVE, 0 blockers
- independent adversarial QA: PASS, 0 blockers

The branch head is immutable. Any requested source change will be delivered in a fresh replacement branch/PR.