### PR TITLE
fix(harness): stamp workflow receipts with real session-layout paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+- Workflow state receipts now stamp the real `.gjc/_session-*/state/...` paths instead of the legacy `.gjc/state/sessions/...` layout, so doctor/operator tooling follows paths that actually exist.
+
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).

--- a/packages/coding-agent/src/skill-state/workflow-state-contract.ts
+++ b/packages/coding-agent/src/skill-state/workflow-state-contract.ts
@@ -56,7 +56,6 @@ function safeString(value: unknown): string {
 	return typeof value === "string" ? value : "";
 }
 
-
 export function workflowModeStateFileName(skill: CanonicalGjcWorkflowSkill): string {
 	return `${skill}-state.json`;
 }

--- a/packages/coding-agent/src/skill-state/workflow-state-contract.ts
+++ b/packages/coding-agent/src/skill-state/workflow-state-contract.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { activeSnapshotPath, modeStatePath } from "../gjc-runtime/session-layout";
 import { CANONICAL_GJC_WORKFLOW_SKILLS, type CanonicalGjcWorkflowSkill, SKILL_ACTIVE_STATE_FILE } from "./active-state";
 import { WORKFLOW_STATE_RECEIPT_FRESH_MS, WORKFLOW_STATE_RECEIPT_VERSION } from "./workflow-state-version";
 
@@ -55,9 +56,6 @@ function safeString(value: unknown): string {
 	return typeof value === "string" ? value : "";
 }
 
-function encodePathSegment(value: string): string {
-	return encodeURIComponent(value).replaceAll(".", "%2E");
-}
 
 export function workflowModeStateFileName(skill: CanonicalGjcWorkflowSkill): string {
 	return `${skill}-state.json`;
@@ -66,14 +64,8 @@ export function workflowModeStateFileName(skill: CanonicalGjcWorkflowSkill): str
 export function workflowStateStoragePath(cwd: string, skill: CanonicalGjcWorkflowSkill, sessionId?: string): string {
 	const normalizedSessionId = safeString(sessionId).trim();
 	if (normalizedSessionId) {
-		return path.join(
-			cwd,
-			".gjc",
-			"state",
-			"sessions",
-			encodePathSegment(normalizedSessionId),
-			workflowModeStateFileName(skill),
-		);
+		// Canonical session layout is `.gjc/_session-{id}/state/<skill>-state.json`.
+		return modeStatePath(cwd, normalizedSessionId, skill);
 	}
 	return path.join(cwd, ".gjc", "state", workflowModeStateFileName(skill));
 }
@@ -81,14 +73,8 @@ export function workflowStateStoragePath(cwd: string, skill: CanonicalGjcWorkflo
 export function workflowActiveStatePath(cwd: string, sessionId?: string): string {
 	const normalizedSessionId = safeString(sessionId).trim();
 	if (normalizedSessionId) {
-		return path.join(
-			cwd,
-			".gjc",
-			"state",
-			"sessions",
-			encodePathSegment(normalizedSessionId),
-			SKILL_ACTIVE_STATE_FILE,
-		);
+		// Canonical HUD snapshot is `.gjc/_session-{id}/state/skill-active-state.json`.
+		return activeSnapshotPath(cwd, normalizedSessionId);
 	}
 	return path.join(cwd, ".gjc", "state", SKILL_ACTIVE_STATE_FILE);
 }

--- a/packages/coding-agent/test/skill-state/workflow-state-receipt-paths.test.ts
+++ b/packages/coding-agent/test/skill-state/workflow-state-receipt-paths.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import {
+	buildWorkflowStateReceipt,
+	workflowActiveStatePath,
+	workflowStateStoragePath,
+} from "../../src/skill-state/workflow-state-contract";
+
+describe("workflow receipt paths", () => {
+	test("session-scoped receipts use the real _session- layout, not legacy state/sessions", () => {
+		const cwd = "/repo";
+		const sessionId = "sess-a";
+		const storage = workflowStateStoragePath(cwd, "ultragoal", sessionId);
+		const active = workflowActiveStatePath(cwd, sessionId);
+		expect(storage).toBe(path.join(cwd, ".gjc", "_session-sess-a", "state", "ultragoal-state.json"));
+		expect(active).toBe(path.join(cwd, ".gjc", "_session-sess-a", "state", "skill-active-state.json"));
+		expect(storage).not.toContain(`${path.sep}state${path.sep}sessions${path.sep}`);
+		expect(active).not.toContain(`${path.sep}state${path.sep}sessions${path.sep}`);
+
+		const receipt = buildWorkflowStateReceipt({
+			cwd,
+			skill: "ultragoal",
+			owner: "gjc-state-cli",
+			command: "gjc state ultragoal write --input '<json>'",
+			sessionId,
+			nowIso: "2026-07-17T00:00:00.000Z",
+			mutationId: "m1",
+		});
+		expect(receipt.storage_path).toBe(storage);
+		expect(receipt.state_path).toBe(active);
+	});
+});


### PR DESCRIPTION
## Summary
- `workflowStateStoragePath` / `workflowActiveStatePath` now use the canonical session-layout helpers (`modeStatePath`, `activeSnapshotPath`).
- Session-scoped receipts point at `.gjc/_session-*/state/...` instead of the dead legacy `.gjc/state/sessions/...` tree.
- Regression test locks the path contract.

Closes #2393.

## Why this is necessary
Receipts are the operator/doctor contract for “where is workflow state?”. Today they lie: CLI writes report the real `_session-` path, but the receipt stamps a nonexistent `state/sessions` path. That is an API-contract bug that wastes incident time and makes automation fail closed against the wrong filesystem.

## Test plan
- [x] `bun test packages/coding-agent/test/skill-state/workflow-state-receipt-paths.test.ts`