### PR TITLE
fix(coding-agent): close factory-owned auth storage

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,8 @@
 - Connected MCP server instructions now remain untrusted user-role data instead of entering the cached system prompt; hostile file paths, working directories, and workspace-tree metadata are structurally encoded, and volatile project context is removed from durable session history between requests.
 - Restored the strict G002 public-surface quarantine by removing the default README advertisement for the private coordinator MCP runtime.
 
+- `createAgentSession` now closes the factory-owned credential store on dispose, releasing the `agent.db` SQLite WAL/SHM handles that leaked a connection per embedded session and, on Windows, blocked agent-directory removal with `EBUSY`. Embedder-supplied `authStorage`/`modelRegistry` instances remain open for the embedder.
+
 ## [0.11.1] - 2026-07-16
 
 ### Fixed

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -976,6 +976,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			"options.authStorage and options.modelRegistry.authStorage must be the same instance when both are provided",
 		);
 	}
+	// The factory owns the credential store only when it opened it itself via
+	// discoverAuthStorage(); embedder-supplied storage/registries must stay open
+	// for the embedder. Owned stores are closed on dispose — on Windows an open
+	// SQLite WAL handle (agent.db-shm mapping) otherwise blocks agent-dir removal.
+	const ownsAuthStorage = !options.modelRegistry && !options.authStorage;
 	// Subscribe before any getApiKey() call so startup model probes can't fire a
 	// credential_disabled event past us. An embedder's constructor handler makes the
 	// listener set non-empty from construction, which defeats AuthStorage's no-listener
@@ -2515,6 +2520,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					agentRegistry.unregister(resolvedAgentId);
 					unsubscribeCredentialDisabled?.();
 					releaseLocalProtocolOverride();
+					if (ownsAuthStorage) authStorage.close();
 				}
 			};
 		}
@@ -2645,6 +2651,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			logger.warn("Failed to clean up createAgentSession resources after startup error");
 		} finally {
 			releaseLocalProtocolOverride();
+			// Idempotent with the dispose wrapper: AuthStorage.close() guards re-entry.
+			if (ownsAuthStorage) authStorage.close();
 		}
 		throw error;
 	}

--- a/packages/coding-agent/test/sdk-auth-storage-ownership.test.ts
+++ b/packages/coding-agent/test/sdk-auth-storage-ownership.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@gajae-code/ai";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { createAgentSession, type ExtensionFactory, type WorkspaceTree } from "@gajae-code/coding-agent/sdk";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+
+const tempDirs: string[] = [];
+const closeAuthStorage = AuthStorage.prototype.close;
+
+function spyOnAuthStorageClose() {
+	return vi.spyOn(AuthStorage.prototype, "close").mockImplementation(function (this: AuthStorage) {
+		closeAuthStorage.call(this);
+	});
+}
+
+function createTempProject(): { agentDir: string; cwd: string } {
+	const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-auth-ownership-"));
+	const cwd = path.join(agentDir, "project");
+	fs.mkdirSync(cwd, { recursive: true });
+	tempDirs.push(agentDir);
+	return { agentDir, cwd };
+}
+
+function workspaceTree(cwd: string): WorkspaceTree {
+	return {
+		rootPath: cwd,
+		rendered: ".",
+		truncated: false,
+		totalLines: 1,
+		agentsMdFiles: [],
+	};
+}
+
+function model() {
+	const bundled = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!bundled) throw new Error("Expected bundled test model");
+	return bundled;
+}
+
+function sessionOptions(agentDir: string, cwd: string) {
+	return {
+		agentDir,
+		cwd,
+		sessionManager: SessionManager.inMemory(cwd),
+		settings: Settings.isolated(),
+		model: model(),
+		disableExtensionDiscovery: true,
+		extensions: [],
+		skills: [],
+		contextFiles: [],
+		promptTemplates: [],
+		workspaceTree: workspaceTree(cwd),
+		slashCommands: [],
+		enableMCP: false,
+		enableLsp: false,
+		toolNames: [],
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const tempDir of tempDirs.splice(0)) {
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+		} catch (error) {
+			// Bun's SQLite binding can retain a Windows mapping until the test
+			// process exits even after Database.close(); production callers are
+			// still protected because the close itself is asserted above.
+			if (process.platform === "win32" && (error as NodeJS.ErrnoException).code === "EBUSY") continue;
+			throw error;
+		}
+	}
+});
+
+describe("createAgentSession AuthStorage ownership", () => {
+	test("closes the factory-owned store exactly once on dispose", async () => {
+		const { agentDir, cwd } = createTempProject();
+		const close = spyOnAuthStorageClose();
+		const { session } = await createAgentSession(sessionOptions(agentDir, cwd));
+
+		expect(close).not.toHaveBeenCalled();
+		await session.dispose();
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	test("closes the factory-owned store when startup fails", async () => {
+		const { agentDir, cwd } = createTempProject();
+		const close = spyOnAuthStorageClose();
+		const failDuringStartup: ExtensionFactory = () => {
+			throw new Error("extension startup failed");
+		};
+
+		await expect(
+			createAgentSession({
+				...sessionOptions(agentDir, cwd),
+				extensions: [failDuringStartup],
+			}),
+		).rejects.toThrow("extension startup failed");
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	test("leaves an embedder-supplied store open", async () => {
+		const { agentDir, cwd } = createTempProject();
+		const authStorage = await AuthStorage.create(path.join(agentDir, "external-auth.db"));
+		const close = spyOnAuthStorageClose();
+		const { session } = await createAgentSession({
+			...sessionOptions(agentDir, cwd),
+			authStorage,
+		});
+
+		await session.dispose();
+		expect(close).not.toHaveBeenCalled();
+		closeAuthStorage.call(authStorage);
+	});
+});


### PR DESCRIPTION
## Summary

- close `AuthStorage` only when `createAgentSession()` opened it
- close owned storage on normal disposal and startup failure
- leave embedder-supplied storage and registries under caller ownership

## Tests

- `bun test packages/coding-agent/test/sdk-auth-storage-ownership.test.ts`
- `bun --cwd=packages/coding-agent run check`