### PR TITLE
feat(tui): double-Esc draft clear with self-invalidating gesture state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
 
 ## [0.11.0] - 2026-07-15
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -27,6 +27,8 @@ interface Expandable {
 }
 
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
+const DRAFT_CLEAR_DOUBLE_ESCAPE_WINDOW_MS = 800;
+const EMPTY_EDITOR_DOUBLE_ESCAPE_WINDOW_MS = 500;
 const IMAGE_PLACEHOLDER_PATTERN = /\[image ([1-9]\d*)\]/g;
 const IMAGE_PLACEHOLDER_PRESENT_PATTERN = /\[image [1-9]\d*\]/;
 
@@ -45,6 +47,29 @@ export class InputController {
 	#steerConsumePending = false;
 
 	#globalInterruptUnsubscribe: (() => void) | undefined;
+	#draftClearEscapeText: string | undefined;
+
+	#resetEscapeGestures(): void {
+		this.ctx.lastEscapeTime = 0;
+		this.ctx.lastComposerClearEscapeTime = 0;
+		this.#draftClearEscapeText = undefined;
+	}
+
+	#armDraftClearEscape(text: string, now: number): void {
+		this.ctx.lastEscapeTime = 0;
+		this.ctx.lastComposerClearEscapeTime = now;
+		this.#draftClearEscapeText = text;
+		this.ctx.showStatus("press Esc again to clear");
+	}
+
+	#resetDraftClearEscape(): void {
+		this.ctx.lastComposerClearEscapeTime = 0;
+		this.#draftClearEscapeText = undefined;
+	}
+
+	#resetEmptyEditorEscape(): void {
+		this.ctx.lastEscapeTime = 0;
+	}
 
 	#matchesInterruptKey(data: string): boolean {
 		return this.ctx.keybindings.getKeys("app.interrupt").some(key => matchesKey(data, key));
@@ -146,6 +171,7 @@ export class InputController {
 				return undefined;
 			}
 			if (this.ctx.hasActiveBtw() && this.ctx.handleBtwEscape()) {
+				this.#resetEscapeGestures();
 				return { consume: true };
 			}
 			const hookDialogActive = this.#hasHookDialog();
@@ -153,6 +179,7 @@ export class InputController {
 				// Inline ask/custom-input editors use Esc to return to the option list.
 				// Let the focused selector see the key instead of converting a typo
 				// into a full workflow/session abort while the agent is streaming.
+				this.#resetEscapeGestures();
 				return undefined;
 			}
 			if (
@@ -165,6 +192,7 @@ export class InputController {
 					streaming: hookDialogActive,
 				})
 			) {
+				this.#resetEscapeGestures();
 				return { consume: true };
 			}
 			return undefined;
@@ -178,11 +206,18 @@ export class InputController {
 			silent: options?.silent,
 		});
 	}
+	#clearComposer(): void {
+		const text = this.ctx.editor.getText();
+		if (text.trim()) {
+			this.ctx.editor.addToHistory(text);
+		}
+		this.ctx.clearEditor();
+	}
 
 	setupKeyHandlers(): void {
 		this.ctx.editor.setActionKeys("app.interrupt", this.ctx.keybindings.getKeys("app.interrupt"));
-		this.ctx.editor.shouldBypassAutocompleteOnEscape = () =>
-			Boolean(
+		this.ctx.editor.shouldBypassAutocompleteOnEscape = () => {
+			const bypassAutocomplete = Boolean(
 				this.ctx.loadingAnimation ||
 					this.ctx.hasActiveBtw() ||
 					(this.#steerConsumePending && this.ctx.session.hasQueuedSteering) ||
@@ -197,18 +232,28 @@ export class InputController {
 					this.ctx.autoCompactionEscapeHandler ||
 					this.ctx.retryEscapeHandler,
 			);
+			if (!bypassAutocomplete) this.#resetEscapeGestures();
+			return bypassAutocomplete;
+		};
 		this.#installGlobalInterruptListener();
 
 		// An open btw panel must stay dismissable with Esc even while another
 		// controller (auto-compaction, auto-retry, manual compaction, etc.) has
 		// temporarily replaced editor.onEscape. This priority hook is never
 		// swapped out, so it always wins for the interrupt key.
-		this.ctx.editor.onInterruptPriority = () => (this.ctx.hasActiveBtw() ? this.ctx.handleBtwEscape() : false);
+		this.ctx.editor.onInterruptPriority = () => {
+			if (!this.ctx.hasActiveBtw()) return false;
+			const consumed = this.ctx.handleBtwEscape();
+			if (consumed) this.#resetEscapeGestures();
+			return consumed;
+		};
 		this.ctx.editor.onEscape = () => {
 			if (this.ctx.hasActiveBtw() && this.ctx.handleBtwEscape()) {
+				this.#resetEscapeGestures();
 				return;
 			}
 			if (this.#steerConsumePending) {
+				this.#resetEscapeGestures();
 				if (this.ctx.session.hasQueuedSteering) {
 					// Second Esc before the scheduled steer continuation drains the
 					// queue: restore/drop the queued steer and perform a real abort,
@@ -220,20 +265,7 @@ export class InputController {
 				this.#steerConsumePending = false;
 			}
 			if (this.#handleCancellableWorkEscape({ maintenance: true, retry: true })) {
-				return;
-			}
-			// Normal input state with user-typed text: Esc must not interrupt a
-			// running task (streaming turn, bash/eval). A double Esc within the
-			// 500ms window clears the composer instead. Bash/Python input modes
-			// keep their own Esc handling in the chain below.
-			if (!this.ctx.isBashMode && !this.ctx.isPythonMode && this.ctx.editor.getText().trim()) {
-				const now = Date.now();
-				if (now - this.ctx.lastComposerClearEscapeTime < 500) {
-					this.ctx.clearEditor();
-					this.ctx.lastComposerClearEscapeTime = 0;
-				} else {
-					this.ctx.lastComposerClearEscapeTime = now;
-				}
+				this.#resetEscapeGestures();
 				return;
 			}
 			if (
@@ -246,23 +278,45 @@ export class InputController {
 					streaming: true,
 				})
 			) {
+				this.#resetEscapeGestures();
 				return;
 			}
-			if (!this.ctx.editor.getText().trim()) {
+
+			const text = this.ctx.editor.getText();
+			if (!this.ctx.isBashMode && !this.ctx.isPythonMode && text.trim()) {
+				this.#resetEmptyEditorEscape();
+				const now = Date.now();
+				if (
+					now - this.ctx.lastComposerClearEscapeTime < DRAFT_CLEAR_DOUBLE_ESCAPE_WINDOW_MS &&
+					this.#draftClearEscapeText === text
+				) {
+					this.#clearComposer();
+					this.#resetDraftClearEscape();
+				} else {
+					this.#armDraftClearEscape(text, now);
+				}
+				return;
+			}
+
+			if (!text.trim()) {
+				this.#resetDraftClearEscape();
 				// Double-interrupt with empty editor triggers /tree, /branch, or nothing based on setting
 				const action = settings.get("doubleEscapeAction");
-				if (action !== "none") {
-					const now = Date.now();
-					if (now - this.ctx.lastEscapeTime < 500) {
-						if (action === "tree") {
-							this.ctx.showTreeSelector();
-						} else {
-							this.ctx.showUserMessageSelector();
-						}
-						this.ctx.lastEscapeTime = 0;
+				if (action === "none") {
+					this.#resetEmptyEditorEscape();
+					return;
+				}
+
+				const now = Date.now();
+				if (now - this.ctx.lastEscapeTime < EMPTY_EDITOR_DOUBLE_ESCAPE_WINDOW_MS) {
+					if (action === "tree") {
+						this.ctx.showTreeSelector();
 					} else {
-						this.ctx.lastEscapeTime = now;
+						this.ctx.showUserMessageSelector();
 					}
+					this.#resetEmptyEditorEscape();
+				} else {
+					this.ctx.lastEscapeTime = now;
 				}
 			}
 		};
@@ -391,6 +445,7 @@ export class InputController {
 		}
 
 		this.ctx.editor.onChange = (text: string) => {
+			this.#resetEscapeGestures();
 			const wasBashMode = this.ctx.isBashMode;
 			const wasBashNoContext = this.ctx.isBashNoContext;
 			const wasPythonMode = this.ctx.isPythonMode;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -1,6 +1,6 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { AsyncJobManager } from "@gajae-code/coding-agent/async";
-import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
 import { InputController } from "@gajae-code/coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext, SubmittedUserInput } from "@gajae-code/coding-agent/modes/types";
 import { SubagentTool, type ToolSession } from "@gajae-code/coding-agent/tools";
@@ -12,6 +12,9 @@ beforeAll(async () => {
 
 afterAll(() => {
 	resetSettingsForTest();
+});
+afterEach(() => {
+	settings.set("doubleEscapeAction", "tree");
 });
 
 type FakeEditor = {
@@ -82,6 +85,7 @@ function createContext(): {
 		abortHandoff: ReturnType<typeof vi.fn>;
 		abortRetry: ReturnType<typeof vi.fn>;
 		retryNow: ReturnType<typeof vi.fn>;
+		showStatus: ReturnType<typeof vi.fn>;
 	};
 } {
 	let editorText = "";
@@ -98,6 +102,7 @@ function createContext(): {
 	const onInputCallback = vi.fn();
 	const prompt = vi.fn();
 	const requestRender = vi.fn();
+	const showStatus = vi.fn();
 	const handleBtwCommand = vi.fn(async () => {});
 	const handleBtwEscape = vi.fn(() => true);
 	const hasActiveBtw = vi.fn(() => false);
@@ -199,6 +204,7 @@ function createContext(): {
 		hasActiveBtw,
 		showTreeSelector: vi.fn(),
 		showUserMessageSelector: vi.fn(),
+		showStatus,
 		showSessionSelector: vi.fn(),
 	} as unknown as InteractiveModeContext;
 
@@ -226,6 +232,7 @@ function createContext(): {
 			requestRender,
 			startPendingSubmission,
 			clearEditor,
+			showStatus,
 		},
 	};
 }
@@ -561,7 +568,7 @@ describe("InputController escape behavior", () => {
 		expect(editor.getText()).toBe("stop after this");
 		expect(editor.shouldBypassAutocompleteOnEscape?.()).toBe(false);
 	});
-	it("double Esc clears a composed draft without aborting an active stream", () => {
+	it("interrupts an active stream even when the composer contains a draft", () => {
 		const { ctx, editor, spies } = createContext();
 		(ctx.session as { isStreaming: boolean }).isStreaming = true;
 		const controller = new InputController(ctx);
@@ -569,14 +576,12 @@ describe("InputController escape behavior", () => {
 		controller.setupKeyHandlers();
 		editor.setText("draft message");
 		editor.onEscape?.();
-		editor.onEscape?.();
 
-		expect(spies.clearEditor).toHaveBeenCalledTimes(1);
-		expect(spies.abort).not.toHaveBeenCalled();
-		expect(editor.getText()).toBe("");
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.clearEditor).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("draft message");
 	});
-
-	it("single Esc with a composed draft neither clears nor aborts", () => {
+	it("hints on a single Esc with a composed draft", () => {
 		const { ctx, editor, spies } = createContext();
 		const controller = new InputController(ctx);
 
@@ -585,11 +590,60 @@ describe("InputController escape behavior", () => {
 		editor.onEscape?.();
 
 		expect(spies.clearEditor).not.toHaveBeenCalled();
-		expect(spies.abort).not.toHaveBeenCalled();
+		expect(editor.addToHistory).not.toHaveBeenCalled();
+		expect(spies.showStatus).toHaveBeenCalledWith("press Esc again to clear");
 		expect(editor.getText()).toBe("draft message");
 	});
+	it("clears an idle draft and saves it to prompt history on double Esc", () => {
+		const { ctx, editor, spies } = createContext();
+		const controller = new InputController(ctx);
 
-	it("double Esc clears a composed draft without aborting a running bash command", () => {
+		controller.setupKeyHandlers();
+		editor.setText("draft message");
+		editor.onEscape?.();
+		editor.onEscape?.();
+
+		expect(spies.clearEditor).toHaveBeenCalledTimes(1);
+		expect(editor.addToHistory).toHaveBeenCalledWith("draft message");
+		expect(editor.getText()).toBe("");
+	});
+	it("opens the default tree selector on double Esc with an empty editor", () => {
+		const { ctx, editor } = createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+		editor.onEscape?.();
+
+		expect(ctx.showTreeSelector).toHaveBeenCalledTimes(1);
+		expect(ctx.showUserMessageSelector).not.toHaveBeenCalled();
+	});
+	it("opens the branch selector on double Esc when configured", () => {
+		settings.set("doubleEscapeAction", "branch");
+		const { ctx, editor } = createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+		editor.onEscape?.();
+
+		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
+		expect(ctx.showUserMessageSelector).toHaveBeenCalledTimes(1);
+	});
+
+	it("does nothing on double Esc with an empty editor when disabled", () => {
+		settings.set("doubleEscapeAction", "none");
+		const { ctx, editor } = createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+		editor.onEscape?.();
+
+		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
+		expect(ctx.showUserMessageSelector).not.toHaveBeenCalled();
+	});
+	it("interrupts a running bash command even when the composer contains a draft", () => {
 		const { ctx, editor, spies } = createContext();
 		(ctx.session as { isBashRunning: boolean }).isBashRunning = true;
 		const controller = new InputController(ctx);
@@ -597,13 +651,11 @@ describe("InputController escape behavior", () => {
 		controller.setupKeyHandlers();
 		editor.setText("draft");
 		editor.onEscape?.();
-		editor.onEscape?.();
 
-		expect(spies.clearEditor).toHaveBeenCalledTimes(1);
-		expect(spies.abortBash).not.toHaveBeenCalled();
+		expect(spies.abortBash).toHaveBeenCalledTimes(1);
+		expect(spies.clearEditor).not.toHaveBeenCalled();
 	});
-
-	it("double Esc clears a composed draft without aborting a running eval", () => {
+	it("interrupts a running eval even when the composer contains a draft", () => {
 		const { ctx, editor, spies } = createContext();
 		(ctx.session as { isEvalRunning: boolean }).isEvalRunning = true;
 		const controller = new InputController(ctx);
@@ -611,10 +663,20 @@ describe("InputController escape behavior", () => {
 		controller.setupKeyHandlers();
 		editor.setText("draft");
 		editor.onEscape?.();
-		editor.onEscape?.();
 
-		expect(spies.clearEditor).toHaveBeenCalledTimes(1);
-		expect(spies.abortEval).not.toHaveBeenCalled();
+		expect(spies.abortEval).toHaveBeenCalledTimes(1);
+		expect(spies.clearEditor).not.toHaveBeenCalled();
+	});
+
+	it("keeps Ctrl+C destructive without saving the discarded draft", () => {
+		const { ctx, editor } = createContext();
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		editor.setText("discarded draft");
+		editor.onClear?.();
+
+		expect(editor.getText()).toBe("");
+		expect(editor.addToHistory).not.toHaveBeenCalled();
 	});
 
 	it("clears pending images along with the composed text on double Esc", () => {
@@ -657,18 +719,108 @@ describe("InputController escape behavior", () => {
 		expect(ctx.isBashMode).toBe(false);
 	});
 
-	it("re-arms instead of clearing when the second Esc falls outside the 500ms window", () => {
+	it("resets the draft-clear double-Esc state after 800ms", () => {
+		const now = vi.spyOn(Date, "now").mockReturnValue(10_000);
+		try {
+			const { ctx, editor, spies } = createContext();
+			const controller = new InputController(ctx);
+
+			controller.setupKeyHandlers();
+			editor.setText("draft");
+			editor.onEscape?.();
+			now.mockReturnValue(10_801);
+			editor.onEscape?.();
+
+			expect(spies.clearEditor).not.toHaveBeenCalled();
+			expect(spies.showStatus).toHaveBeenCalledTimes(2);
+			expect(editor.getText()).toBe("draft");
+		} finally {
+			now.mockRestore();
+		}
+	});
+	it("re-arms draft clearing when the draft changes between Esc presses", () => {
 		const { ctx, editor, spies } = createContext();
 		const controller = new InputController(ctx);
-
 		controller.setupKeyHandlers();
+		editor.setText("first draft");
+		editor.onEscape?.();
+		editor.setText("changed draft");
+		editor.onEscape?.();
+
+		expect(spies.clearEditor).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("changed draft");
+		expect(spies.showStatus).toHaveBeenCalledTimes(2);
+	});
+	it("disarms draft clearing when autocomplete consumes Esc", () => {
+		const { ctx, editor, spies } = createContext();
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
 		editor.setText("draft");
 		editor.onEscape?.();
-		ctx.lastComposerClearEscapeTime = Date.now() - 1000;
+		expect(editor.shouldBypassAutocompleteOnEscape?.()).toBe(false);
 		editor.onEscape?.();
 
 		expect(spies.clearEditor).not.toHaveBeenCalled();
 		expect(editor.getText()).toBe("draft");
+	});
+	it("disarms draft clearing when editor input changes modes", () => {
+		const { ctx, editor, spies } = createContext();
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		editor.setText("draft");
+		editor.onEscape?.();
+		editor.setText("!draft");
+		editor.onChange?.("!draft");
+		editor.setText("draft");
+		editor.onChange?.("draft");
+		editor.onEscape?.();
+
+		expect(spies.clearEditor).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("draft");
+	});
+
+	it("disarms empty-editor rewind when work starts between Esc presses", () => {
+		const { ctx, editor, spies } = createContext();
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		editor.onEscape?.();
+		(ctx.session as { isStreaming: boolean }).isStreaming = true;
+		editor.onEscape?.();
+		(ctx.session as { isStreaming: boolean }).isStreaming = false;
+		editor.onEscape?.();
+
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
+		expect(ctx.showUserMessageSelector).not.toHaveBeenCalled();
+	});
+
+	it("disarms both gestures when a higher-priority Esc consumer handles the key", () => {
+		const { ctx, editor, spies } = createContext();
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		editor.setText("draft");
+		editor.onEscape?.();
+		spies.hasActiveBtw.mockReturnValue(true);
+		editor.onEscape?.();
+		spies.hasActiveBtw.mockReturnValue(false);
+		editor.onEscape?.();
+
+		expect(spies.clearEditor).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("draft");
+
+		editor.setText("");
+		editor.onEscape?.();
+		spies.hasActiveBtw.mockReturnValue(true);
+		editor.onEscape?.();
+		spies.hasActiveBtw.mockReturnValue(false);
+		editor.onEscape?.();
+
+		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
+		expect(ctx.showUserMessageSelector).not.toHaveBeenCalled();
 	});
 	it("treats a whitespace-only composer as empty and still aborts an active stream", () => {
 		const { ctx, editor, spies } = createContext();


### PR DESCRIPTION
## Summary
Resubmission of #2328, addressing all three review blockers. Clean single commit on current `dev` (671d1bd1).

Adds a grok-build-inspired hint-confirmed double-Esc (800ms) that clears a non-empty idle draft and saves it to prompt history. First press shows "press Esc again to clear".

## Blocker responses
1. **`doubleEscapeAction` contract restored** — the empty-editor double-Esc keeps the upstream dispatch verbatim: `tree` → tree selector (default), `branch` → user-message selector, `none` → gesture fully disabled (no arming), original 500ms window. Negative tests added for all three values.
2. **Ctrl+C stays destructive** — the interrupt-path clear is plain `clearEditor()` again; only the confirmed double-Esc draft clear persists the draft to prompt history. Test asserts Ctrl+C does not write history.
3. **Gesture state is bound and self-invalidating** — arming snapshots the draft text; the second Esc fires only if the draft is unchanged within the window. Draft edits (`onChange`), bash/python mode changes, and every higher-priority Escape consumer (btw panel, hook dialogs, cancellable work, autocomplete bypass, steer-consume) disarm both gestures, so a stolen first Esc can never leave a live armed state. Cross-state sequence tests added.

## Testing
- `bun test packages/coding-agent/test/input-controller-escape.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts` — 74 pass (was 66; +8 covering none/tree/branch dispatch, Ctrl+C privacy, draft-edit invalidation, stolen-Esc disarm, expiry).
- `bun --cwd=packages/coding-agent run check` — biome + SDK canonicalization + tsc pass.