### PR TITLE
fix(ci): repair postmerge settings hotfix shards

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -332,14 +332,14 @@ jobs:
       - name: Validate canonical affected plan
         run: bun scripts/ci-dev-affected.ts --validate-plan
       - name: Download shard completion receipts
-        if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' }}
+        if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' && needs.affected-shards.result == 'success' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: dev-affected-shard-${{ github.run_id }}-*
           path: .ci-dev-shard-receipts
           merge-multiple: true
       - name: Validate canonical shard completion
-        if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' }}
+        if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' && needs.affected-shards.result == 'success' }}
         run: bun scripts/ci-dev-affected.ts --validate-shard-receipts
       - name: Aggregate affected path validation shards
         env:

--- a/artifacts/pr2478-postmerge-hotfix-test-report.json
+++ b/artifacts/pr2478-postmerge-hotfix-test-report.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "kind": "api-package-test-report",
+  "commit": "5a253ec8826ab4b00b62e66fb304405c9ed9d426",
+  "base": "d5660c7e5c7153898923388eb370b7df59052c91",
+  "status": "passed",
+  "summary": {
+    "tests": 175,
+    "assertions": 2232,
+    "failures": 0,
+    "packageCheck": "passed",
+    "build": "passed",
+    "sdkInventoryCheck": "passed",
+    "cleaner": "passed",
+    "architectReview": "CLEAR/APPROVE"
+  },
+  "commands": [
+    "bun test packages/coding-agent/test/command-palette.test.ts packages/coding-agent/test/file-lock-gc-toctou.test.ts packages/coding-agent/test/sdk-operation-inventory.test.ts packages/coding-agent/test/sdk-operation-matrix.test.ts packages/coding-agent/test/slash-command-builtin-registry.test.ts packages/coding-agent/test/agent-session-default-model-selection.test.ts packages/coding-agent/test/config/atomic-yaml-patch.test.ts packages/coding-agent/test/harness-control-plane/receipt-spool.test.ts scripts/ci-dev-affected.test.ts",
+    "bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts --check",
+    "bun --cwd=packages/coding-agent run check",
+    "bun run build"
+  ],
+  "adversarialCoverage": [
+    "command palette draft preservation and overlapping dispatch",
+    "file-lock missing/changed ownership and dual failure",
+    "SDK scanner missing/unbalanced anchors and explicit exclusion metadata",
+    "goal builtin canonical controller fixture",
+    "affected aggregate failed/cancelled/skipped truth table",
+    "strict missing/extra/duplicate/wrong/malformed shard receipts",
+    "default-model durable and cleanup failure recovery",
+    "atomic YAML concurrency, CAS conflict, and rename failure"
+  ],
+  "blockers": []
+}

--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -62,6 +62,8 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"agent_session:closeWriterStrict": "internal ACP lifecycle teardown plumbing, not a user-facing control seam",
 	"agent_session:disposeChildSubprocesses": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:waitForIdle": "internal accessor/plumbing, not a user-facing control seam",
+	"agent_session:awaitPendingContextTransformations":
+		"internal context-transformation lifecycle barrier, not a user-facing SDK control seam",
 	"agent_session:drainAsyncJobDeliveriesForAcp": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:getAsyncDeliveryStateForAcp":
 		"internal ACP lifecycle quiescence plumbing, not a user-facing control seam",

--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -276,16 +276,29 @@ export interface SourceSeam {
 	sourceFile: string;
 	sourceKind: SourceKind;
 }
-interface InventoryRecord {
+interface IncludedInventoryRecord {
 	sourceId: string;
 	sourceFile: string;
 	sourceKind: SourceKind;
-	decision: "include" | "exclude";
-	rationale?: string;
-	sdkId?: string;
+	decision: "include";
+	sdkId: string;
 	adapterMappings: Operation["adapterDispositions"];
 	testIds: string[];
 }
+
+interface ExcludedInventoryRecord {
+	sourceId: string;
+	sourceFile: string;
+	sourceKind: SourceKind;
+	decision: "exclude";
+	rationale: string;
+	exclusionMetadata: {
+		adapterMappings: "not_applicable";
+		testIds: "not_applicable";
+	};
+}
+
+type InventoryRecord = IncludedInventoryRecord | ExcludedInventoryRecord;
 
 function repoPath(file: string): string {
 	return path.relative(repoRoot, file).split(path.sep).join("/");
@@ -297,7 +310,10 @@ function collectCaseSeams(source: string, prefix: string): string[] {
 }
 
 export function scanSlashCommands(sourceText: string): string[] {
-	const builtinRegistry = sourceText.slice(sourceText.indexOf("const BUILTIN_SLASH_COMMAND_REGISTRY"));
+	const anchor = "const BUILTIN_SLASH_COMMAND_REGISTRY";
+	const anchorIndex = sourceText.indexOf(anchor);
+	if (anchorIndex === -1) throw new Error(`SDK operation inventory scanner: required anchor ${anchor} was not found.`);
+	const builtinRegistry = sourceText.slice(anchorIndex);
 	return [...builtinRegistry.matchAll(/^\t\tname:\s*["']([^"']+)["']/gm)].map(match => `slash_command:${match[1]}`);
 }
 
@@ -670,14 +686,17 @@ export function scanAgentSessionMethods(sourceText: string): string[] {
 		for (let bodyIndex = index + 2; bodyIndex < tokens.length; bodyIndex++) {
 			if (tokens[bodyIndex]!.text === "<") angleDepth++;
 			else if (tokens[bodyIndex]!.text === ">" && angleDepth > 0) angleDepth--;
+			else if (tokens[bodyIndex]!.text === ";" && angleDepth === 0) break;
 			else if (tokens[bodyIndex]!.text === "{" && angleDepth === 0) {
 				bodyStart = bodyIndex;
 				break;
 			}
 		}
-		if (bodyStart === undefined) return [];
+		if (bodyStart === undefined)
+			throw new Error("SDK operation inventory scanner: AgentSession class is missing its opening body delimiter.");
 		const bodyEnd = matchingToken(tokens, bodyStart, "{", "}");
-		if (bodyEnd === undefined) return [];
+		if (bodyEnd === undefined)
+			throw new Error("SDK operation inventory scanner: AgentSession class body is unbalanced.");
 
 		const methods: string[] = [];
 		for (let memberStart = bodyStart + 1; memberStart < bodyEnd; ) {
@@ -691,7 +710,7 @@ export function scanAgentSessionMethods(sourceText: string): string[] {
 		}
 		return methods;
 	}
-	return [];
+	throw new Error("SDK operation inventory scanner: required AgentSession class declaration was not found.");
 }
 
 export function scanAcpMethods(sourceText: string): string[] {
@@ -782,14 +801,24 @@ function generatedRecords(seams: Awaited<ReturnType<typeof scanSeams>>): Invento
 		const sdkId = SEAM_TO_SDK[seam.sourceId];
 		const rationale = lockedExclusion(seam.sourceId);
 		if (!sdkId && !rationale) continue;
-		const operation = sdkId ? OPERATIONS.find(candidate => candidate.sdkId === sdkId) : undefined;
-		if (sdkId && !operation) throw new Error(`SEAM_TO_SDK maps ${seam.sourceId} to unknown SDK ID: ${sdkId}`);
+		if (!sdkId) {
+			if (!rationale) continue;
+			records.push({
+				...seam,
+				decision: "exclude",
+				rationale,
+				exclusionMetadata: { adapterMappings: "not_applicable", testIds: "not_applicable" },
+			});
+			continue;
+		}
+		const operation = OPERATIONS.find(candidate => candidate.sdkId === sdkId);
+		if (!operation) throw new Error(`SEAM_TO_SDK maps ${seam.sourceId} to unknown SDK ID: ${sdkId}`);
 		records.push({
 			...seam,
-			decision: (sdkId ? "include" : "exclude") as "include" | "exclude",
-			...(sdkId ? { sdkId } : { rationale }),
-			adapterMappings: operation?.adapterDispositions ?? OPERATIONS[0]!.adapterDispositions,
-			testIds: operation?.testIds ?? ["packages/coding-agent/test/sdk-operation-inventory.test.ts"],
+			decision: "include",
+			sdkId,
+			adapterMappings: operation.adapterDispositions,
+			testIds: operation.testIds,
 		});
 	}
 	return records;
@@ -810,8 +839,17 @@ function validateRegistry(records: InventoryRecord[]): string[] {
 		if (operation.testIds.length === 0) errors.push(`${operation.id} is missing test IDs.`);
 	}
 	for (const record of records) {
-		if (record.decision === "exclude" && !record.rationale)
-			errors.push(`${record.sourceId} exclusion lacks a locked rationale.`);
+		if (record.decision === "exclude") {
+			if (!record.rationale) errors.push(`${record.sourceId} exclusion lacks a locked rationale.`);
+			if (
+				record.exclusionMetadata.adapterMappings !== "not_applicable" ||
+				record.exclusionMetadata.testIds !== "not_applicable"
+			)
+				errors.push(
+					`${record.sourceId} exclusion metadata must mark adapter mappings and test IDs as not applicable.`,
+				);
+			continue;
+		}
 		if (ADAPTERS.some(adapter => !record.adapterMappings[adapter]))
 			errors.push(`${record.sourceId} is missing adapter mappings.`);
 		if (record.testIds.length === 0) errors.push(`${record.sourceId} is missing test IDs.`);

--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -63,23 +63,26 @@ function writeLockInfo(lockPath: string): Promise<LockInfo> {
 }
 
 async function readLockInfo(lockPath: string): Promise<LockInfo | null> {
+	let parsed: unknown;
 	try {
-		const content = await fs.readFile(`${lockPath}/info`, "utf-8");
-		const info = JSON.parse(content) as Partial<LockInfo>;
-		if (
-			typeof info.pid !== "number" ||
-			!Number.isInteger(info.pid) ||
-			info.pid <= 0 ||
-			typeof info.timestamp !== "number" ||
-			!Number.isFinite(info.timestamp) ||
-			(info.start_time !== undefined && (typeof info.start_time !== "string" || !info.start_time))
-		) {
-			return null;
-		}
-		return info as LockInfo;
-	} catch {
-		return null;
+		parsed = JSON.parse(await fs.readFile(`${lockPath}/info`, "utf-8"));
+	} catch (error) {
+		if (isEnoent(error) || error instanceof SyntaxError) return null;
+		throw error;
 	}
+
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+	const { pid, start_time, timestamp } = parsed as Partial<LockInfo>;
+	if (
+		typeof pid !== "number" ||
+		!Number.isInteger(pid) ||
+		pid <= 0 ||
+		typeof timestamp !== "number" ||
+		!Number.isFinite(timestamp) ||
+		(start_time !== undefined && (typeof start_time !== "string" || !start_time))
+	)
+		return null;
+	return { pid, start_time, timestamp };
 }
 
 /** @internal */
@@ -237,11 +240,7 @@ async function tryAcquireLock(lockPath: string): Promise<LockInfo | null> {
 }
 
 async function releaseLock(lockPath: string, owner: FileLockOwnerToken): Promise<void> {
-	try {
-		await removeFileLockDirForGc(lockPath, owner);
-	} catch {
-		// Ignore errors on release
-	}
+	await removeFileLockDirForGc(lockPath, owner);
 }
 async function acquireLock(filePath: string, options: FileLockOptions = {}): Promise<() => Promise<void>> {
 	const opts = { ...DEFAULT_OPTIONS, ...options };
@@ -270,9 +269,17 @@ export async function withFileLock<T>(
 	options: FileLockOptions = {},
 ): Promise<T> {
 	const release = await acquireLock(filePath, options);
+	let result: T;
 	try {
-		return await fn();
-	} finally {
-		await release();
+		result = await fn();
+	} catch (operationError) {
+		try {
+			await release();
+		} catch (releaseError) {
+			throw new AggregateError([operationError, releaseError], "File lock operation and release both failed.");
+		}
+		throw operationError;
 	}
+	await release();
+	return result;
 }

--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -240,7 +240,8 @@ async function tryAcquireLock(lockPath: string): Promise<LockInfo | null> {
 }
 
 async function releaseLock(lockPath: string, owner: FileLockOwnerToken): Promise<void> {
-	await removeFileLockDirForGc(lockPath, owner);
+	const outcome = await removeFileLockDirForGc(lockPath, owner);
+	if (outcome !== "removed") throw new Error(`Failed to release file lock: ${outcome}.`);
 }
 async function acquireLock(filePath: string, options: FileLockOptions = {}): Promise<() => Promise<void>> {
 	const opts = { ...DEFAULT_OPTIONS, ...options };

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1743,7 +1743,7 @@ export class InputController {
 		}
 
 		const actions = [...this.#commandPaletteActions.values()];
-		const slashCommands = this.ctx.getSlashCommands?.() ?? this.#slashCommands;
+		const slashCommands = [...(this.ctx.getSlashCommands?.() ?? this.#slashCommands)];
 		if (!this.ctx.showCommandPalette) {
 			let overlayHandle: ReturnType<typeof this.ctx.ui.showOverlay> | undefined;
 			const close = () => {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1743,6 +1743,7 @@ export class InputController {
 		}
 
 		const actions = [...this.#commandPaletteActions.values()];
+		const slashCommands = this.ctx.getSlashCommands?.() ?? this.#slashCommands;
 		if (!this.ctx.showCommandPalette) {
 			let overlayHandle: ReturnType<typeof this.ctx.ui.showOverlay> | undefined;
 			const close = () => {
@@ -1763,7 +1764,7 @@ export class InputController {
 							: undefined,
 						handler: () => this.actionRegistry.execute(action.id),
 					})),
-				...(this.ctx.getSlashCommands?.() ?? this.#slashCommands).map(command => ({
+				...slashCommands.map(command => ({
 					id: `slash:/${command.name}`,
 					label: `/${command.name}`,
 					description: command.description,
@@ -1792,7 +1793,7 @@ export class InputController {
 			this.ctx.ui.requestRender();
 			return;
 		}
-		this.ctx.showCommandPalette(this.#slashCommands, actions, async name => {
+		this.ctx.showCommandPalette(slashCommands, actions, async name => {
 			if (this.#paletteCommandInFlight) {
 				this.ctx.showStatus("A palette command is still running.");
 				return;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1735,6 +1735,26 @@ export class InputController {
 		}
 	}
 
+	async #dispatchPaletteSlashCommand(name: string, restoreComposer: () => void): Promise<void> {
+		if (this.#paletteCommandInFlight) {
+			this.ctx.showStatus("A palette command is still running.");
+			return;
+		}
+
+		if (this.ctx.editor.getText() || this.ctx.pendingImages.length > 0) {
+			this.ctx.showStatus("Send or clear the draft before running a palette command.");
+			return;
+		}
+
+		restoreComposer();
+		this.#paletteCommandInFlight = true;
+		try {
+			await this.ctx.editor.onSubmit?.(`/${name}`);
+		} finally {
+			this.#paletteCommandInFlight = false;
+		}
+	}
+
 	openCommandPalette(): void {
 		if (this.ctx.isTranscriptViewerOpen?.()) return;
 		if (this.#paletteCommandInFlight) {
@@ -1773,12 +1793,12 @@ export class InputController {
 			const palette = new CommandPalette(
 				entries,
 				entry => {
-					close();
-					if (entry.handler) void entry.handler();
-					else {
+					if (entry.handler) {
+						close();
+						void entry.handler();
+					} else {
 						const command = entry.id.slice("slash:/".length);
-						this.ctx.editor.setText(`/${command}`);
-						void this.ctx.editor.onSubmit?.(`/${command}`);
+						void this.#dispatchPaletteSlashCommand(command, close);
 					}
 				},
 				close,
@@ -1793,24 +1813,12 @@ export class InputController {
 			this.ctx.ui.requestRender();
 			return;
 		}
-		this.ctx.showCommandPalette(slashCommands, actions, async name => {
-			if (this.#paletteCommandInFlight) {
-				this.ctx.showStatus("A palette command is still running.");
-				return;
-			}
-
-			if (this.ctx.editor.getText() || this.ctx.pendingImages.length > 0) {
-				this.ctx.showStatus("Send or clear the draft before running a palette command.");
-				return;
-			}
-
-			this.#paletteCommandInFlight = true;
-			try {
-				await this.submitText(`/${name}`, { ownsComposer: false, editor: this.ctx.editor });
-			} finally {
-				this.#paletteCommandInFlight = false;
-			}
-		});
+		this.ctx.showCommandPalette(slashCommands, actions, name =>
+			this.#dispatchPaletteSlashCommand(name, () => {
+				this.ctx.ui.setFocus(this.ctx.editor);
+				this.ctx.ui.requestRender(true);
+			}),
+		);
 	}
 
 	cycleThinkingLevel(): void {

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2754,6 +2754,24 @@
 		]
 	},
 	{
+		"sourceId": "agent_session:awaitPendingContextTransformations",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal context-transformation lifecycle barrier, not a user-facing SDK control seam",
+		"adapterMappings": {
+			"telegram": "generic_safe",
+			"discord": "generic_safe",
+			"slack": "generic_safe",
+			"mcp": "generic_safe",
+			"acp": "generic_safe",
+			"daemonCli": "generic_safe"
+		},
+		"testIds": [
+			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
+		]
+	},
+	{
 		"sourceId": "agent_session:subscribe",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -1625,17 +1625,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "interactive diagnostics command; session on/off delegate to the notifications extension, not an SDK ingress seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:settings",
@@ -1643,17 +1636,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:theme",
@@ -1661,17 +1647,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:pet",
@@ -1679,17 +1658,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:goal",
@@ -1787,17 +1759,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:dump",
@@ -1859,17 +1824,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only transcript viewer, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:context",
@@ -1913,17 +1871,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:help",
@@ -1931,17 +1882,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:hotkeys",
@@ -1949,17 +1893,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:tools",
@@ -1985,17 +1922,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:monitors",
@@ -2003,17 +1933,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:tree",
@@ -2021,17 +1944,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:provider",
@@ -2039,17 +1955,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:login",
@@ -2075,17 +1984,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:ssh",
@@ -2093,17 +1995,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:clear",
@@ -2147,17 +2042,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:compact",
@@ -2183,17 +2071,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:resume",
@@ -2219,17 +2100,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only sessions dashboard, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:btw",
@@ -2237,17 +2111,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:retry",
@@ -2291,17 +2158,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:memory",
@@ -2309,17 +2169,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "slash_command:rename",
@@ -2363,17 +2216,10 @@
 		"sourceKind": "slash_command",
 		"decision": "exclude",
 		"rationale": "visual/local-only command, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:constructor",
@@ -2381,17 +2227,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:nextToolChoice",
@@ -2399,17 +2238,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setForcedToolChoice",
@@ -2417,17 +2249,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getActiveSkillState",
@@ -2435,17 +2260,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getActiveSkillPhase",
@@ -2453,17 +2271,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:peekQueueInvoker",
@@ -2471,17 +2282,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:peekStandingResolveHandler",
@@ -2489,17 +2293,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setStandingResolveHandler",
@@ -2507,17 +2304,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setSdkPlanModeHandler",
@@ -2525,17 +2315,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal host lifecycle plumbing for mode.plan.set",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:beginTemporaryProviderSessionScope",
@@ -2543,17 +2326,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal temporary model/provider restoration scope, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:restoreTemporaryProviderSessionScope",
@@ -2561,17 +2337,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal temporary model/provider restoration scope, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:commitTemporaryProviderSessionScope",
@@ -2579,17 +2348,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal temporary model/provider restoration scope, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:buildForkContextSeed",
@@ -2597,17 +2359,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getHindsightSessionState",
@@ -2615,17 +2370,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setHindsightSessionState",
@@ -2633,17 +2381,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:markPlanCompactAbortPending",
@@ -2651,17 +2392,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:clearPlanCompactAbortPending",
@@ -2669,17 +2403,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:enqueueCustomMessageDisplay",
@@ -2687,17 +2414,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getAgentId",
@@ -2705,17 +2425,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getAsyncJobSnapshot",
@@ -2741,17 +2454,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:awaitPendingContextTransformations",
@@ -2759,17 +2465,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal context-transformation lifecycle barrier, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:subscribe",
@@ -2777,17 +2476,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:dispose",
@@ -2795,17 +2487,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:closeWriterStrict",
@@ -2813,17 +2498,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal ACP lifecycle teardown plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:disposeChildSubprocesses",
@@ -2831,17 +2509,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:waitForIdle",
@@ -2849,17 +2520,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:drainAsyncJobDeliveriesForAcp",
@@ -2867,17 +2531,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getAsyncDeliveryStateForAcp",
@@ -2885,17 +2542,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal ACP lifecycle quiescence plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getLastAssistantMessage",
@@ -2939,17 +2589,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:registerForegroundBashBackgroundRequestHandler",
@@ -2957,17 +2600,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:hasForegroundBashBackgroundRequestHandler",
@@ -2975,17 +2611,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setSdkPermissionMode",
@@ -3011,17 +2640,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal reverse-provider plumbing, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:requestForegroundBashBackground",
@@ -3029,17 +2651,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getAllToolNames",
@@ -3065,17 +2680,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:isToolDiscoveryEnabled",
@@ -3083,17 +2691,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getDiscoverableTools",
@@ -3119,17 +2720,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getSelectedDiscoveredToolNames",
@@ -3137,17 +2731,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:activateDiscoveredTools",
@@ -3155,17 +2742,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:refreshSshTool",
@@ -3173,17 +2753,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setActiveToolsByName",
@@ -3209,17 +2782,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:refreshMCPTools",
@@ -3227,17 +2793,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:refreshGjcSubskillTools",
@@ -3245,17 +2804,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:continuePersistedHistory",
@@ -3263,17 +2815,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal startup lifecycle plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:buildDisplaySessionContext",
@@ -3281,17 +2826,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:convertMessagesToLlm",
@@ -3299,17 +2837,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:prepareSimpleStreamOptions",
@@ -3317,17 +2848,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getPlanModeState",
@@ -3335,17 +2859,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getSdkConfigItems",
@@ -3371,17 +2888,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:invokeSkill",
@@ -3479,17 +2989,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setGoalModeState",
@@ -3497,17 +3000,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getWorkflowGateEmitter",
@@ -3515,17 +3011,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getAskAnswerSource",
@@ -3533,17 +3022,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setWorkflowGateEmitter",
@@ -3551,17 +3033,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:markPlanReferenceSent",
@@ -3569,17 +3044,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setPlanReferencePath",
@@ -3587,17 +3055,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setClientBridge",
@@ -3605,17 +3066,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getCheckpointState",
@@ -3623,17 +3077,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setCheckpointState",
@@ -3641,17 +3088,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:sendPlanModeContext",
@@ -3659,17 +3099,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:sendGoalModeContext",
@@ -3677,17 +3110,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:resolveRoleModel",
@@ -3695,17 +3121,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:resolveRoleModelWithThinking",
@@ -3713,17 +3132,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setSlashCommands",
@@ -3731,17 +3143,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setMCPPromptCommands",
@@ -3749,17 +3154,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:prompt",
@@ -3785,17 +3183,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal custom-message plumbing, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:steer",
@@ -3839,17 +3230,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:queueDeferredMessageForTests",
@@ -3857,17 +3241,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getPendingNextTurnMessagesForTests",
@@ -3875,17 +3252,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "read-only test seam, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setCancelAndSubmitAbortOutcomeProviderForTests",
@@ -3893,17 +3263,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "test-only cancellation seam, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:sendCustomMessage",
@@ -3911,17 +3274,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal custom-message plumbing, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:purgeQueuedCustomMessages",
@@ -3929,17 +3285,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:sendUserMessage",
@@ -3965,17 +3314,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getQueuedMessages",
@@ -4055,17 +3397,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getTodoPhases",
@@ -4109,17 +3444,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:activeMidRunBarrierCountForTests",
@@ -4127,17 +3455,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "read-only test seam, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:activeMidRunMaintenanceCountForTests",
@@ -4145,17 +3466,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "read-only test seam, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:runMidRunMaintenanceForTests",
@@ -4163,17 +3477,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "test-only maintenance seam, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:estimateMidRunContextTokensForTests",
@@ -4181,17 +3488,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "test-only estimator seam, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:abort",
@@ -4217,17 +3517,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "interactive queue transaction plumbing, not an independent SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:newSession",
@@ -4325,17 +3618,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getActiveModelProfile",
@@ -4343,17 +3629,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getConfiguredModelChain",
@@ -4361,17 +3640,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal profile and fallback-chain state, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setConfiguredModelChain",
@@ -4379,17 +3651,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal profile and fallback-chain state, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setDefaultFallbackRuntimeModel",
@@ -4397,17 +3662,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal fallback runtime bookkeeping, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:seedDefaultFallbackResolution",
@@ -4415,17 +3673,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal fallback resolution bookkeeping, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getSessionDefaultModelSelector",
@@ -4433,17 +3684,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:recordResumeDefaultModel",
@@ -4451,17 +3695,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setModelTemporary",
@@ -4469,17 +3706,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setModelTemporaryForControl",
@@ -4487,17 +3717,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal Telegram control wrapper over the reviewed model.set seam, not an independent public SDK operation",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setDefaultModelSelection",
@@ -4541,17 +3764,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal role-model display accessor, not a user-facing SDK seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:cycleRoleModels",
@@ -4559,17 +3775,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getAvailableModels",
@@ -4613,17 +3822,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal Telegram control wrapper over the reviewed thinking.set seam, not an independent public SDK operation",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getThinkingScopeForControl",
@@ -4631,17 +3833,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal Telegram control status accessor, not a user-facing SDK operation seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getThinkingVisibility",
@@ -4649,17 +3844,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal extension and Telegram display accessor, not a user-facing SDK operation seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setThinkingVisibility",
@@ -4667,17 +3855,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal extension display mutation without a public SDK registry operation",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setThinkingVisibilityForControl",
@@ -4685,17 +3866,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal Telegram control wrapper over display state, not an independent public SDK operation",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:cycleThinkingLevel",
@@ -4721,17 +3895,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:isFastForProvider",
@@ -4739,17 +3906,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:isFastForSubagentProvider",
@@ -4757,17 +3917,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:isFastModeActive",
@@ -4775,17 +3928,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setServiceTier",
@@ -4847,17 +3993,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setSteeringMode",
@@ -4937,17 +4076,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:runIdleCompaction",
@@ -4955,17 +4087,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:abortBranchSummary",
@@ -4973,17 +4098,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:abortHandoff",
@@ -4991,17 +4109,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:handoff",
@@ -5027,17 +4138,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setResourceSampler",
@@ -5045,17 +4149,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setRetainedMemorySampler",
@@ -5063,17 +4160,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:setAutoCompactionEnabled",
@@ -5189,17 +4279,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:abortBash",
@@ -5225,17 +4308,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:assertEvalExecutionAllowed",
@@ -5243,17 +4319,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:trackEvalExecution",
@@ -5261,17 +4330,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal execution bookkeeping, not a user-facing SDK control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:recordPythonResult",
@@ -5279,17 +4341,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:abortEval",
@@ -5297,17 +4352,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:respondAsBackground",
@@ -5315,17 +4363,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:emitIrcRelayObservation",
@@ -5333,17 +4374,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:emitSubagentSteerObservation",
@@ -5351,17 +4385,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:emitSubagentSteerRelayObservation",
@@ -5369,17 +4396,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:runEphemeralTurn",
@@ -5387,17 +4407,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:reload",
@@ -5459,17 +4472,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getUserMessagesForBranching",
@@ -5531,17 +4537,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "test-only observability, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:fetchUsageReports",
@@ -5567,17 +4566,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal Telegram control wrapper over the reviewed usage.get seam, not an independent public SDK operation",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:exportToHtml",
@@ -5621,17 +4613,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:getLastVisibleHandoffText",
@@ -5639,17 +4624,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:formatSessionAsText",
@@ -5693,17 +4671,10 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	},
 	{
 		"sourceId": "agent_session:registerBeforeAgentStartContributor",
@@ -5711,16 +4682,9 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
-		"adapterMappings": {
-			"telegram": "generic_safe",
-			"discord": "generic_safe",
-			"slack": "generic_safe",
-			"mcp": "generic_safe",
-			"acp": "generic_safe",
-			"daemonCli": "generic_safe"
-		},
-		"testIds": [
-			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
-		]
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
 	}
 ]

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9099,7 +9099,14 @@ export class AgentSession {
 					{ path: "modelRoles.default" as SettingPath, op: "set", value: selector },
 				]);
 			} catch (error) {
-				await this.sessionManager.discardDefaultModelSelectionStage(stage);
+				try {
+					await this.sessionManager.discardDefaultModelSelectionStage(stage);
+				} catch (cleanupError) {
+					throw new AggregateError(
+						[error, cleanupError],
+						"Default model selection persistence and staged session cleanup both failed.",
+					);
+				}
 				throw error;
 			}
 			if (this.#defaultModelSelectionMutationRevision !== expectedMutationRevision) {

--- a/packages/coding-agent/test/agent-session-default-model-selection.test.ts
+++ b/packages/coding-agent/test/agent-session-default-model-selection.test.ts
@@ -948,6 +948,36 @@ describe("AgentSession durable default model selection", () => {
 		expect(session.model).toBe(INITIAL_MODEL);
 	});
 
+	it("preserves durable and staged cleanup failures without publishing a selection", async () => {
+		// Given
+		const durableError = new Error("durable write failed");
+		const cleanupError = new Error("stage discard failed");
+		const priorModelRoles = { default: "initial-provider/initial:low", planner: "planner/model:medium" };
+		settings.set("modelRoles", priorModelRoles);
+		const entriesBeforeSelection = sessionManager.getEntries();
+		const contextBeforeSelection = sessionManager.buildSessionContext();
+		const setModel = vi.spyOn(session.agent, "setModel");
+		vi.spyOn(settings, "commitAtomicBatchWithCurrent").mockRejectedValue(durableError);
+		vi.spyOn(sessionManager, "discardDefaultModelSelectionStage").mockRejectedValue(cleanupError);
+
+		// When
+		let selectionError: unknown;
+		try {
+			await session.setDefaultModelSelection(targetModel(), Effort.High);
+		} catch (error) {
+			selectionError = error;
+		}
+
+		// Then
+		expect(selectionError).toBeInstanceOf(AggregateError);
+		expect((selectionError as AggregateError).errors).toEqual([durableError, cleanupError]);
+		expect(setModel).not.toHaveBeenCalled();
+		expect(settings.getGlobal("modelRoles")).toEqual(priorModelRoles);
+		expect(session.model).toBe(INITIAL_MODEL);
+		expect(sessionManager.getEntries()).toEqual(entriesBeforeSelection);
+		expect(sessionManager.buildSessionContext()).toEqual(contextBeforeSelection);
+	});
+
 	it("does not route a durably committed default through the temporary mutation path", async () => {
 		// Given
 		const temporaryMutation = vi.spyOn(session, "setModelTemporary");

--- a/packages/coding-agent/test/command-palette.test.ts
+++ b/packages/coding-agent/test/command-palette.test.ts
@@ -106,8 +106,14 @@ describe("CommandPalette", () => {
 		expect(output).not.toContain("Command 0");
 	});
 
-	it("uses the resolved slash command catalog for palette entries", () => {
+	it("uses the live slash command registry for both palette routes", () => {
 		let overlay: CommandPalette | undefined;
+		const liveCommands = [
+			{ name: "clear", description: "Built-in command" },
+			{ name: "extension:demo", description: "Extension command" },
+			{ name: "custom:demo", description: "Custom command" },
+			{ name: "skill:demo", description: "Demo skill" },
+		];
 		const ctx = {
 			editor: { getText: () => "", setText: () => {}, onSubmit: async () => {} },
 			ui: {
@@ -136,17 +142,18 @@ describe("CommandPalette", () => {
 			showStatus: () => {},
 			historyStorage: { getRecent: () => [] },
 			skillCommands: new Map([["skill:demo", { description: "Demo skill" }]]),
-			getSlashCommands: () => [
-				{ name: "clear", description: "Built-in command" },
-				{ name: "extension:demo", description: "Extension command" },
-				{ name: "custom:demo", description: "Custom command" },
-				{ name: "skill:demo", description: "Demo skill" },
-			],
+			getSlashCommands: () => liveCommands,
 		} as unknown as InteractiveModeContext;
 		new InputController(ctx).openCommandPalette();
 		expect(overlay?.getEntries().map(entry => entry.label)).toEqual(
 			expect.arrayContaining(["/clear", "/extension:demo", "/custom:demo", "/skill:demo"]),
 		);
+		let forwardedCommands: unknown;
+		ctx.showCommandPalette = commands => {
+			forwardedCommands = commands;
+		};
+		new InputController(ctx).openCommandPalette();
+		expect(forwardedCommands).toBe(liveCommands);
 	});
 
 	it("restores composer focus before executing a selected registry action", async () => {

--- a/packages/coding-agent/test/command-palette.test.ts
+++ b/packages/coding-agent/test/command-palette.test.ts
@@ -153,7 +153,8 @@ describe("CommandPalette", () => {
 			forwardedCommands = commands;
 		};
 		new InputController(ctx).openCommandPalette();
-		expect(forwardedCommands).toBe(liveCommands);
+		expect(forwardedCommands).toEqual(liveCommands);
+		expect(forwardedCommands).not.toBe(liveCommands);
 	});
 
 	it("restores composer focus before executing a selected registry action", async () => {
@@ -183,8 +184,8 @@ describe("CommandPalette", () => {
 				hasForegroundBashBackgroundRequestHandler: () => false,
 			},
 			chatContainer: { children: [] },
-			goalModeEnabled: false,
-			handlePlanModeCommand: () => order.push("execute"),
+			goalModeController: { enabled: false, paused: false, handleCommand: async () => {} },
+			planModeController: { enabled: false, handleCommand: async () => order.push("execute") },
 			showError: () => {},
 			showStatus: () => {},
 			historyStorage: { getRecent: () => [] },

--- a/packages/coding-agent/test/command-palette.test.ts
+++ b/packages/coding-agent/test/command-palette.test.ts
@@ -12,6 +12,68 @@ const entries: CommandPaletteEntry[] = [
 
 beforeAll(() => initTheme());
 
+function createInputControllerContext(options: {
+	draft?: string;
+	pendingImages?: InteractiveModeContext["pendingImages"];
+	onSubmit?: (text: string) => Promise<void>;
+	delegated?: boolean;
+}) {
+	let text = options.draft ?? "";
+	let overlay: CommandPalette | undefined;
+	let executeDelegated: ((name: string) => Promise<void>) | undefined;
+	const statuses: string[] = [];
+	const editor = {
+		getText: () => text,
+		setText: (value: string) => {
+			text = value;
+		},
+		onSubmit: options.onSubmit ?? (async () => {}),
+	};
+	const ctx = {
+		editor,
+		ui: {
+			showOverlay(component: CommandPalette) {
+				overlay = component;
+				return { hide: () => {} };
+			},
+			setFocus: () => {},
+			requestRender: () => {},
+		},
+		keybindings: { getKeys: () => [] },
+		settings: { get: (key: string) => key === "plan.enabled" },
+		session: {
+			model: undefined,
+			messages: [],
+			queuedMessageCount: 0,
+			isStreaming: false,
+			getRoleModelCycleCandidateCount: () => 0,
+			hasForegroundBashBackgroundRequestHandler: () => false,
+		},
+		chatContainer: { children: [] },
+		goalModeController: { enabled: false, paused: false, handleCommand: async () => {} },
+		planModeController: { enabled: false, handleCommand: async () => {} },
+		showError: () => {},
+		showStatus: (status: string) => statuses.push(status),
+		historyStorage: { getRecent: () => [] },
+		skillCommands: new Map(),
+		pendingImages: options.pendingImages ?? [],
+		getSlashCommands: () => [{ name: "clear", description: "Clear the session" }],
+	} as unknown as InteractiveModeContext;
+	if (options.delegated) {
+		ctx.showCommandPalette = (_commands, _actions, execute) => {
+			executeDelegated = execute;
+		};
+	}
+	const controller = new InputController(ctx);
+	return {
+		controller,
+		getText: () => text,
+		getOverlay: () => overlay,
+		getExecuteDelegated: () => executeDelegated,
+		statuses,
+	};
+}
+
 describe("CommandPalette", () => {
 	it("fuzzy filters actions, commands, and skills", () => {
 		const palette = new CommandPalette(
@@ -202,15 +264,25 @@ describe("CommandPalette", () => {
 	it("dispatches a selected skill slash command through the composer submit handler", async () => {
 		let overlay: CommandPalette | undefined;
 		const submitted: string[] = [];
-		const editor = { getText: () => "", setText: () => {}, onSubmit: async (text: string) => submitted.push(text) };
+		const order: string[] = [];
+		const editor = {
+			getText: () => "",
+			setText: () => {},
+			onSubmit: async (text: string) => {
+				submitted.push(text);
+				order.push("execute");
+			},
+		};
 		const ctx = {
 			editor,
 			ui: {
 				showOverlay(component: CommandPalette) {
 					overlay = component;
-					return { hide: () => {} };
+					return { hide: () => order.push("hide") };
 				},
-				setFocus: () => {},
+				setFocus: (target: unknown) => {
+					if (target === editor) order.push("focus");
+				},
 				requestRender: () => {},
 			},
 			keybindings: { getKeys: () => [] },
@@ -223,8 +295,10 @@ describe("CommandPalette", () => {
 				getRoleModelCycleCandidateCount: () => 0,
 			},
 			chatContainer: { children: [] },
-			goalModeEnabled: false,
-			handlePlanModeCommand: () => {},
+			pendingImages: [],
+			goalModeController: { enabled: false, paused: false, handleCommand: async () => {} },
+			planModeController: { enabled: false, handleCommand: async () => {} },
+
 			showError: () => {},
 			showStatus: () => {},
 			historyStorage: { getRecent: () => [] },
@@ -236,5 +310,50 @@ describe("CommandPalette", () => {
 		overlay?.handleInput("\n");
 		await Promise.resolve();
 		expect(submitted).toEqual(["/skill:demo"]);
+		expect(order).toEqual(["hide", "focus", "execute"]);
+	});
+	it("preserves drafts when slash commands are selected through either palette route", async () => {
+		const local = createInputControllerContext({ draft: "keep this draft" });
+		local.controller.openCommandPalette();
+		for (const key of "/clear") local.getOverlay()?.handleInput(key);
+		local.getOverlay()?.handleInput("\n");
+		await Promise.resolve();
+		expect(local.getText()).toBe("keep this draft");
+		expect(local.statuses).toEqual(["Send or clear the draft before running a palette command."]);
+
+		const delegated = createInputControllerContext({ draft: "keep this draft", delegated: true });
+		delegated.controller.openCommandPalette();
+		await delegated.getExecuteDelegated()?.("clear");
+		expect(delegated.getText()).toBe("keep this draft");
+		expect(delegated.statuses).toEqual(["Send or clear the draft before running a palette command."]);
+	});
+
+	it("rejects overlapping slash command execution through either palette route", async () => {
+		let releaseLocal!: () => void;
+		const local = createInputControllerContext({
+			onSubmit: () => new Promise<void>(resolve => (releaseLocal = resolve)),
+		});
+		local.controller.openCommandPalette();
+		for (const key of "/clear") local.getOverlay()?.handleInput(key);
+		local.getOverlay()?.handleInput("\n");
+		local.getOverlay()?.handleInput("\n");
+		await Promise.resolve();
+		expect(local.statuses).toEqual(["A palette command is still running."]);
+		releaseLocal();
+		await Promise.resolve();
+
+		let releaseDelegated!: () => void;
+		const delegated = createInputControllerContext({
+			delegated: true,
+			onSubmit: () => new Promise<void>(resolve => (releaseDelegated = resolve)),
+		});
+		delegated.controller.openCommandPalette();
+		const execute = delegated.getExecuteDelegated();
+		const first = execute?.("clear");
+		const second = execute?.("clear");
+		await Promise.resolve();
+		expect(delegated.statuses).toEqual(["A palette command is still running."]);
+		releaseDelegated();
+		await Promise.all([first, second]);
 	});
 });

--- a/packages/coding-agent/test/file-lock-gc-toctou.test.ts
+++ b/packages/coding-agent/test/file-lock-gc-toctou.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test, vi } from "bun:test";
 import { writeFileSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -13,6 +13,7 @@ const LIVE_PID = 636_363;
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+	vi.restoreAllMocks();
 	for (const dir of tempDirs.splice(0)) {
 		await fs.rm(dir, { recursive: true, force: true });
 	}
@@ -138,6 +139,61 @@ describe("withFileLock stale owner liveness (#652)", () => {
 		expect(await fs.exists(lockDir)).toBe(true);
 		const onDisk = JSON.parse(await fs.readFile(path.join(lockDir, "info"), "utf8"));
 		expect(onDisk).toEqual(replacement);
+	});
+});
+describe("file lock cleanup failure handling (#2478)", () => {
+	test("does not reap a stale lock when its metadata read fails unexpectedly", async () => {
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "state.json");
+		const lockDir = `${lockedFile}.lock`;
+		const readError = Object.assign(new Error("metadata access denied"), { code: "EACCES" });
+		await writeInfo(lockDir, { pid: DEAD_PID, timestamp: Date.now() - 10_000 });
+
+		vi.spyOn(fs, "readFile").mockRejectedValueOnce(readError);
+
+		await expect(withFileLock(lockedFile, async () => {}, { staleMs: 1, retries: 1, retryDelayMs: 1 })).rejects.toBe(
+			readError,
+		);
+		expect(await fs.exists(lockDir)).toBe(true);
+	});
+
+	test("rejects when release fails after successful protected work", async () => {
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "state.json");
+		const lockDir = `${lockedFile}.lock`;
+		const releaseError = Object.assign(new Error("lock removal denied"), { code: "EACCES" });
+		let completed = false;
+
+		vi.spyOn(fs, "rm").mockRejectedValueOnce(releaseError);
+
+		await expect(
+			withFileLock(lockedFile, async () => {
+				completed = true;
+			}),
+		).rejects.toBe(releaseError);
+		expect(completed).toBe(true);
+		expect(await fs.exists(lockDir)).toBe(true);
+	});
+
+	test("preserves operation and release failures", async () => {
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "state.json");
+		const operationError = new Error("protected work failed");
+		const releaseError = Object.assign(new Error("lock removal denied"), { code: "EACCES" });
+
+		vi.spyOn(fs, "rm").mockRejectedValueOnce(releaseError);
+
+		let failure: unknown;
+		try {
+			await withFileLock(lockedFile, async () => {
+				throw operationError;
+			});
+		} catch (error) {
+			failure = error;
+		}
+
+		expect(failure).toBeInstanceOf(AggregateError);
+		expect((failure as AggregateError).errors).toEqual([operationError, releaseError]);
 	});
 });
 describe("file lock owner-token removal guard (#606)", () => {

--- a/packages/coding-agent/test/file-lock-gc-toctou.test.ts
+++ b/packages/coding-agent/test/file-lock-gc-toctou.test.ts
@@ -126,19 +126,31 @@ describe("withFileLock stale owner liveness (#652)", () => {
 		expect(await fs.exists(lockDir)).toBe(true);
 	});
 
-	test("release refuses to remove a lock that no longer has this owner token", async () => {
+	test("rejects after successful protected work when ownership is lost during release", async () => {
 		const base = await makeTemp();
 		const lockedFile = path.join(base, "state.json");
 		const lockDir = `${lockedFile}.lock`;
 		const replacement = { pid: LIVE_PID, start_time: "test-start", timestamp: Date.now() + 1_000 };
 
-		await withFileLock(lockedFile, async () => {
-			await writeInfo(lockDir, replacement);
-		});
-
-		expect(await fs.exists(lockDir)).toBe(true);
+		await expect(
+			withFileLock(lockedFile, async () => {
+				await writeInfo(lockDir, replacement);
+			}),
+		).rejects.toThrow("Failed to release file lock: owner_changed.");
 		const onDisk = JSON.parse(await fs.readFile(path.join(lockDir, "info"), "utf8"));
 		expect(onDisk).toEqual(replacement);
+	});
+
+	test("rejects after successful protected work when the lock disappears during release", async () => {
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "state.json");
+		const lockDir = `${lockedFile}.lock`;
+
+		await expect(
+			withFileLock(lockedFile, async () => {
+				await fs.rm(lockDir, { recursive: true });
+			}),
+		).rejects.toThrow("Failed to release file lock: missing.");
 	});
 });
 describe("file lock cleanup failure handling (#2478)", () => {
@@ -175,17 +187,17 @@ describe("file lock cleanup failure handling (#2478)", () => {
 		expect(await fs.exists(lockDir)).toBe(true);
 	});
 
-	test("preserves operation and release failures", async () => {
+	test("preserves operation and ownership-loss release failures", async () => {
 		const base = await makeTemp();
 		const lockedFile = path.join(base, "state.json");
+		const lockDir = `${lockedFile}.lock`;
 		const operationError = new Error("protected work failed");
-		const releaseError = Object.assign(new Error("lock removal denied"), { code: "EACCES" });
-
-		vi.spyOn(fs, "rm").mockRejectedValueOnce(releaseError);
+		const replacement = { pid: LIVE_PID, start_time: "test-start", timestamp: Date.now() + 1_000 };
 
 		let failure: unknown;
 		try {
 			await withFileLock(lockedFile, async () => {
+				await writeInfo(lockDir, replacement);
 				throw operationError;
 			});
 		} catch (error) {
@@ -193,7 +205,13 @@ describe("file lock cleanup failure handling (#2478)", () => {
 		}
 
 		expect(failure).toBeInstanceOf(AggregateError);
-		expect((failure as AggregateError).errors).toEqual([operationError, releaseError]);
+		const errors = (failure as AggregateError).errors;
+		expect(errors).toHaveLength(2);
+		expect(errors[0]).toBe(operationError);
+		expect(errors[1]).toBeInstanceOf(Error);
+		expect((errors[1] as Error).message).toBe("Failed to release file lock: owner_changed.");
+		const onDisk = JSON.parse(await fs.readFile(path.join(lockDir, "info"), "utf8"));
+		expect(onDisk).toEqual(replacement);
 	});
 });
 describe("file lock owner-token removal guard (#606)", () => {

--- a/packages/coding-agent/test/sdk-operation-inventory.test.ts
+++ b/packages/coding-agent/test/sdk-operation-inventory.test.ts
@@ -71,7 +71,9 @@ describe("SDK operation inventory", () => {
 			sourceId: string;
 			decision: string;
 			rationale?: string;
+			exclusionMetadata?: { adapterMappings: string; testIds: string };
 		}>;
+
 		const expected = new Map([
 			[
 				"agent_session:runMidRunMaintenanceForTests",
@@ -84,7 +86,14 @@ describe("SDK operation inventory", () => {
 		]);
 		for (const [sourceId, rationale] of expected) {
 			const record = records.find(candidate => candidate.sourceId === sourceId);
-			expect(record).toEqual(expect.objectContaining({ sourceId, decision: "exclude", rationale }));
+			expect(record).toEqual(
+				expect.objectContaining({
+					sourceId,
+					decision: "exclude",
+					rationale,
+					exclusionMetadata: { adapterMappings: "not_applicable", testIds: "not_applicable" },
+				}),
+			);
 		}
 	});
 
@@ -124,6 +133,27 @@ describe("SDK operation inventory", () => {
 			);
 		});
 	}
+
+	it("fails closed when the slash-command scanner anchor is absent", () => {
+		expect(() => scanSlashCommands('const COMMANDS = [{ name: "goal" }];')).toThrow(
+			"SDK operation inventory scanner: required anchor const BUILTIN_SLASH_COMMAND_REGISTRY was not found.",
+		);
+	});
+
+	it("fails closed when the AgentSession scanner anchor is absent", () => {
+		expect(() => scanAgentSessionMethods("class OtherSession {} ")).toThrow(
+			"SDK operation inventory scanner: required AgentSession class declaration was not found.",
+		);
+	});
+
+	it("fails closed when the AgentSession class body is malformed", () => {
+		expect(() => scanAgentSessionMethods("class AgentSession extends Base")).toThrow(
+			"SDK operation inventory scanner: AgentSession class is missing its opening body delimiter.",
+		);
+		expect(() => scanAgentSessionMethods("class AgentSession { action() {} ")).toThrow(
+			"SDK operation inventory scanner: AgentSession class body is unbalanced.",
+		);
+	});
 
 	it("classifies explicit AgentSession test seams as non-public authority", async () => {
 		const source = await Bun.file(path.join(repoRoot, "packages/coding-agent/src/session/agent-session.ts")).text();

--- a/packages/coding-agent/test/slash-command-builtin-registry.test.ts
+++ b/packages/coding-agent/test/slash-command-builtin-registry.test.ts
@@ -265,8 +265,11 @@ function createGoalTuiRuntime(goalModeEnabled: boolean) {
 	const addToHistory = vi.fn();
 	const setText = vi.fn();
 	const ctx = {
-		goalModeEnabled,
-		handleGoalModeCommand,
+		goalModeController: {
+			enabled: goalModeEnabled,
+			paused: false,
+			handleCommand: handleGoalModeCommand,
+		},
 		editor: { addToHistory, setText },
 	} as unknown as InteractiveModeContext;
 

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -89,6 +89,15 @@ describe("dev-ci canonical-plan workflow contract", () => {
 		const aggregateWorkflow = workflow.slice(workflow.indexOf("  affected:\n"));
 		expect(aggregateWorkflow).toContain("name: Validate canonical affected plan");
 		expect(aggregateWorkflow).toContain("run: bun scripts/ci-dev-affected.ts --validate-plan");
+		const receiptConsumerCondition = "if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' && needs.affected-shards.result == 'success' }}";
+		expect(workflow.match(new RegExp(receiptConsumerCondition.replace(/[.$|?*+(){}[\]\\]/g, "\\$&"), "g"))).toHaveLength(2);
+		for (const name of ["Download shard completion receipts", "Validate canonical shard completion"]) {
+			const step = workflow.slice(workflow.indexOf(`name: ${name}`), workflow.indexOf("\n      - name:", workflow.indexOf(`name: ${name}`) + 1));
+			expect(step).toContain(receiptConsumerCondition);
+		}
+		expect(aggregateWorkflow).toContain("if: ${{ always() }}");
+		const aggregateValidationStep = aggregateWorkflow.slice(aggregateWorkflow.indexOf("name: Aggregate affected path validation shards"));
+		expect(aggregateValidationStep).not.toContain("if:");
 	});
 
 	test("aggregate result truth table rejects every missing, failed, cancelled, and unplanned dependency", () => {

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -96,8 +96,13 @@ describe("dev-ci canonical-plan workflow contract", () => {
 			expect(step).toContain(receiptConsumerCondition);
 		}
 		expect(aggregateWorkflow).toContain("if: ${{ always() }}");
-		const aggregateValidationStep = aggregateWorkflow.slice(aggregateWorkflow.indexOf("name: Aggregate affected path validation shards"));
-		expect(aggregateValidationStep).not.toContain("if:");
+		const aggregateValidationStart = aggregateWorkflow.indexOf("name: Aggregate affected path validation shards");
+		const aggregateValidationEnd = aggregateWorkflow.indexOf("\n      - name:", aggregateValidationStart + 1);
+		const aggregateValidationStep = aggregateWorkflow.slice(
+			aggregateValidationStart,
+			aggregateValidationEnd === -1 ? undefined : aggregateValidationEnd,
+		);
+		expect(aggregateValidationStep).not.toContain("\n        if:");
 	});
 
 	test("aggregate result truth table rejects every missing, failed, cancelled, and unplanned dependency", () => {

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -121,6 +121,7 @@ describe("dev-ci canonical-plan workflow contract", () => {
 			{ ...valid[0]!, native: "cancelled" },
 			{ ...valid[0]!, shards: "failure" },
 			{ ...valid[0]!, shards: "cancelled" },
+			{ ...valid[0]!, shards: "skipped" },
 			{ ...valid[0]!, windowsDoctor: "failure" },
 			{ ...valid[0]!, windowsDoctor: "cancelled" },
 			{ ...valid[0]!, windowsDoctor: "skipped" },


### PR DESCRIPTION
## Summary
- repair the SDK operation inventory for `agent_session:awaitPendingContextTransformations` and make seam scanning/exclusion metadata fail closed
- restore command-palette live-registry dispatch and canonical `/goal` controller fixtures after #2481
- make failed-shard receipt consumers skip while the unconditional aggregate reports the real shard failure
- retain #2478 postmerge file-lock and default-model failure-evidence hardening

## Failure evidence
- Dev CI run 29639126417: SDK inventory, command palette, and `/goal` fixture failures; aggregate receipt mismatch downstream of failed shards
- Dev CI run 29639953690: same three root failures at current dev head; aggregate remained downstream

## Verification
- 175 focused tests passed, 2,232 assertions, 0 failures
- `bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts --check`
- `bun --cwd=packages/coding-agent run check`
- `bun run build`
- AI slop cleaner: PASS, zero blockers
- Architect: CLEAR / APPROVE
- QA artifact: `artifacts/pr2478-postmerge-hotfix-test-report.json`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*