### PR TITLE
fix(sdk): contain disconnected response failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- SDK response delivery failures caused by disconnected clients no longer escape the session host as process-level unhandled rejections.
 - Palette slash commands now run only from an empty composer; drafts are never touched.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).
 - Palette slash submissions no longer clear or rewrite composer text, cursor state, history, or pending images created while an asynchronous input hook is awaiting; canonical keyboard submission cleanup remains unchanged (#2441).

--- a/packages/coding-agent/src/sdk/host/host.ts
+++ b/packages/coding-agent/src/sdk/host/host.ts
@@ -180,6 +180,14 @@ export class SessionSdkHost {
 	async #send(connectionId: string, frame: SdkFrame): Promise<void> {
 		await this.#options.sendFrame(connectionId, frame);
 	}
+	async #sendError(connectionId: string, frame: SdkFrame, error: unknown): Promise<void> {
+		try {
+			await this.#send(connectionId, errorFrame(connectionId, frame, error));
+		} catch {
+			// The original failure may be a closed transport. A second response
+			// cannot be delivered and must not escape the connection boundary.
+		}
+	}
 
 	async #onFrame(connectionId: string, frame: SdkFrame): Promise<void> {
 		try {
@@ -298,7 +306,7 @@ export class SessionSdkHost {
 					return;
 			}
 		} catch (error) {
-			await this.#send(connectionId, errorFrame(connectionId, frame, error));
+			await this.#sendError(connectionId, frame, error);
 		}
 	}
 	#observeRequest(kind: "control" | "query", connectionId: string, frame: SdkFrame): void {

--- a/packages/coding-agent/test/sdk-host.test.ts
+++ b/packages/coding-agent/test/sdk-host.test.ts
@@ -135,4 +135,51 @@ describe("SessionSdkHost", () => {
 		});
 		await host.stop();
 	});
+	test("contains response delivery failures at the disconnected client", async () => {
+		const hostModule = new URL("../src/sdk/host/host.ts", import.meta.url).href;
+		const script = `
+			import { SessionSdkHost } from ${JSON.stringify(hostModule)};
+
+			let receive;
+			let liveDelivered = false;
+			const host = new SessionSdkHost({
+				sessionId: "s",
+				stateRoot: "/tmp/s",
+				token: "t",
+				sendFrame: (connectionId, frame) => {
+					if (connectionId === "closed") throw new Error("SDK connection is not available");
+					if (connectionId === "live" && frame.id === "live-replay") liveDelivered = true;
+				},
+				onFrame: handler => {
+					receive = handler;
+					return () => {};
+				},
+			});
+
+			await host.start();
+			receive("closed", {
+				type: "event_replay",
+				id: "closed-replay",
+				sinceGeneration: host.generation,
+				sinceSeq: 0,
+			});
+			await Bun.sleep(10);
+			receive("live", {
+				type: "event_replay",
+				id: "live-replay",
+				sinceGeneration: host.generation,
+				sinceSeq: 0,
+			});
+			await Bun.sleep(10);
+			if (!liveDelivered) throw new Error("live SDK client did not receive its response");
+			await host.stop();
+		`;
+		const child = Bun.spawn([process.execPath, "-e", script], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+		expect(exitCode).toBe(0);
+		expect(stderr).toBe("");
+	});
 });


### PR DESCRIPTION
Closes #2488.

## Problem

When an SDK client disconnects while the host is delivering a response, the response send throws. `SessionSdkHost.#onFrame` catches it and tries to send a structured error frame over the same closed connection. A second delivery failure then escapes the fire-and-forget frame callback as a process-level unhandled rejection.

The production fingerprint occurred five times during one live GJC 0.11 session failure. A controlled current-`dev` host probe reproduced one unhandled rejection from the same double-send path.

## Fix

- Route structured-error delivery through a best-effort helper.
- Contain only failure of that second delivery at the per-connection boundary.
- Preserve normal error propagation into the structured response path and preserve successful structured error responses for live clients.
- Keep the host available to other SDK connections after one client disappears.

## Regression coverage

`packages/coding-agent/test/sdk-host.test.ts` runs the disconnected-response scenario in an isolated Bun subprocess. The child must exit cleanly with no stderr, and a second live SDK client must still receive its replay response. Existing coverage continues to verify successful structured error delivery.

## Verification

- `bun test packages/coding-agent/test/sdk-host.test.ts` — 5 pass, 0 fail, 23 assertions
- `bun --cwd=packages/coding-agent run check` — PASS (Biome, SDK canonicalization, TypeScript)
- `git diff --check` — PASS
- Architect review — CLEAR, no findings
- Gitleaks scan of all three changed files — no leaks found

An additional `sdk-host-wiring.test.ts` attempt could not start in this source worktree because the optional local `pi_natives` binary was not built; the focused host suite and the package check above completed successfully.
