### PR TITLE
Fix non-TTY empty stdin launch hang

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Non-TTY launches with empty stdin now fail fast instead of entering an unreachable interactive TUI, while positional prompts, piped content, and `@file` text or images route to print mode and protocol modes retain ownership of stdin.
+
 ## [0.9.3] - 2026-07-09
 
 ### Fixed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -109,8 +109,16 @@ function applyRpcDefaultSettingOverrides(targetSettings: Settings = settings): v
 	}
 }
 
-async function readPipedInput(): Promise<string | undefined> {
-	if (process.stdin.isTTY !== false) return undefined;
+export function shouldReadPipedInput(mode: Args["mode"], stdinIsTTY: boolean): boolean {
+	if (stdinIsTTY) return false;
+	return mode !== "rpc" && mode !== "rpc-ui" && mode !== "acp" && mode !== "bridge";
+}
+
+async function readPipedInput(mode: Args["mode"]): Promise<string | undefined> {
+	// Protocol modes own stdin and must receive the stream untouched. Bun reports
+	// non-TTY stdin as `undefined`, not `false`, so only an explicit TTY means
+	// there is no piped input to read.
+	if (!shouldReadPipedInput(mode, process.stdin.isTTY === true)) return undefined;
 	try {
 		const text = await Bun.stdin.text();
 		if (text.trim().length === 0) return undefined;
@@ -118,6 +126,37 @@ async function readPipedInput(): Promise<string | undefined> {
 	} catch {
 		return undefined;
 	}
+}
+
+export interface LaunchDisposition {
+	autoPrint: boolean;
+	isInteractive: boolean;
+	error?: string;
+}
+
+export function resolveLaunchDisposition(input: {
+	print: boolean;
+	mode: Args["mode"];
+	stdinIsTTY: boolean;
+	hasPreparedInput: boolean;
+	hasPipedInput: boolean;
+}): LaunchDisposition {
+	if (input.print || input.mode !== undefined) {
+		return { autoPrint: false, isInteractive: false };
+	}
+
+	const autoPrint = input.hasPipedInput || (!input.stdinIsTTY && input.hasPreparedInput);
+	if (autoPrint) {
+		return { autoPrint: true, isInteractive: false };
+	}
+	if (!input.stdinIsTTY) {
+		return {
+			autoPrint: false,
+			isInteractive: false,
+			error: "stdin is not a TTY and no prompt was provided; use -p/--print with a prompt",
+		};
+	}
+	return { autoPrint: false, isInteractive: true };
 }
 
 export interface InteractiveModeNotify {
@@ -843,7 +882,7 @@ export async function runRootCommand(
 		Bun.env.PI_NO_TITLE = "1";
 	}
 	const { pipedInput, fileText, fileImages } = await logger.time("prepareInitialMessage", async () => {
-		const pipedInput = await readPipedInput();
+		const pipedInput = await readPipedInput(parsedArgs.mode);
 		if (parsedArgs.fileArgs.length === 0) {
 			return { pipedInput, fileText: undefined, fileImages: undefined };
 		}
@@ -858,8 +897,18 @@ export async function runRootCommand(
 		fileImages,
 		stdinContent: pipedInput,
 	});
-	const autoPrint = pipedInput !== undefined && !parsedArgs.print && parsedArgs.mode === undefined;
-	const isInteractive = !parsedArgs.print && !autoPrint && parsedArgs.mode === undefined;
+	const disposition = resolveLaunchDisposition({
+		print: parsedArgs.print === true,
+		mode: parsedArgs.mode,
+		stdinIsTTY: process.stdin.isTTY === true,
+		hasPreparedInput: initialMessage !== undefined || initialImages !== undefined || parsedArgs.messages.length > 0,
+		hasPipedInput: pipedInput !== undefined,
+	});
+	if (disposition.error) {
+		process.stderr.write(`${chalk.red(`Error: ${disposition.error}`)}\n`);
+		process.exit(1);
+	}
+	const { isInteractive } = disposition;
 	const mode = parsedArgs.mode || "text";
 
 	// Initialize discovery system with settings for provider persistence

--- a/packages/coding-agent/test/launch-disposition.test.ts
+++ b/packages/coding-agent/test/launch-disposition.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveLaunchDisposition, shouldReadPipedInput } from "@gajae-code/coding-agent/main";
+
+const repoRoot = path.resolve(import.meta.dir, "../../..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+const cleanupRoots: string[] = [];
+
+const base = {
+	stdinIsTTY: true,
+	hasPreparedInput: false,
+	hasPipedInput: false,
+	print: false,
+	mode: undefined,
+};
+
+afterAll(async () => {
+	await Promise.all(cleanupRoots.map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+interface ProcessResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+async function runNonTty(args: string[], stdin: string): Promise<ProcessResult> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-non-tty-launch-"));
+	cleanupRoots.push(root);
+	const stateRoot = path.join(root, "state");
+	await fs.mkdir(stateRoot, { recursive: true });
+
+	const proc = Bun.spawn([process.execPath, cliEntry, ...args], {
+		cwd: root,
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			...process.env,
+			XDG_CONFIG_HOME: stateRoot,
+			XDG_DATA_HOME: stateRoot,
+			GJC_CODING_AGENT_DIR: path.join(stateRoot, "agent"),
+			PI_CODING_AGENT_DIR: path.join(stateRoot, "agent"),
+			GJC_NOTIFICATIONS: "0",
+			GJC_SDK_DISABLE: "1",
+			NO_COLOR: "1",
+		},
+	});
+	if (stdin.length > 0) proc.stdin.write(stdin);
+	await proc.stdin.end();
+
+	const completion = Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<"timeout">(resolve => {
+		timeoutId = setTimeout(() => resolve("timeout"), 10_000);
+	});
+	const outcome = await Promise.race([
+		completion.then(value => ({ kind: "completed" as const, value })),
+		timeout.then(() => ({ kind: "timeout" as const })),
+	]);
+	if (timeoutId) clearTimeout(timeoutId);
+
+	if (outcome.kind === "timeout") {
+		proc.kill("SIGKILL");
+		await completion;
+		throw new Error("non-TTY CLI subprocess did not exit within 10 seconds");
+	}
+	const [stdout, stderr, exitCode] = outcome.value;
+	return { exitCode, stdout, stderr };
+}
+
+function expectModelResolutionBoundary(result: ProcessResult): void {
+	expect(result.exitCode).toBe(1);
+	expect(result.stderr).toContain('Model "invalid/model" not found');
+	expect(result.stderr).not.toContain("stdin is not a TTY and no prompt was provided");
+}
+
+describe("resolveLaunchDisposition", () => {
+	it("launches interactive on a TTY with no flags", () => {
+		expect(resolveLaunchDisposition(base)).toEqual({ autoPrint: false, isInteractive: true });
+	});
+
+	it("auto-prints every prepared non-TTY input shape", () => {
+		for (const input of [
+			{ hasPreparedInput: true, hasPipedInput: true },
+			{ hasPreparedInput: true, hasPipedInput: false },
+		]) {
+			expect(resolveLaunchDisposition({ ...base, ...input, stdinIsTTY: false })).toEqual({
+				autoPrint: true,
+				isInteractive: false,
+			});
+		}
+	});
+
+	it("fails fast for empty non-TTY stdin without prepared input", () => {
+		const disposition = resolveLaunchDisposition({ ...base, stdinIsTTY: false });
+		expect(disposition).toEqual({
+			autoPrint: false,
+			isInteractive: false,
+			error: expect.stringContaining("stdin is not a TTY"),
+		});
+	});
+
+	it("leaves explicit print and protocol modes untouched", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, print: true })).toEqual({
+			autoPrint: false,
+			isInteractive: false,
+		});
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, mode: "rpc" })).toEqual({
+			autoPrint: false,
+			isInteractive: false,
+		});
+	});
+
+	it("reads pipes only for print-capable modes", () => {
+		for (const mode of [undefined, "text", "json"] as const) {
+			expect(shouldReadPipedInput(mode, false)).toBe(true);
+		}
+		for (const mode of ["rpc", "rpc-ui", "acp", "bridge"] as const) {
+			expect(shouldReadPipedInput(mode, false)).toBe(false);
+		}
+		expect(shouldReadPipedInput(undefined, true)).toBe(false);
+	});
+});
+
+describe("non-TTY CLI subprocess", () => {
+	it("fails fast on empty stdin instead of entering the TUI", async () => {
+		const result = await runNonTty(["--no-session"], "");
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain("stdin is not a TTY and no prompt was provided");
+	});
+
+	it("reads piped content when Bun reports non-TTY isTTY as undefined", async () => {
+		const result = await runNonTty(["--no-session", "--model", "invalid/model"], "review this");
+		expectModelResolutionBoundary(result);
+	});
+
+	it("preserves piped input for explicit print, text, and json modes", async () => {
+		for (const args of [["--print"], ["--mode", "text"], ["--mode", "json"]]) {
+			const result = await runNonTty(["--no-session", "--model", "invalid/model", ...args], "review this");
+			expectModelResolutionBoundary(result);
+		}
+	});
+
+	it("leaves protocol stdin unread for every stdio protocol mode", async () => {
+		for (const mode of ["rpc", "rpc-ui", "acp", "bridge"]) {
+			const result = await runNonTty(
+				["--no-session", "--model", "invalid/model", "--mode", mode],
+				"protocol-owned input",
+			);
+			if (mode === "acp") {
+				expect(result.exitCode).toBe(0);
+				expect(result.stderr).toContain("Failed to parse JSON message: protocol-owned input");
+				expect(result.stderr).not.toContain("stdin is not a TTY and no prompt was provided");
+			} else {
+				expectModelResolutionBoundary(result);
+			}
+		}
+	});
+
+	it("accepts positional and @file text as prepared input with empty stdin", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-non-tty-file-"));
+		cleanupRoots.push(root);
+		const textPath = path.join(root, "notes.txt");
+		await Bun.write(textPath, "review these notes");
+
+		for (const args of [
+			["--no-session", "--model", "invalid/model", "review this"],
+			["--no-session", "--model", "invalid/model", `@${textPath}`],
+		]) {
+			const result = await runNonTty(args, "");
+			expectModelResolutionBoundary(result);
+		}
+	});
+
+	it("accepts @file image input with empty stdin", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-non-tty-image-"));
+		cleanupRoots.push(root);
+		const imagePath = path.join(root, "pixel.png");
+		await Bun.write(
+			imagePath,
+			Buffer.from(
+				"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+				"base64",
+			),
+		);
+
+		const result = await runNonTty(["--no-session", "--model", "invalid/model", `@${imagePath}`], "");
+		expectModelResolutionBoundary(result);
+	});
+});


### PR DESCRIPTION
## Summary

- fail fast when an implicit interactive launch has empty non-TTY stdin and no prepared prompt
- route positional prompts, piped content, and `@file` text/images to print mode when stdin is non-TTY
- leave explicit `--print` and rpc/rpc-ui/acp/bridge stdin ownership unchanged

This is a ground-up follow-up to closed, unmerged PR #2010 on current `dev`. It addresses every blocker from that review: Bun's non-TTY `stdin.isTTY === undefined`, prepared `@file` text/image input, protocol-stream ownership, process-level coverage, and the missing changelog entry.

Closes #2507

## Verification

- before fix on `origin/dev` (`9342de55`): empty stdin reproduction timed out with rc 124
- after fix: the same reproduction exits rc 1 with the non-TTY diagnostic
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/launch-disposition.test.ts packages/coding-agent/test/main-interactive-input.test.ts packages/coding-agent/test/acp-stdout-hygiene.test.ts` — 15 pass
- independent architect review — CLEAR
- `gitleaks git --no-banner --redact --log-opts='origin/dev..HEAD' .` — no leaks found
