### PR TITLE
test(coding-agent): isolate notification broker teardown

### DIFF
--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -1055,6 +1055,10 @@ export default class Harness extends Command {
 			envAssignments.push(`${RECEIPT_SPOOL_DIR_ENV}=${shellQuote(process.env[RECEIPT_SPOOL_DIR_ENV])}`);
 		if (process.env.GJC_HARNESS_TEST_NODE_MODULES)
 			envAssignments.push(`GJC_HARNESS_TEST_NODE_MODULES=${shellQuote(process.env.GJC_HARNESS_TEST_NODE_MODULES)}`);
+		if (process.env.GJC_HARNESS_TEST_DISABLE_BROKER)
+			envAssignments.push(
+				`GJC_HARNESS_TEST_DISABLE_BROKER=${shellQuote(process.env.GJC_HARNESS_TEST_DISABLE_BROKER)}`,
+			);
 		if (process.env.GJC_SDK_DISABLE)
 			envAssignments.push(`GJC_SDK_DISABLE=${shellQuote(process.env.GJC_SDK_DISABLE)}`);
 		const shellCommand = `exec env ${envAssignments.join(" ")} ${this.#buildOwnerCommand(sessionId).map(shellQuote).join(" ")}`;
@@ -1260,6 +1264,9 @@ export default class Harness extends Command {
 					: {}),
 				...(process.env.GJC_HARNESS_TEST_NODE_MODULES
 					? { GJC_HARNESS_TEST_NODE_MODULES: process.env.GJC_HARNESS_TEST_NODE_MODULES }
+					: {}),
+				...(process.env.GJC_HARNESS_TEST_DISABLE_BROKER
+					? { GJC_HARNESS_TEST_DISABLE_BROKER: process.env.GJC_HARNESS_TEST_DISABLE_BROKER }
 					: {}),
 				...(process.env.GJC_SDK_DISABLE ? { GJC_SDK_DISABLE: process.env.GJC_SDK_DISABLE } : {}),
 			},

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -2421,7 +2421,9 @@ export function createNotificationsExtension(
 			const agentDir = lifecycleAgentDir ?? settings?.getAgentDir?.();
 			if (lifecycleRequired && !agentDir) throw new Error("Lifecycle SDK host requires an agent directory.");
 
-			if (agentDir) {
+			const brokerDisabledForHarnessTest =
+				process.env.GJC_HARNESS_TEST_DISABLE_BROKER === "1" && Boolean(process.env.GJC_HARNESS_TEST_NODE_MODULES);
+			if (agentDir && !brokerDisabledForHarnessTest) {
 				try {
 					await ensureBroker({ agentDir });
 					throwIfLifecycleStopped();

--- a/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
@@ -135,13 +135,22 @@ export function createHarnessCliEnv(repoRoot: string, baseEnv: NodeJS.ProcessEnv
 	linkWorkspacePackages(path.join(nodePathRoot, "@gajae-code"), packages);
 	const cleanupRepoLinks = createRepoNodeModulesLinks(repoRoot, packages);
 
+	// Harness subprocesses need SDK endpoints, but their test-only session discovery
+	// must never spawn a detached broker or touch operator notification state.
+	const tempAgentDir = path.join(registryRoot, "agent");
+
 	const existingNodePath = baseEnv.NODE_PATH;
 	const env: NodeJS.ProcessEnv = {
 		...baseEnv,
 		[WORKSPACE_NODE_MODULES_ENV]: path.join(repoRoot, "node_modules"),
 		GJC_HARNESS_ROOT_REGISTRY_DIR: registryRoot,
+		GJC_HARNESS_TEST_DISABLE_BROKER: "1",
+		GJC_NOTIFICATIONS: "0",
+		GJC_CODING_AGENT_DIR: tempAgentDir,
+		PI_CODING_AGENT_DIR: tempAgentDir,
 		NODE_PATH: existingNodePath ? `${nodePathRoot}${path.delimiter}${existingNodePath}` : nodePathRoot,
 	};
+	delete env.GJC_NOTIFICATIONS_TOKEN;
 
 	return {
 		env,

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -173,7 +173,7 @@ async function seedOwnerDiedBeforeFirstPrompt(sessionId: string): Promise<void> 
 }
 
 describe("gjc harness CLI (foundation)", () => {
-	it("test CLI env cleanup removes overlapping created links and preserves pre-existing links", async () => {
+	it("test CLI env isolates operator state, disables only broker discovery, and preserves links", async () => {
 		const fakeRepo = await mkdtemp(path.join(tmpdir(), "harness-cli-env-repo-"));
 		try {
 			const packageDir = path.join(fakeRepo, "packages", "ai");
@@ -181,8 +181,18 @@ describe("gjc harness CLI (foundation)", () => {
 			await writeFile(path.join(packageDir, "package.json"), JSON.stringify({ name: "@gajae-code/ai" }), "utf8");
 			const linkPath = path.join(fakeRepo, "node_modules", "@gajae-code", "ai");
 
-			const first = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			const first = createHarnessCliEnv(fakeRepo, {
+				GJC_NOTIFICATIONS: "1",
+				GJC_NOTIFICATIONS_TOKEN: "live-token",
+				GJC_CODING_AGENT_DIR: "/operator/gjc-agent",
+				PI_CODING_AGENT_DIR: "/operator/pi-agent",
+			});
 			const second = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			expect(first.env.GJC_NOTIFICATIONS).toBe("0");
+			expect(first.env.GJC_NOTIFICATIONS_TOKEN).toBeUndefined();
+			expect(first.env.GJC_HARNESS_TEST_DISABLE_BROKER).toBe("1");
+			expect(first.env.GJC_CODING_AGENT_DIR).toBe(path.join(first.env.GJC_HARNESS_ROOT_REGISTRY_DIR!, "agent"));
+			expect(first.env.PI_CODING_AGENT_DIR).toBe(first.env.GJC_CODING_AGENT_DIR);
 			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
 			first.cleanup();
 			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);

--- a/packages/coding-agent/test/helpers/notification-settings.ts
+++ b/packages/coding-agent/test/helpers/notification-settings.ts
@@ -1,0 +1,56 @@
+import { Settings } from "../../src/config/settings";
+import type { SettingPath } from "../../src/config/settings-schema";
+import { brokerOwnerForTest } from "../../src/sdk/broker/ensure";
+
+/** Keep notification tests off the user's real config and daemon state. */
+export function isolatedNotificationSettings(
+	agentDir: string,
+	overrides: Partial<Record<SettingPath, unknown>> = {},
+): Settings {
+	const settings = Settings.isolated({ "notifications.enabled": false, ...overrides });
+	return new Proxy(settings, {
+		get(target, prop) {
+			if (prop === "getAgentDir") return () => agentDir;
+			const value = Reflect.get(target, prop, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	});
+}
+export type NotificationRuntimeShutdown = () => Promise<void>;
+
+export async function stopIsolatedNotificationBroker(
+	agentDir: string,
+	options: { required?: boolean } = { required: true },
+): Promise<void> {
+	const brokerOwner = brokerOwnerForTest(agentDir);
+	if (!brokerOwner) {
+		if (options.required !== false)
+			throw new Error(`Notification test broker owner was not retained for ${agentDir}.`);
+		return;
+	}
+	await brokerOwner.stop();
+}
+
+export async function cleanupIsolatedNotificationRuntimes(
+	shutdowns: NotificationRuntimeShutdown[],
+	agentDirs: string[],
+	requiredAgentDirs: Set<string>,
+): Promise<void> {
+	const errors: unknown[] = [];
+	for (const shutdown of shutdowns.splice(0).reverse()) {
+		try {
+			await shutdown();
+		} catch (error) {
+			errors.push(error);
+		}
+	}
+	for (const agentDir of agentDirs.splice(0)) {
+		try {
+			await stopIsolatedNotificationBroker(agentDir, { required: requiredAgentDirs.has(agentDir) });
+		} catch (error) {
+			errors.push(error);
+		}
+	}
+	requiredAgentDirs.clear();
+	if (errors.length > 0) throw new AggregateError(errors, "Notification runtime cleanup failed; preserving roots.");
+}

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -24,6 +24,11 @@ import {
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { daemonPaths } from "../src/sdk/bus/telegram-daemon";
 import { SessionManager } from "../src/session/session-manager";
+import {
+	cleanupIsolatedNotificationRuntimes,
+	isolatedNotificationSettings,
+	type NotificationRuntimeShutdown,
+} from "./helpers/notification-settings";
 
 const BASE_CFG: NotificationConfig = {
 	enabled: false,
@@ -68,8 +73,12 @@ const PRIMARY_GLOBAL_CFG: NotificationConfig = {
 	sessionScope: "primary",
 };
 const tempDirs: string[] = [];
+const brokerAgentDirs: string[] = [];
+const requiredBrokerAgentDirs = new Set<string>();
+const runtimeShutdowns: NotificationRuntimeShutdown[] = [];
 
-afterEach(() => {
+afterEach(async () => {
+	await cleanupIsolatedNotificationRuntimes(runtimeShutdowns, brokerAgentDirs, requiredBrokerAgentDirs);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -348,9 +357,10 @@ describe("notifications config", () => {
 	test("settings-enabled subagent sessions do not register the notifications extension", async () => {
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-subagent-"));
 		tempDirs.push(cwd);
+		brokerAgentDirs.push(cwd);
 		const previous = process.env.GJC_NOTIFICATIONS;
 		delete process.env.GJC_NOTIFICATIONS;
-		const settings = Settings.isolated({
+		const settings = isolatedNotificationSettings(cwd, {
 			"notifications.enabled": true,
 			"notifications.telegram.botToken": " ",
 			"notifications.telegram.chatId": "\t",
@@ -359,8 +369,6 @@ describe("notifications config", () => {
 			"notifications.discord.guildId": "discord-guild",
 			"notifications.discord.parentChannelId": "discord-parent",
 		});
-
-		const disposers: Array<() => Promise<void>> = [];
 
 		try {
 			resetSettingsForTest();
@@ -380,7 +388,13 @@ describe("notifications config", () => {
 				enableMCP: false,
 				enableLsp: false,
 			});
-			disposers.push(() => topLevel.session.dispose());
+			runtimeShutdowns.push(async () => {
+				try {
+					await topLevel.session.extensionRunner?.emit({ type: "session_shutdown" });
+				} finally {
+					await topLevel.session.dispose();
+				}
+			});
 
 			const subagent = await createAgentSession({
 				cwd,
@@ -398,7 +412,13 @@ describe("notifications config", () => {
 				enableLsp: false,
 				taskDepth: 1,
 			});
-			disposers.push(() => subagent.session.dispose());
+			runtimeShutdowns.push(async () => {
+				try {
+					await subagent.session.extensionRunner?.emit({ type: "session_shutdown" });
+				} finally {
+					await subagent.session.dispose();
+				}
+			});
 			const parentPrefixSubagent = await createAgentSession({
 				cwd,
 				agentDir: cwd,
@@ -415,7 +435,13 @@ describe("notifications config", () => {
 				enableLsp: false,
 				parentTaskPrefix: "0-Sub",
 			});
-			disposers.push(() => parentPrefixSubagent.session.dispose());
+			runtimeShutdowns.push(async () => {
+				try {
+					await parentPrefixSubagent.session.extensionRunner?.emit({ type: "session_shutdown" });
+				} finally {
+					await parentPrefixSubagent.session.dispose();
+				}
+			});
 			const agentTypeOnlySubagent = await createAgentSession({
 				cwd,
 				agentDir: cwd,
@@ -432,7 +458,13 @@ describe("notifications config", () => {
 				enableLsp: false,
 				currentAgentType: "executor",
 			});
-			disposers.push(() => agentTypeOnlySubagent.session.dispose());
+			runtimeShutdowns.push(async () => {
+				try {
+					await agentTypeOnlySubagent.session.extensionRunner?.emit({ type: "session_shutdown" });
+				} finally {
+					await agentTypeOnlySubagent.session.dispose();
+				}
+			});
 			const explicitExtensionSubagent = await createAgentSession({
 				cwd,
 				agentDir: cwd,
@@ -449,8 +481,15 @@ describe("notifications config", () => {
 				enableLsp: false,
 				taskDepth: 1,
 			});
-			disposers.push(() => explicitExtensionSubagent.session.dispose());
+			runtimeShutdowns.push(async () => {
+				try {
+					await explicitExtensionSubagent.session.extensionRunner?.emit({ type: "session_shutdown" });
+				} finally {
+					await explicitExtensionSubagent.session.dispose();
+				}
+			});
 			await topLevel.session.extensionRunner?.emit({ type: "session_start" });
+			requiredBrokerAgentDirs.add(cwd);
 			await subagent.session.extensionRunner?.emit({ type: "session_start" });
 			await parentPrefixSubagent.session.extensionRunner?.emit({ type: "session_start" });
 			await agentTypeOnlySubagent.session.extensionRunner?.emit({ type: "session_start" });
@@ -485,7 +524,6 @@ describe("notifications config", () => {
 			expect(fs.existsSync(explicitExtensionSubagentEndpoint)).toBe(false);
 			expect(fs.existsSync(daemonPaths(cwd).roots)).toBe(false);
 		} finally {
-			await Promise.all(disposers.reverse().map(dispose => dispose()));
 			if (previous === undefined) {
 				delete process.env.GJC_NOTIFICATIONS;
 			} else {
@@ -498,12 +536,13 @@ describe("notifications config", () => {
 	test("sessionScope=primary keeps a canonical SDK endpoint while suppressing GJC-spawned child delivery", async () => {
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-notif-spawned-"));
 		tempDirs.push(cwd);
+		brokerAgentDirs.push(cwd);
 		const previousNotif = process.env.GJC_NOTIFICATIONS;
 		const previousSpawn = process.env.GJC_SPAWNED_BY_SESSION;
 		delete process.env.GJC_NOTIFICATIONS;
 		delete process.env.GJC_SPAWNED_BY_SESSION;
 		const adapterSettings = (scope: "all" | "primary"): Settings =>
-			Settings.isolated({
+			isolatedNotificationSettings(cwd, {
 				"notifications.enabled": true,
 				"notifications.discord.botToken": "discord-token",
 				"notifications.discord.applicationId": "discord-application",
@@ -513,7 +552,6 @@ describe("notifications config", () => {
 			});
 		const primarySettings = adapterSettings("primary");
 		const allSettings = adapterSettings("all");
-		const disposers: Array<() => Promise<void>> = [];
 		const spawn = async (settings: Settings) =>
 			createAgentSession({
 				cwd,
@@ -539,22 +577,41 @@ describe("notifications config", () => {
 			// while the session-scoped delivery guard above suppresses notifications.
 			process.env.GJC_SPAWNED_BY_SESSION = "parent-abc";
 			const suppressed = await spawn(primarySettings);
-			disposers.push(() => suppressed.session.dispose());
+			runtimeShutdowns.push(async () => {
+				try {
+					await suppressed.session.extensionRunner?.emit({ type: "session_shutdown" });
+				} finally {
+					await suppressed.session.dispose();
+				}
+			});
 			expect(process.env.GJC_SPAWNED_BY_SESSION).toBeUndefined();
 
 			// 2. Spawned child under the default "all" scope still registers.
 			process.env.GJC_SPAWNED_BY_SESSION = "parent-abc";
 			const preserved = await spawn(allSettings);
-			disposers.push(() => preserved.session.dispose());
+			runtimeShutdowns.push(async () => {
+				try {
+					await preserved.session.extensionRunner?.emit({ type: "session_shutdown" });
+				} finally {
+					await preserved.session.dispose();
+				}
+			});
 
 			// 3. Spawned child under primary WITH explicit opt-in keeps its endpoint.
 			process.env.GJC_SPAWNED_BY_SESSION = "parent-abc";
 			process.env.GJC_NOTIFICATIONS = "1";
 			const optedIn = await spawn(primarySettings);
-			disposers.push(() => optedIn.session.dispose());
+			runtimeShutdowns.push(async () => {
+				try {
+					await optedIn.session.extensionRunner?.emit({ type: "session_shutdown" });
+				} finally {
+					await optedIn.session.dispose();
+				}
+			});
 			delete process.env.GJC_NOTIFICATIONS;
 
 			await suppressed.session.extensionRunner?.emit({ type: "session_start" });
+			requiredBrokerAgentDirs.add(cwd);
 			await preserved.session.extensionRunner?.emit({ type: "session_start" });
 			await optedIn.session.extensionRunner?.emit({ type: "session_start" });
 
@@ -562,7 +619,6 @@ describe("notifications config", () => {
 			expect(fs.existsSync(endpointFor(preserved.session.sessionId))).toBe(true);
 			expect(fs.existsSync(endpointFor(optedIn.session.sessionId))).toBe(true);
 		} finally {
-			await Promise.all(disposers.reverse().map(dispose => dispose()));
 			if (previousNotif === undefined) delete process.env.GJC_NOTIFICATIONS;
 			else process.env.GJC_NOTIFICATIONS = previousNotif;
 			if (previousSpawn === undefined) delete process.env.GJC_SPAWNED_BY_SESSION;

--- a/packages/coding-agent/test/notifications-file-redaction.test.ts
+++ b/packages/coding-agent/test/notifications-file-redaction.test.ts
@@ -2,10 +2,14 @@ import { afterEach, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Settings } from "../src/config/settings";
 import { getTelegramFileSink } from "../src/sdk/bus/attachment-registry";
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
+import {
+	cleanupIsolatedNotificationRuntimes,
+	isolatedNotificationSettings,
+	type NotificationRuntimeShutdown,
+} from "./helpers/notification-settings";
 
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
 async function waitFor(pred: () => boolean, ms = 4000, label = "condition"): Promise<void> {
@@ -22,9 +26,17 @@ type Frame = { type: string; redact?: boolean };
 
 const tempDirs: string[] = [];
 const openSockets: WebSocket[] = [];
+const agentDirs: string[] = [];
+const runtimeShutdowns: NotificationRuntimeShutdown[] = [];
+const requiredAgentDirs = new Set<string>();
 
-afterEach(() => {
-	for (const ws of openSockets.splice(0)) ws.close();
+afterEach(async () => {
+	for (const ws of openSockets.splice(0)) {
+		try {
+			ws.close();
+		} catch {}
+	}
+	await cleanupIsolatedNotificationRuntimes(runtimeShutdowns, agentDirs, requiredAgentDirs);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -48,11 +60,12 @@ function createHarness(redact: boolean) {
 		registerCommand: () => {},
 		sendUserMessage: () => {},
 	} as never;
-	const settings = Settings.isolated({ "notifications.redact": redact });
-	createNotificationsExtension(api, { settings });
-
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-file-redaction-"));
 	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
+	const settings = isolatedNotificationSettings(agentDir, { "notifications.redact": redact });
+	createNotificationsExtension(api, { settings });
 	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	let sid = `file-redaction-${suffix}`;
 	const ctx = {
@@ -64,12 +77,16 @@ function createHarness(redact: boolean) {
 			getCwd: () => cwd,
 		},
 	} as never;
+	runtimeShutdowns.push(async () => {
+		await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
+	});
 	const endpoint = () => path.join(cwd, ".gjc", "state", "sdk", `${sid}.json`);
 
 	return {
 		handlers,
 		ctx,
 		cwd,
+		agentDir,
 		get sid() {
 			return sid;
 		},
@@ -86,6 +103,7 @@ async function startAndConnect(harness: ReturnType<typeof createHarness>): Promi
 	token: string;
 }> {
 	await harness.handlers.get("session_start")!({ type: "session_start" }, harness.ctx);
+	requiredAgentDirs.add(harness.agentDir);
 	await waitFor(() => fs.existsSync(harness.endpoint()), 4000, "endpoint file");
 	const { url, token } = readEndpoint(harness.endpoint());
 	const frames: Frame[] = [];
@@ -129,6 +147,7 @@ test("session_switch keeps telegram_send file attachments blocked under redactio
 	await withNotifications(async () => {
 		const harness = createHarness(true);
 		await harness.handlers.get("session_start")!({ type: "session_start" }, harness.ctx);
+		requiredAgentDirs.add(harness.agentDir);
 		await waitFor(() => fs.existsSync(harness.endpoint()), 4000, "endpoint file");
 
 		const previousId = harness.sid;

--- a/packages/coding-agent/test/notifications-lifecycle-create-autoresume.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-create-autoresume.test.ts
@@ -1,23 +1,44 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { setAgentDir } from "@gajae-code/utils";
+import { getAgentDir, setAgentDir } from "@gajae-code/utils";
 import type { Args } from "../src/cli/args";
 import { Settings } from "../src/config/settings";
 import { createSessionManager } from "../src/main";
 import { SessionManager } from "../src/session/session-manager";
 
 const LIFECYCLE_ENV = ["GJC_LIFECYCLE_REQUEST_ID", "GJC_SESSION_ID"] as const;
+const agentDirs: string[] = [];
+let previousAgentDir: string;
+let previousLifecycleEnv: Record<(typeof LIFECYCLE_ENV)[number], string | undefined>;
 
-afterEach(() => {
-	for (const k of LIFECYCLE_ENV) delete process.env[k];
+beforeEach(() => {
+	previousAgentDir = getAgentDir();
+	previousLifecycleEnv = {
+		GJC_LIFECYCLE_REQUEST_ID: process.env.GJC_LIFECYCLE_REQUEST_ID,
+		GJC_SESSION_ID: process.env.GJC_SESSION_ID,
+	};
+});
+
+afterEach(async () => {
+	try {
+		for (const agentDir of agentDirs.splice(0)) await fsp.rm(agentDir, { recursive: true, force: true });
+	} finally {
+		for (const key of LIFECYCLE_ENV) {
+			const value = previousLifecycleEnv[key];
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		setAgentDir(previousAgentDir);
+	}
 });
 
 test("normal root launch creates a current SessionManager for root token logs", async () => {
 	const agentDir = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-root-token-session-"));
+	agentDirs.push(agentDir);
 	setAgentDir(agentDir);
 	const cwd = path.join(agentDir, "repo");
 	fs.mkdirSync(cwd, { recursive: true });
@@ -29,8 +50,6 @@ test("normal root launch creates a current SessionManager for root token logs", 
 	expect(created).toBeDefined();
 	expect(created?.getSessionId()).toBeTruthy();
 	expect(created?.getCwd()).toBe(cwd);
-
-	await fsp.rm(agentDir, { recursive: true, force: true });
 });
 
 // Regression for the PR #1148 stage-17 blocker: a `/session_create` child is a
@@ -40,6 +59,7 @@ test("normal root launch creates a current SessionManager for root token logs", 
 // create a fresh session that adopts the pre-allocated id.
 test("lifecycle /session_create bypasses autoResume; normal launch still resumes", async () => {
 	const agentDir = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-lc-autoresume-"));
+	agentDirs.push(agentDir);
 	setAgentDir(agentDir);
 	const cwd = path.join(agentDir, "repo");
 	fs.mkdirSync(cwd, { recursive: true });
@@ -69,6 +89,4 @@ test("lifecycle /session_create bypasses autoResume; normal launch still resumes
 	// The freshly created SDK session under the same env adopts the pre-allocated id.
 	const fresh = SessionManager.inMemory(cwd);
 	expect(fresh.getSessionId()).toBe("s-prealloc-autoresume-1");
-
-	await fsp.rm(agentDir, { recursive: true, force: true });
 });

--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -7,6 +7,11 @@ import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { TelegramNotificationDaemon } from "../src/sdk/bus/telegram-daemon";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
 import { renderThreadedFrame } from "../src/sdk/bus/threaded-render";
+import {
+	cleanupIsolatedNotificationRuntimes,
+	isolatedNotificationSettings,
+	type NotificationRuntimeShutdown,
+} from "./helpers/notification-settings";
 
 // ---------------------------------------------------------------------------
 // 1) Pure render contract: streamed turn frames become editable, and live +
@@ -61,7 +66,10 @@ type Handler = (event: unknown, ctx: unknown) => unknown;
 type Frame = { type: string; phase?: string; text?: string; messageRef?: string };
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
+const runtimeShutdowns: NotificationRuntimeShutdown[] = [];
+const requiredAgentDirs = new Set<string>();
 const envKeys = [
 	"GJC_NOTIFICATIONS",
 	"GJC_NOTIFICATIONS_STREAM",
@@ -70,22 +78,22 @@ const envKeys = [
 ] as const;
 let savedEnv: Record<string, string | undefined> = {};
 
-afterEach(() => {
-	for (const ws of openSockets.splice(0)) {
-		try {
-			ws.close();
-		} catch {}
+afterEach(async () => {
+	try {
+		for (const ws of openSockets.splice(0)) {
+			try {
+				ws.close();
+			} catch {}
+		}
+		await cleanupIsolatedNotificationRuntimes(runtimeShutdowns, agentDirs, requiredAgentDirs);
+		for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+	} finally {
+		for (const k of envKeys) {
+			if (savedEnv[k] === undefined) delete process.env[k];
+			else process.env[k] = savedEnv[k];
+		}
+		savedEnv = {};
 	}
-	for (const dir of tempDirs.splice(0)) {
-		try {
-			fs.rmSync(dir, { recursive: true, force: true });
-		} catch {}
-	}
-	for (const k of envKeys) {
-		if (savedEnv[k] === undefined) delete process.env[k];
-		else process.env[k] = savedEnv[k];
-	}
-	savedEnv = {};
 });
 
 function setEnv(over: Partial<Record<(typeof envKeys)[number], string>>): void {
@@ -95,16 +103,19 @@ function setEnv(over: Partial<Record<(typeof envKeys)[number], string>>): void {
 }
 
 async function bootSession(): Promise<{ handlers: Map<string, Handler>; ctx: unknown; frames: Frame[] }> {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-stream-"));
+	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => handlers.set(event, handler),
 		registerCommand: () => {},
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-stream-"));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(agentDir),
+	});
 	const sid = `stream-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const ctx = {
 		cwd,
@@ -117,8 +128,12 @@ async function bootSession(): Promise<{ handlers: Map<string, Handler>; ctx: unk
 		getContextUsage: () => undefined,
 		getModel: () => undefined,
 	} as never;
+	runtimeShutdowns.push(async () => {
+		await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
+	});
 
 	await handlers.get("session_start")!({ type: "session_start" }, ctx);
+	requiredAgentDirs.add(agentDir);
 	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sid}.json`);
 	await waitFor(() => fs.existsSync(endpointFile), 4000, "endpoint file");
 	const { url, token } = readEndpoint(endpointFile);

--- a/packages/coding-agent/test/notifications-postmortem-close.test.ts
+++ b/packages/coding-agent/test/notifications-postmortem-close.test.ts
@@ -5,6 +5,11 @@ import * as path from "node:path";
 import { postmortem } from "@gajae-code/utils";
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
+import {
+	cleanupIsolatedNotificationRuntimes,
+	isolatedNotificationSettings,
+	type NotificationRuntimeShutdown,
+} from "./helpers/notification-settings";
 
 /**
  * Regression for "hard terminal close orphans the Telegram topic": a native
@@ -31,14 +36,29 @@ type Frame = { type: string; sessionId?: string };
 type CleanupCallback = (reason: postmortem.Reason) => void | Promise<void>;
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
-afterEach(() => {
-	for (const ws of openSockets.splice(0)) ws.close();
-	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
-	vi.restoreAllMocks();
+const runtimeShutdowns: NotificationRuntimeShutdown[] = [];
+const requiredAgentDirs = new Set<string>();
+afterEach(async () => {
+	try {
+		for (const ws of openSockets.splice(0)) {
+			try {
+				ws.close();
+			} catch {}
+		}
+		await cleanupIsolatedNotificationRuntimes(runtimeShutdowns, agentDirs, requiredAgentDirs);
+		for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+	} finally {
+		vi.restoreAllMocks();
+	}
 });
 
 function createHarness(prefix: string) {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => {
@@ -47,10 +67,9 @@ function createHarness(prefix: string) {
 		registerCommand: () => {},
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(agentDir),
+	});
 
 	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const sid = `${prefix}${suffix}`;
@@ -63,9 +82,12 @@ function createHarness(prefix: string) {
 			getCwd: () => cwd,
 		},
 	} as never;
+	runtimeShutdowns.push(async () => {
+		await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
+	});
 
 	const endpoint = path.join(cwd, ".gjc", "state", "sdk", `${sid}.json`);
-	return { handlers, ctx, sid, endpoint };
+	return { handlers, ctx, sid, endpoint, agentDir };
 }
 
 async function connectFrames(endpoint: string): Promise<Frame[]> {
@@ -105,6 +127,7 @@ test("postmortem teardown emits session_closed to connected clients", async () =
 
 		const harness = createHarness("gjc-notif-pm-");
 		await harness.handlers.get("session_start")!({ type: "session_start" }, harness.ctx);
+		requiredAgentDirs.add(harness.agentDir);
 		await waitFor(() => fs.existsSync(harness.endpoint), 4000, "endpoint file");
 		const frames = await connectFrames(harness.endpoint);
 
@@ -134,6 +157,7 @@ test("graceful session_shutdown cancels the postmortem registration", async () =
 
 		const harness = createHarness("gjc-notif-pm-cancel-");
 		await harness.handlers.get("session_start")!({ type: "session_start" }, harness.ctx);
+		requiredAgentDirs.add(harness.agentDir);
 		await waitFor(() => fs.existsSync(harness.endpoint), 4000, "endpoint file");
 		expect(registered.has(`notifications-session-closed:${harness.sid}`)).toBe(true);
 

--- a/packages/coding-agent/test/notifications-session-switch.test.ts
+++ b/packages/coding-agent/test/notifications-session-switch.test.ts
@@ -14,6 +14,11 @@ import { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
 import { SessionManager } from "../src/session/session-manager";
 import { getAskAnswerSource } from "../src/tools/ask-answer-registry";
+import {
+	cleanupIsolatedNotificationRuntimes,
+	isolatedNotificationSettings,
+	type NotificationRuntimeShutdown,
+} from "./helpers/notification-settings";
 
 /**
  * Regression for "the SDK notification transport spawns a new session instead of renaming":
@@ -38,9 +43,17 @@ type Handler = (event: unknown, ctx: unknown) => unknown;
 type Frame = { type: string; title?: string; sessionId?: string; state?: string };
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
-afterEach(() => {
-	for (const ws of openSockets.splice(0)) ws.close();
+const runtimeShutdowns: NotificationRuntimeShutdown[] = [];
+const requiredAgentDirs = new Set<string>();
+afterEach(async () => {
+	for (const ws of openSockets.splice(0)) {
+		try {
+			ws.close();
+		} catch {}
+	}
+	await cleanupIsolatedNotificationRuntimes(runtimeShutdowns, agentDirs, requiredAgentDirs);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -56,20 +69,32 @@ async function withNotifications<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 function createHarness(prefix: string, initialName: string | undefined = "Original") {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
 	const api = {
 		on: (event: string, handler: Handler) => {
-			handlers.set(event, handler);
+			handlers.set(
+				event,
+				event === "session_start"
+					? async (value: unknown, context: unknown) => {
+							const result = await handler(value, context);
+							requiredAgentDirs.add(agentDir);
+							return result;
+						}
+					: handler,
+			);
 		},
 		registerCommand: (name: string, command: { handler: (args: string, ctx: unknown) => Promise<void> }) =>
 			commands.set(name, command),
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(agentDir),
+	});
 
 	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	let sid = `${prefix}${suffix}`;
@@ -83,6 +108,9 @@ function createHarness(prefix: string, initialName: string | undefined = "Origin
 			getCwd: () => cwd,
 		},
 	} as never;
+	runtimeShutdowns.push(async () => {
+		await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
+	});
 
 	const notifDir = path.join(cwd, ".gjc", "state", "sdk");
 	return {
@@ -147,6 +175,8 @@ test("session_switch publishes successor SDK authority only after AgentSession r
 	const targetSessionId = targetSessionManager.getSessionId();
 	await targetSessionManager.close();
 	if (!targetSessionFile) throw new Error("Expected persisted target session");
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 
 	const handlers = new Map<string, Handler>();
 	const api = {
@@ -154,8 +184,13 @@ test("session_switch publishes successor SDK authority only after AgentSession r
 		registerCommand: () => {},
 		sendUserMessage: async () => {},
 	} as never;
-	createNotificationsExtension(api);
+	createNotificationsExtension(api, {
+		settings: isolatedNotificationSettings(agentDir),
+	});
 	const ctx = { cwd, sessionManager: currentSessionManager } as never;
+	runtimeShutdowns.push(async () => {
+		await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
+	});
 	const predecessorSessionId = currentSessionManager.getSessionId();
 	const predecessorEndpoint = path.join(cwd, ".gjc", "state", "sdk", `${predecessorSessionId}.json`);
 	const successorEndpoint = path.join(cwd, ".gjc", "state", "sdk", `${targetSessionId}.json`);
@@ -185,6 +220,7 @@ test("session_switch publishes successor SDK authority only after AgentSession r
 			extensionRunner,
 		});
 		await handlers.get("session_start")!({ type: "session_start" }, ctx);
+		requiredAgentDirs.add(agentDir);
 		await waitFor(() => fs.existsSync(predecessorEndpoint), 4000, "predecessor endpoint");
 
 		expect(await session.switchSession(targetSessionFile)).toBe(true);
@@ -201,14 +237,21 @@ test("session_switch publishes successor SDK authority only after AgentSession r
 test("turn.prompt preflight rejection returns a correlated failure without an accepted lifecycle", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-prompt-preflight-"));
 	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
-	createNotificationsExtension({
-		on: (event: string, handler: Handler) => handlers.set(event, handler),
-		registerCommand: () => {},
-		sendUserMessage: async () => {
-			throw Object.assign(new Error("submission preflight rejected"), { code: "unavailable" });
+	createNotificationsExtension(
+		{
+			on: (event: string, handler: Handler) => handlers.set(event, handler),
+			registerCommand: () => {},
+			sendUserMessage: async () => {
+				throw Object.assign(new Error("submission preflight rejected"), { code: "unavailable" });
+			},
+		} as never,
+		{
+			settings: isolatedNotificationSettings(agentDir),
 		},
-	} as never);
+	);
 	const sessionId = `preflight-${process.pid}-${Date.now()}`;
 	const ctx = {
 		cwd,
@@ -219,7 +262,11 @@ test("turn.prompt preflight rejection returns a correlated failure without an ac
 			getCwd: () => cwd,
 		},
 	} as never;
+	runtimeShutdowns.push(async () => {
+		await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
+	});
 	await handlers.get("session_start")!({ type: "session_start" }, ctx);
+	requiredAgentDirs.add(agentDir);
 	const endpointPath = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
 	await waitFor(() => fs.existsSync(endpointPath), 4000, "preflight endpoint");
 	const { url, token } = readEndpoint(endpointPath);
@@ -264,15 +311,24 @@ test("turn.prompt preflight rejection returns a correlated failure without an ac
 test("accepted turn.prompt submission failures emit a correlated terminal event", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-prompt-terminal-failure-"));
 	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
-	createNotificationsExtension({
-		on: (event: string, handler: Handler) => handlers.set(event, handler),
-		registerCommand: () => {},
-		sendUserMessage: (_content: unknown, options: { onPreflightAccepted?: () => void } | undefined) => {
-			options?.onPreflightAccepted?.();
-			return Promise.reject(Object.assign(new Error("submission failed after acceptance"), { code: "unavailable" }));
+	createNotificationsExtension(
+		{
+			on: (event: string, handler: Handler) => handlers.set(event, handler),
+			registerCommand: () => {},
+			sendUserMessage: (_content: unknown, options: { onPreflightAccepted?: () => void } | undefined) => {
+				options?.onPreflightAccepted?.();
+				return Promise.reject(
+					Object.assign(new Error("submission failed after acceptance"), { code: "unavailable" }),
+				);
+			},
+		} as never,
+		{
+			settings: isolatedNotificationSettings(agentDir),
 		},
-	} as never);
+	);
 	const sessionId = `terminal-failure-${process.pid}-${Date.now()}`;
 	const ctx = {
 		cwd,
@@ -283,7 +339,11 @@ test("accepted turn.prompt submission failures emit a correlated terminal event"
 			getCwd: () => cwd,
 		},
 	} as never;
+	runtimeShutdowns.push(async () => {
+		await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
+	});
 	await handlers.get("session_start")!({ type: "session_start" }, ctx);
+	requiredAgentDirs.add(agentDir);
 	const endpointPath = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
 	await waitFor(() => fs.existsSync(endpointPath), 4000, "terminal failure endpoint");
 	const { url, token } = readEndpoint(endpointPath);
@@ -338,6 +398,10 @@ test("session_switch rotates SDK authority while preserving topic identity", asy
 	const prevEnv = process.env.GJC_NOTIFICATIONS;
 	process.env.GJC_NOTIFICATIONS = "1";
 	try {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-switch-"));
+		tempDirs.push(cwd);
+		const agentDir = path.join(cwd, ".agent");
+		agentDirs.push(agentDir);
 		const handlers = new Map<string, Handler>();
 		const api = {
 			on: (event: string, handler: Handler) => {
@@ -346,10 +410,9 @@ test("session_switch rotates SDK authority while preserving topic identity", asy
 			registerCommand: () => {},
 			sendUserMessage: () => {},
 		} as never;
-		createNotificationsExtension(api);
-
-		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-switch-"));
-		tempDirs.push(cwd);
+		createNotificationsExtension(api, {
+			settings: isolatedNotificationSettings(agentDir),
+		});
 
 		const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 		let sid = `switch-a-${suffix}`;
@@ -363,8 +426,12 @@ test("session_switch rotates SDK authority while preserving topic identity", asy
 				getCwd: () => cwd,
 			},
 		} as never;
+		runtimeShutdowns.push(async () => {
+			await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
+		});
 
 		await handlers.get("session_start")!({ type: "session_start" }, ctx);
+		requiredAgentDirs.add(agentDir);
 
 		const notifDir = path.join(cwd, ".gjc", "state", "sdk");
 		const originalEndpoint = path.join(notifDir, `${sid}.json`);

--- a/packages/coding-agent/test/notifications-turn-ordering.test.ts
+++ b/packages/coding-agent/test/notifications-turn-ordering.test.ts
@@ -2,8 +2,14 @@ import { afterEach, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { daemonPaths } from "../src/sdk/bus/daemon-paths";
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
+import {
+	cleanupIsolatedNotificationRuntimes,
+	isolatedNotificationSettings,
+	type NotificationRuntimeShutdown,
+} from "./helpers/notification-settings";
 
 /**
  * Regression for the text-before-ask ordering bug: the assistant text that
@@ -41,9 +47,17 @@ type TestContextUsage = {
 type TestModel = { id?: string };
 
 const tempDirs: string[] = [];
+const agentDirs: string[] = [];
 const openSockets: WebSocket[] = [];
-afterEach(() => {
-	for (const ws of openSockets.splice(0)) ws.close();
+const runtimeShutdowns: NotificationRuntimeShutdown[] = [];
+const requiredAgentDirs = new Set<string>();
+afterEach(async () => {
+	for (const ws of openSockets.splice(0)) {
+		try {
+			ws.close();
+		} catch {}
+	}
+	await cleanupIsolatedNotificationRuntimes(runtimeShutdowns, agentDirs, requiredAgentDirs);
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -56,6 +70,10 @@ async function setup(options: { contextUsage?: TestContextUsage | false; model?:
 	token: string;
 	sid: string;
 }> {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-order-"));
+	tempDirs.push(cwd);
+	const agentDir = path.join(cwd, ".agent");
+	agentDirs.push(agentDir);
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => {
@@ -64,10 +82,7 @@ async function setup(options: { contextUsage?: TestContextUsage | false; model?:
 		registerCommand: () => {},
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api);
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-order-"));
-	tempDirs.push(cwd);
+	createNotificationsExtension(api, { settings: isolatedNotificationSettings(agentDir) });
 	const sid = `order-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const ctx = {
 		cwd,
@@ -83,8 +98,13 @@ async function setup(options: { contextUsage?: TestContextUsage | false; model?:
 				: (options.contextUsage ?? { tokens: 12, contextWindow: 100, percent: 12, source: "provider_anchor" }),
 		getModel: () => (options.model === false ? undefined : (options.model ?? { id: "test-model" })),
 	} as never;
+	runtimeShutdowns.push(async () => {
+		await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
+	});
 
 	await handlers.get("session_start")!({ type: "session_start" }, ctx);
+	requiredAgentDirs.add(agentDir);
+	expect(fs.existsSync(daemonPaths(agentDir).roots)).toBe(false);
 
 	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sid}.json`);
 	await waitFor(() => fs.existsSync(endpointFile), 4000, "endpoint file");

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -48,6 +48,8 @@ afterEach(() => {
 	delete process.env.GJC_SDK_DISABLE;
 	delete process.env.GJC_NOTIFICATIONS;
 	delete process.env.GJC_LIFECYCLE_TEST_TOKEN;
+	delete process.env.GJC_HARNESS_TEST_DISABLE_BROKER;
+	delete process.env.GJC_HARNESS_TEST_NODE_MODULES;
 	delete process.env.GJC_LIFECYCLE_TEST_SECRET;
 	delete process.env.GJC_LIFECYCLE_TEST_API_KEY;
 });
@@ -266,6 +268,7 @@ test("lifecycle teardown records failed host and server cleanup as false", async
 			brokerRegistrationReleased: false,
 		});
 	} finally {
+		await brokerOwnerForTest(cwd)?.stop();
 		stop.mockRestore();
 		(NotificationServer.prototype as unknown as { stop: () => void }).stop = nativeStop;
 	}
@@ -290,6 +293,7 @@ test("lifecycle session shutdown disposes the exact endpoint once", async () => 
 		expect(stop).toHaveBeenCalledTimes(1);
 		expect(tracker.result.fenced).toBe(true);
 	} finally {
+		await brokerOwnerForTest(cwd)?.stop();
 		stop.mockRestore();
 	}
 });
@@ -361,6 +365,26 @@ test("SDK broker registration records an absolute lifecycle scope", async () => 
 	} finally {
 		await brokerOwnerForTest(agentDir)?.stop();
 	}
+});
+
+test("harness test seam keeps the SDK endpoint but skips detached broker discovery", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-harness-no-broker-"));
+	const agentDir = path.join(cwd, ".agent");
+	const sessionId = "harness-no-broker";
+	dirs.push(cwd);
+	process.env.GJC_NOTIFICATIONS = "1";
+	process.env.GJC_HARNESS_TEST_DISABLE_BROKER = "1";
+	process.env.GJC_HARNESS_TEST_NODE_MODULES = path.join(cwd, "node_modules");
+
+	const handlers = start(context(cwd, sessionId), {
+		get: () => undefined,
+		getAgentDir: () => agentDir,
+	} as unknown as Settings);
+	await waitFor(() => fs.existsSync(path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`)), "SDK endpoint");
+
+	expect(brokerOwnerForTest(agentDir)).toBeUndefined();
+	expect(fs.existsSync(path.join(agentDir, "sdk", "broker.json"))).toBe(false);
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, context(cwd, sessionId));
 });
 
 test("ExtensionRunner forwards SDK permission providers into its production context", () => {


### PR DESCRIPTION
## Summary

Replacement for closed #2224 and #2238, limited to the leak paths those PRs exposed.

- Give every directly exercised notification extension an isolated temporary agent directory.
- Shut down the in-process notification runtime, stop the exact retained SDK broker owner, then remove the temporary root.
- Preserve partial-start evidence: cleanup attempts every registered runtime/broker and throws after aggregation; roots are removed only after verified cleanup.
- Register SDK session shutdown fallbacks with afterEach before session startup, including the config/session fixtures, so body failures cannot bypass runtime teardown.
- Isolate harness CLI subprocesses from operator notification state while preserving SDK endpoints. The broker-disable seam requires both harness-test sentinels and is explicitly forwarded to detached/tmux owners.
- Restore inherited lifecycle env and global agentDir values in the autoresume fixture.
- Reap the two lifecycle SDK-host fixture brokers through `brokerOwnerForTest(agentDir)?.stop()`.

## Process safety

- No PID-, process-name-, or broad signal teardown was added. `git diff --name-only -G'process\.kill|child\.kill|SIGTERM|SIGKILL|killall' origin/dev...HEAD` is empty.
- `harness-control-plane/owner.ts`, `harness-tmux-owner.test.ts`, and the owner-routing teardown tests are unchanged. The only `commands/harness.ts` change explicitly propagates the two-key test seam.
- Broker cleanup uses the retained `BrokerOwner`, whose `stop()` reaps the exact spawned `ChildProcess`; no discovery PID is signalled by these fixtures.
- Existing reused-PID protection passed: `broker never signals a PID reused after its lifecycle marker was written`.

## Verification

Exact head: `aad342a6e7cdfd77b143c42fe22dd948163ec3c5`

- `bun run --cwd packages/coding-agent check`
- notification suite twice: **590 pass, 0 fail** on each run (`bun test packages/coding-agent/test/notifications*.test.ts`)
- harness + SDK host matrix: **90 pass, 7 platform skips, 0 fail**
- SDK host suite: **36 pass, 0 fail**
- exact-child and reused-PID safety tests: **2 pass, 0 fail**
- `bun run ci:test:smoke`

Residue checks after each notification/harness run:

- matching worktree SDK brokers: **0**
- operator broker discovery: **absent before and after**
- operator Telegram roots registry SHA-256 unchanged: `148dcb955dedcd262e6e0190921467b428881ce192c2f8129e395dfaff3320ea`
- `gjc-notif-*`, `gjc-sdk-subagent-*`, `gjc-sdk-notif-spawned-*`, and `gjc-harness-root-registry-*` roots: **0**

Exact diff against current `dev` (`68538a6e7282eab51a26eab4965535f284d8ad1b`): **13 files, +420/-93**.