### PR TITLE
fix(goal): hold repeated timeout continuations

### DIFF
--- a/packages/coding-agent/src/goals/continuation-timeout-guard.ts
+++ b/packages/coding-agent/src/goals/continuation-timeout-guard.ts
@@ -1,0 +1,79 @@
+export type ToolOutcomeKind = "timeout" | "success" | "other-error";
+
+export interface TimeoutToolOutcome {
+	toolName: string;
+	argsKey: string;
+	kind: ToolOutcomeKind;
+}
+
+export interface TimeoutHoldState {
+	heldSnapshotKey?: string;
+	fingerprint?: string;
+	streak: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function canonicalizeArgs(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(item => canonicalizeArgs(item));
+	}
+	if (isRecord(value)) {
+		const canonical: Record<string, unknown> = {};
+		for (const key of Object.keys(value).sort()) {
+			if (value[key] !== undefined) {
+				canonical[key] = canonicalizeArgs(value[key]);
+			}
+		}
+		return canonical;
+	}
+	return value;
+}
+
+export function toResultText(result: unknown): string {
+	if (typeof result === "string") return result;
+	if (!isRecord(result) || !Array.isArray(result.content)) return "";
+	return result.content
+		.filter(
+			(content): content is { type: "text"; text: string } =>
+				isRecord(content) && content.type === "text" && typeof content.text === "string",
+		)
+		.map(content => content.text)
+		.join("\n");
+}
+
+export function classifyToolOutcome(isError: unknown, text: string): ToolOutcomeKind {
+	if (isError !== true) return "success";
+	return /\btimed out\b|\btimeout\b/i.test(text) ? "timeout" : "other-error";
+}
+
+export function canonicalArgsKey(args: unknown): string {
+	return JSON.stringify(canonicalizeArgs(args ?? null)) ?? "null";
+}
+
+export function turnTimeoutFingerprint(outcomes: readonly TimeoutToolOutcome[]): string | null {
+	if (outcomes.length === 0 || outcomes.some(outcome => outcome.kind !== "timeout")) return null;
+	const [first] = outcomes;
+	if (!first || outcomes.some(outcome => outcome.toolName !== first.toolName || outcome.argsKey !== first.argsKey)) {
+		return null;
+	}
+	return `${first.toolName}\u0000${first.argsKey}`;
+}
+
+export function decideTimeoutHold(
+	prev: TimeoutHoldState,
+	turn: { snapshotKey: string; fingerprint: string | null },
+): { hold: boolean; next: TimeoutHoldState } {
+	if (turn.fingerprint === null) {
+		return { hold: false, next: { heldSnapshotKey: undefined, fingerprint: undefined, streak: 0 } };
+	}
+	const continues =
+		prev.streak >= 1 && prev.fingerprint === turn.fingerprint && prev.heldSnapshotKey === turn.snapshotKey;
+	const streak = continues ? prev.streak + 1 : 1;
+	return {
+		hold: streak >= 2,
+		next: { heldSnapshotKey: turn.snapshotKey, fingerprint: turn.fingerprint, streak },
+	};
+}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -44,6 +44,14 @@ import type { CompactOptions } from "../extensibility/extensions/types";
 import { resolveSkillSlashCommands, type Skill } from "../extensibility/skills";
 import { BUILTIN_SLASH_COMMANDS, loadSlashCommands } from "../extensibility/slash-commands";
 import { consumePendingGoalModeRequest } from "../gjc-runtime/goal-mode-request";
+import {
+	canonicalArgsKey,
+	classifyToolOutcome,
+	decideTimeoutHold,
+	type TimeoutToolOutcome,
+	toResultText,
+	turnTimeoutFingerprint,
+} from "../goals/continuation-timeout-guard";
 import { type Goal, type GoalModeState, normalizeGoal } from "../goals/state";
 import { resolveLocalUrlToPath } from "../internal-urls";
 import { getLspStartupWarningMessage, LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
@@ -406,6 +414,13 @@ export class InteractiveMode implements InteractiveModeContext {
 	#goalTurnHadToolCalls = false;
 	#goalContinuationTurnInFlight = false;
 	#goalSuppressNextContinuation = false;
+	#goalTurnToolStarts = new Map<string, { toolName: string; argsKey: string }>();
+	#goalTurnOutcomes: TimeoutToolOutcome[] = [];
+	#goalTurnUnpaired = false;
+	#goalTurnSnapshotKey: string | undefined;
+	#goalHeldSnapshotKey: string | undefined;
+	#goalTimeoutFingerprint: string | undefined;
+	#goalIdenticalTimeoutStreak = 0;
 	#planModePreviousModelState: { model: Model; thinkingLevel?: ThinkingLevel } | undefined;
 	#pendingModelSwitch: { model: Model; thinkingLevel?: ThinkingLevel } | undefined;
 	#planModeProviderSessionScope: TemporaryProviderSessionScope | undefined;
@@ -1285,8 +1300,19 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.requestRender();
 	}
 
+	#resetGoalTimeoutHold(): void {
+		this.#goalTurnToolStarts.clear();
+		this.#goalTurnOutcomes = [];
+		this.#goalTurnUnpaired = false;
+		this.#goalTurnSnapshotKey = undefined;
+		this.#goalHeldSnapshotKey = undefined;
+		this.#goalTimeoutFingerprint = undefined;
+		this.#goalIdenticalTimeoutStreak = 0;
+	}
+
 	#resetGoalContinuationSuppression(): void {
 		this.#goalSuppressNextContinuation = false;
+		this.#resetGoalTimeoutHold();
 	}
 
 	#getPausedGoalState(): GoalModeState | undefined {
@@ -1304,13 +1330,36 @@ export class InteractiveMode implements InteractiveModeContext {
 	async #handleGoalSessionEvent(event: AgentSessionEvent): Promise<void> {
 		if (event.type === "agent_start") {
 			this.#goalTurnHadToolCalls = false;
+			this.#goalTurnToolStarts.clear();
+			this.#goalTurnOutcomes = [];
+			this.#goalTurnUnpaired = false;
+			const goal = this.session.getGoalModeState()?.goal;
+			this.#goalTurnSnapshotKey = goal ? `${goal.id}\u0000${goal.objective}` : undefined;
 			this.#cancelGoalContinuation();
 			return;
 		}
 		if (event.type === "tool_execution_start") {
 			this.#goalTurnHadToolCalls = true;
+			this.#goalTurnToolStarts.set(event.toolCallId, {
+				toolName: event.toolName,
+				argsKey: canonicalArgsKey(event.args),
+			});
 			if (!this.#goalContinuationTurnInFlight) {
 				this.#resetGoalContinuationSuppression();
+			}
+			return;
+		}
+		if (event.type === "tool_execution_end") {
+			const start = this.#goalTurnToolStarts.get(event.toolCallId);
+			if (!start) {
+				this.#goalTurnHadToolCalls = true;
+				this.#goalTurnUnpaired = true;
+			} else {
+				this.#goalTurnOutcomes.push({
+					...start,
+					kind: classifyToolOutcome(event.isError, toResultText(event.result)),
+				});
+				this.#goalTurnToolStarts.delete(event.toolCallId);
 			}
 			return;
 		}
@@ -1325,12 +1374,18 @@ export class InteractiveMode implements InteractiveModeContext {
 				await this.#exitGoalMode({ reason: "dropped", silent: true });
 				return;
 			}
+			const goal = event.state?.goal;
+			const snapshotKey = goal ? `${goal.id}\u0000${goal.objective}` : undefined;
+			if (this.#goalHeldSnapshotKey !== undefined && this.#goalHeldSnapshotKey !== snapshotKey) {
+				this.#resetGoalContinuationSuppression();
+			}
 			if (event.state?.enabled === true && !this.#goalModePreviousTools) {
 				this.#goalModePreviousTools = this.session.getActiveToolNames();
 			}
 			this.goalModeEnabled = event.state?.enabled === true;
 			this.goalModePaused = event.state?.enabled !== true && event.state?.goal?.status === "paused";
 			if (!event.state?.enabled) {
+				this.#resetGoalContinuationSuppression();
 				this.#cancelGoalContinuation();
 			}
 			this.#updateGoalModeStatus();
@@ -1341,7 +1396,34 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		if (this.#goalContinuationTurnInFlight) {
 			this.#goalSuppressNextContinuation = !this.#goalTurnHadToolCalls;
+			const fingerprint =
+				this.#goalTurnToolStarts.size > 0 || this.#goalTurnUnpaired
+					? null
+					: turnTimeoutFingerprint(this.#goalTurnOutcomes);
+			const decision = decideTimeoutHold(
+				{
+					heldSnapshotKey: this.#goalHeldSnapshotKey,
+					fingerprint: this.#goalTimeoutFingerprint,
+					streak: this.#goalIdenticalTimeoutStreak,
+				},
+				{ snapshotKey: this.#goalTurnSnapshotKey ?? "", fingerprint },
+			);
+			if (fingerprint === null) {
+				this.#resetGoalTimeoutHold();
+			} else {
+				this.#goalHeldSnapshotKey = decision.next.heldSnapshotKey;
+				this.#goalTimeoutFingerprint = decision.next.fingerprint;
+				this.#goalIdenticalTimeoutStreak = decision.next.streak;
+			}
+			if (decision.hold) {
+				this.#goalSuppressNextContinuation = true;
+				this.showStatus(
+					`Goal paused for attention: repeated identical timeout from ${this.#goalTurnOutcomes[0]?.toolName ?? "tool"}. Send a message to continue.`,
+				);
+			}
 			this.#goalContinuationTurnInFlight = false;
+		} else {
+			this.#resetGoalTimeoutHold();
 		}
 		if (this.session.getGoalModeState()?.mode === "exiting") {
 			await this.#exitGoalMode({ reason: "completed", silent: true });
@@ -1668,6 +1750,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.goalModePaused = options?.paused ?? false;
 		this.#goalModePreviousTools = undefined;
 		this.#goalContinuationTurnInFlight = false;
+		this.#resetGoalContinuationSuppression();
 		this.#cancelGoalContinuation();
 		this.#updateGoalModeStatus();
 		if (!options?.silent) {

--- a/packages/coding-agent/test/goals/continuation-timeout-guard.test.ts
+++ b/packages/coding-agent/test/goals/continuation-timeout-guard.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import {
+	canonicalArgsKey,
+	classifyToolOutcome,
+	decideTimeoutHold,
+	toResultText,
+	turnTimeoutFingerprint,
+} from "@gajae-code/coding-agent/goals/continuation-timeout-guard";
+
+describe("continuation timeout guard", () => {
+	it("classifies timeout, successful, and other-error tool outcomes", () => {
+		expect(classifyToolOutcome(true, "Command timed out after 10 ms")).toBe("timeout");
+		expect(classifyToolOutcome(false, "Command timed out after 10 ms")).toBe("success");
+		expect(classifyToolOutcome(true, "permission denied")).toBe("other-error");
+	});
+
+	it("only reads text content when classifying a result", () => {
+		const result = {
+			content: [{ type: "text", text: "permission denied" }],
+			details: { timeoutMs: 10 },
+		};
+		expect(toResultText(result)).toBe("permission denied");
+		expect(classifyToolOutcome(true, toResultText(result))).toBe("other-error");
+	});
+
+	it("canonicalizes nested object keys while preserving array order", () => {
+		expect(canonicalArgsKey({ b: [{ z: 1, a: 2 }], a: { d: 4, c: 3 }, unset: undefined })).toBe(
+			canonicalArgsKey({ a: { c: 3, d: 4 }, b: [{ a: 2, z: 1 }] }),
+		);
+	});
+
+	it("only fingerprints non-empty identical timeout outcomes", () => {
+		const timeout = { toolName: "bash", argsKey: '{"command":"slow"}', kind: "timeout" as const };
+		expect(turnTimeoutFingerprint([])).toBeNull();
+		expect(turnTimeoutFingerprint([{ ...timeout, kind: "success" }])).toBeNull();
+		expect(turnTimeoutFingerprint([timeout, { ...timeout, kind: "other-error" }])).toBeNull();
+		expect(turnTimeoutFingerprint([timeout, { ...timeout, argsKey: '{"command":"other"}' }])).toBeNull();
+		expect(turnTimeoutFingerprint([timeout])).toBe('bash\u0000{"command":"slow"}');
+		expect(turnTimeoutFingerprint([timeout, timeout])).toBe('bash\u0000{"command":"slow"}');
+	});
+
+	it("holds on the second same-snapshot fingerprint and resets on changes", () => {
+		const first = decideTimeoutHold({ streak: 0 }, { snapshotKey: "goal-a", fingerprint: "bash\u0000{}" });
+		expect(first).toEqual({
+			hold: false,
+			next: { heldSnapshotKey: "goal-a", fingerprint: "bash\u0000{}", streak: 1 },
+		});
+		const second = decideTimeoutHold(first.next, { snapshotKey: "goal-a", fingerprint: "bash\u0000{}" });
+		expect(second.hold).toBe(true);
+		expect(second.next.streak).toBe(2);
+		expect(decideTimeoutHold(second.next, { snapshotKey: "goal-b", fingerprint: "bash\u0000{}" })).toEqual({
+			hold: false,
+			next: { heldSnapshotKey: "goal-b", fingerprint: "bash\u0000{}", streak: 1 },
+		});
+		expect(decideTimeoutHold(second.next, { snapshotKey: "goal-a", fingerprint: "read\u0000{}" })).toEqual({
+			hold: false,
+			next: { heldSnapshotKey: "goal-a", fingerprint: "read\u0000{}", streak: 1 },
+		});
+	});
+});

--- a/packages/coding-agent/test/goals/goal-continuation-timeout-loop.test.ts
+++ b/packages/coding-agent/test/goals/goal-continuation-timeout-loop.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { InteractiveMode } from "@gajae-code/coding-agent/modes/interactive-mode";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { createTools, type Tool, type ToolSession } from "@gajae-code/coding-agent/tools";
+import { TempDir } from "@gajae-code/utils";
+
+type Harness = {
+	tempDir: TempDir;
+	authStorage: AuthStorage;
+	session: AgentSession;
+	mode: InteractiveMode;
+	cleanup: () => Promise<void>;
+};
+
+type ContinuationTimer = {
+	cancelled: boolean;
+	callback: () => void;
+};
+
+let continuationTimers: ContinuationTimer[] = [];
+
+function installContinuationTimerControl(): void {
+	const realSetTimeout = globalThis.setTimeout;
+	const realClearTimeout = globalThis.clearTimeout;
+	const controlledSetTimeout = (callback: () => void, delay?: number): ReturnType<typeof setTimeout> => {
+		if (delay !== 800) return realSetTimeout(callback, delay);
+		const timer: ContinuationTimer = { cancelled: false, callback };
+		continuationTimers.push(timer);
+		return timer as unknown as ReturnType<typeof setTimeout>;
+	};
+	const controlledClearTimeout = (timer: unknown): void => {
+		if (typeof timer === "object" && timer !== null && "cancelled" in timer && "callback" in timer) {
+			(timer as unknown as ContinuationTimer).cancelled = true;
+			return;
+		}
+		realClearTimeout(timer as ReturnType<typeof setTimeout>);
+	};
+	vi.spyOn(globalThis, "setTimeout").mockImplementation(controlledSetTimeout as unknown as typeof setTimeout);
+	vi.spyOn(globalThis, "clearTimeout").mockImplementation(controlledClearTimeout as unknown as typeof clearTimeout);
+}
+
+async function advanceGoalContinuation(): Promise<void> {
+	for (let i = 0; i < 100 && continuationTimers.length === 0; i++) {
+		await Bun.sleep(0);
+	}
+	const timer = continuationTimers.shift();
+	expect(timer).toBeDefined();
+	if (!timer || timer.cancelled) throw new Error("Expected an active goal continuation timer");
+	timer.callback();
+	await flush();
+}
+
+async function createHarness(): Promise<Harness> {
+	resetSettingsForTest();
+	const tempDir = TempDir.createSync("@goal-timeout-loop-");
+	await Settings.init({ inMemory: true, cwd: tempDir.path() });
+	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+	const model = new ModelRegistry(authStorage).find("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected test model");
+	const settings = Settings.isolated({
+		"compaction.enabled": false,
+		"goal.enabled": true,
+		"goal.continuationModes": ["interactive"],
+		"pet.mode": "off",
+		"starReminder.enabled": false,
+		"startup.quiet": true,
+	});
+	const toolSession: ToolSession = {
+		cwd: tempDir.path(),
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings,
+	};
+	const tools = await createTools(toolSession, ["read"]);
+	const session = new AgentSession({
+		agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools, messages: [] } }),
+		sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+		settings,
+		modelRegistry: new ModelRegistry(authStorage),
+		toolRegistry: new Map<string, Tool>(tools.map(tool => [tool.name, tool] as const)),
+		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
+	});
+	const mode = new InteractiveMode(session, "test");
+	await mode.init();
+	mode.ui.stop();
+	await mode.handleGoalModeCommand("Prevent timeout loop");
+	return {
+		tempDir,
+		authStorage,
+		session,
+		mode,
+		cleanup: async () => {
+			mode.stop();
+			await session.dispose();
+			authStorage.close();
+			tempDir.removeSync();
+			resetSettingsForTest();
+		},
+	};
+}
+
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+async function runContinuation(
+	harness: Harness,
+	outcomes: Array<{ toolName: string; args: unknown; isError: boolean; result: unknown }>,
+	unpaired: "none" | "start" | "end" = "none",
+): Promise<void> {
+	expect(harness.mode.goalModeEnabled).toBe(true);
+	expect(harness.session.settings.get("goal.continuationModes")).toContain("interactive");
+	const input = harness.mode.getUserInput();
+	await advanceGoalContinuation();
+	const submission = await input;
+	expect(submission).toMatchObject({ customType: "goal-continuation" });
+	expect(harness.mode.markPendingSubmissionStarted(submission)).toBe(true);
+	harness.session.agent.emitExternalEvent({ type: "agent_start" });
+	for (const [index, outcome] of outcomes.entries()) {
+		const toolCallId = `call-${index}`;
+		harness.session.agent.emitExternalEvent({
+			type: "tool_execution_start",
+			toolCallId,
+			toolName: outcome.toolName,
+			args: outcome.args,
+		});
+		if (unpaired !== "start") {
+			harness.session.agent.emitExternalEvent({
+				type: "tool_execution_end",
+				toolCallId,
+				toolName: outcome.toolName,
+				isError: outcome.isError,
+				result: outcome.result,
+			});
+		}
+	}
+	if (unpaired === "end") {
+		harness.session.agent.emitExternalEvent({
+			type: "tool_execution_end",
+			toolCallId: "missing",
+			toolName: "bash",
+			isError: true,
+			result: "Command timed out",
+		});
+	}
+	harness.session.agent.emitExternalEvent({ type: "agent_end", messages: [] });
+	await flush();
+	await Bun.sleep(0);
+	harness.mode.finishPendingSubmission(submission);
+}
+
+const timeout = (args: unknown = { command: "slow" }, toolName = "bash") => ({
+	toolName,
+	args,
+	isError: true,
+	result: { content: [{ type: "text", text: "Command timed out after 10 ms" }] },
+});
+const success = (args: unknown = { command: "slow" }) => ({
+	toolName: "bash",
+	args,
+	isError: false,
+	result: { content: [{ type: "text", text: "done" }] },
+});
+const otherError = (args: unknown = { command: "slow" }) => ({
+	toolName: "bash",
+	args,
+	isError: true,
+	result: { content: [{ type: "text", text: "permission denied" }] },
+});
+
+describe("goal continuation repeated timeout guard", () => {
+	let harness: Harness;
+
+	beforeAll(() => initTheme());
+	beforeEach(async () => {
+		harness = await createHarness();
+		continuationTimers = [];
+		installContinuationTimerControl();
+	});
+	afterEach(async () => {
+		await harness.cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it("holds after repeated turns with multiple identical timeout calls and surfaces attention status", async () => {
+		const status = vi.spyOn(harness.mode, "showStatus");
+		await runContinuation(harness, [timeout(), timeout()]);
+		await runContinuation(harness, [timeout(), timeout()]);
+		const blocked = harness.mode.getUserInput();
+		await flush();
+		expect(harness.mode.onInputCallback).toBeDefined();
+		expect(status).toHaveBeenCalledWith(
+			"Goal paused for attention: repeated identical timeout from bash. Send a message to continue.",
+		);
+		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "attention" }));
+		await blocked;
+	});
+
+	it("permits one timeout continuation", async () => {
+		await runContinuation(harness, [timeout()]);
+		const next = harness.mode.getUserInput();
+		await advanceGoalContinuation();
+		await expect(next).resolves.toMatchObject({ customType: "goal-continuation" });
+	});
+
+	it("resets the streak for changed args and changed tools", async () => {
+		await runContinuation(harness, [timeout()]);
+		await runContinuation(harness, [timeout({ command: "different" })]);
+		await runContinuation(harness, [timeout({ command: "slow" }, "read")]);
+		const next = harness.mode.getUserInput();
+		await advanceGoalContinuation();
+		await expect(next).resolves.toMatchObject({ customType: "goal-continuation" });
+	});
+
+	it("fails open for repeated non-timeout errors and mixed-progress turns", async () => {
+		await runContinuation(harness, [otherError()]);
+		await runContinuation(harness, [otherError()]);
+		await runContinuation(harness, [timeout(), success()]);
+		await runContinuation(harness, [timeout(), success()]);
+		const next = harness.mode.getUserInput();
+		await advanceGoalContinuation();
+		await expect(next).resolves.toMatchObject({ customType: "goal-continuation" });
+	});
+
+	it("resets durably after a non-synthetic user message", async () => {
+		await runContinuation(harness, [timeout()]);
+		harness.session.agent.emitExternalEvent({
+			type: "message_start",
+			message: { role: "user", content: "continue", timestamp: 0 },
+		});
+		await flush();
+		await runContinuation(harness, [timeout()]);
+		const next = harness.mode.getUserInput();
+		await advanceGoalContinuation();
+		await expect(next).resolves.toMatchObject({ customType: "goal-continuation" });
+	});
+
+	it("releases suppression when the goal id or objective changes after a hold", async () => {
+		await runContinuation(harness, [timeout()]);
+		await runContinuation(harness, [timeout()]);
+		await harness.session.goalRuntime.replaceGoal({ objective: "Changed objective" });
+		await flush();
+		const next = harness.mode.getUserInput();
+		await advanceGoalContinuation();
+		await expect(next).resolves.toMatchObject({ customType: "goal-continuation" });
+	});
+
+	it("fails open for unmatched starts", async () => {
+		await runContinuation(harness, [timeout()], "start");
+		await runContinuation(harness, [timeout()], "start");
+		const next = harness.mode.getUserInput();
+		await advanceGoalContinuation();
+		await expect(next).resolves.toMatchObject({ customType: "goal-continuation" });
+	});
+
+	it("fails open for end-only unmatched tool events", async () => {
+		await runContinuation(harness, [], "end");
+		await runContinuation(harness, [], "end");
+		const next = harness.mode.getUserInput();
+		await advanceGoalContinuation();
+		await expect(next).resolves.toMatchObject({ customType: "goal-continuation" });
+	});
+
+	it("resets the timeout streak after an ordinary agent turn", async () => {
+		await runContinuation(harness, [timeout()]);
+		harness.session.agent.emitExternalEvent({ type: "agent_start" });
+		continuationTimers = [];
+		harness.session.agent.emitExternalEvent({ type: "agent_end", messages: [] });
+		await flush();
+		await runContinuation(harness, [timeout()]);
+		const next = harness.mode.getUserInput();
+		await advanceGoalContinuation();
+		await expect(next).resolves.toMatchObject({ customType: "goal-continuation" });
+	});
+
+	it("suppresses an empty hidden continuation", async () => {
+		await runContinuation(harness, []);
+		const blocked = harness.mode.getUserInput();
+		await flush();
+		expect(continuationTimers).toHaveLength(0);
+		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "attention" }));
+		await blocked;
+	});
+});


### PR DESCRIPTION
## Summary
- hold hidden goal continuation after two consecutive identical timeout-only turns on the same goal id/objective
- fail open for progress, mixed results, changed work, non-timeout errors, unpaired events, ordinary intervening turns, and operator/goal resets
- add deterministic pure and real-subscriber regressions while preserving the existing empty-turn guard

## Verification
- `bun test packages/coding-agent/test/goals/continuation-timeout-guard.test.ts packages/coding-agent/test/goals/goal-continuation-timeout-loop.test.ts packages/coding-agent/test/goals/goal-mode-integration.test.ts` — 31 passed
- `bun test packages/coding-agent/test/goals` — 71 passed
- `bun run --filter @gajae-code/coding-agent check:types` — passed
- `bunx biome check` on all four changed files — passed
- `bun run --filter @gajae-code/coding-agent check` — passed
- affected selector self-test — 50 passed; post-rebase affected plan enumerated coding-agent check, 8 test shards, smoke, native, and build gates
- signed commit verified at `ab25a5db41e06552541100e10e341284902511f1` on exact dev base `1e8e48bd186f09c7ed1c2218734774a53bd2384e`

Closes #2318

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*