### PR TITLE
fix(coding-agent): tolerate Windows directory fsync EPERM

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Windows startup no longer fails when the parent-directory durability sync reports `EPERM`; the compatibility handling remains limited to directory fsync, while ordinary file sync failures still propagate.
 
 ## [0.11.0] - 2026-07-15
 

--- a/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-broker.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-broker.ts
@@ -939,7 +939,7 @@ function assertPersistedGate(
 function isUnsupportedWindowsDirectorySyncError(error: unknown): boolean {
 	if (process.platform !== "win32") return false;
 	const code = (error as NodeJS.ErrnoException | undefined)?.code;
-	return code === "EINVAL" || code === "ENOTSUP" || code === "EOPNOTSUPP";
+	return code === "EPERM" || code === "EINVAL" || code === "ENOTSUP" || code === "EOPNOTSUPP";
 }
 
 /** A write may have reached `rename` but not the directory fsync durability barrier. */

--- a/packages/coding-agent/test/workflow-gate-broker.test.ts
+++ b/packages/coding-agent/test/workflow-gate-broker.test.ts
@@ -409,6 +409,44 @@ describe("WorkflowGateBroker", () => {
 				),
 		).toThrow(/directory fsync failed/);
 	});
+	it("ignores Windows EPERM only for the parent directory fsync", () => {
+		const dir = mkdtempSync(path.join(tmpdir(), "gate-windows-fsync-eperm-"));
+		const file = path.join(dir, "gates.json");
+		let syncs = 0;
+		const store = new FileGateStore(file, () => {
+			syncs++;
+			if (syncs === 2) {
+				const error = new Error("directory fsync unsupported") as NodeJS.ErrnoException;
+				error.code = "EPERM";
+				throw error;
+			}
+		});
+
+		expect(() =>
+			new WorkflowGateBroker("run-windows-fsync-eperm", store).openGate(
+				{ stage: "deep-interview", kind: "question", schema: { type: "string" } },
+				liveContinuation(),
+			),
+		).not.toThrow();
+		expect(syncs).toBeGreaterThanOrEqual(2);
+	});
+
+	it("does not ignore Windows EPERM for the file fsync", () => {
+		const dir = mkdtempSync(path.join(tmpdir(), "gate-windows-file-fsync-eperm-"));
+		const file = path.join(dir, "gates.json");
+		const store = new FileGateStore(file, () => {
+			const error = new Error("file fsync denied") as NodeJS.ErrnoException;
+			error.code = "EPERM";
+			throw error;
+		});
+
+		expect(() =>
+			new WorkflowGateBroker("run-windows-file-fsync-eperm", store).openGate(
+				{ stage: "deep-interview", kind: "question", schema: { type: "string" } },
+				liveContinuation(),
+			),
+		).toThrow(/file fsync denied/);
+	});
 	it("quarantines a disk-accepted record after post-rename fsync uncertainty instead of reissuing it", async () => {
 		const file = path.join(mkdtempSync(path.join(tmpdir(), "gate-uncertain-accepted-")), "gates.json");
 		let syncs = 0;


### PR DESCRIPTION
## Summary

- Treat `EPERM` as an unsupported parent-directory fsync result on Windows.
- Keep ordinary file fsync failures fatal.
- Add regression coverage for both directory and file fsync behavior.

## Problem

GJC 0.11.0 can fail during Windows startup with `GateStoreWriteError: gate store write uncertain: EPERM: operation not permitted, fsync`. The file write and atomic rename have succeeded, but Bun/Node may report `EPERM` when syncing the parent directory.

## Verification

- `bun test packages/coding-agent/test/workflow-gate-broker.test.ts` (20 pass, 0 fail)
- `git diff --check`

The broader `bun run check:ts` reached the SDK manifest tests but could not complete because the local Windows native addon predates 0.11.0 and lacks the `__piNativesV0_11_0` sentinel.