### PR TITLE
fix(ci): await goal context turn idle

### DIFF
--- a/packages/coding-agent/test/goal-mode-static-once.test.ts
+++ b/packages/coding-agent/test/goal-mode-static-once.test.ts
@@ -59,12 +59,17 @@ describe("goal-mode static-once context injection", () => {
 		});
 	}
 
+	async function promptAndWait(text: string): Promise<void> {
+		await session.prompt(text);
+		await session.waitForIdle();
+	}
+
 	it("injects goal-mode-context exactly once across multiple turns with an unchanged goal", async () => {
 		createSession();
 		setActiveGoal("Ship the release", "goal-1");
 
 		for (let turn = 0; turn < 5; turn++) {
-			await session.prompt(`turn ${turn}`);
+			await promptAndWait(`turn ${turn}`);
 		}
 
 		// Static-once: exactly one durable goal-mode-context copy despite 5 turns.
@@ -80,12 +85,12 @@ describe("goal-mode static-once context injection", () => {
 	it("re-injects once when the active goal is replaced", async () => {
 		createSession();
 		setActiveGoal("First objective", "goal-1");
-		await session.prompt("turn a");
-		await session.prompt("turn b");
+		await promptAndWait("turn a");
+		await promptAndWait("turn b");
 		expect(goalContextCount(session.messages)).toBe(1);
 
 		setActiveGoal("Second objective", "goal-2");
-		await session.prompt("turn c");
+		await promptAndWait("turn c");
 
 		// A new activation identity triggers exactly one more injection.
 		expect(goalContextCount(session.messages)).toBe(2);


### PR DESCRIPTION
## Summary
- await `AgentSession.waitForIdle()` between sequential goal-mode turns
- preserve unchanged-goal static-once and replacement-goal reinjection assertions

## Root cause
Dev CI run `29305819085` shard 8 raised `AgentBusyError` on the next `prompt()` even after the previous prompt promise resolved. The fixture assumed prompt resolution alone was the turn-idle barrier; after #2205, post-prompt work can remain active. This is a deterministic fixture synchronization race, not a goal-context product regression.

## Verification
- exact two-case file: 50/50
- full shard 8/8: 1555 pass, 28 skip, 0 fail
- coding-agent check: pass
- Biome and `git diff --check`: pass

One test file only. No production changes, sleeps, skips, retries, timeout changes, deletion, or assertion weakening.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*