### PR TITLE
feat(coding-agent): subagent session picker for the Ctrl+S observer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Added
 - Double-Esc now clears an idle draft after a confirmation hint, saving it to prompt history; from an empty editor it follows the configured tree, branch, or disabled action.
 - Added a searchable command palette with direct action dispatch; slash commands run only from an empty composer, and drafts are never touched.
+- The subagent session observer (Ctrl+S) now opens a session picker that lists the main session and every subagent with live status, agent, and progress; Enter opens a subagent's transcript, `[`/`]` cycles agents, and Esc/Ctrl+S steps back to the list. Previously Ctrl+S jumped straight into the most recently active subagent's transcript with no way to browse the others.
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -66,6 +66,8 @@ export class SessionObserverOverlayComponent extends Container {
 	#onDone: () => void;
 	#selectedSessionId?: string;
 	#observeKeys: KeyId[];
+	#mode: "picker" | "viewer" = "picker";
+	#pickerIndex = 0;
 	#transcriptCache?: { path: string; bytesRead: number; entries: SessionMessageEntry[]; model?: string };
 
 	// Scroll state
@@ -94,14 +96,18 @@ export class SessionObserverOverlayComponent extends Container {
 		this.#onDone = onDone;
 		this.#observeKeys = observeKeys;
 
-		// Jump directly to the most recently active sub-agent
+		// Open the picker listing main + subagent sessions. Pre-select the most
+		// recently active sub-agent so Enter dives straight into the busy one.
+		const subagents = this.#registry.getSessions().filter(s => s.kind === "subagent");
+		if (subagents.length === 0) {
+			// Nothing to observe — close immediately.
+			queueMicrotask(() => this.#onDone());
+			return;
+		}
 		const mostRecent = this.#getMostRecentSubagent();
 		if (mostRecent) {
-			this.#selectedSessionId = mostRecent.id;
-			this.#setupViewer();
-		} else {
-			// No sub-agents — close immediately
-			queueMicrotask(() => this.#onDone());
+			const idx = this.#getPickerSessions().findIndex(s => s.id === mostRecent.id);
+			this.#pickerIndex = idx >= 0 ? idx : 0;
 		}
 	}
 
@@ -116,7 +122,117 @@ export class SessionObserverOverlayComponent extends Container {
 	}
 
 	override render(width: number): string[] {
-		return this.#renderViewer(width);
+		return this.#mode === "picker" ? this.#renderPicker(width) : this.#renderViewer(width);
+	}
+
+	#getPickerSessions(): ObservableSession[] {
+		return this.#registry.getSessions();
+	}
+
+	#enterViewer(sessionId: string): void {
+		this.#mode = "viewer";
+		this.#selectedSessionId = sessionId;
+		this.#transcriptCache = undefined;
+		this.#navigationStack = [];
+		this.#setupViewer();
+	}
+
+	#returnToPicker(): void {
+		this.#mode = "picker";
+		this.#transcriptCache = undefined;
+		this.#navigationStack = [];
+		if (this.#selectedSessionId) {
+			const idx = this.#getPickerSessions().findIndex(s => s.id === this.#selectedSessionId);
+			if (idx >= 0) this.#pickerIndex = idx;
+		}
+	}
+
+	#handlePickerInput(keyData: string): void {
+		const sessions = this.#getPickerSessions();
+		const count = sessions.length;
+
+		if (matchesKey(keyData, "escape")) {
+			this.#onDone();
+			return;
+		}
+		if (keyData === "j" || matchesKey(keyData, "down")) {
+			if (count > 0) this.#pickerIndex = Math.min(this.#pickerIndex + 1, count - 1);
+			return;
+		}
+		if (keyData === "k" || matchesKey(keyData, "up")) {
+			if (count > 0) this.#pickerIndex = Math.max(this.#pickerIndex - 1, 0);
+			return;
+		}
+		if (keyData === "g") {
+			this.#pickerIndex = 0;
+			return;
+		}
+		if (keyData === "G") {
+			if (count > 0) this.#pickerIndex = count - 1;
+			return;
+		}
+		if (matchesKey(keyData, "enter") || keyData === "\r" || keyData === "\n") {
+			const target = sessions[this.#pickerIndex];
+			if (!target) return;
+			// Main session has no observable transcript here — Enter jumps back out.
+			if (target.kind === "main") {
+				this.#onDone();
+				return;
+			}
+			this.#enterViewer(target.id);
+			return;
+		}
+	}
+
+	#renderPicker(width: number): string[] {
+		const termHeight = process.stdout.rows || 40;
+		const sessions = this.#getPickerSessions();
+		const subagentCount = sessions.filter(s => s.kind === "subagent").length;
+
+		// Header chrome: border + title + count + border = 4 lines.
+		// Footer chrome: spacer + hints + border = 3 lines.
+		const viewport = Math.max(3, termHeight - 7);
+
+		if (this.#pickerIndex >= sessions.length) this.#pickerIndex = Math.max(0, sessions.length - 1);
+
+		let start = 0;
+		if (sessions.length > viewport) {
+			start = Math.max(0, Math.min(this.#pickerIndex - Math.floor(viewport / 2), sessions.length - viewport));
+		}
+		const visible = sessions.slice(start, start + viewport);
+
+		const lines: string[] = [];
+		lines.push(...new DynamicBorder().render(width));
+		lines.push(` ${theme.fg("accent", "Session Observer")}`);
+		lines.push(` ${theme.fg("dim", `${sessions.length} session(s) · ${subagentCount} subagent(s)`)}`);
+		lines.push(...new DynamicBorder().render(width));
+
+		for (let i = 0; i < visible.length; i++) {
+			const session = visible[i];
+			const selected = start + i === this.#pickerIndex;
+			lines.push(` ${this.#buildPickerRow(session, selected, width - 2)}`);
+		}
+		const pad = viewport - visible.length;
+		for (let i = 0; i < pad; i++) lines.push("");
+
+		lines.push("");
+		lines.push(` ${theme.fg("dim", "j/k:navigate  Enter:open  g/G:top/bottom  Esc/Ctrl+S:close")}`);
+		lines.push(...new DynamicBorder().render(width));
+		return lines;
+	}
+
+	#buildPickerRow(session: ObservableSession, selected: boolean, width: number): string {
+		const cursor = selected ? theme.fg("accent", "▶") : " ";
+		const statusColor = session.status === "active" ? "success" : session.status === "failed" ? "error" : "dim";
+		const status = theme.fg(statusColor, `[${session.status}]`);
+		// The subagent label already carries its description, so show the agent
+		// role once (not a duplicated description) alongside the label.
+		const agentPart = session.agent ? `${theme.fg("dim", session.agent)}  ` : "";
+		const rawLabel = sanitizeLine(session.label, TRUNCATE_LENGTHS.TITLE);
+		const label = selected ? theme.bold(rawLabel) : rawLabel;
+		const stats = session.kind === "subagent" ? this.#buildStatsLine(session) : "";
+		const statsPart = stats ? `  ${stats}` : "";
+		return truncateToWidth(`${cursor} ${status} ${agentPart}${label}${statsPart}`, width);
 	}
 
 	#setupViewer(): void {
@@ -136,6 +252,12 @@ export class SessionObserverOverlayComponent extends Container {
 
 	/** Rebuild content from live registry data */
 	refreshFromRegistry(): void {
+		if (this.#mode === "picker") {
+			// Picker reads the registry live on render; just keep the cursor in range.
+			const count = this.#getPickerSessions().length;
+			if (this.#pickerIndex >= count) this.#pickerIndex = Math.max(0, count - 1);
+			return;
+		}
 		if (this.#selectedSessionId) {
 			// Keep auto-scrolling to bottom unless the user navigated away from the last entry
 			this.#wasAtBottom = this.#selectedEntryIndex >= this.#viewerEntries.length - 1;
@@ -628,24 +750,33 @@ export class SessionObserverOverlayComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
-		// Ctrl+S (observe key) always closes the overlay
+		// Observe key (Ctrl+S): in the viewer it steps back to the picker;
+		// in the picker it toggles the overlay closed.
 		for (const key of this.#observeKeys) {
 			if (matchesKey(keyData, key)) {
-				this.#onDone();
+				if (this.#mode === "viewer") {
+					this.#returnToPicker();
+				} else {
+					this.#onDone();
+				}
 				return;
 			}
 		}
 
-		this.#handleViewerInput(keyData);
+		if (this.#mode === "picker") {
+			this.#handlePickerInput(keyData);
+		} else {
+			this.#handleViewerInput(keyData);
+		}
 	}
 
 	#handleViewerInput(keyData: string): void {
 		const entryCount = this.#viewerEntries.length;
 
-		// Escape — pop breadcrumb navigation or close overlay
+		// Escape — pop breadcrumb navigation, or return to the picker
 		if (matchesKey(keyData, "escape")) {
 			if (!this.#navigateBack()) {
-				this.#onDone();
+				this.#returnToPicker();
 			}
 			return;
 		}

--- a/packages/coding-agent/test/modes/components/session-observer-picker.test.ts
+++ b/packages/coding-agent/test/modes/components/session-observer-picker.test.ts
@@ -1,0 +1,117 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { SessionObserverOverlayComponent } from "../../../src/modes/components/session-observer-overlay";
+import { SessionObserverRegistry } from "../../../src/modes/session-observer-registry";
+import * as themeModule from "../../../src/modes/theme/theme";
+import { TASK_SUBAGENT_LIFECYCLE_CHANNEL } from "../../../src/task";
+import { EventBus } from "../../../src/utils/event-bus";
+
+interface SubSpec {
+	id: string;
+	desc: string;
+	agent: string;
+	file: string;
+}
+
+function buildRegistry(subs: SubSpec[]): SessionObserverRegistry {
+	const bus = new EventBus();
+	const registry = new SessionObserverRegistry();
+	registry.subscribeToEventBus(bus);
+	registry.setMainSession("/tmp/session-observer-main.jsonl");
+	subs.forEach((sub, i) => {
+		bus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: sub.id,
+			agent: sub.agent,
+			agentSource: "builtin",
+			description: sub.desc,
+			status: "started",
+			sessionFile: sub.file,
+			index: i + 1,
+		});
+	});
+	return registry;
+}
+
+function makeOverlay(registry: SessionObserverRegistry): {
+	overlay: SessionObserverOverlayComponent;
+	isDone: () => boolean;
+} {
+	let done = false;
+	const overlay = new SessionObserverOverlayComponent(registry, () => {
+		done = true;
+	}, []);
+	return { overlay, isDone: () => done };
+}
+
+function renderText(overlay: SessionObserverOverlayComponent, width: number): string {
+	return overlay
+		.render(width)
+		.map(line => Bun.stripANSI(line))
+		.join("\n");
+}
+
+const TWO_SUBS: SubSpec[] = [
+	{ id: "1-executor", desc: "Implement ingestion pipeline", agent: "executor", file: "/tmp/sa-1.jsonl" },
+	{ id: "2-planner", desc: "Sequence review UI work", agent: "planner", file: "/tmp/sa-2.jsonl" },
+];
+
+describe("SessionObserverOverlayComponent picker mode", () => {
+	beforeAll(async () => {
+		await themeModule.initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+	});
+
+	it("opens in picker mode and lists the main session plus every subagent", () => {
+		const { overlay } = makeOverlay(buildRegistry(TWO_SUBS));
+		const out = renderText(overlay, 100);
+
+		expect(out).toContain("Session Observer");
+		expect(out).toContain("2 subagent(s)");
+		expect(out).toContain("Main Session");
+		expect(out).toContain("Implement ingestion pipeline");
+		expect(out).toContain("Sequence review UI work");
+		// Picker footer, not the transcript viewer footer.
+		expect(out).toContain("j/k:navigate");
+		expect(out).not.toContain("cycle agents");
+	});
+
+	it("keeps every rendered row within the viewport width", () => {
+		const { overlay } = makeOverlay(buildRegistry(TWO_SUBS));
+		for (const line of overlay.render(100).map(l => Bun.stripANSI(l))) {
+			expect(Bun.stringWidth(line, { countAnsiEscapeCodes: false })).toBeLessThanOrEqual(100);
+		}
+	});
+
+	it("Enter on a subagent opens the transcript viewer and Escape returns to the picker", () => {
+		const { overlay } = makeOverlay(buildRegistry(TWO_SUBS));
+
+		overlay.handleInput("\r");
+		let out = renderText(overlay, 100);
+		expect(out).toContain("cycle agents");
+		expect(out).not.toContain("j/k:navigate");
+
+		overlay.handleInput("\u001b");
+		out = renderText(overlay, 100);
+		expect(out).toContain("j/k:navigate");
+		expect(out).not.toContain("cycle agents");
+	});
+
+	it("Enter on the main session row closes the overlay", () => {
+		const { overlay, isDone } = makeOverlay(buildRegistry(TWO_SUBS));
+		overlay.handleInput("g"); // jump to the top row (main session)
+		overlay.handleInput("\r");
+		expect(isDone()).toBe(true);
+	});
+
+	it("closes immediately when there are no subagent sessions", async () => {
+		const bus = new EventBus();
+		const registry = new SessionObserverRegistry();
+		registry.subscribeToEventBus(bus);
+		registry.setMainSession("/tmp/session-observer-main.jsonl");
+
+		let done = false;
+		new SessionObserverOverlayComponent(registry, () => {
+			done = true;
+		}, []);
+		await new Promise<void>(resolve => queueMicrotask(resolve));
+		expect(done).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/silent-abort-overlay-render.test.ts
+++ b/packages/coding-agent/test/silent-abort-overlay-render.test.ts
@@ -96,8 +96,9 @@ describe("Observer overlay silent-abort regression", () => {
 
 		const overlay = new SessionObserverOverlayComponent(registry, () => {}, ["ctrl+s"]);
 
-		// Render with a reasonable width — the overlay reads the session file
-		// and calls #buildTranscriptLines internally.
+		// The overlay opens in picker mode; Enter dives into the transcript viewer,
+		// which reads the session file and calls #buildTranscriptLines internally.
+		overlay.handleInput("\r");
 		const rendered = overlay.render(120);
 		const renderedText = rendered.join("\n");
 
@@ -156,6 +157,7 @@ describe("Observer overlay silent-abort regression", () => {
 
 		const overlay = new SessionObserverOverlayComponent(registry, () => {}, ["ctrl+s"]);
 
+		overlay.handleInput("\r"); // enter the transcript viewer for the subagent
 		const rendered = overlay.render(120);
 		const renderedText = rendered.join("\n");
 


### PR DESCRIPTION
## What & why

The session observer overlay (`Ctrl+S`) already documented a **picker mode** in its own file header — _"Picker mode: lists main + active subagent sessions"_ — but the implementation skipped it and jumped straight into the **most recently active** subagent's transcript. When several subagents run in parallel (e.g. an ultragoal / team fan-out) there was no way to see them all or choose which one to inspect.

This PR implements that documented picker, so `Ctrl+S` opens a real list of the main session plus every subagent.

## Behaviour

**Before:** `Ctrl+S` → jump straight into the most recent subagent transcript. No list.

**After:**
- `Ctrl+S` → picker listing the main session + every subagent with **live status, agent role, and progress** (tools / ctx / Σtokens / duration / cost).
- `Enter` → open that subagent's transcript.
- `[` / `]` (and `←` / `→`) → cycle agents inside the viewer (unchanged).
- `Esc` / `Ctrl+S` in the viewer → step back to the list.
- `Esc` in the list → close the overlay.
- The most-recently-active subagent stays **pre-selected**, so a single `Enter` reaches it (one extra keypress vs. the old jump-straight-in).

The picker reuses the existing `SessionObserverRegistry.getSessions()` data — no new state plumbing.

## Live capture

Real TUI, three finished `architect` subagents, after pressing `Ctrl+S`:

```
────────────────────────────────────────────────────────────────────
 Session Observer
 4 session(s) · 3 subagent(s)
────────────────────────────────────────────────────────────────────
   [active] Main Session
   [completed] architect  Map the executor runtime   7 tools · 50K/1M ctx · Σ51K · 1m16s · $0.46
   [completed] architect  Map the subagent tool     12 tools · 54K/1M ctx · Σ60K · 1m17s · $0.55
 ▶ [completed] architect  Map task orchestration    14 tools · 55K/1M ctx · Σ62K · 1m39s · $0.60

 j/k:navigate  Enter:open  g/G:top/bottom  Esc/Ctrl+S:close
────────────────────────────────────────────────────────────────────
```

## Tests / checks

- `bun test packages/coding-agent/test/modes/components/session-observer-picker.test.ts` — **new** (5 tests): picker listing, viewport-width safety, `Enter`→viewer→`Esc` round trip, `Enter` on main closes, no-subagent immediate close.
- `bun test packages/coding-agent/test/silent-abort-overlay-render.test.ts` — updated (2 tests): drive `Enter` into the viewer before asserting transcript rendering, since that path now lives behind the picker.
- `bun --cwd packages/coding-agent run check:types` — clean.
- `biome check` on touched files — clean.

## Notes

- User-facing behaviour change → changelog entry added under `packages/coding-agent/CHANGELOG.md` (`[Unreleased] → Added`).
- Base branch: `dev` (per `CONTRIBUTING.md`).
