### PR TITLE
fix(gates): tolerate Bun Windows directory fsync EPERM

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Input-free interactive TTY startup now keeps the TUI reachable when configured model profiles are missing required provider credentials, skips only the blocked profiles, and preserves later `--mpreset` and explicit model/thinking precedence; redirected terminals, input-bearing, resume-continuation, image-only, print/text, and unrelated activation failures remain fail-closed (#2277).
+- Windows Bun runtimes no longer crash while committing the durable workflow-gate store when directory `fsync` reports the unsupported-operation code `EPERM`; unexpected directory-sync failures remain fail-closed.
 - Browser geo settings now propagate coherently across request `Accept-Language`, navigator languages, and `Intl` locale/timezone surfaces; configured managed browsers are isolated by geo/profile posture, concurrent acquisition is serialized, and unset geo preserves Chromium's native locale/timezone instead of injecting a fixed New York profile.
 
 - Cooperative mid-run context maintenance now waits at a cancellation-aware FIFO consumer-drain checkpoint before flushing or rewriting session history. Materialized tool results and steering messages are synchronously canonicalized first; aborted barriers and hook/signal-cancelled compactions settle without rewriting or scheduling a continuation. Promotion, pruning, and compaction each start a clean provider/prompt-cache epoch. Script-aware #2067 unsent-delta accounting remains cache-free and distinct from the lifecycle checkpoint.

--- a/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-broker.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-broker.ts
@@ -936,10 +936,14 @@ function assertPersistedGate(
 		invalidFileState(filePath);
 }
 
-function isUnsupportedWindowsDirectorySyncError(error: unknown): boolean {
-	if (process.platform !== "win32") return false;
+export function isUnsupportedWindowsDirectorySyncError(
+	error: unknown,
+	platform: NodeJS.Platform = process.platform,
+): boolean {
+	if (platform !== "win32") return false;
 	const code = (error as NodeJS.ErrnoException | undefined)?.code;
-	return code === "EINVAL" || code === "ENOTSUP" || code === "EOPNOTSUPP";
+	// Bun reports EPERM when fsyncSync is applied to a Windows directory handle.
+	return code === "EINVAL" || code === "ENOTSUP" || code === "EOPNOTSUPP" || code === "EPERM";
 }
 
 /** A write may have reached `rename` but not the directory fsync durability barrier. */

--- a/packages/coding-agent/test/workflow-gate-broker.test.ts
+++ b/packages/coding-agent/test/workflow-gate-broker.test.ts
@@ -6,6 +6,7 @@ import type { GateContinuation } from "../src/modes/shared/agent-wire/workflow-g
 import {
 	FileGateStore,
 	type GateAuditEvent,
+	isUnsupportedWindowsDirectorySyncError,
 	MemoryGateStore,
 	WorkflowGateBroker,
 	WorkflowGateBrokerError,
@@ -383,6 +384,13 @@ describe("WorkflowGateBroker", () => {
 		await expect(broker.resolve({ gate_id: gate.gate_id, answer: "approve" })).rejects.toThrow(
 			/no live pending gate/,
 		);
+	});
+
+	it("classifies only unsupported Windows directory sync errors", () => {
+		expect(isUnsupportedWindowsDirectorySyncError({ code: "EPERM" }, "win32")).toBe(true);
+		expect(isUnsupportedWindowsDirectorySyncError({ code: "EINVAL" }, "win32")).toBe(true);
+		expect(isUnsupportedWindowsDirectorySyncError({ code: "EACCES" }, "win32")).toBe(false);
+		expect(isUnsupportedWindowsDirectorySyncError({ code: "EPERM" }, "darwin")).toBe(false);
 	});
 
 	it("fails closed on a corrupt FileGateStore instead of silently resetting", () => {


### PR DESCRIPTION
## Summary

Fixes Windows startup crashes when Bun 1.3.14 reports `EPERM` from `fsyncSync` on the parent directory handle used by the durable workflow-gate store.

## Safety

- Keeps file `fsync` and atomic temp-file rename unchanged.
- Ignores only the known unsupported Windows directory-sync errno `EPERM`.
- Continues to fail closed for unexpected directory-sync failures such as `EACCES` or `EBADF`.
- On Windows this preserves atomic complete-state recovery, while acknowledging that directory-entry crash durability is not available through this operation.

## Tests

- `bun test packages/coding-agent/test/workflow-gate-broker.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-broker.ts packages/coding-agent/test/workflow-gate-broker.test.ts`
- `git diff --check`
