### PR TITLE
fix(dev): recognize Windows Bun workspace gjc shim

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -44,6 +44,50 @@ jobs:
         id: plan
         run: bun scripts/ci-dev-affected.ts --matrix-json
 
+  windows-dev-doctor:
+    name: Windows dev:doctor
+    needs: [affected-plan]
+    if: ${{ needs.affected-plan.outputs.relevant == 'true' && contains(needs.affected-plan.outputs.changed_paths, 'scripts/dev-link') }}
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3"
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+        with:
+          toolchain: nightly-2026-04-29
+      - name: Prepend rustup toolchain bin to PATH
+        shell: bash
+        run: |
+          toolchain_bin="$(dirname "$(rustup which cargo)")"
+          echo "$toolchain_bin" >> "$GITHUB_PATH"
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: windows-dev-doctor-win32-x64
+          cache-on-failure: true
+          cache-workspace-crates: true
+      - name: Cache bun dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+      - run: bun install --frozen-lockfile
+      - name: Build native addon (win32-x64 baseline)
+        env:
+          TARGET_PLATFORM: win32
+          TARGET_ARCH: x64
+          TARGET_VARIANTS: baseline
+        run: bun run ci:build:native
+      - name: Verify Windows workspace shim and doctor
+        shell: pwsh
+        run: |
+          bun test scripts/dev-link.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          bun run dev:doctor
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
   # Native addon build runs at most once per run and publishes the built `.node`
   # files as an artifact the runtime-dependent shards download. A content-hash
   # cache of the native sources lets PRs that don't touch crates/natives restore
@@ -187,7 +231,7 @@ jobs:
   affected:
     name: Affected path validation
     if: ${{ always() }}
-    needs: [affected-plan, affected-native, affected-shards]
+    needs: [affected-plan, affected-native, affected-shards, windows-dev-doctor]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
@@ -196,12 +240,15 @@ jobs:
           plan='${{ needs.affected-plan.result }}'
           native='${{ needs.affected-native.result }}'
           shards='${{ needs.affected-shards.result }}'
+          windows='${{ needs.windows-dev-doctor.result }}'
           echo "affected-plan: $plan"
           echo "affected-native: $native"
           echo "affected-shards: $shards"
+          echo "windows-dev-doctor: $windows"
           test "$plan" = success || { echo "planner did not succeed"; exit 1; }
           case "$native" in success|skipped) ;; *) echo "native build did not pass"; exit 1 ;; esac
           case "$shards" in success|skipped) ;; *) echo "one or more affected shards did not pass"; exit 1 ;; esac
+          case "$windows" in success|skipped) ;; *) echo "Windows dev:doctor did not pass"; exit 1 ;; esac
           echo "Affected path validation: all required shards passed"
 
   gjc-state-gates-matrix:

--- a/scripts/dev-link.test.ts
+++ b/scripts/dev-link.test.ts
@@ -2,8 +2,17 @@ import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import {
+	commandExtensions,
+	findGjcOnPath,
+	isApprovedWorkspaceSource,
+	isLocalWindowsBunShim,
+	pathDirs,
+	smokeTest,
+} from "./dev-link";
 
 const tempRoots: string[] = [];
+const shimFlags = (5478 << 3) | 0b101;
 
 async function makeExecutable(file: string, content: string): Promise<void> {
 	await fs.mkdir(path.dirname(file), { recursive: true });
@@ -11,12 +20,227 @@ async function makeExecutable(file: string, content: string): Promise<void> {
 	await fs.chmod(file, 0o755);
 }
 
+function bunMetadata(target = "@gajae-code\\coding-agent\\bin\\gjc.js", command = "bun "): Buffer {
+	const pathBytes = Buffer.from(target, "utf16le");
+	const framing = Buffer.from('"\0', "utf16le");
+	const shebang = Buffer.from(command, "utf16le");
+	const lengths = Buffer.alloc(8);
+	lengths.writeUInt32LE(pathBytes.length, 0);
+	lengths.writeUInt32LE(shebang.length, 4);
+	const flags = Buffer.alloc(2);
+	flags.writeUInt16LE(shimFlags, 0);
+	return Buffer.concat([pathBytes, framing, shebang, lengths, flags]);
+}
+
+function windowsShimExecutable(): Buffer {
+	const executable = Buffer.alloc(0x200);
+	executable.write("MZ", 0);
+	executable.writeUInt32LE(0x80, 0x3c);
+	executable.write("PE\0\0", 0x80);
+	executable.writeUInt16LE(1, 0x86);
+	executable.writeUInt16LE(0, 0x94);
+	executable.writeUInt32LE(0x140, 0x98 + 16);
+	executable.writeUInt32LE(0xc0, 0x98 + 20);
+	return executable;
+}
+
+function fixtureBun(root: string): string {
+	return path.join(root, "bun.exe");
+}
+
+function isFixtureShim(file: string, root: string): boolean {
+	return isLocalWindowsBunShim(file, root, fixtureBun(root));
+}
+
+function isFixtureSource(file: string, real: string | null, root: string, platform: NodeJS.Platform): boolean {
+	return isApprovedWorkspaceSource(file, real, root, platform, fixtureBun(root));
+}
+
+async function workspaceFixture(): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dev-link-windows-"));
+	tempRoots.push(root);
+	const packageRoot = path.join(root, "packages", "coding-agent");
+	await fs.mkdir(path.join(packageRoot, "bin"), { recursive: true });
+	await fs.mkdir(path.join(packageRoot, "src"), { recursive: true });
+	await Bun.write(
+		path.join(packageRoot, "package.json"),
+		JSON.stringify({ bin: { gjc: "bin/gjc.js" }, exports: { "./cli": "./src/cli.ts" } }),
+	);
+	await Bun.write(
+		path.join(packageRoot, "bin", "gjc.js"),
+		'#!/usr/bin/env bun\nimport { runCli } from "@gajae-code/coding-agent/cli";\n\nawait runCli(process.argv.slice(2));\n',
+	);
+	await Bun.write(path.join(packageRoot, "src", "cli.ts"), "export {};\n");
+	await fs.mkdir(path.join(root, "node_modules", "@gajae-code"), { recursive: true });
+	await fs.symlink(packageRoot, path.join(root, "node_modules", "@gajae-code", "coding-agent"), "dir");
+	await fs.mkdir(path.join(root, "node_modules", ".bin"), { recursive: true });
+	await Bun.write(path.join(root, "node_modules", ".bin", "gjc.exe"), windowsShimExecutable());
+	await Bun.write(path.join(root, "node_modules", ".bin", "gjc.bunx"), bunMetadata());
+	await Bun.write(fixtureBun(root), Buffer.concat([Buffer.from("bun-runtime"), windowsShimExecutable(), Buffer.from("tail")]));
+	return root;
+}
+
 afterEach(async () => {
 	await Promise.all(tempRoots.splice(0).map(root => fs.rm(root, { force: true, recursive: true })));
 });
 
+describe("dev:link command discovery", () => {
+	test("uses Windows PATH directory order and PATHEXT order with case-insensitive deduplication", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dev-link-path-"));
+		tempRoots.push(root);
+		const first = path.join(root, "first");
+		const second = path.join(root, "second");
+		await makeExecutable(path.join(first, "gjc.CMD"), "");
+		await makeExecutable(path.join(first, "gjc.exe"), "");
+		await makeExecutable(path.join(second, "gjc.exe"), "");
+		expect(pathDirs(`${first};${second}`, "win32")).toEqual([first, second]);
+		expect(commandExtensions("win32", ".CMD;.exe;.CMD;.EXE")).toEqual([".CMD", ".exe"]);
+		expect(findGjcOnPath(`${first};${second}`, "win32", ".CMD;.exe;.CMD;.EXE").map(hit => hit.file)).toEqual([
+			path.join(first, "gjc.CMD"),
+			path.join(first, "gjc.exe"),
+			path.join(second, "gjc.exe"),
+		]);
+	});
+
+	test("uses the documented Windows PATHEXT fallback and keeps Unix extensionless", () => {
+		expect(commandExtensions("win32", "")).toEqual([".COM", ".EXE", ".BAT", ".CMD"]);
+		expect(commandExtensions("linux", ".EXE")).toEqual([""]);
+	});
+});
+
+
+describe.skipIf(process.platform === "win32")("dev:link Windows Bun workspace shim provenance", () => {
+	test("accepts a direct canonical source link and the exact valid Bun workspace shim", async () => {
+		const root = await workspaceFixture();
+		const source = path.join(root, "packages", "coding-agent", "src", "cli.ts");
+		const shim = path.join(root, "node_modules", ".bin", "gjc.exe");
+		expect(isFixtureSource("ignored", source, root, "win32")).toBe(true);
+		expect(isFixtureShim(shim, root)).toBe(true);
+		expect(isFixtureSource(shim, null, root, "win32")).toBe(true);
+	});
+
+	test("keeps smoke health independent from accepted provenance", async () => {
+		const root = await workspaceFixture();
+		const shim = path.join(root, "node_modules", ".bin", "gjc.exe");
+		const failedSmoke = path.join(root, "failed-smoke");
+		await makeExecutable(failedSmoke, "#!/usr/bin/env sh\necho smoke-test: failed\nexit 1\n");
+		expect(isFixtureSource(shim, null, root, "win32")).toBe(true);
+		expect(smokeTest(failedSmoke).ok).toBe(false);
+	});
+
+	test("fails closed for missing, corrupt, foreign, or substituted shim metadata", async () => {
+		const root = await workspaceFixture();
+		const shim = path.join(root, "node_modules", ".bin", "gjc.exe");
+		const metadata = path.join(root, "node_modules", ".bin", "gjc.bunx");
+		await fs.rm(metadata);
+		expect(isFixtureShim(shim, root)).toBe(false);
+		await Bun.write(metadata, Buffer.from("corrupt"));
+		expect(isFixtureShim(shim, root)).toBe(false);
+		await fs.mkdir(path.join(root, "node_modules", "foreign", "bin"), { recursive: true });
+		await Bun.write(path.join(root, "node_modules", "foreign", "bin", "gjc.js"), "#!/usr/bin/env bun\n");
+		await Bun.write(metadata, bunMetadata("foreign\\bin\\gjc.js"));
+		expect(isFixtureShim(shim, root)).toBe(false);
+		await Bun.write(metadata, bunMetadata());
+		const trusted = windowsShimExecutable();
+		for (const fragment of [
+			trusted.subarray(0, 1),
+			Buffer.from("MZ"),
+			trusted.subarray(0, -1),
+			Buffer.concat([trusted, Buffer.from("suffix")]),
+			trusted.subarray(32, 96),
+		]) {
+			await Bun.write(shim, fragment);
+			expect(isFixtureShim(shim, root)).toBe(false);
+		}
+
+		const substituted = Buffer.from(trusted);
+		substituted[0x1f0] = 1;
+		Buffer.from("smoke-test: ok").copy(substituted, 0x1d0);
+		await Bun.write(shim, substituted);
+		expect(isFixtureShim(shim, root)).toBe(false);
+		expect(substituted.includes(Buffer.from("smoke-test: ok"))).toBe(true);
+	});
+
+	test("rejects inconsistent metadata lengths, trailing bytes, versions, flags, commands, and oversized files", async () => {
+		const root = await workspaceFixture();
+		const shim = path.join(root, "node_modules", ".bin", "gjc.exe");
+		const metadata = path.join(root, "node_modules", ".bin", "gjc.bunx");
+		const valid = bunMetadata();
+
+		const badLength = Buffer.from(valid);
+		badLength.writeUInt32LE(badLength.readUInt32LE(badLength.length - 6) + 2, badLength.length - 6);
+		await Bun.write(metadata, badLength);
+		expect(isFixtureShim(shim, root)).toBe(false);
+
+		await Bun.write(metadata, Buffer.concat([valid.subarray(0, -2), Buffer.from([0, 0]), valid.subarray(-2)]));
+		expect(isFixtureShim(shim, root)).toBe(false);
+
+		const wrongVersion = Buffer.from(valid);
+		wrongVersion.writeUInt16LE((5477 << 3) | 0b101, wrongVersion.length - 2);
+		await Bun.write(metadata, wrongVersion);
+		expect(isFixtureShim(shim, root)).toBe(false);
+
+		const wrongFlags = Buffer.from(valid);
+		wrongFlags.writeUInt16LE((5478 << 3) | 0b111, wrongFlags.length - 2);
+		await Bun.write(metadata, wrongFlags);
+		expect(isFixtureShim(shim, root)).toBe(false);
+
+		await Bun.write(metadata, bunMetadata(undefined, "node "));
+		expect(isFixtureShim(shim, root)).toBe(false);
+
+		await Bun.write(metadata, Buffer.alloc(64 * 1024));
+		expect(isFixtureShim(shim, root)).toBe(false);
+		await Bun.write(metadata, Buffer.alloc(64 * 1024 + 1));
+		expect(isFixtureShim(shim, root)).toBe(false);
+
+		await Bun.write(metadata, valid);
+		await Bun.write(shim, Buffer.alloc(1024 * 1024 + 1));
+		expect(isFixtureShim(shim, root)).toBe(false);
+	});
+
+	test("rejects bin and canonical export mismatches", async () => {
+		const root = await workspaceFixture();
+		const shim = path.join(root, "node_modules", ".bin", "gjc.exe");
+		await Bun.write(path.join(root, "packages", "coding-agent", "package.json"), JSON.stringify({ bin: { gjc: "bin/other.js" } }));
+		expect(isFixtureShim(shim, root)).toBe(false);
+		const exportRoot = await workspaceFixture();
+		const exportShim = path.join(exportRoot, "node_modules", ".bin", "gjc.exe");
+		await Bun.write(
+			path.join(exportRoot, "packages", "coding-agent", "package.json"),
+			JSON.stringify({ bin: { gjc: "bin/gjc.js" }, exports: { "./cli": "./src/other.ts" } }),
+		);
+		await Bun.write(path.join(exportRoot, "packages", "coding-agent", "src", "other.ts"), "export {};\n");
+		expect(isFixtureShim(exportShim, exportRoot)).toBe(false);
+
+		const markerRoot = await workspaceFixture();
+		const markerShim = path.join(markerRoot, "node_modules", ".bin", "gjc.exe");
+		await Bun.write(
+			path.join(markerRoot, "packages", "coding-agent", "bin", "gjc.js"),
+			'#!/usr/bin/env bun\n// from "@gajae-code/coding-agent/cli"\nconsole.log("smoke-test: ok");\n',
+		);
+		expect(isFixtureShim(markerShim, markerRoot)).toBe(false);
+	});
+
+	test("rejects wrong-extension, compiled, and published targets even at an allowlisted path", async () => {
+		const root = await workspaceFixture();
+		const shim = path.join(root, "node_modules", ".bin", "gjc.exe");
+		expect(isFixtureSource(path.join(root, "node_modules", ".bin", "gjc.cmd"), null, root, "win32")).toBe(false);
+		expect(isFixtureSource(path.join(root, "dist", "gjc.exe"), path.join(root, "dist", "gjc.exe"), root, "win32")).toBe(false);
+		expect(
+			isFixtureSource(
+				path.join(root, "node_modules", "gajae-code", "bin", "gjc.js"),
+				path.join(root, "node_modules", "gajae-code", "bin", "gjc.js"),
+				root,
+				"win32",
+			),
+		).toBe(false);
+		expect(isFixtureSource(shim, null, root, "linux")).toBe(false);
+	});
+});
+
+
 describe("dev:link", () => {
-	test("fails when a shadow gjc earlier on PATH would make smoke-test validate the wrong command", async () => {
+	test.skipIf(process.platform === "win32")("fails when a shadow gjc earlier on PATH would make smoke-test validate the wrong command", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dev-link-shadow-"));
 		tempRoots.push(root);
 		const shadowDir = path.join(root, "shadow-bin");
@@ -25,17 +249,11 @@ describe("dev:link", () => {
 			path.join(shadowDir, "gjc"),
 			`#!/usr/bin/env sh\nif [ "$1" = "--smoke-test" ]; then echo "smoke-test: ok"; exit 0; fi\necho shadow\nexit 0\n`,
 		);
-
 		const result = Bun.spawnSync([process.execPath, "scripts/dev-link.ts"], {
-			env: {
-				...process.env,
-				GJC_DEV_LINK_DIR: targetDir,
-				PATH: `${shadowDir}:${targetDir}`,
-			},
+			env: { ...process.env, GJC_DEV_LINK_DIR: targetDir, PATH: `${shadowDir}:${targetDir}` },
 			stderr: "pipe",
 			stdout: "pipe",
 		});
-
 		expect(result.exitCode).not.toBe(0);
 		expect(result.stdout.toString()).toContain(`Linked ${path.join(targetDir, "gjc")}`);
 		expect(result.stderr.toString()).toContain("still resolves to a different command earlier on PATH");

--- a/scripts/dev-link.ts
+++ b/scripts/dev-link.ts
@@ -7,9 +7,7 @@
  * (`packages/coding-agent/src/cli.ts`) instead of a compiled binary or a
  * published npm install. Running from source is the only mode that can
  * dynamically load `@gajae-code/natives` for skills — a `bun build --compile`
- * standalone binary cannot, which surfaces as:
- *
- *   Failed to load skill: Cannot find module '@gajae-code/natives' from '/$bunfs/root/gjc'
+ * standalone binary cannot.
  *
  * Usage:
  *   bun scripts/dev-link.ts            # link `gjc` -> src/cli.ts on PATH
@@ -26,10 +24,12 @@ import * as path from "node:path";
 const repoRoot = path.join(import.meta.dir, "..");
 const cliSource = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
 const cliSourceReal = realpath(cliSource) ?? cliSource;
-
 const HOME = os.homedir();
-const PATH_SEP = process.platform === "win32" ? ";" : ":";
 const targetDir = process.env.GJC_DEV_LINK_DIR ?? path.join(HOME, ".local", "bin");
+const BUN_SHIM_VERSION = 5478;
+const MAX_BUN_SHIM_METADATA_BYTES = 64 * 1024;
+const MAX_BUN_SHIM_EXECUTABLE_BYTES = 1024 * 1024;
+const EXPECTED_WORKSPACE_WRAPPER = '#!/usr/bin/env bun\nimport { runCli } from "@gajae-code/coding-agent/cli";\n\nawait runCli(process.argv.slice(2));\n';
 
 function realpath(p: string): string | null {
 	try {
@@ -49,32 +49,210 @@ function lexists(p: string): boolean {
 	}
 }
 
-function pathDirs(): string[] {
-	return (process.env.PATH ?? "").split(PATH_SEP).filter(Boolean);
+export function commandExtensions(platform = process.platform, pathext = process.env.PATHEXT): string[] {
+	if (platform !== "win32") return [""];
+	const values = (pathext ?? ".COM;.EXE;.BAT;.CMD")
+		.split(";")
+		.map(value => value.trim())
+		.filter(Boolean)
+		.map(value => (value.startsWith(".") ? value : `.${value}`));
+	if (values.length === 0) return [".COM", ".EXE", ".BAT", ".CMD"];
+	const seen = new Set<string>();
+	return values.filter(value => {
+		const key = value.toLowerCase();
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
+}
+
+export function pathDirs(envPath = process.env.PATH ?? "", platform = process.platform): string[] {
+	return envPath.split(platform === "win32" ? ";" : ":").filter(Boolean);
 }
 
 function isOnPath(dir: string): boolean {
 	const want = realpath(dir) ?? dir;
-	return pathDirs().some(d => (realpath(d) ?? d) === want);
+	return pathDirs().some(entry => (realpath(entry) ?? entry) === want);
 }
 
-interface GjcHit {
+export interface GjcHit {
 	dir: string;
 	file: string;
 	real: string | null;
 }
 
-/** All `gjc` entries on PATH, in resolution order (first wins). */
-function findGjcOnPath(): GjcHit[] {
+/** All `gjc` entries on PATH, in shell resolution order (first wins). */
+export function findGjcOnPath(
+	envPath = process.env.PATH ?? "",
+	platform = process.platform,
+	pathext = process.env.PATHEXT,
+): GjcHit[] {
 	const hits: GjcHit[] = [];
 	const seen = new Set<string>();
-	for (const dir of pathDirs()) {
-		const file = path.join(dir, "gjc");
-		if (seen.has(file) || !lexists(file)) continue;
-		seen.add(file);
-		hits.push({ dir, file, real: realpath(file) });
+	for (const dir of pathDirs(envPath, platform)) {
+		for (const extension of commandExtensions(platform, pathext)) {
+			const file = path.join(dir, `gjc${extension}`);
+			const key = platform === "win32" ? file.toLowerCase() : file;
+			if (seen.has(key) || !lexists(file)) continue;
+			seen.add(key);
+			hits.push({ dir, file, real: realpath(file) });
+		}
 	}
 	return hits;
+}
+
+function sameWindowsPath(left: string, right: string): boolean {
+	return left.replaceAll("/", "\\").toLowerCase() === right.replaceAll("/", "\\").toLowerCase();
+}
+
+interface BunShimMetadata {
+	target: string;
+	command: string;
+}
+
+function decodeBunShimMetadata(metadata: Buffer): BunShimMetadata | null {
+	if (metadata.length < 14 || metadata.length > MAX_BUN_SHIM_METADATA_BYTES || metadata.length % 2 !== 0) return null;
+	const flags = metadata.readUInt16LE(metadata.length - 2);
+	if ((flags >> 3) !== BUN_SHIM_VERSION || (flags & 0b111) !== 0b101) return null;
+	const lengthsStart = metadata.length - 10;
+	const binPathByteLength = metadata.readUInt32LE(lengthsStart);
+	const argByteLength = metadata.readUInt32LE(lengthsStart + 4);
+	if (
+		binPathByteLength % 2 !== 0 ||
+		argByteLength === 0 ||
+		argByteLength % 2 !== 0 ||
+		binPathByteLength + argByteLength + 14 !== metadata.length
+	) {
+		return null;
+	}
+	const framingStart = binPathByteLength;
+	const commandStart = framingStart + 4;
+	if (metadata.readUInt16LE(framingStart) !== 0x22 || metadata.readUInt16LE(framingStart + 2) !== 0) return null;
+	try {
+		const target = metadata.subarray(0, framingStart).toString("utf16le");
+		const command = metadata.subarray(commandStart, lengthsStart).toString("utf16le");
+		return command === "bun " ? { target, command } : null;
+	} catch {
+		return null;
+	}
+}
+
+function readBoundedFile(file: string, maxBytes: number): Buffer | null {
+	let descriptor: number | undefined;
+	try {
+		descriptor = fs.openSync(file, "r");
+		const stat = fs.fstatSync(descriptor);
+		if (!stat.isFile() || stat.size === 0 || stat.size > maxBytes) return null;
+		const result = Buffer.alloc(stat.size);
+		let offset = 0;
+		while (offset < result.length) {
+			const read = fs.readSync(descriptor, result, offset, result.length - offset, offset);
+			if (read === 0) return null;
+			offset += read;
+		}
+		const overflow = Buffer.alloc(1);
+		if (fs.readSync(descriptor, overflow, 0, 1, offset) !== 0) return null;
+		return result;
+	} catch {
+		return null;
+	} finally {
+		if (descriptor !== undefined) fs.closeSync(descriptor);
+	}
+}
+
+function fileContainsBytes(file: string, needle: Buffer): boolean {
+	let descriptor: number | undefined;
+	try {
+		const stat = fs.statSync(file);
+		if (!stat.isFile() || stat.size < needle.length) return false;
+		descriptor = fs.openSync(file, "r");
+		const chunkBytes = 64 * 1024;
+		const buffer = Buffer.alloc(chunkBytes + needle.length - 1);
+		let overlap = 0;
+		let position = 0;
+		while (position < stat.size) {
+			const read = fs.readSync(descriptor, buffer, overlap, chunkBytes, position);
+			if (read === 0) return false;
+			const total = overlap + read;
+			if (buffer.subarray(0, total).indexOf(needle) !== -1) return true;
+			overlap = Math.min(needle.length - 1, total);
+			buffer.copy(buffer, 0, total - overlap, total);
+			position += read;
+		}
+		return false;
+	} catch {
+		return false;
+	} finally {
+		if (descriptor !== undefined) fs.closeSync(descriptor);
+	}
+}
+
+function isCompletePortableExecutable(file: Buffer): boolean {
+	if (file.length < 0x40 || file[0] !== 0x4d || file[1] !== 0x5a) return false;
+	const peOffset = file.readUInt32LE(0x3c);
+	if (peOffset + 24 > file.length || file.toString("ascii", peOffset, peOffset + 4) !== "PE\0\0") return false;
+	const sectionCount = file.readUInt16LE(peOffset + 6);
+	const optionalHeaderBytes = file.readUInt16LE(peOffset + 20);
+	if (sectionCount === 0 || sectionCount > 96) return false;
+	const sectionTable = peOffset + 24 + optionalHeaderBytes;
+	if (sectionTable + sectionCount * 40 > file.length) return false;
+	let imageEnd = sectionTable + sectionCount * 40;
+	for (let index = 0; index < sectionCount; index++) {
+		const section = sectionTable + index * 40;
+		const rawBytes = file.readUInt32LE(section + 16);
+		const rawOffset = file.readUInt32LE(section + 20);
+		if (rawOffset > file.length || rawBytes > file.length - rawOffset) return false;
+		imageEnd = Math.max(imageEnd, rawOffset + rawBytes);
+	}
+	return imageEnd === file.length;
+}
+
+function isBunEmbeddedWindowsShim(file: string, bunExecutable: string): boolean {
+	const shim = readBoundedFile(file, MAX_BUN_SHIM_EXECUTABLE_BYTES);
+	return shim !== null && isCompletePortableExecutable(shim) && fileContainsBytes(bunExecutable, shim);
+}
+
+/**
+ * Bun's Windows shim is a PE beside `<name>.bunx`. The latter is a bounded,
+ * versioned UTF-16LE record; accepting the PE requires every local binding
+ * below, never merely a successful command invocation.
+ */
+export function isLocalWindowsBunShim(file: string, root = repoRoot, bunExecutable = process.execPath): boolean {
+	const expectedShim = path.join(root, "node_modules", ".bin", "gjc.exe");
+	if (!sameWindowsPath(file, expectedShim)) return false;
+	if (!isBunEmbeddedWindowsShim(expectedShim, bunExecutable)) return false;
+	const metadata = readBoundedFile(`${expectedShim.slice(0, -4)}.bunx`, MAX_BUN_SHIM_METADATA_BYTES);
+	const decoded = metadata ? decodeBunShimMetadata(metadata) : null;
+	if (!decoded) return false;
+
+	const packageRoot = path.join(root, "packages", "coding-agent");
+	const packageManifest = path.join(packageRoot, "package.json");
+	const wrapper = path.join(packageRoot, "bin", "gjc.js");
+	let resolvedCli: string;
+	let encodedTarget: string;
+	try {
+		const manifest: unknown = JSON.parse(fs.readFileSync(packageManifest, "utf8"));
+		if (
+			typeof manifest !== "object" ||
+			manifest === null ||
+			!("bin" in manifest) ||
+			typeof manifest.bin !== "object" ||
+			manifest.bin === null ||
+			!("gjc" in manifest.bin) ||
+			manifest.bin.gjc !== "bin/gjc.js"
+		) {
+			return false;
+		}
+		resolvedCli = Bun.resolveSync("@gajae-code/coding-agent/cli", root);
+		encodedTarget = path.join(root, "node_modules", ...decoded.target.split(/[\\/]+/));
+	} catch {
+		return false;
+	}
+	return (
+		realpath(encodedTarget) === realpath(wrapper) &&
+		fs.readFileSync(wrapper, "utf8") === EXPECTED_WORKSPACE_WRAPPER &&
+		realpath(resolvedCli) === realpath(path.join(packageRoot, "src", "cli.ts"))
+	);
 }
 
 function describe(real: string | null): string {
@@ -82,21 +260,33 @@ function describe(real: string | null): string {
 	if (real === cliSourceReal) return "workspace source (cli.ts) — OK";
 	if (/[/\\]dist[/\\]/.test(real)) return `compiled binary: ${real}`;
 	if (real.includes("$bunfs")) return `compiled binary (bunfs): ${real}`;
-	if (real.includes(`${path.sep}node_modules${path.sep}gajae-code${path.sep}`)) {
-		return `published wrapper: ${real}`;
-	}
+	if (real.includes(`${path.sep}node_modules${path.sep}gajae-code${path.sep}`)) return `published wrapper: ${real}`;
 	return real;
 }
 
-function smokeTest(gjcPath: string): { ok: boolean; output: string } {
+export function smokeTest(gjcPath: string): { ok: boolean; output: string } {
 	const res = Bun.spawnSync([gjcPath, "--smoke-test"], { stdout: "pipe", stderr: "pipe" });
 	const output = `${res.stdout.toString()}${res.stderr.toString()}`.trim();
 	return { ok: res.exitCode === 0 && output.includes("smoke-test: ok"), output };
 }
 
-function assertResolvedGjcIsSource(winner: GjcHit | undefined): void {
-	if (!winner || winner.real === cliSourceReal) return;
+export function isApprovedWorkspaceSource(
+	file: string,
+	real: string | null,
+	root = repoRoot,
+	platform = process.platform,
+	bunExecutable = process.execPath,
+): boolean {
+	const source = path.join(root, "packages", "coding-agent", "src", "cli.ts");
+	return real === (realpath(source) ?? source) || (platform === "win32" && isLocalWindowsBunShim(file, root, bunExecutable));
+}
 
+function isApprovedSource(winner: GjcHit): boolean {
+	return isApprovedWorkspaceSource(winner.file, winner.real);
+}
+
+function assertResolvedGjcIsSource(winner: GjcHit | undefined): void {
+	if (!winner || isApprovedSource(winner)) return;
 	console.error("");
 	console.error("✗ Linked, but `gjc` still resolves to a different command earlier on PATH.");
 	console.error(`  Resolved: ${winner.file}`);
@@ -107,13 +297,6 @@ function assertResolvedGjcIsSource(winner: GjcHit | undefined): void {
 	process.exit(1);
 }
 
-/**
- * Guard: `bun install` run from another worktree rewrites the
- * `node_modules/@gajae-code/*` workspace symlinks to point at THAT checkout,
- * and a later `bun install` here won't repair them (name+version still match,
- * so bun considers the install satisfied). Fail loudly instead of letting the
- * build break with confusing missing-export errors.
- */
 function assertWorkspaceLinksLocal(): void {
 	const repoRootReal = realpath(repoRoot) ?? repoRoot;
 	const scopeDir = path.join(repoRoot, "node_modules", "@gajae-code");
@@ -121,9 +304,8 @@ function assertWorkspaceLinksLocal(): void {
 	try {
 		entries = fs.readdirSync(scopeDir);
 	} catch {
-		return; // no install yet — nothing to validate
+		return;
 	}
-
 	const stale: Array<{ link: string; real: string }> = [];
 	for (const entry of entries) {
 		const link = path.join(scopeDir, entry);
@@ -133,13 +315,9 @@ function assertWorkspaceLinksLocal(): void {
 			continue;
 		}
 		const real = realpath(link);
-		if (real && !real.startsWith(repoRootReal + path.sep)) {
-			stale.push({ link, real });
-		}
+		if (real && !real.startsWith(repoRootReal + path.sep)) stale.push({ link, real });
 	}
-
 	if (stale.length === 0) return;
-
 	console.error("✗ Workspace symlinks point outside this checkout (stale cross-worktree install):");
 	for (const { link, real } of stale) {
 		console.error(`    ${link}`);
@@ -150,14 +328,12 @@ function assertWorkspaceLinksLocal(): void {
 }
 
 function assertSourceExists(): void {
-	if (!fs.existsSync(cliSource)) {
-		console.error(`✗ Cannot find CLI source at ${cliSource}`);
-		console.error("  Run this from the gajae-code checkout.");
-		process.exit(1);
-	}
+	if (fs.existsSync(cliSource)) return;
+	console.error(`✗ Cannot find CLI source at ${cliSource}`);
+	console.error("  Run this from the gajae-code checkout.");
+	process.exit(1);
 }
 
-/** Doctor: verify the `gjc` the shell resolves is this checkout's source. */
 function check(): never {
 	assertSourceExists();
 	assertWorkspaceLinksLocal();
@@ -167,20 +343,16 @@ function check(): never {
 		console.error("  Fix: bun run dev:link");
 		process.exit(1);
 	}
-
 	const winner = hits[0];
-	const onSource = winner.real === cliSourceReal;
 	console.log(`gjc resolves to: ${winner.file}`);
 	console.log(`            -> ${describe(winner.real)}`);
-
-	if (!onSource) {
+	if (!isApprovedSource(winner)) {
 		console.error("");
 		console.error("✗ `gjc` is NOT this checkout's source — it has drifted.");
 		console.error(`  Expected: ${cliSourceReal}`);
 		console.error("  Fix: bun run dev:link");
 		process.exit(1);
 	}
-
 	const smoke = smokeTest(winner.file);
 	if (!smoke.ok) {
 		console.error("");
@@ -189,45 +361,32 @@ function check(): never {
 		console.error("  Fix: bun run dev:link  (and rebuild natives if needed: bun run build:native)");
 		process.exit(1);
 	}
-
 	console.log("✓ gjc runs this checkout's source and natives load (smoke-test: ok).");
 	process.exit(0);
 }
 
-/** Link: point `gjc` at this checkout's source on PATH. */
 function link(): never {
 	assertSourceExists();
 	assertWorkspaceLinksLocal();
-
 	if (process.platform === "win32") {
 		console.error("dev:link targets Unix-like systems (symlink into ~/.local/bin).");
 		console.error("On Windows, install the dev CLI with Bun instead:");
 		console.error("  bun --cwd=packages/coding-agent link");
 		process.exit(1);
 	}
-
 	fs.mkdirSync(targetDir, { recursive: true });
 	const target = path.join(targetDir, "gjc");
-
-	if (lexists(target)) {
-		fs.rmSync(target, { force: true });
-	}
+	if (lexists(target)) fs.rmSync(target, { force: true });
 	fs.symlinkSync(cliSource, target);
 	console.log(`✓ Linked ${target} -> ${cliSource}`);
-
 	if (!isOnPath(targetDir)) {
 		console.warn(`! ${targetDir} is not on your PATH — add it so \`gjc\` resolves:`);
 		console.warn(`    export PATH="${targetDir}:$PATH"`);
 	}
-
-	// The repo's own `node_modules/.bin/gjc` is recreated by every `bun install`
-	// and sits earlier on PATH, so remove it automatically instead of nagging.
 	const repoBinShadow = path.join(repoRoot, "node_modules", ".bin", "gjc");
-
-	// Warn about any drifted `gjc` that shadows the link (earlier on PATH).
 	for (const hit of findGjcOnPath()) {
-		if (hit.file === target) break; // our link wins from here on
-		if (hit.real === cliSourceReal) continue; // another correct source link — harmless
+		if (hit.file === target) break;
+		if (hit.real === cliSourceReal) continue;
 		if (realpath(hit.file) === realpath(repoBinShadow) || hit.file === repoBinShadow) {
 			fs.rmSync(hit.file, { force: true });
 			console.log(`✓ Removed in-repo shadow: ${hit.file}`);
@@ -236,18 +395,11 @@ function link(): never {
 		console.warn("");
 		console.warn(`! A different \`gjc\` shadows the dev link (earlier on PATH): ${hit.file}`);
 		console.warn(`    -> ${describe(hit.real)}`);
-		if (hit.dir === path.join(HOME, ".bun", "bin")) {
-			console.warn("    Remove the published global install: bun remove -g gajae-code");
-		} else {
-			console.warn(`    Remove it: rm "${hit.file}"`);
-		}
+		console.warn(`    Remove it: rm "${hit.file}"`);
 	}
-
 	const winner = findGjcOnPath()[0];
 	assertResolvedGjcIsSource(winner);
-
-	const smokePath = winner?.file ?? target;
-	const smoke = smokeTest(smokePath);
+	const smoke = smokeTest(winner?.file ?? target);
 	if (!smoke.ok) {
 		console.error("");
 		console.error("✗ Linked, but `gjc --smoke-test` failed (natives/worker did not load):");
@@ -259,8 +411,7 @@ function link(): never {
 	process.exit(0);
 }
 
-if (process.argv.includes("--check")) {
-	check();
-} else {
-	link();
+if (import.meta.main) {
+	if (process.argv.includes("--check")) check();
+	else link();
 }


### PR DESCRIPTION
## Summary
- resolve `gjc` with Windows `PATHEXT` ordering in `dev:doctor`
- accept only fail-closed Bun workspace `gjc.exe` shim provenance while keeping exact-winner native smoke validation
- add Windows/path/shim regressions and run them in hosted Windows CI

## Validation
- `bun test scripts/dev-link.test.ts`
- `bun run check:tools`
- signed commit verification

Closes #2222