### PR TITLE
feat: add ephemeral retained multi-turn /btw-r side chat

### DIFF
--- a/packages/coding-agent/src/modes/components/btw-panel.ts
+++ b/packages/coding-agent/src/modes/components/btw-panel.ts
@@ -7,33 +7,63 @@ type BtwPanelState = "running" | "complete" | "aborted" | "error";
 
 interface BtwPanelComponentOptions {
 	question: string;
+	retained?: boolean;
 	tui: TUI;
+}
+
+interface RetainedTurn {
+	question: string;
+	answer: string;
+	state: BtwPanelState;
+	errorMessage?: string;
 }
 
 export class BtwPanelComponent extends Container {
 	#question: string;
 	#tui: TUI;
+	#retained: boolean;
 	#state: BtwPanelState = "running";
 	#answer = "";
 	#errorMessage: string | undefined;
+	#completedTurns: RetainedTurn[] = [];
+	#streamingContent = new Container();
 	#closed = false;
 
 	constructor(options: BtwPanelComponentOptions) {
 		super();
 		this.#question = options.question;
+		this.#retained = options.retained ?? false;
 		this.#tui = options.tui;
+		this.#rebuild();
+	}
+
+	beginRetainedTurn(question: string): void {
+		if (!this.#retained || this.#closed) return;
+		this.#completedTurns.push(this.#currentTurn());
+		this.#question = question;
+		this.#answer = "";
+		this.#errorMessage = undefined;
+		this.#state = "running";
 		this.#rebuild();
 	}
 
 	appendText(delta: string): void {
 		if (!delta || this.#closed) return;
 		this.#answer += delta;
+		if (this.#retained) {
+			this.#updateStreamingContent();
+			return;
+		}
 		this.#rebuild();
 	}
 
 	setAnswer(text: string): void {
 		if (this.#closed) return;
 		this.#answer = text;
+		if (this.#retained) {
+			this.#updateStreamingContent();
+			return;
+		}
 		this.#rebuild();
 	}
 
@@ -60,15 +90,30 @@ export class BtwPanelComponent extends Container {
 
 	close(): void {
 		this.#closed = true;
+		this.#completedTurns = [];
+		this.#answer = "";
+		this.#errorMessage = undefined;
+		this.#streamingContent.clear();
 	}
 
 	#rebuild(): void {
 		this.clear();
 		this.addChild(new DynamicBorder(str => theme.fg("dim", str)));
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("accent", replaceTabs(this.#question)), 1, 0));
-		this.addChild(new Spacer(1));
-		this.addChild(this.#contentComponent());
+		if (this.#retained) {
+			for (const turn of this.#completedTurns) {
+				this.addChild(this.#turnComponent(turn));
+				this.addChild(new Spacer(1));
+			}
+			this.addChild(new Text(theme.fg("accent", replaceTabs(this.#question)), 1, 0));
+			this.addChild(new Spacer(1));
+			this.#updateStreamingContent(false);
+			this.addChild(this.#streamingContent);
+		} else {
+			this.addChild(new Text(theme.fg("accent", replaceTabs(this.#question)), 1, 0));
+			this.addChild(new Spacer(1));
+			this.addChild(this.#contentComponent(this.#state, this.#answer, this.#errorMessage));
+		}
 		this.addChild(new Spacer(1));
 		this.addChild(new Text(this.#footerLine(), 1, 0));
 		this.addChild(new Spacer(1));
@@ -76,7 +121,42 @@ export class BtwPanelComponent extends Container {
 		this.#tui.requestRender();
 	}
 
+	#updateStreamingContent(requestRender = true): void {
+		this.#streamingContent.clear();
+		this.#streamingContent.addChild(this.#contentComponent(this.#state, this.#answer, this.#errorMessage));
+		if (requestRender) this.#tui.requestRender();
+	}
+
+	#currentTurn(): RetainedTurn {
+		return {
+			question: this.#question,
+			answer: this.#answer,
+			state: this.#state,
+			errorMessage: this.#errorMessage,
+		};
+	}
+
+	#turnComponent(turn: RetainedTurn): Component {
+		const container = new Container();
+		container.addChild(new Text(theme.fg("accent", replaceTabs(turn.question)), 1, 0));
+		container.addChild(new Spacer(1));
+		container.addChild(this.#contentComponent(turn.state, turn.answer, turn.errorMessage));
+		return container;
+	}
+
 	#footerLine(): string {
+		if (this.#retained) {
+			switch (this.#state) {
+				case "running":
+					return theme.fg("muted", "Esc cancel /btw-r");
+				case "complete":
+					return theme.fg("muted", "Type a follow-up · Esc dismiss");
+				case "aborted":
+					return theme.fg("warning", `${theme.status.warning} Cancelled · Type a follow-up · Esc dismiss`);
+				case "error":
+					return theme.fg("error", `${theme.status.error} Error · Type a follow-up · Esc dismiss`);
+			}
+		}
 		switch (this.#state) {
 			case "running":
 				return theme.fg("muted", "Esc cancel /btw");
@@ -89,14 +169,13 @@ export class BtwPanelComponent extends Container {
 		}
 	}
 
-	#contentComponent(): Component {
-		if (this.#state === "error") {
-			return new Text(theme.fg("error", replaceTabs(this.#errorMessage ?? "Unknown error")), 1, 0);
+	#contentComponent(state: BtwPanelState, answer: string, errorMessage: string | undefined): Component {
+		if (state === "error") {
+			return new Text(theme.fg("error", replaceTabs(errorMessage ?? "Unknown error")), 1, 0);
 		}
-		const text = replaceTabs(this.#answer).trim();
+		const text = replaceTabs(answer).trim();
 		if (!text) {
-			const waiting =
-				this.#state === "running" ? `${theme.status.pending} Waiting for response…` : "No text returned.";
+			const waiting = state === "running" ? `${theme.status.pending} Waiting for response…` : "No text returned.";
 			return new Text(theme.fg("dim", waiting), 1, 0);
 		}
 		return new Markdown(text, 1, 0, getMarkdownTheme());

--- a/packages/coding-agent/src/modes/controllers/btw-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/btw-controller.ts
@@ -1,12 +1,19 @@
+import type { AgentMessage } from "@gajae-code/agent-core";
 import { prompt } from "@gajae-code/utils";
+import btwRUserPrompt from "../../prompts/system/btw-r-user.md" with { type: "text" };
 import btwUserPrompt from "../../prompts/system/btw-user.md" with { type: "text" };
 import { BtwPanelComponent } from "../components/btw-panel";
 import type { InteractiveModeContext } from "../types";
+
+type RetainedFollowUpResult = "accepted" | "busy" | "closed";
 
 interface BtwRequest {
 	component: BtwPanelComponent;
 	abortController: AbortController;
 	question: string;
+	mode: "one-shot" | "retained";
+	inFlight: boolean;
+	contextMessages: AgentMessage[];
 }
 
 export class BtwController {
@@ -18,9 +25,21 @@ export class BtwController {
 		return this.#activeRequest !== undefined;
 	}
 
+	hasOpenPanel(): boolean {
+		return this.hasActiveRequest();
+	}
+
+	hasOpenRetainedThread(): boolean {
+		return this.#activeRequest?.mode === "retained";
+	}
+
+	isRetainedTurnInFlight(): boolean {
+		return this.#activeRequest?.mode === "retained" && this.#activeRequest.inFlight;
+	}
+
 	handleEscape(): boolean {
 		if (!this.#activeRequest) return false;
-		this.#closeActiveRequest({ abort: this.#activeRequest.abortController.signal.aborted === false });
+		this.#closeActiveRequest({ abort: this.#activeRequest.inFlight });
 		return true;
 	}
 
@@ -29,56 +48,137 @@ export class BtwController {
 	}
 
 	async start(question: string): Promise<void> {
+		if (this.hasOpenRetainedThread()) {
+			this.ctx.showStatus("A /btw-r thread is open. Type a follow-up or press Esc to dismiss it.");
+			return;
+		}
+
 		const trimmedQuestion = question.trim();
 		if (!trimmedQuestion) {
 			this.ctx.showStatus("Usage: /btw <question>");
 			return;
 		}
+		if (!this.#hasModel("/btw")) return;
 
-		const model = this.ctx.session.model;
-		if (!model) {
-			this.ctx.showError("No active model available for /btw.");
+		this.#closeActiveRequest({ abort: true });
+		const request = this.#openRequest(trimmedQuestion, "one-shot");
+		void this.#runOneShotRequest(request);
+	}
+
+	async startRetained(question: string): Promise<void> {
+		if (this.hasOpenRetainedThread()) {
+			this.ctx.showStatus("A /btw-r thread is already open. Type a follow-up or press Esc to dismiss it.");
 			return;
 		}
 
-		this.#closeActiveRequest({ abort: true });
+		const trimmedQuestion = question.trim();
+		if (!trimmedQuestion) {
+			this.ctx.showStatus("Usage: /btw-r <question>");
+			return;
+		}
+		if (!this.#hasModel("/btw-r")) return;
 
+		this.#closeActiveRequest({ abort: true });
+		const request = this.#openRequest(trimmedQuestion, "retained");
+		void this.#runRetainedRequest(request);
+	}
+
+	async submitRetainedFollowUp(question: string): Promise<RetainedFollowUpResult> {
+		const request = this.#activeRequest;
+		if (!request || request.mode !== "retained") {
+			return "closed";
+		}
+		if (request.inFlight) {
+			this.ctx.showStatus("The /btw-r thread is still answering. Wait for it to finish.");
+			return "busy";
+		}
+
+		const trimmedQuestion = question.trim();
+		if (!trimmedQuestion) return "closed";
+		if (!this.#hasModel("/btw-r")) return "closed";
+
+		request.question = trimmedQuestion;
+		request.abortController = new AbortController();
+		request.inFlight = true;
+		request.component.beginRetainedTurn(trimmedQuestion);
+		void this.#runRetainedRequest(request);
+		return "accepted";
+	}
+
+	#hasModel(command: "/btw" | "/btw-r"): boolean {
+		if (this.ctx.session.model) return true;
+		this.ctx.showError(`No active model available for ${command}.`);
+		return false;
+	}
+
+	#openRequest(question: string, mode: BtwRequest["mode"]): BtwRequest {
 		const request: BtwRequest = {
-			component: new BtwPanelComponent({ question: trimmedQuestion, tui: this.ctx.ui }),
+			component: new BtwPanelComponent({ question, retained: mode === "retained", tui: this.ctx.ui }),
 			abortController: new AbortController(),
-			question: trimmedQuestion,
+			question,
+			mode,
+			inFlight: true,
+			contextMessages: [],
 		};
 		this.ctx.btwContainer.clear();
 		this.ctx.btwContainer.addChild(request.component);
 		this.ctx.ui.requestRender();
 		this.#activeRequest = request;
-		void this.#runRequest(request);
+		return request;
 	}
 
-	async #runRequest(request: BtwRequest): Promise<void> {
+	async #runOneShotRequest(request: BtwRequest): Promise<void> {
 		try {
 			const promptText = prompt.render(btwUserPrompt, { question: request.question });
 			const { replyText } = await this.ctx.session.runEphemeralTurn({
 				promptText,
 				onTextDelta: delta => {
-					if (this.#isActiveRequest(request)) {
-						request.component.appendText(delta);
-					}
+					if (this.#isActiveRequest(request)) request.component.appendText(delta);
 				},
 				signal: request.abortController.signal,
 			});
-
-			if (!this.#isActiveRequest(request)) {
-				return;
-			}
-			if (replyText) {
-				request.component.setAnswer(replyText);
-			}
+			if (!this.#isActiveRequest(request)) return;
+			request.inFlight = false;
+			if (replyText) request.component.setAnswer(replyText);
 			request.component.markComplete();
 		} catch (error) {
-			if (!this.#isActiveRequest(request)) {
+			if (!this.#isActiveRequest(request)) return;
+			request.inFlight = false;
+			if (request.abortController.signal.aborted) {
+				request.component.markAborted();
 				return;
 			}
+			request.component.markError(error instanceof Error ? error.message : String(error));
+		}
+	}
+
+	async #runRetainedRequest(request: BtwRequest): Promise<void> {
+		try {
+			const promptText = prompt.render(btwRUserPrompt, { question: request.question });
+			const { replyText, assistantMessage } = await this.ctx.session.runEphemeralTurn({
+				promptText,
+				contextMessages: [...request.contextMessages],
+				onTextDelta: delta => {
+					if (this.#isActiveRequest(request)) request.component.appendText(delta);
+				},
+				signal: request.abortController.signal,
+			});
+			if (!this.#isActiveRequest(request)) return;
+			request.inFlight = false;
+			request.contextMessages.push(
+				{
+					role: "user",
+					content: [{ type: "text", text: request.question }],
+					attribution: "user",
+					timestamp: Date.now(),
+				},
+				assistantMessage,
+			);
+			if (replyText) request.component.setAnswer(replyText);
+			request.component.markComplete();
+		} catch (error) {
+			if (!this.#isActiveRequest(request)) return;
+			request.inFlight = false;
 			if (request.abortController.signal.aborted) {
 				request.component.markAborted();
 				return;
@@ -91,9 +191,7 @@ export class BtwController {
 		const request = this.#activeRequest;
 		if (!request) return;
 		this.#activeRequest = undefined;
-		if (options.abort) {
-			request.abortController.abort();
-		}
+		if (options.abort) request.abortController.abort();
 		request.component.close();
 		this.ctx.btwContainer.clear();
 		this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/controllers/btw-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/btw-controller.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@gajae-code/agent-core";
+import type { AssistantMessage } from "@gajae-code/ai";
 import { prompt } from "@gajae-code/utils";
 import btwRUserPrompt from "../../prompts/system/btw-r-user.md" with { type: "text" };
 import btwUserPrompt from "../../prompts/system/btw-user.md" with { type: "text" };
@@ -85,7 +86,7 @@ export class BtwController {
 
 	async submitRetainedFollowUp(question: string): Promise<RetainedFollowUpResult> {
 		const request = this.#activeRequest;
-		if (!request || request.mode !== "retained") {
+		if (request?.mode !== "retained") {
 			return "closed";
 		}
 		if (request.inFlight) {
@@ -165,15 +166,7 @@ export class BtwController {
 			});
 			if (!this.#isActiveRequest(request)) return;
 			request.inFlight = false;
-			request.contextMessages.push(
-				{
-					role: "user",
-					content: [{ type: "text", text: request.question }],
-					attribution: "user",
-					timestamp: Date.now(),
-				},
-				assistantMessage,
-			);
+			this.#appendRetainedExchange(request, assistantMessage);
 			if (replyText) request.component.setAnswer(replyText);
 			request.component.markComplete();
 		} catch (error) {
@@ -183,8 +176,45 @@ export class BtwController {
 				request.component.markAborted();
 				return;
 			}
-			request.component.markError(error instanceof Error ? error.message : String(error));
+			const message = error instanceof Error ? error.message : String(error);
+			// Keep the failed user turn visible to later follow-ups so "try again"
+			// still sees the question that remains on the retained panel.
+			this.#appendRetainedExchange(request, this.#errorAssistantMessage(message));
+			request.component.markError(message);
 		}
+	}
+
+	#appendRetainedExchange(request: BtwRequest, assistantMessage: AgentMessage): void {
+		request.contextMessages.push(
+			{
+				role: "user",
+				content: [{ type: "text", text: request.question }],
+				attribution: "user",
+				timestamp: Date.now(),
+			},
+			assistantMessage,
+		);
+	}
+
+	#errorAssistantMessage(message: string): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [{ type: "text", text: `Error: ${message}` }],
+			api: "btw-r",
+			provider: "btw-r",
+			model: "btw-r",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			timestamp: Date.now(),
+			errorMessage: message,
+		};
 	}
 
 	#closeActiveRequest(options: { abort: boolean }): void {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1073,7 +1073,9 @@ export class InputController {
 	async handleFollowUp(): Promise<void> {
 		const text = this.ctx.editor.getText().trim();
 		if (!text) return;
-		if (this.ctx.hasActiveBtwR()) {
+		// Mirror Enter: plain retained capture only. Slash-origin stays on normal
+		// dispatch so /skill:* and other slash commands keep working.
+		if (this.ctx.hasActiveBtwR() && !text.startsWith("/")) {
 			if ((await this.ctx.handleBtwRFollowUp(text)) === "accepted") {
 				this.ctx.editor.setText("");
 			}

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -610,18 +610,19 @@ export class InputController {
 			text = slashResult;
 		}
 
+		if (this.ctx.hasActiveBtwR() && !wasSlashOrigin) {
+			if ((await this.ctx.handleBtwRFollowUp(text)) === "accepted" && this.#canModifyComposer(composer)) {
+				this.ctx.editor.setText("");
+			}
+			return;
+		}
+
 		// Handle skill commands (/skill:name [args]). While streaming, Enter
 		// honors `busyPromptMode`: "steer" interrupts the active turn, "queue"
 		// runs after it completes (matches the free-text Enter semantics applied
 		// a few lines below at the streaming branch). Explicit queue shortcuts
 		// route through `handleFollowUp` and dispatch as `followUp`.
 		if (await this.#invokeSkillCommand(text, this.#busyStreamingBehavior(), composer)) {
-			return;
-		}
-		if (this.ctx.hasActiveBtwR() && !wasSlashOrigin) {
-			if ((await this.ctx.handleBtwRFollowUp(text)) === "accepted" && this.#canModifyComposer(composer)) {
-				this.ctx.editor.setText("");
-			}
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -543,6 +543,16 @@ export class InputController {
 	async submitText(text: string, composer: ComposerSubmissionOptions): Promise<void> {
 		text = text.trim();
 		if ((!isSettingsInitialized() || settings.get("emojiAutocomplete")) && text) text = expandEmoticons(text);
+		if (this.ctx.hasActiveBtwR()) {
+			if (!text) return;
+			if (text === "." || text === "c") {
+				if ((await this.ctx.handleBtwRFollowUp(text)) === "accepted" && this.#canModifyComposer(composer)) {
+					this.ctx.editor.setText("");
+				}
+				return;
+			}
+		}
+
 
 		// Empty submit while streaming with queued messages: flush queues immediately
 		if (!text && this.ctx.session.isStreaming && this.ctx.session.queuedMessageCount > 0) {
@@ -585,6 +595,8 @@ export class InputController {
 		}
 
 		if (!text) return;
+		const wasSlashOrigin = text.startsWith("/");
+
 
 		// Handle built-in slash commands
 		const slashResult = await executeBuiltinSlashCommand(text, {
@@ -606,6 +618,12 @@ export class InputController {
 		// a few lines below at the streaming branch). Explicit queue shortcuts
 		// route through `handleFollowUp` and dispatch as `followUp`.
 		if (await this.#invokeSkillCommand(text, this.#busyStreamingBehavior(), composer)) {
+			return;
+		}
+		if (this.ctx.hasActiveBtwR() && !wasSlashOrigin) {
+			if ((await this.ctx.handleBtwRFollowUp(text)) === "accepted" && this.#canModifyComposer(composer)) {
+				this.ctx.editor.setText("");
+			}
 			return;
 		}
 
@@ -1057,6 +1075,12 @@ export class InputController {
 	async handleFollowUp(): Promise<void> {
 		const text = this.ctx.editor.getText().trim();
 		if (!text) return;
+		if (this.ctx.hasActiveBtwR()) {
+			if ((await this.ctx.handleBtwRFollowUp(text)) === "accepted") {
+				this.ctx.editor.setText("");
+			}
+			return;
+		}
 
 		// Compaction first: while compacting, queue free text and `/skill:*`
 		// commands in the compaction-local queue. `flushCompactionQueue`

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -553,7 +553,6 @@ export class InputController {
 			}
 		}
 
-
 		// Empty submit while streaming with queued messages: flush queues immediately
 		if (!text && this.ctx.session.isStreaming && this.ctx.session.queuedMessageCount > 0) {
 			// Abort current stream and let queued messages be processed
@@ -596,7 +595,6 @@ export class InputController {
 
 		if (!text) return;
 		const wasSlashOrigin = text.startsWith("/");
-
 
 		// Handle built-in slash commands
 		const slashResult = await executeBuiltinSlashCommand(text, {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2971,9 +2971,21 @@ export class InteractiveMode implements InteractiveModeContext {
 	handleBtwCommand(question: string): Promise<void> {
 		return this.#btwController.start(question);
 	}
+	handleBtwRCommand(question: string): Promise<void> {
+		return this.#btwController.startRetained(question);
+	}
+
 
 	hasActiveBtw(): boolean {
-		return this.#btwController.hasActiveRequest();
+		return this.#btwController.hasOpenPanel();
+	}
+
+	hasActiveBtwR(): boolean {
+		return this.#btwController.hasOpenRetainedThread();
+	}
+
+	handleBtwRFollowUp(question: string): Promise<"accepted" | "busy" | "closed"> {
+		return this.#btwController.submitRetainedFollowUp(question);
 	}
 
 	handleBtwEscape(): boolean {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2975,7 +2975,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#btwController.startRetained(question);
 	}
 
-
 	hasActiveBtw(): boolean {
 		return this.#btwController.hasOpenPanel();
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -336,7 +336,10 @@ export interface InteractiveModeContext {
 	handleBackgroundCommand(): void;
 	handleImagePaste(): Promise<boolean>;
 	handleBtwCommand(question: string): Promise<void>;
+	handleBtwRCommand(question: string): Promise<void>;
 	hasActiveBtw(): boolean;
+	hasActiveBtwR(): boolean;
+	handleBtwRFollowUp(question: string): Promise<"accepted" | "busy" | "closed">;
 	handleBtwEscape(): boolean;
 	cycleThinkingLevel(): void;
 	cycleRoleModel(options?: { temporary?: boolean }): Promise<void>;

--- a/packages/coding-agent/src/prompts/system/btw-r-user.md
+++ b/packages/coding-agent/src/prompts/system/btw-r-user.md
@@ -1,0 +1,7 @@
+<btw-r>
+This is the current turn of an ephemeral retained side chat for the interactive session.
+Answer directly using the conversation context and prior side-chat turns already provided.
+Do not use tools.
+Question:
+{{question}}
+</btw-r>

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -12997,15 +12997,19 @@ export class AgentSession {
 	 * does not block on, or interfere with, any in-flight main turn.  The
 	 * session's history and persisted state are NOT modified by this call.
 	 *
-	 * Used by `respondAsBackground` (IRC) and `BtwController` (`/btw`) to share
-	 * the snapshot + stream pipeline.  The snapshot includes any in-flight
-	 * streaming assistant text so the model sees the half-finished response
-	 * rather than missing context.
+	 * Used by `respondAsBackground` (IRC) and `BtwController` (`/btw`, `/btw-r`)
+	 * to share the snapshot + stream pipeline. Optional `contextMessages` are
+	 * caller-owned side-thread turns replayed after roster prepend and before
+	 * the current virtual prompt. The snapshot includes any in-flight streaming
+	 * assistant text so the model sees the half-finished response rather than
+	 * missing context.
 	 */
 	async runEphemeralTurn(args: {
 		promptText: string;
 		onTextDelta?: (delta: string) => void;
 		signal?: AbortSignal;
+		/** Completed caller-owned side-thread messages replayed before this turn's prompt. */
+		contextMessages?: readonly AgentMessage[];
 		/** Defer the successful roster-claim commit until the caller accepts its exchange. */
 		deferRosterCommit?: boolean;
 	}): Promise<{
@@ -13033,12 +13037,16 @@ export class AgentSession {
 			if (rosterClaim && !rosterMessage) {
 				this.#releaseIrcRosterClaim(rosterClaim.token, rosterClaim.epoch);
 			}
-			let snapshot = this.#buildEphemeralSnapshot(args.promptText, rosterMessage ? [rosterMessage] : undefined);
+			let snapshot = this.#buildEphemeralSnapshot(
+				args.promptText,
+				args.contextMessages,
+				rosterMessage ? [rosterMessage] : undefined,
+			);
 			let llmMessages = await this.convertMessagesToLlm(snapshot, args.signal);
 			if (rosterMessage && !this.#isCurrentIrcRosterClaim(rosterClaim!.token, rosterClaim!.epoch)) {
 				this.#releaseIrcRosterClaim(rosterClaim!.token, rosterClaim!.epoch);
 				// Conversion is asynchronous, so rebuild without a claim invalidated while it awaited.
-				snapshot = this.#buildEphemeralSnapshot(args.promptText);
+				snapshot = this.#buildEphemeralSnapshot(args.promptText, args.contextMessages);
 				llmMessages = await this.convertMessagesToLlm(snapshot, args.signal);
 			}
 			const context: Context = {
@@ -13120,7 +13128,11 @@ export class AgentSession {
 	 * the partial response in context, then appends the prompt as a virtual
 	 * user message.
 	 */
-	#buildEphemeralSnapshot(promptText: string, prependMessages?: AgentMessage[]): AgentMessage[] {
+	#buildEphemeralSnapshot(
+		promptText: string,
+		contextMessages?: readonly AgentMessage[],
+		prependMessages?: readonly AgentMessage[],
+	): AgentMessage[] {
 		const messages = [...this.messages];
 		const streaming = this.agent.state.streamMessage;
 		if (streaming && streaming.role === "assistant") {
@@ -13152,6 +13164,7 @@ export class AgentSession {
 			}
 		}
 		if (prependMessages) messages.push(...prependMessages);
+		if (contextMessages) messages.push(...contextMessages);
 		messages.push({
 			role: "user",
 			content: [{ type: "text", text: promptText }],

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1468,6 +1468,17 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "btw-r",
+		description: "Start an ephemeral retained side chat using the current session context",
+		inlineHint: "<question>",
+		allowArgs: true,
+		handleTui: async (command, runtime) => {
+			const question = command.text.slice(`/${command.name}`.length).trim();
+			runtime.ctx.editor.setText("");
+			await runtime.ctx.handleBtwRCommand(question);
+		},
+	},
+	{
 		name: "retry",
 		priority: 70,
 		description: "Retry or continue the last interrupted turn",

--- a/packages/coding-agent/test/agent-session-ephemeral-context.test.ts
+++ b/packages/coding-agent/test/agent-session-ephemeral-context.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { Agent, type AgentMessage } from "@gajae-code/agent-core";
+import { type AssistantMessage, type Usage } from "@gajae-code/ai";
+import { convertToLlm } from "@gajae-code/coding-agent/session/messages";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentRegistry } from "@gajae-code/coding-agent/registry/agent-registry";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { createMockModel, registerMockApi, type MockModel } from "@gajae-code/ai/providers/mock";
+
+registerMockApi();
+
+const usage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const sessions: AgentSession[] = [];
+
+afterEach(async () => {
+	for (const session of sessions.splice(0)) await session.dispose();
+});
+
+function user(text: string): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp: 1 };
+}
+
+function assistant(text: string, thinking?: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			...(thinking ? [{ type: "thinking" as const, thinking }] : []),
+			{ type: "text", text },
+		],
+		api: "mock",
+		provider: "mock",
+		model: "mock-model",
+		usage,
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+function text(message: AgentMessage): string {
+	if (message.role !== "user" && message.role !== "assistant") return "";
+	const content = message.content;
+	if (typeof content === "string") return content;
+	return content
+		.filter((block): block is { type: "text"; text: string } => block.type === "text")
+		.map(block => block.text)
+		.join("");
+}
+
+function createHarness(options: { onConvert?: (messages: AgentMessage[]) => Promise<void> } = {}): {
+	session: AgentSession;
+	model: MockModel;
+	snapshots: AgentMessage[][];
+	registry: AgentRegistry;
+} {
+	const model = createMockModel({ handler: () => ({ content: ["ephemeral reply"] }) });
+	const snapshots: AgentMessage[][] = [];
+	const registry = new AgentRegistry();
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: {
+			model,
+			systemPrompt: ["system prompt"],
+			messages: [user("main user"), assistant("main assistant")],
+			tools: [],
+		},
+		streamFn: model.stream,
+		convertToLlm: async messages => convertToLlm(messages),
+	});
+	const session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(),
+		settings: Settings.isolated({ "compaction.enabled": false }),
+		modelRegistry: { getApiKey: async () => "test-key", getAvailable: () => [model] } as never,
+		agentId: "0-Main",
+		agentRegistry: registry,
+		convertToLlm: async messages => {
+			snapshots.push([...messages]);
+			await options.onConvert?.(messages);
+			return convertToLlm(messages);
+		},
+	});
+	sessions.push(session);
+	return { session, model, snapshots, registry };
+}
+
+function addPeer(registry: AgentRegistry): void {
+	registry.register({
+		id: "1-Worker",
+		displayName: "Worker",
+		rosterLabel: "Worker",
+		kind: "sub",
+		session: null,
+		status: "running",
+	});
+}
+
+describe("AgentSession ephemeral context", () => {
+	it("replays main messages, caller context, and the virtual prompt in order without mutation or tools", async () => {
+		const { session, model, snapshots } = createHarness();
+		const context = [user("first question"), assistant("first answer"), user("second question"), assistant("second answer", "private reasoning")];
+		const contextBefore = structuredClone(context);
+		const sessionBefore = structuredClone(session.messages);
+
+		await session.runEphemeralTurn({ promptText: "current prompt", contextMessages: context });
+
+		expect(snapshots).toHaveLength(1);
+		expect(snapshots[0]?.map(message => `${message.role}:${text(message)}`)).toEqual([
+			"user:main user",
+			"assistant:main assistant",
+			"user:first question",
+			"assistant:first answer",
+			"user:second question",
+			"assistant:second answer",
+			"user:current prompt",
+		]);
+		expect(snapshots[0]?.[5]).toBe(context[3]);
+		expect((snapshots[0]?.[5] as AssistantMessage).content).toContainEqual({ type: "thinking", thinking: "private reasoning" });
+		expect(context).toEqual(contextBefore);
+		expect(session.messages).toEqual(sessionBefore);
+		expect(model.calls[0]?.context.tools).toEqual([]);
+		expect(model.calls[0]?.options?.toolChoice).toBe("none");
+	});
+
+	it("preserves caller context when an IRC roster claim is invalidated during conversion", async () => {
+		let session!: AgentSession;
+		let conversions = 0;
+		const harness = createHarness({
+			onConvert: async () => {
+				conversions += 1;
+				if (conversions === 1) await session.newSession();
+			},
+		});
+		session = harness.session;
+		addPeer(harness.registry);
+		const context = [user("retained question"), assistant("retained answer", "reasoning")];
+
+		await session.runEphemeralTurn({ promptText: "current prompt", contextMessages: context });
+
+		expect(harness.snapshots).toHaveLength(2);
+		expect(JSON.stringify(harness.snapshots[0])).toContain("irc-peer-roster");
+		expect(JSON.stringify(harness.snapshots[1])).not.toContain("irc-peer-roster");
+		expect(harness.snapshots[1]?.map(message => `${message.role}:${text(message)}`)).toEqual([
+			"user:retained question",
+			"assistant:retained answer",
+			"user:current prompt",
+		]);
+		expect(harness.snapshots[1]?.[1]).toBe(context[1]);
+	});
+});

--- a/packages/coding-agent/test/agent-session-ephemeral-context.test.ts
+++ b/packages/coding-agent/test/agent-session-ephemeral-context.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { Agent, type AgentMessage } from "@gajae-code/agent-core";
-import { type AssistantMessage, type Usage } from "@gajae-code/ai";
-import { convertToLlm } from "@gajae-code/coding-agent/session/messages";
+import type { AssistantMessage, Usage } from "@gajae-code/ai";
+import { createMockModel, type MockModel, registerMockApi } from "@gajae-code/ai/providers/mock";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { AgentRegistry } from "@gajae-code/coding-agent/registry/agent-registry";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { convertToLlm } from "@gajae-code/coding-agent/session/messages";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
-import { createMockModel, registerMockApi, type MockModel } from "@gajae-code/ai/providers/mock";
 
 registerMockApi();
 
@@ -32,10 +32,7 @@ function user(text: string): AgentMessage {
 function assistant(text: string, thinking?: string): AssistantMessage {
 	return {
 		role: "assistant",
-		content: [
-			...(thinking ? [{ type: "thinking" as const, thinking }] : []),
-			{ type: "text", text },
-		],
+		content: [...(thinking ? [{ type: "thinking" as const, thinking }] : []), { type: "text", text }],
 		api: "mock",
 		provider: "mock",
 		model: "mock-model",
@@ -106,7 +103,12 @@ function addPeer(registry: AgentRegistry): void {
 describe("AgentSession ephemeral context", () => {
 	it("replays main messages, caller context, and the virtual prompt in order without mutation or tools", async () => {
 		const { session, model, snapshots } = createHarness();
-		const context = [user("first question"), assistant("first answer"), user("second question"), assistant("second answer", "private reasoning")];
+		const context = [
+			user("first question"),
+			assistant("first answer"),
+			user("second question"),
+			assistant("second answer", "private reasoning"),
+		];
 		const contextBefore = structuredClone(context);
 		const sessionBefore = structuredClone(session.messages);
 
@@ -123,7 +125,10 @@ describe("AgentSession ephemeral context", () => {
 			"user:current prompt",
 		]);
 		expect(snapshots[0]?.[5]).toBe(context[3]);
-		expect((snapshots[0]?.[5] as AssistantMessage).content).toContainEqual({ type: "thinking", thinking: "private reasoning" });
+		expect((snapshots[0]?.[5] as AssistantMessage).content).toContainEqual({
+			type: "thinking",
+			thinking: "private reasoning",
+		});
 		expect(context).toEqual(contextBefore);
 		expect(session.messages).toEqual(sessionBefore);
 		expect(model.calls[0]?.context.tools).toEqual([]);

--- a/packages/coding-agent/test/modes/components/btw-panel.test.ts
+++ b/packages/coding-agent/test/modes/components/btw-panel.test.ts
@@ -1,0 +1,64 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { BtwPanelComponent } from "@gajae-code/coding-agent/modes/components/btw-panel";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { Component, TUI } from "@gajae-code/tui";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+function makeTui(): TUI {
+	return { requestRender: vi.fn() } as unknown as TUI;
+}
+
+function renderTree(component: Component, width = 80): string {
+	const lines: string[] = [];
+	const walk = (node: Component) => {
+		if (typeof (node as { render?: (width: number) => string[] }).render === "function") {
+			lines.push(...(node as { render: (width: number) => string[] }).render(width));
+		}
+		const children = (node as { children?: Component[] }).children;
+		if (Array.isArray(children)) {
+			for (const child of children) walk(child);
+		}
+	};
+	walk(component);
+	return lines.join("\n");
+}
+
+describe("BtwPanelComponent retained rendering", () => {
+	it("keeps completed turns ordered and updates only the streaming region across deltas", () => {
+		const tui = makeTui();
+		const panel = new BtwPanelComponent({ question: "First question?", retained: true, tui });
+		const initialChildren = [...panel.children];
+		panel.appendText("First ");
+		panel.appendText("answer");
+		// Streaming deltas must not rebuild the outer retained shell.
+		expect(panel.children).toEqual(initialChildren);
+		panel.markComplete();
+
+		panel.beginRetainedTurn("Second question?");
+		const afterSecondTurn = [...panel.children];
+		panel.appendText("Second answer");
+		expect(panel.children).toEqual(afterSecondTurn);
+
+		const joined = renderTree(panel);
+		expect(joined).toContain("First question?");
+		expect(joined).toContain("First answer");
+		expect(joined).toContain("Second question?");
+		expect(joined).toContain("Second answer");
+		expect(joined).toContain("Esc cancel /btw-r");
+	});
+
+	it("shows follow-up dismiss guidance after completion and clears state on close", () => {
+		const tui = makeTui();
+		const panel = new BtwPanelComponent({ question: "Only?", retained: true, tui });
+		panel.setAnswer("Done");
+		panel.markComplete();
+		expect(renderTree(panel)).toContain("Type a follow-up · Esc dismiss");
+
+		panel.close();
+		panel.appendText("should be ignored");
+		expect(renderTree(panel)).not.toContain("should be ignored");
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/btw-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-controller.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from "bun:test";
+import type { AgentMessage } from "@gajae-code/agent-core";
 import type { AssistantMessage, Usage } from "@gajae-code/ai";
 import { BtwController } from "@gajae-code/coding-agent/modes/controllers/btw-controller";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -29,6 +30,7 @@ function createAssistantMessage(text: string): AssistantMessage {
 
 interface RunEphemeralTurnArgs {
 	promptText: string;
+	contextMessages?: readonly AgentMessage[];
 	onTextDelta?: (delta: string) => void;
 	signal?: AbortSignal;
 }
@@ -157,5 +159,108 @@ describe("BtwController", () => {
 		await controller.start("Anything?");
 		expect(runEphemeralTurn).not.toHaveBeenCalled();
 		expect(ctx.showError).toHaveBeenCalled();
+	});
+	it("replays completed retained turns as raw user and returned assistant messages", async () => {
+		const firstAssistant = createAssistantMessage("First answer");
+		const runEphemeralTurn = vi
+			.fn<(args: RunEphemeralTurnArgs) => Promise<RunEphemeralTurnResult>>()
+			.mockResolvedValueOnce({ replyText: "First answer", assistantMessage: firstAssistant })
+			.mockResolvedValueOnce({ replyText: "Second answer", assistantMessage: createAssistantMessage("Second answer") });
+		const ctx = makeCtx(makeFakeSession(runEphemeralTurn));
+		const controller = new BtwController(ctx);
+
+		await controller.startRetained("  First question?  ");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(controller.hasOpenRetainedThread()).toBe(true);
+		expect(controller.isRetainedTurnInFlight()).toBe(false);
+		expect(await controller.submitRetainedFollowUp("Second question?")).toBe("accepted");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const secondCall = runEphemeralTurn.mock.calls[1]?.[0];
+		expect(secondCall?.promptText).toContain("<btw-r>");
+		expect(secondCall?.contextMessages).toHaveLength(2);
+		const firstContextMessage = secondCall?.contextMessages?.[0];
+		expect(firstContextMessage).toMatchObject({
+			role: "user",
+			content: [{ type: "text", text: "First question?" }],
+			attribution: "user",
+		});
+		expect(secondCall?.contextMessages?.[1]).toBe(firstAssistant);
+		expect(controller.isRetainedTurnInFlight()).toBe(false);
+	});
+
+	it("rejects retained follow-ups while a request is in flight", async () => {
+		const runEphemeralTurn = vi.fn(async () => new Promise<RunEphemeralTurnResult>(() => {}));
+		const ctx = makeCtx(makeFakeSession(runEphemeralTurn));
+		const controller = new BtwController(ctx);
+
+		await controller.startRetained("First?");
+		expect(await controller.submitRetainedFollowUp("Second?")).toBe("busy");
+		expect(runEphemeralTurn).toHaveBeenCalledTimes(1);
+		expect(ctx.showStatus).toHaveBeenCalledWith(expect.stringContaining("still answering"));
+	});
+	it("blocks one-shot replacement and retained re-entry while a retained thread is open", async () => {
+		const runEphemeralTurn = vi.fn(async () => new Promise<RunEphemeralTurnResult>(() => {}));
+		const ctx = makeCtx(makeFakeSession(runEphemeralTurn));
+		const controller = new BtwController(ctx);
+
+		await controller.startRetained("First?");
+		await controller.start("One-shot?");
+		await controller.startRetained("Replacement?");
+
+		expect(runEphemeralTurn).toHaveBeenCalledTimes(1);
+		expect(controller.hasOpenRetainedThread()).toBe(true);
+		expect(ctx.showStatus).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps retained complete and error panels open until Escape", async () => {
+		const runEphemeralTurn = vi
+			.fn<(args: RunEphemeralTurnArgs) => Promise<RunEphemeralTurnResult>>()
+			.mockResolvedValueOnce({ replyText: "Answer", assistantMessage: createAssistantMessage("Answer") })
+			.mockRejectedValueOnce(new Error("boom"));
+		const controller = new BtwController(makeCtx(makeFakeSession(runEphemeralTurn)));
+
+		await controller.startRetained("First?");
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(controller.hasActiveRequest()).toBe(true);
+		expect(controller.isRetainedTurnInFlight()).toBe(false);
+
+		expect(await controller.submitRetainedFollowUp("Second?")).toBe("accepted");
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(controller.hasOpenRetainedThread()).toBe(true);
+		expect(controller.isRetainedTurnInFlight()).toBe(false);
+
+		expect(controller.handleEscape()).toBe(true);
+		expect(controller.hasOpenRetainedThread()).toBe(false);
+	});
+	it("lets /btw-r replace an open one-shot /btw panel", async () => {
+		const signals: AbortSignal[] = [];
+		const runEphemeralTurn = vi
+			.fn<(args: RunEphemeralTurnArgs) => Promise<RunEphemeralTurnResult>>()
+			.mockImplementationOnce(async args => {
+				signals.push(args.signal as AbortSignal);
+				return new Promise(() => {});
+			})
+			.mockImplementationOnce(async args => {
+				signals.push(args.signal as AbortSignal);
+				return { replyText: "retained", assistantMessage: createAssistantMessage("retained") };
+			});
+		const btwContainer = new Container();
+		const controller = new BtwController(makeCtx(makeFakeSession(runEphemeralTurn), btwContainer));
+
+		await controller.start("One-shot?");
+		await controller.startRetained("Retained?");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(runEphemeralTurn).toHaveBeenCalledTimes(2);
+		expect(signals[0]?.aborted).toBe(true);
+		expect(controller.hasOpenRetainedThread()).toBe(true);
+		expect(btwContainer.children).toHaveLength(1);
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/btw-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-controller.test.ts
@@ -165,7 +165,10 @@ describe("BtwController", () => {
 		const runEphemeralTurn = vi
 			.fn<(args: RunEphemeralTurnArgs) => Promise<RunEphemeralTurnResult>>()
 			.mockResolvedValueOnce({ replyText: "First answer", assistantMessage: firstAssistant })
-			.mockResolvedValueOnce({ replyText: "Second answer", assistantMessage: createAssistantMessage("Second answer") });
+			.mockResolvedValueOnce({
+				replyText: "Second answer",
+				assistantMessage: createAssistantMessage("Second answer"),
+			});
 		const ctx = makeCtx(makeFakeSession(runEphemeralTurn));
 		const controller = new BtwController(ctx);
 
@@ -237,6 +240,41 @@ describe("BtwController", () => {
 
 		expect(controller.handleEscape()).toBe(true);
 		expect(controller.hasOpenRetainedThread()).toBe(false);
+	});
+
+	it("records failed retained turns into context so later follow-ups can see the failed question", async () => {
+		const runEphemeralTurn = vi
+			.fn<(args: RunEphemeralTurnArgs) => Promise<RunEphemeralTurnResult>>()
+			.mockRejectedValueOnce(new Error("provider unavailable"))
+			.mockResolvedValueOnce({
+				replyText: "Recovered answer",
+				assistantMessage: createAssistantMessage("Recovered answer"),
+			});
+		const controller = new BtwController(makeCtx(makeFakeSession(runEphemeralTurn)));
+
+		await controller.startRetained("Failed question?");
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(controller.hasOpenRetainedThread()).toBe(true);
+		expect(controller.isRetainedTurnInFlight()).toBe(false);
+
+		expect(await controller.submitRetainedFollowUp("try again")).toBe("accepted");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const retryCall = runEphemeralTurn.mock.calls[1]?.[0];
+		expect(retryCall?.contextMessages).toHaveLength(2);
+		expect(retryCall?.contextMessages?.[0]).toMatchObject({
+			role: "user",
+			content: [{ type: "text", text: "Failed question?" }],
+			attribution: "user",
+		});
+		expect(retryCall?.contextMessages?.[1]).toMatchObject({
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: "provider unavailable",
+			content: [{ type: "text", text: "Error: provider unavailable" }],
+		});
 	});
 	it("lets /btw-r replace an open one-shot /btw panel", async () => {
 		const signals: AbortSignal[] = [];

--- a/packages/coding-agent/test/modes/controllers/btw-escape-dismiss.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-escape-dismiss.test.ts
@@ -107,6 +107,28 @@ describe("btw panel Esc dismissal (issue #455)", () => {
 		expect(btwContainer.children).toHaveLength(0);
 	});
 
+	it("dismisses retained completed and errored panels on Esc", async () => {
+		const completed = makeHarness(async () => ({
+			replyText: "Answer",
+			assistantMessage: {},
+		}));
+		await completed.btw.startRetained("Why?");
+		await drain();
+		expect(completed.btw.hasOpenRetainedThread()).toBe(true);
+		completed.editor.handleInput(ESC);
+		expect(completed.btw.hasOpenRetainedThread()).toBe(false);
+		expect(completed.btwContainer.children).toHaveLength(0);
+
+		const errored = makeHarness(async () => {
+			throw new Error("boom");
+		});
+		await errored.btw.startRetained("Why?");
+		await drain();
+		expect(errored.btw.hasOpenRetainedThread()).toBe(true);
+		errored.editor.handleInput(ESC);
+		expect(errored.btw.hasOpenRetainedThread()).toBe(false);
+		expect(errored.btwContainer.children).toHaveLength(0);
+	});
 	it("dismisses under the kitty keyboard protocol encoding of Esc", async () => {
 		setKittyProtocolActive(true);
 		try {

--- a/packages/coding-agent/test/modes/controllers/btw-input-routing.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-input-routing.test.ts
@@ -168,16 +168,24 @@ describe("InputController retained /btw-r routing", () => {
 			disableModelInvocation: false,
 			content: "Demo skill body",
 		};
-		(harness.ctx as { skillCommands?: Map<string, typeof skill> }).skillCommands = new Map([["skill:demo", skill]]);
-		const promptCustomMessage = vi.fn(async () => {});
-		(harness.ctx.session as { promptCustomMessage?: typeof promptCustomMessage }).promptCustomMessage =
-			promptCustomMessage;
-		(harness.ctx.session as { sessionId?: string }).sessionId = "test-session";
-		(
-			harness.ctx.session as {
+		const ctxMut = harness.ctx as unknown as {
+			skillCommands: Map<string, typeof skill>;
+			session: {
+				promptCustomMessage: (
+					message: unknown,
+					options?: { streamingBehavior?: string; followUpQueuePolicy?: string },
+				) => Promise<void>;
+				sessionId?: string;
 				enqueueCustomMessageDisplay?: (text: string, behavior: string) => string;
-			}
-		).enqueueCustomMessageDisplay = vi.fn(() => "tag");
+			};
+		};
+		ctxMut.skillCommands = new Map([["skill:demo", skill]]);
+		const promptCustomMessage = vi.fn(
+			async (_message: unknown, _options?: { streamingBehavior?: string; followUpQueuePolicy?: string }) => {},
+		);
+		ctxMut.session.promptCustomMessage = promptCustomMessage;
+		ctxMut.session.sessionId = "test-session";
+		ctxMut.session.enqueueCustomMessageDisplay = vi.fn(() => "tag");
 
 		harness.editor.setText("/skill:demo args");
 		const controller = new InputController(harness.ctx);

--- a/packages/coding-agent/test/modes/controllers/btw-input-routing.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-input-routing.test.ts
@@ -156,4 +156,39 @@ describe("InputController retained /btw-r routing", () => {
 		expect(harness.prompt).not.toHaveBeenCalled();
 		expect(harness.editor.addToHistory).not.toHaveBeenCalled();
 	});
+
+	it("keeps slash-origin follow-up keybinding off the retained path so /skill:* can dispatch normally", async () => {
+		const harness = createHarness({ retainedOpen: true, streaming: true });
+		const skill = {
+			name: "demo",
+			description: "demo skill",
+			filePath: "demo.md",
+			baseDir: process.cwd(),
+			source: "user" as const,
+			disableModelInvocation: false,
+			content: "Demo skill body",
+		};
+		(harness.ctx as { skillCommands?: Map<string, typeof skill> }).skillCommands = new Map([["skill:demo", skill]]);
+		const promptCustomMessage = vi.fn(async () => {});
+		(harness.ctx.session as { promptCustomMessage?: typeof promptCustomMessage }).promptCustomMessage =
+			promptCustomMessage;
+		(harness.ctx.session as { sessionId?: string }).sessionId = "test-session";
+		(
+			harness.ctx.session as {
+				enqueueCustomMessageDisplay?: (text: string, behavior: string) => string;
+			}
+		).enqueueCustomMessageDisplay = vi.fn(() => "tag");
+
+		harness.editor.setText("/skill:demo args");
+		const controller = new InputController(harness.ctx);
+		await controller.handleFollowUp();
+
+		// Slash-origin must never enter retained capture.
+		expect(harness.handleBtwRFollowUp).not.toHaveBeenCalled();
+		expect(promptCustomMessage).toHaveBeenCalled();
+		expect(promptCustomMessage.mock.calls[0]?.[1]).toMatchObject({
+			streamingBehavior: "followUp",
+			followUpQueuePolicy: "sequential",
+		});
+	});
 });

--- a/packages/coding-agent/test/modes/controllers/btw-input-routing.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-input-routing.test.ts
@@ -1,0 +1,149 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { InputController } from "@gajae-code/coding-agent/modes/controllers/input-controller";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+});
+
+function createHarness(options: { retainedOpen?: boolean; accepted?: boolean; streaming?: boolean } = {}) {
+	let editorText = "";
+	const hasActiveBtwR = vi.fn(() => options.retainedOpen ?? false);
+	const handleBtwRFollowUp = vi.fn<(question: string) => Promise<"accepted" | "busy" | "closed">>(
+		async () => ((options.accepted ?? true) ? "accepted" : "busy"),
+	);
+	const onInputCallback = vi.fn();
+	const abort = vi.fn(async () => {});
+	const prompt = vi.fn(async () => {});
+	const editor = {
+		setText(text: string) {
+			editorText = text;
+		},
+		getText() {
+			return editorText;
+		},
+		onSubmit: undefined as undefined | ((text: string) => Promise<void>),
+		addToHistory: vi.fn(),
+		setActionKeys: vi.fn(),
+		setCustomKeyHandler: vi.fn(),
+		clearCustomKeyHandlers: vi.fn(),
+	};
+	const ctx = {
+		settings: { get: () => undefined },
+		editor,
+		ui: { requestRender: vi.fn(), addInputListener: vi.fn(() => () => {}) },
+		session: {
+			isStreaming: options.streaming ?? false,
+			isCompacting: false,
+			isBashRunning: false,
+			isEvalRunning: false,
+			queuedMessageCount: 1,
+			hasQueuedSteering: false,
+			messages: [{ role: "user", content: "existing" }],
+			extensionRunner: undefined,
+			prompt,
+			abort,
+		},
+		sessionManager: { getSessionName: () => "existing", getCwd: () => process.cwd() },
+		keybindings: { getKeys: () => [] },
+		pendingImages: [],
+		lastEscapeTime: 0,
+		lastComposerClearEscapeTime: 0,
+		isBashMode: false,
+		isBashNoContext: false,
+		isPythonMode: false,
+		locallySubmittedUserSignatures: new Set<string>(),
+		onInputCallback,
+		startPendingSubmission: vi.fn((input: { text: string }) => ({ ...input, cancelled: false, started: true })),
+		flushPendingBashComponents: vi.fn(),
+		updateEditorBorderColor: vi.fn(),
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+		handleBashCommand: vi.fn(),
+		handlePythonCommand: vi.fn(),
+		handleBackgroundCommand: vi.fn(),
+		handleBtwCommand: vi.fn(async () => {}),
+		hasActiveBtw: vi.fn(() => false),
+		handleBtwEscape: vi.fn(() => false),
+		hasActiveBtwR,
+		handleBtwRFollowUp,
+	} as unknown as InteractiveModeContext;
+	new InputController(ctx).setupEditorSubmitHandler();
+	return { ctx, editor, hasActiveBtwR, handleBtwRFollowUp, onInputCallback, abort, prompt };
+}
+
+async function submit(
+	harness: { editor: { setText(text: string): void; onSubmit?: (text: string) => Promise<void> } },
+	text: string,
+) {
+	harness.editor.setText(text);
+	await harness.editor.onSubmit?.(text);
+}
+
+describe("InputController retained /btw-r routing", () => {
+	it("captures empty, continuation literals, plain text, bash, and Python only while retained is open", async () => {
+		const open = createHarness({ retainedOpen: true, streaming: true });
+		await submit(open, "");
+		expect(open.abort).not.toHaveBeenCalled();
+		expect(open.handleBtwRFollowUp).not.toHaveBeenCalled();
+
+		for (const text of [".", "c", "plain follow-up", "!pwd", "$1 + 1"]) await submit(open, text);
+		expect(open.handleBtwRFollowUp.mock.calls.map(call => call[0])).toEqual([".", "c", "plain follow-up", "!pwd", "$1 + 1"]);
+		expect(open.onInputCallback).not.toHaveBeenCalled();
+		expect(open.editor.addToHistory).not.toHaveBeenCalled();
+		expect(open.editor.getText()).toBe("");
+
+		const closed = createHarness({ retainedOpen: false, streaming: true });
+		await submit(closed, "");
+		expect(closed.abort).toHaveBeenCalledTimes(1);
+		await submit(closed, ".");
+		await submit(closed, "c");
+		await submit(closed, "!pwd");
+		await submit(closed, "$1 + 1");
+		expect(closed.ctx.handleBashCommand).toHaveBeenCalledWith("pwd", false);
+		expect(closed.ctx.handlePythonCommand).toHaveBeenCalledWith("1 + 1", false);
+		expect(closed.onInputCallback).toHaveBeenCalledWith({ text: "", cancelled: false, started: true });
+		expect(closed.handleBtwRFollowUp).not.toHaveBeenCalled();
+	});
+
+	it("preserves the draft when a retained follow-up is busy", async () => {
+		const harness = createHarness({ retainedOpen: true, accepted: false });
+		await submit(harness, "wait for the current answer");
+		expect(harness.handleBtwRFollowUp).toHaveBeenCalledWith("wait for the current answer");
+		expect(harness.editor.getText()).toBe("wait for the current answer");
+		expect(harness.onInputCallback).not.toHaveBeenCalled();
+	});
+
+	it("keeps slash-origin input on normal dispatch, including a prompt-returning command", async () => {
+		const harness = createHarness({ retainedOpen: true });
+		await submit(harness, "/btw a known slash");
+		expect(harness.ctx.handleBtwCommand).toHaveBeenCalledWith("a known slash");
+		expect(harness.handleBtwRFollowUp).not.toHaveBeenCalled();
+
+		await submit(harness, "/provicer");
+		expect(harness.ctx.showError).toHaveBeenCalled();
+		expect(harness.handleBtwRFollowUp).not.toHaveBeenCalled();
+
+		await submit(harness, "/notify on");
+		expect(harness.onInputCallback).toHaveBeenLastCalledWith({ text: "/notify on", cancelled: false, started: true });
+		expect(harness.handleBtwRFollowUp).not.toHaveBeenCalled();
+	});
+
+	it("returns to the main input path after Esc closes the retained thread", async () => {
+		const harness = createHarness({ retainedOpen: false });
+		await submit(harness, "main prompt after Esc");
+		expect(harness.onInputCallback).toHaveBeenCalledWith({ text: "main prompt after Esc", cancelled: false, started: true });
+		expect(harness.handleBtwRFollowUp).not.toHaveBeenCalled();
+	});
+	it("routes explicit follow-up keybinding into the retained thread instead of the main session", async () => {
+		const harness = createHarness({ retainedOpen: true, streaming: true });
+		harness.editor.setText("follow-up via keybinding");
+		const controller = new InputController(harness.ctx);
+		await controller.handleFollowUp();
+		expect(harness.handleBtwRFollowUp).toHaveBeenCalledWith("follow-up via keybinding");
+		expect(harness.editor.getText()).toBe("");
+		expect(harness.prompt).not.toHaveBeenCalled();
+		expect(harness.editor.addToHistory).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/btw-input-routing.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-input-routing.test.ts
@@ -10,8 +10,8 @@ beforeAll(async () => {
 function createHarness(options: { retainedOpen?: boolean; accepted?: boolean; streaming?: boolean } = {}) {
 	let editorText = "";
 	const hasActiveBtwR = vi.fn(() => options.retainedOpen ?? false);
-	const handleBtwRFollowUp = vi.fn<(question: string) => Promise<"accepted" | "busy" | "closed">>(
-		async () => ((options.accepted ?? true) ? "accepted" : "busy"),
+	const handleBtwRFollowUp = vi.fn<(question: string) => Promise<"accepted" | "busy" | "closed">>(async () =>
+		(options.accepted ?? true) ? "accepted" : "busy",
 	);
 	const onInputCallback = vi.fn();
 	const abort = vi.fn(async () => {});
@@ -89,7 +89,13 @@ describe("InputController retained /btw-r routing", () => {
 		expect(open.handleBtwRFollowUp).not.toHaveBeenCalled();
 
 		for (const text of [".", "c", "plain follow-up", "!pwd", "$1 + 1"]) await submit(open, text);
-		expect(open.handleBtwRFollowUp.mock.calls.map(call => call[0])).toEqual([".", "c", "plain follow-up", "!pwd", "$1 + 1"]);
+		expect(open.handleBtwRFollowUp.mock.calls.map(call => call[0])).toEqual([
+			".",
+			"c",
+			"plain follow-up",
+			"!pwd",
+			"$1 + 1",
+		]);
 		expect(open.onInputCallback).not.toHaveBeenCalled();
 		expect(open.editor.addToHistory).not.toHaveBeenCalled();
 		expect(open.editor.getText()).toBe("");
@@ -133,7 +139,11 @@ describe("InputController retained /btw-r routing", () => {
 	it("returns to the main input path after Esc closes the retained thread", async () => {
 		const harness = createHarness({ retainedOpen: false });
 		await submit(harness, "main prompt after Esc");
-		expect(harness.onInputCallback).toHaveBeenCalledWith({ text: "main prompt after Esc", cancelled: false, started: true });
+		expect(harness.onInputCallback).toHaveBeenCalledWith({
+			text: "main prompt after Esc",
+			cancelled: false,
+			started: true,
+		});
 		expect(harness.handleBtwRFollowUp).not.toHaveBeenCalled();
 	});
 	it("routes explicit follow-up keybinding into the retained thread instead of the main session", async () => {

--- a/packages/coding-agent/test/modes/controllers/btw-input-routing.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-input-routing.test.ts
@@ -157,6 +157,38 @@ describe("InputController retained /btw-r routing", () => {
 		expect(harness.editor.addToHistory).not.toHaveBeenCalled();
 	});
 
+	it("captures non-slash text with an embedded skill command in the retained thread", async () => {
+		const harness = createHarness({ retainedOpen: true });
+		const skill = {
+			name: "demo",
+			description: "demo skill",
+			filePath: "demo.md",
+			baseDir: process.cwd(),
+			source: "user" as const,
+			disableModelInvocation: false,
+			content: "Demo skill body",
+		};
+		const ctxMut = harness.ctx as unknown as {
+			skillCommands: Map<string, typeof skill>;
+			session: {
+				promptCustomMessage: (
+					message: unknown,
+					options?: { streamingBehavior?: string; followUpQueuePolicy?: string },
+				) => Promise<void>;
+			};
+		};
+		ctxMut.skillCommands = new Map([["skill:demo", skill]]);
+		const promptCustomMessage = vi.fn(
+			async (_message: unknown, _options?: { streamingBehavior?: string; followUpQueuePolicy?: string }) => {},
+		);
+		ctxMut.session.promptCustomMessage = promptCustomMessage;
+
+		await submit(harness, "what does /skill:demo do?");
+
+		expect(harness.handleBtwRFollowUp).toHaveBeenCalledWith("what does /skill:demo do?");
+		expect(promptCustomMessage).not.toHaveBeenCalled();
+		expect(harness.onInputCallback).not.toHaveBeenCalled();
+	});
 	it("keeps slash-origin follow-up keybinding off the retained path so /skill:* can dispatch normally", async () => {
 		const harness = createHarness({ retainedOpen: true, streaming: true });
 		const skill = {

--- a/packages/coding-agent/test/slash-commands/btw.test.ts
+++ b/packages/coding-agent/test/slash-commands/btw.test.ts
@@ -4,14 +4,17 @@ import { executeBuiltinSlashCommand } from "@gajae-code/coding-agent/slash-comma
 
 function createRuntime() {
 	const handleBtwCommand = vi.fn(async () => {});
+	const handleBtwRCommand = vi.fn(async () => {});
 	const setText = vi.fn();
 	return {
 		handleBtwCommand,
+		handleBtwRCommand,
 		setText,
 		runtime: {
 			ctx: {
 				editor: { setText } as unknown as InteractiveModeContext["editor"],
 				handleBtwCommand,
+				handleBtwRCommand,
 			} as unknown as InteractiveModeContext,
 			handleBackgroundCommand: () => {},
 		},
@@ -39,5 +42,14 @@ describe("/btw slash command", () => {
 
 		expect(handled).toBe(true);
 		expect(harness.handleBtwCommand).toHaveBeenCalledWith("explain why the cache reuse matters here");
+	});
+	it("registers /btw-r and preserves its full question suffix", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/btw-r explain this in more detail", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setText).toHaveBeenCalledWith("");
+		expect(harness.handleBtwRCommand).toHaveBeenCalledWith("explain this in more detail");
 	});
 });


### PR DESCRIPTION
## Summary
- Keep one-shot `/btw` unchanged.
- Add `/btw-r` as a same-panel temporary multi-turn side chat that reuses the existing BTW controller/panel path.
- While the retained panel is open, plain editor text becomes follow-ups; slash commands still dispatch normally; tools stay off; the main session transcript is not written; Esc closes the panel.
- Thread context is main-session snapshot + retained Q/A pairs via structured `contextMessages` on both ephemeral snapshot paths (including IRC roster rebuild).

## Why
Users sometimes need a short multi-turn clarification without polluting the main agent transcript. `/btw` already covers one-shot ephemeral Q&A; `/btw-r` covers the retained multi-turn case with the same mental model.

## Test plan
- [x] `bun test packages/coding-agent/test/slash-commands/btw.test.ts`
- [x] `bun test packages/coding-agent/test/modes/controllers/btw-controller.test.ts`
- [x] `bun test packages/coding-agent/test/modes/controllers/btw-escape-dismiss.test.ts`
- [x] `bun test packages/coding-agent/test/modes/controllers/btw-input-routing.test.ts`
- [x] `bun test packages/coding-agent/test/modes/components/btw-panel.test.ts`
- [x] `bun test packages/coding-agent/test/agent-session-ephemeral-context.test.ts`
- [x] Focused suite total: 29 pass / 0 fail

## Notes
- Scope is implement + focused tests only; no broader docs/changelog sweep in this PR.
- Absorption-friendly core: retained mode discrimination, input capture matrix, structured ephemeral context, panel multi-turn render.