### PR TITLE
fix(coding-agent): prevent cleanup from deleting live worktrees

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.
+- `gjc worktree clear` no longer misclassifies live Git worktrees that use relative `.git` pointers as orphaned cleanup targets.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).
 - Palette slash submissions no longer clear or rewrite composer text, cursor state, history, or pending images created while an asynchronous input hook is awaiting; canonical keyboard submission cleanup remains unchanged (#2441).
 - Dead browser-tab recovery now expires descriptors without releasing replacement, revived, or differently owned tabs, while exactly-once teardown closes stale targets and releases browser holds without refcount underflow (#2437).

--- a/packages/coding-agent/src/cli/worktree-cli.ts
+++ b/packages/coding-agent/src/cli/worktree-cli.ts
@@ -16,25 +16,12 @@
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getWorktreesDir, isEnoent } from "@gajae-code/utils";
+import { getWorktreesDir } from "@gajae-code/utils/dirs";
 import chalk from "chalk";
 import * as git from "../utils/git";
+import { scanWorktrees, type WorktreeEntry } from "./worktree-scanner";
 
-type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray";
-
-export interface WorktreeEntry {
-	/** Absolute path to the worktree dir (or stray container) under `~/.gjc/wt/`. */
-	path: string;
-	/** Classification of what we found on disk. */
-	kind: WorktreeKind;
-	/** Parent repo root, when this is a registered git worktree. */
-	parentRepo?: string;
-	/** Branch name extracted from the parent's tracking file, when available. */
-	branch?: string;
-	/** When set, the entry is unhealthy and `gjc worktree clear` will remove it. */
-	orphanReason?: string;
-}
-
+export type { WorktreeEntry } from "./worktree-scanner";
 export interface ListWorktreesOptions {
 	json: boolean;
 }
@@ -146,131 +133,6 @@ export async function clearWorktrees(options: ClearWorktreesOptions): Promise<vo
 	}
 	console.log(chalk.dim(`\n${succeeded} removed${failed > 0 ? ` · ${chalk.red(`${failed} failed`)}` : ""}`));
 	if (failed > 0) process.exitCode = 1;
-}
-
-// ───────────────────────────────────────────────────────────────────────────
-// Scanner
-// ───────────────────────────────────────────────────────────────────────────
-
-async function scanWorktrees(): Promise<WorktreeEntry[]> {
-	const root = getWorktreesDir();
-	let topLevel: string[];
-	try {
-		topLevel = await fs.readdir(root);
-	} catch (err) {
-		if (isEnoent(err)) return [];
-		throw err;
-	}
-
-	const entries: WorktreeEntry[] = [];
-	for (const name of topLevel) {
-		const dir = path.join(root, name);
-		const stat = await fs.stat(dir).catch(() => null);
-		if (!stat?.isDirectory()) continue;
-
-		const direct = await classifyDir(dir);
-		if (direct) {
-			entries.push(direct);
-			continue;
-		}
-
-		// Legacy nesting: ~/.gjc/wt/<encoded-project>/<branch-or-id>
-		let children: string[];
-		try {
-			children = await fs.readdir(dir);
-		} catch {
-			continue;
-		}
-		let nested = 0;
-		for (const child of children) {
-			const childDir = path.join(dir, child);
-			const childStat = await fs.stat(childDir).catch(() => null);
-			if (!childStat?.isDirectory()) continue;
-			const childClassified = await classifyDir(childDir);
-			if (childClassified) {
-				entries.push(childClassified);
-				nested += 1;
-			}
-		}
-		if (nested === 0) {
-			entries.push({
-				path: dir,
-				kind: children.length === 0 ? "empty" : "stray",
-				orphanReason: children.length === 0 ? "empty directory" : "no recognizable worktree contents",
-			});
-		}
-	}
-	return entries;
-}
-
-async function classifyDir(dir: string): Promise<WorktreeEntry | null> {
-	const gitEntry = path.join(dir, ".git");
-	const gitStat = await fs.stat(gitEntry).catch(() => null);
-	if (gitStat?.isFile()) {
-		return classifyPrCheckout(dir, gitEntry);
-	}
-	const mergedStat = await fs.stat(path.join(dir, "merged")).catch(() => null);
-	if (mergedStat?.isDirectory()) {
-		return {
-			path: dir,
-			kind: "task-isolation",
-			orphanReason: "task-isolation leftover (no live task owns it)",
-		};
-	}
-	return null;
-}
-
-async function classifyPrCheckout(dir: string, gitEntry: string): Promise<WorktreeEntry> {
-	let contents: string;
-	try {
-		contents = await fs.readFile(gitEntry, "utf8");
-	} catch (err) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			orphanReason: `cannot read .git file: ${err instanceof Error ? err.message : String(err)}`,
-		};
-	}
-	const match = /^gitdir:\s*(.+?)\s*$/m.exec(contents);
-	const parentGitDir = match?.[1];
-	if (!parentGitDir) {
-		return { path: dir, kind: "pr-checkout", orphanReason: "malformed .git file (no gitdir line)" };
-	}
-	// parentGitDir is `<parent-repo>/.git/worktrees/<name>`; back out the repo root.
-	const parentRepo = path.dirname(path.dirname(path.dirname(parentGitDir)));
-	const branch = await readWorktreeBranch(path.join(parentGitDir, "HEAD"));
-
-	const parentDirStat = await fs.stat(parentGitDir).catch(() => null);
-	if (!parentDirStat?.isDirectory()) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			parentRepo,
-			branch,
-			orphanReason: "parent repo no longer tracks this worktree",
-		};
-	}
-	const parentRepoStat = await fs.stat(parentRepo).catch(() => null);
-	if (!parentRepoStat?.isDirectory()) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			parentRepo,
-			branch,
-			orphanReason: "parent repo missing",
-		};
-	}
-	return { path: dir, kind: "pr-checkout", parentRepo, branch };
-}
-
-async function readWorktreeBranch(headFile: string): Promise<string | undefined> {
-	try {
-		const head = (await fs.readFile(headFile, "utf8")).trim();
-		const refMatch = /^ref:\s*refs\/heads\/(.+)$/.exec(head);
-		return refMatch?.[1];
-	} catch {
-		return undefined;
-	}
 }
 
 function formatEntryDetail(entry: WorktreeEntry): string {

--- a/packages/coding-agent/src/cli/worktree-scanner.ts
+++ b/packages/coding-agent/src/cli/worktree-scanner.ts
@@ -1,0 +1,147 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getWorktreesDir } from "@gajae-code/utils/dirs";
+import { isEnoent } from "@gajae-code/utils/fs-error";
+
+type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray";
+
+export interface WorktreeEntry {
+	/** Absolute path to the worktree dir (or stray container) under `~/.gjc/wt/`. */
+	path: string;
+	/** Classification of what we found on disk. */
+	kind: WorktreeKind;
+	/** Parent repo root, when this is a registered git worktree. */
+	parentRepo?: string;
+	/** Branch name extracted from the parent's tracking file, when available. */
+	branch?: string;
+	/** When set, the entry is unhealthy and `gjc worktree clear` will remove it. */
+	orphanReason?: string;
+}
+
+export async function scanWorktrees(root = getWorktreesDir()): Promise<WorktreeEntry[]> {
+	let topLevel: string[];
+	try {
+		topLevel = await fs.readdir(root);
+	} catch (err) {
+		if (isEnoent(err)) return [];
+		throw err;
+	}
+
+	const entries: WorktreeEntry[] = [];
+	for (const name of topLevel) {
+		const dir = path.join(root, name);
+		const stat = await fs.stat(dir).catch(() => null);
+		if (!stat?.isDirectory()) continue;
+
+		const direct = await classifyDir(dir);
+		if (direct) {
+			entries.push(direct);
+			continue;
+		}
+
+		// Legacy nesting: ~/.gjc/wt/<encoded-project>/<branch-or-id>
+		let children: string[];
+		try {
+			children = await fs.readdir(dir);
+		} catch {
+			continue;
+		}
+		let nested = 0;
+		for (const child of children) {
+			const childDir = path.join(dir, child);
+			const childStat = await fs.stat(childDir).catch(() => null);
+			if (!childStat?.isDirectory()) continue;
+			const childClassified = await classifyDir(childDir);
+			if (childClassified) {
+				entries.push(childClassified);
+				nested += 1;
+			}
+		}
+		if (nested === 0) {
+			entries.push({
+				path: dir,
+				kind: children.length === 0 ? "empty" : "stray",
+				orphanReason: children.length === 0 ? "empty directory" : "no recognizable worktree contents",
+			});
+		}
+	}
+	return entries;
+}
+
+async function classifyDir(dir: string): Promise<WorktreeEntry | null> {
+	const gitEntry = path.join(dir, ".git");
+	const gitStat = await fs.stat(gitEntry).catch(() => null);
+	if (gitStat?.isFile()) {
+		return classifyPrCheckout(dir, gitEntry);
+	}
+	const mergedStat = await fs.stat(path.join(dir, "merged")).catch(() => null);
+	if (mergedStat?.isDirectory()) {
+		return {
+			path: dir,
+			kind: "task-isolation",
+			orphanReason: "task-isolation leftover (no live task owns it)",
+		};
+	}
+	return null;
+}
+
+function parseGitDirPointer(contents: string): string | undefined {
+	const prefix = "gitdir: ";
+	if (!contents.startsWith(prefix)) return undefined;
+	const pointer = contents.slice(prefix.length).replace(/[\r\n]+$/, "");
+	return pointer.length > 0 && !pointer.includes("\n") ? pointer : undefined;
+}
+
+async function classifyPrCheckout(dir: string, gitEntry: string): Promise<WorktreeEntry> {
+	let contents: string;
+	try {
+		contents = await fs.readFile(gitEntry, "utf8");
+	} catch (err) {
+		return {
+			path: dir,
+			kind: "pr-checkout",
+			orphanReason: `cannot read .git file: ${err instanceof Error ? err.message : String(err)}`,
+		};
+	}
+	const gitDirPointer = parseGitDirPointer(contents);
+	if (!gitDirPointer) {
+		return { path: dir, kind: "pr-checkout", orphanReason: "malformed .git file (no gitdir line)" };
+	}
+	const resolvedGitEntry = await fs.realpath(gitEntry).catch(() => gitEntry);
+	const parentGitDir = path.resolve(path.dirname(resolvedGitEntry), gitDirPointer);
+	// parentGitDir is `<parent-repo>/.git/worktrees/<name>`; back out the repo root.
+	const parentRepo = path.dirname(path.dirname(path.dirname(parentGitDir)));
+	const branch = await readWorktreeBranch(path.join(parentGitDir, "HEAD"));
+
+	const parentDirStat = await fs.stat(parentGitDir).catch(() => null);
+	if (!parentDirStat?.isDirectory()) {
+		return {
+			path: dir,
+			kind: "pr-checkout",
+			parentRepo,
+			branch,
+			orphanReason: "parent repo no longer tracks this worktree",
+		};
+	}
+	const parentRepoStat = await fs.stat(parentRepo).catch(() => null);
+	if (!parentRepoStat?.isDirectory()) {
+		return {
+			path: dir,
+			kind: "pr-checkout",
+			parentRepo,
+			branch,
+			orphanReason: "parent repo missing",
+		};
+	}
+	return { path: dir, kind: "pr-checkout", parentRepo, branch };
+}
+
+async function readWorktreeBranch(headFile: string): Promise<string | undefined> {
+	try {
+		const head = (await fs.readFile(headFile, "utf8")).trim();
+		const refMatch = /^ref:\s*refs\/heads\/(.+)$/.exec(head);
+		return refMatch?.[1];
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/coding-agent/test/worktree-cli.test.ts
+++ b/packages/coding-agent/test/worktree-cli.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { scanWorktrees } from "../src/cli/worktree-scanner";
+
+const temporaryDirectories: string[] = [];
+
+type ScannerFixture = {
+	worktreeDir: string;
+	worktreesRoot: string;
+};
+
+type LiveFixture = ScannerFixture & {
+	parentRepo: string;
+};
+type LiveFixtureOptions = {
+	adminName?: string;
+	head?: string;
+	nested?: boolean;
+	pointerSuffix?: string;
+};
+
+async function createLiveFixture(
+	pointerKind: "absolute" | "relative",
+	options: LiveFixtureOptions = {},
+): Promise<LiveFixture> {
+	const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "gjc-worktree-scan-")));
+	temporaryDirectories.push(root);
+	const worktreesRoot = path.join(root, "worktrees");
+	const worktreeDir = options.nested
+		? path.join(worktreesRoot, "legacy-project", "checkout")
+		: path.join(worktreesRoot, "checkout");
+	const parentRepo = path.join(root, "parent repo");
+	const parentGitDir = path.join(parentRepo, ".git", "worktrees", options.adminName ?? "checkout");
+	await fs.mkdir(worktreeDir, { recursive: true });
+	await fs.mkdir(parentGitDir, { recursive: true });
+	await fs.writeFile(
+		path.join(parentGitDir, "HEAD"),
+		options.head ?? "ref: refs/heads/feature/relative-pointer\n",
+		"utf8",
+	);
+	const pointer = pointerKind === "relative" ? path.relative(worktreeDir, parentGitDir) : parentGitDir;
+	await fs.writeFile(path.join(worktreeDir, ".git"), `gitdir: ${pointer}${options.pointerSuffix ?? "\n"}`, "utf8");
+	return { parentRepo, worktreeDir, worktreesRoot };
+}
+
+async function createPointerFixture(pointer: string): Promise<ScannerFixture> {
+	const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "gjc-worktree-scan-")));
+	temporaryDirectories.push(root);
+	const worktreesRoot = path.join(root, "worktrees");
+	const worktreeDir = path.join(worktreesRoot, "checkout");
+	await fs.mkdir(worktreeDir, { recursive: true });
+	await fs.writeFile(path.join(worktreeDir, ".git"), pointer, "utf8");
+	return { worktreeDir, worktreesRoot };
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })),
+	);
+});
+
+describe("managed worktree scanning", () => {
+	it.each(["relative", "absolute"] as const)("keeps a live checkout with a %s gitdir pointer", async pointerKind => {
+		const fixture = await createLiveFixture(pointerKind);
+
+		expect(await scanWorktrees(fixture.worktreesRoot)).toEqual([
+			{
+				path: fixture.worktreeDir,
+				kind: "pr-checkout",
+				parentRepo: fixture.parentRepo,
+				branch: "feature/relative-pointer",
+			},
+		]);
+	});
+	it("handles CRLF and detached HEAD metadata without orphaning", async () => {
+		const fixture = await createLiveFixture("relative", {
+			head: `${"a".repeat(40)}\n`,
+			pointerSuffix: "\r\n",
+		});
+
+		expect(await scanWorktrees(fixture.worktreesRoot)).toEqual([
+			{
+				path: fixture.worktreeDir,
+				kind: "pr-checkout",
+				parentRepo: fixture.parentRepo,
+				branch: undefined,
+			},
+		]);
+	});
+	it.each([
+		"\r",
+		"\n\n",
+		"\r\n\r\n",
+		"\r\r\n",
+	])("accepts Git-compatible trailing line-ending runs: %p", async pointerSuffix => {
+		const fixture = await createLiveFixture("relative", { pointerSuffix });
+
+		expect(await scanWorktrees(fixture.worktreesRoot)).toEqual([
+			{
+				path: fixture.worktreeDir,
+				kind: "pr-checkout",
+				parentRepo: fixture.parentRepo,
+				branch: "feature/relative-pointer",
+			},
+		]);
+	});
+
+	it("preserves whitespace that belongs to the gitdir path", async () => {
+		const fixture = await createLiveFixture("relative", { adminName: "checkout " });
+
+		expect(await scanWorktrees(fixture.worktreesRoot)).toEqual([
+			{
+				path: fixture.worktreeDir,
+				kind: "pr-checkout",
+				parentRepo: fixture.parentRepo,
+				branch: "feature/relative-pointer",
+			},
+		]);
+	});
+
+	it("does not discard trailing spaces from a missing gitdir target", async () => {
+		const fixture = await createLiveFixture("relative", { pointerSuffix: "   \n" });
+
+		expect(await scanWorktrees(fixture.worktreesRoot)).toEqual([
+			{
+				path: fixture.worktreeDir,
+				kind: "pr-checkout",
+				parentRepo: fixture.parentRepo,
+				branch: undefined,
+				orphanReason: "parent repo no longer tracks this worktree",
+			},
+		]);
+	});
+
+	it("resolves relative gitdir pointers from the nested legacy checkout directory", async () => {
+		const fixture = await createLiveFixture("relative", { nested: true });
+
+		expect(await scanWorktrees(fixture.worktreesRoot)).toEqual([
+			{
+				path: fixture.worktreeDir,
+				kind: "pr-checkout",
+				parentRepo: fixture.parentRepo,
+				branch: "feature/relative-pointer",
+			},
+		]);
+	});
+	it("resolves a relative gitdir from the real location of a symlinked checkout", async () => {
+		const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "gjc-worktree-scan-")));
+		temporaryDirectories.push(root);
+		const worktreesRoot = path.join(root, "worktrees");
+		const actualWorktreeDir = path.join(root, "actual", "deep", "checkout");
+		const linkedWorktreeDir = path.join(worktreesRoot, "checkout-link");
+		const parentRepo = path.join(root, "parent repo");
+		const parentGitDir = path.join(parentRepo, ".git", "worktrees", "checkout");
+		await fs.mkdir(actualWorktreeDir, { recursive: true });
+		await fs.mkdir(parentGitDir, { recursive: true });
+		await fs.writeFile(path.join(parentGitDir, "HEAD"), "ref: refs/heads/feature/symlink\n", "utf8");
+		await fs.writeFile(
+			path.join(actualWorktreeDir, ".git"),
+			`gitdir: ${path.relative(actualWorktreeDir, parentGitDir)}\n`,
+			"utf8",
+		);
+		await fs.mkdir(worktreesRoot, { recursive: true });
+		await fs.symlink(actualWorktreeDir, linkedWorktreeDir, process.platform === "win32" ? "junction" : "dir");
+
+		expect(await scanWorktrees(worktreesRoot)).toEqual([
+			{
+				path: linkedWorktreeDir,
+				kind: "pr-checkout",
+				parentRepo,
+				branch: "feature/symlink",
+			},
+		]);
+	});
+
+	it("resolves a missing relative gitdir before reporting the checkout as orphaned", async () => {
+		const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "gjc-worktree-scan-")));
+		temporaryDirectories.push(root);
+		const expectedParentRepo = path.join(root, "missing parent");
+		const missingGitDir = path.join(expectedParentRepo, ".git", "worktrees", "checkout");
+		const worktreeDir = path.join(root, "worktrees", "checkout");
+		await fs.mkdir(worktreeDir, { recursive: true });
+		await fs.writeFile(path.join(worktreeDir, ".git"), `gitdir: ${path.relative(worktreeDir, missingGitDir)}\n`);
+
+		const [entry] = await scanWorktrees(path.join(root, "worktrees"));
+		expect(entry).toMatchObject({
+			path: worktreeDir,
+			kind: "pr-checkout",
+			parentRepo: expectedParentRepo,
+			orphanReason: "parent repo no longer tracks this worktree",
+		});
+		expect(path.isAbsolute(entry?.parentRepo ?? "")).toBe(true);
+	});
+
+	it.each([
+		"not a gitdir file\n",
+		"gitdir:\n",
+		"gitdir: \n",
+		"gitdir:\t../../repo/.git/worktrees/checkout\n",
+		"gitdir:\n../../repo/.git/worktrees/checkout\n",
+		"prefix\ngitdir: ../../repo/.git/worktrees/checkout\n",
+		"gitdir: ../../repo/.git/worktrees/checkout\nextra\n",
+	])("rejects invalid gitfile syntax: %p", async contents => {
+		const fixture = await createPointerFixture(contents);
+
+		expect(await scanWorktrees(fixture.worktreesRoot)).toEqual([
+			{
+				path: fixture.worktreeDir,
+				kind: "pr-checkout",
+				orphanReason: "malformed .git file (no gitdir line)",
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
- resolve relative `.git` gitdir pointers from the real gitfile location instead of the process cwd
- preserve Git-compatible pointer parsing, including path whitespace and complete trailing CR/LF runs
- keep symlink-addressed and legacy nested worktrees classified as live
- extract the pure scanner for deterministic regression coverage

## Why
With `worktree.useRelativePaths=true`, Git writes relative gitdir pointers. `gjc worktree clear` previously resolved those pointers against its current process directory, misclassified registered worktrees as orphaned, and could select them for default cleanup.

## Verification
- `bun test packages/coding-agent/test/worktree-cli.test.ts` — 19 pass
- related worktree suites (`worktree-cli`, `task/worktree`, `gjc-runtime/launch-worktree`) — 35 pass
- `bun --cwd=packages/coding-agent run check`
  - Biome: 2,156 files
  - SDK canonicalization
  - TypeScript
- coding-agent binary build completed with a matching published native addon staged locally
- real Git dogfood covered relative/absolute pointers, symlink access, Unicode and spaced paths, detached HEAD, LF/CR/LF/CRLF runs, malformed gitfiles, default cleanup, dry-run, and `--all` deregistration
- three independent review lanes (Git semantics, cleanup safety, compatibility) returned CLEAR for patch-introduced regressions

## Local environment note
`session-manager/worktree-continue.test.ts` requires an unreleased native symbol (`canonicalExistingDirectoryIdentity`) absent from the published `0.11.1` addon, so its four cases stop during setup locally. CI's source-matched native build is the remaining integration check.