### PR TITLE
Fix Windows AVX2 variant detection (always-baseline + console flash per process)

### DIFF
--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows AVX2 variant detection now uses an in-process `kernel32!IsProcessorFeaturePresent` probe under Bun, with a Windows PowerShell 5.1-compatible P/Invoke fallback. The previous `System.Runtime.Intrinsics` probe does not exist on stock Windows PowerShell, so detection always chose the baseline addon on AVX2-capable CPUs, and the per-process `powershell.exe` spawn flashed a console window from every detached, console-less parent (e.g. the SDK broker).
+
 ## [0.11.0] - 2026-07-15
 
 ### Fixed

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -231,7 +231,10 @@ export function loadFromCandidates({ candidates, requireCandidate, validateCandi
 
 function runCommand(command, args) {
 	try {
-		const result = childProcess.spawnSync(command, args, { encoding: "utf-8" });
+		// windowsHide keeps the probe console-less: inside a detached, console-less
+		// parent (e.g. the SDK broker) spawning a console app like powershell.exe
+		// would otherwise allocate and flash a new console window per invocation.
+		const result = childProcess.spawnSync(command, args, { encoding: "utf-8", windowsHide: true });
 		if (result.error) return null;
 		if (result.status !== 0) return null;
 		return (result.stdout || "").trim();
@@ -246,6 +249,8 @@ function getVariantOverride() {
 	if (value === "modern" || value === "baseline") return value;
 	return null;
 }
+
+const WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE = 40;
 
 function detectAvx2Support() {
 	if (process.arch !== "x64") {
@@ -271,11 +276,30 @@ function detectAvx2Support() {
 	}
 
 	if (process.platform === "win32") {
+		// PF_AVX2_INSTRUCTIONS_AVAILABLE: in-process kernel32 probe, no subprocess
+		// and no console window. Preferred because a detached, console-less parent
+		// (e.g. the SDK broker) spawning powershell.exe would flash a new console
+		// window per process start.
+		if (typeof Bun !== "undefined") {
+			try {
+				const { dlopen } = createRequire(import.meta.url)("bun:ffi");
+				const kernel32 = dlopen("kernel32.dll", {
+					IsProcessorFeaturePresent: { args: ["i32"], returns: "bool" },
+				});
+				return Boolean(kernel32.symbols.IsProcessorFeaturePresent(WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE));
+			} catch {
+				// Fall through to the PowerShell probe (ffi unavailable/failed).
+			}
+		}
+		// P/Invoke works on both Windows PowerShell 5.1 and pwsh 7+. A
+		// System.Runtime.Intrinsics type probe would always read false on 5.1
+		// (.NET Framework has no such type), silently forcing baseline.
 		const output = runCommand("powershell.exe", [
 			"-NoProfile",
 			"-NonInteractive",
 			"-Command",
-			"[System.Runtime.Intrinsics.X86.Avx2]::IsSupported",
+			"Add-Type -Namespace GjcNative -Name Cpu -MemberDefinition '[DllImport(\"kernel32.dll\")] public static extern bool IsProcessorFeaturePresent(int feature);'; " +
+				`[GjcNative.Cpu]::IsProcessorFeaturePresent(${WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE})`,
 		]);
 		return output && output.toLowerCase() === "true";
 	}

--- a/scripts/host-detect.ts
+++ b/scripts/host-detect.ts
@@ -1,13 +1,39 @@
+import { dlopen } from "bun:ffi";
 import * as fs from "node:fs";
+
+const WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE = 40;
 
 function runCommand(command: string, args: string[]): string | null {
 	try {
-		const result = Bun.spawnSync([command, ...args], { stdout: "pipe", stderr: "pipe" });
+		const result = Bun.spawnSync([command, ...args], { stdout: "pipe", stderr: "pipe", windowsHide: true });
 		if (result.exitCode !== 0) return null;
 		return result.stdout.toString("utf-8").trim();
 	} catch {
 		return null;
 	}
+}
+
+function detectWin32Avx2Support(): boolean {
+	// In-process kernel32 probe: no subprocess, no console window.
+	try {
+		const kernel32 = dlopen("kernel32.dll", {
+			IsProcessorFeaturePresent: { args: ["i32"], returns: "bool" },
+		});
+		return Boolean(kernel32.symbols.IsProcessorFeaturePresent(WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE));
+	} catch {
+		// Fall through to the PowerShell probe.
+	}
+	// P/Invoke works on both Windows PowerShell 5.1 and pwsh 7+. A
+	// System.Runtime.Intrinsics type probe would always read false on 5.1
+	// (.NET Framework has no such type), silently forcing baseline.
+	const output = runCommand("powershell.exe", [
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		"Add-Type -Namespace GjcNative -Name Cpu -MemberDefinition '[DllImport(\"kernel32.dll\")] public static extern bool IsProcessorFeaturePresent(int feature);'; " +
+			`[GjcNative.Cpu]::IsProcessorFeaturePresent(${WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE})`,
+	]);
+	return output?.toLowerCase() === "true";
 }
 
 export function detectHostAvx2Support(): boolean {
@@ -30,13 +56,7 @@ export function detectHostAvx2Support(): boolean {
 	}
 
 	if (process.platform === "win32") {
-		const output = runCommand("powershell.exe", [
-			"-NoProfile",
-			"-NonInteractive",
-			"-Command",
-			"[System.Runtime.Intrinsics.X86.Avx2]::IsSupported",
-		]);
-		return output?.toLowerCase() === "true";
+		return detectWin32Avx2Support();
 	}
 
 	return false;


### PR DESCRIPTION
## Problem

The native loader's Windows AVX2 probe runs `powershell.exe -Command [System.Runtime.Intrinsics.X86.Avx2]::IsSupported` on every process start. Two bugs:

1. That type does not exist on Windows PowerShell 5.1 (.NET Framework), which is what stock Windows ships. The probe always fails, so the loader always selects the `baseline` addon even on AVX2-capable CPUs (verified on a Ryzen 9700X: probe exits 1 with `Unable to find type`).
2. The spawn has no `windowsHide`, so any detached, console-less parent (the SDK broker, session hosts, daemons) flashes a visible console window on every single process start. During a broker-heavy test run this looks like PowerShell windows opening and closing every second.

## Fix

- Under Bun, probe `kernel32!IsProcessorFeaturePresent(PF_AVX2_INSTRUCTIONS_AVAILABLE = 40)` in-process via `bun:ffi`: no subprocess, no window, correct result.
- Non-Bun fallback: a P/Invoke-based PowerShell probe that works on both Windows PowerShell 5.1 and pwsh 7+, spawned with `windowsHide: true`.
- `scripts/host-detect.ts` (build-time variant selection) gets the same treatment; it previously always built/selected `baseline` on Windows for the same reason.

Selecting `modern` is safe with only a baseline addon on disk: `getAddonFilenames()` already falls back `modern → baseline → default`.

## Verification

- `detectHostAvx2Support()` now returns `true` on an AVX2 host where it returned `false` before.
- Addon load probe passes; `packages/natives` loader tests pass (one pre-existing, unrelated path-separator failure on Windows reproduces identically on `main`).
- Re-ran a broker-heavy test slice under a WMI process watcher: zero `powershell.exe` spawns from GJC processes (previously one per broker child).