### PR TITLE
fix(ai): neutralize header-form leaked control tokens (gpt-5.6 invalid_prompt)

### DIFF
--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -119,7 +119,7 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(items: Array<Record
 		return sanitized ? [sanitized] : [];
 	});
 }
-const RESERVED_CONTROL_TOKEN_RE = /<\|(?=[^<>|\n]{1,64}\|>)/g;
+const RESERVED_CONTROL_TOKEN_RE = /<\|(?=[A-Za-z0-9_]+[^<>|\n]*\|>)/g;
 /**
  * Neutralize leaked OpenAI Harmony / control tokens (`<|channel|>`, `<|message|>`,
  * `<|call|>`, `<|constrain|>`, `<|recipient|>`, `<|content|>`, ...) in replayed
@@ -132,10 +132,14 @@ const RESERVED_CONTROL_TOKEN_RE = /<\|(?=[^<>|\n]{1,64}\|>)/g;
  * text stays human-readable.
  *
  * The match covers both the simple `<|ident|>` form and the header form whose body
- * carries a recipient/space/dot (e.g. `<|assistant to=functions.bash|>`); the latter
- * survived the earlier `[A-Za-z0-9_]`-only pattern and kept bricking sessions. Any
- * `<|…|>` run of up to 64 non-`<>|`/non-newline chars is neutralized; the inserted
- * zero-width space makes the rewrite idempotent (`<\u200b|` no longer matches `<|`).
+ * starts with a role/token identifier and carries a recipient (e.g.
+ * `<|assistant to=functions.some.long.tool.name|>`); the latter survived the earlier
+ * `[A-Za-z0-9_]{1,32}`-only pattern and kept bricking sessions. Requiring an
+ * identifier char immediately after `<|` (rather than any char) is a strict superset
+ * of the old pattern that still leaves non-control pipe syntax untouched — e.g. F#
+ * `value <| f |> g` has a space after `<|`, so it never matches — and dropping the
+ * length cap keeps arbitrarily long tool recipients covered. The inserted zero-width
+ * space makes the rewrite idempotent (`<\u200b|` no longer matches `<|`).
  */
 export function neutralizeReservedControlTokens(text: string): string {
 	if (!text.includes("<|")) return text;

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -119,7 +119,7 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(items: Array<Record
 		return sanitized ? [sanitized] : [];
 	});
 }
-const RESERVED_CONTROL_TOKEN_RE = /<\|(?=[A-Za-z0-9_]{1,32}\|>)/g;
+const RESERVED_CONTROL_TOKEN_RE = /<\|(?=[^<>|\n]{1,64}\|>)/g;
 /**
  * Neutralize leaked OpenAI Harmony / control tokens (`<|channel|>`, `<|message|>`,
  * `<|call|>`, `<|constrain|>`, `<|recipient|>`, `<|content|>`, ...) in replayed
@@ -130,6 +130,12 @@ const RESERVED_CONTROL_TOKEN_RE = /<\|(?=[A-Za-z0-9_]{1,32}\|>)/g;
  * the offending item is re-sent on each turn. Insert a zero-width space after `<`
  * so the delimiter can no longer be tokenized as a reserved control token while the
  * text stays human-readable.
+ *
+ * The match covers both the simple `<|ident|>` form and the header form whose body
+ * carries a recipient/space/dot (e.g. `<|assistant to=functions.bash|>`); the latter
+ * survived the earlier `[A-Za-z0-9_]`-only pattern and kept bricking sessions. Any
+ * `<|…|>` run of up to 64 non-`<>|`/non-newline chars is neutralized; the inserted
+ * zero-width space makes the rewrite idempotent (`<\u200b|` no longer matches `<|`).
  */
 export function neutralizeReservedControlTokens(text: string): string {
 	if (!text.includes("<|")) return text;

--- a/packages/ai/test/control-token-header-form-repro.test.ts
+++ b/packages/ai/test/control-token-header-form-repro.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { neutralizeReservedControlTokens, neutralizeResponsesInputControlTokens } from "../src/utils";
+
+// Follow-up to #2144/#2192/#2197. The reserved-control-token sanitizer only
+// neutralized simple `<|ident|>` markers, so a leaked *header-form* Harmony
+// marker whose body contains a space / `=` / `.` (e.g. `<|assistant to=functions.bash|>`)
+// survived replay and kept the gpt-5.6 / Codex endpoint rejecting every turn with
+// `Request blocked (code=invalid_prompt)`, permanently wedging the session.
+const HEADER_FORM = "<|assistant to=functions.bash|>";
+
+function hasRawControlToken(text: string): boolean {
+	return text.includes("<|");
+}
+
+describe("neutralizeReservedControlTokens header-form markers", () => {
+	it("neutralizes a leaked role-header marker with spaces/=/. in the body", () => {
+		const out = neutralizeReservedControlTokens(`before ${HEADER_FORM} after`);
+		expect(hasRawControlToken(out)).toBe(false);
+		expect(out).toContain("<\u200b|assistant to=functions.bash|>");
+	});
+
+	it("still neutralizes simple markers and mixed dumps", () => {
+		const dump = "Not blocked.<|assistant to=functions.bash|>run<|channel|>analysis<|end|>";
+		const out = neutralizeReservedControlTokens(dump);
+		expect(hasRawControlToken(out)).toBe(false);
+	});
+
+	it("is idempotent: already-neutralized text is left unchanged", () => {
+		const once = neutralizeReservedControlTokens(`x ${HEADER_FORM} y`);
+		const twice = neutralizeReservedControlTokens(once);
+		expect(twice).toBe(once);
+	});
+
+	it("neutralizes header-form markers nested anywhere in the responses input", () => {
+		const input = [
+			{
+				type: "message",
+				role: "assistant",
+				content: [{ type: "output_text", text: `plan ${HEADER_FORM}` }],
+			},
+			{ type: "function_call_output", output: `tool said ${HEADER_FORM}` },
+		];
+		const out = neutralizeResponsesInputControlTokens(input);
+		expect(hasRawControlToken(JSON.stringify(out))).toBe(false);
+	});
+
+	it("does not touch ordinary text without control-token markers", () => {
+		const plain = "a < b and c > d, ratio a|b";
+		expect(neutralizeReservedControlTokens(plain)).toBe(plain);
+	});
+});

--- a/packages/ai/test/control-token-header-form-repro.test.ts
+++ b/packages/ai/test/control-token-header-form-repro.test.ts
@@ -48,4 +48,21 @@ describe("neutralizeReservedControlTokens header-form markers", () => {
 		const plain = "a < b and c > d, ratio a|b";
 		expect(neutralizeReservedControlTokens(plain)).toBe(plain);
 	});
+
+	it("neutralizes header-form markers with recipients longer than the old cap (#2268 review)", () => {
+		// A leaked marker naming a long MCP/custom tool wire name must still be caught;
+		// a fixed length cap would let `assistant to=functions.<long-name>` slip through.
+		const longTool = "functions.some_really_long_mcp_custom_tool_wire_name_exceeding_sixty_four_chars";
+		const marker = `<|assistant to=${longTool}|>`;
+		expect(marker.length).toBeGreaterThan(64);
+		expect(hasRawControlToken(neutralizeReservedControlTokens(`x ${marker} y`))).toBe(false);
+	});
+
+	it("preserves non-control pipe syntax like F# operators (#2268 review)", () => {
+		// `<|` / `|>` are ordinary F# operators; a space follows `<|`, so it is not a
+		// role/token header and must be left byte-identical (no zero-width space).
+		for (const src of ["let r = value <| f |> g", "xs |> List.map f <| seed", "a <| b |> c"]) {
+			expect(neutralizeReservedControlTokens(src)).toBe(src);
+		}
+	});
 });


### PR DESCRIPTION
## Problem

After #2144, #2192, and #2197, `Request blocked (code=invalid_prompt)` **still permanently wedges** `openai-codex` (gpt-5.6-*) sessions. Reproduced on `gjc 0.10.2` (ships all three). Details in #2267.

All three prior fixes route through one regex — `RESERVED_CONTROL_TOKEN_RE` in `packages/ai/src/utils.ts` — which only matched the simple `<|ident|>` form:

```ts
const RESERVED_CONTROL_TOKEN_RE = /<\|(?=[A-Za-z0-9_]{1,32}\|>)/g;
```

A leaked **header-form** Harmony marker whose body carries a recipient (space + `to=` + dotted tool name) — e.g. `<|assistant to=functions.bash|>` — fails the `[A-Za-z0-9_]{1,32}` lookahead, survives replay/request-boundary/compaction sanitizing, and reaches gpt-5.6 verbatim, re-poisoning every subsequent turn (instant `invalid_prompt`, 0 tokens, unrecoverable). It is also self-propagating: a session that merely *quotes* the marker while debugging poisons its own history.

## Fix

Anchor the body to a leading identifier char and drop the length cap:

```diff
-const RESERVED_CONTROL_TOKEN_RE = /<\|(?=[A-Za-z0-9_]{1,32}\|>)/g;
+const RESERVED_CONTROL_TOKEN_RE = /<\|(?=[A-Za-z0-9_]+[^<>|\n]*\|>)/g;
```

- **Strict superset** of the original identifier-only pattern — every marker the old regex caught still matches.
- Header forms (`<|role to=functions.name|>`) are now covered, with **no length cap**, so arbitrarily long MCP/custom tool recipients are caught.
- Requiring an identifier char immediately after `<|` leaves **non-control pipe syntax untouched** — e.g. F# `value <| f |> g` has a space after `<|`, so it never matches.

`neutralizeReservedControlTokens` is the single primitive behind `neutralizeResponsesInputControlTokens` (request boundary), the replay-history sanitizer, and the compaction sanitizers, so this one change closes the gap on every path.

## Tests

New `packages/ai/test/control-token-header-form-repro.test.ts`:

- header-form marker neutralized (no raw `<|` survives) and stays human-readable;
- simple markers and mixed dumps still neutralized (no regression vs #2144/#2192);
- idempotent; nested-anywhere in the responses `input` array; ordinary text untouched;
- **header recipient longer than the old 64-char cap** is neutralized (review follow-up);
- **F# pipe operators** (`value <| f |> g`, `xs |> List.map f <| seed`, `a <| b |> c`) left byte-identical (review follow-up).

Verified locally (darwin-arm64, bun 1.3.14):

- `bun test packages/ai/test/control-token-header-form-repro.test.ts` → **7 pass / 0 fail**
- `bun test packages/ai/test/openai-responses-history-payload.test.ts` (sanitizer integration) → **30 pass / 0 fail**
- `bun test packages/ai` (full package) → **1662 pass / 337 skip / 0 fail** (1999 tests, 199 files)
- `biome check` (changed files) → clean
- `bun --cwd=packages/ai run check:types` (`tsc --noEmit`) → clean

## Review

Both Codex review P2s (long-recipient cap, F# false positive) addressed in `e06e7df`; see replies on the review threads.

## Follow-up (not this PR)

The session-level circuit-breaker + operator "repair poisoned history" command that #2144 deferred are still unfiled and still needed — widening the regex stops *new* poisoning but does not repair already-wedged sessions or stop the tight instant-retry loop. Tracked in #2267.

Closes #2267
