### PR TITLE
fix(web-search): stop widening SearXNG week filters

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 - Team worker launches now receive the validated owning `GJC_SESSION_ID` for sanctioned session-scoped writes while preserving absent identity, fail-closed resolution, and separate spawn provenance (#2597).
 - Managed and explicit session directories now canonicalize benign ancestor symlinks (e.g. macOS `/var -> /private/var`, a symlinked `$HOME` or project directory) to a symlink-free trusted root before the strict owner-only and reparse guards run, so session creation, moves, resume, and writes no longer fail with `reparse_point` / `Unsafe reparse storage path` under a symlinked temp root or home. The native primitive stays strict and continues to reject symlinked components at or below the trusted root.
+- SearXNG searches no longer widen the unsupported `week` recency filter to `month`; unsupported weekly filtering is now omitted as required by the provider contract.
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).

--- a/packages/coding-agent/src/web/search/providers/searxng.ts
+++ b/packages/coding-agent/src/web/search/providers/searxng.ts
@@ -38,14 +38,12 @@ import { classifyProviderHttpError, withHardTimeout } from "./utils";
 const DEFAULT_NUM_RESULTS = 10;
 const MAX_NUM_RESULTS = 20;
 
-/** Map our recency filter to SearXNG time_range parameter.
- *  SearXNG only supports day/month/year, so week maps to month. */
-const RECENCY_MAP: Record<"day" | "week" | "month" | "year", string> = {
+/** Map supported recency filters to SearXNG time_range values. */
+const RECENCY_MAP = {
 	day: "day",
-	week: "month",
 	month: "month",
 	year: "year",
-};
+} as const;
 
 /** SearXNG JSON API response types */
 interface SearXNGResult {
@@ -173,7 +171,7 @@ function buildRequest(
 		url.searchParams.set("pageno", "1");
 	}
 
-	if (params.recency) {
+	if (params.recency && params.recency !== "week") {
 		url.searchParams.set("time_range", RECENCY_MAP[params.recency]);
 	}
 

--- a/packages/coding-agent/test/tools/web-search-searxng.test.ts
+++ b/packages/coding-agent/test/tools/web-search-searxng.test.ts
@@ -40,7 +40,8 @@ describe("SearXNG web search provider", () => {
 		expect(captured.url?.pathname).toBe("/search");
 		expect(captured.url?.searchParams.get("q")).toBe("private search");
 		expect(captured.url?.searchParams.get("format")).toBe("json");
-		expect(captured.url?.searchParams.get("time_range")).toBe("month");
+		expect(captured.url?.searchParams.get("pageno")).toBe("1");
+		expect(captured.url?.searchParams.get("time_range")).toBeNull();
 		expect(captured.headers?.get("Authorization")).toBe(
 			`Basic ${Buffer.from("alice:s3cret", "utf-8").toString("base64")}`,
 		);
@@ -49,6 +50,64 @@ describe("SearXNG web search provider", () => {
 			relatedQuestions: ["related search"],
 			sources: [{ title: "SearXNG", url: "https://example.com/result", snippet: "Metasearch result" }],
 		});
+	});
+	it.each([
+		["day", "day"],
+		["month", "month"],
+		["year", "year"],
+	] as const)("sends %s recency as SearXNG time_range %s", async (recency, expectedTimeRange) => {
+		resetSettingsForTest();
+		process.env.SEARXNG_ENDPOINT = "https://searx.example.org";
+		try {
+			const captured: { url?: URL } = {};
+			using _hook = hookFetch(input => {
+				captured.url = new URL(input.toString());
+				return new Response(JSON.stringify({ results: [] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+
+			await searchSearXNG({ query: "recent search", recency });
+
+			expect(captured.url?.searchParams.get("time_range")).toBe(expectedTimeRange);
+		} finally {
+			resetSettingsForTest();
+			delete process.env.SEARXNG_ENDPOINT;
+		}
+	});
+	it("preserves configured request parameters with a temporal filter", async () => {
+		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "searxng-request-"));
+		try {
+			await Bun.write(
+				path.join(agentDir, "config.yml"),
+				["searxng:", "  endpoint: https://searx.example.org", "  categories: general", "  language: en", ""].join(
+					"\n",
+				),
+			);
+			await Settings.init({ agentDir });
+
+			const captured: { url?: URL } = {};
+			using _hook = hookFetch(input => {
+				captured.url = new URL(input.toString());
+				return new Response(JSON.stringify({ results: [] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+
+			await searchSearXNG({ query: "recent search", num_results: 1, recency: "day" });
+
+			expect(captured.url?.searchParams.get("q")).toBe("recent search");
+			expect(captured.url?.searchParams.get("format")).toBe("json");
+			expect(captured.url?.searchParams.get("pageno")).toBe("1");
+			expect(captured.url?.searchParams.get("time_range")).toBe("day");
+			expect(captured.url?.searchParams.get("categories")).toBe("general");
+			expect(captured.url?.searchParams.get("language")).toBe("en");
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(agentDir, { recursive: true, force: true });
+		}
 	});
 
 	it("reads Basic auth credentials from nested config.yml settings", async () => {


### PR DESCRIPTION
## What

- Map SearXNG's supported `day`, `month`, and `year` recency values exactly.
- Omit `time_range` for the unsupported `week` filter instead of widening it to `month`.
- Add URL-level coverage for supported and unsupported recency values and neighboring request parameters.

## Why

The shared search-provider contract requires unsupported temporal filters to be ignored rather than approximated. Widening seven days to a month can return stale results as though they satisfied the request.

## Testing

- `bun test packages/coding-agent/test/tools/web-search-searxng.test.ts` — 15 passed
- `bun --cwd=packages/coding-agent run check` — passed

---

- [x] Tested locally
- [x] CHANGELOG updated
