### PR TITLE
fix(sdk): compact the broker session index log to stop unbounded heartbeat growth

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- The SDK broker session index (`~/.gjc/agent/sdk/sessions/index.jsonl`) now compacts itself once the log exceeds 1 MiB: superseded per-session `host_heartbeat` rows are pruned into the snapshot and the log is truncated under the append lock. Previously every live host appended a heartbeat row every 5 seconds forever, growing the shared log without bound (observed >100 MB) until concurrent hosts failed with `Failed to acquire lock for .../sessions/index.jsonl after 50 attempts`. Readers that consumed beyond a compaction now rebuild from the snapshot instead of reporting a truncated/dead index.
+
 ## [0.11.1] - 2026-07-16
 
 ### Fixed

--- a/packages/coding-agent/src/sdk/broker/session-index.ts
+++ b/packages/coding-agent/src/sdk/broker/session-index.ts
@@ -48,6 +48,13 @@ export const sessionIndexChecksum = (event: Omit<SessionIndexEvent, "checksum">)
 const dirFor = (agentDir: string) => path.join(agentDir, "sdk", "sessions");
 const logFor = (agentDir: string) => path.join(dirFor(agentDir), "index.jsonl");
 const snapshotFor = (agentDir: string) => path.join(dirFor(agentDir), "index.snapshot.json");
+/**
+ * Compact the on-disk log once it grows past this size. Every live SDK host
+ * appends a `host_heartbeat` row every few seconds, so without compaction the
+ * shared log grows without bound and `append`'s lock+replay cost grows with it
+ * until concurrent hosts starve on the file lock.
+ */
+const COMPACT_LOG_BYTES = 1024 * 1024;
 async function appendSync(file: string, value: string): Promise<void> {
 	const h = await fs.open(file, "a", 0o600);
 	try {
@@ -65,13 +72,36 @@ function alive(pid: number): boolean {
 		return (e as NodeJS.ErrnoException).code === "EPERM";
 	}
 }
+/**
+ * Drop `host_heartbeat` events superseded by a newer heartbeat for the same
+ * session. Only the latest heartbeat per session is observable: `listSessions`
+ * keeps the last event per session and merges heartbeat rows with the fields of
+ * the previous non-heartbeat event, and the registration lookups filter on
+ * `host_registered`/`host_unregistered`. Pruning preserves event order and the
+ * global newest event, so `indexSeq` continuity is unaffected.
+ */
+function pruneSupersededHeartbeats(events: SessionIndexEvent[]): SessionIndexEvent[] {
+	const newestHeartbeatSeen = new Set<string>();
+	const kept: SessionIndexEvent[] = [];
+	for (let i = events.length - 1; i >= 0; i--) {
+		const event = events[i]!;
+		if (event.type === "host_heartbeat") {
+			if (newestHeartbeatSeen.has(event.sessionId)) continue;
+			newestHeartbeatSeen.add(event.sessionId);
+		}
+		kept.push(event);
+	}
+	return kept.reverse();
+}
 export class SessionIndex {
 	#agentDir: string;
 	#events: SessionIndexEvent[] = [];
 	#warnings: string[] = [];
 	#logOffset = 0;
-	constructor(agentDir: string) {
+	#compactLogBytes: number;
+	constructor(agentDir: string, options?: { compactLogBytes?: number }) {
 		this.#agentDir = agentDir;
+		this.#compactLogBytes = options?.compactLogBytes ?? COMPACT_LOG_BYTES;
 	}
 	async open(): Promise<this> {
 		await this.assertSupportedStateVersions();
@@ -112,27 +142,29 @@ export class SessionIndex {
 		}
 		await this.#tail(snapshotSeq);
 	}
-	async #tail(snapshotSeq = this.indexSeq): Promise<void> {
+	/**
+	 * Read newly appended log rows. Returns `"truncated"` when the log shrank
+	 * beneath the consumed offset — another process compacted it — so the caller
+	 * can rebuild from the snapshot instead of treating the index as dead.
+	 */
+	async #tail(snapshotSeq = this.indexSeq): Promise<"ok" | "truncated"> {
 		let data: Buffer;
 		try {
 			const handle = await fs.open(logFor(this.#agentDir), "r");
 			try {
 				const stat = await handle.stat();
-				if (stat.size < this.#logOffset) {
-					this.#warnings.push("Session index log was truncated");
-					return;
-				}
+				if (stat.size < this.#logOffset) return "truncated";
 				data = Buffer.alloc(stat.size - this.#logOffset);
 				if (data.length) await handle.read(data, 0, data.length, this.#logOffset);
 			} finally {
 				await handle.close();
 			}
 		} catch (e) {
-			if ((e as NodeJS.ErrnoException).code === "ENOENT") return;
+			if ((e as NodeJS.ErrnoException).code === "ENOENT") return "ok";
 			throw e;
 		}
 		const lastNewline = data.lastIndexOf(0x0a);
-		if (lastNewline < 0) return;
+		if (lastNewline < 0) return "ok";
 		const consumed = data.subarray(0, lastNewline + 1);
 		this.#logOffset += consumed.length;
 		for (const line of consumed.toString("utf8").split("\n")) {
@@ -144,19 +176,20 @@ export class SessionIndex {
 			} catch (error) {
 				if (error instanceof UnsupportedStateVersionError) throw error;
 				this.#warnings.push("Corrupt session index entry; replay truncated");
-				return;
+				return "ok";
 			}
 			if (event.indexSeq <= snapshotSeq) continue;
 			const { checksum, ...unsigned } = event;
 			if (checksum !== sessionIndexChecksum(unsigned) || event.indexSeq !== this.indexSeq + 1) {
 				this.#warnings.push("Corrupt session index entry; replay truncated");
-				return;
+				return "ok";
 			}
 			this.#events.push(event);
 		}
+		return "ok";
 	}
 	async refresh(): Promise<void> {
-		await this.#tail();
+		if ((await this.#tail()) === "truncated") await this.replay();
 	}
 	get indexSeq(): number {
 		return this.#events.at(-1)?.indexSeq ?? 0;
@@ -177,8 +210,25 @@ export class SessionIndex {
 			const event: SessionIndexEvent = { ...unsigned, checksum: sessionIndexChecksum(unsigned) };
 			await appendSync(logFor(this.#agentDir), JSON.stringify(event));
 			await this.refresh();
+			await this.#compactIfOversized();
 			return event;
 		});
+	}
+	/**
+	 * Compact the shared log while holding the append lock: prune superseded
+	 * heartbeat rows from memory, persist the pruned state as the snapshot, then
+	 * truncate the log. Snapshot-then-truncate ordering means a crash between the
+	 * two steps only leaves redundant log rows (skipped on replay as
+	 * `indexSeq <= snapshotSeq`), never lost events. Other processes observe the
+	 * shrunken log as `"truncated"` in {@link refresh} and rebuild from the
+	 * snapshot.
+	 */
+	async #compactIfOversized(): Promise<void> {
+		if (this.#logOffset < this.#compactLogBytes) return;
+		this.#events = pruneSupersededHeartbeats(this.#events);
+		await this.snapshot();
+		await fs.truncate(logFor(this.#agentDir), 0);
+		this.#logOffset = 0;
 	}
 	async snapshot(): Promise<void> {
 		const file = snapshotFor(this.#agentDir);

--- a/packages/coding-agent/test/sdk-session-index.test.ts
+++ b/packages/coding-agent/test/sdk-session-index.test.ts
@@ -45,4 +45,41 @@ describe("SDK session index", () => {
 				.map(line => JSON.parse(line).indexSeq),
 		).toEqual(Array.from({ length: 20 }, (_, i) => i + 1));
 	});
+	it("compacts an oversized log by pruning superseded heartbeats and truncating", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const log = path.join(dir, "sdk", "sessions", "index.jsonl");
+		const index = await new SessionIndex(dir, { compactLogBytes: 1 }).open();
+		await index.append(event("s"));
+		for (let i = 0; i < 5; i++) await index.append({ ...event("s"), type: "host_heartbeat" as const });
+		expect((await fs.stat(log)).size).toBe(0);
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.indexSeq).toBe(6);
+		const sessions = replay.listSessions().sessions;
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]?.sessionId).toBe("s");
+		expect(sessions[0]?.locator).toEqual({ repo: "r", stateRoot: "q" });
+		// Only the registration and the newest heartbeat survive compaction.
+		const snapshot = JSON.parse(await fs.readFile(path.join(dir, "sdk", "sessions", "index.snapshot.json"), "utf8"));
+		expect(snapshot.events.map((e: { indexSeq: number }) => e.indexSeq)).toEqual([1, 6]);
+	});
+	it("keeps concurrent writers consistent across a compaction by another writer", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const compacting = await new SessionIndex(dir, { compactLogBytes: 1 }).open();
+		const other = await new SessionIndex(dir).open();
+		await other.append(event("a"));
+		await compacting.append({ ...event("a"), type: "host_heartbeat" as const });
+		// `other`'s consumed offset now exceeds the truncated log; it must rebuild
+		// from the snapshot instead of reporting a dead index.
+		await other.append(event("b"));
+		expect(other.indexSeq).toBe(3);
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.indexSeq).toBe(3);
+		expect(
+			replay
+				.listSessions()
+				.sessions.map(session => session.sessionId)
+				.sort(),
+		).toEqual(["a", "b"]);
+		expect(replay.listSessions().warnings).toHaveLength(0);
+	});
 });


### PR DESCRIPTION
## Problem

Every live SDK host appends a `host_heartbeat` row to the machine-shared `~/.gjc/agent/sdk/sessions/index.jsonl` every 5 seconds (`packages/coding-agent/src/sdk/bus/index.ts`), and nothing ever removes them. `SessionIndex.snapshot()` existed but had no production caller.

On this machine (400+ sessions over a few weeks) the log reached **107 MB**. Because `SessionIndex.append()` re-tails the log under `withFileLock`, lock hold times grew with the log until concurrent hosts steadily failed with:

```
sdk broker heartbeat failed: Error: Failed to acquire lock for
/Users/<user>/.gjc/agent/sdk/sessions/index.jsonl after 50 attempts
```

(dozens of these per minute across ~17 PIDs in `~/.gjc/logs/gjc.2026-07-17.log`).

## Fix

- `append()` now compacts once the consumed log exceeds 1 MiB, still holding the append lock:
  1. prune `host_heartbeat` rows superseded by a newer heartbeat for the same session (only the latest heartbeat per session is observable — `listSessions` keeps the last event per session, and registration lookups filter on `host_registered`/`host_unregistered`);
  2. persist the pruned state via the existing snapshot path (write-tmp, fsync, rename);
  3. truncate the log.
- Snapshot-then-truncate ordering keeps the crash window loss-free: leftover log rows replay as `indexSeq <= snapshotSeq` and are skipped.
- Readers whose consumed offset now exceeds the shrunken log rebuild from the snapshot in `refresh()` instead of pushing a permanent "Session index log was truncated" warning and going stale.
- `indexSeq` monotonicity and per-event checksums are unchanged; pruning never removes the newest event, so sequencing continuity is preserved.

## Tests

- `bun test packages/coding-agent/test/sdk-session-index.test.ts` — 5 pass (2 new: compaction prunes + truncates and survives replay; a second concurrent writer stays consistent across a compaction by another writer, no warnings).
- `bun test packages/coding-agent/test/sdk-broker.test.ts sdk-broker-transport sdk-broker-restart sdk-broker-host-integration` — 46 pass.
- `bun test .../sdk-broker-lifecycle-e2e.test.ts sdk-lifecycle-idempotency-restart sdk-machine-lifecycle-topology` — 53 pass / 2 fail; the 2 failures (`factory failure preserves reason`, `post-registration startup failure`) reproduce identically on unmodified `main` on this host (env-dependent readiness timing), not introduced by this change.
- `biome check` clean; `tsc -p tsconfig.tools.json --noEmit` clean.

## Notes

- Threshold is a module constant (1 MiB) with a test-only constructor override (`{ compactLogBytes }`).
- Changelog entry added under `## [Unreleased]` in `packages/coding-agent/CHANGELOG.md`.