### PR TITLE
feat(computer): add isolated macOS Gate 0 feasibility harness

### DIFF
--- a/crates/pi-natives/src/computer/controller.rs
+++ b/crates/pi-natives/src/computer/controller.rs
@@ -44,8 +44,8 @@ impl ComputerController {
 		})
 	}
 
-	/// Return the non-prompting combined Accessibility + PostEvent TCC state for
-	/// the hidden Gate-0 experiment.
+	/// Return the non-prompting combined Accessibility + `PostEvent` TCC state
+	/// for the hidden Gate-0 experiment.
 	#[napi(js_name = "gate0PermissionStatus")]
 	pub fn gate0_permission_status(&self) -> Gate0PermissionStatus {
 		let status = permissions::preflight();
@@ -212,25 +212,6 @@ fn gate0_harmless_probe_result(
 	Gate0HarmlessProbeResult { screenshot, accessibility: input_authority, pointer_move_restore }
 }
 
-#[cfg(test)]
-mod tests {
-	use super::gate0_harmless_probe_result;
-
-	#[test]
-	fn gate0_skips_pointer_execution_without_combined_authority() {
-		for authority in [false, true] {
-			let mut calls = 0;
-			let result = gate0_harmless_probe_result(true, authority, || {
-				calls += 1;
-				true
-			});
-			assert_eq!(result.accessibility, authority);
-			assert_eq!(result.pointer_move_restore, authority);
-			assert_eq!(calls, usize::from(authority));
-		}
-	}
-}
-
 fn gate0_pointer_move_restore() -> bool {
 	harmless_move_restore().unwrap_or(false)
 }
@@ -248,4 +229,23 @@ fn exec_error(err: ExecError) -> napi::Error {
 
 fn napi_error(code: &'static str, reason: String) -> napi::Error {
 	napi::Error::new(napi::Status::GenericFailure, format!("{code}: {reason}"))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::gate0_harmless_probe_result;
+
+	#[test]
+	fn gate0_skips_pointer_execution_without_combined_authority() {
+		for authority in [false, true] {
+			let mut calls = 0;
+			let result = gate0_harmless_probe_result(true, authority, || {
+				calls += 1;
+				true
+			});
+			assert_eq!(result.accessibility, authority);
+			assert_eq!(result.pointer_move_restore, authority);
+			assert_eq!(calls, usize::from(authority));
+		}
+	}
 }

--- a/crates/pi-natives/src/computer/controller.rs
+++ b/crates/pi-natives/src/computer/controller.rs
@@ -1,18 +1,19 @@
 //! N-API controller surface for macOS computer-use.
 //!
-//! Side-effecting methods are thin adapters: they construct an [`InputAction`]
-//! and delegate to [`execute_input`]. No direct input controller methods are
-//! called from this module.
+//! Normal side-effecting methods are thin adapters: they construct an
+//! [`InputAction`] and delegate to [`execute_input`]. The explicit Gate-0 probe
+//! is the sole exception: it performs a bounded move-and-restore experiment.
 
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::computer::{
-	ComputerScreenshot,
+	ComputerScreenshot, Gate0HarmlessProbeResult, Gate0PermissionStatus,
 	capture::capture_primary_display,
 	executor::{DisplayContext, ExecError, InputAction, MacPermissionGate, execute_input},
 	hotkey,
-	input::{MouseButton, guarded_controller},
+	input::{MouseButton, guarded_controller, harmless_move_restore},
+	permissions,
 	supervisor::Supervisor,
 };
 
@@ -41,6 +42,36 @@ impl ComputerController {
 			display_epoch: frame.display_epoch as f64,
 			capture_id:    frame.capture_id,
 		})
+	}
+
+	/// Return the non-prompting combined Accessibility + PostEvent TCC state for
+	/// the hidden Gate-0 experiment.
+	#[napi(js_name = "gate0PermissionStatus")]
+	pub fn gate0_permission_status(&self) -> Gate0PermissionStatus {
+		let status = permissions::preflight();
+		Gate0PermissionStatus {
+			accessibility:    permissions::gate0_input_injection_granted(),
+			screen_recording: status.screen_recording,
+		}
+	}
+
+	/// Explicitly request Screen Recording access for the hidden Gate-0
+	/// experiment. Normal controller initialization and screenshot paths never
+	/// call this.
+	#[napi(js_name = "gate0RequestScreenRecording")]
+	pub fn gate0_request_screen_recording(&self) -> bool {
+		permissions::request_screen_recording_access()
+	}
+
+	/// Run the hidden Gate-0 probe without returning screenshot bytes or cursor
+	/// coordinates. The pointer path moves exactly one logical pixel and
+	/// restores the original location without clicking, typing, or holding
+	/// input state.
+	#[napi(js_name = "gate0HarmlessProbe")]
+	pub fn gate0_harmless_probe(&self) -> Gate0HarmlessProbeResult {
+		let screenshot = capture_primary_display().is_ok();
+		let accessibility = permissions::gate0_input_injection_granted();
+		gate0_harmless_probe_result(screenshot, accessibility, gate0_pointer_move_restore)
 	}
 
 	#[napi]
@@ -172,6 +203,37 @@ fn parse_button(button: Option<String>) -> napi::Result<MouseButton> {
 	}
 }
 
+fn gate0_harmless_probe_result(
+	screenshot: bool,
+	input_authority: bool,
+	pointer_probe: impl FnOnce() -> bool,
+) -> Gate0HarmlessProbeResult {
+	let pointer_move_restore = input_authority && pointer_probe();
+	Gate0HarmlessProbeResult { screenshot, accessibility: input_authority, pointer_move_restore }
+}
+
+#[cfg(test)]
+mod tests {
+	use super::gate0_harmless_probe_result;
+
+	#[test]
+	fn gate0_skips_pointer_execution_without_combined_authority() {
+		for authority in [false, true] {
+			let mut calls = 0;
+			let result = gate0_harmless_probe_result(true, authority, || {
+				calls += 1;
+				true
+			});
+			assert_eq!(result.accessibility, authority);
+			assert_eq!(result.pointer_move_restore, authority);
+			assert_eq!(calls, usize::from(authority));
+		}
+	}
+}
+
+fn gate0_pointer_move_restore() -> bool {
+	harmless_move_restore().unwrap_or(false)
+}
 fn epoch_from_f64(value: f64) -> u64 {
 	if value.is_finite() && value >= 0.0 {
 		value as u64

--- a/crates/pi-natives/src/computer/input.rs
+++ b/crates/pi-natives/src/computer/input.rs
@@ -16,9 +16,12 @@
 
 use super::coords::{CoordError, LogicalPoint, NormalizedDisplay};
 
+#[cfg(any(target_os = "macos", test))]
 const CURSOR_TOLERANCE: f64 = 0.49;
+#[cfg(any(target_os = "macos", test))]
 const CURSOR_COMPARISON_EPSILON: f64 = 1e-9;
 
+#[cfg(any(target_os = "macos", test))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct CursorBounds {
 	min_x: f64,
@@ -27,6 +30,7 @@ struct CursorBounds {
 	max_y: f64,
 }
 
+#[cfg(any(target_os = "macos", test))]
 impl CursorBounds {
 	fn move_target(self, original: LogicalPoint) -> Option<LogicalPoint> {
 		if !self.min_x.is_finite()
@@ -58,9 +62,12 @@ impl CursorBounds {
 	}
 }
 
+#[cfg(any(target_os = "macos", test))]
 const PROBE_DEADLINE_MS: u64 = 100;
+#[cfg(any(target_os = "macos", test))]
 const PROBE_POLL_MS: u64 = 1;
 
+#[cfg(any(target_os = "macos", test))]
 trait HarmlessMoveBackend {
 	type Error;
 
@@ -72,6 +79,7 @@ trait HarmlessMoveBackend {
 	fn sleep_millis(&mut self, millis: u64);
 }
 
+#[cfg(any(target_os = "macos", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CleanupConfirmation {
 	NotRequired,
@@ -80,25 +88,30 @@ enum CleanupConfirmation {
 	Unconfirmed,
 }
 
+#[cfg(any(target_os = "macos", test))]
 #[derive(Debug, PartialEq)]
 struct HarmlessMoveVerification<E> {
 	primary: Result<bool, E>,
 	cleanup: CleanupConfirmation,
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn is_near(actual: LogicalPoint, expected: LogicalPoint) -> bool {
 	(actual.x - expected.x).abs() <= CURSOR_TOLERANCE + CURSOR_COMPARISON_EPSILON
 		&& (actual.y - expected.y).abs() <= CURSOR_TOLERANCE + CURSOR_COMPARISON_EPSILON
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn is_distinct_from(actual: LogicalPoint, opposite: LogicalPoint) -> bool {
 	!is_near(actual, opposite)
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn before_deadline<B: HarmlessMoveBackend>(backend: &mut B, deadline: u64) -> bool {
 	backend.monotonic_millis() < deadline
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn poll<B: HarmlessMoveBackend>(backend: &mut B, deadline: u64) -> bool {
 	let now = backend.monotonic_millis();
 	if now >= deadline {
@@ -108,6 +121,7 @@ fn poll<B: HarmlessMoveBackend>(backend: &mut B, deadline: u64) -> bool {
 	before_deadline(backend, deadline)
 }
 
+#[cfg(any(target_os = "macos", test))]
 enum Observation<E> {
 	Stable,
 	Unsafe,
@@ -118,6 +132,7 @@ enum Observation<E> {
 /// Observe `expected` twice, separated by a bounded poll. `pending` is safe to
 /// wait through (for example, the original point while a target event arrives),
 /// but it is never accepted as confirmation.
+#[cfg(any(target_os = "macos", test))]
 fn observe_stable<B: HarmlessMoveBackend>(
 	backend: &mut B,
 	expected: LogicalPoint,
@@ -153,6 +168,7 @@ fn observe_stable<B: HarmlessMoveBackend>(
 
 /// The only restoration path. It never warps unless target was observed
 /// stably, and it confirms original twice under the single probe deadline.
+#[cfg(any(target_os = "macos", test))]
 fn restore_cursor<B: HarmlessMoveBackend>(
 	backend: &mut B,
 	original: LogicalPoint,
@@ -163,9 +179,8 @@ fn restore_cursor<B: HarmlessMoveBackend>(
 		if !before_deadline(backend, deadline) {
 			return CleanupConfirmation::Unconfirmed;
 		}
-		let current = match backend.current_cursor_position() {
-			Ok(current) => current,
-			Err(_) => return CleanupConfirmation::Unconfirmed,
+		let Ok(current) = backend.current_cursor_position() else {
+			return CleanupConfirmation::Unconfirmed;
 		};
 		if !before_deadline(backend, deadline) {
 			return CleanupConfirmation::Unconfirmed;
@@ -199,6 +214,7 @@ fn restore_cursor<B: HarmlessMoveBackend>(
 	CleanupConfirmation::Unconfirmed
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn verify_harmless_move_restore<B: HarmlessMoveBackend>(
 	backend: &mut B,
 ) -> HarmlessMoveVerification<B::Error> {
@@ -692,7 +708,7 @@ mod mac {
 			Self { source, started: std::time::Instant::now() }
 		}
 
-		fn checked_mouse_event(event: CgEventRef) -> Result<CgEventRef, HarmlessMoveError> {
+		const fn checked_mouse_event(event: CgEventRef) -> Result<CgEventRef, HarmlessMoveError> {
 			if event.is_null() {
 				Err(HarmlessMoveError::MouseEventCreateFailed)
 			} else {
@@ -724,19 +740,6 @@ mod mac {
 
 		fn post_mouse(&self, at: LogicalPoint, event_type: u32, button: u32) {
 			let _ = self.post_mouse_checked(at, event_type, button);
-		}
-	}
-
-	#[cfg(test)]
-	mod tests {
-		use super::{HarmlessMoveError, MacEventSink};
-
-		#[test]
-		fn null_mouse_event_is_rejected_before_post_or_release() {
-			assert_eq!(
-				MacEventSink::checked_mouse_event(std::ptr::null_mut()),
-				Err(HarmlessMoveError::MouseEventCreateFailed)
-			);
 		}
 	}
 
@@ -906,6 +909,19 @@ mod mac {
 		verification
 			.primary
 			.map(|moved| moved && verification.cleanup == super::CleanupConfirmation::Confirmed)
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use super::{HarmlessMoveError, MacEventSink};
+
+		#[test]
+		fn null_mouse_event_is_rejected_before_post_or_release() {
+			assert_eq!(
+				MacEventSink::checked_mouse_event(std::ptr::null_mut()),
+				Err(HarmlessMoveError::MouseEventCreateFailed)
+			);
+		}
 	}
 }
 
@@ -1423,7 +1439,7 @@ mod live_tests {
 	use crate::computer::capture::capture_primary_display;
 
 	/// Fires a real cursor move (no clicks/keys) and reads the position back to
-	/// prove the CGEvent input pipeline works end to end. Ignored by default;
+	/// prove the `CGEvent` input pipeline works end to end. Ignored by default;
 	/// run with `--ignored` on a macOS host with Accessibility granted.
 	#[test]
 	#[ignore = "moves the real cursor; needs macOS + Accessibility granted"]
@@ -1472,7 +1488,7 @@ mod live_tests {
 	}
 
 	/// G005 acceptance drill: drives all nine primitives through the gated
-	/// execute_input path against the focused frontmost app, then waits for a
+	/// `execute_input` path against the focused frontmost app, then waits for a
 	/// human kill-switch press and proves input is blocked afterward.
 	#[test]
 	#[ignore = "live G005: drives the focused app + needs a human hotkey press"]

--- a/crates/pi-natives/src/computer/input.rs
+++ b/crates/pi-natives/src/computer/input.rs
@@ -3,9 +3,8 @@
 //! # Safety model
 //! Input is **runtime-gated**: [`InputController::guarded`] refuses to
 //! construct unless Accessibility is granted (see [`super::permissions`]), so
-//! no event can be posted while the TCC gate is closed. This module is also
-//! **not** wired to napi or the model surface yet — per the approved plan,
-//! input is exposed only after the kill-switch supervisor is proven live.
+//! no event can be posted while the TCC gate is closed. The Gate-0 harmless
+//! probe is separately bounded and reports only redacted boolean results.
 //!
 //! # Testability
 //! All event *orchestration* (action → low-level event sequence, held
@@ -16,6 +15,244 @@
 //! in a granted `gjc` session, not from a non-TCC-trusted test binary.
 
 use super::coords::{CoordError, LogicalPoint, NormalizedDisplay};
+
+const CURSOR_TOLERANCE: f64 = 0.49;
+const CURSOR_COMPARISON_EPSILON: f64 = 1e-9;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct CursorBounds {
+	min_x: f64,
+	max_x: f64,
+	min_y: f64,
+	max_y: f64,
+}
+
+impl CursorBounds {
+	fn move_target(self, original: LogicalPoint) -> Option<LogicalPoint> {
+		if !self.min_x.is_finite()
+			|| !self.max_x.is_finite()
+			|| !self.min_y.is_finite()
+			|| !self.max_y.is_finite()
+			|| self.min_x >= self.max_x
+			|| self.min_y >= self.max_y
+			|| !original.x.is_finite()
+			|| !original.y.is_finite()
+			|| original.x < self.min_x
+			|| original.x >= self.max_x
+			|| original.y < self.min_y
+			|| original.y >= self.max_y
+		{
+			return None;
+		}
+		if original.x + 1.0 < self.max_x {
+			Some(LogicalPoint { x: original.x + 1.0, y: original.y })
+		} else if original.x - 1.0 >= self.min_x {
+			Some(LogicalPoint { x: original.x - 1.0, y: original.y })
+		} else if original.y + 1.0 < self.max_y {
+			Some(LogicalPoint { x: original.x, y: original.y + 1.0 })
+		} else if original.y - 1.0 >= self.min_y {
+			Some(LogicalPoint { x: original.x, y: original.y - 1.0 })
+		} else {
+			None
+		}
+	}
+}
+
+const PROBE_DEADLINE_MS: u64 = 100;
+const PROBE_POLL_MS: u64 = 1;
+
+trait HarmlessMoveBackend {
+	type Error;
+
+	fn current_cursor_position(&mut self) -> Result<LogicalPoint, Self::Error>;
+	fn cursor_bounds(&mut self, at: LogicalPoint) -> Result<CursorBounds, Self::Error>;
+	fn warp_cursor(&mut self, to: LogicalPoint) -> Result<(), Self::Error>;
+	fn post_move(&mut self, to: LogicalPoint) -> Result<(), Self::Error>;
+	fn monotonic_millis(&mut self) -> u64;
+	fn sleep_millis(&mut self, millis: u64);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CleanupConfirmation {
+	NotRequired,
+	Confirmed,
+	ConfirmedAfterEventFailure,
+	Unconfirmed,
+}
+
+#[derive(Debug, PartialEq)]
+struct HarmlessMoveVerification<E> {
+	primary: Result<bool, E>,
+	cleanup: CleanupConfirmation,
+}
+
+fn is_near(actual: LogicalPoint, expected: LogicalPoint) -> bool {
+	(actual.x - expected.x).abs() <= CURSOR_TOLERANCE + CURSOR_COMPARISON_EPSILON
+		&& (actual.y - expected.y).abs() <= CURSOR_TOLERANCE + CURSOR_COMPARISON_EPSILON
+}
+
+fn is_distinct_from(actual: LogicalPoint, opposite: LogicalPoint) -> bool {
+	!is_near(actual, opposite)
+}
+
+fn before_deadline<B: HarmlessMoveBackend>(backend: &mut B, deadline: u64) -> bool {
+	backend.monotonic_millis() < deadline
+}
+
+fn poll<B: HarmlessMoveBackend>(backend: &mut B, deadline: u64) -> bool {
+	let now = backend.monotonic_millis();
+	if now >= deadline {
+		return false;
+	}
+	backend.sleep_millis((deadline - now).min(PROBE_POLL_MS));
+	before_deadline(backend, deadline)
+}
+
+enum Observation<E> {
+	Stable,
+	Unsafe,
+	Deadline,
+	Error(E),
+}
+
+/// Observe `expected` twice, separated by a bounded poll. `pending` is safe to
+/// wait through (for example, the original point while a target event arrives),
+/// but it is never accepted as confirmation.
+fn observe_stable<B: HarmlessMoveBackend>(
+	backend: &mut B,
+	expected: LogicalPoint,
+	opposite: LogicalPoint,
+	deadline: u64,
+	pending: LogicalPoint,
+) -> Observation<B::Error> {
+	let mut seen_expected = false;
+	while before_deadline(backend, deadline) {
+		let current = match backend.current_cursor_position() {
+			Ok(current) => current,
+			Err(error) => return Observation::Error(error),
+		};
+		if !before_deadline(backend, deadline) {
+			return Observation::Deadline;
+		}
+		if is_near(current, expected) && is_distinct_from(current, opposite) {
+			if seen_expected {
+				return Observation::Stable;
+			}
+			seen_expected = true;
+		} else if !is_near(current, pending) || !is_distinct_from(current, expected) {
+			return Observation::Unsafe;
+		} else {
+			seen_expected = false;
+		}
+		if !poll(backend, deadline) {
+			break;
+		}
+	}
+	Observation::Deadline
+}
+
+/// The only restoration path. It never warps unless target was observed
+/// stably, and it confirms original twice under the single probe deadline.
+fn restore_cursor<B: HarmlessMoveBackend>(
+	backend: &mut B,
+	original: LogicalPoint,
+	target: LogicalPoint,
+	deadline: u64,
+) -> CleanupConfirmation {
+	for _ in 0..2 {
+		if !before_deadline(backend, deadline) {
+			return CleanupConfirmation::Unconfirmed;
+		}
+		let current = match backend.current_cursor_position() {
+			Ok(current) => current,
+			Err(_) => return CleanupConfirmation::Unconfirmed,
+		};
+		if !before_deadline(backend, deadline) {
+			return CleanupConfirmation::Unconfirmed;
+		}
+		if is_near(current, original) && is_distinct_from(current, target) {
+			return match observe_stable(backend, original, target, deadline, target) {
+				Observation::Stable => CleanupConfirmation::Confirmed,
+				Observation::Unsafe | Observation::Deadline | Observation::Error(_) => {
+					CleanupConfirmation::Unconfirmed
+				},
+			};
+		}
+		if !is_near(current, target) || !is_distinct_from(current, original) {
+			return CleanupConfirmation::Unconfirmed;
+		}
+		if backend.warp_cursor(original).is_err() {
+			continue;
+		}
+		// Event creation failure does not bypass bounded readback confirmation.
+		let post_failed = backend.post_move(original).is_err();
+		match observe_stable(backend, original, target, deadline, target) {
+			Observation::Stable if post_failed => {
+				return CleanupConfirmation::ConfirmedAfterEventFailure;
+			},
+			Observation::Stable => return CleanupConfirmation::Confirmed,
+			Observation::Unsafe | Observation::Deadline | Observation::Error(_) => {
+				return CleanupConfirmation::Unconfirmed;
+			},
+		}
+	}
+	CleanupConfirmation::Unconfirmed
+}
+
+fn verify_harmless_move_restore<B: HarmlessMoveBackend>(
+	backend: &mut B,
+) -> HarmlessMoveVerification<B::Error> {
+	let deadline = backend.monotonic_millis().saturating_add(PROBE_DEADLINE_MS);
+	let original = match backend.current_cursor_position() {
+		Ok(original) => original,
+		Err(error) => {
+			return HarmlessMoveVerification {
+				primary: Err(error),
+				cleanup: CleanupConfirmation::NotRequired,
+			};
+		},
+	};
+	let target = match backend.cursor_bounds(original) {
+		Ok(bounds) => match bounds.move_target(original) {
+			Some(target) => target,
+			None => {
+				return HarmlessMoveVerification {
+					primary: Ok(false),
+					cleanup: CleanupConfirmation::NotRequired,
+				};
+			},
+		},
+		Err(error) => {
+			return HarmlessMoveVerification {
+				primary: Err(error),
+				cleanup: CleanupConfirmation::NotRequired,
+			};
+		},
+	};
+	if let Err(error) = backend.warp_cursor(target) {
+		return HarmlessMoveVerification {
+			primary: Err(error),
+			cleanup: CleanupConfirmation::NotRequired,
+		};
+	}
+	let target_post_error = backend.post_move(target).err();
+	let observed = observe_stable(backend, target, original, deadline, original);
+	let cleanup = match observed {
+		Observation::Stable => restore_cursor(backend, original, target, deadline),
+		Observation::Unsafe | Observation::Deadline | Observation::Error(_) => {
+			CleanupConfirmation::Unconfirmed
+		},
+	};
+	let primary = match target_post_error {
+		Some(error) => Err(error),
+		None => match observed {
+			Observation::Stable => Ok(cleanup == CleanupConfirmation::Confirmed),
+			Observation::Unsafe | Observation::Deadline => Ok(false),
+			Observation::Error(error) => Err(error),
+		},
+	};
+	HarmlessMoveVerification { primary, cleanup }
+}
 
 /// A mouse button.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -281,7 +518,10 @@ impl<S: EventSink> InputController<S> {
 }
 
 #[cfg(target_os = "macos")]
-pub use mac::{MacEventSink, current_cursor_position, guarded_controller};
+pub use mac::{
+	CursorPositionError, HarmlessMoveError, MacEventSink, current_cursor_position,
+	guarded_controller, harmless_move_restore,
+};
 
 #[cfg(target_os = "macos")]
 mod mac {
@@ -290,11 +530,26 @@ mod mac {
 
 	use std::ffi::c_void;
 
-	use super::{EventSink, InputController, MouseButton};
-	use crate::computer::{
-		coords::LogicalPoint,
-		permissions::{PermissionError, require_accessibility_for_input},
+	use super::{
+		CursorBounds, EventSink, HarmlessMoveBackend, InputController, LogicalPoint, MouseButton,
 	};
+	use crate::computer::permissions::{
+		PermissionError, gate0_input_injection_granted, require_accessibility_for_input,
+	};
+
+	#[repr(C)]
+	#[derive(Clone, Copy)]
+	struct CgSize {
+		width:  f64,
+		height: f64,
+	}
+
+	#[repr(C)]
+	#[derive(Clone, Copy)]
+	struct CgRect {
+		origin: CgPoint,
+		size:   CgSize,
+	}
 
 	#[repr(C)]
 	#[derive(Clone, Copy)]
@@ -354,6 +609,13 @@ mod mac {
 		fn CGEventCreate(source: CgEventSourceRef) -> CgEventRef;
 		fn CGEventGetLocation(event: CgEventRef) -> CgPoint;
 		fn CGWarpMouseCursorPosition(new_cursor_position: CgPoint) -> i32;
+		fn CGGetDisplaysWithPoint(
+			point: CgPoint,
+			max_displays: u32,
+			displays: *mut u32,
+			display_count: *mut u32,
+		) -> i32;
+		fn CGDisplayBounds(display: u32) -> CgRect;
 		fn CFRelease(cf: *const c_void);
 	}
 
@@ -365,9 +627,61 @@ mod mac {
 		}
 	}
 
+	/// Failure while obtaining the global cursor position.
+	#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+	pub enum CursorPositionError {
+		/// Core Graphics could not create the event used to read the cursor.
+		EventCreateFailed,
+	}
+
+	impl std::fmt::Display for CursorPositionError {
+		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+			write!(f, "Core Graphics could not read the cursor position")
+		}
+	}
+
+	impl std::error::Error for CursorPositionError {}
+
+	/// Failure during the bounded Gate-0 cursor move-and-restore experiment.
+	#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+	pub enum HarmlessMoveError {
+		/// The cursor position could not be observed.
+		CursorPosition(CursorPositionError),
+		/// Core Graphics could not identify the display containing the cursor.
+		DisplayLookupFailed(i32),
+		/// Core Graphics could not create the synthetic mouse-move event.
+		MouseEventCreateFailed,
+		/// Core Graphics rejected a cursor warp.
+		WarpFailed(i32),
+	}
+
+	impl From<CursorPositionError> for HarmlessMoveError {
+		fn from(value: CursorPositionError) -> Self {
+			Self::CursorPosition(value)
+		}
+	}
+
+	impl std::fmt::Display for HarmlessMoveError {
+		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+			match self {
+				Self::CursorPosition(error) => std::fmt::Display::fmt(error, f),
+				Self::DisplayLookupFailed(status) => {
+					write!(f, "Core Graphics display lookup failed ({status})")
+				},
+				Self::MouseEventCreateFailed => {
+					write!(f, "Core Graphics could not create the synthetic mouse-move event")
+				},
+				Self::WarpFailed(status) => write!(f, "Core Graphics cursor warp failed ({status})"),
+			}
+		}
+	}
+
+	impl std::error::Error for HarmlessMoveError {}
+
 	/// CGEvent-backed sink. Holds an event source for the session.
 	pub struct MacEventSink {
-		source: CgEventSourceRef,
+		source:  CgEventSourceRef,
+		started: std::time::Instant,
 	}
 
 	impl MacEventSink {
@@ -375,20 +689,106 @@ mod mac {
 			// SAFETY: `CGEventSourceCreate` returns an owned source (or null,
 			// which CGEvent creation tolerates); released on drop.
 			let source = unsafe { CGEventSourceCreate(SOURCE_COMBINED_SESSION) };
-			Self { source }
+			Self { source, started: std::time::Instant::now() }
 		}
 
-		fn post_mouse(&self, at: LogicalPoint, event_type: u32, button: u32) {
+		fn checked_mouse_event(event: CgEventRef) -> Result<CgEventRef, HarmlessMoveError> {
+			if event.is_null() {
+				Err(HarmlessMoveError::MouseEventCreateFailed)
+			} else {
+				Ok(event)
+			}
+		}
+
+		fn post_mouse_checked(
+			&self,
+			at: LogicalPoint,
+			event_type: u32,
+			button: u32,
+		) -> Result<(), HarmlessMoveError> {
 			let position = CgPoint { x: at.x, y: at.y };
 			// SAFETY: `source` is the owned event source; the created event is
 			// posted and released exactly once.
 			unsafe {
-				let event = CGEventCreateMouseEvent(self.source, event_type, position, button);
-				if !event.is_null() {
-					CGEventPost(HID_EVENT_TAP, event);
-					CFRelease(event.cast_const());
-				}
+				let event = Self::checked_mouse_event(CGEventCreateMouseEvent(
+					self.source,
+					event_type,
+					position,
+					button,
+				))?;
+				CGEventPost(HID_EVENT_TAP, event);
+				CFRelease(event.cast_const());
 			}
+			Ok(())
+		}
+
+		fn post_mouse(&self, at: LogicalPoint, event_type: u32, button: u32) {
+			let _ = self.post_mouse_checked(at, event_type, button);
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use super::{HarmlessMoveError, MacEventSink};
+
+		#[test]
+		fn null_mouse_event_is_rejected_before_post_or_release() {
+			assert_eq!(
+				MacEventSink::checked_mouse_event(std::ptr::null_mut()),
+				Err(HarmlessMoveError::MouseEventCreateFailed)
+			);
+		}
+	}
+
+	impl HarmlessMoveBackend for MacEventSink {
+		type Error = HarmlessMoveError;
+
+		fn current_cursor_position(&mut self) -> Result<LogicalPoint, Self::Error> {
+			current_cursor_position().map_err(Into::into)
+		}
+
+		fn cursor_bounds(&mut self, at: LogicalPoint) -> Result<CursorBounds, Self::Error> {
+			let mut display = 0;
+			let mut count = 0;
+			// SAFETY: output pointers reference initialized local storage and allow exactly
+			// one display.
+			let status = unsafe {
+				CGGetDisplaysWithPoint(CgPoint { x: at.x, y: at.y }, 1, &mut display, &mut count)
+			};
+			if status != 0 || count != 1 {
+				return Err(HarmlessMoveError::DisplayLookupFailed(status));
+			}
+			// SAFETY: `display` was returned by Core Graphics and `CGDisplayBounds` is a
+			// pure query.
+			let bounds = unsafe { CGDisplayBounds(display) };
+			Ok(CursorBounds {
+				min_x: bounds.origin.x,
+				max_x: bounds.origin.x + bounds.size.width,
+				min_y: bounds.origin.y,
+				max_y: bounds.origin.y + bounds.size.height,
+			})
+		}
+
+		fn monotonic_millis(&mut self) -> u64 {
+			self.started.elapsed().as_millis() as u64
+		}
+
+		fn sleep_millis(&mut self, millis: u64) {
+			std::thread::sleep(std::time::Duration::from_millis(millis));
+		}
+
+		fn warp_cursor(&mut self, to: LogicalPoint) -> Result<(), Self::Error> {
+			// SAFETY: pure Core Graphics cursor warp to a finite logical point.
+			let status = unsafe { CGWarpMouseCursorPosition(CgPoint { x: to.x, y: to.y }) };
+			if status == 0 {
+				Ok(())
+			} else {
+				Err(HarmlessMoveError::WarpFailed(status))
+			}
+		}
+
+		fn post_move(&mut self, to: LogicalPoint) -> Result<(), Self::Error> {
+			self.post_mouse_checked(to, MOUSE_MOVED, BTN_LEFT)
 		}
 	}
 
@@ -475,26 +875,46 @@ mod mac {
 	}
 
 	/// Read the current global cursor position in logical points (top-left
-	/// origin). Used to verify mouse-move injection without clicking.
-	#[must_use]
-	pub fn current_cursor_position() -> LogicalPoint {
+	/// origin).
+	///
+	/// # Errors
+	/// Returns [`CursorPositionError::EventCreateFailed`] rather than
+	/// substituting a coordinate when Core Graphics cannot create the read
+	/// event.
+	pub fn current_cursor_position() -> Result<LogicalPoint, CursorPositionError> {
 		// SAFETY: `CGEventCreate(null)` returns an event whose location is the
 		// current cursor; it is released after the read.
 		unsafe {
 			let event = CGEventCreate(std::ptr::null_mut());
 			if event.is_null() {
-				return LogicalPoint { x: 0.0, y: 0.0 };
+				return Err(CursorPositionError::EventCreateFailed);
 			}
 			let location = CGEventGetLocation(event);
 			CFRelease(event.cast_const());
-			LogicalPoint { x: location.x, y: location.y }
+			Ok(LogicalPoint { x: location.x, y: location.y })
 		}
+	}
+
+	/// Move the cursor one in-bounds logical pixel, post one checked mouse-move
+	/// event, observe the result, then restore and re-observe the original
+	/// location.
+	pub fn harmless_move_restore() -> Result<bool, HarmlessMoveError> {
+		if !gate0_input_injection_granted() {
+			return Ok(false);
+		}
+		let verification = super::verify_harmless_move_restore(&mut MacEventSink::new());
+		verification
+			.primary
+			.map(|moved| moved && verification.cleanup == super::CleanupConfirmation::Confirmed)
 	}
 }
 
 #[cfg(test)]
 mod tests {
-	use super::{EventSink, InputController, InputError, MouseButton, SinkOp, key_code_for};
+	use super::{
+		CursorBounds, EventSink, HarmlessMoveBackend, InputController, InputError, MouseButton,
+		SinkOp, key_code_for, verify_harmless_move_restore,
+	};
 	use crate::computer::coords::{LogicalPoint, NormalizedDisplay};
 
 	#[derive(Default)]
@@ -527,6 +947,334 @@ mod tests {
 	fn display() -> NormalizedDisplay {
 		// 200x100 physical px at 2x => clicks map to logical /2.
 		NormalizedDisplay::new(200, 100, 2.0, 2.0, 0.0, 0.0)
+	}
+
+	struct FakeHarmlessMoveBackend {
+		bounds:              Option<CursorBounds>,
+		reads:               Vec<Result<LogicalPoint, &'static str>>,
+		read_clock_advances: Vec<u64>,
+		warps:               Vec<Result<(), &'static str>>,
+		warp_targets:        Vec<LogicalPoint>,
+		post_results:        Vec<Result<(), &'static str>>,
+		posts:               Vec<LogicalPoint>,
+		now:                 u64,
+	}
+
+	impl HarmlessMoveBackend for FakeHarmlessMoveBackend {
+		type Error = &'static str;
+
+		fn current_cursor_position(&mut self) -> Result<LogicalPoint, Self::Error> {
+			let result = self.reads.remove(0);
+			if !self.read_clock_advances.is_empty() {
+				self.now += self.read_clock_advances.remove(0);
+			}
+			result
+		}
+
+		fn cursor_bounds(&mut self, _at: LogicalPoint) -> Result<CursorBounds, Self::Error> {
+			self.bounds.ok_or("no display")
+		}
+
+		fn warp_cursor(&mut self, to: LogicalPoint) -> Result<(), Self::Error> {
+			self.warp_targets.push(to);
+			self.warps.remove(0)
+		}
+
+		fn post_move(&mut self, to: LogicalPoint) -> Result<(), Self::Error> {
+			self.posts.push(to);
+			self.post_results.remove(0)
+		}
+
+		fn monotonic_millis(&mut self) -> u64 {
+			self.now
+		}
+
+		fn sleep_millis(&mut self, millis: u64) {
+			self.now += millis;
+		}
+	}
+
+	fn point(x: f64, y: f64) -> LogicalPoint {
+		LogicalPoint { x, y }
+	}
+	fn bounds() -> CursorBounds {
+		CursorBounds { min_x: 0.0, max_x: 10.0, min_y: 0.0, max_y: 10.0 }
+	}
+	fn fake(
+		reads: Vec<Result<LogicalPoint, &'static str>>,
+		warps: Vec<Result<(), &'static str>>,
+		posts: Vec<Result<(), &'static str>>,
+	) -> FakeHarmlessMoveBackend {
+		FakeHarmlessMoveBackend {
+			bounds: Some(bounds()),
+			reads,
+			read_clock_advances: vec![],
+			warps,
+			warp_targets: vec![],
+			post_results: posts,
+			posts: vec![],
+			now: 0,
+		}
+	}
+
+	#[test]
+	fn harmless_move_requires_stable_delayed_target_and_restore_under_one_deadline() {
+		let original = point(5.0, 5.0);
+		let target = point(6.0, 5.0);
+		let mut backend = fake(
+			vec![
+				Ok(original),
+				Ok(original),
+				Ok(target),
+				Ok(target),
+				Ok(target),
+				Ok(original),
+				Ok(original),
+			],
+			vec![Ok(()), Ok(())],
+			vec![Ok(()), Ok(())],
+		);
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Ok(true));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Confirmed);
+		assert_eq!(backend.posts, vec![target, original]);
+		assert_eq!(backend.now, 3);
+	}
+
+	#[test]
+	fn harmless_move_deadline_is_shared_and_early_original_does_not_confirm_cleanup() {
+		let original = point(5.0, 5.0);
+		let reads =
+			std::iter::repeat_n(Ok(original), super::PROBE_DEADLINE_MS as usize + 1).collect();
+		let mut backend = fake(reads, vec![Ok(())], vec![Ok(())]);
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Ok(false));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Unconfirmed);
+		assert_eq!(backend.now, super::PROBE_DEADLINE_MS);
+		assert_eq!(backend.warp_targets.len(), 1);
+	}
+
+	#[test]
+	fn harmless_move_preserves_primary_event_error_and_records_confirmed_cleanup() {
+		let original = point(5.0, 5.0);
+		let target = point(6.0, 5.0);
+		let mut backend = fake(
+			vec![Ok(original), Ok(target), Ok(target), Ok(target), Ok(original), Ok(original)],
+			vec![Ok(()), Ok(())],
+			vec![Err("target event"), Ok(())],
+		);
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Err("target event"));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Confirmed);
+	}
+
+	#[test]
+	fn harmless_move_preserves_target_event_failure_when_cleanup_is_unconfirmed() {
+		let original = point(5.0, 5.0);
+		let target = point(6.0, 5.0);
+		let mut backend = fake(
+			vec![Ok(original), Ok(target), Ok(target), Ok(point(50.0, 50.0))],
+			vec![Ok(()), Ok(())],
+			vec![Err("target event"), Ok(())],
+		);
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Err("target event"));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Unconfirmed);
+	}
+
+	#[test]
+	fn harmless_move_event_or_read_failure_without_safe_target_is_unconfirmed() {
+		let original = point(5.0, 5.0);
+		let mut backend = fake(vec![Ok(original), Err("target read")], vec![Ok(())], vec![Ok(())]);
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Err("target read"));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Unconfirmed);
+		assert_eq!(backend.warp_targets, vec![point(6.0, 5.0)]);
+	}
+
+	#[test]
+	fn harmless_move_restore_event_failure_still_confirms_readback() {
+		let original = point(5.0, 5.0);
+		let target = point(6.0, 5.0);
+		let mut backend = fake(
+			vec![Ok(original), Ok(target), Ok(target), Ok(target), Ok(original), Ok(original)],
+			vec![Ok(()), Ok(())],
+			vec![Ok(()), Err("restore event")],
+		);
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Ok(false));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::ConfirmedAfterEventFailure);
+	}
+
+	#[test]
+	fn harmless_move_retries_restore_at_most_twice_then_fails_closed() {
+		let original = point(5.0, 5.0);
+		let target = point(6.0, 5.0);
+		let mut backend = fake(
+			vec![Ok(original), Ok(target), Ok(target), Ok(target), Ok(target)],
+			vec![Ok(()), Err("restore"), Err("restore")],
+			vec![Ok(())],
+		);
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Ok(false));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Unconfirmed);
+		assert_eq!(backend.warp_targets, vec![target, original, original]);
+	}
+
+	#[test]
+	fn harmless_move_recovers_when_first_restore_warp_fails() {
+		let original = point(5.0, 5.0);
+		let target = point(6.0, 5.0);
+		let mut backend = fake(
+			vec![
+				Ok(original),
+				Ok(target),
+				Ok(target),
+				Ok(target),
+				Ok(target),
+				Ok(original),
+				Ok(original),
+			],
+			vec![Ok(()), Err("restore"), Ok(())],
+			vec![Ok(()), Ok(())],
+		);
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Ok(true));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Confirmed);
+		assert_eq!(backend.warp_targets, vec![target, original, original]);
+	}
+
+	#[test]
+	fn harmless_move_fails_initial_read_and_target_warp_without_cleanup() {
+		let mut read_error = fake(vec![Err("initial")], vec![], vec![]);
+		assert_eq!(verify_harmless_move_restore(&mut read_error).primary, Err("initial"));
+		let mut warp_error = fake(vec![Ok(point(5.0, 5.0))], vec![Err("warp")], vec![]);
+		assert_eq!(verify_harmless_move_restore(&mut warp_error).primary, Err("warp"));
+	}
+
+	#[test]
+	fn harmless_move_rejects_interference_and_exact_tolerance_boundaries_on_both_axes() {
+		let original = point(5.0, 5.0);
+		let target = point(6.0, 5.0);
+		assert!(super::is_near(point(5.49, 5.49), original));
+		assert!(super::is_near(point(5.48, 5.48), original));
+		assert!(!super::is_near(point(5.491, 5.0), original));
+		assert!(!super::is_near(point(5.0, 5.491), original));
+		for interference in [point(5.5, 5.0), point(50.0, 50.0)] {
+			let mut backend = fake(vec![Ok(original), Ok(interference)], vec![Ok(())], vec![Ok(())]);
+			let result = verify_harmless_move_restore(&mut backend);
+			assert_eq!(result.primary, Ok(false));
+			assert_eq!(result.cleanup, super::CleanupConfirmation::Unconfirmed);
+			assert_eq!(backend.warp_targets, vec![target]);
+		}
+	}
+
+	#[test]
+	fn harmless_move_does_not_restore_after_interference_before_first_restore_warp() {
+		let original = point(5.0, 5.0);
+		let target = point(6.0, 5.0);
+		let mut backend = fake(
+			vec![Ok(original), Ok(target), Ok(target), Ok(point(50.0, 50.0))],
+			vec![Ok(()), Ok(())],
+			vec![Ok(())],
+		);
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Ok(false));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Unconfirmed);
+		assert_eq!(backend.warp_targets, vec![target]);
+	}
+
+	#[test]
+	fn harmless_move_does_not_retry_restore_after_interference() {
+		let original = point(5.0, 5.0);
+		let target = point(6.0, 5.0);
+		let mut backend = fake(
+			vec![Ok(original), Ok(target), Ok(target), Ok(target), Ok(point(50.0, 50.0))],
+			vec![Ok(()), Err("restore")],
+			vec![Ok(())],
+		);
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Ok(false));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Unconfirmed);
+		assert_eq!(backend.warp_targets, vec![target, original]);
+	}
+
+	#[test]
+	fn harmless_move_rejects_read_error_and_deadline_before_restoration() {
+		let original = point(5.0, 5.0);
+		let target = point(6.0, 5.0);
+		let mut read_error = fake(
+			vec![Ok(original), Ok(target), Ok(target), Err("restore read")],
+			vec![Ok(()), Ok(())],
+			vec![Ok(())],
+		);
+		let result = verify_harmless_move_restore(&mut read_error);
+		assert_eq!(result.primary, Ok(false));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Unconfirmed);
+		assert_eq!(read_error.warp_targets, vec![target]);
+
+		let mut deadline =
+			fake(vec![Ok(original), Ok(target), Ok(target), Ok(target)], vec![Ok(()), Ok(())], vec![
+				Ok(()),
+			]);
+		deadline.read_clock_advances = vec![0, 0, 98, 1];
+		let result = verify_harmless_move_restore(&mut deadline);
+		assert_eq!(result.primary, Ok(false));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Unconfirmed);
+		assert_eq!(deadline.warp_targets, vec![target]);
+	}
+
+	#[test]
+	fn harmless_move_rejects_observation_read_that_crosses_deadline() {
+		let original = point(5.0, 5.0);
+		let target = point(6.0, 5.0);
+		let mut backend =
+			fake(vec![Ok(original), Ok(target), Ok(target)], vec![Ok(())], vec![Ok(())]);
+		backend.read_clock_advances = vec![0, 0, super::PROBE_DEADLINE_MS];
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Ok(false));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::Unconfirmed);
+		assert_eq!(backend.warp_targets, vec![target]);
+	}
+
+	#[test]
+	fn cursor_bounds_selects_every_cardinal_target_and_rejects_invalid_candidates() {
+		assert_eq!(bounds().move_target(point(5.0, 5.0)), Some(point(6.0, 5.0)),);
+		assert_eq!(
+			CursorBounds { min_x: 4.0, max_x: 6.0, min_y: 0.0, max_y: 10.0 }
+				.move_target(point(5.0, 5.0)),
+			Some(point(4.0, 5.0)),
+		);
+		assert_eq!(
+			CursorBounds { min_x: 5.0, max_x: 6.0, min_y: 0.0, max_y: 10.0 }
+				.move_target(point(5.0, 5.0)),
+			Some(point(5.0, 6.0)),
+		);
+		assert_eq!(
+			CursorBounds { min_x: 5.0, max_x: 6.0, min_y: 5.0, max_y: 7.0 }
+				.move_target(point(5.0, 6.0)),
+			Some(point(5.0, 5.0)),
+		);
+		for invalid in [
+			CursorBounds { min_x: 0.0, max_x: 1.0, min_y: 0.0, max_y: 1.0 },
+			CursorBounds { min_x: f64::NAN, max_x: 10.0, min_y: 0.0, max_y: 10.0 },
+			CursorBounds { min_x: 0.0, max_x: f64::INFINITY, min_y: 0.0, max_y: 10.0 },
+			CursorBounds { min_x: 0.0, max_x: 0.0, min_y: 0.0, max_y: 10.0 },
+			CursorBounds { min_x: 0.0, max_x: 10.0, min_y: 1.0, max_y: 1.0 },
+		] {
+			assert_eq!(invalid.move_target(point(5.0, 5.0)), None);
+		}
+		assert_eq!(bounds().move_target(point(10.0, 5.0)), None);
+	}
+
+	#[test]
+	fn harmless_move_returns_bounds_lookup_error_without_warping() {
+		let mut backend = fake(vec![Ok(point(5.0, 5.0))], vec![], vec![]);
+		backend.bounds = None;
+		let result = verify_harmless_move_restore(&mut backend);
+		assert_eq!(result.primary, Err("no display"));
+		assert_eq!(result.cleanup, super::CleanupConfirmation::NotRequired);
+		assert!(backend.warp_targets.is_empty());
 	}
 
 	#[test]
@@ -696,7 +1444,7 @@ mod live_tests {
 		let expected = display
 			.to_logical_point(target_px, target_py)
 			.expect("center is in bounds");
-		let pos = current_cursor_position();
+		let pos = current_cursor_position().expect("cursor position should be readable");
 		let dx = (pos.x - expected.x).abs();
 		let dy = (pos.y - expected.y).abs();
 		assert!(

--- a/crates/pi-natives/src/computer/mod.rs
+++ b/crates/pi-natives/src/computer/mod.rs
@@ -7,12 +7,9 @@
 //! `wait`).
 //!
 //! # Status
-//! Slice 1 foundation. Only the framework-free coordinate contract
-//! ([`coords`]) ships so far; it is unit-testable without a display or granted
-//! TCC permissions. The native capture/input backend, the kill-switch
-//! supervisor + event-tap lifecycle, and the napi `ComputerController` surface
-//! land in later slices. See `docs/computer-use/` for the approved spec, the
-//! consensus plan, and the architecture decision record.
+//! Native capture, input, supervision, and the napi `ComputerController` exist.
+//! The only input exposed for Gate-0 is a hidden, bounded harmless probe; the
+//! production broker and public computer-use surface remain out of scope.
 //!
 //! # Architecture
 //! ```text
@@ -73,6 +70,27 @@ pub struct ComputerScreenshot {
 	pub display_epoch: f64,
 	/// Process-local opaque capture id.
 	pub capture_id:    u32,
+}
+
+/// Redacted Gate-0 TCC status. This contains grant state only.
+#[napi(object)]
+pub struct Gate0PermissionStatus {
+	/// Whether Accessibility input injection is granted.
+	pub accessibility:    bool,
+	/// Whether Screen Recording capture is granted.
+	pub screen_recording: bool,
+}
+
+/// Redacted Gate-0 harmless-probe outcome. No desktop data or coordinates are
+/// returned.
+#[napi(object)]
+pub struct Gate0HarmlessProbeResult {
+	/// Whether a screenshot could be captured and immediately discarded.
+	pub screenshot:           bool,
+	/// Whether Accessibility was granted when the probe ran.
+	pub accessibility:        bool,
+	/// Whether the cursor moved one logical pixel and was restored.
+	pub pointer_move_restore: bool,
 }
 
 /// Capture the primary display for JS callers (macOS).

--- a/crates/pi-natives/src/computer/permissions.rs
+++ b/crates/pi-natives/src/computer/permissions.rs
@@ -4,8 +4,9 @@
 //! Two distinct TCC permissions gate the computer tool:
 //! - **Screen Recording** — required for `screenshot` capture (see
 //!   [`super::capture`]).
-//! - **Accessibility** — required for input injection (click/type/etc.). This
-//!   is a *separate* grant from Screen Recording.
+//! - **Accessibility** and **PostEvent** — together required by Gate-0 to
+//!   establish synthetic input authority; this is separate from Screen
+//!   Recording.
 //!
 //! This module performs non-prompting preflight checks and can open the correct
 //! System Settings pane so the user can grant a missing permission, then retry.
@@ -27,6 +28,12 @@ unsafe extern "C" {
 	/// Returns whether the current process already has Screen Recording access,
 	/// without prompting.
 	fn CGPreflightScreenCaptureAccess() -> bool;
+	/// Returns whether the current process can post synthetic input events,
+	/// without prompting. Available on macOS 10.15 and later.
+	fn CGPreflightPostEventAccess() -> bool;
+	/// Requests Screen Recording access for the current process. This may prompt
+	/// the user and must only be called by an explicit, hidden experiment.
+	fn CGRequestScreenCaptureAccess() -> bool;
 }
 
 /// A TCC permission the computer tool depends on.
@@ -95,12 +102,46 @@ pub fn accessibility_granted() -> bool {
 	unsafe { AXIsProcessTrusted() }
 }
 
+/// Whether the process can post synthetic input events (no prompt).
+#[must_use]
+pub fn post_event_granted() -> bool {
+	// SAFETY: `CGPreflightPostEventAccess` takes no arguments and only reads the
+	// current process's PostEvent TCC state.
+	unsafe { CGPreflightPostEventAccess() }
+}
+
+/// Whether both Accessibility and PostEvent authority are available for Gate-0
+/// synthetic input. This pure seam keeps the combined authority contract
+/// independently testable.
+#[must_use]
+pub const fn gate0_capabilities_granted(accessibility: bool, post_event: bool) -> bool {
+	accessibility && post_event
+}
+
+/// Whether the current process has both non-prompting TCC capabilities Gate-0
+/// needs to establish synthetic input authority.
+#[must_use]
+pub fn gate0_input_injection_granted() -> bool {
+	gate0_capabilities_granted(accessibility_granted(), post_event_granted())
+}
+
 /// Whether the process already has Screen Recording access (no prompt).
 #[must_use]
 pub fn screen_recording_granted() -> bool {
 	// SAFETY: `CGPreflightScreenCaptureAccess` takes no arguments and only reads
 	// the current process's capture-access state.
 	unsafe { CGPreflightScreenCaptureAccess() }
+}
+
+/// Explicitly request Screen Recording access for the current process.
+///
+/// This is the sole prompting TCC seam. Normal computer preflight and capture
+/// paths must use [`screen_recording_granted`] instead.
+#[must_use]
+pub fn request_screen_recording_access() -> bool {
+	// SAFETY: `CGRequestScreenCaptureAccess` takes no arguments and requests the
+	// current process's TCC grant.
+	unsafe { CGRequestScreenCaptureAccess() }
 }
 
 /// Read the current grant state for both required permissions.
@@ -154,7 +195,7 @@ pub fn require_screen_recording_for_capture() -> Result<(), PermissionError> {
 
 #[cfg(test)]
 mod tests {
-	use super::{TccPermission, preflight};
+	use super::{TccPermission, gate0_capabilities_granted, preflight};
 
 	#[test]
 	fn settings_urls_target_the_privacy_panes() {
@@ -168,6 +209,14 @@ mod tests {
 				.settings_url()
 				.contains("Privacy_ScreenCapture")
 		);
+	}
+
+	#[test]
+	fn gate0_requires_accessibility_and_post_event_authority() {
+		assert!(gate0_capabilities_granted(true, true));
+		assert!(!gate0_capabilities_granted(true, false));
+		assert!(!gate0_capabilities_granted(false, true));
+		assert!(!gate0_capabilities_granted(false, false));
 	}
 
 	/// Reports the live TCC grant state. Ignored by default (result depends on

--- a/crates/pi-natives/src/computer/permissions.rs
+++ b/crates/pi-natives/src/computer/permissions.rs
@@ -4,7 +4,7 @@
 //! Two distinct TCC permissions gate the computer tool:
 //! - **Screen Recording** — required for `screenshot` capture (see
 //!   [`super::capture`]).
-//! - **Accessibility** and **PostEvent** — together required by Gate-0 to
+//! - **Accessibility** and **`PostEvent`** — together required by Gate-0 to
 //!   establish synthetic input authority; this is separate from Screen
 //!   Recording.
 //!
@@ -110,8 +110,8 @@ pub fn post_event_granted() -> bool {
 	unsafe { CGPreflightPostEventAccess() }
 }
 
-/// Whether both Accessibility and PostEvent authority are available for Gate-0
-/// synthetic input. This pure seam keeps the combined authority contract
+/// Whether both Accessibility and `PostEvent` authority are available for
+/// Gate-0 synthetic input. This pure seam keeps the combined authority contract
 /// independently testable.
 #[must_use]
 pub const fn gate0_capabilities_granted(accessibility: bool, post_event: bool) -> bool {

--- a/packages/coding-agent/scripts/computer-broker-live-e2e.ts
+++ b/packages/coding-agent/scripts/computer-broker-live-e2e.ts
@@ -55,6 +55,13 @@ interface SignedReceipt {
 	signature: { algorithm: "ed25519"; keyId: string; value: string };
 }
 
+export interface HostProcessIdentity {
+	host: Host;
+	pid: number;
+	executableSha256: string;
+	startTokenSha256: string;
+}
+
 export interface RestartProof {
 	schemaVersion: 1;
 	kind: "screen-recording-restart-request";
@@ -63,6 +70,7 @@ export interface RestartProof {
 	cell: Gate0Receipt["cell"];
 	artifact: { identity: "packages/coding-agent/dist/gjc"; sourceRevision: string; sha256: string };
 	codesign: CodeSignSummary;
+	hostProcess: HostProcessIdentity;
 	requestedAt: string;
 	request: { attempted: true; code: "permission_pending" | "ok" };
 }
@@ -426,6 +434,101 @@ export async function runBoundedCommand(
 	);
 	return settled.promise;
 }
+
+const HOST_PROCESS_ANCESTRY_LIMIT = 32;
+const HOST_PROCESS_TIMEOUT_MS = 1_000;
+
+export interface HostProcessDependencies {
+	execute?: CommandRunner;
+	ppid?: number;
+}
+
+function hostExecutableMatches(host: Host, executable: string): boolean {
+	const normalized = executable.toLowerCase();
+	if (host === "terminal") return normalized === "terminal.app" || normalized.includes("/terminal.app/");
+	if (host === "ghostty")
+		return normalized === "ghostty" || normalized.endsWith("/ghostty") || normalized.includes("/ghostty.app/");
+	return normalized === "cmux" || normalized.endsWith("/cmux") || normalized.includes("/cmux.app/");
+}
+
+function psField(value: string, maximumLength: number): string | null {
+	const trimmed = value.trim();
+	return trimmed && trimmed.length <= maximumLength && !/[\r\n]/.test(trimmed) ? trimmed : null;
+}
+
+export async function captureHostProcess(
+	host: Host,
+	dependencies: HostProcessDependencies = {},
+): Promise<HostProcessIdentity> {
+	const execute = dependencies.execute ?? runBoundedCommand;
+	let pid = dependencies.ppid ?? process.ppid;
+	const visited = new Set<number>();
+	const deadline = Date.now() + HOST_PROCESS_TIMEOUT_MS;
+	for (let depth = 0; depth < HOST_PROCESS_ANCESTRY_LIMIT; depth++) {
+		if (!Number.isSafeInteger(pid) || pid <= 0 || visited.has(pid)) break;
+		visited.add(pid);
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) fail("terminal host process ancestry is unavailable");
+		const [ppidResult, executableResult, startResult] = await Promise.all([
+			execute(["/bin/ps", "-o", "ppid=", "-p", String(pid)], undefined, remaining),
+			execute(["/bin/ps", "-o", "comm=", "-p", String(pid)], undefined, remaining),
+			execute(["/bin/ps", "-o", "lstart=", "-p", String(pid)], undefined, remaining),
+		]);
+		const ppidText = !ppidResult.timedOut && ppidResult.exitCode === 0 ? psField(ppidResult.stdout, 16) : null;
+		const executable =
+			!executableResult.timedOut && executableResult.exitCode === 0 ? psField(executableResult.stdout, 1_024) : null;
+		const startToken = !startResult.timedOut && startResult.exitCode === 0 ? psField(startResult.stdout, 128) : null;
+		const ppid = ppidText && /^\d+$/.test(ppidText) ? Number(ppidText) : NaN;
+		if (!Number.isSafeInteger(ppid) || ppid < 0 || !executable || !startToken)
+			fail("terminal host process ancestry is unavailable");
+		const record = { ppid, executable, startToken };
+		if (hostExecutableMatches(host, record.executable)) {
+			return {
+				host,
+				pid,
+				executableSha256: createHash("sha256").update(record.executable).digest("hex"),
+				startTokenSha256: createHash("sha256").update(record.startToken).digest("hex"),
+			};
+		}
+		pid = record.ppid;
+	}
+	fail("declared terminal host is not a direct process ancestor");
+}
+
+function sameHostProcess(left: HostProcessIdentity, right: HostProcessIdentity): boolean {
+	return (
+		left.host === right.host &&
+		left.pid === right.pid &&
+		left.executableSha256 === right.executableSha256 &&
+		left.startTokenSha256 === right.startTokenSha256
+	);
+}
+
+export function requireStableHostProcess(
+	before: HostProcessIdentity,
+	after: HostProcessIdentity,
+	phase: "restart request" | "post-restart continuity",
+): void {
+	if (!sameHostProcess(before, after)) fail(`terminal host process changed during ${phase}`);
+}
+
+export function requireRestartedHostProcess(proof: HostProcessIdentity, current: HostProcessIdentity): void {
+	if (proof.host !== current.host || proof.executableSha256 !== current.executableSha256)
+		fail("restart proof does not match the current terminal host executable");
+	if (proof.pid === current.pid && proof.startTokenSha256 === current.startTokenSha256)
+		fail("restart proof does not prove a terminal host process restart");
+}
+
+export function requireRestartProofContinuity(proof: RestartProof, continuity: RunCellContinuityResult): void {
+	if (
+		continuity.sourceRevision !== proof.artifact.sourceRevision ||
+		continuity.baseline.sha256 !== proof.artifact.sha256 ||
+		!continuity.baselineCodesign.verified ||
+		continuity.baselineCodesign.signing !== proof.codesign.signing ||
+		continuity.baselineCodesign.verified !== proof.codesign.verified
+	)
+		fail("restart proof does not match the executed baseline continuity");
+}
 export async function codesignSummary(
 	artifact: string,
 	execute: CommandRunner = runBoundedCommand,
@@ -691,6 +794,7 @@ export function validRestartProof(value: unknown): value is RestartProof {
 			"codesign",
 			"collectionId",
 			"gate",
+			"hostProcess",
 			"kind",
 			"request",
 			"requestedAt",
@@ -698,7 +802,8 @@ export function validRestartProof(value: unknown): value is RestartProof {
 		])
 	)
 		return false;
-	const { artifact, cell, codesign, request } = value;
+	const { artifact, cell, codesign, hostProcess, request } = value;
+
 	return (
 		value.schemaVersion === 1 &&
 		value.kind === "screen-recording-restart-request" &&
@@ -719,6 +824,8 @@ export function validRestartProof(value: unknown): value is RestartProof {
 		typeof artifact.sha256 === "string" &&
 		/^[a-f0-9]{64}$/.test(artifact.sha256) &&
 		validCodeSign(codesign) &&
+		validHostProcess(hostProcess) &&
+		hostProcess.host === cell.host &&
 		typeof value.requestedAt === "string" &&
 		!Number.isNaN(Date.parse(value.requestedAt)) &&
 		isRecord(request) &&
@@ -845,6 +952,8 @@ async function requestCell(args: string[]): Promise<void> {
 			fail("release artifact must have a verified ad-hoc signature");
 		const existing = await loadRestartProof(root, collection, cell);
 		if (existing) fail("restart proof already exists for this cell");
+		const requestHost = await captureHostProcess(cell.host);
+
 		const result = experimentResult(await invokeExperiment(artifact.path, { operation: "probe", request: true }));
 		const requestCode = restartRequestCode(result);
 		const currentArtifact = await releaseArtifact(artifact.path);
@@ -859,6 +968,9 @@ async function requestCell(args: string[]): Promise<void> {
 			currentCodesign.verified !== codesign.verified
 		)
 			fail("artifact, source, or codesign state changed during restart request collection");
+		const postRequestHost = await captureHostProcess(cell.host);
+		requireStableHostProcess(requestHost, postRequestHost, "restart request");
+
 		const proof: RestartProof = {
 			schemaVersion: 1,
 			kind: "screen-recording-restart-request",
@@ -867,6 +979,8 @@ async function requestCell(args: string[]): Promise<void> {
 			cell,
 			artifact: { identity: "packages/coding-agent/dist/gjc", sourceRevision, sha256: artifact.sha256 },
 			codesign,
+			hostProcess: requestHost,
+
 			requestedAt: new Date().toISOString(),
 			request: { attempted: true, code: requestCode },
 		};
@@ -888,7 +1002,11 @@ async function runCell(args: string[]): Promise<void> {
 		const startedAt = new Date().toISOString(),
 			artifact = await releaseArtifact(requireFlag(args, "artifact"));
 		const proof = await loadRestartProof(root, collection, cell);
+		let restartHost: HostProcessIdentity | null = null;
 		if (proof) {
+			restartHost = await captureHostProcess(cell.host);
+			requireRestartedHostProcess(proof.hostProcess, restartHost);
+
 			const sourceRevision = await readSourceRevision();
 			const codesign = await codesignSummary(artifact.path);
 			if (
@@ -901,6 +1019,7 @@ async function runCell(args: string[]): Promise<void> {
 				fail("restart proof does not match the current artifact, source, or codesign state");
 		}
 		const continuity = await runCellContinuity(artifact, cell.topology, {}, !proof);
+		if (proof) requireRestartProofContinuity(proof, continuity);
 		if (!proof && !continuity.baselinePair.probe.requestAttempted)
 			fail("baseline did not exercise the explicit Screen Recording request");
 		const receipt: Gate0Receipt = {
@@ -926,6 +1045,10 @@ async function runCell(args: string[]): Promise<void> {
 			lifecycle: { markers: continuity.updatedPair.lifecycle.lifecycle },
 			result: { success: true, code: "ok" },
 		};
+		if (proof && restartHost) {
+			requireStableHostProcess(restartHost, await captureHostProcess(cell.host), "post-restart continuity");
+		}
+
 		await persistReceiptAndConsumeProof(root, receipt, proof);
 		process.stdout.write(`${canonicalJson({ gate: 0, cell, result: receipt.result } as JsonValue)}\n`);
 	} finally {
@@ -939,6 +1062,21 @@ function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): 
 	const actual = Object.keys(value).sort();
 	return actual.length === keys.length && actual.every((key, index) => key === keys[index]);
 }
+function validHostProcess(value: unknown): value is HostProcessIdentity {
+	return (
+		isRecord(value) &&
+		hasExactKeys(value, ["executableSha256", "host", "pid", "startTokenSha256"]) &&
+		HOST_VALUES.has(value.host as Host) &&
+		typeof value.pid === "number" &&
+		Number.isSafeInteger(value.pid) &&
+		value.pid > 0 &&
+		typeof value.executableSha256 === "string" &&
+		/^[a-f0-9]{64}$/.test(value.executableSha256) &&
+		typeof value.startTokenSha256 === "string" &&
+		/^[a-f0-9]{64}$/.test(value.startTokenSha256)
+	);
+}
+
 function validCodeSign(value: unknown): value is CodeSignSummary {
 	return (
 		isRecord(value) &&

--- a/packages/coding-agent/scripts/computer-broker-live-e2e.ts
+++ b/packages/coding-agent/scripts/computer-broker-live-e2e.ts
@@ -1,0 +1,906 @@
+import {
+	createHash,
+	createPrivateKey,
+	createPublicKey,
+	generateKeyPairSync,
+	randomBytes,
+	sign,
+	verify,
+} from "node:crypto";
+import type { Stats } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+	type Gate0AncestryKind,
+	type Gate0Code,
+	type Gate0LifecycleMarker,
+	type Gate0Result,
+	isGate0Result,
+} from "../src/gjc-runtime/computer-broker-gate0";
+
+type Topology = "A1" | "A2";
+type Macos = "14" | "15" | "26";
+type Host = "terminal" | "ghostty" | "cmux";
+type Signing = "adhoc" | "other" | "unavailable";
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+export interface Gate0Receipt {
+	schemaVersion: 1;
+	gate: 0;
+	collectionId: string;
+	cell: { topology: Topology; macos: Macos; host: Host; arch: "arm64" };
+	artifact: {
+		identity: "packages/coding-agent/dist/gjc";
+		sourceRevision: string;
+		baselineSha256: string;
+		updatedSha256: string;
+	};
+	codesign: {
+		baseline: { verified: boolean; signing: Signing };
+		updated: { verified: boolean; signing: Signing };
+		compatible: boolean;
+	};
+	continuity: { baselineSuccess: true; updatedSuccess: true };
+	timestamps: { startedAt: string; completedAt: string };
+	permissions: { screenRecordingGranted: boolean; accessibilityGranted: boolean; requestAttempted: boolean };
+	ancestry: { kind: Gate0AncestryKind; bounded: true };
+	lifecycle: { markers: Gate0LifecycleMarker[] };
+	result: { success: boolean; code: Gate0Code };
+}
+
+interface SignedReceipt {
+	receipt: Gate0Receipt;
+	signature: { algorithm: "ed25519"; keyId: string; value: string };
+}
+export interface ReleaseArtifact {
+	path: string;
+	sha256: string;
+}
+export interface CommandResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+	timedOut: boolean;
+}
+export type CommandRunner = (command: string[], cwd?: string, timeoutMs?: number) => Promise<CommandResult>;
+interface HiddenArtifactChild {
+	stdout: ReadableStream<Uint8Array>;
+	exited: Promise<number>;
+	kill(signal: "SIGTERM" | "SIGKILL"): void;
+}
+export type HiddenArtifactSpawner = (artifact: string, input: JsonValue) => HiddenArtifactChild;
+export type ExperimentResult = Gate0Result;
+export type Gate0ExperimentInvoker = (artifact: string, input: JsonValue) => Promise<ExperimentResult>;
+export interface CodeSignSummary {
+	verified: boolean;
+	signing: Signing;
+}
+export interface RunCellContinuityDependencies {
+	runPair?: typeof runCellExperimentPair;
+	build?: () => Promise<void>;
+	readArtifact?: (value: string) => Promise<ReleaseArtifact>;
+	codesign?: (artifact: string) => Promise<CodeSignSummary>;
+	sourceRevision?: () => Promise<string>;
+}
+export interface RunCellContinuityResult {
+	sourceRevision: string;
+	baseline: ReleaseArtifact;
+	updated: ReleaseArtifact;
+	baselineCodesign: CodeSignSummary;
+	updatedCodesign: CodeSignSummary;
+	baselinePair: { probe: ExperimentResult; lifecycle: ExperimentResult };
+	updatedPair: { probe: ExperimentResult; lifecycle: ExperimentResult };
+}
+
+const MACOS_VALUES = new Set<Macos>(["14", "15", "26"]);
+const HOST_VALUES = new Set<Host>(["terminal", "ghostty", "cmux"]);
+const TOPOLOGY_VALUES = new Set<Topology>(["A1", "A2"]);
+const RECEIPT_ROOT_ENV = "GJC_COMPUTER_GATE0_EVIDENCE_ROOT";
+const COLLECTION_ID_ENV = "GJC_COMPUTER_GATE0_COLLECTION_ID";
+const PRIVATE_KEY_NAME = "receipt-signing.key";
+const PUBLIC_KEY_NAME = "receipt-signing.pub.pem";
+const TRUSTED_SIGNERS_NAME = "trusted-signers";
+const EXPERIMENT_LOCK_NAME = "experiment.lock";
+const INVOCATION_TIMEOUT_MS = 15_000;
+const BUILD_TIMEOUT_MS = 15 * 60_000;
+const COLLECTION_WINDOW_MS = 30 * 24 * 60 * 60_000;
+const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
+
+export class Gate0RunnerError extends Error {
+	constructor(message: string) {
+		super(`gate0: ${message}`);
+		this.name = "Gate0RunnerError";
+	}
+}
+
+function fail(message: string): never {
+	throw new Gate0RunnerError(message);
+}
+function stringFlag(args: string[], name: string): string | null {
+	const matches = args.filter(arg => arg.startsWith(`--${name}=`));
+	return matches.length === 1 ? matches[0]!.slice(name.length + 3) : null;
+}
+function requireFlag(args: string[], name: string): string {
+	const value = stringFlag(args, name);
+	if (!value) fail(`--${name} is required exactly once`);
+	return value;
+}
+function collectionId(env: NodeJS.ProcessEnv = process.env): string {
+	const value = env[COLLECTION_ID_ENV];
+	if (!value || !/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/.test(value))
+		fail(`${COLLECTION_ID_ENV} must be a bounded UUID-like token`);
+	return value;
+}
+function parseCell(args: string[]): Gate0Receipt["cell"] {
+	if (requireFlag(args, "gate") !== "0") fail("only --gate=0 is supported");
+	const topology = requireFlag(args, "topology"),
+		macos = requireFlag(args, "macos"),
+		host = requireFlag(args, "host"),
+		arch = requireFlag(args, "arch");
+	if (!TOPOLOGY_VALUES.has(topology as Topology)) fail("--topology must be A1 or A2");
+	if (!MACOS_VALUES.has(macos as Macos)) fail("--macos must be 14, 15, or 26");
+	if (!HOST_VALUES.has(host as Host)) fail("--host must be terminal, ghostty, or cmux");
+	if (arch !== "arm64") fail("--arch must be arm64");
+	return { topology: topology as Topology, macos: macos as Macos, host: host as Host, arch: "arm64" };
+}
+function defaultEvidenceRoot(): string {
+	return path.join(os.homedir(), "Library", "Application Support", "gajae-code", "gate0-evidence-v2");
+}
+function evidenceRoot(env: NodeJS.ProcessEnv = process.env): string {
+	const configured = env[RECEIPT_ROOT_ENV];
+	return configured ? path.resolve(configured) : defaultEvidenceRoot();
+}
+function canonicalize(value: JsonValue): JsonValue {
+	return Array.isArray(value)
+		? value.map(canonicalize)
+		: value !== null && typeof value === "object"
+			? Object.fromEntries(
+					Object.entries(value)
+						.sort(([a], [b]) => a.localeCompare(b))
+						.map(([key, child]) => [key, canonicalize(child)]),
+				)
+			: value;
+}
+export function canonicalJson(value: JsonValue): string {
+	return JSON.stringify(canonicalize(value));
+}
+function receiptPayload(receipt: Gate0Receipt): Buffer {
+	return Buffer.from(canonicalJson(receipt as unknown as JsonValue));
+}
+function keyId(publicDer: Buffer): string {
+	return createHash("sha256").update(publicDer).digest("hex");
+}
+
+async function lstatSafe(target: string): Promise<Stats> {
+	try {
+		return await fs.lstat(target);
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT")
+			fail("required evidence path is missing");
+		throw error;
+	}
+}
+
+function ownedByCurrentUser(stats: Stats): boolean {
+	return typeof process.getuid !== "function" || stats.uid === process.getuid();
+}
+
+async function requireDirectPath(target: string): Promise<void> {
+	const [actual, parent] = await Promise.all([fs.realpath(target), fs.realpath(path.dirname(target))]);
+	if (actual !== path.join(parent, path.basename(target))) fail("evidence path traverses a symbolic link");
+}
+async function secureDirectory(target: string): Promise<void> {
+	const stats = await lstatSafe(target);
+	await requireDirectPath(target);
+	if (stats.isSymbolicLink() || !stats.isDirectory() || !ownedByCurrentUser(stats) || (stats.mode & 0o077) !== 0)
+		fail("evidence directory is unsafe");
+}
+async function secureFile(target: string, privateFile: boolean): Promise<void> {
+	const stats = await lstatSafe(target);
+	await requireDirectPath(target);
+	const unsafeMode = privateFile ? (stats.mode & 0o077) !== 0 : (stats.mode & 0o022) !== 0;
+	if (stats.isSymbolicLink() || !stats.isFile() || !ownedByCurrentUser(stats) || unsafeMode)
+		fail("evidence file is unsafe");
+}
+async function ensureEvidenceRoot(root: string): Promise<void> {
+	try {
+		await secureDirectory(root);
+	} catch (error) {
+		if (!(error instanceof Error) || error.message !== "gate0: required evidence path is missing") throw error;
+		await fs.mkdir(root, { recursive: true, mode: 0o700 });
+		await secureDirectory(root);
+	}
+	await fs.chmod(root, 0o700);
+	await secureDirectory(root);
+	for (const name of ["receipts", TRUSTED_SIGNERS_NAME]) {
+		const target = path.join(root, name);
+		await fs.mkdir(target, { recursive: true, mode: 0o700 });
+		await fs.chmod(target, 0o700);
+		await secureDirectory(target);
+	}
+}
+async function signer(root: string): Promise<{ privateKey: ReturnType<typeof createPrivateKey>; id: string }> {
+	const privatePath = path.join(root, PRIVATE_KEY_NAME),
+		publicPath = path.join(root, PUBLIC_KEY_NAME);
+	try {
+		const pair = generateKeyPairSync("ed25519");
+		const privatePem = pair.privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+		const publicPem = pair.publicKey.export({ type: "spki", format: "pem" }).toString();
+		const handle = await fs.open(privatePath, "wx", 0o600);
+		try {
+			await handle.writeFile(privatePem);
+		} finally {
+			await handle.close();
+		}
+		await fs.writeFile(publicPath, publicPem, { mode: 0o644, flag: "wx" });
+	} catch (error) {
+		if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") throw error;
+	}
+	await secureFile(privatePath, true);
+	await secureFile(publicPath, false);
+	let privateKey: ReturnType<typeof createPrivateKey>;
+	let publicKey: ReturnType<typeof createPublicKey>;
+	try {
+		privateKey = createPrivateKey(await fs.readFile(privatePath));
+		publicKey = createPublicKey(await fs.readFile(publicPath));
+	} catch {
+		fail("receipt signer PEM is malformed");
+	}
+	if (privateKey.asymmetricKeyType !== "ed25519" || publicKey.asymmetricKeyType !== "ed25519")
+		fail("receipt signer keys must be Ed25519");
+	const publicDer = publicKey.export({ type: "spki", format: "der" }) as Buffer;
+	const id = keyId(publicDer);
+	const derived = createPublicKey(privateKey.export({ type: "pkcs8", format: "pem" })).export({
+		type: "spki",
+		format: "der",
+	}) as Buffer;
+	if (!derived.equals(publicDer)) fail("receipt signer key pair does not match");
+	const trustedPath = path.join(root, TRUSTED_SIGNERS_NAME, `${id}.pem`);
+	try {
+		await fs.writeFile(trustedPath, await fs.readFile(publicPath), { mode: 0o644, flag: "wx" });
+	} catch (error) {
+		if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") throw error;
+	}
+	await secureFile(trustedPath, false);
+	return { privateKey, id };
+}
+
+export async function loadReceiptSigner(root: string): Promise<void> {
+	await signer(root);
+}
+async function sha256File(file: string): Promise<string> {
+	const hasher = new Bun.CryptoHasher("sha256"),
+		handle = await fs.open(file, "r");
+	try {
+		const buffer = Buffer.allocUnsafe(64 * 1024);
+		for (;;) {
+			const { bytesRead } = await handle.read(buffer, 0, buffer.byteLength, null);
+			if (!bytesRead) break;
+			hasher.update(buffer.subarray(0, bytesRead));
+		}
+	} finally {
+		await handle.close();
+	}
+	return hasher.digest("hex");
+}
+export interface ReleaseArtifactDependencies {
+	expectedPath?: string;
+	lstat?: (target: string) => Promise<Stats>;
+	hash?: (target: string) => Promise<string>;
+}
+
+export async function releaseArtifact(
+	value: string,
+	dependencies: ReleaseArtifactDependencies = {},
+): Promise<ReleaseArtifact> {
+	const artifact = path.resolve(value),
+		expected = path.resolve(dependencies.expectedPath ?? path.resolve(import.meta.dir, "../dist/gjc")),
+		lstat = dependencies.lstat ?? fs.lstat,
+		hash = dependencies.hash ?? sha256File;
+	if (artifact !== expected) fail("--artifact must be packages/coding-agent/dist/gjc");
+	let stats: Stats;
+	try {
+		stats = await lstat(artifact);
+	} catch {
+		fail("--artifact must be a non-symlink executable packaged release artifact");
+	}
+	if (stats.isSymbolicLink() || !stats.isFile() || (stats.mode & 0o111) === 0)
+		fail("--artifact must be a non-symlink executable packaged release artifact");
+	return { path: artifact, sha256: await hash(artifact) };
+}
+export function detectedHost(env: NodeJS.ProcessEnv = process.env): Host | null {
+	if (env.CMUX_BUNDLE_ID?.toLowerCase() === "com.cmuxterm.app" || env.CMUX_SHELL_INTEGRATION === "1") return "cmux";
+	const terminal = env.TERM_PROGRAM?.toLowerCase();
+	if (terminal === "apple_terminal" || terminal === "terminal") return "terminal";
+	if (terminal === "ghostty" || env.GHOSTTY_RESOURCES_DIR) return "ghostty";
+	return terminal === "cmux" ? "cmux" : null;
+}
+function hostMacosMajor(): string | null {
+	const result = Bun.spawnSync(["/usr/bin/sw_vers", "-productVersion"], { stdout: "pipe", stderr: "ignore" });
+	return result.exitCode === 0 ? (result.stdout.toString().trim().split(".")[0] ?? null) : null;
+}
+function validateEnvironment(cell: Gate0Receipt["cell"]): void {
+	if (process.platform !== "darwin") fail("host platform is not macOS");
+	if (process.arch !== "arm64") fail("host architecture is not arm64");
+	if (hostMacosMajor() !== cell.macos) fail("declared macOS version does not match the host");
+	if (detectedHost() !== cell.host) fail("declared terminal host does not match the process host");
+}
+function cleanupFailure(): Gate0RunnerError {
+	return new Gate0RunnerError("timed-out child cleanup failed");
+}
+
+async function killAndWait(
+	child: { kill(signal: "SIGTERM" | "SIGKILL"): void; exited: Promise<number> },
+	timeoutMs: number,
+): Promise<boolean> {
+	const deadline = Date.now() + Math.max(timeoutMs, 1);
+	const exited = child.exited.then(
+		() => true,
+		() => false,
+	);
+	const waitForExit = async (until: number): Promise<boolean> => {
+		const remaining = until - Date.now();
+		if (remaining <= 0) return false;
+		return Promise.race([exited, Bun.sleep(remaining).then(() => false)]);
+	};
+	if (await Promise.race([exited, Bun.sleep(0).then(() => false)])) return true;
+	try {
+		child.kill("SIGTERM");
+	} catch {}
+	if (await waitForExit(Math.min(deadline, Date.now() + Math.max(1, Math.floor((deadline - Date.now()) / 2)))))
+		return true;
+	try {
+		child.kill("SIGKILL");
+	} catch {}
+	return waitForExit(deadline);
+}
+
+export type BoundedCommandSpawner = (
+	command: string[],
+	options: { cwd?: string; stdout: "pipe"; stderr: "pipe" },
+) => {
+	stdout: ReadableStream<Uint8Array>;
+	stderr: ReadableStream<Uint8Array>;
+	exited: Promise<number>;
+	kill(signal: "SIGTERM" | "SIGKILL"): void;
+};
+
+export async function runBoundedCommand(
+	command: string[],
+	cwd?: string,
+	timeoutMs = INVOCATION_TIMEOUT_MS,
+	spawn: BoundedCommandSpawner = (argv, options) => Bun.spawn(argv, options),
+): Promise<CommandResult> {
+	const child = spawn(command, { cwd, stdout: "pipe", stderr: "pipe" });
+	const settled = Promise.withResolvers<CommandResult>();
+	let closing = false;
+	const limit = Math.max(timeoutMs, 1);
+	const cleanupMs = Math.min(250, Math.max(25, Math.floor(limit / 10)), Math.max(1, limit - 1));
+	const deadline = Date.now() + limit;
+	let timer: ReturnType<typeof setTimeout>;
+	const finishFailure = async (timedOut: boolean): Promise<void> => {
+		if (closing) return;
+		closing = true;
+		clearTimeout(timer);
+		if (!(await killAndWait(child, Math.max(1, deadline - Date.now())))) {
+			settled.reject(cleanupFailure());
+			return;
+		}
+		settled.resolve({ exitCode: -1, stdout: "", stderr: "", timedOut });
+	};
+	timer = setTimeout(() => void finishFailure(true), Math.max(1, limit - cleanupMs));
+	void Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]).then(
+		([stdout, stderr, exitCode]) => {
+			if (closing) return;
+			closing = true;
+			clearTimeout(timer);
+			settled.resolve({ exitCode, stdout, stderr, timedOut: false });
+		},
+		() => void finishFailure(false),
+	);
+	return settled.promise;
+}
+export async function codesignSummary(
+	artifact: string,
+	execute: CommandRunner = runBoundedCommand,
+): Promise<CodeSignSummary> {
+	const verification = await execute(["codesign", "--verify", "--strict", "--verbose=2", artifact]);
+	if (verification.timedOut || verification.exitCode !== 0) return { verified: false, signing: "unavailable" };
+	const display = await execute(["codesign", "--display", "--verbose=2", artifact]);
+	if (display.timedOut || display.exitCode !== 0) return { verified: false, signing: "unavailable" };
+	const signing = /signature=adhoc/i.test(`${display.stdout}\n${display.stderr}`) ? "adhoc" : "other";
+	return { verified: true, signing };
+}
+async function buildReleaseArtifact(execute: CommandRunner = runBoundedCommand): Promise<void> {
+	const result = await execute(["bun", "--cwd=packages/coding-agent", "run", "build"], REPO_ROOT, BUILD_TIMEOUT_MS);
+	if (result.timedOut) fail("release artifact build timed out");
+	if (result.exitCode !== 0) fail("release artifact build failed");
+}
+async function readHeadRevision(execute: CommandRunner = runBoundedCommand): Promise<string> {
+	const result = await execute(["git", "rev-parse", "HEAD"], REPO_ROOT);
+	const revision = result.stdout.trim();
+	if (result.timedOut || result.exitCode !== 0 || !/^[a-f0-9]{40,64}$/.test(revision))
+		fail("source revision is unavailable");
+	return revision;
+}
+
+export async function readSourceRevision(execute: CommandRunner = runBoundedCommand): Promise<string> {
+	const status = await execute(["git", "status", "--porcelain", "--untracked-files=all"], REPO_ROOT);
+	if (
+		status.timedOut ||
+		status.exitCode !== 0 ||
+		status.stdout.split("\n").some(line => line !== "" && !line.startsWith("?? .gjc/"))
+	)
+		fail("source changes must be committed before recording Gate-0 evidence");
+	return readHeadRevision(execute);
+}
+export function experimentResult(value: unknown): ExperimentResult {
+	if (!isGate0Result(value)) fail("hidden experiment returned an invalid Gate-0 result");
+	return value;
+}
+export async function runCellExperimentPair(
+	artifact: string,
+	topology: Topology,
+	invoke: Gate0ExperimentInvoker = invokeExperiment,
+	request = true,
+): Promise<{ probe: ExperimentResult; lifecycle: ExperimentResult }> {
+	const probe = experimentResult(await invoke(artifact, { operation: "probe", request }));
+	const lifecycle = experimentResult(await invoke(artifact, { operation: "lifecycle", phase: topology }));
+	if (
+		probe.phase !== "probe" ||
+		probe.ancestry.kind !== "outer_owner" ||
+		(!request && probe.requestAttempted) ||
+		lifecycle.phase !== topology ||
+		lifecycle.requestAttempted ||
+		lifecycle.ancestry.kind !== (topology === "A1" ? "persistent_child" : "outer_owner") ||
+		lifecycle.lifecycle.join(",") !== "preflight,tmux_created,attached,detached,reattached,cleaned"
+	)
+		fail("hidden experiment result does not match the run-cell contract");
+	return { probe, lifecycle };
+}
+function timeoutResult(input: JsonValue): ExperimentResult {
+	const record = input as { operation?: unknown; phase?: unknown },
+		phase =
+			record.operation === "lifecycle" && (record.phase === "A1" || record.phase === "A2") ? record.phase : "probe";
+	return {
+		topology: "gate0",
+		phase,
+		permission: { accessibility: false, screenRecording: false },
+		requestAttempted: false,
+		success: false,
+		code: "timeout",
+		ancestry: { kind: phase === "A1" ? "persistent_child" : "outer_owner", bounded: true },
+		lifecycle: [],
+	};
+}
+function spawnHiddenArtifact(artifact: string, input: JsonValue): HiddenArtifactChild {
+	return Bun.spawn([artifact, "--internal-computer-gate0"], {
+		env: { ...process.env, GJC_COMPUTER_GATE0_INPUT: canonicalJson(input) },
+		stdout: "pipe",
+		stderr: "ignore",
+	});
+}
+export async function invokeExperiment(
+	artifact: string,
+	input: JsonValue,
+	spawn: HiddenArtifactSpawner = spawnHiddenArtifact,
+	timeoutMs = INVOCATION_TIMEOUT_MS,
+): Promise<ExperimentResult> {
+	const child = spawn(artifact, input);
+	const settled = Promise.withResolvers<{ stdout: string; exitCode: number } | null>();
+	let closing = false;
+	const limit = Math.min(Math.max(timeoutMs, 1), INVOCATION_TIMEOUT_MS);
+	const cleanupMs = Math.min(250, Math.max(1, Math.floor(limit / 10)));
+	const deadline = Date.now() + limit;
+	let timer: ReturnType<typeof setTimeout>;
+	const finishFailure = async (timedOut: boolean): Promise<void> => {
+		if (closing) return;
+		closing = true;
+		clearTimeout(timer);
+		if (!(await killAndWait(child, Math.max(1, deadline - Date.now())))) {
+			settled.reject(cleanupFailure());
+			return;
+		}
+		settled.resolve(timedOut ? null : { stdout: "", exitCode: -1 });
+	};
+	timer = setTimeout(() => void finishFailure(true), Math.max(1, limit - cleanupMs));
+	void Promise.all([new Response(child.stdout).text(), child.exited]).then(
+		([stdout, exitCode]) => {
+			if (closing) return;
+			closing = true;
+			clearTimeout(timer);
+			settled.resolve({ stdout, exitCode });
+		},
+		() => void finishFailure(false),
+	);
+	const outcome = await settled.promise;
+	if (!outcome) return timeoutResult(input);
+	if (outcome.exitCode !== 0) fail("hidden experiment exited unsuccessfully");
+	const line = outcome.stdout.endsWith("\n") ? outcome.stdout.slice(0, -1) : outcome.stdout;
+	if (!line || line.includes("\n")) fail("hidden experiment must emit exactly one JSON result");
+	try {
+		return experimentResult(JSON.parse(line));
+	} catch (error) {
+		if (error instanceof Error && error.message.startsWith("gate0:")) throw error;
+		fail("hidden experiment result is not JSON");
+	}
+}
+function pairSucceeded(
+	pair: { probe: ExperimentResult; lifecycle: ExperimentResult },
+	allowPendingRequest = false,
+): boolean {
+	return (
+		pair.lifecycle.success &&
+		(pair.probe.success ||
+			(allowPendingRequest && pair.probe.requestAttempted && pair.probe.code === "permission_pending"))
+	);
+}
+export async function runCellContinuity(
+	artifact: ReleaseArtifact,
+	topology: Topology,
+	dependencies: RunCellContinuityDependencies = {},
+): Promise<RunCellContinuityResult> {
+	const runPair = dependencies.runPair ?? runCellExperimentPair,
+		build = dependencies.build ?? buildReleaseArtifact,
+		readArtifact = dependencies.readArtifact ?? releaseArtifact,
+		codesign = dependencies.codesign ?? codesignSummary,
+		source = dependencies.sourceRevision ?? readSourceRevision;
+	const sourceRevision = await source();
+	const baselineCodesign = await codesign(artifact.path);
+	if (!baselineCodesign.verified || baselineCodesign.signing !== "adhoc")
+		fail("baseline release artifact must have a verified ad-hoc signature");
+	const baselinePair = await runPair(artifact.path, topology, undefined, true);
+	if (!pairSucceeded(baselinePair, true)) fail("baseline hidden experiment failed");
+	await build();
+	const postBuildRevision = await source();
+	if (postBuildRevision !== sourceRevision) fail("source revision changed during rebuild");
+	const updated = await readArtifact(artifact.path);
+	if (updated.sha256 === artifact.sha256) fail("rebuilt release artifact did not change");
+	const updatedCodesign = await codesign(updated.path);
+	if (!updatedCodesign.verified || updatedCodesign.signing !== "adhoc")
+		fail("updated release artifact must have a verified ad-hoc signature");
+	const updatedPair = await runPair(updated.path, topology, undefined, false);
+	if (!pairSucceeded(updatedPair)) fail("updated hidden experiment failed");
+	return { sourceRevision, baseline: artifact, updated, baselineCodesign, updatedCodesign, baselinePair, updatedPair };
+}
+export async function acquireExperimentLock(root: string): Promise<() => Promise<void>> {
+	const lockPath = path.join(root, EXPERIMENT_LOCK_NAME);
+	const token = randomBytes(24).toString("hex");
+	const record = JSON.stringify({ pid: process.pid, createdAt: Date.now(), token });
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			const handle = await fs.open(lockPath, "wx", 0o600);
+			try {
+				await handle.writeFile(record);
+			} finally {
+				await handle.close();
+			}
+			return async () => {
+				try {
+					if ((await fs.readFile(lockPath, "utf8")) === record) await fs.unlink(lockPath);
+				} catch (error) {
+					if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") throw error;
+				}
+			};
+		} catch (error) {
+			if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") throw error;
+		}
+		await secureFile(lockPath, true);
+		let current: { pid?: unknown; createdAt?: unknown; token?: unknown };
+		let observed: string;
+		try {
+			observed = await fs.readFile(lockPath, "utf8");
+			current = JSON.parse(observed);
+		} catch {
+			fail("experiment lock is malformed");
+		}
+		if (
+			typeof current.pid !== "number" ||
+			!Number.isSafeInteger(current.pid) ||
+			current.pid <= 0 ||
+			typeof current.createdAt !== "number" ||
+			!Number.isSafeInteger(current.createdAt) ||
+			typeof current.token !== "string" ||
+			!/^[a-f0-9]{48}$/.test(current.token)
+		)
+			fail("experiment lock is malformed");
+		if (Date.now() - current.createdAt < -60_000) fail("experiment lock is malformed");
+		let live = false;
+		try {
+			process.kill(current.pid, 0);
+			live = true;
+		} catch (ownerError) {
+			if (
+				!(ownerError instanceof Error) ||
+				!("code" in ownerError) ||
+				(ownerError.code !== "ESRCH" && ownerError.code !== "EPERM")
+			)
+				throw ownerError;
+			live = ownerError.code === "EPERM";
+		}
+		if (live) fail("a Gate-0 experiment is already running");
+		if ((await fs.readFile(lockPath, "utf8")) === observed) await fs.unlink(lockPath);
+	}
+	fail("a Gate-0 experiment is already running");
+}
+async function writeReceipt(root: string, receipt: Gate0Receipt): Promise<void> {
+	const local = await signer(root);
+	const signed: SignedReceipt = {
+		receipt,
+		signature: {
+			algorithm: "ed25519",
+			keyId: local.id,
+			value: sign(null, receiptPayload(receipt), local.privateKey).toString("base64"),
+		},
+	};
+	const file = `${receipt.cell.topology}-${receipt.cell.macos}-${receipt.cell.host}-${receipt.cell.arch}-${Date.now()}-${randomBytes(6).toString("hex")}.json`,
+		destination = path.join(root, "receipts", file),
+		temporary = `${destination}.tmp`;
+	await fs.writeFile(temporary, `${canonicalJson(signed as unknown as JsonValue)}\n`, { mode: 0o600, flag: "wx" });
+	await fs.rename(temporary, destination);
+}
+async function runCell(args: string[]): Promise<void> {
+	const cell = parseCell(args),
+		collection = collectionId();
+	validateEnvironment(cell);
+	const root = evidenceRoot();
+	await ensureEvidenceRoot(root);
+	const releaseLock = await acquireExperimentLock(root);
+	try {
+		const startedAt = new Date().toISOString(),
+			artifact = await releaseArtifact(requireFlag(args, "artifact")),
+			continuity = await runCellContinuity(artifact, cell.topology);
+		if (!continuity.baselinePair.probe.requestAttempted)
+			fail("baseline did not exercise the explicit Screen Recording request");
+		const receipt: Gate0Receipt = {
+			schemaVersion: 1,
+			gate: 0,
+			collectionId: collection,
+			cell,
+			artifact: {
+				identity: "packages/coding-agent/dist/gjc",
+				sourceRevision: continuity.sourceRevision,
+				baselineSha256: continuity.baseline.sha256,
+				updatedSha256: continuity.updated.sha256,
+			},
+			codesign: { baseline: continuity.baselineCodesign, updated: continuity.updatedCodesign, compatible: true },
+			continuity: { baselineSuccess: true, updatedSuccess: true },
+			timestamps: { startedAt, completedAt: new Date().toISOString() },
+			permissions: {
+				screenRecordingGranted: continuity.updatedPair.lifecycle.permission.screenRecording,
+				accessibilityGranted: continuity.updatedPair.lifecycle.permission.accessibility,
+				requestAttempted: continuity.baselinePair.probe.requestAttempted,
+			},
+			ancestry: continuity.updatedPair.lifecycle.ancestry,
+			lifecycle: { markers: continuity.updatedPair.lifecycle.lifecycle },
+			result: { success: true, code: "ok" },
+		};
+		await writeReceipt(root, receipt);
+		process.stdout.write(`${canonicalJson({ gate: 0, cell, result: receipt.result } as JsonValue)}\n`);
+	} finally {
+		await releaseLock();
+	}
+}
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+	const actual = Object.keys(value).sort();
+	return actual.length === keys.length && actual.every((key, index) => key === keys[index]);
+}
+function validCodeSign(value: unknown): value is CodeSignSummary {
+	return (
+		isRecord(value) &&
+		hasExactKeys(value, ["signing", "verified"]) &&
+		value.verified === true &&
+		value.signing === "adhoc"
+	);
+}
+function validReceipt(value: unknown): value is Gate0Receipt {
+	if (
+		!isRecord(value) ||
+		!hasExactKeys(value, [
+			"ancestry",
+			"artifact",
+			"cell",
+			"codesign",
+			"collectionId",
+			"continuity",
+			"gate",
+			"lifecycle",
+			"permissions",
+			"result",
+			"schemaVersion",
+			"timestamps",
+		])
+	)
+		return false;
+	const { cell, artifact, codesign, continuity, timestamps, permissions, ancestry, lifecycle, result } = value;
+	return (
+		value.schemaVersion === 1 &&
+		value.gate === 0 &&
+		typeof value.collectionId === "string" &&
+		/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/.test(value.collectionId) &&
+		isRecord(cell) &&
+		hasExactKeys(cell, ["arch", "host", "macos", "topology"]) &&
+		TOPOLOGY_VALUES.has(cell.topology as Topology) &&
+		MACOS_VALUES.has(cell.macos as Macos) &&
+		HOST_VALUES.has(cell.host as Host) &&
+		cell.arch === "arm64" &&
+		isRecord(artifact) &&
+		hasExactKeys(artifact, ["baselineSha256", "identity", "sourceRevision", "updatedSha256"]) &&
+		artifact.identity === "packages/coding-agent/dist/gjc" &&
+		typeof artifact.sourceRevision === "string" &&
+		/^[a-f0-9]{40,64}$/.test(artifact.sourceRevision) &&
+		typeof artifact.baselineSha256 === "string" &&
+		/^[a-f0-9]{64}$/.test(artifact.baselineSha256) &&
+		typeof artifact.updatedSha256 === "string" &&
+		/^[a-f0-9]{64}$/.test(artifact.updatedSha256) &&
+		artifact.baselineSha256 !== artifact.updatedSha256 &&
+		isRecord(codesign) &&
+		hasExactKeys(codesign, ["baseline", "compatible", "updated"]) &&
+		validCodeSign(codesign.baseline) &&
+		validCodeSign(codesign.updated) &&
+		codesign.compatible === true &&
+		isRecord(continuity) &&
+		hasExactKeys(continuity, ["baselineSuccess", "updatedSuccess"]) &&
+		continuity.baselineSuccess === true &&
+		continuity.updatedSuccess === true &&
+		isRecord(timestamps) &&
+		hasExactKeys(timestamps, ["completedAt", "startedAt"]) &&
+		typeof timestamps.startedAt === "string" &&
+		typeof timestamps.completedAt === "string" &&
+		!Number.isNaN(Date.parse(timestamps.startedAt)) &&
+		!Number.isNaN(Date.parse(timestamps.completedAt)) &&
+		isRecord(permissions) &&
+		hasExactKeys(permissions, ["accessibilityGranted", "requestAttempted", "screenRecordingGranted"]) &&
+		permissions.screenRecordingGranted === true &&
+		permissions.accessibilityGranted === true &&
+		permissions.requestAttempted === true &&
+		isRecord(ancestry) &&
+		hasExactKeys(ancestry, ["bounded", "kind"]) &&
+		((cell.topology === "A1" && ancestry.kind === "persistent_child") ||
+			(cell.topology === "A2" && ancestry.kind === "outer_owner")) &&
+		ancestry.bounded === true &&
+		isRecord(lifecycle) &&
+		hasExactKeys(lifecycle, ["markers"]) &&
+		Array.isArray(lifecycle.markers) &&
+		lifecycle.markers.join(",") === "preflight,tmux_created,attached,detached,reattached,cleaned" &&
+		isRecord(result) &&
+		hasExactKeys(result, ["code", "success"]) &&
+		result.success === true &&
+		result.code === "ok"
+	);
+}
+async function trustedPublicKey(root: string, id: unknown): Promise<ReturnType<typeof createPublicKey>> {
+	if (typeof id !== "string" || !/^[a-f0-9]{64}$/.test(id)) fail("receipt signer is invalid");
+	const trust = path.join(root, TRUSTED_SIGNERS_NAME, `${id}.pem`);
+	await secureFile(trust, false);
+	let publicKey: ReturnType<typeof createPublicKey>;
+	try {
+		publicKey = createPublicKey(await fs.readFile(trust));
+	} catch {
+		fail("trusted signer PEM is malformed");
+	}
+	if (publicKey.asymmetricKeyType !== "ed25519") fail("trusted signer key must be Ed25519");
+	const derived = keyId(publicKey.export({ type: "spki", format: "der" }) as Buffer);
+	if (derived !== id) fail("trusted signer key id does not match PEM");
+	return publicKey;
+}
+function canonicalEd25519Signature(value: string): Buffer {
+	if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==)$/.test(value)) fail("receipt signature is invalid");
+	const signature = Buffer.from(value, "base64");
+	if (signature.byteLength !== 64 || signature.toString("base64") !== value) fail("receipt signature is invalid");
+	return signature;
+}
+
+async function loadReceipts(root: string): Promise<Gate0Receipt[]> {
+	await secureDirectory(path.join(root, "receipts"));
+	await secureDirectory(path.join(root, TRUSTED_SIGNERS_NAME));
+	const entries = await fs.readdir(path.join(root, "receipts"), { withFileTypes: true });
+	const receipts: Gate0Receipt[] = [];
+	for (const entry of entries) {
+		if (entry.isSymbolicLink()) fail("receipt path is unsafe");
+		if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+		const receiptPath = path.join(root, "receipts", entry.name);
+		await secureFile(receiptPath, true);
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(await fs.readFile(receiptPath, "utf8"));
+		} catch {
+			fail("receipt is unreadable");
+		}
+		if (
+			!isRecord(parsed) ||
+			!hasExactKeys(parsed, ["receipt", "signature"]) ||
+			!validReceipt(parsed.receipt) ||
+			!isRecord(parsed.signature) ||
+			!hasExactKeys(parsed.signature, ["algorithm", "keyId", "value"]) ||
+			parsed.signature.algorithm !== "ed25519" ||
+			typeof parsed.signature.value !== "string"
+		)
+			fail("receipt is malformed");
+		const publicKey = await trustedPublicKey(root, parsed.signature.keyId);
+		const signature = canonicalEd25519Signature(parsed.signature.value);
+		if (!verify(null, receiptPayload(parsed.receipt), publicKey, signature)) fail("receipt signature is invalid");
+		receipts.push(parsed.receipt);
+	}
+	return receipts;
+}
+function requiredMatrix(topology: Topology, macos: Macos[], hosts: Host[]): Set<string> {
+	if (macos.length !== 3 || new Set(macos).size !== 3 || !macos.every(item => MACOS_VALUES.has(item)))
+		fail("--macos must declare 14,15,26 exactly");
+	if (hosts.length !== 3 || new Set(hosts).size !== 3 || !hosts.every(item => HOST_VALUES.has(item)))
+		fail("--hosts must declare terminal,ghostty,cmux exactly");
+	return new Set(macos.flatMap(version => hosts.map(host => `${topology}/${version}/${host}/arm64`)));
+}
+export interface AggregateDependencies {
+	sourceRevision?: () => Promise<string>;
+	execute?: CommandRunner;
+	loadReceipts?: (root: string) => Promise<Gate0Receipt[]>;
+	now?: () => number;
+}
+
+export async function aggregate(args: string[], dependencies: AggregateDependencies = {}): Promise<void> {
+	if (requireFlag(args, "gate") !== "0") fail("only --gate=0 is supported");
+	if (!args.includes("--require-all")) fail("--require-all is required");
+	const topologyValue = requireFlag(args, "topology");
+	if (!TOPOLOGY_VALUES.has(topologyValue as Topology)) fail("--topology must be A1 or A2");
+	const topology = topologyValue as Topology;
+	const required = requiredMatrix(
+		topology,
+		requireFlag(args, "macos").split(",") as Macos[],
+		requireFlag(args, "hosts").split(",") as Host[],
+	);
+	const expectedCollection = collectionId();
+	const root = evidenceRoot(),
+		source = dependencies.sourceRevision ?? (() => readSourceRevision(dependencies.execute)),
+		readReceipts = dependencies.loadReceipts ?? loadReceipts,
+		now = dependencies.now ?? Date.now;
+	await ensureEvidenceRoot(root);
+	const currentRevision = await source();
+	const receipts = await readReceipts(root);
+	const currentTime = now();
+	const matching = receipts.filter(receipt => receipt.cell.topology === topology);
+	for (const receipt of matching) {
+		const started = Date.parse(receipt.timestamps.startedAt);
+		const completed = Date.parse(receipt.timestamps.completedAt);
+		if (receipt.collectionId !== expectedCollection) fail("receipt collection ID does not match");
+		if (receipt.artifact.sourceRevision !== currentRevision)
+			fail("receipt source revision does not match current HEAD");
+		if (
+			started > completed ||
+			currentTime - started > COLLECTION_WINDOW_MS ||
+			started > currentTime + 60_000 ||
+			completed > currentTime + 60_000
+		)
+			fail("receipt timestamp is outside the collection window");
+	}
+	const identities = new Set<string>();
+	for (const receipt of matching) {
+		const identity = `${receipt.cell.topology}/${receipt.cell.macos}/${receipt.cell.host}/${receipt.cell.arch}`;
+		if (!required.has(identity)) fail("receipt cell does not belong to the declared matrix");
+		if (identities.has(identity)) fail("duplicate receipt cell");
+		identities.add(identity);
+	}
+	if (identities.size !== required.size || [...required].some(identity => !identities.has(identity)))
+		fail("required receipt cell is missing");
+	if ((await source()) !== currentRevision) fail("source revision changed during aggregation");
+	process.stdout.write(
+		`${canonicalJson({ gate: 0, topology, cells: identities.size, result: "passed" } as JsonValue)}\n`,
+	);
+}
+async function main(argv: string[]): Promise<void> {
+	const [command, ...args] = argv;
+	if (command === "run-cell") return runCell(args);
+	if (command === "aggregate") return aggregate(args);
+	fail("expected run-cell or aggregate");
+}
+if (import.meta.main)
+	main(process.argv.slice(2)).catch(error => {
+		const message = error instanceof Gate0RunnerError ? error.message : "gate0: internal error";
+		process.stderr.write(`${message}\n`);
+		process.exitCode = 1;
+	});

--- a/packages/coding-agent/scripts/computer-broker-live-e2e.ts
+++ b/packages/coding-agent/scripts/computer-broker-live-e2e.ts
@@ -54,6 +54,23 @@ interface SignedReceipt {
 	receipt: Gate0Receipt;
 	signature: { algorithm: "ed25519"; keyId: string; value: string };
 }
+
+export interface RestartProof {
+	schemaVersion: 1;
+	kind: "screen-recording-restart-request";
+	gate: 0;
+	collectionId: string;
+	cell: Gate0Receipt["cell"];
+	artifact: { identity: "packages/coding-agent/dist/gjc"; sourceRevision: string; sha256: string };
+	codesign: CodeSignSummary;
+	requestedAt: string;
+	request: { attempted: true; code: "permission_pending" | "ok" };
+}
+
+interface SignedRestartProof {
+	proof: RestartProof;
+	signature: { algorithm: "ed25519"; keyId: string; value: string };
+}
 export interface ReleaseArtifact {
 	path: string;
 	sha256: string;
@@ -106,6 +123,8 @@ const EXPERIMENT_LOCK_NAME = "experiment.lock";
 const INVOCATION_TIMEOUT_MS = 15_000;
 const BUILD_TIMEOUT_MS = 15 * 60_000;
 const COLLECTION_WINDOW_MS = 30 * 24 * 60 * 60_000;
+const RESTART_PROOFS_NAME = "request-proofs";
+
 const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
 
 export class Gate0RunnerError extends Error {
@@ -169,6 +188,11 @@ export function canonicalJson(value: JsonValue): string {
 function receiptPayload(receipt: Gate0Receipt): Buffer {
 	return Buffer.from(canonicalJson(receipt as unknown as JsonValue));
 }
+
+export function restartProofPayload(proof: RestartProof): Buffer {
+	return Buffer.from(canonicalJson(proof as unknown as JsonValue));
+}
+
 function keyId(publicDer: Buffer): string {
 	return createHash("sha256").update(publicDer).digest("hex");
 }
@@ -214,7 +238,7 @@ async function ensureEvidenceRoot(root: string): Promise<void> {
 	}
 	await fs.chmod(root, 0o700);
 	await secureDirectory(root);
-	for (const name of ["receipts", TRUSTED_SIGNERS_NAME]) {
+	for (const name of ["receipts", RESTART_PROOFS_NAME, TRUSTED_SIGNERS_NAME]) {
 		const target = path.join(root, name);
 		await fs.mkdir(target, { recursive: true, mode: 0o700 });
 		await fs.chmod(target, 0o700);
@@ -541,6 +565,7 @@ export async function runCellContinuity(
 	artifact: ReleaseArtifact,
 	topology: Topology,
 	dependencies: RunCellContinuityDependencies = {},
+	baselineRequest = true,
 ): Promise<RunCellContinuityResult> {
 	const runPair = dependencies.runPair ?? runCellExperimentPair,
 		build = dependencies.build ?? buildReleaseArtifact,
@@ -551,8 +576,9 @@ export async function runCellContinuity(
 	const baselineCodesign = await codesign(artifact.path);
 	if (!baselineCodesign.verified || baselineCodesign.signing !== "adhoc")
 		fail("baseline release artifact must have a verified ad-hoc signature");
-	const baselinePair = await runPair(artifact.path, topology, undefined, true);
-	if (!pairSucceeded(baselinePair, true)) fail("baseline hidden experiment failed");
+	const baselinePair = await runPair(artifact.path, topology, undefined, baselineRequest);
+
+	if (!pairSucceeded(baselinePair, baselineRequest)) fail("baseline hidden experiment failed");
 	await build();
 	const postBuildRevision = await source();
 	if (postBuildRevision !== sourceRevision) fail("source revision changed during rebuild");
@@ -641,6 +667,216 @@ async function writeReceipt(root: string, receipt: Gate0Receipt): Promise<void> 
 	await fs.writeFile(temporary, `${canonicalJson(signed as unknown as JsonValue)}\n`, { mode: 0o600, flag: "wx" });
 	await fs.rename(temporary, destination);
 }
+export function restartProofFile(collection: string, cell: Gate0Receipt["cell"]): string {
+	const name = `${collection}-${cell.topology}-${cell.macos}-${cell.host}-${cell.arch}.json`;
+	if (name.length > 255 || !/^[A-Za-z0-9][A-Za-z0-9._-]+\.json$/.test(name)) fail("restart proof filename is unsafe");
+	return name;
+}
+
+function sameCell(left: Gate0Receipt["cell"], right: Gate0Receipt["cell"]): boolean {
+	return (
+		left.topology === right.topology &&
+		left.macos === right.macos &&
+		left.host === right.host &&
+		left.arch === right.arch
+	);
+}
+
+export function validRestartProof(value: unknown): value is RestartProof {
+	if (
+		!isRecord(value) ||
+		!hasExactKeys(value, [
+			"artifact",
+			"cell",
+			"codesign",
+			"collectionId",
+			"gate",
+			"kind",
+			"request",
+			"requestedAt",
+			"schemaVersion",
+		])
+	)
+		return false;
+	const { artifact, cell, codesign, request } = value;
+	return (
+		value.schemaVersion === 1 &&
+		value.kind === "screen-recording-restart-request" &&
+		value.gate === 0 &&
+		typeof value.collectionId === "string" &&
+		/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/.test(value.collectionId) &&
+		isRecord(cell) &&
+		hasExactKeys(cell, ["arch", "host", "macos", "topology"]) &&
+		TOPOLOGY_VALUES.has(cell.topology as Topology) &&
+		MACOS_VALUES.has(cell.macos as Macos) &&
+		HOST_VALUES.has(cell.host as Host) &&
+		cell.arch === "arm64" &&
+		isRecord(artifact) &&
+		hasExactKeys(artifact, ["identity", "sha256", "sourceRevision"]) &&
+		artifact.identity === "packages/coding-agent/dist/gjc" &&
+		typeof artifact.sourceRevision === "string" &&
+		/^[a-f0-9]{40,64}$/.test(artifact.sourceRevision) &&
+		typeof artifact.sha256 === "string" &&
+		/^[a-f0-9]{64}$/.test(artifact.sha256) &&
+		validCodeSign(codesign) &&
+		typeof value.requestedAt === "string" &&
+		!Number.isNaN(Date.parse(value.requestedAt)) &&
+		isRecord(request) &&
+		hasExactKeys(request, ["attempted", "code"]) &&
+		request.attempted === true &&
+		(request.code === "permission_pending" || request.code === "ok")
+	);
+}
+
+export async function writeRestartProof(root: string, proof: RestartProof): Promise<void> {
+	const local = await signer(root);
+	const signed: SignedRestartProof = {
+		proof,
+		signature: {
+			algorithm: "ed25519",
+			keyId: local.id,
+			value: sign(null, restartProofPayload(proof), local.privateKey).toString("base64"),
+		},
+	};
+	const destination = path.join(root, RESTART_PROOFS_NAME, restartProofFile(proof.collectionId, proof.cell));
+	await fs.writeFile(destination, `${canonicalJson(signed as unknown as JsonValue)}\n`, { mode: 0o600, flag: "wx" });
+}
+
+async function validateRestartProofDirectory(root: string): Promise<void> {
+	const directory = path.join(root, RESTART_PROOFS_NAME);
+	await secureDirectory(directory);
+	for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+		if (entry.isSymbolicLink() || !entry.isFile()) fail("restart proof path is unsafe");
+		await secureFile(path.join(directory, entry.name), true);
+	}
+}
+
+export async function loadRestartProof(
+	root: string,
+	collection: string,
+	cell: Gate0Receipt["cell"],
+): Promise<RestartProof | null> {
+	const directory = path.join(root, RESTART_PROOFS_NAME);
+	await validateRestartProofDirectory(root);
+	const proofPath = path.join(directory, restartProofFile(collection, cell));
+	try {
+		await fs.lstat(proofPath);
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+		throw error;
+	}
+	await secureFile(proofPath, true);
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(await fs.readFile(proofPath, "utf8"));
+	} catch {
+		fail("restart proof is unreadable");
+	}
+	if (
+		!isRecord(parsed) ||
+		!hasExactKeys(parsed, ["proof", "signature"]) ||
+		!validRestartProof(parsed.proof) ||
+		!isRecord(parsed.signature) ||
+		!hasExactKeys(parsed.signature, ["algorithm", "keyId", "value"]) ||
+		parsed.signature.algorithm !== "ed25519" ||
+		typeof parsed.signature.value !== "string"
+	)
+		fail("restart proof is malformed");
+	const publicKey = await trustedPublicKey(root, parsed.signature.keyId);
+	const signature = canonicalEd25519Signature(parsed.signature.value);
+	if (!verify(null, restartProofPayload(parsed.proof), publicKey, signature))
+		fail("restart proof signature is invalid");
+	const requested = Date.parse(parsed.proof.requestedAt);
+	const now = Date.now();
+	if (now - requested > COLLECTION_WINDOW_MS || requested > now + 60_000)
+		fail("restart proof timestamp is outside the collection window");
+	if (parsed.proof.collectionId !== collection || !sameCell(parsed.proof.cell, cell))
+		fail("restart proof does not match the requested cell");
+	return parsed.proof;
+}
+
+export async function removeRestartProof(root: string, proof: RestartProof): Promise<void> {
+	const target = path.join(root, RESTART_PROOFS_NAME, restartProofFile(proof.collectionId, proof.cell));
+	await secureFile(target, true);
+	await fs.unlink(target);
+}
+
+export function restartRequestCode(result: ExperimentResult): RestartProof["request"]["code"] {
+	if (
+		result.phase !== "probe" ||
+		result.ancestry.kind !== "outer_owner" ||
+		result.lifecycle.length !== 0 ||
+		result.requestAttempted !== true ||
+		(result.code !== "permission_pending" && result.code !== "ok") ||
+		(result.code === "permission_pending" && result.permission.screenRecording) ||
+		(result.code === "ok" && (!result.permission.screenRecording || !result.permission.accessibility))
+	)
+		fail("hidden experiment result does not match the restart request contract");
+	return result.code;
+}
+
+export interface PersistReceiptDependencies {
+	writeReceipt?: (root: string, receipt: Gate0Receipt) => Promise<void>;
+	removeRestartProof?: (root: string, proof: RestartProof) => Promise<void>;
+}
+
+export async function persistReceiptAndConsumeProof(
+	root: string,
+	receipt: Gate0Receipt,
+	proof: RestartProof | null,
+	dependencies: PersistReceiptDependencies = {},
+): Promise<void> {
+	await (dependencies.writeReceipt ?? writeReceipt)(root, receipt);
+	if (proof) await (dependencies.removeRestartProof ?? removeRestartProof)(root, proof);
+}
+
+async function requestCell(args: string[]): Promise<void> {
+	const cell = parseCell(args),
+		collection = collectionId();
+	validateEnvironment(cell);
+	const root = evidenceRoot();
+	await ensureEvidenceRoot(root);
+	const releaseLock = await acquireExperimentLock(root);
+	try {
+		const artifact = await releaseArtifact(requireFlag(args, "artifact"));
+		const sourceRevision = await readSourceRevision();
+		const codesign = await codesignSummary(artifact.path);
+		if (!codesign.verified || codesign.signing !== "adhoc")
+			fail("release artifact must have a verified ad-hoc signature");
+		const existing = await loadRestartProof(root, collection, cell);
+		if (existing) fail("restart proof already exists for this cell");
+		const result = experimentResult(await invokeExperiment(artifact.path, { operation: "probe", request: true }));
+		const requestCode = restartRequestCode(result);
+		const currentArtifact = await releaseArtifact(artifact.path);
+		const currentSource = await readSourceRevision();
+		const currentCodesign = await codesignSummary(currentArtifact.path);
+		if (
+			currentArtifact.sha256 !== artifact.sha256 ||
+			currentSource !== sourceRevision ||
+			!currentCodesign.verified ||
+			currentCodesign.signing !== "adhoc" ||
+			currentCodesign.signing !== codesign.signing ||
+			currentCodesign.verified !== codesign.verified
+		)
+			fail("artifact, source, or codesign state changed during restart request collection");
+		const proof: RestartProof = {
+			schemaVersion: 1,
+			kind: "screen-recording-restart-request",
+			gate: 0,
+			collectionId: collection,
+			cell,
+			artifact: { identity: "packages/coding-agent/dist/gjc", sourceRevision, sha256: artifact.sha256 },
+			codesign,
+			requestedAt: new Date().toISOString(),
+			request: { attempted: true, code: requestCode },
+		};
+		await writeRestartProof(root, proof);
+		process.stdout.write(`${canonicalJson({ gate: 0, cell, restartRequired: true } as JsonValue)}\n`);
+	} finally {
+		await releaseLock();
+	}
+}
+
 async function runCell(args: string[]): Promise<void> {
 	const cell = parseCell(args),
 		collection = collectionId();
@@ -650,9 +886,22 @@ async function runCell(args: string[]): Promise<void> {
 	const releaseLock = await acquireExperimentLock(root);
 	try {
 		const startedAt = new Date().toISOString(),
-			artifact = await releaseArtifact(requireFlag(args, "artifact")),
-			continuity = await runCellContinuity(artifact, cell.topology);
-		if (!continuity.baselinePair.probe.requestAttempted)
+			artifact = await releaseArtifact(requireFlag(args, "artifact"));
+		const proof = await loadRestartProof(root, collection, cell);
+		if (proof) {
+			const sourceRevision = await readSourceRevision();
+			const codesign = await codesignSummary(artifact.path);
+			if (
+				proof.artifact.sourceRevision !== sourceRevision ||
+				proof.artifact.sha256 !== artifact.sha256 ||
+				!validCodeSign(codesign) ||
+				codesign.signing !== proof.codesign.signing ||
+				codesign.verified !== proof.codesign.verified
+			)
+				fail("restart proof does not match the current artifact, source, or codesign state");
+		}
+		const continuity = await runCellContinuity(artifact, cell.topology, {}, !proof);
+		if (!proof && !continuity.baselinePair.probe.requestAttempted)
 			fail("baseline did not exercise the explicit Screen Recording request");
 		const receipt: Gate0Receipt = {
 			schemaVersion: 1,
@@ -671,13 +920,13 @@ async function runCell(args: string[]): Promise<void> {
 			permissions: {
 				screenRecordingGranted: continuity.updatedPair.lifecycle.permission.screenRecording,
 				accessibilityGranted: continuity.updatedPair.lifecycle.permission.accessibility,
-				requestAttempted: continuity.baselinePair.probe.requestAttempted,
+				requestAttempted: proof ? true : continuity.baselinePair.probe.requestAttempted,
 			},
 			ancestry: continuity.updatedPair.lifecycle.ancestry,
 			lifecycle: { markers: continuity.updatedPair.lifecycle.lifecycle },
 			result: { success: true, code: "ok" },
 		};
-		await writeReceipt(root, receipt);
+		await persistReceiptAndConsumeProof(root, receipt, proof);
 		process.stdout.write(`${canonicalJson({ gate: 0, cell, result: receipt.result } as JsonValue)}\n`);
 	} finally {
 		await releaseLock();
@@ -894,9 +1143,10 @@ export async function aggregate(args: string[], dependencies: AggregateDependenc
 }
 async function main(argv: string[]): Promise<void> {
 	const [command, ...args] = argv;
+	if (command === "request-cell") return requestCell(args);
 	if (command === "run-cell") return runCell(args);
 	if (command === "aggregate") return aggregate(args);
-	fail("expected run-cell or aggregate");
+	fail("expected request-cell, run-cell, or aggregate");
 }
 if (import.meta.main)
 	main(process.argv.slice(2)).catch(error => {

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -8,6 +8,11 @@ import "@gajae-code/utils/postmortem";
 import { Args, type CliConfig, Command, type CommandEntry, Flags, run } from "@gajae-code/utils/cli";
 import { APP_NAME, formatBunRuntimeError, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
 import { runFixtureReport } from "./cli/fixture-report";
+import {
+	gate0InternalErrorResult,
+	runComputerBrokerGate0,
+	runComputerBrokerGate0FromEnvironment,
+} from "./gjc-runtime/computer-broker-gate0";
 import { isTmuxOwnerIsolationCliArgv, runTmuxOwnerIsolationCliFromStdin } from "./gjc-runtime/tmux-owner-isolation-cli";
 
 if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
@@ -297,8 +302,14 @@ export function routeRootArgv(argv: readonly string[]): string[] {
 			: ["launch", ...normalizedArgv];
 }
 
+export interface RunCliDependencies {
+	reexecWithScrubbedMallocEnv?: () => Promise<number | null>;
+	runGate0FromEnvironment?: typeof runComputerBrokerGate0FromEnvironment;
+	writeGate0Output?: (value: string) => void;
+}
+
 /** Run the CLI with the given argv (no `process.argv` prefix). */
-export async function runCli(argv: string[]): Promise<void> {
+export async function runCli(argv: string[], dependencies: RunCliDependencies = {}): Promise<void> {
 	// macOS malloc-env launch boundary. Re-exec once with a scrubbed environment
 	// BEFORE any fast path or subprocess spawn, so the startup env snapshot Bun hands
 	// to every child lane (Bun.spawn defaults, node:child_process, native PTY, tmux
@@ -312,13 +323,32 @@ export async function runCli(argv: string[]): Promise<void> {
 		process.env.GJC_MALLOC_ENV_REEXEC === undefined &&
 		(process.env.MallocStackLogging !== undefined || process.env.MallocStackLoggingNoCompact !== undefined)
 	) {
-		const { reexecWithScrubbedMallocEnv } = await import("./cli/malloc-env-guard");
+		const reexecWithScrubbedMallocEnv =
+			dependencies.reexecWithScrubbedMallocEnv ??
+			(await import("./cli/malloc-env-guard")).reexecWithScrubbedMallocEnv;
 		const code = await reexecWithScrubbedMallocEnv();
 		if (code !== null) {
 			process.exitCode = code;
 			return;
 		}
-		// Re-exec could not be spawned; fall through and run in this process.
+		if (argv[0] === "--internal-computer-gate0") {
+			(dependencies.writeGate0Output ?? (value => process.stdout.write(value)))(
+				`${JSON.stringify(gate0InternalErrorResult())}\n`,
+			);
+			process.exitCode = 1;
+			return;
+		}
+	}
+	if (argv[0] === "--internal-computer-gate0") {
+		if (argv.length !== 1) {
+			(dependencies.writeGate0Output ?? (value => process.stdout.write(value)))(
+				`${JSON.stringify(await runComputerBrokerGate0(undefined))}\n`,
+			);
+			process.exitCode = 1;
+			return;
+		}
+		await (dependencies.runGate0FromEnvironment ?? runComputerBrokerGate0FromEnvironment)();
+		return;
 	}
 	if (isTmuxOwnerIsolationCliArgv(argv)) {
 		await runTmuxOwnerIsolationCliFromStdin();

--- a/packages/coding-agent/src/gjc-runtime/computer-broker-gate0-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/computer-broker-gate0-tmux.ts
@@ -1,0 +1,246 @@
+import crypto from "node:crypto";
+
+/** This private feasibility harness never shares a tmux server with normal launch. */
+export const GATE0_LIFECYCLE_TIMEOUT_MS = 14_000;
+export type Gate0LifecycleMarker = "preflight" | "tmux_created" | "attached" | "detached" | "reattached" | "cleaned";
+
+export interface Gate0TmuxChild {
+	exited: Promise<number>;
+	stdin: { write(value: string): void; end(): Promise<void> };
+	kill(signal?: number | NodeJS.Signals): void;
+}
+
+export interface Gate0TmuxLifecycleOptions {
+	phase: "A1" | "A2";
+	tmuxCommand: string;
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	timeoutMs?: number;
+	signal?: AbortSignal;
+	spawn?: (
+		argv: string[],
+		options: { cwd: string; env: NodeJS.ProcessEnv; stdin: "pipe"; stdout: "pipe"; stderr: "pipe" },
+	) => Gate0TmuxChild;
+	now?: () => number;
+	randomBytes?: (size: number) => { toString(encoding: "hex"): string };
+}
+
+function failure(code: "GATE0_TIMEOUT" | "GATE0_CLEANUP_FAILURE" | "GATE0_TMUX_FAILURE"): Error {
+	return new Error(code);
+}
+
+export function gate0TmuxEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {};
+	for (const [key, value] of Object.entries(source)) {
+		if (
+			key === "TMUX" ||
+			key === "TMUX_PANE" ||
+			key === "TMUX_TMPDIR" ||
+			key === "TERM_PROGRAM" ||
+			key === "TERM_PROGRAM_VERSION" ||
+			key.startsWith("CMUX_") ||
+			key.startsWith("GHOSTTY_") ||
+			key.startsWith("GJC_TMUX_") ||
+			key.startsWith("GJC_SESSION_") ||
+			key.startsWith("GJC_COORDINATOR_")
+		)
+			continue;
+		env[key] = value;
+	}
+	return env;
+}
+
+function waitFor<T>(promise: Promise<T>, ms: number): Promise<T> {
+	const deferred = Promise.withResolvers<T>();
+	const timer = setTimeout(() => deferred.reject(failure("GATE0_TIMEOUT")), Math.max(1, ms));
+	void promise.then(
+		value => {
+			clearTimeout(timer);
+			deferred.resolve(value);
+		},
+		error => {
+			clearTimeout(timer);
+			deferred.reject(error);
+		},
+	);
+	return deferred.promise;
+}
+
+async function stopChild(child: Gate0TmuxChild, deadline: number, now: () => number): Promise<boolean> {
+	const waitForExit = async (until: number): Promise<boolean> => {
+		const remaining = until - now();
+		if (remaining <= 0) return false;
+		try {
+			await waitFor(child.exited, remaining);
+			return true;
+		} catch {
+			return false;
+		}
+	};
+	if (await waitForExit(Math.min(deadline, now() + 1))) return true;
+	try {
+		child.kill("SIGTERM");
+	} catch {}
+	const termDeadline = Math.min(deadline, now() + Math.max(1, Math.floor((deadline - now()) / 2)));
+	if (await waitForExit(termDeadline)) return true;
+	try {
+		child.kill("SIGKILL");
+	} catch {}
+	return waitForExit(deadline);
+}
+
+/** Runs one client command and bounds both its execution and its termination. */
+async function commandStatus(
+	spawn: NonNullable<Gate0TmuxLifecycleOptions["spawn"]>,
+	argv: string[],
+	cwd: string,
+	env: NodeJS.ProcessEnv,
+	deadline: number,
+	now: () => number,
+	cleanupDeadline = deadline,
+	onSpawn?: () => void,
+): Promise<number> {
+	if (now() >= deadline) throw failure("GATE0_TIMEOUT");
+	const child = spawn(argv, { cwd, env, stdin: "pipe", stdout: "pipe", stderr: "pipe" });
+	onSpawn?.();
+	const remaining = Math.max(1, deadline - now());
+	try {
+		return await waitFor(child.exited, remaining);
+	} catch (error) {
+		if (!(await stopChild(child, cleanupDeadline, now))) throw failure("GATE0_CLEANUP_FAILURE");
+		throw error;
+	}
+}
+
+async function controlAttach(
+	spawn: NonNullable<Gate0TmuxLifecycleOptions["spawn"]>,
+	argv: string[],
+	cwd: string,
+	env: NodeJS.ProcessEnv,
+	deadline: number,
+	now: () => number,
+	cleanupDeadline = deadline,
+): Promise<void> {
+	if (now() >= deadline) throw failure("GATE0_TIMEOUT");
+	const child = spawn(argv, { cwd, env, stdin: "pipe", stdout: "pipe", stderr: "pipe" });
+	try {
+		child.stdin.write("detach-client\n");
+		await waitFor(Promise.resolve(child.stdin.end()), Math.max(1, deadline - now()));
+	} catch {
+		if (!(await stopChild(child, cleanupDeadline, now))) throw failure("GATE0_CLEANUP_FAILURE");
+		throw failure("GATE0_TMUX_FAILURE");
+	}
+	try {
+		if ((await waitFor(child.exited, Math.max(1, deadline - now()))) !== 0) throw failure("GATE0_TMUX_FAILURE");
+	} catch (error) {
+		if (!(await stopChild(child, cleanupDeadline, now))) throw failure("GATE0_CLEANUP_FAILURE");
+		throw error;
+	}
+}
+
+/**
+ * Runs an isolated, random-server tmux experiment. Cleanup is part of the
+ * result: an unverifiable kill-server is an internal failure, never success.
+ */
+export async function runGate0TmuxLifecycle(options: Gate0TmuxLifecycleOptions): Promise<Gate0LifecycleMarker[]> {
+	const timeoutMs = Math.min(Math.max(options.timeoutMs ?? GATE0_LIFECYCLE_TIMEOUT_MS, 1), GATE0_LIFECYCLE_TIMEOUT_MS);
+	const now = options.now ?? Date.now;
+	const deadline = now() + timeoutMs;
+	const cleanupReserveMs = Math.min(3_000, Math.max(1, Math.floor(timeoutMs / 3)), Math.max(0, timeoutMs - 1));
+	const namespaceCleanupReserveMs = Math.min(Math.max(1, Math.floor(cleanupReserveMs / 2)), cleanupReserveMs);
+	const clientCleanupDeadline = deadline - namespaceCleanupReserveMs;
+	const workDeadline = deadline - cleanupReserveMs;
+	const cwd = options.cwd ?? process.cwd();
+	const env = gate0TmuxEnvironment(options.env ?? process.env);
+	const spawn = options.spawn ?? ((argv, spawnOptions) => Bun.spawn(argv, spawnOptions) as unknown as Gate0TmuxChild);
+	const server = `gjc-gate0-${(options.randomBytes ?? crypto.randomBytes)(12).toString("hex")}`;
+	const session = "gate0";
+	const args = (...command: string[]) => [options.tmuxCommand, "-f", "/dev/null", "-L", server, ...command];
+	const markers: Gate0LifecycleMarker[] = ["preflight"];
+	let createClientSpawned = false;
+	let mainFailure: unknown;
+	try {
+		if (options.signal?.aborted) throw failure("GATE0_TIMEOUT");
+		if (
+			(await commandStatus(
+				spawn,
+				args("new-session", "-d", "-s", session, "--", "/bin/sleep", "15"),
+				cwd,
+				env,
+				workDeadline,
+				now,
+				clientCleanupDeadline,
+				() => {
+					createClientSpawned = true;
+				},
+			)) !== 0
+		)
+			throw failure("GATE0_TMUX_FAILURE");
+		markers.push("tmux_created");
+		if (
+			(await commandStatus(
+				spawn,
+				args("has-session", "-t", session),
+				cwd,
+				env,
+				workDeadline,
+				now,
+				clientCleanupDeadline,
+			)) !== 0
+		)
+			throw failure("GATE0_TMUX_FAILURE");
+		await controlAttach(
+			spawn,
+			args("-C", "attach-session", "-t", session),
+			cwd,
+			env,
+			workDeadline,
+			now,
+			clientCleanupDeadline,
+		);
+		markers.push("attached", "detached");
+		if (
+			(await commandStatus(
+				spawn,
+				args("has-session", "-t", session),
+				cwd,
+				env,
+				workDeadline,
+				now,
+				clientCleanupDeadline,
+			)) !== 0
+		)
+			throw failure("GATE0_TMUX_FAILURE");
+		await controlAttach(
+			spawn,
+			args("-C", "attach-session", "-t", session),
+			cwd,
+			env,
+			workDeadline,
+			now,
+			clientCleanupDeadline,
+		);
+		markers.push("reattached");
+	} catch (error) {
+		mainFailure = error;
+	} finally {
+		if (createClientSpawned) {
+			let cleanupFailed = false;
+			try {
+				await commandStatus(spawn, args("kill-server"), cwd, env, deadline, now);
+			} catch (error) {
+				cleanupFailed = error instanceof Error && error.message === "GATE0_CLEANUP_FAILURE";
+			}
+			try {
+				if ((await commandStatus(spawn, args("has-session", "-t", session), cwd, env, deadline, now)) === 0)
+					cleanupFailed = true;
+			} catch {
+				cleanupFailed = true;
+			}
+			if (cleanupFailed) mainFailure = failure("GATE0_CLEANUP_FAILURE");
+			else markers.push("cleaned");
+		}
+	}
+	if (mainFailure) throw mainFailure;
+	return markers;
+}

--- a/packages/coding-agent/src/gjc-runtime/computer-broker-gate0.ts
+++ b/packages/coding-agent/src/gjc-runtime/computer-broker-gate0.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { ComputerController } from "@gajae-code/natives";
+import { loadNative } from "@gajae-code/natives/loader-state";
 import { isCompiledBinary } from "@gajae-code/utils/env";
 import {
 	GATE0_LIFECYCLE_TIMEOUT_MS,
@@ -30,6 +30,10 @@ export interface Gate0NativeController {
 	gate0RequestScreenRecording(): boolean;
 	gate0HarmlessProbe(): { screenshot: boolean; accessibility: boolean; pointerMoveRestore: boolean };
 }
+
+type Gate0NativeBindings = Record<string, unknown> & {
+	ComputerController: new () => Gate0NativeController;
+};
 
 /** The sole redacted schema emitted by the hidden Gate-0 dispatcher. */
 export interface Gate0Result {
@@ -92,7 +96,8 @@ const GATE0_MARKERS = new Set<Gate0LifecycleMarker>([
 ]);
 
 function nativeController(): Gate0NativeController {
-	return new ComputerController() as Gate0NativeController;
+	const { ComputerController } = loadNative<Gate0NativeBindings>();
+	return new ComputerController();
 }
 
 function result(

--- a/packages/coding-agent/src/gjc-runtime/computer-broker-gate0.ts
+++ b/packages/coding-agent/src/gjc-runtime/computer-broker-gate0.ts
@@ -1,0 +1,758 @@
+import crypto from "node:crypto";
+import { ComputerController } from "@gajae-code/natives";
+import { isCompiledBinary } from "@gajae-code/utils/env";
+import {
+	GATE0_LIFECYCLE_TIMEOUT_MS,
+	type Gate0LifecycleMarker,
+	runGate0TmuxLifecycle,
+} from "./computer-broker-gate0-tmux";
+import { resolveGjcTmuxBinary } from "./tmux-common";
+
+export const GATE0_INPUT_ENV = "GJC_COMPUTER_GATE0_INPUT";
+const GATE0_PERSISTENT_CHILD_ENV = "GJC_COMPUTER_GATE0_PERSISTENT_CHILD";
+const GATE0_INTERNAL_TIMEOUT_MS = GATE0_LIFECYCLE_TIMEOUT_MS - 1_000;
+
+export type Gate0Code =
+	| "ok"
+	| "invalid_input"
+	| "permission_denied"
+	| "permission_pending"
+	| "probe_failed"
+	| "timeout"
+	| "native_unavailable"
+	| "internal_error";
+
+export type Gate0AncestryKind = "persistent_child" | "outer_owner";
+export type { Gate0LifecycleMarker };
+
+export interface Gate0NativeController {
+	gate0PermissionStatus(): { accessibility: boolean; screenRecording: boolean };
+	gate0RequestScreenRecording(): boolean;
+	gate0HarmlessProbe(): { screenshot: boolean; accessibility: boolean; pointerMoveRestore: boolean };
+}
+
+/** The sole redacted schema emitted by the hidden Gate-0 dispatcher. */
+export interface Gate0Result {
+	topology: "gate0";
+	phase: "probe" | "A1" | "A2";
+	permission: { accessibility: boolean; screenRecording: boolean };
+	requestAttempted: boolean;
+	success: boolean;
+	code: Gate0Code;
+	ancestry: { kind: Gate0AncestryKind; bounded: true };
+	lifecycle: Gate0LifecycleMarker[];
+}
+
+interface Gate0PersistentChild {
+	stdin: { write(value: string): void; flush(): Promise<void>; end(): Promise<void> };
+	stdout: ReadableStream<Uint8Array>;
+	exited: Promise<number>;
+	kill(signal?: number | NodeJS.Signals): void;
+}
+
+export interface Gate0Dependencies {
+	controllerFactory?: () => Gate0NativeController;
+	timeoutMs?: number;
+	tmuxCommand?: string;
+	lifecycleRunner?: typeof runGate0TmuxLifecycle;
+	/** Internal test seam for the experiment-owned A1 child. */
+	persistentChildSpawner?: (options: { nonce: string }) => Gate0PersistentChild;
+	/** Test seam; A1 is supported only by packaged release artifacts. */
+	isCompiledBinary?: () => boolean;
+	/** Test seam for a single lifecycle deadline. */
+	now?: () => number;
+}
+
+type Gate0Input = { operation: "probe"; request?: boolean } | { operation: "lifecycle"; phase: "A1" | "A2" };
+
+interface PersistentInput {
+	operation: "persistent-child";
+	phase: "A1";
+	nonce: string;
+}
+
+const GATE0_CODES = new Set<Gate0Code>([
+	"ok",
+	"invalid_input",
+	"permission_denied",
+	"permission_pending",
+	"probe_failed",
+	"timeout",
+	"native_unavailable",
+	"internal_error",
+]);
+const PERSISTENT_PROBE_CODES = new Set<Gate0Code>(["ok", "permission_denied", "probe_failed", "internal_error"]);
+const GATE0_MARKERS = new Set<Gate0LifecycleMarker>([
+	"preflight",
+	"tmux_created",
+	"attached",
+	"detached",
+	"reattached",
+	"cleaned",
+]);
+
+function nativeController(): Gate0NativeController {
+	return new ComputerController() as Gate0NativeController;
+}
+
+function result(
+	phase: Gate0Result["phase"],
+	permission: Gate0Result["permission"],
+	ancestry: Gate0AncestryKind,
+	overrides: Partial<Omit<Gate0Result, "topology" | "phase" | "permission" | "ancestry">> = {},
+): Gate0Result {
+	return {
+		topology: "gate0",
+		phase,
+		permission: { accessibility: permission.accessibility, screenRecording: permission.screenRecording },
+		requestAttempted: overrides.requestAttempted === true,
+		success: overrides.success === true,
+		code: overrides.code ?? "internal_error",
+		ancestry: { kind: ancestry, bounded: true },
+		lifecycle: overrides.lifecycle ? [...overrides.lifecycle] : [],
+	};
+}
+
+/** Builds the exact redacted failure DTO for failures before dispatch can begin. */
+export function gate0InternalErrorResult(
+	phase: Gate0Result["phase"] = "probe",
+	ancestry: Gate0AncestryKind = "outer_owner",
+): Gate0Result {
+	return result(phase, { accessibility: false, screenRecording: false }, ancestry, { code: "internal_error" });
+}
+
+function parseInput(input: string | undefined): Gate0Input | null {
+	if (!input) return null;
+	try {
+		const value: unknown = JSON.parse(input);
+		if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+		const record = value as Record<string, unknown>;
+		if (
+			record.operation === "probe" &&
+			(record.request === undefined || typeof record.request === "boolean") &&
+			Object.keys(record).every(key => key === "operation" || key === "request")
+		)
+			return { operation: "probe", request: record.request === true };
+		if (
+			record.operation === "lifecycle" &&
+			(record.phase === "A1" || record.phase === "A2") &&
+			Object.keys(record).every(key => key === "operation" || key === "phase")
+		)
+			return { operation: "lifecycle", phase: record.phase };
+	} catch {}
+	return null;
+}
+
+function parsePersistentInput(input: string | undefined): PersistentInput | null {
+	try {
+		const value: unknown = input ? JSON.parse(input) : null;
+		if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+		const record = value as Record<string, unknown>;
+		return record.operation === "persistent-child" &&
+			record.phase === "A1" &&
+			typeof record.nonce === "string" &&
+			/^[a-f0-9]{32,64}$/.test(record.nonce) &&
+			Object.keys(record).length === 3
+			? { operation: "persistent-child", phase: "A1", nonce: record.nonce }
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function errorCode(error: unknown): Gate0Code {
+	const message = error instanceof Error ? error.message : "";
+	if (message === "GATE0_TIMEOUT" || message === "GATE0_OPERATION_TIMEOUT") return "timeout";
+	if (message === "GATE0_PERMISSION_PENDING") return "permission_pending";
+	if (message === "GATE0_PERMISSION_DENIED") return "permission_denied";
+	if (message === "COMPUTER_NATIVE_UNAVAILABLE" || message === "COMPUTER_NATIVE_UNSUPPORTED")
+		return "native_unavailable";
+	return "internal_error";
+}
+
+function permissionStatus(controller: Gate0NativeController): Gate0Result["permission"] {
+	const status = controller.gate0PermissionStatus();
+	if (typeof status.accessibility !== "boolean" || typeof status.screenRecording !== "boolean")
+		throw new Error("GATE0_PERMISSION_STATUS_FAILURE");
+	return { accessibility: status.accessibility, screenRecording: status.screenRecording };
+}
+
+async function probe(
+	controller: Gate0NativeController,
+	phase: Gate0Result["phase"],
+	ancestry: Gate0AncestryKind,
+	request: boolean,
+): Promise<Gate0Result> {
+	let permission: Gate0Result["permission"] = { accessibility: false, screenRecording: false };
+	let requestAttempted = false;
+	try {
+		permission = permissionStatus(controller);
+		if (request && !permission.screenRecording) {
+			requestAttempted = true;
+			controller.gate0RequestScreenRecording();
+			permission = permissionStatus(controller);
+		}
+		const probeResult = controller.gate0HarmlessProbe();
+		permission = permissionStatus(controller);
+		const harmless =
+			probeResult.screenshot === true &&
+			probeResult.accessibility === true &&
+			probeResult.pointerMoveRestore === true;
+		const success = harmless && permission.accessibility && permission.screenRecording;
+		const code: Gate0Code = success
+			? "ok"
+			: requestAttempted && !permission.screenRecording
+				? "permission_pending"
+				: !permission.screenRecording || !permission.accessibility
+					? "permission_denied"
+					: "probe_failed";
+		return result(phase, permission, ancestry, { success, code, requestAttempted });
+	} catch (error) {
+		return result(phase, permission, ancestry, { code: errorCode(error), requestAttempted });
+	}
+}
+
+function exactKeys(record: Record<string, unknown>, keys: readonly string[]): boolean {
+	return Object.keys(record).length === keys.length && keys.every(key => key in record);
+}
+
+function gate0Result(value: unknown): Gate0Result | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	const record = value as Record<string, unknown>;
+	if (
+		!exactKeys(record, [
+			"topology",
+			"phase",
+			"permission",
+			"requestAttempted",
+			"success",
+			"code",
+			"ancestry",
+			"lifecycle",
+		])
+	)
+		return null;
+	const permission = record.permission;
+	const ancestry = record.ancestry;
+	if (
+		record.topology !== "gate0" ||
+		(record.phase !== "probe" && record.phase !== "A1" && record.phase !== "A2") ||
+		!permission ||
+		typeof permission !== "object" ||
+		Array.isArray(permission) ||
+		!exactKeys(permission as Record<string, unknown>, ["accessibility", "screenRecording"]) ||
+		typeof (permission as Record<string, unknown>).accessibility !== "boolean" ||
+		typeof (permission as Record<string, unknown>).screenRecording !== "boolean" ||
+		typeof record.requestAttempted !== "boolean" ||
+		typeof record.success !== "boolean" ||
+		typeof record.code !== "string" ||
+		!GATE0_CODES.has(record.code as Gate0Code) ||
+		record.success !== (record.code === "ok") ||
+		!ancestry ||
+		typeof ancestry !== "object" ||
+		Array.isArray(ancestry) ||
+		!exactKeys(ancestry as Record<string, unknown>, ["kind", "bounded"]) ||
+		((ancestry as Record<string, unknown>).kind !== "persistent_child" &&
+			(ancestry as Record<string, unknown>).kind !== "outer_owner") ||
+		(ancestry as Record<string, unknown>).bounded !== true ||
+		(record.phase === "A1"
+			? (ancestry as Record<string, unknown>).kind !== "persistent_child"
+			: (ancestry as Record<string, unknown>).kind !== "outer_owner") ||
+		!Array.isArray(record.lifecycle) ||
+		!record.lifecycle.every(
+			marker => typeof marker === "string" && GATE0_MARKERS.has(marker as Gate0LifecycleMarker),
+		) ||
+		(record.phase === "probe" &&
+			(record.lifecycle.length !== 0 ||
+				(record.requestAttempted &&
+					record.code === "permission_pending" &&
+					(permission as Record<string, unknown>).screenRecording === true))) ||
+		(record.phase !== "probe" && record.requestAttempted) ||
+		(record.code === "ok" &&
+			(!(permission as Record<string, unknown>).accessibility ||
+				!(permission as Record<string, unknown>).screenRecording)) ||
+		(record.code === "permission_denied" &&
+			(permission as Record<string, unknown>).accessibility === true &&
+			(permission as Record<string, unknown>).screenRecording === true) ||
+		(record.code === "permission_pending" &&
+			(!record.requestAttempted || (permission as Record<string, unknown>).screenRecording !== false)) ||
+		(record.success && record.phase !== "probe" && !completeLifecycle(record.lifecycle))
+	)
+		return null;
+	return result(
+		record.phase,
+		{
+			accessibility: (permission as Record<string, unknown>).accessibility as boolean,
+			screenRecording: (permission as Record<string, unknown>).screenRecording as boolean,
+		},
+		(ancestry as Record<string, unknown>).kind as Gate0AncestryKind,
+		{
+			requestAttempted: record.requestAttempted,
+			success: record.success,
+			code: record.code as Gate0Code,
+			lifecycle: record.lifecycle as Gate0LifecycleMarker[],
+		},
+	);
+}
+
+export function isGate0Result(value: unknown): value is Gate0Result {
+	return gate0Result(value) !== null;
+}
+
+function gate0Wait<T>(promise: Promise<T>, timeoutMs: number, onTimeout: () => void | Promise<void>): Promise<T> {
+	const deferred = Promise.withResolvers<T>();
+	let settled = false;
+	const timer = setTimeout(
+		async () => {
+			if (settled) return;
+			settled = true;
+			try {
+				await onTimeout();
+				deferred.reject(new Error("GATE0_TIMEOUT"));
+			} catch {
+				deferred.reject(new Error("GATE0_CLEANUP_FAILURE"));
+			}
+		},
+		Math.min(Math.max(timeoutMs, 1), GATE0_LIFECYCLE_TIMEOUT_MS),
+	);
+	void promise.then(
+		value => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			deferred.resolve(value);
+		},
+		error => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			deferred.reject(error);
+		},
+	);
+	return deferred.promise;
+}
+
+function lifecycleTimeoutMs(dependencies: Gate0Dependencies): number {
+	return Math.min(Math.max(dependencies.timeoutMs ?? GATE0_INTERNAL_TIMEOUT_MS, 1), GATE0_INTERNAL_TIMEOUT_MS);
+}
+
+function cleanupReserveMs(timeoutMs: number): number {
+	return Math.min(1_000, Math.max(1, Math.floor(timeoutMs / 3)), Math.max(0, timeoutMs - 1));
+}
+
+function cleanupSignalReserveMs(timeoutMs: number): number {
+	const reserve = cleanupReserveMs(timeoutMs);
+	return Math.min(reserve, Math.max(1, Math.floor(reserve / 2)));
+}
+
+function remainingMs(deadline: number, now: () => number): number {
+	return Math.max(0, deadline - now());
+}
+
+function waitUntil<T>(
+	promise: Promise<T>,
+	deadline: number,
+	now: () => number,
+	onTimeout: () => void | Promise<void>,
+): Promise<T> {
+	const timeoutMs = remainingMs(deadline, now);
+	if (timeoutMs <= 0) {
+		return Promise.resolve(onTimeout()).then(
+			() => Promise.reject(new Error("GATE0_TIMEOUT")),
+			() => Promise.reject(new Error("GATE0_CLEANUP_FAILURE")),
+		);
+	}
+	return gate0Wait(promise, timeoutMs, onTimeout);
+}
+
+function completeLifecycle(markers: unknown): markers is Gate0LifecycleMarker[] {
+	const expected: Gate0LifecycleMarker[] = [
+		"preflight",
+		"tmux_created",
+		"attached",
+		"detached",
+		"reattached",
+		"cleaned",
+	];
+	return (
+		Array.isArray(markers) &&
+		markers.length === expected.length &&
+		markers.every((marker, index) => marker === expected[index])
+	);
+}
+
+function persistentProbeResult(value: unknown): Gate0Result | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	const record = value as Record<string, unknown>;
+	const permission = record.permission;
+	const ancestry = record.ancestry;
+	if (
+		!exactKeys(record, [
+			"topology",
+			"phase",
+			"permission",
+			"requestAttempted",
+			"success",
+			"code",
+			"ancestry",
+			"lifecycle",
+		]) ||
+		record.topology !== "gate0" ||
+		record.phase !== "A1" ||
+		!permission ||
+		typeof permission !== "object" ||
+		Array.isArray(permission) ||
+		!exactKeys(permission as Record<string, unknown>, ["accessibility", "screenRecording"]) ||
+		typeof (permission as Record<string, unknown>).accessibility !== "boolean" ||
+		typeof (permission as Record<string, unknown>).screenRecording !== "boolean" ||
+		!ancestry ||
+		typeof ancestry !== "object" ||
+		Array.isArray(ancestry) ||
+		!exactKeys(ancestry as Record<string, unknown>, ["kind", "bounded"]) ||
+		(ancestry as Record<string, unknown>).kind !== "persistent_child" ||
+		(ancestry as Record<string, unknown>).bounded !== true ||
+		record.requestAttempted !== false ||
+		typeof record.success !== "boolean" ||
+		!PERSISTENT_PROBE_CODES.has(record.code as Gate0Code) ||
+		record.success !== (record.code === "ok") ||
+		!Array.isArray(record.lifecycle) ||
+		record.lifecycle.length !== 0 ||
+		(record.code === "ok" &&
+			(!(permission as Record<string, unknown>).accessibility ||
+				!(permission as Record<string, unknown>).screenRecording)) ||
+		(record.code === "permission_denied" &&
+			(permission as Record<string, unknown>).accessibility === true &&
+			(permission as Record<string, unknown>).screenRecording === true)
+	)
+		return null;
+	return result(
+		"A1",
+		{
+			accessibility: (permission as Record<string, unknown>).accessibility as boolean,
+			screenRecording: (permission as Record<string, unknown>).screenRecording as boolean,
+		},
+		"persistent_child",
+		{ success: record.success, code: record.code as Gate0Code },
+	);
+}
+
+async function runLifecycle(
+	phase: "A1" | "A2",
+	dependencies: Gate0Dependencies,
+	abort: AbortController,
+	operationDeadline: number,
+	totalDeadline: number,
+): Promise<Gate0LifecycleMarker[]> {
+	const now = dependencies.now ?? Date.now;
+	const timeoutMs = remainingMs(operationDeadline, now);
+	if (timeoutMs <= 0) {
+		abort.abort();
+		throw new Error("GATE0_TIMEOUT");
+	}
+	const lifecycle = (dependencies.lifecycleRunner ?? runGate0TmuxLifecycle)({
+		phase,
+		tmuxCommand: dependencies.tmuxCommand ?? resolveGjcTmuxBinary({ env: process.env }).command,
+		timeoutMs,
+		signal: abort.signal,
+	});
+	let timedOut = false;
+	const abortTimer = setTimeout(() => {
+		timedOut = true;
+		abort.abort();
+	}, timeoutMs);
+	try {
+		const markers = await waitUntil(lifecycle, totalDeadline, now, () => abort.abort());
+		if (timedOut) throw new Error("GATE0_OPERATION_TIMEOUT");
+		if (!completeLifecycle(markers)) throw new Error("GATE0_LIFECYCLE_FAILURE");
+		return markers;
+	} catch (error) {
+		if (error instanceof Error && error.message === "GATE0_TIMEOUT") {
+			if (remainingMs(totalDeadline, now) <= 0) throw new Error("GATE0_CLEANUP_FAILURE");
+			throw new Error("GATE0_OPERATION_TIMEOUT");
+		}
+		throw error;
+	} finally {
+		clearTimeout(abortTimer);
+	}
+}
+
+interface Gate0Reader {
+	read(): Promise<{ done: boolean; value?: Uint8Array }>;
+}
+
+interface PersistentFrame {
+	nonce: string;
+	sequence: "preflight" | "postflight";
+	result: Gate0Result;
+}
+
+const GATE0_FRAME_MAX_BYTES = 4_096;
+
+async function readPersistentFrame(
+	reader: Gate0Reader,
+	buffer: { value: string },
+	nonce: string,
+	sequence: PersistentFrame["sequence"],
+): Promise<Gate0Result> {
+	for (;;) {
+		const newline = buffer.value.indexOf("\n");
+		if (newline !== -1) {
+			const line = buffer.value.slice(0, newline);
+			if (new TextEncoder().encode(line).byteLength > GATE0_FRAME_MAX_BYTES)
+				throw new Error("GATE0_PERSISTENT_CHILD_FAILURE");
+			buffer.value = buffer.value.slice(newline + 1);
+			try {
+				const frame: unknown = JSON.parse(line);
+				if (!frame || typeof frame !== "object" || Array.isArray(frame)) throw new Error();
+				const record = frame as Record<string, unknown>;
+				const parsed = persistentProbeResult(record.result);
+				if (
+					!exactKeys(record, ["nonce", "sequence", "result"]) ||
+					record.nonce !== nonce ||
+					record.sequence !== sequence ||
+					!parsed
+				)
+					throw new Error();
+				return parsed;
+			} catch {
+				throw new Error("GATE0_PERSISTENT_CHILD_FAILURE");
+			}
+		}
+		if (new TextEncoder().encode(buffer.value).byteLength > GATE0_FRAME_MAX_BYTES)
+			throw new Error("GATE0_PERSISTENT_CHILD_FAILURE");
+		const next = await reader.read();
+		if (next.done || !next.value) throw new Error("GATE0_PERSISTENT_CHILD_FAILURE");
+		buffer.value += new TextDecoder().decode(next.value, { stream: true });
+	}
+}
+
+function lifecycleResult(
+	phase: "A1" | "A2",
+	ancestry: Gate0AncestryKind,
+	snapshot: Gate0Result,
+	lifecycle: Gate0LifecycleMarker[],
+): Gate0Result {
+	return result(phase, snapshot.permission, ancestry, {
+		success: snapshot.success,
+		code: snapshot.code,
+		lifecycle,
+	});
+}
+
+async function runA1PersistentLifecycle(dependencies: Gate0Dependencies): Promise<Gate0Result> {
+	const abort = new AbortController();
+	const now = dependencies.now ?? Date.now;
+	const timeoutMs = lifecycleTimeoutMs(dependencies);
+	const totalDeadline = now() + timeoutMs;
+	const operationDeadline = totalDeadline - cleanupReserveMs(timeoutMs);
+	const signalReserveMs = cleanupSignalReserveMs(timeoutMs);
+	const gracefulCleanupDeadline = totalDeadline - signalReserveMs;
+	const termDeadline = totalDeadline - Math.floor(signalReserveMs / 2);
+	let child: Gate0PersistentChild | undefined;
+	let writer: Gate0PersistentChild["stdin"] | undefined;
+	let reader: Gate0Reader | undefined;
+	let exited = false;
+	let cleanupFailed = false;
+	let output = result("A1", { accessibility: false, screenRecording: false }, "persistent_child");
+	let writerEnd: Promise<void> | undefined;
+	const closeWriter = (): Promise<void> => {
+		if (!writer) return Promise.resolve();
+		writerEnd ??= Promise.resolve().then(() => writer!.end());
+		return writerEnd;
+	};
+	const awaitExit = async (deadline: number): Promise<boolean> => {
+		if (!child) return true;
+		try {
+			await waitUntil(child.exited, deadline, now, () => abort.abort());
+			exited = true;
+			return true;
+		} catch {
+			return false;
+		}
+	};
+	const cleanupChild = async (): Promise<boolean> => {
+		abort.abort();
+		if (!child || exited) return true;
+		try {
+			await waitUntil(closeWriter(), gracefulCleanupDeadline, now, () => {});
+		} catch {}
+		if (exited) return true;
+		try {
+			child.kill("SIGTERM");
+		} catch {}
+		if (await awaitExit(termDeadline)) return true;
+		try {
+			child.kill("SIGKILL");
+		} catch {}
+		return awaitExit(totalDeadline);
+	};
+	const cleanupOnTimeout = async (): Promise<void> => {
+		if (!(await cleanupChild())) throw new Error("GATE0_CLEANUP_FAILURE");
+	};
+	try {
+		if (!(dependencies.isCompiledBinary ?? isCompiledBinary)())
+			return result("A1", { accessibility: false, screenRecording: false }, "persistent_child", {
+				code: "native_unavailable",
+			});
+		const nonce = crypto.randomBytes(24).toString("hex");
+		child =
+			dependencies.persistentChildSpawner?.({ nonce }) ??
+			(Bun.spawn([process.execPath, "--internal-computer-gate0"], {
+				env: {
+					...process.env,
+					[GATE0_PERSISTENT_CHILD_ENV]: "1",
+					[GATE0_INPUT_ENV]: JSON.stringify({ operation: "persistent-child", phase: "A1", nonce }),
+				},
+				stdin: "pipe",
+				stdout: "pipe",
+				stderr: "ignore",
+			}) as unknown as Gate0PersistentChild);
+		writer = child.stdin;
+		void child.exited.then(
+			() => {
+				exited = true;
+			},
+			() => {},
+		);
+		reader = child.stdout.getReader();
+		const buffer = { value: "" };
+		const send = async (sequence: PersistentFrame["sequence"], deadline: number) => {
+			if (!writer || !reader) throw new Error("GATE0_PERSISTENT_CHILD_FAILURE");
+			writer.write(`${JSON.stringify({ nonce, sequence })}\n`);
+			await waitUntil(Promise.resolve(writer.flush()), deadline, now, cleanupOnTimeout);
+			return waitUntil(readPersistentFrame(reader, buffer, nonce, sequence), deadline, now, cleanupOnTimeout);
+		};
+		const preflight = await send("preflight", operationDeadline);
+		const markers = await runLifecycle("A1", dependencies, abort, operationDeadline, totalDeadline);
+		const postflight = await send("postflight", operationDeadline);
+		await waitUntil(closeWriter(), operationDeadline, now, cleanupOnTimeout);
+		if ((await waitUntil(child.exited, operationDeadline, now, cleanupOnTimeout)) !== 0)
+			throw new Error("GATE0_PERSISTENT_CHILD_FAILURE");
+		exited = true;
+		output = lifecycleResult("A1", "persistent_child", preflight.success ? postflight : preflight, markers);
+	} catch (error) {
+		output = result("A1", { accessibility: false, screenRecording: false }, "persistent_child", {
+			code: errorCode(error),
+		});
+	} finally {
+		if (!(await cleanupChild())) cleanupFailed = true;
+	}
+	return cleanupFailed
+		? result("A1", { accessibility: false, screenRecording: false }, "persistent_child", { code: "internal_error" })
+		: output;
+}
+
+export async function runComputerBrokerGate0(
+	inputJson: string | undefined,
+	dependencies: Gate0Dependencies = {},
+): Promise<Gate0Result> {
+	const input = parseInput(inputJson);
+	if (!input)
+		return result("probe", { accessibility: false, screenRecording: false }, "outer_owner", {
+			code: "invalid_input",
+		});
+	if (input.operation === "lifecycle" && input.phase === "A1") return runA1PersistentLifecycle(dependencies);
+
+	if (input.operation === "lifecycle") {
+		const now = dependencies.now ?? Date.now;
+		const timeoutMs = lifecycleTimeoutMs(dependencies);
+		const totalDeadline = now() + timeoutMs;
+		const operationDeadline = totalDeadline - cleanupReserveMs(timeoutMs);
+		let controller: Gate0NativeController;
+		try {
+			controller = (dependencies.controllerFactory ?? nativeController)();
+		} catch (error) {
+			return result("A2", { accessibility: false, screenRecording: false }, "outer_owner", {
+				code: remainingMs(totalDeadline, now) <= 0 ? "timeout" : errorCode(error),
+			});
+		}
+		if (remainingMs(operationDeadline, now) <= 0)
+			return result("A2", { accessibility: false, screenRecording: false }, "outer_owner", { code: "timeout" });
+		const preflight = await probe(controller, "A2", "outer_owner", false);
+		const abort = new AbortController();
+		try {
+			const markers = await runLifecycle("A2", dependencies, abort, operationDeadline, totalDeadline);
+			if (remainingMs(totalDeadline, now) <= 0) throw new Error("GATE0_TIMEOUT");
+			const postflight = await probe(controller, "A2", "outer_owner", false);
+			if (remainingMs(totalDeadline, now) <= 0) throw new Error("GATE0_TIMEOUT");
+			return lifecycleResult("A2", "outer_owner", preflight.success ? postflight : preflight, markers);
+		} catch (error) {
+			return result("A2", preflight.permission, "outer_owner", { code: errorCode(error) });
+		} finally {
+			abort.abort();
+		}
+	}
+	let controller: Gate0NativeController;
+	try {
+		controller = (dependencies.controllerFactory ?? nativeController)();
+	} catch (error) {
+		return result("probe", { accessibility: false, screenRecording: false }, "outer_owner", {
+			code: errorCode(error),
+		});
+	}
+	return probe(controller, "probe", "outer_owner", input.request === true);
+}
+
+async function runPersistentChild(inputJson: string | undefined): Promise<void> {
+	const input = parsePersistentInput(inputJson);
+	if (!input) {
+		process.exitCode = 1;
+		return;
+	}
+	let controller: Gate0NativeController;
+	try {
+		controller = nativeController();
+	} catch {
+		process.exitCode = 1;
+		return;
+	}
+	const deadline = setTimeout(() => process.exit(1), GATE0_INTERNAL_TIMEOUT_MS);
+	let buffer = "";
+	let expected: PersistentFrame["sequence"] = "preflight";
+	let count = 0;
+	try {
+		for await (const chunk of process.stdin) {
+			buffer += chunk.toString();
+			if (Buffer.byteLength(buffer, "utf8") > GATE0_FRAME_MAX_BYTES)
+				throw new Error("GATE0_PERSISTENT_CHILD_FAILURE");
+			for (;;) {
+				const newline = buffer.indexOf("\n");
+				if (newline === -1) break;
+				const line = buffer.slice(0, newline);
+				if (Buffer.byteLength(line, "utf8") > GATE0_FRAME_MAX_BYTES)
+					throw new Error("GATE0_PERSISTENT_CHILD_FAILURE");
+				buffer = buffer.slice(newline + 1);
+				const command: unknown = JSON.parse(line);
+				if (!command || typeof command !== "object" || Array.isArray(command))
+					throw new Error("GATE0_PERSISTENT_CHILD_FAILURE");
+				const record = command as Record<string, unknown>;
+				if (
+					!exactKeys(record, ["nonce", "sequence"]) ||
+					record.nonce !== input.nonce ||
+					record.sequence !== expected ||
+					count >= 2
+				)
+					throw new Error("GATE0_PERSISTENT_CHILD_FAILURE");
+				const output = await probe(controller, "A1", "persistent_child", false);
+				process.stdout.write(`${JSON.stringify({ nonce: input.nonce, sequence: expected, result: output })}\n`);
+				count++;
+				if (count < 2) expected = "postflight";
+			}
+		}
+		if (count === 2 && buffer.length === 0) return;
+		throw new Error("GATE0_PERSISTENT_CHILD_FAILURE");
+	} catch {
+		process.exitCode = 1;
+	} finally {
+		clearTimeout(deadline);
+	}
+}
+
+export async function runComputerBrokerGate0FromEnvironment(
+	env: NodeJS.ProcessEnv = process.env,
+	dependencies?: Gate0Dependencies,
+): Promise<void> {
+	if (env[GATE0_PERSISTENT_CHILD_ENV] === "1") return runPersistentChild(env[GATE0_INPUT_ENV]);
+	const output = await runComputerBrokerGate0(env[GATE0_INPUT_ENV], dependencies);
+	process.stdout.write(`${JSON.stringify(output)}\n`);
+}

--- a/packages/coding-agent/test/gjc-runtime/computer-broker-gate0-runner.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/computer-broker-gate0-runner.test.ts
@@ -7,10 +7,12 @@ import {
 	acquireExperimentLock,
 	aggregate as aggregateEvidence,
 	canonicalJson,
+	captureHostProcess,
 	codesignSummary,
 	detectedHost,
 	type ExperimentResult,
 	type Gate0Receipt,
+	type HostProcessIdentity,
 	invokeExperiment,
 	loadReceiptSigner,
 	loadRestartProof,
@@ -19,6 +21,9 @@ import {
 	readSourceRevision,
 	releaseArtifact,
 	removeRestartProof,
+	requireRestartedHostProcess,
+	requireRestartProofContinuity,
+	requireStableHostProcess,
 	restartProofFile,
 	restartProofPayload,
 	restartRequestCode,
@@ -117,6 +122,13 @@ function restartProof(overrides: Partial<RestartProof> = {}): RestartProof {
 		codesign: { verified: true, signing: "adhoc" },
 		requestedAt: new Date().toISOString(),
 		request: { attempted: true, code: "permission_pending" },
+		hostProcess: {
+			host: "ghostty",
+			pid: 42,
+			executableSha256: "c".repeat(64),
+			startTokenSha256: "d".repeat(64),
+		},
+
 		...overrides,
 	};
 }
@@ -1046,6 +1058,9 @@ describe("computer broker Gate-0 receipt runner", () => {
 		const proof = restartProof();
 		expect(validRestartProof(proof)).toBe(true);
 		expect(validRestartProof({ ...proof, extra: true })).toBe(false);
+		expect(validRestartProof({ ...proof, hostProcess: { ...proof.hostProcess, rawPath: "/secret" } })).toBe(false);
+		expect(validRestartProof({ ...proof, hostProcess: { host: "ghostty" } })).toBe(false);
+
 		await writeRestartProof(root, proof);
 		expect(await loadRestartProof(root, COLLECTION_ID, proof.cell)).toEqual(proof);
 		await expect(writeRestartProof(root, proof)).rejects.toMatchObject({ code: "EEXIST" });
@@ -1057,7 +1072,7 @@ describe("computer broker Gate-0 receipt runner", () => {
 		await writeRestartProof(tamperedRoot, proof);
 		const file = path.join(tamperedRoot, "request-proofs", restartProofFile(COLLECTION_ID, proof.cell));
 		const tampered = JSON.parse(await fs.readFile(file, "utf8"));
-		tampered.proof.request.code = "ok";
+		tampered.proof.hostProcess.pid = 43;
 		await fs.writeFile(file, `${canonicalJson(tampered)}\n`, { mode: 0o600 });
 		await expect(loadRestartProof(tamperedRoot, COLLECTION_ID, proof.cell)).rejects.toThrow("signature is invalid");
 
@@ -1098,6 +1113,7 @@ describe("computer broker Gate-0 receipt runner", () => {
 		const mismatch = restartProof({
 			collectionId: "gate0-other-collection",
 			cell: { ...expected, host: "terminal" },
+			hostProcess: { ...restartProof().hostProcess, host: "terminal" },
 		});
 		await writeSignedRestartProofAt(mismatchRoot, expected, mismatch);
 		await expect(loadRestartProof(mismatchRoot, COLLECTION_ID, expected)).rejects.toThrow(
@@ -1187,6 +1203,105 @@ describe("computer broker Gate-0 receipt runner", () => {
 				false,
 			),
 		).rejects.toThrow("does not match the run-cell contract");
+	});
+
+	it("captures only hashed direct terminal-host ancestry through an injected ps seam", async () => {
+		const executeFor =
+			(records: Record<number, { ppid: number; executable: string; start: string }>) =>
+			async (command: string[]) => {
+				const record = records[Number(command.at(-1))];
+				if (!record) return { exitCode: 1, stdout: "", stderr: "", timedOut: false };
+				const field = command[2];
+				const stdout =
+					field === "ppid="
+						? `${record.ppid}\n`
+						: field === "comm="
+							? `${record.executable}\n`
+							: field === "lstart="
+								? `${record.start}\n`
+								: "";
+				return { exitCode: stdout ? 0 : 1, stdout, stderr: "", timedOut: false };
+			};
+
+		for (const [host, executable] of [
+			["terminal", `/Applications/${"TerminalBundlePath".repeat(24)}/Terminal.app/Contents/MacOS/Terminal`],
+			["ghostty", "/Applications/Ghostty.app/Contents/MacOS/Ghostty"],
+			["cmux", "/Applications/cmux.app/Contents/MacOS/cmux"],
+		] as const) {
+			const identity = await captureHostProcess(host, {
+				ppid: 100,
+				execute: executeFor({
+					100: { ppid: 50, executable: "/bin/zsh", start: "Tue Jul 17 10:00:00 2026" },
+					50: { ppid: 1, executable, start: "Tue Jul 17 09:00:00 2026" },
+				}),
+			});
+			expect(identity).toEqual({
+				host,
+				pid: 50,
+				executableSha256: createHash("sha256").update(executable).digest("hex"),
+				startTokenSha256: createHash("sha256").update("Tue Jul 17 09:00:00 2026").digest("hex"),
+			});
+		}
+		await expect(
+			captureHostProcess("terminal", {
+				ppid: 100,
+				execute: executeFor({
+					100: { ppid: 1, executable: "/usr/bin/tmux", start: "Tue Jul 17 10:00:00 2026" },
+					1: { ppid: 0, executable: "/sbin/launchd", start: "Tue Jul 17 00:00:00 2026" },
+				}),
+			}),
+		).rejects.toThrow("declared terminal host is not a direct process ancestor");
+	});
+
+	it("requires a stable changed terminal-host process generation for staged continuation", () => {
+		const requested: HostProcessIdentity = {
+			host: "ghostty",
+			pid: 42,
+			executableSha256: "c".repeat(64),
+			startTokenSha256: "d".repeat(64),
+		};
+		expect(() => requireRestartedHostProcess(requested, requested)).toThrow(
+			"does not prove a terminal host process restart",
+		);
+		expect(() =>
+			requireRestartedHostProcess(requested, { ...requested, startTokenSha256: "e".repeat(64) }),
+		).not.toThrow();
+		expect(() => requireRestartedHostProcess(requested, { ...requested, executableSha256: "f".repeat(64) })).toThrow(
+			"does not match the current terminal host executable",
+		);
+		expect(() => requireStableHostProcess(requested, { ...requested, pid: 43 }, "restart request")).toThrow(
+			"terminal host process changed during restart request",
+		);
+		expect(() =>
+			requireStableHostProcess(
+				requested,
+				{ ...requested, startTokenSha256: "e".repeat(64) },
+				"post-restart continuity",
+			),
+		).toThrow("terminal host process changed during post-restart continuity");
+	});
+
+	it("binds a staged proof to the executed baseline continuity snapshot", () => {
+		const proof = restartProof();
+		const continuity = {
+			sourceRevision: REVISION,
+			baseline: { path: "baseline", sha256: BASELINE_SHA },
+			updated: { path: "updated", sha256: UPDATED_SHA },
+			baselineCodesign: { verified: true, signing: "adhoc" as const },
+			updatedCodesign: { verified: true, signing: "adhoc" as const },
+			baselinePair: successfulPair("A1"),
+			updatedPair: successfulPair("A1"),
+		};
+		expect(() => requireRestartProofContinuity(proof, continuity)).not.toThrow();
+		expect(() => requireRestartProofContinuity(proof, { ...continuity, sourceRevision: "f".repeat(40) })).toThrow(
+			"does not match the executed baseline continuity",
+		);
+		expect(() =>
+			requireRestartProofContinuity(proof, {
+				...continuity,
+				baseline: { ...continuity.baseline, sha256: "f".repeat(64) },
+			}),
+		).toThrow("does not match the executed baseline continuity");
 	});
 
 	it("detects the originating terminal through managed tmux markers", () => {

--- a/packages/coding-agent/test/gjc-runtime/computer-broker-gate0-runner.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/computer-broker-gate0-runner.test.ts
@@ -1,0 +1,1031 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { createHash, createPublicKey, generateKeyPairSync, randomBytes, sign } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	acquireExperimentLock,
+	aggregate as aggregateEvidence,
+	canonicalJson,
+	codesignSummary,
+	detectedHost,
+	type ExperimentResult,
+	type Gate0Receipt,
+	invokeExperiment,
+	loadReceiptSigner,
+	readSourceRevision,
+	releaseArtifact,
+	runBoundedCommand,
+	runCellContinuity,
+	runCellExperimentPair,
+} from "../../scripts/computer-broker-live-e2e";
+
+const SCRIPT = path.resolve(import.meta.dir, "../../scripts/computer-broker-live-e2e.ts");
+const roots: string[] = [];
+const REVISION = Bun.spawnSync(["git", "rev-parse", "HEAD"], { stdout: "pipe" }).stdout.toString().trim();
+const BASELINE_SHA = "a".repeat(64);
+const UPDATED_SHA = "b".repeat(64);
+const COLLECTION_ID = "gate0-collection-20260717";
+
+async function evidenceRoot(): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-gate0-runner-"));
+	roots.push(root);
+	await fs.mkdir(path.join(root, "receipts"), { mode: 0o700 });
+	await fs.mkdir(path.join(root, "trusted-signers"), { mode: 0o700 });
+	const pair = generateKeyPairSync("ed25519");
+	const privatePem = pair.privateKey.export({ type: "pkcs8", format: "pem" });
+	const publicPem = pair.publicKey.export({ type: "spki", format: "pem" });
+	const publicDer = createPublicKey(publicPem).export({ type: "spki", format: "der" }) as Buffer;
+	const keyId = createHash("sha256").update(publicDer).digest("hex");
+	await fs.writeFile(path.join(root, "receipt-signing.key"), privatePem, { mode: 0o600 });
+	await fs.writeFile(path.join(root, "receipt-signing.pub.pem"), publicPem, { mode: 0o644 });
+	await fs.writeFile(path.join(root, "trusted-signers", `${keyId}.pem`), publicPem, { mode: 0o644 });
+	return root;
+}
+
+function cell(
+	topology: "A1" | "A2",
+	macos: "14" | "15" | "26",
+	host: "terminal" | "ghostty" | "cmux",
+	timestamps = { startedAt: new Date(Date.now() - 1_000).toISOString(), completedAt: new Date().toISOString() },
+): Gate0Receipt {
+	return {
+		schemaVersion: 1,
+		gate: 0,
+		collectionId: COLLECTION_ID,
+		cell: { topology, macos, host, arch: "arm64" },
+		artifact: {
+			identity: "packages/coding-agent/dist/gjc",
+			sourceRevision: REVISION,
+			baselineSha256: BASELINE_SHA,
+			updatedSha256: UPDATED_SHA,
+		},
+		codesign: {
+			baseline: { verified: true, signing: "adhoc" },
+			updated: { verified: true, signing: "adhoc" },
+			compatible: true,
+		},
+		continuity: { baselineSuccess: true, updatedSuccess: true },
+		timestamps,
+		permissions: { screenRecordingGranted: true, accessibilityGranted: true, requestAttempted: true },
+		ancestry: { kind: topology === "A1" ? "persistent_child" : "outer_owner", bounded: true },
+		lifecycle: { markers: ["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"] },
+		result: { success: true, code: "ok" },
+	};
+}
+
+function experiment(phase: "probe" | "A1" | "A2", success = true): ExperimentResult {
+	return {
+		topology: "gate0",
+		phase,
+		permission: { accessibility: true, screenRecording: true },
+		requestAttempted: false,
+		success,
+		code: success ? "ok" : "probe_failed",
+		ancestry: { kind: phase === "A1" ? "persistent_child" : "outer_owner", bounded: true },
+		lifecycle:
+			phase === "probe" ? [] : ["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"],
+	};
+}
+
+function successfulPair(topology: "A1" | "A2") {
+	return { probe: experiment("probe"), lifecycle: experiment(topology) };
+}
+
+async function writeReceipt(root: string, receipt: Gate0Receipt, signature?: string): Promise<void> {
+	const privateKey = await fs.readFile(path.join(root, "receipt-signing.key"));
+	const publicKey = createPublicKey(await fs.readFile(path.join(root, "receipt-signing.pub.pem")));
+	const keyId = createHash("sha256")
+		.update(publicKey.export({ type: "spki", format: "der" }) as Buffer)
+		.digest("hex");
+	const value = signature ?? sign(null, Buffer.from(canonicalJson(receipt as never)), privateKey).toString("base64");
+	const name = `${receipt.cell.topology}-${receipt.cell.macos}-${receipt.cell.host}-${randomBytes(4).toString("hex")}.json`;
+	await fs.writeFile(
+		path.join(root, "receipts", name),
+		`${canonicalJson({ receipt, signature: { algorithm: "ed25519", keyId, value } } as never)}\n`,
+		{ mode: 0o600 },
+	);
+}
+
+async function seedMatrix(
+	root: string,
+	topology: "A1" | "A2" = "A1",
+	timestamps?: Gate0Receipt["timestamps"],
+): Promise<void> {
+	for (const macos of ["14", "15", "26"] as const) {
+		for (const host of ["terminal", "ghostty", "cmux"] as const)
+			await writeReceipt(root, cell(topology, macos, host, timestamps));
+	}
+}
+
+async function removeCell(
+	root: string,
+	topology: "A1" | "A2",
+	macos: "14" | "15" | "26",
+	host: "terminal" | "ghostty" | "cmux",
+): Promise<void> {
+	const prefix = `${topology}-${macos}-${host}-`;
+	const name = (await fs.readdir(path.join(root, "receipts"))).find(entry => entry.startsWith(prefix));
+	if (!name) throw new Error("fixture receipt is missing");
+	await fs.rm(path.join(root, "receipts", name));
+}
+
+async function aggregate(
+	root: string,
+	topology: "A1" | "A2" = "A1",
+	dependencies: Parameters<typeof aggregateEvidence>[1] = {},
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const previousRoot = process.env.GJC_COMPUTER_GATE0_EVIDENCE_ROOT;
+	const previousCollection = process.env.GJC_COMPUTER_GATE0_COLLECTION_ID;
+	process.env.GJC_COMPUTER_GATE0_EVIDENCE_ROOT = root;
+	process.env.GJC_COMPUTER_GATE0_COLLECTION_ID = COLLECTION_ID;
+	try {
+		await aggregateEvidence(
+			["--gate=0", `--topology=${topology}`, "--macos=14,15,26", "--hosts=terminal,ghostty,cmux", "--require-all"],
+			{
+				execute: async command =>
+					command[1] === "status"
+						? { exitCode: 0, stdout: "?? .gjc/runtime-state\n", stderr: "", timedOut: false }
+						: { exitCode: 0, stdout: REVISION, stderr: "", timedOut: false },
+				...dependencies,
+			},
+		);
+		return { exitCode: 0, stdout: "", stderr: "" };
+	} catch (error) {
+		return { exitCode: 1, stdout: "", stderr: error instanceof Error ? error.message : "gate0: internal error" };
+	} finally {
+		if (previousRoot === undefined) delete process.env.GJC_COMPUTER_GATE0_EVIDENCE_ROOT;
+		else process.env.GJC_COMPUTER_GATE0_EVIDENCE_ROOT = previousRoot;
+		if (previousCollection === undefined) delete process.env.GJC_COMPUTER_GATE0_COLLECTION_ID;
+		else process.env.GJC_COMPUTER_GATE0_COLLECTION_ID = previousCollection;
+	}
+}
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("computer broker Gate-0 receipt runner", () => {
+	for (const topology of ["A1", "A2"] as const) {
+		it(`accepts only a complete, passing, exact nine-cell ${topology} topology matrix`, async () => {
+			const root = await evidenceRoot();
+			await seedMatrix(root, topology);
+			expect((await aggregate(root, topology)).exitCode).toBe(0);
+		});
+
+		it(`rejects missing, duplicate, and wrong-ancestry ${topology} cells`, async () => {
+			const missing = await evidenceRoot();
+			await seedMatrix(missing, topology);
+			await removeCell(missing, topology, "14", "terminal");
+			expect((await aggregate(missing, topology)).exitCode).not.toBe(0);
+
+			const duplicate = await evidenceRoot();
+			await seedMatrix(duplicate, topology);
+			await writeReceipt(duplicate, cell(topology, "14", "terminal"));
+			expect((await aggregate(duplicate, topology)).exitCode).not.toBe(0);
+
+			const wrongAncestry = await evidenceRoot();
+			await seedMatrix(wrongAncestry, topology);
+			await removeCell(wrongAncestry, topology, "14", "terminal");
+			await writeReceipt(wrongAncestry, {
+				...cell(topology, "14", "terminal"),
+				ancestry: { kind: topology === "A1" ? "outer_owner" : "persistent_child", bounded: true },
+			});
+			expect((await aggregate(wrongAncestry, topology)).exitCode).not.toBe(0);
+		});
+	}
+
+	it("accepts cross-cell artifact hashes but rejects invalid cells and continuity hashes", async () => {
+		const crossMachine = await evidenceRoot();
+		await seedMatrix(crossMachine);
+		await removeCell(crossMachine, "A1", "14", "terminal");
+		await writeReceipt(crossMachine, {
+			...cell("A1", "14", "terminal"),
+			artifact: {
+				...cell("A1", "14", "terminal").artifact,
+				baselineSha256: "c".repeat(64),
+				updatedSha256: "d".repeat(64),
+			},
+		});
+		expect((await aggregate(crossMachine)).exitCode).toBe(0);
+
+		for (const mutate of [
+			(receipt: Gate0Receipt) => ({ ...receipt, cell: { ...receipt.cell, macos: "13" as "14" } }),
+			(receipt: Gate0Receipt) => ({ ...receipt, cell: { ...receipt.cell, host: "unknown" as "terminal" } }),
+			(receipt: Gate0Receipt) => ({ ...receipt, cell: { ...receipt.cell, arch: "x64" as "arm64" } }),
+			(receipt: Gate0Receipt) => ({
+				...receipt,
+				artifact: { ...receipt.artifact, updatedSha256: receipt.artifact.baselineSha256 },
+			}),
+			(receipt: Gate0Receipt) => ({
+				...receipt,
+				permissions: { ...receipt.permissions, accessibilityGranted: false },
+			}),
+			(receipt: Gate0Receipt) => ({
+				...receipt,
+				permissions: { ...receipt.permissions, screenRecordingGranted: false },
+			}),
+			(receipt: Gate0Receipt) => ({
+				...receipt,
+				codesign: { ...receipt.codesign, baseline: { verified: true, signing: "other" as const } },
+			}),
+		]) {
+			const root = await evidenceRoot();
+			await seedMatrix(root);
+			await removeCell(root, "A1", "14", "terminal");
+			await writeReceipt(root, mutate(cell("A1", "14", "terminal")));
+			expect((await aggregate(root)).exitCode).not.toBe(0);
+		}
+	});
+
+	it("rejects source-revision mismatch, invalid signatures, and failed cells", async () => {
+		const sourceMismatch = await evidenceRoot();
+		await seedMatrix(sourceMismatch);
+		await removeCell(sourceMismatch, "A1", "14", "terminal");
+		await writeReceipt(sourceMismatch, {
+			...cell("A1", "14", "terminal"),
+			artifact: { ...cell("A1", "14", "terminal").artifact, sourceRevision: "2".repeat(40) },
+		});
+		expect((await aggregate(sourceMismatch)).exitCode).not.toBe(0);
+
+		const unsigned = await evidenceRoot();
+		await seedMatrix(unsigned);
+		await removeCell(unsigned, "A1", "14", "terminal");
+		await writeReceipt(unsigned, cell("A1", "14", "terminal"), "0".repeat(64));
+		expect((await aggregate(unsigned)).exitCode).not.toBe(0);
+
+		const failed = await evidenceRoot();
+		await seedMatrix(failed);
+		await removeCell(failed, "A1", "14", "terminal");
+		await writeReceipt(failed, {
+			...cell("A1", "14", "terminal"),
+			result: { success: false, code: "permission_denied" },
+		});
+		expect((await aggregate(failed)).exitCode).not.toBe(0);
+	});
+
+	it("isolates Ed25519 trust, canonical signature, label, and local signer guards", async () => {
+		const otherKey = await evidenceRoot();
+		await seedMatrix(otherKey);
+		const rsa = generateKeyPairSync("rsa", { modulusLength: 2048 }).publicKey;
+		const rsaDer = rsa.export({ type: "spki", format: "der" }) as Buffer;
+		const rsaId = createHash("sha256").update(rsaDer).digest("hex");
+		const name = (await fs.readdir(path.join(otherKey, "receipts")))[0]!;
+		const receiptPath = path.join(otherKey, "receipts", name);
+		const envelope = JSON.parse(await fs.readFile(receiptPath, "utf8"));
+		envelope.signature.keyId = rsaId;
+		await fs.writeFile(receiptPath, `${JSON.stringify(envelope)}\n`, { mode: 0o600 });
+		await fs.writeFile(
+			path.join(otherKey, "trusted-signers", `${rsaId}.pem`),
+			rsa.export({ type: "spki", format: "pem" }),
+			{
+				mode: 0o644,
+			},
+		);
+		expect((await aggregate(otherKey)).stderr).toBe("gate0: trusted signer key must be Ed25519");
+
+		const nonCanonical = await evidenceRoot();
+		await seedMatrix(nonCanonical);
+		const nonCanonicalName = (await fs.readdir(path.join(nonCanonical, "receipts")))[0]!;
+		const nonCanonicalPath = path.join(nonCanonical, "receipts", nonCanonicalName);
+		const nonCanonicalEnvelope = JSON.parse(await fs.readFile(nonCanonicalPath, "utf8"));
+		const canonicalSignature = nonCanonicalEnvelope.signature.value;
+		const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+		const lastDataIndex = nonCanonicalEnvelope.signature.value.length - 3;
+		const original = nonCanonicalEnvelope.signature.value[lastDataIndex]!;
+		nonCanonicalEnvelope.signature.value = `${nonCanonicalEnvelope.signature.value.slice(0, lastDataIndex)}${alphabet[alphabet.indexOf(original) ^ 1]}==`;
+		expect(
+			Buffer.from(nonCanonicalEnvelope.signature.value, "base64").equals(Buffer.from(canonicalSignature, "base64")),
+		).toBe(true);
+		await fs.writeFile(nonCanonicalPath, `${JSON.stringify(nonCanonicalEnvelope)}\n`, { mode: 0o600 });
+		expect((await aggregate(nonCanonical)).stderr).toBe("gate0: receipt signature is invalid");
+
+		const wrongLabel = await evidenceRoot();
+		await seedMatrix(wrongLabel);
+		const wrongLabelName = (await fs.readdir(path.join(wrongLabel, "receipts")))[0]!;
+		const wrongLabelPath = path.join(wrongLabel, "receipts", wrongLabelName);
+		const wrongLabelEnvelope = JSON.parse(await fs.readFile(wrongLabelPath, "utf8"));
+		wrongLabelEnvelope.signature.algorithm = "rsa";
+		await fs.writeFile(wrongLabelPath, `${JSON.stringify(wrongLabelEnvelope)}\n`, { mode: 0o600 });
+		expect((await aggregate(wrongLabel)).stderr).toBe("gate0: receipt is malformed");
+
+		const nonEdSigner = await evidenceRoot();
+		const rsaPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+		await fs.writeFile(
+			path.join(nonEdSigner, "receipt-signing.key"),
+			rsaPair.privateKey.export({ type: "pkcs8", format: "pem" }),
+			{
+				mode: 0o600,
+			},
+		);
+		await fs.writeFile(
+			path.join(nonEdSigner, "receipt-signing.pub.pem"),
+			rsaPair.publicKey.export({ type: "spki", format: "pem" }),
+			{
+				mode: 0o644,
+			},
+		);
+		await expect(loadReceiptSigner(nonEdSigner)).rejects.toThrow("receipt signer keys must be Ed25519");
+
+		const mismatchedSigner = await evidenceRoot();
+		const first = generateKeyPairSync("ed25519");
+		const second = generateKeyPairSync("ed25519");
+		await fs.writeFile(
+			path.join(mismatchedSigner, "receipt-signing.key"),
+			first.privateKey.export({ type: "pkcs8", format: "pem" }),
+			{
+				mode: 0o600,
+			},
+		);
+		await fs.writeFile(
+			path.join(mismatchedSigner, "receipt-signing.pub.pem"),
+			second.publicKey.export({ type: "spki", format: "pem" }),
+			{
+				mode: 0o644,
+			},
+		);
+		await expect(loadReceiptSigner(mismatchedSigner)).rejects.toThrow("receipt signer key pair does not match");
+	});
+
+	it("rejects untrusted signers, collection replay, and extra signed-envelope keys", async () => {
+		const untrusted = await evidenceRoot();
+		await seedMatrix(untrusted);
+		await fs.rm(path.join(untrusted, "trusted-signers"), { recursive: true });
+		await fs.mkdir(path.join(untrusted, "trusted-signers"), { mode: 0o700 });
+		expect((await aggregate(untrusted)).exitCode).not.toBe(0);
+
+		const replay = await evidenceRoot();
+		await seedMatrix(replay);
+		await removeCell(replay, "A1", "14", "terminal");
+		await writeReceipt(replay, { ...cell("A1", "14", "terminal"), collectionId: "another-collection-20260717" });
+		expect((await aggregate(replay)).exitCode).not.toBe(0);
+
+		const extraEnvelope = await evidenceRoot();
+		await seedMatrix(extraEnvelope);
+		const name = (await fs.readdir(path.join(extraEnvelope, "receipts")))[0]!;
+		const receiptPath = path.join(extraEnvelope, "receipts", name);
+		const envelope = JSON.parse(await fs.readFile(receiptPath, "utf8"));
+		envelope.untrusted = true;
+		await fs.writeFile(receiptPath, `${JSON.stringify(envelope)}\n`, { mode: 0o600 });
+		expect((await aggregate(extraEnvelope)).exitCode).not.toBe(0);
+	});
+
+	it("accepts independently signed machine receipts only after public-key trust import", async () => {
+		const aggregateRoot = await evidenceRoot();
+		await seedMatrix(aggregateRoot);
+		await removeCell(aggregateRoot, "A1", "14", "terminal");
+
+		const contributorRoot = await evidenceRoot();
+		await writeReceipt(contributorRoot, cell("A1", "14", "terminal"));
+		const contributorReceipt = (await fs.readdir(path.join(contributorRoot, "receipts")))[0]!;
+		const publicPem = await fs.readFile(path.join(contributorRoot, "receipt-signing.pub.pem"));
+		const publicDer = createPublicKey(publicPem).export({ type: "spki", format: "der" }) as Buffer;
+		const contributorId = createHash("sha256").update(publicDer).digest("hex");
+		await fs.copyFile(
+			path.join(contributorRoot, "receipts", contributorReceipt),
+			path.join(aggregateRoot, "receipts", contributorReceipt),
+		);
+		await fs.copyFile(
+			path.join(contributorRoot, "receipt-signing.pub.pem"),
+			path.join(aggregateRoot, "trusted-signers", `${contributorId}.pem`),
+		);
+		expect((await aggregate(aggregateRoot)).exitCode).toBe(0);
+	});
+
+	it("rejects symlinked receipt evidence paths", async () => {
+		const root = await evidenceRoot();
+		await seedMatrix(root);
+		const name = (await fs.readdir(path.join(root, "receipts")))[0]!;
+		const target = path.join(root, "receipts", name);
+		const link = path.join(root, "receipts", "linked.json");
+		await fs.symlink(target, link);
+		expect((await aggregate(root)).exitCode).not.toBe(0);
+	});
+
+	it("rejects symlinked trusted signer files", async () => {
+		const root = await evidenceRoot();
+		await seedMatrix(root);
+		const trusted = (await fs.readdir(path.join(root, "trusted-signers")))[0]!;
+		await fs.rm(path.join(root, "trusted-signers", trusted));
+		await fs.symlink(path.join(root, "receipt-signing.pub.pem"), path.join(root, "trusted-signers", trusted));
+		expect((await aggregate(root)).exitCode).not.toBe(0);
+	});
+
+	it("stores only the redacted receipt contract", () => {
+		const receipt = cell("A1", "14", "terminal");
+		const serialized = canonicalJson(receipt as never);
+		expect(Object.keys(receipt).sort()).toEqual([
+			"ancestry",
+			"artifact",
+			"cell",
+			"codesign",
+			"collectionId",
+			"continuity",
+			"gate",
+			"lifecycle",
+			"permissions",
+			"result",
+			"schemaVersion",
+			"timestamps",
+		]);
+		expect(serialized).not.toContain("screenshot");
+		expect(serialized).not.toContain("coordinate");
+		expect(serialized).not.toContain("prompt");
+		expect(serialized).not.toContain("secret");
+		expect(serialized).not.toContain("/Users/");
+	});
+
+	it("redacts absolute paths and sentinel secrets at the CLI error boundary", async () => {
+		const sentinelRoot = "/dev/null/SENTINEL_SECRET_gate0_absolute_path";
+		const proc = Bun.spawn(
+			[
+				process.execPath,
+				SCRIPT,
+				"aggregate",
+				"--gate=0",
+				"--topology=A1",
+				"--macos=14,15,26",
+				"--hosts=terminal,ghostty,cmux",
+				"--require-all",
+			],
+			{
+				env: {
+					...process.env,
+					GJC_COMPUTER_GATE0_EVIDENCE_ROOT: sentinelRoot,
+					GJC_COMPUTER_GATE0_COLLECTION_ID: COLLECTION_ID,
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		expect(exitCode).not.toBe(0);
+		expect(stdout).toBe("");
+		expect(stderr).toBe("gate0: internal error\n");
+		expect(stderr).not.toContain("SENTINEL_SECRET");
+		expect(stderr).not.toContain(sentinelRoot);
+	});
+
+	it("parses only one valid redacted hidden-result line and rejects every other child outcome", async () => {
+		const encoded = (value: string) =>
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode(value));
+					controller.close();
+				},
+			});
+		const cases: Array<{ name: string; stdout: ReadableStream<Uint8Array>; exitCode: number; expected?: string }> = [
+			{ name: "valid", stdout: encoded(`${JSON.stringify(experiment("probe"))}\n`), exitCode: 0 },
+			{
+				name: "malformed JSON",
+				stdout: encoded("{\n"),
+				exitCode: 0,
+				expected: "gate0: hidden experiment result is not JSON",
+			},
+			{
+				name: "extra record",
+				stdout: encoded("{}\n{}\n"),
+				exitCode: 0,
+				expected: "gate0: hidden experiment must emit exactly one JSON result",
+			},
+			{
+				name: "leading blank line",
+				stdout: encoded(`\n${JSON.stringify(experiment("probe"))}\n`),
+				exitCode: 0,
+				expected: "gate0: hidden experiment must emit exactly one JSON result",
+			},
+			{
+				name: "trailing blank line",
+				stdout: encoded(`${JSON.stringify(experiment("probe"))}\n\n`),
+				exitCode: 0,
+				expected: "gate0: hidden experiment must emit exactly one JSON result",
+			},
+			{
+				name: "whitespace-only extra line",
+				stdout: encoded(`${JSON.stringify(experiment("probe"))}\n \n`),
+				exitCode: 0,
+				expected: "gate0: hidden experiment must emit exactly one JSON result",
+			},
+			{
+				name: "invalid schema",
+				stdout: encoded("{}\n"),
+				exitCode: 0,
+				expected: "gate0: hidden experiment returned an invalid Gate-0 result",
+			},
+			{
+				name: "nonzero exit",
+				stdout: encoded(`${JSON.stringify(experiment("probe"))}\n`),
+				exitCode: 1,
+				expected: "gate0: hidden experiment exited unsuccessfully",
+			},
+			{
+				name: "stream rejection",
+				stdout: new ReadableStream<Uint8Array>({
+					start: controller => controller.error(new Error("SENTINEL_SECRET")),
+				}),
+				exitCode: 0,
+				expected: "gate0: hidden experiment exited unsuccessfully",
+			},
+		];
+		for (const testCase of cases) {
+			const result = invokeExperiment("unused", { operation: "probe" }, () => ({
+				stdout: testCase.stdout,
+				exited: Promise.resolve(testCase.exitCode),
+				kill: () => {},
+			}));
+			if (!testCase.expected) await expect(result).resolves.toMatchObject({ phase: "probe", success: true });
+			else await expect(result).rejects.toThrow(testCase.expected);
+		}
+	});
+
+	it("cleans up a live child after hidden stdout fails", async () => {
+		const exited = Promise.withResolvers<number>();
+		const signals: string[] = [];
+		await expect(
+			invokeExperiment(
+				"unused",
+				{ operation: "probe" },
+				() => ({
+					stdout: new ReadableStream<Uint8Array>({
+						start: controller => controller.error(new Error("SENTINEL_SECRET")),
+					}),
+					exited: exited.promise,
+					kill: signal => {
+						signals.push(signal);
+						if (signal === "SIGKILL") exited.resolve(-1);
+					},
+				}),
+				100,
+			),
+		).rejects.toThrow("gate0: hidden experiment exited unsuccessfully");
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+	});
+
+	it("fails closed when hidden stdout rejection cannot confirm child exit", async () => {
+		const signals: string[] = [];
+		await expect(
+			invokeExperiment(
+				"unused",
+				{ operation: "probe" },
+				() => ({
+					stdout: new ReadableStream<Uint8Array>({
+						start: controller => controller.error(new Error("SENTINEL_SECRET")),
+					}),
+					exited: new Promise<number>(() => {}),
+					kill: signal => signals.push(signal),
+				}),
+				100,
+			),
+		).rejects.toThrow("gate0: timed-out child cleanup failed");
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+	});
+
+	it("returns a timeout only after TERM/SIGKILL cleanup confirms exit", async () => {
+		const exited = Promise.withResolvers<number>();
+		const signals: string[] = [];
+		const result = await invokeExperiment(
+			"unused",
+			{ operation: "lifecycle", phase: "A1" },
+			() => ({
+				stdout: new ReadableStream<Uint8Array>(),
+				exited: exited.promise,
+				kill: signal => {
+					signals.push(signal);
+					if (signal === "SIGKILL") exited.resolve(-1);
+				},
+			}),
+			100,
+		);
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(result).toMatchObject({ phase: "A1", success: false, code: "timeout" });
+	});
+
+	it("rejects timed-out experiments when exit cannot be confirmed", async () => {
+		const signals: string[] = [];
+		await expect(
+			invokeExperiment(
+				"unused",
+				{ operation: "probe" },
+				() => ({
+					stdout: new ReadableStream<Uint8Array>(),
+					exited: new Promise<number>(() => {}),
+					kill: signal => signals.push(signal),
+				}),
+				100,
+			),
+		).rejects.toThrow(/^gate0: timed-out child cleanup failed$/);
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+	});
+
+	it("rejects timed-out experiments when child termination throws", async () => {
+		const signals: string[] = [];
+		await expect(
+			invokeExperiment(
+				"unused",
+				{ operation: "probe" },
+				() => ({
+					stdout: new ReadableStream<Uint8Array>(),
+					exited: new Promise<number>(() => {}),
+					kill: signal => {
+						signals.push(signal);
+						throw new Error("private child output");
+					},
+				}),
+				100,
+			),
+		).rejects.toThrow(/^gate0: timed-out child cleanup failed$/);
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+	});
+
+	it("requires codesign verification as well as display metadata", async () => {
+		const displayOnly = await codesignSummary("unused", async command => ({
+			exitCode: command[1] === "--verify" ? 1 : 0,
+			stdout: "Signature=adhoc",
+			stderr: "",
+			timedOut: false,
+		}));
+		expect(displayOnly).toEqual({ verified: false, signing: "unavailable" });
+
+		const verified = await codesignSummary("unused", async () => ({
+			exitCode: 0,
+			stdout: "Signature=adhoc",
+			stderr: "",
+			timedOut: false,
+		}));
+		expect(verified).toEqual({ verified: true, signing: "adhoc" });
+	});
+
+	it("kills and awaits a bounded command before returning timeout", async () => {
+		const started = Date.now();
+		const result = await runBoundedCommand([process.execPath, "-e", "await Bun.sleep(10_000)"], undefined, 20);
+		expect(result.timedOut).toBe(true);
+		expect(Date.now() - started).toBeLessThan(1_000);
+	});
+
+	it("cleans up a live child after stdout rejection before returning a synthetic command failure", async () => {
+		const exited = Promise.withResolvers<number>();
+		const signals: string[] = [];
+		const result = await runBoundedCommand(["unused"], undefined, 50, () => ({
+			stdout: new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.error(new Error("private stdout"));
+				},
+			}),
+			stderr: new ReadableStream<Uint8Array>(),
+			exited: exited.promise,
+			kill: signal => {
+				signals.push(signal);
+				if (signal === "SIGKILL") exited.resolve(23);
+			},
+		}));
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(result).toEqual({ exitCode: -1, stdout: "", stderr: "", timedOut: false });
+	});
+
+	it("cleans up a live child after stderr rejection before returning a synthetic command failure", async () => {
+		const exited = Promise.withResolvers<number>();
+		const signals: string[] = [];
+		const result = await runBoundedCommand(["unused"], undefined, 50, () => ({
+			stdout: new ReadableStream<Uint8Array>(),
+			stderr: new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.error(new Error("private stderr"));
+				},
+			}),
+			exited: exited.promise,
+			kill: signal => {
+				signals.push(signal);
+				if (signal === "SIGKILL") exited.resolve(29);
+			},
+		}));
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(result).toEqual({ exitCode: -1, stdout: "", stderr: "", timedOut: false });
+	});
+
+	it("redacts live-child stream rejection when cleanup cannot confirm exit", async () => {
+		const signals: string[] = [];
+		const result = runBoundedCommand(["unused"], undefined, 50, () => ({
+			stdout: new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.error(new Error("private child output"));
+				},
+			}),
+			stderr: new ReadableStream<Uint8Array>(),
+			exited: new Promise<number>(() => {}),
+			kill: signal => signals.push(signal),
+		}));
+		let failure: unknown;
+		try {
+			await result;
+		} catch (error) {
+			failure = error;
+		}
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(failure).toBeInstanceOf(Error);
+		expect((failure as Error).message).toBe("gate0: timed-out child cleanup failed");
+	});
+
+	it("falls back to SIGKILL when SIGTERM throws during stream-rejection cleanup", async () => {
+		const exited = Promise.withResolvers<number>();
+		const signals: string[] = [];
+		const result = await runBoundedCommand(["unused"], undefined, 50, () => ({
+			stdout: new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.error(new Error("private child output"));
+				},
+			}),
+			stderr: new ReadableStream<Uint8Array>(),
+			exited: exited.promise,
+			kill: signal => {
+				signals.push(signal);
+				if (signal === "SIGTERM") throw new Error("private kill failure");
+				exited.resolve(31);
+			},
+		}));
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(result).toEqual({ exitCode: -1, stdout: "", stderr: "", timedOut: false });
+	});
+
+	it("rejects unchanged update hashes and baseline or post-update failures at the continuity seam", async () => {
+		const common = {
+			build: async () => {},
+			readArtifact: async () => ({ path: "updated", sha256: UPDATED_SHA }),
+			codesign: async () => ({ verified: true as const, signing: "adhoc" as const }),
+			sourceRevision: async () => REVISION,
+		};
+		await expect(
+			runCellContinuity({ path: "baseline", sha256: BASELINE_SHA }, "A1", {
+				...common,
+				readArtifact: async () => ({ path: "updated", sha256: BASELINE_SHA }),
+				runPair: async () => successfulPair("A1"),
+			}),
+		).rejects.toThrow("rebuilt release artifact did not change");
+		await expect(
+			runCellContinuity({ path: "baseline", sha256: BASELINE_SHA }, "A1", {
+				...common,
+				codesign: async () => ({ verified: true, signing: "other" }),
+				runPair: async () => successfulPair("A1"),
+			}),
+		).rejects.toThrow("verified ad-hoc signature");
+		await expect(
+			runCellContinuity({ path: "baseline", sha256: BASELINE_SHA }, "A1", {
+				...common,
+				runPair: async () => ({ ...successfulPair("A1"), probe: experiment("probe", false) }),
+			}),
+		).rejects.toThrow("baseline hidden experiment failed");
+		let calls = 0;
+		await expect(
+			runCellContinuity({ path: "baseline", sha256: BASELINE_SHA }, "A1", {
+				...common,
+				runPair: async () => {
+					calls += 1;
+					return calls === 1
+						? successfulPair("A1")
+						: { ...successfulPair("A1"), lifecycle: experiment("A1", false) };
+				},
+			}),
+		).rejects.toThrow("updated hidden experiment failed");
+	});
+
+	it("accepts one pending baseline request when the later lifecycle proves the grant", async () => {
+		let calls = 0;
+		const pending = experiment("probe", false);
+		pending.code = "permission_pending";
+		pending.requestAttempted = true;
+		const result = await runCellContinuity({ path: "baseline", sha256: BASELINE_SHA }, "A2", {
+			build: async () => {},
+			readArtifact: async () => ({ path: "updated", sha256: UPDATED_SHA }),
+			codesign: async () => ({ verified: true, signing: "adhoc" }),
+			sourceRevision: async () => REVISION,
+			runPair: async () => (++calls === 1 ? { probe: pending, lifecycle: experiment("A2") } : successfulPair("A2")),
+		});
+		expect(result.baselinePair.probe.code).toBe("permission_pending");
+		expect(result.updatedPair.probe.requestAttempted).toBe(false);
+	});
+
+	it("rejects dirty source inputs while allowing only Ultragoal state", async () => {
+		const commandResult = (stdout: string) => ({ exitCode: 0, stdout, stderr: "", timedOut: false });
+		await expect(
+			readSourceRevision(async command =>
+				command[1] === "status"
+					? commandResult("?? packages/coding-agent/src/untracked.ts\n")
+					: commandResult(REVISION),
+			),
+		).rejects.toThrow("source changes must be committed");
+		await expect(
+			readSourceRevision(async command =>
+				command[1] === "status" ? commandResult("?? .gjc/runtime-state\n") : commandResult(REVISION),
+			),
+		).resolves.toBe(REVISION);
+	});
+
+	it("uses the default clean-source reader before and immediately before aggregate success", async () => {
+		const root = await evidenceRoot();
+		await seedMatrix(root);
+		const commandResult = (stdout: string) => ({ exitCode: 0, stdout, stderr: "", timedOut: false });
+		const dirty = await aggregate(root, "A1", {
+			execute: async command =>
+				command[1] === "status"
+					? commandResult("?? packages/coding-agent/src/untracked.ts\n")
+					: commandResult(REVISION),
+		});
+		expect(dirty).toMatchObject({
+			exitCode: 1,
+			stderr: "gate0: source changes must be committed before recording Gate-0 evidence",
+		});
+
+		let statusCalls = 0;
+		const finalDirty = await aggregate(root, "A1", {
+			execute: async command => {
+				if (command[1] !== "status") return commandResult(REVISION);
+				return commandResult(
+					statusCalls++ === 0 ? "?? .gjc/runtime-state\n" : " M packages/coding-agent/src/runtime.ts\n",
+				);
+			},
+		});
+		expect(finalDirty).toMatchObject({
+			exitCode: 1,
+			stderr: "gate0: source changes must be committed before recording Gate-0 evidence",
+		});
+
+		let revisionCalls = 0;
+		const revisionChanged = await aggregate(root, "A1", {
+			execute: async command =>
+				command[1] === "status"
+					? commandResult("?? .gjc/runtime-state\n")
+					: commandResult(revisionCalls++ === 0 ? REVISION : "f".repeat(40)),
+		});
+		expect(revisionChanged).toMatchObject({
+			exitCode: 1,
+			stderr: "gate0: source revision changed during aggregation",
+		});
+
+		const calls: string[] = [];
+		const clean = await aggregate(root, "A1", {
+			execute: async command => {
+				calls.push(command[1]!);
+				return commandResult(command[1] === "status" ? "?? .gjc/runtime-state\n" : REVISION);
+			},
+		});
+		expect(clean).toMatchObject({ exitCode: 0 });
+		expect(calls).toEqual(["status", "rev-parse", "status", "rev-parse"]);
+	});
+
+	it("enforces independently signed receipt timestamp boundaries", async () => {
+		const now = Date.parse("2026-07-17T12:00:00.000Z");
+		for (const [name, timestamps, accepted] of [
+			["reversed", { startedAt: new Date(now).toISOString(), completedAt: new Date(now - 1).toISOString() }, false],
+			[
+				"stale",
+				{
+					startedAt: new Date(now - 30 * 24 * 60 * 60_000 - 1).toISOString(),
+					completedAt: new Date(now).toISOString(),
+				},
+				false,
+			],
+			[
+				"future",
+				{ startedAt: new Date(now + 60_001).toISOString(), completedAt: new Date(now + 60_001).toISOString() },
+				false,
+			],
+			[
+				"completed future",
+				{ startedAt: new Date(now).toISOString(), completedAt: new Date(now + 60_001).toISOString() },
+				false,
+			],
+			[
+				"window edge",
+				{
+					startedAt: new Date(now - 30 * 24 * 60 * 60_000).toISOString(),
+					completedAt: new Date(now).toISOString(),
+				},
+				true,
+			],
+			[
+				"skew edge",
+				{ startedAt: new Date(now + 60_000).toISOString(), completedAt: new Date(now + 60_000).toISOString() },
+				true,
+			],
+			[
+				"completed skew edge",
+				{ startedAt: new Date(now).toISOString(), completedAt: new Date(now + 60_000).toISOString() },
+				true,
+			],
+		] as const) {
+			const root = await evidenceRoot();
+			await seedMatrix(root, "A1", timestamps);
+			expect((await aggregate(root, "A1", { now: () => now })).exitCode, name).toBe(accepted ? 0 : 1);
+		}
+	});
+
+	it("admits the literal default release artifact path through injected file checks", async () => {
+		const artifact = path.resolve("packages/coding-agent/dist/gjc");
+		const stats = { isSymbolicLink: () => false, isFile: () => true, mode: 0o700 } as never;
+		await expect(
+			releaseArtifact(artifact, { lstat: async () => stats, hash: async () => "c".repeat(64) }),
+		).resolves.toEqual({
+			path: artifact,
+			sha256: "c".repeat(64),
+		});
+		await expect(
+			releaseArtifact(path.resolve("packages/coding-agent/dist/gjc-adjacent"), { lstat: async () => stats }),
+		).rejects.toThrow("--artifact must be packages/coding-agent/dist/gjc");
+	});
+	it("admits only the exact non-symlink executable release artifact and hashes its bytes", async () => {
+		const root = await evidenceRoot();
+		const artifact = path.join(root, "gjc");
+		await fs.writeFile(artifact, "release bytes", { mode: 0o700 });
+		const expectedSha = createHash("sha256").update("release bytes").digest("hex");
+		await expect(releaseArtifact(path.join(root, "wrong"), { expectedPath: artifact })).rejects.toThrow(
+			"--artifact must be",
+		);
+		await expect(
+			releaseArtifact(path.join(root, "missing"), { expectedPath: path.join(root, "missing") }),
+		).rejects.toThrow("non-symlink executable");
+		const link = path.join(root, "linked-gjc");
+		await fs.symlink(artifact, link);
+		await expect(releaseArtifact(link, { expectedPath: link })).rejects.toThrow("non-symlink executable");
+		await fs.chmod(artifact, 0o600);
+		await expect(releaseArtifact(artifact, { expectedPath: artifact })).rejects.toThrow("non-symlink executable");
+		await fs.chmod(artifact, 0o700);
+		await expect(releaseArtifact(artifact, { expectedPath: artifact })).resolves.toEqual({
+			path: artifact,
+			sha256: expectedSha,
+		});
+	});
+
+	it("never reaps a live experiment lock and safely reaps a proven-dead owner", async () => {
+		const root = await evidenceRoot();
+		const lock = path.join(root, "experiment.lock");
+		for (const createdAt of [Date.now(), Date.now() - 60 * 60_000]) {
+			await fs.writeFile(lock, JSON.stringify({ pid: process.pid, createdAt, token: "a".repeat(48) }), {
+				mode: 0o600,
+			});
+			await expect(acquireExperimentLock(root)).rejects.toThrow("already running");
+		}
+		await fs.writeFile(
+			lock,
+			JSON.stringify({ pid: 2_147_483_647, createdAt: Date.now() - 60 * 60_000, token: "b".repeat(48) }),
+			{ mode: 0o600 },
+		);
+		const release = await acquireExperimentLock(root);
+		await release();
+		await expect(fs.lstat(lock)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("uses exactly one permission request across baseline and updated continuity", async () => {
+		const requests: boolean[] = [];
+		await runCellContinuity({ path: "baseline", sha256: BASELINE_SHA }, "A1", {
+			build: async () => {},
+			readArtifact: async () => ({ path: "updated", sha256: UPDATED_SHA }),
+			codesign: async () => ({ verified: true, signing: "adhoc" }),
+			sourceRevision: async () => REVISION,
+			runPair: async (_artifact, _topology, _invoke, request) => {
+				requests.push(request === true);
+				return successfulPair("A1");
+			},
+		});
+		expect(requests).toEqual([true, false]);
+
+		let revisions = 0;
+		await expect(
+			runCellContinuity({ path: "baseline", sha256: BASELINE_SHA }, "A1", {
+				build: async () => {},
+				readArtifact: async () => ({ path: "updated", sha256: UPDATED_SHA }),
+				codesign: async () => ({ verified: true, signing: "adhoc" }),
+				sourceRevision: async () => (revisions++ === 0 ? REVISION : "f".repeat(40)),
+				runPair: async () => successfulPair("A1"),
+			}),
+		).rejects.toThrow("source revision changed during rebuild");
+	});
+
+	it("uses the hidden Gate-0 result schema at the run-cell invocation seam", async () => {
+		const pair = await runCellExperimentPair("unused", "A1", async (_artifact, input) =>
+			(input as { operation?: unknown }).operation === "probe" ? experiment("probe") : experiment("A1"),
+		);
+		expect(pair.lifecycle.ancestry.kind).toBe("persistent_child");
+		const unexpectedRequest = experiment("probe");
+		unexpectedRequest.requestAttempted = true;
+		await expect(
+			runCellExperimentPair(
+				"unused",
+				"A1",
+				async (_artifact, input) =>
+					(input as { operation?: unknown }).operation === "probe" ? unexpectedRequest : experiment("A1"),
+				false,
+			),
+		).rejects.toThrow("does not match the run-cell contract");
+	});
+
+	it("detects the originating terminal through managed tmux markers", () => {
+		expect(detectedHost({ TERM_PROGRAM: "tmux", CMUX_BUNDLE_ID: "com.cmuxterm.app" })).toBe("cmux");
+		expect(detectedHost({ TERM_PROGRAM: "tmux", GHOSTTY_RESOURCES_DIR: "/Applications/Ghostty.app" })).toBe(
+			"ghostty",
+		);
+		expect(detectedHost({ TERM_PROGRAM: "Apple_Terminal" })).toBe("terminal");
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/computer-broker-gate0-runner.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/computer-broker-gate0-runner.test.ts
@@ -13,11 +13,20 @@ import {
 	type Gate0Receipt,
 	invokeExperiment,
 	loadReceiptSigner,
+	loadRestartProof,
+	persistReceiptAndConsumeProof,
+	type RestartProof,
 	readSourceRevision,
 	releaseArtifact,
+	removeRestartProof,
+	restartProofFile,
+	restartProofPayload,
+	restartRequestCode,
 	runBoundedCommand,
 	runCellContinuity,
 	runCellExperimentPair,
+	validRestartProof,
+	writeRestartProof,
 } from "../../scripts/computer-broker-live-e2e";
 
 const SCRIPT = path.resolve(import.meta.dir, "../../scripts/computer-broker-live-e2e.ts");
@@ -31,6 +40,7 @@ async function evidenceRoot(): Promise<string> {
 	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-gate0-runner-"));
 	roots.push(root);
 	await fs.mkdir(path.join(root, "receipts"), { mode: 0o700 });
+	await fs.mkdir(path.join(root, "request-proofs"), { mode: 0o700 });
 	await fs.mkdir(path.join(root, "trusted-signers"), { mode: 0o700 });
 	const pair = generateKeyPairSync("ed25519");
 	const privatePem = pair.privateKey.export({ type: "pkcs8", format: "pem" });
@@ -90,6 +100,44 @@ function experiment(phase: "probe" | "A1" | "A2", success = true): ExperimentRes
 
 function successfulPair(topology: "A1" | "A2") {
 	return { probe: experiment("probe"), lifecycle: experiment(topology) };
+}
+
+function restartProof(overrides: Partial<RestartProof> = {}): RestartProof {
+	return {
+		schemaVersion: 1,
+		kind: "screen-recording-restart-request",
+		gate: 0,
+		collectionId: COLLECTION_ID,
+		cell: { topology: "A1", macos: "26", host: "ghostty", arch: "arm64" },
+		artifact: {
+			identity: "packages/coding-agent/dist/gjc",
+			sourceRevision: REVISION,
+			sha256: BASELINE_SHA,
+		},
+		codesign: { verified: true, signing: "adhoc" },
+		requestedAt: new Date().toISOString(),
+		request: { attempted: true, code: "permission_pending" },
+		...overrides,
+	};
+}
+
+async function writeSignedRestartProofAt(
+	root: string,
+	expectedCell: RestartProof["cell"],
+	proof: RestartProof,
+): Promise<void> {
+	const privateKey = await fs.readFile(path.join(root, "receipt-signing.key"));
+	const publicKey = createPublicKey(await fs.readFile(path.join(root, "receipt-signing.pub.pem")));
+	const keyId = createHash("sha256")
+		.update(publicKey.export({ type: "spki", format: "der" }) as Buffer)
+		.digest("hex");
+	const value = sign(null, restartProofPayload(proof), privateKey).toString("base64");
+	const target = path.join(root, "request-proofs", restartProofFile(COLLECTION_ID, expectedCell));
+	await fs.writeFile(
+		target,
+		`${canonicalJson({ proof, signature: { algorithm: "ed25519", keyId, value } } as never)}\n`,
+		{ mode: 0o600 },
+	);
 }
 
 async function writeReceipt(root: string, receipt: Gate0Receipt, signature?: string): Promise<void> {
@@ -975,6 +1023,126 @@ describe("computer broker Gate-0 receipt runner", () => {
 		const release = await acquireExperimentLock(root);
 		await release();
 		await expect(fs.lstat(lock)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("accepts only explicit pending or granted restart request results", () => {
+		const pending = experiment("probe", false);
+		pending.requestAttempted = true;
+		pending.code = "permission_pending";
+		pending.permission.screenRecording = false;
+		expect(restartRequestCode(pending)).toBe("permission_pending");
+
+		const granted = experiment("probe");
+		granted.requestAttempted = true;
+		expect(restartRequestCode(granted)).toBe("ok");
+
+		expect(() => restartRequestCode(experiment("probe"))).toThrow("restart request contract");
+		pending.permission.screenRecording = true;
+		expect(() => restartRequestCode(pending)).toThrow("restart request contract");
+	});
+
+	it("roundtrips an exact signed restart proof and refuses overwrite", async () => {
+		const root = await evidenceRoot();
+		const proof = restartProof();
+		expect(validRestartProof(proof)).toBe(true);
+		expect(validRestartProof({ ...proof, extra: true })).toBe(false);
+		await writeRestartProof(root, proof);
+		expect(await loadRestartProof(root, COLLECTION_ID, proof.cell)).toEqual(proof);
+		await expect(writeRestartProof(root, proof)).rejects.toMatchObject({ code: "EEXIST" });
+	});
+
+	it("rejects tampered, noncanonical, and untrusted restart proofs", async () => {
+		const tamperedRoot = await evidenceRoot();
+		const proof = restartProof();
+		await writeRestartProof(tamperedRoot, proof);
+		const file = path.join(tamperedRoot, "request-proofs", restartProofFile(COLLECTION_ID, proof.cell));
+		const tampered = JSON.parse(await fs.readFile(file, "utf8"));
+		tampered.proof.request.code = "ok";
+		await fs.writeFile(file, `${canonicalJson(tampered)}\n`, { mode: 0o600 });
+		await expect(loadRestartProof(tamperedRoot, COLLECTION_ID, proof.cell)).rejects.toThrow("signature is invalid");
+
+		const noncanonicalRoot = await evidenceRoot();
+		await writeRestartProof(noncanonicalRoot, proof);
+		const noncanonicalFile = path.join(
+			noncanonicalRoot,
+			"request-proofs",
+			restartProofFile(COLLECTION_ID, proof.cell),
+		);
+		const noncanonical = JSON.parse(await fs.readFile(noncanonicalFile, "utf8"));
+		noncanonical.signature.value += "=";
+		await fs.writeFile(noncanonicalFile, `${canonicalJson(noncanonical)}\n`, { mode: 0o600 });
+		await expect(loadRestartProof(noncanonicalRoot, COLLECTION_ID, proof.cell)).rejects.toThrow(
+			"receipt signature is invalid",
+		);
+
+		const untrustedRoot = await evidenceRoot();
+		await writeRestartProof(untrustedRoot, proof);
+		const untrustedFile = path.join(untrustedRoot, "request-proofs", restartProofFile(COLLECTION_ID, proof.cell));
+		const untrusted = JSON.parse(await fs.readFile(untrustedFile, "utf8"));
+		await fs.unlink(path.join(untrustedRoot, "trusted-signers", `${untrusted.signature.keyId}.pem`));
+		await expect(loadRestartProof(untrustedRoot, COLLECTION_ID, proof.cell)).rejects.toThrow(
+			"required evidence path is missing",
+		);
+	});
+
+	it("rejects stale and exact-cell-mismatched restart proofs", async () => {
+		const staleRoot = await evidenceRoot();
+		const stale = restartProof({ requestedAt: new Date(Date.now() - 31 * 24 * 60 * 60_000).toISOString() });
+		await writeRestartProof(staleRoot, stale);
+		await expect(loadRestartProof(staleRoot, COLLECTION_ID, stale.cell)).rejects.toThrow(
+			"timestamp is outside the collection window",
+		);
+
+		const mismatchRoot = await evidenceRoot();
+		const expected = restartProof().cell;
+		const mismatch = restartProof({
+			collectionId: "gate0-other-collection",
+			cell: { ...expected, host: "terminal" },
+		});
+		await writeSignedRestartProofAt(mismatchRoot, expected, mismatch);
+		await expect(loadRestartProof(mismatchRoot, COLLECTION_ID, expected)).rejects.toThrow(
+			"does not match the requested cell",
+		);
+	});
+
+	it("preserves restart proof on receipt failure and consumes it only after receipt success", async () => {
+		const root = await evidenceRoot();
+		const proof = restartProof();
+		const proofPath = path.join(root, "request-proofs", restartProofFile(COLLECTION_ID, proof.cell));
+		await writeRestartProof(root, proof);
+		await expect(
+			persistReceiptAndConsumeProof(root, cell("A1", "26", "ghostty"), proof, {
+				writeReceipt: async () => {
+					throw new Error("receipt write failed");
+				},
+				removeRestartProof,
+			}),
+		).rejects.toThrow("receipt write failed");
+		expect((await fs.lstat(proofPath)).isFile()).toBe(true);
+
+		await persistReceiptAndConsumeProof(root, cell("A1", "26", "ghostty"), proof);
+		await expect(fs.lstat(proofPath)).rejects.toMatchObject({ code: "ENOENT" });
+		expect((await fs.readdir(path.join(root, "receipts"))).length).toBe(1);
+	});
+
+	it("runs both post-restart continuity probes without another Screen Recording request", async () => {
+		const requests: boolean[] = [];
+		await runCellContinuity(
+			{ path: "baseline", sha256: BASELINE_SHA },
+			"A1",
+			{
+				build: async () => {},
+				readArtifact: async () => ({ path: "updated", sha256: UPDATED_SHA }),
+				codesign: async () => ({ verified: true, signing: "adhoc" }),
+				sourceRevision: async () => REVISION,
+				runPair: async (_artifact, _topology, _invoke, request) => {
+					requests.push(request === true);
+					return successfulPair("A1");
+				},
+			},
+			false,
+		);
+		expect(requests).toEqual([false, false]);
 	});
 
 	it("uses exactly one permission request across baseline and updated continuity", async () => {

--- a/packages/coding-agent/test/gjc-runtime/computer-broker-gate0.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/computer-broker-gate0.test.ts
@@ -40,6 +40,16 @@ function persistentOutput(nonce: string, sequences: Array<"preflight" | "postfli
 	);
 }
 
+function acceleratedA1TimeoutClock(): () => number {
+	let calls = 0;
+	return () => {
+		calls++;
+		if (calls <= 3) return 0;
+		if (calls <= 6) return 599;
+		return 824;
+	};
+}
+
 describe("computer broker Gate-0", () => {
 	it("keeps the hidden selector out of actual public help", async () => {
 		expect(commands.map(command => command.name)).not.toContain("--internal-computer-gate0");
@@ -127,6 +137,7 @@ describe("computer broker Gate-0", () => {
 	});
 
 	it("awaits A2 lifecycle cleanup after its deadline expires", async () => {
+		const clock = [0, 0, 599, 599];
 		let observeAbort = () => {};
 		const abortedSignal = new Promise<void>(resolve => {
 			observeAbort = resolve;
@@ -134,7 +145,8 @@ describe("computer broker Gate-0", () => {
 		let releaseCleanup = () => {};
 		const output = runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A2" }), {
 			controllerFactory: () => controller(),
-			timeoutMs: 30,
+			timeoutMs: 900,
+			now: () => clock.shift() ?? 599,
 			lifecycleRunner: ({ signal }) =>
 				new Promise<Gate0LifecycleMarker[]>(resolve => {
 					signal?.addEventListener("abort", () => {
@@ -168,7 +180,8 @@ describe("computer broker Gate-0", () => {
 		});
 		const output = runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
 			isCompiledBinary: () => true,
-			timeoutMs: 30,
+			timeoutMs: 900,
+			now: acceleratedA1TimeoutClock(),
 			persistentChildSpawner: ({ nonce }) => ({
 				stdin: { write: () => {}, flush: async () => {}, end: async () => {} },
 				stdout: new ReadableStream({
@@ -349,7 +362,8 @@ describe("computer broker Gate-0", () => {
 		const signals: string[] = [];
 		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
 			isCompiledBinary: () => true,
-			timeoutMs: 100,
+			timeoutMs: 900,
+			now: acceleratedA1TimeoutClock(),
 			persistentChildSpawner: ({ nonce }) => ({
 				stdin: { write: () => {}, flush: async () => {}, end: async () => {} },
 				stdout: new ReadableStream({ start: stream => stream.enqueue(persistentOutput(nonce, ["preflight"])) }),
@@ -748,7 +762,8 @@ describe("computer broker Gate-0", () => {
 		const signals: string[] = [];
 		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
 			isCompiledBinary: () => true,
-			timeoutMs: 30,
+			timeoutMs: 900,
+			now: acceleratedA1TimeoutClock(),
 			persistentChildSpawner: ({ nonce }) => ({
 				stdin: { write: () => {}, flush: async () => {}, end: async () => {} },
 				stdout: new ReadableStream({ start: stream => stream.enqueue(persistentOutput(nonce, ["preflight"])) }),
@@ -775,7 +790,8 @@ describe("computer broker Gate-0", () => {
 		const signals: string[] = [];
 		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
 			isCompiledBinary: () => true,
-			timeoutMs: 30,
+			timeoutMs: 900,
+			now: acceleratedA1TimeoutClock(),
 			persistentChildSpawner: ({ nonce }) => ({
 				stdin: { write: () => {}, flush: async () => {}, end: () => new Promise<void>(() => {}) },
 				stdout: new ReadableStream({

--- a/packages/coding-agent/test/gjc-runtime/computer-broker-gate0.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/computer-broker-gate0.test.ts
@@ -1,0 +1,859 @@
+import { describe, expect, it } from "bun:test";
+import { commands, runCli } from "@gajae-code/coding-agent/cli";
+import {
+	type Gate0NativeController,
+	isGate0Result,
+	runComputerBrokerGate0,
+} from "@gajae-code/coding-agent/gjc-runtime/computer-broker-gate0";
+import {
+	type Gate0LifecycleMarker,
+	type Gate0TmuxChild,
+	gate0TmuxEnvironment,
+	runGate0TmuxLifecycle,
+} from "@gajae-code/coding-agent/gjc-runtime/computer-broker-gate0-tmux";
+
+function controller(overrides: Partial<Gate0NativeController> = {}): Gate0NativeController {
+	return {
+		gate0PermissionStatus: () => ({ accessibility: true, screenRecording: true }),
+		gate0RequestScreenRecording: () => true,
+		gate0HarmlessProbe: () => ({ screenshot: true, accessibility: true, pointerMoveRestore: true }),
+		...overrides,
+	};
+}
+
+function persistentProbe() {
+	return {
+		topology: "gate0" as const,
+		phase: "A1" as const,
+		permission: { accessibility: true, screenRecording: true },
+		requestAttempted: false,
+		success: true,
+		code: "ok" as const,
+		ancestry: { kind: "persistent_child" as const, bounded: true as const },
+		lifecycle: [] as Gate0LifecycleMarker[],
+	};
+}
+
+function persistentOutput(nonce: string, sequences: Array<"preflight" | "postflight">): Uint8Array {
+	return new TextEncoder().encode(
+		`${sequences.map(sequence => JSON.stringify({ nonce, sequence, result: persistentProbe() })).join("\n")}\n`,
+	);
+}
+
+describe("computer broker Gate-0", () => {
+	it("keeps the hidden selector out of actual public help", async () => {
+		expect(commands.map(command => command.name)).not.toContain("--internal-computer-gate0");
+		const cli = new URL("../../src/cli.ts", import.meta.url).pathname;
+		const child = Bun.spawn([process.execPath, cli, "--help"], { stdout: "pipe", stderr: "pipe" });
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+		expect(exitCode).toBe(0);
+		expect(`${stdout}\n${stderr}`).not.toContain("--internal-computer-gate0");
+	});
+
+	it.if(process.platform === "darwin")("fails closed when hidden malloc re-exec cannot start", async () => {
+		const previousMalloc = process.env.MallocStackLogging;
+		const previousGuard = process.env.GJC_MALLOC_ENV_REEXEC;
+		const previousExitCode = process.exitCode;
+		let invoked = false;
+		let stdout = "";
+		try {
+			process.env.MallocStackLogging = "1";
+			delete process.env.GJC_MALLOC_ENV_REEXEC;
+			await runCli(["--internal-computer-gate0"], {
+				reexecWithScrubbedMallocEnv: async () => null,
+				runGate0FromEnvironment: async () => {
+					invoked = true;
+				},
+				writeGate0Output: value => {
+					stdout += value;
+				},
+			});
+			expect(invoked).toBe(false);
+			expect(process.exitCode).toBe(1);
+			const output = JSON.parse(stdout);
+			expect(output).toMatchObject({ success: false, code: "internal_error" });
+			expect(isGate0Result(output)).toBe(true);
+		} finally {
+			if (previousMalloc === undefined) delete process.env.MallocStackLogging;
+			else process.env.MallocStackLogging = previousMalloc;
+			if (previousGuard === undefined) delete process.env.GJC_MALLOC_ENV_REEXEC;
+			else process.env.GJC_MALLOC_ENV_REEXEC = previousGuard;
+			process.exitCode = previousExitCode ?? 0;
+		}
+	});
+
+	it("refuses malformed input with a stable code", async () => {
+		const output = await runComputerBrokerGate0("not-json");
+		expect(output).toMatchObject({ success: false, code: "invalid_input" });
+	});
+
+	it("attempts an explicit screen-recording request at most once", async () => {
+		let requests = 0;
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "probe", request: true }), {
+			controllerFactory: () =>
+				controller({
+					gate0PermissionStatus: () => ({ accessibility: true, screenRecording: false }),
+					gate0RequestScreenRecording: () => {
+						requests++;
+						return false;
+					},
+					gate0HarmlessProbe: () => ({ screenshot: false, accessibility: true, pointerMoveRestore: true }),
+				}),
+		});
+		expect(requests).toBe(1);
+		expect(output.requestAttempted).toBe(true);
+		expect(output.code).toBe("permission_pending");
+	});
+
+	it("never requests Screen Recording during a non-requesting preflight", async () => {
+		let requests = 0;
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "probe", request: false }), {
+			controllerFactory: () =>
+				controller({
+					gate0PermissionStatus: () => ({ accessibility: true, screenRecording: false }),
+					gate0RequestScreenRecording: () => {
+						requests++;
+						return false;
+					},
+					gate0HarmlessProbe: () => ({ screenshot: false, accessibility: true, pointerMoveRestore: true }),
+				}),
+		});
+		expect(requests).toBe(0);
+		expect(output).toMatchObject({ requestAttempted: false, success: false, code: "permission_denied" });
+	});
+
+	it("awaits A2 lifecycle cleanup after its deadline expires", async () => {
+		let observeAbort = () => {};
+		const abortedSignal = new Promise<void>(resolve => {
+			observeAbort = resolve;
+		});
+		let releaseCleanup = () => {};
+		const output = runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A2" }), {
+			controllerFactory: () => controller(),
+			timeoutMs: 30,
+			lifecycleRunner: ({ signal }) =>
+				new Promise<Gate0LifecycleMarker[]>(resolve => {
+					signal?.addEventListener("abort", () => {
+						observeAbort();
+						releaseCleanup = () =>
+							resolve(["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"]);
+					});
+				}),
+		});
+		await abortedSignal;
+		let settled = false;
+		void output.then(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(false);
+		releaseCleanup();
+		expect(await output).toMatchObject({ success: false, code: "timeout" });
+	});
+
+	it("does not return an A1 timeout until lifecycle cleanup and child exit complete", async () => {
+		let observeAbort = () => {};
+		const abortedSignal = new Promise<void>(resolve => {
+			observeAbort = resolve;
+		});
+		let killed = 0;
+		let releaseCleanup = () => {};
+		let releaseExit = (_code: number) => {};
+		const exited = new Promise<number>(resolve => {
+			releaseExit = resolve;
+		});
+		const output = runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
+			isCompiledBinary: () => true,
+			timeoutMs: 30,
+			persistentChildSpawner: ({ nonce }) => ({
+				stdin: { write: () => {}, flush: async () => {}, end: async () => {} },
+				stdout: new ReadableStream({
+					start: stream =>
+						stream.enqueue(
+							new TextEncoder().encode(
+								`${JSON.stringify({ nonce, sequence: "preflight", result: { topology: "gate0", phase: "A1", permission: { accessibility: true, screenRecording: true }, requestAttempted: false, success: true, code: "ok", ancestry: { kind: "persistent_child", bounded: true }, lifecycle: [] } })}\n`,
+							),
+						),
+				}),
+				exited,
+				kill: () => killed++,
+			}),
+			lifecycleRunner: ({ signal }) =>
+				new Promise<Gate0LifecycleMarker[]>(resolve => {
+					signal?.addEventListener("abort", () => {
+						observeAbort();
+						releaseCleanup = () =>
+							resolve(["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"]);
+					});
+				}),
+		});
+		await abortedSignal;
+		let settled = false;
+		void output.then(() => {
+			settled = true;
+		});
+		releaseCleanup();
+		for (let attempt = 0; attempt < 100 && killed === 0; attempt++) await Bun.sleep(1);
+		expect(settled).toBe(false);
+		expect(killed).toBeGreaterThan(0);
+		releaseExit(0);
+		expect(await output).toMatchObject({ success: false, code: "timeout" });
+	});
+
+	it("uses one A1 deadline across preflight and the lifecycle runner", async () => {
+		let clock = 0;
+		const lifecycleTimeouts: number[] = [];
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
+			isCompiledBinary: () => true,
+			timeoutMs: 90,
+			now: () => clock,
+			persistentChildSpawner: ({ nonce }) => ({
+				stdin: {
+					write: () => {},
+					flush: async () => {
+						clock += 10;
+					},
+					end: async () => {},
+				},
+				stdout: new ReadableStream({
+					start: stream => stream.enqueue(persistentOutput(nonce, ["preflight", "postflight"])),
+				}),
+				exited: Promise.resolve(0),
+				kill: () => {},
+			}),
+			lifecycleRunner: async ({ timeoutMs }) => {
+				lifecycleTimeouts.push(timeoutMs ?? 0);
+				return ["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"];
+			},
+		});
+		expect(lifecycleTimeouts).toEqual([50]);
+		expect(output).toMatchObject({ success: true, code: "ok" });
+	});
+
+	it("fails closed when A1 child cleanup cannot be confirmed", async () => {
+		let clock = 0;
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
+			isCompiledBinary: () => true,
+			timeoutMs: 30,
+			now: () => clock,
+			persistentChildSpawner: () => ({
+				stdin: {
+					write: () => {},
+					flush: async () => {
+						clock = 30;
+					},
+					end: async () => {},
+				},
+				stdout: new ReadableStream<Uint8Array>(),
+				exited: new Promise<number>(() => {}),
+				kill: () => {},
+			}),
+		});
+		expect(output).toMatchObject({ success: false, code: "internal_error" });
+	});
+
+	it("passes A2 only the shared operational budget remaining after preflight", async () => {
+		let clock = 0;
+		let probes = 0;
+		const lifecycleTimeouts: number[] = [];
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A2" }), {
+			timeoutMs: 90,
+			now: () => clock,
+			controllerFactory: () =>
+				controller({
+					gate0HarmlessProbe: () => {
+						if (++probes === 1) clock += 10;
+						return { screenshot: true, accessibility: true, pointerMoveRestore: true };
+					},
+				}),
+			lifecycleRunner: async ({ timeoutMs }) => {
+				lifecycleTimeouts.push(timeoutMs ?? 0);
+				return ["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"];
+			},
+		});
+		expect(lifecycleTimeouts).toEqual([50]);
+		expect(output).toMatchObject({ success: true, code: "ok" });
+	});
+
+	it("refuses source-mode A1 before spawning an experiment child", async () => {
+		let spawned = false;
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
+			isCompiledBinary: () => false,
+			persistentChildSpawner: () => {
+				spawned = true;
+				throw new Error("must not spawn");
+			},
+		});
+		expect(output).toMatchObject({ phase: "A1", success: false, code: "native_unavailable" });
+		expect(spawned).toBe(false);
+	});
+
+	it("maps A1 setup failures to one redacted result", async () => {
+		for (const dependencies of [
+			{
+				isCompiledBinary: () => {
+					throw new Error("private setup detail");
+				},
+			},
+			{
+				isCompiledBinary: () => true,
+				persistentChildSpawner: () => {
+					throw new Error("private spawn detail");
+				},
+			},
+		]) {
+			const output = await runComputerBrokerGate0(
+				JSON.stringify({ operation: "lifecycle", phase: "A1" }),
+				dependencies,
+			);
+			expect(output).toMatchObject({ phase: "A1", success: false, code: "internal_error" });
+			expect(JSON.stringify(output)).not.toMatch(/private|detail/);
+			expect(isGate0Result(output)).toBe(true);
+		}
+	});
+
+	it("uses the complete failing A1 snapshot without mixing permissions", async () => {
+		const denied = {
+			...persistentProbe(),
+			permission: { accessibility: false, screenRecording: true },
+			success: false,
+			code: "permission_denied" as const,
+		};
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
+			isCompiledBinary: () => true,
+			persistentChildSpawner: ({ nonce }) => ({
+				stdin: { write: () => {}, flush: async () => {}, end: async () => {} },
+				stdout: new ReadableStream({
+					start: stream =>
+						stream.enqueue(
+							new TextEncoder().encode(
+								`${JSON.stringify({ nonce, sequence: "preflight", result: denied })}\n${JSON.stringify({ nonce, sequence: "postflight", result: persistentProbe() })}\n`,
+							),
+						),
+				}),
+				exited: Promise.resolve(0),
+				kill: () => {},
+			}),
+			lifecycleRunner: async () => ["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"],
+		});
+		expect(output).toMatchObject({ success: false, code: "permission_denied", permission: denied.permission });
+		expect(isGate0Result(output)).toBe(true);
+	});
+
+	it("escalates a TERM-resistant A1 child to SIGKILL", async () => {
+		const exited = Promise.withResolvers<number>();
+		const signals: string[] = [];
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
+			isCompiledBinary: () => true,
+			timeoutMs: 100,
+			persistentChildSpawner: ({ nonce }) => ({
+				stdin: { write: () => {}, flush: async () => {}, end: async () => {} },
+				stdout: new ReadableStream({ start: stream => stream.enqueue(persistentOutput(nonce, ["preflight"])) }),
+				exited: exited.promise,
+				kill: signal => {
+					signals.push(String(signal));
+					if (signal === "SIGKILL") exited.resolve(-1);
+				},
+			}),
+			lifecycleRunner: ({ signal }) =>
+				new Promise(resolve => {
+					signal?.addEventListener("abort", () =>
+						resolve(["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"]),
+					);
+				}),
+		});
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(output).toMatchObject({ success: false, code: "timeout" });
+	});
+
+	it("rejects duplicate A1 frames and nonzero child shutdown", async () => {
+		for (const fixture of [
+			{ sequences: ["preflight", "preflight"] as const, exitCode: 0 },
+			{ sequences: ["preflight", "postflight"] as const, exitCode: 1 },
+		]) {
+			const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
+				isCompiledBinary: () => true,
+				persistentChildSpawner: ({ nonce }) => ({
+					stdin: { write: () => {}, flush: async () => {}, end: async () => {} },
+					stdout: new ReadableStream({
+						start: stream => stream.enqueue(persistentOutput(nonce, [...fixture.sequences])),
+					}),
+					exited: Promise.resolve(fixture.exitCode),
+					kill: () => {},
+				}),
+				lifecycleRunner: async () => ["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"],
+			});
+			expect(output).toMatchObject({ phase: "A1", success: false, code: "internal_error" });
+		}
+	});
+
+	it("does not classify misleading internal messages as permission failures", async () => {
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "probe" }), {
+			controllerFactory: () => {
+				throw new Error("permission denied while decoding an internal database");
+			},
+		});
+		expect(output.code).toBe("internal_error");
+	});
+
+	it("fails closed on malformed, extra, and incomplete hidden result contracts", async () => {
+		const valid = {
+			topology: "gate0",
+			phase: "A2",
+			permission: { accessibility: true, screenRecording: true },
+			requestAttempted: false,
+			success: true,
+			code: "ok",
+			ancestry: { kind: "outer_owner", bounded: true },
+			lifecycle: ["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"],
+		};
+		expect(isGate0Result({ ...valid, extra: true })).toBe(false);
+		expect(isGate0Result({ ...valid, success: false })).toBe(false);
+		expect(isGate0Result({ ...valid, phase: "A1" })).toBe(false);
+		expect(isGate0Result({ ...valid, permission: { accessibility: false, screenRecording: false } })).toBe(false);
+		expect(isGate0Result({ ...valid, lifecycle: [] })).toBe(false);
+		for (const lifecycle of [
+			["preflight", "cleaned"],
+			["preflight", "tmux_created", "attached", "reattached", "detached", "cleaned"],
+		]) {
+			const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A2" }), {
+				controllerFactory: () => controller(),
+				lifecycleRunner: async () => lifecycle as Gate0LifecycleMarker[],
+			});
+			expect(output).toMatchObject({ success: false, code: "internal_error" });
+		}
+	});
+
+	it("returns only redacted result fields", async () => {
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "probe" }), {
+			controllerFactory: () => controller(),
+		});
+		expect(Object.keys(output).sort()).toEqual([
+			"ancestry",
+			"code",
+			"lifecycle",
+			"permission",
+			"phase",
+			"requestAttempted",
+			"success",
+			"topology",
+		]);
+		expect(JSON.stringify(output)).not.toMatch(/png|pixel|coordinate|text|key|secret/i);
+	});
+
+	it("runs A2 preflight and post-transition probes around the tmux lifecycle", async () => {
+		let probes = 0;
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A2" }), {
+			controllerFactory: () =>
+				controller({
+					gate0HarmlessProbe: () => ({ screenshot: ++probes > 0, accessibility: true, pointerMoveRestore: true }),
+				}),
+			lifecycleRunner: async () => ["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"],
+		});
+		expect(probes).toBe(2);
+		expect(output).toMatchObject({ success: true, code: "ok", ancestry: { kind: "outer_owner" } });
+	});
+
+	it("returns canonical failures across A2 permission transitions", async () => {
+		const granted = { accessibility: true, screenRecording: true };
+		const denied = { accessibility: false, screenRecording: true };
+		for (const fixture of [
+			{
+				statuses: [denied, denied, granted, granted],
+				probes: [
+					{ screenshot: true, accessibility: false, pointerMoveRestore: false },
+					{ screenshot: true, accessibility: true, pointerMoveRestore: true },
+				],
+				expected: denied,
+			},
+			{
+				statuses: [granted, granted, granted, denied],
+				probes: [
+					{ screenshot: true, accessibility: true, pointerMoveRestore: true },
+					{ screenshot: true, accessibility: false, pointerMoveRestore: false },
+				],
+				expected: denied,
+			},
+		]) {
+			const statuses = [...fixture.statuses];
+			const probes = [...fixture.probes];
+			const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A2" }), {
+				controllerFactory: () =>
+					controller({
+						gate0PermissionStatus: () => statuses.shift() ?? denied,
+						gate0HarmlessProbe: () => probes.shift() ?? fixture.probes.at(-1)!,
+					}),
+				lifecycleRunner: async () => ["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"],
+			});
+			expect(output).toMatchObject({ success: false, code: "permission_denied", permission: fixture.expected });
+			expect(isGate0Result(output)).toBe(true);
+		}
+	});
+
+	it("rechecks permission after a harmless-probe race", async () => {
+		const statuses = [
+			{ accessibility: true, screenRecording: true },
+			{ accessibility: false, screenRecording: true },
+		];
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "probe" }), {
+			controllerFactory: () =>
+				controller({
+					gate0PermissionStatus: () => statuses.shift() ?? statuses[0]!,
+				}),
+		});
+		expect(output).toMatchObject({ success: false, code: "permission_denied", permission: { accessibility: false } });
+		expect(isGate0Result(output)).toBe(true);
+	});
+	it("uses a random no-config tmux server and strips nested ownership environment", async () => {
+		const argv: string[][] = [];
+		const options: Array<{ env: NodeJS.ProcessEnv }> = [];
+		const exits = [0, 0, 0, 0, 0, 0, 1];
+		const spawn = (command: string[], spawnOptions: { env: NodeJS.ProcessEnv }): Gate0TmuxChild => {
+			argv.push(command);
+			options.push(spawnOptions);
+			return {
+				exited: Promise.resolve(exits.shift() ?? 1),
+				stdin: { write: () => {}, end: async () => {} },
+				kill: () => {},
+			};
+		};
+		await runGate0TmuxLifecycle({
+			phase: "A2",
+			tmuxCommand: "/usr/bin/tmux",
+			env: {
+				PATH: "/bin",
+				TMUX: "outer",
+				TMUX_PANE: "%1",
+				GJC_TMUX_OWNER: "owner",
+				GJC_COORDINATOR_SESSION_ID: "session",
+				TERM_PROGRAM: "Ghostty",
+				CMUX_BUNDLE_ID: "com.cmuxterm.app",
+				GHOSTTY_RESOURCES_DIR: "/Applications/Ghostty.app",
+			},
+			randomBytes: () => ({ toString: () => "0123456789abcdef01234567" }),
+			spawn,
+		});
+		const prefix = ["/usr/bin/tmux", "-f", "/dev/null", "-L", "gjc-gate0-0123456789abcdef01234567"];
+		expect(argv).toEqual([
+			[...prefix, "new-session", "-d", "-s", "gate0", "--", "/bin/sleep", "15"],
+			[...prefix, "has-session", "-t", "gate0"],
+			[...prefix, "-C", "attach-session", "-t", "gate0"],
+			[...prefix, "has-session", "-t", "gate0"],
+			[...prefix, "-C", "attach-session", "-t", "gate0"],
+			[...prefix, "kill-server"],
+			[...prefix, "has-session", "-t", "gate0"],
+		]);
+		expect(
+			gate0TmuxEnvironment({
+				TMUX: "outer",
+				TMUX_PANE: "%1",
+				GJC_TMUX_OWNER: "owner",
+				GJC_COORDINATOR_SESSION_ID: "session",
+				TERM_PROGRAM: "Ghostty",
+				CMUX_BUNDLE_ID: "com.cmuxterm.app",
+				GHOSTTY_RESOURCES_DIR: "/Applications/Ghostty.app",
+				PATH: "/bin",
+			}),
+		).toEqual({ PATH: "/bin" });
+		expect(options.every(option => JSON.stringify(option.env) === JSON.stringify({ PATH: "/bin" }))).toBe(true);
+	});
+
+	it("fails closed when random-server cleanup cannot be verified", async () => {
+		const exits = [0, 0, 0, 0, 0, 1];
+		const spawn = (): Gate0TmuxChild => ({
+			exited: Promise.resolve(exits.shift() ?? 0),
+			stdin: { write: () => {}, end: async () => {} },
+			kill: () => {},
+		});
+		await expect(runGate0TmuxLifecycle({ phase: "A2", tmuxCommand: "/usr/bin/tmux", spawn })).rejects.toThrow(
+			"GATE0_CLEANUP_FAILURE",
+		);
+	});
+
+	it("requires confirmed client termination after TERM and SIGKILL", async () => {
+		const signals: string[] = [];
+		await expect(
+			runGate0TmuxLifecycle({
+				phase: "A2",
+				tmuxCommand: "/usr/bin/tmux",
+				timeoutMs: 30,
+				spawn: () => ({
+					exited: new Promise<number>(() => {}),
+					stdin: { write: () => {}, end: async () => {} },
+					kill: signal => signals.push(String(signal)),
+				}),
+			}),
+		).rejects.toThrow("GATE0_CLEANUP_FAILURE");
+		expect(signals).toEqual(["SIGTERM", "SIGKILL", "SIGTERM", "SIGKILL"]);
+	});
+
+	it("fails closed when tmux client termination throws", async () => {
+		await expect(
+			runGate0TmuxLifecycle({
+				phase: "A2",
+				tmuxCommand: "/usr/bin/tmux",
+				timeoutMs: 30,
+				spawn: () => ({
+					exited: new Promise<number>(() => {}),
+					stdin: { write: () => {}, end: async () => {} },
+					kill: () => {
+						throw new Error("unavailable");
+					},
+				}),
+			}),
+		).rejects.toThrow("GATE0_CLEANUP_FAILURE");
+	});
+
+	it("accepts a nonzero kill-server status only when absence is verified", async () => {
+		const exits = [0, 0, 0, 0, 0, 1, 1];
+		const markers = await runGate0TmuxLifecycle({
+			phase: "A2",
+			tmuxCommand: "/usr/bin/tmux",
+			spawn: () => ({
+				exited: Promise.resolve(exits.shift() ?? 1),
+				stdin: { write: () => {}, end: async () => {} },
+				kill: () => {},
+			}),
+		});
+		expect(markers.at(-1)).toBe("cleaned");
+	});
+	it("rejects nested persistent-frame extras without leaking them", async () => {
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
+			isCompiledBinary: () => true,
+			persistentChildSpawner: ({ nonce }) => ({
+				stdin: { write: () => {}, flush: async () => {}, end: async () => {} },
+				stdout: new ReadableStream({
+					start: stream =>
+						stream.enqueue(
+							new TextEncoder().encode(
+								`${JSON.stringify({
+									nonce,
+									sequence: "preflight",
+									result: {
+										...persistentProbe(),
+										permission: { accessibility: true, screenRecording: true, secret: "leak" },
+									},
+								})}\n`,
+							),
+						),
+				}),
+				exited: Promise.resolve(0),
+				kill: () => {},
+			}),
+		});
+		expect(output).toMatchObject({ success: false, code: "internal_error" });
+		expect(JSON.stringify(output)).not.toContain("leak");
+		expect(isGate0Result(output)).toBe(true);
+	});
+
+	it("cleans an A1 child when stream setup fails", async () => {
+		const signals: string[] = [];
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
+			isCompiledBinary: () => true,
+			persistentChildSpawner: () => ({
+				stdin: { write: () => {}, flush: async () => {}, end: async () => {} },
+				stdout: {
+					getReader: () => {
+						throw new Error("stream setup failed");
+					},
+				} as unknown as ReadableStream<Uint8Array>,
+				exited: Promise.resolve(0),
+				kill: signal => signals.push(String(signal)),
+			}),
+		});
+		expect(output).toMatchObject({ success: false, code: "internal_error" });
+		expect(signals).toEqual([]);
+		expect(isGate0Result(output)).toBe(true);
+	});
+
+	it("cleans a namespace after a nonzero new-session client", async () => {
+		const argv: string[][] = [];
+		const exits = [1, 1, 1];
+		await expect(
+			runGate0TmuxLifecycle({
+				phase: "A2",
+				tmuxCommand: "/usr/bin/tmux",
+				randomBytes: () => ({ toString: () => "a".repeat(24) }),
+				spawn: command => {
+					argv.push(command);
+					return {
+						exited: Promise.resolve(exits.shift() ?? 1),
+						stdin: { write: () => {}, end: async () => {} },
+						kill: () => {},
+					};
+				},
+			}),
+		).rejects.toThrow("GATE0_TMUX_FAILURE");
+		expect(argv.map(command => command.at(-1))).toEqual(["15", "kill-server", "gate0"]);
+		expect(
+			argv.every(command => command.slice(1, 5).join(" ") === "-f /dev/null -L gjc-gate0-aaaaaaaaaaaaaaaaaaaaaaaa"),
+		).toBe(true);
+	});
+
+	it("cleans a namespace after a timed-out new-session client", async () => {
+		const argv: string[][] = [];
+		const signals: string[] = [];
+		const createExit = Promise.withResolvers<number>();
+		let calls = 0;
+		await expect(
+			runGate0TmuxLifecycle({
+				phase: "A2",
+				tmuxCommand: "/usr/bin/tmux",
+				timeoutMs: 60,
+				randomBytes: () => ({ toString: () => "b".repeat(24) }),
+				spawn: command => {
+					argv.push(command);
+					if (calls++ === 0) {
+						return {
+							exited: createExit.promise,
+							stdin: { write: () => {}, end: async () => {} },
+							kill: signal => {
+								signals.push(String(signal));
+								if (signal === "SIGKILL") createExit.resolve(-1);
+							},
+						};
+					}
+					return { exited: Promise.resolve(1), stdin: { write: () => {}, end: async () => {} }, kill: () => {} };
+				},
+			}),
+		).rejects.toThrow("GATE0_TIMEOUT");
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(argv.map(command => command.at(-1))).toEqual(["15", "kill-server", "gate0"]);
+	});
+	it("keeps A2 controller construction inside its one lifecycle deadline", async () => {
+		let clock = 0;
+		let lifecycleCalls = 0;
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A2" }), {
+			timeoutMs: 30,
+			now: () => clock,
+			controllerFactory: () => {
+				clock = 30;
+				return controller();
+			},
+			lifecycleRunner: async () => {
+				lifecycleCalls++;
+				return ["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"];
+			},
+		});
+		expect(output).toMatchObject({ success: false, code: "timeout" });
+		expect(lifecycleCalls).toBe(0);
+	});
+
+	it("preserves A1 SIGKILL fallback when SIGTERM throws", async () => {
+		const exited = Promise.withResolvers<number>();
+		const signals: string[] = [];
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
+			isCompiledBinary: () => true,
+			timeoutMs: 30,
+			persistentChildSpawner: ({ nonce }) => ({
+				stdin: { write: () => {}, flush: async () => {}, end: async () => {} },
+				stdout: new ReadableStream({ start: stream => stream.enqueue(persistentOutput(nonce, ["preflight"])) }),
+				exited: exited.promise,
+				kill: signal => {
+					signals.push(String(signal));
+					if (signal === "SIGTERM") throw new Error("term unavailable");
+					if (signal === "SIGKILL") exited.resolve(-1);
+				},
+			}),
+			lifecycleRunner: ({ signal }) =>
+				new Promise(resolve =>
+					signal?.addEventListener("abort", () =>
+						resolve(["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"]),
+					),
+				),
+		});
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(output).toMatchObject({ success: false, code: "timeout" });
+	});
+
+	it("reserves A1 termination time when writer close never settles", async () => {
+		const exited = Promise.withResolvers<number>();
+		const signals: string[] = [];
+		const output = await runComputerBrokerGate0(JSON.stringify({ operation: "lifecycle", phase: "A1" }), {
+			isCompiledBinary: () => true,
+			timeoutMs: 30,
+			persistentChildSpawner: ({ nonce }) => ({
+				stdin: { write: () => {}, flush: async () => {}, end: () => new Promise<void>(() => {}) },
+				stdout: new ReadableStream({
+					start: stream => stream.enqueue(persistentOutput(nonce, ["preflight", "postflight"])),
+				}),
+				exited: exited.promise,
+				kill: signal => {
+					signals.push(String(signal));
+					if (signal === "SIGKILL") exited.resolve(-1);
+				},
+			}),
+			lifecycleRunner: async () => ["preflight", "tmux_created", "attached", "detached", "reattached", "cleaned"],
+		});
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(output).toMatchObject({ success: false, code: "timeout" });
+	});
+
+	it("bounds rejected and never-settling tmux control closes before namespace cleanup", async () => {
+		for (const end of [() => Promise.reject(new Error("close failed")), () => new Promise<void>(() => {})]) {
+			const exited = Promise.withResolvers<number>();
+			const signals: string[] = [];
+			let calls = 0;
+			await expect(
+				runGate0TmuxLifecycle({
+					phase: "A2",
+					tmuxCommand: "/usr/bin/tmux",
+					timeoutMs: 100,
+					spawn: () => {
+						if (calls++ === 2)
+							return {
+								exited: exited.promise,
+								stdin: { write: () => {}, end },
+								kill: signal => {
+									signals.push(String(signal));
+									if (signal === "SIGKILL") exited.resolve(-1);
+								},
+							};
+						return {
+							exited: Promise.resolve(calls === 5 ? 1 : 0),
+							stdin: { write: () => {}, end: async () => {} },
+							kill: () => {},
+						};
+					},
+				}),
+			).rejects.toThrow("GATE0_TMUX_FAILURE");
+			expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+			expect(calls).toBe(5);
+		}
+	});
+
+	it("uses tmux SIGKILL fallback after a throwing SIGTERM", async () => {
+		const exited = Promise.withResolvers<number>();
+		const signals: string[] = [];
+		let calls = 0;
+		await expect(
+			runGate0TmuxLifecycle({
+				phase: "A2",
+				tmuxCommand: "/usr/bin/tmux",
+				timeoutMs: 30,
+				spawn: () => {
+					if (calls++ === 2)
+						return {
+							exited: exited.promise,
+							stdin: { write: () => {}, end: () => Promise.reject(new Error("close failed")) },
+							kill: signal => {
+								signals.push(String(signal));
+								if (signal === "SIGTERM") throw new Error("term unavailable");
+								if (signal === "SIGKILL") exited.resolve(-1);
+							},
+						};
+					return {
+						exited: Promise.resolve(calls === 5 ? 1 : 0),
+						stdin: { write: () => {}, end: async () => {} },
+						kill: () => {},
+					};
+				},
+			}),
+		).rejects.toThrow("GATE0_TMUX_FAILURE");
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+	});
+});

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -3,6 +3,24 @@
 export declare class ComputerController {
   constructor()
   screenshot(): ComputerScreenshot
+  /**
+   * Return the non-prompting combined Accessibility + PostEvent TCC state for
+   * the hidden Gate-0 experiment.
+   */
+  gate0PermissionStatus(): Gate0PermissionStatus
+  /**
+   * Explicitly request Screen Recording access for the hidden Gate-0
+   * experiment. Normal controller initialization and screenshot paths never
+   * call this.
+   */
+  gate0RequestScreenRecording(): boolean
+  /**
+   * Run the hidden Gate-0 probe without returning screenshot bytes or cursor
+   * coordinates. The pointer path moves exactly one logical pixel and
+   * restores the original location without clicking, typing, or holding
+   * input state.
+   */
+  gate0HarmlessProbe(): Gate0HarmlessProbeResult
   click(expectedEpoch: number | undefined | null, x: number, y: number, button?: string | undefined | null): void
   doubleClick(expectedEpoch: number | undefined | null, x: number, y: number, button?: string | undefined | null): void
   move(expectedEpoch: number | undefined | null, x: number, y: number): void
@@ -793,6 +811,27 @@ export interface FuzzyFindResult {
   matches: Array<FuzzyFindMatch>
   /** Total number of matches found (may exceed `matches.len()`). */
   totalMatches: number
+}
+
+/**
+ * Redacted Gate-0 harmless-probe outcome. No desktop data or coordinates are
+ * returned.
+ */
+export interface Gate0HarmlessProbeResult {
+  /** Whether a screenshot could be captured and immediately discarded. */
+  screenshot: boolean
+  /** Whether Accessibility was granted when the probe ran. */
+  accessibility: boolean
+  /** Whether the cursor moved one logical pixel and was restored. */
+  pointerMoveRestore: boolean
+}
+
+/** Redacted Gate-0 TCC status. This contains grant state only. */
+export interface Gate0PermissionStatus {
+  /** Whether Accessibility input injection is granted. */
+  accessibility: boolean
+  /** Whether Screen Recording capture is granted. */
+  screenRecording: boolean
 }
 
 /** Get list of supported languages. */

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -4,8 +4,8 @@ export declare class ComputerController {
   constructor()
   screenshot(): ComputerScreenshot
   /**
-   * Return the non-prompting combined Accessibility + PostEvent TCC state for
-   * the hidden Gate-0 experiment.
+   * Return the non-prompting combined Accessibility + `PostEvent` TCC state
+   * for the hidden Gate-0 experiment.
    */
   gate0PermissionStatus(): Gate0PermissionStatus
   /**

--- a/packages/natives/native/loader-state.d.ts
+++ b/packages/natives/native/loader-state.d.ts
@@ -71,4 +71,4 @@ export interface LoadFromCandidatesResult<T> {
 
 export function loadFromCandidates<T>(input: LoadFromCandidatesInput<T>): LoadFromCandidatesResult<T>;
 
-export function loadNative(): Record<string, unknown>;
+export function loadNative<T extends Record<string, unknown> = Record<string, unknown>>(): T;

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -72,6 +72,11 @@
 			"types": "./native/index.d.ts",
 			"import": "./native/index.js",
 			"default": "./native/index.js"
+		},
+		"./loader-state": {
+			"types": "./native/loader-state.d.ts",
+			"import": "./native/loader-state.js",
+			"default": "./native/loader-state.js"
 		}
 	}
 }

--- a/packages/natives/test/computer.test.ts
+++ b/packages/natives/test/computer.test.ts
@@ -1,30 +1,19 @@
 import { describe, expect, it } from "bun:test";
 
+import { ComputerController, computerScreenshot } from "../native/index.js";
+
 const isMacOS = process.platform === "darwin";
+const SCREEN_RECORDING_PERMISSION_ERROR = "screen capture failed; the Screen Recording permission may not be granted";
 
-type NativeComputerModule = {
-	ComputerController: new () => Record<string, unknown>;
-	computerScreenshot: () => {
-		widthPx: number;
-		heightPx: number;
-		scaleX: number;
-		scaleY: number;
-		png: Uint8Array;
-		displayEpoch: number;
-		captureId: number;
-	};
-};
-
-async function loadNativeComputerModule(): Promise<NativeComputerModule> {
-	return (await import("../native/index.js")) as unknown as NativeComputerModule;
+function isScreenRecordingPermissionError(error: unknown): boolean {
+	return error instanceof Error && error.message === SCREEN_RECORDING_PERMISSION_ERROR;
 }
 
 describe.if(isMacOS)("ComputerController napi binding", () => {
-	it("exists with expected methods", async () => {
-		const { ComputerController } = await loadNativeComputerModule();
+	it("exists with expected methods", () => {
 		const controller = new ComputerController();
 		expect(controller).toBeInstanceOf(ComputerController);
-		for (const method of [
+		const methods = [
 			"screenshot",
 			"click",
 			"doubleClick",
@@ -34,25 +23,55 @@ describe.if(isMacOS)("ComputerController napi binding", () => {
 			"type",
 			"keypress",
 			"wait",
-		]) {
+			"gate0PermissionStatus",
+			"gate0RequestScreenRecording",
+			"gate0HarmlessProbe",
+		] as const;
+		for (const method of methods) {
 			expect(typeof controller[method]).toBe("function");
 		}
 	});
-});
 
+	it("returns the redacted Gate-0 permission-status shape without prompting", () => {
+		const controller = new ComputerController();
+		const status = controller.gate0PermissionStatus();
+		expect(status).toEqual({
+			accessibility: expect.any(Boolean),
+			screenRecording: expect.any(Boolean),
+		});
+	});
+
+	it("returns only the redacted harmless-probe shape", () => {
+		const controller = new ComputerController();
+		const status = controller.gate0PermissionStatus();
+		const probe = controller.gate0HarmlessProbe();
+
+		expect(probe).toEqual({
+			screenshot: expect.any(Boolean),
+			accessibility: expect.any(Boolean),
+			pointerMoveRestore: expect.any(Boolean),
+		});
+		expect(probe.accessibility).toBe(status.accessibility);
+		if (status.screenRecording) {
+			expect(probe.screenshot).toBe(true);
+		}
+		if (status.accessibility) {
+			expect(probe.pointerMoveRestore).toBe(true);
+		}
+	});
+});
 // The native `computerScreenshot` binding is macOS-only and captures the real
-// primary display, so it requires the Screen Recording permission. Gate on
-// platform and skip gracefully when capture is unavailable in the environment.
+// primary display, so only its exact missing-permission error is skipped.
 describe.if(isMacOS)("computer screenshot napi binding", () => {
-	it("returns a decodable PNG whose dimensions match the descriptor", async () => {
-		const { computerScreenshot } = await loadNativeComputerModule();
-		let shot: ReturnType<NativeComputerModule["computerScreenshot"]>;
+	it("returns a decodable PNG whose dimensions match the descriptor", () => {
+		let shot: ReturnType<typeof computerScreenshot>;
 		try {
 			shot = computerScreenshot();
 		} catch (err) {
-			// Screen Recording not granted to this process — surfaced, not silent.
-			console.warn(`skipping: computerScreenshot unavailable (${String(err)})`);
-			return;
+			if (isScreenRecordingPermissionError(err)) {
+				return;
+			}
+			throw err;
 		}
 
 		expect(shot.widthPx).toBeGreaterThan(0);


### PR DESCRIPTION
## What

Adds the isolated, hidden Gate-0 feasibility harness for testing whether a packaged GJC identity retains macOS Screen Recording and Accessibility/PostEvent authority across tmux lifecycle transitions, process restart, and binary rebuild.

It compares:

- **A1:** persistent packaged helper child started before tmux.
- **A2:** terminal-launched outer packaged GJC remains the computer-use owner.

The evidence runner supports both one-shot permission activation and a restart-aware two-stage flow:

1. `request-cell` records an exact signed redacted proof of the explicit Screen Recording request and direct terminal-host process generation.
2. After a real terminal-app process restart, `run-cell` requires a different compatible host generation, performs request-free baseline/update continuity, writes the existing final receipt, and only then consumes the proof.

## Scope

This PR is **Gate-0 feasibility infrastructure only**. It intentionally does not implement or enable a production computer broker/client/server, authenticated IPC, leases, configuration/default changes, Gate 1, or rollout. Even a complete all-pass matrix requires separate architecture review and explicit approval.

## Evidence integrity

- Exact packaged artifact path, clean committed source, baseline/update SHA-256, strict ad-hoc codesign verification.
- Canonical Ed25519 receipts and restart proofs with explicit trusted-key validation.
- Exact cell/collection/source/artifact/codesign/timestamp binding.
- Direct terminal-host ancestry; ambient reparented tmux is rejected for restart staging.
- Terminal restart is attested using only host enum, PID, executable-path hash, and process-start-token hash. Raw process paths, argv, environment, screenshots, cursor coordinates, typed data, and secrets are not persisted.
- Random isolated tmux namespace, bounded cleanup, verified absence, strict redacted hidden JSON.
- Exact macOS 14/15/26 × Terminal.app/Ghostty/cmux × arm64 matrix; missing or duplicate cells fail closed.

## Verification

- Focused Gate-0 runner/runtime/computer suite: **119 passed, 0 failed**.
- `bun --cwd=packages/coding-agent run check`.
- `bun --cwd=packages/natives run check`.
- `cargo check -p pi-natives`.
- Native computer nextest: **60 passed, 94 skipped**.
- Public workflow/default-surface, G002, and strict rebrand gates pass.
- Release artifact builds, is strict-codesign valid, and is Mach-O arm64.
- CI for the Gate-0-only commit chain passed coding-agent/native checks, runner/runtime/native tests, Rust checks/tests, CLI smoke, and native build.

## Live Ghostty finding

On macOS 26/arm64, a fresh native Ghostty process requires an app-process restart after `CGRequestScreenCaptureAccess()` before capture authority becomes active. After restart, packaged A1 and A2 both pass with granted permissions, bounded expected ancestry, the exact six lifecycle markers, and no residual Gate-0 process. The staged proof flow exists specifically to collect this required restart without weakening evidence.

Full Gate-0 topology selection remains blocked until current-schema signed receipts cover every required OS/terminal cell.