### PR TITLE
fix(tui): centralize expand-hint copy on one constant

### DIFF
--- a/packages/coding-agent/src/modes/components/branch-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/branch-summary-message.ts
@@ -1,6 +1,7 @@
 import { Box, Markdown, Spacer, Text } from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import type { BranchSummaryMessage } from "../../session/messages";
+import { EXPAND_HINT_TEXT } from "../../tools/render-utils";
 
 /**
  * Component that renders a branch summary message with collapsed/expanded state.
@@ -39,7 +40,7 @@ export class BranchSummaryMessageComponent extends Box {
 				}),
 			);
 		} else {
-			this.addChild(new Text(theme.fg("customMessageText", "Branch summary (ctrl+o to expand)"), 0, 0));
+			this.addChild(new Text(theme.fg("customMessageText", `Branch summary (${EXPAND_HINT_TEXT})`), 0, 0));
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/components/compaction-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/compaction-summary-message.ts
@@ -1,6 +1,7 @@
 import { Box, Markdown, Spacer, Text } from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import type { CompactionSummaryMessage } from "../../session/messages";
+import { EXPAND_HINT_TEXT } from "../../tools/render-utils";
 
 /**
  * Component that renders a compaction message with collapsed/expanded state.
@@ -41,7 +42,7 @@ export class CompactionSummaryMessageComponent extends Box {
 			);
 		} else {
 			this.addChild(
-				new Text(theme.fg("customMessageText", `Compacted from ${tokenStr} tokens (ctrl+o to expand)`), 0, 0),
+				new Text(theme.fg("customMessageText", `Compacted from ${tokenStr} tokens (${EXPAND_HINT_TEXT})`), 0, 0),
 			);
 			if (this.message.shortSummary) {
 				this.addChild(new Text(theme.fg("customMessageText", this.message.shortSummary), 0, 1));

--- a/packages/coding-agent/src/modes/components/execution-shared.ts
+++ b/packages/coding-agent/src/modes/components/execution-shared.ts
@@ -10,6 +10,7 @@
 import { type Component, Container, Loader, Spacer, Text, type TUI } from "@gajae-code/tui";
 import { getSymbolTheme, theme } from "../../modes/theme/theme";
 import { formatTruncationMetaNotice, type TruncationMeta } from "../../tools/output-meta";
+import { EXPAND_HINT_TEXT } from "../../tools/render-utils";
 import { DynamicBorder } from "./dynamic-border";
 import { truncateToVisualLines } from "./visual-truncate";
 
@@ -76,7 +77,7 @@ export function buildStatusFooter(opts: {
 	const parts: string[] = [];
 
 	if (opts.hiddenLineCount > 0 && !opts.suppressHiddenCount) {
-		parts.push(theme.fg("dim", `… ${opts.hiddenLineCount} more lines (ctrl+o to expand)`));
+		parts.push(theme.fg("dim", `… ${opts.hiddenLineCount} more lines (${EXPAND_HINT_TEXT})`));
 	}
 	if (opts.status === "cancelled") {
 		parts.push(theme.fg("warning", "(cancelled)"));

--- a/packages/coding-agent/src/modes/components/ttsr-notification.ts
+++ b/packages/coding-agent/src/modes/components/ttsr-notification.ts
@@ -1,6 +1,7 @@
 import { Box, Container, Spacer, Text } from "@gajae-code/tui";
 import type { Rule } from "../../capability/rule";
 import { theme } from "../../modes/theme/theme";
+import { EXPAND_HINT_TEXT } from "../../tools/render-utils";
 
 /**
  * Component that renders a TTSR (Time Traveling Stream Rules) notification.
@@ -73,7 +74,7 @@ export class TtsrNotificationComponent extends Container {
 				return desc && desc.split("\n").length > 2;
 			});
 			if (hasMoreContent) {
-				this.#box.addChild(new Text(theme.italic(" (ctrl+o to expand)"), 0, 0));
+				this.#box.addChild(new Text(theme.italic(` (${EXPAND_HINT_TEXT})`), 0, 0));
 			}
 		}
 	}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -31,7 +31,7 @@ import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-ski
 import { checkComposerBashPolicy } from "./composer-bash-policy";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
-import { formatToolWorkingDirectory, replaceTabs } from "./render-utils";
+import { EXPAND_HINT_TEXT, formatToolWorkingDirectory, replaceTabs } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
@@ -1333,7 +1333,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 								outputLines.push(
 									uiTheme.fg(
 										"dim",
-										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length}) (ctrl+o to expand)`,
+										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length}) (${EXPAND_HINT_TEXT})`,
 									),
 								);
 							}

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -20,7 +20,7 @@ import {
 	resolveOutputSinkHeadBytes,
 	stripOutputNotice,
 } from "./output-meta";
-import { formatTitle, replaceTabs, shortenPath, truncateToWidth, wrapBrackets } from "./render-utils";
+import { EXPAND_HINT_TEXT, formatTitle, replaceTabs, shortenPath, truncateToWidth, wrapBrackets } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -947,7 +947,7 @@ export const evalToolRenderer = {
 						const outputLines = [...outputContent.lines];
 						if (!expanded && outputContent.hiddenCount > 0) {
 							outputLines.push(
-								uiTheme.fg("dim", `… ${outputContent.hiddenCount} more lines (ctrl+o to expand)`),
+								uiTheme.fg("dim", `… ${outputContent.hiddenCount} more lines (${EXPAND_HINT_TEXT})`),
 							);
 						}
 						if (statusLines.length > 0) {
@@ -1066,7 +1066,7 @@ export const evalToolRenderer = {
 					outputLines.push("");
 					const skippedLine = uiTheme.fg(
 						"dim",
-						`… (${cachedSkipped} earlier lines, showing ${cachedLines.length} of ${cachedSkipped + cachedLines.length}) (ctrl+o to expand)`,
+						`… (${cachedSkipped} earlier lines, showing ${cachedLines.length} of ${cachedSkipped + cachedLines.length}) (${EXPAND_HINT_TEXT})`,
 					);
 					outputLines.push(truncateToWidth(skippedLine, width));
 				}

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -75,8 +75,10 @@ export const TRUNCATE_LENGTHS = {
 	SHORT: 40,
 } as const;
 
-/** Standard expand hint text */
-export const EXPAND_HINT = "(Ctrl+O for more)";
+/** Standard expand hint text (plain, no theme brackets). */
+export const EXPAND_HINT_TEXT = "ctrl+o to expand";
+/** Bracket-wrapped default used by formatExpandHint via theme brackets. */
+export const EXPAND_HINT = EXPAND_HINT_TEXT;
 
 // =============================================================================
 // Text Truncation Utilities

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -20,6 +20,7 @@ import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } fro
 import { ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
+import { EXPAND_HINT_TEXT } from "./render-utils";
 
 const sshSchema = z.object({
 	host: z.string().describe("ssh host"),
@@ -266,7 +267,7 @@ export const sshToolRenderer = {
 							outputLines.push(
 								uiTheme.fg(
 									"dim",
-									`… (${skippedCount} earlier lines, showing ${visualLines.length} of ${totalVisualLines}) (ctrl+o to expand)`,
+									`… (${skippedCount} earlier lines, showing ${visualLines.length} of ${totalVisualLines}) (${EXPAND_HINT_TEXT})`,
 								),
 							);
 						}
@@ -281,7 +282,7 @@ export const sshToolRenderer = {
 						const remaining = outputLinesRaw.length - maxLines;
 						outputLines.push(...displayLines.map(line => uiTheme.fg("toolOutput", line)));
 						if (remaining > 0) {
-							outputLines.push(uiTheme.fg("dim", `… (${remaining} more lines) (ctrl+o to expand)`));
+							outputLines.push(uiTheme.fg("dim", `… (${remaining} more lines) (${EXPAND_HINT_TEXT})`));
 						}
 					}
 				}

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -17,10 +17,10 @@ import { renderStatusLine } from "../tui";
 import { CachedOutputBlock } from "../tui/output-block";
 import type { ToolSession } from ".";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
+import { EXPAND_HINT_TEXT } from "./render-utils";
 import { ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
-import { EXPAND_HINT_TEXT } from "./render-utils";
 
 const sshSchema = z.object({
 	host: z.string().describe("ssh host"),


### PR DESCRIPTION
## Summary
- Introduce `EXPAND_HINT_TEXT` as the single plain-text source for collapsed-output expand copy
- Replace hard-coded `(ctrl+o to expand)` strings in bash/eval/ssh renderers, execution-shared status line, branch/compaction summaries, and TTSR notification
- Keep `formatExpandHint` on the same constant so themed and freeform hints cannot drift

## Why
Nine surfaces independently hard-coded the expand affordance, so wording already drifted (`Ctrl+O for more` vs `ctrl+o to expand`). This is a mechanical consistency fix and a step toward #2448 without the blocked package API boundary change (keybinding-aware capability still needs an owner decision).

## Verification
- `bun test packages/coding-agent/test/modes/components/redesigned-shell.test.ts packages/coding-agent/test/tools/bash-sixel-render.test.ts` (25 pass)

## Non-goals
- Keybinding-aware / focus-aware expand hints (still blocked on the package API boundary decision in #2448)