### PR TITLE
feat(browser): WebRTC IP-leak suppression + opt-in geo alignment; UA-cleanliness gate

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2398,6 +2398,27 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"browser.geo.timezone": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "tools",
+			label: "Geo timezone override",
+			description:
+				"Optional IANA timezone (e.g. 'America/New_York') for headless sessions. Default unset preserves the real timezone. Only set this to a value coherent with your egress (e.g. a proxy region); an incoherent timezone increases bot detection.",
+		},
+	},
+	"browser.geo.locale": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "tools",
+			label: "Geo locale override",
+			description:
+				"Optional UI locale (e.g. 'en-US') for headless sessions. Default unset preserves the real locale. Only set this coherently with your egress region.",
+		},
+	},
+
 	"browser.gc.enabled": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -235,6 +235,10 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 				appArgs: params.app?.args,
 				profileReuse:
 					(this.session.settings.get("browser.profileReuse") as "auto" | "opt-in" | undefined) ?? "auto",
+				geo: {
+					timezone: this.session.settings.get("browser.geo.timezone") as string | undefined,
+					locale: this.session.settings.get("browser.geo.locale") as string | undefined,
+				},
 				signal,
 			}),
 		);

--- a/packages/coding-agent/src/tools/browser/STEALTH-THIRD-PARTY-NOTICES.md
+++ b/packages/coding-agent/src/tools/browser/STEALTH-THIRD-PARTY-NOTICES.md
@@ -9,7 +9,7 @@ carries an attributing header comment.
 | Source project | License | Techniques referenced |
 |----------------|---------|-----------------------|
 | rebrowser-patches | MIT | CDP `Runtime.enable` leak mitigation (data-driven; landed only if the offline baseline shows a runtime/CDP leak signal) |
-| puppeteer-extra-plugin-stealth | MIT | Fingerprint evasion signal set (navigator/webgl/plugins/permissions surfaces) overlapping and complementing the existing 14 injection scripts |
+| puppeteer-extra-plugin-stealth | MIT | Fingerprint evasion signal set (navigator/webgl/plugins/permissions/webrtc surfaces) overlapping and complementing the existing injection scripts |
 | fingerprint-suite (fingerprint-injector / generator) | Apache-2.0 | Coherent fingerprint attribute generation ideas |
 
 No source files from these projects are copied into this repository. Only the

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -20,6 +20,7 @@ import stealthHardwareScript from "../puppeteer/11_stealth_hardware.txt" with { 
 import stealthCodecsScript from "../puppeteer/12_stealth_codecs.txt" with { type: "text" };
 import stealthWorkerScript from "../puppeteer/13_stealth_worker.txt" with { type: "text" };
 import stealthPermissionsScript from "../puppeteer/14_stealth_permissions.txt" with { type: "text" };
+import stealthWebrtcScript from "../puppeteer/15_stealth_webrtc.txt" with { type: "text" };
 import { ToolError } from "../tool-errors";
 
 export const DEFAULT_VIEWPORT = { width: 1365, height: 768, deviceScaleFactor: 1.25 };
@@ -239,6 +240,14 @@ export interface LaunchHeadlessOptions {
 	 * pass an isolated copy, never a live profile dir.
 	 */
 	profileWarmupDir?: string;
+	/**
+	 * Optional opt-in geo alignment (see settings browser.geo.*). When set, the
+	 * browser is launched with a matching timezone (TZ env) and/or UI language
+	 * (--lang) at the source. Default unset = strict no-op: the real environment
+	 * timezone/locale are preserved (never half-spoof). Only align these to a
+	 * coherent value (e.g. one matching a configured proxy egress).
+	 */
+	geo?: { timezone?: string; locale?: string };
 }
 
 export async function launchHeadlessBrowser(opts: LaunchHeadlessOptions): Promise<Browser> {
@@ -253,6 +262,10 @@ export async function launchHeadlessBrowser(opts: LaunchHeadlessOptions): Promis
 		"--no-sandbox",
 		"--disable-setuid-sandbox",
 		"--disable-blink-features=AutomationControlled",
+		// Suppress WebRTC leaking the real local/public IP via ICE candidates
+		// (a common bot tell). Keeps WebRTC functional over the default public
+		// interface only; 15_stealth_webrtc.txt adds a candidate-level guard.
+		"--force-webrtc-ip-handling-policy=default_public_interface_only",
 		`--window-size=${initialViewport.width},${initialViewport.height}`,
 	];
 	if (opts.profileWarmupDir) {
@@ -269,15 +282,22 @@ export async function launchHeadlessBrowser(opts: LaunchHeadlessOptions): Promis
 			launchArgs.push("--proxy-bypass-list=<-loopback>");
 		}
 	}
+	// Opt-in geo alignment (default no-op). Locale via --lang at the source;
+	// timezone via the TZ env passed to the Chrome subprocess.
+	if (opts.geo?.locale) {
+		launchArgs.push(`--lang=${opts.geo.locale}`);
+	}
 	const ignoreCert = process.env.PUPPETEER_PROXY_IGNORE_CERT_ERRORS?.toLowerCase();
 	if (ignoreCert === "true" || ignoreCert === "1" || ignoreCert === "yes" || ignoreCert === "on") {
 		launchArgs.push("--ignore-certificate-errors");
 	}
+	const launchEnv = opts.geo?.timezone ? { ...process.env, TZ: opts.geo.timezone } : undefined;
 	return await puppeteer.launch({
 		headless: opts.headless,
 		defaultViewport: opts.headless ? initialViewport : null,
 		executablePath: await ensureChromiumExecutable(),
 		args: launchArgs,
+		...(launchEnv ? { env: launchEnv } : {}),
 		ignoreDefaultArgs: [...STEALTH_IGNORE_DEFAULT_ARGS],
 		protocolTimeout: BROWSER_PROTOCOL_TIMEOUT_MS,
 	});
@@ -569,6 +589,7 @@ const STEALTH_PATCH_SCRIPTS = [
 	stealthCodecsScript,
 	stealthWorkerScript,
 	stealthPermissionsScript,
+	stealthWebrtcScript,
 ];
 
 function buildStealthInjectionScript(scripts: readonly string[] = STEALTH_PATCH_SCRIPTS): string {

--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -80,6 +80,11 @@ export interface AcquireBrowserOptions {
 	 * Chrome profile (see profile-reuse.ts). Omitted = synthetic session.
 	 */
 	profileReuse?: ProfileReusePosture;
+	/**
+	 * Opt-in geo alignment for the default headless path (from settings
+	 * `browser.geo.*`). Default unset = no-op (real timezone/locale preserved).
+	 */
+	geo?: { timezone?: string; locale?: string };
 }
 
 export async function acquireBrowser(kind: BrowserKind, opts: AcquireBrowserOptions): Promise<BrowserHandle> {
@@ -113,6 +118,7 @@ async function openBrowserHandle(kind: BrowserKind, opts: AcquireBrowserOptions)
 			headless: kind.headless,
 			viewport: opts.viewport,
 			profileWarmupDir,
+			...(opts.geo ? { geo: opts.geo } : {}),
 		});
 		return {
 			key: browserKey(kind),

--- a/packages/coding-agent/src/tools/puppeteer/15_stealth_webrtc.txt
+++ b/packages/coding-agent/src/tools/puppeteer/15_stealth_webrtc.txt
@@ -1,0 +1,60 @@
+// WebRTC IP-leak guard.
+//
+// Even with --force-webrtc-ip-handling-policy, RTCPeerConnection can surface
+// ICE candidates that embed a raw local/public IP literal — a bot/deanon tell
+// that CreepJS and others read. This wrapper strips ONLY candidates that carry
+// a non-mDNS raw IP literal; mDNS ".local" candidates and all other WebRTC
+// behavior (offer/answer, data channels) are left intact so real WebRTC keeps
+// working.
+//
+// Technique adapted (reimplemented) from puppeteer-extra-plugin-stealth
+// (navigator.mediaDevices / webrtc) — see STEALTH-THIRD-PARTY-NOTICES.md.
+
+try {
+	const RTCP = typeof RTCPeerConnection !== "undefined" ? RTCPeerConnection : undefined;
+	if (RTCP && RTCP.prototype) {
+		// A raw IPv4/IPv6 literal that is NOT an mDNS ".local" hostname.
+		const rawIpInCandidate = (candidate) => {
+			if (typeof candidate !== "string" || candidate.length === 0) return false;
+			if (/\.local\b/i.test(candidate)) return false; // mDNS obfuscated — safe
+			const ipv4 = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/;
+			const ipv6 = /\b(?:[0-9a-f]{1,4}:){2,}[0-9a-f]{0,4}\b/i;
+			return ipv4.test(candidate) || ipv6.test(candidate);
+		};
+
+		const origAddEventListener = RTCP.prototype.addEventListener;
+		RTCP.prototype.addEventListener = new Window_Proxy(origAddEventListener, {
+			apply(target, ctx, args) {
+				if (args[0] === "icecandidate" && typeof args[1] === "function") {
+					const userCb = args[1];
+					const wrapped = function (event) {
+						if (event && event.candidate && rawIpInCandidate(event.candidate.candidate)) {
+							return; // drop the raw-IP candidate; keep gathering others
+						}
+						return Reflect.apply(userCb, this, arguments);
+					};
+					return Reflect.apply(target, ctx, [args[0], wrapped, args[2]]);
+				}
+				return Reflect.apply(target, ctx, args);
+			},
+		});
+
+		// Also guard the onicecandidate setter path.
+		const desc = Object_getOwnPropertyDescriptor(RTCP.prototype, "onicecandidate");
+		if (desc && desc.set) {
+			Object_defineProperty(RTCP.prototype, "onicecandidate", {
+				configurable: true,
+				enumerable: desc.enumerable,
+				get: desc.get,
+				set(cb) {
+					if (typeof cb !== "function") return desc.set.call(this, cb);
+					const wrapped = function (event) {
+						if (event && event.candidate && rawIpInCandidate(event.candidate.candidate)) return;
+						return Reflect.apply(cb, this, arguments);
+					};
+					return desc.set.call(this, wrapped);
+				},
+			});
+		}
+	}
+} catch (e) {}

--- a/packages/coding-agent/test/tools/browser-stealth-network.integration.test.ts
+++ b/packages/coding-agent/test/tools/browser-stealth-network.integration.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Browser, CDPSession } from "puppeteer-core";
+import { applyStealthPatches, launchHeadlessBrowser } from "../../src/tools/browser/launch";
+
+// These integration tests launch a real (cached) Chromium and no-op skip when
+// none is resolvable, so they never fail Chromium-less CI environments.
+function chromiumAvailable(): boolean {
+	if (process.env.PUPPETEER_EXECUTABLE_PATH) return true;
+	const cache = path.join(os.homedir(), ".gjc", "puppeteer", "chrome");
+	try {
+		return fs.existsSync(cache) && fs.readdirSync(cache).length > 0;
+	} catch {
+		return false;
+	}
+}
+
+async function withStealthPage<T>(
+	fn: (page: import("puppeteer-core").Page, browser: Browser) => Promise<T>,
+): Promise<T> {
+	const browser = await launchHeadlessBrowser({ headless: true });
+	try {
+		const page = await browser.newPage();
+		await applyStealthPatches(browser, page, { browserSession: null as CDPSession | null, override: null });
+		return await fn(page, browser);
+	} finally {
+		await browser.close();
+	}
+}
+
+describe("stealth network posture (integration)", () => {
+	it("Phase A gate: no HeadlessChrome token in request headers, navigator, or UA-CH brands", async () => {
+		if (!chromiumAvailable()) {
+			expect(true).toBe(true);
+			return;
+		}
+		const headers: Record<string, string> = {};
+		const server = Bun.serve({
+			port: 0,
+			fetch(req) {
+				req.headers.forEach((v, k) => {
+					if (/user-agent|sec-ch-ua/i.test(k)) headers[k] = v;
+				});
+				return new Response("<html><body>ok</body></html>", { headers: { "content-type": "text/html" } });
+			},
+		});
+		try {
+			const url = `http://127.0.0.1:${server.port}/`;
+			const probe = await withStealthPage(async page => {
+				await page.goto(url, { waitUntil: "load" });
+				return page.evaluate(() => {
+					const nav = navigator as unknown as {
+						userAgent: string;
+						userAgentData?: { brands?: Array<{ brand: string }> };
+					};
+					return {
+						navUA: nav.userAgent,
+						brands: (nav.userAgentData?.brands ?? []).map(b => b.brand),
+					};
+				});
+			});
+			expect(headers["user-agent"]).toBeTruthy();
+			expect(headers["user-agent"]).not.toContain("Headless");
+			expect(headers["sec-ch-ua"] ?? "").not.toContain("Headless");
+			expect(probe.navUA).not.toContain("Headless");
+			expect(probe.brands.join(",")).not.toContain("Headless");
+			// navigator UA Chrome major must match the request-header UA major.
+			const major = (ua: string) => ua.match(/Chrome\/(\d+)/)?.[1];
+			expect(major(probe.navUA)).toBe(major(headers["user-agent"]!));
+		} finally {
+			server.stop(true);
+		}
+	}, 120_000);
+
+	it("B1: RTCPeerConnection exposes no non-mDNS raw IP candidate, and WebRTC still negotiates", async () => {
+		if (!chromiumAvailable()) {
+			expect(true).toBe(true);
+			return;
+		}
+		const result = await withStealthPage(async page => {
+			await page.goto("about:blank");
+			return page.evaluate(async () => {
+				const rawIp = (c: string) =>
+					!/\.local\b/i.test(c) &&
+					(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/.test(c) || /\b(?:[0-9a-f]{1,4}:){2,}[0-9a-f]{0,4}\b/i.test(c));
+				let apiWorks = false;
+				const leaked: string[] = [];
+				// Minimal typed shim so this compiles without depending on the
+				// toolchain's DOM WebRTC lib coverage (runs in the browser context).
+				type IceEvt = { candidate: { candidate: string } | null };
+				type MinimalPc = {
+					onicecandidate: ((e: IceEvt) => void) | null;
+					createDataChannel(label: string): void;
+					createOffer(): Promise<unknown>;
+					setLocalDescription(desc: unknown): Promise<void>;
+					localDescription: { sdp?: string } | null;
+					iceGatheringState: string;
+					addEventListener(type: string, cb: () => void): void;
+					close(): void;
+				};
+				const PcCtor = (globalThis as unknown as { RTCPeerConnection: new () => MinimalPc }).RTCPeerConnection;
+				try {
+					const pc = new PcCtor();
+					pc.onicecandidate = e => {
+						if (e.candidate?.candidate && rawIp(e.candidate.candidate)) leaked.push(e.candidate.candidate);
+					};
+					pc.createDataChannel("x");
+					// The guard must not break the core API: offer + gather succeed.
+					await pc.setLocalDescription(await pc.createOffer());
+					await new Promise<void>(res => {
+						pc.addEventListener("icegatheringstatechange", () => pc.iceGatheringState === "complete" && res());
+						setTimeout(res, 3000);
+					});
+					apiWorks = !!pc.localDescription?.sdp;
+					pc.close();
+				} catch {
+					apiWorks = false;
+				}
+				return { leaked, apiWorks };
+			});
+		});
+		// No raw-IP candidate leaked, and the WebRTC API stays functional (the guard
+		// filters only raw-IP candidates; it never nulls the offer/gather flow).
+		expect(result.leaked).toEqual([]);
+		expect(result.apiWorks).toBe(true);
+	}, 120_000);
+
+	it("B2: geo unset is a no-op; geo set overrides the timezone", async () => {
+		if (!chromiumAvailable()) {
+			expect(true).toBe(true);
+			return;
+		}
+		// Default (no geo): the browser's natural timezone with NO override applied.
+		const defaultTz = await withStealthPage(async page => {
+			await page.goto("about:blank");
+			return page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone);
+		});
+		expect(defaultTz).toBeTruthy();
+
+		// geo set: timezone reflects the override (via TZ env at launch) and differs
+		// from the untouched default, proving the override actually took effect.
+		const target = defaultTz === "America/New_York" ? "Asia/Tokyo" : "America/New_York";
+		const browser = await launchHeadlessBrowser({ headless: true, geo: { timezone: target } });
+		try {
+			const page = await browser.newPage();
+			await applyStealthPatches(browser, page, { browserSession: null as CDPSession | null, override: null });
+			await page.goto("about:blank");
+			const overriddenTz = await page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone);
+			expect(overriddenTz).toBe(target);
+			expect(overriddenTz).not.toBe(defaultTz);
+		} finally {
+			await browser.close();
+		}
+	}, 120_000);
+});


### PR DESCRIPTION
## Summary
Follow-up to #2264 / #2270, planned via ralplan consensus (Architect APPROVE + Critic OKAY). Closes the remaining CreepJS network-posture gaps surfaced by live testing. **Measure-first** changed the plan: the UA vector was already clean, so Phase A ships as a regression gate rather than a code fix.

## Phase A — raw UA token (measured: no code fix needed)
A request-header-capture harness confirmed the request `User-Agent` is already `Chrome/148` and `Sec-CH-UA` carries no Headless brand — the existing CDP override already covers request headers + Sec-CH-UA. So Phase A is a **regression gate**: a new integration test asserts no `Headless` token appears in the request `User-Agent`, `Sec-CH-UA`, `navigator.userAgent`, or `userAgentData` brands, and that the navigator UA major matches the request-header major.

## Phase B1 — WebRTC IP-leak suppression (default ON, overridable)
- Launch flag `--force-webrtc-ip-handling-policy=default_public_interface_only`.
- New `15_stealth_webrtc.txt` filters **only** ICE candidates exposing a non-mDNS raw IP literal; it never nulls the candidate stream.
- Test asserts no raw-IP candidate leaks **and** the WebRTC offer/gather API stays functional.

## Phase B2 — timezone/locale alignment (opt-in)
- Settings `browser.geo.timezone` / `browser.geo.locale`, default **unset = strict no-op**.
- Applied at the source (TZ env + `--lang`) on the headless path only; chrome-profile path untouched.
- Test asserts unset is a no-op and a configured timezone overrides the default.

## Honest scope
No public-IP faking (requires a real proxy) and no incoherent timezone/locale spoof (would *increase* detection). Those remain deferred.

## Verification
- New `browser-stealth-network.integration.test.ts`: 3/3 pass (UA gate, WebRTC no-leak + API functional, geo no-op/override).
- 71/71 existing browser tests green (no regression). `tsc` + `biome` clean.
