### PR TITLE
fix(ultragoal): treat explicit user request as execution approval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,10 @@ Use the smallest workflow that satisfies the request:
 1. Direct implementation for clear, low-risk edits.
 2. `deep-interview` when intent, scope, or acceptance criteria are ambiguous.
 3. `ralplan` when requirements are clear enough to plan but architecture, sequencing, or verification needs consensus.
-4. `ultragoal` when work should be split into durable goals with an auditable ledger.
+4. `ultragoal` when work should be split into durable goals with an auditable ledger. An explicit user request for ultragoal is execution approval — start without re-asking.
 5. `team` when approved work benefits from parallel workers.
 
-Do not execute implementation from `deep-interview` or `ralplan` unless the user explicitly approves execution. Planning artifacts must remain `pending approval` until that approval exists.
+Do not execute implementation from `deep-interview` or `ralplan` unless the user explicitly approves execution. Planning artifacts must remain `pending approval` until that approval exists. An explicit user request to run `ultragoal` or `team` is that approval for the named execution skill.
 
 Subagent await timeouts are observation windows, not failure signals. Do not cancel a subagent merely because `subagent await` timed out; inspect/list, continue independent work, and cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Explicit user requests for `ultragoal` (`ultragoal`, `/skill:ultragoal`, `gjc ultragoal`, or equivalent) are now treated as execution approval: the agent starts immediately and no longer re-asks whether to begin. The ralplan-first detour remains only for inferred ultragoal routes without an approved plan.
+
 ## [0.11.1] - 2026-07-16
 
 ### Fixed

--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -9,6 +9,12 @@ source: "forked from upstream ultragoal skill and rebranded for GJC"
 
 Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durable multi-goal planning, or sequential execution over GJC goal mode.
 
+## Explicit start is approval
+
+When the user explicitly asks to run ultragoal in the current prompt — `ultragoal`, `/skill:ultragoal`, `gjc ultragoal`, "ultragoal 실행", or an equivalent direct execution request — that is execution approval. Start immediately: materialize goals from the brief and drive execution. Do not re-prompt with "should I start?", "execute?", or other pre-start approval options.
+
+This override applies only to the pre-start consent gate. During an active run, keep the existing blocker/pause/`ask` discipline.
+
 ## Purpose
 
 `ultragoal` turns a brief into repo-native durable artifacts and then drives execution through the unified `goal` tool as a UX bridge only. `goals.json` is the canonical source of goal identity and state; `ledger.jsonl` is the canonical proof stream for checkpoints, receipts, blockers, steering, and reviews. The inline `goal` tool and goal-mode-request create-bridge exist only to keep the agent's interactive loop focused on the current aggregate or story objective. Completion is verified purely from durable `goals.json` plus fresh `ledger.jsonl` receipts, never from inline goal state. The agent, not the CLI or hooks, calls `goal({"op":"complete"})` or `goal({"op":"drop"})` after durable run completion or cleanup; CLI commands and hooks never mutate goal state.
@@ -199,7 +205,7 @@ Forced-delegation rules:
 
 When delegating with native subagents, an await timeout only limits the leader's wait. It is not subagent failure evidence and must not be used as a cancellation reason; inspect or continue independent work, and cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
 
-If an Ultragoal request has no approved plan or consensus artifact, run `ralplan` first and preserve its PRD, test spec, role roster, and verification guidance in the Ultragoal ledger. Do not silently substitute ad-hoc execution for missing planning.
+If ultragoal was only inferred (the user did not explicitly request it) and there is no approved plan or consensus artifact, run `ralplan` first and preserve its PRD, test spec, role roster, and verification guidance in the Ultragoal ledger. Do not silently substitute ad-hoc execution for missing planning on inferred routes. When the user explicitly requested ultragoal, skip the pre-start approval ask and begin execution from the current brief/plan without detouring through a second consent prompt.
 
 The Ultragoal leader owns `.gjc/_session-{sessionid}/ultragoal/goals.json` and `.gjc/_session-{sessionid}/ultragoal/ledger.jsonl`. Role agents return implementation/review evidence; they do not checkpoint Ultragoal or mutate goal state.
 

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -69,7 +69,7 @@ Use for read-only plan critique. It approves only when execution can proceed wit
 - Ambiguous implementation asks with missing target, scope, acceptance criteria, or safety boundary require clarification or the appropriate planning workflow before mutation.
 - Vague requirements → use `deep-interview`; clear requirements with non-trivial architecture/sequence risk → use `ralplan --deliberate` and stop at pending approval.
 - Architecture/sequence risk that is clear enough to plan but not safe to execute directly → use `ralplan --deliberate` and stop at pending approval.
-- Durable goal ledger needed → use `ultragoal`; approved work that benefits from coordinated persistent workers → use `team`.
+- Durable goal ledger needed → use `ultragoal`. When the user explicitly requests ultragoal execution in the current prompt (`ultragoal`, `/skill:ultragoal`, `gjc ultragoal`, or equivalent), that request is execution approval: invoke ultragoal immediately and do not re-ask whether to start. When ultragoal is only inferred and no approved plan exists, prefer `ralplan` first; approved work that benefits from coordinated persistent workers → use `team`.
 - Large enough implementation work → delegate bounded slices to `executor`; use `planner`, `architect`, and `critic` for bounded planning/review lanes when a full workflow is unnecessary.
 - Treat root-cause phase schema workflows as special-purpose gates only for contradiction, regression, or high-risk transition analysis; do not apply them to ordinary clear fixes.
 - Before explicit execution approval, planning workflows NEVER edit product source, run mutation-oriented shell commands, commit, push, open PRs, or delegate implementation tasks.
@@ -78,7 +78,8 @@ Use for read-only plan critique. It approves only when execution can proceed wit
 <skill-discipline>
 - Never ignore a skill invocation or any skill text. When a skill is active, read it in full and follow it exactly.
 - Read-only, interview, and planning skills must not implement or mutate before approval. Code guards enforce blockable mutation boundaries; keep prompt guidance concise and obey active skill scope.
-- Recommend `/skill:<name>` only when the task fits a bundled skill; otherwise, when no skill is active or the active skill permits it, perform non-destructive correct action directly.
+- When the user explicitly requests a bundled workflow skill by name in the current prompt (`/skill:<name>`, the skill name, or `gjc <name>`), that request is approval: invoke it immediately in the same turn. Do not re-ask "should I start?" / "execute?" before beginning.
+- Recommend `/skill:<name>` only when the task fits a bundled skill but the user did not name it; otherwise, when no skill is active or the active skill permits it, perform non-destructive correct action directly.
 </skill-discipline>
 
 <runtime-state>

--- a/packages/coding-agent/src/prompts/tools/skill.md
+++ b/packages/coding-agent/src/prompts/tools/skill.md
@@ -18,6 +18,7 @@ Invoke another available skill in the current turn.
 - Do NOT chain into the same skill recursively. If a skill's flow needs another iteration, follow its in-document instructions.
 - `name` MUST be one concrete skill name, NOT a glob or wildcard. Passing `*`, `?`, or a pattern like `git-*` is rejected immediately — the `--skills '*'` launch filter is unrelated to this tool's `name`.
 - The chained skill's planning/execution-boundary rules still apply. Chaining does not grant execution approval.
+- When the user explicitly requested the target skill in the current prompt, invoke it without re-asking for start/execution approval. Chaining from a planning skill still requires the planning skill's own handoff rules.
 </critical>
 
 <examples>

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -319,6 +319,14 @@ Project executor override body.
 		}
 		expect(systemPrompt).toContain("delegate bounded slices to `executor`");
 		expect(systemPrompt).toContain("committed repo-visible `.gjc` defaults are not the source of truth");
+		expect(systemPrompt).toContain("explicitly requests ultragoal execution");
+		expect(systemPrompt).toContain("that request is execution approval");
+		expect(systemPrompt).toContain("do not re-ask whether to start");
+		expect(systemPrompt).toContain("that request is approval: invoke it immediately");
+		expect(ultragoal).toContain("## Explicit start is approval");
+		expect(ultragoal).toContain("that is execution approval");
+		expect(ultragoal).toContain("Do not re-prompt with \"should I start?\"");
+		expect(ultragoal).toContain("only inferred");
 		expect(ultragoal).toContain("run `ralplan` first");
 		expect(ultragoal).toContain("Role agents return implementation/review evidence");
 		expect(ultragoal).toContain("await timeout only limits the leader's wait");


### PR DESCRIPTION
## Summary

- When a user **explicitly** asks for ultragoal in the prompt (`ultragoal`, `/skill:ultragoal`, `gjc ultragoal`, "ultragoal 실행", etc.), treat that as **execution approval** and start immediately.
- Stop the redundant pre-start consent loop that asked "실행할까요?" / "should I start?" even after the user already named ultragoal.
- Keep the ralplan-first planning detour only for **inferred** ultragoal routes with no approved plan; do not re-gate explicit ultragoal starts through a second approval prompt.
- Contract-test the system-prompt routing, skill-discipline, and ultragoal skill wording so this cannot regress silently.

## Why this fix is necessary

This is a high-friction product bug, not a nice-to-have polish item.

1. **User intent was already explicit.** Saying "ultragoal로 해" / `/skill:ultragoal` / `gjc ultragoal ...` is consent to execute. Asking again whether to start is pure ceremony and trains users to distrust the agent.
2. **It breaks the execution workflow's value proposition.** Ultragoal exists for durable, autonomous multi-goal execution with evidence. Forcing a pre-start approval after the user already selected ultragoal turns an execution skill into another planning gate.
3. **The old guidance actively caused the bad behavior.** Ultragoal told agents to run `ralplan` first when no approved plan existed, and ralplan always ends in an approval ask. Combined with skill-discipline "recommend then wait", explicit ultragoal requests still got double-gated.
4. **Safety is preserved where it matters.** Planning skills (`deep-interview`, `ralplan`) still require explicit execution approval. Active ultragoal runs still keep blocker/pause/`ask` discipline. Only the redundant **pre-start** consent ask is removed for already-explicit ultragoal requests.

Without this, every intentional ultragoal launch pays an unnecessary human round-trip and the agent looks like it is stalling on work the user already ordered.

## Test plan

- [x] `bun test packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/system-prompt-templates.test.ts`
- [ ] Manual: prompt with explicit `ultragoal <task>` and confirm agent starts create-goals/execution without a pre-start approval ask
- [ ] Manual: inferred durable multi-goal need without naming ultragoal still prefers ralplan-first when no approved plan exists
- [ ] Manual: deep-interview/ralplan still stop at pending approval until explicit execution selection