### PR TITLE
fix(browser): harden isolated profile reuse

### DIFF
--- a/packages/coding-agent/src/tools/browser/benchmark/run-suite.ts
+++ b/packages/coding-agent/src/tools/browser/benchmark/run-suite.ts
@@ -7,14 +7,12 @@
  * browser; the integration test wires a live puppeteer Page.
  */
 
+import type { Page } from "puppeteer-core";
 import type { DetectorResult, RawProbe } from "./detector-report";
 import { parseProbe } from "./detector-report";
 
 /** Minimal surface of a puppeteer Page that the harness needs. */
-export interface SuitePage {
-	goto(url: string, options?: { waitUntil?: string }): Promise<unknown>;
-	evaluate<T>(fn: () => T): Promise<T>;
-}
+export type SuitePage = Pick<Page, "goto" | "evaluate">;
 
 export interface SuiteFixture {
 	/** file:// (or http://) URL of the offline detector fixture. */
@@ -34,7 +32,7 @@ export async function runOfflineSuite(page: SuitePage, fixtures: readonly SuiteF
 	const results: DetectorResult[] = [];
 	for (const fixture of fixtures) {
 		await page.goto(fixture.url, { waitUntil: "load" });
-		const raw = await page.evaluate<RawProbe>(readProbe);
+		const raw = await page.evaluate(readProbe);
 		results.push(parseProbe(raw));
 	}
 	return results;

--- a/packages/coding-agent/src/tools/browser/profile-reuse.ts
+++ b/packages/coding-agent/src/tools/browser/profile-reuse.ts
@@ -42,6 +42,10 @@ function defaultTempDir(): string {
 	return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-profile-warmup-"));
 }
 
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Resolve profile reuse for a default session. When the posture resolves to
  * `real`, copies an allowlisted, lock-free subset of the discovered profile
@@ -66,15 +70,33 @@ export function resolveProfileReuse(inputs: ResolveProfileReuseInputs): ProfileR
 		};
 	}
 
-	const destDir = inputs.destDir ?? (inputs.makeTempDir ?? defaultTempDir)();
+	const ownsDestDir = inputs.destDir === undefined;
+	let destDir: string | undefined;
 	const copy = inputs.copy ?? collectWarmupArtifacts;
-	const manifest = copy(discovered.profileDir, destDir);
-	return {
-		mode: "real",
-		reason: decision.reason,
-		warning: decision.warning,
-		discovered,
-		warmupDir: destDir,
-		manifest,
-	};
+	try {
+		destDir = inputs.destDir ?? (inputs.makeTempDir ?? defaultTempDir)();
+		const manifest = copy(discovered.profileDir, destDir);
+		return {
+			mode: "real",
+			reason: decision.reason,
+			warning: decision.warning,
+			discovered,
+			warmupDir: destDir,
+			manifest,
+		};
+	} catch (error) {
+		if (ownsDestDir && destDir) {
+			try {
+				fs.rmSync(destDir, { recursive: true, force: true });
+			} catch {}
+		}
+		return {
+			mode: "synthetic",
+			reason: "synthetic-copy-failed",
+			warning: `Could not safely copy the discovered Chrome profile; using synthetic browser state instead: ${errorMessage(error)}`,
+			discovered,
+			warmupDir: null,
+			manifest: null,
+		};
+	}
 }

--- a/packages/coding-agent/src/tools/browser/profile-warmup.ts
+++ b/packages/coding-agent/src/tools/browser/profile-warmup.ts
@@ -18,6 +18,7 @@ import * as path from "node:path";
 
 /** Chromium single-instance lock artifacts — must never be copied. */
 export const CHROME_LOCK_ARTIFACTS = ["SingletonLock", "SingletonSocket", "SingletonCookie"] as const;
+const CHROME_LOCK_ARTIFACT_SET = new Set<string>(CHROME_LOCK_ARTIFACTS);
 
 /**
  * Profile-relative artifacts worth seeding for warm-up. Kept intentionally
@@ -43,12 +44,16 @@ export interface WarmupManifest {
 	excludedLocks: string[];
 }
 
-function copyRecursive(src: string, dest: string): void {
+function copyRecursive(src: string, dest: string, manifest: WarmupManifest): void {
 	const stat = fs.statSync(src);
 	if (stat.isDirectory()) {
 		fs.mkdirSync(dest, { recursive: true });
 		for (const entry of fs.readdirSync(src)) {
-			copyRecursive(path.join(src, entry), path.join(dest, entry));
+			if (CHROME_LOCK_ARTIFACT_SET.has(entry)) {
+				if (!manifest.excludedLocks.includes(entry)) manifest.excludedLocks.push(entry);
+				continue;
+			}
+			copyRecursive(path.join(src, entry), path.join(dest, entry), manifest);
 		}
 	} else {
 		fs.mkdirSync(path.dirname(dest), { recursive: true });
@@ -76,6 +81,11 @@ export function collectWarmupArtifacts(sourceProfileDir: string, destDir: string
 	if (!fs.existsSync(sourceProfileDir)) {
 		throw new Error(`source profile directory does not exist: ${sourceProfileDir}`);
 	}
+	const resolvedSource = path.resolve(sourceProfileDir);
+	const resolvedDest = path.resolve(destDir);
+	if (resolvedDest === resolvedSource || resolvedDest.startsWith(`${resolvedSource}${path.sep}`)) {
+		throw new Error("warm-up destination must be outside the source profile directory");
+	}
 	fs.mkdirSync(destDir, { recursive: true });
 
 	// Record (but never copy) any lock artifacts present in the source.
@@ -91,7 +101,7 @@ export function collectWarmupArtifacts(sourceProfileDir: string, destDir: string
 			manifest.skippedMissing.push(artifact);
 			continue;
 		}
-		copyRecursive(src, path.join(destDir, artifact));
+		copyRecursive(src, path.join(destDir, artifact), manifest);
 		manifest.copied.push(artifact);
 	}
 

--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -104,9 +104,9 @@ async function openBrowserHandle(kind: BrowserKind, opts: AcquireBrowserOptions)
 				posture: opts.profileReuse,
 				discoveryEnv: defaultDiscoveryEnv(fs.existsSync),
 			});
+			if (reuse.warning) logger.warn(reuse.warning);
 			if (reuse.mode === "real" && reuse.warmupDir) {
 				profileWarmupDir = reuse.warmupDir;
-				if (reuse.warning) logger.warn(reuse.warning);
 			}
 		}
 		const browser = await launchHeadlessBrowser({

--- a/packages/coding-agent/test/tools/browser-benchmark-suite.integration.test.ts
+++ b/packages/coding-agent/test/tools/browser-benchmark-suite.integration.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Browser, CDPSession } from "puppeteer-core";
 import { evaluateSuiteGate, renderReport } from "../../src/tools/browser/benchmark/detector-report";
-import { runOfflineSuite, type SuitePage } from "../../src/tools/browser/benchmark/run-suite";
+import { runOfflineSuite } from "../../src/tools/browser/benchmark/run-suite";
 import { applyStealthPatches, launchHeadlessBrowser } from "../../src/tools/browser/launch";
 
 const FIXTURE = path.join(import.meta.dir, "..", "fixtures", "stealth-detectors", "sannysoft-probe.html");
@@ -40,9 +40,7 @@ describe("offline stealth benchmark (integration)", () => {
 				override: null,
 			});
 
-			// runOfflineSuite is decoupled from puppeteer's concrete Page type for unit
-			// testability; adapt the real Page to the minimal SuitePage surface here.
-			const results = await runOfflineSuite(page as unknown as SuitePage, [{ url: FIXTURE_URL }]);
+			const results = await runOfflineSuite(page, [{ url: FIXTURE_URL }]);
 			expect(results.length).toBe(1);
 			const detector = results[0]!;
 			expect(detector.detector).toBe("sannysoft-offline");

--- a/packages/coding-agent/test/tools/browser-profile-reuse.test.ts
+++ b/packages/coding-agent/test/tools/browser-profile-reuse.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { chromeUserDataRoots, discoverDefaultChromeProfile } from "../../src/tools/browser/profile-discovery";
 import { resolveProfileReuse } from "../../src/tools/browser/profile-reuse";
@@ -67,6 +69,39 @@ describe("resolveProfileReuse", () => {
 		expect(res.mode).toBe("synthetic");
 		expect(res.warmupDir).toBeNull();
 		expect(copyCalled).toBe(false);
+	});
+
+	it("falls back to synthetic and removes an owned temp copy when warm-up fails", () => {
+		const profileDir = "/home/x/.config/google-chrome/Default";
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "profile-reuse-fallback-"));
+		const res = resolveProfileReuse({
+			discoveryEnv: env({ platform: "linux", home: "/home/x", existing: [profileDir] }),
+			makeTempDir: () => tempDir,
+			copy: (_source, dest) => {
+				fs.writeFileSync(path.join(dest, "partial"), "partial");
+				throw new Error("profile changed during copy");
+			},
+		});
+
+		expect(res.mode).toBe("synthetic");
+		expect(res.reason).toBe("synthetic-copy-failed");
+		expect(res.warning).toContain("using synthetic browser state instead");
+		expect(res.warmupDir).toBeNull();
+		expect(fs.existsSync(tempDir)).toBe(false);
+	});
+
+	it("falls back to synthetic when the isolated temp directory cannot be created", () => {
+		const profileDir = "/home/x/.config/google-chrome/Default";
+		const res = resolveProfileReuse({
+			discoveryEnv: env({ platform: "linux", home: "/home/x", existing: [profileDir] }),
+			makeTempDir: () => {
+				throw new Error("temp unavailable");
+			},
+		});
+
+		expect(res.mode).toBe("synthetic");
+		expect(res.reason).toBe("synthetic-copy-failed");
+		expect(res.warning).toContain("temp unavailable");
 	});
 
 	it("opt-in without explicit request stays synthetic even when a profile exists", () => {

--- a/packages/coding-agent/test/tools/browser-profile-warmup.test.ts
+++ b/packages/coding-agent/test/tools/browser-profile-warmup.test.ts
@@ -51,6 +51,19 @@ describe("collectWarmupArtifacts", () => {
 		}
 	});
 
+	it("excludes lock artifacts nested inside copied directories", () => {
+		const networkDir = path.join(source, "Network");
+		fs.mkdirSync(networkDir, { recursive: true });
+		fs.writeFileSync(path.join(networkDir, "Cookies"), "cookie-bytes");
+		fs.writeFileSync(path.join(networkDir, "SingletonLock"), "lock");
+
+		const manifest = collectWarmupArtifacts(source, dest);
+
+		expect(manifest.excludedLocks).toContain("SingletonLock");
+		expect(fs.existsSync(path.join(dest, "Network", "SingletonLock"))).toBe(false);
+		expect(fs.readFileSync(path.join(dest, "Network", "Cookies"), "utf8")).toBe("cookie-bytes");
+	});
+
 	it("never mutates the source profile", () => {
 		fs.writeFileSync(path.join(source, "Cookies"), "original");
 		const before = fs.readdirSync(source).sort();
@@ -60,6 +73,13 @@ describe("collectWarmupArtifacts", () => {
 		const after = fs.readdirSync(source).sort();
 		expect(after).toEqual(before);
 		expect(fs.readFileSync(path.join(source, "Cookies"), "utf8")).toBe("original");
+	});
+
+	it("rejects a destination inside the source profile", () => {
+		expect(() => collectWarmupArtifacts(source, path.join(source, "isolated"))).toThrow(
+			"destination must be outside",
+		);
+		expect(fs.existsSync(path.join(source, "isolated"))).toBe(false);
 	});
 
 	it("skips missing artifacts without failing", () => {


### PR DESCRIPTION
Repairs post-merge safety and type-contract issues from #2264.

- derives the benchmark page surface from Puppeteer instead of using an unsafe cast
- rejects warm-up destinations inside the source profile
- excludes Chromium Singleton artifacts recursively
- falls back to synthetic state and cleans owned temp copies when warm-up fails
- logs fallback warnings and adds focused regression coverage

Verification:
- `bun --cwd=packages/coding-agent run check`
- 29 focused browser unit tests
- browser benchmark integration in CI-mode isolated HOME

Live local Chromium execution also exposed the pre-existing SwiftShader WebGL detector failure from #2264; this repair does not weaken that detector gate.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*