### PR TITLE
fix(coordinator): resolve terminal turns from session-local runtime state (#2549)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- Coordinator MCP turns from broker-spawned sessions now reach terminal state: `read_turn`/`await_turn` fall back to the session-local runtime sidecar state (with a stale-write guard) when the coordinator session-states store was never runtime-updated, carrying the sidecar's `final_response` into the durable turn record (#2549).
+- Coordinator MCP turns from broker-spawned sessions now reach terminal state: the runtime sidecar stamps terminal writes with the SDK prompt correlation captured at scheduling time (reset on turn boundaries), and `read_turn`/`await_turn` fall back to the session-local runtime state only when it names the turn's exact runtime correlation — carrying the sidecar's `final_response` into the durable turn record without wall-clock attribution (#2549).
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Coordinator MCP turns from broker-spawned sessions now reach terminal state: `read_turn`/`await_turn` fall back to the session-local runtime sidecar state (with a stale-write guard) when the coordinator session-states store was never runtime-updated, carrying the sidecar's `final_response` into the durable turn record (#2549).
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -11,6 +11,7 @@ import {
 	COORDINATOR_MCP_TOOL_NAMES,
 	type CoordinatorToolName,
 } from "../coordinator/contract";
+import { sessionRuntimeDir } from "../gjc-runtime/session-layout";
 import { SdkClient, SdkClientError } from "../sdk/client/client";
 import { readSdkBrokerDiscovery } from "../sdk/client/discovery";
 import {
@@ -1232,6 +1233,46 @@ async function readSessionState(namespaceDir: string, sessionId: string): Promis
 	return (await readJsonFile(sessionStateFile(namespaceDir, sessionId))) as CoordinatorSessionState | null;
 }
 
+function isRuntimeSourcedSessionState(value: unknown, sessionId: string): value is CoordinatorSessionState {
+	const record = asRecord(value);
+	if (!record) return false;
+	if (record.schema_version !== 1) return false;
+	if (record.session_id !== sessionId) return false;
+	if (record.source !== "agent_session_event") return false;
+	if (typeof record.updated_at !== "string") return false;
+	return (
+		record.state === "ready_for_input" ||
+		record.state === "running" ||
+		record.state === "needs_user_input" ||
+		record.state === "completed" ||
+		record.state === "errored"
+	);
+}
+
+// Broker-spawned sessions never receive GJC_COORDINATOR_SESSION_STATE_FILE (only
+// the tmux/lifecycle launch paths wire it), so their runtime sidecar writes
+// transitions to the session-local default file instead of the coordinator
+// session-states store. Read that file directly so terminal transitions are
+// still observable through the coordinator.
+async function readSessionLocalRuntimeState(
+	session: Record<string, unknown>,
+	sessionId: string,
+): Promise<CoordinatorSessionState | null> {
+	const cwd = typeof session.cwd === "string" && session.cwd.trim().length > 0 ? session.cwd : null;
+	if (!cwd) return null;
+	const payload = await readJsonFile(path.join(sessionRuntimeDir(cwd, sessionId), "runtime-state.json"));
+	return isRuntimeSourcedSessionState(payload, sessionId) ? payload : null;
+}
+
+// A session-local runtime state carries no turn correlation (current_turn_id is
+// never populated on this path), so only trust it for a turn that was already
+// running when the state was written.
+function runtimeStateCoversTurn(state: CoordinatorSessionState, turn: TurnRecord): boolean {
+	const stateMs = Date.parse(state.updated_at);
+	const turnMs = Date.parse(turn.started_at ?? turn.created_at);
+	return Number.isFinite(stateMs) && Number.isFinite(turnMs) && stateMs >= turnMs;
+}
+
 async function writeSessionStateUnlocked(
 	namespaceDir: string,
 	sessionId: string,
@@ -2379,6 +2420,26 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			resolvedTurn = { ...resolvedTurn, status: "waiting_for_answer", updated_at: timestamp };
 			await writeTurnRecord(namespaceDir, resolvedTurn);
 			await writeActiveTurn(namespaceDir, resolvedTurn);
+		}
+		if (
+			session &&
+			ACTIVE_TURN_STATUSES.has(resolvedTurn.status) &&
+			sessionState?.source !== "agent_session_event" &&
+			sessionState?.state !== "completed" &&
+			sessionState?.state !== "errored"
+		) {
+			const runtimeState = await readSessionLocalRuntimeState(session, resolvedTurn.session_id);
+			if (
+				runtimeState &&
+				(runtimeState.state === "completed" || runtimeState.state === "errored") &&
+				runtimeStateCoversTurn(runtimeState, resolvedTurn)
+			) {
+				sessionState = {
+					...runtimeState,
+					current_turn_id: sessionState?.current_turn_id ?? resolvedTurn.turn_id,
+					last_turn_id: sessionState?.last_turn_id ?? runtimeState.last_turn_id,
+				};
+			}
 		}
 		if (
 			sessionState &&

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -1264,13 +1264,20 @@ async function readSessionLocalRuntimeState(
 	return isRuntimeSourcedSessionState(payload, sessionId) ? payload : null;
 }
 
-// A session-local runtime state carries no turn correlation (current_turn_id is
-// never populated on this path), so only trust it for a turn that was already
-// running when the state was written.
-function runtimeStateCoversTurn(state: CoordinatorSessionState, turn: TurnRecord): boolean {
-	const stateMs = Date.parse(state.updated_at);
-	const turnMs = Date.parse(turn.started_at ?? turn.created_at);
-	return Number.isFinite(stateMs) && Number.isFinite(turnMs) && stateMs >= turnMs;
+// A session-local terminal state is only trusted when it names the exact
+// runtime turn this coordinator turn was acknowledged with. The sidecar stamps
+// terminal writes with the SDK prompt correlation captured at scheduling time,
+// so a previous turn's delayed terminal write can never be attributed to a
+// successor turn — wall-clock ordering is not a substitute for this match, and
+// states without the stamp (older runtimes) are never trusted.
+function runtimeStateMatchesTurn(state: CoordinatorSessionState, turn: TurnRecord): boolean {
+	const runtimeTurnId = (state as unknown as Record<string, unknown>).runtime_turn_id;
+	return (
+		typeof runtimeTurnId === "string" &&
+		runtimeTurnId.length > 0 &&
+		typeof turn.delivery.runtime_turn_id === "string" &&
+		runtimeTurnId === turn.delivery.runtime_turn_id
+	);
 }
 
 async function writeSessionStateUnlocked(
@@ -2432,7 +2439,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			if (
 				runtimeState &&
 				(runtimeState.state === "completed" || runtimeState.state === "errored") &&
-				runtimeStateCoversTurn(runtimeState, resolvedTurn)
+				runtimeStateMatchesTurn(runtimeState, resolvedTurn)
 			) {
 				sessionState = {
 					...runtimeState,

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -544,6 +544,36 @@ function branchForContext(context: RuntimeStateContext): string | null {
 	return context.branch ?? (process.env[GJC_COORDINATOR_SESSION_BRANCH_ENV]?.trim() || null);
 }
 
+export interface RuntimeTurnCorrelation {
+	turnId: string;
+	commandId?: string | null;
+}
+
+/**
+ * Active SDK prompt correlation per session, registered by the in-process SDK
+ * bus when the agent loop starts a prompt. Terminal event persistence captures
+ * the value synchronously when the write is scheduled, so a terminal runtime
+ * state carries the identity of the runtime turn that actually produced it —
+ * out-of-process readers (the coordinator MCP bridge) must not infer that
+ * attribution from wall-clock ordering.
+ */
+const activeRuntimeTurnCorrelations = new Map<string, RuntimeTurnCorrelation>();
+
+export function setActiveRuntimeTurnCorrelation(sessionId: string, correlation: RuntimeTurnCorrelation | null): void {
+	const id = sessionId.trim();
+	if (!id) return;
+	const turnId = correlation?.turnId.trim();
+	if (turnId) {
+		activeRuntimeTurnCorrelations.set(id, { turnId, commandId: correlation?.commandId?.trim() || null });
+	} else {
+		activeRuntimeTurnCorrelations.delete(id);
+	}
+}
+
+function capturedRuntimeTurnCorrelation(sessionId: string): RuntimeTurnCorrelation | null {
+	return activeRuntimeTurnCorrelations.get(sessionId.trim()) ?? null;
+}
+
 function basePayload(input: {
 	context: RuntimeStateContext;
 	previous: Record<string, unknown>;
@@ -553,6 +583,7 @@ function basePayload(input: {
 	event: string;
 	reason: string | null;
 	sessionId: string;
+	correlation?: RuntimeTurnCorrelation | null;
 }): Record<string, unknown> {
 	const identity = normalizedIdentity(input.context);
 	if (identity.sessionId !== input.sessionId) throw new PreviousRuntimeStateReadError();
@@ -564,6 +595,12 @@ function basePayload(input: {
 		updated_at: input.now,
 		current_turn_id: typeof input.previous.current_turn_id === "string" ? input.previous.current_turn_id : null,
 		last_turn_id: typeof input.previous.last_turn_id === "string" ? input.previous.last_turn_id : null,
+		// SDK prompt correlation is turn-scoped: terminal writes carry the identity
+		// captured when the write was scheduled, and turn-boundary writes always
+		// reset it so a previous turn's identity can never be attributed to a
+		// successor turn.
+		runtime_turn_id: input.correlation?.turnId ?? null,
+		runtime_command_id: input.correlation?.commandId ?? null,
 		live: input.state === "running",
 		reason: input.reason,
 		source: input.source,
@@ -878,6 +915,11 @@ export async function persistCoordinatorRuntimeStateFromEvent(
 	if (!stateFile || !state) return;
 	context = contextWithManagedOwnerGeneration(context);
 	const identity = normalizedIdentity(context);
+	// Capture synchronously at scheduling time: by the time this serialized
+	// write executes, a successor prompt may already have re-registered the
+	// active correlation.
+	const correlation =
+		state === "completed" || state === "errored" ? capturedRuntimeTurnCorrelation(identity.sessionId) : null;
 	await serializeStateFileWrite(
 		stateFile,
 		async () =>
@@ -899,6 +941,7 @@ export async function persistCoordinatorRuntimeStateFromEvent(
 								event: event.type,
 								reason: null,
 								sessionId: identity.sessionId,
+								correlation,
 							}),
 							...(state === "completed" || state === "errored" ? { ended_at: now } : {}),
 							...(finalResponseForEvent(event) ? { final_response: finalResponseForEvent(event) } : {}),

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -3801,9 +3801,11 @@ export function createNotificationsExtension(
 		rt.activePromptCorrelation = correlation;
 		// Register the active prompt identity so the runtime-state sidecar can stamp
 		// terminal writes with the exact runtime turn (consumed out-of-process by
-		// the coordinator MCP bridge). Not cleared on agent_end: the terminal write
-		// captures it at scheduling time, and the next agent_start re-registers.
-		if (correlation) setActiveRuntimeTurnCorrelation(id, correlation);
+		// the coordinator MCP bridge). Not cleared on agent_end — the terminal write
+		// captures it at scheduling time — but a correlation-less start (e.g. a
+		// local TUI prompt on the same session) must clear it so its terminal state
+		// can never inherit the previous SDK turn's identity.
+		setActiveRuntimeTurnCorrelation(id, correlation ?? null);
 		rt.emitPromptLifecycle(correlation, { type: "agent_start", sessionId: id, ...correlation });
 		try {
 			// `activity` is the native live-host lifecycle surface. The separately

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -33,6 +33,7 @@ import { NotificationServer, nativeBuildInfo } from "@gajae-code/natives";
 import { logger, postmortem, VERSION } from "@gajae-code/utils";
 import { Settings } from "../../config/settings";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../../extensibility/extensions";
+import { setActiveRuntimeTurnCorrelation } from "../../gjc-runtime/session-state-sidecar";
 import type {
 	WorkflowGateEmitter,
 	WorkflowGateTerminalController,
@@ -3798,6 +3799,11 @@ export function createNotificationsExtension(
 		rt.busy = true;
 		const correlation = rt.pendingPromptCorrelations.shift();
 		rt.activePromptCorrelation = correlation;
+		// Register the active prompt identity so the runtime-state sidecar can stamp
+		// terminal writes with the exact runtime turn (consumed out-of-process by
+		// the coordinator MCP bridge). Not cleared on agent_end: the terminal write
+		// captures it at scheduling time, and the next agent_start re-registers.
+		if (correlation) setActiveRuntimeTurnCorrelation(id, correlation);
 		rt.emitPromptLifecycle(correlation, { type: "agent_start", sessionId: id, ...correlation });
 		try {
 			// `activity` is the native live-host lifecycle surface. The separately
@@ -4122,6 +4128,7 @@ export function createNotificationsExtension(
 
 	api.on("session_shutdown", async (_event, ctx) => {
 		const id = sessionId(ctx);
+		setActiveRuntimeTurnCorrelation(id, null);
 		const rt = runtimes.get(id);
 		if (rt) terminalizeInFlightTools(rt, id, "unknown");
 		const controllerStop =

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -1501,7 +1501,7 @@ describe("Coordinator MCP canonical SDK controls", () => {
 });
 
 describe("Coordinator MCP session-local runtime state fallback", () => {
-	function sessionLocalRuntimeState(root: string, state: "completed" | "errored", updatedAt: string) {
+	function sessionLocalRuntimeState(root: string, state: "completed" | "errored", runtimeTurnId: string | null) {
 		return {
 			schema_version: 1,
 			session_id: "visible-session",
@@ -1509,7 +1509,7 @@ describe("Coordinator MCP session-local runtime state fallback", () => {
 			ready_for_input: state === "completed",
 			current_turn_id: null,
 			last_turn_id: null,
-			updated_at: updatedAt,
+			updated_at: new Date().toISOString(),
 			source: "agent_session_event",
 			event: "agent_end",
 			live: false,
@@ -1517,6 +1517,8 @@ describe("Coordinator MCP session-local runtime state fallback", () => {
 			cwd: root,
 			workdir: root,
 			session_file: null,
+			runtime_turn_id: runtimeTurnId,
+			runtime_command_id: null,
 			final_response: {
 				text: "DONE",
 				format: "markdown",
@@ -1527,10 +1529,7 @@ describe("Coordinator MCP session-local runtime state fallback", () => {
 		};
 	}
 
-	it("resolves terminal turns from the session-local runtime state when the coordinator store was never runtime-updated", async () => {
-		const root = await tempRoot();
-		const server = await createSdkControlServer(root, []);
-		await registerSdkSession(server, root);
+	async function sendTrackedPrompt(server: Awaited<ReturnType<typeof createSdkControlServer>>) {
 		const sent = await server.callTool("gjc_coordinator_send_prompt", {
 			session_id: "visible-session",
 			prompt: "work",
@@ -1538,28 +1537,41 @@ describe("Coordinator MCP session-local runtime state fallback", () => {
 			allow_mutation: true,
 		});
 		const turnId = sent.turn_id;
+		const runtimeTurnId = (sent.turn as { delivery?: { runtime_turn_id?: unknown } }).delivery?.runtime_turn_id;
 		if (typeof turnId !== "string") throw new Error("missing coordinator turn id");
+		if (typeof runtimeTurnId !== "string") throw new Error("missing runtime turn id");
+		return { turnId, runtimeTurnId };
+	}
+
+	it("resolves terminal turns from a session-local runtime state naming this runtime turn", async () => {
+		const root = await tempRoot();
+		const server = await createSdkControlServer(root, []);
+		await registerSdkSession(server, root);
+		const { turnId, runtimeTurnId } = await sendTrackedPrompt(server);
 		const runtimeDir = sessionRuntimeDir(root, "visible-session");
 		await fs.mkdir(runtimeDir, { recursive: true });
 		const runtimeStateFile = path.join(runtimeDir, "runtime-state.json");
 
-		// A terminal state written before this turn started (e.g. a previous turn's
-		// completion) carries no turn correlation and must not resolve the new turn.
+		// A delayed terminal write from a previous runtime turn carries that turn's
+		// correlation (or none, on older runtimes); neither may resolve this turn,
+		// no matter how fresh the write's timestamp is.
+		await Bun.write(runtimeStateFile, JSON.stringify(sessionLocalRuntimeState(root, "completed", null)));
+		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: turnId })).resolves.toMatchObject({
+			ok: true,
+			turn: { status: "active" },
+		});
 		await Bun.write(
 			runtimeStateFile,
-			JSON.stringify(sessionLocalRuntimeState(root, "completed", new Date(Date.now() - 60_000).toISOString())),
+			JSON.stringify(sessionLocalRuntimeState(root, "completed", "some-previous-runtime-turn")),
 		);
 		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: turnId })).resolves.toMatchObject({
 			ok: true,
 			turn: { status: "active" },
 		});
 
-		// A terminal transition recorded while the turn was running resolves it and
-		// carries the sidecar's final_response into the durable turn record.
-		await Bun.write(
-			runtimeStateFile,
-			JSON.stringify(sessionLocalRuntimeState(root, "completed", new Date(Date.now() + 60_000).toISOString())),
-		);
+		// A terminal state stamped with this turn's runtime correlation resolves it
+		// and carries the sidecar's final_response into the durable turn record.
+		await Bun.write(runtimeStateFile, JSON.stringify(sessionLocalRuntimeState(root, "completed", runtimeTurnId)));
 		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: turnId })).resolves.toMatchObject({
 			ok: true,
 			turn: { status: "completed", final_response: { text: "DONE" } },
@@ -1567,23 +1579,16 @@ describe("Coordinator MCP session-local runtime state fallback", () => {
 		});
 	});
 
-	it("marks turns failed from a session-local errored runtime state", async () => {
+	it("marks turns failed from a session-local errored runtime state naming this runtime turn", async () => {
 		const root = await tempRoot();
 		const server = await createSdkControlServer(root, []);
 		await registerSdkSession(server, root);
-		const sent = await server.callTool("gjc_coordinator_send_prompt", {
-			session_id: "visible-session",
-			prompt: "work",
-			idempotency_key: "prompt-1",
-			allow_mutation: true,
-		});
-		const turnId = sent.turn_id;
-		if (typeof turnId !== "string") throw new Error("missing coordinator turn id");
+		const { turnId, runtimeTurnId } = await sendTrackedPrompt(server);
 		const runtimeDir = sessionRuntimeDir(root, "visible-session");
 		await fs.mkdir(runtimeDir, { recursive: true });
 		await Bun.write(
 			path.join(runtimeDir, "runtime-state.json"),
-			JSON.stringify(sessionLocalRuntimeState(root, "errored", new Date(Date.now() + 60_000).toISOString())),
+			JSON.stringify(sessionLocalRuntimeState(root, "errored", runtimeTurnId)),
 		);
 		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: turnId })).resolves.toMatchObject({
 			ok: true,

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createCoordinatorMcpServer } from "../src/coordinator-mcp/server";
+import { sessionRuntimeDir } from "../src/gjc-runtime/session-layout";
 import { writeBrokerDiscovery } from "../src/sdk/broker/discovery";
 import { type SdkClient, SdkClientError } from "../src/sdk/client/client";
 
@@ -1496,5 +1497,98 @@ describe("Coordinator MCP canonical SDK controls", () => {
 		]);
 		expect(await Bun.file(idleFile).exists()).toBe(false);
 		expect(await Bun.file(path.join(sessionsDir, "registered-session.json")).exists()).toBe(true);
+	});
+});
+
+describe("Coordinator MCP session-local runtime state fallback", () => {
+	function sessionLocalRuntimeState(root: string, state: "completed" | "errored", updatedAt: string) {
+		return {
+			schema_version: 1,
+			session_id: "visible-session",
+			state,
+			ready_for_input: state === "completed",
+			current_turn_id: null,
+			last_turn_id: null,
+			updated_at: updatedAt,
+			source: "agent_session_event",
+			event: "agent_end",
+			live: false,
+			reason: null,
+			cwd: root,
+			workdir: root,
+			session_file: null,
+			final_response: {
+				text: "DONE",
+				format: "markdown",
+				source: "runtime_state",
+				artifact_path: null,
+				truncated: false,
+			},
+		};
+	}
+
+	it("resolves terminal turns from the session-local runtime state when the coordinator store was never runtime-updated", async () => {
+		const root = await tempRoot();
+		const server = await createSdkControlServer(root, []);
+		await registerSdkSession(server, root);
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "work",
+			idempotency_key: "prompt-1",
+			allow_mutation: true,
+		});
+		const turnId = sent.turn_id;
+		if (typeof turnId !== "string") throw new Error("missing coordinator turn id");
+		const runtimeDir = sessionRuntimeDir(root, "visible-session");
+		await fs.mkdir(runtimeDir, { recursive: true });
+		const runtimeStateFile = path.join(runtimeDir, "runtime-state.json");
+
+		// A terminal state written before this turn started (e.g. a previous turn's
+		// completion) carries no turn correlation and must not resolve the new turn.
+		await Bun.write(
+			runtimeStateFile,
+			JSON.stringify(sessionLocalRuntimeState(root, "completed", new Date(Date.now() - 60_000).toISOString())),
+		);
+		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: turnId })).resolves.toMatchObject({
+			ok: true,
+			turn: { status: "active" },
+		});
+
+		// A terminal transition recorded while the turn was running resolves it and
+		// carries the sidecar's final_response into the durable turn record.
+		await Bun.write(
+			runtimeStateFile,
+			JSON.stringify(sessionLocalRuntimeState(root, "completed", new Date(Date.now() + 60_000).toISOString())),
+		);
+		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: turnId })).resolves.toMatchObject({
+			ok: true,
+			turn: { status: "completed", final_response: { text: "DONE" } },
+			session_state: { state: "completed" },
+		});
+	});
+
+	it("marks turns failed from a session-local errored runtime state", async () => {
+		const root = await tempRoot();
+		const server = await createSdkControlServer(root, []);
+		await registerSdkSession(server, root);
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "work",
+			idempotency_key: "prompt-1",
+			allow_mutation: true,
+		});
+		const turnId = sent.turn_id;
+		if (typeof turnId !== "string") throw new Error("missing coordinator turn id");
+		const runtimeDir = sessionRuntimeDir(root, "visible-session");
+		await fs.mkdir(runtimeDir, { recursive: true });
+		await Bun.write(
+			path.join(runtimeDir, "runtime-state.json"),
+			JSON.stringify(sessionLocalRuntimeState(root, "errored", new Date(Date.now() + 60_000).toISOString())),
+		);
+		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: turnId })).resolves.toMatchObject({
+			ok: true,
+			turn: { status: "failed" },
+			session_state: { state: "errored" },
+		});
 	});
 });

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -236,6 +236,23 @@ describe("coordinator runtime state sidecar", () => {
 				runtime_turn_id: "runtime-turn-a",
 				runtime_command_id: "command-a",
 			});
+
+			// A correlation-less turn (e.g. a local TUI prompt) clears the registry,
+			// so its terminal state never inherits a previous SDK turn's identity.
+			setActiveRuntimeTurnCorrelation("correlation-session", null);
+			await persistCoordinatorRuntimeStateFromEvent(
+				{ type: "turn_start" },
+				{ sessionId: "fallback", cwd: root, sessionFile: null },
+			);
+			await persistCoordinatorRuntimeStateFromEvent(
+				{ type: "agent_end", messages: [] },
+				{ sessionId: "fallback", cwd: root, sessionFile: null },
+			);
+			expect(await readJson(stateFile)).toMatchObject({
+				state: "completed",
+				runtime_turn_id: null,
+				runtime_command_id: null,
+			});
 		} finally {
 			setActiveRuntimeTurnCorrelation("correlation-session", null);
 		}

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -20,6 +20,7 @@ import {
 	persistCoordinatorRuntimeStateFromEvent,
 	persistCoordinatorRuntimeStateFromPostmortem,
 	readTerminalRuntimeStateMarker,
+	setActiveRuntimeTurnCorrelation,
 	stateForEvent,
 } from "../src/gjc-runtime/session-state-sidecar";
 import {
@@ -199,6 +200,44 @@ describe("coordinator runtime state sidecar", () => {
 			});
 		} finally {
 			setSystemTime();
+		}
+	});
+
+	it("stamps terminal writes with the runtime turn correlation captured at scheduling time", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "correlation-session";
+		try {
+			setActiveRuntimeTurnCorrelation("correlation-session", { turnId: "runtime-turn-a", commandId: "command-a" });
+			await persistCoordinatorRuntimeStateFromEvent(
+				{ type: "turn_start" },
+				{ sessionId: "fallback", cwd: root, sessionFile: null },
+			);
+			// Turn-boundary writes never carry a correlation, so a previous turn's
+			// identity cannot leak onto a successor turn's running state.
+			expect(await readJson(stateFile)).toMatchObject({
+				state: "running",
+				runtime_turn_id: null,
+				runtime_command_id: null,
+			});
+
+			// Schedule the terminal write, then immediately re-register a successor
+			// correlation before it executes (the delayed agent_end write race): the
+			// terminal payload must keep the identity captured at scheduling time.
+			const pendingTerminal = persistCoordinatorRuntimeStateFromEvent(
+				{ type: "agent_end", messages: [] },
+				{ sessionId: "fallback", cwd: root, sessionFile: null },
+			);
+			setActiveRuntimeTurnCorrelation("correlation-session", { turnId: "runtime-turn-b", commandId: "command-b" });
+			await pendingTerminal;
+			expect(await readJson(stateFile)).toMatchObject({
+				state: "completed",
+				runtime_turn_id: "runtime-turn-a",
+				runtime_command_id: "command-a",
+			});
+		} finally {
+			setActiveRuntimeTurnCorrelation("correlation-session", null);
 		}
 	});
 


### PR DESCRIPTION
Fixes #2549.

## Problem

Turns started through the coordinator MCP bridge against broker-spawned SDK sessions never reach a terminal state: after the runtime completes, `gjc_coordinator_read_turn` keeps reporting `active` and `gjc_coordinator_await_turn` times out forever.

Root cause (details in #2549): the runtime sidecar publishes transitions to the file named by `GJC_COORDINATOR_SESSION_STATE_FILE`, but only the tmux/lifecycle launch paths set that env — the broker spawn (`sdk/broker/lifecycle.ts`) uses a fixed env allowlist with no way to thread it. So `completed`/`errored` land in the session-local default file (`<cwd>/.gjc/_session-<sid>/runtime/runtime-state.json`) that the coordinator never consulted.

## Fix

Coordinator-side, self-contained — no broker protocol change:

- During turn reconciliation, when the coordinator session-states store was never runtime-updated (`source !== "agent_session_event"`) and the turn is still active, read the session-local sidecar file and, if it reports a terminal state, use it as the effective session state. The sidecar's `final_response` is carried into the durable turn record, so `read_turn` returns the final text.
- Stale-write guard: a session-local terminal state carries no turn correlation (`current_turn_id` is never populated on this path), so it is only trusted when its `updated_at` is not older than the turn's `started_at` — a previous turn's completion cannot resolve a newer turn.

The deeper alternative — threading the env through `session.create` → `SessionLaunch` → the broker spawn — is called out in #2549; happy to follow up in that direction if preferred, but this keeps the observable coordinator contract working without touching the SDK protocol.

## Tests

- `bun test test/coordinator-mcp-server.test.ts` — 38 pass (2 new: terminal resolution from session-local state incl. `final_response` carry-through and stale-write guard; failed resolution from `errored`).
- `bun test test/coordinator-mcp.test.ts test/coordinator-mcp-policy.test.ts test/coordinator-mcp-actual-runtime-readiness.test.ts test/coordinator-mcp-model-preset.test.ts` — 19 pass.
- `biome check` on changed files clean; `bun run check:types` clean.

Also verified end-to-end on a live bridge (v0.11.1): a real `start_session` → prompt → runtime `agent_end` now resolves `read_turn` to `completed` with the runtime's final response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
