### PR TITLE
fix(acp): normalize scoped session list paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Fenced SDK WebSocket lifecycle callbacks and request settlement to the owning retry cycle/socket incarnation, so stale open, close, error, message, and timeout delivery cannot reject or corrupt work on a replacement connection; sent mutations remain non-replayed and deterministic race regressions cover the reconnect boundary (#2164).
+- Matched ACP session-list CWDs after lexical canonicalization, so equivalent absolute workspace paths no longer produce an empty scoped listing.
 - Owned LSP stdin `EPIPE` and `ERR_STREAM_DESTROYED` failures now terminalize and evict only the affected client, reject pending and stale requests with a stable transport-closed error, and permit clean client recreation without suppressing serialization or unrelated sink failures (#2138).
 - Serialized fresh prompt preflight and durable default-model selection through deterministic per-session admission, preventing a later `model.set` from overtaking an earlier prompt while preserving provider-stream and continuation behavior (#2199).
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -141,7 +141,7 @@ export function paginateAcpSessions(listed: unknown[], cwd: string | undefined, 
 			(value): value is BrokerSession & { locator: { repo: string } } =>
 				typeof value?.sessionId === "string" && typeof value.locator?.repo === "string",
 		)
-		.filter(value => !cwd || value.locator.repo === cwd);
+		.filter(value => !cwd || path.resolve(value.locator.repo) === path.resolve(cwd));
 	const sessions = filtered
 		.slice(offset, offset + SESSION_PAGE_SIZE)
 		.map(

--- a/packages/coding-agent/test/acp-startup-options.test.ts
+++ b/packages/coding-agent/test/acp-startup-options.test.ts
@@ -36,13 +36,17 @@ test("ACP maps non-prompt permission handling to the SDK allow policy", async ()
 	expect(modes).toEqual(["prompt", "allow", "allow"]);
 });
 
-test("ACP paginates after cwd filtering and terminates the filtered cursor", () => {
+test("ACP paginates after canonical cwd filtering and terminates the filtered cursor", () => {
 	const foreign = Array.from({ length: 50 }, (_, index) => ({
 		sessionId: `foreign-${index}`,
 		locator: { repo: "/other" },
 	}));
 	const sessions = [...foreign, { sessionId: "workspace", locator: { repo: "/workspace" } }];
 	expect(paginateAcpSessions(sessions, "/workspace", 0)).toEqual({
+		sessions: [{ sessionId: "workspace", cwd: "/workspace", title: "workspace" }],
+		nextCursor: undefined,
+	});
+	expect(paginateAcpSessions(sessions, "/workspace/.", 0)).toEqual({
 		sessions: [{ sessionId: "workspace", cwd: "/workspace", title: "workspace" }],
 		nextCursor: undefined,
 	});


### PR DESCRIPTION
## Defect

`AcpAgent.listSessions()` already validates broker session CWDs with `path.resolve`, but `paginateAcpSessions()` then filtered the same sessions with raw string equality. An equivalent lexical absolute path such as `/workspace/.` therefore passed scope validation and still produced an empty ACP session page.

## Fix

Use the same `path.resolve` comparison in the projection filter. This is deliberately lexical only: it does not add realpath/symlink authority or change lifecycle behavior.

Scope: 3 files, +7/-2.

## Verification

- `bun test test/acp-startup-options.test.ts test/sdk-acp-production-path.test.ts` — 9 passed
- `bun run check` in `packages/coding-agent` — passed
- independent architecture review — CLEAR / APPROVE
- independent red-team review — PASS, no medium-or-higher findings

A root `bun run check:ts` replay progressed through the unchanged SDK closure manifest with all emitted receipts green but exceeded the 30-minute local timeout; GitHub affected-path CI remains authoritative for the full repository lane.