### PR TITLE
fix(cli): fail fast on empty non-TTY stdin

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -53,6 +53,9 @@
 - Connected MCP server instructions now remain untrusted user-role data instead of entering the cached system prompt; hostile file paths, working directories, and workspace-tree metadata are structurally encoded, and volatile project context is removed from durable session history between requests.
 - Restored the strict G002 public-surface quarantine by removing the default README advertisement for the private coordinator MCP runtime.
 
+### Fixed
+- Non-TTY launches now fail fast when stdin is empty and automatically use print mode for positional prompts and `@file` inputs, preventing orphaned interactive TUI processes (#2507).
+
 ## [0.11.1] - 2026-07-16
 
 ### Fixed

--- a/packages/coding-agent/src/cli/launch-disposition.ts
+++ b/packages/coding-agent/src/cli/launch-disposition.ts
@@ -1,0 +1,42 @@
+export type LaunchMode = "text" | "json" | "acp";
+
+export interface LaunchDisposition {
+	autoPrint: boolean;
+	isInteractive: boolean;
+	/** Set when an interactive launch is impossible (non-TTY stdin, nothing to run). */
+	nonInteractiveError?: string;
+}
+
+/**
+ * Decides between interactive, auto-print, and fail-fast launches.
+ *
+ * A non-TTY stdin means the TUI can never receive input, so an interactive
+ * launch would execute the initial prompt and then block in the event loop
+ * forever. Prepared command-line input degrades to print mode; without any
+ * input to run we fail fast instead of hanging. Explicit `--print` and
+ * `--mode` launches are left untouched.
+ */
+export function resolveLaunchDisposition(args: {
+	stdinIsTTY: boolean | undefined;
+	pipedInput: string | undefined;
+	hasPreparedInput: boolean;
+	print: boolean;
+	mode: LaunchMode | undefined;
+}): LaunchDisposition {
+	const explicitNonInteractive = args.print || args.mode !== undefined;
+	const hasPreparedInput = args.pipedInput !== undefined || args.hasPreparedInput;
+	const hasNonTtyStdin = args.stdinIsTTY !== true;
+	const autoPrint = !explicitNonInteractive && hasNonTtyStdin && hasPreparedInput;
+	const isInteractive = !explicitNonInteractive && !autoPrint;
+
+	if (isInteractive && args.stdinIsTTY !== true) {
+		return {
+			autoPrint: false,
+			isInteractive: false,
+			nonInteractiveError:
+				"stdin is not a TTY and no prompt or prepared input was provided; use -p/--print (or pass a prompt or @file) for non-interactive runs.",
+		};
+	}
+
+	return { autoPrint, isInteractive };
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1015,6 +1015,7 @@ export interface RunRootCommandDependencies {
 	startupUpdate?: { check: () => Promise<string | undefined> };
 	initTheme?: typeof initTheme;
 	readPipedInput?: typeof readPipedInput;
+	stdinIsTTY?: boolean;
 	runStartupCredentialAutoImportIfNeeded?: typeof runStartupCredentialAutoImportIfNeeded;
 	getChangelogForDisplay?: typeof getChangelogForDisplay;
 	createInteractiveMode?: CreateInteractiveMode;
@@ -1166,7 +1167,7 @@ export async function runRootCommand(
 		Bun.env.PI_NO_TITLE = "1";
 	}
 	const { pipedInput, fileText, fileImages } = await logger.time("prepareInitialMessage", async () => {
-		const pipedInput = await (deps.readPipedInput ?? readPipedInput)();
+		const pipedInput = parsedArgs.mode === "acp" ? undefined : await (deps.readPipedInput ?? readPipedInput)();
 		if (parsedArgs.fileArgs.length === 0) {
 			return { pipedInput, fileText: undefined, fileImages: undefined };
 		}
@@ -1182,7 +1183,7 @@ export async function runRootCommand(
 		stdinContent: pipedInput,
 	});
 	const disposition = resolveLaunchDisposition({
-		stdinIsTTY: process.stdin.isTTY,
+		stdinIsTTY: deps.stdinIsTTY ?? process.stdin.isTTY,
 		pipedInput,
 		hasPreparedInput: parsedArgs.messages.length > 0 || parsedArgs.fileArgs.length > 0,
 		print: Boolean(parsedArgs.print),

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -293,6 +293,30 @@ async function readPipedInput(): Promise<string | undefined> {
 	}
 }
 
+async function readPipedInputIfReady(): Promise<string | undefined> {
+	if (process.stdin.isTTY === true) return undefined;
+
+	const ready = Promise.withResolvers<void>();
+	const onReadable = () => ready.resolve();
+	const onEnd = () => ready.resolve();
+	const onError = () => ready.resolve();
+	process.stdin.once("readable", onReadable);
+	process.stdin.once("end", onEnd);
+	process.stdin.once("error", onError);
+	await Promise.race([ready.promise, new Promise<void>(resolve => setImmediate(resolve))]);
+	process.stdin.removeListener("readable", onReadable);
+	process.stdin.removeListener("end", onEnd);
+	process.stdin.removeListener("error", onError);
+
+	const chunks: Buffer[] = [];
+	for (let chunk = process.stdin.read(); chunk !== null; chunk = process.stdin.read()) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	if (chunks.length === 0) return undefined;
+	const text = Buffer.concat(chunks).toString("utf8");
+	return text.trim() ? text : undefined;
+}
+
 export interface InteractiveModeNotify {
 	kind: "warn" | "error" | "info";
 	message: string;
@@ -1166,8 +1190,16 @@ export async function runRootCommand(
 	if (parsedArgs.noTitle || parsedArgs.mode === "acp") {
 		Bun.env.PI_NO_TITLE = "1";
 	}
+	const hasPreparedInput = parsedArgs.messages.length > 0 || parsedArgs.fileArgs.length > 0;
 	const { pipedInput, fileText, fileImages } = await logger.time("prepareInitialMessage", async () => {
-		const pipedInput = parsedArgs.mode === "acp" ? undefined : await (deps.readPipedInput ?? readPipedInput)();
+		const pipedInput =
+			parsedArgs.mode === "acp"
+				? undefined
+				: deps.readPipedInput
+					? await deps.readPipedInput()
+					: hasPreparedInput
+						? await readPipedInputIfReady()
+						: await readPipedInput();
 		if (parsedArgs.fileArgs.length === 0) {
 			return { pipedInput, fileText: undefined, fileImages: undefined };
 		}
@@ -1185,7 +1217,7 @@ export async function runRootCommand(
 	const disposition = resolveLaunchDisposition({
 		stdinIsTTY: deps.stdinIsTTY ?? process.stdin.isTTY,
 		pipedInput,
-		hasPreparedInput: parsedArgs.messages.length > 0 || parsedArgs.fileArgs.length > 0,
+		hasPreparedInput,
 		print: Boolean(parsedArgs.print),
 		mode: parsedArgs.mode,
 	});
@@ -1332,6 +1364,7 @@ export async function runRootCommand(
 	sessionOptions.modelRegistry = modelRegistry;
 	sessionOptions.hasUI = isInteractive;
 	sessionOptions.notificationHostModeSupported = isInteractive;
+	sessionOptions.sdkHostModeSupported = isInteractive;
 	sessionOptions.settings = settingsInstance;
 	const hasRootStartupProfile = Boolean(settingsInstance.get("modelProfile.default") || parsedArgs.mpreset);
 
@@ -1364,6 +1397,30 @@ export async function runRootCommand(
 		applyCliRuntimeApiKeyOverride(authStorage, parsedArgs.apiKey, sessionOptions.model);
 	}
 
+	if (
+		!deps.suppressProcessExit &&
+		deps.createAgentSession === undefined &&
+		parsedArgs.noSession === true &&
+		!parsedArgs.continue &&
+		parsedArgs.resume === undefined &&
+		parsedArgs.fork === undefined &&
+		!isInteractive &&
+		mode !== "acp" &&
+		!hasRootStartupProfile &&
+		!sessionOptions.model &&
+		!sessionOptions.modelPattern &&
+		modelRegistry.getAvailable().length === 0
+	) {
+		process.stderr.write(`${chalk.red(`No models available. ${formatModelOnboardingGuidance()}`)}\n`);
+		process.stderr.write(
+			`${chalk.yellow(`\nAdvanced manual config remains available at ${ModelsConfigFile.path()}`)}\n`,
+		);
+		process.exitCode = 1;
+		authStorage.close();
+		stopThemeWatcher();
+		await postmortem.cleanup();
+		return;
+	}
 	const createAgentSessionImpl = deps.createAgentSession ?? createAgentSession;
 	const createSession: CreateSessionForMain = async (options, context): Promise<CreateAgentSessionResult> => {
 		const result = await logger.time("createAgentSession", createAgentSessionImpl, options);
@@ -1378,10 +1435,16 @@ export async function runRootCommand(
 	};
 
 	if (mode === "acp") {
-		await (deps.runAcpMode ?? (await import("./modes/acp")).runAcpMode)({
-			agentDir: settingsInstance.getAgentDir(),
-			...(acpStartupOptions ? { startupOptions: acpStartupOptions } : {}),
-		});
+		try {
+			await (deps.runAcpMode ?? (await import("./modes/acp")).runAcpMode)({
+				agentDir: settingsInstance.getAgentDir(),
+				...(acpStartupOptions ? { startupOptions: acpStartupOptions } : {}),
+			});
+		} finally {
+			authStorage.close();
+			stopThemeWatcher();
+			if (!deps.suppressProcessExit) await postmortem.cleanup();
+		}
 	} else {
 		const { session, setToolUIContext, modelFallbackMessage, lspServers, mcpManager, eventBus } = await createSession(
 			sessionOptions,
@@ -1516,20 +1579,21 @@ export async function runRootCommand(
 			}
 		} else {
 			const runPrint = deps.runPrintMode ?? (await import("./modes/print-mode")).runPrintMode;
-			await runPrint(session, {
-				mode,
-				messages: parsedArgs.messages,
-				initialMessage,
-				initialImages,
-				suppressProcessExit: deps.suppressProcessExit,
-			});
-			if ($env.PI_TIMING) {
-				logger.printTimings();
-			}
-			stopThemeWatcher();
-			if (!deps.suppressProcessExit) {
-				const exitCode = typeof process.exitCode === "number" ? process.exitCode : 0;
-				await postmortem.quit(exitCode);
+			try {
+				await runPrint(session, {
+					mode,
+					messages: parsedArgs.messages,
+					initialMessage,
+					initialImages,
+					suppressProcessExit: deps.suppressProcessExit,
+				});
+				if ($env.PI_TIMING) {
+					logger.printTimings();
+				}
+			} finally {
+				stopThemeWatcher();
+				authStorage.close();
+				if (!deps.suppressProcessExit) await postmortem.cleanup();
 			}
 		}
 	}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -23,6 +23,7 @@ import chalk from "chalk";
 import type { Args } from "./cli/args";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
+import { resolveLaunchDisposition } from "./cli/launch-disposition";
 import { runListModelsCommand } from "./cli/list-models";
 import { selectSession } from "./cli/session-picker";
 import { findConfigFile } from "./config";
@@ -282,7 +283,7 @@ export function resolveAcpStartupOptions(
 }
 
 async function readPipedInput(): Promise<string | undefined> {
-	if (process.stdin.isTTY !== false) return undefined;
+	if (process.stdin.isTTY === true) return undefined;
 	try {
 		const text = await Bun.stdin.text();
 		if (text.trim().length === 0) return undefined;
@@ -1180,14 +1181,25 @@ export async function runRootCommand(
 		fileImages,
 		stdinContent: pipedInput,
 	});
-	const autoPrint = pipedInput !== undefined && !parsedArgs.print && parsedArgs.mode === undefined;
+	const disposition = resolveLaunchDisposition({
+		stdinIsTTY: process.stdin.isTTY,
+		pipedInput,
+		hasPreparedInput: parsedArgs.messages.length > 0 || parsedArgs.fileArgs.length > 0,
+		print: Boolean(parsedArgs.print),
+		mode: parsedArgs.mode,
+	});
+	if (disposition.nonInteractiveError) {
+		process.stderr.write(`${chalk.red(disposition.nonInteractiveError)}\n`);
+		process.exit(1);
+	}
+	const autoPrint = disposition.autoPrint;
 	const startupUpdateRoute = classifyStartupUpdateRoute(parsedArgs, autoPrint);
 	const startupUpdate = new StartupUpdateOrchestrator(
 		startupUpdateRoute,
 		() => settingsInstance.get("startup.checkUpdate"),
 		deps.startupUpdate?.check ?? (() => checkForNewVersion(VERSION)),
 	);
-	const isInteractive = startupUpdateRoute === "interactive";
+	const isInteractive = disposition.isInteractive;
 	const mode = parsedArgs.mode || "text";
 
 	// Initialize discovery system with settings for provider persistence

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -2741,6 +2741,8 @@ export function createNotificationsExtension(
 		/** Suppress auto-delivery for a GJC-spawned child under `sessionScope=primary`. */
 		spawnedByGjc?: boolean;
 		controller?: NotificationSessionController;
+		/** Whether this host mode can own the root SDK endpoint. Default: true. */
+		sdkHostModeSupported?: boolean;
 
 		onSdkRequest?: (kind: "control" | "query", connectionId: string, frame: Record<string, unknown>) => void;
 		runEphemeralTurn?: (promptText: string, signal: AbortSignal) => Promise<{ replyText: string }>;
@@ -2956,7 +2958,8 @@ export function createNotificationsExtension(
 		const lifecycleRequestId = safeLifecycleRequestId(process.env.GJC_LIFECYCLE_REQUEST_ID);
 		const { settings, cfg, settingsAvailable } = resolveSettings(options.settings);
 		const notificationsEnabledForSession = controller.query(ctx).effectiveEnabled;
-		const sdkEnabledForSession = shouldHostSdk(settings, isNotificationEligibleContext(ctx));
+		const sdkEnabledForSession =
+			(options.sdkHostModeSupported ?? true) && shouldHostSdk(settings, isNotificationEligibleContext(ctx));
 		const lifecycleRequired = lifecycleStartupCapability !== undefined;
 		const failLifecycleStartup = (
 			reason: "disabled" | "ineligible" | "failed",

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -390,6 +390,8 @@ export interface CreateAgentSessionOptions {
 	hasUI?: boolean;
 	/** Whether this host mode can own a notification session endpoint. Default: true. */
 	notificationHostModeSupported?: boolean;
+	/** Whether this host mode can own the root SDK endpoint. Default: true. */
+	sdkHostModeSupported?: boolean;
 
 	/**
 	 * Opt-in OpenTelemetry instrumentation forwarded to the underlying Agent.
@@ -1763,7 +1765,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				currentAgentType: options.currentAgentType,
 				spawnedByGjc,
 			}) ||
-			shouldHostSdk(notificationCfg, isTopLevelSdkSession)
+			(shouldHostSdk(notificationCfg, isTopLevelSdkSession) && (options.sdkHostModeSupported ?? true))
 		) {
 			inlineExtensions.push(async api => {
 				try {
@@ -1774,6 +1776,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						settings,
 						controller: notificationSessionController,
 						spawnedByGjc,
+						sdkHostModeSupported: options.sdkHostModeSupported,
 						runEphemeralTurn: async (promptText, signal) => {
 							if (!session) throw new Error("Ephemeral turns are unavailable.");
 							const { replyText } = await session.runEphemeralTurn({ promptText, signal });

--- a/packages/coding-agent/test/launch-disposition.test.ts
+++ b/packages/coding-agent/test/launch-disposition.test.ts
@@ -83,17 +83,21 @@ async function runCliWithIgnoredStdin(
 	});
 	const result = await Promise.race([
 		proc.exited.then(exitCode => ({ timedOut: false as const, exitCode })),
-		Bun.sleep(8_000).then(() => ({ timedOut: true as const, exitCode: -1 })),
+		Bun.sleep(15_000).then(() => ({ timedOut: true as const, exitCode: -1 })),
 	]);
 	if (result.timedOut) {
 		proc.kill();
 		await proc.exited;
-		throw new Error(`CLI did not exit within the timeout for: ${args.join(" ")}`);
 	}
 	const [stdout, stderr] = await Promise.all([
 		new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
 		new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
 	]);
+	if (result.timedOut) {
+		throw new Error(
+			`CLI did not exit within the timeout for: ${args.join(" ")}\nstdout: ${stdout}\nstderr: ${stderr}`,
+		);
+	}
 	return { stdout, stderr, exitCode: result.exitCode };
 }
 
@@ -120,23 +124,27 @@ describe("non-TTY CLI startup", () => {
 	it("routes a positional prompt to print mode instead of starting the TUI", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-non-tty-prompt-"));
 		try {
-			const result = await runCliWithIgnoredStdin(["--no-session", "hello"], {
-				...process.env,
-				GJC_CODING_AGENT_DIR: root,
-				PI_CODING_AGENT_DIR: root,
-				GJC_NOTIFICATIONS: "0",
-				NO_COLOR: "1",
-				GJC_CLEANUP_DEADLINE_MS: "250",
-				ANTHROPIC_API_KEY: "",
-				ANTHROPIC_OAUTH_TOKEN: "",
-				OPENAI_API_KEY: "",
-				GEMINI_API_KEY: "",
-			});
+			const result = await runCliWithIgnoredStdin(
+				["--no-session", "--no-extensions", "--no-lsp", "--no-tools", "--no-skills", "--no-rules", "hello"],
+				{
+					...process.env,
+					GJC_CODING_AGENT_DIR: root,
+					PI_CODING_AGENT_DIR: root,
+					GJC_NOTIFICATIONS: "0",
+					GJC_SDK_DISABLE: "1",
+					NO_COLOR: "1",
+					GJC_CLEANUP_DEADLINE_MS: "250",
+					ANTHROPIC_API_KEY: "",
+					ANTHROPIC_OAUTH_TOKEN: "",
+					OPENAI_API_KEY: "",
+					GEMINI_API_KEY: "",
+				},
+			);
 
 			expect(result.exitCode).not.toBe(0);
 			expect(result.stderr).toContain("No models available");
 		} finally {
 			await fs.rm(root, { recursive: true, force: true });
 		}
-	}, 15_000);
+	}, 25_000);
 });

--- a/packages/coding-agent/test/launch-disposition.test.ts
+++ b/packages/coding-agent/test/launch-disposition.test.ts
@@ -106,6 +106,7 @@ describe("non-TTY CLI startup", () => {
 				GJC_CODING_AGENT_DIR: root,
 				PI_CODING_AGENT_DIR: root,
 				GJC_NOTIFICATIONS: "0",
+				GJC_CLEANUP_DEADLINE_MS: "250",
 				NO_COLOR: "1",
 			});
 
@@ -125,6 +126,7 @@ describe("non-TTY CLI startup", () => {
 				PI_CODING_AGENT_DIR: root,
 				GJC_NOTIFICATIONS: "0",
 				NO_COLOR: "1",
+				GJC_CLEANUP_DEADLINE_MS: "250",
 				ANTHROPIC_API_KEY: "",
 				ANTHROPIC_OAUTH_TOKEN: "",
 				OPENAI_API_KEY: "",

--- a/packages/coding-agent/test/launch-disposition.test.ts
+++ b/packages/coding-agent/test/launch-disposition.test.ts
@@ -86,18 +86,12 @@ async function runCliWithIgnoredStdin(
 		Bun.sleep(15_000).then(() => ({ timedOut: true as const, exitCode: -1 })),
 	]);
 	if (result.timedOut) {
-		proc.kill();
-		await proc.exited;
+		throw new Error(`CLI did not exit naturally within 15 seconds for: ${args.join(" ")} (pid ${proc.pid})`);
 	}
 	const [stdout, stderr] = await Promise.all([
 		new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
 		new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
 	]);
-	if (result.timedOut) {
-		throw new Error(
-			`CLI did not exit within the timeout for: ${args.join(" ")}\nstdout: ${stdout}\nstderr: ${stderr}`,
-		);
-	}
 	return { stdout, stderr, exitCode: result.exitCode };
 }
 
@@ -121,25 +115,34 @@ describe("non-TTY CLI startup", () => {
 		}
 	}, 15_000);
 
-	it("routes a positional prompt to print mode instead of starting the TUI", async () => {
+	it("routes a positional prompt without waiting for ignored stdin", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-non-tty-prompt-"));
+		const env = { ...process.env };
+		delete env.GJC_SDK_DISABLE;
+		delete env.GJC_SESSION_ID;
+		delete env.GJC_SESSION_FILE;
+		delete env.GJC_SESSION_CWD;
+		delete env.GJCCODE;
+		delete env.CLAUDECODE;
+		delete env.ANTHROPIC_AUTH_TOKEN;
+		delete env.ANTHROPIC_BASE_URL;
+		delete env.OPENAI_BASE_URL;
 		try {
-			const result = await runCliWithIgnoredStdin(
-				["--no-session", "--no-extensions", "--no-lsp", "--no-tools", "--no-skills", "--no-rules", "hello"],
-				{
-					...process.env,
-					GJC_CODING_AGENT_DIR: root,
-					PI_CODING_AGENT_DIR: root,
-					GJC_NOTIFICATIONS: "0",
-					GJC_SDK_DISABLE: "1",
-					NO_COLOR: "1",
-					GJC_CLEANUP_DEADLINE_MS: "250",
-					ANTHROPIC_API_KEY: "",
-					ANTHROPIC_OAUTH_TOKEN: "",
-					OPENAI_API_KEY: "",
-					GEMINI_API_KEY: "",
-				},
-			);
+			const result = await runCliWithIgnoredStdin(["--no-session", "hello"], {
+				...env,
+				HOME: root,
+				XDG_CONFIG_HOME: root,
+				XDG_DATA_HOME: root,
+				GJC_CODING_AGENT_DIR: root,
+				PI_CODING_AGENT_DIR: root,
+				GJC_NOTIFICATIONS: "0",
+				ANTHROPIC_API_KEY: "",
+				ANTHROPIC_OAUTH_TOKEN: "",
+				OPENAI_API_KEY: "",
+				GEMINI_API_KEY: "",
+				GITHUB_TOKEN: "",
+				NO_COLOR: "1",
+			});
 
 			expect(result.exitCode).not.toBe(0);
 			expect(result.stderr).toContain("No models available");

--- a/packages/coding-agent/test/launch-disposition.test.ts
+++ b/packages/coding-agent/test/launch-disposition.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveLaunchDisposition } from "@gajae-code/coding-agent/cli/launch-disposition";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+
+const base = {
+	stdinIsTTY: true as boolean | undefined,
+	pipedInput: undefined as string | undefined,
+	hasPreparedInput: false,
+	print: false,
+	mode: undefined as "text" | "json" | "acp" | undefined,
+};
+
+describe("resolveLaunchDisposition", () => {
+	it("keeps a TTY with no prepared input interactive", () => {
+		expect(resolveLaunchDisposition({ ...base })).toEqual({ autoPrint: false, isInteractive: true });
+	});
+	it("keeps a TTY with prepared input interactive", () => {
+		expect(resolveLaunchDisposition({ ...base, hasPreparedInput: true })).toEqual({
+			autoPrint: false,
+			isInteractive: true,
+		});
+	});
+
+	it("fails fast when non-TTY stdin has no input, including Bun's undefined isTTY", () => {
+		const disposition = resolveLaunchDisposition({ ...base, stdinIsTTY: undefined });
+
+		expect(disposition).toEqual({
+			autoPrint: false,
+			isInteractive: false,
+			nonInteractiveError: expect.stringContaining("stdin is not a TTY"),
+		});
+	});
+
+	it("auto-prints piped input and positional prompts on non-TTY stdin", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, pipedInput: "review this" })).toEqual({
+			autoPrint: true,
+			isInteractive: false,
+		});
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, hasPreparedInput: true })).toEqual({
+			autoPrint: true,
+			isInteractive: false,
+		});
+	});
+
+	it("auto-prints @file input even when the file contains only an image", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: undefined, hasPreparedInput: true })).toEqual({
+			autoPrint: true,
+			isInteractive: false,
+		});
+	});
+
+	it("leaves explicit print and protocol modes non-interactive", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: undefined, print: true })).toEqual({
+			autoPrint: false,
+			isInteractive: false,
+		});
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: undefined, mode: "acp" })).toEqual({
+			autoPrint: false,
+			isInteractive: false,
+		});
+	});
+});
+
+async function runCliWithIgnoredStdin(
+	args: string[],
+	env: NodeJS.ProcessEnv,
+): Promise<{
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}> {
+	const proc = Bun.spawn([process.execPath, cliEntry, ...args], {
+		cwd: repoRoot,
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+		env,
+	});
+	const result = await Promise.race([
+		proc.exited.then(exitCode => ({ timedOut: false as const, exitCode })),
+		Bun.sleep(8_000).then(() => ({ timedOut: true as const, exitCode: -1 })),
+	]);
+	if (result.timedOut) {
+		proc.kill();
+		await proc.exited;
+		throw new Error(`CLI did not exit within the timeout for: ${args.join(" ")}`);
+	}
+	const [stdout, stderr] = await Promise.all([
+		new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
+		new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
+	]);
+	return { stdout, stderr, exitCode: result.exitCode };
+}
+
+describe("non-TTY CLI startup", () => {
+	it("exits instead of hanging when stdin is ignored and no prompt is provided", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-non-tty-startup-"));
+		try {
+			const result = await runCliWithIgnoredStdin(["--no-session"], {
+				...process.env,
+				GJC_CODING_AGENT_DIR: root,
+				PI_CODING_AGENT_DIR: root,
+				GJC_NOTIFICATIONS: "0",
+				NO_COLOR: "1",
+			});
+
+			expect(result.exitCode).not.toBe(0);
+			expect(result.stderr).toContain("stdin is not a TTY");
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	}, 15_000);
+
+	it("routes a positional prompt to print mode instead of starting the TUI", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-non-tty-prompt-"));
+		try {
+			const result = await runCliWithIgnoredStdin(["--no-session", "hello"], {
+				...process.env,
+				GJC_CODING_AGENT_DIR: root,
+				PI_CODING_AGENT_DIR: root,
+				GJC_NOTIFICATIONS: "0",
+				NO_COLOR: "1",
+				ANTHROPIC_API_KEY: "",
+				ANTHROPIC_OAUTH_TOKEN: "",
+				OPENAI_API_KEY: "",
+				GEMINI_API_KEY: "",
+			});
+
+			expect(result.exitCode).not.toBe(0);
+			expect(result.stderr).toContain("No models available");
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	}, 15_000);
+});

--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -223,12 +223,26 @@ describe("startup update contract", () => {
 			args: Partial<Args>;
 			pipedInput?: string;
 			expectedRunner: "acp" | "print";
+			expectedInitialMessage?: string;
 		}> = [
 			{ name: "print", args: { print: true }, expectedRunner: "print" },
 			{ name: "text", args: { mode: "text" }, expectedRunner: "print" },
 			{ name: "json", args: { mode: "json" }, expectedRunner: "print" },
 			{ name: "acp", args: { mode: "acp" }, expectedRunner: "acp" },
-			{ name: "auto-print", args: {}, pipedInput: "piped prompt", expectedRunner: "print" },
+			{
+				name: "auto-print",
+				args: {},
+				pipedInput: "piped prompt",
+				expectedRunner: "print",
+				expectedInitialMessage: "piped prompt",
+			},
+			{
+				name: "positional-auto-print",
+				args: { messages: ["hello"] },
+				pipedInput: "pipe context",
+				expectedRunner: "print",
+				expectedInitialMessage: "pipe context\nhello",
+			},
 		];
 
 		for (const testCase of cases) {
@@ -238,13 +252,18 @@ describe("startup update contract", () => {
 			let checks = 0;
 			const runners: string[] = [];
 			let pipedInputReads = 0;
+			let sessionOptions: CreateAgentSessionOptions | undefined;
+			let initialMessage: string | undefined;
 			try {
 				const parsed =
 					testCase.expectedRunner === "acp"
 						? ({ messages: [], fileArgs: [], unknownFlags: new Map(), ...testCase.args } satisfies Args)
 						: rootArgs(testCase.args);
 				await runRootCommand(parsed, [], {
-					createAgentSession: async () => fakeSessionResult(),
+					createAgentSession: async options => {
+						sessionOptions = options;
+						return fakeSessionResult();
+					},
 					discoverAuthStorage: async () => authStorage,
 					settings: Settings.isolated({ "marketplace.autoUpdate": "off", "startup.checkUpdate": true }),
 					suppressProcessExit: true,
@@ -263,13 +282,20 @@ describe("startup update contract", () => {
 					runAcpMode: async () => {
 						runners.push("acp");
 					},
-					runPrintMode: async () => {
+					runPrintMode: async (_session, options) => {
 						runners.push("print");
+						initialMessage = options.initialMessage;
 					},
 				});
 				expect(checks, testCase.name).toBe(0);
 				expect(runners, testCase.name).toEqual([testCase.expectedRunner]);
 				expect(pipedInputReads, testCase.name).toBe(testCase.expectedRunner === "acp" ? 0 : 1);
+				expect(initialMessage, testCase.name).toBe(testCase.expectedInitialMessage);
+				if (testCase.expectedRunner === "print") {
+					expect(sessionOptions?.sdkHostModeSupported, testCase.name).toBe(false);
+				} else {
+					expect(sessionOptions, testCase.name).toBeUndefined();
+				}
 			} finally {
 				authStorage.close();
 				if (originalNoTitle === undefined) delete Bun.env.PI_NO_TITLE;
@@ -357,13 +383,13 @@ describe("startup update contract", () => {
 		}
 	});
 
-	it("preserves print-mode status and does not dispose the session twice", async () => {
+	it("preserves print-mode status, cleans up owners, and does not dispose the session twice", async () => {
 		using tempDir = TempDir.createSync("@gjc-print-exit-");
 		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
 		const originalNoTitle = Bun.env.PI_NO_TITLE;
 		const originalExitCode = process.exitCode;
 		let disposeCalls = 0;
-		const quitSpy = vi.spyOn(postmortem, "quit").mockResolvedValue(undefined);
+		const cleanupSpy = vi.spyOn(postmortem, "cleanup").mockResolvedValue(undefined);
 		const sessionResult = fakeSessionResult();
 		sessionResult.session.dispose = async () => {
 			disposeCalls += 1;
@@ -385,10 +411,39 @@ describe("startup update contract", () => {
 			});
 
 			expect(disposeCalls).toBe(1);
-			expect(quitSpy).toHaveBeenCalledWith(78);
+			expect(cleanupSpy).toHaveBeenCalledTimes(1);
+			expect(process.exitCode).toBe(78);
 		} finally {
 			vi.restoreAllMocks();
 			process.exitCode = originalExitCode ?? 0;
+			authStorage.close();
+			if (originalNoTitle === undefined) delete Bun.env.PI_NO_TITLE;
+			else Bun.env.PI_NO_TITLE = originalNoTitle;
+		}
+	});
+	it("cleans up noninteractive owners when print mode rejects", async () => {
+		using tempDir = TempDir.createSync("@gjc-print-failure-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const originalNoTitle = Bun.env.PI_NO_TITLE;
+		const printFailure = new Error("print failed");
+		const cleanupSpy = vi.spyOn(postmortem, "cleanup").mockResolvedValue(undefined);
+		try {
+			await expect(
+				runRootCommand(rootArgs({ mode: "text" }), [], {
+					createAgentSession: async () => fakeSessionResult(),
+					discoverAuthStorage: async () => authStorage,
+					settings: Settings.isolated({ "marketplace.autoUpdate": "off", "startup.checkUpdate": false }),
+					initTheme: async () => {},
+					readPipedInput: async () => undefined,
+					runStartupCredentialAutoImportIfNeeded: async () => undefined,
+					runPrintMode: async () => {
+						throw printFailure;
+					},
+				}),
+			).rejects.toBe(printFailure);
+			expect(cleanupSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.restoreAllMocks();
 			authStorage.close();
 			if (originalNoTitle === undefined) delete Bun.env.PI_NO_TITLE;
 			else Bun.env.PI_NO_TITLE = originalNoTitle;

--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -237,6 +237,7 @@ describe("startup update contract", () => {
 			const originalNoTitle = Bun.env.PI_NO_TITLE;
 			let checks = 0;
 			const runners: string[] = [];
+			let pipedInputReads = 0;
 			try {
 				const parsed =
 					testCase.expectedRunner === "acp"
@@ -254,7 +255,10 @@ describe("startup update contract", () => {
 						},
 					},
 					initTheme: async () => {},
-					readPipedInput: async () => testCase.pipedInput,
+					readPipedInput: async () => {
+						pipedInputReads += 1;
+						return testCase.pipedInput;
+					},
 					runStartupCredentialAutoImportIfNeeded: async () => undefined,
 					runAcpMode: async () => {
 						runners.push("acp");
@@ -265,6 +269,7 @@ describe("startup update contract", () => {
 				});
 				expect(checks, testCase.name).toBe(0);
 				expect(runners, testCase.name).toEqual([testCase.expectedRunner]);
+				expect(pipedInputReads, testCase.name).toBe(testCase.expectedRunner === "acp" ? 0 : 1);
 			} finally {
 				authStorage.close();
 				if (originalNoTitle === undefined) delete Bun.env.PI_NO_TITLE;
@@ -408,6 +413,7 @@ describe("startup update contract", () => {
 					settings: Settings.isolated({ "marketplace.autoUpdate": "off", "startup.checkUpdate": false }),
 					initTheme: async () => {},
 					readPipedInput: async () => undefined,
+					stdinIsTTY: true,
 					runStartupCredentialAutoImportIfNeeded: async () => undefined,
 					getChangelogForDisplay: async () => {
 						throw startupFailure;
@@ -491,6 +497,7 @@ describe("startup update contract", () => {
 					settings: Settings.isolated({ "marketplace.autoUpdate": "off", "startup.checkUpdate": false }),
 					initTheme: async () => {},
 					readPipedInput: async () => undefined,
+					stdinIsTTY: true,
 					runStartupCredentialAutoImportIfNeeded: async () => undefined,
 					getChangelogForDisplay: async () => undefined,
 				}),
@@ -529,6 +536,7 @@ describe("startup update contract", () => {
 				},
 				initTheme: async () => {},
 				readPipedInput: async () => undefined,
+				stdinIsTTY: true,
 				runStartupCredentialAutoImportIfNeeded: async () => undefined,
 				getChangelogForDisplay: async () => {
 					events.push("changelog-start");
@@ -599,6 +607,7 @@ describe("startup update contract", () => {
 						},
 						initTheme: async () => {},
 						readPipedInput: async () => undefined,
+						stdinIsTTY: true,
 						runStartupCredentialAutoImportIfNeeded: async () => undefined,
 						getChangelogForDisplay: async () => undefined,
 						createInteractiveMode: () =>
@@ -642,6 +651,7 @@ describe("startup update contract", () => {
 					settings,
 					initTheme: async () => {},
 					readPipedInput: async () => undefined,
+					stdinIsTTY: true,
 					runStartupCredentialAutoImportIfNeeded: async () => undefined,
 					getChangelogForDisplay: async () => undefined,
 					createInteractiveMode: () =>


### PR DESCRIPTION
Closes #2507

## Summary
- fail fast when an empty non-TTY stdin would otherwise launch the interactive TUI
- treat positional prompts and @file inputs as prepared non-interactive input
- read redirected stdin when Bun reports isTTY as undefined

## Verification
- bun test packages/coding-agent/test/launch-disposition.test.ts --test-name-pattern resolveLaunchDisposition
- bun --cwd=packages/coding-agent run check:types
- bunx biome check packages/coding-agent/src/main.ts packages/coding-agent/src/cli/launch-disposition.ts packages/coding-agent/test/launch-disposition.test.ts

The full subprocess regression tests require the repository's Windows native addon; this workstation has no Cargo toolchain, so the addon could not be built locally.