### PR TITLE
Fix Windows detached spawns and fsync in SDK broker paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows: detached SDK broker, session-host, and chat/Telegram daemon spawns now route through a `Bun.spawn`-backed console-less facade (Bun's `node:child_process` ignores `windowsHide` for detached children, flashing a console window per spawn). Discovery/store fsync opens writable handles and treats unsupported directory flushes as best-effort instead of failing broker startup with `EPERM`, and legacy regular-file broker locks that Windows reports as `ENOENT` are recovered.
+
 ## [0.11.1] - 2026-07-16
 
 ### Fixed

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -311,22 +311,27 @@ export class Broker {
 			return this.#lockSnapshot(await fs.readFile(this.#lockRecordPath(), "utf8"));
 		} catch (e) {
 			const code = (e as NodeJS.ErrnoException).code;
-			if (code === "ENOTDIR") {
-				try {
-					return this.#lockSnapshot(await fs.readFile(this.#lock, "utf8"));
-				} catch (legacyError) {
-					if ((legacyError as NodeJS.ErrnoException).code === "ENOENT") return null;
-					throw legacyError;
-				}
-			}
+			if (code === "ENOTDIR") return this.#readLegacyLock();
+			// Windows reports ENOENT (not ENOTDIR) when the lock path itself is a
+			// legacy regular file, so ENOENT falls through to the stat probe below
+			// instead of concluding the lock is absent.
 			if (code !== "ENOENT") throw e;
 		}
 		try {
 			const lock = await fs.stat(this.#lock);
-			return lock.isDirectory() ? { pid: 0, identity: `directory:${lock.dev}:${lock.ino}` } : null;
+			if (lock.isDirectory()) return { pid: 0, identity: `directory:${lock.dev}:${lock.ino}` };
+			return this.#readLegacyLock();
 		} catch (e) {
 			if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
 			throw e;
+		}
+	}
+	async #readLegacyLock(): Promise<BrokerLockSnapshot | null> {
+		try {
+			return this.#lockSnapshot(await fs.readFile(this.#lock, "utf8"));
+		} catch (legacyError) {
+			if ((legacyError as NodeJS.ErrnoException).code === "ENOENT") return null;
+			throw legacyError;
 		}
 	}
 	async #createLock(): Promise<void> {

--- a/packages/coding-agent/src/sdk/broker/discovery.ts
+++ b/packages/coding-agent/src/sdk/broker/discovery.ts
@@ -33,7 +33,19 @@ export function isPidAlive(pid: number): boolean {
 	}
 }
 async function syncFile(file: string): Promise<void> {
-	const handle = await fs.open(file, "r");
+	// Windows FlushFileBuffers requires a writable handle (a read-only open
+	// fails the flush with EPERM) and cannot flush directory handles at all.
+	// Open writable there and treat unsyncable targets (directories) as a
+	// best-effort no-op: the rename-based publish stays atomic for readers
+	// even where the durability barrier is unavailable.
+	const win32 = process.platform === "win32";
+	let handle: fs.FileHandle;
+	try {
+		handle = await fs.open(file, win32 ? "r+" : "r");
+	} catch (error) {
+		if (win32) return;
+		throw error;
+	}
 	try {
 		await handle.sync();
 	} finally {

--- a/packages/coding-agent/src/sdk/broker/ensure.ts
+++ b/packages/coding-agent/src/sdk/broker/ensure.ts
@@ -1,4 +1,5 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { spawnDetachedChild } from "../../utils/detached-spawn";
 import { type BrokerDiscovery, brokerProcessIncarnation, readBrokerDiscovery } from "./discovery";
 import { resolveSdkInternalSpawnCommand, type SdkInternalSpawnCommand } from "./runtime";
 export interface EnsureBrokerSettings {
@@ -203,9 +204,10 @@ async function ensureBrokerOnce(settings: EnsureBrokerSettings, initiator: Ensur
 	}
 
 	const command = resolveSdkInternalSpawnCommand("broker-internal");
-	const child = spawn(command.file, [...command.args, "--agent-dir", settings.agentDir], {
-		detached: true,
-		stdio: "ignore",
+	// spawnDetachedChild keeps the detached broker console-less on Windows; Bun's
+	// node:child_process ignores windowsHide for detached children and would
+	// otherwise flash a new console window on every broker spawn.
+	const child = spawnDetachedChild(command.file, [...command.args, "--agent-dir", settings.agentDir], {
 		env: brokerSpawnEnvironment(command, settings.env),
 		...(command.kind === "bun-source" ? { cwd: command.cwd } : {}),
 	});

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1,23 +1,22 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import { getSessionsDir, resolveEquivalentPath } from "@gajae-code/utils";
-
 import {
 	ensureLaunchWorktree,
 	ensureReusableNodeModules,
 	type GjcLaunchWorktreePlan,
 	planLaunchWorktree,
 } from "../../gjc-runtime/launch-worktree";
-
 import { SessionManager } from "../../session/session-manager";
 import {
 	FileSessionStorage,
 	SessionDeleteVerificationError,
 	type VerifiedSessionDeleteTarget,
 } from "../../session/session-storage";
+import { spawnDetachedChild } from "../../utils/detached-spawn";
 import { SdkClient, SdkClientError } from "../client/client";
 import type { SdkStartupFailure, SdkStartupRollbackResult } from "../startup-capability";
 
@@ -747,6 +746,10 @@ function isLifecycleFailureArtifact(value: unknown): value is LifecycleFailureAr
 }
 
 async function syncDirectory(directory: string): Promise<void> {
+	// Windows cannot flush directory handles (FlushFileBuffers fails with
+	// EPERM), so the directory durability barrier is best-effort there. The
+	// rename-based publish stays atomic for readers either way.
+	if (process.platform === "win32") return;
 	const handle = await fs.open(directory, fsSync.constants.O_RDONLY);
 	try {
 		await handle.sync();
@@ -1677,10 +1680,10 @@ async function executeLifecycleResponse(
 		let spawnedAuthority: EffectMarker | undefined;
 		try {
 			const cmd = command(broker);
-			const spawned = spawn(cmd.file, cmd.args, {
+			// spawnDetachedChild keeps detached session hosts console-less on Windows
+			// (Bun's node:child_process ignores windowsHide for detached children).
+			const spawned = spawnDetachedChild(cmd.file, cmd.args, {
 				cwd: launch.cwd,
-				detached: true,
-				stdio: "ignore",
 				env: {
 					...("kind" in cmd ? cmd.env : process.env),
 					GJC_AGENT_DIR: broker.settings.agentDir,

--- a/packages/coding-agent/src/sdk/bus/chat-daemon-control.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-daemon-control.ts
@@ -1,4 +1,4 @@
-import { spawn as childProcessSpawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -12,6 +12,7 @@ import type {
 	DaemonStatus,
 } from "../../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../../daemon/runtime";
+import { spawnDetachedChild } from "../../utils/detached-spawn";
 import { getNotificationConfig, isDiscordConfigured, isSlackConfigured } from "./config";
 
 export type ChatDaemonKind = "discord" | "slack";
@@ -495,7 +496,9 @@ export class ChatDaemonController implements BuiltInDaemonController {
 			agentDir: this.settings.getAgentDir(),
 			execPath: this.deps.execPath,
 		});
-		(this.deps.spawn ?? ((command, args, opts) => childProcessSpawn(command, args, opts)))(command, args, {
+		// spawnDetachedChild keeps the detached chat daemon console-less on Windows
+		// (Bun's node:child_process ignores windowsHide for detached children).
+		(this.deps.spawn ?? ((cmd, cmdArgs) => spawnDetachedChild(cmd, cmdArgs)))(command, args, {
 			detached: true,
 			stdio: "ignore",
 		}).unref?.();

--- a/packages/coding-agent/src/sdk/bus/conversation-store.ts
+++ b/packages/coding-agent/src/sdk/bus/conversation-store.ts
@@ -319,18 +319,24 @@ export class ConversationStore<T extends ConversationRecord> {
 		try {
 			await this.#fs.writeFile(temporary, `${JSON.stringify(document)}\n`, { mode: 0o600 });
 			await this.#fs.chmod(temporary, 0o600);
-			const handle = await this.#fs.open(temporary, "r");
+			// Windows FlushFileBuffers requires a writable handle (a read-only
+			// open fails the flush with EPERM) and cannot flush directory handles
+			// at all; the directory durability barrier is best-effort there.
+			const win32 = process.platform === "win32";
+			const handle = await this.#fs.open(temporary, win32 ? "r+" : "r");
 			try {
 				await handle.sync();
 			} finally {
 				await handle.close();
 			}
 			await this.#fs.rename(temporary, this.#file);
-			const directory = await this.#fs.open(this.#directory, "r");
-			try {
-				await directory.sync();
-			} finally {
-				await directory.close();
+			if (!win32) {
+				const directory = await this.#fs.open(this.#directory, "r");
+				try {
+					await directory.sync();
+				} finally {
+					await directory.close();
+				}
 			}
 		} catch (error) {
 			await this.#fs.unlink(temporary).catch(() => undefined);

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -1,4 +1,3 @@
-import { spawn as childProcessSpawn } from "node:child_process";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -8,6 +7,7 @@ import { withFileLock } from "../../config/file-lock";
 import type { Settings } from "../../config/settings";
 import type { DaemonRuntimeInfo } from "../../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../../daemon/runtime";
+import { spawnDetachedChild } from "../../utils/detached-spawn";
 import { getNotificationConfig, isTelegramConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand, parseRichToggleCommand, parseTelegramControlCommand } from "./config-commands";
 import { daemonPaths, HEARTBEAT_TTL_MS } from "./daemon-paths";
@@ -650,17 +650,18 @@ function defaultDaemonSpawn(
 ): SpawnResult {
 	// Redirect the detached daemon's stdout/stderr to a log file so failures
 	// (e.g. a rejected sendMessage) are diagnosable instead of vanishing.
-	let stdio: "ignore" | ["ignore", number, number] = opts.stdio;
+	let outputFd: number | undefined;
 	if (opts.logPath) {
 		try {
 			fs.mkdirSync(path.dirname(opts.logPath), { recursive: true, mode: 0o700 });
-			const fd = fs.openSync(opts.logPath, "a", 0o600);
-			stdio = ["ignore", fd, fd];
+			outputFd = fs.openSync(opts.logPath, "a", 0o600);
 		} catch {
 			// Fall back to ignoring output if the log file cannot be opened.
 		}
 	}
-	const child = childProcessSpawn(command, args, { detached: opts.detached, stdio });
+	// spawnDetachedChild keeps the detached daemon console-less on Windows
+	// (Bun's node:child_process ignores windowsHide for detached children).
+	const child = spawnDetachedChild(command, args, outputFd === undefined ? {} : { outputFd });
 	// Best-effort autostart: a spawn failure must never crash the host session.
 	child.on("error", () => undefined);
 	return { unref: () => child.unref() };

--- a/packages/coding-agent/src/utils/detached-spawn.ts
+++ b/packages/coding-agent/src/utils/detached-spawn.ts
@@ -1,0 +1,74 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+
+export interface DetachedSpawnOptions {
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	/** Optional file descriptor receiving both stdout and stderr (e.g. a daemon log). */
+	outputFd?: number;
+}
+
+/**
+ * Spawns a detached child that never opens a console window.
+ *
+ * On Windows under Bun, `node:child_process` ignores `windowsHide: true` for
+ * `detached: true` children: every detached broker/session-host/daemon spawn
+ * opens a visible console window. `Bun.spawn` honors `windowsHide` and its
+ * detached children do not allocate a new console, so Windows spawns route
+ * through `Bun.spawn` behind a minimal ChildProcess-shaped facade exposing
+ * exactly the surface the callers use: `pid`, `exitCode`, `signalCode`,
+ * `kill`, `unref`, and `error`/`exit`/`close` events.
+ *
+ * Spawn failures (e.g. a missing executable) throw synchronously, matching
+ * Bun's `node:child_process` behavior that existing callers rely on.
+ *
+ * On other platforms (and non-Bun runtimes) this defers to
+ * `node:child_process.spawn` with `windowsHide: true`, preserving prior
+ * behavior.
+ */
+export function spawnDetachedChild(file: string, args: string[], options: DetachedSpawnOptions = {}): ChildProcess {
+	const stdioTail =
+		options.outputFd === undefined
+			? (["ignore", "ignore"] as const)
+			: ([options.outputFd, options.outputFd] as const);
+	if (process.platform !== "win32" || typeof Bun === "undefined") {
+		return spawn(file, args, {
+			detached: true,
+			stdio: ["ignore", ...stdioTail],
+			// A detached console-subsystem child would otherwise flash a cmd window on Windows under Node.
+			windowsHide: true,
+			env: options.env,
+			...(options.cwd ? { cwd: options.cwd } : {}),
+		});
+	}
+	const proc = Bun.spawn([file, ...args], {
+		stdio: ["ignore", ...stdioTail] as never,
+		detached: true,
+		windowsHide: true,
+		env: options.env as Record<string, string | undefined> | undefined,
+		...(options.cwd ? { cwd: options.cwd } : {}),
+	});
+	const emitter = new EventEmitter();
+	const emitExit = (): void => {
+		emitter.emit("exit", proc.exitCode, proc.signalCode);
+		emitter.emit("close", proc.exitCode, proc.signalCode);
+	};
+	proc.exited.then(emitExit, emitExit);
+	Object.defineProperties(emitter, {
+		pid: { get: () => proc.pid },
+		exitCode: { get: () => proc.exitCode },
+		signalCode: { get: () => proc.signalCode },
+	});
+	const facade = emitter as unknown as ChildProcess & {
+		kill: (signal?: NodeJS.Signals | number) => boolean;
+		unref: () => void;
+	};
+	facade.kill = (signal?: NodeJS.Signals | number): boolean => {
+		proc.kill(signal as never);
+		return true;
+	};
+	facade.unref = (): void => {
+		proc.unref();
+	};
+	return facade;
+}


### PR DESCRIPTION
## Problem

On Windows under Bun, the SDK broker stack is unusable:

1. `node:child_process.spawn()` ignores `windowsHide` for `detached: true` children, so every detached broker/session-host/daemon spawn opens a visible console window.
2. `FlushFileBuffers` requires a writable handle: the read-only `fs.open(file, "r")` + `handle.sync()` in discovery/store publishing fails with `EPERM`, killing broker startup (`Detached SDK broker exited before discovery (code=1)`), and directory handles cannot be flushed at all.
3. A legacy regular-file broker lock surfaces as `ENOENT` (not `ENOTDIR`) on Windows, so it was treated as "no lock".

## Fix

- `spawnDetachedChild()`: a `Bun.spawn`-backed, `ChildProcess`-shaped facade (pid/exitCode/signalCode/kill/unref + error/exit/close) used by broker ensure, lifecycle session hosts, and the chat/Telegram daemons. Non-Windows and non-Bun runtimes keep using `node:child_process.spawn` with `windowsHide: true`.
- File sync opens `r+` on win32 and treats unsyncable targets as best-effort; directory sync is skipped on win32. The rename-based publish stays atomic for readers either way.
- Legacy regular-file lock recovery handles the Windows `ENOENT` shape.

## Verification

- On Windows: `sdk-broker`, `sdk-broker-restart`, `sdk-broker-transport`, `daemon-control` suites pass 80/80 (all previously failed at spawn/fsync).
- `tsc -p packages/coding-agent/tsconfig.json --noEmit` clean.
- Real broker start/stop no longer opens console windows.