### PR TITLE
feat(tui): pin explicit fold choices (minimal, source-compatible)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Added the versioned, readonly managed session-directory SDK: `SESSION_DIRECTORY_API_VERSION`, `resolveManagedSessionScope`, and `listManagedSessionCandidates` are exported from `@gajae-code/coding-agent/sdk`. The package boundary continues to reject private `session/internal/*` imports. Managed writes use v2 workspace scopes with validated opt-in legacy copy-retain migration (#2177).
 
 ### Changed
+- Explicit fold choices from the user shortcut or extension `setToolsExpanded` now pin a block for its component lifetime, so automatic stamping no longer overwrites them; sessions that never toggle are unchanged.
 
 - Renamed the notifications SDK to the Gajae-Code SDK: `docs/notifications-sdk.md` is now `docs/sdk.md`, `src/notifications/` is now `src/sdk/bus/`, and `src/sdk.ts` is now the `src/sdk/` module directory. Old deep-import specifiers no longer resolve.
 - Moved SDK discovery from `.gjc/state/notifications/` to `.gjc/state/sdk/`. Restart sessions and daemons together when upgrading; the runtime does not dual-scan the old and new directories.

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -271,7 +271,11 @@ export interface ExtensionUIContext {
 	/** Get current tool output expansion state. */
 	getToolsExpanded(): boolean;
 
-	/** Set tool output expansion state. */
+	/**
+	 * Set tool output expansion state. This is an explicit fold choice, pinning
+	 * existing tool and read components for their renderer instance lifetime,
+	 * the same as the user shortcut.
+	 */
 	setToolsExpanded(expanded: boolean): void;
 }
 

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -80,6 +80,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	#entries = new Map<string, ReadEntry>();
 	#text: Text;
 	#expanded = false;
+	#manuallyExpanded: boolean | undefined;
 	#showContentPreview: boolean;
 
 	constructor(options: ReadToolGroupOptions = {}) {
@@ -137,7 +138,19 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		this.#updateDisplay();
 	}
 
+	/** Applies automatic expansion unless this renderer instance has an explicit fold choice. */
 	setExpanded(expanded: boolean): void {
+		if (this.#manuallyExpanded !== undefined) return;
+		this.#expanded = expanded;
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Applies and pins an explicit fold choice for this renderer instance only.
+	 * Transcript rebuilds recreate components from global state and drop this pin.
+	 */
+	setManuallyExpanded(expanded: boolean): void {
+		this.#manuallyExpanded = expanded;
 		this.#expanded = expanded;
 		this.#updateDisplay();
 	}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -159,6 +159,15 @@ export interface ToolExecutionHandle {
 	): void;
 	setArgsComplete(toolCallId?: string): void;
 	setExpanded(expanded: boolean): void;
+	/**
+	 * Applies an explicit fold choice for this renderer instance. The pin lasts
+	 * only for this instance; transcript rebuilds recreate it from global state.
+	 * Optional for source compatibility: this interface is publicly exported and
+	 * pre-existing structural implementers must keep compiling. Dispatchers must
+	 * guard with `typeof handle.setManuallyExpanded === "function"` and fall
+	 * back to {@link setExpanded}.
+	 */
+	setManuallyExpanded?(expanded: boolean): void;
 }
 
 /**
@@ -174,6 +183,7 @@ export class ToolExecutionComponent extends Container {
 	#toolLabel: string;
 	#args: any;
 	#expanded = false;
+	#manuallyExpanded: boolean | undefined;
 	#showImages: boolean;
 	#editFuzzyThreshold: number | undefined;
 	#editAllowFuzzy: boolean | undefined;
@@ -450,7 +460,19 @@ export class ToolExecutionComponent extends Container {
 		super.dispose();
 	}
 
+	/** Applies automatic expansion unless this renderer instance has an explicit fold choice. */
 	setExpanded(expanded: boolean): void {
+		if (this.#manuallyExpanded !== undefined) return;
+		this.#expanded = expanded;
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Applies and pins an explicit fold choice for this renderer instance only.
+	 * Transcript rebuilds recreate components from global state and drop this pin.
+	 */
+	setManuallyExpanded(expanded: boolean): void {
+		this.#manuallyExpanded = expanded;
 		this.#expanded = expanded;
 		this.#updateDisplay();
 	}

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -30,6 +30,7 @@ import { type QueuedMessageMoveDirection, QueuedMessageSelectorComponent } from 
 
 interface Expandable {
 	setExpanded(expanded: boolean): void;
+	setManuallyExpanded?(expanded: boolean): void;
 }
 
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
@@ -1539,7 +1540,17 @@ export class InputController {
 		this.ctx.toolOutputExpanded = expanded;
 		for (const child of this.ctx.chatContainer.children) {
 			if (isExpandable(child)) {
-				child.setExpanded(expanded);
+				// Callable guard: setManuallyExpanded is optional on the exported
+				// contract, and hostile/legacy children may expose it as a
+				// non-function property or an unstable getter. Read once, then
+				// invoke only a real function; everything else falls back to the
+				// automatic path.
+				const setManuallyExpanded = child.setManuallyExpanded;
+				if (typeof setManuallyExpanded === "function") {
+					setManuallyExpanded.call(child, expanded);
+				} else {
+					child.setExpanded(expanded);
+				}
 			}
 		}
 		this.ctx.ui.requestRender();

--- a/packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts
@@ -66,6 +66,24 @@ describe("ToolExecutionComponent spacing", () => {
 		expect(trailing + leading).toBe(1);
 	});
 });
+it("preserves manual expansion through automatic updates and drops it on remount", () => {
+	const component = new ToolExecutionComponent("custom", { path: "/tmp/example.ts" }, {}, undefined, uiStub);
+	component.setManuallyExpanded(true);
+	component.setExpanded(false);
+
+	expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("Args");
+
+	const remounted = new ToolExecutionComponent("custom", { path: "/tmp/example.ts" }, {}, undefined, uiStub);
+	remounted.setExpanded(false);
+	expect(Bun.stripANSI(remounted.render(80).join("\n"))).not.toContain("Args");
+});
+
+it("lets untouched components follow automatic expansion", () => {
+	const component = new ToolExecutionComponent("custom", { path: "/tmp/example.ts" }, {}, undefined, uiStub);
+	component.setExpanded(true);
+
+	expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("Args");
+});
 
 it("replaces generic SIXEL output while the IRC sidebar is visible and restores passthrough when hidden", () => {
 	terminal.imageProtocol = ImageProtocol.Sixel;

--- a/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
@@ -148,4 +148,16 @@ describe("ExtensionUiController transcript rebuild policy", () => {
 
 		expect(fixture.rebuildChatFromMessages).toHaveBeenCalledWith("reconcile-same-transcript");
 	});
+	it("routes extension fold choices through the interactive context", async () => {
+		const fixture = createFixture();
+		await fixture.controller.initHooksAndCustomTools();
+
+		const setToolUIContext = fixture.ctx.setToolUIContext as Mock<
+			(context: ExtensionUIContext, interactive: boolean) => void
+		>;
+		const uiContext = setToolUIContext.mock.calls[0]?.[0] as ExtensionUIContext;
+		uiContext.setToolsExpanded(true);
+
+		expect(fixture.ctx.setToolsExpanded).toHaveBeenCalledWith(true);
+	});
 });

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { getDefault } from "../src/config/settings-schema";
 import { ReadToolGroupComponent, readArgsTargetInternalUrl } from "../src/modes/components/read-tool-group";
+import { InputController } from "../src/modes/controllers/input-controller";
 import * as themeModule from "../src/modes/theme/theme";
+import type { InteractiveModeContext } from "../src/modes/types";
 
 describe("ReadToolGroupComponent", () => {
 	beforeAll(async () => {
@@ -92,6 +94,102 @@ describe("ReadToolGroupComponent", () => {
 		const matches = rendered.match(/Read \/tmp\/example\.ts:L10-L20/g) ?? [];
 
 		expect(matches).toHaveLength(1);
+	});
+	it("preserves manual fold choices through automatic and entry updates", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/one.ts" }, "read-1");
+		component.updateResult({ content: [{ type: "text", text: "one\ntwo\nthree\nfour\nfive" }] }, false, "read-1");
+		component.setManuallyExpanded(true);
+		component.setExpanded(false);
+		component.updateArgs({ path: "/tmp/two.ts" }, "read-2");
+		component.updateResult(
+			{ content: [{ type: "text", text: "warning" }], details: { suffixResolution: { from: "a", to: "b" } } },
+			false,
+			"read-2",
+		);
+		component.updateArgs({ path: "/tmp/three.ts" }, "read-3");
+		component.updateResult({ content: [{ type: "text", text: "error" }], isError: true }, false, "read-3");
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("four");
+
+		component.setManuallyExpanded(false);
+		component.setExpanded(true);
+		expect(Bun.stripANSI(component.render(120).join("\n"))).not.toContain("four");
+	});
+
+	it("lets unpinned read groups follow automatic expansion", () => {
+		const component = new ReadToolGroupComponent({ showContentPreview: true });
+		component.updateArgs({ path: "/tmp/example.ts" }, "read-1");
+		component.updateResult({ content: [{ type: "text", text: "one\ntwo\nthree\nfour" }] }, false, "read-1");
+		component.setExpanded(true);
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("four");
+	});
+	it("accepts a controller override as a fresh explicit pin", () => {
+		const manuallyExpandable = { setExpanded: vi.fn(), setManuallyExpanded: vi.fn() };
+		const automaticallyExpandable = { setExpanded: vi.fn() };
+		const ctx = {
+			toolOutputExpanded: false,
+			chatContainer: { children: [manuallyExpandable, automaticallyExpandable] },
+			ui: { requestRender: vi.fn() },
+		} as unknown as InteractiveModeContext;
+
+		new InputController(ctx).setToolsExpanded(true);
+
+		expect(manuallyExpandable.setManuallyExpanded).toHaveBeenCalledWith(true);
+		expect(manuallyExpandable.setExpanded).not.toHaveBeenCalled();
+		expect(automaticallyExpandable.setExpanded).toHaveBeenCalledWith(true);
+	});
+
+	it("dispatches the pin only to real functions and never throws on hostile children", () => {
+		const inherited = Object.create({ setManuallyExpanded: vi.fn() });
+		inherited.setExpanded = vi.fn();
+		const absent = { setExpanded: vi.fn() };
+		const nullish = { setExpanded: vi.fn(), setManuallyExpanded: null };
+		const truthyNonFunction = { setExpanded: vi.fn(), setManuallyExpanded: true };
+		let hostileReads = 0;
+		const hostileGetter = {
+			setExpanded: vi.fn(),
+			get setManuallyExpanded() {
+				hostileReads += 1;
+				return hostileReads > 1 ? undefined : (true as unknown);
+			},
+		};
+		const ctx = {
+			toolOutputExpanded: false,
+			chatContainer: { children: [inherited, absent, nullish, truthyNonFunction, hostileGetter] },
+			ui: { requestRender: vi.fn() },
+		} as unknown as InteractiveModeContext;
+
+		expect(() => new InputController(ctx).setToolsExpanded(true)).not.toThrow();
+
+		// Inherited callable receives the pin; every non-callable shape falls
+		// back to plain setExpanded instead of being invoked.
+		expect(Object.getPrototypeOf(inherited).setManuallyExpanded).toHaveBeenCalledWith(true);
+		expect(inherited.setExpanded).not.toHaveBeenCalled();
+		expect(absent.setExpanded).toHaveBeenCalledWith(true);
+		expect(nullish.setExpanded).toHaveBeenCalledWith(true);
+		expect(truthyNonFunction.setExpanded).toHaveBeenCalledWith(true);
+		expect(hostileGetter.setExpanded).toHaveBeenCalledWith(true);
+	});
+
+	it("keeps ToolExecutionHandle source-compatible for legacy structural implementers", () => {
+		// Compile-time compatibility fixture: an implementer written against the
+		// pre-pin interface (no setManuallyExpanded) must keep typechecking.
+		const legacy: import("../src/modes/components/tool-execution").ToolExecutionHandle = {
+			updateArgs: vi.fn(),
+			updateResult: vi.fn(),
+			setArgsComplete: vi.fn(),
+			setExpanded: vi.fn(),
+		};
+		const ctx = {
+			toolOutputExpanded: false,
+			chatContainer: { children: [legacy] },
+			ui: { requestRender: vi.fn() },
+		} as unknown as InteractiveModeContext;
+
+		new InputController(ctx).setToolsExpanded(true);
+		expect(legacy.setExpanded).toHaveBeenCalledWith(true);
 	});
 });
 


### PR DESCRIPTION
## Summary
Resubmission of #2449 fixing its three FAIL findings. Head `4e1e4488`, single commit rebased onto current dev `1e677440` (the head the reviewer cross-checked against). Scope unchanged: 8 fold-pin files, +181/−2, zero `expandHint` surfaces touched. #2448 remains open and is deliberately not closed by this PR.

## Finding responses
1. **Source (TS2420/TS2741 on legacy implementers)** — `ToolExecutionHandle.setManuallyExpanded` is now OPTIONAL on the exported interface, with a docstring stating the compatibility rationale and the required dispatch guard. A compile-level fixture test constructs a legacy structural implementer WITHOUT the method and typechecks + dispatches through the automatic fallback.
2. **Consumer** — direct implementers need no new member; pin capability is opt-in. The two in-repo components implement it; everything else keeps the pre-PR contract.
3. **Runtime (truthy-nonfunction TypeError)** — dispatch reads the property ONCE into a local and invokes only `typeof === "function"` via `.call(child, …)`; the single read also defeats unstable getters that change between check and call. Adversarial regression covers: inherited callable (receives the pin), absent, `null`, truthy non-function, and a hostile getter — all non-callable shapes fall back to `setExpanded`, and the sweep never throws.

## Testing
- read-tool-group (incl. new adversarial dispatch + legacy-implementer fixtures) + tool-execution-spacing + extension-ui-transcript-policy — 33 pass; re-verified post-rebase on `1e677440`.
- `bun --cwd=packages/coding-agent run check` (biome, SDK canonicalization, tsc) — pass.