### PR TITLE
fix(coding-agent): delete dead duplicate CLI help exports

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -1,11 +1,10 @@
 /**
- * CLI argument parsing and help display
+ * CLI argument parsing
  */
 import * as path from "node:path";
 import { type Effort, THINKING_EFFORTS } from "@gajae-code/ai";
-import { APP_NAME, CONFIG_DIR_NAME, logger } from "@gajae-code/utils";
+import { logger } from "@gajae-code/utils";
 import { CliParseError } from "@gajae-code/utils/cli";
-import chalk from "chalk";
 import { parseEffort } from "../thinking";
 import { BUILTIN_TOOLS } from "../tools";
 
@@ -252,93 +251,4 @@ export function parseArgs(args: string[]): Args {
 	}
 
 	return result;
-}
-
-export function getExtraHelpText(): string {
-	return `${chalk.bold("Environment Variables:")}
-  ${chalk.dim("# Core Providers")}
-  ANTHROPIC_API_KEY          - Anthropic Claude models
-  ANTHROPIC_OAUTH_TOKEN      - Anthropic OAuth (takes precedence over API key)
-  CLAUDE_CODE_USE_FOUNDRY    - Enable Anthropic Foundry mode (uses Foundry endpoint + mTLS)
-  FOUNDRY_BASE_URL           - Anthropic Foundry base URL (e.g., https://<foundry-host>)
-  ANTHROPIC_FOUNDRY_API_KEY  - Anthropic token used as Authorization: Bearer <token> in Foundry mode
-  ANTHROPIC_CUSTOM_HEADERS   - Extra Foundry headers (e.g., "user-id: USERNAME")
-  CLAUDE_CODE_CLIENT_CERT    - Client certificate (PEM path or inline PEM) for mTLS
-  CLAUDE_CODE_CLIENT_KEY     - Client private key (PEM path or inline PEM) for mTLS
-  NODE_EXTRA_CA_CERTS        - CA bundle path (or inline PEM) for server certificate validation
-  OPENAI_API_KEY             - OpenAI GPT models
-  GEMINI_API_KEY             - Google Gemini models
-  GITHUB_TOKEN               - GitHub Copilot (or GH_TOKEN, COPILOT_GITHUB_TOKEN)
-
-  ${chalk.dim("# Additional LLM Providers")}
-  AZURE_OPENAI_API_KEY       - Azure OpenAI models
-  GROQ_API_KEY               - Groq models
-  CEREBRAS_API_KEY           - Cerebras models
-  XAI_API_KEY                - xAI Grok models
-  OPENROUTER_API_KEY         - OpenRouter aggregated models
-  KILO_API_KEY               - Kilo Gateway models
-  MISTRAL_API_KEY            - Mistral models
-  ZAI_API_KEY                - z.ai models (ZhipuAI/GLM)
-  MINIMAX_API_KEY            - MiniMax models
-  OPENCODE_API_KEY           - OpenCode Zen/OpenCode Go models
-  CURSOR_ACCESS_TOKEN        - Cursor AI models
-  AI_GATEWAY_API_KEY         - Vercel AI Gateway
-
-  ${chalk.dim("# Cloud Providers")}
-  AWS_PROFILE                - AWS Bedrock (or AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY)
-  GOOGLE_CLOUD_PROJECT       - Google Vertex AI (requires GOOGLE_CLOUD_LOCATION)
-  GOOGLE_APPLICATION_CREDENTIALS - Service account for Vertex AI
-
-  ${chalk.dim("# Search & Tools")}
-  EXA_API_KEY                - Exa web search
-  BRAVE_API_KEY              - Brave web search
-  PERPLEXITY_API_KEY         - Perplexity web search (API)
-  PERPLEXITY_COOKIES         - Perplexity web search (session cookie)
-  TAVILY_API_KEY             - Tavily web search
-  ANTHROPIC_SEARCH_API_KEY   - Anthropic search provider
-
-  ${chalk.dim("# Configuration")}
-  GJC_CODING_AGENT_DIR       - Session storage directory (default: ~/${CONFIG_DIR_NAME}/agent)
-  GJC_PACKAGE_DIR            - Override package directory (for Nix/Guix store paths)
-  GJC_SMOL_MODEL              - Override smol/fast model (see --smol)
-  GJC_SLOW_MODEL              - Override slow/reasoning model (see --slow)
-  GJC_PLAN_MODEL              - Override planning model (see --plan)
-  GJC_NO_PTY                  - Disable PTY-based interactive bash execution
-  --tmux                       - Launch interactive startup inside a fresh tmux session
-  gjc session                  - List, inspect, create, remove, or attach tagged GJC-managed tmux sessions
-  GJC_LAUNCH_POLICY           - Launch policy for --tmux startup: tmux or direct
-  GJC_TMUX_SESSION            - Explicit tmux session name override for --tmux startup
-  GJC_TMUX_PROFILE            - Apply GJC tmux scroll/mouse/clipboard profile to --tmux sessions (set 0/off to skip)
-  GJC_MOUSE                   - Mouse-wheel scroll in --tmux sessions (set 0/off to let the host terminal scroll)
-
-  For complete environment variable reference, see:
-  ${chalk.dim("docs/environment-variables.md")}
-${chalk.bold("Available Tools (default-enabled unless noted):")}
-  read          - Read file contents
-  bash          - Execute bash commands
-  edit          - Edit files with find/replace
-  write         - Write files (creates/overwrites)
-  grep          - Search file contents
-  find          - Find files by glob pattern
-  lsp           - Language server protocol (code intelligence)
-  python        - Execute Python code (requires: ${APP_NAME} setup python)
-  notebook      - Edit Jupyter notebooks
-  browser       - Browser automation (Puppeteer)
-  task          - Launch sub-agents for parallel tasks
-  todo_write    - Manage todo/task lists
-  web_search    - Search the web
-  ask           - Ask user questions (interactive mode only)
-
-${chalk.bold("Useful Commands:")}
-  ${APP_NAME} --list-models        - List configured provider models
-  ${APP_NAME} --help               - Show this help`;
-}
-
-export function printHelp(): void {
-	process.stdout.write(
-		`${chalk.bold(APP_NAME)} - red-claw AI coding assistant\n\n` +
-			`Run ${APP_NAME} --help for full command and option details.\n` +
-			`Run ${APP_NAME} <command> --help for command-specific help.\n\n` +
-			`${getExtraHelpText()}\n`,
-	);
 }

--- a/packages/coding-agent/test/cli-help-load-order.test.ts
+++ b/packages/coding-agent/test/cli-help-load-order.test.ts
@@ -344,3 +344,50 @@ ${stderr}`;
 		expect(combined).not.toContain("Bun is a fast JavaScript runtime");
 	}, 15_000);
 });
+
+const argsPath = path.join(repoRoot, "packages", "coding-agent", "src", "cli", "args.ts");
+const fastHelpPath = path.join(repoRoot, "packages", "coding-agent", "src", "cli", "fast-help.ts");
+
+describe("CLI help single source of truth", () => {
+	it("cli.ts sources help from fast-help.ts, not args.ts", async () => {
+		const cliSource = await Bun.file(cliEntry).text();
+
+		// Root help is rendered via the live fast-help module; the dead
+		// args.ts help exports must not be on the import path.
+		expect(cliSource).toContain('import("./cli/fast-help")');
+		expect(cliSource).not.toContain('import("./cli/args")');
+	});
+
+	it("fast-help.ts is the live help SSOT and renders the retained sections", async () => {
+		const fastHelpSource = await Bun.file(fastHelpPath).text();
+
+		// fast-help.ts owns the live help export that cli.ts calls.
+		expect(fastHelpSource).toContain("export function getExtraHelpText");
+
+		// Every section fast-help.ts emits must be present so the live --help
+		// output keeps the documented command/env/tool surface.
+		expect(fastHelpSource).toContain("Commands:");
+		expect(fastHelpSource).toContain("Environment Variables:");
+		expect(fastHelpSource).toContain("Available Tools (default-enabled unless noted):");
+		expect(fastHelpSource).toContain("Useful Commands:");
+	});
+
+	it("fast-help.ts never emits the stale pre-rebrand tagline", async () => {
+		const fastHelpSource = await Bun.file(fastHelpPath).text();
+
+		// The old product name tagline must not leak into live help output.
+		expect(fastHelpSource).not.toContain("red-claw");
+	});
+
+	it("args.ts no longer carries the dead duplicate help exports or stale tagline", async () => {
+		const argsSource = await Bun.file(argsPath).text();
+
+		// The dead getExtraHelpText/printHelp duplicates could drift silently from
+		// fast-help.ts; they must be gone, along with the stale tagline they held
+		// and the chalk/import bindings only they used.
+		expect(argsSource).not.toContain("export function getExtraHelpText");
+		expect(argsSource).not.toContain("export function printHelp");
+		expect(argsSource).not.toContain("red-claw");
+		expect(argsSource).not.toContain("chalk");
+	});
+});


### PR DESCRIPTION
## Summary

`packages/coding-agent/src/cli/args.ts` carried two dead duplicate help implementations — `getExtraHelpText()` and `printHelp()` — that were never on the live help path. The root `cli.ts` renders `--help` exclusively via `cli/fast-help.ts` (the live single source of truth), so these `args.ts` exports were unreachable. Because they duplicated the live help text, they could (and did) drift silently from `fast-help.ts`, and `printHelp()` still contained a stale `"red-claw AI coding assistant"` tagline referencing the old product name.

This is **dead duplicate code cleanup**, not a live CLI branding bug: the stale tagline never reached actual `--help` output because `printHelp()` was never called.

## Changes

- **`packages/coding-agent/src/cli/args.ts`**: Deleted the dead `getExtraHelpText()` and `printHelp()` exports. Removed the now-unused `chalk`, `APP_NAME`, and `CONFIG_DIR_NAME` imports (they were only referenced by the deleted functions). Updated the file header comment from "CLI argument parsing and help display" to "CLI argument parsing". The live `parseArgs` / `Args` / `Mode` exports are untouched — other modules (`main.ts`, `commands/launch.ts`, `commands/acp.ts`, `commands/sdk.ts`, `rlm/index.ts`, `gjc-runtime/launch-tmux.ts`, and several tests) still import those.
- **`packages/coding-agent/test/cli-help-load-order.test.ts`**: Added a `describe("CLI help single source of truth")` block with four assertions: `cli.ts` imports help from `fast-help.ts` (not `args.ts`); `fast-help.ts` owns the live `getExtraHelpText` export and renders the retained sections (`Commands:`, `Environment Variables:`, `Available Tools`, `Useful Commands:`); `fast-help.ts` never emits the stale `red-claw` tagline; and `args.ts` no longer carries the dead help exports, the stale tagline, or the `chalk` binding.

## Why

Per the repo-safety guidance in `packages/coding-agent/src/prompts/system/system-prompt.md` — "Fix problems at their source. Remove obsolete code rather than leaving dead aliases or comments." — the dead duplicate help in `args.ts` is obsolete code that can drift from the live `fast-help.ts` SSOT. Removing it eliminates a maintenance hazard and the stale-tagline drift vector without changing any user-facing behavior.

## Verification

```
bun test packages/coding-agent/test/cli-help-load-order.test.ts
```

The four new source-inspection assertions pass. (The pre-existing spawn-based tests in the same file require a fully installed workspace `node_modules` to resolve `@gajae-code/utils/postmortem`; they pass in CI and are unchanged by this PR.)

`scripts/rebrand-inventory.ts --strict` was not run: it scans for `oh-my-pi`/`omp` legacy tokens, not the `red-claw` tagline, so it is not directly relevant to this dead-code cleanup.

## Files

- `packages/coding-agent/src/cli/args.ts`
- `packages/coding-agent/test/cli-help-load-order.test.ts`
