### PR TITLE
fix(task): model subagent initialization as monotonic phase

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).
+- Running subagent snapshots now expose a monotonic initialization phase without changing the public lifecycle status, suppress stale live-progress claims before and after a live control handle exists, and explain premature steering failures.
 
 
 ### Fixed

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -76,6 +76,9 @@ export type SubagentRunOutcome = { kind: "completed"; text: string } | { kind: "
 /** Canonical lifecycle of a subagent across pause/resume cycles. */
 export type SubagentLifecycle = "running" | "paused" | "queued" | "completed" | "failed" | "cancelled";
 
+/** Startup state for a running subagent attempt, independent of its public lifecycle status. */
+export type SubagentPhase = "initializing" | "active";
+
 /** Maximum time allowed to prove owned subagents have stopped before replacement. */
 export const OWNER_SUBAGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
 
@@ -145,6 +148,8 @@ export interface SubagentRecord {
 	currentJobId: string | null;
 	historicalJobIds: string[];
 	status: SubagentLifecycle;
+	/** Internal startup phase for the current running attempt; absent outside running attempts. */
+	phase?: SubagentPhase;
 	sessionFile: string | null;
 	/** False for ephemeral sessions (no persistent artifacts dir). */
 	resumable: boolean;
@@ -658,6 +663,14 @@ export class AsyncJobManager {
 
 	/** Register or replace the canonical record for a subagent. */
 	registerSubagentRecord(record: SubagentRecord): void {
+		const existing = this.#subagentRecords.get(record.subagentId);
+		const sameActiveAttempt = existing?.currentJobId === record.currentJobId && existing.phase === "active";
+		record.phase =
+			record.status === "running"
+				? this.#liveHandles.has(record.subagentId) || sameActiveAttempt
+					? "active"
+					: "initializing"
+				: undefined;
 		this.#subagentRecords.set(record.subagentId, record);
 	}
 
@@ -712,6 +725,8 @@ export class AsyncJobManager {
 
 	registerLiveHandle(subagentId: string, handle: SubagentLiveHandle): void {
 		this.#liveHandles.set(subagentId, handle);
+		const record = this.#subagentRecords.get(subagentId);
+		if (record?.status === "running") record.phase = "active";
 	}
 
 	getLiveHandle(subagentId: string): SubagentLiveHandle | undefined {
@@ -741,14 +756,15 @@ export class AsyncJobManager {
 	}
 
 	/**
-	 * True only when a live, in-session progress producer exists for this id: a
-	 * canonical registered record with a live handle or an in-memory running job.
-	 * False for `SubagentTool` backward-compat job synthesis and resumed-from-disk
-	 * records, which have no live producer to stream from.
+	 * True only when a live, in-session progress producer exists for this id. An
+	 * initializing record is not live; an active record requires its live handle.
+	 * Records without a phase retain the legacy live-handle/running-job fallback.
 	 */
 	hasLiveSubagent(subagentId: string, filter?: AsyncJobFilter): boolean {
 		const rec = this.getSubagentRecord(subagentId, filter);
 		if (!rec) return false;
+		if (rec.phase === "initializing") return false;
+		if (rec.phase === "active") return this.#liveHandles.has(rec.subagentId);
 		if (this.#liveHandles.has(rec.subagentId)) return true;
 		const job = rec.currentJobId ? this.#jobs.get(rec.currentJobId) : undefined;
 		return job?.status === "running";
@@ -1010,6 +1026,7 @@ export class AsyncJobManager {
 		const rec = this.#recordByJobId(jobId);
 		if (rec) {
 			rec.status = "paused";
+			rec.phase = undefined;
 			this.#liveHandles.delete(rec.subagentId);
 			this.#subagentProgress.delete(rec.subagentId);
 		}
@@ -1019,6 +1036,7 @@ export class AsyncJobManager {
 		const rec = this.#recordByJobId(jobId);
 		if (!rec) return;
 		if (rec.status === "paused" || rec.status === "queued") return;
+		rec.phase = undefined;
 		this.#liveHandles.delete(rec.subagentId);
 		this.#subagentProgress.delete(rec.subagentId);
 	}
@@ -1027,6 +1045,7 @@ export class AsyncJobManager {
 		const rec = this.#recordByJobId(jobId);
 		if (!rec) return;
 		rec.status = status;
+		rec.phase = undefined;
 		this.#liveHandles.delete(rec.subagentId);
 		this.#subagentProgress.delete(rec.subagentId);
 	}
@@ -1071,6 +1090,7 @@ export class AsyncJobManager {
 		if (this.getRunningJobs().length >= this.#maxRunningJobs) {
 			const seq = ++this.#resumeSeq;
 			rec.status = "queued";
+			rec.phase = undefined;
 			rec.queued = { ownerId: rec.ownerId, seq, message, createdAt: Date.now() };
 			this.#resumeQueue.push({
 				subagentId: rec.subagentId,
@@ -1101,6 +1121,8 @@ export class AsyncJobManager {
 		if (prevJobId && prevJobId !== newJobId) rec.historicalJobIds.push(prevJobId);
 		rec.currentJobId = newJobId;
 		rec.status = this.#jobs.get(newJobId)?.status ?? "running";
+		rec.phase =
+			rec.status === "running" ? (this.#liveHandles.has(rec.subagentId) ? "active" : "initializing") : undefined;
 		rec.queued = undefined;
 		return { ok: true, status: rec.status, jobId: newJobId };
 	}
@@ -1152,6 +1174,7 @@ export class AsyncJobManager {
 				}
 			}
 			rec.status = "cancelled";
+			rec.phase = undefined;
 			this.#liveHandles.delete(rec.subagentId);
 			this.#subagentProgress.delete(rec.subagentId);
 			this.#drainResumeQueue();
@@ -1161,6 +1184,7 @@ export class AsyncJobManager {
 			const idx = this.#resumeQueue.findIndex(e => e.subagentId === rec.subagentId);
 			if (idx !== -1) this.#resumeQueue.splice(idx, 1);
 			rec.status = "cancelled";
+			rec.phase = undefined;
 			rec.queued = undefined;
 			this.#subagentProgress.delete(rec.subagentId);
 			return true;

--- a/packages/coding-agent/src/prompts/tools/subagent.md
+++ b/packages/coding-agent/src/prompts/tools/subagent.md
@@ -34,7 +34,7 @@ Resume one subagent by `id` (preferred) or a single-item `ids` array.
 
 ## `action: "steer"`
 Send a non-empty `message` to one subagent by `id` (preferred) or a single-item `ids` array.
-- A running subagent receives the message through its live handle.
+- A running subagent with `phase: "active"` receives the message through its live handle; `phase: "initializing"` rejects steering with retry guidance.
 - Optional `pause: true` requests a safe-boundary pause after steering a running subagent.
 - `pause` only matters while the target is running.
 - A non-active subagent (`paused`, `queued`, or terminal) automatically resumes with the message; `pause` is ignored for that target.
@@ -47,7 +47,7 @@ Stop selected subagents by `ids`, including running, paused, or queued subagents
 
 # Statuses
 
-- `running` — currently executing.
+- `running` — lifecycle is running; snapshots may further distinguish `phase: "initializing"` from `phase: "active"`.
 - `paused` — stopped at a safe boundary with resumable context.
 - `queued` — resume requested and waiting for execution capacity.
 - `completed` — finished successfully.

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -179,6 +179,8 @@ function renderSubagentSnapshotBody(snapshot: SubagentSnapshot, expanded: boolea
 		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, undefined, true)) {
 			lines.push(`  ${pl}`);
 		}
+	} else if (snapshot.phase === "initializing") {
+		lines.push(`  ${theme.fg("dim", "initializing session; live control unavailable")}`);
 	} else if (snapshot.liveProgressAvailable && (snapshot.status === "running" || snapshot.status === "queued")) {
 		lines.push(`  ${theme.fg("dim", "running, no activity yet")}`);
 	}

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
 import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
-import { type AsyncJob, AsyncJobManager, jobElapsedMs, type SubagentRecord } from "../async";
+import { type AsyncJob, AsyncJobManager, jobElapsedMs, type SubagentPhase, type SubagentRecord } from "../async";
 import subagentDescription from "../prompts/tools/subagent.md" with { type: "text" };
 import type { AgentProgress, AgentSource, TaskToolDetails } from "../task/types";
 import { Ellipsis, truncateToWidth } from "../tui";
@@ -72,6 +72,8 @@ export interface SubagentSnapshot {
 	progress?: AgentProgress;
 	/** True when a live in-session progress producer exists for this subagent. */
 	liveProgressAvailable?: boolean;
+	/** Startup phase for a running subagent; lifecycle status remains stable. */
+	phase?: SubagentPhase;
 	/** Model the subagent actually runs on (after any auth fallback). */
 	effectiveModel?: string;
 	/** Model originally requested via role/preset mapping; differs from effective on fallback. */
@@ -263,7 +265,13 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 				if (!record.sessionFile) throw new ToolError(`Subagent ${record.subagentId} has no session file.`);
 				if (record.status === "running") {
 					const handle = manager.getLiveHandle(record.subagentId);
-					if (!handle) throw new ToolError(`Subagent ${record.subagentId} has no live handle.`);
+					if (!handle) {
+						throw new ToolError(
+							record.phase === "initializing"
+								? `Subagent ${record.subagentId} is still initializing; retry after its phase becomes active.`
+								: `Subagent ${record.subagentId} has no live handle; inspect it for a terminal transition before retrying.`,
+						);
+					}
 					const fromAgentId = this.session.getAgentId?.() ?? undefined;
 					await handle.injectMessage(message, "steer", { fromAgentId });
 					if (params.pause === true) manager.pauseSubagent(record.subagentId, ownerFilter);
@@ -586,6 +594,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		const lines = [`## ${title} (${snapshots.length})`, ""];
 		for (const snapshot of snapshots) {
 			lines.push(`### ${snapshot.id} — ${snapshot.status}`);
+			if (snapshot.phase === "initializing") lines.push("Phase: initializing (live control unavailable)");
 			if (snapshot.jobId !== snapshot.id) lines.push(`Job: ${snapshot.jobId}`);
 			if (snapshot.agent) lines.push(`Agent: ${snapshot.agent} (${snapshot.agentSource})`);
 			if (snapshot.effectiveModel) {
@@ -659,6 +668,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		attachLiveProgress = false,
 	): SubagentSnapshot {
 		const liveFields = this.#liveProgressFields(manager, record, attachLiveProgress);
+		const phase = record.status === "running" ? record.phase : undefined;
 		const job = record.currentJobId ? manager.getJob(record.currentJobId) : undefined;
 		if (job) {
 			return {
@@ -666,6 +676,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 				id: record.subagentId,
 				jobId: record.currentJobId ?? job.id,
 				status: record.status,
+				...(phase ? { phase } : {}),
 				...liveFields,
 			};
 		}
@@ -673,6 +684,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			id: record.subagentId,
 			jobId: record.currentJobId ?? record.subagentId,
 			status: record.status,
+			...(phase ? { phase } : {}),
 			label: "subagent",
 			agent: "unknown",
 			agentSource: "bundled",
@@ -839,6 +851,7 @@ function canonicalizeSnapshotForSignature(snapshot: SubagentSnapshot): unknown {
 		id: snapshot.id,
 		jobId: snapshot.jobId,
 		status: snapshot.status,
+		phase: snapshot.phase ?? null,
 		label: snapshot.label,
 		agent: snapshot.agent,
 		agentSource: snapshot.agentSource,

--- a/packages/coding-agent/test/tools/subagent-live-progress.test.ts
+++ b/packages/coding-agent/test/tools/subagent-live-progress.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { AsyncJobManager, type SubagentRecord } from "../../src/async";
+import { AsyncJobManager, type SubagentLiveHandle, type SubagentRecord } from "../../src/async";
 import { Settings } from "../../src/config/settings";
 import type { AgentProgress } from "../../src/task/types";
 import { SubagentTool, type ToolSession } from "../../src/tools";
@@ -21,7 +21,12 @@ function createManager(): AsyncJobManager {
 	AsyncJobManager.setInstance(manager);
 	return manager;
 }
-
+function liveHandle(): SubagentLiveHandle {
+	return {
+		requestPause: () => {},
+		injectMessage: async () => {},
+	};
+}
 function makeProgress(overrides: Partial<AgentProgress> & Pick<AgentProgress, "id">): AgentProgress {
 	return {
 		index: 0,
@@ -73,6 +78,7 @@ describe("subagent await live progress", () => {
 			},
 		);
 		manager.registerSubagentRecord(runningRecord("0-Live", jobId));
+		manager.registerLiveHandle("0-Live", liveHandle());
 		// Record progress BEFORE await; no further progress event will fire.
 		manager.recordSubagentProgress(
 			"0-Live",
@@ -122,6 +128,8 @@ describe("subagent await live progress", () => {
 		);
 		manager.registerSubagentRecord(runningRecord("0-A", jobA));
 		manager.registerSubagentRecord(runningRecord("0-B", jobB));
+		manager.registerLiveHandle("0-A", liveHandle());
+		manager.registerLiveHandle("0-B", liveHandle());
 		manager.recordSubagentProgress("0-A", makeProgress({ id: "0-A", currentTool: "read" }));
 		manager.recordSubagentProgress("0-B", makeProgress({ id: "0-B", currentTool: "bash" }));
 
@@ -202,7 +210,28 @@ describe("AsyncJobManager subagent progress retention", () => {
 		AsyncJobManager.resetForTests();
 	});
 
-	it("hasLiveSubagent is true for a canonical running record and false for synthesized/absent ids", () => {
+	it("preserves an active phase when the live handle wins registration race", () => {
+		const manager = createManager();
+		manager.registerLiveHandle("0-Race", liveHandle());
+
+		manager.registerSubagentRecord(runningRecord("0-Race", "job-race"));
+
+		expect(manager.getSubagentRecord("0-Race")?.phase).toBe("active");
+		expect(manager.hasLiveSubagent("0-Race")).toBe(true);
+	});
+
+	it("does not regress an active attempt when its record is registered again after handle teardown", () => {
+		const manager = createManager();
+		manager.registerSubagentRecord(runningRecord("0-Reregister", "job-reregister"));
+		manager.registerLiveHandle("0-Reregister", liveHandle());
+		manager.removeLiveHandle("0-Reregister");
+
+		manager.registerSubagentRecord(runningRecord("0-Reregister", "job-reregister"));
+
+		expect(manager.getSubagentRecord("0-Reregister")?.phase).toBe("active");
+		expect(manager.hasLiveSubagent("0-Reregister")).toBe(false);
+	});
+	it("tracks the initializing-to-active phase transition for canonical running records", () => {
 		const manager = createManager();
 		const jobId = manager.register(
 			"task",
@@ -218,6 +247,12 @@ describe("AsyncJobManager subagent progress retention", () => {
 			},
 		);
 		manager.registerSubagentRecord(runningRecord("0-Live", jobId));
+		expect(manager.getSubagentRecord("0-Live")?.phase).toBe("initializing");
+		expect(manager.hasLiveSubagent("0-Live")).toBe(false);
+
+		manager.registerLiveHandle("0-Live", liveHandle());
+
+		expect(manager.getSubagentRecord("0-Live")?.phase).toBe("active");
 
 		expect(manager.hasLiveSubagent("0-Live")).toBe(true);
 		expect(manager.hasLiveSubagent("0-Absent")).toBe(false);
@@ -225,7 +260,20 @@ describe("AsyncJobManager subagent progress retention", () => {
 		manager.cancelSubagent("0-Live", { ownerId: "0-Main" });
 	});
 
-	it("clears retained progress on terminal cleanup (cancel)", async () => {
+	it("keeps an active phase monotonic after handle removal and rejects stale live progress", () => {
+		const manager = createManager();
+		manager.registerSubagentRecord(runningRecord("0-Teardown", "job-teardown"));
+		manager.registerLiveHandle("0-Teardown", liveHandle());
+		manager.recordSubagentProgress("0-Teardown", makeProgress({ id: "0-Teardown", currentTool: "read" }));
+
+		manager.removeLiveHandle("0-Teardown");
+
+		expect(manager.getSubagentRecord("0-Teardown")?.phase).toBe("active");
+		expect(manager.hasLiveSubagent("0-Teardown")).toBe(false);
+		expect(manager.getSubagentProgress("0-Teardown")?.currentTool).toBe("read");
+	});
+
+	it("clears retained progress and phase on terminal cleanup (cancel)", async () => {
 		const manager = createManager();
 		const jobId = manager.register(
 			"task",
@@ -241,13 +289,19 @@ describe("AsyncJobManager subagent progress retention", () => {
 			},
 		);
 		manager.registerSubagentRecord(runningRecord("0-Clean", jobId));
+		manager.registerLiveHandle("0-Clean", liveHandle());
+		expect(manager.getSubagentRecord("0-Clean")?.phase).toBe("active");
 		manager.recordSubagentProgress("0-Clean", makeProgress({ id: "0-Clean", currentTool: "read" }));
 		expect(manager.getSubagentProgress("0-Clean")).toBeDefined();
+		manager.removeLiveHandle("0-Clean");
+		expect(manager.getSubagentRecord("0-Clean")?.phase).toBe("active");
+		expect(manager.hasLiveSubagent("0-Clean")).toBe(false);
 
 		manager.cancelSubagent("0-Clean", { ownerId: "0-Main" });
 		await manager.getJob(jobId)?.promise;
 
 		expect(manager.getSubagentProgress("0-Clean")).toBeUndefined();
+		expect(manager.getSubagentRecord("0-Clean")?.phase).toBeUndefined();
 		await manager.dispose({ timeoutMs: 100 });
 	});
 
@@ -302,6 +356,7 @@ describe("AsyncJobManager subagent progress retention", () => {
 
 		const result = manager.resumeSubagent("0-Resume", { ownerId: "0-Main" }, "go");
 		expect(result.ok).toBe(true);
+		expect(manager.getSubagentRecord("0-Resume")?.phase).toBe("initializing");
 		// Retained progress from the previous run must be gone before the new run emits.
 		expect(manager.getSubagentProgress("0-Resume")).toBeUndefined();
 	});
@@ -506,6 +561,7 @@ describe("subagent await emit gating", () => {
 				},
 			);
 			manager.registerSubagentRecord(runningRecord(id, jobId));
+			manager.registerLiveHandle(id, liveHandle());
 			manager.recordSubagentProgress(id, makeProgress({ id, currentTool: "read", recentOutput: ["scan"] }));
 		});
 

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -177,6 +177,22 @@ describe("subagentToolRenderer", () => {
 		expect(out).toContain("running, no activity yet");
 	});
 
+	it("renders initialization without claiming live activity", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-Starting",
+					status: "running",
+					phase: "initializing",
+					liveProgressAvailable: false,
+				}),
+			],
+		});
+		expect(out).toContain("0-Starting");
+		expect(out).toContain("initializing session; live control unavailable");
+		expect(out).not.toContain("running, no activity yet");
+	});
+
 	it("renders static status without a no-activity claim when no live producer", () => {
 		const out = render({
 			subagents: [snapshot({ id: "0-Static", status: "running", liveProgressAvailable: false })],
@@ -348,6 +364,23 @@ describe("subagent await renderer body cache (PR2)", () => {
 		// New component (new renderResult), identical content -> module cache hit.
 		renderWith(live("0-A"));
 		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+	});
+
+	it("invalidates the body cache when startup phase becomes active", () => {
+		const initializing: SubagentToolDetails = {
+			subagents: [snapshot({ id: "0-Starting", phase: "initializing" })],
+		};
+		const active: SubagentToolDetails = {
+			subagents: [snapshot({ id: "0-Starting", phase: "active" })],
+		};
+
+		const first = Bun.stripANSI(renderWith(initializing).join("\n"));
+		expect(first).toContain("initializing session; live control unavailable");
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+
+		const second = Bun.stripANSI(renderWith(active).join("\n"));
+		expect(second).not.toContain("initializing session; live control unavailable");
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(2);
 	});
 
 	it("does not re-render the heavy body for spinner-only frame changes", () => {

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -441,6 +441,38 @@ describe("SubagentTool", () => {
 		await manager.dispose({ timeoutMs: 100 });
 	});
 
+	it("rejects steering during initialization without changing public lifecycle status", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		manager.registerSubagentRecord({
+			subagentId: "0-Starting",
+			ownerId: "0-Main",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/0-Starting.jsonl",
+			resumable: true,
+		});
+
+		const inspection = await tool.execute("subagent-inspect-starting", {
+			action: "inspect",
+			ids: ["0-Starting"],
+		});
+		expect(inspection.details?.subagents[0]?.status).toBe("running");
+		expect(inspection.details?.subagents[0]?.phase).toBe("initializing");
+		expect(getText(inspection)).toContain("Phase: initializing");
+
+		await expect(
+			tool.execute("subagent-steer-starting", {
+				action: "steer",
+				ids: ["0-Starting"],
+				message: "start now",
+			}),
+		).rejects.toThrow("still initializing; retry after its phase becomes active");
+
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
 	it("steer running injects a message and optionally requests pause", async () => {
 		const manager = createManager();
 		const tool = new SubagentTool(createSession());


### PR DESCRIPTION
## What

- keep the public subagent lifecycle status stable as `running` during startup
- expose an additive `phase: initializing | active` snapshot field owned by the canonical subagent record
- advance initialization monotonically when the executor live handle registers, without regressing during handle teardown or same-attempt record replacement
- suppress stale live-progress claims without a live handle and return actionable guidance for premature steering
- include phase in the renderer cache signature so active snapshots cannot reuse an initializing body

## Why

Supersedes #2276 and addresses both blocking review findings there:

1. `initializing` is no longer a new public lifecycle status; durable status remains backward compatible.
2. Phase is no longer derived from current handle absence, so normal teardown cannot produce `running/active → initializing/initializing`.

The manager now owns a monotonic startup marker for each running attempt, including handle-before-record registration and resume races.

## Testing

- `bun test packages/coding-agent/test/tools/subagent-live-progress.test.ts packages/coding-agent/test/tools/subagent-render.test.ts packages/coding-agent/test/tools/subagent.test.ts` — 65 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — pass (Biome, generated hotkeys check, SDK canonicalization, package type check)
- `git diff --check` — pass
- independent architecture rereview — CLEAR / APPROVE

---

- [x] Target is `dev`
- [x] Focused tests and package checks pass
- [x] CHANGELOG updated