### PR TITLE
Close the factory-owned auth store on session dispose

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `createAgentSession` now closes the factory-owned credential store on dispose, releasing the `agent.db` SQLite WAL/SHM handles that leaked a connection per embedded session and, on Windows, blocked agent-directory removal with `EBUSY`. Embedder-supplied `authStorage`/`modelRegistry` instances remain open for the embedder.
+
 ## [0.11.1] - 2026-07-16
 
 ### Fixed

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -985,6 +985,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			"options.authStorage and options.modelRegistry.authStorage must be the same instance when both are provided",
 		);
 	}
+	// The factory owns the credential store only when it opened it itself via
+	// discoverAuthStorage(); embedder-supplied storage/registries must stay open
+	// for the embedder. Owned stores are closed on dispose — on Windows an open
+	// SQLite WAL handle (agent.db-shm mapping) otherwise blocks agent-dir removal.
+	const ownsAuthStorage = !options.modelRegistry && !options.authStorage;
 	// Subscribe before any getApiKey() call so startup model probes can't fire a
 	// credential_disabled event past us. An embedder's constructor handler makes the
 	// listener set non-empty from construction, which defeats AuthStorage's no-listener
@@ -2583,6 +2588,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					agentRegistry.unregister(resolvedAgentId);
 					unsubscribeCredentialDisabled?.();
 					releaseLocalProtocolOverride();
+					if (ownsAuthStorage) authStorage.close();
 				}
 			};
 		}
@@ -2713,6 +2719,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			logger.warn("Failed to clean up createAgentSession resources after startup error");
 		} finally {
 			releaseLocalProtocolOverride();
+			// Idempotent with the dispose wrapper: AuthStorage.close() guards re-entry.
+			if (ownsAuthStorage) authStorage.close();
 		}
 		throw error;
 	}


### PR DESCRIPTION
## Problem

`createAgentSession()` opens `agent.db` (SQLite, WAL mode) through `discoverAuthStorage()` but never closes it. Every embedded session leaks one SQLite connection. On Windows the retained WAL/SHM mapping is worse: after `session.dispose()` the agent directory cannot be removed (`EBUSY`), which deterministically fails fixture cleanup in `sdk-adapter-dispositions.test.ts` (the surviving lock holders are exactly `agent.db`, `agent.db-shm`, `agent.db-wal`).

## Fix

- Track ownership: the factory owns the store only when neither `options.authStorage` nor `options.modelRegistry` was supplied.
- Close the owned store in the `dispose` wrapper and in the startup-error cleanup path. `AuthStorage.close()` already guards re-entry, so the double-close is safe. Embedder-supplied stores remain untouched.

## Verification

- `tsc -p packages/coding-agent/tsconfig.json --noEmit` clean.
- On Windows, `sdk-adapter-dispositions.test.ts` `^AD-M-` rows went from deterministic `EBUSY` cleanup failures to 91/91 pass with this change (validated together with the Windows spawn fixes from the companion PR, since spawning the detached broker at all requires those on Windows).