### PR TITLE
Keep model selector open for individual role assignments

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.
+- Individual default and named-role model assignments now keep the model selector open for consecutive choices, while batch assignments retain their existing close-on-success behavior.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).
 - Palette slash submissions no longer clear or rewrite composer text, cursor state, history, or pending images created while an asynchronous input hook is awaiting; canonical keyboard submission cleanup remains unchanged (#2441).
 - Dead browser-tab recovery now expires descriptors without releasing replacement, revived, or differently owned tabs, while exactly-once teardown closes stale targets and releases browser holds without refcount underflow (#2437).

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -334,6 +334,8 @@ export class ModelSelectorComponent extends Container {
 	#selectedActionIndex: number = 0;
 	#pendingThinkingChoice?: PendingThinkingChoice;
 	#selectedThinkingIndex: number = 0;
+	#assignmentState: "idle" | "assigning" = "idle";
+	#closeAfterAssignment = false;
 
 	// Preset landing state
 	#viewMode: ModelSelectorViewMode = "presets";
@@ -1469,6 +1471,12 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
+		if (this.#assignmentState === "assigning") {
+			if (getKeybindings().matches(keyData, "tui.select.cancel")) {
+				this.#closeAfterAssignment = true;
+			}
+			return;
+		}
 		if (this.#pendingThinkingChoice) {
 			this.#handleThinkingMenuInput(keyData);
 			return;
@@ -1833,23 +1841,49 @@ export class ModelSelectorComponent extends Container {
 				? item.selector
 				: formatModelSelectorValue(item.selector, selectedThinkingLevel);
 
-		// Update local state for UI
-		for (const targetRole of roles ?? [role]) {
-			this.#roles[targetRole] = { model: item.model, thinkingLevel: selectedThinkingLevel };
-		}
-
-		// Notify caller (for updating agent state if needed)
-		this.#onSelectCallback({
+		const selection: Extract<ModelSelectorSelection, { kind: "assignment" }> = {
 			kind: "assignment",
 			model: item.model,
 			role,
 			roles,
 			thinkingLevel: selectedThinkingLevel,
 			selector: selectorValue,
-		});
+		};
+		if (this.#isTrackedSingleAssignment(selection)) {
+			void this.#handleTrackedAssignment(selection);
+			return;
+		}
+
+		// Update local state for UI
+		for (const targetRole of roles ?? [role]) {
+			this.#roles[targetRole] = { model: item.model, thinkingLevel: selectedThinkingLevel };
+		}
+
+		// Notify caller (for updating agent state if needed)
+		this.#onSelectCallback(selection);
 
 		// Update list to show new badges
 		this.#updateList();
+	}
+	#isTrackedSingleAssignment(selection: Extract<ModelSelectorSelection, { kind: "assignment" }>): boolean {
+		return selection.role !== null && selection.roles === undefined;
+	}
+
+	async #handleTrackedAssignment(selection: Extract<ModelSelectorSelection, { kind: "assignment" }>): Promise<void> {
+		if (this.#assignmentState !== "idle") return;
+		this.#assignmentState = "assigning";
+		this.#tui.requestRender();
+		try {
+			await Promise.resolve(this.#onSelectCallback(selection));
+		} catch {
+			// The controller reports tracked assignment failures before rethrowing.
+		} finally {
+			this.#assignmentState = "idle";
+			const shouldClose = this.#closeAfterAssignment;
+			this.#closeAfterAssignment = false;
+			if (shouldClose) this.#onCancelCallback();
+			else this.#tui.requestRender();
+		}
 	}
 
 	getSearchInput(): Input {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1520,6 +1520,14 @@ export class SelectorController {
 	showModelSelector(options?: { temporaryOnly?: boolean }): void {
 		this.showSelector(done => {
 			let modelSelector: ModelSelectorComponent;
+			const refreshRoleAssignments = () => {
+				modelSelector.refreshRoleAssignments({
+					currentModel: this.ctx.session.model,
+					currentThinkingLevel: this.ctx.session.thinkingLevel,
+					activeModelProfile:
+						this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+				});
+			};
 			modelSelector = new ModelSelectorComponent(
 				this.ctx.ui,
 				this.ctx.session.model,
@@ -1527,6 +1535,8 @@ export class SelectorController {
 				this.ctx.session.modelRegistry,
 				this.ctx.session.scopedModels,
 				async selection => {
+					const isTrackedSingleAssignment =
+						selection.kind === "assignment" && selection.role !== null && selection.roles === undefined;
 					try {
 						if (selection.kind === "createProfile") {
 							done();
@@ -1562,7 +1572,7 @@ export class SelectorController {
 							this.ctx.showStatus(`Temporary model: ${selectedSelector ?? model.id}`);
 							done();
 							this.ctx.ui.requestRender();
-						} else if (selection.roles) {
+						} else if (selection.roles !== undefined) {
 							const targetRoles: readonly GjcModelAssignmentTargetId[] = selection.roles;
 							const includesDefault = targetRoles.includes("default");
 							const includesRoleAgent = targetRoles.some(targetRole => targetRole !== "default");
@@ -1640,25 +1650,23 @@ export class SelectorController {
 								selectedSelector ?? `${model.provider}/${model.id}`,
 								thinkingLevel,
 							);
-							materializeActiveModelProfileAssignment({
-								session: this.ctx.session,
-								settings: this.ctx.settings,
-								role,
-								selector: value,
-							});
+							if (
+								!materializeActiveModelProfileAssignment({
+									session: this.ctx.session,
+									settings: this.ctx.settings,
+									role,
+									selector: value,
+								})
+							) {
+								this.ctx.settings.setModelRole(role, value);
+							}
 							if (thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit) {
 								this.ctx.session.setThinkingLevel(thinkingLevel);
 							}
-							modelSelector.refreshRoleAssignments({
-								currentModel: this.ctx.session.model,
-								currentThinkingLevel: this.ctx.session.thinkingLevel,
-								activeModelProfile:
-									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
-							});
+							refreshRoleAssignments();
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
 							this.ctx.showStatus(`Default model: ${selectedSelector ?? model.id}`);
-							done();
 							this.ctx.ui.requestRender();
 						} else {
 							const apiKey = await this.ctx.session.modelRegistry.getApiKey(model, this.ctx.session.sessionId);
@@ -1681,22 +1689,21 @@ export class SelectorController {
 									this.ctx.settings.setAgentModelOverride(role, value);
 								}
 							}
-							modelSelector.refreshRoleAssignments({
-								currentModel: this.ctx.session.model,
-								currentThinkingLevel: this.ctx.session.thinkingLevel,
-								activeModelProfile:
-									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
-							});
+							refreshRoleAssignments();
 							this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
 							await this.ctx.notifyConfigChanged?.();
 							this.ctx.showStatus(`${role} agent model: ${value}`);
-							done();
 							this.ctx.ui.requestRender();
 						}
 					} catch (error) {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
+						if (isTrackedSingleAssignment) {
+							refreshRoleAssignments();
+							this.ctx.ui.requestRender();
+							throw error;
+						}
 					}
 				},
 				() => {

--- a/packages/coding-agent/test/model-selector-controller-batch.test.ts
+++ b/packages/coding-agent/test/model-selector-controller-batch.test.ts
@@ -47,7 +47,7 @@ function createControllerContext() {
 			getAvailableModelProfileNames: () => [],
 			getModelProfiles: () => new Map(),
 			resolveCanonicalModel: () => undefined,
-			getApiKey: vi.fn(async () => "key"),
+			getApiKey: vi.fn(async (): Promise<string | undefined> => "key"),
 		},
 		async setModel(
 			nextModel: Model,

--- a/packages/coding-agent/test/model-selector-controller-batch.test.ts
+++ b/packages/coding-agent/test/model-selector-controller-batch.test.ts
@@ -80,6 +80,7 @@ function createControllerContext() {
 		showStatus: vi.fn(),
 		showError: vi.fn(),
 		notifyConfigChanged: vi.fn(async () => {}),
+		restoreComposer: vi.fn(),
 	};
 	return {
 		ctx,
@@ -96,6 +97,23 @@ async function openSelector(ctx: ReturnType<typeof createControllerContext>["ctx
 	new SelectorController(ctx as never).showModelSelector();
 	return ctx.editorContainer.addChild.mock.calls[0]?.[0] as ModelSelectorComponent;
 }
+async function settleSelectorInput(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+async function openReadySelector(ctx: Parameters<typeof openSelector>[0]): Promise<ModelSelectorComponent> {
+	const selector = await openSelector(ctx);
+	await settleSelectorInput();
+	return selector;
+}
+
+function selectMenuAction(selector: ModelSelectorComponent, actionIndex: number): void {
+	selector.handleInput("\n");
+	for (let index = 0; index < actionIndex; index += 1) selector.handleInput("\x1b[B");
+	selector.handleInput("\n");
+}
 
 describe("SelectorController model batch assignments", () => {
 	beforeAll(async () => {
@@ -108,66 +126,173 @@ describe("SelectorController model batch assignments", () => {
 			executor: "provider-a/profile-executor:medium",
 			architect: "provider-a/profile-architect:low",
 		});
-		const selector = await openSelector(ctx);
+		const selector = await openReadySelector(ctx);
 
-		await selector.__testSelectAssignment({
-			model: selectedModel,
-			role: "default",
-			roles: ["executor", "architect", "planner", "critic"],
-			thinkingLevel: ThinkingLevel.Low,
-			selector: "provider-a/selected:low",
-		});
+		selectMenuAction(selector, 5);
+		await settleSelectorInput();
 
 		expect(setModelCalls).toEqual([]);
 		expect(settings.getModelRole("default")).toBe("provider-a/original-default:medium");
 		expect(settings.get("task.agentModelOverrides")).toEqual({
-			executor: "provider-a/selected:low",
-			architect: "provider-a/selected:low",
-			planner: "provider-a/selected:low",
-			critic: "provider-a/selected:low",
+			executor: "provider-a/selected",
+			architect: "provider-a/selected",
+			planner: "provider-a/selected",
+			critic: "provider-a/selected",
 		});
 
 		settings.clearOverride("task.agentModelOverrides");
 		expect(settings.get("task.agentModelOverrides")).toEqual({
-			executor: "provider-a/selected:low",
-			architect: "provider-a/selected:low",
-			planner: "provider-a/selected:low",
-			critic: "provider-a/selected:low",
+			executor: "provider-a/selected",
+			architect: "provider-a/selected",
+			planner: "provider-a/selected",
+			critic: "provider-a/selected",
 		});
 		expect(ctx.showStatus).toHaveBeenCalledWith(
-			"Role-agent models set to provider-a/selected:low for EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+			"Role-agent models set to provider-a/selected for EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
 		);
+		expect(ctx.restoreComposer).toHaveBeenCalledTimes(1);
 	});
 
 	test("all targets selection writes DEFAULT plus every role-agent override", async () => {
 		const { ctx, settings, setModelCalls } = createControllerContext();
-		const selector = await openSelector(ctx);
+		const selector = await openReadySelector(ctx);
 
-		await selector.__testSelectAssignment({
-			model: selectedModel,
-			role: "default",
-			roles: ["default", "executor", "architect", "planner", "critic"],
-			thinkingLevel: ThinkingLevel.High,
-			selector: "provider-a/selected:high",
-		});
+		selectMenuAction(selector, 6);
+		await settleSelectorInput();
 
 		expect(setModelCalls).toEqual([
 			{
 				model: selectedModel,
 				role: "default",
-				options: { cause: "user-selection", selector: "provider-a/selected", thinkingLevel: ThinkingLevel.High },
+				options: { cause: "user-selection", selector: "provider-a/selected", thinkingLevel: ThinkingLevel.Inherit },
 			},
 		]);
-		expect(settings.getModelRole("default")).toBe("provider-a/selected:high");
+		expect(settings.getModelRole("default")).toBe("provider-a/selected");
 		expect(settings.get("task.agentModelOverrides")).toEqual({
-			executor: "provider-a/selected:high",
-			architect: "provider-a/selected:high",
-			planner: "provider-a/selected:high",
-			critic: "provider-a/selected:high",
+			executor: "provider-a/selected",
+			architect: "provider-a/selected",
+			planner: "provider-a/selected",
+			critic: "provider-a/selected",
 		});
 		expect(ctx.showStatus).toHaveBeenCalledWith(
-			"All model targets set to provider-a/selected:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+			"All model targets set to provider-a/selected for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
 		);
+		expect(ctx.restoreComposer).toHaveBeenCalledTimes(1);
+	});
+	test("individual DEFAULT assignment stays open until cancel", async () => {
+		const { ctx, settings } = createControllerContext();
+		const selector = await openReadySelector(ctx);
+
+		selectMenuAction(selector, 0);
+		await settleSelectorInput();
+
+		expect(settings.getModelRole("default")).toBe("provider-a/selected");
+		expect(ctx.restoreComposer).not.toHaveBeenCalled();
+
+		selector.handleInput("\x1b");
+		expect(ctx.restoreComposer).toHaveBeenCalledTimes(1);
+	});
+	test("serializes consecutive named role assignments on the mounted selector", async () => {
+		const { ctx, settings, session } = createControllerContext();
+		const firstGate = Promise.withResolvers<string>();
+		const secondGate = Promise.withResolvers<string>();
+		session.modelRegistry.getApiKey
+			.mockImplementationOnce(async () => await firstGate.promise)
+			.mockImplementationOnce(async () => await secondGate.promise);
+		const selector = await openReadySelector(ctx);
+
+		selectMenuAction(selector, 1);
+		expect(session.modelRegistry.getApiKey).toHaveBeenCalledTimes(1);
+		firstGate.resolve("key");
+		await settleSelectorInput();
+
+		selectMenuAction(selector, 2);
+		expect(session.modelRegistry.getApiKey).toHaveBeenCalledTimes(2);
+		secondGate.resolve("key");
+		await settleSelectorInput();
+
+		expect(settings.get("task.agentModelOverrides")).toMatchObject({
+			executor: "provider-a/selected",
+			architect: "provider-a/selected",
+		});
+		expect(ctx.restoreComposer).not.toHaveBeenCalled();
+	});
+	test("suppresses pending menu input and defers repeated cancel once through successful assignment", async () => {
+		const { ctx, settings, session } = createControllerContext();
+		const gate = Promise.withResolvers<string>();
+		session.modelRegistry.getApiKey.mockImplementation(async () => await gate.promise);
+		const selector = await openReadySelector(ctx);
+
+		selectMenuAction(selector, 1);
+		selector.handleInput("\n");
+		selector.handleInput("\x1b");
+		selector.handleInput("\x1b");
+		expect(session.modelRegistry.getApiKey).toHaveBeenCalledTimes(1);
+
+		gate.resolve("key");
+		await settleSelectorInput();
+
+		expect(settings.get("task.agentModelOverrides")).toMatchObject({ executor: "provider-a/selected" });
+		expect(ctx.restoreComposer).toHaveBeenCalledTimes(1);
+	});
+	test("reports rejected and missing-key tracked assignments before one deferred restore", async () => {
+		for (const apiKeyResult of [
+			async (): Promise<string | undefined> => {
+				throw new Error("credential rejected");
+			},
+			async (): Promise<string | undefined> => undefined,
+		]) {
+			const { ctx, session } = createControllerContext();
+			const order: string[] = [];
+			ctx.showError.mockImplementation(() => order.push("error"));
+			ctx.ui.requestRender.mockImplementation(() => order.push("render"));
+			ctx.restoreComposer.mockImplementation(() => order.push("restore"));
+			session.modelRegistry.getApiKey.mockImplementation(async () => await apiKeyResult());
+			const selector = await openReadySelector(ctx);
+			const refreshRoleAssignments = selector.refreshRoleAssignments.bind(selector);
+			vi.spyOn(selector, "refreshRoleAssignments").mockImplementation(options => {
+				order.push("refresh");
+				refreshRoleAssignments(options);
+			});
+			order.length = 0;
+
+			selectMenuAction(selector, 1);
+			selector.handleInput("\x1b");
+			selector.handleInput("\x1b");
+			await settleSelectorInput();
+
+			expect(ctx.showError).toHaveBeenCalledTimes(1);
+			expect(ctx.restoreComposer).toHaveBeenCalledTimes(1);
+			const errorIndex = order.indexOf("error");
+			const refreshIndex = order.indexOf("refresh");
+			const restoreIndex = order.indexOf("restore");
+			const refreshRenderIndex = order.indexOf("render", refreshIndex);
+			expect(errorIndex).toBeLessThan(refreshIndex);
+			expect(refreshIndex).toBeLessThan(refreshRenderIndex);
+			expect(refreshRenderIndex).toBeLessThan(restoreIndex);
+		}
+	});
+	test("refreshes tracked assignment truth after failure and permits retry", async () => {
+		const { ctx, settings, session } = createControllerContext();
+		const failure = Promise.withResolvers<string>();
+		const success = Promise.withResolvers<string>();
+		session.modelRegistry.getApiKey
+			.mockImplementationOnce(async () => await failure.promise)
+			.mockImplementationOnce(async () => await success.promise);
+		const selector = await openReadySelector(ctx);
+
+		selectMenuAction(selector, 1);
+		failure.reject(new Error("credential rejected"));
+		await settleSelectorInput();
+		expect(ctx.showError).toHaveBeenCalledTimes(1);
+		expect(settings.get("task.agentModelOverrides")).toMatchObject({ executor: "provider-a/original-executor:low" });
+
+		selectMenuAction(selector, 1);
+		success.resolve("key");
+		await settleSelectorInput();
+
+		expect(session.modelRegistry.getApiKey).toHaveBeenCalledTimes(2);
+		expect(settings.get("task.agentModelOverrides")).toMatchObject({ executor: "provider-a/selected" });
 	});
 
 	test("temporary selection replaces the live fallback chain with the selected model", async () => {

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -133,6 +133,7 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 		updateEditorBorderColor: vi.fn(),
 		showStatus: vi.fn(),
 		showError: vi.fn(),
+		restoreComposer: vi.fn(),
 	};
 	return { ctx, settings, session, flush, setCalls };
 }
@@ -387,6 +388,7 @@ describe("model selector profiles", () => {
 		expect(settings.get("task.agentModelOverrides")).toMatchObject({ executor: "provider-a/alternate" });
 		expect(settings.get("modelProfile.default")).toBe("old-profile");
 		expect(ctx.showStatus).toHaveBeenCalledWith("Model profile: Profile Alpha");
+		expect(ctx.restoreComposer).toHaveBeenCalledTimes(1);
 	});
 
 	test("Set as default persists and flushes modelProfile.default", async () => {
@@ -399,6 +401,7 @@ describe("model selector profiles", () => {
 		expect(setCalls).toContainEqual({ path: "defaultThinkingLevel", value: ThinkingLevel.High });
 		expect(flush).toHaveBeenCalledTimes(1);
 		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
+		expect(ctx.restoreComposer).toHaveBeenCalledTimes(1);
 	});
 
 	test("credential failure shows error and leaves model and overrides unchanged", async () => {


### PR DESCRIPTION
## Summary

- keep the model selector mounted after assigning a model to `DEFAULT` or an individual named role
- serialize in-flight individual assignments and defer repeated cancel input until settlement
- preserve close-on-success behavior for batch, temporary, and profile selections
- refresh authoritative role state after tracked failures and allow retry without reopening the selector

## Testing

- `bun test packages/coding-agent/test/model-selector-controller-batch.test.ts packages/coding-agent/test/model-selector-profiles.test.ts packages/coding-agent/test/keybindings-escape-components.test.ts packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/model-selector-batch-thinking.test.ts` (57 passed)
- `bun --cwd=packages/coding-agent run check`
  - Biome passed
  - SDK canonicalization passed
  - type checking remains blocked by the existing `@agentclientprotocol/sdk` mismatch around `DeleteSessionRequest`, `SessionCapabilities.delete`, and `deleteSession` in unchanged ACP files

## Behavior

Individual `DEFAULT`, `EXECUTOR`, `ARCHITECT`, `PLANNER`, and `CRITIC` assignments stay in the same selector for consecutive choices. `Set for all role agents` and `Set for all targets` continue to close the selector after success.