### PR TITLE
fix(sdk): stabilize dev lifecycle shard

### DIFF
--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -1643,8 +1643,8 @@ function installedOperations(ctx: ExtensionContext, kind: "control" | "query"): 
 			operation.kind === kind &&
 			(kind !== "control" ||
 				(!UNINSTALLED_CONTROL_OPERATIONS.has(operation.sdkId) &&
-						((operation.sdkId !== "workflow.gate_answer" && operation.sdkId !== "workflow.plan_approve") ||
-							hasTerminalArbitrationCapability(ctx.workflowGate)) &&
+					((operation.sdkId !== "workflow.gate_answer" && operation.sdkId !== "workflow.plan_approve") ||
+						hasTerminalArbitrationCapability(ctx.workflowGate)) &&
 					(!required[operation.sdkId] || bindings.has(required[operation.sdkId]!)))),
 	);
 	return new Set(candidates.map(operation => operation.sdkId));
@@ -1855,10 +1855,11 @@ function sdkControlSurface(
 	const cancelPendingPreflights = () => {
 		for (const cancel of pendingPreflightCancellations) cancel();
 	};
+	const isSessionBusy = () => isBusy() || ctx.isIdle?.() === false;
 	const awaitAbortReady = async () => {
 		cancelPendingPreflights();
 		await (ctx.abort as () => unknown)();
-		while (isBusy() || !ctx.isIdle()) {
+		while (isSessionBusy()) {
 			await Bun.sleep(10);
 		}
 	};
@@ -1870,12 +1871,12 @@ function sdkControlSurface(
 		rejectWhenBusy = false,
 		requesterConnectionId?: string,
 	) => {
-		if (forceFresh && (isBusy() || !ctx.isIdle())) {
+		if (forceFresh && isSessionBusy()) {
 			throw Object.assign(new Error("Previous turn did not finish aborting before replacement prompt submission."), {
 				code: "busy",
 			});
 		}
-		if (rejectWhenBusy && (isBusy() || !ctx.isIdle()))
+		if (rejectWhenBusy && isSessionBusy())
 			throw Object.assign(
 				new Error("turn.prompt is unavailable while the agent is busy; use turn.steer explicitly."),
 				{

--- a/packages/coding-agent/test/sdk-default-model-selection-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-default-model-selection-e2e.test.ts
@@ -222,4 +222,4 @@ test("model.set executes every Q10-advertised selection and persists the public 
 	} finally {
 		await freshSession.dispose();
 	}
-});
+}, 30000);

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2927,7 +2927,9 @@ test("SDK host omits direct workflow controls for a legacy workflow-gate emitter
 		"capabilities response",
 	);
 	const response = JSON.parse(
-		String(frames.find(frame => frame.type === "control_command_result" && frame.requestId === "capabilities")?.message),
+		String(
+			frames.find(frame => frame.type === "control_command_result" && frame.requestId === "capabilities")?.message,
+		),
 	) as { page: { items: Array<{ operations: string[] }> } };
 	const operations = response.page.items[0]!.operations;
 	expect(operations).not.toContain("workflow.gate_answer");

--- a/packages/coding-agent/test/sdk-query-pagination.test.ts
+++ b/packages/coding-agent/test/sdk-query-pagination.test.ts
@@ -177,7 +177,7 @@ describe("SDK query pagination", () => {
 			expect(complete.page?.complete).toBe(true);
 		}
 		expect(query.cursors.size).toBe(0);
-	});
+	}, 30000);
 
 	it("writes owner-private chunked spills atomically with bounded buffering", async () => {
 		const stateRoot = await mkdtemp(join(tmpdir(), "gjc-sdk-query-test-"));


### PR DESCRIPTION
Fixes #2291.

Repairs the post-merge Dev CI regression observed at https://github.com/Yeachan-Heo/gajae-code/actions/runs/29407224073:
- preserves typed `turn.prompt` preflight errors and accepted correlated terminal events when a minimal extension context does not expose `isIdle`;
- applies the exact two Biome formatting changes reported by the coding-agent check;
- gives two integration-heavy shard-7 tests explicit 30s budgets so shared-process load does not trip Bun's 5s default.

Validation:
- `bun test test/notifications-session-switch.test.ts` — 12 pass
- `bun test test/sdk-host-wiring.test.ts --test-name-pattern 'pre-ack|prompt terminal|preflight|turn.prompt'` — 6 pass
- `bun test --shard=7/8` — 1085 pass, 66 skip, 0 fail
- `bun run check` in `packages/coding-agent` — pass

Signed commit: `05d9f01e59e369de96d989afbd0499aeb42d557f`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*