### PR TITLE
fix(agent): neutralize control tokens on remote compaction paths (gpt-5.6 Request blocked)

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Extended the gpt-5.6 `Request blocked (code=invalid_prompt)` fix to the compaction paths that bypass the streaming transport. Remote OpenAI compaction (`/responses/compact`, `compaction.remoteEnabled` default on — the "remote compact task" in openai/codex#32028) built its native `input` from reasoning signatures, verbatim history items, and message/tool text without neutralizing leaked Harmony control-token markers (e.g. `<|channel|>analysis`), so gpt-5.6 rejected the compaction request and, on retry, could escalate to account-level blocking. `requestOpenAiRemoteCompaction` now neutralizes reserved control tokens across the whole outgoing `input`, and the generic `requestRemoteCompaction` prompt/systemPrompt are neutralized too. Local summarization was already covered by the streaming-transport request-boundary fix.
+
 ## [0.10.0] - 2026-07-12
 
 ### Fixed

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -24,6 +24,8 @@ import type { AssistantMessage, Message, Model } from "@gajae-code/ai/types";
 import {
 	getOpenAIResponsesHistoryItems,
 	getOpenAIResponsesHistoryPayload,
+	neutralizeReservedControlTokens,
+	neutralizeResponsesInputControlTokens,
 	normalizeResponsesToolCallId,
 } from "@gajae-code/ai/utils";
 import { $env, logger } from "@gajae-code/utils";
@@ -479,10 +481,12 @@ export async function requestOpenAiRemoteCompaction(
 	const endpoint = resolveOpenAiCompactEndpoint(model, options?.authCredentialType);
 	const request: OpenAiRemoteCompactionRequest = {
 		model: model.id,
-		input: trimOpenAiCompactInput(
-			compactInput,
-			resolveOpenAiCompactInputBudget(model.contextWindow, model.maxTokens),
-			instructions,
+		input: neutralizeResponsesInputControlTokens(
+			trimOpenAiCompactInput(
+				compactInput,
+				resolveOpenAiCompactInputBudget(model.contextWindow, model.maxTokens),
+				instructions,
+			),
 		),
 		instructions,
 	};
@@ -553,10 +557,17 @@ export async function requestRemoteCompaction(
 	request: RemoteCompactionRequest,
 	signal?: AbortSignal,
 ): Promise<RemoteCompactionResponse> {
+	// The prompt embeds the serialized transcript, which can carry leaked Harmony
+	// control-token markers (e.g. `<|channel|>analysis`) from model output; a
+	// gpt-5.6-backed summarization endpoint rejects those with `Request blocked`.
+	const sanitizedRequest: RemoteCompactionRequest = {
+		systemPrompt: neutralizeReservedControlTokens(request.systemPrompt),
+		prompt: neutralizeReservedControlTokens(request.prompt),
+	};
 	const response = await fetch(endpoint, {
 		method: "POST",
 		headers: { "content-type": "application/json" },
-		body: JSON.stringify(request),
+		body: JSON.stringify(sanitizedRequest),
 		signal,
 	});
 

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -169,6 +169,46 @@ describe("remote compaction input trimming", () => {
 		expect(requestInput?.some(item => item.type === "custom_tool_call")).toBe(false);
 		expect(requestInput?.some(item => item.type === "custom_tool_call_output")).toBe(false);
 	});
+
+	test("neutralizes leaked Harmony control tokens in the remote compaction request input", async () => {
+		let requestInput: Array<Record<string, unknown>> | undefined;
+		using _hook = hookFetch(async (_input, init) => {
+			const body = JSON.parse(String(init?.body)) as { input: Array<Record<string, unknown>> };
+			requestInput = body.input;
+			return Response.json({
+				output: [{ type: "compaction_summary", summary: "compact" }],
+			});
+		});
+
+		// Remote compaction (/responses/compact) bypasses the streaming transport, so
+		// leaked `<|channel|>analysis` markers in reasoning/text/tool content would
+		// otherwise reach gpt-5.6 verbatim and return `Request blocked`.
+		await requestOpenAiRemoteCompaction(
+			makeOpenAiModel(),
+			"test-key",
+			[
+				{
+					type: "reasoning",
+					summary: [{ type: "summary_text", text: "Plan.<|channel|>analysis<|message|>go" }],
+				},
+				{
+					type: "message",
+					role: "user",
+					content: [{ type: "input_text", text: "hi<|recipient|>functions.bash" }],
+				},
+				{ type: "function_call_output", call_id: "c1", output: "done<|call|>" },
+			],
+			"compact",
+		);
+
+		const serialized = JSON.stringify(requestInput);
+		expect(serialized).not.toContain("<|channel|>");
+		expect(serialized).not.toContain("<|message|>");
+		expect(serialized).not.toContain("<|recipient|>");
+		expect(serialized).not.toContain("<|call|>");
+		expect(serialized).toContain("<\u200b|channel|>");
+		expect(serialized).toContain("Plan.");
+	});
 });
 
 describe("remote compaction endpoint", () => {

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -131,7 +131,7 @@ const RESERVED_CONTROL_TOKEN_RE = /<\|(?=[A-Za-z0-9_]{1,32}\|>)/g;
  * so the delimiter can no longer be tokenized as a reserved control token while the
  * text stays human-readable.
  */
-function neutralizeReservedControlTokens(text: string): string {
+export function neutralizeReservedControlTokens(text: string): string {
 	if (!text.includes("<|")) return text;
 	return text.replace(RESERVED_CONTROL_TOKEN_RE, "<\u200b|");
 }
@@ -148,8 +148,8 @@ function neutralizeReservedControlTokens(text: string): string {
  * evolve; the zero-width-space insertion is idempotent (`<\u200b|` no longer
  * matches `<|`) and keeps the text human-readable.
  */
-export function neutralizeResponsesInputControlTokens(items: ResponseInput): ResponseInput {
-	return items.map(item => deepNeutralizeReservedControlTokens(item)) as ResponseInput;
+export function neutralizeResponsesInputControlTokens<T>(items: readonly T[]): T[] {
+	return items.map(item => deepNeutralizeReservedControlTokens(item) as T);
 }
 
 function deepNeutralizeReservedControlTokens(value: unknown): unknown {


### PR DESCRIPTION
## Follow-up to #2192

`Request blocked (code=invalid_prompt)` still reproduced on gpt-5.6 after #2192 because that fix only neutralized control tokens on the **streaming Responses transports**. Compaction has two paths that bypass those transports:

- **`requestOpenAiRemoteCompaction`** — `/responses/compact` (`compaction.remoteEnabled` defaults on; this is the "remote compact task" in openai/codex#32028). It builds its native `input` from reasoning `thinkingSignature`s, verbatim provider-history items, and message/tool-output text with **no** control-token neutralization.
- **`requestRemoteCompaction`** — the generic self-hosted summarizer POST sends the serialized transcript prompt raw.

Leaked Harmony markers (e.g. `<|channel|>analysis`) therefore reached gpt-5.6 verbatim. Per the upstream reports this doesn't just 400 — on retry it can escalate to **account-level blocking** (oh-my-pi#5184, openai/codex#32028).

## Fix

- `requestOpenAiRemoteCompaction`: neutralize reserved control tokens across the entire outgoing `input` array (`neutralizeResponsesInputControlTokens`).
- `requestRemoteCompaction`: neutralize the `prompt` and `systemPrompt` (`neutralizeReservedControlTokens`).
- `@gajae-code/ai` helper generalized to any input-item array; the string-level neutralizer is now exported.

All `openai-responses`-api providers (including custom ones) were already covered on normal turns and local summarization by the #2192 streaming-transport request-boundary fix.

## Tests

- New `remote-compaction.test.ts` case: leaked markers in reasoning, user, and tool-output items are neutralized before the request is sent.
- Full compaction + harmony suites: 71 pass / 0 fail. `packages/ai` typecheck + transport tests green (30 pass). biome clean.

(Note: local cross-package typecheck/test resolves `@gajae-code/ai` via the shared worktree `node_modules` symlink to the main checkout, so validation was run with resolution pinned to this branch's `packages/ai`; CI checks out the branch fresh and resolves correctly.)
