### PR TITLE
fix(ci): repair current dev validation fixtures

### DIFF
--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -136,15 +136,15 @@ describe("python eval lifecycle red-team", () => {
 		const unrelated = Bun.spawn(["/bin/sh", "-c", "sleep 30"], { stdout: "ignore", stderr: "ignore" });
 		let childPid: number | undefined;
 		try {
-			const result = await executePython("%%bash\n(sleep 30) &\necho owned_child:$!\nwait", {
+			const pidFile = `${tempDir.path()}/owned-child.pid`;
+			const result = await executePython(`%%bash\n(sleep 30) &\nprintf '%s' "$!" > "${pidFile}"\nwait`, {
 				cwd: tempDir.path(),
 				sessionId: "redteam-bash-descendant-timeout",
 				kernelMode: "session",
 				timeoutMs: 500,
 			});
-			const match = result.output.match(/owned_child:(\d+)/);
-			expect(match).not.toBeNull();
-			childPid = Number(match?.[1]);
+			childPid = Number(await Bun.file(pidFile).text());
+			expect(Number.isSafeInteger(childPid) && childPid > 0).toBe(true);
 			expect(result.cancelled).toBe(true);
 			expect(await waitForProcessGone(childPid)).toBe(true);
 			expect(isProcessAlive(unrelated.pid)).toBe(true);

--- a/scripts/generate-json-schemas.ts
+++ b/scripts/generate-json-schemas.ts
@@ -124,11 +124,14 @@ function settingTypeToJsonSchema(definition: SettingDefinition): JsonSchemaObjec
 				items: arrayItemsSchema(definition.default, "items" in definition ? definition.items : undefined),
 			};
 		case "record":
-			return { type: "object", additionalProperties: recordValueSchema(definition.valueSchema) };
+			return {
+				type: "object",
+				additionalProperties: recordValueSchema("valueSchema" in definition ? definition.valueSchema : undefined),
+			};
 	}
 }
 
-function recordValueSchema(valueSchema: Extract<SettingDefinition, { type: "record" }>["valueSchema"]): JsonSchema {
+function recordValueSchema(valueSchema?: { readonly type: "model-selector-value" }): JsonSchema {
 	if (valueSchema?.type !== "model-selector-value") return true;
 	const selector = { type: "string", minLength: 1, pattern: "\\S" };
 	return {


### PR DESCRIPTION
## Summary
- narrow record-schema generation across record definitions that do not declare `valueSchema`
- persist the owned bash descendant PID to a temp file so timeout cancellation does not depend on partial stdout capture

## Evidence
- current-dev run `29301730982`: root typecheck and shard-7 failures
- Python ownership case 10/10; full file 4/4
- `bun run check:tools`: pass
- schema generation check: pass
- exact coding-agent shard 7/8: 1384 pass, 24 skip

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*