### PR TITLE
fix(coding-agent): persist credential import decisions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Fixed `gjc --tmux` startup from GNOME and other VTE terminals by recognizing `vte-spawn-*.scope` only when cgroup metadata proves matching user-manager ancestry (#2159).
 - Fixed native Windows `GJC_TMUX_COMMAND=tmux` resolution when WinGet's `tmux.exe` is a psmux alias with a generic `tmux` banner: GJC now compares executable identity with the installed `psmux.exe`/`pmux.exe` companions and fails closed when identity cannot be established instead of authorizing native-tmux semantics (#2086).
 
+- Accepted or declined initial external credential-import decisions now persist across normal restarts and upgrades, suppressing automatic startup and bare `/login` discovery; same-version legacy markers remain compatible and explicit `/provider` import remains available ([#2117](https://github.com/Yeachan-Heo/gajae-code/issues/2117)).
+
 ## [0.10.1] - 2026-07-13
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -3,7 +3,7 @@ import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
 import type { Component, OverlayHandle } from "@gajae-code/tui";
 import { Input, isPetMode, Loader, Spacer, Text } from "@gajae-code/tui";
-import { getAgentDbPath, getProjectDir } from "@gajae-code/utils";
+import { getAgentDbPath, getProjectDir, logger, VERSION } from "@gajae-code/utils";
 import {
 	activateModelProfile,
 	type MaterializeModelProfileForDeletionResult,
@@ -45,9 +45,22 @@ import type { InteractiveModeContext, OAuthSelectorOptions } from "../../modes/t
 import { type SessionInfo, SessionManager } from "../../session/session-manager";
 import { FileSessionStorage } from "../../session/session-storage";
 import {
+	CREDENTIAL_AUTO_IMPORT_DISCOVERY_WARNING,
+	CREDENTIAL_AUTO_IMPORT_PERSISTENCE_WARNING,
+	CREDENTIAL_AUTO_IMPORT_REFRESH_WARNING,
+	CREDENTIAL_AUTO_IMPORT_RETRY_WARNING,
 	CREDENTIAL_AUTO_IMPORT_ROTATION_WARNING,
+	CREDENTIAL_AUTO_IMPORT_STATE_UNREADABLE_WARNING,
+	type CredentialAutoImportStateReadResult,
+	type CredentialAutoImportStateStore,
+	createCredentialAutoImportStateStore,
+	formatCredentialAutoImportCandidateLabel,
+	formatCredentialAutoImportPrompt,
+	isCredentialAutoImportStateResolvedForVersion,
+	logCredentialAutoImportFailures,
 	runExternalCredentialAutoImport,
 } from "../../setup/credential-auto-import";
+
 import {
 	filterAutoImportOAuthCredentials,
 	formatDiscoverySummary,
@@ -145,7 +158,14 @@ function formatProviderOnboardingCommandGuide(): string {
 }
 
 export class SelectorController {
-	constructor(private ctx: InteractiveModeContext) {}
+	#credentialAutoImportStateStore?: CredentialAutoImportStateStore;
+
+	constructor(
+		private ctx: InteractiveModeContext,
+		credentialAutoImportStateStore?: CredentialAutoImportStateStore,
+	) {
+		this.#credentialAutoImportStateStore = credentialAutoImportStateStore;
+	}
 
 	async #refreshOAuthProviderAuthState(): Promise<void> {
 		const oauthProviders = getOAuthProviders();
@@ -1658,34 +1678,110 @@ export class SelectorController {
 			options?.allowExternalCredentialDiscovery === true &&
 			options.trigger === "bare-login"
 		) {
-			const preview = await runExternalCredentialAutoImport({
-				authStorage: {
-					importCredentialIfAbsent: async () => ({
-						inserted: false,
-						reason: "skipped-existing",
-						provider: "",
-						entries: [],
-					}),
-				},
-				trigger: "bare-login",
-				discover: options.externalCredentialDiscover,
-			});
-			const result = preview.discovery ?? { importable: [], skipped: [], environment: [] };
-			const candidates = filterAutoImportOAuthCredentials(result.importable);
-			if (candidates.length > 0) {
-				const confirmed = await this.ctx.showHookConfirm(
-					`Import ${candidates.length} external credential(s)?`,
-					`${formatDiscoverySummary({ ...result, importable: candidates }).join("\n")}\n\n${CREDENTIAL_AUTO_IMPORT_ROTATION_WARNING}`,
-				);
-				if (confirmed) {
-					const summary = await runExternalCredentialAutoImport({
-						authStorage: this.ctx.session.modelRegistry.authStorage,
-						trigger: "bare-login",
-						discover: options.externalCredentialDiscover,
-					});
-					externalCredentialCandidates = summary.imported;
-					if (externalCredentialCandidates.length > 0) {
-						await this.ctx.session.modelRegistry.refresh("offline");
+			const stateStore =
+				this.#credentialAutoImportStateStore ??
+				createCredentialAutoImportStateStore(this.ctx.settings.getAgentDir());
+			let stateRead: CredentialAutoImportStateReadResult | undefined;
+			try {
+				stateRead = await stateStore.read();
+			} catch {
+				logger.warn("Credential auto-import state read failed", { classification: "state-read-failed" });
+				stateRead = { state: {}, problems: [], unreadable: true };
+			}
+			if (stateRead?.unreadable === true) {
+				logger.warn("Credential auto-import state unavailable", { classification: "state-unreadable" });
+				this.ctx.showWarning(CREDENTIAL_AUTO_IMPORT_STATE_UNREADABLE_WARNING);
+			} else if (stateRead && !isCredentialAutoImportStateResolvedForVersion(stateRead.state, VERSION)) {
+				const preview = await runExternalCredentialAutoImport({
+					authStorage: {
+						importCredentialIfAbsent: async () => ({
+							inserted: false,
+							reason: "skipped-existing",
+							provider: "",
+							entries: [],
+						}),
+					},
+					trigger: "bare-login",
+					discover: options.externalCredentialDiscover,
+				});
+				if (!preview.discovered) {
+					this.ctx.showWarning(CREDENTIAL_AUTO_IMPORT_DISCOVERY_WARNING);
+				} else {
+					const result = preview.discovery ?? { importable: [], skipped: [], environment: [] };
+					const candidates = filterAutoImportOAuthCredentials(result.importable);
+					const previewSourceFailures = preview.failures.filter(failure => failure.credential === undefined);
+					if (candidates.length === 0 && previewSourceFailures.length > 0) {
+						this.ctx.showWarning(CREDENTIAL_AUTO_IMPORT_DISCOVERY_WARNING);
+					} else if (candidates.length > 0) {
+						const confirmed = await this.ctx.showHookConfirm(
+							`Import ${candidates.length} external credential(s)?`,
+							`${formatCredentialAutoImportPrompt(candidates)}\n\n${CREDENTIAL_AUTO_IMPORT_ROTATION_WARNING}`,
+						);
+						if (!confirmed) {
+							let persisted = false;
+							try {
+								persisted = await stateStore.write({ initialImportResolution: "declined" });
+							} catch {
+								logger.warn("Credential auto-import state persistence failed", {
+									classification: "state-write-failed",
+								});
+							}
+							if (!persisted) this.ctx.showWarning(CREDENTIAL_AUTO_IMPORT_PERSISTENCE_WARNING);
+						} else {
+							const summary = await runExternalCredentialAutoImport({
+								authStorage: this.ctx.session.modelRegistry.authStorage,
+								trigger: "bare-login",
+								discover: options.externalCredentialDiscover,
+							});
+							if (!summary.discovered) {
+								logCredentialAutoImportFailures("bare-login", summary.failures);
+								this.ctx.showWarning(CREDENTIAL_AUTO_IMPORT_RETRY_WARNING);
+							} else {
+								const secondResult = summary.discovery ?? { importable: [], skipped: [], environment: [] };
+								const secondCandidates = filterAutoImportOAuthCredentials(secondResult.importable);
+								const secondSourceFailures = summary.failures.filter(
+									failure => failure.credential === undefined,
+								);
+								const handledCandidates = summary.imported.length + summary.skipped.length > 0;
+								if (handledCandidates || (secondCandidates.length === 0 && secondSourceFailures.length === 0)) {
+									let persisted = false;
+									try {
+										persisted = await stateStore.write({ initialImportResolution: "accepted" });
+									} catch {
+										logger.warn("Credential auto-import state persistence failed", {
+											classification: "state-write-failed",
+										});
+									}
+									if (!persisted) this.ctx.showWarning(CREDENTIAL_AUTO_IMPORT_PERSISTENCE_WARNING);
+									externalCredentialCandidates = summary.imported.map(credential => ({
+										...credential,
+										source: formatCredentialAutoImportCandidateLabel(credential),
+									}));
+									if (!handledCandidates) {
+										this.ctx.showStatus("External credentials were no longer available to import.");
+									}
+									if (summary.imported.length > 0) {
+										try {
+											await this.ctx.session.modelRegistry.refresh("offline");
+										} catch {
+											logger.warn("Credential auto-import refresh failed", {
+												classification: "refresh-failed",
+											});
+											this.ctx.showWarning(CREDENTIAL_AUTO_IMPORT_REFRESH_WARNING);
+										}
+									}
+									if (handledCandidates && summary.failures.length > 0) {
+										logCredentialAutoImportFailures("bare-login", summary.failures);
+										this.ctx.showWarning(CREDENTIAL_AUTO_IMPORT_RETRY_WARNING);
+									}
+								} else if (secondCandidates.length > 0 && summary.failures.length > 0) {
+									logCredentialAutoImportFailures("bare-login", summary.failures);
+									this.ctx.showWarning(CREDENTIAL_AUTO_IMPORT_RETRY_WARNING);
+								} else {
+									this.ctx.showWarning(CREDENTIAL_AUTO_IMPORT_DISCOVERY_WARNING);
+								}
+							}
+						}
 					}
 				}
 			}

--- a/packages/coding-agent/src/setup/credential-auto-import.ts
+++ b/packages/coding-agent/src/setup/credential-auto-import.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type {
@@ -7,8 +8,8 @@ import type {
 	AuthStorage,
 } from "@gajae-code/ai";
 import { getAgentDir, logger, VERSION } from "@gajae-code/utils";
+import { withFileLock } from "../config/file-lock";
 import type { ModelRegistry } from "../config/model-registry";
-
 import {
 	type CredentialDiscoveryResult,
 	type CredentialOrigin,
@@ -23,40 +24,204 @@ import {
 
 export const CREDENTIAL_AUTO_IMPORT_ROTATION_WARNING =
 	"Refreshing in gjc may log out the Claude/Codex CLI because OAuth refresh tokens can rotate.";
+export const CREDENTIAL_AUTO_IMPORT_PERSISTENCE_WARNING =
+	"Credential import preference could not be saved; external credentials may be offered again.";
+export const CREDENTIAL_AUTO_IMPORT_REFRESH_WARNING =
+	"Imported credentials were saved, but provider availability could not be refreshed.";
+export const CREDENTIAL_AUTO_IMPORT_DISCOVERY_WARNING =
+	"External credential discovery could not be completed. Use /provider to import credentials manually.";
+export const CREDENTIAL_AUTO_IMPORT_RETRY_WARNING =
+	"Some external credentials could not be imported. Use /provider to retry.";
+
+export const CREDENTIAL_AUTO_IMPORT_STATE_UNREADABLE_WARNING =
+	"Credential import preference could not be read. External credential discovery was skipped; use /provider to import credentials manually.";
 
 export type CredentialAutoImportSourceLabel = "claude-code-file" | "claude-code-keychain" | "codex-file";
 export type CredentialAutoImportTrigger = "startup" | "bare-login" | "setup-cli";
+export type InitialImportResolution = "accepted" | "declined";
+export type CredentialAutoImportStateProblem =
+	| "invalid-initial-import-resolution"
+	| "invalid-last-import-version"
+	| "malformed-json"
+	| "malformed-root";
 
 const CREDENTIAL_AUTO_IMPORT_STATE_FILENAME = "credential-auto-import-state.json";
+const VERSION_MARKER_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
-interface CredentialAutoImportStateFile {
-	lastImportVersion?: unknown;
+export interface CredentialAutoImportStateFile {
+	lastImportVersion?: string;
+	initialImportResolution?: InitialImportResolution;
+}
+
+export interface CredentialAutoImportStateReadResult {
+	state: CredentialAutoImportStateFile;
+	problems: CredentialAutoImportStateProblem[];
+	unreadable: boolean;
+}
+
+export interface CredentialAutoImportStateMutation {
+	lastImportVersion?: string;
+	initialImportResolution?: InitialImportResolution;
+}
+
+export interface CredentialAutoImportStateStore {
+	read: () => Promise<CredentialAutoImportStateReadResult>;
+	write: (mutation: CredentialAutoImportStateMutation) => Promise<boolean>;
+}
+
+export interface CredentialAutoImportStateStoreDependencies {
+	withFileLock?: <T>(filePath: string, transaction: () => Promise<T>) => Promise<T>;
+	rename?: (oldPath: string, newPath: string) => Promise<void>;
 }
 
 export function getCredentialAutoImportStatePath(agentDir: string = getAgentDir()): string {
 	return path.join(agentDir, CREDENTIAL_AUTO_IMPORT_STATE_FILENAME);
 }
 
-export async function readCredentialImportMarker(agentDir?: string): Promise<string | undefined> {
+function isEnoent(error: unknown): boolean {
+	return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
+function isValidVersionMarker(value: unknown): value is string {
+	return (
+		typeof value === "string" &&
+		value.length > 0 &&
+		value.trim() === value &&
+		value.length <= 128 &&
+		VERSION_MARKER_PATTERN.test(value)
+	);
+}
+
+function isInitialImportResolution(value: unknown): value is InitialImportResolution {
+	return value === "accepted" || value === "declined";
+}
+
+function projectCredentialAutoImportState(value: unknown): CredentialAutoImportStateReadResult {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return { state: {}, problems: ["malformed-root"], unreadable: false };
+	}
+
+	const record = value as Record<string, unknown>;
+	const state: CredentialAutoImportStateFile = {};
+	const problems: CredentialAutoImportStateProblem[] = [];
+	if (Object.hasOwn(record, "initialImportResolution")) {
+		if (isInitialImportResolution(record.initialImportResolution)) {
+			state.initialImportResolution = record.initialImportResolution;
+		} else {
+			problems.push("invalid-initial-import-resolution");
+		}
+	}
+	if (Object.hasOwn(record, "lastImportVersion")) {
+		if (isValidVersionMarker(record.lastImportVersion)) {
+			state.lastImportVersion = record.lastImportVersion;
+		} else {
+			problems.push("invalid-last-import-version");
+		}
+	}
+	return { state, problems, unreadable: false };
+}
+
+async function readCredentialAutoImportStateAtPath(statePath: string): Promise<CredentialAutoImportStateReadResult> {
 	try {
-		const raw = await fs.readFile(getCredentialAutoImportStatePath(agentDir), "utf-8");
-		const parsed = JSON.parse(raw) as CredentialAutoImportStateFile;
-		return typeof parsed.lastImportVersion === "string" ? parsed.lastImportVersion : undefined;
-	} catch {
-		return undefined;
+		const raw = await fs.readFile(statePath, "utf-8");
+		try {
+			return projectCredentialAutoImportState(JSON.parse(raw) as unknown);
+		} catch {
+			return { state: {}, problems: ["malformed-json"], unreadable: false };
+		}
+	} catch (error: unknown) {
+		if (isEnoent(error)) return { state: {}, problems: [], unreadable: false };
+		return { state: {}, problems: [], unreadable: true };
 	}
 }
 
-export async function writeCredentialImportMarker(version: string, agentDir?: string): Promise<boolean> {
-	try {
-		const statePath = getCredentialAutoImportStatePath(agentDir);
-		await fs.mkdir(path.dirname(statePath), { recursive: true });
-		await fs.writeFile(statePath, `${JSON.stringify({ lastImportVersion: version })}\n`);
-		return true;
-	} catch (error: unknown) {
-		logger.warn("Failed to persist credential auto-import state", { error });
-		return false;
+function serializeCredentialAutoImportState(state: CredentialAutoImportStateFile): string {
+	const serialized: CredentialAutoImportStateFile = {};
+	if (isValidVersionMarker(state.lastImportVersion)) serialized.lastImportVersion = state.lastImportVersion;
+	if (isInitialImportResolution(state.initialImportResolution)) {
+		serialized.initialImportResolution = state.initialImportResolution;
 	}
+	return `${JSON.stringify(serialized)}\n`;
+}
+
+async function writeCredentialAutoImportStateAtomic(
+	statePath: string,
+	state: CredentialAutoImportStateFile,
+	rename: (oldPath: string, newPath: string) => Promise<void> = fs.rename,
+): Promise<void> {
+	const temporaryPath = `${statePath}.tmp.${process.pid}.${Date.now()}.${randomUUID()}`;
+	try {
+		const handle = await fs.open(temporaryPath, "wx", 0o600);
+		try {
+			await handle.writeFile(serializeCredentialAutoImportState(state));
+		} finally {
+			await handle.close();
+		}
+		await rename(temporaryPath, statePath);
+	} catch (error: unknown) {
+		await fs.rm(temporaryPath, { force: true }).catch(() => {});
+		throw error;
+	}
+}
+
+export function createCredentialAutoImportStateStore(
+	agentDir: string = getAgentDir(),
+	dependencies: CredentialAutoImportStateStoreDependencies = {},
+): CredentialAutoImportStateStore {
+	const statePath = getCredentialAutoImportStatePath(agentDir);
+	const lock = dependencies.withFileLock ?? withFileLock;
+	const rename = dependencies.rename ?? fs.rename;
+	return {
+		read: () => readCredentialAutoImportStateAtPath(statePath),
+		write: async mutation => {
+			if (
+				(mutation.lastImportVersion !== undefined && !isValidVersionMarker(mutation.lastImportVersion)) ||
+				(mutation.initialImportResolution !== undefined &&
+					!isInitialImportResolution(mutation.initialImportResolution))
+			) {
+				return false;
+			}
+			try {
+				await fs.mkdir(path.dirname(statePath), { recursive: true, mode: 0o700 });
+				await lock(statePath, async () => {
+					const current = await readCredentialAutoImportStateAtPath(statePath);
+					if (current.unreadable) throw new Error("Credential auto-import state became unreadable");
+					const next: CredentialAutoImportStateFile = { ...current.state };
+					if (mutation.lastImportVersion !== undefined) next.lastImportVersion = mutation.lastImportVersion;
+					if (next.initialImportResolution === undefined && mutation.initialImportResolution !== undefined) {
+						next.initialImportResolution = mutation.initialImportResolution;
+					}
+					await writeCredentialAutoImportStateAtomic(statePath, next, rename);
+				});
+				return true;
+			} catch {
+				logger.warn("Credential auto-import state persistence failed", { classification: "state-write-failed" });
+				return false;
+			}
+		},
+	};
+}
+
+export async function readCredentialAutoImportState(agentDir?: string): Promise<CredentialAutoImportStateReadResult> {
+	return createCredentialAutoImportStateStore(agentDir).read();
+}
+
+export function isCredentialAutoImportStateResolvedForVersion(
+	state: CredentialAutoImportStateFile,
+	version: string,
+): boolean {
+	return (
+		state.initialImportResolution !== undefined ||
+		(state.lastImportVersion !== undefined && state.lastImportVersion === version)
+	);
+}
+
+export async function readCredentialImportMarker(agentDir?: string): Promise<string | undefined> {
+	return (await readCredentialAutoImportState(agentDir)).state.lastImportVersion;
+}
+
+export async function writeCredentialImportMarker(version: string, agentDir?: string): Promise<boolean> {
+	return createCredentialAutoImportStateStore(agentDir).write({ lastImportVersion: version });
 }
 
 export enum CredentialAutoImportFailureClass {
@@ -91,6 +256,63 @@ export interface CredentialAutoImportResult {
 	discovered: boolean;
 	discovery?: CredentialDiscoveryResult;
 	globalDiscoveryFailure?: CredentialAutoImportFailure;
+}
+
+const CREDENTIAL_AUTO_IMPORT_PROMPT_PROVIDERS: readonly ExternalProvider[] = ["anthropic", "openai-codex"];
+const CREDENTIAL_AUTO_IMPORT_PROMPT_ORIGINS: readonly CredentialOrigin[] = [
+	"claude-code-file",
+	"claude-code-keychain",
+	"codex-file",
+];
+const CREDENTIAL_AUTO_IMPORT_ORIGIN_LABELS: Record<CredentialOrigin, string> = {
+	"claude-code-file": "Claude Code file",
+	"claude-code-keychain": "Claude Code Keychain",
+	"codex-file": "Codex CLI file",
+};
+const CREDENTIAL_AUTO_IMPORT_FAILURE_CLASSES = new Set(Object.values(CredentialAutoImportFailureClass));
+
+export function formatCredentialAutoImportCandidateLabel(
+	candidate: Pick<ImportableCredential, "provider" | "origin">,
+): string {
+	const provider = CREDENTIAL_AUTO_IMPORT_PROMPT_PROVIDERS.includes(candidate.provider)
+		? EXTERNAL_PROVIDER_LABELS[candidate.provider]
+		: undefined;
+	const origin = CREDENTIAL_AUTO_IMPORT_PROMPT_ORIGINS.includes(candidate.origin)
+		? CREDENTIAL_AUTO_IMPORT_ORIGIN_LABELS[candidate.origin]
+		: undefined;
+	return provider && origin ? `${provider} · ${origin}` : "External OAuth credential";
+}
+
+export function formatCredentialAutoImportPrompt(
+	candidates: readonly Pick<ImportableCredential, "provider" | "origin">[],
+): string {
+	const lines: string[] = [];
+	for (const provider of CREDENTIAL_AUTO_IMPORT_PROMPT_PROVIDERS) {
+		for (const origin of CREDENTIAL_AUTO_IMPORT_PROMPT_ORIGINS) {
+			const count = candidates.filter(
+				candidate => candidate.provider === provider && candidate.origin === origin,
+			).length;
+			if (count > 0)
+				lines.push(
+					`${EXTERNAL_PROVIDER_LABELS[provider]} · ${CREDENTIAL_AUTO_IMPORT_ORIGIN_LABELS[origin]}: ${count}`,
+				);
+		}
+	}
+	return `External OAuth credentials found: ${candidates.length}\n${lines.join("\n")}`;
+}
+
+export function logCredentialAutoImportFailures(
+	trigger: CredentialAutoImportTrigger,
+	failures: readonly Pick<CredentialAutoImportFailure, "failureClass">[],
+): void {
+	const failureCounts: Partial<Record<CredentialAutoImportFailureClass, number>> = {};
+	for (const failure of failures) {
+		if (!CREDENTIAL_AUTO_IMPORT_FAILURE_CLASSES.has(failure.failureClass)) continue;
+		failureCounts[failure.failureClass] = (failureCounts[failure.failureClass] ?? 0) + 1;
+	}
+	if (Object.keys(failureCounts).length > 0) {
+		logger.warn("Credential auto-import completed with failures", { trigger, failureCounts });
+	}
 }
 
 export type CredentialAutoImportAuthStorage = Pick<AuthStorage, "importCredentialIfAbsent">;
@@ -204,18 +426,38 @@ export function formatCredentialAutoImportResult(result: CredentialAutoImportRes
 	return lines;
 }
 
-export interface CredentialImportMarkerStore {
-	read: () => Promise<string | undefined> | string | undefined;
-	write: (version: string) => Promise<boolean> | boolean;
-}
-
 export interface StartupCredentialAutoImportOptions {
 	authStorage: CredentialAutoImportOptions["authStorage"];
 	modelRegistry: Pick<ModelRegistry, "refresh">;
 	discover?: CredentialAutoImportOptions["discover"];
 	version?: string;
 	agentDir?: string;
-	markerStore?: CredentialImportMarkerStore;
+	stateStore?: CredentialAutoImportStateStore;
+}
+
+function appendNoticeLine(notice: string | undefined, line: string): string {
+	return notice ? `${notice}\n${line}` : line;
+}
+
+async function readStateSafely(store: CredentialAutoImportStateStore): Promise<CredentialAutoImportStateReadResult> {
+	try {
+		return await store.read();
+	} catch {
+		logger.warn("Credential auto-import state read failed", { classification: "state-read-failed" });
+		return { state: {}, problems: [], unreadable: true };
+	}
+}
+
+async function writeStateSafely(
+	store: CredentialAutoImportStateStore,
+	mutation: CredentialAutoImportStateMutation,
+): Promise<boolean> {
+	try {
+		return await store.write(mutation);
+	} catch {
+		logger.warn("Credential auto-import state persistence failed", { classification: "state-write-failed" });
+		return false;
+	}
 }
 
 export async function runStartupCredentialAutoImportIfNeeded({
@@ -224,17 +466,15 @@ export async function runStartupCredentialAutoImportIfNeeded({
 	discover,
 	version = VERSION,
 	agentDir,
-	markerStore,
+	stateStore,
 }: StartupCredentialAutoImportOptions): Promise<string | undefined> {
-	const store = markerStore ?? {
-		read: () => readCredentialImportMarker(agentDir),
-		write: (nextVersion: string) => writeCredentialImportMarker(nextVersion, agentDir),
-	};
-	const lastVersion = await store.read();
-	if (lastVersion === version) {
-		// Steady state: user already completed this version's auto-import gate. Skip all file/Keychain reads.
+	const store = stateStore ?? createCredentialAutoImportStateStore(agentDir);
+	const stateRead = await readStateSafely(store);
+	if (stateRead.unreadable) {
+		logger.warn("Credential auto-import state unavailable", { classification: "state-unreadable" });
 		return undefined;
 	}
+	if (isCredentialAutoImportStateResolvedForVersion(stateRead.state, version)) return undefined;
 
 	const result = await runExternalCredentialAutoImport({
 		authStorage: activeAuthStorage,
@@ -242,17 +482,32 @@ export async function runStartupCredentialAutoImportIfNeeded({
 		trigger: "startup",
 	});
 	if (!result.discovered) {
+		logCredentialAutoImportFailures("startup", result.failures);
 		return undefined;
 	}
 
 	const candidates = filterAutoImportOAuthCredentials(result.discovery?.importable ?? []);
-	if (candidates.length > 0 && result.imported.length === 0 && result.skipped.length === 0) {
-		return undefined;
+	const handledCandidates = result.imported.length + result.skipped.length > 0;
+	if (result.failures.length > 0) logCredentialAutoImportFailures("startup", result.failures);
+	let persisted = true;
+	if (handledCandidates) {
+		persisted = await writeStateSafely(store, {
+			lastImportVersion: version,
+			initialImportResolution: "accepted",
+		});
+	} else if (candidates.length === 0 && result.failures.length === 0) {
+		persisted = await writeStateSafely(store, { lastImportVersion: version });
 	}
-	await store.write(version);
 
+	let notice = buildCredentialAutoImportNotice(result);
+	if (!persisted) notice = appendNoticeLine(notice, CREDENTIAL_AUTO_IMPORT_PERSISTENCE_WARNING);
 	if (result.imported.length > 0) {
-		await activeModelRegistry.refresh("offline");
+		try {
+			await activeModelRegistry.refresh("offline");
+		} catch {
+			logger.warn("Credential auto-import refresh failed", { classification: "refresh-failed" });
+			notice = appendNoticeLine(notice, CREDENTIAL_AUTO_IMPORT_REFRESH_WARNING);
+		}
 	}
-	return buildCredentialAutoImportNotice(result);
+	return notice;
 }

--- a/packages/coding-agent/test/credential-auto-import-flows.test.ts
+++ b/packages/coding-agent/test/credential-auto-import-flows.test.ts
@@ -1,12 +1,27 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { AuthCredentialIfAbsentSnapshotResult } from "@gajae-code/ai";
 import { Container } from "@gajae-code/tui";
-import { VERSION } from "@gajae-code/utils";
+import { logger, VERSION } from "@gajae-code/utils";
+
 import { handleCredentialsSetup } from "../src/cli/setup-cli";
+import { ProviderOnboardingSelectorComponent } from "../src/modes/components/provider-onboarding-selector";
 import { SelectorController } from "../src/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
 import {
+	CREDENTIAL_AUTO_IMPORT_PERSISTENCE_WARNING,
+	CREDENTIAL_AUTO_IMPORT_REFRESH_WARNING,
+	CREDENTIAL_AUTO_IMPORT_RETRY_WARNING,
 	CREDENTIAL_AUTO_IMPORT_ROTATION_WARNING,
+	type CredentialAutoImportStateFile,
+	type CredentialAutoImportStateMutation,
+	type CredentialAutoImportStateStore,
+	type CredentialAutoImportStateStoreDependencies,
+	createCredentialAutoImportStateStore,
+	getCredentialAutoImportStatePath,
+	readCredentialAutoImportState,
 	runStartupCredentialAutoImportIfNeeded,
 } from "../src/setup/credential-auto-import";
 import type { CredentialDiscoveryResult, DiscoveryOptions, ImportableCredential } from "../src/setup/credential-import";
@@ -131,20 +146,27 @@ describe("credential auto-import trigger guards", () => {
 });
 
 describe("startup credential auto-import marker matrix", () => {
-	function makeMarkerStore(lastVersion?: string) {
-		let marker = lastVersion;
+	function makeStateStore(lastVersion?: string) {
+		const state: CredentialAutoImportStateFile = lastVersion ? { lastImportVersion: lastVersion } : {};
 		let writes = 0;
-		return {
-			markerStore: {
-				read: () => marker,
-				write: (value: string) => {
-					marker = value;
-					writes += 1;
-					return true;
-				},
+		const stateStore: CredentialAutoImportStateStore = {
+			read: async () => ({ state: { ...state }, problems: [], unreadable: false }),
+			write: async mutation => {
+				if (mutation.lastImportVersion !== undefined) state.lastImportVersion = mutation.lastImportVersion;
+				if (state.initialImportResolution === undefined && mutation.initialImportResolution !== undefined) {
+					state.initialImportResolution = mutation.initialImportResolution;
+				}
+				writes += 1;
+				return true;
 			},
+		};
+		return {
+			stateStore,
 			get marker() {
-				return marker;
+				return state.lastImportVersion;
+			},
+			get resolution() {
+				return state.initialImportResolution;
 			},
 			get writes() {
 				return writes;
@@ -172,14 +194,14 @@ describe("startup credential auto-import marker matrix", () => {
 		discover: (options?: DiscoveryOptions) => Promise<CredentialDiscoveryResult>;
 		outcomes?: Array<AuthCredentialIfAbsentSnapshotResult | Error>;
 	}) {
-		const marker = makeMarkerStore(args.lastVersion);
+		const marker = makeStateStore(args.lastVersion);
 		const a = authStorage(args.outcomes ?? []);
 		const refreshCalls: string[] = [];
 		const notice = await runStartupCredentialAutoImportIfNeeded({
 			authStorage: a.authStorage as never,
 			modelRegistry: { refresh: async (mode?: string) => refreshCalls.push(mode ?? "") } as never,
 			discover: args.discover,
-			markerStore: marker.markerStore,
+			stateStore: marker.stateStore,
 		});
 		return { marker, auth: a, refreshCalls, notice };
 	}
@@ -202,16 +224,27 @@ describe("startup credential auto-import marker matrix", () => {
 		expect(result.marker.writes).toBe(0);
 	});
 
-	test("global discovery failure does not advance marker", async () => {
-		const result = await runCase({
-			discover: async () => {
-				throw new Error("boom");
-			},
-		});
-		expect(result.marker.marker).toBeUndefined();
-		expect(result.marker.writes).toBe(0);
-		expect(result.refreshCalls).toHaveLength(0);
-		expect(result.notice).toBeUndefined();
+	test("global discovery failure logs only bounded failure evidence and does not advance marker", async () => {
+		const errorSentinel = "STARTUP_GLOBAL_DISCOVERY_ERROR_SENTINEL";
+		const warning = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const result = await runCase({
+				discover: async () => {
+					throw new Error(`global discovery failed ${errorSentinel}`);
+				},
+			});
+			expect(result.marker.marker).toBeUndefined();
+			expect(result.marker.writes).toBe(0);
+			expect(result.refreshCalls).toHaveLength(0);
+			expect(result.notice).toBeUndefined();
+			expect(warning).toHaveBeenCalledWith("Credential auto-import completed with failures", {
+				trigger: "startup",
+				failureCounts: { "discovery-unavailable": 1 },
+			});
+			expect(JSON.stringify(warning.mock.calls)).not.toContain(errorSentinel);
+		} finally {
+			warning.mockRestore();
+		}
 	});
 
 	test("no candidates advances marker without refresh or notice", async () => {
@@ -220,6 +253,7 @@ describe("startup credential auto-import marker matrix", () => {
 		expect(result.marker.writes).toBe(1);
 		expect(result.refreshCalls).toHaveLength(0);
 		expect(result.notice).toBeUndefined();
+		expect(result.marker.resolution).toBeUndefined();
 	});
 
 	test("all skipped advances marker without refresh or notice", async () => {
@@ -227,6 +261,7 @@ describe("startup credential auto-import marker matrix", () => {
 		expect(result.marker.marker).toBe(VERSION);
 		expect(result.refreshCalls).toHaveLength(0);
 		expect(result.notice).toBeUndefined();
+		expect(result.marker.resolution).toBe("accepted");
 	});
 
 	test("all failed does not advance marker or refresh", async () => {
@@ -238,6 +273,7 @@ describe("startup credential auto-import marker matrix", () => {
 		expect(result.marker.writes).toBe(0);
 		expect(result.refreshCalls).toHaveLength(0);
 		expect(result.notice).toBeUndefined();
+		expect(result.marker.resolution).toBeUndefined();
 	});
 
 	test("partial import advances marker, refreshes registry, and emits exact rotation warning", async () => {
@@ -252,9 +288,430 @@ describe("startup credential auto-import marker matrix", () => {
 		expect(CREDENTIAL_AUTO_IMPORT_ROTATION_WARNING).toBe(
 			"Refreshing in gjc may log out the Claude/Codex CLI because OAuth refresh tokens can rotate.",
 		);
+		expect(result.marker.resolution).toBe("accepted");
+	});
+
+	test("startup keeps an accepted transition and logs bounded mixed failure evidence", async () => {
+		const marker = makeStateStore();
+		const sourceSentinel = "STARTUP_SOURCE_SENTINEL";
+		const reasonSentinel = "STARTUP_REASON_SENTINEL";
+		const environmentSentinel = "STARTUP_ENVIRONMENT_SENTINEL";
+		const errorSentinel = "STARTUP_ERROR_SENTINEL";
+		const warning = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const notice = await runStartupCredentialAutoImportIfNeeded({
+				authStorage: authStorage([
+					inserted("anthropic"),
+					skipped("openai-codex"),
+					new Error(`write conflict ${errorSentinel}`),
+				]).authStorage as never,
+				modelRegistry: { refresh: async () => {} } as never,
+				discover: async () => ({
+					importable: [
+						oauthCredential({ source: sourceSentinel }),
+						oauthCredential({ provider: "openai-codex", origin: "codex-file", source: sourceSentinel }),
+						oauthCredential({ source: sourceSentinel }),
+					],
+					skipped: [
+						{
+							origin: "claude-code-file",
+							source: sourceSentinel,
+							reason: `unreadable ${reasonSentinel}`,
+						},
+					],
+					environment: [
+						{ provider: "anthropic", variable: environmentSentinel, redactedValue: environmentSentinel },
+					],
+				}),
+				stateStore: marker.stateStore,
+			});
+			expect(marker.marker).toBe(VERSION);
+			expect(marker.resolution).toBe("accepted");
+			expect(notice).toContain(CREDENTIAL_AUTO_IMPORT_ROTATION_WARNING);
+			expect(warning).toHaveBeenCalledWith("Credential auto-import completed with failures", {
+				trigger: "startup",
+				failureCounts: { "source-unreadable": 1, "write-conflict": 1 },
+			});
+			const emitted = JSON.stringify(warning.mock.calls);
+			for (const sentinel of [sourceSentinel, reasonSentinel, environmentSentinel, errorSentinel]) {
+				expect(emitted).not.toContain(sentinel);
+			}
+		} finally {
+			warning.mockRestore();
+		}
+	});
+
+	test("source-failed zero candidates remain unresolved for a later startup retry", async () => {
+		const marker = makeStateStore();
+		const result = await runStartupCredentialAutoImportIfNeeded({
+			authStorage: authStorage([]).authStorage as never,
+			modelRegistry: { refresh: async () => {} } as never,
+			discover: async () =>
+				discovery(
+					[],
+					[
+						{
+							origin: "claude-code-file",
+							source: "external credential source",
+							reason: "unreadable credential file",
+						},
+					],
+				),
+			stateStore: marker.stateStore,
+		});
+		expect(result).toBeUndefined();
+		expect(marker.writes).toBe(0);
+		expect(marker.resolution).toBeUndefined();
+	});
+
+	test("startup keeps its accepted decision when the provider refresh fails", async () => {
+		const marker = makeStateStore();
+		const notice = await runStartupCredentialAutoImportIfNeeded({
+			authStorage: authStorage([inserted()]).authStorage as never,
+			modelRegistry: {
+				refresh: async () => {
+					throw new Error("refresh failed");
+				},
+			} as never,
+			discover: async () => discovery([oauthCredential()]),
+			stateStore: marker.stateStore,
+		});
+		expect(marker.resolution).toBe("accepted");
+		expect(notice).toContain(CREDENTIAL_AUTO_IMPORT_REFRESH_WARNING);
 	});
 });
 
+describe("credential auto-import state classification and compatibility", () => {
+	const temporaryAgentDirs: string[] = [];
+
+	afterEach(async () => {
+		await Promise.all(
+			temporaryAgentDirs.splice(0).map(agentDir => fs.rm(agentDir, { recursive: true, force: true })),
+		);
+	});
+
+	async function createTemporaryAgentDir(): Promise<string> {
+		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-credential-auto-import-"));
+		temporaryAgentDirs.push(agentDir);
+		return agentDir;
+	}
+
+	function createWriteTransactionBarrier(): {
+		dependencies: CredentialAutoImportStateStoreDependencies;
+		firstEntered: Promise<void>;
+		secondEntered: Promise<void>;
+		releaseNext: () => Promise<void>;
+	} {
+		const firstEntered = Promise.withResolvers<void>();
+		const secondEntered = Promise.withResolvers<void>();
+		const queued: Array<() => Promise<void>> = [];
+		let entries = 0;
+		const dependencies: CredentialAutoImportStateStoreDependencies = {
+			withFileLock: async <T>(_statePath: string, transaction: () => Promise<T>): Promise<T> => {
+				const result = Promise.withResolvers<T>();
+				queued.push(async () => {
+					try {
+						result.resolve(await transaction());
+					} catch (error) {
+						result.reject(error);
+					}
+				});
+				entries += 1;
+				if (entries === 1) firstEntered.resolve();
+				if (entries === 2) secondEntered.resolve();
+				return result.promise;
+			},
+		};
+		return {
+			dependencies,
+			firstEntered: firstEntered.promise,
+			secondEntered: secondEntered.promise,
+			releaseNext: async () => {
+				const transaction = queued.shift();
+				if (!transaction) throw new Error("No queued state transaction");
+				await transaction();
+			},
+		};
+	}
+
+	async function writeStateTransactionsInOrder(
+		agentDir: string,
+		firstMutation: CredentialAutoImportStateMutation,
+		secondMutation: CredentialAutoImportStateMutation,
+	): Promise<[boolean, boolean]> {
+		const barrier = createWriteTransactionBarrier();
+		const firstStore = createCredentialAutoImportStateStore(agentDir, barrier.dependencies);
+		const secondStore = createCredentialAutoImportStateStore(agentDir, barrier.dependencies);
+		const firstWrite = firstStore.write(firstMutation);
+		await barrier.firstEntered;
+		const secondWrite = secondStore.write(secondMutation);
+		await barrier.secondEntered;
+		await barrier.releaseNext();
+		await barrier.releaseNext();
+		const [firstResult, secondResult] = await Promise.all([firstWrite, secondWrite]);
+		return [firstResult, secondResult];
+	}
+
+	test("classifies malformed JSON and non-object state without projecting a resolution", async () => {
+		const agentDir = await createTemporaryAgentDir();
+		const statePath = getCredentialAutoImportStatePath(agentDir);
+		for (const [serialized, problem] of [
+			["{", "malformed-json"],
+			["null", "malformed-root"],
+			["[]", "malformed-root"],
+		] as const) {
+			await fs.writeFile(statePath, serialized);
+			expect(await readCredentialAutoImportState(agentDir)).toEqual({
+				state: {},
+				problems: [problem],
+				unreadable: false,
+			});
+		}
+	});
+
+	test("refuses invalid state mutations without creating a state file", async () => {
+		const agentDir = await createTemporaryAgentDir();
+		const store = createCredentialAutoImportStateStore(agentDir);
+		expect(await store.write({ lastImportVersion: "not a version" })).toBe(false);
+		expect(await store.write({ initialImportResolution: "later" as never })).toBe(false);
+		expect(await fs.readdir(agentDir)).toEqual([]);
+	});
+
+	test("keeps startup discovery behind an injected unreadable state gate", async () => {
+		let reads = 0;
+		let writes = 0;
+		let discoveryReads = 0;
+		const stateStore: CredentialAutoImportStateStore = {
+			read: async () => {
+				reads += 1;
+				return { state: {}, problems: [], unreadable: true };
+			},
+			write: async () => {
+				writes += 1;
+				return true;
+			},
+		};
+		await runStartupCredentialAutoImportIfNeeded({
+			authStorage: { importCredentialIfAbsent: mock(async () => inserted()) },
+			modelRegistry: { refresh: async () => {} } as never,
+			discover: async () => {
+				discoveryReads += 1;
+				return discovery([oauthCredential()]);
+			},
+			stateStore,
+		});
+		expect(reads).toBe(1);
+		expect(writes).toBe(0);
+		expect(discoveryReads).toBe(0);
+	});
+
+	test("writes state through a mode-restricted temporary file and removes it after atomic replacement", async () => {
+		const rootDir = await createTemporaryAgentDir();
+		const agentDir = path.join(rootDir, "state");
+		const statePath = getCredentialAutoImportStatePath(agentDir);
+		expect(await createCredentialAutoImportStateStore(agentDir).write({ initialImportResolution: "accepted" })).toBe(
+			true,
+		);
+		expect((await fs.stat(agentDir)).mode & 0o777).toBe(0o700);
+		expect((await fs.stat(statePath)).mode & 0o777).toBe(0o600);
+		expect((await fs.readdir(agentDir)).filter(entry => entry.includes(".tmp."))).toEqual([]);
+	});
+
+	test("keeps durable state and removes the temporary file when atomic replacement fails", async () => {
+		const agentDir = await createTemporaryAgentDir();
+		const statePath = getCredentialAutoImportStatePath(agentDir);
+		const durableBytes = '{"initialImportResolution":"declined"}\n';
+		const errorSentinel = "ATOMIC_WRITE_FAILURE_SENTINEL";
+		await fs.writeFile(statePath, durableBytes);
+		const warning = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const store = createCredentialAutoImportStateStore(agentDir, {
+				rename: async () => {
+					throw new Error(errorSentinel);
+				},
+			});
+			expect(await store.write({ lastImportVersion: "1.2.3" })).toBe(false);
+			expect(await fs.readFile(statePath, "utf-8")).toBe(durableBytes);
+			expect((await fs.readdir(agentDir)).filter(entry => entry.includes(".tmp."))).toEqual([]);
+			expect(warning).toHaveBeenCalledWith("Credential auto-import state persistence failed", {
+				classification: "state-write-failed",
+			});
+			expect(JSON.stringify(warning.mock.calls)).not.toContain(errorSentinel);
+		} finally {
+			warning.mockRestore();
+		}
+	});
+
+	test("uses the normal-read projection inside the lock transaction", async () => {
+		const agentDir = await createTemporaryAgentDir();
+		const statePath = getCredentialAutoImportStatePath(agentDir);
+		await fs.writeFile(statePath, '{"initialImportResolution":"later","lastImportVersion":"1.2.3"}\n');
+		const store = createCredentialAutoImportStateStore(agentDir);
+		expect(await store.read()).toEqual({
+			state: { lastImportVersion: "1.2.3" },
+			problems: ["invalid-initial-import-resolution"],
+			unreadable: false,
+		});
+		expect(await store.write({ initialImportResolution: "accepted" })).toBe(true);
+		expect(await fs.readFile(statePath, "utf-8")).toBe(
+			'{"lastImportVersion":"1.2.3","initialImportResolution":"accepted"}\n',
+		);
+	});
+
+	test("projects valid canonical resolution independently and repairs an invalid marker sibling", async () => {
+		const agentDir = await createTemporaryAgentDir();
+		const statePath = getCredentialAutoImportStatePath(agentDir);
+		await fs.writeFile(statePath, '{"ignored":true,"initialImportResolution":"declined","lastImportVersion":7}\n');
+
+		const initialRead = await readCredentialAutoImportState(agentDir);
+		expect(initialRead.state).toEqual({ initialImportResolution: "declined" });
+		expect(initialRead.problems).toEqual(["invalid-last-import-version"]);
+
+		const store = createCredentialAutoImportStateStore(agentDir);
+		expect(await store.write({ lastImportVersion: "1.2.3" })).toBe(true);
+		expect(await fs.readFile(statePath, "utf-8")).toBe(
+			'{"lastImportVersion":"1.2.3","initialImportResolution":"declined"}\n',
+		);
+	});
+
+	test("keeps a valid marker when the canonical sibling is invalid and replaces it with the first terminal resolution", async () => {
+		const agentDir = await createTemporaryAgentDir();
+		const statePath = getCredentialAutoImportStatePath(agentDir);
+		await fs.writeFile(statePath, '{"initialImportResolution":"later","lastImportVersion":"1.2.3"}\n');
+
+		const initialRead = await readCredentialAutoImportState(agentDir);
+		expect(initialRead.state).toEqual({ lastImportVersion: "1.2.3" });
+		expect(initialRead.problems).toEqual(["invalid-initial-import-resolution"]);
+
+		const store = createCredentialAutoImportStateStore(agentDir);
+		expect(await store.write({ initialImportResolution: "accepted" })).toBe(true);
+		expect(await readCredentialAutoImportState(agentDir)).toEqual({
+			state: { lastImportVersion: "1.2.3", initialImportResolution: "accepted" },
+			problems: [],
+			unreadable: false,
+		});
+	});
+
+	for (const { label, first, second, expectedBytes } of [
+		{
+			label: "accepted before declined",
+			first: "accepted",
+			second: "declined",
+			expectedBytes: '{"initialImportResolution":"accepted"}\n',
+		},
+		{
+			label: "declined before accepted",
+			first: "declined",
+			second: "accepted",
+			expectedBytes: '{"initialImportResolution":"declined"}\n',
+		},
+	] as const) {
+		test(`preserves the first terminal resolution with barrier-controlled ${label} writers`, async () => {
+			const agentDir = await createTemporaryAgentDir();
+			expect(
+				await writeStateTransactionsInOrder(
+					agentDir,
+					{ initialImportResolution: first },
+					{ initialImportResolution: second },
+				),
+			).toEqual([true, true]);
+			expect(await fs.readFile(getCredentialAutoImportStatePath(agentDir), "utf-8")).toBe(expectedBytes);
+		});
+	}
+
+	for (const { label, first, second } of [
+		{
+			label: "marker before resolution",
+			first: { lastImportVersion: "1.2.3" },
+			second: { initialImportResolution: "declined" },
+		},
+		{
+			label: "resolution before marker",
+			first: { initialImportResolution: "declined" },
+			second: { lastImportVersion: "1.2.3" },
+		},
+	] as const) {
+		test(`merges marker and terminal resolution with barrier-controlled ${label} writers`, async () => {
+			const agentDir = await createTemporaryAgentDir();
+			expect(await writeStateTransactionsInOrder(agentDir, first, second)).toEqual([true, true]);
+			expect(await fs.readFile(getCredentialAutoImportStatePath(agentDir), "utf-8")).toBe(
+				'{"lastImportVersion":"1.2.3","initialImportResolution":"declined"}\n',
+			);
+		});
+	}
+
+	test("accepted and declined real state suppress restart discovery", async () => {
+		const acceptedAgentDir = await createTemporaryAgentDir();
+		let acceptedDiscoveryReads = 0;
+		const acceptedAuthStorage = {
+			importCredentialIfAbsent: async () => skipped(),
+		};
+		const acceptedDiscover = async () => {
+			acceptedDiscoveryReads += 1;
+			return discovery([oauthCredential()]);
+		};
+		await runStartupCredentialAutoImportIfNeeded({
+			authStorage: acceptedAuthStorage as never,
+			modelRegistry: { refresh: async () => {} } as never,
+			discover: acceptedDiscover,
+			version: "1.2.3",
+			agentDir: acceptedAgentDir,
+		});
+		await runStartupCredentialAutoImportIfNeeded({
+			authStorage: acceptedAuthStorage as never,
+			modelRegistry: { refresh: async () => {} } as never,
+			discover: acceptedDiscover,
+			version: "1.2.4",
+			agentDir: acceptedAgentDir,
+		});
+		expect(acceptedDiscoveryReads).toBe(1);
+
+		const declinedAgentDir = await createTemporaryAgentDir();
+		const declinedStore = createCredentialAutoImportStateStore(declinedAgentDir);
+		expect(await declinedStore.write({ initialImportResolution: "declined" })).toBe(true);
+		let declinedDiscoveryReads = 0;
+		await runStartupCredentialAutoImportIfNeeded({
+			authStorage: acceptedAuthStorage as never,
+			modelRegistry: { refresh: async () => {} } as never,
+			discover: async () => {
+				declinedDiscoveryReads += 1;
+				return discovery([oauthCredential()]);
+			},
+			version: "1.2.3",
+			agentDir: declinedAgentDir,
+		});
+		expect(declinedDiscoveryReads).toBe(0);
+	});
+
+	for (const { label, serialized } of [
+		{
+			label: "canonical-valid marker-invalid",
+			serialized: '{"initialImportResolution":"accepted","lastImportVersion":"later"}\n',
+		},
+		{
+			label: "marker-valid canonical-invalid",
+			serialized: `{"initialImportResolution":"later","lastImportVersion":"${VERSION}"}\n`,
+		},
+	] as const) {
+		test(`startup skips discovery for ${label} state projection`, async () => {
+			const agentDir = await createTemporaryAgentDir();
+			const statePath = getCredentialAutoImportStatePath(agentDir);
+			let discoveryReads = 0;
+			await fs.writeFile(statePath, serialized);
+			await runStartupCredentialAutoImportIfNeeded({
+				authStorage: { importCredentialIfAbsent: async () => inserted() },
+				modelRegistry: { refresh: async () => {} } as never,
+				discover: async () => {
+					discoveryReads += 1;
+					return discovery([oauthCredential()]);
+				},
+				agentDir,
+			});
+			expect(discoveryReads).toBe(0);
+			expect(await fs.readFile(statePath, "utf-8")).toBe(serialized);
+		});
+	}
+});
 describe("setup credentials keychain and preview behavior", () => {
 	let stdout = "";
 	let exitCode: string | number | undefined | null;
@@ -353,16 +810,54 @@ describe("setup credentials keychain and preview behavior", () => {
 });
 
 describe("bare /login external credential import gate", () => {
-	function createControllerHarness(args: { confirm: boolean; importOutcome?: AuthCredentialIfAbsentSnapshotResult }) {
+	function inMemoryStateStore(initial: CredentialAutoImportStateFile = {}) {
+		const state: CredentialAutoImportStateFile = { ...initial };
+		const writes: CredentialAutoImportStateFile[] = [];
+		const stateStore: CredentialAutoImportStateStore = {
+			read: async () => ({ state: { ...state }, problems: [], unreadable: false }),
+			write: async mutation => {
+				if (mutation.lastImportVersion !== undefined) state.lastImportVersion = mutation.lastImportVersion;
+				if (state.initialImportResolution === undefined && mutation.initialImportResolution !== undefined) {
+					state.initialImportResolution = mutation.initialImportResolution;
+				}
+				writes.push({ ...state });
+				return true;
+			},
+		};
+		return { state, stateStore, writes };
+	}
+	function createControllerHarness(
+		args: {
+			confirm: boolean;
+			importOutcome?: AuthCredentialIfAbsentSnapshotResult;
+			importOutcomes?: Array<AuthCredentialIfAbsentSnapshotResult | Error>;
+			onImport?: () => void;
+			onRequestRender?: () => void;
+			agentDir?: string;
+		},
+		stateStore?: CredentialAutoImportStateStore,
+	) {
 		installTestTheme();
 		const importCalls: string[] = [];
 		const refreshCalls: string[] = [];
 		const confirmMessages: Array<{ title: string; message: string }> = [];
+		const warnings: string[] = [];
+		const statuses: string[] = [];
+		const settingsReads: string[] = [];
+		const editorContainer = new Container();
 		const ctx = {
-			ui: { setFocus: mock(() => {}), requestRender: mock(() => {}) },
-			editorContainer: new Container(),
+			ui: { setFocus: mock(() => {}), requestRender: mock(() => args.onRequestRender?.()) },
+			editorContainer,
 			editor: new Container(),
 			chatContainer: new Container(),
+			settings: {
+				getAgentDir: () => {
+					settingsReads.push("read");
+					return args.agentDir ?? path.join(os.tmpdir(), "gjc-credential-auto-import-controller");
+				},
+			},
+			showWarning: (message: string) => warnings.push(message),
+			showStatus: (message: string) => statuses.push(message),
 			showHookConfirm: mock(async (title: string, message: string) => {
 				confirmMessages.push({ title, message });
 				return args.confirm;
@@ -375,53 +870,412 @@ describe("bare /login external credential import gate", () => {
 						hasAuth: () => false,
 						importCredentialIfAbsent: async (provider: string) => {
 							importCalls.push(provider);
-							return args.importOutcome ?? inserted(provider);
+							const outcome = args.importOutcomes?.shift() ?? args.importOutcome ?? inserted(provider);
+							if (outcome instanceof Error) throw outcome;
+							args.onImport?.();
+							return outcome;
 						},
 					},
 					getApiKeyForProvider: mock(async () => undefined),
 				},
 			},
 		} as never;
-		return { controller: new SelectorController(ctx), importCalls, refreshCalls, confirmMessages };
+		return {
+			controller: new SelectorController(ctx, stateStore),
+			importCalls,
+			refreshCalls,
+			confirmMessages,
+			editorContainer,
+			settingsReads,
+			statuses,
+			warnings,
+		};
 	}
 
-	function bareLoginOptions() {
+	function bareLoginOptions(result: CredentialDiscoveryResult = discovery([oauthCredential()])) {
 		return {
 			allowExternalCredentialDiscovery: true,
 			trigger: "bare-login" as const,
-			externalCredentialDiscover: async () => discovery([oauthCredential()]),
+			externalCredentialDiscover: async () => result,
 		};
 	}
 
 	test("bare /login shows rotation warning before persisting imported OAuth credentials", async () => {
-		const harness = createControllerHarness({ confirm: true });
+		const state = inMemoryStateStore();
+		const harness = createControllerHarness({ confirm: true }, state.stateStore);
 
 		await harness.controller.showOAuthSelector("login", undefined, bareLoginOptions());
 
 		expect(harness.confirmMessages).toHaveLength(1);
-		expect(harness.confirmMessages[0]?.message).toContain("Claude Code (test)");
+		expect(harness.confirmMessages[0]?.message).toContain("Claude (Anthropic) · Claude Code file: 1");
+		expect(harness.confirmMessages[0]?.message).not.toContain("Claude Code (test)");
+		expect(harness.confirmMessages[0]?.message).not.toContain(oauthCredential().redactedToken);
 		expect(harness.confirmMessages[0]?.message).toContain(CREDENTIAL_AUTO_IMPORT_ROTATION_WARNING);
 		expect(harness.importCalls).toEqual(["anthropic"]);
 		expect(harness.refreshCalls).toEqual(["offline"]);
+		expect(state.state.initialImportResolution).toBe("accepted");
 	});
 
-	test("declining bare /login import does not persist discovered credentials", async () => {
-		const harness = createControllerHarness({ confirm: false });
+	test("declining bare /login import persists a permanent decline without importing credentials", async () => {
+		const state = inMemoryStateStore();
+		const harness = createControllerHarness({ confirm: false }, state.stateStore);
 
 		await harness.controller.showOAuthSelector("login", undefined, bareLoginOptions());
 
 		expect(harness.confirmMessages).toHaveLength(1);
 		expect(harness.importCalls).toEqual([]);
 		expect(harness.refreshCalls).toEqual([]);
+		expect(state.state.initialImportResolution).toBe("declined");
 	});
 
 	test("confirmed bare /login import remains idempotent when credential already exists", async () => {
-		const harness = createControllerHarness({ confirm: true, importOutcome: skipped() });
+		const harness = createControllerHarness(
+			{ confirm: true, importOutcome: skipped() },
+			inMemoryStateStore().stateStore,
+		);
 
 		await harness.controller.showOAuthSelector("login", undefined, bareLoginOptions());
 
 		expect(harness.confirmMessages).toHaveLength(1);
 		expect(harness.importCalls).toEqual(["anthropic"]);
 		expect(harness.refreshCalls).toEqual([]);
+	});
+
+	test("bare /login leaves canonical state unresolved when every accepted credential write fails", async () => {
+		const errorSentinel = "LOGIN_ALL_WRITES_FAILED_SENTINEL";
+		const state = inMemoryStateStore();
+		const warning = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const harness = createControllerHarness(
+				{ confirm: true, importOutcomes: [new Error(`write conflict ${errorSentinel}`)] },
+				state.stateStore,
+			);
+			let discoveryReads = 0;
+			await harness.controller.showOAuthSelector("login", undefined, {
+				...bareLoginOptions(),
+				externalCredentialDiscover: async () => {
+					discoveryReads += 1;
+					return discovery([oauthCredential()]);
+				},
+			});
+			expect(discoveryReads).toBe(2);
+			expect(harness.importCalls).toEqual(["anthropic"]);
+			expect(state.writes).toEqual([]);
+			expect(state.state).toEqual({});
+			expect(harness.warnings).toEqual([CREDENTIAL_AUTO_IMPORT_RETRY_WARNING]);
+			expect(harness.editorContainer.children).toHaveLength(1);
+			expect(warning).toHaveBeenCalledWith("Credential auto-import completed with failures", {
+				trigger: "bare-login",
+				failureCounts: { "write-conflict": 1 },
+			});
+			const visible = JSON.stringify({
+				logs: warning.mock.calls,
+				confirmMessages: harness.confirmMessages,
+				warnings: harness.warnings,
+				statuses: harness.statuses,
+			});
+			expect(visible).not.toContain(errorSentinel);
+		} finally {
+			warning.mockRestore();
+		}
+	});
+
+	test("bare /login leaves canonical state unresolved when the accepted second scan fails globally", async () => {
+		const errorSentinel = "LOGIN_SECOND_SCAN_FAILURE_SENTINEL";
+		const state = inMemoryStateStore();
+		const warning = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const harness = createControllerHarness({ confirm: true }, state.stateStore);
+			let discoveryReads = 0;
+			await harness.controller.showOAuthSelector("login", undefined, {
+				...bareLoginOptions(),
+				externalCredentialDiscover: async () => {
+					discoveryReads += 1;
+					if (discoveryReads === 2) throw new Error(`second scan failed ${errorSentinel}`);
+					return discovery([oauthCredential()]);
+				},
+			});
+			expect(discoveryReads).toBe(2);
+			expect(harness.importCalls).toEqual([]);
+			expect(state.writes).toEqual([]);
+			expect(state.state).toEqual({});
+			expect(harness.warnings).toEqual([CREDENTIAL_AUTO_IMPORT_RETRY_WARNING]);
+			expect(harness.editorContainer.children).toHaveLength(1);
+			expect(warning).toHaveBeenCalledWith("Credential auto-import completed with failures", {
+				trigger: "bare-login",
+				failureCounts: { "discovery-unavailable": 1 },
+			});
+			const visible = JSON.stringify({
+				logs: warning.mock.calls,
+				confirmMessages: harness.confirmMessages,
+				warnings: harness.warnings,
+				statuses: harness.statuses,
+			});
+			expect(visible).not.toContain(errorSentinel);
+		} finally {
+			warning.mockRestore();
+		}
+	});
+
+	test("bare /login keeps accepted state and exposes only bounded mixed failure evidence", async () => {
+		const sourceSentinel = "LOGIN_SOURCE_SENTINEL";
+		const reasonSentinel = "LOGIN_REASON_SENTINEL";
+		const environmentSentinel = "LOGIN_ENVIRONMENT_SENTINEL";
+		const errorSentinel = "LOGIN_ERROR_SENTINEL";
+		const result: CredentialDiscoveryResult = {
+			importable: [
+				oauthCredential({ source: sourceSentinel }),
+				oauthCredential({ provider: "openai-codex", origin: "codex-file", source: sourceSentinel }),
+				oauthCredential({ source: sourceSentinel }),
+			],
+			skipped: [{ origin: "claude-code-file", source: sourceSentinel, reason: `unreadable ${reasonSentinel}` }],
+			environment: [{ provider: "anthropic", variable: environmentSentinel, redactedValue: environmentSentinel }],
+		};
+		const state = inMemoryStateStore();
+		const warning = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const harness = createControllerHarness(
+				{
+					confirm: true,
+					importOutcomes: [
+						inserted("anthropic"),
+						skipped("openai-codex"),
+						new Error(`write conflict ${errorSentinel}`),
+					],
+				},
+				state.stateStore,
+			);
+			await harness.controller.showOAuthSelector("login", undefined, bareLoginOptions(result));
+			expect(state.state.initialImportResolution).toBe("accepted");
+			expect(harness.importCalls).toEqual(["anthropic", "openai-codex", "anthropic"]);
+			expect(harness.warnings).toEqual([CREDENTIAL_AUTO_IMPORT_RETRY_WARNING]);
+			expect(warning).toHaveBeenCalledWith("Credential auto-import completed with failures", {
+				trigger: "bare-login",
+				failureCounts: { "source-unreadable": 1, "write-conflict": 1 },
+			});
+			const visible = JSON.stringify({
+				state: state.state,
+				logs: warning.mock.calls,
+				confirmMessages: harness.confirmMessages,
+				warnings: harness.warnings,
+				statuses: harness.statuses,
+			});
+			for (const sentinel of [sourceSentinel, reasonSentinel, environmentSentinel, errorSentinel]) {
+				expect(visible).not.toContain(sentinel);
+			}
+		} finally {
+			warning.mockRestore();
+		}
+	});
+
+	test("resolved and same-version legacy state suppress bare /login discovery before preview", async () => {
+		for (const initialState of [
+			{ initialImportResolution: "accepted" as const },
+			{ initialImportResolution: "declined" as const },
+			{ lastImportVersion: VERSION },
+		]) {
+			const state = inMemoryStateStore(initialState);
+			const harness = createControllerHarness({ confirm: true }, state.stateStore);
+			let discoveryReads = 0;
+			await harness.controller.showOAuthSelector("login", undefined, {
+				...bareLoginOptions(),
+				externalCredentialDiscover: async () => {
+					discoveryReads += 1;
+					return discovery([oauthCredential()]);
+				},
+			});
+			expect(discoveryReads).toBe(0);
+			expect(harness.confirmMessages).toHaveLength(0);
+		}
+	});
+
+	test("bare /login reads resolved state from the configured agent directory", async () => {
+		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-credential-auto-import-controller-"));
+		try {
+			await createCredentialAutoImportStateStore(agentDir).write({ initialImportResolution: "declined" });
+			const harness = createControllerHarness({ confirm: true, agentDir });
+			let discoveryReads = 0;
+			await harness.controller.showOAuthSelector("login", undefined, {
+				...bareLoginOptions(),
+				externalCredentialDiscover: async () => {
+					discoveryReads += 1;
+					return discovery();
+				},
+			});
+			expect(harness.settingsReads).toEqual(["read"]);
+			expect(discoveryReads).toBe(0);
+			expect(harness.confirmMessages).toHaveLength(0);
+		} finally {
+			await fs.rm(agentDir, { recursive: true, force: true });
+		}
+	});
+
+	for (const { label, serialized } of [
+		{
+			label: "canonical-valid marker-invalid",
+			serialized: '{"initialImportResolution":"accepted","lastImportVersion":"later"}\n',
+		},
+		{
+			label: "marker-valid canonical-invalid",
+			serialized: `{"initialImportResolution":"later","lastImportVersion":"${VERSION}"}\n`,
+		},
+	] as const) {
+		test(`bare /login skips discovery for ${label} state projection`, async () => {
+			const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-credential-auto-import-controller-"));
+			const statePath = getCredentialAutoImportStatePath(agentDir);
+			try {
+				await fs.writeFile(statePath, serialized);
+				const harness = createControllerHarness({ confirm: true, agentDir });
+				let discoveryReads = 0;
+				await harness.controller.showOAuthSelector("login", undefined, {
+					...bareLoginOptions(),
+					externalCredentialDiscover: async () => {
+						discoveryReads += 1;
+						return discovery([oauthCredential()]);
+					},
+				});
+				expect(harness.settingsReads).toEqual(["read"]);
+				expect(discoveryReads).toBe(0);
+				expect(harness.confirmMessages).toHaveLength(0);
+				expect(await fs.readFile(statePath, "utf-8")).toBe(serialized);
+			} finally {
+				await fs.rm(agentDir, { recursive: true, force: true });
+			}
+		});
+	}
+
+	test("persists accepted and declined across controller restart with real state I/O", async () => {
+		for (const [resolution, confirm] of [
+			["accepted", true],
+			["declined", false],
+		] as const) {
+			const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-credential-auto-import-controller-"));
+			try {
+				let firstDiscoveryReads = 0;
+				const first = createControllerHarness({ confirm, agentDir });
+				await first.controller.showOAuthSelector("login", undefined, {
+					...bareLoginOptions(),
+					externalCredentialDiscover: async () => {
+						firstDiscoveryReads += 1;
+						return discovery([oauthCredential()]);
+					},
+				});
+				expect(first.settingsReads).toEqual(["read"]);
+				expect(firstDiscoveryReads).toBe(confirm ? 2 : 1);
+				expect(await readCredentialAutoImportState(agentDir)).toEqual({
+					state: { initialImportResolution: resolution },
+					problems: [],
+					unreadable: false,
+				});
+
+				let restartDiscoveryReads = 0;
+				const restarted = createControllerHarness({ confirm: true, agentDir });
+				await restarted.controller.showOAuthSelector("login", undefined, {
+					...bareLoginOptions(),
+					externalCredentialDiscover: async () => {
+						restartDiscoveryReads += 1;
+						return discovery([oauthCredential()]);
+					},
+				});
+				expect(restarted.settingsReads).toEqual(["read"]);
+				expect(restartDiscoveryReads).toBe(0);
+				expect(restarted.confirmMessages).toEqual([]);
+				expect(restarted.importCalls).toEqual([]);
+			} finally {
+				await fs.rm(agentDir, { recursive: true, force: true });
+			}
+		}
+	});
+
+	test("old legacy marker remains eligible and failed persistence re-offers after a real-state restart", async () => {
+		const oldMarker = inMemoryStateStore({ lastImportVersion: "0.0.1" });
+		const oldMarkerHarness = createControllerHarness({ confirm: false }, oldMarker.stateStore);
+		await oldMarkerHarness.controller.showOAuthSelector("login", undefined, bareLoginOptions());
+		expect(oldMarkerHarness.confirmMessages).toHaveLength(1);
+
+		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-credential-auto-import-controller-"));
+		try {
+			const realStateStore = createCredentialAutoImportStateStore(agentDir);
+			let writes = 0;
+			const failingStateStore: CredentialAutoImportStateStore = {
+				read: realStateStore.read,
+				write: async () => {
+					writes += 1;
+					return false;
+				},
+			};
+			const first = createControllerHarness({ confirm: false, agentDir }, failingStateStore);
+			await first.controller.showOAuthSelector("login", undefined, bareLoginOptions());
+			expect(writes).toBe(1);
+			expect(first.warnings).toEqual([CREDENTIAL_AUTO_IMPORT_PERSISTENCE_WARNING]);
+			expect(await readCredentialAutoImportState(agentDir)).toEqual({ state: {}, problems: [], unreadable: false });
+
+			let retryDiscoveryReads = 0;
+			const restarted = createControllerHarness({ confirm: false, agentDir }, failingStateStore);
+			await restarted.controller.showOAuthSelector("login", undefined, {
+				...bareLoginOptions(),
+				externalCredentialDiscover: async () => {
+					retryDiscoveryReads += 1;
+					return discovery([oauthCredential()]);
+				},
+			});
+			expect(retryDiscoveryReads).toBe(1);
+			expect(restarted.confirmMessages).toHaveLength(1);
+		} finally {
+			await fs.rm(agentDir, { recursive: true, force: true });
+		}
+	});
+
+	test("explicit provider credential import bypasses automatic import state after the final render", async () => {
+		let discoveryReads = 0;
+		const { promise: importCompleted, resolve: resolveImport } = Promise.withResolvers<void>();
+		const discoverSpy = spyOn(credentialImport, "discoverExternalCredentials").mockImplementation(async () => {
+			discoveryReads += 1;
+			return discovery([oauthCredential()]);
+		});
+		let stateReads = 0;
+		let stateWrites = 0;
+		const stateStore: CredentialAutoImportStateStore = {
+			read: async () => {
+				stateReads += 1;
+				return { state: {}, problems: [], unreadable: false };
+			},
+			write: async () => {
+				stateWrites += 1;
+				return true;
+			},
+		};
+		let importStarted = false;
+		try {
+			const harness = createControllerHarness(
+				{
+					confirm: true,
+					onImport: () => {
+						importStarted = true;
+					},
+					onRequestRender: () => {
+						if (importStarted) resolveImport();
+					},
+				},
+				stateStore,
+			);
+			harness.controller.showProviderOnboarding();
+			const selector = harness.editorContainer.children[0];
+			if (!(selector instanceof ProviderOnboardingSelectorComponent)) {
+				throw new Error("Expected provider onboarding selector");
+			}
+			selector.handleInput("\x1b[B");
+			selector.handleInput("\x1b[B");
+			selector.handleInput("\x1b[B");
+			selector.handleInput("\n");
+			await importCompleted;
+			expect(discoveryReads).toBe(2);
+			expect(harness.importCalls).toEqual(["anthropic"]);
+			expect(stateReads).toBe(0);
+			expect(stateWrites).toBe(0);
+			expect(harness.settingsReads).toEqual([]);
+		} finally {
+			discoverSpy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- persist accepted or declined initial external credential-import decisions in the agent directory
- suppress repeated startup and bare `/login` discovery across restarts/upgrades while preserving legacy same-version markers
- keep explicit `/provider` credential import reachable and fail safely on unreadable or unwritable state

## Verification
- `bun test packages/coding-agent/test/credential-auto-import-flows.test.ts` (46 pass)
- `bun test ./packages/coding-agent/test/credential-import.test.ts ./packages/coding-agent/test/slash-command-builtin-registry.test.ts ./packages/coding-agent/test/main-interactive-input.test.ts` (58 pass)
- `bun run check:types` in `packages/coding-agent` (pass)
- `bunx biome check` on the changed TypeScript files (pass)
- exact-head architect review: CLEAR, shippable

## Additional check
- repository-wide `bun run check:ts` reached an unrelated existing SDK native fixture failure: `sdk-acp-two-client-race.test.ts` reports `server.onSdkFrame is not a function`

Closes #2117

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*