### PR TITLE
fix(ultragoal): treat explicit user request as execution approval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,10 @@ Use the smallest workflow that satisfies the request:
 1. Direct implementation for clear, low-risk edits.
 2. `deep-interview` when intent, scope, or acceptance criteria are ambiguous.
 3. `ralplan` when requirements are clear enough to plan but architecture, sequencing, or verification needs consensus.
-4. `ultragoal` when work should be split into durable goals with an auditable ledger.
+4. `ultragoal` when work should be split into durable goals with an auditable ledger. An explicit user request for ultragoal is execution approval — start without re-asking.
 5. `team` when approved work benefits from parallel workers.
 
-Do not execute implementation from `deep-interview` or `ralplan` unless the user explicitly approves execution. Planning artifacts must remain `pending approval` until that approval exists.
+Do not execute implementation from `deep-interview` or `ralplan` unless the user explicitly approves execution. Planning artifacts must remain `pending approval` until that approval exists. An explicit user request to run `ultragoal` or `team` is that approval for the named execution skill.
 
 Subagent await timeouts are observation windows, not failure signals. Do not cancel a subagent merely because `subagent await` timed out; inspect/list, continue independent work, and cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,11 +19,14 @@
 - Active deep-interview sessions now resume automatically after a normal assistant stop while ordinary active interviewing remains eligible, using bounded workflow-state continuation; recovery, leak, stale-state, handoff, and crystallization blocks remain Stop-gate handled.
 
 ### Changed
-+- Removed deprecated `DiscoverableMCPTool`, `DiscoverableMCPSearchIndex`, and related MCP-only discovery helper exports. Use the unified `DiscoverableTool` discovery APIs; the `mcp.discoveryMode` settings alias remains supported.
+- Removed deprecated `DiscoverableMCPTool`, `DiscoverableMCPSearchIndex`, and related MCP-only discovery helper exports. Use the unified `DiscoverableTool` discovery APIs; the `mcp.discoveryMode` settings alias remains supported.
 
 ### Fixed
 - Connected MCP server instructions now remain untrusted user-role data instead of entering the cached system prompt; hostile file paths, working directories, and workspace-tree metadata are structurally encoded, and volatile project context is removed from durable session history between requests.
 - Restored the strict G002 public-surface quarantine by removing the default README advertisement for the private coordinator MCP runtime.
+
+### Fixed
+- Explicit user requests for `ultragoal` (`ultragoal`, `/skill:ultragoal`, `gjc ultragoal`, or equivalent) are now treated as execution approval: the agent starts immediately and no longer re-asks whether to begin. The ralplan-first detour remains only for inferred ultragoal routes without an approved plan.
 
 ## [0.11.1] - 2026-07-16
 

--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -9,6 +9,12 @@ source: "forked from upstream ultragoal skill and rebranded for GJC"
 
 Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durable multi-goal planning, or sequential execution over GJC goal mode.
 
+## Explicit start is approval
+
+When the user explicitly asks to run ultragoal in the current prompt — `ultragoal`, `/skill:ultragoal`, `gjc ultragoal`, "ultragoal 실행", or an equivalent direct execution request — that is execution approval. Start immediately: materialize goals from the brief and drive execution. Do not re-prompt with "should I start?", "execute?", or other pre-start approval options.
+
+This override applies only to the pre-start consent gate. During an active run, keep the existing blocker/pause/`ask` discipline.
+
 ## Purpose
 
 `ultragoal` turns a brief into repo-native durable artifacts and then drives execution through the unified `goal` tool as a UX bridge only. `goals.json` is the canonical source of goal identity and state; `ledger.jsonl` is the canonical proof stream for checkpoints, receipts, blockers, steering, and reviews. The inline `goal` tool and goal-mode-request create-bridge exist only to keep the agent's interactive loop focused on the current aggregate or story objective. Completion is verified purely from durable `goals.json` plus fresh `ledger.jsonl` receipts, never from inline goal state. The agent, not the CLI or hooks, calls `goal({"op":"complete"})` or `goal({"op":"drop"})` after durable run completion or cleanup; CLI commands and hooks never mutate goal state.
@@ -199,7 +205,7 @@ Forced-delegation rules:
 
 When delegating with native subagents, an await timeout only limits the leader's wait. It is not subagent failure evidence and must not be used as a cancellation reason; inspect or continue independent work, and cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
 
-If an Ultragoal request has no approved plan or consensus artifact, run `ralplan` first and preserve its PRD, test spec, role roster, and verification guidance in the Ultragoal ledger. Do not silently substitute ad-hoc execution for missing planning.
+If ultragoal was only inferred (the user did not explicitly request it) and there is no approved plan or consensus artifact, run `ralplan` first and preserve its PRD, test spec, role roster, and verification guidance in the Ultragoal ledger. Do not silently substitute ad-hoc execution for missing planning on inferred routes. When the user explicitly requested ultragoal, skip the pre-start approval ask and begin execution from the current brief/plan without detouring through a second consent prompt.
 
 The Ultragoal leader owns `.gjc/_session-{sessionid}/ultragoal/goals.json` and `.gjc/_session-{sessionid}/ultragoal/ledger.jsonl`. Role agents return implementation/review evidence; they do not checkpoint Ultragoal or mutate goal state.
 

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -22,9 +22,9 @@ Optimize for correctness first, maintainability second, and brevity third. Prefe
 - Clear, low-risk implementation requests use direct tools and focused verification; do not invoke workflows or role agents for ceremony.
 - Informational questions are answer-only/read-only unless the user explicitly requests a change, command, or execution.
 - Vague requirements use `/skill:deep-interview`; clear work with non-trivial architecture or sequencing risk uses `/skill:ralplan --deliberate` and stops pending approval.
-- Use `/skill:ultragoal` for durable goal ledgers and `/skill:team` for approved coordinated persistent work.
+- Use `/skill:ultragoal` for durable goal ledgers and `/skill:team` for approved coordinated persistent work. When the user explicitly requests ultragoal execution in the current prompt (`ultragoal`, `/skill:ultragoal`, `gjc ultragoal`, or equivalent), that request is execution approval: invoke ultragoal immediately and do not re-ask whether to start. When ultragoal is only inferred and no approved plan exists, prefer ralplan first.
 - Delegate large implementation slices to `executor`; use `planner`, `architect`, or `critic` for bounded planning and review.
-- Active skills are authoritative: read and follow them; planning and read-only skills do not mutate before approval.
+- Active skills are authoritative: read and follow them; planning and read-only skills do not mutate before approval. When the user explicitly requests a bundled workflow skill by name in the current prompt (`/skill:<name>`, the skill name, or `gjc <name>`), that request is approval: invoke it immediately in the same turn. Do not re-ask "should I start?" / "execute?" before beginning.
 </routing>
 </gjc-runtime>
 {{/unless}}

--- a/packages/coding-agent/src/prompts/tools/skill.md
+++ b/packages/coding-agent/src/prompts/tools/skill.md
@@ -18,6 +18,7 @@ Invoke another available skill in the current turn.
 - Do NOT chain into the same skill recursively. If a skill's flow needs another iteration, follow its in-document instructions.
 - `name` MUST be one concrete skill name, NOT a glob or wildcard. Passing `*`, `?`, or a pattern like `git-*` is rejected immediately — the `--skills '*'` launch filter is unrelated to this tool's `name`.
 - The chained skill's planning/execution-boundary rules still apply. Chaining does not grant execution approval.
+- When the user explicitly requested the target skill in the current prompt, invoke it without re-asking for start/execution approval. Chaining from a planning skill still requires the planning skill's own handoff rules.
 </critical>
 
 <examples>

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -331,6 +331,15 @@ Project executor override body.
 
 		expect(systemPrompt).toContain("Delegate large implementation slices to `executor`");
 		expect(systemPrompt).not.toContain("<role-agent-surface>");
+		expect(systemPrompt).toContain("explicitly requests ultragoal execution");
+		expect(systemPrompt).toContain("that request is execution approval");
+		expect(systemPrompt).toContain("do not re-ask whether to start");
+		expect(systemPrompt).toContain("that request is approval: invoke it immediately");
+		expect(ultragoal).toContain("## Explicit start is approval");
+		expect(ultragoal).toContain("that is execution approval");
+		expect(ultragoal).toContain("Do not re-prompt with \"should I start?\"");
+		expect(ultragoal).toContain("only inferred");
+		expect(ultragoal).toContain("run `ralplan` first");
 		expect(ultragoal).toContain("Role agents return implementation/review evidence");
 	});
 
@@ -404,6 +413,10 @@ Project executor override body.
 		expect(routing).toContain("`/skill:ultragoal`");
 		expect(routing).toContain("`/skill:team`");
 		expect(routing).toContain("Delegate large implementation slices to `executor`");
+		expect(routing).toContain("explicitly requests ultragoal execution");
+		expect(routing).toContain("that request is execution approval");
+		expect(routing).toContain("do not re-ask whether to start");
+		expect(routing).toContain("that request is approval: invoke it immediately");
 		expect(routing.split("\n").filter(line => line.startsWith("-"))).toHaveLength(6);
 		expect(decomposition).toMatch(/skip it for one-step or obvious two-step fixes/i);
 	});


### PR DESCRIPTION
## Summary

- When a user **explicitly** asks for ultragoal in the prompt (`ultragoal`, `/skill:ultragoal`, `gjc ultragoal`, "ultragoal 실행", etc.), treat that as **execution approval** and start immediately.
- Stop the redundant pre-start consent loop that asked "실행할까요?" / "should I start?" even after the user already named ultragoal.
- Keep the ralplan-first planning detour only for **inferred** ultragoal routes with no approved plan; do not re-gate explicit ultragoal starts through a second approval prompt.
- Contract-test the compact system-prompt routing and ultragoal skill wording so this cannot regress silently.

## Why this fix is necessary

This is a high-friction product bug, not a nice-to-have polish item.

1. **User intent was already explicit.** Saying "ultragoal로 해" / `/skill:ultragoal` / `gjc ultragoal ...` is consent to execute. Asking again whether to start is pure ceremony and trains users to distrust the agent.
2. **It breaks the execution workflow's value proposition.** Ultragoal exists for durable, autonomous multi-goal execution with evidence. Forcing a pre-start approval after the user already selected ultragoal turns an execution skill into another planning gate.
3. **The old guidance actively caused the bad behavior.** Ultragoal told agents to run `ralplan` first when no approved plan existed, and ralplan always ends in an approval ask. Explicit ultragoal requests still got double-gated.
4. **Safety is preserved where it matters.** Planning skills (`deep-interview`, `ralplan`) still require explicit execution approval. Active ultragoal runs still keep blocker/pause/`ask` discipline. Only the redundant **pre-start** consent ask is removed for already-explicit ultragoal requests.

Without this, every intentional ultragoal launch pays an unnecessary human round-trip and the agent looks like it is stalling on work the user already ordered.

## Test plan

- [x] `bun test packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/system-prompt-templates.test.ts`
- [ ] Manual: prompt with explicit `ultragoal <task>` and confirm agent starts create-goals/execution without a pre-start approval ask
- [ ] Manual: inferred durable multi-goal need without naming ultragoal still prefers ralplan-first when no approved plan exists
- [ ] Manual: deep-interview/ralplan still stop at pending approval until explicit execution selection