### PR TITLE
fix(harness): stamp workflow receipts with real session-layout paths

### DIFF
--- a/packages/coding-agent/src/skill-state/workflow-state-contract.ts
+++ b/packages/coding-agent/src/skill-state/workflow-state-contract.ts
@@ -1,5 +1,5 @@
-import * as path from "node:path";
-import { CANONICAL_GJC_WORKFLOW_SKILLS, type CanonicalGjcWorkflowSkill, SKILL_ACTIVE_STATE_FILE } from "./active-state";
+import { activeSnapshotPath, modeStatePath } from "../gjc-runtime/session-layout";
+import { CANONICAL_GJC_WORKFLOW_SKILLS, type CanonicalGjcWorkflowSkill } from "./active-state";
 import { WORKFLOW_STATE_RECEIPT_FRESH_MS, WORKFLOW_STATE_RECEIPT_VERSION } from "./workflow-state-version";
 
 export {
@@ -55,42 +55,16 @@ function safeString(value: unknown): string {
 	return typeof value === "string" ? value : "";
 }
 
-function encodePathSegment(value: string): string {
-	return encodeURIComponent(value).replaceAll(".", "%2E");
-}
-
 export function workflowModeStateFileName(skill: CanonicalGjcWorkflowSkill): string {
 	return `${skill}-state.json`;
 }
 
-export function workflowStateStoragePath(cwd: string, skill: CanonicalGjcWorkflowSkill, sessionId?: string): string {
-	const normalizedSessionId = safeString(sessionId).trim();
-	if (normalizedSessionId) {
-		return path.join(
-			cwd,
-			".gjc",
-			"state",
-			"sessions",
-			encodePathSegment(normalizedSessionId),
-			workflowModeStateFileName(skill),
-		);
-	}
-	return path.join(cwd, ".gjc", "state", workflowModeStateFileName(skill));
-}
+/** Session id used when a receipt is stamped without an explicit session. */
+const RECEIPT_FALLBACK_SESSION_ID = "default";
 
-export function workflowActiveStatePath(cwd: string, sessionId?: string): string {
-	const normalizedSessionId = safeString(sessionId).trim();
-	if (normalizedSessionId) {
-		return path.join(
-			cwd,
-			".gjc",
-			"state",
-			"sessions",
-			encodePathSegment(normalizedSessionId),
-			SKILL_ACTIVE_STATE_FILE,
-		);
-	}
-	return path.join(cwd, ".gjc", "state", SKILL_ACTIVE_STATE_FILE);
+function receiptSessionId(sessionId?: string): string {
+	const normalized = safeString(sessionId).trim();
+	return normalized || RECEIPT_FALLBACK_SESSION_ID;
 }
 
 export function buildWorkflowStateReceipt(input: {
@@ -104,13 +78,16 @@ export function buildWorkflowStateReceipt(input: {
 }): WorkflowStateReceipt {
 	const mutatedAt = input.nowIso ?? new Date().toISOString();
 	const freshUntil = new Date(Date.parse(mutatedAt) + WORKFLOW_STATE_RECEIPT_FRESH_MS).toISOString();
+	const sessionId = receiptSessionId(input.sessionId);
 	return {
 		version: WORKFLOW_STATE_RECEIPT_VERSION,
 		skill: input.skill,
 		owner: input.owner,
 		command: input.command,
-		state_path: workflowActiveStatePath(input.cwd, input.sessionId),
-		storage_path: workflowStateStoragePath(input.cwd, input.skill, input.sessionId),
+		// Match the on-disk layout used by writers/readers (session-layout), not the
+		// historical `.gjc/state/sessions/...` paths that never existed on disk.
+		state_path: activeSnapshotPath(input.cwd, sessionId),
+		storage_path: modeStatePath(input.cwd, sessionId, input.skill),
 		mutated_at: mutatedAt,
 		fresh_until: freshUntil,
 		status: "fresh",

--- a/packages/coding-agent/src/skill-state/workflow-state-contract.ts
+++ b/packages/coding-agent/src/skill-state/workflow-state-contract.ts
@@ -1,5 +1,5 @@
 import { activeSnapshotPath, modeStatePath } from "../gjc-runtime/session-layout";
-import { CANONICAL_GJC_WORKFLOW_SKILLS, type CanonicalGjcWorkflowSkill } from "./active-state";
+import { CANONICAL_GJC_WORKFLOW_SKILLS, type CanonicalGjcWorkflowSkill, SKILL_ACTIVE_STATE_FILE } from "./active-state";
 import { WORKFLOW_STATE_RECEIPT_FRESH_MS, WORKFLOW_STATE_RECEIPT_VERSION } from "./workflow-state-version";
 
 export {

--- a/packages/coding-agent/test/gjc-runtime/workflow-receipt-paths.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/workflow-receipt-paths.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { activeSnapshotPath, modeStatePath } from "../../src/gjc-runtime/session-layout";
+import { buildWorkflowStateReceipt } from "../../src/skill-state/workflow-state-contract";
+
+describe("workflow receipt paths", () => {
+	test("receipts stamp the real _session- layout paths", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-receipt-paths-"));
+		const sessionId = "sess-receipt-1";
+		const skill = "ralplan" as const;
+
+		const receipt = buildWorkflowStateReceipt({
+			cwd,
+			skill,
+			owner: "gjc-state-cli",
+			command: "gjc state ralplan write",
+			sessionId,
+			nowIso: "2026-07-17T00:00:00.000Z",
+			mutationId: "mut-1",
+		});
+
+		const expectedState = activeSnapshotPath(cwd, sessionId);
+		const expectedStorage = modeStatePath(cwd, sessionId, skill);
+		expect(receipt.state_path).toBe(expectedState);
+		expect(receipt.storage_path).toBe(expectedStorage);
+		expect(receipt.state_path).toContain(`${path.sep}.gjc${path.sep}_session-`);
+		expect(receipt.state_path).not.toContain(`${path.sep}state${path.sep}sessions${path.sep}`);
+		expect(receipt.storage_path).not.toContain(`${path.sep}state${path.sep}sessions${path.sep}`);
+
+		await fs.mkdir(path.dirname(expectedState), { recursive: true });
+		await fs.writeFile(expectedState, "{}\n");
+		await fs.writeFile(expectedStorage, "{}\n");
+		await expect(fs.stat(receipt.state_path)).resolves.toBeDefined();
+		await expect(fs.stat(receipt.storage_path)).resolves.toBeDefined();
+	});
+
+	test("missing sessionId falls back to a stable default session segment", () => {
+		const cwd = "/tmp/project";
+		const receipt = buildWorkflowStateReceipt({
+			cwd,
+			skill: "deep-interview",
+			owner: "gjc-runtime",
+			command: "gjc deep-interview",
+		});
+		expect(receipt.state_path).toBe(activeSnapshotPath(cwd, "default"));
+		expect(receipt.storage_path).toBe(modeStatePath(cwd, "default", "deep-interview"));
+	});
+});


### PR DESCRIPTION
## Summary
- `buildWorkflowStateReceipt` now derives `state_path` / `storage_path` from `session-layout` (`activeSnapshotPath` / `modeStatePath`) instead of the unused legacy `.gjc/state/sessions/...` helpers
- Deletes `workflowActiveStatePath` / `workflowStateStoragePath` so receipt paths match the real `_session-` layout writers and readers use
- Adds a focused unit test that asserts the stamped paths exist after a write and never use the legacy layout

## Why
Receipts pointed operators/doctor tooling at nonexistent paths while CLI write results already reported the real on-disk path (issue #2393).

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/workflow-receipt-paths.test.ts` (2 pass)

Closes #2393