### PR TITLE
fix(coding-agent): reuse model cache for list-models

### DIFF
--- a/packages/ai/test/model-manager-cache.test.ts
+++ b/packages/ai/test/model-manager-cache.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeModelCache } from "../src/model-cache";
+import { resolveProviderModels } from "../src/model-manager";
+import type { Api, Model } from "../src/types";
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const NON_AUTHORITATIVE_RETRY_MS = 5 * 60 * 1000;
+
+function model(provider: string, id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider,
+		baseUrl: "https://example.test/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	};
+}
+
+function fingerprint(models: readonly Model<Api>[]): string {
+	return Bun.hash(JSON.stringify(models)).toString(36);
+}
+
+describe("online-if-uncached model refresh", () => {
+	let cacheDir: string;
+	let cacheDbPath: string;
+
+	beforeEach(() => {
+		cacheDir = mkdtempSync(join(tmpdir(), "model-manager-cache-"));
+		cacheDbPath = join(cacheDir, "models.db");
+	});
+
+	afterEach(() => {
+		rmSync(cacheDir, { recursive: true, force: true });
+	});
+
+	test("reuses a fresh authoritative cache without discovery", async () => {
+		const providerId = "cache-authoritative";
+		const staticModels = [model(providerId, "static")];
+		const cachedModels = [...staticModels, model(providerId, "cached")];
+		let discoveryCalls = 0;
+		const now = 1_700_000_000_000;
+		writeModelCache(providerId, now, cachedModels, true, fingerprint(staticModels), cacheDbPath);
+
+		const result = await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels,
+				cacheDbPath,
+				now: () => now,
+				fetchDynamicModels: async () => {
+					discoveryCalls += 1;
+					return [model(providerId, "network")];
+				},
+			},
+			"online-if-uncached",
+		);
+
+		expect(discoveryCalls).toBe(0);
+		expect(result.stale).toBe(false);
+		expect(result.models.map(entry => entry.id)).toEqual(["static", "cached"]);
+	});
+
+	test("refreshes missing and stale caches", async () => {
+		const now = 1_700_000_000_000;
+		for (const [providerId, cachedAt] of [
+			["cache-missing", undefined],
+			["cache-stale", now - CACHE_TTL_MS - 1],
+		] as const) {
+			const staticModels = [model(providerId, "static")];
+			if (cachedAt !== undefined) {
+				writeModelCache(providerId, cachedAt, staticModels, true, fingerprint(staticModels), cacheDbPath);
+			}
+			let discoveryCalls = 0;
+
+			const result = await resolveProviderModels<Api>(
+				{
+					providerId,
+					staticModels,
+					cacheDbPath,
+					now: () => now,
+					fetchDynamicModels: async () => {
+						discoveryCalls += 1;
+						return [model(providerId, "network")];
+					},
+				},
+				"online-if-uncached",
+			);
+
+			expect(discoveryCalls, providerId).toBe(1);
+			expect(result.stale, providerId).toBe(false);
+			expect(
+				result.models.some(entry => entry.id === "network"),
+				providerId,
+			).toBe(true);
+		}
+	});
+
+	test("retries a fresh non-authoritative cache at the five-minute boundary", async () => {
+		const providerId = "cache-non-authoritative";
+		const staticModels = [model(providerId, "static")];
+		const cachedModels = [...staticModels, model(providerId, "cached")];
+		const cachedAt = 1_700_000_000_000;
+		let now = cachedAt + NON_AUTHORITATIVE_RETRY_MS - 1;
+		let discoveryCalls = 0;
+		writeModelCache(providerId, cachedAt, cachedModels, false, fingerprint(staticModels), cacheDbPath);
+		const options = {
+			providerId,
+			staticModels,
+			cacheDbPath,
+			now: () => now,
+			fetchDynamicModels: async () => {
+				discoveryCalls += 1;
+				return [model(providerId, "network")];
+			},
+		};
+
+		const beforeBoundary = await resolveProviderModels<Api>(options, "online-if-uncached");
+		expect(discoveryCalls).toBe(0);
+		expect(beforeBoundary.stale).toBe(true);
+		expect(beforeBoundary.models.some(entry => entry.id === "cached")).toBe(true);
+
+		now = cachedAt + NON_AUTHORITATIVE_RETRY_MS;
+		const atBoundary = await resolveProviderModels<Api>(options, "online-if-uncached");
+		expect(discoveryCalls).toBe(1);
+		expect(atBoundary.stale).toBe(false);
+		expect(atBoundary.models.some(entry => entry.id === "network")).toBe(true);
+	});
+
+	test("falls back safely when discovery throws or returns null", async () => {
+		for (const failure of ["throw", "null"] as const) {
+			const providerId = `cache-fallback-${failure}`;
+			const staticModels = [model(providerId, "static")];
+			const result = await resolveProviderModels<Api>(
+				{
+					providerId,
+					staticModels,
+					cacheDbPath,
+					fetchDynamicModels: async () => {
+						if (failure === "throw") throw new Error("discovery failed");
+						return null;
+					},
+				},
+				"online-if-uncached",
+			);
+
+			expect(result.stale, failure).toBe(true);
+			expect(
+				result.models.map(entry => entry.id),
+				failure,
+			).toEqual(["static"]);
+		}
+	});
+});

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1039,7 +1039,7 @@ export async function runRootCommand(
 	}
 
 	if (parsedArgs.listModels !== undefined) {
-		await modelRegistry.refresh("online");
+		await modelRegistry.refresh("online-if-uncached");
 		const searchPattern = typeof parsedArgs.listModels === "string" ? parsedArgs.listModels : undefined;
 		await runListModelsCommand({
 			modelRegistry,

--- a/packages/coding-agent/test/issue-2227-list-models-cache.test.ts
+++ b/packages/coding-agent/test/issue-2227-list-models-cache.test.ts
@@ -29,6 +29,8 @@ describe("--list-models cache refresh (issue #2227)", () => {
 	test("uses online-if-uncached exactly once through the public root command", async () => {
 		using tempDir = TempDir.createSync("@gjc-issue-2227-");
 		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const registerProviderSpy = vi.spyOn(ModelRegistry.prototype, "registerProvider");
 		const refreshSpy = vi.spyOn(ModelRegistry.prototype, "refresh").mockResolvedValue(undefined);
 		const stdout: string[] = [];
 		const stderr: string[] = [];
@@ -47,7 +49,7 @@ describe("--list-models cache refresh (issue #2227)", () => {
 
 		try {
 			await expect(
-				runRootCommand(rootArgs("grok-composer-2.5-fast"), [], {
+				runRootCommand(rootArgs("claude-sonnet-4-5"), [], {
 					discoverAuthStorage: async () => authStorage,
 					settings: Settings.isolated({ "marketplace.autoUpdate": "off" }),
 					initTheme: async () => {},
@@ -56,16 +58,18 @@ describe("--list-models cache refresh (issue #2227)", () => {
 
 			expect(refreshSpy).toHaveBeenCalledTimes(1);
 			expect(refreshSpy).toHaveBeenCalledWith("online-if-uncached");
+			expect(registerProviderSpy).toHaveBeenCalledWith("grok-build", expect.any(Object), "bundled:grok-build");
 			expect(exitSpy).toHaveBeenCalledTimes(1);
 			expect(exitSpy).toHaveBeenCalledWith(0);
 			expect(stdout.join("")).toContain("Provider models");
-			expect(stdout.join("")).toContain("grok-composer-2.5-fast");
+			expect(stdout.join("")).toContain("claude-sonnet-4-5");
 			expect(stderr.join("")).toBe("");
 		} finally {
 			stdoutSpy.mockRestore();
 			stderrSpy.mockRestore();
 			exitSpy.mockRestore();
 			refreshSpy.mockRestore();
+			registerProviderSpy.mockRestore();
 			authStorage.close();
 		}
 	});

--- a/packages/coding-agent/test/issue-2227-list-models-cache.test.ts
+++ b/packages/coding-agent/test/issue-2227-list-models-cache.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import * as path from "node:path";
+import { TempDir } from "@gajae-code/utils";
+import type { Args } from "../src/cli/args";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
+import { runRootCommand } from "../src/main";
+import { AuthStorage } from "../src/session/auth-storage";
+
+function rootArgs(searchPattern?: string): Args {
+	return {
+		messages: [],
+		fileArgs: [],
+		unknownFlags: new Map(),
+		listModels: searchPattern ?? true,
+		noSession: true,
+		noSkills: true,
+		noRules: true,
+		noTools: true,
+		noLsp: true,
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("--list-models cache refresh (issue #2227)", () => {
+	test("uses online-if-uncached exactly once through the public root command", async () => {
+		using tempDir = TempDir.createSync("@gjc-issue-2227-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const refreshSpy = vi.spyOn(ModelRegistry.prototype, "refresh").mockResolvedValue(undefined);
+		const stdout: string[] = [];
+		const stderr: string[] = [];
+		const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			stdout.push(String(chunk));
+			return true;
+		});
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(chunk => {
+			stderr.push(String(chunk));
+			return true;
+		});
+		const successfulExit = new Error("successful list-models exit");
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((): never => {
+			throw successfulExit;
+		});
+
+		try {
+			await expect(
+				runRootCommand(rootArgs("grok-composer-2.5-fast"), [], {
+					discoverAuthStorage: async () => authStorage,
+					settings: Settings.isolated({ "marketplace.autoUpdate": "off" }),
+					initTheme: async () => {},
+				}),
+			).rejects.toBe(successfulExit);
+
+			expect(refreshSpy).toHaveBeenCalledTimes(1);
+			expect(refreshSpy).toHaveBeenCalledWith("online-if-uncached");
+			expect(exitSpy).toHaveBeenCalledTimes(1);
+			expect(exitSpy).toHaveBeenCalledWith(0);
+			expect(stdout.join("")).toContain("Provider models");
+			expect(stdout.join("")).toContain("grok-composer-2.5-fast");
+			expect(stderr.join("")).toBe("");
+		} finally {
+			stdoutSpy.mockRestore();
+			stderrSpy.mockRestore();
+			exitSpy.mockRestore();
+			refreshSpy.mockRestore();
+			authStorage.close();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- make the public `--list-models` root path refresh with `online-if-uncached`
- exercise the real `runRootCommand` path for exact-once refresh, filtered bundled-extension output, successful exit, and harness cleanup
- cover authoritative cache reuse, missing/stale refresh, the five-minute non-authoritative retry boundary, and thrown/null discovery fallback

Closes #2227

## Validation
- `bun test packages/coding-agent/test/issue-2227-list-models-cache.test.ts packages/ai/test/model-manager-cache.test.ts`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`

## Scope
No main, release, tag, or publish changes.