### PR TITLE
fix(coding-agent): close hostile review gaps in profile recovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- Interactive startup now keeps the TUI reachable when a configured model profile is missing required provider credentials, while input-bearing, resume-continuation, image-only, print/text, and unrelated activation failures remain fail-closed (#2277).
+- Input-free interactive TTY startup now keeps the TUI reachable when configured model profiles are missing required provider credentials, skips only the blocked profiles, and preserves later `--mpreset` and explicit model/thinking precedence; redirected terminals, input-bearing, resume-continuation, image-only, print/text, and unrelated activation failures remain fail-closed (#2277).
 - Browser geo settings now propagate coherently across request `Accept-Language`, navigator languages, and `Intl` locale/timezone surfaces; configured managed browsers are isolated by geo/profile posture, concurrent acquisition is serialized, and unset geo preserves Chromium's native locale/timezone instead of injecting a fixed New York profile.
 
 - Cooperative mid-run context maintenance now waits at a cancellation-aware FIFO consumer-drain checkpoint before flushing or rewriting session history. Materialized tool results and steering messages are synchronously canonicalized first; aborted barriers and hook/signal-cancelled compactions settle without rewriting or scheduling a continuation. Promotion, pruning, and compaction each start a clean provider/prompt-cache epoch. Script-aware #2067 unsent-delta accounting remains cache-free and distinct from the lifecycle checkpoint.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -368,23 +368,36 @@ type CreateSessionForMain = (
 	context?: { skipPostCreateModelRefresh?: boolean },
 ) => Promise<CreateAgentSessionResult>;
 
-export async function applyStartupModelProfiles(args: {
+type StartupModelProfileArgs = {
 	session: AgentSession;
 	settings: Settings;
 	modelRegistry: ModelRegistry;
 	parsedArgs: Pick<Args, "default" | "model" | "mpreset" | "thinking">;
 	startupModel?: CreateAgentSessionOptions["model"];
 	startupThinkingLevel?: CreateAgentSessionOptions["thinkingLevel"];
-}): Promise<void> {
+};
+
+async function applyStartupModelProfilesWithPolicy(
+	args: StartupModelProfileArgs,
+	onCredentialError?: (error: ModelProfileCredentialError) => void,
+): Promise<void> {
 	const applyProfile = async (
 		profileName: string,
 		persistDefault: boolean,
 		options: { thinkingLevelOverride?: CreateAgentSessionOptions["thinkingLevel"] } = {},
 	): Promise<void> => {
-		await activateModelProfile(
-			{ session: args.session, modelRegistry: args.modelRegistry, settings: args.settings, profileName },
-			{ persistDefault, thinkingLevelOverride: options.thinkingLevelOverride },
-		);
+		try {
+			await activateModelProfile(
+				{ session: args.session, modelRegistry: args.modelRegistry, settings: args.settings, profileName },
+				{ persistDefault, thinkingLevelOverride: options.thinkingLevelOverride },
+			);
+		} catch (error) {
+			if (onCredentialError && error instanceof ModelProfileCredentialError) {
+				onCredentialError(error);
+				return;
+			}
+			throw error;
+		}
 	};
 
 	// Capture the explicitly-selected startup model BEFORE profile activation can
@@ -407,7 +420,7 @@ export async function applyStartupModelProfiles(args: {
 		await applyProfile(args.parsedArgs.mpreset, args.parsedArgs.default === true);
 	}
 
-	// Explicit CLI --model/--thinking must win over any activated profile.
+	// Explicit CLI --model/--thinking must win over any activated or skipped profile.
 	if (explicitModel) {
 		await args.session.setModelTemporary(explicitModel, args.startupThinkingLevel ?? args.parsedArgs.thinking, {
 			persistAsSessionDefault: true,
@@ -421,31 +434,35 @@ export async function applyStartupModelProfiles(args: {
 	}
 }
 
-export async function applyStartupModelProfilesOrExit(
-	args: Parameters<typeof applyStartupModelProfiles>[0] & { recoverCredentialError?: boolean },
-): Promise<{ recoverableError?: string }> {
+export async function applyStartupModelProfiles(args: StartupModelProfileArgs): Promise<void> {
+	await applyStartupModelProfilesWithPolicy(args);
+}
+
+async function exitForStartupModelProfileError(args: StartupModelProfileArgs, error: unknown): Promise<never> {
+	const message = error instanceof Error ? error.message : String(error);
+	process.stderr.write(`${chalk.red(`Error: ${message}`)}\n`);
+	await args.session.dispose();
+	process.exit(1);
+}
+
+export async function applyStartupModelProfilesOrExit(args: StartupModelProfileArgs): Promise<void> {
 	try {
 		await applyStartupModelProfiles(args);
-		return {};
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		if (args.recoverCredentialError === true && error instanceof ModelProfileCredentialError) {
-			return { recoverableError: message };
-		}
-		process.stderr.write(`${chalk.red(`Error: ${message}`)}\n`);
-		await args.session.dispose();
-		process.exit(1);
+		await exitForStartupModelProfileError(args, error);
 	}
 }
 
 export function isStartupModelProfileCredentialRecoveryEligible(options: {
 	isInteractive: boolean;
+	hasInteractiveTerminal: boolean;
 	initialMessage: string | undefined;
 	initialMessages: readonly string[];
 	resumeAction: "continue-tail" | "open-idle" | undefined;
 }): boolean {
 	return (
 		options.isInteractive &&
+		options.hasInteractiveTerminal &&
 		options.initialMessage === undefined &&
 		options.initialMessages.length === 0 &&
 		options.resumeAction !== "continue-tail"
@@ -453,17 +470,26 @@ export function isStartupModelProfileCredentialRecoveryEligible(options: {
 }
 
 export async function applyStartupModelProfilesForRoot(
-	args: Parameters<typeof applyStartupModelProfiles>[0] & {
+	args: StartupModelProfileArgs & {
 		isInteractive: boolean;
+		hasInteractiveTerminal: boolean;
 		initialMessage: string | undefined;
 		initialMessages: readonly string[];
 		resumeAction: "continue-tail" | "open-idle" | undefined;
 	},
-): Promise<{ recoverableError?: string }> {
-	return applyStartupModelProfilesOrExit({
-		...args,
-		recoverCredentialError: isStartupModelProfileCredentialRecoveryEligible(args),
-	});
+): Promise<{ recoverableErrors: string[] }> {
+	if (!isStartupModelProfileCredentialRecoveryEligible(args)) {
+		await applyStartupModelProfilesOrExit(args);
+		return { recoverableErrors: [] };
+	}
+
+	const recoverableErrors: string[] = [];
+	try {
+		await applyStartupModelProfilesWithPolicy(args, error => recoverableErrors.push(error.message));
+	} catch (error) {
+		await exitForStartupModelProfileError(args, error);
+	}
+	return { recoverableErrors };
 }
 
 interface InteractiveModeFactoryOptions {
@@ -1345,7 +1371,7 @@ export async function runRootCommand(
 		}
 
 		if (!(parsedArgs.authBootstrap === true && isInteractive)) {
-			const { recoverableError } = await applyStartupModelProfilesForRoot({
+			const { recoverableErrors } = await applyStartupModelProfilesForRoot({
 				session,
 				settings: settingsInstance,
 				modelRegistry,
@@ -1353,11 +1379,12 @@ export async function runRootCommand(
 				startupModel: sessionOptions.model,
 				startupThinkingLevel: sessionOptions.thinkingLevel,
 				isInteractive,
+				hasInteractiveTerminal: hasResumePickerTerminal(),
 				initialMessage,
 				initialMessages: parsedArgs.messages,
 				resumeAction: bareResumeAction,
 			});
-			if (recoverableError) {
+			for (const recoverableError of recoverableErrors) {
 				notifs.push({ kind: "error", message: recoverableError });
 			}
 		}

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -348,42 +348,6 @@ test("persisted default thinking overrides startup default profile effort", asyn
 	).toEqual(["profile-provider/default:xhigh"]);
 });
 
-test("interactive startup surfaces missing-credential profile errors as recoverable notifications instead of exiting", async () => {
-	const session = fakeSession();
-	const settings = Settings.isolated({ "modelProfile.default": "codex-medium" });
-	const registry = {
-		...fakeRegistry([
-			{
-				name: "codex-medium",
-				requiredProviders: ["openai-codex"],
-				modelMapping: { default: "openai-codex/default:high" },
-				source: "user",
-			},
-		]),
-		getApiKeyForProvider: async () => undefined,
-	} as never;
-
-	const exitSpy = spyOn(process, "exit").mockImplementation((() => {
-		throw new Error("process.exit must not be called in interactive recovery");
-	}) as never);
-	try {
-		const result = await applyStartupModelProfilesOrExit({
-			session,
-			settings,
-			modelRegistry: registry,
-			parsedArgs: {},
-			startupModel: undefined,
-			startupThinkingLevel: undefined,
-			recoverCredentialError: true,
-		});
-
-		expect(exitSpy).not.toHaveBeenCalled();
-		expect(result.recoverableError).toContain('Model profile "codex-medium" requires credentials for: openai-codex');
-	} finally {
-		exitSpy.mockRestore();
-	}
-});
-
 test("noninteractive startup keeps the exit-on-missing-credential contract", async () => {
 	const session = fakeSession();
 	const settings = Settings.isolated({ "modelProfile.default": "codex-medium" });
@@ -417,7 +381,6 @@ test("noninteractive startup keeps the exit-on-missing-credential contract", asy
 				parsedArgs: {},
 				startupModel: undefined,
 				startupThinkingLevel: undefined,
-				recoverCredentialError: false,
 			}),
 		).rejects.toBe(exit);
 		expect(exitSpy).toHaveBeenCalledWith(1);
@@ -445,7 +408,6 @@ test("credential recovery does not mask unrelated model-profile activation error
 				parsedArgs: {},
 				startupModel: undefined,
 				startupThinkingLevel: undefined,
-				recoverCredentialError: true,
 			}),
 		).rejects.toBe(exit);
 		expect(exitSpy).toHaveBeenCalledWith(1);
@@ -457,17 +419,19 @@ test("credential recovery does not mask unrelated model-profile activation error
 
 describe("startup model-profile credential recovery eligibility", () => {
 	test.each([
-		["ordinary input-free interactive startup", true, undefined, [], undefined, true],
-		["print or text startup", false, undefined, [], undefined, false],
-		["explicit startup prompt", true, "hello", [], undefined, false],
-		["slash or positional startup message", true, undefined, ["/login"], undefined, false],
-		["image-only startup", true, "", [], undefined, false],
-		["automatic resume continuation", true, undefined, [], "continue-tail", false],
-		["idle resume picker selection", true, undefined, [], "open-idle", true],
-	] as const)("%s", (_name, isInteractive, initialMessage, initialMessages, resumeAction, expected) => {
+		["ordinary input-free interactive startup", true, true, undefined, [], undefined, true],
+		["redirected stdin or stdout", true, false, undefined, [], undefined, false],
+		["print or text startup", false, true, undefined, [], undefined, false],
+		["explicit startup prompt", true, true, "hello", [], undefined, false],
+		["slash or positional startup message", true, true, undefined, ["/login"], undefined, false],
+		["image-only startup", true, true, "", [], undefined, false],
+		["automatic resume continuation", true, true, undefined, [], "continue-tail", false],
+		["idle resume picker selection", true, true, undefined, [], "open-idle", true],
+	] as const)("%s", (_name, isInteractive, hasInteractiveTerminal, initialMessage, initialMessages, resumeAction, expected) => {
 		expect(
 			isStartupModelProfileCredentialRecoveryEligible({
 				isInteractive,
+				hasInteractiveTerminal,
 				initialMessage,
 				initialMessages,
 				resumeAction,
@@ -499,21 +463,25 @@ test("root startup recovers a missing credential only for an input-free interact
 		startupModel: undefined,
 		startupThinkingLevel: undefined,
 		isInteractive: true,
+		hasInteractiveTerminal: true,
 		initialMessage: undefined,
 		initialMessages: [],
 		resumeAction: undefined,
 	});
 
-	expect(result.recoverableError).toContain('Model profile "codex-medium" requires credentials for: openai-codex');
+	expect(result.recoverableErrors).toEqual([
+		expect.stringContaining('Model profile "codex-medium" requires credentials for: openai-codex'),
+	]);
 });
 
 test.each([
-	["print or text", false, undefined, [], undefined],
-	["explicit prompt", true, "hello", [], undefined],
-	["positional or slash input", true, undefined, ["do work"], undefined],
-	["image-only input", true, "", [], undefined],
-	["automatic resume continuation", true, undefined, [], "continue-tail"],
-] as const)("root startup keeps %s credential failures fatal", async (_name, isInteractive, initialMessage, initialMessages, resumeAction) => {
+	["redirected terminal", true, false, undefined, [], undefined],
+	["print or text", false, true, undefined, [], undefined],
+	["explicit prompt", true, true, "hello", [], undefined],
+	["positional or slash input", true, true, undefined, ["do work"], undefined],
+	["image-only input", true, true, "", [], undefined],
+	["automatic resume continuation", true, true, undefined, [], "continue-tail"],
+] as const)("root startup keeps %s credential failures fatal", async (_name, isInteractive, hasInteractiveTerminal, initialMessage, initialMessages, resumeAction) => {
 	const session = fakeSession();
 	const settings = Settings.isolated({ "modelProfile.default": "codex-medium" });
 	const registry = {
@@ -542,6 +510,7 @@ test.each([
 				startupModel: undefined,
 				startupThinkingLevel: undefined,
 				isInteractive,
+				hasInteractiveTerminal,
 				initialMessage,
 				initialMessages,
 				resumeAction,
@@ -551,6 +520,90 @@ test.each([
 		stderrSpy.mockRestore();
 		exitSpy.mockRestore();
 	}
+});
+
+test("recoverable blocked default still applies healthy --mpreset and explicit CLI override", async () => {
+	const explicitModel = model("cli-provider", "explicit");
+	const session = fakeSession(explicitModel);
+	const settings = Settings.isolated({ "modelProfile.default": "blocked-default" });
+	const registry = {
+		...fakeRegistry([
+			{
+				name: "blocked-default",
+				requiredProviders: ["blocked-provider"],
+				modelMapping: { default: "blocked-provider/default:medium" },
+				source: "user",
+			},
+			{
+				name: "healthy-session",
+				requiredProviders: ["profile-provider"],
+				modelMapping: { default: "profile-provider/default:high" },
+				source: "user",
+			},
+		]),
+		getApiKeyForProvider: async (provider: string) => (provider === "blocked-provider" ? undefined : "key"),
+	} as never;
+
+	const result = await applyStartupModelProfilesForRoot({
+		session,
+		settings,
+		modelRegistry: registry,
+		parsedArgs: { mpreset: "healthy-session", model: "cli-provider/explicit", thinking: ThinkingLevel.Low },
+		startupModel: explicitModel,
+		startupThinkingLevel: ThinkingLevel.Low,
+		isInteractive: true,
+		hasInteractiveTerminal: true,
+		initialMessage: undefined,
+		initialMessages: [],
+		resumeAction: undefined,
+	});
+
+	expect(result.recoverableErrors).toHaveLength(1);
+	expect(
+		session.setModelTemporaryCalls.map(call => `${call.model.provider}/${call.model.id}:${call.thinkingLevel}`),
+	).toEqual(["profile-provider/default:high", "cli-provider/explicit:low"]);
+});
+
+test("recoverable blocked --mpreset still reapplies explicit CLI override after a healthy default", async () => {
+	const explicitModel = model("cli-provider", "explicit");
+	const session = fakeSession(explicitModel);
+	const settings = Settings.isolated({ "modelProfile.default": "healthy-default" });
+	const registry = {
+		...fakeRegistry([
+			{
+				name: "healthy-default",
+				requiredProviders: ["profile-provider"],
+				modelMapping: { default: "profile-provider/default:medium" },
+				source: "user",
+			},
+			{
+				name: "blocked-session",
+				requiredProviders: ["blocked-provider"],
+				modelMapping: { default: "blocked-provider/default:high" },
+				source: "user",
+			},
+		]),
+		getApiKeyForProvider: async (provider: string) => (provider === "blocked-provider" ? undefined : "key"),
+	} as never;
+
+	const result = await applyStartupModelProfilesForRoot({
+		session,
+		settings,
+		modelRegistry: registry,
+		parsedArgs: { mpreset: "blocked-session", model: "cli-provider/explicit", thinking: ThinkingLevel.XHigh },
+		startupModel: explicitModel,
+		startupThinkingLevel: ThinkingLevel.XHigh,
+		isInteractive: true,
+		hasInteractiveTerminal: true,
+		initialMessage: undefined,
+		initialMessages: [],
+		resumeAction: undefined,
+	});
+
+	expect(result.recoverableErrors).toHaveLength(1);
+	expect(
+		session.setModelTemporaryCalls.map(call => `${call.model.provider}/${call.model.id}:${call.thinkingLevel}`),
+	).toEqual(["profile-provider/default:medium", "cli-provider/explicit:xhigh"]);
 });
 
 test("thinking-only startup uses authoritative override semantics", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #2290, which was merged externally while its required exact-head hostile review was still running.

The hostile review found two merge blockers in the merged implementation:

- recovery did not require a real stdin/stdout TTY, so redirected/headless startup could enter a non-recoverable interactive path;
- recovery wrapped the whole default-profile → `--mpreset` → explicit CLI override pipeline, so a blocked profile suppressed later independent startup intent.

This change:

- requires a genuine interactive terminal before recovering into the TUI;
- handles credential failures per profile attempt, skipping only the blocked profile;
- preserves later healthy `--mpreset` activation and explicit model/thinking precedence;
- restores the exported strict `applyStartupModelProfilesOrExit(): Promise<void>` contract;
- adds redirected-terminal and mixed-profile sequencing regressions.

## Verification

- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/cli-args-mpreset.test.ts packages/coding-agent/test/startup-update-contract.test.ts packages/coding-agent/test/main-interactive-input.test.ts packages/coding-agent/test/resume-confirm-continue.test.ts packages/coding-agent/test/model-profile-activation-redteam.test.ts` — 78 passed

Do not merge until CI and fresh exact-head hostile review are green.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*