### PR TITLE
fix(acp): publish scoped session authority atomically

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -723,8 +723,8 @@ export class AcpAgent implements Agent {
 						"conflict",
 						`ACP session ${candidate.sessionId} has conflicting cwd authority.`,
 					);
-				this.#knownSessionCwds.set(candidate.sessionId, params.cwd);
 			}
+			for (const sessionId of discovered) this.#knownSessionCwds.set(sessionId, params.cwd);
 		}
 		return paginateAcpSessions(listed, params.cwd ?? undefined, this.#cursor(params.cursor));
 	}

--- a/packages/coding-agent/test/sdk-acp-production-path.test.ts
+++ b/packages/coding-agent/test/sdk-acp-production-path.test.ts
@@ -98,6 +98,70 @@ test("production ACP routes zero-session SDK globals through the broker adapter"
 	abort.abort();
 });
 
+test("failed scoped list publication does not authorize earlier sessions", async () => {
+	const directory = await mkdtemp(path.join(tmpdir(), "gjc-sdk-acp-list-atomic-"));
+	directories.push(directory);
+	const agentDir = path.join(directory, ".gjc", "agent");
+	const cwd = path.join(directory, "workspace");
+	const token = "acp-list-atomic-token";
+	const requests: Array<Record<string, unknown>> = [];
+	let server!: TestServer;
+	server = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0,
+		fetch(request) {
+			if (new URL(request.url).searchParams.get("token") !== token)
+				return new Response("Unauthorized", { status: 401 });
+			if (!server.upgrade(request)) return new Response("Upgrade failed", { status: 400 });
+		},
+		websocket: {
+			open(socket) {
+				socket.send(JSON.stringify({ type: "broker_hello", protocolVersion: 3 }));
+			},
+			message(socket, raw) {
+				const frame = JSON.parse(String(raw)) as Record<string, unknown>;
+				requests.push(frame);
+				const result =
+					frame.operation === "session.list"
+						? {
+								sessions: [
+									{ sessionId: "earlier-session", locator: { repo: cwd } },
+									{ sessionId: "duplicate-session", locator: { repo: cwd } },
+									{ sessionId: "duplicate-session", locator: { repo: cwd } },
+								],
+							}
+						: {};
+				socket.send(JSON.stringify({ type: "broker_response", id: frame.id, ok: true, result }));
+			},
+		},
+	});
+	servers.push(server);
+	await writeBrokerDiscovery(agentDir, {
+		version: 1,
+		protocolVersion: 3,
+		packageGeneration: "test",
+		ownerId: "test-owner",
+		pid: process.pid,
+		host: "127.0.0.1",
+		port: server.port!,
+		url: `ws://127.0.0.1:${server.port!}`,
+		token,
+		startedAt: Date.now(),
+		heartbeatAt: Date.now(),
+	});
+
+	const abort = new AbortController();
+	const agent = new AcpAgent({ signal: abort.signal } as unknown as AgentSideConnection, { agentDir });
+	await expect(agent.listSessions({ cwd })).rejects.toThrow("Broker returned duplicate session id");
+
+	const requestCount = requests.length;
+	expect(await agent.closeSession({ sessionId: "earlier-session" })).toEqual({});
+	expect(requests).toHaveLength(requestCount);
+	expect(await agent.deleteSession({ sessionId: "earlier-session" })).toEqual({});
+	expect(requests).toHaveLength(requestCount);
+	abort.abort();
+});
+
 test("production ACP preserves lifecycle, turn, replay, and connection ownership contracts over SDK WebSockets", async () => {
 	const directory = await mkdtemp(path.join(tmpdir(), "gjc-sdk-acp-contract-"));
 	directories.push(directory);


### PR DESCRIPTION
## Reproducible defect

A scoped ACP `session.list` response was published into the connection-owned `#knownSessionCwds` map one row at a time. If an earlier row validated but a later row was duplicated or conflicted, `listSessions` rejected while leaving the earlier row authorized. A subsequent cwd-less `closeSession` or `deleteSession` could therefore reach broker lifecycle control even though the listing that was supposed to establish authority failed.

## Focused fix

Validate the complete scoped batch into the existing local `discovered` set, then publish the set only after the loop exits successfully. The success-path state is unchanged and there is no await between validation and commit.

The regression uses the production WebSocket broker path:

1. broker returns `earlier-session`, then a duplicated later session id;
2. `listSessions({ cwd })` rejects;
3. cwd-less close and delete for `earlier-session` remain no-ops and emit no broker request.

On unpatched `dev`, the test deterministically fails because close emits a second broker request (`expected 1`, `received 2`).

## Scope

- 2 files
- 65 insertions, 1 deletion
- no broker, lifecycle, storage, CLI, MCP, coordinator, or idempotency changes

This is the first isolated current-`dev`-compatible defect slice following the review direction on closed #2212.

## Verification

Exact head: `48ffcb198d3a8c17cde87d85b7b3107810f94c51`
Base: `bc8f8f12f8b76c27a07ae5435a791ef3eeacc8bf`

- baseline regression oracle: **2 passed, 1 failed** (`requests` grew from 1 to 2)
- fixed `sdk-acp-production-path.test.ts`: **3 passed, 0 failed**
- focused + adjacent ACP tests: **6 passed, 0 failed** across 3 files
- `bun run check` in `packages/coding-agent`: passed
- `git diff --check`: passed
- independent Architect: **CLEAR / CLEAR / CLEAR — APPROVE**
- adversarial QA: **PASS**, no blockers