### PR TITLE
fix(skill): list available skills when lookup fails

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+- Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
+
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6058,7 +6058,11 @@ export class AgentSession {
 		if (typeof args !== "string")
 			throw Object.assign(new Error("skill.invoke args must be a string."), { code: "invalid_input" });
 		const skill = this.skills.find(candidate => candidate.name === skillName);
-		if (!skill) throw Object.assign(new Error(`Skill ${skillName} was not found.`), { code: "invalid_input" });
+		if (!skill) {
+			const available = this.skills.map(candidate => candidate.name).sort();
+			const availableHint = available.length > 0 ? ` Available: ${available.join(", ")}.` : "";
+			throw Object.assign(new Error(`Skill ${skillName} was not found.${availableHint}`), { code: "invalid_input" });
+		}
 		const deepInterviewUserIntentEpoch = this.#claimDeepInterviewUserIntent();
 		const activation = await resolveSubskillActivationForSkillInvocation({
 			cwd: this.sessionManager.getCwd(),


### PR DESCRIPTION
## Summary
- When `/skill:<name>` / session skill lookup fails, the error now includes the sorted available skill names.

## Why this is necessary
Unknown-skill errors are common when models invent skill names. Without a candidate list they burn turns rediscovering the roster. Actionable errors reduce retries and wrong workflow launches.

## Test plan
- [x] Code path inspection of agent-session skill lookup