### PR TITLE
feat(tui): add mood-reactive gajae pet status line segment

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added the standalone `@gajae-code/bridge-client` transport-only v3 SDK package. It exports `SdkClient` and its associated types; `@gajae-code/coding-agent/sdk` remains a compatibility re-export with the exact same class identity. Historical BridgeClient backend protocol, handshake, commands, SSE, and host-control bypass surfaces remain unavailable.
 - Added explicit `--mcp-config <absolute-path>` support for one trusted, tools-only MCP config in top-level standalone sessions without enabling automatic user or project MCP discovery; exact reads reject links and identity changes, and MCP tool-name collisions fail closed.
 - Added additive v3 workflow-gate correlation compatibility surfaces (#2171): explicit Rust workflow-frame readers/registration preserve `workflowGateId` without changing legacy `ActionNeeded`, `ServerMessage`, or `register_ask`; N-API retains `registerAsk` and adds correlated/arbitrated registration and exact unclaimed-retirement APIs. Private presentation leases, routes, claims, receipts, epochs, and endpoint generations remain non-public.
+- Added an opt-in mood-reactive `pet` status line segment: a tiny text-mode gajae companion that wiggles its claws while the agent streams, gets tired under heavy context pressure, and turns alarmed on unacknowledged background-job failures. Faces are fixed-width across all moods and symbol presets (including a pure-ASCII set), so it never causes status-line layout jitter — a zero-dependency complement to the pixel Gajae Pet on terminals without sixel/kitty image support.
 
 ### Changed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -77,6 +77,7 @@ export const TAB_METADATA: Record<SettingTab, { label: string; icon: `tab.${stri
 export type StatusLineSegmentId =
 	| "gajae"
 	| "pi" // legacy custom alias; public presets use gajae
+	| "pet" // mood-reactive gajae pet
 	| "model"
 	| "mode"
 	| "path"

--- a/packages/coding-agent/src/modes/components/status-line/pet.ts
+++ b/packages/coding-agent/src/modes/components/status-line/pet.ts
@@ -1,0 +1,84 @@
+/**
+ * Gajae pet: a tiny mood-reactive crustacean identity segment for the
+ * status line.
+ *
+ * Mood resolution and frame selection are pure functions so the render path
+ * stays cheap and unit-testable. The working claw-wiggle animation derives
+ * its frame from the wall clock, so it needs no timers: it simply advances
+ * whenever streaming re-renders the status line and freezes when idle.
+ *
+ * Every face is exactly the same visible width across moods and symbol
+ * presets, so the pet never causes status-line layout jitter.
+ */
+import type { SymbolPreset, ThemeColor } from "../../theme/theme";
+import type { ContextUsageLevel } from "./context-thresholds";
+
+export type PetMood = "alarmed" | "working" | "tired" | "idle";
+
+export interface PetMoodInput {
+	/** An unacknowledged background job failure is latched. */
+	jobsFailed: boolean;
+	/** The agent is currently streaming a response. */
+	streaming: boolean;
+	/** Context usage level from the shared status-line thresholds. */
+	contextLevel: ContextUsageLevel;
+}
+
+/** Milliseconds per claw-wiggle animation frame while working. */
+export const PET_FRAME_MS = 600;
+
+interface PetFaces {
+	idle: string;
+	working: readonly [string, string];
+	tired: string;
+	alarmed: string;
+}
+
+const UNICODE_FACES: PetFaces = {
+	idle: "V(°ᴥ°)V",
+	working: ["v(°ᴥ°)V", "V(°ᴥ°)v"],
+	tired: "V(-ᴥ-)V",
+	alarmed: "V(>ᴥ<)V",
+};
+
+const ASCII_FACES: PetFaces = {
+	idle: "V(o.o)V",
+	working: ["v(o.o)V", "V(o.o)v"],
+	tired: "V(-.-)V",
+	alarmed: "V(>.<)V",
+};
+
+/**
+ * Resolve the pet's mood from session signals. Priority: an unacknowledged
+ * job failure always alarms the pet; otherwise activity (streaming) wins over
+ * context pressure; a heavy context (purple/error level) makes it tired.
+ */
+export function resolvePetMood(input: PetMoodInput): PetMood {
+	if (input.jobsFailed) return "alarmed";
+	if (input.streaming) return "working";
+	if (input.contextLevel === "purple" || input.contextLevel === "error") return "tired";
+	return "idle";
+}
+
+/** Pick the face for a mood, preset, and wall-clock time. */
+export function getPetFrame(mood: PetMood, preset: SymbolPreset, now: number): string {
+	const faces = preset === "ascii" ? ASCII_FACES : UNICODE_FACES;
+	if (mood === "working") {
+		return faces.working[Math.floor(now / PET_FRAME_MS) % 2];
+	}
+	return faces[mood];
+}
+
+/** Theme color slot for a mood; reuses semantic tokens so every theme works. */
+export function getPetColor(mood: PetMood): ThemeColor {
+	switch (mood) {
+		case "alarmed":
+			return "error";
+		case "working":
+			return "accent";
+		case "tired":
+			return "warning";
+		case "idle":
+			return "muted";
+	}
+}

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -8,6 +8,7 @@ import { shortenPath } from "../../../tools/render-utils";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
 import { sanitizeStatusText } from "../../shared";
 import { getContextUsageLevel, getContextUsageThemeColor } from "./context-thresholds";
+import { getPetColor, getPetFrame, resolvePetMood } from "./pet";
 import type { RenderedSegment, SegmentContext, StatusLineSegment, StatusLineSegmentId } from "./types";
 
 export type { SegmentContext } from "./types";
@@ -75,6 +76,22 @@ const legacyPiSegment: StatusLineSegment = {
 	id: "pi",
 	render(_ctx) {
 		return gajaeSegment.render(_ctx);
+	},
+};
+
+// Mood-reactive gajae pet: alarmed on latched job failures, claw-wiggling
+// while the agent streams, tired under heavy context pressure, chill otherwise.
+const petSegment: StatusLineSegment = {
+	id: "pet",
+	render(ctx) {
+		const mood = resolvePetMood({
+			jobsFailed: ctx.jobs.worstState === "failed",
+			streaming: ctx.session.isStreaming === true,
+			// Unknown context usage (null) counts as no pressure.
+			contextLevel: getContextUsageLevel(ctx.contextPercent ?? 0, ctx.contextWindow),
+		});
+		const frame = getPetFrame(mood, theme.getSymbolPreset(), Date.now());
+		return { content: theme.fg(getPetColor(mood), frame), visible: true };
 	},
 };
 
@@ -579,6 +596,7 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	cache_write: cacheWriteSegment,
 	session_name: sessionNameSegment,
 	usage: usageSegment,
+	pet: petSegment,
 };
 
 export function renderSegment(id: StatusLineSegmentId, ctx: SegmentContext): RenderedSegment {

--- a/packages/coding-agent/test/status-line-pet.test.ts
+++ b/packages/coding-agent/test/status-line-pet.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
+import {
+	getPetColor,
+	getPetFrame,
+	PET_FRAME_MS,
+	type PetMood,
+	resolvePetMood,
+} from "../src/modes/components/status-line/pet";
+import { renderSegment, type SegmentContext } from "../src/modes/components/status-line/segments";
+import { EMPTY_JOBS_SNAPSHOT } from "../src/modes/jobs-observer";
+import { initTheme, type SymbolPreset } from "../src/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+});
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+function makeCtx(overrides: Partial<SegmentContext> = {}): SegmentContext {
+	return {
+		session: { state: {} } as unknown as SegmentContext["session"],
+		width: 120,
+		options: {},
+		planMode: null,
+		goalMode: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		jobs: EMPTY_JOBS_SNAPSHOT,
+		sessionStartTime: Date.now(),
+		git: { branch: null, status: null, pr: null },
+		usage: null,
+		...overrides,
+	};
+}
+
+describe("pet mood resolution", () => {
+	test("job failure trumps everything", () => {
+		expect(resolvePetMood({ jobsFailed: true, streaming: true, contextLevel: "error" })).toBe("alarmed");
+	});
+
+	test("streaming wins over context pressure", () => {
+		expect(resolvePetMood({ jobsFailed: false, streaming: true, contextLevel: "purple" })).toBe("working");
+	});
+
+	test("heavy context makes the pet tired", () => {
+		expect(resolvePetMood({ jobsFailed: false, streaming: false, contextLevel: "purple" })).toBe("tired");
+		expect(resolvePetMood({ jobsFailed: false, streaming: false, contextLevel: "error" })).toBe("tired");
+	});
+
+	test("idle otherwise (normal and warning levels)", () => {
+		expect(resolvePetMood({ jobsFailed: false, streaming: false, contextLevel: "normal" })).toBe("idle");
+		expect(resolvePetMood({ jobsFailed: false, streaming: false, contextLevel: "warning" })).toBe("idle");
+	});
+});
+
+describe("pet frames", () => {
+	const moods: PetMood[] = ["idle", "working", "tired", "alarmed"];
+	const presets: SymbolPreset[] = ["unicode", "nerd", "ascii"];
+
+	test("working animation alternates claws on the frame clock", () => {
+		const a = getPetFrame("working", "unicode", 0);
+		const b = getPetFrame("working", "unicode", PET_FRAME_MS);
+		const c = getPetFrame("working", "unicode", PET_FRAME_MS * 2);
+		expect(a).not.toBe(b);
+		expect(c).toBe(a);
+	});
+
+	test("non-working moods are time-invariant", () => {
+		for (const mood of ["idle", "tired", "alarmed"] as const) {
+			expect(getPetFrame(mood, "unicode", 0)).toBe(getPetFrame(mood, "unicode", PET_FRAME_MS));
+		}
+	});
+
+	test("ascii preset uses ASCII-only faces", () => {
+		for (const mood of moods) {
+			const frame = getPetFrame(mood, "ascii", 0);
+			expect(frame).toMatch(/^[\x20-\x7e]+$/);
+		}
+	});
+
+	test("every face has the same visible width (no layout jitter)", () => {
+		const widths = new Set<number>();
+		for (const preset of presets) {
+			for (const mood of moods) {
+				widths.add(Bun.stringWidth(getPetFrame(mood, preset, 0)));
+				widths.add(Bun.stringWidth(getPetFrame(mood, preset, PET_FRAME_MS)));
+			}
+		}
+		expect(widths.size).toBe(1);
+	});
+
+	test("each mood maps to a distinct semantic color slot", () => {
+		expect(new Set(moods.map(getPetColor)).size).toBe(moods.length);
+	});
+});
+
+describe("pet status-line segment", () => {
+	test("visible and idle by default", () => {
+		const rendered = renderSegment("pet", makeCtx());
+		expect(rendered.visible).toBe(true);
+		expect(Bun.stripANSI(rendered.content)).toBe(getPetFrame("idle", "unicode", 0));
+	});
+
+	test("alarmed on latched job failure", () => {
+		const rendered = renderSegment(
+			"pet",
+			makeCtx({ jobs: { ...EMPTY_JOBS_SNAPSHOT, worstState: "failed", failedUnacknowledged: true } }),
+		);
+		expect(Bun.stripANSI(rendered.content)).toBe(getPetFrame("alarmed", "unicode", 0));
+	});
+
+	test("working while the session streams", () => {
+		const ctx = makeCtx({
+			session: { state: {}, isStreaming: true } as unknown as SegmentContext["session"],
+		});
+		const face = Bun.stripANSI(renderSegment("pet", ctx).content);
+		const frames = [getPetFrame("working", "unicode", 0), getPetFrame("working", "unicode", PET_FRAME_MS)];
+		expect(frames).toContain(face);
+	});
+
+	test("tired under heavy context pressure", () => {
+		const rendered = renderSegment("pet", makeCtx({ contextPercent: 75, contextWindow: 400_000 }));
+		expect(Bun.stripANSI(rendered.content)).toBe(getPetFrame("tired", "unicode", 0));
+	});
+});


### PR DESCRIPTION
## What

Adds an opt-in `pet` status line segment: a tiny text-mode gajae companion that reacts to session state.

| Mood | Face (unicode) | Face (ascii preset) | Color slot | Trigger |
| --- | --- | --- | --- | --- |
| alarmed | `V(>ᴥ<)V` | `V(>.<)V` | `error` | latched background-job failure (`jobs.worstState === "failed"`) |
| working | `v(°ᴥ°)V` ↔ `V(°ᴥ°)v` | `v(o.o)V` ↔ `V(o.o)v` | `accent` | agent is streaming (claw-wiggle animation) |
| tired | `V(-ᴥ-)V` | `V(-.-)V` | `warning` | heavy context pressure (reuses the shared `context-thresholds` purple/error levels) |
| idle | `V(°ᴥ°)V` | `V(o.o)V` | `muted` | otherwise |

Demo (`leftSegments: ["pet", "model"]`):

```
idle:    V(°ᴥ°)V / ⬢ model ······
working: V(°ᴥ°)v / ⬢ model ······
alarmed: V(>ᴥ<)V / ⬢ model ······
```

Design notes:

- **Zero timers.** The working animation derives its frame from the wall clock (`Date.now()` in 600 ms buckets), so it advances for free on streaming re-renders and freezes when idle — no new render loops.
- **No layout jitter.** Every face is exactly the same visible width across all moods and symbol presets, asserted by a test over the full mood × preset matrix.
- **Theme-proof.** Colors resolve through existing semantic tokens (`error`/`accent`/`warning`/`muted`), so every bundled and custom theme works unchanged.
- **Fully opt-in.** Not added to any preset; registered at the end of the segment registry so existing custom-editor row order (and its tests) are untouched. It shows up automatically in Settings → status line custom editor as `Segment: pet`.
- Mood resolution and frame selection live in a small pure module (`status-line/pet.ts`) for cheap rendering and direct unit testing.

## Why

The pixel Gajae Pet is capability-gated: on terminals without sixel/kitty image support (plain SSH, multiplexers without passthrough), `/pet` can only warn and stay `off`. This segment is the zero-dependency companion for exactly those environments — the brand mascot living in the status rail as plain themed text, and a compact alternative even where the overlay pet works. Extends the crustacean identity line (`gajae` segment, red-claw/blue-crab themes) with state feedback: one glance tells you streaming / job-failure / context-pressure.

## Testing

- New `packages/coding-agent/test/status-line-pet.test.ts` (13 tests): mood priority (failure > streaming > context pressure > idle), wall-clock frame alternation and time-invariance of static moods, pure-ASCII faces under the `ascii` preset, constant visible width across the full mood × preset matrix (`Bun.stringWidth`), distinct color slots per mood, and rendered-segment behavior through `renderSegment("pet", …)` (idle default, alarmed on failed jobs snapshot, working while streaming, tired at 75% of a 400k window).
- Adjacent suites re-run green: `jobs-segment`, `status-line-overflow`, `settings-selector-status-line-custom`, `status-line-thinking`, `status-line-path`, `status-line-usage`, `status-line-context-cache` (74 tests total).
- Live `StatusLineComponent.render()` smoke across idle/working/alarmed states (output above).

---

- [x] `bun check` passes (biome + `tsc --noEmit` clean on touched packages)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
