### PR TITLE
fix: require explicit team workflow invocation

### DIFF
--- a/packages/coding-agent/src/hooks/skill-keywords.ts
+++ b/packages/coding-agent/src/hooks/skill-keywords.ts
@@ -66,12 +66,6 @@ export const GJC_SKILL_KEYWORD_DEFINITIONS: readonly SkillKeywordDefinition[] = 
 		priority: 8,
 		guidance: "Activate GJC team workflow",
 	},
-	{
-		keyword: "coordinated team",
-		skill: "team",
-		priority: 8,
-		guidance: "Activate GJC team workflow",
-	},
 ] as const;
 
 export function isGjcWorkflowSkill(value: string): value is GjcWorkflowSkill {

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -206,6 +206,12 @@ describe("GJC native skill-state hooks", () => {
 		expect(detectSkillKeywords("$autopilot deep interview")).toEqual([]);
 		expect(detectSkillKeywords("please run a consensus plan")[0]?.skill).toBe("ralplan");
 	});
+	it("requires explicit Team workflow invocations", () => {
+		expect(detectSkillKeywords("coordinated team")).toEqual([]);
+		expect(detectSkillKeywords("team")).toEqual([]);
+		expect(detectSkillKeywords("$team")).toEqual([{ keyword: "$team", skill: "team", priority: 8 }]);
+		expect(detectSkillKeywords("$gjc:team")).toEqual([{ keyword: "$gjc:team", skill: "team", priority: 8 }]);
+	});
 
 	it("UserPromptSubmit adds advisory answer-only context for question-only prompts", async () => {
 		const root = await cwd();


### PR DESCRIPTION
## Summary
- remove the implicit `coordinated team` Team activation keyword
- preserve `$team` and `$gjc:team` explicit invocation support
- add detector regression coverage for natural-language and explicit forms

## Verification
- `bun test packages/coding-agent/test/gjc-skill-state-hooks.test.ts` (49 passed)
- `bunx biome check packages/coding-agent/src/hooks/skill-keywords.ts packages/coding-agent/test/gjc-skill-state-hooks.test.ts`

## Scope
This PR targets the development branch as requested. It fixes the explicit-only activation contract; tmux startup/runtime causality remains out of scope because the original event lacks direct runtime evidence.