### PR TITLE
fix(coding-agent): bind ultragoal ask handoffs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,9 @@
 ### Fixed
 - Active deep-interview sessions now resume automatically after a normal assistant stop while ordinary active interviewing remains eligible, using bounded workflow-state continuation; recovery, leak, stale-state, handoff, and crystallization blocks remain Stop-gate handled.
 
+### Fixed
+- Ultragoal ask guards now release only after a receipt-backed same-session handoff to deep-interview or ralplan, while malformed, stale, ambiguous, forged, or still-active Ultragoal state remains fail-closed.
+
 ## [0.11.0] - 2026-07-15
 
 ### Fixed

--- a/packages/coding-agent/src/gjc-runtime/session-layout.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-layout.ts
@@ -153,6 +153,12 @@ export function auditPath(cwd: string, gjcSessionId: string): string {
 export function transactionJournalPath(cwd: string, gjcSessionId: string, mutationId: string): string {
 	return path.join(sessionStateDir(cwd, gjcSessionId), "transactions", `${encodeSessionSegment(mutationId)}.json`);
 }
+export function workflowTransactionLockPath(cwd: string, gjcSessionId: string): string {
+	return path.join(sessionStateDir(cwd, gjcSessionId), "workflow-transaction");
+}
+export function ultragoalAskHandoffCommitPath(cwd: string, gjcSessionId: string, mutationId: string): string {
+	return path.join(sessionStateDir(cwd, gjcSessionId), "handoff-commits", `${encodeSessionSegment(mutationId)}.json`);
+}
 export function teamStateRoot(cwd: string, gjcSessionId: string): string {
 	return path.join(sessionStateDir(cwd, gjcSessionId), "team");
 }

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -24,11 +24,23 @@ import {
 	WORKFLOW_STATE_VERSION,
 	type WorkflowStateMutationOwner,
 	type WorkflowStateReceipt,
+	workflowActiveStatePath,
+	workflowStateStoragePath,
 } from "../skill-state/workflow-state-contract";
 import { renderCliWriteReceipt } from "./cli-write-receipt";
 import { applyAmbiguityFloorToEnvelope } from "./deep-interview-ambiguity";
 import { mergeDeepInterviewEnvelope, normalizeDeepInterviewEnvelope } from "./deep-interview-state";
-import { activeSnapshotPath, auditPath, modeStatePath, sessionStateDir } from "./session-layout";
+import {
+	activeEntryPath,
+	activeSnapshotPath,
+	activeStateDir,
+	auditPath,
+	modeStatePath,
+	sessionStateDir,
+	transactionJournalPath,
+	ultragoalAskHandoffCommitPath,
+	workflowTransactionLockPath,
+} from "./session-layout";
 import {
 	resolveGjcSessionForRead,
 	resolveGjcSessionForWrite,
@@ -53,6 +65,7 @@ import {
 	appendAuditEntry,
 	beginWorkflowTransactionJournal,
 	completeWorkflowTransactionJournal,
+	createJsonNoClobber,
 	detectWorkflowEnvelopeIntegrityMismatch,
 	type GenericHardPruneTarget,
 	hardPrune,
@@ -61,8 +74,15 @@ import {
 	softDelete,
 	updateWorkflowTransactionJournal,
 	type WorkflowEnvelopeIntegrityMismatch,
+	withWorkflowStateLock,
 	writeGuardedWorkflowEnvelopeAtomic,
 } from "./state-writer";
+import {
+	deriveUltragoalAskAuthorityPlanBinding,
+	readUltragoalLedger,
+	readUltragoalPlan,
+	type UltragoalAskAuthorityPlanBinding,
+} from "./ultragoal-runtime";
 import { getSkillManifest, isKnownWorkflowState, isValidTransition, typedArgsFor } from "./workflow-manifest";
 
 /**
@@ -426,7 +446,12 @@ async function readJsonValue(filePath: string): Promise<unknown | null> {
 	}
 }
 
-type DoctorProblemType = "orphan_journal" | "checksum_mismatch" | "schema_violation" | "stale_active_state";
+type DoctorProblemType =
+	| "orphan_journal"
+	| "pending_transaction"
+	| "checksum_mismatch"
+	| "schema_violation"
+	| "stale_active_state";
 
 interface DoctorProblem {
 	type: DoctorProblemType;
@@ -543,6 +568,348 @@ function pushPhaseDriftProblem(options: {
 		),
 	);
 }
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+	return Object.keys(value).length === keys.length && keys.every(key => Object.hasOwn(value, key));
+}
+
+const COMMITTED_ASK_HANDOFF_AUTHORITY_KEYS = [
+	"version",
+	"commitment",
+	"caller",
+	"callee",
+	"session_id",
+	"plan_run_id",
+	"plan_generation",
+	"plan_content_sha256",
+	"plan_state_revision",
+	"plan_created_event_id",
+	"ledger_generation",
+	"ledger_head_sha256",
+	"ledger_head_event_id",
+	"caller_state_revision",
+	"callee_state_revision",
+	"handoff_at",
+	"mutation_id",
+	"caller_receipt",
+	"callee_receipt",
+] as const;
+
+const HANDOFF_RECEIPT_KEYS = [
+	"version",
+	"skill",
+	"owner",
+	"command",
+	"state_path",
+	"storage_path",
+	"mutated_at",
+	"fresh_until",
+	"status",
+	"mutation_id",
+] as const;
+function nonEmptyStringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function validPastTimestamp(value: unknown): value is string {
+	const timestamp = typeof value === "string" ? Date.parse(value) : Number.NaN;
+	return Number.isFinite(timestamp) && timestamp <= Date.now();
+}
+
+function hasDurablyIssuedHandoffReceipt(input: {
+	value: unknown;
+	skill: CanonicalGjcWorkflowSkill;
+	callee: string;
+	sessionId: string;
+	handoffAt: unknown;
+	mutationId: unknown;
+	cwd: string;
+}): boolean {
+	if (!isPlainObject(input.value) || !hasExactKeys(input.value, HANDOFF_RECEIPT_KEYS)) return false;
+	const freshUntil = Date.parse(nonEmptyStringValue(input.value.fresh_until) ?? "");
+	const handoffTime = Date.parse(typeof input.handoffAt === "string" ? input.handoffAt : "");
+	return (
+		input.value.version === 1 &&
+		input.value.skill === input.skill &&
+		input.value.owner === "gjc-state-cli" &&
+		input.value.command === `gjc state ultragoal handoff --to ${input.callee}` &&
+		input.value.state_path === workflowActiveStatePath(input.cwd, input.sessionId) &&
+		input.value.storage_path === workflowStateStoragePath(input.cwd, input.skill, input.sessionId) &&
+		input.value.mutated_at === input.handoffAt &&
+		Number.isFinite(handoffTime) &&
+		Number.isFinite(freshUntil) &&
+		freshUntil >= handoffTime &&
+		input.value.status === "fresh" &&
+		input.value.mutation_id === input.mutationId
+	);
+}
+
+function hasBoundHandoffEnvelope(input: {
+	value: unknown;
+	skill: CanonicalGjcWorkflowSkill;
+	sessionId: string;
+	active: boolean;
+	authority: Record<string, unknown>;
+	receiptKey: "caller_receipt" | "callee_receipt";
+	revisionKey: "caller_state_revision" | "callee_state_revision";
+	cwd: string;
+}): boolean {
+	if (!isPlainObject(input.value)) return false;
+	const expectedReceipt = input.authority[input.receiptKey];
+	const receipt = input.value.receipt;
+	if (
+		!hasDurablyIssuedHandoffReceipt({
+			value: expectedReceipt,
+			skill: input.skill,
+			callee: input.authority.callee as string,
+			sessionId: input.sessionId,
+			handoffAt: input.authority.handoff_at,
+			mutationId: input.authority.mutation_id,
+			cwd: input.cwd,
+		}) ||
+		!isPlainObject(receipt)
+	) {
+		return false;
+	}
+	const checksum = receipt.content_sha256;
+	const mutatedAt = nonEmptyStringValue(receipt.mutated_at);
+	const freshUntil = nonEmptyStringValue(receipt.fresh_until);
+	const checksumComputedAt = isPlainObject(checksum) ? nonEmptyStringValue(checksum.computed_at) : undefined;
+	return (
+		input.value.skill === input.skill &&
+		input.value.version === WORKFLOW_STATE_VERSION &&
+		input.value.session_id === input.sessionId &&
+		input.value.active === input.active &&
+		input.value.current_phase === (input.active ? initialPhaseForSkill(input.skill) : "handoff") &&
+		(input.active
+			? input.value.handoff_from === input.authority.caller
+			: input.value.handoff_to === input.authority.callee) &&
+		input.value.handoff_at === input.authority.handoff_at &&
+		input.value.state_revision === input.authority[input.revisionKey] &&
+		HANDOFF_RECEIPT_KEYS.every(key => receipt[key] === (expectedReceipt as Record<string, unknown>)[key]) &&
+		receipt.skill === input.skill &&
+		receipt.status === "fresh" &&
+		Boolean(mutatedAt && validPastTimestamp(mutatedAt)) &&
+		Boolean(
+			freshUntil && Number.isFinite(Date.parse(freshUntil)) && Date.parse(freshUntil) >= Date.parse(mutatedAt ?? ""),
+		) &&
+		isPlainObject(checksum) &&
+		checksum.algorithm === "sha256" &&
+		typeof checksum.value === "string" &&
+		/^[a-f0-9]{64}$/i.test(checksum.value) &&
+		checksum.covered_path === modeStatePath(input.cwd, input.sessionId, input.skill) &&
+		Boolean(checksumComputedAt && validPastTimestamp(checksumComputedAt))
+	);
+}
+
+function hasAuthoritativeHandoffEntry(input: {
+	value: unknown;
+	skill: CanonicalGjcWorkflowSkill;
+	sessionId: string;
+	active: boolean;
+	authority: Record<string, unknown>;
+	receiptKey: "caller_receipt" | "callee_receipt";
+}): boolean {
+	if (!isPlainObject(input.value) || !isPlainObject(input.authority[input.receiptKey])) return false;
+	const receipt = input.value.receipt;
+	const expectedReceipt = input.authority[input.receiptKey] as Record<string, unknown>;
+	return (
+		input.value.skill === input.skill &&
+		input.value.session_id === input.sessionId &&
+		input.value.active === input.active &&
+		input.value.phase === (input.active ? initialPhaseForSkill(input.skill) : "handoff") &&
+		(input.active
+			? input.value.handoff_from === input.authority.caller
+			: input.value.handoff_to === input.authority.callee) &&
+		input.value.handoff_at === input.authority.handoff_at &&
+		isPlainObject(receipt) &&
+		HANDOFF_RECEIPT_KEYS.every(key => receipt[key] === expectedReceipt[key])
+	);
+}
+function hasVerifiedHandoffSnapshot(input: {
+	value: unknown;
+	callerEntry: Record<string, unknown>;
+	calleeEntry: Record<string, unknown>;
+	callee: CanonicalGjcWorkflowSkill;
+	sessionId: string;
+}): boolean {
+	if (!isPlainObject(input.value) || !Array.isArray(input.value.active_skills)) return false;
+	return (
+		input.value.version === 1 &&
+		input.value.active === true &&
+		input.value.skill === input.callee &&
+		input.value.phase === initialPhaseForSkill(input.callee) &&
+		input.value.session_id === input.sessionId &&
+		input.value.updated_at === input.calleeEntry.updated_at &&
+		JSON.stringify(input.value.active_skills) === JSON.stringify([input.calleeEntry, input.callerEntry])
+	);
+}
+
+async function recoverCommittedAskHandoffJournal(input: {
+	cwd: string;
+	sessionId: string;
+	journalPath: string;
+	journal: Record<string, unknown>;
+}): Promise<boolean> {
+	const mutationId = typeof input.journal.mutation_id === "string" ? input.journal.mutation_id : "";
+	const callee = typeof input.journal.callee === "string" ? input.journal.callee : "";
+	const canonicalCallee = canonicalWorkflowSkill(callee);
+	const requiredSteps = ["callee-mode-state", "caller-mode-state", "active-state", "ask-commit"];
+	const commitPath = ultragoalAskHandoffCommitPath(input.cwd, input.sessionId, mutationId);
+	const callerPath = modeStateFile(input.cwd, "ultragoal", input.sessionId);
+	const calleePath = canonicalCallee ? modeStateFile(input.cwd, canonicalCallee, input.sessionId) : "";
+	const expectedPaths = [calleePath, callerPath, activeStateFile(input.cwd, input.sessionId), commitPath];
+	const journalPaths = input.journal.paths;
+	const steps = input.journal.steps;
+	const createdAt = typeof input.journal.created_at === "string" ? Date.parse(input.journal.created_at) : Number.NaN;
+	const updatedAt = typeof input.journal.updated_at === "string" ? Date.parse(input.journal.updated_at) : Number.NaN;
+	if (
+		input.journal.version !== 1 ||
+		input.journal.status !== "committed" ||
+		input.journal.caller !== "ultragoal" ||
+		!canonicalCallee ||
+		!["deep-interview", "ralplan"].includes(callee) ||
+		!mutationId ||
+		!Number.isFinite(createdAt) ||
+		!Number.isFinite(updatedAt) ||
+		updatedAt < createdAt ||
+		path.resolve(input.journalPath) !==
+			path.resolve(transactionJournalPath(input.cwd, input.sessionId, mutationId)) ||
+		!Array.isArray(journalPaths) ||
+		journalPaths.length !== expectedPaths.length ||
+		!journalPaths.every(
+			(value, index) => typeof value === "string" && path.resolve(value) === path.resolve(expectedPaths[index]!),
+		) ||
+		!Array.isArray(steps) ||
+		JSON.stringify(steps) !== JSON.stringify(requiredSteps)
+	) {
+		return false;
+	}
+	const [commit, callerState, calleeState, callerEntry, calleeEntry, snapshot, plan, ledger] = await Promise.all([
+		readRawJson(commitPath),
+		readRawJson(callerPath),
+		readRawJson(calleePath),
+		readRawJson(activeEntryPath(input.cwd, input.sessionId, "ultragoal")),
+		readRawJson(activeEntryPath(input.cwd, input.sessionId, callee)),
+		readRawJson(activeStateFile(input.cwd, input.sessionId)),
+		readUltragoalPlan(input.cwd, input.sessionId),
+		readUltragoalLedger(input.cwd, input.sessionId),
+	]);
+	const activeEntryDirectory = activeStateDir(input.cwd, input.sessionId);
+	let activeEntryNames: string[];
+	try {
+		activeEntryNames = await fs.readdir(activeEntryDirectory);
+	} catch {
+		return false;
+	}
+	const authoritativeEntries: Record<string, unknown>[] = [];
+	for (const name of activeEntryNames.sort()) {
+		if (!name.endsWith(".json")) return false;
+		const filePath = path.join(activeEntryDirectory, name);
+		const parsed = (await readRawJson(filePath)).value;
+		if (
+			!isPlainObject(parsed) ||
+			typeof parsed.skill !== "string" ||
+			parsed.skill.trim() === "" ||
+			path.resolve(activeEntryPath(input.cwd, input.sessionId, parsed.skill)) !== path.resolve(filePath) ||
+			typeof parsed.active !== "boolean" ||
+			parsed.session_id !== input.sessionId
+		) {
+			return false;
+		}
+		authoritativeEntries.push(parsed);
+	}
+	const activeEntries = authoritativeEntries.filter(entry => entry.active === true);
+	if (activeEntries.length !== 1 || activeEntries[0]?.skill !== canonicalCallee) return false;
+	const authority = commit.value;
+	const planBinding = plan ? deriveUltragoalAskAuthorityPlanBinding(plan, ledger) : undefined;
+	if (
+		!isPlainObject(authority) ||
+		!hasExactKeys(authority, COMMITTED_ASK_HANDOFF_AUTHORITY_KEYS) ||
+		authority.version !== 1 ||
+		authority.commitment !== "committed" ||
+		authority.caller !== "ultragoal" ||
+		authority.callee !== callee ||
+		authority.session_id !== input.sessionId ||
+		authority.mutation_id !== mutationId ||
+		authority.mutation_id !== `ultragoal:handoff:${callee}:${authority.handoff_at}` ||
+		typeof authority.caller_state_revision !== "number" ||
+		!Number.isSafeInteger(authority.caller_state_revision) ||
+		typeof authority.callee_state_revision !== "number" ||
+		!Number.isSafeInteger(authority.callee_state_revision) ||
+		!planBinding ||
+		authority.plan_run_id !== planBinding.planRunId ||
+		authority.plan_generation !== planBinding.planGeneration ||
+		authority.plan_content_sha256 !== planBinding.planContentSha256 ||
+		authority.plan_state_revision !== planBinding.planStateRevision ||
+		authority.plan_created_event_id !== planBinding.planCreatedEventId ||
+		authority.ledger_generation !== planBinding.ledgerGeneration ||
+		authority.ledger_head_sha256 !== planBinding.ledgerHeadSha256 ||
+		authority.ledger_head_event_id !== planBinding.ledgerHeadEventId ||
+		!isPlainObject(callerState.value) ||
+		!isPlainObject(calleeState.value) ||
+		callerState.value.ultragoal_ask_handoff === undefined ||
+		calleeState.value.ultragoal_ask_handoff === undefined ||
+		JSON.stringify(callerState.value.ultragoal_ask_handoff) !== JSON.stringify(authority) ||
+		JSON.stringify(calleeState.value.ultragoal_ask_handoff) !== JSON.stringify(authority) ||
+		!hasBoundHandoffEnvelope({
+			value: callerState.value,
+			skill: "ultragoal",
+			sessionId: input.sessionId,
+			active: false,
+			authority,
+			receiptKey: "caller_receipt",
+			revisionKey: "caller_state_revision",
+			cwd: input.cwd,
+		}) ||
+		!hasBoundHandoffEnvelope({
+			value: calleeState.value,
+			skill: canonicalCallee,
+			sessionId: input.sessionId,
+			active: true,
+			authority,
+			receiptKey: "callee_receipt",
+			revisionKey: "callee_state_revision",
+			cwd: input.cwd,
+		}) ||
+		!hasAuthoritativeHandoffEntry({
+			value: callerEntry.value,
+			skill: "ultragoal",
+			sessionId: input.sessionId,
+			active: false,
+			authority,
+			receiptKey: "caller_receipt",
+		}) ||
+		!hasAuthoritativeHandoffEntry({
+			value: calleeEntry.value,
+			skill: canonicalCallee,
+			sessionId: input.sessionId,
+			active: true,
+			authority,
+			receiptKey: "callee_receipt",
+		}) ||
+		!isPlainObject(callerEntry.value) ||
+		!isPlainObject(calleeEntry.value) ||
+		!hasVerifiedHandoffSnapshot({
+			value: snapshot.value,
+			callerEntry: callerEntry.value,
+			calleeEntry: calleeEntry.value,
+			callee: canonicalCallee,
+			sessionId: input.sessionId,
+		}) ||
+		(await detectWorkflowEnvelopeIntegrityMismatch(callerPath)) !== undefined ||
+		(await detectWorkflowEnvelopeIntegrityMismatch(calleePath)) !== undefined
+	) {
+		return false;
+	}
+	await fs.rm(input.journalPath);
+	const journalDirectory = await fs.open(path.dirname(input.journalPath), "r");
+	try {
+		await journalDirectory.sync();
+	} finally {
+		await journalDirectory.close();
+	}
+	return true;
+}
 
 async function collectDoctorSummary(
 	cwd: string,
@@ -610,7 +977,37 @@ async function collectDoctorSummary(
 		const status = isPlainObject(value) && typeof value.status === "string" ? value.status : undefined;
 		const paths =
 			isPlainObject(value) && Array.isArray(value.paths) ? value.paths.filter(p => typeof p === "string") : [];
-		const hasLiveMutation = status === "pending" && paths.some(filePath => path.resolve(filePath).startsWith(root));
+		const steps =
+			isPlainObject(value) && Array.isArray(value.steps) ? value.steps.filter(step => typeof step === "string") : [];
+		if (status === "pending") {
+			problems.push(
+				doctorProblem(
+					"pending_transaction",
+					journalPath,
+					`transaction remains pending after durable steps: ${steps.join(", ") || "none"}`,
+					"gjc state doctor --json",
+				),
+			);
+			continue;
+		}
+		if (status === "committed") {
+			if (
+				isPlainObject(value) &&
+				(await recoverCommittedAskHandoffJournal({ cwd, sessionId, journalPath, journal: value }))
+			) {
+				continue;
+			}
+			problems.push(
+				doctorProblem(
+					"orphan_journal",
+					journalPath,
+					`committed transaction journal is incomplete or cannot be verified after steps: ${steps.join(", ") || "none"}`,
+					"gjc state doctor --json",
+				),
+			);
+			continue;
+		}
+		const hasLiveMutation = paths.some(filePath => path.resolve(filePath).startsWith(root));
 		if (!hasLiveMutation) {
 			problems.push(
 				doctorProblem(
@@ -707,6 +1104,7 @@ async function collectDoctorSummary(
 	);
 	const byKind: Record<DoctorProblemType, number> = {
 		orphan_journal: 0,
+		pending_transaction: 0,
 		checksum_mismatch: 0,
 		schema_violation: 0,
 		stale_active_state: 0,
@@ -759,10 +1157,11 @@ async function handleDoctor(
 		payloadSessionId: payload?.session_id,
 		envSessionId: process.env.GJC_SESSION_ID,
 	});
-	const summary = await collectDoctorSummary(
-		cwd,
-		rawSkill as CanonicalGjcWorkflowSkill | undefined,
-		session.gjcSessionId,
+	const summary = await withWorkflowStateLock(
+		workflowTransactionLockPath(cwd, session.gjcSessionId),
+		async () =>
+			await collectDoctorSummary(cwd, rawSkill as CanonicalGjcWorkflowSkill | undefined, session.gjcSessionId),
+		{ cwd },
 	);
 	return {
 		status: summary.ok ? 0 : 1,
@@ -940,6 +1339,146 @@ async function readAuditWindow(
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+const ULTRAGOAL_ASK_HANDOFF_CALLEES = new Set(["deep-interview", "ralplan"]);
+
+interface UltragoalAskHandoffAuthority {
+	version: 1;
+	commitment: "committed";
+	caller: "ultragoal";
+	callee: "deep-interview" | "ralplan";
+	session_id: string;
+	plan_run_id: string;
+	plan_generation: string;
+	plan_content_sha256: string;
+	plan_state_revision: number;
+	plan_created_event_id: string;
+	ledger_generation: number;
+	ledger_head_sha256: string;
+	ledger_head_event_id: string;
+	caller_state_revision: number;
+	callee_state_revision: number;
+	handoff_at: string;
+	mutation_id: string;
+	caller_receipt: WorkflowStateReceipt;
+	callee_receipt: WorkflowStateReceipt;
+}
+
+function isUltragoalAskHandoffCallee(value: string): value is UltragoalAskHandoffAuthority["callee"] {
+	return ULTRAGOAL_ASK_HANDOFF_CALLEES.has(value);
+}
+
+function withoutUltragoalAskHandoffAuthority(state: Record<string, unknown>): Record<string, unknown> {
+	const { ultragoal_ask_handoff: _discarded, ...remaining } = state;
+	return remaining;
+}
+
+async function readUltragoalAskAuthorityPlanBinding(
+	cwd: string,
+	sessionId: string,
+): Promise<UltragoalAskAuthorityPlanBinding | undefined> {
+	const [plan, ledger] = await Promise.all([readUltragoalPlan(cwd, sessionId), readUltragoalLedger(cwd, sessionId)]);
+	return plan ? deriveUltragoalAskAuthorityPlanBinding(plan, ledger) : undefined;
+}
+
+function buildUltragoalAskHandoffAuthority(input: {
+	callee: UltragoalAskHandoffAuthority["callee"];
+	sessionId: string;
+	plan: UltragoalAskAuthorityPlanBinding;
+	callerStateRevision: number;
+	calleeStateRevision: number;
+	handoffAt: string;
+	mutationId: string;
+	callerReceipt: WorkflowStateReceipt;
+	calleeReceipt: WorkflowStateReceipt;
+}): UltragoalAskHandoffAuthority {
+	return {
+		version: 1,
+		commitment: "committed",
+		caller: "ultragoal",
+		callee: input.callee,
+		session_id: input.sessionId,
+		plan_run_id: input.plan.planRunId,
+		plan_generation: input.plan.planGeneration,
+		plan_content_sha256: input.plan.planContentSha256,
+		plan_state_revision: input.plan.planStateRevision,
+		plan_created_event_id: input.plan.planCreatedEventId,
+		ledger_generation: input.plan.ledgerGeneration,
+		ledger_head_sha256: input.plan.ledgerHeadSha256,
+		ledger_head_event_id: input.plan.ledgerHeadEventId,
+		caller_state_revision: input.callerStateRevision,
+		callee_state_revision: input.calleeStateRevision,
+		handoff_at: input.handoffAt,
+		mutation_id: input.mutationId,
+		caller_receipt: input.callerReceipt,
+		callee_receipt: input.calleeReceipt,
+	};
+}
+async function assertUltragoalAskHandoffCaller(input: {
+	cwd: string;
+	sessionId: string;
+	callerPath: string;
+	callerState: Record<string, unknown>;
+}): Promise<void> {
+	if (
+		input.callerState.active !== true ||
+		input.callerState.current_phase !== "handoff" ||
+		input.callerState.session_id !== input.sessionId
+	) {
+		throw new StateCommandError(
+			2,
+			"gjc state ultragoal handoff requires an active same-session caller in the handoff phase",
+		);
+	}
+	if ((await detectWorkflowEnvelopeIntegrityMismatch(input.callerPath)) !== undefined) {
+		throw new StateCommandError(2, "gjc state ultragoal handoff caller integrity check failed");
+	}
+	const entryPath = activeEntryPath(input.cwd, input.sessionId, "ultragoal");
+	let entry: unknown;
+	try {
+		entry = JSON.parse(await fs.readFile(entryPath, "utf8"));
+	} catch (error) {
+		throw new StateCommandError(
+			2,
+			`gjc state ultragoal handoff requires an authoritative active caller entry: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+	if (
+		!isPlainObject(entry) ||
+		entry.skill !== "ultragoal" ||
+		entry.active !== true ||
+		entry.phase !== "handoff" ||
+		entry.session_id !== input.sessionId
+	) {
+		throw new StateCommandError(
+			2,
+			"gjc state ultragoal handoff requires a matching active authoritative caller entry in the handoff phase",
+		);
+	}
+}
+
+async function createDurableUltragoalAskHandoffCommit(
+	cwd: string,
+	sessionId: string,
+	mutationId: string,
+	authority: UltragoalAskHandoffAuthority,
+): Promise<void> {
+	const commitPath = ultragoalAskHandoffCommitPath(cwd, sessionId, mutationId);
+	await createJsonNoClobber(commitPath, authority, { cwd });
+	const commitFile = await fs.open(commitPath, "r");
+	try {
+		await commitFile.sync();
+	} finally {
+		await commitFile.close();
+	}
+	const commitDirectory = await fs.open(path.dirname(commitPath), "r");
+	try {
+		await commitDirectory.sync();
+	} finally {
+		await commitDirectory.close();
+	}
 }
 
 /**
@@ -1132,105 +1671,110 @@ export async function reconcileWorkflowSkillState(options: {
 		payloadSessionId: options.sessionId,
 		envSessionId: process.env.GJC_SESSION_ID,
 	});
-	const filePath = modeStateFile(cwd, mode, sessionId);
-	const existingRead = await readExistingStateForMutation(filePath);
-	const existingPayload = existingRead.kind === "valid" ? existingRead.value : {};
-	const nowIsoStr = nowIso();
-	const mutationId = `${mode}:reconcile:${nowIsoStr}`;
+	return await withWorkflowStateLock(
+		workflowTransactionLockPath(cwd, sessionId),
+		async () => {
+			const filePath = modeStateFile(cwd, mode, sessionId);
+			const existingRead = await readExistingStateForMutation(filePath);
+			const existingPayload = existingRead.kind === "valid" ? existingRead.value : {};
+			const nowIsoStr = nowIso();
+			const mutationId = `${mode}:reconcile:${nowIsoStr}`;
 
-	const trimmedPhase = options.phase.trim();
-	const manifestStates = new Set(getSkillManifest(mode).states.map(state => state.id));
-	if (!manifestStates.has(trimmedPhase)) {
-		throw new StateCommandError(2, `unknown ${mode} phase "${trimmedPhase}" for reconciliation`);
-	}
+			const trimmedPhase = options.phase.trim();
+			const manifestStates = new Set(getSkillManifest(mode).states.map(state => state.id));
+			if (!manifestStates.has(trimmedPhase)) {
+				throw new StateCommandError(2, `unknown ${mode} phase "${trimmedPhase}" for reconciliation`);
+			}
 
-	const fromPhase =
-		typeof existingPayload.current_phase === "string" ? existingPayload.current_phase.trim() : undefined;
-	const receipt = buildWorkflowStateReceipt({
-		cwd,
-		skill: mode,
-		owner: "gjc-runtime",
-		command: `gjc ${mode} (reconcile)`,
-		sessionId,
-		nowIso: nowIsoStr,
-		mutationId,
-	});
-	receipt.verb = "reconcile";
-	receipt.forced = true;
-	receipt.from_phase = fromPhase;
-	receipt.to_phase = trimmedPhase;
+			const fromPhase =
+				typeof existingPayload.current_phase === "string" ? existingPayload.current_phase.trim() : undefined;
+			const receipt = buildWorkflowStateReceipt({
+				cwd,
+				skill: mode,
+				owner: "gjc-runtime",
+				command: `gjc ${mode} (reconcile)`,
+				sessionId,
+				nowIso: nowIsoStr,
+				mutationId,
+			});
+			receipt.verb = "reconcile";
+			receipt.forced = true;
+			receipt.from_phase = fromPhase;
+			receipt.to_phase = trimmedPhase;
 
-	const merged =
-		mode === "deep-interview"
-			? // Enforce the deterministic ambiguity floor on every reconcile so a
-				// self-reported score can never undercut persisted contradiction evidence.
-				(applyAmbiguityFloorToEnvelope(mergeDeepInterviewEnvelope(existingPayload, payload)).envelope as Record<
-					string,
-					unknown
-				>)
-			: mergeWithNullDelete(existingPayload, payload);
-	merged.skill = mode;
-	merged.current_phase = trimmedPhase;
-	merged.active = active;
-	merged.version = WORKFLOW_STATE_VERSION;
-	merged.updated_at = nowIsoStr;
-	merged.receipt = receipt;
-	if (sessionId && typeof merged.session_id !== "string") merged.session_id = sessionId;
+			let merged =
+				mode === "deep-interview"
+					? // Enforce the deterministic ambiguity floor on every reconcile so a
+						// self-reported score can never undercut persisted contradiction evidence.
+						(applyAmbiguityFloorToEnvelope(mergeDeepInterviewEnvelope(existingPayload, payload))
+							.envelope as Record<string, unknown>)
+					: mergeWithNullDelete(existingPayload, payload);
+			merged = withoutUltragoalAskHandoffAuthority(merged);
+			merged.skill = mode;
+			merged.current_phase = trimmedPhase;
+			merged.active = active;
+			merged.version = WORKFLOW_STATE_VERSION;
+			merged.updated_at = nowIsoStr;
+			merged.receipt = receipt;
+			if (sessionId && typeof merged.session_id !== "string") merged.session_id = sessionId;
 
-	const validation = validateWorkflowStateEnvelope(mode, merged);
-	if (!validation.valid) throw new StateCommandError(2, validation.error ?? `invalid ${mode} state envelope`);
+			const validation = validateWorkflowStateEnvelope(mode, merged);
+			if (!validation.valid) throw new StateCommandError(2, validation.error ?? `invalid ${mode} state envelope`);
 
-	if (existingRead.kind === "corrupt") await fs.rm(filePath, { force: true });
-	await writeGuardedWorkflowEnvelopeAtomic(filePath, merged, {
-		cwd,
-		policy: "source",
-		receipt: {
-			cwd,
-			skill: mode,
-			owner: "gjc-runtime",
-			command: `gjc ${mode} (reconcile)`,
-			sessionId,
-			nowIso: nowIsoStr,
-			mutationId,
-			verb: "reconcile",
-			forced: true,
-			fromPhase,
-			toPhase: trimmedPhase,
+			if (existingRead.kind === "corrupt") await fs.rm(filePath, { force: true });
+			await writeGuardedWorkflowEnvelopeAtomic(filePath, merged, {
+				cwd,
+				policy: "source",
+				receipt: {
+					cwd,
+					skill: mode,
+					owner: "gjc-runtime",
+					command: `gjc ${mode} (reconcile)`,
+					sessionId,
+					nowIso: nowIsoStr,
+					mutationId,
+					verb: "reconcile",
+					forced: true,
+					fromPhase,
+					toPhase: trimmedPhase,
+				},
+				audit: {
+					category: "state",
+					verb: "reconcile",
+					owner: "gjc-runtime",
+					sessionId,
+					skill: mode,
+					mutationId,
+					forced: true,
+					fromPhase,
+					toPhase: trimmedPhase,
+				},
+			});
+			const persisted = (await readJsonFile(filePath)) ?? {};
+			const sourceRevision = options.sourceRevision ?? existingStateRevision(persisted);
+
+			// Reconciliation drives the active-state/HUD update directly (not via the
+			// best-effort syncWorkflowSkillState wrapper) so a failed HUD/active-state write
+			// is surfaced to the caller and recorded as a reconcile failure, rather than
+			// silently leaving a stale chip behind a freshly reconciled mode-state.
+			await syncSkillActiveState({
+				cwd,
+				skill: mode,
+				active,
+				phase: trimmedPhase,
+				sessionId,
+				threadId,
+				turnId,
+				source: "gjc-runtime-reconcile",
+				hud: buildHudForMode(mode, merged),
+				receipt,
+				sourceRevision,
+			});
+			await touchStateActivityMarker(cwd, sessionId, filePath);
+			return { stateFile: filePath };
 		},
-		audit: {
-			category: "state",
-			verb: "reconcile",
-			owner: "gjc-runtime",
-			sessionId,
-			skill: mode,
-			mutationId,
-			forced: true,
-			fromPhase,
-			toPhase: trimmedPhase,
-		},
-	});
-	const persisted = (await readJsonFile(filePath)) ?? {};
-	const sourceRevision = options.sourceRevision ?? existingStateRevision(persisted);
-
-	// Reconciliation drives the active-state/HUD update directly (not via the
-	// best-effort syncWorkflowSkillState wrapper) so a failed HUD/active-state write
-	// is surfaced to the caller and recorded as a reconcile failure, rather than
-	// silently leaving a stale chip behind a freshly reconciled mode-state.
-	await syncSkillActiveState({
-		cwd,
-		skill: mode,
-		active,
-		phase: trimmedPhase,
-		sessionId,
-		threadId,
-		turnId,
-		source: "gjc-runtime-reconcile",
-		hud: buildHudForMode(mode, merged),
-		receipt,
-		sourceRevision,
-	});
-	await touchStateActivityMarker(cwd, sessionId, filePath);
-	return { stateFile: filePath };
+		{ cwd },
+	);
 }
 export async function readWorkflowStateJson(
 	cwd: string,
@@ -1330,134 +1874,151 @@ async function handleWrite(
 			"gjc state write requires --mode <skill>, positional <skill>, input.skill, or an active workflow in the current session active state",
 		);
 
-	const filePath = modeStateFile(cwd, mode, sessionId);
-	const forced = hasFlag(args, "--force");
-	const existingRead = await readExistingStateForMutation(filePath);
-	if (existingRead.kind === "corrupt" && !forced) {
-		throw new StateCommandError(
-			2,
-			`existing state for ${mode} is corrupt or tampered (${existingRead.error}); use --force to overwrite`,
-		);
-	}
-	const existingPayload = existingRead.kind === "valid" ? existingRead.value : {};
-	const nowIsoStr = nowIso();
-	const mutationId = `${mode}:${nowIsoStr}`;
-	const receipt = buildWorkflowStateReceipt({
-		cwd,
-		skill: mode,
-		owner: "gjc-state-cli",
-		command: `gjc state ${mode} write`,
-		sessionId,
-		nowIso: nowIsoStr,
-		mutationId,
-	});
-	const innerState = (payload.state as Record<string, unknown> | undefined) ?? {};
-	const incomingPhase =
-		typeof payload.current_phase === "string" && payload.current_phase.trim()
-			? payload.current_phase.trim()
-			: typeof payload.phase === "string" && payload.phase.trim()
-				? payload.phase.trim()
-				: typeof innerState.current_phase === "string" && (innerState.current_phase as string).trim()
-					? (innerState.current_phase as string).trim()
-					: undefined;
-	let merged: Record<string, unknown>;
-	if (mode === "deep-interview") {
-		// Deep-interview keeps interview data nested under `state` and merges rounds
-		// losslessly by durable key; never flatten or delete `state` (that drops recorder history).
-		// The deterministic ambiguity floor is applied after the merge so a reported
-		// score written through the CLI can never undercut persisted contradiction evidence.
-		merged = applyAmbiguityFloorToEnvelope(
-			mergeDeepInterviewEnvelope(existingPayload, payload, { replace: hasFlag(args, "--replace") }),
-		).envelope;
-	} else if (hasFlag(args, "--replace")) {
-		merged = { ...payload };
-	} else {
-		merged = mergeWithNullDelete(existingPayload, payload);
-		// Flatten payload.state.* into the top-level envelope so downstream consumers
-		// see a single canonical structure with the receipt at top level.
-		if (payload.state && typeof payload.state === "object" && !Array.isArray(payload.state)) {
-			merged = mergeWithNullDelete(merged, payload.state as Record<string, unknown>);
-			delete merged.state;
-		}
-	}
-	const preDefaultValidation = validateWorkflowStateEnvelope(mode, merged);
-	if (!preDefaultValidation.valid) {
-		throw new StateCommandError(2, preDefaultValidation.error ?? `invalid ${mode} state envelope`);
-	}
-	merged.skill = mode;
-	if (incomingPhase) {
-		merged.current_phase = incomingPhase;
-	} else if (typeof merged.current_phase !== "string" || !merged.current_phase.trim()) {
-		const retainedPhase =
-			typeof existingPayload.current_phase === "string" ? existingPayload.current_phase.trim() : "";
-		merged.current_phase = retainedPhase || initialPhaseForSkill(mode);
-	} else {
-		merged.current_phase = merged.current_phase.trim();
-	}
-	merged.version = WORKFLOW_STATE_VERSION;
-	if (typeof merged.active !== "boolean") merged.active = true;
-	merged.updated_at = nowIsoStr;
-	merged.receipt = receipt;
-	if (sessionId && typeof merged.session_id !== "string") merged.session_id = sessionId;
+	return await withWorkflowStateLock(
+		workflowTransactionLockPath(cwd, sessionId),
+		async () => {
+			const filePath = modeStateFile(cwd, mode, sessionId);
+			const forced = hasFlag(args, "--force");
+			const existingRead = await readExistingStateForMutation(filePath);
+			if (existingRead.kind === "corrupt" && !forced) {
+				throw new StateCommandError(
+					2,
+					`existing state for ${mode} is corrupt or tampered (${existingRead.error}); use --force to overwrite`,
+				);
+			}
+			const existingPayload = existingRead.kind === "valid" ? existingRead.value : {};
+			const nowIsoStr = nowIso();
+			const mutationId = `${mode}:${nowIsoStr}`;
+			const receipt = buildWorkflowStateReceipt({
+				cwd,
+				skill: mode,
+				owner: "gjc-state-cli",
+				command: `gjc state ${mode} write`,
+				sessionId,
+				nowIso: nowIsoStr,
+				mutationId,
+			});
+			const innerState = (payload.state as Record<string, unknown> | undefined) ?? {};
+			const incomingPhase =
+				typeof payload.current_phase === "string" && payload.current_phase.trim()
+					? payload.current_phase.trim()
+					: typeof payload.phase === "string" && payload.phase.trim()
+						? payload.phase.trim()
+						: typeof innerState.current_phase === "string" && (innerState.current_phase as string).trim()
+							? (innerState.current_phase as string).trim()
+							: undefined;
+			let merged: Record<string, unknown>;
+			if (mode === "deep-interview") {
+				// Deep-interview keeps interview data nested under `state` and merges rounds
+				// losslessly by durable key; never flatten or delete `state` (that drops recorder history).
+				// The deterministic ambiguity floor is applied after the merge so a reported
+				// score written through the CLI can never undercut persisted contradiction evidence.
+				merged = applyAmbiguityFloorToEnvelope(
+					mergeDeepInterviewEnvelope(existingPayload, payload, { replace: hasFlag(args, "--replace") }),
+				).envelope;
+			} else if (hasFlag(args, "--replace")) {
+				merged = { ...payload };
+			} else {
+				merged = mergeWithNullDelete(existingPayload, payload);
+				// Flatten payload.state.* into the top-level envelope so downstream consumers
+				// see a single canonical structure with the receipt at top level.
+				if (payload.state && typeof payload.state === "object" && !Array.isArray(payload.state)) {
+					merged = mergeWithNullDelete(merged, payload.state as Record<string, unknown>);
+					delete merged.state;
+				}
+			}
+			merged = withoutUltragoalAskHandoffAuthority(merged);
+			const preDefaultValidation = validateWorkflowStateEnvelope(mode, merged);
+			if (!preDefaultValidation.valid) {
+				throw new StateCommandError(2, preDefaultValidation.error ?? `invalid ${mode} state envelope`);
+			}
+			merged.skill = mode;
+			if (incomingPhase) {
+				merged.current_phase = incomingPhase;
+			} else if (typeof merged.current_phase !== "string" || !merged.current_phase.trim()) {
+				const retainedPhase =
+					typeof existingPayload.current_phase === "string" ? existingPayload.current_phase.trim() : "";
+				merged.current_phase = retainedPhase || initialPhaseForSkill(mode);
+			} else {
+				merged.current_phase = merged.current_phase.trim();
+			}
+			merged.version = WORKFLOW_STATE_VERSION;
+			if (typeof merged.active !== "boolean") merged.active = true;
+			merged.updated_at = nowIsoStr;
+			merged.receipt = receipt;
+			if (sessionId && typeof merged.session_id !== "string") merged.session_id = sessionId;
 
-	const fromPhase =
-		typeof existingPayload.current_phase === "string" ? existingPayload.current_phase.trim() : undefined;
-	const toPhase = merged.current_phase as string;
-	const manifestStates = new Set(getSkillManifest(mode).states.map(state => state.id));
-	if (!manifestStates.has(toPhase) && !forced) {
-		throw new StateCommandError(2, `unknown ${mode} phase "${toPhase}"; use --force to bypass`);
-	}
-	if (fromPhase && toPhase && isKnownWorkflowState(mode, fromPhase) && isKnownWorkflowState(mode, toPhase)) {
-		if (!isValidTransition(mode, fromPhase, toPhase) && !forced) {
-			throw new StateCommandError(
-				2,
-				`invalid ${mode} phase transition from ${fromPhase} to ${toPhase}; use --force to bypass`,
-			);
-		}
-	}
+			const fromPhase =
+				typeof existingPayload.current_phase === "string" ? existingPayload.current_phase.trim() : undefined;
+			const toPhase = merged.current_phase as string;
+			const manifestStates = new Set(getSkillManifest(mode).states.map(state => state.id));
+			if (!manifestStates.has(toPhase) && !forced) {
+				throw new StateCommandError(2, `unknown ${mode} phase "${toPhase}"; use --force to bypass`);
+			}
+			if (fromPhase && toPhase && isKnownWorkflowState(mode, fromPhase) && isKnownWorkflowState(mode, toPhase)) {
+				if (!isValidTransition(mode, fromPhase, toPhase) && !forced) {
+					throw new StateCommandError(
+						2,
+						`invalid ${mode} phase transition from ${fromPhase} to ${toPhase}; use --force to bypass`,
+					);
+				}
+			}
 
-	const validation = validateWorkflowStateEnvelope(mode, merged);
-	if (!validation.valid) throw new StateCommandError(2, validation.error ?? `invalid ${mode} state envelope`);
+			const validation = validateWorkflowStateEnvelope(mode, merged);
+			if (!validation.valid) throw new StateCommandError(2, validation.error ?? `invalid ${mode} state envelope`);
 
-	const {
-		warning: outOfBandWarning,
-		stamped,
-		revision: stampedRevision,
-	} = await writeJsonAtomic(cwd, filePath, merged, "write", {
-		sessionId,
-		skill: mode,
-		mutationId,
-		force: forced,
-		fromPhase,
-		toPhase,
-	});
-	const stampedReceipt = isPlainObject(stamped.receipt) ? stamped.receipt : {};
+			const {
+				warning: outOfBandWarning,
+				stamped,
+				revision: stampedRevision,
+			} = await writeJsonAtomic(cwd, filePath, merged, "write", {
+				sessionId,
+				skill: mode,
+				mutationId,
+				force: forced,
+				fromPhase,
+				toPhase,
+			});
+			const stampedReceipt = isPlainObject(stamped.receipt) ? stamped.receipt : {};
 
-	const phase = typeof merged.current_phase === "string" ? merged.current_phase : undefined;
-	const active = merged.active !== false;
-	// Reflect the lock-owned mode-state revision onto the in-memory payload so the active-state/HUD
-	// sync derives a `sourceRevision` from the revision this write actually owns (computed inside the
-	// writer lock), not the stale pre-write value or a post-lock re-read a concurrent writer could
-	// have advanced; otherwise the active-state writer stale-skips the update and the mirror keeps the
-	// prior phase (e.g. staying "interviewing" after a "handoff" write).
-	merged.state_revision = stampedRevision;
-	await syncWorkflowSkillState({ cwd, mode, sessionId, threadId, turnId, active, phase, payload: merged, receipt });
-	await touchStateActivityMarker(cwd, sessionId, filePath);
+			const phase = typeof merged.current_phase === "string" ? merged.current_phase : undefined;
+			const active = merged.active !== false;
+			// Reflect the lock-owned mode-state revision onto the in-memory payload so the active-state/HUD
+			// sync derives a `sourceRevision` from the revision this write actually owns (computed inside the
+			// writer lock), not the stale pre-write value or a post-lock re-read a concurrent writer could
+			// have advanced; otherwise the active-state writer stale-skips the update and the mirror keeps the
+			// prior phase (e.g. staying "interviewing" after a "handoff" write).
+			merged.state_revision = stampedRevision;
+			await syncWorkflowSkillState({
+				cwd,
+				mode,
+				sessionId,
+				threadId,
+				turnId,
+				active,
+				phase,
+				payload: merged,
+				receipt,
+			});
+			await touchStateActivityMarker(cwd, sessionId, filePath);
 
-	return {
-		status: 0,
-		stdout: renderCliWriteReceipt({
-			ok: true,
-			skill: mode,
-			state_path: filePath,
-			current_phase: phase,
-			active,
-			mutation_id: typeof stampedReceipt.mutation_id === "string" ? stampedReceipt.mutation_id : mutationId,
-			status: typeof stampedReceipt.status === "string" ? stampedReceipt.status : undefined,
-			content_sha256: stampedReceipt.content_sha256,
-		}),
-		...(outOfBandWarning ? { stderr: `${outOfBandWarning}\n` } : {}),
-	};
+			return {
+				status: 0,
+				stdout: renderCliWriteReceipt({
+					ok: true,
+					skill: mode,
+					state_path: filePath,
+					current_phase: phase,
+					active,
+					mutation_id: typeof stampedReceipt.mutation_id === "string" ? stampedReceipt.mutation_id : mutationId,
+					status: typeof stampedReceipt.status === "string" ? stampedReceipt.status : undefined,
+					content_sha256: stampedReceipt.content_sha256,
+				}),
+				...(outOfBandWarning ? { stderr: `${outOfBandWarning}\n` } : {}),
+			};
+		},
+		{ cwd },
+	);
 }
 
 async function handleClear(
@@ -1474,76 +2035,85 @@ async function handleClear(
 			"gjc state clear requires --mode <skill>, positional <skill>, input.skill, or an active workflow in the current session active state",
 		);
 
-	const filePath = modeStateFile(cwd, mode, sessionId);
-	const forced = hasFlag(args, "--force");
-	const existingRead = await readExistingStateForMutation(filePath);
-	if (existingRead.kind === "corrupt" && !forced) {
-		throw new StateCommandError(
-			2,
-			`existing state for ${mode} is corrupt or tampered (${existingRead.error}); use --force to overwrite`,
-		);
-	}
-	const existing = existingRead.kind === "valid" ? existingRead.value : {};
-	const staleReason = await describeStaleClearState(cwd, sessionId, mode, existing);
-	if (staleReason && !forced) {
-		throw new StateCommandError(2, `existing state for ${mode} is stale (${staleReason}); use --force to clear`);
-	}
-	const clearedAt = nowIso();
-	const cleared: Record<string, unknown> = {
-		skill: mode,
-		...existing,
-		active: false,
-		current_phase: "complete",
-		updated_at: clearedAt,
-		version: WORKFLOW_STATE_VERSION,
-	};
-	cleared.skill = mode;
-	const mutationId = `${mode}:clear:${clearedAt}`;
-	const receipt = buildWorkflowStateReceipt({
-		cwd,
-		skill: mode,
-		owner: "gjc-state-cli",
-		command: `gjc state ${mode} clear`,
-		sessionId,
-		nowIso: clearedAt,
-		mutationId,
-	});
-	cleared.receipt = receipt;
-	const { warning: outOfBandWarning, stamped } = await writeJsonAtomic(cwd, filePath, cleared, "clear", {
-		sessionId,
-		skill: mode,
-		mutationId,
-		force: forced,
-		fromPhase: typeof existing.current_phase === "string" ? existing.current_phase : undefined,
-		toPhase: "complete",
-	});
-	const stampedReceipt = isPlainObject(stamped.receipt) ? stamped.receipt : {};
+	return await withWorkflowStateLock(
+		workflowTransactionLockPath(cwd, sessionId),
+		async () => {
+			const filePath = modeStateFile(cwd, mode, sessionId);
+			const forced = hasFlag(args, "--force");
+			const existingRead = await readExistingStateForMutation(filePath);
+			if (existingRead.kind === "corrupt" && !forced) {
+				throw new StateCommandError(
+					2,
+					`existing state for ${mode} is corrupt or tampered (${existingRead.error}); use --force to overwrite`,
+				);
+			}
+			const existing = existingRead.kind === "valid" ? existingRead.value : {};
+			const staleReason = await describeStaleClearState(cwd, sessionId, mode, existing);
+			if (staleReason && !forced) {
+				throw new StateCommandError(
+					2,
+					`existing state for ${mode} is stale (${staleReason}); use --force to clear`,
+				);
+			}
+			const clearedAt = nowIso();
+			const cleared: Record<string, unknown> = {
+				skill: mode,
+				...withoutUltragoalAskHandoffAuthority(existing),
+				active: false,
+				current_phase: "complete",
+				updated_at: clearedAt,
+				version: WORKFLOW_STATE_VERSION,
+			};
+			cleared.skill = mode;
+			const mutationId = `${mode}:clear:${clearedAt}`;
+			const receipt = buildWorkflowStateReceipt({
+				cwd,
+				skill: mode,
+				owner: "gjc-state-cli",
+				command: `gjc state ${mode} clear`,
+				sessionId,
+				nowIso: clearedAt,
+				mutationId,
+			});
+			cleared.receipt = receipt;
+			const { warning: outOfBandWarning, stamped } = await writeJsonAtomic(cwd, filePath, cleared, "clear", {
+				sessionId,
+				skill: mode,
+				mutationId,
+				force: forced,
+				fromPhase: typeof existing.current_phase === "string" ? existing.current_phase : undefined,
+				toPhase: "complete",
+			});
+			const stampedReceipt = isPlainObject(stamped.receipt) ? stamped.receipt : {};
 
-	await syncWorkflowSkillState({
-		cwd,
-		mode,
-		sessionId,
-		threadId,
-		turnId,
-		active: false,
-		phase: "complete",
-		payload: cleared,
-	});
-	await touchStateActivityMarker(cwd, sessionId, filePath);
-	return {
-		status: 0,
-		stdout: renderCliWriteReceipt({
-			ok: true,
-			skill: mode,
-			state_path: filePath,
-			active: false,
-			current_phase: typeof cleared.current_phase === "string" ? cleared.current_phase : undefined,
-			mutation_id: typeof stampedReceipt.mutation_id === "string" ? stampedReceipt.mutation_id : mutationId,
-			status: typeof stampedReceipt.status === "string" ? stampedReceipt.status : undefined,
-			content_sha256: stampedReceipt.content_sha256,
-		}),
-		...(outOfBandWarning ? { stderr: `${outOfBandWarning}\n` } : {}),
-	};
+			await syncWorkflowSkillState({
+				cwd,
+				mode,
+				sessionId,
+				threadId,
+				turnId,
+				active: false,
+				phase: "complete",
+				payload: cleared,
+			});
+			await touchStateActivityMarker(cwd, sessionId, filePath);
+			return {
+				status: 0,
+				stdout: renderCliWriteReceipt({
+					ok: true,
+					skill: mode,
+					state_path: filePath,
+					active: false,
+					current_phase: typeof cleared.current_phase === "string" ? cleared.current_phase : undefined,
+					mutation_id: typeof stampedReceipt.mutation_id === "string" ? stampedReceipt.mutation_id : mutationId,
+					status: typeof stampedReceipt.status === "string" ? stampedReceipt.status : undefined,
+					content_sha256: stampedReceipt.content_sha256,
+				}),
+				...(outOfBandWarning ? { stderr: `${outOfBandWarning}\n` } : {}),
+			};
+		},
+		{ cwd },
+	);
 }
 
 /**
@@ -1572,316 +2142,383 @@ async function handleHandoff(
 ): Promise<StateCommandResult> {
 	const selectors = await resolveSelectors(args, cwd, positionalSkill, "handoff");
 	const { gjcSessionId: sessionId, threadId, turnId } = selectors;
-	const caller = selectors.mode ?? (await inferModeFromActiveState(cwd, sessionId));
-	if (!caller) {
-		throw new StateCommandError(
-			2,
-			"gjc state handoff requires --mode <caller>, positional <caller>, input.skill, or an active workflow in the current session active state",
-		);
-	}
-	const calleeRaw = flagValue(args, "--to")?.trim();
-	if (!calleeRaw) {
-		throw new StateCommandError(2, "gjc state handoff requires --to <callee>");
-	}
-	assertSafePathComponent(calleeRaw, "to");
-	const callee = calleeRaw;
-	const calleeIsWorkflow = isKnownMode(callee);
-	if (callee === caller) {
-		throw new StateCommandError(2, `gjc state handoff: --to must differ from caller (both are "${caller}")`);
-	}
+	return await withWorkflowStateLock(
+		workflowTransactionLockPath(cwd, sessionId),
+		async () => {
+			const caller = selectors.mode ?? (await inferModeFromActiveState(cwd, sessionId));
+			if (!caller) {
+				throw new StateCommandError(
+					2,
+					"gjc state handoff requires --mode <caller>, positional <caller>, input.skill, or an active workflow in the current session active state",
+				);
+			}
+			const calleeRaw = flagValue(args, "--to")?.trim();
+			if (!calleeRaw) {
+				throw new StateCommandError(2, "gjc state handoff requires --to <callee>");
+			}
+			assertSafePathComponent(calleeRaw, "to");
+			const callee = calleeRaw;
+			const calleeIsWorkflow = isKnownMode(callee);
+			if (callee === caller) {
+				throw new StateCommandError(2, `gjc state handoff: --to must differ from caller (both are "${caller}")`);
+			}
 
-	const callerPath = modeStateFile(cwd, caller, sessionId);
-	const calleePath = calleeIsWorkflow ? modeStateFile(cwd, callee, sessionId) : undefined;
-	const forced = hasFlag(args, "--force");
-	const callerRead = await readExistingStateForMutation(callerPath);
-	if (callerRead.kind === "corrupt" && !forced) {
-		throw new StateCommandError(
-			2,
-			`existing state for ${caller} is corrupt or tampered (${callerRead.error}); use --force to overwrite`,
-		);
-	}
-	if (callerRead.kind === "absent") {
-		throw new StateCommandError(
-			2,
-			`gjc state ${caller} handoff: caller is not active (no mode-state file at ${callerPath})`,
-		);
-	}
-	const existingCaller = callerRead.kind === "valid" ? callerRead.value : {};
+			const callerPath = modeStateFile(cwd, caller, sessionId);
+			const calleePath = calleeIsWorkflow ? modeStateFile(cwd, callee, sessionId) : undefined;
+			const forced = hasFlag(args, "--force");
+			const callerRead = await readExistingStateForMutation(callerPath);
+			if (callerRead.kind === "corrupt" && !forced) {
+				throw new StateCommandError(
+					2,
+					`existing state for ${caller} is corrupt or tampered (${callerRead.error}); use --force to overwrite`,
+				);
+			}
+			if (callerRead.kind === "absent") {
+				throw new StateCommandError(
+					2,
+					`gjc state ${caller} handoff: caller is not active (no mode-state file at ${callerPath})`,
+				);
+			}
+			const existingCaller = callerRead.kind === "valid" ? callerRead.value : {};
+			const ultragoalAskPlan =
+				caller === "ultragoal" && isUltragoalAskHandoffCallee(callee)
+					? await readUltragoalAskAuthorityPlanBinding(cwd, sessionId)
+					: undefined;
+			if (ultragoalAskPlan) {
+				await assertUltragoalAskHandoffCaller({ cwd, sessionId, callerPath, callerState: existingCaller });
+			}
 
-	const handoffAt = nowIso();
-	const mutationId = `${caller}:handoff:${callee}:${handoffAt}`;
-	const callerReceipt = buildWorkflowStateReceipt({
-		cwd,
-		skill: caller,
-		owner: "gjc-state-cli",
-		command: `gjc state ${caller} handoff --to ${callee}`,
-		sessionId,
-		nowIso: handoffAt,
-		mutationId,
-	});
+			const handoffAt = nowIso();
+			const mutationId = `${caller}:handoff:${callee}:${handoffAt}`;
+			const callerReceipt = buildWorkflowStateReceipt({
+				cwd,
+				skill: caller,
+				owner: "gjc-state-cli",
+				command: `gjc state ${caller} handoff --to ${callee}`,
+				sessionId,
+				nowIso: handoffAt,
+				mutationId,
+			});
 
-	// Runtime callees have no native mode-state to clear later, so do not
-	// persist them as active-state entries; the prompt observer tracks them
-	// in memory the same way direct `/skill:<runtime>` invocation does.
-	if (!calleeIsWorkflow) {
-		const normalizedCaller =
-			caller === "deep-interview"
-				? (normalizeDeepInterviewEnvelope(migrateWorkflowState(existingCaller, caller).state) as Record<
-						string,
-						unknown
-					>)
-				: migrateWorkflowState(existingCaller, caller).state;
-		const mergedCallerState: Record<string, unknown> = {
-			...normalizedCaller,
-			skill: caller,
-			version: WORKFLOW_STATE_VERSION,
-			active: false,
-			current_phase: "handoff",
-			handoff_to: callee,
-			handoff_at: handoffAt,
-			updated_at: handoffAt,
-			receipt: callerReceipt,
-		};
-		const force = hasFlag(args, "--force");
-		await beginWorkflowTransactionJournal({
-			cwd,
-			sessionId,
-			mutationId,
-			caller,
-			paths: [callerPath, activeStateFile(cwd, sessionId)],
-		});
-		const callerWrite = await writeJsonAtomic(cwd, callerPath, mergedCallerState, "handoff", {
-			sessionId,
-			skill: caller,
-			mutationId,
-			force,
-			fromPhase: typeof existingCaller.current_phase === "string" ? existingCaller.current_phase : undefined,
-			toPhase: "handoff",
-		});
-		await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, { steps: ["caller-mode-state"] });
-		if (callerWrite.warning) process.stderr.write(`${callerWrite.warning}\n`);
-		const stampedCallerReceipt = isPlainObject(callerWrite.stamped.receipt) ? callerWrite.stamped.receipt : {};
-		await syncSkillActiveState({
-			cwd,
-			skill: caller,
-			active: false,
-			phase: "handoff",
-			sessionId,
-			threadId,
-			turnId,
-			source: "gjc-state-cli",
-			hud: buildHudForMode(caller, mergedCallerState),
-			handoff_to: callee,
-			handoff_at: handoffAt,
-			receipt: callerReceipt,
-		});
-		await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, {
-			steps: ["caller-mode-state", "active-state"],
-		});
-		await completeWorkflowTransactionJournal(cwd, sessionId, mutationId);
-		await touchStateActivityMarker(cwd, sessionId, callerPath);
-		return {
-			status: 0,
-			stdout: renderCliWriteReceipt({
-				ok: true,
-				from: caller,
-				to: callee,
+			// Runtime callees have no native mode-state to clear later, so do not
+			// persist them as active-state entries; the prompt observer tracks them
+			// in memory the same way direct `/skill:<runtime>` invocation does.
+			if (!calleeIsWorkflow) {
+				const normalizedCaller = withoutUltragoalAskHandoffAuthority(
+					caller === "deep-interview"
+						? (normalizeDeepInterviewEnvelope(migrateWorkflowState(existingCaller, caller).state) as Record<
+								string,
+								unknown
+							>)
+						: migrateWorkflowState(existingCaller, caller).state,
+				);
+				const mergedCallerState: Record<string, unknown> = {
+					...normalizedCaller,
+					skill: caller,
+					version: WORKFLOW_STATE_VERSION,
+					active: false,
+					current_phase: "handoff",
+					handoff_to: callee,
+					handoff_at: handoffAt,
+					updated_at: handoffAt,
+					receipt: callerReceipt,
+				};
+				const force = hasFlag(args, "--force");
+				await beginWorkflowTransactionJournal({
+					cwd,
+					sessionId,
+					mutationId,
+					caller,
+					paths: [callerPath, activeStateFile(cwd, sessionId)],
+				});
+				const callerWrite = await writeJsonAtomic(cwd, callerPath, mergedCallerState, "handoff", {
+					sessionId,
+					skill: caller,
+					mutationId,
+					force,
+					fromPhase: typeof existingCaller.current_phase === "string" ? existingCaller.current_phase : undefined,
+					toPhase: "handoff",
+				});
+				await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, { steps: ["caller-mode-state"] });
+				if (callerWrite.warning) process.stderr.write(`${callerWrite.warning}\n`);
+				const stampedCallerReceipt = isPlainObject(callerWrite.stamped.receipt) ? callerWrite.stamped.receipt : {};
+				await syncSkillActiveState({
+					cwd,
+					skill: caller,
+					active: false,
+					phase: "handoff",
+					sessionId,
+					threadId,
+					turnId,
+					source: "gjc-state-cli",
+					hud: buildHudForMode(caller, mergedCallerState),
+					handoff_to: callee,
+					handoff_at: handoffAt,
+					receipt: callerReceipt,
+				});
+				await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, {
+					steps: ["caller-mode-state", "active-state"],
+				});
+				await completeWorkflowTransactionJournal(cwd, sessionId, mutationId);
+				await touchStateActivityMarker(cwd, sessionId, callerPath);
+				return {
+					status: 0,
+					stdout: renderCliWriteReceipt({
+						ok: true,
+						from: caller,
+						to: callee,
+						handoff_at: handoffAt,
+						phases: {
+							from: mergedCallerState.current_phase,
+						},
+						receipts: {
+							from: {
+								mutation_id: stampedCallerReceipt.mutation_id,
+								status: stampedCallerReceipt.status,
+								content_sha256: stampedCallerReceipt.content_sha256,
+							},
+						},
+						paths: {
+							from: callerPath,
+							active_state: activeStateFile(cwd, sessionId),
+						},
+					}),
+				};
+			}
+
+			if (!calleePath) {
+				throw new StateCommandError(2, `gjc state handoff failed to resolve workflow callee path for ${callee}`);
+			}
+			const calleeRead = await readExistingStateForMutation(calleePath);
+			if (calleeRead.kind === "corrupt" && !forced) {
+				throw new StateCommandError(
+					2,
+					`existing state for ${callee} is corrupt or tampered (${calleeRead.error}); use --force to overwrite`,
+				);
+			}
+			const existingCallee = calleeRead.kind === "valid" ? calleeRead.value : {};
+			const calleeReceipt = buildWorkflowStateReceipt({
+				cwd,
+				skill: callee,
+				owner: "gjc-state-cli",
+				command: `gjc state ${caller} handoff --to ${callee}`,
+				sessionId,
+				nowIso: handoffAt,
+				mutationId,
+			});
+			const callerStateRevision = (existingStateRevision(existingCaller) ?? 0) + 1;
+			const calleeStateRevision = (existingStateRevision(existingCallee) ?? 0) + 1;
+			const ultragoalAskHandoff =
+				ultragoalAskPlan && isUltragoalAskHandoffCallee(callee)
+					? buildUltragoalAskHandoffAuthority({
+							callee,
+							sessionId,
+							plan: ultragoalAskPlan,
+							callerStateRevision,
+							calleeStateRevision,
+							handoffAt,
+							mutationId,
+							callerReceipt,
+							calleeReceipt,
+						})
+					: undefined;
+
+			const calleeInitial = initialPhaseForSkill(callee);
+			const normalizedCaller = withoutUltragoalAskHandoffAuthority(
+				caller === "deep-interview"
+					? (normalizeDeepInterviewEnvelope(migrateWorkflowState(existingCaller, caller).state) as Record<
+							string,
+							unknown
+						>)
+					: migrateWorkflowState(existingCaller, caller).state,
+			);
+			const normalizedCallee = withoutUltragoalAskHandoffAuthority(
+				callee === "deep-interview"
+					? (normalizeDeepInterviewEnvelope(migrateWorkflowState(existingCallee, callee).state) as Record<
+							string,
+							unknown
+						>)
+					: migrateWorkflowState(existingCallee, callee).state,
+			);
+			const mergedCalleeState: Record<string, unknown> = {
+				...normalizedCallee,
+				skill: callee,
+				version: WORKFLOW_STATE_VERSION,
+				active: true,
+				current_phase: calleeInitial,
+				handoff_from: caller,
 				handoff_at: handoffAt,
-				phases: {
-					from: mergedCallerState.current_phase,
+				updated_at: handoffAt,
+				receipt: calleeReceipt,
+				...(ultragoalAskHandoff ? { ultragoal_ask_handoff: ultragoalAskHandoff } : {}),
+			};
+			if (sessionId && typeof mergedCalleeState.session_id !== "string") {
+				mergedCalleeState.session_id = sessionId;
+			}
+			const mergedCallerState: Record<string, unknown> = {
+				...normalizedCaller,
+				skill: caller,
+				version: WORKFLOW_STATE_VERSION,
+				active: false,
+				current_phase: "handoff",
+				handoff_to: callee,
+				handoff_at: handoffAt,
+				updated_at: handoffAt,
+				receipt: callerReceipt,
+				...(ultragoalAskHandoff ? { ultragoal_ask_handoff: ultragoalAskHandoff } : {}),
+			};
+
+			await beginWorkflowTransactionJournal({
+				cwd,
+				sessionId,
+				mutationId,
+				caller,
+				callee,
+				paths: [
+					calleePath,
+					callerPath,
+					activeStateFile(cwd, sessionId),
+					...(ultragoalAskHandoff ? [ultragoalAskHandoffCommitPath(cwd, sessionId, mutationId)] : []),
+				],
+			});
+
+			// Atomic write order (architecture blocker AR-3): mode-state files first,
+			// then a single atomic active-state mutation per file (session before root)
+			// via applyHandoffToActiveState. The single-write transaction prevents the
+			// HUD from observing a window where neither caller nor callee is active,
+			// and write order keeps the session-scoped source of truth ahead of the
+			// root aggregate. strict:true on the active-state read tolerates ENOENT
+			// only; corrupt JSON / IO failures propagate as non-zero CLI status.
+			const force = hasFlag(args, "--force");
+			const calleeWrite = await writeJsonAtomic(cwd, calleePath, mergedCalleeState, "handoff", {
+				sessionId,
+				skill: callee,
+				mutationId,
+				force,
+				fromPhase: typeof existingCallee.current_phase === "string" ? existingCallee.current_phase : undefined,
+				toPhase: calleeInitial,
+			});
+			await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, { steps: ["callee-mode-state"] });
+			const callerWrite = await writeJsonAtomic(cwd, callerPath, mergedCallerState, "handoff", {
+				sessionId,
+				skill: caller,
+				mutationId,
+				force,
+				fromPhase: typeof existingCaller.current_phase === "string" ? existingCaller.current_phase : undefined,
+				toPhase: "handoff",
+			});
+			await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, {
+				steps: ["callee-mode-state", "caller-mode-state"],
+			});
+			if (
+				ultragoalAskHandoff &&
+				(callerWrite.revision !== callerStateRevision || calleeWrite.revision !== calleeStateRevision)
+			) {
+				throw new StateCommandError(
+					1,
+					`handoff state revisions changed while minting ask authority for ${mutationId}`,
+				);
+			}
+			const warnings = [calleeWrite.warning, callerWrite.warning].filter(
+				(warning): warning is string => typeof warning === "string",
+			);
+			const stampedCallerReceipt = isPlainObject(callerWrite.stamped.receipt) ? callerWrite.stamped.receipt : {};
+			const stampedCalleeReceipt = isPlainObject(calleeWrite.stamped.receipt) ? calleeWrite.stamped.receipt : {};
+			for (const warning of warnings) process.stderr.write(`${warning}\n`);
+			if (process.env.GJC_STATE_HANDOFF_FAIL_AFTER_CALLER === mutationId) {
+				throw new StateCommandError(1, `injected handoff failure after caller write for ${mutationId}`);
+			}
+			await applyHandoffToActiveState({
+				cwd,
+				nowIso: handoffAt,
+				strict: true,
+				caller: {
+					cwd,
+					skill: caller,
+					active: false,
+					phase: "handoff",
+					sessionId,
+					threadId,
+					turnId,
+					source: "gjc-state-cli",
+					hud: buildHudForMode(caller, mergedCallerState),
+					handoff_to: callee,
+					handoff_at: handoffAt,
+					receipt: callerReceipt,
 				},
-				receipts: {
-					from: {
-						mutation_id: stampedCallerReceipt.mutation_id,
-						status: stampedCallerReceipt.status,
-						content_sha256: stampedCallerReceipt.content_sha256,
+				callee: {
+					cwd,
+					skill: callee,
+					active: true,
+					phase: calleeInitial,
+					sessionId,
+					threadId,
+					turnId,
+					source: "gjc-state-cli",
+					hud: buildHudForMode(callee, mergedCalleeState),
+					handoff_from: caller,
+					handoff_at: handoffAt,
+					receipt: calleeReceipt,
+				},
+			});
+			await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, {
+				steps: ["callee-mode-state", "caller-mode-state", "active-state"],
+			});
+			if (
+				ultragoalAskHandoff &&
+				(process.env.GJC_STATE_HANDOFF_FAIL_BEFORE_ASK_COMMIT === "1" ||
+					process.env.GJC_STATE_HANDOFF_FAIL_BEFORE_ASK_COMMIT === mutationId)
+			) {
+				throw new StateCommandError(1, `injected handoff failure before ask commit for ${mutationId}`);
+			}
+			if (ultragoalAskHandoff) {
+				await createDurableUltragoalAskHandoffCommit(cwd, sessionId, mutationId, ultragoalAskHandoff);
+				await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, {
+					steps: ["callee-mode-state", "caller-mode-state", "active-state", "ask-commit"],
+				});
+				if (
+					process.env.GJC_STATE_HANDOFF_FAIL_AFTER_ASK_COMMIT === "1" ||
+					process.env.GJC_STATE_HANDOFF_FAIL_AFTER_ASK_COMMIT === mutationId
+				) {
+					throw new StateCommandError(1, `injected handoff failure after ask commit for ${mutationId}`);
+				}
+			}
+			await completeWorkflowTransactionJournal(cwd, sessionId, mutationId);
+			await touchStateActivityMarker(cwd, sessionId, callerPath);
+
+			return {
+				status: 0,
+				stdout: renderCliWriteReceipt({
+					ok: true,
+					from: caller,
+					to: callee,
+					handoff_at: handoffAt,
+					phases: {
+						from: mergedCallerState.current_phase,
+						to: mergedCalleeState.current_phase,
 					},
-				},
-				paths: {
-					from: callerPath,
-					active_state: activeStateFile(cwd, sessionId),
-				},
-			}),
-		};
-	}
-
-	if (!calleePath) {
-		throw new StateCommandError(2, `gjc state handoff failed to resolve workflow callee path for ${callee}`);
-	}
-	const calleeRead = await readExistingStateForMutation(calleePath);
-	if (calleeRead.kind === "corrupt" && !forced) {
-		throw new StateCommandError(
-			2,
-			`existing state for ${callee} is corrupt or tampered (${calleeRead.error}); use --force to overwrite`,
-		);
-	}
-	const existingCallee = calleeRead.kind === "valid" ? calleeRead.value : {};
-	const calleeReceipt = buildWorkflowStateReceipt({
-		cwd,
-		skill: callee,
-		owner: "gjc-state-cli",
-		command: `gjc state ${caller} handoff --to ${callee}`,
-		sessionId,
-		nowIso: handoffAt,
-		mutationId,
-	});
-
-	const calleeInitial = initialPhaseForSkill(callee);
-	const normalizedCaller =
-		caller === "deep-interview"
-			? (normalizeDeepInterviewEnvelope(migrateWorkflowState(existingCaller, caller).state) as Record<
-					string,
-					unknown
-				>)
-			: migrateWorkflowState(existingCaller, caller).state;
-	const normalizedCallee =
-		callee === "deep-interview"
-			? (normalizeDeepInterviewEnvelope(migrateWorkflowState(existingCallee, callee).state) as Record<
-					string,
-					unknown
-				>)
-			: migrateWorkflowState(existingCallee, callee).state;
-	const mergedCalleeState: Record<string, unknown> = {
-		...normalizedCallee,
-		skill: callee,
-		version: WORKFLOW_STATE_VERSION,
-		active: true,
-		current_phase: calleeInitial,
-		handoff_from: caller,
-		handoff_at: handoffAt,
-		updated_at: handoffAt,
-		receipt: calleeReceipt,
-	};
-	if (sessionId && typeof mergedCalleeState.session_id !== "string") {
-		mergedCalleeState.session_id = sessionId;
-	}
-	const mergedCallerState: Record<string, unknown> = {
-		...normalizedCaller,
-		skill: caller,
-		version: WORKFLOW_STATE_VERSION,
-		active: false,
-		current_phase: "handoff",
-		handoff_to: callee,
-		handoff_at: handoffAt,
-		updated_at: handoffAt,
-		receipt: callerReceipt,
-	};
-
-	await beginWorkflowTransactionJournal({
-		cwd,
-		sessionId,
-		mutationId,
-		caller,
-		callee,
-		paths: [calleePath, callerPath, activeStateFile(cwd, sessionId)],
-	});
-
-	// Atomic write order (architecture blocker AR-3): mode-state files first,
-	// then a single atomic active-state mutation per file (session before root)
-	// via applyHandoffToActiveState. The single-write transaction prevents the
-	// HUD from observing a window where neither caller nor callee is active,
-	// and write order keeps the session-scoped source of truth ahead of the
-	// root aggregate. strict:true on the active-state read tolerates ENOENT
-	// only; corrupt JSON / IO failures propagate as non-zero CLI status.
-	const force = hasFlag(args, "--force");
-	const calleeWrite = await writeJsonAtomic(cwd, calleePath, mergedCalleeState, "handoff", {
-		sessionId,
-		skill: callee,
-		mutationId,
-		force,
-		fromPhase: typeof existingCallee.current_phase === "string" ? existingCallee.current_phase : undefined,
-		toPhase: calleeInitial,
-	});
-	await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, { steps: ["callee-mode-state"] });
-	const callerWrite = await writeJsonAtomic(cwd, callerPath, mergedCallerState, "handoff", {
-		sessionId,
-		skill: caller,
-		mutationId,
-		force,
-		fromPhase: typeof existingCaller.current_phase === "string" ? existingCaller.current_phase : undefined,
-		toPhase: "handoff",
-	});
-	await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, {
-		steps: ["callee-mode-state", "caller-mode-state"],
-	});
-	const warnings = [calleeWrite.warning, callerWrite.warning].filter(
-		(warning): warning is string => typeof warning === "string",
+					receipts: {
+						from: {
+							mutation_id: stampedCallerReceipt.mutation_id,
+							status: stampedCallerReceipt.status,
+							content_sha256: stampedCallerReceipt.content_sha256,
+						},
+						to: {
+							mutation_id: stampedCalleeReceipt.mutation_id,
+							status: stampedCalleeReceipt.status,
+							content_sha256: stampedCalleeReceipt.content_sha256,
+						},
+					},
+					paths: {
+						from: callerPath,
+						to: calleePath,
+						active_state: activeStateFile(cwd, sessionId),
+					},
+				}),
+			};
+		},
+		{ cwd },
 	);
-	const stampedCallerReceipt = isPlainObject(callerWrite.stamped.receipt) ? callerWrite.stamped.receipt : {};
-	const stampedCalleeReceipt = isPlainObject(calleeWrite.stamped.receipt) ? calleeWrite.stamped.receipt : {};
-	for (const warning of warnings) process.stderr.write(`${warning}\n`);
-	if (process.env.GJC_STATE_HANDOFF_FAIL_AFTER_CALLER === mutationId) {
-		throw new StateCommandError(1, `injected handoff failure after caller write for ${mutationId}`);
-	}
-	await applyHandoffToActiveState({
-		cwd,
-		nowIso: handoffAt,
-		strict: true,
-		caller: {
-			cwd,
-			skill: caller,
-			active: false,
-			phase: "handoff",
-			sessionId,
-			threadId,
-			turnId,
-			source: "gjc-state-cli",
-			hud: buildHudForMode(caller, mergedCallerState),
-			handoff_to: callee,
-			handoff_at: handoffAt,
-			receipt: callerReceipt,
-		},
-		callee: {
-			cwd,
-			skill: callee,
-			active: true,
-			phase: calleeInitial,
-			sessionId,
-			threadId,
-			turnId,
-			source: "gjc-state-cli",
-			hud: buildHudForMode(callee, mergedCalleeState),
-			handoff_from: caller,
-			handoff_at: handoffAt,
-			receipt: calleeReceipt,
-		},
-	});
-	await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, {
-		steps: ["callee-mode-state", "caller-mode-state", "active-state"],
-	});
-	await completeWorkflowTransactionJournal(cwd, sessionId, mutationId);
-	await touchStateActivityMarker(cwd, sessionId, callerPath);
-
-	return {
-		status: 0,
-		stdout: renderCliWriteReceipt({
-			ok: true,
-			from: caller,
-			to: callee,
-			handoff_at: handoffAt,
-			phases: {
-				from: mergedCallerState.current_phase,
-				to: mergedCalleeState.current_phase,
-			},
-			receipts: {
-				from: {
-					mutation_id: stampedCallerReceipt.mutation_id,
-					status: stampedCallerReceipt.status,
-					content_sha256: stampedCallerReceipt.content_sha256,
-				},
-				to: {
-					mutation_id: stampedCalleeReceipt.mutation_id,
-					status: stampedCalleeReceipt.status,
-					content_sha256: stampedCalleeReceipt.content_sha256,
-				},
-			},
-			paths: {
-				from: callerPath,
-				to: calleePath,
-				active_state: activeStateFile(cwd, sessionId),
-			},
-		}),
-	};
 }
 
 async function handleContract(
@@ -2200,25 +2837,40 @@ async function handleMigrate(
 			"gjc state migrate requires --mode <skill>, positional <skill>, input.skill, or an active workflow in the current session active state",
 		);
 	}
-	const filePath = modeStateFile(cwd, mode, selectors.gjcSessionId);
-	const forced = hasFlag(args, "--force");
-	const mismatchWarning = await warnAndAuditOutOfBandIfNeeded(cwd, selectors.gjcSessionId, filePath, mode, {
-		forced,
-	});
-	if (mismatchWarning && !forced) {
-		throw new StateCommandError(2, `${mismatchWarning}; use --force to migrate tampered mode-state`);
-	}
-	const result = await migrateAndPersistLegacyState({
-		cwd,
-		skill: mode,
-		statePath: filePath,
-		sessionId: selectors.gjcSessionId,
-	});
-	return {
-		status: 0,
-		stdout: `${JSON.stringify({ skill: mode, ...result, integrity_mismatch: Boolean(mismatchWarning) }, null, 2)}\n`,
-		...(mismatchWarning ? { stderr: `${mismatchWarning}\n` } : {}),
-	};
+	return await withWorkflowStateLock(
+		workflowTransactionLockPath(cwd, selectors.gjcSessionId),
+		async () => {
+			const filePath = modeStateFile(cwd, mode, selectors.gjcSessionId);
+			const forced = hasFlag(args, "--force");
+			const mismatchWarning = await warnAndAuditOutOfBandIfNeeded(cwd, selectors.gjcSessionId, filePath, mode, {
+				forced,
+			});
+			if (mismatchWarning && !forced) {
+				throw new StateCommandError(2, `${mismatchWarning}; use --force to migrate tampered mode-state`);
+			}
+			const result = await migrateAndPersistLegacyState({
+				cwd,
+				skill: mode,
+				statePath: filePath,
+				sessionId: selectors.gjcSessionId,
+			});
+			const persisted = await readExistingStateForMutation(filePath);
+			if (persisted.kind === "valid" && Object.hasOwn(persisted.value, "ultragoal_ask_handoff")) {
+				await writeJsonAtomic(cwd, filePath, withoutUltragoalAskHandoffAuthority(persisted.value), "write", {
+					sessionId: selectors.gjcSessionId,
+					skill: mode,
+					mutationId: `${mode}:migrate:revoke-ask-authority:${nowIso()}`,
+					force: forced,
+				});
+			}
+			return {
+				status: 0,
+				stdout: `${JSON.stringify({ skill: mode, ...result, integrity_mismatch: Boolean(mismatchWarning) }, null, 2)}\n`,
+				...(mismatchWarning ? { stderr: `${mismatchWarning}\n` } : {}),
+			};
+		},
+		{ cwd },
+	);
 }
 
 export async function runNativeStateCommand(args: string[], cwd = process.cwd()): Promise<StateCommandResult> {

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -1,12 +1,28 @@
 import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { CanonicalGjcWorkflowSkill } from "../skill-state/canonical-skills";
+import {
+	WORKFLOW_STATE_VERSION,
+	workflowActiveStatePath,
+	workflowStateStoragePath,
+} from "../skill-state/workflow-state-contract";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
+import {
+	activeEntryPath,
+	activeStateDir,
+	modeStatePath,
+	transactionJournalPath,
+	ultragoalAskHandoffCommitPath,
+} from "./session-layout";
 import { resolveGjcSessionForRead, SessionResolutionError } from "./session-resolution";
+import { detectWorkflowEnvelopeIntegrityMismatch } from "./state-writer";
 import {
 	validateDeferredMemberReceiptFresh,
 	validateReceiptFreshBase,
 	validateSupersededFinalAggregateReceipt,
 } from "./ultragoal-receipt-freshness";
 import {
+	deriveUltragoalAskAuthorityPlanBinding,
 	getUltragoalPaths,
 	getUltragoalRunCompletionState,
 	readUltragoalLedger,
@@ -14,6 +30,7 @@ import {
 	recordUltragoalNudgeIfBudgetRemaining,
 	resolveUltragoalNudgeBudget,
 	selectUltragoalNudgeTarget,
+	type UltragoalAskAuthorityPlanBinding,
 	type UltragoalGoal,
 	type UltragoalLedgerEvent,
 	type UltragoalNudgeSurface,
@@ -119,7 +136,370 @@ function isEnoent(error: unknown): boolean {
 		typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT"
 	);
 }
+const ASK_HANDOFF_CALLEES = new Set(["deep-interview", "ralplan"]);
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function readAuthoritativeActiveEntriesStrict(
+	cwd: string,
+	sessionId: string,
+): Promise<Record<string, unknown>[]> {
+	const dir = activeStateDir(cwd, sessionId);
+	let names: string[];
+	try {
+		names = await fs.readdir(dir);
+	} catch (error) {
+		if (isEnoent(error)) return [];
+		throw new Error(
+			`Unable to enumerate authoritative active entries: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	const entries: Record<string, unknown>[] = [];
+	for (const name of names.sort()) {
+		if (!name.endsWith(".json")) throw new Error(`Unexpected authoritative active entry: ${name}`);
+		const filePath = path.join(dir, name);
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(await fs.readFile(filePath, "utf-8"));
+		} catch (error) {
+			throw new Error(
+				`Unable to read authoritative active entry ${name}: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+		if (!isPlainObject(parsed)) throw new Error(`Authoritative active entry ${name} must be a JSON object`);
+		if (typeof parsed.skill !== "string" || parsed.skill.trim() === "") {
+			throw new Error(`Authoritative active entry ${name} must name a skill`);
+		}
+		if (activeEntryPath(cwd, sessionId, parsed.skill) !== filePath) {
+			throw new Error(`Authoritative active entry filename/skill mismatch for ${name}`);
+		}
+		if (typeof parsed.active !== "boolean") {
+			throw new Error(`Authoritative ${parsed.skill} active entry must have a boolean active field`);
+		}
+		if (parsed.session_id !== sessionId) {
+			throw new Error(`Authoritative ${parsed.skill} active entry has a mismatched session_id`);
+		}
+		entries.push(parsed);
+	}
+	return entries;
+}
+
+const ULTRAGOAL_PLAN_RUN_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const COMMITTED_ASK_HANDOFF_KEYS = [
+	"version",
+	"commitment",
+	"caller",
+	"callee",
+	"session_id",
+	"plan_run_id",
+	"plan_generation",
+	"plan_content_sha256",
+	"plan_state_revision",
+	"plan_created_event_id",
+	"ledger_generation",
+	"ledger_head_sha256",
+	"ledger_head_event_id",
+	"caller_state_revision",
+	"callee_state_revision",
+	"handoff_at",
+	"mutation_id",
+	"caller_receipt",
+	"callee_receipt",
+] as const;
+const HANDOFF_RECEIPT_KEYS = [
+	"version",
+	"skill",
+	"owner",
+	"command",
+	"state_path",
+	"storage_path",
+	"mutated_at",
+	"fresh_until",
+	"status",
+	"mutation_id",
+] as const;
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+	return Object.keys(value).length === keys.length && keys.every(key => Object.hasOwn(value, key));
+}
+
+function nonEmptyStringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function validPastTimestamp(value: unknown): value is string {
+	const timestamp = typeof value === "string" ? Date.parse(value) : Number.NaN;
+	return Number.isFinite(timestamp) && timestamp <= Date.now();
+}
+
+function hasDurablyIssuedHandoffReceipt(input: {
+	value: unknown;
+	skill: string;
+	callee: string;
+	sessionId: string;
+	handoffAt: string;
+	mutationId: string;
+	cwd: string;
+}): boolean {
+	if (!isPlainObject(input.value) || !hasExactKeys(input.value, HANDOFF_RECEIPT_KEYS)) return false;
+	const freshUntil = Date.parse(nonEmptyStringValue(input.value.fresh_until) ?? "");
+	const handoffTime = Date.parse(input.handoffAt);
+	// A committed handoff is durable proof, not a renewable receipt lease: its
+	// receipt must have been issued fresh for the handoff, but later passage of
+	// the HUD freshness window does not revoke the immutable proof. Explicitly
+	// persisted stale receipts are never accepted as handoff proof.
+	return (
+		input.value.version === 1 &&
+		input.value.skill === input.skill &&
+		input.value.owner === "gjc-state-cli" &&
+		input.value.command === `gjc state ultragoal handoff --to ${input.callee}` &&
+		input.value.state_path === workflowActiveStatePath(input.cwd, input.sessionId) &&
+		input.value.storage_path ===
+			workflowStateStoragePath(input.cwd, input.skill as CanonicalGjcWorkflowSkill, input.sessionId) &&
+		input.value.mutated_at === input.handoffAt &&
+		Number.isFinite(handoffTime) &&
+		Number.isFinite(freshUntil) &&
+		freshUntil >= handoffTime &&
+		input.value.status === "fresh" &&
+		input.value.mutation_id === input.mutationId
+	);
+}
+
+function hasBoundCurrentModeReceipt(input: {
+	value: unknown;
+	skill: string;
+	sessionId: string;
+	cwd: string;
+	expectedReceipt: unknown;
+	expectedStateRevision: unknown;
+}): boolean {
+	if (!isPlainObject(input.value) || input.value.state_revision !== input.expectedStateRevision) return false;
+	const receipt = input.value.receipt;
+	const expectedReceipt = input.expectedReceipt;
+	if (!isPlainObject(receipt) || !isPlainObject(expectedReceipt)) return false;
+	const checksum = receipt.content_sha256;
+	const mutatedAt = nonEmptyStringValue(receipt.mutated_at);
+	const freshUntil = nonEmptyStringValue(receipt.fresh_until);
+	const checksumComputedAt = isPlainObject(checksum) ? nonEmptyStringValue(checksum.computed_at) : undefined;
+	return (
+		HANDOFF_RECEIPT_KEYS.every(key => receipt[key] === expectedReceipt[key]) &&
+		receipt.skill === input.skill &&
+		receipt.status === "fresh" &&
+		Boolean(mutatedAt && validPastTimestamp(mutatedAt)) &&
+		Boolean(
+			freshUntil && Number.isFinite(Date.parse(freshUntil)) && Date.parse(freshUntil) >= Date.parse(mutatedAt ?? ""),
+		) &&
+		isPlainObject(checksum) &&
+		checksum.algorithm === "sha256" &&
+		typeof checksum.value === "string" &&
+		/^[a-f0-9]{64}$/i.test(checksum.value) &&
+		checksum.covered_path === modeStatePath(input.cwd, input.sessionId, input.skill) &&
+		Boolean(checksumComputedAt && validPastTimestamp(checksumComputedAt))
+	);
+}
+
+function hasCommittedAskHandoffAuthority(input: {
+	value: unknown;
+	callee: string;
+	planBinding: UltragoalAskAuthorityPlanBinding;
+	sessionId: string;
+	cwd: string;
+}): boolean {
+	if (!isPlainObject(input.value) || !hasExactKeys(input.value, COMMITTED_ASK_HANDOFF_KEYS)) return false;
+	const handoffAt = input.value.handoff_at;
+	const mutationId = input.value.mutation_id;
+	if (
+		input.value.version !== 1 ||
+		input.value.commitment !== "committed" ||
+		input.value.caller !== "ultragoal" ||
+		input.value.callee !== input.callee ||
+		input.value.session_id !== input.sessionId ||
+		input.value.plan_run_id !== input.planBinding.planRunId ||
+		input.value.plan_generation !== input.planBinding.planGeneration ||
+		input.value.plan_content_sha256 !== input.planBinding.planContentSha256 ||
+		input.value.plan_state_revision !== input.planBinding.planStateRevision ||
+		input.value.plan_created_event_id !== input.planBinding.planCreatedEventId ||
+		input.value.ledger_generation !== input.planBinding.ledgerGeneration ||
+		input.value.ledger_head_sha256 !== input.planBinding.ledgerHeadSha256 ||
+		input.value.ledger_head_event_id !== input.planBinding.ledgerHeadEventId ||
+		typeof input.value.caller_state_revision !== "number" ||
+		typeof input.value.callee_state_revision !== "number" ||
+		!validPastTimestamp(handoffAt) ||
+		typeof mutationId !== "string" ||
+		mutationId !== `ultragoal:handoff:${input.callee}:${handoffAt}`
+	) {
+		return false;
+	}
+	return (
+		hasDurablyIssuedHandoffReceipt({
+			value: input.value.caller_receipt,
+			skill: "ultragoal",
+			callee: input.callee,
+			sessionId: input.sessionId,
+			handoffAt,
+			mutationId,
+			cwd: input.cwd,
+		}) &&
+		hasDurablyIssuedHandoffReceipt({
+			value: input.value.callee_receipt,
+			skill: input.callee,
+			callee: input.callee,
+			sessionId: input.sessionId,
+			handoffAt,
+			mutationId,
+			cwd: input.cwd,
+		})
+	);
+}
+
+async function readModeStateForHandoff(
+	cwd: string,
+	sessionId: string,
+	skill: string,
+): Promise<{ value: Record<string, unknown>; path: string } | undefined> {
+	const filePath = modeStatePath(cwd, sessionId, skill);
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(await fs.readFile(filePath, "utf-8"));
+	} catch (error) {
+		if (isEnoent(error)) return undefined;
+		throw new Error(
+			`Unable to read authoritative ${skill} mode state: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (!isPlainObject(parsed)) return undefined;
+	return { value: parsed, path: filePath };
+}
+async function hasCommittedHandoffTransaction(input: {
+	cwd: string;
+	sessionId: string;
+	mutationId: string;
+	authority: unknown;
+}): Promise<boolean> {
+	try {
+		await fs.access(transactionJournalPath(input.cwd, input.sessionId, input.mutationId));
+		return false;
+	} catch (error) {
+		if (!isEnoent(error)) throw error;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(
+			await fs.readFile(ultragoalAskHandoffCommitPath(input.cwd, input.sessionId, input.mutationId), "utf-8"),
+		);
+	} catch (error) {
+		if (isEnoent(error)) return false;
+		throw error;
+	}
+	return JSON.stringify(parsed) === JSON.stringify(input.authority);
+}
+
+function samePlanAuthorityBinding(
+	left: UltragoalAskAuthorityPlanBinding,
+	right: UltragoalAskAuthorityPlanBinding,
+): boolean {
+	return (
+		left.planRunId === right.planRunId &&
+		left.planGeneration === right.planGeneration &&
+		left.planContentSha256 === right.planContentSha256 &&
+		left.planStateRevision === right.planStateRevision &&
+		left.planCreatedEventId === right.planCreatedEventId &&
+		left.ledgerGeneration === right.ledgerGeneration &&
+		left.ledgerHeadSha256 === right.ledgerHeadSha256 &&
+		left.ledgerHeadEventId === right.ledgerHeadEventId
+	);
+}
+
+async function committedAskHandoffCallee(
+	cwd: string,
+	sessionId: string,
+	entries: readonly Record<string, unknown>[],
+	plan: UltragoalPlan,
+	ledger: readonly UltragoalLedgerEvent[],
+): Promise<string | undefined> {
+	const planBinding = deriveUltragoalAskAuthorityPlanBinding(plan, ledger);
+	if (!planBinding) return undefined;
+	const activeEntries = entries.filter(entry => entry.active === true);
+	if (activeEntries.length !== 1) return undefined;
+	const [entry] = activeEntries;
+	const callee = typeof entry.skill === "string" ? entry.skill : "";
+	if (!ASK_HANDOFF_CALLEES.has(callee) || typeof entry.phase !== "string" || entry.phase.trim() === "")
+		return undefined;
+	const callerEntry = entries.find(candidate => candidate.skill === "ultragoal");
+	if (callerEntry?.active !== false) return undefined;
+
+	const [callerState, calleeState] = await Promise.all([
+		readModeStateForHandoff(cwd, sessionId, "ultragoal"),
+		readModeStateForHandoff(cwd, sessionId, callee),
+	]);
+	if (!callerState || !calleeState) return undefined;
+	const callerAuthority = callerState.value.ultragoal_ask_handoff;
+	const calleeAuthority = calleeState.value.ultragoal_ask_handoff;
+	if (
+		JSON.stringify(callerAuthority) !== JSON.stringify(calleeAuthority) ||
+		!isPlainObject(callerAuthority) ||
+		!hasCommittedAskHandoffAuthority({
+			value: callerAuthority,
+			callee,
+			planBinding,
+			sessionId,
+			cwd,
+		}) ||
+		typeof callerAuthority.mutation_id !== "string" ||
+		!(await hasCommittedHandoffTransaction({
+			cwd,
+			sessionId,
+			mutationId: callerAuthority.mutation_id,
+			authority: callerAuthority,
+		}))
+	) {
+		return undefined;
+	}
+	if (
+		callerState.value.skill !== "ultragoal" ||
+		callerState.value.version !== WORKFLOW_STATE_VERSION ||
+		callerState.value.active !== false ||
+		callerState.value.current_phase !== "handoff" ||
+		callerState.value.session_id !== sessionId ||
+		callerState.value.handoff_to !== callee ||
+		callerState.value.handoff_at !== callerAuthority.handoff_at ||
+		calleeState.value.skill !== callee ||
+		calleeState.value.version !== WORKFLOW_STATE_VERSION ||
+		calleeState.value.active !== true ||
+		calleeState.value.session_id !== sessionId ||
+		calleeState.value.handoff_from !== "ultragoal" ||
+		calleeState.value.handoff_at !== callerAuthority.handoff_at ||
+		!hasBoundCurrentModeReceipt({
+			value: callerState.value,
+			skill: "ultragoal",
+			sessionId,
+			cwd,
+			expectedReceipt: callerAuthority.caller_receipt,
+			expectedStateRevision: callerAuthority.caller_state_revision,
+		}) ||
+		!hasBoundCurrentModeReceipt({
+			value: calleeState.value,
+			skill: callee,
+			sessionId,
+			cwd,
+			expectedReceipt: callerAuthority.callee_receipt,
+			expectedStateRevision: callerAuthority.callee_state_revision,
+		}) ||
+		(await detectWorkflowEnvelopeIntegrityMismatch(callerState.path)) !== undefined ||
+		(await detectWorkflowEnvelopeIntegrityMismatch(calleeState.path)) !== undefined
+	) {
+		return undefined;
+	}
+	return callee;
+}
+
+async function hasStablePlanRunIdentity(cwd: string, sessionId: string, plan: UltragoalPlan): Promise<boolean> {
+	if (!plan.planRunId || !ULTRAGOAL_PLAN_RUN_ID_PATTERN.test(plan.planRunId)) return false;
+	const rechecked = await readUltragoalPlan(cwd, sessionId);
+	return rechecked?.planRunId === plan.planRunId;
+}
 function activeAskDiagnostic(input: {
 	reason: string;
 	source: UltragoalAskBlockDiagnostic["source"];
@@ -648,7 +1028,71 @@ export async function isUltragoalAskBlocked(
 			ledgerPath: paths.ledgerPath,
 		});
 	}
-
+	let handoffCallee: string | undefined;
+	try {
+		handoffCallee = await committedAskHandoffCallee(
+			cwd,
+			sessionId,
+			await readAuthoritativeActiveEntriesStrict(cwd, sessionId),
+			plan,
+			ledger,
+		);
+	} catch (error) {
+		return activeAskDiagnostic({
+			reason: `Unable to validate authoritative workflow handoff state: ${error instanceof Error ? error.message : String(error)}`,
+			source: "durable_state_unreadable",
+			goalsPath: paths.goalsPath,
+			ledgerPath: paths.ledgerPath,
+		});
+	}
+	if (handoffCallee) {
+		try {
+			const [recheckedPlan, recheckedLedger] = await Promise.all([
+				readUltragoalPlan(cwd, sessionId),
+				readUltragoalLedger(cwd, sessionId),
+			]);
+			const originalBinding = deriveUltragoalAskAuthorityPlanBinding(plan, ledger);
+			const recheckedBinding = recheckedPlan
+				? deriveUltragoalAskAuthorityPlanBinding(recheckedPlan, recheckedLedger)
+				: undefined;
+			const recheckedCallee =
+				recheckedPlan &&
+				recheckedBinding &&
+				(await committedAskHandoffCallee(
+					cwd,
+					sessionId,
+					await readAuthoritativeActiveEntriesStrict(cwd, sessionId),
+					recheckedPlan,
+					recheckedLedger,
+				));
+			if (
+				!originalBinding ||
+				!recheckedBinding ||
+				!samePlanAuthorityBinding(originalBinding, recheckedBinding) ||
+				recheckedCallee !== handoffCallee
+			) {
+				return activeAskDiagnostic({
+					reason: "Workflow handoff authority changed while authorizing ask.",
+					source: "durable_state",
+					goalsPath: paths.goalsPath,
+					ledgerPath: paths.ledgerPath,
+				});
+			}
+		} catch (error) {
+			return activeAskDiagnostic({
+				reason: `Unable to recheck workflow handoff authority: ${error instanceof Error ? error.message : String(error)}`,
+				source: "durable_state_unreadable",
+				goalsPath: paths.goalsPath,
+				ledgerPath: paths.ledgerPath,
+			});
+		}
+		return inactiveAskDiagnostic({
+			reason: `Ultragoal is inactive after a committed workflow handoff to ${handoffCallee}.`,
+			source: "durable_state",
+			goalsPath: paths.goalsPath,
+			ledgerPath: paths.ledgerPath,
+		});
+	}
 	if (plan.goals.some(goal => goal.status === "review_blocked")) {
 		const goalIds = plan.goals.filter(goal => goal.status === "review_blocked").map(goal => goal.id);
 		return activeAskDiagnostic({
@@ -697,6 +1141,25 @@ export async function isUltragoalAskBlocked(
 			ledgerPath: paths.ledgerPath,
 			goalIds: diagnostic.goalId ? [diagnostic.goalId] : undefined,
 		});
+	}
+	if (plan.planRunId) {
+		try {
+			if (!(await hasStablePlanRunIdentity(cwd, sessionId, plan))) {
+				return activeAskDiagnostic({
+					reason: "Ultragoal plan changed while validating completion.",
+					source: "durable_state",
+					goalsPath: paths.goalsPath,
+					ledgerPath: paths.ledgerPath,
+				});
+			}
+		} catch (error) {
+			return activeAskDiagnostic({
+				reason: `Unable to recheck Ultragoal plan identity: ${error instanceof Error ? error.message : String(error)}`,
+				source: "durable_state_unreadable",
+				goalsPath: paths.goalsPath,
+				ledgerPath: paths.ledgerPath,
+			});
+		}
 	}
 	return inactiveAskDiagnostic({
 		reason: "Ultragoal run is verified complete.",

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -17,7 +17,7 @@ import {
 
 export { computeUltragoalPlanGeneration, receiptRelevantGoals } from "./ultragoal-receipt-freshness";
 
-import { gjcRoot, sessionUltragoalDir } from "./session-layout";
+import { gjcRoot, sessionUltragoalDir, workflowTransactionLockPath } from "./session-layout";
 import {
 	resolveGjcSessionForRead,
 	resolveGjcSessionForWrite,
@@ -152,6 +152,12 @@ export interface UltragoalGoal {
 
 export interface UltragoalPlan {
 	version: 1;
+	/**
+	 * Cryptographically random identity for this durable plan instance. It is
+	 * intentionally distinct from timestamps and mutable completion generations.
+	 * Legacy plans do not have this field and must not gain handoff authority.
+	 */
+	planRunId?: string;
 	brief: string;
 	gjcGoalMode: UltragoalGjcGoalMode;
 	gjcObjective: string;
@@ -160,6 +166,16 @@ export interface UltragoalPlan {
 	createdAt: string;
 	updatedAt: string;
 	[key: string]: unknown;
+}
+export interface UltragoalAskAuthorityPlanBinding {
+	planRunId: string;
+	planGeneration: string;
+	planContentSha256: string;
+	planStateRevision: number;
+	planCreatedEventId: string;
+	ledgerGeneration: number;
+	ledgerHeadSha256: string;
+	ledgerHeadEventId: string;
 }
 
 export type UltragoalReceiptKind = "per-goal" | "final-aggregate";
@@ -309,6 +325,7 @@ const ACCEPTED_PROOF_STATUSES = new Set([COVERED_STATUS, "passed", "verified"]);
 const MIN_SUBSTANTIVE_EVIDENCE_WORDS = 5;
 const MIN_SUBSTANTIVE_EVIDENCE_CHARS = 32;
 
+const ULTRAGOAL_PLAN_RUN_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SCHEDULABLE_STATUSES = new Set<UltragoalGoalStatus>(["pending", "active", "failed"]);
 const COMPLETE_CHECKPOINT_ALLOWED_PRE_STATUSES = new Set<UltragoalGoalStatus>(["active", "failed"]);
 
@@ -352,6 +369,40 @@ export function hashStructuredValue(value: unknown): string {
 		.update(JSON.stringify(stableStructuredValue(value)))
 		.digest("hex");
 }
+export function deriveUltragoalAskAuthorityPlanBinding(
+	plan: UltragoalPlan,
+	ledger: readonly UltragoalLedgerEvent[],
+): UltragoalAskAuthorityPlanBinding | undefined {
+	if (!plan.planRunId || !ULTRAGOAL_PLAN_RUN_ID_PATTERN.test(plan.planRunId)) return undefined;
+	const planCreatedEvents = ledger.filter(event => event.event === "plan_created");
+	const genesis = planCreatedEvents.at(-1);
+	const ledgerHead = ledger.at(-1);
+	if (
+		!genesis ||
+		genesis.planRunId !== plan.planRunId ||
+		typeof genesis.eventId !== "string" ||
+		genesis.eventId.trim() === "" ||
+		!ledgerHead ||
+		typeof ledgerHead.eventId !== "string" ||
+		ledgerHead.eventId.trim() === ""
+	) {
+		// A handoff proof relies on the immutable plan-creation ledger row and
+		// canonical ledger head as well as the exact current plan content.
+		return undefined;
+	}
+	const planContentSha256 = hashStructuredValue(plan);
+	const planStateRevision = persistedStateRevision(plan);
+	return {
+		planRunId: plan.planRunId,
+		planGeneration: `${planStateRevision}:${planContentSha256}`,
+		planContentSha256,
+		planStateRevision,
+		planCreatedEventId: genesis.eventId,
+		ledgerGeneration: ledger.length,
+		ledgerHeadSha256: hashStructuredValue(ledger),
+		ledgerHeadEventId: ledgerHead.eventId,
+	};
+}
 
 export function getUltragoalPaths(cwd: string, sessionId?: string | null): UltragoalPaths {
 	const explicitSessionId = sessionId?.trim() || process.env.GJC_SESSION_ID?.trim();
@@ -370,21 +421,36 @@ function isEnoent(error: unknown): boolean {
 	);
 }
 
+/**
+ * All ordinary Ultragoal ledger appends acquire the session transaction lock.
+ * The only nested case is nudge consumption, which already owns the ledger-path
+ * lock and then acquires this session lock. No session-locked path acquires the
+ * ledger-path lock, so the sole lock order is ledger → session.
+ */
 async function appendLedger(cwd: string, event: JsonObject, sessionId?: string | null): Promise<UltragoalLedgerEvent> {
 	const resolvedSessionId =
 		sessionId?.trim() || resolveGjcSessionForWrite(cwd, { envSessionId: process.env.GJC_SESSION_ID }).gjcSessionId;
 	const paths = getUltragoalPaths(cwd, resolvedSessionId);
-	const entry: UltragoalLedgerEvent = {
-		eventId: typeof event.eventId === "string" ? event.eventId : crypto.randomUUID(),
-		...event,
-		timestamp: new Date().toISOString(),
-	};
-	await appendJsonl(paths.ledgerPath, entry, {
-		cwd,
-		audit: { category: "ledger", verb: "append", owner: "gjc-runtime", sessionId: resolvedSessionId },
-	});
-	await writeSessionActivityMarker(cwd, resolvedSessionId, { writer: "ultragoal-runtime", path: paths.ledgerPath });
-	return entry;
+	return await withWorkflowStateLock(
+		workflowTransactionLockPath(cwd, resolvedSessionId),
+		async () => {
+			const entry: UltragoalLedgerEvent = {
+				eventId: typeof event.eventId === "string" ? event.eventId : crypto.randomUUID(),
+				...event,
+				timestamp: new Date().toISOString(),
+			};
+			await appendJsonl(paths.ledgerPath, entry, {
+				cwd,
+				audit: { category: "ledger", verb: "append", owner: "gjc-runtime", sessionId: resolvedSessionId },
+			});
+			await writeSessionActivityMarker(cwd, resolvedSessionId, {
+				writer: "ultragoal-runtime",
+				path: paths.ledgerPath,
+			});
+			return entry;
+		},
+		{ cwd },
+	);
 }
 
 export async function readUltragoalLedger(cwd: string, sessionId?: string | null): Promise<UltragoalLedgerEvent[]> {
@@ -482,11 +548,10 @@ export function selectUltragoalNudgeTarget(
 }
 
 /**
- * Atomic consuming writer. Locks the ledger path, rereads + counts nudge rows for the
- * target story, and appends exactly one `nudge` row inside the same critical section
- * only while budget remains. Reuses the lockless `appendLedger` inside the lock (it
- * does not acquire a conflicting lock), so concurrent guarded attempts cannot both
- * observe `count = budget - 1` and overshoot the budget.
+ * Atomic consuming writer. It holds the ledger-path lock while it counts and
+ * appends, then `appendLedger` acquires the session transaction lock. This is
+ * the documented ledger → session order; session-locked writers never acquire
+ * the ledger-path lock, so no reverse-order cycle exists.
  */
 export async function recordUltragoalNudgeIfBudgetRemaining(input: {
 	cwd: string;
@@ -558,17 +623,26 @@ async function writePlan(cwd: string, plan: UltragoalPlan, sessionId?: string | 
 	const resolvedSessionId =
 		sessionId?.trim() || resolveGjcSessionForWrite(cwd, { envSessionId: process.env.GJC_SESSION_ID }).gjcSessionId;
 	const paths = getUltragoalPaths(cwd, resolvedSessionId);
-	await writeArtifact(paths.briefPath, `${plan.brief.trim()}\n`, {
-		cwd,
-		audit: { category: "artifact", verb: "write", owner: "gjc-runtime", sessionId: resolvedSessionId },
-	});
-	await writeGuardedJsonAtomic(paths.goalsPath, plan, {
-		cwd,
-		policy: "source",
-		expectedRevision: typeof plan.state_revision === "number" ? persistedStateRevision(plan) : undefined,
-		audit: { category: "state", verb: "write", owner: "gjc-runtime", sessionId: resolvedSessionId },
-	});
-	await writeSessionActivityMarker(cwd, resolvedSessionId, { writer: "ultragoal-runtime", path: paths.goalsPath });
+	await withWorkflowStateLock(
+		workflowTransactionLockPath(cwd, resolvedSessionId),
+		async () => {
+			await writeArtifact(paths.briefPath, `${plan.brief.trim()}\n`, {
+				cwd,
+				audit: { category: "artifact", verb: "write", owner: "gjc-runtime", sessionId: resolvedSessionId },
+			});
+			await writeGuardedJsonAtomic(paths.goalsPath, plan, {
+				cwd,
+				policy: "source",
+				expectedRevision: typeof plan.state_revision === "number" ? persistedStateRevision(plan) : undefined,
+				audit: { category: "state", verb: "write", owner: "gjc-runtime", sessionId: resolvedSessionId },
+			});
+			await writeSessionActivityMarker(cwd, resolvedSessionId, {
+				writer: "ultragoal-runtime",
+				path: paths.goalsPath,
+			});
+		},
+		{ cwd },
+	);
 }
 
 function chooseReceiptKind(
@@ -1311,8 +1385,13 @@ function normalizePlan(raw: unknown): UltragoalPlan {
 				(value): value is string => typeof value === "string" && value.trim().length > 0,
 			)
 		: undefined;
+	const planRunId =
+		typeof record.planRunId === "string" && ULTRAGOAL_PLAN_RUN_ID_PATTERN.test(record.planRunId)
+			? record.planRunId
+			: undefined;
 	return {
 		version: 1,
+		...(planRunId ? { planRunId } : {}),
 		brief,
 		gjcGoalMode,
 		gjcObjective,
@@ -1522,6 +1601,7 @@ export async function createUltragoalPlan(input: {
 	}
 	const plan: UltragoalPlan = {
 		version: 1,
+		planRunId: crypto.randomUUID(),
 		brief,
 		gjcGoalMode: input.gjcGoalMode ?? "aggregate",
 		gjcObjective: DEFAULT_ULTRAGOAL_OBJECTIVE,
@@ -1530,7 +1610,11 @@ export async function createUltragoalPlan(input: {
 		updatedAt: now,
 	};
 	await writePlan(input.cwd, plan, input.sessionId);
-	await appendLedger(input.cwd, { event: "plan_created", goalIds: plan.goals.map(goal => goal.id) }, input.sessionId);
+	await appendLedger(
+		input.cwd,
+		{ event: "plan_created", goalIds: plan.goals.map(goal => goal.id), planRunId: plan.planRunId },
+		input.sessionId,
+	);
 	return plan;
 }
 

--- a/packages/coding-agent/src/tools/ultragoal-ask-guard.ts
+++ b/packages/coding-agent/src/tools/ultragoal-ask-guard.ts
@@ -1,4 +1,6 @@
 import type { AgentTool } from "@gajae-code/agent-core";
+import { workflowTransactionLockPath } from "../gjc-runtime/session-layout";
+import { withWorkflowStateLock } from "../gjc-runtime/state-writer";
 import {
 	consumeUltragoalAskNudge,
 	isUltragoalAskBlocked,
@@ -26,9 +28,10 @@ function sessionScopedAskGuardId(
 	context: UltragoalAskGuardContext,
 	activeSkill: string | undefined,
 ): string | undefined {
-	if (activeSkill !== "ultragoal" && !UPSTREAM_PLANNING_ASK_SKILLS.has(activeSkill ?? "")) return undefined;
 	const activeSessionId = context.activeSkillState?.session_id?.trim();
-	if (activeSessionId) return activeSessionId;
+	if (activeSessionId && (activeSkill === "ultragoal" || UPSTREAM_PLANNING_ASK_SKILLS.has(activeSkill ?? ""))) {
+		return activeSessionId;
+	}
 	const sessionId = context.sessionId?.trim();
 	return sessionId || undefined;
 }
@@ -41,6 +44,16 @@ export function formatUltragoalAskBlockMessage(diagnostic: UltragoalAskBlockDiag
 	].join("\n");
 }
 
+async function throwUltragoalAskBlocked(
+	cwd: string,
+	sessionId: string | undefined,
+	diagnostic: UltragoalAskBlockDiagnostic,
+): Promise<never> {
+	const nudge = await consumeUltragoalAskNudge(cwd, sessionId);
+	if (nudge.nudged) throw new ToolError(nudge.message);
+	throw new ToolError(formatUltragoalAskBlockMessage(diagnostic));
+}
+
 export async function assertUltragoalAskAllowed(cwd: string, context: UltragoalAskGuardContext = {}): Promise<void> {
 	const activeSkill = normalizedActiveSkill(context);
 	// Deep-interview and ralplan are upstream planning workflows whose core gates
@@ -49,11 +62,15 @@ export async function assertUltragoalAskAllowed(cwd: string, context: UltragoalA
 	// prompts; same-session active Ultragoal state still falls through to the
 	// blocker/nudge checks below.
 	const sessionId = sessionScopedAskGuardId(context, activeSkill);
-	const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+	const diagnostic = sessionId
+		? await withWorkflowStateLock(
+				workflowTransactionLockPath(cwd, sessionId),
+				() => isUltragoalAskBlocked(cwd, { sessionId }),
+				{ cwd },
+			)
+		: await isUltragoalAskBlocked(cwd, { sessionId });
 	if (!diagnostic.active) return;
-	const nudge = await consumeUltragoalAskNudge(cwd, sessionId);
-	if (nudge.nudged) throw new ToolError(nudge.message);
-	throw new ToolError(formatUltragoalAskBlockMessage(diagnostic));
+	await throwUltragoalAskBlocked(cwd, sessionId, diagnostic);
 }
 
 export function guardToolForUltragoalAsk<T extends AgentTool>(
@@ -69,8 +86,33 @@ export function guardToolForUltragoalAsk<T extends AgentTool>(
 			if (prop === ULTRAGOAL_ASK_GUARD) return true;
 			if (prop !== "execute") return Reflect.get(target, prop, receiver);
 			return async (...args: unknown[]): Promise<unknown> => {
-				await assertUltragoalAskAllowed(getCwd(), getContext());
-				return Reflect.apply(target.execute, target, args);
+				const cwd = getCwd();
+				const context = getContext();
+				const sessionId = sessionScopedAskGuardId(context, normalizedActiveSkill(context));
+				if (!sessionId) {
+					await assertUltragoalAskAllowed(cwd, context);
+					return Reflect.apply(target.execute, target, args);
+				}
+
+				let execution: unknown;
+				let started = false;
+				const diagnostic = await withWorkflowStateLock(
+					workflowTransactionLockPath(cwd, sessionId),
+					async () => {
+						const result = await isUltragoalAskBlocked(cwd, { sessionId });
+						if (!result.active) {
+							// Start the tool synchronously while the exact authorization
+							// snapshot is still protected. Store its returned promise
+							// without awaiting it so the interactive lifetime is unlocked.
+							execution = Reflect.apply(target.execute, target, args);
+							started = true;
+						}
+						return result;
+					},
+					{ cwd },
+				);
+				if (started) return execution;
+				await throwUltragoalAskBlocked(cwd, sessionId, diagnostic);
 			};
 		},
 	}) as T & GuardedTool;

--- a/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
+++ b/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
@@ -4,18 +4,25 @@ import * as path from "node:path";
 import type { AgentTool, AgentToolContext } from "@gajae-code/agent-core";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import {
+	activeEntryPath,
 	activeSnapshotPath,
 	modeStatePath,
 	sessionActivityPath,
+	transactionJournalPath,
+	ultragoalAskHandoffCommitPath,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import { reconcileWorkflowSkillState, runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+import { stampWorkflowEnvelopeChecksum } from "@gajae-code/coding-agent/gjc-runtime/state-writer";
 import { isUltragoalAskBlocked } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
 import {
+	addUltragoalSubgoal,
 	computeUltragoalPlanGeneration,
 	createUltragoalPlan,
 	getUltragoalPaths,
 	hashStructuredValue,
 } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-runtime";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { syncSkillActiveState } from "@gajae-code/coding-agent/skill-state/active-state";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { AskTool } from "@gajae-code/coding-agent/tools/ask";
 import { ToolError } from "@gajae-code/coding-agent/tools/tool-errors";
@@ -38,7 +45,9 @@ beforeAll(async () => {
 afterEach(async () => {
 	if (ORIGINAL_GJC_SESSION_ID === undefined) delete process.env.GJC_SESSION_ID;
 	else process.env.GJC_SESSION_ID = ORIGINAL_GJC_SESSION_ID;
+	delete process.env.GJC_STATE_HANDOFF_FAIL_BEFORE_ASK_COMMIT;
 	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+	delete process.env.GJC_STATE_HANDOFF_FAIL_AFTER_ASK_COMMIT;
 });
 
 function createSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolSession {
@@ -71,29 +80,43 @@ async function writeActivityMarker(cwd: string, sessionId: string, updatedAt: st
 }
 
 async function writeActiveDeepInterviewState(cwd: string, sessionId: string): Promise<void> {
-	const now = new Date().toISOString();
-	const activeState = {
-		version: 1,
-		active: true,
+	await syncSkillActiveState({
+		cwd,
+		sessionId,
 		skill: "deep-interview",
+		active: true,
 		phase: "interviewing",
-		updated_at: now,
-		session_id: sessionId,
-		active_skills: [
-			{
-				skill: "deep-interview",
-				phase: "interviewing",
-				active: true,
-				updated_at: now,
-				session_id: sessionId,
-			},
+	});
+}
+async function prepareUltragoalCaller(cwd: string, sessionId: string, active = true, phase = "handoff"): Promise<void> {
+	const prepared = await runNativeStateCommand(
+		[
+			"write",
+			"--mode",
+			"ultragoal",
+			"--session-id",
+			sessionId,
+			"--input",
+			JSON.stringify({ active, current_phase: phase }),
+			"--json",
 		],
-	};
-	await Bun.write(activeSnapshotPath(cwd, sessionId), `${JSON.stringify(activeState, null, 2)}\n`);
-	await Bun.write(
-		modeStatePath(cwd, sessionId, "deep-interview"),
-		`${JSON.stringify({ active: true, current_phase: "interviewing", session_id: sessionId }, null, 2)}\n`,
+		cwd,
 	);
+	expect(prepared.status, prepared.stderr).toBe(0);
+}
+
+async function handoffUltragoal(
+	cwd: string,
+	sessionId: string,
+	callee: "deep-interview" | "ralplan",
+	expectedStatus = 0,
+): Promise<void> {
+	await prepareUltragoalCaller(cwd, sessionId);
+	const result = await runNativeStateCommand(
+		["handoff", "--mode", "ultragoal", "--to", callee, "--session-id", sessionId, "--json"],
+		cwd,
+	);
+	expect(result.status, result.stderr).toBe(expectedStatus);
 }
 
 function stubAskTool(execute: () => Promise<void>): AgentTool {
@@ -241,14 +264,13 @@ describe("ultragoal ask guard", () => {
 		expect(result.content[0]).toMatchObject({ type: "text" });
 	});
 
-	it("blocks active deep-interview ask when the same session has active ultragoal state", async () => {
+	it("allows active deep-interview ask after same-session ultragoal handoff", async () => {
 		const cwd = await tempDir();
-		const sessionId = "deep-interview-with-ultragoal-state";
+		const sessionId = "deep-interview-after-ultragoal-handoff";
 
 		process.env.GJC_SESSION_ID = sessionId;
 		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
-		delete process.env.GJC_SESSION_ID;
-		await writeActiveDeepInterviewState(cwd, sessionId);
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
 
 		const select = vi.fn(async () => "Continue");
 		const tool = new AskTool(
@@ -258,16 +280,576 @@ describe("ultragoal ask guard", () => {
 			}),
 		);
 
+		const result = await tool.execute(
+			"call",
+			{ questions: [{ id: "q", question: "Continue interview?", options: [{ label: "Continue" }] }] },
+			undefined,
+			undefined,
+			createContext(select),
+		);
+
+		expect(select).toHaveBeenCalledTimes(1);
+		expect(result.content[0]).toMatchObject({ type: "text" });
+	});
+	it("allows ask after a committed same-session ultragoal to ralplan handoff", async () => {
+		const cwd = await tempDir();
+		const sessionId = "ralplan-after-ultragoal-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "ralplan");
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(false);
+		expect(diagnostic.reason).toContain("committed workflow handoff to ralplan");
+	});
+	it("rejects an inactive ultragoal caller before mutating a handoff", async () => {
+		const cwd = await tempDir();
+		const sessionId = "inactive-ultragoal-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await prepareUltragoalCaller(cwd, sessionId, false);
+		const result = await runNativeStateCommand(
+			["handoff", "--mode", "ultragoal", "--to", "deep-interview", "--session-id", sessionId, "--json"],
+			cwd,
+		);
+
+		expect(result.status).toBe(2);
+		await expect(fs.access(modeStatePath(cwd, sessionId, "deep-interview"))).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 		await expect(
-			tool.execute(
-				"call",
-				{ questions: [{ id: "q", question: "Continue interview?", options: [{ label: "Continue" }] }] },
-				undefined,
-				undefined,
-				createContext(select),
-			),
-		).rejects.toThrow(/try-harder nudge/);
-		expect(select).not.toHaveBeenCalled();
+			fs.access(path.dirname(ultragoalAskHandoffCommitPath(cwd, sessionId, "inactive-handoff"))),
+		).rejects.toMatchObject({ code: "ENOENT" });
+	});
+	it("rejects an ultragoal caller outside the explicit handoff phase", async () => {
+		const cwd = await tempDir();
+		const sessionId = "wrong-phase-ultragoal-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await prepareUltragoalCaller(cwd, sessionId, true, "pending");
+		const result = await runNativeStateCommand(
+			["handoff", "--mode", "ultragoal", "--to", "ralplan", "--session-id", sessionId, "--json"],
+			cwd,
+		);
+
+		expect(result.status).toBe(2);
+		await expect(fs.access(modeStatePath(cwd, sessionId, "ralplan"))).rejects.toMatchObject({ code: "ENOENT" });
+	});
+	it("rejects a replacement plan that reuses the authorized run ID", async () => {
+		const cwd = await tempDir();
+		const sessionId = "reused-plan-run-id-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		const originalPlan = await createUltragoalPlan({ cwd, brief: "Implement the original story" });
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
+		await createUltragoalPlan({ cwd, brief: "Implement the replacement story" });
+		const paths = getUltragoalPaths(cwd, sessionId);
+		const replacement = JSON.parse(await fs.readFile(paths.goalsPath, "utf8"));
+		replacement.planRunId = originalPlan.planRunId;
+		await fs.writeFile(paths.goalsPath, JSON.stringify(replacement, null, 2));
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("rejects a restored same-run plan after sanctioned ledger advancement", async () => {
+		const cwd = await tempDir();
+		const sessionId = "restored-plan-ledger-generation-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		const paths = getUltragoalPaths(cwd, sessionId);
+		const authorizedPlan = await fs.readFile(paths.goalsPath, "utf8");
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
+		await addUltragoalSubgoal({
+			cwd,
+			title: "Later required work",
+			objective: "Implement the later required work",
+			evidence: "The original plan needs this required follow-up implementation task.",
+			rationale: "The sanctioned steering mutation advances the authoritative ledger.",
+		});
+		await fs.writeFile(paths.goalsPath, authorizedPlan);
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("strips handoff authority during sanctioned migration", async () => {
+		const cwd = await tempDir();
+		const sessionId = "migrate-handoff-authority";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "ralplan");
+		const migration = await runNativeStateCommand(
+			["migrate", "--mode", "ralplan", "--session-id", sessionId, "--json"],
+			cwd,
+		);
+
+		expect(migration.status, migration.stderr).toBe(0);
+		const calleeState = JSON.parse(await fs.readFile(modeStatePath(cwd, sessionId, "ralplan"), "utf8"));
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+		expect(calleeState.ultragoal_ask_handoff).toBeUndefined();
+		expect(diagnostic.active).toBe(true);
+	});
+	it("cannot revive handoff authority through clear then reconciliation", async () => {
+		const cwd = await tempDir();
+		const sessionId = "clear-reconcile-handoff-replay";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
+		const cleared = await runNativeStateCommand(
+			["clear", "--mode", "deep-interview", "--session-id", sessionId, "--json"],
+			cwd,
+		);
+		expect(cleared.status, cleared.stderr).toBe(0);
+		await reconcileWorkflowSkillState({
+			cwd,
+			mode: "deep-interview",
+			sessionId,
+			active: true,
+			phase: "interviewing",
+			payload: {},
+		});
+
+		const calleeState = JSON.parse(await fs.readFile(modeStatePath(cwd, sessionId, "deep-interview"), "utf8"));
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+		expect(calleeState.ultragoal_ask_handoff).toBeUndefined();
+		expect(diagnostic.active).toBe(true);
+	});
+	it("rejects matching mode states without a durable handleHandoff commit", async () => {
+		const cwd = await tempDir();
+		const sessionId = "missing-handoff-commit";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
+		const callerState = JSON.parse(await fs.readFile(modeStatePath(cwd, sessionId, "ultragoal"), "utf8"));
+		await fs.rm(ultragoalAskHandoffCommitPath(cwd, sessionId, callerState.ultragoal_ask_handoff.mutation_id));
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("invalidates handoff ask authority on a later sanctioned state write", async () => {
+		const cwd = await tempDir();
+		const sessionId = "state-write-after-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
+		const write = await runNativeStateCommand(
+			[
+				"write",
+				"--mode",
+				"deep-interview",
+				"--session-id",
+				sessionId,
+				"--input",
+				JSON.stringify({ active: true, current_phase: "interviewing" }),
+				"--json",
+			],
+			cwd,
+		);
+		expect(write.status, write.stderr).toBe(0);
+		const calleeState = JSON.parse(await fs.readFile(modeStatePath(cwd, sessionId, "deep-interview"), "utf8"));
+		expect(calleeState.ultragoal_ask_handoff).toBeUndefined();
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("strips captured handoff authority from sanctioned merge and replace writes", async () => {
+		for (const replace of [false, true]) {
+			const cwd = await tempDir();
+			const sessionId = `replayed-handoff-${replace ? "replace" : "merge"}`;
+
+			process.env.GJC_SESSION_ID = sessionId;
+			await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+			await handoffUltragoal(cwd, sessionId, "ralplan");
+			const calleePath = modeStatePath(cwd, sessionId, "ralplan");
+			const calleeState = JSON.parse(await fs.readFile(calleePath, "utf8"));
+			const write = await runNativeStateCommand(
+				[
+					"write",
+					"--mode",
+					"ralplan",
+					"--session-id",
+					sessionId,
+					"--input",
+					JSON.stringify(calleeState),
+					...(replace ? ["--replace"] : []),
+					"--json",
+				],
+				cwd,
+			);
+			expect(write.status, write.stderr).toBe(0);
+			const persisted = JSON.parse(await fs.readFile(calleePath, "utf8"));
+			expect(persisted.ultragoal_ask_handoff).toBeUndefined();
+
+			const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+			expect(diagnostic.active).toBe(true);
+		}
+	});
+	it("fails closed when handoff crashes after active-state commit but before ask proof", async () => {
+		const cwd = await tempDir();
+		const sessionId = "handoff-crash-before-proof";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		process.env.GJC_STATE_HANDOFF_FAIL_BEFORE_ASK_COMMIT = "1";
+		await handoffUltragoal(cwd, sessionId, "deep-interview", 1);
+		delete process.env.GJC_STATE_HANDOFF_FAIL_BEFORE_ASK_COMMIT;
+		const callerState = JSON.parse(await fs.readFile(modeStatePath(cwd, sessionId, "ultragoal"), "utf8"));
+		const mutationId = callerState.ultragoal_ask_handoff.mutation_id;
+		const journal = JSON.parse(await fs.readFile(transactionJournalPath(cwd, sessionId, mutationId), "utf8"));
+		expect(journal).toMatchObject({
+			status: "pending",
+			steps: ["callee-mode-state", "caller-mode-state", "active-state"],
+		});
+		await expect(fs.access(ultragoalAskHandoffCommitPath(cwd, sessionId, mutationId))).rejects.toMatchObject({
+			code: "ENOENT",
+		});
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("fails closed while a crash leaves the durable ask proof journal pending", async () => {
+		const cwd = await tempDir();
+		const sessionId = "handoff-crash-after-proof";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		process.env.GJC_STATE_HANDOFF_FAIL_AFTER_ASK_COMMIT = "1";
+		await handoffUltragoal(cwd, sessionId, "ralplan", 1);
+		delete process.env.GJC_STATE_HANDOFF_FAIL_AFTER_ASK_COMMIT;
+
+		const callerState = JSON.parse(await fs.readFile(modeStatePath(cwd, sessionId, "ultragoal"), "utf8"));
+		const mutationId = callerState.ultragoal_ask_handoff.mutation_id;
+		const journal = JSON.parse(await fs.readFile(transactionJournalPath(cwd, sessionId, mutationId), "utf8"));
+		expect(journal).toMatchObject({
+			status: "pending",
+			steps: ["callee-mode-state", "caller-mode-state", "active-state", "ask-commit"],
+		});
+		await fs.access(ultragoalAskHandoffCommitPath(cwd, sessionId, mutationId));
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+		expect(diagnostic.active).toBe(true);
+	});
+	it("doctor cleans a verified committed-before-delete handoff journal", async () => {
+		const cwd = await tempDir();
+		const sessionId = "committed-handoff-journal-recovery";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
+		const callerState = JSON.parse(await fs.readFile(modeStatePath(cwd, sessionId, "ultragoal"), "utf8"));
+		const mutationId = callerState.ultragoal_ask_handoff.mutation_id;
+		const journalPath = transactionJournalPath(cwd, sessionId, mutationId);
+		await fs.mkdir(path.dirname(journalPath), { recursive: true });
+		await fs.writeFile(
+			journalPath,
+			JSON.stringify({
+				version: 1,
+				mutation_id: mutationId,
+				status: "committed",
+				created_at: callerState.handoff_at,
+				updated_at: callerState.handoff_at,
+				caller: "ultragoal",
+				callee: "deep-interview",
+				paths: [
+					modeStatePath(cwd, sessionId, "deep-interview"),
+					modeStatePath(cwd, sessionId, "ultragoal"),
+					activeSnapshotPath(cwd, sessionId),
+					ultragoalAskHandoffCommitPath(cwd, sessionId, mutationId),
+				],
+				steps: ["callee-mode-state", "caller-mode-state", "active-state", "ask-commit"],
+			}),
+		);
+
+		const doctor = await runNativeStateCommand(["doctor", "--session-id", sessionId, "--json"], cwd);
+
+		expect(doctor.status, doctor.stdout).toBe(0);
+		await expect(fs.access(journalPath)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+	it("retains and reports tampered committed handoff journals", async () => {
+		for (const tamper of [
+			"active-entry",
+			"ledger-head",
+			"checksum",
+			"wrong-filename",
+			"paths",
+			"embedded-removed",
+			"embedded-replaced",
+			"receipt-extra",
+			"receipt-future",
+			"snapshot-missing",
+			"snapshot-tampered",
+			"extra-active-entry",
+			"string-revisions",
+		] as const) {
+			const cwd = await tempDir();
+			const sessionId = `committed-handoff-journal-${tamper}`;
+
+			process.env.GJC_SESSION_ID = sessionId;
+			await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+			await handoffUltragoal(cwd, sessionId, "deep-interview");
+			const callerState = JSON.parse(await fs.readFile(modeStatePath(cwd, sessionId, "ultragoal"), "utf8"));
+			const mutationId = callerState.ultragoal_ask_handoff.mutation_id;
+			const callerPath = modeStatePath(cwd, sessionId, "ultragoal");
+			const calleePath = modeStatePath(cwd, sessionId, "deep-interview");
+			const commitPath = ultragoalAskHandoffCommitPath(cwd, sessionId, mutationId);
+			const writeStamped = async (statePath: string, state: Record<string, unknown>, computedAt?: string) =>
+				await fs.writeFile(statePath, JSON.stringify(stampWorkflowEnvelopeChecksum(state, statePath, computedAt)));
+			const journalPath = transactionJournalPath(
+				cwd,
+				sessionId,
+				tamper === "wrong-filename" ? `${mutationId}:wrong-file` : mutationId,
+			);
+			if (tamper === "active-entry") {
+				const entryPath = activeEntryPath(cwd, sessionId, "deep-interview");
+				const entry = JSON.parse(await fs.readFile(entryPath, "utf8"));
+				entry.active = false;
+				await fs.writeFile(entryPath, JSON.stringify(entry));
+			}
+			if (tamper === "ledger-head") {
+				await fs.appendFile(
+					getUltragoalPaths(cwd, sessionId).ledgerPath,
+					`${JSON.stringify({ eventId: "tampered-ledger-head", event: "tampered", timestamp: new Date().toISOString() })}\n`,
+				);
+			}
+			if (tamper === "checksum") {
+				const statePath = modeStatePath(cwd, sessionId, "deep-interview");
+				const state = JSON.parse(await fs.readFile(statePath, "utf8"));
+				state.current_phase = "complete";
+				await fs.writeFile(statePath, JSON.stringify(state));
+			}
+			if (tamper === "embedded-removed" || tamper === "embedded-replaced") {
+				const state = JSON.parse(await fs.readFile(calleePath, "utf8"));
+				if (tamper === "embedded-removed") delete state.ultragoal_ask_handoff;
+				else state.ultragoal_ask_handoff = { ...state.ultragoal_ask_handoff, mutation_id: "replaced" };
+				await writeStamped(calleePath, state);
+			}
+			if (tamper === "receipt-extra") {
+				const authority = JSON.parse(await fs.readFile(commitPath, "utf8"));
+				authority.caller_receipt.extra = "recovery must reject unknown receipt fields";
+				await fs.writeFile(commitPath, JSON.stringify(authority));
+				for (const statePath of [callerPath, calleePath]) {
+					const state = JSON.parse(await fs.readFile(statePath, "utf8"));
+					state.ultragoal_ask_handoff = authority;
+					state.receipt.extra = "recovery must reject unknown receipt fields";
+					await writeStamped(statePath, state);
+				}
+			}
+			if (tamper === "receipt-future") {
+				const state = JSON.parse(await fs.readFile(calleePath, "utf8"));
+				await writeStamped(calleePath, state, new Date(Date.now() + 60_000).toISOString());
+			}
+			if (tamper === "snapshot-missing") {
+				await fs.rm(activeSnapshotPath(cwd, sessionId));
+			}
+			if (tamper === "snapshot-tampered") {
+				const snapshotPath = activeSnapshotPath(cwd, sessionId);
+				const snapshot = JSON.parse(await fs.readFile(snapshotPath, "utf8"));
+				snapshot.phase = "tampered";
+				await fs.writeFile(snapshotPath, JSON.stringify(snapshot));
+			}
+			if (tamper === "extra-active-entry") {
+				await fs.writeFile(
+					activeEntryPath(cwd, sessionId, "custom-review"),
+					JSON.stringify({ skill: "custom-review", session_id: sessionId, active: true, phase: "running" }),
+				);
+			}
+			if (tamper === "string-revisions") {
+				const authority = JSON.parse(await fs.readFile(commitPath, "utf8"));
+				authority.caller_state_revision = String(authority.caller_state_revision);
+				authority.callee_state_revision = String(authority.callee_state_revision);
+				await fs.writeFile(commitPath, JSON.stringify(authority));
+				for (const statePath of [callerPath, calleePath]) {
+					const state = JSON.parse(await fs.readFile(statePath, "utf8"));
+					state.state_revision = String(state.state_revision);
+					state.ultragoal_ask_handoff = authority;
+					await writeStamped(statePath, state);
+				}
+			}
+			await fs.mkdir(path.dirname(journalPath), { recursive: true });
+			await fs.writeFile(
+				journalPath,
+				JSON.stringify({
+					version: 1,
+					mutation_id: mutationId,
+					status: "committed",
+					created_at: callerState.handoff_at,
+					updated_at: callerState.handoff_at,
+					caller: "ultragoal",
+					callee: "deep-interview",
+					paths:
+						tamper === "paths"
+							? []
+							: [
+									modeStatePath(cwd, sessionId, "deep-interview"),
+									modeStatePath(cwd, sessionId, "ultragoal"),
+									activeSnapshotPath(cwd, sessionId),
+									ultragoalAskHandoffCommitPath(cwd, sessionId, mutationId),
+								],
+					steps: ["callee-mode-state", "caller-mode-state", "active-state", "ask-commit"],
+				}),
+			);
+
+			const doctor = await runNativeStateCommand(["doctor", "--session-id", sessionId, "--json"], cwd);
+
+			expect(doctor.status, `${tamper}: ${doctor.stdout}`).toBe(1);
+			await fs.access(journalPath);
+		}
+	});
+	it("keeps durable handoff proof valid after transient receipt freshness expires", async () => {
+		const cwd = await tempDir();
+		const sessionId = "durable-handoff-receipt-expiry";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
+		const now = Date.now();
+		const spy = vi.spyOn(Date, "now").mockReturnValue(now + 31 * 60_000);
+		try {
+			const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+			expect(diagnostic.active).toBe(false);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+	it("blocks a committed handoff when a custom workflow is also active", async () => {
+		const cwd = await tempDir();
+		const sessionId = "custom-overlapping-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
+		await syncSkillActiveState({
+			cwd,
+			sessionId,
+			skill: "custom-review",
+			active: true,
+			phase: "running",
+		});
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("fails closed on a malformed custom entry after committed handoff", async () => {
+		const cwd = await tempDir();
+		const sessionId = "malformed-custom-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await handoffUltragoal(cwd, sessionId, "ralplan");
+		await Bun.write(activeEntryPath(cwd, sessionId, "custom-review"), "{}\n");
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("durable_state_unreadable");
+	});
+	it("does not accept callee activation without committed handoff provenance", async () => {
+		const cwd = await tempDir();
+		const sessionId = "forged-deep-interview-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await writeActiveDeepInterviewState(cwd, sessionId);
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("does not treat active team state as a backward handoff", async () => {
+		const cwd = await tempDir();
+		const sessionId = "team-with-incomplete-ultragoal";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await syncSkillActiveState({
+			cwd,
+			sessionId,
+			skill: "team",
+			active: true,
+			phase: "running",
+		});
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("fails closed on structurally invalid canonical active entries", async () => {
+		const cwd = await tempDir();
+		const sessionId = "malformed-handoff-entry";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await Bun.write(
+			activeEntryPath(cwd, sessionId, "deep-interview"),
+			`${JSON.stringify({ skill: "deep-interview", session_id: sessionId })}\n`,
+		);
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("durable_state_unreadable");
+		expect(diagnostic.reason).toContain("boolean active field");
+	});
+	it("rejects a stale handoff entry from an earlier ultragoal run", async () => {
+		const cwd = await tempDir();
+		const sessionId = "stale-ultragoal-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		const originalPlan = await createUltragoalPlan({ cwd, brief: "Implement the earlier story" });
+		await handoffUltragoal(cwd, sessionId, "deep-interview");
+		const replacementPlan = await createUltragoalPlan({ cwd, brief: "Implement the replacement story" });
+		const paths = getUltragoalPaths(cwd, sessionId);
+		const persistedReplacement = JSON.parse(await fs.readFile(paths.goalsPath, "utf8"));
+		persistedReplacement.createdAt = originalPlan.createdAt;
+		await fs.writeFile(paths.goalsPath, JSON.stringify(persistedReplacement, null, 2));
+		expect(persistedReplacement.createdAt).toBe(originalPlan.createdAt);
+		expect(replacementPlan.planRunId).not.toBe(originalPlan.planRunId);
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+	});
+	it("keeps ask blocked when ultragoal remains active during an overlapping handoff", async () => {
+		const cwd = await tempDir();
+		const sessionId = "overlapping-ultragoal-handoff";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		await writeActiveDeepInterviewState(cwd, sessionId);
+		await syncSkillActiveState({
+			cwd,
+			sessionId,
+			skill: "ultragoal",
+			active: true,
+			phase: "handoff",
+		});
+
+		const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
 	});
 
 	it("allows ask when the ultragoal run is verified complete", async () => {
@@ -310,7 +892,7 @@ describe("ultragoal ask guard", () => {
 			`${JSON.stringify({ eventId, event: "goal_checkpointed", goalId: plan.goals[0].id, status: "complete", completionVerification: plan.goals[0].completionVerification, qualityGateJson })}\n`,
 		);
 		const diagnostic = await isUltragoalAskBlocked(cwd);
-		expect(diagnostic.active).toBe(false);
+		expect(diagnostic.active, diagnostic.reason).toBe(false);
 		expect(diagnostic.source).toBe("durable_state");
 	});
 


### PR DESCRIPTION
## Summary

Fix Ultragoal’s Ask guard so a planning-workflow handoff is accepted only when it comes from one complete, durable, same-session `gjc state ... handoff` transaction.

The previous guard could remain blocked after a legitimate handoff, while weaker provenance checks also left replay and crash-boundary ambiguity. This change makes the authorization contract explicit and fail-closed.

## What changed

- Require an active same-session Ultragoal caller in the explicit `handoff` phase.
- Bind authorization to the exact plan generation, full ordered ledger head, mode-state revisions, receipts, active entries, mutation ID, and durable commit proof.
- Serialize plan and ledger mutations with the session transaction lock.
- Strip handoff authority from every non-handoff state mutation path, including write, replace, clear, reconcile, and migration.
- Keep transaction journals pending through durable proof creation and fsync; complete them only after all committed steps are durable.
- Make doctor recovery verify the complete runtime authorization predicate before deleting committed journal evidence.
- Linearize Ask authorization and synchronous tool invocation under the same short-held session lock without holding that lock during the interactive prompt.
- Add failpoints and hostile regression coverage for replay, stale generations, malformed/overlapping active entries, receipt/checksum tampering, snapshot tampering, and crash images.

## Security and correctness invariants

- A copied or edited state envelope cannot mint handoff authority.
- Reusing a prior `planRunId`, restoring old plan bytes, or appending newer ledger history cannot revive stale authority.
- Missing, pending, malformed, or under-verified transaction evidence blocks Ask.
- Doctor retains suspicious evidence instead of cleaning it up.
- Concurrent cooperating state mutations are ordered before or after Ask invocation; there is no check/invoke gap.

## Verification

- `bun test packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts packages/coding-agent/test/gjc-runtime/ultragoal-nudge-guard.test.ts packages/coding-agent/test/gjc-runtime/state-handoff.test.ts`
  - 64 passed, 0 failed, 319 assertions
- `bun run ci:check:full`
  - passed after rebasing onto current `origin/dev`
- `git diff --check`
  - passed
- Independent adversarial architecture review
  - `CLEAR` / `APPROVE`

## Scope

Coding-agent workflow state and Ask-guard behavior only. The separate native descriptor hardening work is intentionally excluded from this PR pending Windows runtime validation.