### PR TITLE
fix(sdk): harden Windows detached startup and durable writes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,8 @@
 - Connected MCP server instructions now remain untrusted user-role data instead of entering the cached system prompt; hostile file paths, working directories, and workspace-tree metadata are structurally encoded, and volatile project context is removed from durable session history between requests.
 - Restored the strict G002 public-surface quarantine by removing the default README advertisement for the private coordinator MCP runtime.
 
+- Windows: detached SDK broker, session-host, and chat/Telegram daemon spawns now route through a `Bun.spawn`-backed console-less facade (Bun's `node:child_process` ignores `windowsHide` for detached children, flashing a console window per spawn). Discovery, conversation-store, and session-index file syncs use writable handles while lifecycle directory flushes are best-effort instead of failing with `EPERM`; legacy regular-file broker locks that Windows reports as `ENOENT` are also recovered.
+
 ## [0.11.1] - 2026-07-16
 
 ### Fixed

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -409,22 +409,27 @@ export class Broker {
 			return this.#lockSnapshot(await fs.readFile(this.#lockRecordPath(), "utf8"));
 		} catch (e) {
 			const code = (e as NodeJS.ErrnoException).code;
-			if (code === "ENOTDIR") {
-				try {
-					return this.#lockSnapshot(await fs.readFile(this.#lock, "utf8"));
-				} catch (legacyError) {
-					if ((legacyError as NodeJS.ErrnoException).code === "ENOENT") return null;
-					throw legacyError;
-				}
-			}
+			if (code === "ENOTDIR") return this.#readLegacyLock();
+			// Windows reports ENOENT (not ENOTDIR) when the lock path itself is a
+			// legacy regular file, so ENOENT falls through to the stat probe below
+			// instead of concluding the lock is absent.
 			if (code !== "ENOENT") throw e;
 		}
 		try {
 			const lock = await fs.stat(this.#lock);
-			return lock.isDirectory() ? { pid: 0, identity: `directory:${lock.dev}:${lock.ino}` } : null;
+			if (lock.isDirectory()) return { pid: 0, identity: `directory:${lock.dev}:${lock.ino}` };
+			return this.#readLegacyLock();
 		} catch (e) {
 			if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
 			throw e;
+		}
+	}
+	async #readLegacyLock(): Promise<BrokerLockSnapshot | null> {
+		try {
+			return this.#lockSnapshot(await fs.readFile(this.#lock, "utf8"));
+		} catch (legacyError) {
+			if ((legacyError as NodeJS.ErrnoException).code === "ENOENT") return null;
+			throw legacyError;
 		}
 	}
 	async #createLock(): Promise<void> {

--- a/packages/coding-agent/src/sdk/broker/discovery.ts
+++ b/packages/coding-agent/src/sdk/broker/discovery.ts
@@ -33,7 +33,9 @@ export function isPidAlive(pid: number): boolean {
 	}
 }
 async function syncFile(file: string): Promise<void> {
-	const handle = await fs.open(file, "r");
+	// Windows FlushFileBuffers requires a writable file handle; opening the
+	// discovery snapshot read-only makes the durability barrier fail with EPERM.
+	const handle = await fs.open(file, process.platform === "win32" ? "r+" : "r");
 	try {
 		await handle.sync();
 	} finally {

--- a/packages/coding-agent/src/sdk/broker/ensure.ts
+++ b/packages/coding-agent/src/sdk/broker/ensure.ts
@@ -1,4 +1,5 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { spawnDetachedChild } from "../../utils/detached-spawn";
 import { type BrokerDiscovery, brokerProcessIncarnation, readBrokerDiscovery } from "./discovery";
 import { resolveSdkInternalSpawnCommand, type SdkInternalSpawnCommand } from "./runtime";
 export interface EnsureBrokerSettings {
@@ -203,9 +204,10 @@ async function ensureBrokerOnce(settings: EnsureBrokerSettings, initiator: Ensur
 	}
 
 	const command = resolveSdkInternalSpawnCommand("broker-internal");
-	const child = spawn(command.file, [...command.args, "--agent-dir", settings.agentDir], {
-		detached: true,
-		stdio: "ignore",
+	// spawnDetachedChild keeps the detached broker console-less on Windows; Bun's
+	// node:child_process ignores windowsHide for detached children and would
+	// otherwise flash a new console window on every broker spawn.
+	const child = spawnDetachedChild(command.file, [...command.args, "--agent-dir", settings.agentDir], {
 		env: brokerSpawnEnvironment(command, settings.env),
 		...(command.kind === "bun-source" ? { cwd: command.cwd } : {}),
 	});

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -423,6 +423,9 @@ export class LifecycleLedger {
 		this.#warnings.push("Malformed lifecycle ledger entry quarantined");
 	}
 	async #syncDirectory(): Promise<void> {
+		// Windows cannot flush directory handles. The file was already synced
+		// before its atomic rename, so directory-entry durability is best-effort.
+		if (process.platform === "win32") return;
 		const directory = await fs.open(path.dirname(this.#file), fsSync.constants.O_RDONLY);
 		try {
 			await directory.sync();

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1,11 +1,10 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import * as native from "@gajae-code/natives";
 import { resolveEquivalentPath } from "@gajae-code/utils";
-
 import {
 	ensureLaunchWorktree,
 	ensureReusableNodeModules,
@@ -21,6 +20,7 @@ import {
 	type VerifiedSessionDeleteResult,
 	type VerifiedSessionDeleteTarget,
 } from "../../session/session-storage";
+import { spawnDetachedChild } from "../../utils/detached-spawn";
 import { SdkClient, SdkClientError } from "../client/client";
 import {
 	type LogicalSessionCandidate,
@@ -825,6 +825,10 @@ function isLifecycleFailureArtifact(value: unknown): value is LifecycleFailureAr
 }
 
 async function syncDirectory(directory: string): Promise<void> {
+	// Windows cannot flush directory handles (FlushFileBuffers fails with
+	// EPERM), so the directory durability barrier is best-effort there. The
+	// rename-based publish stays atomic for readers either way.
+	if (process.platform === "win32") return;
 	const handle = await fs.open(directory, fsSync.constants.O_RDONLY);
 	try {
 		await handle.sync();
@@ -2698,10 +2702,10 @@ async function executeLifecycleResponse(
 		let spawnedAuthority: EffectMarker | undefined;
 		try {
 			const cmd = command(broker);
-			const spawned = spawn(cmd.file, cmd.args, {
+			// spawnDetachedChild keeps detached session hosts console-less on Windows
+			// (Bun's node:child_process ignores windowsHide for detached children).
+			const spawned = spawnDetachedChild(cmd.file, cmd.args, {
 				cwd: launch.cwd,
-				detached: true,
-				stdio: "ignore",
 				env: {
 					...("kind" in cmd ? cmd.env : process.env),
 					GJC_AGENT_DIR: broker.settings.agentDir,

--- a/packages/coding-agent/src/sdk/broker/session-index.ts
+++ b/packages/coding-agent/src/sdk/broker/session-index.ts
@@ -245,7 +245,8 @@ export class SessionIndex {
 				mode: 0o600,
 			},
 		);
-		const h = await fs.open(tmp, "r");
+		// FlushFileBuffers requires a writable file handle on Windows.
+		const h = await fs.open(tmp, process.platform === "win32" ? "r+" : "r");
 		try {
 			await h.sync();
 		} finally {

--- a/packages/coding-agent/src/sdk/bus/chat-daemon-control.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-daemon-control.ts
@@ -1,4 +1,4 @@
-import { spawn as childProcessSpawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -12,6 +12,7 @@ import type {
 	DaemonStatus,
 } from "../../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../../daemon/runtime";
+import { spawnDetachedChild } from "../../utils/detached-spawn";
 import { getNotificationConfig, isDiscordConfigured, isSlackConfigured } from "./config";
 
 export type ChatDaemonKind = "discord" | "slack";
@@ -495,7 +496,9 @@ export class ChatDaemonController implements BuiltInDaemonController {
 			agentDir: this.settings.getAgentDir(),
 			execPath: this.deps.execPath,
 		});
-		(this.deps.spawn ?? ((command, args, opts) => childProcessSpawn(command, args, opts)))(command, args, {
+		// spawnDetachedChild keeps the detached chat daemon console-less on Windows
+		// (Bun's node:child_process ignores windowsHide for detached children).
+		(this.deps.spawn ?? ((cmd, cmdArgs) => spawnDetachedChild(cmd, cmdArgs)))(command, args, {
 			detached: true,
 			stdio: "ignore",
 		}).unref?.();

--- a/packages/coding-agent/src/sdk/bus/conversation-store.ts
+++ b/packages/coding-agent/src/sdk/bus/conversation-store.ts
@@ -319,18 +319,24 @@ export class ConversationStore<T extends ConversationRecord> {
 		try {
 			await this.#fs.writeFile(temporary, `${JSON.stringify(document)}\n`, { mode: 0o600 });
 			await this.#fs.chmod(temporary, 0o600);
-			const handle = await this.#fs.open(temporary, "r");
+			// Windows FlushFileBuffers requires a writable handle (a read-only
+			// open fails the flush with EPERM) and cannot flush directory handles
+			// at all; the directory durability barrier is best-effort there.
+			const win32 = process.platform === "win32";
+			const handle = await this.#fs.open(temporary, win32 ? "r+" : "r");
 			try {
 				await handle.sync();
 			} finally {
 				await handle.close();
 			}
 			await this.#fs.rename(temporary, this.#file);
-			const directory = await this.#fs.open(this.#directory, "r");
-			try {
-				await directory.sync();
-			} finally {
-				await directory.close();
+			if (!win32) {
+				const directory = await this.#fs.open(this.#directory, "r");
+				try {
+					await directory.sync();
+				} finally {
+					await directory.close();
+				}
 			}
 		} catch (error) {
 			await this.#fs.unlink(temporary).catch(() => undefined);

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -1,4 +1,3 @@
-import { spawn as childProcessSpawn } from "node:child_process";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -8,6 +7,7 @@ import { withFileLock } from "../../config/file-lock";
 import type { Settings } from "../../config/settings";
 import type { DaemonRuntimeInfo } from "../../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../../daemon/runtime";
+import { spawnDetachedChild } from "../../utils/detached-spawn";
 import { getNotificationConfig, isTelegramConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand, parseRichToggleCommand, parseTelegramControlCommand } from "./config-commands";
 import { daemonPaths, HEARTBEAT_TTL_MS } from "./daemon-paths";
@@ -653,17 +653,18 @@ function defaultDaemonSpawn(
 ): SpawnResult {
 	// Redirect the detached daemon's stdout/stderr to a log file so failures
 	// (e.g. a rejected sendMessage) are diagnosable instead of vanishing.
-	let stdio: "ignore" | ["ignore", number, number] = opts.stdio;
+	let outputFd: number | undefined;
 	if (opts.logPath) {
 		try {
 			fs.mkdirSync(path.dirname(opts.logPath), { recursive: true, mode: 0o700 });
-			const fd = fs.openSync(opts.logPath, "a", 0o600);
-			stdio = ["ignore", fd, fd];
+			outputFd = fs.openSync(opts.logPath, "a", 0o600);
 		} catch {
 			// Fall back to ignoring output if the log file cannot be opened.
 		}
 	}
-	const child = childProcessSpawn(command, args, { detached: opts.detached, stdio });
+	// spawnDetachedChild keeps the detached daemon console-less on Windows
+	// (Bun's node:child_process ignores windowsHide for detached children).
+	const child = spawnDetachedChild(command, args, outputFd === undefined ? {} : { outputFd });
 	// Best-effort autostart: a spawn failure must never crash the host session.
 	child.on("error", () => undefined);
 	return { unref: () => child.unref() };

--- a/packages/coding-agent/src/utils/detached-spawn.ts
+++ b/packages/coding-agent/src/utils/detached-spawn.ts
@@ -1,0 +1,74 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+
+export interface DetachedSpawnOptions {
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	/** Optional file descriptor receiving both stdout and stderr (e.g. a daemon log). */
+	outputFd?: number;
+}
+
+/**
+ * Spawns a detached child that never opens a console window.
+ *
+ * On Windows under Bun, `node:child_process` ignores `windowsHide: true` for
+ * `detached: true` children: every detached broker/session-host/daemon spawn
+ * opens a visible console window. `Bun.spawn` honors `windowsHide` and its
+ * detached children do not allocate a new console, so Windows spawns route
+ * through `Bun.spawn` behind a minimal ChildProcess-shaped facade exposing
+ * exactly the surface the callers use: `pid`, `exitCode`, `signalCode`,
+ * `kill`, `unref`, and `error`/`exit`/`close` events.
+ *
+ * Spawn failures (e.g. a missing executable) throw synchronously, matching
+ * Bun's `node:child_process` behavior that existing callers rely on.
+ *
+ * On other platforms (and non-Bun runtimes) this defers to
+ * `node:child_process.spawn` with `windowsHide: true`, preserving prior
+ * behavior.
+ */
+export function spawnDetachedChild(file: string, args: string[], options: DetachedSpawnOptions = {}): ChildProcess {
+	const stdioTail =
+		options.outputFd === undefined
+			? (["ignore", "ignore"] as const)
+			: ([options.outputFd, options.outputFd] as const);
+	if (process.platform !== "win32" || typeof Bun === "undefined") {
+		return spawn(file, args, {
+			detached: true,
+			stdio: ["ignore", ...stdioTail],
+			// A detached console-subsystem child would otherwise flash a cmd window on Windows under Node.
+			windowsHide: true,
+			env: options.env,
+			...(options.cwd ? { cwd: options.cwd } : {}),
+		});
+	}
+	const proc = Bun.spawn([file, ...args], {
+		stdio: ["ignore", ...stdioTail] as never,
+		detached: true,
+		windowsHide: true,
+		env: options.env as Record<string, string | undefined> | undefined,
+		...(options.cwd ? { cwd: options.cwd } : {}),
+	});
+	const emitter = new EventEmitter();
+	const emitExit = (): void => {
+		emitter.emit("exit", proc.exitCode, proc.signalCode);
+		emitter.emit("close", proc.exitCode, proc.signalCode);
+	};
+	proc.exited.then(emitExit, emitExit);
+	Object.defineProperties(emitter, {
+		pid: { get: () => proc.pid },
+		exitCode: { get: () => proc.exitCode },
+		signalCode: { get: () => proc.signalCode },
+	});
+	const facade = emitter as unknown as ChildProcess & {
+		kill: (signal?: NodeJS.Signals | number) => boolean;
+		unref: () => void;
+	};
+	facade.kill = (signal?: NodeJS.Signals | number): boolean => {
+		proc.kill(signal as never);
+		return true;
+	};
+	facade.unref = (): void => {
+		proc.unref();
+	};
+	return facade;
+}


### PR DESCRIPTION
## Summary

- route detached broker, session-host, and chat/Telegram daemon spawns through a console-less Windows facade
- use writable handles for Windows file durability barriers and make unsupported directory flushes best-effort
- recover legacy regular-file broker locks on Windows

## Tests

- `bun test packages/coding-agent/test/sdk-session-index.test.ts packages/coding-agent/test/sdk-broker-restart.test.ts packages/coding-agent/test/daemon-control.test.ts`
- `bun --cwd=packages/coding-agent run check`