### PR TITLE
fix(coding-agent): recover expired dead browser tabs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Palette slash commands now run only from an empty composer; drafts are never touched.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).
 - Palette slash submissions no longer clear or rewrite composer text, cursor state, history, or pending images created while an asynchronous input hook is awaiting; canonical keyboard submission cleanup remains unchanged (#2441).
+- Dead browser-tab recovery now expires descriptors without releasing replacement, revived, or differently owned tabs, while exactly-once teardown closes stale targets and releases browser holds without refcount underflow (#2437).
 
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.

--- a/packages/coding-agent/src/tools/browser/dead-tab-recovery.ts
+++ b/packages/coding-agent/src/tools/browser/dead-tab-recovery.ts
@@ -1,0 +1,78 @@
+export type DeadTabRecoveryConsumeStatus = "consumed" | "expired_or_missing" | "owner_mismatch";
+
+export interface DeadTabRecoveryConsumeResult<T> {
+	status: DeadTabRecoveryConsumeStatus;
+	descriptor?: T;
+}
+
+interface StoredDescriptor<T> {
+	descriptor: T;
+	ownerId: string | undefined;
+	expiresAt: number;
+}
+
+interface DeadTabRecoveryDeps {
+	now(): number;
+	onPeek(): void;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+const descriptors = new Map<string, StoredDescriptor<unknown>>();
+let deps: DeadTabRecoveryDeps = { now: () => Date.now(), onPeek: () => {} };
+
+/** Store a short-lived immutable recovery descriptor for a dead tab worker. */
+export function registerDeadTabRecovery<T extends object>(
+	name: string,
+	ownerId: string | undefined,
+	descriptor: T,
+	ttlMs = DEFAULT_TTL_MS,
+): void {
+	descriptors.set(name, { descriptor: Object.freeze(descriptor), ownerId, expiresAt: deps.now() + ttlMs });
+}
+
+/**
+ * Check whether a recovery descriptor may be consumed by this owner. The test hook is
+ * intentionally synchronous: recovery must not yield between this check and consume.
+ */
+export function peekDeadTabRecovery<T>(name: string, ownerId: string | undefined): DeadTabRecoveryConsumeResult<T> {
+	const stored = descriptors.get(name);
+	const result: DeadTabRecoveryConsumeResult<T> =
+		!stored || stored.expiresAt <= deps.now()
+			? { status: "expired_or_missing" }
+			: stored.ownerId !== ownerId
+				? { status: "owner_mismatch" }
+				: { status: "consumed", descriptor: stored.descriptor as T };
+	deps.onPeek();
+	return result;
+}
+
+/** Consume only a live descriptor belonging to the expected owner. */
+export function consumeDeadTabRecovery<T>(name: string, ownerId: string | undefined): DeadTabRecoveryConsumeResult<T> {
+	const stored = descriptors.get(name);
+	if (!stored || stored.expiresAt <= deps.now()) {
+		if (stored) descriptors.delete(name);
+		return { status: "expired_or_missing" };
+	}
+	if (stored.ownerId !== ownerId) return { status: "owner_mismatch" };
+	descriptors.delete(name);
+	return { status: "consumed", descriptor: stored.descriptor as T };
+}
+
+export function discardDeadTabRecovery(name: string): void {
+	descriptors.delete(name);
+}
+
+/** Whether an unconsumed descriptor remains live at the supplied policy clock. */
+export function isDeadTabRecoveryLive(name: string, now: number): boolean {
+	const stored = descriptors.get(name);
+	return stored !== undefined && stored.expiresAt > now;
+}
+
+export function __setDeadTabRecoveryDepsForTest(overrides: Partial<DeadTabRecoveryDeps>): void {
+	deps = { ...deps, ...overrides };
+}
+
+export function __resetDeadTabRecoveryForTest(): void {
+	descriptors.clear();
+	deps = { now: () => Date.now(), onPeek: () => {} };
+}

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -5,6 +5,13 @@ import type { ToolSession } from "../../sdk";
 import { expandPath } from "../path-utils";
 import { ToolAbortError, ToolError } from "../tool-errors";
 import { pickElectronTarget } from "./attach";
+import {
+	consumeDeadTabRecovery,
+	discardDeadTabRecovery,
+	isDeadTabRecoveryLive,
+	peekDeadTabRecovery,
+	registerDeadTabRecovery,
+} from "./dead-tab-recovery";
 import { type BrowserHandle, type BrowserKindTag, holdBrowser, releaseBrowser } from "./registry";
 import type {
 	ReadyInfo,
@@ -55,6 +62,8 @@ export interface TabSession {
 	pending: Map<string, PendingRun>;
 	dialogPolicy?: DialogPolicy;
 	kindTag: BrowserKindTag;
+	/** Immutable inputs needed to recreate this worker after an unexpected exit. */
+	recoveryOpts: AcquireTabOptions;
 	/** Session that acquired this tab; used for session-scoped teardown (F13). */
 	ownerId?: string;
 	/** Unix-ms timestamp of the last acquire/run activity; drives GC idle + LRU ordering. */
@@ -73,6 +82,10 @@ export interface AcquireTabOptions {
 	dialogs?: DialogPolicy;
 	/** Owning session id so dispose can release only this session's tabs (F13). */
 	ownerId?: string;
+	/** Internal recovery-only target id; makes a headless replacement attach, not open a page. */
+	recoveryTargetId?: string;
+	/** Recovery fence: replacement must not overwrite a tab installed after dead teardown. */
+	requireVacantName?: boolean;
 }
 
 export interface AcquireTabResult {
@@ -98,7 +111,19 @@ export interface ReleaseTabOptions {
 }
 
 const tabs = new Map<string, TabSession>();
+const recoveringTabs = new Map<string, { ownerId: string | undefined; promise: Promise<TabSession> }>();
+let afterWorkerInitializationForTest: ((name: string) => void) | undefined;
+let workerFactoryForTest: (() => Promise<WorkerHandle>) | undefined;
+let workerInitializerForTest:
+	| ((worker: WorkerHandle, payload: WorkerInitPayload, timeoutMs: number) => Promise<ReadyInfo>)
+	| undefined;
 const GRACE_MS = 750;
+
+interface DeadTabDescriptor {
+	tab: TabSession;
+	browser: BrowserHandle;
+	opts: AcquireTabOptions;
+}
 
 /**
  * Remaining time (ms) until an absolute teardown deadline, or +Infinity when no deadline
@@ -156,6 +181,46 @@ function beginRelease(tab: TabSession): boolean {
 	return true;
 }
 
+async function withTemporaryBrowserHold<T>(browser: BrowserHandle, work: () => Promise<T>): Promise<T> {
+	holdBrowser(browser);
+	try {
+		return await work();
+	} finally {
+		await releaseBrowser(browser, { kill: false });
+	}
+}
+
+/** Test-only: exercise the same hold-transfer primitive used by replacement recovery. */
+export async function withTemporaryBrowserHoldForTest<T>(browser: BrowserHandle, work: () => Promise<T>): Promise<T> {
+	return await withTemporaryBrowserHold(browser, work);
+}
+
+/** Test-only: close exactly the target belonging to the supplied dead session. */
+export async function closeOrphanTargetForTest(tab: TabSession): Promise<void> {
+	await closeOrphanTarget(tab);
+}
+
+function recoveryPromiseForOwner(name: string, ownerId: string | undefined): Promise<TabSession> | undefined {
+	const existing = recoveringTabs.get(name);
+	if (!existing || existing.ownerId !== ownerId) return undefined;
+	return existing.promise;
+}
+
+/** Test-only: install an in-flight recovery and observe owner isolation. */
+export function __setRecoveringTabForTest(
+	name: string,
+	ownerId: string | undefined,
+	promise: Promise<TabSession>,
+): void {
+	recoveringTabs.set(name, { ownerId, promise });
+}
+
+export function recoveryPromiseForOwnerForTest(
+	name: string,
+	ownerId: string | undefined,
+): Promise<TabSession> | undefined {
+	return recoveryPromiseForOwner(name, ownerId);
+}
 /** Read-only, GC-facing projection of a live tab. Never exposes the mutable `tabs` map. */
 export interface TabGcSnapshot {
 	name: string;
@@ -193,14 +258,14 @@ export function listTabsForGc(): TabGcSnapshot[] {
  */
 export async function releaseTabIfGcEligible(name: string, policy: BrowserGcEligibilityPolicy): Promise<boolean> {
 	const tab = tabs.get(name);
-	if (!tab) return false;
-	if (tab.releasing) return false;
-	if (tab.state !== "alive") return false;
+	if (!tab || tab.releasing) return false;
+	if (tab.state === "dead") {
+		if (recoveringTabs.has(name) || isDeadTabRecoveryLive(name, policy.now())) return false;
+		return await releaseDeadTabForRecovery(name, tab, tab.ownerId);
+	}
 	if (tab.pending.size !== 0) return false;
 	if (tab.kindTag !== "headless" && tab.kindTag !== "spawned") return false;
 	if (policy.now() - tab.lastUsedAt <= policy.idleMs) return false;
-	// All predicates passed synchronously; releaseTab applies the shared begin-release guard
-	// on the same microtask, so no other code runs between the check and the state transition.
 	return await releaseTab(name, { kill: false });
 }
 
@@ -212,6 +277,36 @@ export function setTabForTest(tab: TabSession): void {
 /** Test-only: clear the tab registry between cases. */
 export function clearTabsForTest(): void {
 	tabs.clear();
+	recoveringTabs.clear();
+	afterWorkerInitializationForTest = undefined;
+	workerFactoryForTest = undefined;
+	workerInitializerForTest = undefined;
+}
+
+export function __setAfterWorkerInitializationForTest(callback: ((name: string) => void) | undefined): void {
+	afterWorkerInitializationForTest = callback;
+}
+export function __setAcquireTabWorkerDepsForTest(
+	factory: (() => Promise<WorkerHandle>) | undefined,
+	initializer:
+		| ((worker: WorkerHandle, payload: WorkerInitPayload, timeoutMs: number) => Promise<ReadyInfo>)
+		| undefined,
+): void {
+	workerFactoryForTest = factory;
+	workerInitializerForTest = initializer;
+}
+
+async function initializeAcquireWorker(
+	worker: WorkerHandle,
+	payload: WorkerInitPayload,
+	timeoutMs: number,
+): Promise<ReadyInfo> {
+	return await (workerInitializerForTest?.(worker, payload, timeoutMs) ??
+		initializeTabWorker(worker, payload, timeoutMs));
+}
+
+async function spawnAcquireWorker(): Promise<WorkerHandle> {
+	return await (workerFactoryForTest?.() ?? spawnTabWorker());
 }
 
 export async function acquireTab(
@@ -220,6 +315,9 @@ export async function acquireTab(
 	opts: AcquireTabOptions,
 ): Promise<AcquireTabResult> {
 	const existing = tabs.get(name);
+	if (opts.requireVacantName && existing)
+		throw new ToolError(`Tab ${JSON.stringify(name)} was replaced during recovery.`);
+	let replacementHold = false;
 	if (existing) {
 		if (existing.browser === browser && existing.state === "alive") {
 			if (opts.dialogs !== undefined && opts.dialogs !== existing.dialogPolicy) {
@@ -240,33 +338,50 @@ export async function acquireTab(
 				return { tab: tabs.get(name)!, created: false };
 			}
 		} else {
-			await releaseTab(name, { kill: false });
+			if (existing.browser === browser) {
+				holdBrowser(browser);
+				replacementHold = true;
+			}
+			try {
+				await releaseTab(name, { kill: false });
+			} catch (error) {
+				if (replacementHold) await releaseBrowser(browser, { kill: false });
+				throw error;
+			}
 		}
 	}
 
-	const initPayload = await buildInitPayload(browser, opts);
-	let worker = await spawnTabWorker();
+	let initPayload: WorkerInitPayload;
+	try {
+		initPayload = await buildInitPayload(browser, opts);
+	} catch (error) {
+		if (replacementHold) await releaseBrowser(browser, { kill: false });
+		throw error;
+	}
+	let worker = await spawnAcquireWorker();
 	let info: ReadyInfo;
 	try {
-		info = await initializeTabWorker(worker, initPayload, opts.timeoutMs + GRACE_MS);
+		info = await initializeAcquireWorker(worker, initPayload, opts.timeoutMs + GRACE_MS);
 	} catch (error) {
 		// `BuildMessage`-class failures arrive asynchronously via the worker's `error` event,
 		// after `spawnTabWorker`'s synchronous try/catch has already returned. Fall back to
 		// the inline worker here so module-resolution failures don't poison every tab open.
 		await worker.terminate().catch(() => undefined);
 		if (worker.mode === "inline") {
-			if (browser.refCount === 0) await releaseBrowser(browser, { kill: false });
+			if (replacementHold) await releaseBrowser(browser, { kill: false });
+			else if (browser.refCount === 0) await releaseBrowser(browser, { kill: false });
 			throw error;
 		}
 		logger.warn("Tab worker init failed; retrying with inline tab worker (no sync-loop guard)", {
 			error: error instanceof Error ? error.message : String(error),
 		});
-		worker = await spawnInlineWorker();
+		worker = await (workerFactoryForTest?.() ?? spawnInlineWorker());
 		try {
-			info = await initializeTabWorker(worker, initPayload, opts.timeoutMs + GRACE_MS);
+			info = await initializeAcquireWorker(worker, initPayload, opts.timeoutMs + GRACE_MS);
 		} catch (inlineError) {
 			await worker.terminate().catch(() => undefined);
-			if (browser.refCount === 0) await releaseBrowser(browser, { kill: false });
+			if (replacementHold) await releaseBrowser(browser, { kill: false });
+			else if (browser.refCount === 0) await releaseBrowser(browser, { kill: false });
 			const finalError = new ToolError(
 				`Failed to start browser tab worker (inline fallback also failed): ${inlineError instanceof Error ? inlineError.message : String(inlineError)}`,
 			);
@@ -275,7 +390,14 @@ export async function acquireTab(
 		}
 	}
 
+	afterWorkerInitializationForTest?.(name);
+	if (opts.requireVacantName && tabs.has(name)) {
+		await worker.terminate().catch(() => undefined);
+		if (replacementHold) await releaseBrowser(browser, { kill: false });
+		throw new ToolError(`Tab ${JSON.stringify(name)} was replaced during recovery.`);
+	}
 	holdBrowser(browser);
+	if (replacementHold) await releaseBrowser(browser, { kill: false });
 	const tab: TabSession = {
 		name,
 		browser,
@@ -288,8 +410,10 @@ export async function acquireTab(
 		kindTag: browser.kind.kind,
 		ownerId: opts.ownerId,
 		lastUsedAt: Date.now(),
+		recoveryOpts: freezeRecoveryOptions(opts),
 	};
 	worker.onMessage(msg => handleTabMessage(tab, msg));
+	worker.onError(error => markTabDead(tab, error));
 	tabs.set(name, tab);
 	return { tab, created: true };
 }
@@ -307,8 +431,9 @@ async function runInTabWithSnapshot(
 	opts: { code: string; timeoutMs: number; signal?: AbortSignal; session?: ToolSession },
 	snapshot: SessionSnapshot,
 ): Promise<RunResultOk> {
-	const tab = tabs.get(name);
-	if (!tab || tab.state === "dead") throw new ToolError(`Tab ${JSON.stringify(name)} is not alive. Reopen it.`);
+	let tab = tabs.get(name);
+	if (tab?.state === "dead") tab = await recoverDeadTab(name, opts.session);
+	if (tab?.state !== "alive") throw new ToolError(`Tab ${JSON.stringify(name)} is not alive. Reopen it.`);
 	if (tab.pending.size > 0) throw new ToolError(`Tab ${JSON.stringify(name)} is busy`);
 	tab.lastUsedAt = Date.now();
 	const id = Snowflake.next();
@@ -340,6 +465,82 @@ async function runInTabWithSnapshot(
 		tab.pending.delete(id);
 	}
 }
+function markTabDead(tab: TabSession, error: Error): void {
+	if (tabs.get(tab.name) !== tab || tab.state !== "alive" || tab.releasing) return;
+	tab.state = "dead";
+	const closeError = new ToolError(`Browser tab worker stopped: ${error.message}`);
+	for (const pending of tab.pending.values()) pending.reject(closeError);
+	tab.pending.clear();
+	registerDeadTabRecovery(tab.name, tab.ownerId, Object.freeze({ tab, browser: tab.browser, opts: tab.recoveryOpts }));
+}
+function freezeRecoveryOptions(opts: AcquireTabOptions): AcquireTabOptions {
+	return Object.freeze({
+		...opts,
+		signal: undefined,
+		viewport: opts.viewport ? Object.freeze({ ...opts.viewport }) : undefined,
+	});
+}
+
+async function recoverDeadTab(name: string, session: ToolSession | undefined): Promise<TabSession | undefined> {
+	const ownerId = session?.getSessionId?.() ?? undefined;
+	const existing = recoveryPromiseForOwner(name, ownerId);
+	if (existing) return await existing;
+	if (recoveringTabs.has(name)) return undefined;
+	const peeked = peekDeadTabRecovery<DeadTabDescriptor>(name, ownerId);
+	if (peeked.status !== "consumed" || !peeked.descriptor) return undefined;
+	const descriptor = peeked.descriptor;
+	const consumed = consumeDeadTabRecovery<DeadTabDescriptor>(name, ownerId);
+	if (consumed.status === "owner_mismatch") return undefined;
+	if (consumed.status === "expired_or_missing") {
+		await releaseDeadTabForRecovery(name, descriptor.tab, ownerId);
+		return undefined;
+	}
+	const recovery = withTemporaryBrowserHold(descriptor.browser, async (): Promise<TabSession> => {
+		if (!(await releaseDeadTabForRecovery(name, descriptor.tab, ownerId, true))) {
+			throw new ToolError(`Tab ${JSON.stringify(name)} is not alive. Reopen it.`);
+		}
+		try {
+			return (
+				await acquireTab(name, descriptor.browser, {
+					...descriptor.opts,
+					recoveryTargetId: descriptor.tab.targetId,
+					requireVacantName: true,
+				})
+			).tab;
+		} catch (error) {
+			if (descriptor.tab.kindTag === "headless") await closeOrphanTarget(descriptor.tab).catch(() => undefined);
+			throw error;
+		}
+	});
+	recoveringTabs.set(name, { ownerId, promise: recovery });
+	try {
+		return await recovery;
+	} finally {
+		if (recoveringTabs.get(name)?.promise === recovery) recoveringTabs.delete(name);
+	}
+}
+
+/**
+ * Claim and release exactly the dead tab that produced a recovery descriptor. Every
+ * predicate and the release election run synchronously before teardown can await.
+ */
+export async function releaseDeadTabForRecovery(
+	name: string,
+	expected: TabSession,
+	ownerId: string | undefined,
+	preserveHeadlessTarget = false,
+): Promise<boolean> {
+	if (
+		tabs.get(name) !== expected ||
+		expected.state !== "dead" ||
+		expected.ownerId !== ownerId ||
+		!beginRelease(expected)
+	) {
+		return false;
+	}
+	await releaseClaimedTab(expected, { kill: false }, false, preserveHeadlessTarget);
+	return true;
+}
 
 export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Promise<boolean> {
 	const tab = tabs.get(name);
@@ -351,9 +552,19 @@ export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Pr
 		logger.debug("releaseTab: already releasing", { name });
 		return false;
 	}
-	const wasAlive = tab.state === "alive";
+	await releaseClaimedTab(tab, opts, tab.state === "alive");
+	return true;
+}
+
+async function releaseClaimedTab(
+	tab: TabSession,
+	opts: ReleaseTabOptions,
+	wasAlive: boolean,
+	preserveHeadlessTarget = false,
+): Promise<void> {
 	tab.state = "dead";
-	const closeError = new ToolError(`Tab ${JSON.stringify(name)} was closed`);
+	discardDeadTabRecovery(tab.name);
+	const closeError = new ToolError(`Tab ${JSON.stringify(tab.name)} was closed`);
 	for (const [id, pending] of tab.pending) {
 		try {
 			tab.worker.send({ type: "abort", id });
@@ -371,19 +582,29 @@ export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Pr
 			forced = true;
 		}
 	}
-	await awaitWithinBudget(tab.worker.terminate(), remainingBudget(deadlineAt), "worker.terminate");
-	if (forced && tab.kindTag === "headless") {
-		await awaitWithinBudget(closeOrphanTarget(tab), remainingBudget(deadlineAt), "closeOrphanTarget");
+	try {
+		await awaitWithinBudget(
+			Promise.resolve().then(() => tab.worker.terminate()),
+			remainingBudget(deadlineAt),
+			"worker.terminate",
+		);
+		if (!preserveHeadlessTarget && (forced || !wasAlive) && tab.kindTag === "headless") {
+			await awaitWithinBudget(
+				Promise.resolve().then(() => closeOrphanTarget(tab)),
+				remainingBudget(deadlineAt),
+				"closeOrphanTarget",
+			);
+		}
+	} finally {
+		await awaitWithinBudget(
+			Promise.resolve().then(() => releaseBrowser(tab.browser, { kill: opts.kill ?? false })),
+			remainingBudget(deadlineAt),
+			"releaseBrowser",
+		);
+		// Only delete if the map still holds THIS tab: a same-name reacquire during our async
+		// teardown may have installed a fresh tab that we must not evict.
+		if (tabs.get(tab.name) === tab) tabs.delete(tab.name);
 	}
-	await awaitWithinBudget(
-		releaseBrowser(tab.browser, { kill: opts.kill ?? false }),
-		remainingBudget(deadlineAt),
-		"releaseBrowser",
-	);
-	// Only delete if the map still holds THIS tab: a same-name reacquire during our async
-	// teardown may have installed a fresh tab that we must not evict.
-	if (tabs.get(name) === tab) tabs.delete(name);
-	return true;
 }
 
 export async function releaseAllTabs(opts: ReleaseTabOptions = {}): Promise<number> {
@@ -404,12 +625,18 @@ export async function releaseTabsForOwner(
 	opts: ReleaseTabOptions = {},
 ): Promise<number> {
 	if (!ownerId) return 0;
-	const names = [...tabs.entries()].filter(([, tab]) => tab.ownerId === ownerId).map(([name]) => name);
+	const ownedTabs = [...tabs.values()].filter(tab => tab.ownerId === ownerId);
 	let count = 0;
-	for (const name of names) {
-		if (await releaseTab(name, opts)) count++;
+	for (const tab of ownedTabs) {
+		if (await releaseOwnedTab(tab, ownerId, opts)) count++;
 	}
 	return count;
+}
+
+async function releaseOwnedTab(expected: TabSession, ownerId: string, opts: ReleaseTabOptions): Promise<boolean> {
+	if (tabs.get(expected.name) !== expected || expected.ownerId !== ownerId || !beginRelease(expected)) return false;
+	await releaseClaimedTab(expected, opts, expected.state === "alive");
+	return true;
 }
 
 export async function dropHeadlessTabs(): Promise<void> {
@@ -421,6 +648,15 @@ async function buildInitPayload(browser: BrowserHandle, opts: AcquireTabOptions)
 	const safeDir = getPuppeteerDir();
 	const browserWSEndpoint = browser.browser.wsEndpoint();
 	if (!browserWSEndpoint) throw new ToolError("Browser websocket endpoint is unavailable");
+	if (opts.recoveryTargetId) {
+		return {
+			mode: "attach",
+			browserWSEndpoint,
+			safeDir,
+			targetId: opts.recoveryTargetId,
+			dialogs: opts.dialogs,
+		};
+	}
 	if (browser.kind.kind === "headless") {
 		return {
 			mode: "headless",
@@ -443,6 +679,12 @@ async function buildInitPayload(browser: BrowserHandle, opts: AcquireTabOptions)
 		targetId,
 		dialogs: opts.dialogs,
 	};
+}
+export async function buildInitPayloadForTest(
+	browser: BrowserHandle,
+	opts: AcquireTabOptions,
+): Promise<WorkerInitPayload> {
+	return await buildInitPayload(browser, opts);
 }
 
 function handleTabMessage(tab: TabSession, msg: WorkerOutbound): void {
@@ -531,13 +773,17 @@ async function forceKillTab(name: string, reason: string): Promise<void> {
 	if (!tab) return;
 	if (!beginRelease(tab)) return;
 	tab.state = "dead";
+	discardDeadTabRecovery(name);
 	const error = new ToolError(reason);
 	for (const pending of tab.pending.values()) pending.reject(error);
 	tab.pending.clear();
-	await tab.worker.terminate().catch(() => undefined);
-	if (tab.kindTag === "headless") await closeOrphanTarget(tab);
-	await releaseBrowser(tab.browser, { kill: false });
-	if (tabs.get(name) === tab) tabs.delete(name);
+	try {
+		await tab.worker.terminate().catch(() => undefined);
+		if (tab.kindTag === "headless") await closeOrphanTarget(tab).catch(() => undefined);
+	} finally {
+		await releaseBrowser(tab.browser, { kill: false }).catch(() => undefined);
+		if (tabs.get(name) === tab) tabs.delete(name);
+	}
 }
 
 async function closeOrphanTarget(tab: TabSession): Promise<void> {

--- a/packages/coding-agent/src/tools/resource-gc.ts
+++ b/packages/coding-agent/src/tools/resource-gc.ts
@@ -177,7 +177,7 @@ function ownerBrowserPolicy(snapshot: TabGcSnapshot): BrowserGcPolicy | null {
 /** Coarse, ordering-only eligibility; the live recheck in releaseTabIfGcEligible is authoritative. */
 function isCoarselyEligible(snapshot: TabGcSnapshot): boolean {
 	return (
-		snapshot.state === "alive" &&
+		(snapshot.state === "alive" || snapshot.state === "dead") &&
 		snapshot.pendingCount === 0 &&
 		(snapshot.kindTag === "headless" || snapshot.kindTag === "spawned")
 	);
@@ -230,7 +230,7 @@ function evaluateRssPressureWarning(d: ResourceGcDeps): void {
 		return;
 	}
 	const reclaimableRemains = collectIdleCandidates(d).some(
-		c => c.snapshot.ownerId !== undefined && pressured.has(c.snapshot.ownerId),
+		c => c.snapshot.state === "alive" && c.snapshot.ownerId !== undefined && pressured.has(c.snapshot.ownerId),
 	);
 	if (reclaimableRemains) {
 		rssWarningActive = false;

--- a/packages/coding-agent/test/tools/browser-dead-tab-recovery.test.ts
+++ b/packages/coding-agent/test/tools/browser-dead-tab-recovery.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import {
+	__resetDeadTabRecoveryForTest,
+	__setDeadTabRecoveryDepsForTest,
+	consumeDeadTabRecovery,
+	peekDeadTabRecovery,
+	registerDeadTabRecovery,
+} from "../../src/tools/browser/dead-tab-recovery";
+import type { BrowserHandle } from "../../src/tools/browser/registry";
+import {
+	__setAcquireTabWorkerDepsForTest,
+	__setAfterWorkerInitializationForTest,
+	__setRecoveringTabForTest,
+	acquireTab,
+	buildInitPayloadForTest,
+	clearTabsForTest,
+	closeOrphanTargetForTest,
+	getTab,
+	recoveryPromiseForOwnerForTest,
+	setTabForTest,
+	type TabSession,
+	withTemporaryBrowserHoldForTest,
+} from "../../src/tools/browser/tab-supervisor";
+
+describe("dead tab recovery descriptors (#2437)", () => {
+	afterEach(() => __resetDeadTabRecoveryForTest());
+	afterEach(() => clearTabsForTest());
+
+	it("expires descriptors without consuming a replacement", () => {
+		let now = 1_000;
+		__setDeadTabRecoveryDepsForTest({ now: () => now });
+		registerDeadTabRecovery("tab", "owner", { version: 1 }, 10);
+		now += 10;
+		expect(consumeDeadTabRecovery<{ version: number }>("tab", "owner").status).toBe("expired_or_missing");
+		registerDeadTabRecovery("tab", "owner", { version: 2 }, 10);
+		expect(consumeDeadTabRecovery<{ version: number }>("tab", "owner")).toEqual({
+			status: "consumed",
+			descriptor: { version: 2 },
+		});
+	});
+
+	it("keeps a descriptor consumable by its rightful owner after an owner mismatch", () => {
+		registerDeadTabRecovery("tab", "owner-a", { retained: true });
+		expect(peekDeadTabRecovery("tab", "owner-b").status).toBe("owner_mismatch");
+		expect(consumeDeadTabRecovery("tab", "owner-b").status).toBe("owner_mismatch");
+		expect(consumeDeadTabRecovery<{ retained: boolean }>("tab", "owner-a")).toEqual({
+			status: "consumed",
+			descriptor: { retained: true },
+		});
+	});
+
+	it("expires exactly between peek and consume while retaining the observed descriptor", () => {
+		let now = 1_000;
+		__setDeadTabRecoveryDepsForTest({
+			now: () => now,
+			onPeek: () => {
+				now += 10;
+			},
+		});
+		registerDeadTabRecovery("tab", "owner", { tabIdentity: "dead-tab" }, 10);
+
+		const peeked = peekDeadTabRecovery<{ tabIdentity: string }>("tab", "owner");
+		expect(peeked).toEqual({ status: "consumed", descriptor: { tabIdentity: "dead-tab" } });
+		expect(consumeDeadTabRecovery("tab", "owner").status).toBe("expired_or_missing");
+	});
+
+	it("builds an attach worker payload for a preserved headless recovery target", async () => {
+		const browser = {
+			browser: { wsEndpoint: () => "ws://browser" },
+			kind: { kind: "headless", headless: true },
+		} as unknown as BrowserHandle;
+		await expect(
+			buildInitPayloadForTest(browser, { timeoutMs: 100, recoveryTargetId: "preserved-target" }),
+		).resolves.toEqual(expect.objectContaining({ mode: "attach", targetId: "preserved-target" }));
+	});
+
+	it("balances temporary holds on success and failure without closing early", async () => {
+		const close = vi.fn(async () => {});
+		const browser = {
+			refCount: 1,
+			kind: { kind: "headless", headless: true },
+			browser: { connected: true, close },
+		} as unknown as BrowserHandle;
+		await expect(withTemporaryBrowserHoldForTest(browser, async () => "ok")).resolves.toBe("ok");
+		expect(browser.refCount).toBe(1);
+		expect(close).not.toHaveBeenCalled();
+		await expect(
+			withTemporaryBrowserHoldForTest(browser, async () => {
+				throw new Error("fail");
+			}),
+		).rejects.toThrow("fail");
+		expect(browser.refCount).toBe(1);
+		expect(close).not.toHaveBeenCalled();
+	});
+
+	it("closes only the preserved target selected by target id", async () => {
+		const selected = vi.fn(async () => {});
+		const sibling = vi.fn(async () => {});
+		const tab = {
+			targetId: "preserved",
+			browser: {
+				browser: {
+					targets: () => [
+						{ _targetId: "sibling", page: async () => ({ close: sibling }) },
+						{ _targetId: "preserved", page: async () => ({ close: selected }) },
+					],
+				},
+			},
+		} as unknown as TabSession;
+		await closeOrphanTargetForTest(tab);
+		expect(selected).toHaveBeenCalledTimes(1);
+		expect(sibling).not.toHaveBeenCalled();
+	});
+
+	it("does not expose an in-flight owner recovery to a foreign owner", () => {
+		const { promise, resolve } = Promise.withResolvers<TabSession>();
+		__setRecoveringTabForTest("tab", "owner-a", promise);
+		expect(recoveryPromiseForOwnerForTest("tab", "owner-b")).toBeUndefined();
+		expect(recoveryPromiseForOwnerForTest("tab", "owner-a")).toBe(promise);
+		resolve({} as TabSession);
+	});
+
+	it("fences recovery acquisition when a replacement appears during worker initialization", async () => {
+		const terminate = vi.fn(async () => {});
+		const worker = {
+			mode: "worker" as const,
+			send: () => {},
+			onMessage: () => () => {},
+			onError: () => () => {},
+			terminate,
+		};
+		const browser = {
+			refCount: 1,
+			kind: { kind: "headless", headless: true },
+			browser: { wsEndpoint: () => "ws://browser", connected: true, close: vi.fn(async () => {}) },
+		} as unknown as BrowserHandle;
+		const replacement = {
+			name: "tab",
+			browser,
+			state: "alive",
+			ownerId: "owner-b",
+			pending: new Map(),
+		} as unknown as TabSession;
+		__setAcquireTabWorkerDepsForTest(
+			async () => worker,
+			async () => ({ targetId: "preserved", url: "", viewport: { width: 1, height: 1 } }),
+		);
+		__setAfterWorkerInitializationForTest(() => setTabForTest(replacement));
+		await expect(
+			acquireTab("tab", browser, { timeoutMs: 10, recoveryTargetId: "preserved", requireVacantName: true }),
+		).rejects.toThrow("replaced during recovery");
+		expect(terminate).toHaveBeenCalledTimes(1);
+		expect(getTab("tab")).toBe(replacement);
+		expect(browser.refCount).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/tools/browser-gc.test.ts
+++ b/packages/coding-agent/test/tools/browser-gc.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { Browser } from "puppeteer-core";
+import {
+	__resetDeadTabRecoveryForTest,
+	__setDeadTabRecoveryDepsForTest,
+	registerDeadTabRecovery,
+} from "../../src/tools/browser/dead-tab-recovery";
 import type { BrowserHandle, BrowserKindTag } from "../../src/tools/browser/registry";
 import {
 	clearTabsForTest,
 	getTab,
 	listTabsForGc,
+	releaseDeadTabForRecovery,
 	releaseTab,
 	releaseTabIfGcEligible,
 	setTabForTest,
@@ -97,10 +103,12 @@ function installTab(opts: InstallOpts): {
 describe("tab-supervisor GC primitives", () => {
 	beforeEach(() => {
 		clearTabsForTest();
+		__resetDeadTabRecoveryForTest();
 	});
 	afterEach(() => {
 		clearTabsForTest();
 		vi.restoreAllMocks();
+		__resetDeadTabRecoveryForTest();
 	});
 
 	it("evicts an idle headless tab: worker terminated, browser closed, tab removed", async () => {
@@ -124,7 +132,6 @@ describe("tab-supervisor GC primitives", () => {
 		{ label: "in-flight", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW - 5000, pendingCount: 1 } },
 		{ label: "recently used", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW } },
 		{ label: "idle exactly at threshold", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW - IDLE_MS } },
-		{ label: "dead", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW - 5000, state: "dead" } },
 	];
 
 	for (const { label, opts } of protectedCases) {
@@ -153,6 +160,40 @@ describe("tab-supervisor GC primitives", () => {
 		expect(close).toHaveBeenCalledTimes(1);
 		expect(handle.refCount).toBe(0);
 		expect(getTab("a")).toBeUndefined();
+	});
+
+	it("retains a dead tab during its live recovery TTL, then GC releases that exact tab", async () => {
+		let now = NOW;
+		__setDeadTabRecoveryDepsForTest({ now: () => now });
+		const { close } = installTab({ name: "dead", kindTag: "headless", lastUsedAt: NOW - 5000, state: "dead" });
+		const dead = getTab("dead")!;
+		registerDeadTabRecovery("dead", dead.ownerId, { dead }, 100);
+		expect(await releaseTabIfGcEligible("dead", { now: () => now, idleMs: IDLE_MS })).toBe(false);
+		expect(getTab("dead")).toBe(dead);
+		now += 100;
+		expect(await releaseTabIfGcEligible("dead", { now: () => now, idleMs: IDLE_MS })).toBe(true);
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(getTab("dead")).toBeUndefined();
+	});
+
+	it("closes an orphaned headless target during ordinary dead-tab release", async () => {
+		const { handle } = installTab({ name: "dead", kindTag: "headless", lastUsedAt: NOW - 5000, state: "dead" });
+		const closeTarget = vi.fn(async () => {});
+		(handle.browser as unknown as { targets(): unknown[] }).targets = () => [
+			{ _targetId: "target-1", page: async () => ({ close: closeTarget }) },
+		];
+		expect(await releaseTab("dead")).toBe(true);
+		expect(closeTarget).toHaveBeenCalledTimes(1);
+	});
+
+	it("exact dead-session release cannot remove a same-name replacement", async () => {
+		const { handle } = installTab({ name: "tab", kindTag: "headless", lastUsedAt: NOW, state: "dead" });
+		const dead = getTab("tab")!;
+		const replacement = { ...dead, state: "alive", releasing: undefined } as TabSession;
+		setTabForTest(replacement);
+		expect(await releaseDeadTabForRecovery("tab", dead, dead.ownerId)).toBe(false);
+		expect(getTab("tab")).toBe(replacement);
+		expect(handle.refCount).toBe(1);
 	});
 
 	it("listTabsForGc reflects live tab fields without exposing the map", () => {

--- a/packages/coding-agent/test/tools/resource-gc.test.ts
+++ b/packages/coding-agent/test/tools/resource-gc.test.ts
@@ -78,6 +78,21 @@ describe("resource GC controller", () => {
 		expect(releaseTab.mock.calls.map(c => c[0])).toEqual(["old", "mid"]);
 	});
 
+	it("forwards expired dead managed tabs to the authoritative supervisor recheck", async () => {
+		const settings = Settings.isolated({
+			"browser.gc.enabled": true,
+			"browser.gc.idleMs": 1000,
+			"browser.gc.rssLimitMb": 1_000_000,
+			"computer.screenshotGc.enabled": false,
+		});
+		registerResourceGcSession({ sessionId: "s1", settings });
+		const releaseTab = vi.fn(async () => true);
+		await sweepOnce(
+			baseDeps({ releaseTab, listTabs: () => [snapshot("dead", "s1", NOW - 5000, { state: "dead" })] }),
+		);
+		expect(releaseTab).toHaveBeenCalledWith("dead", expect.objectContaining({ idleMs: 1000 }));
+	});
+
 	it("skips tabs owned by no registered session", async () => {
 		const settings = Settings.isolated({ "browser.gc.idleMs": 1000, "browser.gc.rssLimitMb": 1_000_000 });
 		registerResourceGcSession({ sessionId: "s1", settings });
@@ -89,6 +104,25 @@ describe("resource GC controller", () => {
 			}),
 		);
 		expect(releaseTab.mock.calls.map(c => c[0])).toEqual(["mine"]);
+	});
+
+	it("warns under RSS pressure when only a recovery-held dead tab remains", async () => {
+		const settings = Settings.isolated({
+			"browser.gc.enabled": true,
+			"browser.gc.idleMs": 1000,
+			"browser.gc.rssLimitMb": 100,
+			"computer.screenshotGc.enabled": false,
+		});
+		registerResourceGcSession({ sessionId: "s1", settings });
+		const logWarn = vi.fn();
+		await sweepOnce(
+			baseDeps({
+				logWarn,
+				rssBytes: () => 200 * MB,
+				listTabs: () => [snapshot("recovering", "s1", NOW - 5000, { state: "dead" })],
+			}),
+		);
+		expect(logWarn).toHaveBeenCalledTimes(1);
 	});
 
 	it("never evicts non-idle tabs under RSS pressure (IR-1) and warns once instead", async () => {


### PR DESCRIPTION
## Summary
- add owner-bound dead-tab recovery descriptors and target-preserving worker recovery
- release only the exact unchanged dead tab when a descriptor expires between peek and consume
- protect replacement/live tabs and serialize recovery/GC/manual teardown through exact release election
- preserve browser holds and target/refcount accounting across success, failure, shared-browser, and GC paths

## Verification
- focused browser tests: 52 pass
- coding-agent package check: pass
- coding-agent build: pass
- hostile architect review: CLEAR / APPROVE
- adversarial executor QA: PASS

Fixes #2437