### PR TITLE
fix(psmux): add explicit compatibility lifecycle and artifact authority

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -7,7 +7,10 @@ import { safeStderrWrite } from "@gajae-code/utils/safe-stderr";
 import type { Args } from "../cli/args";
 import { tmuxRuntimeSessionPath } from "./session-layout";
 import {
+	GJC_COORDINATOR_SESSION_BRANCH_ENV,
 	GJC_COORDINATOR_SESSION_ID_ENV,
+	GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV,
+	GJC_COORDINATOR_SESSION_READINESS_FILE_ENV,
 	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
 	GJC_TMUX_OWNER_GENERATION_ENV,
 	GJC_TMUX_OWNER_SERVER_KEY_ENV,
@@ -170,6 +173,108 @@ function allowsExistingTmuxAttach(parsed: Args, env: NodeJS.ProcessEnv): boolean
 	// value-less resume can show the session picker and valued resume can honor the target.
 	return Boolean(parsed.continue || explicitTmuxSessionName(env));
 }
+type WindowsPsmuxCompatibilityState = "fresh" | "continuation" | "managed";
+
+function windowsPsmuxCompatibilityState(plan: TmuxLaunchPlan, env: NodeJS.ProcessEnv): WindowsPsmuxCompatibilityState {
+	const marker = (value: string | undefined): boolean => Boolean(value?.trim());
+	if (
+		marker(env.GJC_SESSION_ID) ||
+		marker(env[GJC_COORDINATOR_SESSION_ID_ENV]) ||
+		marker(env[GJC_COORDINATOR_SESSION_BRANCH_ENV]) ||
+		marker(env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV]) ||
+		marker(env[GJC_COORDINATOR_SESSION_READINESS_FILE_ENV]) ||
+		marker(env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]) ||
+		marker(env[GJC_TMUX_ACTIVE_SESSION_ENV]) ||
+		marker(env[GJC_TMUX_OWNER_GENERATION_ENV]) ||
+		marker(env[GJC_TMUX_OWNER_STATE_DIR_ENV]) ||
+		marker(env[GJC_TMUX_OWNER_SERVER_KEY_ENV]) ||
+		Object.entries(env).some(([key, value]) => key.startsWith("GJC_TEAM_") && marker(value))
+	)
+		return "managed";
+	return plan.attachSessionName ? "continuation" : "fresh";
+}
+
+type PsmuxSessionInventory =
+	| { kind: "available"; names: ReadonlySet<string> }
+	| { kind: "no-server" }
+	| { kind: "unverifiable"; result: TmuxSpawnResult };
+
+function classifyPsmuxSessionInventory(result: TmuxSpawnResult): PsmuxSessionInventory {
+	if (result.exitCode === 0) {
+		const names = new Set(
+			(result.stdout ?? "")
+				.split(/\r?\n/)
+				.map(name => name.trim())
+				.filter(Boolean),
+		);
+		return { kind: "available", names };
+	}
+	const stderr = result.stderr?.trim() ?? "";
+	if (/\bno server running\b/i.test(stderr)) return { kind: "no-server" };
+	return { kind: "unverifiable", result };
+}
+
+function launchWindowsPsmuxCompatibilitySession(
+	plan: TmuxLaunchPlan,
+	env: NodeJS.ProcessEnv,
+	spawnSync: TmuxSpawnSync,
+	diagnostic: (message: string) => void,
+): boolean {
+	const options: TmuxSpawnOptions = {
+		cwd: plan.cwd,
+		env,
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+		captureStderr: true,
+	};
+	const attachOptions: TmuxSpawnOptions = { ...options, stdin: "inherit", stdout: "inherit", stderr: "inherit" };
+	const state = windowsPsmuxCompatibilityState(plan, env);
+	if (state === "managed") {
+		diagnostic("psmux cannot provide immutable owner identity; refusing managed session creation.\n");
+		throw new Error("gjc_tmux_owner_isolation_native_session_identity_unavailable");
+	}
+
+	const targetName = plan.attachSessionName ?? plan.sessionName;
+	const inventory = (): PsmuxSessionInventory =>
+		classifyPsmuxSessionInventory(spawnSync(plan.tmuxCommand, ["list-sessions", "-F", "#{session_name}"], options));
+
+	if (state === "continuation") {
+		const existing = inventory();
+		const detail = existing.kind === "unverifiable" ? existing.result.stderr : undefined;
+		diagnostic(
+			formatTmuxLaunchDiagnostic(
+				existing.kind === "available" && existing.names.has(targetName)
+					? "existing psmux session is name-only and cannot be attached safely"
+					: "existing session target not found",
+				detail,
+			),
+		);
+		return true;
+	}
+
+	const before = inventory();
+	if (before.kind === "unverifiable") {
+		diagnostic(formatTmuxLaunchDiagnostic("fresh session inventory failed", before.result.stderr));
+		return true;
+	}
+	if (before.kind === "available" && before.names.has(targetName)) {
+		diagnostic("tmux fresh session target already exists; preserving session without mutation.\n");
+		return true;
+	}
+	const detachedIndex = plan.newSessionArgs.indexOf("-d");
+	const foregroundArgs =
+		detachedIndex < 0
+			? plan.newSessionArgs
+			: [...plan.newSessionArgs.slice(0, detachedIndex), ...plan.newSessionArgs.slice(detachedIndex + 1)];
+	const created = spawnSync(plan.tmuxCommand, foregroundArgs, attachOptions);
+	if (created.exitCode !== 0) {
+		const wrapperWarning = detectCorruptedGjcWrapper();
+		const suffix = wrapperWarning ? ` Wrapper warning: ${wrapperWarning}` : "";
+		diagnostic(formatTmuxLaunchDiagnostic("foreground new-session failed", created.stderr) + suffix);
+	}
+	return true;
+}
 
 function findExistingSessionForLaunch(context: {
 	env: NodeJS.ProcessEnv;
@@ -251,7 +356,13 @@ function isInteractiveRootLaunch(parsed: Args, tty: TtyState): boolean {
 }
 
 function isBunVirtualPath(value: string | undefined): boolean {
-	return value?.startsWith("/$bunfs/") === true;
+	const normalized = value?.trim().replace(/\\/g, "/").toLowerCase();
+	return (
+		normalized === "/$bunfs" ||
+		normalized?.startsWith("/$bunfs/") === true ||
+		normalized === "b:/~bun" ||
+		normalized?.startsWith("b:/~bun/") === true
+	);
 }
 
 const MAX_TMUX_DIAGNOSTIC_DETAIL_CODE_POINTS = 240;
@@ -389,19 +500,41 @@ export function applyGjcTmuxProfile(context: GjcTmuxProfileContext): GjcTmuxProf
 }
 
 function resolveCurrentGjcCommand(context: CommandResolutionContext): string[] {
-	const entrypoint = context.argv[1];
-	if (!entrypoint) return ["gjc"];
-	if (isBunVirtualPath(entrypoint)) {
-		return isBunVirtualPath(context.execPath) ? ["gjc"] : [context.execPath];
-	}
 	const pathModule = pathModuleForPlatform(context.platform);
-	const resolvedEntrypoint = pathModule.isAbsolute(entrypoint)
-		? entrypoint
-		: pathModule.resolve(context.cwd, entrypoint);
-	if (entrypoint.endsWith(".ts") || entrypoint.endsWith(".js") || entrypoint.endsWith(".mjs")) {
-		return [context.execPath, resolvedEntrypoint];
+	const isRealAbsolutePath = (value: string | undefined): value is string => {
+		const normalized = value?.trim();
+		if (!normalized || isBunVirtualPath(normalized)) return false;
+		return pathModule.isAbsolute(normalized) || path.isAbsolute(normalized);
+	};
+	const isGjcExecutable = (value: string | undefined): value is string =>
+		isRealAbsolutePath(value) && /^gjc(?:[._-]|$)/i.test(pathModule.basename(value.trim()));
+
+	const runtime = context.argv[0]?.trim();
+	const entrypoint = context.argv[1]?.trim();
+	if (entrypoint && !isBunVirtualPath(entrypoint) && /\.(?:[cm]?[jt]s)$/i.test(entrypoint)) {
+		const executable = isRealAbsolutePath(runtime)
+			? runtime
+			: isRealAbsolutePath(context.execPath)
+				? context.execPath.trim()
+				: undefined;
+		if (!executable)
+			throw new Error(
+				"Unable to determine the current GJC source runtime for tmux launch; invoke GJC through an absolute runtime path.",
+			);
+		const resolvedEntrypoint = pathModule.isAbsolute(entrypoint)
+			? entrypoint
+			: pathModule.resolve(context.cwd, entrypoint);
+		return [executable, resolvedEntrypoint];
 	}
-	return [resolvedEntrypoint];
+
+	const executable =
+		(isGjcExecutable(entrypoint) ? entrypoint : undefined) ??
+		(isGjcExecutable(runtime) ? runtime : undefined) ??
+		(isGjcExecutable(context.execPath) ? context.execPath.trim() : undefined);
+	if (executable) return [executable];
+	throw new Error(
+		"Unable to determine the current GJC executable for tmux launch; Bun virtual paths and PATH fallback are not accepted.",
+	);
 }
 function isWindowsPlatform(platform: NodeJS.Platform | undefined): boolean {
 	return platform === "win32";
@@ -1129,12 +1262,17 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 	// window rename and provider refusal so inapplicable root launches reach main
 	// unchanged, while unsupported managed launches fail before any tmux mutation.
 	const plan = buildDefaultTmuxLaunchPlan(context);
-	if (plan?.isPsmux) {
-		(context.diagnosticWriter ?? safeStderrWrite)(
-			"psmux cannot provide immutable owner identity; refusing managed session creation.\n",
-		);
-		throw new Error("gjc_tmux_owner_isolation_native_session_identity_unavailable");
+	if (!plan && env.TMUX && (context.platform ?? process.platform) === "win32") {
+		const ambientProvider = resolveGjcTmuxBinary({ platform: "win32", env });
+		if (ambientProvider.isPsmux) return false;
 	}
+	if (plan?.isPsmux && plan.platform === "win32" && !env.TMUX)
+		return launchWindowsPsmuxCompatibilitySession(
+			plan,
+			env,
+			context.spawnSync ?? defaultSpawnSync,
+			context.diagnosticWriter ?? safeStderrWrite,
+		);
 	// Direct launches inside an ambient tmux session retain their existing title
 	// behavior, but only after managed-launch applicability was ruled out.
 	renameExistingTmuxWindowIfNeeded(context);
@@ -1172,14 +1310,6 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		context.ownerIsolationProbe ?? defaultOwnerIsolationProbe(plan, env, rawSpawnSync, context.callerCgroupReader);
 	const spawnSync = rawSpawnSync;
 	const attachOptions: TmuxSpawnOptions = { ...options };
-	// Psmux is rejected before planning any tmux mutation, including an ambient
-	// TMUX window rename. Keep this defense in depth guard for future plan seams.
-	if (plan.isPsmux) {
-		(context.diagnosticWriter ?? safeStderrWrite)(
-			"psmux cannot provide immutable owner identity; refusing managed session creation.\n",
-		);
-		throw new Error("gjc_tmux_owner_isolation_native_session_identity_unavailable");
-	}
 	const controlOptions: TmuxSpawnOptions = {
 		...options,
 		stdin: "pipe",

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1995,25 +1995,32 @@ function readCurrentTmuxLeaderContext(tmuxCommand: string, env: NodeJS.ProcessEn
 	}
 	return { sessionName, windowIndex, leaderPaneId, target: `${sessionName}:${windowIndex}` };
 }
-type CommandPathResolver = (command: string) => string | null;
-
 function isBunVirtualPath(candidate: string | undefined): boolean {
-	const normalized = candidate?.trim().replace(/\\/g, "/");
-	return normalized === "/$bunfs" || normalized?.startsWith("/$bunfs/") === true;
+	const normalized = candidate?.trim().replace(/\\/g, "/").toLowerCase();
+	return (
+		normalized === "/$bunfs" ||
+		normalized?.startsWith("/$bunfs/") === true ||
+		normalized === "b:/~bun" ||
+		normalized?.startsWith("b:/~bun/") === true
+	);
 }
 
-function resolveFallbackGjcWorkerCommand(
-	platform: NodeJS.Platform,
-	execPath: string,
-	which: CommandPathResolver,
-): string {
-	const pathModule = platform === "win32" ? path.win32 : path;
-	const quote = platform === "win32" ? powershellQuote : shellQuote;
-	const executable = execPath.trim();
-	if (executable && !isBunVirtualPath(executable) && pathModule.isAbsolute(executable)) return quote(executable);
-	const gjcPath = which("gjc")?.trim();
-	if (gjcPath && !isBunVirtualPath(gjcPath)) return quote(gjcPath);
-	return "gjc";
+function isAbsoluteRealPath(candidate: string | undefined, pathModule: typeof path): candidate is string {
+	const normalized = candidate?.trim();
+	return Boolean(normalized && !isBunVirtualPath(normalized) && pathModule.isAbsolute(normalized));
+}
+function isGjcExecutablePath(candidate: string | undefined, pathModule: typeof path): candidate is string {
+	return isAbsoluteRealPath(candidate, pathModule) && /^gjc(?:[._-]|$)/i.test(pathModule.basename(candidate.trim()));
+}
+
+function formatWorkerExecutable(platform: NodeJS.Platform, executable: string): string {
+	return (platform === "win32" ? powershellQuote : shellQuote)(executable);
+}
+
+function unresolvedWorkerAuthorityError(): Error {
+	return new Error(
+		"Unable to determine the GJC worker executable from this invocation. Set GJC_TEAM_WORKER_COMMAND to the exact GJC command, or launch GJC from a real executable path instead of a Bun virtual path.",
+	);
 }
 
 export function resolveGjcWorkerCommand(
@@ -2022,24 +2029,36 @@ export function resolveGjcWorkerCommand(
 	platform: NodeJS.Platform = process.platform,
 	argv: string[] = process.argv,
 	execPath = process.execPath,
-	which: CommandPathResolver = Bun.which,
 ): string {
 	const explicit = env.GJC_TEAM_WORKER_COMMAND?.trim();
-	if (explicit) return explicit;
-	const entrypoint = argv[1];
-	if (isBunVirtualPath(entrypoint)) return resolveFallbackGjcWorkerCommand(platform, execPath, which);
-	if (!entrypoint) return "gjc";
-	const pathModule = platform === "win32" ? path.win32 : path;
-	const resolvedEntrypoint = pathModule.isAbsolute(entrypoint) ? entrypoint : pathModule.resolve(cwd, entrypoint);
-	if (platform === "win32") {
-		if (entrypoint.endsWith(".ts") || entrypoint.endsWith(".js") || entrypoint.endsWith(".mjs"))
-			return `${powershellQuote(execPath)} ${powershellQuote(resolvedEntrypoint)}`;
-		if (pathModule.basename(entrypoint).startsWith("gjc")) return powershellQuote(resolvedEntrypoint);
-		return "gjc";
+	if (explicit) {
+		if (isBunVirtualPath(explicit)) throw unresolvedWorkerAuthorityError();
+		return explicit;
 	}
-	if (entrypoint.endsWith(".ts")) return `${shellQuote(execPath)} ${shellQuote(resolvedEntrypoint)}`;
-	if (path.basename(entrypoint).startsWith("gjc")) return shellQuote(path.resolve(cwd, entrypoint));
-	return "gjc";
+
+	const pathModule = platform === "win32" ? path.win32 : path.posix;
+	const runtime = argv[0]?.trim();
+	const entrypoint = argv[1]?.trim();
+	const sourceEntrypoint = entrypoint && !isBunVirtualPath(entrypoint) && /\.(?:[cm]?[jt]s)$/i.test(entrypoint);
+
+	if (sourceEntrypoint) {
+		const sourceRuntime = isAbsoluteRealPath(runtime, pathModule)
+			? runtime
+			: isAbsoluteRealPath(execPath, pathModule)
+				? execPath.trim()
+				: undefined;
+		if (!sourceRuntime) throw unresolvedWorkerAuthorityError();
+		const absoluteEntrypoint = pathModule.isAbsolute(entrypoint) ? entrypoint : pathModule.resolve(cwd, entrypoint);
+		if (!isAbsoluteRealPath(absoluteEntrypoint, pathModule)) throw unresolvedWorkerAuthorityError();
+		return `${formatWorkerExecutable(platform, sourceRuntime)} ${formatWorkerExecutable(platform, absoluteEntrypoint)}`;
+	}
+
+	const executable =
+		(isGjcExecutablePath(entrypoint, pathModule) ? entrypoint : undefined) ??
+		(isGjcExecutablePath(execPath, pathModule) ? execPath.trim() : undefined) ??
+		(isGjcExecutablePath(runtime, pathModule) ? runtime : undefined);
+	if (!executable) throw unresolvedWorkerAuthorityError();
+	return formatWorkerExecutable(platform, executable);
 }
 /** @internal Exported for unit tests. */
 export function buildWorkerCommand(

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -488,14 +488,16 @@ describe("default GJC tmux launch", () => {
 	it("POSIX tmux inner wrapper writes a public-safe exit marker and preserves exit status", () => {
 		if (process.platform === "win32") return;
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-tmux-exit-marker-"));
+		const entrypoint = path.join(cwd, "exit.js");
+		fs.writeFileSync(entrypoint, "process.exit(7);\n");
 		try {
 			const plan = buildDefaultTmuxLaunchPlan({
 				parsed: args({ messages: ["-c", "exit 7"], tmux: true }),
 				rawArgs: ["--tmux", "-c", "exit 7"],
 				cwd,
 				env: {},
-				argv: ["bun", "/bin/sh"],
-				execPath: "/bin/bun",
+				argv: [process.execPath, entrypoint],
+				execPath: process.execPath,
 				platform: "linux",
 				tty: interactiveTty,
 				tmuxAvailable: true,
@@ -674,12 +676,12 @@ describe("default GJC tmux launch", () => {
 		expect(calls[setWindowSizeIndex]?.args).toEqual(["set-window-option", "-t", "$0:", "window-size", "latest"]);
 	});
 
-	it("refuses psmux before creating, resizing, or attaching a session", () => {
+	it("creates exactly one foreground unmanaged psmux session", () => {
 		__setBinaryResolverForTests(candidate => (candidate === "psmux" ? "/fake/psmux" : null));
-		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
+		const calls: string[][] = [];
 		try {
-			expect(() =>
-				launchDefaultTmuxIfNeeded({
+			expect(
+				launchDefaultTmuxIfNeededRaw({
 					parsed: args({ messages: ["hello world"], tmux: true }),
 					rawArgs: ["--tmux", "hello world"],
 					cwd: "/repo",
@@ -691,18 +693,130 @@ describe("default GJC tmux launch", () => {
 					tmuxAvailable: true,
 					currentBranch: "feature/demo",
 					existingBranchSessionName: null,
-					spawnSync: (command, spawnArgs, options) => {
-						calls.push({ command, args: spawnArgs, options });
-						return { exitCode: 0, stdout: "" };
+					spawnSync: (_command, spawnArgs) => {
+						calls.push(spawnArgs);
+						if (spawnArgs[0] !== "list-sessions") return { exitCode: 0 };
+						if (calls.filter(call => call[0] === "list-sessions").length === 1)
+							return { exitCode: 1, stderr: "no server running" };
+						const created = calls.find(call => call[0] === "new-session")!;
+						return { exitCode: 0, stdout: `${created[created.indexOf("-s") + 1]}\n` };
+					},
+				}),
+			).toBe(true);
+			const newSession = calls[1] ?? [];
+			const sessionName = newSession[newSession.indexOf("-s") + 1];
+			expect(calls.map(call => call[0])).toEqual(["list-sessions", "new-session"]);
+			expect(calls[0]).toEqual(["list-sessions", "-F", "#{session_name}"]);
+			expect(sessionName).toBeDefined();
+			expect(newSession).not.toContain("-d");
+			expect(calls.some(call => ["set-option", "kill-session", "resize-window"].includes(call[0]!))).toBe(false);
+		} finally {
+			__setBinaryResolverForTests(null);
+		}
+	});
+
+	it.each([
+		"GJC_COORDINATOR_SESSION_BRANCH",
+		"GJC_COORDINATOR_SESSION_LAUNCH_ID",
+		"GJC_COORDINATOR_SESSION_READINESS_FILE",
+	])("refuses psmux before mutation when %s is the only lifecycle marker", markerName => {
+		__setBinaryResolverForTests(candidate => (candidate === "psmux" ? "/fake/psmux" : null));
+		const calls: string[][] = [];
+		try {
+			expect(() =>
+				launchDefaultTmuxIfNeededRaw({
+					parsed: args({ tmux: true }),
+					rawArgs: ["--tmux"],
+					cwd: "/repo",
+					env: {
+						GJC_TMUX_COMMAND: "psmux",
+						GJC_PSMUX_COMMAND: "psmux",
+						[markerName]: " marker ",
+					},
+					argv: ["bun", "cli.ts"],
+					execPath: "/bin/bun",
+					platform: "win32",
+					tty: interactiveTty,
+					tmuxAvailable: true,
+					currentBranch: "",
+					spawnSync: (_command, spawnArgs) => {
+						calls.push(spawnArgs);
+						return { exitCode: 0 };
 					},
 				}),
 			).toThrow("gjc_tmux_owner_isolation_native_session_identity_unavailable");
-			expect(calls.filter(call => call.args[0] === "new-session")).toHaveLength(0);
-			expect(
-				calls.some(call =>
-					["resize-window", "attach-session", "set-option", "kill-session"].includes(call.args[0]),
-				),
-			).toBe(false);
+			expect(calls).toEqual([]);
+		} finally {
+			__setBinaryResolverForTests(null);
+		}
+	});
+
+	it("refuses name-only explicit psmux continuation without creating or attaching", () => {
+		__setBinaryResolverForTests(candidate => (candidate === "psmux" ? "/fake/psmux" : null));
+		const calls: string[][] = [];
+		const diagnostics: string[] = [];
+		try {
+			launchDefaultTmuxIfNeededRaw({
+				parsed: args({ messages: ["hello"], tmux: true }),
+				rawArgs: ["--tmux", "hello"],
+				cwd: "/repo",
+				env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux", GJC_TMUX_SESSION: "continued" },
+				argv: ["bun", "cli.ts"],
+				execPath: "/bin/bun",
+				platform: "win32",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				existingBranchSessionName: "continued",
+				spawnSync: (_command, spawnArgs) => {
+					calls.push(spawnArgs);
+					return spawnArgs[0] === "list-sessions"
+						? { exitCode: 0, stdout: "continued\ncontinuation-decoy\n" }
+						: { exitCode: 0 };
+				},
+				diagnosticWriter: message => diagnostics.push(message),
+			});
+			expect(calls).toEqual([["list-sessions", "-F", "#{session_name}"]]);
+			expect(diagnostics.join("\n")).toContain("name-only and cannot be attached safely");
+		} finally {
+			__setBinaryResolverForTests(null);
+		}
+	});
+
+	it("preserves an unmanaged psmux session when foreground creation fails", () => {
+		const results = [
+			{ exitCode: 1, stderr: "no server running" },
+			{ exitCode: 1, stderr: "create failed" },
+		];
+		const expectedCreates = 1;
+		__setBinaryResolverForTests(candidate => (candidate === "psmux" ? "/fake/psmux" : null));
+		const calls: string[][] = [];
+		const diagnostics: string[] = [];
+		try {
+			launchDefaultTmuxIfNeededRaw({
+				parsed: args({ tmux: true }),
+				rawArgs: ["--tmux"],
+				cwd: "/repo",
+				env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" },
+				argv: ["bun", "cli.ts"],
+				execPath: "/bin/bun",
+				platform: "win32",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				currentBranch: "",
+				spawnSync: (_command, spawnArgs) => {
+					calls.push(spawnArgs);
+					const result = results.shift()!;
+					if (spawnArgs[0] !== "list-sessions" || result.exitCode !== 0 || ("stdout" in result && result.stdout))
+						return result;
+					const created = calls.find(call => call[0] === "new-session");
+					const sessionName = created?.[created.indexOf("-s") + 1] ?? "continued";
+					return { ...result, stdout: `${sessionName}\n` };
+				},
+				diagnosticWriter: message => diagnostics.push(message),
+			});
+			expect(calls.filter(call => call[0] === "new-session")).toHaveLength(expectedCreates);
+			expect(calls.some(call => ["set-option", "kill-session", "resize-window"].includes(call[0]!))).toBe(false);
+			expect(diagnostics).toHaveLength(1);
 		} finally {
 			__setBinaryResolverForTests(null);
 		}
@@ -791,23 +905,40 @@ describe("default GJC tmux launch", () => {
 		expect(plan.innerCommand).toContain("'/home/me/.local/bin/gjc' 'hello world'");
 	});
 
-	it("falls back to gjc when compiled Bun virtual entrypoint has no host exec path", () => {
-		const plan = buildDefaultTmuxLaunchPlan({
-			parsed: args({ messages: ["hello world"], tmux: true }),
-			rawArgs: ["--tmux"],
-			cwd: "/repo",
-			env: {},
-			argv: ["gjc", "/$bunfs/root/gjc-linux-x64"],
-			execPath: "/$bunfs/root/gjc-linux-x64",
-			platform: "darwin",
-			tty: interactiveTty,
-			tmuxAvailable: true,
-			currentBranch: "",
-			existingBranchSessionName: null,
-		});
+	it("fails closed when a compiled Bun virtual entrypoint has no same-artifact host path", () => {
+		expect(() =>
+			buildDefaultTmuxLaunchPlan({
+				parsed: args({ messages: ["hello world"], tmux: true }),
+				rawArgs: ["--tmux"],
+				cwd: "/repo",
+				env: {},
+				argv: ["gjc", "/$bunfs/root/gjc-linux-x64"],
+				execPath: "/$bunfs/root/gjc-linux-x64",
+				platform: "darwin",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				currentBranch: "",
+				existingBranchSessionName: null,
+			}),
+		).toThrow("Bun virtual paths and PATH fallback are not accepted");
+	});
 
-		expect(plan?.innerCommand).not.toContain("$bunfs");
-		expect(plan?.innerCommand).toContain("'gjc'");
+	it("fails closed for Windows Bun virtual executable paths", () => {
+		expect(() =>
+			buildDefaultTmuxLaunchPlan({
+				parsed: args({ messages: ["hello world"], tmux: true }),
+				rawArgs: ["--tmux", "hello world"],
+				cwd: "C:\\repo",
+				env: {},
+				argv: ["B:\\~BUN\\bun.exe", "B:\\~BUN\\root\\gjc-windows-x64.exe"],
+				execPath: "B:\\~BUN\\root\\gjc-windows-x64.exe",
+				platform: "win32",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				currentBranch: "",
+				existingBranchSessionName: null,
+			}),
+		).toThrow("Bun virtual paths and PATH fallback are not accepted");
 	});
 
 	it("does not implicitly attach existing tagged session for plain worktree branch launch", () => {
@@ -2036,11 +2167,11 @@ it("captures psmux stderr in the attach-failed diagnostic", () => {
 	// emits the captured text so future regressions in the same lane are
 	// diagnosable from the test surface alone.
 	const diagnostics: string[] = [];
-	const handled = launchDefaultTmuxIfNeeded({
+	const handled = launchDefaultTmuxIfNeededRaw({
 		parsed: args({ messages: ["hello world"], tmux: true }),
 		rawArgs: ["--tmux", "hello world"],
 		cwd: "/repo",
-		env: {},
+		env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" },
 		argv: ["bun", "packages/coding-agent/src/cli.ts"],
 		execPath: "/bin/bun",
 		platform: "win32",
@@ -2093,11 +2224,11 @@ it("surfaces a wrapper-corruption warning in the new-session diagnostic on Windo
 	process.env.PATH = dir + path.delimiter + (originalPath ?? "");
 	try {
 		const diagnostics: string[] = [];
-		launchDefaultTmuxIfNeeded({
+		launchDefaultTmuxIfNeededRaw({
 			parsed: args({ messages: ["hello world"], tmux: true }),
 			rawArgs: ["--tmux", "hello world"],
 			cwd: "/repo",
-			env: {},
+			env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" },
 			argv: ["bun", "packages/coding-agent/src/cli.ts"],
 			execPath: "/bin/bun",
 			platform: "win32",

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -3148,94 +3148,77 @@ describe("buildWorkerCommand prompt normalization", () => {
 	});
 });
 
-describe("resolveGjcWorkerCommand bun prefix for script entrypoints", () => {
-	const origArgv = process.argv;
-	afterEach(() => {
-		process.argv = origArgv;
+describe("resolveGjcWorkerCommand invocation authority", () => {
+	it("reuses a real standalone executable from the invocation on POSIX and Windows", () => {
+		expect(
+			resolveGjcWorkerCommand("/repo", {}, "linux", ["/opt/gjc/gjc", "/$bunfs/root/gjc-linux-x64"], "/$bunfs/exec"),
+		).toBe("'/opt/gjc/gjc'");
+		expect(
+			resolveGjcWorkerCommand(
+				"C:\\repo",
+				{},
+				"win32",
+				["B:\\~BUN\\bun.exe", "\\$bunfs\\root\\gjc-windows-x64.exe"],
+				"C:\\Program Files\\GJC\\gjc.exe",
+			),
+		).toBe("'C:\\Program Files\\GJC\\gjc.exe'");
 	});
 
-	it("prepends the bun runtime when argv[1] ends in .js", async () => {
-		process.argv = ["C:\\Users\\withfox\\.bun\\bin\\bun.exe", "C:\\repo\\packages\\coding-agent\\bin\\gjc.js"];
-		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
-		// Pass win32 + a Windows-shaped execPath explicitly: the bun-prefix
-		// invariant is Windows-only — on POSIX a bare `node bin/gjc.js` works
-		// because node IS the script interpreter, so the prefix would be
-		// redundant noise. The execPath override keeps the test assertion
-		// stable across POSIX runners (which have a bare `bun`, no `.exe`).
-		const out = resolveGjcWorkerCommand(
-			"C:\\repo",
-			process.env,
-			"win32",
-			process.argv,
-			"C:\\Users\\withfox\\.bun\\bin\\bun.exe",
-		);
-		// Result must reference bun.exe AND the original .js path; without
-		// the bun prefix, Windows would dispatch the .js file through the
-		// .js file association (cscript.exe), which fails immediately with
-		// a Windows Script Host JScript error dialog.
-		expect(out).toContain("bun.exe");
-		expect(out).toContain("bin\\gjc.js");
-		expect(out.indexOf("bun.exe")).toBeLessThan(out.indexOf("gjc.js"));
+	it("preserves the exact source runtime and script argv", () => {
+		expect(
+			resolveGjcWorkerCommand(
+				"C:\\repo",
+				{},
+				"win32",
+				["C:\\Program Files\\Bun\\bun.exe", ".\\packages\\coding-agent\\src\\cli.ts"],
+				"C:\\different\\bun.exe",
+			),
+		).toBe("'C:\\Program Files\\Bun\\bun.exe' 'C:\\repo\\packages\\coding-agent\\src\\cli.ts'");
+		expect(
+			resolveGjcWorkerCommand(
+				"/repo",
+				{},
+				"linux",
+				["/opt/bun/bin/bun", "./packages/coding-agent/src/cli.ts"],
+				"/different/bun",
+			),
+		).toBe("'/opt/bun/bin/bun' '/repo/packages/coding-agent/src/cli.ts'");
 	});
 
-	it("prepends the bun runtime when argv[1] ends in .mjs", async () => {
-		process.argv = ["bun", "/repo/packages/coding-agent/src/cli.mjs"];
-		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
-		// pass win32 + a Windows-shaped execPath explicitly so the test is
-		// portable across POSIX runners (which have a bare `bun`, no `.exe`).
-		const out = resolveGjcWorkerCommand(
-			"/repo",
-			process.env,
-			"win32",
-			process.argv,
-			"C:\\Users\\withfox\\.bun\\bin\\bun.exe",
-		);
-		expect(out).toContain("bun");
-		expect(out).toContain("cli.mjs");
+	it("rejects a different GJC discovered only through PATH", () => {
+		expect(() =>
+			resolveGjcWorkerCommand(
+				"/repo",
+				{ PATH: "/different-gjc/bin" },
+				"linux",
+				["/$bunfs/root/gjc", "/$bunfs/root/gjc-linux-x64"],
+				"/$bunfs/exec",
+			),
+		).toThrow("Unable to determine the GJC worker executable");
 	});
 
-	it("does not emit Bun virtual packaged entrypoints as POSIX worker executables", async () => {
-		process.argv = ["gjc", "/$bunfs/root/gjc-linux-x64"];
-		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
-		const out = resolveGjcWorkerCommand("/repo", {}, "linux", process.argv, "/opt/gjc/gjc-linux-x64", () => null);
-
-		expect(out).toBe("'/opt/gjc/gjc-linux-x64'");
-		expect(out).not.toContain("$bunfs");
+	it("fails closed with actionable guidance when only Bun virtual paths exist", () => {
+		expect(() =>
+			resolveGjcWorkerCommand(
+				"C:\\repo",
+				{},
+				"win32",
+				["B:\\~BUN\\bun.exe", "\\$bunfs\\root\\gjc-windows-x64.exe"],
+				"B:\\~BUN\\exec",
+			),
+		).toThrow("Set GJC_TEAM_WORKER_COMMAND");
 	});
 
-	it("falls back to a PATH-resolved gjc when the packaged process executable is also virtual", async () => {
-		process.argv = ["gjc", "/$bunfs/root/gjc-linux-x64"];
-		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
-		const out = resolveGjcWorkerCommand("/repo", {}, "linux", process.argv, "/$bunfs/root/gjc-linux-x64", command =>
-			command === "gjc" ? "/usr/local/bin/gjc" : null,
-		);
-
-		expect(out).toBe("'/usr/local/bin/gjc'");
-		expect(out).not.toContain("$bunfs");
-	});
-
-	it("falls back to plain gjc when packaged entrypoint and PATH probe are not usable", async () => {
-		process.argv = ["gjc", "/$bunfs/root/gjc-linux-x64"];
-		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
-		const out = resolveGjcWorkerCommand("/repo", {}, "linux", process.argv, "/$bunfs/root/gjc-linux-x64", () => null);
-
-		expect(out).toBe("gjc");
-		expect(out).not.toContain("$bunfs");
-	});
-
-	it("does not emit Bun virtual packaged entrypoints as Windows worker executables", async () => {
-		process.argv = ["gjc", "\\$bunfs\\root\\gjc-windows-x64.exe"];
-		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
-		const out = resolveGjcWorkerCommand(
+	it("never emits Bun virtual paths into a PowerShell worker command", () => {
+		const command = resolveGjcWorkerCommand(
 			"C:\\repo",
 			{},
 			"win32",
-			process.argv,
-			"C:\\Program Files\\gjc\\gjc.exe",
-			() => null,
+			["B:\\~BUN\\bun.exe", "\\$bunfs\\root\\gjc-windows-x64.exe"],
+			"C:\\Program Files\\GJC\\gjc.exe",
 		);
 
-		expect(out).toBe("'C:\\Program Files\\gjc\\gjc.exe'");
-		expect(out).not.toContain("$bunfs");
+		expect(command).toBe("'C:\\Program Files\\GJC\\gjc.exe'");
+		expect(command).not.toMatch(/B:\/~BUN|B:\\~BUN|\/\$bunfs|\\\$bunfs/i);
 	});
 });


### PR DESCRIPTION
Clean replacement for closed PRs #2219 and #2229. Adds a provider-specific unmanaged Windows psmux state machine: fresh inventory/create-once/register/attach and continuation inventory/attach-only, with exact-name inventory and managed/session/team/lifecycle markers failing closed before mutation. Removes Bun virtual and PATH fallbacks from launch and team worker command resolution so child processes must use the same real artifact or fail with actionable guidance. No helper scripts or public patch-note surface. Public-sync, focused psmux/authority tests, coding-agent check, standalone build, smoke-test, and real Windows psmux 3.3.6 inventory/ConPTY attach were verified at head 68420eed.