### PR TITLE
fix(coding-agent): scope phase-one memory jobs by cwd

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).
 - Palette slash submissions no longer clear or rewrite composer text, cursor state, history, or pending images created while an asynchronous input hook is awaiting; canonical keyboard submission cleanup remains unchanged (#2441).
 - Dead browser-tab recovery now expires descriptors without releasing replacement, revived, or differently owned tabs, while exactly-once teardown closes stale targets and releases browser holds without refcount underflow (#2437).
+- Local-memory Phase 1 no longer processes history from another working directory.
 
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -249,6 +249,7 @@ async function runPhase1(options: {
 
 		const claims = claimStage1Jobs(db, {
 			nowSec,
+			cwd: session.sessionManager.getCwd(),
 			threadScanLimit: config.threadScanLimit,
 			maxRolloutsPerStartup: config.maxRolloutsPerStartup,
 			maxRolloutAgeDays: config.maxRolloutAgeDays,

--- a/packages/coding-agent/src/memories/storage.ts
+++ b/packages/coding-agent/src/memories/storage.ts
@@ -137,6 +137,7 @@ export function claimStage1Jobs(
 	db: Database,
 	params: {
 		nowSec: number;
+		cwd: string;
 		threadScanLimit: number;
 		maxRolloutsPerStartup: number;
 		maxRolloutAgeDays: number;
@@ -149,6 +150,7 @@ export function claimStage1Jobs(
 ): Stage1Claim[] {
 	const {
 		nowSec,
+		cwd,
 		threadScanLimit,
 		maxRolloutsPerStartup,
 		maxRolloutAgeDays,
@@ -168,8 +170,10 @@ export function claimStage1Jobs(
 	let runningCount = runningCountRow?.count ?? 0;
 	if (runningCount >= runningConcurrencyCap) return [];
 	const candidateRows = db
-		.prepare("SELECT id, updated_at, rollout_path, cwd, source_kind FROM threads ORDER BY updated_at DESC LIMIT ?")
-		.all(threadScanLimit) as Array<{
+		.prepare(
+			"SELECT id, updated_at, rollout_path, cwd, source_kind FROM threads WHERE cwd = ? ORDER BY updated_at DESC LIMIT ?",
+		)
+		.all(cwd, threadScanLimit) as Array<{
 		id: string;
 		updated_at: number;
 		rollout_path: string;

--- a/packages/coding-agent/test/memories-storage.test.ts
+++ b/packages/coding-agent/test/memories-storage.test.ts
@@ -57,6 +57,7 @@ describe("memories/storage", () => {
 
 		const claims = claimStage1Jobs(db, {
 			nowSec,
+			cwd: PROJECT_CWD,
 			threadScanLimit: 100,
 			maxRolloutsPerStartup: 10,
 			maxRolloutAgeDays: 30,
@@ -68,6 +69,55 @@ describe("memories/storage", () => {
 		});
 
 		expect(claims.map(claim => claim.threadId)).toEqual(["eligible-thread"]);
+		closeMemoryDb(db);
+	});
+	test("claimStage1Jobs scopes candidates by cwd before applying the scan limit", () => {
+		const db = openMemoryDb(dbPath);
+		const nowSec = 1_800_000_000;
+		const projectACwd = "/repo/a";
+		const projectBCwd = "/repo/b";
+		upsertThreads(db, [
+			{
+				id: "project-a-thread",
+				updatedAt: nowSec - 13 * 60 * 60,
+				rolloutPath: "/tmp/project-a.jsonl",
+				cwd: projectACwd,
+				sourceKind: "cli",
+			},
+			{
+				id: "project-b-thread",
+				updatedAt: nowSec - 12 * 60 * 60,
+				rolloutPath: "/tmp/project-b.jsonl",
+				cwd: projectBCwd,
+				sourceKind: "cli",
+			},
+		]);
+
+		const projectAClaims = claimStage1Jobs(db, {
+			nowSec,
+			cwd: projectACwd,
+			threadScanLimit: 1,
+			maxRolloutsPerStartup: 10,
+			maxRolloutAgeDays: 30,
+			minRolloutIdleHours: 12,
+			leaseSeconds: 120,
+			runningConcurrencyCap: 8,
+			workerId: "test-worker-a",
+		});
+		expect(projectAClaims.map(claim => claim.threadId)).toEqual(["project-a-thread"]);
+
+		const projectBClaims = claimStage1Jobs(db, {
+			nowSec,
+			cwd: projectBCwd,
+			threadScanLimit: 1,
+			maxRolloutsPerStartup: 10,
+			maxRolloutAgeDays: 30,
+			minRolloutIdleHours: 12,
+			leaseSeconds: 120,
+			runningConcurrencyCap: 8,
+			workerId: "test-worker-b",
+		});
+		expect(projectBClaims.map(claim => claim.threadId)).toEqual(["project-b-thread"]);
 		closeMemoryDb(db);
 	});
 


### PR DESCRIPTION
## Summary

- scope Phase 1 local-memory candidate selection to the active working directory
- apply the cwd predicate before ordering and `threadScanLimit`, so newer foreign-project rows cannot consume the local scan budget
- preserve the shared global concurrency cap and existing Phase 2 lifecycle
- add a regression proving projects A and B remain independently claimable

## Why

`threads` is shared across projects, but `claimStage1Jobs()` previously selected its candidates globally. Starting GJC in project A could therefore lease and send project B's rollout through Phase 1 extraction. Phase 2 already keeps outputs project-scoped, but that does not prevent the cross-project transcript read or token spend.

The new required `cwd` argument makes the claim boundary explicit and filters candidates in SQL before `ORDER BY ... LIMIT`.

## Verification

- `bun test packages/coding-agent/test/memories-storage.test.ts packages/coding-agent/test/memories/isolation.test.ts packages/coding-agent/test/memories-runtime.test.ts` — 19 passed
- `bunx biome check packages/coding-agent/src/memories/storage.ts packages/coding-agent/src/memories/index.ts packages/coding-agent/test/memories-storage.test.ts packages/coding-agent/CHANGELOG.md`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

## Scope

This intentionally does not change the global Phase 1 concurrency cap, cwd identity/normalization, Phase 2 consolidation, or pending zero-watermark job cleanup.