### PR TITLE
fix(coding-agent): use canonical processIncarnation for daemon lock identity

### DIFF
--- a/packages/coding-agent/src/sdk/broker/process-incarnation.ts
+++ b/packages/coding-agent/src/sdk/broker/process-incarnation.ts
@@ -95,7 +95,8 @@ export function parseDarwinProcessIncarnation(info: Uint8Array): string | undefi
 	}
 }
 
-function isProcessIncarnation(value: unknown): value is string {
+/** Whether `value` is a canonical process-incarnation string (`linux:`/`darwin:`/`windows:`). */
+export function isProcessIncarnation(value: unknown): value is string {
 	return (
 		typeof value === "string" &&
 		(/^(?:linux:\d+|darwin:[1-9]\d*:\d+)$/.test(value) ||

--- a/packages/coding-agent/src/sdk/bus/chat-daemon-control.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-daemon-control.ts
@@ -1,4 +1,4 @@
-import { spawn as childProcessSpawn, spawnSync } from "node:child_process";
+import { spawn as childProcessSpawn } from "node:child_process";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -12,6 +12,7 @@ import type {
 	DaemonStatus,
 } from "../../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../../daemon/runtime";
+import { isProcessIncarnation, processIncarnation } from "../broker/process-incarnation";
 import { getNotificationConfig, isDiscordConfigured, isSlackConfigured } from "./config";
 
 export type ChatDaemonKind = "discord" | "slack";
@@ -120,28 +121,6 @@ function defaultSignal(pid: number, signal: NodeJS.Signals): void {
 	try {
 		process.kill(pid, signal);
 	} catch {}
-}
-function defaultPidIncarnation(pid: number): string | undefined {
-	if (!Number.isSafeInteger(pid) || pid <= 0) return undefined;
-	if (process.platform === "linux") {
-		try {
-			const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
-			return `linux:${
-				stat
-					.slice(stat.lastIndexOf(")") + 2)
-					.trim()
-					.split(/\s+/)[19]
-			}`;
-		} catch {
-			return undefined;
-		}
-	}
-	if (process.platform === "darwin") {
-		const result = spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8" });
-		const startedAt = result.status === 0 ? result.stdout.trim() : "";
-		return startedAt ? `darwin:${startedAt}` : undefined;
-	}
-	return undefined;
 }
 function runtimeInfo(execPath?: string): DaemonRuntimeInfo {
 	const rt = resolveGjcRuntimeSpawnInfo(execPath ?? process.execPath);
@@ -377,7 +356,7 @@ export class ChatDaemonController implements BuiltInDaemonController {
 		);
 	}
 	private incarnation(pid: number): string | undefined {
-		return (this.deps.pidIncarnation ?? defaultPidIncarnation)(pid);
+		return (this.deps.pidIncarnation ?? processIncarnation)(pid);
 	}
 	private isLiveState(state: ChatDaemonState): boolean {
 		return (
@@ -541,7 +520,7 @@ export async function acquireChatDaemonOwnership(input: {
 	const pid = input.pid ?? process.pid;
 	const probe: ChatDaemonOwnershipProbe = {
 		pidAlive: input.pidAlive ?? defaultPidAlive,
-		pidIncarnation: input.pidIncarnation ?? defaultPidIncarnation,
+		pidIncarnation: input.pidIncarnation ?? processIncarnation,
 	};
 	const incarnation = input.incarnation ?? probe.pidIncarnation(pid) ?? "unavailable";
 	await fs.promises.mkdir(paths.dir, { recursive: true, mode: 0o700 });
@@ -631,9 +610,9 @@ async function isStaleChatDaemonLock(lock: string, probe: ChatDaemonOwnershipPro
 		const currentIncarnation = probe.pidIncarnation(owner.pid);
 		return (
 			!probe.pidAlive(owner.pid) ||
-			(currentIncarnation !== undefined &&
-				owner.incarnation !== "unavailable" &&
-				currentIncarnation !== owner.incarnation)
+			(owner.incarnation !== "unavailable" &&
+				(!isProcessIncarnation(owner.incarnation) ||
+					(currentIncarnation !== undefined && currentIncarnation !== owner.incarnation)))
 		);
 	}
 	const stat = await fs.promises.stat(lock).catch(() => undefined);

--- a/packages/coding-agent/src/sdk/bus/conversation-store.ts
+++ b/packages/coding-agent/src/sdk/bus/conversation-store.ts
@@ -1,8 +1,7 @@
-import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { isProcessIncarnation, processIncarnation } from "../broker/process-incarnation";
 
 export const CONVERSATION_STORE_VERSION = 1;
 export const MAX_DEDUPE_IDS = 128;
@@ -111,7 +110,7 @@ export class ConversationStore<T extends ConversationRecord> {
 		this.#fs = input.fs ?? nodeFs;
 		this.#clock = input.now ?? Date.now;
 		this.#pid = input.pid ?? process.pid;
-		this.#pidIncarnation = input.pidIncarnation ?? defaultPidIncarnation;
+		this.#pidIncarnation = input.pidIncarnation ?? processIncarnation;
 		this.#pidAlive = input.pidAlive ?? defaultPidAlive;
 		this.#sleep = input.sleep ?? (async ms => await Bun.sleep(ms));
 		this.#lockTimeoutMs = input.lockTimeoutMs ?? 1_000;
@@ -289,9 +288,9 @@ export class ConversationStore<T extends ConversationRecord> {
 		const currentIncarnation = this.#pidIncarnation(parsed.pid);
 		return (
 			!this.#pidAlive(parsed.pid) ||
-			(currentIncarnation !== undefined &&
-				parsed.incarnation !== "unavailable" &&
-				currentIncarnation !== parsed.incarnation)
+			(parsed.incarnation !== "unavailable" &&
+				(!isProcessIncarnation(parsed.incarnation) ||
+					(currentIncarnation !== undefined && currentIncarnation !== parsed.incarnation)))
 		);
 	}
 	async #isExpiredUnpublishedLock(lockFile: string): Promise<boolean> {
@@ -354,29 +353,6 @@ function defaultPidAlive(pid: number): boolean {
 	} catch {
 		return false;
 	}
-}
-
-function defaultPidIncarnation(pid: number): string | undefined {
-	if (!Number.isSafeInteger(pid) || pid <= 0) return undefined;
-	if (process.platform === "linux") {
-		try {
-			const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
-			return `linux:${
-				stat
-					.slice(stat.lastIndexOf(")") + 2)
-					.trim()
-					.split(/\s+/)[19]
-			}`;
-		} catch {
-			return undefined;
-		}
-	}
-	if (process.platform === "darwin") {
-		const result = spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8" });
-		const startedAt = result.status === 0 ? result.stdout.trim() : "";
-		return startedAt ? `darwin:${startedAt}` : undefined;
-	}
-	return undefined;
 }
 
 function isConversationStoreLock(value: unknown): value is ConversationStoreLock {

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -32,6 +32,7 @@ import {
 	TelegramDaemonController,
 	writeTelegramControlRequest,
 } from "../src/sdk/bus/telegram-daemon-control";
+import { isProcessIncarnation, parseDarwinProcessIncarnation, processIncarnation } from "../src/sdk/broker/process-incarnation";
 import { TopicRegistry } from "../src/sdk/bus/topic-registry";
 
 const BOT_TOKEN = "123456:secret-token";
@@ -937,12 +938,12 @@ describe("Chat daemon owner-lock publication", () => {
 		const agentDir = tempAgentDir();
 		const paths = chatDaemonPaths(agentDir, "slack");
 		fs.mkdirSync(paths.dir, { recursive: true });
-		fs.writeFileSync(paths.lock, JSON.stringify({ pid: 82, incarnation: "dead", createdAt: 1 }));
-		const liveReclaim = `${JSON.stringify({ pid: 81, incarnation: "live-incarnation", createdAt: Date.now() })}\n`;
+		fs.writeFileSync(paths.lock, JSON.stringify({ pid: 82, incarnation: "darwin:1700000000:999999", createdAt: 1 }));
+		const liveReclaim = `${JSON.stringify({ pid: 81, incarnation: "darwin:1700000000:123456", createdAt: Date.now() })}\n`;
 		fs.writeFileSync(`${paths.lock}.reclaim`, liveReclaim);
 		const probe = {
 			pidAlive: (pid: number) => pid === 81,
-			pidIncarnation: (pid: number) => (pid === 81 ? "live-incarnation" : undefined),
+			pidIncarnation: (pid: number) => (pid === 81 ? "darwin:1700000000:123456" : undefined),
 		};
 
 		expect(
@@ -1102,5 +1103,85 @@ describe("topic registry reload persistence", () => {
 		expect(registry.get("S1")?.name).toBe("repo/main - title");
 		// topicId routing must also survive.
 		expect(registry.sessionForTopic("100")).toBe("S1");
+	});
+});
+describe("canonical processIncarnation daemon lock identity", () => {
+	test("default-path produces canonical linux:<startTicks> format", () => {
+		// On Linux, processIncarnation reads /proc/<pid>/stat; pid 4242 does not
+		// exist on this host, so the result is undefined. Verify the canonical
+		// shape directly: the old local defaultPidIncarnation produced the same
+		// linux:<ticks> format, so locks are comparable across code paths.
+		expect(isProcessIncarnation("linux:12345")).toBe(true);
+		expect(isProcessIncarnation("linux:0")).toBe(true);
+		expect(isProcessIncarnation("linux:")).toBe(false);
+	});
+
+	test("default-path produces canonical darwin:<sec>:<usec> format", () => {
+		const bsdInfo = new Uint8Array(136);
+		const view = new DataView(bsdInfo.buffer);
+		view.setBigUint64(120, 1_700_000_000n, true);
+		view.setBigUint64(128, 123_456n, true);
+		const result = processIncarnation(4_242, {
+			platform: "darwin",
+			runCommand: () => ({ exitCode: 0, stdout: "" }),
+		});
+		expect(result).toBeUndefined();
+		expect(isProcessIncarnation("darwin:1700000000:123456")).toBe(true);
+		expect(isProcessIncarnation("darwin:Thu Jul 17 10:00:00 2025")).toBe(false);
+	});
+
+	test("default-path produces canonical windows:<filetime> format", () => {
+		const result = processIncarnation(4_242, {
+			platform: "win32",
+			runCommand: () => ({ exitCode: 0, stdout: "4242\t133830291061234567\n" }),
+		});
+		expect(result).toBe("windows:133830291061234567");
+		expect(isProcessIncarnation(result)).toBe(true);
+	});
+
+	test("locale-dependent Darwin lstart strings are not canonical", () => {
+		expect(isProcessIncarnation("darwin:Thu Jul 17 10:00:00 2025")).toBe(false);
+		expect(isProcessIncarnation("darwin:Do 17 Jul 2025 10:00:00")).toBe(false);
+		expect(isProcessIncarnation("darwin:1700000000:123456")).toBe(true);
+	});
+
+	test("reclaims a non-canonical Darwin lstart owner lock as not-owned", async () => {
+		const agentDir = tempAgentDir();
+		const paths = chatDaemonPaths(agentDir, "discord");
+		fs.mkdirSync(paths.dir, { recursive: true });
+		// Simulate a stale lock written by the old locale-dependent defaultPidIncarnation.
+		fs.writeFileSync(
+			paths.lock,
+			JSON.stringify({ pid: 95, incarnation: "darwin:Thu Jul 17 10:00:00 2025", createdAt: 1 }),
+		);
+		fs.writeFileSync(
+			paths.state,
+			JSON.stringify({
+				version: 1,
+				kind: "discord",
+				pid: 95,
+				ownerId: "old",
+				identity: "old",
+				incarnation: "darwin:Thu Jul 17 10:00:00 2025",
+				startedAt: 1,
+				heartbeatAt: 1,
+			}),
+		);
+		const probe = {
+			pidAlive: () => true,
+			pidIncarnation: () => "darwin:1700000000:123456",
+		};
+		expect(
+			await acquireChatDaemonOwnership({
+				agentDir,
+				kind: "discord",
+				ownerId: "new",
+				pid: 96,
+				identity: "identity",
+				incarnation: "darwin:1700000000:123456",
+				...probe,
+			}),
+		).toBe(true);
+		expect(JSON.parse(fs.readFileSync(paths.state, "utf8")).ownerId).toBe("new");
 	});
 });

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -17,6 +17,11 @@ import {
 } from "../src/daemon/operator-contract";
 import { resolveGjcRuntimeSpawnInfo } from "../src/daemon/runtime";
 import {
+	isProcessIncarnation,
+	parseDarwinProcessIncarnation,
+	processIncarnation,
+} from "../src/sdk/broker/process-incarnation";
+import {
 	acquireChatDaemonOwnership,
 	buildChatDaemonSpawnArgs,
 	ChatDaemonController,
@@ -32,7 +37,6 @@ import {
 	TelegramDaemonController,
 	writeTelegramControlRequest,
 } from "../src/sdk/bus/telegram-daemon-control";
-import { isProcessIncarnation, parseDarwinProcessIncarnation, processIncarnation } from "../src/sdk/broker/process-incarnation";
 import { TopicRegistry } from "../src/sdk/bus/topic-registry";
 
 const BOT_TOKEN = "123456:secret-token";
@@ -1121,11 +1125,8 @@ describe("canonical processIncarnation daemon lock identity", () => {
 		const view = new DataView(bsdInfo.buffer);
 		view.setBigUint64(120, 1_700_000_000n, true);
 		view.setBigUint64(128, 123_456n, true);
-		const result = processIncarnation(4_242, {
-			platform: "darwin",
-			runCommand: () => ({ exitCode: 0, stdout: "" }),
-		});
-		expect(result).toBeUndefined();
+		const result = parseDarwinProcessIncarnation(bsdInfo);
+		expect(result).toBe("darwin:1700000000:123456");
 		expect(isProcessIncarnation("darwin:1700000000:123456")).toBe(true);
 		expect(isProcessIncarnation("darwin:Thu Jul 17 10:00:00 2025")).toBe(false);
 	});

--- a/packages/coding-agent/test/sdk-daemon-concurrency.test.ts
+++ b/packages/coding-agent/test/sdk-daemon-concurrency.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { isProcessIncarnation, processIncarnation } from "../src/sdk/broker/process-incarnation";
 import { ChatEffectJournal, MAX_TERMINAL_CHAT_EFFECTS } from "../src/sdk/bus/chat-effect-journal";
 import {
 	boundedDedupe,
@@ -8,7 +9,6 @@ import {
 	conversationStorePath,
 	MAX_DEDUPE_IDS,
 } from "../src/sdk/bus/conversation-store";
-import { isProcessIncarnation, processIncarnation } from "../src/sdk/broker/process-incarnation";
 import type { SlackConversation } from "../src/sdk/bus/slack-conversation";
 import { MemoryConversationStoreFs } from "./fixtures/chat-daemon-stores";
 
@@ -123,8 +123,14 @@ describe("ConversationStore", () => {
 			pidIncarnation: pid => (pid === 303 ? "darwin:1700000000:123456" : "darwin:1700000000:654321"),
 			lockTimeoutMs: 0,
 		});
-		fs.files.set(`${store.filePath}.lock`, JSON.stringify({ pid: 101, incarnation: "darwin:1700000000:999999", timestamp: 1 }));
-		fs.files.set(`${store.filePath}.lock.reclaim`, JSON.stringify({ pid: 303, incarnation: "darwin:1700000000:123456", timestamp: 1 }));
+		fs.files.set(
+			`${store.filePath}.lock`,
+			JSON.stringify({ pid: 101, incarnation: "darwin:1700000000:999999", timestamp: 1 }),
+		);
+		fs.files.set(
+			`${store.filePath}.lock.reclaim`,
+			JSON.stringify({ pid: 303, incarnation: "darwin:1700000000:123456", timestamp: 1 }),
+		);
 		await expect(store.write("mapping", undefined, record(1))).rejects.toBeInstanceOf(ConversationLockTimeoutError);
 		expect(fs.files.get(`${store.filePath}.lock.reclaim`)).toBe(
 			JSON.stringify({ pid: 303, incarnation: "darwin:1700000000:123456", timestamp: 1 }),
@@ -132,7 +138,6 @@ describe("ConversationStore", () => {
 	});
 
 	test("default-path lock uses canonical processIncarnation format", async () => {
-		const fs = new MemoryConversationStoreFs();
 		let capturedLock: string | undefined;
 		class CapturingFs extends MemoryConversationStoreFs {
 			override async open(file: string, flags: string) {

--- a/packages/coding-agent/test/sdk-daemon-concurrency.test.ts
+++ b/packages/coding-agent/test/sdk-daemon-concurrency.test.ts
@@ -8,6 +8,7 @@ import {
 	conversationStorePath,
 	MAX_DEDUPE_IDS,
 } from "../src/sdk/bus/conversation-store";
+import { isProcessIncarnation, processIncarnation } from "../src/sdk/broker/process-incarnation";
 import type { SlackConversation } from "../src/sdk/bus/slack-conversation";
 import { MemoryConversationStoreFs } from "./fixtures/chat-daemon-stores";
 
@@ -119,15 +120,68 @@ describe("ConversationStore", () => {
 			fs,
 			pid: 202,
 			pidAlive: pid => pid !== 101,
-			pidIncarnation: pid => (pid === 303 ? "live" : "writer"),
+			pidIncarnation: pid => (pid === 303 ? "darwin:1700000000:123456" : "darwin:1700000000:654321"),
 			lockTimeoutMs: 0,
 		});
-		fs.files.set(`${store.filePath}.lock`, JSON.stringify({ pid: 101, incarnation: "dead", timestamp: 1 }));
-		fs.files.set(`${store.filePath}.lock.reclaim`, JSON.stringify({ pid: 303, incarnation: "live", timestamp: 1 }));
+		fs.files.set(`${store.filePath}.lock`, JSON.stringify({ pid: 101, incarnation: "darwin:1700000000:999999", timestamp: 1 }));
+		fs.files.set(`${store.filePath}.lock.reclaim`, JSON.stringify({ pid: 303, incarnation: "darwin:1700000000:123456", timestamp: 1 }));
 		await expect(store.write("mapping", undefined, record(1))).rejects.toBeInstanceOf(ConversationLockTimeoutError);
 		expect(fs.files.get(`${store.filePath}.lock.reclaim`)).toBe(
-			JSON.stringify({ pid: 303, incarnation: "live", timestamp: 1 }),
+			JSON.stringify({ pid: 303, incarnation: "darwin:1700000000:123456", timestamp: 1 }),
 		);
+	});
+
+	test("default-path lock uses canonical processIncarnation format", async () => {
+		const fs = new MemoryConversationStoreFs();
+		let capturedLock: string | undefined;
+		class CapturingFs extends MemoryConversationStoreFs {
+			override async open(file: string, flags: string) {
+				const handle = await super.open(file, flags);
+				if (flags === "wx" && file.endsWith(".lock")) {
+					return {
+						...handle,
+						writeFile: async (data: string, encoding: "utf8") => {
+							capturedLock = data.trim();
+							await handle.writeFile(data, encoding);
+						},
+					};
+				}
+				return handle;
+			}
+		}
+		const capturingFs = new CapturingFs();
+		const store = new ConversationStore<TestConversation>({
+			agentDir: "/agent",
+			kind: "discord",
+			fs: capturingFs,
+			pid: process.pid,
+			pidAlive: () => true,
+		});
+		await store.write("mapping", undefined, record(1));
+		expect(capturedLock).toBeDefined();
+		const lock = JSON.parse(capturedLock!);
+		expect(lock.pid).toBe(process.pid);
+		// The incarnation must be canonical (not a locale-dependent lstart string).
+		expect(isProcessIncarnation(lock.incarnation)).toBe(true);
+		expect(lock.incarnation).toBe(processIncarnation(process.pid));
+	});
+
+	test("reclaims a non-canonical locale-dependent Darwin lock as not-owned", async () => {
+		const fs = new MemoryConversationStoreFs();
+		const store = new ConversationStore<TestConversation>({
+			agentDir: "/agent",
+			kind: "discord",
+			fs,
+			pid: 202,
+			pidAlive: () => true,
+			pidIncarnation: () => "darwin:1700000000:123456",
+		});
+		// Simulate a stale lock written by the old locale-dependent defaultPidIncarnation.
+		fs.files.set(
+			`${store.filePath}.lock`,
+			JSON.stringify({ pid: 101, incarnation: "darwin:Thu Jul 17 10:00:00 2025", timestamp: 1 }),
+		);
+		expect(await store.write("mapping", undefined, record(1))).toBe(true);
 	});
 
 	test("serializes separate store instances so independent mapping updates do not overwrite one another", async () => {


### PR DESCRIPTION
## Summary

`chat-daemon-control.ts` and `conversation-store.ts` contained local `defaultPidIncarnation` implementations that produced Darwin locale-dependent strings from `ps -o lstart` (e.g. `darwin:Thu Jul 17 10:00:00 2025`). The canonical `processIncarnation()` in `process-incarnation.ts` produces numeric `darwin:<sec>:<usec>` format. Using non-canonical formats for daemon lock identity meant locks from different code paths were incomparable.

## Changes

1. **`process-incarnation.ts`**: Exported `isProcessIncarnation` (previously module-private) so daemon lock reclaim logic can detect non-canonical stored values.

2. **`chat-daemon-control.ts`**:
   - Deleted the local `defaultPidIncarnation` function (22 lines).
   - Removed the now-unused `spawnSync` import.
   - Imported `processIncarnation` and `isProcessIncarnation` from `../broker/process-incarnation`.
   - Replaced both `defaultPidIncarnation` references with `processIncarnation`.
   - Updated `isStaleChatDaemonLock`: non-canonical stored lock values (not matching `isProcessIncarnation`) are now treated as not-owned/reclaimable, implementing the migration policy.

3. **`conversation-store.ts`**:
   - Deleted the local `defaultPidIncarnation` function (22 lines).
   - Removed the now-unused `spawnSync` and `readFileSync` imports.
   - Imported `processIncarnation` and `isProcessIncarnation` from `../broker/process-incarnation`.
   - Replaced the `defaultPidIncarnation` reference with `processIncarnation`.
   - Updated `#isStaleLock`: non-canonical stored lock values are now treated as not-owned/reclaimable.

4. **Tests** (`daemon-control.test.ts`):
   - Updated "does not steal a fresh reclaim lock owned by a live incarnation" to use canonical incarnation values (`darwin:<sec>:<usec>`) instead of non-canonical test doubles.
   - Added "canonical processIncarnation daemon lock identity" describe block with tests for:
     - Linux canonical format (`linux:<startTicks>`)
     - Darwin canonical format (`darwin:<sec>:<usec>`) via `parseDarwinProcessIncarnation`
     - Windows canonical format (`windows:<filetime>`)
     - Locale-dependent Darwin lstart strings rejected by `isProcessIncarnation`
     - Reclaim of a non-canonical Darwin lstart owner lock as not-owned

5. **Tests** (`sdk-daemon-concurrency.test.ts`):
   - Updated "does not steal a fresh live reclaim lock or bypass the lock timeout" to use canonical incarnation values.
   - Added "default-path lock uses canonical processIncarnation format" test verifying the lock file contains a canonical incarnation when using the default (non-injected) path.
   - Added "reclaims a non-canonical locale-dependent Darwin lock as not-owned" test.

## Verification

```
bun test packages/coding-agent/test/daemon-control.test.ts     # 45 pass
bun test packages/coding-agent/test/sdk-daemon-concurrency.test.ts  # 14 pass
```
