### PR TITLE
fix(coding-agent): settle resumed retries before idle

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Removed the `--mode rpc`, `--mode rpc-ui`, and `--mode bridge` external ingress modes. Machine clients must use the SDK WebSocket interfaces documented in `docs/sdk.md`; no RPC or Bridge compatibility path remains.
 - Documented the current GPT-5.6 Codex and combo profile mappings as product judgments, including the durable `opus-codex` `anthropic/claude-sonnet-5` planner override and `fable-opus-codex` `anthropic/claude-opus-4-8:medium` planner.
 ### Fixed
+- Startup continuation now participates in the existing managed fallback and in-flight recovery envelope, preventing a retryable resumed turn from publishing `agent_end`/idle before retry success, exhaustion, cancellation, or startup failure has settled (#2092).
 
 - Fenced SDK WebSocket lifecycle callbacks and request settlement to the owning retry cycle/socket incarnation, so stale open, close, error, message, and timeout delivery cannot reject or corrupt work on a replacement connection; sent mutations remain non-replayed and deterministic race regressions cover the reconnect boundary (#2164).
 - Owned LSP stdin `EPIPE` and `ERR_STREAM_DESTROYED` failures now terminalize and evict only the affected client, reject pending and stale requests with a stable transport-closed error, and permit clean client recreation without suppressing serialization or unrelated sink failures (#2138).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5482,7 +5482,13 @@ export class AgentSession {
 		if (!canContinuePersistedHistory(this.agent.state.messages)) {
 			throw new Error("Cannot continue from persisted message history");
 		}
-		await this.agent.continue();
+		this.#beginInFlight();
+		try {
+			await this.agent.continue(this.#managedFallbackPromptOptions());
+			await this.#waitForPostPromptRecovery();
+		} finally {
+			this.#endInFlight();
+		}
 	}
 
 	buildDisplaySessionContext(): SessionContext {

--- a/packages/coding-agent/test/agent-session-startup-continue.test.ts
+++ b/packages/coding-agent/test/agent-session-startup-continue.test.ts
@@ -1,12 +1,17 @@
-import { describe, expect, it, vi } from "bun:test";
-import { Agent, type AgentMessage } from "@gajae-code/agent-core";
-import type { AssistantMessage, ToolResultMessage } from "@gajae-code/ai";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { scheduler } from "node:timers/promises";
+import { Agent, type AgentMessage, type AgentOptions } from "@gajae-code/agent-core";
+import type { AssistantMessage, Model, ToolResultMessage } from "@gajae-code/ai";
 import { getBundledModel } from "@gajae-code/ai/models";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
-import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AgentSession, type AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
 
 function testModel() {
 	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
@@ -110,5 +115,191 @@ describe("AgentSession startup continuation", () => {
 		await expect(session.continuePersistedHistory()).rejects.toBe(expected);
 		expect(continueSpy).toHaveBeenCalledTimes(1);
 		await session.dispose();
+	});
+});
+
+function selector(model: Model): string {
+	return `${model.provider}/${model.id}`;
+}
+
+function retryableFailure(model: Model): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage & { transportFailure: { kind: "transport"; status: number } } = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage: "rate limit exceeded",
+			errorStatus: 429,
+			timestamp: Date.now(),
+			transportFailure: { kind: "transport", status: 429 },
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
+}
+
+describe("AgentSession startup continuation lifecycle", () => {
+	let tempDir: TempDir | undefined;
+	let authStorage: AuthStorage | undefined;
+	let session: AgentSession | undefined;
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	async function createManagedSession(streamFn: AgentOptions["streamFn"], maxAttempts = 1): Promise<void> {
+		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!primary || !fallback) throw new Error("Expected bundled fallback test models");
+		tempDir = TempDir.createSync("@startup-continue-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey(primary.provider, "primary-key");
+		authStorage.setRuntimeApiKey(fallback.provider, "fallback-key");
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-key`,
+			initialState: {
+				model: primary,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [{ role: "user", content: "resume", timestamp: 0 }],
+			},
+			streamFn,
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"fallback.maxAttempts": maxAttempts,
+			"retry.baseDelayMs": 1,
+		});
+		settings.setModelRole("default", selector(primary));
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		session.setConfiguredModelChain("default", [selector(primary), selector(fallback)], "test");
+	}
+
+	it("emits one terminal agent_end after a successful managed continuation", async () => {
+		const mock = createMockModel({ responses: [{ content: ["continued"] }] });
+		await createManagedSession((model, context, options) => mock.stream(model, context, options));
+		const events: AgentSessionEvent[] = [];
+		session!.subscribe(event => events.push(event));
+
+		await session!.continuePersistedHistory();
+		await session!.waitForIdle();
+
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
+		expect(session!.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			content: [{ type: "text", text: "continued" }],
+		});
+		expect(session!.isStreaming).toBe(false);
+	});
+
+	it("holds agent_end until a managed retry recovers", async () => {
+		let attempts = 0;
+		const accepted = createMockModel({ responses: [{ content: ["recovered"] }] });
+		await createManagedSession((model, context, options) => {
+			attempts += 1;
+			return attempts === 1 ? retryableFailure(model) : accepted.stream(model, context, options);
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const order: string[] = [];
+		session!.subscribe(event => {
+			if (event.type === "auto_retry_start" || event.type === "auto_retry_end" || event.type === "agent_end") {
+				order.push(event.type);
+			}
+		});
+
+		await session!.continuePersistedHistory();
+		await session!.waitForIdle();
+
+		expect(attempts).toBe(2);
+		expect(order).toEqual(["auto_retry_start", "auto_retry_end", "agent_end"]);
+	});
+
+	it("emits one terminal agent_end when the managed fallback chain is exhausted", async () => {
+		await createManagedSession(model => retryableFailure(model));
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const events: AgentSessionEvent[] = [];
+		session!.subscribe(event => events.push(event));
+
+		await session!.continuePersistedHistory();
+		await session!.waitForIdle();
+
+		const agentEnds = events.filter(event => event.type === "agent_end");
+		expect(agentEnds).toHaveLength(1);
+		expect(session!.messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "error" });
+		expect(session!.isStreaming).toBe(false);
+	});
+
+	it("propagates continuation-start failure without fabricating agent_end", async () => {
+		const mock = createMockModel({ responses: [{ content: ["unused"] }] });
+		await createManagedSession((model, context, options) => mock.stream(model, context, options));
+		const expected = new Error("continuation failed before loop entry");
+		vi.spyOn(session!.agent, "continue").mockRejectedValue(expected);
+		const events: AgentSessionEvent[] = [];
+		session!.subscribe(event => events.push(event));
+
+		await expect(session!.continuePersistedHistory()).rejects.toBe(expected);
+
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(0);
+		expect(session!.isStreaming).toBe(false);
+	});
+
+	it("emits one cancelled agent_end when startup continuation is aborted", async () => {
+		const pending = new AssistantMessageEventStream();
+		await createManagedSession(() => pending);
+		const events: AgentSessionEvent[] = [];
+		session!.subscribe(event => events.push(event));
+		const continuation = session!.continuePersistedHistory();
+		for (let index = 0; index < 20 && session!.agent.activeRunId === undefined; index += 1) await Bun.sleep(1);
+
+		await session!.abort();
+		await continuation;
+		await session!.waitForIdle();
+
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
+		expect(events.find(event => event.type === "agent_end")).toMatchObject({ stopReason: "cancelled" });
+		expect(session!.isStreaming).toBe(false);
+	});
+
+	it("does not duplicate terminal delivery after the agent event subscription reconnects", async () => {
+		const mock = createMockModel({ responses: [{ content: ["continued"] }, { content: ["after reconnect"] }] });
+		await createManagedSession((model, context, options) => mock.stream(model, context, options));
+		const events: AgentSessionEvent[] = [];
+		session!.subscribe(event => events.push(event));
+
+		await session!.continuePersistedHistory();
+		expect(await session!.newSession()).toBe(true);
+		await session!.prompt("verify reconnect");
+		await session!.waitForIdle();
+
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(2);
+		expect(
+			events.filter(
+				event =>
+					event.type === "message_end" &&
+					event.message.role === "assistant" &&
+					event.message.content.some(part => part.type === "text" && part.text === "after reconnect"),
+			),
+		).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
## Summary

- run `continuePersistedHistory()` inside the existing prompt in-flight and post-recovery envelope
- opt startup continuation into the existing managed fallback logical-run owner
- keep `agent_end` deferred until retry success, exhaustion, cancellation, or startup failure settles
- add deterministic success, managed retry, exhaustion, continuation-start failure, cancellation, reconnect, and terminal dedup regressions

No new public event, wire frame, capability, replay contract, or retry policy is introduced.

## Root cause

Startup continuation called `agent.continue()` while `#promptInFlightCount` remained zero. A retryable first attempt could therefore flush `agent_end` before `auto_retry_end`, which notification consumers interpreted as final idle.

## Verification

- `bun test test/agent-session-startup-continue.test.ts` — 9 pass
- `bun test test/agent-session-startup-continue.test.ts test/agent-session-fallback-cancel-idle.test.ts test/agent-session-retry-busy-recovery.test.ts test/agent-session-concurrent.test.ts` — 37 pass
- `bunx biome check packages/coding-agent/src/session/agent-session.ts packages/coding-agent/test/agent-session-startup-continue.test.ts` — passed
- `bun run check` in `packages/coding-agent` — passed, including SDK canonicalization and TypeScript check
- root `bun run check:ts` advanced through tools, publish declarations, Node 20 baseline, public sync, schemas, and 192 SDK manifest tests before the 20-minute command timeout; no failure was observed before timeout

Closes #2092

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*