### PR TITLE
feat(coding-agent): opt-in ghost-text prompt suggestions (Claude Code-style autocomplete)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in prompt suggestions (Claude Code-style ghost-text autocomplete): with the `promptSuggestions` setting enabled, a smol-model prediction of your likely next prompt renders as dim ghost text in the empty composer after each agent turn; Tab accepts it, typing dismisses it, and a new turn clears it. Predictions are heuristically gated (silence on evaluative/meta/agent-voice/overlong output) and never generated while the composer has text or a turn is streaming.
+
 ## [0.11.1] - 2026-07-16
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1294,6 +1294,16 @@ export const SETTINGS_SCHEMA = {
 			description: "Suggest emojis from `:name:` shortcodes and expand text emoticons like `:D` or `:-)`",
 		},
 	},
+	promptSuggestions: {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			label: "Prompt Suggestions",
+			description:
+				"Predict your likely next prompt after each turn (smol-model call) and show it as ghost text; Tab accepts",
+		},
+	},
 
 	"startup.quiet": {
 		type: "boolean",

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -241,6 +241,7 @@ export class EventController {
 	}
 
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
+		this.ctx.promptSuggestion?.onAgentStart();
 		this.#lastIntent = undefined;
 		this.#readToolCallArgs.clear();
 		this.#readToolCallAssistantComponents.clear();
@@ -835,6 +836,7 @@ export class EventController {
 		this.ctx.ui.requestRender();
 		this.#scheduleIdleCompaction();
 		this.sendCompletionNotification();
+		this.ctx.promptSuggestion?.onAgentEnd();
 	}
 
 	async #handleAutoCompactionStart(

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -390,7 +390,11 @@ export class InputController {
 			this.ctx.editor.setCustomKeyHandler(key, () => this.handleForegroundToolBackgroundFold());
 		}
 
+		// Tab on an empty composer accepts the pending ghost-text prompt suggestion.
+		this.ctx.editor.onTab = (text: string) => this.ctx.promptSuggestion?.tryAcceptOnTab(text) === true;
+
 		this.ctx.editor.onChange = (text: string) => {
+			this.ctx.promptSuggestion?.notifyEditorChanged(text);
 			const wasBashMode = this.ctx.isBashMode;
 			const wasBashNoContext = this.ctx.isBashNoContext;
 			const wasPythonMode = this.ctx.isPythonMode;
@@ -1250,6 +1254,7 @@ export class InputController {
 			moveCursorToMessageStart: () => this.ctx.editor.moveToMessageStart(),
 			moveCursorToLineStart: () => this.ctx.editor.moveToLineStart(),
 			moveCursorToLineEnd: () => this.ctx.editor.moveToLineEnd(),
+			getPromptSuggestion: () => this.ctx.promptSuggestion?.current ?? null,
 		});
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -112,6 +112,7 @@ import { TodoCommandController } from "./controllers/todo-command-controller";
 import { IrcObservationLedger } from "./irc-observation-ledger";
 import { JobsObserver } from "./jobs-observer";
 import { OAuthManualInputManager } from "./oauth-manual-input";
+import { PromptSuggestionController } from "./prompt-suggestion-controller";
 import { SessionObserverRegistry } from "./session-observer-registry";
 import { interruptHint } from "./shared";
 import { shouldShowExtensionCommand } from "./slash-command-visibility";
@@ -390,6 +391,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	fileSlashCommands: Set<string> = new Set();
 	skillCommands: Map<string, Skill> = new Map();
 	oauthManualInput: OAuthManualInputManager = new OAuthManualInputManager();
+	promptSuggestion: PromptSuggestionController;
 
 	#baseSlashCommands: SlashCommand[] = [];
 	#baseReservedSlashCommandNames: Set<string> = new Set();
@@ -542,6 +544,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#todoCommandController = new TodoCommandController(this);
 		this.#selectorController = new SelectorController(this);
 		this.#inputController = new InputController(this);
+		this.promptSuggestion = new PromptSuggestionController(this);
 		this.#observerRegistry = new SessionObserverRegistry();
 	}
 

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -44,6 +44,11 @@ interface PromptActionAutocompleteOptions {
 	moveCursorToMessageStart: () => void;
 	moveCursorToLineStart: () => void;
 	moveCursorToLineEnd: () => void;
+	/**
+	 * Ghost-text next-prompt prediction shown in the empty composer as a dim
+	 * inline hint (Tab accepts it via the editor's onTab handler).
+	 */
+	getPromptSuggestion?: () => string | null;
 }
 
 function fuzzyMatch(query: string, target: string): boolean {
@@ -186,11 +191,18 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 	#baseProvider: CombinedAutocompleteProvider;
 	#actions: PromptActionDefinition[];
 	#commands: SlashCommand[];
+	#getPromptSuggestion: (() => string | null) | undefined;
 
-	constructor(commands: SlashCommand[], basePath: string, actions: PromptActionDefinition[]) {
+	constructor(
+		commands: SlashCommand[],
+		basePath: string,
+		actions: PromptActionDefinition[],
+		getPromptSuggestion?: () => string | null,
+	) {
 		this.#baseProvider = new CombinedAutocompleteProvider(commands, basePath);
 		this.#actions = actions;
 		this.#commands = commands;
+		this.#getPromptSuggestion = getPromptSuggestion;
 	}
 
 	async getSuggestions(
@@ -302,6 +314,11 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 	}
 
 	getInlineHint(lines: string[], cursorLine: number, cursorCol: number): string | null {
+		// An empty composer renders the pending prompt suggestion as ghost text.
+		if (lines.every(line => line === "")) {
+			const suggestion = this.#getPromptSuggestion?.();
+			if (suggestion) return suggestion;
+		}
 		return this.#baseProvider.getInlineHint?.(lines, cursorLine, cursorCol) ?? null;
 	}
 	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
@@ -456,5 +473,10 @@ export function createPromptActionAutocompleteProvider(
 		},
 	];
 
-	return new PromptActionAutocompleteProvider(options.commands, options.basePath, actions);
+	return new PromptActionAutocompleteProvider(
+		options.commands,
+		options.basePath,
+		actions,
+		options.getPromptSuggestion,
+	);
 }

--- a/packages/coding-agent/src/modes/prompt-suggestion-controller.ts
+++ b/packages/coding-agent/src/modes/prompt-suggestion-controller.ts
@@ -1,0 +1,96 @@
+import { logger } from "@gajae-code/utils";
+import { generatePromptSuggestion } from "../utils/prompt-suggestion";
+import type { InteractiveModeContext } from "./types";
+
+/**
+ * Owns the ghost-text next-prompt prediction lifecycle for interactive mode.
+ *
+ * After each agent turn ends (and only when `promptSuggestions` is enabled
+ * and the composer is empty), a smol-model prediction of the user's next
+ * prompt is generated in the background. The result renders as dim ghost
+ * text in the empty composer via the autocomplete provider's inline hint;
+ * Tab accepts it, typing dismisses it, and a new turn clears it.
+ */
+export class PromptSuggestionController {
+	#ctx: InteractiveModeContext;
+	#current: string | null = null;
+	/** Monotonic token; bumping it invalidates any in-flight generation. */
+	#generation = 0;
+
+	constructor(ctx: InteractiveModeContext) {
+		this.#ctx = ctx;
+	}
+
+	/** Current suggestion to render as ghost text, or null. */
+	get current(): string | null {
+		return this.#current;
+	}
+
+	/** Drop the current suggestion and invalidate any in-flight generation. */
+	clear(): void {
+		this.#generation++;
+		if (this.#current === null) return;
+		this.#current = null;
+		this.#ctx.ui.requestRender();
+	}
+
+	/** A new agent turn started; any pending suggestion is stale. */
+	onAgentStart(): void {
+		this.clear();
+	}
+
+	/**
+	 * Editor content changed. A non-empty composer means the user is writing
+	 * their own prompt: dismiss the suggestion and cancel pending generation.
+	 */
+	notifyEditorChanged(text: string): void {
+		if (text.length > 0) this.clear();
+	}
+
+	/**
+	 * Agent turn ended; kick off background generation when the feature is
+	 * enabled and the composer is idle and empty.
+	 */
+	onAgentEnd(): void {
+		if (!this.#ctx.settings.get("promptSuggestions")) return;
+		if (this.#ctx.shutdownRequested) return;
+		if (this.#ctx.session.isStreaming) return;
+		if (this.#ctx.editor.getText().trim() !== "") return;
+
+		const generation = ++this.#generation;
+		void generatePromptSuggestion(
+			this.#ctx.session.messages,
+			this.#ctx.session.modelRegistry,
+			this.#ctx.settings,
+			this.#ctx.session.sessionId,
+			this.#ctx.session.model,
+			provider => this.#ctx.session.agent.metadataForProvider(provider),
+		)
+			.then(suggestion => {
+				if (generation !== this.#generation) return;
+				if (!suggestion) return;
+				// The world may have moved on while the model was thinking.
+				if (this.#ctx.session.isStreaming) return;
+				if (this.#ctx.editor.getText().trim() !== "") return;
+				this.#current = suggestion;
+				this.#ctx.ui.requestRender();
+			})
+			.catch(error => {
+				logger.debug("prompt-suggestion: generation failed", { error: String(error) });
+			});
+	}
+
+	/**
+	 * Tab handler for the composer: accept the suggestion when the composer
+	 * is empty. Returns true when Tab was consumed.
+	 */
+	tryAcceptOnTab(text: string): boolean {
+		const suggestion = this.#current;
+		if (!suggestion || text.trim() !== "") return false;
+		// setText fires onChange with non-empty text, which clears #current.
+		this.#ctx.editor.setText(suggestion);
+		this.clear();
+		this.#ctx.ui.requestRender();
+		return true;
+	}
+}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -32,6 +32,7 @@ import type { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import type { IrcObservationLedger } from "./irc-observation-ledger";
 import type { OAuthManualInputManager } from "./oauth-manual-input";
+import type { PromptSuggestionController } from "./prompt-suggestion-controller";
 import type { Theme } from "./theme/theme";
 import type { ParsedIrcMessage } from "./utils/irc-message";
 
@@ -149,6 +150,8 @@ export interface InteractiveModeContext {
 	skillCommands: Map<string, Skill>;
 	oauthManualInput: OAuthManualInputManager;
 	todoPhases: TodoPhase[];
+	/** Ghost-text next-prompt prediction; absent in ACP/lightweight test contexts. */
+	promptSuggestion?: PromptSuggestionController;
 
 	// Lifecycle
 	init(): Promise<void>;

--- a/packages/coding-agent/src/prompts/system/prompt-suggestion-system.md
+++ b/packages/coding-agent/src/prompts/system/prompt-suggestion-system.md
@@ -1,0 +1,32 @@
+[SUGGESTION MODE: Suggest what the user might naturally type next into the coding agent.]
+
+FIRST: Look at the user's recent messages and original request.
+
+Your job is to predict what THEY would type - not what you think they should do.
+
+THE TEST: Would they think "I was just about to type that"?
+
+EXAMPLES:
+User asked "fix the bug and run tests", bug is fixed → "run the tests"
+After code written → "try it out"
+Agent offers options → suggest the one the user would likely pick, based on conversation
+Agent asks to continue → "yes" or "go ahead"
+Task complete, obvious follow-up → "commit this" or "push it"
+After error or misunderstanding → silence (let them assess/correct)
+
+Be specific: "run the tests" beats "continue".
+
+NEVER SUGGEST:
+- Evaluative ("looks good", "thanks")
+- Questions ("what about…?")
+- Agent-voice ("Let me…", "I'll…", "Here's…")
+- New ideas they didn't ask about
+- Multiple sentences
+
+Stay silent if the next step isn't obvious from what the user said.
+
+Stay silent if a suggestion could be unsafe or inappropriate — including any sensitive topic (security incidents, credentials, harm, private data). Even when the user is doing legitimate security or cybersecurity work, do not predict potentially unsafe actions.
+
+Format: 2-12 words, match the user's style. Or nothing.
+
+Reply with ONLY the suggestion, no quotes or explanation.

--- a/packages/coding-agent/src/utils/prompt-suggestion.ts
+++ b/packages/coding-agent/src/utils/prompt-suggestion.ts
@@ -1,0 +1,265 @@
+/**
+ * Predict the user's likely next prompt after an agent turn using a smol,
+ * fast model. Native GJC port of the ghost-text prompt-suggestion behavior
+ * from Claude Code: the prediction renders as dim ghost text in the empty
+ * composer and Tab accepts it.
+ */
+import type { AgentMessage } from "@gajae-code/agent-core";
+import { type Api, type AssistantMessage, completeSimple, type Model } from "@gajae-code/ai";
+import { logger, prompt } from "@gajae-code/utils";
+import type { ModelRegistry } from "../config/model-registry";
+import { resolveRoleSelection } from "../config/model-resolver";
+import type { Settings } from "../config/settings";
+import suggestionSystemPrompt from "../prompts/system/prompt-suggestion-system.md" with { type: "text" };
+
+const SUGGESTION_SYSTEM_PROMPT = prompt.render(suggestionSystemPrompt);
+
+export const PROMPT_SUGGESTION_MAX_WORDS = 12;
+export const PROMPT_SUGGESTION_MAX_CHARS = 100;
+
+const SUGGESTION_MAX_TOKENS = 64;
+const REASONING_SAFE_MAX_TOKENS = 1024;
+const MAX_CONTEXT_MESSAGES = 12;
+const MAX_MESSAGE_CHARS = 1500;
+const MAX_CONTEXT_CHARS = 8000;
+
+/** Single words a user plausibly types on their own; anything else needs >= 2 words. */
+const SINGLE_WORD_ALLOWLIST = new Set([
+	"yes",
+	"yeah",
+	"yep",
+	"yea",
+	"yup",
+	"sure",
+	"ok",
+	"okay",
+	"push",
+	"commit",
+	"deploy",
+	"stop",
+	"continue",
+	"check",
+	"exit",
+	"quit",
+	"no",
+]);
+
+/** Model responses that are meta-statements about staying silent, not suggestions. */
+const META_TEXT_PATTERN = /\bsilence is\b|\bstay(s|ing)? silent\b/;
+
+/**
+ * Strip wrapper tags and label prefixes a model sometimes adds despite being
+ * told to reply with only the suggestion.
+ */
+export function sanitizePromptSuggestion(raw: string): string {
+	return raw
+		.trim()
+		.replace(/^<(suggestion|response|output|answer|result)>([\s\S]*)<\/\1>$/i, (match, tag: string, inner: string) =>
+			// Keep the original when the inner text itself contains the closing
+			// tag (nested/ambiguous markup) instead of producing a mangled strip.
+			inner.includes(`</${tag.toLowerCase()}>`) || inner.includes(`</${tag.toUpperCase()}>`) ? match : inner,
+		)
+		.replace(
+			/^\s*(suggested\s+(response|reply|input|prompt)|suggestion|response|reply|answer|output|result)\s*:\s*/i,
+			"",
+		)
+		.trim();
+}
+
+/**
+ * Heuristic gate rejecting model output that would make a bad ghost-text
+ * suggestion. Returns the rejection reason, or null when the text is usable.
+ */
+export function suppressPromptSuggestionReason(text: string): string | null {
+	if (!text) return "empty";
+	const lower = text.toLowerCase();
+	const wordCount = text.trim().split(/\s+/).length;
+
+	if (lower === "done") return "done";
+	if (
+		lower === "nothing found" ||
+		lower === "nothing found." ||
+		lower.startsWith("nothing to suggest") ||
+		lower.startsWith("no suggestion") ||
+		META_TEXT_PATTERN.test(lower) ||
+		/^\W*silence\W*$/.test(lower)
+	) {
+		return "meta_text";
+	}
+	if (/^\(.*\)$|^\[.*\]$/.test(text)) return "meta_wrapped";
+	if (
+		lower.startsWith("api error:") ||
+		lower.startsWith("prompt is too long") ||
+		lower.startsWith("request timed out") ||
+		lower.startsWith("invalid api key")
+	) {
+		return "error_message";
+	}
+	if (/^\w+:\s/.test(text)) return "prefixed_label";
+	if (wordCount < 2 && !text.startsWith("/") && !SINGLE_WORD_ALLOWLIST.has(lower)) return "too_few_words";
+	if (wordCount > PROMPT_SUGGESTION_MAX_WORDS) return "too_many_words";
+	if (text.length >= PROMPT_SUGGESTION_MAX_CHARS) return "too_long";
+	if (/[.!?]\s+[A-Z]/.test(text)) return "multiple_sentences";
+	if (/[\n*]|\*\*/.test(text)) return "has_formatting";
+	if (
+		/thanks|thank you|looks good|sounds good|that works|that worked|that's all|nice|great|perfect|makes sense|awesome|excellent/.test(
+			lower,
+		)
+	) {
+		return "evaluative";
+	}
+	if (
+		/^(let me|i'll|i've|i'm|i can|i would|i think|i notice|here's|here is|here are|that's|this is|this will|you can|you should|you could|sure,|of course|certainly)/i.test(
+			text,
+		)
+	) {
+		return "claude_voice";
+	}
+	return null;
+}
+
+function extractTranscriptEntry(message: AgentMessage): { role: "User" | "Assistant"; text: string } | null {
+	if (message.role === "user") {
+		const content = message.content;
+		const text =
+			typeof content === "string"
+				? content
+				: content
+						.filter(block => block.type === "text")
+						.map(block => block.text)
+						.join("\n");
+		const trimmed = text.trim();
+		return trimmed ? { role: "User", text: trimmed } : null;
+	}
+	if (message.role === "assistant") {
+		const text = (message as AssistantMessage).content
+			.filter(block => block.type === "text")
+			.map(block => block.text)
+			.join("\n")
+			.trim();
+		return text ? { role: "Assistant", text } : null;
+	}
+	return null;
+}
+
+/**
+ * Build a compact recent-conversation transcript for the prediction request.
+ * Returns null when there is no user message to predict from.
+ */
+export function buildPromptSuggestionContext(messages: AgentMessage[]): string | null {
+	const entries: { role: "User" | "Assistant"; text: string }[] = [];
+	let totalChars = 0;
+	for (let index = messages.length - 1; index >= 0 && entries.length < MAX_CONTEXT_MESSAGES; index--) {
+		const message = messages[index];
+		if (!message) continue;
+		const entry = extractTranscriptEntry(message);
+		if (!entry) continue;
+		const text = entry.text.length > MAX_MESSAGE_CHARS ? `${entry.text.slice(0, MAX_MESSAGE_CHARS)}…` : entry.text;
+		if (totalChars + text.length > MAX_CONTEXT_CHARS && entries.length > 0) break;
+		entries.push({ role: entry.role, text });
+		totalChars += text.length;
+	}
+	if (!entries.some(entry => entry.role === "User")) return null;
+	entries.reverse();
+	const transcript = entries.map(entry => `${entry.role}: ${entry.text}`).join("\n\n");
+	return `<conversation>\n${transcript}\n</conversation>\n\nPredict the user's next message.`;
+}
+
+function getSuggestionModel(
+	registry: ModelRegistry,
+	settings: Settings,
+	currentModel?: Model<Api>,
+): Model<Api> | undefined {
+	const availableModels = registry.getAvailable();
+	if (availableModels.length === 0) return undefined;
+	const model = resolveRoleSelection(["default"], settings, availableModels, registry)?.model;
+	if (model) return model;
+	return currentModel;
+}
+
+function extractSuggestionText(contentBlocks: AssistantMessage["content"]): string {
+	let text = "";
+	for (const content of contentBlocks) {
+		if (content.type === "text") {
+			text += content.text;
+		}
+	}
+	return text;
+}
+
+/**
+ * Generate a predicted next user prompt from the recent conversation.
+ * Returns null when no usable suggestion is produced (silence is the
+ * expected steady state).
+ */
+export async function generatePromptSuggestion(
+	messages: AgentMessage[],
+	registry: ModelRegistry,
+	settings: Settings,
+	sessionId?: string,
+	currentModel?: Model<Api>,
+	metadataResolver?: (provider: string) => Record<string, unknown> | undefined,
+): Promise<string | null> {
+	const context = buildPromptSuggestionContext(messages);
+	if (!context) return null;
+
+	const model = getSuggestionModel(registry, settings, currentModel);
+	if (!model) {
+		logger.debug("prompt-suggestion: no model available");
+		return null;
+	}
+
+	const apiKey = await registry.getApiKey(model, sessionId);
+	if (!apiKey) {
+		logger.debug("prompt-suggestion: no API key", { provider: model.provider, id: model.id });
+		return null;
+	}
+	// Resolve metadata after getApiKey so the session-sticky credential for
+	// this request is already recorded (same contract as title-generator).
+	const metadata = metadataResolver?.(model.provider);
+
+	// A suggestion is a 2-12 word task, but some reasoning backends ignore
+	// disableReasoning; reserve output room for the answer after any
+	// unavoidable thinking tokens.
+	const maxTokens = model.reasoning
+		? Math.max(SUGGESTION_MAX_TOKENS, REASONING_SAFE_MAX_TOKENS)
+		: SUGGESTION_MAX_TOKENS;
+
+	try {
+		const response = await completeSimple(
+			model,
+			{
+				systemPrompt: [SUGGESTION_SYSTEM_PROMPT],
+				messages: [{ role: "user", content: context, timestamp: Date.now() }],
+			},
+			{
+				apiKey,
+				maxTokens,
+				disableReasoning: true,
+				metadata,
+			},
+		);
+
+		if (response.stopReason === "error") {
+			logger.debug("prompt-suggestion: response error", {
+				model: `${model.provider}/${model.id}`,
+				errorMessage: response.errorMessage,
+			});
+			return null;
+		}
+
+		const suggestion = sanitizePromptSuggestion(extractSuggestionText(response.content));
+		const suppressReason = suppressPromptSuggestionReason(suggestion);
+		if (suppressReason) {
+			logger.debug("prompt-suggestion: suppressed", { reason: suppressReason });
+			return null;
+		}
+		return suggestion;
+	} catch (err) {
+		logger.debug("prompt-suggestion: error", {
+			model: `${model.provider}/${model.id}`,
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return null;
+	}
+}

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -411,7 +411,9 @@ describe("InputController keybinding setup", () => {
 		controller.setupKeyHandlers();
 		await Bun.sleep(0);
 
-		expect(editor.onTab).toBeUndefined();
+		// The prompt-suggestion onTab handler must not consume Tab while the
+		// composer has text, so editor autocomplete still sees the key.
+		expect(editor.onTab?.(editor.getText())).toBeFalsy();
 		expect(editor.onTabDeclined).toBeUndefined();
 		expect(spies.prompt).not.toHaveBeenCalled();
 		expect(spies.updatePendingMessagesDisplay).not.toHaveBeenCalled();
@@ -428,7 +430,9 @@ describe("InputController keybinding setup", () => {
 		controller.setupKeyHandlers();
 		await Bun.sleep(0);
 
-		expect(editor.onTab).toBeUndefined();
+		// The prompt-suggestion onTab handler must not consume Tab while the
+		// composer has text, so editor autocomplete still sees the key.
+		expect(editor.onTab?.(editor.getText())).toBeFalsy();
 		expect(editor.onTabDeclined).toBeUndefined();
 		expect(spies.queueCompactionMessage).not.toHaveBeenCalled();
 		expect(spies.prompt).not.toHaveBeenCalled();

--- a/packages/coding-agent/test/prompt-suggestion-controller.test.ts
+++ b/packages/coding-agent/test/prompt-suggestion-controller.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as ai from "@gajae-code/ai";
+import { getBundledModel } from "@gajae-code/ai";
+import { PromptSuggestionController } from "../src/modes/prompt-suggestion-controller";
+import type { InteractiveModeContext } from "../src/modes/types";
+
+interface FakeCtxOptions {
+	enabled?: boolean;
+	editorText?: string;
+	isStreaming?: boolean;
+}
+
+function createFakeCtx(options: FakeCtxOptions = {}) {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled model");
+	let editorText = options.editorText ?? "";
+	const state = {
+		renderCount: 0,
+		setTextCalls: [] as string[],
+	};
+	const ctx = {
+		settings: {
+			get(key: string) {
+				return key === "promptSuggestions" ? (options.enabled ?? true) : undefined;
+			},
+			getModelRole(role: string) {
+				return role === "default" ? `${model.provider}/${model.id}` : undefined;
+			},
+			getStorage() {
+				return undefined;
+			},
+		},
+		shutdownRequested: false,
+		session: {
+			isStreaming: options.isStreaming ?? false,
+			messages: [{ role: "user", content: "fix the bug", timestamp: Date.now() }],
+			modelRegistry: {
+				getAvailable: () => [model],
+				getApiKey: async () => "test-key",
+			},
+			sessionId: "test-session",
+			model,
+			agent: {
+				metadataForProvider: () => undefined,
+			},
+		},
+		editor: {
+			getText: () => editorText,
+			setText: (text: string) => {
+				editorText = text;
+				state.setTextCalls.push(text);
+			},
+		},
+		ui: {
+			requestRender: () => {
+				state.renderCount++;
+			},
+		},
+	} as unknown as InteractiveModeContext;
+	return { ctx, state, setEditorText: (text: string) => (editorText = text) };
+}
+
+function mockPrediction(text: string) {
+	return vi.spyOn(ai, "completeSimple").mockResolvedValue({
+		stopReason: "stop",
+		content: [{ type: "text", text }],
+	} as never);
+}
+
+async function settle() {
+	// Let the generation promise chain resolve.
+	await new Promise(resolve => setImmediate(resolve));
+	await new Promise(resolve => setImmediate(resolve));
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("PromptSuggestionController", () => {
+	it("stores the prediction after agent end and renders it", async () => {
+		const { ctx, state } = createFakeCtx();
+		const controller = new PromptSuggestionController(ctx);
+		mockPrediction("run the tests");
+
+		controller.onAgentEnd();
+		await settle();
+
+		expect(controller.current).toBe("run the tests");
+		expect(state.renderCount).toBeGreaterThan(0);
+	});
+
+	it("does nothing when the setting is disabled", async () => {
+		const { ctx } = createFakeCtx({ enabled: false });
+		const controller = new PromptSuggestionController(ctx);
+		const completeSimpleMock = mockPrediction("run the tests");
+
+		controller.onAgentEnd();
+		await settle();
+
+		expect(controller.current).toBeNull();
+		expect(completeSimpleMock).not.toHaveBeenCalled();
+	});
+
+	it("does not generate while the composer has text", async () => {
+		const { ctx } = createFakeCtx({ editorText: "draft in progress" });
+		const controller = new PromptSuggestionController(ctx);
+		const completeSimpleMock = mockPrediction("run the tests");
+
+		controller.onAgentEnd();
+		await settle();
+
+		expect(controller.current).toBeNull();
+		expect(completeSimpleMock).not.toHaveBeenCalled();
+	});
+
+	it("discards a stale generation when a new turn starts mid-flight", async () => {
+		const { ctx } = createFakeCtx();
+		const controller = new PromptSuggestionController(ctx);
+		mockPrediction("run the tests");
+
+		controller.onAgentEnd();
+		controller.onAgentStart();
+		await settle();
+
+		expect(controller.current).toBeNull();
+	});
+
+	it("discards a completed generation when the composer gained text meanwhile", async () => {
+		const { ctx, setEditorText } = createFakeCtx();
+		const controller = new PromptSuggestionController(ctx);
+		mockPrediction("run the tests");
+
+		controller.onAgentEnd();
+		setEditorText("user started typing");
+		await settle();
+
+		expect(controller.current).toBeNull();
+	});
+
+	it("dismisses the suggestion when the user types", async () => {
+		const { ctx } = createFakeCtx();
+		const controller = new PromptSuggestionController(ctx);
+		mockPrediction("run the tests");
+
+		controller.onAgentEnd();
+		await settle();
+		expect(controller.current).toBe("run the tests");
+
+		controller.notifyEditorChanged("r");
+		expect(controller.current).toBeNull();
+	});
+
+	it("accepts the suggestion on Tab from an empty composer", async () => {
+		const { ctx, state } = createFakeCtx();
+		const controller = new PromptSuggestionController(ctx);
+		mockPrediction("run the tests");
+
+		controller.onAgentEnd();
+		await settle();
+
+		expect(controller.tryAcceptOnTab("")).toBe(true);
+		expect(state.setTextCalls).toEqual(["run the tests"]);
+		expect(controller.current).toBeNull();
+	});
+
+	it("does not consume Tab when the composer has text or no suggestion exists", async () => {
+		const { ctx, state } = createFakeCtx();
+		const controller = new PromptSuggestionController(ctx);
+		mockPrediction("run the tests");
+
+		expect(controller.tryAcceptOnTab("")).toBe(false);
+
+		controller.onAgentEnd();
+		await settle();
+
+		expect(controller.tryAcceptOnTab("some draft")).toBe(false);
+		expect(state.setTextCalls).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/prompt-suggestion.test.ts
+++ b/packages/coding-agent/test/prompt-suggestion.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AgentMessage } from "@gajae-code/agent-core";
+import * as ai from "@gajae-code/ai";
+import { type Api, getBundledModel, type Model } from "@gajae-code/ai";
+import {
+	buildPromptSuggestionContext,
+	generatePromptSuggestion,
+	sanitizePromptSuggestion,
+	suppressPromptSuggestionReason,
+} from "../src/utils/prompt-suggestion";
+
+function getModelOrThrow(id: string): Model<Api> {
+	const model = getBundledModel("anthropic", id);
+	if (!model) throw new Error(`Expected model ${id}`);
+	return model;
+}
+
+function createSettings(model: Model<Api>) {
+	return {
+		getModelRole(role: string) {
+			return role === "default" ? `${model.provider}/${model.id}` : undefined;
+		},
+		getStorage() {
+			return undefined;
+		},
+	} as never;
+}
+
+function createRegistry(model: Model<Api>) {
+	return {
+		getAvailable: () => [model],
+		getApiKey: async () => "test-key",
+	} as never;
+}
+
+function userMessage(text: string): AgentMessage {
+	return { role: "user", content: text, timestamp: Date.now() } as never;
+}
+
+function assistantMessage(text: string): AgentMessage {
+	return { role: "assistant", content: [{ type: "text", text }] } as never;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("sanitizePromptSuggestion", () => {
+	it("strips wrapper tags", () => {
+		expect(sanitizePromptSuggestion("<suggestion>run the tests</suggestion>")).toBe("run the tests");
+		expect(sanitizePromptSuggestion("<response>commit this</response>")).toBe("commit this");
+	});
+
+	it("keeps ambiguous nested wrappers intact", () => {
+		const nested = "<suggestion>outer </suggestion> inner</suggestion>";
+		expect(sanitizePromptSuggestion(nested)).toBe(nested);
+	});
+
+	it("strips label prefixes", () => {
+		expect(sanitizePromptSuggestion("Suggestion: run the tests")).toBe("run the tests");
+		expect(sanitizePromptSuggestion("suggested response: go ahead")).toBe("go ahead");
+	});
+
+	it("trims whitespace", () => {
+		expect(sanitizePromptSuggestion("  run the tests \n")).toBe("run the tests");
+	});
+});
+
+describe("suppressPromptSuggestionReason", () => {
+	it("accepts a normal short suggestion", () => {
+		expect(suppressPromptSuggestionReason("run the tests")).toBeNull();
+	});
+
+	it("accepts allow-listed single words and slash commands", () => {
+		expect(suppressPromptSuggestionReason("yes")).toBeNull();
+		expect(suppressPromptSuggestionReason("commit")).toBeNull();
+		expect(suppressPromptSuggestionReason("/compact")).toBeNull();
+	});
+
+	it("rejects empty and meta output", () => {
+		expect(suppressPromptSuggestionReason("")).toBe("empty");
+		expect(suppressPromptSuggestionReason("done")).toBe("done");
+		expect(suppressPromptSuggestionReason("nothing to suggest here")).toBe("meta_text");
+		expect(suppressPromptSuggestionReason("I will stay silent")).toBe("meta_text");
+		expect(suppressPromptSuggestionReason("(no suggestion applicable)")).toBe("meta_wrapped");
+	});
+
+	it("rejects error passthrough", () => {
+		expect(suppressPromptSuggestionReason("API Error: rate limited")).toBe("error_message");
+	});
+
+	it("rejects labels, arbitrary single words, and overlong output", () => {
+		expect(suppressPromptSuggestionReason("Note: something")).toBe("prefixed_label");
+		expect(suppressPromptSuggestionReason("refactor")).toBe("too_few_words");
+		expect(suppressPromptSuggestionReason("a b c d e f g h i j k l m")).toBe("too_many_words");
+		expect(suppressPromptSuggestionReason(`fix ${"x".repeat(100)}`)).toBe("too_long");
+	});
+
+	it("rejects prose-shaped output", () => {
+		expect(suppressPromptSuggestionReason("Run it. Then commit")).toBe("multiple_sentences");
+		expect(suppressPromptSuggestionReason("run **all** tests")).toBe("has_formatting");
+		expect(suppressPromptSuggestionReason("looks good to me")).toBe("evaluative");
+		expect(suppressPromptSuggestionReason("I'll run the tests")).toBe("claude_voice");
+		expect(suppressPromptSuggestionReason("Here's the next step")).toBe("claude_voice");
+	});
+});
+
+describe("buildPromptSuggestionContext", () => {
+	it("returns null when there is no user message", () => {
+		expect(buildPromptSuggestionContext([])).toBeNull();
+		expect(buildPromptSuggestionContext([assistantMessage("hi")])).toBeNull();
+	});
+
+	it("builds a chronological transcript from recent messages", () => {
+		const context = buildPromptSuggestionContext([
+			userMessage("fix the bug and run tests"),
+			assistantMessage("Fixed the null check in parser.ts."),
+		]);
+		expect(context).toContain("User: fix the bug and run tests");
+		expect(context).toContain("Assistant: Fixed the null check in parser.ts.");
+		expect(context?.indexOf("User:")).toBeLessThan(context?.indexOf("Assistant:") ?? -1);
+	});
+
+	it("truncates very long messages", () => {
+		const context = buildPromptSuggestionContext([userMessage("x".repeat(5000))]);
+		expect(context).toContain("…");
+		expect(context?.length ?? 0).toBeLessThan(3000);
+	});
+
+	it("skips messages without extractable text", () => {
+		const toolResult = { role: "toolResult", content: [{ type: "text", text: "output" }] } as never;
+		const context = buildPromptSuggestionContext([userMessage("run it"), toolResult]);
+		expect(context).toContain("User: run it");
+		expect(context).not.toContain("output");
+	});
+});
+
+describe("generatePromptSuggestion", () => {
+	it("returns the sanitized model prediction", async () => {
+		const model = getModelOrThrow("claude-sonnet-4-5");
+		const completeSimpleMock = vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			stopReason: "stop",
+			content: [{ type: "text", text: "Suggestion: run the tests" }],
+		} as never);
+
+		const suggestion = await generatePromptSuggestion(
+			[userMessage("fix the bug and run tests"), assistantMessage("Bug fixed.")],
+			createRegistry(model),
+			createSettings(model),
+		);
+
+		expect(suggestion).toBe("run the tests");
+		expect(completeSimpleMock.mock.calls[0]?.[2]).toMatchObject({ disableReasoning: true });
+	});
+
+	it("returns null when the prediction is suppressed", async () => {
+		const model = getModelOrThrow("claude-sonnet-4-5");
+		vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			stopReason: "stop",
+			content: [{ type: "text", text: "Looks good, thanks!" }],
+		} as never);
+
+		const suggestion = await generatePromptSuggestion(
+			[userMessage("fix the bug")],
+			createRegistry(model),
+			createSettings(model),
+		);
+
+		expect(suggestion).toBeNull();
+	});
+
+	it("returns null on response errors", async () => {
+		const model = getModelOrThrow("claude-sonnet-4-5");
+		vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			stopReason: "error",
+			errorMessage: "boom",
+			content: [],
+		} as never);
+
+		const suggestion = await generatePromptSuggestion(
+			[userMessage("fix the bug")],
+			createRegistry(model),
+			createSettings(model),
+		);
+
+		expect(suggestion).toBeNull();
+	});
+
+	it("returns null without calling the model when there is no user message", async () => {
+		const model = getModelOrThrow("claude-sonnet-4-5");
+		const completeSimpleMock = vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			stopReason: "stop",
+			content: [{ type: "text", text: "run the tests" }],
+		} as never);
+
+		const suggestion = await generatePromptSuggestion([], createRegistry(model), createSettings(model));
+
+		expect(suggestion).toBeNull();
+		expect(completeSimpleMock).not.toHaveBeenCalled();
+	});
+});

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -921,6 +921,11 @@
 			"description": "Suggest emojis from `:name:` shortcodes and expand text emoticons like `:D` or `:-)`",
 			"default": true
 		},
+		"promptSuggestions": {
+			"type": "boolean",
+			"description": "Predict your likely next prompt after each turn (smol-model call) and show it as ghost text; Tab accepts",
+			"default": false
+		},
 		"startup": {
 			"type": "object",
 			"properties": {


### PR DESCRIPTION
## What

Ports Claude Code's prompt-suggestion feature (`CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION` / ghost-text "predict the next user prompt") as a native GJC implementation. GJC already had `@` file, `/` command, and emoji autocomplete — this adds the one autocomplete surface Claude Code has that GJC lacked.

With the new `promptSuggestions` setting enabled (Settings → Interaction, **default off**), after each agent turn ends with an empty composer, a smol-model prediction of the user's likely next prompt renders as dim ghost text in the composer:

- **Tab** accepts the suggestion (only when the composer is empty — Tab with text keeps falling through to path/slash autocomplete exactly as before)
- typing dismisses it and cancels any in-flight generation
- a new agent turn clears it

Claude Code ships as a compiled binary, so nothing is copied; the behavior was reverse-specified from the released binary (system-prompt contract, output sanitizer, and the suppression heuristics) and implemented on GJC's existing `completeSimple`/title-generator pattern.

## How

- `src/utils/prompt-suggestion.ts` — pure core: recent-conversation transcript builder (12-message / char-budget cap, requires ≥1 user message), wrapper/label sanitizer, and a heuristic suppression gate (`empty`, `done`, `meta_text`, `meta_wrapped`, `error_message`, `prefixed_label`, `too_few_words` with a single-word allowlist, `too_many_words` >12, `too_long` ≥100 chars, `multiple_sentences`, `has_formatting`, `evaluative`, `claude_voice`). Silence is the expected steady state.
- `src/prompts/system/prompt-suggestion-system.md` — generation prompt (static md per repo convention).
- `src/modes/prompt-suggestion-controller.ts` — lifecycle owner with a monotonic generation token: stale results, mid-flight turns, shutdown, and composer edits all invalidate in-flight predictions. Model/key resolution, reasoning-safe token budget, and metadata resolver follow the title-generator contract.
- Editor integration reuses existing seams, no TUI package changes: ghost text renders through `PromptActionAutocompleteProvider.getInlineHint` (empty composer only), acceptance through the previously unused `Editor.onTab` hook, dismissal through the existing `onChange` pipeline, generation/clear through `agent_end`/`agent_start` in the event controller. ACP/lightweight contexts are unaffected (`promptSuggestion?` is optional on `InteractiveModeContext`).
- `promptSuggestions` boolean setting (default **off** since every turn costs a smol-model call); `schemas/config.schema.json` regenerated.

## Verification

- `bun test test/prompt-suggestion.test.ts test/prompt-suggestion-controller.test.ts` — 26 new tests: sanitizer, every suppression reason, transcript builder, generator (mocked `completeSimple`), and controller lifecycle (setting gate, empty-composer gate, stale-generation discard, typing dismissal, Tab accept/fall-through).
- Dependent suites green: input-controller escape/keybindings/skill-queue, event-controller abort-render, g004, interactive-mode editor-component/plan-review/irc-sidebar, autocomplete + emoji + max-visible, title-generator, composer-placeholder.
- Two structural assertions in `input-controller-keybindings.test.ts` (`editor.onTab === undefined` during streaming/compaction) were updated to behavioral ones — the protected contract (Tab stays available to editor autocomplete when the composer has text) is asserted directly and still holds.
- `tsc --noEmit` clean, `biome check` clean (2128 files), `check:schemas` clean.
- Full `bun test` for the package: 10798 pass / 16 fail — all 16 failures reproduce identically on a clean `origin/main` worktree in this environment (tmux-, sandbox-, and git-config-dependent suites: sdk-broker-lifecycle-e2e, bisect, settings-selector-pet, harness-tmux-owner, launch-tmux, session-state-sidecar, session-manager-resume-readonly, resume-confirm-continue); zero regressions from this change.

## Notes / follow-up

- Print/SDK-mode parity (Claude Code's `--prompt-suggestions` stream-json `prompt_suggestion` message) is intentionally out of scope for this PR; the interactive ghost-text surface is self-contained. Happy to follow up if wanted.
- No telemetry was ported.