### PR TITLE
fix(acp): reject malformed list cursors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Fenced SDK WebSocket lifecycle callbacks and request settlement to the owning retry cycle/socket incarnation, so stale open, close, error, message, and timeout delivery cannot reject or corrupt work on a replacement connection; sent mutations remain non-replayed and deterministic race regressions cover the reconnect boundary (#2164).
+- Rejected malformed ACP session-list cursors before broker lookup or connection-local authority changes instead of accepting numeric prefixes.
 - Owned LSP stdin `EPIPE` and `ERR_STREAM_DESTROYED` failures now terminalize and evict only the affected client, reject pending and stale requests with a stable transport-closed error, and permit clean client recreation without suppressing serialization or unrelated sink failures (#2138).
 - Serialized fresh prompt preflight and durable default-model selection through deterministic per-session admission, preventing a later `model.set` from overtaking an earlier prompt while preserving provider-stream and continuation behavior (#2199).
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -701,6 +701,7 @@ export class AcpAgent implements Agent {
 
 	async listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
 		if (params.cwd) this.#assertAbsoluteCwd(params.cwd);
+		const cursor = this.#cursor(params.cursor);
 		const result = object(await (await this.#brokerAdapter()).global("session.list"));
 		const listing = object(result?.result) ?? result;
 		const listed = Array.isArray(listing?.sessions) ? listing.sessions : [];
@@ -726,7 +727,7 @@ export class AcpAgent implements Agent {
 				this.#knownSessionCwds.set(candidate.sessionId, params.cwd);
 			}
 		}
-		return paginateAcpSessions(listed, params.cwd ?? undefined, this.#cursor(params.cursor));
+		return paginateAcpSessions(listed, params.cwd ?? undefined, cursor);
 	}
 
 	async closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
@@ -1447,10 +1448,12 @@ export class AcpAgent implements Agent {
 		}, ACP_BOOTSTRAP_RACE_GUARD_MS);
 	}
 
-	#cursor(cursor: string | null | undefined): number {
-		if (!cursor) return 0;
-		const value = Number.parseInt(cursor, 10);
-		if (!Number.isSafeInteger(value) || value < 0) throw new Error(`Invalid ACP session cursor: ${cursor}`);
+	#cursor(cursor: unknown): number {
+		if (cursor == null) return 0;
+		if (typeof cursor !== "string" || !/^(?:0|[1-9]\d*)$/.test(cursor))
+			throw new Error(`Invalid ACP session cursor: ${String(cursor)}`);
+		const value = Number(cursor);
+		if (!Number.isSafeInteger(value)) throw new Error(`Invalid ACP session cursor: ${cursor}`);
 		return value;
 	}
 

--- a/packages/coding-agent/test/sdk-acp-production-path.test.ts
+++ b/packages/coding-agent/test/sdk-acp-production-path.test.ts
@@ -95,6 +95,12 @@ test("production ACP routes zero-session SDK globals through the broker adapter"
 	expect(lifecycle).toMatchObject({ ok: false, error: { code: "operation_prohibited" } });
 	expect(JSON.stringify(lifecycle)).not.toContain(token);
 	expect(requests).toHaveLength(1);
+	expect(await agent.listSessions({ cursor: "0" })).toEqual({ sessions: [], nextCursor: undefined });
+	expect(requests).toHaveLength(2);
+	for (const cursor of ["1junk", "1e2", " 1", "+1", "01", "", "9007199254740992"])
+		await expect(agent.listSessions({ cursor })).rejects.toThrow(`Invalid ACP session cursor: ${cursor}`);
+	await expect(agent.listSessions({ cursor: 1 as never })).rejects.toThrow("Invalid ACP session cursor: 1");
+	expect(requests).toHaveLength(2);
 	abort.abort();
 });
 


### PR DESCRIPTION
## Defect

ACP session-list cursors were parsed with `Number.parseInt` only after the broker listing and scoped authority loop. Inputs such as `1junk`, `1e2`, or `+1` therefore reached the broker, could mutate connection-local CWD authority, and were silently interpreted as another offset.

## Fix

Parse before broker lookup and accept only canonical unsigned decimal cursor strings emitted by this server, bounded by `Number.MAX_SAFE_INTEGER`. Null/undefined still mean the first page; malformed, overflow, and non-string runtime values fail before any broker request or authority publication.

This patch is independent of #2218 and isolates one cursor defect only.

Scope: 3 files, +15/-5.

## Verification

- `bun test test/sdk-acp-production-path.test.ts test/acp-startup-options.test.ts` — 9 passed / 71 assertions
- `bun run check` in `packages/coding-agent` — passed
- malformed/overflow/non-string inputs issue zero broker requests in the production WebSocket fixture
- architecture/red-team review in progress on exact head `09d0cfa30af20e7ebfe91450ce1d4c38466fe5ea`; no medium-or-higher finding identified