### PR TITLE
feat(tui): pin explicit fold choices; complete capability-threaded expansion hints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 - The tool-output expand shortcut now stamps an explicit fold choice for each live component, so automatic expansion stamping cannot overwrite it. Transcript rebuilds/remounts create components from the global tool-output setting and reset that provenance.
-- Tool-output expansion hints now use the configured shortcut consistently and remain hidden while selectors or overlays own input focus.
+- Tool-output expansion hints now use each interactive mode's current TUI focus and overlay state at render time, keeping configured shortcuts isolated across concurrent modes and fresh through overlay lifecycle changes.
 
 ## [0.11.0] - 2026-07-15
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - The tool-output expand shortcut now stamps an explicit fold choice for each live component, so automatic expansion stamping cannot overwrite it. Transcript rebuilds/remounts create components from the global tool-output setting and reset that provenance.
+- Tool-output expansion hints now use the configured shortcut consistently and remain hidden while selectors or overlays own input focus.
 
 ## [0.11.0] - 2026-07-15
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
 
+### Changed
+- The tool-output expand shortcut now stamps an explicit per-block fold choice, and automatic expansion stamping can no longer overwrite a block whose state came from an explicit user action. All current automatic stamping happens at component creation, so behavior is unchanged today; this locks the invariant for future per-block folds.
+
 ## [0.11.0] - 2026-07-15
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
 
 ### Changed
-- The tool-output expand shortcut now stamps an explicit per-block fold choice, and automatic expansion stamping can no longer overwrite a block whose state came from an explicit user action. All current automatic stamping happens at component creation, so behavior is unchanged today; this locks the invariant for future per-block folds.
+- The tool-output expand shortcut now stamps an explicit fold choice for each live component, so automatic expansion stamping cannot overwrite it. Transcript rebuilds/remounts create components from the global tool-output setting and reset that provenance.
 
 ## [0.11.0] - 2026-07-15
 

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -403,6 +403,7 @@ function renderDiffSection(
 	expanded: boolean,
 	uiTheme: Theme,
 	renderDiffFn: (t: string, o?: { filePath?: string }) => string,
+	expandHintCapability: import("../tools/render-utils").ExpandHintCapability,
 ): string {
 	let text = "";
 	const diffStats = getDiffStats(diff);
@@ -426,7 +427,10 @@ function renderDiffSection(
 		const remainder: string[] = [];
 		if (hiddenHunks > 0) remainder.push(`${hiddenHunks} more hunks`);
 		if (hiddenLines > 0) remainder.push(`${hiddenLines} more lines`);
-		text += uiTheme.fg("toolOutput", `\n… (${remainder.join(", ")}) ${formatExpandHint(uiTheme)}`);
+		text += uiTheme.fg(
+			"toolOutput",
+			`\n… (${remainder.join(", ")}) ${formatExpandHint(uiTheme, false, true, expandHintCapability)}`,
+		);
 	}
 	return text;
 }
@@ -599,18 +603,36 @@ function renderSingleFileResult(
 					text += `\n\n${uiTheme.fg("error", replaceTabs(errorText, rawPath))}`;
 				}
 			} else if (details?.diff) {
-				text += renderDiffSection(details.diff, rawPath, expanded, uiTheme, renderDiffFn);
+				text += renderDiffSection(
+					details.diff,
+					rawPath,
+					expanded,
+					uiTheme,
+					renderDiffFn,
+					options.expandHintCapability!,
+				);
 			} else if (editDiffPreview) {
 				if ("error" in editDiffPreview) {
 					text += `\n\n${uiTheme.fg("error", replaceTabs(editDiffPreview.error, rawPath))}`;
 				} else if (editDiffPreview.diff) {
-					text += renderDiffSection(editDiffPreview.diff, rawPath, expanded, uiTheme, renderDiffFn);
+					text += renderDiffSection(
+						editDiffPreview.diff,
+						rawPath,
+						expanded,
+						uiTheme,
+						renderDiffFn,
+						options.expandHintCapability!,
+					);
 				}
 			}
 
 			if (details?.diagnostics) {
-				text += formatDiagnostics(details.diagnostics, expanded, uiTheme, (fp: string) =>
-					uiTheme.getLangIcon(getLanguageFromPath(fp)),
+				text += formatDiagnostics(
+					details.diagnostics,
+					expanded,
+					uiTheme,
+					(fp: string) => uiTheme.getLangIcon(getLanguageFromPath(fp)),
+					options.expandHintCapability!,
 				);
 			}
 

--- a/packages/coding-agent/src/exa/render.ts
+++ b/packages/coding-agent/src/exa/render.ts
@@ -15,6 +15,7 @@ import {
 	formatStatusIcon,
 	getDomain,
 	getPreviewLines,
+	noExpandHintCapability,
 	PREVIEW_LIMITS,
 	TRUNCATE_LENGTHS,
 	truncateToWidth,
@@ -63,7 +64,12 @@ export function renderExaResult(
 			const maxLines = expanded ? rawLines.length : Math.min(rawLines.length, COLLAPSED_PREVIEW_LINES);
 			const displayLines = rawLines.slice(0, maxLines);
 			const remaining = rawLines.length - maxLines;
-			const expandHint = formatExpandHint(uiTheme, expanded, remaining > 0);
+			const expandHint = formatExpandHint(
+				uiTheme,
+				expanded,
+				remaining > 0,
+				options.expandHintCapability ?? noExpandHintCapability,
+			);
 
 			let text = `${formatStatusIcon("info", uiTheme)} ${uiTheme.fg("dim", "Raw response")}${expandHint}`;
 
@@ -106,7 +112,12 @@ export function renderExaResult(
 		const totalLines = previewText.split("\n").filter(l => l.trim()).length;
 		hasMorePreview = totalLines > COLLAPSED_PREVIEW_LINES || resultCount > 1;
 	}
-	const expandHint = formatExpandHint(uiTheme, expanded, hasMorePreview);
+	const expandHint = formatExpandHint(
+		uiTheme,
+		expanded,
+		hasMorePreview,
+		options.expandHintCapability ?? noExpandHintCapability,
+	);
 
 	let text = `${icon} ${uiTheme.fg("dim", summaryText)}${expandHint}`;
 

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -136,6 +136,8 @@ export interface RenderResultOptions {
 	isPartial: boolean;
 	/** Current spinner frame index for animated elements (0-9, only provided during partial results) */
 	spinnerFrame?: number;
+	/** Interactive-mode focus capability for render-time expansion hints. */
+	expandHintCapability?: import("../../tools/render-utils").ExpandHintCapability;
 }
 
 export type CustomToolResult<TDetails = any> = AgentToolResult<TDetails>;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -271,7 +271,10 @@ export interface ExtensionUIContext {
 	/** Get current tool output expansion state. */
 	getToolsExpanded(): boolean;
 
-	/** Set tool output expansion state. */
+	/**
+	 * Set tool output expansion state. This applies an explicit fold choice to existing
+	 * tool/read components, pinning them against automatic updates like the user shortcut.
+	 */
 	setToolsExpanded(expanded: boolean): void;
 }
 

--- a/packages/coding-agent/src/lsp/render.ts
+++ b/packages/coding-agent/src/lsp/render.ts
@@ -137,6 +137,9 @@ export function renderResult(
 	if (request?.apply !== undefined) requestLines.push(theme.fg("dim", `apply: ${request.apply ? "true" : "false"}`));
 
 	const outputBlock = new CachedOutputBlock();
+	const expandHintCapability = (
+		options as RenderResultOptions & { expandHintCapability: import("../tools/render-utils").ExpandHintCapability }
+	).expandHintCapability;
 
 	return {
 		render(width: number): string[] {
@@ -150,26 +153,26 @@ export function renderResult(
 
 			if (codeBlockMatch) {
 				label = "Hover";
-				bodyLines = renderHover(codeBlockMatch, text, lines, expanded, theme);
+				bodyLines = renderHover(codeBlockMatch, text, lines, expanded, theme, expandHintCapability);
 			} else if (errorMatch || warningMatch || hasStatusError) {
 				label = "Diagnostics";
 				const errorCount = errorMatch ? Number.parseInt(errorMatch[1], 10) : 0;
 				const warnCount = warningMatch ? Number.parseInt(warningMatch[1], 10) : 0;
 				state = errorCount > 0 ? "error" : warnCount > 0 ? "warning" : "success";
-				bodyLines = renderDiagnostics(errorMatch, warningMatch, lines, expanded, theme);
+				bodyLines = renderDiagnostics(errorMatch, warningMatch, lines, expanded, theme, expandHintCapability);
 			} else if (refMatch) {
 				label = "References";
-				bodyLines = renderReferences(refMatch, lines, expanded, theme);
+				bodyLines = renderReferences(refMatch, lines, expanded, theme, expandHintCapability);
 			} else if (symbolsMatch) {
 				label = "Symbols";
-				bodyLines = renderSymbols(symbolsMatch, lines, expanded, theme);
+				bodyLines = renderSymbols(symbolsMatch, lines, expanded, theme, expandHintCapability);
 			} else if (result.details?.action === "diagnostics" && text === "OK") {
 				label = "Diagnostics";
 				state = "success";
 				bodyLines = [`${theme.styledSymbol("status.success", "success")} ${theme.fg("dim", "OK")}`];
 			} else {
 				label = "Response";
-				bodyLines = renderGeneric(text, lines, expanded, theme);
+				bodyLines = renderGeneric(text, lines, expanded, theme, expandHintCapability);
 			}
 
 			const actionLabel = (request?.action ?? result.details?.action ?? label.toLowerCase()).replace(/_/g, " ");
@@ -210,6 +213,7 @@ function renderHover(
 	_lines: string[],
 	expanded: boolean,
 	theme: Theme,
+	expandHintCapability: import("../tools/render-utils").ExpandHintCapability,
 ): string[] {
 	const lang = codeBlockMatch[1] || "";
 	const code = codeBlockMatch[2].trim();
@@ -246,7 +250,7 @@ function renderHover(
 	// Collapsed view
 	const firstCodeLine = codeLines[0] || "";
 	const hasMore = codeLines.length > 1 || Boolean(afterCode) || Boolean(beforeCode);
-	const expandHint = formatExpandHint(theme, expanded, hasMore);
+	const expandHint = formatExpandHint(theme, expanded, hasMore, expandHintCapability);
 
 	let output = `${icon}${langLabel}${expandHint}`;
 	if (beforeCode) {
@@ -316,6 +320,7 @@ function renderDiagnostics(
 	lines: string[],
 	expanded: boolean,
 	theme: Theme,
+	expandHintCapability: import("../tools/render-utils").ExpandHintCapability,
 ): string[] {
 	const errorCount = errorMatch ? Number.parseInt(errorMatch[1], 10) : 0;
 	const warnCount = warningMatch ? Number.parseInt(warningMatch[1], 10) : 0;
@@ -373,7 +378,7 @@ function renderDiagnostics(
 		parsedDiagnostics.length > 0 ? parsedDiagnostics.slice(0, 3) : fallbackDiagnostics.slice(0, 3);
 	const remaining =
 		(parsedDiagnostics.length > 0 ? parsedDiagnostics.length : fallbackDiagnostics.length) - previewItems.length;
-	const expandHint = formatExpandHint(theme, expanded, remaining > 0);
+	const expandHint = formatExpandHint(theme, expanded, remaining > 0, expandHintCapability);
 	let output = `${icon} ${theme.fg("dim", meta.join(theme.sep.dot))}${expandHint}`;
 	for (let i = 0; i < previewItems.length; i++) {
 		const item = previewItems[i];
@@ -404,7 +409,13 @@ function renderDiagnostics(
 /**
  * Render references grouped by file.
  */
-function renderReferences(refMatch: RegExpMatchArray, lines: string[], expanded: boolean, theme: Theme): string[] {
+function renderReferences(
+	refMatch: RegExpMatchArray,
+	lines: string[],
+	expanded: boolean,
+	theme: Theme,
+	expandHintCapability: import("../tools/render-utils").ExpandHintCapability,
+): string[] {
 	const refCount = Number.parseInt(refMatch[1], 10);
 	const icon =
 		refCount > 0 ? theme.styledSymbol("status.success", "success") : theme.styledSymbol("status.warning", "warning");
@@ -425,7 +436,7 @@ function renderReferences(refMatch: RegExpMatchArray, lines: string[], expanded:
 	const files = Array.from(byFile.keys());
 
 	const renderGrouped = (maxFiles: number, maxLocsPerFile: number, showHint: boolean): string => {
-		const expandHint = formatExpandHint(theme, undefined, showHint);
+		const expandHint = formatExpandHint(theme, undefined, showHint, expandHintCapability);
 		let output = `${icon} ${theme.fg("dim", `${refCount} found`)}${expandHint}`;
 
 		const filesToShow = files.slice(0, maxFiles);
@@ -491,7 +502,13 @@ function renderReferences(refMatch: RegExpMatchArray, lines: string[], expanded:
 /**
  * Render document symbols in a hierarchical tree.
  */
-function renderSymbols(symbolsMatch: RegExpMatchArray, lines: string[], expanded: boolean, theme: Theme): string[] {
+function renderSymbols(
+	symbolsMatch: RegExpMatchArray,
+	lines: string[],
+	expanded: boolean,
+	theme: Theme,
+	expandHintCapability: import("../tools/render-utils").ExpandHintCapability,
+): string[] {
 	const fileName = symbolsMatch[1];
 	const icon = theme.styledSymbol("status.info", "accent");
 
@@ -565,7 +582,7 @@ function renderSymbols(symbolsMatch: RegExpMatchArray, lines: string[], expanded
 	// Collapsed: show first 3 top-level symbols
 	const topLevel = symbols.filter(s => s.indent === 0).slice(0, 3);
 	const hasMoreSymbols = symbols.length > topLevel.length;
-	const expandHint = formatExpandHint(theme, expanded, hasMoreSymbols);
+	const expandHint = formatExpandHint(theme, expanded, hasMoreSymbols, expandHintCapability);
 	let output = `${icon} ${theme.fg("dim", `in ${fileName}`)}${expandHint}`;
 	for (let i = 0; i < topLevel.length; i++) {
 		const sym = topLevel[i];
@@ -590,7 +607,13 @@ function renderSymbols(symbolsMatch: RegExpMatchArray, lines: string[], expanded
 /**
  * Generic fallback rendering for unknown result types.
  */
-function renderGeneric(text: string, lines: string[], expanded: boolean, theme: Theme): string[] {
+function renderGeneric(
+	text: string,
+	lines: string[],
+	expanded: boolean,
+	theme: Theme,
+	expandHintCapability: import("../tools/render-utils").ExpandHintCapability,
+): string[] {
 	const hasError = text.includes("Error:") || text.includes(theme.status.error);
 	const hasSuccess = text.includes(theme.status.success) || text.includes("Applied");
 
@@ -612,7 +635,7 @@ function renderGeneric(text: string, lines: string[], expanded: boolean, theme: 
 	}
 
 	const firstLine = lines[0] || "No output";
-	const expandHint = formatExpandHint(theme, expanded, lines.length > 1);
+	const expandHint = formatExpandHint(theme, expanded, lines.length > 1, expandHintCapability);
 	let output = `${icon} ${theme.fg("dim", truncateToWidth(firstLine, TRUNCATE_LENGTHS.TITLE))}${expandHint}`;
 
 	if (lines.length > 1) {

--- a/packages/coding-agent/src/modes/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/components/bash-execution.ts
@@ -17,6 +17,7 @@ import {
 import { sanitizeText } from "@gajae-code/utils";
 import { theme } from "../../modes/theme/theme";
 import type { TruncationMeta } from "../../tools/output-meta";
+import type { ExpandHintCapability } from "../../tools/render-utils";
 import {
 	containsSixelSequence,
 	getSixelLineMask,
@@ -56,6 +57,7 @@ export class BashExecutionComponent extends Container {
 		private readonly command: string,
 		ui: TUI,
 		excludeFromContext = false,
+		private readonly expandHintCapability?: ExpandHintCapability,
 	) {
 		super();
 
@@ -217,6 +219,7 @@ export class BashExecutionComponent extends Container {
 				truncation: this.#truncation,
 				hiddenLineCount,
 				suppressHiddenCount: hasSixelOutput && !fallbackActive,
+				expandHintCapability: this.expandHintCapability,
 			});
 			if (footer) this.#contentContainer.addChild(footer);
 		}

--- a/packages/coding-agent/src/modes/components/branch-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/branch-summary-message.ts
@@ -46,7 +46,7 @@ export class BranchSummaryMessageComponent extends Box {
 		} else {
 			this.addChild({
 				render: () => [
-					theme.fg("customMessageText", `Branch summary${expandHintSuffix(theme, this.expandHintCapability)}`),
+					theme.fg("customMessageText", `Branch summary${expandHintSuffix(theme, this.expandHintCapability!)}`),
 				],
 				invalidate: () => {},
 			});

--- a/packages/coding-agent/src/modes/components/branch-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/branch-summary-message.ts
@@ -1,6 +1,7 @@
 import { Box, Markdown, Spacer, Text } from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import type { BranchSummaryMessage } from "../../session/messages";
+import type { ExpandHintCapability } from "../../tools/render-utils";
 import { expandHintSuffix } from "../../tools/render-utils";
 
 /**
@@ -10,7 +11,10 @@ import { expandHintSuffix } from "../../tools/render-utils";
 export class BranchSummaryMessageComponent extends Box {
 	#expanded = false;
 
-	constructor(private readonly message: BranchSummaryMessage) {
+	constructor(
+		private readonly message: BranchSummaryMessage,
+		private readonly expandHintCapability?: ExpandHintCapability,
+	) {
 		super(1, 1, t => theme.bg("customMessageBg", t));
 		this.#updateDisplay();
 	}
@@ -40,7 +44,12 @@ export class BranchSummaryMessageComponent extends Box {
 				}),
 			);
 		} else {
-			this.addChild(new Text(theme.fg("customMessageText", `Branch summary${expandHintSuffix(theme)}`), 0, 0));
+			this.addChild({
+				render: () => [
+					theme.fg("customMessageText", `Branch summary${expandHintSuffix(theme, this.expandHintCapability)}`),
+				],
+				invalidate: () => {},
+			});
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/components/branch-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/branch-summary-message.ts
@@ -1,6 +1,7 @@
 import { Box, Markdown, Spacer, Text } from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import type { BranchSummaryMessage } from "../../session/messages";
+import { expandHintSuffix } from "../../tools/render-utils";
 
 /**
  * Component that renders a branch summary message with collapsed/expanded state.
@@ -39,7 +40,7 @@ export class BranchSummaryMessageComponent extends Box {
 				}),
 			);
 		} else {
-			this.addChild(new Text(theme.fg("customMessageText", "Branch summary (ctrl+o to expand)"), 0, 0));
+			this.addChild(new Text(theme.fg("customMessageText", `Branch summary${expandHintSuffix(theme)}`), 0, 0));
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/components/compaction-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/compaction-summary-message.ts
@@ -49,7 +49,7 @@ export class CompactionSummaryMessageComponent extends Box {
 				render: () => [
 					theme.fg(
 						"customMessageText",
-						`Compacted from ${tokenStr} tokens${expandHintSuffix(theme, this.expandHintCapability)}`,
+						`Compacted from ${tokenStr} tokens${expandHintSuffix(theme, this.expandHintCapability!)}`,
 					),
 				],
 				invalidate: () => {},

--- a/packages/coding-agent/src/modes/components/compaction-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/compaction-summary-message.ts
@@ -1,6 +1,7 @@
 import { Box, Markdown, Spacer, Text } from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import type { CompactionSummaryMessage } from "../../session/messages";
+import type { ExpandHintCapability } from "../../tools/render-utils";
 import { expandHintSuffix } from "../../tools/render-utils";
 
 /**
@@ -10,7 +11,10 @@ import { expandHintSuffix } from "../../tools/render-utils";
 export class CompactionSummaryMessageComponent extends Box {
 	#expanded = false;
 
-	constructor(private readonly message: CompactionSummaryMessage) {
+	constructor(
+		private readonly message: CompactionSummaryMessage,
+		private readonly expandHintCapability?: ExpandHintCapability,
+	) {
 		super(1, 1, t => theme.bg("customMessageBg", t));
 		this.#updateDisplay();
 	}
@@ -41,13 +45,15 @@ export class CompactionSummaryMessageComponent extends Box {
 				}),
 			);
 		} else {
-			this.addChild(
-				new Text(
-					theme.fg("customMessageText", `Compacted from ${tokenStr} tokens${expandHintSuffix(theme)}`),
-					0,
-					0,
-				),
-			);
+			this.addChild({
+				render: () => [
+					theme.fg(
+						"customMessageText",
+						`Compacted from ${tokenStr} tokens${expandHintSuffix(theme, this.expandHintCapability)}`,
+					),
+				],
+				invalidate: () => {},
+			});
 			if (this.message.shortSummary) {
 				this.addChild(new Text(theme.fg("customMessageText", this.message.shortSummary), 0, 1));
 			}

--- a/packages/coding-agent/src/modes/components/compaction-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/compaction-summary-message.ts
@@ -1,6 +1,7 @@
 import { Box, Markdown, Spacer, Text } from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import type { CompactionSummaryMessage } from "../../session/messages";
+import { expandHintSuffix } from "../../tools/render-utils";
 
 /**
  * Component that renders a compaction message with collapsed/expanded state.
@@ -41,7 +42,11 @@ export class CompactionSummaryMessageComponent extends Box {
 			);
 		} else {
 			this.addChild(
-				new Text(theme.fg("customMessageText", `Compacted from ${tokenStr} tokens (ctrl+o to expand)`), 0, 0),
+				new Text(
+					theme.fg("customMessageText", `Compacted from ${tokenStr} tokens${expandHintSuffix(theme)}`),
+					0,
+					0,
+				),
 			);
 			if (this.message.shortSummary) {
 				this.addChild(new Text(theme.fg("customMessageText", this.message.shortSummary), 0, 1));

--- a/packages/coding-agent/src/modes/components/eval-execution.ts
+++ b/packages/coding-agent/src/modes/components/eval-execution.ts
@@ -7,6 +7,7 @@ import { Container, type Loader, padding, Text, type TUI, visibleWidth } from "@
 import { sanitizeText } from "@gajae-code/utils";
 import { highlightCode, theme } from "../../modes/theme/theme";
 import type { TruncationMeta } from "../../tools/output-meta";
+import type { ExpandHintCapability } from "../../tools/render-utils";
 import {
 	buildExecutionFrame,
 	buildStatusFooter,
@@ -55,6 +56,7 @@ export class EvalExecutionComponent extends Container {
 		ui: TUI,
 		private readonly excludeFromContext = false,
 		private readonly language: EvalExecutionLanguage = "python",
+		private readonly expandHintCapability?: ExpandHintCapability,
 	) {
 		super();
 
@@ -140,6 +142,7 @@ export class EvalExecutionComponent extends Container {
 				exitCode: this.#exitCode,
 				truncation: this.#truncation,
 				hiddenLineCount,
+				expandHintCapability: this.expandHintCapability,
 			});
 			if (footer) this.#contentContainer.addChild(footer);
 		}

--- a/packages/coding-agent/src/modes/components/execution-shared.ts
+++ b/packages/coding-agent/src/modes/components/execution-shared.ts
@@ -10,6 +10,7 @@
 import { type Component, Container, Loader, Spacer, Text, type TUI } from "@gajae-code/tui";
 import { getSymbolTheme, theme } from "../../modes/theme/theme";
 import { formatTruncationMetaNotice, type TruncationMeta } from "../../tools/output-meta";
+import { expandHintSuffix } from "../../tools/render-utils";
 import { DynamicBorder } from "./dynamic-border";
 import { truncateToVisualLines } from "./visual-truncate";
 
@@ -76,7 +77,7 @@ export function buildStatusFooter(opts: {
 	const parts: string[] = [];
 
 	if (opts.hiddenLineCount > 0 && !opts.suppressHiddenCount) {
-		parts.push(theme.fg("dim", `… ${opts.hiddenLineCount} more lines (ctrl+o to expand)`));
+		parts.push(theme.fg("dim", `… ${opts.hiddenLineCount} more lines${expandHintSuffix(theme)}`));
 	}
 	if (opts.status === "cancelled") {
 		parts.push(theme.fg("warning", "(cancelled)"));

--- a/packages/coding-agent/src/modes/components/execution-shared.ts
+++ b/packages/coding-agent/src/modes/components/execution-shared.ts
@@ -82,7 +82,7 @@ export function buildStatusFooter(opts: {
 			? () =>
 					theme.fg(
 						"dim",
-						`… ${opts.hiddenLineCount} more lines${expandHintSuffix(theme, opts.expandHintCapability)}`,
+						`… ${opts.hiddenLineCount} more lines${expandHintSuffix(theme, opts.expandHintCapability!)}`,
 					)
 			: undefined;
 	if (opts.status === "cancelled") {

--- a/packages/coding-agent/src/modes/components/execution-shared.ts
+++ b/packages/coding-agent/src/modes/components/execution-shared.ts
@@ -10,7 +10,7 @@
 import { type Component, Container, Loader, Spacer, Text, type TUI } from "@gajae-code/tui";
 import { getSymbolTheme, theme } from "../../modes/theme/theme";
 import { formatTruncationMetaNotice, type TruncationMeta } from "../../tools/output-meta";
-import { expandHintSuffix } from "../../tools/render-utils";
+import { type ExpandHintCapability, expandHintSuffix } from "../../tools/render-utils";
 import { DynamicBorder } from "./dynamic-border";
 import { truncateToVisualLines } from "./visual-truncate";
 
@@ -73,12 +73,18 @@ export function buildStatusFooter(opts: {
 	hiddenLineCount: number;
 	/** Suppress the "… N more lines" hint (used when sixel passthrough renders the full output). */
 	suppressHiddenCount?: boolean;
-}): Text | undefined {
+	expandHintCapability?: ExpandHintCapability;
+}): Component | undefined {
 	const parts: string[] = [];
 
-	if (opts.hiddenLineCount > 0 && !opts.suppressHiddenCount) {
-		parts.push(theme.fg("dim", `… ${opts.hiddenLineCount} more lines${expandHintSuffix(theme)}`));
-	}
+	const hiddenLine =
+		opts.hiddenLineCount > 0 && !opts.suppressHiddenCount
+			? () =>
+					theme.fg(
+						"dim",
+						`… ${opts.hiddenLineCount} more lines${expandHintSuffix(theme, opts.expandHintCapability)}`,
+					)
+			: undefined;
 	if (opts.status === "cancelled") {
 		parts.push(theme.fg("warning", "(cancelled)"));
 	} else if (opts.status === "error") {
@@ -88,8 +94,11 @@ export function buildStatusFooter(opts: {
 		parts.push(theme.fg("warning", formatTruncationMetaNotice(opts.truncation)));
 	}
 
-	if (parts.length === 0) return undefined;
-	return new Text(`\n${parts.join("\n")}`, 1, 0);
+	if (!hiddenLine && parts.length === 0) return undefined;
+	return {
+		render: width => new Text(`\n${[hiddenLine?.(), ...parts].filter(Boolean).join("\n")}`, 1, 0).render(width),
+		invalidate: () => {},
+	};
 }
 
 /**

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -145,7 +145,8 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	}
 
 	/**
-	 * Apply an explicit user fold choice. Automatic updates must retain this choice.
+	 * Apply an explicit fold choice for this component instance. Automatic updates
+	 * retain this choice; transcript rebuilds create a new instance from the global state.
 	 */
 	setManuallyExpanded(expanded: boolean): void {
 		this.#manuallyExpanded = expanded;
@@ -209,7 +210,8 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 
 	/**
 	 * Add a code-cell content preview below the entry summary.
-	 * When collapsed: shows first COLLAPSED_PREVIEW_LINES lines with "… N more lines (Ctrl+O for more)" hint.
+	 * When collapsed: shows first COLLAPSED_PREVIEW_LINES lines with the configured
+	 * app.tools.expand keybinding hint, when available.
 	 * When expanded: shows full content.
 	 */
 	#addContentPreview(entry: ReadEntry): void {

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -3,7 +3,7 @@ import { Container, Text } from "@gajae-code/tui";
 import { InternalUrlRouter } from "../../internal-urls";
 import { getLanguageFromPath, theme } from "../../modes/theme/theme";
 import { splitPathAndSel } from "../../tools/path-utils";
-import { PREVIEW_LIMITS, shortenPath } from "../../tools/render-utils";
+import { type ExpandHintCapability, PREVIEW_LIMITS, shortenPath } from "../../tools/render-utils";
 import { renderCodeCell } from "../../tui";
 import type { ToolExecutionHandle } from "./tool-execution";
 
@@ -55,6 +55,7 @@ type ReadToolResultDetails = {
 
 type ReadToolGroupOptions = {
 	showContentPreview?: boolean;
+	expandHintCapability?: ExpandHintCapability;
 };
 
 function getSuffixResolution(details: ReadToolResultDetails | undefined): ReadToolSuffixResolution | undefined {
@@ -82,10 +83,12 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	#expanded = false;
 	#manuallyExpanded: boolean | undefined;
 	#showContentPreview: boolean;
+	#expandHintCapability?: ExpandHintCapability;
 
 	constructor(options: ReadToolGroupOptions = {}) {
 		super();
 		this.#showContentPreview = options.showContentPreview ?? false;
+		this.#expandHintCapability = options.expandHintCapability;
 		this.#text = new Text("", 0, 0);
 		this.addChild(this.#text);
 		this.#updateDisplay();
@@ -220,11 +223,13 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		const correctionSuffix = entry.correctedFrom ? ` (corrected from ${shortenPath(entry.correctedFrom)})` : "";
 		const title = filePath ? `Read ${filePath}${correctionSuffix}` : "Read";
 		let cachedWidth: number | undefined;
+		let cachedCanExpand: boolean | undefined;
 		let cachedLines: string[] | undefined;
 		const expanded = this.#expanded;
 		const component: Component = {
 			render: (width: number) => {
-				if (cachedLines && cachedWidth === width) return cachedLines;
+				const canExpand = this.#expandHintCapability?.();
+				if (cachedLines && cachedWidth === width && cachedCanExpand === canExpand) return cachedLines;
 				cachedLines = renderCodeCell(
 					{
 						code: entry.contentText ?? "",
@@ -233,15 +238,18 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 						status: entry.status === "success" ? "complete" : entry.status,
 						expanded,
 						codeMaxLines: expanded ? undefined : COLLAPSED_PREVIEW_LINES,
+						expandHintCapability: this.#expandHintCapability,
 						width,
 					},
 					theme,
 				);
 				cachedWidth = width;
+				cachedCanExpand = canExpand;
 				return cachedLines;
 			},
 			invalidate: () => {
 				cachedWidth = undefined;
+				cachedCanExpand = undefined;
 				cachedLines = undefined;
 			},
 		};

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -80,6 +80,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	#entries = new Map<string, ReadEntry>();
 	#text: Text;
 	#expanded = false;
+	#manuallyExpanded: boolean | undefined;
 	#showContentPreview: boolean;
 
 	constructor(options: ReadToolGroupOptions = {}) {
@@ -138,6 +139,16 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	}
 
 	setExpanded(expanded: boolean): void {
+		if (this.#manuallyExpanded !== undefined) return;
+		this.#expanded = expanded;
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Apply an explicit user fold choice. Automatic updates must retain this choice.
+	 */
+	setManuallyExpanded(expanded: boolean): void {
+		this.#manuallyExpanded = expanded;
 		this.#expanded = expanded;
 		this.#updateDisplay();
 	}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -174,6 +174,7 @@ export class ToolExecutionComponent extends Container {
 	#toolLabel: string;
 	#args: any;
 	#expanded = false;
+	#manuallyExpanded: boolean | undefined;
 	#showImages: boolean;
 	#editFuzzyThreshold: number | undefined;
 	#editAllowFuzzy: boolean | undefined;
@@ -451,6 +452,16 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	setExpanded(expanded: boolean): void {
+		if (this.#manuallyExpanded !== undefined) return;
+		this.#expanded = expanded;
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Apply an explicit user fold choice. Automatic updates must retain this choice.
+	 */
+	setManuallyExpanded(expanded: boolean): void {
+		this.#manuallyExpanded = expanded;
 		this.#expanded = expanded;
 		this.#updateDisplay();
 	}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -458,7 +458,8 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	/**
-	 * Apply an explicit user fold choice. Automatic updates must retain this choice.
+	 * Apply an explicit fold choice for this component instance. Automatic updates
+	 * retain this choice; transcript rebuilds create a new instance from the global state.
 	 */
 	setManuallyExpanded(expanded: boolean): void {
 		this.#manuallyExpanded = expanded;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -31,7 +31,13 @@ import {
 	JSON_TREE_SCALAR_LEN_EXPANDED,
 	renderJsonTreeLines,
 } from "../../tools/json-tree";
-import { formatExpandHint, replaceTabs, resolveImageOptions, truncateToWidth } from "../../tools/render-utils";
+import {
+	type ExpandHintCapability,
+	formatExpandHint,
+	replaceTabs,
+	resolveImageOptions,
+	truncateToWidth,
+} from "../../tools/render-utils";
 import { toolRenderers } from "../../tools/renderers";
 import { renderStatusLine } from "../../tui";
 import { containsSixelSequence, getSixelLineMask, sanitizeWithOptionalSixelPassthrough } from "../../utils/sixel";
@@ -216,6 +222,7 @@ export class ToolExecutionComponent extends Container {
 		expanded: boolean;
 		isPartial: boolean;
 		renderContext?: Record<string, unknown>;
+		expandHintCapability?: ExpandHintCapability;
 	} = {
 		expanded: false,
 		isPartial: true,
@@ -229,6 +236,7 @@ export class ToolExecutionComponent extends Container {
 		ui: TUI,
 		cwd: string = getProjectDir(),
 		_toolCallId?: string,
+		expandHintCapability?: ExpandHintCapability,
 	) {
 		super();
 		this.#toolName = toolName;
@@ -243,6 +251,7 @@ export class ToolExecutionComponent extends Container {
 		this.#shareArgsWithRenderer = argsCanBeSharedWithRenderer(toolName, tool);
 		this.#lastArgsReference = args;
 		this.#args = this.#shareArgsWithRenderer ? args : cloneToolArgs(args);
+		this.#renderState.expandHintCapability = expandHintCapability;
 
 		this.addChild(new Spacer(1));
 
@@ -530,7 +539,12 @@ export class ToolExecutionComponent extends Container {
 				try {
 					const renderResult = tool.renderResult as (
 						result: { content: Array<{ type: string; text?: string }>; details?: unknown; isError?: boolean },
-						options: { expanded: boolean; isPartial: boolean; spinnerFrame?: number },
+						options: {
+							expanded: boolean;
+							isPartial: boolean;
+							spinnerFrame?: number;
+							expandHintCapability?: ExpandHintCapability;
+						},
 						theme: Theme,
 						args?: unknown,
 					) => Component;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -34,6 +34,7 @@ import {
 import {
 	type ExpandHintCapability,
 	formatExpandHint,
+	noExpandHintCapability,
 	replaceTabs,
 	resolveImageOptions,
 	truncateToWidth,
@@ -914,7 +915,14 @@ export class ToolExecutionComponent extends Container {
 				if (tree.lines.length > 0) {
 					lines.push(...tree.lines);
 					if (!this.#expanded) {
-						lines.push(formatExpandHint(theme, this.#expanded, true));
+						lines.push(
+							formatExpandHint(
+								theme,
+								this.#expanded,
+								true,
+								this.#renderState.expandHintCapability ?? noExpandHintCapability,
+							),
+						);
 					} else if (tree.truncated) {
 						lines.push(theme.fg("dim", "…"));
 					}
@@ -935,9 +943,18 @@ export class ToolExecutionComponent extends Container {
 
 		if (outputLines.length > maxOutputLines) {
 			const remaining = outputLines.length - maxOutputLines;
-			lines.push(`${theme.fg("dim", `… ${remaining} more lines`)} ${formatExpandHint(theme, this.#expanded, true)}`);
+			lines.push(
+				`${theme.fg("dim", `… ${remaining} more lines`)} ${formatExpandHint(theme, this.#expanded, true, this.#renderState.expandHintCapability ?? noExpandHintCapability)}`,
+			);
 		} else if (!this.#expanded) {
-			lines.push(formatExpandHint(theme, this.#expanded, true));
+			lines.push(
+				formatExpandHint(
+					theme,
+					this.#expanded,
+					true,
+					this.#renderState.expandHintCapability ?? noExpandHintCapability,
+				),
+			);
 		}
 
 		return lines.join("\n");

--- a/packages/coding-agent/src/modes/components/ttsr-notification.ts
+++ b/packages/coding-agent/src/modes/components/ttsr-notification.ts
@@ -1,6 +1,7 @@
 import { Box, Container, Spacer, Text } from "@gajae-code/tui";
 import type { Rule } from "../../capability/rule";
 import { theme } from "../../modes/theme/theme";
+import { expandHintSuffix } from "../../tools/render-utils";
 
 /**
  * Component that renders a TTSR (Time Traveling Stream Rules) notification.
@@ -73,7 +74,7 @@ export class TtsrNotificationComponent extends Container {
 				return desc && desc.split("\n").length > 2;
 			});
 			if (hasMoreContent) {
-				this.#box.addChild(new Text(theme.italic(" (ctrl+o to expand)"), 0, 0));
+				this.#box.addChild(new Text(theme.italic(expandHintSuffix(theme)), 0, 0));
 			}
 		}
 	}

--- a/packages/coding-agent/src/modes/components/ttsr-notification.ts
+++ b/packages/coding-agent/src/modes/components/ttsr-notification.ts
@@ -79,7 +79,7 @@ export class TtsrNotificationComponent extends Container {
 			});
 			if (hasMoreContent) {
 				this.#box.addChild({
-					render: () => [theme.italic(expandHintSuffix(theme, this.expandHintCapability))],
+					render: () => [theme.italic(expandHintSuffix(theme, this.expandHintCapability!))],
 					invalidate: () => {},
 				});
 			}

--- a/packages/coding-agent/src/modes/components/ttsr-notification.ts
+++ b/packages/coding-agent/src/modes/components/ttsr-notification.ts
@@ -1,6 +1,7 @@
 import { Box, Container, Spacer, Text } from "@gajae-code/tui";
 import type { Rule } from "../../capability/rule";
 import { theme } from "../../modes/theme/theme";
+import type { ExpandHintCapability } from "../../tools/render-utils";
 import { expandHintSuffix } from "../../tools/render-utils";
 
 /**
@@ -11,7 +12,10 @@ export class TtsrNotificationComponent extends Container {
 	#box: Box;
 	#expanded = false;
 
-	constructor(private readonly rules: Rule[]) {
+	constructor(
+		private readonly rules: Rule[],
+		private readonly expandHintCapability?: ExpandHintCapability,
+	) {
 		super();
 
 		this.addChild(new Spacer(1));
@@ -74,7 +78,10 @@ export class TtsrNotificationComponent extends Container {
 				return desc && desc.split("\n").length > 2;
 			});
 			if (hasMoreContent) {
-				this.#box.addChild(new Text(theme.italic(expandHintSuffix(theme)), 0, 0));
+				this.#box.addChild({
+					render: () => [theme.italic(expandHintSuffix(theme, this.expandHintCapability))],
+					invalidate: () => {},
+				});
 			}
 		}
 	}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1094,7 +1094,12 @@ export class CommandController {
 
 	async handleBashCommand(command: string, excludeFromContext = false): Promise<void> {
 		const isDeferred = this.ctx.session.isStreaming;
-		this.ctx.bashComponent = new BashExecutionComponent(command, this.ctx.ui, excludeFromContext);
+		this.ctx.bashComponent = new BashExecutionComponent(
+			command,
+			this.ctx.ui,
+			excludeFromContext,
+			this.ctx.expandHintCapability,
+		);
 
 		if (isDeferred) {
 			this.ctx.pendingMessagesContainer.addChild(this.ctx.bashComponent);
@@ -1135,7 +1140,13 @@ export class CommandController {
 
 	async handlePythonCommand(code: string, excludeFromContext = false): Promise<void> {
 		const isDeferred = this.ctx.session.isStreaming;
-		this.ctx.pythonComponent = new EvalExecutionComponent(code, this.ctx.ui, excludeFromContext);
+		this.ctx.pythonComponent = new EvalExecutionComponent(
+			code,
+			this.ctx.ui,
+			excludeFromContext,
+			"python",
+			this.ctx.expandHintCapability,
+		);
 
 		if (isDeferred) {
 			this.ctx.pendingMessagesContainer.addChild(this.ctx.pythonComponent);

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -585,6 +585,7 @@ export class EventController {
 						this.ctx.ui,
 						this.ctx.sessionManager.getCwd(),
 						content.id,
+						this.ctx.expandHintCapability,
 					);
 					component.setExpanded(this.ctx.toolOutputExpanded);
 					this.ctx.pendingTools.set(content.id, component);
@@ -701,6 +702,7 @@ export class EventController {
 				this.ctx.ui,
 				this.ctx.sessionManager.getCwd(),
 				event.toolCallId,
+				this.ctx.expandHintCapability,
 			);
 			component.setExpanded(this.ctx.toolOutputExpanded);
 			this.ctx.pendingTools.set(event.toolCallId, component);
@@ -985,7 +987,7 @@ export class EventController {
 	}
 
 	async #handleTtsrTriggered(event: Extract<AgentSessionEvent, { type: "ttsr_triggered" }>): Promise<void> {
-		const component = new TtsrNotificationComponent(event.rules);
+		const component = new TtsrNotificationComponent(event.rules, this.ctx.expandHintCapability);
 		component.setExpanded(this.ctx.toolOutputExpanded);
 		addChatChild(this.ctx, component);
 		this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -171,6 +171,7 @@ export class EventController {
 			addChatChild(this.ctx, new Text("", 0, 0));
 			const group = new ReadToolGroupComponent({
 				showContentPreview: this.ctx.settings.get("read.toolResultPreview"),
+				expandHintCapability: this.ctx.expandHintCapability,
 			});
 			group.setExpanded(this.ctx.toolOutputExpanded);
 			addChatChild(this.ctx, group);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -26,6 +26,13 @@ interface Expandable {
 	setExpanded(expanded: boolean): void;
 }
 
+interface ManuallyExpandable extends Expandable {
+	setManuallyExpanded(expanded: boolean): void;
+}
+
+function isManuallyExpandable(obj: unknown): obj is ManuallyExpandable {
+	return isExpandable(obj) && "setManuallyExpanded" in obj && typeof obj.setManuallyExpanded === "function";
+}
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
 const DRAFT_CLEAR_DOUBLE_ESCAPE_WINDOW_MS = 800;
 const EMPTY_EDITOR_DOUBLE_ESCAPE_WINDOW_MS = 500;
@@ -1418,7 +1425,9 @@ export class InputController {
 	setToolsExpanded(expanded: boolean): void {
 		this.ctx.toolOutputExpanded = expanded;
 		for (const child of this.ctx.chatContainer.children) {
-			if (isExpandable(child)) {
+			if (isManuallyExpandable(child)) {
+				child.setManuallyExpanded(expanded);
+			} else if (isExpandable(child)) {
 				child.setExpanded(expanded);
 			}
 		}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -105,6 +105,7 @@ import {
 	setSearchFallbackProviders,
 	setSearchHardTimeoutMs,
 } from "../../tools";
+import { setExpandHintOwnerFocused } from "../../tools/render-utils";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
@@ -718,8 +719,11 @@ export class SelectorController {
 				this.ctx.editorContainer.addChild(this.ctx.editor);
 				this.ctx.ui.setFocus(this.ctx.editor);
 			}
+			setExpandHintOwnerFocused(true);
+			this.ctx.ui.requestRender();
 		};
 		const { component, focus } = create(done);
+		setExpandHintOwnerFocused(false);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(component);
 		this.ctx.ui.setFocus(focus);
@@ -2376,6 +2380,7 @@ export class SelectorController {
 		const done = () => {
 			cleanup?.();
 			overlayHandle?.hide();
+			setExpandHintOwnerFocused(true);
 			this.ctx.ui.requestRender();
 		};
 
@@ -2386,6 +2391,7 @@ export class SelectorController {
 			this.ctx.ui.requestRender();
 		});
 
+		setExpandHintOwnerFocused(false);
 		overlayHandle = this.ctx.ui.showOverlay(selector, {
 			anchor: "bottom-center",
 			width: "100%",
@@ -2408,6 +2414,7 @@ export class SelectorController {
 			this.ctx.editorContainer.clear();
 			this.ctx.editorContainer.addChild(this.ctx.editor);
 			this.ctx.ui.setFocus(this.ctx.editor);
+			setExpandHintOwnerFocused(true);
 			this.ctx.ui.requestRender();
 		};
 		overlay = new JobsOverlayComponent(observer, {
@@ -2417,6 +2424,7 @@ export class SelectorController {
 				this.ctx.ui.requestRender();
 			},
 		});
+		setExpandHintOwnerFocused(false);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(overlay);
 		this.ctx.ui.setFocus(overlay.getFocus());

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -105,7 +105,6 @@ import {
 	setSearchFallbackProviders,
 	setSearchHardTimeoutMs,
 } from "../../tools";
-import { setExpandHintOwnerFocused } from "../../tools/render-utils";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
@@ -719,11 +718,9 @@ export class SelectorController {
 				this.ctx.editorContainer.addChild(this.ctx.editor);
 				this.ctx.ui.setFocus(this.ctx.editor);
 			}
-			setExpandHintOwnerFocused(true);
 			this.ctx.ui.requestRender();
 		};
 		const { component, focus } = create(done);
-		setExpandHintOwnerFocused(false);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(component);
 		this.ctx.ui.setFocus(focus);
@@ -2380,7 +2377,6 @@ export class SelectorController {
 		const done = () => {
 			cleanup?.();
 			overlayHandle?.hide();
-			setExpandHintOwnerFocused(true);
 			this.ctx.ui.requestRender();
 		};
 
@@ -2391,7 +2387,6 @@ export class SelectorController {
 			this.ctx.ui.requestRender();
 		});
 
-		setExpandHintOwnerFocused(false);
 		overlayHandle = this.ctx.ui.showOverlay(selector, {
 			anchor: "bottom-center",
 			width: "100%",
@@ -2414,7 +2409,6 @@ export class SelectorController {
 			this.ctx.editorContainer.clear();
 			this.ctx.editorContainer.addChild(this.ctx.editor);
 			this.ctx.ui.setFocus(this.ctx.editor);
-			setExpandHintOwnerFocused(true);
 			this.ctx.ui.requestRender();
 		};
 		overlay = new JobsOverlayComponent(observer, {
@@ -2424,7 +2418,6 @@ export class SelectorController {
 				this.ctx.ui.requestRender();
 			},
 		});
-		setExpandHintOwnerFocused(false);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(overlay);
 		this.ctx.ui.setFocus(overlay.getFocus());

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -338,6 +338,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	btwContainer: Container;
 	editor: CustomEditor;
 	editorContainer: Container;
+	expandHintCapability = () =>
+		!this.ui.hasOverlay() && (this.ui.focusedComponent === null || this.ui.focusedComponent === this.editor);
 	hookWidgetContainerAbove: Container;
 	hookWidgetContainerBelow: Container;
 	petFloorContainer: Container = new Container();

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -20,6 +20,7 @@ import type { HistoryStorage } from "../session/history-storage";
 import type { SessionContext, SessionManager } from "../session/session-manager";
 import type { CredentialAutoImportOptions } from "../setup/credential-auto-import";
 import type { LspStartupServerInfo } from "../tools";
+import type { ExpandHintCapability } from "../tools/render-utils";
 import type { AssistantMessageComponent } from "./components/assistant-message";
 import type { BashExecutionComponent } from "./components/bash-execution";
 import type { CustomEditor } from "./components/custom-editor";
@@ -83,6 +84,7 @@ export interface InteractiveModeContext {
 	btwContainer: Container;
 	editor: CustomEditor;
 	editorContainer: Container;
+	expandHintCapability?: ExpandHintCapability;
 	hookWidgetContainerAbove: Container;
 	hookWidgetContainerBelow: Container;
 	statusLine: StatusLineComponent;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -400,7 +400,12 @@ export class UiHelpers {
 	addMessageToChat(message: AgentMessage, options?: { populateHistory?: boolean }): Component[] {
 		switch (message.role) {
 			case "bashExecution": {
-				const component = new BashExecutionComponent(message.command, this.ctx.ui, message.excludeFromContext);
+				const component = new BashExecutionComponent(
+					message.command,
+					this.ctx.ui,
+					message.excludeFromContext,
+					this.ctx.expandHintCapability,
+				);
 				if (message.output) {
 					component.appendOutput(message.output);
 				}
@@ -411,7 +416,13 @@ export class UiHelpers {
 				break;
 			}
 			case "pythonExecution": {
-				const component = new EvalExecutionComponent(message.code, this.ctx.ui, message.excludeFromContext);
+				const component = new EvalExecutionComponent(
+					message.code,
+					this.ctx.ui,
+					message.excludeFromContext,
+					"python",
+					this.ctx.expandHintCapability,
+				);
 				if (message.output) {
 					component.appendOutput(message.output);
 				}
@@ -509,14 +520,14 @@ export class UiHelpers {
 			}
 			case "compactionSummary": {
 				addChatChild(this.ctx, new Spacer(1));
-				const component = new CompactionSummaryMessageComponent(message);
+				const component = new CompactionSummaryMessageComponent(message, this.ctx.expandHintCapability);
 				component.setExpanded(this.ctx.toolOutputExpanded);
 				addChatChild(this.ctx, component);
 				break;
 			}
 			case "branchSummary": {
 				addChatChild(this.ctx, new Spacer(1));
-				const component = new BranchSummaryMessageComponent(message);
+				const component = new BranchSummaryMessageComponent(message, this.ctx.expandHintCapability);
 				component.setExpanded(this.ctx.toolOutputExpanded);
 				addChatChild(this.ctx, component);
 				break;
@@ -710,6 +721,7 @@ export class UiHelpers {
 						this.ctx.ui,
 						this.ctx.sessionManager.getCwd(),
 						content.id,
+						this.ctx.expandHintCapability,
 					);
 					component.setExpanded(this.ctx.toolOutputExpanded);
 					addChatChild(this.ctx, component);

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -679,6 +679,7 @@ export class UiHelpers {
 							if (!readGroup) {
 								readGroup = new ReadToolGroupComponent({
 									showContentPreview: this.ctx.settings.get("read.toolResultPreview"),
+									expandHintCapability: this.ctx.expandHintCapability,
 								});
 								readGroup.setExpanded(this.ctx.toolOutputExpanded);
 								addChatChild(this.ctx, readGroup);
@@ -760,6 +761,7 @@ export class UiHelpers {
 						if (!readGroup) {
 							readGroup = new ReadToolGroupComponent({
 								showContentPreview: this.ctx.settings.get("read.toolResultPreview"),
+								expandHintCapability: this.ctx.expandHintCapability,
 							});
 							readGroup.setExpanded(this.ctx.toolOutputExpanded);
 							addChatChild(this.ctx, readGroup);

--- a/packages/coding-agent/src/runtime-mcp/render.ts
+++ b/packages/coding-agent/src/runtime-mcp/render.ts
@@ -43,13 +43,13 @@ export function renderMCPCall(args: Record<string, unknown>, theme: Theme, label
 /**
  * Render MCP tool result.
  */
-export function renderMCPResult(
+function renderMCPResultStatic(
 	result: { content: Array<{ type: string; text?: string }>; details?: MCPToolDetails; isError?: boolean },
 	options: RenderResultOptions,
 	theme: Theme,
 	args?: Record<string, unknown>,
 ): Component {
-	const { expanded } = options;
+	const { expanded, expandHintCapability } = options;
 	const lines: string[] = [];
 
 	// Args section (when expanded)
@@ -91,7 +91,7 @@ export function renderMCPResult(
 				}
 				// Always show expand hint when collapsed (expanded view shows longer values and deeper nesting)
 				if (!expanded) {
-					lines.push(formatExpandHint(theme, expanded, true));
+					lines.push(formatExpandHint(theme, expanded, true, expandHintCapability!));
 				} else if (tree.truncated) {
 					lines.push(theme.fg("dim", "…"));
 				}
@@ -113,11 +113,28 @@ export function renderMCPResult(
 
 	if (outputLines.length > maxOutputLines) {
 		const remaining = outputLines.length - maxOutputLines;
-		lines.push(`${theme.fg("dim", `… ${remaining} more lines`)} ${formatExpandHint(theme, expanded, true)}`);
+		lines.push(
+			`${theme.fg("dim", `… ${remaining} more lines`)} ${formatExpandHint(theme, expanded, true, expandHintCapability!)}`,
+		);
 	} else if (!expanded) {
 		// Show expand hint when collapsed even if all lines shown (lines may be truncated)
-		lines.push(formatExpandHint(theme, expanded, true));
+		lines.push(formatExpandHint(theme, expanded, true, expandHintCapability!));
 	}
 
 	return new Text(lines.join("\n"), 0, 0);
+}
+/**
+ * Render MCP results dynamically so focus changes are reflected without
+ * reconstructing the owning tool component.
+ */
+export function renderMCPResult(
+	result: { content: Array<{ type: string; text?: string }>; details?: MCPToolDetails; isError?: boolean },
+	options: RenderResultOptions,
+	theme: Theme,
+	args?: Record<string, unknown>,
+): Component {
+	return {
+		render: width => renderMCPResultStatic(result, options, theme, args).render(width),
+		invalidate: () => {},
+	};
 }

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1295,7 +1295,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 								outputLines.push(
 									uiTheme.fg(
 										"dim",
-										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length})${expandHintSuffix(uiTheme)}`,
+										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length})${expandHintSuffix(uiTheme, options.expandHintCapability)}`,
 									),
 								);
 							}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -31,7 +31,7 @@ import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-ski
 import { checkComposerBashPolicy } from "./composer-bash-policy";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
-import { formatToolWorkingDirectory, replaceTabs } from "./render-utils";
+import { expandHintSuffix, formatToolWorkingDirectory, replaceTabs } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
@@ -1295,7 +1295,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 								outputLines.push(
 									uiTheme.fg(
 										"dim",
-										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length}) (ctrl+o to expand)`,
+										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length})${expandHintSuffix(uiTheme)}`,
 									),
 								);
 							}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1295,7 +1295,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 								outputLines.push(
 									uiTheme.fg(
 										"dim",
-										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length})${expandHintSuffix(uiTheme, options.expandHintCapability)}`,
+										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length})${expandHintSuffix(uiTheme, options.expandHintCapability!)}`,
 									),
 								);
 							}

--- a/packages/coding-agent/src/tools/debug.ts
+++ b/packages/coding-agent/src/tools/debug.ts
@@ -579,7 +579,10 @@ export const debugToolRenderer = {
 				const remaining = rawLines.length - displayedLines.length;
 				if (remaining > 0) {
 					displayedLines.push(
-						theme.fg("muted", `… ${remaining} more lines ${formatExpandHint(theme, options.expanded, true)}`),
+						theme.fg(
+							"muted",
+							`… ${remaining} more lines ${formatExpandHint(theme, options.expanded, true, (options as RenderResultOptions & { expandHintCapability: import("./render-utils").ExpandHintCapability }).expandHintCapability)}`,
+						),
 					);
 				}
 				return outputBlock.render(

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -949,7 +949,7 @@ export const evalToolRenderer = {
 							outputLines.push(
 								uiTheme.fg(
 									"dim",
-									`… ${outputContent.hiddenCount} more lines${expandHintSuffix(uiTheme, options.expandHintCapability)}`,
+									`… ${outputContent.hiddenCount} more lines${expandHintSuffix(uiTheme, options.expandHintCapability!)}`,
 								),
 							);
 						}
@@ -1069,7 +1069,7 @@ export const evalToolRenderer = {
 					outputLines.push("");
 					const skippedLine = uiTheme.fg(
 						"dim",
-						`… (${cachedSkipped} earlier lines, showing ${cachedLines.length} of ${cachedSkipped + cachedLines.length})${expandHintSuffix(uiTheme, options.expandHintCapability)}`,
+						`… (${cachedSkipped} earlier lines, showing ${cachedLines.length} of ${cachedSkipped + cachedLines.length})${expandHintSuffix(uiTheme, options.expandHintCapability!)}`,
 					);
 					outputLines.push(truncateToWidth(skippedLine, width));
 				}

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -947,7 +947,10 @@ export const evalToolRenderer = {
 						const outputLines = [...outputContent.lines];
 						if (!expanded && outputContent.hiddenCount > 0) {
 							outputLines.push(
-								uiTheme.fg("dim", `… ${outputContent.hiddenCount} more lines${expandHintSuffix(uiTheme)}`),
+								uiTheme.fg(
+									"dim",
+									`… ${outputContent.hiddenCount} more lines${expandHintSuffix(uiTheme, options.expandHintCapability)}`,
+								),
 							);
 						}
 						if (statusLines.length > 0) {
@@ -1066,7 +1069,7 @@ export const evalToolRenderer = {
 					outputLines.push("");
 					const skippedLine = uiTheme.fg(
 						"dim",
-						`… (${cachedSkipped} earlier lines, showing ${cachedLines.length} of ${cachedSkipped + cachedLines.length})${expandHintSuffix(uiTheme)}`,
+						`… (${cachedSkipped} earlier lines, showing ${cachedLines.length} of ${cachedSkipped + cachedLines.length})${expandHintSuffix(uiTheme, options.expandHintCapability)}`,
 					);
 					outputLines.push(truncateToWidth(skippedLine, width));
 				}

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -20,7 +20,7 @@ import {
 	resolveOutputSinkHeadBytes,
 	stripOutputNotice,
 } from "./output-meta";
-import { formatTitle, replaceTabs, shortenPath, truncateToWidth, wrapBrackets } from "./render-utils";
+import { expandHintSuffix, formatTitle, replaceTabs, shortenPath, truncateToWidth, wrapBrackets } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -947,7 +947,7 @@ export const evalToolRenderer = {
 						const outputLines = [...outputContent.lines];
 						if (!expanded && outputContent.hiddenCount > 0) {
 							outputLines.push(
-								uiTheme.fg("dim", `… ${outputContent.hiddenCount} more lines (ctrl+o to expand)`),
+								uiTheme.fg("dim", `… ${outputContent.hiddenCount} more lines${expandHintSuffix(uiTheme)}`),
 							);
 						}
 						if (statusLines.length > 0) {
@@ -1066,7 +1066,7 @@ export const evalToolRenderer = {
 					outputLines.push("");
 					const skippedLine = uiTheme.fg(
 						"dim",
-						`… (${cachedSkipped} earlier lines, showing ${cachedLines.length} of ${cachedSkipped + cachedLines.length}) (ctrl+o to expand)`,
+						`… (${cachedSkipped} earlier lines, showing ${cachedLines.length} of ${cachedSkipped + cachedLines.length})${expandHintSuffix(uiTheme)}`,
 					);
 					outputLines.push(truncateToWidth(skippedLine, width));
 				}

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -1545,7 +1545,7 @@ export function renderReadUrlResult(
 						? previewLines.map(line => uiTheme.fg("dim", line))
 						: [uiTheme.fg("dim", "(no content)")];
 				if (remaining > 0) {
-					const hint = formatExpandHint(uiTheme, expanded, true);
+					const hint = formatExpandHint(uiTheme, expanded, true, options.expandHintCapability!);
 					contentPreviewLines.push(uiTheme.fg("muted", `… ${remaining} more lines${hint ? ` ${hint}` : ""}`));
 				}
 				lastExpanded = expanded;

--- a/packages/coding-agent/src/tools/gh-renderer.ts
+++ b/packages/coding-agent/src/tools/gh-renderer.ts
@@ -234,6 +234,7 @@ function renderFailedLogs(
 	width: number,
 	theme: Theme,
 	expanded: boolean,
+	expandHintCapability: import("./render-utils").ExpandHintCapability,
 ): string[] {
 	if (failedLogs.length === 0) {
 		return [];
@@ -261,7 +262,12 @@ function renderFailedLogs(
 
 		if (!expanded && tailLines.length > previewLimit) {
 			const remaining = tailLines.length - previewLimit;
-			lines.push(theme.fg("dim", `  … ${remaining} more log lines ${formatExpandHint(theme, false, true)}`));
+			lines.push(
+				theme.fg(
+					"dim",
+					`  … ${remaining} more log lines ${formatExpandHint(theme, false, true, expandHintCapability)}`,
+				),
+			);
 		}
 	}
 
@@ -296,7 +302,9 @@ function buildWatchLines(
 		}
 	}
 
-	lines.push(...renderFailedLogs(watch.failedLogs ?? [], width, theme, options.expanded));
+	lines.push(
+		...renderFailedLogs(watch.failedLogs ?? [], width, theme, options.expanded, options.expandHintCapability!),
+	);
 	return lines;
 }
 
@@ -350,7 +358,7 @@ function renderFallbackComponent(
 				out.push(truncateVisualWidth(colored, lineWidth));
 			}
 			if (!expanded && remaining > 0) {
-				const hint = formatExpandHint(theme, expanded, true);
+				const hint = formatExpandHint(theme, expanded, true, options.expandHintCapability!);
 				const more = `${formatMoreItems(remaining, "line")}${hint ? ` ${hint}` : ""}`;
 				out.push(theme.fg("dim", more));
 			}

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -143,13 +143,34 @@ export function formatStatusIcon(status: ToolUIStatus, theme: Theme, spinnerFram
 }
 
 /**
+ * Tool-output expansion hints advertise `app.tools.expand` only while the
+ * composer owns input focus.
+ */
+let expandHintOwnerFocused = true;
+
+export function setExpandHintOwnerFocused(focused: boolean): void {
+	expandHintOwnerFocused = focused;
+}
+
+function formatExpandKey(): string {
+	return expandHintOwnerFocused ? formatKeyHints(getKeybindings().getKeys("app.tools.expand")) : "";
+}
+
+/**
  * Format the expand hint with proper theming.
- * Returns empty string if already expanded or there is nothing more to show.
+ * Returns empty string if already expanded, there is nothing more to show, or
+ * the composer does not own input focus.
  */
 export function formatExpandHint(theme: Theme, expanded?: boolean, hasMore?: boolean): string {
 	if (expanded || hasMore === false) return "";
-	const key = formatKeyHints(getKeybindings().getKeys("app.tools.expand"));
+	const key = formatExpandKey();
 	return key ? theme.fg("dim", wrapBrackets(`(${key} for more)`, theme)) : "";
+}
+
+/** Format a suffix for collapsed tool output that can be expanded. */
+export function expandHintSuffix(_theme: Theme): string {
+	const key = formatExpandKey();
+	return key ? ` (${key} to expand)` : "";
 }
 
 /**

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -147,9 +147,11 @@ export function formatStatusIcon(status: ToolUIStatus, theme: Theme, spinnerFram
  * hints may be displayed for that mode's composer.
  */
 export type ExpandHintCapability = () => boolean;
+/** Capability for non-interactive render contexts where expansion cannot open an overlay. */
+export const noExpandHintCapability: ExpandHintCapability = () => false;
 
-function formatExpandKey(capability: ExpandHintCapability | undefined): string {
-	return capability?.() ? formatKeyHints(getKeybindings().getKeys("app.tools.expand")) : "";
+function formatExpandKey(capability: ExpandHintCapability): string {
+	return capability() ? formatKeyHints(getKeybindings().getKeys("app.tools.expand")) : "";
 }
 
 /**
@@ -159,9 +161,9 @@ function formatExpandKey(capability: ExpandHintCapability | undefined): string {
  */
 export function formatExpandHint(
 	theme: Theme,
-	expanded?: boolean,
-	hasMore?: boolean,
-	capability?: ExpandHintCapability,
+	expanded: boolean | undefined,
+	hasMore: boolean | undefined,
+	capability: ExpandHintCapability,
 ): string {
 	if (expanded || hasMore === false) return "";
 	const key = formatExpandKey(capability);
@@ -169,7 +171,7 @@ export function formatExpandHint(
 }
 
 /** Format a suffix for collapsed tool output that can be expanded. */
-export function expandHintSuffix(_theme: Theme, capability?: ExpandHintCapability): string {
+export function expandHintSuffix(_theme: Theme, capability: ExpandHintCapability): string {
 	const key = formatExpandKey(capability);
 	return key ? ` (${key} to expand)` : "";
 }
@@ -289,6 +291,7 @@ export function formatDiagnostics(
 	expanded: boolean,
 	theme: Theme,
 	getLangIcon: (filePath: string) => string,
+	capability: ExpandHintCapability,
 ): string {
 	if (diag.messages.length === 0) return "";
 
@@ -405,7 +408,7 @@ export function formatDiagnostics(
 		output += `\n ${theme.fg("dim", theme.tree.last)} ${theme.fg(
 			"muted",
 			`… ${remaining} more`,
-		)} ${formatExpandHint(theme)}`;
+		)} ${formatExpandHint(theme, false, true, capability)}`;
 	}
 
 	return output;

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -10,8 +10,9 @@ import * as path from "node:path";
 import type { ToolCallContext } from "@gajae-code/agent-core";
 import type { Ellipsis } from "@gajae-code/natives";
 import type { Component } from "@gajae-code/tui";
-import { replaceTabs, truncateToWidth } from "@gajae-code/tui";
+import { getKeybindings, replaceTabs, truncateToWidth } from "@gajae-code/tui";
 import { pluralize } from "@gajae-code/utils";
+import { formatKeyHints } from "../config/keybindings";
 import { settings } from "../config/settings";
 import type { Theme } from "../modes/theme/theme";
 import { Hasher } from "../tui/utils";
@@ -74,9 +75,6 @@ export const TRUNCATE_LENGTHS = {
 	/** Very short (task previews, badges) */
 	SHORT: 40,
 } as const;
-
-/** Standard expand hint text */
-export const EXPAND_HINT = "(Ctrl+O for more)";
 
 // =============================================================================
 // Text Truncation Utilities
@@ -149,9 +147,9 @@ export function formatStatusIcon(status: ToolUIStatus, theme: Theme, spinnerFram
  * Returns empty string if already expanded or there is nothing more to show.
  */
 export function formatExpandHint(theme: Theme, expanded?: boolean, hasMore?: boolean): string {
-	if (expanded) return "";
-	if (hasMore === false) return "";
-	return theme.fg("dim", wrapBrackets(EXPAND_HINT, theme));
+	if (expanded || hasMore === false) return "";
+	const key = formatKeyHints(getKeybindings().getKeys("app.tools.expand"));
+	return key ? theme.fg("dim", wrapBrackets(`(${key} for more)`, theme)) : "";
 }
 
 /**

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -143,17 +143,13 @@ export function formatStatusIcon(status: ToolUIStatus, theme: Theme, spinnerFram
 }
 
 /**
- * Tool-output expansion hints advertise `app.tools.expand` only while the
- * composer owns input focus.
+ * Capability supplied by an interactive mode to determine whether expansion
+ * hints may be displayed for that mode's composer.
  */
-let expandHintOwnerFocused = true;
+export type ExpandHintCapability = () => boolean;
 
-export function setExpandHintOwnerFocused(focused: boolean): void {
-	expandHintOwnerFocused = focused;
-}
-
-function formatExpandKey(): string {
-	return expandHintOwnerFocused ? formatKeyHints(getKeybindings().getKeys("app.tools.expand")) : "";
+function formatExpandKey(capability: ExpandHintCapability | undefined): string {
+	return capability?.() ? formatKeyHints(getKeybindings().getKeys("app.tools.expand")) : "";
 }
 
 /**
@@ -161,15 +157,20 @@ function formatExpandKey(): string {
  * Returns empty string if already expanded, there is nothing more to show, or
  * the composer does not own input focus.
  */
-export function formatExpandHint(theme: Theme, expanded?: boolean, hasMore?: boolean): string {
+export function formatExpandHint(
+	theme: Theme,
+	expanded?: boolean,
+	hasMore?: boolean,
+	capability?: ExpandHintCapability,
+): string {
 	if (expanded || hasMore === false) return "";
-	const key = formatExpandKey();
+	const key = formatExpandKey(capability);
 	return key ? theme.fg("dim", wrapBrackets(`(${key} for more)`, theme)) : "";
 }
 
 /** Format a suffix for collapsed tool output that can be expanded. */
-export function expandHintSuffix(_theme: Theme): string {
-	const key = formatExpandKey();
+export function expandHintSuffix(_theme: Theme, capability?: ExpandHintCapability): string {
+	const key = formatExpandKey(capability);
 	return key ? ` (${key} to expand)` : "";
 }
 

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -267,7 +267,7 @@ export const sshToolRenderer = {
 							outputLines.push(
 								uiTheme.fg(
 									"dim",
-									`… (${skippedCount} earlier lines, showing ${visualLines.length} of ${totalVisualLines})${expandHintSuffix(uiTheme)}`,
+									`… (${skippedCount} earlier lines, showing ${visualLines.length} of ${totalVisualLines})${expandHintSuffix(uiTheme, options.expandHintCapability)}`,
 								),
 							);
 						}
@@ -282,7 +282,12 @@ export const sshToolRenderer = {
 						const remaining = outputLinesRaw.length - maxLines;
 						outputLines.push(...displayLines.map(line => uiTheme.fg("toolOutput", line)));
 						if (remaining > 0) {
-							outputLines.push(uiTheme.fg("dim", `… (${remaining} more lines)${expandHintSuffix(uiTheme)}`));
+							outputLines.push(
+								uiTheme.fg(
+									"dim",
+									`… (${remaining} more lines)${expandHintSuffix(uiTheme, options.expandHintCapability)}`,
+								),
+							);
 						}
 					}
 				}

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -17,6 +17,7 @@ import { renderStatusLine } from "../tui";
 import { CachedOutputBlock } from "../tui/output-block";
 import type { ToolSession } from ".";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
+import { expandHintSuffix } from "./render-utils";
 import { ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -266,7 +267,7 @@ export const sshToolRenderer = {
 							outputLines.push(
 								uiTheme.fg(
 									"dim",
-									`… (${skippedCount} earlier lines, showing ${visualLines.length} of ${totalVisualLines}) (ctrl+o to expand)`,
+									`… (${skippedCount} earlier lines, showing ${visualLines.length} of ${totalVisualLines})${expandHintSuffix(uiTheme)}`,
 								),
 							);
 						}
@@ -281,7 +282,7 @@ export const sshToolRenderer = {
 						const remaining = outputLinesRaw.length - maxLines;
 						outputLines.push(...displayLines.map(line => uiTheme.fg("toolOutput", line)));
 						if (remaining > 0) {
-							outputLines.push(uiTheme.fg("dim", `… (${remaining} more lines) (ctrl+o to expand)`));
+							outputLines.push(uiTheme.fg("dim", `… (${remaining} more lines)${expandHintSuffix(uiTheme)}`));
 						}
 					}
 				}

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -267,7 +267,7 @@ export const sshToolRenderer = {
 							outputLines.push(
 								uiTheme.fg(
 									"dim",
-									`… (${skippedCount} earlier lines, showing ${visualLines.length} of ${totalVisualLines})${expandHintSuffix(uiTheme, options.expandHintCapability)}`,
+									`… (${skippedCount} earlier lines, showing ${visualLines.length} of ${totalVisualLines})${expandHintSuffix(uiTheme, options.expandHintCapability!)}`,
 								),
 							);
 						}
@@ -285,7 +285,7 @@ export const sshToolRenderer = {
 							outputLines.push(
 								uiTheme.fg(
 									"dim",
-									`… (${remaining} more lines)${expandHintSuffix(uiTheme, options.expandHintCapability)}`,
+									`… (${remaining} more lines)${expandHintSuffix(uiTheme, options.expandHintCapability!)}`,
 								),
 							);
 						}

--- a/packages/coding-agent/src/tools/vim.ts
+++ b/packages/coding-agent/src/tools/vim.ts
@@ -881,6 +881,8 @@ export const vimToolRenderer = {
 				options.expanded,
 				uiTheme,
 				(filePath: string) => uiTheme.getLangIcon(getLanguageFromPath(filePath)),
+				(options as RenderResultOptions & { expandHintCapability: import("./render-utils").ExpandHintCapability })
+					.expandHintCapability,
 			);
 			if (diagText) {
 				sections.push({ lines: [diagText] });

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -843,6 +843,7 @@ function renderContentPreview(
 	expanded: boolean,
 	language: string | undefined,
 	uiTheme: Theme,
+	expandHintCapability: import("./render-utils").ExpandHintCapability,
 ): string {
 	if (!content) return "";
 	const rawLines = normalizeDisplayText(content).split("\n");
@@ -861,7 +862,7 @@ function renderContentPreview(
 		text += ` ${gutter}${body}\n`;
 	}
 	if (!expanded && hidden > 0) {
-		const hint = formatExpandHint(uiTheme, expanded, hidden > 0);
+		const hint = formatExpandHint(uiTheme, expanded, hidden > 0, expandHintCapability);
 		const moreLine = `${formatMoreItems(hidden, "line")}${hint ? ` ${hint}` : ""}`;
 		text += uiTheme.fg("dim", moreLine);
 	}
@@ -921,15 +922,19 @@ export const writeToolRenderer = {
 		return {
 			render(width: number) {
 				const { expanded } = options;
-				const key = new Hasher().bool(expanded).u32(width).digest();
+				const key = new Hasher().bool(expanded).bool(options.expandHintCapability!()).u32(width).digest();
 				if (cached?.key === key) return cached.lines;
 
 				let text = header;
-				text += renderContentPreview(fileContent, expanded, lang, uiTheme);
+				text += renderContentPreview(fileContent, expanded, lang, uiTheme, options.expandHintCapability!);
 
 				if (diagnostics) {
-					const diagText = formatDiagnostics(diagnostics, expanded, uiTheme, fp =>
-						uiTheme.getLangIcon(getLanguageFromPath(fp)),
+					const diagText = formatDiagnostics(
+						diagnostics,
+						expanded,
+						uiTheme,
+						fp => uiTheme.getLangIcon(getLanguageFromPath(fp)),
+						options.expandHintCapability!,
 					);
 					if (diagText.trim()) {
 						const diagLines = diagText.split("\n");

--- a/packages/coding-agent/src/tui/code-cell.ts
+++ b/packages/coding-agent/src/tui/code-cell.ts
@@ -9,6 +9,7 @@ import {
 	formatExpandHint,
 	formatMoreItems,
 	formatStatusIcon,
+	noExpandHintCapability,
 	replaceTabs,
 } from "../tools/render-utils";
 import { renderOutputBlock } from "./output-block";
@@ -106,7 +107,12 @@ export function renderCodeCell(options: CodeCellOptions, theme: Theme): string[]
 	const codeLines = highlightCode(visibleCode, language);
 	const hiddenCodeLines = rawCodeLines.length - maxCodeLines;
 	if (hiddenCodeLines > 0) {
-		const hint = formatExpandHint(theme, expanded, hiddenCodeLines > 0, options.expandHintCapability);
+		const hint = formatExpandHint(
+			theme,
+			expanded,
+			hiddenCodeLines > 0,
+			options.expandHintCapability ?? noExpandHintCapability,
+		);
 		const moreLine = `${formatMoreItems(hiddenCodeLines, "line")}${hint ? ` ${hint}` : ""}`;
 		codeLines.push(theme.fg("dim", moreLine));
 	}
@@ -121,7 +127,12 @@ export function renderCodeCell(options: CodeCellOptions, theme: Theme): string[]
 		outputLines.push(...displayLines);
 		const remaining = rawLines.length - maxLines;
 		if (remaining > 0) {
-			const hint = formatExpandHint(theme, expanded, remaining > 0);
+			const hint = formatExpandHint(
+				theme,
+				expanded,
+				remaining > 0,
+				options.expandHintCapability ?? noExpandHintCapability,
+			);
 			const moreLine = `${formatMoreItems(remaining, "line")}${hint ? ` ${hint}` : ""}`;
 			outputLines.push(theme.fg("dim", moreLine));
 		}
@@ -147,6 +158,7 @@ export interface MarkdownCellOptions {
 	outputMaxLines?: number;
 	contentMaxLines?: number;
 	expanded?: boolean;
+	expandHintCapability?: ExpandHintCapability;
 	width: number;
 }
 
@@ -173,7 +185,12 @@ export function renderMarkdownCell(options: MarkdownCellOptions, theme: Theme): 
 	const contentLines = allLines.slice(0, maxContentLines);
 	const hiddenContentLines = allLines.length - maxContentLines;
 	if (hiddenContentLines > 0) {
-		const hint = formatExpandHint(theme, expanded, hiddenContentLines > 0);
+		const hint = formatExpandHint(
+			theme,
+			expanded,
+			hiddenContentLines > 0,
+			options.expandHintCapability ?? noExpandHintCapability,
+		);
 		const moreLine = `${formatMoreItems(hiddenContentLines, "line")}${hint ? ` ${hint}` : ""}`;
 		contentLines.push(theme.fg("dim", moreLine));
 	}
@@ -188,7 +205,12 @@ export function renderMarkdownCell(options: MarkdownCellOptions, theme: Theme): 
 		outputLines.push(...displayLines);
 		const remaining = rawLines.length - maxLines;
 		if (remaining > 0) {
-			const hint = formatExpandHint(theme, expanded, remaining > 0);
+			const hint = formatExpandHint(
+				theme,
+				expanded,
+				remaining > 0,
+				options.expandHintCapability ?? noExpandHintCapability,
+			);
 			const moreLine = `${formatMoreItems(remaining, "line")}${hint ? ` ${hint}` : ""}`;
 			outputLines.push(theme.fg("dim", moreLine));
 		}

--- a/packages/coding-agent/src/tui/code-cell.ts
+++ b/packages/coding-agent/src/tui/code-cell.ts
@@ -3,6 +3,7 @@
  */
 import { Markdown } from "@gajae-code/tui";
 import { getMarkdownTheme, highlightCode, type Theme } from "../modes/theme/theme";
+import type { ExpandHintCapability } from "../tools/render-utils";
 import {
 	formatDuration,
 	formatExpandHint,
@@ -26,6 +27,7 @@ export interface CodeCellOptions {
 	outputMaxLines?: number;
 	codeMaxLines?: number;
 	expanded?: boolean;
+	expandHintCapability?: ExpandHintCapability;
 	width: number;
 }
 
@@ -104,7 +106,7 @@ export function renderCodeCell(options: CodeCellOptions, theme: Theme): string[]
 	const codeLines = highlightCode(visibleCode, language);
 	const hiddenCodeLines = rawCodeLines.length - maxCodeLines;
 	if (hiddenCodeLines > 0) {
-		const hint = formatExpandHint(theme, expanded, hiddenCodeLines > 0);
+		const hint = formatExpandHint(theme, expanded, hiddenCodeLines > 0, options.expandHintCapability);
 		const moreLine = `${formatMoreItems(hiddenCodeLines, "line")}${hint ? ` ${hint}` : ""}`;
 		codeLines.push(theme.fg("dim", moreLine));
 	}

--- a/packages/coding-agent/src/web/search/render.ts
+++ b/packages/coding-agent/src/web/search/render.ts
@@ -16,6 +16,7 @@ import {
 	formatStatusIcon,
 	getDomain,
 	getPreviewLines,
+	noExpandHintCapability,
 	PREVIEW_LIMITS,
 	TRUNCATE_LENGTHS,
 	truncateToWidth,
@@ -35,14 +36,19 @@ const MAX_QUERY_PREVIEW = 2;
 const MAX_QUERY_LEN = 90;
 const MAX_REQUEST_ID_LEN = 36;
 
-function renderFallbackText(contentText: string, expanded: boolean, theme: Theme): Component {
+function renderFallbackText(
+	contentText: string,
+	expanded: boolean,
+	theme: Theme,
+	expandHintCapability: import("../../tools/render-utils").ExpandHintCapability,
+): Component {
 	const lines = contentText.split("\n").filter(line => line.trim());
 	const maxLines = expanded ? lines.length : 6;
 	const displayLines = lines.slice(0, maxLines).map(line => truncateToWidth(line.trim(), 110));
 	const remaining = lines.length - displayLines.length;
 
 	const headerIcon = formatStatusIcon("warning", theme);
-	const expandHint = formatExpandHint(theme, expanded, remaining > 0);
+	const expandHint = formatExpandHint(theme, expanded, remaining > 0, expandHintCapability);
 	let text = `${headerIcon} ${theme.fg("dim", "Response")}${expandHint}`;
 
 	if (displayLines.length === 0) {
@@ -90,7 +96,12 @@ export function renderSearchResult(
 	const rawText = result.content?.find(block => block.type === "text")?.text?.trim() ?? "";
 	const response = details?.response;
 	if (!response) {
-		return renderFallbackText(rawText, options.expanded, theme);
+		return renderFallbackText(
+			rawText,
+			options.expanded,
+			theme,
+			options.expandHintCapability ?? noExpandHintCapability,
+		);
 	}
 
 	const sources = Array.isArray(response.sources) ? response.sources : [];

--- a/packages/coding-agent/test/modes/components/expand-hint-focus.test.ts
+++ b/packages/coding-agent/test/modes/components/expand-hint-focus.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Container, Input, setKeybindings, Text, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
+import { KeybindingsManager } from "../../../src/config/keybindings";
+import { resetSettingsForTest, Settings } from "../../../src/config/settings";
+import { BashExecutionComponent } from "../../../src/modes/components/bash-execution";
+import { BranchSummaryMessageComponent } from "../../../src/modes/components/branch-summary-message";
+import { CompactionSummaryMessageComponent } from "../../../src/modes/components/compaction-summary-message";
+import { EvalExecutionComponent } from "../../../src/modes/components/eval-execution";
+import { ReadToolGroupComponent } from "../../../src/modes/components/read-tool-group";
+import { TtsrNotificationComponent } from "../../../src/modes/components/ttsr-notification";
+import { ExtensionUiController } from "../../../src/modes/controllers/extension-ui-controller";
+import { initTheme } from "../../../src/modes/theme/theme";
+import type { InteractiveModeContext } from "../../../src/modes/types";
+
+const HINT = "Ctrl+O";
+
+type UiFixture = { ui: TUI; editor: Input; terminal: VirtualTerminal };
+
+function createUi(): UiFixture {
+	const terminal = new VirtualTerminal();
+	const ui = new TUI(terminal);
+	const editor = new Input();
+	ui.addChild(editor);
+	ui.setFocus(editor);
+	ui.start();
+	return { ui, editor, terminal };
+}
+
+function capability({ ui, editor }: UiFixture): () => boolean {
+	return () => !ui.hasOverlay() && (ui.focusedComponent === null || ui.focusedComponent === editor);
+}
+
+function render(component: { render(width: number): string[] }): string {
+	return Bun.stripANSI(component.render(100).join("\n"));
+}
+
+function manyLines(): string {
+	return Array.from({ length: 25 }, (_value, index) => `output ${index + 1}`).join("\n");
+}
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme(false);
+	setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "ctrl+o" }));
+});
+afterEach(() => {
+	setKeybindings(KeybindingsManager.inMemory());
+});
+
+describe("instance-scoped expansion hints", () => {
+	it("keeps concurrent TUI hint capabilities isolated", () => {
+		const first = createUi();
+		const second = createUi();
+		const firstComponent = new BashExecutionComponent("echo first", first.ui, false, capability(first));
+		const secondComponent = new BashExecutionComponent("echo second", second.ui, false, capability(second));
+		firstComponent.setComplete(0, false, { output: manyLines() });
+		secondComponent.setComplete(0, false, { output: manyLines() });
+
+		expect(render(firstComponent)).toContain(HINT);
+		expect(render(secondComponent)).toContain(HINT);
+		const overlay = first.ui.showOverlay(new Text("overlay"));
+		expect(render(firstComponent)).not.toContain(HINT);
+		expect(render(secondComponent)).toContain(HINT);
+		overlay.hide();
+		expect(render(firstComponent)).toContain(HINT);
+	});
+
+	it("tracks nested, disposed, and callback-hidden overlays through the TUI lifecycle", () => {
+		const fixture = createUi();
+		const canExpand = capability(fixture);
+		const first = fixture.ui.showOverlay(new Text("first"));
+		const second = fixture.ui.showOverlay(new Text("second"));
+		expect(canExpand()).toBe(false);
+		second.hide();
+		expect(canExpand()).toBe(false);
+		first.hide();
+		expect(canExpand()).toBe(true);
+
+		const disposable = new Container();
+		const disposableOverlay = fixture.ui.showOverlay(disposable);
+		expect(canExpand()).toBe(false);
+		disposable.dispose();
+		disposableOverlay.hide();
+		expect(canExpand()).toBe(true);
+
+		let visible = true;
+		fixture.ui.showOverlay(new Text("conditional"), { visible: () => visible });
+		expect(canExpand()).toBe(false);
+		visible = false;
+		fixture.terminal.sendInput("x");
+		expect(canExpand()).toBe(true);
+	});
+
+	it("uses current overlay state on the first post-overlay frame for every cached hint family", () => {
+		const fixture = createUi();
+		const canExpand = capability(fixture);
+		const components = [
+			new BranchSummaryMessageComponent({ summary: "summary" } as never, canExpand),
+			new CompactionSummaryMessageComponent({ summary: "summary", tokensBefore: 1234 } as never, canExpand),
+			new TtsrNotificationComponent([{ name: "rule", content: "one\ntwo\nthree" } as never], canExpand),
+			new BashExecutionComponent("echo output", fixture.ui, false, canExpand),
+			new EvalExecutionComponent("print('output')", fixture.ui, false, "python", canExpand),
+			new ReadToolGroupComponent({ showContentPreview: true, expandHintCapability: canExpand }),
+		];
+		(components[3] as BashExecutionComponent).setComplete(0, false, { output: manyLines() });
+		(components[4] as EvalExecutionComponent).setComplete(0, false, { output: manyLines() });
+		const readGroup = components[5] as ReadToolGroupComponent;
+		readGroup.updateArgs({ path: "/tmp/example.ts" }, "read");
+		readGroup.updateResult({ content: [{ type: "text", text: "one\ntwo\nthree\nfour" }] }, false, "read");
+
+		for (const component of components) expect(render(component)).toContain(HINT);
+		const overlay = fixture.ui.showOverlay(new Text("overlay"));
+		for (const component of components) expect(render(component)).not.toContain(HINT);
+		overlay.hide();
+		for (const component of components) expect(render(component)).toContain(HINT);
+	});
+
+	it("suppresses hints for the real extension custom-overlay path", async () => {
+		const fixture = createUi();
+		const component = new BashExecutionComponent("echo output", fixture.ui, false, capability(fixture));
+		component.setComplete(0, false, { output: manyLines() });
+		let close: ((result: undefined) => void) | undefined;
+		(fixture.editor as unknown as { getText: () => string }).getText = () => fixture.editor.getValue();
+		const controller = new ExtensionUiController({
+			ui: fixture.ui,
+			editor: fixture.editor,
+			editorContainer: new Container(),
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext);
+
+		const result = controller.showHookCustom<undefined>(
+			(_ui, _theme, _keybindings, done) => {
+				close = done;
+				return new Text("extension overlay");
+			},
+			{ overlay: true },
+		);
+		await Promise.resolve();
+		expect(fixture.ui.hasOverlay()).toBe(true);
+		expect(render(component)).not.toContain(HINT);
+		close?.(undefined);
+		await result;
+		expect(fixture.ui.hasOverlay()).toBe(false);
+		expect(render(component)).toContain(HINT);
+	});
+});

--- a/packages/coding-agent/test/modes/components/expand-hint-focus.test.ts
+++ b/packages/coding-agent/test/modes/components/expand-hint-focus.test.ts
@@ -8,10 +8,14 @@ import { BranchSummaryMessageComponent } from "../../../src/modes/components/bra
 import { CompactionSummaryMessageComponent } from "../../../src/modes/components/compaction-summary-message";
 import { EvalExecutionComponent } from "../../../src/modes/components/eval-execution";
 import { ReadToolGroupComponent } from "../../../src/modes/components/read-tool-group";
+import { ToolExecutionComponent } from "../../../src/modes/components/tool-execution";
 import { TtsrNotificationComponent } from "../../../src/modes/components/ttsr-notification";
 import { ExtensionUiController } from "../../../src/modes/controllers/extension-ui-controller";
-import { initTheme } from "../../../src/modes/theme/theme";
+import { getThemeByName, initTheme } from "../../../src/modes/theme/theme";
 import type { InteractiveModeContext } from "../../../src/modes/types";
+import { renderMCPResult } from "../../../src/runtime-mcp/render";
+import { writeToolRenderer } from "../../../src/tools/write";
+import { renderCodeCell, renderMarkdownCell } from "../../../src/tui/code-cell";
 
 const HINT = "Ctrl+O";
 
@@ -143,6 +147,73 @@ describe("instance-scoped expansion hints", () => {
 		close?.(undefined);
 		await result;
 		expect(fixture.ui.hasOverlay()).toBe(false);
+		expect(render(component)).toContain(HINT);
+	});
+	it("refreshes generic fallback, runtime MCP, and secondary code-cell hints across overlays", async () => {
+		const fixture = createUi();
+		const canExpand = capability(fixture);
+		const generic = new ToolExecutionComponent(
+			"unknown",
+			{},
+			{},
+			undefined,
+			fixture.ui,
+			"/tmp",
+			undefined,
+			canExpand,
+		);
+		generic.updateResult({ content: [{ type: "text", text: manyLines() }] });
+		const theme = await getThemeByName("red-claw");
+		expect(theme).toBeDefined();
+		const mcp = renderMCPResult(
+			{ content: [{ type: "text", text: manyLines() }] },
+			{ expanded: false, isPartial: false, expandHintCapability: canExpand },
+			theme!,
+		);
+		const code = () =>
+			renderCodeCell(
+				{ code: manyLines(), expanded: false, codeMaxLines: 1, width: 100, expandHintCapability: canExpand },
+				theme!,
+			);
+		const markdown = () =>
+			renderMarkdownCell(
+				{ content: manyLines(), expanded: false, contentMaxLines: 1, width: 100, expandHintCapability: canExpand },
+				theme!,
+			);
+
+		expect(render(generic)).toContain(HINT);
+		expect(render(mcp)).toContain(HINT);
+		expect(Bun.stripANSI(code().join("\n"))).toContain(HINT);
+		expect(Bun.stripANSI(markdown().join("\n"))).toContain(HINT);
+		const overlay = fixture.ui.showOverlay(new Text("overlay"));
+		generic.setExpanded(false);
+		expect(render(generic)).not.toContain(HINT);
+		expect(render(mcp)).not.toContain(HINT);
+		expect(Bun.stripANSI(code().join("\n"))).not.toContain(HINT);
+		expect(Bun.stripANSI(markdown().join("\n"))).not.toContain(HINT);
+		overlay.hide();
+		generic.setExpanded(false);
+		expect(render(generic)).toContain(HINT);
+		expect(render(mcp)).toContain(HINT);
+		expect(Bun.stripANSI(code().join("\n"))).toContain(HINT);
+		expect(Bun.stripANSI(markdown().join("\n"))).toContain(HINT);
+	});
+
+	it("threads write preview hints through render options", async () => {
+		const fixture = createUi();
+		const canExpand = capability(fixture);
+		const theme = await getThemeByName("red-claw");
+		expect(theme).toBeDefined();
+		const component = writeToolRenderer.renderResult(
+			{ content: [], details: undefined },
+			{ expanded: false, isPartial: false, expandHintCapability: canExpand },
+			theme!,
+			{ path: "/tmp/output.ts", content: manyLines() },
+		);
+		expect(render(component)).toContain(HINT);
+		const overlay = fixture.ui.showOverlay(new Text("overlay"));
+		expect(render(component)).not.toContain(HINT);
+		overlay.hide();
 		expect(render(component)).toContain(HINT);
 	});
 });

--- a/packages/coding-agent/test/modes/components/pinned-folds.test.ts
+++ b/packages/coding-agent/test/modes/components/pinned-folds.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { Container, type TUI } from "@gajae-code/tui";
+import { resetSettingsForTest, Settings } from "../../../src/config/settings.js";
+import { AssistantMessageComponent } from "../../../src/modes/components/assistant-message.js";
+import { ToolExecutionComponent } from "../../../src/modes/components/tool-execution.js";
+import { InputController } from "../../../src/modes/controllers/input-controller.js";
+import { initTheme } from "../../../src/modes/theme/theme.js";
+import type { InteractiveModeContext } from "../../../src/modes/types.js";
+
+const uiStub = { requestRender() {} } as unknown as TUI;
+
+function render(component: ToolExecutionComponent | AssistantMessageComponent): string {
+	return Bun.stripANSI(component.render(100).join("\n"));
+}
+
+function assistantMessage(thinking: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "thinking", thinking }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+function toolResult(lines: number): { content: Array<{ type: string; text: string }> } {
+	return {
+		content: [
+			{
+				type: "text",
+				text: Array.from({ length: lines }, (_, index) =>
+					index === 0 ? "fold-start-marker" : `line ${index + 1}`,
+				).join("\n"),
+			},
+		],
+	};
+}
+
+describe("manual output folds", () => {
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		await initTheme(false);
+	});
+
+	it("retains a manually expanded tool result when its automatic completion state changes", () => {
+		const component = new ToolExecutionComponent("bash", { command: "echo output" }, {}, undefined, uiStub);
+		component.setManuallyExpanded(true);
+		component.updateResult(toolResult(30), false);
+		component.setExpanded(false);
+
+		expect(render(component)).toContain("fold-start-marker");
+	});
+
+	it("keeps automatic folding behavior for untouched tool results", () => {
+		const component = new ToolExecutionComponent("bash", { command: "echo output" }, {}, undefined, uiStub);
+		component.updateResult(toolResult(30), false);
+		component.setExpanded(false);
+
+		expect(render(component)).not.toContain("fold-start-marker");
+	});
+
+	it("lets the global fold toggle override an earlier pin", () => {
+		const component = new ToolExecutionComponent("bash", { command: "echo output" }, {}, undefined, uiStub);
+		const chatContainer = new Container();
+		chatContainer.addChild(component);
+		const ctx = { chatContainer, toolOutputExpanded: false, ui: uiStub } as unknown as InteractiveModeContext;
+		const controller = new InputController(ctx);
+
+		component.setManuallyExpanded(true);
+		controller.setToolsExpanded(false);
+		component.updateResult(toolResult(30), false);
+
+		expect(render(component)).not.toContain("fold-start-marker");
+	});
+
+	it("keeps hidden thinking hidden through streaming updates", () => {
+		const thinking = { type: "thinking" as const, thinking: "private thought" };
+		const component = new AssistantMessageComponent(assistantMessage(thinking.thinking));
+		component.setHideThinkingBlock(true);
+		thinking.thinking += " still private";
+		component.updateContent(assistantMessage(thinking.thinking), { streaming: true });
+
+		const output = render(component);
+		expect(output).toContain("Thinking...");
+		expect(output).not.toContain("private thought");
+	});
+});

--- a/packages/coding-agent/test/modes/components/pinned-folds.test.ts
+++ b/packages/coding-agent/test/modes/components/pinned-folds.test.ts
@@ -3,6 +3,7 @@ import type { AssistantMessage } from "@gajae-code/ai";
 import { Container, type TUI } from "@gajae-code/tui";
 import { resetSettingsForTest, Settings } from "../../../src/config/settings.js";
 import { AssistantMessageComponent } from "../../../src/modes/components/assistant-message.js";
+import { ReadToolGroupComponent } from "../../../src/modes/components/read-tool-group.js";
 import { ToolExecutionComponent } from "../../../src/modes/components/tool-execution.js";
 import { InputController } from "../../../src/modes/controllers/input-controller.js";
 import { initTheme } from "../../../src/modes/theme/theme.js";
@@ -10,7 +11,7 @@ import type { InteractiveModeContext } from "../../../src/modes/types.js";
 
 const uiStub = { requestRender() {} } as unknown as TUI;
 
-function render(component: ToolExecutionComponent | AssistantMessageComponent): string {
+function render(component: ToolExecutionComponent | ReadToolGroupComponent | AssistantMessageComponent): string {
 	return Bun.stripANSI(component.render(100).join("\n"));
 }
 
@@ -83,6 +84,20 @@ describe("manual output folds", () => {
 		component.updateResult(toolResult(30), false);
 
 		expect(render(component)).not.toContain("fold-start-marker");
+	});
+	it("lets the global fold toggle override an earlier read-group pin", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		const chatContainer = new Container();
+		chatContainer.addChild(component);
+		const ctx = { chatContainer, toolOutputExpanded: false, ui: uiStub } as unknown as InteractiveModeContext;
+		const controller = new InputController(ctx);
+
+		component.updateArgs({ path: "/tmp/example.ts" }, "read");
+		component.setManuallyExpanded(true);
+		controller.setToolsExpanded(false);
+		component.updateResult(toolResult(4), false, "read");
+
+		expect(render(component)).not.toContain("line 4");
 	});
 
 	it("keeps hidden thinking hidden through streaming updates", () => {

--- a/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
@@ -14,6 +14,7 @@ type Fixture = {
 	ctx: InteractiveModeContext;
 	getActions: () => ExtensionActions;
 	getCommandActions: () => ExtensionCommandContextActions;
+	getUiContext: () => ExtensionUIContext;
 	setNextSessionId: (id: string) => void;
 	rebuildInitialMessages: Mock<(policy: TranscriptRebuildPolicy) => void>;
 	rebuildChatFromMessages: Mock<(policy: TranscriptRebuildPolicy) => void>;
@@ -23,6 +24,7 @@ type Fixture = {
 function createFixture(initialSessionId = "session-a"): Fixture {
 	let actions: ExtensionActions | undefined;
 	let commandActions: ExtensionCommandContextActions | undefined;
+	let uiContext: ExtensionUIContext | undefined;
 	let sessionId = initialSessionId;
 	let nextSessionId = initialSessionId;
 	const rebuildInitialMessages = vi.fn<(policy: TranscriptRebuildPolicy) => void>();
@@ -33,10 +35,11 @@ function createFixture(initialSessionId = "session-a"): Fixture {
 			capturedActions: ExtensionActions,
 			_contextActions: ExtensionContextActions,
 			capturedCommandActions?: ExtensionCommandContextActions,
-			_uiContext?: ExtensionUIContext,
+			capturedUiContext?: ExtensionUIContext,
 		): void {
 			actions = capturedActions;
 			commandActions = capturedCommandActions;
+			uiContext = capturedUiContext;
 		},
 		onError: vi.fn(),
 		emit: vi.fn(async () => undefined),
@@ -88,6 +91,10 @@ function createFixture(initialSessionId = "session-a"): Fixture {
 			if (!commandActions) throw new Error("Extension command actions were not initialized");
 			return commandActions;
 		},
+		getUiContext: () => {
+			if (!uiContext) throw new Error("Extension UI context was not initialized");
+			return uiContext;
+		},
 		setNextSessionId: id => {
 			nextSessionId = id;
 		},
@@ -98,6 +105,14 @@ function createFixture(initialSessionId = "session-a"): Fixture {
 }
 
 describe("ExtensionUiController transcript rebuild policy", () => {
+	it("routes extension fold choices through the same explicit pinning action as the user shortcut", async () => {
+		const fixture = createFixture();
+		await fixture.controller.initHooksAndCustomTools();
+
+		fixture.getUiContext().setToolsExpanded(true);
+
+		expect(fixture.ctx.setToolsExpanded).toHaveBeenCalledWith(true);
+	});
 	it("resets identity when a hook-runner switch loads a different session id from the same path", async () => {
 		const fixture = createFixture();
 		fixture.setNextSessionId("session-b");

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
-import { setKeybindings } from "@gajae-code/tui";
+import { Input, setKeybindings, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 import { KeybindingsManager } from "../src/config/keybindings";
 import { getDefault } from "../src/config/settings-schema";
 import { ReadToolGroupComponent, readArgsTargetInternalUrl } from "../src/modes/components/read-tool-group";
@@ -16,6 +17,13 @@ describe("ReadToolGroupComponent", () => {
 	beforeEach(() => {
 		setKeybindings(KeybindingsManager.inMemory());
 	});
+	function expandHintCapability(): () => boolean {
+		const ui = new TUI(new VirtualTerminal());
+		const editor = new Input();
+		ui.addChild(editor);
+		ui.setFocus(editor);
+		return () => !ui.hasOverlay() && (ui.focusedComponent === null || ui.focusedComponent === editor);
+	}
 
 	it("keeps inline read previews disabled by default", () => {
 		expect(getDefault("read.toolResultPreview")).toBe(false);
@@ -58,7 +66,10 @@ describe("ReadToolGroupComponent", () => {
 
 	it("highlights only the collapsed preview lines", () => {
 		const highlightSpy = vi.spyOn(themeModule, "highlightCode");
-		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		const component = new ReadToolGroupComponent({
+			showContentPreview: true,
+			expandHintCapability: expandHintCapability(),
+		});
 		component.updateArgs({ path: "/tmp/example.ts" }, "read-2");
 		component.updateResult(
 			{
@@ -150,7 +161,10 @@ describe("ReadToolGroupComponent", () => {
 	});
 
 	it("uses the configured expansion key hint and omits it when unbound", () => {
-		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		const component = new ReadToolGroupComponent({
+			showContentPreview: true,
+			expandHintCapability: expandHintCapability(),
+		});
 		component.updateArgs({ path: "/tmp/example.ts" }, "read");
 		component.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "read");
 

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { setKeybindings } from "@gajae-code/tui";
+import { KeybindingsManager } from "../src/config/keybindings";
 import { getDefault } from "../src/config/settings-schema";
 import { ReadToolGroupComponent, readArgsTargetInternalUrl } from "../src/modes/components/read-tool-group";
 import * as themeModule from "../src/modes/theme/theme";
@@ -10,6 +12,9 @@ describe("ReadToolGroupComponent", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+	});
+	beforeEach(() => {
+		setKeybindings(KeybindingsManager.inMemory());
 	});
 
 	it("keeps inline read previews disabled by default", () => {
@@ -92,6 +97,84 @@ describe("ReadToolGroupComponent", () => {
 		const matches = rendered.match(/Read \/tmp\/example\.ts:L10-L20/g) ?? [];
 
 		expect(matches).toHaveLength(1);
+	});
+	it("retains a manual collapse through automatic updates across mixed read entries", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/success.ts" }, "success");
+		component.updateArgs({ path: "/tmp/error.ts" }, "error");
+		component.updateArgs({ path: "/tmp/warning.ts" }, "warning");
+		component.setManuallyExpanded(false);
+		component.updateArgs({ path: "/tmp/success-renamed.ts" }, "success");
+		component.setExpanded(true);
+		component.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "success");
+		component.updateResult({ content: [{ type: "text", text: "e\nf\ng\nh" }], isError: true }, false, "error");
+		component.updateResult(
+			{
+				content: [{ type: "text", text: "i\nj\nk\nl" }],
+				details: { suffixResolution: { from: "/tmp/warn.ts", to: "/tmp/warning.ts" } },
+			},
+			false,
+			"warning",
+		);
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).not.toContain("\nd");
+		expect(rendered).not.toContain("\nh");
+		expect(rendered).not.toContain("\nl");
+	});
+
+	it("retains a manual expansion through automatic updates", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/example.ts" }, "read");
+		component.setManuallyExpanded(true);
+		component.updateArgs({ path: "/tmp/example-renamed.ts" }, "read");
+		component.setExpanded(false);
+		component.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "read");
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("d");
+	});
+
+	it("follows automatic expansion until explicitly pinned, then applies the new pin", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/example.ts" }, "read");
+		component.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "read");
+		component.setExpanded(true);
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("d");
+
+		component.setManuallyExpanded(false);
+		expect(Bun.stripANSI(component.render(120).join("\n"))).not.toContain("\nd");
+
+		component.setManuallyExpanded(true);
+		component.setExpanded(false);
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("d");
+	});
+
+	it("uses the configured expansion key hint and omits it when unbound", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/example.ts" }, "read");
+		component.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "read");
+
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+x" }));
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("Alt+X for more");
+
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": [] }));
+		component.invalidate();
+		expect(Bun.stripANSI(component.render(120).join("\n"))).not.toContain("for more");
+	});
+
+	it("resets manual fold provenance when a transcript rebuild creates a new component", () => {
+		const original = new ReadToolGroupComponent({ showContentPreview: true });
+		original.updateArgs({ path: "/tmp/example.ts" }, "read");
+		original.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "read");
+		original.setManuallyExpanded(true);
+
+		const rebuilt = new ReadToolGroupComponent({ showContentPreview: true });
+		rebuilt.setExpanded(false);
+		rebuilt.updateArgs({ path: "/tmp/example.ts" }, "read");
+		rebuilt.updateResult({ content: [{ type: "text", text: "a\nb\nc\nd" }] }, false, "read");
+
+		expect(Bun.stripANSI(original.render(120).join("\n"))).toContain("d");
+		expect(Bun.stripANSI(rebuilt.render(120).join("\n"))).not.toContain("\nd");
 	});
 });
 

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -1,16 +1,102 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getThemeByName } from "@gajae-code/coding-agent/modes/theme/theme";
+import { KeybindingsManager } from "@gajae-code/coding-agent/config/keybindings";
+import { BranchSummaryMessageComponent } from "@gajae-code/coding-agent/modes/components/branch-summary-message";
+import { buildStatusFooter } from "@gajae-code/coding-agent/modes/components/execution-shared";
+import { getThemeByName, setThemeInstance, theme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { BranchSummaryMessage } from "@gajae-code/coding-agent/session/messages";
+import { evalToolRenderer } from "@gajae-code/coding-agent/tools/eval";
 import {
 	dedupeParseErrors,
+	expandHintSuffix,
 	formatCodeFrameLine,
 	formatDiagnostics,
+	formatExpandHint,
 	formatParseErrors,
 	formatScreenshot,
 	getPreviewLines,
+	setExpandHintOwnerFocused,
 	shortenPath,
 } from "@gajae-code/coding-agent/tools/render-utils";
+import { setKeybindings } from "@gajae-code/tui";
+
+beforeAll(async () => {
+	const testTheme = await getThemeByName("red-claw");
+	if (!testTheme) throw new Error("Failed to load test theme");
+	setThemeInstance(testTheme);
+});
+
+afterEach(() => {
+	setKeybindings(KeybindingsManager.inMemory());
+	setExpandHintOwnerFocused(true);
+});
+
+describe("tool-output expansion hints", () => {
+	it("uses the configured binding in execution, eval, and summary surfaces", () => {
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+x" }));
+
+		const footer = buildStatusFooter({
+			status: "complete",
+			exitCode: 0,
+			truncation: undefined,
+			hiddenLineCount: 3,
+		});
+		const summary = new BranchSummaryMessageComponent({ summary: "Summary" } as BranchSummaryMessage);
+
+		expect(Bun.stripANSI(footer!.render(120).join("\n"))).toContain("3 more lines (Alt+X to expand)");
+		expect(Bun.stripANSI(summary.render(120).join("\n"))).toContain("Branch summary (Alt+X to expand)");
+		const evalOutput = evalToolRenderer.renderResult(
+			{ content: [{ type: "text", text: Array.from({ length: 20 }, (_, index) => `line ${index}`).join("\n") }] },
+			{ expanded: false, renderContext: { expanded: false, previewLines: 1 } } as never,
+			theme,
+		);
+
+		expect(Bun.stripANSI(evalOutput.render(120).join("\n"))).toContain("Alt+X to expand");
+	});
+
+	it("preserves surrounding output when the action is unbound", () => {
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": [] }));
+
+		expect(expandHintSuffix(theme)).toBe("");
+		expect(
+			Bun.stripANSI(
+				buildStatusFooter({
+					status: "complete",
+					exitCode: 0,
+					truncation: undefined,
+					hiddenLineCount: 3,
+				})!
+					.render(120)
+					.join("\n"),
+			),
+		).toContain("3 more lines");
+		expect(
+			Bun.stripANSI(
+				buildStatusFooter({
+					status: "complete",
+					exitCode: 0,
+					truncation: undefined,
+					hiddenLineCount: 3,
+				})!
+					.render(120)
+					.join("\n"),
+			),
+		).not.toContain("to expand");
+	});
+
+	it("suppresses hints while the composer does not own focus", () => {
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+x" }));
+
+		setExpandHintOwnerFocused(false);
+		expect(expandHintSuffix(theme)).toBe("");
+		expect(formatExpandHint(theme)).toBe("");
+
+		setExpandHintOwnerFocused(true);
+		expect(expandHintSuffix(theme)).toContain("Alt+X to expand");
+		expect(Bun.stripANSI(formatExpandHint(theme))).toContain("Alt+X for more");
+	});
+});
 
 describe("parse error formatting", () => {
 	it("deduplicates parse errors while preserving order", () => {

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -262,6 +262,7 @@ describe("formatDiagnostics", () => {
 			true,
 			theme!,
 			() => "go",
+			() => false,
 		);
 
 		expect(formatted).not.toContain("\t");

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -16,7 +16,6 @@ import {
 	formatParseErrors,
 	formatScreenshot,
 	getPreviewLines,
-	setExpandHintOwnerFocused,
 	shortenPath,
 } from "@gajae-code/coding-agent/tools/render-utils";
 import { setKeybindings } from "@gajae-code/tui";
@@ -29,10 +28,10 @@ beforeAll(async () => {
 
 afterEach(() => {
 	setKeybindings(KeybindingsManager.inMemory());
-	setExpandHintOwnerFocused(true);
 });
 
 describe("tool-output expansion hints", () => {
+	const focused = () => true;
 	it("uses the configured binding in execution, eval, and summary surfaces", () => {
 		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+x" }));
 
@@ -41,14 +40,19 @@ describe("tool-output expansion hints", () => {
 			exitCode: 0,
 			truncation: undefined,
 			hiddenLineCount: 3,
+			expandHintCapability: focused,
 		});
-		const summary = new BranchSummaryMessageComponent({ summary: "Summary" } as BranchSummaryMessage);
+		const summary = new BranchSummaryMessageComponent({ summary: "Summary" } as BranchSummaryMessage, focused);
 
 		expect(Bun.stripANSI(footer!.render(120).join("\n"))).toContain("3 more lines (Alt+X to expand)");
 		expect(Bun.stripANSI(summary.render(120).join("\n"))).toContain("Branch summary (Alt+X to expand)");
 		const evalOutput = evalToolRenderer.renderResult(
 			{ content: [{ type: "text", text: Array.from({ length: 20 }, (_, index) => `line ${index}`).join("\n") }] },
-			{ expanded: false, renderContext: { expanded: false, previewLines: 1 } } as never,
+			{
+				expanded: false,
+				renderContext: { expanded: false, previewLines: 1 },
+				expandHintCapability: focused,
+			} as never,
 			theme,
 		);
 
@@ -58,7 +62,7 @@ describe("tool-output expansion hints", () => {
 	it("preserves surrounding output when the action is unbound", () => {
 		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": [] }));
 
-		expect(expandHintSuffix(theme)).toBe("");
+		expect(expandHintSuffix(theme, focused)).toBe("");
 		expect(
 			Bun.stripANSI(
 				buildStatusFooter({
@@ -66,6 +70,7 @@ describe("tool-output expansion hints", () => {
 					exitCode: 0,
 					truncation: undefined,
 					hiddenLineCount: 3,
+					expandHintCapability: focused,
 				})!
 					.render(120)
 					.join("\n"),
@@ -78,6 +83,7 @@ describe("tool-output expansion hints", () => {
 					exitCode: 0,
 					truncation: undefined,
 					hiddenLineCount: 3,
+					expandHintCapability: focused,
 				})!
 					.render(120)
 					.join("\n"),
@@ -88,13 +94,14 @@ describe("tool-output expansion hints", () => {
 	it("suppresses hints while the composer does not own focus", () => {
 		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+x" }));
 
-		setExpandHintOwnerFocused(false);
-		expect(expandHintSuffix(theme)).toBe("");
-		expect(formatExpandHint(theme)).toBe("");
+		let composerFocused = false;
+		const capability = () => composerFocused;
+		expect(expandHintSuffix(theme, capability)).toBe("");
+		expect(formatExpandHint(theme, undefined, undefined, capability)).toBe("");
 
-		setExpandHintOwnerFocused(true);
-		expect(expandHintSuffix(theme)).toContain("Alt+X to expand");
-		expect(Bun.stripANSI(formatExpandHint(theme))).toContain("Alt+X for more");
+		composerFocused = true;
+		expect(expandHintSuffix(theme, capability)).toContain("Alt+X to expand");
+		expect(Bun.stripANSI(formatExpandHint(theme, undefined, undefined, capability))).toContain("Alt+X for more");
 	});
 });
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -740,6 +740,9 @@ export class TUI extends Container {
 			component.focused = true;
 		}
 	}
+	get focusedComponent(): Component | null {
+		return this.#focusedComponent;
+	}
 
 	setBottomPinnedComponent(component: Component | null): void {
 		this.#bottomPinnedComponent = component;


### PR DESCRIPTION
## Summary
Resubmission of #2416 (closed on incomplete capability threading). Head `111cbccd`, base dev `8b639c43`. Carries all previously accepted work: fold pins with invariant coverage, live-lifetime scoping, extension semantics, instance-scoped render-time hint gating with real-TUI regressions.

## Blocker response: every hint callsite now threads the capability
- A full audit found the reviewer's three examples were part of a larger set — 19 capability-less callsites across tool-execution's generic fallback, runtime-mcp, code-cell secondary branches, edit, exa, lsp (×5), fetch, gh-renderer (×2), write, debug, web-search, and a render-utils-internal caller. All are threaded now.
- **Enforcement is structural:** the capability parameter is REQUIRED on `formatExpandHint`/`expandHintSuffix`, so tsc fails on any future unthreaded callsite — the silent-miss class cannot recur. Live interactive flows pass the mode capability end-to-end (verified at the construction sites: ToolExecutionComponent, event-controller, ui-helpers, read groups, runtime-mcp bridge). The only remaining fallback is the explicit named `noExpandHintCapability` constant at public renderer-options boundaries whose non-interactive callers (no TUI, no focus concept) legitimately render no hint — greppable and documented; no anonymous `() => false` exists.
- First-frame focus regressions now also cover the three reviewer-named families — generic tool-execution fallback, runtime-mcp output, code-cell/markdown secondary branches — plus a write-renderer threading assertion (hint with focus, gone under a real overlay, restored on close). Runtime-mcp output re-renders dynamically with its supplied capability; write previews include capability state in cache invalidation.

## Testing
- expand-hint-focus (real TUI + real overlays) + render-utils + pinned-folds + read-tool-group + extension-ui-transcript-policy — 52 pass.
- `bun --cwd=packages/coding-agent run check` (biome, SDK canonicalization, tsc — the required-parameter proof) — pass.