### PR TITLE
fix(coding-agent): preserve compacted prompts in transcript rebuilds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,8 @@
 - Connected MCP server instructions now remain untrusted user-role data instead of entering the cached system prompt; hostile file paths, working directories, and workspace-tree metadata are structurally encoded, and volatile project context is removed from durable session history between requests.
 - Restored the strict G002 public-surface quarantine by removing the default README advertisement for the private coordinator MCP runtime.
 
+- Interactive transcript rebuilds now render the complete active-branch history: compaction no longer erases pre-summary user prompts and assistant turns from the chat display, while the provider context keeps using the compacted summary.
+
 ## [0.11.1] - 2026-07-16
 
 ### Fixed

--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -81,6 +81,7 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"agent_session:refreshMCPTools": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:refreshGjcSubskillTools": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:buildDisplaySessionContext": "internal accessor/plumbing, not a user-facing control seam",
+	"agent_session:buildTranscriptSessionContext": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:convertMessagesToLlm": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:prepareSimpleStreamOptions": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:getPlanModeState": "internal accessor/plumbing, not a user-facing control seam",

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1230,7 +1230,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	rebuildChatFromMessages(policy: TranscriptRebuildPolicy): void {
 		prepareTranscriptRebuild(this.ui, policy);
 		this.chatContainer.clear();
-		const context = this.session.buildDisplaySessionContext();
+		const context = this.session.buildTranscriptSessionContext();
 		this.renderSessionContext(context);
 	}
 

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -812,7 +812,7 @@ export class UiHelpers {
 		this.ctx.pendingPythonComponents = [];
 
 		// Reuse a pre-built context when available (e.g. from navigateTree) to avoid a second O(N) walk.
-		const context = prebuiltContext ?? this.ctx.sessionManager.buildSessionContext();
+		const context = prebuiltContext ?? this.ctx.session.buildTranscriptSessionContext();
 		this.ctx.renderSessionContext(context, {
 			updateFooter: true,
 			populateHistory: true,

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -3276,6 +3276,24 @@
 		]
 	},
 	{
+		"sourceId": "agent_session:buildTranscriptSessionContext",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal accessor/plumbing, not a user-facing control seam",
+		"adapterMappings": {
+			"telegram": "generic_safe",
+			"discord": "generic_safe",
+			"slack": "generic_safe",
+			"mcp": "generic_safe",
+			"acp": "generic_safe",
+			"daemonCli": "generic_safe"
+		},
+		"testIds": [
+			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
+		]
+	},
+	{
 		"sourceId": "agent_session:convertMessagesToLlm",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5984,6 +5984,14 @@ export class AgentSession {
 		const context = deobfuscateSessionContext(this.sessionManager.buildSessionContext(), this.#obfuscator);
 		return { ...context, messages: this.#withoutEphemeralCustomMessages(context.messages) };
 	}
+	/**
+	 * Build the complete active-branch transcript for the interactive UI.
+	 * Provider context remains compacted through buildDisplaySessionContext().
+	 */
+	buildTranscriptSessionContext(): SessionContext {
+		const context = deobfuscateSessionContext(this.sessionManager.buildTranscriptContext(), this.#obfuscator);
+		return { ...context, messages: this.#withoutEphemeralCustomMessages(context.messages) };
+	}
 
 	/** Convert session messages using the same pre-LLM pipeline as the active session. */
 	async convertMessagesToLlm(messages: AgentMessage[], signal?: AbortSignal): Promise<Message[]> {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -903,11 +903,20 @@ export function getLatestCompactionEntry(entries: SessionEntry[]): CompactionEnt
  * If leafId is provided, walks from that entry to root.
  * Handles compaction and branch summaries along the path.
  */
+export interface BuildSessionContextOptions {
+	/**
+	 * Preserve messages compacted out of the provider context for transcript rendering.
+	 * This must stay false for LLM requests, which require the compacted summary.
+	 */
+	includeCompactedHistory?: boolean;
+}
+
 export function buildSessionContext(
 	entries: SessionEntry[],
 	leafId?: string | null,
 	byId?: Map<string, SessionEntry>,
 	sessionIdentityNamespace = "legacy-session",
+	options: BuildSessionContextOptions = {},
 ): SessionContext {
 	// Build uuid index if not available
 	if (!byId) {
@@ -1104,7 +1113,7 @@ export function buildSessionContext(
 		}
 	};
 
-	if (compaction) {
+	if (compaction && !options.includeCompactedHistory) {
 		const providerPayload: ProviderPayload | undefined = (() => {
 			const candidate = compaction.preserveData?.openaiRemoteCompaction;
 			if (!candidate || typeof candidate !== "object") return undefined;
@@ -5848,6 +5857,17 @@ export class SessionManager {
 		this.#sessionContextLeafRevision = this.#leafRevision;
 		this.#sessionContextReplayMetadataRevision = this.#replayMetadataRevision;
 		return this.#sessionContextCache;
+	}
+	/**
+	 * Build the complete active-branch transcript for display.
+	 *
+	 * Unlike buildSessionContext(), this retains messages summarized out of the
+	 * provider context so transcript rebuilds never erase a user's prompt.
+	 */
+	buildTranscriptContext(): SessionContext {
+		return buildSessionContext(this.getBranch(), this.#leafId, undefined, this.#sessionId, {
+			includeCompactedHistory: true,
+		});
 	}
 
 	#getActivePathEntriesForProviderContext(fromId?: string | null): SessionEntry[] {

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -180,6 +180,31 @@ describe("buildSessionContext", () => {
 			expect((ctx.messages[3] as any).content).toBe("third");
 			expect((ctx.messages[4] as any).content[0].text).toBe("response3");
 		});
+		it("preserves compacted user prompts for transcript rendering", () => {
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "first"),
+				msg("2", "1", "assistant", "response1"),
+				msg("3", "2", "user", "second"),
+				msg("4", "3", "assistant", "response2"),
+				compaction("5", "4", "Summary of first two turns", "3"),
+				msg("6", "5", "user", "third"),
+				msg("7", "6", "assistant", "response3"),
+			];
+
+			const ctx = buildSessionContext(entries, undefined, undefined, "test", {
+				includeCompactedHistory: true,
+			});
+
+			expect(ctx.messages.map(message => message.role)).toEqual([
+				"user",
+				"assistant",
+				"user",
+				"assistant",
+				"user",
+				"assistant",
+			]);
+			expect((ctx.messages[0] as any).content).toBe("first");
+		});
 
 		it("handles compaction keeping from first message", () => {
 			const entries: SessionEntry[] = [


### PR DESCRIPTION
## Summary

- preserve compacted user prompts when the interactive transcript is rebuilt
- keep provider/LLM context compacted while giving the TUI a dedicated full-history context
- strip ephemeral custom messages and update the SDK operation inventory

## Tests

- `bun test packages/coding-agent/test/session-manager/build-context.test.ts`
- `bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts --check`
- `bun --cwd=packages/coding-agent run check`