### PR TITLE
feat(coding-agent): add busy prompt mode controls

### DIFF
--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -445,34 +445,33 @@ fn parse_key_id(key_id: &str) -> Option<ParsedKeyId<'_>> {
 	let mut modifier = 0;
 	let mut key: Option<&str> = if forced_key_plus { Some("+") } else { None };
 
-	for part in prefix.split('+') {
-		let p = part.trim();
-		let [c0, ..] = p.as_bytes() else {
-			continue;
-		};
+	if !prefix.is_empty() {
+		for part in prefix.split('+') {
+			let p = part.trim();
+			if p.is_empty() {
+				return None;
+			}
 
-		match c0 {
-			b'c' | b'C' if p.eq_ignore_ascii_case("ctrl") => {
-				modifier |= MOD_CTRL;
+			let modifier_bit = match p {
+				p if p.eq_ignore_ascii_case("ctrl") => MOD_CTRL,
+				p if p.eq_ignore_ascii_case("shift") => MOD_SHIFT,
+				p if p.eq_ignore_ascii_case("alt") => MOD_ALT,
+				p if p.eq_ignore_ascii_case("super") => MOD_SUPER,
+				_ => 0,
+			};
+			if modifier_bit != 0 {
+				if (!forced_key_plus && key.is_some()) || modifier & modifier_bit != 0 {
+					return None;
+				}
+				modifier |= modifier_bit;
 				continue;
-			},
-			b's' | b'S' if p.eq_ignore_ascii_case("shift") => {
-				modifier |= MOD_SHIFT;
-				continue;
-			},
-			b'a' | b'A' if p.eq_ignore_ascii_case("alt") => {
-				modifier |= MOD_ALT;
-				continue;
-			},
-			b's' | b'S' if p.eq_ignore_ascii_case("super") => {
-				modifier |= MOD_SUPER;
-				continue;
-			},
-			_ => {},
+			}
+
+			if key.is_some() {
+				return None;
+			}
+			key = Some(p);
 		}
-
-		// Treat this as the key token (last non-modifier wins)
-		key = Some(p);
 	}
 
 	let mut key = key?;

--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -70,6 +70,7 @@ const CP_KP_EQUALS: i32 = 57415;
 const MOD_SHIFT: u32 = 1;
 const MOD_ALT: u32 = 2;
 const MOD_CTRL: u32 = 4;
+const MOD_SUPER: u32 = 8;
 const MOD_NUM_LOCK: u32 = 128;
 
 /// Event types from Kitty keyboard protocol (flag 2).
@@ -461,6 +462,10 @@ fn parse_key_id(key_id: &str) -> Option<ParsedKeyId<'_>> {
 			},
 			b'a' | b'A' if p.eq_ignore_ascii_case("alt") => {
 				modifier |= MOD_ALT;
+				continue;
+			},
+			b's' | b'S' if p.eq_ignore_ascii_case("super") => {
+				modifier |= MOD_SUPER;
 				continue;
 			},
 			_ => {},
@@ -1325,7 +1330,7 @@ fn parse_functional(bytes: &[u8]) -> Option<ParsedKittySequence> {
 
 fn format_kitty_key(parsed: &ParsedKittySequence) -> Option<Cow<'static, str>> {
 	let effective_mod = parsed.modifier & !LOCK_MASK;
-	if effective_mod & !(MOD_SHIFT | MOD_CTRL | MOD_ALT) != 0 {
+	if effective_mod & !(MOD_SHIFT | MOD_CTRL | MOD_ALT | MOD_SUPER) != 0 {
 		return None;
 	}
 	let effective_codepoint =
@@ -1427,6 +1432,9 @@ fn format_with_mods(mods: u32, key_name: &str) -> String {
 	if mods & MOD_ALT != 0 {
 		result.push_str("alt+");
 	}
+	if mods & MOD_SUPER != 0 {
+		result.push_str("super+");
+	}
 	result.push_str(key_name);
 	result
 }
@@ -1472,8 +1480,9 @@ mod tests {
 	}
 
 	#[test]
-	fn parse_key_ignores_kitty_sequences_with_unsupported_modifiers() {
-		assert_eq!(parse_key_inner(b"\x1b[99;9u", true).as_deref(), None);
+	fn parse_key_supports_kitty_super_modifier() {
+		assert_eq!(parse_key_inner(b"\x1b[99;9u", true).as_deref(), Some("super+c"));
+		assert!(matches_key_inner(b"\x1b[13;9u", "super+enter", true));
 	}
 
 	#[test]

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -42,7 +42,7 @@ Set an action to an empty array to disable it:
 | `app.editor.external` | `Ctrl+G` | Edit the draft in `$VISUAL` / `$EDITOR` |
 | `app.message.followUp` | _(none)_ | Optional remap for a follow-up message; `Ctrl+Enter` remains editor newline unless remapped |
 | `app.message.queue` | `Alt+Q` (macOS/Windows), `Alt+Enter` (otherwise) | Explicitly queue a message for the next turn |
-| `app.message.oppositeBusyMode` | `Command+Enter` (macOS) | Submit one message using the opposite of `busyPromptMode` |
+| `app.message.oppositeBusyMode` | `Super+Enter` | Submit one message using the opposite of `busyPromptMode` |
 | `app.message.dequeue` | `Alt+Up` | Dequeue a queued message back into the editor |
 
 | `app.clipboard.copyLine` | `Alt+Shift+L` | Copy the current line |
@@ -53,7 +53,7 @@ Set an action to an empty array to disable it:
 Older unqualified action names are migrated when `keybindings.json` is loaded, but new docs and new configs should use the namespaced action IDs above.
 
 On macOS and native Windows terminals, GJC defaults `app.message.queue` to `Alt+Q`; other platforms use `Alt+Enter`. Windows Terminal and PowerShell commonly reserve `Alt+Enter` for fullscreen before GJC can receive it. Users who prefer another chord can remap `app.message.queue` in `~/.gjc/agent/keybindings.json`.
-While the agent is streaming on macOS, `Command+Enter` submits the current message once using the opposite of `busyPromptMode`: configured `steer` queues that message, while configured `queue` steers it into the active turn. The shortcut is inactive while idle or compacting and is remappable through `app.message.oppositeBusyMode`.
+While the agent is streaming, `Super+Enter` submits the current message once using the opposite of `busyPromptMode`: configured `steer` queues that message, while configured `queue` steers it into the active turn. The shortcut is inactive while idle or compacting and is remappable through `app.message.oppositeBusyMode`. This portable default depends on the terminal forwarding the Super modifier, not the host operating system.
 
 In the main GJC composer, plain `PageUp` / `PageDown` page the visible transcript viewport instead of browsing prompt history; use `Up` / `Down` or `Ctrl+R` for prompt history. Autocomplete and selector surfaces still use `PageUp` / `PageDown` for list paging while they have focus.
 
@@ -141,7 +141,7 @@ Authoritative inventory of the keybinding registry, one row per action. Generate
 | `app.editor.external` | `ctrl+g` | |
 | `app.message.followUp` | _(none)_ | `Ctrl+Enter` remains editor newline unless the user explicitly remaps this action; while idle the chord still falls through to newline |
 | `app.message.queue` | `alt+q` (macOS/Windows), `alt+enter` (otherwise) | platform-aware; avoids the Windows Terminal fullscreen shortcut |
-| `app.message.oppositeBusyMode` | `super+enter` (macOS only) | one-message inversion of `busyPromptMode`; inactive while idle or compacting |
+| `app.message.oppositeBusyMode` | `super+enter` | one-message inversion of `busyPromptMode`; inactive while idle or compacting |
 | `app.message.dequeue` | `alt+up` | |
 | `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on win32) | platform-aware; single source of truth in `KEYBINDINGS` |
 | `app.clipboard.copyLine` | `alt+shift+l` | registry-backed via input-controller custom handler |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -40,8 +40,9 @@ Set an action to an empty array to disable it:
 | `app.thinking.toggle` | `Ctrl+T` | Toggle thinking-block visibility |
 | `app.thinking.cycle` | `Shift+Tab` | Cycle thinking level |
 | `app.editor.external` | `Ctrl+G` | Edit the draft in `$VISUAL` / `$EDITOR` |
-| `app.message.followUp` | _(none)_ | Optional remap for a follow-up message; `Ctrl+Enter` is reserved for editor newline |
-| `app.message.queue` | `Alt+Enter` (`Alt+Q` on win32) | Explicitly queue a message for the next turn |
+| `app.message.followUp` | _(none)_ | Optional remap for a follow-up message; `Ctrl+Enter` remains editor newline unless remapped |
+| `app.message.queue` | `Alt+Q` (macOS/Windows), `Alt+Enter` (otherwise) | Explicitly queue a message for the next turn |
+| `app.message.oppositeBusyMode` | `Command+Enter` (macOS) | Submit one message using the opposite of `busyPromptMode` |
 | `app.message.dequeue` | `Alt+Up` | Dequeue a queued message back into the editor |
 
 | `app.clipboard.copyLine` | `Alt+Shift+L` | Copy the current line |
@@ -51,7 +52,8 @@ Set an action to an empty array to disable it:
 
 Older unqualified action names are migrated when `keybindings.json` is loaded, but new docs and new configs should use the namespaced action IDs above.
 
-On native Windows terminals, GJC defaults `app.message.queue` to `Alt+Q` because Windows Terminal and PowerShell commonly reserve `Alt+Enter` for fullscreen before GJC can receive it. Users who prefer another chord can remap `app.message.queue` in `~/.gjc/agent/keybindings.json`.
+On macOS and native Windows terminals, GJC defaults `app.message.queue` to `Alt+Q`; other platforms use `Alt+Enter`. Windows Terminal and PowerShell commonly reserve `Alt+Enter` for fullscreen before GJC can receive it. Users who prefer another chord can remap `app.message.queue` in `~/.gjc/agent/keybindings.json`.
+While the agent is streaming on macOS, `Command+Enter` submits the current message once using the opposite of `busyPromptMode`: configured `steer` queues that message, while configured `queue` steers it into the active turn. The shortcut is inactive while idle or compacting and is remappable through `app.message.oppositeBusyMode`.
 
 In the main GJC composer, plain `PageUp` / `PageDown` page the visible transcript viewport instead of browsing prompt history; use `Up` / `Down` or `Ctrl+R` for prompt history. Autocomplete and selector surfaces still use `PageUp` / `PageDown` for list paging while they have focus.
 
@@ -137,8 +139,9 @@ Authoritative inventory of the keybinding registry, one row per action. Generate
 | `app.tools.expand` | `ctrl+o` | |
 | `app.tool.backgroundFold` | `ctrl+b` | |
 | `app.editor.external` | `ctrl+g` | |
-| `app.message.followUp` | _(none)_ | `Ctrl+Enter` remains newline unless the user explicitly remaps this action; while idle the chord still falls through to newline |
-| `app.message.queue` | `alt+enter` (`alt+q` on win32) | platform-aware; avoids the Windows Terminal fullscreen shortcut |
+| `app.message.followUp` | _(none)_ | `Ctrl+Enter` remains editor newline unless the user explicitly remaps this action; while idle the chord still falls through to newline |
+| `app.message.queue` | `alt+q` (macOS/Windows), `alt+enter` (otherwise) | platform-aware; avoids the Windows Terminal fullscreen shortcut |
+| `app.message.oppositeBusyMode` | `super+enter` (macOS only) | one-message inversion of `busyPromptMode`; inactive while idle or compacting |
 | `app.message.dequeue` | `alt+up` | |
 | `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on win32) | platform-aware; single source of truth in `KEYBINDINGS` |
 | `app.clipboard.copyLine` | `alt+shift+l` | registry-backed via input-controller custom handler |

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -66,8 +66,8 @@ export function defaultMessageQueueKeysForPlatform(platform: NodeJS.Platform = p
 	return platform === "win32" || platform === "darwin" ? "alt+q" : "alt+enter";
 }
 
-export function defaultOppositeBusyModeKeysForPlatform(platform: NodeJS.Platform = process.platform): KeyId[] {
-	return platform === "darwin" ? ["super+enter"] : [];
+export function defaultOppositeBusyModeKeysForPlatform(_platform: NodeJS.Platform = process.platform): KeyId[] {
+	return ["super+enter"];
 }
 
 /**

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -32,6 +32,7 @@ interface AppKeybindings {
 	"app.editor.external": true;
 	"app.message.followUp": true;
 	"app.message.queue": true;
+	"app.message.oppositeBusyMode": true;
 	"app.message.dequeue": true;
 	"app.clipboard.pasteImage": true;
 	"app.clipboard.copyLine": true;
@@ -63,6 +64,10 @@ declare module "@gajae-code/tui" {
 
 export function defaultMessageQueueKeysForPlatform(platform: NodeJS.Platform = process.platform): KeyId {
 	return platform === "win32" || platform === "darwin" ? "alt+q" : "alt+enter";
+}
+
+export function defaultOppositeBusyModeKeysForPlatform(platform: NodeJS.Platform = process.platform): KeyId[] {
+	return platform === "darwin" ? ["super+enter"] : [];
 }
 
 /**
@@ -128,7 +133,11 @@ export const KEYBINDINGS = {
 	},
 	"app.message.followUp": {
 		defaultKeys: [],
-		description: "Send follow-up message (no default; Ctrl+Enter submits)",
+		description: "Send follow-up message (no default; Ctrl+Enter remains editor newline unless remapped)",
+	},
+	"app.message.oppositeBusyMode": {
+		defaultKeys: defaultOppositeBusyModeKeysForPlatform(),
+		description: "Submit once using the opposite busy prompt mode",
 	},
 	"app.message.queue": {
 		defaultKeys: defaultMessageQueueKeysForPlatform(),

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5,15 +5,20 @@ import { getThinkingLevelMetadata } from "../thinking-metadata";
 import { EDIT_MODES } from "../utils/edit-mode";
 import { CONFIGURABLE_SEARCH_PROVIDER_IDS } from "../web/search/types";
 import type { ModelSelectorValue } from "./model-selector-value";
-
-const THINKING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as readonly Effort[];
-const DEFAULT_THINKING_LEVELS = ["off", ...THINKING_EFFORTS] as const;
-
 import {
 	DEFAULT_DISABLED_EXTENSIONS,
 	DEFAULT_SKILL_DISCOVERY_SETTINGS,
 	type SkillDiscoverySettings,
 } from "./skill-settings-defaults";
+
+const THINKING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as readonly Effort[];
+const DEFAULT_THINKING_LEVELS = ["off", ...THINKING_EFFORTS] as const;
+
+export type BusyPromptMode = "steer" | "queue";
+
+export function normalizeBusyPromptMode(value: unknown): BusyPromptMode {
+	return value === "queue" ? "queue" : "steer";
+}
 
 /** Unified settings schema - single source of truth for all settings.
  *

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -47,6 +47,7 @@ import {
 	type GroupPrefix,
 	type GroupTypeMap,
 	getDefault,
+	normalizeBusyPromptMode,
 	SETTINGS_SCHEMA,
 	type SettingPath,
 	type SettingValue,
@@ -369,6 +370,8 @@ export class Settings implements NotificationSettingsReader {
 	/** Legacy fallback migration warnings emitted once per settings instance. */
 	#legacyFallbackMigrationWarnings = 0;
 	#legacyFallbackMigrationGlobalFingerprint: string | undefined;
+	/** Invalid persisted busy prompt mode warning emitted once per settings instance. */
+	#busyPromptModeInvalidWarningEmitted = false;
 
 	/** Whether to persist changes */
 	#persist: boolean;
@@ -465,6 +468,9 @@ export class Settings implements NotificationSettingsReader {
 	get<P extends SettingPath>(path: P): SettingValue<P> {
 		const segments = path.split(".");
 		const value = getByPath(this.#merged, segments);
+		if (path === "busyPromptMode") {
+			return this.#normalizeBusyPromptMode(value) as SettingValue<P>;
+		}
 		if (value !== undefined) {
 			const pathScopedValue = resolvePathScopedStringArray(path, value, this.#cwd);
 			return (pathScopedValue ?? value) as SettingValue<P>;
@@ -472,6 +478,25 @@ export class Settings implements NotificationSettingsReader {
 		return getDefault(path);
 	}
 
+	#normalizeBusyPromptMode(value: unknown): "steer" | "queue" {
+		const persistedValue = Object.hasOwn(this.#overrides, "busyPromptMode")
+			? undefined
+			: Object.hasOwn(this.#project, "busyPromptMode")
+				? this.#project.busyPromptMode
+				: this.#global.busyPromptMode;
+		if (
+			value !== "queue" &&
+			value !== "steer" &&
+			persistedValue !== undefined &&
+			this.#persist &&
+			!this.#busyPromptModeInvalidWarningEmitted
+		) {
+			this.#busyPromptModeInvalidWarningEmitted = true;
+			logger.warn("Settings: invalid busyPromptMode; using steer", { value: persistedValue });
+		}
+
+		return normalizeBusyPromptMode(value);
+	}
 	/**
 	 * Get a setting value from the user/global config only.
 	 *

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -21,6 +21,7 @@ type ConfigurableEditorAction = Extract<
 	| "app.message.dequeue"
 	| "app.message.followUp"
 	| "app.message.queue"
+	| "app.message.oppositeBusyMode"
 	| "app.clipboard.pasteImage"
 	| "app.clipboard.copyPrompt"
 >;
@@ -45,6 +46,7 @@ const CONFIGURABLE_EDITOR_ACTIONS = [
 	"app.history.search",
 	"app.message.followUp",
 	"app.message.queue",
+	"app.message.oppositeBusyMode",
 	"app.message.dequeue",
 	"app.clipboard.pasteImage",
 	"app.clipboard.copyPrompt",
@@ -101,6 +103,11 @@ export class CustomEditor extends Editor {
 	onDequeue?: () => void;
 	/** Called when the configured queue shortcut is pressed. */
 	onQueue?: () => void;
+	/**
+	 * Called when the configured opposite-busy-mode shortcut is pressed.
+	 * Return true to consume the key, or false to continue normal action dispatch.
+	 */
+	onOppositeBusyMode?: () => boolean;
 	/** Called when Caps Lock is pressed. */
 	onCapsLock?: () => void;
 	/** Called when PageUp/PageDown should scroll the transcript viewport instead of prompt history. */
@@ -267,6 +274,12 @@ export class CustomEditor extends Editor {
 
 		if (!matchesKey(data, "pageUp") && !matchesKey(data, "pageDown")) {
 			this.onViewportFollowLive?.();
+		}
+
+		// Opposite-busy mode has conditional priority over colliding application
+		// actions while streaming, but falls through to them while inactive.
+		if (this.#matchesAction(data, "app.message.oppositeBusyMode") && this.onOppositeBusyMode?.()) {
+			return;
 		}
 		// Intercept configured image paste (async - fires and handles result)
 		if (this.#matchesAction(data, "app.clipboard.pasteImage") && this.onPasteImage) {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -917,7 +917,19 @@ export class CommandController {
 	}
 
 	async #runNewSessionFlow(options?: NewSessionOptions, label: string = "New session started"): Promise<boolean> {
-		if (!(await this.ctx.session.newSession(options))) return false;
+		const stagedDraft = await this.#stageCompactionQueueDraft();
+		if (!stagedDraft) return false;
+		let switched: boolean;
+		try {
+			switched = await this.ctx.session.newSession(options);
+		} catch (error) {
+			await this.#restoreStagedDraft(stagedDraft);
+			throw error;
+		}
+		if (!switched) {
+			await this.#restoreStagedDraft(stagedDraft);
+			return false;
+		}
 
 		if (this.ctx.loadingAnimation) {
 			this.ctx.loadingAnimation.stop();
@@ -947,6 +959,41 @@ export class CommandController {
 		this.ctx.ui.requestRender();
 		return true;
 	}
+	#mergeCompactionQueueWithEditorDraft(): string {
+		const queuedText = this.ctx.compactionQueuedMessages
+			.map(message => message.text)
+			.filter(text => text.length > 0)
+			.join("\n\n");
+		const editorText = this.ctx.editor.getText();
+		return queuedText && editorText ? `${queuedText}\n\n${editorText}` : queuedText || editorText;
+	}
+
+	async #stageCompactionQueueDraft(): Promise<{ staged: boolean; previousDraft: string | null } | undefined> {
+		if (this.ctx.compactionQueuedMessages.length === 0) {
+			return { staged: false, previousDraft: null };
+		}
+		try {
+			const previousDraft = await this.ctx.sessionManager.readDraft();
+			await this.ctx.sessionManager.saveDraft(this.#mergeCompactionQueueWithEditorDraft());
+			return { staged: true, previousDraft };
+		} catch (error) {
+			this.ctx.showError(`Failed to save queued draft: ${error instanceof Error ? error.message : String(error)}`);
+			return undefined;
+		}
+	}
+
+	async #restoreStagedDraft(stage: { staged: boolean; previousDraft: string | null }): Promise<boolean> {
+		if (!stage.staged) return true;
+		try {
+			await this.ctx.sessionManager.saveDraft(stage.previousDraft ?? "");
+			return true;
+		} catch (error) {
+			this.ctx.showError(
+				`Failed to restore queued draft: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return false;
+		}
+	}
 
 	async handleClearCommand(): Promise<boolean> {
 		return this.#runNewSessionFlow();
@@ -965,7 +1012,16 @@ export class CommandController {
 				await Bun.sleep(10);
 			}
 		}
-		if (!(await this.ctx.session.clearContext())) return;
+		const stagedDraft = await this.#stageCompactionQueueDraft();
+		if (!stagedDraft) return;
+		let cleared: boolean;
+		try {
+			cleared = await this.ctx.session.clearContext();
+		} catch (error) {
+			await this.#restoreStagedDraft(stagedDraft);
+			throw error;
+		}
+		if (!(await this.#restoreStagedDraft(stagedDraft)) || !cleared) return;
 		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
 
 		this.ctx.statusLine.invalidate();
@@ -977,7 +1033,8 @@ export class CommandController {
 		prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
-		this.ctx.compactionQueuedMessages = [];
+		// Keep compaction-local messages available to be replayed after the
+		// same-session context reset.
 		this.ctx.streamingComponent = undefined;
 		this.ctx.streamingMessage = undefined;
 		this.ctx.pendingTools.clear();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -7,7 +7,11 @@ import { type AppKeybinding, KEYBINDINGS } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { normalizeBusyPromptMode } from "../../config/settings-schema";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
-import { buildSkillPromptMessage, parseSkillInvocations } from "../../extensibility/skills";
+import {
+	type BuiltSkillPromptMessage,
+	buildSkillPromptMessage,
+	parseSkillInvocations,
+} from "../../extensibility/skills";
 import { expandEmoticons } from "../../modes/emoji-autocomplete";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
 import { theme } from "../../modes/theme/theme";
@@ -17,7 +21,7 @@ import {
 	canApplyComposerSubmission,
 	type InteractiveModeContext,
 } from "../../modes/types";
-import type { AgentSessionEvent, QueuedMessageEditEntry } from "../../session/agent-session";
+import type { AgentSessionEvent, QueuedMessageEditEntry, QueuedMessagePayload } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { copyToClipboard, readImageFromClipboard } from "../../utils/clipboard";
@@ -49,6 +53,14 @@ export class InputController {
 
 	#lastBackgroundFoldKeyTime = 0;
 	#slashCommands: SlashCommand[] = [];
+	#claimedSubmission:
+		| {
+				text: string;
+				images: InteractiveModeContext["pendingImages"];
+				streamingBehavior: "steer" | "followUp";
+		  }
+		| undefined;
+	#submittedImageOwners = new Set<InteractiveModeContext["pendingImages"]>();
 
 	/** Set after a first Esc silently consumes a queued steer. Kept until the
 	 *  queued steer is either cancelled by a second Esc or drained by continuation,
@@ -552,8 +564,39 @@ export class InputController {
 	}
 
 	async submitText(text: string, composer: ComposerSubmissionOptions): Promise<void> {
+		const claimedSubmission = this.#claimedSubmission;
+		const pendingImages = claimedSubmission?.images ?? this.ctx.pendingImages;
+		this.#submittedImageOwners.add(pendingImages);
+		return this.#submitEditorInput(text, pendingImages, composer)
+			.catch(error => {
+				this.#restoreClaimedSubmission(
+					claimedSubmission ?? {
+						text,
+						images: pendingImages,
+						streamingBehavior: this.#busyStreamingBehavior(),
+					},
+					composer,
+				);
+				this.ctx.showError(`Failed to submit input: ${error instanceof Error ? error.message : String(error)}`);
+			})
+			.finally(() => {
+				this.#submittedImageOwners.delete(pendingImages);
+			});
+	}
+
+	async #submitEditorInput(
+		text: string,
+		submittedImages: InteractiveModeContext["pendingImages"],
+		composer: ComposerSubmissionOptions,
+	): Promise<void> {
+		const claimedSubmission = this.#claimedSubmission;
+		this.#claimedSubmission = undefined;
+		const wasClaimed = claimedSubmission !== undefined;
+		const streamingBehavior = claimedSubmission?.streamingBehavior ?? this.#busyStreamingBehavior();
+		const submittedText = text;
 		text = text.trim();
 		if ((!isSettingsInitialized() || settings.get("emojiAutocomplete")) && text) text = expandEmoticons(text);
+		const pendingImages = claimedSubmission?.images ?? submittedImages;
 
 		// Empty submit while streaming with queued messages: flush queues immediately
 		if (!text && this.ctx.session.isStreaming && this.ctx.session.queuedMessageCount > 0) {
@@ -567,21 +610,19 @@ export class InputController {
 		// Continue shortcuts: "." or "c" sends empty message (agent continues, no visible message)
 		if (text === "." || text === "c") {
 			if (this.ctx.onInputCallback) {
-				this.ctx.editor.setText("");
-				this.ctx.pendingImages = [];
+				this.#clearPendingImagesIfOwnedBy(pendingImages, composer);
 				this.ctx.onInputCallback({ text: "", cancelled: false, started: true });
 			}
 			return;
 		}
 
 		const runner = this.ctx.session.extensionRunner;
-		const pendingImages = this.ctx.pendingImages;
-		let inputImages = this.#visiblePendingImagesForText(text);
+		let inputImages = this.#visiblePendingImagesForText(text, pendingImages);
 
 		if (runner?.hasHandlers("input")) {
 			const result = await runner.emitInput(text, inputImages, "interactive");
 			if (result?.handled) {
-				if (this.#canModifyComposer(composer)) {
+				if (this.#canModifyComposer(composer) && this.ctx.editor.getText() === submittedText) {
 					this.ctx.editor.setText("");
 				}
 				this.#clearPendingImagesIfOwnedBy(pendingImages, composer);
@@ -611,15 +652,6 @@ export class InputController {
 			text = slashResult;
 		}
 
-		// Handle skill commands (/skill:name [args]). While streaming, Enter
-		// honors `busyPromptMode`: "steer" interrupts the active turn, "queue"
-		// runs after it completes (matches the free-text Enter semantics applied
-		// a few lines below at the streaming branch). Explicit queue shortcuts
-		// route through `handleFollowUp` and dispatch as `followUp`.
-		if (await this.#invokeSkillCommand(text, this.#busyStreamingBehavior(), composer)) {
-			return;
-		}
-
 		// Handle bash command (! for normal, !! for excluded from context)
 		if (text.startsWith("!")) {
 			const isExcluded = text.startsWith("!!");
@@ -627,9 +659,10 @@ export class InputController {
 			if (command) {
 				if (this.ctx.session.isBashRunning) {
 					this.ctx.showWarning("A bash command is already running. Press Esc to cancel it first.");
-					if (this.#canModifyComposer(composer)) {
-						this.ctx.editor.setText(text);
-					}
+					this.#restoreClaimedSubmission(
+						{ text: submittedText, images: pendingImages, streamingBehavior },
+						composer,
+					);
 					return;
 				}
 				if (this.#canModifyComposer(composer)) {
@@ -650,9 +683,10 @@ export class InputController {
 			if (code) {
 				if (this.ctx.session.isEvalRunning) {
 					this.ctx.showWarning("A Python execution is already running. Press Esc to cancel it first.");
-					if (this.#canModifyComposer(composer)) {
-						this.ctx.editor.setText(text);
-					}
+					this.#restoreClaimedSubmission(
+						{ text: submittedText, images: pendingImages, streamingBehavior },
+						composer,
+					);
 					return;
 				}
 				if (this.#canModifyComposer(composer)) {
@@ -664,14 +698,49 @@ export class InputController {
 				return;
 			}
 		}
+		// Keep skill invocations queued during compaction so they retain their
+		// custom-message dispatch path when the compaction queue flushes.
+		if (
+			this.ctx.session.isCompacting &&
+			parseSkillInvocations(text, this.ctx.skillCommands ?? new Map()).length > 0
+		) {
+			if ((inputImages?.length ?? 0) > 0) {
+				this.ctx.showStatus("Compaction in progress. Retry after it completes to send images.");
+				this.#restoreClaimedSubmission({ text: submittedText, images: pendingImages, streamingBehavior }, composer);
+				return;
+			}
+			const successorText =
+				this.#canModifyComposer(composer) && this.ctx.editor.getText() !== submittedText
+					? this.ctx.editor.getText()
+					: undefined;
+			this.ctx.queueCompactionMessage(text, streamingBehavior, composer);
+			if (successorText) this.ctx.editor.setText(successorText);
+			return;
+		}
+
+		// Handle skill commands (/skill:name [args]). While streaming, Enter
+		// honors `busyPromptMode`: "steer" interrupts the active turn, "queue"
+		// runs after it completes. Explicit queue shortcuts route through
+		// `handleFollowUp` and dispatch as `followUp`.
+		if (
+			await this.#invokeSkillCommand(text, streamingBehavior, composer, this.ctx.editor.getText() !== submittedText)
+		) {
+			return;
+		}
 
 		// Queue input during compaction
 		if (this.ctx.session.isCompacting) {
 			if ((inputImages?.length ?? 0) > 0) {
 				this.ctx.showStatus("Compaction in progress. Retry after it completes to send images.");
+				this.#restoreClaimedSubmission({ text: submittedText, images: pendingImages, streamingBehavior }, composer);
 				return;
 			}
-			this.ctx.queueCompactionMessage(text, "steer", composer);
+			const successorText =
+				this.#canModifyComposer(composer) && this.ctx.editor.getText() !== submittedText
+					? this.ctx.editor.getText()
+					: undefined;
+			this.ctx.queueCompactionMessage(text, streamingBehavior, composer);
+			if (successorText) this.ctx.editor.setText(successorText);
 			return;
 		}
 
@@ -682,7 +751,7 @@ export class InputController {
 		if (this.ctx.session.isStreaming) {
 			if (this.#canModifyComposer(composer)) {
 				this.ctx.editor.addToHistory(text);
-				this.ctx.editor.setText("");
+				if (this.ctx.editor.getText() === submittedText) this.ctx.editor.setText("");
 			}
 			const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
 			this.#clearPendingImagesIfOwnedBy(pendingImages, composer);
@@ -690,7 +759,7 @@ export class InputController {
 			// (a user-role `message_start` event) leaves any draft the user has
 			// typed since queuing intact. Same protection as #783, applied to
 			// the streaming/queue path.
-			const streamingBehavior = this.#busyStreamingBehavior();
+
 			const promptOptions =
 				streamingBehavior === "followUp"
 					? { streamingBehavior, images, followUpQueuePolicy: "sequential" as const }
@@ -740,7 +809,14 @@ export class InputController {
 			this.#clearPendingImagesIfOwnedBy(pendingImages, composer);
 
 			// Render user message immediately, then let session events catch up
+			const preserveSuccessor = this.#canModifyComposer(composer) && this.ctx.editor.getText() !== submittedText;
+			const successorText = preserveSuccessor ? this.ctx.editor.getText() : undefined;
+			const successorImages = preserveSuccessor ? this.ctx.pendingImages : undefined;
 			const submission = this.ctx.startPendingSubmission({ text, images }, composer);
+			if (successorText || successorImages?.length) {
+				this.ctx.editor.setText(successorText ?? "");
+				this.ctx.pendingImages = successorImages ?? [];
+			}
 
 			this.ctx.onInputCallback(submission);
 		}
@@ -892,15 +968,15 @@ export class InputController {
 		this.ctx.ui.requestRender();
 	}
 
-	#removeQueuedMessageForEditing(id: string): string | undefined {
+	#removeQueuedMessageForEditing(id: string): QueuedMessagePayload | undefined {
 		const compactionPrefix = "compaction:";
 		if (id.startsWith(compactionPrefix)) {
 			const index = Number(id.slice(compactionPrefix.length));
 			if (!Number.isInteger(index)) return undefined;
 			const [entry] = this.ctx.compactionQueuedMessages.splice(index, 1);
-			return entry?.text;
+			return entry ? { text: entry.text, images: [] } : undefined;
 		}
-		return this.ctx.session.removeQueuedMessageForEditing(id);
+		return this.ctx.session.removeQueuedMessagePayloadForEditing(id);
 	}
 	#parseCompactionQueuedMessageId(id: string): number | undefined {
 		const compactionPrefix = "compaction:";
@@ -935,11 +1011,33 @@ export class InputController {
 	}
 
 	#deleteQueuedMessage(entry: QueuedMessageEditEntry): boolean {
-		const queuedText = this.#removeQueuedMessageForEditing(entry.id);
+		const queued = this.#removeQueuedMessageForEditing(entry.id);
 		this.ctx.updatePendingMessagesDisplay();
-		if (!queuedText) return false;
-		this.ctx.locallySubmittedUserSignatures.delete(`${queuedText}\u00000`);
+		if (!queued) return false;
+		this.ctx.locallySubmittedUserSignatures.delete(`${queued.text}\u0000${queued.images.length}`);
 		return true;
+	}
+
+	#shiftImagePlaceholders(text: string, offset: number): string {
+		if (offset === 0) return text;
+		return text.replace(IMAGE_PLACEHOLDER_PATTERN, (placeholder, imageNumberText: string) => {
+			const imageNumber = Number.parseInt(imageNumberText, 10);
+			return Number.isInteger(imageNumber) ? `[image ${imageNumber + offset}]` : placeholder;
+		});
+	}
+
+	#restoreQueuedPayloadsToEditor(payloads: QueuedMessagePayload[], currentText: string): void {
+		const images: InteractiveModeContext["pendingImages"] = [];
+		const textParts: string[] = [];
+		for (const payload of payloads) {
+			textParts.push(this.#shiftImagePlaceholders(payload.text, images.length));
+			images.push(...payload.images);
+			this.ctx.locallySubmittedUserSignatures.delete(`${payload.text}\u0000${payload.images.length}`);
+		}
+		const shiftedCurrentText = this.#shiftImagePlaceholders(currentText, images.length);
+		if (shiftedCurrentText.trim()) textParts.push(shiftedCurrentText);
+		this.ctx.editor.setText(textParts.filter(text => text.trim()).join("\n\n"));
+		this.ctx.pendingImages = [...images, ...(this.ctx.pendingImages ?? [])];
 	}
 
 	#restoreQueuedMessageToEditor(entry: QueuedMessageEditEntry | undefined): number {
@@ -947,14 +1045,13 @@ export class InputController {
 			this.ctx.updatePendingMessagesDisplay();
 			return 0;
 		}
-		const queuedText = this.#removeQueuedMessageForEditing(entry.id);
-		if (!queuedText) {
+		const queued = this.#removeQueuedMessageForEditing(entry.id);
+		if (!queued) {
 			this.ctx.updatePendingMessagesDisplay();
 			return 0;
 		}
 
-		this.ctx.locallySubmittedUserSignatures.delete(`${queuedText}\u00000`);
-		this.ctx.editor.setText(queuedText);
+		this.#restoreQueuedPayloadsToEditor([queued], this.ctx.editor.getText());
 		this.ctx.updatePendingMessagesDisplay();
 		return 1;
 	}
@@ -996,17 +1093,18 @@ export class InputController {
 		text: string,
 		streamingBehavior: "steer" | "followUp",
 		options?: ComposerSubmissionOptions,
+		preserveComposer = false,
 	): Promise<boolean> {
 		const invocations = parseSkillInvocations(text, this.ctx.skillCommands ?? new Map());
 		if (invocations.length === 0) return false;
 		if (!options || this.#canModifyComposer(options)) {
 			this.ctx.editor.addToHistory(text);
-			this.ctx.editor.setText("");
+			if (!preserveComposer) this.ctx.editor.setText("");
 		}
+
+		const prepared: Array<BuiltSkillPromptMessage & { displayText: string; retryText: string; tag?: string }> = [];
 		try {
-			for (let index = 0; index < invocations.length; index += 1) {
-				const invocation = invocations[index];
-				if (!invocation) continue;
+			for (const invocation of invocations) {
 				const activationResult = await resolveSubskillActivationForSkillInvocation({
 					cwd: this.ctx.sessionManager.getCwd(),
 					sessionId: this.ctx.session.sessionId,
@@ -1019,32 +1117,44 @@ export class InputController {
 					cwd: this.ctx.sessionManager.getCwd(),
 					sessionId: this.ctx.session.sessionId,
 				});
-				const details: SkillPromptDetails = built.details;
-				const displayText = `/${invocation.commandName}${activationResult.cleanedArgs ? ` ${activationResult.cleanedArgs}` : ""}`;
-				// When the agent is streaming, register a compact slash-form text as
-				// the pending-display twin BEFORE dispatching the CustomMessage. The
-				// returned tag is embedded in details so AgentSession.#handleAgentEvent
-				// can remove the matching display entry when the agent consumes this
-				// message (mirrors the user-message dequeue path).
+				prepared.push({
+					...built,
+					displayText: `/${invocation.commandName}${activationResult.cleanedArgs ? ` ${activationResult.cleanedArgs}` : ""}`,
+					retryText: `/${invocation.commandName}${invocation.args ? ` ${invocation.args}` : ""}`,
+				});
+			}
+		} catch (err) {
+			this.ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);
+			throw err;
+		}
+
+		let dispatchedCount = 0;
+		try {
+			for (let index = 0; index < prepared.length; index += 1) {
+				const item = prepared[index];
+				if (!item) continue;
+				const details: SkillPromptDetails = item.details;
 				if (this.ctx.session.isStreaming) {
-					const tag = this.ctx.session.enqueueCustomMessageDisplay(displayText, streamingBehavior);
+					const tag = this.ctx.session.enqueueCustomMessageDisplay(item.displayText, streamingBehavior);
 					details.__pendingDisplayTag = tag;
+					item.tag = tag;
 				}
-				const isLast = index === invocations.length - 1;
+				const isLast = index === prepared.length - 1;
 				if (!this.ctx.session.isStreaming && !isLast) {
 					await this.ctx.session.sendCustomMessage({
 						customType: SKILL_PROMPT_MESSAGE_TYPE,
-						content: built.message,
+						content: item.message,
 						display: true,
 						details,
 						attribution: "user",
 					});
+					dispatchedCount = index + 1;
 					continue;
 				}
 				await this.ctx.session.promptCustomMessage(
 					{
 						customType: SKILL_PROMPT_MESSAGE_TYPE,
-						content: built.message,
+						content: item.message,
 						display: true,
 						details,
 						attribution: "user",
@@ -1053,116 +1163,117 @@ export class InputController {
 						? { streamingBehavior, followUpQueuePolicy: "sequential" }
 						: { streamingBehavior },
 				);
-			}
-			if (this.ctx.session.isStreaming) {
-				this.ctx.updatePendingMessagesDisplay();
-				this.ctx.ui.requestRender();
+				dispatchedCount = index + 1;
 			}
 		} catch (err) {
-			this.ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);
+			const undispatched = prepared.slice(dispatchedCount);
+			for (const item of undispatched) {
+				if (item.tag) this.ctx.session.removeQueuedCustomMessageByDisplayTag(item.tag);
+			}
+			const remainingText = undispatched.map(item => item.retryText).join("\n");
+			if (remainingText && (!options || this.#canModifyComposer(options))) {
+				const currentText = this.ctx.editor.getText();
+				this.ctx.editor.setText(currentText ? `${currentText}\n${remainingText}` : remainingText);
+			}
+			this.ctx.updatePendingMessagesDisplay();
+			this.ctx.ui.requestRender();
+			this.ctx.showError(`Failed to dispatch skill: ${err instanceof Error ? err.message : String(err)}`);
+			return true;
+		}
+
+		if (this.ctx.session.isStreaming) {
+			this.ctx.updatePendingMessagesDisplay();
+			this.ctx.ui.requestRender();
 		}
 		return true;
 	}
 
 	/** Send editor text as a follow-up message (queued behind current stream). */
 	async handleFollowUp(): Promise<void> {
-		const text = this.ctx.editor.getText().trim();
-		if (!text) return;
-
-		// Compaction first: while compacting, queue free text and `/skill:*`
-		// commands in the compaction-local queue. `flushCompactionQueue`
-		// replays skill entries through the custom-message skill path after
-		// compaction finishes so they are not degraded into plain prompts.
-		if (this.ctx.session.isCompacting) {
-			if (this.ctx.pendingImages.length > 0) {
-				this.ctx.showStatus("Compaction in progress. Retry after it completes to send images.");
-				return;
-			}
-			this.ctx.queueCompactionMessage(text, "followUp");
-			return;
-		}
-
-		// Skill commands invoke through the custom-message path regardless of
-		// which keybinding submitted them. Enter routes them as `steer`;
-		// explicit queue shortcuts route them as `followUp`.
-		if (await this.#invokeSkillCommand(text, "followUp")) {
-			return;
-		}
-
-		if (this.ctx.session.isStreaming) {
-			this.ctx.editor.addToHistory(text);
-			this.ctx.editor.setText("");
-			await this.ctx.withLocalSubmission(text, () =>
-				this.ctx.session.prompt(text, {
-					streamingBehavior: "followUp",
-					followUpQueuePolicy: "sequential",
-				}),
-			);
-			this.ctx.updatePendingMessagesDisplay();
-			this.ctx.ui.requestRender();
-			return;
-		}
-
-		// Not streaming — just submit normally
-		this.ctx.editor.addToHistory(text);
-		this.ctx.editor.setText("");
-		await this.ctx.withLocalSubmission(text, () => this.ctx.session.prompt(text));
+		await this.#claimAndSubmit("followUp");
 	}
 
 	/** Send editor text explicitly as a queued next-turn message. */
 	async handleQueueSubmit(): Promise<void> {
-		return this.handleFollowUp();
+		await this.#claimAndSubmit("followUp");
 	}
 
 	/** Submit once using the opposite of the configured busy prompt mode. */
 	async handleOppositeBusyPromptSubmit(): Promise<void> {
-		const text = this.ctx.editor.getText().trim();
-		if (!text || !this.ctx.session.isStreaming || this.ctx.session.isCompacting) return;
+		if (!this.ctx.session.isStreaming || this.ctx.session.isCompacting) return;
+		const streamingBehavior = this.#busyStreamingBehavior() === "steer" ? "followUp" : "steer";
+		await this.#claimAndSubmit(streamingBehavior);
+	}
 
-		// Claim the draft before the first await so rapid repeated shortcuts cannot
-		// snapshot and submit the same text twice.
-		const pendingImages = this.ctx.pendingImages;
-		const images = this.#visiblePendingImagesForText(text) ?? [];
+	#restoreClaimedSubmission(
+		claimed: {
+			text: string;
+			images: InteractiveModeContext["pendingImages"];
+			streamingBehavior: "steer" | "followUp";
+		},
+		composer: ComposerSubmissionOptions,
+	): void {
+		if (!this.#canModifyComposer(composer)) return;
+		const currentText = this.ctx.editor.getText();
+		const currentImages = this.ctx.pendingImages;
+		const mergedImages = [...currentImages];
+		const claimedImageNumbers = claimed.images.map(image => {
+			const existingIndex = currentImages.indexOf(image);
+			if (existingIndex !== -1) return existingIndex + 1;
+			mergedImages.push(image);
+			return mergedImages.length;
+		});
+		const restoredClaimedText = claimed.text.replace(
+			IMAGE_PLACEHOLDER_PATTERN,
+			(placeholder, imageNumberText: string) => {
+				const claimedIndex = Number.parseInt(imageNumberText, 10) - 1;
+				const mergedImageNumber = claimedImageNumbers[claimedIndex];
+				return mergedImageNumber === undefined ? placeholder : `[image ${mergedImageNumber}]`;
+			},
+		);
+		this.ctx.editor.setText(currentText ? `${currentText}\n${restoredClaimedText}` : restoredClaimedText);
+		this.ctx.pendingImages = mergedImages;
+	}
+
+	async #claimAndSubmit(streamingBehavior: "steer" | "followUp"): Promise<void> {
+		const text = this.ctx.editor.getText().trim();
+		if (!text) return;
+		if (this.ctx.session.isCompacting && (this.#visiblePendingImagesForText(text)?.length ?? 0) > 0) {
+			this.ctx.showStatus("Compaction in progress. Retry after it completes to send images.");
+			return;
+		}
+
+		// Claim synchronously in the key callback's call stack. Subsequent rapid
+		// key events observe an empty draft instead of submitting this one again.
+		const images = this.ctx.pendingImages;
+		this.#claimedSubmission = { text, images, streamingBehavior };
 		this.ctx.editor.setText("");
 
-		const streamingBehavior =
-			normalizeBusyPromptMode(this.ctx.settings.get("busyPromptMode")) === "steer" ? "followUp" : "steer";
-		if (await this.#invokeSkillCommand(text, streamingBehavior)) return;
-
-		this.ctx.editor.addToHistory(text);
-		this.#clearPendingImagesIfOwnedBy(pendingImages);
-		await this.ctx.withLocalSubmission(
-			text,
-			() =>
-				this.ctx.session.prompt(text, {
-					streamingBehavior,
-					images: images.length > 0 ? images : undefined,
-					...(streamingBehavior === "followUp" ? { followUpQueuePolicy: "sequential" as const } : {}),
-				}),
-			{ imageCount: images.length },
-		);
-		this.ctx.updatePendingMessagesDisplay();
-		this.ctx.ui.requestRender();
+		if (!this.ctx.editor.onSubmit) this.setupEditorSubmitHandler();
+		await this.ctx.editor.onSubmit?.(text);
 	}
 
 	restoreLatestQueuedMessageToEditor(): number {
 		const compactionQueued = this.ctx.compactionQueuedMessages.pop();
-		const queuedText = compactionQueued?.text ?? this.ctx.session.popLastQueuedMessage();
-		if (!queuedText) {
+		const queued =
+			compactionQueued !== undefined
+				? { text: compactionQueued.text, images: [] }
+				: this.ctx.session.popLastQueuedMessagePayload();
+		if (!queued) {
 			this.ctx.updatePendingMessagesDisplay();
 			return 0;
 		}
 
-		this.ctx.locallySubmittedUserSignatures.delete(`${queuedText}\u00000`);
-		this.ctx.editor.setText(queuedText);
+		this.#restoreQueuedPayloadsToEditor([queued], this.ctx.editor.getText());
 		this.ctx.updatePendingMessagesDisplay();
 		return 1;
 	}
 
 	restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): number {
-		this.ctx.locallySubmittedUserSignatures.clear();
-		const { steering, followUp } = this.ctx.session.clearQueue();
-		const compactionQueued = (this.ctx.compactionQueuedMessages ?? []).map(entry => entry.text);
+		const { steering, followUp } = this.ctx.session.clearQueuedMessagePayloads();
+		const compactionQueued = (this.ctx.compactionQueuedMessages ?? []).map(
+			(entry): QueuedMessagePayload => ({ text: entry.text, images: [] }),
+		);
 		this.ctx.compactionQueuedMessages = [];
 		const allQueued = [...steering, ...followUp, ...compactionQueued];
 		if (allQueued.length === 0) {
@@ -1172,10 +1283,7 @@ export class InputController {
 			}
 			return 0;
 		}
-		const queuedText = allQueued.join("\n\n");
-		const currentText = options?.currentText ?? this.ctx.editor.getText();
-		const combinedText = [queuedText, currentText].filter(t => t.trim()).join("\n\n");
-		this.ctx.editor.setText(combinedText);
+		this.#restoreQueuedPayloadsToEditor(allQueued, options?.currentText ?? this.ctx.editor.getText());
 		this.ctx.updatePendingMessagesDisplay();
 		if (options?.abort) {
 			void this.#abortInteractive();
@@ -1323,8 +1431,11 @@ export class InputController {
 		return `[image ${this.ctx.pendingImages.length}]`;
 	}
 
-	#visiblePendingImagesForText(text: string): InteractiveModeContext["pendingImages"] | undefined {
-		if (this.ctx.pendingImages.length === 0) {
+	#visiblePendingImagesForText(
+		text: string,
+		pendingImages = this.ctx.pendingImages,
+	): InteractiveModeContext["pendingImages"] | undefined {
+		if (pendingImages.length === 0) {
 			return undefined;
 		}
 
@@ -1335,10 +1446,10 @@ export class InputController {
 			if (!placeholderNumberText) continue;
 			const placeholderNumber = Number.parseInt(placeholderNumberText, 10);
 			const imageIndex = placeholderNumber - 1;
-			if (imageIndex < 0 || imageIndex >= this.ctx.pendingImages.length || seenImageIndexes.has(imageIndex)) {
+			if (imageIndex < 0 || imageIndex >= pendingImages.length || seenImageIndexes.has(imageIndex)) {
 				continue;
 			}
-			const image = this.ctx.pendingImages[imageIndex];
+			const image = pendingImages[imageIndex];
 			if (!image) continue;
 			images.push(image);
 			seenImageIndexes.add(imageIndex);
@@ -1374,6 +1485,7 @@ export class InputController {
 				if (
 					this.ctx.pendingImages === pendingImages &&
 					pendingImages.length === pendingImageCount &&
+					!this.#submittedImageOwners.has(pendingImages) &&
 					this.ctx.editor.getText().length === 0
 				) {
 					this.ctx.pendingImages = [];

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -429,6 +429,16 @@ export class InputController {
 		this.ctx.editor.setActionKeys("app.message.queue", this.ctx.keybindings.getKeys("app.message.queue"));
 		this.ctx.editor.onQueue = queue;
 		this.#registerCommandPaletteAction("app.message.queue", queue);
+		this.ctx.editor.setActionKeys(
+			"app.message.oppositeBusyMode",
+			this.ctx.keybindings.getKeys("app.message.oppositeBusyMode"),
+		);
+		this.ctx.editor.onOppositeBusyMode = () => {
+			if (!this.ctx.session.isStreaming || this.ctx.session.isCompacting) return false;
+			if (!this.ctx.editor.getText().trim()) return false;
+			void this.handleOppositeBusyPromptSubmit();
+			return true;
+		};
 
 		this.ctx.editor.onViewportPageScroll = direction => this.ctx.ui.scrollViewportPages(direction);
 		this.ctx.editor.onViewportFollowLive = () => {
@@ -492,14 +502,6 @@ export class InputController {
 			this.ctx.editor.setCustomKeyHandler(key, () => {
 				if (!this.#isFollowUpShortcutActive()) return false;
 				void this.handleFollowUp();
-				return true;
-			});
-		}
-		for (const key of this.ctx.keybindings.getKeys("app.message.oppositeBusyMode")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => {
-				if (!this.ctx.session.isStreaming || this.ctx.session.isCompacting) return false;
-				if (!this.ctx.editor.getText().trim()) return false;
-				void this.handleOppositeBusyPromptSubmit();
 				return true;
 			});
 		}
@@ -1117,14 +1119,17 @@ export class InputController {
 		const text = this.ctx.editor.getText().trim();
 		if (!text || !this.ctx.session.isStreaming || this.ctx.session.isCompacting) return;
 
+		// Claim the draft before the first await so rapid repeated shortcuts cannot
+		// snapshot and submit the same text twice.
+		const pendingImages = this.ctx.pendingImages;
+		const images = this.#visiblePendingImagesForText(text) ?? [];
+		this.ctx.editor.setText("");
+
 		const streamingBehavior =
 			normalizeBusyPromptMode(this.ctx.settings.get("busyPromptMode")) === "steer" ? "followUp" : "steer";
 		if (await this.#invokeSkillCommand(text, streamingBehavior)) return;
 
-		const pendingImages = this.ctx.pendingImages;
-		const images = this.#visiblePendingImagesForText(text) ?? [];
 		this.ctx.editor.addToHistory(text);
-		this.ctx.editor.setText("");
 		this.#clearPendingImagesIfOwnedBy(pendingImages);
 		await this.ctx.withLocalSubmission(
 			text,

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -5,6 +5,7 @@ import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@gajae
 import { $env, sanitizeText } from "@gajae-code/utils";
 import { type AppKeybinding, KEYBINDINGS } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
+import { normalizeBusyPromptMode } from "../../config/settings-schema";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
 import { buildSkillPromptMessage, parseSkillInvocations } from "../../extensibility/skills";
 import { expandEmoticons } from "../../modes/emoji-autocomplete";
@@ -494,6 +495,14 @@ export class InputController {
 				return true;
 			});
 		}
+		for (const key of this.ctx.keybindings.getKeys("app.message.oppositeBusyMode")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				if (!this.ctx.session.isStreaming || this.ctx.session.isCompacting) return false;
+				if (!this.ctx.editor.getText().trim()) return false;
+				void this.handleOppositeBusyPromptSubmit();
+				return true;
+			});
+		}
 		for (const key of this.ctx.keybindings.getKeys("app.stt.toggle")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleSTTToggle());
 		}
@@ -956,7 +965,7 @@ export class InputController {
 	 * completes (in submission order). Only consulted while streaming.
 	 */
 	#busyStreamingBehavior(): "steer" | "followUp" {
-		return this.ctx.settings.get("busyPromptMode") === "steer" ? "steer" : "followUp";
+		return normalizeBusyPromptMode(this.ctx.settings.get("busyPromptMode")) === "steer" ? "steer" : "followUp";
 	}
 
 	#isFollowUpShortcutActive(): boolean {
@@ -1101,6 +1110,34 @@ export class InputController {
 	/** Send editor text explicitly as a queued next-turn message. */
 	async handleQueueSubmit(): Promise<void> {
 		return this.handleFollowUp();
+	}
+
+	/** Submit once using the opposite of the configured busy prompt mode. */
+	async handleOppositeBusyPromptSubmit(): Promise<void> {
+		const text = this.ctx.editor.getText().trim();
+		if (!text || !this.ctx.session.isStreaming || this.ctx.session.isCompacting) return;
+
+		const streamingBehavior =
+			normalizeBusyPromptMode(this.ctx.settings.get("busyPromptMode")) === "steer" ? "followUp" : "steer";
+		if (await this.#invokeSkillCommand(text, streamingBehavior)) return;
+
+		const pendingImages = this.ctx.pendingImages;
+		const images = this.#visiblePendingImagesForText(text) ?? [];
+		this.ctx.editor.addToHistory(text);
+		this.ctx.editor.setText("");
+		this.#clearPendingImagesIfOwnedBy(pendingImages);
+		await this.ctx.withLocalSubmission(
+			text,
+			() =>
+				this.ctx.session.prompt(text, {
+					streamingBehavior,
+					images: images.length > 0 ? images : undefined,
+					...(streamingBehavior === "followUp" ? { followUpQueuePolicy: "sequential" as const } : {}),
+				}),
+			{ imageCount: images.length },
+		);
+		this.ctx.updatePendingMessagesDisplay();
+		this.ctx.ui.requestRender();
 	}
 
 	restoreLatestQueuedMessageToEditor(): number {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -2002,14 +2002,14 @@ export class SelectorController {
 		});
 	}
 
-	#clearTransientSessionUi(): void {
+	#clearTransientSessionUi(options?: { preserveCompactionQueue?: boolean }): void {
 		if (this.ctx.loadingAnimation) {
 			this.ctx.loadingAnimation.stop();
 			this.ctx.loadingAnimation = undefined;
 		}
 		this.ctx.statusContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
-		this.ctx.compactionQueuedMessages = [];
+		if (!options?.preserveCompactionQueue) this.ctx.compactionQueuedMessages = [];
 		this.ctx.streamingComponent = undefined;
 		this.ctx.streamingMessage = undefined;
 		this.ctx.pendingTools.clear();
@@ -2022,6 +2022,41 @@ export class SelectorController {
 			titleSource?: "auto" | "user" | undefined;
 		};
 		setSessionTerminalTitle(sessionManager.getSessionName?.(), sessionManager.getCwd());
+	}
+	#mergeCompactionQueueWithEditorDraft(): string {
+		const queuedText = this.ctx.compactionQueuedMessages
+			.map(message => message.text)
+			.filter(text => text.length > 0)
+			.join("\n\n");
+		const editorText = this.ctx.editor.getText();
+		return queuedText && editorText ? `${queuedText}\n\n${editorText}` : queuedText || editorText;
+	}
+
+	async #stageCompactionQueueDraft(): Promise<{ staged: boolean; previousDraft: string | null } | undefined> {
+		if (this.ctx.compactionQueuedMessages.length === 0) {
+			return { staged: false, previousDraft: null };
+		}
+		try {
+			const previousDraft = await this.ctx.sessionManager.readDraft();
+			await this.ctx.sessionManager.saveDraft(this.#mergeCompactionQueueWithEditorDraft());
+			return { staged: true, previousDraft };
+		} catch (error) {
+			this.ctx.showError(`Failed to save queued draft: ${error instanceof Error ? error.message : String(error)}`);
+			return undefined;
+		}
+	}
+
+	async #restoreStagedDraft(stage: { staged: boolean; previousDraft: string | null }): Promise<boolean> {
+		if (!stage.staged) return true;
+		try {
+			await this.ctx.sessionManager.saveDraft(stage.previousDraft ?? "");
+			return true;
+		} catch (error) {
+			this.ctx.showError(
+				`Failed to restore queued draft: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return false;
+		}
 	}
 
 	async #deleteSession(sessionPath: string): Promise<void> {
@@ -2039,8 +2074,17 @@ export class SelectorController {
 			return true;
 		}
 
-		const detached = await this.ctx.session.newSession();
+		const stagedDraft = await this.#stageCompactionQueueDraft();
+		if (!stagedDraft) return false;
+		let detached: boolean;
+		try {
+			detached = await this.ctx.session.newSession();
+		} catch (error) {
+			await this.#restoreStagedDraft(stagedDraft);
+			throw error;
+		}
 		if (!detached) {
+			await this.#restoreStagedDraft(stagedDraft);
 			return false;
 		}
 		this.ctx.resetIrcSidebarSession();
@@ -2060,14 +2104,25 @@ export class SelectorController {
 
 	async handleResumeSession(sessionPath: string): Promise<void> {
 		const previousSessionId = this.ctx.sessionManager.getSessionId();
-		this.#clearTransientSessionUi();
+		const stagedDraft = await this.#stageCompactionQueueDraft();
+		if (!stagedDraft) return;
 		const migrationPolicy =
 			this.ctx.settings?.get("session.directoryMigration") === "disabled" ? "disabled" : "copy-retain";
-		const writableSessionPath = await SessionManager.prepareManagedCandidateForWrite(sessionPath, migrationPolicy);
-
-		// Switch session via AgentSession (emits hook and tool session events)
-		if (!(await this.ctx.session.switchSession(writableSessionPath))) return;
+		let switched: boolean;
+		try {
+			const writableSessionPath = await SessionManager.prepareManagedCandidateForWrite(sessionPath, migrationPolicy);
+			switched = await this.ctx.session.switchSession(writableSessionPath);
+		} catch (error) {
+			await this.#restoreStagedDraft(stagedDraft);
+			throw error;
+		}
+		if (!switched) {
+			await this.#restoreStagedDraft(stagedDraft);
+			return;
+		}
 		const switchingToDifferentSession = previousSessionId !== this.ctx.sessionManager.getSessionId();
+		if (!switchingToDifferentSession && !(await this.#restoreStagedDraft(stagedDraft))) return;
+		this.#clearTransientSessionUi({ preserveCompactionQueue: !switchingToDifferentSession });
 		if (switchingToDifferentSession) this.ctx.resetIrcSidebarSession();
 		this.#refreshSessionTerminalTitle();
 		this.ctx.updateEditorBorderColor();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -33,6 +33,7 @@ import chalk from "chalk";
 import { AsyncJobManager } from "../async";
 import { type AppKeybinding, KeybindingsManager } from "../config/keybindings";
 import { isSettingsInitialized, type Settings, settings } from "../config/settings";
+import { normalizeBusyPromptMode } from "../config/settings-schema";
 import { DEFAULT_GJC_DEFINITION_NAMES } from "../defaults/gjc-defaults";
 import type {
 	ExtensionUIContext,
@@ -180,6 +181,7 @@ const FRIENDLY_KEY_PARTS: Record<string, string> = {
 	enter: "Enter",
 	meta: process.platform === "darwin" ? "Command" : "Meta",
 	option: "Option",
+	super: process.platform === "darwin" ? "Command" : "Super",
 	shift: "Shift",
 };
 
@@ -1045,10 +1047,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editor.setMaxHeight(this.#computeEditorMaxHeight());
 	}
 
-	#isPromptDeliveryBusy(): boolean {
-		return this.session.isStreaming || this.session.isCompacting;
-	}
-
 	#getFirstKeyForAction(action: AppKeybinding): string | undefined {
 		return this.keybindings.getKeys(action)[0];
 	}
@@ -1061,13 +1059,28 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#getFirstKeyForAction(preferredAction) ?? this.#getFirstKeyForAction(fallbackAction);
 	}
 
+	#getOppositeBusyModeShortcut(): string | undefined {
+		return this.#getFirstKeyForAction("app.message.oppositeBusyMode");
+	}
+
 	#getComposerPlaceholder(): string {
-		if (!this.#isPromptDeliveryBusy()) return DEFAULT_COMPOSER_PLACEHOLDER;
-		const enterAction = this.settings.get("busyPromptMode") === "steer" ? "Steer" : "Queue";
-		const parts = [`Enter: ${enterAction}`];
-		const queueKey = this.#getMessageQueueShortcut();
-		if (queueKey) parts.push(`${formatShortcutForPlaceholder(queueKey)}: Queue`);
-		return `${DEFAULT_COMPOSER_PLACEHOLDER} · ${parts.join(" · ")}`;
+		if (this.session.isCompacting) {
+			return `${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Queue after compaction`;
+		}
+		if (this.session.isStreaming) {
+			const enterAction =
+				normalizeBusyPromptMode(this.settings.get("busyPromptMode")) === "steer" ? "Steer" : "Queue";
+			const parts = [`Enter: ${enterAction}`];
+			const queueKey = this.#getMessageQueueShortcut();
+			if (queueKey) parts.push(`${formatShortcutForPlaceholder(queueKey)}: Queue`);
+			const oppositeKey = this.#getOppositeBusyModeShortcut();
+			if (oppositeKey) {
+				const oppositeAction = enterAction === "Steer" ? "Queue" : "Steer";
+				parts.push(`${formatShortcutForPlaceholder(oppositeKey)}: ${oppositeAction} once`);
+			}
+			return `${DEFAULT_COMPOSER_PLACEHOLDER} · ${parts.join(" · ")}`;
+		}
+		return DEFAULT_COMPOSER_PLACEHOLDER;
 	}
 
 	#getWelcomeReservedRows(width: number): number {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -761,8 +761,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		// resume does not re-restore the same text.
 		try {
 			const draft = await this.sessionManager.consumeDraft();
-			if (draft && !this.editor.getText()) {
-				this.editor.setText(draft);
+			if (draft) {
+				const editorText = this.editor.getText();
+				this.editor.setText(editorText ? `${draft}\n\n${editorText}` : draft);
 				this.updateEditorChrome();
 				this.ui.requestRender();
 			}
@@ -2328,6 +2329,13 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.isInitialized = false;
 		}
 	}
+	#mergeCompactionQueueWithDraft(editorText: string): string {
+		const queuedText = this.compactionQueuedMessages
+			.map(message => message.text)
+			.filter(text => text.length > 0)
+			.join("\n\n");
+		return queuedText && editorText ? `${queuedText}\n\n${editorText}` : queuedText || editorText;
+	}
 
 	async shutdown(): Promise<void> {
 		if (this.#isShuttingDown) return;
@@ -2336,7 +2344,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Snapshot the editor before any teardown empties it. Persisting the draft
 		// here covers Ctrl+D shutdown with non-empty text; for /exit the editor is
 		// already cleared so saveDraft("") just removes any stale sidecar.
-		const draftText = this.editor.getText();
+		const draftText = this.#mergeCompactionQueueWithDraft(this.editor.getText());
 
 		// Flush pending session writes before shutdown
 		await this.sessionManager.flush();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1076,6 +1076,11 @@ export interface QueuedMessageEditEntry {
 	label: string;
 }
 
+export interface QueuedMessagePayload {
+	text: string;
+	images: ImageContent[];
+}
+
 /** A custom message contributed at the before-agent-start point. */
 export type BeforeAgentStartInternalMessage = Pick<
 	CustomMessage,
@@ -2425,6 +2430,16 @@ export class AgentSession {
 	#queuedMessageEditId(mode: QueuedMessageEditMode, sequence: number): string {
 		return `${mode}:${sequence}`;
 	}
+
+	#queuedMessagePayload(entry: QueuedDisplayEntry, message: AgentMessage | undefined): QueuedMessagePayload {
+		const images: ImageContent[] = [];
+		if (message?.role === "user" && Array.isArray(message.content)) {
+			for (const block of message.content) {
+				if (block.type === "image") images.push(block);
+			}
+		}
+		return { text: entry.text, images };
+	}
 	/** Register a compact display string for a custom message that the caller is
 	 *  about to dispatch via `promptCustomMessage` / `sendCustomMessage`.
 	 *  Returns a stable tag the caller MUST embed in
@@ -2445,6 +2460,12 @@ export class AgentSession {
 			this.#followUpMessages.push(entry);
 		}
 		return tag;
+	}
+
+	removeQueuedCustomMessageByDisplayTag(tag: string): void {
+		this.purgeQueuedCustomMessages(message => readPendingDisplayTag(message.details) === tag);
+		this.#steeringMessages = this.#steeringMessages.filter(entry => entry.tag !== tag);
+		this.#followUpMessages = this.#followUpMessages.filter(entry => entry.tag !== tag);
 	}
 
 	getAgentId(): string | undefined {
@@ -7442,16 +7463,37 @@ export class AgentSession {
 	}
 
 	/**
-	 * Clear queued messages and return them.
-	 * Useful for restoring to editor when user aborts.
+	 * Clear queued messages and return their complete user payloads.
+	 * Custom-message display entries have no image payload.
 	 */
-	clearQueue(): { steering: string[]; followUp: string[] } {
-		const steering = this.#steeringMessages.map(e => e.text);
-		const followUp = this.#followUpMessages.map(e => e.text);
+	clearQueuedMessagePayloads(): {
+		steering: QueuedMessagePayload[];
+		followUp: QueuedMessagePayload[];
+	} {
+		const steeringMessages = this.agent.snapshotSteering();
+		const followUpMessages = this.agent.snapshotFollowUp();
+		const steering = this.#steeringMessages.map((entry, index) =>
+			this.#queuedMessagePayload(entry, steeringMessages[index]),
+		);
+		const followUp = this.#followUpMessages.map((entry, index) =>
+			this.#queuedMessagePayload(entry, followUpMessages[index]),
+		);
 		this.#steeringMessages = [];
 		this.#followUpMessages = [];
 		this.agent.clearAllQueues();
 		return { steering, followUp };
+	}
+
+	/**
+	 * Clear queued messages and return the historical text-only view.
+	 * Prefer clearQueuedMessagePayloads() when restoring editable drafts.
+	 */
+	clearQueue(): { steering: string[]; followUp: string[] } {
+		const { steering, followUp } = this.clearQueuedMessagePayloads();
+		return {
+			steering: steering.map(entry => entry.text),
+			followUp: followUp.map(entry => entry.text),
+		};
 	}
 
 	/** Number of pending messages (includes steering, follow-up, and next-turn messages) */
@@ -7506,7 +7548,7 @@ export class AgentSession {
 		return entries;
 	}
 
-	removeQueuedMessageForEditing(id: string): string | undefined {
+	removeQueuedMessagePayloadForEditing(id: string): QueuedMessagePayload | undefined {
 		const [mode, sequenceText] = id.split(":");
 		if ((mode !== "steer" && mode !== "followUp") || sequenceText === undefined) return undefined;
 		const sequence = Number(sequenceText);
@@ -7517,12 +7559,13 @@ export class AgentSession {
 		if (index === -1) return undefined;
 
 		const [entry] = queue.splice(index, 1);
-		if (mode === "steer") {
-			this.agent.removeSteerAt(index);
-		} else {
-			this.agent.removeFollowUpAt(index);
-		}
-		return entry?.text;
+		if (!entry) return undefined;
+		const message = mode === "steer" ? this.agent.removeSteerAt(index) : this.agent.removeFollowUpAt(index);
+		return this.#queuedMessagePayload(entry, message);
+	}
+
+	removeQueuedMessageForEditing(id: string): string | undefined {
+		return this.removeQueuedMessagePayloadForEditing(id)?.text;
 	}
 
 	moveQueuedMessageForEditing(id: string, direction: "up" | "down"): boolean {
@@ -7552,24 +7595,29 @@ export class AgentSession {
 	}
 
 	/**
-	 * Pop the newest queued message across steering and follow-up queues.
-	 * Used by dequeue keybinding to restore messages to editor one at a time.
-	 * Returns the popped entry's `.text`; the tag (if any) dies with the
-	 * record — no orphan state can outlive the queue entry.
+	 * Pop the newest queued payload across steering and follow-up queues.
+	 * The tag (if any) dies with the display record.
 	 */
-	popLastQueuedMessage(): string | undefined {
+	popLastQueuedMessagePayload(): QueuedMessagePayload | undefined {
 		const steeringEntry = this.#steeringMessages.at(-1);
 		const followUpEntry = this.#followUpMessages.at(-1);
 
 		if (steeringEntry && (!followUpEntry || steeringEntry.sequence > followUpEntry.sequence)) {
-			return this.removeQueuedMessageForEditing(this.#queuedMessageEditId("steer", steeringEntry.sequence));
+			return this.removeQueuedMessagePayloadForEditing(this.#queuedMessageEditId("steer", steeringEntry.sequence));
 		}
 
 		if (followUpEntry) {
-			return this.removeQueuedMessageForEditing(this.#queuedMessageEditId("followUp", followUpEntry.sequence));
+			return this.removeQueuedMessagePayloadForEditing(
+				this.#queuedMessageEditId("followUp", followUpEntry.sequence),
+			);
 		}
 
 		return undefined;
+	}
+
+	/** Pop the newest queued message using the historical text-only view. */
+	popLastQueuedMessage(): string | undefined {
+		return this.popLastQueuedMessagePayload()?.text;
 	}
 
 	get skillsSettings(): SkillsSettings | undefined {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -4738,6 +4738,17 @@ export class SessionManager {
 		await this.storage.writeText(draftPath, text);
 	}
 
+	/** Read the saved draft without consuming it. */
+	async readDraft(): Promise<string | null> {
+		const draftPath = this.#getDraftPath();
+		if (!draftPath) return null;
+		try {
+			return await this.storage.readText(draftPath);
+		} catch (err) {
+			if (isEnoent(err)) return null;
+			throw err;
+		}
+	}
 	/**
 	 * Read and remove the saved draft. Returns the previously-saved text, or
 	 * null when no draft is pending. Single-shot: a successful read removes the

--- a/packages/coding-agent/test/agent-session-queued-prompts.test.ts
+++ b/packages/coding-agent/test/agent-session-queued-prompts.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import type { AgentMessage } from "@gajae-code/agent-core";
 import { Agent } from "@gajae-code/agent-core";
-import { getBundledModel, type TextContent } from "@gajae-code/ai";
+import { getBundledModel, type ImageContent, type TextContent } from "@gajae-code/ai";
 import { createMockModel, type MockHandler } from "@gajae-code/ai/providers/mock";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
@@ -228,6 +228,40 @@ describe("AgentSession queued prompts (issue #434)", () => {
 		await session.waitForIdle();
 
 		expect(userTexts(session)).toEqual(["p1", "steer me", "queue newest"]);
+	});
+
+	it("preserves image attachments when removing a queued prompt for editing", async () => {
+		const gate = Promise.withResolvers<void>();
+		session = buildSession([
+			async () => {
+				await gate.promise;
+				return { content: ["turn 1"] };
+			},
+			{ content: ["after queue"] },
+		]);
+
+		const first = session.prompt("p1");
+		await waitUntil(() => session!.isStreaming);
+		const image: ImageContent = {
+			type: "image",
+			data: "aW1hZ2U=",
+			mimeType: "image/png",
+		};
+		await session.prompt("inspect [image 1]", {
+			streamingBehavior: "followUp",
+			images: [image],
+		});
+
+		const entry = session.getQueuedMessageEntries()[0];
+		const removed = session.removeQueuedMessagePayloadForEditing(entry?.id ?? "");
+
+		expect(removed).toEqual({ text: "inspect [image 1]", images: [image] });
+		expect(session.getQueuedMessages().followUp).toEqual([]);
+
+		gate.resolve();
+		await first;
+		await session.waitForIdle();
+		expect(userTexts(session)).toEqual(["p1"]);
 	});
 
 	it("reorders queued follow-up prompts selected for editing", async () => {

--- a/packages/coding-agent/test/config-cli.test.ts
+++ b/packages/coding-agent/test/config-cli.test.ts
@@ -95,6 +95,34 @@ describe("config CLI schema coverage", () => {
 			value: 0.2,
 		});
 	});
+	it("accepts steer and queue busy prompt modes and rejects invalid values", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const exitSpy = vi
+			.spyOn(process, "exit")
+			.mockImplementation((code?: string | number | null | undefined): never => {
+				throw new Error(`exit ${code}`);
+			});
+
+		await runConfigCommand({ action: "set", key: "busyPromptMode", value: "steer", flags: { json: true } });
+		await runConfigCommand({ action: "get", key: "busyPromptMode", flags: { json: true } });
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({
+			key: "busyPromptMode",
+			value: "steer",
+		});
+
+		await runConfigCommand({ action: "set", key: "busyPromptMode", value: "queue", flags: { json: true } });
+		await runConfigCommand({ action: "get", key: "busyPromptMode", flags: { json: true } });
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({
+			key: "busyPromptMode",
+			value: "queue",
+		});
+		await expect(
+			runConfigCommand({ action: "set", key: "busyPromptMode", value: "later", flags: { json: true } }),
+		).rejects.toThrow("exit 1");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Valid values: steer, queue"));
+	});
 	it("sets numeric idle compaction settings from CLI values", async () => {
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 		await runConfigCommand({

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -124,38 +124,6 @@ describe("CustomEditor queue keybinding", () => {
 		expect(editor.getText()).toBe("");
 	});
 
-describe("CustomEditor opposite busy mode keybinding", () => {
-	it("takes priority over a colliding built-in action while active", () => {
-		const editor = createEditor();
-		const onOppositeBusyMode = vi.fn(() => true);
-		const onQueue = vi.fn();
-		editor.onOppositeBusyMode = onOppositeBusyMode;
-		editor.onQueue = onQueue;
-		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
-		editor.setActionKeys("app.message.queue", ["alt+enter"]);
-
-		editor.handleInput("\x1b\r");
-
-		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
-		expect(onQueue).not.toHaveBeenCalled();
-	});
-
-	it("falls through to a colliding built-in action while inactive", () => {
-		const editor = createEditor();
-		const onOppositeBusyMode = vi.fn(() => false);
-		const onQueue = vi.fn();
-		editor.onOppositeBusyMode = onOppositeBusyMode;
-		editor.onQueue = onQueue;
-		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
-		editor.setActionKeys("app.message.queue", ["alt+enter"]);
-
-		editor.handleInput("\x1b\r");
-
-		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
-		expect(onQueue).toHaveBeenCalledTimes(1);
-	});
-});
-
 	it("keeps Ctrl+Enter as a multiline newline chord", () => {
 		const editor = createEditor();
 		const onQueue = vi.fn();
@@ -246,6 +214,38 @@ describe("CustomEditor opposite busy mode keybinding", () => {
 		expect(onQueue).not.toHaveBeenCalled();
 
 		editor.handleInput("\x1bq");
+		expect(onQueue).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("CustomEditor opposite busy mode keybinding", () => {
+	it("takes priority over a colliding built-in action while active", () => {
+		const editor = createEditor();
+		const onOppositeBusyMode = vi.fn(() => true);
+		const onQueue = vi.fn();
+		editor.onOppositeBusyMode = onOppositeBusyMode;
+		editor.onQueue = onQueue;
+		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
+		editor.setActionKeys("app.message.queue", ["alt+enter"]);
+
+		editor.handleInput("\x1b\r");
+
+		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
+		expect(onQueue).not.toHaveBeenCalled();
+	});
+
+	it("falls through to a colliding built-in action while inactive", () => {
+		const editor = createEditor();
+		const onOppositeBusyMode = vi.fn(() => false);
+		const onQueue = vi.fn();
+		editor.onOppositeBusyMode = onOppositeBusyMode;
+		editor.onQueue = onQueue;
+		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
+		editor.setActionKeys("app.message.queue", ["alt+enter"]);
+
+		editor.handleInput("\x1b\r");
+
+		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
 		expect(onQueue).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -124,6 +124,38 @@ describe("CustomEditor queue keybinding", () => {
 		expect(editor.getText()).toBe("");
 	});
 
+describe("CustomEditor opposite busy mode keybinding", () => {
+	it("takes priority over a colliding built-in action while active", () => {
+		const editor = createEditor();
+		const onOppositeBusyMode = vi.fn(() => true);
+		const onQueue = vi.fn();
+		editor.onOppositeBusyMode = onOppositeBusyMode;
+		editor.onQueue = onQueue;
+		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
+		editor.setActionKeys("app.message.queue", ["alt+enter"]);
+
+		editor.handleInput("\x1b\r");
+
+		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
+		expect(onQueue).not.toHaveBeenCalled();
+	});
+
+	it("falls through to a colliding built-in action while inactive", () => {
+		const editor = createEditor();
+		const onOppositeBusyMode = vi.fn(() => false);
+		const onQueue = vi.fn();
+		editor.onOppositeBusyMode = onOppositeBusyMode;
+		editor.onQueue = onQueue;
+		editor.setActionKeys("app.message.oppositeBusyMode", ["alt+enter"]);
+		editor.setActionKeys("app.message.queue", ["alt+enter"]);
+
+		editor.handleInput("\x1b\r");
+
+		expect(onOppositeBusyMode).toHaveBeenCalledTimes(1);
+		expect(onQueue).toHaveBeenCalledTimes(1);
+	});
+});
+
 	it("keeps Ctrl+Enter as a multiline newline chord", () => {
 		const editor = createEditor();
 		const onQueue = vi.fn();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -29,6 +29,7 @@ type FakeEditor = {
 	onExternalEditor?: () => void;
 	onDequeue?: () => void;
 	onQueue?: () => void | Promise<void>;
+	onOppositeBusyMode?: () => boolean;
 	onChange?: (text: string) => void;
 	onSubmit?: (text: string) => void | Promise<void>;
 	onTabDeclined?: (text: string) => void;
@@ -374,11 +375,8 @@ describe("InputController keybinding setup", () => {
 		const controller = new InputController(ctx);
 		controller.setupKeyHandlers();
 
-		const registration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
-			([key]) => key === "super+enter",
-		);
-		expect(registration).toBeDefined();
-		expect(registration?.[1]()).toBe(true);
+		expect(spies.setActionKeys).toHaveBeenCalledWith("app.message.oppositeBusyMode", ["super+enter"]);
+		expect(editor.onOppositeBusyMode?.()).toBe(true);
 		await Bun.sleep(0);
 
 		expect(spies.prompt).toHaveBeenCalledWith(`opposite from ${busyPromptMode}`, {
@@ -394,17 +392,31 @@ describe("InputController keybinding setup", () => {
 		const controller = new InputController(ctx);
 		controller.setupKeyHandlers();
 
-		const registration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
-			([key]) => key === "super+enter",
-		);
-		expect(registration).toBeDefined();
-		expect(registration?.[1]()).toBe(false);
+		expect(editor.onOppositeBusyMode?.()).toBe(false);
 
 		(ctx.session as unknown as { isStreaming: boolean; isCompacting: boolean }).isStreaming = true;
 		(ctx.session as unknown as { isStreaming: boolean; isCompacting: boolean }).isCompacting = true;
-		expect(registration?.[1]()).toBe(false);
+		expect(editor.onOppositeBusyMode?.()).toBe(false);
 		await Bun.sleep(0);
 		expect(spies.prompt).not.toHaveBeenCalled();
+	});
+
+	it("claims the draft before rapid repeated opposite-mode submissions", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
+		editor.setText("submit exactly once");
+		new InputController(ctx).setupKeyHandlers();
+
+		expect(editor.onOppositeBusyMode?.()).toBe(true);
+		expect(editor.onOppositeBusyMode?.()).toBe(false);
+		await Bun.sleep(0);
+
+		expect(spies.prompt).toHaveBeenCalledTimes(1);
+		expect(spies.prompt).toHaveBeenCalledWith("submit exactly once", {
+			streamingBehavior: "followUp",
+			images: undefined,
+			followUpQueuePolicy: "sequential",
+		});
 	});
 
 	it("queues direct free text while streaming when busyPromptMode is queue", async () => {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -45,6 +45,7 @@ type FakeEditor = {
 async function createContext(options?: {
 	busyPromptMode?: "steer" | "queue";
 	followUpKeys?: string[];
+	oppositeBusyModeKeys?: string[];
 	ircSidebarToggleKeys?: string[];
 }) {
 	let editorText = "";
@@ -53,6 +54,7 @@ async function createContext(options?: {
 		"app.model.select": ["ctrl+l"],
 		"app.message.queue": ["alt+enter"],
 		"app.message.followUp": options?.followUpKeys ?? [],
+		"app.message.oppositeBusyMode": options?.oppositeBusyModeKeys ?? ["super+enter"],
 		"app.message.dequeue": ["alt+up", "alt+down"],
 		"app.irc.sidebar.toggle": options?.ircSidebarToggleKeys ?? ["alt+i"],
 	};
@@ -62,6 +64,7 @@ async function createContext(options?: {
 	const prompt = vi.fn(async () => {});
 	const updatePendingMessagesDisplay = vi.fn();
 	const handleBashCommand = vi.fn(async () => {});
+	const handlePythonCommand = vi.fn(async () => {});
 	const showStatus = vi.fn();
 	const onInputCallback = vi.fn();
 	const toggleIrcSidebar = vi.fn();
@@ -247,6 +250,7 @@ async function createContext(options?: {
 		showModelSelector,
 		updateEditorBorderColor: vi.fn(),
 		handleBashCommand,
+		handlePythonCommand,
 		showWarning: vi.fn(),
 		showStatus,
 		hasActiveBtw: vi.fn(() => false),
@@ -264,6 +268,7 @@ async function createContext(options?: {
 			startPendingSubmission,
 			updatePendingMessagesDisplay,
 			handleBashCommand,
+			handlePythonCommand,
 			showStatus,
 			queueCompactionMessage,
 			popLastQueuedMessage,
@@ -357,6 +362,117 @@ describe("InputController keybinding setup", () => {
 			followUpQueuePolicy: "sequential",
 		});
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		["steer", "followUp", "sequential"],
+		["queue", "steer", undefined],
+	] as const)("Command+Enter submits once as %s mode's opposite", async (busyPromptMode, streamingBehavior, followUpQueuePolicy) => {
+		const { InputController, ctx, editor, spies } = await createContext({ busyPromptMode });
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
+		editor.setText(`opposite from ${busyPromptMode}`);
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		const registration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
+			([key]) => key === "super+enter",
+		);
+		expect(registration).toBeDefined();
+		expect(registration?.[1]()).toBe(true);
+		await Bun.sleep(0);
+
+		expect(spies.prompt).toHaveBeenCalledWith(`opposite from ${busyPromptMode}`, {
+			streamingBehavior,
+			images: undefined,
+			...(followUpQueuePolicy ? { followUpQueuePolicy } : {}),
+		});
+	});
+
+	it("lets Command+Enter fall through while idle or compacting", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		editor.setText("do not invert");
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		const registration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
+			([key]) => key === "super+enter",
+		);
+		expect(registration).toBeDefined();
+		expect(registration?.[1]()).toBe(false);
+
+		(ctx.session as unknown as { isStreaming: boolean; isCompacting: boolean }).isStreaming = true;
+		(ctx.session as unknown as { isStreaming: boolean; isCompacting: boolean }).isCompacting = true;
+		expect(registration?.[1]()).toBe(false);
+		await Bun.sleep(0);
+		expect(spies.prompt).not.toHaveBeenCalled();
+	});
+
+	it("queues direct free text while streaming when busyPromptMode is queue", async () => {
+		const { InputController, ctx, editor, spies } = await createContext({ busyPromptMode: "queue" });
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("queue this message");
+
+		expect(spies.prompt).toHaveBeenCalledWith("queue this message", {
+			streamingBehavior: "followUp",
+			images: undefined,
+			followUpQueuePolicy: "sequential",
+		});
+		expect(spies.onInputCallback).not.toHaveBeenCalled();
+	});
+
+	it("queues direct images while streaming when busyPromptMode is queue", async () => {
+		const { InputController, ctx, editor, spies } = await createContext({ busyPromptMode: "queue" });
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
+		const image = { type: "image", data: "image-data" } as unknown as InteractiveModeContext["pendingImages"][number];
+		ctx.pendingImages = [image];
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("queue image [image 1]");
+
+		expect(spies.prompt).toHaveBeenCalledWith("queue image [image 1]", {
+			streamingBehavior: "followUp",
+			images: [image],
+			followUpQueuePolicy: "sequential",
+		});
+		expect(ctx.pendingImages).toEqual([]);
+	});
+
+	it("submits direct text normally while idle when busyPromptMode is queue", async () => {
+		const { InputController, ctx, editor, spies } = await createContext({ busyPromptMode: "queue" });
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("idle message");
+
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(spies.onInputCallback).toHaveBeenCalledWith({
+			text: "idle message",
+			images: undefined,
+			cancelled: false,
+			started: true,
+		});
+	});
+
+	it.each([
+		["!echo normal", "echo normal", false, "handleBashCommand"],
+		["!!echo excluded", "echo excluded", true, "handleBashCommand"],
+		["$print('normal')", "print('normal')", false, "handlePythonCommand"],
+		["$$print('excluded')", "print('excluded')", true, "handlePythonCommand"],
+	] as const)("runs %s directly during compaction", async (input, command, excluded, handler) => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		(ctx.session as unknown as { isCompacting: boolean }).isCompacting = true;
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.(input);
+
+		expect(spies[handler]).toHaveBeenCalledWith(command, excluded);
+		expect(spies.queueCompactionMessage).not.toHaveBeenCalled();
+		expect(spies.prompt).not.toHaveBeenCalled();
 	});
 
 	it("does not register a default Ctrl+Enter follow-up handler", async () => {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -67,6 +67,7 @@ async function createContext(options?: {
 	const handleBashCommand = vi.fn(async () => {});
 	const handlePythonCommand = vi.fn(async () => {});
 	const showStatus = vi.fn();
+	const showError = vi.fn();
 	const onInputCallback = vi.fn();
 	const toggleIrcSidebar = vi.fn();
 	const startPendingSubmission = vi.fn(
@@ -130,6 +131,21 @@ async function createContext(options?: {
 		sessionQueuedMessages.length = 0;
 		return { steering: [], followUp };
 	});
+	const popLastQueuedMessagePayload = vi.fn(() => {
+		const text = popLastQueuedMessage();
+		return text === undefined ? undefined : { text, images: [] };
+	});
+	const removeQueuedMessagePayloadForEditing = vi.fn((id: string) => {
+		const text = removeQueuedMessageForEditing(id);
+		return text === undefined ? undefined : { text, images: [] };
+	});
+	const clearQueuedMessagePayloads = vi.fn(() => {
+		const { steering, followUp } = clearQueue();
+		return {
+			steering: steering.map(text => ({ text, images: [] })),
+			followUp: followUp.map(text => ({ text, images: [] })),
+		};
+	});
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
@@ -179,6 +195,9 @@ async function createContext(options?: {
 			getQueuedMessageEntries,
 			removeQueuedMessageForEditing,
 			moveQueuedMessageForEditing,
+			popLastQueuedMessagePayload,
+			clearQueuedMessagePayloads,
+			removeQueuedMessagePayloadForEditing,
 		} as unknown as InteractiveModeContext["session"],
 		keybindings: {
 			getKeys(action: string) {
@@ -253,6 +272,7 @@ async function createContext(options?: {
 		handleBashCommand,
 		handlePythonCommand,
 		showWarning: vi.fn(),
+		showError,
 		showStatus,
 		hasActiveBtw: vi.fn(() => false),
 	} as unknown as InteractiveModeContext;
@@ -271,6 +291,7 @@ async function createContext(options?: {
 			handleBashCommand,
 			handlePythonCommand,
 			showStatus,
+			showError,
 			queueCompactionMessage,
 			popLastQueuedMessage,
 			clearQueue,
@@ -417,6 +438,73 @@ describe("InputController keybinding setup", () => {
 			images: undefined,
 			followUpQueuePolicy: "sequential",
 		});
+	});
+
+	it("claims the draft before rapid repeated explicit queue submissions", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
+		editor.setText("queue exactly once");
+		new InputController(ctx).setupKeyHandlers();
+
+		editor.onQueue?.();
+		editor.onQueue?.();
+		await Bun.sleep(0);
+
+		expect(spies.prompt).toHaveBeenCalledTimes(1);
+		expect(spies.prompt).toHaveBeenCalledWith("queue exactly once", {
+			streamingBehavior: "followUp",
+			images: undefined,
+			followUpQueuePolicy: "sequential",
+		});
+	});
+
+	it("runs explicit queue through extension transforms", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const emitInput = vi.fn(async () => ({ text: "transformed queue" }));
+		(
+			ctx.session as unknown as {
+				isStreaming: boolean;
+				extensionRunner: { hasHandlers(name: string): boolean; emitInput: typeof emitInput };
+			}
+		).isStreaming = true;
+		(ctx.session as unknown as { extensionRunner: unknown }).extensionRunner = {
+			hasHandlers: (name: string) => name === "input",
+			emitInput,
+			getShortcuts: () => new Map(),
+		};
+		editor.setText("original queue");
+		new InputController(ctx).setupKeyHandlers();
+
+		await editor.onQueue?.();
+		await Bun.sleep(0);
+
+		expect(emitInput).toHaveBeenCalledWith("original queue", undefined, "interactive");
+		expect(spies.prompt).toHaveBeenCalledWith("transformed queue", {
+			streamingBehavior: "followUp",
+			images: undefined,
+			followUpQueuePolicy: "sequential",
+		});
+	});
+
+	it.each([
+		["! echo queued", "echo queued", "bash"],
+		["$ print('queued')", "print('queued')", "python"],
+	] as const)("keeps %s on its local command boundary for explicit queue", async (draft, command, kind) => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
+		editor.setText(draft);
+		new InputController(ctx).setupKeyHandlers();
+
+		await editor.onQueue?.();
+
+		if (kind === "bash") {
+			expect(spies.handleBashCommand).toHaveBeenCalledWith(command, false);
+			expect(spies.handlePythonCommand).not.toHaveBeenCalled();
+		} else {
+			expect(spies.handlePythonCommand).toHaveBeenCalledWith(command, false);
+			expect(spies.handleBashCommand).not.toHaveBeenCalled();
+		}
+		expect(spies.prompt).not.toHaveBeenCalled();
 	});
 
 	it("queues direct free text while streaming when busyPromptMode is queue", async () => {
@@ -577,7 +665,11 @@ describe("InputController keybinding setup", () => {
 		await editor.onQueue?.();
 		await Bun.sleep(0);
 
-		expect(spies.queueCompactionMessage).toHaveBeenCalledWith("queue while compacting via shortcut", "followUp");
+		expect(spies.queueCompactionMessage).toHaveBeenCalledWith(
+			"queue while compacting via shortcut",
+			"followUp",
+			expect.objectContaining({ ownsComposer: true, editor }),
+		);
 		expect(spies.prompt).not.toHaveBeenCalled();
 		expect(editor.getText()).toBe("");
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
@@ -591,7 +683,7 @@ describe("InputController keybinding setup", () => {
 
 		controller.handleDequeue();
 
-		expect(editor.getText()).toBe("single compaction queue");
+		expect(editor.getText()).toBe("single compaction queue\n\ncurrent draft");
 		expect(queues.compactionQueuedMessages).toEqual([]);
 		expect(spies.popLastQueuedMessage).not.toHaveBeenCalled();
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
@@ -605,11 +697,31 @@ describe("InputController keybinding setup", () => {
 
 		controller.handleDequeue();
 
-		expect(editor.getText()).toBe("single session queue");
+		expect(editor.getText()).toBe("single session queue\n\ncurrent draft");
 		expect(queues.sessionQueuedMessages).toEqual([]);
 		expect(spies.clearQueue).not.toHaveBeenCalled();
 		expect(spies.removeQueuedMessageForEditing).toHaveBeenCalledWith("followUp:0");
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("restores queued image payloads and rebases the current draft placeholders", async () => {
+		const { InputController, ctx, editor, queues } = await createContext();
+		const queuedImage = { type: "image" as const, data: "queued", mimeType: "image/png" };
+		const currentImage = { type: "image" as const, data: "current", mimeType: "image/png" };
+		queues.sessionQueuedMessages.push("queued [image 1]");
+		(
+			ctx.session as unknown as { removeQueuedMessagePayloadForEditing(id: string): unknown }
+		).removeQueuedMessagePayloadForEditing = () => ({
+			text: "queued [image 1]",
+			images: [queuedImage],
+		});
+		ctx.pendingImages = [currentImage];
+		editor.setText("current [image 1]");
+
+		new InputController(ctx).handleDequeue();
+
+		expect(editor.getText()).toBe("queued [image 1]\n\ncurrent [image 2]");
+		expect(ctx.pendingImages).toEqual([queuedImage, currentImage]);
 	});
 
 	it("opens a selector so older queued messages can be restored", async () => {
@@ -628,7 +740,7 @@ describe("InputController keybinding setup", () => {
 		selector.getSelectList().setSelectedIndex(0);
 		selector.getSelectList().handleInput("\n");
 
-		expect(editor.getText()).toBe("older session queue");
+		expect(editor.getText()).toBe("older session queue\n\ncurrent draft");
 		expect(queues.sessionQueuedMessages).toEqual(["newest session queue"]);
 		expect(spies.removeQueuedMessageForEditing).toHaveBeenCalledWith("followUp:0");
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
@@ -688,7 +800,7 @@ describe("InputController keybinding setup", () => {
 		}
 		selector.getSelectList().handleInput("\n");
 
-		expect(editor.getText()).toBe("newer steer");
+		expect(editor.getText()).toBe("newer steer\n\ncurrent draft");
 		expect(spies.removeQueuedMessageForEditing).toHaveBeenCalledWith("steer:2");
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
@@ -949,33 +1061,55 @@ describe("InputController keybinding setup", () => {
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
 
-	it("marks idle follow-up submissions as local", async () => {
+	it("routes idle explicit queue through the canonical idle submission pipeline", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
-		// Default fake session is idle.
 		editor.setText("plain idle submit");
 		const controller = new InputController(ctx);
 
 		await controller.handleFollowUp();
 
-		expect(ctx.locallySubmittedUserSignatures.has("plain idle submit\u00000")).toBe(true);
-		// Idle submit calls prompt() with no streamingBehavior.
-		expect(spies.prompt).toHaveBeenCalledWith("plain idle submit");
+		expect(spies.onInputCallback).toHaveBeenCalledWith(
+			expect.objectContaining({ text: "plain idle submit", cancelled: false }),
+		);
+		expect(spies.prompt).not.toHaveBeenCalled();
 	});
 
-	it("removes the signature when an idle follow-up submission rejects", async () => {
+	it("restores a plain Enter draft when prompt delivery rejects", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
-		spies.prompt.mockImplementationOnce(async () => {
-			throw new Error("boom");
-		});
-		editor.setText("doomed submit");
+		const delivery = Promise.withResolvers<void>();
+		spies.prompt.mockImplementationOnce(async () => delivery.promise);
+		const oldImage = { type: "image" as const, data: "old", mimeType: "image/png" };
+		const newImage = { type: "image" as const, data: "new", mimeType: "image/png" };
+		ctx.pendingImages = [oldImage];
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
 		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
 
-		await expect(controller.handleFollowUp()).rejects.toThrow("boom");
+		const submit = editor.onSubmit?.("doomed submit [image 1]");
+		editor.setText("new draft [image 1]");
+		ctx.pendingImages = [newImage];
+		delivery.reject(new Error("boom"));
+		await submit;
 
-		// Contract: a thrown delivery error must not leave a stale signature
-		// behind, otherwise the next attempt with the same text would silently
-		// suppress the editor-clear protection that was meant for the failed call.
-		expect(ctx.locallySubmittedUserSignatures.has("doomed submit\u00000")).toBe(false);
+		expect(editor.getText()).toBe("new draft [image 1]\ndoomed submit [image 2]");
+		expect(ctx.pendingImages).toEqual([newImage, oldImage]);
+		expect(spies.showError).toHaveBeenCalledWith("Failed to submit input: boom");
+		expect(ctx.locallySubmittedUserSignatures.has("doomed submit [image 1]\u00001")).toBe(false);
+	});
+
+	it("rolls back an image draft without duplicating its claimed attachment", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const image = { type: "image" as const, data: "old", mimeType: "image/png" };
+		ctx.pendingImages = [image];
+		(ctx.session as unknown as { isStreaming: boolean }).isStreaming = true;
+		spies.prompt.mockRejectedValueOnce(new Error("boom"));
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("doomed [image 1]");
+
+		expect(editor.getText()).toBe("doomed [image 1]");
+		expect(ctx.pendingImages).toEqual([image]);
 	});
 
 	it("removes the signature when a streaming follow-up rejects", async () => {
@@ -988,7 +1122,7 @@ describe("InputController keybinding setup", () => {
 		editor.setText("queued during stream");
 		const controller = new InputController(ctx);
 
-		await expect(controller.handleFollowUp()).rejects.toThrow("queue full");
+		await controller.handleFollowUp();
 
 		expect(ctx.locallySubmittedUserSignatures.has("queued during stream\u00000")).toBe(false);
 	});

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -98,6 +98,7 @@ function createStubInputControllerContext(opts: {
 		addToHistory: vi.fn(),
 	};
 	const enqueueCustomMessageDisplay = vi.fn((_text: string, _mode: "steer" | "followUp") => "sk-test-0");
+	const removeQueuedCustomMessageByDisplayTag = vi.fn();
 	// Annotate parameters so `mock.calls[N]` is typed as a tuple (not `[]`) and
 	// `message` carries required skill prompt details for assertion below.
 	const promptCustomMessage = vi.fn(
@@ -123,6 +124,7 @@ function createStubInputControllerContext(opts: {
 			isEvalRunning: false,
 			extensionRunner: undefined,
 			enqueueCustomMessageDisplay,
+			removeQueuedCustomMessageByDisplayTag,
 			sendCustomMessage,
 			promptCustomMessage,
 			prompt,
@@ -152,6 +154,7 @@ function createStubInputControllerContext(opts: {
 		editor,
 		enqueueCustomMessageDisplay,
 		promptCustomMessage,
+		removeQueuedCustomMessageByDisplayTag,
 		sendCustomMessage,
 		prompt,
 		queueCompactionMessage,
@@ -234,6 +237,25 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 		}
 		const messageArg = firstCall[0];
 		expect(messageArg.details.__pendingDisplayTag).toBe("sk-test-0");
+	});
+
+	it("removes the exact pending display tag when skill dispatch fails", async () => {
+		const { ctx, editor, promptCustomMessage, removeQueuedCustomMessageByDisplayTag } =
+			createStubInputControllerContext({
+				skillCommands,
+				isStreaming: true,
+				busyPromptMode: "steer",
+			});
+		promptCustomMessage.mockRejectedValueOnce(new Error("dispatch failed"));
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+		editor.setText("/skill:test-skill failure");
+
+		await controller.handleFollowUp();
+
+		expect(removeQueuedCustomMessageByDisplayTag).toHaveBeenCalledWith("sk-test-0");
+		expect(ctx.updatePendingMessagesDisplay).toHaveBeenCalled();
+		expect(ctx.ui.requestRender).toHaveBeenCalled();
 	});
 
 	it("E3b: embedded default skill command does not require .gjc on disk", async () => {
@@ -346,6 +368,31 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 		expect(promptCustomMessage.mock.calls[0]?.[0].content).toContain("Do the second thing.");
 		expect(promptCustomMessage.mock.calls[0]?.[0].content).toContain("User: beta gamma");
 	});
+
+	it("restores only the undispatched suffix when a chained skill dispatch fails", async () => {
+		const secondSkillPath = writeSkillFile(tempDir.path(), "second-skill", "Do the second thing.");
+		skillCommands.set("skill:second-skill", {
+			name: "second-skill",
+			description: "Second skill",
+			filePath: secondSkillPath,
+			baseDir: tempDir.path(),
+			source: "test",
+		});
+		const { ctx, editor, sendCustomMessage, promptCustomMessage } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: false,
+		});
+		promptCustomMessage.mockRejectedValueOnce(new Error("second dispatch failed"));
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		const submit = editor.onSubmit?.("/skill:test-skill alpha /skill:second-skill beta");
+		editor.setText("");
+		await submit;
+
+		expect(sendCustomMessage).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("/skill:second-skill beta");
+	});
 });
 
 describe("InputController busyPromptMode + skill commands (issue #434)", () => {
@@ -404,7 +451,11 @@ describe("InputController busyPromptMode + skill commands (issue #434)", () => {
 
 		await editor.onSubmit?.("/skill:test-skill compact");
 
-		expect(queueCompactionMessage).toHaveBeenCalledWith("/skill:test-skill compact", "steer");
+		expect(queueCompactionMessage).toHaveBeenCalledWith(
+			"/skill:test-skill compact",
+			"followUp",
+			expect.objectContaining({ ownsComposer: true, editor }),
+		);
 		expect(enqueueCustomMessageDisplay).not.toHaveBeenCalled();
 		expect(promptCustomMessage).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -85,6 +85,7 @@ function createStubInputControllerContext(opts: {
 	skillCommands: Map<string, Skill>;
 	isStreaming: boolean;
 	busyPromptMode?: "steer" | "queue";
+	isCompacting?: boolean;
 }) {
 	let editorText = "";
 	const editor: StubEditor = {
@@ -107,6 +108,8 @@ function createStubInputControllerContext(opts: {
 	const updatePendingMessagesDisplay = vi.fn();
 	const requestRender = vi.fn();
 	const showError = vi.fn();
+	const showStatus = vi.fn();
+	const queueCompactionMessage = vi.fn();
 
 	const ctx = {
 		editor,
@@ -115,7 +118,7 @@ function createStubInputControllerContext(opts: {
 		session: {
 			sessionId: "stub-session",
 			isStreaming: opts.isStreaming,
-			isCompacting: false,
+			isCompacting: opts.isCompacting ?? false,
 			isBashRunning: false,
 			isEvalRunning: false,
 			extensionRunner: undefined,
@@ -131,6 +134,7 @@ function createStubInputControllerContext(opts: {
 			getCwd: () => process.cwd(),
 		},
 		showError,
+		showStatus,
 		updatePendingMessagesDisplay,
 		// Defaults that InputController touches on submit but don't matter here.
 		isBashMode: false,
@@ -138,11 +142,21 @@ function createStubInputControllerContext(opts: {
 		pendingImages: [],
 		isBackgrounded: false,
 		compactionQueuedMessages: [],
+		queueCompactionMessage,
 		locallySubmittedUserSignatures: new Set<string>(),
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage, sendCustomMessage, prompt };
+	return {
+		ctx,
+		editor,
+		enqueueCustomMessageDisplay,
+		promptCustomMessage,
+		sendCustomMessage,
+		prompt,
+		queueCompactionMessage,
+		showStatus,
+	};
 }
 
 describe("InputController #invokeSkillCommand (E1-E3)", () => {
@@ -359,11 +373,9 @@ describe("InputController busyPromptMode + skill commands (issue #434)", () => {
 		vi.restoreAllMocks();
 	});
 
-	// Skill-command-specific routing. Free-text Enter routing and the Ctrl+Enter
-	// keybinding are covered in input-controller-busy-prompt-mode.test.ts; the
-	// E1 case above already covers the default (steer) skill path.
+	// Skill commands use the same busy-mode routing as free text.
 	it("queue: Enter on a skill command while streaming queues it as followUp", async () => {
-		const { ctx, editor, enqueueCustomMessageDisplay } = createStubInputControllerContext({
+		const { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage } = createStubInputControllerContext({
 			skillCommands,
 			isStreaming: true,
 			busyPromptMode: "queue",
@@ -374,6 +386,47 @@ describe("InputController busyPromptMode + skill commands (issue #434)", () => {
 		await editor.onSubmit?.("/skill:test-skill go");
 
 		expect(enqueueCustomMessageDisplay).toHaveBeenCalledWith("/skill:test-skill go", "followUp");
+		const call = promptCustomMessage.mock.calls[0];
+		expect(call?.[0].details.__pendingDisplayTag).toBe("sk-test-0");
+		expect(call?.[1]).toEqual({ streamingBehavior: "followUp", followUpQueuePolicy: "sequential" });
+	});
+
+	it("queues skill commands locally as steer during compaction", async () => {
+		const { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage, queueCompactionMessage } =
+			createStubInputControllerContext({
+				skillCommands,
+				isStreaming: true,
+				busyPromptMode: "queue",
+				isCompacting: true,
+			});
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("/skill:test-skill compact");
+
+		expect(queueCompactionMessage).toHaveBeenCalledWith("/skill:test-skill compact", "steer");
+		expect(enqueueCustomMessageDisplay).not.toHaveBeenCalled();
+		expect(promptCustomMessage).not.toHaveBeenCalled();
+	});
+
+	it("rejects image-bearing skill commands during compaction", async () => {
+		const { ctx, editor, promptCustomMessage, queueCompactionMessage, showStatus } = createStubInputControllerContext(
+			{
+				skillCommands,
+				isStreaming: true,
+				busyPromptMode: "queue",
+				isCompacting: true,
+			},
+		);
+		ctx.pendingImages = [{ type: "image", data: "image-data", mimeType: "image/png" }];
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("/skill:test-skill inspect [image 1]");
+
+		expect(showStatus).toHaveBeenCalledWith("Compaction in progress. Retry after it completes to send images.");
+		expect(queueCompactionMessage).not.toHaveBeenCalled();
+		expect(promptCustomMessage).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -441,7 +441,8 @@ describe("InteractiveMode.setEditorComponent", () => {
 	}
 
 	function expectedOppositeBusyModeHint(action: "Steer" | "Queue"): string {
-		return process.platform === "darwin" ? ` · Command+Enter: ${action} once` : "";
+		const shortcut = process.platform === "darwin" ? "Command+Enter" : "Super+Enter";
+		return ` · ${shortcut}: ${action} once`;
 	}
 
 	function renderedPlaceholder(): string {

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -16,7 +16,7 @@ import type {
 } from "../src/extensibility/extensions";
 import { CustomEditor } from "../src/modes/components/custom-editor";
 import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
-import { InteractiveMode } from "../src/modes/interactive-mode";
+import { DEFAULT_COMPOSER_PLACEHOLDER, InteractiveMode } from "../src/modes/interactive-mode";
 import { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
 import { associateSessionMessageEntryId, type SessionContext, SessionManager } from "../src/session/session-manager";
@@ -420,10 +420,6 @@ describe("InteractiveMode.setEditorComponent", () => {
 				.anchors.some(anchor => anchor?.id === `${liveId}:content:0:text`),
 		).toBe(true);
 	});
-	function expectedNewlineShortcutHint(): string {
-		const shortcut = process.platform === "win32" ? "Alt+Enter/Ctrl+J" : "Shift+Enter/Ctrl+J";
-		return `${shortcut}: New line`;
-	}
 
 	it("keeps the composer right border inside a trailing gutter for CJK input", () => {
 		mode.editor.focused = true;
@@ -444,31 +440,58 @@ describe("InteractiveMode.setEditorComponent", () => {
 		return `${shortcut}: Queue`;
 	}
 
-	it("shows busy steering and queueing hints only while work is active", () => {
-		let rendered = mode.editor.render(160).map(stripRenderControls).join("\n");
-		expect(rendered).toContain("Type your message...");
-		expect(rendered).toContain(expectedNewlineShortcutHint());
-		expect(rendered).toContain("Ctrl+C: Clear");
-		expect(rendered).toContain("Ctrl+R: Search history");
-		expect(rendered).toContain("Shift+Tab: Reasoning");
-		expect(rendered).not.toContain("Enter: Steer");
-		expect(rendered).not.toContain(expectedQueueShortcutHint());
+	function expectedOppositeBusyModeHint(action: "Steer" | "Queue"): string {
+		return process.platform === "darwin" ? ` · Command+Enter: ${action} once` : "";
+	}
+
+	function renderedPlaceholder(): string {
+		const line = mode.editor
+			.render(320)
+			.map(stripRenderControls)
+			.find(candidate => candidate.includes("Type your message..."));
+		if (!line) throw new Error("expected rendered composer placeholder");
+		const start = line.indexOf("Type your message...");
+		const end = line.lastIndexOf("│");
+		return line.slice(start, end > start ? end : undefined).trimEnd();
+	}
+
+	it("renders idle, streaming, and compaction composer placeholders with exact precedence", () => {
+		expect(renderedPlaceholder()).toBe(DEFAULT_COMPOSER_PLACEHOLDER);
 
 		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = true;
 		mode.updateEditorChrome();
 
-		rendered = mode.editor.render(160).map(stripRenderControls).join("\n");
-		expect(rendered).toContain("Type your message...");
-		expect(rendered).toContain("Enter: Steer");
-		expect(rendered).toContain(expectedQueueShortcutHint());
+		expect(renderedPlaceholder()).toBe(
+			`${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Steer · ${expectedQueueShortcutHint()}${expectedOppositeBusyModeHint("Queue")}`,
+		);
 
-		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = false;
+		mode.settings.set("busyPromptMode", "queue");
+		mode.updateEditorChrome();
+		expect(renderedPlaceholder()).toBe(
+			`${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Queue · ${expectedQueueShortcutHint()}${expectedOppositeBusyModeHint("Steer")}`,
+		);
+
+		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = true;
+		Object.defineProperty(session, "isCompacting", { configurable: true, get: () => true });
+		mode.updateEditorChrome();
+		expect(renderedPlaceholder()).toBe(`${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Queue after compaction`);
+	});
+
+	it("renders a remapped queue chord and omits it when both queue bindings are disabled", () => {
+		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = true;
+		const getKeys = vi.spyOn(mode.keybindings, "getKeys").mockImplementation(action => {
+			if (action === "app.message.followUp") return ["ctrl+shift+q"];
+			if (action === "app.message.queue") return ["alt+q"];
+			return [];
+		});
 		mode.updateEditorChrome();
 
-		rendered = mode.editor.render(160).map(stripRenderControls).join("\n");
-		expect(rendered).toContain("Type your message...");
-		expect(rendered).not.toContain("Enter: Steer");
-		expect(rendered).not.toContain(expectedQueueShortcutHint());
+		const remappedHint = process.platform === "darwin" ? "Ctrl+Shift+Q: Queue" : "Alt+Q: Queue";
+		expect(renderedPlaceholder()).toBe(`${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Steer · ${remappedHint}`);
+
+		getKeys.mockReturnValue([]);
+		mode.updateEditorChrome();
+		expect(renderedPlaceholder()).toBe(`${DEFAULT_COMPOSER_PLACEHOLDER} · Enter: Steer`);
 	});
 
 	it("renders the composer directly below the status line without hook widgets", async () => {

--- a/packages/coding-agent/test/interactive-mode-issue-2261-new-session.test.ts
+++ b/packages/coding-agent/test/interactive-mode-issue-2261-new-session.test.ts
@@ -4,7 +4,7 @@ import { Agent } from "@gajae-code/agent-core";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { resolveLocalUrlToPath } from "@gajae-code/coding-agent/internal-urls";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
-import { TempDir } from "@gajae-code/utils";
+import { postmortem, TempDir } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import type { ExtensionCommandContextActions } from "../src/extensibility/extensions";
 import { BtwController } from "../src/modes/controllers/btw-controller";
@@ -128,6 +128,19 @@ describe("Issue #2261 InteractiveMode session-switch preparation", () => {
 		expect(disposeBtw).toHaveBeenCalledTimes(1);
 		expect(clearExtensionListeners).toHaveBeenCalledTimes(1);
 	});
+	it("saves compaction-local queue entries before the editor draft on shutdown", async () => {
+		mode.compactionQueuedMessages = [
+			{ text: "first queued", mode: "followUp" },
+			{ text: "second queued", mode: "steer" },
+		];
+		mode.editor.setText("editor draft");
+		const saveDraft = vi.spyOn(session.sessionManager, "saveDraft");
+		vi.spyOn(postmortem, "quit").mockResolvedValue(undefined);
+
+		await mode.shutdown();
+
+		expect(saveDraft).toHaveBeenCalledWith("first queued\n\nsecond queued\n\neditor draft");
+	});
 });
 
 let commandActions: ExtensionCommandContextActions | undefined;
@@ -153,8 +166,11 @@ function createExtensionContext(success: boolean): {
 		loadingAnimation: { stop: vi.fn() },
 		statusContainer: { clear: vi.fn() },
 		resetIrcSidebarSession: vi.fn(),
+		resetObserverRegistry: vi.fn(),
 		statusLine: { invalidate: vi.fn(), setSessionStartTime: vi.fn() },
 		updateEditorTopBorder: vi.fn(),
+		updateEditorBorderColor: vi.fn(),
+		editor: { getText: () => "editor draft" },
 		ui: {
 			requestRender: vi.fn(),
 			resetViewportAnchorIntent: vi.fn(),
@@ -168,7 +184,13 @@ function createExtensionContext(success: boolean): {
 		compactionQueuedMessages: [{ text: "queued", mode: "followUp" }],
 		pendingTools: new Map([["old-tool", {}]]),
 		reloadTodos: vi.fn(),
-		sessionManager: { getSessionName: () => "old", getCwd: () => "/old" },
+		showError: vi.fn(),
+		sessionManager: {
+			getSessionName: () => "old",
+			getCwd: () => "/old",
+			saveDraft: vi.fn(async () => {}),
+			readDraft: vi.fn(async () => "prior draft"),
+		},
 	} as unknown as InteractiveModeContext;
 	return { context, unsubscribePreviousListener, unsubscribeSuccessorListener };
 }
@@ -204,6 +226,24 @@ describe("Issue #2261 extension session.new", () => {
 			expect(context.compactionQueuedMessages).toEqual(success ? [] : [{ text: "queued", mode: "followUp" }]);
 			expect(context.pendingTools.has("old-tool")).toBe(!success);
 			expect(context.reloadTodos).toHaveBeenCalledTimes(success ? 1 : 0);
+		});
+	}
+});
+describe("Issue #2261 compaction queue draft persistence", () => {
+	for (const success of [false, true]) {
+		it(`${success ? "clears only after" : "retains after"} a ${success ? "successful" : "failed"} new-session transition`, async () => {
+			const { context } = createExtensionContext(success);
+			const controller = new CommandController(context);
+
+			const result = await controller.handleClearCommand();
+
+			expect(result).toBe(success);
+			expect(context.sessionManager.saveDraft).toHaveBeenCalledWith("queued\n\neditor draft");
+			expect(context.compactionQueuedMessages).toEqual(success ? [] : [{ text: "queued", mode: "followUp" }]);
+			if (!success) {
+				expect(context.sessionManager.saveDraft).toHaveBeenLastCalledWith("prior draft");
+			}
+			expect(context.editor.getText()).toBe("editor draft");
 		});
 	}
 });

--- a/packages/coding-agent/test/keybindings-audit.test.ts
+++ b/packages/coding-agent/test/keybindings-audit.test.ts
@@ -26,8 +26,8 @@ describe("docs/keybindings.md current-surface audit", () => {
 		expect(defaultMessageQueueKeysForPlatform("win32")).toBe("alt+q");
 		expect(defaultMessageQueueKeysForPlatform("linux")).toBe("alt+enter");
 		expect(defaultOppositeBusyModeKeysForPlatform("darwin")).toEqual(["super+enter"]);
-		expect(defaultOppositeBusyModeKeysForPlatform("win32")).toEqual([]);
-		expect(defaultOppositeBusyModeKeysForPlatform("linux")).toEqual([]);
+		expect(defaultOppositeBusyModeKeysForPlatform("win32")).toEqual(["super+enter"]);
+		expect(defaultOppositeBusyModeKeysForPlatform("linux")).toEqual(["super+enter"]);
 		expect(KEYBINDINGS["app.message.oppositeBusyMode"].description).toBe(
 			"Submit once using the opposite busy prompt mode",
 		);
@@ -43,7 +43,7 @@ describe("docs/keybindings.md current-surface audit", () => {
 			"| `app.message.followUp` | _(none)_ | `Ctrl+Enter` remains editor newline unless the user explicitly remaps this action; while idle the chord still falls through to newline |",
 		);
 		expect(doc).toContain(
-			"| `app.message.oppositeBusyMode` | `Command+Enter` (macOS) | Submit one message using the opposite of `busyPromptMode` |",
+			"| `app.message.oppositeBusyMode` | `Super+Enter` | Submit one message using the opposite of `busyPromptMode` |",
 		);
 		expect(doc).toContain(
 			"configured `steer` queues that message, while configured `queue` steers it into the active turn.",

--- a/packages/coding-agent/test/keybindings-audit.test.ts
+++ b/packages/coding-agent/test/keybindings-audit.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { KEYBINDINGS } from "../src/config/keybindings";
+import {
+	defaultMessageQueueKeysForPlatform,
+	defaultOppositeBusyModeKeysForPlatform,
+	KEYBINDINGS,
+} from "../src/config/keybindings";
 
 const DOC_PATH = join(import.meta.dir, "../../../docs/keybindings.md");
 
@@ -10,5 +14,39 @@ describe("docs/keybindings.md current-surface audit", () => {
 		const doc = readFileSync(DOC_PATH, "utf8");
 		const missing = Object.keys(KEYBINDINGS).filter(id => !doc.includes(`\`${id}\``));
 		expect(missing).toEqual([]);
+	});
+
+	it("keeps follow-up and platform queue documentation aligned with the registry", () => {
+		const doc = readFileSync(DOC_PATH, "utf8");
+
+		expect(KEYBINDINGS["app.message.followUp"].description).toBe(
+			"Send follow-up message (no default; Ctrl+Enter remains editor newline unless remapped)",
+		);
+		expect(defaultMessageQueueKeysForPlatform("darwin")).toBe("alt+q");
+		expect(defaultMessageQueueKeysForPlatform("win32")).toBe("alt+q");
+		expect(defaultMessageQueueKeysForPlatform("linux")).toBe("alt+enter");
+		expect(defaultOppositeBusyModeKeysForPlatform("darwin")).toEqual(["super+enter"]);
+		expect(defaultOppositeBusyModeKeysForPlatform("win32")).toEqual([]);
+		expect(defaultOppositeBusyModeKeysForPlatform("linux")).toEqual([]);
+		expect(KEYBINDINGS["app.message.oppositeBusyMode"].description).toBe(
+			"Submit once using the opposite busy prompt mode",
+		);
+		expect(doc).toContain("| `app.message.queue` | `Alt+Q` (macOS/Windows), `Alt+Enter` (otherwise) |");
+		expect(doc).toContain("| `app.message.queue` | `alt+q` (macOS/Windows), `alt+enter` (otherwise) |");
+		expect(doc).toContain(
+			"On macOS and native Windows terminals, GJC defaults `app.message.queue` to `Alt+Q`; other platforms use `Alt+Enter`.",
+		);
+		expect(doc).toContain(
+			"| `app.message.followUp` | _(none)_ | Optional remap for a follow-up message; `Ctrl+Enter` remains editor newline unless remapped |",
+		);
+		expect(doc).toContain(
+			"| `app.message.followUp` | _(none)_ | `Ctrl+Enter` remains editor newline unless the user explicitly remaps this action; while idle the chord still falls through to newline |",
+		);
+		expect(doc).toContain(
+			"| `app.message.oppositeBusyMode` | `Command+Enter` (macOS) | Submit one message using the opposite of `busyPromptMode` |",
+		);
+		expect(doc).toContain(
+			"configured `steer` queues that message, while configured `queue` steers it into the active turn.",
+		);
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/issue-2261-new-session-fail-closed.test.ts
+++ b/packages/coding-agent/test/modes/controllers/issue-2261-new-session-fail-closed.test.ts
@@ -14,6 +14,8 @@ function createContext(success: boolean): InteractiveModeContext {
 			getSessionFile: () => "/old/session.jsonl",
 			getSessionName: () => "old",
 			getCwd: () => "/old",
+			readDraft: vi.fn(async () => null),
+			saveDraft: vi.fn(async () => {}),
 		},
 		statusLine: { invalidate: vi.fn(), setSessionStartTime: vi.fn() },
 		updateEditorTopBorder: vi.fn(),
@@ -25,6 +27,7 @@ function createContext(success: boolean): InteractiveModeContext {
 		pendingTools: new Map([["old", {}]]),
 		reloadTodos: vi.fn(),
 		showError: vi.fn(),
+		editor: { getText: () => "" },
 	} as unknown as InteractiveModeContext;
 }
 
@@ -77,6 +80,7 @@ describe("Issue #2261 CommandController fail-closed session replacement", () => 
 			session: { clearContext, newSession: vi.fn(), isCompacting: false },
 			loadingAnimation: undefined,
 			statusContainer: { clear: vi.fn() },
+			compactionQueuedMessages: [],
 		} as unknown as InteractiveModeContext;
 		const controller = new CommandController(context);
 

--- a/packages/coding-agent/test/session-manager/draft.test.ts
+++ b/packages/coding-agent/test/session-manager/draft.test.ts
@@ -27,6 +27,18 @@ describe("SessionManager draft", () => {
 		expect(await session.consumeDraft()).toBeNull();
 	});
 
+	it("reads a draft without consuming the sidecar", async () => {
+		using tempDir = TempDir.createSync("@pi-session-draft-read-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		await session.flush();
+		await session.saveDraft("staged text");
+
+		expect(await session.readDraft()).toBe("staged text");
+		expect(await session.readDraft()).toBe("staged text");
+		expect(await session.consumeDraft()).toBe("staged text");
+	});
+
 	it("places the draft inside the artifacts directory so dropSession cleans it", async () => {
 		using tempDir = TempDir.createSync("@pi-session-draft-location-");
 		const session = SessionManager.create(tempDir.path(), tempDir.path());

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1,12 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Effort } from "@gajae-code/ai";
 import { onAppendOnlyModeChanged, resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
-import { getCustomThemesDir, getProjectAgentDir, Snowflake } from "@gajae-code/utils";
+import { getCustomThemesDir, getProjectAgentDir, logger, Snowflake } from "@gajae-code/utils";
 import { YAML } from "bun";
 import { withFileLock } from "../src/config/file-lock";
+import { SETTINGS_SCHEMA } from "../src/config/settings-schema";
+import { getSettingDef } from "../src/modes/components/settings-defs";
 import { createLightweightDaemonSettings } from "../src/sdk/bus/telegram-daemon-cli";
 
 describe("Settings", () => {
@@ -530,5 +532,43 @@ describe("Settings", () => {
 		const migration = schema?.properties?.session?.properties?.directoryMigration;
 		expect(migration?.default).toBe("copy-retain");
 		expect(migration?.enum).toEqual(["copy-retain", "disabled"]);
+	});
+
+	describe("busy prompt mode", () => {
+		it("derives the Interaction enum from the canonical schema", () => {
+			expect(SETTINGS_SCHEMA.busyPromptMode).toMatchObject({
+				type: "enum",
+				values: ["steer", "queue"],
+				default: "steer",
+				ui: { tab: "interaction" },
+			});
+			expect(getSettingDef("busyPromptMode")).toMatchObject({
+				path: "busyPromptMode",
+				type: "enum",
+				values: ["steer", "queue"],
+				tab: "interaction",
+			});
+		});
+		it("defaults invalid and absent values to steer while preserving queue", () => {
+			expect(Settings.isolated().get("busyPromptMode")).toBe("steer");
+			expect(Settings.isolated({ busyPromptMode: "queue" }).get("busyPromptMode")).toBe("queue");
+			expect(Settings.isolated({ busyPromptMode: "steer" }).get("busyPromptMode")).toBe("steer");
+			expect(Settings.isolated({ busyPromptMode: "later" }).get("busyPromptMode")).toBe("steer");
+			expect(Settings.isolated({ busyPromptMode: { mode: "queue" } }).get("busyPromptMode")).toBe("steer");
+		});
+
+		it("warns once for malformed persisted values without rewriting them", async () => {
+			await writeSettings({ busyPromptMode: { mode: "queue" } });
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(settings.get("busyPromptMode")).toBe("steer");
+			expect(settings.get("busyPromptMode")).toBe("steer");
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			expect(warnSpy).toHaveBeenCalledWith("Settings: invalid busyPromptMode; using steer", {
+				value: { mode: "queue" },
+			});
+			expect(await readSettings()).toEqual({ busyPromptMode: { mode: "queue" } });
+		});
 	});
 });

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -74,6 +74,13 @@ describe("matchesKey", () => {
 		setKittyProtocolActive(false);
 	});
 
+	it("matches Command+Enter through the Kitty super modifier", () => {
+		setKittyProtocolActive(true);
+		expect(matchesKey("\x1b[13;9u", "super+enter")).toBe(true);
+		expect(matchesKey("\x1b[13;9u", "enter")).toBe(false);
+		setKittyProtocolActive(false);
+	});
+
 	it("preserves keypad navigation matches when NumLock is on but modifiers are held", () => {
 		setKittyProtocolActive(true);
 		expect(matchesKey("\x1b[57400;133u", "ctrl+end")).toBe(true);
@@ -142,7 +149,7 @@ describe("parseKey", () => {
 
 	it("ignores Kitty sequences with unsupported modifiers", () => {
 		setKittyProtocolActive(true);
-		expect(parseKey("\x1b[99;9u")).toBeUndefined();
+		expect(parseKey("\x1b[99;17u")).toBeUndefined();
 		setKittyProtocolActive(false);
 	});
 });

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -80,6 +80,12 @@ describe("matchesKey", () => {
 		expect(matchesKey("\x1b[13;9u", "enter")).toBe(false);
 		setKittyProtocolActive(false);
 	});
+	it("rejects unsupported modifiers and malformed key ordering", () => {
+		setKittyProtocolActive(true);
+		expect(matchesKey("\r", "meta+enter")).toBe(false);
+		expect(matchesKey("\x1b[13;5u", "enter+ctrl")).toBe(false);
+		setKittyProtocolActive(false);
+	});
 
 	it("preserves keypad navigation matches when NumLock is on but modifiers are held", () => {
 		setKittyProtocolActive(true);

--- a/scripts/generate-json-schemas.test.ts
+++ b/scripts/generate-json-schemas.test.ts
@@ -68,6 +68,13 @@ describe("generated JSON Schemas", () => {
 		})).toBe(false);
 	});
 
+	it("emits busy prompt mode enum and default", () => {
+		const schema = configSchema() as any;
+		expect(schema.properties.busyPromptMode).toMatchObject({
+			enum: ["steer", "queue"],
+			default: "steer",
+		});
+	});
 	it("emits web search fallback item enum and provider webSearch enum", () => {
 		const configSchema = JSON_SCHEMA_OUTPUTS.find(output => output.path === "schemas/config.schema.json")?.schema as any;
 		const fallbackItems = configSchema.properties.web_search.properties.fallback.items;


### PR DESCRIPTION
## Summary
- add schema-backed busy prompt routing with `steer` and `queue`, defaulting to `steer`
- add macOS Command+Enter one-message inversion through `app.message.oppositeBusyMode`
- resolve the prior review findings: active opposite-mode dispatch wins over colliding built-in actions, and synchronous draft claiming prevents rapid duplicate submissions

## Verification
- `bun test packages/tui/test/keys.test.ts packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/config-cli.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/input-controller-skill-queue.test.ts packages/coding-agent/test/interactive-mode-editor-component.test.ts packages/coding-agent/test/keybindings-audit.test.ts packages/coding-agent/test/keybindings-display.test.ts packages/coding-agent/test/agent-session-queued-prompts.test.ts packages/coding-agent/test/agent-session-steer-interrupt.test.ts scripts/generate-json-schemas.test.ts`
- `bun --cwd=packages/coding-agent run check:schemas`
- `bun --cwd=packages/coding-agent run check:types`
- `cargo test -p pi-natives keys::tests::parse_key_supports_kitty_super_modifier`
- `cargo fmt --check -- crates/pi-natives/src/keys.rs`

Replaces #2405.