### PR TITLE
fix(discord): make inbound lease recovery deterministic

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Discord inbound lease recovery now exposes a deterministic scheduler seam, preserves exponential retry wakeups after transient endpoint lookup failures, and cancels pending recovery exactly on daemon stop instead of relying on wall-clock sleeps in regression coverage.
 - Input-free interactive TTY startup now keeps the TUI reachable when configured model profiles are missing required provider credentials, skips only the blocked profiles, and preserves later `--mpreset` and explicit model/thinking precedence; redirected terminals, input-bearing, resume-continuation, image-only, print/text, and unrelated activation failures remain fail-closed (#2277).
 - Browser geo settings now propagate coherently across request `Accept-Language`, navigator languages, and `Intl` locale/timezone surfaces; configured managed browsers are isolated by geo/profile posture, concurrent acquisition is serialized, and unset geo preserves Chromium's native locale/timezone instead of injecting a fixed New York profile.
 

--- a/packages/coding-agent/src/sdk/bus/discord-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/discord-daemon.ts
@@ -78,6 +78,11 @@ export interface DiscordEndpointBinding {
 	send(frame: Record<string, unknown>): void | Promise<void>;
 }
 
+export interface DiscordLeaseRecoveryScheduler {
+	setTimeout(callback: () => void | Promise<void>, delayMs: number): unknown;
+	clearTimeout(handle: unknown): void;
+}
+
 export interface DiscordNotificationDaemonOptions {
 	agentDir: string;
 	repo: string;
@@ -85,6 +90,7 @@ export interface DiscordNotificationDaemonOptions {
 	parentChannelId: string;
 	provider: DiscordProvider;
 	now?: () => number;
+	leaseRecoveryScheduler?: DiscordLeaseRecoveryScheduler;
 	resolveEndpoint: (sessionId: string, expectedGeneration?: number) => Promise<DiscordEndpointBinding | null>;
 	onCommand?: (
 		sessionId: string,
@@ -151,6 +157,7 @@ type DiscordInboundClaim = {
 export class DiscordNotificationDaemon {
 	readonly #store: ConversationStore<DiscordConversation>;
 	readonly #now: () => number;
+	readonly #leaseRecoveryScheduler: DiscordLeaseRecoveryScheduler;
 	readonly #creates = new Map<string, Promise<DiscordConversation>>();
 	readonly #resumes = new Map<string, Promise<DiscordConversation | undefined>>();
 	readonly #archives = new Map<string, Promise<void>>();
@@ -167,7 +174,7 @@ export class DiscordNotificationDaemon {
 	#stopTask: Promise<void> | undefined;
 	#providerStarting = false;
 
-	#leaseRecoveryTimer: ReturnType<typeof setTimeout> | undefined;
+	#leaseRecoveryTimer: unknown;
 	#leaseRecoveryAt: number | undefined;
 	#leaseRecoveryFailures = 0;
 
@@ -179,6 +186,10 @@ export class DiscordNotificationDaemon {
 		this.#store = new ConversationStore({ agentDir: options.agentDir, kind: "discord", now: options.now });
 		this.#effects = new ChatEffectJournal({ agentDir: options.agentDir, transport: "discord", now: options.now });
 		this.#now = options.now ?? Date.now;
+		this.#leaseRecoveryScheduler = options.leaseRecoveryScheduler ?? {
+			setTimeout: (callback, delayMs) => setTimeout(() => void callback(), delayMs),
+			clearTimeout: handle => clearTimeout(handle as ReturnType<typeof setTimeout>),
+		};
 		this.#resolveEndpoint = options.resolveEndpoint;
 	}
 
@@ -240,7 +251,7 @@ export class DiscordNotificationDaemon {
 		} catch (error) {
 			if (lifecycleGeneration === this.#lifecycleGeneration) {
 				this.#started = false;
-				if (this.#leaseRecoveryTimer) clearTimeout(this.#leaseRecoveryTimer);
+				if (this.#leaseRecoveryTimer) this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
 				this.#leaseRecoveryTimer = undefined;
 				this.#leaseRecoveryAt = undefined;
 			}
@@ -255,7 +266,7 @@ export class DiscordNotificationDaemon {
 		const stopProvider = this.#started || this.#providerStarting;
 		++this.#lifecycleGeneration;
 		this.#started = false;
-		if (this.#leaseRecoveryTimer) clearTimeout(this.#leaseRecoveryTimer);
+		if (this.#leaseRecoveryTimer) this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
 		this.#leaseRecoveryTimer = undefined;
 		this.#leaseRecoveryAt = undefined;
 
@@ -2146,23 +2157,23 @@ export class DiscordNotificationDaemon {
 				recoveryFailed ? now : undefined,
 			);
 		if (recoveryAt === undefined) {
-			if (this.#leaseRecoveryTimer) clearTimeout(this.#leaseRecoveryTimer);
+			if (this.#leaseRecoveryTimer) this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
 			this.#leaseRecoveryTimer = undefined;
 			this.#leaseRecoveryAt = undefined;
 			this.#leaseRecoveryFailures = 0;
 			return;
 		}
 		if (this.#leaseRecoveryAt !== undefined && this.#leaseRecoveryAt <= recoveryAt) return;
-		if (this.#leaseRecoveryTimer) clearTimeout(this.#leaseRecoveryTimer);
+		if (this.#leaseRecoveryTimer) this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
 		this.#leaseRecoveryAt = recoveryAt;
 		const delay =
 			recoveryAt <= now
 				? Math.min(1_000, 25 * 2 ** Math.min(this.#leaseRecoveryFailures, 5))
 				: Math.min(recoveryAt - now, 2_147_483_647);
-		this.#leaseRecoveryTimer = setTimeout(() => {
+		this.#leaseRecoveryTimer = this.#leaseRecoveryScheduler.setTimeout(() => {
 			this.#leaseRecoveryTimer = undefined;
 			this.#leaseRecoveryAt = undefined;
-			void this.#track(this.#recoverLeasedEffects());
+			return this.#track(this.#recoverLeasedEffects());
 		}, delay);
 	}
 	async #recoverLeasedEffects(): Promise<void> {

--- a/packages/coding-agent/src/sdk/bus/discord-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/discord-daemon.ts
@@ -2140,8 +2140,11 @@ export class DiscordNotificationDaemon {
 	}
 	async #scheduleLeaseRecovery(recoveryFailed = false): Promise<void> {
 		if (!this.#started) return;
+		const lifecycleGeneration = this.#lifecycleGeneration;
+		const effects = await this.#effects.list();
+		if (!this.#started || lifecycleGeneration !== this.#lifecycleGeneration) return;
 		const now = this.#now();
-		const recoveryAt = (await this.#effects.list())
+		const recoveryAt = effects
 			.filter(effect => effect.transport === "discord")
 			.reduce<number | undefined>(
 				(earliest, effect) => {
@@ -2172,7 +2175,6 @@ export class DiscordNotificationDaemon {
 			recoveryAt <= now
 				? Math.min(1_000, 25 * 2 ** Math.min(this.#leaseRecoveryFailures, 5))
 				: Math.min(recoveryAt - now, 2_147_483_647);
-		const lifecycleGeneration = this.#lifecycleGeneration;
 		this.#leaseRecoveryTimer = this.#leaseRecoveryScheduler.setTimeout(() => {
 			if (lifecycleGeneration !== this.#lifecycleGeneration) return;
 			this.#leaseRecoveryTimer = undefined;

--- a/packages/coding-agent/src/sdk/bus/discord-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/discord-daemon.ts
@@ -251,7 +251,8 @@ export class DiscordNotificationDaemon {
 		} catch (error) {
 			if (lifecycleGeneration === this.#lifecycleGeneration) {
 				this.#started = false;
-				if (this.#leaseRecoveryTimer) this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
+				if (this.#leaseRecoveryTimer !== undefined)
+					this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
 				this.#leaseRecoveryTimer = undefined;
 				this.#leaseRecoveryAt = undefined;
 			}
@@ -266,7 +267,7 @@ export class DiscordNotificationDaemon {
 		const stopProvider = this.#started || this.#providerStarting;
 		++this.#lifecycleGeneration;
 		this.#started = false;
-		if (this.#leaseRecoveryTimer) this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
+		if (this.#leaseRecoveryTimer !== undefined) this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
 		this.#leaseRecoveryTimer = undefined;
 		this.#leaseRecoveryAt = undefined;
 
@@ -2157,23 +2158,26 @@ export class DiscordNotificationDaemon {
 				recoveryFailed ? now : undefined,
 			);
 		if (recoveryAt === undefined) {
-			if (this.#leaseRecoveryTimer) this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
+			if (this.#leaseRecoveryTimer !== undefined)
+				this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
 			this.#leaseRecoveryTimer = undefined;
 			this.#leaseRecoveryAt = undefined;
 			this.#leaseRecoveryFailures = 0;
 			return;
 		}
 		if (this.#leaseRecoveryAt !== undefined && this.#leaseRecoveryAt <= recoveryAt) return;
-		if (this.#leaseRecoveryTimer) this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
+		if (this.#leaseRecoveryTimer !== undefined) this.#leaseRecoveryScheduler.clearTimeout(this.#leaseRecoveryTimer);
 		this.#leaseRecoveryAt = recoveryAt;
 		const delay =
 			recoveryAt <= now
 				? Math.min(1_000, 25 * 2 ** Math.min(this.#leaseRecoveryFailures, 5))
 				: Math.min(recoveryAt - now, 2_147_483_647);
+		const lifecycleGeneration = this.#lifecycleGeneration;
 		this.#leaseRecoveryTimer = this.#leaseRecoveryScheduler.setTimeout(() => {
+			if (lifecycleGeneration !== this.#lifecycleGeneration) return;
 			this.#leaseRecoveryTimer = undefined;
 			this.#leaseRecoveryAt = undefined;
-			return this.#track(this.#recoverLeasedEffects());
+			return this.#track(this.#recoverLeasedEffects()).catch(() => {});
 		}, delay);
 	}
 	async #recoverLeasedEffects(): Promise<void> {

--- a/packages/coding-agent/test/sdk-discord-daemon.test.ts
+++ b/packages/coding-agent/test/sdk-discord-daemon.test.ts
@@ -17,6 +17,7 @@ import type { DiscordConversation } from "../src/sdk/bus/discord-conversation";
 import {
 	type DiscordEndpointBinding,
 	DiscordEndpointBindingError,
+	type DiscordLeaseRecoveryScheduler,
 	DiscordNotificationDaemon,
 	type DiscordNotificationDaemonOptions,
 } from "../src/sdk/bus/discord-daemon";
@@ -29,6 +30,35 @@ import type {
 import { SdkClientError } from "../src/sdk/client/client";
 
 const actionCustomIds = new Map<string, string>();
+
+class ManualLeaseRecoveryScheduler implements DiscordLeaseRecoveryScheduler {
+	#next: { handle: object; callback: () => void | Promise<void>; delayMs: number } | undefined;
+
+	setTimeout(callback: () => void | Promise<void>, delayMs: number): unknown {
+		const handle = {};
+		this.#next = { handle, callback, delayMs };
+		return handle;
+	}
+
+	clearTimeout(handle: unknown): void {
+		if (this.#next?.handle === handle) this.#next = undefined;
+	}
+
+	get delayMs(): number | undefined {
+		return this.#next?.delayMs;
+	}
+
+	get pending(): boolean {
+		return this.#next !== undefined;
+	}
+
+	async runNext(): Promise<void> {
+		const next = this.#next;
+		if (!next) throw new Error("Expected a scheduled Discord lease recovery.");
+		this.#next = undefined;
+		await next.callback();
+	}
+}
 
 class FakeDiscordProvider implements DiscordProvider {
 	readonly applicationId = "app";
@@ -2089,6 +2119,7 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 			});
 			await journal.claim(leasedEffectId, "dead-worker", 10);
 			const commands: string[] = [];
+			const recoveryScheduler = new ManualLeaseRecoveryScheduler();
 			restarted = new DiscordNotificationDaemon({
 				agentDir,
 				repo: agentDir,
@@ -2096,6 +2127,7 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 				parentChannelId: "parent",
 				provider,
 				now: () => now,
+				leaseRecoveryScheduler: recoveryScheduler,
 				resolveEndpoint: endpoint,
 				onCommand: async (_sessionId, command) => {
 					commands.push(command);
@@ -2103,12 +2135,14 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 				},
 			});
 			await restarted.start();
+			expect(recoveryScheduler.delayMs).toBe(10);
 			failScheduledDrain = true;
 			now = 11;
-			await Bun.sleep(30);
+			await recoveryScheduler.runNext();
 			expect(failedScheduledDrains).toBe(1);
+			expect(recoveryScheduler.delayMs).toBe(50);
 			failScheduledDrain = false;
-			await Bun.sleep(100);
+			await recoveryScheduler.runNext();
 			expect(commands).toEqual(["/sdk query recovered"]);
 			await restarted.stop();
 			restarted = undefined;
@@ -2135,6 +2169,7 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 			now = 20;
 			await journal.claim(stoppedEffectId, "dead-worker", 10);
 			const stoppedCommands: string[] = [];
+			const stoppedRecoveryScheduler = new ManualLeaseRecoveryScheduler();
 			restarted = new DiscordNotificationDaemon({
 				agentDir,
 				repo: agentDir,
@@ -2142,6 +2177,7 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 				parentChannelId: "parent",
 				provider,
 				now: () => now,
+				leaseRecoveryScheduler: stoppedRecoveryScheduler,
 				resolveEndpoint: endpoint,
 				onCommand: async (_sessionId, command) => {
 					stoppedCommands.push(command);
@@ -2149,10 +2185,11 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 				},
 			});
 			await restarted.start();
+			expect(stoppedRecoveryScheduler.pending).toBe(true);
 			await restarted.stop();
 			restarted = undefined;
+			expect(stoppedRecoveryScheduler.pending).toBe(false);
 			now = 31;
-			await Bun.sleep(20);
 			expect(stoppedCommands).toEqual([]);
 		} finally {
 			await restarted?.stop();

--- a/packages/coding-agent/test/sdk-discord-daemon.test.ts
+++ b/packages/coding-agent/test/sdk-discord-daemon.test.ts
@@ -32,12 +32,13 @@ import { SdkClientError } from "../src/sdk/client/client";
 const actionCustomIds = new Map<string, string>();
 
 class ManualLeaseRecoveryScheduler implements DiscordLeaseRecoveryScheduler {
-	#next: { handle: object; callback: () => void | Promise<void>; delayMs: number } | undefined;
+	#next: { handle: unknown; callback: () => void | Promise<void>; delayMs: number } | undefined;
+
+	constructor(private readonly handle: unknown = {}) {}
 
 	setTimeout(callback: () => void | Promise<void>, delayMs: number): unknown {
-		const handle = {};
-		this.#next = { handle, callback, delayMs };
-		return handle;
+		this.#next = { handle: this.handle, callback, delayMs };
+		return this.handle;
 	}
 
 	clearTimeout(handle: unknown): void {
@@ -52,11 +53,15 @@ class ManualLeaseRecoveryScheduler implements DiscordLeaseRecoveryScheduler {
 		return this.#next !== undefined;
 	}
 
-	async runNext(): Promise<void> {
+	takeNext(): () => void | Promise<void> {
 		const next = this.#next;
 		if (!next) throw new Error("Expected a scheduled Discord lease recovery.");
 		this.#next = undefined;
-		await next.callback();
+		return next.callback;
+	}
+
+	async runNext(): Promise<void> {
+		await this.takeNext()();
 	}
 }
 
@@ -2169,7 +2174,7 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 			now = 20;
 			await journal.claim(stoppedEffectId, "dead-worker", 10);
 			const stoppedCommands: string[] = [];
-			const stoppedRecoveryScheduler = new ManualLeaseRecoveryScheduler();
+			const stoppedRecoveryScheduler = new ManualLeaseRecoveryScheduler(0);
 			restarted = new DiscordNotificationDaemon({
 				agentDir,
 				repo: agentDir,
@@ -2187,10 +2192,18 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 			await restarted.start();
 			expect(stoppedRecoveryScheduler.pending).toBe(true);
 			await restarted.stop();
-			restarted = undefined;
 			expect(stoppedRecoveryScheduler.pending).toBe(false);
+
+			await restarted.start();
+			const staleRecovery = stoppedRecoveryScheduler.takeNext();
+			await restarted.stop();
+			await restarted.start();
+			expect(stoppedRecoveryScheduler.pending).toBe(true);
 			now = 31;
+			await staleRecovery();
 			expect(stoppedCommands).toEqual([]);
+			await restarted.stop();
+			restarted = undefined;
 		} finally {
 			await restarted?.stop();
 			await fs.rm(agentDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- inject a lease-recovery scheduler into the Discord daemon while preserving the production timer adapter
- make recovery callbacks awaitable so tests can prove the expiry wake, transient-failure backoff, successful retry, and stop cancellation without wall-clock sleeps
- replace the load-sensitive 30ms/100ms assertion in the dead unexpired inbound lease regression with a deterministic manual scheduler

## Root cause
The daemon did schedule the required retry. After lease expiry, the first recovery failed as injected and correctly armed a 50ms exponential retry. The test then assumed a real 100ms sleep guaranteed that callback had run. Under the loaded post-merge shard, timer/callback execution was delayed past that assertion. This was a timing-only assertion, not a missing scheduler wake.

## Supersession and adjacent CI
- successor Dev CI at `2810868f` passed shard-4, but there are no Discord daemon/test changes between failing `0afb4e958` and `2810868f`; that pass was incidental, not a fix
- shard-1 detached-owner finalize evidence failed once, then passed on the requested rerun; it is not bundled into this Discord repair

## Verification
- original wall-clock regression: 20/20 isolated passes, demonstrating load sensitivity rather than deterministic correctness
- deterministic recovery regression: pass, 7 assertions
- complete `sdk-discord-daemon.test.ts`: 51 pass, 0 fail, 213 assertions
- coding-agent Biome, SDK canonicalization, and TypeScript checks: pass
- local affected shard: Discord recovery passed; one unrelated local terminal-capability baseline test failed
- hosted successor shard-4 rerun: pass
- hosted successor shard-1 rerun: pass

Closes the Discord inbound lease recovery CI coverage gap found in Dev CI run 29429894180.