### PR TITLE
fix(skills): align user discovery paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).
 - Coordinator MCP question polling now requires a session, reconciles pending workflow gates into bounded public questions, diagnostics, and reconciliation state, and submits bound idempotent answers through `workflow.gate_answer` without exposing private gate payloads (#2550).
-
+- Runtime skill discovery now follows native user config-root precedence: nearest project, canonical `GJC_CONFIG_DIR`/`PI_CONFIG_DIR`/`.gjc` `agent/skills`, configured legacy `<config>/skills`, then historical legacy `~/.gjc/skills`, preserving exact fallback precedence (#2572).
 
 ### Fixed
 - SDK host response delivery to a disconnected client no longer escalates a second structured-error send failure into a process-level unhandled rejection; failures stay local to that connection.

--- a/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
+++ b/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
@@ -4,7 +4,8 @@ import * as path from "node:path";
 import { findRepoRoot } from "../capability/fs";
 import type { Skill as CapabilitySkill } from "../capability/skill";
 import type { SkillsSettings } from "../config/settings-schema";
-import { compareSkillOrder, scanSkillsFromDir } from "../discovery/helpers";
+import { compareSkillOrder, SOURCE_PATHS, scanSkillsFromDir } from "../discovery/helpers";
+import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../skill-state/canonical-skills";
 import type { Skill } from "./skills";
 
 export type RuntimeSkillDiscoverySource = "project" | "user";
@@ -32,6 +33,7 @@ function getRuntimeHome(): string {
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;
+const BUILT_IN_SKILL_NAMES = new Set<string>(CANONICAL_GJC_WORKFLOW_SKILLS);
 
 function normalizeLimit(limit: number | undefined): number {
 	if (limit === undefined || !Number.isFinite(limit)) return DEFAULT_LIMIT;
@@ -54,6 +56,18 @@ async function getProjectSkillDirs(cwd: string, home: string): Promise<{ dirs: s
 		current = parent;
 	}
 	return { dirs, repoRoot };
+}
+
+function getUserSkillDirs(home: string): string[] {
+	const canonicalUserDir = SOURCE_PATHS.native.userAgent;
+	const configuredLegacyDir = SOURCE_PATHS.native.userBase;
+	return [
+		...new Set([
+			path.join(home, canonicalUserDir, "skills"),
+			path.join(home, configuredLegacyDir, "skills"),
+			path.join(home, ".gjc", "skills"),
+		]),
+	];
 }
 
 function getUseWhen(skill: CapabilitySkill): string[] | undefined {
@@ -110,6 +124,7 @@ function isAllowedByPolicy(
 	source: RuntimeSkillDiscoverySource,
 	policy: SkillsSettings | undefined,
 ): boolean {
+	if (BUILT_IN_SKILL_NAMES.has(skill.name)) return false;
 	if (!sourceEnabled(source, policy)) return false;
 	if (isDisabledSkill(skill.name, policy?.disabledExtensions)) return false;
 	if (matchesIgnorePatterns(skill.name, policy?.ignoredSkills)) return false;
@@ -158,12 +173,14 @@ export async function discoverRuntimeSkills(
 		}
 	}
 	if ((source === "all" || source === "user") && sourceEnabled("user", policy)) {
-		scanJobs.push(
-			scanSkillsFromDir(
-				{ cwd: options.cwd, home, repoRoot: home },
-				{ dir: path.join(home, ".gjc", "skills"), providerId: "runtime", level: "user", requireDescription: true },
-			).then(result => result.items.map(skill => ({ skill, source: "user" as const }))),
-		);
+		for (const dir of getUserSkillDirs(home)) {
+			scanJobs.push(
+				scanSkillsFromDir(
+					{ cwd: options.cwd, home, repoRoot: home },
+					{ dir, providerId: "runtime", level: "user", requireDescription: true },
+				).then(result => result.items.map(skill => ({ skill, source: "user" as const }))),
+			);
+		}
 	}
 
 	const seenNames = new Set<string>();
@@ -175,6 +192,7 @@ export async function discoverRuntimeSkills(
 		if (seenPaths.has(realPath) || seenNames.has(entry.skill.name)) continue;
 		seenPaths.add(realPath);
 		seenNames.add(entry.skill.name);
+
 		const candidate: RuntimeSkillDiscoveryCandidate = {
 			name: entry.skill.name,
 			description:
@@ -213,12 +231,14 @@ export async function findRuntimeSkillByName(
 		);
 	}
 	if (sourceEnabled("user", policy)) {
-		scanJobs.push(
-			scanSkillsFromDir(
-				{ cwd, home, repoRoot: home },
-				{ dir: path.join(home, ".gjc", "skills"), providerId: "runtime", level: "user", requireDescription: true },
-			).then(result => result.items.map(skill => ({ skill, source: "user" as const }))),
-		);
+		for (const dir of getUserSkillDirs(home)) {
+			scanJobs.push(
+				scanSkillsFromDir(
+					{ cwd, home, repoRoot: home },
+					{ dir, providerId: "runtime", level: "user", requireDescription: true },
+				).then(result => result.items.map(skill => ({ skill, source: "user" as const }))),
+			);
+		}
 	}
 	for (const entry of (await Promise.all(scanJobs)).flat()) {
 		if (entry.skill.name === normalized && isAllowedByPolicy(entry.skill, entry.source, policy)) {

--- a/packages/coding-agent/src/prompts/tools/skill-discovery.md
+++ b/packages/coding-agent/src/prompts/tools/skill-discovery.md
@@ -1,8 +1,7 @@
 Discover project and user runtime skills without loading full skill content.
 
 <instruction>
-- Searches only custom runtime skill locations: project `.gjc/skills` and user `~/.gjc/skills`.
-- Built-in, bundled, and internal workflow skills are intentionally excluded.
+- Searches only custom runtime skill locations: nearest project `.gjc/skills`; then, under the home directory, canonical `<config>/agent/skills`, configured legacy `<config>/skills`, and historical legacy `.gjc/skills`. `<config>` is the home-relative directory name from `GJC_CONFIG_DIR`, then `PI_CONFIG_DIR`, then `.gjc`; even an absolute-looking configured name is joined beneath `<home>`. Duplicate names use that exact precedence. Built-in, bundled, and internal workflow skills are intentionally excluded.
 - Returns thin metadata only: name, description, source scope, path, and use conditions when present.
 - To load a selected skill's full `SKILL.md`, invoke it through the existing `skill` tool with the exact `name` returned here.
 </instruction>

--- a/packages/coding-agent/test/tools/skill-discovery.test.ts
+++ b/packages/coding-agent/test/tools/skill-discovery.test.ts
@@ -3,13 +3,20 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { getSessionSlashCommands } from "@gajae-code/coding-agent/extensibility/extensions/get-commands-handler";
 import type { Skill } from "@gajae-code/coding-agent/extensibility/skills";
 import { buildSystemPrompt } from "@gajae-code/coding-agent/system-prompt";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { SkillTool } from "@gajae-code/coding-agent/tools/skill";
 import { SkillDiscoveryTool } from "@gajae-code/coding-agent/tools/skill-discovery";
 
-async function makeSkill(root: string, name: string, description: string, body = "Skill body"): Promise<string> {
+async function makeSkill(
+	root: string,
+	name: string,
+	description: string,
+	body = "Skill body",
+	hide = false,
+): Promise<string> {
 	const dir = path.join(root, name);
 	await fs.mkdir(dir, { recursive: true });
 	const filePath = path.join(dir, "SKILL.md");
@@ -18,6 +25,8 @@ async function makeSkill(root: string, name: string, description: string, body =
 		`---
 name: ${name}
 description: ${description}
+${hide ? "hide: true\n" : ""}
+
 globs:
   - "**/*.ts"
 ---
@@ -135,6 +144,12 @@ describe("SkillDiscoveryTool", () => {
 	it("does not return bundled built-in skills or grow the core prompt catalog", async () => {
 		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-builtins-suppressed-"));
 		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill");
+		await makeSkill(
+			path.join(cwd, ".gjc", "skills"),
+			"ralplan",
+			"On-disk built-in impostor",
+			"Should be suppressed.",
+		);
 		const settings = runtimeSkillSettings();
 		const builtInSkill: Skill = {
 			name: "ralplan",
@@ -151,6 +166,7 @@ describe("SkillDiscoveryTool", () => {
 		const names = details!.candidates.map(candidate => candidate.name);
 		expect(names).toContain("project-helper");
 		expect(names).not.toContain("ralplan");
+		expect(result.details?.candidates.find(candidate => candidate.name === "ralplan")).toBeUndefined();
 
 		const prompt = await buildSystemPrompt({
 			cwd,
@@ -215,6 +231,227 @@ describe("SkillDiscoveryTool", () => {
 		);
 		await expect(tool.execute("call", { name: "project-helper" })).rejects.toThrow(/unknown skill/);
 		expect(sent).toHaveLength(0);
+	});
+
+	it("discovers canonical and legacy user roots in native precedence order", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-user-root-cwd-"));
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-user-root-home-"));
+		const originalHome = process.env.HOME;
+		const originalGjcConfigDir = process.env.GJC_CONFIG_DIR;
+		const originalPiConfigDir = process.env.PI_CONFIG_DIR;
+		const originalCodingAgentDir = process.env.GJC_CODING_AGENT_DIR;
+		const originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+
+		try {
+			process.env.HOME = home;
+			process.env.GJC_CONFIG_DIR = "/absolute-looking-gjc";
+			process.env.PI_CONFIG_DIR = ".decoy-pi";
+			process.env.GJC_CODING_AGENT_DIR = path.join(home, ".decoy-agent");
+			process.env.PI_CODING_AGENT_DIR = path.join(home, ".decoy-pi-agent");
+			process.env.XDG_CONFIG_HOME = path.join(home, ".xdg-decoy");
+
+			await makeSkill(
+				path.join(home, "/absolute-looking-gjc", "agent", "skills"),
+				"shared",
+				"Canonical user skill",
+				"Canonical body.",
+			);
+			await makeSkill(
+				path.join(home, "/absolute-looking-gjc", "skills"),
+				"shared",
+				"Configured legacy user skill",
+				"Legacy body.",
+			);
+			await makeSkill(path.join(home, ".gjc", "skills"), "historical", "Historical legacy user skill");
+			await makeSkill(path.join(cwd, ".gjc", "skills"), "shared", "Project user skill", "Project body.");
+
+			await makeSkill(path.join(home, ".decoy-agent", "skills"), "decoy", "Decoy user skill");
+			await makeSkill(path.join(home, ".decoy-pi-agent", "skills"), "pi-decoy", "PI decoy user skill");
+			await makeSkill(path.join(home, ".xdg-decoy", "gjc", "agent", "skills"), "xdg-decoy", "XDG decoy user skill");
+
+			const result = await new SkillDiscoveryTool(createSession(cwd, { settings: runtimeSkillSettings() })).execute(
+				"call",
+				{
+					source: "user",
+				},
+			);
+			expect(result.details?.candidates).toEqual([
+				expect.objectContaining({
+					name: "historical",
+					description: "Historical legacy user skill",
+					source: "user",
+				}),
+				expect.objectContaining({ name: "shared", description: "Canonical user skill", source: "user" }),
+			]);
+
+			const allSources = await new SkillDiscoveryTool(
+				createSession(cwd, { settings: runtimeSkillSettings() }),
+			).execute("call", {});
+			expect(allSources.details?.candidates).toEqual([
+				expect.objectContaining({ name: "historical", source: "user" }),
+				expect.objectContaining({ name: "shared", description: "Project user skill", source: "project" }),
+			]);
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			if (originalGjcConfigDir === undefined) delete process.env.GJC_CONFIG_DIR;
+			else process.env.GJC_CONFIG_DIR = originalGjcConfigDir;
+			if (originalPiConfigDir === undefined) delete process.env.PI_CONFIG_DIR;
+			else process.env.PI_CONFIG_DIR = originalPiConfigDir;
+			if (originalCodingAgentDir === undefined) delete process.env.GJC_CODING_AGENT_DIR;
+			else process.env.GJC_CODING_AGENT_DIR = originalCodingAgentDir;
+			if (originalPiCodingAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
+			if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+			else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+			await fs.rm(cwd, { recursive: true, force: true });
+			await fs.rm(home, { recursive: true, force: true });
+		}
+	});
+
+	it("uses the default and PI_CONFIG_DIR canonical user roots", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-user-canonical-cwd-"));
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-user-canonical-home-"));
+		const originalHome = process.env.HOME;
+		const originalGjcConfigDir = process.env.GJC_CONFIG_DIR;
+		const originalPiConfigDir = process.env.PI_CONFIG_DIR;
+		try {
+			process.env.HOME = home;
+			delete process.env.GJC_CONFIG_DIR;
+			delete process.env.PI_CONFIG_DIR;
+			await makeSkill(
+				path.join(home, ".gjc", "agent", "skills"),
+				"default-canonical",
+				"Default canonical user skill",
+			);
+			await makeSkill(path.join(home, ".gjc", "skills"), "default-canonical", "Default legacy user skill");
+			let result = await new SkillDiscoveryTool(createSession(cwd, { settings: runtimeSkillSettings() })).execute(
+				"call",
+				{
+					source: "user",
+				},
+			);
+			expect(result.details?.candidates).toEqual([
+				expect.objectContaining({ name: "default-canonical", description: "Default canonical user skill" }),
+			]);
+
+			process.env.PI_CONFIG_DIR = ".pi-config";
+			await makeSkill(path.join(home, ".pi-config", "agent", "skills"), "pi-canonical", "PI canonical user skill");
+			result = await new SkillDiscoveryTool(createSession(cwd, { settings: runtimeSkillSettings() })).execute(
+				"call",
+				{
+					source: "user",
+				},
+			);
+			expect(result.details?.candidates.map(candidate => candidate.name)).toEqual([
+				"default-canonical",
+				"pi-canonical",
+			]);
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			if (originalGjcConfigDir === undefined) delete process.env.GJC_CONFIG_DIR;
+			else process.env.GJC_CONFIG_DIR = originalGjcConfigDir;
+			if (originalPiConfigDir === undefined) delete process.env.PI_CONFIG_DIR;
+			else process.env.PI_CONFIG_DIR = originalPiConfigDir;
+			await fs.rm(cwd, { recursive: true, force: true });
+			await fs.rm(home, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps hidden runtime skills discoverable and exactly invocable", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-hidden-runtime-skill-"));
+		try {
+			await makeSkill(
+				path.join(cwd, ".gjc", "skills"),
+				"hidden-helper",
+				"Hidden helper skill",
+				"Hidden body.",
+				true,
+			);
+			const settings = runtimeSkillSettings();
+			const discovery = await new SkillDiscoveryTool(createSession(cwd, { settings })).execute("call", {
+				query: "hidden-helper",
+			});
+			expect(discovery.details?.candidates).toEqual([
+				expect.objectContaining({ name: "hidden-helper", description: "Hidden helper skill", source: "project" }),
+			]);
+
+			const sent: Array<{ content: string; details?: unknown }> = [];
+			await new SkillTool(
+				createSession(cwd, {
+					skills: [],
+					settings,
+					sendCustomMessage: async message => {
+						sent.push({ content: String(message.content), details: message.details });
+					},
+				}),
+			).execute("call", { name: "hidden-helper" });
+			expect(sent[0]?.content).toContain("Hidden body.");
+			const hiddenSkill: Skill = {
+				name: "hidden-helper",
+				description: "Hidden helper skill",
+				filePath: path.join(cwd, ".gjc", "skills", "hidden-helper", "SKILL.md"),
+				baseDir: path.join(cwd, ".gjc", "skills", "hidden-helper"),
+				source: "runtime:project",
+				hide: true,
+			};
+			expect(
+				getSessionSlashCommands({
+					customCommands: [],
+					skills: [hiddenSkill],
+					skillsSettings: runtimeSkillSettings().getGroup("skills"),
+				}).map(command => command.name),
+			).not.toContain("skill:hidden-helper");
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("applies policy before realpath/name dedup, then query, sort, and limit", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-skill-discovery-pipeline-"));
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-skill-discovery-pipeline-home-"));
+		const originalHome = process.env.HOME;
+		try {
+			process.env.HOME = home;
+			const skillsDir = path.join(cwd, ".gjc", "skills");
+			const alphaPath = await makeSkill(skillsDir, "alpha", "Sort alpha", "Alpha body.");
+			await fs.symlink(path.dirname(alphaPath), path.join(skillsDir, "zz-alias-alpha"), "dir");
+			await makeSkill(skillsDir, "ralplan", "Sort built-in", "Suppressed body.");
+			const userAlphaPath = await makeSkill(
+				path.join(home, ".gjc", "skills"),
+				"alpha",
+				"Lower-only user alpha",
+				"User body.",
+			);
+			await makeSkill(skillsDir, "zulu", "Sort zulu", "Zulu body.");
+
+			const userOnly = await new SkillDiscoveryTool(
+				createSession(cwd, { settings: runtimeSkillSettings({ "skills.enablePiProject": false }) }),
+			).execute("call", { query: "lower-only" });
+			expect(userOnly.details?.candidates).toEqual([
+				expect.objectContaining({ name: "alpha", path: userAlphaPath, source: "user" }),
+			]);
+
+			const dedupBeforeQuery = await new SkillDiscoveryTool(
+				createSession(cwd, { settings: runtimeSkillSettings() }),
+			).execute("call", { query: "lower-only" });
+			expect(dedupBeforeQuery.details?.candidates).toEqual([]);
+
+			const result = await new SkillDiscoveryTool(createSession(cwd, { settings: runtimeSkillSettings() })).execute(
+				"call",
+				{ query: "sort", limit: 1 },
+			);
+			expect(result.details?.candidates).toEqual([
+				expect.objectContaining({ name: "alpha", description: "Sort alpha", path: alphaPath, source: "project" }),
+			]);
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			await fs.rm(cwd, { recursive: true, force: true });
+			await fs.rm(home, { recursive: true, force: true });
+		}
 	});
 
 	it("applies source enable flags and skill filters to discovery and invocation", async () => {

--- a/packages/coding-agent/test/tools/skill.test.ts
+++ b/packages/coding-agent/test/tools/skill.test.ts
@@ -34,6 +34,33 @@ async function makeTempCwd(): Promise<string> {
 	return mkdtemp(path.join(os.tmpdir(), "skill-tool-cwd-"));
 }
 
+async function makeRuntimeSkill(root: string, name: string, description: string, body: string): Promise<string> {
+	const dir = path.join(root, name);
+	const filePath = path.join(dir, "SKILL.md");
+	await fs.mkdir(dir, { recursive: true });
+	await fs.writeFile(
+		filePath,
+		`---
+name: ${name}
+description: ${description}
+---
+
+${body}
+`,
+		"utf8",
+	);
+	return filePath;
+}
+
+function runtimeSkillSettings(): Settings {
+	return Settings.isolated({
+		"skill.enabled": true,
+		"skills.enabled": true,
+		"skills.enablePiProject": true,
+		"skills.enablePiUser": true,
+	});
+}
+
 function encodeSessionSegment(value: string): string {
 	return encodeURIComponent(value).replaceAll(".", "%2E");
 }
@@ -181,6 +208,223 @@ describe("SkillTool", () => {
 			settings: Settings.isolated(),
 		};
 		expect(SkillTool.createIf(session)).toBeNull();
+	});
+
+	it("uses runtime fallback through createIf while session skills retain name precedence", async () => {
+		const cwd = await makeTempCwd();
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "skill-tool-runtime-home-"));
+		const originalHome = process.env.HOME;
+		const originalGjcConfigDir = process.env.GJC_CONFIG_DIR;
+		const originalPiConfigDir = process.env.PI_CONFIG_DIR;
+		let unrelated: Skill | undefined;
+		let preloaded: Skill | undefined;
+		try {
+			process.env.HOME = home;
+			process.env.GJC_CONFIG_DIR = ".gjc";
+			delete process.env.PI_CONFIG_DIR;
+			const runtimePath = await makeRuntimeSkill(
+				path.join(home, ".gjc", "agent", "skills"),
+				"runtime-helper",
+				"Runtime helper",
+				"Runtime fallback body.",
+			);
+			unrelated = await makeSkill("unrelated", "Unrelated body.");
+			const captured: CapturedSend[] = [];
+			const session = createSession(cwd, [unrelated], captured, { settings: runtimeSkillSettings() });
+
+			const tool = SkillTool.createIf(session);
+			expect(tool).not.toBeNull();
+			const fallback = await tool!.execute("call-1", { name: "runtime-helper" });
+			expect(captured[0]?.message.content).toContain("Runtime fallback body.");
+			expect(fallback.details?.path).toBe(runtimePath);
+
+			preloaded = await makeSkill("runtime-helper", "Preloaded body.");
+			const preloadedCaptured: CapturedSend[] = [];
+			const preloadedTool = SkillTool.createIf(
+				createSession(cwd, [unrelated, preloaded], preloadedCaptured, {
+					settings: runtimeSkillSettings(),
+				}),
+			);
+			expect(preloadedTool).not.toBeNull();
+			const preloadedResult = await preloadedTool!.execute("call-2", { name: "runtime-helper" });
+			expect(preloadedCaptured[0]?.message.content).toContain("Preloaded body.");
+			expect(preloadedCaptured[0]?.message.content).not.toContain("Runtime fallback body.");
+			expect(preloadedResult.details?.path).toBe(preloaded.filePath);
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			if (originalGjcConfigDir === undefined) delete process.env.GJC_CONFIG_DIR;
+			else process.env.GJC_CONFIG_DIR = originalGjcConfigDir;
+			if (originalPiConfigDir === undefined) delete process.env.PI_CONFIG_DIR;
+			else process.env.PI_CONFIG_DIR = originalPiConfigDir;
+			if (unrelated) await fs.rm(unrelated.baseDir, { recursive: true, force: true });
+			if (preloaded) await fs.rm(preloaded.baseDir, { recursive: true, force: true });
+			await fs.rm(cwd, { recursive: true, force: true });
+			await fs.rm(home, { recursive: true, force: true });
+		}
+	});
+
+	it("uses exact runtime fallback precedence across project, canonical, configured, and historical roots", async () => {
+		const cwd = await makeTempCwd();
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "skill-tool-runtime-precedence-home-"));
+		const originalHome = process.env.HOME;
+		const originalGjcConfigDir = process.env.GJC_CONFIG_DIR;
+		const originalPiConfigDir = process.env.PI_CONFIG_DIR;
+		const originalCodingAgentDir = process.env.GJC_CODING_AGENT_DIR;
+		const originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+		let loaded: Skill | undefined;
+		try {
+			process.env.HOME = home;
+			delete process.env.GJC_CONFIG_DIR;
+			delete process.env.PI_CONFIG_DIR;
+			const gjcAgentDecoyDir = path.join(home, "gjc-agent-decoy");
+			const piAgentDecoyDir = path.join(home, "pi-agent-decoy");
+			const xdgConfigHome = path.join(home, "xdg-decoy");
+			process.env.GJC_CODING_AGENT_DIR = gjcAgentDecoyDir;
+			process.env.PI_CODING_AGENT_DIR = piAgentDecoyDir;
+			process.env.XDG_CONFIG_HOME = xdgConfigHome;
+			const defaultCanonicalPath = await makeRuntimeSkill(
+				path.join(home, ".gjc", "agent", "skills"),
+				"default-canonical",
+				"Default canonical",
+				"Default canonical body.",
+			);
+			const captured: CapturedSend[] = [];
+			loaded = await makeSkill("loaded", "Loaded");
+			const tool = SkillTool.createIf(createSession(cwd, [loaded], captured, { settings: runtimeSkillSettings() }))!;
+			const defaultResult = await tool.execute("call-default-canonical", { name: "default-canonical" });
+			expect(captured.at(-1)?.message.content).toContain("Default canonical body.");
+			expect(defaultResult.details?.path).toBe(defaultCanonicalPath);
+
+			process.env.GJC_CONFIG_DIR = ".configured-gjc";
+			process.env.PI_CONFIG_DIR = ".configured-pi";
+			const configuredRoot = path.join(home, ".configured-gjc");
+			const canonicalPath = await makeRuntimeSkill(
+				path.join(configuredRoot, "agent", "skills"),
+				"canonical-only",
+				"Canonical",
+				"Canonical body.",
+			);
+			const configuredPath = await makeRuntimeSkill(
+				path.join(configuredRoot, "skills"),
+				"configured-only",
+				"Configured legacy",
+				"Configured legacy body.",
+			);
+			const historicalPath = await makeRuntimeSkill(
+				path.join(home, ".gjc", "skills"),
+				"historical-only",
+				"Historical legacy",
+				"Historical body.",
+			);
+			const projectPath = await makeRuntimeSkill(
+				path.join(cwd, ".gjc", "skills"),
+				"winner",
+				"Project",
+				"Project body.",
+			);
+			await makeRuntimeSkill(
+				path.join(configuredRoot, "agent", "skills"),
+				"winner",
+				"Canonical",
+				"Canonical winner body.",
+			);
+			await makeRuntimeSkill(path.join(configuredRoot, "skills"), "winner", "Configured", "Configured winner body.");
+			await makeRuntimeSkill(path.join(home, ".gjc", "skills"), "winner", "Historical", "Historical winner body.");
+			const canonicalDuplicatePath = await makeRuntimeSkill(
+				path.join(configuredRoot, "agent", "skills"),
+				"canonical-configured-historical",
+				"Canonical duplicate",
+				"Canonical duplicate body.",
+			);
+			await makeRuntimeSkill(
+				path.join(configuredRoot, "skills"),
+				"canonical-configured-historical",
+				"Configured duplicate",
+				"Configured duplicate body.",
+			);
+			await makeRuntimeSkill(
+				path.join(home, ".gjc", "skills"),
+				"canonical-configured-historical",
+				"Historical duplicate",
+				"Historical duplicate body.",
+			);
+			const configuredDuplicatePath = await makeRuntimeSkill(
+				path.join(configuredRoot, "skills"),
+				"configured-historical",
+				"Configured duplicate",
+				"Configured duplicate body.",
+			);
+			await makeRuntimeSkill(
+				path.join(home, ".gjc", "skills"),
+				"configured-historical",
+				"Historical duplicate",
+				"Historical duplicate body.",
+			);
+			const gjcDecoyPath = await makeRuntimeSkill(
+				path.join(gjcAgentDecoyDir, "skills"),
+				"gjc-direct-decoy",
+				"GJC direct decoy",
+				"Decoy.",
+			);
+			const piDecoyPath = await makeRuntimeSkill(
+				path.join(piAgentDecoyDir, "skills"),
+				"pi-direct-decoy",
+				"PI direct decoy",
+				"Decoy.",
+			);
+			const xdgDecoyPath = await makeRuntimeSkill(
+				path.join(xdgConfigHome, "gjc", "agent", "skills"),
+				"xdg-decoy",
+				"XDG decoy",
+				"Decoy.",
+			);
+			for (const [name, expectedPath, body] of [
+				["canonical-only", canonicalPath, "Canonical body."],
+				["configured-only", configuredPath, "Configured legacy body."],
+				["historical-only", historicalPath, "Historical body."],
+				["winner", projectPath, "Project body."],
+				["canonical-configured-historical", canonicalDuplicatePath, "Canonical duplicate body."],
+				["configured-historical", configuredDuplicatePath, "Configured duplicate body."],
+			] as const) {
+				const result = await tool.execute(`call-${name}`, { name });
+				expect(captured.at(-1)?.message.content).toContain(body);
+				expect(result.details?.path).toBe(expectedPath);
+			}
+			delete process.env.GJC_CONFIG_DIR;
+			const piCanonicalPath = await makeRuntimeSkill(
+				path.join(home, ".configured-pi", "agent", "skills"),
+				"pi-canonical",
+				"PI canonical",
+				"PI canonical body.",
+			);
+			const piResult = await tool.execute("call-pi", { name: "pi-canonical" });
+			expect(captured.at(-1)?.message.content).toContain("PI canonical body.");
+			expect(piResult.details?.path).toBe(piCanonicalPath);
+			const capturedBeforeDecoys = captured.length;
+			for (const name of ["gjc-direct-decoy", "pi-direct-decoy", "xdg-decoy"]) {
+				await expect(tool.execute(`call-${name}`, { name })).rejects.toThrow(/unknown skill/);
+			}
+			expect(captured).toHaveLength(capturedBeforeDecoys);
+			expect([gjcDecoyPath, piDecoyPath, xdgDecoyPath]).not.toContain(piResult.details?.path);
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			if (originalGjcConfigDir === undefined) delete process.env.GJC_CONFIG_DIR;
+			else process.env.GJC_CONFIG_DIR = originalGjcConfigDir;
+			if (originalPiConfigDir === undefined) delete process.env.PI_CONFIG_DIR;
+			else process.env.PI_CONFIG_DIR = originalPiConfigDir;
+			if (originalCodingAgentDir === undefined) delete process.env.GJC_CODING_AGENT_DIR;
+			else process.env.GJC_CODING_AGENT_DIR = originalCodingAgentDir;
+			if (originalPiCodingAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
+			if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+			else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+			if (loaded) await fs.rm(loaded.baseDir, { recursive: true, force: true });
+			await fs.rm(cwd, { recursive: true, force: true });
+			await fs.rm(home, { recursive: true, force: true });
+		}
 	});
 
 	it("dispatches the chained skill same-turn without deliverAs nextTurn", async () => {


### PR DESCRIPTION
## Summary
- align `skill_discovery` and exact runtime fallback with the native configurable user skill root
- retain configured and historical legacy user roots with deterministic precedence
- preserve project/session precedence, built-in suppression, `hide: true`, and policy gates
- add focused regression coverage for default/override/legacy/duplicate and non-regression behavior

## Verification
- `bun --cwd=packages/coding-agent test test/tools/skill-discovery.test.ts test/tools/skill.test.ts` — 37 passed, 0 failed
- `bun --cwd=packages/coding-agent run check` — passed
- `bun --cwd=packages/coding-agent run build` — passed
- final SHA `e16e232020caabda48c8b537d94aa5aa9f032fdd` — Architect CLEAR/APPROVE; adversarial QA passed

## Aggregate-suite causality
The noisy broad suite is not attributed to this changed surface. The current parallel run ended after a Bun worker SIGILL with 5120 pass / 10 skip / 605 fail / 1 error across 5735 tests and 1027 files. An isolated `origin/dev` worktree independently produced 11315 pass / 348 skip / 25 fail / 3 errors across 11688 tests and 1027 files. `AD-M-C23: retry.auto.set forwarded` passes in isolation on both the final branch and `origin/dev`; its aggregate producer stack ran through `withFixtureBrokerEnvironment` into model-registry/model-equivalence OOM after prior unrelated failures.

Closes #2572