### PR TITLE
fix(computer): bound inline screenshots by dimensions for many-image requests

### DIFF
--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -6,7 +6,7 @@ import type { ImageContent } from "@gajae-code/ai";
 import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import computerDescription from "../prompts/tools/computer.md" with { type: "text" };
-import { resizeImage } from "../utils/image-resize";
+import { formatDimensionNote, resizeImage } from "../utils/image-resize";
 import { markScreenshotFallbackDirCreatedForGc } from "./computer-gc";
 import type { ToolSession } from "./index";
 import type { OutputMeta } from "./output-meta";
@@ -701,11 +701,16 @@ async function inlineImageContentFromNativeResult(
 	details: ComputerToolDetails,
 	session: ToolSession,
 ): Promise<ImageContent | undefined> {
+	// Anthropic rejects requests carrying more than 20 images when any image
+	// exceeds 2000px per dimension ("many-image requests"), so gating on bytes
+	// alone is not enough: an in-budget full-resolution capture can still brick
+	// the session once enough screenshots accumulate in history. Always route
+	// through resizeImage (its fast path returns already-small images
+	// untouched) and tell the model how to map coordinates back to the native
+	// screenshot frame when the inline image was scaled.
 	const image = fullResolutionImageContentFromNativeResult(value);
 	if (!image) return undefined;
 	const maxBytes = getInlineScreenshotMaxBytes(session);
-	const originalBytes = Buffer.byteLength(image.data, "base64");
-	if (originalBytes <= maxBytes) return image;
 
 	try {
 		const resized = await resizeImage(image, {
@@ -715,6 +720,8 @@ async function inlineImageContentFromNativeResult(
 			jpegQuality: COMPUTER_INLINE_SCREENSHOT_JPEG_QUALITY,
 		});
 		if (resized.buffer.length <= maxBytes) {
+			const note = formatDimensionNote(resized);
+			if (note) details.message = `${details.message} ${note}`;
 			return { type: "image", data: resized.data, mimeType: resized.mimeType };
 		}
 	} catch {

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -87,6 +87,33 @@ function makeNoisePng(width: number, height: number): Buffer {
 	]);
 }
 
+function makeFlatPng(width: number, height: number): Buffer {
+	const ihdr = Buffer.alloc(13);
+	ihdr.writeUInt32BE(width, 0);
+	ihdr.writeUInt32BE(height, 4);
+	ihdr[8] = 8;
+	ihdr[9] = 6;
+	const stride = 1 + width * 4;
+	const raw = Buffer.alloc(stride * height);
+	for (let y = 0; y < height; y += 1) {
+		const row = y * stride;
+		raw[row] = 0;
+		for (let x = 0; x < width; x += 1) {
+			const offset = row + 1 + x * 4;
+			raw[offset] = 0x33;
+			raw[offset + 1] = 0x66;
+			raw[offset + 2] = 0x99;
+			raw[offset + 3] = 0xff;
+		}
+	}
+	return Buffer.concat([
+		Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+		pngChunk("IHDR", ihdr),
+		pngChunk("IDAT", zlibSync(raw)),
+		pngChunk("IEND", Buffer.alloc(0)),
+	]);
+}
+
 describe("computer tool schema", () => {
 	const validCases = [
 		{ action: "screenshot" },
@@ -461,6 +488,88 @@ describe("computer tool dispatch", () => {
 		expect(artifactPath).toBeTruthy();
 		if (!artifactPath) throw new Error("expected persisted screenshot path");
 		expect((await fs.stat(artifactPath)).size).toBe(600 * 1024);
+	});
+
+	it("bounds large-dimension screenshots that fit the byte budget while preserving the full-resolution artifact", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const png = makeFlatPng(2400, 1600);
+		expect(png.length).toBeLessThan(5 * 1024 * 1024);
+		setComputerControllerFactoryForTests(() => ({
+			screenshot: () => ({ widthPx: 2400, heightPx: 1600, png }),
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("large-dims-shot", { action: "screenshot" });
+
+		expect(result.isError).not.toBe(true);
+		const image = result.content.find(block => block.type === "image");
+		expect(image).toBeTruthy();
+		if (image?.type !== "image") throw new Error("expected inline image");
+		const { width, height } = await new Bun.Image(Buffer.from(image.data, "base64")).metadata();
+		expect(width).toBeLessThanOrEqual(1568);
+		expect(height).toBeLessThanOrEqual(1568);
+		const artifactPath = result.details?.screenshot?.path;
+		expect(artifactPath).toBeTruthy();
+		if (!artifactPath) throw new Error("expected persisted screenshot path");
+		expect((await fs.readFile(artifactPath)).equals(png)).toBe(true);
+	});
+
+	it("appends the coordinate-mapping note when the inline screenshot was scaled", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const png = makeFlatPng(2400, 1600);
+		setComputerControllerFactoryForTests(() => ({
+			screenshot: () => ({ widthPx: 2400, heightPx: 1600, png }),
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("scaled-note-shot", { action: "screenshot" });
+
+		expect(result.isError).not.toBe(true);
+		expect(textOf(result)).toContain("original 2400x1600");
+		expect(textOf(result)).toContain("displayed at");
+	});
+
+	it("returns small in-spec screenshots byte-identical without a dimension note", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const png = makeFlatPng(800, 600);
+		setComputerControllerFactoryForTests(() => ({
+			screenshot: () => ({ widthPx: 800, heightPx: 600, png }),
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("small-shot", { action: "screenshot" });
+
+		expect(result.isError).not.toBe(true);
+		const image = result.content.find(block => block.type === "image");
+		expect(image).toBeTruthy();
+		if (image?.type !== "image") throw new Error("expected inline image");
+		expect(image.data).toBe(png.toString("base64"));
+		expect(image.mimeType).toBe("image/png");
+		expect(textOf(result)).not.toContain("displayed at");
+	});
+
+	it("recompresses dimension-safe screenshots that are not comfortably under the byte budget", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const png = makeNoisePng(1024, 1024);
+		expect(png.length).toBeGreaterThan((5 * 1024 * 1024) / 4);
+		expect(png.length).toBeLessThan(5 * 1024 * 1024);
+		setComputerControllerFactoryForTests(() => ({
+			screenshot: () => ({ widthPx: 1024, heightPx: 1024, png }),
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("compact-budget-shot", { action: "screenshot" });
+
+		expect(result.isError).not.toBe(true);
+		const image = result.content.find(block => block.type === "image");
+		expect(image).toBeTruthy();
+		if (image?.type !== "image") throw new Error("expected inline image");
+		expect(Buffer.byteLength(image.data, "base64")).toBeLessThan(png.length);
+		expect(textOf(result)).not.toContain("displayed at");
 	});
 
 	it("persists screenshot fallbacks in private per-session directories with restrictive file modes", async () => {


### PR DESCRIPTION
## Problem

`inlineImageContentFromNativeResult()` in `packages/coding-agent/src/tools/computer.ts` gates the inline screenshot only on **bytes**:

```ts
const originalBytes = Buffer.byteLength(image.data, "base64");
if (originalBytes <= maxBytes) return image;
```

Screen content compresses well, so a full-resolution Retina capture (e.g. 4112x2658 at ~1-2.6MB PNG) sails under the 5MB budget and reaches the provider at full resolution.

Anthropic's vision docs state that when a single API request carries **more than 20 images**, a stricter per-image limit applies: images must not exceed **2000px per dimension**, otherwise the request is rejected with an `invalid_request_error` referencing "many-image requests". A computer-use session trivially accumulates 20+ screenshots in history, and because history re-sends prior images every turn, the first oversized capture eventually bricks the session permanently: every subsequent turn replays the same oversized images and re-fails with the same 400. This is the same fail-forever mechanism described in #1161.

## Fix

Always route the inline screenshot through the shared `resizeImage` util (1568px longest edge, existing byte budget) instead of early-returning on the byte check:

- `resizeImage`'s internal fast path returns small, compact images byte-identical (no re-encode) when they are within 1568px **and** comfortably under the byte budget (at most a quarter of it); other in-budget screenshots are recompressed - see the behavior change section.
- When the inline image was scaled, append the existing `formatDimensionNote` coordinate-mapping note to the tool message. The coordinate contract is native screenshot pixels (`prompts/tools/computer.md`, `validatePointerCoordinates`), so the model needs the multiplier to map what it sees back to the native frame. This also fixes the existing over-budget resize path, which shipped a scaled image with **no** mapping note.
- The decode-failure path is unchanged: undecodable captures fall back exactly as before (raw passthrough under budget, omission message over budget).
- The full-resolution PNG artifact on disk (`persistScreenshotFallback`) is unchanged.

This completes the inline screenshot bounding introduced in #935 for the many-image dimension case; #1161 previously targeted the same 2000px bug class on the shared image-ingestion path.

## Behavior change (disclosed)

Two classes of previously-raw screenshots now reach the provider re-encoded:

- Screenshots larger than 1568px (even under the byte budget) arrive at <=1568px, smallest of PNG/JPEG/WebP, with the coordinate note.
- Dimension-safe screenshots that are under the byte budget but **not** comfortably under it (above roughly `budget/4`, i.e. ~1.25MB at the 5MB default) are recompressed at native dimensions with no note; previously they were returned raw. Covered by a dedicated regression test.

Rationale:

- The full-resolution PNG is still persisted to disk and its path returned, per #935's design, so full fidelity remains one `read`/`inspect_image` away.
- Standard-tier models are server-side downscaled to 1568px anyway, so full-res inline pixels cost tokens without adding fidelity.
- The high-resolution tier (2576px) exceeds the 2000px many-image cap, so 1568px is the only statically always-safe bound; model-aware sizing is a possible follow-up, out of scope here.

## Tests

New (in `test/tools/computer.test.ts`, plus a `makeFlatPng` helper for large-dimension/small-byte captures):

- large-dimension in-budget capture: decoded inline image is <=1568px on both axes AND the full-resolution artifact on disk is byte-identical to the native capture
- scaled capture: coordinate-mapping note (`original 2400x1600`, `displayed at ...`) present in the text block
- small in-spec capture: inline image is byte-identical passthrough (`image/png`), no note
- dimension-safe capture above `budget/4`: inline image is recompressed (smaller than the original), no note

Existing inline-screenshot tests (oversized bounding, byte-budget setting, undecodable omission) pass unmodified. Focused lanes green locally: `bun test` (computer + image-resize suites, 48 pass / 234 expects), `tsc --noEmit`, Biome on touched files.

## References

- #935 (inline screenshot byte bound + full-res artifact persistence, which this completes)
- #1161 (same 2000px many-image bug class on the ingestion path; closed for targeting `main`)
- Anthropic vision docs, "Request limits": requests with more than 20 images enforce a stricter per-image dimension limit; resize each image so neither dimension exceeds 2000px - https://platform.claude.com/docs/en/build-with-claude/vision
