### PR TITLE
fix(deep-interview): resume incomplete rounds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
 
+### Fixed
+- Active deep-interview sessions now resume automatically when a model stops after recording an answer, using bounded workflow-state continuation instead of requiring another user prompt.
+
 ## [0.11.0] - 2026-07-15
 
 ### Fixed

--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -743,6 +743,9 @@ function buildHandoffModeStateRecoveryMessage(skill: GjcWorkflowSkill, phase: st
 }
 
 function buildHandoffForceAskMessage(skill: GjcWorkflowSkill, phase: string, statePath: string): string {
+	if (skill === "deep-interview" && phase.trim().toLowerCase() === "interviewing") {
+		return `GJC deep-interview is still interviewing and must not stop (${statePath}). Continue the active round immediately: score and persist an answered round, then report progress. Use the ask tool for the next question. Only stop after crystallizing, recording a handoff, or explicitly cancelling the workflow. ${buildHandoffStopReleaseGuidance(skill)}`;
+	}
 	return `GJC handoff skill "${skill}" must not stop without offering a next step (phase: ${phase}; state: ${statePath}). ${buildHandoffStopReleaseGuidance(skill)}`;
 }
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -229,7 +229,7 @@ import { requestGjcWorkerIntegrationAttempt } from "../gjc-runtime/team-runtime"
 import { GoalRuntime } from "../goals/runtime";
 import type { Goal, GoalModeState } from "../goals/state";
 import type { HindsightSessionState } from "../hindsight/state";
-import { ensureWorkflowSkillActivationState } from "../hooks/skill-state";
+import { buildSkillStopOutput, ensureWorkflowSkillActivationState } from "../hooks/skill-state";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import { shutdownAll as shutdownAllLspClients } from "../lsp/client";
 import { resolveMemoryBackend } from "../memory-backend";
@@ -1417,6 +1417,7 @@ export class AgentSession {
 	#fallbackInvocationId = 0;
 	// Todo completion reminder state
 	#todoReminderCount = 0;
+	#deepInterviewStopReminderCount = 0;
 	#lastGoalReminderAssistantTimestamp: number | undefined = undefined;
 	#todoPhases: TodoPhase[] = [];
 	#toolChoiceQueue = new ToolChoiceQueue();
@@ -3130,6 +3131,9 @@ export class AgentSession {
 			}
 			if (msg.stopReason !== "error" && msg.stopReason !== "aborted") {
 				if (this.#enforceRewindBeforeYield()) {
+					return;
+				}
+				if (await this.#checkActiveDeepInterviewCompletion()) {
 					return;
 				}
 				if (await this.#checkGoalCompletion(msg)) {
@@ -6508,6 +6512,9 @@ export class AgentSession {
 
 			// Reset todo reminder count on new user prompt
 			this.#todoReminderCount = 0;
+			if (message.role === "user") {
+				this.#deepInterviewStopReminderCount = 0;
+			}
 
 			// Validate model
 			if (!this.model) {
@@ -9854,6 +9861,29 @@ export class AgentSession {
 			timestamp: Date.now(),
 		});
 		this.#scheduleAgentContinue({ generation: this.#promptGeneration });
+		return true;
+	}
+	async #checkActiveDeepInterviewCompletion(): Promise<boolean> {
+		const output = await buildSkillStopOutput({
+			cwd: this.sessionManager.getCwd(),
+			sessionId: this.sessionManager.getSessionId(),
+			sessionFile: this.sessionManager.getSessionFile(),
+		});
+		if (output?.decision !== "block") return false;
+		const stopReason = typeof output.stopReason === "string" ? output.stopReason : "";
+		if (!stopReason.startsWith("gjc_skill_deep_interview_")) return false;
+		if (this.#deepInterviewStopReminderCount >= 2) return false;
+
+		const systemMessage = typeof output.systemMessage === "string" ? output.systemMessage : "";
+		if (!systemMessage) return false;
+		this.#deepInterviewStopReminderCount++;
+		this.agent.appendMessage({
+			role: "developer",
+			content: [{ type: "text", text: systemMessage }],
+			attribution: "agent",
+			timestamp: Date.now(),
+		});
+		this.#scheduleAgentContinue({ generation: this.#promptGeneration, skipCompactionCheck: true });
 		return true;
 	}
 	/**

--- a/packages/coding-agent/test/agent-session-deep-interview-continuation.test.ts
+++ b/packages/coding-agent/test/agent-session-deep-interview-continuation.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai/models";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { ensureWorkflowSkillActivationState } from "@gajae-code/coding-agent/hooks/skill-state";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
+
+describe("AgentSession deep-interview continuation", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-deep-interview-continuation-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected built-in anthropic model to exist");
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			}),
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		await ensureWorkflowSkillActivationState({
+			cwd: tempDir.path(),
+			skill: "deep-interview",
+			sessionId: sessionManager.getSessionId(),
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	async function emitAssistantStop(timestamp: number): Promise<void> {
+		const assistantMessage = { ...createAssistantMessage("Round recorded."), timestamp };
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+		await Bun.sleep(50);
+		await session.waitForIdle();
+	}
+
+	it("continues when the model stops during an active interview", async () => {
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		await emitAssistantStop(100);
+
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		const reminder = session.agent.state.messages.find(message => message.role === "developer");
+		expect(JSON.stringify(reminder?.content)).toContain("score and persist an answered round");
+		expect(JSON.stringify(reminder?.content)).toContain("Use the ask tool for the next question");
+	});
+
+	it("bounds automatic continuation attempts", async () => {
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		await emitAssistantStop(100);
+		await emitAssistantStop(200);
+		await emitAssistantStop(300);
+
+		expect(continueSpy).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
## What

- Detect a normal assistant stop while a durable deep-interview workflow remains active.
- Inject the existing workflow stop decision as a developer continuation and resume the agent automatically.
- Bound automatic continuation to two attempts per user prompt.
- Give interviewing rounds specific recovery guidance: score and persist the answer, report progress, then ask the next question.
- Add regression coverage and a changelog entry.

## Why

A model can return `stop` immediately after the `ask` tool records a round answer, leaving deep-interview active and requiring the user to type an unrelated prompt such as `go`. The native Stop hook already detects the durable active workflow, but AgentSession did not consume that decision on an ordinary agent stop.

## Testing

- `bun test test/agent-session-deep-interview-continuation.test.ts test/gjc-skill-state-hooks.test.ts` (50 passed)
- `bun run check:types` (passed)
- Biome check on changed TypeScript files (passed)
- `git diff --check` (passed)
- `bun run check` reached and passed TypeScript/package checks, then failed in the existing Rust `pi-natives` Darwin build at `path_identity.rs:508` because this branch references `libc::stat.st_mtimespec`, which is unavailable in the current toolchain. No Rust files are changed by this PR.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)