### PR TITLE
fix(ultragoal): re-mint final-aggregate receipts instead of deadlocking on stale ones (red-team hardened)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -1,7 +1,11 @@
 import * as fs from "node:fs/promises";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
 import { resolveGjcSessionForRead, SessionResolutionError } from "./session-resolution";
-import { validateDeferredMemberReceiptFresh, validateReceiptFreshBase } from "./ultragoal-receipt-freshness";
+import {
+	validateDeferredMemberReceiptFresh,
+	validateReceiptFreshBase,
+	validateSupersededFinalAggregateReceipt,
+} from "./ultragoal-receipt-freshness";
 import {
 	getUltragoalPaths,
 	getUltragoalRunCompletionState,
@@ -156,8 +160,33 @@ function requiredGoals(plan: UltragoalPlan): UltragoalGoal[] {
 	return plan.goals.filter(goal => goal.status !== "superseded");
 }
 
+/**
+ * Select the goal whose final-aggregate receipt should represent the run.
+ * Prefer a receipt that still validates fresh; several goals can hold
+ * final-aggregate receipts once plan growth (e.g. `steer add_subgoal`) stales
+ * an earlier one and a later checkpoint re-mints. Fall back to the newest
+ * holder (array-last) purely for diagnostics when none validates.
+ */
+function findFinalAggregateReceiptGoal(
+	plan: UltragoalPlan,
+	ledger: readonly UltragoalLedgerEvent[],
+): UltragoalGoal | null {
+	const candidates = [...requiredGoals(plan)]
+		.reverse()
+		.filter(goal => goal.completionVerification?.receiptKind === "final-aggregate");
+	if (candidates.length === 0) return null;
+	return (
+		candidates.find(
+			goal =>
+				validateCompletionReceipt({ plan, ledger, goal, receiptKind: "final-aggregate" }).state ===
+				"active_verified_complete",
+		) ?? candidates[0]!
+	);
+}
+
 function findReceiptGoal(
 	plan: UltragoalPlan,
+	ledger: readonly UltragoalLedgerEvent[],
 	currentObjective: string,
 ): { goal: UltragoalGoal; receiptKind: UltragoalReceiptKind } | null {
 	if (
@@ -165,9 +194,7 @@ function findReceiptGoal(
 		currentObjective === DEFAULT_ULTRAGOAL_OBJECTIVE ||
 		plan.gjcObjectiveAliases?.some(alias => alias === currentObjective)
 	) {
-		const finalGoal = [...requiredGoals(plan)]
-			.reverse()
-			.find(goal => goal.completionVerification?.receiptKind === "final-aggregate");
+		const finalGoal = findFinalAggregateReceiptGoal(plan, ledger);
 		return finalGoal ? { goal: finalGoal, receiptKind: "final-aggregate" } : null;
 	}
 	const storyGoal = plan.goals.find(goal => goal.objective === currentObjective);
@@ -300,6 +327,28 @@ export function validateCompletionReceipt(input: {
 					goalId: input.goal.id,
 				};
 			}
+			if (
+				priorGoal.completionVerification.validationBatch?.role !== "deferred-member" &&
+				priorGoal.completionVerification.receiptKind === "final-aggregate"
+			) {
+				// A prior goal may hold the run's previous final-aggregate receipt
+				// when plan growth staled it and a later checkpoint re-minted the
+				// aggregate receipt. Accept it as historical evidence for its own
+				// goal instead of demanding an impossible per-goal receipt.
+				const supersededDiagnostic = validateSupersededFinalAggregateReceipt({
+					ledger: input.ledger,
+					goal: priorGoal,
+					receipt: priorGoal.completionVerification,
+				});
+				if (supersededDiagnostic) {
+					return {
+						state: supersededDiagnostic.state,
+						message: `Ultragoal final receipt requires valid historical evidence for ${priorGoal.id}: ${supersededDiagnostic.message}`,
+						goalId: input.goal.id,
+					};
+				}
+				continue;
+			}
 			const priorDiagnostic =
 				priorGoal.completionVerification.validationBatch?.role === "deferred-member"
 					? validateDeferredMemberReceiptFresh({
@@ -381,7 +430,7 @@ export async function readUltragoalVerificationState(input: {
 			message: "Ultragoal has blocked or failed goals; record blockers or rerun verification.",
 		};
 	}
-	const receiptTarget = findReceiptGoal(plan, currentObjective);
+	const receiptTarget = findReceiptGoal(plan, ledger, currentObjective);
 	if (!receiptTarget) {
 		// When earlier required goals are already complete but later ones remain, name the
 		// specific blocking goals (a final-aggregate receipt cannot exist yet anyway). Only
@@ -623,9 +672,7 @@ export async function isUltragoalAskBlocked(
 		});
 	}
 
-	const finalReceiptGoal = [...requiredGoals(plan)]
-		.reverse()
-		.find(goal => goal.completionVerification?.receiptKind === "final-aggregate");
+	const finalReceiptGoal = findFinalAggregateReceiptGoal(plan, ledger);
 	if (!finalReceiptGoal) {
 		return activeAskDiagnostic({
 			reason: "Ultragoal aggregate completion is missing a final aggregate receipt.",

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
@@ -354,7 +354,21 @@ export function findFreshBatchCloseReceipt(input: {
 		receipt: finalReceipt,
 		receiptKind: finalReceipt.receiptKind,
 	});
-	return diagnostic ? null : finalReceipt;
+	if (!diagnostic) return finalReceipt;
+	// A batch close staled only by later plan growth (e.g. `steer add_subgoal`
+	// after the batch completed) still proves the batch was validly closed:
+	// the member receipts are freshness-checked separately, the close is
+	// anchored to its ledger event, and the final goal's row is untouched.
+	// Without this, completing a goal appended after a closed batch can never
+	// validate, because the old close can never be fresh against the grown
+	// plan and identical-evidence replays of fresh receipts are no-ops.
+	const historicalDiagnostic = validateLedgerAnchoredHistoricalReceipt({
+		ledger: input.ledger,
+		goal: finalGoal,
+		receipt: finalReceipt,
+		label: "superseded batch-close receipt",
+	});
+	return historicalDiagnostic ? null : finalReceipt;
 }
 
 export function validateDeferredMemberReceiptFresh(input: {

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
@@ -244,6 +244,57 @@ export function validateReceiptFreshBase(input: {
 	return null;
 }
 
+/**
+ * Validate a final-aggregate receipt that was legitimately superseded — its
+ * aggregate claim staled by later plan growth (e.g. `steer add_subgoal`
+ * appending goals after a terminal run) — as a historical attestation for its
+ * own goal: ledger-anchored, quality gate untampered, goal untouched since
+ * verification, and internally consistent. Plan-generation freshness against
+ * the CURRENT plan is intentionally not required; that is exactly what later
+ * plan growth invalidates by design. Returns null when the receipt stands as
+ * valid historical evidence.
+ */
+export function validateSupersededFinalAggregateReceipt(input: {
+	ledger: readonly UltragoalLedgerEvent[];
+	goal: UltragoalGoal;
+	receipt: UltragoalCompletionVerification;
+}): UltragoalReceiptFreshnessDiagnostic | null {
+	if (
+		input.receipt.schemaVersion !== 1 ||
+		input.receipt.goalId !== input.goal.id ||
+		input.receipt.receiptKind !== "final-aggregate" ||
+		!input.receipt.planGeneration ||
+		!input.receipt.checkpointLedgerEventId ||
+		hashStructuredValue(input.receipt.basis) !== input.receipt.planGeneration
+	) {
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} superseded final-aggregate receipt is malformed.`,
+			goalId: input.goal.id,
+		};
+	}
+	const event = findLedgerReceiptEvent(input.ledger, input.receipt);
+	if (!event)
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} superseded final-aggregate receipt ledger event is missing.`,
+			goalId: input.goal.id,
+		};
+	if (hashStructuredValue(event.qualityGateJson) !== input.receipt.qualityGateHash)
+		return {
+			state: "active_dirty_quality_gate",
+			message: `Ultragoal ${input.goal.id} superseded final-aggregate receipt quality-gate hash does not match ledger.`,
+			goalId: input.goal.id,
+		};
+	if (input.goal.updatedAt !== input.receipt.verifiedAt)
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} changed after its superseded final-aggregate receipt was verified.`,
+			goalId: input.goal.id,
+		};
+	return null;
+}
+
 export function findFreshBatchCloseReceipt(input: {
 	plan: UltragoalPlan;
 	ledger: readonly UltragoalLedgerEvent[];

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
@@ -245,31 +245,31 @@ export function validateReceiptFreshBase(input: {
 }
 
 /**
- * Validate a final-aggregate receipt that was legitimately superseded — its
- * aggregate claim staled by later plan growth (e.g. `steer add_subgoal`
- * appending goals after a terminal run) — as a historical attestation for its
- * own goal: ledger-anchored, quality gate untampered, goal untouched since
- * verification, and internally consistent. Plan-generation freshness against
- * the CURRENT plan is intentionally not required; that is exactly what later
- * plan growth invalidates by design. Returns null when the receipt stands as
- * valid historical evidence.
+ * Validate a receipt whose plan-generation freshness was legitimately staled
+ * by later plan growth as a historical attestation for its own goal:
+ * internally consistent, anchored to a ledger checkpoint event that carries a
+ * byte-identical receipt, quality gate untampered, and the goal row untouched
+ * since verification. Plan-generation freshness against the CURRENT plan is
+ * intentionally not required; that is exactly what later plan growth
+ * invalidates by design. Returns null when the receipt stands as valid
+ * historical evidence.
  */
-export function validateSupersededFinalAggregateReceipt(input: {
+function validateLedgerAnchoredHistoricalReceipt(input: {
 	ledger: readonly UltragoalLedgerEvent[];
 	goal: UltragoalGoal;
 	receipt: UltragoalCompletionVerification;
+	label: string;
 }): UltragoalReceiptFreshnessDiagnostic | null {
 	if (
 		input.receipt.schemaVersion !== 1 ||
 		input.receipt.goalId !== input.goal.id ||
-		input.receipt.receiptKind !== "final-aggregate" ||
 		!input.receipt.planGeneration ||
 		!input.receipt.checkpointLedgerEventId ||
 		hashStructuredValue(input.receipt.basis) !== input.receipt.planGeneration
 	) {
 		return {
 			state: "active_stale_receipt",
-			message: `Ultragoal ${input.goal.id} superseded final-aggregate receipt is malformed.`,
+			message: `Ultragoal ${input.goal.id} ${input.label} is malformed.`,
 			goalId: input.goal.id,
 		};
 	}
@@ -277,22 +277,58 @@ export function validateSupersededFinalAggregateReceipt(input: {
 	if (!event)
 		return {
 			state: "active_stale_receipt",
-			message: `Ultragoal ${input.goal.id} superseded final-aggregate receipt ledger event is missing.`,
+			message: `Ultragoal ${input.goal.id} ${input.label} ledger event is missing.`,
+			goalId: input.goal.id,
+		};
+	// Bind the goals.json receipt to the FULL receipt recorded on the ledger
+	// event. Field-selective matching would accept a coordinated edit of the
+	// goals-row basis/generation paired with only the event generation.
+	const eventReceipt = event.completionVerification as UltragoalCompletionVerification | undefined;
+	if (!eventReceipt || hashStructuredValue(eventReceipt) !== hashStructuredValue(input.receipt))
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} ${input.label} does not match its ledger event receipt.`,
 			goalId: input.goal.id,
 		};
 	if (hashStructuredValue(event.qualityGateJson) !== input.receipt.qualityGateHash)
 		return {
 			state: "active_dirty_quality_gate",
-			message: `Ultragoal ${input.goal.id} superseded final-aggregate receipt quality-gate hash does not match ledger.`,
+			message: `Ultragoal ${input.goal.id} ${input.label} quality-gate hash does not match ledger.`,
 			goalId: input.goal.id,
 		};
 	if (input.goal.updatedAt !== input.receipt.verifiedAt)
 		return {
 			state: "active_stale_receipt",
-			message: `Ultragoal ${input.goal.id} changed after its superseded final-aggregate receipt was verified.`,
+			message: `Ultragoal ${input.goal.id} changed after its ${input.label} was verified.`,
 			goalId: input.goal.id,
 		};
 	return null;
+}
+
+/**
+ * Validate a final-aggregate receipt that was legitimately superseded — its
+ * aggregate claim staled by later plan growth (e.g. `steer add_subgoal`
+ * appending goals after a terminal run) — as historical evidence for its own
+ * goal. Returns null when the receipt stands.
+ */
+export function validateSupersededFinalAggregateReceipt(input: {
+	ledger: readonly UltragoalLedgerEvent[];
+	goal: UltragoalGoal;
+	receipt: UltragoalCompletionVerification;
+}): UltragoalReceiptFreshnessDiagnostic | null {
+	if (input.receipt.receiptKind !== "final-aggregate") {
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} superseded final-aggregate receipt is malformed.`,
+			goalId: input.goal.id,
+		};
+	}
+	return validateLedgerAnchoredHistoricalReceipt({
+		ledger: input.ledger,
+		goal: input.goal,
+		receipt: input.receipt,
+		label: "superseded final-aggregate receipt",
+	});
 }
 
 export function findFreshBatchCloseReceipt(input: {

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -579,6 +579,12 @@ function chooseReceiptKind(
 ): UltragoalReceiptKind {
 	if (plan.gjcGoalMode === "per-story") return "per-goal";
 	if (status !== "complete") return "per-goal";
+	// A non-final validation-batch member must always carry a per-goal
+	// deferred receipt; only the batch's final goal may close the batch and
+	// (in aggregate mode) carry the final-aggregate receipt. Without this, a
+	// context-stale re-verification replay of a member could mint an invalid
+	// final-aggregate receipt with validationBatch.role "deferred-member".
+	if (goal.validationBatch && goal.validationBatch.finalGoalId !== goal.id) return "per-goal";
 	const requiredGoals = requiredUltragoalGoals(plan);
 	// Only a still-fresh final-aggregate receipt on another goal defers this
 	// checkpoint to per-goal. A stale one (e.g. staled by `steer add_subgoal`

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -573,16 +573,26 @@ async function writePlan(cwd: string, plan: UltragoalPlan, sessionId?: string | 
 
 function chooseReceiptKind(
 	plan: UltragoalPlan,
+	ledger: readonly UltragoalLedgerEvent[],
 	goal: UltragoalGoal,
 	status: UltragoalGoalStatus,
 ): UltragoalReceiptKind {
 	if (plan.gjcGoalMode === "per-story") return "per-goal";
 	if (status !== "complete") return "per-goal";
 	const requiredGoals = requiredUltragoalGoals(plan);
-	const existingFinalAggregateGoal = requiredGoals.find(
-		item => item.id !== goal.id && item.completionVerification?.receiptKind === "final-aggregate",
-	);
-	if (existingFinalAggregateGoal) return "per-goal";
+	// Only a still-fresh final-aggregate receipt on another goal defers this
+	// checkpoint to per-goal. A stale one (e.g. staled by `steer add_subgoal`
+	// appending goals after a terminal run) must not suppress re-minting,
+	// otherwise the run can never regain a verifiable final-aggregate receipt:
+	// the completion guard demands a fresh final-aggregate receipt while this
+	// gate would keep answering per-goal forever.
+	const existingFreshFinalAggregateGoal = requiredGoals.find(item => {
+		if (item.id === goal.id) return false;
+		const receipt = item.completionVerification;
+		if (receipt?.receiptKind !== "final-aggregate") return false;
+		return validateReceiptFreshBase({ plan, ledger, goal: item, receipt, receiptKind: "final-aggregate" }) === null;
+	});
+	if (existingFreshFinalAggregateGoal) return "per-goal";
 	const unfinishedRequiredGoals = requiredGoals.filter(
 		item => item.id !== goal.id && !TERMINAL_OR_SKIPPED_STATUSES.has(item.status),
 	);
@@ -4047,7 +4057,7 @@ export async function checkpointUltragoalGoal(input: {
 			blockedGoal.updatedAt = now;
 		}
 	}
-	const receiptKind = input.status === "complete" ? chooseReceiptKind(plan, goal, input.status) : null;
+	const receiptKind = input.status === "complete" ? chooseReceiptKind(plan, ledgerBefore, goal, input.status) : null;
 	const pendingCheckpointEventId = crypto.randomUUID();
 	if (input.status === "complete" && receiptKind && qualityGateJson && !Array.isArray(qualityGateJson)) {
 		goal.completionVerification = buildCompletionReceipt({

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -3974,13 +3974,21 @@ export async function checkpointUltragoalGoal(input: {
 	const evidence = input.evidence.trim();
 	if (!evidence) throw new Error("checkpoint evidence is required");
 	const ledgerBefore = await readUltragoalLedger(input.cwd);
-	const matchingIdempotentEvent = ledgerBefore.find(
+	const matchingIdempotentEvents = ledgerBefore.filter(
 		event =>
 			event.event === "goal_checkpointed" &&
 			event.goalId === goal.id &&
 			event.status === input.status &&
 			event.evidence === evidence,
 	);
+	// Re-verification replays legitimately append repeated same-status,
+	// same-evidence checkpoint events for one goal. The recorded receipt must
+	// be compared against ITS OWN checkpoint event — resolved by the receipt's
+	// checkpointLedgerEventId, falling back to the latest match — never the
+	// oldest duplicate, which would wrongly report the current receipt stale.
+	const matchingIdempotentEvent =
+		matchingIdempotentEvents.find(event => event.eventId === goal.completionVerification?.checkpointLedgerEventId) ??
+		matchingIdempotentEvents.at(-1);
 	const batchMetadata = input.status === "complete" ? requireFreshValidationBatchMetadata(goal) : undefined;
 	if (batchMetadata && goal.completionVerification?.validationBatch) {
 		const receiptBatch = goal.completionVerification.validationBatch;

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -3997,7 +3997,35 @@ export async function checkpointUltragoalGoal(input: {
 	if (input.status === "complete" && goal.completionVerification?.validationBatch && !batchMetadata) {
 		throw new Error(`Goal ${goal.id} has stale validation batch completion receipt`);
 	}
-	if (goal.status === input.status && goal.evidence === evidence && matchingIdempotentEvent) {
+	// An identical-evidence complete replay is only a no-op while the recorded
+	// receipt still validates fresh. When the goal row itself is untouched
+	// (updatedAt still matches the receipt's verifiedAt) but later goal-tagged
+	// ledger events (e.g. blocker classifications) or plan growth staled the
+	// receipt, the replay is a genuine re-verification: it must run the full
+	// quality gate and mint a fresh receipt, otherwise a completed goal with a
+	// context-staled receipt can never be repaired (different evidence is
+	// rejected on complete goals by design). A mutated goal row keeps the
+	// fail-loud tamper handling in the idempotent branch below.
+	const staleCompleteReceiptReplay =
+		input.status === "complete" &&
+		goal.status === "complete" &&
+		goal.evidence === evidence &&
+		Boolean(matchingIdempotentEvent) &&
+		(!goal.completionVerification ||
+			(goal.completionVerification.verifiedAt === goal.updatedAt &&
+				validateReceiptFreshBase({
+					plan,
+					ledger: ledgerBefore,
+					goal,
+					receipt: goal.completionVerification,
+					receiptKind: goal.completionVerification.receiptKind,
+				}) !== null));
+	if (
+		goal.status === input.status &&
+		goal.evidence === evidence &&
+		matchingIdempotentEvent &&
+		!staleCompleteReceiptReplay
+	) {
 		if (batchMetadata) {
 			const receipt = goal.completionVerification;
 			const receiptBatch = receipt?.validationBatch;
@@ -4019,6 +4047,18 @@ export async function checkpointUltragoalGoal(input: {
 			)
 				throw new Error(`Goal ${goal.id} has stale validation batch metadata hash in close receipt`);
 		}
+		// A complete goal whose row changed after its receipt was verified is
+		// neither a clean no-op nor a repairable context-stale replay: fail loud
+		// instead of silently laundering a tampered/inconsistent durable row.
+		if (
+			input.status === "complete" &&
+			goal.completionVerification &&
+			goal.completionVerification.verifiedAt !== goal.updatedAt
+		) {
+			throw new Error(
+				`Goal ${goal.id} changed after its completion receipt was verified; refusing idempotent replay. Investigate the durable goals.json row before re-checkpointing.`,
+			);
+		}
 		// Idempotent re-checkpoint: this goal is already recorded in the target status with the same
 		// evidence, so skip the plan rewrite and ledger append to avoid duplicate goal_checkpointed
 		// events. The ledger is the dedup source of truth because it is exactly what a duplicate write
@@ -4030,7 +4070,7 @@ export async function checkpointUltragoalGoal(input: {
 	const changeSet = input.status === "complete" ? await computeCheckpointChangeSet(input.cwd) : undefined;
 	if (input.status === "complete") {
 		validatePipelineCheckpointSafety(plan, goal, changeSet);
-		validateCompleteCheckpointTargetGoal(goal);
+		if (!staleCompleteReceiptReplay) validateCompleteCheckpointTargetGoal(goal);
 	}
 	const qualityGateJson =
 		input.status === "complete"

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -3167,6 +3167,40 @@ describe("native GJC ultragoal runtime", () => {
 		return plan;
 	}
 
+	it("keeps per-goal deferred receipts when replaying a context-staled validation batch member", async () => {
+		const root = await batchTempDir();
+		const plan = await completedValidationBatchPlan(root);
+
+		const classified = await runNativeUltragoalCommand(
+			[
+				"classify-blocker",
+				"--classification",
+				"resolvable",
+				"--evidence",
+				"post-completion audit note tagged to the completed member",
+				"--goal-id",
+				"G001",
+			],
+			root,
+		);
+		expect(classified.status).toBe(0);
+
+		// The goal-tagged event stales G001's deferred receipt AND the batch
+		// aggregate close. The member's re-verification replay must stay a
+		// per-goal deferred receipt; minting final-aggregate on a non-final
+		// batch member would poison subsequent batch-close repair.
+		const replayed = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "g001 deferred",
+			qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+		});
+		const memberReceipt = replayed.goals[0]?.completionVerification;
+		expect(memberReceipt?.receiptKind).toBe("per-goal");
+		expect(memberReceipt?.validationBatch?.role).toBe("deferred-member");
+	});
+
 	it("no-ops repeated identical-evidence batch close replays after a re-mint", async () => {
 		const root = await batchTempDir();
 		const plan = await completedValidationBatchPlan(root);

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -11,7 +11,10 @@ import {
 	sessionUltragoalDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { reconcileWorkflowSkillState } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
-import { validateCompletionReceipt } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
+import {
+	validateCompletionReceipt,
+	verifyUltragoalDurableCompletionState,
+} from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
 
 import {
 	addUltragoalSubgoal,
@@ -2986,7 +2989,52 @@ describe("native GJC ultragoal runtime", () => {
 		expect(await Bun.file(goalsPath).text()).toBe(goalsAfterFinal);
 	});
 
-	it("uses per-goal receipts when repairing a non-final goal after aggregate completion (#1777)", async () => {
+	it("re-mints a final-aggregate receipt when goals are appended after aggregate completion", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		const afterFirst = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		expect(afterFirst.goals[0]?.completionVerification?.receiptKind).toBe("final-aggregate");
+
+		await addUltragoalSubgoal({
+			cwd: root,
+			title: "Appended stage",
+			objective: "Complete the appended stage.",
+			evidence: "The run gained a new required goal after aggregate completion.",
+			rationale: "Cover final-aggregate re-minting after an append staled the prior receipt.",
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		const afterAppended = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G002",
+			status: "complete",
+			evidence: "appended goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+
+		// Appending G002 staled G001's final-aggregate receipt by design. The
+		// closing checkpoint must mint a fresh final-aggregate receipt instead of
+		// deferring to the stale one, which would leave the run permanently
+		// unable to satisfy the final-aggregate completion guard.
+		expect(afterAppended.goals[1]?.completionVerification?.receiptKind).toBe("final-aggregate");
+
+		const plan = await readUltragoalPlan(root);
+		if (!plan) throw new Error("missing ultragoal plan");
+		const ledger = await readUltragoalLedger(root);
+		expect(
+			validateCompletionReceipt({ plan, ledger, goal: plan.goals[1]!, receiptKind: "final-aggregate" }).state,
+		).toBe("active_verified_complete");
+		const durable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+		expect(durable.state).toBe("active_verified_complete");
+	});
+
+	it("re-mints the final-aggregate receipt when repairing a non-final goal after aggregate completion (#1777)", async () => {
 		for (const repairStatus of ["active", "failed"] as const) {
 			const root = await tempDir();
 			await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
@@ -3032,15 +3080,22 @@ describe("native GJC ultragoal runtime", () => {
 				qualityGateJson: await passingLiveQualityGate(root),
 			});
 
-			expect(repaired.goals[0]?.completionVerification?.receiptKind).toBe("per-goal");
+			// The hand-edited repair staled G002's final-aggregate receipt (its
+			// plan generation covers every required goal). The repair checkpoint
+			// closes the run again, so it must re-mint the final-aggregate
+			// receipt; a per-goal receipt would leave the run with no fresh
+			// final-aggregate receipt forever.
+			expect(repaired.goals[0]?.completionVerification?.receiptKind).toBe("final-aggregate");
 			expect(
 				validateCompletionReceipt({
 					plan: repaired,
 					ledger: await readUltragoalLedger(root),
 					goal: repaired.goals[0]!,
-					receiptKind: "per-goal",
+					receiptKind: "final-aggregate",
 				}).state,
 			).toBe("active_verified_complete");
+			const durable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+			expect(durable.state).toBe("active_verified_complete");
 		}
 	});
 

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -3308,6 +3308,40 @@ describe("native GJC ultragoal runtime", () => {
 		);
 	});
 
+	it("verifies completion of a goal appended after a closed validation batch", async () => {
+		const root = await batchTempDir();
+		await completedValidationBatchPlan(root);
+
+		// Appending a goal stales the batch aggregate close by design. The
+		// appended goal's completion must still be able to close the run: the
+		// old batch close stands as ledger-anchored historical evidence for
+		// the deferred members.
+		await addUltragoalSubgoal({
+			cwd: root,
+			title: "Appended stage",
+			objective: "Complete the appended stage.",
+			evidence: "The batch run gained a new required goal after closing.",
+			rationale: "Cover post-close appends regaining a fresh final-aggregate receipt.",
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		const appended = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G004",
+			status: "complete",
+			evidence: "appended goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		expect(appended.goals[3]?.completionVerification?.receiptKind).toBe("final-aggregate");
+
+		const plan = await readUltragoalPlan(root);
+		if (!plan) throw new Error("missing ultragoal plan");
+		const ledger = await readUltragoalLedger(root);
+		expect(
+			validateCompletionReceipt({ plan, ledger, goal: plan.goals[3]!, receiptKind: "final-aggregate" }).state,
+		).toBe("active_verified_complete");
+		const durable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+		expect(durable.state).toBe("active_verified_complete");
+	});
 	it("re-mints the final-aggregate receipt when repairing a non-final goal after aggregate completion (#1777)", async () => {
 		for (const repairStatus of ["active", "failed"] as const) {
 			const root = await tempDir();

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -3130,6 +3130,66 @@ describe("native GJC ultragoal runtime", () => {
 		).rejects.toThrow("changed after its completion receipt was verified");
 	});
 
+	it("rejects a superseded final-aggregate receipt whose forged basis is mirrored onto the ledger event generation", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		await addUltragoalSubgoal({
+			cwd: root,
+			title: "Appended stage",
+			objective: "Complete the appended stage.",
+			evidence: "The run gained a new required goal after aggregate completion.",
+			rationale: "Red-team: forged superseded receipt provenance must be rejected.",
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G002",
+			status: "complete",
+			evidence: "appended goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+
+		// Coordinated tamper: forge the goals-row basis and generation of
+		// G001's superseded final-aggregate receipt, and mirror ONLY the
+		// generation onto its ledger checkpoint event. Field-selective ledger
+		// matching would accept this as verified provenance.
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		const forgedReceipt = saved.goals[0].completionVerification;
+		forgedReceipt.basis.planHashBeforeCheckpoint = "forged";
+		forgedReceipt.planGeneration = hashStructuredValue(forgedReceipt.basis);
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+		const ledgerPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl");
+		const rewritten = (await Bun.file(ledgerPath).text())
+			.split("\n")
+			.filter(line => line.trim())
+			.map(line => {
+				const event = JSON.parse(line);
+				if (event.eventId === forgedReceipt.checkpointLedgerEventId) {
+					event.completionVerification.planGeneration = forgedReceipt.planGeneration;
+				}
+				return JSON.stringify(event);
+			});
+		await fs.writeFile(ledgerPath, `${rewritten.join("\n")}\n`);
+
+		const plan = await readUltragoalPlan(root);
+		if (!plan) throw new Error("missing ultragoal plan");
+		const ledger = await readUltragoalLedger(root);
+		expect(
+			validateCompletionReceipt({ plan, ledger, goal: plan.goals[1]!, receiptKind: "final-aggregate" }).state,
+		).not.toBe("active_verified_complete");
+		const durable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+		expect(durable.state).not.toBe("active_verified_complete");
+	});
+
 	async function completedValidationBatchPlan(root: string) {
 		await writeStructuralArtifacts(root);
 		let plan = await createUltragoalPlan({

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -3082,6 +3082,22 @@ describe("native GJC ultragoal runtime", () => {
 		);
 		const durable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
 		expect(durable.state).toBe("active_verified_complete");
+
+		// A further identical-evidence replay of the now-fresh receipt is a
+		// pure no-op resolved against the receipt's own (latest) checkpoint
+		// event, never the oldest duplicate.
+		const receiptIdAfterRemint = replayed.goals[0]?.completionVerification?.receiptId;
+		const again = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		expect(again.goals[0]?.completionVerification?.receiptId).toBe(receiptIdAfterRemint);
+		expect((await readUltragoalLedger(root)).filter(event => event.event === "goal_checkpointed")).toHaveLength(
+			checkpointsBefore + 1,
+		);
 	});
 
 	it("rejects identical-evidence replay when the goal row changed after receipt verification", async () => {
@@ -3112,6 +3128,90 @@ describe("native GJC ultragoal runtime", () => {
 				qualityGateJson: await passingLiveQualityGate(root),
 			}),
 		).rejects.toThrow("changed after its completion receipt was verified");
+	});
+
+	async function completedValidationBatchPlan(root: string) {
+		await writeStructuralArtifacts(root);
+		let plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+			validationBatches: [
+				{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+			],
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "g001 deferred",
+			qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G002",
+			status: "complete",
+			evidence: "g002 deferred",
+			qualityGateJson: deferredBatchGate("G002", plan.goals[1]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G003",
+			status: "complete",
+			evidence: "batch close",
+			qualityGateJson: batchCloseGate(plan),
+		});
+		expect(plan.goals[2]?.completionVerification?.receiptKind).toBe("final-aggregate");
+		return plan;
+	}
+
+	it("no-ops repeated identical-evidence batch close replays after a re-mint", async () => {
+		const root = await batchTempDir();
+		const plan = await completedValidationBatchPlan(root);
+		const classified = await runNativeUltragoalCommand(
+			[
+				"classify-blocker",
+				"--classification",
+				"resolvable",
+				"--evidence",
+				"post-completion audit note tagged to the batch final",
+				"--goal-id",
+				"G003",
+			],
+			root,
+		);
+		expect(classified.status).toBe(0);
+
+		// First replay re-verifies the staled close and appends a second
+		// same-status, same-evidence checkpoint event.
+		const reclosed = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G003",
+			status: "complete",
+			evidence: "batch close",
+			qualityGateJson: batchCloseGate(plan),
+		});
+		const recloseReceiptId = reclosed.goals[2]?.completionVerification?.receiptId;
+		const checkpointsAfterReclose = (await readUltragoalLedger(root)).filter(
+			event => event.event === "goal_checkpointed",
+		).length;
+
+		// The next replay must resolve the receipt against ITS OWN checkpoint
+		// event (the latest duplicate) and no-op, not compare against the
+		// oldest duplicate and throw.
+		const again = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G003",
+			status: "complete",
+			evidence: "batch close",
+			qualityGateJson: batchCloseGate(plan),
+		});
+		expect(again.goals[2]?.completionVerification?.receiptId).toBe(recloseReceiptId);
+		expect((await readUltragoalLedger(root)).filter(event => event.event === "goal_checkpointed")).toHaveLength(
+			checkpointsAfterReclose,
+		);
 	});
 
 	it("re-mints the final-aggregate receipt when repairing a non-final goal after aggregate completion (#1777)", async () => {

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -3034,6 +3034,86 @@ describe("native GJC ultragoal runtime", () => {
 		expect(durable.state).toBe("active_verified_complete");
 	});
 
+	it("re-mints the receipt on identical-evidence replay after a goal-tagged ledger event staled it", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		const classified = await runNativeUltragoalCommand(
+			[
+				"classify-blocker",
+				"--classification",
+				"resolvable",
+				"--evidence",
+				"post-completion audit note tagged to the completed goal",
+				"--goal-id",
+				"G001",
+			],
+			root,
+		);
+		expect(classified.status).toBe(0);
+
+		// The goal-tagged blocker_classified event stales the recorded receipt.
+		const staleDurable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+		expect(staleDurable.state).not.toBe("active_verified_complete");
+		const checkpointsBefore = (await readUltragoalLedger(root)).filter(
+			event => event.event === "goal_checkpointed",
+		).length;
+
+		// Different evidence stays rejected on complete goals; the identical
+		// evidence replay must re-verify and mint a fresh receipt instead of
+		// no-opping on the stale one (which would be unrepairable forever).
+		const replayed = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		expect(replayed.goals[0]?.completionVerification?.receiptKind).toBe("final-aggregate");
+		expect((await readUltragoalLedger(root)).filter(event => event.event === "goal_checkpointed")).toHaveLength(
+			checkpointsBefore + 1,
+		);
+		const durable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+		expect(durable.state).toBe("active_verified_complete");
+	});
+
+	it("rejects identical-evidence replay when the goal row changed after receipt verification", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		saved.goals[0].updatedAt = new Date(Date.now() + 1000).toISOString();
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+
+		// A mutated complete row is neither a clean no-op nor a repairable
+		// context-stale replay; it must fail loud instead of silently
+		// laundering the inconsistency.
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "first goal verified",
+				qualityGateJson: await passingLiveQualityGate(root),
+			}),
+		).rejects.toThrow("changed after its completion receipt was verified");
+	});
+
 	it("re-mints the final-aggregate receipt when repairing a non-final goal after aggregate completion (#1777)", async () => {
 		for (const repairStatus of ["active", "failed"] as const) {
 			const root = await tempDir();


### PR DESCRIPTION
## Problem

An aggregate ultragoal run that reaches completion and then grows can never complete again. Deterministic repro (hit in a real session on 0.10.2):

1. Complete an aggregate run — the last checkpoint mints a `final-aggregate` receipt. `goal complete` works.
2. `gjc ultragoal steer --kind add_subgoal` — per the freshness rules this correctly stales the existing final-aggregate receipt (its plan generation covers the required-goal set).
3. Complete the appended goal — the checkpoint mints only a `per-goal` receipt.
4. `goal complete` is now refused **forever** with `nudgeTargetKind=final_aggregate_receipt`, even though `status`/`complete-goals` report every goal complete. The `pause` escape is consumed by the same nudge gate, so the agent burns the entire try-harder budget with no reachable success state.

Root cause is a contradiction between the minter and the verifier:

- `chooseReceiptKind()` returns `per-goal` whenever *any other* required goal holds a final-aggregate receipt — without checking whether that receipt is still fresh — so a replacement final-aggregate receipt can never be minted.
- The completion guard requires a *fresh* final-aggregate receipt.
- Receipt replays are idempotent no-ops and different-evidence checkpoints on complete goals are rejected, so the stale receipt can't be refreshed on its original goal either.

A second unrecoverable shape exists for per-goal receipts: any later goal-tagged ledger event (e.g. `classify-blocker --goal-id`) stales a completed goal's receipt, and the identical-evidence replay no-ops on the stale receipt instead of re-verifying.

## Fix

- `chooseReceiptKind` only defers to another goal's final-aggregate receipt while that receipt still validates fresh (`validateReceiptFreshBase`); a stale one no longer suppresses re-minting.
- Final-aggregate validation accepts a prior goal's superseded final-aggregate receipt as ledger-anchored historical evidence (new `validateSupersededFinalAggregateReceipt`: ledger event anchoring, quality-gate hash match, goal row untouched since verification, internal generation consistency) instead of demanding an impossible per-goal receipt. Plan-generation freshness against the *current* plan is intentionally not required — that is exactly what later plan growth invalidates by design.
- The run's final-aggregate receipt goal is selected by freshness rather than array position (`findFinalAggregateReceiptGoal`), so a re-minted receipt on a repaired earlier goal is found.
- An identical-evidence complete replay re-verifies (full quality gate) and re-mints when the goal row is untouched (`updatedAt === verifiedAt`) but the receipt was context-staled. Mutated goal rows keep the existing fail-loud tamper handling, and fresh-receipt replays remain byte-identical no-ops (#638 dedup preserved).

## Behavioral change to an existing test

`uses per-goal receipts when repairing a non-final goal after aggregate completion (#1777)` asserted a `per-goal` receipt for the repair checkpoint. That expectation encoded the deadlock: the repair edit stales the run's final-aggregate receipt, so with a per-goal repair receipt the run retains no fresh final-aggregate receipt forever. The test now asserts the repair checkpoint (which closes the run again) re-mints `final-aggregate` and that `verifyUltragoalDurableCompletionState` reports `active_verified_complete`. The sibling #1777 idempotency guarantees (no duplicate events, byte-identical goals.json on fresh replays) are unchanged and still covered.

## Tests

New regression tests in `test/gjc-runtime/ultragoal-runtime.test.ts`:

- `re-mints a final-aggregate receipt when goals are appended after aggregate completion` — the repro above, asserting receipt kind, receipt validation, and durable completion.
- `re-mints the receipt on identical-evidence replay after a goal-tagged ledger event staled it` — `classify-blocker --goal-id` stales the receipt; replay re-verifies, appends exactly one checkpoint event, and restores durable completion.

Verification:

- `bun test` on `ultragoal-runtime`, `ultragoal-durable-completion-release`, `ultragoal-nudge-guard`, `ultragoal-pause-guard(+redteam)`, `ultragoal-review`, `ultragoal-dogfood`, `tools/ultragoal-ask-guard`: **190 pass / 0 fail**.
- `tsc --noEmit` and `biome check` clean on the touched files.
- Validated against a copy of the real deadlocked session state: `BEFORE: active_missing_final_receipt — Ultragoal G001 receipt generation is stale.` → identical-evidence replay of the closing goal → `AFTER: active_verified_complete`.


## v2 — response to the external red-team review on #2284

Supersedes #2284 (closed after REQUEST_CHANGES; the head was force-pushed during restructuring so it could not be reopened). Rebased onto current `dev` and addressed **all four red-team findings**, each in a dedicated commit with a regression test:

| Finding | Commit | Fix | Regression test |
| --- | --- | --- | --- |
| 1 (HIGH) invalid FA receipt on batch member replay | `5c37a20` | `chooseReceiptKind` short-circuits to `per-goal` for non-final validation-batch members | `keeps per-goal deferred receipts when replaying a context-staled validation batch member` |
| 2 (HIGH) appended goal blocked after closed batch | `7ef35a2` | `findFreshBatchCloseReceipt` accepts a superseded close as ledger-anchored historical evidence (member freshness still checked separately) | `verifies completion of a goal appended after a closed validation batch` |
| 3 (MEDIUM) idempotent match resolves oldest duplicate | `7681dc0` | resolve by the receipt's `checkpointLedgerEventId`, fall back to the latest match | `no-ops repeated identical-evidence batch close replays after a re-mint` |
| 4 (HIGH) forged superseded receipt provenance accepted | `5fcb674` | historical validation binds the goals.json receipt to the FULL receipt on its ledger checkpoint event (hash equality) | `rejects a superseded final-aggregate receipt whose forged basis is mirrored onto the ledger event generation` (replicates the demonstrated attack) |

Verification on this head: focused ultragoal suites → **195 pass / 0 fail (740 assertions)**; all seven commits built and tested green individually; repo-wide `biome check` (2817 files) + `tsc --noEmit` clean; findings 1/4 regressions verified to fail with their fixes reverted.
