### PR TITLE
fix(discord): bound terminal prune mapping scans

### DIFF
--- a/packages/coding-agent/src/sdk/bus/chat-effect-journal.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-effect-journal.ts
@@ -340,13 +340,15 @@ export class ChatEffectJournal {
 	}
 
 	async #pruneTerminal(): Promise<void> {
-		const referenced = new Set<string>();
-		for (const mapping of Object.values((await this.#mappings.load()).conversations))
-			collectEffectReferences(mapping, referenced);
 		const terminal = (await this.list())
 			.filter(effect => effect.state === "terminal")
 			.sort((left, right) => left.updatedAt - right.updatedAt);
-		for (const effect of terminal.slice(0, Math.max(0, terminal.length - MAX_TERMINAL_CHAT_EFFECTS))) {
+		if (terminal.length <= MAX_TERMINAL_CHAT_EFFECTS) return;
+
+		const referenced = new Set<string>();
+		for (const mapping of Object.values((await this.#mappings.load()).conversations))
+			collectEffectReferences(mapping, referenced);
+		for (const effect of terminal.slice(0, terminal.length - MAX_TERMINAL_CHAT_EFFECTS)) {
 			if (!referenced.has(effect.id)) await this.#store.delete(effect.id, effect.generation);
 		}
 	}

--- a/packages/coding-agent/test/sdk-discord-daemon.test.ts
+++ b/packages/coding-agent/test/sdk-discord-daemon.test.ts
@@ -2332,6 +2332,32 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 		});
 	});
 
+	test("does not scan conversation mappings below the terminal prune threshold", async () => {
+		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-discord-prune-bound-"));
+		try {
+			const journal = new ChatEffectJournal({ agentDir, transport: "discord" });
+			await journal.enqueue({
+				id: "terminal-below-threshold",
+				kind: "post-message",
+				transport: "discord",
+				sessionId: "session",
+				endpointGeneration: 1,
+				payload: { threadId: "thread", content: "bounded" },
+			});
+			const lease = await journal.claim("terminal-below-threshold", "owner", 60_000);
+			expect(lease).toBeDefined();
+			const load = vi.spyOn(ConversationStore.prototype, "load");
+			load.mockClear();
+			try {
+				await journal.record("terminal-below-threshold", { owner: "owner", epoch: lease!.epoch }, "terminal");
+				expect(load).toHaveBeenCalledTimes(1);
+			} finally {
+				load.mockRestore();
+			}
+		} finally {
+			await fs.rm(agentDir, { recursive: true, force: true });
+		}
+	});
 	test("keeps a terminal effect referenced by a crash-window receipt through terminal pruning", async () => {
 		await withDaemon(async (daemon, provider, agentDir) => {
 			const conversation = await daemon.notify({ sessionId: "session", endpointGeneration: 1, content: "open" });
@@ -2377,7 +2403,7 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 			});
 			const lease = await journal.claim(effectId, "owner", 60_000);
 			await journal.record(effectId, { owner: "owner", epoch: lease!.epoch }, "terminal");
-			for (let index = 0; index < 129; index++) {
+			for (let index = 0; index < 127; index++) {
 				const id = `terminal-prune-${index}`;
 				await journal.enqueue({
 					id,
@@ -2389,6 +2415,25 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 				});
 				const terminalLease = await journal.claim(id, "owner", 60_000);
 				await journal.record(id, { owner: "owner", epoch: terminalLease!.epoch }, "terminal");
+			}
+			const overflowId = "terminal-prune-overflow";
+			await journal.enqueue({
+				id: overflowId,
+				kind: "post-message",
+				transport: "discord",
+				sessionId: "session",
+				endpointGeneration: 1,
+				payload: { threadId: conversation.threadId!, content: "overflow" },
+			});
+			const overflowLease = await journal.claim(overflowId, "owner", 60_000);
+			expect(overflowLease).toBeDefined();
+			const load = vi.spyOn(ConversationStore.prototype, "load");
+			load.mockClear();
+			try {
+				await journal.record(overflowId, { owner: "owner", epoch: overflowLease!.epoch }, "terminal");
+				expect(load).toHaveBeenCalledTimes(2);
+			} finally {
+				load.mockRestore();
 			}
 			expect(await journal.read(effectId)).toMatchObject({ state: "terminal" });
 


### PR DESCRIPTION
## Summary
- avoid loading Discord conversation mappings for terminal journal records while the terminal count is still at or below the prune threshold
- preserve mapping-reference lookup once overflow pruning is actually required
- add deterministic `ConversationStore.load` call-count contracts below threshold and at overflow

## Root cause
Post-merge Dev CI run 29436632828 timed out the crash-window terminal-pruning regression after 1695 shard tests. Rerun attempt 2 passed, but isolated runs varied from 1.36s to 3.01s. The journal performed a conversation-mapping file load for every terminal record before it knew whether the 128-record pruning threshold had been crossed. The test creates the exact threshold boundary under shard load, so this unnecessary per-record I/O consumed its timing margin.

This is not a leaked timer, owner, or unresolved promise. It is a bounded performance defect in the prune path.

## Deterministic evidence
- current dev with the new call-count test but without the code fix fails: below-threshold terminalization performs **2** `ConversationStore.load()` calls
- patched behavior performs **1** load below threshold
- overflow behavior performs **2** loads, proving mappings are still consulted when pruning is required
- the referenced crash-window effect remains terminal and its receipt is reconciled on daemon restart

## Verification
- focused prune contracts: pass
- complete `sdk-discord-daemon.test.ts`: 52 pass, 0 fail, 218 assertions
- coding-agent Biome, SDK canonicalization, and TypeScript: pass
- exact local shard: target prune test passed; unrelated local environment/process contamination failures remained outside this two-file diff
- hosted exact shard rerun attempt 2: green

Strict scope: two tracked files only. Existing untracked `.gjc/` receipts were not modified or committed.