### PR TITLE
fix(vendor/insane-search): cross-platform yt-dlp resolution (upstream v0.9.2)

### DIFF
--- a/packages/coding-agent/vendor/insane-search/MANIFEST.json
+++ b/packages/coding-agent/vendor/insane-search/MANIFEST.json
@@ -20,7 +20,8 @@
   ],
   "exclusionRationale": "Excludes upstream install hooks (SessionStart settings.json mutation), GitHub star-baiting (gh api user/starred), the update-notifier, and the past-session transcript-language scanner. Only the runtime Phase 0-3 engine and its Playwright/stealth templates are vendored.",
   "localPatches": [
-    "engine/content_safety.py + FetchResult trust/risk metadata (content_trust, prompt_injection_risk, prompt_injection_signals, untrusted_content_boundary) and to_untrusted_text(): cherry-picked from insane-search a16f7c1 (upstream PR #5, v0.9.0). Adds prompt-injection labelling to the JSON surface (to_dict); the default CLI text output is intentionally left unchanged (plain content preserved, no envelope)."
+    "engine/content_safety.py + FetchResult trust/risk metadata (content_trust, prompt_injection_risk, prompt_injection_signals, untrusted_content_boundary) and to_untrusted_text(): cherry-picked from insane-search a16f7c1 (upstream PR #5, v0.9.0). Adds prompt-injection labelling to the JSON surface (to_dict); the default CLI text output is intentionally left unchanged (plain content preserved, no envelope).",
+    "engine/phase0.py _ytdlp_argv() console-script→module fallback + engine/bias_check.py rel.as_posix() Windows exemption + engine/tests/test_u9.py: cherry-picked from insane-search 33f898d (upstream PR #6, released v0.9.2). Cross-platform yt-dlp resolution; no capability or site logic added."
   ],
   "notes": "Runtime engine is invoked via `python3 -m engine \"<url>\" --json` with cwd=this directory and PYTHONPATH pointed at this directory. Phase 0-2 require python3 + curl_cffi; Phase 3 requires node + playwright/playwright-extra/puppeteer-extra-plugin-stealth installed under engine/templates. GJC never auto-installs these dependencies."
 }

--- a/packages/coding-agent/vendor/insane-search/engine/bias_check.py
+++ b/packages/coding-agent/vendor/insane-search/engine/bias_check.py
@@ -98,7 +98,10 @@ def _line_is_exempt(line: str, ext: str) -> bool:
 def _scan_file(path: Path, root: Path) -> list[str]:
     """Return list of violation strings for this file."""
     rel = path.relative_to(root.parent)
-    if str(rel) in EXPLICIT_ALLOW_FILES:
+    # Compare with forward slashes so the exemption matches on Windows too —
+    # `str(rel)` yields backslashes there, silently defeating the phase0.py
+    # exemption (EXPLICIT_ALLOW_FILES uses POSIX-style paths).
+    if rel.as_posix() in EXPLICIT_ALLOW_FILES:
         return []
 
     ext = path.suffix.lower()

--- a/packages/coding-agent/vendor/insane-search/engine/phase0.py
+++ b/packages/coding-agent/vendor/insane-search/engine/phase0.py
@@ -24,8 +24,11 @@ Each attempt dict: {"route","platform","ok","status","bytes","note"}.
 """
 from __future__ import annotations
 
+import importlib.util
 import re
+import shutil
 import subprocess
+import sys
 from typing import Optional
 from urllib.parse import urlsplit
 
@@ -182,11 +185,33 @@ def _x(url: str, timeout: int) -> dict:
 
 
 # --- youtube -----------------------------------------------------------------
+def _ytdlp_argv() -> Optional[list[str]]:
+    """Best yt-dlp invocation for this environment, or None if unavailable.
+
+    Prefers the ``yt-dlp`` console script on PATH; falls back to
+    ``<python> -m yt_dlp`` when the script dir is not on PATH but the module is
+    importable — the common case for ``pip install --user`` and Windows / venv
+    installs, where the Scripts/bin dir is frequently absent from PATH. Mirrors
+    the ``which yt-dlp || python3 -m yt_dlp`` fallback already documented in
+    references/media.md."""
+    exe = shutil.which("yt-dlp")
+    if exe:
+        return [exe]
+    if importlib.util.find_spec("yt_dlp") is not None:
+        return [sys.executable, "-m", "yt_dlp"]
+    return None
+
+
 def _youtube(url: str, timeout: int) -> dict:
     attempts: list[dict] = []
+    argv = _ytdlp_argv()
+    if argv is None:
+        attempts.append(_attempt("youtube", "yt-dlp", False, 0, "", "yt-dlp not installed"))
+        return {"platform": "youtube", "ok": False, "route": None, "content": "",
+                "final_url": url, "attempts": attempts}
     try:
         p = subprocess.run(
-            ["yt-dlp", "--dump-json", "--skip-download", url],
+            argv + ["--dump-json", "--skip-download", url],
             capture_output=True, text=True, timeout=max(timeout, 60),
         )
         ok = p.returncode == 0 and p.stdout.strip().startswith("{")

--- a/packages/coding-agent/vendor/insane-search/engine/tests/test_u9.py
+++ b/packages/coding-agent/vendor/insane-search/engine/tests/test_u9.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""U9 regression tests — cross-platform yt-dlp invocation resolution.
+
+Deterministic and network-free. Locks in that the YouTube Phase-0 route
+resolves yt-dlp robustly:
+  * prefer the `yt-dlp` console script when it is on PATH,
+  * fall back to `<python> -m yt_dlp` when the script dir is not on PATH but
+    the module is importable (pip --user / venv / Windows), and
+  * report "not installed" only when neither is available — without even
+    invoking subprocess.
+
+Regression context: on Windows and `pip install --user`, the console script
+lands in a Scripts/bin dir that is commonly absent from PATH, so
+`subprocess.run(["yt-dlp", ...])` raised FileNotFoundError and the route
+reported "yt-dlp not installed" even though yt-dlp *was* installed and
+importable — silently disabling the headline media route. references/media.md
+already documents the `which yt-dlp || python3 -m yt_dlp` fallback; this locks
+the same behaviour into the engine.
+
+Run:  python3 engine/tests/test_u9.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+sys.path.insert(0, ROOT)
+
+from engine import phase0  # noqa: E402
+
+
+def t_prefers_console_script_on_path() -> None:
+    with mock.patch.object(phase0.shutil, "which", return_value="/usr/bin/yt-dlp"):
+        argv = phase0._ytdlp_argv()
+    assert argv == ["/usr/bin/yt-dlp"], argv
+    print("  ✓ console script on PATH → used directly")
+
+
+def t_falls_back_to_module_when_not_on_path() -> None:
+    with mock.patch.object(phase0.shutil, "which", return_value=None), \
+         mock.patch.object(phase0.importlib.util, "find_spec", return_value=object()):
+        argv = phase0._ytdlp_argv()
+    assert argv == [sys.executable, "-m", "yt_dlp"], argv
+    print("  ✓ not on PATH but importable → <python> -m yt_dlp")
+
+
+def t_none_when_neither_available() -> None:
+    with mock.patch.object(phase0.shutil, "which", return_value=None), \
+         mock.patch.object(phase0.importlib.util, "find_spec", return_value=None):
+        argv = phase0._ytdlp_argv()
+    assert argv is None, argv
+    print("  ✓ truly missing → None")
+
+
+def t_youtube_route_reports_not_installed_without_subprocess() -> None:
+    def _boom(*a, **k):
+        raise AssertionError("subprocess.run must not run when yt-dlp is unavailable")
+    with mock.patch.object(phase0, "_ytdlp_argv", return_value=None), \
+         mock.patch.object(phase0.subprocess, "run", _boom):
+        out = phase0._youtube("https://www.youtube.com/watch?v=x", timeout=5)
+    assert out["ok"] is False, out
+    assert out["attempts"] and out["attempts"][-1]["note"] == "yt-dlp not installed", out["attempts"]
+    print("  ✓ unavailable → 'not installed' note, subprocess not invoked")
+
+
+def t_youtube_route_uses_resolved_argv() -> None:
+    captured = {}
+
+    class _P:
+        returncode = 0
+        stdout = '{"title": "x"}'
+        stderr = ""
+
+    def _fake_run(cmd, *a, **k):
+        captured["cmd"] = cmd
+        return _P()
+
+    with mock.patch.object(phase0, "_ytdlp_argv", return_value=[sys.executable, "-m", "yt_dlp"]), \
+         mock.patch.object(phase0.subprocess, "run", _fake_run):
+        out = phase0._youtube("https://youtu.be/abc", timeout=5)
+    assert out["ok"] is True, out
+    assert captured["cmd"][:3] == [sys.executable, "-m", "yt_dlp"], captured["cmd"]
+    assert captured["cmd"][3:] == ["--dump-json", "--skip-download", "https://youtu.be/abc"], captured["cmd"]
+    print("  ✓ resolved argv is passed through to subprocess with the yt-dlp flags")
+
+
+ALL = [
+    ("prefers_console_script_on_path", t_prefers_console_script_on_path),
+    ("falls_back_to_module_when_not_on_path", t_falls_back_to_module_when_not_on_path),
+    ("none_when_neither_available", t_none_when_neither_available),
+    ("youtube_route_reports_not_installed_without_subprocess", t_youtube_route_reports_not_installed_without_subprocess),
+    ("youtube_route_uses_resolved_argv", t_youtube_route_uses_resolved_argv),
+]
+
+
+def main() -> int:
+    p = f = 0
+    for name, fn in ALL:
+        try:
+            print(f"[{name}]")
+            fn()
+            p += 1
+        except AssertionError as e:
+            f += 1
+            print(f"  ✗ FAIL: {e}")
+        except Exception as e:
+            f += 1
+            print(f"  ✗ ERROR: {type(e).__name__}: {e}")
+    print(f"\n{p} passed, {f} failed")
+    return 0 if f == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Surgical cherry-pick of upstream [fivetaku/insane-search#6](https://github.com/fivetaku/insane-search/pull/6), released as [v0.9.2](https://github.com/fivetaku/insane-search/releases/tag/v0.9.2), onto the vendored engine. Applied as a patch (not a wholesale sync) to preserve the vendor's local modifications.

## What it fixes

The YouTube Phase-0 route invoked yt-dlp only as the bare `yt-dlp` console script. With `pip install --user`, venv, and especially Windows installs, the script dir is commonly absent from PATH, so the route reported **"yt-dlp not installed" even though yt-dlp was installed and importable** — silently disabling the media route.

- `engine/phase0.py`: new `_ytdlp_argv()` — console script on PATH first, else `<python> -m yt_dlp`. Non-regressive when yt-dlp is on PATH.
- `engine/bias_check.py`: `rel.as_posix()` so the sanctioned `phase0.py` exemption matches on Windows. No behavior change on POSIX.
- `engine/tests/test_u9.py`: network-free regression suite.

## Validation (run in this branch's vendor tree)

```
test_u9 5/5, test_u1 12/12, test_u5 14/14, test_u7 7/7, test_u8 11/11,
test_hardening OK, test_smoke 8/8, bias_check ✅ clean
```

Note: `test_u4` `warmup_once_guard_online` fails with a `NameError: allow_private` **identically on pristine `dev`** — pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)