### PR TITLE
fix(sdk): prune superseded heartbeats from session-index snapshots to bound state growth

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
+- SDK session index snapshots now prune superseded per-session `host_heartbeat` rows during snapshot/rotation, so `~/.gjc/agent/sdk/sessions/` state stays bounded. Previously every live host appended a heartbeat every 5 seconds and rotation carried all of them forward into the snapshot, growing state without bound (observed >100 MB) until concurrent hosts failed with `Failed to acquire lock for .../sessions/index.jsonl after 50 attempts`. Snapshot validation now accepts the resulting sparse (strictly increasing) sequence while remaining checksum-strict; dense legacy snapshots stay valid.
 
 
 ### Fixed

--- a/packages/coding-agent/src/sdk/broker/session-index.ts
+++ b/packages/coding-agent/src/sdk/broker/session-index.ts
@@ -52,18 +52,46 @@ const ROTATE_BYTES = 4 * 1024 * 1024;
 function isValidSnapshot(snapshot: unknown): snapshot is { indexSeq: number; events: SessionIndexEvent[] } {
 	if (!snapshot || typeof snapshot !== "object") return false;
 	const { indexSeq, events } = snapshot as { indexSeq?: unknown; events?: unknown };
-	return (
-		typeof indexSeq === "number" &&
-		Number.isSafeInteger(indexSeq) &&
-		indexSeq >= 0 &&
-		Array.isArray(events) &&
-		events.length === indexSeq &&
-		events.every((event, index) => {
-			if (!event || typeof event !== "object") return false;
-			const { checksum, ...unsigned } = event as SessionIndexEvent;
-			return event.indexSeq === index + 1 && checksum === sessionIndexChecksum(unsigned);
-		})
-	);
+	if (typeof indexSeq !== "number" || !Number.isSafeInteger(indexSeq) || indexSeq < 0 || !Array.isArray(events))
+		return false;
+	// The sequence may be sparse: snapshots prune superseded heartbeat rows, so
+	// require strictly increasing checksummed rows ending at `indexSeq` instead
+	// of a dense 1..indexSeq run. Dense legacy snapshots remain valid.
+	if (events.length === 0) return indexSeq === 0;
+	let previousSeq = 0;
+	for (const event of events) {
+		if (!event || typeof event !== "object") return false;
+		const { checksum, ...unsigned } = event as SessionIndexEvent;
+		if (
+			typeof event.indexSeq !== "number" ||
+			event.indexSeq <= previousSeq ||
+			checksum !== sessionIndexChecksum(unsigned)
+		)
+			return false;
+		previousSeq = event.indexSeq;
+	}
+	return previousSeq === indexSeq;
+}
+/**
+ * Drop `host_heartbeat` events superseded by a newer heartbeat for the same
+ * session. Only the latest heartbeat per session is observable: `listSessions`
+ * keeps the last event per session and merges heartbeat rows with the fields
+ * of the previous non-heartbeat event, and the registration lookups filter on
+ * `host_registered`/`host_unregistered`. Pruning preserves relative order and
+ * the global newest event, so `indexSeq` stays the sequence high-water mark.
+ */
+function pruneSupersededHeartbeats(events: SessionIndexEvent[]): SessionIndexEvent[] {
+	const newestHeartbeatSeen = new Set<string>();
+	const kept: SessionIndexEvent[] = [];
+	for (let i = events.length - 1; i >= 0; i--) {
+		const event = events[i]!;
+		if (event.type === "host_heartbeat") {
+			if (newestHeartbeatSeen.has(event.sessionId)) continue;
+			newestHeartbeatSeen.add(event.sessionId);
+		}
+		kept.push(event);
+	}
+	return kept.reverse();
 }
 
 async function appendSync(file: string, value: string): Promise<void> {
@@ -237,6 +265,12 @@ export class SessionIndex {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT" && !(error instanceof SyntaxError)) throw error;
 		}
 		if (isValidSnapshot(current) && current.indexSeq > this.indexSeq) return;
+		// Prune superseded heartbeat rows so the snapshot cannot grow without
+		// bound: every live host appends a heartbeat every few seconds, and
+		// carrying all of them forward across rotations made the state grow
+		// forever (observed >100 MB) until concurrent hosts starved on the
+		// append lock.
+		this.#events = pruneSupersededHeartbeats(this.#events);
 		const tmp = `${file}.${process.pid}.tmp`;
 		await fs.writeFile(
 			tmp,

--- a/packages/coding-agent/test/sdk-session-index.test.ts
+++ b/packages/coding-agent/test/sdk-session-index.test.ts
@@ -10,6 +10,7 @@ const event = (sessionId: string) => ({
 	endpointGeneration: 1,
 	pid: process.pid,
 });
+const heartbeat = (sessionId: string) => ({ ...event(sessionId), type: "host_heartbeat" as const });
 describe("SDK session index", () => {
 	it("replays only rows after the snapshotted prefix", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
@@ -218,5 +219,62 @@ describe("SDK session index", () => {
 		).toMatchObject({
 			indexSeq: expect.any(Number),
 		});
+	}, 30_000);
+	it("prunes superseded heartbeats from the snapshot so state stays bounded", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("s"));
+		for (let i = 0; i < 5; i++) await index.append(heartbeat("s"));
+		await index.snapshot();
+		const snapshot = JSON.parse(await fs.readFile(path.join(dir, "sdk", "sessions", "index.snapshot.json"), "utf8"));
+		// Only the registration and the newest heartbeat survive; the sequence
+		// high-water mark is retained.
+		expect(snapshot.events.map((e: { indexSeq: number }) => e.indexSeq)).toEqual([1, 6]);
+		expect(snapshot.indexSeq).toBe(6);
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.indexSeq).toBe(6);
+		const sessions = replay.listSessions().sessions;
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]?.sessionId).toBe("s");
+		expect(sessions[0]?.locator).toEqual({ repo: "r", stateRoot: "q" });
+		expect(replay.listSessions().warnings).toEqual([]);
+	});
+	it("keeps appending and replaying correctly from a sparse pruned snapshot", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("a"));
+		await index.append(heartbeat("a"));
+		await index.append(heartbeat("a"));
+		await index.snapshot();
+		const other = await new SessionIndex(dir).open();
+		await other.append(event("b"));
+		expect(other.indexSeq).toBe(4);
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.indexSeq).toBe(4);
+		expect(
+			replay
+				.listSessions()
+				.sessions.map(session => session.sessionId)
+				.sort(),
+		).toEqual(["a", "b"]);
+		expect(replay.listSessions().warnings).toEqual([]);
+	});
+	it("bounds heartbeat-driven state across repeated rotations", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const index = await new SessionIndex(dir).open();
+		const largeHeartbeat = () => ({
+			...heartbeat("s"),
+			locator: { repo: "r".repeat(600_000), stateRoot: "q" },
+		});
+		await index.append({ ...event("s"), locator: { repo: "r".repeat(600_000), stateRoot: "q" } });
+		// Enough oversized heartbeats to force several rotations.
+		for (let i = 0; i < 24; i++) await index.append(largeHeartbeat());
+		const snapshot = JSON.parse(await fs.readFile(path.join(dir, "sdk", "sessions", "index.snapshot.json"), "utf8"));
+		// Snapshot carries at most the registration plus the latest heartbeat
+		// per session instead of every heartbeat ever appended.
+		expect(snapshot.events.length).toBeLessThanOrEqual(3);
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.indexSeq).toBe(25);
+		expect(replay.listSessions().sessions).toHaveLength(1);
 	}, 30_000);
 });


### PR DESCRIPTION
Reopened against `dev` per CONTRIBUTING.md; supersedes #2506 (wrongly targeted `main`). Rebuilt on top of the #2457 rotation hardening rather than rebasing the old branch.

## Problem

Every live SDK host appends a `host_heartbeat` row to the machine-shared `~/.gjc/agent/sdk/sessions/index.jsonl` every 5 seconds (`packages/coding-agent/src/sdk/bus/index.ts`). #2457 added log rotation, which bounds the *log file* — but `#rotate()` snapshots first and the snapshot carries **every heartbeat ever appended** forward across rotations. Total on-disk/in-memory state (and the `replay()` cost every `append()` pays under the file lock) still grows without bound.

Observed on a busy machine (400+ sessions over a few weeks): **107 MB** of session-index state and ~17 concurrent processes steadily failing with:

```
sdk broker heartbeat failed: Error: Failed to acquire lock for
~/.gjc/agent/sdk/sessions/index.jsonl after 50 attempts
```

plus cascading `Failed to persist coordinator runtime state` warnings.

## Fix

- `#snapshotUnderLock()` prunes `host_heartbeat` rows superseded by a newer heartbeat for the same session before persisting. This is behavior-preserving: only the latest heartbeat per session is observable — `listSessions` keeps the last event per session (merging heartbeat rows with the previous non-heartbeat event's fields), and `findHostRegistration` / `hostUnregisteredAfter` / `hasHostRegistrationForLifecycle` filter on `host_registered`/`host_unregistered`.
- `isValidSnapshot()` accepts the resulting **sparse** sequence: strictly increasing checksummed `indexSeq` rows ending exactly at the snapshot `indexSeq`, instead of requiring a dense `1..indexSeq` run. Dense legacy snapshots remain valid; per-row checksum and monotonicity checks are unchanged, and pruning never removes the newest event so `indexSeq` stays the high-water mark.
- Rotation, corrupt-suffix fail-closed behavior, stale-reader resync, and Windows fsync tolerance from #2457 are untouched.

## Tests

- `bun test packages/coding-agent/test/sdk-session-index.test.ts` — **14 pass** (11 existing #2457 tests unchanged + 3 new: snapshot prunes superseded heartbeats and replays cleanly; append/replay from a sparse pruned snapshot stays monotonic across writers; repeated heartbeat-driven rotations keep the snapshot bounded to registration + latest heartbeat).
- `tsc -p tsconfig.tools.json --noEmit` clean; `biome check` clean on both files.
- Broker integration suites require the native addon; 37/45 pass on this host with a stale prebuilt addon, and the 8 failures are all `canonicalExistingDirectoryIeentity is not a function` addon-version skew — unrelated to this change (the current `dev` Rust tree does not build on this host: pre-existing `libc::stat.st_mtimespec` compile error in `crates/pi-natives/src/path_identity.rs:508`, also unrelated).

## Changelog

- Entry added under `## [Unreleased]` in `packages/coding-agent/CHANGELOG.md`.