### PR TITLE
fix(coding-agent): keep login reachable after credentials expire

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -57,6 +57,8 @@ export interface Args {
 	fileArgs: string[];
 	/** Retained for test/runtime compatibility; extension-defined flags are no longer parsed. */
 	unknownFlags: Map<string, boolean | string>;
+	/** Exact interactive startup login intent, recognized before model-profile activation. */
+	authBootstrap?: true;
 }
 
 function isStartupSlashCommandArg(arg: string | undefined): boolean {
@@ -66,6 +68,13 @@ function isStartupSlashCommandArg(arg: string | undefined): boolean {
 		arg === "/provicer" ||
 		arg?.startsWith("/provicer:") === true
 	);
+}
+
+function isStartupLoginCommandArg(args: readonly string[], index: number): boolean {
+	const command = args[index];
+	if (command !== "/login" && command !== "login") return false;
+	const argumentCount = args.length - index - 1;
+	return argumentCount === 0 || (argumentCount === 1 && !args[index + 1].startsWith("-"));
 }
 
 export function parseArgs(args: string[]): Args {
@@ -78,6 +87,12 @@ export function parseArgs(args: string[]): Args {
 	for (let i = 0; i < args.length; i++) {
 		let arg = args[i];
 
+		if (isStartupLoginCommandArg(args, i)) {
+			result.authBootstrap = true;
+			const loginCommand = arg === "login" ? "/login" : arg;
+			result.messages.push([loginCommand, ...args.slice(i + 1)].join(" "));
+			break;
+		}
 		if (isStartupSlashCommandArg(arg)) {
 			result.messages.push(args.slice(i).join(" "));
 			break;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1298,14 +1298,16 @@ export async function runRootCommand(
 			await deps.rlmPreset.onSessionCreated(session);
 		}
 
-		await applyStartupModelProfilesOrExit({
-			session,
-			settings: settingsInstance,
-			modelRegistry,
-			parsedArgs,
-			startupModel: sessionOptions.model,
-			startupThinkingLevel: sessionOptions.thinkingLevel,
-		});
+		if (!(parsedArgs.authBootstrap === true && isInteractive)) {
+			await applyStartupModelProfilesOrExit({
+				session,
+				settings: settingsInstance,
+				modelRegistry,
+				parsedArgs,
+				startupModel: sessionOptions.model,
+				startupThinkingLevel: sessionOptions.thinkingLevel,
+			});
+		}
 
 		if (modelFallbackMessage) {
 			notifs.push({ kind: "warn", message: modelFallbackMessage });

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -170,3 +170,31 @@ describe("GJC public CLI command surface", () => {
 		}
 	}, 15_000);
 });
+
+describe("startup login parsing", () => {
+	it("normalizes exact bare and slash login recovery forms", () => {
+		expect(parseArgs(["login"])).toMatchObject({ authBootstrap: true, messages: ["/login"] });
+		expect(parseArgs(["login", "openai-codex"])).toMatchObject({
+			authBootstrap: true,
+			messages: ["/login openai-codex"],
+		});
+		expect(parseArgs(["--no-title", "login", "openai-codex"])).toMatchObject({
+			noTitle: true,
+			authBootstrap: true,
+			messages: ["/login openai-codex"],
+		});
+		expect(parseArgs(["/login"])).toMatchObject({ authBootstrap: true, messages: ["/login"] });
+		expect(parseArgs(["/login", "https://localhost/callback?code=callback"])).toMatchObject({
+			authBootstrap: true,
+			messages: ["/login https://localhost/callback?code=callback"],
+		});
+	});
+
+	it("does not mark ordinary prompts or unsupported login-shaped commands as recovery", () => {
+		expect(parseArgs([]).authBootstrap).toBeUndefined();
+		expect(parseArgs(["/logout", "openai-codex"]).authBootstrap).toBeUndefined();
+		expect(parseArgs(["/provider", "login", "openai-codex"]).authBootstrap).toBeUndefined();
+		expect(parseArgs(["login", "openai-codex", "extra"]).authBootstrap).toBeUndefined();
+		expect(parseArgs(["/login", "openai-codex", "extra"]).authBootstrap).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { getBundledModel } from "@gajae-code/ai";
 import { postmortem, TempDir } from "@gajae-code/utils";
-import type { Args } from "../src/cli/args";
+import { type Args, parseArgs } from "../src/cli/args";
 import { Settings } from "../src/config/settings";
 import { SETTINGS_SCHEMA } from "../src/config/settings-schema";
 import {
@@ -467,6 +467,100 @@ describe("startup update contract", () => {
 			}
 		}
 	}, 15_000);
+	it("reaches login recovery before a credentialless default profile can abort startup", async () => {
+		using tempDir = TempDir.createSync("@gjc-auth-bootstrap-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const stop = new Error("stop auth bootstrap harness");
+		const parsed = parseArgs(["login", "openai-codex"]);
+		const settings = Settings.isolated({
+			"marketplace.autoUpdate": "off",
+			"startup.checkUpdate": false,
+			"modelProfile.default": "codex-medium",
+		});
+		let initialized = false;
+
+		try {
+			await expect(
+				runRootCommand(parsed, [], {
+					createAgentSession: async () => fakeSessionResult(),
+					discoverAuthStorage: async () => authStorage,
+					settings,
+					initTheme: async () => {},
+					readPipedInput: async () => undefined,
+					runStartupCredentialAutoImportIfNeeded: async () => undefined,
+					getChangelogForDisplay: async () => undefined,
+					createInteractiveMode: () =>
+						({
+							init: async () => {
+								initialized = true;
+							},
+							showNewVersionNotification: () => {},
+							renderInitialMessages: () => {},
+							editor: { setText: () => {} },
+							showOAuthSelector: async (mode: string, provider?: string) => {
+								expect(mode).toBe("login");
+								expect(provider).toBe("openai-codex");
+							},
+							handleBackgroundCommand: () => {},
+							showError: () => {},
+							getUserInput: async () => {
+								throw stop;
+							},
+						}) as unknown as InteractiveMode,
+				}),
+			).rejects.toBe(stop);
+			expect(initialized).toBe(true);
+			expect(parsed.messages).toEqual(["/login openai-codex"]);
+			expect(parsed.authBootstrap).toBe(true);
+			expect(settings.get("modelProfile.default")).toBe("codex-medium");
+		} finally {
+			authStorage.close();
+		}
+	});
+	it("keeps credential validation active for noninteractive login-shaped input", async () => {
+		using tempDir = TempDir.createSync("@gjc-auth-bootstrap-text-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const settings = Settings.isolated({
+			"marketplace.autoUpdate": "off",
+			"startup.checkUpdate": false,
+			"modelProfile.default": "codex-medium",
+		});
+		const parsed = parseArgs(["--mode", "text", "login", "openai-codex"]);
+		let printModeStarted = false;
+		const exit = new Error("exit 1");
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((): never => {
+			throw exit;
+		});
+		const stderr: string[] = [];
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+			stderr.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		});
+
+		try {
+			await expect(
+				runRootCommand(parsed, [], {
+					createAgentSession: async () => fakeSessionResult(),
+					discoverAuthStorage: async () => authStorage,
+					settings,
+					initTheme: async () => {},
+					readPipedInput: async () => undefined,
+					runStartupCredentialAutoImportIfNeeded: async () => undefined,
+					runPrintMode: async () => {
+						printModeStarted = true;
+					},
+				}),
+			).rejects.toBe(exit);
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(printModeStarted).toBe(false);
+			expect(settings.get("modelProfile.default")).toBe("codex-medium");
+			expect(stderr.join("")).toContain('Model profile "codex-medium" requires credentials for: openai-codex');
+		} finally {
+			stderrSpy.mockRestore();
+			exitSpy.mockRestore();
+			authStorage.close();
+		}
+	});
 	it("keeps updater and default-installer APIs outside startup wiring", async () => {
 		const source = await Bun.file(new URL("../src/main.ts", import.meta.url)).text();
 


### PR DESCRIPTION
## Summary
- recognize exact bare `gjc login [provider]` and startup `/login [provider|callback]` as explicit auth-bootstrap intent
- defer startup model-profile activation only for that intent on the local interactive route
- preserve ordinary/noninteractive credential validation and the selected default profile

## Reproduction and fix
A persisted default model profile is activated before the TUI starts. When its required credential is missing or expired, startup exits before `/login` can run. The patch marks explicit login recovery at argv parsing and skips only that pre-TUI activation for the interactive recovery route; the existing `/login` implementation performs authentication.

## Verification
- `bun test` focused/relevant suites: 111 passed, 0 failed
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`

Closes #2128

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*