### PR TITLE
feat(coding-agent): establish deep-interview fact provenance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
 - Added a searchable command palette with direct action dispatch; slash commands run only from an empty composer, and drafts are never touched.
+- Added deep-interview fact provenance boundaries that preserve legacy state safely and prevent malformed new facts from bypassing closure.
 
 ### Fixed
 

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -694,6 +694,11 @@ async function seedDeepInterviewState(cwd: string, resolved: ResolvedDeepIntervi
 		threshold_source: resolved.thresholdSource,
 		state: {
 			initial_idea: resolved.idea,
+			fact_provenance: {
+				version: 1,
+				activated_at: now,
+				migration: "new",
+			},
 			rounds: [],
 			established_facts: [],
 			current_ambiguity: 1.0,

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
@@ -23,6 +23,26 @@ export type DeepInterviewTriggerKind = "A" | "B" | "C" | "D";
 /** `active` triggers must satisfy the bidirectional invariant; disputed/unresolved are exempt with rationale. */
 export type DeepInterviewTriggerStatus = "active" | "disputed" | "unresolved";
 
+export interface DeepInterviewFactProvenanceMeta {
+	version: 1;
+	activated_at: string;
+	migration: "new" | "legacy_migrated";
+}
+
+export type DeepInterviewFactSource =
+	| "user_confirmed"
+	| "repository_verified"
+	| "agent_assisted"
+	| "blocked"
+	| "legacy";
+
+export type DeepInterviewFactResolution =
+	| "unknown"
+	| "unresolved"
+	| "user_confirmed"
+	| "repository_verified"
+	| "superseded";
+
 export interface DeepInterviewEstablishedFact {
 	id: string;
 	statement: string;
@@ -30,6 +50,9 @@ export interface DeepInterviewEstablishedFact {
 	component?: string;
 	dimension?: string;
 	evidence?: string;
+	source?: DeepInterviewFactSource;
+	resolution?: DeepInterviewFactResolution;
+	provenance_error?: string;
 	disputed: boolean;
 	/**
 	 * Resolution pointer for a disputed fact: the id of the fact that replaced it
@@ -128,6 +151,72 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function isValidProvenanceMeta(value: unknown): value is DeepInterviewFactProvenanceMeta {
+	if (!isPlainObject(value)) return false;
+	return (
+		value.version === 1 &&
+		typeof value.activated_at === "string" &&
+		!Number.isNaN(Date.parse(value.activated_at)) &&
+		(value.migration === "new" || value.migration === "legacy_migrated")
+	);
+}
+
+function hasPostContractFact(value: unknown): boolean {
+	return (
+		Array.isArray(value) &&
+		value.some(
+			fact =>
+				isPlainObject(fact) &&
+				(Object.hasOwn(fact, "source") ||
+					Object.hasOwn(fact, "resolution") ||
+					Object.hasOwn(fact, "provenance_error")),
+		)
+	);
+}
+
+function normalizeFactProvenance(inner: Record<string, unknown>, originalMarker: unknown): void {
+	const facts = Array.isArray(inner.established_facts)
+		? inner.established_facts.filter(isPlainObject).map(fact => ({ ...fact }))
+		: [];
+	const validMarker = isValidProvenanceMeta(originalMarker);
+	const markerlessLegacy = originalMarker === undefined && !hasPostContractFact(facts);
+
+	if (validMarker) {
+		inner.fact_provenance = { ...originalMarker };
+	} else if (markerlessLegacy) {
+		inner.fact_provenance = {
+			version: 1,
+			activated_at: new Date(0).toISOString(),
+			migration: "legacy_migrated",
+		} satisfies DeepInterviewFactProvenanceMeta;
+	} else {
+		delete inner.fact_provenance;
+		inner.provenance_error =
+			originalMarker === undefined ? "post_contract_marker_missing" : "invalid_fact_provenance_marker";
+	}
+
+	const migration = isValidProvenanceMeta(inner.fact_provenance) ? inner.fact_provenance.migration : undefined;
+	inner.established_facts = facts.map(fact => {
+		if (migration === "legacy_migrated") {
+			return {
+				...fact,
+				source: fact.source ?? "legacy",
+				resolution: fact.resolution ?? (fact.superseded_by ? "superseded" : "unresolved"),
+			};
+		}
+		const source = fact.source;
+		const resolution = fact.resolution;
+		const terminal =
+			resolution === "user_confirmed" ||
+			resolution === "repository_verified" ||
+			(resolution === "superseded" && nonEmptyString(fact.superseded_by));
+		if (migration === "new" && (!source || !resolution || !terminal)) {
+			return { ...fact, provenance_error: "fact_provenance_unresolved" };
+		}
+		return fact;
+	});
+}
+
 /**
  * Interview transcript/scoring fields that are canonical under `state`. When a
  * legacy flattened envelope carries them at the top level they are hoisted into
@@ -199,7 +288,9 @@ const ENVELOPE_RESERVED_STATE_KEYS = [
  */
 export function normalizeDeepInterviewEnvelope(value: unknown): DeepInterviewStateEnvelope {
 	const envelope: DeepInterviewStateEnvelope = isPlainObject(value) ? { ...value } : {};
-	const inner: Record<string, unknown> = isPlainObject(envelope.state) ? { ...envelope.state } : {};
+	const originalInner = isPlainObject(envelope.state) ? envelope.state : {};
+	const originalMarker = originalInner.fact_provenance;
+	const inner: Record<string, unknown> = { ...originalInner };
 
 	for (const field of TRANSCRIPT_STATE_FIELDS) {
 		if (inner[field] === undefined && envelope[field] !== undefined) inner[field] = envelope[field];
@@ -214,6 +305,7 @@ export function normalizeDeepInterviewEnvelope(value: unknown): DeepInterviewSta
 
 	if (!Array.isArray(inner.rounds)) inner.rounds = [];
 	if (!Array.isArray(inner.established_facts)) inner.established_facts = [];
+	normalizeFactProvenance(inner, originalMarker);
 	envelope.state = inner;
 	return envelope;
 }
@@ -335,9 +427,17 @@ export function mergeDeepInterviewEnvelope(
 	const incomingHasEstablishedFacts =
 		Object.hasOwn(incomingNestedState, "established_facts") || Object.hasOwn(incomingEnvelope, "established_facts");
 	const normalizedIncoming = normalizeDeepInterviewEnvelope(incoming);
-	if (options.replace) return normalizedIncoming;
-
 	const normalizedExisting = normalizeDeepInterviewEnvelope(existing);
+	const existingStateBeforeReplace = isPlainObject(normalizedExisting.state) ? normalizedExisting.state : {};
+	if (options.replace) {
+		const replacementState = isPlainObject(normalizedIncoming.state) ? { ...normalizedIncoming.state } : {};
+		if (isValidProvenanceMeta(existingStateBeforeReplace.fact_provenance)) {
+			replacementState.fact_provenance = existingStateBeforeReplace.fact_provenance;
+			delete replacementState.provenance_error;
+		}
+		return normalizeDeepInterviewEnvelope({ ...normalizedIncoming, state: replacementState });
+	}
+
 	const merged: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(normalizedExisting)) {
 		if (key !== "state") merged[key] = value;
@@ -352,6 +452,7 @@ export function mergeDeepInterviewEnvelope(
 	const incomingState = isPlainObject(normalizedIncoming.state) ? normalizedIncoming.state : {};
 	const mergedState: Record<string, unknown> = { ...existingState };
 	for (const [key, value] of Object.entries(incomingState)) {
+		if (key === "fact_provenance" || key === "provenance_error") continue;
 		if (key === "rounds") continue;
 		if (key === "established_facts" && !incomingHasEstablishedFacts) continue;
 		if (value === null) delete mergedState[key];
@@ -362,5 +463,5 @@ export function mergeDeepInterviewEnvelope(
 		asRecordArray(incomingState.rounds),
 	);
 	merged.state = mergedState;
-	return merged as DeepInterviewStateEnvelope;
+	return normalizeDeepInterviewEnvelope(merged);
 }

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-state.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-state.test.ts
@@ -51,6 +51,44 @@ describe("deep-interview-state: normalizeDeepInterviewEnvelope", () => {
 		expect(inner(normalized).initial_idea).toBe("x");
 		expect(normalized.custom_unknown).toEqual({ keep: true });
 	});
+
+	it("migrates only genuinely markerless facts and blocks post-contract marker loss", () => {
+		const legacy = normalizeDeepInterviewEnvelope({
+			state: { established_facts: [{ id: "f1", statement: "legacy", round: 1, disputed: false }] },
+		});
+		expect(inner(legacy).fact_provenance).toEqual({
+			version: 1,
+			activated_at: "1970-01-01T00:00:00.000Z",
+			migration: "legacy_migrated",
+		});
+		expect(inner(legacy).established_facts).toEqual([
+			{
+				id: "f1",
+				statement: "legacy",
+				round: 1,
+				disputed: false,
+				source: "legacy",
+				resolution: "unresolved",
+			},
+		]);
+
+		const missing = normalizeDeepInterviewEnvelope({
+			state: {
+				established_facts: [
+					{
+						id: "f2",
+						statement: "post-contract",
+						round: 2,
+						disputed: false,
+						source: "user_confirmed",
+						resolution: "user_confirmed",
+					},
+				],
+			},
+		});
+		expect(inner(missing).fact_provenance).toBeUndefined();
+		expect(inner(missing).provenance_error).toBe("post_contract_marker_missing");
+	});
 });
 
 describe("deep-interview-state: mergeDeepInterviewRounds", () => {
@@ -121,13 +159,20 @@ describe("deep-interview-state: mergeDeepInterviewEnvelope", () => {
 			},
 		};
 
+		const expectedFacts = [
+			{
+				...facts[0],
+				source: "legacy",
+				resolution: "unresolved",
+			},
+		];
 		const nestedPartial = mergeDeepInterviewEnvelope(existing, { state: { current_ambiguity: 0.3 } });
-		expect(inner(nestedPartial).established_facts).toEqual(facts);
+		expect(inner(nestedPartial).established_facts).toEqual(expectedFacts);
 		expect(inner(nestedPartial).current_ambiguity).toBe(0.3);
 		expect(inner(nestedPartial).rounds).toHaveLength(1);
 
 		const topLevelPartial = mergeDeepInterviewEnvelope(existing, { current_phase: "handoff" });
-		expect(inner(topLevelPartial).established_facts).toEqual(facts);
+		expect(inner(topLevelPartial).established_facts).toEqual(expectedFacts);
 		expect(topLevelPartial.current_phase).toBe("handoff");
 	});
 
@@ -151,6 +196,34 @@ describe("deep-interview-state: mergeDeepInterviewEnvelope", () => {
 		);
 		expect(inner(merged).rounds).toEqual([]);
 		expect(merged.active).toBe(false);
+	});
+	it("does not allow merge or replace writes to downgrade a trusted new marker", () => {
+		const existing = {
+			state: {
+				fact_provenance: {
+					version: 1,
+					activated_at: "2026-07-17T00:00:00.000Z",
+					migration: "new",
+				},
+				rounds: [],
+				established_facts: [],
+			},
+		};
+		const forged = {
+			state: {
+				fact_provenance: {
+					version: 1,
+					activated_at: "1970-01-01T00:00:00.000Z",
+					migration: "legacy_migrated",
+				},
+			},
+		};
+		expect(inner(mergeDeepInterviewEnvelope(existing, forged)).fact_provenance).toEqual(
+			inner(existing).fact_provenance,
+		);
+		expect(inner(mergeDeepInterviewEnvelope(existing, forged, { replace: true })).fact_provenance).toEqual(
+			inner(existing).fact_provenance,
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

This PR establishes a durable provenance boundary for `deep-interview` established facts. It is intentionally limited to the shared state foundation (PR 2 of the broader interview-integrity work); intent-contract enforcement and blocked-exit/bridge behavior are tracked separately.

## Problem

Deep-interview state is persisted across interruptions and upgraded in place. Before this change, an established fact carried its content, evidence, and disputed status, but not a machine-enforceable answer to two questions:

1. Where did this fact come from: a user decision, a repository observation, an agent-assisted assumption, or a legacy state file?
2. Is the fact terminal enough to permit closure, or does it still require an explicit decision?

A naive migration would classify every fact without provenance as `legacy`. That is unsafe: a malformed *new* writer could omit provenance, be treated as historical data, and bypass the closure gate. Conversely, treating every missing field as an error would make legitimate pre-feature sessions unreadable.

## Solution

- Add versioned provenance metadata to the deep-interview state contract.
- Seed newly created interview state with a trusted provenance boundary before any fact writer can run.
- Treat only a genuinely pre-boundary persisted envelope as eligible for lossless `legacy` / `unknown` migration.
- Preserve legacy state and unknown extension fields without silently promoting legacy facts to user-confirmed facts.
- Prevent post-boundary facts with missing, invalid, or forged provenance from being reclassified as legacy.
- Keep the logic in the canonical state normalization/merge layer so recorder, runtime, and state writers apply identical rules.

## Why this is separate

This PR deliberately does **not** implement the user-locked artifact intent contract or BLOCKED-spec/handoff suppression. Those features consume this shared provenance model but have distinct runtime and workflow surfaces. Keeping the foundation separate makes review, rollback, and future cherry-picks safer.

## Verification

- `bun test packages/coding-agent/test/gjc-runtime/deep-interview-state.test.ts`
  - 17 passed, 0 failed
- `bunx biome check packages/coding-agent/src/gjc-runtime/deep-interview-state.ts packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts packages/coding-agent/test/gjc-runtime/deep-interview-state.test.ts`

The regression coverage includes fresh-state initialization, true legacy migration, malformed post-boundary facts, downgrade resistance, and lossless state handling.