### PR TITLE
fix(coding-agent): preserve legal sqlite-prefixed tables

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 - Team worker launches now receive the validated owning `GJC_SESSION_ID` for sanctioned session-scoped writes while preserving absent identity, fail-closed resolution, and separate spawn provenance (#2597).
 - Managed and explicit session directories now canonicalize benign ancestor symlinks (e.g. macOS `/var -> /private/var`, a symlinked `$HOME` or project directory) to a symlink-free trusted root before the strict owner-only and reparse guards run, so session creation, moves, resume, and writes no longer fail with `reparse_point` / `Unsafe reparse storage path` under a symlinked temp root or home. The native primitive stays strict and continues to reject symlinked components at or below the trusted root.
+- SQLite inspection now excludes only the literal reserved `sqlite_` table-name prefix, so legal user tables such as `sqlitefoo` remain listable and readable.
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).

--- a/packages/coding-agent/src/tools/sqlite-reader.ts
+++ b/packages/coding-agent/src/tools/sqlite-reader.ts
@@ -13,6 +13,8 @@ const MAX_RENDER_WIDTH = 120;
 const MAX_COLUMN_WIDTH = 40;
 const MIN_COLUMN_WIDTH = 1;
 
+const USER_TABLE_PREDICATE = "name NOT GLOB 'sqlite_*'";
+
 type SqliteBinding = Exclude<SQLQueryBindings, Record<string, unknown>>;
 
 type SqliteRow = Record<string, unknown>;
@@ -182,7 +184,7 @@ function getTableMasterRow(db: Database, table: string): SqliteMasterRow {
 	const row =
 		db
 			.prepare<SqliteMasterRow, [string]>(
-				"SELECT name, sql FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name = ?",
+				`SELECT name, sql FROM sqlite_master WHERE type = 'table' AND ${USER_TABLE_PREDICATE} AND name = ?`,
 			)
 			.get(table) ?? null;
 	if (!row) {
@@ -502,7 +504,7 @@ export function parseSqliteSelector(subPath: string, queryString: string): Sqlit
 export function listTables(db: Database): { name: string; rowCount: number }[] {
 	const names = db
 		.prepare<Pick<SqliteMasterRow, "name">, []>(
-			"SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name COLLATE NOCASE",
+			`SELECT name FROM sqlite_master WHERE type = 'table' AND ${USER_TABLE_PREDICATE} ORDER BY name COLLATE NOCASE`,
 		)
 		.all();
 

--- a/packages/coding-agent/test/tools/sqlite.test.ts
+++ b/packages/coding-agent/test/tools/sqlite.test.ts
@@ -62,6 +62,12 @@ function createFixtureDatabase(dbPath: string): void {
 				id INTEGER PRIMARY KEY,
 				payload TEXT NOT NULL
 			);
+			CREATE TABLE sqlitefoo (
+				value TEXT NOT NULL
+			);
+			CREATE TABLE sqliteXtable (
+				value TEXT NOT NULL
+			);
 		`);
 
 		db.prepare("INSERT INTO users (name, email, status, created) VALUES (?, ?, ?, ?)").run(
@@ -110,6 +116,8 @@ function createFixtureDatabase(dbPath: string): void {
 
 		db.prepare("INSERT INTO composite (team_id, user_id, value) VALUES (?, ?, ?)").run(1, 2, "pair");
 		db.prepare("INSERT INTO wide_rows (id, payload) VALUES (?, ?)").run(1, "x".repeat(320));
+		db.prepare("INSERT INTO sqlitefoo (value) VALUES (?)").run("foo");
+		db.prepare("INSERT INTO sqliteXtable (value) VALUES (?)").run("bar");
 	} finally {
 		db.close();
 	}
@@ -237,13 +245,15 @@ describe("SQLite tool support", () => {
 		});
 	});
 
-	it("lists tables for a .sqlite database and excludes sqlite internal tables", async () => {
+	it("lists user tables with sqlite prefixes and excludes SQLite internal tables", async () => {
 		const result = await readTool.execute("sqlite-list", { path: sqlitePath });
 		const text = getText(result);
 
 		expect(text).toContain("users (6 rows)");
 		expect(text).toContain("slugs (2 rows)");
 		expect(text).toContain("notes (3 rows)");
+		expect(text).toContain("sqlitefoo (1 rows)");
+		expect(text).toContain("sqliteXtable (1 rows)");
 		expect(text).not.toContain("sqlite_sequence");
 	});
 
@@ -264,6 +274,14 @@ describe("SQLite tool support", () => {
 		expect(text).toContain("CREATE TABLE users");
 		expect(text).toContain("Sample rows:");
 		expect(text).toContain("Alice");
+	});
+	it("reads tables that start with sqlite without an underscore", async () => {
+		const schemaResult = await readTool.execute("sqlite-prefix-schema", { path: `${sqlitePath}:sqlitefoo` });
+		const tableResult = await readTool.execute("sqlite-prefix-table", { path: `${sqlitePath}:sqliteXtable?limit=1` });
+
+		expect(getText(schemaResult)).toContain("CREATE TABLE sqlitefoo");
+		expect(getText(schemaResult)).toContain("foo");
+		expect(getText(tableResult)).toContain("bar");
 	});
 
 	it("returns a row by integer primary key", async () => {


### PR DESCRIPTION
## What

- Exclude only SQLite's literal reserved `sqlite_` table-name prefix when listing and resolving tables.
- Keep legal user tables such as `sqlitefoo` and `sqliteXtable` visible and readable.
- Add regression coverage for listing, schema reads, table reads, and `sqlite_sequence` exclusion.

## Why

The existing `LIKE 'sqlite_%'` predicate treats `_` as a wildcard, so it hides legal user tables whose names merely begin with `sqlite`.

## Testing

- `bun test packages/coding-agent/test/tools/sqlite.test.ts` — 27 passed
- `bun --cwd=packages/coding-agent run check` — passed

---

- [x] Tested locally
- [x] CHANGELOG updated
