### PR TITLE
feat(browser): patch headless Notification.permission tell (CreepJS)

### DIFF
--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -19,6 +19,7 @@ import stealthPluginsScript from "../puppeteer/10_stealth_plugins.txt" with { ty
 import stealthHardwareScript from "../puppeteer/11_stealth_hardware.txt" with { type: "text" };
 import stealthCodecsScript from "../puppeteer/12_stealth_codecs.txt" with { type: "text" };
 import stealthWorkerScript from "../puppeteer/13_stealth_worker.txt" with { type: "text" };
+import stealthPermissionsScript from "../puppeteer/14_stealth_permissions.txt" with { type: "text" };
 import { ToolError } from "../tool-errors";
 
 export const DEFAULT_VIEWPORT = { width: 1365, height: 768, deviceScaleFactor: 1.25 };
@@ -567,6 +568,7 @@ const STEALTH_PATCH_SCRIPTS = [
 	stealthHardwareScript,
 	stealthCodecsScript,
 	stealthWorkerScript,
+	stealthPermissionsScript,
 ];
 
 function buildStealthInjectionScript(scripts: readonly string[] = STEALTH_PATCH_SCRIPTS): string {

--- a/packages/coding-agent/src/tools/puppeteer/14_stealth_permissions.txt
+++ b/packages/coding-agent/src/tools/puppeteer/14_stealth_permissions.txt
@@ -1,0 +1,57 @@
+// Permissions / notification headless tell.
+//
+// Headless Chrome reports `Notification.permission === "denied"` by default and
+// a matching `permissions.query({name:"notifications"})` state, while a real
+// user browser reports `"default"` / `"prompt"`. Detectors such as CreepJS key
+// on this exact mismatch to flag headless. Normalize both to the human default.
+//
+// Technique adapted (reimplemented) from puppeteer-extra-plugin-stealth
+// (navigator.permissions) — see STEALTH-THIRD-PARTY-NOTICES.md.
+
+try {
+	if (typeof Notification !== "undefined" && Notification.permission === "denied") {
+		Object_defineProperty(Notification, "permission", {
+			get() {
+				return "default";
+			},
+			configurable: true,
+		});
+	}
+} catch (e) {}
+
+try {
+	const permissions = navigator.permissions;
+	const originalQuery = permissions && permissions.query;
+	if (originalQuery && typeof PermissionStatus !== "undefined") {
+		permissions.query = new Window_Proxy(originalQuery, {
+			apply(target, ctx, args) {
+				const params = args[0];
+				if (params && params.name === "notifications") {
+					return Promise_resolve(
+						Object_create(PermissionStatus.prototype, {
+							state: {
+								get() {
+									return "prompt";
+								},
+								enumerable: true,
+								configurable: true,
+							},
+							name: {
+								value: "notifications",
+								enumerable: true,
+								configurable: true,
+							},
+							onchange: {
+								value: null,
+								writable: true,
+								enumerable: true,
+								configurable: true,
+							},
+						}),
+					);
+				}
+				return Reflect.apply(target, ctx, args);
+			},
+		});
+	}
+} catch (e) {}

--- a/packages/coding-agent/test/fixtures/stealth-detectors/sannysoft-probe.html
+++ b/packages/coding-agent/test/fixtures/stealth-detectors/sannysoft-probe.html
@@ -42,17 +42,18 @@
 				// window.chrome runtime object present in Chrome.
 				signals.push(signal("chrome", "window.chrome present", typeof window.chrome === "object" && window.chrome !== null));
 
-				// Notification permission must not be "denied" while state is default.
+				// Notification.permission must be readable AND not "denied": headless
+				// Chrome defaults to "denied", a real user browser to "default".
 				var permsOk = true;
 				var permDetail = "n/a";
 				try {
 					permDetail = Notification && Notification.permission;
-					permsOk = permDetail !== undefined;
+					permsOk = permDetail !== undefined && permDetail !== "denied";
 				} catch (e) {
 					permsOk = false;
 					permDetail = "error";
 				}
-				signals.push(signal("permissions", "Notification.permission readable", permsOk, String(permDetail)));
+				signals.push(signal("notification", "Notification.permission not headless-denied", permsOk, String(permDetail)));
 
 				// WebGL vendor/renderer should not be blank or SwiftShader-only.
 				var glOk = false;

--- a/packages/coding-agent/test/tools/browser-benchmark-suite.integration.test.ts
+++ b/packages/coding-agent/test/tools/browser-benchmark-suite.integration.test.ts
@@ -50,6 +50,11 @@ describe("offline stealth benchmark (integration)", () => {
 			const webdriver = detector.signals.find(s => s.id === "webdriver");
 			expect(webdriver?.status).toBe("pass");
 
+			// The permissions patch must normalize the headless Notification.permission
+			// tell ("denied" -> "default") that CreepJS keys on.
+			const notification = detector.signals.find(s => s.id === "notification");
+			expect(notification?.status).toBe("pass");
+
 			// Persist a baseline + report artifact (observability).
 			const artifactsDir = path.join(import.meta.dir, "..", "..", "artifacts", "stealth-benchmark");
 			fs.mkdirSync(artifactsDir, { recursive: true });


### PR DESCRIPTION
## Summary
Follow-up to #2264. Real-task testing against **CreepJS** showed the headless browser was still flagged as headless. I reproduced the precise cause with a focused harness:

- page / worker / iframe `navigator.userAgent` are **already** normalized to `Chrome/148` (the existing CDP UA override covers them), **but**
- `Notification.permission` returns **`"denied"`** (headless Chrome's default) while a real browser returns **`"default"`** — a mismatch CreepJS's headless detector keys on.

## Change
- **`14_stealth_permissions.txt`** (new injection script): normalize `Notification.permission` `"denied" -> "default"` and keep `navigator.permissions.query({name:"notifications"})` consistent (`"prompt"`). Reimplemented from `puppeteer-extra-plugin-stealth` (attribution in the script header + existing NOTICES).
- Registered in the stealth injection order in `launch.ts`.
- Strengthened the offline benchmark `notification` signal to **fail** on the headless `"denied"` default, and assert it **passes** in the live integration test — so this regression is now gated, not just manually observed.

## Verification
- Live: `Notification.permission` now reports `"default"` (recorded in `baseline.json`).
- 57/57 browser tests green (incl. the live Chromium integration); `tsc` + `biome` clean.

## Scope / not included
- The WebRTC real-IP / timezone / locale leaks CreepJS also reports are network-posture concerns (proxy/WebRTC policy), out of scope here.
- Fingerprint Pro already returns `bot: not_detected`; its low-confidence "browser tampering" flag (ML score 0) is the inherent stealth-vs-tamper tradeoff, not addressed here.
