### PR TITLE
feat(coding-agent): add busy prompt mode controls

### DIFF
--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -70,6 +70,7 @@ const CP_KP_EQUALS: i32 = 57415;
 const MOD_SHIFT: u32 = 1;
 const MOD_ALT: u32 = 2;
 const MOD_CTRL: u32 = 4;
+const MOD_SUPER: u32 = 8;
 const MOD_NUM_LOCK: u32 = 128;
 
 /// Event types from Kitty keyboard protocol (flag 2).
@@ -461,6 +462,10 @@ fn parse_key_id(key_id: &str) -> Option<ParsedKeyId<'_>> {
 			},
 			b'a' | b'A' if p.eq_ignore_ascii_case("alt") => {
 				modifier |= MOD_ALT;
+				continue;
+			},
+			b's' | b'S' if p.eq_ignore_ascii_case("super") => {
+				modifier |= MOD_SUPER;
 				continue;
 			},
 			_ => {},
@@ -1325,7 +1330,7 @@ fn parse_functional(bytes: &[u8]) -> Option<ParsedKittySequence> {
 
 fn format_kitty_key(parsed: &ParsedKittySequence) -> Option<Cow<'static, str>> {
 	let effective_mod = parsed.modifier & !LOCK_MASK;
-	if effective_mod & !(MOD_SHIFT | MOD_CTRL | MOD_ALT) != 0 {
+	if effective_mod & !(MOD_SHIFT | MOD_CTRL | MOD_ALT | MOD_SUPER) != 0 {
 		return None;
 	}
 	let effective_codepoint =
@@ -1427,6 +1432,9 @@ fn format_with_mods(mods: u32, key_name: &str) -> String {
 	if mods & MOD_ALT != 0 {
 		result.push_str("alt+");
 	}
+	if mods & MOD_SUPER != 0 {
+		result.push_str("super+");
+	}
 	result.push_str(key_name);
 	result
 }
@@ -1472,8 +1480,9 @@ mod tests {
 	}
 
 	#[test]
-	fn parse_key_ignores_kitty_sequences_with_unsupported_modifiers() {
-		assert_eq!(parse_key_inner(b"\x1b[99;9u", true).as_deref(), None);
+	fn parse_key_supports_kitty_super_modifier() {
+		assert_eq!(parse_key_inner(b"\x1b[99;9u", true).as_deref(), Some("super+c"));
+		assert!(matches_key_inner(b"\x1b[13;9u", "super+enter", true));
 	}
 
 	#[test]

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -40,8 +40,9 @@ Set an action to an empty array to disable it:
 | `app.thinking.toggle` | `Ctrl+T` | Toggle thinking-block visibility |
 | `app.thinking.cycle` | `Shift+Tab` | Cycle thinking level |
 | `app.editor.external` | `Ctrl+G` | Edit the draft in `$VISUAL` / `$EDITOR` |
-| `app.message.followUp` | _(none)_ | Optional remap for a follow-up message; `Ctrl+Enter` is reserved for editor newline |
-| `app.message.queue` | `Alt+Enter` (`Alt+Q` on win32) | Explicitly queue a message for the next turn |
+| `app.message.followUp` | _(none)_ | Optional remap for a follow-up message; `Ctrl+Enter` remains editor newline unless remapped |
+| `app.message.queue` | `Alt+Q` (macOS/Windows), `Alt+Enter` (otherwise) | Explicitly queue a message for the next turn |
+| `app.message.oppositeBusyMode` | `Command+Enter` (macOS) | Submit one message using the opposite of `busyPromptMode` |
 | `app.message.dequeue` | `Alt+Up` | Dequeue a queued message back into the editor |
 
 | `app.clipboard.copyLine` | `Alt+Shift+L` | Copy the current line |
@@ -51,7 +52,8 @@ Set an action to an empty array to disable it:
 
 Older unqualified action names are migrated when `keybindings.json` is loaded, but new docs and new configs should use the namespaced action IDs above.
 
-On native Windows terminals, GJC defaults `app.message.queue` to `Alt+Q` because Windows Terminal and PowerShell commonly reserve `Alt+Enter` for fullscreen before GJC can receive it. Users who prefer another chord can remap `app.message.queue` in `~/.gjc/agent/keybindings.json`.
+On macOS and native Windows terminals, GJC defaults `app.message.queue` to `Alt+Q`; other platforms use `Alt+Enter`. Windows Terminal and PowerShell commonly reserve `Alt+Enter` for fullscreen before GJC can receive it. Users who prefer another chord can remap `app.message.queue` in `~/.gjc/agent/keybindings.json`.
+While the agent is streaming on macOS, `Command+Enter` submits the current message once using the opposite of `busyPromptMode`: configured `steer` queues that message, while configured `queue` steers it into the active turn. The shortcut is inactive while idle or compacting and is remappable through `app.message.oppositeBusyMode`.
 
 In the main GJC composer, plain `PageUp` / `PageDown` page the visible transcript viewport instead of browsing prompt history; use `Up` / `Down` or `Ctrl+R` for prompt history. Autocomplete and selector surfaces still use `PageUp` / `PageDown` for list paging while they have focus.
 
@@ -137,8 +139,9 @@ Authoritative inventory of the keybinding registry, one row per action. Generate
 | `app.tools.expand` | `ctrl+o` | |
 | `app.tool.backgroundFold` | `ctrl+b` | |
 | `app.editor.external` | `ctrl+g` | |
-| `app.message.followUp` | _(none)_ | `Ctrl+Enter` remains newline unless the user explicitly remaps this action; while idle the chord still falls through to newline |
-| `app.message.queue` | `alt+enter` (`alt+q` on win32) | platform-aware; avoids the Windows Terminal fullscreen shortcut |
+| `app.message.followUp` | _(none)_ | `Ctrl+Enter` remains editor newline unless the user explicitly remaps this action; while idle the chord still falls through to newline |
+| `app.message.queue` | `alt+q` (macOS/Windows), `alt+enter` (otherwise) | platform-aware; avoids the Windows Terminal fullscreen shortcut |
+| `app.message.oppositeBusyMode` | `super+enter` (macOS only) | one-message inversion of `busyPromptMode`; inactive while idle or compacting |
 | `app.message.dequeue` | `alt+up` | |
 | `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on win32) | platform-aware; single source of truth in `KEYBINDINGS` |
 | `app.clipboard.copyLine` | `alt+shift+l` | registry-backed via input-controller custom handler |

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -32,6 +32,7 @@ interface AppKeybindings {
 	"app.editor.external": true;
 	"app.message.followUp": true;
 	"app.message.queue": true;
+	"app.message.oppositeBusyMode": true;
 	"app.message.dequeue": true;
 	"app.clipboard.pasteImage": true;
 	"app.clipboard.copyLine": true;
@@ -63,6 +64,10 @@ declare module "@gajae-code/tui" {
 
 export function defaultMessageQueueKeysForPlatform(platform: NodeJS.Platform = process.platform): KeyId {
 	return platform === "win32" || platform === "darwin" ? "alt+q" : "alt+enter";
+}
+
+export function defaultOppositeBusyModeKeysForPlatform(platform: NodeJS.Platform = process.platform): KeyId[] {
+	return platform === "darwin" ? ["super+enter"] : [];
 }
 
 /**
@@ -128,7 +133,11 @@ export const KEYBINDINGS = {
 	},
 	"app.message.followUp": {
 		defaultKeys: [],
-		description: "Send follow-up message (no default; Ctrl+Enter submits)",
+		description: "Send follow-up message (no default; Ctrl+Enter remains editor newline unless remapped)",
+	},
+	"app.message.oppositeBusyMode": {
+		defaultKeys: defaultOppositeBusyModeKeysForPlatform(),
+		description: "Submit once using the opposite busy prompt mode",
 	},
 	"app.message.queue": {
 		defaultKeys: defaultMessageQueueKeysForPlatform(),

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5,15 +5,20 @@ import { getThinkingLevelMetadata } from "../thinking-metadata";
 import { EDIT_MODES } from "../utils/edit-mode";
 import { CONFIGURABLE_SEARCH_PROVIDER_IDS } from "../web/search/types";
 import type { ModelSelectorValue } from "./model-selector-value";
-
-const THINKING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as readonly Effort[];
-const DEFAULT_THINKING_LEVELS = ["off", ...THINKING_EFFORTS] as const;
-
 import {
 	DEFAULT_DISABLED_EXTENSIONS,
 	DEFAULT_SKILL_DISCOVERY_SETTINGS,
 	type SkillDiscoverySettings,
 } from "./skill-settings-defaults";
+
+const THINKING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as readonly Effort[];
+const DEFAULT_THINKING_LEVELS = ["off", ...THINKING_EFFORTS] as const;
+
+export type BusyPromptMode = "steer" | "queue";
+
+export function normalizeBusyPromptMode(value: unknown): BusyPromptMode {
+	return value === "queue" ? "queue" : "steer";
+}
 
 /** Unified settings schema - single source of truth for all settings.
  *

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -47,6 +47,7 @@ import {
 	type GroupPrefix,
 	type GroupTypeMap,
 	getDefault,
+	normalizeBusyPromptMode,
 	SETTINGS_SCHEMA,
 	type SettingPath,
 	type SettingValue,
@@ -369,6 +370,8 @@ export class Settings implements NotificationSettingsReader {
 	/** Legacy fallback migration warnings emitted once per settings instance. */
 	#legacyFallbackMigrationWarnings = 0;
 	#legacyFallbackMigrationGlobalFingerprint: string | undefined;
+	/** Invalid persisted busy prompt mode warning emitted once per settings instance. */
+	#busyPromptModeInvalidWarningEmitted = false;
 
 	/** Whether to persist changes */
 	#persist: boolean;
@@ -465,6 +468,9 @@ export class Settings implements NotificationSettingsReader {
 	get<P extends SettingPath>(path: P): SettingValue<P> {
 		const segments = path.split(".");
 		const value = getByPath(this.#merged, segments);
+		if (path === "busyPromptMode") {
+			return this.#normalizeBusyPromptMode(value) as SettingValue<P>;
+		}
 		if (value !== undefined) {
 			const pathScopedValue = resolvePathScopedStringArray(path, value, this.#cwd);
 			return (pathScopedValue ?? value) as SettingValue<P>;
@@ -472,6 +478,25 @@ export class Settings implements NotificationSettingsReader {
 		return getDefault(path);
 	}
 
+	#normalizeBusyPromptMode(value: unknown): "steer" | "queue" {
+		const persistedValue = Object.hasOwn(this.#overrides, "busyPromptMode")
+			? undefined
+			: Object.hasOwn(this.#project, "busyPromptMode")
+				? this.#project.busyPromptMode
+				: this.#global.busyPromptMode;
+		if (
+			value !== "queue" &&
+			value !== "steer" &&
+			persistedValue !== undefined &&
+			this.#persist &&
+			!this.#busyPromptModeInvalidWarningEmitted
+		) {
+			this.#busyPromptModeInvalidWarningEmitted = true;
+			logger.warn("Settings: invalid busyPromptMode; using steer", { value: persistedValue });
+		}
+
+		return normalizeBusyPromptMode(value);
+	}
 	/**
 	 * Get a setting value from the user/global config only.
 	 *

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -21,6 +21,7 @@ type ConfigurableEditorAction = Extract<
 	| "app.message.dequeue"
 	| "app.message.followUp"
 	| "app.message.queue"
+	| "app.message.oppositeBusyMode"
 	| "app.clipboard.pasteImage"
 	| "app.clipboard.copyPrompt"
 >;
@@ -45,6 +46,7 @@ const CONFIGURABLE_EDITOR_ACTIONS = [
 	"app.history.search",
 	"app.message.followUp",
 	"app.message.queue",
+	"app.message.oppositeBusyMode",
 	"app.message.dequeue",
 	"app.clipboard.pasteImage",
 	"app.clipboard.copyPrompt",
@@ -101,6 +103,11 @@ export class CustomEditor extends Editor {
 	onDequeue?: () => void;
 	/** Called when the configured queue shortcut is pressed. */
 	onQueue?: () => void;
+	/**
+	 * Called when the configured opposite-busy-mode shortcut is pressed.
+	 * Return true to consume the key, or false to continue normal action dispatch.
+	 */
+	onOppositeBusyMode?: () => boolean;
 	/** Called when Caps Lock is pressed. */
 	onCapsLock?: () => void;
 	/** Called when PageUp/PageDown should scroll the transcript viewport instead of prompt history. */
@@ -267,6 +274,12 @@ export class CustomEditor extends Editor {
 
 		if (!matchesKey(data, "pageUp") && !matchesKey(data, "pageDown")) {
 			this.onViewportFollowLive?.();
+		}
+
+		// Opposite-busy mode has conditional priority over colliding application
+		// actions while streaming, but falls through to them while inactive.
+		if (this.#matchesAction(data, "app.message.oppositeBusyMode") && this.onOppositeBusyMode?.()) {
+			return;
 		}
 		// Intercept configured image paste (async - fires and handles result)
 		if (this.#matchesAction(data, "app.clipboard.pasteImage") && this.onPasteImage) {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -376,6 +376,16 @@ export class InputController {
 		this.ctx.editor.onDequeue = () => this.handleDequeue();
 		this.ctx.editor.setActionKeys("app.message.queue", this.ctx.keybindings.getKeys("app.message.queue"));
 		this.ctx.editor.onQueue = () => void this.handleQueueSubmit();
+		this.ctx.editor.setActionKeys(
+			"app.message.oppositeBusyMode",
+			this.ctx.keybindings.getKeys("app.message.oppositeBusyMode"),
+		);
+		this.ctx.editor.onOppositeBusyMode = () => {
+			if (!this.ctx.session.isStreaming || this.ctx.session.isCompacting) return false;
+			if (!this.ctx.editor.getText().trim()) return false;
+			void this.handleOppositeBusyPromptSubmit();
+			return true;
+		};
 
 		this.ctx.editor.onViewportPageScroll = direction => this.ctx.ui.scrollViewportPages(direction);
 		this.ctx.editor.onViewportFollowLive = () => {
@@ -420,14 +430,6 @@ export class InputController {
 			this.ctx.editor.setCustomKeyHandler(key, () => {
 				if (!this.#isFollowUpShortcutActive()) return false;
 				void this.handleFollowUp();
-				return true;
-			});
-		}
-		for (const key of this.ctx.keybindings.getKeys("app.message.oppositeBusyMode")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => {
-				if (!this.ctx.session.isStreaming || this.ctx.session.isCompacting) return false;
-				if (!this.ctx.editor.getText().trim()) return false;
-				void this.handleOppositeBusyPromptSubmit();
 				return true;
 			});
 		}
@@ -1034,14 +1036,17 @@ export class InputController {
 		const text = this.ctx.editor.getText().trim();
 		if (!text || !this.ctx.session.isStreaming || this.ctx.session.isCompacting) return;
 
+		// Claim the draft before the first await so rapid repeated shortcuts cannot
+		// snapshot and submit the same text twice.
+		const pendingImages = this.ctx.pendingImages;
+		const images = this.#visiblePendingImagesForText(text) ?? [];
+		this.ctx.editor.setText("");
+
 		const streamingBehavior =
 			normalizeBusyPromptMode(this.ctx.settings.get("busyPromptMode")) === "steer" ? "followUp" : "steer";
 		if (await this.#invokeSkillCommand(text, streamingBehavior)) return;
 
-		const pendingImages = this.ctx.pendingImages;
-		const images = this.#visiblePendingImagesForText(text) ?? [];
 		this.ctx.editor.addToHistory(text);
-		this.ctx.editor.setText("");
 		this.#clearPendingImagesIfOwnedBy(pendingImages);
 		await this.ctx.withLocalSubmission(
 			text,

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -4,6 +4,7 @@ import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@gajae-code/tui";
 import { $env, sanitizeText } from "@gajae-code/utils";
 import { isSettingsInitialized, settings } from "../../config/settings";
+import { normalizeBusyPromptMode } from "../../config/settings-schema";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
 import { buildSkillPromptMessage, parseSkillInvocations } from "../../extensibility/skills";
 import { expandEmoticons } from "../../modes/emoji-autocomplete";
@@ -422,6 +423,14 @@ export class InputController {
 				return true;
 			});
 		}
+		for (const key of this.ctx.keybindings.getKeys("app.message.oppositeBusyMode")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				if (!this.ctx.session.isStreaming || this.ctx.session.isCompacting) return false;
+				if (!this.ctx.editor.getText().trim()) return false;
+				void this.handleOppositeBusyPromptSubmit();
+				return true;
+			});
+		}
 		for (const key of this.ctx.keybindings.getKeys("app.stt.toggle")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleSTTToggle());
 		}
@@ -522,15 +531,6 @@ export class InputController {
 				text = slashResult;
 			}
 
-			// Handle skill commands (/skill:name [args]). While streaming, Enter
-			// honors `busyPromptMode`: "steer" interrupts the active turn, "queue"
-			// runs after it completes (matches the free-text Enter semantics applied
-			// a few lines below at the streaming branch). Explicit queue shortcuts
-			// route through `handleFollowUp` and dispatch as `followUp`.
-			if (await this.#invokeSkillCommand(text, this.#busyStreamingBehavior())) {
-				return;
-			}
-
 			// Handle bash command (! for normal, !! for excluded from context)
 			if (text.startsWith("!")) {
 				const isExcluded = text.startsWith("!!");
@@ -566,6 +566,27 @@ export class InputController {
 					this.ctx.updateEditorBorderColor();
 					return;
 				}
+			}
+			// Keep skill invocations queued during compaction so they retain their
+			// custom-message dispatch path when the compaction queue flushes.
+			if (
+				this.ctx.session.isCompacting &&
+				parseSkillInvocations(text, this.ctx.skillCommands ?? new Map()).length > 0
+			) {
+				if ((inputImages?.length ?? 0) > 0) {
+					this.ctx.showStatus("Compaction in progress. Retry after it completes to send images.");
+					return;
+				}
+				this.ctx.queueCompactionMessage(text, "steer");
+				return;
+			}
+
+			// Handle skill commands (/skill:name [args]). While streaming, Enter
+			// honors `busyPromptMode`: "steer" interrupts the active turn, "queue"
+			// runs after it completes. Explicit queue shortcuts route through
+			// `handleFollowUp` and dispatch as `followUp`.
+			if (await this.#invokeSkillCommand(text, this.#busyStreamingBehavior())) {
+				return;
 			}
 
 			// Queue input during compaction
@@ -867,7 +888,7 @@ export class InputController {
 	 * completes (in submission order). Only consulted while streaming.
 	 */
 	#busyStreamingBehavior(): "steer" | "followUp" {
-		return this.ctx.settings.get("busyPromptMode") === "steer" ? "steer" : "followUp";
+		return normalizeBusyPromptMode(this.ctx.settings.get("busyPromptMode")) === "steer" ? "steer" : "followUp";
 	}
 
 	#isFollowUpShortcutActive(): boolean {
@@ -1006,6 +1027,34 @@ export class InputController {
 	/** Send editor text explicitly as a queued next-turn message. */
 	async handleQueueSubmit(): Promise<void> {
 		return this.handleFollowUp();
+	}
+
+	/** Submit once using the opposite of the configured busy prompt mode. */
+	async handleOppositeBusyPromptSubmit(): Promise<void> {
+		const text = this.ctx.editor.getText().trim();
+		if (!text || !this.ctx.session.isStreaming || this.ctx.session.isCompacting) return;
+
+		const streamingBehavior =
+			normalizeBusyPromptMode(this.ctx.settings.get("busyPromptMode")) === "steer" ? "followUp" : "steer";
+		if (await this.#invokeSkillCommand(text, streamingBehavior)) return;
+
+		const pendingImages = this.ctx.pendingImages;
+		const images = this.#visiblePendingImagesForText(text) ?? [];
+		this.ctx.editor.addToHistory(text);
+		this.ctx.editor.setText("");
+		this.#clearPendingImagesIfOwnedBy(pendingImages);
+		await this.ctx.withLocalSubmission(
+			text,
+			() =>
+				this.ctx.session.prompt(text, {
+					streamingBehavior,
+					images: images.length > 0 ? images : undefined,
+					...(streamingBehavior === "followUp" ? { followUpQueuePolicy: "sequential" as const } : {}),
+				}),
+			{ imageCount: images.length },
+		);
+		this.ctx.updatePendingMessagesDisplay();
+		this.ctx.ui.requestRender();
 	}
 
 	restoreLatestQueuedMessageToEditor(): number {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -33,6 +33,7 @@ import chalk from "chalk";
 import { AsyncJobManager } from "../async";
 import { type AppKeybinding, KeybindingsManager } from "../config/keybindings";
 import { isSettingsInitialized, type Settings, settings } from "../config/settings";
+import { normalizeBusyPromptMode } from "../config/settings-schema";
 import { DEFAULT_GJC_DEFINITION_NAMES } from "../defaults/gjc-defaults";
 import type {
 	ExtensionUIContext,
@@ -177,6 +178,7 @@ const FRIENDLY_KEY_PARTS: Record<string, string> = {
 	enter: "Enter",
 	meta: process.platform === "darwin" ? "Command" : "Meta",
 	option: "Option",
+	super: process.platform === "darwin" ? "Command" : "Super",
 	shift: "Shift",
 };
 
@@ -1037,10 +1039,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editor.setMaxHeight(this.#computeEditorMaxHeight());
 	}
 
-	#isPromptDeliveryBusy(): boolean {
-		return this.session.isStreaming || this.session.isCompacting;
-	}
-
 	#getFirstKeyForAction(action: AppKeybinding): string | undefined {
 		return this.keybindings.getKeys(action)[0];
 	}
@@ -1053,13 +1051,28 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#getFirstKeyForAction(preferredAction) ?? this.#getFirstKeyForAction(fallbackAction);
 	}
 
+	#getOppositeBusyModeShortcut(): string | undefined {
+		return this.#getFirstKeyForAction("app.message.oppositeBusyMode");
+	}
+
 	#getComposerPlaceholder(): string {
-		if (!this.#isPromptDeliveryBusy()) return DEFAULT_COMPOSER_PLACEHOLDER;
-		const enterAction = this.settings.get("busyPromptMode") === "steer" ? "Steer" : "Queue";
-		const parts = [`Enter: ${enterAction}`];
-		const queueKey = this.#getMessageQueueShortcut();
-		if (queueKey) parts.push(`${formatShortcutForPlaceholder(queueKey)}: Queue`);
-		return `${DEFAULT_COMPOSER_PLACEHOLDER} · ${parts.join(" · ")}`;
+		if (this.session.isCompacting) {
+			return `${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Queue after compaction`;
+		}
+		if (this.session.isStreaming) {
+			const enterAction =
+				normalizeBusyPromptMode(this.settings.get("busyPromptMode")) === "steer" ? "Steer" : "Queue";
+			const parts = [`Enter: ${enterAction}`];
+			const queueKey = this.#getMessageQueueShortcut();
+			if (queueKey) parts.push(`${formatShortcutForPlaceholder(queueKey)}: Queue`);
+			const oppositeKey = this.#getOppositeBusyModeShortcut();
+			if (oppositeKey) {
+				const oppositeAction = enterAction === "Steer" ? "Queue" : "Steer";
+				parts.push(`${formatShortcutForPlaceholder(oppositeKey)}: ${oppositeAction} once`);
+			}
+			return `${DEFAULT_COMPOSER_PLACEHOLDER} · ${parts.join(" · ")}`;
+		}
+		return DEFAULT_COMPOSER_PLACEHOLDER;
 	}
 
 	#getWelcomeReservedRows(width: number): number {

--- a/packages/coding-agent/test/config-cli.test.ts
+++ b/packages/coding-agent/test/config-cli.test.ts
@@ -95,6 +95,34 @@ describe("config CLI schema coverage", () => {
 			value: 0.2,
 		});
 	});
+	it("accepts steer and queue busy prompt modes and rejects invalid values", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const exitSpy = vi
+			.spyOn(process, "exit")
+			.mockImplementation((code?: string | number | null | undefined): never => {
+				throw new Error(`exit ${code}`);
+			});
+
+		await runConfigCommand({ action: "set", key: "busyPromptMode", value: "steer", flags: { json: true } });
+		await runConfigCommand({ action: "get", key: "busyPromptMode", flags: { json: true } });
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({
+			key: "busyPromptMode",
+			value: "steer",
+		});
+
+		await runConfigCommand({ action: "set", key: "busyPromptMode", value: "queue", flags: { json: true } });
+		await runConfigCommand({ action: "get", key: "busyPromptMode", flags: { json: true } });
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({
+			key: "busyPromptMode",
+			value: "queue",
+		});
+		await expect(
+			runConfigCommand({ action: "set", key: "busyPromptMode", value: "later", flags: { json: true } }),
+		).rejects.toThrow("exit 1");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Valid values: steer, queue"));
+	});
 	it("sets numeric idle compaction settings from CLI values", async () => {
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 		await runConfigCommand({

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -124,38 +124,6 @@ describe("CustomEditor queue keybinding", () => {
 		expect(editor.getText()).toBe("");
 	});
 
-describe("CustomEditor opposite busy mode keybinding", () => {
-	it("takes priority over a colliding built-in action while active", () => {
-		const editor = createEditor();
-		const onOppositeBusyMode = vi.fn(() => true);
-		const onQueue = vi.fn();
-		editor.onOppositeBusyMode = onOppositeBusyMode;
-		editor.onQueue = onQueue;
-		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
-		editor.setActionKeys("app.message.queue", ["alt+enter"]);
-
-		editor.handleInput("\x1b\r");
-
-		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
-		expect(onQueue).not.toHaveBeenCalled();
-	});
-
-	it("falls through to a colliding built-in action while inactive", () => {
-		const editor = createEditor();
-		const onOppositeBusyMode = vi.fn(() => false);
-		const onQueue = vi.fn();
-		editor.onOppositeBusyMode = onOppositeBusyMode;
-		editor.onQueue = onQueue;
-		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
-		editor.setActionKeys("app.message.queue", ["alt+enter"]);
-
-		editor.handleInput("\x1b\r");
-
-		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
-		expect(onQueue).toHaveBeenCalledTimes(1);
-	});
-});
-
 	it("keeps Ctrl+Enter as a multiline newline chord", () => {
 		const editor = createEditor();
 		const onQueue = vi.fn();
@@ -246,6 +214,38 @@ describe("CustomEditor opposite busy mode keybinding", () => {
 		expect(onQueue).not.toHaveBeenCalled();
 
 		editor.handleInput("\x1bq");
+		expect(onQueue).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("CustomEditor opposite busy mode keybinding", () => {
+	it("takes priority over a colliding built-in action while active", () => {
+		const editor = createEditor();
+		const onOppositeBusyMode = vi.fn(() => true);
+		const onQueue = vi.fn();
+		editor.onOppositeBusyMode = onOppositeBusyMode;
+		editor.onQueue = onQueue;
+		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
+		editor.setActionKeys("app.message.queue", ["alt+enter"]);
+
+		editor.handleInput("\x1b\r");
+
+		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
+		expect(onQueue).not.toHaveBeenCalled();
+	});
+
+	it("falls through to a colliding built-in action while inactive", () => {
+		const editor = createEditor();
+		const onOppositeBusyMode = vi.fn(() => false);
+		const onQueue = vi.fn();
+		editor.onOppositeBusyMode = onOppositeBusyMode;
+		editor.onQueue = onQueue;
+		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
+		editor.setActionKeys("app.message.queue", ["alt+enter"]);
+
+		editor.handleInput("\x1b\r");
+
+		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
 		expect(onQueue).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -124,6 +124,38 @@ describe("CustomEditor queue keybinding", () => {
 		expect(editor.getText()).toBe("");
 	});
 
+describe("CustomEditor opposite busy mode keybinding", () => {
+	it("takes priority over a colliding built-in action while active", () => {
+		const editor = createEditor();
+		const onOppositeBusyMode = vi.fn(() => true);
+		const onQueue = vi.fn();
+		editor.onOppositeBusyMode = onOppositeBusyMode;
+		editor.onQueue = onQueue;
+		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
+		editor.setActionKeys("app.message.queue", ["alt+enter"]);
+
+		editor.handleInput("\x1b\r");
+
+		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
+		expect(onQueue).not.toHaveBeenCalled();
+	});
+
+	it("falls through to a colliding built-in action while inactive", () => {
+		const editor = createEditor();
+		const onOppositeBusyMode = vi.fn(() => false);
+		const onQueue = vi.fn();
+		editor.onOppositeBusyMode = onOppositeBusyMode;
+		editor.onQueue = onQueue;
+		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
+		editor.setActionKeys("app.message.queue", ["alt+enter"]);
+
+		editor.handleInput("\x1b\r");
+
+		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
+		expect(onQueue).toHaveBeenCalledTimes(1);
+	});
+});
+
 	it("keeps Ctrl+Enter as a multiline newline chord", () => {
 		const editor = createEditor();
 		const onQueue = vi.fn();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -29,6 +29,7 @@ type FakeEditor = {
 	onExternalEditor?: () => void;
 	onDequeue?: () => void;
 	onQueue?: () => void | Promise<void>;
+	onOppositeBusyMode?: () => boolean;
 	onChange?: (text: string) => void;
 	onSubmit?: (text: string) => void | Promise<void>;
 	onTabDeclined?: (text: string) => void;
@@ -371,11 +372,8 @@ describe("InputController keybinding setup", () => {
 		const controller = new InputController(ctx);
 		controller.setupKeyHandlers();
 
-		const registration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
-			([key]) => key === "super+enter",
-		);
-		expect(registration).toBeDefined();
-		expect(registration?.[1]()).toBe(true);
+		expect(spies.setActionKeys).toHaveBeenCalledWith("app.message.oppositeBusyMode", ["super+enter"]);
+		expect(editor.onOppositeBusyMode?.()).toBe(true);
 		await Bun.sleep(0);
 
 		expect(spies.prompt).toHaveBeenCalledWith(`opposite from ${busyPromptMode}`, {
@@ -391,17 +389,31 @@ describe("InputController keybinding setup", () => {
 		const controller = new InputController(ctx);
 		controller.setupKeyHandlers();
 
-		const registration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
-			([key]) => key === "super+enter",
-		);
-		expect(registration).toBeDefined();
-		expect(registration?.[1]()).toBe(false);
+		expect(editor.onOppositeBusyMode?.()).toBe(false);
 
 		(ctx.session as unknown as { isStreaming: boolean; isCompacting: boolean }).isStreaming = true;
 		(ctx.session as unknown as { isStreaming: boolean; isCompacting: boolean }).isCompacting = true;
-		expect(registration?.[1]()).toBe(false);
+		expect(editor.onOppositeBusyMode?.()).toBe(false);
 		await Bun.sleep(0);
 		expect(spies.prompt).not.toHaveBeenCalled();
+	});
+
+	it("claims the draft before rapid repeated opposite-mode submissions", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
+		editor.setText("submit exactly once");
+		new InputController(ctx).setupKeyHandlers();
+
+		expect(editor.onOppositeBusyMode?.()).toBe(true);
+		expect(editor.onOppositeBusyMode?.()).toBe(false);
+		await Bun.sleep(0);
+
+		expect(spies.prompt).toHaveBeenCalledTimes(1);
+		expect(spies.prompt).toHaveBeenCalledWith("submit exactly once", {
+			streamingBehavior: "followUp",
+			images: undefined,
+			followUpQueuePolicy: "sequential",
+		});
 	});
 
 	it("queues direct free text while streaming when busyPromptMode is queue", async () => {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -45,6 +45,7 @@ type FakeEditor = {
 async function createContext(options?: {
 	busyPromptMode?: "steer" | "queue";
 	followUpKeys?: string[];
+	oppositeBusyModeKeys?: string[];
 	ircSidebarToggleKeys?: string[];
 }) {
 	let editorText = "";
@@ -53,6 +54,7 @@ async function createContext(options?: {
 		"app.model.select": ["ctrl+l"],
 		"app.message.queue": ["alt+enter"],
 		"app.message.followUp": options?.followUpKeys ?? [],
+		"app.message.oppositeBusyMode": options?.oppositeBusyModeKeys ?? ["super+enter"],
 		"app.message.dequeue": ["alt+up", "alt+down"],
 		"app.irc.sidebar.toggle": options?.ircSidebarToggleKeys ?? ["alt+i"],
 	};
@@ -62,6 +64,7 @@ async function createContext(options?: {
 	const prompt = vi.fn(async () => {});
 	const updatePendingMessagesDisplay = vi.fn();
 	const handleBashCommand = vi.fn(async () => {});
+	const handlePythonCommand = vi.fn(async () => {});
 	const showStatus = vi.fn();
 	const onInputCallback = vi.fn();
 	const toggleIrcSidebar = vi.fn();
@@ -244,6 +247,7 @@ async function createContext(options?: {
 		showModelSelector,
 		updateEditorBorderColor: vi.fn(),
 		handleBashCommand,
+		handlePythonCommand,
 		showWarning: vi.fn(),
 		showStatus,
 		hasActiveBtw: vi.fn(() => false),
@@ -261,6 +265,7 @@ async function createContext(options?: {
 			startPendingSubmission,
 			updatePendingMessagesDisplay,
 			handleBashCommand,
+			handlePythonCommand,
 			showStatus,
 			queueCompactionMessage,
 			popLastQueuedMessage,
@@ -354,6 +359,117 @@ describe("InputController keybinding setup", () => {
 			followUpQueuePolicy: "sequential",
 		});
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		["steer", "followUp", "sequential"],
+		["queue", "steer", undefined],
+	] as const)("Command+Enter submits once as %s mode's opposite", async (busyPromptMode, streamingBehavior, followUpQueuePolicy) => {
+		const { InputController, ctx, editor, spies } = await createContext({ busyPromptMode });
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
+		editor.setText(`opposite from ${busyPromptMode}`);
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		const registration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
+			([key]) => key === "super+enter",
+		);
+		expect(registration).toBeDefined();
+		expect(registration?.[1]()).toBe(true);
+		await Bun.sleep(0);
+
+		expect(spies.prompt).toHaveBeenCalledWith(`opposite from ${busyPromptMode}`, {
+			streamingBehavior,
+			images: undefined,
+			...(followUpQueuePolicy ? { followUpQueuePolicy } : {}),
+		});
+	});
+
+	it("lets Command+Enter fall through while idle or compacting", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		editor.setText("do not invert");
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		const registration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
+			([key]) => key === "super+enter",
+		);
+		expect(registration).toBeDefined();
+		expect(registration?.[1]()).toBe(false);
+
+		(ctx.session as unknown as { isStreaming: boolean; isCompacting: boolean }).isStreaming = true;
+		(ctx.session as unknown as { isStreaming: boolean; isCompacting: boolean }).isCompacting = true;
+		expect(registration?.[1]()).toBe(false);
+		await Bun.sleep(0);
+		expect(spies.prompt).not.toHaveBeenCalled();
+	});
+
+	it("queues direct free text while streaming when busyPromptMode is queue", async () => {
+		const { InputController, ctx, editor, spies } = await createContext({ busyPromptMode: "queue" });
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("queue this message");
+
+		expect(spies.prompt).toHaveBeenCalledWith("queue this message", {
+			streamingBehavior: "followUp",
+			images: undefined,
+			followUpQueuePolicy: "sequential",
+		});
+		expect(spies.onInputCallback).not.toHaveBeenCalled();
+	});
+
+	it("queues direct images while streaming when busyPromptMode is queue", async () => {
+		const { InputController, ctx, editor, spies } = await createContext({ busyPromptMode: "queue" });
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
+		const image = { type: "image", data: "image-data" } as unknown as InteractiveModeContext["pendingImages"][number];
+		ctx.pendingImages = [image];
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("queue image [image 1]");
+
+		expect(spies.prompt).toHaveBeenCalledWith("queue image [image 1]", {
+			streamingBehavior: "followUp",
+			images: [image],
+			followUpQueuePolicy: "sequential",
+		});
+		expect(ctx.pendingImages).toEqual([]);
+	});
+
+	it("submits direct text normally while idle when busyPromptMode is queue", async () => {
+		const { InputController, ctx, editor, spies } = await createContext({ busyPromptMode: "queue" });
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("idle message");
+
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(spies.onInputCallback).toHaveBeenCalledWith({
+			text: "idle message",
+			images: undefined,
+			cancelled: false,
+			started: true,
+		});
+	});
+
+	it.each([
+		["!echo normal", "echo normal", false, "handleBashCommand"],
+		["!!echo excluded", "echo excluded", true, "handleBashCommand"],
+		["$print('normal')", "print('normal')", false, "handlePythonCommand"],
+		["$$print('excluded')", "print('excluded')", true, "handlePythonCommand"],
+	] as const)("runs %s directly during compaction", async (input, command, excluded, handler) => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		(ctx.session as unknown as { isCompacting: boolean }).isCompacting = true;
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.(input);
+
+		expect(spies[handler]).toHaveBeenCalledWith(command, excluded);
+		expect(spies.queueCompactionMessage).not.toHaveBeenCalled();
+		expect(spies.prompt).not.toHaveBeenCalled();
 	});
 
 	it("does not register a default Ctrl+Enter follow-up handler", async () => {

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -85,6 +85,7 @@ function createStubInputControllerContext(opts: {
 	skillCommands: Map<string, Skill>;
 	isStreaming: boolean;
 	busyPromptMode?: "steer" | "queue";
+	isCompacting?: boolean;
 }) {
 	let editorText = "";
 	const editor: StubEditor = {
@@ -107,6 +108,8 @@ function createStubInputControllerContext(opts: {
 	const updatePendingMessagesDisplay = vi.fn();
 	const requestRender = vi.fn();
 	const showError = vi.fn();
+	const showStatus = vi.fn();
+	const queueCompactionMessage = vi.fn();
 
 	const ctx = {
 		editor,
@@ -115,7 +118,7 @@ function createStubInputControllerContext(opts: {
 		session: {
 			sessionId: "stub-session",
 			isStreaming: opts.isStreaming,
-			isCompacting: false,
+			isCompacting: opts.isCompacting ?? false,
 			isBashRunning: false,
 			isEvalRunning: false,
 			extensionRunner: undefined,
@@ -131,6 +134,7 @@ function createStubInputControllerContext(opts: {
 			getCwd: () => process.cwd(),
 		},
 		showError,
+		showStatus,
 		updatePendingMessagesDisplay,
 		// Defaults that InputController touches on submit but don't matter here.
 		isBashMode: false,
@@ -138,11 +142,21 @@ function createStubInputControllerContext(opts: {
 		pendingImages: [],
 		isBackgrounded: false,
 		compactionQueuedMessages: [],
+		queueCompactionMessage,
 		locallySubmittedUserSignatures: new Set<string>(),
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage, sendCustomMessage, prompt };
+	return {
+		ctx,
+		editor,
+		enqueueCustomMessageDisplay,
+		promptCustomMessage,
+		sendCustomMessage,
+		prompt,
+		queueCompactionMessage,
+		showStatus,
+	};
 }
 
 describe("InputController #invokeSkillCommand (E1-E3)", () => {
@@ -359,11 +373,9 @@ describe("InputController busyPromptMode + skill commands (issue #434)", () => {
 		vi.restoreAllMocks();
 	});
 
-	// Skill-command-specific routing. Free-text Enter routing and the Ctrl+Enter
-	// keybinding are covered in input-controller-busy-prompt-mode.test.ts; the
-	// E1 case above already covers the default (steer) skill path.
+	// Skill commands use the same busy-mode routing as free text.
 	it("queue: Enter on a skill command while streaming queues it as followUp", async () => {
-		const { ctx, editor, enqueueCustomMessageDisplay } = createStubInputControllerContext({
+		const { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage } = createStubInputControllerContext({
 			skillCommands,
 			isStreaming: true,
 			busyPromptMode: "queue",
@@ -374,6 +386,47 @@ describe("InputController busyPromptMode + skill commands (issue #434)", () => {
 		await editor.onSubmit?.("/skill:test-skill go");
 
 		expect(enqueueCustomMessageDisplay).toHaveBeenCalledWith("/skill:test-skill go", "followUp");
+		const call = promptCustomMessage.mock.calls[0];
+		expect(call?.[0].details.__pendingDisplayTag).toBe("sk-test-0");
+		expect(call?.[1]).toEqual({ streamingBehavior: "followUp", followUpQueuePolicy: "sequential" });
+	});
+
+	it("queues skill commands locally as steer during compaction", async () => {
+		const { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage, queueCompactionMessage } =
+			createStubInputControllerContext({
+				skillCommands,
+				isStreaming: true,
+				busyPromptMode: "queue",
+				isCompacting: true,
+			});
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("/skill:test-skill compact");
+
+		expect(queueCompactionMessage).toHaveBeenCalledWith("/skill:test-skill compact", "steer");
+		expect(enqueueCustomMessageDisplay).not.toHaveBeenCalled();
+		expect(promptCustomMessage).not.toHaveBeenCalled();
+	});
+
+	it("rejects image-bearing skill commands during compaction", async () => {
+		const { ctx, editor, promptCustomMessage, queueCompactionMessage, showStatus } = createStubInputControllerContext(
+			{
+				skillCommands,
+				isStreaming: true,
+				busyPromptMode: "queue",
+				isCompacting: true,
+			},
+		);
+		ctx.pendingImages = [{ type: "image", data: "image-data", mimeType: "image/png" }];
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("/skill:test-skill inspect [image 1]");
+
+		expect(showStatus).toHaveBeenCalledWith("Compaction in progress. Retry after it completes to send images.");
+		expect(queueCompactionMessage).not.toHaveBeenCalled();
+		expect(promptCustomMessage).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -16,7 +16,7 @@ import type {
 } from "../src/extensibility/extensions";
 import { CustomEditor } from "../src/modes/components/custom-editor";
 import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
-import { InteractiveMode } from "../src/modes/interactive-mode";
+import { DEFAULT_COMPOSER_PLACEHOLDER, InteractiveMode } from "../src/modes/interactive-mode";
 import { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
 import { associateSessionMessageEntryId, type SessionContext, SessionManager } from "../src/session/session-manager";
@@ -420,10 +420,6 @@ describe("InteractiveMode.setEditorComponent", () => {
 				.anchors.some(anchor => anchor?.id === `${liveId}:content:0:text`),
 		).toBe(true);
 	});
-	function expectedNewlineShortcutHint(): string {
-		const shortcut = process.platform === "win32" ? "Alt+Enter/Ctrl+J" : "Shift+Enter/Ctrl+J";
-		return `${shortcut}: New line`;
-	}
 
 	it("keeps the composer right border inside a trailing gutter for CJK input", () => {
 		mode.editor.focused = true;
@@ -444,31 +440,58 @@ describe("InteractiveMode.setEditorComponent", () => {
 		return `${shortcut}: Queue`;
 	}
 
-	it("shows busy steering and queueing hints only while work is active", () => {
-		let rendered = mode.editor.render(160).map(stripRenderControls).join("\n");
-		expect(rendered).toContain("Type your message...");
-		expect(rendered).toContain(expectedNewlineShortcutHint());
-		expect(rendered).toContain("Ctrl+C: Clear");
-		expect(rendered).toContain("Ctrl+R: Search history");
-		expect(rendered).toContain("Shift+Tab: Reasoning");
-		expect(rendered).not.toContain("Enter: Steer");
-		expect(rendered).not.toContain(expectedQueueShortcutHint());
+	function expectedOppositeBusyModeHint(action: "Steer" | "Queue"): string {
+		return process.platform === "darwin" ? ` · Command+Enter: ${action} once` : "";
+	}
+
+	function renderedPlaceholder(): string {
+		const line = mode.editor
+			.render(320)
+			.map(stripRenderControls)
+			.find(candidate => candidate.includes("Type your message..."));
+		if (!line) throw new Error("expected rendered composer placeholder");
+		const start = line.indexOf("Type your message...");
+		const end = line.lastIndexOf("│");
+		return line.slice(start, end > start ? end : undefined).trimEnd();
+	}
+
+	it("renders idle, streaming, and compaction composer placeholders with exact precedence", () => {
+		expect(renderedPlaceholder()).toBe(DEFAULT_COMPOSER_PLACEHOLDER);
 
 		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = true;
 		mode.updateEditorChrome();
 
-		rendered = mode.editor.render(160).map(stripRenderControls).join("\n");
-		expect(rendered).toContain("Type your message...");
-		expect(rendered).toContain("Enter: Steer");
-		expect(rendered).toContain(expectedQueueShortcutHint());
+		expect(renderedPlaceholder()).toBe(
+			`${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Steer · ${expectedQueueShortcutHint()}${expectedOppositeBusyModeHint("Queue")}`,
+		);
 
-		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = false;
+		mode.settings.set("busyPromptMode", "queue");
+		mode.updateEditorChrome();
+		expect(renderedPlaceholder()).toBe(
+			`${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Queue · ${expectedQueueShortcutHint()}${expectedOppositeBusyModeHint("Steer")}`,
+		);
+
+		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = true;
+		Object.defineProperty(session, "isCompacting", { configurable: true, get: () => true });
+		mode.updateEditorChrome();
+		expect(renderedPlaceholder()).toBe(`${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Queue after compaction`);
+	});
+
+	it("renders a remapped queue chord and omits it when both queue bindings are disabled", () => {
+		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = true;
+		const getKeys = vi.spyOn(mode.keybindings, "getKeys").mockImplementation(action => {
+			if (action === "app.message.followUp") return ["ctrl+shift+q"];
+			if (action === "app.message.queue") return ["alt+q"];
+			return [];
+		});
 		mode.updateEditorChrome();
 
-		rendered = mode.editor.render(160).map(stripRenderControls).join("\n");
-		expect(rendered).toContain("Type your message...");
-		expect(rendered).not.toContain("Enter: Steer");
-		expect(rendered).not.toContain(expectedQueueShortcutHint());
+		const remappedHint = process.platform === "darwin" ? "Ctrl+Shift+Q: Queue" : "Alt+Q: Queue";
+		expect(renderedPlaceholder()).toBe(`${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Steer · ${remappedHint}`);
+
+		getKeys.mockReturnValue([]);
+		mode.updateEditorChrome();
+		expect(renderedPlaceholder()).toBe(`${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Steer`);
 	});
 
 	it("renders the composer directly below the status line without hook widgets", async () => {

--- a/packages/coding-agent/test/keybindings-audit.test.ts
+++ b/packages/coding-agent/test/keybindings-audit.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { KEYBINDINGS } from "../src/config/keybindings";
+import {
+	defaultMessageQueueKeysForPlatform,
+	defaultOppositeBusyModeKeysForPlatform,
+	KEYBINDINGS,
+} from "../src/config/keybindings";
 
 const DOC_PATH = join(import.meta.dir, "../../../docs/keybindings.md");
 
@@ -10,5 +14,39 @@ describe("docs/keybindings.md current-surface audit", () => {
 		const doc = readFileSync(DOC_PATH, "utf8");
 		const missing = Object.keys(KEYBINDINGS).filter(id => !doc.includes(`\`${id}\``));
 		expect(missing).toEqual([]);
+	});
+
+	it("keeps follow-up and platform queue documentation aligned with the registry", () => {
+		const doc = readFileSync(DOC_PATH, "utf8");
+
+		expect(KEYBINDINGS["app.message.followUp"].description).toBe(
+			"Send follow-up message (no default; Ctrl+Enter remains editor newline unless remapped)",
+		);
+		expect(defaultMessageQueueKeysForPlatform("darwin")).toBe("alt+q");
+		expect(defaultMessageQueueKeysForPlatform("win32")).toBe("alt+q");
+		expect(defaultMessageQueueKeysForPlatform("linux")).toBe("alt+enter");
+		expect(defaultOppositeBusyModeKeysForPlatform("darwin")).toEqual(["super+enter"]);
+		expect(defaultOppositeBusyModeKeysForPlatform("win32")).toEqual([]);
+		expect(defaultOppositeBusyModeKeysForPlatform("linux")).toEqual([]);
+		expect(KEYBINDINGS["app.message.oppositeBusyMode"].description).toBe(
+			"Submit once using the opposite busy prompt mode",
+		);
+		expect(doc).toContain("| `app.message.queue` | `Alt+Q` (macOS/Windows), `Alt+Enter` (otherwise) |");
+		expect(doc).toContain("| `app.message.queue` | `alt+q` (macOS/Windows), `alt+enter` (otherwise) |");
+		expect(doc).toContain(
+			"On macOS and native Windows terminals, GJC defaults `app.message.queue` to `Alt+Q`; other platforms use `Alt+Enter`.",
+		);
+		expect(doc).toContain(
+			"| `app.message.followUp` | _(none)_ | Optional remap for a follow-up message; `Ctrl+Enter` remains editor newline unless remapped |",
+		);
+		expect(doc).toContain(
+			"| `app.message.followUp` | _(none)_ | `Ctrl+Enter` remains editor newline unless the user explicitly remaps this action; while idle the chord still falls through to newline |",
+		);
+		expect(doc).toContain(
+			"| `app.message.oppositeBusyMode` | `Command+Enter` (macOS) | Submit one message using the opposite of `busyPromptMode` |",
+		);
+		expect(doc).toContain(
+			"configured `steer` queues that message, while configured `queue` steers it into the active turn.",
+		);
 	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1,12 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Effort } from "@gajae-code/ai";
 import { onAppendOnlyModeChanged, resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
-import { getCustomThemesDir, getProjectAgentDir, Snowflake } from "@gajae-code/utils";
+import { getCustomThemesDir, getProjectAgentDir, logger, Snowflake } from "@gajae-code/utils";
 import { YAML } from "bun";
 import { withFileLock } from "../src/config/file-lock";
+import { SETTINGS_SCHEMA } from "../src/config/settings-schema";
+import { getSettingDef } from "../src/modes/components/settings-defs";
 import { createLightweightDaemonSettings } from "../src/sdk/bus/telegram-daemon-cli";
 
 describe("Settings", () => {
@@ -530,5 +532,43 @@ describe("Settings", () => {
 		const migration = schema?.properties?.session?.properties?.directoryMigration;
 		expect(migration?.default).toBe("copy-retain");
 		expect(migration?.enum).toEqual(["copy-retain", "disabled"]);
+	});
+
+	describe("busy prompt mode", () => {
+		it("derives the Interaction enum from the canonical schema", () => {
+			expect(SETTINGS_SCHEMA.busyPromptMode).toMatchObject({
+				type: "enum",
+				values: ["steer", "queue"],
+				default: "steer",
+				ui: { tab: "interaction" },
+			});
+			expect(getSettingDef("busyPromptMode")).toMatchObject({
+				path: "busyPromptMode",
+				type: "enum",
+				values: ["steer", "queue"],
+				tab: "interaction",
+			});
+		});
+		it("defaults invalid and absent values to steer while preserving queue", () => {
+			expect(Settings.isolated().get("busyPromptMode")).toBe("steer");
+			expect(Settings.isolated({ busyPromptMode: "queue" }).get("busyPromptMode")).toBe("queue");
+			expect(Settings.isolated({ busyPromptMode: "steer" }).get("busyPromptMode")).toBe("steer");
+			expect(Settings.isolated({ busyPromptMode: "later" }).get("busyPromptMode")).toBe("steer");
+			expect(Settings.isolated({ busyPromptMode: { mode: "queue" } }).get("busyPromptMode")).toBe("steer");
+		});
+
+		it("warns once for malformed persisted values without rewriting them", async () => {
+			await writeSettings({ busyPromptMode: { mode: "queue" } });
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(settings.get("busyPromptMode")).toBe("steer");
+			expect(settings.get("busyPromptMode")).toBe("steer");
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			expect(warnSpy).toHaveBeenCalledWith("Settings: invalid busyPromptMode; using steer", {
+				value: { mode: "queue" },
+			});
+			expect(await readSettings()).toEqual({ busyPromptMode: { mode: "queue" } });
+		});
 	});
 });

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -74,6 +74,13 @@ describe("matchesKey", () => {
 		setKittyProtocolActive(false);
 	});
 
+	it("matches Command+Enter through the Kitty super modifier", () => {
+		setKittyProtocolActive(true);
+		expect(matchesKey("\x1b[13;9u", "super+enter")).toBe(true);
+		expect(matchesKey("\x1b[13;9u", "enter")).toBe(false);
+		setKittyProtocolActive(false);
+	});
+
 	it("preserves keypad navigation matches when NumLock is on but modifiers are held", () => {
 		setKittyProtocolActive(true);
 		expect(matchesKey("\x1b[57400;133u", "ctrl+end")).toBe(true);
@@ -142,7 +149,7 @@ describe("parseKey", () => {
 
 	it("ignores Kitty sequences with unsupported modifiers", () => {
 		setKittyProtocolActive(true);
-		expect(parseKey("\x1b[99;9u")).toBeUndefined();
+		expect(parseKey("\x1b[99;17u")).toBeUndefined();
 		setKittyProtocolActive(false);
 	});
 });

--- a/scripts/generate-json-schemas.test.ts
+++ b/scripts/generate-json-schemas.test.ts
@@ -68,6 +68,13 @@ describe("generated JSON Schemas", () => {
 		})).toBe(false);
 	});
 
+	it("emits busy prompt mode enum and default", () => {
+		const schema = configSchema() as any;
+		expect(schema.properties.busyPromptMode).toMatchObject({
+			enum: ["steer", "queue"],
+			default: "steer",
+		});
+	});
 	it("emits web search fallback item enum and provider webSearch enum", () => {
 		const configSchema = JSON_SCHEMA_OUTPUTS.find(output => output.path === "schemas/config.schema.json")?.schema as any;
 		const fallbackItems = configSchema.properties.web_search.properties.fallback.items;


### PR DESCRIPTION
## Summary
- add schema-backed busy prompt routing with `steer` and `queue`, defaulting to `steer`
- add macOS Command+Enter one-message inversion through remappable `app.message.oppositeBusyMode`
- resolve built-in keybinding collision precedence while streaming
- prevent rapid duplicate shortcut submissions by claiming drafts synchronously
- preserve skill, image, compaction, shell, and Python submission boundaries
- add Kitty `super` modifier parsing

Supersedes closed PRs #2405 and #2430.

## Verification
- focused coding-agent/TUI/schema suite: 208 passed
- `bun --cwd=packages/coding-agent run check:schemas`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/test/custom-editor-keybindings.test.ts`
- `cargo test -p pi-natives keys::tests::parse_key_supports_kitty_super_modifier`
- `cargo fmt --check -- crates/pi-natives/src/keys.rs`