### PR TITLE
fix(tests): isolate notification state and reap SDK brokers

### DIFF
--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -217,36 +217,52 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	sdkServer.stop(true);
-	const signalled = new Set<number>();
-	const serverPid = await readFile(path.join(root, "tmux-server.pid"), "utf8")
-		.then(value => Number(value.trim()))
-		.catch(error => {
+	let ownerTeardownError: unknown;
+	try {
+		sdkServer.stop(true);
+		const signalled = new Set<number>();
+		const serverPid = await readFile(path.join(root, "tmux-server.pid"), "utf8")
+			.then(value => Number(value.trim()))
+			.catch(error => {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+				throw error;
+			});
+		if (serverPid !== null && Number.isSafeInteger(serverPid) && serverPid > 0) {
+			try {
+				process.kill(serverPid, "SIGTERM");
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+			}
+			signalled.add(serverPid);
+		}
+		const lease = await readLease(root, SID).catch(error => {
 			if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
 			throw error;
 		});
-	if (serverPid !== null && Number.isSafeInteger(serverPid) && serverPid > 0) {
-		try {
-			process.kill(serverPid, "SIGTERM");
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+		if (lease?.pid) {
+			try {
+				process.kill(lease.pid, "SIGTERM");
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+			}
+			signalled.add(lease.pid);
 		}
-		signalled.add(serverPid);
+		for (const pid of signalled) await waitForExactExit(pid);
+	} catch (error) {
+		ownerTeardownError = error;
 	}
-	const lease = await readLease(root, SID).catch(error => {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-		throw error;
-	});
-	if (lease?.pid) {
-		try {
-			process.kill(lease.pid, "SIGTERM");
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+	try {
+		await cliEnv.cleanup();
+	} catch (brokerCleanupError) {
+		if (ownerTeardownError) {
+			throw new AggregateError(
+				[ownerTeardownError, brokerCleanupError],
+				"Detached harness owner and SDK broker cleanup both failed; preserving roots.",
+			);
 		}
-		signalled.add(lease.pid);
+		throw brokerCleanupError;
 	}
-	for (const pid of signalled) await waitForExactExit(pid);
-	await cliEnv.cleanup();
+	if (ownerTeardownError) throw ownerTeardownError;
 	await rm(root, { recursive: true, force: true });
 	await rm(workspace, { recursive: true, force: true });
 });

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -191,12 +191,25 @@ async function runHarness(
 }
 
 const sleep = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms));
+async function waitForExactExit(pid: number, timeoutMs = 5_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			process.kill(pid, 0);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+			throw error;
+		}
+		await sleep(25);
+	}
+	throw new Error(`Detached harness owner pid ${pid} did not exit within ${timeoutMs}ms.`);
+}
 
 beforeEach(async () => {
 	// Short paths keep the AF_UNIX socket path under the sun_path limit.
 	root = await mkdtemp(path.join(tmpdir(), "h"));
 	workspace = await mkdtemp(path.join(tmpdir(), "hw"));
-	cliEnv = createHarnessCliEnv(repoRoot);
+	cliEnv = await createHarnessCliEnv(repoRoot);
 	tmuxCommand = await createFakeTmuxBin(root);
 
 	disableSdkHost = false;
@@ -205,7 +218,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
 	sdkServer.stop(true);
-	cliEnv.cleanup();
+	const signalled = new Set<number>();
 	const serverPid = await readFile(path.join(root, "tmux-server.pid"), "utf8")
 		.then(value => Number(value.trim()))
 		.catch(error => {
@@ -218,6 +231,7 @@ afterEach(async () => {
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
 		}
+		signalled.add(serverPid);
 	}
 	const lease = await readLease(root, SID).catch(error => {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
@@ -229,7 +243,10 @@ afterEach(async () => {
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
 		}
+		signalled.add(lease.pid);
 	}
+	for (const pid of signalled) await waitForExactExit(pid);
+	await cliEnv.cleanup();
 	await rm(root, { recursive: true, force: true });
 	await rm(workspace, { recursive: true, force: true });
 });

--- a/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
@@ -93,7 +93,7 @@ const passingFinalizeChecks: FinalizeChecks = {
 
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "h"));
-	cliEnv = createHarnessCliEnv(repoRoot);
+	cliEnv = await createHarnessCliEnv(repoRoot);
 	await writeSessionState(root, seed(root));
 	owner = new RuntimeOwner({
 		root,
@@ -107,10 +107,10 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	cliEnv.cleanup();
 	await owner?.stop();
 	await new Promise<void>(resolve => hungServer?.close(() => resolve()) ?? resolve());
 	hungServer = null;
+	await cliEnv.cleanup();
 	await rm(root, { recursive: true, force: true });
 });
 

--- a/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
@@ -107,10 +107,26 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	await owner?.stop();
-	await new Promise<void>(resolve => hungServer?.close(() => resolve()) ?? resolve());
-	hungServer = null;
-	await cliEnv.cleanup();
+	let ownerTeardownError: unknown;
+	try {
+		await owner?.stop();
+		await new Promise<void>(resolve => hungServer?.close(() => resolve()) ?? resolve());
+		hungServer = null;
+	} catch (error) {
+		ownerTeardownError = error;
+	}
+	try {
+		await cliEnv.cleanup();
+	} catch (brokerCleanupError) {
+		if (ownerTeardownError) {
+			throw new AggregateError(
+				[ownerTeardownError, brokerCleanupError],
+				"Harness runtime owner and SDK broker cleanup both failed; preserving roots.",
+			);
+		}
+		throw brokerCleanupError;
+	}
+	if (ownerTeardownError) throw ownerTeardownError;
 	await rm(root, { recursive: true, force: true });
 });
 

--- a/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { brokerOwnerForTest, ensureBroker } from "../../src/sdk/broker/ensure";
 
 interface PackageManifest {
 	name?: unknown;
@@ -21,7 +22,7 @@ interface RepoLinkMarker {
 
 export interface HarnessCliEnv {
 	env: NodeJS.ProcessEnv;
-	cleanup(): void;
+	cleanup(): Promise<void>;
 }
 
 function readPackageName(manifestPath: string): string | null {
@@ -128,7 +129,10 @@ function createRepoNodeModulesLinks(repoRoot: string, packages: LinkedWorkspaceP
 	};
 }
 
-export function createHarnessCliEnv(repoRoot: string, baseEnv: NodeJS.ProcessEnv = process.env): HarnessCliEnv {
+export async function createHarnessCliEnv(
+	repoRoot: string,
+	baseEnv: NodeJS.ProcessEnv = process.env,
+): Promise<HarnessCliEnv> {
 	const nodePathRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-harness-node-path-"));
 	const registryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-harness-root-registry-"));
 	const packages = collectWorkspacePackages(repoRoot);
@@ -150,12 +154,20 @@ export function createHarnessCliEnv(repoRoot: string, baseEnv: NodeJS.ProcessEnv
 	};
 	delete env.GJC_NOTIFICATIONS_TOKEN;
 
+	const cleanupFiles = (): void => {
+		cleanupRepoLinks();
+		fs.rmSync(nodePathRoot, { recursive: true, force: true });
+		fs.rmSync(registryRoot, { recursive: true, force: true });
+	};
+	await ensureBroker({ agentDir: tempAgentDir, env });
+	const brokerOwner = brokerOwnerForTest(tempAgentDir);
+	if (!brokerOwner) throw new Error(`Harness test broker owner was not retained for ${tempAgentDir}.`);
+
 	return {
 		env,
-		cleanup() {
-			cleanupRepoLinks();
-			fs.rmSync(nodePathRoot, { recursive: true, force: true });
-			fs.rmSync(registryRoot, { recursive: true, force: true });
+		async cleanup() {
+			await brokerOwner.stop();
+			cleanupFiles();
 		},
 	};
 }

--- a/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
@@ -135,13 +135,20 @@ export function createHarnessCliEnv(repoRoot: string, baseEnv: NodeJS.ProcessEnv
 	linkWorkspacePackages(path.join(nodePathRoot, "@gajae-code"), packages);
 	const cleanupRepoLinks = createRepoNodeModulesLinks(repoRoot, packages);
 
+	// Harness subprocesses must never inherit the operator's notifications or agent state.
+	const tempAgentDir = path.join(registryRoot, "agent");
+
 	const existingNodePath = baseEnv.NODE_PATH;
 	const env: NodeJS.ProcessEnv = {
 		...baseEnv,
 		[WORKSPACE_NODE_MODULES_ENV]: path.join(repoRoot, "node_modules"),
 		GJC_HARNESS_ROOT_REGISTRY_DIR: registryRoot,
+		GJC_NOTIFICATIONS: "0",
+		GJC_CODING_AGENT_DIR: tempAgentDir,
+		PI_CODING_AGENT_DIR: tempAgentDir,
 		NODE_PATH: existingNodePath ? `${nodePathRoot}${path.delimiter}${existingNodePath}` : nodePathRoot,
 	};
+	delete env.GJC_NOTIFICATIONS_TOKEN;
 
 	return {
 		env,

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -173,7 +173,7 @@ async function seedOwnerDiedBeforeFirstPrompt(sessionId: string): Promise<void> 
 }
 
 describe("gjc harness CLI (foundation)", () => {
-	it("test CLI env cleanup removes overlapping created links and preserves pre-existing links", async () => {
+	it("test CLI env isolates operator state, cleans created links, and preserves pre-existing links", async () => {
 		const fakeRepo = await mkdtemp(path.join(tmpdir(), "harness-cli-env-repo-"));
 		try {
 			const packageDir = path.join(fakeRepo, "packages", "ai");
@@ -181,8 +181,17 @@ describe("gjc harness CLI (foundation)", () => {
 			await writeFile(path.join(packageDir, "package.json"), JSON.stringify({ name: "@gajae-code/ai" }), "utf8");
 			const linkPath = path.join(fakeRepo, "node_modules", "@gajae-code", "ai");
 
-			const first = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			const first = createHarnessCliEnv(fakeRepo, {
+				GJC_NOTIFICATIONS: "1",
+				GJC_NOTIFICATIONS_TOKEN: "live-token",
+				GJC_CODING_AGENT_DIR: "/production/gjc-agent",
+				PI_CODING_AGENT_DIR: "/production/pi-agent",
+			});
 			const second = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			expect(first.env.GJC_NOTIFICATIONS).toBe("0");
+			expect(first.env.GJC_NOTIFICATIONS_TOKEN).toBeUndefined();
+			expect(first.env.GJC_CODING_AGENT_DIR).toBe(path.join(first.env.GJC_HARNESS_ROOT_REGISTRY_DIR!, "agent"));
+			expect(first.env.PI_CODING_AGENT_DIR).toBe(first.env.GJC_CODING_AGENT_DIR);
 			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
 			first.cleanup();
 			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -12,6 +12,7 @@ import {
 	sessionPaths,
 	writeSessionState,
 } from "../../src/harness-control-plane/storage";
+import { brokerOwnerForTest } from "../../src/sdk/broker/ensure";
 import { createHarnessCliEnv, type HarnessCliEnv } from "./cli-workspace-env";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
@@ -25,14 +26,14 @@ let originalGjcSessionId: string | undefined;
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "harness-cli-root-"));
 	workspace = realpathSync(await mkdtemp(path.join(tmpdir(), "harness-cli-ws-")));
-	cliEnv = createHarnessCliEnv(repoRoot);
+	cliEnv = await createHarnessCliEnv(repoRoot);
 	originalGjcSessionId = process.env.GJC_SESSION_ID;
 	process.env.GJC_SESSION_ID = "test-session";
 	cliEnv.env.GJC_SESSION_ID = "test-session";
 });
 
 afterEach(async () => {
-	cliEnv.cleanup();
+	await cliEnv.cleanup();
 	await rm(root, { recursive: true, force: true });
 	await rm(workspace, { recursive: true, force: true });
 	if (originalGjcSessionId === undefined) {
@@ -181,27 +182,30 @@ describe("gjc harness CLI (foundation)", () => {
 			await writeFile(path.join(packageDir, "package.json"), JSON.stringify({ name: "@gajae-code/ai" }), "utf8");
 			const linkPath = path.join(fakeRepo, "node_modules", "@gajae-code", "ai");
 
-			const first = createHarnessCliEnv(fakeRepo, {
+			const first = await createHarnessCliEnv(fakeRepo, {
 				GJC_NOTIFICATIONS: "1",
 				GJC_NOTIFICATIONS_TOKEN: "live-token",
 				GJC_CODING_AGENT_DIR: "/production/gjc-agent",
 				PI_CODING_AGENT_DIR: "/production/pi-agent",
 			});
-			const second = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			const second = await createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
 			expect(first.env.GJC_NOTIFICATIONS).toBe("0");
 			expect(first.env.GJC_NOTIFICATIONS_TOKEN).toBeUndefined();
 			expect(first.env.GJC_CODING_AGENT_DIR).toBe(path.join(first.env.GJC_HARNESS_ROOT_REGISTRY_DIR!, "agent"));
 			expect(first.env.PI_CODING_AGENT_DIR).toBe(first.env.GJC_CODING_AGENT_DIR);
+			const firstAgentDir = first.env.GJC_CODING_AGENT_DIR!;
+			expect(brokerOwnerForTest(firstAgentDir)).toBeDefined();
 			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
-			first.cleanup();
+			await first.cleanup();
+			expect(brokerOwnerForTest(firstAgentDir)).toBeUndefined();
 			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
-			second.cleanup();
+			await second.cleanup();
 			expect(await Bun.file(linkPath).exists()).toBe(false);
 
 			await mkdir(path.dirname(linkPath), { recursive: true });
 			await symlink(packageDir, linkPath, "dir");
-			const withPreexistingLink = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
-			withPreexistingLink.cleanup();
+			const withPreexistingLink = await createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			await withPreexistingLink.cleanup();
 			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
 		} finally {
 			await rm(fakeRepo, { recursive: true, force: true });

--- a/packages/coding-agent/test/harness-tmux-owner.test.ts
+++ b/packages/coding-agent/test/harness-tmux-owner.test.ts
@@ -182,7 +182,7 @@ async function waitForExactExit(pid: number, timeoutMs: number): Promise<boolean
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "harness-tmux-owner-"));
 	workspace = await mkdtemp(path.join(tmpdir(), "harness-tmux-workspace-"));
-	cliEnv = createHarnessCliEnv(repoRoot);
+	cliEnv = await createHarnessCliEnv(repoRoot);
 });
 
 afterEach(async () => {
@@ -202,7 +202,7 @@ afterEach(async () => {
 		// PRESERVE the roots for inspection instead of silently rm-ing an orphaned tree.
 		if (!(await waitForExactExit(lease.pid, LEASE_EXIT_TIMEOUT_MS))) leaseExitFailed = lease.pid;
 	}
-	cliEnv.cleanup();
+	await cliEnv.cleanup();
 	if (leaseExitFailed !== null)
 		throw new Error(
 			`detached owner lease pid ${leaseExitFailed} did not exit within ${LEASE_EXIT_TIMEOUT_MS}ms; preserving roots for inspection`,

--- a/packages/coding-agent/test/harness-tmux-owner.test.ts
+++ b/packages/coding-agent/test/harness-tmux-owner.test.ts
@@ -186,27 +186,40 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	const lease = await readLease(root, sessionId).catch(error => {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-		throw error;
-	});
-	let leaseExitFailed: number | null = null;
-	if (lease?.pid) {
-		try {
-			process.kill(lease.pid, "SIGTERM");
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+	let ownerTeardownError: unknown;
+	try {
+		const lease = await readLease(root, sessionId).catch(error => {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+			throw error;
+		});
+		if (lease?.pid) {
+			try {
+				process.kill(lease.pid, "SIGTERM");
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+			}
+			// A live detached owner must exit before its broker or roots are removed.
+			if (!(await waitForExactExit(lease.pid, LEASE_EXIT_TIMEOUT_MS))) {
+				throw new Error(
+					`detached owner lease pid ${lease.pid} did not exit within ${LEASE_EXIT_TIMEOUT_MS}ms; preserving roots for inspection`,
+				);
+			}
 		}
-		// Bounded exact lease-PID exit wait: a live detached owner must tear down (and signal its
-		// descendants) before we delete the roots. A timeout is a real leak — fail loudly and
-		// PRESERVE the roots for inspection instead of silently rm-ing an orphaned tree.
-		if (!(await waitForExactExit(lease.pid, LEASE_EXIT_TIMEOUT_MS))) leaseExitFailed = lease.pid;
+	} catch (error) {
+		ownerTeardownError = error;
 	}
-	await cliEnv.cleanup();
-	if (leaseExitFailed !== null)
-		throw new Error(
-			`detached owner lease pid ${leaseExitFailed} did not exit within ${LEASE_EXIT_TIMEOUT_MS}ms; preserving roots for inspection`,
-		);
+	try {
+		await cliEnv.cleanup();
+	} catch (brokerCleanupError) {
+		if (ownerTeardownError) {
+			throw new AggregateError(
+				[ownerTeardownError, brokerCleanupError],
+				"Detached harness owner and SDK broker cleanup both failed; preserving roots.",
+			);
+		}
+		throw brokerCleanupError;
+	}
+	if (ownerTeardownError) throw ownerTeardownError;
 	await rm(root, { recursive: true, force: true });
 	await rm(workspace, { recursive: true, force: true });
 });

--- a/packages/coding-agent/test/helpers/notification-settings.ts
+++ b/packages/coding-agent/test/helpers/notification-settings.ts
@@ -1,0 +1,13 @@
+import { Settings } from "../../src/config/settings";
+
+/** Keep notification tests off the user's real config and daemon state. */
+export function isolatedNotificationSettings(agentDir: string): Settings {
+	const settings = Settings.isolated({ "notifications.enabled": false });
+	return new Proxy(settings, {
+		get(target, prop) {
+			if (prop === "getAgentDir") return () => agentDir;
+			const value = Reflect.get(target, prop, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	});
+}

--- a/packages/coding-agent/test/helpers/notification-settings.ts
+++ b/packages/coding-agent/test/helpers/notification-settings.ts
@@ -1,4 +1,5 @@
 import { Settings } from "../../src/config/settings";
+import { brokerOwnerForTest } from "../../src/sdk/broker/ensure";
 
 /** Keep notification tests off the user's real config and daemon state. */
 export function isolatedNotificationSettings(agentDir: string): Settings {
@@ -10,4 +11,10 @@ export function isolatedNotificationSettings(agentDir: string): Settings {
 			return typeof value === "function" ? value.bind(target) : value;
 		},
 	});
+}
+
+export async function stopIsolatedNotificationBroker(agentDir: string): Promise<void> {
+	const brokerOwner = brokerOwnerForTest(agentDir);
+	if (!brokerOwner) throw new Error(`Notification test broker owner was not retained for ${agentDir}.`);
+	await brokerOwner.stop();
 }

--- a/packages/coding-agent/test/notifications-lifecycle-create-autoresume.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-create-autoresume.test.ts
@@ -4,21 +4,36 @@ import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { setAgentDir } from "@gajae-code/utils";
+import { getAgentDir, setAgentDir } from "@gajae-code/utils";
 import type { Args } from "../src/cli/args";
 import { Settings } from "../src/config/settings";
 import { createSessionManager } from "../src/main";
+import { brokerOwnerForTest, ensureBroker } from "../src/sdk/broker/ensure";
 import { SessionManager } from "../src/session/session-manager";
 
 const LIFECYCLE_ENV = ["GJC_LIFECYCLE_REQUEST_ID", "GJC_SESSION_ID"] as const;
+const agentDirs: string[] = [];
+const originalAgentDir = getAgentDir();
 
-afterEach(() => {
-	for (const k of LIFECYCLE_ENV) delete process.env[k];
+afterEach(async () => {
+	try {
+		for (const k of LIFECYCLE_ENV) delete process.env[k];
+		for (const agentDir of agentDirs.splice(0)) {
+			const brokerOwner = brokerOwnerForTest(agentDir);
+			if (!brokerOwner) throw new Error(`Autoresume test broker owner was not retained for ${agentDir}.`);
+			await brokerOwner.stop();
+			await fsp.rm(agentDir, { recursive: true, force: true });
+		}
+	} finally {
+		setAgentDir(originalAgentDir);
+	}
 });
 
 test("normal root launch creates a current SessionManager for root token logs", async () => {
 	const agentDir = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-root-token-session-"));
+	agentDirs.push(agentDir);
 	setAgentDir(agentDir);
+	await ensureBroker({ agentDir });
 	const cwd = path.join(agentDir, "repo");
 	fs.mkdirSync(cwd, { recursive: true });
 
@@ -29,8 +44,6 @@ test("normal root launch creates a current SessionManager for root token logs", 
 	expect(created).toBeDefined();
 	expect(created?.getSessionId()).toBeTruthy();
 	expect(created?.getCwd()).toBe(cwd);
-
-	await fsp.rm(agentDir, { recursive: true, force: true });
 });
 
 // Regression for the PR #1148 stage-17 blocker: a `/session_create` child is a
@@ -40,7 +53,9 @@ test("normal root launch creates a current SessionManager for root token logs", 
 // create a fresh session that adopts the pre-allocated id.
 test("lifecycle /session_create bypasses autoResume; normal launch still resumes", async () => {
 	const agentDir = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-lc-autoresume-"));
+	agentDirs.push(agentDir);
 	setAgentDir(agentDir);
+	await ensureBroker({ agentDir });
 	const cwd = path.join(agentDir, "repo");
 	fs.mkdirSync(cwd, { recursive: true });
 
@@ -69,6 +84,4 @@ test("lifecycle /session_create bypasses autoResume; normal launch still resumes
 	// The freshly created SDK session under the same env adopts the pre-allocated id.
 	const fresh = SessionManager.inMemory(cwd);
 	expect(fresh.getSessionId()).toBe("s-prealloc-autoresume-1");
-
-	await fsp.rm(agentDir, { recursive: true, force: true });
 });

--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -7,7 +7,7 @@ import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { TelegramNotificationDaemon } from "../src/sdk/bus/telegram-daemon";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
 import { renderThreadedFrame } from "../src/sdk/bus/threaded-render";
-import { isolatedNotificationSettings } from "./helpers/notification-settings";
+import { isolatedNotificationSettings, stopIsolatedNotificationBroker } from "./helpers/notification-settings";
 
 // ---------------------------------------------------------------------------
 // 1) Pure render contract: streamed turn frames become editable, and live +
@@ -62,6 +62,7 @@ type Handler = (event: unknown, ctx: unknown) => unknown;
 type Frame = { type: string; phase?: string; text?: string; messageRef?: string };
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
 const envKeys = [
 	"GJC_NOTIFICATIONS",
@@ -71,17 +72,14 @@ const envKeys = [
 ] as const;
 let savedEnv: Record<string, string | undefined> = {};
 
-afterEach(() => {
+afterEach(async () => {
 	for (const ws of openSockets.splice(0)) {
 		try {
 			ws.close();
 		} catch {}
 	}
-	for (const dir of tempDirs.splice(0)) {
-		try {
-			fs.rmSync(dir, { recursive: true, force: true });
-		} catch {}
-	}
+	for (const agentDir of agentDirs.splice(0)) await stopIsolatedNotificationBroker(agentDir);
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 	for (const k of envKeys) {
 		if (savedEnv[k] === undefined) delete process.env[k];
 		else process.env[k] = savedEnv[k];
@@ -98,6 +96,8 @@ function setEnv(over: Partial<Record<(typeof envKeys)[number], string>>): void {
 async function bootSession(): Promise<{ handlers: Map<string, Handler>; ctx: unknown; frames: Frame[] }> {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-stream-"));
 	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => handlers.set(event, handler),
@@ -105,7 +105,7 @@ async function bootSession(): Promise<{ handlers: Map<string, Handler>; ctx: unk
 		sendUserMessage: () => {},
 	} as never;
 	createNotificationsExtension(api, {
-		settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+		settings: isolatedNotificationSettings(agentDir),
 	});
 	const sid = `stream-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const ctx = {

--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -7,6 +7,7 @@ import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { TelegramNotificationDaemon } from "../src/sdk/bus/telegram-daemon";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
 import { renderThreadedFrame } from "../src/sdk/bus/threaded-render";
+import { isolatedNotificationSettings } from "./helpers/notification-settings";
 
 // ---------------------------------------------------------------------------
 // 1) Pure render contract: streamed turn frames become editable, and live +
@@ -95,16 +96,17 @@ function setEnv(over: Partial<Record<(typeof envKeys)[number], string>>): void {
 }
 
 async function bootSession(): Promise<{ handlers: Map<string, Handler>; ctx: unknown; frames: Frame[] }> {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-stream-"));
+	tempDirs.push(cwd);
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => handlers.set(event, handler),
 		registerCommand: () => {},
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-stream-"));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+	});
 	const sid = `stream-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const ctx = {
 		cwd,

--- a/packages/coding-agent/test/notifications-postmortem-close.test.ts
+++ b/packages/coding-agent/test/notifications-postmortem-close.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { postmortem } from "@gajae-code/utils";
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
+import { isolatedNotificationSettings } from "./helpers/notification-settings";
 
 /**
  * Regression for "hard terminal close orphans the Telegram topic": a native
@@ -39,6 +40,8 @@ afterEach(() => {
 });
 
 function createHarness(prefix: string) {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => {
@@ -47,10 +50,9 @@ function createHarness(prefix: string) {
 		registerCommand: () => {},
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+	});
 
 	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const sid = `${prefix}${suffix}`;

--- a/packages/coding-agent/test/notifications-postmortem-close.test.ts
+++ b/packages/coding-agent/test/notifications-postmortem-close.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { postmortem } from "@gajae-code/utils";
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
-import { isolatedNotificationSettings } from "./helpers/notification-settings";
+import { isolatedNotificationSettings, stopIsolatedNotificationBroker } from "./helpers/notification-settings";
 
 /**
  * Regression for "hard terminal close orphans the Telegram topic": a native
@@ -32,9 +32,11 @@ type Frame = { type: string; sessionId?: string };
 type CleanupCallback = (reason: postmortem.Reason) => void | Promise<void>;
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
-afterEach(() => {
+afterEach(async () => {
 	for (const ws of openSockets.splice(0)) ws.close();
+	for (const agentDir of agentDirs.splice(0)) await stopIsolatedNotificationBroker(agentDir);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 	vi.restoreAllMocks();
 });
@@ -42,6 +44,8 @@ afterEach(() => {
 function createHarness(prefix: string) {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => {
@@ -51,7 +55,7 @@ function createHarness(prefix: string) {
 		sendUserMessage: () => {},
 	} as never;
 	createNotificationsExtension(api, {
-		settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+		settings: isolatedNotificationSettings(agentDir),
 	});
 
 	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;

--- a/packages/coding-agent/test/notifications-session-switch.test.ts
+++ b/packages/coding-agent/test/notifications-session-switch.test.ts
@@ -14,6 +14,7 @@ import { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
 import { SessionManager } from "../src/session/session-manager";
 import { getAskAnswerSource } from "../src/tools/ask-answer-registry";
+import { isolatedNotificationSettings } from "./helpers/notification-settings";
 
 /**
  * Regression for "the SDK notification transport spawns a new session instead of renaming":
@@ -56,6 +57,8 @@ async function withNotifications<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 function createHarness(prefix: string, initialName: string | undefined = "Original") {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
 	const handlers = new Map<string, Handler>();
 	const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
 	const api = {
@@ -66,10 +69,9 @@ function createHarness(prefix: string, initialName: string | undefined = "Origin
 			commands.set(name, command),
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+	});
 
 	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	let sid = `${prefix}${suffix}`;
@@ -154,7 +156,9 @@ test("session_switch publishes successor SDK authority only after AgentSession r
 		registerCommand: () => {},
 		sendUserMessage: async () => {},
 	} as never;
-	createNotificationsExtension(api);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+	});
 	const ctx = { cwd, sessionManager: currentSessionManager } as never;
 	const predecessorSessionId = currentSessionManager.getSessionId();
 	const predecessorEndpoint = path.join(cwd, ".gjc", "state", "sdk", `${predecessorSessionId}.json`);
@@ -202,13 +206,18 @@ test("turn.prompt preflight rejection returns a correlated failure without an ac
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-prompt-preflight-"));
 	tempDirs.push(cwd);
 	const handlers = new Map<string, Handler>();
-	createNotificationsExtension({
-		on: (event: string, handler: Handler) => handlers.set(event, handler),
-		registerCommand: () => {},
-		sendUserMessage: async () => {
-			throw Object.assign(new Error("submission preflight rejected"), { code: "unavailable" });
+	createNotificationsExtension(
+		{
+			on: (event: string, handler: Handler) => handlers.set(event, handler),
+			registerCommand: () => {},
+			sendUserMessage: async () => {
+				throw Object.assign(new Error("submission preflight rejected"), { code: "unavailable" });
+			},
+		} as never,
+		{
+			settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
 		},
-	} as never);
+	);
 	const sessionId = `preflight-${process.pid}-${Date.now()}`;
 	const ctx = {
 		cwd,
@@ -265,14 +274,21 @@ test("accepted turn.prompt submission failures emit a correlated terminal event"
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-prompt-terminal-failure-"));
 	tempDirs.push(cwd);
 	const handlers = new Map<string, Handler>();
-	createNotificationsExtension({
-		on: (event: string, handler: Handler) => handlers.set(event, handler),
-		registerCommand: () => {},
-		sendUserMessage: (_content: unknown, options: { onPreflightAccepted?: () => void } | undefined) => {
-			options?.onPreflightAccepted?.();
-			return Promise.reject(Object.assign(new Error("submission failed after acceptance"), { code: "unavailable" }));
+	createNotificationsExtension(
+		{
+			on: (event: string, handler: Handler) => handlers.set(event, handler),
+			registerCommand: () => {},
+			sendUserMessage: (_content: unknown, options: { onPreflightAccepted?: () => void } | undefined) => {
+				options?.onPreflightAccepted?.();
+				return Promise.reject(
+					Object.assign(new Error("submission failed after acceptance"), { code: "unavailable" }),
+				);
+			},
+		} as never,
+		{
+			settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
 		},
-	} as never);
+	);
 	const sessionId = `terminal-failure-${process.pid}-${Date.now()}`;
 	const ctx = {
 		cwd,
@@ -338,6 +354,8 @@ test("session_switch rotates SDK authority while preserving topic identity", asy
 	const prevEnv = process.env.GJC_NOTIFICATIONS;
 	process.env.GJC_NOTIFICATIONS = "1";
 	try {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-switch-"));
+		tempDirs.push(cwd);
 		const handlers = new Map<string, Handler>();
 		const api = {
 			on: (event: string, handler: Handler) => {
@@ -346,10 +364,9 @@ test("session_switch rotates SDK authority while preserving topic identity", asy
 			registerCommand: () => {},
 			sendUserMessage: () => {},
 		} as never;
-		createNotificationsExtension(api);
-
-		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-switch-"));
-		tempDirs.push(cwd);
+		createNotificationsExtension(api, {
+			settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+		});
 
 		const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 		let sid = `switch-a-${suffix}`;

--- a/packages/coding-agent/test/notifications-session-switch.test.ts
+++ b/packages/coding-agent/test/notifications-session-switch.test.ts
@@ -14,7 +14,7 @@ import { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
 import { SessionManager } from "../src/session/session-manager";
 import { getAskAnswerSource } from "../src/tools/ask-answer-registry";
-import { isolatedNotificationSettings } from "./helpers/notification-settings";
+import { isolatedNotificationSettings, stopIsolatedNotificationBroker } from "./helpers/notification-settings";
 
 /**
  * Regression for "the SDK notification transport spawns a new session instead of renaming":
@@ -39,9 +39,11 @@ type Handler = (event: unknown, ctx: unknown) => unknown;
 type Frame = { type: string; title?: string; sessionId?: string; state?: string };
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
-afterEach(() => {
+afterEach(async () => {
 	for (const ws of openSockets.splice(0)) ws.close();
+	for (const agentDir of agentDirs.splice(0)) await stopIsolatedNotificationBroker(agentDir);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -59,6 +61,8 @@ async function withNotifications<T>(fn: () => Promise<T>): Promise<T> {
 function createHarness(prefix: string, initialName: string | undefined = "Original") {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
 	const api = {
@@ -70,7 +74,7 @@ function createHarness(prefix: string, initialName: string | undefined = "Origin
 		sendUserMessage: () => {},
 	} as never;
 	createNotificationsExtension(api, {
-		settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+		settings: isolatedNotificationSettings(agentDir),
 	});
 
 	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -149,6 +153,8 @@ test("session_switch publishes successor SDK authority only after AgentSession r
 	const targetSessionId = targetSessionManager.getSessionId();
 	await targetSessionManager.close();
 	if (!targetSessionFile) throw new Error("Expected persisted target session");
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 
 	const handlers = new Map<string, Handler>();
 	const api = {
@@ -157,7 +163,7 @@ test("session_switch publishes successor SDK authority only after AgentSession r
 		sendUserMessage: async () => {},
 	} as never;
 	createNotificationsExtension(api, {
-		settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+		settings: isolatedNotificationSettings(agentDir),
 	});
 	const ctx = { cwd, sessionManager: currentSessionManager } as never;
 	const predecessorSessionId = currentSessionManager.getSessionId();
@@ -205,6 +211,8 @@ test("session_switch publishes successor SDK authority only after AgentSession r
 test("turn.prompt preflight rejection returns a correlated failure without an accepted lifecycle", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-prompt-preflight-"));
 	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	createNotificationsExtension(
 		{
@@ -215,7 +223,7 @@ test("turn.prompt preflight rejection returns a correlated failure without an ac
 			},
 		} as never,
 		{
-			settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+			settings: isolatedNotificationSettings(agentDir),
 		},
 	);
 	const sessionId = `preflight-${process.pid}-${Date.now()}`;
@@ -273,6 +281,8 @@ test("turn.prompt preflight rejection returns a correlated failure without an ac
 test("accepted turn.prompt submission failures emit a correlated terminal event", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-prompt-terminal-failure-"));
 	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	createNotificationsExtension(
 		{
@@ -286,7 +296,7 @@ test("accepted turn.prompt submission failures emit a correlated terminal event"
 			},
 		} as never,
 		{
-			settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+			settings: isolatedNotificationSettings(agentDir),
 		},
 	);
 	const sessionId = `terminal-failure-${process.pid}-${Date.now()}`;
@@ -356,6 +366,8 @@ test("session_switch rotates SDK authority while preserving topic identity", asy
 	try {
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-switch-"));
 		tempDirs.push(cwd);
+		const agentDir = path.join(cwd, ".agent");
+		agentDirs.push(agentDir);
 		const handlers = new Map<string, Handler>();
 		const api = {
 			on: (event: string, handler: Handler) => {
@@ -365,7 +377,7 @@ test("session_switch rotates SDK authority while preserving topic identity", asy
 			sendUserMessage: () => {},
 		} as never;
 		createNotificationsExtension(api, {
-			settings: isolatedNotificationSettings(path.join(cwd, ".agent")),
+			settings: isolatedNotificationSettings(agentDir),
 		});
 
 		const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;

--- a/packages/coding-agent/test/notifications-turn-ordering.test.ts
+++ b/packages/coding-agent/test/notifications-turn-ordering.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { daemonPaths } from "../src/sdk/bus/daemon-paths";
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
-import { isolatedNotificationSettings } from "./helpers/notification-settings";
+import { isolatedNotificationSettings, stopIsolatedNotificationBroker } from "./helpers/notification-settings";
 
 /**
  * Regression for the text-before-ask ordering bug: the assistant text that
@@ -43,9 +43,11 @@ type TestContextUsage = {
 type TestModel = { id?: string };
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
-afterEach(() => {
+afterEach(async () => {
 	for (const ws of openSockets.splice(0)) ws.close();
+	for (const agentDir of agentDirs.splice(0)) await stopIsolatedNotificationBroker(agentDir);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -61,6 +63,7 @@ async function setup(options: { contextUsage?: TestContextUsage | false; model?:
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-order-"));
 	tempDirs.push(cwd);
 	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => {

--- a/packages/coding-agent/test/notifications-turn-ordering.test.ts
+++ b/packages/coding-agent/test/notifications-turn-ordering.test.ts
@@ -2,8 +2,10 @@ import { afterEach, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { daemonPaths } from "../src/sdk/bus/daemon-paths";
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
+import { isolatedNotificationSettings } from "./helpers/notification-settings";
 
 /**
  * Regression for the text-before-ask ordering bug: the assistant text that
@@ -56,6 +58,9 @@ async function setup(options: { contextUsage?: TestContextUsage | false; model?:
 	token: string;
 	sid: string;
 }> {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-order-"));
+	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => {
@@ -64,10 +69,7 @@ async function setup(options: { contextUsage?: TestContextUsage | false; model?:
 		registerCommand: () => {},
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-order-"));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, { settings: isolatedNotificationSettings(agentDir) });
 	const sid = `order-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const ctx = {
 		cwd,
@@ -85,6 +87,7 @@ async function setup(options: { contextUsage?: TestContextUsage | false; model?:
 	} as never;
 
 	await handlers.get("session_start")!({ type: "session_start" }, ctx);
+	expect(fs.existsSync(daemonPaths(agentDir).roots)).toBe(false);
 
 	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sid}.json`);
 	await waitFor(() => fs.existsSync(endpointFile), 4000, "endpoint file");


### PR DESCRIPTION
## Summary

Notification integration tests could fall back to live operator settings. The first revision isolated their settings and harness agent directories, but verification exposed a second lifecycle gap: successful isolated SDK brokers were detached and left running after tests deleted their temp roots.

This test-only patch now:

- gives direct notification extension tests isolated in-memory settings with a temp `getAgentDir()`
- tracks each temp agent directory and awaits `brokerOwnerForTest(agentDir).stop()` before deleting its root
- pre-starts harness brokers in the test parent with the same sanitized subprocess environment, retains the exact owner handle, and awaits its stop during cleanup
- waits for detached harness owners before stopping the parent-owned broker
- guarantees broker cleanup even when earlier owner/tmux teardown fails, aggregates dual cleanup failures, and preserves roots for evidence
- fixes the existing autoresume fixture by pre-starting/stopping its exact broker and restoring the process-global agent directory
- forces harness subprocesses to use a temp agent directory with `GJC_NOTIFICATIONS=0` and removes inherited `GJC_NOTIFICATIONS_TOKEN`

No name-based process killing is used. No production daemon, cleanup, deletion, lease, journal, replay, or broker implementation changes are included.

## Scope

- 11 test/helper files
- no `src/` changes
- no dependencies, schemas, or public API changes

## Verification

Base: `bc8f8f12f8b76c27a07ae5435a791ef3eeacc8bf`
Head: `bcc2eb8628a48e9b3d32141332804fef3f996fb3`

- `bun test packages/coding-agent/test/notifications*.test.ts` — 590 pass, 0 fail
- affected notification + harness matrix — 92 pass, 7 platform skips, 0 fail
- direct notification matrix repeated — 38 pass per run, 0 fail; broker count remained 0
- harness matrix repeated — 54 pass, 7 platform skips per run; broker count remained 0
- final failure-path harness matrix — 28 pass, 7 platform skips, 0 fail; broker count 0
- `bun run --cwd packages/coding-agent check` — pass
- `bun run ci:test:smoke` — pass
- post-test process count for `/private/tmp/gajae-code-test-isolation/... sdk broker-internal` — 0
- notification/autoresume/harness temp-root globs after teardown — empty
- measured operator Telegram roots-registry SHA-256 before/after an affected run — unchanged (`148dcb955dedcd262e6e0190921467b428881ce192c2f8129e395dfaff3320ea`)
- three independent read-only review lanes found no critical/high blockers; the reported cleanup failure-path gap was fixed before this head
