### PR TITLE
feat(tui): add mid-turn send-now message queue controls

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Added configurable Ctrl+Enter send-now behavior for queued and draft prompts during active turns.
 
 ## [0.11.0] - 2026-07-15
 

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -31,6 +31,7 @@ interface AppKeybindings {
 	"app.tool.backgroundFold": true;
 	"app.editor.external": true;
 	"app.message.followUp": true;
+	"app.message.sendNow": true;
 	"app.message.queue": true;
 	"app.message.dequeue": true;
 	"app.clipboard.pasteImage": true;
@@ -129,6 +130,10 @@ export const KEYBINDINGS = {
 	"app.message.followUp": {
 		defaultKeys: [],
 		description: "Send follow-up message (no default; Ctrl+Enter submits)",
+	},
+	"app.message.sendNow": {
+		defaultKeys: "ctrl+enter",
+		description: "Cancel current turn and send message now",
 	},
 	"app.message.queue": {
 		defaultKeys: defaultMessageQueueKeysForPlatform(),

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -368,6 +368,13 @@ export class InputController {
 				return true;
 			});
 		}
+		for (const key of this.ctx.keybindings.getKeys("app.message.sendNow")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				if (!this.ctx.session.isStreaming || !this.ctx.editor.getText().trim()) return false;
+				void this.#sendNow(this.ctx.editor.getText());
+				return true;
+			});
+		}
 		for (const key of this.ctx.keybindings.getKeys("app.stt.toggle")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleSTTToggle());
 		}
@@ -414,10 +421,11 @@ export class InputController {
 			text = text.trim();
 			if ((!isSettingsInitialized() || settings.get("emojiAutocomplete")) && text) text = expandEmoticons(text);
 
-			// Empty submit while streaming with queued messages: flush queues immediately
-			if (!text && this.ctx.session.isStreaming && this.ctx.session.queuedMessageCount > 0) {
-				// Abort current stream and let queued messages be processed
-				await this.#abortInteractive();
+			// Empty submit while streaming with queued messages sends the next queued
+			// message immediately. Compaction-local messages intentionally stay queued
+			// until compaction completes.
+			if (!text && this.ctx.session.isStreaming) {
+				await this.#sendNextQueuedMessageNow();
 				return;
 			}
 
@@ -544,6 +552,9 @@ export class InputController {
 				await this.ctx.withLocalSubmission(text, () => this.ctx.session.prompt(text, promptOptions), {
 					imageCount: images?.length ?? 0,
 				});
+				if (streamingBehavior === "followUp") {
+					this.#showQueuedMessageHint();
+				}
 				this.ctx.updatePendingMessagesDisplay();
 				this.ctx.ui.requestRender();
 				return;
@@ -937,6 +948,7 @@ export class InputController {
 					followUpQueuePolicy: "sequential",
 				}),
 			);
+			this.#showQueuedMessageHint();
 			this.ctx.updatePendingMessagesDisplay();
 			this.ctx.ui.requestRender();
 			return;
@@ -951,6 +963,27 @@ export class InputController {
 	/** Send editor text explicitly as a queued next-turn message. */
 	async handleQueueSubmit(): Promise<void> {
 		return this.handleFollowUp();
+	}
+	#showQueuedMessageHint(): void {
+		const sendNowKey = this.ctx.keybindings.getDisplayString?.("app.message.sendNow") || "Ctrl+Enter";
+		this.ctx.showStatus(`Queued — Enter again to send now, ${sendNowKey} to cancel & send`, { dim: true });
+	}
+
+	async #sendNextQueuedMessageNow(): Promise<void> {
+		const queuedMessage = this.ctx.session.getQueuedMessageEntries()[0];
+		if (!queuedMessage) return;
+
+		const text = this.ctx.session.removeQueuedMessageForEditing(queuedMessage.id);
+		this.ctx.updatePendingMessagesDisplay();
+		if (!text) return;
+
+		await this.#sendNow(text);
+	}
+
+	async #sendNow(text: string): Promise<void> {
+		await this.#abortInteractive();
+		this.ctx.editor.setText("");
+		await this.ctx.editor.onSubmit?.(text);
 	}
 
 	restoreLatestQueuedMessageToEditor(): number {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -45,6 +45,7 @@ type FakeEditor = {
 async function createContext(options?: {
 	busyPromptMode?: "steer" | "queue";
 	followUpKeys?: string[];
+	sendNowKeys?: string[];
 	ircSidebarToggleKeys?: string[];
 }) {
 	let editorText = "";
@@ -53,6 +54,7 @@ async function createContext(options?: {
 		"app.model.select": ["ctrl+l"],
 		"app.message.queue": ["alt+enter"],
 		"app.message.followUp": options?.followUpKeys ?? [],
+		"app.message.sendNow": options?.sendNowKeys ?? ["ctrl+enter"],
 		"app.message.dequeue": ["alt+up", "alt+down"],
 		"app.irc.sidebar.toggle": options?.ircSidebarToggleKeys ?? ["alt+i"],
 	};
@@ -61,6 +63,9 @@ async function createContext(options?: {
 	const showModelSelector = vi.fn();
 	const prompt = vi.fn(async () => {});
 	const updatePendingMessagesDisplay = vi.fn();
+	const abort = vi.fn(async () => {
+		(session as unknown as { isStreaming: boolean }).isStreaming = false;
+	});
 	const handleBashCommand = vi.fn(async () => {});
 	const showStatus = vi.fn();
 	const onInputCallback = vi.fn();
@@ -147,6 +152,24 @@ async function createContext(options?: {
 			editorContainerChildren.push(child);
 		}),
 	};
+	const session = {
+		isStreaming: false,
+		isCompacting: false,
+		isGeneratingHandoff: false,
+		isBashRunning: false,
+		isEvalRunning: false,
+		messages: [],
+		abort,
+		abortBash: vi.fn(),
+		extensionRunner: undefined,
+		prompt,
+		popLastQueuedMessage,
+		clearQueue,
+		getQueuedMessages: () => ({ steering: [], followUp: [...sessionQueuedMessages] }),
+		getQueuedMessageEntries,
+		removeQueuedMessageForEditing,
+		moveQueuedMessageForEditing,
+	} as unknown as InteractiveModeContext["session"];
 	const ctx = {
 		editor: editor as unknown as InteractiveModeContext["editor"],
 		ui: { requestRender: vi.fn(), setFocus: vi.fn() } as unknown as InteractiveModeContext["ui"],
@@ -156,23 +179,7 @@ async function createContext(options?: {
 		retryLoader: undefined,
 		autoCompactionEscapeHandler: undefined,
 		retryEscapeHandler: undefined,
-		session: {
-			isStreaming: false,
-			isCompacting: false,
-			isGeneratingHandoff: false,
-			isBashRunning: false,
-			isEvalRunning: false,
-			messages: [],
-			abortBash: vi.fn(),
-			extensionRunner: undefined,
-			prompt,
-			popLastQueuedMessage,
-			clearQueue,
-			getQueuedMessages: () => ({ steering: [], followUp: [...sessionQueuedMessages] }),
-			getQueuedMessageEntries,
-			removeQueuedMessageForEditing,
-			moveQueuedMessageForEditing,
-		} as unknown as InteractiveModeContext["session"],
+		session,
 		keybindings: {
 			getKeys(action: string) {
 				return keyMap[action] ? [...keyMap[action]] : [];
@@ -263,6 +270,7 @@ async function createContext(options?: {
 			handleBashCommand,
 			showStatus,
 			queueCompactionMessage,
+			abort,
 			popLastQueuedMessage,
 			clearQueue,
 			getQueuedMessageEntries,
@@ -356,17 +364,20 @@ describe("InputController keybinding setup", () => {
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
 
-	it("does not register a default Ctrl+Enter follow-up handler", async () => {
+	it("registers the default Ctrl+Enter send-now handler", async () => {
 		const { InputController, ctx, editor } = await createContext();
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
 
-		expect(editor.setCustomKeyHandler).not.toHaveBeenCalledWith("ctrl+enter", expect.any(Function));
+		expect(editor.setCustomKeyHandler).toHaveBeenCalledWith("ctrl+enter", expect.any(Function));
 	});
 
 	it("lets an explicit Ctrl+Enter follow-up remap fall through while idle", async () => {
-		const { InputController, ctx, editor, spies } = await createContext({ followUpKeys: ["ctrl+enter"] });
+		const { InputController, ctx, editor, spies } = await createContext({
+			followUpKeys: ["ctrl+enter"],
+			sendNowKeys: [],
+		});
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
@@ -380,8 +391,11 @@ describe("InputController keybinding setup", () => {
 		expect(spies.prompt).not.toHaveBeenCalled();
 	});
 
-	it("consumes Ctrl+Enter as follow-up while streaming", async () => {
-		const { InputController, ctx, editor, spies } = await createContext({ followUpKeys: ["ctrl+enter"] });
+	it("consumes an explicit Ctrl+Enter follow-up remap while streaming", async () => {
+		const { InputController, ctx, editor, spies } = await createContext({
+			followUpKeys: ["ctrl+enter"],
+			sendNowKeys: [],
+		});
 		const session = ctx.session as unknown as { isStreaming: boolean };
 		session.isStreaming = true;
 		editor.setText("follow up from shortcut");
@@ -399,6 +413,80 @@ describe("InputController keybinding setup", () => {
 			streamingBehavior: "followUp",
 			followUpQueuePolicy: "sequential",
 		});
+	});
+	it("cancels and submits the next queued message on empty streaming Enter", async () => {
+		const { InputController, ctx, editor, spies, queues } = await createContext();
+		const session = ctx.session as unknown as { isStreaming: boolean };
+		session.isStreaming = true;
+		queues.sessionQueuedMessages.push("send this next");
+		const controller = new InputController(ctx);
+
+		controller.setupEditorSubmitHandler();
+		await editor.onSubmit?.("");
+
+		expect(spies.abort).toHaveBeenCalledWith({
+			timeoutMs: 5_000,
+			cause: "user_interrupt",
+			silent: undefined,
+		});
+		expect(spies.removeQueuedMessageForEditing).toHaveBeenCalledWith("followUp:0");
+		expect(spies.onInputCallback).toHaveBeenCalledWith(
+			expect.objectContaining({ text: "send this next", cancelled: false, started: true }),
+		);
+		expect(queues.sessionQueuedMessages).toEqual([]);
+	});
+
+	it("cancels and submits a streaming draft from the send-now chord", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isStreaming: boolean };
+		session.isStreaming = true;
+		editor.setText("send this draft");
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.setupEditorSubmitHandler();
+		const registration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
+			([key]) => key === "ctrl+enter",
+		);
+		const handler = registration?.[1] as () => boolean;
+
+		expect(handler()).toBe(true);
+		await Bun.sleep(0);
+
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.onInputCallback).toHaveBeenCalledWith(
+			expect.objectContaining({ text: "send this draft", cancelled: false, started: true }),
+		);
+		expect(editor.getText()).toBe("");
+	});
+
+	it("leaves the send-now chord to plain submission while idle", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		editor.setText("idle draft");
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		const registration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
+			([key]) => key === "ctrl+enter",
+		);
+		const handler = registration?.[1] as () => boolean | undefined;
+
+		expect(handler()).toBe(false);
+		expect(spies.abort).not.toHaveBeenCalled();
+		expect(spies.onInputCallback).not.toHaveBeenCalled();
+	});
+
+	it("keeps empty streaming Enter as a no-op when no session messages are queued", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isStreaming: boolean };
+		session.isStreaming = true;
+		const controller = new InputController(ctx);
+
+		controller.setupEditorSubmitHandler();
+		await editor.onSubmit?.("");
+
+		expect(spies.abort).not.toHaveBeenCalled();
+		expect(spies.onInputCallback).not.toHaveBeenCalled();
 	});
 
 	it("leaves streaming Tab available for editor autocomplete", async () => {


### PR DESCRIPTION
## Summary
Ports grok-build's mid-turn send-now semantics onto the existing message queue (behavior port; no code copied).

- **Double-Enter send-now**: while a turn is running, Enter on an empty editor with a non-empty queue interrupts the current turn and submits the top queued message as the next turn. Empty queue + empty editor stays a no-op.
- **Cancel-and-send chord**: new configurable `app.message.sendNow` action (default `Ctrl+Enter`). Mid-turn with a draft it cancels the turn and submits the draft; idle it falls through to normal submit.
- Queue hint via the existing status surface when a message is queued mid-turn.
- Compaction-local queued messages remain protected — send-now only consumes session queue entries.

## Testing
- `bun test packages/coding-agent/test/input-controller-keybindings.test.ts` — 37 pass (dequeue-now, chord, idle fallthrough, empty-queue no-op).
- `bun --cwd=packages/coding-agent run check:types` — pass.

Part 2/4 of the grok-build TUI behavior-port series.