### PR TITLE
fix: enforce Codex GPT-5.6 prompt cap

### DIFF
--- a/packages/ai/src/context-cap-policy.ts
+++ b/packages/ai/src/context-cap-policy.ts
@@ -1,0 +1,59 @@
+import type { Api, Model } from "./types";
+
+export interface CodexGpt56ContextCapPolicy {
+	fallback: number;
+	ceiling: number;
+}
+
+export const CODEX_GPT_5_6_CONTEXT_CAP: CodexGpt56ContextCapPolicy = {
+	fallback: 272_000,
+	ceiling: 272_000,
+};
+
+const CODEX_GPT_5_6_MODEL_IDS: ReadonlySet<string> = new Set([
+	"gpt-5.6",
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+	"gpt-5.6-luna",
+]);
+
+export function isCodexProductTransport(model: Pick<Model<Api>, "api" | "provider">): boolean {
+	return model.provider === "openai-codex" || model.api === "openai-codex-responses";
+}
+
+export function isCodexGpt56Tier(model: Pick<Model<Api>, "id">): boolean {
+	return CODEX_GPT_5_6_MODEL_IDS.has(model.id.toLowerCase());
+}
+
+export function resolveCodexGpt56DiscoveryContext(
+	model: Pick<Model<Api>, "api" | "id" | "provider">,
+	rawContextWindow: unknown,
+	policy: CodexGpt56ContextCapPolicy = CODEX_GPT_5_6_CONTEXT_CAP,
+): number {
+	const observed = isPositiveFiniteNumber(rawContextWindow) ? rawContextWindow : policy.fallback;
+	if (!isCodexGpt56Tier(model) || !isCodexProductTransport(model)) {
+		return observed;
+	}
+	return Math.min(observed, policy.ceiling);
+}
+
+export function applyFinalCodexGpt56ContextCap<TApi extends Api>(
+	models: readonly Model<TApi>[],
+	policy: CodexGpt56ContextCapPolicy = CODEX_GPT_5_6_CONTEXT_CAP,
+): Model<TApi>[] {
+	return models.map(model => {
+		if (
+			!isCodexGpt56Tier(model as Model<Api>) ||
+			!isCodexProductTransport(model as Model<Api>) ||
+			!isPositiveFiniteNumber(model.contextWindow) ||
+			model.contextWindow <= policy.ceiling
+		) {
+			return model;
+		}
+		return { ...model, contextWindow: policy.ceiling };
+	});
+}
+
+function isPositiveFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0;
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -4,6 +4,7 @@ export * from "./auth-broker";
 export { type AuthGatewayBootOptions, type ModelResolver, startAuthGateway } from "./auth-gateway/server";
 export * from "./auth-gateway/types";
 export * from "./auth-storage";
+export * from "./context-cap-policy";
 export * from "./model-cache";
 export * from "./model-manager";
 export * from "./model-thinking";

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -1,3 +1,4 @@
+import { applyFinalCodexGpt56ContextCap } from "./context-cap-policy";
 import { readModelCache, writeModelCache } from "./model-cache";
 import { isRetiredModel, isRetiredModelKey } from "./model-retirements";
 import { applyGeneratedModelPolicies, enrichModelThinking } from "./model-thinking";
@@ -98,7 +99,7 @@ function passModelList<TApi extends Api>(value: unknown): Model<TApi>[] {
 		out.push(enrichModelThinking(item as Model<TApi>));
 	}
 	applyGeneratedModelPolicies(out as Model<Api>[]);
-	return out;
+	return applyFinalCodexGpt56ContextCap(out);
 }
 
 /**
@@ -161,11 +162,13 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	const cacheModels = dynamicFetchSucceeded ? [] : normalizeModelList<TApi>(cache?.models ?? []);
 	const dynamicModels = fetchedDynamicModels ?? [];
 	const mergedWithCache = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), cacheModels);
-	const models = mergeDynamicModels(mergedWithCache, dynamicModels);
+	const models = applyFinalCodexGpt56ContextCap(mergeDynamicModels(mergedWithCache, dynamicModels));
 	const dynamicAuthoritative = !hasDynamicFetcher || dynamicFetchSucceeded || shouldUseFreshCacheAsAuthoritative;
 	if (shouldFetchFromNetwork) {
 		if (dynamicFetchSucceeded) {
-			const snapshotModels = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), dynamicModels);
+			const snapshotModels = applyFinalCodexGpt56ContextCap(
+				mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), dynamicModels),
+			);
 			writeModelCache(options.providerId, now(), snapshotModels, true, staticFingerprint, dbPath);
 		} else {
 			// Dynamic fetch failed — update cache with a non-authoritative snapshot so
@@ -174,9 +177,11 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 			writeModelCache(
 				options.providerId,
 				now(),
-				mergeDynamicModels(
-					mergeModelSources(staticModels, modelsDevModels),
-					normalizeModelList<TApi>(latestCache?.models ?? cache?.models ?? []),
+				applyFinalCodexGpt56ContextCap(
+					mergeDynamicModels(
+						mergeModelSources(staticModels, modelsDevModels),
+						normalizeModelList<TApi>(latestCache?.models ?? cache?.models ?? []),
+					),
 				),
 				false,
 				staticFingerprint,
@@ -393,7 +398,7 @@ function normalizeModelList<TApi extends Api>(value: unknown): Model<TApi>[] {
 			models.push(enrichModelThinking(item as Model<TApi>));
 		}
 	}
-	return models;
+	return applyFinalCodexGpt56ContextCap(models);
 }
 
 function isModelLike(value: unknown): value is Model<Api> {

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -1,3 +1,4 @@
+import { CODEX_GPT_5_6_CONTEXT_CAP, isCodexGpt56Tier, isCodexProductTransport } from "./context-cap-policy";
 import { resolveOpenAICompat } from "./providers/openai-completions-compat";
 import type { Api, Model as ApiModel, ThinkingConfig } from "./types";
 import { isClaudeForcedToolChoiceIncapableModelId } from "./utils/tool-choice-capability";
@@ -477,15 +478,13 @@ function applyGpt55ContextWindow(model: ApiModel<Api>, parsedModel: OpenAIModel)
 	}
 	return false;
 }
-const GPT_5_6_TIER_VARIANTS: ReadonlySet<OpenAIVariant> = new Set(["base", "sol", "terra", "luna"]);
-
-function applyGpt56ContextWindow(model: ApiModel<Api>, parsedModel: OpenAIModel): boolean {
-	if (!semverGte(parsedModel.version, "5.6") || !GPT_5_6_TIER_VARIANTS.has(parsedModel.variant)) {
+function applyGpt56ContextWindow(model: ApiModel<Api>): boolean {
+	if (!isCodexGpt56Tier(model) || !isCodexProductTransport(model)) {
 		return false;
 	}
-	// GPT-5.6 tiers enforce a ~373K usable prompt budget on both transports
-	// (matches the openai-codex live catalog), despite the 1M+ marketing window.
-	model.contextWindow = 373_000;
+	// Codex product metadata is bounded by the currently enforced prompt cap.
+	// Smaller observed limits remain authoritative; first-party OpenAI is untouched.
+	model.contextWindow = Math.min(model.contextWindow, CODEX_GPT_5_6_CONTEXT_CAP.ceiling);
 	return true;
 }
 
@@ -493,7 +492,7 @@ function applyOpenAICatalogPolicy(model: ApiModel<Api>, parsedModel: OpenAIModel
 	if (applyGpt55ContextWindow(model, parsedModel)) {
 		return;
 	}
-	if (applyGpt56ContextWindow(model, parsedModel)) {
+	if (applyGpt56ContextWindow(model)) {
 		return;
 	}
 	// OpenAI code backend models: 400K figure includes output budget; input window is 272K.

--- a/packages/ai/src/utils/discovery/codex.ts
+++ b/packages/ai/src/utils/discovery/codex.ts
@@ -1,10 +1,10 @@
 import * as z from "zod/v4";
+import { resolveCodexGpt56DiscoveryContext } from "../../context-cap-policy";
 import { CODEX_BASE_URL, OPENAI_HEADER_VALUES, OPENAI_HEADERS } from "../../providers/openai-codex/constants";
 import type { Model } from "../../types";
 import { isRecord } from "../../utils";
 
 const DEFAULT_MODEL_LIST_PATHS = ["/codex/models", "/models"] as const;
-const DEFAULT_CONTEXT_WINDOW = 272_000;
 const DEFAULT_MAX_TOKENS = 128_000;
 const DEFAULT_CODEX_CLIENT_VERSION = "0.99.0";
 const NPM_CODEX_LATEST_URL = "https://registry.npmjs.org/@openai%2Fcodex/latest";
@@ -258,7 +258,8 @@ function normalizeCodexModelEntry(entry: unknown, baseUrl: string): NormalizedCo
 	}
 
 	const name = toNonEmptyString(payload.display_name) ?? slug;
-	const contextWindow = toPositiveInt(payload.context_window) ?? DEFAULT_CONTEXT_WINDOW;
+	const modelIdentity = { id: slug, api: "openai-codex-responses", provider: "openai-codex" } as const;
+	const contextWindow = resolveCodexGpt56DiscoveryContext(modelIdentity, payload.context_window);
 	const maxTokens = Math.min(DEFAULT_MAX_TOKENS, contextWindow);
 	const reasoning = supportsReasoning(payload.default_reasoning_level, payload.supported_reasoning_levels);
 	const input = normalizeInputModalities(payload.input_modalities);
@@ -344,16 +345,6 @@ function toNonEmptyString(value: unknown): string | null {
 	}
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : null;
-}
-
-function toPositiveInt(value: unknown): number | null {
-	if (typeof value !== "number" || !Number.isFinite(value)) {
-		return null;
-	}
-	if (value <= 0) {
-		return null;
-	}
-	return Math.trunc(value);
 }
 
 function toFiniteNumber(value: unknown): number | null {

--- a/packages/ai/test/codex-discovery-context-cap.test.ts
+++ b/packages/ai/test/codex-discovery-context-cap.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { fetchCodexModels } from "../src/utils/discovery/codex";
+
+function response(contextWindow: unknown): Response {
+	return new Response(
+		JSON.stringify({
+			models: [
+				{
+					slug: "gpt-5.6-sol",
+					display_name: "GPT-5.6 Sol",
+					context_window: contextWindow,
+					supported_in_api: true,
+				},
+			],
+		}),
+		{ status: 200, headers: { "content-type": "application/json" } },
+	);
+}
+
+function fetchResponse(contextWindow: unknown): typeof fetch {
+	return (() => Promise.resolve(response(contextWindow))) as unknown as typeof fetch;
+}
+
+describe("Codex GPT-5.6 discovery context cap", () => {
+	it("uses the conservative fallback for absent metadata", async () => {
+		const result = await fetchCodexModels({
+			accessToken: "test-token",
+			clientVersion: "0.99.0",
+			fetchFn: fetchResponse(undefined),
+		});
+		expect(result?.models[0]?.contextWindow).toBe(272_000);
+	});
+
+	it("caps larger live metadata but preserves a smaller live cap", async () => {
+		for (const [observed, expected] of [
+			[373_000, 272_000],
+			[200_000, 200_000],
+		] as const) {
+			const result = await fetchCodexModels({
+				accessToken: "test-token",
+				clientVersion: "0.99.0",
+				fetchFn: fetchResponse(observed),
+			});
+			expect(result?.models[0]?.contextWindow).toBe(expected);
+		}
+	});
+});

--- a/packages/ai/test/context-cap-policy.test.ts
+++ b/packages/ai/test/context-cap-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import {
+	applyFinalCodexGpt56ContextCap,
+	CODEX_GPT_5_6_CONTEXT_CAP,
+	resolveCodexGpt56DiscoveryContext,
+} from "../src/context-cap-policy";
+import type { Api, Model } from "../src/types";
+
+function model(overrides: Partial<Model<Api>> = {}): Model<Api> {
+	return {
+		id: "gpt-5.6-sol",
+		name: "GPT-5.6 Sol",
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 373_000,
+		maxTokens: 128_000,
+		...overrides,
+	};
+}
+
+describe("Codex GPT-5.6 context cap policy", () => {
+	it("uses the conservative fallback and preserves smaller live limits", () => {
+		const identity = model();
+		expect(resolveCodexGpt56DiscoveryContext(identity, undefined)).toBe(272_000);
+		expect(resolveCodexGpt56DiscoveryContext(identity, 373_000)).toBe(272_000);
+		expect(resolveCodexGpt56DiscoveryContext(identity, 200_000)).toBe(200_000);
+	});
+
+	it("scopes the ceiling to exact tiers and Codex product transports", () => {
+		const capped = applyFinalCodexGpt56ContextCap([
+			model({ id: "gpt-5.6" }),
+			model({ id: "gpt-5.6-sol" }),
+			model({ id: "gpt-5.6-terra", provider: "custom" }),
+			model({ id: "gpt-5.6-luna", api: "openai-responses" }),
+			model({ id: "gpt-5.6-sol", api: "openai-responses", provider: "openai" }),
+			model({ id: "gpt-5.5" }),
+			model({ id: "gpt-5.6-codex" }),
+		]);
+		expect(capped.map(entry => entry.contextWindow)).toEqual([
+			272_000, 272_000, 272_000, 272_000, 373_000, 373_000, 373_000,
+		]);
+	});
+
+	it("supports a future authority increase without promoting stale smaller observations", () => {
+		const futurePolicy = { ...CODEX_GPT_5_6_CONTEXT_CAP, fallback: 372_000, ceiling: 372_000 };
+		const identity = model();
+		expect(resolveCodexGpt56DiscoveryContext(identity, undefined, futurePolicy)).toBe(372_000);
+		expect(resolveCodexGpt56DiscoveryContext(identity, 372_000, futurePolicy)).toBe(372_000);
+		expect(applyFinalCodexGpt56ContextCap([model({ contextWindow: 272_000 })], futurePolicy)[0]?.contextWindow).toBe(
+			272_000,
+		);
+		expect(applyFinalCodexGpt56ContextCap([model({ contextWindow: 373_000 })], futurePolicy)[0]?.contextWindow).toBe(
+			372_000,
+		);
+	});
+});

--- a/packages/ai/test/model-manager-context-cap.test.ts
+++ b/packages/ai/test/model-manager-context-cap.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeModelCache } from "../src/model-cache";
+import { resolveProviderModels } from "../src/model-manager";
+import type { Api, Model } from "../src/types";
+
+function codexModel(contextWindow: number): Model<Api> {
+	return {
+		id: "gpt-5.6-sol",
+		name: "GPT-5.6 Sol",
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow,
+		maxTokens: 128_000,
+	};
+}
+
+describe("model manager Codex GPT-5.6 cap", () => {
+	let cacheDir: string;
+	let cacheDbPath: string;
+
+	beforeEach(() => {
+		cacheDir = mkdtempSync(join(tmpdir(), "issue-2240-"));
+		cacheDbPath = join(cacheDir, "models.db");
+	});
+
+	afterEach(() => {
+		rmSync(cacheDir, { recursive: true, force: true });
+	});
+
+	it("downgrades a stale oversized cache when refresh fails", async () => {
+		const now = () => 1_800_000_000_000;
+		writeModelCache("openai-codex", now(), [codexModel(373_000)], false, "empty", cacheDbPath);
+		const result = await resolveProviderModels<Api>(
+			{
+				providerId: "openai-codex",
+				staticModels: [],
+				cacheDbPath,
+				now,
+				fetchDynamicModels: async () => null,
+			},
+			"online",
+		);
+		expect(result.models[0]?.contextWindow).toBe(272_000);
+	});
+
+	it("prefers a newly observed smaller live cap over stale larger cache metadata", async () => {
+		const now = () => 1_800_000_000_000;
+		writeModelCache("openai-codex", now(), [codexModel(373_000)], true, "empty", cacheDbPath);
+		const result = await resolveProviderModels<Api>(
+			{
+				providerId: "openai-codex",
+				staticModels: [],
+				cacheDbPath,
+				now,
+				fetchDynamicModels: async () => [codexModel(200_000)],
+			},
+			"online",
+		);
+		expect(result.models[0]?.contextWindow).toBe(200_000);
+	});
+});

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -419,32 +419,33 @@ describe("generated model policies", () => {
 		}
 	});
 
-	it("normalizes GPT-5.6 tier context windows to the 373K prompt budget", () => {
+	it("caps only Codex product GPT-5.6 tiers at the 272K prompt budget", () => {
 		const models: Model<Api>[] = [
 			{
-				...createModel({
-					id: "gpt-5.6-sol",
-					api: "openai-codex-responses",
-					provider: "openai-codex",
-				}),
+				...createModel({ id: "gpt-5.6-sol", api: "openai-codex-responses", provider: "openai-codex" }),
 				contextWindow: 1_050_000,
 				maxTokens: 128000,
 			},
 			{
-				...createModel({
-					id: "gpt-5.6-terra",
-					api: "openai-responses",
-					provider: "openai",
-				}),
-				contextWindow: 272000,
+				...createModel({ id: "gpt-5.6-terra", api: "openai-responses", provider: "openai" }),
+				contextWindow: 1_050_000,
+				maxTokens: 128000,
+			},
+			{
+				...createModel({ id: "gpt-5.6-luna", api: "openai-codex-responses", provider: "custom" }),
+				contextWindow: 200_000,
+				maxTokens: 128000,
+			},
+			{
+				...createModel({ id: "gpt-5.6-codex", api: "openai-codex-responses", provider: "openai-codex" }),
+				contextWindow: 373_000,
 				maxTokens: 128000,
 			},
 		];
 
 		applyGeneratedModelPolicies(models);
 
-		expect(models[0]?.contextWindow).toBe(373_000);
-		expect(models[1]?.contextWindow).toBe(373_000);
+		expect(models.map(model => model.contextWindow)).toEqual([272_000, 1_050_000, 200_000, 272_000]);
 		expect(models[0]?.applyPatchToolType).toBe("freeform");
 		expect(models[1]?.applyPatchToolType).toBe("freeform");
 	});

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -4,6 +4,7 @@ import {
 	type Api,
 	type AssistantMessageEventStream,
 	type AuthCredentialSelector,
+	applyFinalCodexGpt56ContextCap,
 	type CacheRetention,
 	type Context,
 	createModelManager,
@@ -1182,7 +1183,7 @@ export class ModelRegistry {
 		// Merge runtime extension models so they survive refresh() cycles
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
 		const withModelOverrides = this.#applyModelOverrides(combined, this.#modelOverrides);
-		this.#models = this.#applyRuntimeProviderOverrides(withModelOverrides);
+		this.#models = applyFinalCodexGpt56ContextCap(this.#applyRuntimeProviderOverrides(withModelOverrides));
 		this.#rebuildCanonicalIndex();
 		this.#lastStaticLoadMtime = this.#modelsConfigFile.getMtimeMs();
 	}
@@ -1824,7 +1825,7 @@ export class ModelRegistry {
 		// Merge runtime extension models so they survive online discovery completion
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
 		const withModelOverrides = this.#applyModelOverrides(combined, this.#modelOverrides);
-		this.#models = this.#applyRuntimeProviderOverrides(withModelOverrides);
+		this.#models = applyFinalCodexGpt56ContextCap(this.#applyRuntimeProviderOverrides(withModelOverrides));
 		this.#rebuildCanonicalIndex();
 	}
 
@@ -1833,6 +1834,7 @@ export class ModelRegistry {
 		strategy: ModelRefreshStrategy,
 	): Promise<Model<Api>[]> {
 		const cached = readModelCache<Api>(providerConfig.provider, 24 * 60 * 60 * 1000, Date.now, this.#cacheDbPath);
+		const cachedModels = applyFinalCodexGpt56ContextCap(cached?.models ?? []);
 		const requiresAuth = !this.#keylessProviders.has(providerConfig.provider);
 		if (requiresAuth) {
 			const apiKey = await this.#peekApiKeyForProvider(providerConfig.provider);
@@ -1843,10 +1845,10 @@ export class ModelRegistry {
 					optional: providerConfig.optional ?? false,
 					stale: cached !== null,
 					fetchedAt: cached?.updatedAt,
-					models: cached?.models.map(model => model.id) ?? [],
+					models: cachedModels.map(model => model.id),
 				});
 				this.#lastDiscoveryWarnings.delete(providerConfig.provider);
-				return cached?.models ?? [];
+				return cachedModels;
 			}
 		}
 
@@ -2899,13 +2901,15 @@ export class ModelRegistry {
 			if (config.oauth?.modifyModels) {
 				const credential = this.authStorage.getOAuthCredential(providerName);
 				if (credential) {
-					this.#models = config.oauth.modifyModels(withRuntimeTransportOverride, credential);
+					this.#models = applyFinalCodexGpt56ContextCap(
+						config.oauth.modifyModels(withRuntimeTransportOverride, credential),
+					);
 					this.#rebuildCanonicalIndex();
 					return;
 				}
 			}
 
-			this.#models = withRuntimeTransportOverride;
+			this.#models = applyFinalCodexGpt56ContextCap(withRuntimeTransportOverride);
 			this.#rebuildCanonicalIndex();
 			return;
 		}


### PR DESCRIPTION
## Summary
- enforce the current 272,000-token prompt cap only for GPT-5.6 base/Sol/Terra/Luna on Codex product transports
- preserve smaller live limits and first-party OpenAI context windows
- apply one source-aware policy across discovery, cache/model-manager refresh, registry resolution, listing, and compaction inputs
- cover rollback, future transition, transport/tier matrix, stale cache, and neighboring-model regressions

## Validation
- `bun test packages/ai/test/context-cap-policy.test.ts packages/ai/test/codex-discovery-context-cap.test.ts packages/ai/test/model-thinking.test.ts packages/ai/test/openai-codex-default.test.ts`
- `bun test packages/ai/test/model-manager-context-cap.test.ts packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/list-models.test.ts packages/coding-agent/test/compaction.test.ts`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- signed commit verified with `git verify-commit HEAD`

Closes #2240

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*