### PR TITLE
test(coding-agent): repair managed SDK lifecycle fixture scope

### DIFF
--- a/packages/coding-agent/test/helpers/sdk-lifecycle-fixture.ts
+++ b/packages/coding-agent/test/helpers/sdk-lifecycle-fixture.ts
@@ -121,7 +121,7 @@ export async function createLifecycleFixture(): Promise<LifecycleFixture> {
 	const agentDir = path.join(repo, ".gjc", "agent");
 	const stateRoot = path.join(repo, ".gjc", "state");
 	const environment = createFixtureBrokerEnvironment(repo, agentDir);
-	const fixtureSessionDir = path.join(agentDir, "sessions", "-");
+	const fixtureSessionDir = SessionManager.getDefaultSessionDir(repo, agentDir);
 	const started = await startFixtureBrokerWithLeaseForTest({ agentDir, env: environment });
 	const cleanup = createFixtureRootCleanup(repo, agentDir, started.lease);
 	return {


### PR DESCRIPTION
## Summary
- create saved SDK lifecycle fixture sessions in the canonical managed workspace scope
- fix postmerge shard-5 `invalid_input` failures without changing product behavior

## Evidence
- `bun --cwd=packages/coding-agent test test/sdk-machine-lifecycle-topology.test.ts`: 3 pass, 0 fail, 109 assertions
- exact postmerge failure: Dev CI 29545493266 shard 5 rejected the legacy hardcoded `sessions/-` path

Postmerge follow-up for #2451 / #2462.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*