### PR TITLE
fix(tests): isolate notification state safely

### DIFF
--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -4,7 +4,6 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { type PlanRequest, planTmuxOwnerIsolationSync } from "../../src/gjc-runtime/tmux-owner-isolation";
 import { resolveOwner } from "../../src/harness-control-plane/owner";
-import { readLease } from "../../src/harness-control-plane/session-lease";
 import { createHarnessCliEnv, type HarnessCliEnv } from "./cli-workspace-env";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
@@ -191,12 +190,30 @@ async function runHarness(
 }
 
 const sleep = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms));
+async function retireLiveOwnerForCleanup(timeoutMs = 5_000): Promise<void> {
+	let owner = await resolveOwner(root, SID);
+	if (!owner.live) return;
+	if (!owner.socketPath) {
+		throw new Error("Live detached harness owner has no routable control endpoint; preserving roots.");
+	}
+	const retired = await runHarness(["retire", "--session", SID]);
+	if (retired.code !== 0 || (retired.json?.evidence as { retired?: unknown } | undefined)?.retired !== true) {
+		throw new Error("Live detached harness owner refused routed retirement; preserving roots.");
+	}
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		owner = await resolveOwner(root, SID);
+		if (!owner.live) return;
+		await sleep(25);
+	}
+	throw new Error("Routed detached harness owner did not exit before broker cleanup; preserving roots.");
+}
 
 beforeEach(async () => {
 	// Short paths keep the AF_UNIX socket path under the sun_path limit.
 	root = await mkdtemp(path.join(tmpdir(), "h"));
 	workspace = await mkdtemp(path.join(tmpdir(), "hw"));
-	cliEnv = createHarnessCliEnv(repoRoot);
+	cliEnv = await createHarnessCliEnv(repoRoot);
 	tmuxCommand = await createFakeTmuxBin(root);
 
 	disableSdkHost = false;
@@ -204,32 +221,25 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	sdkServer.stop(true);
-	cliEnv.cleanup();
-	const serverPid = await readFile(path.join(root, "tmux-server.pid"), "utf8")
-		.then(value => Number(value.trim()))
-		.catch(error => {
-			if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-			throw error;
-		});
-	if (serverPid !== null && Number.isSafeInteger(serverPid) && serverPid > 0) {
-		try {
-			process.kill(serverPid, "SIGTERM");
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
-		}
+	let ownerTeardownError: unknown;
+	try {
+		sdkServer.stop(true);
+		await retireLiveOwnerForCleanup();
+	} catch (error) {
+		ownerTeardownError = error;
 	}
-	const lease = await readLease(root, SID).catch(error => {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-		throw error;
-	});
-	if (lease?.pid) {
-		try {
-			process.kill(lease.pid, "SIGTERM");
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+	try {
+		await cliEnv.cleanup({ preserveFiles: ownerTeardownError !== undefined });
+	} catch (brokerCleanupError) {
+		if (ownerTeardownError) {
+			throw new AggregateError(
+				[ownerTeardownError, brokerCleanupError],
+				"Detached harness owner and SDK broker cleanup both failed; preserving roots.",
+			);
 		}
+		throw brokerCleanupError;
 	}
+	if (ownerTeardownError) throw ownerTeardownError;
 	await rm(root, { recursive: true, force: true });
 	await rm(workspace, { recursive: true, force: true });
 });

--- a/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
@@ -93,7 +93,7 @@ const passingFinalizeChecks: FinalizeChecks = {
 
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "h"));
-	cliEnv = createHarnessCliEnv(repoRoot);
+	cliEnv = await createHarnessCliEnv(repoRoot);
 	await writeSessionState(root, seed(root));
 	owner = new RuntimeOwner({
 		root,
@@ -107,10 +107,26 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	cliEnv.cleanup();
-	await owner?.stop();
-	await new Promise<void>(resolve => hungServer?.close(() => resolve()) ?? resolve());
-	hungServer = null;
+	let ownerTeardownError: unknown;
+	try {
+		await owner?.stop();
+		await new Promise<void>(resolve => hungServer?.close(() => resolve()) ?? resolve());
+		hungServer = null;
+	} catch (error) {
+		ownerTeardownError = error;
+	}
+	try {
+		await cliEnv.cleanup();
+	} catch (brokerCleanupError) {
+		if (ownerTeardownError) {
+			throw new AggregateError(
+				[ownerTeardownError, brokerCleanupError],
+				"Harness runtime owner and SDK broker cleanup both failed; preserving roots.",
+			);
+		}
+		throw brokerCleanupError;
+	}
+	if (ownerTeardownError) throw ownerTeardownError;
 	await rm(root, { recursive: true, force: true });
 });
 

--- a/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { brokerOwnerForTest, ensureBroker } from "../../src/sdk/broker/ensure";
 
 interface PackageManifest {
 	name?: unknown;
@@ -21,7 +22,7 @@ interface RepoLinkMarker {
 
 export interface HarnessCliEnv {
 	env: NodeJS.ProcessEnv;
-	cleanup(): void;
+	cleanup(options?: { preserveFiles?: boolean }): Promise<void>;
 }
 
 function readPackageName(manifestPath: string): string | null {
@@ -128,27 +129,45 @@ function createRepoNodeModulesLinks(repoRoot: string, packages: LinkedWorkspaceP
 	};
 }
 
-export function createHarnessCliEnv(repoRoot: string, baseEnv: NodeJS.ProcessEnv = process.env): HarnessCliEnv {
+export async function createHarnessCliEnv(
+	repoRoot: string,
+	baseEnv: NodeJS.ProcessEnv = process.env,
+): Promise<HarnessCliEnv> {
 	const nodePathRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-harness-node-path-"));
 	const registryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-harness-root-registry-"));
 	const packages = collectWorkspacePackages(repoRoot);
 	linkWorkspacePackages(path.join(nodePathRoot, "@gajae-code"), packages);
 	const cleanupRepoLinks = createRepoNodeModulesLinks(repoRoot, packages);
 
+	// Harness subprocesses must never inherit the operator's notifications or agent state.
+	const tempAgentDir = path.join(registryRoot, "agent");
+
 	const existingNodePath = baseEnv.NODE_PATH;
 	const env: NodeJS.ProcessEnv = {
 		...baseEnv,
 		[WORKSPACE_NODE_MODULES_ENV]: path.join(repoRoot, "node_modules"),
 		GJC_HARNESS_ROOT_REGISTRY_DIR: registryRoot,
+		GJC_NOTIFICATIONS: "0",
+		GJC_CODING_AGENT_DIR: tempAgentDir,
+		PI_CODING_AGENT_DIR: tempAgentDir,
 		NODE_PATH: existingNodePath ? `${nodePathRoot}${path.delimiter}${existingNodePath}` : nodePathRoot,
 	};
+	delete env.GJC_NOTIFICATIONS_TOKEN;
+
+	const cleanupFiles = (): void => {
+		cleanupRepoLinks();
+		fs.rmSync(nodePathRoot, { recursive: true, force: true });
+		fs.rmSync(registryRoot, { recursive: true, force: true });
+	};
+	await ensureBroker({ agentDir: tempAgentDir, env });
+	const brokerOwner = brokerOwnerForTest(tempAgentDir);
+	if (!brokerOwner) throw new Error(`Harness test broker owner was not retained for ${tempAgentDir}.`);
 
 	return {
 		env,
-		cleanup() {
-			cleanupRepoLinks();
-			fs.rmSync(nodePathRoot, { recursive: true, force: true });
-			fs.rmSync(registryRoot, { recursive: true, force: true });
+		async cleanup(options) {
+			await brokerOwner.stop();
+			if (!options?.preserveFiles) cleanupFiles();
 		},
 	};
 }

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -12,6 +12,7 @@ import {
 	sessionPaths,
 	writeSessionState,
 } from "../../src/harness-control-plane/storage";
+import { brokerOwnerForTest } from "../../src/sdk/broker/ensure";
 import { createHarnessCliEnv, type HarnessCliEnv } from "./cli-workspace-env";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
@@ -25,14 +26,14 @@ let originalGjcSessionId: string | undefined;
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "harness-cli-root-"));
 	workspace = realpathSync(await mkdtemp(path.join(tmpdir(), "harness-cli-ws-")));
-	cliEnv = createHarnessCliEnv(repoRoot);
+	cliEnv = await createHarnessCliEnv(repoRoot);
 	originalGjcSessionId = process.env.GJC_SESSION_ID;
 	process.env.GJC_SESSION_ID = "test-session";
 	cliEnv.env.GJC_SESSION_ID = "test-session";
 });
 
 afterEach(async () => {
-	cliEnv.cleanup();
+	await cliEnv.cleanup();
 	await rm(root, { recursive: true, force: true });
 	await rm(workspace, { recursive: true, force: true });
 	if (originalGjcSessionId === undefined) {
@@ -173,7 +174,7 @@ async function seedOwnerDiedBeforeFirstPrompt(sessionId: string): Promise<void> 
 }
 
 describe("gjc harness CLI (foundation)", () => {
-	it("test CLI env cleanup removes overlapping created links and preserves pre-existing links", async () => {
+	it("test CLI env isolates operator state, cleans created links, and preserves pre-existing links", async () => {
 		const fakeRepo = await mkdtemp(path.join(tmpdir(), "harness-cli-env-repo-"));
 		try {
 			const packageDir = path.join(fakeRepo, "packages", "ai");
@@ -181,18 +182,38 @@ describe("gjc harness CLI (foundation)", () => {
 			await writeFile(path.join(packageDir, "package.json"), JSON.stringify({ name: "@gajae-code/ai" }), "utf8");
 			const linkPath = path.join(fakeRepo, "node_modules", "@gajae-code", "ai");
 
-			const first = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
-			const second = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			const first = await createHarnessCliEnv(fakeRepo, {
+				GJC_NOTIFICATIONS: "1",
+				GJC_NOTIFICATIONS_TOKEN: "live-token",
+				GJC_CODING_AGENT_DIR: "/production/gjc-agent",
+				PI_CODING_AGENT_DIR: "/production/pi-agent",
+			});
+			const second = await createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			expect(first.env.GJC_NOTIFICATIONS).toBe("0");
+			expect(first.env.GJC_NOTIFICATIONS_TOKEN).toBeUndefined();
+			expect(first.env.GJC_CODING_AGENT_DIR).toBe(path.join(first.env.GJC_HARNESS_ROOT_REGISTRY_DIR!, "agent"));
+			expect(first.env.PI_CODING_AGENT_DIR).toBe(first.env.GJC_CODING_AGENT_DIR);
+			const firstAgentDir = first.env.GJC_CODING_AGENT_DIR!;
+			expect(brokerOwnerForTest(firstAgentDir)).toBeDefined();
 			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
-			first.cleanup();
+			await first.cleanup();
+			expect(brokerOwnerForTest(firstAgentDir)).toBeUndefined();
 			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
-			second.cleanup();
+			await second.cleanup();
 			expect(await Bun.file(linkPath).exists()).toBe(false);
+
+			const preserved = await createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			const preservedRoot = preserved.env.GJC_HARNESS_ROOT_REGISTRY_DIR!;
+			const preservedAgentDir = preserved.env.GJC_CODING_AGENT_DIR!;
+			await preserved.cleanup({ preserveFiles: true });
+			expect(brokerOwnerForTest(preservedAgentDir)).toBeUndefined();
+			expect((await lstat(preservedRoot)).isDirectory()).toBe(true);
+			await preserved.cleanup();
 
 			await mkdir(path.dirname(linkPath), { recursive: true });
 			await symlink(packageDir, linkPath, "dir");
-			const withPreexistingLink = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
-			withPreexistingLink.cleanup();
+			const withPreexistingLink = await createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			await withPreexistingLink.cleanup();
 			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
 		} finally {
 			await rm(fakeRepo, { recursive: true, force: true });

--- a/packages/coding-agent/test/harness-tmux-owner.test.ts
+++ b/packages/coding-agent/test/harness-tmux-owner.test.ts
@@ -3,7 +3,7 @@ import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { planTmuxOwnerIsolation } from "../src/gjc-runtime/tmux-owner-isolation";
-import { readLease } from "../src/harness-control-plane/session-lease";
+import { resolveOwner } from "../src/harness-control-plane/owner";
 import { createHarnessCliEnv, type HarnessCliEnv } from "./harness-control-plane/cli-workspace-env";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
@@ -13,6 +13,7 @@ const sessionId = "tmux-owner-test";
 let root: string;
 let workspace: string;
 let cliEnv: HarnessCliEnv;
+let ownerRoute: { tmuxCommand: string; env: NodeJS.ProcessEnv } | null;
 
 async function createUnverifiableTmux(): Promise<{ command: string; log: string }> {
 	const bin = path.join(root, "bin");
@@ -121,92 +122,84 @@ async function runHarness(
 	tmuxCommand: string,
 	expectedExitCode = 0,
 	env: NodeJS.ProcessEnv = {},
+	args: string[] = ["start", "--input", JSON.stringify({ harness: "gajae-code", workspace, sessionId, detach: true })],
 ): Promise<Record<string, unknown>> {
-	const proc = Bun.spawn(
-		[
-			"bun",
-			cliEntry,
-			"harness",
-			"start",
-			"--input",
-			JSON.stringify({ harness: "gajae-code", workspace, sessionId, detach: true }),
-		],
-		{
-			cwd: workspace,
-			env: {
-				...cliEnv.env,
-				GJC_HARNESS_STATE_ROOT: root,
-				GJC_HARNESS_TEST_ASSUME_LINUX_OWNER_ISOLATION: "1",
-				// The owner process must not inherit the test runner's ambient tmux client:
-				// its startup title update would target that shared server instead of the
-				// private -L socket exercised by this fixture.
-				TMUX: "",
-				GJC_TMUX_COMMAND: tmuxCommand,
-				...env,
-			},
-			stdout: "pipe",
-			stderr: "pipe",
+	const proc = Bun.spawn(["bun", cliEntry, "harness", ...args], {
+		cwd: workspace,
+		env: {
+			...cliEnv.env,
+			GJC_HARNESS_STATE_ROOT: root,
+			GJC_HARNESS_TEST_ASSUME_LINUX_OWNER_ISOLATION: "1",
+			// The owner process must not inherit the test runner's ambient tmux client:
+			// its startup title update would target that shared server instead of the
+			// private -L socket exercised by this fixture.
+			TMUX: "",
+			GJC_TMUX_COMMAND: tmuxCommand,
+			...env,
 		},
-	);
+		stdout: "pipe",
+		stderr: "pipe",
+	});
 	const [output, stderr, exitCode] = await Promise.all([
 		new Response(proc.stdout).text(),
 		new Response(proc.stderr).text(),
 		proc.exited,
 	]);
 	if (exitCode !== expectedExitCode) throw new Error(`harness exit ${exitCode}: ${stderr || output}`);
-	return JSON.parse(output) as Record<string, unknown>;
+	const result = JSON.parse(output) as Record<string, unknown>;
+	if (args[0] === "start" && (result.state as { ownerLive?: unknown } | undefined)?.ownerLive === true) {
+		ownerRoute = { tmuxCommand, env: { ...env } };
+	}
+	return result;
 }
 
-const LEASE_EXIT_TIMEOUT_MS = 5_000;
+const OWNER_EXIT_TIMEOUT_MS = 5_000;
 
-/**
- * Bounded, exact-PID exit wait for a lease owner the test signalled. Returns true once `pid`
- * is confirmed gone (ESRCH on signal-0), false on timeout. The pid is not a child of this
- * process (the owner was detached and reparented), so there is no local zombie to reap — the
- * kernel/init reaps it on exit and signal-0 then reports ESRCH.
- */
-async function waitForExactExit(pid: number, timeoutMs: number): Promise<boolean> {
-	const deadline = Date.now() + timeoutMs;
+async function retireLiveOwnerForCleanup(): Promise<void> {
+	let owner = await resolveOwner(root, sessionId);
+	if (!owner.live) return;
+	if (!owner.socketPath || !ownerRoute) {
+		throw new Error("Live harness owner has no retained control route; preserving roots.");
+	}
+	const retired = await runHarness(ownerRoute.tmuxCommand, 0, ownerRoute.env, ["retire", "--session", sessionId]);
+	if ((retired.evidence as { retired?: unknown } | undefined)?.retired !== true) {
+		throw new Error("Live harness owner refused routed retirement; preserving roots.");
+	}
+	const deadline = Date.now() + OWNER_EXIT_TIMEOUT_MS;
 	while (Date.now() < deadline) {
-		try {
-			process.kill(pid, 0);
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code === "ESRCH") return true;
-			throw error;
-		}
+		owner = await resolveOwner(root, sessionId);
+		if (!owner.live) return;
 		await Bun.sleep(25);
 	}
-	return false;
+	throw new Error("Routed harness owner did not exit before broker cleanup; preserving roots.");
 }
 
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "harness-tmux-owner-"));
 	workspace = await mkdtemp(path.join(tmpdir(), "harness-tmux-workspace-"));
-	cliEnv = createHarnessCliEnv(repoRoot);
+	cliEnv = await createHarnessCliEnv(repoRoot);
+	ownerRoute = null;
 });
 
 afterEach(async () => {
-	const lease = await readLease(root, sessionId).catch(error => {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-		throw error;
-	});
-	let leaseExitFailed: number | null = null;
-	if (lease?.pid) {
-		try {
-			process.kill(lease.pid, "SIGTERM");
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
-		}
-		// Bounded exact lease-PID exit wait: a live detached owner must tear down (and signal its
-		// descendants) before we delete the roots. A timeout is a real leak — fail loudly and
-		// PRESERVE the roots for inspection instead of silently rm-ing an orphaned tree.
-		if (!(await waitForExactExit(lease.pid, LEASE_EXIT_TIMEOUT_MS))) leaseExitFailed = lease.pid;
+	let ownerTeardownError: unknown;
+	try {
+		await retireLiveOwnerForCleanup();
+	} catch (error) {
+		ownerTeardownError = error;
 	}
-	cliEnv.cleanup();
-	if (leaseExitFailed !== null)
-		throw new Error(
-			`detached owner lease pid ${leaseExitFailed} did not exit within ${LEASE_EXIT_TIMEOUT_MS}ms; preserving roots for inspection`,
-		);
+	try {
+		await cliEnv.cleanup({ preserveFiles: ownerTeardownError !== undefined });
+	} catch (brokerCleanupError) {
+		if (ownerTeardownError) {
+			throw new AggregateError(
+				[ownerTeardownError, brokerCleanupError],
+				"Detached harness owner and SDK broker cleanup both failed; preserving roots.",
+			);
+		}
+		throw brokerCleanupError;
+	}
+	if (ownerTeardownError) throw ownerTeardownError;
 	await rm(root, { recursive: true, force: true });
 	await rm(workspace, { recursive: true, force: true });
 });

--- a/packages/coding-agent/test/helpers/notification-settings.ts
+++ b/packages/coding-agent/test/helpers/notification-settings.ts
@@ -1,0 +1,24 @@
+import { Settings } from "../../src/config/settings";
+import type { SettingPath } from "../../src/config/settings-schema";
+import { brokerOwnerForTest } from "../../src/sdk/broker/ensure";
+
+/** Keep notification tests off the user's real config and daemon state. */
+export function isolatedNotificationSettings(
+	agentDir: string,
+	overrides: Partial<Record<SettingPath, unknown>> = {},
+): Settings {
+	const settings = Settings.isolated({ "notifications.enabled": false, ...overrides });
+	return new Proxy(settings, {
+		get(target, prop) {
+			if (prop === "getAgentDir") return () => agentDir;
+			const value = Reflect.get(target, prop, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	});
+}
+
+export async function stopIsolatedNotificationBroker(agentDir: string): Promise<void> {
+	const brokerOwner = brokerOwnerForTest(agentDir);
+	if (!brokerOwner) throw new Error(`Notification test broker owner was not retained for ${agentDir}.`);
+	await brokerOwner.stop();
+}

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -24,6 +24,7 @@ import {
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { daemonPaths } from "../src/sdk/bus/telegram-daemon";
 import { SessionManager } from "../src/session/session-manager";
+import { isolatedNotificationSettings, stopIsolatedNotificationBroker } from "./helpers/notification-settings";
 
 const BASE_CFG: NotificationConfig = {
 	enabled: false,
@@ -68,8 +69,10 @@ const PRIMARY_GLOBAL_CFG: NotificationConfig = {
 	sessionScope: "primary",
 };
 const tempDirs: string[] = [];
+const brokerAgentDirs: string[] = [];
 
-afterEach(() => {
+afterEach(async () => {
+	for (const agentDir of brokerAgentDirs.splice(0)) await stopIsolatedNotificationBroker(agentDir);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -350,7 +353,7 @@ describe("notifications config", () => {
 		tempDirs.push(cwd);
 		const previous = process.env.GJC_NOTIFICATIONS;
 		delete process.env.GJC_NOTIFICATIONS;
-		const settings = Settings.isolated({
+		const settings = isolatedNotificationSettings(cwd, {
 			"notifications.enabled": true,
 			"notifications.telegram.botToken": " ",
 			"notifications.telegram.chatId": "\t",
@@ -451,6 +454,7 @@ describe("notifications config", () => {
 			});
 			disposers.push(() => explicitExtensionSubagent.session.dispose());
 			await topLevel.session.extensionRunner?.emit({ type: "session_start" });
+			brokerAgentDirs.push(cwd);
 			await subagent.session.extensionRunner?.emit({ type: "session_start" });
 			await parentPrefixSubagent.session.extensionRunner?.emit({ type: "session_start" });
 			await agentTypeOnlySubagent.session.extensionRunner?.emit({ type: "session_start" });
@@ -485,13 +489,16 @@ describe("notifications config", () => {
 			expect(fs.existsSync(explicitExtensionSubagentEndpoint)).toBe(false);
 			expect(fs.existsSync(daemonPaths(cwd).roots)).toBe(false);
 		} finally {
-			await Promise.all(disposers.reverse().map(dispose => dispose()));
-			if (previous === undefined) {
-				delete process.env.GJC_NOTIFICATIONS;
-			} else {
-				process.env.GJC_NOTIFICATIONS = previous;
+			try {
+				await Promise.all(disposers.reverse().map(dispose => dispose()));
+			} finally {
+				if (previous === undefined) {
+					delete process.env.GJC_NOTIFICATIONS;
+				} else {
+					process.env.GJC_NOTIFICATIONS = previous;
+				}
+				resetSettingsForTest();
 			}
-			resetSettingsForTest();
 		}
 	}, 30000);
 
@@ -503,7 +510,7 @@ describe("notifications config", () => {
 		delete process.env.GJC_NOTIFICATIONS;
 		delete process.env.GJC_SPAWNED_BY_SESSION;
 		const adapterSettings = (scope: "all" | "primary"): Settings =>
-			Settings.isolated({
+			isolatedNotificationSettings(cwd, {
 				"notifications.enabled": true,
 				"notifications.discord.botToken": "discord-token",
 				"notifications.discord.applicationId": "discord-application",
@@ -555,6 +562,7 @@ describe("notifications config", () => {
 			delete process.env.GJC_NOTIFICATIONS;
 
 			await suppressed.session.extensionRunner?.emit({ type: "session_start" });
+			brokerAgentDirs.push(cwd);
 			await preserved.session.extensionRunner?.emit({ type: "session_start" });
 			await optedIn.session.extensionRunner?.emit({ type: "session_start" });
 
@@ -562,12 +570,15 @@ describe("notifications config", () => {
 			expect(fs.existsSync(endpointFor(preserved.session.sessionId))).toBe(true);
 			expect(fs.existsSync(endpointFor(optedIn.session.sessionId))).toBe(true);
 		} finally {
-			await Promise.all(disposers.reverse().map(dispose => dispose()));
-			if (previousNotif === undefined) delete process.env.GJC_NOTIFICATIONS;
-			else process.env.GJC_NOTIFICATIONS = previousNotif;
-			if (previousSpawn === undefined) delete process.env.GJC_SPAWNED_BY_SESSION;
-			else process.env.GJC_SPAWNED_BY_SESSION = previousSpawn;
-			resetSettingsForTest();
+			try {
+				await Promise.all(disposers.reverse().map(dispose => dispose()));
+			} finally {
+				if (previousNotif === undefined) delete process.env.GJC_NOTIFICATIONS;
+				else process.env.GJC_NOTIFICATIONS = previousNotif;
+				if (previousSpawn === undefined) delete process.env.GJC_SPAWNED_BY_SESSION;
+				else process.env.GJC_SPAWNED_BY_SESSION = previousSpawn;
+				resetSettingsForTest();
+			}
 		}
 	}, 30000);
 

--- a/packages/coding-agent/test/notifications-file-redaction.test.ts
+++ b/packages/coding-agent/test/notifications-file-redaction.test.ts
@@ -2,10 +2,10 @@ import { afterEach, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Settings } from "../src/config/settings";
 import { getTelegramFileSink } from "../src/sdk/bus/attachment-registry";
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
+import { isolatedNotificationSettings, stopIsolatedNotificationBroker } from "./helpers/notification-settings";
 
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
 async function waitFor(pred: () => boolean, ms = 4000, label = "condition"): Promise<void> {
@@ -22,9 +22,11 @@ type Frame = { type: string; redact?: boolean };
 
 const tempDirs: string[] = [];
 const openSockets: WebSocket[] = [];
+const agentDirs: string[] = [];
 
-afterEach(() => {
+afterEach(async () => {
 	for (const ws of openSockets.splice(0)) ws.close();
+	for (const agentDir of agentDirs.splice(0)) await stopIsolatedNotificationBroker(agentDir);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -48,11 +50,12 @@ function createHarness(redact: boolean) {
 		registerCommand: () => {},
 		sendUserMessage: () => {},
 	} as never;
-	const settings = Settings.isolated({ "notifications.redact": redact });
-	createNotificationsExtension(api, { settings });
-
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-file-redaction-"));
 	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
+	const settings = isolatedNotificationSettings(agentDir, { "notifications.redact": redact });
+	createNotificationsExtension(api, { settings });
 	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	let sid = `file-redaction-${suffix}`;
 	const ctx = {

--- a/packages/coding-agent/test/notifications-lifecycle-create-autoresume.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-create-autoresume.test.ts
@@ -4,21 +4,36 @@ import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { setAgentDir } from "@gajae-code/utils";
+import { getAgentDir, setAgentDir } from "@gajae-code/utils";
 import type { Args } from "../src/cli/args";
 import { Settings } from "../src/config/settings";
 import { createSessionManager } from "../src/main";
+import { brokerOwnerForTest, ensureBroker } from "../src/sdk/broker/ensure";
 import { SessionManager } from "../src/session/session-manager";
 
 const LIFECYCLE_ENV = ["GJC_LIFECYCLE_REQUEST_ID", "GJC_SESSION_ID"] as const;
+const agentDirs: string[] = [];
+const originalAgentDir = getAgentDir();
 
-afterEach(() => {
-	for (const k of LIFECYCLE_ENV) delete process.env[k];
+afterEach(async () => {
+	try {
+		for (const k of LIFECYCLE_ENV) delete process.env[k];
+		for (const agentDir of agentDirs.splice(0)) {
+			const brokerOwner = brokerOwnerForTest(agentDir);
+			if (!brokerOwner) throw new Error(`Autoresume test broker owner was not retained for ${agentDir}.`);
+			await brokerOwner.stop();
+			await fsp.rm(agentDir, { recursive: true, force: true });
+		}
+	} finally {
+		setAgentDir(originalAgentDir);
+	}
 });
 
 test("normal root launch creates a current SessionManager for root token logs", async () => {
 	const agentDir = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-root-token-session-"));
+	agentDirs.push(agentDir);
 	setAgentDir(agentDir);
+	await ensureBroker({ agentDir });
 	const cwd = path.join(agentDir, "repo");
 	fs.mkdirSync(cwd, { recursive: true });
 
@@ -29,8 +44,6 @@ test("normal root launch creates a current SessionManager for root token logs", 
 	expect(created).toBeDefined();
 	expect(created?.getSessionId()).toBeTruthy();
 	expect(created?.getCwd()).toBe(cwd);
-
-	await fsp.rm(agentDir, { recursive: true, force: true });
 });
 
 // Regression for the PR #1148 stage-17 blocker: a `/session_create` child is a
@@ -40,7 +53,9 @@ test("normal root launch creates a current SessionManager for root token logs", 
 // create a fresh session that adopts the pre-allocated id.
 test("lifecycle /session_create bypasses autoResume; normal launch still resumes", async () => {
 	const agentDir = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-lc-autoresume-"));
+	agentDirs.push(agentDir);
 	setAgentDir(agentDir);
+	await ensureBroker({ agentDir });
 	const cwd = path.join(agentDir, "repo");
 	fs.mkdirSync(cwd, { recursive: true });
 
@@ -69,6 +84,4 @@ test("lifecycle /session_create bypasses autoResume; normal launch still resumes
 	// The freshly created SDK session under the same env adopts the pre-allocated id.
 	const fresh = SessionManager.inMemory(cwd);
 	expect(fresh.getSessionId()).toBe("s-prealloc-autoresume-1");
-
-	await fsp.rm(agentDir, { recursive: true, force: true });
 });

--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -7,6 +7,7 @@ import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { TelegramNotificationDaemon } from "../src/sdk/bus/telegram-daemon";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
 import { renderThreadedFrame } from "../src/sdk/bus/threaded-render";
+import { isolatedNotificationSettings, stopIsolatedNotificationBroker } from "./helpers/notification-settings";
 
 // ---------------------------------------------------------------------------
 // 1) Pure render contract: streamed turn frames become editable, and live +
@@ -61,6 +62,7 @@ type Handler = (event: unknown, ctx: unknown) => unknown;
 type Frame = { type: string; phase?: string; text?: string; messageRef?: string };
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
 const envKeys = [
 	"GJC_NOTIFICATIONS",
@@ -70,17 +72,14 @@ const envKeys = [
 ] as const;
 let savedEnv: Record<string, string | undefined> = {};
 
-afterEach(() => {
+afterEach(async () => {
 	for (const ws of openSockets.splice(0)) {
 		try {
 			ws.close();
 		} catch {}
 	}
-	for (const dir of tempDirs.splice(0)) {
-		try {
-			fs.rmSync(dir, { recursive: true, force: true });
-		} catch {}
-	}
+	for (const agentDir of agentDirs.splice(0)) await stopIsolatedNotificationBroker(agentDir);
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 	for (const k of envKeys) {
 		if (savedEnv[k] === undefined) delete process.env[k];
 		else process.env[k] = savedEnv[k];
@@ -95,16 +94,19 @@ function setEnv(over: Partial<Record<(typeof envKeys)[number], string>>): void {
 }
 
 async function bootSession(): Promise<{ handlers: Map<string, Handler>; ctx: unknown; frames: Frame[] }> {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-stream-"));
+	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => handlers.set(event, handler),
 		registerCommand: () => {},
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-stream-"));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(agentDir),
+	});
 	const sid = `stream-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const ctx = {
 		cwd,

--- a/packages/coding-agent/test/notifications-postmortem-close.test.ts
+++ b/packages/coding-agent/test/notifications-postmortem-close.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { postmortem } from "@gajae-code/utils";
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
+import { isolatedNotificationSettings, stopIsolatedNotificationBroker } from "./helpers/notification-settings";
 
 /**
  * Regression for "hard terminal close orphans the Telegram topic": a native
@@ -31,14 +32,20 @@ type Frame = { type: string; sessionId?: string };
 type CleanupCallback = (reason: postmortem.Reason) => void | Promise<void>;
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
-afterEach(() => {
+afterEach(async () => {
 	for (const ws of openSockets.splice(0)) ws.close();
+	for (const agentDir of agentDirs.splice(0)) await stopIsolatedNotificationBroker(agentDir);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 	vi.restoreAllMocks();
 });
 
 function createHarness(prefix: string) {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => {
@@ -47,10 +54,9 @@ function createHarness(prefix: string) {
 		registerCommand: () => {},
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(agentDir),
+	});
 
 	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const sid = `${prefix}${suffix}`;

--- a/packages/coding-agent/test/notifications-session-switch.test.ts
+++ b/packages/coding-agent/test/notifications-session-switch.test.ts
@@ -14,6 +14,7 @@ import { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
 import { SessionManager } from "../src/session/session-manager";
 import { getAskAnswerSource } from "../src/tools/ask-answer-registry";
+import { isolatedNotificationSettings, stopIsolatedNotificationBroker } from "./helpers/notification-settings";
 
 /**
  * Regression for "the SDK notification transport spawns a new session instead of renaming":
@@ -38,9 +39,11 @@ type Handler = (event: unknown, ctx: unknown) => unknown;
 type Frame = { type: string; title?: string; sessionId?: string; state?: string };
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
-afterEach(() => {
+afterEach(async () => {
 	for (const ws of openSockets.splice(0)) ws.close();
+	for (const agentDir of agentDirs.splice(0)) await stopIsolatedNotificationBroker(agentDir);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -56,6 +59,10 @@ async function withNotifications<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 function createHarness(prefix: string, initialName: string | undefined = "Original") {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
 	const api = {
@@ -66,10 +73,9 @@ function createHarness(prefix: string, initialName: string | undefined = "Origin
 			commands.set(name, command),
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(agentDir),
+	});
 
 	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	let sid = `${prefix}${suffix}`;
@@ -147,6 +153,8 @@ test("session_switch publishes successor SDK authority only after AgentSession r
 	const targetSessionId = targetSessionManager.getSessionId();
 	await targetSessionManager.close();
 	if (!targetSessionFile) throw new Error("Expected persisted target session");
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 
 	const handlers = new Map<string, Handler>();
 	const api = {
@@ -154,7 +162,9 @@ test("session_switch publishes successor SDK authority only after AgentSession r
 		registerCommand: () => {},
 		sendUserMessage: async () => {},
 	} as never;
-	createNotificationsExtension(api);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(agentDir),
+	});
 	const ctx = { cwd, sessionManager: currentSessionManager } as never;
 	const predecessorSessionId = currentSessionManager.getSessionId();
 	const predecessorEndpoint = path.join(cwd, ".gjc", "state", "sdk", `${predecessorSessionId}.json`);
@@ -201,14 +211,21 @@ test("session_switch publishes successor SDK authority only after AgentSession r
 test("turn.prompt preflight rejection returns a correlated failure without an accepted lifecycle", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-prompt-preflight-"));
 	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
-	createNotificationsExtension({
-		on: (event: string, handler: Handler) => handlers.set(event, handler),
-		registerCommand: () => {},
-		sendUserMessage: async () => {
-			throw Object.assign(new Error("submission preflight rejected"), { code: "unavailable" });
+	createNotificationsExtension(
+		{
+			on: (event: string, handler: Handler) => handlers.set(event, handler),
+			registerCommand: () => {},
+			sendUserMessage: async () => {
+				throw Object.assign(new Error("submission preflight rejected"), { code: "unavailable" });
+			},
+		} as never,
+		{
+			settings: isolatedNotificationSettings(agentDir),
 		},
-	} as never);
+	);
 	const sessionId = `preflight-${process.pid}-${Date.now()}`;
 	const ctx = {
 		cwd,
@@ -264,15 +281,24 @@ test("turn.prompt preflight rejection returns a correlated failure without an ac
 test("accepted turn.prompt submission failures emit a correlated terminal event", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-prompt-terminal-failure-"));
 	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
-	createNotificationsExtension({
-		on: (event: string, handler: Handler) => handlers.set(event, handler),
-		registerCommand: () => {},
-		sendUserMessage: (_content: unknown, options: { onPreflightAccepted?: () => void } | undefined) => {
-			options?.onPreflightAccepted?.();
-			return Promise.reject(Object.assign(new Error("submission failed after acceptance"), { code: "unavailable" }));
+	createNotificationsExtension(
+		{
+			on: (event: string, handler: Handler) => handlers.set(event, handler),
+			registerCommand: () => {},
+			sendUserMessage: (_content: unknown, options: { onPreflightAccepted?: () => void } | undefined) => {
+				options?.onPreflightAccepted?.();
+				return Promise.reject(
+					Object.assign(new Error("submission failed after acceptance"), { code: "unavailable" }),
+				);
+			},
+		} as never,
+		{
+			settings: isolatedNotificationSettings(agentDir),
 		},
-	} as never);
+	);
 	const sessionId = `terminal-failure-${process.pid}-${Date.now()}`;
 	const ctx = {
 		cwd,
@@ -338,6 +364,10 @@ test("session_switch rotates SDK authority while preserving topic identity", asy
 	const prevEnv = process.env.GJC_NOTIFICATIONS;
 	process.env.GJC_NOTIFICATIONS = "1";
 	try {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-switch-"));
+		tempDirs.push(cwd);
+		const agentDir = path.join(cwd, ".agent");
+		agentDirs.push(agentDir);
 		const handlers = new Map<string, Handler>();
 		const api = {
 			on: (event: string, handler: Handler) => {
@@ -346,10 +376,9 @@ test("session_switch rotates SDK authority while preserving topic identity", asy
 			registerCommand: () => {},
 			sendUserMessage: () => {},
 		} as never;
-		createNotificationsExtension(api);
-
-		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-switch-"));
-		tempDirs.push(cwd);
+		createNotificationsExtension(api, {
+			settings: isolatedNotificationSettings(agentDir),
+		});
 
 		const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 		let sid = `switch-a-${suffix}`;

--- a/packages/coding-agent/test/notifications-turn-ordering.test.ts
+++ b/packages/coding-agent/test/notifications-turn-ordering.test.ts
@@ -2,8 +2,10 @@ import { afterEach, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { daemonPaths } from "../src/sdk/bus/daemon-paths";
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
+import { isolatedNotificationSettings, stopIsolatedNotificationBroker } from "./helpers/notification-settings";
 
 /**
  * Regression for the text-before-ask ordering bug: the assistant text that
@@ -41,9 +43,11 @@ type TestContextUsage = {
 type TestModel = { id?: string };
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
-afterEach(() => {
+afterEach(async () => {
 	for (const ws of openSockets.splice(0)) ws.close();
+	for (const agentDir of agentDirs.splice(0)) await stopIsolatedNotificationBroker(agentDir);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -56,6 +60,10 @@ async function setup(options: { contextUsage?: TestContextUsage | false; model?:
 	token: string;
 	sid: string;
 }> {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-order-"));
+	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => {
@@ -64,10 +72,7 @@ async function setup(options: { contextUsage?: TestContextUsage | false; model?:
 		registerCommand: () => {},
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-order-"));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, { settings: isolatedNotificationSettings(agentDir) });
 	const sid = `order-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const ctx = {
 		cwd,
@@ -85,6 +90,7 @@ async function setup(options: { contextUsage?: TestContextUsage | false; model?:
 	} as never;
 
 	await handlers.get("session_start")!({ type: "session_start" }, ctx);
+	expect(fs.existsSync(daemonPaths(agentDir).roots)).toBe(false);
 
 	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sid}.json`);
 	await waitFor(() => fs.existsSync(endpointFile), 4000, "endpoint file");


### PR DESCRIPTION
## Summary

Replacement for closed #2224, narrowed around test isolation and exact teardown authority.

- isolates direct notification-extension fixtures from the operator agent directory and Telegram registry
- pre-starts harness SDK brokers in the test parent and retains their exact owner handles
- retires live harness owners through their session-owned control endpoints before broker cleanup
- removes the changed teardown paths' PID-only `SIGTERM` / `kill(pid, 0)` logic
- awaits exact broker stop before deleting roots; teardown uncertainty stops the broker but preserves evidence files
- restores process-global agent-dir state in the autoresume fixture

Test-only change: 13 files under `packages/coding-agent/test`; no production source, API, schema, dependency, daemon policy, or deletion-authority changes.

## Process-safety boundary

The prior rejection was correct: a numeric PID was not durable cleanup authority. This replacement adds **zero PID-signalling lines**. Live owners self-retire over the unique control endpoint under the test-owned harness root. If that route is absent, refuses retirement, or does not exit within the bound, cleanup fails closed and preserves roots. SDK brokers are stopped only through the retained `brokerOwnerForTest(agentDir)` owner.

## Verification

Exact head: `f15b16ddb`
Base: `c3d8b5d81`

- full notification suite: 590 pass, 0 fail
- affected harness matrix: 54 pass, 7 platform skips, 0 fail
- routed-teardown/evidence-preservation regression included in the harness matrix
- `bun run --cwd packages/coding-agent check` — pass
- `bun run ci:test:smoke` — pass
- post-run matching `sdk broker-internal` processes under this worktree — 0
- operator Telegram roots-registry SHA-256 unchanged: `148dcb955dedcd262e6e0190921467b428881ce192c2f8129e395dfaff3320ea`

Supersedes #2224.