### PR TITLE
fix(coding-agent): tolerate Windows directory fsync EPERM

### DIFF
--- a/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-broker.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-broker.ts
@@ -939,7 +939,7 @@ function assertPersistedGate(
 function isUnsupportedWindowsDirectorySyncError(error: unknown): boolean {
 	if (process.platform !== "win32") return false;
 	const code = (error as NodeJS.ErrnoException | undefined)?.code;
-	return code === "EINVAL" || code === "ENOTSUP" || code === "EOPNOTSUPP";
+	return code === "EINVAL" || code === "ENOTSUP" || code === "EOPNOTSUPP" || code === "EPERM";
 }
 
 /** A write may have reached `rename` but not the directory fsync durability barrier. */

--- a/packages/coding-agent/test/workflow-gate-broker.test.ts
+++ b/packages/coding-agent/test/workflow-gate-broker.test.ts
@@ -409,6 +409,17 @@ describe("WorkflowGateBroker", () => {
 				),
 		).toThrow(/directory fsync failed/);
 	});
+	it.skipIf(process.platform !== "win32")("ignores EPERM from a Windows directory fsync", () => {
+		const file = path.join(mkdtempSync(path.join(tmpdir(), "gate-windows-fsync-")), "gates.json");
+		let syncs = 0;
+		const store = new FileGateStore(file, () => {
+			syncs++;
+			if (syncs === 2) throw Object.assign(new Error("directory fsync is unsupported"), { code: "EPERM" });
+		});
+
+		expect(store.nextSeq("ralplan")).toBe(1);
+		expect(new FileGateStore(file).nextSeq("ralplan")).toBe(2);
+	});
 	it("quarantines a disk-accepted record after post-rename fsync uncertainty instead of reissuing it", async () => {
 		const file = path.join(mkdtempSync(path.join(tmpdir(), "gate-uncertain-accepted-")), "gates.json");
 		let syncs = 0;


### PR DESCRIPTION
Fix: Tolerate Windows directory fsync EPERM

Adds EPERM to the unsupported Windows directory-sync errors handled by FileGateStore.

Bun on Windows returns EPERM when fsync is invoked on a directory file descriptor. The gate-store persistence path
syncs the parent directory after an atomic rename; without handling this code, otherwise successful writes fail with
uncertain durability.

Adds a Windows-only regression test that injects EPERM during the parent-directory sync and verifies persistence
continues.

## Tests
PASS: bun test packages/coding-agent/test/workflow-gate-broker.test.ts — 19 pass, 0 fail, 53 expect() calls.

## Changed files
packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-broker.ts
packages/coding-agent/test/workflow-gate-broker.test.ts