### PR TITLE
fix(coding-agent): classify midrun SDK test seams

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Cooperative mid-run context maintenance now waits at a cancellation-aware FIFO consumer-drain checkpoint before flushing or rewriting session history. Materialized tool results and steering messages are synchronously canonicalized first; aborted barriers and hook/signal-cancelled compactions settle without rewriting or scheduling a continuation. Promotion, pruning, and compaction each start a clean provider/prompt-cache epoch. Script-aware #2067 unsent-delta accounting remains cache-free and distinct from the lifecycle checkpoint.
+- Classified the cooperative mid-run maintenance driver and token estimator test seams as locked non-public SDK exclusions, restoring deterministic operation-inventory generation and post-merge dev CI coverage.
 
 ### Added
 

--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -46,6 +46,10 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"agent_session:markPlanCompactAbortPending": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:clearPlanCompactAbortPending": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:enqueueCustomMessageDisplay": "internal accessor/plumbing, not a user-facing control seam",
+	"agent_session:runMidRunMaintenanceForTests": "test-only maintenance seam, not a user-facing SDK control seam",
+	"agent_session:estimateMidRunContextTokensForTests": "test-only estimator seam, not a user-facing SDK control seam",
+	"agent_session:activeMidRunBarrierCountForTests": "read-only test seam, not a user-facing SDK control seam",
+	"agent_session:activeMidRunMaintenanceCountForTests": "read-only test seam, not a user-facing SDK control seam",
 	"agent_session:getAgentId": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:emitNotice": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:subscribe": "internal accessor/plumbing, not a user-facing control seam",
@@ -587,6 +591,22 @@ function nextMemberStart(tokens: readonly Token[], start: number, classEnd: numb
 
 type MethodDeclaration = { end: number; name?: string };
 
+type ParsedMemberName = { computed: boolean; end: number; name?: string };
+
+function parseMemberName(tokens: readonly Token[], start: number): ParsedMemberName | undefined {
+	const direct = tokens[start];
+	if (isMemberName(direct)) return { computed: false, end: start + 1, name: memberName(direct!) };
+	if (direct?.text !== "[" || tokens[start + 2]?.text !== "]") return undefined;
+	const computed = tokens[start + 1];
+	if (computed?.kind === "string" || computed?.kind === "number") {
+		return { computed: true, end: start + 3, name: memberName(computed) };
+	}
+	if (computed?.kind === "template" && !computed.hasSubstitution) {
+		return { computed: true, end: start + 3, name: computed.value };
+	}
+	return undefined;
+}
+
 function scanMethodDeclaration(
 	tokens: readonly Token[],
 	start: number,
@@ -597,20 +617,29 @@ function scanMethodDeclaration(
 	if (tokens[index]?.text === "async" && tokens[index + 1]?.text !== "(") index++;
 	if (tokens[index]?.text === "*") index++;
 	const candidate = tokens[index];
-	if (!isMemberName(candidate)) return undefined;
-
-	const afterName = skipTypeParameters(tokens, index + 1);
-	if ((candidate!.text === "get" || candidate!.text === "set") && isMemberName(tokens[afterName])) {
-		const accessorEnd = skipTypeParameters(tokens, afterName + 1);
-		if (tokens[accessorEnd]?.text === "(") {
-			const close = matchingToken(tokens, accessorEnd, "(", ")");
-			if (close !== undefined) return { end: memberEnd(tokens, close + 1, classEnd) };
-		}
+	if (candidate?.text === "get" || candidate?.text === "set") {
+		const accessor = parseMemberName(tokens, index + 1);
+		if (!accessor) return undefined;
+		const accessorEnd = skipTypeParameters(tokens, accessor.end);
+		if (tokens[accessorEnd]?.text !== "(") return undefined;
+		const close = matchingToken(tokens, accessorEnd, "(", ")");
+		if (close === undefined) return undefined;
+		return {
+			end: memberEnd(tokens, close + 1, classEnd),
+			name: accessor.name?.endsWith("ForTests") ? accessor.name : undefined,
+		};
 	}
+
+	const method = parseMemberName(tokens, index);
+	if (!method) return undefined;
+	const afterName = skipTypeParameters(tokens, method.end);
 	if (tokens[afterName]?.text !== "(") return undefined;
 	const close = matchingToken(tokens, afterName, "(", ")");
 	if (close === undefined) return undefined;
-	return { end: memberEnd(tokens, close + 1, classEnd), name: memberName(candidate!) };
+	return {
+		end: memberEnd(tokens, close + 1, classEnd),
+		name: method.computed && !method.name?.endsWith("ForTests") ? undefined : method.name,
+	};
 }
 
 export function scanAgentSessionMethods(sourceText: string): string[] {

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -4086,6 +4086,78 @@
 		]
 	},
 	{
+		"sourceId": "agent_session:activeMidRunBarrierCountForTests",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "read-only test seam, not a user-facing SDK control seam",
+		"adapterMappings": {
+			"telegram": "generic_safe",
+			"discord": "generic_safe",
+			"slack": "generic_safe",
+			"mcp": "generic_safe",
+			"acp": "generic_safe",
+			"daemonCli": "generic_safe"
+		},
+		"testIds": [
+			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
+		]
+	},
+	{
+		"sourceId": "agent_session:activeMidRunMaintenanceCountForTests",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "read-only test seam, not a user-facing SDK control seam",
+		"adapterMappings": {
+			"telegram": "generic_safe",
+			"discord": "generic_safe",
+			"slack": "generic_safe",
+			"mcp": "generic_safe",
+			"acp": "generic_safe",
+			"daemonCli": "generic_safe"
+		},
+		"testIds": [
+			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
+		]
+	},
+	{
+		"sourceId": "agent_session:runMidRunMaintenanceForTests",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "test-only maintenance seam, not a user-facing SDK control seam",
+		"adapterMappings": {
+			"telegram": "generic_safe",
+			"discord": "generic_safe",
+			"slack": "generic_safe",
+			"mcp": "generic_safe",
+			"acp": "generic_safe",
+			"daemonCli": "generic_safe"
+		},
+		"testIds": [
+			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
+		]
+	},
+	{
+		"sourceId": "agent_session:estimateMidRunContextTokensForTests",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "test-only estimator seam, not a user-facing SDK control seam",
+		"adapterMappings": {
+			"telegram": "generic_safe",
+			"discord": "generic_safe",
+			"slack": "generic_safe",
+			"mcp": "generic_safe",
+			"acp": "generic_safe",
+			"daemonCli": "generic_safe"
+		},
+		"testIds": [
+			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
+		]
+	},
+	{
 		"sourceId": "agent_session:abort",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",

--- a/packages/coding-agent/test/sdk-operation-inventory.test.ts
+++ b/packages/coding-agent/test/sdk-operation-inventory.test.ts
@@ -103,6 +103,20 @@ describe("SDK operation inventory", () => {
 		});
 	}
 
+	it("classifies explicit AgentSession test seams as non-public authority", async () => {
+		const source = await Bun.file(path.join(repoRoot, "packages/coding-agent/src/session/agent-session.ts")).text();
+		const sourceIds = scanAgentSessionMethods(source).filter(sourceId => sourceId.endsWith("ForTests"));
+		expect(sourceIds).toEqual(
+			expect.arrayContaining([
+				"agent_session:runMidRunMaintenanceForTests",
+				"agent_session:estimateMidRunContextTokensForTests",
+				"agent_session:activeMidRunBarrierCountForTests",
+				"agent_session:activeMidRunMaintenanceCountForTests",
+			]),
+		);
+		expect(pendingReviewErrors(sourceIds.map(sourceId => ({ sourceId })))).toEqual([]);
+	});
+
 	it("discovers AgentSession method declarations independent of modifiers and layout", () => {
 		const seams = scanAgentSessionMethods(`
 			function decorator(_: unknown, _context: unknown) {}
@@ -116,6 +130,7 @@ describe("SDK operation inventory", () => {
 				override overrideable(): void {}
 				get accessor(): string { return "value"; }
 				set accessor(_value: string) {}
+				get accessorForTests(): number { return 1; }
 				*generatorMethod(): Generator<string> { yield "value"; }
 				@decorator
 				decoratedMethod(): void {}
@@ -132,6 +147,7 @@ describe("SDK operation inventory", () => {
 			"agent_session:privateMethod",
 			"agent_session:staticMethod",
 			"agent_session:overrideable",
+			"agent_session:accessorForTests",
 			"agent_session:generatorMethod",
 			"agent_session:decoratedMethod",
 			"agent_session:multilineMethod",
@@ -168,10 +184,30 @@ describe("SDK operation inventory", () => {
 					yield \`{\${value}}\`;
 				}
 				["computed"]() {}
+				["resetForTests"]() {}
+				get ["stateForTests"](): number { return 1; }
+				[\`templateMethodForTests\`]() {}
+				get [\`templateGetterForTests\`](): number { return 1; }
+				set [\`templateSetterForTests\`](_value: number) {}
+				[dynamicForTests]() {}
 				field = () => ({ text: "notAMethod() {}" });
 			}
 		`);
-		expect(seams).toEqual(["agent_session:decoratedPrivate"]);
+		expect(seams).toEqual([
+			"agent_session:decoratedPrivate",
+			"agent_session:resetForTests",
+			"agent_session:stateForTests",
+			"agent_session:templateMethodForTests",
+			"agent_session:templateGetterForTests",
+			"agent_session:templateSetterForTests",
+		]);
+		expect(pendingReviewErrors(seams.slice(1).map(sourceId => ({ sourceId })))).toEqual([
+			"Pending review source seam: agent_session:resetForTests. Add it to SEAM_TO_SDK or LOCKED_EXCLUSIONS.",
+			"Pending review source seam: agent_session:stateForTests. Add it to SEAM_TO_SDK or LOCKED_EXCLUSIONS.",
+			"Pending review source seam: agent_session:templateMethodForTests. Add it to SEAM_TO_SDK or LOCKED_EXCLUSIONS.",
+			"Pending review source seam: agent_session:templateGetterForTests. Add it to SEAM_TO_SDK or LOCKED_EXCLUSIONS.",
+			"Pending review source seam: agent_session:templateSetterForTests. Add it to SEAM_TO_SDK or LOCKED_EXCLUSIONS.",
+		]);
 	});
 
 	it("finds direct and nested ACP method cases without reading strings or interpolated templates", () => {


### PR DESCRIPTION
## Summary

- classify `runMidRunMaintenanceForTests` and `estimateMidRunContextTokensForTests` as locked test-only, non-public SDK seams
- regenerate the deterministic SDK operation inventory
- pin regression coverage that discovers explicit `ForTests` AgentSession methods and requires every one to be classified

## Regression

Repairs post-merge Dev CI run https://github.com/Yeachan-Heo/gajae-code/actions/runs/29351504904, failed job `87148744707` after PR #2213 merged. The failure was deterministic: `sdk-operation-inventory.test.ts` rejected both unclassified source seams.

## Verification

- `bun test packages/coding-agent/test/sdk-operation-inventory.test.ts` — 13 pass, 0 fail
- `bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts --check` — pass
- `bun --cwd=packages/coding-agent run check` — pass
- `bun test --shard=1/8` in `packages/coding-agent` — 1365 pass, 68 skip, 0 fail
- `bun --cwd=packages/coding-agent run build` — pass

The package-wide unsharded test command was also attempted, but exceeded the 30-minute local bound after two unrelated #2035 timing tests hit their 5-second per-test timeout. The exact failed CI shard and focused inventory contract are green.

Signed-off-by: Yeachan-Heo <yeachan-heo@gajae.dev>