### PR TITLE
fix(async): bind resume authority per descriptor (#2303)

### DIFF
--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -163,6 +163,12 @@ export interface ResumeDescriptor {
 	data: unknown;
 }
 
+/**
+ * In-memory resume runner bound to the session that originally launched a
+ * subagent. Never serialized: process restart drops it so resume fails closed.
+ */
+export type ResumeRunner = (subagentId: string, message?: string, descriptor?: ResumeDescriptor) => string | undefined;
+
 function sessionFileFromResumeDescriptorData(data: unknown): string | null {
 	if (typeof data !== "object" || data === null) return null;
 	const sessionFile = (data as { sessionFile?: unknown }).sessionFile;
@@ -365,8 +371,16 @@ export class AsyncJobManager {
 	readonly #subagentProgress = new Map<string, AgentProgress>();
 	readonly #resumeQueue: ResumeQueueEntry[] = [];
 	#resumeSeq = 0;
-	#resumeRunner?: (subagentId: string, message?: string, descriptor?: ResumeDescriptor) => string | undefined;
+	#resumeRunner?: ResumeRunner;
 	readonly #resumeDescriptors = new Map<string, ResumeDescriptor>();
+	/**
+	 * Per-descriptor in-memory resume runners, keyed by subagentId, captured at
+	 * registerResumeDescriptor time so each resume executes under the authority of
+	 * the session that originally launched that subagent. Fixes #2303's global
+	 * last-writer-wins slot. In-memory only: a process restart drops these and
+	 * resume fails closed with reason "no_runner".
+	 */
+	readonly #descriptorResumeRunners = new Map<string, ResumeRunner>();
 	readonly #deadLetteredDeliveries = new Map<string, AsyncJobDelivery>();
 	readonly #ownerSubagentShutdownLeases = new Map<string, OwnerSubagentShutdownLeaseState>();
 	#ownerSubagentShutdownSeq = 0;
@@ -733,14 +747,23 @@ export class AsyncJobManager {
 	}
 
 	/** Install the TaskTool-owned resume runner. Returns the new job id, or undefined on failure. */
-	setResumeRunner(
-		runner: (subagentId: string, message?: string, descriptor?: ResumeDescriptor) => string | undefined,
-	): void {
+	setResumeRunner(runner: ResumeRunner): void {
 		this.#resumeRunner = runner;
 	}
 
-	registerResumeDescriptor(descriptor: ResumeDescriptor): void {
+	registerResumeDescriptor(descriptor: ResumeDescriptor, runner?: ResumeRunner): void {
 		this.#resumeDescriptors.set(descriptor.subagentId, descriptor);
+		if (runner) this.#descriptorResumeRunners.set(descriptor.subagentId, runner);
+	}
+
+	/**
+	 * Resolve the resume runner for a subagent: prefer the per-descriptor runner
+	 * captured at registration time (the originating parent's execution authority),
+	 * falling back to the process-global runner only for descriptors registered
+	 * without one.
+	 */
+	#resolveResumeRunner(subagentId: string): ResumeRunner | undefined {
+		return this.#descriptorResumeRunners.get(subagentId) ?? this.#resumeRunner;
 	}
 
 	getResumeDescriptor(subagentId: string, filter?: AsyncJobFilter): ResumeDescriptor | undefined {
@@ -1036,7 +1059,7 @@ export class AsyncJobManager {
 			return { ok: false, status: "queued", reason: "already_queued" };
 		}
 		if (!rec.resumable || !rec.sessionFile) return { ok: false, reason: "context_unavailable" };
-		if (!this.#resumeRunner) return { ok: false, reason: "no_runner" };
+		if (!this.#resolveResumeRunner(rec.subagentId)) return { ok: false, reason: "no_runner" };
 		if (this.getRunningJobs().length >= this.#maxRunningJobs) {
 			const seq = ++this.#resumeSeq;
 			rec.status = "queued";
@@ -1064,7 +1087,8 @@ export class AsyncJobManager {
 		// Clear any retained progress from the previous run so a resumed subagent
 		// never renders the prior run's tool/output as live before it emits again.
 		this.#subagentProgress.delete(rec.subagentId);
-		const newJobId = this.#resumeRunner?.(rec.subagentId, message, this.#resumeDescriptors.get(rec.subagentId));
+		const runner = this.#resolveResumeRunner(rec.subagentId);
+		const newJobId = runner?.(rec.subagentId, message, this.#resumeDescriptors.get(rec.subagentId));
 		if (!newJobId) return { ok: false, reason: "resume_failed" };
 		if (prevJobId && prevJobId !== newJobId) rec.historicalJobIds.push(prevJobId);
 		rec.currentJobId = newJobId;
@@ -1144,6 +1168,7 @@ export class AsyncJobManager {
 			if (!ownerId || rec.ownerId === ownerId) {
 				this.#liveHandles.delete(sid);
 				this.#resumeDescriptors.delete(sid);
+				this.#descriptorResumeRunners.delete(sid);
 				this.#subagentRecords.delete(sid);
 				this.#subagentProgress.delete(sid);
 			}
@@ -1536,6 +1561,7 @@ export class AsyncJobManager {
 		this.#liveHandles.clear();
 		this.#subagentProgress.clear();
 		this.#resumeDescriptors.clear();
+		this.#descriptorResumeRunners.clear();
 		this.#resumeQueue.length = 0;
 		this.#ownerSubagentShutdownLeases.clear();
 		this.#notifyChange();

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -19,7 +19,7 @@ import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@gajae
 import type { Model, Usage } from "@gajae-code/ai";
 import { $env, prompt, Snowflake } from "@gajae-code/utils";
 import type { ToolSession } from "..";
-import { AsyncJobManager, OwnerSubagentShutdownError } from "../async";
+import { AsyncJobManager, OwnerSubagentShutdownError, type ResumeRunner } from "../async";
 import { resolveAgentModelPatterns } from "../config/model-resolver";
 import type { Theme } from "../modes/theme/theme";
 import planModeSubagentPrompt from "../prompts/system/plan-mode-subagent.md" with { type: "text" };
@@ -547,8 +547,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		};
 
 		const maxConcurrency = this.session.settings.get("task.maxConcurrency");
+		let resumeRunner: ResumeRunner | undefined;
 		if (typeof manager.setResumeRunner === "function") {
-			manager.setResumeRunner((_subagentId, message, resumeDescriptor) => {
+			resumeRunner = (_subagentId, message, resumeDescriptor) => {
 				const descriptor = isTaskResumeDescriptor(resumeDescriptor?.data) ? resumeDescriptor.data : undefined;
 				if (!descriptor) return undefined;
 				const forkSeeds = descriptor.forkContextSeed
@@ -590,7 +591,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						},
 					},
 				);
-			});
+			};
+			manager.setResumeRunner(resumeRunner);
 		}
 		const semaphore = new Semaphore(maxConcurrency);
 		const buildForkContextSeedForTask = async (task: TaskItem): Promise<ForkContextSeed | undefined> => {
@@ -770,18 +772,21 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				);
 				startedJobs.push({ jobId, taskId: taskItem.id });
 				if (typeof manager.registerResumeDescriptor === "function") {
-					manager.registerResumeDescriptor({
-						subagentId: uniqueId,
-						ownerId: this.session.getAgentId?.() ?? undefined,
-						data: {
-							toolCallId: _toolCallId,
-							params,
-							task: { ...taskItem, id: uniqueId },
-							sessionFile: subtaskSessionFile,
-							forkContextSeed: frozenForkSeed,
-							agentSource: fallbackAgentSource,
-						} satisfies TaskResumeDescriptor,
-					});
+					manager.registerResumeDescriptor(
+						{
+							subagentId: uniqueId,
+							ownerId: this.session.getAgentId?.() ?? undefined,
+							data: {
+								toolCallId: _toolCallId,
+								params,
+								task: { ...taskItem, id: uniqueId },
+								sessionFile: subtaskSessionFile,
+								forkContextSeed: frozenForkSeed,
+								agentSource: fallbackAgentSource,
+							} satisfies TaskResumeDescriptor,
+						},
+						resumeRunner,
+					);
 				}
 				if (typeof manager.registerSubagentRecord === "function") {
 					manager.registerSubagentRecord({

--- a/packages/coding-agent/test/async/job-manager-resume-runner-authority.test.ts
+++ b/packages/coding-agent/test/async/job-manager-resume-runner-authority.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AsyncJobManager,
+	type ResumeDescriptor,
+	type ResumeRunner,
+	type SubagentRecord,
+} from "@gajae-code/coding-agent/async/job-manager";
+
+// Regression coverage for #2303: AsyncJobManager.setResumeRunner used to be a
+// process-global, last-writer-wins slot, so resuming a completed nested
+// orchestrator re-executed under whichever session launched a task most
+// recently (the orchestrator's own spawn whitelist), dying at the pre-model
+// spawn gate. The fix binds a per-descriptor in-memory runner at
+// registerResumeDescriptor time so each resume runs under its originating
+// parent's execution authority. These tests use plain test doubles: no real
+// agent sessions, no timers, no interval-driven scheduling.
+
+interface RunnerCall {
+	label: string;
+	subagentId: string;
+	agent: string;
+	allowed: boolean;
+}
+
+function agentOf(descriptor?: ResumeDescriptor): string {
+	const data = descriptor?.data as { agent?: string } | undefined;
+	return data?.agent ?? descriptor?.subagentId ?? "";
+}
+
+/**
+ * Models the task/index.ts resume runner as evaluated inside a specific
+ * session's spawn authority. A denial returns undefined, which the manager
+ * surfaces as `resume_failed` with zero model turns — exactly the pre-model
+ * spawn-gate death #2303 describes.
+ */
+function authorityRunner(label: string, spawns: string, calls: RunnerCall[]): ResumeRunner {
+	const whitelist = spawns
+		.split(",")
+		.map(s => s.trim())
+		.filter(Boolean);
+	return (subagentId, _message, descriptor) => {
+		const agent = agentOf(descriptor);
+		const allowed = spawns === "*" ? true : whitelist.includes(agent);
+		calls.push({ label, subagentId, agent, allowed });
+		return allowed ? `${label}:${subagentId}:job` : undefined;
+	};
+}
+
+function completedRecord(subagentId: string, ownerId?: string): SubagentRecord {
+	return {
+		subagentId,
+		ownerId,
+		currentJobId: `${subagentId}-orig`,
+		historicalJobIds: [],
+		status: "completed",
+		sessionFile: `/tmp/${subagentId}.jsonl`,
+		resumable: true,
+	};
+}
+
+function descriptorFor(subagentId: string, agent: string, ownerId?: string): ResumeDescriptor {
+	return { subagentId, ownerId, data: { sessionFile: `/tmp/${subagentId}.jsonl`, agent } };
+}
+
+describe("AsyncJobManager per-descriptor resume authority (#2303)", () => {
+	// Assertion 1 — repro guard: the pre-fix global-slot behavior denies.
+	test("repro: global-slot behavior denies resuming a completed nested orchestrator (zero model turns)", () => {
+		const calls: RunnerCall[] = [];
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+
+		// Orchestrator was launched by main, then spawned a child which rebound
+		// the global runner to the orchestrator's own (self-excluding) whitelist.
+		manager.registerSubagentRecord(completedRecord("wf0-orchestrator"));
+		// Pre-fix reproduction: descriptor registered WITHOUT a per-descriptor
+		// runner, so resolution falls back to the last global runner.
+		manager.registerResumeDescriptor(descriptorFor("wf0-orchestrator", "wf0-orchestrator"));
+		manager.setResumeRunner(authorityRunner("orchestrator", "worker-a,worker-b", calls));
+
+		const result = manager.resumeSubagent("wf0-orchestrator", undefined, "please continue");
+
+		expect(result.ok).toBe(false);
+		expect(result.reason).toBe("resume_failed");
+		// The runner was reached but denied at the spawn gate: no job, no turns.
+		expect(calls).toEqual([
+			{ label: "orchestrator", subagentId: "wf0-orchestrator", agent: "wf0-orchestrator", allowed: false },
+		]);
+	});
+
+	// Assertion 3 — the fix: nested launch after descriptor registration keeps
+	// the originating parent's runner even though the global slot was rebound.
+	test("nested launch after descriptor registration: resume(X) uses main's authority, not the rebound global runner", () => {
+		const calls: RunnerCall[] = [];
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const mainRunner = authorityRunner("main", "*", calls);
+		const orchestratorRunner = authorityRunner("orchestrator", "worker-a,worker-b", calls);
+
+		// Main launches the orchestrator and binds the descriptor to main's runner.
+		manager.registerSubagentRecord(completedRecord("wf0-orchestrator", "main"));
+		manager.registerResumeDescriptor(descriptorFor("wf0-orchestrator", "wf0-orchestrator", "main"), mainRunner);
+		manager.setResumeRunner(mainRunner);
+
+		// Orchestrator later spawns a worker — this rebinds the GLOBAL slot.
+		manager.setResumeRunner(orchestratorRunner);
+
+		const result = manager.resumeSubagent("wf0-orchestrator", undefined, "continue");
+
+		expect(result.ok).toBe(true);
+		expect(result.jobId).toBe("main:wf0-orchestrator:job");
+		expect(calls).toEqual([
+			{ label: "main", subagentId: "wf0-orchestrator", agent: "wf0-orchestrator", allowed: true },
+		]);
+	});
+
+	// Assertion 2 — two parent sessions each resume under their own authority.
+	test("two parents: each descriptor resumes under its own originating parent's spawn authority", () => {
+		const calls: RunnerCall[] = [];
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const p1Runner = authorityRunner("P1", "*", calls);
+		const p2Runner = authorityRunner("P2", "worker-a", calls);
+
+		manager.registerSubagentRecord(completedRecord("sub-from-p1", "P1"));
+		manager.registerResumeDescriptor(descriptorFor("sub-from-p1", "wf0-orchestrator", "P1"), p1Runner);
+
+		manager.registerSubagentRecord(completedRecord("sub-from-p2", "P2"));
+		manager.registerResumeDescriptor(descriptorFor("sub-from-p2", "worker-a", "P2"), p2Runner);
+
+		// Global slot ends up bound to whoever launched last (P2).
+		manager.setResumeRunner(p2Runner);
+
+		const r1 = manager.resumeSubagent("sub-from-p1");
+		const r2 = manager.resumeSubagent("sub-from-p2");
+
+		expect(r1.ok).toBe(true);
+		expect(r1.jobId).toBe("P1:sub-from-p1:job");
+		expect(r2.ok).toBe(true);
+		expect(r2.jobId).toBe("P2:sub-from-p2:job");
+		// P1's subagent must never be evaluated under P2's whitelist.
+		expect(calls).toEqual([
+			{ label: "P1", subagentId: "sub-from-p1", agent: "wf0-orchestrator", allowed: true },
+			{ label: "P2", subagentId: "sub-from-p2", agent: "worker-a", allowed: true },
+		]);
+	});
+
+	// Assertion 4 — interleaved registrations/launches never cross-bind runners.
+	test("interleaving: interleaved registration and global rebinding never cross-bind runners", () => {
+		const calls: RunnerCall[] = [];
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const mainRunner = authorityRunner("main", "*", calls);
+		const orchRunner = authorityRunner("orchestrator", "worker-a,worker-b", calls);
+
+		// Interleave: register X (main), rebind global to orchestrator, register
+		// worker-a (orchestrator), rebind global back to main.
+		manager.registerSubagentRecord(completedRecord("wf0-orchestrator", "main"));
+		manager.registerResumeDescriptor(descriptorFor("wf0-orchestrator", "wf0-orchestrator", "main"), mainRunner);
+		manager.setResumeRunner(orchRunner);
+		manager.registerSubagentRecord(completedRecord("worker-a", "wf0-orchestrator"));
+		manager.registerResumeDescriptor(descriptorFor("worker-a", "worker-a", "wf0-orchestrator"), orchRunner);
+		manager.setResumeRunner(mainRunner);
+
+		const rWorker = manager.resumeSubagent("worker-a");
+		const rOrch = manager.resumeSubagent("wf0-orchestrator");
+
+		// Each resumed under its own launcher's authority regardless of the
+		// current global slot value.
+		expect(rWorker.jobId).toBe("orchestrator:worker-a:job");
+		expect(rOrch.jobId).toBe("main:wf0-orchestrator:job");
+		expect(calls).toEqual([
+			{ label: "orchestrator", subagentId: "worker-a", agent: "worker-a", allowed: true },
+			{ label: "main", subagentId: "wf0-orchestrator", agent: "wf0-orchestrator", allowed: true },
+		]);
+	});
+
+	// Assertion 5 — descriptor cleanup drops the per-descriptor runner (no leak).
+	test("descriptor cleanup: runOwnerCleanups drops the per-descriptor runner (no stale reuse)", () => {
+		const calls: RunnerCall[] = [];
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const originalRunner = authorityRunner("original", "*", calls);
+		const replacementRunner = authorityRunner("replacement", "*", calls);
+
+		manager.registerSubagentRecord(completedRecord("wf0-orchestrator", "main"));
+		manager.registerResumeDescriptor(descriptorFor("wf0-orchestrator", "wf0-orchestrator", "main"), originalRunner);
+
+		// Owner cleanup purges the subagent record, descriptor, and its runner.
+		manager.runOwnerCleanups({ ownerId: "main" });
+		expect(manager.getResumeDescriptor("wf0-orchestrator")).toBeUndefined();
+
+		// Re-register the same id WITHOUT a per-descriptor runner and install a
+		// distinct global runner. If cleanup had leaked the original per-descriptor
+		// runner, it would win here; instead resolution must fall back to global.
+		manager.registerSubagentRecord(completedRecord("wf0-orchestrator", "main"));
+		manager.registerResumeDescriptor(descriptorFor("wf0-orchestrator", "wf0-orchestrator", "main"));
+		manager.setResumeRunner(replacementRunner);
+
+		const result = manager.resumeSubagent("wf0-orchestrator");
+
+		expect(result.ok).toBe(true);
+		expect(result.jobId).toBe("replacement:wf0-orchestrator:job");
+		expect(calls.map(c => c.label)).toEqual(["replacement"]);
+	});
+
+	// Assertion 6 — restart / no-runner fails closed.
+	test("restart/no-runner: a fresh manager with only persistable state fails closed with no_runner", () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+
+		// Simulated restart: persistable state (record + descriptor) is replayed,
+		// but the in-memory runners (global + per-descriptor) are gone.
+		manager.registerSubagentRecord(completedRecord("wf0-orchestrator", "main"));
+		manager.registerResumeDescriptor(descriptorFor("wf0-orchestrator", "wf0-orchestrator", "main"));
+
+		const result = manager.resumeSubagent("wf0-orchestrator", undefined, "continue");
+
+		expect(result.ok).toBe(false);
+		expect(result.reason).toBe("no_runner");
+	});
+
+	// Assertion 7 — self-recursion / whitelist gates still deny genuinely
+	// disallowed spawns (authority is bound, not broadened).
+	test("whitelist gate: a genuinely disallowed spawn still fails under the originating parent's authority", () => {
+		const calls: RunnerCall[] = [];
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		// Originating parent's whitelist legitimately excludes the resumed agent.
+		const parentRunner = authorityRunner("parent", "worker-a,worker-b", calls);
+
+		manager.registerSubagentRecord(completedRecord("worker-c", "parent"));
+		manager.registerResumeDescriptor(descriptorFor("worker-c", "worker-c", "parent"), parentRunner);
+		manager.setResumeRunner(parentRunner);
+
+		const result = manager.resumeSubagent("worker-c");
+
+		// The fix must not broaden permission: a real denial still denies.
+		expect(result.ok).toBe(false);
+		expect(result.reason).toBe("resume_failed");
+		expect(calls).toEqual([{ label: "parent", subagentId: "worker-c", agent: "worker-c", allowed: false }]);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #2303. `AsyncJobManager.setResumeRunner` was a process-global, last-writer-wins slot. Every `TaskTool` launch rebound it to the launching session, so resuming a **completed nested orchestrator** re-executed under whichever session launched a task most recently — the orchestrator's own self-excluding `spawns:` whitelist — dying at the pre-model spawn gate (`Cannot spawn '<orchestrator>'`) with zero model turns.

## Fix

Per-descriptor in-memory execution authority (option A from the issue):

- `job-manager.ts`: add `ResumeRunner` type and a `#descriptorResumeRunners` map keyed by `subagentId`, captured at `registerResumeDescriptor(descriptor, runner?)` time. `#resolveResumeRunner` prefers the per-descriptor runner and falls back to the global slot. `resumeSubagent`/`#startResume` resolve through it; cleanup (`runOwnerCleanups` purge) and `dispose` drop/clear the map in lockstep with `#resumeDescriptors`.
- `task/index.ts`: hoist the session-bound runner closure to a named const and pass it to `registerResumeDescriptor` per launch, so each descriptor keeps the authority of the session that launched it.

The runner map is **in-memory only** — never serialized — so a process restart drops it and resume fails closed with reason `no_runner`.

## Constraints honored

- No broadened spawn permission (whitelist / self-recursion gates unchanged; genuine denials still deny).
- No persisted closures (in-memory map only).
- Restart fail-closed preserved (`no_runner`).
- Completed-job resume/steer semantics unchanged.

## Tests

New `test/async/job-manager-resume-runner-authority.test.ts` — 7 deterministic assertions, pure test doubles (no real sessions, no timers):

1. Repro guard: global-slot behavior denies the completed nested orchestrator (zero model turns).
2. Nested launch after descriptor registration: `resume(X)` uses main's authority, not the rebound global runner.
3. Two parents: each descriptor resumes under its own originating parent's authority.
4. Interleaving: interleaved registration + global rebinding never cross-binds runners.
5. Descriptor cleanup: `runOwnerCleanups` drops the per-descriptor runner (no stale reuse).
6. Restart/no-runner: fresh manager with only persistable state fails closed with `no_runner`.
7. Whitelist gate: a genuinely disallowed spawn still fails (authority bound, not broadened).

## Gates

- `bun run check:types` (coding-agent) — clean.
- `biome check` on changed files — clean.
- `bun test test/async/` — 48 pass; `bun test test/task/` — 205 pass; new suite — 7 pass.
- Full-suite pre-existing timeout flakiness (OpenAI Responses replay, before_agent_start attribution, mid-run compaction) is unrelated and passes in isolation.

## Review / merge gate

Requesting a hostile review pinned to the exact head SHA. **Do not merge without a fresh GJC verdict** on that head.

Closes #2303
