### PR TITLE
test(coding-agent): make chat-effect pruning deterministic

### DIFF
--- a/packages/coding-agent/src/sdk/bus/chat-effect-journal.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-effect-journal.ts
@@ -118,6 +118,7 @@ function canClaim(effect: ChatEffect, now: number): boolean {
 export class ChatEffectJournal {
 	readonly #store: ConversationStore<ChatEffect>;
 	readonly #mappings: ConversationStore<EffectReferenceMapping>;
+	readonly #maxTerminalEffects: number;
 
 	readonly #now: () => number;
 
@@ -131,10 +132,17 @@ export class ChatEffectJournal {
 		pidIncarnation?: (pid: number) => string | undefined;
 		sleep?: (ms: number) => Promise<void>;
 		lockTimeoutMs?: number;
+		maxTerminalEffects?: number;
 	}) {
 		this.#store = new ConversationStore<ChatEffect>({ ...input, kind: input.transport, fileName: "effects.json" });
 		this.#mappings = new ConversationStore<EffectReferenceMapping>({ ...input, kind: input.transport });
 
+		if (
+			input.maxTerminalEffects !== undefined &&
+			(!Number.isSafeInteger(input.maxTerminalEffects) || input.maxTerminalEffects < 1)
+		)
+			throw new Error("Chat effect terminal retention must be a positive safe integer");
+		this.#maxTerminalEffects = input.maxTerminalEffects ?? MAX_TERMINAL_CHAT_EFFECTS;
 		this.#now = input.now ?? Date.now;
 	}
 
@@ -343,12 +351,12 @@ export class ChatEffectJournal {
 		const terminal = (await this.list())
 			.filter(effect => effect.state === "terminal")
 			.sort((left, right) => left.updatedAt - right.updatedAt);
-		if (terminal.length <= MAX_TERMINAL_CHAT_EFFECTS) return;
+		if (terminal.length <= this.#maxTerminalEffects) return;
 
 		const referenced = new Set<string>();
 		for (const mapping of Object.values((await this.#mappings.load()).conversations))
 			collectEffectReferences(mapping, referenced);
-		for (const effect of terminal.slice(0, terminal.length - MAX_TERMINAL_CHAT_EFFECTS)) {
+		for (const effect of terminal.slice(0, terminal.length - this.#maxTerminalEffects)) {
 			if (!referenced.has(effect.id)) await this.#store.delete(effect.id, effect.generation);
 		}
 	}

--- a/packages/coding-agent/test/sdk-discord-daemon.test.ts
+++ b/packages/coding-agent/test/sdk-discord-daemon.test.ts
@@ -2362,7 +2362,7 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 		await withDaemon(async (daemon, provider, agentDir) => {
 			const conversation = await daemon.notify({ sessionId: "session", endpointGeneration: 1, content: "open" });
 			const effectId = `discord:app:guild:parent:${conversation.threadId}:prune-receipt`;
-			const journal = new ChatEffectJournal({ agentDir, transport: "discord" });
+			const journal = new ChatEffectJournal({ agentDir, transport: "discord", maxTerminalEffects: 2 });
 			await journal.enqueue({
 				id: effectId,
 				kind: "discord.inbound.command",
@@ -2403,19 +2403,17 @@ describe("DiscordNotificationDaemon fake-provider acceptance", () => {
 			});
 			const lease = await journal.claim(effectId, "owner", 60_000);
 			await journal.record(effectId, { owner: "owner", epoch: lease!.epoch }, "terminal");
-			for (let index = 0; index < 127; index++) {
-				const id = `terminal-prune-${index}`;
-				await journal.enqueue({
-					id,
-					kind: "post-message",
-					transport: "discord",
-					sessionId: "session",
-					endpointGeneration: 1,
-					payload: { threadId: conversation.threadId!, content: String(index) },
-				});
-				const terminalLease = await journal.claim(id, "owner", 60_000);
-				await journal.record(id, { owner: "owner", epoch: terminalLease!.epoch }, "terminal");
-			}
+			const id = "terminal-prune-0";
+			await journal.enqueue({
+				id,
+				kind: "post-message",
+				transport: "discord",
+				sessionId: "session",
+				endpointGeneration: 1,
+				payload: { threadId: conversation.threadId!, content: "0" },
+			});
+			const terminalLease = await journal.claim(id, "owner", 60_000);
+			await journal.record(id, { owner: "owner", epoch: terminalLease!.epoch }, "terminal");
 			const overflowId = "terminal-prune-overflow";
 			await journal.enqueue({
 				id: overflowId,


### PR DESCRIPTION
## Summary

Postmerge Dev CI for #2564 exposed a deterministic test-time budget problem in `sdk-discord-daemon.test.ts`: the crash-window pruning case created and terminalized 129 fsynced effects to cross the production retention threshold, so hosted shard contention could exceed Bun's 5s per-test limit.

The failure is unrelated to #2564's workflow-gate terminalization path: the failing helper constructs `DiscordNotificationDaemon` and `ChatEffectJournal` directly, and #2564 did not modify the Discord daemon, conversation store, or chat-effect journal.

This follow-up removes the real-time dependency instead of increasing the timeout:

- add a validated `maxTerminalEffects` test seam to `ChatEffectJournal` (production default remains 128)
- exercise the identical referenced-receipt pruning boundary with retention 2 and three terminal effects

## Evidence

- exact named test: 8 concurrent runs, all pass, 0.54–0.77s each
- full `sdk-discord-daemon.test.ts`: 52 pass in 4.43s
- `bun --cwd=packages/coding-agent run check`: pass

This PR is the postmerge verification repair for #2550. It does not alter workflow-gate or coordinator production behavior.