### PR TITLE
fix(sdk): deliver accepted prompt lifecycle terminals

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Cooperative mid-run context maintenance now waits at a cancellation-aware FIFO consumer-drain checkpoint before flushing or rewriting session history. Materialized tool results and steering messages are synchronously canonicalized first; aborted barriers and hook/signal-cancelled compactions settle without rewriting or scheduling a continuation. Promotion, pruning, and compaction each start a clean provider/prompt-cache epoch. Script-aware #2067 unsent-delta accounting remains cache-free and distinct from the lifecycle checkpoint.
 - Classified the cooperative mid-run maintenance driver and token estimator test seams as locked non-public SDK exclusions, restoring deterministic operation-inventory generation and post-merge dev CI coverage.
+- Accepted SDK prompts now deliver correlated `agent_start` and exactly one terminal lifecycle frame directly to the requesting authenticated WebSocket connection while retaining replayable host events. Harness owner observation also waits for every previously accepted frame to finish serial persistence, so message-update storms and polling gaps cannot hide sticky completion evidence (#2169).
 
 ### Added
 

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -93,6 +93,13 @@ function flattenAggregateCauses(errors: readonly unknown[]): unknown[] {
 	return causes;
 }
 
+/**
+ * Nominal sentinel: raised only after #stopOnce has verified teardown so the
+ * retry loop can rethrow it immediately. A private class prevents a lookalike
+ * cleanup AggregateError (message collision) from bypassing verification retries.
+ */
+class FramePumpAfterVerifiedCleanupError extends AggregateError {}
+
 export interface OwnerOptions {
 	root: string;
 	sessionId: string;
@@ -795,18 +802,14 @@ export class RuntimeOwner {
 			try {
 				await this.#stopOnce();
 				if (this.#framePumpFailure !== null) {
-					throw new AggregateError(
+					throw new FramePumpAfterVerifiedCleanupError(
 						[this.#framePumpFailure, ...flattenAggregateCauses(this.#lastStopFailures)],
 						`Runtime owner frame pump failed after verified cleanup: ${String(this.#framePumpFailure)}`,
 					);
 				}
 				return;
 			} catch (error) {
-				if (
-					error instanceof AggregateError &&
-					error.message.startsWith("Runtime owner frame pump failed after verified cleanup:")
-				)
-					throw error;
+				if (error instanceof FramePumpAfterVerifiedCleanupError) throw error;
 				if (this.#lastStopFailures.length === MAX_RETAINED_CLEANUP_FAILURES) this.#lastStopFailures.shift();
 				this.#lastStopFailures.push(error);
 				if (attempt >= this.#opts.cleanupRetryLimit)

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -106,6 +106,13 @@ export interface OwnerOptions {
 	validationCommands?: ValidationCommandSpec[];
 	/** Test seam for deterministic control-endpoint teardown failures. */
 	controlServerFactory?: (socketPath: string, handler: EndpointHandler) => ControlServer;
+	/** Test seam for deterministic lease-release teardown failures. */
+	leaseRelease?: typeof releaseLease;
+	/** Test seams for frame persistence failures. */
+	framePersistence?: {
+		appendEvent?: typeof appendEvent;
+		writeSessionState?: typeof writeSessionState;
+	};
 	/** Test seams; production retries verified shutdown without a finite limit. */
 	cleanupRetryMs?: number;
 	cleanupRetryLimit?: number;
@@ -125,9 +132,12 @@ const MAX_RETAINED_CLEANUP_FAILURES = 32;
 
 export class RuntimeOwner {
 	readonly ownerId: string;
-	#opts: Required<Omit<OwnerOptions, "clock" | "finalizeChecks" | "validationCommands" | "controlServerFactory">> & {
-		clock?: () => number;
-	};
+	#opts: Required<
+		Omit<
+			OwnerOptions,
+			"clock" | "finalizeChecks" | "validationCommands" | "controlServerFactory" | "framePersistence"
+		>
+	> & { clock?: () => number };
 	#server: ControlServer;
 	#cursor = 0;
 	#leaseEpoch = 0;
@@ -138,10 +148,14 @@ export class RuntimeOwner {
 	#validationCommands?: ValidationCommandSpec[];
 	#unsubscribeFrames: (() => void) | null = null;
 	#framePump: Promise<void> = Promise.resolve();
+	#framePumpFailure: unknown = null;
 	#coalesced = new Map<string, true>();
 	#stopPromise: Promise<void> | null = null;
 	#lastStopFailures: unknown[] = [];
 	#reportedStopFailures = new Set<string>();
+	#transportClosed = false;
+	#serverClosed = false;
+	#framePersistence: Required<NonNullable<OwnerOptions["framePersistence"]>>;
 
 	constructor(opts: OwnerOptions) {
 		this.ownerId = opts.ownerId ?? `owner-${randomUUID()}`;
@@ -157,9 +171,14 @@ export class RuntimeOwner {
 			clock: opts.clock,
 			cleanupRetryMs: opts.cleanupRetryMs ?? DEFAULT_CLEANUP_RETRY_MS,
 			cleanupRetryLimit: opts.cleanupRetryLimit ?? Number.POSITIVE_INFINITY,
+			leaseRelease: opts.leaseRelease ?? releaseLease,
 		};
 		this.#finalizeChecks = opts.finalizeChecks;
 		this.#validationCommands = opts.validationCommands;
+		this.#framePersistence = {
+			appendEvent: opts.framePersistence?.appendEvent ?? appendEvent,
+			writeSessionState: opts.framePersistence?.writeSessionState ?? writeSessionState,
+		};
 		this.#server = (opts.controlServerFactory ?? ((socketPath, handler) => new ControlServer(socketPath, handler)))(
 			this.#socketPath,
 			req => this.#handle(req),
@@ -235,9 +254,14 @@ export class RuntimeOwner {
 		if (!mapped) return;
 		if (mapped.semantic || (mapped.signal && !mapped.coalesceKey)) {
 			this.#framePump = this.#framePump
-				.then(() => this.#flushCoalesced())
-				.then(() => this.#emitMapped(mapped))
-				.catch(() => {});
+				.then(async () => {
+					if (this.#framePumpFailure !== null) return;
+					await this.#flushCoalesced();
+					await this.#emitMapped(mapped);
+				})
+				.catch(error => {
+					if (this.#framePumpFailure === null) this.#framePumpFailure = error;
+				});
 		} else if (mapped.coalesceKey) {
 			// Coalesce progress-noise by key; never enqueues a per-frame emit, so a message_update
 			// storm cannot starve semantic frames. Bound memory.
@@ -253,7 +277,7 @@ export class RuntimeOwner {
 		if (this.#coalesced.size === 0) return;
 		const coalescedFrames = this.#coalesced.size;
 		this.#coalesced.clear();
-		await this.#emit("info", "rpc_activity", { coalescedFrames });
+		await this.#emit("info", "rpc_activity", { coalescedFrames }, true);
 	}
 
 	async #emitMapped(mapped: AgentWireOwnerObservation): Promise<void> {
@@ -267,13 +291,14 @@ export class RuntimeOwner {
 			) {
 				state.lifecycle = "finalizing";
 				state.updatedAt = new Date(this.#opts.clock ? this.#opts.clock() : Date.now()).toISOString();
-				await writeSessionState(this.#opts.root, state);
+				await this.#framePersistence.writeSessionState(this.#opts.root, state);
 			}
 		}
 		await this.#emit(
 			mapped.severity,
 			mapped.kind,
 			mapped.signal ? { ...mapped.evidence, signal: mapped.signal } : mapped.evidence,
+			true,
 		);
 	}
 
@@ -304,7 +329,12 @@ export class RuntimeOwner {
 		return rpcActive ? "rpc-not-idle" : null;
 	}
 
-	async #emit(severity: Severity, kind: string, evidence: Record<string, unknown>): Promise<void> {
+	async #emit(
+		severity: Severity,
+		kind: string,
+		evidence: Record<string, unknown>,
+		framePersistence = false,
+	): Promise<void> {
 		const lease = await readLease(this.#opts.root, this.#opts.sessionId);
 		// Single-writer guard: only emit while we still hold a live lease.
 		if (!lease || !canWriteEvents(lease, this.ownerId, this.#opts.clock)) return;
@@ -330,7 +360,11 @@ export class RuntimeOwner {
 			nextAllowedActions: nextAllowedActions(view.lifecycle, true, { submitUnavailableReason: submitGateReason }),
 			writer: { ownerId: this.ownerId, leaseEpoch: this.#leaseEpoch },
 		};
-		await appendEvent(this.#opts.root, this.#opts.sessionId, envelope);
+		await (framePersistence ? this.#framePersistence.appendEvent : appendEvent)(
+			this.#opts.root,
+			this.#opts.sessionId,
+			envelope,
+		);
 	}
 
 	#response(
@@ -681,7 +715,31 @@ export class RuntimeOwner {
 	}
 
 	async #observe(): Promise<PrimitiveResponse> {
+		// Observation is a read barrier over every frame accepted before this request.
+		// Without it, a fast poll can read state/event storage while the serial frame
+		// pump is still persisting a terminal event, losing sticky completion evidence.
+		await this.#framePump;
 		const state = await this.#loadState();
+		if (this.#framePumpFailure !== null) {
+			const failedState: SessionState = {
+				...state,
+				lifecycle: "blocked",
+				blockers: [...new Set([...state.blockers, "frame-persistence-failed"])],
+			};
+			return this.#response(
+				failedState,
+				{
+					observation: {
+						lifecycle: "blocked",
+						observedSignals: ["frame-persistence-failed"],
+						rpcLive: this.#opts.transport.isLive?.() ?? true,
+					},
+					framePumpFailure: { severity: "critical", error: String(this.#framePumpFailure) },
+					ownerRouted: true,
+				},
+				false,
+			);
+		}
 		const observation = await this.#observeGit();
 		const submitGateReason =
 			typeof observation.submitUnavailableReason === "string" ? observation.submitUnavailableReason : null;
@@ -736,59 +794,88 @@ export class RuntimeOwner {
 		for (let attempt = 1; ; attempt++) {
 			try {
 				await this.#stopOnce();
+				if (this.#framePumpFailure !== null) {
+					throw new AggregateError(
+						[this.#framePumpFailure, ...flattenAggregateCauses(this.#lastStopFailures)],
+						`Runtime owner frame pump failed after verified cleanup: ${String(this.#framePumpFailure)}`,
+					);
+				}
 				return;
 			} catch (error) {
+				if (
+					error instanceof AggregateError &&
+					error.message.startsWith("Runtime owner frame pump failed after verified cleanup:")
+				)
+					throw error;
 				if (this.#lastStopFailures.length === MAX_RETAINED_CLEANUP_FAILURES) this.#lastStopFailures.shift();
 				this.#lastStopFailures.push(error);
 				if (attempt >= this.#opts.cleanupRetryLimit)
-					throw new AggregateError(this.#lastStopFailures, "Runtime owner cleanup could not be verified.");
+					throw new AggregateError(
+						[
+							...(this.#framePumpFailure === null ? [] : [this.#framePumpFailure]),
+							...flattenAggregateCauses(this.#lastStopFailures),
+						],
+						"Runtime owner cleanup could not be verified.",
+					);
 				await Bun.sleep(this.#opts.cleanupRetryMs);
 			}
 		}
 	}
 
-	async #reportStopFailure(kind: string, error: unknown): Promise<void> {
-		if (this.#reportedStopFailures.has(kind)) return;
+	async #reportStopFailure(kind: string, error: unknown): Promise<unknown | null> {
+		if (this.#reportedStopFailures.has(kind)) return null;
 		this.#reportedStopFailures.add(kind);
-		await this.#emit("critical", kind, { error: String(error) }).catch(() => {});
+		try {
+			await this.#emit("critical", kind, { error: String(error) });
+			return null;
+		} catch (reportError) {
+			return reportError;
+		}
 	}
 
 	async #stopOnce(): Promise<void> {
 		const failures: unknown[] = [];
+		const recordFailure = async (kind: string, error: unknown): Promise<void> => {
+			failures.push(error);
+			const reportFailure = await this.#reportStopFailure(kind, error);
+			if (reportFailure !== null) failures.push(reportFailure);
+		};
 		const unsubscribe = this.#unsubscribeFrames;
 		if (unsubscribe) {
 			try {
 				unsubscribe();
 				this.#unsubscribeFrames = null;
 			} catch (error) {
-				failures.push(error);
-				await this.#reportStopFailure("owner_unsubscribe_failed", error);
+				await recordFailure("owner_unsubscribe_failed", error);
 			}
 		}
-		await this.#framePump.catch(() => {});
+		await this.#framePump;
 
-		// The transport owns the exact spawned child. Keep the heartbeat and control
-		// endpoint live until its termination is verified so a replacement cannot
-		// acquire authority merely because this daemon exits.
-		try {
-			await this.#closeTransport();
-		} catch (error) {
-			failures.push(error);
-			await this.#reportStopFailure("owner_transport_stop_failed", error);
+		// The transport owns the exact spawned child. Do not surrender the lease while
+		// it is unverified; once each stage succeeds, retain that proof across retries.
+		if (!this.#transportClosed) {
+			try {
+				await this.#closeTransport();
+				this.#transportClosed = true;
+			} catch (error) {
+				await recordFailure("owner_transport_stop_failed", error);
+			}
 		}
-		if (failures.length > 0) throw new AggregateError(failures, "Runtime owner transport cleanup failed.");
+		if (!this.#transportClosed) throw new AggregateError(failures, "Runtime owner transport cleanup failed.");
 
-		try {
-			await this.#server.close();
-		} catch (error) {
-			failures.push(error);
-			await this.#reportStopFailure("owner_server_stop_failed", error);
+		if (!this.#serverClosed) {
+			try {
+				await this.#server.close();
+				this.#serverClosed = true;
+			} catch (error) {
+				await recordFailure("owner_server_stop_failed", error);
+			}
 		}
-		if (failures.length > 0) throw new AggregateError(failures, "Runtime owner endpoint cleanup failed.");
+		if (!this.#serverClosed) throw new AggregateError(failures, "Runtime owner endpoint cleanup failed.");
 
 		if (this.#leaseHeld) {
 			try {
-				await releaseLease(this.#opts.root, this.#opts.sessionId, this.ownerId);
+				await this.#opts.leaseRelease(this.#opts.root, this.#opts.sessionId, this.ownerId);
 				this.#leaseHeld = false;
 			} catch (error) {
 				if (error instanceof LeaseError && error.code === "not_lease_holder") {
@@ -796,15 +883,17 @@ export class RuntimeOwner {
 					// verified closed, so there is no old authority left to release.
 					this.#leaseHeld = false;
 				} else {
-					await this.#reportStopFailure("owner_lease_release_failed", error);
-					throw error;
+					await recordFailure("owner_lease_release_failed", error);
 				}
 			}
 		}
+		if (this.#leaseHeld) throw new AggregateError(failures, "Runtime owner lease cleanup failed.");
+
 		if (this.#heartbeatTimer) {
 			clearInterval(this.#heartbeatTimer);
 			this.#heartbeatTimer = null;
 		}
+		if (failures.length > 0) throw new AggregateError(failures, "Runtime owner cleanup failed.");
 	}
 }
 

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -19,6 +19,8 @@
  * generated), or `GJC_NOTIFICATIONS_TOKEN`.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import { execFile } from "node:child_process";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
@@ -536,7 +538,21 @@ interface SessionRuntime {
 	/** Identity bound to the agent lifecycle currently in flight. */
 	activePromptCorrelation?: { commandId: string; turnId: string };
 	/** Records a correlated prompt terminal boundary after agent unwind. */
-	recordPromptTerminal: (correlation: { commandId: string; turnId: string } | undefined) => void;
+	/** Atomically claims a correlated prompt terminal boundary after agent unwind. */
+	recordPromptTerminal: (correlation: { commandId: string; turnId: string } | undefined) => boolean;
+	/** Delivers a correlated lifecycle frame only to its accepted requester after acknowledgement. */
+	emitPromptLifecycle: (
+		correlation: { commandId: string; turnId: string } | undefined,
+		frame:
+			| { type: "agent_start" | "agent_end"; sessionId: string; commandId?: string; turnId?: string }
+			| {
+					type: "agent_failed";
+					sessionId: string;
+					commandId: string;
+					turnId: string;
+					error: { code: string; message: string };
+			  },
+	) => void;
 	/** Inbound Telegram update ids injected but not yet consumed by a turn. */
 	pendingInbound: Set<number>;
 	/** Latest assistant text of the in-flight turn (from message_update). */
@@ -558,6 +574,9 @@ interface SessionRuntime {
 	/** Stops optional broker presence heartbeats. */
 	stopBrokerHeartbeat: () => void;
 }
+
+/** Request-local requester authority for stable ControlSurface dispatches. */
+const controlRequesterContext = new AsyncLocalStorage<string>();
 type SessionStartStatus = "started" | "already" | "disabled" | "failed";
 type SessionStartResult = {
 	status: SessionStartStatus;
@@ -576,25 +595,12 @@ function pushSessionFrame(
 /** Agent lifecycle is SDK session truth, independent of optional chat delivery. */
 function emitAgentLifecycle(
 	runtime: Pick<SessionRuntime, "server" | "host">,
-	frame:
-		| { type: "agent_start" | "agent_end"; sessionId: string; commandId?: string; turnId?: string }
-		| {
-				type: "agent_failed";
-				sessionId: string;
-				commandId: string;
-				turnId: string;
-				error: { code: string; message: string };
-		  },
-	connectionId?: string,
+	frame: { type: "agent_start" | "agent_end"; sessionId: string; commandId?: string; turnId?: string },
 ): void {
-	// Lifecycle terminals remain replayable and are also sent directly to the
-	// requester. ACP/MCP/daemon prompt trackers cannot rely on a later replay to
-	// close an already acknowledged submission.
-	runtime.host.emitEvent({ kind: frame.type, payload: frame });
 	try {
 		const json = JSON.stringify(frame);
-		if (connectionId) runtime.server.sendTo(connectionId, json);
-		else runtime.server.pushFrame(json);
+		runtime.host.emitEvent({ kind: frame.type, payload: frame });
+		runtime.server.pushFrame(json);
 	} catch (error) {
 		logger.warn(`sdk: lifecycle delivery failed: ${String(error)}`);
 	}
@@ -1295,9 +1301,21 @@ function sdkQuerySurface(
 		cwd: ctx.cwd,
 		kind: ctx.sessionMetadata?.kind ?? "main",
 	});
-	const sessionManager = ctx.sessionManager as typeof ctx.sessionManager & {
-		getLastAssistantText?: () => string | undefined;
-		getLastAssistantMessage?: () => unknown;
+	const lastAssistantText = () => {
+		for (const entry of ctx.sessionManager.getBranch().toReversed()) {
+			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+			const { content } = entry.message;
+			if (typeof content === "string") return content;
+			if (Array.isArray(content))
+				return content
+					.filter(
+						(block): block is { type: "text"; text: string } =>
+							block.type === "text" && typeof block.text === "string",
+					)
+					.map(block => block.text)
+					.join("");
+		}
+		return undefined;
 	};
 	const getDiff = async () => {
 		try {
@@ -1355,7 +1373,8 @@ function sdkQuerySurface(
 		getSessionMetadata: metadata,
 		getStats: () => ctx.sessionManager.getUsageStatistics(),
 		getBranchCandidates: () => ctx.getBranchCandidates(),
-		getLastAssistant: () => sessionManager.getLastAssistantText?.() ?? sessionManager.getLastAssistantMessage?.(),
+		getLastAssistant: lastAssistantText,
+
 		getCapabilities: () => ({
 			operations: [...installedOperations(ctx, "control"), ...installedOperations(ctx, "query")],
 			hostTools: getInstalledDefinitions("host_tools") !== undefined,
@@ -1390,7 +1409,10 @@ function sdkControlSurface(
 	pendingInteractive: Map<string, PendingInteractiveAsk>,
 	api: ExtensionAPI,
 	isBusy: () => boolean,
-	onPromptAccepted: (correlation: { commandId: string; turnId: string }) => void = () => {},
+	onPromptAccepted: (
+		correlation: { commandId: string; turnId: string },
+		requesterConnectionId?: string,
+	) => void = () => {},
 	onPromptFailed: (correlation: { commandId: string; turnId: string }, error: unknown) => void = () => {},
 	settings?: Settings,
 	configOverrides: Map<string, unknown> = new Map(),
@@ -1425,17 +1447,32 @@ function sdkControlSurface(
 		for (const cancel of pendingPreflightCancellations) cancel();
 	};
 	const awaitAbortReady = async () => {
+		cancelPendingPreflights();
 		await (ctx.abort as () => unknown)();
 		while (isBusy() || !ctx.isIdle()) {
 			await Bun.sleep(10);
 		}
 	};
-	const submitPrompt = async (text: string, images: unknown, forceFresh = false, deliverAs?: "steer" | "followUp") => {
+	const submitPrompt = async (
+		text: string,
+		images: unknown,
+		forceFresh = false,
+		deliverAs?: "steer" | "followUp",
+		rejectWhenBusy = false,
+		requesterConnectionId?: string,
+	) => {
 		if (forceFresh && (isBusy() || !ctx.isIdle())) {
 			throw Object.assign(new Error("Previous turn did not finish aborting before replacement prompt submission."), {
 				code: "busy",
 			});
 		}
+		if (rejectWhenBusy && (isBusy() || !ctx.isIdle()))
+			throw Object.assign(
+				new Error("turn.prompt is unavailable while the agent is busy; use turn.steer explicitly."),
+				{
+					code: "busy",
+				},
+			);
 		const promptImages = Array.isArray(images) ? (images as { data: string; mimeType?: string }[]) : [];
 		const content: string | (TextContent | ImageContent)[] =
 			promptImages.length > 0
@@ -1467,7 +1504,7 @@ function sdkControlSurface(
 		const onPreflightAccepted = () => {
 			if (preflightSettled) return;
 			accepted = true;
-			onPromptAccepted(correlation);
+			onPromptAccepted(correlation, requesterConnectionId);
 			settlePreflight({ status: "accepted" });
 		};
 		// Do not acknowledge the prompt until AgentSession's async preflight
@@ -1510,9 +1547,9 @@ function sdkControlSurface(
 		}
 	};
 	const surface: ControlSurface & { cancelPendingPreflights(): void } = {
-		prompt: (text, images) => submitPrompt(text, images),
+		prompt: (text, images) => submitPrompt(text, images, false, undefined, true, controlRequesterContext.getStore()),
 		steer: text => sendSteer(text),
-		followUp: text => submitPrompt(text, undefined, false, "followUp"),
+		followUp: text => submitPrompt(text, undefined, false, "followUp", false, controlRequesterContext.getStore()),
 		abort: () => {
 			cancelPendingPreflights();
 			ctx.abort();
@@ -1520,7 +1557,7 @@ function sdkControlSurface(
 		},
 		abortAndPrompt: async text => {
 			await awaitAbortReady();
-			return await submitPrompt(text, undefined, true);
+			return await submitPrompt(text, undefined, true, undefined, false, controlRequesterContext.getStore());
 		},
 		cancelPendingPreflights,
 		answerAsk: (id, answer) => {
@@ -1959,69 +1996,153 @@ export function createNotificationsExtension(
 
 		const configOverrides = new Map<string, unknown>();
 		const configRevision = { current: 0 };
+		const PROMPT_SUBMISSION_CAPACITY = 128;
+		const PROMPT_SUBMISSION_TTL_MS = 5 * 60_000;
+		const PROMPT_TERMINAL_TOMBSTONE_CAPACITY = 256;
+		const PROMPT_TERMINAL_TOMBSTONE_TTL_MS = 15 * 60_000;
 		const promptSubmissionKey = (correlation: { commandId: string; turnId: string }) =>
 			`${correlation.commandId}:${correlation.turnId}`;
-		const promptSubmissions = new Map<
-			string,
-			{
-				acknowledged: boolean;
-				connectionId?: string;
-				failed: boolean;
-				error: unknown;
-				terminal: boolean;
-			}
-		>();
+		type PromptLifecycleFrame =
+			| { type: "agent_start" | "agent_end"; sessionId: string; commandId?: string; turnId?: string }
+			| {
+					type: "agent_failed";
+					sessionId: string;
+					commandId: string;
+					turnId: string;
+					error: { code: string; message: string };
+			  };
+		type PromptSubmission = {
+			acknowledged: boolean;
+			connectionId: string;
+			abandoned: boolean;
+			failed: boolean;
+			error: unknown;
+			terminal: boolean;
+			createdAt: number;
+			bufferedLifecycle: PromptLifecycleFrame[];
+		};
+		const promptSubmissions = new Map<string, PromptSubmission>();
+		const promptTerminalTombstones = new Map<string, number>();
 		const removePendingPromptCorrelation = (correlation: { commandId: string; turnId: string }) => {
 			const pendingIndex = pendingPromptCorrelations.findIndex(
 				candidate => candidate.commandId === correlation.commandId && candidate.turnId === correlation.turnId,
 			);
 			if (pendingIndex !== -1) pendingPromptCorrelations.splice(pendingIndex, 1);
 		};
-		const emitPromptFailure = (correlation: { commandId: string; turnId: string }, error: unknown) => {
-			const submissionKey = promptSubmissionKey(correlation);
-			const submission = promptSubmissions.get(submissionKey);
-			if (!submission?.acknowledged || !runtime) return;
-			promptSubmissions.delete(submissionKey);
-			const candidate = error as { code?: unknown; message?: unknown };
-			emitAgentLifecycle(
-				runtime,
-				{
-					type: "agent_failed",
-					sessionId: runtime.id,
-					...correlation,
-					error: {
-						code: typeof candidate.code === "string" ? candidate.code : "internal",
-						message: typeof candidate.message === "string" ? candidate.message : "Prompt submission failed.",
-					},
-				},
-				submission.connectionId,
-			);
-			// A submission can fail after preflight without ever reaching agent_start.
-			// Deliver idle directly after agent_failed so all prompt trackers receive a
-			// recognized terminal transition even though no normal agent_end will fire.
-			if (!runtime.busy && submission.connectionId) {
-				const terminal = {
-					type: "activity",
-					sessionId: runtime.id,
-					...correlation,
-					state: "idle",
-				};
-				runtime.host.emitEvent({ kind: terminal.type, payload: terminal });
+		const addTerminalTombstone = (key: string, now = Date.now()) => {
+			promptTerminalTombstones.delete(key);
+			promptTerminalTombstones.set(key, now + PROMPT_TERMINAL_TOMBSTONE_TTL_MS);
+			while (promptTerminalTombstones.size > PROMPT_TERMINAL_TOMBSTONE_CAPACITY)
+				promptTerminalTombstones.delete(promptTerminalTombstones.keys().next().value!);
+		};
+		const finalizePrompt = (key: string, correlation: { commandId: string; turnId: string }) => {
+			promptSubmissions.delete(key);
+			removePendingPromptCorrelation(correlation);
+			addTerminalTombstone(key);
+		};
+		const cleanupPromptRecords = (now = Date.now()) => {
+			for (const [key, expiresAt] of promptTerminalTombstones)
+				if (expiresAt <= now) promptTerminalTombstones.delete(key);
+			for (const [key, submission] of promptSubmissions)
+				if (submission.createdAt + PROMPT_SUBMISSION_TTL_MS <= now) {
+					const [commandId, turnId] = key.split(":", 2);
+					if (commandId && turnId) finalizePrompt(key, { commandId, turnId });
+				}
+		};
+		const abandonPrompt = (submission: PromptSubmission) => {
+			submission.abandoned = true;
+			submission.bufferedLifecycle.length = 0;
+		};
+		const emitPromptLifecycle = (
+			correlation: { commandId: string; turnId: string } | undefined,
+			frame: PromptLifecycleFrame,
+		) => {
+			cleanupPromptRecords();
+			if (!correlation || !runtime) {
+				emitAgentLifecycle(runtime!, frame as Extract<PromptLifecycleFrame, { type: "agent_start" | "agent_end" }>);
+				return;
+			}
+			const key = promptSubmissionKey(correlation);
+			const submission = promptSubmissions.get(key);
+			if (!submission) return;
+			if (submission.abandoned) {
+				if (submission.terminal) finalizePrompt(key, correlation);
+				return;
+			}
+			if (!submission.acknowledged) {
+				submission.bufferedLifecycle.push(frame);
+				return;
+			}
+			try {
+				runtime.server.sendTo(submission.connectionId, JSON.stringify(frame));
+			} catch (error) {
+				logger.warn(`sdk: correlated lifecycle delivery failed: ${String(error)}`);
+				abandonPrompt(submission);
+			}
+			if (submission.terminal) finalizePrompt(key, correlation);
+		};
+		const flushPromptLifecycle = (key: string, submission: PromptSubmission) => {
+			for (const frame of submission.bufferedLifecycle.splice(0)) {
 				try {
-					runtime.server.sendTo(submission.connectionId, JSON.stringify(terminal));
-				} catch (deliveryError) {
-					logger.warn(`sdk: prompt failure terminal delivery failed: ${String(deliveryError)}`);
+					server.sendTo(submission.connectionId, JSON.stringify(frame));
+				} catch (error) {
+					logger.warn(`sdk: buffered correlated lifecycle delivery failed: ${String(error)}`);
+					abandonPrompt(submission);
+					break;
 				}
 			}
+			if (submission.terminal) {
+				const [commandId, turnId] = key.split(":", 2);
+				if (commandId && turnId) finalizePrompt(key, { commandId, turnId });
+			}
 		};
-
-		const recordPromptAccepted = (correlation: { commandId: string; turnId: string }) => {
+		const recordPromptAccepted = (
+			correlation: { commandId: string; turnId: string },
+			requesterConnectionId?: string,
+		) => {
+			if (!requesterConnectionId) return;
+			cleanupPromptRecords();
+			while (promptSubmissions.size >= PROMPT_SUBMISSION_CAPACITY) {
+				const oldest = promptSubmissions.entries().next().value as [string, PromptSubmission] | undefined;
+				if (!oldest) break;
+				const [key] = oldest;
+				const [commandId, turnId] = key.split(":", 2);
+				if (commandId && turnId) finalizePrompt(key, { commandId, turnId });
+			}
 			pendingPromptCorrelations.push(correlation);
 			promptSubmissions.set(promptSubmissionKey(correlation), {
 				acknowledged: false,
+				connectionId: requesterConnectionId,
+				abandoned: false,
 				failed: false,
 				error: undefined,
 				terminal: false,
+				createdAt: Date.now(),
+				bufferedLifecycle: [],
+			});
+		};
+		const recordPromptTerminal = (correlation: { commandId: string; turnId: string } | undefined) => {
+			if (!correlation) return false;
+			cleanupPromptRecords();
+			const key = promptSubmissionKey(correlation);
+			if (promptTerminalTombstones.has(key)) return false;
+			const submission = promptSubmissions.get(key);
+			if (!submission || submission.terminal) return false;
+			submission.terminal = true;
+			return true;
+		};
+		const emitPromptFailure = (correlation: { commandId: string; turnId: string }, error: unknown) => {
+			const submission = promptSubmissions.get(promptSubmissionKey(correlation));
+			if (!submission || !runtime || !recordPromptTerminal(correlation)) return;
+			const candidate = error as { code?: unknown; message?: unknown };
+			emitPromptLifecycle(correlation, {
+				type: "agent_failed",
+				sessionId: runtime.id,
+				...correlation,
+				error: {
+					code: typeof candidate.code === "string" ? candidate.code : "internal",
+					message: typeof candidate.message === "string" ? candidate.message : "Prompt submission failed.",
+				},
 			});
 		};
 		const recordPromptFailure = (correlation: { commandId: string; turnId: string }, error: unknown) => {
@@ -2033,23 +2154,11 @@ export function createNotificationsExtension(
 			emitPromptFailure(correlation, error);
 		};
 		const acknowledgePrompt = (connectionId: string, correlation: { commandId: string; turnId: string }) => {
-			const submission = promptSubmissions.get(promptSubmissionKey(correlation));
-			if (!submission) return;
-			submission.connectionId = connectionId;
+			const key = promptSubmissionKey(correlation);
+			const submission = promptSubmissions.get(key);
+			if (!submission || submission.abandoned || submission.connectionId !== connectionId) return;
 			submission.acknowledged = true;
-			if (submission.failed) {
-				emitPromptFailure(correlation, submission.error);
-			} else if (submission.terminal) {
-				promptSubmissions.delete(promptSubmissionKey(correlation));
-			}
-		};
-
-		const recordPromptTerminal = (correlation: { commandId: string; turnId: string } | undefined) => {
-			if (!correlation) return;
-			const submission = promptSubmissions.get(promptSubmissionKey(correlation));
-			if (!submission) return;
-			submission.terminal = true;
-			if (submission.acknowledged && !submission.failed) promptSubmissions.delete(promptSubmissionKey(correlation));
+			flushPromptLifecycle(key, submission);
 		};
 
 		const cursors = new CursorRegistry(token, revisions);
@@ -2080,13 +2189,31 @@ export function createNotificationsExtension(
 			ctx,
 			pendingInteractive,
 			api,
-			() => runtime?.busy === true,
+			() => runtime?.busy === true || pendingPromptCorrelations.length > 0,
 			recordPromptAccepted,
 			recordPromptFailure,
 			settings,
 			configOverrides,
 			configRevision,
 		);
+		const abandonPromptResponse = (connectionId: string, frame: Record<string, unknown>) => {
+			if (
+				frame.type !== "control_response" ||
+				frame.ok !== true ||
+				!frame.result ||
+				typeof frame.result !== "object"
+			)
+				return;
+			const result = frame.result as { accepted?: unknown; commandId?: unknown; turnId?: unknown };
+			if (result.accepted !== true || typeof result.commandId !== "string" || typeof result.turnId !== "string")
+				return;
+			const submission = promptSubmissions.get(
+				promptSubmissionKey({ commandId: result.commandId, turnId: result.turnId }),
+			);
+			if (!submission || submission.acknowledged || submission.connectionId !== connectionId) return;
+			abandonPrompt(submission);
+		};
+
 		const sendSdkFrame = (connectionId: string, frame: Record<string, unknown>) => {
 			const json = JSON.stringify(frame);
 			if (connectionId.startsWith("seam:")) {
@@ -2100,6 +2227,7 @@ export function createNotificationsExtension(
 					});
 				} catch (error) {
 					logger.warn(`sdk: seam response delivery failed for ${connectionId}: ${String(error)}`);
+					abandonPromptResponse(connectionId, frame);
 					throw error;
 				}
 				return;
@@ -2108,6 +2236,7 @@ export function createNotificationsExtension(
 				server.sendTo(connectionId, json);
 			} catch (error) {
 				logger.warn(`sdk: directed response delivery failed for ${connectionId}: ${String(error)}`);
+				abandonPromptResponse(connectionId, frame);
 				throw error;
 			}
 		};
@@ -2153,7 +2282,7 @@ export function createNotificationsExtension(
 					if (response.ok === true && pending) await rotateSessionAuthority(pending.event, pending.ctx);
 				}
 			},
-			control: async (_connectionId, frame) => {
+			control: async (connectionId, frame) => {
 				const request = frame as {
 					id?: unknown;
 					operation?: unknown;
@@ -2172,17 +2301,20 @@ export function createNotificationsExtension(
 						error: { code: "conflict", message: "session identity mutation is already active" },
 					};
 				if (rotatesIdentity) identityControlInFlight = true;
-				const response = await dispatchControl(
-					controlSurface,
-					OPERATIONS.find(row => row.kind === "control" && row.sdkId === operation),
-					{
-						id: requestId,
-						operation,
-						input: request.input,
-						expectedRevision: typeof request.expectedRevision === "string" ? request.expectedRevision : undefined,
-						idempotencyKey: typeof request.idempotencyKey === "string" ? request.idempotencyKey : undefined,
-						confirm: request.confirm === true,
-					},
+				const response = await controlRequesterContext.run(connectionId, () =>
+					dispatchControl(
+						controlSurface,
+						OPERATIONS.find(row => row.kind === "control" && row.sdkId === operation),
+						{
+							id: requestId,
+							operation,
+							input: request.input,
+							expectedRevision:
+								typeof request.expectedRevision === "string" ? request.expectedRevision : undefined,
+							idempotencyKey: typeof request.idempotencyKey === "string" ? request.idempotencyKey : undefined,
+							confirm: request.confirm === true,
+						},
+					),
 				);
 				if (rotatesIdentity && response.ok !== true) {
 					identityControlInFlight = false;
@@ -2242,6 +2374,7 @@ export function createNotificationsExtension(
 			pendingPromptCorrelations,
 			activePromptCorrelation: undefined,
 			recordPromptTerminal,
+			emitPromptLifecycle,
 			pendingInbound: new Set<number>(),
 		};
 		runtimes.set(id, runtime);
@@ -2285,8 +2418,11 @@ export function createNotificationsExtension(
 					inboundSdkFrame?.(inbound.connectionId, JSON.parse(inbound.json) as Record<string, unknown>);
 				} catch {}
 			});
-			server.onConnectionClose((err, connectionId) => {
-				if (!err && connectionId) host.handleDisconnect(connectionId);
+			server.onConnectionClose((_err, connectionId) => {
+				if (!connectionId) return;
+				host.handleDisconnect(connectionId);
+				for (const submission of promptSubmissions.values())
+					if (submission.connectionId === connectionId) abandonPrompt(submission);
 			});
 
 			server.onReply((err, reply) => {
@@ -2913,7 +3049,7 @@ export function createNotificationsExtension(
 		rt.busy = true;
 		const correlation = rt.pendingPromptCorrelations.shift();
 		rt.activePromptCorrelation = correlation;
-		emitAgentLifecycle(rt, { type: "agent_start", sessionId: id, ...correlation });
+		rt.emitPromptLifecycle(correlation, { type: "agent_start", sessionId: id, ...correlation });
 		try {
 			// `activity` is the native live-host lifecycle surface. The separately
 			// emitted agent_start above is replayable with command/turn correlation.
@@ -2954,9 +3090,12 @@ export function createNotificationsExtension(
 		// Clear the streaming flag for SDK consumers even when notifications are off.
 		rt.busy = false;
 		const correlation = rt.activePromptCorrelation;
-		rt.activePromptCorrelation = undefined;
-		rt.recordPromptTerminal(correlation);
-		emitAgentLifecycle(rt, { type: "agent_end", sessionId: id, ...correlation });
+		if (correlation) {
+			if (rt.recordPromptTerminal(correlation))
+				rt.emitPromptLifecycle(correlation, { type: "agent_end", sessionId: id, ...correlation });
+		} else {
+			rt.emitPromptLifecycle(undefined, { type: "agent_end", sessionId: id });
+		}
 		try {
 			pushSessionFrame(rt, { type: "activity", sessionId: id, state: "idle" });
 		} catch (e) {

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -540,7 +540,7 @@ interface SessionRuntime {
 	/** Records a correlated prompt terminal boundary after agent unwind. */
 	/** Atomically claims a correlated prompt terminal boundary after agent unwind. */
 	recordPromptTerminal: (correlation: { commandId: string; turnId: string } | undefined) => boolean;
-	/** Delivers a correlated lifecycle frame only to its accepted requester after acknowledgement. */
+	/** Records correlated lifecycle frames for replay and delivers them only to the accepted requester after acknowledgement. */
 	emitPromptLifecycle: (
 		correlation: { commandId: string; turnId: string } | undefined,
 		frame:
@@ -2065,6 +2065,7 @@ export function createNotificationsExtension(
 			const key = promptSubmissionKey(correlation);
 			const submission = promptSubmissions.get(key);
 			if (!submission) return;
+			runtime.host.emitEvent({ kind: frame.type, payload: frame });
 			if (submission.abandoned) {
 				if (submission.terminal) finalizePrompt(key, correlation);
 				return;

--- a/packages/coding-agent/test/harness-control-plane/owner-frames.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner-frames.test.ts
@@ -20,6 +20,7 @@ class FrameTransport implements HarnessSessionTransport {
 	live = true;
 	closeCalls = 0;
 	closeFailures = 0;
+	closeFailure: (() => unknown) | null = null;
 	closed = false;
 	#cb: ((frame: Record<string, unknown>) => void) | null = null;
 	#lastAt: string | null = null;
@@ -39,7 +40,7 @@ class FrameTransport implements HarnessSessionTransport {
 		this.closeCalls += 1;
 		if (this.closeFailures > 0) {
 			this.closeFailures -= 1;
-			throw new Error("injected transport cleanup failure");
+			throw this.closeFailure?.() ?? new Error("injected transport cleanup failure");
 		}
 		this.closed = true;
 	}
@@ -350,6 +351,68 @@ describe("owner frame -> observability", () => {
 		expect(transport.closeCalls).toBe(2);
 		expect(serverCloseCalls).toBe(2);
 		expect(leaseReleaseCalls).toBe(2);
+		owner = null;
+	});
+
+	it("retries a lookalike frame-pump cleanup aggregate before surfacing the latched failure", async () => {
+		const transport = new FrameTransport();
+		transport.closeFailures = 1;
+		transport.closeFailure = () =>
+			new AggregateError(
+				[new Error("injected lookalike transport cleanup failure")],
+				"Runtime owner frame pump failed after verified cleanup: lookalike",
+			);
+		let serverCloseCalls = 0;
+		let serverClosed = false;
+		let leaseReleaseCalls = 0;
+		let leaseReleased = false;
+		const runtime = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			transport,
+			cleanupRetryMs: 0,
+			cleanupRetryLimit: 4,
+			controlServerFactory(socketPath, handler) {
+				const server = new ControlServer(socketPath, handler);
+				const close = server.close.bind(server);
+				server.close = async () => {
+					serverCloseCalls += 1;
+					await close();
+					serverClosed = true;
+				};
+				return server;
+			},
+			leaseRelease: async (...args) => {
+				leaseReleaseCalls += 1;
+				await releaseLease(...args);
+				leaseReleased = true;
+			},
+			framePersistence: {
+				async appendEvent() {
+					throw new Error("injected latched frame pump failure");
+				},
+			},
+		});
+		owner = runtime;
+		await runtime.start();
+		transport.emit({ type: "agent_start" });
+		await flush();
+
+		const failure = await runtime.stop().then(
+			() => null,
+			error => error,
+		);
+		expect(failure).toBeInstanceOf(AggregateError);
+		expect((failure as Error).message).toContain("Runtime owner frame pump failed after verified cleanup:");
+		const causes = (failure as AggregateError).errors.map(String).join("\n");
+		expect(causes).toContain("injected latched frame pump failure");
+		expect(causes).toContain("injected lookalike transport cleanup failure");
+		expect(transport.closed).toBe(true);
+		expect(serverClosed).toBe(true);
+		expect(leaseReleased).toBe(true);
+		expect(transport.closeCalls).toBe(2);
+		expect(serverCloseCalls).toBe(1);
+		expect(leaseReleaseCalls).toBe(1);
 		owner = null;
 	});
 

--- a/packages/coding-agent/test/harness-control-plane/owner-frames.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner-frames.test.ts
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
-import { callEndpoint } from "../../src/harness-control-plane/control-endpoint";
+import { ControlServer, callEndpoint } from "../../src/harness-control-plane/control-endpoint";
 import { RuntimeOwner } from "../../src/harness-control-plane/owner";
+import { releaseLease } from "../../src/harness-control-plane/session-lease";
 import type { HarnessSessionTransport, SessionStateSnapshot } from "../../src/harness-control-plane/session-transport";
 import { readEvents, writeSessionState } from "../../src/harness-control-plane/storage";
 import {
@@ -17,6 +18,9 @@ import {
 class FrameTransport implements HarnessSessionTransport {
 	cursor = 0;
 	live = true;
+	closeCalls = 0;
+	closeFailures = 0;
+	closed = false;
 	#cb: ((frame: Record<string, unknown>) => void) | null = null;
 	#lastAt: string | null = null;
 	async getState(): Promise<SessionStateSnapshot> {
@@ -31,7 +35,14 @@ class FrameTransport implements HarnessSessionTransport {
 	async waitForAgentStart(): Promise<{ cursor: number } | null> {
 		return null;
 	}
-	async close(): Promise<void> {}
+	async close(): Promise<void> {
+		this.closeCalls += 1;
+		if (this.closeFailures > 0) {
+			this.closeFailures -= 1;
+			throw new Error("injected transport cleanup failure");
+		}
+		this.closed = true;
+	}
 	onEventFrame(cb: (frame: Record<string, unknown>) => void): () => void {
 		this.#cb = cb;
 		return () => {
@@ -202,46 +213,174 @@ describe("owner frame -> observability", () => {
 		expect(obsJson).not.toContain("SECRET_PARTIAL");
 		expect(obsJson).not.toContain("SECRET_OUTPUT");
 	});
-	it("AC-6: a message_update storm cannot starve agent_end (completed) or bloat the event log", async () => {
+	it("AC-6: repeated message_update storms cannot starve terminal observation or bloat the event log", async () => {
 		const transport = new FrameTransport();
 		owner = new RuntimeOwner({ root, sessionId: SID, transport });
 		const info = await owner.start();
-		transport.emit({ type: "agent_start" });
-		for (let i = 0; i < 500; i++) transport.emit({ type: "message_update", messageId: "m1", delta: "noise" });
-		transport.emit({ type: "agent_end" });
-		await flush();
+		for (let turn = 0; turn < 8; turn++) {
+			transport.emit({ type: "agent_start" });
+			for (let i = 0; i < 500; i++)
+				transport.emit({ type: "message_update", messageId: `m${turn}`, delta: "noise" });
+			transport.emit({ type: "agent_end" });
+			const obs = obsOf(
+				(await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, unknown>,
+			);
+			expect(obs.observedSignals).toContain("completed");
+		}
 
 		const events = await readEvents(root, SID, 0);
-		expect(events.map(e => e.kind)).toContain("rpc_agent_completed");
-		// 500 message_update frames are coalesced, not emitted 1:1.
+		expect(events.filter(event => event.kind === "rpc_agent_completed")).toHaveLength(8);
+		// Four thousand message_update frames are coalesced instead of emitted 1:1.
 		expect(events.length).toBeLessThan(60);
-		const obs = obsOf(
-			(await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, unknown>,
-		);
-		expect(obs.observedSignals).toContain("completed");
 	});
 
-	it("AC-7: transient tool-call/completed survive polling gaps (sticky from the event log)", async () => {
+	it("AC-7: repeated poll gaps retain sticky tool-call/completed signals without settlement sleeps", async () => {
 		const transport = new FrameTransport();
 		owner = new RuntimeOwner({ root, sessionId: SID, transport });
 		const info = await owner.start();
-		// frames happen BETWEEN observe polls
-		transport.emit({ type: "tool_execution_start", toolCallId: "t1", toolName: "read", args: { path: "x" } });
-		transport.emit({
-			type: "tool_execution_end",
-			toolCallId: "t1",
-			toolName: "read",
-			result: { details: { status: "ok" } },
+		for (let turn = 0; turn < 8; turn++) {
+			// Every frame sequence lands between observe polls.
+			transport.emit({
+				type: "tool_execution_start",
+				toolCallId: `t${turn}`,
+				toolName: "read",
+				args: { path: "x" },
+			});
+			transport.emit({
+				type: "tool_execution_end",
+				toolCallId: `t${turn}`,
+				toolName: "read",
+				result: { details: { status: "ok" } },
+			});
+			transport.emit({ type: "agent_end" });
+			const obs = obsOf(
+				(await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, unknown>,
+			);
+			expect(obs.observedSignals).toContain("tool-call");
+			expect(obs.observedSignals).toContain("completed");
+			expect(obs.observedSignals).toContain("idle");
+		}
+	});
+
+	it("latches append failure as blocking observation evidence and rejects shutdown", async () => {
+		const transport = new FrameTransport();
+		const runtime = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			transport,
+			framePersistence: {
+				async appendEvent() {
+					throw new Error("injected frame append failure");
+				},
+			},
 		});
-		transport.emit({ type: "agent_end" });
-		await flush();
-		// getState reports idle now, but the later observe still shows the transient signals.
-		const obs = obsOf(
-			(await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, unknown>,
+		owner = runtime;
+		const info = await runtime.start();
+		transport.emit({ type: "agent_start" });
+
+		const response = (await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, any>;
+		expect(response.ok).toBe(false);
+		expect(response.state.lifecycle).toBe("blocked");
+		expect(response.state.blockers).toContain("frame-persistence-failed");
+		expect(obsOf(response).observedSignals).toEqual(["frame-persistence-failed"]);
+		expect(response.evidence.framePumpFailure.error).toContain("injected frame append failure");
+		expect(response.evidence.framePumpFailure.severity).toBe("critical");
+		const repeated = (await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, any>;
+		expect(repeated.ok).toBe(false);
+		expect(repeated.state.blockers).toContain("frame-persistence-failed");
+		await expect(runtime.stop()).rejects.toThrow("injected frame append failure");
+		owner = null;
+	});
+
+	it("retries all cleanup stages before surfacing a latched frame-pump failure", async () => {
+		const transport = new FrameTransport();
+		transport.closeFailures = 1;
+		let serverCloseCalls = 0;
+		let serverClosed = false;
+		let leaseReleaseCalls = 0;
+		let leaseReleased = false;
+		const runtime = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			transport,
+			cleanupRetryMs: 0,
+			cleanupRetryLimit: 4,
+			controlServerFactory(socketPath, handler) {
+				const server = new ControlServer(socketPath, handler);
+				const close = server.close.bind(server);
+				server.close = async () => {
+					serverCloseCalls += 1;
+					await close();
+					serverClosed = true;
+					if (serverCloseCalls === 1) throw new Error("injected server cleanup failure");
+				};
+				return server;
+			},
+			leaseRelease: async (...args) => {
+				leaseReleaseCalls += 1;
+				if (leaseReleaseCalls === 1) throw new Error("injected lease cleanup failure");
+				await releaseLease(...args);
+				leaseReleased = true;
+			},
+			framePersistence: {
+				async appendEvent() {
+					throw new Error("injected frame pump failure");
+				},
+			},
+		});
+		owner = runtime;
+		const info = await runtime.start();
+		transport.emit({ type: "agent_start" });
+		const blocked = (await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, any>;
+		expect(blocked.state.blockers).toContain("frame-persistence-failed");
+
+		const failure = await runtime.stop().then(
+			() => null,
+			error => error,
 		);
-		expect(obs.observedSignals).toContain("tool-call");
-		expect(obs.observedSignals).toContain("completed");
-		expect(obs.observedSignals).toContain("idle"); // overlay present, did not evict semantic signals
+		expect(failure).toBeInstanceOf(AggregateError);
+		const causes = (failure as AggregateError).errors.map(String).join("\n");
+		expect(causes).toContain("injected frame pump failure");
+		expect(causes).toContain("injected transport cleanup failure");
+		expect(causes).toContain("injected server cleanup failure");
+		expect(causes).toContain("injected lease cleanup failure");
+		expect(transport.closed).toBe(true);
+		expect(serverClosed).toBe(true);
+		expect(leaseReleased).toBe(true);
+		expect(transport.closeCalls).toBe(2);
+		expect(serverCloseCalls).toBe(2);
+		expect(leaseReleaseCalls).toBe(2);
+		owner = null;
+	});
+
+	it("latches terminal state-write failure before emitting completion", async () => {
+		const transport = new FrameTransport();
+		const runtime = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			transport,
+			framePersistence: {
+				async writeSessionState() {
+					throw new Error("injected terminal state write failure");
+				},
+			},
+		});
+		owner = runtime;
+		const info = await runtime.start();
+		transport.emit({ type: "agent_end" });
+
+		const response = (await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, any>;
+		expect(response.ok).toBe(false);
+		expect(response.state.lifecycle).toBe("blocked");
+		expect(response.state.blockers).toContain("frame-persistence-failed");
+		expect(obsOf(response).observedSignals).toEqual(["frame-persistence-failed"]);
+		expect(response.evidence.framePumpFailure.error).toContain("injected terminal state write failure");
+		expect(response.evidence.framePumpFailure.severity).toBe("critical");
+		expect(await readEvents(root, SID, 0)).not.toContainEqual(
+			expect.objectContaining({ kind: "rpc_agent_completed" }),
+		);
+		await expect(runtime.stop()).rejects.toThrow("injected terminal state write failure");
+		owner = null;
 	});
 
 	it("rpcLive is distinct from ownerLive (RPC death does not imply dead owner)", async () => {

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -34,7 +34,7 @@ import type {
 	ClientBridgePermissionOutcome,
 	ClientBridgePermissionToolCall,
 } from "../src/session/client-bridge";
-
+import { SessionManager } from "../src/session/session-manager";
 import { getAskAnswerSource } from "../src/tools/ask-answer-registry";
 
 type SdkPermissionProvider =
@@ -110,6 +110,7 @@ function context(
 			getSessionId: () => sessionId,
 			getSessionName: () => "SDK wiring",
 			getUsageStatistics: () => ({ input: 1, output: 2, cacheRead: 0, cacheWrite: 0, premiumRequests: 0, cost: 0 }),
+			getBranch: () => [],
 		},
 		getContextUsage: () => ({ tokens: 3, contextWindow: 100, percent: 3 }),
 		model: { provider: "fixture-provider", id: "reasoning-model" },
@@ -820,7 +821,6 @@ test("SDK host preserves ordered prompt image blocks in the host payload", async
 		socket.addEventListener("open", () => resolve(), { once: true });
 		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
 	});
-	void handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
 
 	const prompt = async (requestId: string, input: Record<string, unknown>) => {
 		socket.send(
@@ -842,6 +842,8 @@ test("SDK host preserves ordered prompt image blocks in the host payload", async
 		text: "Compare these screenshots.",
 		images: [{ data: "cG5nLWJ5dGVz", mimeType: "image/png" }, { data: "ZGVmYXVsdC1taW1l" }],
 	});
+	await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+	await handlers.get("agent_end")?.({ type: "agent_end" }, sessionContext);
 	await prompt("images-only", {
 		text: "",
 		images: [{ data: "d2VicC1ieXRlcw", mimeType: "image/webp" }],
@@ -854,9 +856,9 @@ test("SDK host preserves ordered prompt image blocks in the host payload", async
 				{ type: "image", data: "cG5nLWJ5dGVz", mimeType: "image/png" },
 				{ type: "image", data: "ZGVmYXVsdC1taW1l", mimeType: "image/jpeg" },
 			],
-			{ deliverAs: "steer" },
+			undefined,
 		],
-		[[{ type: "image", data: "d2VicC1ieXRlcw", mimeType: "image/webp" }], { deliverAs: "steer" }],
+		[[{ type: "image", data: "d2VicC1ieXRlcw", mimeType: "image/webp" }]],
 	]);
 });
 
@@ -904,21 +906,213 @@ test("SDK host correlates follow-up acknowledgements with the later agent start"
 	if (typeof commandId !== "string" || typeof turnId !== "string") throw new Error("missing follow-up correlation");
 	expect(sent).toEqual([["queued follow-up", { deliverAs: "followUp" }]]);
 	void handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
-	socket.send(JSON.stringify({ type: "event_replay", id: "follow-up-replay", sinceGeneration: 1, sinceSeq: 0 }));
 	await waitFor(
-		() => frames.some(frame => frame.type === "event_replay_result" && frame.id === "follow-up-replay"),
-		"correlated agent start replay",
+		() => frames.some(frame => frame.type === "agent_start" && frame.commandId === commandId),
+		"correlated agent start",
 	);
-	const replay = frames.find(frame => frame.type === "event_replay_result" && frame.id === "follow-up-replay");
-	expect(replay?.events).toEqual(
-		expect.arrayContaining([
-			expect.objectContaining({
-				type: "event",
-				kind: "agent_start",
-				payload: expect.objectContaining({ type: "agent_start", sessionId, commandId, turnId }),
-			}),
-		]),
+	expect(frames).toEqual(
+		expect.arrayContaining([expect.objectContaining({ type: "agent_start", sessionId, commandId, turnId })]),
 	);
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+});
+
+test("SDK host directly delivers correlated lifecycle frames for an accepted prompt", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-success-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-prompt-success-${Date.now()}`;
+	const sessionContext = context(cwd, sessionId);
+	const handlers = start(sessionContext);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	const observerFrames: Record<string, unknown>[] = [];
+	const observer = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(observer);
+	observer.addEventListener("message", event => observerFrames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		observer.addEventListener("open", () => resolve(), { once: true });
+		observer.addEventListener("error", () => reject(new Error("observer WS error")), { once: true });
+	});
+	socket.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "prompt-success",
+			operation: "turn.prompt",
+			input: { text: "accepted prompt" },
+		}),
+	);
+	await waitFor(
+		() => frames.some(frame => frame.type === "control_response" && frame.id === "prompt-success"),
+		"accepted prompt acknowledgement",
+	);
+	const acknowledgement = frames.find(frame => frame.type === "control_response" && frame.id === "prompt-success") as {
+		result?: { commandId?: unknown; turnId?: unknown };
+	};
+	expect(acknowledgement).toMatchObject({
+		ok: true,
+		result: { accepted: true, commandId: expect.any(String), turnId: expect.any(String) },
+	});
+	await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+	socket.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "prompt-while-busy",
+			operation: "turn.prompt",
+			input: { text: "must not steer" },
+		}),
+	);
+	await waitFor(
+		() => frames.some(frame => frame.type === "control_response" && frame.id === "prompt-while-busy"),
+		"busy prompt rejection",
+	);
+	expect(frames.find(frame => frame.type === "control_response" && frame.id === "prompt-while-busy")).toMatchObject({
+		ok: false,
+		error: { code: "busy" },
+	});
+	await handlers.get("agent_end")?.({ type: "agent_end" }, sessionContext);
+	await waitFor(
+		() => frames.some(frame => frame.type === "agent_start") && frames.some(frame => frame.type === "agent_end"),
+		"correlated accepted prompt lifecycle",
+	);
+	const correlation = {
+		commandId: acknowledgement.result?.commandId,
+		turnId: acknowledgement.result?.turnId,
+	};
+	expect(frames.filter(frame => frame.type === "agent_start")).toEqual([
+		expect.objectContaining({ type: "agent_start", sessionId, ...correlation }),
+	]);
+	expect(frames.filter(frame => frame.type === "agent_end" || frame.type === "agent_failed")).toEqual([
+		expect.objectContaining({ type: "agent_end", sessionId, ...correlation }),
+	]);
+	expect(observerFrames.some(frame => frame.type === "agent_start" || frame.type === "agent_end")).toBe(false);
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+});
+
+test("SDK host serializes concurrent prompt admission without replaying private lifecycle", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-concurrent-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-prompt-concurrent-${Date.now()}`;
+	const submissions: string[] = [];
+	const preflightStarted = Promise.withResolvers<void>();
+	const releasePreflight = Promise.withResolvers<void>();
+	const sessionContext = context(cwd, sessionId);
+	const handlers = start(
+		sessionContext,
+		undefined,
+		async (content, options) => {
+			submissions.push(String(content));
+			preflightStarted.resolve();
+			await releasePreflight.promise;
+			options?.onPreflightAccepted?.();
+		},
+		true,
+	);
+
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const firstFrames: Record<string, unknown>[] = [];
+	const secondFrames: Record<string, unknown>[] = [];
+	const first = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	const second = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(first, second);
+	first.addEventListener("message", event => firstFrames.push(JSON.parse(String(event.data))));
+	second.addEventListener("message", event => secondFrames.push(JSON.parse(String(event.data))));
+	await Promise.all(
+		[first, second].map(
+			socket =>
+				new Promise<void>((resolve, reject) => {
+					socket.addEventListener("open", () => resolve(), { once: true });
+					socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+				}),
+		),
+	);
+	first.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "first-prompt",
+			operation: "turn.prompt",
+			input: { text: "accepted once" },
+			idempotencyKey: "concurrent-prompt",
+		}),
+	);
+	await preflightStarted.promise;
+
+	second.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "conflicting-prompt",
+			operation: "turn.prompt",
+			input: { text: "must fail closed" },
+			idempotencyKey: "concurrent-prompt",
+		}),
+	);
+	releasePreflight.resolve();
+	await waitFor(
+		() => secondFrames.some(frame => frame.type === "control_response" && frame.id === "conflicting-prompt"),
+		"serialized conflicting prompt response",
+	);
+	await waitFor(
+		() => firstFrames.some(frame => frame.type === "control_response" && frame.id === "first-prompt"),
+		"accepted prompt response",
+	);
+	expect(submissions).toEqual(["accepted once"]);
+	expect(
+		secondFrames.find(frame => frame.type === "control_response" && frame.id === "conflicting-prompt"),
+	).toMatchObject({
+		ok: false,
+		error: { code: "busy" },
+	});
+	const acknowledgement = firstFrames.find(
+		frame => frame.type === "control_response" && frame.id === "first-prompt",
+	) as {
+		result?: { commandId?: unknown; turnId?: unknown };
+	};
+	const correlation = { commandId: acknowledgement.result?.commandId, turnId: acknowledgement.result?.turnId };
+	await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+	await handlers.get("agent_end")?.({ type: "agent_end" }, sessionContext);
+	await waitFor(
+		() => firstFrames.some(frame => frame.type === "agent_end" && frame.commandId === correlation.commandId),
+		"accepted prompt terminal",
+	);
+	await handlers.get("agent_end")?.({ type: "agent_end" }, sessionContext);
+	expect(
+		firstFrames.filter(frame => frame.type === "agent_end" && frame.commandId === correlation.commandId),
+	).toHaveLength(1);
+	expect(secondFrames.some(frame => frame.type === "agent_start" || frame.type === "agent_end")).toBe(false);
+	first.close();
+	const recoveryFrames: Record<string, unknown>[] = [];
+	const recovery = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(recovery);
+	recovery.addEventListener("message", event => recoveryFrames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		recovery.addEventListener("open", () => resolve(), { once: true });
+		recovery.addEventListener("error", () => reject(new Error("recovery WS error")), { once: true });
+	});
+	recovery.send(JSON.stringify({ type: "event_replay", id: "prompt-recovery", sinceGeneration: 1, sinceSeq: 0 }));
+	await waitFor(
+		() => recoveryFrames.some(frame => frame.type === "event_replay_result" && frame.id === "prompt-recovery"),
+		"prompt lifecycle recovery",
+	);
+	const replay = recoveryFrames.find(
+		frame => frame.type === "event_replay_result" && frame.id === "prompt-recovery",
+	) as {
+		events?: Array<{ payload?: Record<string, unknown> }>;
+	};
+	const privateLifecycle = replay.events?.filter(
+		event =>
+			event.payload?.commandId === correlation.commandId &&
+			(event.payload?.type === "agent_start" || event.payload?.type === "agent_end"),
+	);
+	expect(privateLifecycle).toHaveLength(0);
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
 });
 
@@ -1116,7 +1310,7 @@ test("SDK host abort-and-prompt cancels a never-resolving preflight before repla
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-abort-prompt-never-preflight-"));
 	dirs.push(cwd);
 	const sessionId = `sdk-abort-prompt-never-preflight-${Date.now()}`;
-	const live = { idle: false };
+	const live = { idle: true };
 	const preflightStarted = Promise.withResolvers<void>();
 	const neverPreflight = Promise.withResolvers<never>();
 	const abortSettled = Promise.withResolvers<void>();
@@ -1623,18 +1817,17 @@ test("SDK host replay gaps are generation-scoped and sequence gaps remain cohere
 	await host.stop();
 });
 
-test("Q17 returns resource_gone before the host has an assistant message and returns it after", async () => {
+test("Q17 returns resource_gone without an assistant and reads the newest persisted assistant message after reopen", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-last-assistant-"));
 	dirs.push(cwd);
-	const sessionId = `sdk-q17-${Date.now()}`;
-	let lastAssistant: string | undefined;
-	start({
-		...context(cwd, sessionId),
-		sessionManager: {
-			...(context(cwd, sessionId).sessionManager as object),
-			getLastAssistantText: () => lastAssistant,
-		},
-	});
+	const original = SessionManager.create(cwd, cwd);
+	await original.flush();
+	const sessionFile = original.getSessionFile();
+	if (!sessionFile) throw new Error("Expected persisted session file");
+	await original.close();
+	const sessionManager = await SessionManager.open(sessionFile, cwd);
+	const sessionId = sessionManager.getSessionId();
+	const handlers = start({ ...context(cwd, sessionId), sessionManager });
 	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
 	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
 	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
@@ -1666,15 +1859,32 @@ test("Q17 returns resource_gone before the host has an assistant message and ret
 	);
 	expect(
 		JSON.parse(
-			String(
-				frames.find(
-					frame =>
-						frame.type === "control_command_result" && frame.requestId === "before" && frame.status === "ok",
-				)?.message,
-			),
+			String(frames.find(frame => frame.type === "control_command_result" && frame.requestId === "before")?.message),
 		),
-	).toMatchObject({ ok: false, error: { code: "resource_gone" } });
-	lastAssistant = "Assistant reply";
+	).toMatchObject({
+		ok: false,
+		error: { code: "resource_gone" },
+	});
+	const assistantMessage = (text: string, timestamp: number) => ({
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text }],
+		api: "anthropic-messages" as const,
+		provider: "anthropic" as const,
+		model: "fixture-model",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp,
+	});
+	sessionManager.appendMessage(assistantMessage("Older reply", Date.now()));
+	sessionManager.appendMessage(assistantMessage("Newest persisted reply", Date.now() + 1));
+	await sessionManager.flush();
 	query("after");
 	await waitFor(
 		() =>
@@ -1685,13 +1895,17 @@ test("Q17 returns resource_gone before the host has an assistant message and ret
 	);
 	expect(
 		JSON.parse(
-			String(
-				frames.find(
-					frame => frame.type === "control_command_result" && frame.requestId === "after" && frame.status === "ok",
-				)?.message,
-			),
+			String(frames.find(frame => frame.type === "control_command_result" && frame.requestId === "after")?.message),
 		),
-	).toMatchObject({ ok: true, page: { items: ["Assistant reply"] } });
+	).toMatchObject({
+		ok: true,
+		page: { items: ["Newest persisted reply"] },
+	});
+	await handlers.get("session_shutdown")?.(
+		{ type: "session_shutdown" },
+		{ ...context(cwd, sessionId), sessionManager },
+	);
+	await sessionManager.close();
 });
 
 test("terminal shutdown removes session snapshot spills", async () => {

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2134,6 +2134,48 @@ test("Q17 returns resource_gone without an assistant and reads a completed persi
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
 	await agentSession.dispose();
 	await sessionManager.close();
+
+	const reopenedSessionManager = await SessionManager.open(sessionFile, cwd);
+	const reopenedSessionContext = { ...context(cwd, sessionId), sessionManager: reopenedSessionManager };
+	const reopenedHandlers = start(reopenedSessionContext);
+	await waitFor(() => fs.existsSync(endpointFile), "reopened SDK endpoint");
+	const reopenedEndpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const reopenedFrames: Record<string, unknown>[] = [];
+	const reopenedSocket = new WebSocket(
+		`${reopenedEndpoint.url}/?token=${encodeURIComponent(reopenedEndpoint.token)}`,
+	);
+	sockets.push(reopenedSocket);
+	reopenedSocket.addEventListener("message", event => reopenedFrames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		reopenedSocket.addEventListener("open", () => resolve(), { once: true });
+		reopenedSocket.addEventListener("error", () => reject(new Error("reopened WS error")), { once: true });
+	});
+	reopenedSocket.send(
+		JSON.stringify({
+			type: "control_command",
+			sessionId,
+			token: reopenedEndpoint.token,
+			requestId: "reopened",
+			command: { type: "query_request", id: "reopened", query: "Q17" },
+		}),
+	);
+	await waitFor(
+		() =>
+			reopenedFrames.some(
+				frame => frame.type === "control_command_result" && frame.requestId === "reopened" && frame.status === "ok",
+			),
+		"reopened completed-turn Q17 response",
+	);
+	expect(
+		JSON.parse(
+			String(reopenedFrames.find(frame => frame.type === "control_command_result" && frame.requestId === "reopened")?.message),
+		),
+	).toMatchObject({
+		ok: true,
+		page: { items: ["Completed persisted reply"] },
+	});
+	await reopenedHandlers.get("session_shutdown")?.({ type: "session_shutdown" }, reopenedSessionContext);
+	await reopenedSessionManager.close();
 	authStorage.close();
 });
 

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2141,9 +2141,7 @@ test("Q17 returns resource_gone without an assistant and reads a completed persi
 	await waitFor(() => fs.existsSync(endpointFile), "reopened SDK endpoint");
 	const reopenedEndpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
 	const reopenedFrames: Record<string, unknown>[] = [];
-	const reopenedSocket = new WebSocket(
-		`${reopenedEndpoint.url}/?token=${encodeURIComponent(reopenedEndpoint.token)}`,
-	);
+	const reopenedSocket = new WebSocket(`${reopenedEndpoint.url}/?token=${encodeURIComponent(reopenedEndpoint.token)}`);
 	sockets.push(reopenedSocket);
 	reopenedSocket.addEventListener("message", event => reopenedFrames.push(JSON.parse(String(event.data))));
 	await new Promise<void>((resolve, reject) => {
@@ -2168,7 +2166,10 @@ test("Q17 returns resource_gone without an assistant and reads a completed persi
 	);
 	expect(
 		JSON.parse(
-			String(reopenedFrames.find(frame => frame.type === "control_command_result" && frame.requestId === "reopened")?.message),
+			String(
+				reopenedFrames.find(frame => frame.type === "control_command_result" && frame.requestId === "reopened")
+					?.message,
+			),
 		),
 	).toMatchObject({
 		ok: true,

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2,8 +2,12 @@ import { afterEach, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { NotificationServer } from "@gajae-code/natives";
-import type { Settings } from "../src/config/settings";
+import { Settings, type Settings } from "../src/config/settings";
+import { ModelRegistry } from "../src/config/model-registry";
 import { ExtensionRunner } from "../src/extensibility/extensions/runner";
 import type {
 	ExtensionActions,
@@ -34,6 +38,8 @@ import type {
 	ClientBridgePermissionOutcome,
 	ClientBridgePermissionToolCall,
 } from "../src/session/client-bridge";
+import { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
 import { SessionManager } from "../src/session/session-manager";
 import { getAskAnswerSource } from "../src/tools/ask-answer-registry";
 
@@ -996,7 +1002,78 @@ test("SDK host directly delivers correlated lifecycle frames for an accepted pro
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
 });
 
-test("SDK host serializes concurrent prompt admission without replaying private lifecycle", async () => {
+test("SDK host replays an accepted prompt terminal after its requester disconnects", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-disconnect-replay-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-prompt-disconnect-replay-${Date.now()}`;
+	const sessionContext = context(cwd, sessionId);
+	const handlers = start(sessionContext);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const frames: Record<string, unknown>[] = [];
+	const requester = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(requester);
+	requester.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		requester.addEventListener("open", () => resolve(), { once: true });
+		requester.addEventListener("error", () => reject(new Error("requester WS error")), { once: true });
+	});
+	requester.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "disconnect-prompt",
+			operation: "turn.prompt",
+			input: { text: "recover my terminal" },
+		}),
+	);
+	await waitFor(
+		() => frames.some(frame => frame.type === "control_response" && frame.id === "disconnect-prompt"),
+		"accepted prompt acknowledgement",
+	);
+	const acknowledgement = frames.find(frame => frame.type === "control_response" && frame.id === "disconnect-prompt") as {
+		result?: { commandId?: unknown; turnId?: unknown };
+	};
+	const correlation = { commandId: acknowledgement.result?.commandId, turnId: acknowledgement.result?.turnId };
+	await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+	await waitFor(
+		() => frames.some(frame => frame.type === "agent_start" && frame.commandId === correlation.commandId),
+		"correlated agent start",
+	);
+	const requesterClosed = new Promise<void>(resolve => requester.addEventListener("close", () => resolve(), { once: true }));
+	requester.close();
+	await requesterClosed;
+	await handlers.get("agent_end")?.({ type: "agent_end" }, sessionContext);
+	const recoveryFrames: Record<string, unknown>[] = [];
+	const recovery = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(recovery);
+	recovery.addEventListener("message", event => recoveryFrames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		recovery.addEventListener("open", () => resolve(), { once: true });
+		recovery.addEventListener("error", () => reject(new Error("recovery WS error")), { once: true });
+	});
+	recovery.send(JSON.stringify({ type: "event_replay", id: "disconnect-replay", sinceGeneration: 1, sinceSeq: 0 }));
+	await waitFor(
+		() => recoveryFrames.some(frame => frame.type === "event_replay_result" && frame.id === "disconnect-replay"),
+		"disconnected prompt replay",
+	);
+	const replay = recoveryFrames.find(frame => frame.type === "event_replay_result" && frame.id === "disconnect-replay") as {
+		events?: Array<{ payload?: Record<string, unknown> }>;
+	};
+	const lifecycle = replay.events?.filter(
+		event =>
+			event.payload?.commandId === correlation.commandId &&
+			(event.payload?.type === "agent_start" || event.payload?.type === "agent_end"),
+	);
+	expect(lifecycle).toEqual([
+		expect.objectContaining({ payload: { type: "agent_start", sessionId, ...correlation } }),
+		expect.objectContaining({ payload: { type: "agent_end", sessionId, ...correlation } }),
+	]);
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+});
+
+
+test("SDK host serializes concurrent prompt admission and replays correlated lifecycle", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-concurrent-"));
 	dirs.push(cwd);
 	const sessionId = `sdk-prompt-concurrent-${Date.now()}`;
@@ -1107,12 +1184,15 @@ test("SDK host serializes concurrent prompt admission without replaying private 
 	) as {
 		events?: Array<{ payload?: Record<string, unknown> }>;
 	};
-	const privateLifecycle = replay.events?.filter(
+	const replayedLifecycle = replay.events?.filter(
 		event =>
 			event.payload?.commandId === correlation.commandId &&
 			(event.payload?.type === "agent_start" || event.payload?.type === "agent_end"),
 	);
-	expect(privateLifecycle).toHaveLength(0);
+	expect(replayedLifecycle).toEqual([
+		expect.objectContaining({ payload: { type: "agent_start", sessionId, ...correlation } }),
+		expect.objectContaining({ payload: { type: "agent_end", sessionId, ...correlation } }),
+	]);
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
 });
 
@@ -1817,7 +1897,7 @@ test("SDK host replay gaps are generation-scoped and sequence gaps remain cohere
 	await host.stop();
 });
 
-test("Q17 returns resource_gone without an assistant and reads the newest persisted assistant message after reopen", async () => {
+test("Q17 returns resource_gone without an assistant and reads a completed persisted turn after reopen", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-last-assistant-"));
 	dirs.push(cwd);
 	const original = SessionManager.create(cwd, cwd);
@@ -1827,7 +1907,28 @@ test("Q17 returns resource_gone without an assistant and reads the newest persis
 	await original.close();
 	const sessionManager = await SessionManager.open(sessionFile, cwd);
 	const sessionId = sessionManager.getSessionId();
-	const handlers = start({ ...context(cwd, sessionId), sessionManager });
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled test model");
+	const authStorage = await AuthStorage.create(path.join(cwd, "auth.db"));
+	authStorage.setRuntimeApiKey(model.provider, "test-key");
+	const agentSession = new AgentSession({
+		agent: new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: createMockModel({ responses: [{ content: ["Completed persisted reply"] }] }).stream,
+		}),
+		sessionManager,
+		settings: Settings.isolated({ "compaction.enabled": false }),
+		modelRegistry: new ModelRegistry(authStorage, path.join(cwd, "models.yml")),
+	});
+	agentSession.subscribe(() => {});
+	const sessionContext = { ...context(cwd, sessionId), sessionManager };
+	const handlers = start(
+		sessionContext,
+		undefined,
+		(content, options) => agentSession.prompt(String(content), options),
+		true,
+	);
 	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
 	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
 	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
@@ -1865,33 +1966,35 @@ test("Q17 returns resource_gone without an assistant and reads the newest persis
 		ok: false,
 		error: { code: "resource_gone" },
 	});
-	const assistantMessage = (text: string, timestamp: number) => ({
-		role: "assistant" as const,
-		content: [{ type: "text" as const, text }],
-		api: "anthropic-messages" as const,
-		provider: "anthropic" as const,
-		model: "fixture-model",
-		usage: {
-			input: 1,
-			output: 1,
-			cacheRead: 0,
-			cacheWrite: 0,
-			totalTokens: 2,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-		},
-		stopReason: "stop" as const,
-		timestamp,
-	});
-	sessionManager.appendMessage(assistantMessage("Older reply", Date.now()));
-	sessionManager.appendMessage(assistantMessage("Newest persisted reply", Date.now() + 1));
+	socket.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "completed-turn",
+			operation: "turn.prompt",
+			input: { text: "Persist a real assistant response" },
+		}),
+	);
+	await waitFor(
+		() => frames.some(frame => frame.type === "control_response" && frame.id === "completed-turn"),
+		"completed turn acknowledgement",
+	);
+	await agentSession.waitForIdle();
 	await sessionManager.flush();
+	expect(sessionManager.getBranch()).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				type: "message",
+				message: expect.objectContaining({ role: "assistant" }),
+			}),
+		]),
+	);
 	query("after");
 	await waitFor(
 		() =>
 			frames.some(
 				frame => frame.type === "control_command_result" && frame.requestId === "after" && frame.status === "ok",
 			),
-		"message Q17 response",
+		"completed-turn Q17 response",
 	);
 	expect(
 		JSON.parse(
@@ -1899,13 +2002,12 @@ test("Q17 returns resource_gone without an assistant and reads the newest persis
 		),
 	).toMatchObject({
 		ok: true,
-		page: { items: ["Newest persisted reply"] },
+		page: { items: ["Completed persisted reply"] },
 	});
-	await handlers.get("session_shutdown")?.(
-		{ type: "session_shutdown" },
-		{ ...context(cwd, sessionId), sessionManager },
-	);
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+	await agentSession.dispose();
 	await sessionManager.close();
+	authStorage.close();
 });
 
 test("terminal shutdown removes session snapshot spills", async () => {

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -6,8 +6,8 @@ import { Agent } from "@gajae-code/agent-core";
 import { getBundledModel } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { NotificationServer } from "@gajae-code/natives";
-import { Settings, type Settings } from "../src/config/settings";
 import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
 import { ExtensionRunner } from "../src/extensibility/extensions/runner";
 import type {
 	ExtensionActions,
@@ -32,14 +32,13 @@ import {
 	SdkStartupRollbackTracker,
 	sanitizeSdkStartupMessage,
 } from "../src/sdk/startup-capability";
-
+import { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
 import type {
 	ClientBridgePermissionOption,
 	ClientBridgePermissionOutcome,
 	ClientBridgePermissionToolCall,
 } from "../src/session/client-bridge";
-import { AgentSession } from "../src/session/agent-session";
-import { AuthStorage } from "../src/session/auth-storage";
 import { SessionManager } from "../src/session/session-manager";
 import { getAskAnswerSource } from "../src/tools/ask-answer-registry";
 
@@ -1002,6 +1001,129 @@ test("SDK host directly delivers correlated lifecycle frames for an accepted pro
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
 });
 
+test("SDK host buffers synchronous pre-ack start and end until after acknowledgement", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-pre-ack-end-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-prompt-pre-ack-end-${Date.now()}`;
+	const sessionContext = context(cwd, sessionId);
+	let handlers!: Map<string, (event: unknown, context: unknown) => unknown>;
+	handlers = start(
+		sessionContext,
+		undefined,
+		(_content, options) => {
+			options?.onPreflightAccepted?.();
+			void handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+			void handlers.get("agent_end")?.({ type: "agent_end" }, sessionContext);
+		},
+		true,
+	);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	socket.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "pre-ack-end",
+			operation: "turn.prompt",
+			input: { text: "finish synchronously" },
+		}),
+	);
+	await waitFor(
+		() =>
+			frames.some(frame => frame.type === "control_response" && frame.id === "pre-ack-end") &&
+			frames.some(frame => frame.type === "agent_end"),
+		"pre-ack end lifecycle",
+	);
+	const acknowledgementIndex = frames.findIndex(
+		frame => frame.type === "control_response" && frame.id === "pre-ack-end",
+	);
+	const acknowledgement = frames[acknowledgementIndex] as { result?: { commandId?: unknown; turnId?: unknown } };
+	const correlation = { commandId: acknowledgement.result?.commandId, turnId: acknowledgement.result?.turnId };
+	const startFrames = frames.filter(frame => frame.type === "agent_start");
+	const terminalFrames = frames.filter(frame => frame.type === "agent_end" || frame.type === "agent_failed");
+	expect(acknowledgement).toMatchObject({
+		ok: true,
+		result: { accepted: true, commandId: expect.any(String), turnId: expect.any(String) },
+	});
+	expect(acknowledgementIndex).toBeLessThan(frames.findIndex(frame => frame.type === "agent_start"));
+	expect(startFrames).toEqual([expect.objectContaining({ type: "agent_start", sessionId, ...correlation })]);
+	expect(terminalFrames).toEqual([expect.objectContaining({ type: "agent_end", sessionId, ...correlation })]);
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+});
+
+test("SDK host buffers synchronous pre-ack accepted failure until after acknowledgement", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-pre-ack-failed-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-prompt-pre-ack-failed-${Date.now()}`;
+	const sessionContext = context(cwd, sessionId);
+	let handlers!: Map<string, (event: unknown, context: unknown) => unknown>;
+	handlers = start(
+		sessionContext,
+		undefined,
+		(_content, options) => {
+			options?.onPreflightAccepted?.();
+			void handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+			throw Object.assign(new Error("synchronous accepted failure"), { code: "unavailable" });
+		},
+		true,
+	);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	socket.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "pre-ack-failed",
+			operation: "turn.prompt",
+			input: { text: "fail synchronously" },
+		}),
+	);
+	await waitFor(
+		() =>
+			frames.some(frame => frame.type === "control_response" && frame.id === "pre-ack-failed") &&
+			frames.some(frame => frame.type === "agent_failed"),
+		"pre-ack accepted failure lifecycle",
+	);
+	const acknowledgementIndex = frames.findIndex(
+		frame => frame.type === "control_response" && frame.id === "pre-ack-failed",
+	);
+	const acknowledgement = frames[acknowledgementIndex] as { result?: { commandId?: unknown; turnId?: unknown } };
+	const correlation = { commandId: acknowledgement.result?.commandId, turnId: acknowledgement.result?.turnId };
+	const startFrames = frames.filter(frame => frame.type === "agent_start");
+	const terminalFrames = frames.filter(frame => frame.type === "agent_end" || frame.type === "agent_failed");
+	expect(acknowledgement).toMatchObject({
+		ok: true,
+		result: { accepted: true, commandId: expect.any(String), turnId: expect.any(String) },
+	});
+	expect(acknowledgementIndex).toBeLessThan(frames.findIndex(frame => frame.type === "agent_start"));
+	expect(startFrames).toEqual([expect.objectContaining({ type: "agent_start", sessionId, ...correlation })]);
+	expect(terminalFrames).toEqual([
+		expect.objectContaining({
+			type: "agent_failed",
+			sessionId,
+			...correlation,
+			error: { code: "unavailable", message: "synchronous accepted failure" },
+		}),
+	]);
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+});
+
 test("SDK host replays an accepted prompt terminal after its requester disconnects", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-disconnect-replay-"));
 	dirs.push(cwd);
@@ -1031,7 +1153,9 @@ test("SDK host replays an accepted prompt terminal after its requester disconnec
 		() => frames.some(frame => frame.type === "control_response" && frame.id === "disconnect-prompt"),
 		"accepted prompt acknowledgement",
 	);
-	const acknowledgement = frames.find(frame => frame.type === "control_response" && frame.id === "disconnect-prompt") as {
+	const acknowledgement = frames.find(
+		frame => frame.type === "control_response" && frame.id === "disconnect-prompt",
+	) as {
 		result?: { commandId?: unknown; turnId?: unknown };
 	};
 	const correlation = { commandId: acknowledgement.result?.commandId, turnId: acknowledgement.result?.turnId };
@@ -1040,7 +1164,9 @@ test("SDK host replays an accepted prompt terminal after its requester disconnec
 		() => frames.some(frame => frame.type === "agent_start" && frame.commandId === correlation.commandId),
 		"correlated agent start",
 	);
-	const requesterClosed = new Promise<void>(resolve => requester.addEventListener("close", () => resolve(), { once: true }));
+	const requesterClosed = new Promise<void>(resolve =>
+		requester.addEventListener("close", () => resolve(), { once: true }),
+	);
 	requester.close();
 	await requesterClosed;
 	await handlers.get("agent_end")?.({ type: "agent_end" }, sessionContext);
@@ -1057,7 +1183,9 @@ test("SDK host replays an accepted prompt terminal after its requester disconnec
 		() => recoveryFrames.some(frame => frame.type === "event_replay_result" && frame.id === "disconnect-replay"),
 		"disconnected prompt replay",
 	);
-	const replay = recoveryFrames.find(frame => frame.type === "event_replay_result" && frame.id === "disconnect-replay") as {
+	const replay = recoveryFrames.find(
+		frame => frame.type === "event_replay_result" && frame.id === "disconnect-replay",
+	) as {
 		events?: Array<{ payload?: Record<string, unknown> }>;
 	};
 	const lifecycle = replay.events?.filter(
@@ -1071,7 +1199,6 @@ test("SDK host replays an accepted prompt terminal after its requester disconnec
 	]);
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
 });
-
 
 test("SDK host serializes concurrent prompt admission and replays correlated lifecycle", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-concurrent-"));


### PR DESCRIPTION
## Summary
- deliver accepted-prompt lifecycle only to the authenticated requester after acknowledgement
- serialize concurrent prompt admission on the stable session control surface and fail busy prompts closed
- enforce exactly one terminal with bounded pending records and terminal tombstones
- suppress private lifecycle on peer/reconnect replay while preserving public activity replay
- make Q17 authoritative from the canonical persisted SessionManager branch; keep Q21 as queue messages
- make owner observation wait for accepted frame persistence and surface pump failure only after verified teardown retries

Closes #2169

## Exact head
`68875fd894e288ea4dbbf1ccd741df990f4f70b7` — signed commit

## Verification
- focused lifecycle/query/owner suite: 54 pass, 0 fail
- coding-agent `bun run check`: passed (Biome, SDK canonicalization, TypeScript)
- final QA exact head: PASS; changed-file suite 45/45, targeted adversarial repeats 5x and cleanup repeats 3x, Q21 continuity passed
- hostile exact-head review: architecture CLEAR, product CLEAR, code CLEAR, APPROVE; no blockers
- GitHub exact-head checks: all required checks successful, including native build, changed host/owner tests, package shard, state gates, and affected-path validation

## Contract correction
Current SDK v3 mapping is Q17 = `session.last_assistant`; Q21 = `queue.messages.list`. The regression proves persisted Q17 authority and separately preserves Q21 queue continuity.