### PR TITLE
ci: shard state gates, cache native builds, and cut redundant runner work

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -38,6 +38,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify checked-out source head
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          test "$head" = "$CI_DEV_SOURCE_SHA" || { echo "Checked-out SHA $head does not match $CI_DEV_SOURCE_SHA"; exit 1; }
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
@@ -91,9 +96,10 @@ jobs:
         with:
           shared-key: windows-dev-doctor-win32-x64
           cache-on-failure: true
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
           cache-workspace-crates: true
       - name: Cache bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
@@ -112,12 +118,9 @@ jobs:
           bun run dev:doctor
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-  # Native addon build runs at most once per run and publishes the built `.node`
-  # files as an artifact the runtime-dependent shards download. A content-hash
-  # cache of the native sources lets PRs that don't touch crates/natives restore
-  # the prebuilt addon and skip the Rust/native source build entirely; only a
-  # cache miss (native source actually changed) recompiles. Skipped when the plan
-  # needs no native build at all.
+  # Native addon build runs once per run and publishes the built `.node` files as
+  # an artifact the runtime-dependent shards download. It is skipped when the
+  # plan needs no native build at all.
   affected-native:
     name: Affected path validation / native-build
     needs: [affected-plan]
@@ -130,10 +133,16 @@ jobs:
       CI_DEV_AFFECTED_PLAN: .ci-dev-affected-plan.json
       CI_DEV_PLAN_DIGEST: ${{ needs.affected-plan.outputs.plan_digest }}
       CI_DEV_PLAN_SOURCE_SHA: ${{ needs.affected-plan.outputs.plan_source_sha }}
+      CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify checked-out source head
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          test "$head" = "$CI_DEV_SOURCE_SHA" || { echo "Checked-out SHA $head does not match $CI_DEV_SOURCE_SHA"; exit 1; }
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "24"
@@ -146,42 +155,24 @@ jobs:
           name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}
           path: .
       - run: bun scripts/ci-dev-affected.ts --validate-plan
-      - name: Detect native host ABI
-        id: native-host
-        shell: bash
-        run: |
-          glibc="$(getconf GNU_LIBC_VERSION | tr ' ' '-')"
-          echo "glibc=$glibc" >> "$GITHUB_OUTPUT"
-      - name: Restore cached native addon
-        id: native-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
-        with:
-          path: packages/natives/native/pi_natives.*.node
-          key: dev-affected-native-v2-baseline-modern-${{ runner.os }}-${{ steps.native-host.outputs.glibc }}-${{ hashFiles('crates/**/*.rs', 'crates/**/Cargo.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'packages/natives/scripts/**', 'packages/natives/package.json', 'scripts/ci-build-native.ts', 'scripts/host-detect.ts') }}
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
-        if: steps.native-cache.outputs.cache-hit != 'true'
         with:
           toolchain: nightly-2026-04-29
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
-        if: steps.native-cache.outputs.cache-hit != 'true'
         with:
           shared-key: dev-affected-native-linux-x64
           cache-on-failure: true
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
           cache-workspace-crates: true
       - name: Cache bun dependencies
-        if: steps.native-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - name: Install system deps
-        if: steps.native-cache.outputs.cache-hit != 'true'
         run: bash scripts/ci-install-system-deps.sh
-      - if: steps.native-cache.outputs.cache-hit != 'true'
-        run: bun install --frozen-lockfile
+      - run: bun install --frozen-lockfile
       - name: Build affected native addon(s)
-        if: steps.native-cache.outputs.cache-hit != 'true'
         run: bun scripts/ci-dev-affected.ts --native-build
       - name: Verify required native addon variants
         run: |
@@ -225,10 +216,16 @@ jobs:
       CI_DEV_MATRIX_RUST: ${{ matrix.rust }}
       CI_DEV_MATRIX_NEXTEST: ${{ matrix.nextest }}
       CI_DEV_MATRIX_NATIVE: ${{ matrix.native }}
+      CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify checked-out source head
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          test "$head" = "$CI_DEV_SOURCE_SHA" || { echo "Checked-out SHA $head does not match $CI_DEV_SOURCE_SHA"; exit 1; }
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "24"
@@ -261,7 +258,7 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
           cache-workspace-crates: true
       - name: Cache bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
@@ -295,11 +292,10 @@ jobs:
           retention-days: 1
 
 
-  # Branch protection must keep requiring this stable aggregate status. It runs
-  # no validation itself; it passes iff the planner, native build, every affected
-  # shard, and every affected shard succeeded (skipped native
-  # and affected shards are fine for no-op or docs-only changes). The job name
-  # must stay exactly "Affected path validation".
+  # Branch protection must keep requiring this stable aggregate status. It validates
+  # the canonical plan and receipts, then passes iff the planner, native build,
+  # every affected shard, and Windows doctor satisfy their planned contracts. The
+  # job name must stay exactly "Affected path validation".
   affected:
     name: Affected path validation
     if: ${{ always() }}
@@ -311,19 +307,26 @@ jobs:
       CI_DEV_PLAN_DIGEST: ${{ needs.affected-plan.outputs.plan_digest }}
       CI_DEV_PLAN_SOURCE_SHA: ${{ needs.affected-plan.outputs.plan_source_sha }}
       CI_DEV_SHARD_RECEIPTS: .ci-dev-shard-receipts
+      CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify checked-out source head
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          test "$head" = "$CI_DEV_SOURCE_SHA" || { echo "Checked-out SHA $head does not match $CI_DEV_SOURCE_SHA"; exit 1; }
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
       - name: Download canonical affected plan
-        if: ${{ needs.affected-plan.result == 'success' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}
           path: .
+      - name: Validate canonical affected plan
+        run: bun scripts/ci-dev-affected.ts --validate-plan
       - name: Download shard completion receipts
         if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -335,34 +338,15 @@ jobs:
         if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' }}
         run: bun scripts/ci-dev-affected.ts --validate-shard-receipts
       - name: Aggregate affected path validation shards
-        run: |
-          plan='${{ needs.affected-plan.result }}'
-          native='${{ needs.affected-native.result }}'
-          shards='${{ needs.affected-shards.result }}'
-          has_native='${{ needs.affected-plan.outputs.has_native }}'
-          has_tasks='${{ needs.affected-plan.outputs.has_tasks }}'
-          windows_doctor='${{ needs.windows-dev-doctor.result }}'
-          echo "affected-plan: $plan"
-          echo "affected-native: $native"
-          echo "affected-shards: $shards"
-          echo "planned native work: $has_native"
-          echo "planned shard work: $has_tasks"
-          echo "windows-dev-doctor: $windows_doctor"
-          test "$plan" = success || { echo "planner did not succeed"; exit 1; }
-          case "$has_native" in true|false) ;; *) echo "planner emitted invalid has_native=$has_native"; exit 1 ;; esac
-          case "$has_tasks" in true|false) ;; *) echo "planner emitted invalid has_tasks=$has_tasks"; exit 1 ;; esac
-          if [ "$has_native" = true ]; then
-            test "$native" = success || { echo "required native build did not succeed"; exit 1; }
-          else
-            test "$native" = skipped || { echo "unplanned native build was not skipped"; exit 1; }
-          fi
-          if [ "$has_tasks" = true ]; then
-            test "$shards" = success || { echo "required affected shards did not succeed"; exit 1; }
-          else
-            test "$shards" = skipped || { echo "unplanned affected shards were not skipped"; exit 1; }
-          fi
-          case "$windows_doctor" in success|skipped) ;; *) echo "Windows dev:doctor did not pass"; exit 1 ;; esac
-          echo "Affected path validation: all required shards passed"
+        env:
+          CI_DEV_PLAN_RESULT: ${{ needs.affected-plan.result }}
+          CI_DEV_NATIVE_RESULT: ${{ needs.affected-native.result }}
+          CI_DEV_SHARDS_RESULT: ${{ needs.affected-shards.result }}
+          CI_DEV_HAS_NATIVE: ${{ needs.affected-plan.outputs.has_native }}
+          CI_DEV_HAS_TASKS: ${{ needs.affected-plan.outputs.has_tasks }}
+          CI_DEV_WINDOWS_DOCTOR_RESULT: ${{ needs.windows-dev-doctor.result }}
+          CI_DEV_WINDOWS_DOCTOR_REQUIRED: ${{ contains(needs.affected-plan.outputs.changed_paths, 'scripts/dev-link') }}
+        run: bun scripts/ci-dev-affected.ts --validate-aggregate
 
   gjc-state-gates-matrix:
     name: gjc-state-gates / ${{ matrix.group }}

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describeTasks, expandWithDependents, loadBuildInventory, normalizeChangedPaths, packageScriptCommand, planTargetedTasks, planTasks, requiresCargoWorkspaceEmergency, resolvePackageCwd, runCommand, type CargoInventoryUnit, type WorkspacePackage } from "./ci-dev-affected";
+import { describeTasks, expandWithDependents, loadBuildInventory, normalizeChangedPaths, packageScriptCommand, planTargetedTasks, planTasks, requiresCargoWorkspaceEmergency, resolvePackageCwd, runCommand, validateAffectedAggregate, type AffectedAggregateResults, type CargoInventoryUnit, type WorkspacePackage } from "./ci-dev-affected";
 
 // Matrix planning validates live workspace and Cargo manifests in subprocesses.
 // Hosted runners can need more than Bun's 5s default during their first cold scan.
@@ -46,11 +46,10 @@ describe("planTasks command shape (issue #622)", () => {
 });
 
 describe("dev-ci canonical-plan workflow contract", () => {
-	test("transports and validates the planner artifact before conditional setup", async () => {
+	test("binds the canonical plan to its checked-out source and validates it before aggregate decisions", async () => {
 		const workflow = await Bun.file(path.join(import.meta.dir, "..", ".github", "workflows", "dev-ci.yml")).text();
-		expect(workflow).toContain("ref: ${{ github.event.pull_request.head.sha || github.sha }}");
 		expect(workflow.match(/ref: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/g)).toHaveLength(5);
-		expect(workflow.match(/Verify checked-out source head/g)).toHaveLength(1);
+		expect(workflow.match(/Verify checked-out source head/g)).toHaveLength(5);
 		expect(workflow).toContain("name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}");
 		expect(workflow.match(/\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/g)).toHaveLength(8);
 		expect(workflow).toContain("include-hidden-files: true");
@@ -59,19 +58,15 @@ describe("dev-ci canonical-plan workflow contract", () => {
 		expect(workflow).toContain("CI_DEV_PLAN_SOURCE_SHA: ${{ needs.affected-plan.outputs.plan_source_sha }}");
 		expect(workflow).toContain("CI_DEV_MATRIX_NEXTEST: ${{ matrix.nextest }}");
 		expect(workflow).toContain("timeout-minutes: ${{ matrix.key == 'root-check' && 30 || 90 }}");
-		expect(workflow).toContain("run: bun scripts/ci-dev-affected.ts --validate-plan");
-		expect(workflow.indexOf("run: bun scripts/ci-dev-affected.ts --validate-plan")).toBeLessThan(workflow.indexOf("if: ${{ matrix.rust }}"));
+		expect(workflow.match(/run: bun scripts\/ci-dev-affected\.ts --validate-plan/g)).toHaveLength(3);
 		expect(workflow).toContain("if: ${{ matrix.nextest }}");
 		expect(workflow).toContain("affected-native.result != 'failure'");
 		expect(workflow).toContain("name: Affected path validation");
-		expect(workflow).toContain("has_native='${{ needs.affected-plan.outputs.has_native }}'");
-		expect(workflow).toContain("has_tasks='${{ needs.affected-plan.outputs.has_tasks }}'");
-		expect(workflow).toContain('test "$native" = success');
-		expect(workflow).toContain('test "$shards" = success');
-		expect(workflow).toContain('test "$native" = skipped');
-		expect(workflow).toContain('test "$shards" = skipped');
-		expect(workflow).toContain('case "$has_native" in true|false)');
-		expect(workflow).toContain('case "$has_tasks" in true|false)');
+		expect(workflow).toContain("CI_DEV_HAS_NATIVE: ${{ needs.affected-plan.outputs.has_native }}");
+		expect(workflow).toContain("CI_DEV_HAS_TASKS: ${{ needs.affected-plan.outputs.has_tasks }}");
+		expect(workflow).toContain("--validate-aggregate");
+		expect(workflow).toContain("CI_DEV_WINDOWS_DOCTOR_RESULT: ${{ needs.windows-dev-doctor.result }}");
+		expect(workflow).toContain("CI_DEV_WINDOWS_DOCTOR_REQUIRED: ${{ contains(needs.affected-plan.outputs.changed_paths, 'scripts/dev-link') }}");
 		expect(workflow).toContain("max-parallel: 8");
 		expect(workflow).toContain("CI_DEV_MATRIX_IDENTITY: ${{ matrix.identity }}");
 		expect(workflow).toContain("Upload shard completion receipt");
@@ -79,7 +74,40 @@ describe("dev-ci canonical-plan workflow contract", () => {
 		expect(workflow).toContain("--validate-shard-receipts");
 		expect(workflow).toContain("pi_natives.linux-x64-baseline.node");
 		expect(workflow).toContain("pi_natives.linux-x64-modern.node");
-		expect(workflow).toContain("dev-affected-native-v2-baseline-modern-");
+		expect(workflow).not.toContain("native-cache");
+		expect(workflow).not.toContain("pull_request_target");
+		expect(workflow).not.toContain("uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830");
+		expect(workflow.match(/uses: actions\/cache\/restore@0057852bfaa89a56745cba8c7296529d2fc39830/g)).toHaveLength(4);
+		expect(workflow.match(/save-if: \$\{\{ github\.event_name == 'push' && github\.ref == 'refs\/heads\/dev' \}\}/g)).toHaveLength(3);
+	});
+
+	test("aggregate result truth table rejects every missing, failed, cancelled, and unplanned dependency", () => {
+		const valid: AffectedAggregateResults[] = [
+			{ plan: "success", native: "success", shards: "success", windowsDoctor: "success", windowsDoctorRequired: "true", hasNative: "true", hasTasks: "true" },
+			{ plan: "success", native: "skipped", shards: "skipped", windowsDoctor: "skipped", windowsDoctorRequired: "false", hasNative: "false", hasTasks: "false" },
+			{ plan: "success", native: "success", shards: "skipped", windowsDoctor: "skipped", windowsDoctorRequired: "false", hasNative: "true", hasTasks: "false" },
+			{ plan: "success", native: "skipped", shards: "success", windowsDoctor: "success", windowsDoctorRequired: "true", hasNative: "false", hasTasks: "true" },
+		];
+		for (const results of valid) expect(() => validateAffectedAggregate(results)).not.toThrow();
+
+		for (const results of [
+			{ ...valid[0]!, plan: "failure" },
+			{ ...valid[0]!, plan: "cancelled" },
+			{ ...valid[0]!, native: "failure" },
+			{ ...valid[0]!, native: "cancelled" },
+			{ ...valid[0]!, shards: "failure" },
+			{ ...valid[0]!, shards: "cancelled" },
+			{ ...valid[0]!, windowsDoctor: "failure" },
+			{ ...valid[0]!, windowsDoctor: "cancelled" },
+			{ ...valid[0]!, windowsDoctor: "skipped" },
+			{ ...valid[1]!, windowsDoctor: "success" },
+			{ ...valid[1]!, windowsDoctorRequired: "" },
+			{ ...valid[1]!, windowsDoctorRequired: "maybe" },
+			{ ...valid[1]!, hasNative: "" },
+			{ ...valid[1]!, hasTasks: "maybe" },
+			{ ...valid[1]!, native: "success" },
+			{ ...valid[1]!, shards: "success" },
+		]) expect(() => validateAffectedAggregate(results)).toThrow();
 	});
 });
 
@@ -228,6 +256,7 @@ describe("--matrix-json and --task CLI fan-out", () => {
 	const scriptPath = path.join(import.meta.dir, "ci-dev-affected.ts");
 	const repoRoot = path.join(import.meta.dir, "..");
 	const tempDirs: string[] = [];
+	const sourceSha = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repoRoot }).stdout.toString().trim();
 
 	afterAll(async () => {
 		await Promise.all(tempDirs.map(dir => fs.rm(dir, { recursive: true, force: true })));
@@ -250,7 +279,8 @@ describe("--matrix-json and --task CLI fan-out", () => {
 				CI_DEV_AFFECTED_PLAN: undefined,
 				CI_DEV_PLAN_DIGEST: undefined,
 				CI_DEV_PLAN_SOURCE_SHA: undefined,
-				CI_DEV_SOURCE_SHA: undefined,
+				GITHUB_SHA: undefined,
+				CI_DEV_SOURCE_SHA: sourceSha,
 				CI_DEV_MATRIX_IDENTITY: undefined,
 				CI_DEV_MATRIX_KEY: undefined,
 				CI_DEV_MATRIX_NATIVE: undefined,
@@ -362,8 +392,7 @@ describe("--matrix-json and --task CLI fan-out", () => {
 	test("package documentation changes do not schedule build shards", async () => {
 		const { stdout, exitCode } = await runScript(["--matrix-json"], "packages/coding-agent/README.md", {
 			CI_DEV_PLAN_MODE: "pr",
-			CI_DEV_SOURCE_SHA: "a".repeat(40),
-			PATH: path.dirname(Bun.which("bun") ?? process.execPath),
+			PATH: `${path.dirname(Bun.which("bun") ?? process.execPath)}${path.delimiter}${process.env.PATH ?? ""}`,
 		});
 		expect(exitCode).toBe(0);
 		expect(JSON.parse(stdout.trim())).toEqual([]);

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -138,6 +138,10 @@ async function main(): Promise<void> {
 		await validateShardReceipts();
 		return;
 	}
+	if (process.argv.includes("--validate-aggregate")) {
+		await validateAggregate();
+		return;
+	}
 	if (process.argv.includes("--native-build")) {
 		await runNativeBuild();
 		return;
@@ -290,11 +294,13 @@ export function describeTasks(tasks: readonly Task[]): TaskMatrixEntry[] {
 // downstream job reuses the planner's exact diff via CI_DEV_CHANGED_PATHS
 // instead of re-resolving the base ref on each runner.
 async function emitMatrix(): Promise<void> {
+	const sourceSha = await resolveSourceSha();
+	await requireCommitObject(sourceSha, "source head");
+	await assertCheckedOutSourceHead(sourceSha);
 	const paths = normalizeChangedPaths(await getChangedPaths());
 	const mode = resolvePlanMode();
 	const tasks = await resolvePlannedTasks(paths);
 	const entries = describeTasks(tasks);
-	const sourceSha = Bun.env.CI_DEV_SOURCE_SHA?.trim() || (Bun.env.GITHUB_SHA ?? "HEAD");
 	const canonical = JSON.stringify({ schemaVersion: 1, sourceSha, mode, paths, tasks: serializeTasks(tasks) });
 	const digest = new Bun.CryptoHasher("sha256").update(canonical).digest("hex");
 	await Bun.write(path.join(repoRoot, ".ci-dev-affected-plan.json"), canonical);
@@ -391,10 +397,10 @@ async function getChangedPaths(): Promise<string[]> {
 	}
 
 	const base = await resolveBaseRef();
-	const head = Bun.env.CI_DEV_SOURCE_SHA?.trim() || Bun.env.GITHUB_SHA?.trim() || "HEAD";
+	const head = await resolveSourceSha();
 	await requireCommitObject(base, "base");
 	await requireCommitObject(head, "source head");
-	const range = `${base}...${head}`;
+	const range = `${base}..${head}`;
 	const diff = await $`git diff --name-only -z ${range}`.cwd(repoRoot).quiet().nothrow();
 	if (diff.exitCode !== 0) {
 		const stderr = diff.stderr.toString().trim();
@@ -408,31 +414,35 @@ async function requireCommitObject(ref: string, label: string): Promise<void> {
 	if (result.exitCode !== 0) throw new Error(`Failed to compute changed paths: ${label} '${ref}' is not available`);
 }
 
+async function resolveSourceSha(): Promise<string> {
+	const configured = Bun.env.CI_DEV_SOURCE_SHA?.trim() || Bun.env.GITHUB_SHA?.trim();
+	if (configured) return configured;
+	const checkedOut = await $`git rev-parse HEAD`.cwd(repoRoot).quiet().nothrow();
+	if (checkedOut.exitCode !== 0) throw new Error("Failed to resolve source head");
+	return checkedOut.stdout.toString().trim();
+}
+
+async function assertCheckedOutSourceHead(sourceSha: string): Promise<void> {
+	const checkedOut = await $`git rev-parse HEAD`.cwd(repoRoot).quiet().nothrow();
+	if (checkedOut.exitCode !== 0 || checkedOut.stdout.toString().trim() !== sourceSha) {
+		throw new Error(`Failed to publish affected plan: checked-out SHA does not match source head '${sourceSha}'`);
+	}
+}
+
 async function resolveBaseRef(): Promise<string> {
 	const eventName = Bun.env.GITHUB_EVENT_NAME?.trim();
 	const before = Bun.env.GITHUB_EVENT_BEFORE?.trim();
 	const baseSha = Bun.env.GITHUB_BASE_SHA?.trim();
 	const baseRef = Bun.env.GITHUB_BASE_REF?.trim();
 
-	if (eventName === "pull_request" && baseRef) {
-		const mergeBase = await $`git merge-base HEAD ${`origin/${baseRef}`}`.cwd(repoRoot).quiet().nothrow();
-		if (mergeBase.exitCode === 0) {
-			const value = mergeBase.stdout.toString().trim();
-			if (value !== "") return value;
-		}
-		return `origin/${baseRef}`;
-	}
 	if (baseSha && !ZERO_SHA.test(baseSha)) {
 		return baseSha;
 	}
+	if (eventName === "pull_request" && baseRef) {
+		return `origin/${baseRef}`;
+	}
 	if (before && !ZERO_SHA.test(before)) {
 		return before;
-	}
-
-	const mergeBase = await $`git merge-base HEAD origin/dev`.cwd(repoRoot).quiet().nothrow();
-	if (mergeBase.exitCode === 0) {
-		const value = mergeBase.stdout.toString().trim();
-		if (value !== "") return value;
 	}
 	return "origin/dev";
 }
@@ -1240,6 +1250,54 @@ function serializeTasks(tasks: readonly Task[]): Task[] {
 function canonicalTaskIdentity(task: Task): string {
 	const cwd = task.cwd ? path.relative(repoRoot, task.cwd) || "." : ".";
 	return task.identity ?? `legacy:${toBase64Url(task.key)}:${toBase64Url(cwd)}`;
+}
+
+export interface AffectedAggregateResults {
+	plan: string;
+	native: string;
+	shards: string;
+	windowsDoctor: string;
+	windowsDoctorRequired: string;
+	hasNative: string;
+	hasTasks: string;
+}
+
+export function validateAffectedAggregate(results: AffectedAggregateResults): void {
+	if (results.plan !== "success") throw new Error("planner did not succeed");
+	if (results.hasNative !== "true" && results.hasNative !== "false") throw new Error(`planner emitted invalid has_native=${results.hasNative}`);
+	if (results.hasTasks !== "true" && results.hasTasks !== "false") throw new Error(`planner emitted invalid has_tasks=${results.hasTasks}`);
+	if (results.native !== (results.hasNative === "true" ? "success" : "skipped")) throw new Error(results.hasNative === "true" ? "required native build did not succeed" : "unplanned native build was not skipped");
+	if (results.shards !== (results.hasTasks === "true" ? "success" : "skipped")) throw new Error(results.hasTasks === "true" ? "required affected shards did not succeed" : "unplanned affected shards were not skipped");
+	if (results.windowsDoctorRequired !== "true" && results.windowsDoctorRequired !== "false") throw new Error(`planner emitted invalid windows_doctor_required=${results.windowsDoctorRequired}`);
+	if (results.windowsDoctor !== (results.windowsDoctorRequired === "true" ? "success" : "skipped")) throw new Error(results.windowsDoctorRequired === "true" ? "required Windows dev:doctor did not succeed" : "unplanned Windows dev:doctor was not skipped");
+}
+
+async function validateAggregate(): Promise<void> {
+	const results: AffectedAggregateResults = {
+		plan: Bun.env.CI_DEV_PLAN_RESULT?.trim() || "",
+		native: Bun.env.CI_DEV_NATIVE_RESULT?.trim() || "",
+		shards: Bun.env.CI_DEV_SHARDS_RESULT?.trim() || "",
+		windowsDoctor: Bun.env.CI_DEV_WINDOWS_DOCTOR_RESULT?.trim() || "",
+		windowsDoctorRequired: Bun.env.CI_DEV_WINDOWS_DOCTOR_REQUIRED?.trim() || "",
+		hasNative: Bun.env.CI_DEV_HAS_NATIVE?.trim() || "",
+		hasTasks: Bun.env.CI_DEV_HAS_TASKS?.trim() || "",
+	};
+	console.log(`affected-plan: ${results.plan}`);
+	console.log(`affected-native: ${results.native}`);
+	console.log(`affected-shards: ${results.shards}`);
+	console.log(`planned native work: ${results.hasNative}`);
+	console.log(`planned shard work: ${results.hasTasks}`);
+	console.log(`windows-dev-doctor: ${results.windowsDoctor}`);
+	console.log(`planned Windows dev:doctor: ${results.windowsDoctorRequired}`);
+	validateAffectedAggregate(results);
+	const tasks = await loadCanonicalPlan();
+	if (!tasks) throw new Error("affected-plan-invalid: aggregate requires a canonical plan");
+	const expectedHasNative = String(tasks.some(task => task.capabilities?.nativeProducer === true));
+	const expectedHasTasks = String(tasks.some(task => task.capabilities?.nativeProducer !== true));
+	if (results.hasNative !== expectedHasNative || results.hasTasks !== expectedHasTasks) {
+		throw new Error("affected-plan-invalid: planner flags do not match canonical plan");
+	}
+	console.log("Affected path validation: all required shards passed");
 }
 
 async function validateShardReceipts(): Promise<void> {


### PR DESCRIPTION
## Summary
- Merge the `relevance` planner job into `rust-hash` (one fewer runner per run). The relevance decision now runs **before** the fallible artifact probe, the probe is fail-open (`set +e`/`exit 0`), and all consumers use `relevant != 'false'` so ambiguity always runs validation — strictly safer than before.
- Shard main-CI `gjc-state-gates` into the `static/runtime/integrity/read` matrix Dev CI already uses; the required aggregate status keeps the exact name `gjc-state-gates`, same tag/fork guards, success-only assertion.
- Add a content-hash prebuilt-native cache to `windows_smoke` (keyed on Rust sources, `rust-toolchain.toml`, native scripts, `bun.lock`, root `package.json`); a hit skips the Windows Rust toolchain install, rust-cache, and the entire native build.
- Bun cache hygiene in both workflows: `restore-keys` prefix fallback everywhere, pure consumers switched to `actions/cache/restore` (PRs stop writing duplicate entries), the state-gate matrix remains the writer per workflow.
- Parallelize the seven independent root checks in `ci:check:full` via `bun run --parallel` (failure propagation verified empirically).

## Safety
- No required status renamed: `gjc-state-gates` (main), `Affected path validation` + `gjc-state-gates` (dev) unchanged.
- Tag-push/release job conditions byte-identical apart from cache-only changes.
- Fork-PR job graph traced identical to pre-change (no expensive step or cache write newly runs on forks).

## Review evidence
- Round-2 architect review: architecture/product/code all CLEAR, APPROVE, zero findings (round 1 blocked on 3 findings, all fixed: fail-open relevance ordering, native cache key completeness, aggregate tag guard).
- Executor QA/red-team: 7/7 adversarial cases passed (shard failure/cancellation aggregate semantics, fork-PR empty-output graph, tag-path equivalence, cache poisoning/staleness, writer preservation, actionlint/YAML, parallel failure propagation).
- Artifacts: `artifacts/ultragoal-ci-optimize-qa-report.json`, `artifacts/ultragoal-ci-optimize-cli-replay.json`.

## Validation
- `actionlint` clean on both workflows (pre-existing SC2016 info notice at dev-ci.yml:290 unchanged).
- YAML parse clean on all changed workflow files.