### PR TITLE
fix(ci): synchronize wall-clock timeout fixture

### DIFF
--- a/packages/coding-agent/test/task/executor-wall-clock.test.ts
+++ b/packages/coding-agent/test/task/executor-wall-clock.test.ts
@@ -24,11 +24,13 @@ import { EventBus } from "../../src/utils/event-bus";
 interface HangingSessionHandle {
 	session: AgentSession;
 	abortCalls: () => number;
+	promptStarted: Promise<void>;
 }
 
 function createHangingSession(): HangingSessionHandle {
 	let abortCount = 0;
 	const { promise: hang, resolve: releaseHang } = Promise.withResolvers<void>();
+	const { promise: promptStarted, resolve: markPromptStarted } = Promise.withResolvers<void>();
 	const session: Partial<AgentSession> = {
 		state: { messages: [] } as never,
 		agent: { state: { systemPrompt: ["test"] } } as never,
@@ -43,6 +45,7 @@ function createHangingSession(): HangingSessionHandle {
 		seedDefaultFallbackResolution: () => {},
 		subscribe: (_listener: (event: AgentSessionEvent) => void) => () => {},
 		prompt: async (_text: string, _options?: PromptOptions) => {
+			markPromptStarted();
 			await hang;
 		},
 		waitForIdle: async () => {
@@ -58,6 +61,7 @@ function createHangingSession(): HangingSessionHandle {
 	return {
 		session: session as AgentSession,
 		abortCalls: () => abortCount,
+		promptStarted,
 	};
 }
 
@@ -146,6 +150,7 @@ const invalidRawCostCases: ReadonlyArray<{
 
 describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.restoreAllMocks();
 	});
 
@@ -171,16 +176,20 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 	};
 
 	it("aborts a stalled subagent and surfaces a runtime-limit reason", async () => {
+		vi.useFakeTimers();
 		const settings = Settings.isolated({ "task.maxRuntimeMs": 50 });
 		const handle = createHangingSession();
 		mockCreateAgentSession(handle.session);
 
 		const startedAt = Date.now();
-		const result = await runSubprocess({
+		const pending = runSubprocess({
 			...baseOptions,
 			id: "subagent-timeout",
 			settings,
 		});
+		await handle.promptStarted;
+		vi.advanceTimersByTime(50);
+		const result = await pending;
 		const elapsedMs = Date.now() - startedAt;
 
 		expect(result.aborted).toBe(true);


### PR DESCRIPTION
## Summary
- gate the wall-clock timeout assertion on the hanging prompt actually starting
- use fake time so the 50 ms production budget cannot expire during unrelated session setup under CI load
- retain the exact runtime-limit reason, abort invocation, exit code, and bounded-completion assertions

## Root cause
Post-merge Dev CI run `29305360750` at `6fae7cc5475ba85b075608f1e87e6c0cb9e8693d` returned an aborted runtime-limit result while `abortCalls()` was zero. The real 50 ms timer expired during test fixture setup before the hanging session became active, so the assertion tested the setup-timeout branch instead of the intended stalled-prompt abort branch.

## Verification
- focused case: 50/50, then 20/20 on refreshed current dev
- full file: 32 pass
- current shard 2/8: 1312 pass, 36 skip, 0 fail
- coding-agent check: pass
- coding-agent build: pass on the preceding merge base; post-merge canonical build required
- Biome and `git diff --check`: pass

One test file only. No production change, timeout inflation, skip, retry behavior, or assertion weakening.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*