### PR TITLE
ci: shard affected build gates

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -27,22 +27,37 @@ jobs:
       has_native: ${{ steps.plan.outputs.has_native }}
       changed_paths: ${{ steps.plan.outputs.changed_paths }}
       plan_mode: ${{ steps.plan.outputs.plan_mode }}
+      plan_digest: ${{ steps.plan.outputs.plan_digest }}
+      plan_source_sha: ${{ steps.plan.outputs.plan_source_sha }}
     env:
       GITHUB_EVENT_BEFORE: ${{ github.event.before }}
       GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+        with:
+          toolchain: nightly-2026-04-29
       - name: Compute changed-path relevance
         id: relevance
         run: bun scripts/ci-job-relevance.ts
       - name: Compute affected task matrix
         id: plan
         run: bun scripts/ci-dev-affected.ts --matrix-json
+      - name: Upload canonical affected plan
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .ci-dev-affected-plan.json
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
 
   windows-dev-doctor:
     name: Windows dev:doctor
@@ -50,8 +65,17 @@ jobs:
     if: ${{ needs.affected-plan.outputs.relevant == 'true' && contains(needs.affected-plan.outputs.changed_paths, 'scripts/dev-link') }}
     runs-on: windows-latest
     timeout-minutes: 60
+    env:
+      CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify checked-out source head
+        shell: pwsh
+        run: |
+          $head = (git rev-parse HEAD).Trim()
+          if ($head -ne $env:CI_DEV_SOURCE_SHA) { throw "Checked-out SHA $head does not match $env:CI_DEV_SOURCE_SHA" }
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
@@ -97,20 +121,31 @@ jobs:
   affected-native:
     name: Affected path validation / native-build
     needs: [affected-plan]
-    if: ${{ needs.affected-plan.outputs.relevant == 'true' && needs.affected-plan.outputs.has_native == 'true' }}
+    if: ${{ needs.affected-plan.outputs.has_native == 'true' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:
       CI_DEV_CHANGED_PATHS: ${{ needs.affected-plan.outputs.changed_paths }}
       CI_DEV_PLAN_MODE: ${{ needs.affected-plan.outputs.plan_mode }}
+      CI_DEV_AFFECTED_PLAN: .ci-dev-affected-plan.json
+      CI_DEV_PLAN_DIGEST: ${{ needs.affected-plan.outputs.plan_digest }}
+      CI_DEV_PLAN_SOURCE_SHA: ${{ needs.affected-plan.outputs.plan_source_sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "24"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
+      - name: Download and validate canonical affected plan
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .
+      - run: bun scripts/ci-dev-affected.ts --validate-plan
       - name: Detect native host ABI
         id: native-host
         shell: bash
@@ -122,7 +157,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: packages/natives/native/pi_natives.*.node
-          key: dev-affected-native-${{ runner.os }}-${{ steps.native-host.outputs.glibc }}-${{ hashFiles('crates/**/*.rs', 'crates/**/Cargo.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'packages/natives/scripts/**', 'packages/natives/package.json', 'scripts/ci-build-native.ts', 'scripts/host-detect.ts') }}
+          key: dev-affected-native-v2-baseline-modern-${{ runner.os }}-${{ steps.native-host.outputs.glibc }}-${{ hashFiles('crates/**/*.rs', 'crates/**/Cargo.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'packages/natives/scripts/**', 'packages/natives/package.json', 'scripts/ci-build-native.ts', 'scripts/host-detect.ts') }}
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
         if: steps.native-cache.outputs.cache-hit != 'true'
         with:
@@ -148,11 +183,17 @@ jobs:
       - name: Build affected native addon(s)
         if: steps.native-cache.outputs.cache-hit != 'true'
         run: bun scripts/ci-dev-affected.ts --native-build
+      - name: Verify required native addon variants
+        run: |
+          test -f packages/natives/native/pi_natives.linux-x64-baseline.node
+          test -f packages/natives/native/pi_natives.linux-x64-modern.node
       - name: Upload native addon(s)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: dev-affected-native-${{ github.run_id }}
-          path: packages/natives/native/pi_natives.*.node
+          name: dev-affected-native-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            packages/natives/native/pi_natives.linux-x64-baseline.node
+            packages/natives/native/pi_natives.linux-x64-modern.node
           if-no-files-found: error
           retention-days: 1
 
@@ -162,7 +203,7 @@ jobs:
   affected-shards:
     name: Affected path validation / ${{ matrix.key }}
     needs: [affected-plan, affected-native]
-    if: ${{ always() && needs.affected-plan.outputs.relevant == 'true' && needs.affected-plan.outputs.has_tasks == 'true' && needs.affected-native.result != 'failure' && needs.affected-native.result != 'cancelled' }}
+    if: ${{ always() && needs.affected-plan.outputs.has_tasks == 'true' && needs.affected-native.result != 'failure' && needs.affected-native.result != 'cancelled' }}
     runs-on: ubuntu-22.04
     # Broad push-mode coding-agent/root test shards have repeatedly reached the
     # previous 30m cap, and root-test can exceed 60m on large affected sets
@@ -172,18 +213,36 @@ jobs:
     timeout-minutes: 90
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix: ${{ fromJSON(needs.affected-plan.outputs.matrix) }}
     env:
       CI_DEV_CHANGED_PATHS: ${{ needs.affected-plan.outputs.changed_paths }}
       CI_DEV_PLAN_MODE: ${{ needs.affected-plan.outputs.plan_mode }}
+      CI_DEV_AFFECTED_PLAN: .ci-dev-affected-plan.json
+      CI_DEV_PLAN_DIGEST: ${{ needs.affected-plan.outputs.plan_digest }}
+      CI_DEV_PLAN_SOURCE_SHA: ${{ needs.affected-plan.outputs.plan_source_sha }}
+      CI_DEV_MATRIX_KEY: ${{ matrix.key }}
+      CI_DEV_MATRIX_IDENTITY: ${{ matrix.identity }}
+      CI_DEV_SHARD_INDEX: ${{ strategy.job-index }}
+      CI_DEV_MATRIX_RUST: ${{ matrix.rust }}
+      CI_DEV_MATRIX_NEXTEST: ${{ matrix.nextest }}
+      CI_DEV_MATRIX_NATIVE: ${{ matrix.native }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "24"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
+      - name: Download and validate canonical affected plan
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .
+      - run: bun scripts/ci-dev-affected.ts --validate-plan
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         if: ${{ startsWith(matrix.key, 'python-') }}
         with:
@@ -193,7 +252,7 @@ jobs:
         with:
           toolchain: nightly-2026-04-29
       - uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e  # v2
-        if: ${{ matrix.rust }}
+        if: ${{ matrix.nextest }}
         with:
           tool: nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
@@ -215,7 +274,7 @@ jobs:
         if: ${{ matrix.native }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
-          name: dev-affected-native-${{ github.run_id }}
+          name: dev-affected-native-${{ github.run_id }}-${{ github.run_attempt }}
           path: packages/natives/native
       - name: Run affected task shard
         env:
@@ -223,6 +282,19 @@ jobs:
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: bun scripts/ci-dev-affected.ts --task="$AFFECTED_TASK_KEY"
+      - name: Write shard completion receipt
+        run: |
+          bun -e 'await Bun.write(`.ci-dev-shard-receipts/${process.env.CI_DEV_SHARD_INDEX}.json`, JSON.stringify({ key: process.env.AFFECTED_TASK_KEY, identity: process.env.CI_DEV_MATRIX_IDENTITY }))'
+        env:
+          AFFECTED_TASK_KEY: ${{ matrix.key }}
+      - name: Upload shard completion receipt
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: dev-affected-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}
+          path: .ci-dev-shard-receipts/${{ strategy.job-index }}.json
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
 
 
   # Windows' replacement semantics differ from POSIX and are covered separately
@@ -232,8 +304,17 @@ jobs:
     name: Notification atomicity / Windows
     runs-on: windows-latest
     timeout-minutes: 30
+    env:
+      CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify checked-out source head
+        shell: pwsh
+        run: |
+          $head = (git rev-parse HEAD).Trim()
+          if ($head -ne $env:CI_DEV_SOURCE_SHA) { throw "Checked-out SHA $head does not match $env:CI_DEV_SOURCE_SHA" }
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
@@ -313,22 +394,63 @@ jobs:
     needs: [affected-plan, affected-native, affected-shards, windows-dev-doctor, notification-atomic-windows]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    env:
+      CI_DEV_AFFECTED_PLAN: .ci-dev-affected-plan.json
+      CI_DEV_PLAN_DIGEST: ${{ needs.affected-plan.outputs.plan_digest }}
+      CI_DEV_PLAN_SOURCE_SHA: ${{ needs.affected-plan.outputs.plan_source_sha }}
+      CI_DEV_SHARD_RECEIPTS: .ci-dev-shard-receipts
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3"
+      - name: Download canonical affected plan
+        if: ${{ needs.affected-plan.result == 'success' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .
+      - name: Download shard completion receipts
+        if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          pattern: dev-affected-shard-${{ github.run_id }}-${{ github.run_attempt }}-*
+          path: .ci-dev-shard-receipts
+          merge-multiple: true
+      - name: Validate canonical shard completion
+        if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' }}
+        run: bun scripts/ci-dev-affected.ts --validate-shard-receipts
       - name: Aggregate affected path validation shards
         run: |
           plan='${{ needs.affected-plan.result }}'
           native='${{ needs.affected-native.result }}'
           shards='${{ needs.affected-shards.result }}'
+          has_native='${{ needs.affected-plan.outputs.has_native }}'
+          has_tasks='${{ needs.affected-plan.outputs.has_tasks }}'
           windows_doctor='${{ needs.windows-dev-doctor.result }}'
           windows_atomic='${{ needs.notification-atomic-windows.result }}'
           echo "affected-plan: $plan"
           echo "affected-native: $native"
           echo "affected-shards: $shards"
+          echo "planned native work: $has_native"
+          echo "planned shard work: $has_tasks"
           echo "windows-dev-doctor: $windows_doctor"
           echo "notification-atomic-windows: $windows_atomic"
           test "$plan" = success || { echo "planner did not succeed"; exit 1; }
-          case "$native" in success|skipped) ;; *) echo "native build did not pass"; exit 1 ;; esac
-          case "$shards" in success|skipped) ;; *) echo "one or more affected shards did not pass"; exit 1 ;; esac
+          case "$has_native" in true|false) ;; *) echo "planner emitted invalid has_native=$has_native"; exit 1 ;; esac
+          case "$has_tasks" in true|false) ;; *) echo "planner emitted invalid has_tasks=$has_tasks"; exit 1 ;; esac
+          if [ "$has_native" = true ]; then
+            test "$native" = success || { echo "required native build did not succeed"; exit 1; }
+          else
+            test "$native" = skipped || { echo "unplanned native build was not skipped"; exit 1; }
+          fi
+          if [ "$has_tasks" = true ]; then
+            test "$shards" = success || { echo "required affected shards did not succeed"; exit 1; }
+          else
+            test "$shards" = skipped || { echo "unplanned affected shards were not skipped"; exit 1; }
+          fi
           case "$windows_doctor" in success|skipped) ;; *) echo "Windows dev:doctor did not pass"; exit 1 ;; esac
           test "$windows_atomic" = success || { echo "Windows atomicity gate did not pass"; exit 1; }
           echo "Affected path validation: all required shards passed"

--- a/scripts/ci-dev-affected-build-inventory.json
+++ b/scripts/ci-dev-affected-build-inventory.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "typescript": [
+    { "id": "coding-agent", "name": "@gajae-code/coding-agent", "dir": "packages/coding-agent", "nativeConsumer": true, "nativeProducer": false },
+    { "id": "stats", "name": "@gajae-code/stats", "dir": "packages/stats", "nativeConsumer": false, "nativeProducer": false }
+  ],
+  "cargo": [
+    { "id": "gjc-sdk", "name": "gjc-sdk", "manifestPath": "crates/gjc-sdk/Cargo.toml", "supported": true, "nativeAddonSource": false },
+    { "id": "pi-ast", "name": "pi-ast", "manifestPath": "crates/pi-ast/Cargo.toml", "supported": true, "nativeAddonSource": false },
+    { "id": "pi-iso", "name": "pi-iso", "manifestPath": "crates/pi-iso/Cargo.toml", "supported": true, "nativeAddonSource": false },
+    { "id": "pi-natives", "name": "pi-natives", "manifestPath": "crates/pi-natives/Cargo.toml", "supported": true, "nativeAddonSource": true },
+    { "id": "pi-shell", "name": "pi-shell", "manifestPath": "crates/pi-shell/Cargo.toml", "supported": true, "nativeAddonSource": false }
+  ],
+  "emergency": {
+    "cargoWorkspaceBuild": {
+      "id": "cargo-workspace-emergency",
+      "key": "cargo-build:emergency:workspace",
+      "identity": "emergency:cargo-workspace:root",
+      "command": ["cargo", "build", "--workspace"],
+      "cwd": ".",
+      "capabilities": { "rust": true, "nextest": false, "nativeConsumer": false, "nativeProducer": false },
+      "allowedReasons": ["cargo-name-ambiguity"]
+    }
+  }
+}

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -1,8 +1,12 @@
-import { afterAll, describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describeTasks, packageScriptCommand, planTargetedTasks, planTasks, resolvePackageCwd, runCommand, type WorkspacePackage } from "./ci-dev-affected";
+import { describeTasks, expandWithDependents, loadBuildInventory, normalizeChangedPaths, packageScriptCommand, planTargetedTasks, planTasks, requiresCargoWorkspaceEmergency, resolvePackageCwd, runCommand, type CargoInventoryUnit, type WorkspacePackage } from "./ci-dev-affected";
+
+// Matrix planning validates live workspace and Cargo manifests in subprocesses.
+// Hosted runners can need more than Bun's 5s default during their first cold scan.
+setDefaultTimeout(30_000);
 
 const packages: WorkspacePackage[] = [
 	{
@@ -39,6 +43,43 @@ describe("planTasks command shape (issue #622)", () => {
 		expect(runTest?.cwd).toBe(resolvePackageCwd("packages/example"));
 	});
 
+});
+
+describe("dev-ci canonical-plan workflow contract", () => {
+	test("transports and validates the planner artifact before conditional setup", async () => {
+		const workflow = await Bun.file(path.join(import.meta.dir, "..", ".github", "workflows", "dev-ci.yml")).text();
+		expect(workflow).toContain("ref: ${{ github.event.pull_request.head.sha || github.sha }}");
+		expect(workflow.match(/ref: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/g)).toHaveLength(6);
+		expect(workflow.match(/Verify checked-out source head/g)).toHaveLength(2);
+		expect(workflow).toContain("name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}");
+		expect(workflow.match(/\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/g)).toHaveLength(8);
+		expect(workflow).toContain("include-hidden-files: true");
+		expect(workflow.match(/include-hidden-files: true/g)).toHaveLength(2);
+		expect(workflow).toContain("CI_DEV_PLAN_DIGEST: ${{ needs.affected-plan.outputs.plan_digest }}");
+		expect(workflow).toContain("CI_DEV_PLAN_SOURCE_SHA: ${{ needs.affected-plan.outputs.plan_source_sha }}");
+		expect(workflow).toContain("CI_DEV_MATRIX_NEXTEST: ${{ matrix.nextest }}");
+		expect(workflow).toContain("run: bun scripts/ci-dev-affected.ts --validate-plan");
+		expect(workflow.indexOf("run: bun scripts/ci-dev-affected.ts --validate-plan")).toBeLessThan(workflow.indexOf("if: ${{ matrix.rust }}"));
+		expect(workflow).toContain("if: ${{ matrix.nextest }}");
+		expect(workflow).toContain("affected-native.result != 'failure'");
+		expect(workflow).toContain("name: Affected path validation");
+		expect(workflow).toContain("has_native='${{ needs.affected-plan.outputs.has_native }}'");
+		expect(workflow).toContain("has_tasks='${{ needs.affected-plan.outputs.has_tasks }}'");
+		expect(workflow).toContain('test "$native" = success');
+		expect(workflow).toContain('test "$shards" = success');
+		expect(workflow).toContain('test "$native" = skipped');
+		expect(workflow).toContain('test "$shards" = skipped');
+		expect(workflow).toContain('case "$has_native" in true|false)');
+		expect(workflow).toContain('case "$has_tasks" in true|false)');
+		expect(workflow).toContain("max-parallel: 8");
+		expect(workflow).toContain("CI_DEV_MATRIX_IDENTITY: ${{ matrix.identity }}");
+		expect(workflow).toContain("Upload shard completion receipt");
+		expect(workflow).toContain("Validate canonical shard completion");
+		expect(workflow).toContain("--validate-shard-receipts");
+		expect(workflow).toContain("pi_natives.linux-x64-baseline.node");
+		expect(workflow).toContain("pi_natives.linux-x64-modern.node");
+		expect(workflow).toContain("dev-affected-native-v2-baseline-modern-");
+	});
 });
 
 	describe("deep-interview selector narrowing", () => {
@@ -165,6 +206,16 @@ describe("describeTasks matrix emission", () => {
 		expect(entries.every(entry => !entry.nativeBuild)).toBe(true);
 	});
 
+	test("selector self-check shards provision Rust without nextest in PR and push plans", () => {
+		const entries = [
+			...describeTasks(planTargetedTasks(["scripts/ci-dev-affected.ts"], packages, [])),
+			...describeTasks(planTasks(["scripts/ci-dev-affected.ts"], packages)),
+		];
+		for (const key of ["ci-selftest", "ci-dry-run", "affected-selftest", "affected-dry-run"]) {
+			expect(entries.find(entry => entry.key === key)).toMatchObject({ rust: true, nextest: false });
+		}
+	});
+
 	test("cwd is emitted repo-relative for package-scoped tasks", () => {
 		const entries = describeTasks(planForPaths(["packages/example/src/index.ts"]));
 		const pkgCheck = entries.find(entry => entry.key === "check:@gajae-code/example");
@@ -179,12 +230,13 @@ describe("--matrix-json and --task CLI fan-out", () => {
 
 	afterAll(async () => {
 		await Promise.all(tempDirs.map(dir => fs.rm(dir, { recursive: true, force: true })));
+		await fs.rm(path.join(repoRoot, ".ci-dev-affected-plan.json"), { force: true });
 	});
 
 	async function runScript(
 		args: readonly string[],
 		changedPaths: string,
-		extraEnv: Record<string, string> = {},
+		extraEnv: Record<string, string | undefined> = {},
 	): Promise<{ stdout: string; stderr: string; exitCode: number }> {
 		const proc = Bun.spawn(["bun", scriptPath, ...args], {
 			cwd: repoRoot,
@@ -194,6 +246,18 @@ describe("--matrix-json and --task CLI fan-out", () => {
 			// tests and explicit shard-mode cases.
 			env: {
 				...process.env,
+				CI_DEV_AFFECTED_PLAN: undefined,
+				CI_DEV_PLAN_DIGEST: undefined,
+				CI_DEV_PLAN_SOURCE_SHA: undefined,
+				CI_DEV_SOURCE_SHA: undefined,
+				CI_DEV_MATRIX_IDENTITY: undefined,
+				CI_DEV_MATRIX_KEY: undefined,
+				CI_DEV_MATRIX_NATIVE: undefined,
+				CI_DEV_MATRIX_NEXTEST: undefined,
+				CI_DEV_MATRIX_RUST: undefined,
+				CI_DEV_SHARD_INDEX: undefined,
+				CI_DEV_SHARD_RECEIPTS: undefined,
+				AFFECTED_TASK_KEY: undefined,
 				GITHUB_EVENT_NAME: "push",
 				CI_DEV_PLAN_MODE: "push",
 				CI_DEV_CHANGED_PATHS: changedPaths,
@@ -222,18 +286,200 @@ describe("--matrix-json and --task CLI fan-out", () => {
 
 		const entries = JSON.parse(stdout.trim());
 		expect(entries.some((entry: { key: string; rust: boolean; native: boolean }) => entry.key === "rust-check" && entry.rust === true && entry.native === false)).toBe(true);
+		expect(entries.some((entry: { key: string; rust: boolean; nativeBuild: boolean }) => entry.key.startsWith("cargo-build:") && entry.rust === true && entry.nativeBuild === false)).toBe(true);
+		expect(entries.filter((entry: { key: string }) => entry.key === "native-linux-x64")).toHaveLength(1);
 
 		const output = await Bun.file(outputFile).text();
 		expect(output).toContain("has_tasks=true");
-		expect(output).toContain("has_native=false");
+		expect(output).toContain("has_native=true");
 		expect(output).toContain("changed_paths<<");
 
 		const matrixLine = output.split("\n").find(line => line.startsWith("matrix="));
 		expect(matrixLine).toBeDefined();
 		const matrix = JSON.parse((matrixLine as string).slice("matrix=".length));
 		expect(matrix.include.some((shard: { key: string }) => shard.key === "rust-check")).toBe(true);
+		expect(matrix.include.some((shard: { key: string }) => shard.key.startsWith("cargo-build:"))).toBe(true);
 		// Native build tasks never appear as shards.
 		expect(matrix.include.every((shard: { key: string }) => shard.key !== "native-linux-x64")).toBe(true);
+	});
+
+	test("changed-path ranges use the canonical source head instead of ambient PR merge SHA", async () => {
+		const head = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repoRoot }).stdout.toString().trim();
+		// The affected-shard checkout intentionally contains only the canonical source
+		// commit. Reusing it as the base proves source-head authority without assuming
+		// that unrelated parent or remote refs exist in the shallow checkout.
+		const base = head;
+		const missingMergeSha = "1".repeat(40);
+		const pr = await runScript(["--matrix-json"], "", {
+			GITHUB_EVENT_NAME: "pull_request", GITHUB_BASE_REF: "", GITHUB_BASE_SHA: base,
+			GITHUB_SHA: missingMergeSha, CI_DEV_SOURCE_SHA: head,
+		});
+		expect(pr.exitCode).toBe(0);
+
+		const push = await runScript(["--matrix-json"], "", {
+			GITHUB_EVENT_NAME: "push", GITHUB_EVENT_BEFORE: base, GITHUB_BASE_SHA: "",
+			GITHUB_SHA: missingMergeSha, CI_DEV_SOURCE_SHA: head,
+		});
+		expect(push.exitCode).toBe(0);
+
+		const missingHead = await runScript(["--matrix-json"], "", {
+			GITHUB_EVENT_NAME: "pull_request", GITHUB_BASE_REF: "", GITHUB_BASE_SHA: base,
+			GITHUB_SHA: head, CI_DEV_SOURCE_SHA: "2".repeat(40),
+		});
+		expect(missingHead.exitCode).toBe(1);
+		expect(missingHead.stderr).toContain("source head");
+		expect(missingHead.stderr).toContain("is not available");
+	});
+
+	test("Cargo selection includes transitive dependents and never emits vendored shards", async () => {
+		const sdk = await runScript(["--matrix-json"], "crates/gjc-sdk/src/lib.rs");
+		expect(sdk.exitCode).toBe(0);
+		const sdkKeys = (JSON.parse(sdk.stdout.trim()) as Array<{ key: string }>).map(entry => entry.key);
+		expect(sdkKeys.filter(key => key.startsWith("cargo-build:"))).toEqual([
+			"cargo-build:cargo:Z2pjLXNkaw:Y3JhdGVzL2dqYy1zZGsvQ2FyZ28udG9tbA",
+			"cargo-build:cargo:cGktbmF0aXZlcw:Y3JhdGVzL3BpLW5hdGl2ZXMvQ2FyZ28udG9tbA",
+		]);
+		expect(sdkKeys.filter(key => key === "native-linux-x64")).toHaveLength(1);
+
+		const vendored = await runScript(["--matrix-json"], "crates/brush-core-vendored/src/lib.rs");
+		expect(vendored.exitCode).toBe(0);
+		const vendoredKeys = (JSON.parse(vendored.stdout.trim()) as Array<{ key: string }>).map(entry => entry.key);
+		expect(vendoredKeys.filter(key => key.startsWith("cargo-build:"))).toHaveLength(5);
+		expect(vendoredKeys.some(key => key.includes("brush"))).toBe(false);
+	});
+
+	test("root/shared build inputs select every inventory TypeScript build in stable order", async () => {
+		const { stdout, exitCode } = await runScript(["--matrix-json"], "bun.lock");
+		expect(exitCode).toBe(0);
+		const entries = JSON.parse(stdout.trim()) as Array<{ key: string }>;
+		expect(entries.filter(entry => entry.key.startsWith("ts-build:")).map(entry => entry.key)).toEqual([
+			"ts-build:ts:Y29kaW5nLWFnZW50:cGFja2FnZXMvY29kaW5nLWFnZW50",
+			"ts-build:ts:c3RhdHM:cGFja2FnZXMvc3RhdHM",
+		]);
+	});
+
+	test("package documentation changes do not schedule build shards", async () => {
+		const { stdout, exitCode } = await runScript(["--matrix-json"], "packages/coding-agent/README.md", {
+			CI_DEV_PLAN_MODE: "pr",
+			CI_DEV_SOURCE_SHA: "a".repeat(40),
+			PATH: path.dirname(process.execPath),
+		});
+		expect(exitCode).toBe(0);
+		expect(JSON.parse(stdout.trim())).toEqual([]);
+	});
+
+	test("unknown unowned inputs fail open to every TypeScript and Cargo build family", async () => {
+		for (const changedPath of ["Makefile", "packages/new-workspace/src/index.ts"]) {
+			const { stdout, exitCode } = await runScript(["--matrix-json"], changedPath);
+			expect(exitCode).toBe(0);
+			const entries = JSON.parse(stdout.trim()) as Array<{ key: string }>;
+			expect(entries.filter(entry => entry.key.startsWith("ts-build:")).map(entry => entry.key)).toHaveLength(2);
+			expect(entries.filter(entry => entry.key.startsWith("cargo-build:")).map(entry => entry.key)).toHaveLength(5);
+			expect(entries.filter(entry => entry.key === "native-linux-x64")).toHaveLength(1);
+		}
+	});
+
+	test("native workspace changes have exact PR and push plans", async () => {
+		const pr = await runScript(["--matrix-json"], "packages/natives/src/index.ts", { CI_DEV_PLAN_MODE: "pr" });
+		expect(pr.exitCode).toBe(0);
+		expect((JSON.parse(pr.stdout.trim()) as Array<{ key: string }>).map(entry => entry.key)).toEqual([
+			"check:@gajae-code/natives",
+			"native-linux-x64",
+			"ts-build:ts:Y29kaW5nLWFnZW50:cGFja2FnZXMvY29kaW5nLWFnZW50",
+			"ts-build:ts:c3RhdHM:cGFja2FnZXMvc3RhdHM",
+		]);
+
+		const push = await runScript(["--matrix-json"], "packages/natives/src/index.ts", { CI_DEV_PLAN_MODE: "push" });
+		expect(push.exitCode).toBe(0);
+		expect((JSON.parse(push.stdout.trim()) as Array<{ key: string }>).map(entry => entry.key)).toEqual([
+			"check:@gajae-code/agent-core", "test:@gajae-code/agent-core",
+			"check:@gajae-code/ai", "test:@gajae-code/ai",
+			"check:@gajae-code/coding-agent",
+			...Array.from({ length: 8 }, (_, index) => `test:@gajae-code/coding-agent:shard-${index + 1}-of-8`),
+			"check:@gajae-code/natives", "test:@gajae-code/natives",
+			"check:@gajae-code/stats",
+			"check:@gajae-code/tui", "test:@gajae-code/tui",
+			"check:@gajae-code/typescript-edit-benchmark", "test:@gajae-code/typescript-edit-benchmark",
+			"check:@gajae-code/utils", "test:@gajae-code/utils",
+			"native-linux-x64",
+			"ts-build:ts:Y29kaW5nLWFnZW50:cGFja2FnZXMvY29kaW5nLWFnZW50",
+			"ts-build:ts:c3RhdHM:cGFja2FnZXMvc3RhdHM",
+		]);
+	});
+
+	test("canonical plan validation binds exact bytes and source head", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-plan-"));
+		tempDirs.push(tempDir);
+		const outputFile = path.join(tempDir, "github-output.txt");
+		const planFile = path.join(tempDir, "plan.json");
+		const head = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repoRoot }).stdout.toString().trim();
+		const generated = await runScript(["--matrix-json"], "packages/stats/src/index.ts", {
+			GITHUB_OUTPUT: outputFile,
+			CI_DEV_SOURCE_SHA: head,
+		});
+		expect(generated.exitCode).toBe(0);
+		await Bun.write(planFile, Bun.file(path.join(repoRoot, ".ci-dev-affected-plan.json")));
+		const output = await Bun.file(outputFile).text();
+		const digest = output.split("\n").find(line => line.startsWith("plan_digest="))?.slice("plan_digest=".length);
+		expect(digest).toBeDefined();
+		const valid = await runScript(["--validate-plan"], "packages/stats/src/index.ts", {
+			CI_DEV_AFFECTED_PLAN: planFile,
+			CI_DEV_PLAN_DIGEST: digest as string,
+			CI_DEV_PLAN_SOURCE_SHA: head,
+		});
+		expect(valid.exitCode).toBe(0);
+		const receiptDir = path.join(tempDir, "receipts");
+		await fs.mkdir(receiptDir);
+		const plan = JSON.parse(await Bun.file(planFile).text()) as { tasks: Array<{ key: string; identity: string; capabilities: { nativeProducer: boolean } }> };
+		const expectedShards = plan.tasks.filter(task => !task.capabilities.nativeProducer);
+		for (const [index, task] of expectedShards.entries()) {
+			await Bun.write(path.join(receiptDir, `${index}.json`), JSON.stringify({ key: task.key, identity: task.identity }));
+		}
+		const receiptsValid = await runScript(["--validate-shard-receipts"], "packages/stats/src/index.ts", {
+			CI_DEV_AFFECTED_PLAN: planFile,
+			CI_DEV_PLAN_DIGEST: digest as string,
+			CI_DEV_PLAN_SOURCE_SHA: head,
+			CI_DEV_SHARD_RECEIPTS: receiptDir,
+		});
+		expect(receiptsValid.exitCode).toBe(0);
+		await fs.rm(path.join(receiptDir, "0.json"));
+		const receiptMissing = await runScript(["--validate-shard-receipts"], "packages/stats/src/index.ts", {
+			CI_DEV_AFFECTED_PLAN: planFile,
+			CI_DEV_PLAN_DIGEST: digest as string,
+			CI_DEV_PLAN_SOURCE_SHA: head,
+			CI_DEV_SHARD_RECEIPTS: receiptDir,
+		});
+		expect(receiptMissing.exitCode).toBe(1);
+		expect(receiptMissing.stderr).toContain("shard receipt set does not match canonical plan");
+		const wrongSource = await runScript(["--validate-plan"], "packages/stats/src/index.ts", {
+			CI_DEV_AFFECTED_PLAN: planFile,
+			CI_DEV_PLAN_DIGEST: digest as string,
+			CI_DEV_PLAN_SOURCE_SHA: "0".repeat(40),
+		});
+		expect(wrongSource.exitCode).toBe(1);
+		expect(wrongSource.stderr).toContain("source SHA mismatch");
+
+		const matrixEntry = (JSON.parse(generated.stdout.trim()) as Array<{ key: string; rust: boolean; nextest: boolean; native: boolean }>).find(entry => !entry.key.startsWith("native-linux-x64"));
+		expect(matrixEntry).toBeDefined();
+		const wrongCapabilities = await runScript(["--validate-plan"], "packages/stats/src/index.ts", {
+			CI_DEV_AFFECTED_PLAN: planFile,
+			CI_DEV_PLAN_DIGEST: digest as string,
+			CI_DEV_PLAN_SOURCE_SHA: head,
+			CI_DEV_MATRIX_KEY: matrixEntry?.key as string,
+			CI_DEV_MATRIX_RUST: String(!(matrixEntry?.rust ?? false)),
+			CI_DEV_MATRIX_NEXTEST: String(matrixEntry?.nextest ?? false),
+			CI_DEV_MATRIX_NATIVE: String(matrixEntry?.native ?? false),
+		});
+		expect(wrongCapabilities.exitCode).toBe(1);
+		expect(wrongCapabilities.stderr).toContain("matrix capabilities mismatch");
+		await Bun.write(planFile, `${await Bun.file(planFile).text()}\n`);
+		const tampered = await runScript(["--validate-plan"], "packages/stats/src/index.ts", {
+			CI_DEV_AFFECTED_PLAN: planFile,
+			CI_DEV_PLAN_DIGEST: digest as string,
+			CI_DEV_PLAN_SOURCE_SHA: head,
+		});
+		expect(tampered.exitCode).toBe(1);
+		expect(tampered.stderr).toContain("digest mismatch");
 	});
 
 	test("--task runs exactly the selected planned task", async () => {
@@ -345,10 +591,13 @@ describe("planTargetedTasks PR-mode targeting", () => {
 		const liveShard = entries.find(entry => entry.key === "test:packages/coding-agent/test/rlm-live-model-e2e.test.ts");
 		expect(liveShard).toEqual({
 			key: "test:packages/coding-agent/test/rlm-live-model-e2e.test.ts",
+			identity: "legacy:dGVzdDpwYWNrYWdlcy9jb2RpbmctYWdlbnQvdGVzdC9ybG0tbGl2ZS1tb2RlbC1lMmUudGVzdC50cw:Lg",
 			description: "Test packages/coding-agent/test/rlm-live-model-e2e.test.ts",
 			command: ["bun", "test", "packages/coding-agent/test/rlm-live-model-e2e.test.ts"],
+			cwd: undefined,
 			native: true,
 			rust: false,
+			nextest: false,
 			nativeBuild: false,
 		});
 		expect(entries.find(entry => entry.key === "native-linux-x64")?.nativeBuild).toBe(true);
@@ -543,5 +792,66 @@ describe("push-mode broad planning still runs the fuller suite", () => {
 			"test:@gajae-code/coding-agent:shard-7-of-8",
 			"test:@gajae-code/coding-agent:shard-8-of-8",
 		]);
+	});
+});
+
+describe("normalizeChangedPaths", () => {
+	test("normalizes, deduplicates, and orders safe repository-relative paths", () => {
+		expect(normalizeChangedPaths(["packages\\stats/src/index.ts", "./packages/stats/src/index.ts"])).toEqual(["packages/stats/src/index.ts"]);
+	});
+
+	test("rejects absolute and escaping paths", () => {
+		for (const unsafe of ["/etc/passwd", "../package.json", "packages/../package.json", "C:/workspace/package.json"]) {
+			expect(() => normalizeChangedPaths([unsafe])).toThrow("affected-path-invalid");
+		}
+	});
+});
+
+describe("build inventory validation", () => {
+	test("rejects unknown fields and duplicate Cargo names without the typed emergency", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-inventory-"));
+		try {
+			const source = JSON.parse(await Bun.file(path.join(import.meta.dir, "ci-dev-affected-build-inventory.json")).text()) as {
+				schemaVersion: number;
+				typescript: Array<Record<string, unknown>>;
+				cargo: Array<Record<string, unknown>>;
+				emergency: Record<string, unknown>;
+			};
+			const unknownPath = path.join(root, "unknown.json");
+			await Bun.write(unknownPath, JSON.stringify({ ...source, unexpected: true }));
+			await expect(loadBuildInventory(unknownPath)).rejects.toThrow("unexpected build inventory field");
+
+			const duplicatePath = path.join(root, "duplicate.json");
+			const duplicateCargo = source.cargo.map((unit, index) => index === 1 ? { ...unit, name: source.cargo[0]?.name } : unit);
+			await Bun.write(duplicatePath, JSON.stringify({ ...source, cargo: duplicateCargo, emergency: {} }));
+			await expect(loadBuildInventory(duplicatePath)).rejects.toThrow("duplicate Cargo names require workspace emergency");
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("workspace dependent closure", () => {
+	const leaf: WorkspacePackage = { name: "leaf", dir: "packages/leaf", manifest: { name: "leaf", dependencies: { top: "workspace:*" } } };
+	const middle: WorkspacePackage = { name: "middle", dir: "packages/middle", manifest: { name: "middle", dependencies: { leaf: "workspace:*" } } };
+	const top: WorkspacePackage = { name: "top", dir: "packages/top", manifest: { name: "top", dependencies: { middle: "workspace:*" } } };
+	const graph = [leaf, middle, top];
+
+	test("selects direct and transitive dependents through a cycle without duplicates", () => {
+		expect(expandWithDependents([leaf], graph).map(unit => unit.name)).toEqual(["leaf", "middle", "top"]);
+		expect(expandWithDependents([middle], graph).map(unit => unit.name)).toEqual(["leaf", "middle", "top"]);
+	});
+});
+
+describe("Cargo workspace ambiguity", () => {
+	const first: CargoInventoryUnit = { id: "first", name: "duplicate", manifestPath: "crates/first/Cargo.toml", supported: true, nativeAddonSource: false };
+	const second: CargoInventoryUnit = { id: "second", name: "duplicate", manifestPath: "crates/second/Cargo.toml", supported: true, nativeAddonSource: false };
+	const unique: CargoInventoryUnit = { id: "unique", name: "unique", manifestPath: "crates/unique/Cargo.toml", supported: true, nativeAddonSource: false };
+	const supported = [first, second, unique];
+
+	test("uses the workspace emergency when any selected name is globally duplicated", () => {
+		expect(requiresCargoWorkspaceEmergency([first], supported)).toBe(true);
+		expect(requiresCargoWorkspaceEmergency([first, second], supported)).toBe(true);
+		expect(requiresCargoWorkspaceEmergency([unique], supported)).toBe(false);
 	});
 });

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -54,9 +54,52 @@ export interface WorkspacePackage {
 
 export interface Task {
 	key: string;
+	identity?: string;
 	description: string;
 	command: readonly string[];
 	cwd?: string;
+	capabilities?: TaskCapabilities;
+	phase?: "legacy" | "native-producer" | "ts-build" | "cargo-build";
+}
+
+export interface TaskCapabilities {
+	rust: boolean;
+	nextest: boolean;
+	nativeConsumer: boolean;
+	nativeProducer: boolean;
+}
+
+export interface TsInventoryUnit {
+	id: string;
+	name: string;
+	dir: string;
+	nativeConsumer: boolean;
+	nativeProducer: boolean;
+}
+
+export interface CargoInventoryUnit {
+	id: string;
+	name: string;
+	manifestPath: string;
+	supported: true;
+	nativeAddonSource: boolean;
+}
+
+export interface CargoWorkspaceEmergency {
+	id: "cargo-workspace-emergency";
+	key: "cargo-build:emergency:workspace";
+	identity: "emergency:cargo-workspace:root";
+	command: readonly ["cargo", "build", "--workspace"];
+	cwd: ".";
+	capabilities: TaskCapabilities;
+	allowedReasons: readonly ["cargo-name-ambiguity"];
+}
+
+export interface BuildInventory {
+	schemaVersion: 1;
+	typescript: readonly TsInventoryUnit[];
+	cargo: readonly CargoInventoryUnit[];
+	emergency: { cargoWorkspaceBuild?: CargoWorkspaceEmergency };
 }
 
 // Machine-readable descriptor for one planned task, emitted by `--matrix-json`
@@ -66,11 +109,13 @@ export interface Task {
 // native-build job rather than as shards.
 export interface TaskMatrixEntry {
 	key: string;
+	identity: string;
 	description: string;
 	command: readonly string[];
 	cwd?: string;
 	native: boolean;
 	rust: boolean;
+	nextest: boolean;
 	nativeBuild: boolean;
 }
 
@@ -83,6 +128,14 @@ async function main(): Promise<void> {
 	}
 	if (process.argv.includes("--matrix-json")) {
 		await emitMatrix();
+		return;
+	}
+	if (process.argv.includes("--validate-plan")) {
+		if (!(await loadCanonicalPlan())) throw new Error("affected-plan-invalid: canonical plan is required");
+		return;
+	}
+	if (process.argv.includes("--validate-shard-receipts")) {
+		await validateShardReceipts();
 		return;
 	}
 	if (process.argv.includes("--native-build")) {
@@ -113,9 +166,6 @@ async function main(): Promise<void> {
 	}
 }
 
-if (import.meta.main) {
-	await main();
-}
 
 // CI runs in one of two planning modes:
 //   - "pr": pull_request runs get a fast, narrowly targeted plan (run only the
@@ -138,12 +188,15 @@ export function resolvePlanMode(): PlanMode {
 // targeted plan from a filesystem index of test files (for source→test mapping);
 // push mode reuses the broad affected planner unchanged.
 async function resolvePlannedTasks(paths: readonly string[]): Promise<Task[]> {
+	const fromArtifact = await loadCanonicalPlan();
+	if (fromArtifact) return fromArtifact;
+	const normalizedPaths = normalizeChangedPaths(paths);
 	const packages = await getWorkspacePackages();
-	if (resolvePlanMode() === "pr") {
-		const testFiles = await gatherTestFiles();
-		return planTargetedTasks(paths, packages, testFiles);
-	}
-	return planTasks(paths, packages);
+	const legacy = resolvePlanMode() === "pr"
+		? planTargetedTasks(normalizedPaths, packages, await gatherTestFiles())
+		: planTasks(normalizedPaths, packages);
+	if (normalizedPaths.length > 0 && normalizedPaths.every(isDocOrChangelogPath)) return legacy;
+	return appendBuildTasks(legacy, normalizedPaths, packages, await loadBuildInventory());
 }
 
 // Repo-relative list of TypeScript test files, used by PR-mode targeting to map
@@ -212,7 +265,7 @@ function taskNeedsNative(key: string): boolean {
 
 // Tasks that need the Rust toolchain (and nextest) provisioned on their shard.
 function taskNeedsRust(key: string): boolean {
-	return key === "rust-check" || key === "rust-test";
+	return key === "rust-check" || key === "rust-test" || key === "ci-selftest" || key === "ci-dry-run" || key === "affected-selftest" || key === "affected-dry-run";
 }
 
 // Build the machine-readable descriptor list for the current changed-path plan.
@@ -220,12 +273,14 @@ function taskNeedsRust(key: string): boolean {
 export function describeTasks(tasks: readonly Task[]): TaskMatrixEntry[] {
 	return tasks.map(task => ({
 		key: task.key,
+		identity: canonicalTaskIdentity(task),
 		description: task.description,
 		command: task.command,
 		cwd: task.cwd ? path.relative(repoRoot, task.cwd) || "." : undefined,
-		native: taskNeedsNative(task.key),
-		rust: taskNeedsRust(task.key),
-		nativeBuild: isNativeBuildKey(task.key),
+		native: task.capabilities?.nativeConsumer ?? taskNeedsNative(task.key),
+		rust: task.capabilities?.rust ?? taskNeedsRust(task.key),
+		nextest: task.capabilities?.nextest ?? task.key === "rust-test",
+		nativeBuild: task.capabilities?.nativeProducer ?? isNativeBuildKey(task.key),
 	}));
 }
 
@@ -236,25 +291,28 @@ export function describeTasks(tasks: readonly Task[]): TaskMatrixEntry[] {
 // downstream job reuses the planner's exact diff via CI_DEV_CHANGED_PATHS
 // instead of re-resolving the base ref on each runner.
 async function emitMatrix(): Promise<void> {
-	const paths = await getChangedPaths();
+	const paths = normalizeChangedPaths(await getChangedPaths());
 	const mode = resolvePlanMode();
 	const tasks = await resolvePlannedTasks(paths);
 	const entries = describeTasks(tasks);
-
+	const sourceSha = Bun.env.CI_DEV_SOURCE_SHA?.trim() || (Bun.env.GITHUB_SHA ?? "HEAD");
+	const canonical = JSON.stringify({ schemaVersion: 1, sourceSha, mode, paths, tasks: serializeTasks(tasks) });
+	const digest = new Bun.CryptoHasher("sha256").update(canonical).digest("hex");
+	await Bun.write(path.join(repoRoot, ".ci-dev-affected-plan.json"), canonical);
 	console.log(JSON.stringify(entries));
 
 	const githubOutput = process.env.GITHUB_OUTPUT;
-	if (!githubOutput) {
-		return;
-	}
+	if (!githubOutput) return;
 	const shards = entries
 		.filter(entry => !entry.nativeBuild)
-		.map(entry => ({ key: entry.key, description: entry.description, native: entry.native, rust: entry.rust }));
+		.map(entry => ({ key: entry.key, identity: entry.identity, description: entry.description, native: entry.native, rust: entry.rust, nextest: entry.nextest }));
 	const hasNative = entries.some(entry => entry.nativeBuild);
 	const lines = [
 		`matrix=${JSON.stringify({ include: shards })}`,
 		`has_tasks=${shards.length > 0}`,
 		`has_native=${hasNative}`,
+		`plan_digest=${digest}`,
+		`plan_source_sha=${sourceSha}`,
 		`plan_mode=${mode}`,
 		"changed_paths<<__GJC_PATHS_EOF__",
 		...paths,
@@ -334,14 +392,21 @@ async function getChangedPaths(): Promise<string[]> {
 	}
 
 	const base = await resolveBaseRef();
-	const head = Bun.env.GITHUB_SHA?.trim() || "HEAD";
-	const range = base.includes("...") || base.includes("..") ? base : `${base}...${head}`;
+	const head = Bun.env.CI_DEV_SOURCE_SHA?.trim() || Bun.env.GITHUB_SHA?.trim() || "HEAD";
+	await requireCommitObject(base, "base");
+	await requireCommitObject(head, "source head");
+	const range = `${base}...${head}`;
 	const diff = await $`git diff --name-only -z ${range}`.cwd(repoRoot).quiet().nothrow();
 	if (diff.exitCode !== 0) {
 		const stderr = diff.stderr.toString().trim();
 		throw new Error(`Failed to compute changed paths for ${range}: ${stderr}`);
 	}
 	return new TextDecoder().decode(diff.stdout).split("\0").filter(Boolean).sort();
+}
+
+async function requireCommitObject(ref: string, label: string): Promise<void> {
+	const result = await $`git cat-file -e ${`${ref}^{commit}`}`.cwd(repoRoot).quiet().nothrow();
+	if (result.exitCode !== 0) throw new Error(`Failed to compute changed paths: ${label} '${ref}' is not available`);
 }
 
 async function resolveBaseRef(): Promise<string> {
@@ -362,7 +427,7 @@ async function resolveBaseRef(): Promise<string> {
 		return baseSha;
 	}
 	if (before && !ZERO_SHA.test(before)) {
-		return `${before}..${Bun.env.GITHUB_SHA?.trim() || "HEAD"}`;
+		return before;
 	}
 
 	const mergeBase = await $`git merge-base HEAD origin/dev`.cwd(repoRoot).quiet().nothrow();
@@ -765,7 +830,7 @@ function findTouchedPackages(paths: readonly string[], packages: readonly Worksp
 	return packages.filter(workspacePackage => paths.some(changedPath => changedPath === workspacePackage.dir || changedPath.startsWith(`${workspacePackage.dir}/`)));
 }
 
-function expandWithDependents(touched: readonly WorkspacePackage[], packages: readonly WorkspacePackage[]): WorkspacePackage[] {
+export function expandWithDependents(touched: readonly WorkspacePackage[], packages: readonly WorkspacePackage[]): WorkspacePackage[] {
 	const workspaceByName = new Map(packages.map(workspacePackage => [workspacePackage.name, workspacePackage]));
 	const selected = new Map(touched.map(workspacePackage => [workspacePackage.name, workspacePackage]));
 	const queue = [...touched.map(workspacePackage => workspacePackage.name)];
@@ -877,6 +942,236 @@ function isWorkflowPath(changedPath: string): boolean {
 	return changedPath.startsWith(".github/workflows/");
 }
 
+
+const BUILD_INVENTORY_PATH = path.join(repoRoot, "scripts/ci-dev-affected-build-inventory.json");
+const NATIVE_PRODUCER: Task = {
+	key: "native-linux-x64",
+	identity: "native:linux-x64:baseline-modern",
+	description: "Build linux x64 native addons",
+	command: ["bash", "-lc", 'TARGET_VARIANTS="baseline modern" bun scripts/ci-build-native.ts'],
+	cwd: repoRoot,
+	capabilities: { rust: true, nextest: false, nativeConsumer: false, nativeProducer: true },
+	phase: "native-producer",
+};
+
+export function normalizeChangedPaths(paths: readonly string[]): string[] {
+	const normalized = paths.map(entry => entry.replaceAll("\\", "/").trim()).map(entry => entry.replace(/^\.\//, ""));
+	for (const entry of normalized) {
+		if (!entry || entry.startsWith("/") || /^[A-Za-z]:\//.test(entry) || entry === ".." || entry.startsWith("../") || entry.includes("/../") || entry.split("/").some(part => part === "." || part === "")) {
+			throw new Error(`affected-path-invalid: unsafe changed path '${entry}'`);
+		}
+	}
+	return Array.from(new Set(normalized)).sort();
+}
+
+export async function loadBuildInventory(inventoryPath = BUILD_INVENTORY_PATH): Promise<BuildInventory> {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(await Bun.file(inventoryPath).text());
+	} catch (error) {
+		throw new Error(`inventory-invalid: cannot read build inventory (${error instanceof Error ? error.message : String(error)})`);
+	}
+	if (!isRecord(parsed) || parsed.schemaVersion !== 1 || !Array.isArray(parsed.typescript) || !Array.isArray(parsed.cargo) || !isRecord(parsed.emergency)) {
+		throw new Error("inventory-invalid: malformed build inventory");
+	}
+	assertExactKeys(parsed, ["schemaVersion", "typescript", "cargo", "emergency"], "build inventory");
+	const inventory: BuildInventory = {
+		schemaVersion: 1,
+		typescript: parsed.typescript.map(parseTsInventoryUnit),
+		cargo: parsed.cargo.map(parseCargoInventoryUnit),
+		emergency: parseEmergency(parsed.emergency),
+	};
+	assertInventory(inventory);
+	await assertTypeScriptInventoryLive(inventory);
+	await expandCargoDependents(inventory.cargo, inventory.cargo, false);
+	return inventory;
+}
+
+function parseTsInventoryUnit(value: unknown): TsInventoryUnit {
+	if (!isRecord(value) || !isString(value.id) || !isString(value.name) || !isString(value.dir) || typeof value.nativeConsumer !== "boolean" || typeof value.nativeProducer !== "boolean") throw new Error("inventory-invalid: malformed TypeScript unit");
+	assertExactKeys(value, ["id", "name", "dir", "nativeConsumer", "nativeProducer"], "TypeScript unit");
+	return { id: value.id, name: value.name, dir: normalizeInventoryPath(value.dir), nativeConsumer: value.nativeConsumer, nativeProducer: value.nativeProducer };
+}
+function parseCargoInventoryUnit(value: unknown): CargoInventoryUnit {
+	if (!isRecord(value) || !isString(value.id) || !isString(value.name) || !isString(value.manifestPath) || value.supported !== true || typeof value.nativeAddonSource !== "boolean") throw new Error("inventory-invalid: malformed Cargo unit");
+	assertExactKeys(value, ["id", "name", "manifestPath", "supported", "nativeAddonSource"], "Cargo unit");
+	return { id: value.id, name: value.name, manifestPath: normalizeInventoryPath(value.manifestPath), supported: true, nativeAddonSource: value.nativeAddonSource };
+}
+function parseEmergency(value: Record<string, unknown>): BuildInventory["emergency"] {
+	if (Object.keys(value).some(key => key !== "cargoWorkspaceBuild")) throw new Error("inventory-invalid: unexpected emergency field");
+	const emergency = value.cargoWorkspaceBuild;
+	if (emergency === undefined) return {};
+	if (!isRecord(emergency) || emergency.id !== "cargo-workspace-emergency" || emergency.key !== "cargo-build:emergency:workspace" || emergency.identity !== "emergency:cargo-workspace:root" || !Array.isArray(emergency.command) || emergency.command.join("\0") !== "cargo\0build\0--workspace" || emergency.cwd !== "." || !isRecord(emergency.capabilities) || emergency.allowedReasons === undefined || !Array.isArray(emergency.allowedReasons) || emergency.allowedReasons.join("\0") !== "cargo-name-ambiguity") throw new Error("inventory-invalid: malformed cargo workspace emergency");
+	assertExactKeys(emergency, ["id", "key", "identity", "command", "cwd", "capabilities", "allowedReasons"], "cargo workspace emergency");
+	const capabilities = emergency.capabilities;
+	if (capabilities.rust !== true || capabilities.nextest !== false || capabilities.nativeConsumer !== false || capabilities.nativeProducer !== false) throw new Error("inventory-invalid: malformed cargo workspace emergency capabilities");
+	assertExactKeys(capabilities, ["rust", "nextest", "nativeConsumer", "nativeProducer"], "cargo workspace emergency capabilities");
+	return { cargoWorkspaceBuild: { id: "cargo-workspace-emergency", key: "cargo-build:emergency:workspace", identity: "emergency:cargo-workspace:root", command: ["cargo", "build", "--workspace"], cwd: ".", capabilities: { rust: true, nextest: false, nativeConsumer: false, nativeProducer: false }, allowedReasons: ["cargo-name-ambiguity"] } };
+}
+function normalizeInventoryPath(value: string): string {
+	const normalized = value.replaceAll("\\", "/").replace(/^\.\//, "");
+	if (!normalized || normalized.startsWith("/") || normalized.includes("../") || normalized.split("/").some(part => !part || part === ".")) throw new Error("inventory-invalid: unsafe inventory path");
+	return normalized;
+}
+function assertInventory(inventory: BuildInventory): void {
+	const unique = (values: readonly string[], label: string) => { if (new Set(values).size !== values.length) throw new Error(`inventory-invalid: duplicate ${label}`); };
+	unique(inventory.typescript.map(unit => unit.id), "TypeScript id");
+	unique(inventory.typescript.map(unit => unit.name), "TypeScript name");
+	unique(inventory.typescript.map(unit => unit.dir), "TypeScript directory");
+	unique(inventory.cargo.map(unit => unit.id), "Cargo id");
+	unique(inventory.cargo.map(unit => unit.manifestPath), "Cargo manifest path");
+	const nativeSources = inventory.cargo.filter(unit => unit.nativeAddonSource);
+	if (nativeSources.length !== 1 || nativeSources[0]?.id !== "pi-natives") throw new Error("inventory-invalid: pi-natives must be the sole native addon source");
+	const counts = new Map<string, number>();
+	for (const unit of inventory.cargo) counts.set(unit.name, (counts.get(unit.name) ?? 0) + 1);
+	if (Array.from(counts.values()).some(count => count > 1) && !inventory.emergency.cargoWorkspaceBuild) throw new Error("inventory-invalid: duplicate Cargo names require workspace emergency");
+}
+
+async function assertTypeScriptInventoryLive(inventory: BuildInventory): Promise<void> {
+	const workspaces = await getWorkspacePackages();
+	const buildable = workspaces.filter(workspacePackage => workspacePackage.name !== "@gajae-code/natives" && workspacePackage.manifest.scripts?.build);
+	const classified = inventory.typescript.filter(unit => !unit.nativeProducer);
+	const buildableNames = new Set(buildable.map(workspacePackage => workspacePackage.name));
+	const classifiedNames = new Set(classified.map(unit => unit.name));
+	if (buildableNames.size !== classifiedNames.size || Array.from(buildableNames).some(name => !classifiedNames.has(name))) {
+		throw new Error("inventory-drift: TypeScript build-capable workspaces are not fully classified");
+	}
+	for (const unit of inventory.typescript) {
+		const manifest = await readPackageManifest(path.join(repoRoot, unit.dir, "package.json"));
+		if (!manifest || manifest.name !== unit.name || (!unit.nativeProducer && !manifest.scripts?.build)) throw new Error(`inventory-drift: TypeScript build unit ${unit.id} does not match its package manifest`);
+	}
+}
+
+async function appendBuildTasks(legacy: readonly Task[], paths: readonly string[], packages: readonly WorkspacePackage[], inventory: BuildInventory): Promise<Task[]> {
+	const withoutNative = legacy.filter(task => !isNativeBuildKey(task.key));
+	const buildPaths = paths.filter(changedPath => !isDocOrChangelogPath(changedPath));
+	const selectedTs = selectTsBuildUnits(buildPaths, packages, inventory);
+	const cargo = await selectCargoBuildTasks(buildPaths, inventory, packages);
+	const legacyNeedsProducer = legacy.some(task => isNativeBuildKey(task.key)) || legacy.some(task => taskNeedsNative(task.key));
+	const cargoNeedsProducer = inventory.cargo
+		.filter(unit => unit.nativeAddonSource)
+		.some(unit => cargo.some(task => task.key === inventory.emergency.cargoWorkspaceBuild?.key || task.identity === stableIdentity("cargo", unit.id, unit.manifestPath)));
+	const needsProducer = legacyNeedsProducer || selectedTs.some(unit => unit.nativeConsumer || unit.nativeProducer) || cargoNeedsProducer;
+	const tsTasks = selectedTs.map(unit => ({ key: `ts-build:${stableIdentity("ts", unit.id, unit.dir)}`, identity: stableIdentity("ts", unit.id, unit.dir), description: `Build ${unit.name}`, command: ["bun", "run", "build"] as const, cwd: resolvePackageCwd(unit.dir), capabilities: { rust: false, nextest: false, nativeConsumer: unit.nativeConsumer, nativeProducer: unit.nativeProducer }, phase: "ts-build" as const }));
+	return [...withoutNative, ...(needsProducer ? [NATIVE_PRODUCER] : []), ...tsTasks, ...cargo];
+}
+function selectTsBuildUnits(paths: readonly string[], packages: readonly WorkspacePackage[], inventory: BuildInventory): TsInventoryUnit[] {
+	const selected = allBuildFallback(paths, packages)
+		? packages
+		: expandWithDependents(findTouchedPackages(paths, packages), packages);
+	const names = new Set(selected.map(unit => unit.name));
+	return inventory.typescript.filter(unit => names.has(unit.name)).sort(compareTsUnits);
+}
+function allBuildFallback(paths: readonly string[], packages: readonly WorkspacePackage[]): boolean {
+	return paths.some(changedPath =>
+		isFullWorkspacePath(changedPath) ||
+		changedPath === "bun.lock" ||
+		changedPath.startsWith("tsconfig") ||
+		isWorkflowHarnessPath(changedPath) ||
+		changedPath === "scripts/ci-dev-affected-build-inventory.json" ||
+		(!isDocOrChangelogPath(changedPath) && !owningPackage(changedPath, packages)),
+	);
+}
+function compareTsUnits(left: TsInventoryUnit, right: TsInventoryUnit): number { return left.dir.localeCompare(right.dir) || left.name.localeCompare(right.name) || left.id.localeCompare(right.id); }
+function stableIdentity(domain: string, id: string, location: string): string { return `${domain}:${toBase64Url(id)}:${toBase64Url(location)}`; }
+function toBase64Url(value: string): string { return Buffer.from(value).toString("base64url"); }
+
+async function selectCargoBuildTasks(paths: readonly string[], inventory: BuildInventory, packages: readonly WorkspacePackage[]): Promise<Task[]> {
+	const supported = inventory.cargo.filter(unit => unit.supported);
+	const fallbackAll = paths.some(changedPath =>
+		changedPath === "Cargo.toml" ||
+		changedPath === "Cargo.lock" ||
+		changedPath === "rust-toolchain.toml" ||
+		changedPath.startsWith(".cargo/") ||
+		isFullWorkspacePath(changedPath) ||
+		isWorkflowHarnessPath(changedPath) ||
+		changedPath === "scripts/ci-dev-affected-build-inventory.json" ||
+		(!isDocOrChangelogPath(changedPath) && !changedPath.startsWith("crates/") && !owningPackage(changedPath, packages)),
+	);
+	if (!fallbackAll && !paths.some(isRustPath)) return [];
+	const cargoChanged = paths.filter(isRustPath);
+	const fallback = fallbackAll || cargoChanged.some(changed => !supported.some(unit => changed === unit.manifestPath || changed.startsWith(`${path.posix.dirname(unit.manifestPath)}/`)));
+	let selected = fallback ? supported : supported.filter(unit => cargoChanged.some(changed => changed === unit.manifestPath || changed.startsWith(`${path.posix.dirname(unit.manifestPath)}/`)));
+	if (!fallback) selected = await expandCargoDependents(selected, supported, true);
+	if (requiresCargoWorkspaceEmergency(selected, supported)) {
+		const emergency = inventory.emergency.cargoWorkspaceBuild;
+		if (!emergency) throw new Error("inventory-invalid: duplicate selected Cargo name has no emergency");
+		return [{
+			key: emergency.key,
+			identity: emergency.identity,
+			description: "Build Cargo workspace",
+			command: emergency.command,
+			cwd: repoRoot,
+			capabilities: emergency.capabilities,
+			phase: "cargo-build",
+		}];
+	}
+	return selected.sort((left, right) => left.manifestPath.localeCompare(right.manifestPath) || left.id.localeCompare(right.id)).map(unit => ({ key: `cargo-build:${stableIdentity("cargo", unit.id, unit.manifestPath)}`, identity: stableIdentity("cargo", unit.id, unit.manifestPath), description: `Build Cargo crate ${unit.name}`, command: ["cargo", "build", "--package", unit.name] as const, cwd: repoRoot, capabilities: { rust: true, nextest: false, nativeConsumer: false, nativeProducer: false }, phase: "cargo-build" as const }));
+}
+
+export function requiresCargoWorkspaceEmergency(
+	selected: readonly CargoInventoryUnit[],
+	supported: readonly CargoInventoryUnit[],
+): boolean {
+	const counts = new Map<string, number>();
+	for (const unit of supported) counts.set(unit.name, (counts.get(unit.name) ?? 0) + 1);
+	return selected.some(unit => (counts.get(unit.name) ?? 0) > 1);
+}
+
+async function expandCargoDependents(
+	initial: readonly CargoInventoryUnit[],
+	supported: readonly CargoInventoryUnit[],
+	fallbackOnMetadataFailure: boolean,
+): Promise<CargoInventoryUnit[]> {
+	const metadata = await $`cargo metadata --format-version=1 --no-deps`.cwd(repoRoot).quiet().nothrow();
+	if (metadata.exitCode !== 0) {
+		if (fallbackOnMetadataFailure) return [...supported];
+		throw new Error(`inventory-drift: cargo metadata failed: ${metadata.stderr.toString().trim()}`);
+	}
+	let decoded: unknown;
+	try {
+		decoded = JSON.parse(metadata.stdout.toString());
+	} catch {
+		if (fallbackOnMetadataFailure) return [...supported];
+		throw new Error("inventory-drift: cargo metadata was not JSON");
+	}
+	if (!isRecord(decoded) || !Array.isArray(decoded.packages) || !Array.isArray(decoded.workspace_members) || !decoded.workspace_members.every(isString)) {
+		if (fallbackOnMetadataFailure) return [...supported];
+		throw new Error("inventory-drift: cargo metadata workspace inventory missing");
+	}
+	const byManifest = new Map<string, CargoInventoryUnit>();
+	for (const unit of supported) byManifest.set(path.resolve(repoRoot, unit.manifestPath), unit);
+	const byPackageId = new Map<string, CargoInventoryUnit>();
+	for (const entry of decoded.packages) {
+		if (!isRecord(entry) || !isString(entry.id) || !isString(entry.name) || !isString(entry.manifest_path)) continue;
+		const unit = byManifest.get(path.resolve(entry.manifest_path));
+		if (unit) {
+			if (unit.name !== entry.name || byPackageId.has(entry.id)) throw new Error("inventory-drift: Cargo registry mapping mismatch");
+			byPackageId.set(entry.id, unit);
+		}
+	}
+	if (byPackageId.size !== supported.length) throw new Error("inventory-drift: supported Cargo inventory does not match metadata");
+	const workspaceMemberIds = new Set(decoded.workspace_members as string[]);
+	if (workspaceMemberIds.size !== supported.length || Array.from(workspaceMemberIds).some(id => !byPackageId.has(id))) {
+		throw new Error("inventory-drift: Cargo workspace contains unclassified members");
+	}
+	const reverse = new Map<string, string[]>();
+	for (const entry of decoded.packages) {
+		if (!isRecord(entry) || !isString(entry.id) || !Array.isArray(entry.dependencies)) continue;
+		for (const dependency of entry.dependencies) {
+			if (!isRecord(dependency) || !isString(dependency.path)) continue;
+			const dependencyUnit = byManifest.get(path.resolve(dependency.path, "Cargo.toml"));
+			if (dependencyUnit) reverse.set(dependencyUnit.id, [...(reverse.get(dependencyUnit.id) ?? []), entry.id]);
+		}
+	}
+	const selected = new Map(initial.map(unit => [unit.id, unit]));
+	const queue = [...selected.keys()];
+	while (queue.length > 0) {
+		const current = queue.shift(); if (!current) continue;
+		for (const packageId of reverse.get(current) ?? []) { const unit = byPackageId.get(packageId); if (unit && !selected.has(unit.id)) { selected.set(unit.id, unit); queue.push(unit.id); } }
+	}
+	return Array.from(selected.values());
+}
 function isWorkflowHarnessPath(changedPath: string): boolean {
 	return isWorkflowPath(changedPath) || changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/check-workflow-yaml.ts";
 }
@@ -904,6 +1199,10 @@ function isString(value: unknown): value is string {
 	return typeof value === "string";
 }
 
+function assertExactKeys(value: Record<string, unknown>, keys: readonly string[], label: string): void {
+	if (Object.keys(value).length !== keys.length || Object.keys(value).some(key => !keys.includes(key))) throw new Error(`inventory-invalid: unexpected ${label} field`);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -918,4 +1217,118 @@ export async function runCommand(command: readonly string[], cwd: string): Promi
 		stderr: "inherit",
 	});
 	return proc.exited;
+}
+
+function serializeTasks(tasks: readonly Task[]): Task[] {
+	return tasks.map(task => {
+		const cwd = task.cwd ? path.relative(repoRoot, task.cwd) || "." : ".";
+		return {
+			key: task.key,
+			identity: canonicalTaskIdentity(task),
+			description: task.description,
+			command: task.command,
+			cwd,
+			capabilities: task.capabilities ?? {
+				rust: taskNeedsRust(task.key),
+				nextest: task.key === "rust-test",
+				nativeConsumer: taskNeedsNative(task.key),
+				nativeProducer: isNativeBuildKey(task.key),
+			},
+			phase: task.phase ?? "legacy",
+		};
+	});
+}
+
+function canonicalTaskIdentity(task: Task): string {
+	const cwd = task.cwd ? path.relative(repoRoot, task.cwd) || "." : ".";
+	return task.identity ?? `legacy:${toBase64Url(task.key)}:${toBase64Url(cwd)}`;
+}
+
+async function validateShardReceipts(): Promise<void> {
+	const tasks = await loadCanonicalPlan();
+	if (!tasks) throw new Error("affected-plan-invalid: shard receipt validation requires a canonical plan");
+	const expected = tasks
+		.filter(task => task.capabilities?.nativeProducer !== true)
+		.map(task => ({ key: task.key, identity: canonicalTaskIdentity(task) }))
+		.sort((left, right) => left.key.localeCompare(right.key));
+	const receiptDir = path.resolve(repoRoot, Bun.env.CI_DEV_SHARD_RECEIPTS?.trim() || ".ci-dev-shard-receipts");
+	const actual: Array<{ key: string; identity: string }> = [];
+	for await (const entry of new Bun.Glob("*.json").scan({ cwd: receiptDir })) {
+		const value = await Bun.file(path.join(receiptDir, entry)).json();
+		if (!isRecord(value) || !isString(value.key) || !isString(value.identity) || Object.keys(value).length !== 2) throw new Error("affected-plan-invalid: malformed shard receipt");
+		actual.push({ key: value.key, identity: value.identity });
+	}
+	actual.sort((left, right) => left.key.localeCompare(right.key));
+	if (JSON.stringify(actual) !== JSON.stringify(expected)) throw new Error("affected-plan-invalid: shard receipt set does not match canonical plan");
+}
+
+async function loadCanonicalPlan(): Promise<Task[] | null> {
+	const planFile = Bun.env.CI_DEV_AFFECTED_PLAN?.trim();
+	if (!planFile) return null;
+	let rawPlan: string;
+	let decoded: unknown;
+	try {
+		rawPlan = await Bun.file(planFile).text();
+		decoded = JSON.parse(rawPlan);
+	} catch {
+		throw new Error("affected-plan-invalid: cannot read canonical plan");
+	}
+	if (!isRecord(decoded) || decoded.schemaVersion !== 1 || !isString(decoded.sourceSha) || (decoded.mode !== "pr" && decoded.mode !== "push") || !Array.isArray(decoded.paths) || !decoded.paths.every(isString) || !Array.isArray(decoded.tasks)) throw new Error("affected-plan-invalid: malformed canonical plan");
+	if (Object.keys(decoded).length !== 5 || Object.keys(decoded).some(key => !["schemaVersion", "sourceSha", "mode", "paths", "tasks"].includes(key))) throw new Error("affected-plan-invalid: unexpected top-level field");
+	const decodedPaths = decoded.paths as string[];
+	const paths = normalizeChangedPaths(decodedPaths);
+	if (paths.length !== decodedPaths.length || paths.some((entry, index) => entry !== decodedPaths[index])) throw new Error("affected-plan-invalid: paths are not canonical");
+	const expectedSha = Bun.env.CI_DEV_PLAN_SOURCE_SHA?.trim();
+	const expectedDigest = Bun.env.CI_DEV_PLAN_DIGEST?.trim();
+	if (!expectedSha || !expectedDigest) throw new Error("affected-plan-invalid: missing expected digest or source SHA");
+	if (decoded.sourceSha !== expectedSha) throw new Error("affected-plan-invalid: source SHA mismatch");
+	const checkedOut = await $`git rev-parse HEAD`.cwd(repoRoot).quiet().nothrow();
+	if (checkedOut.exitCode !== 0 || checkedOut.stdout.toString().trim() !== expectedSha) throw new Error("affected-plan-invalid: checked-out SHA mismatch");
+	const actual = new Bun.CryptoHasher("sha256").update(rawPlan).digest("hex");
+	if (actual !== expectedDigest) throw new Error("affected-plan-invalid: digest mismatch");
+	const tasks = decoded.tasks.map(deserializeTask);
+	if (
+		new Set(tasks.map(task => task.key)).size !== tasks.length ||
+		new Set(tasks.map(task => task.identity)).size !== tasks.length
+	) throw new Error("affected-plan-invalid: duplicate task key or identity");
+	const matrixKey = Bun.env.CI_DEV_MATRIX_KEY?.trim();
+	if (matrixKey) {
+		const task = tasks.find(candidate => candidate.key === matrixKey);
+		if (!task || !task.capabilities) throw new Error("affected-plan-invalid: matrix task mismatch");
+		if (task.capabilities.rust !== (Bun.env.CI_DEV_MATRIX_RUST === "true") || task.capabilities.nextest !== (Bun.env.CI_DEV_MATRIX_NEXTEST === "true") || task.capabilities.nativeConsumer !== (Bun.env.CI_DEV_MATRIX_NATIVE === "true")) throw new Error("affected-plan-invalid: matrix capabilities mismatch");
+	}
+	return tasks;
+}
+function deserializeTask(value: unknown): Task {
+	if (!isRecord(value) || !isString(value.key) || !isString(value.description) || !Array.isArray(value.command) || !value.command.every(isString) || (value.cwd !== undefined && !isString(value.cwd))) throw new Error("affected-plan-invalid: malformed task");
+	assertTaskKeys(value);
+	if (!isString(value.identity) || value.identity.length === 0) throw new Error("affected-plan-invalid: missing task identity");
+	const capabilities = value.capabilities;
+	if (!isRecord(capabilities) || typeof capabilities.rust !== "boolean" || typeof capabilities.nextest !== "boolean" || typeof capabilities.nativeConsumer !== "boolean" || typeof capabilities.nativeProducer !== "boolean") throw new Error("affected-plan-invalid: missing task capabilities");
+	assertExactKeys(capabilities, ["rust", "nextest", "nativeConsumer", "nativeProducer"], "task capabilities");
+	if (value.cwd !== undefined && value.cwd !== ".") normalizeInventoryPath(value.cwd);
+	const phase = value.phase;
+	if (phase !== "legacy" && phase !== "native-producer" && phase !== "ts-build" && phase !== "cargo-build") throw new Error("affected-plan-invalid: missing task phase");
+	return {
+		key: value.key,
+		identity: value.identity,
+		description: value.description,
+		command: value.command,
+		cwd: isString(value.cwd) ? path.resolve(repoRoot, value.cwd) : undefined,
+		capabilities: {
+			rust: capabilities.rust as boolean,
+			nextest: capabilities.nextest as boolean,
+			nativeConsumer: capabilities.nativeConsumer as boolean,
+			nativeProducer: capabilities.nativeProducer as boolean,
+		},
+		phase,
+	};
+}
+function assertTaskKeys(value: Record<string, unknown>): void {
+	const allowed = ["key", "identity", "description", "command", "cwd", "capabilities", "phase"];
+	if (Object.keys(value).some(key => !allowed.includes(key))) throw new Error("affected-plan-invalid: malformed task");
+}
+
+if (import.meta.main) {
+	await main();
 }


### PR DESCRIPTION
## Summary
- add deterministic affected TypeScript workspace and Rust crate build shards
- compile one canonical source-head plan artifact and validate its digest, task capabilities, and checkout SHA downstream
- preserve legacy validation, singleton native artifacts, and the stable `Affected path validation` aggregate with fail-closed truth checks

## Verification
- `bun test scripts/ci-dev-affected.test.ts` — 46 passed, 217 assertions
- `bun run check:tools`
- `bun scripts/check-workflow-yaml.ts`
- `cargo build --workspace`
- `bun run check:rs`
- `bun run test:rs` — 491 passed
- `TARGET_VARIANTS="baseline modern" bun scripts/ci-build-native.ts`
- `bun run build` in `packages/stats`
- `bun run build` in `packages/coding-agent`
- canonical artifact replay plus source-SHA, matrix-capability, and exact-byte tamper rejection

`bun run check:ts` advanced through its preceding gates but the unrelated `sdk-adapter-dispositions` selector reproducibly crashes Bun 1.3.14 with SIGILL on this host; the same selector was retried directly with the same runtime crash.

Closes #2262