### PR TITLE
test: make Telegram daemon pid rewrite deterministic

### DIFF
--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -21,6 +21,7 @@ import {
 	renewDaemonHeartbeat,
 	TelegramBotTransport,
 	type TelegramDaemonFs,
+	type TelegramDaemonOptions,
 	TelegramEventDispatchState,
 	TelegramNotificationDaemon,
 	TelegramUpdatePoller,
@@ -745,12 +746,26 @@ describe("telegram daemon", () => {
 			randomId: () => "owner",
 		});
 		class OneShotDaemon extends TelegramNotificationDaemon {
-			override async scanRoots(): Promise<void> {}
+			#options: TelegramDaemonOptions;
+
+			constructor(options: TelegramDaemonOptions) {
+				super(options);
+				this.#options = options;
+			}
+
+			override async run(): Promise<void> {
+				await renewDaemonHeartbeat({
+					settings: this.#options.settings,
+					ownerId: this.#options.ownerId,
+					pid: this.#options.pid,
+				});
+			}
 		}
 		await runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner"], {
 			SettingsImpl: { init: async () => s },
 			DaemonImpl: OneShotDaemon,
 			processPid: 222,
+			readDaemonState: async () => undefined,
 		});
 		const state = JSON.parse(fs.readFileSync(daemonPaths(agentDir).state, "utf8")) as {
 			pid: number;


### PR DESCRIPTION
## Summary
- Replace the timing-dependent full daemon loop in the owner-PID rewrite regression test with a one-shot daemon seam.
- The injected daemon receives the exact `TelegramDaemonOptions` constructed by `runDaemonInternal` and directly persists one heartbeat, so completion is causal and deterministic.
- Inject `readDaemonState` to keep the ownership watchdog isolated from the assertion path; no timeout, retry, sleep, or polling workaround.

## Regression proof
- Existing persisted state starts with PID `111` and owner `owner`.
- `runDaemonInternal` is invoked with daemon process PID `222`.
- The one-shot daemon renews ownership using only the options supplied by `runDaemonInternal`.
- The persisted state is asserted as PID `222` with the same owner.

## Verification
- Biome check/write on the changed test.
- Exact regression test: **100/100 consecutive passes** under `CI=1 TZ=UTC LC_ALL=C`.
- Full `notifications-telegram-daemon.test.ts`: **155 pass, 0 fail**.
- Telegram baseline manifest check and canonical `check:sdk-closure` passed.
- Root TypeScript/workspace checks and affected `packages/coding-agent` check passed.

Fixes the sole failure in Dev CI run https://github.com/Yeachan-Heo/gajae-code/actions/runs/29376792637.

—
*[repo owner’s gaebal-gajae (clawdbot) 🦞]*