### PR TITLE
fix: contain best-effort token-log telemetry persistence failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Cooperative mid-run context maintenance now waits at a cancellation-aware FIFO consumer-drain checkpoint before flushing or rewriting session history. Materialized tool results and steering messages are synchronously canonicalized first; aborted barriers and hook/signal-cancelled compactions settle without rewriting or scheduling a continuation. Promotion, pruning, and compaction each start a clean provider/prompt-cache epoch. Script-aware #2067 unsent-delta accounting remains cache-free and distinct from the lifecycle checkpoint.
 - Classified the cooperative mid-run maintenance driver and token estimator test seams as locked non-public SDK exclusions, restoring deterministic operation-inventory generation and post-merge dev CI coverage.
+- Contained best-effort token-log telemetry persistence so it can no longer surface as an `onChatUsage` callback failure. When the per-session token-log directory cannot be created — for example a launch from a filesystem root, where the session root resolves to `/.gjc/...` a normal user cannot create — the write is now attempted and its failure is swallowed locally instead of raising `EACCES` on every chat-usage event. The caller's working directory and project identity are left untouched; mandatory session-state writes are unaffected and continue to fail loudly.
 
 ### Added
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -65,7 +65,7 @@ import { runStartupCredentialAutoImportIfNeeded } from "./setup/credential-auto-
 import { formatModelOnboardingGuidance } from "./setup/model-onboarding-guidance";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { resolvePromptInput } from "./system-prompt";
-import { persistTaskTokenLog, resolveTaskTokenLogDir, taskTokenLogFromUsage } from "./task/token-log";
+import { resolveTaskTokenLogDir, taskTokenLogFromUsage, tryPersistTaskTokenLog } from "./task/token-log";
 import type { LspStartupServerInfo } from "./tools";
 import { getDisplayChangelogEntries, getInstalledVersionChangelogEntry, getNewEntries } from "./utils/changelog";
 import type { EventBus } from "./utils/event-bus";
@@ -1218,7 +1218,7 @@ export async function runRootCommand(
 			}
 			if (!rootTokenLogDir) return;
 			rootTokenTurn += 1;
-			await persistTaskTokenLog(
+			await tryPersistTaskTokenLog(
 				taskTokenLogFromUsage(event.usage, {
 					subagentId: "root",
 					agent: event.agent?.name ?? "main",

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -43,7 +43,7 @@ import type { EventBus } from "../utils/event-bus";
 import { buildNamedToolChoiceResult } from "../utils/tool-choice";
 import type { WorkspaceTree } from "../workspace-tree";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
-import { persistTaskTokenLog, taskTokenLogFromUsage } from "./token-log";
+import { taskTokenLogFromUsage, tryPersistTaskTokenLog } from "./token-log";
 import {
 	type AgentDefinition,
 	type AgentProgress,
@@ -1323,7 +1323,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 							onChatUsage: async event => {
 								if (!tokenLogDir) return;
 								subagentTokenTurn += 1;
-								await persistTaskTokenLog(
+								await tryPersistTaskTokenLog(
 									taskTokenLogFromUsage(event.usage, {
 										subagentId: id,
 										agent: agent.name,

--- a/packages/coding-agent/src/task/token-log.test.ts
+++ b/packages/coding-agent/src/task/token-log.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { GJC_SESSION_ACTIVITY_FILE, sessionRoot } from "../gjc-runtime/session-layout";
@@ -10,6 +10,7 @@ import {
 	resolveTaskTokenLogDir,
 	taskTokenLogFromChat,
 	taskTokenLogFromUsage,
+	tryPersistTaskTokenLog,
 } from "./token-log";
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
@@ -91,6 +92,38 @@ describe("task token log", () => {
 			await persistTaskTokenLog(second, { dir });
 
 			expect(await readTaskTokenLogs(dir)).toEqual([first, second]);
+		});
+	});
+
+	it("contains a best-effort persistence failure without throwing or writing", async () => {
+		await withTempDir(async dir => {
+			// A regular file where a session-root directory is expected makes the
+			// recursive mkdir in persistTaskTokenLog fail (ENOTDIR), standing in for
+			// an unwritable session root such as `/.gjc` on a filesystem-root launch.
+			const blocker = join(dir, "not-a-directory");
+			await writeFile(blocker, "", "utf-8");
+			const unwritable = join(blocker, "token-logs");
+			const entry = taskTokenLogFromChat(
+				{ inputTokens: 1, outputTokens: 2, cachedInputTokens: 3, cacheWriteTokens: 4 },
+				{ subagentId: "root", turn: 1, at: "2026-01-01T00:00:00.000Z" },
+			);
+
+			await expect(tryPersistTaskTokenLog(entry, { dir: unwritable })).resolves.toBeUndefined();
+			// Nothing was created: the blocking file is untouched and no token-logs dir appeared.
+			expect(await readdir(dir)).toEqual(["not-a-directory"]);
+		});
+	});
+
+	it("persists best-effort when the directory is writable", async () => {
+		await withTempDir(async dir => {
+			const entry = taskTokenLogFromChat(
+				{ inputTokens: 9, outputTokens: 1, cachedInputTokens: 0, cacheWriteTokens: 0 },
+				{ subagentId: "root", turn: 1, at: "2026-01-01T00:00:00.000Z" },
+			);
+
+			await tryPersistTaskTokenLog(entry, { dir });
+
+			expect(await readTaskTokenLogs(dir)).toEqual([entry]);
 		});
 	});
 

--- a/packages/coding-agent/src/task/token-log.ts
+++ b/packages/coding-agent/src/task/token-log.ts
@@ -97,6 +97,23 @@ export async function persistTaskTokenLog(entry: TaskTokenLog, opts: { dir: stri
 	await fs.appendFile(path.join(opts.dir, TOKEN_LOG_FILE), `${JSON.stringify(entry)}\n`, "utf-8");
 }
 
+/**
+ * Best-effort variant of {@link persistTaskTokenLog}. Token-log persistence is a
+ * telemetry side channel, so a session directory the caller cannot create (for
+ * example a launch from a filesystem root, where the session root would be
+ * `/.gjc/...`) must never surface as an `onChatUsage` callback failure. The
+ * write is attempted and any failure is contained locally; the caller's working
+ * directory and project identity are left untouched. Mandatory state writes must
+ * NOT use this path — they need an explicit storage policy that can report failure.
+ */
+export async function tryPersistTaskTokenLog(entry: TaskTokenLog, opts: { dir: string }): Promise<void> {
+	try {
+		await persistTaskTokenLog(entry, opts);
+	} catch {
+		// Contained: token-log telemetry is best-effort and must not fail a turn.
+	}
+}
+
 export async function readTaskTokenLogs(dir: string): Promise<TaskTokenLog[]> {
 	let raw: string;
 	try {


### PR DESCRIPTION
## What

Contain best-effort token-log telemetry persistence so an unwritable session directory can no longer surface as an `onChatUsage` callback failure. `persistTaskTokenLog` gains a best-effort sibling `tryPersistTaskTokenLog` that attempts the write and swallows any failure; the two telemetry call sites (root in `main.ts`, subagent in `task/executor.ts`) use it. No other behavior changes.

## Why

Launching from a filesystem root resolves the per-session token-log dir to `/.gjc/...`, which a normal user cannot create, so the best-effort write raised `EACCES` on every chat-usage event.

## Revised per review (REQUEST_CHANGES)

The previous revision relocated cwd via `setProjectDir()` (process-wide `chdir`) at the wrong boundary. This revision drops relocation entirely and follows the prescribed direction — keep caller cwd/project identity intact and contain the expected best-effort telemetry failure locally:

- **Project identity**: no `chdir`/`setProjectDir`; `process.cwd()` is unchanged. No config/rules/session/resume relocation or cross-launch collision.
- **No fallback directory**: nothing is selected or created, so there is no writability/ownership/isolation/symlink-race surface.
- **No `--cwd` / no Windows claims**: the changelog no longer advertises a flag or platform behavior; the fix is a platform-agnostic `try/catch`.
- **Mandatory state untouched**: only the best-effort token-log path is contained; mandatory session-state writes continue to fail loudly under their existing policy.

## Testing

- [x] `bun test packages/coding-agent/src/task/token-log.test.ts` (12/12) — new cases: a persistence failure is contained without throwing or writing, and a writable dir still persists.
- [x] `bun --cwd=packages/coding-agent run check:types`
- [x] E2E from `/`: `process.cwd()` stays `/`, `tryPersistTaskTokenLog` to `/.gjc/...` does not throw, and no `/.gjc` is created.
- [x] CHANGELOG updated.