### PR TITLE
fix(agent): preserve managed assistant message shells

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -287,7 +287,7 @@ export function agentLoop(
 			messages: [...context.messages, ...prompts],
 		};
 		const transaction = config.fallbackManaged
-			? new ManagedAttemptTransaction(stream, config.onAssistantMessageEvent)
+			? new ManagedAttemptTransaction(stream, config.onAssistantMessageEvent, config.model)
 			: undefined;
 		const attemptStream = transaction ?? stream;
 		if (!config.fallbackManaged || emitManagedAgentStart) stream.push({ type: "agent_start" });
@@ -336,7 +336,7 @@ export function agentLoopContinue(
 		const newMessages: AgentMessage[] = [];
 		const currentContext: AgentContext = { ...context };
 		const transaction = config.fallbackManaged
-			? new ManagedAttemptTransaction(stream, config.onAssistantMessageEvent)
+			? new ManagedAttemptTransaction(stream, config.onAssistantMessageEvent, config.model)
 			: undefined;
 		const attemptStream = transaction ?? stream;
 		if (!config.fallbackManaged || emitManagedAgentStart) stream.push({ type: "agent_start" });
@@ -516,6 +516,167 @@ function managedAttemptSnapshot<T>(value: T): T {
 }
 
 /**
+ * Recover the required assistant-message shell when a managed snapshot degrades
+ * at its root (notably for Proxy-wrapped provider messages). Only known fields
+ * are read, and executable content is retained only when it has its complete
+ * discriminant shape.
+ */
+function managedAssistantShell(value: unknown, model: AgentLoopConfig["model"]): AssistantMessage {
+	const detailed = managedAttemptSnapshotDetailed(value);
+	const source = isManagedPlainRecord(detailed.snapshot) ? detailed.snapshot : value;
+	if (managedProperty(source, "role") !== "assistant") throw new ManagedAttemptSnapshotError();
+	const rawContent = managedAttemptSnapshot(managedProperty(source, "content"));
+	if (!Array.isArray(rawContent)) throw new ManagedAttemptSnapshotError();
+	const content = rawContent.flatMap(block => {
+		const normalized = managedAssistantContent(block);
+		return normalized ? [normalized] : [];
+	});
+	const usage = managedAssistantUsage(managedAttemptSnapshot(managedProperty(source, "usage")));
+	const api = managedProperty(source, "api");
+	const provider = managedProperty(source, "provider");
+	const messageModel = managedProperty(source, "model");
+	const stopReasonValue = managedProperty(source, "stopReason");
+	const stopReason =
+		stopReasonValue === "stop" ||
+		stopReasonValue === "length" ||
+		stopReasonValue === "toolUse" ||
+		stopReasonValue === "error" ||
+		stopReasonValue === "aborted"
+			? stopReasonValue
+			: "stop";
+	const timestamp = managedProperty(source, "timestamp");
+	const transportFailure = managedTransportFailure(value);
+	const errorMessage = managedProperty(source, "errorMessage");
+	const errorStatus = managedProperty(source, "errorStatus");
+	const safeMetadata: Record<string, unknown> = isManagedPlainRecord(detailed.snapshot)
+		? { ...detailed.snapshot }
+		: {};
+	delete safeMetadata.errorMessage;
+	delete safeMetadata.errorStatus;
+	delete safeMetadata.transportFailure;
+	return {
+		...safeMetadata,
+		role: "assistant",
+		content,
+		api: typeof api === "string" ? (api as AssistantMessage["api"]) : model.api,
+		provider: typeof provider === "string" ? (provider as AssistantMessage["provider"]) : model.provider,
+		model: typeof messageModel === "string" ? messageModel : model.id,
+		usage,
+		stopReason,
+		timestamp: typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : Date.now(),
+		...(transportFailure ? { transportFailure } : {}),
+		...(typeof errorMessage === "string" ? { errorMessage } : {}),
+		...(typeof errorStatus === "number" && Number.isFinite(errorStatus) ? { errorStatus } : {}),
+	};
+}
+
+function managedAssistantContent(value: unknown): AssistantMessage["content"][number] | undefined {
+	if (!isManagedPlainRecord(value)) return undefined;
+	const type = managedProperty(value, "type");
+	if (type === "text") {
+		const text = managedProperty(value, "text");
+		return typeof text === "string" ? { type, text } : undefined;
+	}
+	if (type === "thinking") {
+		const thinking = managedProperty(value, "thinking");
+		return typeof thinking === "string" ? { type, thinking } : undefined;
+	}
+	if (type === "redactedThinking") {
+		const data = managedProperty(value, "data");
+		return typeof data === "string" ? { type, data } : undefined;
+	}
+	if (type !== "toolCall") return undefined;
+	const id = managedProperty(value, "id");
+	const name = managedProperty(value, "name");
+	const argumentsValue = managedProperty(value, "arguments");
+	if (typeof id !== "string" || typeof name !== "string" || !isManagedPlainRecord(argumentsValue)) return undefined;
+	const thoughtSignature = managedProperty(value, "thoughtSignature");
+	const intent = managedProperty(value, "intent");
+	const customWireName = managedProperty(value, "customWireName");
+	const incompleteArguments = managedProperty(value, "incompleteArguments");
+	return {
+		type,
+		id,
+		name,
+		arguments: argumentsValue,
+		...(typeof thoughtSignature === "string" ? { thoughtSignature } : {}),
+		...(typeof intent === "string" ? { intent } : {}),
+		...(typeof customWireName === "string" ? { customWireName } : {}),
+		...(typeof incompleteArguments === "boolean" ? { incompleteArguments } : {}),
+	};
+}
+
+function managedAssistantUsage(value: unknown): AssistantMessage["usage"] {
+	const number = (key: string): number => {
+		const candidate = managedProperty(value, key);
+		return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : 0;
+	};
+	const costValue = managedProperty(value, "cost");
+	const costNumber = (key: string): number => {
+		const candidate = managedProperty(costValue, key);
+		return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : 0;
+	};
+	return {
+		input: number("input"),
+		output: number("output"),
+		cacheRead: number("cacheRead"),
+		cacheWrite: number("cacheWrite"),
+		totalTokens: number("totalTokens"),
+		cost: {
+			input: costNumber("input"),
+			output: costNumber("output"),
+			cacheRead: costNumber("cacheRead"),
+			cacheWrite: costNumber("cacheWrite"),
+			total: costNumber("total"),
+		},
+	};
+}
+
+function managedAssistantEventSnapshot(event: AssistantMessageEvent, message: AssistantMessage): AssistantMessageEvent {
+	const snapshot = managedAttemptSnapshot(event);
+	if (!isManagedPlainRecord(snapshot)) throw new ManagedAttemptSnapshotError();
+	const type = managedProperty(snapshot, "type");
+	const contentIndex = managedProperty(snapshot, "contentIndex");
+	const indexed = () => {
+		if (!Number.isInteger(contentIndex) || (contentIndex as number) < 0) throw new ManagedAttemptSnapshotError();
+		return contentIndex as number;
+	};
+	if (type === "start") return { type, partial: message };
+	if (type === "text_start" || type === "thinking_start" || type === "toolcall_start")
+		return { type, contentIndex: indexed(), partial: message };
+	if (type === "text_delta" || type === "thinking_delta" || type === "toolcall_delta") {
+		const delta = managedProperty(snapshot, "delta");
+		if (typeof delta !== "string") throw new ManagedAttemptSnapshotError();
+		return { type, contentIndex: indexed(), delta, partial: message };
+	}
+	if (type === "text_end" || type === "thinking_end") {
+		const content = managedProperty(snapshot, "content");
+		if (typeof content !== "string") throw new ManagedAttemptSnapshotError();
+		return { type, contentIndex: indexed(), content, partial: message };
+	}
+	if (type === "toolcall_end") {
+		const toolCall = managedAssistantContent(managedProperty(snapshot, "toolCall"));
+		if (toolCall?.type !== "toolCall") throw new ManagedAttemptSnapshotError();
+		return { type, contentIndex: indexed(), toolCall, partial: message };
+	}
+	if (type === "done") {
+		const reason = managedProperty(snapshot, "reason");
+		if (reason !== "stop" && reason !== "length" && reason !== "toolUse") throw new ManagedAttemptSnapshotError();
+		return { type, reason, message };
+	}
+	if (type === "error") {
+		const reason = managedProperty(snapshot, "reason");
+		if (reason !== "aborted" && reason !== "error") throw new ManagedAttemptSnapshotError();
+		return { type, reason, error: message };
+	}
+	throw new ManagedAttemptSnapshotError();
+}
+
+function isManagedPlainRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value) && !nodeUtilTypes.isProxy(value);
+}
+
+/**
  * Holds managed-attempt assistant output above the public event stream. A
  * cancelled provider attempt is therefore unobservable to sessions and their
  * side-effect consumers. Non-managed streams bypass this object entirely.
@@ -532,7 +693,10 @@ class ManagedAttemptTransaction {
 
 	constructor(
 		private readonly stream: EventStream<AgentEvent, AgentMessage[]>,
-		private readonly onAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void,
+		private readonly onAssistantMessageEvent:
+			| ((message: AssistantMessage, event: AssistantMessageEvent) => void)
+			| undefined,
+		private readonly model: AgentLoopConfig["model"],
 	) {}
 
 	push(event: AgentEvent): void {
@@ -548,10 +712,11 @@ class ManagedAttemptTransaction {
 	}
 
 	stageAssistantMessageEvent(message: AssistantMessage, event: AssistantMessageEvent): void {
+		const partial = managedAssistantShell(message, this.model);
 		this.#batch.push({
 			type: "assistant_event",
-			message: managedAttemptSnapshot(message),
-			event: managedAttemptSnapshot(event),
+			message: partial,
+			event: managedAssistantEventSnapshot(event, partial),
 		});
 	}
 
@@ -601,7 +766,7 @@ class ManagedAttemptTransaction {
 			this.discard();
 			throw new ManagedAttemptBufferOverflowError();
 		}
-		const detailed = managedAttemptSnapshotDetailed(event);
+		const detailed = managedAttemptSnapshotDetailed(this.#repairAssistantEvent(event));
 		let snapshot = detailed.snapshot;
 		if (bytes === undefined || detailed.degraded) {
 			// Account the bytes of what is actually retained: a degraded
@@ -635,6 +800,31 @@ class ManagedAttemptTransaction {
 		this.#stagedEventCount += 1;
 
 		this.#stagedBytes += bytes;
+	}
+
+	#repairAssistantEvent(event: AgentEvent): AgentEvent {
+		if (event.type === "message_start" || event.type === "message_end" || event.type === "turn_end") {
+			return event.message.role === "assistant"
+				? { ...event, message: managedAssistantShell(event.message, this.model) }
+				: event;
+		}
+		if (event.type === "message_update") {
+			const message = managedAssistantShell(event.message, this.model);
+			return {
+				...event,
+				message,
+				assistantMessageEvent: managedAssistantEventSnapshot(event.assistantMessageEvent, message),
+			};
+		}
+		if (event.type === "agent_end") {
+			return {
+				...event,
+				messages: event.messages.map(message =>
+					message.role === "assistant" ? managedAssistantShell(message, this.model) : message,
+				),
+			};
+		}
+		return event;
 	}
 }
 
@@ -1055,7 +1245,7 @@ async function runLoopBody(
 			const transaction =
 				initialTransaction ??
 				(config.fallbackManaged
-					? new ManagedAttemptTransaction(stream, config.onAssistantMessageEvent)
+					? new ManagedAttemptTransaction(stream, config.onAssistantMessageEvent, config.model)
 					: undefined);
 			initialTransaction = undefined;
 			const attemptStream = transaction ?? stream;
@@ -1264,7 +1454,7 @@ async function runLoopBody(
 				return;
 			}
 			if (attemptTransaction) {
-				message = managedAttemptSnapshot(message);
+				message = managedAssistantShell(message, config.model);
 				const index = currentContext.messages.length - 1;
 				if (index >= 0 && currentContext.messages[index]?.role === "assistant") {
 					currentContext.messages[index] = message;
@@ -1557,7 +1747,9 @@ async function streamAssistantResponse(
 
 					switch (event.type) {
 						case "start":
-							partialMessage = event.partial;
+							partialMessage = config.fallbackManaged
+								? managedAssistantShell(event.partial, config.model)
+								: event.partial;
 							context.messages.push(partialMessage);
 							addedPartial = true;
 							stream.push({ type: "message_start", message: { ...partialMessage } });
@@ -1577,15 +1769,16 @@ async function streamAssistantResponse(
 						case "toolcall_delta":
 						case "toolcall_end":
 							if (partialMessage) {
-								partialMessage = event.partial;
+								partialMessage = config.fallbackManaged
+									? managedAssistantShell(event.partial, config.model)
+									: event.partial;
+								const partialEvent = config.fallbackManaged ? { ...event, partial: partialMessage } : event;
 								context.messages[context.messages.length - 1] = partialMessage;
-								config.onAssistantMessageEvent?.(partialMessage, event);
-								if (signal?.aborted) {
-									continue;
-								}
+								config.onAssistantMessageEvent?.(partialMessage, partialEvent);
+								if (signal?.aborted) continue;
 								stream.push({
 									type: "message_update",
-									assistantMessageEvent: event,
+									assistantMessageEvent: partialEvent,
 									message: { ...partialMessage },
 								});
 							}
@@ -1593,7 +1786,9 @@ async function streamAssistantResponse(
 
 						case "done":
 						case "error": {
-							const finalMessage = await response.result();
+							const finalMessage = config.fallbackManaged
+								? managedAssistantShell(await response.result(), config.model)
+								: await response.result();
 							if (addedPartial) {
 								context.messages[context.messages.length - 1] = finalMessage;
 							} else {
@@ -1612,7 +1807,9 @@ async function streamAssistantResponse(
 				detachAbortListener?.();
 			}
 
-			const trailing = await response.result();
+			const trailing = config.fallbackManaged
+				? managedAssistantShell(await response.result(), config.model)
+				: await response.result();
 			await finishChat(trailing);
 			return trailing;
 		});

--- a/packages/agent/test/agent-loop-truncated-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-truncated-toolcall.test.ts
@@ -44,7 +44,7 @@ describe("agentLoop: truncated tool-call guard", () => {
 				{ content: ["recovered"] },
 			],
 		});
-		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter, fallbackManaged: true };
 
 		const toolResults: Array<{ isError?: boolean; text: string }> = [];
 		const stream = agentLoop([createUserMessage("write the file")], context, config, undefined, mock.stream);

--- a/packages/agent/test/managed-attempt-trajectory.test.ts
+++ b/packages/agent/test/managed-attempt-trajectory.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
+import type { AssistantMessage, Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import * as z from "zod/v4";
+import { createUserMessage } from "./helpers";
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(
+		message => message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+	) as Message[];
+}
+
+describe("managed attempt trajectory", () => {
+	it("preserves incomplete tool-call metadata without executing it", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const parameters = z.object({ path: z.string(), content: z.string() });
+		const tool: AgentTool<typeof parameters, Record<string, never>> = {
+			name: "write_file",
+			label: "Write",
+			description: "Write a file",
+			parameters,
+			async execute(_id, args) {
+				executed.push(args as Record<string, unknown>);
+				return { content: [{ type: "text", text: "wrote" }], details: {} };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{
+							type: "toolCall",
+							id: "tc-incomplete",
+							name: "write_file",
+							arguments: { path: "a.ts" },
+							incompleteArguments: true,
+						},
+					],
+					stopReason: "length",
+				},
+				{ content: ["recovered"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter, fallbackManaged: true };
+		const assistantMessages: AssistantMessage[] = [];
+		const toolResults: Array<{ isError?: boolean; text: string }> = [];
+		const stream = agentLoop([createUserMessage("write the file")], context, config, undefined, mock.stream);
+
+		for await (const event of stream) {
+			if (event.type === "message_end" && event.message.role === "assistant") {
+				assistantMessages.push(event.message);
+			}
+			if (event.type === "tool_execution_end") {
+				const first = event.result.content?.[0];
+				toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+			}
+		}
+
+		expect(assistantMessages[0]?.content).toContainEqual({
+			type: "toolCall",
+			id: "tc-incomplete",
+			name: "write_file",
+			arguments: { path: "a.ts" },
+			incompleteArguments: true,
+		});
+		expect(executed).toHaveLength(0);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]).toMatchObject({ isError: true });
+		expect(toolResults[0]?.text).toContain("cut off");
+	});
+});

--- a/packages/agent/test/managed-attempt-transaction.test.ts
+++ b/packages/agent/test/managed-attempt-transaction.test.ts
@@ -3,7 +3,7 @@ import type { ManagedAttemptOutcome } from "@gajae-code/agent-core";
 import { Agent } from "@gajae-code/agent-core";
 import { agentLoopContinue, sanitizedDetachedClone } from "@gajae-code/agent-core/agent-loop";
 import type { AgentContext, AgentEvent, AgentLoopConfig } from "@gajae-code/agent-core/types";
-import type { AssistantMessage, Message } from "@gajae-code/ai";
+import type { AssistantMessage, AssistantMessageEvent, Message } from "@gajae-code/ai";
 
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
@@ -826,6 +826,218 @@ describe("managed attempt transaction", () => {
 		expect(
 			agent.state.messages.filter(message => message.role === "assistant").map(message => message.content),
 		).toHaveLength(2);
+	});
+	it("repairs a root-proxied managed assistant shell across published surfaces", async () => {
+		const mock = createMockModel();
+		let live: AssistantMessage | undefined;
+		const streamFn = () => {
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = assistantMessage(mock.model);
+				message.content.push({ type: "text", text: "accepted" });
+				live = new Proxy(message, {});
+				stream.push({ type: "start", partial: live });
+				stream.push({ type: "text_start", contentIndex: 0, partial: live });
+				stream.push({ type: "done", reason: "stop", message: live });
+			});
+			return stream;
+		};
+		const context: AgentContext = {
+			systemPrompt: ["test"],
+			messages: [{ role: "user", content: "run", timestamp: Date.now() }],
+			tools: [],
+		};
+		const callbacks: AssistantMessageEvent[] = [];
+		const stream = agentLoopContinue(
+			context,
+			{
+				model: mock.model,
+				convertToLlm: messages => messages as Message[],
+				fallbackManaged: true,
+				onAssistantMessageEvent: (_message, event) => callbacks.push(event),
+			},
+			undefined,
+			streamFn,
+		);
+		const events: AgentEvent[] = [];
+		for await (const event of stream) events.push(event);
+		const result = await stream.result();
+		(live!.content[0] as { type: "text"; text: string }).text = "mutated";
+		const messages = [
+			context.messages.at(-1),
+			result[0],
+			...events.flatMap(event => {
+				if (event.type === "message_start" || event.type === "message_end" || event.type === "turn_end")
+					return [event.message];
+				if (event.type === "message_update") return [event.message];
+				if (event.type === "agent_end") return event.messages;
+				return [];
+			}),
+		];
+		for (const message of messages) {
+			expect(message).toMatchObject({ role: "assistant", content: [{ type: "text", text: "accepted" }] });
+			expect(() => structuredClone(message)).not.toThrow();
+		}
+		expect(callbacks).toHaveLength(1);
+		expect(callbacks[0]).toMatchObject({ type: "text_start", contentIndex: 0, partial: { role: "assistant" } });
+	});
+
+	it("fails a collapsed root proxy locally without managed retry authority", async () => {
+		const mock = createMockModel();
+		const collapsed = new Proxy(assistantMessage(mock.model), {
+			get() {
+				throw new Error("collapsed root");
+			},
+		});
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["test"], tools: [], messages: [] },
+			streamFn: () => {
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => stream.push({ type: "start", partial: collapsed }));
+				return stream;
+			},
+		});
+		let outcomes = 0;
+		await agent.prompt("run", {
+			fallbackManaged: true,
+			onManagedAttemptOutcome: () => {
+				outcomes += 1;
+				return { type: "retry", continuation: () => {} };
+			},
+		});
+		expect(outcomes).toBe(0);
+		expect(agent.state.error).toContain("local snapshot");
+		expect(agent.state.messages.filter(message => message.role === "assistant")).toHaveLength(1);
+	});
+	it("normalizes null and incomplete tool-call blocks before managed dispatch", async () => {
+		const mock = createMockModel();
+		const malformed = assistantMessage(mock.model) as unknown as { content: unknown[] };
+		malformed.content = [null, { type: "toolCall", id: "call", name: "danger" }];
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["test"], tools: [], messages: [] },
+			streamFn: () => {
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => stream.push({ type: "done", reason: "stop", message: malformed as AssistantMessage }));
+				return stream;
+			},
+		});
+		await agent.prompt("run", { fallbackManaged: true });
+		const message = agent.state.messages.at(-1) as AssistantMessage;
+		expect(message.content).toEqual([]);
+	});
+
+	it("preserves a complete detached toolcall_end event", async () => {
+		const mock = createMockModel();
+		const toolCall = {
+			type: "toolCall" as const,
+			id: "call",
+			name: "safe",
+			arguments: { value: 1 },
+			thoughtSignature: "signature",
+			intent: "inspect safely",
+			customWireName: "custom_safe",
+			incompleteArguments: true,
+		};
+		const callbacks: AssistantMessageEvent[] = [];
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["test"], tools: [], messages: [] },
+			streamFn: () => {
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const partial = assistantMessage(mock.model);
+					stream.push({ type: "start", partial });
+					stream.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial });
+					stream.push({ type: "done", reason: "stop", message: partial });
+				});
+				return stream;
+			},
+			onAssistantMessageEvent: (_message, event) => callbacks.push(event),
+		});
+		await agent.prompt("run", { fallbackManaged: true });
+		const ended = callbacks.find(event => event.type === "toolcall_end");
+		expect(ended).toMatchObject({ toolCall });
+		expect(ended).not.toBeUndefined();
+		expect(ended?.type === "toolcall_end" ? ended.toolCall : undefined).toMatchObject({
+			thoughtSignature: "signature",
+			intent: "inspect safely",
+			customWireName: "custom_safe",
+			incompleteArguments: true,
+		});
+	});
+
+	it("rejects managed events with hidden required fields as local failures", async () => {
+		const mock = createMockModel();
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["test"], tools: [], messages: [] },
+			streamFn: () => {
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const partial = assistantMessage(mock.model);
+					stream.push({ type: "start", partial });
+					stream.push(
+						new Proxy(
+							{ type: "text_delta", contentIndex: 0, partial },
+							{ get: (target, key) => (key === "delta" ? undefined : Reflect.get(target, key)) },
+						) as AssistantMessageEvent,
+					);
+					stream.push({ type: "done", reason: "stop", message: partial });
+				});
+				return stream;
+			},
+		});
+		await agent.prompt("run", { fallbackManaged: true });
+		expect(agent.state.error).toContain("local snapshot");
+	});
+	it("normalizes invalid stop reasons and rejects invalid event indices", async () => {
+		const mock = createMockModel();
+		const invalidMessage = {
+			...assistantMessage(mock.model),
+			stopReason: "invalid",
+			timestamp: Number.POSITIVE_INFINITY,
+			errorStatus: Number.NaN,
+		} as unknown as AssistantMessage;
+		const accepted = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["test"], tools: [], messages: [] },
+			streamFn: () => {
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => stream.push({ type: "done", reason: "stop", message: invalidMessage }));
+				return stream;
+			},
+		});
+		const published: AssistantMessage[] = [];
+		accepted.subscribe(event => {
+			if ((event.type === "message_end" || event.type === "turn_end") && event.message.role === "assistant")
+				published.push(event.message as AssistantMessage);
+			if (event.type === "agent_end") {
+				published.push(...(event.messages.filter(message => message.role === "assistant") as AssistantMessage[]));
+			}
+		});
+		await accepted.prompt("run", { fallbackManaged: true });
+		const committed = accepted.state.messages.at(-1) as AssistantMessage;
+		expect(committed.stopReason).toBe("stop");
+		expect(Number.isFinite(committed.timestamp)).toBe(true);
+		expect(committed.errorStatus).toBeUndefined();
+		for (const message of published) {
+			expect(["stop", "length", "toolUse", "error", "aborted"]).toContain(message.stopReason);
+			expect(Number.isFinite(message.timestamp)).toBe(true);
+			expect(message.errorStatus).toBeUndefined();
+		}
+
+		const rejected = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["test"], tools: [], messages: [] },
+			streamFn: () => {
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const partial = assistantMessage(mock.model);
+					stream.push({ type: "start", partial });
+					stream.push({ type: "text_delta", contentIndex: -1, delta: "x", partial });
+					stream.push({ type: "done", reason: "stop", message: partial });
+				});
+				return stream;
+			},
+		});
+		await rejected.prompt("run", { fallbackManaged: true });
+		expect(rejected.state.error).toContain("local snapshot");
 	});
 });
 

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -123,12 +123,16 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 
 	push(event: T): void {
 		if (this.done) return;
-
-		if (this.isComplete(event)) {
-			this.done = true;
-			this.resolveFinalResult(this.extractResult(event));
+		try {
+			if (this.isComplete(event)) {
+				const result = this.extractResult(event);
+				this.done = true;
+				this.resolveFinalResult(result);
+			}
+		} catch (error) {
+			this.fail(error);
+			return;
 		}
-
 		this.deliver(event);
 	}
 

--- a/packages/ai/test/event-stream.test.ts
+++ b/packages/ai/test/event-stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { AssistantMessage } from "../src/types";
+import type { AssistantMessage, AssistantMessageEvent } from "../src/types";
 import { AssistantMessageEventStream, EventStream } from "../src/utils/event-stream";
 
 function createPartial(text = ""): AssistantMessage {
@@ -32,6 +32,20 @@ describe("AssistantMessageEventStream", () => {
 		expect(stream.queue).toHaveLength(2);
 		expect(stream.queue[0]).toMatchObject({ type: "text_delta", delta: "a" });
 		expect(stream.queue[1]).toMatchObject({ type: "text_delta", delta: "b" });
+	});
+
+	it("fails consumers and result when a final event proxy throws during discriminant access", async () => {
+		const stream = new AssistantMessageEventStream();
+		const error = new Error("hostile event proxy");
+		const hostile = new Proxy({} as object, {
+			get() {
+				throw error;
+			},
+		}) as AssistantMessageEvent;
+		stream.push(hostile);
+		await expect(stream.result()).rejects.toBe(error);
+		const iterator = stream[Symbol.asyncIterator]();
+		await expect(iterator.next()).rejects.toBe(error);
 	});
 });
 


### PR DESCRIPTION
Fixes #2447

## Summary
- reconstruct valid detached assistant shells for managed snapshots and lifecycle events
- fail hostile unrecoverable roots locally without provider retry authority
- preserve incomplete tool-call metadata while keeping incomplete calls non-executable
- fail EventStream consumers cleanly when final-event inspection throws

## Verification
- `bun test packages/agent/test/managed-attempt-trajectory.test.ts packages/agent/test/agent-loop-truncated-toolcall.test.ts packages/agent/test/managed-attempt-transaction.test.ts packages/ai/test/event-stream.test.ts` (44 pass)
- `bun run check` in `packages/agent`
- `bun run check` in `packages/ai`
- `bun test` in `packages/agent` (534 pass)
- `bun test` in `packages/ai` (1737 pass, 337 environment-gated skips)

Signed-off-by: Yeachan Heo <yeachanheo@gmail.com>