### PR TITLE
fix(ci): format model profile tests

### DIFF
--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -234,8 +234,9 @@ describe("model profile activation", () => {
 				architect: "openai-codex/gpt-5.6-sol:xhigh",
 			},
 		],
-	] satisfies Array<[string, Record<string, string>]>)
-	("prepares the reconstructed five-role mapping for %s", async (profileName, expected) => {
+	] satisfies Array<
+		[string, Record<string, string>]
+	>)("prepares the reconstructed five-role mapping for %s", async (profileName, expected) => {
 		const prepared = await prepareModelProfileActivation({
 			session: fakeSession(),
 			modelRegistry: fakeRegistry({ profiles: [...BUILTIN_MODEL_PROFILES] }),

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -359,11 +359,7 @@ function builtinMapping(name: string): Record<Role, string> {
 	return profile.modelMapping as Record<Role, string>;
 }
 
-function substituteCodexFamily(
-	selector: string,
-	source: "sol" | "terra",
-	target: "terra" | "luna",
-): string {
+function substituteCodexFamily(selector: string, source: "sol" | "terra", target: "terra" | "luna"): string {
 	const match = /^openai-codex\/gpt-5\.6-(sol|terra|luna):(.+)$/.exec(selector);
 	if (!match) throw new Error(`Expected GPT-5.6 Codex selector, got: ${selector}`);
 	return match[1] === source ? `openai-codex/gpt-5.6-${target}:${match[2]}` : selector;


### PR DESCRIPTION
## Summary
- apply the repository formatter to the two exact files rejected by post-merge Dev CI
- make no behavioral changes

## Evidence
- Dev CI run `29300182622`, job `86982216413`: exactly two formatter failures
- `bun --cwd=packages/coding-agent run check`: pass

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*