### PR TITLE
fix(coding-agent): compact context between tool iterations

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Extended the gpt-5.6 `Request blocked (code=invalid_prompt)` fix to the compaction paths that bypass the streaming transport. Remote OpenAI compaction (`/responses/compact`, `compaction.remoteEnabled` default on — the "remote compact task" in openai/codex#32028) built its native `input` from reasoning signatures, verbatim history items, and message/tool text without neutralizing leaked Harmony control-token markers (e.g. `<|channel|>analysis`), so gpt-5.6 rejected the compaction request and, on retry, could escalate to account-level blocking. `requestOpenAiRemoteCompaction` now neutralizes reserved control tokens across the whole outgoing `input`, and the generic `requestRemoteCompaction` prompt/systemPrompt are neutralized too. Local summarization was already covered by the streaming-transport request-boundary fix.
 
+### Changed
+
+- `AgentLoopConfig.maintainContext` now receives a required cancellation-aware lifecycle (`signal`, `awaitEventDrain(invocationSignal)`). Agent loops compose the run and maintenance-invocation signals and pass that single signal to EventStream's FIFO consumer-drain barrier, so cancellation removes the pending drain at its owner instead of racing an orphaned wait.
+
 ## [0.10.0] - 2026-07-12
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -729,6 +729,8 @@ async function runLoop(
 	streamFn?: StreamFn,
 	initialTransaction?: ManagedAttemptTransaction,
 ): Promise<void> {
+	const loopSignal = signal ?? new AbortController().signal;
+
 	const telemetry = resolveTelemetry(config.telemetry, config.sessionId);
 	const invokeAgentSpan = startInvokeAgentSpan(telemetry, config.model);
 	const stepCounter = { count: 0 };
@@ -739,7 +741,8 @@ async function runLoop(
 				currentContext,
 				newMessages,
 				config,
-				signal,
+				loopSignal,
+
 				stream,
 				telemetry,
 				invokeAgentSpan,
@@ -767,7 +770,8 @@ async function runLoopBody(
 	currentContext: AgentContext,
 	newMessages: AgentMessage[],
 	config: AgentLoopConfig,
-	signal: AbortSignal | undefined,
+	loopSignal: AbortSignal,
+
 	stream: EventStream<AgentEvent, AgentMessage[]>,
 	telemetry: AgentTelemetry | undefined,
 	invokeAgentSpan: Span | undefined,
@@ -779,6 +783,11 @@ async function runLoopBody(
 	// Check for steering messages at start (user may have typed while waiting)
 	let pendingMessages: AgentMessage[] = (await config.getSteeringMessages?.()) || [];
 	let harmonyRetryAttempt = 0;
+	// Whether at least one assistant response has been produced in THIS run. The
+	// mid-run maintenance checkpoint only fires between tool iterations (after a
+	// model response); pre-turn maintenance is the pre-prompt check's job, so the
+	// first iteration is skipped to avoid duplicating/racing it.
+	let modelHasResponded = false;
 	let harmonyTruncateResumeCount = 0;
 
 	// Outer loop: continues when queued follow-up messages arrive after agent would stop
@@ -812,6 +821,38 @@ async function runLoopBody(
 				pendingMessages = [];
 			}
 
+			// Cooperative mid-run context maintenance. Runs after pending
+			// tool/steering messages are materialized into durable context and
+			// before syncContextBeforeModelCall / the model call — the only
+			// boundary where the full unsent context is already durable. A
+			// non-"not-needed" outcome means context was (or was attempted to be)
+			// rewritten, so end the run WITHOUT the lossy agent_end finalization;
+			// the maintenance owner resumes the run on the rewritten context.
+			// "not-needed" falls through to the model call.
+			if (config.maintainContext && modelHasResponded && !loopSignal.aborted) {
+				const lifecycle = {
+					signal: loopSignal,
+					awaitEventDrain: (invocationSignal: AbortSignal) =>
+						stream.waitForConsumerDrain(AbortSignal.any([loopSignal, invocationSignal])),
+				};
+				const maintenanceOutcome = await config.maintainContext(currentContext, lifecycle);
+				// A callback can settle after its loop has been cancelled. Never let a
+				// stale "not-needed" fall through to streamAssistantResponse, which
+				// invokes the provider before it observes the aborted signal.
+				const outcome = loopSignal.aborted ? "aborted" : maintenanceOutcome;
+
+				if (outcome !== "not-needed") {
+					stream.push({
+						type: "agent_end",
+						messages: newMessages,
+						stopReason: "maintenance",
+						maintenanceOutcome: outcome,
+					});
+					stream.end(newMessages);
+					return;
+				}
+			}
+
 			// Refresh prompt/tool context from live state before each model call
 			if (config.syncContextBeforeModelCall) {
 				await config.syncContextBeforeModelCall(currentContext);
@@ -835,7 +876,7 @@ async function runLoopBody(
 				message = await streamAssistantResponse(
 					currentContext,
 					attemptConfig,
-					signal,
+					loopSignal,
 					attemptTransaction ? (attemptTransaction as unknown as EventStream<AgentEvent, AgentMessage[]>) : stream,
 					telemetry,
 					invokeAgentSpan,
@@ -909,6 +950,7 @@ async function runLoopBody(
 				}
 			}
 			newMessages.push(message);
+			modelHasResponded = true;
 			let steeringMessagesFromExecution: AgentMessage[] | undefined;
 
 			// Detect empty "successful" responses (stopReason "stop" + empty content).
@@ -985,7 +1027,7 @@ async function runLoopBody(
 				const executionResult = await executeToolCalls(
 					currentContext,
 					message,
-					signal,
+					loopSignal,
 					stream,
 					config,
 					telemetry,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -371,6 +371,7 @@ export class Agent {
 	#onHarmonyLeak?: (event: HarmonyAuditEvent) => void | Promise<void>;
 	#onBeforeYield?: () => Promise<void> | void;
 	#shouldPause?: AgentLoopConfig["shouldPause"];
+	#maintainContext?: AgentLoopConfig["maintainContext"];
 	#telemetry?: AgentLoopConfig["telemetry"];
 	#appendOnlyContext?: AppendOnlyContextManager;
 
@@ -706,6 +707,10 @@ export class Agent {
 
 	setShouldPause(fn: AgentLoopConfig["shouldPause"] | undefined): void {
 		this.#shouldPause = fn;
+	}
+
+	setMaintainContext(fn: AgentLoopConfig["maintainContext"] | undefined): void {
+		this.#maintainContext = fn;
 	}
 
 	emitExternalEvent(event: AgentEvent) {
@@ -1381,6 +1386,7 @@ export class Agent {
 		const cursorExecHandlers = fallbackManaged ? undefined : this.#cursorExecHandlersForRun(runId);
 		let managedDecision: ManagedAttemptDecision | undefined;
 		let managedOutcome: ManagedAttemptOutcome | undefined;
+		let maintenanceInterrupted = false;
 
 		const config: AgentLoopConfig = {
 			model,
@@ -1506,6 +1512,12 @@ export class Agent {
 				if (this.#activeRunId !== runId) return false;
 				return this.#shouldPause?.() === true;
 			},
+			maintainContext: this.#maintainContext
+				? async (context, lifecycle) => {
+						if (this.#activeRunId !== runId) return "not-needed";
+						return (await this.#maintainContext?.(context, lifecycle)) ?? "not-needed";
+					}
+				: undefined,
 			telemetry: this.#telemetry,
 		};
 
@@ -1574,6 +1586,11 @@ export class Agent {
 						}
 						this.#state.isStreaming = false;
 						this.#state.streamMessage = null;
+						if (event.stopReason === "maintenance") {
+							maintenanceInterrupted = true;
+							this.#emit(event);
+							continue;
+						}
 						this.#finalizeRun(managedLogicalRunOwner ?? runId, event);
 						continue;
 				}
@@ -1663,7 +1680,12 @@ export class Agent {
 				this.#runningPrompt = undefined;
 				this.#resolveRunningPrompt = undefined;
 			}
-			if (fallbackManaged && !continuation && this.#managedLogicalRunOwner === managedLogicalRunOwner) {
+			if (
+				fallbackManaged &&
+				!continuation &&
+				!maintenanceInterrupted &&
+				this.#managedLogicalRunOwner === managedLogicalRunOwner
+			) {
 				this.#managedLogicalRunOwner = undefined;
 			}
 			if (continuation && ownership.isCurrent()) {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -77,6 +77,15 @@ export type ManagedAttemptOutcomeHandler = (
 ) => ManagedAttemptDecision | Promise<ManagedAttemptDecision>;
 
 /**
+ * Outcome of a cooperative mid-run context-maintenance checkpoint (see
+ * {@link AgentLoopConfig.maintainContext}). Any value other than "not-needed"
+ * means the checkpoint mutated (or attempted to mutate) durable context, so the
+ * loop ends the current run without the lossy `agent_end` finalization and the
+ * maintenance owner resumes the run on the rewritten context.
+ */
+export type MidRunMaintenanceOutcome = "not-needed" | "pruned" | "compacted" | "promoted" | "failed" | "aborted";
+
+/**
  * Configuration for the agent loop.
  */
 export interface AgentLoopConfig extends SimpleStreamOptions {
@@ -222,6 +231,33 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * Use this when tool availability or the system prompt can change mid-turn.
 	 */
 	syncContextBeforeModelCall?: (context: AgentContext) => void | Promise<void>;
+
+	/**
+	 * Cooperative mid-run context-maintenance checkpoint.
+	 *
+	 * Invoked at the top of every loop iteration AFTER pending tool-result /
+	 * steering messages have been materialized into durable context and BEFORE
+	 * {@link syncContextBeforeModelCall} and the model call. This is the only
+	 * boundary where the full unsent context (tool results + dequeued steering)
+	 * is already durable, so a long uninterrupted tool loop can be bounded here
+	 * before it grows past the provider window.
+	 *
+	 * The callback owns the maintenance decision (prune / compact / promote) and
+	 * receives the minimal cancellation-aware lifecycle: `signal` is the
+	 * non-optional loop signal, and `awaitEventDrain(invocationSignal)` waits for
+	 * prior event consumer bodies with loop and invocation cancellation composed.
+	 * Any outcome other than "not-needed" ends the current run with
+	 * `agent_end.stopReason === "maintenance"` (NOT the lossy pause / completed
+	 * finalization); the callback's continuation owner resumes the run on the
+	 * rewritten context.
+	 */
+	maintainContext?: (
+		context: AgentContext,
+		lifecycle: {
+			signal: AbortSignal;
+			awaitEventDrain: (invocationSignal: AbortSignal) => Promise<void>;
+		},
+	) => Promise<MidRunMaintenanceOutcome> | MidRunMaintenanceOutcome;
 
 	/**
 	 * Optional transform applied to tool call arguments before execution.
@@ -532,8 +568,10 @@ export type AgentEvent =
 	| {
 			type: "agent_end";
 			messages: AgentMessage[];
-			/** Indicates whether the loop ended normally, suspended, or was cancelled. */
-			stopReason?: "completed" | "paused" | "cancelled";
+			/** Indicates whether the loop ended normally, suspended, cancelled, or entered maintenance. */
+			stopReason?: "completed" | "paused" | "cancelled" | "maintenance";
+			/** Present iff `stopReason === "maintenance"`; the maintenance outcome. */
+			maintenanceOutcome?: MidRunMaintenanceOutcome;
 			/** Present iff `AgentTelemetryConfig` was supplied on this run. */
 			telemetry?: AgentRunSummary;
 			coverage?: AgentRunCoverage;

--- a/packages/agent/test/agent-loop-maintain-context-lifecycle.test.ts
+++ b/packages/agent/test/agent-loop-maintain-context-lifecycle.test.ts
@@ -1,0 +1,118 @@
+import { expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool, StreamFn } from "@gajae-code/agent-core/types";
+import type { AssistantMessage, Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+import { createAssistantMessage, createUserMessage } from "./helpers";
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(
+		(message): message is Message =>
+			message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+	);
+}
+
+it("provides a non-optional cancellation-aware maintenance lifecycle without a run signal", async () => {
+	const model = createMockModel();
+	const responses: AssistantMessage[] = [
+		createAssistantMessage([{ type: "toolCall", id: "call-1", name: "echo", arguments: {} }], "toolUse"),
+		createAssistantMessage([{ type: "text", text: "complete" }]),
+	];
+	const streamFn: StreamFn = () => {
+		const response = responses.shift();
+		if (!response) throw new Error("Unexpected model request");
+		const stream = new AssistantMessageEventStream();
+		queueMicrotask(() => {
+			stream.push({
+				type: "done",
+				reason: response.stopReason === "toolUse" ? "toolUse" : "stop",
+				message: response,
+			});
+			stream.end(response);
+		});
+		return stream;
+	};
+	const tool: AgentTool = {
+		name: "echo",
+		label: "Echo",
+		description: "Returns a deterministic result.",
+		parameters: { type: "object", properties: {} },
+		execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+	};
+	const context: AgentContext = { systemPrompt: ["You are helpful."], messages: [], tools: [tool] };
+	let maintenanceCalls = 0;
+	const config: AgentLoopConfig = {
+		model: model.model,
+		convertToLlm: identityConverter,
+		maintainContext: async (_context, lifecycle) => {
+			maintenanceCalls += 1;
+			expect(lifecycle.signal).toBeInstanceOf(AbortSignal);
+			expect(lifecycle.signal.aborted).toBe(false);
+			await expect(lifecycle.awaitEventDrain(new AbortController().signal)).resolves.toBeUndefined();
+			return "not-needed" as const;
+		},
+	};
+
+	const stream = agentLoop([createUserMessage("run tool")], context, config, undefined, streamFn);
+	for await (const _event of stream) {
+		// Drain the real consumer path that awaitEventDrain synchronizes with.
+	}
+
+	await expect(stream.result()).resolves.toBeDefined();
+	expect(maintenanceCalls).toBe(1);
+	expect(responses).toEqual([]);
+});
+
+it("ends as aborted when cancellation lands while maintenance resolves", async () => {
+	const model = createMockModel();
+	const maintenanceEntered = Promise.withResolvers<void>();
+	const maintenanceGate = Promise.withResolvers<void>();
+	const controller = new AbortController();
+	let streamCalls = 0;
+	const streamFn: StreamFn = () => {
+		streamCalls += 1;
+		if (streamCalls > 1) throw new Error("Maintenance cancellation must prevent a second model request");
+		const response = createAssistantMessage(
+			[{ type: "toolCall", id: "call-1", name: "echo", arguments: {} }],
+			"toolUse",
+		);
+		const stream = new AssistantMessageEventStream();
+		queueMicrotask(() => {
+			stream.push({ type: "done", reason: "toolUse", message: response });
+			stream.end(response);
+		});
+		return stream;
+	};
+	const tool: AgentTool = {
+		name: "echo",
+		label: "Echo",
+		description: "Returns a deterministic result.",
+		parameters: { type: "object", properties: {} },
+		execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+	};
+	const context: AgentContext = { systemPrompt: ["You are helpful."], messages: [], tools: [tool] };
+	const events: Array<{ type: string; maintenanceOutcome?: string }> = [];
+	const config: AgentLoopConfig = {
+		model: model.model,
+		convertToLlm: identityConverter,
+		maintainContext: async () => {
+			maintenanceEntered.resolve();
+			await maintenanceGate.promise;
+			return "not-needed" as const;
+		},
+	};
+
+	const stream = agentLoop([createUserMessage("run tool")], context, config, controller.signal, streamFn);
+	const drain = (async () => {
+		for await (const event of stream) events.push(event);
+	})();
+	await maintenanceEntered.promise;
+	controller.abort();
+	maintenanceGate.resolve();
+	await drain;
+	await expect(stream.result()).resolves.toBeDefined();
+
+	expect(streamCalls).toBe(1);
+	expect(events.filter(event => event.type === "agent_end" && event.maintenanceOutcome === "aborted")).toHaveLength(1);
+});

--- a/packages/agent/test/managed-attempt-transaction.test.ts
+++ b/packages/agent/test/managed-attempt-transaction.test.ts
@@ -322,6 +322,41 @@ describe("managed retry ownership", () => {
 		expectManagedRunStart(events);
 	});
 
+	it("preserves one managed logical lifecycle across maintenance continuation", async () => {
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "missing-tool", arguments: {} }] },
+				{ content: ["accepted after maintenance"] },
+			],
+		});
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["test"], tools: [], messages: [] },
+			streamFn: mock.stream,
+		});
+		let maintenanceCalls = 0;
+		agent.setMaintainContext(() => (maintenanceCalls++ === 0 ? "compacted" : "not-needed"));
+		const events: Array<{ type: string; stopReason?: string }> = [];
+		const resumed = Promise.withResolvers<void>();
+		const options = { fallbackManaged: true } as const;
+		agent.subscribe(event => {
+			events.push({ type: event.type, stopReason: event.type === "agent_end" ? event.stopReason : undefined });
+			if (event.type === "agent_end" && event.stopReason === "maintenance") {
+				queueMicrotask(() => {
+					void agent.continue(options).then(resumed.resolve, resumed.reject);
+				});
+			}
+		});
+
+		await agent.prompt("run", options);
+		await resumed.promise;
+
+		expect(events.filter(event => event.type === "agent_start")).toHaveLength(1);
+		expect(events.filter(event => event.type === "agent_end" && event.stopReason === "maintenance")).toHaveLength(1);
+		expect(events.filter(event => event.type === "agent_end" && event.stopReason !== "maintenance")).toEqual([
+			{ type: "agent_end", stopReason: "completed" },
+		]);
+	});
+
 	it("dedupes a logical terminal request after an accepted retry", async () => {
 		const mock = createMockModel({ responses: [{ content: ["accepted"] }] });
 		let attempts = 0;

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -152,7 +152,10 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 	waitForConsumerDrain(signal: AbortSignal): Promise<void> {
 		if (signal.aborted) return Promise.reject(abortReason(signal));
 		if (this.#failed) return Promise.reject(this.#error);
-		if (this.done) return Promise.resolve();
+		if (this.done && this.#activeConsumerCount === 0) {
+			if (this.#queueLength === 0) return Promise.resolve();
+			return Promise.reject(new Error("Event stream ended before queued events could be drained"));
+		}
 
 		const { promise, resolve, reject } = Promise.withResolvers<void>();
 		let drain!: ConsumerDrain;

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -1,10 +1,32 @@
 import type { AssistantMessage, AssistantMessageEvent } from "../types";
 
+interface EventQueueNode<T> {
+	type: "event";
+	event: T;
+}
+
+type QueueNode<T> = EventQueueNode<T> | { type: "consumer-drain"; drain: ConsumerDrain };
+
+interface ConsumerDrain {
+	settled: boolean;
+	signal: AbortSignal;
+	abortListener: () => void;
+	resolve: () => void;
+	reject: (reason: unknown) => void;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+	return signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+}
+
 // Generic event stream class for async iteration
+
 export class EventStream<T, R = T> implements AsyncIterable<T> {
-	#queue: T[] = [];
+	#queue: QueueNode<T>[] = [];
 	#queueHead = 0;
 	waiting: Array<{ resolve: (value: IteratorResult<T>) => void; reject: (err: unknown) => void }> = [];
+	#pendingConsumerDrains = new Set<ConsumerDrain>();
+	#activeConsumerCount = 0;
 	done = false;
 	#failed = false;
 	#error: unknown = undefined;
@@ -26,20 +48,20 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		this.extractResult = extractResult;
 	}
 
-	#enqueue(event: T): void {
-		this.#queue.push(event);
+	#enqueue(node: QueueNode<T>): void {
+		this.#queue.push(node);
 	}
 
-	#dequeue(): T | undefined {
+	#dequeue(): QueueNode<T> | undefined {
 		if (this.#queueHead >= this.#queue.length) return undefined;
-		const event = this.#queue[this.#queueHead]!;
-		this.#queue[this.#queueHead] = undefined as T;
+		const node = this.#queue[this.#queueHead]!;
+		this.#queue[this.#queueHead] = undefined as unknown as QueueNode<T>;
 		this.#queueHead++;
 		if (this.#queueHead > 1024 && this.#queueHead * 2 >= this.#queue.length) {
 			this.#queue = this.#queue.slice(this.#queueHead);
 			this.#queueHead = 0;
 		}
-		return event;
+		return node;
 	}
 
 	get #queueLength(): number {
@@ -49,10 +71,54 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 	/**
 	 * Read-only snapshot of the not-yet-consumed events. Always a fresh copy:
 	 * external code can never mutate internal queue state or observe head-index
-	 * tombstones, so the deque cannot desynchronize.
+	 * tombstones or private consumer-drain sentinels, so the deque cannot desynchronize.
 	 */
 	get queue(): T[] {
-		return this.#queue.slice(this.#queueHead);
+		return this.#queue.slice(this.#queueHead).flatMap(node => (node.type === "event" ? [node.event] : []));
+	}
+
+	/** Read-only test seam for outstanding consumer-drain waiters. */
+	get pendingConsumerDrainCountForTests(): number {
+		return this.#pendingConsumerDrains.size;
+	}
+
+	#settleConsumerDrain(drain: ConsumerDrain, status: "resolve" | "reject", reason?: unknown): void {
+		if (drain.settled) return;
+		drain.settled = true;
+		this.#pendingConsumerDrains.delete(drain);
+		drain.signal.removeEventListener("abort", drain.abortListener);
+		if (status === "resolve") {
+			drain.resolve();
+		} else {
+			drain.reject(reason);
+		}
+	}
+
+	#settleAllConsumerDrains(status: "resolve" | "reject", reason?: unknown): void {
+		for (const drain of this.#pendingConsumerDrains) {
+			this.#settleConsumerDrain(drain, status, reason);
+		}
+	}
+
+	#drainQueuedNodesToWaitingConsumers(): void {
+		while (this.waiting.length > 0 && this.#queueLength > 0) {
+			const node = this.#dequeue()!;
+			if (node.type === "consumer-drain") {
+				this.#settleConsumerDrain(node.drain, "resolve");
+
+				continue;
+			}
+			this.waiting.shift()!.resolve({ value: node.event, done: false });
+		}
+	}
+
+	#dequeueEvent(): EventQueueNode<T> | undefined {
+		while (this.#queueLength > 0) {
+			const node = this.#dequeue()!;
+			if (node.type === "event") return node;
+			this.#settleConsumerDrain(node.drain, "resolve");
+		}
+		return undefined;
 	}
 
 	push(event: T): void {
@@ -63,26 +129,49 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 			this.resolveFinalResult(this.extractResult(event));
 		}
 
-		// Deliver to waiting consumer or queue it
-		const waiter = this.waiting.shift();
-		if (waiter) {
-			waiter.resolve({ value: event, done: false });
-		} else {
-			this.#enqueue(event);
-		}
+		this.deliver(event);
 	}
 
 	deliver(event: T): void {
-		const waiter = this.waiting.shift();
-		if (waiter) {
-			waiter.resolve({ value: event, done: false });
-		} else {
-			this.#enqueue(event);
+		if (this.#queueLength === 0) {
+			const waiter = this.waiting.shift();
+			if (waiter) {
+				waiter.resolve({ value: event, done: false });
+				return;
+			}
 		}
+		this.#enqueue({ type: "event", event });
+		this.#drainQueuedNodesToWaitingConsumers();
+	}
+
+	/**
+	 * Resolves after every event enqueued before this call has been yielded and
+	 * the consumer asks the iterator for its next node. The private sentinel is
+	 * never exposed through the async iterator.
+	 */
+	waitForConsumerDrain(signal: AbortSignal): Promise<void> {
+		if (signal.aborted) return Promise.reject(abortReason(signal));
+		if (this.#failed) return Promise.reject(this.#error);
+		if (this.done) return Promise.resolve();
+
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		let drain!: ConsumerDrain;
+		const abortListener = () => this.#settleConsumerDrain(drain, "reject", abortReason(signal));
+
+		drain = { settled: false, signal, abortListener, resolve, reject };
+		this.#pendingConsumerDrains.add(drain);
+		signal.addEventListener("abort", abortListener, { once: true });
+		this.#enqueue({ type: "consumer-drain", drain });
+		this.#drainQueuedNodesToWaitingConsumers();
+		return promise;
 	}
 
 	end(result?: R): void {
 		this.done = true;
+		if (this.#activeConsumerCount === 0) {
+			this.#settleAllConsumerDrains("reject", new Error("Event stream ended before consumer drain completed"));
+		}
+
 		if (result !== undefined) {
 			this.resolveFinalResult(result);
 		}
@@ -94,6 +183,9 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 	}
 
 	endWaiting(): void {
+		if (this.#activeConsumerCount === 0) {
+			this.#settleAllConsumerDrains("reject", new Error("Event stream ended before consumer drain completed"));
+		}
 		while (this.waiting.length > 0) {
 			const waiter = this.waiting.shift()!;
 			waiter.resolve({ value: undefined as any, done: true });
@@ -105,6 +197,8 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		this.done = true;
 		this.#failed = true;
 		this.#error = err;
+		this.#settleAllConsumerDrains("reject", err);
+
 		this.rejectFinalResult(err);
 		while (this.waiting.length > 0) {
 			const waiter = this.waiting.shift()!;
@@ -113,20 +207,27 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 	}
 
 	async *[Symbol.asyncIterator](): AsyncIterator<T> {
-		while (true) {
-			if (this.#queueLength > 0) {
-				yield this.#dequeue()!;
-			} else if (this.#failed) {
-				throw this.#error;
-			} else if (this.done) {
-				return;
-			} else {
-				const result = await new Promise<IteratorResult<T>>((resolve, reject) =>
-					this.waiting.push({ resolve, reject }),
-				);
-				if (result.done) return;
-				yield result.value;
+		this.#activeConsumerCount += 1;
+		try {
+			while (true) {
+				const node = this.#dequeueEvent();
+				if (node !== undefined) {
+					yield node.event;
+				} else if (this.#failed) {
+					throw this.#error;
+				} else if (this.done) {
+					return;
+				} else {
+					const result = await new Promise<IteratorResult<T>>((resolve, reject) =>
+						this.waiting.push({ resolve, reject }),
+					);
+					if (result.done) return;
+					yield result.value;
+				}
 			}
+		} finally {
+			this.#activeConsumerCount -= 1;
+			this.#settleAllConsumerDrains("reject", new Error("Event stream consumer stopped before drain completed"));
 		}
 	}
 
@@ -148,25 +249,5 @@ export class AssistantMessageEventStream extends EventStream<AssistantMessageEve
 				throw new Error("Unexpected event type for final result");
 			},
 		);
-	}
-
-	override push(event: AssistantMessageEvent): void {
-		if (this.done) return;
-
-		// Completion resolves the final result and still emits the terminal event.
-		if (this.isComplete(event)) {
-			this.done = true;
-			this.resolveFinalResult(this.extractResult(event));
-		}
-
-		this.deliver(event);
-	}
-
-	override end(result?: AssistantMessage): void {
-		this.done = true;
-		if (result !== undefined) {
-			this.resolveFinalResult(result);
-		}
-		this.endWaiting();
 	}
 }

--- a/packages/ai/test/event-stream-consumer-drain.test.ts
+++ b/packages/ai/test/event-stream-consumer-drain.test.ts
@@ -214,6 +214,75 @@ describe("EventStream.waitForConsumerDrain", () => {
 		await consumer;
 	});
 
+	it("waits for queued events when drain admission happens after end", async () => {
+		const stream = createStream();
+		const enteredA = deferred();
+		const releaseA = deferred();
+		const seen: string[] = [];
+		const consumer = (async () => {
+			for await (const event of stream) {
+				seen.push(event.id);
+				if (event.id === "A") {
+					enteredA.resolve();
+					await releaseA.promise;
+				}
+			}
+		})();
+
+		stream.push({ id: "A" });
+		await enteredA.promise;
+		stream.push({ id: "B" });
+		stream.end();
+		const drain = stream.waitForConsumerDrain(new AbortController().signal);
+		let settled = false;
+		void drain.then(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		releaseA.resolve();
+		await expect(drain).resolves.toBeUndefined();
+		expect(seen).toEqual(["A", "B"]);
+		await consumer;
+	});
+
+	it("waits for queued events when a terminal event precedes drain admission", async () => {
+		const stream = new EventStream<Event, void>(
+			event => event.id === "done",
+			() => undefined,
+		);
+		const entered = deferred();
+		const release = deferred();
+		const seen: string[] = [];
+		const consumer = (async () => {
+			for await (const event of stream) {
+				seen.push(event.id);
+				if (event.id === "held") {
+					entered.resolve();
+					await release.promise;
+				}
+			}
+		})();
+
+		stream.push({ id: "held" });
+		await entered.promise;
+		stream.push({ id: "queued" });
+		stream.push({ id: "done" });
+		const drain = stream.waitForConsumerDrain(new AbortController().signal);
+		let settled = false;
+		void drain.then(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		release.resolve();
+		await expect(drain).resolves.toBeUndefined();
+		expect(seen).toEqual(["held", "queued", "done"]);
+		await consumer;
+	});
+
 	it("rejects and detaches unconsumed pending drains when streams end or fail", async () => {
 		const ended = createStream();
 		const endTracked = createTrackedAbortController();

--- a/packages/ai/test/event-stream-consumer-drain.test.ts
+++ b/packages/ai/test/event-stream-consumer-drain.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "bun:test";
+import { EventStream } from "../src/utils/event-stream";
+
+type Event = { id: string };
+
+function deferred<T = void>(): PromiseWithResolvers<T> {
+	return Promise.withResolvers<T>();
+}
+
+function createStream(): EventStream<Event, void> {
+	return new EventStream<Event, void>(
+		() => false,
+		() => undefined,
+	);
+}
+
+function createTrackedAbortController(): {
+	controller: AbortController;
+	listenerCount: () => number;
+	addCalls: () => number;
+} {
+	const controller = new AbortController();
+	const signal = controller.signal;
+	const originalAddEventListener = signal.addEventListener.bind(signal);
+	const originalRemoveEventListener = signal.removeEventListener.bind(signal);
+	const listeners = new Set<unknown>();
+
+	let adds = 0;
+
+	Object.defineProperties(signal, {
+		addEventListener: {
+			value: (type: string, listener: unknown, options?: boolean | AddEventListenerOptions) => {
+				if (type === "abort") {
+					adds += 1;
+					listeners.add(listener);
+				}
+				originalAddEventListener(type as "abort", listener as never, options);
+			},
+		},
+		removeEventListener: {
+			value: (type: string, listener: unknown, options?: boolean | EventListenerOptions) => {
+				if (type === "abort") listeners.delete(listener);
+				originalRemoveEventListener(type as "abort", listener as never, options);
+			},
+		},
+	});
+
+	return {
+		controller,
+		listenerCount: () => listeners.size,
+		addCalls: () => adds,
+	};
+}
+
+describe("EventStream.waitForConsumerDrain", () => {
+	it("waits for FIFO consumer bodies before resolving the private sentinel", async () => {
+		const stream = createStream();
+		const enteredA = deferred();
+		const releaseA = deferred();
+		const enteredB = deferred();
+		const releaseB = deferred();
+		const seen: string[] = [];
+		const consumer = (async () => {
+			for await (const event of stream) {
+				seen.push(event.id);
+				if (event.id === "A") {
+					enteredA.resolve();
+					await releaseA.promise;
+				} else if (event.id === "B") {
+					enteredB.resolve();
+					await releaseB.promise;
+				}
+			}
+		})();
+
+		stream.push({ id: "A" });
+		await enteredA.promise;
+		stream.push({ id: "B" });
+		const drain = stream.waitForConsumerDrain(new AbortController().signal);
+		let settled = false;
+		void drain.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+
+		await Promise.resolve();
+		expect(settled).toBe(false);
+		releaseA.resolve();
+		await enteredB.promise;
+		await Promise.resolve();
+		expect(settled).toBe(false);
+		releaseB.resolve();
+		await expect(drain).resolves.toBeUndefined();
+		expect(seen).toEqual(["A", "B"]);
+
+		stream.end();
+		await consumer;
+	});
+
+	it("preserves concurrent sentinel ordering without yielding sentinel events", async () => {
+		const stream = createStream();
+		const iterator = stream[Symbol.asyncIterator]();
+		stream.push({ id: "A" });
+		expect(await iterator.next()).toMatchObject({ done: false, value: { id: "A" } });
+
+		const order: string[] = [];
+		const first = stream.waitForConsumerDrain(new AbortController().signal).then(() => order.push("first"));
+		const second = stream.waitForConsumerDrain(new AbortController().signal).then(() => order.push("second"));
+		expect(stream.pendingConsumerDrainCountForTests).toBe(2);
+		expect(stream.queue).toEqual([]);
+
+		const next = iterator.next();
+		await Promise.all([first, second]);
+		expect(order).toEqual(["first", "second"]);
+		expect(stream.pendingConsumerDrainCountForTests).toBe(0);
+
+		stream.end();
+		expect(await next).toEqual({ value: undefined, done: true });
+	});
+
+	it("rejects queued sentinels on source abort and leaves tombstones inert", async () => {
+		const stream = createStream();
+		const enteredA = deferred();
+		const releaseA = deferred();
+		const enteredB = deferred();
+		const releaseB = deferred();
+		const consumer = (async () => {
+			for await (const event of stream) {
+				if (event.id === "A") {
+					enteredA.resolve();
+					await releaseA.promise;
+				} else if (event.id === "B") {
+					enteredB.resolve();
+					await releaseB.promise;
+				}
+			}
+		})();
+
+		stream.push({ id: "A" });
+		await enteredA.promise;
+		stream.push({ id: "B" });
+		const tracked = createTrackedAbortController();
+		const drain = stream.waitForConsumerDrain(tracked.controller.signal);
+		let settlements = 0;
+		void drain.then(
+			() => {
+				settlements += 1;
+			},
+			() => {
+				settlements += 1;
+			},
+		);
+		expect(tracked.addCalls()).toBe(1);
+		expect(tracked.listenerCount()).toBe(1);
+
+		const reason = new Error("source aborted");
+		tracked.controller.abort(reason);
+		await expect(drain).rejects.toBe(reason);
+		expect(stream.pendingConsumerDrainCountForTests).toBe(0);
+		expect(tracked.listenerCount()).toBe(0);
+		expect(settlements).toBe(1);
+
+		releaseA.resolve();
+		await enteredB.promise;
+		releaseB.resolve();
+		await Promise.resolve();
+		expect(settlements).toBe(1);
+
+		stream.end();
+		await consumer;
+	});
+
+	it("rejects an already-aborted source without enqueuing or registering a listener", async () => {
+		const stream = createStream();
+		const tracked = createTrackedAbortController();
+		const reason = new Error("already aborted");
+		tracked.controller.abort(reason);
+
+		await expect(stream.waitForConsumerDrain(tracked.controller.signal)).rejects.toBe(reason);
+		expect(stream.pendingConsumerDrainCountForTests).toBe(0);
+		expect(stream.queue).toEqual([]);
+		expect(tracked.addCalls()).toBe(0);
+		expect(tracked.listenerCount()).toBe(0);
+	});
+
+	it("does not report a successful drain before a held consumer body finishes when the stream ends", async () => {
+		const stream = createStream();
+		const entered = deferred();
+		const release = deferred();
+		const consumer = (async () => {
+			for await (const _event of stream) {
+				entered.resolve();
+				await release.promise;
+			}
+		})();
+
+		stream.push({ id: "held" });
+		await entered.promise;
+		const drain = stream.waitForConsumerDrain(new AbortController().signal);
+		let settled = false;
+		void drain.then(() => {
+			settled = true;
+		});
+		stream.end();
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		release.resolve();
+		await expect(drain).resolves.toBeUndefined();
+		await consumer;
+	});
+
+	it("rejects and detaches unconsumed pending drains when streams end or fail", async () => {
+		const ended = createStream();
+		const endTracked = createTrackedAbortController();
+		const endDrain = ended.waitForConsumerDrain(endTracked.controller.signal);
+		expect(ended.pendingConsumerDrainCountForTests).toBe(1);
+		ended.end();
+		await expect(endDrain).rejects.toThrow("Event stream ended before consumer drain completed");
+		expect(ended.pendingConsumerDrainCountForTests).toBe(0);
+		expect(endTracked.listenerCount()).toBe(0);
+
+		const failed = createStream();
+		const failTracked = createTrackedAbortController();
+		const failure = new Error("stream failed");
+		const failDrain = failed.waitForConsumerDrain(failTracked.controller.signal);
+		expect(failed.pendingConsumerDrainCountForTests).toBe(1);
+		failed.fail(failure);
+		await expect(failDrain).rejects.toBe(failure);
+		expect(failed.pendingConsumerDrainCountForTests).toBe(0);
+		expect(failTracked.listenerCount()).toBe(0);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Cooperative mid-run context maintenance now waits at a cancellation-aware FIFO consumer-drain checkpoint before flushing or rewriting session history. Materialized tool results and steering messages are synchronously canonicalized first; aborted barriers and hook/signal-cancelled compactions settle without rewriting or scheduling a continuation. Promotion, pruning, and compaction each start a clean provider/prompt-cache epoch. Script-aware #2067 unsent-delta accounting remains cache-free and distinct from the lifecycle checkpoint.
+
 ### Added
 
 - Added the additive SDK Q10 model-catalog DTO: `Q10`, `models.list/current`, `models.list`, and `models.current` now return the same paged registry rows with reasoning/thinking capability metadata and current-model readback. `thinking.validLevels` is an `off`-first canonical menu; sparse raw reasoning descriptors remain available for inspection. The public DTO types are exported from `@gajae-code/coding-agent/sdk`, while undocumented `/sdk/models` deep imports remain unavailable. `inherit` is readback-only and malformed descriptors fail with a safe internal SDK error (#2163).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -23,7 +23,9 @@ import {
 	type AfterToolCallResult,
 	type Agent,
 	AgentBusyError,
+	type AgentContext,
 	type AgentEvent,
+	type AgentLoopConfig,
 	type AgentMessage,
 	type AgentState,
 	type AgentTool,
@@ -32,6 +34,7 @@ import {
 	type ManagedAttemptContinuationOwnership,
 	type ManagedAttemptDecision,
 	type ManagedAttemptOutcome,
+	type MidRunMaintenanceOutcome,
 	resolveTelemetry,
 	type StablePrefixSnapshot,
 	ThinkingLevel,
@@ -539,6 +542,14 @@ export interface AgentSessionConfig {
 	/** Optional provider-facing cache identity, distinct from logical session identity. */
 	providerCacheSessionId?: string;
 }
+
+type MidRunMaintenanceLifecycle = Parameters<NonNullable<AgentLoopConfig["maintainContext"]>>[1];
+
+type AutoCompactionTerminalStatus =
+	| { kind: "compacted" }
+	| { kind: "aborted"; source: "signal" | "hook" }
+	| { kind: "skipped" }
+	| { kind: "failed" };
 
 /** Options for AgentSession.prompt() */
 export interface PromptOptions {
@@ -1324,6 +1335,18 @@ export class AgentSession {
 	// Compaction state
 	#compactionAbortController: AbortController | undefined = undefined;
 	#autoCompactionAbortController: AbortController | undefined = undefined;
+
+	/** Invocation-scoped EventStream drain barriers owned by active maintenance calls. */
+	#activeMidRunBarrierControllers = new Set<AbortController>();
+	/** Maintenance invocations that must settle before resources are torn down. */
+	#activeMidRunMaintenancePromises = new Set<Promise<MidRunMaintenanceOutcome>>();
+	// Anti-loop guard (#1662): signature of the assistant response that last
+	// anchored a mid-run maintenance attempt. A given provider response drives at
+	// most one attempt, so a compaction that cannot shrink further can't wedge the
+	// loop into interrupt → resume → interrupt; a NEW response (fresh signature) is
+	// required to re-trigger. A content signature (not object identity) is used so
+	// it survives the message-array rebuild that compaction/prune perform.
+	#lastMidRunMaintenanceAnchorSignature: string | undefined = undefined;
 	#resourceSampler: () => EmergencyCompactionSample = () => this.#defaultResourceSample();
 	#retainedMemorySampler: (() => RetainedMemorySample) | undefined;
 	#prePromptContextCheckPromise: Promise<void> | undefined = undefined;
@@ -1389,6 +1412,7 @@ export class AgentSession {
 	#providerSessionId: string | undefined;
 	#providerCacheSessionId: string | undefined;
 	#isDisposed = false;
+	#disposePromise: Promise<void> | undefined;
 	// Extension system
 	#extensionRunner: ExtensionRunner | undefined = undefined;
 
@@ -1868,6 +1892,9 @@ export class AgentSession {
 			},
 		});
 		this.agent.setOnBeforeYield(() => this.yieldQueue.flush("streaming"));
+		this.agent.setMaintainContext((context, lifecycle) =>
+			this.#trackMidRunMaintenance(this.#runMidRunMaintenance(context, lifecycle)),
+		);
 		this.#convertToLlm = config.convertToLlm ?? convertToLlm;
 		this.#rebuildSystemPrompt = config.rebuildSystemPrompt;
 		this.#getMcpServerInstructions = config.getMcpServerInstructions;
@@ -2500,6 +2527,12 @@ export class AgentSession {
 			}
 			return;
 		}
+		// A maintenance agent_end is an internal checkpoint only while another
+		// continuation will follow. An aborted maintenance run is its terminal
+		// settlement and must reach public subscribers.
+		if (event.type === "agent_end" && event.stopReason === "maintenance" && event.maintenanceOutcome !== "aborted")
+			return;
+
 		const persistRuntimeState = () => this.#persistRuntimeStateInBackground(event);
 		// Hold agent_end until the prompt's finally and all earlier async event work
 		// have unwound. Subscribers treat this event as the ready signal; flushing it
@@ -2541,6 +2574,13 @@ export class AgentSession {
 		if (event.type === "tool_execution_end" && event.toolName === "yield" && !event.isError) {
 			this.#lastSuccessfulYieldToolCallId = event.toolCallId;
 		}
+
+		// Agent listeners run synchronously, but this handler yields while emitting
+		// session events. Capture the maintenance run identity before that yield so
+		// a later raw listener cannot revive a cancelled/replaced continuation.
+		const maintenanceGeneration =
+			event.type === "agent_end" && event.stopReason === "maintenance" ? this.#promptGeneration : undefined;
+		const maintenanceWasDisposed = this.#isDisposed;
 		// When a user message starts, check if it's from either queue and remove it BEFORE emitting
 		// This ensures the UI sees the updated queue state
 		if (event.type === "message_start" && event.message.role === "user") {
@@ -2605,9 +2645,36 @@ export class AgentSession {
 			this.#silentAbortPending = false;
 		}
 
+		// Canonical persistence must happen synchronously before listener work can
+		// await: the EventStream FIFO drain then guarantees tool results and every
+		// steering message are in the branch before a maintenance rewrite starts.
+		if (event.type === "message_end") {
+			if (event.message.role === "hookMessage" || event.message.role === "custom") {
+				const isRosterReminder = event.message.role === "custom" && event.message.customType === "irc-peer-roster";
+				if (!isRosterReminder) {
+					this.sessionManager.appendCustomMessageEntry(
+						event.message.customType,
+						event.message.content,
+						event.message.display,
+						event.message.details,
+						event.message.attribution ?? "agent",
+						getSessionMessageObservationId(event.message),
+					);
+				}
+			} else if (
+				event.message.role === "user" ||
+				event.message.role === "developer" ||
+				event.message.role === "assistant" ||
+				event.message.role === "toolResult" ||
+				event.message.role === "fileMention"
+			) {
+				this.sessionManager.appendMessage(event.message);
+			}
+		}
+
 		// Deobfuscate assistant message content for display emission — the LLM echoes back
 		// obfuscated placeholders, but listeners (TUI, extensions, exporters) must see real
-		// values. The original event.message stays obfuscated so the persistence path below
+		// values. The original event.message stays obfuscated so the canonical persistence path above
 		// writes `#HASH#` tokens to the session file; convertToLlm re-obfuscates outbound
 		// traffic on the next turn. Walks text, thinking, and toolCall arguments/intent.
 		let displayEvent: AgentEvent = event;
@@ -2804,38 +2871,11 @@ export class AgentSession {
 			this.#maybeAbortStreamingEdit(event, this.#promptGeneration);
 		}
 
-		// Handle session persistence
+		// Handle post-persistence message side effects.
 		if (event.type === "message_end") {
-			// Check if this is a hook/custom message
-			if (event.message.role === "hookMessage" || event.message.role === "custom") {
-				// Roster reminders are request-context-only: never persist them, or a
-				// reload would resurrect stale rosters into agent history.
-				const isRosterReminder = event.message.role === "custom" && event.message.customType === "irc-peer-roster";
-				if (!isRosterReminder) {
-					// Persist as CustomMessageEntry
-					this.sessionManager.appendCustomMessageEntry(
-						event.message.customType,
-						event.message.content,
-						event.message.display,
-						event.message.details,
-						event.message.attribution ?? "agent",
-						getSessionMessageObservationId(event.message),
-					);
-				}
-				if (event.message.role === "custom" && event.message.customType === "ttsr-injection") {
-					this.#markTtsrInjected(this.#extractTtsrRuleNames(event.message.details));
-				}
-			} else if (
-				event.message.role === "user" ||
-				event.message.role === "developer" ||
-				event.message.role === "assistant" ||
-				event.message.role === "toolResult" ||
-				event.message.role === "fileMention"
-			) {
-				// Regular LLM message - persist as SessionMessageEntry
-				this.sessionManager.appendMessage(event.message);
+			if (event.message.role === "custom" && event.message.customType === "ttsr-injection") {
+				this.#markTtsrInjected(this.#extractTtsrRuleNames(event.message.details));
 			}
-			// Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
 
 			// Track assistant message for auto-compaction (checked on agent_end)
 			if (event.message.role === "assistant") {
@@ -2946,6 +2986,29 @@ export class AgentSession {
 
 		// Check auto-retry and auto-compaction after agent completes
 		if (event.type === "agent_end") {
+			// Cooperative mid-run maintenance interruption (issue #2035). The loop
+			// ended the run losslessly after #runMidRunMaintenance did prune/
+			// compact/promote; this handler is the SINGLE continuation owner. Resume
+			// the same run on the rewritten context (no synthetic prompt), skipping
+			// the goal-runtime / skill-state / retry / compaction finalization a
+			// normal agent_end runs — none of that applies to an in-progress run.
+			// "aborted" settles without resuming; the generation guard drops the
+			// continuation if a newer prompt/abort has moved the run on.
+			if (event.stopReason === "maintenance") {
+				this.#lastAssistantMessage = undefined;
+				const outcome = event.maintenanceOutcome;
+				if (
+					outcome &&
+					outcome !== "aborted" &&
+					!maintenanceWasDisposed &&
+					!this.#isDisposed &&
+					maintenanceGeneration !== undefined &&
+					this.#promptGeneration === maintenanceGeneration
+				) {
+					this.#scheduleAgentContinue({ generation: maintenanceGeneration, skipCompactionCheck: true });
+				}
+				return;
+			}
 			const usage = this.getSessionStats().tokens;
 			await this.#goalRuntime.onAgentEnd({
 				currentUsage: {
@@ -3153,21 +3216,26 @@ export class AgentSession {
 		const signal = this.#postPromptTasksAbortController.signal;
 		return this.#schedulePostPromptTask(
 			async () => {
-				if (signal.aborted) {
-					skip("aborted_signal");
-					return;
-				}
-				if (scheduledGeneration !== undefined && this.#promptGeneration !== scheduledGeneration) {
-					skip("generation_changed");
-					return;
-				}
-				if (options?.shouldContinue && !options.shouldContinue()) {
-					skip("queue_drained");
-					return;
-				}
+				const canContinue = (): boolean => {
+					if (signal.aborted || this.#isDisposed) {
+						skip("aborted_signal");
+						return false;
+					}
+					if (scheduledGeneration !== undefined && this.#promptGeneration !== scheduledGeneration) {
+						skip("generation_changed");
+						return false;
+					}
+					if (options?.shouldContinue && !options.shouldContinue()) {
+						skip("queue_drained");
+						return false;
+					}
+					return true;
+				};
+				if (!canContinue()) return;
 				try {
 					if (!options?.skipCompactionCheck) {
 						await this.#checkEstimatedContextBeforePrompt();
+						if (!canContinue()) return;
 					}
 					if (signal.aborted) {
 						skip("aborted_signal");
@@ -4168,6 +4236,7 @@ export class AgentSession {
 	 * Used internally during operations that need to pause event processing.
 	 */
 	#disconnectFromAgent(): void {
+		this.#abortActiveMidRunBarriers();
 		if (this.#unsubscribeAgent) {
 			this.#unsubscribeAgent();
 			this.#unsubscribeAgent = undefined;
@@ -4221,12 +4290,49 @@ export class AgentSession {
 	 * Remove all listeners, flush pending writes, and disconnect from agent.
 	 * Call this when completely done with the session.
 	 */
-	async dispose(): Promise<void> {
+	dispose(): Promise<void> {
 		this.#evalExecutionDisposing = true;
-		await this.#closeSessionAdmission();
+		if (this.#disposePromise) return this.#disposePromise;
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		this.#disposePromise = promise;
+		void this.#dispose().then(resolve, reject);
+		return promise;
+	}
+
+	async #dispose(): Promise<void> {
+		const admissionClosed = this.#closeSessionAdmission();
 		this.#isDisposed = true;
+		// Reject new direct Python starts as soon as disposal begins (synchronously,
+		// before any await) so callers cannot race a start against teardown.
+		this.#evalExecutionDisposing = true;
+		this.#abortActiveMidRunBarriers();
+		this.abortCompaction();
+		this.agent.abort();
+		// Disconnect the Agent event bridge NOW — before the maintenance join and the
+		// bounded idle / forceAbort below — so no agent_end emitted during teardown
+		// (including the one forceAbort emits) can re-enter #handleAgentEvent and start
+		// fresh post-turn maintenance or mutate the closing session. Maintenance promises
+		// are joined directly (not via events), so this does not affect the join.
+		this.#disconnectFromAgent();
+		// R2-5: join any in-flight mid-run maintenance invocation before teardown so the
+		// abort-aware maintenance promise (already aborted above) settles and cannot touch
+		// torn-down state afterward.
+		await this.#waitForActiveMidRunMaintenance();
+		// R2-5: give the aborted Agent run a bounded chance to settle, then force-
+		// invalidate its run id so an abort-ignoring provider/tool cannot emit a late
+		// message_end after teardown. Mirrors AgentSession.abort({ timeoutMs }).
+		const disposeIdleSettled = await Promise.race([
+			this.agent.waitForIdle().then(
+				() => true,
+				() => true,
+			),
+			Bun.sleep(2_000).then(() => false),
+		]);
+		if (!disposeIdleSettled) this.agent.forceAbort("Session disposed");
+		await admissionClosed;
 		this.#pendingBackgroundExchanges = [];
 		this.yieldQueue.clear();
+
 		this.agent.setOnBeforeYield(undefined);
 		try {
 			if (this.#extensionRunner?.hasHandlers("session_shutdown")) {
@@ -4287,12 +4393,14 @@ export class AgentSession {
 		await disposeKernelSessionsByOwner(this.#evalKernelOwnerId);
 		await disposeVmContextsByOwner(this.#evalKernelOwnerId);
 		this.#releasePowerAssertion();
+		// Disconnect the agent event listener BEFORE closing session resources so a late
+		// provider/tool message_end cannot append to the closing SessionManager.
+		this.#disconnectFromAgent();
 		await this.sessionManager.close();
 		this.#closeAllProviderSessions("dispose");
 		const hindsightState = this.setHindsightSessionState(undefined);
 		await hindsightState?.flushRetainQueue();
 		hindsightState?.dispose();
-		this.#disconnectFromAgent();
 		if (this.#unsubscribeAppendOnly) {
 			this.#unsubscribeAppendOnly();
 			this.#unsubscribeAppendOnly = undefined;
@@ -7334,6 +7442,32 @@ export class AgentSession {
 		return this.#applyCompactionPostAppend(compactionEntryId, firstKeptEntryId, fromExtension);
 	}
 
+	/** Read-only test seam for active mid-run EventStream drain barriers. */
+	get activeMidRunBarrierCountForTests(): number {
+		return this.#activeMidRunBarrierControllers.size;
+	}
+
+	/** Read-only test seam for active mid-run maintenance invocations. */
+	get activeMidRunMaintenanceCountForTests(): number {
+		return this.#activeMidRunMaintenancePromises.size;
+	}
+
+	/** Test seam: drive the cooperative mid-run maintenance checkpoint directly. */
+	runMidRunMaintenanceForTests(
+		context: AgentContext,
+		lifecycle: MidRunMaintenanceLifecycle = {
+			signal: new AbortController().signal,
+			awaitEventDrain: async () => {},
+		},
+	): Promise<MidRunMaintenanceOutcome> {
+		return this.#trackMidRunMaintenance(this.#runMidRunMaintenance(context, lifecycle));
+	}
+
+	/** Test seam: estimate mid-run context tokens for a given context view. */
+	estimateMidRunContextTokensForTests(messages: readonly AgentMessage[]): number {
+		return this.#estimateMidRunContextTokens(messages);
+	}
+
 	#cloneTodoPhases(phases: TodoPhase[]): TodoPhase[] {
 		return phases.map(phase => ({
 			name: phase.name,
@@ -7371,6 +7505,7 @@ export class AgentSession {
 		 *  hand-off rather than a failure. */
 		silent?: boolean;
 	}): Promise<void> {
+		this.#abortActiveMidRunBarriers();
 		if (options?.silent) {
 			this.#silentAbortPending = true;
 		} else {
@@ -7803,14 +7938,17 @@ export class AgentSession {
 			cause?: ModelChangeCause;
 			reason?: TemporaryModelReason;
 			providerSessionScope?: TemporaryProviderSessionScope;
+			signal?: AbortSignal;
 		},
 		// biome-ignore lint/suspicious/noConfusingVoidType: Existing session adapters return Promise<void>; a scope is optional.
 	): Promise<TemporaryProviderSessionScope | void> {
+		if (options?.signal?.aborted) return;
 		const suppliedScope = options?.providerSessionScope;
 		if (suppliedScope && this.#temporaryProviderSessionScopes.at(-1)?.token !== suppliedScope) return;
-
 		const previousEditMode = this.#resolveActiveEditMode();
 		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
+		if (options?.signal?.aborted) return;
+
 		if (!apiKey) {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
@@ -8406,7 +8544,7 @@ export class AgentSession {
 	// Compaction
 	// =========================================================================
 
-	async #pruneToolOutputs(): Promise<{ prunedCount: number; tokensSaved: number } | undefined> {
+	async #pruneToolOutputs(signal?: AbortSignal): Promise<{ prunedCount: number; tokensSaved: number } | undefined> {
 		const branchEntries = this.sessionManager.getBranch();
 		const result = pruneToolOutputs(branchEntries, DEFAULT_PRUNE_CONFIG);
 		const argumentResult = pruneAssistantToolArguments(branchEntries, DEFAULT_PRUNE_CONFIG);
@@ -8416,7 +8554,7 @@ export class AgentSession {
 		const tokensSaved =
 			result.tokensSaved + argumentResult.argumentTokensSaved + Math.round(fileMentionResult.bytesSaved / 4);
 		const prunedCount = result.prunedCount + argumentResult.argumentPrunedCount + fileMentionResult.changed.length;
-		if (prunedCount === 0) {
+		if (prunedCount === 0 || signal?.aborted) {
 			return undefined;
 		}
 
@@ -8679,6 +8817,28 @@ export class AgentSession {
 		this.#compactionAbortController?.abort();
 		this.#autoCompactionAbortController?.abort();
 		this.#handoffAbortController?.abort();
+	}
+
+	#abortActiveMidRunBarriers(): void {
+		for (const controller of this.#activeMidRunBarrierControllers) {
+			controller.abort();
+		}
+		this.#activeMidRunBarrierControllers.clear();
+	}
+
+	#trackMidRunMaintenance(maintenance: Promise<MidRunMaintenanceOutcome>): Promise<MidRunMaintenanceOutcome> {
+		this.#activeMidRunMaintenancePromises.add(maintenance);
+		maintenance.then(
+			() => this.#activeMidRunMaintenancePromises.delete(maintenance),
+			() => this.#activeMidRunMaintenancePromises.delete(maintenance),
+		);
+		return maintenance;
+	}
+
+	async #waitForActiveMidRunMaintenance(): Promise<void> {
+		while (this.#activeMidRunMaintenancePromises.size > 0) {
+			await Promise.allSettled([...this.#activeMidRunMaintenancePromises]);
+		}
 	}
 
 	/** Trigger idle compaction through the auto-compaction flow (with UI events). */
@@ -8961,6 +9121,167 @@ export class AgentSession {
 				await this.#runAutoCompaction("threshold", false);
 			}
 		}
+	}
+
+	/**
+	 * Cooperative mid-run context maintenance (issue #2035).
+	 *
+	 * Invoked by the agent loop (via {@link Agent.setMaintainContext}) at the top
+	 * of each tool-loop iteration — after pending tool-result / steering messages
+	 * are durable and before the model call. Threshold-based auto-compaction was
+	 * previously only evaluated at `agent_end` and before a user prompt, so a
+	 * single long agentic run grew straight through the compaction margin and died
+	 * with provider `context_length_exceeded`. This bounds that run.
+	 *
+	 * Decision input is the last assistant `usage.totalTokens` plus the estimated
+	 * trailing tool/steering deltas (NOT the pre-prompt estimator's prompt-only
+	 * anchor, which drops the last assistant's output). Reuses the existing
+	 * prune → promote → compact machinery and returns an explicit outcome.
+	 *
+	 * A non-"not-needed" outcome ends the current run losslessly
+	 * (`agent_end.stopReason === "maintenance"`); the `agent_end` handler is the
+	 * single continuation owner that resumes the run with no synthetic prompt.
+	 * This method never self-continues, runs goal-runtime hooks, clears skill
+	 * state, or emits a user-facing pause.
+	 */
+	async #runMidRunMaintenance(
+		context: AgentContext,
+		lifecycle: MidRunMaintenanceLifecycle,
+	): Promise<MidRunMaintenanceOutcome> {
+		if (this.#isDisposed) return "aborted";
+		const invocationController = new AbortController();
+		this.#activeMidRunBarrierControllers.add(invocationController);
+		const maintenanceSignal = AbortSignal.any([lifecycle.signal, invocationController.signal]);
+		const isAborted = () => maintenanceSignal.aborted;
+
+		try {
+			try {
+				await lifecycle.awaitEventDrain(invocationController.signal);
+			} catch {
+				return isAborted() ? "aborted" : "failed";
+			}
+			if (isAborted()) return "aborted";
+
+			// In-place context-full maintenance only. "off" defers entirely; "handoff"
+			// keeps its existing agent_end / pre-prompt boundaries (a mid-tool-loop
+			// session swap would be far more disruptive than the overflow it avoids).
+			const compactionSettings = this.settings.getGroup("compaction");
+			if (!compactionSettings.enabled || compactionSettings.strategy !== "context-full") return "not-needed";
+			const contextWindow = this.model?.contextWindow ?? 0;
+			if (contextWindow <= 0) return "not-needed";
+			// A compaction already in flight (overflow recovery, manual, idle) owns the
+			// context; never double-compact underneath it.
+			if (this.isCompacting) return "not-needed";
+
+			// Model maxTokens is a capability ceiling, not a per-turn reservation;
+			// track actual context fullness (mirrors the agent_end / pre-prompt checks).
+			const autoCompactionOutputReserveTokens = 0;
+			const anchor = this.#findMidRunUsageAnchor(context.messages);
+			let contextTokens = this.#estimateMidRunContextTokens(context.messages);
+			if (!shouldCompact(contextTokens, contextWindow, compactionSettings, autoCompactionOutputReserveTokens)) {
+				return "not-needed";
+			}
+			// Anti-loop (#1662): a given provider response anchors at most one
+			// maintenance attempt. Until a NEW response re-anchors usage, repeat checks
+			// on the same anchor are no-ops so a compaction that cannot shrink further
+			// cannot wedge the loop into interrupt → resume → interrupt.
+			const anchorSignature = anchor
+				? `${anchor.message.provider}/${anchor.message.model}#${anchor.message.timestamp}#${calculateContextTokens(anchor.message.usage as Usage)}`
+				: undefined;
+			if (anchorSignature) {
+				if (anchorSignature === this.#lastMidRunMaintenanceAnchorSignature) return "not-needed";
+				this.#lastMidRunMaintenanceAnchorSignature = anchorSignature;
+			}
+
+			// The FIFO consumer barrier made every prior materialized message canonical.
+			// Flush those synchronous branch appends before any history rewrite.
+			if (isAborted()) return "aborted";
+			await this.sessionManager.flush();
+			if (isAborted()) return "aborted";
+
+			// 1) Prune stale tool outputs first — cheaper than compaction, may avert it,
+			//    and (like all history rewrites) resets the codex provider session /
+			//    prompt-cache epoch via #closeCodexProviderSessionsForHistoryRewrite.
+			if (isAborted()) return "aborted";
+			const pruneResult = await this.#pruneToolOutputs(maintenanceSignal);
+			if (isAborted()) return "aborted";
+			if (pruneResult) {
+				contextTokens = Math.max(0, contextTokens - pruneResult.tokensSaved);
+			}
+			if (!shouldCompact(contextTokens, contextWindow, compactionSettings, autoCompactionOutputReserveTokens)) {
+				return pruneResult && pruneResult.prunedCount > 0 ? "pruned" : "not-needed";
+			}
+
+			// 2) Try context promotion (switch to a larger-window model) before compacting.
+			const lastAssistant = this.#findLastAssistantMessage();
+			if (lastAssistant && lastAssistant.stopReason !== "aborted" && lastAssistant.stopReason !== "error") {
+				if (isAborted()) return "aborted";
+				const promoted = await this.#tryContextPromotion(lastAssistant, maintenanceSignal);
+				if (isAborted()) return "aborted";
+				if (promoted) return "promoted";
+			}
+
+			// 3) Compact via the existing auto-compaction machinery. continueAfterMaintenance
+			//    is false so it does NOT schedule its own (synthetic) continuation — the
+			//    agent_end("maintenance") handler owns resumption. The oversized-maintenance
+			//    signature guard and the previous_response_id / prompt-cache-epoch reset
+			//    (#applyCompactionPostAppend) are inherited from #runAutoCompaction.
+			if (isAborted()) return "aborted";
+			const compactionStatus = await this.#runAutoCompaction("threshold", false, false, {
+				continueAfterMaintenance: false,
+				deferHandoffMaintenance: false,
+				signal: maintenanceSignal,
+			});
+			if (isAborted()) return "aborted";
+			if (compactionStatus.kind === "compacted") return "compacted";
+			if (compactionStatus.kind === "aborted") {
+				return compactionStatus.source === "hook" ? "not-needed" : "aborted";
+			}
+			return "failed";
+		} finally {
+			this.#activeMidRunBarrierControllers.delete(invocationController);
+		}
+	}
+
+	/**
+	 * Mid-run context-token estimate for {@link #runMidRunMaintenance}.
+	 *
+	 * Anchors on the last non-error assistant's `usage.totalTokens` — at the top
+	 * of a tool-loop iteration that output is already durable context that will be
+	 * re-sent — plus the inflated script-aware delta (see {@link #estimateMessageCompactionDeltaTokens}) of every trailing tool-result /
+	 * steering message appended since. Operates on the loop's authoritative
+	 * context view (not `this.messages`) so it is independent of listener flush
+	 * timing.
+	 */
+	#estimateMidRunContextTokens(messages: readonly AgentMessage[]): number {
+		const anchor = this.#findMidRunUsageAnchor(messages);
+		if (!anchor) {
+			let estimated = 0;
+			for (const message of messages) estimated += this.#estimateMessageCompactionDeltaTokens(message);
+			return estimated;
+		}
+		let tokens = calculateContextTokens(anchor.message.usage as Usage);
+		for (let i = anchor.index + 1; i < messages.length; i++) {
+			tokens += this.#estimateMessageCompactionDeltaTokens(messages[i]);
+		}
+		return tokens;
+	}
+
+	/**
+	 * Locate the anchor for {@link #estimateMidRunContextTokens}: the most recent
+	 * non-aborted/non-error assistant message that carries provider usage. Also
+	 * keys the anti-loop guard so each provider response drives at most one
+	 * maintenance attempt.
+	 */
+	#findMidRunUsageAnchor(messages: readonly AgentMessage[]): { index: number; message: AssistantMessage } | undefined {
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const msg = messages[i];
+			if (msg.role !== "assistant") continue;
+			const assistantMsg = msg as AssistantMessage;
+			if (assistantMsg.stopReason === "aborted" || assistantMsg.stopReason === "error") continue;
+			if (assistantMsg.usage) return { index: i, message: assistantMsg };
+		}
+		return undefined;
 	}
 
 	async #checkEstimatedContextBeforePrompt(pendingMessages: readonly AgentMessage[] = []): Promise<void> {
@@ -9339,7 +9660,8 @@ export class AgentSession {
 	 * Attempt context promotion to a larger model.
 	 * Returns true if promotion succeeded (caller should retry without compacting).
 	 */
-	async #tryContextPromotion(assistantMessage: AssistantMessage): Promise<boolean> {
+	async #tryContextPromotion(assistantMessage: AssistantMessage, signal?: AbortSignal): Promise<boolean> {
+		if (signal?.aborted) return false;
 		const promotionSettings = this.settings.getGroup("contextPromotion");
 		if (!promotionSettings.enabled) return false;
 		const currentModel = this.model;
@@ -9348,14 +9670,19 @@ export class AgentSession {
 			return false;
 		const contextWindow = currentModel.contextWindow ?? 0;
 		if (contextWindow <= 0) return false;
-		const targetModel = await this.#resolveContextPromotionTarget(currentModel, contextWindow);
-		if (!targetModel) return false;
+		const targetModel = await this.#resolveContextPromotionTarget(currentModel, contextWindow, signal);
+		if (!targetModel || signal?.aborted) return false;
 
 		try {
-			await this.setModelTemporary(targetModel, undefined, {
+			const scope = await this.setModelTemporary(targetModel, undefined, {
 				cause: "temporary-operation",
 				reason: "context-promotion",
+				signal,
 			});
+			if (signal?.aborted) {
+				if (scope) this.restoreTemporaryProviderSessionScope(scope);
+				return false;
+			}
 			logger.debug("Context promotion switched model on overflow", {
 				from: `${currentModel.provider}/${currentModel.id}`,
 				to: `${targetModel.provider}/${targetModel.id}`,
@@ -9371,7 +9698,12 @@ export class AgentSession {
 		}
 	}
 
-	async #resolveContextPromotionTarget(currentModel: Model, contextWindow: number): Promise<Model | undefined> {
+	async #resolveContextPromotionTarget(
+		currentModel: Model,
+		contextWindow: number,
+		signal?: AbortSignal,
+	): Promise<Model | undefined> {
+		if (signal?.aborted) return undefined;
 		const availableModels = this.#modelRegistry.getAvailable();
 		if (availableModels.length === 0) return undefined;
 
@@ -9380,7 +9712,7 @@ export class AgentSession {
 		if (modelsAreEqual(candidate, currentModel)) return undefined;
 		if (candidate.contextWindow <= contextWindow) return undefined;
 		const apiKey = await this.#modelRegistry.getApiKey(candidate, this.sessionId);
-		if (!apiKey) return undefined;
+		if (!apiKey || signal?.aborted) return undefined;
 		return candidate;
 	}
 
@@ -9928,13 +10260,18 @@ export class AgentSession {
 		reason: "overflow" | "threshold" | "idle",
 		willRetry: boolean,
 		deferred = false,
-		options?: { continueAfterMaintenance?: boolean; deferHandoffMaintenance?: boolean; force?: boolean },
-	): Promise<void> {
+		options?: {
+			continueAfterMaintenance?: boolean;
+			deferHandoffMaintenance?: boolean;
+			force?: boolean;
+			signal?: AbortSignal;
+		},
+	): Promise<AutoCompactionTerminalStatus> {
 		const compactionSettings = this.settings.getGroup("compaction");
 		// `force` is the non-disableable emergency floor (F6): it bypasses the user's
 		// disabled/off settings so a resource-floor breach still compacts before OOM.
-		if (!options?.force && compactionSettings.strategy === "off") return;
-		if (!options?.force && reason !== "idle" && !compactionSettings.enabled) return;
+		if (!options?.force && compactionSettings.strategy === "off") return { kind: "skipped" };
+		if (!options?.force && reason !== "idle" && !compactionSettings.enabled) return { kind: "skipped" };
 		const generation = this.#promptGeneration;
 		if (
 			options?.deferHandoffMaintenance !== false &&
@@ -9951,27 +10288,44 @@ export class AgentSession {
 				},
 				{ generation },
 			);
-			return;
+			return { kind: "skipped" };
 		}
 
 		let action: "context-full" | "handoff" =
 			compactionSettings.strategy === "handoff" && reason !== "overflow" ? "handoff" : "context-full";
 		const continueAfterMaintenance = options?.continueAfterMaintenance !== false;
-		await this.#emitSessionEvent({ type: "auto_compaction_start", reason, action });
-		// Abort any older auto-compaction before installing this run's controller.
+		// Register the controller before the observable start event so an abort from
+		// a local subscriber, extension, dispose, or caller signal owns this run.
 		this.#autoCompactionAbortController?.abort();
 		const autoCompactionAbortController = new AbortController();
 		this.#autoCompactionAbortController = autoCompactionAbortController;
-		const autoCompactionSignal = autoCompactionAbortController.signal;
+		const autoCompactionSignal = options?.signal
+			? AbortSignal.any([autoCompactionAbortController.signal, options.signal])
+			: autoCompactionAbortController.signal;
 		let maintenanceAttemptSignature: string | undefined;
+		const emitAborted = async (): Promise<AutoCompactionTerminalStatus> => {
+			await this.#emitSessionEvent({
+				type: "auto_compaction_end",
+				action,
+				result: undefined,
+				aborted: true,
+				willRetry: false,
+			});
+			return { kind: "aborted", source: "signal" };
+		};
 
 		try {
+			if (autoCompactionSignal.aborted) return { kind: "aborted", source: "signal" };
+			await this.#emitSessionEvent({ type: "auto_compaction_start", reason, action });
+			if (autoCompactionSignal.aborted) return await emitAborted();
+
 			if (compactionSettings.strategy === "handoff" && reason !== "overflow") {
 				const handoffFocus = AUTO_HANDOFF_THRESHOLD_FOCUS;
 				const handoffResult = await this.handoff(handoffFocus, {
 					autoTriggered: true,
-					signal: this.#autoCompactionAbortController.signal,
+					signal: autoCompactionSignal,
 				});
+
 				if (!handoffResult) {
 					const aborted = autoCompactionSignal.aborted;
 					if (aborted) {
@@ -9982,13 +10336,15 @@ export class AgentSession {
 							aborted: true,
 							willRetry: false,
 						});
-						return;
+						return { kind: "aborted", source: "signal" };
 					}
 					logger.warn("Auto-handoff returned no document; falling back to context-full maintenance", {
 						reason,
 					});
 					action = "context-full";
 				}
+				if (autoCompactionSignal.aborted) return await emitAborted();
+
 				if (handoffResult) {
 					await this.#emitSessionEvent({
 						type: "auto_compaction_end",
@@ -9997,15 +10353,12 @@ export class AgentSession {
 						aborted: false,
 						willRetry: false,
 					});
-					if (
-						continueAfterMaintenance &&
-						!autoCompactionSignal.aborted &&
-						reason !== "idle" &&
-						compactionSettings.autoContinue !== false
-					) {
+					if (autoCompactionSignal.aborted) return { kind: "aborted", source: "signal" };
+					if (continueAfterMaintenance && reason !== "idle" && compactionSettings.autoContinue !== false) {
 						this.#scheduleAutoContinuePrompt(generation);
 					}
-					return;
+					if (autoCompactionSignal.aborted) return { kind: "aborted", source: "signal" };
+					return { kind: "compacted" };
 				}
 			}
 
@@ -10018,7 +10371,7 @@ export class AgentSession {
 					willRetry: false,
 					skipped: true,
 				});
-				return;
+				return { kind: "skipped" };
 			}
 
 			const availableModels = this.#modelRegistry.getAvailable();
@@ -10031,8 +10384,10 @@ export class AgentSession {
 					willRetry: false,
 					skipped: true,
 				});
-				return;
+				return { kind: "skipped" };
 			}
+
+			if (autoCompactionSignal.aborted) return await emitAborted();
 
 			const pathEntries = this.sessionManager.getBranch();
 
@@ -10043,6 +10398,8 @@ export class AgentSession {
 			const preparation = prepareCompaction(pathEntries, compactionSettings, {
 				tokenCorrectionRatio: overflowRatio !== undefined ? Math.max(1, overflowRatio) : undefined,
 			});
+			if (autoCompactionSignal.aborted) return await emitAborted();
+
 			if (!preparation) {
 				const continuationSkipReason = willRetry ? this.#detectOverflowRetryContinuationSkip() : undefined;
 				await this.#emitSessionEvent({
@@ -10069,7 +10426,7 @@ export class AgentSession {
 				} else if (continueAfterMaintenance && reason !== "idle" && compactionSettings.autoContinue !== false) {
 					this.#scheduleAutoContinuePrompt(generation);
 				}
-				return;
+				return { kind: "skipped" };
 			}
 
 			let hookCompaction: CompactionResult | undefined;
@@ -10084,6 +10441,7 @@ export class AgentSession {
 					customInstructions: undefined,
 					signal: autoCompactionSignal,
 				})) as SessionBeforeCompactResult | undefined;
+				if (autoCompactionSignal.aborted) return await emitAborted();
 
 				if (hookResult?.cancel) {
 					await this.#emitSessionEvent({
@@ -10093,7 +10451,7 @@ export class AgentSession {
 						aborted: true,
 						willRetry: false,
 					});
-					return;
+					return { kind: "aborted", source: "hook" };
 				}
 
 				if (hookResult?.compaction) {
@@ -10103,6 +10461,7 @@ export class AgentSession {
 			}
 
 			const compactionPrep = await this.#prepareCompactionFromHooks(preparation, hookCompaction);
+			if (autoCompactionSignal.aborted) return await emitAborted();
 
 			let summary: string;
 			let shortSummary: string | undefined;
@@ -10137,7 +10496,7 @@ export class AgentSession {
 						errorMessage:
 							"Auto-compaction skipped: previous unchanged maintenance request exceeded the model context window; change or reduce the conversation before retrying maintenance.",
 					});
-					return;
+					return { kind: "skipped" };
 				}
 				const retrySettings = this.settings.getGroup("retry");
 				const telemetry = resolveTelemetry(this.agent.telemetry, this.sessionId);
@@ -10151,6 +10510,8 @@ export class AgentSession {
 					let attempt = 0;
 					while (true) {
 						try {
+							if (autoCompactionSignal.aborted) return await emitAborted();
+
 							compactResult = await compact(preparation, candidate, apiKey, undefined, autoCompactionSignal, {
 								...this.#maintenanceProviderTransport(),
 								promptOverride: compactionPrep.hookPrompt,
@@ -10249,7 +10610,7 @@ export class AgentSession {
 					aborted: true,
 					willRetry: false,
 				});
-				return;
+				return { kind: "aborted", source: "signal" };
 			}
 
 			const compactionEntryId = this.sessionManager.appendCompaction(
@@ -10262,6 +10623,7 @@ export class AgentSession {
 				preserveData,
 			);
 			await this.#applyCompactionPostAppend(compactionEntryId, firstKeptEntryId, fromExtension);
+			if (autoCompactionSignal.aborted) return await emitAborted();
 
 			const result: CompactionResult = {
 				summary,
@@ -10282,6 +10644,7 @@ export class AgentSession {
 				willRetry: willRetry && !continuationSkipReason,
 				continuationSkipReason,
 			});
+			if (autoCompactionSignal.aborted) return { kind: "aborted", source: "signal" };
 
 			if (willRetry) {
 				this.#scheduleOverflowRetryContinuation(generation);
@@ -10299,6 +10662,7 @@ export class AgentSession {
 			} else if (continueAfterMaintenance && reason !== "idle" && compactionSettings.autoContinue !== false) {
 				this.#scheduleAutoContinuePrompt(generation);
 			}
+			return { kind: "compacted" };
 		} catch (error) {
 			if (autoCompactionSignal.aborted) {
 				await this.#emitSessionEvent({
@@ -10308,7 +10672,7 @@ export class AgentSession {
 					aborted: true,
 					willRetry: false,
 				});
-				return;
+				return { kind: "aborted", source: "signal" };
 			}
 			const errorMessage = error instanceof Error ? error.message : "compaction failed";
 			if (maintenanceAttemptSignature && this.#isOversizedMaintenanceError(errorMessage)) {
@@ -10325,6 +10689,7 @@ export class AgentSession {
 						? `Context overflow recovery failed: ${errorMessage}`
 						: `Auto-compaction failed: ${errorMessage}`,
 			});
+			return { kind: "failed" };
 		} finally {
 			if (this.#autoCompactionAbortController === autoCompactionAbortController) {
 				this.#autoCompactionAbortController = undefined;
@@ -12771,9 +13136,9 @@ export class AgentSession {
 
 	/**
 	 * Observed heuristic→actual token correction for the compaction keep window
-	 * (Finding 7). Compares the provider's real prompt tokens against the chars/4
-	 * heuristic estimate of the same content (stable system prefix + history
-	 * before the last usage-bearing assistant turn — that turn's own output is
+	 * (Finding 7). Compares the provider's real prompt tokens against the
+	 * script-aware display-token heuristic estimate of the same content (stable
+	 * system prefix + history before the last usage-bearing assistant turn — that turn's own output is
 	 * the response, not part of the request's prompt, so it belongs on neither
 	 * side of the ratio). Image-bearing content is bucketed out
 	 * of BOTH sides using the identical fixed IMAGE_TOKEN_ESTIMATE so the 1200-token

--- a/packages/coding-agent/test/agent-session-abort-timeout.test.ts
+++ b/packages/coding-agent/test/agent-session-abort-timeout.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
-import { Agent } from "@gajae-code/agent-core";
+import { Agent, type AgentTool, type StreamFn } from "@gajae-code/agent-core";
+import type { AssistantMessage } from "@gajae-code/ai";
 import { getBundledModel } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { TempDir } from "@gajae-code/utils";
+import * as z from "zod/v4";
 
 describe("AgentSession abort timeout", () => {
 	let tempDir: TempDir | undefined;
@@ -62,5 +66,118 @@ describe("AgentSession abort timeout", () => {
 		expect(forcedAbort).toHaveBeenCalledTimes(1);
 		expect(session.isStreaming).toBe(false);
 		expect(notices.some(message => message.includes("Abort cleanup timed out"))).toBe(true);
+	});
+
+	it("bounds dispose, force-invalidates an abort-ignoring run, and drops its late events", async () => {
+		tempDir = TempDir.createSync("@gjc-dispose-timeout-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const mock = createMockModel();
+		authStorage.setRuntimeApiKey(mock.model.provider, "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+		const sessionManager = SessionManager.inMemory();
+		const heldStream = new AssistantMessageEventStream();
+		const releaseHeldTool = Promise.withResolvers<void>();
+		const response: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "held-tool-call", name: "hold", arguments: {} }],
+			api: mock.model.api,
+			provider: mock.model.provider,
+			model: mock.model.id,
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+		let streamStarted = false;
+		let toolStarted = false;
+		const holdTool: AgentTool = {
+			name: "hold",
+			label: "Hold",
+			description: "A test tool that ignores cancellation until released",
+			parameters: z.object({}),
+			execute: async () => {
+				toolStarted = true;
+				await releaseHeldTool.promise;
+				return { content: [{ type: "text" as const, text: "released" }] };
+			},
+		};
+		const streamFn: StreamFn = () => {
+			queueMicrotask(() => {
+				heldStream.push({ type: "start", partial: response });
+				streamStarted = true;
+				heldStream.push({ type: "done", reason: "toolUse", message: response });
+			});
+			return heldStream;
+		};
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [holdTool], messages: [] },
+			streamFn,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		const activeSession = session;
+		let teardownStarted = false;
+		let agentEndsAfterTeardownStarted = 0;
+		activeSession.subscribe(event => {
+			if (teardownStarted && event.type === "agent_end") agentEndsAfterTeardownStarted++;
+		});
+
+		const prompt = activeSession.prompt("Start a stream that ignores abort.");
+		let disposed = false;
+		try {
+			const deadline = Date.now() + 1_000;
+			while (!(streamStarted && toolStarted && activeSession.isStreaming)) {
+				if (Date.now() >= deadline) throw new Error("Timed out waiting for the abort-ignoring run to stream");
+				await Bun.sleep(1);
+			}
+
+			const originalForceAbort = agent.forceAbort.bind(agent);
+			const forceAbortResults: boolean[] = [];
+			const forcedAbort = vi.spyOn(agent, "forceAbort").mockImplementation(reason => {
+				const result = originalForceAbort(reason);
+				forceAbortResults.push(result);
+				return result;
+			});
+
+			teardownStarted = true;
+			const started = Date.now();
+			await activeSession.dispose();
+			disposed = true;
+			const elapsed = Date.now() - started;
+
+			expect(elapsed).toBeLessThan(6_000);
+			expect(forcedAbort).toHaveBeenCalledTimes(1);
+			expect(forceAbortResults).toEqual([true]);
+			expect(agent.state.isStreaming).toBe(false);
+
+			const branchIdsAfterDispose = sessionManager.getBranch().map(entry => entry.id);
+			releaseHeldTool.resolve();
+			heldStream.end(response);
+			await prompt;
+			await Bun.sleep(10);
+
+			expect(sessionManager.getBranch().map(entry => entry.id)).toEqual(branchIdsAfterDispose);
+			expect(agentEndsAfterTeardownStarted).toBe(0);
+		} finally {
+			releaseHeldTool.resolve();
+			heldStream.end(response);
+			try {
+				await prompt;
+			} finally {
+				if (!disposed) await activeSession.dispose();
+				session = undefined;
+			}
+		}
 	});
 });

--- a/packages/coding-agent/test/agent-session-midrun-compaction.test.ts
+++ b/packages/coding-agent/test/agent-session-midrun-compaction.test.ts
@@ -1,0 +1,1300 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Agent, type AgentEvent, type AgentTool, type StreamFn } from "@gajae-code/agent-core";
+
+import type { AssistantMessage, Model, StopReason } from "@gajae-code/ai";
+
+import { getBundledModel } from "@gajae-code/ai/models";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { loadExtensions } from "@gajae-code/coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
+import type { AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { convertToLlm } from "@gajae-code/coding-agent/session/messages";
+import { getLatestCompactionEntry, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { getProjectAgentDir, TempDir } from "@gajae-code/utils";
+import * as z from "zod/v4";
+
+/**
+ * Reproduction for issue #2035: threshold auto-compaction used to run only at
+ * `agent_end` and before a user prompt, so a single uninterrupted tool loop grew
+ * straight through the compaction margin and died with provider
+ * `context_length_exceeded`. The cooperative mid-run maintenance checkpoint now
+ * bounds that run in place before the next model call.
+ */
+describe("AgentSession mid-run compaction (issue #2035)", () => {
+	const THRESHOLD = 100_000;
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let sessionManager: SessionManager;
+	let streamCallCount: number;
+	let responder: (call: number) => AssistantMessage;
+	let events: AgentSessionEvent[];
+	let toolExecutionGate: Promise<void> | undefined;
+	let onToolExecutionStart: (() => void) | undefined;
+
+	const model = { ...getBundledModel("anthropic", "claude-sonnet-4-5")!, contextWindow: 200_000, maxTokens: 32_768 };
+
+	function assistant(opts: {
+		content: AssistantMessage["content"];
+		totalTokens: number;
+		stopReason: StopReason;
+		errorMessage?: string;
+	}): AssistantMessage {
+		return {
+			role: "assistant",
+			content: opts.content,
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			usage: {
+				input: opts.totalTokens,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: opts.totalTokens,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: opts.stopReason,
+			errorMessage: opts.errorMessage,
+			timestamp: Date.now() + streamCallCount,
+		};
+	}
+
+	function toolCallTurn(totalTokens: number): AssistantMessage {
+		return assistant({
+			content: [{ type: "toolCall", id: `call-${streamCallCount}`, name: "noop", arguments: {} }],
+			totalTokens,
+			stopReason: "toolUse",
+		});
+	}
+
+	async function waitFor(predicate: () => boolean): Promise<void> {
+		const deadline = Date.now() + 1_000;
+		while (!predicate()) {
+			if (Date.now() >= deadline) throw new Error("Timed out waiting for condition");
+			await Bun.sleep(1);
+		}
+	}
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-midrun-compaction-");
+		streamCallCount = 0;
+		events = [];
+		toolExecutionGate = undefined;
+		onToolExecutionStart = undefined;
+		responder = () =>
+			assistant({ content: [{ type: "text", text: "done" }], totalTokens: 5_000, stopReason: "stop" });
+
+		// Extension short-circuits compaction so no LLM call is made for it.
+		const extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		const extensionPath = path.join(extensionsDir, "compaction-short-circuit.ts");
+		fs.writeFileSync(
+			extensionPath,
+			[
+				"export default function(pi) {",
+				'\tpi.on("session_before_compact", async (event) => ({',
+				"\t\tcompaction: {",
+				'\t\t\tsummary: "compacted summary",',
+				"\t\t\tshortSummary: undefined,",
+				"\t\t\tfirstKeptEntryId: event.preparation.firstKeptEntryId,",
+				"\t\t\ttokensBefore: event.preparation.tokensBefore,",
+				"\t\t\tdetails: {},",
+				"\t\t},",
+				"\t}));",
+				"}",
+			].join("\n"),
+		);
+
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+
+		const loaded = await loadExtensions([extensionPath], tempDir.path());
+		const extensionRunner = new ExtensionRunner(
+			loaded.extensions,
+			loaded.runtime,
+			tempDir.path(),
+			sessionManager,
+			modelRegistry,
+		);
+
+		const noopTool: AgentTool = {
+			name: "noop",
+			label: "Noop",
+			description: "Mock no-op tool",
+			parameters: z.object({}),
+			execute: async () => {
+				onToolExecutionStart?.();
+				await toolExecutionGate;
+				return { content: [{ type: "text" as const, text: "ok" }] };
+			},
+		};
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [noopTool], messages: [] },
+			convertToLlm,
+			streamFn: () => {
+				const call = ++streamCallCount;
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const message = responder(call);
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: message.stopReason as never, message });
+				});
+				return stream;
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": true,
+			"compaction.strategy": "context-full",
+			"compaction.thresholdTokens": THRESHOLD,
+			"compaction.keepRecentTokens": 10,
+			"compaction.autoContinue": true,
+			"contextPromotion.enabled": false,
+		});
+		settings.setModelRole("default", "anthropic/claude-sonnet-4-5");
+		session = new AgentSession({ agent, sessionManager, settings, modelRegistry, extensionRunner });
+		session.setResourceSampler(() => ({ heapUsedBytes: 0, providerBytes: 0, messageCount: 0, imageBytes: 0 }));
+		session.subscribe(event => events.push(event));
+	});
+
+	afterEach(async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	/** Seed a few small prior turns so prepareCompaction has content to summarize. */
+	async function preseed(): Promise<void> {
+		for (let i = 0; i < 3; i++) {
+			session.agent.emitExternalEvent({
+				type: "message_end",
+				message: {
+					role: "user",
+					content: `earlier request ${i} with a bit of context`,
+					timestamp: Date.now(),
+				} as never,
+			});
+			session.agent.emitExternalEvent({
+				type: "message_end",
+				message: assistant({
+					content: [{ type: "text", text: `earlier reply ${i}` }],
+					totalTokens: 2_000,
+					stopReason: "stop",
+				}),
+			});
+		}
+		await Bun.sleep(10);
+	}
+
+	function compactionReasons(): string[] {
+		return events
+			.filter(
+				(e): e is Extract<AgentSessionEvent, { type: "auto_compaction_start" }> =>
+					e.type === "auto_compaction_start",
+			)
+			.map(e => e.reason);
+	}
+
+	function assistantTurns(): AssistantMessage[] {
+		return session.messages.filter((m): m is AssistantMessage => m.role === "assistant");
+	}
+
+	function assistantFor(
+		selectedModel: Model,
+		opts: {
+			content: AssistantMessage["content"];
+			totalTokens: number;
+			stopReason: StopReason;
+			errorMessage?: string;
+		},
+	): AssistantMessage {
+		return {
+			role: "assistant",
+			content: opts.content,
+			api: selectedModel.api,
+			provider: selectedModel.provider,
+			model: selectedModel.id,
+			usage: {
+				input: opts.totalTokens,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: opts.totalTokens,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: opts.stopReason,
+			errorMessage: opts.errorMessage,
+			timestamp: Date.now(),
+		};
+	}
+
+	async function buildLoopSession(options: {
+		model?: Model;
+		settings?: Record<string, unknown>;
+		responder: (call: number) => AssistantMessage;
+		toolResultText?: string;
+		extensionSource?: string;
+		partialForStream?: (message: AssistantMessage) => AssistantMessage;
+
+		afterStreamStart?: (options: Parameters<StreamFn>[2]) => Promise<void>;
+	}): Promise<{
+		session: AgentSession;
+		events: AgentSessionEvent[];
+		agentEvents: AgentEvent[];
+		streamCallCount: () => number;
+	}> {
+		const selectedModel = options.model ?? model;
+		const loopSessionManager = SessionManager.inMemory();
+		let extensionRunner: ExtensionRunner | undefined;
+		if (options.extensionSource) {
+			const extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
+			fs.mkdirSync(extensionsDir, { recursive: true });
+			const extensionPath = path.join(extensionsDir, `midrun-loop-${Date.now()}-${Math.random()}.ts`);
+			fs.writeFileSync(extensionPath, options.extensionSource);
+			const loaded = await loadExtensions([extensionPath], tempDir.path());
+			extensionRunner = new ExtensionRunner(
+				loaded.extensions,
+				loaded.runtime,
+				tempDir.path(),
+				loopSessionManager,
+				modelRegistry,
+			);
+		}
+		const noopTool: AgentTool = {
+			name: "noop",
+			label: "Noop",
+			description: "Mock no-op tool",
+			parameters: z.object({}),
+			execute: async () => ({ content: [{ type: "text" as const, text: options.toolResultText ?? "ok" }] }),
+		};
+		let calls = 0;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: selectedModel, systemPrompt: ["Test"], tools: [noopTool], messages: [] },
+			convertToLlm,
+			cursorOnToolResult: async message => message,
+			streamFn: (_selectedModel, _context, streamOptions) => {
+				const call = ++calls;
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					void (async () => {
+						const message = options.responder(call);
+						const partial = options.partialForStream?.(message) ?? message;
+						stream.push({ type: "start", partial });
+						await options.afterStreamStart?.(streamOptions);
+						stream.push({ type: "done", reason: message.stopReason as never, message });
+					})();
+				});
+				return stream;
+			},
+		});
+		const loopSettings = Settings.isolated({
+			"compaction.enabled": true,
+			"compaction.strategy": "context-full",
+			"compaction.thresholdTokens": THRESHOLD,
+			"compaction.keepRecentTokens": 10,
+			"compaction.autoContinue": true,
+			"contextPromotion.enabled": false,
+			...options.settings,
+		});
+		loopSettings.setModelRole("default", `${selectedModel.provider}/${selectedModel.id}`);
+		const loopSession = new AgentSession({
+			agent,
+			sessionManager: loopSessionManager,
+			settings: loopSettings,
+			modelRegistry,
+			extensionRunner,
+		});
+		loopSession.setResourceSampler(() => ({ heapUsedBytes: 0, providerBytes: 0, messageCount: 0, imageBytes: 0 }));
+		const loopEvents: AgentSessionEvent[] = [];
+		const loopAgentEvents: AgentEvent[] = [];
+		loopSession.subscribe(event => loopEvents.push(event));
+		loopSession.agent.subscribe(event => loopAgentEvents.push(event));
+		return {
+			session: loopSession,
+			events: loopEvents,
+			agentEvents: loopAgentEvents,
+			streamCallCount: () => calls,
+		};
+	}
+
+	async function seedLoop(session: AgentSession, messages: readonly unknown[]): Promise<void> {
+		for (const message of messages) {
+			session.agent.emitExternalEvent({ type: "message_end", message: message as never });
+		}
+		await Bun.sleep(10);
+	}
+
+	async function seedCompactableLoop(session: AgentSession, selectedModel: Model = model): Promise<void> {
+		await seedLoop(
+			session,
+			Array.from({ length: 3 }, (_, index) => [
+				{ role: "user", content: `earlier request ${index}`, timestamp: Date.now() },
+				assistantFor(selectedModel, {
+					content: [{ type: "text", text: `earlier response ${index}` }],
+					totalTokens: 1_000,
+					stopReason: "stop",
+				}),
+			]).flat(),
+		);
+	}
+
+	function shortCircuitExtensionSource(): string {
+		return [
+			"export default function(pi) {",
+			'\tpi.on("session_before_compact", async (event) => ({',
+			"\t\tcompaction: {",
+			'\t\t\tsummary: "compacted summary",',
+			"\t\t\tshortSummary: undefined,",
+			"\t\t\tfirstKeptEntryId: event.preparation.firstKeptEntryId,",
+			"\t\t\ttokensBefore: event.preparation.tokensBefore,",
+			"\t\t\tdetails: {},",
+			"\t\t},",
+			"\t}));",
+			"}",
+		].join("\n");
+	}
+
+	function gatedShortCircuitExtensionSource(): string {
+		return [
+			"export default function(pi) {",
+			'\tpi.on("session_before_compact", async (event) => {',
+			"\t\tconst gate = globalThis.__midrunE2ECompactionGate;",
+			'\t\tif (gate) await Promise.race([gate, new Promise(resolve => event.signal.addEventListener("abort", resolve, { once: true }))]);',
+			"\t\treturn {",
+			"\t\t\tcompaction: {",
+			'\t\t\t\tsummary: "compacted summary",',
+			"\t\t\t\tshortSummary: undefined,",
+			"\t\t\t\tfirstKeptEntryId: event.preparation.firstKeptEntryId,",
+			"\t\t\t\ttokensBefore: event.preparation.tokensBefore,",
+			"\t\t\t\tdetails: {},",
+			"\t\t\t},",
+			"\t\t};",
+			"\t});",
+			"}",
+		].join("\n");
+	}
+
+	it("runs threshold maintenance mid-loop and resumes without a provider overflow", async () => {
+		await preseed();
+		// First model call crosses the threshold while still calling tools; later
+		// calls stop. Without mid-run maintenance the loop would keep growing.
+		responder = call =>
+			call === 1
+				? toolCallTurn(THRESHOLD + 80_000)
+				: assistant({ content: [{ type: "text", text: "done" }], totalTokens: 5_000, stopReason: "stop" });
+
+		await session.prompt("go");
+		await session.waitForIdle();
+
+		// Mid-run maintenance fired (threshold reason) and a fresh compaction landed.
+		expect(compactionReasons()).toContain("threshold");
+		expect(getLatestCompactionEntry(session.sessionManager.getBranch())).not.toBeNull();
+		// The loop was interrupted for maintenance and resumed for exactly one more
+		// model call — no provider overflow, no synthetic auto-continue prompt.
+		expect(streamCallCount).toBe(2);
+		expect(assistantTurns().some(m => m.stopReason === "error")).toBe(false);
+		expect(
+			session.messages.some(m =>
+				JSON.stringify((m as { content?: unknown }).content ?? "").includes(
+					"Resume work on the user's most recent intent",
+				),
+			),
+		).toBe(false);
+	});
+
+	it("without the maintenance hook, a long tool loop grows past the threshold into provider overflow", async () => {
+		await preseed();
+		// Disable the cooperative checkpoint to reproduce the original gap.
+		session.agent.setMaintainContext(undefined);
+		responder = call => {
+			if (call === 1) return toolCallTurn(THRESHOLD + 80_000);
+			if (call === 2) return toolCallTurn(THRESHOLD + 150_000);
+			if (call === 3)
+				return assistant({
+					content: [{ type: "text", text: "" }],
+					totalTokens: 0,
+					stopReason: "error",
+					errorMessage: "context_length_exceeded: Your input exceeds the context window of this model.",
+				});
+			return assistant({ content: [{ type: "text", text: "recovered" }], totalTokens: 4_000, stopReason: "stop" });
+		};
+
+		await session.prompt("go");
+		await session.waitForIdle();
+
+		// The loop grew across multiple past-threshold tool turns with NO mid-run
+		// threshold maintenance; overflow was only handled reactively afterward.
+		const overThresholdToolTurns = assistantTurns().filter(
+			m => m.stopReason === "toolUse" && (m.usage?.totalTokens ?? 0) > THRESHOLD,
+		);
+		expect(overThresholdToolTurns.length).toBeGreaterThanOrEqual(2);
+		expect(streamCallCount).toBeGreaterThanOrEqual(3);
+		// No proactive mid-run threshold maintenance ran: the first compaction was
+		// the reactive overflow recovery, which is only reachable once the provider
+		// rejected the request with context_length_exceeded. A pre-prompt "threshold"
+		// pass may follow, but never precedes the overflow.
+		expect(compactionReasons()[0]).toBe("overflow");
+	});
+	it("T2 drains paired tool results and two steering messages before the single maintenance continuation", async () => {
+		await preseed();
+		responder = call =>
+			call === 1
+				? toolCallTurn(THRESHOLD + 80_000)
+				: assistant({ content: [{ type: "text", text: "done" }], totalTokens: 5_000, stopReason: "stop" });
+		const toolGate = Promise.withResolvers<void>();
+		const toolStarted = Promise.withResolvers<void>();
+		toolExecutionGate = toolGate.promise;
+		onToolExecutionStart = toolStarted.resolve;
+		const agentEvents: AgentEvent[] = [];
+		const unsubscribe = session.agent.subscribe(event => agentEvents.push(event));
+		try {
+			const run = session.prompt("go");
+			await toolStarted.promise;
+			await session.steer("first distinct steering");
+			await session.steer("second distinct steering");
+			toolGate.resolve();
+			await run;
+			await session.waitForIdle();
+		} finally {
+			unsubscribe();
+			toolExecutionGate = undefined;
+			onToolExecutionStart = undefined;
+		}
+
+		const branchMessages = session.sessionManager
+			.getBranch()
+			.flatMap(entry =>
+				entry.type === "message"
+					? [entry.message as { role?: string; toolCallId?: string; content?: unknown }]
+					: [],
+			);
+		expect(branchMessages.filter(message => message.toolCallId === "call-1")).toHaveLength(1);
+		expect(
+			branchMessages.filter(
+				message => message.role === "user" && JSON.stringify(message.content).includes("first distinct steering"),
+			),
+		).toHaveLength(1);
+		expect(
+			branchMessages.filter(
+				message => message.role === "user" && JSON.stringify(message.content).includes("second distinct steering"),
+			),
+		).toHaveLength(1);
+		expect(
+			agentEvents.filter(event => event.type === "agent_end" && event.stopReason === "maintenance"),
+		).toHaveLength(1);
+		expect(events.filter(event => event.type === "agent_end" && event.stopReason === "maintenance")).toHaveLength(0);
+		expect(getLatestCompactionEntry(session.sessionManager.getBranch())).not.toBeNull();
+		expect(streamCallCount).toBe(2);
+	});
+	it("T2 completes the real pruned lifecycle without entering compaction", async () => {
+		authStorage.setRuntimeApiKey("openai-codex", "test-key");
+		const codex = modelRegistry.find("openai-codex", "gpt-5.5");
+		if (!codex) throw new Error("Expected bundled Codex model");
+		const loop = await buildLoopSession({
+			model: codex,
+			responder: call =>
+				call === 1
+					? assistantFor(codex, {
+							content: [{ type: "toolCall", id: "pruned-lifecycle-call", name: "noop", arguments: {} }],
+							totalTokens: THRESHOLD + 1,
+							stopReason: "toolUse",
+						})
+					: assistantFor(codex, {
+							content: [{ type: "text", text: "pruned completion" }],
+							totalTokens: 5_000,
+							stopReason: "stop",
+						}),
+		});
+		let closed = 0;
+		loop.session.providerSessionState.set("openai-codex-responses", { close: () => closed++ });
+		try {
+			await seedLoop(loop.session, [
+				{ role: "user", content: "old request", timestamp: Date.now() },
+				...Array.from({ length: 3 }, (_, index) => ({
+					role: "toolResult",
+					toolCallId: `old-prunable-${index}`,
+					toolName: "bash",
+					content: [{ type: "text", text: "x".repeat(120_000) }],
+					timestamp: Date.now(),
+				})),
+			]);
+			await loop.session.prompt("go", { skipCompactionCheck: true });
+			await loop.session.waitForIdle();
+
+			expect(
+				loop.agentEvents.filter(
+					event =>
+						event.type === "agent_end" &&
+						event.stopReason === "maintenance" &&
+						event.maintenanceOutcome === "pruned",
+				),
+			).toHaveLength(1);
+			expect(
+				loop.events.filter(event => event.type === "agent_end" && event.stopReason === "maintenance"),
+			).toHaveLength(0);
+			expect(loop.events.filter(event => event.type === "agent_end")).toHaveLength(1);
+			expect(loop.events.some(event => event.type === "auto_compaction_start")).toBe(false);
+			expect(getLatestCompactionEntry(loop.session.sessionManager.getBranch())).toBeNull();
+			expect(closed).toBe(1);
+			expect(loop.streamCallCount()).toBe(2);
+		} finally {
+			await loop.session.dispose();
+		}
+	});
+	it("T3 exercises the Cursor split path without retaining the original usage anchor", async () => {
+		let originalAnchor: AssistantMessage | undefined;
+		let bufferedCursorResult = false;
+		const cursorStart = Promise.withResolvers<void>();
+
+		const loop = await buildLoopSession({
+			extensionSource: shortCircuitExtensionSource(),
+			responder: call => {
+				if (call === 1) {
+					originalAnchor = assistantFor(model, {
+						content: [
+							{ type: "text", text: "Cursor preamble and continuation" },
+							{ type: "toolCall", id: "cursor-call", name: "noop", arguments: {} },
+						],
+						totalTokens: THRESHOLD + 80_000,
+						stopReason: "toolUse",
+					});
+					return originalAnchor;
+				}
+				return assistantFor(model, {
+					content: [{ type: "text", text: "done" }],
+					totalTokens: 5_000,
+					stopReason: "stop",
+				});
+			},
+			partialForStream: message => ({
+				...message,
+				content: [
+					{ type: "text", text: "Cursor preamble" },
+					{ type: "toolCall", id: "cursor-call", name: "noop", arguments: {} },
+				],
+			}),
+			afterStreamStart: async streamOptions => {
+				if (bufferedCursorResult) return;
+				bufferedCursorResult = true;
+				await cursorStart.promise;
+
+				await streamOptions?.cursorOnToolResult?.({
+					role: "toolResult",
+					toolCallId: "cursor-server-result",
+					toolName: "noop",
+					content: [{ type: "text", text: "Cursor server-side result" }],
+					isError: false,
+					timestamp: Date.now(),
+				});
+			},
+		});
+		const unsubscribeCursorStart = loop.session.agent.subscribe(event => {
+			if (event.type === "message_start" && event.message.role === "assistant") cursorStart.resolve();
+		});
+
+		try {
+			await seedLoop(loop.session, [
+				{ role: "user", content: "earlier request", timestamp: Date.now() },
+				assistantFor(model, {
+					content: [{ type: "text", text: "earlier response" }],
+					totalTokens: 1_000,
+					stopReason: "stop",
+				}),
+			]);
+			await loop.session.prompt("go");
+			await loop.session.waitForIdle();
+
+			expect(originalAnchor).toBeDefined();
+			expect(loop.session.messages.includes(originalAnchor!)).toBe(false);
+			expect(
+				loop.agentEvents.filter(event => event.type === "agent_end" && event.stopReason === "maintenance"),
+			).toHaveLength(1);
+			expect(loop.streamCallCount()).toBe(2);
+		} finally {
+			unsubscribeCursorStart();
+			await loop.session.dispose();
+		}
+	});
+
+	it("keeps a maintenance agent_end private during a zero-inflight idle-steer continuation", async () => {
+		const loop = await buildLoopSession({
+			extensionSource: shortCircuitExtensionSource(),
+			responder: call => {
+				if (call === 1 || call === 3) {
+					return assistantFor(model, {
+						content: [{ type: "text", text: "done" }],
+						totalTokens: 5_000,
+						stopReason: "stop",
+					});
+				}
+				return assistantFor(model, {
+					content: [{ type: "toolCall", id: "idle-steer-call", name: "noop", arguments: {} }],
+					totalTokens: THRESHOLD + 80_000,
+					stopReason: "toolUse",
+				});
+			},
+		});
+		try {
+			await loop.session.prompt("initial");
+			await loop.session.waitForIdle();
+			loop.events.length = 0;
+			loop.agentEvents.length = 0;
+
+			await loop.session.steer("idle continuation");
+			await loop.session.waitForIdle();
+
+			expect(
+				loop.agentEvents.filter(event => event.type === "agent_end" && event.stopReason === "maintenance"),
+			).toHaveLength(1);
+			expect(
+				loop.events.filter(event => event.type === "agent_end" && event.stopReason === "maintenance"),
+			).toHaveLength(0);
+			expect(loop.events.filter(event => event.type === "agent_end")).toHaveLength(1);
+			expect(loop.streamCallCount()).toBe(3);
+		} finally {
+			await loop.session.dispose();
+		}
+	});
+	it("publishes an aborted maintenance settlement when no prompt is in flight", async () => {
+		const loop = await buildLoopSession({
+			responder: () =>
+				assistantFor(model, { content: [{ type: "text", text: "unused" }], totalTokens: 1, stopReason: "stop" }),
+		});
+		try {
+			loop.session.agent.emitExternalEvent({
+				type: "agent_end",
+				messages: [],
+				stopReason: "maintenance",
+				maintenanceOutcome: "aborted",
+			});
+			await Bun.sleep(0);
+			expect(
+				loop.events.filter(
+					event =>
+						event.type === "agent_end" &&
+						event.stopReason === "maintenance" &&
+						event.maintenanceOutcome === "aborted",
+				),
+			).toHaveLength(1);
+		} finally {
+			await loop.session.dispose();
+		}
+	});
+
+	it("does not continue when a later raw agent subscriber aborts a maintenance checkpoint", async () => {
+		const loop = await buildLoopSession({
+			extensionSource: shortCircuitExtensionSource(),
+			responder: call =>
+				call === 1
+					? assistantFor(model, {
+							content: [{ type: "toolCall", id: "raw-subscriber-cancel-call", name: "noop", arguments: {} }],
+							totalTokens: THRESHOLD + 80_000,
+							stopReason: "toolUse",
+						})
+					: assistantFor(model, {
+							content: [{ type: "text", text: "late continuation" }],
+							totalTokens: 5_000,
+							stopReason: "stop",
+						}),
+		});
+		const unsubscribe = loop.session.agent.subscribe(event => {
+			if (event.type === "agent_end" && event.stopReason === "maintenance") void loop.session.abort();
+		});
+		try {
+			await seedCompactableLoop(loop.session);
+			await loop.session.prompt("go");
+			await loop.session.waitForIdle();
+			expect(loop.streamCallCount()).toBe(1);
+		} finally {
+			unsubscribe();
+			await loop.session.dispose();
+		}
+	});
+	it("T4 abort, dispose, and disconnect the real loop without a late model call", async () => {
+		for (const operation of ["abort", "dispose", "disconnect"] as const) {
+			const gate = Promise.withResolvers<void>();
+			(globalThis as { __midrunE2ECompactionGate?: Promise<void> }).__midrunE2ECompactionGate = gate.promise;
+			const compactionStarted = Promise.withResolvers<void>();
+			const loop = await buildLoopSession({
+				extensionSource: gatedShortCircuitExtensionSource(),
+				responder: call =>
+					call === 1
+						? assistantFor(model, {
+								content: [{ type: "toolCall", id: `${operation}-race-call`, name: "noop", arguments: {} }],
+								totalTokens: THRESHOLD + 80_000,
+								stopReason: "toolUse",
+							})
+						: assistantFor(model, {
+								content: [{ type: "text", text: "late continuation" }],
+								totalTokens: 5_000,
+								stopReason: "stop",
+							}),
+			});
+			const unsubscribe = loop.session.subscribe(event => {
+				if (event.type === "auto_compaction_start") compactionStarted.resolve();
+			});
+			try {
+				await seedCompactableLoop(loop.session);
+				const prompt = loop.session.prompt("go");
+				await compactionStarted.promise;
+				expect(loop.session.activeMidRunBarrierCountForTests).toBe(1);
+
+				if (operation === "abort") await loop.session.abort();
+				else if (operation === "dispose") await loop.session.dispose();
+				else await loop.session.newSession();
+
+				expect(loop.session.activeMidRunBarrierCountForTests).toBe(0);
+				expect(getLatestCompactionEntry(loop.session.sessionManager.getBranch())).toBeNull();
+				gate.resolve();
+				await prompt;
+				await Bun.sleep(10);
+				expect(loop.streamCallCount()).toBe(1);
+				expect(
+					loop.agentEvents.filter(
+						event =>
+							event.type === "agent_end" &&
+							event.stopReason === "maintenance" &&
+							event.maintenanceOutcome === "aborted",
+					),
+				).toHaveLength(1);
+			} finally {
+				unsubscribe();
+				gate.resolve();
+				(globalThis as { __midrunE2ECompactionGate?: Promise<void> }).__midrunE2ECompactionGate = undefined;
+				if (operation !== "dispose") await loop.session.dispose();
+			}
+		}
+	});
+
+	it("T4 joins held prune maintenance for dispose and disconnect before teardown", async () => {
+		for (const operation of ["dispose", "disconnect"] as const) {
+			authStorage.setRuntimeApiKey("openai-codex", "test-key");
+			const codex = modelRegistry.find("openai-codex", "gpt-5.5");
+			if (!codex) throw new Error("Expected bundled Codex model");
+			let closed = 0;
+			const loop = await buildLoopSession({
+				model: codex,
+				responder: call =>
+					call === 1
+						? assistantFor(codex, {
+								content: [{ type: "toolCall", id: `${operation}-prune-call`, name: "noop", arguments: {} }],
+								totalTokens: THRESHOLD + 80_000,
+								stopReason: "toolUse",
+							})
+						: assistantFor(codex, {
+								content: [{ type: "text", text: "late continuation" }],
+								totalTokens: 5_000,
+								stopReason: "stop",
+							}),
+			});
+			loop.session.providerSessionState.set("openai-codex-responses", { close: () => closed++ });
+			const rewriteGate = Promise.withResolvers<void>();
+			const rewriteEntered = Promise.withResolvers<void>();
+			const manager = loop.session.sessionManager as unknown as { rewriteEntries: () => Promise<void> };
+			const originalRewriteEntries = manager.rewriteEntries.bind(manager);
+			manager.rewriteEntries = async () => {
+				rewriteEntered.resolve();
+				await rewriteGate.promise;
+				await originalRewriteEntries();
+			};
+			try {
+				await seedLoop(loop.session, [
+					{ role: "user", content: "old request", timestamp: Date.now() },
+					...Array.from({ length: 3 }, (_, index) => ({
+						role: "toolResult",
+						toolCallId: `${operation}-prunable-${index}`,
+						toolName: "bash",
+						content: [{ type: "text", text: "x".repeat(120_000) }],
+						timestamp: Date.now(),
+					})),
+				]);
+				const prompt = loop.session.prompt("go", { skipCompactionCheck: true });
+				await rewriteEntered.promise;
+				const cancellation = operation === "dispose" ? loop.session.dispose() : loop.session.newSession();
+				await waitFor(() => loop.session.activeMidRunBarrierCountForTests === 0);
+				expect(loop.streamCallCount()).toBe(1);
+
+				rewriteGate.resolve();
+				await Promise.all([prompt, cancellation]);
+				await loop.session.waitForIdle();
+
+				expect(
+					loop.agentEvents.filter(
+						event =>
+							event.type === "agent_end" &&
+							event.stopReason === "maintenance" &&
+							event.maintenanceOutcome === "aborted",
+					),
+				).toHaveLength(1);
+				expect(closed).toBeGreaterThanOrEqual(1);
+				expect(loop.streamCallCount()).toBe(1);
+			} finally {
+				manager.rewriteEntries = originalRewriteEntries;
+				rewriteGate.resolve();
+				if (operation !== "dispose") await loop.session.dispose();
+			}
+		}
+	});
+
+	it("T4 joins held promotion maintenance for dispose and disconnect before teardown", async () => {
+		for (const operation of ["dispose", "disconnect"] as const) {
+			authStorage.setRuntimeApiKey("openai-codex", "test-key");
+			const spark = modelRegistry.find("openai-codex", "gpt-5.3-codex-spark");
+			const large = modelRegistry.find("openai-codex", "gpt-5.5");
+			if (!spark || !large) throw new Error("Expected bundled Codex promotion models");
+			const startModel = { ...spark, contextWindow: 150_000 };
+			const promotionGate = Promise.withResolvers<void>();
+			const promotionLookupEntered = Promise.withResolvers<void>();
+			const registry = modelRegistry as unknown as {
+				getApiKey: (candidate: Model, sessionId?: string) => Promise<string | undefined>;
+			};
+			const originalGetApiKey = registry.getApiKey.bind(registry);
+			registry.getApiKey = async (candidate, sessionId) => {
+				if (candidate.provider === large.provider && candidate.id === large.id) {
+					promotionLookupEntered.resolve();
+					await promotionGate.promise;
+				}
+				return originalGetApiKey(candidate, sessionId);
+			};
+			const loop = await buildLoopSession({
+				model: startModel,
+				settings: { "contextPromotion.enabled": true },
+				responder: call =>
+					call === 1
+						? assistantFor(startModel, {
+								content: [{ type: "toolCall", id: `${operation}-promotion-call`, name: "noop", arguments: {} }],
+								totalTokens: THRESHOLD + 80_000,
+								stopReason: "toolUse",
+							})
+						: assistantFor(startModel, {
+								content: [{ type: "text", text: "late continuation" }],
+								totalTokens: 5_000,
+								stopReason: "stop",
+							}),
+			});
+			try {
+				await seedCompactableLoop(loop.session, startModel);
+				const prompt = loop.session.prompt("go");
+				await promotionLookupEntered.promise;
+				const cancellation = operation === "dispose" ? loop.session.dispose() : loop.session.newSession();
+				await waitFor(() => loop.session.activeMidRunBarrierCountForTests === 0);
+				expect(loop.streamCallCount()).toBe(1);
+
+				promotionGate.resolve();
+				await Promise.all([prompt, cancellation]);
+				await loop.session.waitForIdle();
+
+				expect(
+					loop.agentEvents.filter(
+						event =>
+							event.type === "agent_end" &&
+							event.stopReason === "maintenance" &&
+							event.maintenanceOutcome === "aborted",
+					),
+				).toHaveLength(1);
+				expect(loop.session.model?.id).toBe(startModel.id);
+				expect(loop.streamCallCount()).toBe(1);
+			} finally {
+				registry.getApiKey = originalGetApiKey;
+				promotionGate.resolve();
+				if (operation !== "dispose") await loop.session.dispose();
+			}
+		}
+	});
+	it("T5 treats hook cancellation as a compaction veto and continues the active run", async () => {
+		const loop = await buildLoopSession({
+			extensionSource: [
+				"export default function(pi) {",
+				'\tpi.on("session_before_compact", async () => ({ cancel: true }));',
+				"}",
+			].join("\n"),
+			responder: call =>
+				call === 1
+					? assistantFor(model, {
+							content: [{ type: "toolCall", id: "hook-cancel-call", name: "noop", arguments: {} }],
+							totalTokens: THRESHOLD + 80_000,
+							stopReason: "toolUse",
+						})
+					: assistantFor(model, {
+							content: [{ type: "text", text: "late continuation" }],
+							totalTokens: 5_000,
+							stopReason: "stop",
+						}),
+		});
+		try {
+			await seedCompactableLoop(loop.session);
+			await loop.session.prompt("go");
+			await loop.session.waitForIdle();
+
+			expect(
+				loop.agentEvents.filter(event => event.type === "agent_end" && event.stopReason === "maintenance"),
+			).toHaveLength(0);
+			expect(loop.events.filter(event => event.type === "agent_end")).toHaveLength(1);
+			expect(loop.streamCallCount()).toBe(2);
+			expect(getLatestCompactionEntry(loop.session.sessionManager.getBranch())).toBeNull();
+		} finally {
+			await loop.session.dispose();
+		}
+	});
+
+	it("T5 aborts from auto_compaction_start before preparation and never continues", async () => {
+		const loop = await buildLoopSession({
+			extensionSource: shortCircuitExtensionSource(),
+			responder: call =>
+				call === 1
+					? assistantFor(model, {
+							content: [{ type: "toolCall", id: "start-abort-call", name: "noop", arguments: {} }],
+							totalTokens: THRESHOLD + 80_000,
+							stopReason: "toolUse",
+						})
+					: assistantFor(model, {
+							content: [{ type: "text", text: "late continuation" }],
+							totalTokens: 5_000,
+							stopReason: "stop",
+						}),
+		});
+		const unsubscribe = loop.session.subscribe(event => {
+			if (event.type === "auto_compaction_start") void loop.session.abort();
+		});
+		try {
+			await seedCompactableLoop(loop.session);
+			await loop.session.prompt("go");
+			await loop.session.waitForIdle();
+
+			expect(
+				loop.agentEvents.filter(
+					event =>
+						event.type === "agent_end" &&
+						event.stopReason === "maintenance" &&
+						event.maintenanceOutcome === "aborted",
+				),
+			).toHaveLength(1);
+			expect(
+				loop.events.filter(
+					event =>
+						event.type === "agent_end" &&
+						event.stopReason === "maintenance" &&
+						event.maintenanceOutcome === "aborted",
+				),
+			).toHaveLength(1);
+			expect(loop.streamCallCount()).toBe(1);
+			expect(getLatestCompactionEntry(loop.session.sessionManager.getBranch())).toBeNull();
+		} finally {
+			unsubscribe();
+			await loop.session.dispose();
+		}
+	});
+
+	it("B1 reports aborted when cancellation lands just after compaction append and schedules no continuation", async () => {
+		const loop = await buildLoopSession({
+			extensionSource: shortCircuitExtensionSource(),
+			responder: call =>
+				call === 1
+					? assistantFor(model, {
+							content: [{ type: "toolCall", id: "post-append-call", name: "noop", arguments: {} }],
+							totalTokens: THRESHOLD + 80_000,
+							stopReason: "toolUse",
+						})
+					: assistantFor(model, {
+							content: [{ type: "text", text: "late continuation" }],
+							totalTokens: 5_000,
+							stopReason: "stop",
+						}),
+		});
+		const unsubscribe = loop.session.subscribe(event => {
+			if (event.type === "auto_compaction_end" && event.result) void loop.session.abort();
+		});
+		try {
+			await seedCompactableLoop(loop.session);
+			await loop.session.prompt("go");
+			await loop.session.waitForIdle();
+
+			expect(
+				loop.agentEvents.filter(
+					event =>
+						event.type === "agent_end" &&
+						event.stopReason === "maintenance" &&
+						event.maintenanceOutcome === "aborted",
+				),
+			).toHaveLength(1);
+			expect(loop.streamCallCount()).toBe(1);
+			expect(getLatestCompactionEntry(loop.session.sessionManager.getBranch())).not.toBeNull();
+		} finally {
+			unsubscribe();
+			await loop.session.dispose();
+		}
+	});
+	it("B1 aborts during prune and does not continue after the rewrite finishes", async () => {
+		authStorage.setRuntimeApiKey("openai-codex", "test-key");
+		const codex = modelRegistry.find("openai-codex", "gpt-5.5");
+		if (!codex) throw new Error("Expected bundled Codex model");
+		let closed = 0;
+		const loop = await buildLoopSession({
+			model: codex,
+			responder: call =>
+				call === 1
+					? assistantFor(codex, {
+							content: [{ type: "toolCall", id: "prune-race-call", name: "noop", arguments: {} }],
+							totalTokens: THRESHOLD + 80_000,
+							stopReason: "toolUse",
+						})
+					: assistantFor(codex, {
+							content: [{ type: "text", text: "late continuation" }],
+							totalTokens: 5_000,
+							stopReason: "stop",
+						}),
+		});
+		loop.session.providerSessionState.set("openai-codex-responses", { close: () => closed++ });
+		const rewriteGate = Promise.withResolvers<void>();
+		const rewriteEntered = Promise.withResolvers<void>();
+		const manager = loop.session.sessionManager as unknown as {
+			rewriteEntries: () => Promise<void>;
+		};
+		const originalRewriteEntries = manager.rewriteEntries.bind(manager);
+		manager.rewriteEntries = async () => {
+			rewriteEntered.resolve();
+			await rewriteGate.promise;
+			await originalRewriteEntries();
+		};
+		try {
+			await seedLoop(loop.session, [
+				{ role: "user", content: "old request", timestamp: Date.now() },
+				{
+					role: "toolResult",
+					toolCallId: "old-prunable-output-1",
+					toolName: "bash",
+					content: [{ type: "text", text: "x".repeat(120_000) }],
+					timestamp: Date.now(),
+				},
+				{
+					role: "toolResult",
+					toolCallId: "old-prunable-output-2",
+					toolName: "bash",
+					content: [{ type: "text", text: "y".repeat(120_000) }],
+					timestamp: Date.now(),
+				},
+				{
+					role: "toolResult",
+					toolCallId: "old-prunable-output-3",
+					toolName: "bash",
+					content: [{ type: "text", text: "z".repeat(120_000) }],
+					timestamp: Date.now(),
+				},
+			]);
+			const prompt = loop.session.prompt("go", { skipCompactionCheck: true });
+			await rewriteEntered.promise;
+			const abort = loop.session.abort();
+			rewriteGate.resolve();
+			await Promise.all([prompt, abort]);
+			await loop.session.waitForIdle();
+			await Bun.sleep(10);
+
+			expect(loop.streamCallCount()).toBe(1);
+			expect(getLatestCompactionEntry(loop.session.sessionManager.getBranch())).toBeNull();
+			expect(loop.session.agent.state.messages).toEqual(loop.session.buildDisplaySessionContext().messages);
+			expect(closed).toBe(1);
+		} finally {
+			manager.rewriteEntries = originalRewriteEntries;
+			await loop.session.dispose();
+		}
+	});
+
+	it("B1 aborts during promotion target resolution before the model can switch or continue", async () => {
+		authStorage.setRuntimeApiKey("openai-codex", "test-key");
+		const spark = modelRegistry.find("openai-codex", "gpt-5.3-codex-spark");
+		const large = modelRegistry.find("openai-codex", "gpt-5.5");
+		if (!spark || !large) throw new Error("Expected codex promotion models");
+		const startModel = { ...spark, contextWindow: 150_000 };
+		const promotionGate = Promise.withResolvers<void>();
+		const promotionLookupEntered = Promise.withResolvers<void>();
+		const registry = modelRegistry as unknown as {
+			getApiKey: (candidate: Model, sessionId?: string) => Promise<string | undefined>;
+		};
+		const originalGetApiKey = registry.getApiKey.bind(registry);
+		registry.getApiKey = async (candidate, sessionId) => {
+			if (candidate.provider === large.provider && candidate.id === large.id) {
+				promotionLookupEntered.resolve();
+				await promotionGate.promise;
+			}
+			return originalGetApiKey(candidate, sessionId);
+		};
+		const loop = await buildLoopSession({
+			model: startModel,
+			settings: { "contextPromotion.enabled": true },
+			responder: call =>
+				call === 1
+					? assistantFor(startModel, {
+							content: [{ type: "toolCall", id: "promotion-race-call", name: "noop", arguments: {} }],
+							totalTokens: THRESHOLD + 80_000,
+							stopReason: "toolUse",
+						})
+					: assistantFor(startModel, {
+							content: [{ type: "text", text: "late continuation" }],
+							totalTokens: 5_000,
+							stopReason: "stop",
+						}),
+		});
+		try {
+			await seedCompactableLoop(loop.session, startModel);
+			const prompt = loop.session.prompt("go");
+			await promotionLookupEntered.promise;
+			const abort = loop.session.abort();
+			promotionGate.resolve();
+			await Promise.all([prompt, abort]);
+			await loop.session.waitForIdle();
+
+			expect(loop.session.model?.id).toBe(startModel.id);
+			expect(loop.streamCallCount()).toBe(1);
+			expect(getLatestCompactionEntry(loop.session.sessionManager.getBranch())).toBeNull();
+		} finally {
+			registry.getApiKey = originalGetApiKey;
+			await loop.session.dispose();
+		}
+	});
+	it("T7 promotes through the real loop, resets the provider epoch, and continues exactly once", async () => {
+		authStorage.setRuntimeApiKey("openai-codex", "test-key");
+		const spark = modelRegistry.find("openai-codex", "gpt-5.3-codex-spark");
+		const large = modelRegistry.find("openai-codex", "gpt-5.5");
+		if (!spark || !large) throw new Error("Expected codex promotion models");
+		const startModel = { ...spark, contextWindow: 150_000 };
+		const loop = await buildLoopSession({
+			model: startModel,
+			settings: { "contextPromotion.enabled": true },
+			responder: call =>
+				call === 1
+					? assistantFor(startModel, {
+							content: [{ type: "toolCall", id: "promotion-call", name: "noop", arguments: {} }],
+							totalTokens: THRESHOLD + 80_000,
+							stopReason: "toolUse",
+						})
+					: assistantFor(large, {
+							content: [{ type: "text", text: "promoted completion" }],
+							totalTokens: 5_000,
+							stopReason: "stop",
+						}),
+		});
+		let closed = 0;
+		const previousProviderSessionState = loop.session.providerSessionState;
+		previousProviderSessionState.set("openai-codex-responses", { close: () => closed++ });
+		try {
+			await seedCompactableLoop(loop.session, startModel);
+			await loop.session.prompt("go");
+			await loop.session.waitForIdle();
+
+			expect(loop.session.model?.contextWindow).toBeGreaterThan(startModel.contextWindow!);
+			expect(loop.session.providerSessionState).not.toBe(previousProviderSessionState);
+			expect(closed).toBe(0);
+			expect(getLatestCompactionEntry(loop.session.sessionManager.getBranch())).toBeNull();
+			expect(
+				loop.agentEvents.filter(
+					event =>
+						event.type === "agent_end" &&
+						event.stopReason === "maintenance" &&
+						event.maintenanceOutcome === "promoted",
+				),
+			).toHaveLength(1);
+			expect(loop.streamCallCount()).toBe(2);
+		} finally {
+			await loop.session.dispose();
+		}
+	});
+	it("T8 prevents the CJK-heavy provider overflow that occurs without mid-run maintenance", async () => {
+		const cjk = "가".repeat(16_000);
+		let maintainedOverflow = false;
+		const maintained = await buildLoopSession({
+			extensionSource: shortCircuitExtensionSource(),
+			toolResultText: cjk,
+			responder: call => {
+				if (call === 1) {
+					return assistantFor(model, {
+						content: [{ type: "toolCall", id: "cjk-call", name: "noop", arguments: {} }],
+						totalTokens: THRESHOLD - 5_000,
+						stopReason: "toolUse",
+					});
+				}
+				if (!getLatestCompactionEntry(maintained.session.sessionManager.getBranch())) {
+					maintainedOverflow = true;
+					return assistantFor(model, {
+						content: [],
+						totalTokens: 0,
+						stopReason: "error",
+						errorMessage: "context_length_exceeded: CJK-heavy context overflow",
+					});
+				}
+				return assistantFor(model, {
+					content: [{ type: "text", text: "compacted before overflow" }],
+					totalTokens: 5_000,
+					stopReason: "stop",
+				});
+			},
+		});
+		try {
+			await seedCompactableLoop(maintained.session);
+			await maintained.session.prompt("go");
+			await maintained.session.waitForIdle();
+			expect(maintained.session.activeMidRunMaintenanceCountForTests).toBe(0);
+
+			expect(THRESHOLD - 5_000 + cjk.length / 4).toBeLessThan(THRESHOLD);
+			expect(maintainedOverflow).toBe(false);
+			expect(
+				maintained.events.some(event => event.type === "auto_compaction_start" && event.reason === "threshold"),
+			).toBe(true);
+			expect(maintained.streamCallCount()).toBe(2);
+		} finally {
+			await maintained.session.dispose();
+		}
+
+		let counterfactualOverflow = false;
+		const counterfactual = await buildLoopSession({
+			extensionSource: shortCircuitExtensionSource(),
+			toolResultText: cjk,
+			responder: call => {
+				if (call === 1) {
+					return assistantFor(model, {
+						content: [{ type: "toolCall", id: "cjk-counterfactual-call", name: "noop", arguments: {} }],
+						totalTokens: THRESHOLD - 5_000,
+						stopReason: "toolUse",
+					});
+				}
+				if (call === 2) {
+					counterfactualOverflow = true;
+					return assistantFor(model, {
+						content: [],
+						totalTokens: 0,
+						stopReason: "error",
+						errorMessage: "context_length_exceeded: CJK-heavy context overflow",
+					});
+				}
+				return assistantFor(model, {
+					content: [{ type: "text", text: "recovered after reactive compaction" }],
+					totalTokens: 5_000,
+					stopReason: "stop",
+				});
+			},
+		});
+		try {
+			counterfactual.session.agent.setMaintainContext(undefined);
+			await seedCompactableLoop(counterfactual.session);
+			await counterfactual.session.prompt("go");
+			await counterfactual.session.waitForIdle();
+
+			expect(counterfactualOverflow).toBe(true);
+			expect(counterfactual.streamCallCount()).toBeGreaterThanOrEqual(2);
+		} finally {
+			await counterfactual.session.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/agent-session-midrun-maintenance.test.ts
+++ b/packages/coding-agent/test/agent-session-midrun-maintenance.test.ts
@@ -1,0 +1,503 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Agent, type AgentContext } from "@gajae-code/agent-core";
+import type { AssistantMessage, Model, ProviderSessionState, Usage } from "@gajae-code/ai";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { loadExtensions } from "@gajae-code/coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { getLatestCompactionEntry, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { getProjectAgentDir, TempDir } from "@gajae-code/utils";
+
+/**
+ * Outcome-contract coverage for cooperative mid-run context maintenance
+ * (issue #2035, `AgentSession#runMidRunMaintenance` via the test seam). The
+ * decision anchors on the last assistant's `usage.totalTokens` plus trailing
+ * tool/steering deltas; the action reuses prune → promote → compact and returns
+ * one of `not-needed | pruned | compacted | promoted | failed | aborted`.
+ */
+describe("AgentSession mid-run maintenance outcomes", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	const THRESHOLD = 100_000;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-midrun-maintenance-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("openai-codex", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterEach(async () => {
+		if (session) await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	function codexModel(contextWindow: number): Model {
+		const model = modelRegistry.find("openai-codex", "gpt-5.5");
+		if (!model) throw new Error("Expected bundled openai-codex model to exist");
+		return { ...model, contextWindow, maxTokens: 32_768 };
+	}
+
+	async function shortCircuitExtensionRunner(sessionManager: SessionManager): Promise<ExtensionRunner> {
+		const extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		const extensionPath = path.join(extensionsDir, "compaction-short-circuit.ts");
+		fs.writeFileSync(
+			extensionPath,
+			[
+				"export default function(pi) {",
+				'\tpi.on("session_before_compact", async (event) => {',
+				"\t\tconst gate = globalThis.__midrunCompactGate;",
+				'\t\tif (gate) await Promise.race([gate, new Promise(resolve => event.signal.addEventListener("abort", resolve, { once: true }))]);',
+				"\t\treturn {",
+				"\t\t\tcompaction: {",
+				'\t\t\t\tsummary: "compacted summary",',
+				"\t\t\t\tshortSummary: undefined,",
+				"\t\t\t\tfirstKeptEntryId: event.preparation.firstKeptEntryId,",
+				"\t\t\t\ttokensBefore: event.preparation.tokensBefore,",
+				"\t\t\t\tdetails: {},",
+				"\t\t\t},",
+				"\t\t};",
+				"\t});",
+				"}",
+			].join("\n"),
+		);
+		const loaded = await loadExtensions([extensionPath], tempDir.path());
+		return new ExtensionRunner(loaded.extensions, loaded.runtime, tempDir.path(), sessionManager, modelRegistry);
+	}
+
+	function usage(totalTokens: number, input = totalTokens, output = 0): Usage {
+		return {
+			input,
+			output,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+	}
+
+	function assistant(model: Model, u: Usage, text = "ok"): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [{ type: "text", text }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: u,
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+	}
+
+	async function buildSession(options: {
+		contextWindow?: number;
+		shortCircuit?: boolean;
+		settings?: Record<string, unknown>;
+	}): Promise<AgentSession> {
+		const model = codexModel(options.contextWindow ?? 200_000);
+		const sessionManager = SessionManager.inMemory();
+		const extensionRunner = options.shortCircuit ? await shortCircuitExtensionRunner(sessionManager) : undefined;
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": true,
+			"compaction.strategy": "context-full",
+			"compaction.thresholdTokens": THRESHOLD,
+			"contextPromotion.enabled": false,
+			...options.settings,
+		});
+		return new AgentSession({ agent, sessionManager, settings, modelRegistry, extensionRunner });
+	}
+
+	/** Seed the agent state + session branch with message_end events, then settle persistence. */
+	async function seed(s: AgentSession, messages: readonly unknown[]): Promise<void> {
+		for (const message of messages) {
+			s.agent.emitExternalEvent({ type: "message_end", message: message as never });
+		}
+		await Bun.sleep(10);
+	}
+
+	/**
+	 * Seed a multi-turn conversation whose older turns are summarizable, so
+	 * prepareCompaction returns a real preparation. The last assistant carries
+	 * `finalUsageTotal` (the mid-run estimate anchor). Pair with a low
+	 * `compaction.keepRecentTokens` so the small-content branch still compacts.
+	 */
+	async function seedCompactableConversation(s: AgentSession, finalUsageTotal: number): Promise<void> {
+		const m = s.model!;
+		await seed(s, [
+			{ role: "user", content: "first request: analyze the earlier work in detail", timestamp: Date.now() },
+			assistant(m, usage(1_000), "earlier response one with some content"),
+			{ role: "user", content: "second request: continue the analysis thoroughly", timestamp: Date.now() },
+			assistant(m, usage(1_000), "earlier response two with more content"),
+			{ role: "user", content: "third request: keep going with the plan", timestamp: Date.now() },
+			assistant(m, usage(finalUsageTotal), "final response near the window"),
+		]);
+	}
+
+	function contextOf(s: AgentSession): AgentContext {
+		return { systemPrompt: s.state.systemPrompt, messages: s.messages, tools: [] };
+	}
+
+	async function waitFor(predicate: () => boolean): Promise<void> {
+		const deadline = Date.now() + 1_000;
+		while (!predicate()) {
+			if (Date.now() >= deadline) throw new Error("Timed out waiting for test condition");
+			await Bun.sleep(1);
+		}
+	}
+
+	it("estimates on last-assistant totalTokens, not the prompt-only anchor", async () => {
+		session = await buildSession({});
+		const model = session.model!;
+		// input(prompt-only)=50k but totalTokens(input+output)=100k. The mid-run
+		// estimate must use totalTokens, so it cannot be near the 50k prompt anchor.
+		const estimate = session.estimateMidRunContextTokensForTests([
+			{ role: "user", content: "hi", timestamp: Date.now() } as never,
+			assistant(model, usage(100_000, 50_000, 50_000)),
+		]);
+		expect(estimate).toBeGreaterThanOrEqual(100_000);
+	});
+
+	it("adds trailing tool-result deltas to the totalTokens anchor", async () => {
+		session = await buildSession({});
+		const model = session.model!;
+		const base = [{ role: "user", content: "hi", timestamp: Date.now() } as never, assistant(model, usage(90_000))];
+		const withTrailing = [
+			...base,
+			{
+				role: "toolResult",
+				toolCallId: "t1",
+				toolName: "read",
+				content: [{ type: "text", text: "x".repeat(40_000) }],
+				timestamp: Date.now(),
+			} as never,
+		];
+		const baseEstimate = session.estimateMidRunContextTokensForTests(base);
+		const trailingEstimate = session.estimateMidRunContextTokensForTests(withTrailing);
+		expect(baseEstimate).toBe(90_000);
+		expect(trailingEstimate).toBeGreaterThan(baseEstimate);
+	});
+
+	it("returns not-needed below the threshold", async () => {
+		session = await buildSession({});
+		const model = session.model!;
+		await seed(session, [
+			{ role: "user", content: "hi", timestamp: Date.now() } as never,
+			assistant(model, usage(10_000)),
+		]);
+		expect(await session.runMidRunMaintenanceForTests(contextOf(session))).toBe("not-needed");
+	});
+
+	it("returns not-needed at exactly the threshold and maintains just past it", async () => {
+		session = await buildSession({ shortCircuit: true, settings: { "compaction.keepRecentTokens": 10 } });
+		const model = session.model!;
+		await seed(session, [
+			{ role: "user", content: "hi", timestamp: Date.now() } as never,
+			assistant(model, usage(THRESHOLD)),
+		]);
+		// shouldCompact is strictly greater-than, so exactly-at-threshold does not maintain.
+		expect(await session.runMidRunMaintenanceForTests(contextOf(session))).toBe("not-needed");
+
+		const over = await buildSession({ shortCircuit: true, settings: { "compaction.keepRecentTokens": 10 } });
+		await seedCompactableConversation(over, THRESHOLD + 5_000);
+		expect(
+			await over.runMidRunMaintenanceForTests({
+				systemPrompt: over.state.systemPrompt,
+				messages: over.messages,
+				tools: [],
+			}),
+		).toBe("compacted");
+		await over.dispose();
+	});
+
+	it("returns not-needed when auto maintenance is disabled or strategy is off", async () => {
+		session = await buildSession({ settings: { "compaction.strategy": "off" } });
+		const model = session.model!;
+		await seed(session, [
+			{ role: "user", content: "hi", timestamp: Date.now() } as never,
+			assistant(model, usage(THRESHOLD * 3)),
+		]);
+		expect(await session.runMidRunMaintenanceForTests(contextOf(session))).toBe("not-needed");
+	});
+
+	it("compacts above the threshold and resets the codex provider session (prompt-cache epoch)", async () => {
+		session = await buildSession({ shortCircuit: true, settings: { "compaction.keepRecentTokens": 10 } });
+		const closeSpy = () => {
+			closed++;
+		};
+		let closed = 0;
+		session.providerSessionState.set("openai-codex-responses", { close: closeSpy } satisfies ProviderSessionState);
+
+		await seedCompactableConversation(session, THRESHOLD * 3);
+		const before = getLatestCompactionEntry(session.sessionManager.getBranch());
+		const outcome = await session.runMidRunMaintenanceForTests(contextOf(session));
+
+		expect(outcome).toBe("compacted");
+		const after = getLatestCompactionEntry(session.sessionManager.getBranch());
+		expect(after).not.toBeNull();
+		expect(after?.id).not.toBe(before?.id ?? null);
+		// History was rewritten, so the codex websocket session (previous_response_id)
+		// was closed to start a clean provider/prompt-cache epoch.
+		expect(closed).toBe(1);
+	});
+
+	it("selects a larger-context promotion target instead of compacting", async () => {
+		const sessionManager = SessionManager.inMemory();
+		const sparkModel = modelRegistry.find("openai-codex", "gpt-5.3-codex-spark");
+		const largeModel = modelRegistry.find("openai-codex", "gpt-5.5");
+		if (!sparkModel || !largeModel) throw new Error("Expected codex spark + large models");
+		const startModel = { ...sparkModel, contextWindow: 150_000 };
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model: startModel, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.enabled": true,
+				"compaction.strategy": "context-full",
+				"compaction.thresholdTokens": THRESHOLD,
+				"contextPromotion.enabled": true,
+			}),
+			modelRegistry,
+		});
+		let closed = 0;
+		const previousProviderSessionState = session.providerSessionState;
+		previousProviderSessionState.set("openai-codex-responses", {
+			close: () => closed++,
+		} satisfies ProviderSessionState);
+		await seed(session, [
+			{ role: "user", content: "hi", timestamp: Date.now() } as never,
+			assistant(startModel, usage(THRESHOLD * 1.2)),
+			assistant(startModel, usage(THRESHOLD * 1.2)),
+		]);
+
+		const outcome = await session.runMidRunMaintenanceForTests(contextOf(session));
+		expect(outcome).toBe("promoted");
+		expect(session.model?.contextWindow).toBeGreaterThan(startModel.contextWindow!);
+		expect(session.providerSessionState).not.toBe(previousProviderSessionState);
+		expect(closed).toBe(0);
+		expect(getLatestCompactionEntry(session.sessionManager.getBranch())).toBeNull();
+	});
+
+	it("rolls back a temporary promotion scope when cancellation lands after the model switch", async () => {
+		const sessionManager = SessionManager.inMemory();
+		const sparkModel = modelRegistry.find("openai-codex", "gpt-5.3-codex-spark");
+		const largeModel = modelRegistry.find("openai-codex", "gpt-5.5");
+		if (!sparkModel || !largeModel) throw new Error("Expected codex spark + large models");
+		const startModel = { ...sparkModel, contextWindow: 150_000 };
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model: startModel, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.enabled": true,
+				"compaction.strategy": "context-full",
+				"compaction.thresholdTokens": THRESHOLD,
+				"contextPromotion.enabled": true,
+			}),
+			modelRegistry,
+		});
+		const previousProviderSessionState = session.providerSessionState;
+		previousProviderSessionState.set("openai-codex-responses", { close: () => {} });
+		await seed(session, [
+			{ role: "user", content: "hi", timestamp: Date.now() } as never,
+			assistant(startModel, usage(THRESHOLD * 1.2)),
+		]);
+		const cancellation = new AbortController();
+		const originalSetModelTemporary = session.setModelTemporary.bind(session);
+		session.setModelTemporary = async (...args) => {
+			const scope = await originalSetModelTemporary(...args);
+			cancellation.abort();
+			return scope;
+		};
+
+		const outcome = await session.runMidRunMaintenanceForTests(contextOf(session), {
+			signal: cancellation.signal,
+			awaitEventDrain: async () => {},
+		});
+
+		expect(outcome).toBe("aborted");
+		expect(session.model?.id).toBe(startModel.id);
+		expect(session.providerSessionState).toBe(previousProviderSessionState);
+	});
+
+	it("returns failed when compaction cannot proceed (no compaction backend)", async () => {
+		// No short-circuit extension and the runtime model registry exposes no
+		// usable compaction candidate, so #runAutoCompaction skips without a new
+		// compaction entry — reported as an explicit failure so the run still resumes.
+		session = await buildSession({ shortCircuit: false });
+		const model = session.model!;
+		await seed(session, [
+			{ role: "user", content: "hi", timestamp: Date.now() } as never,
+			assistant(model, usage(THRESHOLD * 3)),
+			assistant(model, usage(THRESHOLD * 3)),
+		]);
+		const outcome = await session.runMidRunMaintenanceForTests(contextOf(session));
+		expect(outcome).toBe("failed");
+		expect(getLatestCompactionEntry(session.sessionManager.getBranch())).toBeNull();
+	});
+
+	it("does not double-compact while a compaction is already in flight", async () => {
+		session = await buildSession({ shortCircuit: true, settings: { "compaction.keepRecentTokens": 10 } });
+		await seedCompactableConversation(session, THRESHOLD * 3);
+		// Block a long-lived idle compaction at session_before_compact so
+		// isCompacting stays true, then confirm the mid-run checkpoint yields the
+		// context instead of stacking a second (double) compaction underneath it.
+		const gate = Promise.withResolvers<void>();
+		(globalThis as { __midrunCompactGate?: Promise<void> }).__midrunCompactGate = gate.promise;
+		try {
+			const inFlight = session.runIdleCompaction();
+			const deadline = Date.now() + 1_000;
+			while (!session.isCompacting && Date.now() < deadline) await Bun.sleep(5);
+			expect(session.isCompacting).toBe(true);
+
+			const outcome = await session.runMidRunMaintenanceForTests(contextOf(session));
+			expect(outcome).toBe("not-needed");
+
+			gate.resolve();
+			await inFlight;
+		} finally {
+			(globalThis as { __midrunCompactGate?: Promise<void> }).__midrunCompactGate = undefined;
+		}
+	});
+	it("T2 canonically persists paired tool results and distinct steering before a prune rewrite", async () => {
+		session = await buildSession({ shortCircuit: true });
+		let closed = 0;
+		session.providerSessionState.set("openai-codex-responses", {
+			close: () => closed++,
+		} satisfies ProviderSessionState);
+		const m = session.model!;
+		const pairedToolResult = {
+			role: "toolResult",
+			toolCallId: "paired-result",
+			toolName: "noop",
+			content: [{ type: "text", text: "paired output" }],
+			timestamp: Date.now(),
+		};
+		await seed(session, [
+			{ role: "user", content: "earlier request", timestamp: Date.now() },
+			{
+				role: "toolResult",
+				toolCallId: "old-output-1",
+				toolName: "bash",
+				content: [{ type: "text", text: "x".repeat(120_000) }],
+				timestamp: Date.now(),
+			},
+			{
+				role: "toolResult",
+				toolCallId: "old-output-3",
+				toolName: "bash",
+				content: [{ type: "text", text: "z".repeat(120_000) }],
+				timestamp: Date.now(),
+			},
+			{
+				role: "toolResult",
+				toolCallId: "old-output-2",
+				toolName: "bash",
+				content: [{ type: "text", text: "y".repeat(120_000) }],
+				timestamp: Date.now(),
+			},
+			assistant(m, usage(THRESHOLD + 1)),
+			pairedToolResult,
+			{ role: "user", content: "first distinct steering", timestamp: Date.now() },
+			{ role: "user", content: "second distinct steering", timestamp: Date.now() },
+		]);
+
+		expect(await session.runMidRunMaintenanceForTests(contextOf(session))).toBe("pruned");
+		const persisted = session.sessionManager
+			.getBranch()
+			.flatMap(entry =>
+				entry.type === "message"
+					? [entry.message as { role?: string; toolCallId?: string; content?: unknown }]
+					: [],
+			);
+		expect(persisted.filter(message => message.toolCallId === "paired-result")).toHaveLength(1);
+		expect(
+			persisted.filter(message => message.role === "user" && message.content === "first distinct steering"),
+		).toHaveLength(1);
+		expect(
+			persisted.filter(message => message.role === "user" && message.content === "second distinct steering"),
+		).toHaveLength(1);
+		expect(closed).toBe(1);
+		expect(getLatestCompactionEntry(session.sessionManager.getBranch())).toBeNull();
+	});
+
+	it("cleans a held EventStream consumer barrier before it can flush or rewrite", async () => {
+		for (const operation of ["abort", "dispose", "disconnect"] as const) {
+			const s = await buildSession({ shortCircuit: true });
+			session = s;
+			await seed(s, [
+				{ role: "user", content: "barrier request", timestamp: Date.now() },
+				assistant(s.model!, usage(THRESHOLD * 3)),
+			]);
+			const stream = new AssistantMessageEventStream();
+			const consumerReady = Promise.withResolvers<void>();
+			const heldConsumer = Promise.withResolvers<void>();
+			const consumer = (async () => {
+				for await (const _event of stream) {
+					consumerReady.resolve();
+					await heldConsumer.promise;
+				}
+			})();
+			stream.push({ type: "start", partial: assistant(s.model!, usage(1)) });
+			await consumerReady.promise;
+			let flushCount = 0;
+			const manager = s.sessionManager as unknown as { flush: () => Promise<void> };
+			const originalFlush = manager.flush.bind(manager);
+			manager.flush = async () => {
+				flushCount++;
+				return originalFlush();
+			};
+			const maintenance = s.runMidRunMaintenanceForTests(contextOf(s), {
+				signal: new AbortController().signal,
+				awaitEventDrain: signal => stream.waitForConsumerDrain(signal),
+			});
+			await waitFor(
+				() => s.activeMidRunBarrierCountForTests === 1 && stream.pendingConsumerDrainCountForTests === 1,
+			);
+			expect(flushCount).toBe(0);
+
+			if (operation === "abort") await s.abort();
+			else if (operation === "dispose") await s.dispose();
+			else await s.newSession();
+
+			expect(s.activeMidRunBarrierCountForTests).toBe(0);
+			expect(stream.pendingConsumerDrainCountForTests).toBe(0);
+			if (operation === "abort") expect(flushCount).toBe(0);
+
+			expect(await maintenance).toBe("aborted");
+			expect(getLatestCompactionEntry(s.sessionManager.getBranch())).toBeNull();
+			heldConsumer.resolve();
+			stream.end();
+			await consumer;
+			if (operation === "abort") expect(flushCount).toBe(0);
+		}
+	});
+
+	it("T6 attempts identical provider-response anchors at most once", async () => {
+		session = await buildSession({ shortCircuit: false });
+		await seed(session, [
+			{ role: "user", content: "anti-wedge request", timestamp: Date.now() },
+			assistant(session.model!, usage(THRESHOLD * 3)),
+		]);
+		expect(await session.runMidRunMaintenanceForTests(contextOf(session))).toBe("failed");
+		expect(await session.runMidRunMaintenanceForTests(contextOf(session))).toBe("not-needed");
+	});
+});


### PR DESCRIPTION
## Summary
- add a cooperative context-maintenance checkpoint between tool iterations, after tool/steering messages are durable and before the next provider call
- preserve one logical run/continuation owner across prune, promotion, compaction, cancellation, managed fallback, and disposal paths
- add a FIFO EventStream consumer-drain barrier so history rewrites cannot race asynchronous session-event persistence
- integrate current `dev` temporary provider-session scopes and managed-attempt lifecycle without resurrecting superseded retry code

## Independent reproduction
The network-free counterfactual disables mid-run maintenance and reproduces a CJK-heavy tool-loop `context_length_exceeded` on the second provider call. With maintenance enabled, threshold compaction occurs before that call and the run completes. The focused test is `T8 prevents the CJK-heavy provider overflow that occurs without mid-run maintenance`.

## Verification
- `bun test packages/ai/test/event-stream-consumer-drain.test.ts packages/agent/test/agent-loop-maintain-context-lifecycle.test.ts packages/agent/test/managed-attempt-transaction.test.ts packages/coding-agent/test/agent-session-midrun-maintenance.test.ts packages/coding-agent/test/agent-session-midrun-compaction.test.ts packages/coding-agent/test/agent-session-abort-timeout.test.ts` — 57 pass
- `bun run check` in `packages/ai` — pass
- `bun run check` in `packages/agent` — pass
- `bun run check` in `packages/coding-agent` — pass
- exact-head adversarial review of `157c8320f` — CLEAR, no blocking findings
- commit `157c8320f` has a valid Git signature

Closes #2035

Signed-off-by: Yeachan-Heo <yeachan-heo@gajae.dev>