### PR TITLE
feat(tui): command palette with direct dispatch; drafts are never touched

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 ### Fixed
-- Palette command dispatch now stashes and clears the composer before command cleanup, restores only unchanged same-session editors, and records non-empty stashes in prompt history so cleared, submitted, or switched-session drafts are never resurrected or lost.
+- Palette slash commands now run only from an empty composer; drafts are never touched.
 
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
-- Added a searchable command palette for available composer actions and slash commands; palette slash commands run one at a time and preserve newer drafts and attachments while command cleanup settles.
+- Added a searchable command palette with direct action dispatch; slash commands run only from an empty composer, and drafts are never touched.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
+- Added a searchable command palette for keybound actions and slash commands.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Palette command dispatch now stashes and clears the composer before command cleanup, restores only unchanged same-session editors, and records non-empty stashes in prompt history so cleared, submitted, or switched-session drafts are never resurrected or lost.
+
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
 - Added a searchable command palette for available composer actions and slash commands; palette slash commands run one at a time and preserve newer drafts and attachments while command cleanup settles.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
-- Added a searchable command palette for available composer actions and slash commands.
+- Added a searchable command palette for available composer actions and slash commands; palette slash commands run one at a time and preserve newer drafts and attachments while command cleanup settles.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
-- Added a searchable command palette for keybound actions and slash commands.
+- Added a searchable command palette for available composer actions and slash commands.
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/components/command-palette.ts
+++ b/packages/coding-agent/src/modes/components/command-palette.ts
@@ -24,7 +24,7 @@ export interface CommandPaletteEntry {
 	description: string;
 	keybinding?: string;
 	searchText?: string;
-	handler?: () => void;
+	handler?: () => void | Promise<void>;
 }
 
 class CommandPaletteList implements Component {

--- a/packages/coding-agent/src/modes/components/command-palette.ts
+++ b/packages/coding-agent/src/modes/components/command-palette.ts
@@ -1,0 +1,120 @@
+import {
+	type Component,
+	Container,
+	fuzzyFilter,
+	Input,
+	matchesKey,
+	padding,
+	replaceTabs,
+	truncateToWidth,
+	visibleWidth,
+} from "@gajae-code/tui";
+import { theme } from "../../modes/theme/theme";
+import { DynamicBorder } from "./dynamic-border";
+
+export interface CommandPaletteEntry {
+	id: string;
+	label: string;
+	description: string;
+	keybinding?: string;
+	searchText?: string;
+}
+
+class CommandPaletteList implements Component {
+	#filteredEntries: CommandPaletteEntry[];
+	#selectedIndex = 0;
+	readonly #searchInput = new Input();
+	onSelect?: (entry: CommandPaletteEntry) => void;
+	onCancel?: () => void;
+
+	constructor(private readonly entries: CommandPaletteEntry[]) {
+		this.#filteredEntries = entries;
+	}
+
+	#filter(query: string): void {
+		this.#filteredEntries = fuzzyFilter(this.entries, query, entry =>
+			[entry.label, entry.description, entry.keybinding ?? "", entry.searchText ?? ""].join(" "),
+		);
+		this.#selectedIndex = Math.max(0, Math.min(this.#selectedIndex, this.#filteredEntries.length - 1));
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const lines = [theme.fg("muted", "  Search commands"), ...this.#searchInput.render(width), ""];
+		if (this.#filteredEntries.length === 0) {
+			lines.push(theme.fg("muted", "  No matching commands"));
+			return lines;
+		}
+
+		const maxVisible = 8;
+		const start = Math.max(
+			0,
+			Math.min(this.#selectedIndex - Math.floor(maxVisible / 2), this.#filteredEntries.length - maxVisible),
+		);
+		const end = Math.min(start + maxVisible, this.#filteredEntries.length);
+		for (let index = start; index < end; index += 1) {
+			const entry = this.#filteredEntries[index];
+			if (!entry) continue;
+			const selected = index === this.#selectedIndex;
+			const cursor = `${theme.nav.cursor} `;
+			const prefix = selected ? theme.fg("accent", cursor) : padding(visibleWidth(cursor));
+			const keybinding = entry.keybinding ? theme.fg("muted", entry.keybinding) : "";
+			const availableLabelWidth = Math.max(
+				1,
+				width - visibleWidth(prefix) - visibleWidth(keybinding) - (keybinding ? 1 : 0),
+			);
+			const label = truncateToWidth(replaceTabs(entry.label), availableLabelWidth);
+			const labelPadding = padding(Math.max(0, availableLabelWidth - visibleWidth(label)));
+			lines.push(
+				prefix + (selected ? theme.bold(label) : label) + labelPadding + (keybinding ? ` ${keybinding}` : ""),
+			);
+			lines.push(theme.fg("dim", truncateToWidth(`  ${replaceTabs(entry.description)}`, width)));
+		}
+		if (start > 0 || end < this.#filteredEntries.length) {
+			lines.push(theme.fg("muted", `  (${this.#selectedIndex + 1}/${this.#filteredEntries.length})`));
+		}
+		lines.push("", theme.fg("muted", "  [Enter to run, Esc to close]"));
+		return lines;
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, "escape")) {
+			this.onCancel?.();
+			return;
+		}
+		if (matchesKey(data, "up")) {
+			this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);
+			return;
+		}
+		if (matchesKey(data, "down")) {
+			this.#selectedIndex = Math.min(this.#filteredEntries.length - 1, this.#selectedIndex + 1);
+			return;
+		}
+		if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
+			const entry = this.#filteredEntries[this.#selectedIndex];
+			if (entry) this.onSelect?.(entry);
+			return;
+		}
+		this.#searchInput.handleInput(data);
+		this.#filter(this.#searchInput.getValue());
+	}
+}
+
+export class CommandPaletteComponent extends Container {
+	#list: CommandPaletteList;
+
+	constructor(entries: CommandPaletteEntry[], onSelect: (entry: CommandPaletteEntry) => void, onCancel: () => void) {
+		super();
+		this.addChild(new DynamicBorder());
+		this.#list = new CommandPaletteList(entries);
+		this.#list.onSelect = onSelect;
+		this.#list.onCancel = onCancel;
+		this.addChild(this.#list);
+		this.addChild(new DynamicBorder());
+	}
+
+	handleInput(data: string): void {
+		this.#list.handleInput(data);
+	}
+}

--- a/packages/coding-agent/src/modes/components/command-palette.ts
+++ b/packages/coding-agent/src/modes/components/command-palette.ts
@@ -15,7 +15,7 @@ import { DynamicBorder } from "./dynamic-border";
 export interface CommandPaletteAction {
 	id: string;
 	label: string;
-	handler: () => void;
+	handler: () => void | Promise<void>;
 }
 
 export interface CommandPaletteEntry {

--- a/packages/coding-agent/src/modes/components/command-palette.ts
+++ b/packages/coding-agent/src/modes/components/command-palette.ts
@@ -12,12 +12,19 @@ import {
 import { theme } from "../../modes/theme/theme";
 import { DynamicBorder } from "./dynamic-border";
 
+export interface CommandPaletteAction {
+	id: string;
+	label: string;
+	handler: () => void;
+}
+
 export interface CommandPaletteEntry {
 	id: string;
 	label: string;
 	description: string;
 	keybinding?: string;
 	searchText?: string;
+	handler?: () => void;
 }
 
 class CommandPaletteList implements Component {

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -107,10 +107,6 @@ export class CustomEditor extends Editor {
 	onViewportPageScroll?: (direction: -1 | 1) => void;
 	/** Called before regular composer input should return the transcript viewport to the live bottom. */
 	onViewportFollowLive?: () => void;
-	/** Called after keyboard or bracketed-paste input changes composer text. */
-	onUserEdit?: () => void;
-	/** Return true to consume a programmatic composer update. */
-	onProgrammaticSetText?: (text: string) => boolean;
 
 	/** Custom key handlers from extensions and non-built-in app actions. */
 	#customKeyHandlers = new Map<KeyId, () => boolean | undefined>();
@@ -122,12 +118,6 @@ export class CustomEditor extends Editor {
 	#pasteDecisionToken = 0;
 	#pasteDecisionTimeout: NodeJS.Timeout | undefined;
 	#pendingPasteInput: string[] = [];
-	#handlingUserInput = false;
-
-	override setText(text: string): void {
-		if (!this.#handlingUserInput && this.onProgrammaticSetText?.(text)) return;
-		super.setText(text);
-	}
 
 	setActionKeys(action: ConfigurableEditorAction, keys: KeyId[]): void {
 		this.#actionKeys.set(action, [...keys]);
@@ -216,11 +206,7 @@ export class CustomEditor extends Editor {
 			if (token !== this.#pasteDecisionToken) return;
 			this.#clearPasteDecisionTimeout();
 			if (!handled) {
-				const textBeforeInput = this.getText();
-				this.#handlingUserInput = true;
 				super.handleInput(`\x1b[200~${pasteContent}\x1b[201~`);
-				this.#handlingUserInput = false;
-				if (this.getText() !== textBeforeInput) this.onUserEdit?.();
 			}
 			this.#pasteDecisionPending = false;
 			this.#drainPendingPasteInput(remaining);
@@ -417,10 +403,6 @@ export class CustomEditor extends Editor {
 		}
 
 		// Pass to parent for normal handling.
-		const textBeforeInput = this.getText();
-		this.#handlingUserInput = true;
 		super.handleInput(data);
-		this.#handlingUserInput = false;
-		if (this.getText() !== textBeforeInput) this.onUserEdit?.();
 	}
 }

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -107,6 +107,10 @@ export class CustomEditor extends Editor {
 	onViewportPageScroll?: (direction: -1 | 1) => void;
 	/** Called before regular composer input should return the transcript viewport to the live bottom. */
 	onViewportFollowLive?: () => void;
+	/** Called after keyboard or bracketed-paste input changes composer text. */
+	onUserEdit?: () => void;
+	/** Return true to consume a programmatic composer update. */
+	onProgrammaticSetText?: (text: string) => boolean;
 
 	/** Custom key handlers from extensions and non-built-in app actions. */
 	#customKeyHandlers = new Map<KeyId, () => boolean | undefined>();
@@ -118,6 +122,12 @@ export class CustomEditor extends Editor {
 	#pasteDecisionToken = 0;
 	#pasteDecisionTimeout: NodeJS.Timeout | undefined;
 	#pendingPasteInput: string[] = [];
+	#handlingUserInput = false;
+
+	override setText(text: string): void {
+		if (!this.#handlingUserInput && this.onProgrammaticSetText?.(text)) return;
+		super.setText(text);
+	}
 
 	setActionKeys(action: ConfigurableEditorAction, keys: KeyId[]): void {
 		this.#actionKeys.set(action, [...keys]);
@@ -206,7 +216,11 @@ export class CustomEditor extends Editor {
 			if (token !== this.#pasteDecisionToken) return;
 			this.#clearPasteDecisionTimeout();
 			if (!handled) {
+				const textBeforeInput = this.getText();
+				this.#handlingUserInput = true;
 				super.handleInput(`\x1b[200~${pasteContent}\x1b[201~`);
+				this.#handlingUserInput = false;
+				if (this.getText() !== textBeforeInput) this.onUserEdit?.();
 			}
 			this.#pasteDecisionPending = false;
 			this.#drainPendingPasteInput(remaining);
@@ -402,7 +416,11 @@ export class CustomEditor extends Editor {
 			}
 		}
 
-		// Pass to parent for normal handling
+		// Pass to parent for normal handling.
+		const textBeforeInput = this.getText();
+		this.#handlingUserInput = true;
 		super.handleInput(data);
+		this.#handlingUserInput = false;
+		if (this.getText() !== textBeforeInput) this.onUserEdit?.();
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -38,13 +38,6 @@ function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
 }
 
-interface PaletteComposerStash {
-	text: string;
-	pendingImages: InteractiveModeContext["pendingImages"];
-	userEditGeneration: number;
-	sessionId: string;
-	editor: InteractiveModeContext["editor"];
-}
 export class InputController {
 	constructor(private ctx: InteractiveModeContext) {}
 
@@ -57,9 +50,6 @@ export class InputController {
 	#steerConsumePending = false;
 	#commandPaletteActions = new Map<AppKeybinding, CommandPaletteAction>();
 	#paletteCommandInFlight = false;
-	#paletteComposerStash: PaletteComposerStash | undefined;
-	#userComposerEditGeneration = 0;
-	#allowProgrammaticComposerClear = false;
 
 	#registerCommandPaletteAction(action: AppKeybinding, handler: () => void | Promise<void>): void {
 		this.#commandPaletteActions.set(action, {
@@ -67,26 +57,6 @@ export class InputController {
 			label: KEYBINDINGS[action].description,
 			handler,
 		});
-	}
-
-	#recordUserComposerEdit(): void {
-		this.#userComposerEditGeneration += 1;
-	}
-
-	/**
-	 * Clear the composer because a submission consumed its text. Submission
-	 * paths resume in a microtask (after the first await in submitText), so the
-	 * editor's user-input window has already closed; without the allow flag the
-	 * palette ownership guard would swallow this clear and leave already-sent
-	 * text in the composer.
-	 */
-	#clearComposerForSubmission(): void {
-		this.#allowProgrammaticComposerClear = true;
-		try {
-			this.ctx.editor.setText("");
-		} finally {
-			this.#allowProgrammaticComposerClear = false;
-		}
 	}
 
 	#globalInterruptUnsubscribe: (() => void) | undefined;
@@ -254,13 +224,7 @@ export class InputController {
 		if (text.trim()) {
 			this.ctx.editor.addToHistory(text);
 		}
-		this.#recordUserComposerEdit();
-		this.#allowProgrammaticComposerClear = true;
-		try {
-			this.ctx.clearEditor();
-		} finally {
-			this.#allowProgrammaticComposerClear = false;
-		}
+		this.ctx.clearEditor();
 	}
 
 	setupKeyHandlers(): void {
@@ -547,15 +511,6 @@ export class InputController {
 			this.ctx.editor.setCustomKeyHandler(key, () => this.handleForegroundToolBackgroundFold());
 		}
 
-		this.ctx.editor.onUserEdit = () => this.#recordUserComposerEdit();
-		this.ctx.editor.onProgrammaticSetText = text =>
-			Boolean(
-				this.#paletteComposerStash &&
-					!this.#allowProgrammaticComposerClear &&
-					this.#userComposerEditGeneration !== this.#paletteComposerStash.userEditGeneration &&
-					this.ctx.editor === this.#paletteComposerStash.editor &&
-					text === "",
-			);
 		this.ctx.editor.onChange = (text: string) => {
 			this.#resetEscapeGestures();
 			const wasBashMode = this.ctx.isBashMode;
@@ -596,7 +551,7 @@ export class InputController {
 		// Continue shortcuts: "." or "c" sends empty message (agent continues, no visible message)
 		if (text === "." || text === "c") {
 			if (this.ctx.onInputCallback) {
-				this.#clearComposerForSubmission();
+				this.ctx.editor.setText("");
 				this.ctx.pendingImages = [];
 				this.ctx.onInputCallback({ text: "", cancelled: false, started: true });
 			}
@@ -610,7 +565,7 @@ export class InputController {
 		if (runner?.hasHandlers("input")) {
 			const result = await runner.emitInput(text, inputImages, "interactive");
 			if (result?.handled) {
-				this.#clearComposerForSubmission();
+				this.ctx.editor.setText("");
 				this.#clearPendingImagesIfOwnedBy(pendingImages);
 				return;
 			}
@@ -699,7 +654,7 @@ export class InputController {
 		// This handles extension commands (execute immediately), prompt template expansion, and queueing
 		if (this.ctx.session.isStreaming) {
 			this.ctx.editor.addToHistory(text);
-			this.#clearComposerForSubmission();
+			this.ctx.editor.setText("");
 			const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
 			this.#clearPendingImagesIfOwnedBy(pendingImages);
 			// Record the signature so the queued message's eventual delivery
@@ -768,13 +723,7 @@ export class InputController {
 		if (now - this.ctx.lastSigintTime < 500) {
 			void this.ctx.shutdown();
 		} else {
-			this.#recordUserComposerEdit();
-			this.#allowProgrammaticComposerClear = true;
-			try {
-				this.ctx.clearEditor();
-			} finally {
-				this.#allowProgrammaticComposerClear = false;
-			}
+			this.ctx.clearEditor();
 			this.ctx.lastSigintTime = now;
 		}
 	}
@@ -1016,7 +965,7 @@ export class InputController {
 		const invocations = parseSkillInvocations(text, this.ctx.skillCommands ?? new Map());
 		if (invocations.length === 0) return false;
 		this.ctx.editor.addToHistory(text);
-		this.#clearComposerForSubmission();
+		this.ctx.editor.setText("");
 		try {
 			for (let index = 0; index < invocations.length; index += 1) {
 				const invocation = invocations[index];
@@ -1105,7 +1054,7 @@ export class InputController {
 
 		if (this.ctx.session.isStreaming) {
 			this.ctx.editor.addToHistory(text);
-			this.#clearComposerForSubmission();
+			this.ctx.editor.setText("");
 			await this.ctx.withLocalSubmission(text, () =>
 				this.ctx.session.prompt(text, {
 					streamingBehavior: "followUp",
@@ -1119,7 +1068,7 @@ export class InputController {
 
 		// Not streaming — just submit normally
 		this.ctx.editor.addToHistory(text);
-		this.#clearComposerForSubmission();
+		this.ctx.editor.setText("");
 		await this.ctx.withLocalSubmission(text, () => this.ctx.session.prompt(text));
 	}
 
@@ -1386,7 +1335,6 @@ export class InputController {
 						// Keep the normalized image when resize fails.
 					}
 				}
-				this.#recordUserComposerEdit();
 
 				this.ctx.pendingImages = [
 					...this.ctx.pendingImages,
@@ -1477,33 +1425,15 @@ export class InputController {
 				return;
 			}
 
+			if (this.ctx.editor.getText() || this.ctx.pendingImages.length > 0) {
+				this.ctx.showStatus("Send or clear the draft before running a palette command.");
+				return;
+			}
+
 			this.#paletteCommandInFlight = true;
-			const stash: PaletteComposerStash = {
-				text: this.ctx.editor.getText(),
-				pendingImages: [...this.ctx.pendingImages],
-				userEditGeneration: this.#userComposerEditGeneration,
-				sessionId: this.ctx.session.sessionId,
-				editor: this.ctx.editor,
-			};
-			this.#paletteComposerStash = stash;
-			// Preserve a non-empty draft before dispatch so a session change cannot strand it.
-			if (stash.text) stash.editor.addToHistory(stash.text);
-			this.ctx.editor.setText("");
-			this.ctx.pendingImages = [];
 			try {
 				await this.submitText(`/${name}`);
 			} finally {
-				if (
-					this.#paletteComposerStash === stash &&
-					this.#userComposerEditGeneration === stash.userEditGeneration &&
-					this.ctx.session.sessionId === stash.sessionId &&
-					this.ctx.editor === stash.editor &&
-					this.ctx.editor.getText() === ""
-				) {
-					this.ctx.editor.setText(stash.text);
-					this.ctx.pendingImages = stash.pendingImages;
-				}
-				if (this.#paletteComposerStash === stash) this.#paletteComposerStash = undefined;
 				this.#paletteCommandInFlight = false;
 			}
 		});

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -520,188 +520,190 @@ export class InputController {
 	}
 
 	setupEditorSubmitHandler(): void {
-		this.ctx.editor.onSubmit = async (text: string) => {
-			text = text.trim();
-			if ((!isSettingsInitialized() || settings.get("emojiAutocomplete")) && text) text = expandEmoticons(text);
+		this.ctx.editor.onSubmit = text => this.submitText(text);
+	}
 
-			// Empty submit while streaming with queued messages: flush queues immediately
-			if (!text && this.ctx.session.isStreaming && this.ctx.session.queuedMessageCount > 0) {
-				// Abort current stream and let queued messages be processed
-				await this.#abortInteractive();
-				return;
-			}
+	async submitText(text: string): Promise<void> {
+		text = text.trim();
+		if ((!isSettingsInitialized() || settings.get("emojiAutocomplete")) && text) text = expandEmoticons(text);
 
-			if (!text) return;
+		// Empty submit while streaming with queued messages: flush queues immediately
+		if (!text && this.ctx.session.isStreaming && this.ctx.session.queuedMessageCount > 0) {
+			// Abort current stream and let queued messages be processed
+			await this.#abortInteractive();
+			return;
+		}
 
-			// Continue shortcuts: "." or "c" sends empty message (agent continues, no visible message)
-			if (text === "." || text === "c") {
-				if (this.ctx.onInputCallback) {
-					this.ctx.editor.setText("");
-					this.ctx.pendingImages = [];
-					this.ctx.onInputCallback({ text: "", cancelled: false, started: true });
-				}
-				return;
-			}
+		if (!text) return;
 
-			const runner = this.ctx.session.extensionRunner;
-			const pendingImages = this.ctx.pendingImages;
-			let inputImages = this.#visiblePendingImagesForText(text);
-
-			if (runner?.hasHandlers("input")) {
-				const result = await runner.emitInput(text, inputImages, "interactive");
-				if (result?.handled) {
-					this.ctx.editor.setText("");
-					this.#clearPendingImagesIfOwnedBy(pendingImages);
-					return;
-				}
-				if (result?.text !== undefined) {
-					text = result.text.trim();
-				}
-				if (result?.images !== undefined) {
-					inputImages = result.images;
-				}
-			}
-
-			if (!text) return;
-
-			// Handle built-in slash commands
-			const slashResult = await executeBuiltinSlashCommand(text, {
-				ctx: this.ctx,
-				handleBackgroundCommand: () => this.handleBackgroundCommand(),
-			});
-			if (slashResult === true) {
-				return;
-			}
-			if (typeof slashResult === "string") {
-				// Command handled but returned remaining text to use as prompt
-				text = slashResult;
-			}
-
-			// Handle skill commands (/skill:name [args]). While streaming, Enter
-			// honors `busyPromptMode`: "steer" interrupts the active turn, "queue"
-			// runs after it completes (matches the free-text Enter semantics applied
-			// a few lines below at the streaming branch). Explicit queue shortcuts
-			// route through `handleFollowUp` and dispatch as `followUp`.
-			if (await this.#invokeSkillCommand(text, this.#busyStreamingBehavior())) {
-				return;
-			}
-
-			// Handle bash command (! for normal, !! for excluded from context)
-			if (text.startsWith("!")) {
-				const isExcluded = text.startsWith("!!");
-				const command = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
-				if (command) {
-					if (this.ctx.session.isBashRunning) {
-						this.ctx.showWarning("A bash command is already running. Press Esc to cancel it first.");
-						this.ctx.editor.setText(text);
-						return;
-					}
-					this.ctx.editor.addToHistory(text);
-					await this.ctx.handleBashCommand(command, isExcluded);
-					this.ctx.isBashMode = false;
-					this.ctx.isBashNoContext = false;
-					this.ctx.updateEditorBorderColor();
-					return;
-				}
-			}
-
-			// Handle python command ($ for normal, $$ for excluded from context)
-			if (text.startsWith("$")) {
-				const isExcluded = text.startsWith("$$");
-				const code = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
-				if (code) {
-					if (this.ctx.session.isEvalRunning) {
-						this.ctx.showWarning("A Python execution is already running. Press Esc to cancel it first.");
-						this.ctx.editor.setText(text);
-						return;
-					}
-					this.ctx.editor.addToHistory(text);
-					await this.ctx.handlePythonCommand(code, isExcluded);
-					this.ctx.isPythonMode = false;
-					this.ctx.updateEditorBorderColor();
-					return;
-				}
-			}
-
-			// Queue input during compaction
-			if (this.ctx.session.isCompacting) {
-				if ((inputImages?.length ?? 0) > 0) {
-					this.ctx.showStatus("Compaction in progress. Retry after it completes to send images.");
-					return;
-				}
-				this.ctx.queueCompactionMessage(text, "steer");
-				return;
-			}
-
-			// If streaming, use prompt() with the busy-prompt behavior the user
-			// selected: "steer" interrupts the active turn, "queue" defers the
-			// prompt to run after the active turn completes (in submission order).
-			// This handles extension commands (execute immediately), prompt template expansion, and queueing
-			if (this.ctx.session.isStreaming) {
-				this.ctx.editor.addToHistory(text);
-				this.ctx.editor.setText("");
-				const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
-				this.#clearPendingImagesIfOwnedBy(pendingImages);
-				// Record the signature so the queued message's eventual delivery
-				// (a user-role `message_start` event) leaves any draft the user has
-				// typed since queuing intact. Same protection as #783, applied to
-				// the streaming/queue path.
-				const streamingBehavior = this.#busyStreamingBehavior();
-				const promptOptions =
-					streamingBehavior === "followUp"
-						? { streamingBehavior, images, followUpQueuePolicy: "sequential" as const }
-						: { streamingBehavior, images };
-				await this.ctx.withLocalSubmission(text, () => this.ctx.session.prompt(text, promptOptions), {
-					imageCount: images?.length ?? 0,
-				});
-				this.ctx.updatePendingMessagesDisplay();
-				this.ctx.ui.requestRender();
-				return;
-			}
-
-			// Normal message submission
-			// First, move any pending bash components to chat
-			this.ctx.flushPendingBashComponents();
-
-			// Generate session title on first message
-			const hasUserMessages = this.ctx.session.messages.some((m: AgentMessage) => m.role === "user");
-			if (!hasUserMessages && !this.ctx.sessionManager.getSessionName() && !$env.PI_NO_TITLE) {
-				const registry = this.ctx.session.modelRegistry;
-				generateSessionTitle(
-					text,
-					registry,
-					this.ctx.settings,
-					this.ctx.session.sessionId,
-					this.ctx.session.model,
-					provider => this.ctx.session.agent.metadataForProvider(provider),
-				)
-					.then(async title => {
-						if (title) {
-							const applied = await this.ctx.sessionManager.setSessionName(title, "auto");
-							if (applied) {
-								setSessionTerminalTitle(
-									this.ctx.sessionManager.getSessionName()!,
-									this.ctx.sessionManager.getCwd(),
-								);
-								this.ctx.updateEditorBorderColor();
-							}
-						}
-					})
-					.catch(() => {});
-			}
-
+		// Continue shortcuts: "." or "c" sends empty message (agent continues, no visible message)
+		if (text === "." || text === "c") {
 			if (this.ctx.onInputCallback) {
-				// Include any pending images from clipboard paste
-				const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
-				this.#clearPendingImagesIfOwnedBy(pendingImages);
-
-				// Render user message immediately, then let session events catch up
-				const submission = this.ctx.startPendingSubmission({ text, images });
-
-				this.ctx.onInputCallback(submission);
+				this.ctx.editor.setText("");
+				this.ctx.pendingImages = [];
+				this.ctx.onInputCallback({ text: "", cancelled: false, started: true });
 			}
+			return;
+		}
+
+		const runner = this.ctx.session.extensionRunner;
+		const pendingImages = this.ctx.pendingImages;
+		let inputImages = this.#visiblePendingImagesForText(text);
+
+		if (runner?.hasHandlers("input")) {
+			const result = await runner.emitInput(text, inputImages, "interactive");
+			if (result?.handled) {
+				this.ctx.editor.setText("");
+				this.#clearPendingImagesIfOwnedBy(pendingImages);
+				return;
+			}
+			if (result?.text !== undefined) {
+				text = result.text.trim();
+			}
+			if (result?.images !== undefined) {
+				inputImages = result.images;
+			}
+		}
+
+		if (!text) return;
+
+		// Handle built-in slash commands
+		const slashResult = await executeBuiltinSlashCommand(text, {
+			ctx: this.ctx,
+			handleBackgroundCommand: () => this.handleBackgroundCommand(),
+		});
+		if (slashResult === true) {
+			return;
+		}
+		if (typeof slashResult === "string") {
+			// Command handled but returned remaining text to use as prompt
+			text = slashResult;
+		}
+
+		// Handle skill commands (/skill:name [args]). While streaming, Enter
+		// honors `busyPromptMode`: "steer" interrupts the active turn, "queue"
+		// runs after it completes (matches the free-text Enter semantics applied
+		// a few lines below at the streaming branch). Explicit queue shortcuts
+		// route through `handleFollowUp` and dispatch as `followUp`.
+		if (await this.#invokeSkillCommand(text, this.#busyStreamingBehavior())) {
+			return;
+		}
+
+		// Handle bash command (! for normal, !! for excluded from context)
+		if (text.startsWith("!")) {
+			const isExcluded = text.startsWith("!!");
+			const command = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
+			if (command) {
+				if (this.ctx.session.isBashRunning) {
+					this.ctx.showWarning("A bash command is already running. Press Esc to cancel it first.");
+					this.ctx.editor.setText(text);
+					return;
+				}
+				this.ctx.editor.addToHistory(text);
+				await this.ctx.handleBashCommand(command, isExcluded);
+				this.ctx.isBashMode = false;
+				this.ctx.isBashNoContext = false;
+				this.ctx.updateEditorBorderColor();
+				return;
+			}
+		}
+
+		// Handle python command ($ for normal, $$ for excluded from context)
+		if (text.startsWith("$")) {
+			const isExcluded = text.startsWith("$$");
+			const code = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
+			if (code) {
+				if (this.ctx.session.isEvalRunning) {
+					this.ctx.showWarning("A Python execution is already running. Press Esc to cancel it first.");
+					this.ctx.editor.setText(text);
+					return;
+				}
+				this.ctx.editor.addToHistory(text);
+				await this.ctx.handlePythonCommand(code, isExcluded);
+				this.ctx.isPythonMode = false;
+				this.ctx.updateEditorBorderColor();
+				return;
+			}
+		}
+
+		// Queue input during compaction
+		if (this.ctx.session.isCompacting) {
+			if ((inputImages?.length ?? 0) > 0) {
+				this.ctx.showStatus("Compaction in progress. Retry after it completes to send images.");
+				return;
+			}
+			this.ctx.queueCompactionMessage(text, "steer");
+			return;
+		}
+
+		// If streaming, use prompt() with the busy-prompt behavior the user
+		// selected: "steer" interrupts the active turn, "queue" defers the
+		// prompt to run after the active turn completes (in submission order).
+		// This handles extension commands (execute immediately), prompt template expansion, and queueing
+		if (this.ctx.session.isStreaming) {
 			this.ctx.editor.addToHistory(text);
-		};
+			this.ctx.editor.setText("");
+			const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
+			this.#clearPendingImagesIfOwnedBy(pendingImages);
+			// Record the signature so the queued message's eventual delivery
+			// (a user-role `message_start` event) leaves any draft the user has
+			// typed since queuing intact. Same protection as #783, applied to
+			// the streaming/queue path.
+			const streamingBehavior = this.#busyStreamingBehavior();
+			const promptOptions =
+				streamingBehavior === "followUp"
+					? { streamingBehavior, images, followUpQueuePolicy: "sequential" as const }
+					: { streamingBehavior, images };
+			await this.ctx.withLocalSubmission(text, () => this.ctx.session.prompt(text, promptOptions), {
+				imageCount: images?.length ?? 0,
+			});
+			this.ctx.updatePendingMessagesDisplay();
+			this.ctx.ui.requestRender();
+			return;
+		}
+
+		// Normal message submission
+		// First, move any pending bash components to chat
+		this.ctx.flushPendingBashComponents();
+
+		// Generate session title on first message
+		const hasUserMessages = this.ctx.session.messages.some((m: AgentMessage) => m.role === "user");
+		if (!hasUserMessages && !this.ctx.sessionManager.getSessionName() && !$env.PI_NO_TITLE) {
+			const registry = this.ctx.session.modelRegistry;
+			generateSessionTitle(
+				text,
+				registry,
+				this.ctx.settings,
+				this.ctx.session.sessionId,
+				this.ctx.session.model,
+				provider => this.ctx.session.agent.metadataForProvider(provider),
+			)
+				.then(async title => {
+					if (title) {
+						const applied = await this.ctx.sessionManager.setSessionName(title, "auto");
+						if (applied) {
+							setSessionTerminalTitle(
+								this.ctx.sessionManager.getSessionName()!,
+								this.ctx.sessionManager.getCwd(),
+							);
+							this.ctx.updateEditorBorderColor();
+						}
+					}
+				})
+				.catch(() => {});
+		}
+
+		if (this.ctx.onInputCallback) {
+			// Include any pending images from clipboard paste
+			const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
+			this.#clearPendingImagesIfOwnedBy(pendingImages);
+
+			// Render user message immediately, then let session events catch up
+			const submission = this.ctx.startPendingSubmission({ text, images });
+
+			this.ctx.onInputCallback(submission);
+		}
+		this.ctx.editor.addToHistory(text);
 	}
 
 	handleCtrlC(): void {
@@ -1400,15 +1402,15 @@ export class InputController {
 	}
 
 	openCommandPalette(): void {
-		this.ctx.showCommandPalette(this.#slashCommands, [...this.#commandPaletteActions.values()], name => {
+		this.ctx.showCommandPalette(this.#slashCommands, [...this.#commandPaletteActions.values()], async name => {
 			const text = this.ctx.editor.getText();
 			const pendingImages = [...this.ctx.pendingImages];
-			this.ctx.editor.setText(`/${name}`);
-			this.ctx.editor.handleInput("\n");
-			// Slash commands run through submit synchronously; restore afterward so command-side
-			// composer mutations do not replace the draft that was present before opening the palette.
-			this.ctx.editor.setText(text);
-			this.ctx.pendingImages = pendingImages;
+			try {
+				await this.submitText(`/${name}`);
+			} finally {
+				this.ctx.editor.setText(text);
+				this.ctx.pendingImages = pendingImages;
+			}
 		});
 	}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@gajae-code/tui";
 import { $env, sanitizeText } from "@gajae-code/utils";
+import type { AppKeybinding } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
 import { buildSkillPromptMessage, parseSkillInvocations } from "../../extensibility/skills";
@@ -40,6 +41,7 @@ export class InputController {
 	constructor(private ctx: InteractiveModeContext) {}
 
 	#lastBackgroundFoldKeyTime = 0;
+	#slashCommands: SlashCommand[] = [];
 
 	/** Set after a first Esc silently consumes a queued steer. Kept until the
 	 *  queued steer is either cancelled by a second Esc or drained by continuation,
@@ -1290,6 +1292,7 @@ export class InputController {
 	}
 
 	createAutocompleteProvider(commands: SlashCommand[], basePath: string): AutocompleteProvider {
+		this.#slashCommands = commands;
 		return createPromptActionAutocompleteProvider({
 			commands,
 			basePath,
@@ -1344,11 +1347,17 @@ export class InputController {
 	}
 
 	openCommandPalette(): void {
-		if (this.ctx.editor.getText().trim().length > 0) {
-			this.ctx.showStatus("Command palette opens from an empty prompt. Type / for inline commands.");
-			return;
-		}
-		this.ctx.editor.handleInput("/");
+		this.ctx.showCommandPalette(
+			this.#slashCommands,
+			action => {
+				const key = this.ctx.keybindings.getKeys(action as AppKeybinding)[0];
+				if (key) this.ctx.editor.handleInput(key);
+			},
+			name => {
+				this.ctx.editor.setText(`/${name}`);
+				this.ctx.editor.handleInput("\n");
+			},
+		);
 	}
 
 	cycleThinkingLevel(): void {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -38,10 +38,12 @@ function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
 }
 
-interface PaletteComposerState {
-	snapshotText: string;
-	successorText: string | undefined;
-	successorImages: InteractiveModeContext["pendingImages"] | undefined;
+interface PaletteComposerStash {
+	text: string;
+	pendingImages: InteractiveModeContext["pendingImages"];
+	userEditGeneration: number;
+	sessionId: string;
+	editor: InteractiveModeContext["editor"];
 }
 export class InputController {
 	constructor(private ctx: InteractiveModeContext) {}
@@ -55,14 +57,36 @@ export class InputController {
 	#steerConsumePending = false;
 	#commandPaletteActions = new Map<AppKeybinding, CommandPaletteAction>();
 	#paletteCommandInFlight = false;
-	#paletteComposerState: PaletteComposerState | undefined;
+	#paletteComposerStash: PaletteComposerStash | undefined;
+	#userComposerEditGeneration = 0;
+	#allowProgrammaticComposerClear = false;
 
-	#registerCommandPaletteAction(action: AppKeybinding, handler: () => void): void {
+	#registerCommandPaletteAction(action: AppKeybinding, handler: () => void | Promise<void>): void {
 		this.#commandPaletteActions.set(action, {
 			id: action,
 			label: KEYBINDINGS[action].description,
 			handler,
 		});
+	}
+
+	#recordUserComposerEdit(): void {
+		this.#userComposerEditGeneration += 1;
+	}
+
+	/**
+	 * Clear the composer because a submission consumed its text. Submission
+	 * paths resume in a microtask (after the first await in submitText), so the
+	 * editor's user-input window has already closed; without the allow flag the
+	 * palette ownership guard would swallow this clear and leave already-sent
+	 * text in the composer.
+	 */
+	#clearComposerForSubmission(): void {
+		this.#allowProgrammaticComposerClear = true;
+		try {
+			this.ctx.editor.setText("");
+		} finally {
+			this.#allowProgrammaticComposerClear = false;
+		}
 	}
 
 	#globalInterruptUnsubscribe: (() => void) | undefined;
@@ -230,7 +254,13 @@ export class InputController {
 		if (text.trim()) {
 			this.ctx.editor.addToHistory(text);
 		}
-		this.ctx.clearEditor();
+		this.#recordUserComposerEdit();
+		this.#allowProgrammaticComposerClear = true;
+		try {
+			this.ctx.clearEditor();
+		} finally {
+			this.#allowProgrammaticComposerClear = false;
+		}
 	}
 
 	setupKeyHandlers(): void {
@@ -388,18 +418,21 @@ export class InputController {
 		this.ctx.editor.setActionKeys("app.thinking.toggle", this.ctx.keybindings.getKeys("app.thinking.toggle"));
 		this.ctx.editor.onToggleThinking = toggleThinking;
 		this.#registerCommandPaletteAction("app.thinking.toggle", toggleThinking);
-		const externalEditor = () => void this.openExternalEditor();
+		const externalEditor = () => this.openExternalEditor();
 		this.ctx.editor.setActionKeys("app.editor.external", this.ctx.keybindings.getKeys("app.editor.external"));
 		this.ctx.editor.onExternalEditor = externalEditor;
 		this.#registerCommandPaletteAction("app.editor.external", externalEditor);
 		this.ctx.editor.onShowHotkeys = () => this.ctx.handleHotkeysCommand();
 		const pasteImage = () => this.handleImagePaste();
+		const pasteImageFromPalette = async () => {
+			await this.handleImagePaste();
+		};
 		this.ctx.editor.setActionKeys(
 			"app.clipboard.pasteImage",
 			this.ctx.keybindings.getKeys("app.clipboard.pasteImage"),
 		);
 		this.ctx.editor.onPasteImage = pasteImage;
-		this.#registerCommandPaletteAction("app.clipboard.pasteImage", pasteImage);
+		this.#registerCommandPaletteAction("app.clipboard.pasteImage", pasteImageFromPalette);
 		const copyPrompt = () => this.handleCopyPrompt();
 		this.ctx.editor.setActionKeys(
 			"app.clipboard.copyPrompt",
@@ -422,7 +455,7 @@ export class InputController {
 		this.ctx.editor.setActionKeys("app.message.dequeue", this.ctx.keybindings.getKeys("app.message.dequeue"));
 		this.ctx.editor.onDequeue = dequeue;
 		this.#registerCommandPaletteAction("app.message.dequeue", dequeue);
-		const queue = () => void this.handleQueueSubmit();
+		const queue = () => this.handleQueueSubmit();
 		this.ctx.editor.setActionKeys("app.message.queue", this.ctx.keybindings.getKeys("app.message.queue"));
 		this.ctx.editor.onQueue = queue;
 		this.#registerCommandPaletteAction("app.message.queue", queue);
@@ -443,15 +476,23 @@ export class InputController {
 			});
 		}
 
-		const togglePlanMode = () => void this.ctx.handlePlanModeCommand();
+		const togglePlanMode = () => this.ctx.handlePlanModeCommand();
 		this.#registerCommandPaletteAction("app.plan.toggle", togglePlanMode);
 		for (const key of this.ctx.keybindings.getKeys("app.plan.toggle")) {
-			this.ctx.editor.setCustomKeyHandler(key, togglePlanMode);
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				void togglePlanMode();
+				return true;
+			});
 		}
-		const newSession = () => void this.ctx.handleClearCommand();
+		const newSession = async () => {
+			await this.ctx.handleClearCommand();
+		};
 		this.#registerCommandPaletteAction("app.session.new", newSession);
 		for (const key of this.ctx.keybindings.getKeys("app.session.new")) {
-			this.ctx.editor.setCustomKeyHandler(key, newSession);
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				void newSession();
+				return true;
+			});
 		}
 		const showTree = () => {
 			this.ctx.showTreeSelector();
@@ -506,6 +547,15 @@ export class InputController {
 			this.ctx.editor.setCustomKeyHandler(key, () => this.handleForegroundToolBackgroundFold());
 		}
 
+		this.ctx.editor.onUserEdit = () => this.#recordUserComposerEdit();
+		this.ctx.editor.onProgrammaticSetText = text =>
+			Boolean(
+				this.#paletteComposerStash &&
+					!this.#allowProgrammaticComposerClear &&
+					this.#userComposerEditGeneration !== this.#paletteComposerStash.userEditGeneration &&
+					this.ctx.editor === this.#paletteComposerStash.editor &&
+					text === "",
+			);
 		this.ctx.editor.onChange = (text: string) => {
 			this.#resetEscapeGestures();
 			const wasBashMode = this.ctx.isBashMode;
@@ -516,11 +566,6 @@ export class InputController {
 			this.ctx.isBashNoContext = trimmed.startsWith("!!");
 			this.ctx.isPythonMode = trimmed.startsWith("$") && !trimmed.startsWith("${");
 			this.#clearPendingImagesIfPlaceholdersRemoved(text);
-			const paletteComposerState = this.#paletteComposerState;
-			if (paletteComposerState && text !== "" && text !== paletteComposerState.snapshotText) {
-				paletteComposerState.successorText = text;
-				paletteComposerState.successorImages = [...this.ctx.pendingImages];
-			}
 			if (
 				wasBashMode !== this.ctx.isBashMode ||
 				wasBashNoContext !== this.ctx.isBashNoContext ||
@@ -551,7 +596,7 @@ export class InputController {
 		// Continue shortcuts: "." or "c" sends empty message (agent continues, no visible message)
 		if (text === "." || text === "c") {
 			if (this.ctx.onInputCallback) {
-				this.ctx.editor.setText("");
+				this.#clearComposerForSubmission();
 				this.ctx.pendingImages = [];
 				this.ctx.onInputCallback({ text: "", cancelled: false, started: true });
 			}
@@ -565,7 +610,7 @@ export class InputController {
 		if (runner?.hasHandlers("input")) {
 			const result = await runner.emitInput(text, inputImages, "interactive");
 			if (result?.handled) {
-				this.ctx.editor.setText("");
+				this.#clearComposerForSubmission();
 				this.#clearPendingImagesIfOwnedBy(pendingImages);
 				return;
 			}
@@ -654,8 +699,7 @@ export class InputController {
 		// This handles extension commands (execute immediately), prompt template expansion, and queueing
 		if (this.ctx.session.isStreaming) {
 			this.ctx.editor.addToHistory(text);
-			this.ctx.editor.setText("");
-			this.#consumePaletteSuccessor(text);
+			this.#clearComposerForSubmission();
 			const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
 			this.#clearPendingImagesIfOwnedBy(pendingImages);
 			// Record the signature so the queued message's eventual delivery
@@ -717,22 +761,6 @@ export class InputController {
 			this.ctx.onInputCallback(submission);
 		}
 		this.ctx.editor.addToHistory(text);
-		this.#consumePaletteSuccessor(text);
-	}
-
-	/**
-	 * A submission that consumes composer text during a pending palette command
-	 * also consumes the recorded successor draft: restoring text the user has
-	 * already sent would resurrect a delivered message into the composer. The
-	 * pre-palette snapshot (never-sent state) remains the restore target.
-	 */
-	#consumePaletteSuccessor(submittedText: string): void {
-		const state = this.#paletteComposerState;
-		if (!state) return;
-		if (state.successorText !== undefined && state.successorText === submittedText) {
-			state.successorText = undefined;
-			state.successorImages = undefined;
-		}
 	}
 
 	handleCtrlC(): void {
@@ -740,7 +768,13 @@ export class InputController {
 		if (now - this.ctx.lastSigintTime < 500) {
 			void this.ctx.shutdown();
 		} else {
-			this.ctx.clearEditor();
+			this.#recordUserComposerEdit();
+			this.#allowProgrammaticComposerClear = true;
+			try {
+				this.ctx.clearEditor();
+			} finally {
+				this.#allowProgrammaticComposerClear = false;
+			}
 			this.ctx.lastSigintTime = now;
 		}
 	}
@@ -982,7 +1016,7 @@ export class InputController {
 		const invocations = parseSkillInvocations(text, this.ctx.skillCommands ?? new Map());
 		if (invocations.length === 0) return false;
 		this.ctx.editor.addToHistory(text);
-		this.ctx.editor.setText("");
+		this.#clearComposerForSubmission();
 		try {
 			for (let index = 0; index < invocations.length; index += 1) {
 				const invocation = invocations[index];
@@ -1071,7 +1105,7 @@ export class InputController {
 
 		if (this.ctx.session.isStreaming) {
 			this.ctx.editor.addToHistory(text);
-			this.ctx.editor.setText("");
+			this.#clearComposerForSubmission();
 			await this.ctx.withLocalSubmission(text, () =>
 				this.ctx.session.prompt(text, {
 					streamingBehavior: "followUp",
@@ -1085,7 +1119,7 @@ export class InputController {
 
 		// Not streaming — just submit normally
 		this.ctx.editor.addToHistory(text);
-		this.ctx.editor.setText("");
+		this.#clearComposerForSubmission();
 		await this.ctx.withLocalSubmission(text, () => this.ctx.session.prompt(text));
 	}
 
@@ -1352,6 +1386,7 @@ export class InputController {
 						// Keep the normalized image when resize fails.
 					}
 				}
+				this.#recordUserComposerEdit();
 
 				this.ctx.pendingImages = [
 					...this.ctx.pendingImages,
@@ -1431,6 +1466,11 @@ export class InputController {
 	}
 
 	openCommandPalette(): void {
+		if (this.#paletteCommandInFlight) {
+			this.ctx.showStatus("A palette command is still running.");
+			return;
+		}
+
 		this.ctx.showCommandPalette(this.#slashCommands, [...this.#commandPaletteActions.values()], async name => {
 			if (this.#paletteCommandInFlight) {
 				this.ctx.showStatus("A palette command is still running.");
@@ -1438,28 +1478,32 @@ export class InputController {
 			}
 
 			this.#paletteCommandInFlight = true;
-			const text = this.ctx.editor.getText();
-			const pendingImages = [...this.ctx.pendingImages];
-			this.#paletteComposerState = { snapshotText: text, successorText: undefined, successorImages: undefined };
+			const stash: PaletteComposerStash = {
+				text: this.ctx.editor.getText(),
+				pendingImages: [...this.ctx.pendingImages],
+				userEditGeneration: this.#userComposerEditGeneration,
+				sessionId: this.ctx.session.sessionId,
+				editor: this.ctx.editor,
+			};
+			this.#paletteComposerStash = stash;
+			// Preserve a non-empty draft before dispatch so a session change cannot strand it.
+			if (stash.text) stash.editor.addToHistory(stash.text);
+			this.ctx.editor.setText("");
+			this.ctx.pendingImages = [];
 			try {
 				await this.submitText(`/${name}`);
 			} finally {
-				// The palette command owns its cleanup only until newer composer input arrives.
-				// A draft or attachment added after the palette closes always wins over this snapshot.
-				const successorText = this.#paletteComposerState?.successorText;
-				const successorImages = this.#paletteComposerState?.successorImages;
-				const hasNewImages = this.ctx.pendingImages.some(image => !pendingImages.includes(image));
-				if (successorText !== undefined) {
-					this.ctx.editor.setText(successorText);
-				} else if (this.ctx.editor.getText() === "" || this.ctx.editor.getText() === text) {
-					this.ctx.editor.setText(text);
+				if (
+					this.#paletteComposerStash === stash &&
+					this.#userComposerEditGeneration === stash.userEditGeneration &&
+					this.ctx.session.sessionId === stash.sessionId &&
+					this.ctx.editor === stash.editor &&
+					this.ctx.editor.getText() === ""
+				) {
+					this.ctx.editor.setText(stash.text);
+					this.ctx.pendingImages = stash.pendingImages;
 				}
-				if (successorImages !== undefined) {
-					this.ctx.pendingImages = successorImages;
-				} else if (!hasNewImages) {
-					this.ctx.pendingImages = pendingImages;
-				}
-				this.#paletteComposerState = undefined;
+				if (this.#paletteComposerStash === stash) this.#paletteComposerStash = undefined;
 				this.#paletteCommandInFlight = false;
 			}
 		});

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@gajae-code/tui";
 import { $env, sanitizeText } from "@gajae-code/utils";
-import type { AppKeybinding } from "../../config/keybindings";
+import { type AppKeybinding, KEYBINDINGS } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
 import { buildSkillPromptMessage, parseSkillInvocations } from "../../extensibility/skills";
@@ -21,6 +21,7 @@ import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } fr
 import { resizeImage } from "../../utils/image-resize";
 import { formatPastedImageReference, resolvePastedImagePath } from "../../utils/pasted-image-path";
 import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
+import type { CommandPaletteAction } from "../components/command-palette";
 import { type QueuedMessageMoveDirection, QueuedMessageSelectorComponent } from "../components/queued-message-selector";
 
 interface Expandable {
@@ -47,6 +48,15 @@ export class InputController {
 	 *  queued steer is either cancelled by a second Esc or drained by continuation,
 	 *  so abort cleanup going idle cannot turn the second Esc into an idle action. */
 	#steerConsumePending = false;
+	#commandPaletteActions = new Map<AppKeybinding, CommandPaletteAction>();
+
+	#registerCommandPaletteAction(action: AppKeybinding, handler: () => void): void {
+		this.#commandPaletteActions.set(action, {
+			id: action,
+			label: KEYBINDINGS[action].description,
+			handler,
+		});
+	}
 
 	#globalInterruptUnsubscribe: (() => void) | undefined;
 	#draftClearEscapeText: string | undefined;
@@ -323,47 +333,73 @@ export class InputController {
 			}
 		};
 
+		const clear = () => this.handleCtrlC();
 		this.ctx.editor.setActionKeys("app.clear", this.ctx.keybindings.getKeys("app.clear"));
-		this.ctx.editor.onClear = () => this.handleCtrlC();
+		this.ctx.editor.onClear = clear;
+		this.#registerCommandPaletteAction("app.clear", clear);
+		const exit = () => this.handleCtrlD();
 		this.ctx.editor.setActionKeys("app.exit", this.ctx.keybindings.getKeys("app.exit"));
-		this.ctx.editor.onExit = () => this.handleCtrlD();
+		this.ctx.editor.onExit = exit;
+		this.#registerCommandPaletteAction("app.exit", exit);
+		const suspend = () => this.handleCtrlZ();
 		this.ctx.editor.setActionKeys("app.suspend", this.ctx.keybindings.getKeys("app.suspend"));
-		this.ctx.editor.onSuspend = () => this.handleCtrlZ();
+		this.ctx.editor.onSuspend = suspend;
+		this.#registerCommandPaletteAction("app.suspend", suspend);
+		const cycleThinking = () => this.cycleThinkingLevel();
 		this.ctx.editor.setActionKeys("app.thinking.cycle", this.ctx.keybindings.getKeys("app.thinking.cycle"));
-		this.ctx.editor.onCycleThinkingLevel = () => this.cycleThinkingLevel();
+		this.ctx.editor.onCycleThinkingLevel = cycleThinking;
+		this.#registerCommandPaletteAction("app.thinking.cycle", cycleThinking);
 		this.ctx.editor.setActionKeys("app.commandPalette.open", this.ctx.keybindings.getKeys("app.commandPalette.open"));
 		this.ctx.editor.onOpenCommandPalette = () => this.openCommandPalette();
+		const cycleModelForward = () => this.cycleRoleModel();
 		this.ctx.editor.setActionKeys("app.model.cycleForward", this.ctx.keybindings.getKeys("app.model.cycleForward"));
-		this.ctx.editor.onCycleModelForward = () => this.cycleRoleModel();
+		this.ctx.editor.onCycleModelForward = cycleModelForward;
+		this.#registerCommandPaletteAction("app.model.cycleForward", cycleModelForward);
+		const cycleModelBackward = () => this.cycleRoleModel({ temporary: true });
 		this.ctx.editor.setActionKeys("app.model.cycleBackward", this.ctx.keybindings.getKeys("app.model.cycleBackward"));
-		this.ctx.editor.onCycleModelBackward = () => this.cycleRoleModel({ temporary: true });
+		this.ctx.editor.onCycleModelBackward = cycleModelBackward;
+		this.#registerCommandPaletteAction("app.model.cycleBackward", cycleModelBackward);
+		const selectTemporaryModel = () => this.ctx.showModelSelector({ temporaryOnly: true });
 		this.ctx.editor.setActionKeys(
 			"app.model.selectTemporary",
 			this.ctx.keybindings.getKeys("app.model.selectTemporary"),
 		);
-		this.ctx.editor.onSelectModelTemporary = () => this.ctx.showModelSelector({ temporaryOnly: true });
+		this.ctx.editor.onSelectModelTemporary = selectTemporaryModel;
+		this.#registerCommandPaletteAction("app.model.selectTemporary", selectTemporaryModel);
 
 		// Global debug handler on TUI (works regardless of focus)
 		this.ctx.ui.onDebug = () => this.ctx.showDebugSelector();
+		const selectModel = () => this.ctx.showModelSelector();
 		this.ctx.editor.setActionKeys("app.model.select", this.ctx.keybindings.getKeys("app.model.select"));
-		this.ctx.editor.onSelectModel = () => this.ctx.showModelSelector();
+		this.ctx.editor.onSelectModel = selectModel;
+		this.#registerCommandPaletteAction("app.model.select", selectModel);
+		const searchHistory = () => this.ctx.showHistorySearch();
 		this.ctx.editor.setActionKeys("app.history.search", this.ctx.keybindings.getKeys("app.history.search"));
-		this.ctx.editor.onHistorySearch = () => this.ctx.showHistorySearch();
+		this.ctx.editor.onHistorySearch = searchHistory;
+		this.#registerCommandPaletteAction("app.history.search", searchHistory);
+		const toggleThinking = () => this.ctx.toggleThinkingBlockVisibility();
 		this.ctx.editor.setActionKeys("app.thinking.toggle", this.ctx.keybindings.getKeys("app.thinking.toggle"));
-		this.ctx.editor.onToggleThinking = () => this.ctx.toggleThinkingBlockVisibility();
+		this.ctx.editor.onToggleThinking = toggleThinking;
+		this.#registerCommandPaletteAction("app.thinking.toggle", toggleThinking);
+		const externalEditor = () => void this.openExternalEditor();
 		this.ctx.editor.setActionKeys("app.editor.external", this.ctx.keybindings.getKeys("app.editor.external"));
-		this.ctx.editor.onExternalEditor = () => void this.openExternalEditor();
+		this.ctx.editor.onExternalEditor = externalEditor;
+		this.#registerCommandPaletteAction("app.editor.external", externalEditor);
 		this.ctx.editor.onShowHotkeys = () => this.ctx.handleHotkeysCommand();
+		const pasteImage = () => this.handleImagePaste();
 		this.ctx.editor.setActionKeys(
 			"app.clipboard.pasteImage",
 			this.ctx.keybindings.getKeys("app.clipboard.pasteImage"),
 		);
-		this.ctx.editor.onPasteImage = () => this.handleImagePaste();
+		this.ctx.editor.onPasteImage = pasteImage;
+		this.#registerCommandPaletteAction("app.clipboard.pasteImage", pasteImage);
+		const copyPrompt = () => this.handleCopyPrompt();
 		this.ctx.editor.setActionKeys(
 			"app.clipboard.copyPrompt",
 			this.ctx.keybindings.getKeys("app.clipboard.copyPrompt"),
 		);
-		this.ctx.editor.onCopyPrompt = () => this.handleCopyPrompt();
+		this.ctx.editor.onCopyPrompt = copyPrompt;
+		this.#registerCommandPaletteAction("app.clipboard.copyPrompt", copyPrompt);
 		this.ctx.editor.onPasteText = text => this.handleTextPaste(text);
 		this.ctx.editor.onPastePendingInputCleared = (reason, droppedInputCount) => {
 			const reasonText = reason === "timeout" ? "timed out" : "exceeded the input queue limit";
@@ -371,12 +407,18 @@ export class InputController {
 				`Paste handling ${reasonText}; discarded ${droppedInputCount} buffered input event${droppedInputCount === 1 ? "" : "s"}.`,
 			);
 		};
+		const expandTools = () => this.toggleToolOutputExpansion();
 		this.ctx.editor.setActionKeys("app.tools.expand", this.ctx.keybindings.getKeys("app.tools.expand"));
-		this.ctx.editor.onExpandTools = () => this.toggleToolOutputExpansion();
+		this.ctx.editor.onExpandTools = expandTools;
+		this.#registerCommandPaletteAction("app.tools.expand", expandTools);
+		const dequeue = () => this.handleDequeue();
 		this.ctx.editor.setActionKeys("app.message.dequeue", this.ctx.keybindings.getKeys("app.message.dequeue"));
-		this.ctx.editor.onDequeue = () => this.handleDequeue();
+		this.ctx.editor.onDequeue = dequeue;
+		this.#registerCommandPaletteAction("app.message.dequeue", dequeue);
+		const queue = () => void this.handleQueueSubmit();
 		this.ctx.editor.setActionKeys("app.message.queue", this.ctx.keybindings.getKeys("app.message.queue"));
-		this.ctx.editor.onQueue = () => void this.handleQueueSubmit();
+		this.ctx.editor.onQueue = queue;
+		this.#registerCommandPaletteAction("app.message.queue", queue);
 
 		this.ctx.editor.onViewportPageScroll = direction => this.ctx.ui.scrollViewportPages(direction);
 		this.ctx.editor.onViewportFollowLive = () => {
@@ -394,28 +436,39 @@ export class InputController {
 			});
 		}
 
-		const planModeKeys = this.ctx.keybindings.getKeys("app.plan.toggle");
-		for (const key of planModeKeys) {
-			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handlePlanModeCommand());
+		const togglePlanMode = () => void this.ctx.handlePlanModeCommand();
+		this.#registerCommandPaletteAction("app.plan.toggle", togglePlanMode);
+		for (const key of this.ctx.keybindings.getKeys("app.plan.toggle")) {
+			this.ctx.editor.setCustomKeyHandler(key, togglePlanMode);
 		}
-
+		const newSession = () => void this.ctx.handleClearCommand();
+		this.#registerCommandPaletteAction("app.session.new", newSession);
 		for (const key of this.ctx.keybindings.getKeys("app.session.new")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleClearCommand());
+			this.ctx.editor.setCustomKeyHandler(key, newSession);
 		}
+		const showTree = () => {
+			this.ctx.showTreeSelector();
+			return undefined;
+		};
+		this.#registerCommandPaletteAction("app.session.tree", showTree);
 		for (const key of this.ctx.keybindings.getKeys("app.session.tree")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => {
-				this.ctx.showTreeSelector();
-			});
+			this.ctx.editor.setCustomKeyHandler(key, showTree);
 		}
+		const forkSession = () => {
+			this.ctx.showUserMessageSelector();
+			return undefined;
+		};
+		this.#registerCommandPaletteAction("app.session.fork", forkSession);
 		for (const key of this.ctx.keybindings.getKeys("app.session.fork")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => {
-				this.ctx.showUserMessageSelector();
-			});
+			this.ctx.editor.setCustomKeyHandler(key, forkSession);
 		}
+		const resumeSession = () => {
+			this.ctx.showSessionSelector();
+			return undefined;
+		};
+		this.#registerCommandPaletteAction("app.session.resume", resumeSession);
 		for (const key of this.ctx.keybindings.getKeys("app.session.resume")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => {
-				this.ctx.showSessionSelector();
-			});
+			this.ctx.editor.setCustomKeyHandler(key, resumeSession);
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.message.followUp")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => {
@@ -1347,17 +1400,16 @@ export class InputController {
 	}
 
 	openCommandPalette(): void {
-		this.ctx.showCommandPalette(
-			this.#slashCommands,
-			action => {
-				const key = this.ctx.keybindings.getKeys(action as AppKeybinding)[0];
-				if (key) this.ctx.editor.handleInput(key);
-			},
-			name => {
-				this.ctx.editor.setText(`/${name}`);
-				this.ctx.editor.handleInput("\n");
-			},
-		);
+		this.ctx.showCommandPalette(this.#slashCommands, [...this.#commandPaletteActions.values()], name => {
+			const text = this.ctx.editor.getText();
+			const pendingImages = [...this.ctx.pendingImages];
+			this.ctx.editor.setText(`/${name}`);
+			this.ctx.editor.handleInput("\n");
+			// Slash commands run through submit synchronously; restore afterward so command-side
+			// composer mutations do not replace the draft that was present before opening the palette.
+			this.ctx.editor.setText(text);
+			this.ctx.pendingImages = pendingImages;
+		});
 	}
 
 	cycleThinkingLevel(): void {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -38,6 +38,11 @@ function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
 }
 
+interface PaletteComposerState {
+	snapshotText: string;
+	successorText: string | undefined;
+	successorImages: InteractiveModeContext["pendingImages"] | undefined;
+}
 export class InputController {
 	constructor(private ctx: InteractiveModeContext) {}
 
@@ -49,6 +54,8 @@ export class InputController {
 	 *  so abort cleanup going idle cannot turn the second Esc into an idle action. */
 	#steerConsumePending = false;
 	#commandPaletteActions = new Map<AppKeybinding, CommandPaletteAction>();
+	#paletteCommandInFlight = false;
+	#paletteComposerState: PaletteComposerState | undefined;
 
 	#registerCommandPaletteAction(action: AppKeybinding, handler: () => void): void {
 		this.#commandPaletteActions.set(action, {
@@ -509,6 +516,11 @@ export class InputController {
 			this.ctx.isBashNoContext = trimmed.startsWith("!!");
 			this.ctx.isPythonMode = trimmed.startsWith("$") && !trimmed.startsWith("${");
 			this.#clearPendingImagesIfPlaceholdersRemoved(text);
+			const paletteComposerState = this.#paletteComposerState;
+			if (paletteComposerState && text !== "" && text !== paletteComposerState.snapshotText) {
+				paletteComposerState.successorText = text;
+				paletteComposerState.successorImages = [...this.ctx.pendingImages];
+			}
 			if (
 				wasBashMode !== this.ctx.isBashMode ||
 				wasBashNoContext !== this.ctx.isBashNoContext ||
@@ -643,6 +655,7 @@ export class InputController {
 		if (this.ctx.session.isStreaming) {
 			this.ctx.editor.addToHistory(text);
 			this.ctx.editor.setText("");
+			this.#consumePaletteSuccessor(text);
 			const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
 			this.#clearPendingImagesIfOwnedBy(pendingImages);
 			// Record the signature so the queued message's eventual delivery
@@ -704,6 +717,22 @@ export class InputController {
 			this.ctx.onInputCallback(submission);
 		}
 		this.ctx.editor.addToHistory(text);
+		this.#consumePaletteSuccessor(text);
+	}
+
+	/**
+	 * A submission that consumes composer text during a pending palette command
+	 * also consumes the recorded successor draft: restoring text the user has
+	 * already sent would resurrect a delivered message into the composer. The
+	 * pre-palette snapshot (never-sent state) remains the restore target.
+	 */
+	#consumePaletteSuccessor(submittedText: string): void {
+		const state = this.#paletteComposerState;
+		if (!state) return;
+		if (state.successorText !== undefined && state.successorText === submittedText) {
+			state.successorText = undefined;
+			state.successorImages = undefined;
+		}
 	}
 
 	handleCtrlC(): void {
@@ -1403,13 +1432,35 @@ export class InputController {
 
 	openCommandPalette(): void {
 		this.ctx.showCommandPalette(this.#slashCommands, [...this.#commandPaletteActions.values()], async name => {
+			if (this.#paletteCommandInFlight) {
+				this.ctx.showStatus("A palette command is still running.");
+				return;
+			}
+
+			this.#paletteCommandInFlight = true;
 			const text = this.ctx.editor.getText();
 			const pendingImages = [...this.ctx.pendingImages];
+			this.#paletteComposerState = { snapshotText: text, successorText: undefined, successorImages: undefined };
 			try {
 				await this.submitText(`/${name}`);
 			} finally {
-				this.ctx.editor.setText(text);
-				this.ctx.pendingImages = pendingImages;
+				// The palette command owns its cleanup only until newer composer input arrives.
+				// A draft or attachment added after the palette closes always wins over this snapshot.
+				const successorText = this.#paletteComposerState?.successorText;
+				const successorImages = this.#paletteComposerState?.successorImages;
+				const hasNewImages = this.ctx.pendingImages.some(image => !pendingImages.includes(image));
+				if (successorText !== undefined) {
+					this.ctx.editor.setText(successorText);
+				} else if (this.ctx.editor.getText() === "" || this.ctx.editor.getText() === text) {
+					this.ctx.editor.setText(text);
+				}
+				if (successorImages !== undefined) {
+					this.ctx.pendingImages = successorImages;
+				} else if (!hasNewImages) {
+					this.ctx.pendingImages = pendingImages;
+				}
+				this.#paletteComposerState = undefined;
+				this.#paletteCommandInFlight = false;
 			}
 		});
 	}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -2,9 +2,10 @@ import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
-import type { Component, OverlayHandle } from "@gajae-code/tui";
+import type { Component, OverlayHandle, SlashCommand } from "@gajae-code/tui";
 import { Input, isPetMode, Loader, Spacer, Text } from "@gajae-code/tui";
 import { getAgentDbPath, getProjectDir, logger, VERSION } from "@gajae-code/utils";
+import { formatKeyHints, KEYBINDINGS } from "../../config/keybindings";
 import {
 	activateModelProfile,
 	type MaterializeModelProfileForDeletionResult,
@@ -108,6 +109,7 @@ import {
 import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
+import { CommandPaletteComponent, type CommandPaletteEntry } from "../components/command-palette";
 import {
 	CustomModelPresetWizardComponent,
 	type CustomModelPresetWizardSubmit,
@@ -726,6 +728,53 @@ export class SelectorController {
 		this.ctx.ui.requestRender();
 	}
 
+	showCommandPalette(
+		commands: SlashCommand[],
+		executeAction: (action: string) => void,
+		executeSlashCommand: (name: string) => void,
+	): void {
+		const seenCommands = new Set<string>();
+		const entries: CommandPaletteEntry[] = [
+			...Object.entries(KEYBINDINGS)
+				.filter(([action]) => action.startsWith("app."))
+				.map(([action, definition]) => ({
+					id: `action:${action}`,
+					label: definition.description,
+					description: action,
+					keybinding:
+						formatKeyHints(this.ctx.keybindings.getKeys(action as keyof typeof KEYBINDINGS)) || undefined,
+					searchText: action,
+				})),
+			...commands
+				.filter(command => {
+					if (seenCommands.has(command.name)) return false;
+					seenCommands.add(command.name);
+					return true;
+				})
+				.map(command => ({
+					id: `command:${command.name}`,
+					label: `/${command.name}`,
+					description: command.description ?? "Slash command",
+					searchText: command.name,
+				})),
+		];
+
+		this.showSelector(done => {
+			const selector = new CommandPaletteComponent(
+				entries,
+				entry => {
+					done();
+					if (entry.id.startsWith("action:")) {
+						executeAction(entry.id.slice("action:".length));
+					} else {
+						executeSlashCommand(entry.id.slice("command:".length));
+					}
+				},
+				done,
+			);
+			return { component: selector, focus: selector };
+		});
+	}
 	showProviderOnboarding(): void {
 		this.showSelector(done => {
 			const selector = new ProviderOnboardingSelectorComponent(

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -735,7 +735,7 @@ export class SelectorController {
 	showCommandPalette(
 		commands: SlashCommand[],
 		actions: CommandPaletteAction[],
-		executeSlashCommand: (name: string) => void,
+		executeSlashCommand: (name: string) => Promise<void>,
 	): void {
 		const seenCommands = new Set<string>();
 		const entries: CommandPaletteEntry[] = [
@@ -767,7 +767,7 @@ export class SelectorController {
 				entries,
 				entry => {
 					done();
-					entry.handler?.();
+					void entry.handler?.();
 				},
 				done,
 			);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -5,7 +5,7 @@ import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
 import type { Component, OverlayHandle, SlashCommand } from "@gajae-code/tui";
 import { Input, isPetMode, Loader, Spacer, Text } from "@gajae-code/tui";
 import { getAgentDbPath, getProjectDir, logger, VERSION } from "@gajae-code/utils";
-import { formatKeyHints, KEYBINDINGS } from "../../config/keybindings";
+import { type AppKeybinding, formatKeyHints } from "../../config/keybindings";
 import {
 	activateModelProfile,
 	type MaterializeModelProfileForDeletionResult,
@@ -109,7 +109,11 @@ import {
 import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
-import { CommandPaletteComponent, type CommandPaletteEntry } from "../components/command-palette";
+import {
+	type CommandPaletteAction,
+	CommandPaletteComponent,
+	type CommandPaletteEntry,
+} from "../components/command-palette";
 import {
 	CustomModelPresetWizardComponent,
 	type CustomModelPresetWizardSubmit,
@@ -730,21 +734,19 @@ export class SelectorController {
 
 	showCommandPalette(
 		commands: SlashCommand[],
-		executeAction: (action: string) => void,
+		actions: CommandPaletteAction[],
 		executeSlashCommand: (name: string) => void,
 	): void {
 		const seenCommands = new Set<string>();
 		const entries: CommandPaletteEntry[] = [
-			...Object.entries(KEYBINDINGS)
-				.filter(([action]) => action.startsWith("app."))
-				.map(([action, definition]) => ({
-					id: `action:${action}`,
-					label: definition.description,
-					description: action,
-					keybinding:
-						formatKeyHints(this.ctx.keybindings.getKeys(action as keyof typeof KEYBINDINGS)) || undefined,
-					searchText: action,
-				})),
+			...actions.map(action => ({
+				id: `action:${action.id}`,
+				label: action.label,
+				description: action.id,
+				keybinding: formatKeyHints(this.ctx.keybindings.getKeys(action.id as AppKeybinding)) || undefined,
+				searchText: action.id,
+				handler: action.handler,
+			})),
 			...commands
 				.filter(command => {
 					if (seenCommands.has(command.name)) return false;
@@ -756,6 +758,7 @@ export class SelectorController {
 					label: `/${command.name}`,
 					description: command.description ?? "Slash command",
 					searchText: command.name,
+					handler: () => executeSlashCommand(command.name),
 				})),
 		];
 
@@ -764,11 +767,7 @@ export class SelectorController {
 				entries,
 				entry => {
 					done();
-					if (entry.id.startsWith("action:")) {
-						executeAction(entry.id.slice("action:".length));
-					} else {
-						executeSlashCommand(entry.id.slice("command:".length));
-					}
+					entry.handler?.();
 				},
 				done,
 			);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -767,7 +767,11 @@ export class SelectorController {
 				entries,
 				entry => {
 					done();
-					void entry.handler?.();
+					void Promise.resolve()
+						.then(() => entry.handler?.())
+						.catch(error => {
+							this.ctx.showError(error instanceof Error ? error.message : String(error));
+						});
 				},
 				done,
 			);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2857,7 +2857,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	showCommandPalette(
 		commands: SlashCommand[],
 		actions: CommandPaletteAction[],
-		executeSlashCommand: (name: string) => void,
+		executeSlashCommand: (name: string) => Promise<void>,
 	): void {
 		this.#selectorController.showCommandPalette(commands, actions, executeSlashCommand);
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2853,6 +2853,14 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	// Selector handling
+	showCommandPalette(
+		commands: SlashCommand[],
+		executeAction: (action: string) => void,
+		executeSlashCommand: (name: string) => void,
+	): void {
+		this.#selectorController.showCommandPalette(commands, executeAction, executeSlashCommand);
+	}
+
 	showSettingsSelector(): void {
 		this.#selectorController.showSettingsSelector();
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -88,6 +88,7 @@ import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-colo
 import { popTerminalTitle, pushTerminalTitle, setSessionTerminalTitle } from "../utils/title-generator";
 import type { AssistantMessageComponent } from "./components/assistant-message";
 import type { BashExecutionComponent } from "./components/bash-execution";
+import type { CommandPaletteAction } from "./components/command-palette";
 import { CustomEditor } from "./components/custom-editor";
 import { DynamicBorder } from "./components/dynamic-border";
 import type { EvalExecutionComponent } from "./components/eval-execution";
@@ -2855,10 +2856,10 @@ export class InteractiveMode implements InteractiveModeContext {
 	// Selector handling
 	showCommandPalette(
 		commands: SlashCommand[],
-		executeAction: (action: string) => void,
+		actions: CommandPaletteAction[],
 		executeSlashCommand: (name: string) => void,
 	): void {
-		this.#selectorController.showCommandPalette(commands, executeAction, executeSlashCommand);
+		this.#selectorController.showCommandPalette(commands, actions, executeSlashCommand);
 	}
 
 	showSettingsSelector(): void {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -290,7 +290,7 @@ export interface InteractiveModeContext {
 	showCommandPalette(
 		commands: SlashCommand[],
 		actions: CommandPaletteAction[],
-		executeSlashCommand: (name: string) => void,
+		executeSlashCommand: (name: string) => Promise<void>,
 	): void;
 	showSettingsSelector(): void;
 	showThemeSelector(): void;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage } from "@gajae-code/agent-core";
 import type { CompactionOutcome } from "@gajae-code/agent-core/compaction";
 import type { AssistantMessage, ImageContent, Message, UsageReport } from "@gajae-code/ai";
-import type { Component, Container, EditorTheme, Loader, Spacer, Text, TUI } from "@gajae-code/tui";
+import type { Component, Container, EditorTheme, Loader, SlashCommand, Spacer, Text, TUI } from "@gajae-code/tui";
 import type { KeybindingsManager } from "../config/keybindings";
 import type { Settings } from "../config/settings";
 import type {
@@ -286,6 +286,11 @@ export interface InteractiveModeContext {
 	refreshSlashCommandState(cwd?: string): Promise<void>;
 
 	// Selector handling
+	showCommandPalette(
+		commands: SlashCommand[],
+		executeAction: (action: string) => void,
+		executeSlashCommand: (name: string) => void,
+	): void;
 	showSettingsSelector(): void;
 	showThemeSelector(): void;
 	showPetSelector(): void;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -22,6 +22,7 @@ import type { CredentialAutoImportOptions } from "../setup/credential-auto-impor
 import type { LspStartupServerInfo } from "../tools";
 import type { AssistantMessageComponent } from "./components/assistant-message";
 import type { BashExecutionComponent } from "./components/bash-execution";
+import type { CommandPaletteAction } from "./components/command-palette";
 import type { CustomEditor } from "./components/custom-editor";
 import type { EvalExecutionComponent } from "./components/eval-execution";
 import type { PetMode } from "./components/gajae-pet-widget";
@@ -288,7 +289,7 @@ export interface InteractiveModeContext {
 	// Selector handling
 	showCommandPalette(
 		commands: SlashCommand[],
-		executeAction: (action: string) => void,
+		actions: CommandPaletteAction[],
 		executeSlashCommand: (name: string) => void,
 	): void;
 	showSettingsSelector(): void;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -39,8 +39,6 @@ type FakeEditor = {
 	onExternalEditor?: () => void;
 	onDequeue?: () => void;
 	onChange?: (text: string) => void;
-	onUserEdit?: () => void;
-	onProgrammaticSetText?: (text: string) => boolean;
 	setText(text: string): void;
 	getText(): string;
 	addToHistory(text: string): void;
@@ -123,7 +121,6 @@ function createContext(): {
 	});
 	const editor: FakeEditor = {
 		setText(text: string) {
-			if (editor.onProgrammaticSetText?.(text)) return;
 			editorText = text;
 			editor.onChange?.(text);
 		},
@@ -901,179 +898,113 @@ describe("InputController command palette", () => {
 		expect(actions.some(action => action.id === "app.commandPalette.open")).toBe(false);
 	});
 
-	it("restores the draft and pending images after delayed slash command cleanup", async () => {
-		const { ctx, editor } = createContext();
+	it("refuses slash commands when the composer has text without touching the draft", async () => {
+		const { ctx, editor, spies } = createContext();
 		const showCommandPalette = vi.fn();
 		ctx.showCommandPalette = showCommandPalette;
+		ctx.handleChangelogCommand = vi.fn();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
+		editor.setText("existing draft");
+
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+		await executeSlashCommand("changelog");
+
+		expect(ctx.handleChangelogCommand).not.toHaveBeenCalled();
+		expect(spies.showStatus).toHaveBeenCalledWith("Send or clear the draft before running a palette command.");
+		expect(editor.getText()).toBe("existing draft");
+		expect(ctx.pendingImages).toEqual([]);
+	});
+	it("refuses slash commands when only pending images are present without touching the composer", async () => {
+		const { ctx, editor, spies } = createContext();
+		const showCommandPalette = vi.fn();
+		ctx.showCommandPalette = showCommandPalette;
+		ctx.handleChangelogCommand = vi.fn();
 		const attachment = { type: "image", data: "attachment" } as InteractiveModeContext["pendingImages"][number];
 		ctx.pendingImages = [attachment];
-		let resolveChangelog!: () => void;
-		const changelog = new Promise<void>(resolve => {
-			resolveChangelog = resolve;
-		});
-		ctx.handleChangelogCommand = vi.fn(() => changelog);
 		const controller = new InputController(ctx);
+
 		controller.setupKeyHandlers();
-		controller.setupEditorSubmitHandler();
-		const onChange = editor.onChange;
-		const emptyChanges = vi.fn();
-		editor.onChange = text => {
-			onChange?.(text);
-			if (!text) emptyChanges();
-		};
-		editor.setText("existing draft [image 1]");
 		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
 
 		controller.openCommandPalette();
-
 		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
-		const execution = executeSlashCommand("changelog");
-		await Promise.resolve();
-		expect(ctx.handleChangelogCommand).toHaveBeenCalledTimes(1);
+		await executeSlashCommand("changelog");
 
-		resolveChangelog();
-		await execution;
-
-		expect(editor.getText()).toBe("existing draft [image 1]");
-		expect(emptyChanges.mock.calls.length).toBeGreaterThanOrEqual(1);
+		expect(ctx.handleChangelogCommand).not.toHaveBeenCalled();
+		expect(spies.showStatus).toHaveBeenCalledWith("Send or clear the draft before running a palette command.");
+		expect(editor.getText()).toBe("");
 		expect(ctx.pendingImages).toEqual([attachment]);
 	});
-	it("keeps a successor draft after delayed slash command cleanup", async () => {
-		const { ctx, editor } = createContext();
+	it("dispatches slash commands from an empty composer", async () => {
+		const { ctx } = createContext();
 		const showCommandPalette = vi.fn();
 		ctx.showCommandPalette = showCommandPalette;
-		let resolveChangelog!: () => void;
-		ctx.handleChangelogCommand = vi.fn(
-			() =>
-				new Promise<void>(resolve => {
-					resolveChangelog = resolve;
-				}),
-		);
+		ctx.handleChangelogCommand = vi.fn();
 		const controller = new InputController(ctx);
+
 		controller.setupKeyHandlers();
 		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
 
-		editor.setText("old draft");
 		controller.openCommandPalette();
 		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
-		const execution = executeSlashCommand("changelog");
-		await Promise.resolve();
+		await executeSlashCommand("changelog");
 
-		editor.onUserEdit?.();
+		expect(ctx.handleChangelogCommand).toHaveBeenCalledTimes(1);
+	});
+	it("runs action entries with a draft without touching the composer", () => {
+		const { ctx, editor } = createContext();
+		const showCommandPalette = vi.fn();
+		ctx.showCommandPalette = showCommandPalette;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.setText("existing draft");
+		controller.openCommandPalette();
+		const actions = showCommandPalette.mock.calls[0]?.[1] as Array<{ id: string; handler: () => void }>;
+		const tree = actions.find(action => action.id === "app.session.tree");
+
+		tree?.handler();
+
+		expect(ctx.showTreeSelector).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("existing draft");
+		expect(ctx.pendingImages).toEqual([]);
+	});
+	it("keeps a draft typed after an empty-composer slash dispatch while command cleanup settles", async () => {
+		const { ctx, editor, spies } = createContext();
+		const showCommandPalette = vi.fn();
+		ctx.showCommandPalette = showCommandPalette;
+		(ctx.session as { isStreaming: boolean }).isStreaming = true;
+		ctx.withLocalSubmission = async (_text, submit) => submit();
+		let resolveCommand!: () => void;
+		spies.prompt.mockImplementation(
+			() =>
+				new Promise<void>(resolve => {
+					resolveCommand = resolve;
+				}),
+		);
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "delayed" }] as SlashCommand[], "");
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+		const execution = executeSlashCommand("delayed");
+		await Bun.sleep(0);
+		expect(spies.prompt).toHaveBeenCalledTimes(1);
+
 		editor.setText("new draft");
-		resolveChangelog();
+		resolveCommand();
 		await execution;
 
+		// Command-authored composer mutations are the command's contract, not the palette's.
 		expect(editor.getText()).toBe("new draft");
 	});
-	it("does not resurrect a successor draft that was submitted during a palette command", async () => {
-		const { ctx, editor, spies } = createContext();
-		const showCommandPalette = vi.fn();
-		ctx.showCommandPalette = showCommandPalette;
-		let resolveChangelog!: () => void;
-		ctx.handleChangelogCommand = vi.fn(
-			() =>
-				new Promise<void>(resolve => {
-					resolveChangelog = resolve;
-				}),
-		);
-		const controller = new InputController(ctx);
-		controller.setupKeyHandlers();
-		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
-
-		editor.setText("old draft");
-		controller.openCommandPalette();
-		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
-		const execution = executeSlashCommand("changelog");
-		await Promise.resolve();
-
-		// The user types a successor draft and SENDS it while the palette command
-		// is still pending; the submission consumer then clears the composer.
-		editor.onUserEdit?.();
-		editor.setText("new draft");
-		await controller.submitText("new draft");
-		controller.handleCtrlC();
-		resolveChangelog();
-		await execution;
-
-		// The submitted text must not be resurrected into the composer.
-		expect(spies.onInputCallback).toHaveBeenCalledTimes(1);
-		expect(editor.getText()).toBe("");
-	});
-
-	it("lets a submission clear the composer despite the pending-palette ownership guard", async () => {
-		const { ctx, editor, spies } = createContext();
-		const showCommandPalette = vi.fn();
-		ctx.showCommandPalette = showCommandPalette;
-		let resolveChangelog!: () => void;
-		ctx.handleChangelogCommand = vi.fn(
-			() =>
-				new Promise<void>(resolve => {
-					resolveChangelog = resolve;
-				}),
-		);
-		const controller = new InputController(ctx);
-		controller.setupKeyHandlers();
-		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
-
-		editor.setText("old draft");
-		controller.openCommandPalette();
-		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
-		const execution = executeSlashCommand("changelog");
-		await Promise.resolve();
-
-		// The user types the continue shortcut and submits while the palette
-		// command is pending. Submission paths resume in a microtask (outside the
-		// editor's user-input window), so their programmatic clear must bypass
-		// the ownership guard instead of leaving the sent text in the composer.
-		editor.onUserEdit?.();
-		editor.setText(".");
-		await controller.submitText(".");
-		expect(editor.getText()).toBe("");
-		expect(spies.onInputCallback).toHaveBeenCalledTimes(1);
-
-		resolveChangelog();
-		await execution;
-
-		// Generation advanced, so the stash is not restored either.
-		expect(editor.getText()).toBe("");
-	});
-
-	it("keeps attachments added while a palette command is running", async () => {
-		const { ctx, editor } = createContext();
-		const showCommandPalette = vi.fn();
-		ctx.showCommandPalette = showCommandPalette;
-		const original = { type: "image", data: "original" } as InteractiveModeContext["pendingImages"][number];
-		const successor = { type: "image", data: "successor" } as InteractiveModeContext["pendingImages"][number];
-		ctx.pendingImages = [original];
-		let resolveChangelog!: () => void;
-		ctx.handleChangelogCommand = vi.fn(
-			() =>
-				new Promise<void>(resolve => {
-					resolveChangelog = resolve;
-				}),
-		);
-		const controller = new InputController(ctx);
-		controller.setupKeyHandlers();
-		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
-
-		editor.setText("old draft [image 1]");
-		controller.openCommandPalette();
-		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
-		const execution = executeSlashCommand("changelog");
-		await Promise.resolve();
-
-		editor.onUserEdit?.();
-		ctx.pendingImages = [...ctx.pendingImages, successor];
-		editor.setText("old draft [image 1] [image 2]");
-		resolveChangelog();
-		await execution;
-
-		expect(ctx.pendingImages).toEqual([successor]);
-	});
-
 	it("refuses a second palette command while the first is pending", async () => {
-		const { ctx, editor, spies } = createContext();
+		const { ctx, spies } = createContext();
 		const showCommandPalette = vi.fn();
 		ctx.showCommandPalette = showCommandPalette;
 		let resolveChangelog!: () => void;
@@ -1084,16 +1015,13 @@ describe("InputController command palette", () => {
 				}),
 		);
 		const controller = new InputController(ctx);
+
 		controller.setupKeyHandlers();
 		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
-
-		editor.setText("draft");
 		controller.openCommandPalette();
 		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
 		const first = executeSlashCommand("changelog");
 		await Promise.resolve();
-		controller.openCommandPalette();
-		expect(showCommandPalette).toHaveBeenCalledTimes(1);
 		await executeSlashCommand("changelog");
 
 		expect(ctx.handleChangelogCommand).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -122,6 +122,7 @@ function createContext(): {
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
+			editor.onChange?.(text);
 		},
 		getText() {
 			return editorText;
@@ -871,10 +872,9 @@ describe("InputController escape behavior", () => {
 });
 describe("InputController command palette", () => {
 	it("runs registered actions directly and excludes unsupported actions and self-reentry", () => {
-		const { ctx, editor } = createContext();
+		const { ctx } = createContext();
 		const showCommandPalette = vi.fn();
 		ctx.showCommandPalette = showCommandPalette;
-		(editor as unknown as { handleInput: ReturnType<typeof vi.fn> }).handleInput = vi.fn();
 		(ctx.keybindings as unknown as { getKeys(action: string): string[] }).getKeys = action =>
 			action === "app.session.tree" ? ["ctrl+d"] : [];
 		const controller = new InputController(ctx);
@@ -894,32 +894,45 @@ describe("InputController command palette", () => {
 		expect(ctx.showTreeSelector).toHaveBeenCalledTimes(1);
 		fork?.handler();
 		expect(ctx.showUserMessageSelector).toHaveBeenCalledTimes(1);
-		expect((editor as unknown as { handleInput: ReturnType<typeof vi.fn> }).handleInput).not.toHaveBeenCalled();
 		expect(actions.some(action => action.id === "app.session.delete")).toBe(false);
 		expect(actions.some(action => action.id === "app.commandPalette.open")).toBe(false);
 	});
 
-	it("restores the draft and pending images after executing a slash command", () => {
+	it("restores the draft and pending images after delayed slash command cleanup", async () => {
 		const { ctx, editor } = createContext();
 		const showCommandPalette = vi.fn();
 		ctx.showCommandPalette = showCommandPalette;
 		const attachment = { type: "image", data: "attachment" } as InteractiveModeContext["pendingImages"][number];
 		ctx.pendingImages = [attachment];
-		editor.setText("existing draft");
-		const input = editor as unknown as {
-			handleInput: ReturnType<typeof vi.fn>;
-		};
-		input.handleInput = vi.fn();
+		let resolveChangelog!: () => void;
+		const changelog = new Promise<void>(resolve => {
+			resolveChangelog = resolve;
+		});
+		ctx.handleChangelogCommand = vi.fn(() => changelog);
 		const controller = new InputController(ctx);
-		controller.createAutocompleteProvider([{ name: "help" }] as SlashCommand[], "");
+		controller.setupKeyHandlers();
+		controller.setupEditorSubmitHandler();
+		const onChange = editor.onChange;
+		const emptyChanges = vi.fn();
+		editor.onChange = text => {
+			onChange?.(text);
+			if (!text) emptyChanges();
+		};
+		editor.setText("existing draft [image 1]");
+		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
 
 		controller.openCommandPalette();
 
-		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => void;
-		executeSlashCommand("help");
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+		const execution = executeSlashCommand("changelog");
+		await Promise.resolve();
+		expect(ctx.handleChangelogCommand).toHaveBeenCalledTimes(1);
 
-		expect(input.handleInput).toHaveBeenCalledWith("\n");
-		expect(editor.getText()).toBe("existing draft");
+		resolveChangelog();
+		await execution;
+
+		expect(editor.getText()).toBe("existing draft [image 1]");
+		expect(emptyChanges).toHaveBeenCalledTimes(1);
 		expect(ctx.pendingImages).toEqual([attachment]);
 	});
 });

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -39,6 +39,8 @@ type FakeEditor = {
 	onExternalEditor?: () => void;
 	onDequeue?: () => void;
 	onChange?: (text: string) => void;
+	onUserEdit?: () => void;
+	onProgrammaticSetText?: (text: string) => boolean;
 	setText(text: string): void;
 	getText(): string;
 	addToHistory(text: string): void;
@@ -121,6 +123,7 @@ function createContext(): {
 	});
 	const editor: FakeEditor = {
 		setText(text: string) {
+			if (editor.onProgrammaticSetText?.(text)) return;
 			editorText = text;
 			editor.onChange?.(text);
 		},
@@ -932,7 +935,7 @@ describe("InputController command palette", () => {
 		await execution;
 
 		expect(editor.getText()).toBe("existing draft [image 1]");
-		expect(emptyChanges).toHaveBeenCalledTimes(1);
+		expect(emptyChanges.mock.calls.length).toBeGreaterThanOrEqual(1);
 		expect(ctx.pendingImages).toEqual([attachment]);
 	});
 	it("keeps a successor draft after delayed slash command cleanup", async () => {
@@ -956,6 +959,7 @@ describe("InputController command palette", () => {
 		const execution = executeSlashCommand("changelog");
 		await Promise.resolve();
 
+		editor.onUserEdit?.();
 		editor.setText("new draft");
 		resolveChangelog();
 		await execution;
@@ -985,16 +989,54 @@ describe("InputController command palette", () => {
 
 		// The user types a successor draft and SENDS it while the palette command
 		// is still pending; the submission consumer then clears the composer.
+		editor.onUserEdit?.();
 		editor.setText("new draft");
 		await controller.submitText("new draft");
-		editor.setText("");
+		controller.handleCtrlC();
 		resolveChangelog();
 		await execution;
 
-		// The sent text must not be resurrected into the composer; the never-sent
-		// pre-palette snapshot is the restore target.
+		// The submitted text must not be resurrected into the composer.
 		expect(spies.onInputCallback).toHaveBeenCalledTimes(1);
-		expect(editor.getText()).toBe("old draft");
+		expect(editor.getText()).toBe("");
+	});
+
+	it("lets a submission clear the composer despite the pending-palette ownership guard", async () => {
+		const { ctx, editor, spies } = createContext();
+		const showCommandPalette = vi.fn();
+		ctx.showCommandPalette = showCommandPalette;
+		let resolveChangelog!: () => void;
+		ctx.handleChangelogCommand = vi.fn(
+			() =>
+				new Promise<void>(resolve => {
+					resolveChangelog = resolve;
+				}),
+		);
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
+
+		editor.setText("old draft");
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+		const execution = executeSlashCommand("changelog");
+		await Promise.resolve();
+
+		// The user types the continue shortcut and submits while the palette
+		// command is pending. Submission paths resume in a microtask (outside the
+		// editor's user-input window), so their programmatic clear must bypass
+		// the ownership guard instead of leaving the sent text in the composer.
+		editor.onUserEdit?.();
+		editor.setText(".");
+		await controller.submitText(".");
+		expect(editor.getText()).toBe("");
+		expect(spies.onInputCallback).toHaveBeenCalledTimes(1);
+
+		resolveChangelog();
+		await execution;
+
+		// Generation advanced, so the stash is not restored either.
+		expect(editor.getText()).toBe("");
 	});
 
 	it("keeps attachments added while a palette command is running", async () => {
@@ -1021,12 +1063,13 @@ describe("InputController command palette", () => {
 		const execution = executeSlashCommand("changelog");
 		await Promise.resolve();
 
+		editor.onUserEdit?.();
 		ctx.pendingImages = [...ctx.pendingImages, successor];
 		editor.setText("old draft [image 1] [image 2]");
 		resolveChangelog();
 		await execution;
 
-		expect(ctx.pendingImages).toEqual([original, successor]);
+		expect(ctx.pendingImages).toEqual([successor]);
 	});
 
 	it("refuses a second palette command while the first is pending", async () => {
@@ -1049,6 +1092,8 @@ describe("InputController command palette", () => {
 		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
 		const first = executeSlashCommand("changelog");
 		await Promise.resolve();
+		controller.openCommandPalette();
+		expect(showCommandPalette).toHaveBeenCalledTimes(1);
 		await executeSlashCommand("changelog");
 
 		expect(ctx.handleChangelogCommand).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -935,4 +935,126 @@ describe("InputController command palette", () => {
 		expect(emptyChanges).toHaveBeenCalledTimes(1);
 		expect(ctx.pendingImages).toEqual([attachment]);
 	});
+	it("keeps a successor draft after delayed slash command cleanup", async () => {
+		const { ctx, editor } = createContext();
+		const showCommandPalette = vi.fn();
+		ctx.showCommandPalette = showCommandPalette;
+		let resolveChangelog!: () => void;
+		ctx.handleChangelogCommand = vi.fn(
+			() =>
+				new Promise<void>(resolve => {
+					resolveChangelog = resolve;
+				}),
+		);
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
+
+		editor.setText("old draft");
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+		const execution = executeSlashCommand("changelog");
+		await Promise.resolve();
+
+		editor.setText("new draft");
+		resolveChangelog();
+		await execution;
+
+		expect(editor.getText()).toBe("new draft");
+	});
+	it("does not resurrect a successor draft that was submitted during a palette command", async () => {
+		const { ctx, editor, spies } = createContext();
+		const showCommandPalette = vi.fn();
+		ctx.showCommandPalette = showCommandPalette;
+		let resolveChangelog!: () => void;
+		ctx.handleChangelogCommand = vi.fn(
+			() =>
+				new Promise<void>(resolve => {
+					resolveChangelog = resolve;
+				}),
+		);
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
+
+		editor.setText("old draft");
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+		const execution = executeSlashCommand("changelog");
+		await Promise.resolve();
+
+		// The user types a successor draft and SENDS it while the palette command
+		// is still pending; the submission consumer then clears the composer.
+		editor.setText("new draft");
+		await controller.submitText("new draft");
+		editor.setText("");
+		resolveChangelog();
+		await execution;
+
+		// The sent text must not be resurrected into the composer; the never-sent
+		// pre-palette snapshot is the restore target.
+		expect(spies.onInputCallback).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("old draft");
+	});
+
+	it("keeps attachments added while a palette command is running", async () => {
+		const { ctx, editor } = createContext();
+		const showCommandPalette = vi.fn();
+		ctx.showCommandPalette = showCommandPalette;
+		const original = { type: "image", data: "original" } as InteractiveModeContext["pendingImages"][number];
+		const successor = { type: "image", data: "successor" } as InteractiveModeContext["pendingImages"][number];
+		ctx.pendingImages = [original];
+		let resolveChangelog!: () => void;
+		ctx.handleChangelogCommand = vi.fn(
+			() =>
+				new Promise<void>(resolve => {
+					resolveChangelog = resolve;
+				}),
+		);
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
+
+		editor.setText("old draft [image 1]");
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+		const execution = executeSlashCommand("changelog");
+		await Promise.resolve();
+
+		ctx.pendingImages = [...ctx.pendingImages, successor];
+		editor.setText("old draft [image 1] [image 2]");
+		resolveChangelog();
+		await execution;
+
+		expect(ctx.pendingImages).toEqual([original, successor]);
+	});
+
+	it("refuses a second palette command while the first is pending", async () => {
+		const { ctx, editor, spies } = createContext();
+		const showCommandPalette = vi.fn();
+		ctx.showCommandPalette = showCommandPalette;
+		let resolveChangelog!: () => void;
+		ctx.handleChangelogCommand = vi.fn(
+			() =>
+				new Promise<void>(resolve => {
+					resolveChangelog = resolve;
+				}),
+		);
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
+
+		editor.setText("draft");
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+		const first = executeSlashCommand("changelog");
+		await Promise.resolve();
+		await executeSlashCommand("changelog");
+
+		expect(ctx.handleChangelogCommand).toHaveBeenCalledTimes(1);
+		expect(spies.showStatus).toHaveBeenCalledWith("A palette command is still running.");
+
+		resolveChangelog();
+		await first;
+	});
 });

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -4,6 +4,7 @@ import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-age
 import { InputController } from "@gajae-code/coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext, SubmittedUserInput } from "@gajae-code/coding-agent/modes/types";
 import { SubagentTool, type ToolSession } from "@gajae-code/coding-agent/tools";
+import type { SlashCommand } from "@gajae-code/tui";
 
 beforeAll(async () => {
 	resetSettingsForTest();
@@ -866,5 +867,59 @@ describe("InputController escape behavior", () => {
 		// The empty-composer double-Esc action must not fire on this single empty Esc.
 		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
 		expect(ctx.showUserMessageSelector).not.toHaveBeenCalled();
+	});
+});
+describe("InputController command palette", () => {
+	it("runs registered actions directly and excludes unsupported actions and self-reentry", () => {
+		const { ctx, editor } = createContext();
+		const showCommandPalette = vi.fn();
+		ctx.showCommandPalette = showCommandPalette;
+		(editor as unknown as { handleInput: ReturnType<typeof vi.fn> }).handleInput = vi.fn();
+		(ctx.keybindings as unknown as { getKeys(action: string): string[] }).getKeys = action =>
+			action === "app.session.tree" ? ["ctrl+d"] : [];
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.openCommandPalette();
+
+		const actions = showCommandPalette.mock.calls[0]?.[1] as Array<{
+			id: string;
+			handler: () => void;
+		}>;
+		const tree = actions.find(action => action.id === "app.session.tree");
+		const fork = actions.find(action => action.id === "app.session.fork");
+
+		expect(tree).toBeDefined();
+		tree?.handler();
+		expect(ctx.showTreeSelector).toHaveBeenCalledTimes(1);
+		fork?.handler();
+		expect(ctx.showUserMessageSelector).toHaveBeenCalledTimes(1);
+		expect((editor as unknown as { handleInput: ReturnType<typeof vi.fn> }).handleInput).not.toHaveBeenCalled();
+		expect(actions.some(action => action.id === "app.session.delete")).toBe(false);
+		expect(actions.some(action => action.id === "app.commandPalette.open")).toBe(false);
+	});
+
+	it("restores the draft and pending images after executing a slash command", () => {
+		const { ctx, editor } = createContext();
+		const showCommandPalette = vi.fn();
+		ctx.showCommandPalette = showCommandPalette;
+		const attachment = { type: "image", data: "attachment" } as InteractiveModeContext["pendingImages"][number];
+		ctx.pendingImages = [attachment];
+		editor.setText("existing draft");
+		const input = editor as unknown as {
+			handleInput: ReturnType<typeof vi.fn>;
+		};
+		input.handleInput = vi.fn();
+		const controller = new InputController(ctx);
+		controller.createAutocompleteProvider([{ name: "help" }] as SlashCommand[], "");
+
+		controller.openCommandPalette();
+
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => void;
+		executeSlashCommand("help");
+
+		expect(input.handleInput).toHaveBeenCalledWith("\n");
+		expect(editor.getText()).toBe("existing draft");
+		expect(ctx.pendingImages).toEqual([attachment]);
 	});
 });

--- a/packages/coding-agent/test/modes/components/command-palette.test.ts
+++ b/packages/coding-agent/test/modes/components/command-palette.test.ts
@@ -1,0 +1,76 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import {
+	CommandPaletteComponent,
+	type CommandPaletteEntry,
+} from "@gajae-code/coding-agent/modes/components/command-palette";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+
+const entries: CommandPaletteEntry[] = [
+	{
+		id: "action:app.session.new",
+		label: "Start a new session",
+		description: "app.session.new",
+		keybinding: "Ctrl+N",
+	},
+	{
+		id: "command:help",
+		label: "/help",
+		description: "Show command help",
+	},
+	{
+		id: "command:skill:review",
+		label: "/skill:review",
+		description: "Review the current change",
+		searchText: "review skill",
+	},
+];
+
+beforeAll(async () => {
+	await initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+describe("CommandPaletteComponent", () => {
+	it("fuzzy filters merged action, slash command, and skill entries and renders bindings", () => {
+		const component = new CommandPaletteComponent(
+			entries,
+			() => {},
+			() => {},
+		);
+
+		expect(component.render(80).join("\n")).toContain("Ctrl+N");
+		component.handleInput("r");
+		component.handleInput("v");
+
+		const rendered = component.render(80).join("\n");
+		expect(rendered).toContain("/skill:review");
+		expect(rendered).not.toContain("Start a new session");
+	});
+
+	it("executes the selected entry on Enter", () => {
+		const selected: string[] = [];
+		const component = new CommandPaletteComponent(
+			entries,
+			entry => selected.push(entry.id),
+			() => {},
+		);
+
+		component.handleInput("\n");
+
+		expect(selected).toEqual(["action:app.session.new"]);
+	});
+
+	it("closes on Escape", () => {
+		let cancelled = false;
+		const component = new CommandPaletteComponent(
+			entries,
+			() => {},
+			() => {
+				cancelled = true;
+			},
+		);
+
+		component.handleInput("\x1b");
+
+		expect(cancelled).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/selector-controller-command-palette.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-command-palette.test.ts
@@ -30,4 +30,36 @@ describe("SelectorController command palette", () => {
 		expect(showError).toHaveBeenCalledWith("palette command failed");
 		expect(unhandled).not.toHaveBeenCalled();
 	});
+	it("surfaces rejected action handlers", async () => {
+		const component = { clear: vi.fn(), addChild: vi.fn() };
+		const showError = vi.fn();
+		const ctx = {
+			editorContainer: component,
+			editor: {},
+			restoreComposer: vi.fn(),
+			keybindings: { getKeys: () => [] },
+			ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+			showError,
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+
+		controller.showCommandPalette(
+			[],
+			[
+				{
+					id: "app.editor.external",
+					label: "External editor",
+					handler: async () => {
+						throw new Error("external editor failed");
+					},
+				},
+			],
+			async () => {},
+		);
+		const palette = component.addChild.mock.calls[0]?.[0] as CommandPaletteComponent;
+		palette.handleInput("\r");
+		await Bun.sleep(0);
+
+		expect(showError).toHaveBeenCalledWith("external editor failed");
+	});
 });

--- a/packages/coding-agent/test/modes/controllers/selector-controller-command-palette.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-command-palette.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { CommandPaletteComponent } from "@gajae-code/coding-agent/modes/components/command-palette";
+import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import type { SlashCommand } from "@gajae-code/tui";
+
+describe("SelectorController command palette", () => {
+	it("surfaces rejected handlers without an unhandled rejection", async () => {
+		const component = { clear: vi.fn(), addChild: vi.fn() };
+		const showError = vi.fn();
+		const ctx = {
+			editorContainer: component,
+			editor: {},
+			restoreComposer: vi.fn(),
+			keybindings: { getKeys: () => [] },
+			ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+			showError,
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+		const unhandled = vi.fn();
+		process.once("unhandledRejection", unhandled);
+
+		controller.showCommandPalette([{ name: "broken", description: "Rejects" }] as SlashCommand[], [], async () => {
+			throw new Error("palette command failed");
+		});
+		const palette = component.addChild.mock.calls[0]?.[0] as CommandPaletteComponent;
+		palette.handleInput("\r");
+		await Bun.sleep(0);
+
+		expect(showError).toHaveBeenCalledWith("palette command failed");
+		expect(unhandled).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
Resubmission of #2434, and a deliberate de-scope. Head `da0e9c01`, rebased onto current dev `e0b4b0ee`.

Six review rounds (#2326 → #2414 → #2419 → #2434) established that every snapshot/successor/stash ownership model for "restore the draft around a palette-dispatched slash command" leaks somewhere: delayed cleanup vs user edits, transformed submissions, session replacement, non-keyboard mutations, non-durable history writes. The root cause was the product contract itself — destructively auto-executing a slash command over a live draft. This head removes the destructive path instead of adding a transaction layer.

## Contract
- Palette always opens; it never mutates the composer.
- **Action entries** execute via direct handlers (accepted in earlier rounds): same closures as the keybindings, registry-only listing, self-reentry excluded, promise-returning wrappers with the selector rejection sink.
- **Slash entries with a non-empty draft (text or pending images): selection is refused** with a deterministic status — the composer stays byte-identical. Nothing to restore because nothing is destroyed.
- **Slash entries from an empty composer** dispatch through the awaitable `submitText` path with the single-flight latch (second selection while pending is refused).
- All ownership machinery from prior rounds is deleted: no stash, no generation counter, no programmatic-setText guard, no CustomEditor seams — grep-level zero references.

## Blocker mapping (from the #2434 review)
1. Durable stash write before destructive clear → moot: no destructive clear exists.
2. Latch/transaction over direct actions → moot for composer ownership (actions never touch the composer); rejection ownership retained and tested.
3. Keyboard-only generation inference → deleted entirely; no inference remains.
4. Adversarial cases (failed history writes, external-editor edits, session replacement, attachments) → the vulnerable machinery no longer exists; refusal tests lock the non-mutation contract, including image-only drafts.

## Testing
- Behavior matrix covered: text-draft refusal, image-only-draft refusal, empty-composer dispatch, mid-flight second-selection refusal, action-with-draft executes without composer mutation, rejected async action surfaces via the sink, and a delayed command finishing after the user typed a new draft leaves that draft intact.
- input-controller-escape + selector-controller-command-palette + command-palette + input-controller-keybindings — 86 pass; `bun --cwd=packages/coding-agent run check` — pass.