### PR TITLE
fix(lsp): defer language-server startup until first use

### DIFF
--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -82,7 +82,7 @@ export type { LspToolDetails } from "./types";
 
 export interface LspStartupServerInfo {
 	name: string;
-	status: "connecting" | "ready" | "error";
+	status: "idle" | "connecting" | "ready" | "error";
 	fileTypes: string[];
 	error?: string;
 }
@@ -102,7 +102,7 @@ export function discoverStartupLspServers(cwd: string): LspStartupServerInfo[] {
 	const config = loadConfig(cwd);
 	return getLspServers(config).map(([name, serverConfig]) => ({
 		name,
-		status: "connecting",
+		status: "idle",
 		fileTypes: serverConfig.fileTypes,
 	}));
 }

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -10,7 +10,7 @@ export interface RecentSession {
 
 export interface LspServerInfo {
 	name: string;
-	status: "ready" | "error" | "connecting";
+	status: "idle" | "ready" | "error" | "connecting";
 	fileTypes: string[];
 }
 
@@ -172,9 +172,9 @@ export class WelcomeComponent implements Component {
 				const icon =
 					server.status === "ready"
 						? theme.styledSymbol("status.success", "success")
-						: server.status === "connecting"
-							? theme.styledSymbol("status.pending", "muted")
-							: theme.styledSymbol("status.error", "error");
+						: server.status === "error"
+							? theme.styledSymbol("status.error", "error")
+							: theme.styledSymbol("status.pending", "muted");
 				const exts = server.fileTypes.slice(0, 3).join(" ");
 				lspLines.push(` ${icon} ${theme.fg("muted", server.name)} ${theme.fg("dim", exts)}`);
 			}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -450,8 +450,7 @@ export class CommandController {
 		if (this.ctx.lspServers && this.ctx.lspServers.length > 0) {
 			info += `\n${theme.bold("LSP Servers")}\n`;
 			for (const server of this.ctx.lspServers) {
-				const statusColor =
-					server.status === "ready" ? "success" : server.status === "connecting" ? "warning" : "error";
+				const statusColor = server.status === "ready" ? "success" : server.status === "error" ? "error" : "warning";
 				const statusText =
 					server.status === "error" && server.error ? `${server.status}: ${server.error}` : server.status;
 				info += `${theme.fg("dim", `${server.name}:`)} ${theme.fg(statusColor, statusText)} ${theme.fg("dim", `(${server.fileTypes.join(", ")})`)}\n`;

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -88,7 +88,6 @@ import { loadSkills, type Skill, type SkillWarning, setActiveSkills } from "../e
 import type { FileSlashCommand } from "../extensibility/slash-commands";
 import type { HindsightSessionState } from "../hindsight/state";
 import { LocalProtocolHandler, type LocalProtocolOptions } from "../internal-urls";
-import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
 import { resolveMemoryBackend } from "../memory-backend";
 import asyncResultTemplate from "../prompts/tools/async-result.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
@@ -157,7 +156,6 @@ import {
 	type ToolSession,
 	WebSearchTool,
 	WriteTool,
-	warmupLspServers,
 } from "../tools";
 import { ToolContextStore } from "../tools/context";
 import { getImageGenTools } from "../tools/image-gen";
@@ -415,7 +413,7 @@ export interface CreateAgentSessionResult {
 	mcpManager?: MCPManager;
 	/** Warning if session was restored with a different model than saved */
 	modelFallbackMessage?: string;
-	/** LSP servers detected for startup; warmup may continue in the background */
+	/** LSP servers configured for lazy startup in interactive mode */
 	lspServers?: LspStartupServerInfo[];
 	/** Shared event bus for tool/extension communication */
 	eventBus: EventBus;
@@ -2482,47 +2480,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 		}
 
-		// Start LSP warmup in the background so startup does not block on language server initialization.
-		// Print/script invocations (`hasUI=false`) don't render the warmup status indicator AND typically
-		// finish before LSP servers would have stabilized — warming them just spends CPU parsing big
-		// `initialize` responses concurrently with the LLM stream consumer, jittering perceived latency.
-		// Tools that need an LSP server still spin one up on demand through `getOrCreateClient`.
-		let lspServers: CreateAgentSessionResult["lspServers"];
-		if (enableLsp && options.hasUI && settings.get("lsp.diagnosticsOnWrite")) {
-			lspServers = discoverStartupLspServers(cwd);
-			if (lspServers.length > 0) {
-				void (async () => {
-					try {
-						const result = await logger.time("warmupLspServers", warmupLspServers, cwd);
-						const serversByName = new Map(result.servers.map(server => [server.name, server] as const));
-						for (const server of lspServers ?? []) {
-							const next = serversByName.get(server.name);
-							if (!next) continue;
-							server.status = next.status;
-							server.fileTypes = next.fileTypes;
-							server.error = next.error;
-						}
-						const event: LspStartupEvent = {
-							type: "completed",
-							servers: result.servers,
-						};
-						eventBus.emit(LSP_STARTUP_EVENT_CHANNEL, event);
-					} catch (error) {
-						const errorMessage = error instanceof Error ? error.message : String(error);
-						logger.warn("LSP server warmup failed", { cwd, error: errorMessage });
-						for (const server of lspServers ?? []) {
-							server.status = "error";
-							server.error = errorMessage;
-						}
-						const event: LspStartupEvent = {
-							type: "failed",
-							error: errorMessage,
-						};
-						eventBus.emit(LSP_STARTUP_EVENT_CHANNEL, event);
-					}
-				})();
-			}
-		}
+		// Discover configured LSP servers for the interactive status display without starting them.
+		// LSP-backed write operations create clients on demand through `getOrCreateClient`.
+		const lspServers =
+			enableLsp && options.hasUI && settings.get("lsp.diagnosticsOnWrite")
+				? discoverStartupLspServers(cwd)
+				: undefined;
 
 		logger.time("startMemoryStartupTask", () =>
 			Promise.resolve(

--- a/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import * as lsp from "@gajae-code/coding-agent/lsp";
+import { createAgentSession } from "@gajae-code/coding-agent/sdk";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
 import {
 	getLspStartupWarningMessage,
 	LSP_STARTUP_EVENT_CHANNEL,
@@ -19,6 +27,58 @@ describe("InteractiveMode LSP startup events", () => {
 		eventBus.emit(LSP_STARTUP_EVENT_CHANNEL, event);
 
 		expect(received).toEqual([event]);
+	});
+	it("does not warm configured LSP servers when creating an interactive session", async () => {
+		const tempDir = TempDir.createSync("@gjc-lsp-lazy-startup-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const discoverSpy = vi
+			.spyOn(lsp, "discoverStartupLspServers")
+			.mockReturnValue([{ name: "rust-analyzer", status: "idle", fileTypes: [".rs"] }]);
+		const warmupSpy = vi.spyOn(lsp, "warmupLspServers");
+		try {
+			const { session, lspServers } = await createAgentSession({
+				cwd: tempDir.path(),
+				agentDir: tempDir.path(),
+				authStorage,
+				modelRegistry: new ModelRegistry(authStorage),
+				settings: Settings.isolated({
+					"async.enabled": false,
+					"bash.autoBackground.enabled": false,
+					"lsp.diagnosticsOnWrite": true,
+				}),
+				disableExtensionDiscovery: true,
+				extensions: [],
+				toolNames: [],
+				workspaceTree: {
+					rootPath: tempDir.path(),
+					rendered: "",
+					truncated: false,
+					totalLines: 0,
+					agentsMdFiles: [],
+				},
+				skills: [],
+				rules: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: true,
+				hasUI: true,
+				skipPythonPreflight: true,
+				sessionManager: SessionManager.inMemory(tempDir.path()),
+				parentTaskPrefix: "test",
+			});
+
+			expect(discoverSpy).toHaveBeenCalledWith(tempDir.path());
+			expect(lspServers).toEqual([{ name: "rust-analyzer", status: "idle", fileTypes: [".rs"] }]);
+			expect(warmupSpy).not.toHaveBeenCalled();
+
+			await session.dispose();
+		} finally {
+			vi.restoreAllMocks();
+			authStorage.close();
+			tempDir.removeSync();
+		}
 	});
 	it("does not warn for optional rust-analyzer startup failures", () => {
 		const event: LspStartupEvent = {

--- a/packages/coding-agent/test/lsp-lifecycle-cleanup.test.ts
+++ b/packages/coding-agent/test/lsp-lifecycle-cleanup.test.ts
@@ -1,10 +1,44 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { type ptree, TempDir } from "@gajae-code/utils";
+import { createLspWritethrough } from "../src/lsp";
+import * as lspClient from "../src/lsp/client";
 import { getActiveClients, isIdleCheckerActiveForTests, setIdleTimeout, shutdownAll } from "../src/lsp/client";
+import * as lspConfig from "../src/lsp/config";
 import DEFAULT_LSP_SERVERS from "../src/lsp/defaults.json" with { type: "json" };
+import type { LspClient, ServerConfig } from "../src/lsp/types";
+
+const TEST_SERVER: ServerConfig = {
+	command: "test-lsp",
+	fileTypes: ["ts"],
+	rootMarkers: [],
+};
+
+function createClient(cwd: string): LspClient {
+	return {
+		name: "test-lsp",
+		cwd,
+		config: TEST_SERVER,
+		proc: {} as ptree.ChildProcess<"pipe">,
+		requestId: 0,
+		diagnostics: new Map(),
+		diagnosticsVersion: 0,
+		openFiles: new Map(),
+		pendingRequests: new Map(),
+		messageBuffer: new Uint8Array(),
+		isReading: false,
+		lastActivity: Date.now(),
+		writeQueue: Promise.resolve(),
+		activeProgressTokens: new Set(),
+		projectLoaded: Promise.resolve(),
+		resolveProjectLoaded: () => {},
+	};
+}
 
 describe("LSP lifecycle cleanup", () => {
 	afterEach(async () => {
 		await shutdownAll();
+		vi.restoreAllMocks();
 	});
 
 	it("shutdownAll stops the idle checker when no clients remain", async () => {
@@ -17,6 +51,29 @@ describe("LSP lifecycle cleanup", () => {
 		expect(isIdleCheckerActiveForTests()).toBe(false);
 	});
 
+	it("starts an LSP client lazily on the first LSP-backed write", async () => {
+		const tempDir = TempDir.createSync("@gjc-lsp-lazy-write-");
+		try {
+			const filePath = path.join(tempDir.path(), "example.ts");
+			const client = createClient(tempDir.path());
+			const getClientSpy = vi.spyOn(lspClient, "getOrCreateClient").mockResolvedValue(client);
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({ servers: {}, idleTimeoutMs: undefined });
+			vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["test-lsp", TEST_SERVER]]);
+			vi.spyOn(lspClient, "syncContent").mockResolvedValue();
+			vi.spyOn(lspClient, "notifySaved").mockResolvedValue();
+
+			const writethrough = createLspWritethrough(tempDir.path(), {
+				enableFormat: false,
+				enableDiagnostics: true,
+			});
+			await writethrough(filePath, "export const value = 1;\n");
+
+			expect(getClientSpy).toHaveBeenCalledWith(TEST_SERVER, tempDir.path());
+			expect(await Bun.file(filePath).text()).toBe("export const value = 1;\n");
+		} finally {
+			tempDir.removeSync();
+		}
+	});
 	it("gives rust-analyzer a longer startup warmup window than the generic LSP default", () => {
 		expect(DEFAULT_LSP_SERVERS["rust-analyzer"].warmupTimeoutMs).toBeGreaterThan(5000);
 	});


### PR DESCRIPTION
Stops eager interactive LSP warmup. Server discovery remains visible and existing write-through creates clients lazily on first LSP-backed write. This prevents rust-analyzer/cargo/rustc from multiplying across idle team workers. Focused startup and first-write tests plus coding-agent check passed on Windows.