### PR TITLE
fix: release expired browser recovery holds

### DIFF
--- a/packages/coding-agent/src/tools/browser/dead-tab-recovery.ts
+++ b/packages/coding-agent/src/tools/browser/dead-tab-recovery.ts
@@ -1,0 +1,97 @@
+import { Snowflake } from "@gajae-code/utils";
+import type { BrowserHandle, BrowserKindTag } from "./registry";
+import type { ReadyInfo } from "./tab-protocol";
+
+export const DEAD_TAB_RECOVERY_TTL_MS = 30_000;
+
+export interface DeadTabRecoveryDescriptor {
+	readonly token: string;
+	readonly name: string;
+	readonly ownerId?: string;
+	readonly browser: BrowserHandle;
+	readonly kindTag: BrowserKindTag;
+	readonly targetId: string;
+	readonly info: Readonly<ReadyInfo>;
+	readonly dialogPolicy?: "accept" | "dismiss";
+	readonly createdAt: number;
+	readonly expiresAt: number;
+}
+
+export interface DeadTabRecoveryRegistration {
+	name: string;
+	ownerId?: string;
+	browser: BrowserHandle;
+	kindTag: BrowserKindTag;
+	targetId: string;
+	info: ReadyInfo;
+	dialogPolicy?: "accept" | "dismiss";
+}
+
+export class DeadTabRecoveryDescriptorRegistry {
+	#byToken = new Map<string, DeadTabRecoveryDescriptor>();
+	#tokenByName = new Map<string, string>();
+
+	constructor(private readonly ttlMs = DEAD_TAB_RECOVERY_TTL_MS) {}
+
+	register(input: DeadTabRecoveryRegistration, now = Date.now()): DeadTabRecoveryDescriptor {
+		this.invalidateName(input.name);
+		const token = Snowflake.next();
+		const descriptor: DeadTabRecoveryDescriptor = Object.freeze({
+			...input,
+			info: Object.freeze({ ...input.info, viewport: Object.freeze({ ...input.info.viewport }) }),
+			token,
+			createdAt: now,
+			expiresAt: now + this.ttlMs,
+		});
+		this.#byToken.set(token, descriptor);
+		this.#tokenByName.set(input.name, token);
+		return descriptor;
+	}
+
+	peekByName(name: string, now = Date.now()): DeadTabRecoveryDescriptor | undefined {
+		const token = this.#tokenByName.get(name);
+		if (!token) return undefined;
+		const descriptor = this.#byToken.get(token);
+		if (!descriptor) {
+			this.#tokenByName.delete(name);
+			return undefined;
+		}
+		if (descriptor.expiresAt <= now) {
+			this.#invalidateToken(token);
+			return undefined;
+		}
+		return descriptor;
+	}
+
+	consume(token: string, ownerId: string | undefined, now = Date.now()): DeadTabRecoveryDescriptor | undefined {
+		const descriptor = this.#byToken.get(token);
+		if (!descriptor) return undefined;
+		this.#invalidateToken(token);
+		if (descriptor.expiresAt <= now) return undefined;
+		if (descriptor.ownerId !== ownerId) return undefined;
+		return descriptor;
+	}
+
+	invalidateName(name: string): void {
+		const token = this.#tokenByName.get(name);
+		if (token) this.#invalidateToken(token);
+	}
+
+	invalidateOwner(ownerId: string | null | undefined): void {
+		if (!ownerId) return;
+		for (const descriptor of [...this.#byToken.values()]) {
+			if (descriptor.ownerId === ownerId) this.#invalidateToken(descriptor.token);
+		}
+	}
+
+	clear(): void {
+		this.#byToken.clear();
+		this.#tokenByName.clear();
+	}
+
+	#invalidateToken(token: string): void {
+		const descriptor = this.#byToken.get(token);
+		this.#byToken.delete(token);
+		if (descriptor && this.#tokenByName.get(descriptor.name) === token) this.#tokenByName.delete(descriptor.name);
+	}
+}

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -62,6 +62,8 @@ export interface TabSession {
 	lastUsedAt: number;
 	/** Set synchronously by the shared begin-release guard so concurrent release is a no-op. */
 	releasing?: boolean;
+	/** Recovered headless tabs run in attach mode, so graceful worker close only disconnects. */
+	recoveredFromDead?: boolean;
 }
 
 export interface AcquireTabOptions {
@@ -441,6 +443,7 @@ async function recoverDeadTabSessionOnce(
 		pending: new Map(),
 		releasing: false,
 		lastUsedAt: Date.now(),
+		recoveredFromDead: true,
 	};
 	worker.onMessage(msg => handleTabMessage(recovered, msg));
 	worker.onError(error => markTabDead(recovered, "worker-error", error));
@@ -511,7 +514,7 @@ export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Pr
 		}
 	}
 	await awaitWithinBudget(tab.worker.terminate(), remainingBudget(deadlineAt), "worker.terminate");
-	if (forced && tab.kindTag === "headless") {
+	if (tab.kindTag === "headless" && (forced || tab.recoveredFromDead)) {
 		await awaitWithinBudget(closeOrphanTarget(tab), remainingBudget(deadlineAt), "closeOrphanTarget");
 	}
 	await awaitWithinBudget(
@@ -671,6 +674,7 @@ function toErrorPayload(error: unknown): RunErrorPayload {
 }
 
 async function forceKillTab(name: string, reason: string): Promise<void> {
+	deadTabRecovery.invalidateName(name);
 	const tab = tabs.get(name);
 	if (!tab) return;
 	if (!beginRelease(tab)) return;

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -393,7 +393,10 @@ async function recoverDeadTabSessionOnce(
 		return undefined;
 	}
 	const consumed = deadTabRecovery.consume(descriptor.token, ownerId);
-	if (!consumed) return undefined;
+	if (!consumed) {
+		await releaseDeadTabIfCurrent(name, tab);
+		return undefined;
+	}
 	const targetId = await resolveRecoveryTargetId(consumed);
 	if (!targetId) {
 		await releaseDeadTabIfCurrent(name, tab);

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -5,6 +5,7 @@ import type { ToolSession } from "../../sdk";
 import { expandPath } from "../path-utils";
 import { ToolAbortError, ToolError } from "../tool-errors";
 import { pickElectronTarget } from "./attach";
+import { type DeadTabRecoveryDescriptor, DeadTabRecoveryDescriptorRegistry } from "./dead-tab-recovery";
 import { type BrowserHandle, type BrowserKindTag, holdBrowser, releaseBrowser } from "./registry";
 import type {
 	ReadyInfo,
@@ -98,6 +99,8 @@ export interface ReleaseTabOptions {
 }
 
 const tabs = new Map<string, TabSession>();
+const deadTabRecovery = new DeadTabRecoveryDescriptorRegistry();
+const recoveryByName = new Map<string, Promise<TabSession | undefined>>();
 const GRACE_MS = 750;
 
 /**
@@ -195,10 +198,14 @@ export async function releaseTabIfGcEligible(name: string, policy: BrowserGcElig
 	const tab = tabs.get(name);
 	if (!tab) return false;
 	if (tab.releasing) return false;
-	if (tab.state !== "alive") return false;
 	if (tab.pending.size !== 0) return false;
-	if (tab.kindTag !== "headless" && tab.kindTag !== "spawned") return false;
 	if (policy.now() - tab.lastUsedAt <= policy.idleMs) return false;
+	if (tab.state === "dead") {
+		if (recoveryByName.has(name)) return false;
+		if (deadTabRecovery.peekByName(name, policy.now())) return false;
+		return await releaseTab(name, { kill: false });
+	}
+	if (tab.kindTag !== "headless" && tab.kindTag !== "spawned") return false;
 	// All predicates passed synchronously; releaseTab applies the shared begin-release guard
 	// on the same microtask, so no other code runs between the check and the state transition.
 	return await releaseTab(name, { kill: false });
@@ -212,6 +219,14 @@ export function setTabForTest(tab: TabSession): void {
 /** Test-only: clear the tab registry between cases. */
 export function clearTabsForTest(): void {
 	tabs.clear();
+	deadTabRecovery.clear();
+	recoveryByName.clear();
+}
+
+/** Test-only: mark a fabricated tab dead through the production death path. */
+export function markTabDeadForTest(name: string, reason = "test"): void {
+	const tab = tabs.get(name);
+	if (tab) markTabDead(tab, reason);
 }
 
 export async function acquireTab(
@@ -290,6 +305,7 @@ export async function acquireTab(
 		lastUsedAt: Date.now(),
 	};
 	worker.onMessage(msg => handleTabMessage(tab, msg));
+	worker.onError(error => markTabDead(tab, "worker-error", error));
 	tabs.set(name, tab);
 	return { tab, created: true };
 }
@@ -307,7 +323,10 @@ async function runInTabWithSnapshot(
 	opts: { code: string; timeoutMs: number; signal?: AbortSignal; session?: ToolSession },
 	snapshot: SessionSnapshot,
 ): Promise<RunResultOk> {
-	const tab = tabs.get(name);
+	let tab = tabs.get(name);
+	if (tab?.state === "dead") {
+		tab = (await recoverDeadTabSession(name, tab, opts)) ?? tab;
+	}
 	if (!tab || tab.state === "dead") throw new ToolError(`Tab ${JSON.stringify(name)} is not alive. Reopen it.`);
 	if (tab.pending.size > 0) throw new ToolError(`Tab ${JSON.stringify(name)} is busy`);
 	tab.lastUsedAt = Date.now();
@@ -341,7 +360,127 @@ async function runInTabWithSnapshot(
 	}
 }
 
+async function recoverDeadTabSession(
+	name: string,
+	tab: TabSession,
+	opts: { code: string; timeoutMs: number; signal?: AbortSignal; session?: ToolSession },
+): Promise<TabSession | undefined> {
+	if (tab.releasing) return undefined;
+	const ownerId = tab.ownerId;
+	const callerOwnerId = opts.session?.getSessionId?.() ?? undefined;
+	if (ownerId !== callerOwnerId) return undefined;
+	const activeRecovery = recoveryByName.get(name);
+	if (activeRecovery) return await activeRecovery;
+	const recovery = recoverDeadTabSessionOnce(name, tab, opts, ownerId).finally(() => {
+		if (recoveryByName.get(name) === recovery) recoveryByName.delete(name);
+	});
+	recoveryByName.set(name, recovery);
+	return await recovery;
+}
+
+async function recoverDeadTabSessionOnce(
+	name: string,
+	tab: TabSession,
+	opts: { code: string; timeoutMs: number; signal?: AbortSignal; session?: ToolSession },
+	ownerId: string | undefined,
+): Promise<TabSession | undefined> {
+	if (opts.signal?.aborted) return undefined;
+	const descriptor = deadTabRecovery.peekByName(name);
+	if (!descriptor) {
+		await releaseDeadTabIfCurrent(name, tab);
+		return undefined;
+	}
+	const consumed = deadTabRecovery.consume(descriptor.token, ownerId);
+	if (!consumed) return undefined;
+	const targetId = await resolveRecoveryTargetId(consumed);
+	if (!targetId) {
+		await releaseDeadTabIfCurrent(name, tab);
+		return undefined;
+	}
+	const browserWSEndpoint = consumed.browser.browser.wsEndpoint();
+	if (!browserWSEndpoint) {
+		await releaseDeadTabIfCurrent(name, tab);
+		return undefined;
+	}
+
+	await tab.worker.terminate().catch(() => undefined);
+	const worker = await spawnTabWorker();
+	let info: ReadyInfo;
+	try {
+		info = await initializeTabWorker(
+			worker,
+			{
+				mode: "attach",
+				browserWSEndpoint,
+				safeDir: getPuppeteerDir(),
+				targetId,
+				dialogs: consumed.dialogPolicy,
+			},
+			opts.timeoutMs + GRACE_MS,
+		);
+	} catch (error) {
+		await worker.terminate().catch(() => undefined);
+		await releaseDeadTabIfCurrent(name, tab);
+		logger.debug("dead tab recovery failed during worker initialization", {
+			name,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return undefined;
+	}
+
+	if (tabs.get(name) !== tab || tab.releasing) {
+		await worker.terminate().catch(() => undefined);
+		return undefined;
+	}
+	const recovered: TabSession = {
+		...tab,
+		targetId,
+		worker,
+		state: "alive",
+		info,
+		pending: new Map(),
+		releasing: false,
+		lastUsedAt: Date.now(),
+	};
+	worker.onMessage(msg => handleTabMessage(recovered, msg));
+	worker.onError(error => markTabDead(recovered, "worker-error", error));
+	tabs.set(name, recovered);
+	logger.debug("Recovered dead browser tab", { name, targetId });
+	return recovered;
+}
+
+async function releaseDeadTabIfCurrent(name: string, tab: TabSession): Promise<void> {
+	if (tabs.get(name) !== tab || tab.releasing || tab.state !== "dead") return;
+	await releaseTab(name, { kill: false });
+}
+
+async function resolveRecoveryTargetId(descriptor: DeadTabRecoveryDescriptor): Promise<string | undefined> {
+	const matches: string[] = [];
+	for (const target of descriptor.browser.browser.targets()) {
+		const targetId = await targetIdForTarget(target).catch(() => undefined);
+		const page = await target.page().catch(() => null);
+		if (!targetId || !page) continue;
+		if (targetId === descriptor.targetId) return targetId;
+		const targetUrl =
+			typeof (target as { url?: () => string }).url === "function" ? (target as { url: () => string }).url() : "";
+		const pageUrl = targetUrl || page.url();
+		if (pageUrl !== descriptor.info.url) continue;
+		if (descriptor.info.title) {
+			const title = await page.title().catch(() => undefined);
+			if (title !== descriptor.info.title) continue;
+		}
+		matches.push(targetId);
+	}
+	return matches.length === 1 ? matches[0] : undefined;
+}
+
+export async function resolveDeadTabRecoveryTargetIdForTest(
+	descriptor: DeadTabRecoveryDescriptor,
+): Promise<string | undefined> {
+	return await resolveRecoveryTargetId(descriptor);
+}
 export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Promise<boolean> {
+	deadTabRecovery.invalidateName(name);
 	const tab = tabs.get(name);
 	if (!tab) {
 		logger.debug("releaseTab: unknown tab", { name });
@@ -404,6 +543,7 @@ export async function releaseTabsForOwner(
 	opts: ReleaseTabOptions = {},
 ): Promise<number> {
 	if (!ownerId) return 0;
+	deadTabRecovery.invalidateOwner(ownerId);
 	const names = [...tabs.entries()].filter(([, tab]) => tab.ownerId === ownerId).map(([name]) => name);
 	let count = 0;
 	for (const name of names) {
@@ -463,6 +603,10 @@ function handleTabMessage(tab: TabSession, msg: WorkerOutbound): void {
 	}
 	if (msg.type === "tool-call") {
 		void dispatchToolCall(tab, msg);
+		return;
+	}
+	if (msg.type === "closed") {
+		markTabDead(tab, "worker-closed");
 		return;
 	}
 	if (msg.type === "log") logWorkerMessage(msg);
@@ -538,6 +682,36 @@ async function forceKillTab(name: string, reason: string): Promise<void> {
 	if (tab.kindTag === "headless") await closeOrphanTarget(tab);
 	await releaseBrowser(tab.browser, { kill: false });
 	if (tabs.get(name) === tab) tabs.delete(name);
+}
+
+function markTabDead(tab: TabSession, reason: string, error?: Error): void {
+	if (tab.state === "dead" || tab.releasing) return;
+	tab.state = "dead";
+	const deadAt = Date.now();
+	tab.lastUsedAt = deadAt;
+	deadTabRecovery.register(
+		{
+			name: tab.name,
+			ownerId: tab.ownerId,
+			browser: tab.browser,
+			kindTag: tab.kindTag,
+			targetId: tab.targetId,
+			info: tab.info,
+			dialogPolicy: tab.dialogPolicy,
+		},
+		deadAt,
+	);
+	const failure = new ToolError(`Tab ${JSON.stringify(tab.name)} is not alive. Reopen it.`);
+	if (error) (failure as { cause?: unknown }).cause = error;
+	for (const [id, pending] of tab.pending) {
+		try {
+			tab.worker.send({ type: "abort", id });
+		} catch {}
+		pending.reject(failure);
+	}
+	tab.pending.clear();
+	void tab.worker.terminate().catch(() => undefined);
+	logger.debug("Marked browser tab dead", { name: tab.name, reason, error: error?.message });
 }
 
 async function closeOrphanTarget(tab: TabSession): Promise<void> {

--- a/packages/coding-agent/src/tools/resource-gc.ts
+++ b/packages/coding-agent/src/tools/resource-gc.ts
@@ -11,10 +11,11 @@ import { cleanupStaleScreenshotFallbackDirs, hasCreatedScreenshotFallbackDir } f
  *    processes) via an idle sweep and an opportunistic RSS-pressure sweep, and
  *  - stale computer-use screenshot fallback directories on disk (lazy-armed + throttled).
  *
- * Eviction targets ONLY alive, non-in-flight, GJC-managed headless/spawned tabs owned by a
- * registered session; connected/real-Chrome/held/in-flight tabs and ownerless tabs are never
- * touched. RSS is the GJC parent-process RSS only (`process.memoryUsage().rss`); pressure
- * eviction is best-effort and never force-evicts.
+ * Eviction targets idle, non-in-flight, GJC-managed tabs owned by a registered session: live
+ * headless/spawned tabs, plus dead tabs whose recovery descriptor has expired. Connected/real
+ * Chrome live tabs, held/in-flight tabs, and ownerless tabs are never touched. RSS is the GJC
+ * parent-process RSS only (`process.memoryUsage().rss`); pressure eviction is best-effort and
+ * never force-evicts.
  */
 
 const DEFAULT_SWEEP_INTERVAL_MS = 30_000;
@@ -176,11 +177,9 @@ function ownerBrowserPolicy(snapshot: TabGcSnapshot): BrowserGcPolicy | null {
 
 /** Coarse, ordering-only eligibility; the live recheck in releaseTabIfGcEligible is authoritative. */
 function isCoarselyEligible(snapshot: TabGcSnapshot): boolean {
-	return (
-		snapshot.state === "alive" &&
-		snapshot.pendingCount === 0 &&
-		(snapshot.kindTag === "headless" || snapshot.kindTag === "spawned")
-	);
+	if (snapshot.pendingCount !== 0) return false;
+	if (snapshot.state === "dead") return true;
+	return snapshot.state === "alive" && (snapshot.kindTag === "headless" || snapshot.kindTag === "spawned");
 }
 
 /** Collect idle, non-in-flight, GJC-managed, owned-and-enabled tabs, sorted LRU (oldest first). */

--- a/packages/coding-agent/test/tools/browser-dead-tab-recovery.test.ts
+++ b/packages/coding-agent/test/tools/browser-dead-tab-recovery.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "bun:test";
+import { DeadTabRecoveryDescriptorRegistry } from "../../src/tools/browser/dead-tab-recovery";
+import type { BrowserHandle } from "../../src/tools/browser/registry";
+import { resolveDeadTabRecoveryTargetIdForTest } from "../../src/tools/browser/tab-supervisor";
+
+function fakeBrowserHandle(): BrowserHandle {
+	return {
+		key: "headless:true",
+		kind: { kind: "headless", headless: true },
+		browser: { targets: () => [], wsEndpoint: () => "ws://browser" } as never,
+		refCount: 1,
+		stealth: { browserSession: null, override: null },
+	};
+}
+
+function fakeTarget(targetId: string, url: string, title = "Example") {
+	return {
+		url: () => url,
+		page: async () => ({ url: () => url, title: async () => title }),
+		createCDPSession: async () => ({
+			send: async () => ({ targetInfo: { targetId } }),
+			detach: async () => {},
+		}),
+	};
+}
+
+function fakeBrowserHandleWithTargets(targets: unknown[]): BrowserHandle {
+	return {
+		...fakeBrowserHandle(),
+		browser: { targets: () => targets, wsEndpoint: () => "ws://browser" } as never,
+	};
+}
+
+describe("dead tab recovery descriptor registry", () => {
+	it("consumes descriptors once and binds them to the owning session", () => {
+		const registry = new DeadTabRecoveryDescriptorRegistry(1_000);
+		const descriptor = registry.register(
+			{
+				name: "main",
+				ownerId: "session-a",
+				browser: fakeBrowserHandle(),
+				kindTag: "headless",
+				targetId: "target-1",
+				info: { url: "https://example.test", targetId: "target-1", viewport: { width: 800, height: 600 } },
+			},
+			100,
+		);
+
+		expect(Object.isFrozen(descriptor)).toBe(true);
+		expect(Object.isFrozen(descriptor.info)).toBe(true);
+		expect(registry.consume(descriptor.token, "session-b", 101)).toBeUndefined();
+		expect(registry.consume(descriptor.token, "session-a", 101)).toBeUndefined();
+	});
+
+	it("allows the owning session to consume exactly once", () => {
+		const registry = new DeadTabRecoveryDescriptorRegistry(1_000);
+		const descriptor = registry.register(
+			{
+				name: "main",
+				ownerId: "session-a",
+				browser: fakeBrowserHandle(),
+				kindTag: "headless",
+				targetId: "target-1",
+				info: { url: "https://example.test", targetId: "target-1", viewport: { width: 800, height: 600 } },
+			},
+			100,
+		);
+
+		expect(registry.consume(descriptor.token, "session-a", 101)?.targetId).toBe("target-1");
+		expect(registry.consume(descriptor.token, "session-a", 102)).toBeUndefined();
+	});
+
+	it("expires descriptors and invalidates owner-scoped recovery", () => {
+		const registry = new DeadTabRecoveryDescriptorRegistry(50);
+		const descriptor = registry.register(
+			{
+				name: "main",
+				ownerId: "session-a",
+				browser: fakeBrowserHandle(),
+				kindTag: "headless",
+				targetId: "target-1",
+				info: { url: "https://example.test", targetId: "target-1", viewport: { width: 800, height: 600 } },
+			},
+			100,
+		);
+
+		expect(registry.peekByName("main", 149)?.token).toBe(descriptor.token);
+		expect(registry.peekByName("main", 150)).toBeUndefined();
+
+		const fresh = registry.register(
+			{
+				name: "main",
+				ownerId: "session-a",
+				browser: fakeBrowserHandle(),
+				kindTag: "headless",
+				targetId: "target-2",
+				info: { url: "https://example.test", targetId: "target-2", viewport: { width: 800, height: 600 } },
+			},
+			200,
+		);
+		registry.invalidateOwner("session-a");
+		expect(registry.consume(fresh.token, "session-a", 201)).toBeUndefined();
+	});
+});
+
+describe("dead tab recovery target matching", () => {
+	it("prefers exact target identity over fallback matching", async () => {
+		const browser = fakeBrowserHandleWithTargets([
+			fakeTarget("fallback", "https://example.test", "Example"),
+			fakeTarget("target-1", "https://other.test", "Other"),
+		]);
+
+		await expect(
+			resolveDeadTabRecoveryTargetIdForTest({
+				token: "token",
+				name: "main",
+				ownerId: "session-a",
+				browser,
+				kindTag: "headless",
+				targetId: "target-1",
+				info: {
+					url: "https://example.test",
+					title: "Example",
+					targetId: "target-1",
+					viewport: { width: 800, height: 600 },
+				},
+				createdAt: 0,
+				expiresAt: 1_000,
+			}),
+		).resolves.toBe("target-1");
+	});
+
+	it("allows only a unique verified fallback target", async () => {
+		const unique = fakeBrowserHandleWithTargets([fakeTarget("target-2", "https://example.test", "Example")]);
+		await expect(
+			resolveDeadTabRecoveryTargetIdForTest({
+				token: "token",
+				name: "main",
+				ownerId: "session-a",
+				browser: unique,
+				kindTag: "headless",
+				targetId: "missing",
+				info: {
+					url: "https://example.test",
+					title: "Example",
+					targetId: "missing",
+					viewport: { width: 800, height: 600 },
+				},
+				createdAt: 0,
+				expiresAt: 1_000,
+			}),
+		).resolves.toBe("target-2");
+
+		const ambiguous = fakeBrowserHandleWithTargets([
+			fakeTarget("target-2", "https://example.test", "Example"),
+			fakeTarget("target-3", "https://example.test", "Example"),
+		]);
+		await expect(
+			resolveDeadTabRecoveryTargetIdForTest({
+				token: "token",
+				name: "main",
+				ownerId: "session-a",
+				browser: ambiguous,
+				kindTag: "headless",
+				targetId: "missing",
+				info: {
+					url: "https://example.test",
+					title: "Example",
+					targetId: "missing",
+					viewport: { width: 800, height: 600 },
+				},
+				createdAt: 0,
+				expiresAt: 1_000,
+			}),
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/tools/browser-gc.test.ts
+++ b/packages/coding-agent/test/tools/browser-gc.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { Browser } from "puppeteer-core";
+import { DEAD_TAB_RECOVERY_TTL_MS } from "../../src/tools/browser/dead-tab-recovery";
 import type { BrowserHandle, BrowserKindTag } from "../../src/tools/browser/registry";
 import {
 	clearTabsForTest,
 	getTab,
 	listTabsForGc,
+	markTabDeadForTest,
 	releaseTab,
 	releaseTabIfGcEligible,
 	setTabForTest,
@@ -124,7 +126,6 @@ describe("tab-supervisor GC primitives", () => {
 		{ label: "in-flight", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW - 5000, pendingCount: 1 } },
 		{ label: "recently used", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW } },
 		{ label: "idle exactly at threshold", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW - IDLE_MS } },
-		{ label: "dead", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW - 5000, state: "dead" } },
 	];
 
 	for (const { label, opts } of protectedCases) {
@@ -144,6 +145,45 @@ describe("tab-supervisor GC primitives", () => {
 		getTab("a")?.pending.set("run", { reject: () => {}, resolve: () => {}, toolCalls: new Map() } as never);
 		expect(await releaseTabIfGcEligible("a", policy)).toBe(false);
 		expect(getTab("a")).toBeDefined();
+	});
+
+	it("holds a dead tab during the recovery window and evicts it after the descriptor expires", async () => {
+		const { close, terminate } = installTab({ name: "a", kindTag: "headless", lastUsedAt: NOW - 5000 });
+		markTabDeadForTest("a", "worker-closed");
+		const deadAt = getTab("a")?.lastUsedAt;
+		expect(deadAt).toBeDefined();
+
+		expect(
+			await releaseTabIfGcEligible("a", {
+				now: () => deadAt! + DEAD_TAB_RECOVERY_TTL_MS - 1,
+				idleMs: 0,
+			}),
+		).toBe(false);
+		expect(getTab("a")).toBeDefined();
+
+		expect(
+			await releaseTabIfGcEligible("a", {
+				now: () => deadAt! + DEAD_TAB_RECOVERY_TTL_MS + 1,
+				idleMs: 0,
+			}),
+		).toBe(true);
+		expect(terminate).toHaveBeenCalled();
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(getTab("a")).toBeUndefined();
+	});
+
+	it("evicts an idle dead tab with no recovery descriptor", async () => {
+		const { close, terminate } = installTab({
+			name: "a",
+			kindTag: "headless",
+			lastUsedAt: NOW - 5000,
+			state: "dead",
+		});
+
+		expect(await releaseTabIfGcEligible("a", policy)).toBe(true);
+		expect(terminate).toHaveBeenCalledTimes(1);
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(getTab("a")).toBeUndefined();
 	});
 
 	it("decrements browser refCount exactly once under concurrent double release", async () => {

--- a/packages/coding-agent/test/tools/browser-gc.test.ts
+++ b/packages/coding-agent/test/tools/browser-gc.test.ts
@@ -9,6 +9,7 @@ import {
 	markTabDeadForTest,
 	releaseTab,
 	releaseTabIfGcEligible,
+	runInTab,
 	setTabForTest,
 	type TabSession,
 } from "../../src/tools/browser/tab-supervisor";
@@ -81,6 +82,7 @@ interface InstallOpts {
 	refCount?: number;
 	recoveredFromDead?: boolean;
 	targetClose?: ReturnType<typeof vi.fn>;
+	ownerId?: string;
 }
 
 function installTab(opts: InstallOpts): {
@@ -105,6 +107,7 @@ function installTab(opts: InstallOpts): {
 		kindTag: opts.kindTag,
 		lastUsedAt: opts.lastUsedAt,
 		recoveredFromDead: opts.recoveredFromDead,
+		ownerId: opts.ownerId,
 	} as unknown as TabSession;
 	setTabForTest(tab);
 	return { close, terminate, handle };
@@ -197,6 +200,35 @@ describe("tab-supervisor GC primitives", () => {
 		expect(await releaseTabIfGcEligible("a", policy)).toBe(true);
 		expect(terminate).toHaveBeenCalledTimes(1);
 		expect(close).toHaveBeenCalledTimes(1);
+		expect(getTab("a")).toBeUndefined();
+	});
+
+	it("releases a dead tab when its recovery descriptor expires during consume", async () => {
+		const { close, handle, terminate } = installTab({
+			name: "a",
+			kindTag: "headless",
+			lastUsedAt: NOW - 5000,
+			ownerId: "session-1",
+		});
+		const nowValues = [NOW, NOW + DEAD_TAB_RECOVERY_TTL_MS - 1, NOW + DEAD_TAB_RECOVERY_TTL_MS + 1];
+		vi.spyOn(Date, "now").mockImplementation(() => nowValues.shift() ?? NOW + DEAD_TAB_RECOVERY_TTL_MS + 1);
+		markTabDeadForTest("a", "worker-closed");
+
+		await expect(
+			runInTab("a", {
+				code: "return 1",
+				timeoutMs: 10,
+				session: {
+					cwd: "/tmp",
+					getSessionId: () => "session-1",
+					settings: { get: () => undefined },
+				} as never,
+			}),
+		).rejects.toThrow('Tab "a" is not alive. Reopen it.');
+
+		expect(terminate).toHaveBeenCalled();
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(handle.refCount).toBe(0);
 		expect(getTab("a")).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/tools/browser-gc.test.ts
+++ b/packages/coding-agent/test/tools/browser-gc.test.ts
@@ -19,14 +19,25 @@ const policy = { now: () => NOW, idleMs: IDLE_MS };
 
 let counter = 0;
 
-function makeFakeBrowser(refCount: number): { handle: BrowserHandle; close: ReturnType<typeof vi.fn> } {
+function makeFakeBrowser(
+	refCount: number,
+	targetClose?: ReturnType<typeof vi.fn>,
+): { handle: BrowserHandle; close: ReturnType<typeof vi.fn> } {
 	const close = vi.fn(async () => {});
 	const browser = {
 		connected: true,
 		close,
 		disconnect: vi.fn(() => {}),
 		process: () => null,
-		targets: () => [],
+		targets: () =>
+			targetClose
+				? [
+						{
+							_targetId: "target-1",
+							page: async () => ({ close: targetClose }),
+						},
+					]
+				: [],
 	} as unknown as Browser;
 	const handle = {
 		key: `headless:test-${counter++}`,
@@ -68,6 +79,8 @@ interface InstallOpts {
 	state?: "alive" | "dead";
 	pendingCount?: number;
 	refCount?: number;
+	recoveredFromDead?: boolean;
+	targetClose?: ReturnType<typeof vi.fn>;
 }
 
 function installTab(opts: InstallOpts): {
@@ -75,7 +88,7 @@ function installTab(opts: InstallOpts): {
 	terminate: ReturnType<typeof vi.fn>;
 	handle: BrowserHandle;
 } {
-	const { handle, close } = makeFakeBrowser(opts.refCount ?? 1);
+	const { handle, close } = makeFakeBrowser(opts.refCount ?? 1, opts.targetClose);
 	const { worker, terminate } = makeFakeWorker();
 	const pending = new Map<string, unknown>();
 	for (let i = 0; i < (opts.pendingCount ?? 0); i++) {
@@ -91,6 +104,7 @@ function installTab(opts: InstallOpts): {
 		pending,
 		kindTag: opts.kindTag,
 		lastUsedAt: opts.lastUsedAt,
+		recoveredFromDead: opts.recoveredFromDead,
 	} as unknown as TabSession;
 	setTabForTest(tab);
 	return { close, terminate, handle };
@@ -192,6 +206,25 @@ describe("tab-supervisor GC primitives", () => {
 		expect([r1, r2].filter(Boolean)).toHaveLength(1);
 		expect(close).toHaveBeenCalledTimes(1);
 		expect(handle.refCount).toBe(0);
+		expect(getTab("a")).toBeUndefined();
+	});
+	it("closes recovered headless page targets on graceful release while the shared browser stays open", async () => {
+		const targetClose = vi.fn(async () => {});
+		const { close, handle, terminate } = installTab({
+			name: "a",
+			kindTag: "headless",
+			lastUsedAt: NOW - 5000,
+			refCount: 2,
+			recoveredFromDead: true,
+			targetClose,
+		});
+
+		expect(await releaseTab("a", { kill: false })).toBe(true);
+
+		expect(terminate).toHaveBeenCalledTimes(1);
+		expect(targetClose).toHaveBeenCalledTimes(1);
+		expect(close).not.toHaveBeenCalled();
+		expect(handle.refCount).toBe(1);
 		expect(getTab("a")).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/tools/resource-gc.test.ts
+++ b/packages/coding-agent/test/tools/resource-gc.test.ts
@@ -78,6 +78,29 @@ describe("resource GC controller", () => {
 		expect(releaseTab.mock.calls.map(c => c[0])).toEqual(["old", "mid"]);
 	});
 
+	it("idle sweep sends expired dead tabs to the authoritative release recheck", async () => {
+		const settings = Settings.isolated({
+			"browser.gc.enabled": true,
+			"browser.gc.idleMs": 1000,
+			"browser.gc.rssLimitMb": 1_000_000,
+			"computer.screenshotGc.enabled": false,
+		});
+		registerResourceGcSession({ sessionId: "s1", settings });
+		const releaseTab = vi.fn(async (_name: string) => true);
+
+		await sweepOnce(
+			baseDeps({
+				releaseTab,
+				listTabs: () => [
+					snapshot("dead", "s1", NOW - 5000, { state: "dead", kindTag: "connected" }),
+					snapshot("live-connected", "s1", NOW - 5000, { kindTag: "connected" }),
+				],
+			}),
+		);
+
+		expect(releaseTab.mock.calls.map(c => c[0])).toEqual(["dead"]);
+	});
+
 	it("skips tabs owned by no registered session", async () => {
 		const settings = Settings.isolated({ "browser.gc.idleMs": 1000, "browser.gc.rssLimitMb": 1_000_000 });
 		registerResourceGcSession({ sessionId: "s1", settings });


### PR DESCRIPTION
## Summary
- preserve the browser dead-tab recovery fixes from the previous submission
- immediately release the current dead tab when a recovery descriptor expires between `peekByName()` and `consume()`
- add regression coverage for the peek→consume expiry race so stale tab/browser holds are not deferred to GC

## Submission note
- This is a substantive follow-up, not an unchanged resubmission: new head commit `15e93486` adds a code fix and regression coverage for an existing non-blocking cleanup gap.
- Supersedes closed PRs #2428, #2425, and #2296.

## Verification
- `bun --cwd=packages/coding-agent run check` → passed
- `bun test packages/coding-agent/test/tools/browser-gc.test.ts` is locally blocked on this workstation by stale `@gajae-code/natives` darwin-arm64 binary sentinel mismatch; CI should exercise it with the Linux native build.