### PR TITLE
fix(natives): repair darwin build of path_identity

### DIFF
--- a/crates/pi-natives/src/path_identity.rs
+++ b/crates/pi-natives/src/path_identity.rs
@@ -497,24 +497,6 @@ mod platform {
 		}
 	}
 
-	#[cfg(any(
-		target_os = "macos",
-		target_os = "ios",
-		target_os = "freebsd",
-		target_os = "openbsd",
-		target_os = "netbsd"
-	))]
-	fn stat_mtime_ns(stat: &libc::stat) -> i128 {
-		i128::from(stat.st_mtimespec.tv_sec) * 1_000_000_000 + i128::from(stat.st_mtimespec.tv_nsec)
-	}
-
-	#[cfg(not(any(
-		target_os = "macos",
-		target_os = "ios",
-		target_os = "freebsd",
-		target_os = "openbsd",
-		target_os = "netbsd"
-	)))]
 	fn stat_mtime_ns(stat: &libc::stat) -> i128 {
 		i128::from(stat.st_mtime) * 1_000_000_000 + i128::from(stat.st_mtime_nsec)
 	}

--- a/crates/pi-natives/src/path_identity.rs
+++ b/crates/pi-natives/src/path_identity.rs
@@ -497,6 +497,12 @@ mod platform {
 		}
 	}
 
+	#[cfg(target_os = "netbsd")]
+	fn stat_mtime_ns(stat: &libc::stat) -> i128 {
+		i128::from(stat.st_mtime) * 1_000_000_000 + i128::from(stat.st_mtimensec)
+	}
+
+	#[cfg(not(target_os = "netbsd"))]
 	fn stat_mtime_ns(stat: &libc::stat) -> i128 {
 		i128::from(stat.st_mtime) * 1_000_000_000 + i128::from(stat.st_mtime_nsec)
 	}


### PR DESCRIPTION
## Summary
- `crates/pi-natives/src/path_identity.rs` fails to compile on macOS: the vendored libc `stat` has no `st_mtimespec` field in this workspace's libc version, breaking `bun run --cwd packages/natives build` on darwin-arm64 (dev @ 904eab21)
- use the portable `st_mtime`/`st_mtime_nsec` accessors on all POSIX targets (libc exposes them uniformly)

## Note
After rebuilding, macOS still hits a runtime issue in the new owner-only security path: temp dirs under `/var` (a symlink to `/private/var` on darwin) are rejected as `reparse_point`, which fails `session-manager` suites on unmodified dev. That ancestor-symlink policy likely needs a darwin allowance for canonicalized roots; flagging for follow-up.

## Verification
- `cargo check -p pi-natives` green on darwin-arm64