### PR TITLE
fix(routing): route managed overflow to compaction (G005 follow-up)

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -58,11 +58,12 @@ jobs:
       - name: Upload canonical affected plan
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dev-affected-plan-${{ github.run_id }}
           path: .ci-dev-affected-plan.json
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
 
   windows-dev-doctor:
     name: Windows dev:doctor
@@ -152,7 +153,7 @@ jobs:
       - name: Download and validate canonical affected plan
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
-          name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dev-affected-plan-${{ github.run_id }}
           path: .
       - run: bun scripts/ci-dev-affected.ts --validate-plan
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
@@ -181,12 +182,13 @@ jobs:
       - name: Upload native addon(s)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: dev-affected-native-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dev-affected-native-${{ github.run_id }}
           path: |
             packages/natives/native/pi_natives.linux-x64-baseline.node
             packages/natives/native/pi_natives.linux-x64-modern.node
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
 
   # One shard per planned task on the broad runner. Native build tasks are
   # excluded (they run in affected-native); shards that load the native addon at
@@ -235,7 +237,7 @@ jobs:
       - name: Download and validate canonical affected plan
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
-          name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dev-affected-plan-${{ github.run_id }}
           path: .
       - run: bun scripts/ci-dev-affected.ts --validate-plan
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -269,7 +271,7 @@ jobs:
         if: ${{ matrix.native }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
-          name: dev-affected-native-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dev-affected-native-${{ github.run_id }}
           path: packages/natives/native
       - name: Run affected task shard
         env:
@@ -285,11 +287,12 @@ jobs:
       - name: Upload shard completion receipt
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: dev-affected-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}
+          name: dev-affected-shard-${{ github.run_id }}-${{ strategy.job-index }}
           path: .ci-dev-shard-receipts/${{ strategy.job-index }}.json
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
 
 
   # Branch protection must keep requiring this stable aggregate status. It validates
@@ -323,7 +326,7 @@ jobs:
       - name: Download canonical affected plan
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
-          name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dev-affected-plan-${{ github.run_id }}
           path: .
       - name: Validate canonical affected plan
         run: bun scripts/ci-dev-affected.ts --validate-plan
@@ -331,7 +334,7 @@ jobs:
         if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
-          pattern: dev-affected-shard-${{ github.run_id }}-${{ github.run_attempt }}-*
+          pattern: dev-affected-shard-${{ github.run_id }}-*
           path: .ci-dev-shard-receipts
           merge-multiple: true
       - name: Validate canonical shard completion

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -8,9 +8,9 @@ import {
 	type AssistantMessage,
 	type AssistantMessageEvent,
 	type Context,
+	classifyContextOverflow,
 	classifyFallbackTrigger,
 	EventStream,
-	isContextOverflow,
 	isZodSchema,
 	streamSimple,
 	type ToolResultMessage,
@@ -100,14 +100,11 @@ class ManagedAttemptSnapshotError extends Error {
 const managedAttemptTextEncoder = new TextEncoder();
 
 const ABORTED: unique symbol = Symbol("agent-loop-aborted");
-/**
- * Detect empty "successful" responses that indicate a proxy-level context
- * overflow (e.g. LiteLLM returning `content: []`, `stopReason: "stop"`, and a
- * fabricated near-zero usage). We delegate to {@link isContextOverflow} which
- * has the threshold constant, so the detection logic stays in one place.
- */
-function isEmptyResponseOverflow(message: AssistantMessage): boolean {
-	return isContextOverflow(message);
+function managedContextOverflow(message: AssistantMessage, config: AgentLoopConfig): boolean {
+	const transportFailure = managedTransportFailure(message);
+	return (
+		message.stopReason === "error" && classifyContextOverflow(message, transportFailure, config.model.contextWindow)
+	);
 }
 
 /** Managed fallback owns retry policy; only attached typed transport facts may discard an attempt. */
@@ -175,6 +172,10 @@ function managedFailureOutcome(message: AssistantMessage): ManagedAttemptOutcome
 		type: "retryable_discarded",
 		failure: { message, transportFailure: managedTransportFailure(message) },
 	};
+}
+
+function managedContextOverflowOutcome(message: AssistantMessage): ManagedAttemptOutcome {
+	return { type: "context_overflow_discarded", message };
 }
 
 function managedFailureMessage(error: unknown, config: AgentLoopConfig): AssistantMessage {
@@ -1340,11 +1341,20 @@ async function runLoopBody(
 				harmonyTruncateResumeCount = 0;
 			} catch (err) {
 				if (!(err instanceof HarmonyLeakInterruption)) {
+					const failureMessage = managedFailureMessage(err, config);
+					if (config.fallbackManaged && transaction && managedContextOverflow(failureMessage, config)) {
+						transaction.discard();
+						currentContext.messages.splice(contextMessageCount);
+						newMessages.splice(newMessageCount);
+						await config.onManagedAttemptOutcome?.(managedContextOverflowOutcome(failureMessage));
+						stream.end(newMessages);
+						return;
+					}
 					if (config.fallbackManaged && transaction && managedRetryableFailure(err)) {
 						transaction.discard();
 						currentContext.messages.splice(contextMessageCount);
 						newMessages.splice(newMessageCount);
-						await config.onManagedAttemptOutcome?.(managedFailureOutcome(managedFailureMessage(err, config)));
+						await config.onManagedAttemptOutcome?.(managedFailureOutcome(failureMessage));
 						stream.end(newMessages);
 						return;
 					}
@@ -1419,17 +1429,22 @@ async function runLoopBody(
 				}
 			}
 
+			const overflow = managedContextOverflow(message, config);
+			if (config.fallbackManaged && overflow) {
+				transaction?.discard();
+				currentContext.messages.splice(contextMessageCount);
+				newMessages.splice(newMessageCount);
+				await config.onManagedAttemptOutcome?.(managedContextOverflowOutcome(message));
+				stream.end(newMessages);
+				return;
+			}
+
 			newMessages.push(message);
 			modelHasResponded = true;
 			let steeringMessagesFromExecution: AgentMessage[] | undefined;
 
-			// Detect empty "successful" responses (stopReason "stop" + empty content).
-			// Some proxies (e.g. LiteLLM) return this when the upstream model's context
-			// window is exceeded, fabricating a near-zero usage instead of surfacing an
-			// error. Without this guard the agent loop treats the empty response as a
-			// natural turn completion and stops, leaving the user with a frozen session.
-			// Promote it to an error so the overflow/compaction recovery path can fire.
-			if (message.stopReason === "stop" && message.content.length === 0 && isEmptyResponseOverflow(message)) {
+			// Preserve the historical public error conversion for unmanaged proxy overflows.
+			if (!config.fallbackManaged && message.stopReason === "stop" && message.content.length === 0 && overflow) {
 				message.stopReason = "error";
 				message.errorMessage = message.errorMessage
 					? `${message.errorMessage} | Provider returned an empty response with anomalously low token usage (possible context overflow via proxy)`

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -102,9 +102,10 @@ const managedAttemptTextEncoder = new TextEncoder();
 const ABORTED: unique symbol = Symbol("agent-loop-aborted");
 function managedContextOverflow(message: AssistantMessage, config: AgentLoopConfig): boolean {
 	const transportFailure = managedTransportFailure(message);
-	return (
-		message.stopReason === "error" && classifyContextOverflow(message, transportFailure, config.model.contextWindow)
-	);
+	// Managed empty-stop responses may be repaired by the managed shell below; only
+	// typed/error overflows are discardable before that normalization boundary.
+	if (config.fallbackManaged && message.stopReason !== "error") return false;
+	return classifyContextOverflow(message, transportFailure, config.model.contextWindow);
 }
 
 /** Managed fallback owns retry policy; only attached typed transport facts may discard an attempt. */

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1626,7 +1626,7 @@ export class Agent {
 					this.requestRunTerminal(managedLogicalRunOwner ?? runId, managedDecision.terminal);
 				} else if (managedOutcome.type === "run_terminal") {
 					this.requestRunTerminal(managedLogicalRunOwner ?? runId, { stopReason: managedOutcome.reason });
-				} else if (managedDecision?.type !== "retry") {
+				} else if (managedDecision?.type !== "retry" && managedDecision?.type !== "maintenance") {
 					this.#finalizeRun(managedLogicalRunOwner ?? runId);
 				}
 			}
@@ -1679,7 +1679,10 @@ export class Agent {
 			});
 		} finally {
 			let continuation: ManagedAttemptContinuation | undefined;
-			if (managedOutcome?.type === "retryable_discarded" && managedDecision?.type === "retry") {
+			if (
+				managedOutcome?.type !== "run_terminal" &&
+				(managedDecision?.type === "retry" || managedDecision?.type === "maintenance")
+			) {
 				continuation = managedDecision.continuation;
 			}
 			const ownership: ManagedAttemptContinuationOwnership = {
@@ -1710,7 +1713,18 @@ export class Agent {
 			if (continuation && ownership.isCurrent()) {
 				try {
 					await continuation(ownership);
-					if (this.#activeRunId === undefined && this.#managedLogicalRunOwner === managedLogicalRunOwner) {
+					if (
+						managedDecision?.type === "maintenance" &&
+						this.#terminalizedLogicalRunIds.has(managedLogicalRunOwner ?? runId) &&
+						this.#managedLogicalRunOwner === managedLogicalRunOwner
+					) {
+						this.#managedLogicalRunOwner = undefined;
+					}
+					if (
+						managedDecision?.type !== "maintenance" &&
+						this.#activeRunId === undefined &&
+						this.#managedLogicalRunOwner === managedLogicalRunOwner
+					) {
 						this.#managedLogicalRunOwner = undefined;
 					}
 				} catch (err) {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -13,6 +13,7 @@ import type {
 	Tool,
 	ToolChoice,
 	ToolResultMessage,
+	TransportFailureFacts,
 	TSchema,
 } from "@gajae-code/ai";
 import type { AppendOnlyContextManager } from "./append-only-context";
@@ -58,6 +59,7 @@ export type ManagedAttemptContinuation = (ownership: ManagedAttemptContinuationO
 /** Decision returned by managed fallback policy for one provisional attempt. */
 export type ManagedAttemptDecision =
 	| { type: "retry"; continuation: ManagedAttemptContinuation }
+	| { type: "maintenance"; continuation: ManagedAttemptContinuation }
 	| { type: "terminal"; terminal: RunTerminalRequest };
 
 /** Structured result for one managed upstream invocation. */
@@ -67,9 +69,10 @@ export type ManagedAttemptOutcome =
 			failure: {
 				message: AssistantMessage;
 				/** Exact provider transport facts, including retry headers, for fallback policy. */
-				transportFailure?: import("@gajae-code/ai").TransportFailureFacts;
+				transportFailure?: TransportFailureFacts;
 			};
 	  }
+	| { type: "context_overflow_discarded"; message: AssistantMessage }
 	| { type: "run_terminal"; reason: "cancelled" | "error" | "exhausted" };
 
 export type ManagedAttemptOutcomeHandler = (

--- a/packages/agent/test/managed-attempt-transaction.test.ts
+++ b/packages/agent/test/managed-attempt-transaction.test.ts
@@ -232,6 +232,54 @@ describe("managed attempt transaction", () => {
 		expect(events.at(-1)).toBe("agent_end");
 	});
 
+	it("classifies an opaque typed OpenAI overflow as discarded maintenance without leaking a lifecycle", async () => {
+		const mock = createMockModel();
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["test"], tools: [], messages: [] },
+			streamFn: async () => {
+				throw Object.assign(new Error(""), {
+					transportFailure: { kind: "transport", status: 400, openaiErrorCode: "context_length_exceeded" },
+				});
+			},
+		});
+		const events: AgentEvent[] = [];
+		const outcomes: ManagedAttemptOutcome[] = [];
+		let maintenanceRuns = 0;
+		agent.subscribe(event => events.push(event));
+
+		await agent.prompt("run", {
+			fallbackManaged: true,
+			onManagedAttemptOutcome: outcome => {
+				outcomes.push(outcome);
+				return {
+					type: "maintenance",
+					continuation: () => {
+						maintenanceRuns += 1;
+					},
+				};
+			},
+		});
+
+		expect(outcomes).toEqual([
+			expect.objectContaining({
+				type: "context_overflow_discarded",
+				message: expect.objectContaining({ errorMessage: "" }),
+			}),
+		]);
+		expect(maintenanceRuns).toBe(1);
+		expect(
+			events.filter(
+				event =>
+					event.type === "message_update" ||
+					((event.type === "message_start" || event.type === "message_end") &&
+						event.message.role === "assistant") ||
+					event.type === "turn_end" ||
+					event.type === "agent_end",
+			),
+		).toEqual([]);
+		expect(agent.state.messages.filter(message => message.role === "assistant")).toHaveLength(0);
+	});
+
 	it("discards retryable managed failures before any assistant lifecycle escapes", async () => {
 		const mock = createMockModel();
 		const streamFn = async () => {
@@ -259,7 +307,11 @@ describe("managed attempt transaction", () => {
 			fallbackManaged: true,
 			onManagedAttemptOutcome: (outcome: ManagedAttemptOutcome) => {
 				outcomes.push(
-					outcome.type === "retryable_discarded" ? (outcome.failure.message.errorMessage ?? "") : outcome.reason,
+					outcome.type === "run_terminal"
+						? outcome.reason
+						: outcome.type === "retryable_discarded"
+							? (outcome.failure.message.errorMessage ?? "")
+							: (outcome.message.errorMessage ?? ""),
 				);
 				return { type: "retry", continuation: () => {} };
 			},
@@ -339,7 +391,11 @@ describe("managed attempt transaction", () => {
 			fallbackManaged: true,
 			onManagedAttemptOutcome: (outcome: ManagedAttemptOutcome) => {
 				outcomes.push(
-					outcome.type === "retryable_discarded" ? (outcome.failure.message.errorMessage ?? "") : outcome.reason,
+					outcome.type === "run_terminal"
+						? outcome.reason
+						: outcome.type === "retryable_discarded"
+							? (outcome.failure.message.errorMessage ?? "")
+							: (outcome.message.errorMessage ?? ""),
 				);
 				if (outcome.type === "retryable_discarded") facts.push(outcome.failure.transportFailure);
 				return { type: "terminal", terminal: { stopReason: "exhausted" } };

--- a/packages/ai/src/utils/fallback-transport.ts
+++ b/packages/ai/src/utils/fallback-transport.ts
@@ -156,7 +156,8 @@ export function transportFailureFacts(
 		finiteStatus(propertyOf(response, "status")) ??
 		finiteStatus(propertyOf(capturedResponse, "status"));
 	const anthropicErrorType = stringValue(propertyOf(nestedError, "type")) ?? stringValue(propertyOf(value, "type"));
-	const openaiErrorCode = stringValue(propertyOf(nestedError, "code"));
+	const openaiErrorCode =
+		stringValue(propertyOf(value, "openaiErrorCode")) ?? stringValue(propertyOf(nestedError, "code"));
 	const providerCode =
 		stringValue(propertyOf(value, "providerCode")) ??
 		openaiErrorCode ??
@@ -183,7 +184,8 @@ export function transportFailureFacts(
 		headers === undefined &&
 		!isQuotaCode(normalizedCode) &&
 		!isAuthCode(normalizedCode) &&
-		!isRateLimitCode(normalizedCode)
+		!isRateLimitCode(normalizedCode) &&
+		!isContextOverflowCode(normalizedCode)
 	) {
 		return undefined;
 	}
@@ -209,6 +211,9 @@ function parseRetryAfterMilliseconds(value: string | null): number | undefined {
 	return Number.isFinite(milliseconds) && milliseconds >= 0 ? Math.round(milliseconds) : undefined;
 }
 
+function isContextOverflowCode(code: string | undefined): boolean {
+	return code === "context_length_exceeded";
+}
 function isQuotaCode(code: string | undefined): boolean {
 	return (
 		code === "insufficient_quota" ||

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage } from "../types";
+import type { TransportFailureFacts } from "./fallback-transport";
 
 /**
  * Regex patterns to detect context overflow errors from different providers.
@@ -119,48 +120,88 @@ const EMPTY_RESPONSE_USAGE_THRESHOLD = 5;
  * @param contextWindow - Optional context window size for detecting silent overflow (z.ai)
  * @returns true if the message indicates a context overflow
  */
-export function isContextOverflow(message: AssistantMessage, contextWindow?: number): boolean {
-	// Case 1: Check error message patterns
-	if (message.stopReason === "error" && message.errorMessage) {
-		// Check known patterns
-		if (OVERFLOW_PATTERNS.some(p => p.test(message.errorMessage!))) {
-			return true;
-		}
+/**
+ * Authoritatively classify a context overflow from the assistant result and
+ * normalized transport facts. Typed facts take precedence over provider prose:
+ * an explicit non-overflow transport failure cannot be upgraded by hostile or
+ * misleading error text.
+ */
+const OVERFLOW_PROVIDER_CODES = new Set(["context_length_exceeded", "request_too_large"]);
+const NON_OVERFLOW_PROVIDER_CODES = new Set([
+	"invalid_request_error",
+	"authentication_error",
+	"invalid_api_key",
+	"invalid_token",
+	"token_expired",
+	"unauthorized",
+	"forbidden",
+	"insufficient_quota",
+	"quota_exceeded",
+	"quota_exhausted",
+	"usage_limit_reached",
+	"usage_not_included",
+	"out_of_credits",
+	"rate_limit",
+	"rate_limit_error",
+	"rate_limit_exceeded",
+	"too_many_requests",
+]);
 
-		// Cerebras and Mistral return 400/413 with no body for context overflow.
-		// Proxy providers (e.g. api.synthetic.new) wrap upstream 400/413 no-body
-		// responses in a JSON envelope, so the status code phrase may appear
-		// anywhere in the message rather than at its start.
-		// Note: 429 is rate limiting (requests/tokens per time), NOT context overflow
-		if (/\b4(00|13)\s*(status code)?\s*\(no body\)/i.test(message.errorMessage)) {
-			return true;
-		}
+function transportCodes(transportFailure: TransportFailureFacts | undefined): string[] {
+	return [transportFailure?.openaiErrorCode, transportFailure?.anthropicErrorType, transportFailure?.providerCode]
+		.filter((code): code is string => typeof code === "string")
+		.map(code => code.toLowerCase());
+}
+
+function hasTypedNonOverflowCode(transportFailure: TransportFailureFacts | undefined): boolean {
+	return transportCodes(transportFailure).some(code => NON_OVERFLOW_PROVIDER_CODES.has(code));
+}
+
+function isTypedNoBodyOverflow(
+	message: AssistantMessage,
+	transportFailure: TransportFailureFacts | undefined,
+): boolean {
+	if (transportFailure?.status !== 400 && transportFailure?.status !== 413) return false;
+	return !message.errorMessage || /\b4(00|13)\s*(status code)?\s*\(no body\)/i.test(message.errorMessage);
+}
+
+export function classifyContextOverflow(
+	message: AssistantMessage,
+	transportFailure?: TransportFailureFacts,
+	contextWindow?: number,
+): boolean {
+	if (transportFailure?.status === 429) return false;
+	const typedCodes = transportCodes(transportFailure);
+	if (typedCodes.some(code => OVERFLOW_PROVIDER_CODES.has(code))) return true;
+	if (hasTypedNonOverflowCode(transportFailure)) return false;
+	if (isTypedNoBodyOverflow(message, transportFailure)) return true;
+
+	const errorMessage = message.errorMessage;
+	if (message.stopReason === "error" && errorMessage) {
+		if (OVERFLOW_PATTERNS.some(pattern => pattern.test(errorMessage))) return true;
+		if (/\b4(00|13)\s*(status code)?\s*\(no body\)/i.test(errorMessage)) return true;
 	}
 
-	// Case 2: Usage-based overflow (silent or provider-specific)
 	if (contextWindow) {
 		const inputTokens = message.usage.input + message.usage.cacheRead + message.usage.cacheWrite;
-		if (inputTokens > contextWindow) {
-			return true;
-		}
+		if (inputTokens > contextWindow) return true;
 	}
 
-	// Case 3: Empty response with anomalously low usage (proxy-level overflow)
-	// Some proxies (e.g. LiteLLM) return a "successful" response (stopReason "stop")
-	// with empty content and a near-zero token count when the upstream model's
-	// context window is exceeded. This is distinct from silent overflow (Case 2),
-	// where the provider reports the real input token count. Here the proxy
-	// fabricates a bogus usage (input: 1, output: 1) that is far below any
-	// realistic turn, so we detect it heuristically.
-	if (
+	return (
 		message.stopReason === "stop" &&
 		message.content.length === 0 &&
 		message.usage.input + message.usage.output <= EMPTY_RESPONSE_USAGE_THRESHOLD
-	) {
-		return true;
-	}
+	);
+}
 
-	return false;
+/**
+ * Check if an assistant message represents a context overflow error.
+ *
+ * Callers with normalized transport facts should use {@link classifyContextOverflow}
+ * so typed provider codes take precedence over error prose.
+ */
+export function isContextOverflow(message: AssistantMessage, contextWindow?: number): boolean {
+	return classifyContextOverflow(message, undefined, contextWindow);
 }
 
 /**

--- a/packages/ai/test/overflow-utils.test.ts
+++ b/packages/ai/test/overflow-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@gajae-code/ai";
-import { isContextOverflow } from "@gajae-code/ai/utils/overflow";
+import { classifyContextOverflow, isContextOverflow } from "@gajae-code/ai/utils/overflow";
 
 function createErrorMessage(errorMessage: string): AssistantMessage {
 	return {
@@ -137,5 +137,64 @@ describe("isContextOverflow - empty response with low usage (proxy-level overflo
 			stopReason: "length",
 		};
 		expect(isContextOverflow(message)).toBe(false);
+	});
+});
+
+describe("classifyContextOverflow - authoritative transport facts", () => {
+	it("detects opaque OpenAI context_length_exceeded without relying on provider prose", () => {
+		const message = createErrorMessage("");
+		message.errorStatus = 400;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				openaiErrorCode: "context_length_exceeded",
+			}),
+		).toBe(true);
+	});
+
+	it.each([
+		{ status: 400, openaiErrorCode: "invalid_request_error" },
+		{ status: 429, openaiErrorCode: "rate_limit_exceeded" },
+	])("does not upgrade typed non-overflow $status failures with hostile overflow prose", transportFailure => {
+		const message = createErrorMessage("context_length_exceeded: context window exceeded");
+		message.errorStatus = transportFailure.status;
+		expect(classifyContextOverflow(message, { kind: "transport", ...transportFailure })).toBe(false);
+	});
+
+	it("keeps authoritative rate-limit status ahead of a contradictory overflow provider code", () => {
+		const message = createErrorMessage("context window exceeded");
+		message.errorStatus = 429;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 429,
+				providerCode: "request_too_large",
+			}),
+		).toBe(false);
+	});
+
+	it.each([
+		{
+			label: "Anthropic request_too_large",
+			transportFailure: { status: 413, anthropicErrorType: "request_too_large" },
+		},
+		{ label: "provider request_too_large", transportFailure: { status: 413, providerCode: "request_too_large" } },
+	])("detects opaque typed $label", ({ transportFailure }) => {
+		const message = createErrorMessage("");
+		message.errorStatus = transportFailure.status;
+		expect(classifyContextOverflow(message, { kind: "transport", ...transportFailure })).toBe(true);
+	});
+
+	it.each([400, 413])("detects typed status-only %i no-body overflow", status => {
+		const message = createErrorMessage("");
+		message.errorStatus = status;
+		expect(classifyContextOverflow(message, { kind: "transport", status })).toBe(true);
+	});
+
+	it("allows unknown typed transport facts to use overflow prose", () => {
+		const message = createErrorMessage("context_length_exceeded: context window exceeded");
+		message.errorStatus = 418;
+		expect(classifyContextOverflow(message, { kind: "transport", status: 418 })).toBe(true);
 	});
 });

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -11854,6 +11854,8 @@ export class AgentSession {
 
 	#isRetryableError(message: AssistantMessage): boolean {
 		if (message.errorMessage?.startsWith("Model fallback chain exhausted;")) return false;
+		const contextWindow = this.model?.contextWindow ?? 0;
+		if (isContextOverflow(message, contextWindow)) return false;
 		const managedFallback = this.#defaultFallbackChain().chain.entries.length > 1;
 		if (!managedFallback) {
 			const classification = this.#classifyErrorForRetry(message);
@@ -12194,6 +12196,7 @@ export class AgentSession {
 		allowLegacyUsageLimit: boolean,
 		transportFailure?: TransportFailureFacts,
 	): { class: FallbackTriggerClass; retryAfterMs?: number } | undefined {
+		if (isContextOverflow(message, this.model?.contextWindow ?? 0)) return undefined;
 		const transport = classifyFallbackTrigger(transportFailure ?? { status: message.errorStatus });
 		if (transport.class !== "other") return transport;
 		// Managed fallback receives authoritative transport facts from the request
@@ -12347,6 +12350,7 @@ export class AgentSession {
 		const classification = managedFallback ? undefined : this.#classifyErrorForRetry(message);
 		const legacyUnbounded = classification === "transient";
 		const attemptsUsed = managedFallback ? controller.attemptsUsed || 1 : this.#retryAttempt + 1;
+		const failedSelector = managedFallback ? controller.currentSelector() : undefined;
 		let outcome = managedFallback
 			? controller.onAttemptFailure(trigger.class, message.errorMessage || "Unknown error")
 			: legacyUnbounded || attemptsUsed <= retrySettings.maxRetries
@@ -12384,9 +12388,8 @@ export class AgentSession {
 						? Math.min(retryAfterMs, retrySettings.maxDelayMs)
 						: cappedExponentialWithFullJitter(retrySettings.baseDelayMs, retrySettings.maxDelayMs, attemptsUsed);
 
-		if (managedFallback && trigger.class === "rate_limit" && trigger.retryAfterMs !== undefined) {
-			const selector = controller.currentSelector();
-			if (selector) this.#modelRegistry.suppressSelector(selector, Date.now() + trigger.retryAfterMs);
+		if (managedFallback && trigger.class === "rate_limit" && trigger.retryAfterMs !== undefined && failedSelector) {
+			this.#modelRegistry.suppressSelector(failedSelector, Date.now() + trigger.retryAfterMs);
 		}
 
 		const retry = async (ownership?: ManagedAttemptContinuationOwnership): Promise<void> => {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -89,6 +89,7 @@ import type {
 	UsageReport,
 } from "@gajae-code/ai";
 import {
+	classifyContextOverflow,
 	clearAnthropicFastModeFallback,
 	getSupportedEfforts,
 	isContextOverflow,
@@ -100,6 +101,7 @@ import {
 import {
 	beginAttempt,
 	classifyFallbackTrigger,
+	type FallbackAttemptToken,
 	type FallbackTriggerClass,
 } from "@gajae-code/ai/utils/fallback-transport";
 
@@ -572,9 +574,9 @@ export interface AgentSessionConfig {
 type MidRunMaintenanceLifecycle = Parameters<NonNullable<AgentLoopConfig["maintainContext"]>>[1];
 
 type AutoCompactionTerminalStatus =
-	| { kind: "compacted" }
+	| { kind: "compacted"; continuationScheduled?: boolean }
 	| { kind: "aborted"; source: "signal" | "hook" }
-	| { kind: "skipped" }
+	| { kind: "skipped"; continuationScheduled?: boolean }
 	| { kind: "failed" };
 
 /** Options for AgentSession.prompt() */
@@ -1458,6 +1460,7 @@ export class AgentSession {
 	#retryPromise: Promise<void> | undefined = undefined;
 	#retryResolve: (() => void) | undefined = undefined;
 	#defaultFallbackController: FallbackChainController | undefined;
+	#overflowMaintenanceAttempts = 0;
 	#defaultFallbackExhaustedLastTurn = false;
 	#fallbackInvocationId = 0;
 	// Todo completion reminder state
@@ -3397,7 +3400,7 @@ export class AgentSession {
 			this.#resolveRetry();
 
 			const compactionTask = this.#checkCompaction(msg);
-			this.#trackPostPromptTask(compactionTask);
+			this.#trackPostPromptTask(compactionTask.then(() => undefined));
 			await compactionTask;
 			// Check for incomplete todos only after a final assistant stop, not intermediate tool-use turns.
 			const hasToolCalls = msg.content.some(content => content.type === "toolCall");
@@ -3616,7 +3619,10 @@ export class AgentSession {
 		const messages = this.agent.state.messages;
 		const lastMsg = messages.at(-1);
 		const contextWindow = this.model?.contextWindow ?? 0;
-		if (lastMsg?.role === "assistant" && isContextOverflow(lastMsg as AssistantMessage, contextWindow)) {
+		if (
+			lastMsg?.role === "assistant" &&
+			classifyContextOverflow(lastMsg as AssistantMessage, lastMsg.transportFailure, contextWindow)
+		) {
 			this.agent.replaceMessages(messages.slice(0, -1));
 		}
 	}
@@ -3628,7 +3634,7 @@ export class AgentSession {
 		return compactionSettings.autoContinue === false ? "auto_continue_disabled_non_resumable_tail" : undefined;
 	}
 
-	#scheduleOverflowRetryContinuation(generation: number): void {
+	#scheduleOverflowRetryContinuation(generation: number): boolean {
 		this.#stripOverflowFailedTurnForRetry();
 		if (this.#isResumableAgentTail()) {
 			this.#scheduleAgentContinue({
@@ -3639,16 +3645,17 @@ export class AgentSession {
 				onSkip: reason => this.#logCompactionContinuationSkipped("overflow_retry", reason),
 				onError: error => this.#logCompactionContinuationError("overflow_retry", error),
 			});
-			return;
+			return true;
 		}
 
 		const compactionSettings = this.settings.getGroup("compaction");
 		if (compactionSettings.autoContinue !== false) {
 			this.#scheduleAutoContinuePrompt(generation);
-			return;
+			return true;
 		}
 
 		this.#logCompactionContinuationSkipped("overflow_retry", "auto_continue_disabled_non_resumable_tail");
+		return false;
 	}
 
 	#scheduleAutoContinuePrompt(generation: number): void {
@@ -6940,6 +6947,7 @@ export class AgentSession {
 				await this.#resetDefaultFallbackForNewTurn();
 				await this.#ensureDefaultFallbackResolution();
 				this.#defaultFallbackChain().resetAttemptBudget();
+				this.#overflowMaintenanceAttempts = 0;
 				this.#throwIfPromptPreflightCancelled(generation, preflightSignal);
 			}
 			// Flush any pending bash messages before the new prompt
@@ -10041,17 +10049,17 @@ export class AgentSession {
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
 	 */
-	async #checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<void> {
+	async #checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<boolean> {
 		// Safety stops are terminal and must not trigger context maintenance.
 		if (
 			assistantMessage.errorKind === "provider_safety_stop" ||
 			(assistantMessage.errorMessage !== undefined &&
 				isLegacyProviderSafetyStopMessage(assistantMessage.errorMessage))
 		) {
-			return;
+			return false;
 		}
 		// Skip if message was aborted (user cancelled) - unless skipAbortedCheck is false
-		if (skipAbortedCheck && assistantMessage.stopReason === "aborted") return;
+		if (skipAbortedCheck && assistantMessage.stopReason === "aborted") return false;
 		const contextWindow = this.model?.contextWindow ?? 0;
 		const generation = this.#promptGeneration;
 		// Skip overflow check if the message came from a different model.
@@ -10067,7 +10075,13 @@ export class AgentSession {
 		const compactionEntry = getLatestCompactionEntry(this.sessionManager.getBranch());
 		const errorIsFromBeforeCompaction =
 			compactionEntry !== null && assistantMessage.timestamp < new Date(compactionEntry.timestamp).getTime();
-		if (sameModel && !errorIsFromBeforeCompaction && isContextOverflow(assistantMessage, contextWindow)) {
+		if (
+			sameModel &&
+			!errorIsFromBeforeCompaction &&
+			classifyContextOverflow(assistantMessage, assistantMessage.transportFailure, contextWindow)
+		) {
+			this.#overflowMaintenanceAttempts += 1;
+			if (this.#overflowMaintenanceAttempts > 1) return false;
 			// Remove the error message from agent state (it IS saved to session for history,
 			// but we don't want it in context for the retry)
 			const messages = this.agent.state.messages;
@@ -10081,24 +10095,23 @@ export class AgentSession {
 				// Retry on the promoted (larger) model without compacting
 				this.#scheduleAgentContinue({ delayMs: 100, generation, suppressPredecessorAgentEnd: true });
 
-				return;
+				return true;
 			}
 
 			// No promotion target available fall through to compaction
 			const compactionSettings = this.settings.getGroup("compaction");
 			if (compactionSettings.enabled && compactionSettings.strategy !== "off") {
-				await this.#runAutoCompaction("overflow", true);
-			} else {
-				this.#scheduleOverflowRetryContinuation(generation);
+				const status = await this.#runAutoCompaction("overflow", true);
+				return "continuationScheduled" in status && status.continuationScheduled === true;
 			}
-			return;
+			return this.#scheduleOverflowRetryContinuation(generation);
 		}
 		const compactionSettings = this.settings.getGroup("compaction");
-		if (!compactionSettings.enabled || compactionSettings.strategy === "off") return;
+		if (!compactionSettings.enabled || compactionSettings.strategy === "off") return false;
 
 		// Case 2: Threshold - turn succeeded but context is getting large
 		// Skip if this was an error (non-overflow errors don't have usage data)
-		if (assistantMessage.stopReason === "error") return;
+		if (assistantMessage.stopReason === "error") return false;
 		let contextTokens = calculateContextTokens(assistantMessage.usage);
 		// Model maxTokens is a capability ceiling, not a per-turn reservation.
 		// Auto maintenance should track actual context fullness.
@@ -10107,7 +10120,8 @@ export class AgentSession {
 		// which breaks the provider prompt-cache prefix mid-epoch. Only prune at a
 		// sanctioned maintenance boundary, i.e. when the un-pruned context already
 		// crosses the compaction threshold. Pruning may then avert full compaction.
-		if (!shouldCompact(contextTokens, contextWindow, compactionSettings, autoCompactionOutputReserveTokens)) return;
+		if (!shouldCompact(contextTokens, contextWindow, compactionSettings, autoCompactionOutputReserveTokens))
+			return true;
 		const pruneEstimate = estimateToolOutputPruneSavings(this.sessionManager.getBranch(), DEFAULT_PRUNE_CONFIG, {
 			relaxedMinimum: 0,
 		});
@@ -10130,6 +10144,7 @@ export class AgentSession {
 				await this.#runAutoCompaction("threshold", false);
 			}
 		}
+		return true;
 	}
 
 	/**
@@ -11541,8 +11556,9 @@ export class AgentSession {
 					continuationSkipReason,
 				});
 				if (willRetry) {
-					this.#scheduleOverflowRetryContinuation(generation);
-				} else if (continueAfterMaintenance && reason !== "idle" && this.agent.hasQueuedMessages()) {
+					return { kind: "skipped", continuationScheduled: this.#scheduleOverflowRetryContinuation(generation) };
+				}
+				if (continueAfterMaintenance && reason !== "idle" && this.agent.hasQueuedMessages()) {
 					this.#scheduleAgentContinue({
 						delayMs: 100,
 						generation,
@@ -11776,8 +11792,9 @@ export class AgentSession {
 			if (autoCompactionSignal.aborted) return { kind: "aborted", source: "signal" };
 
 			if (willRetry) {
-				this.#scheduleOverflowRetryContinuation(generation);
-			} else if (continueAfterMaintenance && reason !== "idle" && this.agent.hasQueuedMessages()) {
+				return { kind: "compacted", continuationScheduled: this.#scheduleOverflowRetryContinuation(generation) };
+			}
+			if (continueAfterMaintenance && reason !== "idle" && this.agent.hasQueuedMessages()) {
 				// Auto-compaction can complete while follow-up/steering/custom messages are waiting.
 				// Kick the loop so queued messages are actually delivered.
 				this.#scheduleAgentContinue({
@@ -11854,8 +11871,9 @@ export class AgentSession {
 
 	#isRetryableError(message: AssistantMessage): boolean {
 		if (message.errorMessage?.startsWith("Model fallback chain exhausted;")) return false;
+		const transportFailure = message.transportFailure;
 		const contextWindow = this.model?.contextWindow ?? 0;
-		if (isContextOverflow(message, contextWindow)) return false;
+		if (classifyContextOverflow(message, transportFailure, contextWindow)) return false;
 		const managedFallback = this.#defaultFallbackChain().chain.entries.length > 1;
 		if (!managedFallback) {
 			const classification = this.#classifyErrorForRetry(message);
@@ -11866,8 +11884,6 @@ export class AgentSession {
 				classification === "first_event_timeout"
 			);
 		}
-		const transportFailure = (message as AssistantMessage & { transportFailure?: TransportFailureFacts })
-			.transportFailure;
 		const trigger = classifyFallbackTrigger(transportFailure ?? { status: message.errorStatus });
 		if (transportFailure) return true;
 		if (
@@ -11976,7 +11992,7 @@ export class AgentSession {
 		// bounded unknown retry class.
 		if (isLegacyProviderSafetyStopMessage(err)) return "terminal";
 		const contextWindow = this.model?.contextWindow ?? 0;
-		if (isContextOverflow(message, contextWindow)) return "overflow";
+		if (classifyContextOverflow(message, message.transportFailure, contextWindow)) return "overflow";
 		if (isLocalModelEndpoint(this.model) && this.#isLocalProviderAvailabilityErrorMessage(err)) {
 			return "local_unavailable";
 		}
@@ -12067,7 +12083,7 @@ export class AgentSession {
 
 	#managedFallbackPromptOptions(): {
 		fallbackManaged?: boolean;
-		nextFallbackAttempt?: (model: Model) => ReturnType<typeof beginAttempt>;
+		nextFallbackAttempt?: (model: Model) => FallbackAttemptToken;
 		onManagedAttemptAccepted?: () => void;
 		onManagedAttemptOutcome?: (
 			outcome: ManagedAttemptOutcome,
@@ -12081,7 +12097,10 @@ export class AgentSession {
 				controller.onAttemptStarted();
 				return beginAttempt(formatModelString(model), String(++this.#fallbackInvocationId));
 			},
-			onManagedAttemptAccepted: () => controller.resetAttemptBudget(),
+			onManagedAttemptAccepted: () => {
+				controller.resetAttemptBudget();
+				this.#overflowMaintenanceAttempts = 0;
+			},
 			onManagedAttemptOutcome: outcome => this.#handleManagedAttemptOutcome(outcome),
 		};
 	}
@@ -12164,6 +12183,24 @@ export class AgentSession {
 			this.#defaultFallbackChain().resetAttemptBudget();
 			return { type: "terminal", terminal: { stopReason: outcome.reason } };
 		}
+		if (outcome.type === "context_overflow_discarded") {
+			// The provider invocation happened, but overflow is context maintenance rather
+			// than a fallback-policy failure. Keep the logical run owner and do not charge,
+			// switch, suppress, or route through retry handling.
+			this.#defaultFallbackChain().discardStartedAttempt();
+			return {
+				type: "maintenance",
+				continuation: async ownership => {
+					if (!ownership.isCurrent()) return;
+					const successorScheduled = await this.#checkCompaction(outcome.message);
+					if (successorScheduled || !ownership.isCurrent()) return;
+					this.agent.requestRunTerminal(ownership.logicalRunId, {
+						stopReason: "error",
+						messages: [outcome.message],
+					});
+				},
+			};
+		}
 		return this.#handleRetryableError(
 			outcome.failure.message,
 			true,
@@ -12196,7 +12233,7 @@ export class AgentSession {
 		allowLegacyUsageLimit: boolean,
 		transportFailure?: TransportFailureFacts,
 	): { class: FallbackTriggerClass; retryAfterMs?: number } | undefined {
-		if (isContextOverflow(message, this.model?.contextWindow ?? 0)) return undefined;
+		if (classifyContextOverflow(message, transportFailure, this.model?.contextWindow ?? 0)) return undefined;
 		const transport = classifyFallbackTrigger(transportFailure ?? { status: message.errorStatus });
 		if (transport.class !== "other") return transport;
 		// Managed fallback receives authoritative transport facts from the request

--- a/packages/coding-agent/src/session/fallback-chain-controller.ts
+++ b/packages/coding-agent/src/session/fallback-chain-controller.ts
@@ -69,6 +69,14 @@ export class FallbackChainController {
 		this.#attemptStarted = true;
 	}
 
+	/** Remove the current started request from fallback-policy accounting without erasing prior failures. */
+	discardStartedAttempt(): void {
+		if (!this.#attemptStarted) return;
+		this.attemptsUsed = Math.max(0, this.attemptsUsed - 1);
+		this.#totalAttemptsUsed = Math.max(0, this.#totalAttemptsUsed - 1);
+		this.#attemptStarted = false;
+	}
+
 	/** Start a logically new request with a fresh fallback-chain budget. */
 	resetAttemptBudget(): void {
 		this.attemptsUsed = 0;

--- a/packages/coding-agent/test/agent-session-fallback-attempt-transaction.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-attempt-transaction.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent, type AgentOptions } from "@gajae-code/agent-core";
+import * as compactionModule from "@gajae-code/agent-core/compaction";
 import { type AssistantMessage, getBundledModel, type Model } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
@@ -112,7 +113,7 @@ function typedOverflowStream(model: Model): AssistantMessageEventStream {
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			},
 			stopReason: "error",
-			errorMessage: "context_length_exceeded: prompt exceeds the context window",
+			errorMessage: "",
 			errorStatus: 400,
 			timestamp: Date.now(),
 			transportFailure: { kind: "transport", status: 400, openaiErrorCode: "context_length_exceeded" },
@@ -271,6 +272,71 @@ describe("AgentSession managed fallback attempt transaction", () => {
 		expect(calls).not.toContain(selector(fallback));
 		expect(events).toContainEqual(expect.objectContaining({ type: "auto_compaction_start", reason: "overflow" }));
 		expect(events.filter(event => event.type === "model_fallback_switched")).toHaveLength(0);
+	});
+
+	it("terminalizes failed managed overflow maintenance and releases the next prompt", async () => {
+		let attempts = 0;
+		const { agent, primary } = createSession((model, context, options) => {
+			attempts += 1;
+			return attempts === 1
+				? typedOverflowStream(model)
+				: createMockModel({ responses: [{ content: ["Independent next prompt"] }] }).stream(
+						model,
+						context,
+						options,
+					);
+		}, 1);
+		session!.settings.set("compaction.enabled", true);
+		session!.settings.set("compaction.autoContinue", false);
+		for (let index = 0; index < 4; index++) {
+			const user = { role: "user" as const, content: `seed ${index}`, timestamp: Date.now() + index * 2 };
+			const assistant: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: `seed response ${index}` }],
+				api: primary.api,
+				provider: primary.provider,
+				model: primary.id,
+				usage: {
+					input: 30_000,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 30_001,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now() + index * 2 + 1,
+			};
+			agent.appendMessage(user);
+			session!.sessionManager.appendMessage(user);
+			agent.appendMessage(assistant);
+			session!.sessionManager.appendMessage(assistant);
+		}
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction").mockImplementation(() => {
+			throw new Error("request_too_large");
+		});
+		const events: AgentSessionEvent[] = [];
+		session!.subscribe(event => events.push(event));
+
+		await session!.prompt("Overflow whose maintenance fails", { skipCompactionCheck: true });
+		await session!.waitForIdle();
+
+		expect(prepareSpy).toHaveBeenCalled();
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
+		expect(agent.activeRunId).toBeUndefined();
+		expect(agent.currentManagedLogicalRunId).toBeUndefined();
+		expect(attempts).toBe(1);
+		prepareSpy.mockRestore();
+
+		await session!.prompt("Independent next prompt", { skipCompactionCheck: true });
+		await session!.waitForIdle();
+
+		expect(attempts).toBe(2);
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(2);
+		expect(session!.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			content: [{ type: "text", text: "Independent next prompt" }],
+		});
 	});
 
 	it("finalizes exhausted when every fallback tail entry is unavailable during resolution", async () => {

--- a/packages/coding-agent/test/agent-session-fallback-attempt-transaction.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-attempt-transaction.test.ts
@@ -92,6 +92,36 @@ function otherTransportFailureStream(model: Model, errorMessage: string): Assist
 	return stream;
 }
 
+function typedOverflowStream(model: Model): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage & {
+			transportFailure: { kind: "transport"; status: number; openaiErrorCode: string };
+		} = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage: "context_length_exceeded: prompt exceeds the context window",
+			errorStatus: 400,
+			timestamp: Date.now(),
+			transportFailure: { kind: "transport", status: 400, openaiErrorCode: "context_length_exceeded" },
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
+}
 describe("AgentSession managed fallback attempt transaction", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
@@ -214,6 +244,33 @@ describe("AgentSession managed fallback attempt transaction", () => {
 
 		expect(calls).toHaveLength(2);
 		expect(events).toContainEqual(expect.objectContaining({ type: "model_fallback_switched", reason: "unknown" }));
+	});
+
+	it("routes typed managed context overflow to compaction without consuming fallback attempts", async () => {
+		const calls: string[] = [];
+		let attempts = 0;
+		const { primary, fallback } = createSession(model => {
+			calls.push(selector(model));
+			return attempts++ === 0
+				? typedOverflowStream(model)
+				: createMockModel({ responses: [{ content: ["Recovered after compaction"] }] }).stream(model, {
+						systemPrompt: [],
+						messages: [],
+						tools: [],
+					});
+		}, 1);
+		session!.settings.set("compaction.enabled", true);
+		session!.settings.set("compaction.autoContinue", false);
+		const events: AgentSessionEvent[] = [];
+		session!.subscribe(event => events.push(event));
+
+		await session!.prompt("Route typed context overflow to compaction");
+		await session!.waitForIdle();
+
+		expect(calls).toContain(selector(primary));
+		expect(calls).not.toContain(selector(fallback));
+		expect(events).toContainEqual(expect.objectContaining({ type: "auto_compaction_start", reason: "overflow" }));
+		expect(events.filter(event => event.type === "model_fallback_switched")).toHaveLength(0);
 	});
 
 	it("finalizes exhausted when every fallback tail entry is unavailable during resolution", async () => {

--- a/packages/coding-agent/test/agent-session-fallback-cancel-idle.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-cancel-idle.test.ts
@@ -44,6 +44,37 @@ function failingStream(model: Model): AssistantMessageEventStream {
 	return stream;
 }
 
+function typedOpaqueOverflowStream(model: Model): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage & {
+			transportFailure: { kind: "transport"; status: number; openaiErrorCode: string };
+		} = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage: "",
+			errorStatus: 400,
+			timestamp: Date.now(),
+			transportFailure: { kind: "transport", status: 400, openaiErrorCode: "context_length_exceeded" },
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
+}
+
 describe("AgentSession managed fallback cancellation completion", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
@@ -194,5 +225,38 @@ describe("AgentSession managed fallback cancellation completion", () => {
 		expect(session!.isStreaming).toBe(false);
 		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
 		expect(events.find(event => event.type === "agent_end")).toMatchObject({ stopReason: "cancelled" });
+	});
+
+	it("abandons the overflow-maintenance handoff before any continuation provider call", async () => {
+		const calls: string[] = [];
+		createSession((model, _context, _options) => {
+			calls.push(selector(model));
+			return typedOpaqueOverflowStream(model);
+		});
+		session!.settings.set("compaction.enabled", true);
+		const compactionStarted = Promise.withResolvers<void>();
+		const events: AgentSessionEvent[] = [];
+		let abort: Promise<void> | undefined;
+		session!.subscribe(event => {
+			events.push(event);
+			if (event.type === "auto_compaction_start" && event.reason === "overflow") {
+				compactionStarted.resolve();
+				abort ??= session!.abort();
+			}
+		});
+
+		const run = session!.prompt("abort overflow maintenance");
+		await compactionStarted.promise;
+		await abort;
+		await run;
+		await session!.waitForIdle();
+
+		expect(calls).toHaveLength(1);
+		expect(session!.isStreaming).toBe(false);
+		expect(session!.isRetrying).toBe(false);
+		expect(events.filter(event => event.type === "agent_end")).toEqual([
+			expect.objectContaining({ stopReason: "cancelled" }),
+		]);
+		expect(events.filter(event => event.type === "model_fallback_switched")).toHaveLength(0);
 	});
 });

--- a/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
@@ -50,6 +50,36 @@ function rateLimitStream(model: Model): AssistantMessageEventStream {
 	return stream;
 }
 
+function typedRateLimitStream(model: Model, retryAfterMs: number): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage & {
+			transportFailure: { kind: "transport"; status: number; headers: Record<string, string> };
+		} = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage: "rate limit exceeded",
+			errorStatus: 429,
+			timestamp: Date.now(),
+			transportFailure: { kind: "transport", status: 429, headers: { "retry-after-ms": String(retryAfterMs) } },
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
+}
 function successfulStream(model: Model, content = "Recovered"): AssistantMessageEventStream {
 	return createMockModel({ responses: [{ content: [content] }] }).stream(model, {
 		systemPrompt: [],
@@ -165,6 +195,33 @@ describe("AgentSession managed fallback upstream request counts", () => {
 				attemptsUsed: 3,
 			}),
 		]);
+	});
+
+	it("suppresses the rate-limited head and returns to it when the cooldown expires", async () => {
+		const calls: string[] = [];
+		let primaryAttempts = 0;
+		const { primary, fallback } = createSession(1, (model, _context, _options) => {
+			calls.push(selector(model));
+			if (selector(model) === selector(primary) && primaryAttempts++ === 0) {
+				return typedRateLimitStream(model, 1);
+			}
+			return successfulStream(model, "Recovered");
+		});
+		const suppressSpy = vi.spyOn(modelRegistry, "suppressSelector");
+
+		await session!.prompt("Switch after a rate limit");
+		await session!.waitForIdle();
+
+		expect(calls).toEqual([selector(primary), selector(fallback)]);
+		expect(suppressSpy).toHaveBeenCalledWith(selector(primary), expect.any(Number));
+		expect(modelRegistry.getSelectorSuppressionStatus(selector(fallback))).toBe("none");
+		await Bun.sleep(5);
+
+		await session!.prompt("Return after cooldown expiry");
+		await session!.waitForIdle();
+
+		expect(calls).toEqual([selector(primary), selector(fallback), selector(primary)]);
+		expect(session!.model).toMatchObject({ provider: primary.provider, id: primary.id });
 	});
 
 	it("emits one switch when an exhausted chain restarts with an unavailable head", async () => {

--- a/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
@@ -50,7 +50,11 @@ function rateLimitStream(model: Model): AssistantMessageEventStream {
 	return stream;
 }
 
-function typedRateLimitStream(model: Model, retryAfterMs: number): AssistantMessageEventStream {
+function typedRateLimitStream(
+	model: Model,
+	retryAfterMs: number,
+	errorMessage = "rate limit exceeded",
+): AssistantMessageEventStream {
 	const stream = new AssistantMessageEventStream();
 	queueMicrotask(() => {
 		const message: AssistantMessage & {
@@ -70,10 +74,41 @@ function typedRateLimitStream(model: Model, retryAfterMs: number): AssistantMess
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			},
 			stopReason: "error",
-			errorMessage: "rate limit exceeded",
+			errorMessage,
 			errorStatus: 429,
 			timestamp: Date.now(),
 			transportFailure: { kind: "transport", status: 429, headers: { "retry-after-ms": String(retryAfterMs) } },
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
+}
+
+function typedOpaqueOverflowStream(model: Model): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage & {
+			transportFailure: { kind: "transport"; status: number; openaiErrorCode: string };
+		} = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage: "",
+			errorStatus: 400,
+			timestamp: Date.now(),
+			transportFailure: { kind: "transport", status: 400, openaiErrorCode: "context_length_exceeded" },
 		};
 		stream.push({ type: "start", partial: message });
 		stream.push({ type: "error", reason: "error", error: message });
@@ -154,6 +189,144 @@ describe("AgentSession managed fallback upstream request counts", () => {
 		}
 	});
 
+	it("keeps an opaque typed overflow budget-neutral before one rate limit advances N=1", async () => {
+		const calls: StreamCall[] = [];
+		const fallbackSwitches: Array<Extract<AgentSessionEvent, { type: "model_fallback_switched" }>> = [];
+		const events: AgentSessionEvent[] = [];
+		let primaryCalls = 0;
+		const { primary, fallback } = createSession(1, (model, context, options) => {
+			calls.push({
+				selector: selector(model),
+				fallbackManaged: options?.fallbackManaged,
+				fallbackAttempt: options?.fallbackAttempt,
+			});
+			if (selector(model) === selector(primary)) {
+				primaryCalls += 1;
+				return primaryCalls === 1 ? typedOpaqueOverflowStream(model) : typedRateLimitStream(model, 50);
+			}
+			return createMockModel({ responses: [{ content: ["Recovered after rate limit"] }] }).stream(
+				model,
+				context,
+				options,
+			);
+		});
+		const suppressSpy = vi.spyOn(modelRegistry, "suppressSelector");
+		session!.subscribe(event => {
+			events.push(event);
+			if (event.type === "model_fallback_switched") fallbackSwitches.push(event);
+		});
+
+		await session!.prompt("Recover through managed overflow maintenance");
+		await session!.waitForIdle();
+
+		expect(calls.map(call => call.selector)).toEqual([selector(primary), selector(primary), selector(fallback)]);
+		expect(calls.map(call => call.fallbackManaged)).toEqual([true, true, true]);
+		const attemptIds = calls.map(call => (call.fallbackAttempt as { attemptId: string }).attemptId);
+		expect(new Set(attemptIds).size).toBe(3);
+		expect(suppressSpy).toHaveBeenCalledTimes(1);
+		expect(suppressSpy).toHaveBeenCalledWith(selector(primary), expect.any(Number));
+		expect(fallbackSwitches).toEqual([
+			expect.objectContaining({
+				from: selector(primary),
+				to: selector(fallback),
+				reason: "rate_limit",
+				attemptsUsed: 1,
+			}),
+		]);
+		const assistantLifecycle = events.filter(
+			event =>
+				(event.type === "message_start" || event.type === "message_update" || event.type === "message_end") &&
+				"message" in event &&
+				event.message.role === "assistant",
+		);
+		expect(assistantLifecycle.filter(event => event.type === "message_start")).toHaveLength(1);
+		expect(assistantLifecycle.filter(event => event.type === "message_end")).toHaveLength(1);
+		expect(events.filter(event => event.type === "agent_end")).toEqual([
+			expect.objectContaining({ stopReason: "completed" }),
+		]);
+		expect(session!.messages.filter(message => message.role === "user")).toHaveLength(1);
+		expect(session!.messages.filter(message => message.role === "assistant")).toHaveLength(1);
+	});
+
+	it("advances typed 429 with hostile overflow prose without running maintenance", async () => {
+		const calls: string[] = [];
+		const events: AgentSessionEvent[] = [];
+		const { primary, fallback } = createSession(1, (model, context, options) => {
+			calls.push(selector(model));
+			return selector(model) === selector(primary)
+				? typedRateLimitStream(model, 50, "context_length_exceeded: context window exceeded")
+				: createMockModel({ responses: [{ content: ["Recovered after typed rate limit"] }] }).stream(
+						model,
+						context,
+						options,
+					);
+		});
+		session!.subscribe(event => events.push(event));
+
+		await session!.prompt("Advance despite hostile overflow prose");
+		await session!.waitForIdle();
+
+		expect(calls).toEqual([selector(primary), selector(fallback)]);
+		expect(events.filter(event => event.type === "auto_compaction_start")).toHaveLength(0);
+		expect(events).toContainEqual(
+			expect.objectContaining({ type: "model_fallback_switched", reason: "rate_limit", attemptsUsed: 1 }),
+		);
+	});
+
+	it("bounds repeated overflow maintenance within one logical run", async () => {
+		const calls: string[] = [];
+		const events: AgentSessionEvent[] = [];
+		const { primary, fallback } = createSession(1, model => {
+			calls.push(selector(model));
+			return typedOpaqueOverflowStream(model);
+		});
+		session!.subscribe(event => events.push(event));
+
+		await session!.prompt("Stop after bounded overflow maintenance");
+		await session!.waitForIdle();
+
+		expect(calls).toEqual([selector(primary), selector(primary)]);
+		expect(calls).not.toContain(selector(fallback));
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
+		expect(session!.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			stopReason: "error",
+		});
+	});
+	it("preserves a prior fallback charge across overflow maintenance", async () => {
+		const calls: string[] = [];
+		const fallbackSwitches: Array<Extract<AgentSessionEvent, { type: "model_fallback_switched" }>> = [];
+		let primaryCalls = 0;
+		const { primary, fallback } = createSession(2, (model, context, options) => {
+			calls.push(selector(model));
+			if (selector(model) === selector(primary)) {
+				primaryCalls += 1;
+				if (primaryCalls === 2) return typedOpaqueOverflowStream(model);
+				return rateLimitStream(model);
+			}
+			return createMockModel({ responses: [{ content: ["Recovered with preserved budget"] }] }).stream(
+				model,
+				context,
+				options,
+			);
+		});
+		session!.subscribe(event => {
+			if (event.type === "model_fallback_switched") fallbackSwitches.push(event);
+		});
+
+		await session!.prompt("Keep the first policy charge across overflow");
+		await session!.waitForIdle();
+
+		expect(calls).toEqual([selector(primary), selector(primary), selector(primary), selector(fallback)]);
+		expect(fallbackSwitches).toEqual([
+			expect.objectContaining({
+				reason: "rate_limit",
+				attemptsUsed: 2,
+				from: selector(primary),
+				to: selector(fallback),
+			}),
+		]);
+	});
 	it("N=3 performs exactly three upstream attempts before switching and reports attemptsUsed", async () => {
 		const calls: StreamCall[] = [];
 		const fallbackSwitches: Array<Extract<AgentSessionEvent, { type: "model_fallback_switched" }>> = [];

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -46,12 +46,19 @@ describe("planTasks command shape (issue #622)", () => {
 });
 
 describe("dev-ci canonical-plan workflow contract", () => {
-	test("binds the canonical plan to its checked-out source and validates it before aggregate decisions", async () => {
+	test("binds canonical artifacts to the run so attempt-2 consumers reuse attempt-1 producers safely", async () => {
 		const workflow = await Bun.file(path.join(import.meta.dir, "..", ".github", "workflows", "dev-ci.yml")).text();
 		expect(workflow.match(/ref: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/g)).toHaveLength(5);
 		expect(workflow.match(/Verify checked-out source head/g)).toHaveLength(5);
-		expect(workflow).toContain("name: dev-affected-plan-${{ github.run_id }}-${{ github.run_attempt }}");
-		expect(workflow.match(/\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/g)).toHaveLength(8);
+		expect(workflow).toContain("name: dev-affected-plan-${{ github.run_id }}");
+		expect(workflow).toContain("name: dev-affected-native-${{ github.run_id }}");
+		expect(workflow).toContain("name: dev-affected-shard-${{ github.run_id }}-${{ strategy.job-index }}");
+		expect(workflow).toContain("pattern: dev-affected-shard-${{ github.run_id }}-*");
+		expect(workflow).not.toContain("github.run_attempt");
+		expect(workflow.match(/overwrite: true/g)).toHaveLength(3);
+		expect(workflow.match(/dev-affected-plan-\$\{\{ github\.run_id \}\}/g)).toHaveLength(4);
+		expect(workflow.match(/dev-affected-native-\$\{\{ github\.run_id \}\}/g)).toHaveLength(2);
+		expect(workflow.match(/dev-affected-shard-\$\{\{ github\.run_id \}\}/g)).toHaveLength(2);
 		expect(workflow).toContain("include-hidden-files: true");
 		expect(workflow.match(/include-hidden-files: true/g)).toHaveLength(2);
 		expect(workflow).toContain("CI_DEV_PLAN_DIGEST: ${{ needs.affected-plan.outputs.plan_digest }}");


### PR DESCRIPTION
## Summary
Follow-up landing the two final architect P1 fixes committed after the routing PR (#2459) merged:
- managed-chain context overflow short-circuits typed-facts retry classification and fallback triggers, so context_length_exceeded 400s reach #checkCompaction instead of burning fallback attempts (matches docs/non-compaction-retry-policy.md)
- advance-path rate-limit suppression captures the FAILED selector before controller advance, so head suppression is recorded correctly and cooldown-expiry reverts to the primary (fallback.maxAttempts:1 regression)

## Verification
- focused fallback/retry/registry suites: 199 pass at 1969e7ae; package typecheck green

Refs #2377 #2378 #2382