### PR TITLE
fix(telegram): reap orphan topics from vanished roots

### DIFF
--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -1705,16 +1705,36 @@ export class TelegramNotificationDaemon {
 
 	async scanRoots(): Promise<void> {
 		const paths = daemonPaths(this.opts.settings.getAgentDir());
-		const rootState = await readJson<{ roots?: string[] }>(this.fsImpl, paths.roots);
+		const rootState = await readJson<{ roots?: string[]; sessions?: Record<string, string> }>(
+			this.fsImpl,
+			paths.roots,
+		);
 		const endpointSessionIds = new Set<string>();
+		const missingRoots = new Set<string>();
 		let allRootsReadable = true;
 		for (const root of rootState?.roots ?? []) {
 			const dir = path.join(root, "sdk");
 			let files: string[];
 			try {
 				files = await this.fsImpl.readdir(dir);
-			} catch {
-				allRootsReadable = false;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+					allRootsReadable = false;
+					continue;
+				}
+				// A missing endpoint directory is conclusive only when its registered
+				// root is also gone. A live root may be between registration and
+				// endpoint publication, so keep it and block global orphan cleanup.
+				try {
+					await this.fsImpl.readdir(root);
+					allRootsReadable = false;
+				} catch (rootError) {
+					if ((rootError as NodeJS.ErrnoException).code === "ENOENT") {
+						missingRoots.add(root);
+					} else {
+						allRootsReadable = false;
+					}
+				}
 				continue;
 			}
 			for (const file of files.filter(item => item.endsWith(".json"))) {
@@ -1739,6 +1759,53 @@ export class TelegramNotificationDaemon {
 					this.connectSession(sessionId, endpoint.url, endpoint.token);
 				} catch {}
 			}
+		}
+		if (missingRoots.size > 0) {
+			await withFileLock(
+				paths.roots,
+				async () => {
+					const current = await readJson<{ roots?: string[]; sessions?: Record<string, string> }>(
+						this.fsImpl,
+						paths.roots,
+					);
+					// The registry vanished after the scan; stale in-memory roots are
+					// not authority to compact or delete topics in this cycle.
+					if (!current) {
+						allRootsReadable = false;
+						return;
+					}
+					const confirmedMissing = new Set<string>();
+					for (const root of current.roots ?? []) {
+						if (!missingRoots.has(root)) continue;
+						try {
+							await this.fsImpl.readdir(root);
+							// The root returned after the scan. Preserve its registration
+							// and suppress orphan deletion because its endpoints were missed.
+							allRootsReadable = false;
+						} catch (error) {
+							if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+								confirmedMissing.add(root);
+							} else {
+								allRootsReadable = false;
+							}
+						}
+					}
+					if (confirmedMissing.size === 0) return;
+					const sessions = Object.fromEntries(
+						Object.entries(current.sessions ?? {}).filter(([, root]) => !confirmedMissing.has(root)),
+					);
+					await writeJsonAtomic(this.fsImpl, paths.roots, {
+						...current,
+						version: 1,
+						roots: (current.roots ?? []).filter(root => !confirmedMissing.has(root)),
+						sessions,
+					});
+				},
+				{ staleMs: 10_000 },
+			).catch(error => {
+				allRootsReadable = false;
+				logger.warn(`notifications: failed to compact missing Telegram roots: ${String(error)}`);
+			});
 		}
 		if (allRootsReadable) {
 			for (const sessionId of this.topics.sessionIds()) {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -4350,7 +4350,7 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 	expect(daemon.sessions.size).toBe(0);
 });
 
-test("scanRoots reaps missing endpoint topics only when all roots are readable and grace has elapsed", async () => {
+test("scanRoots reaps missing endpoint topics when live roots are empty or registered roots vanished", async () => {
 	const agentDir = tempAgentDir();
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
 	const cwd = path.join(agentDir, "repo");
@@ -4376,15 +4376,30 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 
 	const blockedAgentDir = tempAgentDir();
 	const blockedSettings = setPrivateAgentDir(settings(blockedAgentDir), blockedAgentDir);
-	await registerNotificationRoot({
+	const vanishedRoot = await registerNotificationRoot({
 		settings: blockedSettings,
-		cwd: path.join(blockedAgentDir, "unreadable"),
+		cwd: path.join(blockedAgentDir, "vanished"),
 		sessionId: "kept",
 	});
+	const liveRoot = await registerNotificationRoot({
+		settings: blockedSettings,
+		cwd: path.join(blockedAgentDir, "live"),
+		sessionId: "live",
+	});
+	fs.mkdirSync(path.join(liveRoot, "sdk"), { recursive: true });
+	fs.writeFileSync(
+		path.join(liveRoot, "sdk", "live.json"),
+		JSON.stringify({ url: "ws://live", token: "live-token", pid: 4242 }),
+	);
 	fs.mkdirSync(daemonPaths(blockedAgentDir).dir, { recursive: true });
 	fs.writeFileSync(
 		path.join(daemonPaths(blockedAgentDir).dir, "telegram-topics.json"),
-		JSON.stringify({ topics: { kept: { topicId: "202", identitySent: true, createdAt: 0, name: "kept" } } }),
+		JSON.stringify({
+			topics: {
+				kept: { topicId: "202", identitySent: true, createdAt: 0, name: "kept" },
+				live: { topicId: "204", identitySent: true, createdAt: 0, name: "live" },
+			},
+		}),
 	);
 	const blockedBot = new FakeBotApi();
 	const blockedDaemon = new TelegramNotificationDaemon({
@@ -4393,11 +4408,129 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 		botToken: "tok",
 		chatId: "42",
 		botApi: blockedBot,
+		WebSocketImpl: FakeWs as any,
+		pidAlive: pid => pid === 4242,
 		now: () => 120_000,
 	});
 	await blockedDaemon.loadTopics();
 	await blockedDaemon.scanRoots();
-	expect(blockedBot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	expect(blockedDaemon.sessions.has("live")).toBe(true);
+	expect(blockedBot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([
+		202,
+	]);
+	const compacted = JSON.parse(fs.readFileSync(daemonPaths(blockedAgentDir).roots, "utf8")) as {
+		roots: string[];
+		sessions: Record<string, string>;
+	};
+	expect(compacted.roots).toEqual([liveRoot]);
+	expect(compacted.roots).not.toContain(vanishedRoot);
+	expect(compacted.sessions.live).toBe(liveRoot);
+	expect(compacted.sessions.kept).toBeUndefined();
+});
+test.each([
+	"restored",
+	"unreadable",
+	"live",
+	"root-unreadable",
+] as const)("scanRoots preserves a %s root and its topic when absence is not conclusive", async mode => {
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const root = await registerNotificationRoot({
+		settings: s,
+		cwd: path.join(agentDir, "workspace"),
+		sessionId: "kept",
+	});
+	if (mode === "live") fs.mkdirSync(root, { recursive: true });
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+		JSON.stringify({ topics: { kept: { topicId: "203", identitySent: true, createdAt: 0, name: "kept" } } }),
+	);
+	const realFs = topicStateFs(async () => undefined);
+	let rootReads = 0;
+	const fsImpl: TelegramDaemonFs = {
+		...realFs,
+		readdir: async target => {
+			if (target === path.join(root, "sdk")) {
+				throw Object.assign(new Error(mode), { code: mode === "unreadable" ? "EACCES" : "ENOENT" });
+			}
+			if (mode === "root-unreadable" && target === root) {
+				throw Object.assign(new Error(mode), { code: "EACCES" });
+			}
+			if (mode === "restored" && target === root) {
+				rootReads += 1;
+				if (rootReads === 1) throw Object.assign(new Error("missing"), { code: "ENOENT" });
+				fs.mkdirSync(root, { recursive: true });
+				return [];
+			}
+			return realFs.readdir(target);
+		},
+	};
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		fs: fsImpl,
+		now: () => 120_000,
+	});
+	await daemon.loadTopics();
+	await daemon.scanRoots();
+
+	expect(bot.calls.some(call => call.method === "deleteForumTopic")).toBe(false);
+	const registry = JSON.parse(fs.readFileSync(daemonPaths(agentDir).roots, "utf8")) as {
+		roots: string[];
+		sessions: Record<string, string>;
+	};
+	expect(registry.roots).toEqual([root]);
+	expect(registry.sessions.kept).toBe(root);
+	if (mode === "restored") expect(rootReads).toBe(2);
+});
+test("scanRoots keeps topics and registry state when missing-root compaction cannot persist", async () => {
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const root = await registerNotificationRoot({
+		settings: s,
+		cwd: path.join(agentDir, "vanished"),
+		sessionId: "kept",
+	});
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+		JSON.stringify({ topics: { kept: { topicId: "205", identitySent: true, createdAt: 0, name: "kept" } } }),
+	);
+	const realFs = topicStateFs(async () => undefined);
+	const fsImpl: TelegramDaemonFs = {
+		...realFs,
+		rename: async (oldPath, newPath) => {
+			if (newPath === daemonPaths(agentDir).roots) {
+				throw Object.assign(new Error("persist failed"), { code: "EIO" });
+			}
+			await realFs.rename(oldPath, newPath);
+		},
+	};
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		fs: fsImpl,
+		now: () => 120_000,
+	});
+	await daemon.loadTopics();
+	await daemon.scanRoots();
+
+	expect(bot.calls.some(call => call.method === "deleteForumTopic")).toBe(false);
+	const registry = JSON.parse(fs.readFileSync(daemonPaths(agentDir).roots, "utf8")) as {
+		roots: string[];
+		sessions: Record<string, string>;
+	};
+	expect(registry.roots).toEqual([root]);
+	expect(registry.sessions.kept).toBe(root);
 });
 
 test("runDaemonInternal wires SIGTERM to the daemon stop method", async () => {


### PR DESCRIPTION
## Summary

Minimal replacement after the scope feedback on #2201. This patch starts from current `dev` and does **not** carry forward the rejected root/lease/incarnation, authority-journal, crash-replay, quarantine, or provider-uncertainty design.

The root cause is local to `scanRoots()`: one deleted registered root makes `readdir(root/sdk)` throw `ENOENT`, which sets the global `allRootsReadable` flag false and prevents every orphan topic from being considered forever.

This change:

- distinguishes a vanished root from a live root whose `sdk` directory is not published yet
- treats only `sdk ENOENT` + root `ENOENT` as conclusive absence for that root
- re-reads and revalidates missing roots under the same file lock used by `registerNotificationRoot`
- compacts only confirmed-missing roots and their session mappings while preserving live/unrelated entries
- suppresses deletion for EACCES/other uncertainty, a root restored during revalidation, a vanished registry, or compaction I/O failure
- leaves the existing orphan grace window and topic deletion path unchanged

## Scope

- 2 files
- 73 lines of source churn, confined to `TelegramNotificationDaemon.scanRoots()`
- 143 lines of focused tests
- no new files, exports, dependencies, schemas, or public API

## Verification

Review tuple:

- base: `825ea2de656c44435b7402eaaf34c72b2bfd46c2`
- head: `8c315805ace47bdbce0fc6ca162e1f5764a7fcc2`

Observed locally on this exact head:

- `bun run check` — PASS
- `bun test test/notifications-telegram-daemon.test.ts` — 153/153 PASS
- focused six-case root matrix — PASS in 10 consecutive runs
- `bun run ci:test:smoke` — PASS
- `git diff --check` — PASS
- cleaner — PASS, 0 blockers
- architecture/product/code — CLEAR/CLEAR/CLEAR, APPROVE
- adversarial review — PASS, 0 blockers

Focused cases cover: vanished+live roots in one registry, selective root/session compaction and topic deletion, live root with missing `sdk`, sdk/root EACCES, root restoration during locked revalidation, and atomic-persist failure.