### PR TITLE
fix(tui): preserve palette composer ownership

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).
+- Palette slash submissions no longer clear or rewrite composer text, cursor state, history, or pending images created while an asynchronous input hook is awaiting; canonical keyboard submission cleanup remains unchanged (#2441).
 
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -11,7 +11,11 @@ import { expandEmoticons } from "../../modes/emoji-autocomplete";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
 import { theme } from "../../modes/theme/theme";
 import { scrollTmuxToPreviousUserInput as scrollTmuxPaneToPreviousUserInput } from "../../modes/tmux-scroll";
-import type { InteractiveModeContext } from "../../modes/types";
+import {
+	type ComposerSubmissionOptions,
+	canApplyComposerSubmission,
+	type InteractiveModeContext,
+} from "../../modes/types";
 import type { AgentSessionEvent, QueuedMessageEditEntry } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
@@ -532,10 +536,10 @@ export class InputController {
 	}
 
 	setupEditorSubmitHandler(): void {
-		this.ctx.editor.onSubmit = text => this.submitText(text);
+		this.ctx.editor.onSubmit = text => this.submitText(text, { ownsComposer: true, editor: this.ctx.editor });
 	}
 
-	async submitText(text: string): Promise<void> {
+	async submitText(text: string, composer: ComposerSubmissionOptions): Promise<void> {
 		text = text.trim();
 		if ((!isSettingsInitialized() || settings.get("emojiAutocomplete")) && text) text = expandEmoticons(text);
 
@@ -565,8 +569,10 @@ export class InputController {
 		if (runner?.hasHandlers("input")) {
 			const result = await runner.emitInput(text, inputImages, "interactive");
 			if (result?.handled) {
-				this.ctx.editor.setText("");
-				this.#clearPendingImagesIfOwnedBy(pendingImages);
+				if (this.#canModifyComposer(composer)) {
+					this.ctx.editor.setText("");
+				}
+				this.#clearPendingImagesIfOwnedBy(pendingImages, composer);
 				return;
 			}
 			if (result?.text !== undefined) {
@@ -583,6 +589,7 @@ export class InputController {
 		const slashResult = await executeBuiltinSlashCommand(text, {
 			ctx: this.ctx,
 			handleBackgroundCommand: () => this.handleBackgroundCommand(),
+			composer,
 		});
 		if (slashResult === true) {
 			return;
@@ -597,7 +604,7 @@ export class InputController {
 		// runs after it completes (matches the free-text Enter semantics applied
 		// a few lines below at the streaming branch). Explicit queue shortcuts
 		// route through `handleFollowUp` and dispatch as `followUp`.
-		if (await this.#invokeSkillCommand(text, this.#busyStreamingBehavior())) {
+		if (await this.#invokeSkillCommand(text, this.#busyStreamingBehavior(), composer)) {
 			return;
 		}
 
@@ -608,10 +615,14 @@ export class InputController {
 			if (command) {
 				if (this.ctx.session.isBashRunning) {
 					this.ctx.showWarning("A bash command is already running. Press Esc to cancel it first.");
-					this.ctx.editor.setText(text);
+					if (this.#canModifyComposer(composer)) {
+						this.ctx.editor.setText(text);
+					}
 					return;
 				}
-				this.ctx.editor.addToHistory(text);
+				if (this.#canModifyComposer(composer)) {
+					this.ctx.editor.addToHistory(text);
+				}
 				await this.ctx.handleBashCommand(command, isExcluded);
 				this.ctx.isBashMode = false;
 				this.ctx.isBashNoContext = false;
@@ -627,10 +638,14 @@ export class InputController {
 			if (code) {
 				if (this.ctx.session.isEvalRunning) {
 					this.ctx.showWarning("A Python execution is already running. Press Esc to cancel it first.");
-					this.ctx.editor.setText(text);
+					if (this.#canModifyComposer(composer)) {
+						this.ctx.editor.setText(text);
+					}
 					return;
 				}
-				this.ctx.editor.addToHistory(text);
+				if (this.#canModifyComposer(composer)) {
+					this.ctx.editor.addToHistory(text);
+				}
 				await this.ctx.handlePythonCommand(code, isExcluded);
 				this.ctx.isPythonMode = false;
 				this.ctx.updateEditorBorderColor();
@@ -644,7 +659,7 @@ export class InputController {
 				this.ctx.showStatus("Compaction in progress. Retry after it completes to send images.");
 				return;
 			}
-			this.ctx.queueCompactionMessage(text, "steer");
+			this.ctx.queueCompactionMessage(text, "steer", composer);
 			return;
 		}
 
@@ -653,10 +668,12 @@ export class InputController {
 		// prompt to run after the active turn completes (in submission order).
 		// This handles extension commands (execute immediately), prompt template expansion, and queueing
 		if (this.ctx.session.isStreaming) {
-			this.ctx.editor.addToHistory(text);
-			this.ctx.editor.setText("");
+			if (this.#canModifyComposer(composer)) {
+				this.ctx.editor.addToHistory(text);
+				this.ctx.editor.setText("");
+			}
 			const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
-			this.#clearPendingImagesIfOwnedBy(pendingImages);
+			this.#clearPendingImagesIfOwnedBy(pendingImages, composer);
 			// Record the signature so the queued message's eventual delivery
 			// (a user-role `message_start` event) leaves any draft the user has
 			// typed since queuing intact. Same protection as #783, applied to
@@ -708,14 +725,16 @@ export class InputController {
 		if (this.ctx.onInputCallback) {
 			// Include any pending images from clipboard paste
 			const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
-			this.#clearPendingImagesIfOwnedBy(pendingImages);
+			this.#clearPendingImagesIfOwnedBy(pendingImages, composer);
 
 			// Render user message immediately, then let session events catch up
-			const submission = this.ctx.startPendingSubmission({ text, images });
+			const submission = this.ctx.startPendingSubmission({ text, images }, composer);
 
 			this.ctx.onInputCallback(submission);
 		}
-		this.ctx.editor.addToHistory(text);
+		if (this.#canModifyComposer(composer)) {
+			this.ctx.editor.addToHistory(text);
+		}
 	}
 
 	handleCtrlC(): void {
@@ -961,11 +980,17 @@ export class InputController {
 	 * while the agent is streaming; the idle path of `promptCustomMessage`
 	 * ignores it.
 	 */
-	async #invokeSkillCommand(text: string, streamingBehavior: "steer" | "followUp"): Promise<boolean> {
+	async #invokeSkillCommand(
+		text: string,
+		streamingBehavior: "steer" | "followUp",
+		options?: ComposerSubmissionOptions,
+	): Promise<boolean> {
 		const invocations = parseSkillInvocations(text, this.ctx.skillCommands ?? new Map());
 		if (invocations.length === 0) return false;
-		this.ctx.editor.addToHistory(text);
-		this.ctx.editor.setText("");
+		if (!options || this.#canModifyComposer(options)) {
+			this.ctx.editor.addToHistory(text);
+			this.ctx.editor.setText("");
+		}
 		try {
 			for (let index = 0; index < invocations.length; index += 1) {
 				const invocation = invocations[index];
@@ -1279,8 +1304,15 @@ export class InputController {
 		return images.length > 0 ? images : undefined;
 	}
 
-	#clearPendingImagesIfOwnedBy(pendingImages: InteractiveModeContext["pendingImages"]): void {
-		if (this.ctx.pendingImages === pendingImages) {
+	#canModifyComposer(options: ComposerSubmissionOptions): boolean {
+		return canApplyComposerSubmission(options, this.ctx.editor);
+	}
+
+	#clearPendingImagesIfOwnedBy(
+		pendingImages: InteractiveModeContext["pendingImages"],
+		options: ComposerSubmissionOptions,
+	): void {
+		if (this.#canModifyComposer(options) && this.ctx.pendingImages === pendingImages) {
 			this.ctx.pendingImages = [];
 		}
 	}
@@ -1432,7 +1464,7 @@ export class InputController {
 
 			this.#paletteCommandInFlight = true;
 			try {
-				await this.submitText(`/${name}`);
+				await this.submitText(`/${name}`, { ownsComposer: false, editor: this.ctx.editor });
 			} finally {
 				this.#paletteCommandInFlight = false;
 			}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -134,14 +134,16 @@ import {
 	onThemeChange,
 	theme,
 } from "./theme/theme";
-import type {
-	CompactionQueuedMessage,
-	InteractiveModeContext,
-	IrcArrivalSnapshot,
-	SubmittedUserInput,
-	TodoItem,
-	TodoPhase,
-	TranscriptRebuildPolicy,
+import {
+	type CompactionQueuedMessage,
+	type ComposerSubmissionOptions,
+	canApplyComposerSubmission,
+	type InteractiveModeContext,
+	type IrcArrivalSnapshot,
+	type SubmittedUserInput,
+	type TodoItem,
+	type TodoPhase,
+	type TranscriptRebuildPolicy,
 } from "./types";
 import type { ParsedIrcMessage } from "./utils/irc-message";
 import { addChatChild, prepareTranscriptRebuild, UiHelpers } from "./utils/ui-helpers";
@@ -930,12 +932,15 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	startPendingSubmission(input: {
-		text: string;
-		images?: ImageContent[];
-		customType?: string;
-		display?: boolean;
-	}): SubmittedUserInput {
+	startPendingSubmission(
+		input: {
+			text: string;
+			images?: ImageContent[];
+			customType?: string;
+			display?: boolean;
+		},
+		options?: ComposerSubmissionOptions,
+	): SubmittedUserInput {
 		const submission: SubmittedUserInput = {
 			text: input.text,
 			images: input.images,
@@ -960,7 +965,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.optimisticUserMessageSignature = undefined;
 			this.#pendingSubmissionDispose = undefined;
 		}
-		this.editor.setText("");
+		if (canApplyComposerSubmission(options, this.editor)) {
+			this.editor.setText("");
+		}
 		this.ensureLoadingAnimation();
 		this.ui.requestRender();
 		return submission;
@@ -2545,8 +2552,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#uiHelpers.updatePendingMessagesDisplay();
 	}
 
-	queueCompactionMessage(text: string, mode: "steer" | "followUp"): void {
-		this.#uiHelpers.queueCompactionMessage(text, mode);
+	queueCompactionMessage(text: string, mode: "steer" | "followUp", options?: ComposerSubmissionOptions): void {
+		this.#uiHelpers.queueCompactionMessage(text, mode, options);
 	}
 
 	flushCompactionQueue(options?: { willRetry?: boolean }): Promise<void> {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -52,6 +52,17 @@ export type SubmittedUserInput = {
 	started: boolean;
 };
 
+export type ComposerSubmissionOptions = Readonly<{
+	ownsComposer: boolean;
+	editor: CustomEditor;
+}>;
+
+export function canApplyComposerSubmission(
+	options: ComposerSubmissionOptions | undefined,
+	editor: CustomEditor,
+): boolean {
+	return options === undefined || (options.ownsComposer && editor === options.editor);
+}
 export type TodoStatus = "pending" | "in_progress" | "completed" | "abandoned";
 
 export type TodoItem = {
@@ -175,7 +186,7 @@ export interface InteractiveModeContext {
 	showNewVersionNotification(newVersion: string): void;
 	clearEditor(): void;
 	updatePendingMessagesDisplay(): void;
-	queueCompactionMessage(text: string, mode: "steer" | "followUp"): void;
+	queueCompactionMessage(text: string, mode: "steer" | "followUp", options?: ComposerSubmissionOptions): void;
 	flushCompactionQueue(options?: { willRetry?: boolean }): Promise<void>;
 	flushPendingBashComponents(): void;
 	flushPendingModelSwitch(): Promise<void>;
@@ -197,12 +208,15 @@ export interface InteractiveModeContext {
 	commitPetPreviewMode(mode: PetMode): boolean;
 	/** Re-mount the composer (pet-aware) after an overlay/selector closes. */
 	restoreComposer(): void;
-	startPendingSubmission(input: {
-		text: string;
-		images?: ImageContent[];
-		customType?: string;
-		display?: boolean;
-	}): SubmittedUserInput;
+	startPendingSubmission(
+		input: {
+			text: string;
+			images?: ImageContent[];
+			customType?: string;
+			display?: boolean;
+		},
+		options?: ComposerSubmissionOptions,
+	): SubmittedUserInput;
 	cancelPendingSubmission(): boolean;
 	markPendingSubmissionStarted(input: SubmittedUserInput): boolean;
 	finishPendingSubmission(input: SubmittedUserInput): void;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -20,11 +20,13 @@ import { SkillMessageComponent } from "../../modes/components/skill-message";
 import { ToolExecutionComponent } from "../../modes/components/tool-execution";
 import { UserMessageComponent } from "../../modes/components/user-message";
 import { theme } from "../../modes/theme/theme";
-import type {
-	CompactionQueuedMessage,
-	InteractiveModeContext,
-	IrcArrivalSnapshot,
-	TranscriptRebuildPolicy,
+import {
+	type CompactionQueuedMessage,
+	type ComposerSubmissionOptions,
+	canApplyComposerSubmission,
+	type InteractiveModeContext,
+	type IrcArrivalSnapshot,
+	type TranscriptRebuildPolicy,
 } from "../../modes/types";
 import {
 	type CustomMessage,
@@ -916,14 +918,16 @@ export class UiHelpers {
 		}
 	}
 
-	queueCompactionMessage(text: string, mode: "steer" | "followUp"): void {
+	queueCompactionMessage(text: string, mode: "steer" | "followUp", options?: ComposerSubmissionOptions): void {
 		const entry: CompactionQueuedMessage = { text, mode };
 		if (mode === "followUp") {
 			entry.followUpQueuePolicy = "sequential";
 		}
 		this.ctx.compactionQueuedMessages.push(entry);
-		this.ctx.editor.addToHistory(text);
-		this.ctx.editor.setText("");
+		if (canApplyComposerSubmission(options, this.ctx.editor)) {
+			this.ctx.editor.addToHistory(text);
+			this.ctx.editor.setText("");
+		}
 		this.ctx.updatePendingMessagesDisplay();
 		this.ctx.showStatus("Queued message for after compaction");
 	}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -23,7 +23,11 @@ import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../
 import { resolveMemoryBackend } from "../memory-backend";
 import { DynamicBorder } from "../modes/components/dynamic-border";
 import { theme } from "../modes/theme/theme";
-import type { InteractiveModeContext } from "../modes/types";
+import {
+	type ComposerSubmissionOptions,
+	canApplyComposerSubmission,
+	type InteractiveModeContext,
+} from "../modes/types";
 import {
 	buildNotificationStatusReport,
 	checkNotificationHealth,
@@ -62,7 +66,13 @@ import type {
 export type { BuiltinSlashCommand, SubcommandDef } from "./types";
 
 /** TUI-specific runtime accepted by `executeBuiltinSlashCommand`. */
-export type BuiltinSlashCommandRuntime = TuiSlashCommandRuntime;
+export type BuiltinSlashCommandRuntime = TuiSlashCommandRuntime & {
+	composer?: ComposerSubmissionOptions;
+};
+
+function canClearComposer(runtime: BuiltinSlashCommandRuntime): boolean {
+	return canApplyComposerSubmission(runtime.composer, runtime.ctx.editor);
+}
 
 const PET_COMMAND_OPTIONS: ReadonlyArray<{ name: string; mode: PetMode; description: string }> = [
 	{ name: "off", mode: "off", description: "Hide the pet" },
@@ -1688,7 +1698,9 @@ export async function executeBuiltinSlashCommand(
 		const diagnostic = formatUnknownBuiltinSlashCommandDiagnostic(parsed.name);
 		if (!diagnostic) return false;
 		runtime.ctx.showError(diagnostic);
-		runtime.ctx.editor.setText("");
+		if (canClearComposer(runtime)) {
+			runtime.ctx.editor.setText("");
+		}
 		return true;
 	}
 	if (parsed.args.length > 0 && !command.allowArgs) {
@@ -1703,7 +1715,9 @@ export async function executeBuiltinSlashCommand(
 		const ctx = runtime.ctx;
 		const adapted = toSlashCommandRuntime(runtime);
 		const result = await command.handle(parsed, adapted);
-		ctx.editor.setText("");
+		if (canClearComposer(runtime)) {
+			ctx.editor.setText("");
+		}
 		if (result && typeof result === "object" && "prompt" in result) return result.prompt;
 		return true;
 	}

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -2,7 +2,11 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:te
 import { AsyncJobManager } from "@gajae-code/coding-agent/async";
 import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
 import { InputController } from "@gajae-code/coding-agent/modes/controllers/input-controller";
-import type { InteractiveModeContext, SubmittedUserInput } from "@gajae-code/coding-agent/modes/types";
+import type {
+	ComposerSubmissionOptions,
+	InteractiveModeContext,
+	SubmittedUserInput,
+} from "@gajae-code/coding-agent/modes/types";
 import { SubagentTool, type ToolSession } from "@gajae-code/coding-agent/tools";
 import type { SlashCommand } from "@gajae-code/tui";
 
@@ -41,6 +45,8 @@ type FakeEditor = {
 	onChange?: (text: string) => void;
 	setText(text: string): void;
 	getText(): string;
+	getCursor(): { line: number; col: number };
+	setCursor(line: number, col: number): void;
 	addToHistory(text: string): void;
 	setActionKeys(action: string, keys: string[]): void;
 	setCustomKeyHandler(key: string, handler: () => void): void;
@@ -90,6 +96,7 @@ function createContext(): {
 	};
 } {
 	let editorText = "";
+	let editorCursor = { line: 0, col: 0 };
 	const abort = vi.fn(() => Promise.resolve());
 	const abortBash = vi.fn();
 	const abortEval = vi.fn();
@@ -115,17 +122,29 @@ function createContext(): {
 			if (index >= 0) inputListeners.splice(index, 1);
 		};
 	});
-	const startPendingSubmission = vi.fn((input: { text: string; images?: InteractiveModeContext["pendingImages"] }) => {
-		ensureLoadingAnimation();
-		return createSubmission(input);
-	});
+	const startPendingSubmission = vi.fn(
+		(
+			input: { text: string; images?: InteractiveModeContext["pendingImages"] },
+			_options?: ComposerSubmissionOptions,
+		) => {
+			ensureLoadingAnimation();
+			return createSubmission(input);
+		},
+	);
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
+			editorCursor = { line: 0, col: text.length };
 			editor.onChange?.(text);
 		},
 		getText() {
 			return editorText;
+		},
+		getCursor() {
+			return editorCursor;
+		},
+		setCursor(line: number, col: number) {
+			editorCursor = { line, col };
 		},
 		addToHistory: vi.fn(),
 		setActionKeys: vi.fn(),
@@ -252,7 +271,8 @@ describe("InputController escape behavior", () => {
 		controller.setupEditorSubmitHandler();
 		await editor.onSubmit?.("hello");
 
-		expect(spies.startPendingSubmission).toHaveBeenCalledWith({ text: "hello", images: undefined });
+		expect(spies.startPendingSubmission.mock.calls[0]?.[0]).toEqual({ text: "hello", images: undefined });
+		expect(spies.startPendingSubmission.mock.calls[0]?.[1]).toEqual({ ownsComposer: true, editor: ctx.editor });
 		expect(spies.onInputCallback).toHaveBeenCalledWith(submission);
 		expect(editor.shouldBypassAutocompleteOnEscape?.()).toBe(true);
 
@@ -979,13 +999,12 @@ describe("InputController command palette", () => {
 		ctx.showCommandPalette = showCommandPalette;
 		(ctx.session as { isStreaming: boolean }).isStreaming = true;
 		ctx.withLocalSubmission = async (_text, submit) => submit();
-		let resolveCommand!: () => void;
-		spies.prompt.mockImplementation(
-			() =>
-				new Promise<void>(resolve => {
-					resolveCommand = resolve;
-				}),
-		);
+		const commandEntered = Promise.withResolvers<void>();
+		const commandRelease = Promise.withResolvers<void>();
+		spies.prompt.mockImplementation(async () => {
+			commandEntered.resolve();
+			await commandRelease.promise;
+		});
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
@@ -993,15 +1012,217 @@ describe("InputController command palette", () => {
 		controller.openCommandPalette();
 		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
 		const execution = executeSlashCommand("delayed");
-		await Bun.sleep(0);
+		await commandEntered.promise;
 		expect(spies.prompt).toHaveBeenCalledTimes(1);
 
 		editor.setText("new draft");
-		resolveCommand();
+		commandRelease.resolve();
 		await execution;
 
 		// Command-authored composer mutations are the command's contract, not the palette's.
 		expect(editor.getText()).toBe("new draft");
+	});
+	it("preserves newer composer state when an async palette input hook handles the command", async () => {
+		const { ctx, editor } = createContext();
+		const showCommandPalette = vi.fn();
+		const hookEntered = Promise.withResolvers<void>();
+		const hookRelease = Promise.withResolvers<void>();
+		const successorImage = { type: "image", data: "successor" } as InteractiveModeContext["pendingImages"][number];
+		ctx.showCommandPalette = showCommandPalette;
+		(ctx.session as unknown as { extensionRunner: unknown }).extensionRunner = {
+			hasHandlers: () => true,
+			getShortcuts: () => [],
+			emitInput: vi.fn(async () => {
+				hookEntered.resolve();
+				await hookRelease.promise;
+				return { handled: true };
+			}),
+		};
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "delayed" }] as SlashCommand[], "");
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+
+		const execution = executeSlashCommand("delayed");
+		await hookEntered.promise;
+		editor.setText("/delayed");
+		editor.setCursor(0, 3);
+		ctx.pendingImages = [successorImage];
+		hookRelease.resolve();
+		await execution;
+
+		expect(editor.getText()).toBe("/delayed");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 3 });
+		expect(ctx.pendingImages).toEqual([successorImage]);
+		expect(editor.addToHistory).not.toHaveBeenCalled();
+	});
+	it("dispatches transformed palette input without claiming newer composer state", async () => {
+		const { ctx, editor, spies } = createContext();
+		const showCommandPalette = vi.fn();
+		const hookEntered = Promise.withResolvers<void>();
+		const hookRelease = Promise.withResolvers<void>();
+		const successorImage = { type: "image", data: "new-image" } as InteractiveModeContext["pendingImages"][number];
+		ctx.showCommandPalette = showCommandPalette;
+		(ctx.session as unknown as { extensionRunner: unknown }).extensionRunner = {
+			hasHandlers: () => true,
+			getShortcuts: () => [],
+			emitInput: vi.fn(async () => {
+				hookEntered.resolve();
+				await hookRelease.promise;
+				return { text: "transformed prompt", images: [] };
+			}),
+		};
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "delayed" }] as SlashCommand[], "");
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+
+		const execution = executeSlashCommand("delayed");
+		await hookEntered.promise;
+		editor.setText("new draft");
+		editor.setCursor(0, 4);
+		ctx.pendingImages = [successorImage];
+		hookRelease.resolve();
+		await execution;
+
+		expect(spies.startPendingSubmission.mock.calls[0]?.[0]).toEqual({
+			text: "transformed prompt",
+			images: undefined,
+		});
+		expect(spies.startPendingSubmission.mock.calls[0]?.[1]).toEqual({ ownsComposer: false, editor });
+		expect(editor.getText()).toBe("new draft");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 4 });
+		expect(ctx.pendingImages).toEqual([successorImage]);
+		expect(editor.addToHistory).not.toHaveBeenCalled();
+	});
+	it("preserves successor composer state for transformed streaming and compaction paths", async () => {
+		for (const mode of ["streaming", "compacting"] as const) {
+			const { ctx, editor, spies } = createContext();
+			const showCommandPalette = vi.fn();
+			const hookEntered = Promise.withResolvers<void>();
+			const hookRelease = Promise.withResolvers<void>();
+			const queueCompactionMessage = vi.fn();
+			ctx.showCommandPalette = showCommandPalette;
+			ctx.withLocalSubmission = async (_text, submit) => submit();
+			ctx.queueCompactionMessage = queueCompactionMessage;
+			(ctx.session as { isStreaming: boolean; isCompacting: boolean }).isStreaming = mode === "streaming";
+			(ctx.session as { isStreaming: boolean; isCompacting: boolean }).isCompacting = mode === "compacting";
+			(ctx.session as unknown as { extensionRunner: unknown }).extensionRunner = {
+				hasHandlers: () => true,
+				getShortcuts: () => [],
+				emitInput: vi.fn(async () => {
+					hookEntered.resolve();
+					await hookRelease.promise;
+					return { text: "transformed prompt" };
+				}),
+			};
+			const controller = new InputController(ctx);
+			controller.setupKeyHandlers();
+			controller.createAutocompleteProvider([{ name: "delayed" }] as SlashCommand[], "");
+			controller.openCommandPalette();
+			const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+
+			const execution = executeSlashCommand("delayed");
+			await hookEntered.promise;
+			editor.setText(`${mode} successor`);
+			editor.setCursor(0, 5);
+			hookRelease.resolve();
+			await execution;
+
+			expect(editor.getText()).toBe(`${mode} successor`);
+			expect(editor.getCursor()).toEqual({ line: 0, col: 5 });
+			expect(editor.addToHistory).not.toHaveBeenCalled();
+			if (mode === "streaming") {
+				expect(spies.prompt).toHaveBeenCalledTimes(1);
+			} else {
+				expect(queueCompactionMessage).toHaveBeenCalledWith("transformed prompt", "steer", {
+					ownsComposer: false,
+					editor,
+				});
+			}
+		}
+	});
+	it("does not write through replacement editor or session state after the palette hook settles", async () => {
+		const { ctx, editor, spies } = createContext();
+		const showCommandPalette = vi.fn();
+		const hookEntered = Promise.withResolvers<void>();
+		const hookRelease = Promise.withResolvers<void>();
+		ctx.showCommandPalette = showCommandPalette;
+		(ctx.session as unknown as { extensionRunner: unknown }).extensionRunner = {
+			hasHandlers: () => true,
+			getShortcuts: () => [],
+			emitInput: vi.fn(async () => {
+				hookEntered.resolve();
+				await hookRelease.promise;
+				return { text: "replacement prompt" };
+			}),
+		};
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "delayed" }] as SlashCommand[], "");
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+
+		const execution = executeSlashCommand("delayed");
+		await hookEntered.promise;
+		const replacement = { ...editor, setText: vi.fn(), addToHistory: vi.fn() };
+		ctx.editor = replacement as unknown as InteractiveModeContext["editor"];
+		ctx.session = { ...ctx.session } as InteractiveModeContext["session"];
+		hookRelease.resolve();
+		await execution;
+		expect(spies.startPendingSubmission.mock.calls[0]?.[0]).toEqual({
+			text: "replacement prompt",
+			images: undefined,
+		});
+		expect(spies.startPendingSubmission.mock.calls[0]?.[1]).toEqual({ ownsComposer: false, editor });
+
+		expect(replacement.setText).not.toHaveBeenCalled();
+		expect(replacement.addToHistory).not.toHaveBeenCalled();
+	});
+	it("releases the palette latch after a cancelled input hook without mutating the composer", async () => {
+		const { ctx, editor } = createContext();
+		const showCommandPalette = vi.fn();
+		const hookEntered = Promise.withResolvers<void>();
+		const hookRelease = Promise.withResolvers<void>();
+		const successorImage = {
+			type: "image",
+			data: "cancelled-successor",
+		} as InteractiveModeContext["pendingImages"][number];
+		const emitInput = vi.fn(async (): Promise<{ handled?: boolean }> => {
+			hookEntered.resolve();
+			await hookRelease.promise;
+			throw Object.assign(new Error("input hook cancelled"), { name: "AbortError" });
+		});
+		ctx.showCommandPalette = showCommandPalette;
+		(ctx.session as unknown as { extensionRunner: unknown }).extensionRunner = {
+			hasHandlers: () => true,
+			getShortcuts: () => [],
+			emitInput,
+		};
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "delayed" }] as SlashCommand[], "");
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+
+		const first = executeSlashCommand("delayed");
+		await hookEntered.promise;
+		editor.setText("new draft");
+		editor.setCursor(0, 2);
+		ctx.pendingImages = [successorImage];
+		hookRelease.resolve();
+		await expect(first).rejects.toThrow("input hook cancelled");
+		expect(editor.getText()).toBe("new draft");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 2 });
+		expect(ctx.pendingImages).toEqual([successorImage]);
+		editor.setText("");
+		ctx.pendingImages = [];
+
+		emitInput.mockResolvedValueOnce({ handled: true });
+		await executeSlashCommand("delayed");
+		expect(emitInput).toHaveBeenCalledTimes(2);
 	});
 	it("refuses a second palette command while the first is pending", async () => {
 		const { ctx, spies } = createContext();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { QueuedMessageSelectorComponent } from "../src/modes/components/queued-message-selector";
 import { InputController } from "../src/modes/controllers/input-controller";
 import { initTheme } from "../src/modes/theme/theme";
-import type { CompactionQueuedMessage, InteractiveModeContext } from "../src/modes/types";
+import type { CompactionQueuedMessage, ComposerSubmissionOptions, InteractiveModeContext } from "../src/modes/types";
 import type { QueuedMessageEditEntry } from "../src/session/agent-session";
 
 type FakeEditor = {
@@ -66,12 +66,15 @@ async function createContext(options?: {
 	const onInputCallback = vi.fn();
 	const toggleIrcSidebar = vi.fn();
 	const startPendingSubmission = vi.fn(
-		(input: {
-			text: string;
-			images?: InteractiveModeContext["pendingImages"];
-			customType?: string;
-			display?: boolean;
-		}) => ({
+		(
+			input: {
+				text: string;
+				images?: InteractiveModeContext["pendingImages"];
+				customType?: string;
+				display?: boolean;
+			},
+			_options?: ComposerSubmissionOptions,
+		) => ({
 			...input,
 			cancelled: false,
 			started: true,
@@ -650,10 +653,11 @@ describe("InputController keybinding setup", () => {
 
 		await editor.onSubmit?.("send text after deleting the pasted image");
 
-		expect(spies.startPendingSubmission).toHaveBeenCalledWith({
+		expect(spies.startPendingSubmission.mock.calls[0]?.[0]).toEqual({
 			text: "send text after deleting the pasted image",
 			images: undefined,
 		});
+		expect(spies.startPendingSubmission.mock.calls[0]?.[1]).toEqual({ ownsComposer: true, editor: ctx.editor });
 		expect(spies.onInputCallback).toHaveBeenCalledWith({
 			text: "send text after deleting the pasted image",
 			images: undefined,
@@ -681,10 +685,11 @@ describe("InputController keybinding setup", () => {
 
 		await editor.onSubmit?.("describe only [image 2]");
 
-		expect(spies.startPendingSubmission).toHaveBeenCalledWith({
+		expect(spies.startPendingSubmission.mock.calls[0]?.[0]).toEqual({
 			text: "describe only [image 2]",
 			images: [secondImage],
 		});
+		expect(spies.startPendingSubmission.mock.calls[0]?.[1]).toEqual({ ownsComposer: true, editor: ctx.editor });
 		expect(spies.onInputCallback).toHaveBeenCalledWith({
 			text: "describe only [image 2]",
 			images: [secondImage],
@@ -710,10 +715,11 @@ describe("InputController keybinding setup", () => {
 		editor.onChange?.("");
 		await editor.onSubmit?.("describe [image 1]");
 
-		expect(spies.startPendingSubmission).toHaveBeenCalledWith({
+		expect(spies.startPendingSubmission.mock.calls[0]?.[0]).toEqual({
 			text: "describe [image 1]",
 			images: [image],
 		});
+		expect(spies.startPendingSubmission.mock.calls[0]?.[1]).toEqual({ ownsComposer: true, editor: ctx.editor });
 		expect(spies.onInputCallback).toHaveBeenCalledWith({
 			text: "describe [image 1]",
 			images: [image],
@@ -762,17 +768,19 @@ describe("InputController keybinding setup", () => {
 
 		extension.resolve();
 		await firstSubmit;
-		expect(spies.startPendingSubmission).toHaveBeenNthCalledWith(1, {
+		expect(spies.startPendingSubmission.mock.calls[0]?.[0]).toEqual({
 			text: "describe [image 1]",
 			images: [firstImage],
 		});
+		expect(spies.startPendingSubmission.mock.calls[0]?.[1]).toEqual({ ownsComposer: true, editor: ctx.editor });
 		expect(ctx.pendingImages).toEqual([firstImage, secondImage]);
 
 		await editor.onSubmit?.("follow up [image 2]");
-		expect(spies.startPendingSubmission).toHaveBeenNthCalledWith(2, {
+		expect(spies.startPendingSubmission.mock.calls[1]?.[0]).toEqual({
 			text: "follow up [image 2]",
 			images: [secondImage],
 		});
+		expect(spies.startPendingSubmission.mock.calls[1]?.[1]).toEqual({ ownsComposer: true, editor: ctx.editor });
 		expect(ctx.pendingImages).toEqual([]);
 	});
 

--- a/packages/coding-agent/test/modes/controllers/selector-controller-command-palette.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-command-palette.test.ts
@@ -7,7 +7,8 @@ import type { SlashCommand } from "@gajae-code/tui";
 describe("SelectorController command palette", () => {
 	it("surfaces rejected handlers without an unhandled rejection", async () => {
 		const component = { clear: vi.fn(), addChild: vi.fn() };
-		const showError = vi.fn();
+		const errorShown = Promise.withResolvers<void>();
+		const showError = vi.fn(() => errorShown.resolve());
 		const ctx = {
 			editorContainer: component,
 			editor: {},
@@ -18,21 +19,27 @@ describe("SelectorController command palette", () => {
 		} as unknown as InteractiveModeContext;
 		const controller = new SelectorController(ctx);
 		const unhandled = vi.fn();
-		process.once("unhandledRejection", unhandled);
+		process.on("unhandledRejection", unhandled);
 
-		controller.showCommandPalette([{ name: "broken", description: "Rejects" }] as SlashCommand[], [], async () => {
-			throw new Error("palette command failed");
-		});
-		const palette = component.addChild.mock.calls[0]?.[0] as CommandPaletteComponent;
-		palette.handleInput("\r");
-		await Bun.sleep(0);
+		try {
+			controller.showCommandPalette([{ name: "broken", description: "Rejects" }] as SlashCommand[], [], async () => {
+				throw new Error("palette command failed");
+			});
+			const palette = component.addChild.mock.calls[0]?.[0] as CommandPaletteComponent;
+			palette.handleInput("\r");
+			await errorShown.promise;
+			await new Promise<void>(resolve => setImmediate(resolve));
 
-		expect(showError).toHaveBeenCalledWith("palette command failed");
-		expect(unhandled).not.toHaveBeenCalled();
+			expect(showError).toHaveBeenCalledWith("palette command failed");
+			expect(unhandled).not.toHaveBeenCalled();
+		} finally {
+			process.off("unhandledRejection", unhandled);
+		}
 	});
 	it("surfaces rejected action handlers", async () => {
 		const component = { clear: vi.fn(), addChild: vi.fn() };
-		const showError = vi.fn();
+		const errorShown = Promise.withResolvers<void>();
+		const showError = vi.fn(() => errorShown.resolve());
 		const ctx = {
 			editorContainer: component,
 			editor: {},
@@ -58,7 +65,7 @@ describe("SelectorController command palette", () => {
 		);
 		const palette = component.addChild.mock.calls[0]?.[0] as CommandPaletteComponent;
 		palette.handleInput("\r");
-		await Bun.sleep(0);
+		await errorShown.promise;
 
 		expect(showError).toHaveBeenCalledWith("external editor failed");
 	});


### PR DESCRIPTION
## What

- add an explicit owning/non-owning composer submission contract at the canonical `InputController.submitText()` boundary
- make command-palette slash submissions non-owning while keyboard/Enter submissions remain owning
- guard every generic post-`emitInput` composer cleanup with ownership plus captured editor identity
- preserve newer text, cursor state, history, and pending images across handled, transformed, cancelled, streaming, compaction, and replacement races
- retain selected command-owned behavior, ACP contracts, and palette single-flight semantics

## Why

Fixes #2441.

PR #2439 correctly removed palette stash/restore ownership, but canonical submission still retained generic composer cleanup authority across an asynchronous extension input-hook await. A user could type a byte-identical or different draft, move the cursor, add an image, or replace the editor/session before the hook settled, and stale cleanup could erase that newer state.

This change makes ownership explicit rather than inferring it from content equality.

## Generic cleanup audit

Guarded palette-reachable generic cleanup covers:

- handled-hook editor and pending-image clears
- transformed streaming history/text/image cleanup
- normal pending-submission hidden clear, history, and pending images
- transformed skill history/text cleanup
- busy bash/eval fallback writes and history
- compaction queue history/text cleanup
- TUI builtin dispatcher unknown/adapted final clears

Direct command-authored `handleTui` behavior remains command-owned and unchanged.

## Testing

Exact head: `634939d76642eabe9151b8d882c60e391f223714`

- [x] focused 8-file suite — 213 pass, 0 fail, 747 expectations
- [x] `bun --cwd=packages/coding-agent run check`
- [x] `bun --cwd=packages/coding-agent run build`
- [x] deterministic `Promise.withResolvers()` races; no sleep-based synchronization in touched palette rejection coverage
- [x] CHANGELOG updated

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*