### PR TITLE
fix(coding-agent): prevent stale goal reminder suppression

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.
+- Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).
 
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1418,6 +1418,7 @@ export class AgentSession {
 	// Todo completion reminder state
 	#todoReminderCount = 0;
 	#lastGoalReminderAssistantTimestamp: number | undefined = undefined;
+	#suppressNextGoalReminderAfterAbortGoalId: string | undefined = undefined;
 	#todoPhases: TodoPhase[] = [];
 	#toolChoiceQueue = new ToolChoiceQueue();
 
@@ -1975,9 +1976,7 @@ export class AgentSession {
 		this.#syncTodoPhasesFromBranch();
 		this.#goalRuntime = new GoalRuntime({
 			getState: () => this.#goalModeState,
-			setState: state => {
-				this.#goalModeState = state;
-			},
+			setState: state => this.#applyGoalModeState(state),
 			getCurrentUsage: () => {
 				const usage = this.getSessionStats().tokens;
 				return {
@@ -5878,8 +5877,20 @@ export class AgentSession {
 		return this.#goalModeState;
 	}
 
-	setGoalModeState(state: GoalModeState | undefined): void {
+	#applyGoalModeState(state: GoalModeState | undefined): void {
+		if (
+			!state?.enabled ||
+			state.goal.status !== "active" ||
+			(this.#suppressNextGoalReminderAfterAbortGoalId !== undefined &&
+				this.#suppressNextGoalReminderAfterAbortGoalId !== state.goal.id)
+		) {
+			this.#suppressNextGoalReminderAfterAbortGoalId = undefined;
+		}
 		this.#goalModeState = state;
+	}
+
+	setGoalModeState(state: GoalModeState | undefined): void {
+		this.#applyGoalModeState(state);
 	}
 
 	getWorkflowGateEmitter(): WorkflowGateEmitter | undefined {
@@ -7573,6 +7584,11 @@ export class AgentSession {
 		 *  hand-off rather than a failure. */
 		silent?: boolean;
 	}): Promise<void> {
+		const abortGoalState = this.getGoalModeState();
+		this.#suppressNextGoalReminderAfterAbortGoalId =
+			abortGoalState?.enabled === true && abortGoalState.goal.status === "active"
+				? abortGoalState.goal.id
+				: undefined;
 		this.#abortActiveMidRunBarriers();
 		if (options?.silent) {
 			this.#silentAbortPending = true;
@@ -9828,6 +9844,7 @@ export class AgentSession {
 		const state = this.getGoalModeState();
 		if (!state?.enabled || state.goal.status !== "active") {
 			this.#lastGoalReminderAssistantTimestamp = undefined;
+			this.#suppressNextGoalReminderAfterAbortGoalId = undefined;
 			return false;
 		}
 		if (this.#lastGoalReminderAssistantTimestamp === assistantMessage.timestamp) {
@@ -9845,6 +9862,11 @@ export class AgentSession {
 			continuationPrompt,
 			"</system-reminder>",
 		].join("\n");
+		if (this.#suppressNextGoalReminderAfterAbortGoalId !== undefined) {
+			const suppressReminder = this.#suppressNextGoalReminderAfterAbortGoalId === state.goal.id;
+			this.#suppressNextGoalReminderAfterAbortGoalId = undefined;
+			if (suppressReminder) return false;
+		}
 
 		logger.debug("Goal completion: sending active-goal reminder", { goalId: state.goal.id });
 		this.agent.appendMessage({

--- a/packages/coding-agent/test/agent-session-goal-reminder.test.ts
+++ b/packages/coding-agent/test/agent-session-goal-reminder.test.ts
@@ -54,13 +54,13 @@ describe("AgentSession active goal reminders", () => {
 		tempDir.removeSync();
 	});
 
-	function setActiveGoal(): void {
+	function setActiveGoal(id = "goal-1", objective = "Ship the idle reminder fix"): void {
 		session.setGoalModeState({
 			enabled: true,
 			mode: "active",
 			goal: {
-				id: "goal-1",
-				objective: "Ship the idle reminder fix",
+				id,
+				objective,
 				status: "active",
 				tokensUsed: 0,
 				timeUsedSeconds: 0,
@@ -145,6 +145,87 @@ describe("AgentSession active goal reminders", () => {
 		const reminder = session.agent.state.messages.find(message => message.role === "developer");
 		expect(JSON.stringify(reminder?.content)).toContain("Ship the idle reminder fix");
 		expect(JSON.stringify(reminder?.content)).toContain('goal({op:\\"complete\\"})');
+	});
+
+	it("does not let an abort without an active goal suppress a later goal reminder", async () => {
+		await session.abort();
+		setActiveGoal();
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		await emitAssistantStop(125);
+
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(developerReminderCount()).toBe(1);
+	});
+
+	it("suppresses only the first reminder after aborting an active goal", async () => {
+		setActiveGoal();
+		await session.abort();
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		await emitAssistantStop(125);
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(developerReminderCount()).toBe(0);
+
+		await emitAssistantStop(126);
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(developerReminderCount()).toBe(1);
+	});
+
+	it("clears active-goal abort suppression after an inactive reminder evaluation", async () => {
+		setActiveGoal();
+		await session.abort();
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		session.setGoalModeState(undefined);
+		await emitAssistantStop(125);
+		setActiveGoal();
+		await emitAssistantStop(126);
+
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(developerReminderCount()).toBe(1);
+	});
+
+	it("lets a later inactive abort clear suppression from an earlier active-goal abort", async () => {
+		setActiveGoal();
+		await session.abort();
+		session.setGoalModeState(undefined);
+		await session.abort();
+		setActiveGoal();
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		await emitAssistantStop(125);
+
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(developerReminderCount()).toBe(1);
+	});
+
+	it("does not transfer abort suppression to a replacement goal", async () => {
+		setActiveGoal("goal-1", "First goal");
+		await session.abort();
+		setActiveGoal("goal-2", "Replacement goal");
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		await emitAssistantStop(125);
+
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(developerReminderCount()).toBe(1);
+		expect(JSON.stringify(session.agent.state.messages.find(message => message.role === "developer"))).toContain(
+			"Replacement goal",
+		);
+	});
+
+	it("clears abort suppression when the aborted goal is paused and re-enabled", async () => {
+		setActiveGoal();
+		await session.abort();
+		await session.goalRuntime.pauseGoal();
+		await session.goalRuntime.resumeGoal();
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		await emitAssistantStop(125);
+
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(developerReminderCount()).toBe(1);
 	});
 
 	it("continues after a successful yield when an active goal remains uncleared", async () => {


### PR DESCRIPTION
## Summary
- snapshot enabled active-goal state when `AgentSession.abort()` begins
- arm one-shot goal-reminder suppression only for aborts that actually interrupt an active goal
- clear stale suppression on inactive reminder evaluation and later inactive aborts
- add deterministic regression coverage for inactive aborts, active one-shot behavior, clear/re-enable, and repeated abort ordering

## Verification
- `bun test packages/coding-agent/test/agent-session-goal-reminder.test.ts` (12 pass)
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- AI slop cleanup: PASS, no blocking findings
- hostile package QA: PASS
- architecture/product/code review: CLEAR / CLEAR / CLEAR, APPROVE

Fixes #2436