### PR TITLE
fix: isolate token-log telemetry failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Token-log telemetry now skips filesystem-root workspaces and disables itself after a failed write, so a non-writable `/.gjc` cannot surface as an `onChatUsage` callback failure.
 
 ## [0.10.2] - 2026-07-14
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -63,7 +63,7 @@ import { runStartupCredentialAutoImportIfNeeded } from "./setup/credential-auto-
 import { formatModelOnboardingGuidance } from "./setup/model-onboarding-guidance";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { resolvePromptInput } from "./system-prompt";
-import { persistTaskTokenLog, resolveTaskTokenLogDir, taskTokenLogFromUsage } from "./task/token-log";
+import { resolveTaskTokenLogDir, taskTokenLogFromUsage, tryPersistTaskTokenLog } from "./task/token-log";
 import type { LspStartupServerInfo } from "./tools";
 import { getDisplayChangelogEntries, getInstalledVersionChangelogEntry, getNewEntries } from "./utils/changelog";
 import type { EventBus } from "./utils/event-bus";
@@ -1198,19 +1198,23 @@ export async function runRootCommand(
 			}
 			if (!rootTokenLogDir) return;
 			rootTokenTurn += 1;
-			await persistTaskTokenLog(
-				taskTokenLogFromUsage(event.usage, {
-					subagentId: "root",
-					agent: event.agent?.name ?? "main",
-					// Monotonic 1-based sequence of persisted usage events for this
-					// session (event.stepNumber is 0-based and -1 for oneshot spans).
-					turn: rootTokenTurn,
-					at: new Date().toISOString(),
-					model: event.model,
-					cost: event.cost,
-				}),
-				{ dir: rootTokenLogDir },
-			);
+			if (
+				!(await tryPersistTaskTokenLog(
+					taskTokenLogFromUsage(event.usage, {
+						subagentId: "root",
+						agent: event.agent?.name ?? "main",
+						// Monotonic 1-based sequence of persisted usage events for this
+						// session (event.stepNumber is 0-based and -1 for oneshots).
+						turn: rootTokenTurn,
+						at: new Date().toISOString(),
+						model: event.model,
+						cost: event.cost,
+					}),
+					{ dir: rootTokenLogDir },
+				))
+			) {
+				rootTokenLogDir = undefined;
+			}
 		},
 	};
 	sessionOptions.authStorage = authStorage;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -43,7 +43,7 @@ import type { EventBus } from "../utils/event-bus";
 import { buildNamedToolChoiceResult } from "../utils/tool-choice";
 import type { WorkspaceTree } from "../workspace-tree";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
-import { persistTaskTokenLog, taskTokenLogFromUsage } from "./token-log";
+import { taskTokenLogFromUsage, tryPersistTaskTokenLog } from "./token-log";
 import {
 	type AgentDefinition,
 	type AgentProgress,
@@ -1296,6 +1296,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				? { id, name: agent.name, description: agent.description }
 				: undefined;
 			let subagentTokenTurn = 0;
+			let tokenLogDisabled = false;
 			const tokenLogDir = options.parentSessionId
 				? path.join(sessionRoot(cwd, options.parentSessionId), "token-logs")
 				: undefined;
@@ -1312,21 +1313,25 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 							// chaining it here would double-log every subagent turn under root.
 							// Subagent turns are attributed to this child's id instead.
 							onChatUsage: async event => {
-								if (!tokenLogDir) return;
+								if (!tokenLogDir || tokenLogDisabled) return;
 								subagentTokenTurn += 1;
-								await persistTaskTokenLog(
-									taskTokenLogFromUsage(event.usage, {
-										subagentId: id,
-										agent: agent.name,
-										// Monotonic 1-based sequence per subagent session
-										// (event.stepNumber is 0-based and -1 for oneshots).
-										turn: subagentTokenTurn,
-										at: new Date().toISOString(),
-										model: event.model,
-										cost: event.cost,
-									}),
-									{ dir: tokenLogDir },
-								);
+								if (
+									!(await tryPersistTaskTokenLog(
+										taskTokenLogFromUsage(event.usage, {
+											subagentId: id,
+											agent: agent.name,
+											// Monotonic 1-based sequence per subagent session
+											// (event.stepNumber is 0-based and -1 for oneshots).
+											turn: subagentTokenTurn,
+											at: new Date().toISOString(),
+											model: event.model,
+											cost: event.cost,
+										}),
+										{ dir: tokenLogDir },
+									))
+								) {
+									tokenLogDisabled = true;
+								}
 							},
 						}
 					: undefined;

--- a/packages/coding-agent/src/task/token-log.test.ts
+++ b/packages/coding-agent/src/task/token-log.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, parse } from "node:path";
 import { GJC_SESSION_ACTIVITY_FILE, sessionRoot } from "../gjc-runtime/session-layout";
 import {
 	computeCacheHitRate,
@@ -10,6 +10,7 @@ import {
 	resolveTaskTokenLogDir,
 	taskTokenLogFromChat,
 	taskTokenLogFromUsage,
+	tryPersistTaskTokenLog,
 } from "./token-log";
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
@@ -93,6 +94,18 @@ describe("task token log", () => {
 			expect(await readTaskTokenLogs(dir)).toEqual([first, second]);
 		});
 	});
+	it("skips persistence errors because token logs are optional telemetry", async () => {
+		await withTempDir(async dir => {
+			const blockedParent = join(dir, "not-a-directory");
+			await writeFile(blockedParent, "", "utf-8");
+			const entry = taskTokenLogFromChat(
+				{ inputTokens: 1, outputTokens: 2, cachedInputTokens: 3, cacheWriteTokens: 4 },
+				{ subagentId: "root", turn: 1, at: "2026-01-01T00:00:00.000Z" },
+			);
+
+			await expect(tryPersistTaskTokenLog(entry, { dir: join(blockedParent, "token-logs") })).resolves.toBe(false);
+		});
+	});
 
 	it("prefers the current session manager over a stale latest-active session", async () => {
 		await withTempDir(async cwd => {
@@ -118,6 +131,10 @@ describe("task token log", () => {
 				join(sessionRoot(cwd, currentSessionId), "token-logs"),
 			);
 		});
+	});
+	it("does not create token logs under the filesystem root", async () => {
+		const root = parse(process.cwd()).root;
+		await expect(resolveTaskTokenLogDir(root, { getSessionId: () => "root-session" }, "")).resolves.toBeUndefined();
 	});
 
 	it("missing token-log file reads as empty", async () => {

--- a/packages/coding-agent/src/task/token-log.ts
+++ b/packages/coding-agent/src/task/token-log.ts
@@ -76,6 +76,12 @@ export async function resolveTaskTokenLogDir(
 	sessionManager: TaskTokenLogSessionManager | undefined,
 	envSessionId: string | undefined = process.env.GJC_SESSION_ID,
 ): Promise<string | undefined> {
+	// The filesystem root is neither a project nor a safe owner for `/.gjc`.
+	// Token accounting is optional, so do not request privileged global state
+	// merely because GJC was launched from `/`.
+	const resolvedCwd = path.resolve(cwd);
+	if (resolvedCwd === path.parse(resolvedCwd).root) return undefined;
+
 	// Prefer the canonical SessionManager id so root turns land in the SAME
 	// `<session>/token-logs` dir the task executor uses for subagent turns and
 	// that `gjc --fixture <id>` reads from. Fall back to the env/latest-active
@@ -83,18 +89,29 @@ export async function resolveTaskTokenLogDir(
 	// the SDK adopts a pre-allocated id internally). Never let a best-effort
 	// telemetry side channel crash startup — swallow every SessionResolutionError.
 	const managerId = sessionManager?.getSessionId();
-	if (managerId) return path.join(sessionRoot(cwd, managerId), "token-logs");
+	if (managerId) return path.join(sessionRoot(resolvedCwd, managerId), "token-logs");
 	try {
-		const session = await resolveGjcSessionForRead(cwd, { envSessionId });
+		const session = await resolveGjcSessionForRead(resolvedCwd, { envSessionId });
 		return path.join(session.sessionRoot, "token-logs");
 	} catch (error) {
 		if (error instanceof SessionResolutionError) return undefined;
 		throw error;
 	}
 }
+
 export async function persistTaskTokenLog(entry: TaskTokenLog, opts: { dir: string }): Promise<void> {
 	await fs.mkdir(opts.dir, { recursive: true });
 	await fs.appendFile(path.join(opts.dir, TOKEN_LOG_FILE), `${JSON.stringify(entry)}\n`, "utf-8");
+}
+
+/** Token logs are telemetry: a failed write must not fail an agent turn. */
+export async function tryPersistTaskTokenLog(entry: TaskTokenLog, opts: { dir: string }): Promise<boolean> {
+	try {
+		await persistTaskTokenLog(entry, opts);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 export async function readTaskTokenLogs(dir: string): Promise<TaskTokenLog[]> {


### PR DESCRIPTION
## What

- Skip per-session token-log resolution when GJC runs from the filesystem root, avoiding an attempted write under `/.gjc`.
- Treat root and subagent token-log persistence as best-effort telemetry; after a failed write, disable further writes for that session.

## Why

An interactive run started from `/` attempted `mkdir /.gjc` from `onChatUsage`, producing a repeated `EACCES` telemetry callback failure despite token logs being non-essential.

## Testing

- [x] `bun test packages/coding-agent/src/task/token-log.test.ts`
- [x] `bun run check:ts`
- [x] CHANGELOG updated