### PR TITLE
fix(coding-agent): honor GJC_PY and GJC_PYTHON_* env overrides

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Fixed
+- The Python eval runtime now honors the documented `GJC_*` environment variables instead of silently reading only legacy `PI_*` names. `GJC_PY` (tokens `0`/`bash`, `1`/`py`, `js`, `mix`/`both`) overrides the eval backend allowance with precedence over legacy `PI_PY`/`PI_JS`; `GJC_PYTHON_SKIP_CHECK`, `GJC_PYTHON_IPC_TRACE`, and `GJC_PYTHON_INTEGRATION` are read first with `PI_*` fallback (OR semantics, so either truthy name wins). Operators following `docs/environment-variables.md` and `docs/python-repl.md` who set `GJC_PY=py` previously saw no effect — a silent docs/runtime contract break. Legacy `PI_*` names remain supported for backward compatibility.
+
+### Fixed
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -11,7 +11,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $flag, isBunTestRuntime, logger, Snowflake } from "@gajae-code/utils";
+import { $env, isBunTestRuntime, logger, Snowflake } from "@gajae-code/utils";
 import type { Subprocess } from "bun";
 import { $ } from "bun";
 import { Settings } from "../../config/settings";
@@ -23,7 +23,30 @@ import { ensurePythonRuntime, filterEnv, type PythonRuntimeOptions } from "./run
 export type { KernelDisplayOutput, PythonStatusEvent } from "./display";
 export { renderKernelDisplay } from "./display";
 
-const TRACE_IPC = $flag("PI_PYTHON_IPC_TRACE");
+/**
+ * Truthy set for boolean-style Python env flags. Case-insensitive: `1`,
+ * `true`, `yes` (and `on`/`y`) are treated as true; everything else is false.
+ * Mirrors the canonical resolver in `tools/index.ts` so this module can
+ * dual-read `GJC_*` / `PI_*` names without importing the tools barrel (which
+ * would create a circular import at top-level `TRACE_IPC` evaluation).
+ */
+const PYTHON_TRUTHY = new Set(["1", "true", "yes", "on", "y"]);
+
+/** True when `value` is a non-empty string matching a truthy boolean token. */
+function isTruthyPythonFlag(value: string | undefined): boolean {
+	return value !== undefined && PYTHON_TRUTHY.has(value.trim().toLowerCase());
+}
+
+/**
+ * Resolve a boolean Python env flag preferring the `GJC_` name and falling back
+ * to the legacy `PI_` name. Either truthy value wins (OR semantics).
+ */
+function resolvePythonFlag(gjcName: string, piName: string): boolean {
+	return isTruthyPythonFlag($env[gjcName]) || isTruthyPythonFlag($env[piName]);
+}
+
+// Dual-read: `GJC_PYTHON_IPC_TRACE` is preferred, then legacy `PI_PYTHON_IPC_TRACE`.
+const TRACE_IPC = resolvePythonFlag("GJC_PYTHON_IPC_TRACE", "PI_PYTHON_IPC_TRACE");
 
 // Cache the runner script on disk so the subprocess loads it normally. Cached
 // per script hash so installs don't race across versions.
@@ -125,7 +148,7 @@ export async function checkPythonKernelAvailability(
 	cwd: string,
 	runtimeOptions?: PythonRuntimeOptions,
 ): Promise<PythonKernelAvailability> {
-	if (isBunTestRuntime() || $flag("PI_PYTHON_SKIP_CHECK")) {
+	if (isBunTestRuntime() || resolvePythonFlag("GJC_PYTHON_SKIP_CHECK", "PI_PYTHON_SKIP_CHECK")) {
 		return { ok: true };
 	}
 	try {

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -183,8 +183,7 @@ function timeoutSecondsFromMs(timeoutMs: number): number {
 }
 
 async function resolveBackend(session: ToolSession, language: EvalLanguage): Promise<ResolvedBackend> {
-	const allowPy = (session.settings.get("eval.py") as boolean | undefined) ?? true;
-	const allowJs = (session.settings.get("eval.js") as boolean | undefined) ?? true;
+	const { python: allowPy, js: allowJs } = resolveEvalBackends(session);
 
 	if (language === "python") {
 		if (!allowPy) throw new ToolError("Python backend is disabled (eval.py = false).");

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -1,6 +1,6 @@
 import type { AgentTelemetryConfig, AgentTool } from "@gajae-code/agent-core";
 import type { Model, ServiceTier, ToolChoice } from "@gajae-code/ai";
-import { $env, $flag, logger } from "@gajae-code/utils";
+import { $env, logger } from "@gajae-code/utils";
 import type { PromptTemplate } from "../config/prompt-templates";
 import type { Settings } from "../config/settings";
 import { EditTool } from "../edit";
@@ -500,18 +500,76 @@ export interface EvalBackendsAllowance {
 }
 
 /**
- * Parse PI_PY / PI_JS environment variables. Each is a boolean flag; unset
- * means "not specified, defer to settings". Returns null when neither is set
+ * Truthy set for boolean-style Python env flags. Case-insensitive: `1`,
+ * `true`, `yes` (and `on`/`y`) are treated as true; everything else is false.
+ */
+const PYTHON_TRUTHY = new Set(["1", "true", "yes", "on", "y"]);
+
+/** True when `value` is a non-empty string matching a truthy boolean token. */
+function isTruthyFlag(value: string | undefined): boolean {
+	return value !== undefined && PYTHON_TRUTHY.has(value.trim().toLowerCase());
+}
+
+/**
+ * Parse the `GJC_PY` multi-value token into per-backend booleans.
+ *
+ * Tokens (case-insensitive):
+ * - `0` / `bash` → JavaScript only (`{ py: false, js: true }`)
+ * - `1` / `py`   → Python only (`{ py: true, js: false }`)
+ * - `js`         → JavaScript only (`{ py: false, js: true }`)
+ * - `mix` / `both` → both backends (`{ py: true, js: true }`)
+ *
+ * Returns `null` when `GJC_PY` is unset, empty, or holds an unrecognized
+ * token, so the caller can fall back to the legacy `PI_PY` / `PI_JS` flags or
+ * per-key settings. This matches the documented contract that invalid values
+ * are ignored.
+ */
+export function parseGjcPy(env: Record<string, string | undefined>): { py: boolean; js: boolean } | null {
+	const raw = env.GJC_PY;
+	if (raw === undefined) return null;
+	const token = raw.trim().toLowerCase();
+	if (token === "") return null;
+	switch (token) {
+		case "0":
+		case "bash":
+			return { py: false, js: true };
+		case "1":
+		case "py":
+			return { py: true, js: false };
+		case "js":
+			return { py: false, js: true };
+		case "mix":
+		case "both":
+			return { py: true, js: true };
+		default:
+			return null;
+	}
+}
+
+/**
+ * Parse legacy `PI_PY` / `PI_JS` boolean flags. Each is a boolean flag; unset
+ * means "not specified, defer to settings". Returns `null` when neither is set
  * so the caller can fall through to `readEvalBackendsAllowance` per key.
  */
-function getEvalBackendsFromEnv(): EvalBackendsAllowance | null {
-	const pyEnv = $env.PI_PY;
-	const jsEnv = $env.PI_JS;
+function parseLegacyEvalEnvFlags(env: Record<string, string | undefined>): EvalBackendsAllowance | null {
+	const pyEnv = env.PI_PY;
+	const jsEnv = env.PI_JS;
 	if (pyEnv === undefined && jsEnv === undefined) return null;
 	return {
-		python: pyEnv === undefined ? true : $flag("PI_PY"),
-		js: jsEnv === undefined ? true : $flag("PI_JS"),
+		python: pyEnv === undefined ? true : isTruthyFlag(pyEnv),
+		js: jsEnv === undefined ? true : isTruthyFlag(jsEnv),
 	};
+}
+
+/**
+ * Resolve eval-backend allowance from environment only. `GJC_PY` wins when set
+ * to a recognized token; otherwise the legacy `PI_PY` / `PI_JS` flags apply.
+ * Returns `null` when no env override is set so the caller can defer to settings.
+ */
+export function resolveEvalBackendsFromEnv(env: Record<string, string | undefined>): EvalBackendsAllowance | null {
+	const gjc = parseGjcPy(env);
+	if (gjc) return { python: gjc.py, js: gjc.js };
+	return parseLegacyEvalEnvFlags(env);
 }
 
 /** Read per-backend allowance from settings (defaults true). */
@@ -523,11 +581,40 @@ export function readEvalBackendsAllowance(session: ToolSession): EvalBackendsAll
 }
 
 /**
- * Materialize the active eval backend allowance: PI_PY / PI_JS env flags
- * override the per-key settings; otherwise settings (defaults true) win.
+ * Materialize the active eval backend allowance. `GJC_PY` takes precedence
+ * over the legacy `PI_PY` / `PI_JS` env flags, which in turn override the
+ * per-key settings (defaults true). When no env override is set, settings win.
  */
 export function resolveEvalBackends(session: ToolSession): EvalBackendsAllowance {
-	return getEvalBackendsFromEnv() ?? readEvalBackendsAllowance(session);
+	return resolveEvalBackendsFromEnv($env) ?? readEvalBackendsAllowance(session);
+}
+
+/**
+ * Resolve the Python skip-check flag. `GJC_PYTHON_SKIP_CHECK` is preferred;
+ * falls back to legacy `PI_PYTHON_SKIP_CHECK`. Truthy values: `1`, `true`,
+ * `yes` (case-insensitive).
+ */
+export function resolvePythonSkipCheck(env: Record<string, string | undefined>): boolean {
+	return isTruthyFlag(env.GJC_PYTHON_SKIP_CHECK) || isTruthyFlag(env.PI_PYTHON_SKIP_CHECK);
+}
+
+/**
+ * Resolve the Python IPC trace flag. `GJC_PYTHON_IPC_TRACE` is preferred;
+ * falls back to legacy `PI_PYTHON_IPC_TRACE`. Truthy values: `1`, `true`,
+ * `yes` (case-insensitive).
+ */
+export function resolvePythonIpcTrace(env: Record<string, string | undefined>): boolean {
+	return isTruthyFlag(env.GJC_PYTHON_IPC_TRACE) || isTruthyFlag(env.PI_PYTHON_IPC_TRACE);
+}
+
+/**
+ * Resolve the gated Python integration-test gate. Uses OR semantics:
+ * `GJC_PYTHON_INTEGRATION === "1"` OR `PI_PYTHON_INTEGRATION === "1"` enables
+ * it. A truthy value on either name opts the tests in, so `GJC=0, PI=1` is
+ * still true. Truthy values: `1`, `true`, `yes` (case-insensitive).
+ */
+export function resolvePythonIntegrationGate(env: Record<string, string | undefined>): boolean {
+	return isTruthyFlag(env.GJC_PYTHON_INTEGRATION) || isTruthyFlag(env.PI_PYTHON_INTEGRATION);
 }
 
 /**

--- a/packages/coding-agent/test/core/python-runner.integration.test.ts
+++ b/packages/coding-agent/test/core/python-runner.integration.test.ts
@@ -1,16 +1,18 @@
 /**
  * End-to-end exercise of the new subprocess-backed Python runner.
  *
- * Gated by `PI_PYTHON_INTEGRATION=1` so CI without a real Python interpreter
- * (or sandboxes where subprocess spawning is restricted) does not fail.
+ * Gated by `GJC_PYTHON_INTEGRATION=1` (or legacy `PI_PYTHON_INTEGRATION=1`)
+ * so CI without a real Python interpreter (or sandboxes where subprocess
+ * spawning is restricted) does not fail. Either truthy name opts the tests in.
  */
 import { afterEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { disposeAllKernelSessions, executePythonWithKernel } from "@gajae-code/coding-agent/eval/py/executor";
 import { PythonKernel } from "@gajae-code/coding-agent/eval/py/kernel";
+import { resolvePythonIntegrationGate } from "@gajae-code/coding-agent/tools";
 import { TempDir } from "@gajae-code/utils";
 
-const SHOULD_RUN = Bun.env.PI_PYTHON_INTEGRATION === "1";
+const SHOULD_RUN = resolvePythonIntegrationGate(Bun.env);
 
 describe.skipIf(!SHOULD_RUN)("python runner subprocess", () => {
 	afterEach(async () => {

--- a/packages/coding-agent/test/eval/python-lifecycle.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.test.ts
@@ -5,7 +5,7 @@ import type {
 	KernelExecuteResult,
 	KernelShutdownResult,
 } from "@gajae-code/coding-agent/eval/py/kernel";
-import { PythonKernel } from "@gajae-code/coding-agent/eval/py/kernel";
+import { checkPythonKernelAvailability, PythonKernel } from "@gajae-code/coding-agent/eval/py/kernel";
 import { TempDir } from "@gajae-code/utils";
 
 const originalStart = PythonKernel.start;
@@ -201,5 +201,77 @@ describe("python eval lifecycle", () => {
 			}
 			await unrelated.exited.catch(() => undefined);
 		}
+	});
+});
+describe("python kernel env-var dual-read (GJC_* preferred, PI_* fallback)", () => {
+	// `checkPythonKernelAvailability` short-circuits on `isBunTestRuntime()`
+	// (NODE_ENV/BUN_ENV === "test"), which would mask the skip-check branch.
+	// These tests neutralize the test-runtime guard inside a scoped window and
+	// restore it in finally so the real GJC/PI skip-check branch is exercised.
+	const SKIP_ENV_KEYS = [
+		"GJC_PYTHON_SKIP_CHECK",
+		"PI_PYTHON_SKIP_CHECK",
+		"GJC_PYTHON_IPC_TRACE",
+		"PI_PYTHON_IPC_TRACE",
+	] as const;
+	const originalNodeEnv = Bun.env.NODE_ENV;
+	const originalBunEnv = Bun.env.BUN_ENV;
+
+	function clearSkipEnv(): void {
+		for (const key of SKIP_ENV_KEYS) delete Bun.env[key];
+	}
+
+	function neutralizeTestRuntime(): void {
+		// Force isBunTestRuntime() false so the skip-check env var is the
+		// sole gate, not the test-runtime short-circuit.
+		delete Bun.env.NODE_ENV;
+		delete Bun.env.BUN_ENV;
+	}
+
+	function restoreTestRuntime(): void {
+		Bun.env.NODE_ENV = originalNodeEnv;
+		Bun.env.BUN_ENV = originalBunEnv;
+	}
+
+	afterEach(() => {
+		clearSkipEnv();
+		restoreTestRuntime();
+	});
+
+	it("honors GJC_PYTHON_SKIP_CHECK=1 and returns ok without spawning Python", async () => {
+		clearSkipEnv();
+		neutralizeTestRuntime();
+		Bun.env.GJC_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-skipcheck-gjc-");
+		const availability = await checkPythonKernelAvailability(tempDir.path());
+		expect(availability.ok).toBe(true);
+	});
+
+	it("still honors legacy PI_PYTHON_SKIP_CHECK=1 as a fallback", async () => {
+		clearSkipEnv();
+		neutralizeTestRuntime();
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-skipcheck-pi-");
+		const availability = await checkPythonKernelAvailability(tempDir.path());
+		expect(availability.ok).toBe(true);
+	});
+
+	it("OR semantics: GJC=0 with PI=1 still skips the check", async () => {
+		clearSkipEnv();
+		neutralizeTestRuntime();
+		Bun.env.GJC_PYTHON_SKIP_CHECK = "0";
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-skipcheck-or-");
+		const availability = await checkPythonKernelAvailability(tempDir.path());
+		expect(availability.ok).toBe(true);
+	});
+
+	it("accepts truthy tokens true/yes for GJC_PYTHON_SKIP_CHECK (case-insensitive)", async () => {
+		clearSkipEnv();
+		neutralizeTestRuntime();
+		Bun.env.GJC_PYTHON_SKIP_CHECK = "YES";
+		using tempDir = TempDir.createSync("@gjc-python-skipcheck-yes-");
+		const availability = await checkPythonKernelAvailability(tempDir.path());
+		expect(availability.ok).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/tools/eval-fallback.test.ts
+++ b/packages/coding-agent/test/tools/eval-fallback.test.ts
@@ -31,6 +31,7 @@ const mockResult = {
 describe("EvalTool language dispatch", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
+		delete Bun.env.GJC_PY;
 	});
 
 	it('dispatches to the JS backend when cell.language === "js"', async () => {
@@ -90,12 +91,32 @@ describe("EvalTool language dispatch", () => {
 		).rejects.toThrow(/eval\.py = false/);
 	});
 
+	it("rejects py cells when GJC_PY selects JavaScript only", async () => {
+		Bun.env.GJC_PY = "js";
+		const tool = new EvalTool(makeSession());
+		await expect(
+			tool.execute("call-py-env-disabled", {
+				cells: [{ language: "py", code: "print('hi')" }],
+			}),
+		).rejects.toThrow(/eval\.py = false/);
+	});
+
 	it("rejects js cells when eval.js is disabled", async () => {
 		const settings = Settings.isolated();
 		settings.set("eval.js", false);
 		const tool = new EvalTool(makeSession(settings));
 		await expect(
 			tool.execute("call-js-disabled", {
+				cells: [{ language: "js", code: "const x = 1;" }],
+			}),
+		).rejects.toThrow(/eval\.js = false/);
+	});
+
+	it("rejects js cells when GJC_PY selects Python only", async () => {
+		Bun.env.GJC_PY = "py";
+		const tool = new EvalTool(makeSession());
+		await expect(
+			tool.execute("call-js-env-disabled", {
 				cells: [{ language: "js", code: "const x = 1;" }],
 			}),
 		).rejects.toThrow(/eval\.js = false/);

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -1,6 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { type SettingPath, Settings } from "@gajae-code/coding-agent/config/settings";
-import { BUILTIN_TOOLS, createTools, HIDDEN_TOOLS, type ToolSession } from "@gajae-code/coding-agent/tools";
+import {
+	BUILTIN_TOOLS,
+	createTools,
+	HIDDEN_TOOLS,
+	parseGjcPy,
+	resolveEvalBackends,
+	resolveEvalBackendsFromEnv,
+	resolvePythonIpcTrace,
+	resolvePythonIntegrationGate,
+	resolvePythonSkipCheck,
+	type ToolSession,
+} from "@gajae-code/coding-agent/tools";
 
 Bun.env.PI_PYTHON_SKIP_CHECK = "1";
 
@@ -321,5 +332,225 @@ describe("createTools", () => {
 		expect(Object.keys(BUILTIN_TOOLS)).not.toEqual(
 			expect.arrayContaining(["get_goal", "create_goal", "update_goal"]),
 		);
+	});
+});
+
+// Env vars exercised below leak across tests via the shared `Bun.env`/`$env`
+// reference, so each block restores the keys it touches in afterEach.
+const PY_ENV_KEYS = [
+	"GJC_PY",
+	"PI_PY",
+	"PI_JS",
+	"GJC_PYTHON_SKIP_CHECK",
+	"PI_PYTHON_SKIP_CHECK",
+	"GJC_PYTHON_IPC_TRACE",
+	"PI_PYTHON_IPC_TRACE",
+	"GJC_PYTHON_INTEGRATION",
+	"PI_PYTHON_INTEGRATION",
+] as const;
+
+function clearPyEnvKeys(): void {
+	for (const key of PY_ENV_KEYS) delete Bun.env[key];
+}
+
+describe("parseGjcPy", () => {
+	it("returns null when GJC_PY is unset", () => {
+		expect(parseGjcPy({})).toBeNull();
+	});
+
+	it("returns null when GJC_PY is empty or whitespace", () => {
+		expect(parseGjcPy({ GJC_PY: "" })).toBeNull();
+		expect(parseGjcPy({ GJC_PY: "   " })).toBeNull();
+	});
+
+	it("returns null for unrecognized tokens (invalid values are ignored)", () => {
+		expect(parseGjcPy({ GJC_PY: "python" })).toBeNull();
+		expect(parseGjcPy({ GJC_PY: "yes" })).toBeNull();
+		expect(parseGjcPy({ GJC_PY: "2" })).toBeNull();
+	});
+
+	it("parses 0/bash as JavaScript only", () => {
+		expect(parseGjcPy({ GJC_PY: "0" })).toEqual({ py: false, js: true });
+		expect(parseGjcPy({ GJC_PY: "bash" })).toEqual({ py: false, js: true });
+	});
+
+	it("parses 1/py as Python only", () => {
+		expect(parseGjcPy({ GJC_PY: "1" })).toEqual({ py: true, js: false });
+		expect(parseGjcPy({ GJC_PY: "py" })).toEqual({ py: true, js: false });
+	});
+
+	it("parses js as JavaScript only", () => {
+		expect(parseGjcPy({ GJC_PY: "js" })).toEqual({ py: false, js: true });
+	});
+
+	it("parses mix/both as both backends", () => {
+		expect(parseGjcPy({ GJC_PY: "mix" })).toEqual({ py: true, js: true });
+		expect(parseGjcPy({ GJC_PY: "both" })).toEqual({ py: true, js: true });
+	});
+
+	it("is case-insensitive", () => {
+		expect(parseGjcPy({ GJC_PY: "PY" })).toEqual({ py: true, js: false });
+		expect(parseGjcPy({ GJC_PY: "Both" })).toEqual({ py: true, js: true });
+		expect(parseGjcPy({ GJC_PY: "  Js  " })).toEqual({ py: false, js: true });
+	});
+});
+
+describe("resolveEvalBackendsFromEnv", () => {
+	it("returns null when no env override is set", () => {
+		expect(resolveEvalBackendsFromEnv({})).toBeNull();
+	});
+
+	it("prefers GJC_PY over legacy PI_PY/PI_JS", () => {
+		// GJC_PY=py (python only) wins even though PI_JS would enable js.
+		expect(resolveEvalBackendsFromEnv({ GJC_PY: "py", PI_JS: "1" })).toEqual({ python: true, js: false });
+	});
+
+	it("falls back to legacy PI_PY/PI_JS when GJC_PY is unset", () => {
+		expect(resolveEvalBackendsFromEnv({ PI_PY: "1", PI_JS: "0" })).toEqual({ python: true, js: false });
+		expect(resolveEvalBackendsFromEnv({ PI_PY: "0", PI_JS: "1" })).toEqual({ python: false, js: true });
+	});
+
+	it("falls back to legacy flags when GJC_PY is an unrecognized token", () => {
+		expect(resolveEvalBackendsFromEnv({ GJC_PY: "bogus", PI_PY: "1" })).toEqual({ python: true, js: true });
+	});
+
+	it("treats an unset legacy flag as true (defer-to-settings semantics)", () => {
+		// Only PI_PY set: python follows it, js defaults true.
+		expect(resolveEvalBackendsFromEnv({ PI_PY: "0" })).toEqual({ python: false, js: true });
+		expect(resolveEvalBackendsFromEnv({ PI_JS: "0" })).toEqual({ python: true, js: false });
+	});
+
+	it("honors truthy legacy values 1/true/yes case-insensitively", () => {
+		expect(resolveEvalBackendsFromEnv({ PI_PY: "true", PI_JS: "YES" })).toEqual({
+			python: true,
+			js: true,
+		});
+	});
+
+	it("treats non-truthy legacy values as false", () => {
+		expect(resolveEvalBackendsFromEnv({ PI_PY: "no", PI_JS: "0" })).toEqual({ python: false, js: false });
+	});
+});
+
+describe("resolveEvalBackends (session integration)", () => {
+	afterEach(() => clearPyEnvKeys());
+
+	it("defers to settings when no env override is set", () => {
+		clearPyEnvKeys();
+		const session = createTestSession({
+			settings: createSettingsWithOverrides({ "eval.py": false, "eval.js": true }),
+		});
+		expect(resolveEvalBackends(session)).toEqual({ python: false, js: true });
+	});
+
+	it("GJC_PY=py overrides settings to python only", () => {
+		clearPyEnvKeys();
+		Bun.env.GJC_PY = "py";
+		const session = createTestSession({
+			settings: createSettingsWithOverrides({ "eval.py": true, "eval.js": true }),
+		});
+		expect(resolveEvalBackends(session)).toEqual({ python: true, js: false });
+	});
+
+	it("GJC_PY=0 disables python and enables js regardless of settings", () => {
+		clearPyEnvKeys();
+		Bun.env.GJC_PY = "0";
+		const session = createTestSession({
+			settings: createSettingsWithOverrides({ "eval.py": true, "eval.js": false }),
+		});
+		expect(resolveEvalBackends(session)).toEqual({ python: false, js: true });
+	});
+
+	it("GJC_PY wins over legacy PI_PY/PI_JS when both are set", () => {
+		clearPyEnvKeys();
+		Bun.env.GJC_PY = "js";
+		Bun.env.PI_PY = "1";
+		Bun.env.PI_JS = "0";
+		const session = createTestSession();
+		// GJC says js only; PI says py only. GJC wins → python false, js true.
+		expect(resolveEvalBackends(session)).toEqual({ python: false, js: true });
+	});
+
+	it("legacy PI_PY/PI_JS still apply when GJC_PY is unset", () => {
+		clearPyEnvKeys();
+		Bun.env.PI_PY = "1";
+		Bun.env.PI_JS = "0";
+		const session = createTestSession({
+			settings: createSettingsWithOverrides({ "eval.py": false, "eval.js": true }),
+		});
+		expect(resolveEvalBackends(session)).toEqual({ python: true, js: false });
+	});
+});
+
+describe("resolvePythonSkipCheck", () => {
+	it("is false when neither GJC nor PI is set", () => {
+		expect(resolvePythonSkipCheck({})).toBe(false);
+	});
+
+	it("honors GJC_PYTHON_SKIP_CHECK truthy values", () => {
+		expect(resolvePythonSkipCheck({ GJC_PYTHON_SKIP_CHECK: "1" })).toBe(true);
+		expect(resolvePythonSkipCheck({ GJC_PYTHON_SKIP_CHECK: "true" })).toBe(true);
+		expect(resolvePythonSkipCheck({ GJC_PYTHON_SKIP_CHECK: "yes" })).toBe(true);
+	});
+
+	it("falls back to PI_PYTHON_SKIP_CHECK", () => {
+		expect(resolvePythonSkipCheck({ PI_PYTHON_SKIP_CHECK: "1" })).toBe(true);
+	});
+
+	it("prefers GJC over PI but either truthy wins (OR)", () => {
+		expect(resolvePythonSkipCheck({ GJC_PYTHON_SKIP_CHECK: "1", PI_PYTHON_SKIP_CHECK: "0" })).toBe(true);
+		expect(resolvePythonSkipCheck({ GJC_PYTHON_SKIP_CHECK: "0", PI_PYTHON_SKIP_CHECK: "1" })).toBe(true);
+	});
+
+	it("is case-insensitive and ignores whitespace", () => {
+		expect(resolvePythonSkipCheck({ GJC_PYTHON_SKIP_CHECK: "  YES  " })).toBe(true);
+	});
+
+	it("treats non-truthy values as false", () => {
+		expect(resolvePythonSkipCheck({ GJC_PYTHON_SKIP_CHECK: "no" })).toBe(false);
+		expect(resolvePythonSkipCheck({ GJC_PYTHON_SKIP_CHECK: "0" })).toBe(false);
+	});
+});
+
+describe("resolvePythonIpcTrace", () => {
+	it("is false when neither is set", () => {
+		expect(resolvePythonIpcTrace({})).toBe(false);
+	});
+
+	it("honors GJC_PYTHON_IPC_TRACE first, then PI_PYTHON_IPC_TRACE", () => {
+		expect(resolvePythonIpcTrace({ GJC_PYTHON_IPC_TRACE: "1" })).toBe(true);
+		expect(resolvePythonIpcTrace({ PI_PYTHON_IPC_TRACE: "true" })).toBe(true);
+		expect(resolvePythonIpcTrace({ GJC_PYTHON_IPC_TRACE: "0", PI_PYTHON_IPC_TRACE: "1" })).toBe(true);
+	});
+});
+
+describe("resolvePythonIntegrationGate (OR semantics)", () => {
+	it("is false when neither is set", () => {
+		expect(resolvePythonIntegrationGate({})).toBe(false);
+	});
+
+	it("is true when GJC_PYTHON_INTEGRATION=1", () => {
+		expect(resolvePythonIntegrationGate({ GJC_PYTHON_INTEGRATION: "1" })).toBe(true);
+	});
+
+	it("is true when PI_PYTHON_INTEGRATION=1", () => {
+		expect(resolvePythonIntegrationGate({ PI_PYTHON_INTEGRATION: "1" })).toBe(true);
+	});
+
+	it("GJC=0, PI=1 is still true (OR semantics, not GJC-gated)", () => {
+		expect(resolvePythonIntegrationGate({ GJC_PYTHON_INTEGRATION: "0", PI_PYTHON_INTEGRATION: "1" })).toBe(
+			true,
+		);
+	});
+
+	it("both 0 is false", () => {
+		expect(resolvePythonIntegrationGate({ GJC_PYTHON_INTEGRATION: "0", PI_PYTHON_INTEGRATION: "0" })).toBe(
+			false,
+		);
+	});
+
+	it("accepts truthy tokens true/yes case-insensitively", () => {
+		expect(resolvePythonIntegrationGate({ GJC_PYTHON_INTEGRATION: "TRUE" })).toBe(true);
+		expect(resolvePythonIntegrationGate({ PI_PYTHON_INTEGRATION: "yes" })).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -7,8 +7,8 @@ import {
 	parseGjcPy,
 	resolveEvalBackends,
 	resolveEvalBackendsFromEnv,
-	resolvePythonIpcTrace,
 	resolvePythonIntegrationGate,
+	resolvePythonIpcTrace,
 	resolvePythonSkipCheck,
 	type ToolSession,
 } from "@gajae-code/coding-agent/tools";
@@ -538,15 +538,11 @@ describe("resolvePythonIntegrationGate (OR semantics)", () => {
 	});
 
 	it("GJC=0, PI=1 is still true (OR semantics, not GJC-gated)", () => {
-		expect(resolvePythonIntegrationGate({ GJC_PYTHON_INTEGRATION: "0", PI_PYTHON_INTEGRATION: "1" })).toBe(
-			true,
-		);
+		expect(resolvePythonIntegrationGate({ GJC_PYTHON_INTEGRATION: "0", PI_PYTHON_INTEGRATION: "1" })).toBe(true);
 	});
 
 	it("both 0 is false", () => {
-		expect(resolvePythonIntegrationGate({ GJC_PYTHON_INTEGRATION: "0", PI_PYTHON_INTEGRATION: "0" })).toBe(
-			false,
-		);
+		expect(resolvePythonIntegrationGate({ GJC_PYTHON_INTEGRATION: "0", PI_PYTHON_INTEGRATION: "0" })).toBe(false);
 	});
 
 	it("accepts truthy tokens true/yes case-insensitively", () => {


### PR DESCRIPTION
## Summary

Docs (`docs/environment-variables.md`, `docs/python-repl.md`) advertise the `GJC_*` Python env vars — `GJC_PY`, `GJC_PYTHON_SKIP_CHECK`, `GJC_PYTHON_INTEGRATION`, `GJC_PYTHON_IPC_TRACE` — but the runtime only read the legacy `PI_*` names. Operators following the published docs who set `GJC_PY=py` (or any other `GJC_*` var) saw **no effect**: a silent docs/runtime contract break with no warning.

This PR makes the runtime honor the documented `GJC_*` names while keeping the legacy `PI_*` names working.

## User impact

Before: `GJC_PY=py` was a **silent no-op** — the eval backend allowance stayed at its settings/default value, so an operator who tried to force Python-only (or JS-only, or both) per the docs got the wrong backend set with no error. Likewise `GJC_PYTHON_SKIP_CHECK=1`, `GJC_PYTHON_IPC_TRACE=1`, and `GJC_PYTHON_INTEGRATION=1` did nothing.

After: every documented `GJC_*` name is read and takes effect.

## Precedence rules

| Variable | Resolution |
| --- | --- |
| `GJC_PY` | Multi-value token (`0`/`bash`→JS only, `1`/`py`→Python only, `js`→JS only, `mix`/`both`→both). **Wins over** legacy `PI_PY`/`PI_JS` when set to a recognized token. Unrecognized/empty/whitespace tokens are ignored (defer). |
| `PI_PY` / `PI_JS` | Legacy boolean flags; used only when `GJC_PY` is unset/invalid. Truthy: `1`, `true`, `yes` (case-insensitive). Unset → defer to settings. |
| `GJC_PYTHON_SKIP_CHECK` | Read first; falls back to `PI_PYTHON_SKIP_CHECK`. Either truthy wins (**OR semantics**). |
| `GJC_PYTHON_IPC_TRACE` | Read first; falls back to `PI_PYTHON_IPC_TRACE`. Either truthy wins. |
| `GJC_PYTHON_INTEGRATION` | `GJC_PYTHON_INTEGRATION === "1"` **OR** `PI_PYTHON_INTEGRATION === "1"` → gated integration tests run. `GJC=0, PI=1` is **true** (OR, not GJC-gated). |

Eval backend precedence (high → low): `GJC_PY` → legacy `PI_PY`/`PI_JS` → `eval.py`/`eval.js` settings (default `true`).

## Compatibility

- **Legacy `PI_*` names remain fully supported.** No existing operator config breaks. The `GJC_*` names are additive and take precedence only when set.
- Boolean truthy values (`1`/`true`/`yes`, case-insensitive) match the existing `$flag` semantics used elsewhere.
- `GJC_PY` invalid tokens are ignored (defer to legacy/settings), matching the documented "invalid values ignored" contract.

## Changes

- **`packages/coding-agent/src/tools/index.ts`**
  - New pure env parser `parseGjcPy(env)` — maps the `GJC_PY` token to `{ py, js }`; no global `$flag` inside env-parameter helpers.
  - New `resolveEvalBackendsFromEnv(env)` — `GJC_PY` first, then legacy `PI_PY`/`PI_JS`.
  - `resolveEvalBackends(session)` now prefers `GJC_PY` → legacy `PI_*` → settings (public signature unchanged; `eval.ts` callsite unaffected).
  - New pure exported helpers `resolvePythonSkipCheck`, `resolvePythonIpcTrace`, `resolvePythonIntegrationGate` (GJC-first, PI-fallback, OR semantics). Removed the now-unused `$flag` import.
- **`packages/coding-agent/src/eval/py/kernel.ts`**
  - `TRACE_IPC` dual-reads `GJC_PYTHON_IPC_TRACE` then `PI_PYTHON_IPC_TRACE`.
  - `checkPythonKernelAvailability` dual-reads `GJC_PYTHON_SKIP_CHECK` then `PI_PYTHON_SKIP_CHECK`. A local truthy helper mirrors the canonical resolver to avoid a circular import with the tools barrel (the `TRACE_IPC` constant evaluates at module top-level).
- **`packages/coding-agent/test/core/python-runner.integration.test.ts`**
  - Integration gate now uses the shared `resolvePythonIntegrationGate` helper (OR over `GJC_PYTHON_INTEGRATION` / `PI_PYTHON_INTEGRATION`).
- **`packages/coding-agent/test/tools/index.test.ts`**
  - Behavioral tests for every `GJC_PY` token, legacy `PI_*` fallback, GJC-over-PI conflict precedence, session-level `resolveEvalBackends`, and the skip-check / IPC-trace / integration-gate resolvers (including the `GJC=0, PI=1` OR case).
- **`packages/coding-agent/test/eval/python-lifecycle.test.ts`**
  - Behavioral tests exercising the real `checkPythonKernelAvailability` skip-check branch with `GJC_PYTHON_SKIP_CHECK`, legacy `PI_PYTHON_SKIP_CHECK`, the OR case, and case-insensitive truthy tokens (the test-runtime `isBunTestRuntime()` short-circuit is neutralized within a scoped window and restored in `afterEach`).
- **`packages/coding-agent/CHANGELOG.md`** — `## [Unreleased]` → `### Fixed` entry.

## Risk & rollback

- **Low risk.** The change is additive: legacy `PI_*` behavior is preserved exactly when no `GJC_*` var is set. The only behavioral change is that `GJC_*` vars now take effect (which is the documented intent).
- **Rollback:** revert the commit; no data/config migration involved.
- The `eval.ts` callsite (`resolveEvalBackends(this.session)`) is unchanged in signature and behavior when no `GJC_*` env is present.

## Tests

```
bun test packages/coding-agent/test/tools/index.test.ts
bun test packages/coding-agent/test/eval/python-lifecycle.test.ts
```

- `index.test.ts`: **55 pass, 0 fail** (21 pre-existing + 34 new).
- `python-lifecycle.test.ts`: **6 pass, 2 fail** — the 2 failures (`settles pending executions…`, `kills background descendants…`) are **pre-existing and environment-dependent** (they spawn a real Python kernel that gets cancelled in this sandbox); they fail identically on the base commit `26078eec` without this change. All 4 new dual-read tests pass.
- `python-runner.integration.test.ts`: 6 skip, 0 fail (gate correctly stays off when neither integration var is set).

## Verification notes

- The pure helpers were also smoke-checked directly via `bun -e` against the exported `resolvePythonIntegrationGate` (`{}`→false, `GJC=1`→true, `PI=1`→true, `GJC=0,PI=1`→true, `both=0`→false).
