### PR TITLE
Persist the last selected model preset

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Fixed
 - Discord inbound lease recovery now exposes a deterministic scheduler seam, preserves exponential retry wakeups after transient endpoint lookup failures, and cancels pending recovery exactly on daemon stop instead of relying on wall-clock sleeps in regression coverage.
+- Selecting a `/model` preset now persists it as the default, so the preset is restored on fresh startup and after `/new`.
+
+## [0.11.0] - 2026-07-15
+
+### Fixed
 - Input-free interactive TTY startup now keeps the TUI reachable when configured model profiles are missing required provider credentials, skips only the blocked profiles, and preserves later `--mpreset` and explicit model/thinking precedence; redirected terminals, input-bearing, resume-continuation, image-only, print/text, and unrelated activation failures remain fail-closed (#2277).
 - Windows Bun runtimes no longer crash while committing the durable workflow-gate store when directory `fsync` reports the unsupported-operation code `EPERM`; unexpected directory-sync failures remain fail-closed.
 - Browser geo settings now propagate coherently across request `Accept-Language`, navigator languages, and `Intl` locale/timezone surfaces; configured managed browsers are isolated by geo/profile posture, concurrent acquisition is serialized, and unset geo preserves Chromium's native locale/timezone instead of injecting a fixed New York profile.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,11 +4,9 @@
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
 
-## [0.11.0] - 2026-07-15
-
 ### Fixed
 - Discord inbound lease recovery now exposes a deterministic scheduler seam, preserves exponential retry wakeups after transient endpoint lookup failures, and cancels pending recovery exactly on daemon stop instead of relying on wall-clock sleeps in regression coverage.
-- Selecting a `/model` preset now persists it as the default, so the preset is restored on fresh startup and after `/new`.
+- Selecting a `/model` preset defaults to durable persistence (`Set as default`), while `Apply for this session` remains available for session-only activation.
 
 ## [0.11.0] - 2026-07-15
 

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -218,8 +218,8 @@ const PROFILE_ROLE_PREVIEW_ORDER: GjcModelAssignmentTargetId[] = [
 	"critic",
 	"architect",
 ];
-const PRESET_SCOPE_LABELS = ["Apply for this session", "Set as default"];
-const CUSTOM_PRESET_SCOPE_LABELS = ["Apply for this session", "Set as default", "Rename", "Delete"];
+const PRESET_SCOPE_LABELS = ["Set as default"];
+const CUSTOM_PRESET_SCOPE_LABELS = ["Set as default", "Rename", "Delete"];
 
 function isPrintableCharacter(keyData: string): boolean {
 	return keyData.length === 1 && keyData >= " " && keyData !== "\x7f";
@@ -1220,7 +1220,7 @@ export class ModelSelectorComponent extends Container {
 				);
 			}
 		} else {
-			this.#listContainer.addChild(new Text(theme.fg("muted", "  Press Enter to apply this preset"), 0, 0));
+			this.#listContainer.addChild(new Text(theme.fg("muted", "  Press Enter to choose an action"), 0, 0));
 		}
 	}
 
@@ -1606,11 +1606,11 @@ export class ModelSelectorComponent extends Container {
 		if (this.#presetScopeMenuOpen && this.#previewProfileName) {
 			const profile = this.#getProfileByName(this.#previewProfileName);
 			if (!profile) return;
-			if (this.#presetScopeIndex === 2 && isCustomUserProfile(profile)) {
+			if (this.#presetScopeIndex === 1 && isCustomUserProfile(profile)) {
 				this.#onSelectCallback({ kind: "renameProfile", profileName: this.#previewProfileName });
 				return;
 			}
-			if (this.#presetScopeIndex === 3 && isCustomUserProfile(profile)) {
+			if (this.#presetScopeIndex === 2 && isCustomUserProfile(profile)) {
 				this.#onSelectCallback({ kind: "deleteProfile", profileName: this.#previewProfileName });
 				return;
 			}
@@ -1623,7 +1623,7 @@ export class ModelSelectorComponent extends Container {
 			this.#onSelectCallback({
 				kind: "profile",
 				profileName: this.#previewProfileName,
-				setDefault: this.#presetScopeIndex === 1,
+				setDefault: true,
 			});
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -218,8 +218,8 @@ const PROFILE_ROLE_PREVIEW_ORDER: GjcModelAssignmentTargetId[] = [
 	"critic",
 	"architect",
 ];
-const PRESET_SCOPE_LABELS = ["Set as default"];
-const CUSTOM_PRESET_SCOPE_LABELS = ["Set as default", "Rename", "Delete"];
+const PRESET_SCOPE_LABELS = ["Set as default", "Apply for this session"];
+const CUSTOM_PRESET_SCOPE_LABELS = ["Set as default", "Apply for this session", "Rename", "Delete"];
 
 function isPrintableCharacter(keyData: string): boolean {
 	return keyData.length === 1 && keyData >= " " && keyData !== "\x7f";
@@ -1606,11 +1606,11 @@ export class ModelSelectorComponent extends Container {
 		if (this.#presetScopeMenuOpen && this.#previewProfileName) {
 			const profile = this.#getProfileByName(this.#previewProfileName);
 			if (!profile) return;
-			if (this.#presetScopeIndex === 1 && isCustomUserProfile(profile)) {
+			if (this.#presetScopeIndex === 2 && isCustomUserProfile(profile)) {
 				this.#onSelectCallback({ kind: "renameProfile", profileName: this.#previewProfileName });
 				return;
 			}
-			if (this.#presetScopeIndex === 2 && isCustomUserProfile(profile)) {
+			if (this.#presetScopeIndex === 3 && isCustomUserProfile(profile)) {
 				this.#onSelectCallback({ kind: "deleteProfile", profileName: this.#previewProfileName });
 				return;
 			}
@@ -1623,7 +1623,7 @@ export class ModelSelectorComponent extends Container {
 			this.#onSelectCallback({
 				kind: "profile",
 				profileName: this.#previewProfileName,
-				setDefault: true,
+				setDefault: this.#presetScopeIndex === 0,
 			});
 			return;
 		}

--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -196,11 +196,11 @@ describe("preset landing adversarial QA", () => {
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n"); // preview first expanded profile
 		selector.handleInput("\n"); // scope menu
-		expect(normalizeRenderedText(selector.render(260).join("\n"))).toContain("Apply for this session");
+		expect(normalizeRenderedText(selector.render(260).join("\n"))).toContain("Set as default");
 
 		selector.handleInput("\x1b");
 		let text = normalizeRenderedText(selector.render(260).join("\n"));
-		expect(text).not.toContain("Apply for this session");
+		expect(text).not.toContain("Set as default");
 		expect(text).toContain("Preset preview: Codex Eco");
 
 		selector.handleInput("\x1b");
@@ -229,7 +229,7 @@ describe("preset landing adversarial QA", () => {
 		expect(text).toContain("Models");
 		expect(text).toContain("gpt-5.5");
 		expect(text).not.toContain("Preset preview:");
-		expect(text).not.toContain("Apply for this session");
+		expect(text).not.toContain("Set as default");
 	});
 
 	test("up/down wraps at landing boundaries and Browse all preserves model role menu", async () => {

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -135,7 +135,7 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 	return { ctx, settings, session, flush, setCalls, overrideCalls };
 }
 
-async function selectProfileThroughController(controller: SelectorController, setDefault = false): Promise<void> {
+async function selectProfileThroughController(controller: SelectorController, setDefault = true): Promise<void> {
 	controller.showModelSelector();
 	const selector = (controller as unknown as { ctx: { editorContainer: { addChild: ReturnType<typeof vi.fn> } } }).ctx
 		.editorContainer.addChild.mock.calls[0]?.[0] as ModelSelectorComponent;
@@ -178,45 +178,24 @@ describe("model selector profile red-team", () => {
 		expect(rendered.match(/Profile Alpha/g) ?? []).toHaveLength(1);
 	});
 
-	test("profile actions wire Apply for this session to persistDefault false and Set as default to true", async () => {
+	test("profile actions expose only Set as default", async () => {
 		const selections: ModelSelectorSelection[] = [];
-		const applySelector = createSelector(selection => {
+		const selector = createSelector(selection => {
 			selections.push(selection);
 		});
-		await renderSelector(applySelector);
-		applySelector.handleInput("\x1b[C");
-		applySelector.handleInput("\x1b[B");
-		applySelector.handleInput("\n");
-		applySelector.handleInput("\n");
-		applySelector.handleInput("\n");
+		await renderSelector(selector);
+		selector.handleInput("\x1b[C");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		selector.handleInput("\n");
 
-		const defaultSelector = createSelector(selection => {
-			selections.push(selection);
-		});
-		await renderSelector(defaultSelector);
-		defaultSelector.handleInput("\x1b[C");
-		defaultSelector.handleInput("\x1b[B");
-		defaultSelector.handleInput("\n");
-		defaultSelector.handleInput("\n");
-		defaultSelector.handleInput("\x1b[B");
-		defaultSelector.handleInput("\n");
-
-		expect(selections).toEqual([
-			{ kind: "profile", profileName: "profile-a", setDefault: false },
-			{ kind: "profile", profileName: "profile-a", setDefault: true },
-		]);
+		expect(selections).toEqual([{ kind: "profile", profileName: "profile-a", setDefault: true }]);
 	});
 
-	test("controller persists only Set as default and leaves Apply for this session non-default", async () => {
-		const sessionOnly = createControllerContext();
-		await selectProfileThroughController(new SelectorController(sessionOnly.ctx as never), false);
-
-		expect(sessionOnly.setCalls).not.toContainEqual({ path: "modelProfile.default", value: "profile-a" });
-		expect(sessionOnly.settings.get("modelProfile.default")).toBe("old-profile");
-		expect(sessionOnly.ctx.showStatus).toHaveBeenCalledWith("Model profile: Profile Alpha");
-
+	test("controller persists a selected profile as the default", async () => {
 		const persistent = createControllerContext();
-		await selectProfileThroughController(new SelectorController(persistent.ctx as never), true);
+		await selectProfileThroughController(new SelectorController(persistent.ctx as never));
 
 		expect(persistent.setCalls).toContainEqual({ path: "modelProfile.default", value: "profile-a" });
 		expect(persistent.setCalls).toContainEqual({ path: "defaultThinkingLevel", value: ThinkingLevel.High });

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -178,19 +178,65 @@ describe("model selector profile red-team", () => {
 		expect(rendered.match(/Profile Alpha/g) ?? []).toHaveLength(1);
 	});
 
-	test("profile actions expose only Set as default", async () => {
+	test("profile actions default to persistence and retain session-only application", async () => {
 		const selections: ModelSelectorSelection[] = [];
-		const selector = createSelector(selection => {
+		const select = (selection: ModelSelectorSelection) => {
 			selections.push(selection);
-		});
-		await renderSelector(selector);
-		selector.handleInput("\x1b[C");
-		selector.handleInput("\x1b[B");
-		selector.handleInput("\n");
-		selector.handleInput("\n");
-		selector.handleInput("\n");
+		};
+		const persistentSelector = createSelector(select);
+		await renderSelector(persistentSelector);
+		persistentSelector.handleInput("\x1b[C");
+		persistentSelector.handleInput("\x1b[B");
+		persistentSelector.handleInput("\n");
+		persistentSelector.handleInput("\n");
 
-		expect(selections).toEqual([{ kind: "profile", profileName: "profile-a", setDefault: true }]);
+		const menu = normalizeRenderedText(persistentSelector.render(240).join("\n"));
+		expect(menu).toContain("Set as default");
+		expect(menu).toContain("Apply for this session");
+
+		persistentSelector.handleInput("\n");
+
+		const sessionSelector = createSelector(select);
+		await renderSelector(sessionSelector);
+		sessionSelector.handleInput("\x1b[C");
+		sessionSelector.handleInput("\x1b[B");
+		sessionSelector.handleInput("\n");
+		sessionSelector.handleInput("\n");
+		sessionSelector.handleInput("\x1b[B");
+		sessionSelector.handleInput("\n");
+
+		expect(selections).toEqual([
+			{ kind: "profile", profileName: "profile-a", setDefault: true },
+			{ kind: "profile", profileName: "profile-a", setDefault: false },
+		]);
+	});
+
+	test("custom profile action indices retain rename and delete after session application", async () => {
+		const renamed: ModelSelectorSelection[] = [];
+		const renameSelector = createSelector(selection => {
+			renamed.push(selection);
+		});
+		await renderSelector(renameSelector);
+		renameSelector.refreshPresetProfiles("profile-a");
+		renameSelector.handleInput("\n");
+		renameSelector.handleInput("\x1b[B");
+		renameSelector.handleInput("\x1b[B");
+		renameSelector.handleInput("\n");
+
+		const deleted: ModelSelectorSelection[] = [];
+		const deleteSelector = createSelector(selection => {
+			deleted.push(selection);
+		});
+		await renderSelector(deleteSelector);
+		deleteSelector.refreshPresetProfiles("profile-a");
+		deleteSelector.handleInput("\n");
+		deleteSelector.handleInput("\x1b[B");
+		deleteSelector.handleInput("\x1b[B");
+		deleteSelector.handleInput("\x1b[B");
+		deleteSelector.handleInput("\n");
+
+		expect(renamed).toEqual([{ kind: "renameProfile", profileName: "profile-a" }]);
+		expect(deleted).toEqual([{ kind: "deleteProfile", profileName: "profile-a" }]);
 	});
 
 	test("controller persists a selected profile as the default", async () => {

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -402,6 +402,17 @@ describe("model selector profiles", () => {
 		expect(flush).toHaveBeenCalledTimes(1);
 		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
 	});
+	test("Apply for this session does not persist the selected profile", async () => {
+		const { ctx, settings, session, flush, setCalls } = createControllerContext();
+		const controller = new SelectorController(ctx as never);
+		await selectFirstProfile(controller, false);
+
+		expect(session.setModelTemporaryCalls).toHaveLength(1);
+		expect(session.model).toBe(defaultModel);
+		expect(settings.get("modelProfile.default")).toBe("old-profile");
+		expect(setCalls).toEqual([]);
+		expect(flush).not.toHaveBeenCalled();
+	});
 
 	test("credential failure shows error and leaves model and overrides unchanged", async () => {
 		const { ctx, settings, session } = createControllerContext({ missingCredentials: true });

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -137,7 +137,7 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 	return { ctx, settings, session, flush, setCalls };
 }
 
-async function selectFirstProfile(controller: SelectorController, setDefault = false): Promise<void> {
+async function selectFirstProfile(controller: SelectorController, setDefault = true): Promise<void> {
 	controller.showModelSelector();
 	const selector = (controller as unknown as { ctx: { editorContainer: { addChild: ReturnType<typeof vi.fn> } } }).ctx
 		.editorContainer.addChild.mock.calls[0]?.[0] as ModelSelectorComponent;
@@ -376,8 +376,8 @@ describe("model selector profiles", () => {
 		expect(rendered).not.toContain("DEFAULT: provider-a/default");
 	});
 
-	test("Apply for this session activates profile through setModelTemporary", async () => {
-		const { ctx, settings, session } = createControllerContext();
+	test("selecting a profile persists it as the default", async () => {
+		const { ctx, settings, session, flush, setCalls } = createControllerContext();
 		const controller = new SelectorController(ctx as never);
 		await selectFirstProfile(controller);
 
@@ -385,8 +385,10 @@ describe("model selector profiles", () => {
 		expect(session.model).toBe(defaultModel);
 		expect(session.thinkingLevel).toBe(ThinkingLevel.High);
 		expect(settings.get("task.agentModelOverrides")).toMatchObject({ executor: "provider-a/alternate" });
-		expect(settings.get("modelProfile.default")).toBe("old-profile");
-		expect(ctx.showStatus).toHaveBeenCalledWith("Model profile: Profile Alpha");
+		expect(settings.get("modelProfile.default")).toBe("profile-a");
+		expect(setCalls).toContainEqual({ path: "modelProfile.default", value: "profile-a" });
+		expect(flush).toHaveBeenCalledTimes(1);
+		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
 	});
 
 	test("Set as default persists and flushes modelProfile.default", async () => {


### PR DESCRIPTION
## Summary

This PR makes `/model` preset selection durable by default while preserving session-only activation.

- presents **Set as default** as the first/default preset action
- keeps **Apply for this session** as the non-persistent alternative
- persists durable selections through the existing `modelProfile.default` setting
- allows the existing startup and `/new` flows to restore the last selected preset, including presets such as Codex Medium
- keeps custom preset rename and delete actions unchanged

## Verification

Rebased onto `dev` at `df4b59b14c44cd6e8052bb1d7f2dd776fb84ded6`; exact head `3ba64ea6363da99a5e2509bf407aa0e0f556726f`.

- `bun test packages/coding-agent/test/model-selector-profiles.test.ts packages/coding-agent/test/model-selector-profiles-redteam.test.ts packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts packages/coding-agent/test/cli-args-mpreset.test.ts` (79 passed)
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check` on all changed TypeScript files
- exact-head GitHub Actions checks passed

Thank you for taking the time to review this improvement.