### PR TITLE
docs(changelog): fix malformed Unreleased Changed bullet

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Active deep-interview sessions now resume automatically after a normal assistant stop while ordinary active interviewing remains eligible, using bounded workflow-state continuation; recovery, leak, stale-state, handoff, and crystallization blocks remain Stop-gate handled.
 
 ### Changed
-+- Removed deprecated `DiscoverableMCPTool`, `DiscoverableMCPSearchIndex`, and related MCP-only discovery helper exports. Use the unified `DiscoverableTool` discovery APIs; the `mcp.discoveryMode` settings alias remains supported.
+- Removed deprecated `DiscoverableMCPTool`, `DiscoverableMCPSearchIndex`, and related MCP-only discovery helper exports. Use the unified `DiscoverableTool` discovery APIs; the `mcp.discoveryMode` settings alias remains supported.
 
 ### Fixed
 - Connected MCP server instructions now remain untrusted user-role data instead of entering the cached system prompt; hostile file paths, working directories, and workspace-tree metadata are structurally encoded, and volatile project context is removed from durable session history between requests.


### PR DESCRIPTION
## Summary
- Fix a merge-artifact `+-` bullet in the Unreleased Changed section so changelog consumers see a normal list item.

## Why this is necessary
A broken changelog bullet looks like unfinished merge work and can break tooling that assumes valid markdown list syntax. Release notes are operator-facing contract surface; garbage markers erode trust.

## Test plan
- [x] Inspect Unreleased section for a single clean `-` bullet