### PR TITLE
fix(session): close Python admission before disposal

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4220,12 +4220,12 @@ export class AgentSession {
 	 * Call this when completely done with the session.
 	 */
 	async dispose(): Promise<void> {
+		this.#evalExecutionDisposing = true;
 		await this.#closeSessionAdmission();
 		this.#isDisposed = true;
 		this.#pendingBackgroundExchanges = [];
 		this.yieldQueue.clear();
 		this.agent.setOnBeforeYield(undefined);
-		this.#evalExecutionDisposing = true;
 		try {
 			if (this.#extensionRunner?.hasHandlers("session_shutdown")) {
 				await this.#extensionRunner.emit({ type: "session_shutdown" });


### PR DESCRIPTION
## Summary
- close Python/eval admission synchronously when `AgentSession.dispose()` is invoked
- prevent direct Python starts from entering during the awaited general session-admission shutdown

## Root cause
Dev CI run `29305819085` shard 5 showed `executePython()` resolving after disposal began. `dispose()` awaited `#closeSessionAdmission()` before setting `#evalExecutionDisposing`, leaving a real admission window. This is a product ordering regression, not a fixture timing issue.

## Verification
- exact focused case: 50/50
- full Python cleanup file: 11 pass, 70 assertions
- coding-agent check: pass
- full shard 5 exercised; repaired Python case passed, while this highly loaded host separately hit an unrelated existing model-selection 5-second timeout absent from the hosted failure
- Biome and `git diff --check`: pass

One production line moved; no test changes, timeout changes, skips, retries, or weakened assertions. Hosted PR shard is required.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*