### PR TITLE
fix(sdk): idempotent gate completion + capability-gated workflow controls (#2171 follow-up)

### DIFF
--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -808,6 +808,7 @@ export class PresentationArbiter {
 		if (!proof && this.queuedDirectControls.has(gateId)) proof = "not_published";
 		if (!proof && presentation)
 			throw new Error(`workflow gate ${gateId} presentation lacks an active terminal lease`);
+		this.presentations.delete(gateId);
 		this.directControls.delete(gateId);
 		this.queuedDirectControls.delete(gateId);
 		this.retiredProofs.delete(gateId);
@@ -1611,6 +1612,23 @@ const QUERY_BINDINGS: Readonly<Record<string, string | undefined>> = {
 	"runtime.jobs.list": "getJobs",
 };
 
+function hasTerminalArbitrationCapability(
+	workflowGate: WorkflowGateEmitter | undefined,
+): workflowGate is WorkflowGateEmitter &
+	Required<
+		Pick<
+			WorkflowGateEmitter,
+			"resolveGate" | "prepareTerminalization" | "clearPreparedTerminalization" | "registerGateTerminalController"
+		>
+	> {
+	return (
+		typeof workflowGate?.resolveGate === "function" &&
+		typeof workflowGate.prepareTerminalization === "function" &&
+		typeof workflowGate.clearPreparedTerminalization === "function" &&
+		typeof workflowGate.registerGateTerminalController === "function"
+	);
+}
+
 function installedOperations(ctx: ExtensionContext, kind: "control" | "query"): Set<string> {
 	const bindings = new Set(ctx.sdkBindings?.() ?? []);
 	const required = kind === "control" ? CONTROL_BINDINGS : QUERY_BINDINGS;
@@ -1619,8 +1637,8 @@ function installedOperations(ctx: ExtensionContext, kind: "control" | "query"): 
 			operation.kind === kind &&
 			(kind !== "control" ||
 				(!UNINSTALLED_CONTROL_OPERATIONS.has(operation.sdkId) &&
-					((operation.sdkId !== "workflow.gate_answer" && operation.sdkId !== "workflow.plan_approve") ||
-						ctx.workflowGate !== undefined) &&
+						((operation.sdkId !== "workflow.gate_answer" && operation.sdkId !== "workflow.plan_approve") ||
+							hasTerminalArbitrationCapability(ctx.workflowGate)) &&
 					(!required[operation.sdkId] || bindings.has(required[operation.sdkId]!)))),
 	);
 	return new Set(candidates.map(operation => operation.sdkId));
@@ -3320,7 +3338,7 @@ export function createNotificationsExtension(
 					return;
 				}
 				activeRuntime.workflowGate = gate;
-				if (gate.registerGateTerminalController) {
+				if (hasTerminalArbitrationCapability(gate)) {
 					const controller: WorkflowGateTerminalController = {
 						completeGateInteractions: gateId => gatePresentations.complete(gateId),
 						cancelGateInteractions: (gateId, reason) => gatePresentations.cancel(gateId, reason),

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -14,6 +14,7 @@ import { ExtensionUiController } from "../src/modes/controllers/extension-ui-con
 import {
 	BrokerWorkflowGateEmitter,
 	FileGateStore,
+	MemoryGateStore,
 	type WorkflowGateEmitter,
 } from "../src/modes/shared/agent-wire/workflow-gate-broker";
 import type { InteractiveModeContext } from "../src/modes/types";
@@ -2330,6 +2331,124 @@ test("session teardown drains admitted direct gate resolution before detaching i
 		registerController.mockRestore();
 	}
 });
+test("PresentationArbiter drops a retired presentation before terminal persistence recovery", async () => {
+	const publications: string[] = [];
+	const closed: string[] = [];
+	const store = new MemoryGateStore();
+	const originalPut = store.put.bind(store);
+	let failTerminalizedWrite = true;
+	const put = spyOn(store, "put").mockImplementation(record => {
+		if (failTerminalizedWrite && record.terminalized) {
+			failTerminalizedWrite = false;
+			throw new Error("terminalized record write failed");
+		}
+		originalPut(record);
+	});
+	const emitter = new BrokerWorkflowGateEmitter("terminal-recovery", store);
+	const arbiter = new PresentationArbiter(
+		{
+			registerArbitratedAsk(json: string) {
+				const action = JSON.parse(json) as { id: string };
+				publications.push(action.id);
+				return { actionId: action.id, registrationEpoch: publications.length };
+			},
+			retireIfUnclaimed: () => ({ status: "retired" as const }),
+		} as never,
+		() => false,
+		"test",
+	);
+	emitter.registerGateTerminalController!({
+		completeGateInteractions: gateId => arbiter.complete(gateId),
+		cancelGateInteractions: gateId => arbiter.cancel(gateId, "terminalization failed"),
+	});
+	const gateIds: string[] = [];
+	emitter.onGateEmitted!(gate => {
+		gateIds.push(gate.gate_id);
+		arbiter.retain({
+			gateId: gate.gate_id,
+			workflowGateId: gate.gate_id,
+			sessionId: "session",
+			question: gate.gate_id,
+			options: ["approve"],
+			controls: [],
+			multi: false,
+			allowEmpty: false,
+			selectedOptions: [],
+			onClosed: () => closed.push(gate.gate_id),
+		});
+	});
+	const firstAdvance = emitter.emitGate({ stage: "ralplan", kind: "approval", schema: { type: "string" } });
+	const secondAdvance = emitter.emitGate({ stage: "ralplan", kind: "approval", schema: { type: "string" } });
+	const [firstGateId, secondGateId] = gateIds;
+
+	try {
+		await expect(
+			emitter.resolveGate!({ gate_id: firstGateId!, answer: "approve", idempotency_key: firstGateId! }),
+		).rejects.toThrow("terminalized record write failed");
+		expect(publications).toHaveLength(2);
+		expect(closed).toEqual([firstGateId]);
+		expect(store.get(firstGateId!)).toMatchObject({ status: "accepted", terminalized: false, advanced: false });
+
+		await expect(emitter.recoverAcceptedGates!()).resolves.toEqual([firstGateId]);
+		expect(await firstAdvance).toBe("approve");
+		expect(arbiter.complete(firstGateId!)).toBe("already_terminal");
+		expect(closed).toEqual([firstGateId]);
+		expect(arbiter.routeFor(publications[1]!)).toBe(secondGateId);
+	} finally {
+		put.mockRestore();
+		void secondAdvance.catch(() => {});
+	}
+});
+
+test("SDK host omits direct workflow controls for a legacy workflow-gate emitter", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-legacy-workflow-gate-"));
+	dirs.push(cwd);
+	const sessionId = `legacy-workflow-gate-${Date.now()}`;
+	const legacyEmitter = {
+		isUnattended: () => true,
+		emitGate: async () => undefined,
+		resolveGate: async () => ({
+			gate_id: "legacy-gate",
+			status: "accepted" as const,
+			answer_hash: "fixture",
+			resolved_at: new Date().toISOString(),
+		}),
+	} as WorkflowGateEmitter;
+	process.env.GJC_NOTIFICATIONS = "1";
+	start(context(cwd, sessionId, "main", {}, legacyEmitter));
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	const frames: Record<string, unknown>[] = [];
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	socket.send(
+		JSON.stringify({
+			type: "control_command",
+			sessionId,
+			token: endpoint.token,
+			requestId: "capabilities",
+			command: { type: "query_request", id: "capabilities", query: "runtime.capabilities" },
+		}),
+	);
+	await waitFor(
+		() => frames.some(frame => frame.type === "control_command_result" && frame.requestId === "capabilities"),
+		"capabilities response",
+	);
+	const response = JSON.parse(
+		String(frames.find(frame => frame.type === "control_command_result" && frame.requestId === "capabilities")?.message),
+	) as { page: { items: Array<{ operations: string[] }> } };
+	const operations = response.page.items[0]!.operations;
+	expect(operations).not.toContain("workflow.gate_answer");
+	expect(operations).not.toContain("workflow.plan_approve");
+	expect(operations).toContain("model.cycle");
+});
+
 test("PresentationArbiter serializes ordinary and workflow asks, fences queued controls, and fails closed on uncertainty", async () => {
 	const publications: Array<Record<string, unknown>> = [];
 	const retired: Array<{ actionId: string; registrationEpoch: number }> = [];


### PR DESCRIPTION
Follow-up to #2220 (merged as b86930b4), resolving two architect-identified MEDIUM defects that landed in dev with that merge. Independent architect re-review of this exact change: APPROVE, all lanes CLEAR.

## Findings fixed
1. **Non-idempotent gate completion / presentation leak** — `PresentationArbiter.complete()` never deleted the presentation, so recovery after a failed terminalized-record write (native already retired) threw `presentation lacks an active terminal lease` instead of returning `already_terminal`, leaking one presentation per gate. Now deletes the presentation on the non-error completion path (after the no-proof throw check, preserving premature-completion error stickiness).
2. **Over-advertised workflow controls** — operation discovery advertised `workflow.gate_answer`/`workflow.plan_approve` whenever any emitter existed, so legacy emitters lacking terminal-arbitration hooks surfaced controls that deterministically failed as `resource_gone`. New `hasTerminalArbitrationCapability()` guard (resolveGate + prepareTerminalization + clearPreparedTerminalization + registerGateTerminalController) gates both advertisement and controller construction; no id-only fallback.

## Tests
- Recovery idempotency regression (failed terminalized-write after native retirement → `already_terminal`, no leak, onClosed once).
- Legacy-emitter operation-discovery compatibility (controls absent, ordinary ops present).
- `bun test sdk-host-wiring.test.ts`: 46 pass / 0 fail on the current dev base.

Evidence: artifacts/release-blocker-rereview-0.11.0.json (finding detail), architect verdict APPROVE/CLEAR.