### PR TITLE
fix(session): resolve postmerge resume blockers

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1023,6 +1023,7 @@ export interface RunRootCommandDependencies {
 	selectResumeSession?: SelectResumeSession;
 	openExistingSessionStrict?: OpenExistingSessionStrict;
 	initializeSettings?: typeof Settings.init;
+	loadSettingsForScope?: typeof Settings.loadForScope;
 }
 
 export async function runRootCommand(
@@ -1055,10 +1056,6 @@ export async function runRootCommand(
 		await logger.time("maybeAutoChdir", maybeAutoChdir, parsedArgs);
 		autoChdirApplied = true;
 		const resumeCwd = getProjectDir();
-		const resumeMigrationPolicy =
-			(await Settings.loadForScope({ cwd: resumeCwd })).get("session.directoryMigration") === "disabled"
-				? "disabled"
-				: "copy-retain";
 		const sessions = await (deps.listForResumePickerReadOnly ?? SessionManager.listForResumePickerReadOnly)(
 			resumeCwd,
 			parsedArgs.sessionDir,
@@ -1073,6 +1070,12 @@ export async function runRootCommand(
 		if (selection.kind === "cancelled") {
 			return;
 		}
+		const resumeMigrationPolicy =
+			(await (deps.loadSettingsForScope ?? Settings.loadForScope)({ cwd: resumeCwd })).get(
+				"session.directoryMigration",
+			) === "disabled"
+				? "disabled"
+				: "copy-retain";
 		let opened: StrictSessionOpenResult;
 		try {
 			opened = await (deps.openExistingSessionStrict ?? SessionManager.openExistingStrict)(

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1806,8 +1806,10 @@ async function getSortedSessions(sessionDir: string, storage: SessionStorage): P
 					if (entries.length === 0) return;
 					const header = entries[0] as Record<string, unknown>;
 					if (header.type !== "session" || typeof header.id !== "string") return;
-					for (const patch of await readSessionListTrailingPatches(path, storage, buffer)) {
-						applySessionListHeaderPatch(header as unknown as SessionListHeader, patch);
+					if (header.version === CURRENT_SESSION_VERSION) {
+						for (const patch of await readSessionListTrailingPatches(path, storage, buffer)) {
+							applySessionListHeaderPatch(header as unknown as SessionListHeader, patch);
+						}
 					}
 					const mtime = storage.statSync(path).mtimeMs;
 					const firstPrompt = header.title ? undefined : extractFirstUserPrompt(entries);

--- a/packages/coding-agent/test/resume-confirm-continue.test.ts
+++ b/packages/coding-agent/test/resume-confirm-continue.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import * as path from "node:path";
 import type { Args } from "../src/cli/args";
 import { parseArgs } from "../src/cli/args";
@@ -182,16 +182,31 @@ describe("bare resume startup gating", () => {
 		expect(pickerCalls).toBe(0);
 		expect(opens).toBe(0);
 
-		await runRootCommand(bareArgs(), [], {
-			suppressProcessExit: true,
-			isResumePickerTerminal: () => true,
-			listForResumePickerReadOnly: async () => [sessionInfo],
-			selectResumeSession: async () => ({ kind: "cancelled" }),
-			openExistingSessionStrict: async () => {
-				opens++;
-				return { kind: "error", reason: "missing" };
-			},
-		});
+		let settingsLoads = 0;
+		const stdoutWrite = spyOn(process.stdout, "write").mockImplementation(() => true);
+		const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => true);
+		try {
+			await runRootCommand(bareArgs(), [], {
+				suppressProcessExit: true,
+				isResumePickerTerminal: () => true,
+				listForResumePickerReadOnly: async () => [sessionInfo],
+				selectResumeSession: async () => ({ kind: "cancelled" }),
+				loadSettingsForScope: async () => {
+					settingsLoads++;
+					throw new Error("settings must not load after picker cancellation");
+				},
+				openExistingSessionStrict: async () => {
+					opens++;
+					return { kind: "error", reason: "missing" };
+				},
+			});
+		} finally {
+			stdoutWrite.mockRestore();
+			stderrWrite.mockRestore();
+		}
+		expect(settingsLoads).toBe(0);
+		expect(stdoutWrite).not.toHaveBeenCalled();
+		expect(stderrWrite).not.toHaveBeenCalled();
 		expect(opens).toBe(0);
 
 		await runRootCommand(bareArgs(), [], {

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -159,6 +159,35 @@ describe("getRecentSessions", () => {
 		expect(session?.name).toBe("Patched title");
 	});
 
+	it("ignores trailing v4 header patches when listing legacy transcripts", async () => {
+		const file = path.join(tempDir, "legacy-patched-large.jsonl");
+		const records = [
+			{
+				type: "session",
+				version: 3,
+				id: "legacy-patched-large",
+				timestamp: "2025-01-01T00:00:00Z",
+				cwd: "/legacy",
+				title: "Legacy title",
+			},
+			{
+				type: "message",
+				id: "message",
+				parentId: null,
+				timestamp: "2025-01-01T00:00:01Z",
+				message: { role: "user", content: "x".repeat(5_000), timestamp: 1 },
+			},
+			{ type: "header_patch", patch: { title: "Invalid v4 title", cwd: "/invalid-v4-cwd" } },
+		];
+		fs.writeFileSync(file, `${records.map(record => JSON.stringify(record)).join("\n")}\n`);
+
+		const [recent] = await getRecentSessions(tempDir);
+		const [listed] = await SessionManager.list("/legacy", tempDir);
+
+		expect(recent?.name).toBe("Legacy title");
+		expect(listed).toMatchObject({ id: "legacy-patched-large", title: "Legacy title", cwd: "/legacy" });
+	});
+
 	it("replays oversized and separated strict header patches in both listing paths", async () => {
 		const file = path.join(tempDir, "patched-oversized.jsonl");
 		const title = `Patched ${"title".repeat(1_200)}`;


### PR DESCRIPTION
## Summary
- gate bounded trailing header-patch replay to v4 transcripts
- defer writable settings loading until after bare-resume picker selection
- add a legacy-listing regression test

## Verification
- `bun test packages/coding-agent/test/session-manager/file-operations.test.ts packages/coding-agent/test/resume-confirm-continue.test.ts`
- `bun --cwd=packages/coding-agent run check`

No new follow-up issue is created; issue #2359 remains closed completed.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*