### PR TITLE
fix(task): single-source subagent await/cancel doctrine

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+- Subagent await/cancel doctrine now has a single source of truth shared by task handoff text, the subagent tool, and prompt/skill docs, so timeout-vs-cancel guidance cannot drift.
+
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).

--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -197,7 +197,7 @@ Forced-delegation rules:
 - Small, atomic, single-file changes below these thresholds stay with the leader — do not over-delegate trivial work.
 - After integrating delegated slices, run `architect` / `critic` review lanes; worker agents never mutate `.gjc/_session-{sessionid}/ultragoal` or call goal tools.
 
-When delegating with native subagents, an await timeout only limits the leader's wait. It is not subagent failure evidence and must not be used as a cancellation reason; inspect or continue independent work, and cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
+When delegating with native subagents, an await timeout only bounds the wait. It is not subagent failure evidence and must not be used as a cancellation reason; inspect or continue independent work, and cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
 
 If an Ultragoal request has no approved plan or consensus artifact, run `ralplan` first and preserve its PRD, test spec, role roster, and verification guidance in the Ultragoal ledger. Do not silently substitute ad-hoc execution for missing planning.
 

--- a/packages/coding-agent/src/prompts/tools/subagent.md
+++ b/packages/coding-agent/src/prompts/tools/subagent.md
@@ -15,8 +15,8 @@ Inspect selected subagents by `ids`; omit `ids` to inspect current running subag
 ## `action: "await"`
 Wait for selected subagents by `ids`; omit `ids` to wait for current running subagents.
 - Always set `timeout_ms` when the result is not immediately required forever.
-- Await timeout only bounds this tool call's wait; it does not stop the subagent and is not a failure reason.
-- On timeout, inspect progress and keep doing independent work. Never cancel just because an await timed out; cancel only if the subagent has actually failed, gone off-track, or become unrecoverably wrong.
+- An await timeout only bounds the wait. It is not subagent failure evidence and must not be used as a cancellation reason; inspect or continue independent work, and cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
+- On timeout, inspect progress and keep doing independent work.
 - Completed results are receipt-first by default: bounded preview plus `agent://<id>` output ref when available, not full retained output.
 
 ## `action: "pause"`
@@ -42,7 +42,7 @@ Send a non-empty `message` to one subagent by `id` (preferred) or a single-item 
 
 ## `action: "cancel"`
 Stop selected subagents by `ids`, including running, paused, or queued subagents.
-- Use only when the subagent has actually failed, gone off-track, or become unrecoverably wrong; an await timeout alone is never a cancellation reason.
+- Cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong; an await timeout alone is never a cancellation reason.
 - Cancellation keeps the subagent session file for possible later context recovery.
 
 # Statuses

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -19,9 +19,6 @@ import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@gajae
 import type { Model, Usage } from "@gajae-code/ai";
 import { $env, prompt, Snowflake } from "@gajae-code/utils";
 import type { ToolSession } from "..";
-import {
-	SUBAGENT_AWAIT_TIMEOUT_DOCTRINE,
-} from "./subagent-await-doctrine";
 import { AsyncJobManager, OwnerSubagentShutdownError, type ResumeRunner } from "../async";
 import { resolveAgentModelPatterns } from "../config/model-resolver";
 import type { Theme } from "../modes/theme/theme";
@@ -30,6 +27,7 @@ import taskDescriptionTemplate from "../prompts/tools/task.md" with { type: "tex
 import taskSummaryTemplate from "../prompts/tools/task-summary.md" with { type: "text" };
 import type { ForkContextSeed } from "../session/agent-session";
 import { formatBytes, formatDuration } from "../tools/render-utils";
+import { SUBAGENT_AWAIT_TIMEOUT_DOCTRINE } from "./subagent-await-doctrine";
 import {
 	type AgentDefinition,
 	type AgentProgress,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -19,6 +19,9 @@ import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@gajae
 import type { Model, Usage } from "@gajae-code/ai";
 import { $env, prompt, Snowflake } from "@gajae-code/utils";
 import type { ToolSession } from "..";
+import {
+	SUBAGENT_AWAIT_TIMEOUT_DOCTRINE,
+} from "./subagent-await-doctrine";
 import { AsyncJobManager, OwnerSubagentShutdownError, type ResumeRunner } from "../async";
 import { resolveAgentModelPatterns } from "../config/model-resolver";
 import type { Theme } from "../modes/theme/theme";
@@ -861,8 +864,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			})
 			.join("\n");
 		const coordinationHint = ircEnabled
-			? ` DM these ids via \`irc\` to coordinate while they run. Use \`subagent\` to list, inspect, or await with a timeout; a timeout only bounds your wait and is never a cancellation reason. Cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong; \`job\` remains available for generic background jobs.`
-			: ` Use \`subagent\` to list, inspect, or await with a timeout; a timeout only bounds your wait and is never a cancellation reason. Cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong; \`job\` remains available for generic background jobs.`;
+			? ` DM these ids via \`irc\` to coordinate while they run. Use \`subagent\` to list, inspect, or await with a timeout. ${SUBAGENT_AWAIT_TIMEOUT_DOCTRINE} \`job\` remains available for generic background jobs.`
+			: ` Use \`subagent\` to list, inspect, or await with a timeout. ${SUBAGENT_AWAIT_TIMEOUT_DOCTRINE} \`job\` remains available for generic background jobs.`;
 
 		return {
 			content: [

--- a/packages/coding-agent/src/task/subagent-await-doctrine.ts
+++ b/packages/coding-agent/src/task/subagent-await-doctrine.ts
@@ -1,0 +1,9 @@
+/**
+ * Single source of truth for subagent await/cancel doctrine.
+ * Imported by tool prompts, task handoff text, and workflow skills.
+ */
+export const SUBAGENT_AWAIT_TIMEOUT_DOCTRINE =
+	"An await timeout only bounds the wait. It is not subagent failure evidence and must not be used as a cancellation reason; inspect or continue independent work, and cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.";
+
+export const SUBAGENT_CANCEL_ONLY_WHEN_WRONG_DOCTRINE =
+	"Cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong; an await timeout alone is never a cancellation reason.";

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -1,3 +1,4 @@
+import { SUBAGENT_AWAIT_TIMEOUT_DOCTRINE } from "../task/subagent-await-doctrine";
 import * as path from "node:path";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
 import { prompt } from "@gajae-code/utils";
@@ -702,7 +703,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		const subagent = job.metadata?.subagent;
 		const runningTimeoutGuidance =
 			timedOut && job.status === "running"
-				? "Still running after the await timeout; timeout only bounded this wait and is not a failure. Inspect progress, continue independent work, and never cancel just because an await timed out; cancel only if the subagent has actually failed, gone off-track, or become unrecoverably wrong."
+				? `Still running after the await timeout. ${SUBAGENT_AWAIT_TIMEOUT_DOCTRINE}`
 				: undefined;
 		const output = previewJobOutput(job, verbosity);
 		const outputRef = record && verifiedOutputIds.has(record.subagentId) ? `agent://${record.subagentId}` : undefined;

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -1,10 +1,10 @@
-import { SUBAGENT_AWAIT_TIMEOUT_DOCTRINE } from "../task/subagent-await-doctrine";
 import * as path from "node:path";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
 import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { type AsyncJob, AsyncJobManager, jobElapsedMs, type SubagentRecord } from "../async";
 import subagentDescription from "../prompts/tools/subagent.md" with { type: "text" };
+import { SUBAGENT_AWAIT_TIMEOUT_DOCTRINE } from "../task/subagent-await-doctrine";
 import type { AgentProgress, AgentSource, TaskToolDetails } from "../task/types";
 import { Ellipsis, truncateToWidth } from "../tui";
 import type { ToolSession } from "./index";

--- a/packages/coding-agent/test/task/subagent-await-doctrine.test.ts
+++ b/packages/coding-agent/test/task/subagent-await-doctrine.test.ts
@@ -10,10 +10,7 @@ const repoRoot = path.resolve(import.meta.dir, "../../..", "..");
 
 describe("subagent await doctrine single source", () => {
 	test("runtime surfaces import the shared doctrine text", () => {
-		const subagentTool = fs.readFileSync(
-			path.join(repoRoot, "packages/coding-agent/src/tools/subagent.ts"),
-			"utf8",
-		);
+		const subagentTool = fs.readFileSync(path.join(repoRoot, "packages/coding-agent/src/tools/subagent.ts"), "utf8");
 		const taskIndex = fs.readFileSync(path.join(repoRoot, "packages/coding-agent/src/task/index.ts"), "utf8");
 		expect(subagentTool).toContain("SUBAGENT_AWAIT_TIMEOUT_DOCTRINE");
 		expect(taskIndex).toContain("SUBAGENT_AWAIT_TIMEOUT_DOCTRINE");

--- a/packages/coding-agent/test/task/subagent-await-doctrine.test.ts
+++ b/packages/coding-agent/test/task/subagent-await-doctrine.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+	SUBAGENT_AWAIT_TIMEOUT_DOCTRINE,
+	SUBAGENT_CANCEL_ONLY_WHEN_WRONG_DOCTRINE,
+} from "../../src/task/subagent-await-doctrine";
+
+const repoRoot = path.resolve(import.meta.dir, "../../..", "..");
+
+describe("subagent await doctrine single source", () => {
+	test("runtime surfaces import the shared doctrine text", () => {
+		const subagentTool = fs.readFileSync(
+			path.join(repoRoot, "packages/coding-agent/src/tools/subagent.ts"),
+			"utf8",
+		);
+		const taskIndex = fs.readFileSync(path.join(repoRoot, "packages/coding-agent/src/task/index.ts"), "utf8");
+		expect(subagentTool).toContain("SUBAGENT_AWAIT_TIMEOUT_DOCTRINE");
+		expect(taskIndex).toContain("SUBAGENT_AWAIT_TIMEOUT_DOCTRINE");
+		expect(SUBAGENT_AWAIT_TIMEOUT_DOCTRINE).toContain("await timeout");
+		expect(SUBAGENT_CANCEL_ONLY_WHEN_WRONG_DOCTRINE).toContain("never a cancellation reason");
+	});
+
+	test("prompt and skill docs stay aligned with the shared doctrine", () => {
+		const subagentMd = fs.readFileSync(
+			path.join(repoRoot, "packages/coding-agent/src/prompts/tools/subagent.md"),
+			"utf8",
+		);
+		const ultragoal = fs.readFileSync(
+			path.join(repoRoot, "packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md"),
+			"utf8",
+		);
+		expect(subagentMd).toContain(SUBAGENT_AWAIT_TIMEOUT_DOCTRINE);
+		expect(ultragoal).toContain("not subagent failure evidence");
+		expect(ultragoal).toContain("become unrecoverably wrong");
+	});
+});


### PR DESCRIPTION
## Summary
- Add `SUBAGENT_AWAIT_TIMEOUT_DOCTRINE` as the single source of truth.
- Wire task handoff text and subagent tool timeout messaging through it.
- Align ultragoal skill + subagent prompt wording and lock with a drift test.

Addresses #2347 residual duplication.

## Why this is necessary
When await/cancel doctrine drifts across surfaces, leaders cancel healthy workers on timeout. That is a real reliability bug: wasted compute, lost progress, and false failure attribution. One sentence, one source.

## Test plan
- [x] `bun test packages/coding-agent/test/task/subagent-await-doctrine.test.ts`