### PR TITLE
refactor(coding-agent): rename isUnattended to supportsRemoteGateAnswers

### DIFF
--- a/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-broker.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-broker.ts
@@ -88,7 +88,7 @@ export interface AskSelectedAckRecoveryParticipant {
 
 /** SDK-native surface for emitting a workflow gate and awaiting its answer. */
 export interface WorkflowGateEmitter {
-	isUnattended(): boolean;
+	supportsRemoteGateAnswers(): boolean;
 	emitGate(input: OpenGateInput): Promise<unknown>;
 	onGateEmitted?(listener: (gate: WorkflowGate) => void): () => void;
 	resolveGate?(response: WorkflowGateResponse): Promise<WorkflowGateResolution>;
@@ -155,7 +155,7 @@ export class BrokerWorkflowGateEmitter implements WorkflowGateEmitter {
 		});
 	}
 
-	isUnattended(): boolean {
+	supportsRemoteGateAnswers(): boolean {
 		return true;
 	}
 

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -3193,7 +3193,7 @@ export function createNotificationsExtension(
 				}
 				const gate = runtime?.workflowGate;
 				const workflowGateActive =
-					gate?.isUnattended?.() === true &&
+					gate?.supportsRemoteGateAnswers?.() === true &&
 					typeof gate.onGateEmitted === "function" &&
 					typeof gate.resolveGateFromNotification === "function";
 				const gateId = gatePresentations.routeFor(reply.id);

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -759,12 +759,13 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 		};
 		const gateEmitter = this.session.getWorkflowGateEmitter?.();
 		// A durable workflow-gate emitter now exists for every session, and its
-		// isUnattended() is always true, so it can no longer signal "no local UI".
-		// The workflow gate is only the headless (non-TUI) answer path: when a real
-		// interactive UI is present, prefer it — otherwise attended TUI asks would
-		// route to emitGate() and hang forever waiting on a remote responder.
+		// supportsRemoteGateAnswers() is always true, so it can no longer signal
+		// "no local UI". The workflow gate is only the headless (non-TUI) answer
+		// path: when a real interactive UI is present, prefer it — otherwise
+		// attended TUI asks would route to emitGate() and hang forever waiting on
+		// a remote responder.
 		const hasInteractiveUi = context?.hasUI === true && !!context.ui;
-		const canUseWorkflowGate = !hasInteractiveUi && gateEmitter?.isUnattended() === true;
+		const canUseWorkflowGate = !hasInteractiveUi && gateEmitter?.supportsRemoteGateAnswers() === true;
 		// Headless fallback: SDK workflow gates are the non-TUI answer path.
 		if (!canUseWorkflowGate && (!context?.hasUI || !context.ui)) {
 			context?.abort();

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -3012,7 +3012,7 @@ test("SDK host omits direct workflow controls for a legacy workflow-gate emitter
 	dirs.push(cwd);
 	const sessionId = `legacy-workflow-gate-${Date.now()}`;
 	const legacyEmitter = {
-		isUnattended: () => true,
+		supportsRemoteGateAnswers: () => true,
 		emitGate: async () => undefined,
 		resolveGate: async () => ({
 			gate_id: "legacy-gate",

--- a/packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts
+++ b/packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts
@@ -58,7 +58,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 				publishedEmitter = emitter;
 			});
 			const emitter: WorkflowGateEmitter = {
-				isUnattended: () => true,
+				supportsRemoteGateAnswers: () => true,
 				emitGate: input => {
 					received.push(input);
 					return Promise.resolve({ selected: ["JWT"], other: false });
@@ -115,7 +115,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 
 			const received: OpenGateInput[] = [];
 			const emitter: WorkflowGateEmitter = {
-				isUnattended: () => true,
+				supportsRemoteGateAnswers: () => true,
 				emitGate: input => {
 					received.push(input);
 					return Promise.resolve({ selected: ["JWT"], other: false });

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -2385,7 +2385,7 @@ describe("AskTool deep-interview recorder persistence", () => {
 		);
 
 		const gateEmitter = {
-			isUnattended: () => true,
+			supportsRemoteGateAnswers: () => true,
 			emitGate: vi.fn(async () => ({ selected: ["Timeline"] })),
 		};
 		await new AskTool(
@@ -2403,7 +2403,7 @@ describe("AskTool deep-interview recorder persistence", () => {
 
 	it("emits deep-interview question gates by default and honors ralplan approval overrides", async () => {
 		const defaultGateEmitter = {
-			isUnattended: () => true,
+			supportsRemoteGateAnswers: () => true,
 			emitGate: vi.fn(async () => ({ selected: ["Budget"] })),
 		};
 		await new AskTool(
@@ -2423,7 +2423,7 @@ describe("AskTool deep-interview recorder persistence", () => {
 		);
 
 		const ralplanGateEmitter = {
-			isUnattended: () => true,
+			supportsRemoteGateAnswers: () => true,
 			emitGate: vi.fn(async () => ({ selected: ["Approve execution via ultragoal"] })),
 		};
 		await new AskTool(
@@ -2452,10 +2452,10 @@ describe("AskTool deep-interview recorder persistence", () => {
 
 	it("prefers the local interactive UI over the workflow gate when a UI context is present", async () => {
 		// Regression: a durable workflow-gate emitter now exists for every session and
-		// its isUnattended() is always true. Attended TUI asks must still use the local
+		// its supportsRemoteGateAnswers() is always true. Attended TUI asks must still use the local
 		// selector instead of stranding on emitGate() waiting for a remote responder.
 		const gateEmitter = {
-			isUnattended: () => true,
+			supportsRemoteGateAnswers: () => true,
 			emitGate: vi.fn(async () => ({ selected: ["no"] })),
 		};
 		const select = vi.fn(async () => "yes");


### PR DESCRIPTION
## Summary

`BrokerWorkflowGateEmitter.isUnattended()` always returns `true`, so its name lies about its semantics. It is used as a workflow-gate *capability* check ("can this emitter deliver remote gate answers?"), not an attendance check. `ask.ts` already works around this by checking `hasInteractiveUi` locally; `sdk/bus/index.ts` uses it as a gate-capability probe.

This renames `isUnattended()` → `supportsRemoteGateAnswers()` to describe what the method actually means. Clean rename only — no alias, no behavioral change.

## Changes

- `workflow-gate-broker.ts`: rename the `WorkflowGateEmitter` interface method and the `BrokerWorkflowGateEmitter` implementation (`return true` unchanged).
- `tools/ask.ts`: `canUseWorkflowGate = !hasInteractiveUi && gateEmitter?.supportsRemoteGateAnswers() === true`. Updated the explanatory comment to reference the new name. Boolean logic and the attended/headless truth table are unchanged.
- `sdk/bus/index.ts`: `gate?.supportsRemoteGateAnswers?.() === true &&` in the `workflowGateActive` probe.
- Tests updated to the new method name:
  - `test/tools/ask.test.ts` (4 stub emitters + 1 comment)
  - `test/sdk-workflow-gate-emitter.test.ts` (2 stub emitters)
  - `test/sdk-host-wiring.test.ts` (1 stub emitter)
  - `test/workflow-gate-broker.test.ts` — no change needed (it tests `WorkflowGateBroker`/stores directly and never referenced `isUnattended` or constructed `BrokerWorkflowGateEmitter`).

## Mode truth table (unchanged)

| `hasInteractiveUi` | `supportsRemoteGateAnswers()` | `canUseWorkflowGate` | Path |
|---|---|---|---|
| `true` (attended TUI) | `true` | `false` | local UI selector (no hang) |
| `false` (headless) | `true` | `true` | `emitGate()` remote answer path |
| `false` (headless) | absent | `false` | abort: "Ask tool requires interactive mode" |

The rename preserves the exact boolean expression; only the method name changed.

## Verification

- `bun test packages/coding-agent/test/workflow-gate-broker.test.ts` → 19 pass, 0 fail.
- `tsc --noEmit -p packages/coding-agent/tsconfig.json` → exit 0, no type errors (confirms the rename is type-consistent across the interface, implementation, and all three consumer test stubs).
- The other three listed tests (`ask.test.ts`, `sdk-workflow-gate-emitter.test.ts`, `sdk-host-wiring.test.ts`) transitively import `@gajae-code/natives`, whose native addon (`pi_natives.darwin-arm64.node`) cannot be built in this environment: the Rust build fails on `crates/pi-natives/src/path_identity.rs:508` (`st_mtimespec` field removed in the installed `libc` 0.2.186), and the host's prebuilt addon is version-incompatible with the current loader sentinel. This is a pre-existing workstation-wide native-build issue (the host checkout fails identically) and is independent of this pure-TypeScript rename. CI, which builds natives successfully, will run these tests.
