### PR TITLE
fix(natives): detect Windows AVX2 without console probes

### DIFF
--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows AVX2 variant detection now uses an in-process `kernel32!IsProcessorFeaturePresent` probe under Bun, with a Windows PowerShell 5.1-compatible P/Invoke fallback. The previous `System.Runtime.Intrinsics` probe does not exist on stock Windows PowerShell, so detection always chose the baseline addon on AVX2-capable CPUs, and the per-process `powershell.exe` spawn flashed a console window from every detached, console-less parent (e.g. the SDK broker).
+
 ## [0.11.0] - 2026-07-15
 
 ### Fixed

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -231,7 +231,10 @@ export function loadFromCandidates({ candidates, requireCandidate, validateCandi
 
 function runCommand(command, args) {
 	try {
-		const result = childProcess.spawnSync(command, args, { encoding: "utf-8" });
+		// windowsHide keeps the probe console-less: inside a detached, console-less
+		// parent (e.g. the SDK broker) spawning a console app like powershell.exe
+		// would otherwise allocate and flash a new console window per invocation.
+		const result = childProcess.spawnSync(command, args, { encoding: "utf-8", windowsHide: true });
 		if (result.error) return null;
 		if (result.status !== 0) return null;
 		return (result.stdout || "").trim();
@@ -246,6 +249,8 @@ function getVariantOverride() {
 	if (value === "modern" || value === "baseline") return value;
 	return null;
 }
+
+const WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE = 40;
 
 function detectAvx2Support() {
 	if (process.arch !== "x64") {
@@ -271,11 +276,30 @@ function detectAvx2Support() {
 	}
 
 	if (process.platform === "win32") {
+		// PF_AVX2_INSTRUCTIONS_AVAILABLE: in-process kernel32 probe, no subprocess
+		// and no console window. Preferred because a detached, console-less parent
+		// (e.g. the SDK broker) spawning powershell.exe would flash a new console
+		// window per process start.
+		if (typeof Bun !== "undefined") {
+			try {
+				const { dlopen } = createRequire(import.meta.url)("bun:ffi");
+				const kernel32 = dlopen("kernel32.dll", {
+					IsProcessorFeaturePresent: { args: ["i32"], returns: "bool" },
+				});
+				return Boolean(kernel32.symbols.IsProcessorFeaturePresent(WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE));
+			} catch {
+				// Fall through to the PowerShell probe (ffi unavailable/failed).
+			}
+		}
+		// P/Invoke works on both Windows PowerShell 5.1 and pwsh 7+. A
+		// System.Runtime.Intrinsics type probe would always read false on 5.1
+		// (.NET Framework has no such type), silently forcing baseline.
 		const output = runCommand("powershell.exe", [
 			"-NoProfile",
 			"-NonInteractive",
 			"-Command",
-			"[System.Runtime.Intrinsics.X86.Avx2]::IsSupported",
+			"Add-Type -Namespace GjcNative -Name Cpu -MemberDefinition '[DllImport(\"kernel32.dll\")] public static extern bool IsProcessorFeaturePresent(int feature);'; " +
+				`[GjcNative.Cpu]::IsProcessorFeaturePresent(${WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE})`,
 		]);
 		return output && output.toLowerCase() === "true";
 	}

--- a/scripts/host-detect.test.ts
+++ b/scripts/host-detect.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test, vi } from "bun:test";
+import { detectWin32Avx2Support } from "./host-detect";
+
+describe("Windows AVX2 host detection", () => {
+	test("uses the in-process kernel32 result without spawning PowerShell", () => {
+		const command = vi.fn(() => "false");
+
+		expect(detectWin32Avx2Support(() => true, command)).toBe(true);
+		expect(command).not.toHaveBeenCalled();
+	});
+
+	test("treats a negative kernel32 result as authoritative", () => {
+		const command = vi.fn(() => "true");
+
+		expect(detectWin32Avx2Support(() => false, command)).toBe(false);
+		expect(command).not.toHaveBeenCalled();
+	});
+
+	test("falls back to a Windows PowerShell 5.1-compatible P/Invoke probe", () => {
+		const command = vi.fn((_file: string, args: string[]) => {
+			expect(args.join(" ")).toContain("IsProcessorFeaturePresent");
+			expect(args.join(" ")).toContain("DllImport");
+			return "True";
+		});
+
+		expect(detectWin32Avx2Support(() => undefined, command)).toBe(true);
+		expect(command).toHaveBeenCalledTimes(1);
+		expect(command.mock.calls[0]?.[0]).toBe("powershell.exe");
+	});
+});

--- a/scripts/host-detect.ts
+++ b/scripts/host-detect.ts
@@ -1,13 +1,48 @@
+import { dlopen } from "bun:ffi";
 import * as fs from "node:fs";
+
+const WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE = 40;
 
 function runCommand(command: string, args: string[]): string | null {
 	try {
-		const result = Bun.spawnSync([command, ...args], { stdout: "pipe", stderr: "pipe" });
+		const result = Bun.spawnSync([command, ...args], { stdout: "pipe", stderr: "pipe", windowsHide: true });
 		if (result.exitCode !== 0) return null;
 		return result.stdout.toString("utf-8").trim();
 	} catch {
 		return null;
 	}
+}
+
+function probeWin32Avx2Support(): boolean | undefined {
+	try {
+		const kernel32 = dlopen("kernel32.dll", {
+			IsProcessorFeaturePresent: { args: ["i32"], returns: "bool" },
+		});
+		return Boolean(kernel32.symbols.IsProcessorFeaturePresent(WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE));
+	} catch {
+		return undefined;
+	}
+}
+
+export function detectWin32Avx2Support(
+	probe: () => boolean | undefined = probeWin32Avx2Support,
+	command: (file: string, args: string[]) => string | null = runCommand,
+): boolean {
+	// In-process kernel32 probe: no subprocess and no console window.
+	const probed = probe();
+	if (probed !== undefined) return probed;
+
+	// P/Invoke works on both Windows PowerShell 5.1 and pwsh 7+. A
+	// System.Runtime.Intrinsics type probe would always read false on 5.1
+	// (.NET Framework has no such type), silently forcing baseline.
+	const output = command("powershell.exe", [
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		"Add-Type -Namespace GjcNative -Name Cpu -MemberDefinition '[DllImport(\"kernel32.dll\")] public static extern bool IsProcessorFeaturePresent(int feature);'; " +
+			`[GjcNative.Cpu]::IsProcessorFeaturePresent(${WIN32_PF_AVX2_INSTRUCTIONS_AVAILABLE})`,
+	]);
+	return output?.toLowerCase() === "true";
 }
 
 export function detectHostAvx2Support(): boolean {
@@ -30,13 +65,7 @@ export function detectHostAvx2Support(): boolean {
 	}
 
 	if (process.platform === "win32") {
-		const output = runCommand("powershell.exe", [
-			"-NoProfile",
-			"-NonInteractive",
-			"-Command",
-			"[System.Runtime.Intrinsics.X86.Avx2]::IsSupported",
-		]);
-		return output?.toLowerCase() === "true";
+		return detectWin32Avx2Support();
 	}
 
 	return false;


### PR DESCRIPTION
## Summary

- detect AVX2 on Windows in-process through `IsProcessorFeaturePresent`
- keep a PowerShell 5.1-compatible P/Invoke fallback when Bun FFI is unavailable
- hide fallback probe windows and cover both primary and fallback paths

## Tests

- `bun test scripts/host-detect.test.ts packages/natives/test/build-native-profile.test.ts packages/natives/test/windows-staging.test.ts packages/natives/test/embed-native-variants.test.ts packages/natives/test/embed-guard.test.ts`
- `bun --cwd=packages/natives run check`
- `bun run check:tools`