### PR TITLE
fix(ultragoal): fail closed on fuzzy objective path sniffing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Changed
 - The `read` tool is now receipt-by-default: bare and unparseable reads return a bounded receipt (≤50 lines / 10 KiB) with a re-read-with-selector footer only when truncated, `:raw` stays pure verbatim up to a max(2 MiB, spill threshold) ceiling, structural summaries cap unit-granularly at 20 KiB while preserving elision and source-recovery footers, and directories are byte/line capped and never spill. Only an explicit full-content selector (`:raw` or an explicit range) with real content is spill-eligible. Subagent previews now enforce a real byte/code-point cap via per-shape render budgets plus a shape-aware artifact-eligibility tag enforced centrally in output-meta.
 
+
+### Fixed
+- Ultragoal objective ownership no longer treats arbitrary strings that merely mention `goals.json`/`ledger.jsonl` as Ultragoal-owned; only the exact default aggregate objective qualifies for the known-objective path.
+
 ### Fixed
 - Workflow-state handoff no longer self-locks the active-state cache, so a same-turn skill handoff (e.g. ultragoal → ralplan) completes instead of stalling behind a lock the handoff itself still holds (#2638).
 - SDK host shutdown now retries a failed broker unregister instead of short-circuiting with a stale broker-index entry, while retained startup-cleanup owner-release failures remain isolated from the red extension-error path (#2625).

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -71,12 +71,12 @@ function objectiveMatches(currentGoal: CurrentGoalLike, plan: UltragoalPlan, ses
 	return plan.goals.some(goal => goal.objective === normalized);
 }
 
-function isKnownUltragoalObjective(currentObjective: string): boolean {
+export function isKnownUltragoalObjective(currentObjective: string): boolean {
 	const normalized = currentObjective.trim();
-	return (
-		normalized === DEFAULT_ULTRAGOAL_OBJECTIVE ||
-		(normalized.includes(".gjc/ultragoal/goals.json") && normalized.includes(".gjc/ultragoal/ledger.jsonl"))
-	);
+	// Exact default aggregate objective only. Substring path sniffing previously
+	// treated arbitrary objectives that merely mentioned goals.json/ledger paths
+	// as Ultragoal-owned, which could mis-arm guards. Prefer fail-closed.
+	return normalized === DEFAULT_ULTRAGOAL_OBJECTIVE;
 }
 
 async function ultragoalReadPaths(

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-known-objective.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-known-objective.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "../../src/gjc-runtime/goal-mode-request";
+import { isKnownUltragoalObjective } from "../../src/gjc-runtime/ultragoal-guard";
+
+describe("isKnownUltragoalObjective", () => {
+	test("accepts only the exact default aggregate objective", () => {
+		expect(isKnownUltragoalObjective(DEFAULT_ULTRAGOAL_OBJECTIVE)).toBe(true);
+	});
+
+	test("rejects objectives that merely mention ultragoal paths", () => {
+		expect(
+			isKnownUltragoalObjective(
+				"Please inspect .gjc/ultragoal/goals.json and .gjc/ultragoal/ledger.jsonl for fun",
+			),
+		).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-known-objective.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-known-objective.test.ts
@@ -9,9 +9,7 @@ describe("isKnownUltragoalObjective", () => {
 
 	test("rejects objectives that merely mention ultragoal paths", () => {
 		expect(
-			isKnownUltragoalObjective(
-				"Please inspect .gjc/ultragoal/goals.json and .gjc/ultragoal/ledger.jsonl for fun",
-			),
+			isKnownUltragoalObjective("Please inspect .gjc/ultragoal/goals.json and .gjc/ultragoal/ledger.jsonl for fun"),
 		).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
- `isKnownUltragoalObjective` now accepts only the exact default aggregate objective.
- Path-substring sniffing of `.gjc/ultragoal/goals.json` + `ledger.jsonl` is removed.
- Regression tests lock fail-closed behavior.

Related to #2396 (provenance hardening direction).

## Why this is necessary
Guards that decide whether Ultragoal is "active" must fail closed. Substring matching lets arbitrary user goals that mention ledger paths look Ultragoal-owned, which can mis-arm pause/drop/complete protection. Ownership must be exact or explicit, never "looks related".

## Test plan
- [x] `bun test packages/coding-agent/test/gjc-runtime/ultragoal-known-objective.test.ts`