### PR TITLE
fix: separable macOS voice/runtime fixes (ACL verify, default input device, ffmpeg flush, /voice)

### DIFF
--- a/crates/pi-natives/src/path_identity.rs
+++ b/crates/pi-natives/src/path_identity.rs
@@ -662,6 +662,11 @@ mod platform {
 		// SAFETY: the file descriptor is live; the returned ACL is freed exactly once.
 		let acl = unsafe { acl_get_fd(file.as_raw_fd()) };
 		if acl.is_null() {
+			// macOS `acl_get_fd` reports "no ACL present" as NULL + ENOENT — the
+			// common case for freshly created paths, not an API failure.
+			if std::io::Error::last_os_error().raw_os_error() == Some(libc::ENOENT) {
+				return Ok(false);
+			}
 			return Err(NativeOwnerOnlySecurityResult::failure("acl_unavailable"));
 		}
 		let mut entry = std::ptr::null_mut();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,13 @@
 
 ### Fixed
 - SDK host response delivery to a disconnected client no longer escalates a second structured-error send failure into a process-level unhandled rejection; failures stay local to that connection.
+### Added
+- `/voice` slash command that starts speech-to-text without a keychord (macOS terminals often type `˙` for Option+H unless the terminal sends Option as Meta).
+
+### Fixed
+- macOS speech-to-text now records from the system default input device instead of the first enumerated avfoundation device; machines with virtual audio devices (BlackHole, Loopback) silently recorded pure silence.
+- ffmpeg recordings flush per packet, so the recording file grows in real time instead of buffering many seconds of audio invisibly.
+- Fresh macOS checkouts can start the TUI again: `acl_get_fd` reporting "no ACL present" (NULL+ENOENT) is no longer treated as an owner-only security failure.
 
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1139,6 +1139,14 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "voice",
+		description: "Start voice input (same as the stt toggle keybinding)",
+		handleTui: (_command, runtime) => {
+			runtime.ctx.editor.setText("");
+			void runtime.ctx.handleSTTToggle();
+		},
+	},
+	{
 		name: "tools",
 		description: "Show tools currently visible to the agent",
 		acpDescription: "Show available tools",

--- a/packages/coding-agent/src/stt/recorder.ts
+++ b/packages/coding-agent/src/stt/recorder.ts
@@ -58,7 +58,7 @@ async function startSoxRecording(outputPath: string): Promise<RecordingHandle> {
 	};
 }
 
-async function startFFmpegRecording(outputPath: string): Promise<RecordingHandle> {
+async function startFFmpegRecording(outputPath: string, macosAudioDevice = ":default"): Promise<RecordingHandle> {
 	let args: string[];
 	if (isWindows) {
 		const device = await detectWindowsAudioDevice();
@@ -78,12 +78,16 @@ async function startFFmpegRecording(outputPath: string): Promise<RecordingHandle
 			outputPath,
 		];
 	} else if (process.platform === "darwin") {
+		// ":0" is the first *enumerated* avfoundation audio device, not the
+		// system default — on machines with virtual devices (BlackHole,
+		// Loopback) that records pure silence. ":default" targets the actual
+		// default input; the caller falls back to ":0" if it fails to start.
 		args = [
 			"ffmpeg",
 			"-f",
 			"avfoundation",
 			"-i",
-			":0",
+			macosAudioDevice,
 			"-ar",
 			"16000",
 			"-ac",
@@ -311,6 +315,14 @@ export async function startRecording(outputPath: string): Promise<RecordingHandl
 				case "sox":
 					return await startSoxRecording(outputPath);
 				case "ffmpeg":
+					if (process.platform === "darwin") {
+						try {
+							return await startFFmpegRecording(outputPath, ":default");
+						} catch {
+							// Older ffmpeg builds without ":default" support.
+							return await startFFmpegRecording(outputPath, ":0");
+						}
+					}
 					return await startFFmpegRecording(outputPath);
 				case "arecord":
 					return await startArecordRecording(outputPath);

--- a/packages/coding-agent/src/stt/recorder.ts
+++ b/packages/coding-agent/src/stt/recorder.ts
@@ -74,6 +74,8 @@ async function startFFmpegRecording(outputPath: string, macosAudioDevice = ":def
 			"1",
 			"-sample_fmt",
 			"s16",
+			"-flush_packets",
+			"1",
 			"-y",
 			outputPath,
 		];
@@ -94,6 +96,8 @@ async function startFFmpegRecording(outputPath: string, macosAudioDevice = ":def
 			"1",
 			"-sample_fmt",
 			"s16",
+			"-flush_packets",
+			"1",
 			"-y",
 			outputPath,
 		];
@@ -110,6 +114,8 @@ async function startFFmpegRecording(outputPath: string, macosAudioDevice = ":def
 			"1",
 			"-sample_fmt",
 			"s16",
+			"-flush_packets",
+			"1",
 			"-y",
 			outputPath,
 		];


### PR DESCRIPTION
## What

Separable macOS voice/runtime fixes only, per the owner's boundary decision on #2539 ("retain only separable fixes/UX that do not expose an in-process crash boundary"). No Speech framework code, no new TCC surface, no backend architecture — the existing whisper path and TUI only.

- **fix(natives): treat absent macOS ACL as clean in owner-only verify.** macOS `acl_get_fd` reports "no ACL present" as NULL+ENOENT — the common case for freshly created session directories. Mapping it to `acl_unavailable` made every managed session scope fail, so a fresh `dev` checkout cannot start the TUI on macOS at all. Verified empirically (empty-ACL `acl_set_fd` clears fine; NULL+ENOENT is the no-ACL signal).
- **fix(stt): record from the default macOS input device.** avfoundation `":0"` is the first *enumerated* device, not the system default — on machines with virtual audio devices (BlackHole, Loopback) the whisper path silently recorded pure silence (measured: `:0` = BlackHole at -91dB while `":default"` captured real audio at -20dB). `":0"` remains the fallback for older ffmpeg builds.
- **fix(stt): flush ffmpeg output per packet.** ffmpeg buffers low-bitrate WAV for many seconds before writing (measured: 0 bytes on disk for 5+ seconds at 16kHz mono), which starves anything reading the growing file. `-flush_packets 1` makes it grow in real time (~32KB/s measured).
- **feat(tui): `/voice` slash command** for the existing stt toggle — macOS terminals commonly type `˙` for Option+H unless Option-as-Meta is configured, which makes the default `alt+h` binding undiscoverable there.

## Testing

- `bun run check:types` green in `packages/coding-agent`; `packages/natives` check green; `cargo clippy -p pi-natives` clean.
- Recorder fixes verified by measurement on macOS 15 arm64 (device volumedetect comparison; file-growth per second with/without flush).
- ACL fix verified against the exact failing call (`applyOwnerOnlyPathSecurity` on a fresh directory: failure → success) and by the TUI starting from a fresh checkout.

---

- [x] `bun check` passes (focused packages)
- [x] Tested locally (macOS 15 arm64)
- [x] CHANGELOG updated
