### PR TITLE
fix(ai): omit tool_choice when openai-responses has empty tools

### DIFF
--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -309,7 +309,13 @@ function buildParams(
 
 	applyCommonResponsesSamplingParams(params, options, model.provider);
 
-	if (context.tools) {
+	// Use `.length` (not truthiness): empty arrays are truthy, and
+	// `AgentSession.runEphemeralTurn` (`/btw`, IRC replies) intentionally
+	// passes `context.tools = []` with `toolChoice: "none"`. Emitting
+	// `tools: []` + `tool_choice: "none"` is rejected by Responses APIs
+	// ("A tool_choice was set on the request but no tools were specified.")
+	// and mirrors the openai-completions / openai-responses #1227 fix.
+	if (context.tools?.length) {
 		params.tools = convertTools(context.tools);
 		if (options?.toolChoice) {
 			const toolChoice = resolveToolChoice(model, options.toolChoice);
@@ -323,6 +329,11 @@ function buildParams(
 			}
 			params.tool_choice = mapToOpenAIResponsesToolChoice(toolChoice.resolvedChoice);
 		}
+	}
+
+	// Defence-in-depth: drop `tool_choice: "none"` when there are no tools.
+	if (params.tool_choice === "none" && (!Array.isArray(params.tools) || params.tools.length === 0)) {
+		delete params.tool_choice;
 	}
 
 	applyResponsesReasoningParams(params, model, options, messages);

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -543,7 +543,13 @@ function buildParams(
 	// TODO: openai responses has no top-level `frequency_penalty` field as of the current SDK;
 	// `StreamOptions.frequencyPenalty` is intentionally dropped for this provider.
 
-	if (context.tools) {
+	// Use `.length` (not truthiness): empty arrays are truthy, and
+	// `AgentSession.runEphemeralTurn` (`/btw`, IRC replies) intentionally
+	// passes `context.tools = []` with `toolChoice: "none"`. Emitting
+	// `tools: []` + `tool_choice: "none"` is rejected by openai-responses
+	// proxies (e.g. grok-build: "A tool_choice was set on the request but no
+	// tools were specified.") and mirrors the openai-completions #1227 fix.
+	if (context.tools?.length) {
 		params.tools = convertTools(context.tools, supportsStrictMode(model), model);
 		if (options?.toolChoice) {
 			const toolChoice = resolveToolChoice(model, options.toolChoice);
@@ -566,6 +572,13 @@ function buildParams(
 		if (params.tools.some(t => (t as { type?: string }).type === "custom")) {
 			params.parallel_tool_calls = false;
 		}
+	}
+
+	// Defence-in-depth: `tool_choice: "none"` with no tools to gate is
+	// redundant and rejected by some Responses proxies when tools is missing
+	// or empty. Drop it whenever the resolved tools list is empty.
+	if (params.tool_choice === "none" && (!Array.isArray(params.tools) || params.tools.length === 0)) {
+		delete params.tool_choice;
 	}
 
 	applyResponsesReasoningParams(params, model, options, messages, effort =>

--- a/packages/ai/test/azure-openai-responses-tool-choice.test.ts
+++ b/packages/ai/test/azure-openai-responses-tool-choice.test.ts
@@ -171,4 +171,30 @@ describe("Azure OpenAI responses tool choice capability", () => {
 		expect(result.stopReason).toBe("error");
 		expect(getToolChoiceCapabilityOverride(testModel)).toBeUndefined();
 	});
+
+	it("omits tools and tool_choice when /btw passes empty tools + toolChoice none", async () => {
+		let payload: Record<string, unknown> | undefined;
+		const testModel = model();
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				payload = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+				return okResponse(testModel.id);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		await streamAzureOpenAIResponses(
+			testModel,
+			{
+				messages: [{ role: "user", content: "btw what is X", timestamp: 0 }],
+				tools: [],
+			},
+			{
+				apiKey: "test-key",
+				azureBaseUrl: testModel.baseUrl,
+				toolChoice: "none",
+			},
+		).result();
+		expect(payload?.tools).toBeUndefined();
+		expect(payload?.tool_choice).toBeUndefined();
+	});
 });

--- a/packages/ai/test/azure-openai-responses-tool-choice.test.ts
+++ b/packages/ai/test/azure-openai-responses-tool-choice.test.ts
@@ -197,4 +197,24 @@ describe("Azure OpenAI responses tool choice capability", () => {
 		expect(payload?.tools).toBeUndefined();
 		expect(payload?.tool_choice).toBeUndefined();
 	});
+
+	it("keeps tool_choice none when real tools are present", async () => {
+		let payload: Record<string, unknown> | undefined;
+		const testModel = model();
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				payload = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+				return okResponse(testModel.id);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		await streamAzureOpenAIResponses(testModel, testContext, {
+			apiKey: "test-key",
+			azureBaseUrl: testModel.baseUrl,
+			toolChoice: "none",
+		}).result();
+		expect(Array.isArray(payload?.tools)).toBe(true);
+		expect((payload?.tools as unknown[]).length).toBeGreaterThan(0);
+		expect(payload?.tool_choice).toBe("none");
+	});
 });

--- a/packages/ai/test/openai-responses-tool-choice.test.ts
+++ b/packages/ai/test/openai-responses-tool-choice.test.ts
@@ -143,4 +143,49 @@ describe("OpenAI responses tool choice capability", () => {
 		expect(result.stopReason).toBe("error");
 		expect(getToolChoiceCapabilityOverride(testModel)).toBeUndefined();
 	});
+
+	it("omits tools and tool_choice when /btw passes empty tools + toolChoice none", async () => {
+		// Mirrors AgentSession.runEphemeralTurn: context.tools = [] is truthy, so
+		// a bare `if (context.tools)` used to emit tools:[] + tool_choice:"none",
+		// which Responses proxies (including grok-build) reject with
+		// "A tool_choice was set on the request but no tools were specified."
+		let payload: Record<string, unknown> | undefined;
+		const testModel = model();
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				payload = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+				return okResponse(testModel.id);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		await streamOpenAIResponses(
+			testModel,
+			{
+				messages: [{ role: "user", content: "btw what is X", timestamp: 0 }],
+				tools: [],
+			},
+			{ apiKey: "test-key", toolChoice: "none" },
+		).result();
+		expect(payload?.tools).toBeUndefined();
+		expect(payload?.tool_choice).toBeUndefined();
+	});
+
+	it("keeps tool_choice none when real tools are present", async () => {
+		let payload: Record<string, unknown> | undefined;
+		const testModel = model();
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				payload = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+				return okResponse(testModel.id);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		await streamOpenAIResponses(testModel, testContext, {
+			apiKey: "test-key",
+			toolChoice: "none",
+		}).result();
+		expect(Array.isArray(payload?.tools)).toBe(true);
+		expect((payload?.tools as unknown[]).length).toBeGreaterThan(0);
+		expect(payload?.tool_choice).toBe("none");
+	});
 });

--- a/packages/ai/test/responses-empty-tools-request-shaping.test.ts
+++ b/packages/ai/test/responses-empty-tools-request-shaping.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Final-serialized-body regression coverage for openai-responses /
+ * azure-openai-responses request shaping when tools are omitted, empty, or
+ * present — including /btw-style opt-out (`tools: []` + `toolChoice: "none"`).
+ *
+ * Complements #1227 (openai-completions) and the production guard that gates
+ * tool serialization on `context.tools?.length`.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { streamAzureOpenAIResponses } from "../src/providers/azure-openai-responses";
+import { streamOpenAIResponses } from "../src/providers/openai-responses";
+import type { AssistantMessage, Context, Model, Tool, ToolChoice } from "../src/types";
+import { clearToolChoiceIncapabilityRegistryForTests } from "../src/utils/tool-choice-capability";
+import {
+	createBaseModel,
+	createSseResponse,
+	testTool,
+} from "./openai-tool-choice-test-helpers";
+
+const originalFetch = global.fetch;
+
+beforeEach(() => clearToolChoiceIncapabilityRegistryForTests());
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+function okResponse(modelId: string, id = "resp_shape"): Response {
+	return createSseResponse([
+		{ type: "response.created", response: { id, model: modelId, status: "in_progress" } },
+		{
+			type: "response.output_item.added",
+			output_index: 0,
+			item: { id: "msg_1", type: "message", role: "assistant", content: [] },
+		},
+		{
+			type: "response.content_part.added",
+			item_id: "msg_1",
+			output_index: 0,
+			content_index: 0,
+			part: { type: "output_text", text: "" },
+		},
+		{ type: "response.output_text.delta", item_id: "msg_1", output_index: 0, content_index: 0, delta: "ok" },
+		{ type: "response.output_text.done", item_id: "msg_1", output_index: 0, content_index: 0, text: "ok" },
+		{
+			type: "response.output_item.done",
+			output_index: 0,
+			item: { id: "msg_1", type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] },
+		},
+		{
+			type: "response.completed",
+			response: {
+				id,
+				model: modelId,
+				status: "completed",
+				output: [],
+				usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+			},
+		},
+	]);
+}
+
+function openaiModel(overrides: Partial<Model<"openai-responses">> = {}): Model<"openai-responses"> {
+	return {
+		...createBaseModel("openai-responses"),
+		compat: { toolChoiceSupport: "named", ...(overrides.compat ?? {}) },
+		...overrides,
+	};
+}
+
+function azureModel(overrides: Partial<Model<"azure-openai-responses">> = {}): Model<"azure-openai-responses"> {
+	return {
+		...createBaseModel("azure-openai-responses"),
+		provider: "azure",
+		baseUrl: "https://example.openai.azure.com/openai/v1",
+		compat: { toolChoiceSupport: "named", ...(overrides.compat ?? {}) },
+		...overrides,
+	};
+}
+
+function captureFetch(): { getPayload: () => Record<string, unknown> | undefined } {
+	let payload: Record<string, unknown> | undefined;
+	global.fetch = Object.assign(
+		async (_input: string | URL | Request, init?: RequestInit) => {
+			payload = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+			const modelId = typeof payload.model === "string" ? payload.model : "test-model";
+			return okResponse(modelId);
+		},
+		{ preconnect: originalFetch.preconnect },
+	);
+	return { getPayload: () => payload };
+}
+
+function baseMessages(): Context["messages"] {
+	return [{ role: "user", content: "hello", timestamp: 0 }];
+}
+
+function assistantWithToolCall(api: string, provider: string, modelId: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id: "call_1", name: "search", arguments: { q: "x" } }],
+		api,
+		provider,
+		model: modelId,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: 1,
+	};
+}
+
+function toolHistoryMessages(api: string, provider: string, modelId: string): Context["messages"] {
+	return [
+		{ role: "user", content: "search now", timestamp: 0 },
+		assistantWithToolCall(api, provider, modelId),
+		{
+			role: "toolResult",
+			toolCallId: "call_1",
+			toolName: "search",
+			content: [{ type: "text", text: "result" }],
+			isError: false,
+			timestamp: 2,
+		},
+		{ role: "user", content: "btw what is X", timestamp: 3 },
+	];
+}
+
+const freeformTool: Tool = {
+	name: "edit",
+	customWireName: "apply_patch",
+	description: "edit files",
+	parameters: {
+		type: "object",
+		properties: { input: { type: "string" } },
+		required: ["input"],
+	},
+	customFormat: { syntax: "lark", definition: 'start: "*** Begin Patch" LF' },
+};
+
+type ToolBag = "undefined" | "empty" | "present";
+type ChoiceCase = {
+	label: string;
+	toolChoice?: ToolChoice;
+	/** Expected wire tool_choice when tools are present and named support is on. */
+	whenPresent: unknown;
+};
+
+const choiceCases: ChoiceCase[] = [
+	{ label: "omitted", toolChoice: undefined, whenPresent: undefined },
+	{ label: "none", toolChoice: "none", whenPresent: "none" },
+	{ label: "auto", toolChoice: "auto", whenPresent: "auto" },
+	{ label: "any", toolChoice: "any", whenPresent: "required" },
+	{ label: "required", toolChoice: "required", whenPresent: "required" },
+	{
+		label: "named-function",
+		toolChoice: { type: "function", function: { name: "search" } },
+		whenPresent: { type: "function", name: "search" },
+	},
+];
+
+function toolsFor(bag: ToolBag): Tool[] | undefined {
+	if (bag === "undefined") return undefined;
+	if (bag === "empty") return [];
+	return [testTool];
+}
+
+function expectToolsOmitted(payload: Record<string, unknown> | undefined): void {
+	expect(payload?.tools).toBeUndefined();
+	expect(payload?.tool_choice).toBeUndefined();
+}
+
+function expectToolsPresent(
+	payload: Record<string, unknown> | undefined,
+	expectedToolChoice: unknown,
+	minTools = 1,
+): void {
+	expect(Array.isArray(payload?.tools)).toBe(true);
+	expect((payload?.tools as unknown[]).length).toBeGreaterThanOrEqual(minTools);
+	if (expectedToolChoice === undefined) {
+		expect(payload?.tool_choice).toBeUndefined();
+	} else {
+		expect(payload?.tool_choice).toEqual(expectedToolChoice);
+	}
+}
+
+async function streamOpenAI(context: Context, toolChoice?: ToolChoice, model = openaiModel()) {
+	const capture = captureFetch();
+	await streamOpenAIResponses(model, context, {
+		apiKey: "test-key",
+		...(toolChoice !== undefined ? { toolChoice } : {}),
+	}).result();
+	return capture.getPayload();
+}
+
+async function streamAzure(context: Context, toolChoice?: ToolChoice, model = azureModel()) {
+	const capture = captureFetch();
+	await streamAzureOpenAIResponses(model, context, {
+		apiKey: "test-key",
+		azureBaseUrl: model.baseUrl,
+		...(toolChoice !== undefined ? { toolChoice } : {}),
+	}).result();
+	return capture.getPayload();
+}
+
+describe("Responses request shaping: tools undefined vs [] vs present", () => {
+	for (const provider of ["openai-responses", "azure-openai-responses"] as const) {
+		const stream = provider === "openai-responses" ? streamOpenAI : streamAzure;
+
+		describe(provider, () => {
+			for (const bag of ["undefined", "empty", "present"] as const) {
+				for (const choice of choiceCases) {
+					it(`tools=${bag} + toolChoice=${choice.label}`, async () => {
+						const payload = await stream(
+							{ messages: baseMessages(), tools: toolsFor(bag) },
+							choice.toolChoice,
+						);
+
+						if (bag === "present") {
+							expectToolsPresent(payload, choice.whenPresent);
+						} else {
+							// Empty and undefined both skip tool serialization; any
+							// toolChoice (including none/required/named) must not leak.
+							expectToolsOmitted(payload);
+						}
+					});
+				}
+			}
+
+			it("preserves tool_choice none when non-empty tools are present", async () => {
+				const payload = await stream(
+					{ messages: baseMessages(), tools: [testTool] },
+					"none",
+				);
+				expectToolsPresent(payload, "none");
+			});
+
+			it("omits tools/tool_choice with prior tool history when tools=[] + toolChoice none", async () => {
+				const api = provider;
+				const providerName = provider === "openai-responses" ? "custom" : "azure";
+				const modelId = `${provider}-test-model`;
+				const payload = await stream(
+					{
+						messages: toolHistoryMessages(api, providerName, modelId),
+						tools: [],
+					},
+					"none",
+				);
+
+				expectToolsOmitted(payload);
+
+				// History must still serialize as Responses function_call items.
+				const input = payload?.input;
+				expect(Array.isArray(input)).toBe(true);
+				const items = input as Array<{ type?: string; call_id?: string }>;
+				expect(items.some(i => i.type === "function_call")).toBe(true);
+				expect(items.some(i => i.type === "function_call_output")).toBe(true);
+				expect(items.some(i => i.call_id === "call_1" || i.type === "function_call")).toBe(true);
+			});
+
+			it("keeps tools when history exists and tools are non-empty", async () => {
+				const api = provider;
+				const providerName = provider === "openai-responses" ? "custom" : "azure";
+				const modelId = `${provider}-test-model`;
+				const payload = await stream(
+					{
+						messages: toolHistoryMessages(api, providerName, modelId),
+						tools: [testTool],
+					},
+					"auto",
+				);
+				expectToolsPresent(payload, "auto");
+				const input = payload?.input as Array<{ type?: string }>;
+				expect(input.some(i => i.type === "function_call")).toBe(true);
+				expect(input.some(i => i.type === "function_call_output")).toBe(true);
+			});
+		});
+	}
+});
+
+describe("openai-responses freeform / custom tool preservation", () => {
+	it("emits custom tool entries and maps named choice to custom tool_choice", async () => {
+		const model = openaiModel({
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			applyPatchToolType: "freeform",
+		});
+		const capture = captureFetch();
+		await streamOpenAIResponses(
+			model,
+			{
+				messages: baseMessages(),
+				tools: [freeformTool, testTool],
+			},
+			{
+				apiKey: "test-key",
+				toolChoice: { type: "function", function: { name: "edit" } },
+			},
+		).result();
+		const payload = capture.getPayload();
+		expect(Array.isArray(payload?.tools)).toBe(true);
+		const tools = payload?.tools as Array<{ type?: string; name?: string }>;
+		expect(tools.some(t => t.type === "custom" && t.name === "apply_patch")).toBe(true);
+		expect(tools.some(t => t.type === "function" && t.name === "search")).toBe(true);
+		expect(payload?.tool_choice).toEqual({ type: "custom", name: "apply_patch" });
+		// Custom grammar tools force serial tool calling for the turn.
+		expect(payload?.parallel_tool_calls).toBe(false);
+	});
+
+	it("still omits tools and tool_choice for freeform model when tools=[] + none", async () => {
+		const model = openaiModel({
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			applyPatchToolType: "freeform",
+		});
+		const capture = captureFetch();
+		await streamOpenAIResponses(
+			model,
+			{
+				messages: baseMessages(),
+				tools: [],
+			},
+			{ apiKey: "test-key", toolChoice: "none" },
+		).result();
+		expectToolsOmitted(capture.getPayload());
+	});
+});


### PR DESCRIPTION
## Summary
- `/btw` and IRC ephemeral turns call `AgentSession.runEphemeralTurn` with `context.tools = []` and `toolChoice: "none"`.
- `openai-completions` already fixed this in #1227 by requiring `context.tools?.length` and dropping redundant `tool_choice: "none"`.
- `openai-responses` / `azure-openai-responses` still used `if (context.tools)`, so empty arrays produced `tools: []` + `tool_choice: "none"`.
- Responses proxies reject that shape with `400: A tool_choice was set on the request but no tools were specified.` (reproduced against grok-build / openai-responses).

## Changes
- `packages/ai/src/providers/openai-responses.ts`: require non-empty tools before emitting tools/tool_choice; drop `tool_choice: "none"` when tools are missing/empty.
- `packages/ai/src/providers/azure-openai-responses.ts`: same guard for Azure Responses.
- Tests covering empty-tools + `toolChoice: "none"` for both providers, plus a regression that keeps `tool_choice: "none"` when real tools are present.

## Notes
Retargeted to **`dev`** per repo policy (gaebal-gajae / clawdbot). Previous PR #2176 targeted `main` and was closed.

## Test plan
- [x] `bun --cwd packages/ai test test/openai-responses-tool-choice.test.ts test/azure-openai-responses-tool-choice.test.ts test/issue-1227-repro.test.ts` (15 pass)
- [ ] Manual: start a tool-using session on an openai-responses model (e.g. grok-build), then send `/btw` side question and confirm no 400.