### PR TITLE
test(sdk): align headless plan lifecycle parity

### DIFF
--- a/packages/coding-agent/test/sdk-adapter-dispositions.test.ts
+++ b/packages/coding-agent/test/sdk-adapter-dispositions.test.ts
@@ -90,6 +90,7 @@ const expectedDomainErrors: Readonly<Record<string, string>> = {
 	"session.export_html": "invalid_request",
 	"auth.login": "operation_not_session_owned",
 	"skill.invoke": "invalid_input",
+	"mode.plan.set": "unavailable",
 };
 const expectedGlobalErrors: Readonly<Record<string, string>> = {
 	"session.create": "invalid_input",


### PR DESCRIPTION
## Summary
- classify `mode.plan.set` as the expected `unavailable` domain result in machine-adapter parity tests
- preserve fail-closed production behavior: headless hosts without an installed interactive lifecycle must not report plan transitions as successful

## Failure repaired
Dev CI run 29575940164 failed `test:@gajae-code/coding-agent:shard-2-of-8` because MCP, ACP, and daemon CLI forwarded the control correctly, then the production headless host rejected it with the documented `unavailable` error. The aggregate shard-receipt mismatch was downstream of that failed shard.

## Verification
- focused AD-M/A/L-C10 parity: 3 passed, 0 failed; no worktree-owned broker processes remained
- coding-agent check/typecheck passed
- coding-agent build passed
- CI planner selftests: 52 passed
- full local shard reached 1,864 passes; two unrelated environment/timing cases were separately classified (pet terminal-capability environment remains reproducible locally; daemon replacement cleanup passes in isolation)
