### PR TITLE
fix(task): surface subagent initialization state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Cooperative mid-run context maintenance now waits at a cancellation-aware FIFO consumer-drain checkpoint before flushing or rewriting session history. Materialized tool results and steering messages are synchronously canonicalized first; aborted barriers and hook/signal-cancelled compactions settle without rewriting or scheduling a continuation. Promotion, pruning, and compaction each start a clean provider/prompt-cache epoch. Script-aware #2067 unsent-delta accounting remains cache-free and distinct from the lifecycle checkpoint.
 - Classified the cooperative mid-run maintenance driver and token estimator test seams as locked non-public SDK exclusions, restoring deterministic operation-inventory generation and post-merge dev CI coverage.
+- Subagent snapshots now distinguish session initialization from active execution, suppress stale live-progress claims before an executor control handle exists, and return an actionable initialization error when steering is attempted too early.
 
 ### Added
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -673,17 +673,14 @@ export class AsyncJobManager {
 	}
 
 	/**
-	 * True only when a live, in-session progress producer exists for this id: a
-	 * canonical registered record with a live handle or an in-memory running job.
-	 * False for `SubagentTool` backward-compat job synthesis and resumed-from-disk
-	 * records, which have no live producer to stream from.
+	 * True only when an executor-owned live session handle exists for this
+	 * subagent. A registered job can remain `running` while its AgentSession is
+	 * still being initialized; that state has no progress producer or control
+	 * channel yet.
 	 */
 	hasLiveSubagent(subagentId: string, filter?: AsyncJobFilter): boolean {
 		const rec = this.getSubagentRecord(subagentId, filter);
-		if (!rec) return false;
-		if (this.#liveHandles.has(rec.subagentId)) return true;
-		const job = rec.currentJobId ? this.#jobs.get(rec.currentJobId) : undefined;
-		return job?.status === "running";
+		return rec ? this.#liveHandles.has(rec.subagentId) : false;
 	}
 
 	/** Install the TaskTool-owned resume runner. Returns the new job id, or undefined on failure. */

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -113,6 +113,7 @@ function statusIconKind(status: SubagentSnapshot["status"]): ToolUIStatus {
 		case "not_found":
 			return "warning";
 		case "queued":
+		case "initializing":
 			return "pending";
 		default:
 			return "info";
@@ -177,6 +178,8 @@ function renderSubagentSnapshotBody(snapshot: SubagentSnapshot, expanded: boolea
 		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, undefined, true)) {
 			lines.push(`  ${pl}`);
 		}
+	} else if (snapshot.phase === "initializing") {
+		lines.push(`  ${theme.fg("dim", "initializing session; live control unavailable")}`);
 	} else if (snapshot.liveProgressAvailable && (snapshot.status === "running" || snapshot.status === "queued")) {
 		lines.push(`  ${theme.fg("dim", "running, no activity yet")}`);
 	}
@@ -217,7 +220,9 @@ export const subagentToolRenderer = {
 			return new Text(theme.fg("dim", truncateToWidth(fallback, 100)), 0, 0);
 		}
 
-		const runningCount = subagents.filter(s => s.status === "running").length;
+		const runningCount = subagents.filter(
+			snapshot => snapshot.status === "running" || snapshot.status === "initializing",
+		).length;
 
 		// Each snapshot's rendered-state signature is constant for this component
 		// instance, so compute them at most once; the heavy per-subagent bodies are

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -41,6 +41,7 @@ const subagentSchema = z.object({
 type SubagentParams = z.infer<typeof subagentSchema>;
 type SubagentStatus =
 	| "running"
+	| "initializing"
 	| "paused"
 	| "queued"
 	| "completed"
@@ -72,6 +73,8 @@ export interface SubagentSnapshot {
 	progress?: AgentProgress;
 	/** True when a live in-session progress producer exists for this subagent. */
 	liveProgressAvailable?: boolean;
+	/** Startup phase derived from the absence/presence of an executor live handle. */
+	phase?: "initializing" | "active";
 	/** Model the subagent actually runs on (after any auth fallback). */
 	effectiveModel?: string;
 	/** Model originally requested via role/preset mapping; differs from effective on fallback. */
@@ -254,7 +257,11 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 				if (!record.sessionFile) throw new ToolError(`Subagent ${record.subagentId} has no session file.`);
 				if (record.status === "running") {
 					const handle = manager.getLiveHandle(record.subagentId);
-					if (!handle) throw new ToolError(`Subagent ${record.subagentId} has no live handle.`);
+					if (!handle) {
+						throw new ToolError(
+							`Subagent ${record.subagentId} is still initializing; live steering is not available yet.`,
+						);
+					}
 					const fromAgentId = this.session.getAgentId?.() ?? undefined;
 					await handle.injectMessage(message, "steer", { fromAgentId });
 					if (params.pause === true) manager.pauseSubagent(record.subagentId, ownerFilter);
@@ -534,7 +541,11 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			snapshots
 				.filter(
 					s =>
-						s.status !== "running" && s.status !== "paused" && s.status !== "queued" && s.status !== "not_found",
+						s.status !== "running" &&
+						s.status !== "initializing" &&
+						s.status !== "paused" &&
+						s.status !== "queued" &&
+						s.status !== "not_found",
 				)
 				.map(s => s.jobId),
 		);
@@ -545,6 +556,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		const lines = [`## ${title} (${snapshots.length})`, ""];
 		for (const snapshot of snapshots) {
 			lines.push(`### ${snapshot.id} — ${snapshot.status}`);
+			if (snapshot.phase === "initializing") lines.push("Phase: initializing session (live control unavailable)");
 			if (snapshot.jobId !== snapshot.id) lines.push(`Job: ${snapshot.jobId}`);
 			if (snapshot.agent) lines.push(`Agent: ${snapshot.agent} (${snapshot.agentSource})`);
 			if (snapshot.effectiveModel) {
@@ -614,20 +626,34 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		attachLiveProgress = false,
 	): SubagentSnapshot {
 		const liveFields = this.#liveProgressFields(manager, record, attachLiveProgress);
+		const phase =
+			record.status === "running"
+				? manager.getLiveHandle(record.subagentId)
+					? "active"
+					: "initializing"
+				: undefined;
 		const job = record.currentJobId ? manager.getJob(record.currentJobId) : undefined;
 		if (job) {
 			return {
 				...this.#snapshot(job, timedOut, verbosity, verifiedOutputIds, record),
 				id: record.subagentId,
 				jobId: record.currentJobId ?? job.id,
-				status: record.status,
+				status: phase === "initializing" ? "initializing" : record.status,
+				...(phase ? { phase } : {}),
+				...(phase === "initializing" && timedOut
+					? {
+							guidance:
+								"Still initializing after the await timeout; no live session or control channel exists yet. The timeout only bounded this wait and is not a failure. Continue observing, and never cancel just because an await timed out; cancel only if the subagent has actually failed, gone off-track, or become unrecoverably wrong.",
+						}
+					: {}),
 				...liveFields,
 			};
 		}
 		return {
 			id: record.subagentId,
 			jobId: record.currentJobId ?? record.subagentId,
-			status: record.status,
+			status: phase === "initializing" ? "initializing" : record.status,
+			...(phase ? { phase } : {}),
 			label: "subagent",
 			agent: "unknown",
 			agentSource: "bundled",

--- a/packages/coding-agent/test/tools/subagent-live-progress.test.ts
+++ b/packages/coding-agent/test/tools/subagent-live-progress.test.ts
@@ -50,6 +50,12 @@ function runningRecord(subagentId: string, jobId: string): SubagentRecord {
 		resumable: false,
 	};
 }
+function registerLiveHandle(manager: AsyncJobManager, subagentId: string): void {
+	manager.registerLiveHandle(subagentId, {
+		requestPause: () => {},
+		injectMessage: async () => {},
+	});
+}
 
 describe("subagent await live progress", () => {
 	afterEach(() => {
@@ -73,6 +79,7 @@ describe("subagent await live progress", () => {
 			},
 		);
 		manager.registerSubagentRecord(runningRecord("0-Live", jobId));
+		registerLiveHandle(manager, "0-Live");
 		// Record progress BEFORE await; no further progress event will fire.
 		manager.recordSubagentProgress(
 			"0-Live",
@@ -122,6 +129,8 @@ describe("subagent await live progress", () => {
 		);
 		manager.registerSubagentRecord(runningRecord("0-A", jobA));
 		manager.registerSubagentRecord(runningRecord("0-B", jobB));
+		registerLiveHandle(manager, "0-A");
+		registerLiveHandle(manager, "0-B");
 		manager.recordSubagentProgress("0-A", makeProgress({ id: "0-A", currentTool: "read" }));
 		manager.recordSubagentProgress("0-B", makeProgress({ id: "0-B", currentTool: "bash" }));
 
@@ -158,9 +167,13 @@ describe("subagent await live progress", () => {
 		const result = await tool.execute("await", { action: "await", ids: ["0-Synth"], timeout_ms: 5 });
 		const snap = result.details?.subagents.find(s => s.id === "0-Synth");
 
-		expect(snap?.status).toBe("running");
+		expect(snap?.status).toBe("initializing");
+		expect(snap?.phase).toBe("initializing");
 		expect(snap?.progress).toBeUndefined();
 		expect(snap?.liveProgressAvailable).toBe(false);
+		expect(result.content[0]?.type === "text" ? result.content[0].text : "").toContain(
+			"initializing session (live control unavailable)",
+		);
 
 		manager.cancel("job-synth", { ownerId: "0-Main" });
 		await manager.dispose({ timeoutMs: 100 });
@@ -202,7 +215,7 @@ describe("AsyncJobManager subagent progress retention", () => {
 		AsyncJobManager.resetForTests();
 	});
 
-	it("hasLiveSubagent is true for a canonical running record and false for synthesized/absent ids", () => {
+	it("hasLiveSubagent requires an executor live handle", () => {
 		const manager = createManager();
 		const jobId = manager.register(
 			"task",
@@ -218,6 +231,7 @@ describe("AsyncJobManager subagent progress retention", () => {
 			},
 		);
 		manager.registerSubagentRecord(runningRecord("0-Live", jobId));
+		registerLiveHandle(manager, "0-Live");
 
 		expect(manager.hasLiveSubagent("0-Live")).toBe(true);
 		expect(manager.hasLiveSubagent("0-Absent")).toBe(false);
@@ -506,6 +520,7 @@ describe("subagent await emit gating", () => {
 				},
 			);
 			manager.registerSubagentRecord(runningRecord(id, jobId));
+			registerLiveHandle(manager, id);
 			manager.recordSubagentProgress(id, makeProgress({ id, currentTool: "read", recentOutput: ["scan"] }));
 		});
 

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -173,6 +173,21 @@ describe("subagentToolRenderer", () => {
 		expect(out).toContain("running, no activity yet");
 	});
 
+	it("keeps the awaiting header active while a subagent initializes", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-Starting",
+					status: "initializing",
+					phase: "initializing",
+					liveProgressAvailable: false,
+				}),
+			],
+		});
+		expect(out).toContain("awaiting 1 of 1");
+		expect(out).toContain("initializing session; live control unavailable");
+	});
+
 	it("renders static status without a no-activity claim when no live producer", () => {
 		const out = render({
 			subagents: [snapshot({ id: "0-Static", status: "running", liveProgressAvailable: false })],

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -139,13 +139,14 @@ describe("SubagentTool", () => {
 		});
 		const guidance = result.details?.subagents[0]?.guidance ?? "";
 
-		expect(result.details?.subagents[0]?.status).toBe("running");
-		expect(guidance).toContain("Still running");
+		expect(result.details?.subagents[0]?.status).toBe("initializing");
+		expect(guidance).toContain("Still initializing");
 		expect(guidance).toContain("not a failure");
 		expect(guidance).toContain("never cancel just because an await timed out");
 		expect(guidance).toContain("cancel only if the subagent has actually failed");
 		expect(guidance).not.toContain("steer");
 		expect(guidance).not.toContain("shutdown");
+		expect(manager.isDeliverySuppressed("job-slow")).toBe(false);
 
 		await Bun.sleep(80);
 		const completed = await tool.execute("subagent-await-completed", {
@@ -240,7 +241,7 @@ describe("SubagentTool", () => {
 
 		const result = await tool.execute("subagent-resume", { action: "resume", ids: ["0-Resume"] });
 
-		expect(result.details?.subagents[0]?.status).toBe("running");
+		expect(result.details?.subagents[0]?.status).toBe("initializing");
 		expect(result.details?.subagents[0]?.jobId).toBe("job-resumed");
 		await manager.dispose({ timeoutMs: 100 });
 	});
@@ -281,7 +282,7 @@ describe("SubagentTool", () => {
 		const result = await tool.execute("subagent-resume-id", { action: "resume", id: "0-ResumeA" });
 
 		expect(resumed).toEqual(["0-ResumeA"]);
-		expect(result.details?.subagents[0]?.status).toBe("running");
+		expect(result.details?.subagents[0]?.status).toBe("initializing");
 		expect(result.details?.subagents[0]?.jobId).toBe("job-0-ResumeA");
 		await manager.dispose({ timeoutMs: 100 });
 	});
@@ -331,6 +332,29 @@ describe("SubagentTool", () => {
 		expect(steerText).toContain("queued");
 		expect(steerText).not.toContain("consumed");
 		expect(steerText).not.toContain("acted on");
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("rejects live steering while the subagent session is still initializing", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		manager.registerSubagentRecord({
+			subagentId: "0-Starting",
+			ownerId: "0-Main",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/0-Starting.jsonl",
+			resumable: true,
+		});
+
+		await expect(
+			tool.execute("subagent-steer-starting", {
+				action: "steer",
+				id: "0-Starting",
+				message: "change direction",
+			}),
+		).rejects.toThrow("still initializing; live steering is not available yet");
 		await manager.dispose({ timeoutMs: 100 });
 	});
 
@@ -438,7 +462,7 @@ describe("SubagentTool", () => {
 		});
 
 		expect(resumedMessage).toBe("follow up");
-		expect(result.details?.subagents[0]?.status).toBe("running");
+		expect(result.details?.subagents[0]?.status).toBe("initializing");
 		expect(result.details?.subagents[0]?.jobId).toBe("job-auto-resumed");
 		expect(result.details?.subagents[0]?.steerMessage).toBe("follow up");
 		expect(result.details?.subagents[0]?.steerState).toBe("resume_started");


### PR DESCRIPTION
## Summary
- surface registered subagents without a live AgentSession handle as `initializing`
- suppress stale live-progress claims and reject premature steering with actionable guidance
- preserve completion delivery and active renderer semantics while initialization is pending
- add lifecycle, renderer, delivery, and steering regression coverage

## Verification
- `bun test packages/coding-agent/test/tools/subagent-live-progress.test.ts packages/coding-agent/test/tools/subagent-render.test.ts packages/coding-agent/test/tools/subagent.test.ts` (55 passed)
- adversarial AsyncJobManager/SubagentTool lifecycle QA passed
- `git diff --check`
- `bun run check:ts` reaches the existing `schemas/config.schema.json` drift on `origin/dev`; all preceding Biome, TypeScript, declaration, Node 20, and public-sync checks passed

## Review
- Architect: CLEAR/CLEAR/CLEAR, APPROVE
- Executor QA/red-team: passed/passed/passed