### PR TITLE
fix(ci): isolate ACP and GC fixtures

### DIFF
--- a/packages/coding-agent/test/acp/acp-fallback-cancel-completion.test.ts
+++ b/packages/coding-agent/test/acp/acp-fallback-cancel-completion.test.ts
@@ -1,69 +1,129 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import type { AgentSideConnection, PromptRequest, SessionNotification } from "@agentclientprotocol/sdk";
-import { Agent, type AgentOptions } from "@gajae-code/agent-core";
-import { getBundledModel, type Model } from "@gajae-code/ai";
-import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
-import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
-import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { AcpAgent } from "@gajae-code/coding-agent/modes/acp/acp-agent";
-import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
-import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
-import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { writeBrokerDiscovery } from "@gajae-code/coding-agent/sdk/broker/discovery";
 import { TempDir } from "@gajae-code/utils";
 
-function selector(model: Model): string {
-	return `${model.provider}/${model.id}`;
+type TestSocket = { send(message: string): void };
+
+async function bounded<T>(promise: Promise<T>, label: string): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(2_000).then(() => {
+			throw new Error(`Timed out waiting for ${label}`);
+		}),
+	]);
 }
 
-describe("ACP managed fallback cancellation completion", () => {
+describe("ACP production cancellation completion", () => {
 	let tempDir: TempDir;
-	let authStorage: AuthStorage;
-	let session: AgentSession | undefined;
 	let connectionAbort: AbortController;
+	let server: Bun.Server<undefined> | undefined;
 
-	beforeEach(async () => {
-		tempDir = TempDir.createSync("@acp-fallback-cancel-");
-		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
-		authStorage.setRuntimeApiKey("anthropic", "test-key");
-		authStorage.setRuntimeApiKey("openai", "test-key");
-		await Settings.init({ agentDir: tempDir.path(), inMemory: true });
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@acp-cancel-completion-");
 		connectionAbort = new AbortController();
 	});
 
-	afterEach(async () => {
+	afterEach(() => {
 		connectionAbort.abort();
-		await session?.dispose();
-		authStorage.close();
+		server?.stop(true);
 		tempDir.removeSync();
 	});
 
-	it("finishes a cancelled fallback prompt once without failed assistant chunks", async () => {
-		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
-		const fallback = getBundledModel("openai", "gpt-4o-mini");
-		if (!primary || !fallback) throw new Error("Expected bundled test models");
-		const pending = new AssistantMessageEventStream();
-		const streamFn: AgentOptions["streamFn"] = () => pending;
-		const agent = new Agent({
-			getApiKey: provider => `${provider}-key`,
-			initialState: { model: primary, systemPrompt: ["test"], tools: [], messages: [] },
-			streamFn,
-		});
-		const settings = Settings.isolated({
-			"compaction.enabled": false,
-			"fallback.maxAttempts": 3,
-			"retry.baseDelayMs": 50,
-		});
-		settings.setModelRole("default", selector(primary));
-		session = new AgentSession({
-			agent,
-			sessionManager: SessionManager.inMemory(),
-			settings,
-			modelRegistry: new ModelRegistry(authStorage),
-		});
-		session.setConfiguredModelChain("default", [selector(primary), selector(fallback)], "test");
-
+	it("settles acknowledged and rejected cancellation exactly once without failed assistant chunks", async () => {
+		const agentDir = path.join(tempDir.path(), "agent");
+		const cwd = path.join(tempDir.path(), "workspace");
+		const token = "acp-cancel-token";
 		const updates: SessionNotification[] = [];
+		const promptWaiters: Array<PromiseWithResolvers<void>> = [];
+		let promptSocket: TestSocket | undefined;
+		let abortAcknowledged = true;
+
+		server = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch(request, server) {
+				if (new URL(request.url).searchParams.get("token") !== token)
+					return new Response("Unauthorized", { status: 401 });
+				if (!server.upgrade(request)) return new Response("Upgrade failed", { status: 400 });
+			},
+			websocket: {
+				open(socket) {
+					socket.send(JSON.stringify({ type: "hello", connectionId: "acp-cancel-completion" }));
+				},
+				message(socket, raw) {
+					const frame = JSON.parse(String(raw)) as Record<string, unknown>;
+					if (frame.type === "register_provider") {
+						socket.send(
+							JSON.stringify({ type: "register_provider_result", id: frame.id, ok: true, leaseId: "lease" }),
+						);
+						return;
+					}
+					if (frame.type === "broker_request") {
+						const result =
+							frame.operation === "session.create"
+								? {
+										sessionId: "cancel-session",
+										endpoint: { url: `ws://127.0.0.1:${server!.port}`, token },
+									}
+								: {};
+						socket.send(JSON.stringify({ type: "broker_response", id: frame.id, ok: true, result }));
+						return;
+					}
+					if (frame.type === "query_request") {
+						const items =
+							frame.query === "config.list/get"
+								? [{ mode: "default", model: "openai/gpt", thinking: "medium" }]
+								: frame.query === "models.list/current"
+									? [{ provider: "openai", id: "gpt", name: "GPT" }]
+									: [];
+						const result =
+							frame.query === "context.get"
+								? { usage: { tokens: 0, contextWindow: 200_000, percent: 0, source: "test" } }
+								: { page: { items } };
+						socket.send(JSON.stringify({ type: "query_response", id: frame.id, ok: true, result }));
+						return;
+					}
+					if (frame.type !== "control_request") return;
+					if (frame.operation === "turn.prompt") {
+						promptSocket = socket;
+						promptWaiters.shift()?.resolve();
+					}
+					socket.send(
+						JSON.stringify({
+							type: "control_response",
+							id: frame.id,
+							ok: true,
+							result:
+								frame.operation === "turn.prompt"
+									? { commandId: "prompt-command", turnId: "prompt-turn", accepted: true }
+									: frame.operation === "turn.abort"
+										? { aborted: abortAcknowledged }
+										: {},
+						}),
+					);
+				},
+			},
+		});
+		const port = server.port;
+		if (port === undefined) throw new Error("Expected ACP fixture server port");
+
+		await writeBrokerDiscovery(agentDir, {
+			version: 1,
+			protocolVersion: 3,
+			packageGeneration: "test",
+			ownerId: "test-owner",
+			pid: process.pid,
+			host: "127.0.0.1",
+			port,
+			url: `ws://127.0.0.1:${port}`,
+			token,
+			startedAt: Date.now(),
+			heartbeatAt: Date.now(),
+		});
+
 		const connection = {
 			sessionUpdate: async (notification: SessionNotification) => {
 				updates.push(notification);
@@ -71,24 +131,52 @@ describe("ACP managed fallback cancellation completion", () => {
 			signal: connectionAbort.signal,
 			closed: Promise.withResolvers<void>().promise,
 		} as unknown as AgentSideConnection;
-		const acp = new AcpAgent(connection, async () => session!);
-		const created = await acp.newSession({ cwd: tempDir.path(), mcpServers: [] });
-		const prompt = acp.prompt({
-			sessionId: created.sessionId,
-			messageId: "00000000-0000-4000-8000-0000000000fc",
-			prompt: [{ type: "text", text: "cancel managed fallback" }],
-		} as PromptRequest);
-		let promptResolutions = 0;
-		void prompt.then(() => {
-			promptResolutions++;
-		});
-		for (let i = 0; i < 20 && !session.isStreaming; i += 1) await Bun.sleep(1);
-		await acp.cancel({ sessionId: created.sessionId });
+		const acp = new AcpAgent(connection, { agentDir });
+		const created = await bounded(acp.newSession({ cwd, mcpServers: [] }), "new session");
 
-		const response = await prompt;
-		await Bun.sleep(0);
-		expect(response.stopReason).toBe("cancelled");
-		expect(promptResolutions).toBe(1);
+		const firstDelivered = Promise.withResolvers<void>();
+		promptWaiters.push(firstDelivered);
+		let firstResolutions = 0;
+		const firstPrompt = acp
+			.prompt({
+				sessionId: created.sessionId,
+				messageId: "00000000-0000-4000-8000-0000000000fc",
+				prompt: [{ type: "text", text: "cancel acknowledged" }],
+			} as PromptRequest)
+			.then(response => {
+				firstResolutions++;
+				return response;
+			});
+		await bounded(firstDelivered.promise, "first prompt delivery");
+		await bounded(acp.cancel({ sessionId: created.sessionId }), "first cancel acknowledgement");
+		promptSocket!.send(JSON.stringify({ type: "activity", sessionId: created.sessionId, state: "busy" }));
+		promptSocket!.send(JSON.stringify({ type: "activity", sessionId: created.sessionId, state: "idle" }));
+		expect(await bounded(firstPrompt, "first prompt completion")).toEqual({ stopReason: "cancelled" });
+		expect(firstResolutions).toBe(1);
+
+		const secondDelivered = Promise.withResolvers<void>();
+		promptWaiters.push(secondDelivered);
+		let secondResolutions = 0;
+		const secondPrompt = acp
+			.prompt({
+				sessionId: created.sessionId,
+				messageId: "00000000-0000-4000-8000-0000000000fd",
+				prompt: [{ type: "text", text: "cancel rejected" }],
+			} as PromptRequest)
+			.then(response => {
+				secondResolutions++;
+				return response;
+			});
+		await bounded(secondDelivered.promise, "second prompt delivery");
+		abortAcknowledged = false;
+		await expect(
+			bounded(acp.cancel({ sessionId: created.sessionId }), "second cancel acknowledgement"),
+		).rejects.toThrow("SDK did not acknowledge cancellation");
+		promptSocket!.send(JSON.stringify({ type: "activity", sessionId: created.sessionId, state: "busy" }));
+		promptSocket!.send(JSON.stringify({ type: "activity", sessionId: created.sessionId, state: "idle" }));
+		expect(await bounded(secondPrompt, "second prompt completion")).toEqual({ stopReason: "end_turn" });
+		expect(secondResolutions).toBe(1);
+
 		expect(
 			updates.filter(update => {
 				const payload = update.update as {

--- a/packages/coding-agent/test/gc-redteam.test.ts
+++ b/packages/coding-agent/test/gc-redteam.test.ts
@@ -122,11 +122,12 @@ async function seedTeamWorker(
 	return workerDir;
 }
 
-async function collectSingle(adapter: GcStoreAdapter, ctx: GcContext): Promise<GcRecord> {
+async function collectRecord(adapter: GcStoreAdapter, ctx: GcContext, recordPath: string): Promise<GcRecord> {
 	const result = await adapter.collect(ctx);
 	expect(result.errors).toEqual([]);
-	expect(result.records).toHaveLength(1);
-	return result.records[0]!;
+	const record = result.records.find(candidate => candidate.path === recordPath);
+	expect(record).toBeDefined();
+	return record!;
 }
 
 function fakeAdapter(
@@ -183,9 +184,9 @@ describe("gc red-team invariants", () => {
 		const workerDir = await seedTeamWorker(base, registryDir, "w-eperm", EPERM_PID);
 		const ctx = ctxFor(base, registryDir, adversarialProbe);
 
-		const harnessRec = await collectSingle(harnessLeasesGcAdapter, ctx);
-		const fileLockRec = await collectSingle(fileLocksGcAdapter, ctx);
-		const teamRec = await collectSingle(teamWorkersGcAdapter, ctx);
+		const harnessRec = await collectRecord(harnessLeasesGcAdapter, ctx, harnessLease);
+		const fileLockRec = await collectRecord(fileLocksGcAdapter, ctx, lockDir);
+		const teamRec = await collectRecord(teamWorkersGcAdapter, ctx, workerDir);
 
 		for (const rec of [harnessRec, fileLockRec, teamRec]) {
 			expect(rec.pid_status).toBe("eperm");
@@ -222,11 +223,16 @@ describe("gc red-team invariants", () => {
 			ctx,
 			true,
 		);
-		const records = [report.stores.harness_leases[0]!, report.stores.file_locks[0]!, report.stores.team_workers[0]!];
+		const records = [
+			report.stores.harness_leases.find(record => record.path === leaseFile),
+			report.stores.file_locks.find(record => record.path === lockDir),
+			report.stores.team_workers.find(record => record.path === workerDir),
+		];
 		for (const rec of records) {
-			expect(rec.removable).toBe(false);
-			expect(rec.action).toBe("none");
-			expect(["alive", "unknown"]).toContain(rec.pid_status ?? "none");
+			expect(rec).toBeDefined();
+			expect(rec?.removable).toBe(false);
+			expect(rec?.action).toBe("none");
+			expect(["alive", "unknown"]).toContain(rec?.pid_status ?? "none");
 		}
 		expect(report.counts.removed).toBe(0);
 		expect(report.counts.failed).toBe(0);

--- a/packages/coding-agent/test/sdk-acp-production-path.test.ts
+++ b/packages/coding-agent/test/sdk-acp-production-path.test.ts
@@ -354,6 +354,18 @@ test("production ACP preserves lifecycle, turn, replay, and connection ownership
 	promptSocket!.send(JSON.stringify({ type: "activity", sessionId: created.sessionId, state: "busy" }));
 	promptSocket!.send(JSON.stringify({ type: "activity", sessionId: created.sessionId, state: "idle" }));
 	expect(await bounded(cancelledPrompt, "cancelled prompt completion")).toEqual({ stopReason: "cancelled" });
+	expect(
+		updates.filter(update => {
+			const payload = update.update as {
+				sessionUpdate?: string;
+				content?: Array<{ content?: { text?: string } }>;
+			};
+			return (
+				payload.sessionUpdate === "agent_message_chunk" &&
+				payload.content?.some(item => /failed/i.test(item.content?.text ?? ""))
+			);
+		}),
+	).toHaveLength(0);
 	const abortFailurePrompt = agent.prompt({
 		sessionId: created.sessionId,
 		prompt: [{ type: "text", text: "abort failure" }],


### PR DESCRIPTION
## Summary
- migrate the obsolete ACP cancellation fixture from its ignored local-session constructor argument to canonical broker discovery and production broker/session WebSockets
- preserve acknowledged-cancel exactly-once and no-failed-chunk assertions, add rejected-abort end-turn exactly-once coverage, and retain managed fallback semantics in the dedicated AgentSession suite
- make GC red-team assertions select the exact seeded records instead of assuming ambient global lock roots contain exactly one entry

## Root cause evidence
- run `29304096921` at `44a86458390659f2c44c6a9e7a6966cb72d936ae`: shard 3/8 and 6/8 failed on the stale ACP fixture and ambient GC records
- run `29304474813` at `d13c09c40446a33a33bc25c2e17ba525f1aa27d7`: the same failures reproduced after #2202
- exact-head focused reproduction confirmed ACP attempted detached broker autostart because the legacy loader is ignored, while GC discovered two valid global lock-root records and indexed an unrelated record

## Coverage equivalence
- `agent-session-fallback-cancel-idle.test.ts`: retains actual managed fallback cancellation, one terminal completion, idle restoration, and no accepted/error assistant completion
- migrated ACP fixture: real broker/session protocol, cancelled stop reason, one resolution, rejected abort remains `end_turn`, one resolution, no failed assistant chunks
- production ACP path: retains acknowledged vs rejected abort completion and now explicitly asserts no failed assistant chunks

## Verification
- migrated ACP fixture: 20/20 focused stress
- four focused files: 15 pass, 139 assertions
- current d13 shard 6/8: 1281 pass, 85 skip, 0 fail
- current d13 shard 3/8: repaired GC cases pass; this heavily loaded host separately reproduced existing `sdk-host-wiring` timing/global failures that pass 29/29 in isolation and were absent from both hosted failing runs; hosted PR shard is required
- coding-agent check: pass
- coding-agent build: pass
- Biome and `git diff --check`: pass

No production code, test deletion, skips, blanket retries, timeout inflation, or assertion weakening.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*