### PR TITLE
fix(ci): drain Slack lease recovery fixture

### DIFF
--- a/packages/coding-agent/test/sdk-slack-daemon.test.ts
+++ b/packages/coding-agent/test/sdk-slack-daemon.test.ts
@@ -1964,13 +1964,11 @@ describe("SlackNotificationDaemon fake-provider acceptance", () => {
 					idempotencyKey: `slack:T1:C1:${root.rootTs}:U1:event-1:interaction-1`,
 				}),
 			]);
+			const store = daemon.store;
+			await daemon.stop();
+			daemon = undefined;
 			expect(await journal.read(effectId)).toMatchObject({ state: "terminal", receipt: { status: "sent" } });
-			for (let attempt = 0; attempt < 20; attempt++) {
-				const current = await daemon.store.read("T1:C1:intent:session");
-				if ((current?.inboundDispatches?.length ?? 0) === 0 && current?.seenEventIds?.includes("event-1")) break;
-				await Bun.sleep(25);
-			}
-			const recovered = await daemon.store.read("T1:C1:intent:session");
+			const recovered = await store.read("T1:C1:intent:session");
 			expect(recovered?.inboundDispatches).toEqual([]);
 			expect(recovered?.seenEventIds).toContain("event-1");
 			expect(recovered?.seenInteractionIds).toContain("interaction-1");


### PR DESCRIPTION
## Summary
- replace post-send timing polls with the daemon's production stop/drain barrier
- assert the terminal journal receipt and finalized inbound dispatch only after tracked recovery work is quiescent
- change no production behavior

## Evidence
- failing Dev CI run `29300699997`, shard-7 job `86984740672`
- focused recovery case: 20/20 passes
- exact coding-agent shard 7/8: 1151 pass, 33 skip
- coding-agent check: pass

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*