### PR TITLE
fix(coding-agent): align SDK lifecycle session ownership

### DIFF
--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -721,8 +721,7 @@ export class Broker {
 					...(outcome.startupFailure ? { startupFailure: outcome.startupFailure } : {}),
 				},
 			);
-			const reopenedLedger = await new LifecycleLedger(this.settings.agentDir).open();
-			const persisted = reopenedLedger.get(identity);
+			const persisted = await this.ledger.readTerminal(identity, requestHash);
 			const expectedResponseDigest = createHash("sha256").update(canonicalJson(response)).digest("hex");
 			const persistenceVerified =
 				persisted?.responseDigest === expectedResponseDigest &&

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -127,6 +127,8 @@ export type BrokerCleanupEvidence = {
 	plannedTranscriptPath?: string;
 	/** Fully identity-bound startup-failure cleanup plan, persisted before any detach. */
 	lifecycleFiles?: BrokerLifecycleCleanupFile[];
+	/** Delete metadata receipts authorize only the canonical marker/ready sibling pair. */
+	lifecycleDeleteMetadata?: true;
 };
 export type BrokerResponse =
 	| { ok: true; result?: unknown; indexSeq?: number }

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -25,6 +25,7 @@ import {
 	type LifecycleDurableEffectsReceipt,
 	LifecycleLedger,
 	type LifecycleStartupFailureReceipt,
+	type LifecycleState,
 } from "./lifecycle-ledger";
 import { type IndexedSession, SessionIndex } from "./session-index";
 import { BrokerTransport } from "./transport";
@@ -145,6 +146,16 @@ export type BrokerResponse =
 			startupFailure?: LifecycleStartupFailureReceipt;
 	  };
 const error = (code: BrokerErrorCode, message: string): BrokerResponse => ({ ok: false, error: { code, message } });
+
+function isCleanupPending(response: BrokerResponse): boolean {
+	return !response.ok && response.error.code === "cleanup_pending" && response.error.cleanup !== undefined;
+}
+
+function lifecycleResponseState(response: BrokerResponse): LifecycleState {
+	if (response.ok) return "terminal_ok";
+	if (isCleanupPending(response)) return "effect_started";
+	return response.error.code === "terminal_uncertain" ? "terminal_uncertain" : "terminal_error";
+}
 
 type InputNormalization = { input: Record<string, unknown> } | BrokerResponse;
 
@@ -676,7 +687,7 @@ export class Broker {
 				const cleanup = replay.error.cleanup;
 				const outcome = await executeLifecycle(this, operation, input, identity, cleanup);
 				const response = outcome.response;
-				await this.ledger.transition(identity, response.ok ? "terminal_ok" : "terminal_error", {
+				await this.ledger.transition(identity, lifecycleResponseState(response), {
 					response,
 					responseDigest: createHash("sha256").update(canonicalJson(response)).digest("hex"),
 					...(outcome.durableEffects ? { durableEffects: outcome.durableEffects } : {}),
@@ -692,7 +703,7 @@ export class Broker {
 					return replay ?? error("terminal_uncertain", "prior lifecycle operation outcome is uncertain");
 				const outcome = await executeLifecycle(this, operation, input, identity, replay.error.cleanup);
 				const response = outcome.response;
-				await this.ledger.transition(identity, response.ok ? "terminal_ok" : "terminal_error", {
+				await this.ledger.transition(identity, lifecycleResponseState(response), {
 					response,
 					responseDigest: createHash("sha256").update(canonicalJson(response)).digest("hex"),
 					...(outcome.durableEffects ? { durableEffects: outcome.durableEffects } : {}),
@@ -703,24 +714,17 @@ export class Broker {
 			if (begun.kind === "in_progress") return error("broker_restarting", "lifecycle operation is in progress");
 			const outcome = await executeLifecycle(this, operation, input, identity);
 			const response = outcome.response;
-			await this.ledger.transition(
-				identity,
-				response.ok
-					? "terminal_ok"
-					: response.error.code === "terminal_uncertain"
-						? "terminal_uncertain"
-						: "terminal_error",
-				{
-					resultSessionId:
-						response.ok && typeof (response.result as { sessionId?: unknown } | undefined)?.sessionId === "string"
-							? (response.result as { sessionId: string }).sessionId
-							: undefined,
-					response,
-					responseDigest: createHash("sha256").update(canonicalJson(response)).digest("hex"),
-					...(outcome.durableEffects ? { durableEffects: outcome.durableEffects } : {}),
-					...(outcome.startupFailure ? { startupFailure: outcome.startupFailure } : {}),
-				},
-			);
+			await this.ledger.transition(identity, lifecycleResponseState(response), {
+				resultSessionId:
+					response.ok && typeof (response.result as { sessionId?: unknown } | undefined)?.sessionId === "string"
+						? (response.result as { sessionId: string }).sessionId
+						: undefined,
+				response,
+				responseDigest: createHash("sha256").update(canonicalJson(response)).digest("hex"),
+				...(outcome.durableEffects ? { durableEffects: outcome.durableEffects } : {}),
+				...(outcome.startupFailure ? { startupFailure: outcome.startupFailure } : {}),
+			});
+			if (isCleanupPending(response)) return response;
 			const persisted = await this.ledger.readTerminal(identity, requestHash);
 			const expectedResponseDigest = createHash("sha256").update(canonicalJson(response)).digest("hex");
 			const persistenceVerified =

--- a/packages/coding-agent/src/sdk/broker/lifecycle-codec.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-codec.ts
@@ -1,0 +1,11 @@
+const lifecycleUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+/** Decodes persisted lifecycle bytes without replacement characters before JSON parsing. */
+export function decodeLifecycleUtf8(bytes: Uint8Array): string {
+	return lifecycleUtf8Decoder.decode(bytes);
+}
+
+/** Parses persisted lifecycle JSON only after fatal UTF-8 decoding. */
+export function parseLifecycleJson(bytes: Uint8Array): unknown {
+	return JSON.parse(decodeLifecycleUtf8(bytes));
+}

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto";
+import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import type { SdkStartupFailure, SdkStartupRollbackResult } from "../startup-capability";
+import { parseLifecycleJson } from "./lifecycle-codec";
 import { assertSupportedStateVersion, SDK_STATE_VERSION } from "./state-version";
 
 export type LifecycleState =
@@ -87,6 +89,46 @@ export type BeginResult =
 	| { kind: "terminal_uncertain"; entry: LifecycleLedgerEntry }
 	| { kind: "in_progress"; entry: LifecycleLedgerEntry };
 const terminal = (s: LifecycleState) => s === "terminal_ok" || s === "terminal_error";
+const MAX_LIFECYCLE_LEDGER_BYTES = 8 * 1024 * 1024;
+const MAX_LIFECYCLE_LEDGER_LINE_BYTES = 64 * 1024;
+const MAX_LIFECYCLE_LEDGER_ROWS = 10_000;
+const MAX_LIFECYCLE_LEDGER_JSON_DEPTH = 64;
+const MAX_LIFECYCLE_LEDGER_JSON_FIELDS = 1024;
+
+function isBoundedLedgerJson(value: unknown, depth = 0, budget = { fields: 0 }): boolean {
+	if (depth > MAX_LIFECYCLE_LEDGER_JSON_DEPTH) return false;
+	if (value === null || typeof value !== "object") return true;
+	if (Array.isArray(value)) {
+		if (value.length > MAX_LIFECYCLE_LEDGER_JSON_FIELDS) return false;
+		return value.every(item => isBoundedLedgerJson(item, depth + 1, budget));
+	}
+	const record = value as Record<string, unknown>;
+	const keys = Object.keys(record);
+	budget.fields += keys.length;
+	return (
+		budget.fields <= MAX_LIFECYCLE_LEDGER_JSON_FIELDS &&
+		keys.every(key => isBoundedLedgerJson(record[key], depth + 1, budget))
+	);
+}
+
+function isLifecycleLedgerEntry(value: unknown): value is LifecycleLedgerEntry {
+	if (typeof value !== "object" || value === null || Array.isArray(value) || !isBoundedLedgerJson(value)) return false;
+	const entry = value as Partial<LifecycleLedgerEntry>;
+	return (
+		typeof entry.identity === "string" &&
+		entry.identity.length > 0 &&
+		typeof entry.requestHash === "string" &&
+		entry.requestHash.length > 0 &&
+		(entry.state === "accepted" ||
+			entry.state === "effect_started" ||
+			entry.state === "awaiting_ready" ||
+			entry.state === "terminal_ok" ||
+			entry.state === "terminal_error" ||
+			entry.state === "terminal_uncertain") &&
+		typeof entry.ts === "number" &&
+		Number.isSafeInteger(entry.ts)
+	);
+}
 function canonicalJson(value: unknown): string {
 	if (value === null || typeof value !== "object") return JSON.stringify(value);
 	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
@@ -121,42 +163,52 @@ export class LifecycleLedger {
 		this.#corruptFile = `${this.#file}.corrupt`;
 	}
 	async open(): Promise<this> {
-		await this.assertSupportedStateVersions();
 		await fs.mkdir(path.dirname(this.#file), { recursive: true, mode: 0o700 });
 		this.#entries = [];
 		const quarantinedTerminal = new Set<string>();
 		this.#byIdentity.clear();
 		this.#warnings = [];
 		const uncertainAfterCorruption = new Set<string>();
+		const source = await this.#readBoundedSource();
 		let tornTail = false;
-		try {
-			const source = await fs.readFile(this.#file, "utf8");
-			tornTail = source.length > 0 && !source.endsWith("\n");
-			const lines = source.split("\n");
-			for (const line of lines) {
-				if (!line) continue;
+		if (source) {
+			tornTail = source.length > 0 && source.at(-1) !== 0x0a;
+			let lineStart = 0;
+			let rows = 0;
+			for (let offset = 0; offset <= source.length; offset += 1) {
+				if (offset !== source.length && source[offset] !== 0x0a) continue;
+				const line = source.subarray(lineStart, offset);
+				lineStart = offset + 1;
+				if (line.length === 0) continue;
+				rows += 1;
+				if (rows > MAX_LIFECYCLE_LEDGER_ROWS)
+					await this.#rejectOversizedSource("Lifecycle ledger exceeds the maximum row count.");
+				if (line.length > MAX_LIFECYCLE_LEDGER_LINE_BYTES)
+					await this.#rejectOversizedSource("Lifecycle ledger row exceeds the maximum byte length.");
 				try {
-					const e = JSON.parse(line) as LifecycleLedgerEntry;
-					assertSupportedStateVersion(this.#file, e);
-					if (!e.identity || !e.requestHash || !e.state) throw new Error("invalid ledger entry");
-					if (!hasValidTerminalDigests(e)) {
+					const value = parseLifecycleJson(line);
+					if (!isLifecycleLedgerEntry(value)) throw new Error("invalid ledger entry");
+					const entry = value;
+					assertSupportedStateVersion(this.#file, entry);
+					if (!hasValidTerminalDigests(entry)) {
 						await this.#quarantine(line);
 						const {
 							response: _response,
 							responseDigest: _responseDigest,
 							durableEffects: _durableEffects,
 							...uncertain
-						} = e;
+						} = entry;
 						const quarantined = { ...uncertain, state: "terminal_uncertain" as const, ts: Date.now() };
 						this.#entries.push(quarantined);
 						this.#byIdentity.set(quarantined.identity, quarantined);
 						quarantinedTerminal.add(quarantined.identity);
 						continue;
 					}
-					this.#entries.push(e);
-					this.#byIdentity.set(e.identity, e);
-					uncertainAfterCorruption.delete(e.identity);
-				} catch {
+					this.#entries.push(entry);
+					this.#byIdentity.set(entry.identity, entry);
+					uncertainAfterCorruption.delete(entry.identity);
+				} catch (error) {
+					if (error instanceof Error && "code" in error && error.code === "unsupported_state_version") throw error;
 					for (const [identity, latest] of this.#byIdentity) {
 						if (!terminal(latest.state) && latest.state !== "terminal_uncertain")
 							uncertainAfterCorruption.add(identity);
@@ -164,8 +216,6 @@ export class LifecycleLedger {
 					await this.#quarantine(line);
 				}
 			}
-		} catch (e) {
-			if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
 		}
 		if (tornTail) await this.#sealTornTail();
 		for (const identity of quarantinedTerminal) {
@@ -192,6 +242,29 @@ export class LifecycleLedger {
 		}
 		return this;
 	}
+	async #readBoundedSource(): Promise<Buffer | undefined> {
+		let handle: fs.FileHandle | undefined;
+		try {
+			handle = await fs.open(this.#file, fsSync.constants.O_RDONLY | fsSync.constants.O_NOFOLLOW);
+			const stat = await handle.stat({ bigint: true });
+			if (!stat.isFile() || stat.size > BigInt(MAX_LIFECYCLE_LEDGER_BYTES))
+				await this.#rejectOversizedSource("Lifecycle ledger exceeds the maximum file byte length.");
+			const bytes = Buffer.alloc(Number(stat.size) + 1);
+			const { bytesRead } = await handle.read(bytes, 0, bytes.length, 0);
+			if (bytesRead > MAX_LIFECYCLE_LEDGER_BYTES)
+				await this.#rejectOversizedSource("Lifecycle ledger exceeds the maximum file byte length.");
+			return bytes.subarray(0, bytesRead);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+			throw error;
+		} finally {
+			if (handle) await handle.close();
+		}
+	}
+	async #rejectOversizedSource(reason: string): Promise<never> {
+		await this.#quarantine(reason);
+		throw new Error(reason);
+	}
 	async #sealTornTail(): Promise<void> {
 		const h = await fs.open(this.#file, "a", 0o600);
 		try {
@@ -201,10 +274,11 @@ export class LifecycleLedger {
 			await h.close();
 		}
 	}
-	async #quarantine(line: string): Promise<void> {
+	async #quarantine(line: string | Uint8Array): Promise<void> {
 		const h = await fs.open(this.#corruptFile, "a", 0o600);
 		try {
-			await h.writeFile(`${line}\n`);
+			await h.writeFile(line);
+			await h.writeFile("\n");
 			await h.sync();
 		} finally {
 			await h.close();
@@ -269,18 +343,18 @@ export class LifecycleLedger {
 		}
 		return this.#append(next);
 	}
+
 	async assertSupportedStateVersions(): Promise<void> {
-		let source: string;
-		try {
-			source = await fs.readFile(this.#file, "utf8");
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-			throw error;
-		}
-		for (const line of source.split("\n")) {
-			if (!line) continue;
+		const source = await this.#readBoundedSource();
+		if (!source) return;
+		let lineStart = 0;
+		for (let offset = 0; offset <= source.length; offset += 1) {
+			if (offset !== source.length && source[offset] !== 0x0a) continue;
+			const line = source.subarray(lineStart, offset);
+			lineStart = offset + 1;
+			if (line.length === 0 || line.length > MAX_LIFECYCLE_LEDGER_LINE_BYTES) continue;
 			try {
-				assertSupportedStateVersion(this.#file, JSON.parse(line));
+				assertSupportedStateVersion(this.#file, parseLifecycleJson(line));
 			} catch (error) {
 				if (error instanceof Error && "code" in error && error.code === "unsupported_state_version") throw error;
 			}

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -89,9 +89,17 @@ export type BeginResult =
 	| { kind: "terminal_uncertain"; entry: LifecycleLedgerEntry }
 	| { kind: "in_progress"; entry: LifecycleLedgerEntry };
 const terminal = (s: LifecycleState) => s === "terminal_ok" || s === "terminal_error";
-const MAX_LIFECYCLE_LEDGER_BYTES = 8 * 1024 * 1024;
-const MAX_LIFECYCLE_LEDGER_LINE_BYTES = 64 * 1024;
-const MAX_LIFECYCLE_LEDGER_ROWS = 10_000;
+const final = (s: LifecycleState) => terminal(s) || s === "terminal_uncertain";
+export interface LifecycleLedgerLimits {
+	maxBytes?: number;
+	maxLineBytes?: number;
+	maxRows?: number;
+}
+const DEFAULT_LIFECYCLE_LEDGER_LIMITS: Required<LifecycleLedgerLimits> = {
+	maxBytes: 64 * 1024 * 1024,
+	maxLineBytes: 8 * 1024 * 1024,
+	maxRows: 10_000,
+};
 const MAX_LIFECYCLE_LEDGER_JSON_DEPTH = 64;
 const MAX_LIFECYCLE_LEDGER_JSON_FIELDS = 1024;
 
@@ -115,6 +123,7 @@ function isLifecycleLedgerEntry(value: unknown): value is LifecycleLedgerEntry {
 	if (typeof value !== "object" || value === null || Array.isArray(value) || !isBoundedLedgerJson(value)) return false;
 	const entry = value as Partial<LifecycleLedgerEntry>;
 	return (
+		entry.version === SDK_STATE_VERSION &&
 		typeof entry.identity === "string" &&
 		entry.identity.length > 0 &&
 		typeof entry.requestHash === "string" &&
@@ -157,51 +166,60 @@ export class LifecycleLedger {
 	#corruptFile: string;
 	#entries: LifecycleLedgerEntry[] = [];
 	#byIdentity = new Map<string, LifecycleLedgerEntry>();
+	#limits: Required<LifecycleLedgerLimits>;
+	#rowCount = 0;
+	#byteCount = 0;
 	#warnings: string[] = [];
-	constructor(agentDir: string) {
+	constructor(agentDir: string, limits: LifecycleLedgerLimits = {}) {
 		this.#file = path.join(agentDir, "sdk", "lifecycle-ledger.jsonl");
 		this.#corruptFile = `${this.#file}.corrupt`;
+		this.#limits = {
+			maxBytes: limits.maxBytes ?? DEFAULT_LIFECYCLE_LEDGER_LIMITS.maxBytes,
+			maxLineBytes: limits.maxLineBytes ?? DEFAULT_LIFECYCLE_LEDGER_LIMITS.maxLineBytes,
+			maxRows: limits.maxRows ?? DEFAULT_LIFECYCLE_LEDGER_LIMITS.maxRows,
+		};
 	}
 	async open(): Promise<this> {
 		await fs.mkdir(path.dirname(this.#file), { recursive: true, mode: 0o700 });
 		this.#entries = [];
-		const quarantinedTerminal = new Set<string>();
 		this.#byIdentity.clear();
 		this.#warnings = [];
+		this.#rowCount = 0;
+		this.#byteCount = 0;
+		const invalidIdentities = new Set<string>();
+		const syntheticUncertain = new Map<string, LifecycleLedgerEntry>();
 		const uncertainAfterCorruption = new Set<string>();
 		const source = await this.#readBoundedSource();
 		let tornTail = false;
 		if (source) {
+			this.#byteCount = source.length;
 			tornTail = source.length > 0 && source.at(-1) !== 0x0a;
 			let lineStart = 0;
-			let rows = 0;
 			for (let offset = 0; offset <= source.length; offset += 1) {
 				if (offset !== source.length && source[offset] !== 0x0a) continue;
 				const line = source.subarray(lineStart, offset);
 				lineStart = offset + 1;
 				if (line.length === 0) continue;
-				rows += 1;
-				if (rows > MAX_LIFECYCLE_LEDGER_ROWS)
+				this.#rowCount += 1;
+				if (this.#rowCount > this.#limits.maxRows)
 					await this.#rejectOversizedSource("Lifecycle ledger exceeds the maximum row count.");
-				if (line.length > MAX_LIFECYCLE_LEDGER_LINE_BYTES)
+				if (line.length > this.#limits.maxLineBytes)
 					await this.#rejectOversizedSource("Lifecycle ledger row exceeds the maximum byte length.");
 				try {
 					const value = parseLifecycleJson(line);
+					assertSupportedStateVersion(this.#file, value);
 					if (!isLifecycleLedgerEntry(value)) throw new Error("invalid ledger entry");
 					const entry = value;
-					assertSupportedStateVersion(this.#file, entry);
-					if (!hasValidTerminalDigests(entry)) {
+					const prior = this.#byIdentity.get(entry.identity);
+					const invalidHistory =
+						invalidIdentities.has(entry.identity) ||
+						!hasValidTerminalDigests(entry) ||
+						!this.#isValidHistoryContinuation(prior, entry);
+					if (invalidHistory) {
 						await this.#quarantine(line);
-						const {
-							response: _response,
-							responseDigest: _responseDigest,
-							durableEffects: _durableEffects,
-							...uncertain
-						} = entry;
-						const quarantined = { ...uncertain, state: "terminal_uncertain" as const, ts: Date.now() };
-						this.#entries.push(quarantined);
-						this.#byIdentity.set(quarantined.identity, quarantined);
-						quarantinedTerminal.add(quarantined.identity);
+						invalidIdentities.add(entry.identity);
+						if (!syntheticUncertain.has(entry.identity))
+							syntheticUncertain.set(entry.identity, this.#uncertainFrom(prior ?? entry, prior !== undefined));
 						continue;
 					}
 					this.#entries.push(entry);
@@ -210,53 +228,130 @@ export class LifecycleLedger {
 				} catch (error) {
 					if (error instanceof Error && "code" in error && error.code === "unsupported_state_version") throw error;
 					for (const [identity, latest] of this.#byIdentity) {
-						if (!terminal(latest.state) && latest.state !== "terminal_uncertain")
-							uncertainAfterCorruption.add(identity);
+						if (!final(latest.state)) uncertainAfterCorruption.add(identity);
 					}
 					await this.#quarantine(line);
 				}
 			}
 		}
 		if (tornTail) await this.#sealTornTail();
-		for (const identity of quarantinedTerminal) {
-			const entry = this.#byIdentity.get(identity);
-			if (entry) await this.#append(entry);
+		for (const [identity, uncertain] of syntheticUncertain) {
+			this.#byIdentity.set(identity, uncertain);
+			await this.#append(uncertain);
 		}
 		for (const identity of uncertainAfterCorruption) {
 			const entry = this.#byIdentity.get(identity);
-			if (entry && !terminal(entry.state) && entry.state !== "terminal_uncertain") {
-				const uncertain = { ...entry, state: "terminal_uncertain" as const, ts: Date.now() };
-				if (uncertain.response !== undefined)
-					uncertain.responseDigest = createHash("sha256").update(canonicalJson(uncertain.response)).digest("hex");
-				await this.#append(uncertain);
-			}
+			if (entry && !final(entry.state)) await this.#append(this.#uncertainFrom(entry));
 		}
 		// Effects may have completed after the last durable marker; do not retry them after a restart.
 		for (const entry of [...this.#byIdentity.values()]) {
-			if (entry.state === "effect_started" || entry.state === "awaiting_ready") {
-				const uncertain = { ...entry, state: "terminal_uncertain" as const, ts: Date.now() };
-				if (uncertain.response !== undefined)
-					uncertain.responseDigest = createHash("sha256").update(canonicalJson(uncertain.response)).digest("hex");
-				await this.#append(uncertain);
-			}
+			if (entry.state === "effect_started" || entry.state === "awaiting_ready")
+				await this.#append(this.#uncertainFrom(entry));
 		}
 		return this;
+	}
+	/**
+	 * Reads terminal proof for one request without recovering or changing the ledger.
+	 *
+	 * This intentionally accepts an unrelated unterminated final write: concurrent
+	 * appenders may have started a different row after this request's synced terminal
+	 * row. Complete rows are still decoded and validated strictly, and any incomplete
+	 * tail that identifies this request withholds proof.
+	 */
+	async readTerminal(identity: string, requestHash: string): Promise<LifecycleLedgerEntry | undefined> {
+		const source = await this.#readBoundedSourceReadOnly();
+		if (!source) return undefined;
+		let prior: LifecycleLedgerEntry | undefined;
+		let latest: LifecycleLedgerEntry | undefined;
+		let rows = 0;
+		let lineStart = 0;
+		const finalNewline = source.length > 0 && source.at(-1) === 0x0a;
+		const completeLength = finalNewline ? source.length : source.lastIndexOf(0x0a) + 1;
+		for (let offset = 0; offset < completeLength; offset += 1) {
+			if (source[offset] !== 0x0a) continue;
+			const line = source.subarray(lineStart, offset);
+			lineStart = offset + 1;
+			if (line.length === 0) continue;
+			rows += 1;
+			if (rows > this.#limits.maxRows || line.length > this.#limits.maxLineBytes) return undefined;
+			let entry: LifecycleLedgerEntry;
+			try {
+				const value = parseLifecycleJson(line);
+				assertSupportedStateVersion(this.#file, value);
+				if (!isLifecycleLedgerEntry(value)) return undefined;
+				entry = value;
+			} catch {
+				return undefined;
+			}
+			if (entry.identity !== identity) continue;
+			if (
+				entry.requestHash !== requestHash ||
+				!hasValidTerminalDigests(entry) ||
+				!this.#isValidHistoryContinuation(prior, entry)
+			)
+				return undefined;
+			prior = entry;
+			latest = entry;
+		}
+		if (!finalNewline) {
+			const tail = source.subarray(completeLength);
+			// LifecycleLedger writes JSON.stringify entries, so this marker is exact for
+			// a partially persisted row from this identity without inspecting arbitrary
+			// malformed data as a valid record.
+			const identityMarker = Buffer.from(`"identity":${JSON.stringify(identity)}`);
+			if (tail.includes(identityMarker)) return undefined;
+		}
+		return latest && terminal(latest.state) ? latest : undefined;
+	}
+
+	#isValidHistoryContinuation(previous: LifecycleLedgerEntry | undefined, next: LifecycleLedgerEntry): boolean {
+		if (!previous) return true;
+		if (previous.requestHash !== next.requestHash || final(previous.state)) return false;
+		if (previous.state === "accepted") return true;
+		return next.state === "effect_started" || next.state === "awaiting_ready" || final(next.state);
+	}
+	#uncertainFrom(entry: LifecycleLedgerEntry, trusted = true): LifecycleLedgerEntry {
+		if (trusted) return { ...entry, state: "terminal_uncertain", ts: Date.now() };
+		return {
+			version: SDK_STATE_VERSION,
+			identity: entry.identity,
+			requestHash: entry.requestHash,
+			state: "terminal_uncertain",
+			ts: Date.now(),
+		};
 	}
 	async #readBoundedSource(): Promise<Buffer | undefined> {
 		let handle: fs.FileHandle | undefined;
 		try {
 			handle = await fs.open(this.#file, fsSync.constants.O_RDONLY | fsSync.constants.O_NOFOLLOW);
 			const stat = await handle.stat({ bigint: true });
-			if (!stat.isFile() || stat.size > BigInt(MAX_LIFECYCLE_LEDGER_BYTES))
+			if (!stat.isFile() || stat.size > BigInt(this.#limits.maxBytes))
 				await this.#rejectOversizedSource("Lifecycle ledger exceeds the maximum file byte length.");
 			const bytes = Buffer.alloc(Number(stat.size) + 1);
 			const { bytesRead } = await handle.read(bytes, 0, bytes.length, 0);
-			if (bytesRead > MAX_LIFECYCLE_LEDGER_BYTES)
+			if (bytesRead > this.#limits.maxBytes)
 				await this.#rejectOversizedSource("Lifecycle ledger exceeds the maximum file byte length.");
 			return bytes.subarray(0, bytesRead);
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
 			throw error;
+		} finally {
+			if (handle) await handle.close();
+		}
+	}
+	async #readBoundedSourceReadOnly(): Promise<Buffer | undefined> {
+		let handle: fs.FileHandle | undefined;
+		try {
+			handle = await fs.open(this.#file, fsSync.constants.O_RDONLY | fsSync.constants.O_NOFOLLOW);
+			const stat = await handle.stat({ bigint: true });
+			if (!stat.isFile() || stat.size > BigInt(this.#limits.maxBytes)) return undefined;
+			const bytes = Buffer.alloc(Number(stat.size) + 1);
+			const { bytesRead } = await handle.read(bytes, 0, bytes.length, 0);
+			if (bytesRead > this.#limits.maxBytes) return undefined;
+			return bytes.subarray(0, bytesRead);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+			return undefined;
 		} finally {
 			if (handle) await handle.close();
 		}
@@ -270,6 +365,7 @@ export class LifecycleLedger {
 		try {
 			await h.writeFile("\n");
 			await h.sync();
+			this.#byteCount += 1;
 		} finally {
 			await h.close();
 		}
@@ -285,19 +381,68 @@ export class LifecycleLedger {
 		}
 		this.#warnings.push("Malformed lifecycle ledger entry quarantined");
 	}
+	async #syncDirectory(): Promise<void> {
+		const directory = await fs.open(path.dirname(this.#file), fsSync.constants.O_RDONLY);
+		try {
+			await directory.sync();
+		} finally {
+			await directory.close();
+		}
+	}
+	async #compact(): Promise<void> {
+		const snapshot = [...this.#byIdentity.values()];
+		const contents = Buffer.from(snapshot.map(entry => `${JSON.stringify(entry)}\n`).join(""));
+		if (
+			snapshot.length > this.#limits.maxRows ||
+			contents.length > this.#limits.maxBytes ||
+			snapshot.some(entry => Buffer.byteLength(JSON.stringify(entry)) > this.#limits.maxLineBytes)
+		)
+			throw new Error("Lifecycle ledger compaction exceeds configured bounds.");
+		const temporary = path.join(
+			path.dirname(this.#file),
+			`.lifecycle-ledger.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`,
+		);
+		let renamed = false;
+		try {
+			const h = await fs.open(temporary, "wx", 0o600);
+			try {
+				await h.writeFile(contents);
+				await h.sync();
+			} finally {
+				await h.close();
+			}
+			await fs.rename(temporary, this.#file);
+			renamed = true;
+			await this.#syncDirectory();
+			this.#entries = snapshot;
+			this.#rowCount = snapshot.length;
+			this.#byteCount = contents.length;
+		} finally {
+			if (!renamed) await fs.unlink(temporary).catch(() => {});
+		}
+	}
 	get warnings(): readonly string[] {
 		return this.#warnings;
 	}
 	async #append(entry: LifecycleLedgerEntry): Promise<LifecycleLedgerEntry> {
+		const line = Buffer.from(`${JSON.stringify(entry)}\n`);
+		if (line.length - 1 > this.#limits.maxLineBytes)
+			throw new Error("Lifecycle ledger row exceeds the maximum byte length.");
+		if (this.#rowCount + 1 > this.#limits.maxRows || this.#byteCount + line.length > this.#limits.maxBytes)
+			await this.#compact();
+		if (this.#rowCount + 1 > this.#limits.maxRows || this.#byteCount + line.length > this.#limits.maxBytes)
+			throw new Error("Lifecycle ledger append exceeds configured bounds.");
 		const h = await fs.open(this.#file, "a", 0o600);
 		try {
-			await h.writeFile(`${JSON.stringify(entry)}\n`);
+			await h.writeFile(line);
 			await h.sync();
 		} finally {
 			await h.close();
 		}
 		this.#entries.push(entry);
 		this.#byIdentity.set(entry.identity, entry);
+		this.#rowCount += 1;
+		this.#byteCount += line.length;
 		return entry;
 	}
 	async begin(identity: string, requestHash: string): Promise<BeginResult> {
@@ -343,7 +488,6 @@ export class LifecycleLedger {
 		}
 		return this.#append(next);
 	}
-
 	async assertSupportedStateVersions(): Promise<void> {
 		const source = await this.#readBoundedSource();
 		if (!source) return;
@@ -352,7 +496,7 @@ export class LifecycleLedger {
 			if (offset !== source.length && source[offset] !== 0x0a) continue;
 			const line = source.subarray(lineStart, offset);
 			lineStart = offset + 1;
-			if (line.length === 0 || line.length > MAX_LIFECYCLE_LEDGER_LINE_BYTES) continue;
+			if (line.length === 0 || line.length > this.#limits.maxLineBytes) continue;
 			try {
 				assertSupportedStateVersion(this.#file, parseLifecycleJson(line));
 			} catch (error) {
@@ -360,7 +504,6 @@ export class LifecycleLedger {
 			}
 		}
 	}
-
 	get(identity: string): LifecycleLedgerEntry | undefined {
 		return this.#byIdentity.get(identity);
 	}

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -170,6 +170,20 @@ export class LifecycleLedger {
 	#rowCount = 0;
 	#byteCount = 0;
 	#warnings: string[] = [];
+	#mutationTail: Promise<void> = Promise.resolve();
+
+	async #mutate<T>(operation: () => Promise<T>): Promise<T> {
+		const previous = this.#mutationTail;
+		const completion = Promise.withResolvers<void>();
+		this.#mutationTail = previous.then(() => completion.promise);
+		await previous;
+		try {
+			return await operation();
+		} finally {
+			completion.resolve();
+		}
+	}
+
 	constructor(agentDir: string, limits: LifecycleLedgerLimits = {}) {
 		this.#file = path.join(agentDir, "sdk", "lifecycle-ledger.jsonl");
 		this.#corruptFile = `${this.#file}.corrupt`;
@@ -180,6 +194,10 @@ export class LifecycleLedger {
 		};
 	}
 	async open(): Promise<this> {
+		return this.#mutate(async () => this.#open());
+	}
+
+	async #open(): Promise<this> {
 		await fs.mkdir(path.dirname(this.#file), { recursive: true, mode: 0o700 });
 		this.#entries = [];
 		this.#byIdentity.clear();
@@ -213,6 +231,7 @@ export class LifecycleLedger {
 					const prior = this.#byIdentity.get(entry.identity);
 					const invalidHistory =
 						invalidIdentities.has(entry.identity) ||
+						uncertainAfterCorruption.has(entry.identity) ||
 						!hasValidTerminalDigests(entry) ||
 						!this.#isValidHistoryContinuation(prior, entry);
 					if (invalidHistory) {
@@ -224,7 +243,6 @@ export class LifecycleLedger {
 					}
 					this.#entries.push(entry);
 					this.#byIdentity.set(entry.identity, entry);
-					uncertainAfterCorruption.delete(entry.identity);
 				} catch (error) {
 					if (error instanceof Error && "code" in error && error.code === "unsupported_state_version") throw error;
 					for (const [identity, latest] of this.#byIdentity) {
@@ -245,7 +263,7 @@ export class LifecycleLedger {
 		}
 		// Effects may have completed after the last durable marker; do not retry them after a restart.
 		for (const entry of [...this.#byIdentity.values()]) {
-			if (entry.state === "effect_started" || entry.state === "awaiting_ready")
+			if ((entry.state === "effect_started" && !this.#isCleanupPending(entry)) || entry.state === "awaiting_ready")
 				await this.#append(this.#uncertainFrom(entry));
 		}
 		return this;
@@ -310,6 +328,14 @@ export class LifecycleLedger {
 		if (previous.state === "accepted") return true;
 		return next.state === "effect_started" || next.state === "awaiting_ready" || final(next.state);
 	}
+	#isCleanupPending(entry: LifecycleLedgerEntry): boolean {
+		if (!entry.response || typeof entry.response !== "object") return false;
+		const response = entry.response as { ok?: unknown; error?: { code?: unknown; cleanup?: unknown } };
+		return (
+			response.ok === false && response.error?.code === "cleanup_pending" && response.error.cleanup !== undefined
+		);
+	}
+
 	#uncertainFrom(entry: LifecycleLedgerEntry, trusted = true): LifecycleLedgerEntry {
 		if (trusted) return { ...entry, state: "terminal_uncertain", ts: Date.now() };
 		return {
@@ -446,6 +472,10 @@ export class LifecycleLedger {
 		return entry;
 	}
 	async begin(identity: string, requestHash: string): Promise<BeginResult> {
+		return this.#mutate(async () => this.#begin(identity, requestHash));
+	}
+
+	async #begin(identity: string, requestHash: string): Promise<BeginResult> {
 		const prior = this.#byIdentity.get(identity);
 		if (!prior)
 			return {
@@ -459,7 +489,8 @@ export class LifecycleLedger {
 				}),
 			};
 		if (prior.requestHash !== requestHash) return { kind: "idempotency_conflict" };
-		if (terminal(prior.state)) return { kind: "replay", entry: prior };
+		if (terminal(prior.state) || (prior.state === "effect_started" && this.#isCleanupPending(prior)))
+			return { kind: "replay", entry: prior };
 		if (prior.state === "terminal_uncertain") return { kind: "terminal_uncertain", entry: prior };
 		// An accepted row has no durable side effect. Target serialization makes retrying it safe.
 		if (prior.state === "accepted") return { kind: "new", entry: prior };
@@ -470,23 +501,25 @@ export class LifecycleLedger {
 		state: LifecycleState,
 		fields: Omit<Partial<LifecycleLedgerEntry>, "identity" | "requestHash" | "state" | "ts"> = {},
 	): Promise<LifecycleLedgerEntry> {
-		const previous = this.#byIdentity.get(identity);
-		if (!previous) throw new Error("Unknown lifecycle identity");
-		const next = { ...previous, ...fields, state, ts: Date.now() };
-		if (
-			(terminal(state) || state === "terminal_uncertain") &&
-			next.response !== undefined &&
-			next.responseDigest === undefined
-		)
-			next.responseDigest = createHash("sha256").update(canonicalJson(next.response)).digest("hex");
-		if (next.durableEffects && next.durableEffects.digest === undefined) {
-			const { digest: _digest, ...body } = next.durableEffects;
-			next.durableEffects = {
-				...body,
-				digest: createHash("sha256").update(canonicalJson(body)).digest("hex"),
-			};
-		}
-		return this.#append(next);
+		return this.#mutate(async () => {
+			const previous = this.#byIdentity.get(identity);
+			if (!previous) throw new Error("Unknown lifecycle identity");
+			const next = { ...previous, ...fields, state, ts: Date.now() };
+			if (
+				(terminal(state) || state === "terminal_uncertain") &&
+				next.response !== undefined &&
+				next.responseDigest === undefined
+			)
+				next.responseDigest = createHash("sha256").update(canonicalJson(next.response)).digest("hex");
+			if (next.durableEffects && next.durableEffects.digest === undefined) {
+				const { digest: _digest, ...body } = next.durableEffects;
+				next.durableEffects = {
+					...body,
+					digest: createHash("sha256").update(canonicalJson(body)).digest("hex"),
+				};
+			}
+			return this.#append(next);
+		});
 	}
 	async assertSupportedStateVersions(): Promise<void> {
 		const source = await this.#readBoundedSource();

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -255,7 +255,8 @@ export class LifecycleLedger {
 		if (tornTail) await this.#sealTornTail();
 		for (const [identity, uncertain] of syntheticUncertain) {
 			this.#byIdentity.set(identity, uncertain);
-			await this.#append(uncertain);
+			if (this.#entries.some(entry => entry.identity === identity && entry.state === "accepted"))
+				await this.#append(uncertain);
 		}
 		for (const identity of uncertainAfterCorruption) {
 			const entry = this.#byIdentity.get(identity);
@@ -323,7 +324,7 @@ export class LifecycleLedger {
 	}
 
 	#isValidHistoryContinuation(previous: LifecycleLedgerEntry | undefined, next: LifecycleLedgerEntry): boolean {
-		if (!previous) return true;
+		if (!previous) return next.state === "accepted";
 		if (previous.requestHash !== next.requestHash || final(previous.state)) return false;
 		if (previous.state === "accepted") return true;
 		return next.state === "effect_started" || next.state === "awaiting_ready" || final(next.state);
@@ -386,8 +387,22 @@ export class LifecycleLedger {
 		await this.#quarantine(reason);
 		throw new Error(reason);
 	}
+	async #openAppendRegular(file: string): Promise<fs.FileHandle> {
+		const handle = await fs.open(
+			file,
+			fsSync.constants.O_WRONLY | fsSync.constants.O_APPEND | fsSync.constants.O_CREAT | fsSync.constants.O_NOFOLLOW,
+			0o600,
+		);
+		try {
+			if (!(await handle.stat()).isFile()) throw new Error("Lifecycle ledger write target is not a regular file.");
+			return handle;
+		} catch (error) {
+			await handle.close();
+			throw error;
+		}
+	}
 	async #sealTornTail(): Promise<void> {
-		const h = await fs.open(this.#file, "a", 0o600);
+		const h = await this.#openAppendRegular(this.#file);
 		try {
 			await h.writeFile("\n");
 			await h.sync();
@@ -397,7 +412,7 @@ export class LifecycleLedger {
 		}
 	}
 	async #quarantine(line: string | Uint8Array): Promise<void> {
-		const h = await fs.open(this.#corruptFile, "a", 0o600);
+		const h = await this.#openAppendRegular(this.#corruptFile);
 		try {
 			await h.writeFile(line);
 			await h.writeFile("\n");
@@ -415,8 +430,22 @@ export class LifecycleLedger {
 			await directory.close();
 		}
 	}
-	async #compact(): Promise<void> {
-		const snapshot = [...this.#byIdentity.values()];
+	async #compact(replacement?: LifecycleLedgerEntry): Promise<boolean> {
+		const anchors = new Map<string, LifecycleLedgerEntry>();
+		for (const entry of this.#entries) {
+			const latest = replacement?.identity === entry.identity ? replacement : this.#byIdentity.get(entry.identity);
+			if (entry.state === "accepted" && !anchors.has(entry.identity) && entry.requestHash === latest?.requestHash)
+				anchors.set(entry.identity, entry);
+		}
+		const snapshot: LifecycleLedgerEntry[] = [];
+		const compacted = new Map(this.#byIdentity);
+		if (replacement) compacted.set(replacement.identity, replacement);
+		for (const [identity, latest] of compacted) {
+			const anchor = anchors.get(identity);
+			if (!anchor) throw new Error("Lifecycle ledger compaction requires an accepted identity anchor.");
+			snapshot.push(anchor);
+			if (latest.state !== "accepted") snapshot.push(latest);
+		}
 		const contents = Buffer.from(snapshot.map(entry => `${JSON.stringify(entry)}\n`).join(""));
 		if (
 			snapshot.length > this.#limits.maxRows ||
@@ -430,7 +459,14 @@ export class LifecycleLedger {
 		);
 		let renamed = false;
 		try {
-			const h = await fs.open(temporary, "wx", 0o600);
+			const h = await fs.open(
+				temporary,
+				fsSync.constants.O_WRONLY |
+					fsSync.constants.O_CREAT |
+					fsSync.constants.O_EXCL |
+					fsSync.constants.O_NOFOLLOW,
+				0o600,
+			);
 			try {
 				await h.writeFile(contents);
 				await h.sync();
@@ -441,11 +477,13 @@ export class LifecycleLedger {
 			renamed = true;
 			await this.#syncDirectory();
 			this.#entries = snapshot;
+			this.#byIdentity = compacted;
 			this.#rowCount = snapshot.length;
 			this.#byteCount = contents.length;
 		} finally {
 			if (!renamed) await fs.unlink(temporary).catch(() => {});
 		}
+		return replacement !== undefined;
 	}
 	get warnings(): readonly string[] {
 		return this.#warnings;
@@ -454,11 +492,13 @@ export class LifecycleLedger {
 		const line = Buffer.from(`${JSON.stringify(entry)}\n`);
 		if (line.length - 1 > this.#limits.maxLineBytes)
 			throw new Error("Lifecycle ledger row exceeds the maximum byte length.");
+		let replacementCompacted = false;
 		if (this.#rowCount + 1 > this.#limits.maxRows || this.#byteCount + line.length > this.#limits.maxBytes)
-			await this.#compact();
+			replacementCompacted = await this.#compact(this.#byIdentity.has(entry.identity) ? entry : undefined);
+		if (replacementCompacted) return entry;
 		if (this.#rowCount + 1 > this.#limits.maxRows || this.#byteCount + line.length > this.#limits.maxBytes)
 			throw new Error("Lifecycle ledger append exceeds configured bounds.");
-		const h = await fs.open(this.#file, "a", 0o600);
+		const h = await this.#openAppendRegular(this.#file);
 		try {
 			await h.writeFile(line);
 			await h.sync();

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1091,26 +1091,33 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 		if (activeMarker) return undefined;
 		activeMarker = current.capture;
 	}
-	if (!activeMarker) return undefined;
-	let marker: unknown;
-	try {
-		marker = JSON.parse(activeMarker.bytes.toString("utf8"));
-	} catch {
-		return undefined;
-	}
-	if (!isEffectMarker(marker)) return undefined;
-
-	const ready = captureExactRegular(readyPath);
-	if (!ready) return undefined;
-	if (ready.kind === "present") {
-		let readyMarker: unknown;
+	if (!activeMarker && cleanup.metadataCompleted !== true) return undefined;
+	// A completed legacy marker can be absent; its exact ready sibling is then the remaining owner proof.
+	let marker: EffectMarker | undefined;
+	if (activeMarker) {
 		try {
-			readyMarker = JSON.parse(ready.capture.bytes.toString("utf8"));
+			const value: unknown = JSON.parse(activeMarker.bytes.toString("utf8"));
+			if (!isEffectMarker(value)) return undefined;
+			marker = value;
 		} catch {
 			return undefined;
 		}
-		if (!isEffectMarker(readyMarker) || !sameEffectMarker(marker, readyMarker)) return undefined;
 	}
+
+	const ready = captureExactRegular(readyPath);
+	if (!ready) return undefined;
+	let readyMarker: EffectMarker | undefined;
+	if (ready.kind === "present") {
+		try {
+			const value: unknown = JSON.parse(ready.capture.bytes.toString("utf8"));
+			if (!isEffectMarker(value)) return undefined;
+			readyMarker = value;
+		} catch {
+			return undefined;
+		}
+		if (marker && !sameEffectMarker(marker, readyMarker)) return undefined;
+	}
+	if (!marker && !readyMarker && cleanup.metadataCompleted !== true) return undefined;
 
 	return {
 		phase: "lifecycle",
@@ -1120,13 +1127,13 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 			{
 				path: metadataPath,
 				identity: serializeCleanupIdentity({
-					...activeMarker.identity,
-					size: Number(activeMarker.identity.size),
+					...(activeMarker?.identity ?? persistedIdentity),
+					size: Number((activeMarker?.identity ?? persistedIdentity).size),
 				}),
 				attempt: cleanup.metadataAttempt ?? 1,
 				plannedPath,
 				...(detachedPath ? { detachedPath } : {}),
-				...(cleanup.metadataCompleted === true ? { completed: true as const } : {}),
+				...(!activeMarker && cleanup.metadataCompleted === true ? { completed: true as const } : {}),
 			},
 			...(ready.kind === "present"
 				? [
@@ -2743,6 +2750,7 @@ async function executeLifecycleResponse(
 		const lifecycleMetadata: Array<{
 			metadataPath: string;
 			metadata: LifecycleFileCapture;
+			marker: EffectMarker;
 		}> = [];
 		for (const metadataPath of metadataPaths) {
 			if (fsSync.existsSync(metadataPath)) {
@@ -2765,8 +2773,13 @@ async function executeLifecycleResponse(
 			}
 			if (!isEffectMarker(marker) || (record && marker.pid !== record.pid) || !hasObservedProcessExit(marker.pid))
 				return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
-			lifecycleMetadata.push({ metadataPath, metadata });
+			lifecycleMetadata.push({ metadataPath, metadata, marker });
 		}
+		if (
+			lifecycleMetadata.length === metadataPaths.length &&
+			!sameEffectMarker(lifecycleMetadata[0].marker, lifecycleMetadata[1].marker)
+		)
+			return fail("terminal_uncertain", "Lifecycle metadata siblings do not share one owner marker.");
 		const metadataCleanup = lifecycleDeleteMetadataCleanupPlan(validated.metadataRoot, id, lifecycleMetadata);
 		if (metadataCleanup.lifecycleFiles?.length) {
 			await broker.ledger.transition(identity, "effect_started", {

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1024,54 +1024,38 @@ function validateLifecycleCleanupFile(root: string, id: string, file: LifecycleC
 	return cleanupIdentity(file.identity) !== undefined;
 }
 
-function metadataCleanupPlan(
+function lifecycleDeleteMetadataCleanupPlan(
 	metadataRoot: string,
 	id: string,
-	metadataPath: string,
-	identity: BrokerCleanupIdentity,
+	files: ReadonlyArray<{ metadataPath: string; metadata: LifecycleFileCapture }>,
 ): CleanupEvidence {
 	return {
-		phase: "metadata",
+		phase: "lifecycle",
 		sessionId: id,
 		metadataRoot,
-		metadataPath,
-		metadataIdentity: identity,
-		metadataAttempt: 1,
-		plannedMetadataPath: path.join(
-			path.dirname(metadataPath),
-			`.gjc-delete-${randomUUID()}-${path.basename(metadataPath)}`,
-		),
+		lifecycleFiles: files.map(({ metadataPath, metadata }) => ({
+			path: metadataPath,
+			identity: serializeCleanupIdentity({
+				dev: metadata.identity.dev,
+				ino: metadata.identity.ino,
+				size: Number(metadata.identity.size),
+				mtimeNs: metadata.identity.mtimeNs,
+				sha256: metadata.identity.sha256,
+			}),
+			attempt: 1,
+			plannedPath: path.join(
+				path.dirname(metadataPath),
+				`.gjc-delete-${randomUUID()}-${path.basename(metadataPath)}`,
+			),
+		})),
 	};
-}
-
-function isLifecycleMetadataPath(root: string, id: string, value: string): boolean {
-	const resolved = path.resolve(value);
-	return (
-		resolved === path.resolve(lifecycleMarkerPath(root, id)) ||
-		resolved === path.resolve(lifecycleReadyPath(root, id))
-	);
-}
-
-function validateMetadataCleanupPlan(cleanup: CleanupEvidence, id: string): boolean {
-	return (
-		cleanup.phase === "metadata" &&
-		typeof cleanup.metadataRoot === "string" &&
-		typeof cleanup.metadataPath === "string" &&
-		(cleanup.metadataAttempt === undefined ||
-			(Number.isSafeInteger(cleanup.metadataAttempt) && cleanup.metadataAttempt >= 1)) &&
-		typeof cleanup.plannedMetadataPath === "string" &&
-		isLifecycleMetadataPath(cleanup.metadataRoot, id, cleanup.metadataPath) &&
-		path.dirname(path.resolve(cleanup.plannedMetadataPath)) === path.dirname(path.resolve(cleanup.metadataPath)) &&
-		path.basename(cleanup.plannedMetadataPath).startsWith(".gjc-delete-") &&
-		(cleanup.detachedMetadataPath === undefined ||
-			path.dirname(path.resolve(cleanup.detachedMetadataPath)) === path.dirname(path.resolve(cleanup.metadataPath)))
-	);
 }
 
 async function reconcileLifecycleCleanup(
 	broker: Broker,
 	identity: string,
 	cleanup: CleanupEvidence,
+	completion: BrokerResponse = fail("spawn_failed", "No ready SDK endpoint remains available."),
 ): Promise<BrokerResponse> {
 	if (
 		cleanup.phase !== "lifecycle" ||
@@ -1178,7 +1162,7 @@ async function reconcileLifecycleCleanup(
 		lifecycleCleanupHooksForTest.get(broker)?.();
 	}
 	await syncDirectory(path.join(activeCleanup.metadataRoot!, "sdk"));
-	return fail("spawn_failed", "No ready SDK endpoint remains available.");
+	return completion;
 }
 
 async function readSessionLifecycleFailure(
@@ -2445,90 +2429,6 @@ async function executeLifecycleResponse(
 		if (record?.terminalUncertain)
 			return fail("terminal_uncertain", "Session ownership is uncertain and cannot be deleted safely.");
 		if (record?.live) return fail("live_session", "Refusing to delete a live session; close it first.");
-		if (cleanup?.phase === "metadata") {
-			const metadataIdentity = cleanupIdentity(cleanup.metadataIdentity);
-			if (!metadataIdentity || !validateMetadataCleanupPlan(cleanup, id))
-				return fail("terminal_uncertain", "Metadata cleanup replay lacks exact lifecycle metadata authority.");
-			const metadataCandidates = [
-				cleanup.metadataPath!,
-				cleanup.detachedMetadataPath,
-				cleanup.plannedMetadataPath!,
-			].filter(
-				(value, index, values): value is string => typeof value === "string" && values.indexOf(value) === index,
-			);
-			let activePath: string | undefined;
-			let marker: LifecycleFileCapture | undefined;
-			let foundUnauthorized = false;
-			for (const candidate of metadataCandidates) {
-				try {
-					const stat = fsSync.lstatSync(candidate);
-					if (stat.isSymbolicLink() || !stat.isFile()) {
-						foundUnauthorized = true;
-						continue;
-					}
-				} catch (error) {
-					if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
-					foundUnauthorized = true;
-					continue;
-				}
-				const current = captureLifecycleFile(candidate);
-				if (!current) {
-					foundUnauthorized = true;
-					continue;
-				}
-				if (
-					current.identity.dev === metadataIdentity.dev &&
-					current.identity.ino === metadataIdentity.ino &&
-					current.identity.size === BigInt(metadataIdentity.size) &&
-					current.identity.mtimeNs === metadataIdentity.mtimeNs &&
-					current.identity.sha256 === metadataIdentity.sha256 &&
-					!activePath
-				) {
-					activePath = candidate;
-					marker = current;
-				} else {
-					foundUnauthorized = true;
-				}
-			}
-			if (foundUnauthorized)
-				return fail("terminal_uncertain", "Lifecycle metadata marker changed before deferred cleanup.");
-			if (!marker || !activePath) {
-				const completedCleanup = { ...cleanup, metadataCompleted: true as const };
-				await broker.ledger.transition(identity, "effect_started", {
-					response: fail(
-						"cleanup_pending",
-						"Lifecycle metadata cleanup completion was durably reconciled.",
-						completedCleanup,
-					),
-				});
-				return { ok: true, result: { sessionId: id } };
-			}
-			let activeCleanup = cleanup;
-			if (cleanup.detachedMetadataPath || activePath === cleanup.plannedMetadataPath) {
-				activeCleanup = {
-					...cleanup,
-					detachedMetadataPath: activePath,
-					metadataAttempt: (cleanup.metadataAttempt ?? 1) + 1,
-					plannedMetadataPath: path.join(
-						path.dirname(cleanup.metadataPath!),
-						`.gjc-delete-${randomUUID()}-${path.basename(cleanup.metadataPath!)}`,
-					),
-				};
-				await broker.ledger.transition(identity, "effect_started", {
-					response: fail(
-						"cleanup_pending",
-						"Lifecycle metadata retry cleanup is preauthorized for durable reconciliation.",
-						activeCleanup,
-					),
-				});
-			}
-			const result = exactUnlinkLifecycleFile(activePath, marker.identity, activeCleanup.plannedMetadataPath!);
-			if (result.ok) return { ok: true, result: { sessionId: id } };
-			return fail("cleanup_pending", `Lifecycle metadata cleanup remains pending: ${result.code ?? "unknown"}`, {
-				...activeCleanup,
-				...(result.detachedPath ? { detachedMetadataPath: result.detachedPath } : {}),
-			});
-		}
 		const validated = await validateDeletePath(broker, input, id, record, cleanup);
 		if ("ok" in validated) return validated;
 		let cleanupTarget: VerifiedSessionDeleteTarget = {
@@ -2746,19 +2646,8 @@ async function executeLifecycleResponse(
 				return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
 			lifecycleMetadata.push({ metadataPath, metadata });
 		}
-		for (const { metadataPath, metadata } of lifecycleMetadata) {
-			const metadataCleanup = metadataCleanupPlan(
-				validated.metadataRoot,
-				id,
-				metadataPath,
-				serializeCleanupIdentity({
-					dev: metadata.identity.dev,
-					ino: metadata.identity.ino,
-					size: Number(metadata.identity.size),
-					mtimeNs: metadata.identity.mtimeNs,
-					sha256: metadata.identity.sha256,
-				}),
-			);
+		const metadataCleanup = lifecycleDeleteMetadataCleanupPlan(validated.metadataRoot, id, lifecycleMetadata);
+		if (metadataCleanup.lifecycleFiles?.length) {
 			await broker.ledger.transition(identity, "effect_started", {
 				intendedSessionId: id,
 				response: fail(
@@ -2767,16 +2656,7 @@ async function executeLifecycleResponse(
 					metadataCleanup,
 				),
 			});
-			const result = exactUnlinkLifecycleFile(metadataPath, metadata.identity, metadataCleanup.plannedMetadataPath!);
-			if (!result.ok)
-				return fail(
-					"cleanup_pending",
-					`Saved session was deleted but lifecycle metadata cleanup is pending: ${result.code ?? "unknown"}`,
-					{
-						...metadataCleanup,
-						...(result.detachedPath ? { detachedMetadataPath: result.detachedPath } : {}),
-					},
-				);
+			return reconcileLifecycleCleanup(broker, identity, metadataCleanup, { ok: true, result: { sessionId: id } });
 		}
 		return { ok: true, result: { sessionId: id } };
 	}
@@ -2858,7 +2738,17 @@ export async function executeLifecycle(
 	identity: string,
 	cleanup?: CleanupEvidence,
 ): Promise<LifecycleExecutionOutcome> {
-	if (cleanup?.phase === "lifecycle") return { response: await reconcileLifecycleCleanup(broker, identity, cleanup) };
+	if (cleanup?.phase === "lifecycle")
+		return {
+			response: await reconcileLifecycleCleanup(
+				broker,
+				identity,
+				cleanup,
+				operation === "session.delete"
+					? { ok: true, result: { sessionId: cleanup.sessionId } }
+					: fail("spawn_failed", "No ready SDK endpoint remains available."),
+			),
+		};
 	const response = await executeLifecycleResponse(broker, operation, input, identity, cleanup);
 	const entry = broker.ledger.get(identity);
 	const priorDurableEffects = entry?.durableEffects;

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1007,17 +1007,86 @@ function lifecycleCleanupPlan(
 	return { phase: "lifecycle", sessionId: id, metadataRoot: root, lifecycleFiles: files };
 }
 
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isCanonicalLifecycleCleanupOriginal(root: string, id: string, original: string): boolean {
+	const directory = path.join(path.resolve(root), "sdk");
+	if (path.dirname(original) !== directory) return false;
+	const basename = path.basename(original);
+	return (
+		basename === `${id}.json` ||
+		basename === `${id}.lifecycle.json` ||
+		basename === `${id}.lifecycle.ready.json` ||
+		new RegExp(`^${escapeRegExp(id)}\\.lifecycle\\.failure\\.[A-Za-z0-9._-]{1,128}\\.json$`).test(basename)
+	);
+}
+
+function lifecycleCleanupHasMixedMetadataSchema(cleanup: CleanupEvidence): boolean {
+	return [
+		cleanup.metadataIdentity,
+		cleanup.metadataPath,
+		cleanup.metadataAttempt,
+		cleanup.plannedMetadataPath,
+		cleanup.detachedMetadataPath,
+		cleanup.metadataCompleted,
+	].some(value => value !== undefined);
+}
+
+function validateLifecycleCleanupShape(cleanup: CleanupEvidence): BrokerResponse | undefined {
+	const files = cleanup.lifecycleFiles;
+	if (
+		cleanup.phase !== "lifecycle" ||
+		!cleanup.sessionId ||
+		!isCanonicalSessionId(cleanup.sessionId) ||
+		!cleanup.metadataRoot ||
+		!Array.isArray(files) ||
+		files.length === 0 ||
+		files.length > 4 ||
+		lifecycleCleanupHasMixedMetadataSchema(cleanup) ||
+		(cleanup.lifecycleDeleteMetadata === true && files.length > 2)
+	)
+		return fail("terminal_uncertain", "Lifecycle cleanup replay lacks a complete unambiguous schema.");
+	const paths = new Set<string>();
+	for (const file of files) {
+		if (!validateLifecycleCleanupFile(cleanup.metadataRoot, cleanup.sessionId, file))
+			return fail("terminal_uncertain", "Lifecycle cleanup replay contains an invalid path authority.");
+		const entryPaths = new Map<string, "path" | "plannedPath" | "detachedPath">();
+		for (const [field, candidate] of [
+			["path", file.path],
+			["plannedPath", file.plannedPath],
+			["detachedPath", file.detachedPath],
+		] as const) {
+			if (candidate === undefined) continue;
+			const resolved = path.resolve(candidate);
+			const previousField = entryPaths.get(resolved);
+			if (previousField !== undefined) {
+				if (
+					(previousField === "plannedPath" && field === "detachedPath") ||
+					(previousField === "detachedPath" && field === "plannedPath")
+				)
+					continue;
+				return fail("terminal_uncertain", "Lifecycle cleanup replay contains duplicate path authority.");
+			}
+			entryPaths.set(resolved, field);
+			if (paths.has(resolved))
+				return fail("terminal_uncertain", "Lifecycle cleanup replay contains duplicate path authority.");
+			paths.add(resolved);
+		}
+	}
+	return undefined;
+}
+
 function validateLifecycleCleanupFile(root: string, id: string, file: LifecycleCleanupFile): boolean {
 	const directory = path.join(path.resolve(root), "sdk");
 	const original = path.resolve(file.path);
 	const planned = path.resolve(file.plannedPath);
 	if (
-		path.dirname(original) !== directory ||
+		!isCanonicalLifecycleCleanupOriginal(root, id, original) ||
 		path.dirname(planned) !== directory ||
 		!path.basename(planned).startsWith(".gjc-delete-") ||
 		(file.attempt !== undefined && (!Number.isSafeInteger(file.attempt) || file.attempt < 1)) ||
-		(![`${id}.json`, `${id}.lifecycle.json`, `${id}.lifecycle.ready.json`].includes(path.basename(original)) &&
-			!path.basename(original).startsWith(`${id}.lifecycle.failure.`)) ||
 		(file.detachedPath !== undefined && path.dirname(path.resolve(file.detachedPath)) !== directory)
 	)
 		return false;
@@ -1372,15 +1441,8 @@ async function reconcileLifecycleCleanup(
 	cleanup: CleanupEvidence,
 	completion: BrokerResponse = fail("spawn_failed", "No ready SDK endpoint remains available."),
 ): Promise<BrokerResponse> {
-	if (
-		cleanup.phase !== "lifecycle" ||
-		!cleanup.sessionId ||
-		!isCanonicalSessionId(cleanup.sessionId) ||
-		!cleanup.metadataRoot ||
-		!Array.isArray(cleanup.lifecycleFiles) ||
-		cleanup.lifecycleFiles.length === 0
-	)
-		return fail("terminal_uncertain", "Lifecycle cleanup replay lacks immutable identity-bound intent.");
+	const shapeValidation = validateLifecycleCleanupShape(cleanup);
+	if (shapeValidation) return shapeValidation;
 	let activeCleanup =
 		cleanup.lifecycleDeleteMetadata === true || completion.ok
 			? { ...cleanup, lifecycleDeleteMetadata: true as const }
@@ -3028,6 +3090,35 @@ async function exactCleanupProof(
 		: undefined;
 }
 
+function validateLifecycleDeleteMetadataBinding(
+	broker: Broker,
+	operation: string,
+	input: Input,
+	identity: string,
+	cleanup: CleanupEvidence,
+): BrokerResponse | undefined {
+	if (operation !== "session.delete")
+		return fail("terminal_uncertain", "Lifecycle delete metadata cleanup is not authorized for this operation.");
+	const requestedId = sessionId(input);
+	const cwd = lifecycleCwd(input);
+	const requestedRoot = stateRoot(input, cwd);
+	if (
+		!requestedId ||
+		!isCanonicalSessionId(requestedId) ||
+		!cwd ||
+		!requestedRoot ||
+		!hasDefaultStateRoot(cwd, requestedRoot) ||
+		cleanup.sessionId !== requestedId ||
+		!cleanup.metadataRoot ||
+		path.resolve(cleanup.metadataRoot) !== requestedRoot
+	)
+		return fail("terminal_uncertain", "Lifecycle delete metadata cleanup does not match the normalized request.");
+	const recordedRoot = broker.ledger.get(identity)?.effectIntent?.stateRoot;
+	if (recordedRoot && path.resolve(recordedRoot) !== requestedRoot)
+		return fail("terminal_uncertain", "Lifecycle delete metadata cleanup does not match the recorded workspace.");
+	return undefined;
+}
+
 export interface LifecycleExecutionOutcome {
 	response: BrokerResponse;
 	durableEffects?: LifecycleDurableEffectsReceipt;
@@ -3059,6 +3150,8 @@ export async function executeLifecycle(
 					"Legacy metadata cleanup replay lacks immutable identity-bound intent.",
 				),
 			};
+		const binding = validateLifecycleDeleteMetadataBinding(broker, operation, input, identity, migrated);
+		if (binding) return { response: binding };
 		await broker.ledger.transition(identity, "effect_started", {
 			response: fail(
 				"cleanup_pending",
@@ -3073,7 +3166,11 @@ export async function executeLifecycle(
 			}),
 		};
 	}
-	if (cleanup?.phase === "lifecycle")
+	if (cleanup?.phase === "lifecycle") {
+		if (cleanup.lifecycleDeleteMetadata === true || operation === "session.delete") {
+			const binding = validateLifecycleDeleteMetadataBinding(broker, operation, input, identity, cleanup);
+			if (binding) return { response: binding };
+		}
 		return {
 			response: await reconcileLifecycleCleanup(
 				broker,
@@ -3084,6 +3181,7 @@ export async function executeLifecycle(
 					: fail("spawn_failed", "No ready SDK endpoint remains available."),
 			),
 		};
+	}
 	const response = await executeLifecycleResponse(broker, operation, input, identity, cleanup);
 	const entry = broker.ledger.get(identity);
 	const priorDurableEffects = entry?.durableEffects;

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -30,7 +30,7 @@ import {
 } from "../session-directory";
 import type { SdkStartupFailure, SdkStartupRollbackResult } from "../startup-capability";
 import type { Broker, BrokerCleanupEvidence, BrokerCleanupIdentity, BrokerResponse } from "./broker";
-
+import { decodeLifecycleUtf8, parseLifecycleJson } from "./lifecycle-codec";
 import type {
 	LifecycleCleanupProof,
 	LifecycleDurableEffectsReceipt,
@@ -704,7 +704,7 @@ async function readEffectMarker(file: string): Promise<EffectMarker | undefined>
 	try {
 		const captured = captureLifecycleFile(file, true, true);
 		if (!captured) return undefined;
-		const marker: unknown = JSON.parse(captured.bytes.toString("utf8"));
+		const marker: unknown = parseLifecycleJson(captured.bytes);
 		return isExactEffectMarker(marker) ? marker : undefined;
 	} catch {
 		return undefined;
@@ -914,11 +914,11 @@ async function readLifecycleFailureArtifact(
 		const { bytesRead } = await handle.read(bytes, 0, bytes.length, 0);
 		if (bytesRead > 4096) return undefined;
 		const raw = bytes.subarray(0, bytesRead);
-		const value: unknown = JSON.parse(raw.toString("utf8"));
+		const value: unknown = parseLifecycleJson(raw);
 		if (
 			!isLifecycleFailureArtifact(value) ||
 			!sameEffectMarker(value, expected) ||
-			canonicalJson(value) !== raw.toString("utf8")
+			canonicalJson(value) !== decodeLifecycleUtf8(raw)
 		)
 			return undefined;
 		return {
@@ -987,7 +987,7 @@ function lifecycleCleanupPlan(
 		if (file === lifecycleMarkerPath(root, id) || file === lifecycleReadyPath(root, id)) {
 			let marker: unknown;
 			try {
-				marker = JSON.parse(captured.bytes.toString("utf8"));
+				marker = parseLifecycleJson(captured.bytes);
 			} catch {
 				throw new Error("Lifecycle marker changed before cleanup intent persistence.");
 			}
@@ -997,7 +997,7 @@ function lifecycleCleanupPlan(
 		if (file.endsWith(`${id}.json`)) {
 			let endpoint: { pid?: unknown };
 			try {
-				endpoint = JSON.parse(captured.bytes.toString("utf8")) as { pid?: unknown };
+				endpoint = parseLifecycleJson(captured.bytes) as { pid?: unknown };
 			} catch {
 				throw new Error("Lifecycle endpoint changed before cleanup intent persistence.");
 			}
@@ -1255,7 +1255,7 @@ function validateLifecycleMetadataReplay(cleanup: CleanupEvidence): BrokerRespon
 	if (!ready) return undefined;
 	let readyMarker: EffectMarker;
 	try {
-		const value: unknown = JSON.parse(ready.bytes.toString("utf8"));
+		const value: unknown = parseLifecycleJson(ready.bytes);
 		if (!isExactEffectMarker(value)) throw new Error("invalid ready marker");
 
 		readyMarker = value;
@@ -1273,7 +1273,7 @@ function validateLifecycleMetadataReplay(cleanup: CleanupEvidence): BrokerRespon
 		return undefined;
 	}
 	try {
-		const value: unknown = JSON.parse(marker.bytes.toString("utf8"));
+		const value: unknown = parseLifecycleJson(marker.bytes);
 		if (!isExactEffectMarker(value) || !sameEffectMarker(value, readyMarker)) throw new Error("mismatched marker");
 	} catch {
 		return fail("terminal_uncertain", "Lifecycle metadata siblings do not share one owner marker.");
@@ -1295,8 +1295,25 @@ function lifecycleMetadataReplayAbsent(cleanup: CleanupEvidence): boolean {
  * Base dev persisted metadata cleanup one file at a time. Accept only its
  * identity-bound marker receipt and translate it into the current replay plan.
  */
+function hasExactLegacyMetadataCleanupKeys(cleanup: CleanupEvidence): boolean {
+	if (typeof cleanup !== "object" || cleanup === null || Array.isArray(cleanup)) return false;
+	const allowed = new Set([
+		"phase",
+		"sessionId",
+		"metadataRoot",
+		"metadataIdentity",
+		"metadataPath",
+		"metadataAttempt",
+		"plannedMetadataPath",
+		"detachedMetadataPath",
+		"metadataCompleted",
+	]);
+	return Object.keys(cleanup as Record<string, unknown>).every(key => allowed.has(key));
+}
+
 function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | undefined {
 	if (
+		!hasExactLegacyMetadataCleanupKeys(cleanup) ||
 		cleanup.phase !== "metadata" ||
 		typeof cleanup.sessionId !== "string" ||
 		!isCanonicalSessionId(cleanup.sessionId) ||
@@ -1365,7 +1382,7 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 	let marker: EffectMarker | undefined;
 	if (activeMarker) {
 		try {
-			const value: unknown = JSON.parse(activeMarker.bytes.toString("utf8"));
+			const value: unknown = parseLifecycleJson(activeMarker.bytes);
 			if (!isExactEffectMarker(value)) return undefined;
 
 			marker = value;
@@ -1379,7 +1396,7 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 	let readyMarker: EffectMarker | undefined;
 	if (ready.kind === "present") {
 		try {
-			const value: unknown = JSON.parse(ready.capture.bytes.toString("utf8"));
+			const value: unknown = parseLifecycleJson(ready.capture.bytes);
 			if (!isExactEffectMarker(value)) return undefined;
 
 			readyMarker = value;
@@ -1480,7 +1497,7 @@ function preflightLifecycleDeleteMetadata(
 		if (!metadata) continue;
 		let marker: unknown;
 		try {
-			marker = JSON.parse(metadata.bytes.toString("utf8"));
+			marker = parseLifecycleJson(metadata.bytes);
 		} catch {
 			return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
 		}
@@ -1763,7 +1780,7 @@ async function removeOwnedLifecycleArtifacts(root: string, id: string, expected:
 	if (endpoint && endpointSource) {
 		let parsed: { pid?: unknown };
 		try {
-			parsed = JSON.parse(endpoint.bytes.toString("utf8")) as { pid?: unknown };
+			parsed = parseLifecycleJson(endpoint.bytes) as { pid?: unknown };
 		} catch {
 			return false;
 		}

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1092,7 +1092,7 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 		activeMarker = current.capture;
 	}
 	if (!activeMarker && cleanup.metadataCompleted !== true) return undefined;
-	// A completed legacy marker can be absent; its exact ready sibling is then the remaining owner proof.
+	// A completed legacy marker can be absent; bind its ready sibling to the persisted canonical marker digest.
 	let marker: EffectMarker | undefined;
 	if (activeMarker) {
 		try {
@@ -1116,6 +1116,12 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 			return undefined;
 		}
 		if (marker && !sameEffectMarker(marker, readyMarker)) return undefined;
+		if (
+			!marker &&
+			cleanup.metadataCompleted === true &&
+			createHash("sha256").update(canonicalJson(readyMarker)).digest("hex") !== persistedIdentity.sha256
+		)
+			return undefined;
 	}
 	if (!marker && !readyMarker && cleanup.metadataCompleted !== true) return undefined;
 

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1047,12 +1047,13 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 		return undefined;
 	const root = path.resolve(cleanup.metadataRoot);
 	const directory = path.join(root, "sdk");
-	const allowedPaths = [lifecycleMarkerPath(root, cleanup.sessionId), lifecycleReadyPath(root, cleanup.sessionId)];
+	const markerPath = lifecycleMarkerPath(root, cleanup.sessionId);
+	const readyPath = lifecycleReadyPath(root, cleanup.sessionId);
 	const metadataPath = path.resolve(cleanup.metadataPath);
 	const plannedPath = path.resolve(cleanup.plannedMetadataPath);
 	const detachedPath = cleanup.detachedMetadataPath && path.resolve(cleanup.detachedMetadataPath);
 	if (
-		!allowedPaths.includes(metadataPath) ||
+		metadataPath !== markerPath ||
 		path.dirname(plannedPath) !== directory ||
 		!path.basename(plannedPath).startsWith(".gjc-delete-") ||
 		(detachedPath !== undefined && path.dirname(detachedPath) !== directory) ||
@@ -1060,8 +1061,57 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 			(!Number.isSafeInteger(cleanup.metadataAttempt) || cleanup.metadataAttempt < 1))
 	)
 		return undefined;
-	const identity = cleanupIdentity(cleanup.metadataIdentity);
-	if (!identity) return undefined;
+	const persistedIdentity = cleanupIdentity(cleanup.metadataIdentity);
+	if (!persistedIdentity) return undefined;
+
+	const captureExactRegular = (
+		file: string,
+	): { kind: "absent" } | { kind: "present"; capture: LifecycleFileCapture } | undefined => {
+		try {
+			const stat = fsSync.lstatSync(file);
+			if (stat.isSymbolicLink() || !stat.isFile()) return undefined;
+			const capture = captureLifecycleFile(file, true);
+			return capture ? { kind: "present", capture } : undefined;
+		} catch (error) {
+			return (error as NodeJS.ErrnoException).code === "ENOENT" ? { kind: "absent" } : undefined;
+		}
+	};
+
+	const markerCandidates = [metadataPath, detachedPath, plannedPath].filter(
+		(candidate, index, candidates): candidate is string =>
+			typeof candidate === "string" && candidates.indexOf(candidate) === index,
+	);
+	let activeMarker: LifecycleFileCapture | undefined;
+	for (const candidate of markerCandidates) {
+		const current = captureExactRegular(candidate);
+		if (!current) return undefined;
+		if (current.kind === "absent") continue;
+		if (!sameLifecycleCleanupIdentity(current.capture.identity, serializeCleanupIdentity(persistedIdentity)))
+			return undefined;
+		if (activeMarker) return undefined;
+		activeMarker = current.capture;
+	}
+	if (!activeMarker) return undefined;
+	let marker: unknown;
+	try {
+		marker = JSON.parse(activeMarker.bytes.toString("utf8"));
+	} catch {
+		return undefined;
+	}
+	if (!isEffectMarker(marker)) return undefined;
+
+	const ready = captureExactRegular(readyPath);
+	if (!ready) return undefined;
+	if (ready.kind === "present") {
+		let readyMarker: unknown;
+		try {
+			readyMarker = JSON.parse(ready.capture.bytes.toString("utf8"));
+		} catch {
+			return undefined;
+		}
+		if (!isEffectMarker(readyMarker) || !sameEffectMarker(marker, readyMarker)) return undefined;
+	}
+
 	return {
 		phase: "lifecycle",
 		sessionId: cleanup.sessionId,
@@ -1069,12 +1119,28 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 		lifecycleFiles: [
 			{
 				path: metadataPath,
-				identity: serializeCleanupIdentity(identity),
+				identity: serializeCleanupIdentity({
+					...activeMarker.identity,
+					size: Number(activeMarker.identity.size),
+				}),
 				attempt: cleanup.metadataAttempt ?? 1,
 				plannedPath,
 				...(detachedPath ? { detachedPath } : {}),
 				...(cleanup.metadataCompleted === true ? { completed: true as const } : {}),
 			},
+			...(ready.kind === "present"
+				? [
+						{
+							path: readyPath,
+							identity: serializeCleanupIdentity({
+								...ready.capture.identity,
+								size: Number(ready.capture.identity.size),
+							}),
+							attempt: 1,
+							plannedPath: path.join(directory, `.gjc-delete-${randomUUID()}-${path.basename(readyPath)}`),
+						},
+					]
+				: []),
 		],
 	};
 }

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1480,6 +1480,7 @@ function preflightLifecycleDeleteMetadata(
 	root: string,
 	id: string,
 	record: { pid: number } | undefined,
+	readIncarnation: (pid: number) => string | undefined,
 ): LifecycleDeleteMetadataPreflight {
 	const metadataPaths = [lifecycleMarkerPath(root, id), lifecycleReadyPath(root, id)];
 	const lifecycleMetadata: Array<{
@@ -1501,7 +1502,11 @@ function preflightLifecycleDeleteMetadata(
 		} catch {
 			return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
 		}
-		if (!isExactEffectMarker(marker) || (record && marker.pid !== record.pid) || !hasObservedProcessExit(marker.pid))
+		if (
+			!isExactEffectMarker(marker) ||
+			(record && marker.pid !== record.pid) ||
+			observeProcess(marker.pid, marker.incarnation, readIncarnation) !== "exited"
+		)
 			return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
 		lifecycleMetadata.push({ metadataPath, metadata, marker });
 	}
@@ -2932,7 +2937,9 @@ async function executeLifecycleResponse(
 		if (record?.live) return fail("live_session", "Refusing to delete a live session; close it first.");
 		const validated = await validateDeletePath(broker, input, id, record, cleanup);
 		if ("ok" in validated) return validated;
-		const metadataPreflight = preflightLifecycleDeleteMetadata(validated.metadataRoot, id, record);
+		const metadataPreflight = preflightLifecycleDeleteMetadata(validated.metadataRoot, id, record, value =>
+			processIncarnationForBroker(broker, value),
+		);
 		if ("ok" in metadataPreflight) return metadataPreflight;
 		const metadataCleanup = metadataPreflight.cleanup;
 		let cleanupTarget: VerifiedSessionDeleteTarget = {

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1024,6 +1024,130 @@ function validateLifecycleCleanupFile(root: string, id: string, file: LifecycleC
 	return cleanupIdentity(file.identity) !== undefined;
 }
 
+function lifecycleCleanupCandidates(file: LifecycleCleanupFile): string[] {
+	return [file.path, file.detachedPath, file.plannedPath].filter(
+		(value, index, values): value is string => typeof value === "string" && values.indexOf(value) === index,
+	);
+}
+
+function lifecycleMetadataReplayFiles(cleanup: CleanupEvidence): LifecycleCleanupFile[] | undefined {
+	if (cleanup.lifecycleDeleteMetadata !== true) return undefined;
+	return cleanup.lifecycleFiles?.length ? cleanup.lifecycleFiles : undefined;
+}
+
+function absentLifecyclePath(file: string): boolean {
+	try {
+		fsSync.lstatSync(file);
+		return false;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "ENOENT";
+	}
+}
+
+function isLifecycleCleanupResponse(value: LifecycleFileCapture | BrokerResponse | undefined): value is BrokerResponse {
+	return typeof value === "object" && value !== null && "ok" in value;
+}
+
+function validateLifecycleMetadataReplay(cleanup: CleanupEvidence): BrokerResponse | undefined {
+	const files = lifecycleMetadataReplayFiles(cleanup);
+	if (!files) return undefined;
+	const root = path.resolve(cleanup.metadataRoot!);
+	const id = cleanup.sessionId!;
+	const markerPath = lifecycleMarkerPath(root, id);
+	const readyPath = lifecycleReadyPath(root, id);
+	const authorities = new Set<string>();
+	const candidates = new Set<string>();
+	for (const file of files) {
+		const authority = path.resolve(file.path);
+		if ((authority !== markerPath && authority !== readyPath) || authorities.has(authority))
+			return fail("terminal_uncertain", "Lifecycle metadata replay contains duplicate or non-canonical authority.");
+		authorities.add(authority);
+		for (const candidate of lifecycleCleanupCandidates(file)) {
+			const resolved = path.resolve(candidate);
+			if (candidates.has(resolved))
+				return fail("terminal_uncertain", "Lifecycle metadata replay contains duplicate candidate authority.");
+			candidates.add(resolved);
+		}
+	}
+	const markerEntry = files.find(file => path.resolve(file.path) === markerPath);
+	const readyEntry = files.find(file => path.resolve(file.path) === readyPath);
+	const capture = (file: string): LifecycleFileCapture | undefined | BrokerResponse => {
+		try {
+			return captureLifecycleFile(file, true);
+		} catch {
+			return fail("terminal_uncertain", "Lifecycle metadata sibling could not be safely inspected.");
+		}
+	};
+	const marker = capture(markerPath);
+	const ready = capture(readyPath);
+	if (isLifecycleCleanupResponse(marker)) return marker;
+	if (isLifecycleCleanupResponse(ready)) return ready;
+	if (marker && (!markerEntry || !sameLifecycleCleanupIdentity(marker.identity, markerEntry.identity)))
+		return fail("terminal_uncertain", "Lifecycle marker sibling lacks exact replay authority.");
+	if (ready && (!readyEntry || !sameLifecycleCleanupIdentity(ready.identity, readyEntry.identity)))
+		return fail("terminal_uncertain", "Lifecycle readiness sibling lacks exact replay authority.");
+	for (const file of files) {
+		let activeCandidates = 0;
+		for (const candidate of lifecycleCleanupCandidates(file)) {
+			let current: LifecycleFileCapture | undefined;
+			try {
+				current = captureLifecycleFile(candidate, true);
+			} catch {
+				return fail("terminal_uncertain", "Lifecycle metadata candidate could not be safely inspected.");
+			}
+			if (!current) continue;
+			if (!sameLifecycleCleanupIdentity(current.identity, file.identity))
+				return fail("terminal_uncertain", "Lifecycle metadata candidate lacks exact replay authority.");
+			activeCandidates++;
+		}
+		if (file.completed && activeCandidates > 0)
+			return fail(
+				"terminal_uncertain",
+				"Lifecycle cleanup receipt marks a metadata target complete while a candidate remains.",
+			);
+		if (!file.completed && activeCandidates > 1)
+			return fail("terminal_uncertain", "Lifecycle metadata replay has multiple active candidates.");
+	}
+	if (ready && !markerEntry)
+		return fail("terminal_uncertain", "Lifecycle readiness metadata lacks canonical marker authority.");
+	if (!ready) return undefined;
+	let readyMarker: EffectMarker;
+	try {
+		const value: unknown = JSON.parse(ready.bytes.toString("utf8"));
+		if (!isEffectMarker(value)) throw new Error("invalid ready marker");
+		readyMarker = value;
+	} catch {
+		return fail("terminal_uncertain", "Lifecycle readiness metadata ownership could not be verified.");
+	}
+	if (!markerEntry)
+		return fail("terminal_uncertain", "Lifecycle readiness metadata lacks canonical marker authority.");
+	if (!marker) {
+		if (createHash("sha256").update(canonicalJson(readyMarker)).digest("hex") !== markerEntry.identity.sha256)
+			return fail(
+				"terminal_uncertain",
+				"Lifecycle readiness metadata is not bound to the completed marker authority.",
+			);
+		return undefined;
+	}
+	try {
+		const value: unknown = JSON.parse(marker.bytes.toString("utf8"));
+		if (!isEffectMarker(value) || !sameEffectMarker(value, readyMarker)) throw new Error("mismatched marker");
+	} catch {
+		return fail("terminal_uncertain", "Lifecycle metadata siblings do not share one owner marker.");
+	}
+	return undefined;
+}
+
+function lifecycleMetadataReplayAbsent(cleanup: CleanupEvidence): boolean {
+	const files = lifecycleMetadataReplayFiles(cleanup);
+	if (!files) return true;
+	const root = path.resolve(cleanup.metadataRoot!);
+	const id = cleanup.sessionId!;
+	const required = new Set<string>([lifecycleMarkerPath(root, id), lifecycleReadyPath(root, id)]);
+	for (const file of files) for (const candidate of lifecycleCleanupCandidates(file)) required.add(candidate);
+	return [...required].every(absentLifecyclePath);
+}
+
 /**
  * Base dev persisted metadata cleanup one file at a time. Accept only its
  * identity-bound marker receipt and translate it into the current replay plan.
@@ -1129,6 +1253,7 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 		phase: "lifecycle",
 		sessionId: cleanup.sessionId,
 		metadataRoot: root,
+		lifecycleDeleteMetadata: true,
 		lifecycleFiles: [
 			{
 				path: metadataPath,
@@ -1167,6 +1292,7 @@ function lifecycleDeleteMetadataCleanupPlan(
 		phase: "lifecycle",
 		sessionId: id,
 		metadataRoot,
+		lifecycleDeleteMetadata: true,
 		lifecycleFiles: files.map(({ metadataPath, metadata }) => ({
 			path: metadataPath,
 			identity: serializeCleanupIdentity({
@@ -1255,15 +1381,17 @@ async function reconcileLifecycleCleanup(
 		cleanup.lifecycleFiles.length === 0
 	)
 		return fail("terminal_uncertain", "Lifecycle cleanup replay lacks immutable identity-bound intent.");
-	let activeCleanup = cleanup;
+	let activeCleanup =
+		cleanup.lifecycleDeleteMetadata === true || completion.ok
+			? { ...cleanup, lifecycleDeleteMetadata: true as const }
+			: cleanup;
+	const metadataReplayValidation = validateLifecycleMetadataReplay(activeCleanup);
+	if (metadataReplayValidation) return metadataReplayValidation;
 	for (let index = 0; index < activeCleanup.lifecycleFiles!.length; index++) {
 		const file = activeCleanup.lifecycleFiles![index];
 		if (!validateLifecycleCleanupFile(activeCleanup.metadataRoot!, activeCleanup.sessionId!, file))
 			return fail("terminal_uncertain", "Lifecycle cleanup replay contains an invalid path authority.");
-		const candidates = [file.path, file.detachedPath, file.plannedPath].filter(
-			(value, candidateIndex, values): value is string =>
-				typeof value === "string" && values.indexOf(value) === candidateIndex,
-		);
+		const candidates = lifecycleCleanupCandidates(file);
 		if (file.completed) {
 			for (const candidate of candidates) {
 				try {
@@ -1363,6 +1491,8 @@ async function reconcileLifecycleCleanup(
 		});
 		lifecycleCleanupHooksForTest.get(broker)?.();
 	}
+	if (!lifecycleMetadataReplayAbsent(activeCleanup))
+		return fail("terminal_uncertain", "Lifecycle metadata replay left an authorized sibling behind.");
 	await syncDirectory(path.join(activeCleanup.metadataRoot!, "sdk"));
 	return completion;
 }

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -59,6 +59,9 @@ const MAX_READY_TIMEOUT_MS = 60_000;
 const POLL_MS = 50;
 const CLOSE_TIMEOUT_MS = 2_000;
 const MAX_RECEIVED_AT_SKEW_MS = 5_000;
+const MAX_LIFECYCLE_METADATA_BYTES = 4096;
+const MAX_EFFECT_MARKER_LENGTH = 128;
+const MAX_PROCESS_INCARNATION_LENGTH = 256;
 
 export interface LifecycleDeadlines {
 	receivedAt: number;
@@ -671,15 +674,25 @@ function hasObservedProcessExit(pid: number): boolean {
 
 function isEffectMarker(value: unknown): value is EffectMarker {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-	const marker = value as Partial<EffectMarker>;
+	const marker = value as Record<string, unknown>;
 	return (
 		typeof marker.pid === "number" &&
 		Number.isSafeInteger(marker.pid) &&
 		marker.pid > 0 &&
 		typeof marker.effectMarker === "string" &&
-		marker.effectMarker.length > 0 &&
+		/^[A-Za-z0-9._-]+$/.test(marker.effectMarker) &&
+		marker.effectMarker.length <= MAX_EFFECT_MARKER_LENGTH &&
 		typeof marker.incarnation === "string" &&
-		marker.incarnation.length > 0
+		marker.incarnation.length > 0 &&
+		marker.incarnation.length <= MAX_PROCESS_INCARNATION_LENGTH
+	);
+}
+
+function isExactEffectMarker(value: unknown): value is EffectMarker {
+	return (
+		isEffectMarker(value) &&
+		Object.keys(value).length === 3 &&
+		Object.keys(value).every(key => key === "pid" || key === "effectMarker" || key === "incarnation")
 	);
 }
 
@@ -689,8 +702,10 @@ function sameEffectMarker(left: EffectMarker, right: EffectMarker): boolean {
 
 async function readEffectMarker(file: string): Promise<EffectMarker | undefined> {
 	try {
-		const marker: unknown = JSON.parse(await fs.readFile(file, "utf8"));
-		return isEffectMarker(marker) ? marker : undefined;
+		const captured = captureLifecycleFile(file, true, true);
+		if (!captured) return undefined;
+		const marker: unknown = JSON.parse(captured.bytes.toString("utf8"));
+		return isExactEffectMarker(marker) ? marker : undefined;
 	} catch {
 		return undefined;
 	}
@@ -962,7 +977,12 @@ function lifecycleCleanupPlan(
 		lifecycleMarkerPath(root, id),
 	];
 	const files: LifecycleCleanupFile[] = candidates.flatMap(file => {
-		const captured = captureLifecycleFile(file, true);
+		const captured = captureLifecycleFile(
+			file,
+			true,
+			file === lifecycleMarkerPath(root, id) || file === lifecycleReadyPath(root, id),
+		);
+
 		if (!captured) return [];
 		if (file === lifecycleMarkerPath(root, id) || file === lifecycleReadyPath(root, id)) {
 			let marker: unknown;
@@ -971,7 +991,7 @@ function lifecycleCleanupPlan(
 			} catch {
 				throw new Error("Lifecycle marker changed before cleanup intent persistence.");
 			}
-			if (!isEffectMarker(marker) || !sameEffectMarker(marker, expected))
+			if (!isExactEffectMarker(marker) || !sameEffectMarker(marker, expected))
 				throw new Error("Lifecycle marker changed before cleanup intent persistence.");
 		}
 		if (file.endsWith(`${id}.json`)) {
@@ -1034,23 +1054,77 @@ function lifecycleCleanupHasMixedMetadataSchema(cleanup: CleanupEvidence): boole
 	].some(value => value !== undefined);
 }
 
+function isCleanupIdentity(value: unknown): value is BrokerCleanupIdentity {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const identity = value as Record<string, unknown>;
+	return (
+		Object.keys(identity).length === 5 &&
+		Object.keys(identity).every(
+			key => key === "dev" || key === "ino" || key === "size" || key === "mtimeNs" || key === "sha256",
+		) &&
+		typeof identity.dev === "string" &&
+		/^\d+$/.test(identity.dev) &&
+		typeof identity.ino === "string" &&
+		/^\d+$/.test(identity.ino) &&
+		typeof identity.size === "number" &&
+		Number.isSafeInteger(identity.size) &&
+		identity.size >= 0 &&
+		typeof identity.mtimeNs === "string" &&
+		/^\d+$/.test(identity.mtimeNs) &&
+		typeof identity.sha256 === "string" &&
+		/^[a-f0-9]{64}$/.test(identity.sha256)
+	);
+}
+
+function isLifecycleCleanupFile(value: unknown): value is LifecycleCleanupFile {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const file = value as Record<string, unknown>;
+	const allowed = new Set(["path", "identity", "attempt", "plannedPath", "detachedPath", "completed"]);
+	return (
+		Object.keys(file).every(key => allowed.has(key)) &&
+		typeof file.path === "string" &&
+		file.path.length > 0 &&
+		typeof file.plannedPath === "string" &&
+		file.plannedPath.length > 0 &&
+		isCleanupIdentity(file.identity) &&
+		typeof file.attempt === "number" &&
+		Number.isSafeInteger(file.attempt) &&
+		file.attempt > 0 &&
+		(file.detachedPath === undefined || (typeof file.detachedPath === "string" && file.detachedPath.length > 0)) &&
+		(file.completed === undefined || file.completed === true)
+	);
+}
+
+function isLifecycleCleanupEvidence(cleanup: CleanupEvidence): boolean {
+	if (typeof cleanup !== "object" || cleanup === null || Array.isArray(cleanup)) return false;
+	const record = cleanup as Record<string, unknown>;
+	const allowed = new Set(["phase", "sessionId", "metadataRoot", "lifecycleDeleteMetadata", "lifecycleFiles"]);
+	return (
+		Object.keys(record).every(key => allowed.has(key)) &&
+		record.phase === "lifecycle" &&
+		typeof record.sessionId === "string" &&
+		isCanonicalSessionId(record.sessionId) &&
+		typeof record.metadataRoot === "string" &&
+		record.metadataRoot.length > 0 &&
+		Array.isArray(record.lifecycleFiles) &&
+		record.lifecycleFiles.length > 0 &&
+		record.lifecycleFiles.length <= 4 &&
+		(record.lifecycleDeleteMetadata === undefined || record.lifecycleDeleteMetadata === true) &&
+		record.lifecycleFiles.every(isLifecycleCleanupFile)
+	);
+}
+
 function validateLifecycleCleanupShape(cleanup: CleanupEvidence): BrokerResponse | undefined {
-	const files = cleanup.lifecycleFiles;
 	if (
-		cleanup.phase !== "lifecycle" ||
-		!cleanup.sessionId ||
-		!isCanonicalSessionId(cleanup.sessionId) ||
-		!cleanup.metadataRoot ||
-		!Array.isArray(files) ||
-		files.length === 0 ||
-		files.length > 4 ||
+		!isLifecycleCleanupEvidence(cleanup) ||
 		lifecycleCleanupHasMixedMetadataSchema(cleanup) ||
-		(cleanup.lifecycleDeleteMetadata === true && files.length > 2)
+		(cleanup.lifecycleDeleteMetadata === true && cleanup.lifecycleFiles!.length > 2)
 	)
 		return fail("terminal_uncertain", "Lifecycle cleanup replay lacks a complete unambiguous schema.");
+	const files = cleanup.lifecycleFiles!;
 	const paths = new Set<string>();
 	for (const file of files) {
-		if (!validateLifecycleCleanupFile(cleanup.metadataRoot, cleanup.sessionId, file))
+		if (!validateLifecycleCleanupFile(cleanup.metadataRoot!, cleanup.sessionId!, file))
 			return fail("terminal_uncertain", "Lifecycle cleanup replay contains an invalid path authority.");
 		const entryPaths = new Map<string, "path" | "plannedPath" | "detachedPath">();
 		for (const [field, candidate] of [
@@ -1086,11 +1160,10 @@ function validateLifecycleCleanupFile(root: string, id: string, file: LifecycleC
 		!isCanonicalLifecycleCleanupOriginal(root, id, original) ||
 		path.dirname(planned) !== directory ||
 		!path.basename(planned).startsWith(".gjc-delete-") ||
-		(file.attempt !== undefined && (!Number.isSafeInteger(file.attempt) || file.attempt < 1)) ||
 		(file.detachedPath !== undefined && path.dirname(path.resolve(file.detachedPath)) !== directory)
 	)
 		return false;
-	return cleanupIdentity(file.identity) !== undefined;
+	return isCleanupIdentity(file.identity);
 }
 
 function lifecycleCleanupCandidates(file: LifecycleCleanupFile): string[] {
@@ -1142,7 +1215,7 @@ function validateLifecycleMetadataReplay(cleanup: CleanupEvidence): BrokerRespon
 	const readyEntry = files.find(file => path.resolve(file.path) === readyPath);
 	const capture = (file: string): LifecycleFileCapture | undefined | BrokerResponse => {
 		try {
-			return captureLifecycleFile(file, true);
+			return captureLifecycleFile(file, true, true);
 		} catch {
 			return fail("terminal_uncertain", "Lifecycle metadata sibling could not be safely inspected.");
 		}
@@ -1160,7 +1233,7 @@ function validateLifecycleMetadataReplay(cleanup: CleanupEvidence): BrokerRespon
 		for (const candidate of lifecycleCleanupCandidates(file)) {
 			let current: LifecycleFileCapture | undefined;
 			try {
-				current = captureLifecycleFile(candidate, true);
+				current = captureLifecycleFile(candidate, true, true);
 			} catch {
 				return fail("terminal_uncertain", "Lifecycle metadata candidate could not be safely inspected.");
 			}
@@ -1183,7 +1256,8 @@ function validateLifecycleMetadataReplay(cleanup: CleanupEvidence): BrokerRespon
 	let readyMarker: EffectMarker;
 	try {
 		const value: unknown = JSON.parse(ready.bytes.toString("utf8"));
-		if (!isEffectMarker(value)) throw new Error("invalid ready marker");
+		if (!isExactEffectMarker(value)) throw new Error("invalid ready marker");
+
 		readyMarker = value;
 	} catch {
 		return fail("terminal_uncertain", "Lifecycle readiness metadata ownership could not be verified.");
@@ -1200,7 +1274,7 @@ function validateLifecycleMetadataReplay(cleanup: CleanupEvidence): BrokerRespon
 	}
 	try {
 		const value: unknown = JSON.parse(marker.bytes.toString("utf8"));
-		if (!isEffectMarker(value) || !sameEffectMarker(value, readyMarker)) throw new Error("mismatched marker");
+		if (!isExactEffectMarker(value) || !sameEffectMarker(value, readyMarker)) throw new Error("mismatched marker");
 	} catch {
 		return fail("terminal_uncertain", "Lifecycle metadata siblings do not share one owner marker.");
 	}
@@ -1263,7 +1337,8 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 		try {
 			const stat = fsSync.lstatSync(file);
 			if (stat.isSymbolicLink() || !stat.isFile()) return undefined;
-			const capture = captureLifecycleFile(file, true);
+			const capture = captureLifecycleFile(file, true, true);
+
 			return capture ? { kind: "present", capture } : undefined;
 		} catch (error) {
 			return (error as NodeJS.ErrnoException).code === "ENOENT" ? { kind: "absent" } : undefined;
@@ -1291,7 +1366,8 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 	if (activeMarker) {
 		try {
 			const value: unknown = JSON.parse(activeMarker.bytes.toString("utf8"));
-			if (!isEffectMarker(value)) return undefined;
+			if (!isExactEffectMarker(value)) return undefined;
+
 			marker = value;
 		} catch {
 			return undefined;
@@ -1304,7 +1380,8 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 	if (ready.kind === "present") {
 		try {
 			const value: unknown = JSON.parse(ready.capture.bytes.toString("utf8"));
-			if (!isEffectMarker(value)) return undefined;
+			if (!isExactEffectMarker(value)) return undefined;
+
 			readyMarker = value;
 		} catch {
 			return undefined;
@@ -1396,7 +1473,7 @@ function preflightLifecycleDeleteMetadata(
 	for (const metadataPath of metadataPaths) {
 		let metadata: LifecycleFileCapture | undefined;
 		try {
-			metadata = captureLifecycleFile(metadataPath, true);
+			metadata = captureLifecycleFile(metadataPath, true, true);
 		} catch {
 			return fail("terminal_uncertain", "Lifecycle metadata path is occupied by an unsafe object.");
 		}
@@ -1407,7 +1484,7 @@ function preflightLifecycleDeleteMetadata(
 		} catch {
 			return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
 		}
-		if (!isEffectMarker(marker) || (record && marker.pid !== record.pid) || !hasObservedProcessExit(marker.pid))
+		if (!isExactEffectMarker(marker) || (record && marker.pid !== record.pid) || !hasObservedProcessExit(marker.pid))
 			return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
 		lifecycleMetadata.push({ metadataPath, metadata, marker });
 	}
@@ -1480,7 +1557,8 @@ async function reconcileLifecycleCleanup(
 				foundUnauthorized = true;
 				continue;
 			}
-			const current = captureLifecycleFile(candidate);
+			const current = captureLifecycleFile(candidate, true, true);
+
 			if (!current) {
 				foundUnauthorized = true;
 				continue;
@@ -1604,13 +1682,29 @@ type LifecycleFileCapture = {
 	digest: string;
 };
 
-function captureLifecycleFile(file: string, requireRegular = false): LifecycleFileCapture | undefined {
+function captureLifecycleFile(file: string, requireRegular = false, bounded = false): LifecycleFileCapture | undefined {
 	let descriptor: number | undefined;
 	try {
+		const preflight = bounded ? fsSync.lstatSync(file, { bigint: true }) : undefined;
+		if (
+			preflight &&
+			(!preflight.isFile() || preflight.size === 0n || preflight.size > BigInt(MAX_LIFECYCLE_METADATA_BYTES))
+		) {
+			if (requireRegular) throw new Error("Lifecycle metadata is not a bounded regular file.");
+			return undefined;
+		}
 		descriptor = fsSync.openSync(file, fsSync.constants.O_RDONLY | fsSync.constants.O_NOFOLLOW);
 		const stat = fsSync.fstatSync(descriptor, { bigint: true });
-		if (!stat.isFile()) {
-			if (requireRegular) throw new Error("Lifecycle cleanup candidate is not an exact regular file.");
+		if (
+			!stat.isFile() ||
+			(bounded &&
+				(stat.size === 0n ||
+					stat.size > BigInt(MAX_LIFECYCLE_METADATA_BYTES) ||
+					!preflight ||
+					stat.dev !== preflight.dev ||
+					stat.ino !== preflight.ino))
+		) {
+			if (requireRegular) throw new Error("Lifecycle cleanup candidate is not an exact bounded regular file.");
 			return undefined;
 		}
 		const bytes = fsSync.readFileSync(descriptor);
@@ -1689,7 +1783,7 @@ async function removeOwnedLifecycleArtifacts(root: string, id: string, expected:
 	const currentMarker = await readEffectMarker(lifecycleMarkerPath(root, id));
 	if (!currentMarker || !sameEffectMarker(currentMarker, expected)) return false;
 	const readyPath = lifecycleReadyPath(root, id);
-	const ready = captureLifecycleFile(readyPath);
+	const ready = captureLifecycleFile(readyPath, true, true);
 	if (ready && createHash("sha256").update(ready.bytes).digest("hex") !== ready.digest) return false;
 	// Readiness mutation is deferred to the same ledger-backed cleanup transaction.
 	return true;
@@ -3163,6 +3257,8 @@ export async function executeLifecycle(
 		};
 	}
 	if (cleanup?.phase === "lifecycle") {
+		const shapeValidation = validateLifecycleCleanupShape(cleanup);
+		if (shapeValidation) return { response: shapeValidation };
 		if (cleanup.lifecycleDeleteMetadata === true || operation === "session.delete") {
 			const binding = validateLifecycleDeleteMetadataBinding(broker, operation, input, identity, cleanup);
 			if (binding) return { response: binding };

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1044,6 +1044,14 @@ function metadataCleanupPlan(
 	};
 }
 
+function isLifecycleMetadataPath(root: string, id: string, value: string): boolean {
+	const resolved = path.resolve(value);
+	return (
+		resolved === path.resolve(lifecycleMarkerPath(root, id)) ||
+		resolved === path.resolve(lifecycleReadyPath(root, id))
+	);
+}
+
 function validateMetadataCleanupPlan(cleanup: CleanupEvidence, id: string): boolean {
 	return (
 		cleanup.phase === "metadata" &&
@@ -1052,7 +1060,7 @@ function validateMetadataCleanupPlan(cleanup: CleanupEvidence, id: string): bool
 		(cleanup.metadataAttempt === undefined ||
 			(Number.isSafeInteger(cleanup.metadataAttempt) && cleanup.metadataAttempt >= 1)) &&
 		typeof cleanup.plannedMetadataPath === "string" &&
-		path.resolve(cleanup.metadataPath) === path.resolve(lifecycleMarkerPath(cleanup.metadataRoot, id)) &&
+		isLifecycleMetadataPath(cleanup.metadataRoot, id, cleanup.metadataPath) &&
 		path.dirname(path.resolve(cleanup.plannedMetadataPath)) === path.dirname(path.resolve(cleanup.metadataPath)) &&
 		path.basename(cleanup.plannedMetadataPath).startsWith(".gjc-delete-") &&
 		(cleanup.detachedMetadataPath === undefined ||
@@ -1216,16 +1224,13 @@ async function hasOwnedReadinessEvidence(
 	);
 }
 
-function captureLifecycleFile(
-	file: string,
-	requireRegular = false,
-):
-	| {
-			bytes: Buffer;
-			identity: { dev: bigint; ino: bigint; size: bigint; mtimeNs: bigint; sha256: string };
-			digest: string;
-	  }
-	| undefined {
+type LifecycleFileCapture = {
+	bytes: Buffer;
+	identity: { dev: bigint; ino: bigint; size: bigint; mtimeNs: bigint; sha256: string };
+	digest: string;
+};
+
+function captureLifecycleFile(file: string, requireRegular = false): LifecycleFileCapture | undefined {
 	let descriptor: number | undefined;
 	try {
 		descriptor = fsSync.openSync(file, fsSync.constants.O_RDONLY | fsSync.constants.O_NOFOLLOW);
@@ -2443,7 +2448,7 @@ async function executeLifecycleResponse(
 		if (cleanup?.phase === "metadata") {
 			const metadataIdentity = cleanupIdentity(cleanup.metadataIdentity);
 			if (!metadataIdentity || !validateMetadataCleanupPlan(cleanup, id))
-				return fail("terminal_uncertain", "Metadata cleanup replay lacks an exact lifecycle marker authority.");
+				return fail("terminal_uncertain", "Metadata cleanup replay lacks exact lifecycle metadata authority.");
 			const metadataCandidates = [
 				cleanup.metadataPath!,
 				cleanup.detachedMetadataPath,
@@ -2452,7 +2457,7 @@ async function executeLifecycleResponse(
 				(value, index, values): value is string => typeof value === "string" && values.indexOf(value) === index,
 			);
 			let activePath: string | undefined;
-			let marker: ReturnType<typeof captureLifecycleFile>;
+			let marker: LifecycleFileCapture | undefined;
 			let foundUnauthorized = false;
 			for (const candidate of metadataCandidates) {
 				try {
@@ -2710,14 +2715,27 @@ async function executeLifecycleResponse(
 				endpointGeneration: record.endpointGeneration,
 				pid: record.pid,
 			});
-		const metadataPath = lifecycleMarkerPath(validated.metadataRoot, id);
-		if (fsSync.existsSync(metadataPath)) {
-			const stat = fsSync.lstatSync(metadataPath);
-			if (stat.isSymbolicLink() || !stat.isFile())
-				return fail("terminal_uncertain", "Lifecycle metadata path is occupied by an unsafe object.");
-		}
-		const metadata = captureLifecycleFile(metadataPath);
-		if (metadata) {
+		const metadataPaths = [
+			lifecycleMarkerPath(validated.metadataRoot, id),
+			lifecycleReadyPath(validated.metadataRoot, id),
+		];
+		const lifecycleMetadata: Array<{
+			metadataPath: string;
+			metadata: LifecycleFileCapture;
+		}> = [];
+		for (const metadataPath of metadataPaths) {
+			if (fsSync.existsSync(metadataPath)) {
+				const stat = fsSync.lstatSync(metadataPath);
+				if (stat.isSymbolicLink() || !stat.isFile())
+					return fail("terminal_uncertain", "Lifecycle metadata path is occupied by an unsafe object.");
+			}
+			let metadata: LifecycleFileCapture | undefined;
+			try {
+				metadata = captureLifecycleFile(metadataPath);
+			} catch {
+				return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
+			}
+			if (!metadata) continue;
 			let marker: unknown;
 			try {
 				marker = JSON.parse(metadata.bytes.toString("utf8"));
@@ -2726,6 +2744,9 @@ async function executeLifecycleResponse(
 			}
 			if (!isEffectMarker(marker) || (record && marker.pid !== record.pid) || !hasObservedProcessExit(marker.pid))
 				return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
+			lifecycleMetadata.push({ metadataPath, metadata });
+		}
+		for (const { metadataPath, metadata } of lifecycleMetadata) {
 			const metadataCleanup = metadataCleanupPlan(
 				validated.metadataRoot,
 				id,

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -2781,6 +2781,17 @@ async function executeLifecycleResponse(
 				return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
 			lifecycleMetadata.push({ metadataPath, metadata, marker });
 		}
+		const canonicalLifecycleMarker = lifecycleMetadata.find(
+			metadata => metadata.metadataPath === lifecycleMarkerPath(validated.metadataRoot, id),
+		);
+		const lifecycleReadyMarker = lifecycleMetadata.find(
+			metadata => metadata.metadataPath === lifecycleReadyPath(validated.metadataRoot, id),
+		);
+		if (lifecycleReadyMarker && !canonicalLifecycleMarker)
+			return fail(
+				"terminal_uncertain",
+				"Lifecycle readiness metadata lacks canonical marker authority for fresh cleanup.",
+			);
 		if (
 			lifecycleMetadata.length === metadataPaths.length &&
 			!sameEffectMarker(lifecycleMetadata[0].marker, lifecycleMetadata[1].marker)

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1024,6 +1024,61 @@ function validateLifecycleCleanupFile(root: string, id: string, file: LifecycleC
 	return cleanupIdentity(file.identity) !== undefined;
 }
 
+/**
+ * Base dev persisted metadata cleanup one file at a time. Accept only its
+ * identity-bound marker receipt and translate it into the current replay plan.
+ */
+function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | undefined {
+	if (
+		cleanup.phase !== "metadata" ||
+		typeof cleanup.sessionId !== "string" ||
+		!isCanonicalSessionId(cleanup.sessionId) ||
+		typeof cleanup.metadataRoot !== "string" ||
+		cleanup.metadataRoot.length === 0 ||
+		typeof cleanup.metadataPath !== "string" ||
+		cleanup.metadataPath.length === 0 ||
+		!cleanup.metadataIdentity ||
+		typeof cleanup.plannedMetadataPath !== "string" ||
+		cleanup.plannedMetadataPath.length === 0 ||
+		(cleanup.detachedMetadataPath !== undefined &&
+			(typeof cleanup.detachedMetadataPath !== "string" || cleanup.detachedMetadataPath.length === 0)) ||
+		(cleanup.metadataCompleted !== undefined && cleanup.metadataCompleted !== true)
+	)
+		return undefined;
+	const root = path.resolve(cleanup.metadataRoot);
+	const directory = path.join(root, "sdk");
+	const allowedPaths = [lifecycleMarkerPath(root, cleanup.sessionId), lifecycleReadyPath(root, cleanup.sessionId)];
+	const metadataPath = path.resolve(cleanup.metadataPath);
+	const plannedPath = path.resolve(cleanup.plannedMetadataPath);
+	const detachedPath = cleanup.detachedMetadataPath && path.resolve(cleanup.detachedMetadataPath);
+	if (
+		!allowedPaths.includes(metadataPath) ||
+		path.dirname(plannedPath) !== directory ||
+		!path.basename(plannedPath).startsWith(".gjc-delete-") ||
+		(detachedPath !== undefined && path.dirname(detachedPath) !== directory) ||
+		(cleanup.metadataAttempt !== undefined &&
+			(!Number.isSafeInteger(cleanup.metadataAttempt) || cleanup.metadataAttempt < 1))
+	)
+		return undefined;
+	const identity = cleanupIdentity(cleanup.metadataIdentity);
+	if (!identity) return undefined;
+	return {
+		phase: "lifecycle",
+		sessionId: cleanup.sessionId,
+		metadataRoot: root,
+		lifecycleFiles: [
+			{
+				path: metadataPath,
+				identity: serializeCleanupIdentity(identity),
+				attempt: cleanup.metadataAttempt ?? 1,
+				plannedPath,
+				...(detachedPath ? { detachedPath } : {}),
+				...(cleanup.metadataCompleted === true ? { completed: true as const } : {}),
+			},
+		],
+	};
+}
+
 function lifecycleDeleteMetadataCleanupPlan(
 	metadataRoot: string,
 	id: string,
@@ -2738,6 +2793,36 @@ export async function executeLifecycle(
 	identity: string,
 	cleanup?: CleanupEvidence,
 ): Promise<LifecycleExecutionOutcome> {
+	if (cleanup?.phase === "metadata") {
+		if (operation !== "session.delete")
+			return {
+				response: fail(
+					"terminal_uncertain",
+					"Legacy metadata cleanup is not authorized for this lifecycle operation.",
+				),
+			};
+		const migrated = legacyMetadataCleanupPlan(cleanup);
+		if (!migrated)
+			return {
+				response: fail(
+					"terminal_uncertain",
+					"Legacy metadata cleanup replay lacks immutable identity-bound intent.",
+				),
+			};
+		await broker.ledger.transition(identity, "effect_started", {
+			response: fail(
+				"cleanup_pending",
+				"Legacy lifecycle metadata cleanup is preauthorized for durable reconciliation.",
+				migrated,
+			),
+		});
+		return {
+			response: await reconcileLifecycleCleanup(broker, identity, migrated, {
+				ok: true,
+				result: { sessionId: migrated.sessionId },
+			}),
+		};
+	}
 	if (cleanup?.phase === "lifecycle")
 		return {
 			response: await reconcileLifecycleCleanup(

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1284,8 +1284,9 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 		if (activeMarker) return undefined;
 		activeMarker = current.capture;
 	}
-	if (!activeMarker && cleanup.metadataCompleted !== true) return undefined;
-	// A completed legacy marker can be absent; bind its ready sibling to the persisted canonical marker digest.
+	const markerCompleted = !activeMarker;
+	// Legacy receipts can crash after exact marker unlink and before recording metadataCompleted.
+	// With every authorized marker candidate absent, only the persisted marker digest may bind a ready sibling.
 	let marker: EffectMarker | undefined;
 	if (activeMarker) {
 		try {
@@ -1309,14 +1310,9 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 			return undefined;
 		}
 		if (marker && !sameEffectMarker(marker, readyMarker)) return undefined;
-		if (
-			!marker &&
-			cleanup.metadataCompleted === true &&
-			createHash("sha256").update(canonicalJson(readyMarker)).digest("hex") !== persistedIdentity.sha256
-		)
+		if (!marker && createHash("sha256").update(canonicalJson(readyMarker)).digest("hex") !== persistedIdentity.sha256)
 			return undefined;
 	}
-	if (!marker && !readyMarker && cleanup.metadataCompleted !== true) return undefined;
 
 	return {
 		phase: "lifecycle",
@@ -1333,7 +1329,7 @@ function legacyMetadataCleanupPlan(cleanup: CleanupEvidence): CleanupEvidence | 
 				attempt: cleanup.metadataAttempt ?? 1,
 				plannedPath,
 				...(detachedPath ? { detachedPath } : {}),
-				...(!activeMarker && cleanup.metadataCompleted === true ? { completed: true as const } : {}),
+				...(markerCompleted ? { completed: true as const } : {}),
 			},
 			...(ready.kind === "present"
 				? [

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1185,6 +1185,61 @@ function lifecycleDeleteMetadataCleanupPlan(
 	};
 }
 
+type LifecycleDeleteMetadataPreflight = { cleanup: CleanupEvidence } | BrokerResponse;
+
+/**
+ * Capture lifecycle metadata before deleting any saved user data. A fresh delete
+ * may only clean metadata owned by one dead lifecycle process.
+ */
+function preflightLifecycleDeleteMetadata(
+	root: string,
+	id: string,
+	record: { pid: number } | undefined,
+): LifecycleDeleteMetadataPreflight {
+	const metadataPaths = [lifecycleMarkerPath(root, id), lifecycleReadyPath(root, id)];
+	const lifecycleMetadata: Array<{
+		metadataPath: string;
+		metadata: LifecycleFileCapture;
+		marker: EffectMarker;
+	}> = [];
+	for (const metadataPath of metadataPaths) {
+		let metadata: LifecycleFileCapture | undefined;
+		try {
+			metadata = captureLifecycleFile(metadataPath, true);
+		} catch {
+			return fail("terminal_uncertain", "Lifecycle metadata path is occupied by an unsafe object.");
+		}
+		if (!metadata) continue;
+		let marker: unknown;
+		try {
+			marker = JSON.parse(metadata.bytes.toString("utf8"));
+		} catch {
+			return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
+		}
+		if (!isEffectMarker(marker) || (record && marker.pid !== record.pid) || !hasObservedProcessExit(marker.pid))
+			return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
+		lifecycleMetadata.push({ metadataPath, metadata, marker });
+	}
+	const canonicalLifecycleMarker = lifecycleMetadata.find(
+		metadata => metadata.metadataPath === lifecycleMarkerPath(root, id),
+	);
+	const lifecycleReadyMarker = lifecycleMetadata.find(
+		metadata => metadata.metadataPath === lifecycleReadyPath(root, id),
+	);
+	if (lifecycleReadyMarker && !canonicalLifecycleMarker)
+		return fail(
+			"terminal_uncertain",
+			"Lifecycle readiness metadata lacks canonical marker authority for fresh cleanup.",
+		);
+	if (
+		canonicalLifecycleMarker &&
+		lifecycleReadyMarker &&
+		!sameEffectMarker(canonicalLifecycleMarker.marker, lifecycleReadyMarker.marker)
+	)
+		return fail("terminal_uncertain", "Lifecycle metadata siblings do not share one owner marker.");
+	return { cleanup: lifecycleDeleteMetadataCleanupPlan(root, id, lifecycleMetadata) };
+}
+
 async function reconcileLifecycleCleanup(
 	broker: Broker,
 	identity: string,
@@ -1205,12 +1260,25 @@ async function reconcileLifecycleCleanup(
 		const file = activeCleanup.lifecycleFiles![index];
 		if (!validateLifecycleCleanupFile(activeCleanup.metadataRoot!, activeCleanup.sessionId!, file))
 			return fail("terminal_uncertain", "Lifecycle cleanup replay contains an invalid path authority.");
-		if (file.completed) continue;
-
 		const candidates = [file.path, file.detachedPath, file.plannedPath].filter(
 			(value, candidateIndex, values): value is string =>
 				typeof value === "string" && values.indexOf(value) === candidateIndex,
 		);
+		if (file.completed) {
+			for (const candidate of candidates) {
+				try {
+					fsSync.lstatSync(candidate);
+					return fail(
+						"terminal_uncertain",
+						"Lifecycle cleanup receipt marks a target complete while an authorized candidate remains.",
+					);
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code !== "ENOENT")
+						return fail("terminal_uncertain", "Lifecycle cleanup completion could not be safely inspected.");
+				}
+			}
+			continue;
+		}
 		let activePath: string | undefined;
 		let captured: ReturnType<typeof captureLifecycleFile>;
 		let foundUnauthorized = false;
@@ -2565,6 +2633,9 @@ async function executeLifecycleResponse(
 		if (record?.live) return fail("live_session", "Refusing to delete a live session; close it first.");
 		const validated = await validateDeletePath(broker, input, id, record, cleanup);
 		if ("ok" in validated) return validated;
+		const metadataPreflight = preflightLifecycleDeleteMetadata(validated.metadataRoot, id, record);
+		if ("ok" in metadataPreflight) return metadataPreflight;
+		const metadataCleanup = metadataPreflight.cleanup;
 		let cleanupTarget: VerifiedSessionDeleteTarget = {
 			...validated.target,
 			...(validated.target.plannedArtifactsPath &&
@@ -2741,63 +2812,7 @@ async function executeLifecycleResponse(
 				},
 			);
 
-		if (record)
-			await broker.index.append({
-				type: "session_closed",
-				sessionId: id,
-				locator: record.locator,
-				endpointGeneration: record.endpointGeneration,
-				pid: record.pid,
-			});
-		const metadataPaths = [
-			lifecycleMarkerPath(validated.metadataRoot, id),
-			lifecycleReadyPath(validated.metadataRoot, id),
-		];
-		const lifecycleMetadata: Array<{
-			metadataPath: string;
-			metadata: LifecycleFileCapture;
-			marker: EffectMarker;
-		}> = [];
-		for (const metadataPath of metadataPaths) {
-			if (fsSync.existsSync(metadataPath)) {
-				const stat = fsSync.lstatSync(metadataPath);
-				if (stat.isSymbolicLink() || !stat.isFile())
-					return fail("terminal_uncertain", "Lifecycle metadata path is occupied by an unsafe object.");
-			}
-			let metadata: LifecycleFileCapture | undefined;
-			try {
-				metadata = captureLifecycleFile(metadataPath);
-			} catch {
-				return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
-			}
-			if (!metadata) continue;
-			let marker: unknown;
-			try {
-				marker = JSON.parse(metadata.bytes.toString("utf8"));
-			} catch {
-				return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
-			}
-			if (!isEffectMarker(marker) || (record && marker.pid !== record.pid) || !hasObservedProcessExit(marker.pid))
-				return fail("terminal_uncertain", "Lifecycle metadata ownership could not be verified.");
-			lifecycleMetadata.push({ metadataPath, metadata, marker });
-		}
-		const canonicalLifecycleMarker = lifecycleMetadata.find(
-			metadata => metadata.metadataPath === lifecycleMarkerPath(validated.metadataRoot, id),
-		);
-		const lifecycleReadyMarker = lifecycleMetadata.find(
-			metadata => metadata.metadataPath === lifecycleReadyPath(validated.metadataRoot, id),
-		);
-		if (lifecycleReadyMarker && !canonicalLifecycleMarker)
-			return fail(
-				"terminal_uncertain",
-				"Lifecycle readiness metadata lacks canonical marker authority for fresh cleanup.",
-			);
-		if (
-			lifecycleMetadata.length === metadataPaths.length &&
-			!sameEffectMarker(lifecycleMetadata[0].marker, lifecycleMetadata[1].marker)
-		)
-			return fail("terminal_uncertain", "Lifecycle metadata siblings do not share one owner marker.");
-		const metadataCleanup = lifecycleDeleteMetadataCleanupPlan(validated.metadataRoot, id, lifecycleMetadata);
+		const completion = { ok: true, result: { sessionId: id } } as const;
 		if (metadataCleanup.lifecycleFiles?.length) {
 			await broker.ledger.transition(identity, "effect_started", {
 				intendedSessionId: id,
@@ -2807,9 +2822,18 @@ async function executeLifecycleResponse(
 					metadataCleanup,
 				),
 			});
-			return reconcileLifecycleCleanup(broker, identity, metadataCleanup, { ok: true, result: { sessionId: id } });
+			const reconciled = await reconcileLifecycleCleanup(broker, identity, metadataCleanup, completion);
+			if (!reconciled.ok) return reconciled;
 		}
-		return { ok: true, result: { sessionId: id } };
+		if (record)
+			await broker.index.append({
+				type: "session_closed",
+				sessionId: id,
+				locator: record.locator,
+				endpointGeneration: record.endpointGeneration,
+				pid: record.pid,
+			});
+		return completion;
 	}
 	return fail("invalid_input", "Unknown lifecycle operation.");
 }

--- a/packages/coding-agent/test/helpers/sdk-lifecycle-fixture.ts
+++ b/packages/coding-agent/test/helpers/sdk-lifecycle-fixture.ts
@@ -104,10 +104,16 @@ export async function createSharedLifecycleFixture(
 	const environment = createFixtureBrokerEnvironment(root, agentDir);
 	const started = await startFixtureBrokerWithLeaseForTest({ agentDir, env: environment });
 	const cleanup = createFixtureRootCleanup(root, agentDir, started.lease);
-	const workspaces = {
-		A: await managedWorkspace(root, agentDir, "A", sourceIds.A),
-		B: await managedWorkspace(root, agentDir, "B", sourceIds.B),
-	};
+	let workspaces: Record<"A" | "B", SharedLifecycleWorkspace>;
+	try {
+		workspaces = {
+			A: await managedWorkspace(root, agentDir, "A", sourceIds.A),
+			B: await managedWorkspace(root, agentDir, "B", sourceIds.B),
+		};
+	} catch (error) {
+		await cleanupFixtureRoot(cleanup);
+		throw error;
+	}
 	expect(workspaces.A.scope.directoryPath).not.toBe(workspaces.B.scope.directoryPath);
 	return {
 		root,

--- a/packages/coding-agent/test/helpers/sdk-lifecycle-fixture.ts
+++ b/packages/coding-agent/test/helpers/sdk-lifecycle-fixture.ts
@@ -235,7 +235,6 @@ export async function createLifecycleFixture(): Promise<LifecycleFixture> {
 	const agentDir = path.join(repo, ".gjc", "agent");
 	const stateRoot = path.join(repo, ".gjc", "state");
 	const environment = createFixtureBrokerEnvironment(repo, agentDir);
-	const fixtureSessionDir = SessionManager.getDefaultSessionDir(repo, agentDir);
 	const started = await startFixtureBrokerWithLeaseForTest({ agentDir, env: environment });
 	const cleanup = createFixtureRootCleanup(repo, agentDir, started.lease);
 	return {

--- a/packages/coding-agent/test/helpers/sdk-lifecycle-fixture.ts
+++ b/packages/coding-agent/test/helpers/sdk-lifecycle-fixture.ts
@@ -4,6 +4,11 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { startFixtureBrokerWithLeaseForTest } from "../../src/sdk/broker/ensure";
 import { SdkClient } from "../../src/sdk/client";
+import {
+	listManagedSessionCandidates,
+	type ManagedSessionScope,
+	resolveManagedSessionScope,
+} from "../../src/sdk/session-directory";
 import { SessionManager } from "../../src/session/session-manager";
 import { cleanupFixtureRoot, createFixtureBrokerEnvironment, createFixtureRootCleanup } from "./fixture-broker-cleanup";
 
@@ -21,6 +26,109 @@ export type LifecycleFixture = {
 	invokeScenario: (global: LifecycleGlobal) => Promise<void>;
 	cleanup: () => Promise<void>;
 };
+
+export type SharedLifecycleWorkspace = {
+	cwd: string;
+	stateRoot: string;
+	scope: ManagedSessionScope;
+	source: { id: string; path: string; bytes: Uint8Array };
+};
+
+export type SharedLifecycleFixture = {
+	root: string;
+	agentDir: string;
+	environment: NodeJS.ProcessEnv;
+	workspaces: Record<"A" | "B", SharedLifecycleWorkspace>;
+	createBarrier: () => () => Promise<void>;
+	cleanup: () => Promise<void>;
+};
+
+async function managedWorkspace(
+	root: string,
+	agentDir: string,
+	name: "A" | "B",
+	sessionId: string,
+): Promise<SharedLifecycleWorkspace> {
+	const cwd = path.join(root, `workspace-${name.toLowerCase()}`);
+	await fs.mkdir(cwd, { recursive: true });
+	const resolved = await resolveManagedSessionScope({ cwd, agentDir });
+	expect(resolved.kind).toBe("resolved");
+	if (resolved.kind !== "resolved") throw new Error(resolved.message);
+	const scopeDir = SessionManager.getDefaultSessionDir(cwd, agentDir);
+	expect(scopeDir).toBe(resolved.scope.directoryPath);
+	const previousRequestId = process.env.GJC_LIFECYCLE_REQUEST_ID;
+	const previousSessionId = process.env.GJC_SESSION_ID;
+	try {
+		// This is setup only: parallel ingress requests never inherit these variables.
+		process.env.GJC_LIFECYCLE_REQUEST_ID = `prepare-${name.toLowerCase()}-${sessionId}`;
+		process.env.GJC_SESSION_ID = sessionId;
+		const session = SessionManager.create(cwd, scopeDir);
+		await session.ensureOnDisk();
+		const sourcePath = session.getSessionFile();
+		if (!sourcePath) throw new Error("Product session API did not create a saved session path.");
+		expect(session.getSessionId()).toBe(sessionId);
+		expect(path.dirname(sourcePath)).toBe(resolved.scope.directoryPath);
+		await expect(
+			fs.access(path.join(resolved.scope.directoryPath, ".gjc-managed-session-scope.v2.json")),
+		).resolves.toBeNull();
+		const inventory = await listManagedSessionCandidates({ scope: resolved.scope });
+		expect(inventory.kind).toBe("complete");
+		if (inventory.kind !== "complete") throw new Error(inventory.message);
+		const candidates = inventory.owned.filter(
+			candidate => candidate.sessionId === sessionId && candidate.path === sourcePath,
+		);
+		expect(candidates).toHaveLength(1);
+		return {
+			cwd,
+			stateRoot: path.join(cwd, ".gjc", "state"),
+			scope: resolved.scope,
+			source: { id: sessionId, path: sourcePath, bytes: await fs.readFile(sourcePath) },
+		};
+	} finally {
+		if (previousRequestId === undefined) delete process.env.GJC_LIFECYCLE_REQUEST_ID;
+		else process.env.GJC_LIFECYCLE_REQUEST_ID = previousRequestId;
+		if (previousSessionId === undefined) delete process.env.GJC_SESSION_ID;
+		else process.env.GJC_SESSION_ID = previousSessionId;
+	}
+}
+
+/** Owns one external agent directory, broker lease, environment, and cleanup for two sibling workspaces. */
+export async function createSharedLifecycleFixture(
+	sourceIds: Record<"A" | "B", string> = {
+		A: "shared-a-source",
+		B: "shared-b-source",
+	},
+): Promise<SharedLifecycleFixture> {
+	const root = await fs.mkdtemp(path.join(tmpdir(), "gjc-sdk-shared-lifecycle-"));
+	const agentDir = path.join(root, "agent");
+	const environment = createFixtureBrokerEnvironment(root, agentDir);
+	const started = await startFixtureBrokerWithLeaseForTest({ agentDir, env: environment });
+	const cleanup = createFixtureRootCleanup(root, agentDir, started.lease);
+	const workspaces = {
+		A: await managedWorkspace(root, agentDir, "A", sourceIds.A),
+		B: await managedWorkspace(root, agentDir, "B", sourceIds.B),
+	};
+	expect(workspaces.A.scope.directoryPath).not.toBe(workspaces.B.scope.directoryPath);
+	return {
+		root,
+		agentDir,
+		environment,
+		workspaces,
+		createBarrier() {
+			let arrivals = 0;
+			const release = Promise.withResolvers<void>();
+			return async () => {
+				arrivals += 1;
+				if (arrivals > 2) throw new Error("Shared lifecycle barrier accepts exactly two requests.");
+				if (arrivals === 2) release.resolve();
+				await release.promise;
+			};
+		},
+		async cleanup() {
+			await cleanupFixtureRoot(cleanup);
+		},
+	};
+}
 
 async function eventually<T>(read: () => Promise<T | undefined>, description: string): Promise<T> {
 	const deadline = Date.now() + 20_000;
@@ -164,11 +272,29 @@ export async function createLifecycleFixture(): Promise<LifecycleFixture> {
 				createdClosed,
 			);
 
+			const resolved = await resolveManagedSessionScope({ cwd: repo, agentDir });
+			expect(resolved.kind).toBe("resolved");
+			if (resolved.kind !== "resolved") throw new Error(resolved.message);
+			const fixtureSessionDir = SessionManager.getDefaultSessionDir(repo, agentDir);
+			expect(fixtureSessionDir).toBe(resolved.scope.directoryPath);
 			const savedSession = SessionManager.create(repo, fixtureSessionDir);
 			await savedSession.ensureOnDisk();
 			const sourceId = savedSession.getSessionId();
 			const sourcePath = savedSession.getSessionFile();
 			if (!sourcePath) throw new Error("Product session API did not create a saved session path.");
+			expect(path.dirname(sourcePath)).toBe(resolved.scope.directoryPath);
+			await expect(
+				fs.access(path.join(resolved.scope.directoryPath, ".gjc-managed-session-scope.v2.json")),
+			).resolves.toBeNull();
+			const inventory = await listManagedSessionCandidates({ scope: resolved.scope });
+			expect(inventory.kind).toBe("complete");
+			if (inventory.kind !== "complete") throw new Error(inventory.message);
+			expect(inventory.scope.directoryPath).toBe(resolved.scope.directoryPath);
+			const sourceCandidates = inventory.owned.filter(
+				candidate => candidate.sessionId === sourceId && candidate.path === sourcePath,
+			);
+			expect(sourceCandidates).toHaveLength(1);
+			const sourceIdentity = sourceCandidates[0]!.identity;
 
 			const resumed = success(
 				await global(
@@ -249,14 +375,22 @@ export async function createLifecycleFixture(): Promise<LifecycleFixture> {
 					"fork-key",
 				),
 			).toMatchObject({ ok: false, error: { code: "idempotency_conflict" } });
-			const forkPath = await eventually(
-				async () =>
-					(await SessionManager.list(repo, fixtureSessionDir)).find(session => session.id === forkId)?.path,
-				`saved fork session ${forkId}`,
+			const forkPath = await eventually(async () => {
+				const candidates = await listManagedSessionCandidates({ scope: resolved.scope });
+				return candidates.kind === "complete"
+					? candidates.owned.find(session => session.sessionId === forkId)?.path
+					: undefined;
+			}, `saved fork session ${forkId}`);
+			expect(path.dirname(forkPath)).toBe(resolved.scope.directoryPath);
+			const forkInventory = await listManagedSessionCandidates({ scope: resolved.scope });
+			expect(forkInventory.kind).toBe("complete");
+			if (forkInventory.kind !== "complete") throw new Error(forkInventory.message);
+			const forkCandidates = forkInventory.owned.filter(
+				candidate => candidate.sessionId === forkId && candidate.path === forkPath,
 			);
-			const expectedSessionRoot = path.resolve(path.dirname(fixtureSessionDir));
-			if (!path.resolve(forkPath).startsWith(`${expectedSessionRoot}${path.sep}`))
-				throw new Error(`Fork persisted outside agent session root: ${forkPath}`);
+			expect(forkCandidates).toHaveLength(1);
+			expect(forkCandidates[0]!.identity.sessionId).toBe(forkId);
+			expect(sourceIdentity.sessionId).toBe(sourceId);
 			success(await global("session.close", { sessionId: forkId }, "close-fork-key"));
 			await assertClosed(agentDir, stateRoot, forkId, forkEndpoint);
 

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -21,6 +21,7 @@ import {
 	setProcessIncarnationForTest,
 	writeSessionLifecycleFailure,
 } from "../src/sdk/broker/lifecycle";
+import { parseLifecycleJson } from "../src/sdk/broker/lifecycle-codec";
 import { LifecycleLedger } from "../src/sdk/broker/lifecycle-ledger";
 import { SessionIndex } from "../src/sdk/broker/session-index";
 import { runSdkSessionCli } from "../src/sdk/cli";
@@ -135,6 +136,127 @@ test("ledger restart quarantines terminal response and durable-effect digest cor
 		);
 	} finally {
 		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("fatal lifecycle JSON decoding rejects malformed UTF-8 without mutating valid non-ASCII data", () => {
+	const valid = Buffer.from('{"message":"résumé"}', "utf8");
+	expect(parseLifecycleJson(valid)).toEqual({ message: "résumé" });
+	const malformed = Buffer.concat([Buffer.from('{"message":"ok'), Buffer.from([0xc3, 0x28]), Buffer.from('"}')]);
+	expect(() => parseLifecycleJson(malformed)).toThrow();
+	expect(valid.equals(Buffer.from('{"message":"résumé"}', "utf8"))).toBe(true);
+});
+
+test("ledger reopen bounds malformed persisted rows before they gain cleanup authority", async () => {
+	const agentDir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-bounds-"));
+	const ledgerPath = path.join(agentDir, "sdk", "lifecycle-ledger.jsonl");
+	const corruptPath = `${ledgerPath}.corrupt`;
+	const cleanupSentinel = path.join(agentDir, "cleanup-sentinel");
+	try {
+		const ledger = await new LifecycleLedger(agentDir).open();
+		await ledger.begin("safe", "request");
+		await fs.writeFile(cleanupSentinel, "preserve");
+		const validRow = JSON.parse((await fs.readFile(ledgerPath, "utf8")).trim()) as Record<string, unknown>;
+		const malformedUtf8 = Buffer.concat([
+			Buffer.from(`${JSON.stringify({ ...validRow, identity: "malformed" }).slice(0, -2)}"`),
+			Buffer.from([0xc3, 0x28]),
+			Buffer.from("}\n"),
+		]);
+		await fs.appendFile(ledgerPath, malformedUtf8);
+		const malformedBroker = new Broker({ agentDir });
+		await malformedBroker.start();
+		expect((await malformedBroker.ledger.begin("safe", "request")).kind).toBe("terminal_uncertain");
+		await malformedBroker.stop();
+		expect(await fs.readFile(cleanupSentinel, "utf8")).toBe("preserve");
+		expect((await fs.readFile(corruptPath)).includes(Buffer.from([0xc3, 0x28]))).toBe(true);
+
+		for (const [identity, response] of [
+			[
+				"deep",
+				{
+					nested: Array.from({ length: 66 }, () => ({ value: "x" })).reduce(
+						(value, _next) => ({ next: value }),
+						{},
+					),
+				},
+			],
+			[
+				"wide",
+				{ fields: Object.fromEntries(Array.from({ length: 1_025 }, (_, index) => [`field-${index}`, index])) },
+			],
+		] as const) {
+			await fs.appendFile(ledgerPath, `${JSON.stringify({ ...validRow, identity, response })}\n`);
+		}
+		const boundedBroker = new Broker({ agentDir });
+		await boundedBroker.start();
+		expect((await boundedBroker.ledger.begin("safe", "request")).kind).toBe("terminal_uncertain");
+		await boundedBroker.stop();
+		expect(await fs.readFile(cleanupSentinel, "utf8")).toBe("preserve");
+		const quarantined = await fs.readFile(corruptPath, "utf8");
+		expect(quarantined).toContain('"identity":"deep"');
+		expect(quarantined).toContain('"identity":"wide"');
+
+		const expectStartFailure = async (name: string, content: string, message: string) => {
+			const boundedAgentDir = path.join(agentDir, name);
+			const boundedLedgerPath = path.join(boundedAgentDir, "sdk", "lifecycle-ledger.jsonl");
+			await fs.mkdir(path.dirname(boundedLedgerPath), { recursive: true });
+			await fs.writeFile(boundedLedgerPath, content);
+			const broker = new Broker({ agentDir: boundedAgentDir });
+			try {
+				await expect(broker.start()).rejects.toThrow(message);
+			} finally {
+				await broker.stop();
+			}
+		};
+		await expectStartFailure("line-bound", "x".repeat(64 * 1024 + 1), "maximum byte length");
+		await expectStartFailure("row-bound", "{}\n".repeat(10_001), "maximum row count");
+		await expectStartFailure("file-bound", "x".repeat(8 * 1024 * 1024 + 1), "maximum file byte length");
+		expect(await fs.readFile(cleanupSentinel, "utf8")).toBe("preserve");
+	} finally {
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+}, 30_000);
+
+test("legacy metadata cleanup rejects mixed lifecycle and arbitrary receipt keys before mutation", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-legacy-metadata-allowlist-"));
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "legacy-allowlist";
+	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+	const marker = canonicalJson({ pid: process.pid, effectMarker: "legacy", incarnation: "legacy" });
+	try {
+		await fs.mkdir(path.dirname(markerPath), { recursive: true });
+		await fs.writeFile(markerPath, marker);
+		await fs.writeFile(readyPath, marker);
+		const [stat, bytes] = await Promise.all([fs.stat(markerPath, { bigint: true }), fs.readFile(markerPath)]);
+		const cleanup: BrokerCleanupEvidence = {
+			phase: "metadata",
+			sessionId,
+			metadataRoot: stateRoot,
+			metadataPath: markerPath,
+			metadataIdentity: {
+				dev: stat.dev.toString(),
+				ino: stat.ino.toString(),
+				size: Number(stat.size),
+				mtimeNs: stat.mtimeNs.toString(),
+				sha256: createHash("sha256").update(bytes).digest("hex"),
+			},
+			plannedMetadataPath: path.join(stateRoot, "sdk", `.gjc-delete-${sessionId}.lifecycle.json`),
+		};
+		for (const extra of [{ lifecycleFiles: [] }, { lifecycleDeleteMetadata: true }, { arbitrary: true }]) {
+			const outcome = await executeLifecycle(
+				new Broker({ agentDir: path.join(root, "agent") }),
+				"session.delete",
+				{},
+				"legacy-allowlist",
+				{ ...cleanup, ...extra } as BrokerCleanupEvidence,
+			);
+			expect(outcome.response).toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+			expect(await fs.readFile(markerPath, "utf8")).toBe(marker);
+			expect(await fs.readFile(readyPath, "utf8")).toBe(marker);
+		}
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
 	}
 });
 

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -7,11 +7,12 @@ import { NotificationServer } from "@gajae-code/natives";
 import { openLifecycleSessionManager, runSessionHost } from "../src/commands/sdk";
 import { planLaunchWorktree } from "../src/gjc-runtime/launch-worktree";
 import { AcpAgent } from "../src/modes/acp/acp-agent";
-import { Broker, type BrokerResponse } from "../src/sdk/broker/broker";
+import { Broker, type BrokerCleanupEvidence, type BrokerResponse } from "../src/sdk/broker/broker";
 import { brokerOwnerForTest } from "../src/sdk/broker/ensure";
 import { deriveIdempotencyIdentity } from "../src/sdk/broker/identity";
 import {
 	deriveLifecycleDeadlines,
+	executeLifecycle,
 	hasValidLifecycleDeadlines,
 	parseDarwinProcessIncarnation,
 	processIncarnation,
@@ -1270,7 +1271,7 @@ test("broker replays a completed base metadata cleanup receipt and rejects a rep
 	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
 	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
 	const plannedPath = path.join(stateRoot, "sdk", `.gjc-delete-base-${sessionId}.lifecycle.json`);
-	const request = { sessionId };
+	const request = { cwd: root, stateRoot, sessionId };
 	const key = "base-metadata-cleanup-replay";
 	let broker: Broker | undefined;
 	try {
@@ -1443,7 +1444,7 @@ test("broker rejects a corrupt completed lifecycle cleanup receipt when its read
 	const sessionId = "completed-lifecycle-replay";
 	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
 	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
-	const request = { sessionId };
+	const request = { cwd: root, stateRoot, sessionId };
 	const key = "completed-lifecycle-replay";
 	let broker: Broker | undefined;
 	try {
@@ -1461,7 +1462,7 @@ test("broker rejects a corrupt completed lifecycle cleanup receipt when its read
 			fs.readFile(markerPath),
 			fs.readFile(readyPath),
 		]);
-		const target = createHash("sha256").update(canonicalJson(request)).digest("hex");
+		const target = createHash("sha256").update(canonicalJson({ sessionId })).digest("hex");
 		const identity = await deriveIdempotencyIdentity(agentDir, "session.delete", key, target);
 		const requestHash = createHash("sha256")
 			.update(canonicalJson({ operation: "session.delete", input: request }))
@@ -1523,7 +1524,7 @@ test("broker rejects duplicate lifecycle marker replay authorities without unlin
 	const sessionId = "duplicate-lifecycle-replay";
 	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
 	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
-	const request = { sessionId };
+	const request = { cwd: root, stateRoot, sessionId };
 	const key = "duplicate-lifecycle-replay";
 	let broker: Broker | undefined;
 	try {
@@ -1540,7 +1541,7 @@ test("broker rejects duplicate lifecycle marker replay authorities without unlin
 			agentDir,
 			"session.delete",
 			key,
-			createHash("sha256").update(canonicalJson(request)).digest("hex"),
+			createHash("sha256").update(canonicalJson({ sessionId })).digest("hex"),
 		);
 		const ledger = await new LifecycleLedger(agentDir).open();
 		await ledger.begin(
@@ -1599,7 +1600,7 @@ test("broker rejects a ready-only lifecycle replay entry without marker authorit
 	const stateRoot = path.join(root, ".gjc", "state");
 	const sessionId = "ready-only-lifecycle-replay";
 	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
-	const request = { sessionId };
+	const request = { cwd: root, stateRoot, sessionId };
 	const key = "ready-only-lifecycle-replay";
 	let broker: Broker | undefined;
 	try {
@@ -1611,7 +1612,7 @@ test("broker rejects a ready-only lifecycle replay entry without marker authorit
 			agentDir,
 			"session.delete",
 			key,
-			createHash("sha256").update(canonicalJson(request)).digest("hex"),
+			createHash("sha256").update(canonicalJson({ sessionId })).digest("hex"),
 		);
 		const ledger = await new LifecycleLedger(agentDir).open();
 		await ledger.begin(
@@ -1669,7 +1670,7 @@ test("broker fails closed when a lifecycle ready sibling is swapped after marker
 	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
 	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
 	const preservePath = path.join(root, "preserve-ready-user-data");
-	const request = { sessionId };
+	const request = { cwd: root, stateRoot, sessionId };
 	const key = "lifecycle-swap-replay";
 	let broker: Broker | undefined;
 	try {
@@ -1689,7 +1690,7 @@ test("broker fails closed when a lifecycle ready sibling is swapped after marker
 			agentDir,
 			"session.delete",
 			key,
-			createHash("sha256").update(canonicalJson(request)).digest("hex"),
+			createHash("sha256").update(canonicalJson({ sessionId })).digest("hex"),
 		);
 		const ledger = await new LifecycleLedger(agentDir).open();
 		await ledger.begin(
@@ -2933,3 +2934,82 @@ test("ACP, MCP, and daemon global requests bootstrap a broker with zero sessions
 		await fs.rm(root, { recursive: true, force: true });
 	}
 }, 20_000);
+
+test("lifecycle cleanup rejects transplanted and ambiguous receipts before mutation", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-cleanup-receipt-"));
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "cleanup-receipt";
+	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+	const broker = new Broker({ agentDir: path.join(root, "agent") });
+	try {
+		await fs.mkdir(path.dirname(markerPath), { recursive: true });
+		await fs.writeFile(markerPath, "preserve lifecycle receipt bytes");
+		const stat = await fs.stat(markerPath, { bigint: true });
+		const bytes = await fs.readFile(markerPath);
+		const file = (plannedPath: string) => ({
+			path: markerPath,
+			identity: {
+				dev: stat.dev.toString(),
+				ino: stat.ino.toString(),
+				size: Number(stat.size),
+				mtimeNs: stat.mtimeNs.toString(),
+				sha256: createHash("sha256").update(bytes).digest("hex"),
+			},
+			attempt: 1,
+			plannedPath,
+		});
+		const deleteCleanup: BrokerCleanupEvidence = {
+			phase: "lifecycle",
+			lifecycleDeleteMetadata: true,
+			sessionId,
+			metadataRoot: stateRoot,
+			lifecycleFiles: [file(path.join(stateRoot, "sdk", ".gjc-delete-cleanup"))],
+		};
+		for (const [operation, input] of [
+			["session.delete", { cwd: root, stateRoot, sessionId: "other-cleanup-receipt" }],
+			[
+				"session.delete",
+				{ cwd: path.join(root, "other"), stateRoot: path.join(root, "other", ".gjc", "state"), sessionId },
+			],
+			["session.create", { cwd: root, stateRoot }],
+		] as const) {
+			const result = await executeLifecycle(broker, operation, input, "cleanup-receipt", deleteCleanup);
+			expect(result.response).toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+			expect(await fs.readFile(markerPath)).toEqual(bytes);
+		}
+		const duplicate: BrokerCleanupEvidence = {
+			phase: "lifecycle",
+			sessionId,
+			metadataRoot: stateRoot,
+			lifecycleFiles: [
+				file(path.join(stateRoot, "sdk", ".gjc-delete-one")),
+				file(path.join(stateRoot, "sdk", ".gjc-delete-two")),
+			],
+		};
+		const mixed: BrokerCleanupEvidence = {
+			...duplicate,
+			metadataPath: markerPath,
+			lifecycleFiles: [file(path.join(stateRoot, "sdk", ".gjc-delete-mixed"))],
+		};
+		const shared: BrokerCleanupEvidence = {
+			phase: "lifecycle",
+			sessionId,
+			metadataRoot: stateRoot,
+			lifecycleFiles: [{ ...file(path.join(stateRoot, "sdk", ".gjc-delete-shared")), detachedPath: markerPath }],
+		};
+		for (const cleanup of [duplicate, mixed, shared]) {
+			const result = await executeLifecycle(
+				broker,
+				"session.create",
+				{ cwd: root, stateRoot },
+				"cleanup-receipt",
+				cleanup,
+			);
+			expect(result.response).toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+			expect(await fs.readFile(markerPath)).toEqual(bytes);
+		}
+	} finally {
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -1097,6 +1097,77 @@ test("broker replays one identity-bound lifecycle metadata cleanup plan after th
 		await fs.rm(root, { recursive: true, force: true });
 	}
 }, 30_000);
+test("broker refuses fresh lifecycle cleanup when ready sibling has a different owner marker", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-mismatched-ready-cleanup-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const saved = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+	const broker = new Broker({ agentDir });
+	try {
+		await saved.ensureOnDisk();
+		const sessionId = saved.getSessionId();
+		const sessionPath = saved.getSessionFile();
+		if (!sessionPath) throw new Error("Expected persisted delete transcript.");
+		await saved.close();
+		await broker.start();
+		await expect(
+			broker.handleRequest(
+				"session.resume",
+				{ cwd: root, stateRoot, sessionId, sessionPath },
+				"mismatched-ready-resume",
+			),
+		).resolves.toMatchObject({ ok: true, result: { sessionId } });
+		await expect(
+			broker.handleRequest("session.close", { sessionId }, "mismatched-ready-close"),
+		).resolves.toMatchObject({
+			ok: true,
+			result: { sessionId },
+		});
+		await waitFor(
+			async () =>
+				(await fs.access(path.join(stateRoot, "sdk", `${sessionId}.json`)).then(
+					() => false,
+					() => true,
+				))
+					? true
+					: undefined,
+			"mismatched ready endpoint cleanup",
+		);
+		const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+		const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+		const marker = JSON.parse(await fs.readFile(markerPath, "utf8")) as {
+			pid: number;
+			effectMarker: string;
+			incarnation: string;
+		};
+		await fs.writeFile(readyPath, JSON.stringify({ ...marker, effectMarker: "different-ready-owner" }));
+
+		await expect(
+			broker.handleRequest(
+				"session.delete",
+				{ cwd: root, stateRoot, sessionId, sessionPath },
+				"mismatched-ready-delete",
+			),
+		).resolves.toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+		await expect(fs.stat(markerPath)).resolves.toBeDefined();
+		await expect(fs.stat(readyPath)).resolves.toBeDefined();
+		const rows = (await fs.readFile(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8"))
+			.split("\n")
+			.filter(Boolean)
+			.map(line => JSON.parse(line) as Record<string, unknown>);
+		expect(
+			rows.some(
+				row =>
+					((row.response as { error?: { cleanup?: { phase?: unknown } } } | undefined)?.error?.cleanup?.phase ??
+						null) === "lifecycle",
+			),
+		).toBe(false);
+	} finally {
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 30_000);
+
 test("broker replays a base metadata cleanup receipt after reopen without stranding its lifecycle siblings", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-legacy-metadata-replay-"));
 	const agentDir = path.join(root, "agent");
@@ -1141,32 +1212,60 @@ test("broker replays a base metadata cleanup receipt after reopen without strand
 						},
 						metadataAttempt: 1,
 						plannedMetadataPath: plannedPath,
+						metadataCompleted: true,
 					},
 				},
 			},
 		});
+		await fs.unlink(markerPath);
 
 		broker = new Broker({ agentDir });
 		await broker.start();
-		await expect(broker.handleRequest("session.delete", request, key)).resolves.toEqual({
-			ok: true,
-			result: { sessionId },
+		setLifecycleCleanupHookForTest(broker, () => {
+			throw new Error("simulated crash after legacy ready cleanup");
 		});
+		await expect(broker.handleRequest("session.delete", request, key)).rejects.toThrow(
+			"simulated crash after legacy ready cleanup",
+		);
 		await expect(fs.stat(markerPath)).rejects.toThrow();
 		await expect(fs.stat(readyPath)).rejects.toThrow();
 		const rows = (await fs.readFile(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8"))
 			.split("\n")
 			.filter(Boolean)
 			.map(line => JSON.parse(line) as Record<string, unknown>);
+		const preUnlinkPlan = rows.some(row => {
+			const cleanup = (
+				row.response as
+					| {
+							error?: {
+								cleanup?: { phase?: unknown; lifecycleFiles?: Array<{ path?: unknown; completed?: unknown }> };
+							};
+					  }
+					| undefined
+			)?.error?.cleanup;
+			return (
+				cleanup?.phase === "lifecycle" &&
+				cleanup.lifecycleFiles?.some(file => file.path === readyPath && file.completed === undefined) === true
+			);
+		});
+		expect(preUnlinkPlan).toBe(true);
 		const migrated = rows.findLast(row => row.state === "effect_started" && row.response);
 		expect((migrated?.response as { error?: { cleanup?: unknown } } | undefined)?.error?.cleanup).toMatchObject({
 			phase: "lifecycle",
 			sessionId,
 			lifecycleFiles: [
-				expect.objectContaining({ path: markerPath, plannedPath }),
-				expect.objectContaining({ path: readyPath, identity: expect.any(Object) }),
+				expect.objectContaining({ path: markerPath, plannedPath, completed: true }),
+				expect.objectContaining({ path: readyPath, identity: expect.any(Object), completed: true }),
 			],
 		});
+		await broker.stop();
+		broker = new Broker({ agentDir });
+		await broker.start();
+		await expect(broker.handleRequest("session.delete", request, key)).resolves.toEqual({
+			ok: true,
+			result: { sessionId },
+		});
+		await expect(fs.stat(readyPath)).rejects.toThrow();
 		await broker.stop();
 		broker = undefined;
 

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -1097,19 +1097,22 @@ test("broker replays one identity-bound lifecycle metadata cleanup plan after th
 		await fs.rm(root, { recursive: true, force: true });
 	}
 }, 30_000);
-test("broker replays a base metadata cleanup receipt after reopen without stranding its lifecycle marker", async () => {
+test("broker replays a base metadata cleanup receipt after reopen without stranding its lifecycle siblings", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-legacy-metadata-replay-"));
 	const agentDir = path.join(root, "agent");
 	const stateRoot = path.join(root, ".gjc", "state");
 	const sessionId = "legacy-metadata-replay";
 	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
 	const plannedPath = path.join(stateRoot, "sdk", `.gjc-delete-base-${sessionId}.lifecycle.json`);
 	const request = { sessionId };
 	const key = "base-metadata-cleanup-replay";
 	let broker: Broker | undefined;
 	try {
 		await fs.mkdir(path.dirname(markerPath), { recursive: true });
-		await fs.writeFile(markerPath, JSON.stringify({ pid: process.pid, effectMarker: "base", incarnation: "base" }));
+		const marker = { pid: process.pid, effectMarker: "base", incarnation: "base" };
+		await fs.writeFile(markerPath, JSON.stringify(marker));
+		await fs.writeFile(readyPath, JSON.stringify(marker));
 		const [stat, bytes] = await Promise.all([fs.stat(markerPath, { bigint: true }), fs.readFile(markerPath)]);
 		const target = createHash("sha256").update(canonicalJson({ sessionId })).digest("hex");
 		const identity = await deriveIdempotencyIdentity(agentDir, "session.delete", key, target);
@@ -1150,6 +1153,7 @@ test("broker replays a base metadata cleanup receipt after reopen without strand
 			result: { sessionId },
 		});
 		await expect(fs.stat(markerPath)).rejects.toThrow();
+		await expect(fs.stat(readyPath)).rejects.toThrow();
 		const rows = (await fs.readFile(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8"))
 			.split("\n")
 			.filter(Boolean)
@@ -1158,8 +1162,74 @@ test("broker replays a base metadata cleanup receipt after reopen without strand
 		expect((migrated?.response as { error?: { cleanup?: unknown } } | undefined)?.error?.cleanup).toMatchObject({
 			phase: "lifecycle",
 			sessionId,
-			lifecycleFiles: [expect.objectContaining({ path: markerPath, plannedPath })],
+			lifecycleFiles: [
+				expect.objectContaining({ path: markerPath, plannedPath }),
+				expect.objectContaining({ path: readyPath, identity: expect.any(Object) }),
+			],
 		});
+		await broker.stop();
+		broker = undefined;
+
+		const mismatchedSessionId = "legacy-metadata-mismatched-ready";
+		const mismatchedMarkerPath = path.join(stateRoot, "sdk", `${mismatchedSessionId}.lifecycle.json`);
+		const mismatchedReadyPath = path.join(stateRoot, "sdk", `${mismatchedSessionId}.lifecycle.ready.json`);
+		const mismatchedPlannedPath = path.join(
+			stateRoot,
+			"sdk",
+			`.gjc-delete-base-${mismatchedSessionId}.lifecycle.json`,
+		);
+		await fs.writeFile(mismatchedMarkerPath, JSON.stringify(marker));
+		await fs.writeFile(mismatchedReadyPath, JSON.stringify({ ...marker, effectMarker: "mismatched-ready" }));
+		const [mismatchedStat, mismatchedBytes] = await Promise.all([
+			fs.stat(mismatchedMarkerPath, { bigint: true }),
+			fs.readFile(mismatchedMarkerPath),
+		]);
+		const mismatchedRequest = { sessionId: mismatchedSessionId };
+		const mismatchedKey = "base-metadata-mismatched-ready";
+		const mismatchedIdentity = await deriveIdempotencyIdentity(
+			agentDir,
+			"session.delete",
+			mismatchedKey,
+			createHash("sha256").update(canonicalJson(mismatchedRequest)).digest("hex"),
+		);
+		const mismatchedLedger = await new LifecycleLedger(agentDir).open();
+		await mismatchedLedger.begin(
+			mismatchedIdentity,
+			createHash("sha256")
+				.update(canonicalJson({ operation: "session.delete", input: mismatchedRequest }))
+				.digest("hex"),
+		);
+		await mismatchedLedger.transition(mismatchedIdentity, "effect_started", {
+			response: {
+				ok: false,
+				error: {
+					code: "cleanup_pending",
+					message: "Base metadata cleanup is pending.",
+					cleanup: {
+						phase: "metadata",
+						sessionId: mismatchedSessionId,
+						metadataRoot: stateRoot,
+						metadataPath: mismatchedMarkerPath,
+						metadataIdentity: {
+							dev: mismatchedStat.dev.toString(),
+							ino: mismatchedStat.ino.toString(),
+							size: Number(mismatchedStat.size),
+							mtimeNs: mismatchedStat.mtimeNs.toString(),
+							sha256: createHash("sha256").update(mismatchedBytes).digest("hex"),
+						},
+						plannedMetadataPath: mismatchedPlannedPath,
+					},
+				},
+			},
+		});
+		broker = new Broker({ agentDir });
+		await broker.start();
+		await expect(broker.handleRequest("session.delete", mismatchedRequest, mismatchedKey)).resolves.toMatchObject({
+			ok: false,
+			error: { code: "terminal_uncertain" },
+		});
+		await expect(fs.stat(mismatchedMarkerPath)).resolves.toBeDefined();
+		await expect(fs.stat(mismatchedReadyPath)).resolves.toBeDefined();
 	} finally {
 		await broker?.stop();
 		await fs.rm(root, { recursive: true, force: true });

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -1168,7 +1168,7 @@ test("broker refuses fresh lifecycle cleanup when ready sibling has a different 
 	}
 }, 30_000);
 
-test("broker replays a base metadata cleanup receipt after reopen without stranding its lifecycle siblings", async () => {
+test("broker replays a completed base metadata cleanup receipt and rejects a replaced ready sibling after marker loss", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-legacy-metadata-replay-"));
 	const agentDir = path.join(root, "agent");
 	const stateRoot = path.join(root, ".gjc", "state");
@@ -1182,8 +1182,8 @@ test("broker replays a base metadata cleanup receipt after reopen without strand
 	try {
 		await fs.mkdir(path.dirname(markerPath), { recursive: true });
 		const marker = { pid: process.pid, effectMarker: "base", incarnation: "base" };
-		await fs.writeFile(markerPath, JSON.stringify(marker));
-		await fs.writeFile(readyPath, JSON.stringify(marker));
+		await fs.writeFile(markerPath, canonicalJson(marker));
+		await fs.writeFile(readyPath, canonicalJson(marker));
 		const [stat, bytes] = await Promise.all([fs.stat(markerPath, { bigint: true }), fs.readFile(markerPath)]);
 		const target = createHash("sha256").update(canonicalJson({ sessionId })).digest("hex");
 		const identity = await deriveIdempotencyIdentity(agentDir, "session.delete", key, target);
@@ -1277,8 +1277,13 @@ test("broker replays a base metadata cleanup receipt after reopen without strand
 			"sdk",
 			`.gjc-delete-base-${mismatchedSessionId}.lifecycle.json`,
 		);
-		await fs.writeFile(mismatchedMarkerPath, JSON.stringify(marker));
-		await fs.writeFile(mismatchedReadyPath, JSON.stringify({ ...marker, effectMarker: "mismatched-ready" }));
+		const replacedReady = {
+			pid: process.pid + 1,
+			effectMarker: "replaced-ready-owner",
+			incarnation: "replaced-ready-incarnation",
+		};
+		await fs.writeFile(mismatchedMarkerPath, canonicalJson(marker));
+		await fs.writeFile(mismatchedReadyPath, canonicalJson(replacedReady));
 		const [mismatchedStat, mismatchedBytes] = await Promise.all([
 			fs.stat(mismatchedMarkerPath, { bigint: true }),
 			fs.readFile(mismatchedMarkerPath),
@@ -1317,18 +1322,20 @@ test("broker replays a base metadata cleanup receipt after reopen without strand
 							sha256: createHash("sha256").update(mismatchedBytes).digest("hex"),
 						},
 						plannedMetadataPath: mismatchedPlannedPath,
+						metadataCompleted: true,
 					},
 				},
 			},
 		});
+		await fs.unlink(mismatchedMarkerPath);
 		broker = new Broker({ agentDir });
 		await broker.start();
 		await expect(broker.handleRequest("session.delete", mismatchedRequest, mismatchedKey)).resolves.toMatchObject({
 			ok: false,
 			error: { code: "terminal_uncertain" },
 		});
-		await expect(fs.stat(mismatchedMarkerPath)).resolves.toBeDefined();
-		await expect(fs.stat(mismatchedReadyPath)).resolves.toBeDefined();
+		await expect(fs.stat(mismatchedMarkerPath)).rejects.toThrow();
+		await expect(fs.readFile(mismatchedReadyPath, "utf8")).resolves.toBe(canonicalJson(replacedReady));
 	} finally {
 		await broker?.stop();
 		await fs.rm(root, { recursive: true, force: true });

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -1009,6 +1009,94 @@ test("broker directly resumes and forks a canonical cold saved session with scop
 	}
 }, 30_000);
 
+test("broker replays one identity-bound lifecycle metadata cleanup plan after the first delete detach", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-delete-metadata-crash-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const saved = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+	let crashing: Broker | undefined;
+	let reopened: Broker | undefined;
+	try {
+		await saved.ensureOnDisk();
+		const sessionId = saved.getSessionId();
+		const sessionPath = saved.getSessionFile();
+		if (!sessionPath) throw new Error("Expected persisted delete transcript.");
+		await saved.close();
+
+		crashing = new Broker({ agentDir });
+		await crashing.start();
+		await expect(
+			crashing.handleRequest(
+				"session.resume",
+				{ cwd: root, stateRoot, sessionId, sessionPath },
+				"delete-metadata-resume",
+			),
+		).resolves.toMatchObject({ ok: true, result: { sessionId } });
+		await expect(
+			crashing.handleRequest("session.close", { sessionId }, "delete-metadata-close"),
+		).resolves.toMatchObject({
+			ok: true,
+			result: { sessionId },
+		});
+		await waitFor(
+			async () =>
+				(await fs.access(path.join(stateRoot, "sdk", `${sessionId}.json`)).then(
+					() => false,
+					() => true,
+				))
+					? true
+					: undefined,
+			"delete metadata endpoint cleanup",
+		);
+		const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+		const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+		await expect(fs.stat(markerPath)).resolves.toBeDefined();
+		await expect(fs.stat(readyPath)).resolves.toBeDefined();
+		setLifecycleCleanupHookForTest(crashing, () => {
+			throw new Error("simulated crash after first delete metadata detach");
+		});
+		const deleteInput = { cwd: root, stateRoot, sessionId, sessionPath };
+		await expect(crashing.handleRequest("session.delete", deleteInput, "delete-metadata-crash")).rejects.toThrow(
+			"simulated crash after first delete metadata detach",
+		);
+		const rows = (await fs.readFile(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8"))
+			.split("\n")
+			.filter(Boolean)
+			.map(line => JSON.parse(line) as Record<string, unknown>);
+		const persisted = rows.findLast(row => row.state === "effect_started");
+		const cleanup = (
+			persisted?.response as { error?: { cleanup?: { phase?: unknown; lifecycleFiles?: unknown[] } } } | undefined
+		)?.error?.cleanup;
+		expect(cleanup).toMatchObject({ phase: "lifecycle" });
+		expect(cleanup?.lifecycleFiles).toHaveLength(2);
+		expect(cleanup?.lifecycleFiles).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ path: markerPath, identity: expect.any(Object) }),
+				expect.objectContaining({ path: readyPath, identity: expect.any(Object) }),
+			]),
+		);
+		await expect(fs.stat(markerPath)).rejects.toThrow();
+		await expect(fs.stat(readyPath)).resolves.toBeDefined();
+
+		await crashing.stop();
+		crashing = undefined;
+		reopened = new Broker({ agentDir });
+		await reopened.start();
+		await expect(
+			reopened.handleRequest("session.delete", deleteInput, "delete-metadata-crash"),
+		).resolves.toMatchObject({
+			ok: true,
+			result: { sessionId },
+		});
+		await expect(fs.stat(markerPath)).rejects.toThrow();
+		await expect(fs.stat(readyPath)).rejects.toThrow();
+	} finally {
+		await crashing?.stop();
+		await reopened?.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 30_000);
+
 test("broker terminalizes default command resolver failures", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-resolver-failure-"));
 	const agentDir = path.join(root, "agent");

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -196,21 +196,22 @@ test("ledger reopen bounds malformed persisted rows before they gain cleanup aut
 		expect(quarantined).toContain('"identity":"deep"');
 		expect(quarantined).toContain('"identity":"wide"');
 
-		const expectStartFailure = async (name: string, content: string, message: string) => {
+		const expectOpenFailure = async (name: string, content: string, message: string) => {
 			const boundedAgentDir = path.join(agentDir, name);
 			const boundedLedgerPath = path.join(boundedAgentDir, "sdk", "lifecycle-ledger.jsonl");
 			await fs.mkdir(path.dirname(boundedLedgerPath), { recursive: true });
 			await fs.writeFile(boundedLedgerPath, content);
-			const broker = new Broker({ agentDir: boundedAgentDir });
-			try {
-				await expect(broker.start()).rejects.toThrow(message);
-			} finally {
-				await broker.stop();
-			}
+			await expect(
+				new LifecycleLedger(boundedAgentDir, {
+					maxLineBytes: 64 * 1024,
+					maxBytes: 512 * 1024,
+					maxRows: 100,
+				}).open(),
+			).rejects.toThrow(message);
 		};
-		await expectStartFailure("line-bound", "x".repeat(64 * 1024 + 1), "maximum byte length");
-		await expectStartFailure("row-bound", "{}\n".repeat(10_001), "maximum row count");
-		await expectStartFailure("file-bound", "x".repeat(8 * 1024 * 1024 + 1), "maximum file byte length");
+		await expectOpenFailure("line-bound", "x".repeat(64 * 1024 + 1), "maximum byte length");
+		await expectOpenFailure("row-bound", "{}\n".repeat(101), "maximum row count");
+		await expectOpenFailure("file-bound", "x".repeat(512 * 1024 + 1), "maximum file byte length");
 		expect(await fs.readFile(cleanupSentinel, "utf8")).toBe("preserve");
 	} finally {
 		await fs.rm(agentDir, { recursive: true, force: true });
@@ -2402,11 +2403,15 @@ test("broker records the resolved worktree state root and preserves pre-child pr
 test("broker fails closed when the reopened terminal ledger cannot reproduce its response", async () => {
 	const agentDir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-ledger-mismatch-"));
 	const broker = new Broker({ agentDir });
-	const originalOpen = LifecycleLedger.prototype.open;
+	const originalReadTerminal = LifecycleLedger.prototype.readTerminal;
 	try {
 		await broker.start();
-		LifecycleLedger.prototype.open = async () => ({ get: () => undefined }) as unknown as LifecycleLedger;
-		const response = await broker.handleRequest("session.unknown", {}, "ledger-mismatch");
+		LifecycleLedger.prototype.readTerminal = async () => undefined;
+		const response = await broker.handleRequest(
+			"session.unknown",
+			{ sessionId: "ledger-mismatch" },
+			"ledger-mismatch",
+		);
 		expect(response).toEqual({
 			ok: false,
 			error: {
@@ -2416,7 +2421,7 @@ test("broker fails closed when the reopened terminal ledger cannot reproduce its
 			},
 		});
 	} finally {
-		LifecycleLedger.prototype.open = originalOpen;
+		LifecycleLedger.prototype.readTerminal = originalReadTerminal;
 		await broker.stop();
 		await fs.rm(agentDir, { recursive: true, force: true });
 	}

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -1252,6 +1252,63 @@ test("broker replays one identity-bound lifecycle metadata cleanup plan after th
 		await fs.rm(root, { recursive: true, force: true });
 	}
 }, 30_000);
+
+test("broker uses incarnation-aware observations before fresh lifecycle metadata cleanup", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-delete-incarnation-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const broker = new Broker({ agentDir });
+	try {
+		await broker.start();
+		for (const [name, observedIncarnation, expectedOk] of [
+			["reused", "replacement-incarnation", true],
+			["matching", "closed-incarnation", false],
+			["unreadable", undefined, false],
+		] as const) {
+			const saved = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+			await saved.ensureOnDisk();
+			const sessionId = saved.getSessionId();
+			const sessionPath = saved.getSessionFile();
+			if (!sessionPath) throw new Error("Expected persisted delete transcript.");
+			await saved.close();
+			const marker = {
+				pid: process.pid,
+				effectMarker: `closed-${name}`,
+				incarnation: "closed-incarnation",
+			};
+			const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+			const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+			await fs.mkdir(path.dirname(markerPath), { recursive: true });
+			await Promise.all([
+				fs.writeFile(markerPath, canonicalJson(marker)),
+				fs.writeFile(readyPath, canonicalJson(marker)),
+			]);
+			expect(() => process.kill(marker.pid, 0)).not.toThrow();
+			const surfaceBeforeDelete = await snapshotDeleteSurface(sessionPath);
+			setProcessIncarnationForTest(broker, () => observedIncarnation);
+			const result = await broker.handleRequest(
+				"session.delete",
+				{ cwd: root, stateRoot, sessionId, sessionPath },
+				`delete-incarnation-${name}`,
+			);
+			if (expectedOk) {
+				expect(result).toMatchObject({ ok: true, result: { sessionId } });
+				await expect(fs.stat(sessionPath)).rejects.toThrow();
+				await expect(fs.stat(markerPath)).rejects.toThrow();
+				await expect(fs.stat(readyPath)).rejects.toThrow();
+			} else {
+				expect(result).toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+				expect(await snapshotDeleteSurface(sessionPath)).toEqual(surfaceBeforeDelete);
+				await expect(fs.readFile(markerPath, "utf8")).resolves.toBe(canonicalJson(marker));
+				await expect(fs.readFile(readyPath, "utf8")).resolves.toBe(canonicalJson(marker));
+			}
+		}
+	} finally {
+		setProcessIncarnationForTest(broker, undefined);
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 30_000);
 test("broker refuses fresh lifecycle cleanup when ready sibling has a different owner marker", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-mismatched-ready-cleanup-"));
 	const agentDir = path.join(root, "agent");

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -1456,10 +1456,9 @@ test("broker rejects a corrupt completed lifecycle cleanup receipt when its read
 		await fs.mkdir(path.dirname(markerPath), { recursive: true });
 		await fs.writeFile(markerPath, canonicalJson(marker));
 		await fs.writeFile(readyPath, canonicalJson(marker));
-		const [markerStat, markerBytes, readyStat, readyBytes] = await Promise.all([
+		const [markerStat, markerBytes, readyBytes] = await Promise.all([
 			fs.stat(markerPath, { bigint: true }),
 			fs.readFile(markerPath),
-			fs.stat(readyPath, { bigint: true }),
 			fs.readFile(readyPath),
 		]);
 		const target = createHash("sha256").update(canonicalJson(request)).digest("hex");
@@ -1497,22 +1496,6 @@ test("broker rejects a corrupt completed lifecycle cleanup receipt when its read
 
 								completed: true,
 							},
-							{
-								path: readyPath,
-								identity: {
-									dev: readyStat.dev.toString(),
-									ino: readyStat.ino.toString(),
-									size: Number(readyStat.size),
-									mtimeNs: readyStat.mtimeNs.toString(),
-									sha256: createHash("sha256").update(readyBytes).digest("hex"),
-								},
-								attempt: 1,
-								plannedPath: path.join(
-									path.dirname(readyPath),
-									`.gjc-delete-ready-${sessionId}.lifecycle.ready.json`,
-								),
-								completed: true,
-							},
 						],
 					},
 				},
@@ -1533,6 +1516,233 @@ test("broker rejects a corrupt completed lifecycle cleanup receipt when its read
 	}
 }, 30_000);
 
+test("broker rejects duplicate lifecycle marker replay authorities without unlinking siblings", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-duplicate-lifecycle-replay-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "duplicate-lifecycle-replay";
+	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+	const request = { sessionId };
+	const key = "duplicate-lifecycle-replay";
+	let broker: Broker | undefined;
+	try {
+		const marker = { pid: process.pid, effectMarker: "duplicate-replay", incarnation: "duplicate-replay" };
+		await fs.mkdir(path.dirname(markerPath), { recursive: true });
+		await fs.writeFile(markerPath, canonicalJson(marker));
+		await fs.writeFile(readyPath, canonicalJson(marker));
+		const [markerStat, markerBytes, readyBytes] = await Promise.all([
+			fs.stat(markerPath, { bigint: true }),
+			fs.readFile(markerPath),
+			fs.readFile(readyPath),
+		]);
+		const identity = await deriveIdempotencyIdentity(
+			agentDir,
+			"session.delete",
+			key,
+			createHash("sha256").update(canonicalJson(request)).digest("hex"),
+		);
+		const ledger = await new LifecycleLedger(agentDir).open();
+		await ledger.begin(
+			identity,
+			createHash("sha256")
+				.update(canonicalJson({ operation: "session.delete", input: request }))
+				.digest("hex"),
+		);
+		const cleanupFile = (plannedPath: string) => ({
+			path: markerPath,
+			identity: {
+				dev: markerStat.dev.toString(),
+				ino: markerStat.ino.toString(),
+				size: Number(markerStat.size),
+				mtimeNs: markerStat.mtimeNs.toString(),
+				sha256: createHash("sha256").update(markerBytes).digest("hex"),
+			},
+			attempt: 1,
+			plannedPath,
+		});
+		await ledger.transition(identity, "effect_started", {
+			response: {
+				ok: false,
+				error: {
+					code: "cleanup_pending",
+					message: "Lifecycle cleanup is pending.",
+					cleanup: {
+						phase: "lifecycle",
+						lifecycleDeleteMetadata: true,
+						sessionId,
+						metadataRoot: stateRoot,
+						lifecycleFiles: [
+							cleanupFile(path.join(stateRoot, "sdk", ".gjc-delete-one")),
+							cleanupFile(path.join(stateRoot, "sdk", ".gjc-delete-two")),
+						],
+					},
+				},
+			},
+		});
+		broker = new Broker({ agentDir });
+		await broker.start();
+		await expect(broker.handleRequest("session.delete", request, key)).resolves.toMatchObject({
+			ok: false,
+			error: { code: "terminal_uncertain" },
+		});
+		await expect(fs.readFile(markerPath)).resolves.toEqual(markerBytes);
+		await expect(fs.readFile(readyPath)).resolves.toEqual(readyBytes);
+	} finally {
+		await broker?.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 30_000);
+test("broker rejects a ready-only lifecycle replay entry without marker authority", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-ready-only-replay-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "ready-only-lifecycle-replay";
+	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+	const request = { sessionId };
+	const key = "ready-only-lifecycle-replay";
+	let broker: Broker | undefined;
+	try {
+		const marker = { pid: process.pid, effectMarker: "ready-only-replay", incarnation: "ready-only-replay" };
+		await fs.mkdir(path.dirname(readyPath), { recursive: true });
+		await fs.writeFile(readyPath, canonicalJson(marker));
+		const [readyStat, readyBytes] = await Promise.all([fs.stat(readyPath, { bigint: true }), fs.readFile(readyPath)]);
+		const identity = await deriveIdempotencyIdentity(
+			agentDir,
+			"session.delete",
+			key,
+			createHash("sha256").update(canonicalJson(request)).digest("hex"),
+		);
+		const ledger = await new LifecycleLedger(agentDir).open();
+		await ledger.begin(
+			identity,
+			createHash("sha256")
+				.update(canonicalJson({ operation: "session.delete", input: request }))
+				.digest("hex"),
+		);
+		await ledger.transition(identity, "effect_started", {
+			response: {
+				ok: false,
+				error: {
+					code: "cleanup_pending",
+					message: "Lifecycle cleanup is pending.",
+					cleanup: {
+						phase: "lifecycle",
+						lifecycleDeleteMetadata: true,
+						sessionId,
+						metadataRoot: stateRoot,
+						lifecycleFiles: [
+							{
+								path: readyPath,
+								identity: {
+									dev: readyStat.dev.toString(),
+									ino: readyStat.ino.toString(),
+									size: Number(readyStat.size),
+									mtimeNs: readyStat.mtimeNs.toString(),
+									sha256: createHash("sha256").update(readyBytes).digest("hex"),
+								},
+								attempt: 1,
+								plannedPath: path.join(stateRoot, "sdk", ".gjc-delete-ready-only"),
+							},
+						],
+					},
+				},
+			},
+		});
+		broker = new Broker({ agentDir });
+		await broker.start();
+		await expect(broker.handleRequest("session.delete", request, key)).resolves.toMatchObject({
+			ok: false,
+			error: { code: "terminal_uncertain" },
+		});
+		await expect(fs.readFile(readyPath)).resolves.toEqual(readyBytes);
+	} finally {
+		await broker?.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 30_000);
+test("broker fails closed when a lifecycle ready sibling is swapped after marker reconciliation", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-lifecycle-swap-replay-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "lifecycle-swap-replay";
+	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+	const preservePath = path.join(root, "preserve-ready-user-data");
+	const request = { sessionId };
+	const key = "lifecycle-swap-replay";
+	let broker: Broker | undefined;
+	try {
+		const marker = { pid: process.pid, effectMarker: "swap-replay", incarnation: "swap-replay" };
+		await fs.mkdir(path.dirname(markerPath), { recursive: true });
+		await fs.writeFile(markerPath, canonicalJson(marker));
+		await fs.writeFile(readyPath, canonicalJson(marker));
+		await fs.writeFile(preservePath, "preserve this user data");
+		const captures = await Promise.all(
+			[markerPath, readyPath].map(async file => ({
+				path: file,
+				stat: await fs.stat(file, { bigint: true }),
+				bytes: await fs.readFile(file),
+			})),
+		);
+		const identity = await deriveIdempotencyIdentity(
+			agentDir,
+			"session.delete",
+			key,
+			createHash("sha256").update(canonicalJson(request)).digest("hex"),
+		);
+		const ledger = await new LifecycleLedger(agentDir).open();
+		await ledger.begin(
+			identity,
+			createHash("sha256")
+				.update(canonicalJson({ operation: "session.delete", input: request }))
+				.digest("hex"),
+		);
+		await ledger.transition(identity, "effect_started", {
+			response: {
+				ok: false,
+				error: {
+					code: "cleanup_pending",
+					message: "Lifecycle cleanup is pending.",
+					cleanup: {
+						phase: "lifecycle",
+						lifecycleDeleteMetadata: true,
+						sessionId,
+						metadataRoot: stateRoot,
+						lifecycleFiles: captures.map(({ path: file, stat, bytes }) => ({
+							path: file,
+							identity: {
+								dev: stat.dev.toString(),
+								ino: stat.ino.toString(),
+								size: Number(stat.size),
+								mtimeNs: stat.mtimeNs.toString(),
+								sha256: createHash("sha256").update(bytes).digest("hex"),
+							},
+							attempt: 1,
+							plannedPath: path.join(stateRoot, "sdk", `.gjc-delete-swap-${path.basename(file)}`),
+						})),
+					},
+				},
+			},
+		});
+		broker = new Broker({ agentDir });
+		await broker.start();
+		setLifecycleCleanupHookForTest(broker, () => {
+			writeFileSync(readyPath, "replaced before unlink");
+			renameSync(preservePath, `${preservePath}.moved`);
+			writeFileSync(preservePath, "preserve this user data");
+		});
+		await expect(broker.handleRequest("session.delete", request, key)).resolves.toMatchObject({
+			ok: false,
+			error: { code: "terminal_uncertain" },
+		});
+		await expect(fs.readFile(readyPath, "utf8")).resolves.toBe("replaced before unlink");
+		await expect(fs.readFile(preservePath, "utf8")).resolves.toBe("preserve this user data");
+	} finally {
+		await broker?.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 30_000);
 test("broker terminalizes default command resolver failures", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-resolver-failure-"));
 	const agentDir = path.join(root, "agent");

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -25,6 +25,7 @@ import { runSdkSessionCli } from "../src/sdk/cli";
 import { SdkClient } from "../src/sdk/client";
 import { readSdkBrokerDiscovery } from "../src/sdk/client/discovery";
 import { createSdkMcpServer } from "../src/sdk/mcp";
+import { listManagedSessionCandidates, resolveManagedSessionScope } from "../src/sdk/session-directory";
 import { sanitizeSdkStartupMessage } from "../src/sdk/startup-capability";
 import { SessionManager } from "../src/session/session-manager";
 
@@ -730,6 +731,283 @@ test("broker rejects a cross-workspace cold fork source before spawning", async 
 		await fs.rm(root, { recursive: true, force: true });
 	}
 });
+
+test("broker rejects duplicate owned source candidates before spawning", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-duplicate-owned-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const spawnedPath = path.join(root, "spawned");
+	const command = path.join(root, "spawned.js");
+	const broker = new Broker({ agentDir });
+	const previousCommand = process.env.GJC_SDK_SESSION_COMMAND;
+	const previousRequestId = process.env.GJC_LIFECYCLE_REQUEST_ID;
+	const previousSessionId = process.env.GJC_SESSION_ID;
+	try {
+		const scopeResult = await resolveManagedSessionScope({ cwd: root, agentDir });
+		expect(scopeResult.kind).toBe("resolved");
+		if (scopeResult.kind !== "resolved") throw new Error(scopeResult.message);
+		const createDuplicate = async (suffix: string) => {
+			process.env.GJC_LIFECYCLE_REQUEST_ID = `duplicate-prepare-${suffix}`;
+			process.env.GJC_SESSION_ID = "duplicate-owned-source";
+			const session = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+			await session.ensureOnDisk();
+			const sourcePath = session.getSessionFile();
+			if (!sourcePath) throw new Error("Expected duplicate owned source path.");
+			const duplicatePath = path.join(scopeResult.scope.directoryPath, `duplicate-${suffix}.jsonl`);
+			await fs.rename(sourcePath, duplicatePath);
+			return { path: duplicatePath, bytes: await fs.readFile(duplicatePath) };
+		};
+		const first = await createDuplicate("a");
+		const second = await createDuplicate("b");
+		delete process.env.GJC_LIFECYCLE_REQUEST_ID;
+		delete process.env.GJC_SESSION_ID;
+		const inventory = await listManagedSessionCandidates({ scope: scopeResult.scope });
+		expect(inventory.kind).toBe("complete");
+		if (inventory.kind !== "complete") throw new Error(inventory.message);
+		expect(inventory.owned.filter(candidate => candidate.sessionId === "duplicate-owned-source")).toHaveLength(2);
+		const candidatePathsBefore = inventory.owned.map(candidate => candidate.path).sort();
+		const ledgerRowsBefore = (
+			await fs.readFile(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8").catch(() => "")
+		)
+			.split("\n")
+			.filter(Boolean);
+		await fs.writeFile(
+			command,
+			`require("fs").writeFileSync(${JSON.stringify(spawnedPath)}, "spawned"); setInterval(() => {}, 1000);`,
+		);
+		process.env.GJC_SDK_SESSION_COMMAND = `${process.execPath} ${command}`;
+		await broker.start();
+		expect(
+			await broker.handleRequest(
+				"session.fork",
+				{ cwd: root, stateRoot, sourceSessionId: "duplicate-owned-source" },
+				"duplicate-owned-source-request",
+			),
+		).toEqual({
+			ok: false,
+			error: {
+				code: "invalid_input",
+				message: "Source saved session does not match the requested workspace and session id.",
+			},
+		});
+		await expect(fs.access(spawnedPath)).rejects.toThrow();
+		expect(await fs.readFile(first.path)).toEqual(first.bytes);
+		expect(await fs.readFile(second.path)).toEqual(second.bytes);
+		await expect(fs.access(path.join(stateRoot, "sdk", "duplicate-owned-source.json"))).rejects.toThrow();
+		await expect(fs.access(path.join(stateRoot, "sdk", "duplicate-owned-source.lifecycle.json"))).rejects.toThrow();
+		const afterInventory = await listManagedSessionCandidates({ scope: scopeResult.scope });
+		expect(afterInventory.kind).toBe("complete");
+		if (afterInventory.kind !== "complete") throw new Error(afterInventory.message);
+		expect(afterInventory.owned.map(candidate => candidate.path).sort()).toEqual(candidatePathsBefore);
+		const ledgerRowsAfter = (
+			await fs.readFile(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8").catch(() => "")
+		)
+			.split("\n")
+			.filter(Boolean)
+			.slice(ledgerRowsBefore.length)
+			.map(line => JSON.parse(line) as { state?: string });
+		expect(ledgerRowsAfter.some(row => row.state === "effect_started")).toBe(false);
+		const registrations = (await new SessionIndex(agentDir).open())
+			.listSessions()
+			.sessions.filter(session => session.sessionId === "duplicate-owned-source");
+		expect(registrations).toHaveLength(0);
+	} finally {
+		if (previousCommand === undefined) delete process.env.GJC_SDK_SESSION_COMMAND;
+		else process.env.GJC_SDK_SESSION_COMMAND = previousCommand;
+		if (previousRequestId === undefined) delete process.env.GJC_LIFECYCLE_REQUEST_ID;
+		else process.env.GJC_LIFECYCLE_REQUEST_ID = previousRequestId;
+		if (previousSessionId === undefined) delete process.env.GJC_SESSION_ID;
+		else process.env.GJC_SESSION_ID = previousSessionId;
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
+test("broker directly resumes and forks a canonical cold saved session with scoped cleanup", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-canonical-cold-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const broker = new Broker({ agentDir });
+	try {
+		const scopeResult = await resolveManagedSessionScope({ cwd: root, agentDir });
+		expect(scopeResult.kind).toBe("resolved");
+		if (scopeResult.kind !== "resolved") throw new Error(scopeResult.message);
+		const sourceDir = SessionManager.getDefaultSessionDir(root, agentDir);
+		expect(sourceDir).toBe(scopeResult.scope.directoryPath);
+		const source = SessionManager.create(root, sourceDir);
+		await source.ensureOnDisk();
+		const sourceId = source.getSessionId();
+		const sourcePath = source.getSessionFile();
+		if (!sourcePath) throw new Error("Expected canonical saved source path.");
+		const assertCanonicalSource = async () => {
+			const inventory = await listManagedSessionCandidates({ scope: scopeResult.scope });
+			expect(inventory.kind).toBe("complete");
+			if (inventory.kind !== "complete") throw new Error(inventory.message);
+			const candidates = inventory.owned.filter(
+				candidate => candidate.sessionId === sourceId && candidate.path === sourcePath,
+			);
+			expect(candidates).toHaveLength(1);
+			expect(path.dirname(candidates[0]!.path)).toBe(scopeResult.scope.directoryPath);
+			return candidates[0]!;
+		};
+		const sourceCandidate = await assertCanonicalSource();
+		await broker.start();
+		const resumed = await broker.handleRequest(
+			"session.resume",
+			{ cwd: root, stateRoot, sessionId: sourceId, sessionPath: sourcePath },
+			"canonical-cold-resume",
+		);
+		expect(resumed).toMatchObject({ ok: true, result: { sessionId: sourceId } });
+		const resumedSourceCandidate = await assertCanonicalSource();
+		expect(resumedSourceCandidate.identity).toMatchObject({ canonicalPath: sourcePath, sessionId: sourceId });
+		expect(resumedSourceCandidate.identity).not.toEqual(sourceCandidate.identity);
+		expect(
+			await broker.handleRequest("session.close", { sessionId: sourceId }, "canonical-cold-resume-close"),
+		).toMatchObject({
+			ok: true,
+			result: { sessionId: sourceId },
+		});
+		await waitFor(
+			async () =>
+				(await fs.access(path.join(stateRoot, "sdk", `${sourceId}.json`)).then(
+					() => false,
+					() => true,
+				))
+					? true
+					: undefined,
+			"canonical resume endpoint cleanup",
+		);
+		expect(
+			await fs.access(path.join(stateRoot, "sdk", `${sourceId}.lifecycle.json`)).then(
+				() => true,
+				() => false,
+			),
+		).toBe(true);
+		expect(
+			await fs.access(path.join(stateRoot, "sdk", `${sourceId}.lifecycle.ready.json`)).then(
+				() => true,
+				() => false,
+			),
+		).toBe(true);
+		expect(await broker.handleRequest("session.get_endpoint", { sessionId: sourceId })).toMatchObject({
+			ok: false,
+			error: { code: "resource_gone" },
+		});
+		const resumedSourceBytes = await fs.readFile(sourcePath);
+
+		const forkSourceCandidate = await assertCanonicalSource();
+
+		const forked = await broker.handleRequest(
+			"session.fork",
+			{ cwd: root, stateRoot, sourceSessionId: sourceId, sourceSessionPath: sourcePath },
+			"canonical-cold-fork",
+		);
+		expect(forked).toMatchObject({ ok: true });
+		if (!forked.ok) throw new Error(forked.error.message);
+		const forkResult = forked.result as { sessionId?: unknown };
+		const forkId = String(forkResult.sessionId);
+		expect(forkId).not.toBe(sourceId);
+		const inventory = await listManagedSessionCandidates({ scope: scopeResult.scope });
+		expect(inventory.kind).toBe("complete");
+		if (inventory.kind !== "complete") throw new Error(inventory.message);
+		const forkCandidates = inventory.owned.filter(candidate => candidate.sessionId === forkId);
+		expect(forkCandidates).toHaveLength(1);
+		const forkCandidate = forkCandidates[0]!;
+		expect(path.dirname(forkCandidate.path)).toBe(scopeResult.scope.directoryPath);
+		expect(forkCandidate.identity.sessionId).toBe(forkId);
+		expect(
+			await broker.handleRequest("session.close", { sessionId: forkId }, "canonical-cold-fork-close"),
+		).toMatchObject({
+			ok: true,
+			result: { sessionId: forkId },
+		});
+		await waitFor(
+			async () =>
+				(await fs.access(path.join(stateRoot, "sdk", `${forkId}.json`)).then(
+					() => false,
+					() => true,
+				))
+					? true
+					: undefined,
+			"canonical fork endpoint cleanup",
+		);
+		expect(
+			await fs.access(path.join(stateRoot, "sdk", `${forkId}.lifecycle.json`)).then(
+				() => true,
+				() => false,
+			),
+		).toBe(true);
+		expect(
+			await fs.access(path.join(stateRoot, "sdk", `${forkId}.lifecycle.ready.json`)).then(
+				() => true,
+				() => false,
+			),
+		).toBe(true);
+		expect(await broker.handleRequest("session.get_endpoint", { sessionId: forkId })).toMatchObject({
+			ok: false,
+			error: { code: "resource_gone" },
+		});
+		expect(
+			await broker.handleRequest(
+				"session.delete",
+				{ cwd: root, stateRoot, sessionId: forkId, sessionPath: forkCandidate.path },
+				"canonical-cold-fork-delete",
+			),
+		).toMatchObject({ ok: true, result: { sessionId: forkId } });
+		expect(
+			await fs.access(forkCandidate.path).then(
+				() => true,
+				() => false,
+			),
+		).toBe(false);
+		expect(
+			await fs.access(path.join(stateRoot, "sdk", `${forkId}.lifecycle.json`)).then(
+				() => true,
+				() => false,
+			),
+		).toBe(false);
+		expect(
+			await fs.access(path.join(stateRoot, "sdk", `${forkId}.lifecycle.ready.json`)).then(
+				() => true,
+				() => false,
+			),
+		).toBe(false);
+		const afterDelete = await listManagedSessionCandidates({ scope: scopeResult.scope });
+		expect(afterDelete.kind).toBe("complete");
+		if (afterDelete.kind !== "complete") throw new Error(afterDelete.message);
+		expect(afterDelete.owned.some(candidate => candidate.sessionId === forkId)).toBe(false);
+		expect(await fs.readFile(sourcePath)).toEqual(resumedSourceBytes);
+		expect((await assertCanonicalSource()).identity).toEqual(forkSourceCandidate.identity);
+		expect(
+			await broker.handleRequest(
+				"session.delete",
+				{ cwd: root, stateRoot, sessionId: sourceId, sessionPath: sourcePath },
+				"canonical-cold-resume-delete",
+			),
+		).toMatchObject({ ok: true, result: { sessionId: sourceId } });
+		expect(
+			await fs.access(sourcePath).then(
+				() => true,
+				() => false,
+			),
+		).toBe(false);
+		expect(
+			await fs.access(path.join(stateRoot, "sdk", `${sourceId}.lifecycle.json`)).then(
+				() => true,
+				() => false,
+			),
+		).toBe(false);
+		expect(
+			await fs.access(path.join(stateRoot, "sdk", `${sourceId}.lifecycle.ready.json`)).then(
+				() => true,
+				() => false,
+			),
+		).toBe(false);
+	} finally {
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 30_000);
 
 test("broker terminalizes default command resolver failures", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-resolver-failure-"));

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -1515,6 +1515,131 @@ test("broker rejects a corrupt completed lifecycle cleanup receipt when its read
 	}
 }, 30_000);
 
+test("broker rejects malformed lifecycle cleanup receipts without mutating metadata", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-malformed-lifecycle-replay-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "malformed-lifecycle-replay";
+	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+	const request = { cwd: root, stateRoot, sessionId };
+	const marker = canonicalJson({
+		pid: process.pid,
+		effectMarker: "malformed-replay",
+		incarnation: "malformed-replay",
+	});
+	const broker = new Broker({ agentDir });
+	try {
+		await fs.mkdir(path.dirname(markerPath), { recursive: true });
+		await fs.writeFile(markerPath, marker);
+		await fs.writeFile(readyPath, marker);
+		await broker.start();
+		const identity = {
+			dev: "1",
+			ino: "1",
+			size: 1,
+			mtimeNs: "1",
+			sha256: "a".repeat(64),
+		};
+		const validFile = {
+			path: markerPath,
+			identity,
+			attempt: 1,
+			plannedPath: path.join(stateRoot, "sdk", ".gjc-delete-malformed-marker"),
+		};
+		const malformed = [
+			{ lifecycleFiles: [null] },
+			{ lifecycleFiles: [{}] },
+			{ lifecycleFiles: [validFile], lifecycleDeleteMetadata: false },
+			{ lifecycleFiles: [{ ...validFile, completed: "true" }] },
+			{ lifecycleFiles: [{ ...validFile, metadataPath: markerPath }] },
+		] as const;
+		for (const [index, fragment] of malformed.entries()) {
+			const response = await executeLifecycle(
+				broker,
+				"session.delete",
+				request,
+				`malformed-lifecycle-replay-${index}`,
+				{
+					phase: "lifecycle",
+					sessionId,
+					metadataRoot: stateRoot,
+					...fragment,
+				} as unknown as BrokerCleanupEvidence,
+			);
+			expect(response.response).toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+		}
+		expect(await fs.readFile(markerPath, "utf8")).toBe(marker);
+		expect(await fs.readFile(readyPath, "utf8")).toBe(marker);
+	} finally {
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
+test("broker rejects oversized lifecycle marker and readiness receipts before hashing or unlinking", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-oversized-lifecycle-replay-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "oversized-lifecycle-replay";
+	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+	const request = { cwd: root, stateRoot, sessionId };
+	const broker = new Broker({ agentDir });
+	const capture = async (file: string) => {
+		const [stat, bytes] = await Promise.all([fs.stat(file, { bigint: true }), fs.readFile(file)]);
+		return {
+			dev: stat.dev.toString(),
+			ino: stat.ino.toString(),
+			size: Number(stat.size),
+			mtimeNs: stat.mtimeNs.toString(),
+			sha256: createHash("sha256").update(bytes).digest("hex"),
+		};
+	};
+	const cleanup = async (): Promise<BrokerCleanupEvidence> => ({
+		phase: "lifecycle",
+		sessionId,
+		metadataRoot: stateRoot,
+		lifecycleDeleteMetadata: true,
+		lifecycleFiles: [
+			{
+				path: markerPath,
+				identity: await capture(markerPath),
+				attempt: 1,
+				plannedPath: path.join(stateRoot, "sdk", ".gjc-delete-oversized-marker"),
+			},
+			{
+				path: readyPath,
+				identity: await capture(readyPath),
+				attempt: 1,
+				plannedPath: path.join(stateRoot, "sdk", ".gjc-delete-oversized-ready"),
+			},
+		],
+	});
+	try {
+		await fs.mkdir(path.dirname(markerPath), { recursive: true });
+		const valid = canonicalJson({
+			pid: process.pid,
+			effectMarker: "oversized-replay",
+			incarnation: "oversized-replay",
+		});
+		await fs.writeFile(markerPath, `${valid}${" ".repeat(4096)}`);
+		await fs.writeFile(readyPath, valid);
+		await broker.start();
+		let response = await executeLifecycle(broker, "session.delete", request, "oversized-marker", await cleanup());
+		expect(response.response).toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+		expect((await fs.stat(markerPath)).size).toBeGreaterThan(4096);
+		await fs.writeFile(markerPath, valid);
+		await fs.writeFile(readyPath, `${valid}${" ".repeat(4096)}`);
+		response = await executeLifecycle(broker, "session.delete", request, "oversized-ready", await cleanup());
+		expect(response.response).toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+		expect((await fs.stat(readyPath)).size).toBeGreaterThan(4096);
+	} finally {
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
 test("broker rejects duplicate lifecycle marker replay authorities without unlinking siblings", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-duplicate-lifecycle-replay-"));
 	const agentDir = path.join(root, "agent");

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -1168,6 +1168,56 @@ test("broker refuses fresh lifecycle cleanup when ready sibling has a different 
 	}
 }, 30_000);
 
+test("broker preserves ready-only lifecycle metadata without canonical marker authority during fresh delete", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-ready-only-cleanup-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const saved = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+	const broker = new Broker({ agentDir });
+	try {
+		await saved.ensureOnDisk();
+		const sessionId = saved.getSessionId();
+		const sessionPath = saved.getSessionFile();
+		if (!sessionPath) throw new Error("Expected persisted delete transcript.");
+		await saved.close();
+		const deadOwner = Bun.spawn([process.execPath, "-e", ""]);
+		await deadOwner.exited;
+		const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+		const readyMarker = {
+			pid: deadOwner.pid,
+			effectMarker: "ready-only-dead-owner",
+			incarnation: "ready-only-dead-incarnation",
+		};
+		await fs.mkdir(path.dirname(readyPath), { recursive: true });
+		await fs.writeFile(readyPath, canonicalJson(readyMarker));
+
+		await broker.start();
+		await expect(
+			broker.handleRequest(
+				"session.delete",
+				{ cwd: root, stateRoot, sessionId, sessionPath },
+				"ready-only-fresh-delete",
+			),
+		).resolves.toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+		await expect(fs.readFile(readyPath, "utf8")).resolves.toBe(canonicalJson(readyMarker));
+		const rows = (await fs.readFile(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8"))
+			.split("\n")
+			.filter(Boolean)
+			.map(line => JSON.parse(line) as Record<string, unknown>);
+		expect(
+			rows.some(
+				row =>
+					((row.response as { error?: { cleanup?: { phase?: unknown } } } | undefined)?.error?.cleanup?.phase ??
+						null) === "lifecycle",
+			),
+		).toBe(false);
+		expect(rows.some(row => (row.response as { ok?: unknown } | undefined)?.ok === true)).toBe(false);
+	} finally {
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 30_000);
+
 test("broker replays a completed base metadata cleanup receipt and rejects a replaced ready sibling after marker loss", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-legacy-metadata-replay-"));
 	const agentDir = path.join(root, "agent");

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -9,6 +9,7 @@ import { planLaunchWorktree } from "../src/gjc-runtime/launch-worktree";
 import { AcpAgent } from "../src/modes/acp/acp-agent";
 import { Broker, type BrokerResponse } from "../src/sdk/broker/broker";
 import { brokerOwnerForTest } from "../src/sdk/broker/ensure";
+import { deriveIdempotencyIdentity } from "../src/sdk/broker/identity";
 import {
 	deriveLifecycleDeadlines,
 	hasValidLifecycleDeadlines,
@@ -1093,6 +1094,74 @@ test("broker replays one identity-bound lifecycle metadata cleanup plan after th
 	} finally {
 		await crashing?.stop();
 		await reopened?.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 30_000);
+test("broker replays a base metadata cleanup receipt after reopen without stranding its lifecycle marker", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-legacy-metadata-replay-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "legacy-metadata-replay";
+	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+	const plannedPath = path.join(stateRoot, "sdk", `.gjc-delete-base-${sessionId}.lifecycle.json`);
+	const request = { sessionId };
+	const key = "base-metadata-cleanup-replay";
+	let broker: Broker | undefined;
+	try {
+		await fs.mkdir(path.dirname(markerPath), { recursive: true });
+		await fs.writeFile(markerPath, JSON.stringify({ pid: process.pid, effectMarker: "base", incarnation: "base" }));
+		const [stat, bytes] = await Promise.all([fs.stat(markerPath, { bigint: true }), fs.readFile(markerPath)]);
+		const target = createHash("sha256").update(canonicalJson({ sessionId })).digest("hex");
+		const identity = await deriveIdempotencyIdentity(agentDir, "session.delete", key, target);
+		const requestHash = createHash("sha256")
+			.update(canonicalJson({ operation: "session.delete", input: request }))
+			.digest("hex");
+		const ledger = await new LifecycleLedger(agentDir).open();
+		await ledger.begin(identity, requestHash);
+		await ledger.transition(identity, "effect_started", {
+			response: {
+				ok: false,
+				error: {
+					code: "cleanup_pending",
+					message: "Base metadata cleanup is pending.",
+					cleanup: {
+						phase: "metadata",
+						sessionId,
+						metadataRoot: stateRoot,
+						metadataPath: markerPath,
+						metadataIdentity: {
+							dev: stat.dev.toString(),
+							ino: stat.ino.toString(),
+							size: Number(stat.size),
+							mtimeNs: stat.mtimeNs.toString(),
+							sha256: createHash("sha256").update(bytes).digest("hex"),
+						},
+						metadataAttempt: 1,
+						plannedMetadataPath: plannedPath,
+					},
+				},
+			},
+		});
+
+		broker = new Broker({ agentDir });
+		await broker.start();
+		await expect(broker.handleRequest("session.delete", request, key)).resolves.toEqual({
+			ok: true,
+			result: { sessionId },
+		});
+		await expect(fs.stat(markerPath)).rejects.toThrow();
+		const rows = (await fs.readFile(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8"))
+			.split("\n")
+			.filter(Boolean)
+			.map(line => JSON.parse(line) as Record<string, unknown>);
+		const migrated = rows.findLast(row => row.state === "effect_started" && row.response);
+		expect((migrated?.response as { error?: { cleanup?: unknown } } | undefined)?.error?.cleanup).toMatchObject({
+			phase: "lifecycle",
+			sessionId,
+			lifecycleFiles: [expect.objectContaining({ path: markerPath, plannedPath })],
+		});
+	} finally {
+		await broker?.stop();
 		await fs.rm(root, { recursive: true, force: true });
 	}
 }, 30_000);

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -1263,7 +1263,7 @@ test("broker preserves ready-only lifecycle metadata without canonical marker au
 	}
 }, 30_000);
 
-test("broker replays a completed base metadata cleanup receipt and rejects a replaced ready sibling after marker loss", async () => {
+test("broker replays an unmarked base metadata cleanup receipt and rejects a replaced ready sibling after marker loss", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-legacy-metadata-replay-"));
 	const agentDir = path.join(root, "agent");
 	const stateRoot = path.join(root, ".gjc", "state");
@@ -1307,7 +1307,6 @@ test("broker replays a completed base metadata cleanup receipt and rejects a rep
 						},
 						metadataAttempt: 1,
 						plannedMetadataPath: plannedPath,
-						metadataCompleted: true,
 					},
 				},
 			},
@@ -1417,7 +1416,6 @@ test("broker replays a completed base metadata cleanup receipt and rejects a rep
 							sha256: createHash("sha256").update(mismatchedBytes).digest("hex"),
 						},
 						plannedMetadataPath: mismatchedPlannedPath,
-						metadataCompleted: true,
 					},
 				},
 			},

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -3136,3 +3136,172 @@ test("lifecycle cleanup rejects transplanted and ambiguous receipts before mutat
 		await fs.rm(root, { recursive: true, force: true });
 	}
 });
+
+test("lifecycle cleanup receipt parser rejects hostile bounded inputs without touching user data", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-hostile-lifecycle-receipt-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "hostile-lifecycle-receipt";
+	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+	const transcriptPath = path.join(root, "user.jsonl");
+	const artifactsPath = transcriptPath.slice(0, -6);
+	const request = { cwd: root, stateRoot, sessionId };
+	const broker = new Broker({ agentDir });
+	const outsidePlannedPath = path.join(root, "outside-planned");
+	const outsideDetachedPath = path.join(root, "outside-detached");
+	const outsideMarkerPath = path.join(root, "outside-marker");
+	const outsideReadyPath = path.join(root, "outside-ready");
+	const marker = canonicalJson({ pid: process.pid, effectMarker: "hostile-replay", incarnation: "hostile-replay" });
+	const capture = async (file: string) => {
+		const [stat, bytes] = await Promise.all([fs.stat(file, { bigint: true }), fs.readFile(file)]);
+		return {
+			dev: stat.dev.toString(),
+			ino: stat.ino.toString(),
+			size: Number(stat.size),
+			mtimeNs: stat.mtimeNs.toString(),
+			sha256: createHash("sha256").update(bytes).digest("hex"),
+		};
+	};
+	const cleanup = async (): Promise<BrokerCleanupEvidence> => ({
+		phase: "lifecycle",
+		sessionId,
+		metadataRoot: stateRoot,
+		lifecycleDeleteMetadata: true,
+		lifecycleFiles: [
+			{
+				path: markerPath,
+				identity: await capture(markerPath),
+				attempt: 1,
+				plannedPath: path.join(stateRoot, "sdk", ".gjc-delete-hostile-marker"),
+			},
+			{
+				path: readyPath,
+				identity: await capture(readyPath),
+				attempt: 1,
+				plannedPath: path.join(stateRoot, "sdk", ".gjc-delete-hostile-ready"),
+			},
+		],
+	});
+	const restoreBoundSiblings = async (value = marker) => {
+		await Promise.all([fs.rm(markerPath, { force: true }), fs.rm(readyPath, { force: true })]);
+		await Promise.all([fs.writeFile(markerPath, value), fs.writeFile(readyPath, value)]);
+	};
+	let preserved: { transcript: Buffer; artifacts: string | undefined };
+	const assertPreserved = async () => expect(await snapshotDeleteSurface(transcriptPath)).toEqual(preserved);
+	const reject = async (name: string, evidence: BrokerCleanupEvidence) => {
+		const siblingBytes = await Promise.all([fs.readFile(markerPath), fs.readFile(readyPath)]);
+		const started = Date.now();
+		const outcome = await executeLifecycle(broker, "session.delete", request, `hostile-lifecycle-${name}`, evidence);
+		expect(outcome.response).toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+		expect(Date.now() - started).toBeLessThan(1_000);
+		expect(await Promise.all([fs.readFile(markerPath), fs.readFile(readyPath)])).toEqual(siblingBytes);
+		await assertPreserved();
+	};
+	try {
+		await fs.mkdir(path.dirname(markerPath), { recursive: true });
+		await fs.writeFile(transcriptPath, "preserve user transcript\n");
+		await fs.mkdir(artifactsPath);
+		await fs.writeFile(path.join(artifactsPath, "artifact.txt"), "preserve user artifact\n");
+		await Promise.all([
+			fs.writeFile(outsidePlannedPath, "preserve planned target\n"),
+			fs.writeFile(outsideDetachedPath, "preserve detached target\n"),
+			fs.writeFile(outsideMarkerPath, "preserve marker target\n"),
+			fs.writeFile(outsideReadyPath, "preserve ready target\n"),
+		]);
+		await restoreBoundSiblings();
+		preserved = await snapshotDeleteSurface(transcriptPath);
+		await broker.start();
+
+		const valid = await cleanup();
+		const nested = { value: 0 } as { value: number | { value: unknown } };
+		for (let depth = 0; depth < 16; depth++) nested.value = { value: nested.value };
+		const excessiveCardinality: BrokerCleanupEvidence = {
+			...valid,
+			lifecycleFiles: [...valid.lifecycleFiles!, ...valid.lifecycleFiles!, valid.lifecycleFiles![0]],
+		};
+		const deepExtraEntry = {
+			...valid,
+			lifecycleFiles: [{ ...valid.lifecycleFiles![0], unexpected: nested }, valid.lifecycleFiles![1]],
+		} as unknown as BrokerCleanupEvidence;
+		const mixedLegacyEntry = {
+			...valid,
+			metadataPath: markerPath,
+			metadataIdentity: valid.lifecycleFiles![0].identity,
+		} as unknown as BrokerCleanupEvidence;
+		const duplicateAuthority: BrokerCleanupEvidence = {
+			...valid,
+			lifecycleFiles: [
+				valid.lifecycleFiles![0],
+				{ ...valid.lifecycleFiles![0], plannedPath: valid.lifecycleFiles![1].plannedPath },
+			],
+		};
+		for (const [name, evidence] of [
+			["excessive-array", excessiveCardinality],
+			["deep-extra-entry", deepExtraEntry],
+			["mixed-legacy-entry", mixedLegacyEntry],
+			["duplicate-authority", duplicateAuthority],
+		] as const)
+			await reject(name, evidence);
+
+		for (const [name, corruptPath] of [
+			["corrupt-marker", markerPath],
+			["corrupt-ready", readyPath],
+		] as const) {
+			await restoreBoundSiblings();
+			await fs.writeFile(corruptPath, Buffer.from([0xc3, 0x28]));
+			await reject(name, await cleanup());
+			await expect(fs.readFile(corruptPath)).resolves.toEqual(Buffer.from([0xc3, 0x28]));
+		}
+
+		for (const [name, siblingPath, outsidePath] of [
+			["marker-symlink", markerPath, outsideMarkerPath],
+			["ready-symlink", readyPath, outsideReadyPath],
+		] as const) {
+			await restoreBoundSiblings();
+			await fs.rm(siblingPath);
+			await fs.symlink(outsidePath, siblingPath);
+			await reject(name, await cleanup());
+			expect((await fs.lstat(siblingPath)).isSymbolicLink()).toBe(true);
+			await expect(fs.readFile(outsidePath, "utf8")).resolves.toContain("preserve");
+		}
+
+		await restoreBoundSiblings();
+		const traversal = await cleanup();
+		traversal.lifecycleFiles![0].plannedPath = path.join(stateRoot, "sdk", "..", "outside-planned");
+		await reject("planned-traversal", traversal);
+		const detachedOutside = await cleanup();
+		detachedOutside.lifecycleFiles![1].detachedPath = outsideDetachedPath;
+		await reject("detached-outside", detachedOutside);
+		await expect(fs.readFile(outsidePlannedPath, "utf8")).resolves.toBe("preserve planned target\n");
+		await expect(fs.readFile(outsideDetachedPath, "utf8")).resolves.toBe("preserve detached target\n");
+
+		const oversizedField = canonicalJson({
+			pid: process.pid,
+			effectMarker: "x".repeat(3_500),
+			incarnation: "hostile-replay",
+		});
+		expect(Buffer.byteLength(oversizedField)).toBeLessThanOrEqual(4096);
+		await restoreBoundSiblings(oversizedField);
+		await reject("oversized-field", await cleanup());
+		await expect(fs.readFile(markerPath, "utf8")).resolves.toBe(oversizedField);
+		await expect(fs.readFile(readyPath, "utf8")).resolves.toBe(oversizedField);
+
+		await restoreBoundSiblings();
+		await broker.ledger.begin("hostile-lifecycle-control", "hostile-lifecycle-control-request");
+		const control = await executeLifecycle(
+			broker,
+			"session.delete",
+			request,
+			"hostile-lifecycle-control",
+			await cleanup(),
+		);
+		expect(control.response).toEqual({ ok: true, result: { sessionId } });
+		await expect(fs.lstat(markerPath)).rejects.toThrow();
+		await expect(fs.lstat(readyPath)).rejects.toThrow();
+		await assertPreserved();
+	} finally {
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -67,6 +67,37 @@ function canonicalJson(value: unknown): string {
 		.join(",")}}`;
 }
 
+async function snapshotDeleteSurface(
+	sessionPath: string,
+): Promise<{ transcript: Buffer; artifacts: string | undefined }> {
+	const artifactsPath = sessionPath.slice(0, -6);
+	const digestTree = async (directory: string): Promise<string> => {
+		const entries = await fs.readdir(directory, { withFileTypes: true });
+		const parts = await Promise.all(
+			entries
+				.sort((left, right) => left.name.localeCompare(right.name))
+				.map(async entry => {
+					const entryPath = path.join(directory, entry.name);
+					if (entry.isDirectory()) return `d:${entry.name}:${await digestTree(entryPath)}`;
+					if (entry.isFile())
+						return `f:${entry.name}:${createHash("sha256")
+							.update(await fs.readFile(entryPath))
+							.digest("hex")}`;
+
+					return `other:${entry.name}`;
+				}),
+		);
+		return createHash("sha256").update(parts.join("\n")).digest("hex");
+	};
+	return {
+		transcript: await fs.readFile(sessionPath),
+		artifacts: await digestTree(artifactsPath).catch(error => {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+			throw error;
+		}),
+	};
+}
+
 test("startup diagnostics redact identifier-prefixed assignment secrets before bounded truncation", () => {
 	const secret = "credential-value";
 	const message = sanitizeSdkStartupMessage(
@@ -1109,6 +1140,10 @@ test("broker refuses fresh lifecycle cleanup when ready sibling has a different 
 		const sessionPath = saved.getSessionFile();
 		if (!sessionPath) throw new Error("Expected persisted delete transcript.");
 		await saved.close();
+		const artifactsPath = sessionPath.slice(0, -6);
+		await fs.mkdir(path.join(artifactsPath, "nested"), { recursive: true });
+		await fs.writeFile(path.join(artifactsPath, "nested", "preserve.txt"), "preserve mismatch artifacts");
+
 		await broker.start();
 		await expect(
 			broker.handleRequest(
@@ -1141,6 +1176,7 @@ test("broker refuses fresh lifecycle cleanup when ready sibling has a different 
 			incarnation: string;
 		};
 		await fs.writeFile(readyPath, JSON.stringify({ ...marker, effectMarker: "different-ready-owner" }));
+		const surfaceBeforeDelete = await snapshotDeleteSurface(sessionPath);
 
 		await expect(
 			broker.handleRequest(
@@ -1151,6 +1187,8 @@ test("broker refuses fresh lifecycle cleanup when ready sibling has a different 
 		).resolves.toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
 		await expect(fs.stat(markerPath)).resolves.toBeDefined();
 		await expect(fs.stat(readyPath)).resolves.toBeDefined();
+		expect(await snapshotDeleteSurface(sessionPath)).toEqual(surfaceBeforeDelete);
+
 		const rows = (await fs.readFile(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8"))
 			.split("\n")
 			.filter(Boolean)
@@ -1180,6 +1218,10 @@ test("broker preserves ready-only lifecycle metadata without canonical marker au
 		const sessionPath = saved.getSessionFile();
 		if (!sessionPath) throw new Error("Expected persisted delete transcript.");
 		await saved.close();
+		const artifactsPath = sessionPath.slice(0, -6);
+		await fs.mkdir(path.join(artifactsPath, "nested"), { recursive: true });
+		await fs.writeFile(path.join(artifactsPath, "nested", "preserve.txt"), "preserve ready-only artifacts");
+
 		const deadOwner = Bun.spawn([process.execPath, "-e", ""]);
 		await deadOwner.exited;
 		const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
@@ -1190,6 +1232,7 @@ test("broker preserves ready-only lifecycle metadata without canonical marker au
 		};
 		await fs.mkdir(path.dirname(readyPath), { recursive: true });
 		await fs.writeFile(readyPath, canonicalJson(readyMarker));
+		const surfaceBeforeDelete = await snapshotDeleteSurface(sessionPath);
 
 		await broker.start();
 		await expect(
@@ -1200,6 +1243,7 @@ test("broker preserves ready-only lifecycle metadata without canonical marker au
 			),
 		).resolves.toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
 		await expect(fs.readFile(readyPath, "utf8")).resolves.toBe(canonicalJson(readyMarker));
+		expect(await snapshotDeleteSurface(sessionPath)).toEqual(surfaceBeforeDelete);
 		const rows = (await fs.readFile(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8"))
 			.split("\n")
 			.filter(Boolean)
@@ -1386,6 +1430,103 @@ test("broker replays a completed base metadata cleanup receipt and rejects a rep
 		});
 		await expect(fs.stat(mismatchedMarkerPath)).rejects.toThrow();
 		await expect(fs.readFile(mismatchedReadyPath, "utf8")).resolves.toBe(canonicalJson(replacedReady));
+	} finally {
+		await broker?.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 30_000);
+
+test("broker rejects a corrupt completed lifecycle cleanup receipt when its ready sibling remains", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-completed-lifecycle-replay-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "completed-lifecycle-replay";
+	const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+	const readyPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`);
+	const request = { sessionId };
+	const key = "completed-lifecycle-replay";
+	let broker: Broker | undefined;
+	try {
+		const marker = {
+			pid: process.pid,
+			effectMarker: "completed-replay",
+			incarnation: "completed-replay",
+		};
+
+		await fs.mkdir(path.dirname(markerPath), { recursive: true });
+		await fs.writeFile(markerPath, canonicalJson(marker));
+		await fs.writeFile(readyPath, canonicalJson(marker));
+		const [markerStat, markerBytes, readyStat, readyBytes] = await Promise.all([
+			fs.stat(markerPath, { bigint: true }),
+			fs.readFile(markerPath),
+			fs.stat(readyPath, { bigint: true }),
+			fs.readFile(readyPath),
+		]);
+		const target = createHash("sha256").update(canonicalJson(request)).digest("hex");
+		const identity = await deriveIdempotencyIdentity(agentDir, "session.delete", key, target);
+		const requestHash = createHash("sha256")
+			.update(canonicalJson({ operation: "session.delete", input: request }))
+			.digest("hex");
+		const ledger = await new LifecycleLedger(agentDir).open();
+		await ledger.begin(identity, requestHash);
+		await ledger.transition(identity, "effect_started", {
+			response: {
+				ok: false,
+				error: {
+					code: "cleanup_pending",
+					message: "Lifecycle cleanup is pending.",
+					cleanup: {
+						phase: "lifecycle",
+						sessionId,
+						metadataRoot: stateRoot,
+						lifecycleFiles: [
+							{
+								path: markerPath,
+								identity: {
+									dev: markerStat.dev.toString(),
+									ino: markerStat.ino.toString(),
+									size: Number(markerStat.size),
+									mtimeNs: markerStat.mtimeNs.toString(),
+									sha256: createHash("sha256").update(markerBytes).digest("hex"),
+								},
+								attempt: 1,
+								plannedPath: path.join(
+									path.dirname(markerPath),
+									`.gjc-delete-marker-${sessionId}.lifecycle.json`,
+								),
+
+								completed: true,
+							},
+							{
+								path: readyPath,
+								identity: {
+									dev: readyStat.dev.toString(),
+									ino: readyStat.ino.toString(),
+									size: Number(readyStat.size),
+									mtimeNs: readyStat.mtimeNs.toString(),
+									sha256: createHash("sha256").update(readyBytes).digest("hex"),
+								},
+								attempt: 1,
+								plannedPath: path.join(
+									path.dirname(readyPath),
+									`.gjc-delete-ready-${sessionId}.lifecycle.ready.json`,
+								),
+								completed: true,
+							},
+						],
+					},
+				},
+			},
+		});
+		await fs.unlink(markerPath);
+		broker = new Broker({ agentDir });
+		await broker.start();
+		await expect(broker.handleRequest("session.delete", request, key)).resolves.toMatchObject({
+			ok: false,
+			error: { code: "terminal_uncertain" },
+		});
+		await expect(fs.stat(markerPath)).rejects.toThrow();
+		await expect(fs.readFile(readyPath)).resolves.toEqual(readyBytes);
 	} finally {
 		await broker?.stop();
 		await fs.rm(root, { recursive: true, force: true });

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -1035,7 +1035,7 @@ describe("SDK broker identity and discovery", () => {
 		}
 	});
 
-	it("persists an identity-bound metadata quarantine plan before a failed exact detach", async () => {
+	it("persists an identity-bound lifecycle cleanup plan before a failed exact metadata detach", async () => {
 		const dir = await temp();
 		const cwd = path.join(dir, "workspace");
 		const stateRoot = path.join(cwd, ".gjc", "state");
@@ -1072,11 +1072,15 @@ describe("SDK broker identity and discovery", () => {
 				error: {
 					code: "cleanup_pending",
 					cleanup: {
-						phase: "metadata",
-						metadataPath: markerPath,
-						metadataIdentity: expect.objectContaining({ sha256: expect.any(String) }),
-						plannedMetadataPath: expect.stringMatching(/\.gjc-delete-.*\.lifecycle\.json$/),
-						detachedMetadataPath: expect.stringMatching(/\.gjc-delete-.*\.lifecycle\.json$/),
+						phase: "lifecycle",
+						lifecycleFiles: [
+							expect.objectContaining({
+								path: markerPath,
+								identity: expect.objectContaining({ sha256: expect.any(String) }),
+								plannedPath: expect.stringMatching(/\.gjc-delete-.*\.lifecycle\.json$/),
+								detachedPath: expect.stringMatching(/\.gjc-delete-.*\.lifecycle\.json$/),
+							}),
+						],
 					},
 				},
 			});
@@ -1093,9 +1097,13 @@ describe("SDK broker identity and discovery", () => {
 					response: expect.objectContaining({
 						error: expect.objectContaining({
 							cleanup: expect.objectContaining({
-								phase: "metadata",
-								metadataIdentity: expect.objectContaining({ sha256: expect.any(String) }),
-								plannedMetadataPath: expect.stringMatching(/\.gjc-delete-.*\.lifecycle\.json$/),
+								phase: "lifecycle",
+								lifecycleFiles: [
+									expect.objectContaining({
+										identity: expect.objectContaining({ sha256: expect.any(String) }),
+										plannedPath: expect.stringMatching(/\.gjc-delete-.*\.lifecycle\.json$/),
+									}),
+								],
 							}),
 						}),
 					}),
@@ -1119,11 +1127,12 @@ describe("SDK broker identity and discovery", () => {
 									| undefined,
 						)
 						.map(error => error?.cleanup as Record<string, unknown> | undefined)
-						.findLast(
-							cleanup =>
-								cleanup?.detachedMetadataPath === detachedQ1 && cleanup?.plannedMetadataPath !== detachedQ1,
-						);
-					plannedQ2 = pendingCleanup?.plannedMetadataPath as string | undefined;
+						.findLast(cleanup => {
+							const file = (cleanup?.lifecycleFiles as Record<string, unknown>[] | undefined)?.[0];
+							return file?.detachedPath === detachedQ1 && file?.plannedPath !== detachedQ1;
+						});
+					plannedQ2 = (pendingCleanup?.lifecycleFiles as Record<string, unknown>[] | undefined)?.[0]
+						?.plannedPath as string | undefined;
 					expect(plannedQ2).toEqual(expect.any(String));
 					expect(plannedQ2).not.toBe(detachedQ1);
 					expect((identity as { quarantineName?: string }).quarantineName).toBe(path.basename(plannedQ2!));

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -1077,8 +1077,8 @@ describe("SDK broker identity and discovery", () => {
 							expect.objectContaining({
 								path: markerPath,
 								identity: expect.objectContaining({ sha256: expect.any(String) }),
-								plannedPath: expect.stringMatching(/\.gjc-delete-.*\.lifecycle\.json$/),
-								detachedPath: expect.stringMatching(/\.gjc-delete-.*\.lifecycle\.json$/),
+								plannedPath: detachedQ1,
+								detachedPath: detachedQ1,
 							}),
 						],
 					},

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -1035,14 +1035,14 @@ describe("SDK broker identity and discovery", () => {
 		}
 	});
 
-	it("persists an identity-bound lifecycle cleanup plan before a failed exact metadata detach", async () => {
+	it("retries cleanup pending after restart, then reopens and exactly replays successful metadata cleanup", async () => {
 		const dir = await temp();
 		const cwd = path.join(dir, "workspace");
 		const stateRoot = path.join(cwd, ".gjc", "state");
 		const sessionId = "metadata-cleanup-pending";
 		const sessionPath = await managedSessionPath(dir, cwd, sessionId);
 		const markerPath = path.join(stateRoot, "sdk", `${sessionId}.lifecycle.json`);
-		const broker = new Broker({ agentDir: dir });
+		let broker = new Broker({ agentDir: dir });
 		const originalUnlink = native.exactUnlink;
 		let detachedQ1: string | undefined;
 		await fs.mkdir(path.dirname(sessionPath), { recursive: true });
@@ -1111,6 +1111,9 @@ describe("SDK broker identity and discovery", () => {
 			);
 			if (!detachedQ1) throw new Error("Missing persisted Q1 metadata path");
 			vi.restoreAllMocks();
+			await broker.stop();
+			broker = new Broker({ agentDir: dir });
+			await broker.start();
 			let plannedQ2: string | undefined;
 			const replay = vi.spyOn(native, "exactUnlink").mockImplementation((pathname, identity) => {
 				if (pathname === detachedQ1) {
@@ -1152,6 +1155,16 @@ describe("SDK broker identity and discovery", () => {
 			}
 			expect(plannedQ2).toEqual(expect.any(String));
 			expect(await fs.stat(detachedQ1).catch(() => undefined)).toBeUndefined();
+			await broker.stop();
+			broker = new Broker({ agentDir: dir });
+			await broker.start();
+			expect(
+				await broker.handleRequest(
+					"session.delete",
+					{ sessionId, sessionPath, cwd },
+					"metadata-cleanup-pending-key",
+				),
+			).toMatchObject({ ok: true, result: { sessionId } });
 		} finally {
 			vi.restoreAllMocks();
 			await broker.stop();

--- a/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
+++ b/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
@@ -106,6 +106,201 @@ describe("SDK lifecycle ledger", () => {
 		expect(lines.map(line => JSON.parse(line))).toHaveLength(2);
 		expect((await new LifecycleLedger(dir).open()).get("i")?.response).toEqual(response);
 	});
+	it("reads concurrent terminal proof without mutating an unrelated torn append", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-read-terminal-"));
+		const ledgerPath = path.join(dir, "sdk", "lifecycle-ledger.jsonl");
+		const ledger = await new LifecycleLedger(dir).open();
+		await Promise.all([ledger.begin("first", "first-request"), ledger.begin("second", "second-request")]);
+		await Promise.all([
+			ledger.transition("first", "terminal_ok", { response: { sessionId: "first" } }),
+			ledger.transition("second", "terminal_ok", { response: { sessionId: "second" } }),
+		]);
+		await fs.appendFile(
+			ledgerPath,
+			JSON.stringify(lifecycleRow("unrelated", "unrelated-request", "effect_started", Date.now())).slice(0, -1),
+		);
+		const before = await fs.readFile(ledgerPath, "utf8");
+		const verifier = new LifecycleLedger(dir);
+
+		await expect(verifier.readTerminal("first", "first-request")).resolves.toMatchObject({
+			state: "terminal_ok",
+			response: { sessionId: "first" },
+		});
+		await expect(verifier.readTerminal("second", "second-request")).resolves.toMatchObject({
+			state: "terminal_ok",
+			response: { sessionId: "second" },
+		});
+		expect(await fs.readFile(ledgerPath, "utf8")).toBe(before);
+		expect(await fs.stat(`${ledgerPath}.corrupt`).catch(() => undefined)).toBeUndefined();
+	});
+
+	it("withholds terminal proof for incomplete or conflicting target history", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-read-terminal-target-"));
+		const ledgerPath = path.join(dir, "sdk", "lifecycle-ledger.jsonl");
+		const ledger = await new LifecycleLedger(dir).open();
+		await ledger.begin("target", "request");
+		await ledger.transition("target", "terminal_ok", { response: { sessionId: "target" } });
+		const terminalSource = await fs.readFile(ledgerPath, "utf8");
+		await fs.writeFile(ledgerPath, terminalSource.slice(0, -1));
+		await expect(new LifecycleLedger(dir).readTerminal("target", "request")).resolves.toBeUndefined();
+
+		const conflictingDir = await fs.mkdtemp(
+			path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-read-terminal-conflict-"),
+		);
+		const conflictingPath = path.join(conflictingDir, "sdk", "lifecycle-ledger.jsonl");
+		await fs.mkdir(path.dirname(conflictingPath), { recursive: true });
+		await fs.writeFile(
+			conflictingPath,
+			[
+				lifecycleRow("target", "request", "accepted", 1),
+				lifecycleRow("target", "request", "terminal_ok", 2, {
+					response: { sessionId: "target" },
+					responseDigest: "invalid",
+				}),
+			]
+				.map(row => `${JSON.stringify(row)}\n`)
+				.join(""),
+		);
+		await expect(new LifecycleLedger(conflictingDir).readTerminal("target", "request")).resolves.toBeUndefined();
+	});
+});
+
+function lifecycleRow(
+	identity: string,
+	requestHash: string,
+	state: "accepted" | "effect_started" | "awaiting_ready" | "terminal_ok" | "terminal_error",
+	ts: number,
+	fields: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return { version: 1, identity, requestHash, state, ts, ...fields };
+}
+
+describe("SDK lifecycle ledger history validation", () => {
+	it("quarantines a request hash substitution without exposing its effect intent", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-history-"));
+		const ledgerPath = path.join(dir, "sdk", "lifecycle-ledger.jsonl");
+		await fs.mkdir(path.dirname(ledgerPath), { recursive: true });
+		await fs.writeFile(
+			ledgerPath,
+			[
+				lifecycleRow("i", "original", "accepted", 1),
+				lifecycleRow("i", "substituted", "effect_started", 2, {
+					effectIntent: { sessionId: "untrusted", stateRoot: "/untrusted" },
+				}),
+			]
+				.map(row => `${JSON.stringify(row)}\n`)
+				.join(""),
+		);
+
+		const ledger = await new LifecycleLedger(dir).open();
+		expect(await ledger.begin("i", "original")).toMatchObject({ kind: "terminal_uncertain" });
+		expect(ledger.get("i")).toMatchObject({ state: "terminal_uncertain", requestHash: "original" });
+		expect(ledger.get("i")?.effectIntent).toBeUndefined();
+		expect(await fs.readFile(`${ledgerPath}.corrupt`, "utf8")).toContain("substituted");
+	});
+
+	it("quarantines every row after a terminal entry for the same identity", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-history-"));
+		const ledgerPath = path.join(dir, "sdk", "lifecycle-ledger.jsonl");
+		const response = { sessionId: "s" };
+		const responseDigest = createHash("sha256").update(JSON.stringify(response)).digest("hex");
+		await fs.mkdir(path.dirname(ledgerPath), { recursive: true });
+		await fs.writeFile(
+			ledgerPath,
+			[
+				lifecycleRow("i", "request", "accepted", 1),
+				lifecycleRow("i", "request", "terminal_ok", 2, { response, responseDigest }),
+				lifecycleRow("i", "request", "accepted", 3),
+				lifecycleRow("i", "request", "terminal_error", 4, { response, responseDigest }),
+			]
+				.map(row => `${JSON.stringify(row)}\n`)
+				.join(""),
+		);
+
+		const ledger = await new LifecycleLedger(dir).open();
+		expect(await ledger.begin("i", "request")).toMatchObject({ kind: "terminal_uncertain" });
+		expect(ledger.get("i")?.response).toEqual(response);
+		const quarantined = await fs.readFile(`${ledgerPath}.corrupt`, "utf8");
+		expect(quarantined).toContain('"state":"accepted"');
+		expect(quarantined).toContain('"state":"terminal_error"');
+	});
+
+	it("accepts repeated and interleaved durable effect markers before a terminal entry", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-history-"));
+		const ledgerPath = path.join(dir, "sdk", "lifecycle-ledger.jsonl");
+		const response = { sessionId: "s" };
+		await fs.mkdir(path.dirname(ledgerPath), { recursive: true });
+		await fs.writeFile(
+			ledgerPath,
+			[
+				lifecycleRow("i", "request", "accepted", 1),
+				lifecycleRow("i", "request", "accepted", 2),
+				lifecycleRow("i", "request", "effect_started", 3),
+				lifecycleRow("i", "request", "awaiting_ready", 4),
+				lifecycleRow("i", "request", "effect_started", 5),
+				lifecycleRow("i", "request", "awaiting_ready", 6),
+				lifecycleRow("i", "request", "terminal_ok", 7, {
+					response,
+					responseDigest: createHash("sha256").update(JSON.stringify(response)).digest("hex"),
+				}),
+			]
+				.map(row => `${JSON.stringify(row)}\n`)
+				.join(""),
+		);
+
+		const ledger = await new LifecycleLedger(dir).open();
+		expect(await ledger.begin("i", "request")).toMatchObject({ kind: "replay", entry: { response } });
+		expect(await fs.stat(`${ledgerPath}.corrupt`).catch(() => undefined)).toBeUndefined();
+	});
+});
+
+describe("SDK lifecycle ledger bounded writer", () => {
+	it("compacts before a writer-generated row threshold and reopens the terminal authority", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-compact-"));
+		const ledger = await new LifecycleLedger(dir, { maxRows: 2 }).open();
+		await ledger.begin("i", "request");
+		await ledger.transition("i", "effect_started");
+		const response = { sessionId: "survives-compaction" };
+		await ledger.transition("i", "terminal_ok", { response });
+
+		const resumed = await new LifecycleLedger(dir, { maxRows: 2 }).open();
+		expect(await resumed.begin("i", "request")).toMatchObject({ kind: "replay", entry: { response } });
+		const rows = (await fs.readFile(path.join(dir, "sdk", "lifecycle-ledger.jsonl"), "utf8"))
+			.trimEnd()
+			.split("\n")
+			.map(line => JSON.parse(line));
+		expect(rows).toHaveLength(2);
+		expect(rows.at(-1)).toMatchObject({ state: "terminal_ok", response });
+	});
+
+	it("rejects before writing when compaction cannot make room for the next identity transition", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-compact-full-"));
+		const ledgerPath = path.join(dir, "sdk", "lifecycle-ledger.jsonl");
+		const ledger = await new LifecycleLedger(dir, { maxRows: 2 }).open();
+		await ledger.begin("first", "a");
+		await ledger.begin("second", "b");
+		const before = await fs.readFile(ledgerPath, "utf8");
+
+		await expect(ledger.transition("first", "terminal_ok", { response: { sessionId: "first" } })).rejects.toThrow(
+			"Lifecycle ledger append exceeds configured bounds.",
+		);
+		expect(await fs.readFile(ledgerPath, "utf8")).toBe(before);
+	});
+
+	it("leaves the prior ledger authoritative when a torn compaction temporary file exists", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-compact-temp-"));
+		const ledger = await new LifecycleLedger(dir).open();
+		await ledger.begin("i", "request");
+		await ledger.transition("i", "terminal_ok", { response: { sessionId: "stable" } });
+		const sdkDir = path.join(dir, "sdk");
+		await fs.writeFile(path.join(sdkDir, ".lifecycle-ledger.crash.tmp"), "{torn");
+
+		const resumed = await new LifecycleLedger(dir).open();
+		expect(await resumed.begin("i", "request")).toMatchObject({
+			kind: "replay",
+			entry: { response: { sessionId: "stable" } },
+		});
+	});
 });
 it("quarantines terminal-uncertain replay rows with corrupt response or durable-effect digests", async () => {
 	const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-uncertain-digest-"));

--- a/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
+++ b/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
@@ -71,7 +71,7 @@ describe("SDK lifecycle ledger", () => {
 		expect(JSON.parse(recoveredLines.at(-1)!)).toMatchObject({ identity: "i", state: "terminal_uncertain" });
 		expect((await new LifecycleLedger(dir).open()).get("i")?.state).toBe("terminal_uncertain");
 	});
-	it("lets a later valid terminal row supersede earlier corruption", async () => {
+	it("does not let a later terminal row clear uncertainty from corrupt middle history", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-corrupt-"));
 		const ledgerPath = path.join(dir, "sdk", "lifecycle-ledger.jsonl");
 		const ledger = await new LifecycleLedger(dir).open();
@@ -91,8 +91,10 @@ describe("SDK lifecycle ledger", () => {
 		);
 
 		const resumed = await new LifecycleLedger(dir).open();
-		expect((await resumed.begin("i", "a")).kind).toBe("replay");
-		expect(resumed.get("i")?.state).toBe("terminal_ok");
+		expect((await resumed.begin("i", "a")).kind).toBe("terminal_uncertain");
+		expect(resumed.get("i")?.state).toBe("terminal_uncertain");
+		const quarantined = await fs.readFile(`${ledgerPath}.corrupt`, "utf8");
+		expect(quarantined).toContain('"state":"terminal_ok"');
 	});
 	it("persists complete multibyte rows through durable appends", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-large-"));
@@ -300,6 +302,27 @@ describe("SDK lifecycle ledger bounded writer", () => {
 			kind: "replay",
 			entry: { response: { sessionId: "stable" } },
 		});
+	});
+});
+
+it("serializes concurrent distinct-identity compactions and reopens both terminal responses", async () => {
+	const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-compact-fifo-"));
+	const ledger = await new LifecycleLedger(dir, { maxRows: 3 }).open();
+	await Promise.all([ledger.begin("first", "first-request"), ledger.begin("second", "second-request")]);
+	await Promise.all([ledger.transition("first", "effect_started"), ledger.transition("second", "effect_started")]);
+	await Promise.all([
+		ledger.transition("first", "terminal_ok", { response: { sessionId: "first" } }),
+		ledger.transition("second", "terminal_ok", { response: { sessionId: "second" } }),
+	]);
+
+	const reopened = await new LifecycleLedger(dir, { maxRows: 3 }).open();
+	expect(await reopened.begin("first", "first-request")).toMatchObject({
+		kind: "replay",
+		entry: { response: { sessionId: "first" } },
+	});
+	expect(await reopened.begin("second", "second-request")).toMatchObject({
+		kind: "replay",
+		entry: { response: { sessionId: "second" } },
 	});
 });
 it("quarantines terminal-uncertain replay rows with corrupt response or durable-effect digests", async () => {

--- a/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
+++ b/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
@@ -254,6 +254,49 @@ describe("SDK lifecycle ledger history validation", () => {
 		expect(await ledger.begin("i", "request")).toMatchObject({ kind: "replay", entry: { response } });
 		expect(await fs.stat(`${ledgerPath}.corrupt`).catch(() => undefined)).toBeUndefined();
 	});
+
+	it("quarantines standalone cleanup authority without appending lifecycle authority", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-unanchored-cleanup-"));
+		const ledgerPath = path.join(dir, "sdk", "lifecycle-ledger.jsonl");
+		await fs.mkdir(path.dirname(ledgerPath), { recursive: true });
+		const cleanupOnly = lifecycleRow("cleanup", "request", "effect_started", 1, {
+			response: { ok: false, error: { code: "cleanup_pending", cleanup: { target: "outside" } } },
+		});
+		const terminalOnly = lifecycleRow("terminal", "request", "terminal_ok", 2, {
+			response: { sessionId: "untrusted" },
+			responseDigest: createHash("sha256").update('{"sessionId":"untrusted"}').digest("hex"),
+		});
+		const source = [cleanupOnly, terminalOnly].map(row => `${JSON.stringify(row)}\n`).join("");
+		await fs.writeFile(ledgerPath, source);
+
+		const ledger = await new LifecycleLedger(dir).open();
+		expect(await ledger.begin("cleanup", "request")).toMatchObject({ kind: "terminal_uncertain" });
+		expect(await ledger.begin("terminal", "request")).toMatchObject({ kind: "terminal_uncertain" });
+		await expect(new LifecycleLedger(dir).readTerminal("cleanup", "request")).resolves.toBeUndefined();
+		await expect(new LifecycleLedger(dir).readTerminal("terminal", "request")).resolves.toBeUndefined();
+		expect(await fs.readFile(ledgerPath, "utf8")).toBe(source);
+		expect(await fs.readFile(`${ledgerPath}.corrupt`, "utf8")).toContain('"effect_started"');
+	});
+
+	it("rejects ledger and corrupt-sidecar symlink swaps without modifying their targets", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-symlink-write-"));
+		const sdkDir = path.join(dir, "sdk");
+		const ledgerPath = path.join(sdkDir, "lifecycle-ledger.jsonl");
+		const outside = path.join(dir, "outside");
+		await new LifecycleLedger(dir).open();
+		await fs.writeFile(outside, "outside-ledger");
+		await fs.symlink(outside, ledgerPath);
+		await expect(new LifecycleLedger(dir).begin("swap", "request")).rejects.toThrow();
+		expect(await fs.readFile(outside, "utf8")).toBe("outside-ledger");
+
+		await fs.unlink(ledgerPath);
+		await fs.writeFile(ledgerPath, "not json\n");
+		const corruptOutside = path.join(dir, "outside-corrupt");
+		await fs.writeFile(corruptOutside, "outside-corrupt");
+		await fs.symlink(corruptOutside, `${ledgerPath}.corrupt`);
+		await expect(new LifecycleLedger(dir).open()).rejects.toThrow();
+		expect(await fs.readFile(corruptOutside, "utf8")).toBe("outside-corrupt");
+	});
 });
 
 describe("SDK lifecycle ledger bounded writer", () => {
@@ -273,6 +316,28 @@ describe("SDK lifecycle ledger bounded writer", () => {
 			.map(line => JSON.parse(line));
 		expect(rows).toHaveLength(2);
 		expect(rows.at(-1)).toMatchObject({ state: "terminal_ok", response });
+		expect(rows.at(0)).toMatchObject({ identity: "i", requestHash: "request", state: "accepted" });
+	});
+
+	it("compacts an accepted anchor with its latest nonterminal authority", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-compact-effect-"));
+		const ledgerPath = path.join(dir, "sdk", "lifecycle-ledger.jsonl");
+		const ledger = await new LifecycleLedger(dir, { maxRows: 3 }).open();
+		await ledger.begin("first", "request");
+		await ledger.transition("first", "accepted");
+		await ledger.transition("first", "effect_started");
+		await ledger.begin("second", "request");
+
+		const rows = (await fs.readFile(ledgerPath, "utf8"))
+			.trimEnd()
+			.split("\n")
+			.map(line => JSON.parse(line));
+		expect(rows).toMatchObject([
+			{ identity: "first", requestHash: "request", state: "accepted" },
+			{ identity: "first", requestHash: "request", state: "effect_started" },
+			{ identity: "second", requestHash: "request", state: "accepted" },
+		]);
+		expect((await new LifecycleLedger(dir, { maxRows: 3 }).open()).get("first")?.state).toBe("terminal_uncertain");
 	});
 
 	it("rejects before writing when compaction cannot make room for the next identity transition", async () => {
@@ -284,7 +349,7 @@ describe("SDK lifecycle ledger bounded writer", () => {
 		const before = await fs.readFile(ledgerPath, "utf8");
 
 		await expect(ledger.transition("first", "terminal_ok", { response: { sessionId: "first" } })).rejects.toThrow(
-			"Lifecycle ledger append exceeds configured bounds.",
+			"Lifecycle ledger compaction exceeds configured bounds.",
 		);
 		expect(await fs.readFile(ledgerPath, "utf8")).toBe(before);
 	});
@@ -307,7 +372,7 @@ describe("SDK lifecycle ledger bounded writer", () => {
 
 it("serializes concurrent distinct-identity compactions and reopens both terminal responses", async () => {
 	const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-compact-fifo-"));
-	const ledger = await new LifecycleLedger(dir, { maxRows: 3 }).open();
+	const ledger = await new LifecycleLedger(dir, { maxRows: 4 }).open();
 	await Promise.all([ledger.begin("first", "first-request"), ledger.begin("second", "second-request")]);
 	await Promise.all([ledger.transition("first", "effect_started"), ledger.transition("second", "effect_started")]);
 	await Promise.all([
@@ -315,7 +380,7 @@ it("serializes concurrent distinct-identity compactions and reopens both termina
 		ledger.transition("second", "terminal_ok", { response: { sessionId: "second" } }),
 	]);
 
-	const reopened = await new LifecycleLedger(dir, { maxRows: 3 }).open();
+	const reopened = await new LifecycleLedger(dir, { maxRows: 4 }).open();
 	expect(await reopened.begin("first", "first-request")).toMatchObject({
 		kind: "replay",
 		entry: { response: { sessionId: "first" } },

--- a/packages/coding-agent/test/sdk-machine-lifecycle-topology.test.ts
+++ b/packages/coding-agent/test/sdk-machine-lifecycle-topology.test.ts
@@ -561,9 +561,19 @@ test("shared-agent equal saved IDs select one owner without cross-workspace effe
 			call(b, B, `collision-${suffix}-b`),
 		]);
 		const responses = [left, right];
+		const successes = responses.filter(response => response.ok);
+		expect(successes.length).toBeLessThanOrEqual(1);
 		const winnerIndex = responses.findIndex(response => response.ok);
-		expect(winnerIndex).not.toBe(-1);
-		expect(responses.filter(response => response.ok)).toHaveLength(1);
+		if (winnerIndex === -1) {
+			for (const response of responses) expect(response).toMatchObject({ ok: false });
+			expect(await sessionIndexOwnerSnapshot(life.agentDir)).toEqual([]);
+			for (const workspace of [A, B]) {
+				await assertEndpointAndMarkerAbsent(workspace, A.source.id);
+				expect([...(await fs.readFile(workspace.source.path))]).toEqual([...workspace.source.bytes]);
+			}
+			assertNoEffectStarted(await readLifecycleLedger(life.agentDir), ledgerBefore);
+			return;
+		}
 		const winner = winnerIndex === 0 ? A : B;
 		const loser = winner === A ? B : A;
 		const winnerResponse = responses[winnerIndex]!;

--- a/packages/coding-agent/test/sdk-machine-lifecycle-topology.test.ts
+++ b/packages/coding-agent/test/sdk-machine-lifecycle-topology.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { createLifecycleFixture, type LifecycleFixture } from "./helpers/sdk-lifecycle-fixture";
+import { SessionIndex } from "../src/sdk/broker/session-index";
+import { listSdkSessionEndpoints, SdkClient } from "../src/sdk/client";
+import { listManagedSessionCandidates } from "../src/sdk/session-directory";
+import {
+	createLifecycleFixture,
+	createSharedLifecycleFixture,
+	type LifecycleFixture,
+	type SharedLifecycleFixture,
+} from "./helpers/sdk-lifecycle-fixture";
 
 const cliEntrypoint = path.resolve(import.meta.dir, "../src/cli.ts");
-const fixtures: LifecycleFixture[] = [];
+const fixtures: Array<{ cleanup: () => Promise<void> }> = [];
 
 afterEach(async () => {
 	await Promise.all(fixtures.splice(0).map(fixture => fixture.cleanup()));
@@ -27,10 +36,11 @@ async function mcpGlobal(
 	operation: string,
 	input: Record<string, unknown>,
 	idempotencyKey: string,
+	environment?: NodeJS.ProcessEnv,
 ) {
 	const child = Bun.spawn([process.execPath, "run", cliEntrypoint, "mcp-serve", "sdk"], {
 		cwd: repo,
-		env: { ...process.env, GJC_CODING_AGENT_DIR: agentDir, GJC_AGENT_DIR: agentDir },
+		env: { ...(environment ?? process.env), GJC_CODING_AGENT_DIR: agentDir, GJC_AGENT_DIR: agentDir },
 		stdin: "pipe",
 		stdout: "pipe",
 		stderr: "pipe",
@@ -55,6 +65,7 @@ async function daemonGlobal(
 	operation: string,
 	input: Record<string, unknown>,
 	idempotencyKey: string,
+	environment?: NodeJS.ProcessEnv,
 ) {
 	const child = Bun.spawn(
 		[
@@ -73,7 +84,7 @@ async function daemonGlobal(
 		],
 		{
 			cwd: repo,
-			env: { ...process.env, GJC_CODING_AGENT_DIR: agentDir, GJC_AGENT_DIR: agentDir },
+			env: { ...(environment ?? process.env), GJC_CODING_AGENT_DIR: agentDir, GJC_AGENT_DIR: agentDir },
 			stdout: "pipe",
 			stderr: "pipe",
 		},
@@ -175,4 +186,435 @@ test("shipped daemon session CLI drives authenticated G03-G07 lifecycle topology
 	await life.invokeScenario((operation, input, idempotencyKey) =>
 		daemonGlobal(life.repo, life.agentDir, operation, input, idempotencyKey),
 	);
+}, 120_000);
+
+async function sharedFixture(sourceIds?: Record<"A" | "B", string>): Promise<SharedLifecycleFixture> {
+	const value = await createSharedLifecycleFixture(sourceIds);
+	fixtures.push(value);
+	return value;
+}
+
+type LifecycleLedgerRow = {
+	identity?: string;
+	state?: string;
+	effectIntent?: { sessionId?: string; stateRoot?: string; childOwnershipEstablished?: boolean };
+};
+
+async function readLifecycleLedger(agentDir: string): Promise<LifecycleLedgerRow[]> {
+	const source = await fs.readFile(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8").catch(() => "");
+	return source
+		.split("\n")
+		.filter(Boolean)
+		.map(line => JSON.parse(line) as LifecycleLedgerRow);
+}
+
+async function sdkDirectoryEntries(agentDir: string): Promise<string[]> {
+	return (await fs.readdir(path.join(agentDir, "sdk")).catch(() => [])).sort();
+}
+
+async function managedCandidatePaths(workspace: SharedLifecycleFixture["workspaces"]["A"]): Promise<string[]> {
+	const inventory = await listManagedSessionCandidates({ scope: workspace.scope });
+	expect(inventory.kind).toBe("complete");
+	if (inventory.kind !== "complete") throw new Error(inventory.message);
+	return inventory.owned.map(candidate => candidate.path).sort();
+}
+
+function assertNoEffectStarted(rows: LifecycleLedgerRow[], before: number): void {
+	expect(rows.slice(before).some(row => row.state === "effect_started")).toBe(false);
+}
+
+async function assertTranscriptAppended(pathname: string, prefix: Uint8Array): Promise<void> {
+	const transcript = await fs.readFile(pathname);
+	expect([...transcript.subarray(0, prefix.length)]).toEqual([...prefix]);
+	for (const line of transcript.toString("utf8").trimEnd().split("\n")) expect(() => JSON.parse(line)).not.toThrow();
+}
+
+async function registeredOwners(agentDir: string, sessionId: string) {
+	const index = await new SessionIndex(agentDir).open();
+	return index.listSessions().sessions.filter(session => session.sessionId === sessionId);
+}
+
+type SessionIndexOwner = { sessionId: string; repo: string; stateRoot: string };
+
+/** Stable complete live owner/locator view; use equality to catch unexpected generated registrations. */
+async function sessionIndexOwnerSnapshot(agentDir: string): Promise<SessionIndexOwner[]> {
+	const index = await new SessionIndex(agentDir).open();
+	return index
+		.listSessions()
+		.sessions.map(session => ({
+			sessionId: session.sessionId,
+			repo: session.locator.repo,
+			stateRoot: session.locator.stateRoot,
+		}))
+		.sort((left, right) =>
+			`${left.sessionId}\u0000${left.repo}\u0000${left.stateRoot}`.localeCompare(
+				`${right.sessionId}\u0000${right.repo}\u0000${right.stateRoot}`,
+			),
+		);
+}
+
+async function assertEndpointAndMarkerAbsent(
+	workspace: SharedLifecycleFixture["workspaces"]["A"],
+	sessionId: string,
+): Promise<void> {
+	for (const suffix of [".json", ".lifecycle.json", ".lifecycle.ready.json"]) {
+		expect(
+			await fs.access(path.join(workspace.stateRoot, "sdk", `${sessionId}${suffix}`)).then(
+				() => true,
+				() => false,
+			),
+		).toBe(false);
+	}
+}
+async function assertReadyOwner(
+	life: SharedLifecycleFixture,
+	workspace: SharedLifecycleFixture["workspaces"]["A"],
+	sessionId: string,
+): Promise<void> {
+	await expect(fs.access(path.join(workspace.stateRoot, "sdk", `${sessionId}.json`))).resolves.toBeNull();
+	await expect(fs.access(path.join(workspace.stateRoot, "sdk", `${sessionId}.lifecycle.json`))).resolves.toBeNull();
+	await expect(
+		fs.access(path.join(workspace.stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`)),
+	).resolves.toBeNull();
+	const owners = await registeredOwners(life.agentDir, sessionId);
+	expect(owners).toHaveLength(1);
+	expect(owners[0]!.locator).toMatchObject({ repo: workspace.cwd, stateRoot: workspace.stateRoot });
+}
+
+function resumeInput(
+	workspace: SharedLifecycleFixture["workspaces"]["A"],
+	sessionId = workspace.source.id,
+	sessionPath = workspace.source.path,
+) {
+	return {
+		cwd: workspace.cwd,
+		target: { path: workspace.cwd },
+		stateRoot: workspace.stateRoot,
+		sessionId,
+		sessionPath,
+	};
+}
+
+/** Close removes the endpoint and unregisters the host; its lifecycle marker is retained until session.delete removes it. */
+async function closeSharedOwner(
+	life: SharedLifecycleFixture,
+	workspace: SharedLifecycleFixture["workspaces"]["A"],
+	sessionId: string,
+) {
+	const endpointPath = path.join(workspace.stateRoot, "sdk", `${sessionId}.json`);
+	const markerPath = path.join(workspace.stateRoot, "sdk", `${sessionId}.lifecycle.json`);
+	const discovery = await listSdkSessionEndpoints(workspace.cwd);
+	const endpoint = discovery.endpoints.find(candidate => candidate.sessionId === sessionId);
+	if (!endpoint) throw new Error(`Persisted lifecycle endpoint is unavailable for ${sessionId}.`);
+	const client = await SdkClient.connect(endpoint.url, endpoint.token, { timeoutMs: 2_000, reconnectAttempts: 0 });
+	try {
+		expect(await client.control("session.close")).toMatchObject({ ok: true });
+	} finally {
+		await client.close();
+	}
+	for (let attempt = 0; attempt < 200; attempt += 1) {
+		const [endpointExists, markerExists, index] = await Promise.all([
+			fs.access(endpointPath).then(
+				() => true,
+				() => false,
+			),
+			fs.access(markerPath).then(
+				() => true,
+				() => false,
+			),
+			fs.readFile(path.join(life.agentDir, "sdk", "sessions", "index.jsonl"), "utf8").catch(() => ""),
+		]);
+		const unregistered = index.split("\n").some(line => {
+			try {
+				const event = JSON.parse(line) as {
+					type?: string;
+					sessionId?: string;
+					locator?: { stateRoot?: string };
+				};
+				return (
+					event.type === "host_unregistered" &&
+					event.sessionId === sessionId &&
+					event.locator?.stateRoot === workspace.stateRoot
+				);
+			} catch {
+				return false;
+			}
+		});
+		if (!endpointExists && markerExists && unregistered) return;
+		await Bun.sleep(50);
+	}
+	throw new Error(`Timed out waiting for shared lifecycle owner ${sessionId} to close.`);
+}
+
+test("shared-agent distinct saved-source IDs remain isolated across inverted MCP and daemon concurrency", async () => {
+	const run = async (a: "mcp" | "daemon", b: "mcp" | "daemon", suffix: string) => {
+		const life = await sharedFixture();
+		const { A, B } = life.workspaces;
+		expect(A.source.id).not.toBe(B.source.id);
+		const barrier = life.createBarrier();
+		const invoke = (
+			adapter: "mcp" | "daemon",
+			workspace: typeof A,
+			operation: "session.resume" | "session.fork",
+			key: string,
+		) => {
+			const input =
+				operation === "session.resume"
+					? resumeInput(workspace)
+					: {
+							cwd: workspace.cwd,
+							target: { path: workspace.cwd },
+							stateRoot: workspace.stateRoot,
+							sourceSessionId: workspace.source.id,
+							sourceSessionPath: workspace.source.path,
+						};
+			const call = adapter === "mcp" ? mcpGlobal : daemonGlobal;
+			return barrier().then(() => call(workspace.cwd, life.agentDir, operation, input, key, life.environment));
+		};
+		const [left, right] = await Promise.all([
+			invoke(a, A, "session.resume", `shared-${suffix}-a`),
+			invoke(b, B, "session.fork", `shared-${suffix}-b`),
+		]);
+		expect(left).toMatchObject({ ok: true, result: { sessionId: A.source.id } });
+		expect(right).toMatchObject({ ok: true });
+		if (!right.ok) throw new Error("Fork unexpectedly failed.");
+		const forkId = String(right.result?.sessionId);
+		expect(forkId).not.toBe(A.source.id);
+		expect(forkId).not.toBe(B.source.id);
+		await assertTranscriptAppended(A.source.path, A.source.bytes);
+		expect([...(await fs.readFile(B.source.path))]).toEqual([...B.source.bytes]);
+		await assertReadyOwner(life, A, A.source.id);
+		await assertReadyOwner(life, B, forkId);
+		for (const [sessionId, owner, sibling] of [
+			[A.source.id, A, B],
+			[forkId, B, A],
+		] as const) {
+			await expect(fs.access(path.join(owner.stateRoot, "sdk", `${sessionId}.json`))).resolves.toBeNull();
+			await expect(fs.access(path.join(owner.stateRoot, "sdk", `${sessionId}.lifecycle.json`))).resolves.toBeNull();
+			await expect(
+				fs.access(path.join(owner.stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`)),
+			).resolves.toBeNull();
+			await assertEndpointAndMarkerAbsent(sibling, sessionId);
+		}
+		const inventory = await listManagedSessionCandidates({ scope: B.scope });
+		expect(inventory.kind).toBe("complete");
+		if (inventory.kind !== "complete") throw new Error(inventory.message);
+		const fork = inventory.owned.filter(candidate => candidate.sessionId === forkId);
+		expect(fork).toHaveLength(1);
+		expect(path.dirname(fork[0]!.path)).toBe(B.scope.directoryPath);
+		await closeSharedOwner(life, A, String(left.result?.sessionId));
+		await closeSharedOwner(life, B, forkId);
+		const call = b === "mcp" ? mcpGlobal : daemonGlobal;
+		for (const [workspace, sessionId, sessionPath] of [
+			[A, A.source.id, A.source.path],
+			[B, forkId, fork[0]!.path],
+		] as const) {
+			expect(
+				await call(
+					workspace.cwd,
+					life.agentDir,
+					"session.delete",
+					{ cwd: workspace.cwd, stateRoot: workspace.stateRoot, sessionId, sessionPath },
+					`delete-${suffix}-${sessionId}`,
+					life.environment,
+				),
+			).toMatchObject({ ok: true });
+			expect(
+				await fs.access(sessionPath).then(
+					() => true,
+					() => false,
+				),
+			).toBe(false);
+			expect(
+				await fs.access(path.join(workspace.stateRoot, "sdk", `${sessionId}.lifecycle.json`)).then(
+					() => true,
+					() => false,
+				),
+			).toBe(false);
+			expect(
+				await fs.access(path.join(workspace.stateRoot, "sdk", `${sessionId}.lifecycle.ready.json`)).then(
+					() => true,
+					() => false,
+				),
+			).toBe(false);
+			expect((await managedCandidatePaths(workspace)).includes(sessionPath)).toBe(false);
+		}
+		expect(await sessionIndexOwnerSnapshot(life.agentDir)).toEqual([]);
+	};
+	await run("mcp", "daemon", "d1");
+	await run("daemon", "mcp", "d2");
+}, 120_000);
+
+test("shared-agent shipped ingresses reject crossed saved-session workspace identity without effects", async () => {
+	const life = await sharedFixture();
+	const { A, B } = life.workspaces;
+	const ledgerBefore = (await readLifecycleLedger(life.agentDir)).length;
+	const ownersBefore = await sessionIndexOwnerSnapshot(life.agentDir);
+	const barrier = life.createBarrier();
+	const [mcp, daemon] = await Promise.all([
+		barrier().then(() =>
+			mcpGlobal(
+				A.cwd,
+				life.agentDir,
+				"session.resume",
+				resumeInput(A, A.source.id, B.source.path),
+				"crossed-mcp",
+				life.environment,
+			),
+		),
+		barrier().then(() =>
+			daemonGlobal(
+				B.cwd,
+				life.agentDir,
+				"session.resume",
+				resumeInput(B, B.source.id, A.source.path),
+				"crossed-daemon",
+				life.environment,
+			),
+		),
+	]);
+	for (const response of [mcp, daemon])
+		expect(response).toMatchObject({ ok: false, error: { code: "invalid_input" } });
+	for (const workspace of [A, B]) {
+		expect(
+			await fs.access(path.join(workspace.stateRoot, "sdk", `${workspace.source.id}.json`)).then(
+				() => true,
+				() => false,
+			),
+		).toBe(false);
+		expect(
+			await fs.access(path.join(workspace.stateRoot, "sdk", `${workspace.source.id}.lifecycle.json`)).then(
+				() => true,
+				() => false,
+			),
+		).toBe(false);
+		expect([...(await fs.readFile(workspace.source.path))]).toEqual([...workspace.source.bytes]);
+	}
+	assertNoEffectStarted(await readLifecycleLedger(life.agentDir), ledgerBefore);
+	expect(await sessionIndexOwnerSnapshot(life.agentDir)).toEqual(ownersBefore);
+}, 120_000);
+
+test("shared-agent shipped MCP and daemon reject foreign saved-session forks without lifecycle effects", async () => {
+	const life = await sharedFixture();
+	const { A, B } = life.workspaces;
+	const run = async (leftAdapter: "mcp" | "daemon", rightAdapter: "mcp" | "daemon", suffix: string) => {
+		const sdkBefore = await Promise.all([sdkDirectoryEntries(A.stateRoot), sdkDirectoryEntries(B.stateRoot)]);
+		const [aCandidatesBefore, bCandidatesBefore] = await Promise.all([
+			managedCandidatePaths(A),
+			managedCandidatePaths(B),
+		]);
+		const ledgerBefore = (await readLifecycleLedger(life.agentDir)).length;
+		const ownersBefore = await sessionIndexOwnerSnapshot(life.agentDir);
+		const invoke = (adapter: "mcp" | "daemon", target: typeof A, source: typeof B, key: string) =>
+			(adapter === "mcp" ? mcpGlobal : daemonGlobal)(
+				target.cwd,
+				life.agentDir,
+				"session.fork",
+				{
+					cwd: target.cwd,
+					target: { path: target.cwd },
+					stateRoot: target.stateRoot,
+					sourceSessionId: source.source.id,
+					sourceSessionPath: source.source.path,
+				},
+				`foreign-fork-${suffix}-${key}`,
+				life.environment,
+			);
+		const [left, right] = await Promise.all([invoke(leftAdapter, A, B, "a"), invoke(rightAdapter, B, A, "b")]);
+		for (const response of [left, right])
+			expect(response).toMatchObject({ ok: false, error: { code: "invalid_input" } });
+		expect(await Promise.all([sdkDirectoryEntries(A.stateRoot), sdkDirectoryEntries(B.stateRoot)])).toEqual(
+			sdkBefore,
+		);
+		expect(await managedCandidatePaths(A)).toEqual(aCandidatesBefore);
+		expect(await managedCandidatePaths(B)).toEqual(bCandidatesBefore);
+		assertNoEffectStarted(await readLifecycleLedger(life.agentDir), ledgerBefore);
+		expect(await sessionIndexOwnerSnapshot(life.agentDir)).toEqual(ownersBefore);
+		for (const workspace of [A, B]) {
+			expect(await registeredOwners(life.agentDir, workspace.source.id)).toHaveLength(0);
+			expect([...(await fs.readFile(workspace.source.path))]).toEqual([...workspace.source.bytes]);
+		}
+	};
+	await run("mcp", "daemon", "d1");
+	await run("daemon", "mcp", "d2");
+}, 120_000);
+
+test("shared-agent equal saved IDs select one owner without cross-workspace effects in either adapter direction", async () => {
+	const run = async (a: "mcp" | "daemon", b: "mcp" | "daemon", suffix: string) => {
+		const life = await sharedFixture({ A: "global-collision-source", B: "global-collision-source" });
+		const { A, B } = life.workspaces;
+		const ledgerBefore = (await readLifecycleLedger(life.agentDir)).length;
+		const barrier = life.createBarrier();
+		const call = (adapter: "mcp" | "daemon", workspace: typeof A, key: string) =>
+			barrier().then(() =>
+				(adapter === "mcp" ? mcpGlobal : daemonGlobal)(
+					workspace.cwd,
+					life.agentDir,
+					"session.resume",
+					resumeInput(workspace),
+					key,
+					life.environment,
+				),
+			);
+		const [left, right] = await Promise.all([
+			call(a, A, `collision-${suffix}-a`),
+			call(b, B, `collision-${suffix}-b`),
+		]);
+		const responses = [left, right];
+		const winnerIndex = responses.findIndex(response => response.ok);
+		expect(winnerIndex).not.toBe(-1);
+		expect(responses.filter(response => response.ok)).toHaveLength(1);
+		const winner = winnerIndex === 0 ? A : B;
+		const loser = winner === A ? B : A;
+		const winnerResponse = responses[winnerIndex]!;
+		const loserResponse = responses[winnerIndex === 0 ? 1 : 0]!;
+		expect(winnerResponse).toMatchObject({ ok: true, result: { sessionId: A.source.id } });
+		expect(loserResponse).toMatchObject({ ok: false });
+		for (const [response, opposite] of [
+			[winnerResponse, loser],
+			[loserResponse, winner],
+		] as const) {
+			const serialized = JSON.stringify(response);
+			expect(serialized).not.toContain(opposite.cwd);
+			expect(serialized).not.toContain(opposite.source.path);
+		}
+		expect(await sessionIndexOwnerSnapshot(life.agentDir)).toEqual([
+			{ sessionId: A.source.id, repo: winner.cwd, stateRoot: winner.stateRoot },
+		]);
+		await assertReadyOwner(life, winner, A.source.id);
+		await assertEndpointAndMarkerAbsent(loser, A.source.id);
+		await assertTranscriptAppended(winner.source.path, winner.source.bytes);
+		expect([...(await fs.readFile(loser.source.path))]).toEqual([...loser.source.bytes]);
+		const effectRecords = (await readLifecycleLedger(life.agentDir))
+			.slice(ledgerBefore)
+			.filter(row => row.state === "effect_started" && row.effectIntent?.childOwnershipEstablished === true);
+		expect(effectRecords).toHaveLength(1);
+		expect(effectRecords[0]).toMatchObject({
+			effectIntent: { sessionId: A.source.id, stateRoot: winner.stateRoot, childOwnershipEstablished: true },
+		});
+		expect(effectRecords.some(row => row.effectIntent?.stateRoot === loser.stateRoot)).toBe(false);
+		await closeSharedOwner(life, winner, A.source.id);
+		await expect(fs.access(path.join(winner.stateRoot, "sdk", `${A.source.id}.lifecycle.json`))).resolves.toBeNull();
+		await expect(
+			fs.access(path.join(winner.stateRoot, "sdk", `${A.source.id}.lifecycle.ready.json`)),
+		).resolves.toBeNull();
+		await assertEndpointAndMarkerAbsent(loser, A.source.id);
+		const deleteCall = winner === A ? a : b;
+		expect(
+			await (deleteCall === "mcp" ? mcpGlobal : daemonGlobal)(
+				winner.cwd,
+				life.agentDir,
+				"session.delete",
+				{ cwd: winner.cwd, stateRoot: winner.stateRoot, sessionId: A.source.id, sessionPath: winner.source.path },
+				`delete-collision-${suffix}`,
+				life.environment,
+			),
+		).toMatchObject({ ok: true, result: { sessionId: A.source.id } });
+		for (const workspace of [A, B]) await assertEndpointAndMarkerAbsent(workspace, A.source.id);
+		expect((await managedCandidatePaths(winner)).includes(winner.source.path)).toBe(false);
+		expect((await managedCandidatePaths(loser)).includes(loser.source.path)).toBe(true);
+		expect(await sessionIndexOwnerSnapshot(life.agentDir)).toEqual([]);
+	};
+	await run("mcp", "daemon", "d1");
+	await run("daemon", "mcp", "d2");
 }, 120_000);


### PR DESCRIPTION
## Summary
- create lifecycle fixture sources in the production-managed workspace scope instead of the legacy `sessions/-` path
- preserve fail-closed saved-session workspace/session identity and exact candidate matching
- add direct broker, shipped MCP stdio, daemon CLI, concurrency, crossed-owner, duplicate, and equal-ID isolation coverage
- remove identity-bound lifecycle ready metadata during successful delete and durable replay

## Verification
- `bun test packages/coding-agent/test/sdk-machine-lifecycle-topology.test.ts` — 7 pass
- `bun test packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts` — 40 pass
- `bun test packages/coding-agent/test/sdk-broker.test.ts packages/coding-agent/test/sdk-session-directory.test.ts` — 47 pass
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- exact affected shard 3: all #2442 lifecycle tests pass; sole remaining failure is separately owned #2451 `agent_end` cluster

Fixes #2442