### PR TITLE
Fix postmortem signal cleanup reentry

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Consecutive termination signals now await the same in-flight postmortem cleanup instead of letting the later signal exit early and truncate registered teardown callbacks.
+
 ## [0.8.2] - 2026-07-06
 
 ### Fixed

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -26,6 +26,11 @@ export enum Reason {
 const callbackList: ((reason: Reason) => Promise<void> | void)[] = [];
 // Tracks cleanup run state (to prevent recursion/reentry issues)
 let cleanupStage: "idle" | "running" | "complete" = "idle";
+let cleanupPromise: Promise<void> | undefined;
+
+function isSignalReason(reason: Reason): boolean {
+	return reason === Reason.SIGINT || reason === Reason.SIGTERM || reason === Reason.SIGHUP;
+}
 
 /**
  * Internal: runs all registered cleanup callbacks for the given reason.
@@ -42,27 +47,41 @@ function runCleanup(reason: Reason): Promise<void> {
 			if (reason === Reason.EXIT) {
 				return Promise.resolve();
 			}
+			if (isSignalReason(reason) && cleanupPromise) {
+				return cleanupPromise;
+			}
 			logger.error("Cleanup invoked recursively", { stack: new Error().stack });
 			return Promise.resolve();
 		case "complete":
 			return Promise.resolve();
 	}
 
-	// Call .cleanup() for each callback that is still "armed".
-	// Use Promise.try to handle sync/async, but only those armed.
-	const promises = callbackList.toReversed().map(callback => {
-		return Promise.try(() => callback(reason));
-	});
-
-	return Promise.allSettled(promises).then(results => {
+	const deferred = Promise.withResolvers<void>();
+	cleanupPromise = deferred.promise;
+	void (async () => {
+		// Call .cleanup() for each callback that is still "armed".
+		// Use Promise.try to handle sync/async, but only those armed.
+		const promises = callbackList.toReversed().map(callback => {
+			return Promise.try(() => callback(reason));
+		});
+		const results = await Promise.allSettled(promises);
 		for (const result of results) {
 			if (result.status === "rejected") {
 				const err = result.reason instanceof Error ? result.reason : new Error(String(result.reason));
 				logger.error("Cleanup callback failed", { err, stack: err.stack });
 			}
 		}
-		cleanupStage = "complete";
-	});
+	})().then(
+		() => {
+			cleanupStage = "complete";
+			deferred.resolve();
+		},
+		error => {
+			cleanupStage = "complete";
+			deferred.reject(error);
+		},
+	);
+	return cleanupPromise;
 }
 
 // Register signal and error event handlers to trigger cleanup before exit.
@@ -82,8 +101,11 @@ function formatFatalError(label: string, err: Error): string {
 if (isMainThread) {
 	process
 		.on("SIGINT", async () => {
-			await runCleanup(Reason.SIGINT);
-			process.exit(130); // 128 + SIGINT (2)
+			try {
+				await runCleanup(Reason.SIGINT);
+			} finally {
+				process.exit(130); // 128 + SIGINT (2)
+			}
 		})
 		.on("SIGUSR1", () => {
 			if (inspectorOpened) return;
@@ -109,12 +131,18 @@ if (isMainThread) {
 			void runCleanup(Reason.EXIT); // fire and forget (exit imminent)
 		})
 		.on("SIGTERM", async () => {
-			await runCleanup(Reason.SIGTERM);
-			process.exit(143); // 128 + SIGTERM (15)
+			try {
+				await runCleanup(Reason.SIGTERM);
+			} finally {
+				process.exit(143); // 128 + SIGTERM (15)
+			}
 		})
 		.on("SIGHUP", async () => {
-			await runCleanup(Reason.SIGHUP);
-			process.exit(129); // 128 + SIGHUP (1)
+			try {
+				await runCleanup(Reason.SIGHUP);
+			} finally {
+				process.exit(129); // 128 + SIGHUP (1)
+			}
 		});
 } else {
 	// Worker thread: only register exit handler for cleanup.

--- a/packages/utils/test/postmortem-fixture.ts
+++ b/packages/utils/test/postmortem-fixture.ts
@@ -42,6 +42,19 @@ async function runNonExitRecursiveCleanup(): Promise<void> {
 	writeResult({ count });
 }
 
+async function runSignalReentryWhileRunning(): Promise<void> {
+	let count = 0;
+	postmortem.register("fixture-signal-reentry", async reason => {
+		count++;
+		await Bun.sleep(100);
+		writeResult({ count, reason });
+	});
+
+	setTimeout(() => process.emit("SIGTERM"), 20);
+	process.emit("SIGHUP");
+	await Bun.sleep(1_000);
+}
+
 async function runCompletedCleanupExitNoop(): Promise<void> {
 	let count = 0;
 	const exitListener = getPostmortemExitListener();
@@ -62,6 +75,9 @@ switch (scenario) {
 		break;
 	case "non-exit-recursive-cleanup":
 		await runNonExitRecursiveCleanup();
+		break;
+	case "signal-reentry-while-running":
+		await runSignalReentryWhileRunning();
 		break;
 	case "completed-cleanup-exit-noop":
 		await runCompletedCleanupExitNoop();

--- a/packages/utils/test/postmortem.test.ts
+++ b/packages/utils/test/postmortem.test.ts
@@ -57,6 +57,15 @@ describe("postmortem cleanup re-entry", () => {
 		expect(combinedOutput(result)).toContain('"stack"');
 	});
 
+	it("waits for in-flight cleanup when a second signal arrives", async () => {
+		const result = await runScenario("signal-reentry-while-running");
+
+		expect(result.exitCode).toBe(129);
+		expect(parseResult(result.stdout).count).toBe(1);
+		expect(result.stdout).toContain('"reason":"sighup"');
+		expect(hasRecursiveCleanupError(combinedOutput(result))).toBe(false);
+	});
+
 	it("keeps completed cleanup a no-op when the exit handler fires", async () => {
 		const result = await runScenario("completed-cleanup-exit-noop");
 


### PR DESCRIPTION
## Summary

- retain the in-flight postmortem cleanup promise
- make consecutive SIGINT/SIGTERM/SIGHUP handlers await that shared cleanup before exiting
- preserve the existing EXIT no-op and genuine MANUAL recursion diagnostic
- keep signal exit codes deterministic even if cleanup infrastructure rejects

Follow-up to #1462 / #1465: that merged fix covered EXIT-handler re-entry, while this change covers signal-during-signal re-entry that can truncate active teardown callbacks.

Closes #2556

## Verification

- `bun --cwd=packages/utils run check`
- `bun --cwd=packages/utils test test/postmortem.test.ts` — 4 pass
- `bun --cwd=packages/utils test` — 130 pass
- `gitleaks git --no-banner --redact --log-opts='origin/dev..HEAD' .` — no leaks found
- independent architect review — CLEAR

## Regression coverage

The subprocess fixture emits SIGHUP and then SIGTERM while a delayed cleanup callback is active. It verifies that the callback completes once, no recursive-cleanup error is emitted, and the first signal's exit code is retained.
