### PR TITLE
fix(harness): canonicalize workflow receipt path contract

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
+- Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 
 
 ### Fixed

--- a/packages/coding-agent/src/gjc-runtime/state-migrations.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-migrations.ts
@@ -18,7 +18,7 @@ export interface MigrateAndPersistLegacyStateArgs {
 	cwd: string;
 	skill: string;
 	statePath: string;
-	sessionId?: string;
+	sessionId: string;
 }
 
 export interface MigrateAndPersistLegacyStateResult {

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -1449,7 +1449,7 @@ async function handleWrite(
 		stdout: renderCliWriteReceipt({
 			ok: true,
 			skill: mode,
-			state_path: filePath,
+			state_path: receipt.state_path,
 			current_phase: phase,
 			active,
 			mutation_id: typeof stampedReceipt.mutation_id === "string" ? stampedReceipt.mutation_id : mutationId,
@@ -1535,7 +1535,7 @@ async function handleClear(
 		stdout: renderCliWriteReceipt({
 			ok: true,
 			skill: mode,
-			state_path: filePath,
+			state_path: receipt.state_path,
 			active: false,
 			current_phase: typeof cleared.current_phase === "string" ? cleared.current_phase : undefined,
 			mutation_id: typeof stampedReceipt.mutation_id === "string" ? stampedReceipt.mutation_id : mutationId,

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -50,7 +50,7 @@ export interface StateWriterReceiptContext {
 	skill: CanonicalGjcWorkflowSkill;
 	owner: WorkflowStateMutationOwner;
 	command: string;
-	sessionId?: string;
+	sessionId: string;
 	mutationId?: string;
 	nowIso?: string;
 	verb?: string;
@@ -267,7 +267,7 @@ export function stampWorkflowEnvelopeChecksum<T>(value: T, filePath: string, com
 		content_sha256: {
 			algorithm: "sha256",
 			value: workflowEnvelopeContentSha256(envelope),
-			covered_path: filePath,
+			covered_path: path.resolve(filePath),
 			computed_at: computedAt,
 		},
 	};

--- a/packages/coding-agent/src/skill-state/workflow-state-contract.ts
+++ b/packages/coding-agent/src/skill-state/workflow-state-contract.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { activeSnapshotPath, assertNonEmptyGjcSessionId, modeStatePath } from "../gjc-runtime/session-layout";
 import { CANONICAL_GJC_WORKFLOW_SKILLS, type CanonicalGjcWorkflowSkill, SKILL_ACTIVE_STATE_FILE } from "./active-state";
 import { WORKFLOW_STATE_RECEIPT_FRESH_MS, WORKFLOW_STATE_RECEIPT_VERSION } from "./workflow-state-version";
 
@@ -51,46 +52,8 @@ export interface AuditEntry {
 	paths: string[];
 }
 
-function safeString(value: unknown): string {
-	return typeof value === "string" ? value : "";
-}
-
-function encodePathSegment(value: string): string {
-	return encodeURIComponent(value).replaceAll(".", "%2E");
-}
-
 export function workflowModeStateFileName(skill: CanonicalGjcWorkflowSkill): string {
 	return `${skill}-state.json`;
-}
-
-export function workflowStateStoragePath(cwd: string, skill: CanonicalGjcWorkflowSkill, sessionId?: string): string {
-	const normalizedSessionId = safeString(sessionId).trim();
-	if (normalizedSessionId) {
-		return path.join(
-			cwd,
-			".gjc",
-			"state",
-			"sessions",
-			encodePathSegment(normalizedSessionId),
-			workflowModeStateFileName(skill),
-		);
-	}
-	return path.join(cwd, ".gjc", "state", workflowModeStateFileName(skill));
-}
-
-export function workflowActiveStatePath(cwd: string, sessionId?: string): string {
-	const normalizedSessionId = safeString(sessionId).trim();
-	if (normalizedSessionId) {
-		return path.join(
-			cwd,
-			".gjc",
-			"state",
-			"sessions",
-			encodePathSegment(normalizedSessionId),
-			SKILL_ACTIVE_STATE_FILE,
-		);
-	}
-	return path.join(cwd, ".gjc", "state", SKILL_ACTIVE_STATE_FILE);
 }
 
 export function buildWorkflowStateReceipt(input: {
@@ -98,10 +61,12 @@ export function buildWorkflowStateReceipt(input: {
 	skill: CanonicalGjcWorkflowSkill;
 	owner: WorkflowStateMutationOwner;
 	command: string;
-	sessionId?: string;
+	sessionId: string;
 	nowIso?: string;
 	mutationId?: string;
 }): WorkflowStateReceipt {
+	assertNonEmptyGjcSessionId(input.sessionId, "buildWorkflowStateReceipt");
+	const cwd = path.resolve(input.cwd);
 	const mutatedAt = input.nowIso ?? new Date().toISOString();
 	const freshUntil = new Date(Date.parse(mutatedAt) + WORKFLOW_STATE_RECEIPT_FRESH_MS).toISOString();
 	return {
@@ -109,8 +74,8 @@ export function buildWorkflowStateReceipt(input: {
 		skill: input.skill,
 		owner: input.owner,
 		command: input.command,
-		state_path: workflowActiveStatePath(input.cwd, input.sessionId),
-		storage_path: workflowStateStoragePath(input.cwd, input.skill, input.sessionId),
+		state_path: activeSnapshotPath(cwd, input.sessionId),
+		storage_path: modeStatePath(cwd, input.sessionId, input.skill),
 		mutated_at: mutatedAt,
 		fresh_until: freshUntil,
 		status: "fresh",

--- a/packages/coding-agent/test/gjc-runtime/state-receipts.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-receipts.test.ts
@@ -4,6 +4,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { auditPath, modeStatePath } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { runNativeStateCommand } from "../../src/gjc-runtime/state-runtime";
+import { initialPhaseForSkill } from "../../src/skill-state/initial-phase";
+import { buildWorkflowStateReceipt } from "../../src/skill-state/workflow-state-contract";
 
 const TEST_SESSION_ID = "test-session";
 
@@ -118,6 +120,72 @@ describe("G5 gjc state receipts", () => {
 			);
 			expect(handoffEntries).toHaveLength(2);
 			for (const entry of handoffEntries) expectAuditEntry(entry, "handoff");
+		});
+	});
+});
+
+describe("workflow receipt path contract", () => {
+	it("uses session-layout receipt paths for every workflow mode", async () => {
+		await withTempCwd(async cwd => {
+			const sessionId = "receipt/session.id";
+			for (const skill of ["deep-interview", "ralplan", "ultragoal", "team"] as const) {
+				const result = await runNativeStateCommand(
+					[
+						"write",
+						"--mode",
+						skill,
+						"--session-id",
+						sessionId,
+						"--input",
+						JSON.stringify({ current_phase: initialPhaseForSkill(skill) }),
+					],
+					cwd,
+				);
+				expect(result.status).toBe(0);
+				const cli = JSON.parse(result.stdout ?? "{}") as Record<string, unknown>;
+				const storagePath = modeStatePath(cwd, sessionId, skill);
+				const activePath = path.join(path.dirname(storagePath), "skill-active-state.json");
+				const state = await readJson(storagePath);
+				const receipt = state.receipt as Record<string, unknown>;
+				const statePath = receipt.state_path as string;
+				const checksum = receipt.content_sha256 as Record<string, unknown>;
+
+				expect(path.normalize(cli.state_path as string)).toBe(path.normalize(receipt.state_path as string));
+				expect(path.normalize(receipt.state_path as string)).toBe(path.normalize(activePath));
+				expect(path.normalize(receipt.storage_path as string)).toBe(path.normalize(storagePath));
+				expect(path.normalize(checksum.covered_path as string)).toBe(
+					path.normalize(receipt.storage_path as string),
+				);
+				await expect(fs.stat(statePath)).resolves.toBeDefined();
+				await expect(fs.stat(storagePath)).resolves.toBeDefined();
+			}
+		});
+	});
+
+	it("rejects missing receipt sessions instead of constructing a default path", async () => {
+		expect(() =>
+			buildWorkflowStateReceipt({
+				cwd: process.cwd(),
+				skill: "ralplan",
+				owner: "gjc-state-cli",
+				command: "gjc state ralplan write",
+				sessionId: " ",
+			}),
+		).toThrow("non-empty GJC session id");
+
+		await withTempCwd(async cwd => {
+			const sessionId = process.env.GJC_SESSION_ID;
+			delete process.env.GJC_SESSION_ID;
+			try {
+				const result = await runNativeStateCommand(
+					["write", "--mode", "ralplan", "--input", JSON.stringify({ current_phase: "planner" })],
+					cwd,
+				);
+				expect(result.status).toBe(2);
+				expect(result.stderr).toContain("session id is required");
+			} finally {
+				if (sessionId !== undefined) process.env.GJC_SESSION_ID = sessionId;
+			}
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- remove legacy workflow receipt path helpers and require resolved session identity
- stamp `state_path` with the canonical active snapshot and `storage_path` with the canonical per-mode state file
- make native write/clear output agree with receipt `state_path`
- bind `content_sha256.covered_path` to the exact per-mode file
- cover all four workflow modes, real path existence, encoded session IDs, and missing-session failure

## Competing PR disposition
This is the authoritative repaired successor for #2393. PR #2495 preserves legacy helper behavior and misses the CLI/receipt equality contract; PR #2483 invents a synthetic `_session-default` path. Neither external patch is acceptable as-is.

## CI diagnosis
Run 29561521216 correctly failed strict canonical receipt-set validation: the coding-agent task failed before receipt write/upload, leaving three receipts for four non-native tasks. The validator is unchanged and remains fail-closed.

## Verification
- `bun --cwd=packages/coding-agent run check`
- 57 focused workflow-state tests / 434 assertions
- independent QA: 68 tests / 313 assertions
- `bun scripts/verify-gjc-state-writers.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun run build`

Closes #2393 after merge and postmerge validation.

— GJC Maintainer Review