### PR TITLE
fix(skill): suggest closest skill name on unknown-skill errors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+- The skill tool now suggests the closest available skill name on unknown-skill errors so typos recover in one step.
+
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).

--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -40,6 +40,33 @@ function normalizeSkillName(name: string | undefined): string {
 	return (name ?? "").trim();
 }
 
+export function suggestClosestSkillName(requested: string, available: readonly string[]): string | undefined {
+	if (available.length === 0) return undefined;
+	const normalize = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+	const target = normalize(requested);
+	if (!target) return undefined;
+	let bestName: string | undefined;
+	let bestScore = -1;
+	for (const name of available) {
+		const candidate = normalize(name);
+		let score = 0;
+		if (candidate === target) return name;
+		if (candidate.startsWith(target) || target.startsWith(candidate)) score += 50;
+		if (candidate.includes(target) || target.includes(candidate)) score += 25;
+		const chars = new Set(candidate);
+		let overlap = 0;
+		for (const ch of target) if (chars.has(ch)) overlap += 1;
+		score += overlap;
+		score -= Math.abs(candidate.length - target.length);
+		if (score > bestScore) {
+			bestScore = score;
+			bestName = name;
+		}
+	}
+	return bestScore >= 8 ? bestName : undefined;
+}
+
+
 const SKILL_NAME_GLOB_PATTERN = /[*?[\]{}]/;
 
 type SkillToolInput = z.infer<typeof skillSchema>;
@@ -125,9 +152,11 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 				(await findRuntimeSkillByName(this.#session.cwd, requestedName, this.#getRuntimeSkillPolicy()));
 			if (!skill) {
 				const available = skills.map(s => s.name).sort();
+				const suggestion = suggestClosestSkillName(requestedName, available);
+				const suggestHint = suggestion ? ` Did you mean "${suggestion}"?` : "";
 				const hint =
 					available.length > 0
-						? ` Available: ${available.join(", ")}. Use skill_discovery to find project/user runtime skills.`
+						? `${suggestHint} Available: ${available.join(", ")}. Use skill_discovery to find project/user runtime skills.`
 						: " Use skill_discovery to find project/user runtime skills.";
 				throw new ToolError(`skill tool: unknown skill "${requestedName}".${hint}`);
 			}

--- a/packages/coding-agent/test/tools/skill-name-suggestion.test.ts
+++ b/packages/coding-agent/test/tools/skill-name-suggestion.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { suggestClosestSkillName } from "../../src/tools/skill";
+
+describe("suggestClosestSkillName", () => {
+	test("suggests ultragoal for common typos", () => {
+		expect(suggestClosestSkillName("ultragoals", ["deep-interview", "ralplan", "ultragoal", "team"])).toBe(
+			"ultragoal",
+		);
+		expect(suggestClosestSkillName("ral-plan", ["deep-interview", "ralplan", "ultragoal", "team"])).toBe("ralplan");
+	});
+
+	test("returns undefined when nothing is close enough", () => {
+		expect(suggestClosestSkillName("zzzz", ["deep-interview", "ralplan"])).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- Add `suggestClosestSkillName` for skill-tool unknown-name errors.
- Prefer punctuation-insensitive matching so `ral-plan` → `ralplan` and `ultragoals` → `ultragoal`.
- Keep the full available list; suggestion is an extra recovery hint.

## Why this is necessary
Models mistype skill names constantly. Listing available skills helps; naming the closest match collapses the recovery loop further. That is fewer wasted turns and fewer wrong workflow starts.

## Test plan
- [x] `bun test packages/coding-agent/test/tools/skill-name-suggestion.test.ts`