### PR TITLE
fix(coding-agent): bind ultragoal ask handoffs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
 
+### Fixed
+- Ultragoal ask guards now release only after a receipt-backed same-session handoff to deep-interview or ralplan, while malformed, stale, ambiguous, forged, or still-active Ultragoal state remains fail-closed.
+
 ## [0.11.0] - 2026-07-15
 
 ### Fixed

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -28,7 +28,7 @@ import {
 import { renderCliWriteReceipt } from "./cli-write-receipt";
 import { applyAmbiguityFloorToEnvelope } from "./deep-interview-ambiguity";
 import { mergeDeepInterviewEnvelope, normalizeDeepInterviewEnvelope } from "./deep-interview-state";
-import { activeSnapshotPath, auditPath, modeStatePath, sessionStateDir } from "./session-layout";
+import { activeSnapshotPath, auditPath, modeStatePath, sessionStateDir, sessionUltragoalDir } from "./session-layout";
 import {
 	resolveGjcSessionForRead,
 	resolveGjcSessionForWrite,
@@ -941,6 +941,67 @@ async function readAuditWindow(
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
+const ULTRAGOAL_ASK_HANDOFF_CALLEES = new Set(["deep-interview", "ralplan"]);
+const ULTRAGOAL_PLAN_RUN_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface UltragoalAskHandoffAuthority {
+	version: 1;
+	commitment: "committed";
+	caller: "ultragoal";
+	callee: "deep-interview" | "ralplan";
+	session_id: string;
+	plan_run_id: string;
+	handoff_at: string;
+	mutation_id: string;
+	caller_receipt: WorkflowStateReceipt;
+	callee_receipt: WorkflowStateReceipt;
+}
+
+function isUltragoalAskHandoffCallee(value: string): value is UltragoalAskHandoffAuthority["callee"] {
+	return ULTRAGOAL_ASK_HANDOFF_CALLEES.has(value);
+}
+
+function withoutUltragoalAskHandoffAuthority(state: Record<string, unknown>): Record<string, unknown> {
+	const { ultragoal_ask_handoff: _discarded, ...remaining } = state;
+	return remaining;
+}
+
+async function readUltragoalPlanRunId(cwd: string, sessionId: string): Promise<string | undefined> {
+	const goalsPath = path.join(sessionUltragoalDir(cwd, sessionId), "goals.json");
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(await fs.readFile(goalsPath, "utf8"));
+	} catch {
+		// A legacy, incomplete, or malformed plan remains handoff-compatible but
+		// receives no ask authorization. The guard will fail closed.
+		return undefined;
+	}
+	if (!isPlainObject(parsed) || typeof parsed.planRunId !== "string") return undefined;
+	return ULTRAGOAL_PLAN_RUN_ID_PATTERN.test(parsed.planRunId) ? parsed.planRunId : undefined;
+}
+
+function buildUltragoalAskHandoffAuthority(input: {
+	callee: UltragoalAskHandoffAuthority["callee"];
+	sessionId: string;
+	planRunId: string;
+	handoffAt: string;
+	mutationId: string;
+	callerReceipt: WorkflowStateReceipt;
+	calleeReceipt: WorkflowStateReceipt;
+}): UltragoalAskHandoffAuthority {
+	return {
+		version: 1,
+		commitment: "committed",
+		caller: "ultragoal",
+		callee: input.callee,
+		session_id: input.sessionId,
+		plan_run_id: input.planRunId,
+		handoff_at: input.handoffAt,
+		mutation_id: input.mutationId,
+		caller_receipt: input.callerReceipt,
+		callee_receipt: input.calleeReceipt,
+	};
+}
 
 /**
  * Shallow-merge `source` into `target`, with the convention that a `source` key whose value is
@@ -1589,6 +1650,10 @@ async function handleHandoff(
 	if (callee === caller) {
 		throw new StateCommandError(2, `gjc state handoff: --to must differ from caller (both are "${caller}")`);
 	}
+	const ultragoalPlanRunId =
+		caller === "ultragoal" && isUltragoalAskHandoffCallee(callee)
+			? await readUltragoalPlanRunId(cwd, sessionId)
+			: undefined;
 
 	const callerPath = modeStateFile(cwd, caller, sessionId);
 	const calleePath = calleeIsWorkflow ? modeStateFile(cwd, callee, sessionId) : undefined;
@@ -1624,13 +1689,14 @@ async function handleHandoff(
 	// persist them as active-state entries; the prompt observer tracks them
 	// in memory the same way direct `/skill:<runtime>` invocation does.
 	if (!calleeIsWorkflow) {
-		const normalizedCaller =
+		const normalizedCaller = withoutUltragoalAskHandoffAuthority(
 			caller === "deep-interview"
 				? (normalizeDeepInterviewEnvelope(migrateWorkflowState(existingCaller, caller).state) as Record<
 						string,
 						unknown
 					>)
-				: migrateWorkflowState(existingCaller, caller).state;
+				: migrateWorkflowState(existingCaller, caller).state,
+		);
 		const mergedCallerState: Record<string, unknown> = {
 			...normalizedCaller,
 			skill: caller,
@@ -1725,22 +1791,36 @@ async function handleHandoff(
 		nowIso: handoffAt,
 		mutationId,
 	});
+	const ultragoalAskHandoff =
+		ultragoalPlanRunId && isUltragoalAskHandoffCallee(callee)
+			? buildUltragoalAskHandoffAuthority({
+					callee,
+					sessionId,
+					planRunId: ultragoalPlanRunId,
+					handoffAt,
+					mutationId,
+					callerReceipt,
+					calleeReceipt,
+				})
+			: undefined;
 
 	const calleeInitial = initialPhaseForSkill(callee);
-	const normalizedCaller =
+	const normalizedCaller = withoutUltragoalAskHandoffAuthority(
 		caller === "deep-interview"
 			? (normalizeDeepInterviewEnvelope(migrateWorkflowState(existingCaller, caller).state) as Record<
 					string,
 					unknown
 				>)
-			: migrateWorkflowState(existingCaller, caller).state;
-	const normalizedCallee =
+			: migrateWorkflowState(existingCaller, caller).state,
+	);
+	const normalizedCallee = withoutUltragoalAskHandoffAuthority(
 		callee === "deep-interview"
 			? (normalizeDeepInterviewEnvelope(migrateWorkflowState(existingCallee, callee).state) as Record<
 					string,
 					unknown
 				>)
-			: migrateWorkflowState(existingCallee, callee).state;
+			: migrateWorkflowState(existingCallee, callee).state,
+	);
 	const mergedCalleeState: Record<string, unknown> = {
 		...normalizedCallee,
 		skill: callee,
@@ -1751,6 +1831,7 @@ async function handleHandoff(
 		handoff_at: handoffAt,
 		updated_at: handoffAt,
 		receipt: calleeReceipt,
+		...(ultragoalAskHandoff ? { ultragoal_ask_handoff: ultragoalAskHandoff } : {}),
 	};
 	if (sessionId && typeof mergedCalleeState.session_id !== "string") {
 		mergedCalleeState.session_id = sessionId;
@@ -1765,6 +1846,7 @@ async function handleHandoff(
 		handoff_at: handoffAt,
 		updated_at: handoffAt,
 		receipt: callerReceipt,
+		...(ultragoalAskHandoff ? { ultragoal_ask_handoff: ultragoalAskHandoff } : {}),
 	};
 
 	await beginWorkflowTransactionJournal({

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -1,6 +1,15 @@
 import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { CanonicalGjcWorkflowSkill } from "../skill-state/canonical-skills";
+import {
+	WORKFLOW_STATE_VERSION,
+	workflowActiveStatePath,
+	workflowStateStoragePath,
+} from "../skill-state/workflow-state-contract";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
+import { activeEntryPath, activeStateDir, modeStatePath } from "./session-layout";
 import { resolveGjcSessionForRead, SessionResolutionError } from "./session-resolution";
+import { detectWorkflowEnvelopeIntegrityMismatch } from "./state-writer";
 import {
 	validateDeferredMemberReceiptFresh,
 	validateReceiptFreshBase,
@@ -118,6 +127,285 @@ function isEnoent(error: unknown): boolean {
 	return (
 		typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT"
 	);
+}
+const ASK_HANDOFF_CALLEES = new Set(["deep-interview", "ralplan"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function readAuthoritativeActiveEntriesStrict(
+	cwd: string,
+	sessionId: string,
+): Promise<Record<string, unknown>[]> {
+	const dir = activeStateDir(cwd, sessionId);
+	let names: string[];
+	try {
+		names = await fs.readdir(dir);
+	} catch (error) {
+		if (isEnoent(error)) return [];
+		throw new Error(
+			`Unable to enumerate authoritative active entries: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	const entries: Record<string, unknown>[] = [];
+	for (const name of names.sort()) {
+		if (!name.endsWith(".json")) throw new Error(`Unexpected authoritative active entry: ${name}`);
+		const filePath = path.join(dir, name);
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(await fs.readFile(filePath, "utf-8"));
+		} catch (error) {
+			throw new Error(
+				`Unable to read authoritative active entry ${name}: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+		if (!isPlainObject(parsed)) throw new Error(`Authoritative active entry ${name} must be a JSON object`);
+		if (typeof parsed.skill !== "string" || parsed.skill.trim() === "") {
+			throw new Error(`Authoritative active entry ${name} must name a skill`);
+		}
+		if (activeEntryPath(cwd, sessionId, parsed.skill) !== filePath) {
+			throw new Error(`Authoritative active entry filename/skill mismatch for ${name}`);
+		}
+		if (typeof parsed.active !== "boolean") {
+			throw new Error(`Authoritative ${parsed.skill} active entry must have a boolean active field`);
+		}
+		if (parsed.session_id !== sessionId) {
+			throw new Error(`Authoritative ${parsed.skill} active entry has a mismatched session_id`);
+		}
+		entries.push(parsed);
+	}
+	return entries;
+}
+
+const ULTRAGOAL_PLAN_RUN_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const COMMITTED_ASK_HANDOFF_KEYS = [
+	"version",
+	"commitment",
+	"caller",
+	"callee",
+	"session_id",
+	"plan_run_id",
+	"handoff_at",
+	"mutation_id",
+	"caller_receipt",
+	"callee_receipt",
+] as const;
+const HANDOFF_RECEIPT_KEYS = [
+	"version",
+	"skill",
+	"owner",
+	"command",
+	"state_path",
+	"storage_path",
+	"mutated_at",
+	"fresh_until",
+	"status",
+	"mutation_id",
+] as const;
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+	return Object.keys(value).length === keys.length && keys.every(key => Object.hasOwn(value, key));
+}
+
+function nonEmptyStringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function validPastTimestamp(value: unknown): value is string {
+	const timestamp = typeof value === "string" ? Date.parse(value) : Number.NaN;
+	return Number.isFinite(timestamp) && timestamp <= Date.now();
+}
+
+function hasCommittedHandoffReceipt(input: {
+	value: unknown;
+	skill: string;
+	callee: string;
+	sessionId: string;
+	handoffAt: string;
+	mutationId: string;
+	cwd: string;
+}): boolean {
+	if (!isPlainObject(input.value) || !hasExactKeys(input.value, HANDOFF_RECEIPT_KEYS)) return false;
+	const freshUntil = Date.parse(nonEmptyStringValue(input.value.fresh_until) ?? "");
+	const handoffTime = Date.parse(input.handoffAt);
+	return (
+		input.value.version === 1 &&
+		input.value.skill === input.skill &&
+		input.value.owner === "gjc-state-cli" &&
+		input.value.command === `gjc state ultragoal handoff --to ${input.callee}` &&
+		input.value.state_path === workflowActiveStatePath(input.cwd, input.sessionId) &&
+		input.value.storage_path ===
+			workflowStateStoragePath(input.cwd, input.skill as CanonicalGjcWorkflowSkill, input.sessionId) &&
+		input.value.mutated_at === input.handoffAt &&
+		Number.isFinite(handoffTime) &&
+		Number.isFinite(freshUntil) &&
+		freshUntil >= handoffTime &&
+		(input.value.status === "fresh" || input.value.status === "stale") &&
+		input.value.mutation_id === input.mutationId
+	);
+}
+
+function hasCompleteCurrentModeReceipt(input: {
+	value: unknown;
+	skill: string;
+	sessionId: string;
+	cwd: string;
+}): boolean {
+	if (!isPlainObject(input.value)) return false;
+	const receipt = input.value.receipt;
+	if (!isPlainObject(receipt)) return false;
+	const checksum = receipt.content_sha256;
+	if (!isPlainObject(checksum)) return false;
+	const mutatedAt = nonEmptyStringValue(receipt.mutated_at);
+	const freshUntil = nonEmptyStringValue(receipt.fresh_until);
+	const checksumComputedAt = nonEmptyStringValue(checksum.computed_at);
+	return (
+		receipt.version === 1 &&
+		receipt.skill === input.skill &&
+		typeof receipt.owner === "string" &&
+		["gjc-state-cli", "gjc-runtime", "gjc-hook"].includes(receipt.owner) &&
+		Boolean(nonEmptyStringValue(receipt.command)) &&
+		receipt.state_path === workflowActiveStatePath(input.cwd, input.sessionId) &&
+		receipt.storage_path ===
+			workflowStateStoragePath(input.cwd, input.skill as CanonicalGjcWorkflowSkill, input.sessionId) &&
+		Boolean(mutatedAt && validPastTimestamp(mutatedAt)) &&
+		Boolean(
+			freshUntil && Number.isFinite(Date.parse(freshUntil)) && Date.parse(freshUntil) >= Date.parse(mutatedAt ?? ""),
+		) &&
+		(receipt.status === "fresh" || receipt.status === "stale") &&
+		Boolean(nonEmptyStringValue(receipt.mutation_id)) &&
+		checksum.algorithm === "sha256" &&
+		typeof checksum.value === "string" &&
+		/^[a-f0-9]{64}$/i.test(checksum.value) &&
+		checksum.covered_path === modeStatePath(input.cwd, input.sessionId, input.skill) &&
+		Boolean(checksumComputedAt && validPastTimestamp(checksumComputedAt))
+	);
+}
+
+function hasCommittedAskHandoffAuthority(input: {
+	value: unknown;
+	callee: string;
+	plan: UltragoalPlan;
+	sessionId: string;
+	cwd: string;
+}): boolean {
+	if (!isPlainObject(input.value) || !hasExactKeys(input.value, COMMITTED_ASK_HANDOFF_KEYS)) return false;
+	const planRunId = input.plan.planRunId;
+	const handoffAt = input.value.handoff_at;
+	const mutationId = input.value.mutation_id;
+	if (
+		!planRunId ||
+		!ULTRAGOAL_PLAN_RUN_ID_PATTERN.test(planRunId) ||
+		input.value.version !== 1 ||
+		input.value.commitment !== "committed" ||
+		input.value.caller !== "ultragoal" ||
+		input.value.callee !== input.callee ||
+		input.value.session_id !== input.sessionId ||
+		input.value.plan_run_id !== planRunId ||
+		!validPastTimestamp(handoffAt) ||
+		typeof mutationId !== "string" ||
+		mutationId !== `ultragoal:handoff:${input.callee}:${handoffAt}`
+	) {
+		return false;
+	}
+	return (
+		hasCommittedHandoffReceipt({
+			value: input.value.caller_receipt,
+			skill: "ultragoal",
+			callee: input.callee,
+			sessionId: input.sessionId,
+			handoffAt,
+			mutationId,
+			cwd: input.cwd,
+		}) &&
+		hasCommittedHandoffReceipt({
+			value: input.value.callee_receipt,
+			skill: input.callee,
+			callee: input.callee,
+			sessionId: input.sessionId,
+			handoffAt,
+			mutationId,
+			cwd: input.cwd,
+		})
+	);
+}
+
+async function readModeStateForHandoff(
+	cwd: string,
+	sessionId: string,
+	skill: string,
+): Promise<{ value: Record<string, unknown>; path: string } | undefined> {
+	const filePath = modeStatePath(cwd, sessionId, skill);
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(await fs.readFile(filePath, "utf-8"));
+	} catch (error) {
+		if (isEnoent(error)) return undefined;
+		throw new Error(
+			`Unable to read authoritative ${skill} mode state: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (!isPlainObject(parsed)) return undefined;
+	return { value: parsed, path: filePath };
+}
+
+async function committedAskHandoffCallee(
+	cwd: string,
+	sessionId: string,
+	entries: readonly Record<string, unknown>[],
+	plan: UltragoalPlan,
+): Promise<string | undefined> {
+	const activeEntries = entries.filter(entry => entry.active === true);
+	if (activeEntries.length !== 1) return undefined;
+	const [entry] = activeEntries;
+	const callee = typeof entry.skill === "string" ? entry.skill : "";
+	if (!ASK_HANDOFF_CALLEES.has(callee) || typeof entry.phase !== "string" || entry.phase.trim() === "")
+		return undefined;
+	const callerEntry = entries.find(candidate => candidate.skill === "ultragoal");
+	if (callerEntry?.active !== false) return undefined;
+
+	const [callerState, calleeState] = await Promise.all([
+		readModeStateForHandoff(cwd, sessionId, "ultragoal"),
+		readModeStateForHandoff(cwd, sessionId, callee),
+	]);
+	if (!callerState || !calleeState) return undefined;
+	if (
+		callerState.value.skill !== "ultragoal" ||
+		callerState.value.version !== WORKFLOW_STATE_VERSION ||
+		callerState.value.active !== false ||
+		callerState.value.current_phase !== "handoff" ||
+		callerState.value.session_id !== sessionId ||
+		callerState.value.handoff_to !== callee ||
+		typeof callerState.value.handoff_at !== "string" ||
+		calleeState.value.skill !== callee ||
+		calleeState.value.version !== WORKFLOW_STATE_VERSION ||
+		calleeState.value.active !== true ||
+		calleeState.value.session_id !== sessionId ||
+		calleeState.value.handoff_from !== "ultragoal" ||
+		calleeState.value.handoff_at !== callerState.value.handoff_at ||
+		!hasCompleteCurrentModeReceipt({ value: callerState.value, skill: "ultragoal", sessionId, cwd }) ||
+		!hasCompleteCurrentModeReceipt({ value: calleeState.value, skill: callee, sessionId, cwd }) ||
+		(await detectWorkflowEnvelopeIntegrityMismatch(callerState.path)) !== undefined ||
+		(await detectWorkflowEnvelopeIntegrityMismatch(calleeState.path)) !== undefined
+	) {
+		return undefined;
+	}
+	const callerAuthority = callerState.value.ultragoal_ask_handoff;
+	const calleeAuthority = calleeState.value.ultragoal_ask_handoff;
+	if (
+		JSON.stringify(callerAuthority) !== JSON.stringify(calleeAuthority) ||
+		!hasCommittedAskHandoffAuthority({ value: callerAuthority, callee, plan, sessionId, cwd })
+	) {
+		return undefined;
+	}
+	return callee;
+}
+
+async function hasStablePlanRunIdentity(cwd: string, sessionId: string, plan: UltragoalPlan): Promise<boolean> {
+	if (!plan.planRunId || !ULTRAGOAL_PLAN_RUN_ID_PATTERN.test(plan.planRunId)) return false;
+	const rechecked = await readUltragoalPlan(cwd, sessionId);
+	return rechecked?.planRunId === plan.planRunId;
 }
 
 function activeAskDiagnostic(input: {
@@ -648,7 +936,47 @@ export async function isUltragoalAskBlocked(
 			ledgerPath: paths.ledgerPath,
 		});
 	}
-
+	let handoffCallee: string | undefined;
+	try {
+		handoffCallee = await committedAskHandoffCallee(
+			cwd,
+			sessionId,
+			await readAuthoritativeActiveEntriesStrict(cwd, sessionId),
+			plan,
+		);
+	} catch (error) {
+		return activeAskDiagnostic({
+			reason: `Unable to validate authoritative workflow handoff state: ${error instanceof Error ? error.message : String(error)}`,
+			source: "durable_state_unreadable",
+			goalsPath: paths.goalsPath,
+			ledgerPath: paths.ledgerPath,
+		});
+	}
+	if (handoffCallee) {
+		try {
+			if (!(await hasStablePlanRunIdentity(cwd, sessionId, plan))) {
+				return activeAskDiagnostic({
+					reason: "Ultragoal plan changed while validating the workflow handoff.",
+					source: "durable_state",
+					goalsPath: paths.goalsPath,
+					ledgerPath: paths.ledgerPath,
+				});
+			}
+		} catch (error) {
+			return activeAskDiagnostic({
+				reason: `Unable to recheck Ultragoal plan identity: ${error instanceof Error ? error.message : String(error)}`,
+				source: "durable_state_unreadable",
+				goalsPath: paths.goalsPath,
+				ledgerPath: paths.ledgerPath,
+			});
+		}
+		return inactiveAskDiagnostic({
+			reason: `Ultragoal is inactive after a committed workflow handoff to ${handoffCallee}.`,
+			source: "durable_state",
+			goalsPath: paths.goalsPath,
+			ledgerPath: paths.ledgerPath,
+		});
+	}
 	if (plan.goals.some(goal => goal.status === "review_blocked")) {
 		const goalIds = plan.goals.filter(goal => goal.status === "review_blocked").map(goal => goal.id);
 		return activeAskDiagnostic({
@@ -697,6 +1025,25 @@ export async function isUltragoalAskBlocked(
 			ledgerPath: paths.ledgerPath,
 			goalIds: diagnostic.goalId ? [diagnostic.goalId] : undefined,
 		});
+	}
+	if (plan.planRunId) {
+		try {
+			if (!(await hasStablePlanRunIdentity(cwd, sessionId, plan))) {
+				return activeAskDiagnostic({
+					reason: "Ultragoal plan changed while validating completion.",
+					source: "durable_state",
+					goalsPath: paths.goalsPath,
+					ledgerPath: paths.ledgerPath,
+				});
+			}
+		} catch (error) {
+			return activeAskDiagnostic({
+				reason: `Unable to recheck Ultragoal plan identity: ${error instanceof Error ? error.message : String(error)}`,
+				source: "durable_state_unreadable",
+				goalsPath: paths.goalsPath,
+				ledgerPath: paths.ledgerPath,
+			});
+		}
 	}
 	return inactiveAskDiagnostic({
 		reason: "Ultragoal run is verified complete.",

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -152,6 +152,12 @@ export interface UltragoalGoal {
 
 export interface UltragoalPlan {
 	version: 1;
+	/**
+	 * Cryptographically random identity for this durable plan instance. It is
+	 * intentionally distinct from timestamps and mutable completion generations.
+	 * Legacy plans do not have this field and must not gain handoff authority.
+	 */
+	planRunId?: string;
 	brief: string;
 	gjcGoalMode: UltragoalGjcGoalMode;
 	gjcObjective: string;
@@ -309,6 +315,7 @@ const ACCEPTED_PROOF_STATUSES = new Set([COVERED_STATUS, "passed", "verified"]);
 const MIN_SUBSTANTIVE_EVIDENCE_WORDS = 5;
 const MIN_SUBSTANTIVE_EVIDENCE_CHARS = 32;
 
+const ULTRAGOAL_PLAN_RUN_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SCHEDULABLE_STATUSES = new Set<UltragoalGoalStatus>(["pending", "active", "failed"]);
 const COMPLETE_CHECKPOINT_ALLOWED_PRE_STATUSES = new Set<UltragoalGoalStatus>(["active", "failed"]);
 
@@ -1311,8 +1318,13 @@ function normalizePlan(raw: unknown): UltragoalPlan {
 				(value): value is string => typeof value === "string" && value.trim().length > 0,
 			)
 		: undefined;
+	const planRunId =
+		typeof record.planRunId === "string" && ULTRAGOAL_PLAN_RUN_ID_PATTERN.test(record.planRunId)
+			? record.planRunId
+			: undefined;
 	return {
 		version: 1,
+		...(planRunId ? { planRunId } : {}),
 		brief,
 		gjcGoalMode,
 		gjcObjective,
@@ -1522,6 +1534,7 @@ export async function createUltragoalPlan(input: {
 	}
 	const plan: UltragoalPlan = {
 		version: 1,
+		planRunId: crypto.randomUUID(),
 		brief,
 		gjcGoalMode: input.gjcGoalMode ?? "aggregate",
 		gjcObjective: DEFAULT_ULTRAGOAL_OBJECTIVE,
@@ -1530,7 +1543,11 @@ export async function createUltragoalPlan(input: {
 		updatedAt: now,
 	};
 	await writePlan(input.cwd, plan, input.sessionId);
-	await appendLedger(input.cwd, { event: "plan_created", goalIds: plan.goals.map(goal => goal.id) }, input.sessionId);
+	await appendLedger(
+		input.cwd,
+		{ event: "plan_created", goalIds: plan.goals.map(goal => goal.id), planRunId: plan.planRunId },
+		input.sessionId,
+	);
 	return plan;
 }
 

--- a/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
+++ b/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
@@ -4,10 +4,11 @@ import * as path from "node:path";
 import type { AgentTool, AgentToolContext } from "@gajae-code/agent-core";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import {
-	activeSnapshotPath,
+	activeEntryPath,
 	modeStatePath,
 	sessionActivityPath,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
 import { isUltragoalAskBlocked } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
 import {
 	computeUltragoalPlanGeneration,
@@ -16,6 +17,7 @@ import {
 	hashStructuredValue,
 } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-runtime";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { syncSkillActiveState } from "@gajae-code/coding-agent/skill-state/active-state";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { AskTool } from "@gajae-code/coding-agent/tools/ask";
 import { ToolError } from "@gajae-code/coding-agent/tools/tool-errors";
@@ -71,29 +73,42 @@ async function writeActivityMarker(cwd: string, sessionId: string, updatedAt: st
 }
 
 async function writeActiveDeepInterviewState(cwd: string, sessionId: string): Promise<void> {
-	const now = new Date().toISOString();
-	const activeState = {
-		version: 1,
-		active: true,
+	await syncSkillActiveState({
+		cwd,
+		sessionId,
 		skill: "deep-interview",
+		active: true,
 		phase: "interviewing",
-		updated_at: now,
-		session_id: sessionId,
-		active_skills: [
-			{
-				skill: "deep-interview",
-				phase: "interviewing",
-				active: true,
-				updated_at: now,
-				session_id: sessionId,
-			},
-		],
-	};
-	await Bun.write(activeSnapshotPath(cwd, sessionId), `${JSON.stringify(activeState, null, 2)}\n`);
+	});
+}
+async function handoffUltragoal(cwd: string, sessionId: string, callee: "deep-interview" | "ralplan"): Promise<void> {
 	await Bun.write(
-		modeStatePath(cwd, sessionId, "deep-interview"),
-		`${JSON.stringify({ active: true, current_phase: "interviewing", session_id: sessionId }, null, 2)}\n`,
+		modeStatePath(cwd, sessionId, "ultragoal"),
+		`${JSON.stringify(
+			{
+				skill: "ultragoal",
+				version: 1,
+				active: true,
+				current_phase: "handoff",
+				session_id: sessionId,
+				updated_at: new Date().toISOString(),
+			},
+			null,
+			2,
+		)}\n`,
 	);
+	await syncSkillActiveState({
+		cwd,
+		sessionId,
+		skill: "ultragoal",
+		active: true,
+		phase: "handoff",
+	});
+	const result = await runNativeStateCommand(
+		["handoff", "--mode", "ultragoal", "--to", callee, "--session-id", sessionId, "--json"],
+		cwd,
+	);
+	expect(result.status, result.stderr).toBe(0);
 }
 
 function stubAskTool(execute: () => Promise<void>): AgentTool {
@@ -241,14 +256,13 @@ describe("ultragoal ask guard", () => {
 		expect(result.content[0]).toMatchObject({ type: "text" });
 	});
 
-	it("blocks active deep-interview ask when the same session has active ultragoal state", async () => {
+	it("allows active deep-interview ask after same-session ultragoal handoff", async () => {
 		const cwd = await tempDir();
-		const sessionId = "deep-interview-with-ultragoal-state";
+		const sessionId = "deep-interview-after-ultragoal-handoff";
 
 		process.env.GJC_SESSION_ID = sessionId;
 		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
-		delete process.env.GJC_SESSION_ID;
-		await writeActiveDeepInterviewState(cwd, sessionId);
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
 
 		const select = vi.fn(async () => "Continue");
 		const tool = new AskTool(
@@ -258,16 +272,152 @@ describe("ultragoal ask guard", () => {
 			}),
 		);
 
-		await expect(
-			tool.execute(
-				"call",
-				{ questions: [{ id: "q", question: "Continue interview?", options: [{ label: "Continue" }] }] },
-				undefined,
-				undefined,
-				createContext(select),
-			),
-		).rejects.toThrow(/try-harder nudge/);
-		expect(select).not.toHaveBeenCalled();
+		const result = await tool.execute(
+			"call",
+			{ questions: [{ id: "q", question: "Continue interview?", options: [{ label: "Continue" }] }] },
+			undefined,
+			undefined,
+			createContext(select),
+		);
+
+		expect(select).toHaveBeenCalledTimes(1);
+		expect(result.content[0]).toMatchObject({ type: "text" });
+	});
+	it("allows ask after a committed same-session ultragoal to ralplan handoff", async () => {
+		const cwd = await tempDir();
+		const sessionId = "ralplan-after-ultragoal-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "ralplan");
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(false);
+		expect(diagnostic.reason).toContain("committed workflow handoff to ralplan");
+	});
+	it("blocks a committed handoff when a custom workflow is also active", async () => {
+		const cwd = await tempDir();
+		const sessionId = "custom-overlapping-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
+		await syncSkillActiveState({
+			cwd,
+			sessionId,
+			skill: "custom-review",
+			active: true,
+			phase: "running",
+		});
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("fails closed on a malformed custom entry after committed handoff", async () => {
+		const cwd = await tempDir();
+		const sessionId = "malformed-custom-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "ralplan");
+		await Bun.write(activeEntryPath(cwd, sessionId, "custom-review"), "{}\n");
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("durable_state_unreadable");
+	});
+	it("does not accept callee activation without committed handoff provenance", async () => {
+		const cwd = await tempDir();
+		const sessionId = "forged-deep-interview-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await writeActiveDeepInterviewState(cwd, sessionId);
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("does not treat active team state as a backward handoff", async () => {
+		const cwd = await tempDir();
+		const sessionId = "team-with-incomplete-ultragoal";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await syncSkillActiveState({
+			cwd,
+			sessionId,
+			skill: "team",
+			active: true,
+			phase: "running",
+		});
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("fails closed on structurally invalid canonical active entries", async () => {
+		const cwd = await tempDir();
+		const sessionId = "malformed-handoff-entry";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await Bun.write(
+			activeEntryPath(cwd, sessionId, "deep-interview"),
+			`${JSON.stringify({ skill: "deep-interview", session_id: sessionId })}\n`,
+		);
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("durable_state_unreadable");
+		expect(diagnostic.reason).toContain("boolean active field");
+	});
+	it("rejects a stale handoff entry from an earlier ultragoal run", async () => {
+		const cwd = await tempDir();
+		const sessionId = "stale-ultragoal-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		const originalPlan = await createUltragoalPlan({ cwd, brief: "Implement the earlier story" });
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
+		const replacementPlan = await createUltragoalPlan({ cwd, brief: "Implement the replacement story" });
+		const paths = getUltragoalPaths(cwd, sessionId);
+		const persistedReplacement = JSON.parse(await fs.readFile(paths.goalsPath, "utf8"));
+		persistedReplacement.createdAt = originalPlan.createdAt;
+		await fs.writeFile(paths.goalsPath, JSON.stringify(persistedReplacement, null, 2));
+		expect(persistedReplacement.createdAt).toBe(originalPlan.createdAt);
+		expect(replacementPlan.planRunId).not.toBe(originalPlan.planRunId);
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("keeps ask blocked when ultragoal remains active during an overlapping handoff", async () => {
+		const cwd = await tempDir();
+		const sessionId = "overlapping-ultragoal-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await writeActiveDeepInterviewState(cwd, sessionId);
+		await syncSkillActiveState({
+			cwd,
+			sessionId,
+			skill: "ultragoal",
+			active: true,
+			phase: "handoff",
+		});
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
 	});
 
 	it("allows ask when the ultragoal run is verified complete", async () => {


### PR DESCRIPTION
## Summary

Allow question-driven workflows to use `ask` after a legitimate same-session Ultragoal handoff, while preserving fail-closed behavior for incomplete, stale, forged, or overlapping workflow state.

Previously, incomplete required Ultragoal goals blocked every `ask` call even after control had been committed to `deep-interview` or `ralplan`, creating a workflow deadlock.

## Changes

- Assign each Ultragoal plan a stable `planRunId`.
- Persist committed handoff authority in caller and callee mode state.
- Bind ask authorization to the current plan run, reciprocal workflow identities, matching mutation IDs, and verified receipts/content hashes.
- Require exactly one authoritative active workflow entry.
- Permit only committed `ultragoal -> deep-interview|ralplan` handoffs.
- Continue blocking forged activation, stale prior-run handoffs, malformed state, custom overlaps, and incomplete handoffs.

## Security properties

- Fail closed when workflow authority is ambiguous.
- Do not trust a callee active flag by itself.
- Do not authorize a new plan run with an older receipt.
- Preserve the ask block while Ultragoal remains authoritative.

## Verification

```text
bun run ci:check:full
bun test packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts packages/coding-agent/test/gjc-runtime/ultragoal-nudge-guard.test.ts packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
bun packages/coding-agent/src/cli.ts --smoke-test
```

Results:

- CI check gate: pass
- Focused tests: 50 pass, 0 fail
- CLI smoke test: pass
- Independent adversarial architecture review: CLEAR