### PR TITLE
feat(tui): pin explicit fold choices against automatic expansion stamping (minimal)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Added the versioned, readonly managed session-directory SDK: `SESSION_DIRECTORY_API_VERSION`, `resolveManagedSessionScope`, and `listManagedSessionCandidates` are exported from `@gajae-code/coding-agent/sdk`. The package boundary continues to reject private `session/internal/*` imports. Managed writes use v2 workspace scopes with validated opt-in legacy copy-retain migration (#2177).
 
 ### Changed
+- Explicit fold choices from the user shortcut or extension `setToolsExpanded` now pin a block for its component lifetime, so automatic stamping no longer overwrites them; sessions that never toggle are unchanged.
 
 - Renamed the notifications SDK to the Gajae-Code SDK: `docs/notifications-sdk.md` is now `docs/sdk.md`, `src/notifications/` is now `src/sdk/bus/`, and `src/sdk.ts` is now the `src/sdk/` module directory. Old deep-import specifiers no longer resolve.
 - Moved SDK discovery from `.gjc/state/notifications/` to `.gjc/state/sdk/`. Restart sessions and daemons together when upgrading; the runtime does not dual-scan the old and new directories.

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -271,7 +271,11 @@ export interface ExtensionUIContext {
 	/** Get current tool output expansion state. */
 	getToolsExpanded(): boolean;
 
-	/** Set tool output expansion state. */
+	/**
+	 * Set tool output expansion state. This is an explicit fold choice, pinning
+	 * existing tool and read components for their renderer instance lifetime,
+	 * the same as the user shortcut.
+	 */
 	setToolsExpanded(expanded: boolean): void;
 }
 

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -80,6 +80,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	#entries = new Map<string, ReadEntry>();
 	#text: Text;
 	#expanded = false;
+	#manuallyExpanded: boolean | undefined;
 	#showContentPreview: boolean;
 
 	constructor(options: ReadToolGroupOptions = {}) {
@@ -137,7 +138,19 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		this.#updateDisplay();
 	}
 
+	/** Applies automatic expansion unless this renderer instance has an explicit fold choice. */
 	setExpanded(expanded: boolean): void {
+		if (this.#manuallyExpanded !== undefined) return;
+		this.#expanded = expanded;
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Applies and pins an explicit fold choice for this renderer instance only.
+	 * Transcript rebuilds recreate components from global state and drop this pin.
+	 */
+	setManuallyExpanded(expanded: boolean): void {
+		this.#manuallyExpanded = expanded;
 		this.#expanded = expanded;
 		this.#updateDisplay();
 	}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -159,6 +159,11 @@ export interface ToolExecutionHandle {
 	): void;
 	setArgsComplete(toolCallId?: string): void;
 	setExpanded(expanded: boolean): void;
+	/**
+	 * Applies an explicit fold choice for this renderer instance. The pin lasts
+	 * only for this instance; transcript rebuilds recreate it from global state.
+	 */
+	setManuallyExpanded(expanded: boolean): void;
 }
 
 /**
@@ -174,6 +179,7 @@ export class ToolExecutionComponent extends Container {
 	#toolLabel: string;
 	#args: any;
 	#expanded = false;
+	#manuallyExpanded: boolean | undefined;
 	#showImages: boolean;
 	#editFuzzyThreshold: number | undefined;
 	#editAllowFuzzy: boolean | undefined;
@@ -450,7 +456,19 @@ export class ToolExecutionComponent extends Container {
 		super.dispose();
 	}
 
+	/** Applies automatic expansion unless this renderer instance has an explicit fold choice. */
 	setExpanded(expanded: boolean): void {
+		if (this.#manuallyExpanded !== undefined) return;
+		this.#expanded = expanded;
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Applies and pins an explicit fold choice for this renderer instance only.
+	 * Transcript rebuilds recreate components from global state and drop this pin.
+	 */
+	setManuallyExpanded(expanded: boolean): void {
+		this.#manuallyExpanded = expanded;
 		this.#expanded = expanded;
 		this.#updateDisplay();
 	}

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -26,6 +26,7 @@ import { type QueuedMessageMoveDirection, QueuedMessageSelectorComponent } from 
 
 interface Expandable {
 	setExpanded(expanded: boolean): void;
+	setManuallyExpanded?(expanded: boolean): void;
 }
 
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
@@ -1507,7 +1508,11 @@ export class InputController {
 		this.ctx.toolOutputExpanded = expanded;
 		for (const child of this.ctx.chatContainer.children) {
 			if (isExpandable(child)) {
-				child.setExpanded(expanded);
+				if (child.setManuallyExpanded) {
+					child.setManuallyExpanded(expanded);
+				} else {
+					child.setExpanded(expanded);
+				}
 			}
 		}
 		this.ctx.ui.requestRender();

--- a/packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts
@@ -66,6 +66,24 @@ describe("ToolExecutionComponent spacing", () => {
 		expect(trailing + leading).toBe(1);
 	});
 });
+it("preserves manual expansion through automatic updates and drops it on remount", () => {
+	const component = new ToolExecutionComponent("custom", { path: "/tmp/example.ts" }, {}, undefined, uiStub);
+	component.setManuallyExpanded(true);
+	component.setExpanded(false);
+
+	expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("Args");
+
+	const remounted = new ToolExecutionComponent("custom", { path: "/tmp/example.ts" }, {}, undefined, uiStub);
+	remounted.setExpanded(false);
+	expect(Bun.stripANSI(remounted.render(80).join("\n"))).not.toContain("Args");
+});
+
+it("lets untouched components follow automatic expansion", () => {
+	const component = new ToolExecutionComponent("custom", { path: "/tmp/example.ts" }, {}, undefined, uiStub);
+	component.setExpanded(true);
+
+	expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("Args");
+});
 
 it("replaces generic SIXEL output while the IRC sidebar is visible and restores passthrough when hidden", () => {
 	terminal.imageProtocol = ImageProtocol.Sixel;

--- a/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
@@ -148,4 +148,16 @@ describe("ExtensionUiController transcript rebuild policy", () => {
 
 		expect(fixture.rebuildChatFromMessages).toHaveBeenCalledWith("reconcile-same-transcript");
 	});
+	it("routes extension fold choices through the interactive context", async () => {
+		const fixture = createFixture();
+		await fixture.controller.initHooksAndCustomTools();
+
+		const setToolUIContext = fixture.ctx.setToolUIContext as Mock<
+			(context: ExtensionUIContext, interactive: boolean) => void
+		>;
+		const uiContext = setToolUIContext.mock.calls[0]?.[0] as ExtensionUIContext;
+		uiContext.setToolsExpanded(true);
+
+		expect(fixture.ctx.setToolsExpanded).toHaveBeenCalledWith(true);
+	});
 });

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { getDefault } from "../src/config/settings-schema";
 import { ReadToolGroupComponent, readArgsTargetInternalUrl } from "../src/modes/components/read-tool-group";
+import { InputController } from "../src/modes/controllers/input-controller";
 import * as themeModule from "../src/modes/theme/theme";
+import type { InteractiveModeContext } from "../src/modes/types";
 
 describe("ReadToolGroupComponent", () => {
 	beforeAll(async () => {
@@ -92,6 +94,51 @@ describe("ReadToolGroupComponent", () => {
 		const matches = rendered.match(/Read \/tmp\/example\.ts:L10-L20/g) ?? [];
 
 		expect(matches).toHaveLength(1);
+	});
+	it("preserves manual fold choices through automatic and entry updates", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/one.ts" }, "read-1");
+		component.updateResult({ content: [{ type: "text", text: "one\ntwo\nthree\nfour\nfive" }] }, false, "read-1");
+		component.setManuallyExpanded(true);
+		component.setExpanded(false);
+		component.updateArgs({ path: "/tmp/two.ts" }, "read-2");
+		component.updateResult(
+			{ content: [{ type: "text", text: "warning" }], details: { suffixResolution: { from: "a", to: "b" } } },
+			false,
+			"read-2",
+		);
+		component.updateArgs({ path: "/tmp/three.ts" }, "read-3");
+		component.updateResult({ content: [{ type: "text", text: "error" }], isError: true }, false, "read-3");
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("four");
+
+		component.setManuallyExpanded(false);
+		component.setExpanded(true);
+		expect(Bun.stripANSI(component.render(120).join("\n"))).not.toContain("four");
+	});
+
+	it("lets unpinned read groups follow automatic expansion", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/example.ts" }, "read-1");
+		component.updateResult({ content: [{ type: "text", text: "one\ntwo\nthree\nfour" }] }, false, "read-1");
+		component.setExpanded(true);
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("four");
+	});
+	it("accepts a controller override as a fresh explicit pin", () => {
+		const manuallyExpandable = { setExpanded: vi.fn(), setManuallyExpanded: vi.fn() };
+		const automaticallyExpandable = { setExpanded: vi.fn() };
+		const ctx = {
+			toolOutputExpanded: false,
+			chatContainer: { children: [manuallyExpandable, automaticallyExpandable] },
+			ui: { requestRender: vi.fn() },
+		} as unknown as InteractiveModeContext;
+
+		new InputController(ctx).setToolsExpanded(true);
+
+		expect(manuallyExpandable.setManuallyExpanded).toHaveBeenCalledWith(true);
+		expect(manuallyExpandable.setExpanded).not.toHaveBeenCalled();
+		expect(automaticallyExpandable.setExpanded).toHaveBeenCalledWith(true);
 	});
 });
 


### PR DESCRIPTION
## Summary
A deliberate split of the fold-pin feature out of the blocked hint-contract work. Head `808dbb0d`, single commit on current dev `22bd4321`. **8 files, +120/−2; zero hint surfaces touched** (no `expandHint` token appears anywhere in the diff — render-utils, code-cell, runtime-mcp, and all renderer hint text are byte-identical to dev).

This reimplements exactly the content the #2329 second review marked resolved:
- **Explicit fold pins**: `ToolExecutionComponent` and `ReadToolGroupComponent` gain `setManuallyExpanded`; automatic `setExpanded` becomes a no-op on a pinned block. Docstrings scope the pin to the live renderer instance — remount re-stamps from global state (deliberate, tested boundary).
- **Global toggle = explicit choice**: `InputController.setToolsExpanded` routes pin-capable components through the manual API, re-stamping and re-pinning.
- **Extension semantics documented**: `ExtensionUIContext.setToolsExpanded` docstring states it applies an explicit pinning fold choice, with a delegation test.
- Coverage: tool-pin persistence through automatic re-stamps, untouched components keep automatic behavior, controller override re-stamps pins, read-group pin invariants across entry/result updates, and remount reset.

## Relation to the hint-contract work
The expansion-hint capability overhaul (#2404 → #2445) is deliberately NOT included: its required-vs-optional contract across this package's fully exported surfaces needs an owner-level API boundary decision, now tracked in #2448 with the full design record and a revivable branch. This PR neither improves nor regresses the pre-existing hint behavior.

## Testing
- read-tool-group + tool-execution-spacing + extension-ui-transcript-policy — 31 pass.
- `bun --cwd=packages/coding-agent run check` (biome, SDK canonicalization, tsc) — pass.