### PR TITLE
fix(acp): normalize cwd filtering

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -141,7 +141,7 @@ export function paginateAcpSessions(listed: unknown[], cwd: string | undefined, 
 			(value): value is BrokerSession & { locator: { repo: string } } =>
 				typeof value?.sessionId === "string" && typeof value.locator?.repo === "string",
 		)
-		.filter(value => !cwd || value.locator.repo === cwd);
+		.filter(value => !cwd || path.resolve(value.locator.repo) === path.resolve(cwd));
 	const sessions = filtered
 		.slice(offset, offset + SESSION_PAGE_SIZE)
 		.map(

--- a/packages/coding-agent/test/acp-startup-options.test.ts
+++ b/packages/coding-agent/test/acp-startup-options.test.ts
@@ -48,6 +48,15 @@ test("ACP paginates after cwd filtering and terminates the filtered cursor", () 
 	});
 });
 
+test("ACP cwd filtering accepts path-equivalent workspace spellings", () => {
+	expect(
+		paginateAcpSessions([{ sessionId: "workspace", locator: { repo: "/workspace" } }], "/workspace/.", 0),
+	).toEqual({
+		sessions: [{ sessionId: "workspace", cwd: "/workspace", title: "workspace" }],
+		nextCursor: undefined,
+	});
+});
+
 test("ACP reports live SDK config values and mode rather than hard-coded defaults", () => {
 	const state = acpSessionStateFromConfig({
 		result: {


### PR DESCRIPTION
## Reproducible defect

`listSessions` validates a scoped broker session with `path.resolve(candidate.locator.repo) === path.resolve(params.cwd)`, but `paginateAcpSessions` subsequently filtered the same response with strict path-text equality.

As a result, path-equivalent absolute spellings such as `/workspace` and `/workspace/.` passed authority validation but were silently omitted from the ACP response page.

## Focused fix

Use the same `path.resolve` comparison in `paginateAcpSessions` that the existing caller already uses for scoped validation. No authority state, broker behavior, cursor math, or lifecycle operation changes.

The focused regression passes a broker repo `/workspace` with requested cwd `/workspace/.`:

- unpatched `dev`: **7 passed, 1 failed** (`sessions` was unexpectedly empty)
- patched: **8 passed, 0 failed**

## Scope

- 2 files
- 10 insertions, 1 deletion
- one predicate change and one direct unit regression
- independent from PR #2215 and the rejected broad architecture rewrite

This is another isolated current-`dev`-compatible defect slice following the review direction on closed #2212.

## Verification

Exact head: `d28ab2233`
Base: `bc8f8f12f8b76c27a07ae5435a791ef3eeacc8bf`

- focused baseline oracle: **7 passed, 1 failed**
- fixed focused suite: **8 passed, 0 failed**
- focused + production ACP suites: **10 passed, 0 failed**
- `bun run check` in `packages/coding-agent`: passed
- `git diff --check`: passed
- independent Architect: **CLEAR / CLEAR / CLEAR — APPROVE**
- adversarial QA: **PASS**, no blockers