### PR TITLE
fix(browser): fail closed on native locale discovery

### DIFF
--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -36,7 +36,6 @@ const STEALTH_IGNORE_DEFAULT_ARGS = [
 	"--disable-default-apps",
 	"--disable-component-extensions-with-background-pages",
 ];
-const STEALTH_ACCEPT_LANGUAGE = "en-US,en";
 
 const USER_AGENT_TARGET_TIMEOUT_MS = 5_000;
 const USER_AGENT_TARGET_TYPES = new Set(["page", "webview", "background_page"]);
@@ -348,12 +347,10 @@ function acceptLanguageForLocale(locale: string): string {
 
 async function resolveAcceptLanguage(page: Page, locale?: string): Promise<string> {
 	if (locale) return acceptLanguageForLocale(locale);
-	try {
-		const languages = await page.evaluate(() => [...navigator.languages]);
-		return languages.filter(Boolean).join(",") || STEALTH_ACCEPT_LANGUAGE;
-	} catch {
-		return STEALTH_ACCEPT_LANGUAGE;
-	}
+	const languages = await page.evaluate(() => [...navigator.languages]);
+	const acceptLanguage = languages.filter(Boolean).join(",");
+	if (!acceptLanguage) throw new ToolError("Chromium reported no native navigator languages");
+	return acceptLanguage;
 }
 
 function resolvePageClient(page: Page): PuppeteerCdpClient | null {

--- a/packages/coding-agent/test/tools/browser-stealth-network.integration.test.ts
+++ b/packages/coding-agent/test/tools/browser-stealth-network.integration.test.ts
@@ -139,9 +139,6 @@ describe("stealth network posture (integration)", () => {
 
 	it("B2: configured geo keeps request headers, navigator, and Intl coherent", async () => {
 		if (!chromiumAvailable()) {
-			if (process.env.GJC_REQUIRE_CHROMIUM === "1") {
-				throw new Error("GJC_REQUIRE_CHROMIUM=1 requires a resolvable Chromium executable");
-			}
 			expect(true).toBe(true);
 			return;
 		}
@@ -238,9 +235,6 @@ describe("stealth network posture (integration)", () => {
 	});
 	it("B6: headless browser cache serializes identical geo and separates different geo", async () => {
 		if (!chromiumAvailable()) {
-			if (process.env.GJC_REQUIRE_CHROMIUM === "1") {
-				throw new Error("GJC_REQUIRE_CHROMIUM=1 requires a resolvable Chromium executable");
-			}
 			expect(true).toBe(true);
 			return;
 		}


### PR DESCRIPTION
## Follow-up to #2283

The owner merged #2283 while its audit lane was still completing the mandatory cleanup sweep. That sweep found one masking fallback in the unset-geo path: failure to read native `navigator.languages` silently substituted `en-US,en`, contradicting the new native no-op contract.

This focused follow-up:
- removes the hard-coded fallback and fails closed when Chromium cannot report native languages;
- removes redundant per-test `GJC_REQUIRE_CHROMIUM` branches now enforced centrally.

Verification at exact local head:
- real Chromium geo integration: 7/7;
- coding-agent Biome/type/canonicalization check: passed.

No release, publish, canonical-dev mutation, or unrelated change.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*