### PR TITLE
fix(ci): repair postmerge focus and AI cwd regressions

### DIFF
--- a/packages/ai/test/anthropic-cache-eval.integration.test.ts
+++ b/packages/ai/test/anthropic-cache-eval.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
 import { streamAnthropic } from "@gajae-code/ai/providers/anthropic";
 import type { Context, Model, TJsonSchema } from "@gajae-code/ai/types";
 
@@ -33,7 +34,10 @@ type EvalArtifact = {
 };
 
 const artifactPath = new URL("../../../artifacts/architecture-2383-eval.json", import.meta.url);
-const providerSourcePath = "packages/ai/src/providers/anthropic.ts";
+const repoRoot = path.resolve(import.meta.dir, "../../..");
+const packageRoot = path.resolve(import.meta.dir, "..");
+const providerSourceGitPath = "packages/ai/src/providers/anthropic.ts";
+const providerSourcePath = path.resolve(import.meta.dir, "../src/providers/anthropic.ts");
 const model: Model<"anthropic-messages"> = {
 	id: "claude-sonnet-4-5",
 	name: "Claude Sonnet 4.5",
@@ -63,15 +67,17 @@ function cacheIdentityJson(value: unknown): string {
 	return JSON.stringify(value, (key, nestedValue) => (key === "cache_control" ? undefined : nestedValue));
 }
 
-function git(args: string[]): string {
-	const result = Bun.spawnSync(["git", ...args]);
+function git(args: string[], cwd = repoRoot): string {
+	const result = Bun.spawnSync(["git", ...args], { cwd });
 	if (result.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed`);
 	return result.stdout.toString().trim();
 }
 
-async function currentSourceIdentity(): Promise<{ providerSourceBlobOid: string; providerSourceSha256: string }> {
+async function currentSourceIdentity(
+	cwd = repoRoot,
+): Promise<{ providerSourceBlobOid: string; providerSourceSha256: string }> {
 	return {
-		providerSourceBlobOid: git(["rev-parse", `HEAD:${providerSourcePath}`]),
+		providerSourceBlobOid: git(["rev-parse", `HEAD:${providerSourceGitPath}`], cwd),
 		providerSourceSha256: await sha256(await Bun.file(providerSourcePath).text()),
 	};
 }
@@ -312,6 +318,9 @@ async function buildArtifact(): Promise<EvalArtifact> {
 }
 
 describe("Anthropic cache placement eval (deterministic sequential three-request integration)", () => {
+	it("resolves the immutable provider identity from repo and package working directories", async () => {
+		expect(await currentSourceIdentity(packageRoot)).toEqual(await currentSourceIdentity(repoRoot));
+	});
 	it("binds immutable source/fixture evidence and simulates documented explicit cache retention", async () => {
 		const derivedArtifact = await buildArtifact();
 		if (process.env.WRITE_ARCHITECTURE_2383_EVAL === "1")

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1749,7 +1749,7 @@ export class InputController {
 		restoreComposer();
 		this.#paletteCommandInFlight = true;
 		try {
-			await this.ctx.editor.onSubmit?.(`/${name}`);
+			await this.submitText(`/${name}`, { ownsComposer: false, editor: this.ctx.editor });
 		} finally {
 			this.#paletteCommandInFlight = false;
 		}
@@ -1815,7 +1815,7 @@ export class InputController {
 		}
 		this.ctx.showCommandPalette(slashCommands, actions, name =>
 			this.#dispatchPaletteSlashCommand(name, () => {
-				this.ctx.ui.setFocus(this.ctx.editor);
+				this.ctx.ui.setFocus?.(this.ctx.editor);
 				this.ctx.ui.requestRender(true);
 			}),
 		);

--- a/packages/coding-agent/test/command-palette.test.ts
+++ b/packages/coding-agent/test/command-palette.test.ts
@@ -54,10 +54,11 @@ function createInputControllerContext(options: {
 		planModeController: { enabled: false, handleCommand: async () => {} },
 		showError: () => {},
 		showStatus: (status: string) => statuses.push(status),
+		handleChangelogCommand: options.onSubmit ?? (async () => {}),
 		historyStorage: { getRecent: () => [] },
 		skillCommands: new Map(),
 		pendingImages: options.pendingImages ?? [],
-		getSlashCommands: () => [{ name: "clear", description: "Clear the session" }],
+		getSlashCommands: () => [{ name: "changelog", description: "Show changelog" }],
 	} as unknown as InteractiveModeContext;
 	if (options.delegated) {
 		ctx.showCommandPalette = (_commands, _actions, execute) => {
@@ -261,18 +262,10 @@ describe("CommandPalette", () => {
 		expect(order).toEqual(["hide", "focus", "execute"]);
 	});
 
-	it("dispatches a selected skill slash command through the composer submit handler", async () => {
+	it("dispatches a selected slash command through the canonical controller path", async () => {
 		let overlay: CommandPalette | undefined;
-		const submitted: string[] = [];
 		const order: string[] = [];
-		const editor = {
-			getText: () => "",
-			setText: () => {},
-			onSubmit: async (text: string) => {
-				submitted.push(text);
-				order.push("execute");
-			},
-		};
+		const editor = { getText: () => "", setText: () => {} };
 		const ctx = {
 			editor,
 			ui: {
@@ -298,24 +291,23 @@ describe("CommandPalette", () => {
 			pendingImages: [],
 			goalModeController: { enabled: false, paused: false, handleCommand: async () => {} },
 			planModeController: { enabled: false, handleCommand: async () => {} },
-
+			handleChangelogCommand: async () => order.push("execute"),
 			showError: () => {},
 			showStatus: () => {},
 			historyStorage: { getRecent: () => [] },
-			skillCommands: new Map([["skill:demo", { description: "Demo skill" }]]),
-			getSlashCommands: () => [{ name: "skill:demo", description: "Demo skill" }],
+			skillCommands: new Map(),
+			getSlashCommands: () => [{ name: "changelog", description: "Show changelog" }],
 		} as unknown as InteractiveModeContext;
 		new InputController(ctx).openCommandPalette();
-		for (const key of "/skill:demo") overlay?.handleInput(key);
+		for (const key of "/changelog") overlay?.handleInput(key);
 		overlay?.handleInput("\n");
 		await Promise.resolve();
-		expect(submitted).toEqual(["/skill:demo"]);
 		expect(order).toEqual(["hide", "focus", "execute"]);
 	});
 	it("preserves drafts when slash commands are selected through either palette route", async () => {
 		const local = createInputControllerContext({ draft: "keep this draft" });
 		local.controller.openCommandPalette();
-		for (const key of "/clear") local.getOverlay()?.handleInput(key);
+		for (const key of "/changelog") local.getOverlay()?.handleInput(key);
 		local.getOverlay()?.handleInput("\n");
 		await Promise.resolve();
 		expect(local.getText()).toBe("keep this draft");
@@ -323,7 +315,7 @@ describe("CommandPalette", () => {
 
 		const delegated = createInputControllerContext({ draft: "keep this draft", delegated: true });
 		delegated.controller.openCommandPalette();
-		await delegated.getExecuteDelegated()?.("clear");
+		await delegated.getExecuteDelegated()?.("changelog");
 		expect(delegated.getText()).toBe("keep this draft");
 		expect(delegated.statuses).toEqual(["Send or clear the draft before running a palette command."]);
 	});
@@ -334,7 +326,7 @@ describe("CommandPalette", () => {
 			onSubmit: () => new Promise<void>(resolve => (releaseLocal = resolve)),
 		});
 		local.controller.openCommandPalette();
-		for (const key of "/clear") local.getOverlay()?.handleInput(key);
+		for (const key of "/changelog") local.getOverlay()?.handleInput(key);
 		local.getOverlay()?.handleInput("\n");
 		local.getOverlay()?.handleInput("\n");
 		await Promise.resolve();
@@ -349,8 +341,8 @@ describe("CommandPalette", () => {
 		});
 		delegated.controller.openCommandPalette();
 		const execute = delegated.getExecuteDelegated();
-		const first = execute?.("clear");
-		const second = execute?.("clear");
+		const first = execute?.("changelog");
+		const second = execute?.("changelog");
 		await Promise.resolve();
 		expect(delegated.statuses).toEqual(["A palette command is still running."]);
 		releaseDelegated();

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -975,6 +975,22 @@ describe("InputController command palette", () => {
 
 		expect(ctx.handleChangelogCommand).toHaveBeenCalledTimes(1);
 	});
+	it("dispatches slash commands when the UI focus capability is unavailable", async () => {
+		const { ctx } = createContext();
+		const showCommandPalette = vi.fn();
+		ctx.showCommandPalette = showCommandPalette;
+		ctx.handleChangelogCommand = vi.fn();
+		(ctx.ui as { setFocus?: (target: unknown) => void }).setFocus = undefined;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.createAutocompleteProvider([{ name: "changelog" }] as SlashCommand[], "");
+		controller.openCommandPalette();
+		const executeSlashCommand = showCommandPalette.mock.calls[0]?.[2] as (name: string) => Promise<void>;
+		await executeSlashCommand("changelog");
+
+		expect(ctx.handleChangelogCommand).toHaveBeenCalledTimes(1);
+	});
 	it("runs action entries with a draft without touching the composer", () => {
 		const { ctx, editor } = createContext();
 		const showCommandPalette = vi.fn();


### PR DESCRIPTION
## Summary
- make delegated command-palette focus restoration compatibility-safe when `ui.setFocus` is absent
- restore palette slash execution through the canonical non-owning `InputController.submitText` path
- resolve Anthropic cache-eval provider identity from absolute `import.meta.dir`-derived paths while preserving the immutable Git blob OID contract
- cover repository-root and package-cwd identity equivalence directly

## Postmerge failures
- Dev CI run `29642063240`: coding-agent shard 4 failed eight `InputController command palette` tests at `input-controller.ts:1818` because `ctx.ui.setFocus` was unavailable
- Dev CI run `29643119979`: `@gajae-code/ai` failed `anthropic-cache-eval.integration.test.ts` because a root-relative provider path was opened from the package shard cwd

## Verification
- palette matrix: 72 tests, 228 assertions, 0 failures
- AI integration: 2 tests, 43 assertions from repository root and from `packages/ai`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/ai run check`
- `bun run build`
- Cleaner: PASS, zero blockers
- Architect: CLEAR / APPROVE
- Executor QA/red-team: passed on exact head `eb2db5816274a919591abf971c3d6908eca98204`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*