### PR TITLE
fix(agent): coordinate recovery after provider rate limits

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Coordinated same-scope model recovery after terminal rate limits: healthy streams remain unrestricted, while recovery waits for the provider retry deadline and admits one generation-guarded probe before releasing queued streams.
 
 ## [0.11.1] - 2026-07-16
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -32,6 +32,7 @@ import {
 	shouldMitigateHarmonyLeak,
 	signalListLabel,
 } from "./harmony-leak";
+import { ProviderRateLimitRecoveryGate } from "./provider-rate-limit-recovery";
 import { type AgentRunCoverage, type AgentRunSummary, ToolCallBlockedError } from "./run-collector";
 import {
 	type AgentTelemetry,
@@ -60,7 +61,8 @@ import type {
 	StreamFn,
 } from "./types";
 
-/** Sentinel returned by the abort race in `streamAssistantResponse`. */
+const providerRateLimitRecoveryGate = new ProviderRateLimitRecoveryGate();
+
 /**
  * Defensive caps for a provisional managed attempt. These are intentionally
  * well above ordinary streamed responses; they only bound memory when an
@@ -99,7 +101,32 @@ class ManagedAttemptSnapshotError extends Error {
 
 const managedAttemptTextEncoder = new TextEncoder();
 
+/** Sentinel returned by abort races in `streamAssistantResponse`. */
 const ABORTED: unique symbol = Symbol("agent-loop-aborted");
+async function resolveApiKeyAfterAdmission(
+	config: AgentLoopConfig,
+	requestSignal: AbortSignal | undefined,
+): Promise<string | undefined | typeof ABORTED> {
+	if (!config.getApiKey) return config.apiKey;
+	if (!requestSignal) return (await config.getApiKey(config.model.provider)) || config.apiKey;
+	if (requestSignal.aborted) return ABORTED;
+
+	let onAbort: (() => void) | undefined;
+	const abortPromise = new Promise<typeof ABORTED>(resolve => {
+		onAbort = () => resolve(ABORTED);
+		requestSignal.addEventListener("abort", onAbort, { once: true });
+	});
+	try {
+		const apiKey = await Promise.race([
+			Promise.resolve().then(() => config.getApiKey?.(config.model.provider)),
+			abortPromise,
+		]);
+		return apiKey === ABORTED ? ABORTED : apiKey || config.apiKey;
+	} finally {
+		if (onAbort) requestSignal.removeEventListener("abort", onAbort);
+	}
+}
+
 function managedContextOverflow(message: AssistantMessage, config: AgentLoopConfig): boolean {
 	const transportFailure = managedTransportFailure(message);
 	// Managed empty-stop responses may be repaired by the managed shell below; only
@@ -1632,18 +1659,6 @@ async function streamAssistantResponse(
 
 	const streamFunction = streamFn || streamSimple;
 
-	// Resolve API key (important for expiring tokens) — do this before resolving
-	// metadata so that the session-sticky credential recorded by getApiKey is
-	// visible to metadataResolver (e.g. for the correct account_uuid in metadata.user_id).
-	const resolvedApiKey =
-		(config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
-
-	// Re-resolve metadata after credential selection so the per-request value
-	// reflects the credential actually used, not the snapshot from AgentLoopConfig construction.
-	const authCredentialType = config.getAuthCredentialType?.(config.model.provider);
-
-	const resolvedMetadata = config.metadataResolver ? config.metadataResolver(config.model.provider) : config.metadata;
-
 	const dynamicToolChoice = config.getToolChoice?.();
 	const dynamicReasoning = config.getReasoning?.();
 	const harmonyMitigationEnabled = isHarmonyLeakMitigationTarget(config.model);
@@ -1657,51 +1672,100 @@ async function streamAssistantResponse(
 		harmonyRetryAttempt > 0 && config.temperature !== undefined ? config.temperature + 0.05 : config.temperature;
 	const effectiveToolChoice = dynamicToolChoice ?? config.toolChoice;
 	const effectiveReasoning = dynamicReasoning ?? config.reasoning;
+	const rateLimitScope = config.providerRateLimitScope;
+	const rateLimitTicket = rateLimitScope
+		? await providerRateLimitRecoveryGate.acquire(rateLimitScope, config.model, requestSignal).catch(error => {
+				if (requestSignal?.aborted) return undefined;
+				throw error;
+			})
+		: undefined;
+	if (rateLimitScope && requestSignal?.aborted) {
+		if (rateLimitTicket) providerRateLimitRecoveryGate.settle(rateLimitTicket, { type: "aborted" });
+		return emitAbortedAssistantMessage(null, false, context, config, stream);
+	}
 
-	const chatStepNumber = stepCounter.count;
-	stepCounter.count += 1;
-	const chatSpan = startChatSpan(telemetry, config.model, {
-		parent: invokeAgentSpan,
-		stepNumber: chatStepNumber,
-		request: {
-			maxTokens: config.maxTokens,
-			temperature: effectiveTemperature,
-			topP: config.topP,
-			topK: config.topK,
-			presencePenalty: config.presencePenalty,
-			serviceTier: config.serviceTier,
-			reasoningEffort: typeof effectiveReasoning === "string" ? effectiveReasoning : undefined,
-			toolChoice: effectiveToolChoice,
-			tools: llmContext.tools,
-			systemPrompt: llmContext.systemPrompt,
-			messages: llmContext.messages,
-		},
-	});
-
-	// Wrap the user-supplied onResponse so we always observe response headers
-	// for telemetry (`ChatUsageEvent.headers`, gateway auto-detection) without
-	// stealing them from the configured hook.
+	let chatSpan: Span | undefined;
 	let capturedHeaders: Readonly<Record<string, string>> | undefined;
-	const userOnResponse = config.onResponse;
-	const captureOnResponse: AgentLoopConfig["onResponse"] = (response, modelInfo) => {
-		capturedHeaders = response.headers;
-		return userOnResponse?.(response, modelInfo);
-	};
-
-	const finishChat = async (message: AssistantMessage): Promise<void> => {
-		await finishChatSpan(telemetry, chatSpan, message, {
-			stepNumber: chatStepNumber,
-			serviceTier: config.serviceTier,
-			responseHeaders: capturedHeaders,
-			baseUrl: config.model.baseUrl,
-		});
-	};
-
 	try {
+		// Resolve API key (important for expiring tokens) only after admission so a
+		// recovery deadline cannot leave an admitted request with a stale token.
+		const resolvedApiKey = await resolveApiKeyAfterAdmission(config, requestSignal);
+		if (resolvedApiKey === ABORTED || requestSignal?.aborted) {
+			if (rateLimitTicket) providerRateLimitRecoveryGate.settle(rateLimitTicket, { type: "aborted" });
+			return emitAbortedAssistantMessage(null, false, context, config, stream);
+		}
+
+		// Re-resolve metadata after credential selection so the per-request value
+		// reflects the credential actually used, not the snapshot from AgentLoopConfig construction.
+		const authCredentialType = config.getAuthCredentialType?.(config.model.provider);
+		const resolvedMetadata = config.metadataResolver
+			? config.metadataResolver(config.model.provider)
+			: config.metadata;
+
+		const chatStepNumber = stepCounter.count;
+		stepCounter.count += 1;
+		chatSpan = startChatSpan(telemetry, config.model, {
+			parent: invokeAgentSpan,
+			stepNumber: chatStepNumber,
+			request: {
+				maxTokens: config.maxTokens,
+				temperature: effectiveTemperature,
+				topP: config.topP,
+				topK: config.topK,
+				presencePenalty: config.presencePenalty,
+				serviceTier: config.serviceTier,
+				reasoningEffort: typeof effectiveReasoning === "string" ? effectiveReasoning : undefined,
+				toolChoice: effectiveToolChoice,
+				tools: llmContext.tools,
+				systemPrompt: llmContext.systemPrompt,
+				messages: llmContext.messages,
+			},
+		});
+
+		// Wrap the user-supplied onResponse so we always observe response headers
+		// for telemetry (`ChatUsageEvent.headers`, gateway auto-detection) without
+		// stealing them from the configured hook.
+		const userOnResponse = config.onResponse;
+		const captureOnResponse: AgentLoopConfig["onResponse"] = (response, modelInfo) => {
+			capturedHeaders = response.headers;
+			return userOnResponse?.(response, modelInfo);
+		};
+
+		const finishChat = async (message: AssistantMessage): Promise<void> => {
+			await finishChatSpan(telemetry, chatSpan, message, {
+				stepNumber: chatStepNumber,
+				serviceTier: config.serviceTier,
+				responseHeaders: capturedHeaders,
+				baseUrl: config.model.baseUrl,
+			});
+		};
+		const settleFinalMessage = (message: AssistantMessage): void => {
+			if (!rateLimitTicket) return;
+			if (message.errorStatus === 429) {
+				const retryAfterMs = classifyFallbackTrigger(message.transportFailure ?? { status: 429 }).retryAfterMs;
+				providerRateLimitRecoveryGate.settle(rateLimitTicket, { type: "error", status: 429 }, retryAfterMs);
+			} else if (message.stopReason === "aborted") {
+				providerRateLimitRecoveryGate.settle(rateLimitTicket, { type: "aborted" });
+			} else if (message.stopReason === "error") {
+				providerRateLimitRecoveryGate.settle(rateLimitTicket, { type: "error", status: message.errorStatus });
+			} else {
+				providerRateLimitRecoveryGate.settle(rateLimitTicket, { type: "success" });
+			}
+		};
+		const settleAndFinishChat = async (message: AssistantMessage): Promise<AssistantMessage> => {
+			settleFinalMessage(message);
+			await finishChat(message);
+			return message;
+		};
+		const { providerRateLimitScope: _providerRateLimitScope, ...providerConfig } = config;
 		return await runInActiveSpan(chatSpan, async () => {
+			if (requestSignal?.aborted) {
+				const aborted = emitAbortedAssistantMessage(null, false, context, config, stream);
+				return await settleAndFinishChat(aborted);
+			}
 			const fallbackAttempt = config.fallbackManaged ? config.nextFallbackAttempt?.(config.model) : undefined;
 			const response = await streamFunction(config.model, llmContext, {
-				...config,
+				...providerConfig,
 				fallbackAttempt,
 				apiKey: resolvedApiKey,
 				authCredentialType,
@@ -1727,8 +1791,7 @@ async function streamAssistantResponse(
 			if (requestSignal) {
 				if (requestSignal.aborted) {
 					const aborted = emitAbortedAssistantMessage(partialMessage, addedPartial, context, config, stream);
-					await finishChat(aborted);
-					return aborted;
+					return await settleAndFinishChat(aborted);
 				}
 				const { promise, resolve } = Promise.withResolvers<typeof ABORTED>();
 				const onAbort = () => resolve(ABORTED);
@@ -1745,8 +1808,7 @@ async function streamAssistantResponse(
 						if (result === ABORTED) {
 							responseIterator.return?.()?.catch(() => {});
 							const aborted = emitAbortedAssistantMessage(partialMessage, addedPartial, context, config, stream);
-							await finishChat(aborted);
-							return aborted;
+							return await settleAndFinishChat(aborted);
 						}
 						next = result;
 					} else {
@@ -1754,8 +1816,7 @@ async function streamAssistantResponse(
 					}
 					if (requestSignal?.aborted) {
 						const aborted = emitAbortedAssistantMessage(partialMessage, addedPartial, context, config, stream);
-						await finishChat(aborted);
-						return aborted;
+						return await settleAndFinishChat(aborted);
 					}
 					if (next.done) break;
 
@@ -1817,8 +1878,7 @@ async function streamAssistantResponse(
 								stream.push({ type: "message_start", message: { ...finalMessage } });
 							}
 							stream.push({ type: "message_end", message: finalMessage });
-							await finishChat(finalMessage);
-							return finalMessage;
+							return await settleAndFinishChat(finalMessage);
 						}
 					}
 				}
@@ -1829,10 +1889,10 @@ async function streamAssistantResponse(
 			const trailing = config.fallbackManaged
 				? managedAssistantShell(await response.result(), config.model)
 				: await response.result();
-			await finishChat(trailing);
-			return trailing;
+			return await settleAndFinishChat(trailing);
 		});
 	} catch (err) {
+		if (rateLimitTicket) providerRateLimitRecoveryGate.settle(rateLimitTicket, { type: "threw" });
 		failChatSpan(telemetry, chatSpan, {
 			errorObject: err,
 			responseHeaders: capturedHeaders,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -164,6 +164,8 @@ export interface AgentOptions {
 	sessionId?: string;
 	/** Provider-facing cache/session affinity identifier. */
 	providerSessionId?: string;
+	/** @internal Opaque task-subagent identity used for logical-stream 429 recovery. */
+	providerRateLimitScope?: object;
 	/**
 	 * Shared provider state map for session-scoped transport/session caches.
 	 */
@@ -339,6 +341,7 @@ export class Agent {
 	#interruptMode: "immediate" | "wait";
 	#sessionId?: string;
 	#providerSessionId?: string;
+	#providerRateLimitScope?: object;
 	#metadata?: Record<string, unknown>;
 	#metadataResolver?: (provider: string) => Record<string, unknown> | undefined;
 	#providerSessionState?: Map<string, ProviderSessionState>;
@@ -414,6 +417,7 @@ export class Agent {
 		this.#sessionId = opts.sessionId;
 		this.#providerSessionId = opts.providerSessionId;
 		this.#providerSessionState = opts.providerSessionState;
+		this.#providerRateLimitScope = opts.providerRateLimitScope;
 		this.#thinkingBudgets = opts.thinkingBudgets;
 		this.#temperature = opts.temperature;
 		this.#topP = opts.topP;
@@ -1409,6 +1413,7 @@ export class Agent {
 
 		const config: AgentLoopConfig = {
 			model,
+			providerRateLimitScope: this.#providerRateLimitScope,
 			reasoning,
 			temperature: this.#temperature,
 			topP: this.#topP,

--- a/packages/agent/src/provider-rate-limit-recovery.ts
+++ b/packages/agent/src/provider-rate-limit-recovery.ts
@@ -1,0 +1,203 @@
+export interface ProviderRateLimitModel {
+	provider: string;
+	id: string;
+}
+
+export type ProviderRateLimitRecoveryOutcome =
+	| { type: "success" }
+	| { type: "aborted" }
+	| { type: "threw" }
+	| { type: "error"; status?: number };
+
+export interface ProviderRateLimitRecoveryTicket {
+	readonly scope: object;
+	readonly key: string;
+	readonly kind: "healthy" | "probe";
+	readonly generation: number;
+	settled: boolean;
+}
+
+export interface ProviderRateLimitRecoveryClock {
+	now(): number;
+	setTimeout(callback: () => void, delayMs: number): unknown;
+	clearTimeout(handle: unknown): void;
+}
+
+interface Waiter {
+	resolve(ticket: ProviderRateLimitRecoveryTicket): void;
+	reject(reason: unknown): void;
+	signal?: AbortSignal;
+	onAbort?: () => void;
+}
+
+interface Bucket {
+	generation: number;
+	deadline: number;
+	probeInFlight: boolean;
+	probeGeneration?: number;
+	waiters: Waiter[];
+	timer?: unknown;
+}
+
+const realClock: ProviderRateLimitRecoveryClock = {
+	now: () => Date.now(),
+	setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+	clearTimeout: handle => clearTimeout(handle as number),
+};
+
+function abortReason(signal: AbortSignal): unknown {
+	return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+}
+
+function keyFor(model: ProviderRateLimitModel): string {
+	return JSON.stringify([model.provider, model.id]);
+}
+
+function delayOrZero(delayMs: number): number {
+	return Number.isFinite(delayMs) && delayMs >= 0 ? delayMs : 0;
+}
+const MAX_TIMEOUT_DELAY_MS = 2_147_483_647;
+
+function timeoutDelay(delayMs: number): number {
+	return Math.min(Math.max(0, delayMs), MAX_TIMEOUT_DELAY_MS);
+}
+
+/**
+ * Coordinates logical stream recovery after final, structured provider 429s.
+ * Scope identity is intentionally opaque and only used as a WeakMap key.
+ */
+export class ProviderRateLimitRecoveryGate {
+	#buckets = new WeakMap<object, Map<string, Bucket>>();
+	#clock: ProviderRateLimitRecoveryClock;
+
+	constructor(clock: ProviderRateLimitRecoveryClock = realClock) {
+		this.#clock = clock;
+	}
+
+	acquire(
+		scope: object,
+		model: ProviderRateLimitModel,
+		signal?: AbortSignal,
+	): Promise<ProviderRateLimitRecoveryTicket> {
+		if (signal?.aborted) return Promise.reject(abortReason(signal));
+		const key = keyFor(model);
+		const bucket = this.#bucket(scope, key);
+		if (!bucket) return Promise.resolve(this.#ticket(scope, key, "healthy", 0));
+		if (!bucket.probeInFlight && this.#clock.now() >= bucket.deadline) {
+			return Promise.resolve(this.#admitProbe(scope, key, bucket));
+		}
+		return new Promise<ProviderRateLimitRecoveryTicket>((resolve, reject) => {
+			const waiter: Waiter = { resolve, reject, signal };
+			if (signal) {
+				waiter.onAbort = () => {
+					const live = this.#bucket(scope, key);
+					if (live) {
+						const index = live.waiters.indexOf(waiter);
+						if (index >= 0) live.waiters.splice(index, 1);
+						this.#advanceRecovery(scope, key, live);
+					}
+					reject(abortReason(signal));
+				};
+				signal.addEventListener("abort", waiter.onAbort, { once: true });
+			}
+			bucket.waiters.push(waiter);
+			this.#advanceRecovery(scope, key, bucket);
+		});
+	}
+
+	settle(ticket: ProviderRateLimitRecoveryTicket, outcome: ProviderRateLimitRecoveryOutcome, retryAfterMs = 0): void {
+		if (ticket.settled) return;
+		ticket.settled = true;
+		const isRateLimit = outcome.type === "error" && outcome.status === 429;
+		let bucket = this.#bucket(ticket.scope, ticket.key);
+
+		if (isRateLimit) {
+			bucket = this.#enterRecovery(ticket.scope, ticket.key, bucket, retryAfterMs);
+			this.#clearProbeOwnership(bucket, ticket);
+			this.#advanceRecovery(ticket.scope, ticket.key, bucket);
+			return;
+		}
+
+		if (ticket.kind !== "probe" || !bucket) return;
+		if (outcome.type === "success" && bucket.generation === ticket.generation) {
+			this.#closeRecovery(ticket.scope, ticket.key, bucket);
+			return;
+		}
+		this.#clearProbeOwnership(bucket, ticket);
+		this.#advanceRecovery(ticket.scope, ticket.key, bucket);
+	}
+
+	#bucket(scope: object, key: string): Bucket | undefined {
+		return this.#buckets.get(scope)?.get(key);
+	}
+
+	#enterRecovery(scope: object, key: string, bucket: Bucket | undefined, retryAfterMs: number): Bucket {
+		let live = bucket;
+		if (!live) {
+			const byModel = this.#buckets.get(scope) ?? new Map<string, Bucket>();
+			if (!this.#buckets.has(scope)) this.#buckets.set(scope, byModel);
+			live = { generation: 0, deadline: this.#clock.now(), probeInFlight: false, waiters: [] };
+			byModel.set(key, live);
+		}
+		live.generation += 1;
+		live.deadline = Math.max(live.deadline, this.#clock.now() + delayOrZero(retryAfterMs));
+		if (live.timer !== undefined) this.#clock.clearTimeout(live.timer);
+		const generation = live.generation;
+		live.timer = this.#clock.setTimeout(
+			() => this.#onTimer(scope, key, live, generation),
+			timeoutDelay(live.deadline - this.#clock.now()),
+		);
+		return live;
+	}
+
+	#onTimer(scope: object, key: string, bucket: Bucket, generation: number): void {
+		if (this.#bucket(scope, key) !== bucket || bucket.generation !== generation) return;
+		bucket.timer = undefined;
+		const remaining = bucket.deadline - this.#clock.now();
+		if (remaining > 0) {
+			bucket.timer = this.#clock.setTimeout(
+				() => this.#onTimer(scope, key, bucket, generation),
+				timeoutDelay(remaining),
+			);
+			return;
+		}
+		this.#advanceRecovery(scope, key, bucket);
+	}
+
+	#advanceRecovery(scope: object, key: string, bucket: Bucket): void {
+		if (this.#bucket(scope, key) !== bucket || bucket.probeInFlight || this.#clock.now() < bucket.deadline) return;
+		const waiter = bucket.waiters.shift();
+		if (!waiter) return;
+		if (waiter.signal && waiter.onAbort) waiter.signal.removeEventListener("abort", waiter.onAbort);
+		waiter.resolve(this.#admitProbe(scope, key, bucket));
+	}
+
+	#admitProbe(scope: object, key: string, bucket: Bucket): ProviderRateLimitRecoveryTicket {
+		bucket.probeInFlight = true;
+		bucket.probeGeneration = bucket.generation;
+		return this.#ticket(scope, key, "probe", bucket.generation);
+	}
+
+	#clearProbeOwnership(bucket: Bucket, ticket: ProviderRateLimitRecoveryTicket): void {
+		if (bucket.probeInFlight && bucket.probeGeneration === ticket.generation) {
+			bucket.probeInFlight = false;
+			bucket.probeGeneration = undefined;
+		}
+	}
+
+	#closeRecovery(scope: object, key: string, bucket: Bucket): void {
+		if (bucket.timer !== undefined) this.#clock.clearTimeout(bucket.timer);
+		const byModel = this.#buckets.get(scope);
+		byModel?.delete(key);
+		if (byModel?.size === 0) this.#buckets.delete(scope);
+		for (const waiter of bucket.waiters.splice(0)) {
+			if (waiter.signal && waiter.onAbort) waiter.signal.removeEventListener("abort", waiter.onAbort);
+			if (!waiter.signal?.aborted) waiter.resolve(this.#ticket(scope, key, "healthy", 0));
+			else waiter.reject(abortReason(waiter.signal));
+		}
+	}
+
+	#ticket(scope: object, key: string, kind: "healthy" | "probe", generation: number): ProviderRateLimitRecoveryTicket {
+		return { scope, key, kind, generation, settled: false };
+	}
+}

--- a/packages/agent/src/provider-rate-limit-recovery.ts
+++ b/packages/agent/src/provider-rate-limit-recovery.ts
@@ -53,8 +53,9 @@ function keyFor(model: ProviderRateLimitModel): string {
 	return JSON.stringify([model.provider, model.id]);
 }
 
-function delayOrZero(delayMs: number): number {
-	return Number.isFinite(delayMs) && delayMs >= 0 ? delayMs : 0;
+function normalizedDelay(delayMs: number): number {
+	if (delayMs === Number.POSITIVE_INFINITY) return Number.MAX_SAFE_INTEGER;
+	return Number.isFinite(delayMs) && delayMs >= 0 ? Math.min(delayMs, Number.MAX_SAFE_INTEGER) : 0;
 }
 const MAX_TIMEOUT_DELAY_MS = 2_147_483_647;
 
@@ -140,7 +141,7 @@ export class ProviderRateLimitRecoveryGate {
 			byModel.set(key, live);
 		}
 		live.generation += 1;
-		live.deadline = Math.max(live.deadline, this.#clock.now() + delayOrZero(retryAfterMs));
+		live.deadline = Math.max(live.deadline, this.#clock.now() + normalizedDelay(retryAfterMs));
 		if (live.timer !== undefined) this.#clock.clearTimeout(live.timer);
 		const generation = live.generation;
 		live.timer = this.#clock.setTimeout(

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -93,6 +93,8 @@ export type MidRunMaintenanceOutcome = "not-needed" | "pruned" | "compacted" | "
  */
 export interface AgentLoopConfig extends SimpleStreamOptions {
 	model: Model;
+	/** @internal Opaque task-subagent identity used for logical-stream 429 recovery. */
+	providerRateLimitScope?: object;
 	/**
 	 * Supplies a fresh opaque token at each concrete managed transport invocation.
 	 * The callback runs at the stream boundary so controller accounting matches

--- a/packages/agent/test/agent-loop-provider-rate-limit-recovery.test.ts
+++ b/packages/agent/test/agent-loop-provider-rate-limit-recovery.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool, StreamFn } from "@gajae-code/agent-core/types";
+import type { AssistantMessage, Message, Model } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+import { trace } from "@opentelemetry/api";
+import { createAssistantMessage, createUserMessage } from "./helpers";
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(
+		(message): message is Message =>
+			message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+	);
+}
+
+function context(tools: AgentTool[] = []): AgentContext {
+	return { systemPrompt: ["test"], messages: [], tools };
+}
+
+function responseStream(message: AssistantMessage): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		stream.push({ type: "done", reason: message.stopReason === "toolUse" ? "toolUse" : "stop", message });
+		stream.end(message);
+	});
+	return stream;
+}
+
+function rateLimitMessage(model: Model): AssistantMessage {
+	return {
+		...createAssistantMessage([], "error"),
+		provider: model.provider,
+		model: model.id,
+		errorMessage: "rate limited",
+		errorStatus: 429,
+		transportFailure: { kind: "transport", status: 429 },
+	};
+}
+
+async function run(
+	model: Model,
+	scope: object,
+	streamFn: StreamFn,
+	tools: AgentTool[] = [],
+	signal?: AbortSignal,
+	overrides: Partial<AgentLoopConfig> = {},
+) {
+	const config: AgentLoopConfig = {
+		...overrides,
+		model,
+		convertToLlm: identityConverter,
+		providerRateLimitScope: scope,
+	};
+	const stream = agentLoop([createUserMessage("test")], context(tools), config, signal, streamFn);
+	for await (const _event of stream) {
+		// Drain the externally observable event path.
+	}
+	return await stream.result();
+}
+
+describe("agent loop provider rate-limit recovery integration", () => {
+	it("keeps twelve healthy model streams unrestricted and strips opaque scope before StreamFn", async () => {
+		const model = createMockModel().model;
+		const scope = Object.freeze({});
+		let dispatched = 0;
+		const streamFn: StreamFn = (_model, _context, options) => {
+			dispatched += 1;
+			expect(options).toBeDefined();
+			expect(Object.hasOwn(options ?? {}, "providerRateLimitScope")).toBe(false);
+			return responseStream(createAssistantMessage([{ type: "text", text: "ok" }]));
+		};
+
+		await Promise.all(Array.from({ length: 12 }, () => run(model, scope, streamFn)));
+		expect(dispatched).toBe(12);
+	});
+
+	it("turns twelve post-429 logical streams into one probe and settles it before returning", async () => {
+		const model = createMockModel().model;
+		const scope = Object.freeze({});
+		await run(model, scope, () => responseStream(rateLimitMessage(model)));
+
+		const probe = new AssistantMessageEventStream();
+		let dispatched = 0;
+		const probeDispatched = Promise.withResolvers<void>();
+		const streamFn: StreamFn = () => {
+			dispatched += 1;
+			if (dispatched === 1) {
+				probeDispatched.resolve();
+				return probe;
+			}
+			return responseStream(createAssistantMessage([{ type: "text", text: "recovered" }]));
+		};
+		const pending = Array.from({ length: 12 }, () => run(model, scope, streamFn));
+		await probeDispatched.promise;
+
+		expect(dispatched).toBe(1);
+		expect(((12 - dispatched) / 12) * 100).toBeCloseTo(91.7, 1);
+		const recovered = createAssistantMessage([{ type: "text", text: "probe succeeded" }]);
+		probe.push({ type: "done", reason: "stop", message: recovered });
+		probe.end(recovered);
+
+		await Promise.all(pending);
+		expect(dispatched).toBe(12);
+	});
+
+	it("does not dispatch a pre-aborted acquisition while a same-key probe is in flight", async () => {
+		const model = createMockModel().model;
+		const scope = Object.freeze({});
+		await run(model, scope, () => responseStream(rateLimitMessage(model)));
+
+		const probe = new AssistantMessageEventStream();
+		let dispatched = 0;
+		const streamFn: StreamFn = () => {
+			dispatched += 1;
+			return probe;
+		};
+		const activeProbe = run(model, scope, streamFn);
+		await Promise.resolve();
+		const controller = new AbortController();
+		controller.abort();
+		const aborted = await run(model, scope, streamFn, [], controller.signal);
+
+		expect(dispatched).toBe(1);
+		const final = aborted[aborted.length - 1];
+		expect(final?.role).toBe("assistant");
+		if (final?.role === "assistant") expect(final.stopReason).toBe("aborted");
+		const success = createAssistantMessage([{ type: "text", text: "probe succeeded" }]);
+		probe.push({ type: "done", reason: "stop", message: success });
+		probe.end(success);
+		await activeProbe;
+	});
+
+	it("does not hold the model-stream recovery gate during local tool execution", async () => {
+		const model = createMockModel().model;
+		const scope = Object.freeze({});
+		await run(model, scope, () => responseStream(rateLimitMessage(model)));
+
+		const toolEntered = Promise.withResolvers<void>();
+		const releaseTool = Promise.withResolvers<void>();
+		const tool: AgentTool = {
+			name: "local",
+			label: "local",
+			description: "A deliberately held local operation.",
+			parameters: { type: "object", properties: {} },
+			execute: async () => {
+				toolEntered.resolve();
+				await releaseTool.promise;
+				return { content: [{ type: "text", text: "done" }], details: {} };
+			},
+		};
+		let dispatched = 0;
+		const siblingDispatched = Promise.withResolvers<void>();
+		const streamFn: StreamFn = () => {
+			dispatched += 1;
+			if (dispatched === 1) {
+				return responseStream(
+					createAssistantMessage([{ type: "toolCall", id: "local-1", name: "local", arguments: {} }], "toolUse"),
+				);
+			}
+			siblingDispatched.resolve();
+			return responseStream(createAssistantMessage([{ type: "text", text: "ok" }]));
+		};
+
+		const toolRun = run(model, scope, streamFn, [tool]);
+		await toolEntered.promise;
+		const siblingRun = run(model, scope, streamFn);
+		await siblingDispatched.promise;
+		expect(dispatched).toBe(2);
+
+		releaseTool.resolve();
+		await Promise.all([toolRun, siblingRun]);
+	});
+
+	it("isolates recovery by opaque scope, provider, and model key", async () => {
+		const base = createMockModel().model;
+		const scope = Object.freeze({});
+		await run(base, scope, () => responseStream(rateLimitMessage(base)));
+		const alternateScope = Object.freeze({});
+		const alternateProvider = { ...base, provider: `${base.provider}-alternate` };
+		const alternateModel = { ...base, id: `${base.id}-alternate` };
+		let dispatched = 0;
+		const streamFn: StreamFn = () => {
+			dispatched += 1;
+			return responseStream(createAssistantMessage([{ type: "text", text: "isolated" }]));
+		};
+
+		await Promise.all([
+			run(base, alternateScope, streamFn),
+			run(alternateProvider, scope, streamFn),
+			run(alternateModel, scope, streamFn),
+		]);
+		expect(dispatched).toBe(3);
+	});
+	it("settles a rejected credential resolver and promotes exactly one queued successor", async () => {
+		const model = createMockModel().model;
+		const scope = Object.freeze({});
+		await run(model, scope, () => responseStream(rateLimitMessage(model)));
+
+		const resolverEntered = Promise.withResolvers<void>();
+		const rejectResolver = Promise.withResolvers<string | undefined>();
+		let dispatched = 0;
+		const streamFn: StreamFn = () => {
+			dispatched += 1;
+			return responseStream(createAssistantMessage([{ type: "text", text: "recovered" }]));
+		};
+		const failed = run(model, scope, streamFn, [], undefined, {
+			getApiKey: () => {
+				resolverEntered.resolve();
+				return rejectResolver.promise;
+			},
+		});
+		await resolverEntered.promise;
+		const successor = run(model, scope, streamFn);
+		rejectResolver.reject(new Error("credential lookup failed"));
+		await expect(failed).rejects.toThrow("credential lookup failed");
+		await successor;
+
+		expect(dispatched).toBe(1);
+	});
+
+	it("settles an abort during credential lookup without dispatching the aborted probe", async () => {
+		const model = createMockModel().model;
+		const scope = Object.freeze({});
+		await run(model, scope, () => responseStream(rateLimitMessage(model)));
+
+		const resolverEntered = Promise.withResolvers<void>();
+		const credential = Promise.withResolvers<string | undefined>();
+		const controller = new AbortController();
+		let dispatched = 0;
+		const streamFn: StreamFn = () => {
+			dispatched += 1;
+			return responseStream(createAssistantMessage([{ type: "text", text: "recovered" }]));
+		};
+		const aborted = run(model, scope, streamFn, [], controller.signal, {
+			getApiKey: () => {
+				resolverEntered.resolve();
+				return credential.promise;
+			},
+		});
+		await resolverEntered.promise;
+		const successor = run(model, scope, streamFn);
+		controller.abort();
+		await aborted;
+		credential.resolve("late-token");
+		await successor;
+
+		expect(dispatched).toBe(1);
+	});
+
+	it("promotes one queued successor after a probe's terminal 429", async () => {
+		const model = createMockModel().model;
+		const scope = Object.freeze({});
+		await run(model, scope, () => responseStream(rateLimitMessage(model)));
+
+		const probe = new AssistantMessageEventStream();
+		const probeDispatched = Promise.withResolvers<void>();
+		let dispatched = 0;
+		const streamFn: StreamFn = () => {
+			dispatched += 1;
+			if (dispatched === 1) {
+				probeDispatched.resolve();
+				return probe;
+			}
+			return responseStream(createAssistantMessage([{ type: "text", text: "recovered" }]));
+		};
+		const active = run(model, scope, streamFn);
+		await probeDispatched.promise;
+		const successor = run(model, scope, streamFn);
+		const terminal = rateLimitMessage(model);
+		probe.push({ type: "done", reason: "stop", message: terminal });
+		probe.end(terminal);
+		await Promise.all([active, successor]);
+
+		expect(dispatched).toBe(2);
+	});
+
+	it("promotes one queued successor after a probe's terminal non-429 error", async () => {
+		const model = createMockModel().model;
+		const scope = Object.freeze({});
+		await run(model, scope, () => responseStream(rateLimitMessage(model)));
+
+		const probe = new AssistantMessageEventStream();
+		const probeDispatched = Promise.withResolvers<void>();
+		const terminal = {
+			...createAssistantMessage([], "error"),
+			provider: model.provider,
+			model: model.id,
+			errorStatus: 503,
+		};
+		let dispatched = 0;
+		const streamFn: StreamFn = () => {
+			dispatched += 1;
+			if (dispatched === 1) {
+				probeDispatched.resolve();
+				return probe;
+			}
+			return responseStream(createAssistantMessage([{ type: "text", text: "recovered" }]));
+		};
+		const active = run(model, scope, streamFn);
+		await probeDispatched.promise;
+		const successor = run(model, scope, streamFn);
+		probe.push({ type: "done", reason: "stop", message: terminal });
+		probe.end(terminal);
+		await Promise.all([active, successor]);
+
+		expect(dispatched).toBe(2);
+	});
+
+	it("settles synchronous post-admission setup failures and promotes a queued successor", async () => {
+		const model = createMockModel().model;
+		const delegateTracer = trace.getTracer("provider-rate-limit-recovery-test");
+		const scenarios: Array<{
+			name: string;
+			overrides(error: Error): Partial<AgentLoopConfig>;
+			streamThrows?: boolean;
+		}> = [
+			{
+				name: "auth credential type",
+				overrides: error => ({
+					getAuthCredentialType: () => {
+						throw error;
+					},
+				}),
+			},
+			{
+				name: "metadata",
+				overrides: error => ({
+					metadataResolver: () => {
+						throw error;
+					},
+				}),
+			},
+			{
+				name: "chat telemetry",
+				overrides: error => ({
+					telemetry: {
+						tracer: {
+							startSpan: (name: string, options: never, activeContext: never) => {
+								if (name.startsWith("chat ")) throw error;
+								return delegateTracer.startSpan(name, options, activeContext);
+							},
+						} as never,
+					},
+				}),
+			},
+			{
+				name: "synchronous stream",
+				overrides: () => ({}),
+				streamThrows: true,
+			},
+		];
+
+		for (const scenario of scenarios) {
+			const scope = Object.freeze({});
+			await run(model, scope, () => responseStream(rateLimitMessage(model)));
+			const credentialEntered = Promise.withResolvers<void>();
+			const releaseCredential = Promise.withResolvers<string | undefined>();
+			const error = new Error(`${scenario.name} setup failed`);
+			let dispatched = 0;
+			const streamFn: StreamFn = () => {
+				dispatched += 1;
+				if (scenario.streamThrows && dispatched === 1) throw error;
+				return responseStream(createAssistantMessage([{ type: "text", text: "recovered" }]));
+			};
+			const failed = run(model, scope, streamFn, [], undefined, {
+				...scenario.overrides(error),
+				getApiKey: () => {
+					credentialEntered.resolve();
+					return releaseCredential.promise;
+				},
+			});
+			const failure = failed.catch(reason => reason);
+			await credentialEntered.promise;
+			const successor = run(model, scope, streamFn);
+			releaseCredential.resolve("token");
+
+			expect(await failure).toBe(error);
+			await successor;
+			expect(dispatched).toBe(scenario.streamThrows ? 2 : 1);
+		}
+	});
+	it("settles a rejected stream setup and promotes exactly one queued successor", async () => {
+		const model = createMockModel().model;
+		const scope = Object.freeze({});
+		await run(model, scope, () => responseStream(rateLimitMessage(model)));
+
+		const rejectSetup = Promise.withResolvers<AssistantMessageEventStream>();
+		let dispatched = 0;
+		const streamFn: StreamFn = () => {
+			dispatched += 1;
+			return dispatched === 1
+				? rejectSetup.promise
+				: responseStream(createAssistantMessage([{ type: "text", text: "recovered" }]));
+		};
+		const failed = run(model, scope, streamFn);
+		const successor = run(model, scope, streamFn);
+		rejectSetup.reject(new Error("stream setup failed"));
+		await expect(failed).rejects.toThrow("stream setup failed");
+		await successor;
+
+		expect(dispatched).toBe(2);
+	});
+});

--- a/packages/agent/test/agent-loop-provider-rate-limit-recovery.test.ts
+++ b/packages/agent/test/agent-loop-provider-rate-limit-recovery.test.ts
@@ -27,14 +27,14 @@ function responseStream(message: AssistantMessage): AssistantMessageEventStream 
 	return stream;
 }
 
-function rateLimitMessage(model: Model): AssistantMessage {
+function rateLimitMessage(model: Model, headers?: Record<string, string>): AssistantMessage {
 	return {
 		...createAssistantMessage([], "error"),
 		provider: model.provider,
 		model: model.id,
 		errorMessage: "rate limited",
 		errorStatus: 429,
-		transportFailure: { kind: "transport", status: 429 },
+		transportFailure: { kind: "transport", status: 429, ...(headers ? { headers } : {}) },
 	};
 }
 
@@ -104,6 +104,32 @@ describe("agent loop provider rate-limit recovery integration", () => {
 		expect(dispatched).toBe(12);
 	});
 
+	it("keeps a huge finite Retry-After header from causing early cross-layer probe admission", async () => {
+		const model = createMockModel().model;
+		const scope = Object.freeze({});
+		await run(model, scope, () => responseStream(rateLimitMessage(model, { "retry-after": "1e308" })));
+
+		const controller = new AbortController();
+		let dispatched = 0;
+		const blocked = run(
+			model,
+			scope,
+			() => {
+				dispatched += 1;
+				return responseStream(createAssistantMessage([{ type: "text", text: "must stay blocked" }]));
+			},
+			[],
+			controller.signal,
+		);
+
+		await Bun.sleep(10);
+		expect(dispatched).toBe(0);
+		controller.abort();
+		const messages = await blocked;
+		const final = messages.at(-1);
+		expect(final?.role).toBe("assistant");
+		if (final?.role === "assistant") expect(final.stopReason).toBe("aborted");
+	});
 	it("does not dispatch a pre-aborted acquisition while a same-key probe is in flight", async () => {
 		const model = createMockModel().model;
 		const scope = Object.freeze({});

--- a/packages/agent/test/provider-rate-limit-recovery.test.ts
+++ b/packages/agent/test/provider-rate-limit-recovery.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type ProviderRateLimitRecoveryClock,
+	ProviderRateLimitRecoveryGate,
+} from "../src/provider-rate-limit-recovery";
+
+class FakeClock implements ProviderRateLimitRecoveryClock {
+	nowMs = 0;
+	#nextId = 0;
+	#timers = new Map<number, { at: number; callback: () => void }>();
+	cancelled: number[] = [];
+	scheduledDelays: number[] = [];
+
+	now(): number {
+		return this.nowMs;
+	}
+
+	setTimeout(callback: () => void, delayMs: number): unknown {
+		const id = ++this.#nextId;
+		this.#timers.set(id, { at: this.nowMs + delayMs, callback });
+		this.scheduledDelays.push(delayMs);
+		return id;
+	}
+
+	clearTimeout(handle: unknown): void {
+		this.cancelled.push(handle as number);
+		this.#timers.delete(handle as number);
+	}
+
+	advance(ms: number): void {
+		this.nowMs += ms;
+		for (;;) {
+			const due = [...this.#timers.entries()].find(([, timer]) => timer.at <= this.nowMs);
+			if (!due) return;
+			this.#timers.delete(due[0]);
+			due[1].callback();
+		}
+	}
+}
+
+const model = { provider: "provider", id: "model" };
+const rateLimit = { type: "error", status: 429 } as const;
+
+function gate() {
+	const clock = new FakeClock();
+	return { clock, recovery: new ProviderRateLimitRecoveryGate(clock), scope: {} };
+}
+
+describe("ProviderRateLimitRecoveryGate", () => {
+	it("keeps twelve healthy logical streams unrestricted", async () => {
+		const { recovery, scope } = gate();
+		const tickets = await Promise.all(Array.from({ length: 12 }, () => recovery.acquire(scope, model)));
+		expect(tickets.every(ticket => ticket.kind === "healthy")).toBe(true);
+	});
+
+	it("waits for a deadline and admits one FIFO probe (12 speculative streams become 1)", async () => {
+		const { clock, recovery, scope } = gate();
+		const initial = await recovery.acquire(scope, model);
+		recovery.settle(initial, rateLimit, 100);
+		const queued = Array.from({ length: 12 }, () => recovery.acquire(scope, model));
+		let admitted = 0;
+		for (const pending of queued) pending.then(() => admitted++);
+		await Promise.resolve();
+		expect(admitted).toBe(0);
+		clock.advance(100);
+		const probe = await queued[0];
+		await Promise.resolve();
+		expect(probe.kind).toBe("probe");
+		expect(admitted).toBe(1);
+		recovery.settle(probe, { type: "success" });
+		expect((await Promise.all(queued.slice(1))).every(ticket => ticket.kind === "healthy")).toBe(true);
+	});
+
+	it("uses generation-bound replacement timers and monotonic deadlines for repeated 429s", async () => {
+		const { clock, recovery, scope } = gate();
+		const initial = await recovery.acquire(scope, model);
+		const lateHealthy = await recovery.acquire(scope, model);
+		recovery.settle(initial, rateLimit, 100);
+		clock.advance(10);
+		recovery.settle(lateHealthy, rateLimit, 20);
+		const sibling = recovery.acquire(scope, model);
+		expect(clock.cancelled.length).toBeGreaterThanOrEqual(1);
+		clock.advance(20);
+		let admitted = false;
+		sibling.then(() => (admitted = true));
+		await Promise.resolve();
+		expect(admitted).toBe(false);
+		clock.advance(70);
+		expect((await sibling).kind).toBe("probe");
+	});
+
+	it("does not let stale probe success drain after newer 429 evidence", async () => {
+		const { clock, recovery, scope } = gate();
+		const initial = await recovery.acquire(scope, model);
+		const lateHealthy = await recovery.acquire(scope, model);
+		recovery.settle(initial, rateLimit, 10);
+		const first = recovery.acquire(scope, model);
+		const second = recovery.acquire(scope, model);
+		clock.advance(10);
+		const staleProbe = await first;
+		recovery.settle(lateHealthy, rateLimit, 0);
+		recovery.settle(staleProbe, { type: "success" });
+		const successor = await second;
+		expect(successor.kind).toBe("probe");
+	});
+
+	it("promotes one successor after probe 429, abort, throw, or non-429 error", async () => {
+		const { clock, recovery, scope } = gate();
+		const initial = await recovery.acquire(scope, model);
+		recovery.settle(initial, rateLimit, 0);
+		const first = await recovery.acquire(scope, model);
+		const secondPending = recovery.acquire(scope, model);
+		recovery.settle(first, rateLimit, 0);
+		const second = await secondPending;
+		expect(second.kind).toBe("probe");
+		const thirdPending = recovery.acquire(scope, model);
+		recovery.settle(second, { type: "threw" });
+		expect((await thirdPending).kind).toBe("probe");
+		clock.advance(0);
+	});
+
+	it("rejects pre-aborted and removes queued aborted waiters", async () => {
+		const { recovery, scope } = gate();
+		const aborted = new AbortController();
+		aborted.abort();
+		await expect(recovery.acquire(scope, model, aborted.signal)).rejects.toThrow();
+		const initial = await recovery.acquire(scope, model);
+		recovery.settle(initial, rateLimit, 100);
+		const queuedAbort = new AbortController();
+		const queued = recovery.acquire(scope, model, queuedAbort.signal);
+		queuedAbort.abort();
+		await expect(queued).rejects.toThrow();
+	});
+
+	it("isolates opaque scope, provider, and model identities and settles idempotently", async () => {
+		const { recovery, scope } = gate();
+		const initial = await recovery.acquire(scope, model);
+		recovery.settle(initial, rateLimit, 100);
+		recovery.settle(initial, rateLimit, 100);
+		expect((await recovery.acquire({}, model)).kind).toBe("healthy");
+		expect((await recovery.acquire(scope, { provider: "other", id: "model" })).kind).toBe("healthy");
+		expect((await recovery.acquire(scope, { provider: "provider", id: "other" })).kind).toBe("healthy");
+	});
+	it("keeps recovery after an empty timer and recreates it from late healthy 429 evidence", async () => {
+		const { clock, recovery, scope } = gate();
+		const initial = await recovery.acquire(scope, model);
+		recovery.settle(initial, rateLimit, 10);
+		clock.advance(10);
+		const probe = await recovery.acquire(scope, model);
+		recovery.settle(probe, { type: "success" });
+		const lateHealthy = await recovery.acquire(scope, model);
+		recovery.settle(lateHealthy, rateLimit, 10);
+		const blocked = recovery.acquire(scope, model);
+		clock.advance(10);
+		expect((await blocked).kind).toBe("probe");
+	});
+
+	it("advances exactly one queued successor for aborted and non-429 probe outcomes", async () => {
+		const { recovery, scope } = gate();
+		const initial = await recovery.acquire(scope, model);
+		recovery.settle(initial, rateLimit, 0);
+		const first = await recovery.acquire(scope, model);
+		const secondPending = recovery.acquire(scope, model);
+		recovery.settle(first, { type: "aborted" });
+		const second = await secondPending;
+		const thirdPending = recovery.acquire(scope, model);
+		recovery.settle(second, { type: "error", status: 503 });
+		expect((await thirdPending).kind).toBe("probe");
+	});
+	it("rearms oversized retry deadlines in bounded timeout chunks", async () => {
+		const { clock, recovery, scope } = gate();
+		const maxTimeoutDelay = 2_147_483_647;
+		const initial = await recovery.acquire(scope, model);
+		recovery.settle(initial, rateLimit, maxTimeoutDelay * 2 + 1);
+		const queued = recovery.acquire(scope, model);
+
+		clock.advance(maxTimeoutDelay);
+		let admitted = false;
+		queued.then(() => (admitted = true));
+		await Promise.resolve();
+		expect(admitted).toBe(false);
+		clock.advance(maxTimeoutDelay);
+		await Promise.resolve();
+		expect(admitted).toBe(false);
+		clock.advance(1);
+
+		expect((await queued).kind).toBe("probe");
+		expect(clock.scheduledDelays).toEqual([maxTimeoutDelay, maxTimeoutDelay, 1]);
+	});
+});

--- a/packages/agent/test/provider-rate-limit-recovery.test.ts
+++ b/packages/agent/test/provider-rate-limit-recovery.test.ts
@@ -167,6 +167,26 @@ describe("ProviderRateLimitRecoveryGate", () => {
 		recovery.settle(second, { type: "error", status: 503 });
 		expect((await thirdPending).kind).toBe("probe");
 	});
+	it("saturates positive infinite delays instead of admitting an immediate probe", async () => {
+		const { clock, recovery, scope } = gate();
+		const initial = await recovery.acquire(scope, model);
+		recovery.settle(initial, rateLimit, Number.POSITIVE_INFINITY);
+		const controller = new AbortController();
+		const queued = recovery.acquire(scope, model, controller.signal);
+		let admitted = false;
+		queued.then(
+			() => (admitted = true),
+			() => {},
+		);
+
+		expect(clock.scheduledDelays[0]).toBe(2_147_483_647);
+		clock.advance(2_147_483_647);
+		await Promise.resolve();
+		expect(admitted).toBe(false);
+
+		controller.abort();
+		await expect(queued).rejects.toThrow();
+	});
 	it("rearms oversized retry deadlines in bounded timeout chunks", async () => {
 		const { clock, recovery, scope } = gate();
 		const maxTimeoutDelay = 2_147_483_647;

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `transportFailureFacts` now reduces transport headers to a plain record containing only the retained retry signals (`retry-after`, `retry-after-ms`). Providers attach these facts to error `AssistantMessage`s, and the previous shape carried the live fetch/SDK `Headers` instance — which is not structured-cloneable (`structuredClone` throws `DataCloneError`, "The object can not be cloned." under Bun) and not JSON-serializable (persisted as `{}` in session files, silently dropping the retry hint). Under a managed model fallback chain, snapshotting such an error message replaced the real provider failure with the local clone error and exhausted the whole chain. Normalization is idempotent (re-running facts on facts is structurally stable; errors carrying only unretained headers with no status/code now yield no facts instead of an empty facts object), Retry-After classification (`classifyFallbackTrigger`) is unchanged, and arbitrary response headers no longer reach persisted facts.
+- Retry-After parsing now saturates huge finite second and millisecond values before conversion, preventing numeric overflow from turning an upstream cooldown into an immediate recovery retry.
 
 ## [0.11.0] - 2026-07-15
 ### Added

--- a/packages/ai/src/utils/fallback-transport.ts
+++ b/packages/ai/src/utils/fallback-transport.ts
@@ -196,19 +196,25 @@ function headersOf(headers: TransportHeaders | undefined): Headers | undefined {
 	if (headers instanceof Headers) return headers;
 	return headers ? new Headers(headers as Record<string, string>) : undefined;
 }
+const MAX_RETRY_AFTER_MS = Number.MAX_SAFE_INTEGER;
+
+function saturatedRetryDelay(value: number, multiplier = 1): number | undefined {
+	if (!Number.isFinite(value) || value < 0) return undefined;
+	if (value >= MAX_RETRY_AFTER_MS / multiplier) return MAX_RETRY_AFTER_MS;
+	return Math.round(value * multiplier);
+}
 
 function parseRetryAfterSeconds(value: string | null, now = Date.now()): number | undefined {
 	if (!value) return undefined;
-	const seconds = Number(value);
-	if (Number.isFinite(seconds) && seconds >= 0) return Math.round(seconds * 1000);
+	const seconds = saturatedRetryDelay(Number(value), 1000);
+	if (seconds !== undefined) return seconds;
 	const date = Date.parse(value);
 	return Number.isFinite(date) ? Math.max(0, date - now) : undefined;
 }
 
 function parseRetryAfterMilliseconds(value: string | null): number | undefined {
 	if (!value) return undefined;
-	const milliseconds = Number(value);
-	return Number.isFinite(milliseconds) && milliseconds >= 0 ? Math.round(milliseconds) : undefined;
+	return saturatedRetryDelay(Number(value));
 }
 
 function isContextOverflowCode(code: string | undefined): boolean {

--- a/packages/ai/test/model-fallback-transport-facts.test.ts
+++ b/packages/ai/test/model-fallback-transport-facts.test.ts
@@ -78,6 +78,24 @@ describe("fallback transport facts", () => {
 		expect(classifyFallbackTrigger({ kind: "transport", status: 503 })).toEqual({ class: "server" });
 	});
 
+	it("saturates finite Retry-After values whose millisecond conversion exceeds the safe range", () => {
+		const expected = { class: "rate_limit", retryAfterMs: Number.MAX_SAFE_INTEGER } as const;
+		expect(
+			classifyFallbackTrigger({
+				kind: "transport",
+				status: 429,
+				headers: { "retry-after": "1e308" },
+			}),
+		).toEqual(expected);
+		expect(
+			classifyFallbackTrigger({
+				kind: "transport",
+				status: 429,
+				headers: { "retry-after-ms": "1e308" },
+			}),
+		).toEqual(expected);
+	});
+
 	it("normalizes provider transport metadata without parsing error text", () => {
 		const quotaError = Object.assign(new Error("provider response"), {
 			status: 429,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 - Palette slash commands now run only from an empty composer; drafts are never touched.
 - Aborting a session without an enabled active goal no longer suppresses the first reminder when a goal is activated later; active-goal abort suppression is one-shot, goal-owned, and clears across inactive or replacement-goal transitions (#2436).
+- Task subagents sharing the same authentication storage now coordinate per-provider/model recovery probes after terminal rate limits instead of retrying speculatively as a herd.
 - Palette slash submissions no longer clear or rewrite composer text, cursor state, history, or pending images created while an asynchronous input hook is awaiting; canonical keyboard submission cleanup remains unchanged (#2441).
 - Dead browser-tab recovery now expires descriptors without releasing replacement, revived, or differently owned tabs, while exactly-once teardown closes stale targets and releases browser holds without refcount underflow (#2437).
 - Local-memory Phase 1 no longer processes history from another working directory.

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -279,6 +279,8 @@ export interface CreateAgentSessionOptions {
 	authStorage?: AuthStorage;
 	/** Model registry. Default: discoverModels(authStorage, agentDir) */
 	modelRegistry?: ModelRegistry;
+	/** @internal Opaque task-subagent identity used for logical-stream 429 recovery. */
+	providerRateLimitScope?: object;
 
 	/** Model to use. Default: from settings, else first available */
 	model?: Model;
@@ -2330,6 +2332,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					? { messages: options.forkContextSeed.agentMessages }
 					: {}),
 			},
+			providerRateLimitScope: options.providerRateLimitScope,
 			convertToLlm: convertToLlmFinal,
 			onPayload,
 			onResponse,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1444,6 +1444,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					cwd: worktree ?? cwd,
 					authStorage,
 					modelRegistry,
+					providerRateLimitScope: modelRegistry.authStorage,
 					settings: subagentSettings,
 					model,
 					thinkingLevel: effectiveThinkingLevel,

--- a/packages/coding-agent/test/task/executor-provider-rate-limit-scope.test.ts
+++ b/packages/coding-agent/test/task/executor-provider-rate-limit-scope.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { kNoAuth, type ModelRegistry } from "../../src/config/model-registry";
+import { Settings } from "../../src/config/settings";
+import type { LoadExtensionsResult } from "../../src/extensibility/extensions/types";
+import type { CreateAgentSessionResult } from "../../src/sdk";
+import * as sdkModule from "../../src/sdk";
+import type { AgentSession, AgentSessionEvent } from "../../src/session/agent-session";
+import { runSubprocess } from "../../src/task/executor";
+import type { AgentDefinition } from "../../src/task/types";
+import { EventBus } from "../../src/utils/event-bus";
+
+function completedSession(): AgentSession {
+	const session: Partial<AgentSession> = {
+		state: { messages: [] } as never,
+		agent: { state: { systemPrompt: ["test"] } } as never,
+		extensionRunner: undefined as never,
+		sessionManager: { appendSessionInit: () => {} } as never,
+		getActiveToolNames: () => ["read", "yield"],
+		setActiveToolsByName: async () => {},
+		setConfiguredModelChain: () => {},
+		getConfiguredModelChain: () => undefined,
+		seedDefaultFallbackResolution: () => {},
+		subscribe: (_listener: (event: AgentSessionEvent) => void) => () => {},
+		prompt: async () => {},
+		waitForIdle: async () => {},
+		getLastAssistantMessage: () => undefined,
+		abort: async () => {},
+		dispose: async () => {},
+	};
+	return session as AgentSession;
+}
+
+describe("runSubprocess provider rate-limit scope", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("forwards exactly modelRegistry.authStorage as the child logical-stream scope", async () => {
+		const authStorage = Object.freeze({});
+		const modelRegistry = {
+			authStorage,
+			refresh: async () => {},
+			getAvailable: () => [],
+			getApiKey: async () => kNoAuth,
+		} as unknown as ModelRegistry;
+		let capturedScope: object | undefined;
+		let capturedAuthStorage: object | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected child session options");
+			capturedScope = options.providerRateLimitScope;
+			capturedAuthStorage = options.authStorage;
+			return {
+				session: completedSession(),
+				extensionsResult: {} as LoadExtensionsResult,
+				setToolUIContext: () => {},
+				eventBus: new EventBus(),
+			} satisfies CreateAgentSessionResult;
+		});
+		const agent: AgentDefinition = {
+			name: "task",
+			description: "test",
+			systemPrompt: "test",
+			source: "bundled",
+		};
+
+		await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "test",
+			index: 0,
+			id: "scope-forwarding",
+			settings: Settings.isolated(),
+			modelRegistry,
+			enableLsp: false,
+		});
+
+		expect(capturedAuthStorage).toBe(authStorage);
+		expect(capturedScope).toBe(authStorage);
+	});
+});


### PR DESCRIPTION
## What

- coordinate task-subagent provider/model recovery after terminal structured 429s
- keep healthy streams unrestricted, then wait for Retry-After and admit one generation-guarded FIFO probe
- settle probe ownership across aborts, credential/setup failures, stream failures, terminal errors, and success
- saturate huge finite Retry-After seconds/milliseconds before conversion and defensively preserve non-finite cooldowns in the gate

## Why

Concurrent task subagents sharing one provider credential can retry the same rate limit as a herd. Closed PR #2553 introduced the recovery gate, but exact-head review found that `retry-after: 1e308` overflowed to Infinity and was normalized to a zero-delay probe. This head fixes that complete parser-to-gate path and carries the requested adversarial cross-layer regression.

## Testing

- 40 focused tests pass across AI parsing, recovery-gate behavior, agent-loop integration, and task scope propagation
- `bun run --cwd=packages/ai check`
- `bun run --cwd=packages/agent check`
- `bun run --cwd=packages/coding-agent check`
- `git diff --check`
- independent final architecture review: CLEAR / request satisfied

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)