### PR TITLE
fix(sdk): contain disconnected structured-error delivery failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Fixed
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 
+
+### Fixed
+- SDK host response delivery to a disconnected client no longer escalates a second structured-error send failure into a process-level unhandled rejection; failures stay local to that connection.
+
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).

--- a/packages/coding-agent/src/sdk/host/host.ts
+++ b/packages/coding-agent/src/sdk/host/host.ts
@@ -181,6 +181,19 @@ export class SessionSdkHost {
 		await this.#options.sendFrame(connectionId, frame);
 	}
 
+	/**
+	 * Best-effort delivery for structured error frames. When the original failure
+	 * was already a disconnected/dead connection, a second send must not escape
+	 * the fire-and-forget `#onFrame` callback as an unhandled rejection.
+	 */
+	async #sendBestEffort(connectionId: string, frame: SdkFrame): Promise<void> {
+		try {
+			await this.#send(connectionId, frame);
+		} catch {
+			// Per-connection delivery only; never rethrow into fire-and-forget handlers.
+		}
+	}
+
 	async #onFrame(connectionId: string, frame: SdkFrame): Promise<void> {
 		try {
 			switch (frame.type) {
@@ -298,7 +311,9 @@ export class SessionSdkHost {
 					return;
 			}
 		} catch (error) {
-			await this.#send(connectionId, errorFrame(connectionId, frame, error));
+			// Structured error delivery is best-effort: if the client already
+			// disconnected, do not escalate a second send failure process-wide.
+			await this.#sendBestEffort(connectionId, errorFrame(connectionId, frame, error));
 		}
 	}
 	#observeRequest(kind: "control" | "query", connectionId: string, frame: SdkFrame): void {

--- a/packages/coding-agent/test/sdk-host.test.ts
+++ b/packages/coding-agent/test/sdk-host.test.ts
@@ -135,4 +135,41 @@ describe("SessionSdkHost", () => {
 		});
 		await host.stop();
 	});
+
+	test("contains disconnected structured-error delivery failures without unhandled rejections", async () => {
+		let receive!: (connectionId: string, frame: Record<string, unknown>) => void;
+		let failSends = 0;
+		const host = new SessionSdkHost({
+			sessionId: "sess-disconnect",
+			stateRoot: "/tmp/gjc-sdk-host-disconnect",
+			token: "tok",
+			sendFrame: () => {
+				// Fail the success response and the subsequent structured-error delivery.
+				if (failSends < 2) {
+					failSends += 1;
+					throw new Error("connection closed");
+				}
+			},
+			onFrame: handler => {
+				receive = handler;
+				return () => {};
+			},
+		});
+		await host.start();
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			receive("c1", { type: "event_replay", id: "r1", sinceGeneration: 0, sinceSeq: 0 });
+			await new Promise(resolve => setTimeout(resolve, 0));
+			await new Promise(resolve => setTimeout(resolve, 0));
+			expect(failSends).toBe(2);
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+			await host.stop();
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- Route structured-error delivery through a best-effort send path in `SessionSdkHost`.
- Contain second-send failures when the client is already disconnected so fire-and-forget `#onFrame` cannot produce process-level unhandled rejections.
- Add a regression test that fails both the primary response and the structured-error delivery.

Closes #2488.

## Why this is necessary
A live GJC session can die because one SDK client disconnects mid-response. That is an availability bug: one flaky remote client should never crash the host process. Operators lose the whole session and every other connected client with it.

## Test plan
- [x] `bun test packages/coding-agent/test/sdk-host.test.ts`