### PR TITLE
fix(coding-agent): serialize prompt and model admission

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -292,6 +292,8 @@ export interface AgentPromptOptions {
 	toolChoice?: ToolChoice;
 	/** Disable transport replay; fallback accounting is owned by the caller. */
 	fallbackManaged?: boolean;
+	/** Called synchronously after this invocation claims the agent run, before asynchronous provider work. */
+	onRunAccepted?: () => void;
 	/** Called once immediately before every managed upstream request. */
 	nextFallbackAttempt?: AgentLoopConfig["nextFallbackAttempt"];
 	/** Called after a managed upstream request is accepted and committed. */
@@ -1313,6 +1315,7 @@ export class Agent {
 		this.#state.isStreaming = true;
 		this.#state.streamMessage = null;
 		this.#state.error = undefined;
+		options?.onRunAccepted?.();
 
 		const fallbackManaged = options?.fallbackManaged === true;
 		const managedLogicalRunOwner = fallbackManaged ? (this.#managedLogicalRunOwner ?? runId) : undefined;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Fenced SDK WebSocket lifecycle callbacks and request settlement to the owning retry cycle/socket incarnation, so stale open, close, error, message, and timeout delivery cannot reject or corrupt work on a replacement connection; sent mutations remain non-replayed and deterministic race regressions cover the reconnect boundary (#2164).
+- Serialized fresh prompt preflight and durable default-model selection through deterministic per-session admission, preventing a later `model.set` from overtaking an earlier prompt while preserving provider-stream and continuation behavior (#2199).
 
 - Gajae Pet overlays no longer leak images or stale pixels across lifecycle changes: each widget owns a randomized Kitty image ID (deleted on disable, replace, switch, and dispose), the previous Sixel footprint is tracked and erased on movement, resize, and narrow-terminal fallback, replaced pet widgets are disposed before their successors install, and a saved pet preference survives editor replacement while graphics are still unavailable (so a delayed Sixel capability probe can still activate it). Teardown is exception-safe and idempotent: a failed or unavailable terminal write never aborts logical disposal or steals a successor widget's overlay slot, and Sixel/Kitty cleanup authority is retained until the erase is actually delivered so a later mode switch or dispose retries it.
 - Gajae Pet cleanup that fails during final widget disposal is now retained by the TUI for retry, and Kitty image IDs remain reserved until their exact-ID delete is delivered.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -13,6 +13,7 @@
  * Modes use this class and add their own I/O layer on top.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -1227,6 +1228,19 @@ export class StreamingEditFileCache {
 		return this.#totalBytes;
 	}
 }
+type SessionAdmissionKind = "prompt" | "selection";
+
+type SessionAdmissionEntry = {
+	kind: SessionAdmissionKind;
+	ready: PromiseWithResolvers<void>;
+	settled: PromiseWithResolvers<void>;
+	released: boolean;
+};
+
+type SessionAdmissionLease = {
+	release(): void;
+};
+
 export class AgentSession {
 	readonly agent: Agent;
 	readonly sessionManager: SessionManager;
@@ -1241,7 +1255,10 @@ export class AgentSession {
 	#scopedModels: ScopedModelSelection[];
 	#thinkingLevel: ThinkingLevel | undefined;
 	#activeModelProfile: string | undefined;
-	#defaultModelSelectionTail: Promise<void> = Promise.resolve();
+	#sessionAdmissionQueue: SessionAdmissionEntry[] = [];
+	#activeSessionAdmission: SessionAdmissionEntry | undefined;
+	#sessionAdmissionClosed = false;
+	#sessionAdmissionContext = new AsyncLocalStorage<SessionAdmissionEntry>();
 	#defaultModelSelectionMutationRevision = 0;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
@@ -1574,6 +1591,75 @@ export class AgentSession {
 		} catch (error) {
 			logger.warn("Failed to release macOS power assertion", { error: String(error) });
 		}
+	}
+
+	#sessionAdmissionBusyError(): AgentBusyError {
+		return Object.assign(new AgentBusyError("Agent session admission is busy due to same-session reentrancy."), {
+			code: "busy",
+		});
+	}
+
+	#activateNextSessionAdmission(): void {
+		if (this.#activeSessionAdmission || this.#sessionAdmissionClosed) return;
+		const next = this.#sessionAdmissionQueue.shift();
+		if (!next) return;
+		this.#activeSessionAdmission = next;
+		next.ready.resolve();
+	}
+
+	async #withSessionAdmission<T>(
+		kind: SessionAdmissionKind,
+		body: (lease: SessionAdmissionLease) => Promise<T>,
+	): Promise<T> {
+		const owner = this.#sessionAdmissionContext.getStore();
+		if (owner && !owner.released) throw this.#sessionAdmissionBusyError();
+		if (this.#sessionAdmissionClosed || this.#isDisposed) throw this.#sessionAdmissionBusyError();
+
+		const entry: SessionAdmissionEntry = {
+			kind,
+			ready: Promise.withResolvers<void>(),
+			settled: Promise.withResolvers<void>(),
+			released: false,
+		};
+		this.#sessionAdmissionQueue.push(entry);
+		this.#activateNextSessionAdmission();
+		await entry.ready.promise;
+		if (this.#sessionAdmissionClosed || this.#isDisposed) {
+			entry.released = true;
+			entry.settled.resolve();
+			if (this.#activeSessionAdmission === entry) this.#activeSessionAdmission = undefined;
+			this.#activateNextSessionAdmission();
+			throw this.#sessionAdmissionBusyError();
+		}
+
+		const release = () => {
+			if (entry.released) return;
+			entry.released = true;
+			entry.settled.resolve();
+			if (this.#activeSessionAdmission === entry) this.#activeSessionAdmission = undefined;
+			this.#activateNextSessionAdmission();
+		};
+		try {
+			return await this.#sessionAdmissionContext.run(entry, () => body({ release }));
+		} finally {
+			release();
+		}
+	}
+
+	async #closeSessionAdmission(): Promise<void> {
+		this.#sessionAdmissionClosed = true;
+		const queued = this.#sessionAdmissionQueue.splice(0);
+		for (const entry of queued) {
+			entry.released = true;
+			entry.ready.reject(this.#sessionAdmissionBusyError());
+			entry.settled.resolve();
+		}
+		const active = this.#activeSessionAdmission;
+		if (active?.kind === "prompt") {
+			this.#promptGeneration++;
+			this.#promptPreflightAbortController.abort();
+		}
+		if (active) await active.settled.promise;
 	}
 
 	#beginInFlight(): void {
@@ -4134,6 +4220,7 @@ export class AgentSession {
 	 * Call this when completely done with the session.
 	 */
 	async dispose(): Promise<void> {
+		await this.#closeSessionAdmission();
 		this.#isDisposed = true;
 		this.#pendingBackgroundExchanges = [];
 		this.yieldQueue.clear();
@@ -6043,45 +6130,56 @@ export class AgentSession {
 			return;
 		}
 
-		if (workflowIntentDiff) {
-			this.sessionManager.appendCustomEntry(WORKFLOW_INTENT_DIFF_CUSTOM_TYPE, workflowIntentDiff);
-		}
+		const admissionGeneration = this.#promptGeneration;
+		const admissionSignal = this.#promptPreflightAbortController.signal;
+		await this.#withSessionAdmission("prompt", async admission => {
+			this.#throwIfPromptPreflightCancelled(admissionGeneration, admissionSignal);
+			if (workflowIntentDiff) {
+				this.sessionManager.appendCustomEntry(WORKFLOW_INTENT_DIFF_CUSTOM_TYPE, workflowIntentDiff);
+			}
 
-		// Skip eager todo prelude when the user has already queued a directive
-		const hasPendingUserDirective = this.#toolChoiceQueue.inspect().includes("user-force");
-		const eagerTodoPrelude =
-			!options?.synthetic && !hasPendingUserDirective ? this.#createEagerTodoPrelude(expandedText) : undefined;
+			// Skip eager todo prelude when the user has already queued a directive
+			const hasPendingUserDirective = this.#toolChoiceQueue.inspect().includes("user-force");
+			const eagerTodoPrelude =
+				!options?.synthetic && !hasPendingUserDirective ? this.#createEagerTodoPrelude(expandedText) : undefined;
 
-		const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
-		if (options?.images) {
-			userContent.push(...options.images);
-		}
+			const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
+			if (options?.images) {
+				userContent.push(...options.images);
+			}
 
-		const promptAttribution = options?.attribution ?? (options?.synthetic ? "agent" : "user");
-		const message = options?.synthetic
-			? { role: "developer" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() }
-			: { role: "user" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() };
-		await this.refreshGjcSubskillTools();
+			const promptAttribution = options?.attribution ?? (options?.synthetic ? "agent" : "user");
+			const message = options?.synthetic
+				? {
+						role: "developer" as const,
+						content: userContent,
+						attribution: promptAttribution,
+						timestamp: Date.now(),
+					}
+				: { role: "user" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() };
+			await this.refreshGjcSubskillTools();
 
-		if (eagerTodoPrelude?.toolChoice) {
-			this.#toolChoiceQueue.pushOnce(eagerTodoPrelude.toolChoice, {
-				label: "eager-todo",
-			});
-		}
+			if (eagerTodoPrelude?.toolChoice) {
+				this.#toolChoiceQueue.pushOnce(eagerTodoPrelude.toolChoice, {
+					label: "eager-todo",
+				});
+			}
 
-		try {
-			await this.#promptWithMessage(message, expandedText, {
-				...options,
-				prependMessages: eagerTodoPrelude ? [eagerTodoPrelude.message] : undefined,
-			});
-		} finally {
-			// Clean up residual eager-todo directive if the prompt never consumed it
-			// (e.g., compaction aborted, validation failed).
-			this.#toolChoiceQueue.removeByLabel("eager-todo");
-		}
-		if (!options?.synthetic) {
-			await this.#enforcePlanModeToolDecision();
-		}
+			try {
+				await this.#promptWithMessage(message, expandedText, {
+					...options,
+					prependMessages: eagerTodoPrelude ? [eagerTodoPrelude.message] : undefined,
+					admissionLease: admission,
+				});
+			} finally {
+				// Clean up residual eager-todo directive if the prompt never consumed it
+				// (e.g., compaction aborted, validation failed).
+				this.#toolChoiceQueue.removeByLabel("eager-todo");
+			}
+			if (!options?.synthetic) {
+				await this.#enforcePlanModeToolDecision();
+			}
+		});
 	}
 
 	async #syncSkillPromptActiveState(
@@ -6172,22 +6270,27 @@ export class AgentSession {
 			return;
 		}
 
-		const customMessage: CustomMessage<T> = {
-			role: "custom",
-			customType: message.customType,
-			content: message.content,
-			display: message.display,
-			details: message.details,
-			attribution: message.attribution ?? "agent",
-			timestamp: Date.now(),
-		};
+		const admissionGeneration = this.#promptGeneration;
+		const admissionSignal = this.#promptPreflightAbortController.signal;
+		await this.#withSessionAdmission("prompt", async admission => {
+			this.#throwIfPromptPreflightCancelled(admissionGeneration, admissionSignal);
+			const customMessage: CustomMessage<T> = {
+				role: "custom",
+				customType: message.customType,
+				content: message.content,
+				display: message.display,
+				details: message.details,
+				attribution: message.attribution ?? "agent",
+				timestamp: Date.now(),
+			};
 
-		await this.#syncSkillPromptActiveStateSafely(customMessage, true);
-		try {
-			await this.#promptWithMessage(customMessage, textContent, options);
-		} finally {
-			await this.#syncSkillPromptActiveStateSafely(customMessage, false);
-		}
+			await this.#syncSkillPromptActiveStateSafely(customMessage, true);
+			try {
+				await this.#promptWithMessage(customMessage, textContent, { ...options, admissionLease: admission });
+			} finally {
+				await this.#syncSkillPromptActiveStateSafely(customMessage, false);
+			}
+		});
 	}
 
 	async #promptWithMessage(
@@ -6197,6 +6300,7 @@ export class AgentSession {
 			prependMessages?: AgentMessage[];
 			skipPostPromptRecoveryWait?: boolean;
 			predecessorAgentEndHold?: symbol;
+			admissionLease?: SessionAdmissionLease;
 		},
 	): Promise<void> {
 		this.#beginInFlight();
@@ -6383,6 +6487,7 @@ export class AgentSession {
 			const agentPromptOptions = {
 				...(options?.toolChoice ? { toolChoice: options.toolChoice } : undefined),
 				...this.#managedFallbackPromptOptions(),
+				...(options?.admissionLease ? { onRunAccepted: options.admissionLease.release } : undefined),
 			};
 			options?.onPreflightAccepted?.();
 			this.#throwIfPromptPreflightCancelled(generation, preflightSignal);
@@ -7837,11 +7942,7 @@ export class AgentSession {
 		model: Model,
 		thinkingLevel: ThinkingLevel | undefined,
 	): Promise<DefaultModelSelectionResult> {
-		const predecessor = this.#defaultModelSelectionTail;
-		const transaction = Promise.withResolvers<void>();
-		this.#defaultModelSelectionTail = transaction.promise;
-		try {
-			await predecessor;
+		return this.#withSessionAdmission("selection", async () => {
 			if (thinkingLevel === ThinkingLevel.Inherit) {
 				throw new Error("Default model selection cannot inherit a thinking level");
 			}
@@ -7911,9 +8012,7 @@ export class AgentSession {
 				}
 			}
 			return { provider: model.provider, modelId: model.id, thinkingLevel: effectiveLevel };
-		} finally {
-			transaction.resolve();
-		}
+		});
 	}
 	/**
 	 * Cycle to next/previous model.
@@ -10948,7 +11047,7 @@ export class AgentSession {
 
 	async #promptAgentWithIdleRetry(
 		messages: AgentMessage[],
-		options?: { toolChoice?: ToolChoice; fallbackManaged?: boolean },
+		options?: { toolChoice?: ToolChoice; fallbackManaged?: boolean; onRunAccepted?: () => void },
 		predecessorAgentEndHold?: symbol,
 	): Promise<void> {
 		const deadline = Date.now() + 30_000;

--- a/packages/coding-agent/test/agent-session-before-agent-start-attribution.test.ts
+++ b/packages/coding-agent/test/agent-session-before-agent-start-attribution.test.ts
@@ -200,4 +200,143 @@ describe("AgentSession before_agent_start attribution fallback", () => {
 		});
 		expect(replacementAccepted).toBe(true);
 	});
+	it("orders an accepted prompt before a later default selection through provider start", async () => {
+		const { emitBeforeAgentStart } = createSession();
+		const preflightStarted = Promise.withResolvers<void>();
+		const releasePreflight = Promise.withResolvers<void>();
+		emitBeforeAgentStart.mockImplementationOnce(async () => {
+			preflightStarted.resolve();
+			await releasePreflight.promise;
+			return undefined;
+		});
+		const currentModel = session.model;
+		if (!currentModel) throw new Error("Expected session model");
+		const selectionModel = { ...currentModel, provider: "selection-provider", id: "selection-model" };
+		authStorage?.setRuntimeApiKey(selectionModel.provider, "selection-key");
+		const apiKeySpy = vi.spyOn(modelRegistry, "getApiKey");
+
+		const prompt = session.prompt("held in preflight");
+		await preflightStarted.promise;
+		const selection = session.setDefaultModelSelection(selectionModel, undefined);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(apiKeySpy.mock.calls.some(([model]) => model === selectionModel)).toBe(false);
+		releasePreflight.resolve();
+		await prompt;
+		await selection;
+		expect(apiKeySpy.mock.calls.some(([model]) => model === selectionModel)).toBe(true);
+	});
+
+	it("orders an accepted default selection before later prompt preflight", async () => {
+		const { emitBeforeAgentStart } = createSession();
+		const currentModel = session.model;
+		if (!currentModel) throw new Error("Expected session model");
+		const selectionModel = { ...currentModel, provider: "selection-provider", id: "selection-model" };
+		authStorage?.setRuntimeApiKey(selectionModel.provider, "selection-key");
+		const selectionValidationStarted = Promise.withResolvers<void>();
+		const releaseSelectionValidation = Promise.withResolvers<void>();
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model => {
+			if (model === selectionModel) {
+				selectionValidationStarted.resolve();
+				await releaseSelectionValidation.promise;
+				return "selection-key";
+			}
+			return "test-key";
+		});
+
+		const selection = session.setDefaultModelSelection(selectionModel, undefined);
+		await selectionValidationStarted.promise;
+		const prompt = session.prompt("wait behind selection");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(emitBeforeAgentStart).not.toHaveBeenCalled();
+		releaseSelectionValidation.resolve();
+		await selection;
+		await prompt;
+		expect(emitBeforeAgentStart).toHaveBeenCalledTimes(1);
+	});
+
+	it("fails awaited same-session selection reentrancy with a stable busy result", async () => {
+		const { emitBeforeAgentStart } = createSession();
+		const currentModel = session.model;
+		if (!currentModel) throw new Error("Expected session model");
+		let reentrantError: unknown;
+		emitBeforeAgentStart.mockImplementationOnce(async () => {
+			try {
+				await session.setDefaultModelSelection(currentModel, undefined);
+			} catch (error) {
+				reentrantError = error;
+			}
+			return undefined;
+		});
+
+		await session.prompt("reentrant selection");
+
+		expect(reentrantError).toMatchObject({
+			name: "AgentBusyError",
+			code: "busy",
+			message: "Agent session admission is busy due to same-session reentrancy.",
+		});
+	});
+	it("cancels a queued prompt without starving later admission", async () => {
+		createSession();
+		const currentModel = session.model;
+		if (!currentModel) throw new Error("Expected session model");
+		const selectionModel = { ...currentModel, provider: "selection-provider", id: "selection-model" };
+		authStorage?.setRuntimeApiKey(selectionModel.provider, "selection-key");
+		const selectionValidationStarted = Promise.withResolvers<void>();
+		const releaseSelectionValidation = Promise.withResolvers<void>();
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model => {
+			if (model === selectionModel) {
+				selectionValidationStarted.resolve();
+				await releaseSelectionValidation.promise;
+				return "selection-key";
+			}
+			return "test-key";
+		});
+
+		const selection = session.setDefaultModelSelection(selectionModel, undefined);
+		await selectionValidationStarted.promise;
+		const queuedPrompt = session.prompt("cancel while queued");
+		await session.abort();
+		releaseSelectionValidation.resolve();
+		await selection;
+		await expect(queuedPrompt).rejects.toMatchObject({ code: "busy" });
+
+		await session.prompt("successor prompt");
+	});
+	it("disposal drains an active selection", async () => {
+		createSession();
+		const currentModel = session.model;
+		if (!currentModel) throw new Error("Expected session model");
+		const selectionModel = { ...currentModel, provider: "selection-provider", id: "selection-model" };
+		authStorage?.setRuntimeApiKey(selectionModel.provider, "selection-key");
+		const validationStarted = Promise.withResolvers<void>();
+		const releaseValidation = Promise.withResolvers<void>();
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model => {
+			if (model === selectionModel) {
+				validationStarted.resolve();
+				await releaseValidation.promise;
+				return "selection-key";
+			}
+			return "test-key";
+		});
+
+		const selection = session.setDefaultModelSelection(selectionModel, undefined);
+		await validationStarted.promise;
+		const queuedPrompt = session.prompt("queued during disposal");
+		const disposal = session.dispose();
+		const queuedResult = queuedPrompt.then(
+			() => ({ status: "fulfilled" as const }),
+			error => ({ status: "rejected" as const, error }),
+		);
+		releaseValidation.resolve();
+		await selection;
+		const result = await queuedResult;
+		expect(result).toMatchObject({ status: "rejected", error: { code: "busy" } });
+		await disposal;
+		session = undefined as unknown as AgentSession;
+	});
 });


### PR DESCRIPTION
## Summary
- add deterministic per-session FIFO admission shared by fresh prompt preflight and durable default-model selection
- release prompt admission at the exact agent-run acceptance boundary
- reject awaited same-session callback reentrancy with stable `busy` semantics
- preserve existing streaming, continuation, durable recovery, and SDK `model.set` routing

## Verification
- focused admission/selection/concurrency/SDK/agent suite: 115 pass
- coding-agent check: passed
- agent check: passed
- coding-agent build: passed
- workspace `bun run check:ts` remains blocked by unrelated existing `scripts/generate-json-schemas.ts` `valueSchema` narrowing errors

Closes #2199.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*