### PR TITLE
feat(tui): pin explicit fold choices; centralized focus-aware expansion hints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - The tool-output expand shortcut now stamps an explicit fold choice for each live component, so automatic expansion stamping cannot overwrite it. Transcript rebuilds/remounts create components from the global tool-output setting and reset that provenance.
+- Tool-output expansion hints now use the configured shortcut consistently and remain hidden while selectors or overlays own input focus.
 
 ## [0.11.0] - 2026-07-15
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
 
+### Changed
+- The tool-output expand shortcut now stamps an explicit per-block fold choice, and automatic expansion stamping can no longer overwrite a block whose state came from an explicit user action. All current automatic stamping happens at component creation, so behavior is unchanged today; this locks the invariant for future per-block folds.
+
 ## [0.11.0] - 2026-07-15
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
 
 ### Changed
-- The tool-output expand shortcut now stamps an explicit per-block fold choice, and automatic expansion stamping can no longer overwrite a block whose state came from an explicit user action. All current automatic stamping happens at component creation, so behavior is unchanged today; this locks the invariant for future per-block folds.
+- The tool-output expand shortcut now stamps an explicit fold choice for each live component, so automatic expansion stamping cannot overwrite it. Transcript rebuilds/remounts create components from the global tool-output setting and reset that provenance.
 
 ## [0.11.0] - 2026-07-15
 

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -271,7 +271,10 @@ export interface ExtensionUIContext {
 	/** Get current tool output expansion state. */
 	getToolsExpanded(): boolean;
 
-	/** Set tool output expansion state. */
+	/**
+	 * Set tool output expansion state. This applies an explicit fold choice to existing
+	 * tool/read components, pinning them against automatic updates like the user shortcut.
+	 */
 	setToolsExpanded(expanded: boolean): void;
 }
 

--- a/packages/coding-agent/src/modes/components/branch-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/branch-summary-message.ts
@@ -1,6 +1,7 @@
 import { Box, Markdown, Spacer, Text } from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import type { BranchSummaryMessage } from "../../session/messages";
+import { expandHintSuffix } from "../../tools/render-utils";
 
 /**
  * Component that renders a branch summary message with collapsed/expanded state.
@@ -39,7 +40,7 @@ export class BranchSummaryMessageComponent extends Box {
 				}),
 			);
 		} else {
-			this.addChild(new Text(theme.fg("customMessageText", "Branch summary (ctrl+o to expand)"), 0, 0));
+			this.addChild(new Text(theme.fg("customMessageText", `Branch summary${expandHintSuffix(theme)}`), 0, 0));
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/components/compaction-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/compaction-summary-message.ts
@@ -1,6 +1,7 @@
 import { Box, Markdown, Spacer, Text } from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import type { CompactionSummaryMessage } from "../../session/messages";
+import { expandHintSuffix } from "../../tools/render-utils";
 
 /**
  * Component that renders a compaction message with collapsed/expanded state.
@@ -41,7 +42,11 @@ export class CompactionSummaryMessageComponent extends Box {
 			);
 		} else {
 			this.addChild(
-				new Text(theme.fg("customMessageText", `Compacted from ${tokenStr} tokens (ctrl+o to expand)`), 0, 0),
+				new Text(
+					theme.fg("customMessageText", `Compacted from ${tokenStr} tokens${expandHintSuffix(theme)}`),
+					0,
+					0,
+				),
 			);
 			if (this.message.shortSummary) {
 				this.addChild(new Text(theme.fg("customMessageText", this.message.shortSummary), 0, 1));

--- a/packages/coding-agent/src/modes/components/execution-shared.ts
+++ b/packages/coding-agent/src/modes/components/execution-shared.ts
@@ -10,6 +10,7 @@
 import { type Component, Container, Loader, Spacer, Text, type TUI } from "@gajae-code/tui";
 import { getSymbolTheme, theme } from "../../modes/theme/theme";
 import { formatTruncationMetaNotice, type TruncationMeta } from "../../tools/output-meta";
+import { expandHintSuffix } from "../../tools/render-utils";
 import { DynamicBorder } from "./dynamic-border";
 import { truncateToVisualLines } from "./visual-truncate";
 
@@ -76,7 +77,7 @@ export function buildStatusFooter(opts: {
 	const parts: string[] = [];
 
 	if (opts.hiddenLineCount > 0 && !opts.suppressHiddenCount) {
-		parts.push(theme.fg("dim", `… ${opts.hiddenLineCount} more lines (ctrl+o to expand)`));
+		parts.push(theme.fg("dim", `… ${opts.hiddenLineCount} more lines${expandHintSuffix(theme)}`));
 	}
 	if (opts.status === "cancelled") {
 		parts.push(theme.fg("warning", "(cancelled)"));

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -145,7 +145,8 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	}
 
 	/**
-	 * Apply an explicit user fold choice. Automatic updates must retain this choice.
+	 * Apply an explicit fold choice for this component instance. Automatic updates
+	 * retain this choice; transcript rebuilds create a new instance from the global state.
 	 */
 	setManuallyExpanded(expanded: boolean): void {
 		this.#manuallyExpanded = expanded;
@@ -209,7 +210,8 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 
 	/**
 	 * Add a code-cell content preview below the entry summary.
-	 * When collapsed: shows first COLLAPSED_PREVIEW_LINES lines with "… N more lines (Ctrl+O for more)" hint.
+	 * When collapsed: shows first COLLAPSED_PREVIEW_LINES lines with the configured
+	 * app.tools.expand keybinding hint, when available.
 	 * When expanded: shows full content.
 	 */
 	#addContentPreview(entry: ReadEntry): void {

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -80,6 +80,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	#entries = new Map<string, ReadEntry>();
 	#text: Text;
 	#expanded = false;
+	#manuallyExpanded: boolean | undefined;
 	#showContentPreview: boolean;
 
 	constructor(options: ReadToolGroupOptions = {}) {
@@ -138,6 +139,16 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	}
 
 	setExpanded(expanded: boolean): void {
+		if (this.#manuallyExpanded !== undefined) return;
+		this.#expanded = expanded;
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Apply an explicit user fold choice. Automatic updates must retain this choice.
+	 */
+	setManuallyExpanded(expanded: boolean): void {
+		this.#manuallyExpanded = expanded;
 		this.#expanded = expanded;
 		this.#updateDisplay();
 	}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -174,6 +174,7 @@ export class ToolExecutionComponent extends Container {
 	#toolLabel: string;
 	#args: any;
 	#expanded = false;
+	#manuallyExpanded: boolean | undefined;
 	#showImages: boolean;
 	#editFuzzyThreshold: number | undefined;
 	#editAllowFuzzy: boolean | undefined;
@@ -451,6 +452,16 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	setExpanded(expanded: boolean): void {
+		if (this.#manuallyExpanded !== undefined) return;
+		this.#expanded = expanded;
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Apply an explicit user fold choice. Automatic updates must retain this choice.
+	 */
+	setManuallyExpanded(expanded: boolean): void {
+		this.#manuallyExpanded = expanded;
 		this.#expanded = expanded;
 		this.#updateDisplay();
 	}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -458,7 +458,8 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	/**
-	 * Apply an explicit user fold choice. Automatic updates must retain this choice.
+	 * Apply an explicit fold choice for this component instance. Automatic updates
+	 * retain this choice; transcript rebuilds create a new instance from the global state.
 	 */
 	setManuallyExpanded(expanded: boolean): void {
 		this.#manuallyExpanded = expanded;

--- a/packages/coding-agent/src/modes/components/ttsr-notification.ts
+++ b/packages/coding-agent/src/modes/components/ttsr-notification.ts
@@ -1,6 +1,7 @@
 import { Box, Container, Spacer, Text } from "@gajae-code/tui";
 import type { Rule } from "../../capability/rule";
 import { theme } from "../../modes/theme/theme";
+import { expandHintSuffix } from "../../tools/render-utils";
 
 /**
  * Component that renders a TTSR (Time Traveling Stream Rules) notification.
@@ -73,7 +74,7 @@ export class TtsrNotificationComponent extends Container {
 				return desc && desc.split("\n").length > 2;
 			});
 			if (hasMoreContent) {
-				this.#box.addChild(new Text(theme.italic(" (ctrl+o to expand)"), 0, 0));
+				this.#box.addChild(new Text(theme.italic(expandHintSuffix(theme)), 0, 0));
 			}
 		}
 	}

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -26,6 +26,13 @@ interface Expandable {
 	setExpanded(expanded: boolean): void;
 }
 
+interface ManuallyExpandable extends Expandable {
+	setManuallyExpanded(expanded: boolean): void;
+}
+
+function isManuallyExpandable(obj: unknown): obj is ManuallyExpandable {
+	return isExpandable(obj) && "setManuallyExpanded" in obj && typeof obj.setManuallyExpanded === "function";
+}
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
 const DRAFT_CLEAR_DOUBLE_ESCAPE_WINDOW_MS = 800;
 const EMPTY_EDITOR_DOUBLE_ESCAPE_WINDOW_MS = 500;
@@ -1418,7 +1425,9 @@ export class InputController {
 	setToolsExpanded(expanded: boolean): void {
 		this.ctx.toolOutputExpanded = expanded;
 		for (const child of this.ctx.chatContainer.children) {
-			if (isExpandable(child)) {
+			if (isManuallyExpandable(child)) {
+				child.setManuallyExpanded(expanded);
+			} else if (isExpandable(child)) {
 				child.setExpanded(expanded);
 			}
 		}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -105,6 +105,7 @@ import {
 	setSearchFallbackProviders,
 	setSearchHardTimeoutMs,
 } from "../../tools";
+import { setExpandHintOwnerFocused } from "../../tools/render-utils";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
@@ -718,8 +719,11 @@ export class SelectorController {
 				this.ctx.editorContainer.addChild(this.ctx.editor);
 				this.ctx.ui.setFocus(this.ctx.editor);
 			}
+			setExpandHintOwnerFocused(true);
+			this.ctx.ui.requestRender();
 		};
 		const { component, focus } = create(done);
+		setExpandHintOwnerFocused(false);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(component);
 		this.ctx.ui.setFocus(focus);
@@ -2376,6 +2380,7 @@ export class SelectorController {
 		const done = () => {
 			cleanup?.();
 			overlayHandle?.hide();
+			setExpandHintOwnerFocused(true);
 			this.ctx.ui.requestRender();
 		};
 
@@ -2386,6 +2391,7 @@ export class SelectorController {
 			this.ctx.ui.requestRender();
 		});
 
+		setExpandHintOwnerFocused(false);
 		overlayHandle = this.ctx.ui.showOverlay(selector, {
 			anchor: "bottom-center",
 			width: "100%",
@@ -2408,6 +2414,7 @@ export class SelectorController {
 			this.ctx.editorContainer.clear();
 			this.ctx.editorContainer.addChild(this.ctx.editor);
 			this.ctx.ui.setFocus(this.ctx.editor);
+			setExpandHintOwnerFocused(true);
 			this.ctx.ui.requestRender();
 		};
 		overlay = new JobsOverlayComponent(observer, {
@@ -2417,6 +2424,7 @@ export class SelectorController {
 				this.ctx.ui.requestRender();
 			},
 		});
+		setExpandHintOwnerFocused(false);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(overlay);
 		this.ctx.ui.setFocus(overlay.getFocus());

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -31,7 +31,7 @@ import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-ski
 import { checkComposerBashPolicy } from "./composer-bash-policy";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
-import { formatToolWorkingDirectory, replaceTabs } from "./render-utils";
+import { expandHintSuffix, formatToolWorkingDirectory, replaceTabs } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
@@ -1295,7 +1295,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 								outputLines.push(
 									uiTheme.fg(
 										"dim",
-										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length}) (ctrl+o to expand)`,
+										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length})${expandHintSuffix(uiTheme)}`,
 									),
 								);
 							}

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -20,7 +20,7 @@ import {
 	resolveOutputSinkHeadBytes,
 	stripOutputNotice,
 } from "./output-meta";
-import { formatTitle, replaceTabs, shortenPath, truncateToWidth, wrapBrackets } from "./render-utils";
+import { expandHintSuffix, formatTitle, replaceTabs, shortenPath, truncateToWidth, wrapBrackets } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -947,7 +947,7 @@ export const evalToolRenderer = {
 						const outputLines = [...outputContent.lines];
 						if (!expanded && outputContent.hiddenCount > 0) {
 							outputLines.push(
-								uiTheme.fg("dim", `… ${outputContent.hiddenCount} more lines (ctrl+o to expand)`),
+								uiTheme.fg("dim", `… ${outputContent.hiddenCount} more lines${expandHintSuffix(uiTheme)}`),
 							);
 						}
 						if (statusLines.length > 0) {
@@ -1066,7 +1066,7 @@ export const evalToolRenderer = {
 					outputLines.push("");
 					const skippedLine = uiTheme.fg(
 						"dim",
-						`… (${cachedSkipped} earlier lines, showing ${cachedLines.length} of ${cachedSkipped + cachedLines.length}) (ctrl+o to expand)`,
+						`… (${cachedSkipped} earlier lines, showing ${cachedLines.length} of ${cachedSkipped + cachedLines.length})${expandHintSuffix(uiTheme)}`,
 					);
 					outputLines.push(truncateToWidth(skippedLine, width));
 				}

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -143,13 +143,34 @@ export function formatStatusIcon(status: ToolUIStatus, theme: Theme, spinnerFram
 }
 
 /**
+ * Tool-output expansion hints advertise `app.tools.expand` only while the
+ * composer owns input focus.
+ */
+let expandHintOwnerFocused = true;
+
+export function setExpandHintOwnerFocused(focused: boolean): void {
+	expandHintOwnerFocused = focused;
+}
+
+function formatExpandKey(): string {
+	return expandHintOwnerFocused ? formatKeyHints(getKeybindings().getKeys("app.tools.expand")) : "";
+}
+
+/**
  * Format the expand hint with proper theming.
- * Returns empty string if already expanded or there is nothing more to show.
+ * Returns empty string if already expanded, there is nothing more to show, or
+ * the composer does not own input focus.
  */
 export function formatExpandHint(theme: Theme, expanded?: boolean, hasMore?: boolean): string {
 	if (expanded || hasMore === false) return "";
-	const key = formatKeyHints(getKeybindings().getKeys("app.tools.expand"));
+	const key = formatExpandKey();
 	return key ? theme.fg("dim", wrapBrackets(`(${key} for more)`, theme)) : "";
+}
+
+/** Format a suffix for collapsed tool output that can be expanded. */
+export function expandHintSuffix(_theme: Theme): string {
+	const key = formatExpandKey();
+	return key ? ` (${key} to expand)` : "";
 }
 
 /**

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -10,8 +10,9 @@ import * as path from "node:path";
 import type { ToolCallContext } from "@gajae-code/agent-core";
 import type { Ellipsis } from "@gajae-code/natives";
 import type { Component } from "@gajae-code/tui";
-import { replaceTabs, truncateToWidth } from "@gajae-code/tui";
+import { getKeybindings, replaceTabs, truncateToWidth } from "@gajae-code/tui";
 import { pluralize } from "@gajae-code/utils";
+import { formatKeyHints } from "../config/keybindings";
 import { settings } from "../config/settings";
 import type { Theme } from "../modes/theme/theme";
 import { Hasher } from "../tui/utils";
@@ -74,9 +75,6 @@ export const TRUNCATE_LENGTHS = {
 	/** Very short (task previews, badges) */
 	SHORT: 40,
 } as const;
-
-/** Standard expand hint text */
-export const EXPAND_HINT = "(Ctrl+O for more)";
 
 // =============================================================================
 // Text Truncation Utilities
@@ -149,9 +147,9 @@ export function formatStatusIcon(status: ToolUIStatus, theme: Theme, spinnerFram
  * Returns empty string if already expanded or there is nothing more to show.
  */
 export function formatExpandHint(theme: Theme, expanded?: boolean, hasMore?: boolean): string {
-	if (expanded) return "";
-	if (hasMore === false) return "";
-	return theme.fg("dim", wrapBrackets(EXPAND_HINT, theme));
+	if (expanded || hasMore === false) return "";
+	const key = formatKeyHints(getKeybindings().getKeys("app.tools.expand"));
+	return key ? theme.fg("dim", wrapBrackets(`(${key} for more)`, theme)) : "";
 }
 
 /**

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -17,6 +17,7 @@ import { renderStatusLine } from "../tui";
 import { CachedOutputBlock } from "../tui/output-block";
 import type { ToolSession } from ".";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
+import { expandHintSuffix } from "./render-utils";
 import { ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -266,7 +267,7 @@ export const sshToolRenderer = {
 							outputLines.push(
 								uiTheme.fg(
 									"dim",
-									`… (${skippedCount} earlier lines, showing ${visualLines.length} of ${totalVisualLines}) (ctrl+o to expand)`,
+									`… (${skippedCount} earlier lines, showing ${visualLines.length} of ${totalVisualLines})${expandHintSuffix(uiTheme)}`,
 								),
 							);
 						}
@@ -281,7 +282,7 @@ export const sshToolRenderer = {
 						const remaining = outputLinesRaw.length - maxLines;
 						outputLines.push(...displayLines.map(line => uiTheme.fg("toolOutput", line)));
 						if (remaining > 0) {
-							outputLines.push(uiTheme.fg("dim", `… (${remaining} more lines) (ctrl+o to expand)`));
+							outputLines.push(uiTheme.fg("dim", `… (${remaining} more lines)${expandHintSuffix(uiTheme)}`));
 						}
 					}
 				}

--- a/packages/coding-agent/test/modes/components/pinned-folds.test.ts
+++ b/packages/coding-agent/test/modes/components/pinned-folds.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { Container, type TUI } from "@gajae-code/tui";
+import { resetSettingsForTest, Settings } from "../../../src/config/settings.js";
+import { AssistantMessageComponent } from "../../../src/modes/components/assistant-message.js";
+import { ToolExecutionComponent } from "../../../src/modes/components/tool-execution.js";
+import { InputController } from "../../../src/modes/controllers/input-controller.js";
+import { initTheme } from "../../../src/modes/theme/theme.js";
+import type { InteractiveModeContext } from "../../../src/modes/types.js";
+
+const uiStub = { requestRender() {} } as unknown as TUI;
+
+function render(component: ToolExecutionComponent | AssistantMessageComponent): string {
+	return Bun.stripANSI(component.render(100).join("\n"));
+}
+
+function assistantMessage(thinking: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "thinking", thinking }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+function toolResult(lines: number): { content: Array<{ type: string; text: string }> } {
+	return {
+		content: [
+			{
+				type: "text",
+				text: Array.from({ length: lines }, (_, index) =>
+					index === 0 ? "fold-start-marker" : `line ${index + 1}`,
+				).join("\n"),
+			},
+		],
+	};
+}
+
+describe("manual output folds", () => {
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		await initTheme(false);
+	});
+
+	it("retains a manually expanded tool result when its automatic completion state changes", () => {
+		const component = new ToolExecutionComponent("bash", { command: "echo output" }, {}, undefined, uiStub);
+		component.setManuallyExpanded(true);
+		component.updateResult(toolResult(30), false);
+		component.setExpanded(false);
+
+		expect(render(component)).toContain("fold-start-marker");
+	});
+
+	it("keeps automatic folding behavior for untouched tool results", () => {
+		const component = new ToolExecutionComponent("bash", { command: "echo output" }, {}, undefined, uiStub);
+		component.updateResult(toolResult(30), false);
+		component.setExpanded(false);
+
+		expect(render(component)).not.toContain("fold-start-marker");
+	});
+
+	it("lets the global fold toggle override an earlier pin", () => {
+		const component = new ToolExecutionComponent("bash", { command: "echo output" }, {}, undefined, uiStub);
+		const chatContainer = new Container();
+		chatContainer.addChild(component);
+		const ctx = { chatContainer, toolOutputExpanded: false, ui: uiStub } as unknown as InteractiveModeContext;
+		const controller = new InputController(ctx);
+
+		component.setManuallyExpanded(true);
+		controller.setToolsExpanded(false);
+		component.updateResult(toolResult(30), false);
+
+		expect(render(component)).not.toContain("fold-start-marker");
+	});
+
+	it("keeps hidden thinking hidden through streaming updates", () => {
+		const thinking = { type: "thinking" as const, thinking: "private thought" };
+		const component = new AssistantMessageComponent(assistantMessage(thinking.thinking));
+		component.setHideThinkingBlock(true);
+		thinking.thinking += " still private";
+		component.updateContent(assistantMessage(thinking.thinking), { streaming: true });
+
+		const output = render(component);
+		expect(output).toContain("Thinking...");
+		expect(output).not.toContain("private thought");
+	});
+});

--- a/packages/coding-agent/test/modes/components/pinned-folds.test.ts
+++ b/packages/coding-agent/test/modes/components/pinned-folds.test.ts
@@ -3,6 +3,7 @@ import type { AssistantMessage } from "@gajae-code/ai";
 import { Container, type TUI } from "@gajae-code/tui";
 import { resetSettingsForTest, Settings } from "../../../src/config/settings.js";
 import { AssistantMessageComponent } from "../../../src/modes/components/assistant-message.js";
+import { ReadToolGroupComponent } from "../../../src/modes/components/read-tool-group.js";
 import { ToolExecutionComponent } from "../../../src/modes/components/tool-execution.js";
 import { InputController } from "../../../src/modes/controllers/input-controller.js";
 import { initTheme } from "../../../src/modes/theme/theme.js";
@@ -10,7 +11,7 @@ import type { InteractiveModeContext } from "../../../src/modes/types.js";
 
 const uiStub = { requestRender() {} } as unknown as TUI;
 
-function render(component: ToolExecutionComponent | AssistantMessageComponent): string {
+function render(component: ToolExecutionComponent | ReadToolGroupComponent | AssistantMessageComponent): string {
 	return Bun.stripANSI(component.render(100).join("\n"));
 }
 
@@ -83,6 +84,20 @@ describe("manual output folds", () => {
 		component.updateResult(toolResult(30), false);
 
 		expect(render(component)).not.toContain("fold-start-marker");
+	});
+	it("lets the global fold toggle override an earlier read-group pin", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		const chatContainer = new Container();
+		chatContainer.addChild(component);
+		const ctx = { chatContainer, toolOutputExpanded: false, ui: uiStub } as unknown as InteractiveModeContext;
+		const controller = new InputController(ctx);
+
+		component.updateArgs({ path: "/tmp/example.ts" }, "read");
+		component.setManuallyExpanded(true);
+		controller.setToolsExpanded(false);
+		component.updateResult(toolResult(4), false, "read");
+
+		expect(render(component)).not.toContain("line 4");
 	});
 
 	it("keeps hidden thinking hidden through streaming updates", () => {

--- a/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
@@ -14,6 +14,7 @@ type Fixture = {
 	ctx: InteractiveModeContext;
 	getActions: () => ExtensionActions;
 	getCommandActions: () => ExtensionCommandContextActions;
+	getUiContext: () => ExtensionUIContext;
 	setNextSessionId: (id: string) => void;
 	rebuildInitialMessages: Mock<(policy: TranscriptRebuildPolicy) => void>;
 	rebuildChatFromMessages: Mock<(policy: TranscriptRebuildPolicy) => void>;
@@ -23,6 +24,7 @@ type Fixture = {
 function createFixture(initialSessionId = "session-a"): Fixture {
 	let actions: ExtensionActions | undefined;
 	let commandActions: ExtensionCommandContextActions | undefined;
+	let uiContext: ExtensionUIContext | undefined;
 	let sessionId = initialSessionId;
 	let nextSessionId = initialSessionId;
 	const rebuildInitialMessages = vi.fn<(policy: TranscriptRebuildPolicy) => void>();
@@ -33,10 +35,11 @@ function createFixture(initialSessionId = "session-a"): Fixture {
 			capturedActions: ExtensionActions,
 			_contextActions: ExtensionContextActions,
 			capturedCommandActions?: ExtensionCommandContextActions,
-			_uiContext?: ExtensionUIContext,
+			capturedUiContext?: ExtensionUIContext,
 		): void {
 			actions = capturedActions;
 			commandActions = capturedCommandActions;
+			uiContext = capturedUiContext;
 		},
 		onError: vi.fn(),
 		emit: vi.fn(async () => undefined),
@@ -88,6 +91,10 @@ function createFixture(initialSessionId = "session-a"): Fixture {
 			if (!commandActions) throw new Error("Extension command actions were not initialized");
 			return commandActions;
 		},
+		getUiContext: () => {
+			if (!uiContext) throw new Error("Extension UI context was not initialized");
+			return uiContext;
+		},
 		setNextSessionId: id => {
 			nextSessionId = id;
 		},
@@ -98,6 +105,14 @@ function createFixture(initialSessionId = "session-a"): Fixture {
 }
 
 describe("ExtensionUiController transcript rebuild policy", () => {
+	it("routes extension fold choices through the same explicit pinning action as the user shortcut", async () => {
+		const fixture = createFixture();
+		await fixture.controller.initHooksAndCustomTools();
+
+		fixture.getUiContext().setToolsExpanded(true);
+
+		expect(fixture.ctx.setToolsExpanded).toHaveBeenCalledWith(true);
+	});
 	it("resets identity when a hook-runner switch loads a different session id from the same path", async () => {
 		const fixture = createFixture();
 		fixture.setNextSessionId("session-b");

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { setKeybindings } from "@gajae-code/tui";
+import { KeybindingsManager } from "../src/config/keybindings";
 import { getDefault } from "../src/config/settings-schema";
 import { ReadToolGroupComponent, readArgsTargetInternalUrl } from "../src/modes/components/read-tool-group";
 import * as themeModule from "../src/modes/theme/theme";
@@ -10,6 +12,9 @@ describe("ReadToolGroupComponent", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+	});
+	beforeEach(() => {
+		setKeybindings(KeybindingsManager.inMemory());
 	});
 
 	it("keeps inline read previews disabled by default", () => {
@@ -92,6 +97,84 @@ describe("ReadToolGroupComponent", () => {
 		const matches = rendered.match(/Read \/tmp\/example\.ts:L10-L20/g) ?? [];
 
 		expect(matches).toHaveLength(1);
+	});
+	it("retains a manual collapse through automatic updates across mixed read entries", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/success.ts" }, "success");
+		component.updateArgs({ path: "/tmp/error.ts" }, "error");
+		component.updateArgs({ path: "/tmp/warning.ts" }, "warning");
+		component.setManuallyExpanded(false);
+		component.updateArgs({ path: "/tmp/success-renamed.ts" }, "success");
+		component.setExpanded(true);
+		component.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "success");
+		component.updateResult({ content: [{ type: "text", text: "e\nf\ng\nh" }], isError: true }, false, "error");
+		component.updateResult(
+			{
+				content: [{ type: "text", text: "i\nj\nk\nl" }],
+				details: { suffixResolution: { from: "/tmp/warn.ts", to: "/tmp/warning.ts" } },
+			},
+			false,
+			"warning",
+		);
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).not.toContain("\nd");
+		expect(rendered).not.toContain("\nh");
+		expect(rendered).not.toContain("\nl");
+	});
+
+	it("retains a manual expansion through automatic updates", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/example.ts" }, "read");
+		component.setManuallyExpanded(true);
+		component.updateArgs({ path: "/tmp/example-renamed.ts" }, "read");
+		component.setExpanded(false);
+		component.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "read");
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("d");
+	});
+
+	it("follows automatic expansion until explicitly pinned, then applies the new pin", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/example.ts" }, "read");
+		component.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "read");
+		component.setExpanded(true);
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("d");
+
+		component.setManuallyExpanded(false);
+		expect(Bun.stripANSI(component.render(120).join("\n"))).not.toContain("\nd");
+
+		component.setManuallyExpanded(true);
+		component.setExpanded(false);
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("d");
+	});
+
+	it("uses the configured expansion key hint and omits it when unbound", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/example.ts" }, "read");
+		component.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "read");
+
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+x" }));
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("Alt+X for more");
+
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": [] }));
+		component.invalidate();
+		expect(Bun.stripANSI(component.render(120).join("\n"))).not.toContain("for more");
+	});
+
+	it("resets manual fold provenance when a transcript rebuild creates a new component", () => {
+		const original = new ReadToolGroupComponent({ showContentPreview: true });
+		original.updateArgs({ path: "/tmp/example.ts" }, "read");
+		original.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "read");
+		original.setManuallyExpanded(true);
+
+		const rebuilt = new ReadToolGroupComponent({ showContentPreview: true });
+		rebuilt.setExpanded(false);
+		rebuilt.updateArgs({ path: "/tmp/example.ts" }, "read");
+		rebuilt.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "read");
+
+		expect(Bun.stripANSI(original.render(120).join("\n"))).toContain("d");
+		expect(Bun.stripANSI(rebuilt.render(120).join("\n"))).not.toContain("\nd");
 	});
 });
 

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -1,16 +1,102 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getThemeByName } from "@gajae-code/coding-agent/modes/theme/theme";
+import { KeybindingsManager } from "@gajae-code/coding-agent/config/keybindings";
+import { BranchSummaryMessageComponent } from "@gajae-code/coding-agent/modes/components/branch-summary-message";
+import { buildStatusFooter } from "@gajae-code/coding-agent/modes/components/execution-shared";
+import { getThemeByName, setThemeInstance, theme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { BranchSummaryMessage } from "@gajae-code/coding-agent/session/messages";
+import { evalToolRenderer } from "@gajae-code/coding-agent/tools/eval";
 import {
 	dedupeParseErrors,
+	expandHintSuffix,
 	formatCodeFrameLine,
 	formatDiagnostics,
+	formatExpandHint,
 	formatParseErrors,
 	formatScreenshot,
 	getPreviewLines,
+	setExpandHintOwnerFocused,
 	shortenPath,
 } from "@gajae-code/coding-agent/tools/render-utils";
+import { setKeybindings } from "@gajae-code/tui";
+
+beforeAll(async () => {
+	const testTheme = await getThemeByName("red-claw");
+	if (!testTheme) throw new Error("Failed to load test theme");
+	setThemeInstance(testTheme);
+});
+
+afterEach(() => {
+	setKeybindings(KeybindingsManager.inMemory());
+	setExpandHintOwnerFocused(true);
+});
+
+describe("tool-output expansion hints", () => {
+	it("uses the configured binding in execution, eval, and summary surfaces", () => {
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+x" }));
+
+		const footer = buildStatusFooter({
+			status: "complete",
+			exitCode: 0,
+			truncation: undefined,
+			hiddenLineCount: 3,
+		});
+		const summary = new BranchSummaryMessageComponent({ summary: "Summary" } as BranchSummaryMessage);
+
+		expect(Bun.stripANSI(footer!.render(120).join("\n"))).toContain("3 more lines (Alt+X to expand)");
+		expect(Bun.stripANSI(summary.render(120).join("\n"))).toContain("Branch summary (Alt+X to expand)");
+		const evalOutput = evalToolRenderer.renderResult(
+			{ content: [{ type: "text", text: Array.from({ length: 20 }, (_, index) => `line ${index}`).join("\n") }] },
+			{ expanded: false, renderContext: { expanded: false, previewLines: 1 } } as never,
+			theme,
+		);
+
+		expect(Bun.stripANSI(evalOutput.render(120).join("\n"))).toContain("Alt+X to expand");
+	});
+
+	it("preserves surrounding output when the action is unbound", () => {
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": [] }));
+
+		expect(expandHintSuffix(theme)).toBe("");
+		expect(
+			Bun.stripANSI(
+				buildStatusFooter({
+					status: "complete",
+					exitCode: 0,
+					truncation: undefined,
+					hiddenLineCount: 3,
+				})!
+					.render(120)
+					.join("\n"),
+			),
+		).toContain("3 more lines");
+		expect(
+			Bun.stripANSI(
+				buildStatusFooter({
+					status: "complete",
+					exitCode: 0,
+					truncation: undefined,
+					hiddenLineCount: 3,
+				})!
+					.render(120)
+					.join("\n"),
+			),
+		).not.toContain("to expand");
+	});
+
+	it("suppresses hints while the composer does not own focus", () => {
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+x" }));
+
+		setExpandHintOwnerFocused(false);
+		expect(expandHintSuffix(theme)).toBe("");
+		expect(formatExpandHint(theme)).toBe("");
+
+		setExpandHintOwnerFocused(true);
+		expect(expandHintSuffix(theme)).toContain("Alt+X to expand");
+		expect(Bun.stripANSI(formatExpandHint(theme))).toContain("Alt+X for more");
+	});
+});
 
 describe("parse error formatting", () => {
 	it("deduplicates parse errors while preserving order", () => {


### PR DESCRIPTION
## Summary
Resubmission of #2329 (closed after its second review). Contains the previously accepted fold-pin work plus the fix for the one remaining blocker. Head `cc92e3d0`, base dev `df4b59b1` (unchanged from the reviewed base).

**Carried over (accepted in the #2329 second review):** explicit-vs-automatic fold state with pins on ToolExecution/ReadToolGroup components, direct ReadToolGroup pin-invariant coverage, honest live-component-lifetime scoping with a remount-reset test, and documented+tested `ExtensionUIContext.setToolsExpanded` pin semantics.

## Final blocker fix: every expansion hint centralized + focus-aware
- A complete case-insensitive audit found nine hard-coded `(ctrl+o to expand)` literals — the four surfaces the review named (execution-shared, bash, eval ×2, ssh ×2) plus three it did not (branch-summary-message, compaction-summary-message, ttsr-notification). All nine now route through the shared render-utils helpers (`formatExpandHint` / new `expandHintSuffix`), which derive the configured `app.tools.expand` binding and return nothing when the action is unbound.
- **Focus semantics: suppression.** A module-level gate (`setExpandHintOwnerFocused`) documents and enforces that expansion hints advertise `app.tools.expand` only while the composer owns input focus; SelectorController toggles the gate across selector/overlay open and close lifecycles and requests a re-render, so a transcript hint can never advertise a key a focused selector consumes for a different action.
- Tests: custom rebinding renders the custom key on the execution footer, a tool renderer, and a summary surface; unbound ⇒ hint absent with surrounding counts intact; gate off ⇒ hint suppressed, gate on ⇒ restored.
- Remaining `ctrl+o` occurrences in the tree are only the default-binding definition and documented out-of-scope surfaces that bind their own keys (debug log viewer, tree-selector filter, HTML export template).

## Testing
- `bun test` render-utils + pinned-folds + read-tool-group + extension-ui-transcript-policy — 46 pass.
- `bun --cwd=packages/coding-agent run check` (biome, SDK canonicalization, tsc) — pass.