### PR TITLE
fix(ultragoal): re-mint final-aggregate receipts instead of deadlocking on stale ones

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -1,7 +1,11 @@
 import * as fs from "node:fs/promises";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
 import { resolveGjcSessionForRead, SessionResolutionError } from "./session-resolution";
-import { validateDeferredMemberReceiptFresh, validateReceiptFreshBase } from "./ultragoal-receipt-freshness";
+import {
+	validateDeferredMemberReceiptFresh,
+	validateReceiptFreshBase,
+	validateSupersededFinalAggregateReceipt,
+} from "./ultragoal-receipt-freshness";
 import {
 	getUltragoalPaths,
 	getUltragoalRunCompletionState,
@@ -156,8 +160,33 @@ function requiredGoals(plan: UltragoalPlan): UltragoalGoal[] {
 	return plan.goals.filter(goal => goal.status !== "superseded");
 }
 
+/**
+ * Select the goal whose final-aggregate receipt should represent the run.
+ * Prefer a receipt that still validates fresh; several goals can hold
+ * final-aggregate receipts once plan growth (e.g. `steer add_subgoal`) stales
+ * an earlier one and a later checkpoint re-mints. Fall back to the newest
+ * holder (array-last) purely for diagnostics when none validates.
+ */
+function findFinalAggregateReceiptGoal(
+	plan: UltragoalPlan,
+	ledger: readonly UltragoalLedgerEvent[],
+): UltragoalGoal | null {
+	const candidates = [...requiredGoals(plan)]
+		.reverse()
+		.filter(goal => goal.completionVerification?.receiptKind === "final-aggregate");
+	if (candidates.length === 0) return null;
+	return (
+		candidates.find(
+			goal =>
+				validateCompletionReceipt({ plan, ledger, goal, receiptKind: "final-aggregate" }).state ===
+				"active_verified_complete",
+		) ?? candidates[0]!
+	);
+}
+
 function findReceiptGoal(
 	plan: UltragoalPlan,
+	ledger: readonly UltragoalLedgerEvent[],
 	currentObjective: string,
 ): { goal: UltragoalGoal; receiptKind: UltragoalReceiptKind } | null {
 	if (
@@ -165,9 +194,7 @@ function findReceiptGoal(
 		currentObjective === DEFAULT_ULTRAGOAL_OBJECTIVE ||
 		plan.gjcObjectiveAliases?.some(alias => alias === currentObjective)
 	) {
-		const finalGoal = [...requiredGoals(plan)]
-			.reverse()
-			.find(goal => goal.completionVerification?.receiptKind === "final-aggregate");
+		const finalGoal = findFinalAggregateReceiptGoal(plan, ledger);
 		return finalGoal ? { goal: finalGoal, receiptKind: "final-aggregate" } : null;
 	}
 	const storyGoal = plan.goals.find(goal => goal.objective === currentObjective);
@@ -300,6 +327,28 @@ export function validateCompletionReceipt(input: {
 					goalId: input.goal.id,
 				};
 			}
+			if (
+				priorGoal.completionVerification.validationBatch?.role !== "deferred-member" &&
+				priorGoal.completionVerification.receiptKind === "final-aggregate"
+			) {
+				// A prior goal may hold the run's previous final-aggregate receipt
+				// when plan growth staled it and a later checkpoint re-minted the
+				// aggregate receipt. Accept it as historical evidence for its own
+				// goal instead of demanding an impossible per-goal receipt.
+				const supersededDiagnostic = validateSupersededFinalAggregateReceipt({
+					ledger: input.ledger,
+					goal: priorGoal,
+					receipt: priorGoal.completionVerification,
+				});
+				if (supersededDiagnostic) {
+					return {
+						state: supersededDiagnostic.state,
+						message: `Ultragoal final receipt requires valid historical evidence for ${priorGoal.id}: ${supersededDiagnostic.message}`,
+						goalId: input.goal.id,
+					};
+				}
+				continue;
+			}
 			const priorDiagnostic =
 				priorGoal.completionVerification.validationBatch?.role === "deferred-member"
 					? validateDeferredMemberReceiptFresh({
@@ -381,7 +430,7 @@ export async function readUltragoalVerificationState(input: {
 			message: "Ultragoal has blocked or failed goals; record blockers or rerun verification.",
 		};
 	}
-	const receiptTarget = findReceiptGoal(plan, currentObjective);
+	const receiptTarget = findReceiptGoal(plan, ledger, currentObjective);
 	if (!receiptTarget) {
 		// When earlier required goals are already complete but later ones remain, name the
 		// specific blocking goals (a final-aggregate receipt cannot exist yet anyway). Only
@@ -623,9 +672,7 @@ export async function isUltragoalAskBlocked(
 		});
 	}
 
-	const finalReceiptGoal = [...requiredGoals(plan)]
-		.reverse()
-		.find(goal => goal.completionVerification?.receiptKind === "final-aggregate");
+	const finalReceiptGoal = findFinalAggregateReceiptGoal(plan, ledger);
 	if (!finalReceiptGoal) {
 		return activeAskDiagnostic({
 			reason: "Ultragoal aggregate completion is missing a final aggregate receipt.",

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
@@ -244,6 +244,57 @@ export function validateReceiptFreshBase(input: {
 	return null;
 }
 
+/**
+ * Validate a final-aggregate receipt that was legitimately superseded — its
+ * aggregate claim staled by later plan growth (e.g. `steer add_subgoal`
+ * appending goals after a terminal run) — as a historical attestation for its
+ * own goal: ledger-anchored, quality gate untampered, goal untouched since
+ * verification, and internally consistent. Plan-generation freshness against
+ * the CURRENT plan is intentionally not required; that is exactly what later
+ * plan growth invalidates by design. Returns null when the receipt stands as
+ * valid historical evidence.
+ */
+export function validateSupersededFinalAggregateReceipt(input: {
+	ledger: readonly UltragoalLedgerEvent[];
+	goal: UltragoalGoal;
+	receipt: UltragoalCompletionVerification;
+}): UltragoalReceiptFreshnessDiagnostic | null {
+	if (
+		input.receipt.schemaVersion !== 1 ||
+		input.receipt.goalId !== input.goal.id ||
+		input.receipt.receiptKind !== "final-aggregate" ||
+		!input.receipt.planGeneration ||
+		!input.receipt.checkpointLedgerEventId ||
+		hashStructuredValue(input.receipt.basis) !== input.receipt.planGeneration
+	) {
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} superseded final-aggregate receipt is malformed.`,
+			goalId: input.goal.id,
+		};
+	}
+	const event = findLedgerReceiptEvent(input.ledger, input.receipt);
+	if (!event)
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} superseded final-aggregate receipt ledger event is missing.`,
+			goalId: input.goal.id,
+		};
+	if (hashStructuredValue(event.qualityGateJson) !== input.receipt.qualityGateHash)
+		return {
+			state: "active_dirty_quality_gate",
+			message: `Ultragoal ${input.goal.id} superseded final-aggregate receipt quality-gate hash does not match ledger.`,
+			goalId: input.goal.id,
+		};
+	if (input.goal.updatedAt !== input.receipt.verifiedAt)
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} changed after its superseded final-aggregate receipt was verified.`,
+			goalId: input.goal.id,
+		};
+	return null;
+}
+
 export function findFreshBatchCloseReceipt(input: {
 	plan: UltragoalPlan;
 	ledger: readonly UltragoalLedgerEvent[];

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -573,16 +573,26 @@ async function writePlan(cwd: string, plan: UltragoalPlan, sessionId?: string | 
 
 function chooseReceiptKind(
 	plan: UltragoalPlan,
+	ledger: readonly UltragoalLedgerEvent[],
 	goal: UltragoalGoal,
 	status: UltragoalGoalStatus,
 ): UltragoalReceiptKind {
 	if (plan.gjcGoalMode === "per-story") return "per-goal";
 	if (status !== "complete") return "per-goal";
 	const requiredGoals = requiredUltragoalGoals(plan);
-	const existingFinalAggregateGoal = requiredGoals.find(
-		item => item.id !== goal.id && item.completionVerification?.receiptKind === "final-aggregate",
-	);
-	if (existingFinalAggregateGoal) return "per-goal";
+	// Only a still-fresh final-aggregate receipt on another goal defers this
+	// checkpoint to per-goal. A stale one (e.g. staled by `steer add_subgoal`
+	// appending goals after a terminal run) must not suppress re-minting,
+	// otherwise the run can never regain a verifiable final-aggregate receipt:
+	// the completion guard demands a fresh final-aggregate receipt while this
+	// gate would keep answering per-goal forever.
+	const existingFreshFinalAggregateGoal = requiredGoals.find(item => {
+		if (item.id === goal.id) return false;
+		const receipt = item.completionVerification;
+		if (receipt?.receiptKind !== "final-aggregate") return false;
+		return validateReceiptFreshBase({ plan, ledger, goal: item, receipt, receiptKind: "final-aggregate" }) === null;
+	});
+	if (existingFreshFinalAggregateGoal) return "per-goal";
 	const unfinishedRequiredGoals = requiredGoals.filter(
 		item => item.id !== goal.id && !TERMINAL_OR_SKIPPED_STATUSES.has(item.status),
 	);
@@ -4047,7 +4057,7 @@ export async function checkpointUltragoalGoal(input: {
 			blockedGoal.updatedAt = now;
 		}
 	}
-	const receiptKind = input.status === "complete" ? chooseReceiptKind(plan, goal, input.status) : null;
+	const receiptKind = input.status === "complete" ? chooseReceiptKind(plan, ledgerBefore, goal, input.status) : null;
 	const pendingCheckpointEventId = crypto.randomUUID();
 	if (input.status === "complete" && receiptKind && qualityGateJson && !Array.isArray(qualityGateJson)) {
 		goal.completionVerification = buildCompletionReceipt({

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -3997,7 +3997,35 @@ export async function checkpointUltragoalGoal(input: {
 	if (input.status === "complete" && goal.completionVerification?.validationBatch && !batchMetadata) {
 		throw new Error(`Goal ${goal.id} has stale validation batch completion receipt`);
 	}
-	if (goal.status === input.status && goal.evidence === evidence && matchingIdempotentEvent) {
+	// An identical-evidence complete replay is only a no-op while the recorded
+	// receipt still validates fresh. When the goal row itself is untouched
+	// (updatedAt still matches the receipt's verifiedAt) but later goal-tagged
+	// ledger events (e.g. blocker classifications) or plan growth staled the
+	// receipt, the replay is a genuine re-verification: it must run the full
+	// quality gate and mint a fresh receipt, otherwise a completed goal with a
+	// context-staled receipt can never be repaired (different evidence is
+	// rejected on complete goals by design). A mutated goal row keeps the
+	// fail-loud tamper handling in the idempotent branch below.
+	const staleCompleteReceiptReplay =
+		input.status === "complete" &&
+		goal.status === "complete" &&
+		goal.evidence === evidence &&
+		Boolean(matchingIdempotentEvent) &&
+		(!goal.completionVerification ||
+			(goal.completionVerification.verifiedAt === goal.updatedAt &&
+				validateReceiptFreshBase({
+					plan,
+					ledger: ledgerBefore,
+					goal,
+					receipt: goal.completionVerification,
+					receiptKind: goal.completionVerification.receiptKind,
+				}) !== null));
+	if (
+		goal.status === input.status &&
+		goal.evidence === evidence &&
+		matchingIdempotentEvent &&
+		!staleCompleteReceiptReplay
+	) {
 		if (batchMetadata) {
 			const receipt = goal.completionVerification;
 			const receiptBatch = receipt?.validationBatch;
@@ -4019,6 +4047,18 @@ export async function checkpointUltragoalGoal(input: {
 			)
 				throw new Error(`Goal ${goal.id} has stale validation batch metadata hash in close receipt`);
 		}
+		// A complete goal whose row changed after its receipt was verified is
+		// neither a clean no-op nor a repairable context-stale replay: fail loud
+		// instead of silently laundering a tampered/inconsistent durable row.
+		if (
+			input.status === "complete" &&
+			goal.completionVerification &&
+			goal.completionVerification.verifiedAt !== goal.updatedAt
+		) {
+			throw new Error(
+				`Goal ${goal.id} changed after its completion receipt was verified; refusing idempotent replay. Investigate the durable goals.json row before re-checkpointing.`,
+			);
+		}
 		// Idempotent re-checkpoint: this goal is already recorded in the target status with the same
 		// evidence, so skip the plan rewrite and ledger append to avoid duplicate goal_checkpointed
 		// events. The ledger is the dedup source of truth because it is exactly what a duplicate write
@@ -4030,7 +4070,7 @@ export async function checkpointUltragoalGoal(input: {
 	const changeSet = input.status === "complete" ? await computeCheckpointChangeSet(input.cwd) : undefined;
 	if (input.status === "complete") {
 		validatePipelineCheckpointSafety(plan, goal, changeSet);
-		validateCompleteCheckpointTargetGoal(goal);
+		if (!staleCompleteReceiptReplay) validateCompleteCheckpointTargetGoal(goal);
 	}
 	const qualityGateJson =
 		input.status === "complete"

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -11,7 +11,10 @@ import {
 	sessionUltragoalDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { reconcileWorkflowSkillState } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
-import { validateCompletionReceipt } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
+import {
+	validateCompletionReceipt,
+	verifyUltragoalDurableCompletionState,
+} from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
 
 import {
 	addUltragoalSubgoal,
@@ -2986,7 +2989,52 @@ describe("native GJC ultragoal runtime", () => {
 		expect(await Bun.file(goalsPath).text()).toBe(goalsAfterFinal);
 	});
 
-	it("uses per-goal receipts when repairing a non-final goal after aggregate completion (#1777)", async () => {
+	it("re-mints a final-aggregate receipt when goals are appended after aggregate completion", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		const afterFirst = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		expect(afterFirst.goals[0]?.completionVerification?.receiptKind).toBe("final-aggregate");
+
+		await addUltragoalSubgoal({
+			cwd: root,
+			title: "Appended stage",
+			objective: "Complete the appended stage.",
+			evidence: "The run gained a new required goal after aggregate completion.",
+			rationale: "Cover final-aggregate re-minting after an append staled the prior receipt.",
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		const afterAppended = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G002",
+			status: "complete",
+			evidence: "appended goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+
+		// Appending G002 staled G001's final-aggregate receipt by design. The
+		// closing checkpoint must mint a fresh final-aggregate receipt instead of
+		// deferring to the stale one, which would leave the run permanently
+		// unable to satisfy the final-aggregate completion guard.
+		expect(afterAppended.goals[1]?.completionVerification?.receiptKind).toBe("final-aggregate");
+
+		const plan = await readUltragoalPlan(root);
+		if (!plan) throw new Error("missing ultragoal plan");
+		const ledger = await readUltragoalLedger(root);
+		expect(
+			validateCompletionReceipt({ plan, ledger, goal: plan.goals[1]!, receiptKind: "final-aggregate" }).state,
+		).toBe("active_verified_complete");
+		const durable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+		expect(durable.state).toBe("active_verified_complete");
+	});
+
+	it("re-mints the final-aggregate receipt when repairing a non-final goal after aggregate completion (#1777)", async () => {
 		for (const repairStatus of ["active", "failed"] as const) {
 			const root = await tempDir();
 			await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
@@ -3032,15 +3080,22 @@ describe("native GJC ultragoal runtime", () => {
 				qualityGateJson: await passingLiveQualityGate(root),
 			});
 
-			expect(repaired.goals[0]?.completionVerification?.receiptKind).toBe("per-goal");
+			// The hand-edited repair staled G002's final-aggregate receipt (its
+			// plan generation covers every required goal). The repair checkpoint
+			// closes the run again, so it must re-mint the final-aggregate
+			// receipt; a per-goal receipt would leave the run with no fresh
+			// final-aggregate receipt forever.
+			expect(repaired.goals[0]?.completionVerification?.receiptKind).toBe("final-aggregate");
 			expect(
 				validateCompletionReceipt({
 					plan: repaired,
 					ledger: await readUltragoalLedger(root),
 					goal: repaired.goals[0]!,
-					receiptKind: "per-goal",
+					receiptKind: "final-aggregate",
 				}).state,
 			).toBe("active_verified_complete");
+			const durable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+			expect(durable.state).toBe("active_verified_complete");
 		}
 	});
 

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -3034,6 +3034,86 @@ describe("native GJC ultragoal runtime", () => {
 		expect(durable.state).toBe("active_verified_complete");
 	});
 
+	it("re-mints the receipt on identical-evidence replay after a goal-tagged ledger event staled it", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		const classified = await runNativeUltragoalCommand(
+			[
+				"classify-blocker",
+				"--classification",
+				"resolvable",
+				"--evidence",
+				"post-completion audit note tagged to the completed goal",
+				"--goal-id",
+				"G001",
+			],
+			root,
+		);
+		expect(classified.status).toBe(0);
+
+		// The goal-tagged blocker_classified event stales the recorded receipt.
+		const staleDurable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+		expect(staleDurable.state).not.toBe("active_verified_complete");
+		const checkpointsBefore = (await readUltragoalLedger(root)).filter(
+			event => event.event === "goal_checkpointed",
+		).length;
+
+		// Different evidence stays rejected on complete goals; the identical
+		// evidence replay must re-verify and mint a fresh receipt instead of
+		// no-opping on the stale one (which would be unrepairable forever).
+		const replayed = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		expect(replayed.goals[0]?.completionVerification?.receiptKind).toBe("final-aggregate");
+		expect((await readUltragoalLedger(root)).filter(event => event.event === "goal_checkpointed")).toHaveLength(
+			checkpointsBefore + 1,
+		);
+		const durable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+		expect(durable.state).toBe("active_verified_complete");
+	});
+
+	it("rejects identical-evidence replay when the goal row changed after receipt verification", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		saved.goals[0].updatedAt = new Date(Date.now() + 1000).toISOString();
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+
+		// A mutated complete row is neither a clean no-op nor a repairable
+		// context-stale replay; it must fail loud instead of silently
+		// laundering the inconsistency.
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "first goal verified",
+				qualityGateJson: await passingLiveQualityGate(root),
+			}),
+		).rejects.toThrow("changed after its completion receipt was verified");
+	});
+
 	it("re-mints the final-aggregate receipt when repairing a non-final goal after aggregate completion (#1777)", async () => {
 		for (const repairStatus of ["active", "failed"] as const) {
 			const root = await tempDir();


### PR DESCRIPTION
## Problem

An aggregate ultragoal run that reaches completion and then grows can never complete again. Deterministic repro (hit in a real session on 0.10.2):

1. Complete an aggregate run — the last checkpoint mints a `final-aggregate` receipt. `goal complete` works.
2. `gjc ultragoal steer --kind add_subgoal` — per the freshness rules this correctly stales the existing final-aggregate receipt (its plan generation covers the required-goal set).
3. Complete the appended goal — the checkpoint mints only a `per-goal` receipt.
4. `goal complete` is now refused **forever** with `nudgeTargetKind=final_aggregate_receipt`, even though `status`/`complete-goals` report every goal complete. The `pause` escape is consumed by the same nudge gate, so the agent burns the entire try-harder budget with no reachable success state.

Root cause is a contradiction between the minter and the verifier:

- `chooseReceiptKind()` returns `per-goal` whenever *any other* required goal holds a final-aggregate receipt — without checking whether that receipt is still fresh — so a replacement final-aggregate receipt can never be minted.
- The completion guard requires a *fresh* final-aggregate receipt.
- Receipt replays are idempotent no-ops and different-evidence checkpoints on complete goals are rejected, so the stale receipt can't be refreshed on its original goal either.

A second unrecoverable shape exists for per-goal receipts: any later goal-tagged ledger event (e.g. `classify-blocker --goal-id`) stales a completed goal's receipt, and the identical-evidence replay no-ops on the stale receipt instead of re-verifying.

## Fix

- `chooseReceiptKind` only defers to another goal's final-aggregate receipt while that receipt still validates fresh (`validateReceiptFreshBase`); a stale one no longer suppresses re-minting.
- Final-aggregate validation accepts a prior goal's superseded final-aggregate receipt as ledger-anchored historical evidence (new `validateSupersededFinalAggregateReceipt`: ledger event anchoring, quality-gate hash match, goal row untouched since verification, internal generation consistency) instead of demanding an impossible per-goal receipt. Plan-generation freshness against the *current* plan is intentionally not required — that is exactly what later plan growth invalidates by design.
- The run's final-aggregate receipt goal is selected by freshness rather than array position (`findFinalAggregateReceiptGoal`), so a re-minted receipt on a repaired earlier goal is found.
- An identical-evidence complete replay re-verifies (full quality gate) and re-mints when the goal row is untouched (`updatedAt === verifiedAt`) but the receipt was context-staled. Mutated goal rows keep the existing fail-loud tamper handling, and fresh-receipt replays remain byte-identical no-ops (#638 dedup preserved).

## Behavioral change to an existing test

`uses per-goal receipts when repairing a non-final goal after aggregate completion (#1777)` asserted a `per-goal` receipt for the repair checkpoint. That expectation encoded the deadlock: the repair edit stales the run's final-aggregate receipt, so with a per-goal repair receipt the run retains no fresh final-aggregate receipt forever. The test now asserts the repair checkpoint (which closes the run again) re-mints `final-aggregate` and that `verifyUltragoalDurableCompletionState` reports `active_verified_complete`. The sibling #1777 idempotency guarantees (no duplicate events, byte-identical goals.json on fresh replays) are unchanged and still covered.

## Tests

New regression tests in `test/gjc-runtime/ultragoal-runtime.test.ts`:

- `re-mints a final-aggregate receipt when goals are appended after aggregate completion` — the repro above, asserting receipt kind, receipt validation, and durable completion.
- `re-mints the receipt on identical-evidence replay after a goal-tagged ledger event staled it` — `classify-blocker --goal-id` stales the receipt; replay re-verifies, appends exactly one checkpoint event, and restores durable completion.

Verification:

- `bun test` on `ultragoal-runtime`, `ultragoal-durable-completion-release`, `ultragoal-nudge-guard`, `ultragoal-pause-guard(+redteam)`, `ultragoal-review`, `ultragoal-dogfood`, `tools/ultragoal-ask-guard`: **190 pass / 0 fail**.
- `tsc --noEmit` and `biome check` clean on the touched files.
- Validated against a copy of the real deadlocked session state: `BEFORE: active_missing_final_receipt — Ultragoal G001 receipt generation is stale.` → identical-evidence replay of the closing goal → `AFTER: active_verified_complete`.
