### PR TITLE
fix(model-resolver): single thinking-suffix parser (#2379 follow-up)

### DIFF
--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -7,7 +7,7 @@ import { type Api, DEFAULT_MODEL_PER_PROVIDER, type KnownProvider, type Model, m
 
 import { logger } from "@gajae-code/utils";
 import chalk from "chalk";
-import { parseThinkingLevel, resolveThinkingLevelForModel } from "../thinking";
+import { parseThinkingLevel, resolveThinkingLevelForModel, splitSelectorThinkingSuffix } from "../thinking";
 import { isAuthenticatedOrKeyless } from "./model-auth";
 import { compareEquivalentModelVariants } from "./model-equivalence";
 import { MODEL_ROLE_IDS, type ModelRegistry, type ModelRole } from "./model-registry";
@@ -37,27 +37,8 @@ export interface ScopedModel extends ScopedModelSelection {
 	explicitThinkingLevel: boolean;
 }
 
-/**
- * Parse a model string in "provider/modelId" format.
- * Returns undefined if the format is invalid.
- */
-export interface SelectorThinkingSuffix {
-	selector: string;
-	thinkingLevel?: ThinkingLevel;
-	invalidSuffix?: string;
-}
-
-/** Split the final selector suffix once, preserving colons in model IDs. */
-export function splitSelectorThinkingSuffix(selector: string): SelectorThinkingSuffix {
-	const colonIndex = selector.lastIndexOf(":");
-	if (colonIndex === -1) return { selector };
-
-	const suffix = selector.slice(colonIndex + 1);
-	const thinkingLevel = parseThinkingLevel(suffix);
-	return thinkingLevel
-		? { selector: selector.slice(0, colonIndex), thinkingLevel }
-		: { selector: selector.slice(0, colonIndex), invalidSuffix: suffix };
-}
+export type { SelectorThinkingSuffix } from "../thinking";
+export { splitSelectorThinkingSuffix } from "../thinking";
 
 /**
  * Parse a model string in "provider/modelId" format.

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -18,6 +18,7 @@ import {
 	formatModelSelectorValue,
 	parseModelPattern,
 	parseModelString,
+	splitSelectorThinkingSuffix,
 } from "../config/model-resolver";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../discovery/helpers.js";
 import { resolveMemoryBackend } from "../memory-backend";
@@ -253,12 +254,9 @@ function parseModelCommandArgs(args: string): ParsedModelCommandArgs {
 
 function splitExplicitThinkingSelector(selector: string): { baseSelector: string; thinkingLevel?: ThinkingLevel } {
 	const trimmed = selector.trim();
-	const colonIndex = trimmed.lastIndexOf(":");
-	if (colonIndex === -1) {
-		return { baseSelector: trimmed };
-	}
-	const thinkingLevel = parseThinkingLevel(trimmed.slice(colonIndex + 1));
-	return thinkingLevel ? { baseSelector: trimmed.slice(0, colonIndex), thinkingLevel } : { baseSelector: trimmed };
+	const { selector: baseSelector, thinkingLevel } = splitSelectorThinkingSuffix(trimmed);
+	// Preserve the whole selector when the trailing suffix is not a valid thinking level.
+	return thinkingLevel ? { baseSelector, thinkingLevel } : { baseSelector: trimmed };
 }
 
 interface ModelCommandSelection {

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -57,17 +57,32 @@ export function clampExplicitThinkingLevelForModel(
 	return clampThinkingLevelForModel(model, level);
 }
 
+export interface SelectorThinkingSuffix {
+	selector: string;
+	thinkingLevel?: ThinkingLevel;
+	invalidSuffix?: string;
+}
+
+/** Split the final selector suffix once, preserving colons in model IDs. */
+export function splitSelectorThinkingSuffix(selector: string): SelectorThinkingSuffix {
+	const colonIndex = selector.lastIndexOf(":");
+	if (colonIndex === -1) return { selector };
+
+	const suffix = selector.slice(colonIndex + 1);
+	const thinkingLevel = parseThinkingLevel(suffix);
+	return thinkingLevel
+		? { selector: selector.slice(0, colonIndex), thinkingLevel }
+		: { selector: selector.slice(0, colonIndex), invalidSuffix: suffix };
+}
+
 export function formatClampedModelSelector(selector: string, model: Model | undefined): string {
 	const slashIdx = selector.indexOf("/");
 	if (slashIdx <= 0) return selector;
 	const id = selector.slice(slashIdx + 1);
-	const colonIdx = id.lastIndexOf(":");
-	if (colonIdx === -1) return selector;
-	const suffix = id.slice(colonIdx + 1);
-	const thinkingLevel = parseThinkingLevel(suffix);
+	const { selector: baseId, thinkingLevel } = splitSelectorThinkingSuffix(id);
 	if (!thinkingLevel) return selector;
 	const clamped = clampExplicitThinkingLevelForModel(model, thinkingLevel);
 	return clamped && clamped !== ThinkingLevel.Inherit
-		? `${selector.slice(0, slashIdx + 1)}${id.slice(0, colonIdx)}:${clamped}`
-		: selector.slice(0, slashIdx + 1) + id.slice(0, colonIdx);
+		? `${selector.slice(0, slashIdx + 1)}${baseId}:${clamped}`
+		: selector.slice(0, slashIdx + 1) + baseId;
 }


### PR DESCRIPTION
## Summary
Follow-up to #2473 (issue #2379) closing the last review/QA blocker: the staged resolver's single-parser contract was violated by two surviving duplicate thinking-suffix parsers.

- Moved `splitSelectorThinkingSuffix` + `SelectorThinkingSuffix` into `thinking.ts` (co-located with `parseThinkingLevel` to avoid an import cycle); re-exported from `config/model-resolver` so all existing importers are unaffected.
- `thinking.ts` `formatClampedModelSelector` now delegates its id-suffix parse to the canonical splitter.
- `slash-commands/builtin-registry` `splitExplicitThinkingSelector` now delegates to the canonical splitter, preserving whole-selector fallback on invalid suffix.

The OpenRouter route/variant suffix parser (`getOpenRouterRouteSuffix`) is a distinct non-thinking concern (the #2379-preserved OpenRouter fallback) and is intentionally untouched.

## Verification
- `bun run check:types` (coding-agent) green.
- `bun test model-resolver.test.ts model-resolver.golden.test.ts model-registry.test.ts`: 206 pass / 0 fail.
- Duplicate-parser audit: the only thinking-suffix `lastIndexOf(':')` is now the single canonical definition.

Refs #2379