### PR TITLE
feat(tui): pin explicit fold choices against automatic expansion stamping

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- The tool-output expand shortcut now stamps an explicit per-block fold choice, and automatic expansion stamping can no longer overwrite a block whose state came from an explicit user action. All current automatic stamping happens at component creation, so behavior is unchanged today; this locks the invariant for future per-block folds.
+
 ## [0.11.0] - 2026-07-15
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -80,6 +80,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	#entries = new Map<string, ReadEntry>();
 	#text: Text;
 	#expanded = false;
+	#manuallyExpanded: boolean | undefined;
 	#showContentPreview: boolean;
 
 	constructor(options: ReadToolGroupOptions = {}) {
@@ -138,6 +139,16 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	}
 
 	setExpanded(expanded: boolean): void {
+		if (this.#manuallyExpanded !== undefined) return;
+		this.#expanded = expanded;
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Apply an explicit user fold choice. Automatic updates must retain this choice.
+	 */
+	setManuallyExpanded(expanded: boolean): void {
+		this.#manuallyExpanded = expanded;
 		this.#expanded = expanded;
 		this.#updateDisplay();
 	}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -174,6 +174,7 @@ export class ToolExecutionComponent extends Container {
 	#toolLabel: string;
 	#args: any;
 	#expanded = false;
+	#manuallyExpanded: boolean | undefined;
 	#showImages: boolean;
 	#editFuzzyThreshold: number | undefined;
 	#editAllowFuzzy: boolean | undefined;
@@ -451,6 +452,16 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	setExpanded(expanded: boolean): void {
+		if (this.#manuallyExpanded !== undefined) return;
+		this.#expanded = expanded;
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Apply an explicit user fold choice. Automatic updates must retain this choice.
+	 */
+	setManuallyExpanded(expanded: boolean): void {
+		this.#manuallyExpanded = expanded;
 		this.#expanded = expanded;
 		this.#updateDisplay();
 	}

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -26,6 +26,17 @@ interface Expandable {
 	setExpanded(expanded: boolean): void;
 }
 
+interface ManuallyExpandable extends Expandable {
+	setManuallyExpanded(expanded: boolean): void;
+}
+
+function isManuallyExpandable(obj: unknown): obj is ManuallyExpandable {
+	return (
+		isExpandable(obj) &&
+		"setManuallyExpanded" in obj &&
+		typeof obj.setManuallyExpanded === "function"
+	);
+}
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
 const IMAGE_PLACEHOLDER_PATTERN = /\[image ([1-9]\d*)\]/g;
 const IMAGE_PLACEHOLDER_PRESENT_PATTERN = /\[image [1-9]\d*\]/;
@@ -1363,7 +1374,9 @@ export class InputController {
 	setToolsExpanded(expanded: boolean): void {
 		this.ctx.toolOutputExpanded = expanded;
 		for (const child of this.ctx.chatContainer.children) {
-			if (isExpandable(child)) {
+			if (isManuallyExpandable(child)) {
+				child.setManuallyExpanded(expanded);
+			} else if (isExpandable(child)) {
 				child.setExpanded(expanded);
 			}
 		}

--- a/packages/coding-agent/test/modes/components/pinned-folds.test.ts
+++ b/packages/coding-agent/test/modes/components/pinned-folds.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { Container, type TUI } from "@gajae-code/tui";
+import { resetSettingsForTest, Settings } from "../../../src/config/settings.js";
+import { AssistantMessageComponent } from "../../../src/modes/components/assistant-message.js";
+import { ToolExecutionComponent } from "../../../src/modes/components/tool-execution.js";
+import { initTheme } from "../../../src/modes/theme/theme.js";
+import { InputController } from "../../../src/modes/controllers/input-controller.js";
+import type { InteractiveModeContext } from "../../../src/modes/types.js";
+
+const uiStub = { requestRender() {} } as unknown as TUI;
+
+function render(component: ToolExecutionComponent | AssistantMessageComponent): string {
+	return Bun.stripANSI(component.render(100).join("\n"));
+}
+
+function assistantMessage(thinking: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "thinking", thinking }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+function toolResult(lines: number): { content: Array<{ type: string; text: string }> } {
+	return {
+		content: [
+			{
+				type: "text",
+				text: Array.from(
+					{ length: lines },
+					(_, index) => (index === 0 ? "fold-start-marker" : `line ${index + 1}`),
+				).join("\n"),
+			},
+		],
+	};
+}
+
+describe("manual output folds", () => {
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		await initTheme(false);
+	});
+
+	it("retains a manually expanded tool result when its automatic completion state changes", () => {
+		const component = new ToolExecutionComponent("bash", { command: "echo output" }, {}, undefined, uiStub);
+		component.setManuallyExpanded(true);
+		component.updateResult(toolResult(30), false);
+		component.setExpanded(false);
+
+		expect(render(component)).toContain("fold-start-marker");
+	});
+
+	it("keeps automatic folding behavior for untouched tool results", () => {
+		const component = new ToolExecutionComponent("bash", { command: "echo output" }, {}, undefined, uiStub);
+		component.updateResult(toolResult(30), false);
+		component.setExpanded(false);
+
+		expect(render(component)).not.toContain("fold-start-marker");
+	});
+
+	it("lets the global fold toggle override an earlier pin", () => {
+		const component = new ToolExecutionComponent("bash", { command: "echo output" }, {}, undefined, uiStub);
+		const chatContainer = new Container();
+		chatContainer.addChild(component);
+		const ctx = { chatContainer, toolOutputExpanded: false, ui: uiStub } as unknown as InteractiveModeContext;
+		const controller = new InputController(ctx);
+
+		component.setManuallyExpanded(true);
+		controller.setToolsExpanded(false);
+		component.updateResult(toolResult(30), false);
+
+		expect(render(component)).not.toContain("fold-start-marker");
+	});
+
+	it("keeps hidden thinking hidden through streaming updates", () => {
+		const thinking = { type: "thinking" as const, thinking: "private thought" };
+		const component = new AssistantMessageComponent(assistantMessage(thinking.thinking));
+		component.setHideThinkingBlock(true);
+		thinking.thinking += " still private";
+		component.updateContent(assistantMessage(thinking.thinking), { streaming: true });
+
+		const output = render(component);
+		expect(output).toContain("Thinking...");
+		expect(output).not.toContain("private thought");
+	});
+});


### PR DESCRIPTION
## Summary
Ports the *invariant* behind grok-build's `respect_manual_folds` (behavior port; no code copied): fold state set by an explicit user action must never be overwritten by automatic updates.

- Splits fold state into **explicit** (`setManuallyExpanded`, used by the global expand shortcut) and **automatic** (`setExpanded`, creation-time stamping). Automatic calls are a no-op on a pinned block; the global shortcut re-stamps and re-pins.
- Applied to `ToolExecutionComponent` and `ReadToolGroupComponent`; `InputController.setToolsExpanded` routes through the explicit API.

## Honest scope note
An audit of every `setExpanded` callsite on `dev` (event-controller ×4, ui-helpers ×7, input-controller ×1) shows **all automatic callers run at component creation** — no post-creation automatic path exists today, so this PR causes **no user-visible change**. What it delivers is (1) regression tests locking current fold behavior and (2) the pin invariant, so future streaming/completion/per-block-fold work cannot clobber explicit user folds. No per-block toggle UI is introduced — the inline renderer has none, and inventing one was deliberately out of scope.

## Testing
- `bun test packages/coding-agent/test/modes/components/pinned-folds.test.ts` — 4 pass (pin survives simulated automatic re-stamp, untouched blocks keep auto behavior, global toggle overrides pins, hidden thinking persists through streaming).
- `bun --cwd=packages/coding-agent run check:types` — pass.

Part 4/4 of the grok-build TUI behavior-port series.