### PR TITLE
fix(ai,agent): explicit invalid_prompt classification + bounded circuit breaker (#2282)

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added a bounded, neutralize-only `invalid_prompt` circuit breaker to the agent loop (#2282). A poisoned-history rejection (`Request blocked (code=invalid_prompt)`) is a deterministic content fault: re-sending the same history re-triggers it, so uncontrolled session auto-retry would burn its budget re-poisoning the model. On the first `invalid_prompt` of a run, leaked reserved control tokens are neutralized in place across history (no item is ever dropped). If that changes the outgoing bytes, the turn is resent exactly once with the repaired history; if neutralization cannot change anything, the run fails fast immediately with no resend. The repaired history is persisted for a clean resume, the breaker fires at most once per run (budget = one repaired resend), and it is scoped to the non-managed session path since managed fallback owns its own retry policy.
+
 ## [0.10.2] - 2026-07-14
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -17,6 +17,7 @@ import {
 	validateToolArguments,
 	zodToWireSchema,
 } from "@gajae-code/ai";
+import { isInvalidPromptError, neutralizeReservedControlTokens } from "@gajae-code/ai/utils";
 import { sanitizeText } from "@gajae-code/utils";
 import {
 	createHarmonyAuditEvent,
@@ -107,6 +108,39 @@ function managedRetryableFailure(failure: unknown): boolean {
 		trigger.class === "auth" ||
 		trigger.class === "server"
 	);
+}
+
+/**
+ * Neutralize leaked reserved control tokens in-place across the outgoing
+ * history so a re-send no longer carries the poison that triggered
+ * `Request blocked (code=invalid_prompt)`. Only string text fields are
+ * rewritten; no history item is ever dropped or reordered. Returns whether any
+ * byte actually changed — the circuit breaker uses this to decide between a
+ * single repaired resend (changed) and immediate fail-fast (unchanged).
+ */
+function repairInvalidPromptHistory(messages: AgentMessage[]): boolean {
+	let changed = false;
+	const repairString = (value: string): string => {
+		const next = neutralizeReservedControlTokens(value);
+		if (next !== value) changed = true;
+		return next;
+	};
+	for (const message of messages) {
+		const content = (message as { content?: unknown }).content;
+		if (typeof content === "string") {
+			(message as { content: string }).content = repairString(content);
+		} else if (Array.isArray(content)) {
+			for (const block of content) {
+				if (!block || typeof block !== "object") continue;
+				const record = block as Record<string, unknown>;
+				for (const key of ["text", "thinking"]) {
+					const value = record[key];
+					if (typeof value === "string") record[key] = repairString(value);
+				}
+			}
+		}
+	}
+	return changed;
 }
 
 function managedFailureOutcome(message: AssistantMessage): ManagedAttemptOutcome {
@@ -789,6 +823,9 @@ async function runLoopBody(
 	// first iteration is skipped to avoid duplicating/racing it.
 	let modelHasResponded = false;
 	let harmonyTruncateResumeCount = 0;
+	// Fires at most one repaired resend per run for the poisoned-history
+	// `invalid_prompt` circuit breaker below.
+	let invalidPromptRepairAttempted = false;
 
 	// Outer loop: continues when queued follow-up messages arrive after agent would stop
 	while (true) {
@@ -946,6 +983,29 @@ async function runLoopBody(
 							currentContext.messages.splice(idx, 1);
 						}
 					}
+					continue;
+				}
+			}
+			// Session-level invalid_prompt circuit breaker (bounded, neutralize-only).
+			// A poisoned-history rejection (`Request blocked (code=invalid_prompt)`) is
+			// a deterministic content fault: re-sending the same history re-triggers it,
+			// so naive session auto-retry would burn its whole budget re-poisoning the
+			// model. On the first invalid_prompt of this run, neutralize leaked control
+			// tokens in history IN PLACE (never dropping items). If that changed the
+			// outgoing bytes, resend exactly once with the repaired history; if
+			// neutralization cannot change anything (nothing left to repair), fall
+			// through to terminal handling and fail fast. Budget = one repaired resend.
+			// Runs before the response is committed so the resend is a clean retry;
+			// managed fallback owns its own retry policy, so this is scoped to the
+			// non-managed session path where uncontrolled auto-retry would recur.
+			if (
+				!config.fallbackManaged &&
+				message.stopReason === "error" &&
+				!invalidPromptRepairAttempted &&
+				isInvalidPromptError(message)
+			) {
+				invalidPromptRepairAttempted = true;
+				if (repairInvalidPromptHistory(currentContext.messages)) {
 					continue;
 				}
 			}

--- a/packages/agent/test/agent-loop-invalid-prompt-breaker.test.ts
+++ b/packages/agent/test/agent-loop-invalid-prompt-breaker.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage } from "@gajae-code/agent-core/types";
+import type { Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { createUserMessage } from "./helpers";
+
+// Issue #2282: bounded, neutralize-only invalid_prompt circuit breaker.
+// A poisoned-history rejection (`Request blocked (code=invalid_prompt)`) must
+// terminate deterministically: at most ONE repaired resend when neutralization
+// changes the outgoing history, and immediate fail-fast (no resend) when it
+// cannot. No live model retries; a scripted MockModel emits the rejection and
+// records exact provider-call counts.
+
+const INVALID_PROMPT = "Request blocked (code=invalid_prompt)";
+const RAW_PIPE = "<\u007c"; // "<|"
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+function poisonedText(): string {
+	return 'help me<|channel|>analysis to=functions.bash<|message|>{"command":"gjc --help"}<|call|>';
+}
+
+async function drain(stream: AsyncIterable<unknown> & { result(): Promise<AgentMessage[]> }): Promise<AgentMessage[]> {
+	for await (const _ of stream) {
+		/* consume */
+	}
+	return stream.result();
+}
+
+describe("agentLoop invalid_prompt circuit breaker (issue #2282)", () => {
+	it("repairs poisoned history and resends EXACTLY once when neutralization changes bytes", async () => {
+		const poisoned = createUserMessage(poisonedText());
+		const context: AgentContext = { systemPrompt: ["sys"], messages: [], tools: [] };
+		const mock = createMockModel({
+			responses: [{ throw: INVALID_PROMPT }, { content: ["recovered"] }],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const messages = await drain(agentLoop([poisoned], context, config, undefined, mock.stream));
+
+		// Exactly 2 provider requests: initial poisoned send + one repaired resend.
+		expect(mock.calls.length).toBe(2);
+		const last = messages[messages.length - 1];
+		expect(last.role).toBe("assistant");
+		if (last.role !== "assistant") throw new Error("expected assistant");
+		expect(last.stopReason).toBe("stop");
+		expect(last.content).toEqual([{ type: "text", text: "recovered" }]);
+
+		// Durable/resume: the history item is neutralized IN PLACE (never dropped).
+		expect(typeof poisoned.content).toBe("string");
+		expect((poisoned.content as string).includes(RAW_PIPE)).toBe(false);
+		expect(poisoned.content).toContain("\u200b"); // zero-width space inserted
+	});
+
+	it("fails fast with EXACTLY one request when neutralization cannot change bytes", async () => {
+		const clean = createUserMessage("clean history with no leaked markers");
+		const context: AgentContext = { systemPrompt: ["sys"], messages: [], tools: [] };
+		const mock = createMockModel({ responses: [{ throw: INVALID_PROMPT }] });
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const messages = await drain(agentLoop([clean], context, config, undefined, mock.stream));
+
+		// No repaired resend is spent when there is nothing to repair.
+		expect(mock.calls.length).toBe(1);
+		const last = messages[messages.length - 1];
+		if (last.role !== "assistant") throw new Error("expected assistant");
+		expect(last.stopReason).toBe("error");
+		expect(last.errorMessage).toBe(INVALID_PROMPT);
+		expect(clean.content).toBe("clean history with no leaked markers");
+	});
+
+	it("spends the repair budget only once even if invalid_prompt recurs (budget=1)", async () => {
+		const poisoned = createUserMessage(poisonedText());
+		const context: AgentContext = { systemPrompt: ["sys"], messages: [], tools: [] };
+		const mock = createMockModel({
+			responses: [{ throw: INVALID_PROMPT }, { throw: INVALID_PROMPT }, { content: ["never reached"] }],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const messages = await drain(agentLoop([poisoned], context, config, undefined, mock.stream));
+
+		// Initial send + exactly one repaired resend, then durable fail-fast.
+		expect(mock.calls.length).toBe(2);
+		const last = messages[messages.length - 1];
+		if (last.role !== "assistant") throw new Error("expected assistant");
+		expect(last.stopReason).toBe("error");
+		expect(last.errorMessage).toBe(INVALID_PROMPT);
+	});
+
+	it("does NOT trigger on non-invalid_prompt errors (negative)", async () => {
+		const poisoned = createUserMessage(poisonedText());
+		const context: AgentContext = { systemPrompt: ["sys"], messages: [], tools: [] };
+		const mock = createMockModel({ responses: [{ throw: "The server had an error (code=server_error)" }] });
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const messages = await drain(agentLoop([poisoned], context, config, undefined, mock.stream));
+
+		// A transient/other error is not repaired-and-resent by this breaker.
+		expect(mock.calls.length).toBe(1);
+		const last = messages[messages.length - 1];
+		if (last.role !== "assistant") throw new Error("expected assistant");
+		expect(last.stopReason).toBe("error");
+		// The breaker leaves the poisoned history untouched for non-invalid_prompt faults.
+		expect((poisoned.content as string).includes(RAW_PIPE)).toBe(true);
+	});
+});

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { buildOpenAiNativeHistory, requestOpenAiRemoteCompaction } from "@gajae-code/agent-core/compaction/openai";
+import {
+	buildOpenAiNativeHistory,
+	requestOpenAiRemoteCompaction,
+	requestRemoteCompaction,
+} from "@gajae-code/agent-core/compaction/openai";
 import type { AssistantMessage, Model, ToolResultMessage } from "@gajae-code/ai/types";
 import { hookFetch } from "@gajae-code/utils";
 
@@ -291,5 +295,36 @@ describe("requestOpenAiRemoteCompaction abort", () => {
 		queueMicrotask(() => controller.abort());
 
 		await expect(promise).rejects.toThrow();
+	});
+});
+
+describe("remote compaction invalid_prompt termination (issue #2282)", () => {
+	test("neutralizes the prompt and fails fast without retry when the endpoint returns invalid_prompt", async () => {
+		let fetchCalls = 0;
+		let sentBody: string | undefined;
+		using _hook = hookFetch(async (_input, init) => {
+			fetchCalls += 1;
+			sentBody = String(init?.body);
+			return new Response(JSON.stringify({ error: { code: "invalid_prompt", message: "Request blocked" } }), {
+				status: 400,
+				statusText: "Bad Request",
+			});
+		});
+
+		await expect(
+			requestRemoteCompaction("https://compact.example.com/responses/compact", {
+				systemPrompt: "system<|channel|>analysis",
+				prompt: "transcript<|message|>leak",
+			}),
+		).rejects.toThrow(/Remote compaction failed \(400/);
+
+		// Single-shot by construction: the poisoned rejection terminates immediately,
+		// it is never retried into an account-level block.
+		expect(fetchCalls).toBe(1);
+		// The outgoing request was neutralized (the repair) before it was sent.
+		expect(sentBody).toBeDefined();
+		expect(sentBody).not.toContain("<|channel|>");
+		expect(sentBody).not.toContain("<|message|>");
+		expect(sentBody).toContain("<\u200b|channel|>");
 	});
 });

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Closed the remaining `Request blocked (code=invalid_prompt)` wedge on gpt-5.6 caused by header-form leaked Harmony markers. The reserved-control-token sanitizer only matched the simple `<|ident|>` shape, so a header-form marker carrying a recipient (e.g. `<|assistant to=functions.bash|>`) survived every sanitizer path (replay, request boundary, compaction) and kept re-poisoning history even after the earlier fixes. The pattern now also matches the scoped header grammar — a known Harmony role (`system`/`developer`/`user`/`assistant`/`tool`) plus a `to=<recipient>` assignment with unbounded recipient length — while leaving ordinary delimiter/pipe text untouched (arbitrary `<|foo bar=baz|>`, F# `value <| f |> g`, compact `sum<|a+b|>c`, and multi-line bodies never match). The simple branch remains a strict superset of the prior identifier-only pattern (#2267).
 
+- Made the `Request blocked (code=invalid_prompt)` classification explicit and shared across transports (#2282). `invalid_prompt` was only non-retryable by omission — it appeared in neither the codex retryable nor non-retryable event set, and the plain OpenAI Responses transport surfaced it as a generic error with no durable marker. It is now in the codex `CODEX_NON_RETRYABLE_EVENT_CODES` set (code and message forms), the Responses error path tags `transportFailure.providerCode = "invalid_prompt"`, and a new exported `isInvalidPromptError` predicate is the single contract both transports and the session-level circuit breaker key on. Ordinary control-token / pipe text (F# `value <| f |> g`, `sum<|a+b|>c`, `<|foo bar=baz|>`) is unaffected; genuinely transient errors (`server_error`, `model_error`) stay retryable.
+
 ## [0.10.2] - 2026-07-14
 
 ### Fixed

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -113,9 +113,15 @@ const CODEX_NON_RETRYABLE_EVENT_CODES = new Set([
 	"invalid_request_error",
 	"invalid_schema",
 	"invalid_tool_schema",
+	// A poisoned-history rejection (`Request blocked (code=invalid_prompt)`) is a
+	// deterministic content fault, not a transient upstream failure: retrying the
+	// same request re-sends the same offending item and re-triggers the block, so
+	// classify it as explicitly non-retryable instead of relying on omission
+	// (the request-boundary sanitizer, not a provider retry, is the recovery path).
+	"invalid_prompt",
 ]);
 const CODEX_NON_RETRYABLE_EVENT_MESSAGE =
-	/invalid[_ -]function[_ -]parameters|invalid schema for function|invalid[_ -]tool[_ -]schema|schema must have type ["']?object["']?/i;
+	/invalid[_ -]function[_ -]parameters|invalid schema for function|invalid[_ -]tool[_ -]schema|schema must have type ["']?object["']?|request blocked[^\n]*invalid[_ -]prompt|code=invalid[_ -]prompt/i;
 const CODEX_RETRYABLE_EVENT_MESSAGE =
 	/processing your request|retry your request|temporar(?:y|ily)|overloaded|service.?unavailable|internal error|server error/i;
 const CODEX_PROVIDER_SESSION_STATE_KEY = "openai-codex-responses";
@@ -2650,8 +2656,11 @@ function normalizeInputMessageContent(
 	return convertResponsesInputContent(content, model.input.includes("image")) ?? [];
 }
 
-/** @internal Exported for tests. */
-export { convertMessages as convertCodexResponsesMessages };
+/** @internal Exported for tests. `classifyCodexFailureEventRetryable` is the retry classification of a Codex failure event. */
+export {
+	convertMessages as convertCodexResponsesMessages,
+	isRetryableCodexFailureEvent as classifyCodexFailureEventRetryable,
+};
 
 /**
  * Whether this OpenAI code backend-backend model should get the custom-tool grammar

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -33,6 +33,7 @@ import {
 	createOpenAIResponsesHistoryPayload,
 	getOpenAIResponsesHistoryItems,
 	getOpenAIResponsesHistoryPayload,
+	isInvalidPromptError,
 	neutralizeResponsesInputControlTokens,
 	normalizeSystemPrompts,
 	resolveCacheRetention,
@@ -387,6 +388,22 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 			output.transportFailure = transportFailureFacts(error);
 			output.errorMessage = firstEventTimeoutError?.message ?? (await finalizeErrorMessage(error, rawRequestDump));
 			output.errorMessage = rewriteCopilotError(output.errorMessage, error, model.provider);
+			// Explicitly mark the poisoned-history rejection so the shared
+			// `invalid_prompt` contract is present even when the SDK error surfaces
+			// only a message (no structured code). This keeps the responses
+			// transport's classification uniform with the codex transport's
+			// non-retryable event set and lets the session-level circuit breaker
+			// key on one durable marker instead of per-transport string matching.
+			if (
+				output.stopReason === "error" &&
+				!output.transportFailure?.providerCode &&
+				(isInvalidPromptError(error) || isInvalidPromptError(output.errorMessage))
+			) {
+				output.transportFailure = {
+					...(output.transportFailure ?? { kind: "transport" }),
+					providerCode: "invalid_prompt",
+				};
+			}
 			output.duration = Date.now() - startTime;
 			if (firstTokenTime) output.ttft = firstTokenTime - startTime;
 			stream.push({ type: "error", reason: output.stopReason, error: output });

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -155,6 +155,51 @@ export function neutralizeReservedControlTokens(text: string): string {
 }
 
 /**
+ * Shape-tolerant classifier for the poisoned-history rejection that wedges
+ * gpt-5.6 sessions: `Request blocked (code=invalid_prompt)`. Accepts a raw
+ * provider error, an assistant message, or any object carrying a
+ * `providerCode` / `transportFailure` / `errorMessage` field, and returns true
+ * when the failure is the deterministic `invalid_prompt` content fault rather
+ * than a transient upstream error. This is the single shared contract the
+ * provider transports and the session-level circuit breaker key on so the
+ * classification is explicit (not inferred from a catch-all bucket) and
+ * uniformly testable across transports.
+ */
+export function isInvalidPromptError(input: unknown): boolean {
+	if (!input) return false;
+	if (typeof input === "string") return INVALID_PROMPT_MESSAGE_RE.test(input);
+	if (typeof input !== "object") return false;
+	const value = input as {
+		providerCode?: unknown;
+		code?: unknown;
+		errorMessage?: unknown;
+		message?: unknown;
+		transportFailure?: { providerCode?: unknown; code?: unknown };
+		error?: { code?: unknown };
+	};
+	const code =
+		asLowerString(value.providerCode) ??
+		asLowerString(value.code) ??
+		asLowerString(value.transportFailure?.providerCode) ??
+		asLowerString(value.transportFailure?.code) ??
+		asLowerString(value.error?.code);
+	if (code === "invalid_prompt") return true;
+	const message =
+		typeof value.errorMessage === "string"
+			? value.errorMessage
+			: typeof value.message === "string"
+				? value.message
+				: undefined;
+	return message !== undefined && INVALID_PROMPT_MESSAGE_RE.test(message);
+}
+
+const INVALID_PROMPT_MESSAGE_RE = /code=invalid[_ -]prompt|request blocked[^\n]*invalid[_ -]prompt/i;
+
+function asLowerString(value: unknown): string | undefined {
+	return typeof value === "string" ? value.toLowerCase() : undefined;
+}
+
+/**
  * Neutralize leaked reserved control tokens across every string in an outgoing
  * Responses `input` array. This is the request-boundary complement to the
  * replay-history sanitizer: leaked Harmony markers (`<|channel|>analysis`, ...)

--- a/packages/ai/test/invalid-prompt-classification.test.ts
+++ b/packages/ai/test/invalid-prompt-classification.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import { classifyCodexFailureEventRetryable } from "@gajae-code/ai/providers/openai-codex-responses";
+import { isInvalidPromptError, neutralizeReservedControlTokens } from "../src/utils";
+
+// Issue #2282: `Request blocked (code=invalid_prompt)` is a deterministic
+// poisoned-history content fault, not a transient upstream failure. It must be
+// classified as EXPLICITLY non-retryable across transports, and the shared
+// predicate must never fire on valid control-token / pipe / history text.
+
+describe("isInvalidPromptError shared classifier", () => {
+	it("detects the invalid_prompt code across common carrier shapes", () => {
+		expect(isInvalidPromptError({ providerCode: "invalid_prompt" })).toBe(true);
+		expect(isInvalidPromptError({ code: "invalid_prompt" })).toBe(true);
+		expect(isInvalidPromptError({ code: "INVALID_PROMPT" })).toBe(true);
+		expect(isInvalidPromptError({ transportFailure: { providerCode: "invalid_prompt" } })).toBe(true);
+		expect(isInvalidPromptError({ error: { code: "invalid_prompt" } })).toBe(true);
+	});
+
+	it("detects the invalid_prompt message form on strings and message fields", () => {
+		expect(isInvalidPromptError("Request blocked (code=invalid_prompt)")).toBe(true);
+		expect(isInvalidPromptError("code=invalid_prompt")).toBe(true);
+		expect(isInvalidPromptError({ errorMessage: "Request blocked (code=invalid_prompt)" })).toBe(true);
+		expect(isInvalidPromptError({ message: "Request blocked (code=invalid-prompt)" })).toBe(true);
+	});
+
+	it("does NOT fire on other error classes (negative)", () => {
+		expect(isInvalidPromptError({ code: "server_error" })).toBe(false);
+		expect(isInvalidPromptError({ code: "model_error" })).toBe(false);
+		expect(isInvalidPromptError({ code: "internal_error" })).toBe(false);
+		expect(isInvalidPromptError({ code: "invalid_function_parameters" })).toBe(false);
+		expect(isInvalidPromptError({ errorMessage: "The server had an error processing your request" })).toBe(false);
+	});
+
+	it("does NOT fire on empty / non-error inputs (negative)", () => {
+		expect(isInvalidPromptError(undefined)).toBe(false);
+		expect(isInvalidPromptError(null)).toBe(false);
+		expect(isInvalidPromptError("")).toBe(false);
+		expect(isInvalidPromptError(42)).toBe(false);
+		expect(isInvalidPromptError({})).toBe(false);
+	});
+
+	it("does NOT fire on ordinary text that merely mentions prompts (negative)", () => {
+		expect(isInvalidPromptError("the user prompt was invalid for my taste")).toBe(false);
+		expect(isInvalidPromptError({ errorMessage: "invalid prompt template rendered" })).toBe(false);
+	});
+});
+
+describe("codex failure-event retry classification (issue #2282)", () => {
+	it("marks invalid_prompt events non-retryable by code", () => {
+		expect(
+			classifyCodexFailureEventRetryable({
+				type: "error",
+				error: { code: "invalid_prompt", message: "Request blocked" },
+			}),
+		).toBe(false);
+	});
+
+	it("marks invalid_prompt events non-retryable by message", () => {
+		expect(
+			classifyCodexFailureEventRetryable({
+				type: "error",
+				error: { message: "Request blocked (code=invalid_prompt)" },
+			}),
+		).toBe(false);
+	});
+
+	it("keeps genuinely transient events retryable (negative)", () => {
+		expect(
+			classifyCodexFailureEventRetryable({
+				type: "error",
+				error: { code: "server_error", message: "server error" },
+			}),
+		).toBe(true);
+		expect(classifyCodexFailureEventRetryable({ type: "error", error: { code: "model_error" } })).toBe(true);
+		expect(
+			classifyCodexFailureEventRetryable({
+				type: "error",
+				error: { message: "We had an error processing your request" },
+			}),
+		).toBe(true);
+	});
+
+	it("keeps schema/tool faults non-retryable (unchanged behavior)", () => {
+		expect(
+			classifyCodexFailureEventRetryable({ type: "error", error: { code: "invalid_function_parameters" } }),
+		).toBe(false);
+	});
+});
+
+describe("neutralize-only repair preserves valid control-token / history text (issue #2282)", () => {
+	// A raw `<|` survives as poison; a neutralized marker reads `<\u200b|`.
+	const RAW = "<\u007c"; // "<|" written to avoid confusing tooling in this comment
+
+	it("neutralizes leaked reserved markers (changes bytes)", () => {
+		const poisoned = 'ok<|channel|>analysis to=functions.bash<|message|>{"command":"gjc --help"}<|call|>';
+		const out = neutralizeReservedControlTokens(poisoned);
+		expect(out).not.toBe(poisoned);
+		expect(out.includes(RAW)).toBe(false);
+	});
+
+	it("leaves valid pipe / delimiter text byte-identical (negative fixtures)", () => {
+		const fixtures = [
+			"value <| f |> g", // F# operator with spaces
+			"sum<|a+b|>c", // compact punctuation body
+			"<|foo bar=baz|>", // arbitrary key=value, unknown role
+			"<|assistant color=red|>", // known role but not a `to=` recipient
+			"a neutralized item <\u200b|channel|> stays neutralized", // already-neutralized (idempotent)
+			"no markers here at all",
+		];
+		for (const fixture of fixtures) {
+			expect(neutralizeReservedControlTokens(fixture)).toBe(fixture);
+		}
+	});
+});


### PR DESCRIPTION
Closes #2282.

## Problem
`Request blocked (code=invalid_prompt)` is a deterministic poisoned-history content fault. The merged sanitizer (#2144/#2192/#2197/#2268/#2279) repairs history at the request boundary, but the fault was only non-retryable **by omission** (absent from the codex retryable/non-retryable event sets; a generic error with no durable marker on the plain Responses transport), and there was **no proven-terminating deterministic breaker/test**. So a session could still burn retry budget re-poisoning the model.

Only-if-absent gate: a fake-transport repro confirmed neither explicit classification nor a terminating repro test existed, so the fix was implemented.

## Change (TypeScript-only)
**Provider layer (explicit, shared contract):**
- `openai-codex-responses`: `invalid_prompt` added to `CODEX_NON_RETRYABLE_EVENT_CODES` + non-retryable message regex (code and message forms).
- `openai-responses`: error path tags `transportFailure.providerCode = "invalid_prompt"` so the marker is present even when the SDK surfaces only a message.
- New exported `isInvalidPromptError` predicate — the single contract both transports and the session breaker key on.

**Session layer (`agent-loop`, bounded, neutralize-only):**
- On the first `invalid_prompt` of a run, neutralize leaked control tokens in history **in place** (never dropping items); resend **exactly once iff bytes changed**, else **fail fast immediately**. Budget = one repaired resend. Repaired history persists for a clean resume. Scoped to the non-managed path (managed fallback owns its own retry policy); runs before the response commits so the resend is a clean retry.

## Tests (deterministic, no live model retries)
- Classification unit + negative byte-identical fixtures: F# `value <| f |> g`, `sum<|a+b|>c`, `<|foo bar=baz|>`, `<|assistant color=red|>`, already-neutralized item; transient errors stay retryable.
- Fake-transport integration asserting **exactly 2** provider requests when neutralization changes bytes, **exactly 1** when it cannot, budget=1 on recurrence, no trigger on non-invalid_prompt errors, resume persistence.
- Compaction-path termination assertion (single-shot, neutralized, no retry).

## Gates
- `packages/ai`: 1730 pass / 0 fail. `packages/agent`: 514 pass / 0 fail. biome + tsc clean on both.
- G002: all checks pass **except** the pre-existing `MCP quarantine (README.md: MCP)` sub-check, which fails identically on pristine dev `5c6a28f3` with none of these changes present (verified via `git stash`). Not a regression from this PR; out of scope (no README/MCP files touched).

## Safety
- No Rust / `Cargo.lock` changes (the working-tree `Cargo.lock` drift was proven byte-identical to dev and left untouched).
- No new sanitizer grammar; no broad retry-policy refactor beyond the `invalid_prompt` path.
