### PR TITLE
fix(coding-agent): preserve subagents on interrupted await

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Cooperative mid-run context maintenance now waits at a cancellation-aware FIFO consumer-drain checkpoint before flushing or rewriting session history. Materialized tool results and steering messages are synchronously canonicalized first; aborted barriers and hook/signal-cancelled compactions settle without rewriting or scheduling a continuation. Promotion, pruning, and compaction each start a clean provider/prompt-cache epoch. Script-aware #2067 unsent-delta accounting remains cache-free and distinct from the lifecycle checkpoint.
 - Classified the cooperative mid-run maintenance driver and token estimator test seams as locked non-public SDK exclusions, restoring deterministic operation-inventory generation and post-merge dev CI coverage.
 - Accepted SDK prompts now deliver correlated `agent_start` and exactly one terminal lifecycle frame directly to the requesting authenticated WebSocket connection while retaining replayable host events. Harness owner observation also waits for every previously accepted frame to finish serial persistence, so message-update storms and polling gaps cannot hide sticky completion evidence (#2169).
+- `/new` now fails closed while owned subagent shutdown is unproven: it preserves the current session identity and shows an actionable cleanup notice. Successful replacement waits for cooperative child cancellation, cancels owner jobs before switching identity, and `/drop` creates the replacement before attempting old-session deletion (#2261).
 
 ### Added
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -75,6 +75,47 @@ export type SubagentRunOutcome = { kind: "completed"; text: string } | { kind: "
 /** Canonical lifecycle of a subagent across pause/resume cycles. */
 export type SubagentLifecycle = "running" | "paused" | "queued" | "completed" | "failed" | "cancelled";
 
+/** Maximum time allowed to prove owned subagents have stopped before replacement. */
+export const OWNER_SUBAGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+export class OwnerSubagentShutdownError extends Error {
+	readonly code = "owner_shutdown_in_progress";
+
+	constructor() {
+		super("Cannot start subagent while owner shutdown is in progress.");
+		this.name = "OwnerSubagentShutdownError";
+	}
+}
+
+export interface OwnerSubagentShutdownTarget {
+	subagentId: string;
+	jobId: string | null;
+	source: "record" | "metadata_job";
+}
+
+export interface OwnerSubagentShutdownLease {
+	ownerId: string;
+	id: string;
+	targets: readonly OwnerSubagentShutdownTarget[];
+}
+
+export interface OwnerSubagentShutdownProof {
+	ownerId: string;
+	leaseId: string;
+	confirmed: boolean;
+	reason: "confirmed" | "deadline_exceeded" | "missing_terminal_evidence" | "lease_lost";
+	targets: readonly OwnerSubagentShutdownTarget[];
+	terminalIds: readonly string[];
+	unresolvedIds: readonly string[];
+}
+
+interface OwnerSubagentShutdownLeaseState {
+	lease: OwnerSubagentShutdownLease;
+	backingJobIds: ReadonlyMap<string, readonly string[]>;
+	phase: "active" | "proving" | "proved";
+	proof?: OwnerSubagentShutdownProof;
+}
+
 /**
  * Live, executor-owned control handle for a RUNNING subagent. Registered when a
  * subagent run starts and removed on pause/terminal so a paused subagent retains
@@ -327,6 +368,8 @@ export class AsyncJobManager {
 	#resumeRunner?: (subagentId: string, message?: string, descriptor?: ResumeDescriptor) => string | undefined;
 	readonly #resumeDescriptors = new Map<string, ResumeDescriptor>();
 	readonly #deadLetteredDeliveries = new Map<string, AsyncJobDelivery>();
+	readonly #ownerSubagentShutdownLeases = new Map<string, OwnerSubagentShutdownLeaseState>();
+	#ownerSubagentShutdownSeq = 0;
 	#lastDisposeDiagnostics: AsyncJobDisposeDiagnostics = { stuckJobIds: [], deliveriesDrained: true };
 	/**
 	 * Change listeners notified on any mutation that can alter the live job set
@@ -386,6 +429,9 @@ export class AsyncJobManager {
 	): string {
 		if (this.#disposed) {
 			throw new Error("Async job manager is disposed");
+		}
+		if (options?.ownerId && this.#isOwnerSubagentShutdownFenced(options.ownerId)) {
+			throw new OwnerSubagentShutdownError();
 		}
 		const runningCount = this.getRunningJobs().length;
 		if (runningCount >= this.#maxRunningJobs) {
@@ -704,6 +750,224 @@ export class AsyncJobManager {
 		return descriptor;
 	}
 
+	#isOwnerSubagentShutdownFenced(ownerId: string | undefined): boolean {
+		return ownerId !== undefined && this.#ownerSubagentShutdownLeases.has(ownerId);
+	}
+
+	#isTerminalSubagentStatus(status: SubagentLifecycle): boolean {
+		return status === "completed" || status === "failed" || status === "cancelled";
+	}
+
+	beginOwnerSubagentShutdown(ownerId: string): OwnerSubagentShutdownLease | undefined {
+		if (!ownerId || this.#ownerSubagentShutdownLeases.has(ownerId)) return undefined;
+		const targets = new Map<string, OwnerSubagentShutdownTarget>();
+		const backingJobIds = new Map<string, Set<string>>();
+		const addBackingJob = (subagentId: string, jobId: string | null): void => {
+			if (!jobId) return;
+			const ids = backingJobIds.get(subagentId) ?? new Set<string>();
+			ids.add(jobId);
+			backingJobIds.set(subagentId, ids);
+		};
+		for (const record of this.#subagentRecords.values()) {
+			if (record.ownerId !== ownerId || this.#isTerminalSubagentStatus(record.status)) continue;
+			targets.set(record.subagentId, {
+				subagentId: record.subagentId,
+				jobId: record.status === "queued" ? null : record.currentJobId,
+				source: "record",
+			});
+			if (record.status !== "queued") addBackingJob(record.subagentId, record.currentJobId);
+		}
+		for (const job of this.#jobs.values()) {
+			const subagentId = job.metadata?.subagent?.id;
+			if (
+				job.ownerId !== ownerId ||
+				!subagentId ||
+				(job.status !== "running" && job.status !== "paused" && job.status !== "cancelled")
+			) {
+				continue;
+			}
+			if (!targets.has(subagentId)) {
+				targets.set(subagentId, { subagentId, jobId: job.id, source: "metadata_job" });
+			}
+			addBackingJob(subagentId, job.id);
+		}
+		const lease: OwnerSubagentShutdownLease = {
+			ownerId,
+			id: `owner_shutdown_${++this.#ownerSubagentShutdownSeq}`,
+			targets: Array.from(targets.values()),
+		};
+		this.#ownerSubagentShutdownLeases.set(ownerId, {
+			lease,
+			backingJobIds: new Map<string, readonly string[]>(
+				Array.from(backingJobIds, ([subagentId, jobIds]): [string, readonly string[]] => [
+					subagentId,
+					Array.from(jobIds),
+				]),
+			),
+			phase: "active",
+		});
+		return lease;
+	}
+
+	runOwnerProducerCleanups(filter?: AsyncJobFilter): void {
+		this.#runOwnerProducerCleanups(filter, false);
+	}
+
+	runOwnerProducerCleanupsStrict(filter?: AsyncJobFilter): void {
+		this.#runOwnerProducerCleanups(filter, true);
+	}
+
+	#runOwnerProducerCleanups(filter: AsyncJobFilter | undefined, strict: boolean): void {
+		const ownerId = filter?.ownerId;
+		const targets: Array<[string, Set<() => void>]> = [];
+		if (ownerId) {
+			const bag = this.#ownerCleanups.get(ownerId);
+			if (bag) targets.push([ownerId, bag]);
+		} else {
+			for (const entry of this.#ownerCleanups.entries()) targets.push(entry);
+		}
+		const errors: unknown[] = [];
+		for (const [id, bag] of targets) {
+			const callbacks = Array.from(bag);
+			bag.clear();
+			this.#ownerCleanups.delete(id);
+			for (const cleanup of callbacks) {
+				try {
+					cleanup();
+				} catch (error) {
+					errors.push(error);
+					if (strict) {
+						let retryBag = this.#ownerCleanups.get(id);
+						if (!retryBag) {
+							retryBag = new Set();
+							this.#ownerCleanups.set(id, retryBag);
+						}
+						retryBag.add(cleanup);
+					}
+					logger.warn("Async job owner cleanup failed", {
+						ownerId: id,
+						error: error instanceof Error ? error.message : String(error),
+					});
+				}
+			}
+		}
+		if (strict && errors.length > 0) throw new AggregateError(errors, "Async job owner cleanup failed");
+	}
+
+	async cancelAndProveOwnerSubagents(
+		lease: OwnerSubagentShutdownLease,
+		options?: { timeoutMs?: number },
+	): Promise<OwnerSubagentShutdownProof> {
+		const state = this.#ownerSubagentShutdownLeases.get(lease.ownerId);
+		if (!state || state.lease.id !== lease.id) {
+			return this.#ownerSubagentShutdownProof(
+				lease,
+				"lease_lost",
+				lease.targets.map(target => target.subagentId),
+			);
+		}
+		if (state.phase === "proved" && state.proof) return state.proof;
+		state.phase = "proving";
+		const settled = new Set<string>();
+		const promises: Promise<void>[] = [];
+		for (const target of lease.targets) {
+			const backingJobs = (state.backingJobIds.get(target.subagentId) ?? []).map(jobId => ({
+				jobId,
+				job: this.#jobs.get(jobId),
+			}));
+			if (target.source === "record") this.cancelSubagent(target.subagentId, { ownerId: lease.ownerId });
+			for (const { jobId, job } of backingJobs) {
+				this.cancel(jobId, { ownerId: lease.ownerId });
+				if (!job || job.ownerId !== lease.ownerId) continue;
+				promises.push(
+					job.promise.then(
+						() => {
+							settled.add(jobId);
+						},
+						() => {
+							settled.add(jobId);
+						},
+					),
+				);
+			}
+		}
+		const timeoutMs = Math.max(0, options?.timeoutMs ?? OWNER_SUBAGENT_SHUTDOWN_TIMEOUT_MS);
+		let deadlineExceeded = false;
+		await Promise.race([
+			Promise.allSettled(promises),
+			Bun.sleep(timeoutMs).then(() => {
+				deadlineExceeded = true;
+			}),
+		]);
+		const current = this.#ownerSubagentShutdownLeases.get(lease.ownerId);
+		if (!current || current.lease.id !== lease.id || current.phase !== "proving") {
+			return this.#ownerSubagentShutdownProof(
+				lease,
+				"lease_lost",
+				lease.targets.map(target => target.subagentId),
+			);
+		}
+		const unresolvedIds = lease.targets
+			.filter(target => !this.#hasTerminalShutdownEvidence(target, lease.ownerId, current.backingJobIds, settled))
+			.map(target => target.subagentId);
+		const reason =
+			unresolvedIds.length === 0
+				? "confirmed"
+				: deadlineExceeded
+					? "deadline_exceeded"
+					: "missing_terminal_evidence";
+		const proof = this.#ownerSubagentShutdownProof(lease, reason, unresolvedIds);
+		current.phase = "proved";
+		current.proof = proof;
+		return proof;
+	}
+
+	#hasTerminalShutdownEvidence(
+		target: OwnerSubagentShutdownTarget,
+		ownerId: string,
+		backingJobIds: ReadonlyMap<string, readonly string[]>,
+		settled: ReadonlySet<string>,
+	): boolean {
+		const record = this.#subagentRecords.get(target.subagentId);
+		if (!record || record.ownerId !== ownerId || !this.#isTerminalSubagentStatus(record.status)) return false;
+		return (backingJobIds.get(target.subagentId) ?? []).every(jobId => {
+			if (!settled.has(jobId)) return false;
+			const job = this.#jobs.get(jobId);
+			return job === undefined || job.ownerId === ownerId;
+		});
+	}
+
+	#ownerSubagentShutdownProof(
+		lease: OwnerSubagentShutdownLease,
+		reason: OwnerSubagentShutdownProof["reason"],
+		unresolvedIds: readonly string[],
+	): OwnerSubagentShutdownProof {
+		const unresolved = new Set(unresolvedIds);
+		return {
+			ownerId: lease.ownerId,
+			leaseId: lease.id,
+			confirmed: reason === "confirmed",
+			reason,
+			targets: lease.targets,
+			terminalIds: lease.targets
+				.filter(target => !unresolved.has(target.subagentId))
+				.map(target => target.subagentId),
+			unresolvedIds: [...unresolvedIds],
+		};
+	}
+
+	finishOwnerSubagentShutdown(lease: OwnerSubagentShutdownLease, outcome: "commit" | "release"): void {
+		const state = this.#ownerSubagentShutdownLeases.get(lease.ownerId);
+		if (!state || state.lease.id !== lease.id) return;
+		if (outcome === "commit" && state.proof?.confirmed) {
+			const pendingJobIds = this.getDeliveryState({ ownerId: lease.ownerId }).pendingJobIds;
+			this.acknowledgeDeliveries(pendingJobIds);
+			this.#purgeOwnerSubagentState(lease.ownerId);
+		}
+		this.#ownerSubagentShutdownLeases.delete(lease.ownerId);
+		if (outcome === "release") this.#ensureDeliveryLoop();
+	}
+
 	#recordByJobId(jobId: string): SubagentRecord | undefined {
 		for (const rec of this.#subagentRecords.values()) {
 			if (rec.currentJobId === jobId) return rec;
@@ -758,6 +1022,9 @@ export class AsyncJobManager {
 	): { ok: boolean; status?: SubagentLifecycle; jobId?: string; queued?: boolean; reason?: string } {
 		const rec = this.getSubagentRecord(subagentId, filter);
 		if (!rec) return { ok: false, reason: "not_found" };
+		if (this.#isOwnerSubagentShutdownFenced(rec.ownerId)) {
+			return { ok: false, status: rec.status, reason: "owner_shutdown_in_progress" };
+		}
 		if (rec.status === "running") return { ok: false, status: "running", reason: "already_running" };
 		if (rec.status === "queued") {
 			if (message !== undefined && rec.queued) {
@@ -790,6 +1057,9 @@ export class AsyncJobManager {
 		rec: SubagentRecord,
 		message?: string,
 	): { ok: boolean; status?: SubagentLifecycle; jobId?: string; reason?: string } {
+		if (this.#isOwnerSubagentShutdownFenced(rec.ownerId)) {
+			return { ok: false, status: rec.status, reason: "owner_shutdown_in_progress" };
+		}
 		const prevJobId = rec.currentJobId;
 		// Clear any retained progress from the previous run so a resumed subagent
 		// never renders the prior run's tool/output as live before it emits again.
@@ -803,16 +1073,36 @@ export class AsyncJobManager {
 		return { ok: true, status: rec.status, jobId: newJobId };
 	}
 
-	/** Drain queued resumes (FIFO by seq) while concurrency slots are available. */
+	/** Drain queued resumes while preserving fenced owners and allowing foreign progress. */
 	#drainResumeQueue(): void {
 		if (this.#resumeQueue.length === 0) return;
 		this.#resumeQueue.sort((a, b) => a.seq - b.seq);
-		while (this.#resumeQueue.length > 0 && this.getRunningJobs().length < this.#maxRunningJobs) {
-			const entry = this.#resumeQueue.shift();
-			if (!entry) return;
+		let index = 0;
+		while (index < this.#resumeQueue.length && this.getRunningJobs().length < this.#maxRunningJobs) {
+			const entry = this.#resumeQueue[index];
 			const rec = this.#subagentRecords.get(entry.subagentId);
-			if (rec?.status !== "queued") continue;
-			this.#startResume(rec, entry.message);
+			if (rec?.status !== "queued") {
+				this.#resumeQueue.splice(index, 1);
+				continue;
+			}
+			if (this.#isOwnerSubagentShutdownFenced(entry.ownerId)) {
+				index += 1;
+				continue;
+			}
+			try {
+				const result = this.#startResume(rec, entry.message);
+				if (result.reason === "owner_shutdown_in_progress") {
+					index += 1;
+					continue;
+				}
+				this.#resumeQueue.splice(index, 1);
+			} catch (error) {
+				if (error instanceof OwnerSubagentShutdownError) {
+					index += 1;
+					continue;
+				}
+				throw error;
+			}
 		}
 	}
 
@@ -1011,36 +1301,10 @@ export class AsyncJobManager {
 		};
 	}
 
-	/**
-	 * Run and clear every registered cleanup for the given filter. Idempotent
-	 * and error-isolated: a throwing cleanup does not prevent siblings from
-	 * running and never escalates to the caller.
-	 */
+	/** Run producer cleanups, then perform the legacy destructive subagent purge. */
 	runOwnerCleanups(filter?: AsyncJobFilter): void {
-		const ownerId = filter?.ownerId;
-		const targets: Array<[string, Set<() => void>]> = [];
-		if (ownerId) {
-			const bag = this.#ownerCleanups.get(ownerId);
-			if (bag) targets.push([ownerId, bag]);
-		} else {
-			for (const entry of this.#ownerCleanups.entries()) targets.push(entry);
-		}
-		for (const [id, bag] of targets) {
-			const callbacks = Array.from(bag);
-			bag.clear();
-			this.#ownerCleanups.delete(id);
-			for (const cleanup of callbacks) {
-				try {
-					cleanup();
-				} catch (error) {
-					logger.warn("Async job owner cleanup failed", {
-						ownerId: id,
-						error: error instanceof Error ? error.message : String(error),
-					});
-				}
-			}
-		}
-		this.#purgeOwnerSubagentState(ownerId);
+		this.runOwnerProducerCleanups(filter);
+		this.#purgeOwnerSubagentState(filter?.ownerId);
 	}
 
 	getDeliveryState(filter?: AsyncJobFilter): AsyncJobDeliveryState {
@@ -1084,6 +1348,7 @@ export class AsyncJobManager {
 				removed += 1;
 			}
 		}
+		if (removed > 0) this.#ensureDeliveryLoop();
 		return removed;
 	}
 
@@ -1099,7 +1364,7 @@ export class AsyncJobManager {
 		this.#deliveries.splice(
 			0,
 			this.#deliveries.length,
-			...this.#deliveries.filter(delivery => !this.isDeliverySuppressed(delivery.jobId)),
+			...this.#deliveries.filter(delivery => !this.#isDeliveryAcknowledged(delivery.jobId)),
 		);
 		return before - this.#deliveries.length;
 	}
@@ -1117,6 +1382,48 @@ export class AsyncJobManager {
 			job.abortController.abort();
 			this.#scheduleEviction(job.id);
 		}
+	}
+
+	async waitForOwnerInFlightDeliveries(ownerId: string, options?: { timeoutMs?: number }): Promise<boolean> {
+		const inFlight = this.#inFlightDeliveries
+			.filter(delivery => delivery.ownerId === ownerId)
+			.map(delivery => delivery.promise)
+			.filter((promise): promise is Promise<void> => promise !== undefined);
+		if (inFlight.length === 0) return true;
+		const timeoutMs = Math.max(0, options?.timeoutMs ?? OWNER_SUBAGENT_SHUTDOWN_TIMEOUT_MS);
+		let timedOut = false;
+		await Promise.race([
+			Promise.allSettled(inFlight),
+			Bun.sleep(timeoutMs).then(() => {
+				timedOut = true;
+			}),
+		]);
+		return !timedOut;
+	}
+	async cancelAndSettleOwnerJobs(ownerId: string, options?: { timeoutMs?: number }): Promise<boolean> {
+		const jobs = this.getAllJobs({ ownerId });
+		for (const job of jobs) this.cancel(job.id, { ownerId });
+		const timeoutMs = Math.max(0, options?.timeoutMs ?? OWNER_SUBAGENT_SHUTDOWN_TIMEOUT_MS);
+		let timedOut = false;
+		await Promise.race([
+			Promise.allSettled(jobs.map(job => job.promise)),
+			Bun.sleep(timeoutMs).then(() => {
+				timedOut = true;
+			}),
+		]);
+		const inFlight = this.#inFlightDeliveries
+			.filter(delivery => delivery.ownerId === ownerId)
+			.map(delivery => delivery.promise)
+			.filter((promise): promise is Promise<void> => promise !== undefined);
+		if (inFlight.length === 0) return !timedOut;
+		let deliveryTimedOut = false;
+		await Promise.race([
+			Promise.allSettled(inFlight),
+			Bun.sleep(timeoutMs).then(() => {
+				deliveryTimedOut = true;
+			}),
+		]);
+		return !timedOut && !deliveryTimedOut;
 	}
 
 	getLastDisposeDiagnostics(): AsyncJobDisposeDiagnostics {
@@ -1230,6 +1537,7 @@ export class AsyncJobManager {
 		this.#subagentProgress.clear();
 		this.#resumeDescriptors.clear();
 		this.#resumeQueue.length = 0;
+		this.#ownerSubagentShutdownLeases.clear();
 		this.#notifyChange();
 		this.#changeListeners.clear();
 		return drained && waitResult.completed;
@@ -1315,12 +1623,22 @@ export class AsyncJobManager {
 		);
 	}
 
+	#isDeliveryFenced(delivery: AsyncJobDelivery): boolean {
+		return Boolean(delivery.ownerId && this.#isOwnerSubagentShutdownFenced(delivery.ownerId));
+	}
+
+	#hasDeliverable(): boolean {
+		return this.#deliveries.some(
+			delivery => !this.isDeliverySuppressed(delivery.jobId) && !this.#isDeliveryFenced(delivery),
+		);
+	}
+
 	async #deliverNextFiltered(filter: AsyncJobFilter, deadline: number): Promise<boolean> {
 		while (true) {
 			let selected: AsyncJobDelivery | undefined;
 			for (const delivery of this.#deliveries) {
 				if (delivery.ownerId !== filter.ownerId) continue;
-				if (this.isDeliverySuppressed(delivery.jobId)) continue;
+				if (this.isDeliverySuppressed(delivery.jobId) || this.#isDeliveryFenced(delivery)) continue;
 				if (!selected || delivery.nextAttemptAt < selected.nextAttemptAt) {
 					selected = delivery;
 				}
@@ -1328,7 +1646,7 @@ export class AsyncJobManager {
 
 			if (!selected) {
 				const inFlight = this.#filterInFlightDeliveries(filter);
-				if (inFlight.length === 0) return true;
+				if (inFlight.length === 0) return this.#filterDeliveries(filter).length === 0;
 				return this.#waitForDeliveryPromise(inFlight[0]?.promise, deadline);
 			}
 
@@ -1348,13 +1666,17 @@ export class AsyncJobManager {
 		}
 	}
 
+	#isDeliveryAcknowledged(jobId: string): boolean {
+		return this.#suppressedDeliveries.has(jobId);
+	}
+
 	isDeliverySuppressed(jobId: string): boolean {
-		return this.#suppressedDeliveries.has(jobId) || this.#watchedJobs.has(jobId);
+		return this.#isDeliveryAcknowledged(jobId) || this.#watchedJobs.has(jobId);
 	}
 
 	#enqueueDelivery(jobId: string, text: string): void {
 		// Skip delivery if already acknowledged
-		if (this.isDeliverySuppressed(jobId)) {
+		if (this.#isDeliveryAcknowledged(jobId)) {
 			return;
 		}
 		const deliveryText = this.#boundedDeliveryText(text);
@@ -1399,7 +1721,7 @@ export class AsyncJobManager {
 			})
 			.finally(() => {
 				this.#deliveryLoop = undefined;
-				if (!this.#disposed && this.#deliveries.length > 0) {
+				if (!this.#disposed && this.#hasDeliverable()) {
 					this.#ensureDeliveryLoop();
 				}
 			});
@@ -1407,24 +1729,19 @@ export class AsyncJobManager {
 
 	async #runDeliveryLoop(): Promise<void> {
 		while (this.#deliveries.length > 0) {
-			const delivery = this.#deliveries[0];
-			if (this.isDeliverySuppressed(delivery.jobId)) {
-				this.#deliveries.shift();
-				continue;
-			}
+			const delivery = this.#deliveries.find(
+				candidate => !this.isDeliverySuppressed(candidate.jobId) && !this.#isDeliveryFenced(candidate),
+			);
+			if (!delivery) return;
 			const waitMs = delivery.nextAttemptAt - Date.now();
 			if (waitMs > 0) {
 				await Bun.sleep(waitMs);
 			}
-			if (this.#deliveries[0] !== delivery) {
-				continue;
-			}
-			if (this.isDeliverySuppressed(delivery.jobId)) {
-				this.#deliveries.shift();
-				continue;
-			}
+			const index = this.#deliveries.indexOf(delivery);
+			if (index === -1) continue;
+			if (this.isDeliverySuppressed(delivery.jobId) || this.#isDeliveryFenced(delivery)) continue;
 
-			this.#deliveries.shift();
+			this.#deliveries.splice(index, 1);
 			await this.#deliverDelivery(delivery);
 		}
 	}
@@ -1446,7 +1763,7 @@ export class AsyncJobManager {
 					});
 				} else {
 					delivery.nextAttemptAt = Date.now() + this.#getRetryDelay(delivery.attempt);
-					if (!this.isDeliverySuppressed(delivery.jobId)) {
+					if (!this.#isDeliveryAcknowledged(delivery.jobId)) {
 						this.#deliveries.push(delivery);
 					}
 					logger.warn("Async job completion delivery failed", {
@@ -1459,7 +1776,7 @@ export class AsyncJobManager {
 			} finally {
 				const index = this.#inFlightDeliveries.indexOf(delivery);
 				if (index !== -1) this.#inFlightDeliveries.splice(index, 1);
-				if (!this.#disposed && this.#deliveries.length > 0) this.#ensureDeliveryLoop();
+				if (!this.#disposed && this.#hasDeliverable()) this.#ensureDeliveryLoop();
 			}
 		})();
 		delivery.promise = promise;

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -916,22 +916,15 @@ export class CommandController {
 		}
 	}
 
-	async #runNewSessionFlow(options?: NewSessionOptions, label: string = "New session started"): Promise<void> {
+	async #runNewSessionFlow(options?: NewSessionOptions, label: string = "New session started"): Promise<boolean> {
+		if (!(await this.ctx.session.newSession(options))) return false;
+
 		if (this.ctx.loadingAnimation) {
 			this.ctx.loadingAnimation.stop();
 			this.ctx.loadingAnimation = undefined;
 		}
 		this.ctx.statusContainer.clear();
-
-		if (this.ctx.session.isCompacting) {
-			this.ctx.session.abortCompaction();
-			while (this.ctx.session.isCompacting) {
-				await Bun.sleep(10);
-			}
-		}
-		if (!(await this.ctx.session.newSession(options))) return;
 		this.ctx.resetIrcSidebarSession();
-
 		this.ctx.resetObserverRegistry();
 		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
 
@@ -952,10 +945,11 @@ export class CommandController {
 		this.ctx.chatContainer.addChild(new Text(`${theme.fg("accent", `${theme.status.success} ${label}`)}`, 1, 0));
 		await this.ctx.reloadTodos();
 		this.ctx.ui.requestRender();
+		return true;
 	}
 
-	async handleClearCommand(): Promise<void> {
-		await this.#runNewSessionFlow();
+	async handleClearCommand(): Promise<boolean> {
+		return this.#runNewSessionFlow();
 	}
 
 	async handleContextClearCommand(): Promise<void> {
@@ -995,12 +989,12 @@ export class CommandController {
 		this.ctx.ui.requestRender();
 	}
 
-	async handleDropCommand(): Promise<void> {
+	async handleDropCommand(): Promise<boolean> {
 		if (!this.ctx.sessionManager.getSessionFile()) {
 			this.ctx.showError("Nothing to drop (in-memory session)");
-			return;
+			return false;
 		}
-		await this.#runNewSessionFlow({ drop: true }, "Session dropped");
+		return this.#runNewSessionFlow({ drop: true }, "Session dropped");
 	}
 
 	async handleForkCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -53,6 +53,40 @@ export class ExtensionUiController {
 		overlay?.hide();
 	}
 
+	captureSessionUiCleanup(): () => void {
+		const terminalInputUnsubscribers = [...this.#extensionTerminalInputUnsubscribers];
+		const widgetsAbove = [...this.#hookWidgetsAbove.entries()];
+		const widgetsBelow = [...this.#hookWidgetsBelow.entries()];
+		const activeHookCustomComponent = this.#activeHookCustomComponent;
+		const activeHookCustomOverlay = this.#activeHookCustomOverlay;
+		return () => {
+			for (const unsubscribe of terminalInputUnsubscribers) {
+				unsubscribe();
+				this.#extensionTerminalInputUnsubscribers.delete(unsubscribe);
+			}
+			let widgetsChanged = false;
+			for (const [key, widget] of widgetsAbove) {
+				if (this.#hookWidgetsAbove.get(key) !== widget) continue;
+				this.#hookWidgetsAbove.delete(key);
+				widget.dispose?.();
+				widgetsChanged = true;
+			}
+			for (const [key, widget] of widgetsBelow) {
+				if (this.#hookWidgetsBelow.get(key) !== widget) continue;
+				this.#hookWidgetsBelow.delete(key);
+				widget.dispose?.();
+				widgetsChanged = true;
+			}
+			if (
+				this.#activeHookCustomComponent === activeHookCustomComponent &&
+				this.#activeHookCustomOverlay === activeHookCustomOverlay
+			) {
+				this.#clearActiveHookCustom();
+			}
+			if (widgetsChanged) this.#rebuildHookWidgets();
+		};
+	}
+
 	#sdkControl = async (operation: string, input: Record<string, unknown>): Promise<unknown> => {
 		const session = this.ctx.session;
 		switch (operation) {
@@ -414,36 +448,30 @@ export class ExtensionUiController {
 				this.ctx.showStatus("Reloaded session");
 			},
 			newSession: async options => {
-				// Stop any loading animation
+				const cleanupPreviousSessionUi = this.captureSessionUiCleanup();
+				const success = await this.ctx.session.newSession({ parentSession: options?.parentSession });
+				if (!success) {
+					return { cancelled: true };
+				}
+				cleanupPreviousSessionUi();
+
 				if (this.ctx.loadingAnimation) {
 					this.ctx.loadingAnimation.stop();
 					this.ctx.loadingAnimation = undefined;
 				}
 				this.ctx.statusContainer.clear();
-
-				// Create new session
-				this.clearExtensionTerminalInputListeners();
-				this.clearHookWidgets();
-				const success = await this.ctx.session.newSession({ parentSession: options?.parentSession });
-				if (!success) {
-					return { cancelled: true };
-				}
 				this.ctx.resetIrcSidebarSession();
-
 				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
 
-				// Call setup callback if provided
 				if (options?.setup) {
 					await options.setup(this.ctx.sessionManager);
 				}
 
-				// Reset and update status line
 				this.ctx.statusLine.invalidate();
 				this.ctx.statusLine.setSessionStartTime(Date.now());
 				this.ctx.updateEditorTopBorder();
 				this.ctx.ui.requestRender();
 
-				// Clear UI state
 				prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 				this.ctx.chatContainer.clear();
 				this.ctx.pendingMessagesContainer.clear();
@@ -717,28 +745,24 @@ export class ExtensionUiController {
 				if (this.ctx.isBackgrounded) {
 					return { cancelled: true };
 				}
-				// Stop any loading animation
+				const cleanupPreviousSessionUi = this.captureSessionUiCleanup();
+				const success = await this.ctx.session.newSession({ parentSession: options?.parentSession });
+				if (!success) {
+					return { cancelled: true };
+				}
+				cleanupPreviousSessionUi();
+
 				if (this.ctx.loadingAnimation) {
 					this.ctx.loadingAnimation.stop();
 					this.ctx.loadingAnimation = undefined;
 				}
 				this.ctx.statusContainer.clear();
-
-				// Create new session
-				this.clearExtensionTerminalInputListeners();
-				this.clearHookWidgets();
-				const success = await this.ctx.session.newSession({ parentSession: options?.parentSession });
-				if (!success) {
-					return { cancelled: true };
-				}
 				this.ctx.resetIrcSidebarSession();
 
-				// Call setup callback if provided
 				if (options?.setup) {
 					await options.setup(this.ctx.sessionManager);
 				}
 
-				// Clear UI state
 				prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 				this.ctx.chatContainer.clear();
 				this.ctx.pendingMessagesContainer.clear();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1820,19 +1820,22 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (options.compactBeforeExecute) {
 			this.session.markPlanCompactAbortPending();
 		}
+		let sessionSwitchCompleted = true;
 		let compactOutcome: CompactionOutcome | undefined;
 		try {
 			await this.#exitPlanMode({ silent: true, paused: false });
 
 			if (!options.preserveContext) {
-				await this.handleClearCommand();
-				// The new session has a fresh local:// root — persist the approved plan there
-				// so `local://<title>.md` resolves correctly in the execution session.
-				const newLocalPath = resolveLocalUrlToPath(options.finalPlanFilePath, {
-					getArtifactsDir: () => this.sessionManager.getArtifactsDir(),
-					getSessionId: () => this.sessionManager.getSessionId(),
-				});
-				await Bun.write(newLocalPath, planContent);
+				sessionSwitchCompleted = await this.handleClearCommand();
+				if (sessionSwitchCompleted) {
+					// The new session has a fresh local:// root — persist the approved plan there
+					// so `local://<title>.md` resolves correctly in the execution session.
+					const newLocalPath = resolveLocalUrlToPath(options.finalPlanFilePath, {
+						getArtifactsDir: () => this.sessionManager.getArtifactsDir(),
+						getSessionId: () => this.sessionManager.getSessionId(),
+					});
+					await Bun.write(newLocalPath, planContent);
+				}
 			} else if (options.compactBeforeExecute) {
 				// Distill the plan-mode transcript before the execution turn is queued so
 				// the plan-approved synthetic prompt lands as a fresh cache anchor.
@@ -1865,6 +1868,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		// retired regardless of whether the synthetic prompt fires.
 		if (previousTools.length > 0) {
 			await this.session.setActiveToolsByName(previousTools);
+		}
+		if (!sessionSwitchCompleted) {
+			this.showWarning("Plan approved, but the new session could not be created — execution was not dispatched.");
+			return;
 		}
 		this.session.setPlanReferencePath(options.finalPlanFilePath);
 
@@ -2577,15 +2584,18 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#commandController.handleContextCommand();
 	}
 
-	#prepareSessionSwitch(): void {
+	#prepareSessionSwitch(cleanupPreviousSessionUi?: () => void): void {
 		this.#btwController.dispose();
-		this.#extensionUiController.clearExtensionTerminalInputListeners();
+		if (cleanupPreviousSessionUi) cleanupPreviousSessionUi();
+		else this.#extensionUiController.clearExtensionTerminalInputListeners();
 		this.#planReviewContainer = undefined;
 	}
 
-	handleClearCommand(): Promise<void> {
-		this.#prepareSessionSwitch();
-		return this.#commandController.handleClearCommand();
+	async handleClearCommand(): Promise<boolean> {
+		const cleanupPreviousSessionUi = this.#extensionUiController.captureSessionUiCleanup();
+		const switched = await this.#commandController.handleClearCommand();
+		if (switched) this.#prepareSessionSwitch(cleanupPreviousSessionUi);
+		return switched;
 	}
 
 	handleContextClearCommand(): Promise<void> {
@@ -2593,9 +2603,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleContextClearCommand();
 	}
 
-	handleDropCommand(): Promise<void> {
-		this.#prepareSessionSwitch();
-		return this.#commandController.handleDropCommand();
+	async handleDropCommand(): Promise<boolean> {
+		const cleanupPreviousSessionUi = this.#extensionUiController.captureSessionUiCleanup();
+		const switched = await this.#commandController.handleDropCommand();
+		if (switched) this.#prepareSessionSwitch(cleanupPreviousSessionUi);
+		return switched;
 	}
 
 	handleForkCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -263,9 +263,9 @@ export interface InteractiveModeContext {
 	handleContextCommand(): void;
 	handleDumpCommand(): void;
 	handleDebugTranscriptCommand(): Promise<void>;
-	handleClearCommand(): Promise<void>;
+	handleClearCommand(): Promise<boolean>;
 	handleContextClearCommand(): Promise<void>;
-	handleDropCommand(): Promise<void>;
+	handleDropCommand(): Promise<boolean>;
 	handleForkCommand(): Promise<void>;
 	handleBashCommand(command: string, excludeFromContext?: boolean): Promise<void>;
 	handlePythonCommand(code: string, excludeFromContext?: boolean): Promise<void>;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1419,6 +1419,7 @@ export class AgentSession {
 	#providerCacheSessionId: string | undefined;
 	#isDisposed = false;
 	#disposePromise: Promise<void> | undefined;
+	#newSessionTransition: Promise<boolean> | undefined;
 	// Extension system
 	#extensionRunner: ExtensionRunner | undefined = undefined;
 
@@ -7621,7 +7622,20 @@ export class AgentSession {
 	 * @param options - Optional initial messages and parent session path
 	 * @returns true if completed, false if cancelled by hook
 	 */
-	async newSession(options?: NewSessionOptions): Promise<boolean> {
+	newSession(options?: NewSessionOptions): Promise<boolean> {
+		if (this.#newSessionTransition) return this.#newSessionTransition;
+
+		const transition = this.#runNewSessionTransition(options);
+		this.#newSessionTransition = transition;
+		void transition
+			.finally(() => {
+				if (this.#newSessionTransition === transition) this.#newSessionTransition = undefined;
+			})
+			.catch(() => {});
+		return transition;
+	}
+
+	async #runNewSessionTransition(options?: NewSessionOptions): Promise<boolean> {
 		const previousSessionFile = this.sessionFile;
 		const previousWorkflowGateSessionId = this.sessionId;
 		const nextDiscoverySessionToolNames = this.#mcpDiscoveryEnabled
@@ -7643,32 +7657,132 @@ export class AgentSession {
 			}
 		}
 
-		this.#disconnectFromAgent();
-		await this.abort();
-		this.#cancelOwnAsyncJobs();
-		this.#closeAllProviderSessions("new session");
-		this.#rebindProviderSessionState(new Map());
-		this.agent.reset();
-		if (options?.drop && previousSessionFile) {
-			try {
-				await this.sessionManager.dropSession(previousSessionFile);
-			} catch (err) {
-				logger.error("Failed to delete session during /drop", { err });
-			}
-		} else {
-			await this.sessionManager.flush();
+		const manager = AsyncJobManager.instance();
+		const ownerId = this.#agentId;
+		const lease = manager && ownerId ? manager.beginOwnerSubagentShutdown(ownerId) : undefined;
+		if (manager && ownerId && !lease) {
+			this.emitNotice(
+				"error",
+				"Cannot start a new session while owned subagent cleanup is already in progress.",
+				"new-session-subagent-cleanup",
+			);
+			return false;
 		}
-		await this.sessionManager.newSession(options);
-		this.setTodoPhases([]);
-		this.#syncAgentSessionId();
-		this.#bindWorkflowGateEmitter(previousWorkflowGateSessionId);
-		this.#rekeyHindsightMemoryForCurrentSessionId();
-		this.#resetHindsightConversationTrackingIfHindsight();
-		this.#steeringMessages = [];
-		this.#followUpMessages = [];
-		this.#pendingNextTurnMessages = [];
-		this.#scheduledHiddenNextTurnGeneration = undefined;
 
+		if (!lease) {
+			this.#disconnectFromAgent();
+			await this.abort();
+			if (this.isCompacting) {
+				this.abortCompaction();
+				while (this.isCompacting) {
+					await Bun.sleep(10);
+				}
+			}
+			this.#cancelOwnAsyncJobs();
+			this.#closeAllProviderSessions("new session");
+			this.#rebindProviderSessionState(new Map());
+			this.agent.reset();
+			if (!options?.drop) await this.sessionManager.flush();
+			await this.sessionManager.newSession(options);
+			this.setTodoPhases([]);
+			this.#syncAgentSessionId();
+			this.#bindWorkflowGateEmitter(previousWorkflowGateSessionId);
+			this.#rekeyHindsightMemoryForCurrentSessionId();
+			this.#resetHindsightConversationTrackingIfHindsight();
+			this.#steeringMessages = [];
+			this.#followUpMessages = [];
+			this.#pendingNextTurnMessages = [];
+			this.#scheduledHiddenNextTurnGeneration = undefined;
+			await this.#initializeNewSessionState(nextDiscoverySessionToolNames, previousSessionFile);
+			if (options?.drop && previousSessionFile) {
+				try {
+					await this.sessionManager.dropSession(previousSessionFile);
+				} catch (err) {
+					logger.error("Failed to delete session during /drop", { err });
+				}
+			}
+			return true;
+		}
+
+		if (!manager) throw new Error("Owner subagent shutdown manager became unavailable.");
+		if (!ownerId) throw new Error("Owner subagent shutdown owner became unavailable.");
+		const previousSessionIdentity = this.sessionManager.getSessionId();
+		try {
+			try {
+				manager.runOwnerProducerCleanupsStrict({ ownerId });
+				await this.abort();
+				if (this.isCompacting) {
+					this.abortCompaction();
+					while (this.isCompacting) {
+						await Bun.sleep(10);
+					}
+				}
+				const proof = await manager.cancelAndProveOwnerSubagents(lease);
+				if (!proof.confirmed) {
+					this.emitNotice(
+						"error",
+						"Unable to confirm owned subagent cleanup; session was not replaced. Wait for or inspect remaining subagents, then retry /new.",
+						"new-session-subagent-cleanup",
+					);
+					manager.finishOwnerSubagentShutdown(lease, "release");
+					return false;
+				}
+			} catch {
+				this.emitNotice(
+					"error",
+					"Unable to confirm owned subagent cleanup; session was not replaced. Wait for or inspect remaining subagents, then retry /new.",
+					"new-session-subagent-cleanup",
+				);
+				manager.finishOwnerSubagentShutdown(lease, "release");
+				return false;
+			}
+
+			if (!(await manager.waitForOwnerInFlightDeliveries(ownerId))) {
+				throw new Error("Owned async deliveries did not settle before session replacement.");
+			}
+			if (!options?.drop) await this.sessionManager.flush();
+
+			if (!(await manager.cancelAndSettleOwnerJobs(ownerId))) {
+				throw new Error("Owned async jobs did not settle before session replacement.");
+			}
+
+			this.#disconnectFromAgent();
+			this.#closeAllProviderSessions("new session");
+			this.#rebindProviderSessionState(new Map());
+			this.agent.reset();
+			await this.sessionManager.newSession(options);
+			this.setTodoPhases([]);
+			this.#syncAgentSessionId();
+			this.#bindWorkflowGateEmitter(previousWorkflowGateSessionId);
+			this.#rekeyHindsightMemoryForCurrentSessionId();
+			this.#resetHindsightConversationTrackingIfHindsight();
+			this.#steeringMessages = [];
+			this.#followUpMessages = [];
+			this.#pendingNextTurnMessages = [];
+			this.#scheduledHiddenNextTurnGeneration = undefined;
+			await this.#initializeNewSessionState(nextDiscoverySessionToolNames, previousSessionFile);
+			if (options?.drop && previousSessionFile) {
+				try {
+					await this.sessionManager.dropSession(previousSessionFile);
+				} catch (err) {
+					logger.error("Failed to delete session during /drop", { err });
+				}
+			}
+			manager.finishOwnerSubagentShutdown(lease, "commit");
+			return true;
+		} catch (error) {
+			manager.finishOwnerSubagentShutdown(
+				lease,
+				this.sessionManager.getSessionId() !== previousSessionIdentity ? "commit" : "release",
+			);
+			throw error;
+		}
+	}
+
+	async #initializeNewSessionState(
+		nextDiscoverySessionToolNames: string[] | undefined,
+		previousSessionFile: string | undefined,
+	): Promise<void> {
 		const inheritedThinkingLevel = resolveThinkingLevelForModel(this.model, this.#getInheritedThinkingLevel());
 		this.#thinkingLevel = inheritedThinkingLevel;
 		this.agent.setThinkingLevel(toReasoningEffort(inheritedThinkingLevel));
@@ -7687,15 +7801,11 @@ export class AgentSession {
 			this.sessionFile,
 			this.#getConfiguredDefaultSelectedMCPToolNames(),
 		);
-
 		this.#todoReminderCount = 0;
 		this.#planReferenceSent = false;
 		this.#planReferencePath = "local://PLAN.md";
 		this.#reconnectToAgent();
-
 		this.#resetIrcRosterDeliveryState();
-
-		// Emit session_switch event with reason "new" to hooks
 		if (this.#extensionRunner) {
 			await this.#extensionRunner.emit({
 				type: "session_switch",
@@ -7703,8 +7813,6 @@ export class AgentSession {
 				previousSessionFile,
 			});
 		}
-
-		return true;
 	}
 
 	/**

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -19,7 +19,7 @@ import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@gajae
 import type { Model, Usage } from "@gajae-code/ai";
 import { $env, prompt, Snowflake } from "@gajae-code/utils";
 import type { ToolSession } from "..";
-import { AsyncJobManager } from "../async";
+import { AsyncJobManager, OwnerSubagentShutdownError } from "../async";
 import { resolveAgentModelPatterns } from "../config/model-resolver";
 import type { Theme } from "../modes/theme/theme";
 import planModeSubagentPrompt from "../prompts/system/plan-mode-subagent.md" with { type: "text" };
@@ -795,7 +795,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					});
 				}
 			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
+				const message =
+					error instanceof OwnerSubagentShutdownError
+						? error.message
+						: error instanceof Error
+							? error.message
+							: String(error);
 				failedSchedules.push(`${taskItem.id}: ${message}`);
 				const progress = progressByTaskId.get(taskItem.id);
 				if (progress) {

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -23,6 +23,8 @@ import {
 } from "./render-utils";
 import { type SubagentSnapshot, type SubagentToolDetails, subagentAwaitRenderedStateSignature } from "./subagent";
 
+export { subagentAwaitRenderedStateSignature } from "./subagent";
+
 const PREVIEW_LINES_COLLAPSED = 1;
 const PREVIEW_LINES_EXPANDED = 4;
 const PREVIEW_LINE_WIDTH = 80;
@@ -128,7 +130,7 @@ function renderSubagentStatusLine(snapshot: SubagentSnapshot, theme: Theme, spin
 		theme,
 		snapshot.status === "running" ? spinnerFrame : undefined,
 	);
-	const id = theme.fg("muted", snapshot.id);
+	const id = theme.fg("muted", truncateToWidth(replaceTabs(snapshot.id), PREVIEW_LINE_WIDTH, Ellipsis.Unicode));
 	const status = theme.fg("dim", snapshot.status);
 	const duration = theme.fg("dim", formatDuration(snapshot.durationMs));
 	return `${icon} ${id} ${status} ${duration}`;
@@ -195,7 +197,12 @@ function renderSubagentSnapshotBody(snapshot: SubagentSnapshot, expanded: boolea
 		}
 	}
 
-	if (snapshot.guidance) lines.push(`  ${theme.fg("dim", snapshot.guidance)}`);
+	if (snapshot.guidance) {
+		for (const line of getPreviewLines(snapshot.guidance, 1, PREVIEW_LINE_WIDTH, Ellipsis.Unicode)) {
+			lines.push(`  ${theme.fg("dim", replaceTabs(line))}`);
+		}
+	}
+
 	return lines;
 }
 
@@ -218,6 +225,7 @@ export const subagentToolRenderer = {
 		}
 
 		const runningCount = subagents.filter(s => s.status === "running").length;
+		const interrupted = result.details?.interrupted === true;
 
 		// Each snapshot's rendered-state signature is constant for this component
 		// instance, so compute them at most once; the heavy per-subagent bodies are
@@ -232,11 +240,12 @@ export const subagentToolRenderer = {
 				// it is never gated by the heavy body cache.
 				const header = renderStatusLine(
 					{
-						icon: runningCount > 0 ? "info" : "success",
-						spinnerFrame: runningCount > 0 ? options.spinnerFrame : undefined,
-						title: "Subagent",
-						description:
-							runningCount > 0
+						icon: interrupted ? "warning" : runningCount > 0 ? "info" : "success",
+						spinnerFrame: !interrupted && runningCount > 0 ? options.spinnerFrame : undefined,
+						title: interrupted ? "Subagent await interrupted" : "Subagent",
+						description: interrupted
+							? "child subagents continue"
+							: runningCount > 0
 								? `awaiting ${runningCount} of ${subagents.length}`
 								: `${subagents.length} ${subagents.length === 1 ? "subagent" : "subagents"}`,
 					},
@@ -249,7 +258,9 @@ export const subagentToolRenderer = {
 					out.push(truncateToWidth(`  ${theme.fg("dim", "(ctrl+s to observe sessions)")}`, width, Ellipsis.Omit));
 				}
 
-				snapshotSignatures ??= subagents.map(snapshot => subagentAwaitRenderedStateSignature([snapshot]));
+				snapshotSignatures ??= subagents.map(snapshot =>
+					subagentAwaitRenderedStateSignature([snapshot], result.details),
+				);
 				subagents.forEach((snapshot, index) => {
 					// Fresh per-subagent status line (cheap), then the cached heavy body.
 					out.push(

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -80,8 +80,17 @@ export interface SubagentSnapshot {
 	modelFellBack?: boolean;
 }
 
+export type SubagentAwaitOutcome = "completed" | "timed_out" | "interrupted";
+
+const AWAIT_INTERRUPTED_GUIDANCE =
+	"Await interrupted; this subagent continues. Inspect its current state or cancel it only when necessary.";
+
 export interface SubagentToolDetails {
 	subagents: SubagentSnapshot[];
+	/** Await outcome for a live await receipt; omitted when no wait was started. */
+	awaitOutcome?: SubagentAwaitOutcome;
+	/** True only when the parent await was interrupted; the child was not cancelled. */
+	interrupted?: true;
 }
 
 export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentToolDetails> {
@@ -370,35 +379,50 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		// the viewport (the source of the await-panel repaint storms).
 		emitIfChanged(true);
 
-		let timedOut = false;
+		let awaitOutcome: SubagentAwaitOutcome;
+		const { promise: timeoutPromise, resolve: resolveTimeout } = Promise.withResolvers<SubagentAwaitOutcome>();
+		const timeoutTimer = setTimeout(() => resolveTimeout("timed_out"), timeoutMs);
+		const completionPromise = Promise.all(runningJobs.map(job => job.promise)).then(() => "completed" as const);
+		let onAbort: (() => void) | undefined;
 		try {
-			const completionPromise = Promise.all(runningJobs.map(job => job.promise));
-			const timeoutPromise = Bun.sleep(timeoutMs).then(() => {
-				timedOut = true;
-			});
 			if (signal) {
-				const { promise: abortPromise, resolve: abortResolve } = Promise.withResolvers<void>();
-				const onAbort = () => abortResolve();
-				signal.addEventListener("abort", onAbort, { once: true });
-				try {
-					await Promise.race([completionPromise, timeoutPromise, abortPromise]);
-				} finally {
-					signal.removeEventListener("abort", onAbort);
-				}
+				const { promise: abortPromise, resolve: resolveAbort } = Promise.withResolvers<SubagentAwaitOutcome>();
+				onAbort = () => resolveAbort("interrupted");
+				if (signal.aborted) onAbort();
+				else signal.addEventListener("abort", onAbort, { once: true });
+				awaitOutcome = await Promise.race([completionPromise, timeoutPromise, abortPromise]);
 			} else {
-				await Promise.race([completionPromise, timeoutPromise]);
+				awaitOutcome = await Promise.race([completionPromise, timeoutPromise]);
 			}
 		} finally {
-			manager.unwatchJobs(watchedJobIds);
+			clearTimeout(timeoutTimer);
+			if (signal && onAbort) signal.removeEventListener("abort", onAbort);
 			if (progressTimer) clearInterval(progressTimer);
 		}
+		if (awaitOutcome !== "interrupted") {
+			const terminalWatchedJobIds = watchedJobIds.filter(jobId => {
+				const status = manager.getJob(jobId)?.status;
+				return status === "completed" || status === "failed" || status === "cancelled";
+			});
+			manager.acknowledgeDeliveries(terminalWatchedJobIds);
+		}
+		manager.unwatchJobs(watchedJobIds);
 
-		return await this.#buildRecordResult(manager, records, {
-			title: "Subagent await",
-			notFoundIds,
-			timedOut,
+		const finalRecords = this.#visibleRecordsByIds(
+			manager,
+			records.map(record => record.subagentId),
+			ownerFilter,
+		);
+		const finalNotFoundIds = [...new Set([...notFoundIds, ...records.map(record => record.subagentId)])].filter(
+			id => !finalRecords.some(record => record.subagentId === id),
+		);
+		return await this.#buildRecordResult(manager, finalRecords, {
+			title: awaitOutcome === "interrupted" ? "Subagent await interrupted" : "Subagent await",
+			notFoundIds: finalNotFoundIds,
+			timedOut: awaitOutcome === "timed_out",
 			verbosity: params.verbosity ?? "receipt",
 			attachLiveProgress: true,
+			awaitOutcome,
 		});
 	}
 
@@ -516,6 +540,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			timedOut?: boolean;
 			verbosity?: SubagentParams["verbosity"];
 			attachLiveProgress?: boolean;
+			awaitOutcome?: SubagentAwaitOutcome;
 		},
 	): Promise<AgentToolResult<SubagentToolDetails>> {
 		const verifiedOutputIds = await this.#verifiedOutputIds(records);
@@ -530,18 +555,34 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		for (const id of options.notFoundIds ?? []) {
 			snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 		}
-		manager.acknowledgeDeliveries(
-			snapshots
-				.filter(
-					s =>
-						s.status !== "running" && s.status !== "paused" && s.status !== "queued" && s.status !== "not_found",
-				)
-				.map(s => s.jobId),
-		);
-		return this.#buildSnapshotResult(snapshots, options.title);
+		if (options.awaitOutcome !== "interrupted") {
+			manager.acknowledgeDeliveries(
+				snapshots
+					.filter(
+						s =>
+							s.status !== "running" &&
+							s.status !== "paused" &&
+							s.status !== "queued" &&
+							s.status !== "not_found",
+					)
+					.map(s => s.jobId),
+			);
+		}
+		if (options.awaitOutcome === "interrupted") {
+			for (const snapshot of snapshots) {
+				if (snapshot.status === "running" || snapshot.status === "paused" || snapshot.status === "queued") {
+					snapshot.guidance = AWAIT_INTERRUPTED_GUIDANCE;
+				}
+			}
+		}
+		return this.#buildSnapshotResult(snapshots, options.title, options.awaitOutcome);
 	}
 
-	#buildSnapshotResult(snapshots: SubagentSnapshot[], title: string): AgentToolResult<SubagentToolDetails> {
+	#buildSnapshotResult(
+		snapshots: SubagentSnapshot[],
+		title: string,
+		awaitOutcome?: SubagentAwaitOutcome,
+	): AgentToolResult<SubagentToolDetails> {
 		const lines = [`## ${title} (${snapshots.length})`, ""];
 		for (const snapshot of snapshots) {
 			lines.push(`### ${snapshot.id} — ${snapshot.status}`);
@@ -571,7 +612,11 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		}
 		return {
 			content: [{ type: "text", text: lines.join("\n").trimEnd() }],
-			details: { subagents: snapshots },
+			details: {
+				subagents: snapshots,
+				...(awaitOutcome ? { awaitOutcome } : {}),
+				...(awaitOutcome === "interrupted" ? { interrupted: true } : {}),
+			},
 		};
 	}
 
@@ -778,8 +823,15 @@ function previewJobOutput(
  * countdown ticking is sacrificed by design; every real transition still changes
  * the signature.
  */
-export function subagentAwaitRenderedStateSignature(subagents: readonly SubagentSnapshot[]): string {
-	return JSON.stringify(subagents.map(canonicalizeSnapshotForSignature));
+export function subagentAwaitRenderedStateSignature(
+	subagents: readonly SubagentSnapshot[],
+	receipt?: Pick<SubagentToolDetails, "awaitOutcome" | "interrupted">,
+): string {
+	return JSON.stringify({
+		awaitOutcome: receipt?.awaitOutcome ?? null,
+		interrupted: receipt?.interrupted === true,
+		subagents: subagents.map(canonicalizeSnapshotForSignature),
+	});
 }
 
 function canonicalizeSnapshotForSignature(snapshot: SubagentSnapshot): unknown {

--- a/packages/coding-agent/test/agent-session-issue-2261-esc-subagent-cancel.test.ts
+++ b/packages/coding-agent/test/agent-session-issue-2261-esc-subagent-cancel.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai";
+import { AsyncJobManager } from "@gajae-code/coding-agent/async/job-manager";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+
+const CLEANUP_NOTICE =
+	"Unable to confirm owned subagent cleanup; session was not replaced. Wait for or inspect remaining subagents, then retry /new.";
+
+describe("AgentSession Issue #2261 /new owner-subagent cancellation", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let sessionManager: SessionManager;
+	let session: AgentSession;
+	let manager: AsyncJobManager | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@gjc-issue-2261-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled test model");
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+			agentId: "owner",
+		});
+	});
+
+	afterEach(async () => {
+		await session.dispose();
+		await manager?.dispose({ timeoutMs: 100 });
+		AsyncJobManager.setInstance(undefined);
+		authStorage.close();
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	function installOwnerManager(): AsyncJobManager {
+		manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		return manager;
+	}
+
+	it("replaces the session without a job manager or live children", async () => {
+		const previous = session.sessionFile;
+
+		await expect(session.newSession()).resolves.toBe(true);
+		expect(session.sessionFile).toBeDefined();
+		expect(session.sessionFile).not.toBe(previous);
+	});
+
+	it("waits for cooperative owned children before replacing identity", async () => {
+		const ownerManager = installOwnerManager();
+		const previous = session.sessionFile;
+		const jobId = ownerManager.register(
+			"task",
+			"cooperative child",
+			async ({ signal }) => {
+				await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+				return "cancelled";
+			},
+			{
+				id: "child-job",
+				ownerId: "owner",
+				metadata: { subagent: { id: "child", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		ownerManager.registerSubagentRecord({
+			subagentId: "child",
+			ownerId: "owner",
+			currentJobId: jobId,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/child.jsonl",
+			resumable: true,
+		});
+
+		await expect(session.newSession()).resolves.toBe(true);
+		expect(session.sessionFile).not.toBe(previous);
+		expect(ownerManager.getSubagentRecord("child")).toBeUndefined();
+	});
+
+	it("retains identity and emits the exact lease-active notice", async () => {
+		const ownerManager = installOwnerManager();
+		const previous = session.sessionFile;
+		const notices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice") notices.push(event.message);
+		});
+		vi.spyOn(ownerManager, "beginOwnerSubagentShutdown").mockReturnValue(undefined);
+
+		await expect(session.newSession()).resolves.toBe(false);
+		expect(session.sessionFile).toBe(previous);
+		expect(notices).toEqual(["Cannot start a new session while owned subagent cleanup is already in progress."]);
+	});
+
+	it("shares one transition promise for concurrent /new requests and permits a later retry", async () => {
+		const newSession = vi.spyOn(sessionManager, "newSession");
+		const first = session.newSession();
+		const second = session.newSession();
+
+		expect(second).toBe(first);
+		await expect(first).resolves.toBe(true);
+		expect(newSession).toHaveBeenCalledTimes(1);
+
+		await expect(session.newSession()).resolves.toBe(true);
+		expect(newSession).toHaveBeenCalledTimes(2);
+	});
+
+	it("fails closed with the actionable notice and retains identity when owned-child proof is not confirmed", async () => {
+		const ownerManager = installOwnerManager();
+		const previous = session.sessionFile;
+		const notices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice") notices.push(event.message);
+		});
+		vi.spyOn(ownerManager, "beginOwnerSubagentShutdown").mockReturnValue({
+			ownerId: "owner",
+			id: "lease",
+			targets: [{ subagentId: "stuck", jobId: "stuck-job", source: "record" }],
+		});
+		vi.spyOn(ownerManager, "cancelAndProveOwnerSubagents").mockResolvedValue({
+			ownerId: "owner",
+			leaseId: "lease",
+			confirmed: false,
+			reason: "deadline_exceeded",
+			targets: [{ subagentId: "stuck", jobId: "stuck-job", source: "record" }],
+			terminalIds: [],
+			unresolvedIds: ["stuck"],
+		});
+		vi.spyOn(ownerManager, "finishOwnerSubagentShutdown");
+
+		await expect(session.newSession()).resolves.toBe(false);
+		expect(session.sessionFile).toBe(previous);
+		expect(notices).toEqual([CLEANUP_NOTICE]);
+		expect(ownerManager.finishOwnerSubagentShutdown).toHaveBeenCalledWith(expect.any(Object), "release");
+	});
+
+	it("does not cancel generic owner jobs or replace identity when flush rejects", async () => {
+		const ownerManager = installOwnerManager();
+		const previous = session.sessionFile;
+		const genericGate = Promise.withResolvers<string>();
+		const genericJobId = ownerManager.register("bash", "generic", async () => genericGate.promise, {
+			ownerId: "owner",
+		});
+		const cancelAndSettle = vi.spyOn(ownerManager, "cancelAndSettleOwnerJobs");
+		const finishShutdown = vi.spyOn(ownerManager, "finishOwnerSubagentShutdown");
+		vi.spyOn(sessionManager, "flush").mockRejectedValue(new Error("disk full"));
+
+		await expect(session.newSession()).rejects.toThrow("disk full");
+		expect(session.sessionFile).toBe(previous);
+		expect(cancelAndSettle).not.toHaveBeenCalled();
+		expect(ownerManager.getJob(genericJobId)?.status).toBe("running");
+		expect(ownerManager.getDeliveryState({ ownerId: "owner" }).queued).toBe(0);
+		expect(finishShutdown).toHaveBeenCalledWith(expect.any(Object), "release");
+		genericGate.resolve("finished after retained session");
+		await ownerManager.getJob(genericJobId)?.promise;
+	});
+
+	it("waits for in-flight owner delivery before flush and generic owner cancellation", async () => {
+		const ownerManager = installOwnerManager();
+		const order: string[] = [];
+		vi.spyOn(ownerManager, "waitForOwnerInFlightDeliveries").mockImplementation(async () => {
+			order.push("delivery");
+			return true;
+		});
+		vi.spyOn(sessionManager, "flush").mockImplementation(async () => {
+			order.push("flush");
+		});
+		vi.spyOn(ownerManager, "cancelAndSettleOwnerJobs").mockImplementation(async () => {
+			order.push("cancel");
+			return true;
+		});
+
+		await expect(session.newSession()).resolves.toBe(true);
+		expect(order).toEqual(["delivery", "flush", "cancel"]);
+	});
+
+	it("creates the /drop identity before deleting the old session and treats deletion failure as non-fatal", async () => {
+		const previous = session.sessionFile;
+		if (!previous) throw new Error("Expected a persisted session file");
+		const order: string[] = [];
+		vi.spyOn(sessionManager, "newSession").mockImplementation(async options => {
+			order.push("new");
+			return await SessionManager.prototype.newSession.call(sessionManager, options);
+		});
+		vi.spyOn(sessionManager, "dropSession").mockImplementation(async () => {
+			order.push("drop");
+			throw new Error("unlink failed");
+		});
+
+		await expect(session.newSession({ drop: true })).resolves.toBe(true);
+		expect(order).toEqual(["new", "drop"]);
+		expect(session.sessionFile).not.toBe(previous);
+	});
+	it("commits the lease when identity changes before a later initialization error", async () => {
+		const ownerManager = installOwnerManager();
+		const finishShutdown = vi.spyOn(ownerManager, "finishOwnerSubagentShutdown");
+		vi.spyOn(sessionManager, "newSession").mockImplementation(async options => {
+			await SessionManager.prototype.newSession.call(sessionManager, options);
+			throw new Error("post-identity failure");
+		});
+
+		await expect(session.newSession()).rejects.toThrow("post-identity failure");
+		expect(finishShutdown).toHaveBeenCalledWith(expect.any(Object), "commit");
+	});
+
+	it("fails closed with the exact notice when producer cleanup throws, then permits retry", async () => {
+		const ownerManager = installOwnerManager();
+		const previous = session.sessionFile;
+		const notices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice") notices.push(event.message);
+		});
+		let cleanupAttempts = 0;
+		ownerManager.registerOwnerCleanup("owner", () => {
+			cleanupAttempts += 1;
+			if (cleanupAttempts === 1) throw new Error("cleanup failed");
+		});
+
+		await expect(session.newSession()).resolves.toBe(false);
+		expect(session.sessionFile).toBe(previous);
+		expect(notices).toEqual([CLEANUP_NOTICE]);
+		await expect(session.newSession()).resolves.toBe(true);
+		expect(cleanupAttempts).toBe(2);
+	});
+
+	it("settles generic owner jobs and suppresses their delivery before replacing identity", async () => {
+		const completions: string[] = [];
+		manager = new AsyncJobManager({
+			onJobComplete: async jobId => {
+				completions.push(jobId);
+			},
+		});
+		AsyncJobManager.setInstance(manager);
+		const genericJobId = manager.register(
+			"task",
+			"generic",
+			async ({ signal }) => {
+				await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+				return "cancelled";
+			},
+			{ ownerId: "owner" },
+		);
+
+		await expect(session.newSession()).resolves.toBe(true);
+		expect(manager.getJob(genericJobId)?.status).toBe("cancelled");
+		expect(completions).toEqual([]);
+		expect(manager.getDeliveryState({ ownerId: "owner" }).queued).toBe(0);
+	});
+
+	it("fences late same-owner generic admission while leaving foreign jobs isolated", async () => {
+		const ownerManager = installOwnerManager();
+		const foreignGate = Promise.withResolvers<void>();
+		const foreignJobId = ownerManager.register(
+			"task",
+			"foreign",
+			async (): Promise<string> => {
+				await foreignGate.promise;
+				return "foreign";
+			},
+			{ ownerId: "foreign" },
+		);
+		const originalProof = ownerManager.cancelAndProveOwnerSubagents.bind(ownerManager);
+		vi.spyOn(ownerManager, "cancelAndProveOwnerSubagents").mockImplementation(async lease => {
+			expect(() => ownerManager.register("task", "late", async () => "late", { ownerId: "owner" })).toThrow(
+				"Cannot start subagent while owner shutdown is in progress.",
+			);
+			return await originalProof(lease);
+		});
+
+		await expect(session.newSession()).resolves.toBe(true);
+		expect(ownerManager.getJob(foreignJobId)?.status).toBe("running");
+		foreignGate.resolve();
+		await ownerManager.waitForAll();
+	});
+});

--- a/packages/coding-agent/test/async/job-manager-resume-queue.test.ts
+++ b/packages/coding-agent/test/async/job-manager-resume-queue.test.ts
@@ -231,6 +231,33 @@ describe("AsyncJobManager subagent pause/resume/queue", () => {
 		await manager.dispose({ timeoutMs: 500 });
 	});
 
+	test("a fenced queued owner remains queued while a later foreign owner resumes", async () => {
+		const { manager, completions } = makeManager({ maxRunningJobs: 1 });
+		installResumeRunner(manager);
+		const a = spawnControllable(manager, "A", "owner-a");
+		expect(manager.pauseSubagent("A").ok).toBe(true);
+		a.release();
+		await manager.waitForAll();
+		const c = spawnControllable(manager, "C", "owner-c");
+		expect(manager.pauseSubagent("C").ok).toBe(true);
+		c.release();
+		await manager.waitForAll();
+		const b = spawnControllable(manager, "B", "owner-b");
+		expect(manager.resumeSubagent("A").queued).toBe(true);
+		expect(manager.resumeSubagent("C").queued).toBe(true);
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		expect(manager.resumeSubagent("A")).toMatchObject({ ok: false, reason: "owner_shutdown_in_progress" });
+		b.release();
+		await manager.waitForAll();
+		expect(manager.getSubagentRecord("A")?.status).toBe("queued");
+		expect(manager.getSubagentRecord("C")?.status).toBe("completed");
+		expect(completions.map(completion => completion.text)).toContain("resumed:C");
+		const proof = await manager.cancelAndProveOwnerSubagents(lease, { timeoutMs: 50 });
+		expect(proof).toMatchObject({ confirmed: true, terminalIds: ["A"], unresolvedIds: [] });
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		await manager.dispose({ timeoutMs: 500 });
+	});
+
 	test("cancelSubagent on a paused subagent marks cancelled but keeps the record (AC10)", async () => {
 		const { manager } = makeManager();
 		const a = spawnControllable(manager, "A");

--- a/packages/coding-agent/test/async/owner-subagent-shutdown.test.ts
+++ b/packages/coding-agent/test/async/owner-subagent-shutdown.test.ts
@@ -1,0 +1,492 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AsyncJobManager,
+	OWNER_SUBAGENT_SHUTDOWN_TIMEOUT_MS,
+	OwnerSubagentShutdownError,
+	type SubagentRunOutcome,
+} from "@gajae-code/coding-agent/async/job-manager";
+
+function makeManager(maxRunningJobs = 4): AsyncJobManager {
+	return new AsyncJobManager({ onJobComplete: async () => {}, maxRunningJobs, retentionMs: 60_000 });
+}
+
+function registerCooperativeSubagent(manager: AsyncJobManager, subagentId: string, ownerId: string): string {
+	const jobId = manager.register(
+		"task",
+		subagentId,
+		async ({ signal }): Promise<string> => {
+			await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+			return "cancelled cooperatively";
+		},
+		{
+			id: `${subagentId}-job`,
+			ownerId,
+			metadata: { subagent: { id: subagentId, agent: "executor", agentSource: "bundled" } },
+		},
+	);
+	manager.registerSubagentRecord({
+		subagentId,
+		ownerId,
+		currentJobId: jobId,
+		historicalJobIds: [],
+		status: "running",
+		sessionFile: `/tmp/${subagentId}.jsonl`,
+		resumable: true,
+	});
+	return jobId;
+}
+
+describe("owner subagent shutdown leases", () => {
+	test("exports the fixed timeout and fences only the leased owner", async () => {
+		expect(OWNER_SUBAGENT_SHUTDOWN_TIMEOUT_MS).toBe(5_000);
+		const manager = makeManager();
+		const lease = manager.beginOwnerSubagentShutdown("owner-a");
+		expect(lease).toBeDefined();
+		expect(manager.beginOwnerSubagentShutdown("owner-a")).toBeUndefined();
+		expect(() =>
+			manager.register("task", "blocked", async () => "no", {
+				ownerId: "owner-a",
+				metadata: { subagent: { id: "blocked", agent: "executor", agentSource: "bundled" } },
+			}),
+		).toThrow(OwnerSubagentShutdownError);
+		try {
+			manager.register("task", "blocked", async () => "no", {
+				ownerId: "owner-a",
+				metadata: { subagent: { id: "blocked", agent: "executor", agentSource: "bundled" } },
+			});
+		} catch (error) {
+			expect(error).toMatchObject({
+				code: "owner_shutdown_in_progress",
+				message: "Cannot start subagent while owner shutdown is in progress.",
+			});
+		}
+		const foreignJobId = manager.register(
+			"task",
+			"foreign",
+			async (): Promise<SubagentRunOutcome> => ({ kind: "completed", text: "ok" }),
+			{
+				ownerId: "owner-b",
+				metadata: { subagent: { id: "foreign", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		expect(foreignJobId).toMatch(/^bg_/);
+		manager.finishOwnerSubagentShutdown(lease!, "release");
+		await manager.dispose();
+	});
+
+	test("proves a captured running record by stable id and commit purges only its owner", async () => {
+		const manager = makeManager();
+		registerCooperativeSubagent(manager, "running", "owner-a");
+		registerCooperativeSubagent(manager, "foreign", "owner-b");
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		expect(lease.targets).toEqual([{ subagentId: "running", jobId: "running-job", source: "record" }]);
+		const proof = await manager.cancelAndProveOwnerSubagents(lease, { timeoutMs: 100 });
+		expect(proof).toMatchObject({
+			confirmed: true,
+			reason: "confirmed",
+			terminalIds: ["running"],
+			unresolvedIds: [],
+		});
+		manager.finishOwnerSubagentShutdown(lease, "commit");
+		expect(manager.getSubagentRecord("running")).toBeUndefined();
+		expect(manager.getSubagentRecord("foreign")?.status).toBe("running");
+		await manager.dispose();
+	});
+
+	test("proves a paused backing job and terminalizes its canonical record", async () => {
+		const manager = makeManager();
+		const jobId = manager.register("task", "paused", async (): Promise<SubagentRunOutcome> => ({ kind: "paused" }), {
+			ownerId: "owner-a",
+			metadata: { subagent: { id: "paused", agent: "executor", agentSource: "bundled" } },
+		});
+		await manager.waitForAll();
+		manager.registerSubagentRecord({
+			subagentId: "paused",
+			ownerId: "owner-a",
+			currentJobId: jobId,
+			historicalJobIds: [],
+			status: "paused",
+			sessionFile: "/tmp/paused.jsonl",
+			resumable: true,
+		});
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		const proof = await manager.cancelAndProveOwnerSubagents(lease, { timeoutMs: 50 });
+		expect(proof).toMatchObject({ confirmed: true, terminalIds: ["paused"] });
+		expect(manager.getSubagentRecord("paused")?.status).toBe("cancelled");
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		await manager.dispose();
+	});
+
+	test("proves a paused backing job with immediate retention eviction", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {}, retentionMs: 0 });
+		const jobId = manager.register(
+			"task",
+			"paused evicted",
+			async (): Promise<SubagentRunOutcome> => ({ kind: "paused" }),
+			{
+				ownerId: "owner-a",
+				metadata: { subagent: { id: "paused-evicted", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		await manager.waitForAll();
+		manager.registerSubagentRecord({
+			subagentId: "paused-evicted",
+			ownerId: "owner-a",
+			currentJobId: jobId,
+			historicalJobIds: [],
+			status: "paused",
+			sessionFile: "/tmp/paused-evicted.jsonl",
+			resumable: true,
+		});
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		const proof = await manager.cancelAndProveOwnerSubagents(lease, { timeoutMs: 50 });
+
+		expect(proof).toMatchObject({ confirmed: true, terminalIds: ["paused-evicted"], unresolvedIds: [] });
+		expect(manager.getSubagentRecord("paused-evicted")?.status).toBe("cancelled");
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		await manager.dispose();
+	});
+
+	test("captures metadata jobs registered before their canonical record and fails closed at the deadline", async () => {
+		const manager = makeManager();
+		const gate = Promise.withResolvers<void>();
+		const earlyJobId = manager.register(
+			"task",
+			"early",
+			async (): Promise<string> => {
+				await gate.promise;
+				return "late";
+			},
+			{
+				ownerId: "owner-a",
+				metadata: { subagent: { id: "early", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		expect(lease.targets).toEqual([{ subagentId: "early", jobId: earlyJobId, source: "metadata_job" }]);
+		const proof = await manager.cancelAndProveOwnerSubagents(lease, { timeoutMs: 0 });
+		expect(proof).toMatchObject({ confirmed: false, reason: "deadline_exceeded", unresolvedIds: ["early"] });
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		gate.resolve();
+		await manager.waitForAll();
+		await manager.dispose();
+	});
+
+	test("producer cleanup retains records while legacy cleanup remains destructive", async () => {
+		const manager = makeManager();
+		let cleaned = 0;
+		manager.registerSubagentRecord({
+			subagentId: "paused",
+			ownerId: "owner-a",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "paused",
+			sessionFile: "/tmp/paused.jsonl",
+			resumable: true,
+		});
+		manager.registerOwnerCleanup("owner-a", () => {
+			cleaned += 1;
+		});
+		manager.runOwnerProducerCleanups({ ownerId: "owner-a" });
+		expect(cleaned).toBe(1);
+		expect(manager.getSubagentRecord("paused")).toBeDefined();
+		manager.runOwnerCleanups({ ownerId: "owner-a" });
+		expect(manager.getSubagentRecord("paused")).toBeUndefined();
+		await manager.dispose();
+	});
+
+	test("retains a failed strict producer cleanup for a later retry", () => {
+		const manager = makeManager();
+		let attempts = 0;
+		manager.registerOwnerCleanup("owner-a", () => {
+			attempts += 1;
+			if (attempts === 1) throw new Error("cleanup failed");
+		});
+
+		expect(() => manager.runOwnerProducerCleanupsStrict({ ownerId: "owner-a" })).toThrow(
+			"Async job owner cleanup failed",
+		);
+		expect(() => manager.runOwnerProducerCleanupsStrict({ ownerId: "owner-a" })).not.toThrow();
+		expect(attempts).toBe(2);
+	});
+
+	test("holds owner deliveries during a lease, resumes on release, and suppresses on commit", async () => {
+		const delivered: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async jobId => {
+				delivered.push(jobId);
+			},
+			retentionMs: 60_000,
+		});
+		const releaseGate = Promise.withResolvers<string>();
+		const releaseJobId = manager.register("bash", "release delivery", async () => releaseGate.promise, {
+			ownerId: "owner-a",
+		});
+		const releaseLease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		releaseGate.resolve("release");
+		await manager.getJob(releaseJobId)?.promise;
+		await Bun.sleep(10);
+		expect(delivered).toEqual([]);
+		expect(manager.getDeliveryState({ ownerId: "owner-a" }).queued).toBe(1);
+		expect(await manager.drainDeliveries({ filter: { ownerId: "owner-a" }, timeoutMs: 5 })).toBe(false);
+		manager.finishOwnerSubagentShutdown(releaseLease, "release");
+		await manager.drainDeliveries({ filter: { ownerId: "owner-a" }, timeoutMs: 100 });
+		expect(delivered).toEqual([releaseJobId]);
+
+		const commitGate = Promise.withResolvers<string>();
+		const commitJobId = manager.register("bash", "commit delivery", async () => commitGate.promise, {
+			ownerId: "owner-a",
+		});
+		const commitLease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		const proof = await manager.cancelAndProveOwnerSubagents(commitLease, { timeoutMs: 100 });
+		expect(proof.confirmed).toBe(true);
+		commitGate.resolve("commit");
+		await manager.getJob(commitJobId)?.promise;
+		await Bun.sleep(10);
+		expect(manager.getDeliveryState({ ownerId: "owner-a" }).queued).toBe(1);
+		manager.finishOwnerSubagentShutdown(commitLease, "commit");
+		await Bun.sleep(10);
+		expect(delivered).toEqual([releaseJobId]);
+		expect(manager.getDeliveryState({ ownerId: "owner-a" }).queued).toBe(0);
+		await manager.dispose();
+	});
+
+	test("resumes owner delivery after settlement fails and the lease releases", async () => {
+		const delivered: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async jobId => {
+				delivered.push(jobId);
+			},
+			retentionMs: 60_000,
+		});
+		const deliveryGate = Promise.withResolvers<string>();
+		const deliveryJobId = manager.register("bash", "held delivery", async () => deliveryGate.promise, {
+			ownerId: "owner-a",
+		});
+		const stuckGate = Promise.withResolvers<string>();
+		const stuckJobId = manager.register("bash", "stuck settlement", async () => stuckGate.promise, {
+			ownerId: "owner-a",
+		});
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		const proof = await manager.cancelAndProveOwnerSubagents(lease, { timeoutMs: 100 });
+		expect(proof.confirmed).toBe(true);
+		deliveryGate.resolve("held completion");
+		await manager.getJob(deliveryJobId)?.promise;
+		await Bun.sleep(10);
+		expect(manager.getDeliveryState({ ownerId: "owner-a" }).queued).toBe(1);
+		expect(await manager.cancelAndSettleOwnerJobs("owner-a", { timeoutMs: 0 })).toBe(false);
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		await manager.drainDeliveries({ filter: { ownerId: "owner-a" }, timeoutMs: 100 });
+		expect(delivered).toEqual([deliveryJobId]);
+		stuckGate.resolve("late completion");
+		await manager.getJob(stuckJobId)?.promise;
+		await manager.dispose();
+	});
+
+	test("waits for an owner delivery that was already in flight when the lease began", async () => {
+		const deliveryStarted = Promise.withResolvers<void>();
+		const deliveryGate = Promise.withResolvers<void>();
+		const manager = new AsyncJobManager({
+			onJobComplete: async () => {
+				deliveryStarted.resolve();
+				await deliveryGate.promise;
+			},
+			retentionMs: 60_000,
+		});
+		const jobId = manager.register("bash", "in-flight delivery", async () => "done", { ownerId: "owner-a" });
+		await manager.getJob(jobId)?.promise;
+		await deliveryStarted.promise;
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+
+		expect(await manager.waitForOwnerInFlightDeliveries("owner-a", { timeoutMs: 0 })).toBe(false);
+		deliveryGate.resolve();
+		expect(await manager.waitForOwnerInFlightDeliveries("owner-a", { timeoutMs: 100 })).toBe(true);
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		await manager.dispose();
+	});
+
+	test("proves a queued record after its prior run was evicted", async () => {
+		const manager = makeManager();
+		manager.registerSubagentRecord({
+			subagentId: "queued-evicted",
+			ownerId: "owner-a",
+			currentJobId: "evicted-prior-run",
+			historicalJobIds: [],
+			status: "queued",
+			sessionFile: "/tmp/queued-evicted.jsonl",
+			resumable: true,
+		});
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		expect(lease.targets).toEqual([{ subagentId: "queued-evicted", jobId: null, source: "record" }]);
+		const proof = await manager.cancelAndProveOwnerSubagents(lease, { timeoutMs: 100 });
+		expect(proof).toMatchObject({ confirmed: true, terminalIds: ["queued-evicted"], unresolvedIds: [] });
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		await manager.dispose();
+	});
+
+	test("queues a watched completion and delivers it after unwatch", async () => {
+		const delivered: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async jobId => {
+				delivered.push(jobId);
+			},
+			retentionMs: 60_000,
+		});
+		const gate = Promise.withResolvers<string>();
+		const jobId = manager.register("task", "watched completion", async () => gate.promise, {
+			ownerId: "owner-a",
+			metadata: { subagent: { id: "watched", agent: "executor", agentSource: "bundled" } },
+		});
+		manager.watchJobs([jobId]);
+		gate.resolve("done while watched");
+		await manager.getJob(jobId)?.promise;
+		await Bun.sleep(10);
+		expect(delivered).toEqual([]);
+		manager.unwatchJobs([jobId]);
+		await manager.drainDeliveries({ filter: { ownerId: "owner-a" }, timeoutMs: 100 });
+		expect(delivered).toEqual([jobId]);
+		await manager.dispose();
+	});
+
+	test("acknowledging another job preserves a watched completion", async () => {
+		const delivered: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async jobId => {
+				delivered.push(jobId);
+			},
+			retentionMs: 60_000,
+		});
+		const watchedGate = Promise.withResolvers<string>();
+		const watchedJobId = manager.register("task", "watched A", async () => watchedGate.promise, {
+			id: "watched-a-job",
+			ownerId: "owner-a",
+			metadata: { subagent: { id: "watched-a", agent: "executor", agentSource: "bundled" } },
+		});
+		manager.watchJobs([watchedJobId]);
+		watchedGate.resolve("A complete");
+		await manager.getJob(watchedJobId)?.promise;
+
+		const acknowledgedJobId = manager.register("task", "acknowledged B", async () => "B complete", {
+			id: "acknowledged-b-job",
+			ownerId: "owner-a",
+			metadata: { subagent: { id: "acknowledged-b", agent: "executor", agentSource: "bundled" } },
+		});
+		await manager.getJob(acknowledgedJobId)?.promise;
+		manager.acknowledgeDeliveries([acknowledgedJobId]);
+		manager.unwatchJobs([watchedJobId]);
+		await manager.drainDeliveries({ filter: { ownerId: "owner-a" }, timeoutMs: 100 });
+
+		expect(delivered).toContain(watchedJobId);
+		await manager.dispose();
+	});
+
+	test("accepts settled captured work after immediate retention eviction", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {}, retentionMs: 0 });
+		registerCooperativeSubagent(manager, "evicted-running", "owner-a");
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		const proof = await manager.cancelAndProveOwnerSubagents(lease, { timeoutMs: 100 });
+
+		expect(proof).toMatchObject({ confirmed: true, terminalIds: ["evicted-running"], unresolvedIds: [] });
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		await manager.dispose();
+	});
+
+	test("captures a cancelled but unsettled metadata job and requires its canonical record", async () => {
+		const manager = makeManager();
+		const gate = Promise.withResolvers<void>();
+		const jobId = manager.register(
+			"task",
+			"cancelling",
+			async (): Promise<string> => {
+				await gate.promise;
+				return "late";
+			},
+			{
+				ownerId: "owner-a",
+				metadata: { subagent: { id: "cancelling", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.cancel(jobId, { ownerId: "owner-a" });
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		expect(lease.targets).toEqual([{ subagentId: "cancelling", jobId, source: "metadata_job" }]);
+		const proof = await manager.cancelAndProveOwnerSubagents(lease, { timeoutMs: 0 });
+		expect(proof).toMatchObject({ confirmed: false, unresolvedIds: ["cancelling"] });
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		gate.resolve();
+		await manager.waitForAll();
+		await manager.dispose();
+	});
+
+	test("fails missing terminal evidence when a metadata job settles without a canonical record", async () => {
+		const manager = makeManager();
+		const jobId = manager.register(
+			"task",
+			"unrecorded",
+			async ({ signal }): Promise<string> => {
+				await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+				return "cancelled";
+			},
+			{
+				ownerId: "owner-a",
+				metadata: { subagent: { id: "unrecorded", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		expect(lease.targets[0]?.jobId).toBe(jobId);
+		const proof = await manager.cancelAndProveOwnerSubagents(lease, { timeoutMs: 100 });
+		expect(proof).toMatchObject({
+			confirmed: false,
+			reason: "missing_terminal_evidence",
+			unresolvedIds: ["unrecorded"],
+		});
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		await manager.dispose();
+	});
+
+	test("treats every captured target as unresolved after lease loss", async () => {
+		const manager = makeManager();
+		registerCooperativeSubagent(manager, "owned", "owner-a");
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		await expect(manager.cancelAndProveOwnerSubagents(lease)).resolves.toMatchObject({
+			confirmed: false,
+			reason: "lease_lost",
+			unresolvedIds: ["owned"],
+		});
+		await manager.dispose();
+	});
+	test("fails closed for mixed cooperative and noncooperative children", async () => {
+		const manager = makeManager();
+		registerCooperativeSubagent(manager, "cooperative", "owner-a");
+		const gate = Promise.withResolvers<void>();
+		const stuckJobId = manager.register(
+			"task",
+			"stuck",
+			async (): Promise<string> => {
+				await gate.promise;
+				return "late";
+			},
+			{
+				ownerId: "owner-a",
+				metadata: { subagent: { id: "stuck", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.registerSubagentRecord({
+			subagentId: "stuck",
+			ownerId: "owner-a",
+			currentJobId: stuckJobId,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/stuck.jsonl",
+			resumable: true,
+		});
+		const lease = manager.beginOwnerSubagentShutdown("owner-a")!;
+		const proof = await manager.cancelAndProveOwnerSubagents(lease, { timeoutMs: 50 });
+		expect(proof).toMatchObject({ confirmed: false, unresolvedIds: ["stuck"] });
+		expect(proof.terminalIds).toEqual(["cooperative"]);
+		manager.finishOwnerSubagentShutdown(lease, "release");
+		gate.resolve();
+		await manager.waitForAll();
+		await manager.dispose();
+	});
+});

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -1,7 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
+import { AsyncJobManager } from "@gajae-code/coding-agent/async";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { InputController } from "@gajae-code/coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext, SubmittedUserInput } from "@gajae-code/coding-agent/modes/types";
+import { SubagentTool, type ToolSession } from "@gajae-code/coding-agent/tools";
 
 beforeAll(async () => {
 	resetSettingsForTest();
@@ -249,6 +251,50 @@ describe("InputController escape behavior", () => {
 		expect(spies.cancelPendingSubmission).toHaveBeenCalledTimes(1);
 		expect(spies.clearQueue).not.toHaveBeenCalled();
 		expect(spies.abort).not.toHaveBeenCalled();
+	});
+
+	it("interrupts a live subagent await through Esc without cancelling the child", async () => {
+		const { ctx, editor } = createContext();
+		const manager = new AsyncJobManager({ onJobComplete: async () => {}, retentionMs: 10_000 });
+		AsyncJobManager.setInstance(manager);
+		const child = Promise.withResolvers<string>();
+		const childJobId = manager.register("task", "live child", async () => child.promise, {
+			id: "job-input-controller-live-await",
+			ownerId: "0-Main",
+			metadata: { subagent: { id: "0-InputEsc", agent: "executor", agentSource: "bundled" } },
+		});
+		const parentAbort = new AbortController();
+		(ctx.session as { isStreaming: boolean; abort: () => Promise<void> }).isStreaming = true;
+		(ctx.session as { isStreaming: boolean; abort: () => Promise<void> }).abort = vi.fn(async () => {
+			parentAbort.abort();
+		});
+		const tool = new SubagentTool({
+			cwd: "/tmp",
+			hasUI: false,
+			settings: Settings.isolated({}),
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			getAgentId: () => "0-Main",
+		} as ToolSession);
+		const awaiting = tool.execute(
+			"input-controller-live-await",
+			{ action: "await", ids: ["0-InputEsc"], timeout_ms: 10_000 },
+			parentAbort.signal,
+		);
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		editor.onEscape?.();
+		const receipt = await awaiting;
+
+		expect(receipt.details?.interrupted).toBe(true);
+		expect(receipt.details?.awaitOutcome).toBe("interrupted");
+		expect(receipt.details?.subagents[0]?.status).toBe("running");
+		expect(manager.getJob(childJobId)?.status).toBe("running");
+		child.resolve("completed after Esc");
+		await manager.getJob(childJobId)?.promise;
+		await manager.dispose({ timeoutMs: 100 });
+		AsyncJobManager.resetForTests();
 	});
 
 	it("runs /btw as a builtin side request instead of steering the active stream", async () => {

--- a/packages/coding-agent/test/interactive-mode-issue-2261-new-session.test.ts
+++ b/packages/coding-agent/test/interactive-mode-issue-2261-new-session.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { resolveLocalUrlToPath } from "@gajae-code/coding-agent/internal-urls";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { TempDir } from "@gajae-code/utils";
+import { ModelRegistry } from "../src/config/model-registry";
+import type { ExtensionCommandContextActions } from "../src/extensibility/extensions";
+import { BtwController } from "../src/modes/controllers/btw-controller";
+import { CommandController } from "../src/modes/controllers/command-controller";
+import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
+import { InteractiveMode } from "../src/modes/interactive-mode";
+import type { InteractiveModeContext } from "../src/modes/types";
+import { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { SessionManager } from "../src/session/session-manager";
+import { executeBuiltinSlashCommand } from "../src/slash-commands/builtin-registry";
+
+describe("Issue #2261 InteractiveMode session-switch preparation", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-issue-2261-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		mode?.stop();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	async function renderPlanReview(): Promise<void> {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPath, "# Plan\n\nKeep this review open.");
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		vi.spyOn(mode, "showHookSelector").mockResolvedValue("Refine plan");
+		vi.spyOn(session, "abort").mockResolvedValue(undefined);
+		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN", finalPlanFilePath: planFilePath });
+	}
+
+	for (const [command, method] of [
+		["/new", "handleClearCommand"],
+		["/drop", "handleDropCommand"],
+	] as const) {
+		it(`keeps BTW, extension terminal listeners, and the rendered plan review alive when ${command} is cancelled`, async () => {
+			const commandResult = vi.spyOn(CommandController.prototype, method).mockResolvedValue(false);
+			const disposeBtw = vi.spyOn(BtwController.prototype, "dispose");
+			const cleanupPreviousSessionUi = vi.fn();
+			const captureSessionUiCleanup = vi
+				.spyOn(ExtensionUiController.prototype, "captureSessionUiCleanup")
+				.mockReturnValue(cleanupPreviousSessionUi);
+			await renderPlanReview();
+			const review = mode.chatContainer.children.at(-1);
+
+			const handled = await executeBuiltinSlashCommand(command, {
+				ctx: mode as never,
+				handleBackgroundCommand: () => {},
+			});
+			expect(handled).toBe(true);
+
+			expect(commandResult).toHaveBeenCalledTimes(1);
+			expect(disposeBtw).not.toHaveBeenCalled();
+			expect(captureSessionUiCleanup).toHaveBeenCalledTimes(1);
+			expect(cleanupPreviousSessionUi).not.toHaveBeenCalled();
+			expect(mode.chatContainer.children.at(-1)).toBe(review);
+		});
+
+		it(`prepares the session switch exactly once after ${command} succeeds`, async () => {
+			const commandResult = vi.spyOn(CommandController.prototype, method).mockResolvedValue(true);
+			const disposeBtw = vi.spyOn(BtwController.prototype, "dispose");
+			const cleanupPreviousSessionUi = vi.fn();
+			const captureSessionUiCleanup = vi
+				.spyOn(ExtensionUiController.prototype, "captureSessionUiCleanup")
+				.mockReturnValue(cleanupPreviousSessionUi);
+
+			const handled = await executeBuiltinSlashCommand(command, {
+				ctx: mode as never,
+				handleBackgroundCommand: () => {},
+			});
+			expect(handled).toBe(true);
+
+			expect(commandResult).toHaveBeenCalledTimes(1);
+			expect(disposeBtw).toHaveBeenCalledTimes(1);
+			expect(captureSessionUiCleanup).toHaveBeenCalledTimes(1);
+			expect(cleanupPreviousSessionUi).toHaveBeenCalledTimes(1);
+		});
+	}
+
+	it("keeps /context clear eagerly prepared on its separate session contract", async () => {
+		const contextClear = vi
+			.spyOn(CommandController.prototype, "handleContextClearCommand")
+			.mockResolvedValue(undefined);
+		const disposeBtw = vi.spyOn(BtwController.prototype, "dispose");
+		const clearExtensionListeners = vi.spyOn(ExtensionUiController.prototype, "clearExtensionTerminalInputListeners");
+
+		await mode.handleContextClearCommand();
+
+		expect(contextClear).toHaveBeenCalledTimes(1);
+		expect(disposeBtw).toHaveBeenCalledTimes(1);
+		expect(clearExtensionListeners).toHaveBeenCalledTimes(1);
+	});
+});
+
+let commandActions: ExtensionCommandContextActions | undefined;
+
+function createExtensionContext(success: boolean): {
+	context: InteractiveModeContext;
+	unsubscribePreviousListener: ReturnType<typeof vi.fn>;
+	unsubscribeSuccessorListener: ReturnType<typeof vi.fn>;
+} {
+	const unsubscribePreviousListener = vi.fn();
+	const unsubscribeSuccessorListener = vi.fn();
+	const context = {
+		session: {
+			newSession: vi.fn(async () => success),
+			agent: { waitForIdle: vi.fn() },
+			extensionRunner: {
+				hasHandlers: () => false,
+				initialize: (_actions: unknown, _context: unknown, commands: ExtensionCommandContextActions) => {
+					commandActions = commands;
+				},
+			},
+		},
+		loadingAnimation: { stop: vi.fn() },
+		statusContainer: { clear: vi.fn() },
+		resetIrcSidebarSession: vi.fn(),
+		statusLine: { invalidate: vi.fn(), setSessionStartTime: vi.fn() },
+		updateEditorTopBorder: vi.fn(),
+		ui: {
+			requestRender: vi.fn(),
+			resetViewportAnchorIntent: vi.fn(),
+			addInputListener: vi
+				.fn()
+				.mockReturnValueOnce(unsubscribePreviousListener)
+				.mockReturnValue(unsubscribeSuccessorListener),
+		},
+		chatContainer: { clear: vi.fn(), addChild: vi.fn() },
+		pendingMessagesContainer: { clear: vi.fn() },
+		compactionQueuedMessages: [{ text: "queued", mode: "followUp" }],
+		pendingTools: new Map([["old-tool", {}]]),
+		reloadTodos: vi.fn(),
+		sessionManager: { getSessionName: () => "old", getCwd: () => "/old" },
+	} as unknown as InteractiveModeContext;
+	return { context, unsubscribePreviousListener, unsubscribeSuccessorListener };
+}
+
+describe("Issue #2261 extension session.new", () => {
+	afterEach(() => {
+		commandActions = undefined;
+	});
+
+	for (const success of [false, true]) {
+		it(`${success ? "tears down only predecessor" : "retains"} extension terminal listeners and the compaction queue when replacement ${success ? "succeeds" : "fails"}`, async () => {
+			const { context, unsubscribePreviousListener, unsubscribeSuccessorListener } = createExtensionContext(success);
+			const controller = new ExtensionUiController(context);
+			const stopLoading = context.loadingAnimation?.stop;
+			controller.initializeHookRunner({} as never, true);
+			controller.addExtensionTerminalInputListener(() => undefined);
+			(context.session.newSession as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+				if (success) controller.addExtensionTerminalInputListener(() => undefined);
+				return success;
+			});
+			if (!commandActions) throw new Error("Expected extension command actions");
+
+			const result = await commandActions.newSession();
+			expect(result).toEqual({ cancelled: !success });
+
+			expect(context.session.newSession).toHaveBeenCalledTimes(1);
+			expect(unsubscribePreviousListener).toHaveBeenCalledTimes(success ? 1 : 0);
+			expect(unsubscribeSuccessorListener).not.toHaveBeenCalled();
+			expect(stopLoading).toHaveBeenCalledTimes(success ? 1 : 0);
+			expect(context.statusContainer.clear).toHaveBeenCalledTimes(success ? 1 : 0);
+			expect(context.chatContainer.clear).toHaveBeenCalledTimes(success ? 1 : 0);
+			expect(context.pendingMessagesContainer.clear).toHaveBeenCalledTimes(success ? 1 : 0);
+			expect(context.compactionQueuedMessages).toEqual(success ? [] : [{ text: "queued", mode: "followUp" }]);
+			expect(context.pendingTools.has("old-tool")).toBe(!success);
+			expect(context.reloadTodos).toHaveBeenCalledTimes(success ? 1 : 0);
+		});
+	}
+});

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -159,7 +159,7 @@ describe("InteractiveMode plan review rendering", () => {
 		mode.planModeEnabled = true;
 		mode.planModePlanFilePath = planFilePath;
 		vi.spyOn(mode, "showHookSelector").mockResolvedValue("Approve and keep context");
-		const clear = vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+		const clear = vi.spyOn(mode, "handleClearCommand").mockResolvedValue(true);
 		const prompt = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
 
 		await mode.handlePlanApproval({
@@ -188,7 +188,7 @@ describe("InteractiveMode plan review rendering", () => {
 		mode.planModeEnabled = true;
 		mode.planModePlanFilePath = planFilePath;
 		vi.spyOn(mode, "showHookSelector").mockResolvedValue("Approve and execute");
-		const clear = vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+		const clear = vi.spyOn(mode, "handleClearCommand").mockResolvedValue(true);
 		const prompt = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
 
 		await mode.handlePlanApproval({
@@ -202,6 +202,35 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(prompt).toHaveBeenCalledWith(expect.any(String), {
 			synthetic: true,
 		});
+	});
+
+	it("does not dispatch an approved plan when fresh-session creation is refused", async () => {
+		const planFilePath = "local://PLAN.md";
+		const finalPlanFilePath = "local://APPROVED.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nDo not dispatch in the retained session.");
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		vi.spyOn(mode, "showHookSelector").mockResolvedValue("Approve and execute");
+		const clear = vi.spyOn(mode, "handleClearCommand").mockResolvedValue(false);
+		const prompt = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+		const warning = vi.spyOn(mode, "showWarning");
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "PLAN",
+			finalPlanFilePath,
+		});
+
+		expect(clear).toHaveBeenCalledTimes(1);
+		expect(prompt).not.toHaveBeenCalledWith(expect.any(String), { synthetic: true });
+		expect(warning).toHaveBeenCalledWith(
+			"Plan approved, but the new session could not be created — execution was not dispatched.",
+		);
 	});
 
 	it("Approve and compact context: ok outcome dispatches plan-approved after compaction", async () => {

--- a/packages/coding-agent/test/modes/controllers/issue-2261-new-session-fail-closed.test.ts
+++ b/packages/coding-agent/test/modes/controllers/issue-2261-new-session-fail-closed.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { CommandController } from "../../../src/modes/controllers/command-controller";
+import { initTheme } from "../../../src/modes/theme/theme";
+import type { InteractiveModeContext } from "../../../src/modes/types";
+
+function createContext(success: boolean): InteractiveModeContext {
+	return {
+		session: { newSession: vi.fn(async () => success) },
+		loadingAnimation: { stop: vi.fn() },
+		statusContainer: { clear: vi.fn() },
+		resetIrcSidebarSession: vi.fn(),
+		resetObserverRegistry: vi.fn(),
+		sessionManager: {
+			getSessionFile: () => "/old/session.jsonl",
+			getSessionName: () => "old",
+			getCwd: () => "/old",
+		},
+		statusLine: { invalidate: vi.fn(), setSessionStartTime: vi.fn() },
+		updateEditorTopBorder: vi.fn(),
+		updateEditorBorderColor: vi.fn(),
+		ui: { requestRender: vi.fn(), resetViewportAnchorIntent: vi.fn() },
+		chatContainer: { clear: vi.fn(), addChild: vi.fn() },
+		pendingMessagesContainer: { clear: vi.fn() },
+		compactionQueuedMessages: [{ text: "old", mode: "followUp" }],
+		pendingTools: new Map([["old", {}]]),
+		reloadTodos: vi.fn(),
+		showError: vi.fn(),
+	} as unknown as InteractiveModeContext;
+}
+
+beforeAll(() => initTheme());
+
+describe("Issue #2261 CommandController fail-closed session replacement", () => {
+	for (const [label, invoke] of [
+		["/new", (controller: CommandController) => controller.handleClearCommand()],
+		["/drop", (controller: CommandController) => controller.handleDropCommand()],
+	] as const) {
+		it(`does not tear down the current UI or compaction queue when ${label} replacement fails`, async () => {
+			const context = createContext(false);
+			const controller = new CommandController(context);
+
+			await expect(invoke(controller)).resolves.toBe(false);
+
+			expect(context.session.newSession).toHaveBeenCalledTimes(1);
+			expect(context.loadingAnimation?.stop).not.toHaveBeenCalled();
+			expect(context.statusContainer.clear).not.toHaveBeenCalled();
+			expect(context.resetIrcSidebarSession).not.toHaveBeenCalled();
+			expect(context.chatContainer.clear).not.toHaveBeenCalled();
+			expect(context.pendingMessagesContainer.clear).not.toHaveBeenCalled();
+			expect(context.compactionQueuedMessages).toEqual([{ text: "old", mode: "followUp" }]);
+			expect(context.pendingTools.has("old")).toBe(true);
+		});
+
+		it(`tears down the old UI and compaction queue exactly once when ${label} replacement succeeds`, async () => {
+			const context = createContext(true);
+			const controller = new CommandController(context);
+			const stopLoading = context.loadingAnimation?.stop;
+
+			const result = await invoke(controller);
+			expect(result).toBe(true);
+
+			expect(context.session.newSession).toHaveBeenCalledTimes(1);
+			expect(stopLoading).toHaveBeenCalledTimes(1);
+			expect(context.statusContainer.clear).toHaveBeenCalledTimes(1);
+			expect(context.resetIrcSidebarSession).toHaveBeenCalledTimes(1);
+			expect(context.chatContainer.clear).toHaveBeenCalledTimes(1);
+			expect(context.pendingMessagesContainer.clear).toHaveBeenCalledTimes(1);
+			expect(context.compactionQueuedMessages).toEqual([]);
+			expect(context.pendingTools.size).toBe(0);
+			expect(context.reloadTodos).toHaveBeenCalledTimes(1);
+		});
+	}
+
+	it("keeps /context clear on its separate eagerly prepared session contract", async () => {
+		const clearContext = vi.fn(async () => false);
+		const context = {
+			session: { clearContext, newSession: vi.fn(), isCompacting: false },
+			loadingAnimation: undefined,
+			statusContainer: { clear: vi.fn() },
+		} as unknown as InteractiveModeContext;
+		const controller = new CommandController(context);
+
+		await controller.handleContextClearCommand();
+
+		expect(clearContext).toHaveBeenCalledTimes(1);
+		expect(context.statusContainer.clear).toHaveBeenCalledTimes(1);
+		expect(context.session.newSession).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -3,7 +3,11 @@ import type { Theme } from "../../src/modes/theme/theme";
 import { getThemeByName, setThemeInstance } from "../../src/modes/theme/theme";
 import type { AgentProgress } from "../../src/task/types";
 import type { SubagentSnapshot, SubagentToolDetails } from "../../src/tools/subagent";
-import { subagentBodyCacheTestHooks, subagentToolRenderer } from "../../src/tools/subagent-render";
+import {
+	subagentAwaitRenderedStateSignature,
+	subagentBodyCacheTestHooks,
+	subagentToolRenderer,
+} from "../../src/tools/subagent-render";
 
 let theme: Theme;
 
@@ -270,6 +274,38 @@ describe("subagentToolRenderer", () => {
 		expect(out).toContain("Model: anthropic/claude-opus-4-8");
 		expect(out).toContain("requested openai-codex/gpt-5.5");
 		expect(out).toContain("fell back");
+	});
+});
+
+describe("interrupted await receipts", () => {
+	it("renders the interruption state and bounded sanitized active guidance", () => {
+		const unsafeGuidance = `Inspect\t${"x".repeat(400)}`;
+		const details: SubagentToolDetails = {
+			interrupted: true,
+			awaitOutcome: "interrupted",
+			subagents: [
+				snapshot({ id: "0-Running\tUnsafe", status: "running", guidance: unsafeGuidance }),
+				snapshot({ id: "0-Terminal", status: "completed" }),
+			],
+		};
+		const out = render(details);
+
+		expect(out).toContain("Subagent await interrupted");
+		expect(out).toContain("child subagents continue");
+		expect(out).toMatch(/0-Running\s+Unsafe/);
+		expect(out).not.toContain("\t");
+		expect(out).not.toContain("x".repeat(200));
+		expect(out).not.toContain("0-Terminal\n  Inspect");
+	});
+
+	it("includes changed interruption guidance in the receipt signature and body cache key", () => {
+		const active = snapshot({ id: "0-Await", guidance: "Await interrupted; inspect it." });
+		const terminal = snapshot({ id: "0-Await", guidance: undefined });
+
+		expect(subagentAwaitRenderedStateSignature([active])).not.toBe(subagentAwaitRenderedStateSignature([terminal]));
+		expect(subagentAwaitRenderedStateSignature([terminal])).not.toBe(
+			subagentAwaitRenderedStateSignature([terminal], { awaitOutcome: "interrupted", interrupted: true }),
+		);
 	});
 });
 

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -107,6 +107,159 @@ describe("SubagentTool", () => {
 		await manager.dispose({ timeoutMs: 100 });
 	});
 
+	it("consumes a watched completion before unwatch can redeliver it", async () => {
+		const delivered: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async jobId => {
+				delivered.push(jobId);
+			},
+			retentionMs: 10_000,
+		});
+		AsyncJobManager.setInstance(manager);
+		const tool = new SubagentTool(createSession());
+		const gate = Promise.withResolvers<string>();
+		manager.register("task", "live completion", async () => gate.promise, {
+			id: "job-live-completion",
+			ownerId: "0-Main",
+			metadata: {
+				subagent: {
+					id: "0-LiveCompletion",
+					agent: "executor",
+					agentSource: "bundled",
+					description: "live completion",
+					assignment: "Complete while watched.",
+				},
+			},
+		});
+		setTimeout(() => gate.resolve("completed while watched"), 5);
+
+		const result = await tool.execute("subagent-await-live-completion", {
+			action: "await",
+			ids: ["0-LiveCompletion"],
+			timeout_ms: 100,
+		});
+		await Bun.sleep(10);
+
+		expect(result.details?.awaitOutcome).toBe("completed");
+		expect(result.details?.subagents[0]?.resultText).toContain("completed while watched");
+		expect(delivered).toEqual([]);
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("interrupts only a live parent await and leaves the child running", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const acknowledgeDeliveries = vi.spyOn(manager, "acknowledgeDeliveries");
+		const child = Promise.withResolvers<string>();
+		const jobId = manager.register("task", "interruptible subagent", async () => child.promise, {
+			id: "job-interruptible",
+			ownerId: "0-Main",
+			metadata: { subagent: { id: "0-Interruptible", agent: "executor", agentSource: "bundled" } },
+		});
+		const terminalJobId = manager.register("task", "already complete subagent", async () => "already complete", {
+			id: "job-already-complete",
+			ownerId: "0-Main",
+			metadata: { subagent: { id: "0-AlreadyComplete", agent: "executor", agentSource: "bundled" } },
+		});
+		await manager.getJob(terminalJobId)?.promise;
+
+		const controller = new AbortController();
+		const awaiting = tool.execute(
+			"subagent-await-interrupt",
+			{ action: "await", ids: ["0-Interruptible", "0-AlreadyComplete"], timeout_ms: 10_000 },
+
+			controller.signal,
+		);
+		controller.abort();
+		const receipt = await awaiting;
+
+		expect(receipt.details?.awaitOutcome).toBe("interrupted");
+		expect(receipt.details?.interrupted).toBe(true);
+		expect(receipt.details?.subagents[0]?.status).toBe("running");
+		expect(receipt.details?.subagents[0]?.guidance).toContain("continues");
+		expect(receipt.details?.subagents.find(snapshot => snapshot.id === "0-AlreadyComplete")?.status).toBe(
+			"completed",
+		);
+		expect(
+			receipt.details?.subagents.find(snapshot => snapshot.id === "0-AlreadyComplete")?.guidance,
+		).toBeUndefined();
+		expect(getText(receipt)).toContain("Subagent await interrupted");
+		expect(manager.getJob(jobId)?.status).toBe("running");
+		expect(acknowledgeDeliveries).not.toHaveBeenCalled();
+
+		child.resolve("child finished after parent interruption");
+		await manager.getJob(jobId)?.promise;
+		expect(manager.getJob(jobId)?.status).toBe("completed");
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("treats pre-aborted live awaits as interrupted but terminal-only awaits as ordinary", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const child = Promise.withResolvers<string>();
+		const liveJobId = manager.register("task", "live subagent", async () => child.promise, {
+			id: "job-pre-aborted-live",
+			ownerId: "0-Main",
+			metadata: { subagent: { id: "0-PreAbortedLive", agent: "executor", agentSource: "bundled" } },
+		});
+		const terminalJobId = manager.register("task", "terminal subagent", async () => "done", {
+			id: "job-pre-aborted-terminal",
+			ownerId: "0-Main",
+			metadata: { subagent: { id: "0-PreAbortedTerminal", agent: "executor", agentSource: "bundled" } },
+		});
+		await manager.getJob(terminalJobId)?.promise;
+		const controller = new AbortController();
+		controller.abort();
+
+		const live = await tool.execute(
+			"subagent-await-pre-aborted-live",
+			{ action: "await", ids: ["0-PreAbortedLive"], timeout_ms: 10_000 },
+			controller.signal,
+		);
+		const terminal = await tool.execute(
+			"subagent-await-pre-aborted-terminal",
+			{ action: "await", ids: ["0-PreAbortedTerminal"], timeout_ms: 10_000 },
+			controller.signal,
+		);
+
+		expect(live.details?.awaitOutcome).toBe("interrupted");
+		expect(live.details?.interrupted).toBe(true);
+		expect(manager.getJob(liveJobId)?.status).toBe("running");
+		expect(terminal.details?.awaitOutcome).toBeUndefined();
+		expect(terminal.details?.interrupted).toBeUndefined();
+
+		child.resolve("done");
+		await manager.getJob(liveJobId)?.promise;
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("uses the final stable-id snapshot when completion wins the await race", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const child = Promise.withResolvers<string>();
+		const jobId = manager.register("task", "race subagent", async () => child.promise, {
+			id: "job-race",
+			ownerId: "0-Main",
+			metadata: { subagent: { id: "0-Race", agent: "executor", agentSource: "bundled" } },
+		});
+		const controller = new AbortController();
+		const awaiting = tool.execute(
+			"subagent-await-race",
+			{ action: "await", ids: ["0-Race"], timeout_ms: 10_000 },
+			controller.signal,
+		);
+		child.resolve("final result");
+		await manager.getJob(jobId)?.promise;
+		const receipt = await awaiting;
+		controller.abort();
+
+		expect(receipt.details?.awaitOutcome).toBe("completed");
+		expect(receipt.details?.interrupted).toBeUndefined();
+		expect(receipt.details?.subagents[0]?.status).toBe("completed");
+		expect(receipt.details?.subagents[0]?.resultText).toContain("final result");
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
 	it("await timeout is non-terminal and guides continued observation instead of shutdown", async () => {
 		const manager = createManager();
 		const tool = new SubagentTool(createSession());
@@ -140,6 +293,8 @@ describe("SubagentTool", () => {
 		const guidance = result.details?.subagents[0]?.guidance ?? "";
 
 		expect(result.details?.subagents[0]?.status).toBe("running");
+		expect(result.details?.awaitOutcome).toBe("timed_out");
+		expect(result.details?.interrupted).toBeUndefined();
 		expect(guidance).toContain("Still running");
 		expect(guidance).toContain("not a failure");
 		expect(guidance).toContain("never cancel just because an await timed out");


### PR DESCRIPTION
## Summary
- make Esc interrupt only the parent subagent await while child work continues
- require owner-scoped terminal cleanup proof before `/new` or `/drop` replaces session identity
- fence owner admissions and deliveries through the session transition and fail closed on cleanup uncertainty
- add focused manager, session, slash-command, plan-review, and InputController/TUI regression coverage

Closes #2261

## Verification
- `bun test` focused Issue #2261 matrix: 186 pass, 0 fail
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- `git diff --check`