### PR TITLE
docs(pr): require exact-head GJC verdict in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,8 +10,18 @@
 
 <!-- How was this tested? -->
 
+## GJC verdict
+
+<!-- Paste one exact-head verdict. Self-approval is BLOCK. If there was no independent architect/critic/human review, write needs-human and stop. -->
+
+```text
+gajae.pr-review-verdict.v1 <merge-approved|merge-blocked|needs-human> sha256:<exact-head-or-diff-hash> reviewer:<architect|critic|human> evidence:<ci-run-url-or-local-command>
+```
+
 ---
 
+- [ ] Target branch is `dev`
 - [ ] `bun check` passes
 - [ ] Tested locally
 - [ ] CHANGELOG updated (if user-facing)
+- [ ] Verdict above matches the exact PR head, not an earlier commit


### PR DESCRIPTION
## What

Adds an exact-head `gajae.pr-review-verdict.v1` slot to the PR template and makes the `dev` target explicit.

## Why

The repository already speaks this language at merge time (`gajae.pr-review-verdict.v1 ...`), and `CONTRIBUTING.md` already says PRs belong on `dev`. The template was the only place still pretending that evidence and branch targeting are optional. This changes no runtime code; it changes what future PRs must confess.

If this feels obvious, that is the point. The rule was already living in the merge commits; the template just catches up. ㅋㅋ

## Testing

- `git diff --check` passes
- Runtime tests not run: template-only change under `.github/`

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:101944b68b5ce083f5f86ac7d0d905a6fdab1f89250fd4844722fa37629469be reviewer:pending evidence:git diff --check
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally (`git diff --check`)
- [x] CHANGELOG updated (if user-facing) — not user-facing
- [x] Verdict above matches the exact PR head, not an earlier commit
