### PR TITLE
fix(team): treat explicit user request as execution approval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,9 @@ Use the smallest workflow that satisfies the request:
 2. `deep-interview` when intent, scope, or acceptance criteria are ambiguous.
 3. `ralplan` when requirements are clear enough to plan but architecture, sequencing, or verification needs consensus.
 4. `ultragoal` when work should be split into durable goals with an auditable ledger.
-5. `team` when approved work benefits from parallel workers.
+5. `team` when approved work benefits from parallel workers. An explicit user request for team is execution approval — start without re-asking.
 
-Do not execute implementation from `deep-interview` or `ralplan` unless the user explicitly approves execution. Planning artifacts must remain `pending approval` until that approval exists.
+Do not execute implementation from `deep-interview` or `ralplan` unless the user explicitly approves execution. Planning artifacts must remain `pending approval` until that approval exists. An explicit user request to run `ultragoal` or `team` is that approval for the named execution skill.
 
 Subagent await timeouts are observation windows, not failure signals. Do not cancel a subagent merely because `subagent await` timed out; inspect/list, continue independent work, and cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+- Explicit user requests for `team` (`team`, `/skill:team`, `gjc team`, or equivalent) are treated as execution approval: the agent starts immediately and does not re-ask whether to begin.
+
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -7,6 +7,12 @@ source: "forked from upstream team skill and rebranded for GJC"
 
 # Team Skill
 
+## Explicit start is approval
+
+When the user explicitly asks to run team in the current prompt — `team`, `/skill:team`, `gjc team`, or an equivalent direct execution request — that is execution approval. Start the coordinated team workflow immediately. Do not re-prompt with "should I start?", "execute?", or other pre-start approval options.
+
+This override applies only to the pre-start consent gate. After launch, keep the existing worker/lifecycle/shutdown discipline.
+
 `$team` is the tmux-based multi-worker execution mode for GJC. It starts real GJC worker CLI sessions by splitting the current tmux leader window and coordinates them through `.gjc/_session-{sessionid}/state/team/...` files plus CLI team interop (`gjc team api ...`) and state files.
 
 This skill is operationally sensitive. Treat it as an operator workflow, not a generic prompt pattern. In GJC App or plain outside-tmux sessions, do not present `$team` / `gjc team` as directly available; launch GJC CLI from shell first, or stay on the nearest app-safe surface until the user explicitly wants the tmux runtime.

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -22,9 +22,9 @@ Optimize for correctness first, maintainability second, and brevity third. Prefe
 - Clear, low-risk implementation requests use direct tools and focused verification; do not invoke workflows or role agents for ceremony.
 - Informational questions are answer-only/read-only unless the user explicitly requests a change, command, or execution.
 - Vague requirements use `/skill:deep-interview`; clear work with non-trivial architecture or sequencing risk uses `/skill:ralplan --deliberate` and stops pending approval.
-- Use `/skill:ultragoal` for durable goal ledgers and `/skill:team` for approved coordinated persistent work.
+- Use `/skill:ultragoal` for durable goal ledgers and `/skill:team` for approved coordinated persistent work. When the user explicitly requests team execution in the current prompt (`team`, `/skill:team`, `gjc team`, or equivalent), that request is execution approval: invoke team immediately and do not re-ask whether to start.
 - Delegate large implementation slices to `executor`; use `planner`, `architect`, or `critic` for bounded planning and review.
-- Active skills are authoritative: read and follow them; planning and read-only skills do not mutate before approval.
+- Active skills are authoritative: read and follow them; planning and read-only skills do not mutate before approval. When the user explicitly requests a bundled workflow skill by name in the current prompt (`/skill:<name>`, the skill name, or `gjc <name>`), that request is approval: invoke it immediately in the same turn. Do not re-ask "should I start?" / "execute?" before beginning.
 </routing>
 </gjc-runtime>
 {{/unless}}

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -403,9 +403,21 @@ Project executor override body.
 		expect(routing).toContain("`/skill:ralplan --deliberate`");
 		expect(routing).toContain("`/skill:ultragoal`");
 		expect(routing).toContain("`/skill:team`");
+		expect(routing).toContain("explicitly requests team execution");
+		expect(routing).toContain("that request is execution approval");
 		expect(routing).toContain("Delegate large implementation slices to `executor`");
 		expect(routing.split("\n").filter(line => line.startsWith("-"))).toHaveLength(6);
 		expect(decomposition).toMatch(/skip it for one-step or obvious two-step fixes/i);
+	});
+
+
+	it("treats explicit team requests as execution approval", async () => {
+		const team = await Bun.file(
+			path.join(repoRoot, "packages", "coding-agent", "src", "defaults", "gjc", "skills", "team", "SKILL.md"),
+		).text();
+		expect(team).toContain("## Explicit start is approval");
+		expect(team).toContain("that is execution approval");
+		expect(team).toContain("Do not re-prompt with \"should I start?\"");
 	});
 
 	it("documents leader-owned Ultragoal checkpoints for Team bridge workers", async () => {


### PR DESCRIPTION
## Summary
- Explicit `team` / `/skill:team` / `gjc team` requests are execution approval.
- System routing + team skill docs start immediately without a pre-start re-ask.
- Contract tests lock the wording.

Companion to the ultragoal explicit-start fix (#2487).

## Why this is necessary
Same failure mode as ultragoal: user already chose the execution skill, then the agent asks again. That is pure friction and trains distrust. Explicit skill selection is consent.

## Test plan
- [x] `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`