### PR TITLE
fix(subagent): bound parent-facing steer echoes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Parent-facing subagent steer echoes now honor receipt, preview, and full output bounds while children still receive the complete steer message.
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -17,6 +17,13 @@ const MAX_LIST_LIMIT = 50;
 const RECEIPT_PREVIEW_WIDTH = 280;
 const PREVIEW_WIDTH = 2_000;
 const FULL_PREVIEW_WIDTH = 12_000;
+const STEER_RECEIPT_MAX_CHARS = RECEIPT_PREVIEW_WIDTH;
+const STEER_PREVIEW_MAX_CHARS = PREVIEW_WIDTH;
+const STEER_FULL_MAX_CHARS = FULL_PREVIEW_WIDTH;
+const STEER_RECEIPT_MAX_LINES = 12;
+const STEER_PREVIEW_MAX_LINES = 48;
+const STEER_FULL_MAX_LINES = 240;
+const STEER_ELLIPSIS = "…";
 const STEER_QUEUED_GUIDANCE =
 	"The steer message is queued for the subagent's next steering boundary and has not necessarily taken effect yet.";
 
@@ -66,6 +73,8 @@ export interface SubagentSnapshot {
 	truncated?: boolean;
 	guidance?: string;
 	steerMessage?: string;
+	/** True when only the parent-facing steer echo was truncated. */
+	steerMessageTruncated?: boolean;
 	steerState?: "queued" | "resume_queued" | "resume_started";
 	steerPauseRequested?: boolean;
 	/** Live streaming progress for the awaited subagent (await panel only; UI detail). */
@@ -252,6 +261,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			if (message === undefined || message.trim() === "") {
 				throw new ToolError("`steer` requires a non-empty message.");
 			}
+			const steerEcho = previewSteerMessage(message, verbosity);
 			const records: SubagentRecord[] = [];
 			const missing: SubagentSnapshot[] = [];
 			const steerStates = new Map<string, NonNullable<SubagentSnapshot["steerState"]>>();
@@ -291,7 +301,8 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 						const snapshot = this.#recordSnapshot(manager, record, false, verbosity, verifiedOutputIds);
 						return {
 							...snapshot,
-							steerMessage: message,
+							steerMessage: steerEcho.message,
+							steerMessageTruncated: steerEcho.truncated,
 							steerState: steerStates.get(record.subagentId) ?? "queued",
 							steerPauseRequested: params.pause === true,
 							guidance: snapshot.guidance
@@ -598,8 +609,9 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			if (snapshot.description) lines.push(`Description: ${snapshot.description}`);
 			if (snapshot.outputRef) lines.push(`Output: ${snapshot.outputRef}`);
 			if (snapshot.assignment) lines.push("Assignment:", "```", snapshot.assignment, "```");
-			if (snapshot.steerMessage) {
+			if (snapshot.steerMessage !== undefined) {
 				lines.push(`Steer (${snapshot.steerState ?? "queued"}):`, "```", snapshot.steerMessage, "```");
+				if (snapshot.steerMessageTruncated) lines.push("Steer message truncated in parent echo.");
 				lines.push(STEER_QUEUED_GUIDANCE);
 			}
 			if (snapshot.resultPreview) {
@@ -786,6 +798,153 @@ function sanitizeText(text: string, width: number): string {
 	return truncateToWidth(replaceTabs(text), width, Ellipsis.Unicode);
 }
 
+function previewSteerMessage(
+	message: string,
+	verbosity: SubagentParams["verbosity"] = "receipt",
+): { message: string; truncated: boolean } {
+	const width =
+		verbosity === "full" ? FULL_PREVIEW_WIDTH : verbosity === "preview" ? PREVIEW_WIDTH : RECEIPT_PREVIEW_WIDTH;
+	const maxChars =
+		verbosity === "full"
+			? STEER_FULL_MAX_CHARS
+			: verbosity === "preview"
+				? STEER_PREVIEW_MAX_CHARS
+				: STEER_RECEIPT_MAX_CHARS;
+	const maxLines =
+		verbosity === "full"
+			? STEER_FULL_MAX_LINES
+			: verbosity === "preview"
+				? STEER_PREVIEW_MAX_LINES
+				: STEER_RECEIPT_MAX_LINES;
+	const collected = collectSteerEcho(message, maxChars, maxLines);
+	const tabbed = replaceTabs(collected.text);
+	const contentCapped = truncateSteerContent(tabbed, maxChars);
+	const preview = truncateToWidth(contentCapped.text, width, Ellipsis.Unicode);
+	return {
+		message: preview,
+		truncated: collected.truncated || contentCapped.truncated || preview !== contentCapped.text,
+	};
+}
+
+function collectSteerEcho(message: string, maxChars: number, maxLines: number): { text: string; truncated: boolean } {
+	const sourceBudget = maxChars * 8 + 4_096;
+	const outputBudget = maxChars;
+	const out: string[] = [];
+	let index = 0;
+	let outputLength = 0;
+	let lines = 1;
+	let truncated = false;
+
+	while (index < message.length && index < sourceBudget) {
+		const code = message.charCodeAt(index);
+		if (code === 0x1b) {
+			index = skipEscapeSequence(message, index + 1, sourceBudget);
+			continue;
+		}
+		if (code >= 0x80 && code <= 0x9f) {
+			index = skipC1Sequence(message, index, sourceBudget);
+			continue;
+		}
+		if ((code < 0x20 && code !== 0x0a && code !== 0x09) || code === 0x7f) {
+			index++;
+			continue;
+		}
+		const codePoint = message.codePointAt(index)!;
+		const character = String.fromCodePoint(codePoint);
+		if (character === "\n") {
+			if (lines >= maxLines) {
+				truncated = true;
+				break;
+			}
+			lines++;
+		}
+		if (outputLength + character.length > outputBudget) {
+			truncated = true;
+			break;
+		}
+		out.push(character);
+		outputLength += character.length;
+		index += character.length;
+	}
+	if (index < message.length) truncated = true;
+	const text = out.join("");
+	return {
+		text: truncated ? appendSteerEllipsis(text, maxChars) : text,
+		truncated,
+	};
+}
+
+function appendSteerEllipsis(text: string, maxChars: number): string {
+	if (maxChars <= 0) return "";
+	const content = text.endsWith("\n") ? text.slice(0, -1) : text;
+	let contentEnd = Math.min(content.length, Math.max(0, maxChars - STEER_ELLIPSIS.length));
+	const finalCodeUnit = content.charCodeAt(contentEnd - 1);
+	if (finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff) contentEnd--;
+	return `${content.slice(0, contentEnd)}${STEER_ELLIPSIS}`;
+}
+
+function skipEscapeSequence(text: string, index: number, sourceBudget: number): number {
+	if (index >= text.length || index >= sourceBudget) return index;
+	const kind = text.charCodeAt(index);
+	if (kind === 0x5b) return skipCsiSequence(text, index + 1, sourceBudget);
+	if (kind >= 0x20 && kind <= 0x2f) return skipEscapeIntermediateSequence(text, index + 1, sourceBudget);
+	if (kind === 0x5d || kind === 0x50 || kind === 0x58 || kind === 0x5e || kind === 0x5f) {
+		return skipControlString(text, index + 1, sourceBudget, kind === 0x5d);
+	}
+	if (kind === 0x18 || kind === 0x1a || (kind >= 0x30 && kind <= 0x7e)) return index + 1;
+	return index;
+}
+
+function skipEscapeIntermediateSequence(text: string, index: number, sourceBudget: number): number {
+	while (index < text.length && index < sourceBudget) {
+		const code = text.charCodeAt(index);
+		if (code >= 0x20 && code <= 0x2f) {
+			index++;
+			continue;
+		}
+		if (code === 0x18 || code === 0x1a || (code >= 0x30 && code <= 0x7e)) index++;
+		break;
+	}
+	return index;
+}
+
+function skipC1Sequence(text: string, index: number, sourceBudget: number): number {
+	const kind = text.charCodeAt(index++);
+	if (kind === 0x9b) return skipCsiSequence(text, index, sourceBudget);
+	if (kind !== 0x90 && kind !== 0x98 && kind !== 0x9d && kind !== 0x9e && kind !== 0x9f) return index;
+	return skipControlString(text, index, sourceBudget, kind === 0x9d);
+}
+
+function skipCsiSequence(text: string, index: number, sourceBudget: number): number {
+	while (index < text.length && index < sourceBudget) {
+		const code = text.charCodeAt(index++);
+		if (code === 0x18 || code === 0x1a) break;
+		if (code >= 0x40 && code <= 0x7e) break;
+	}
+	return index;
+}
+
+function skipControlString(text: string, index: number, sourceBudget: number, allowBell: boolean): number {
+	while (index < text.length && index < sourceBudget) {
+		const code = text.charCodeAt(index++);
+		if (code === 0x18 || code === 0x1a) break;
+		if ((allowBell && code === 0x07) || code === 0x9c) break;
+		if (code === 0x1b && index < text.length && text.charCodeAt(index) === 0x5c) {
+			index++;
+			break;
+		}
+	}
+	return index;
+}
+
+function truncateSteerContent(text: string, maxChars: number): { text: string; truncated: boolean } {
+	if (text.length <= maxChars) return { text, truncated: false };
+	let contentEnd = Math.max(0, maxChars - STEER_ELLIPSIS.length);
+	const finalCodeUnit = text.charCodeAt(contentEnd - 1);
+	if (finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff) contentEnd--;
+	return { text: `${text.slice(0, contentEnd)}${STEER_ELLIPSIS}`, truncated: true };
+}
+
 function previewJobOutput(
 	job: AsyncJob,
 	verbosity: SubagentParams["verbosity"] = "receipt",
@@ -851,6 +1010,7 @@ function canonicalizeSnapshotForSignature(snapshot: SubagentSnapshot): unknown {
 		truncated: snapshot.truncated ?? false,
 		guidance: snapshot.guidance ?? null,
 		steerMessage: snapshot.steerMessage ?? null,
+		steerMessageTruncated: snapshot.steerMessageTruncated ?? false,
 		steerState: snapshot.steerState ?? null,
 		steerPauseRequested: snapshot.steerPauseRequested ?? false,
 		liveProgressAvailable: snapshot.liveProgressAvailable ?? null,

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -488,6 +488,210 @@ describe("SubagentTool", () => {
 		expect(steerText).not.toContain("acted on");
 		await manager.dispose({ timeoutMs: 100 });
 	});
+	it("steer delivers the complete message while bounding only the parent echo", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const message = `${"🙂\t".repeat(6_100)}done`;
+		const delivered: string[] = [];
+
+		manager.registerSubagentRecord({
+			subagentId: "0-Running",
+			ownerId: "0-Main",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/0-Running.jsonl",
+			resumable: true,
+		});
+		manager.registerLiveHandle("0-Running", {
+			requestPause() {},
+			async injectMessage(content) {
+				delivered.push(content);
+			},
+		});
+		for (const [subagentId, status] of [
+			["0-Paused", "paused"],
+			["0-Queued", "queued"],
+			["0-Terminal", "completed"],
+		] as const) {
+			manager.registerSubagentRecord({
+				subagentId,
+				ownerId: "0-Main",
+				currentJobId: null,
+				historicalJobIds: [],
+				status,
+				sessionFile: `/tmp/${subagentId}.jsonl`,
+				resumable: true,
+				...(status === "queued" ? { queued: { ownerId: "0-Main", seq: 1, createdAt: Date.now() } } : {}),
+			});
+		}
+		manager.setResumeRunner((subagentId, resumeMessage) => {
+			delivered.push(resumeMessage ?? "");
+			return manager.register("task", subagentId, async () => "resumed", {
+				id: `job-${subagentId}`,
+				ownerId: "0-Main",
+				metadata: { subagent: { id: subagentId, agent: "executor", agentSource: "bundled" } },
+			});
+		});
+
+		for (const id of ["0-Running", "0-Paused", "0-Queued", "0-Terminal"]) {
+			await tool.execute(`subagent-steer-${id}`, { action: "steer", id, message });
+		}
+
+		for (const received of [...delivered, manager.getSubagentRecord("0-Queued")?.queued?.message ?? ""]) {
+			expect(new TextEncoder().encode(received)).toEqual(new TextEncoder().encode(message));
+		}
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("steer echoes use verbosity limits and mark only steer truncation", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const message = `${"🙂\t".repeat(6_100)}done`;
+		const injected: string[] = [];
+		manager.registerSubagentRecord({
+			subagentId: "0-Bounded",
+			ownerId: "0-Main",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/0-Bounded.jsonl",
+			resumable: true,
+		});
+		manager.registerLiveHandle("0-Bounded", {
+			requestPause() {},
+			async injectMessage(content) {
+				injected.push(content);
+			},
+		});
+
+		for (const [verbosity, width] of [
+			["receipt", 280],
+			["preview", 2_000],
+			["full", 12_000],
+		] as const) {
+			const result = await tool.execute(`subagent-steer-${verbosity}`, {
+				action: "steer",
+				ids: ["0-Bounded"],
+				message,
+				verbosity,
+			});
+			const snapshot = result.details?.subagents[0];
+			if (!snapshot?.steerMessage) throw new Error("Expected bounded steer echo");
+			expect(snapshot.steerMessageTruncated).toBe(true);
+			expect(snapshot.truncated).toBeUndefined();
+			expect(Bun.stringWidth(snapshot.steerMessage)).toBeLessThanOrEqual(width);
+			expect(getText(result)).toContain(snapshot.steerMessage);
+			expect(new TextDecoder().decode(new TextEncoder().encode(snapshot.steerMessage))).toBe(snapshot.steerMessage);
+			expect(getText(result)).toContain("Steer message truncated in parent echo.");
+		}
+
+		const shortMessage = "preserve short 🙂";
+		const shortResult = await tool.execute("subagent-steer-short", {
+			action: "steer",
+			id: "0-Bounded",
+			message: shortMessage,
+		});
+		expect(shortResult.details?.subagents[0]?.steerMessage).toBe(shortMessage);
+		expect(shortResult.details?.subagents[0]?.steerMessageTruncated).toBe(false);
+		expect(getText(shortResult)).not.toContain("Steer message truncated in parent echo.");
+		expect(injected).toEqual([message, message, message, shortMessage]);
+		await manager.dispose({ timeoutMs: 100 });
+	});
+	it("steer echo caps adversarial invisible and multiline content without altering delivery", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const delivered: string[] = [];
+		manager.registerSubagentRecord({
+			subagentId: "0-Adversarial",
+			ownerId: "0-Main",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/0-Adversarial.jsonl",
+			resumable: true,
+		});
+		manager.registerLiveHandle("0-Adversarial", {
+			requestPause() {},
+			async injectMessage(content) {
+				delivered.push(content);
+			},
+		});
+
+		const inputs = [
+			"newline-only\n".repeat(100_000),
+			"\u200B\u0301".repeat(100_000),
+			"\u001B[31mansi\u001B[0m".repeat(100_000),
+			"delete\u007F".repeat(100_000),
+			"\u001B]unterminated-osc".repeat(100_000),
+			"\u001BPunterminated-dcs".repeat(100_000),
+		];
+		for (const [verbosity, width, maxChars, maxLines] of [
+			["receipt", 280, 1_024, 12],
+			["preview", 2_000, 8_000, 48],
+			["full", 12_000, 48_000, 240],
+		] as const) {
+			for (const input of inputs) {
+				const result = await tool.execute(`subagent-steer-adversarial-${verbosity}`, {
+					action: "steer",
+					ids: ["0-Adversarial"],
+					message: input,
+					verbosity,
+				});
+				const echo = result.details?.subagents[0]?.steerMessage ?? "";
+				expect(result.details?.subagents[0]?.steerMessageTruncated).toBe(true);
+				expect(echo.length).toBeLessThanOrEqual(maxChars);
+				expect(echo.split("\n").length).toBeLessThanOrEqual(maxLines);
+				expect(Bun.stringWidth(echo)).toBeLessThanOrEqual(width);
+				expect(echo).not.toContain("\u001B");
+				expect(echo).not.toContain("\u007F");
+				expect(new TextDecoder().decode(new TextEncoder().encode(echo))).toBe(echo);
+			}
+		}
+		const controlOnlyResult = await tool.execute("subagent-steer-control-only", {
+			action: "steer",
+			ids: ["0-Adversarial"],
+			message: "\u007F",
+		});
+		expect(controlOnlyResult.details?.subagents[0]?.steerMessage).toBe("");
+		expect(getText(controlOnlyResult)).toContain("Steer (queued):");
+		expect(getText(controlOnlyResult)).not.toContain("\u007F");
+		const c1Message =
+			"\u009B31mred\u009B0m \u009Dtitle\u009Cvisible \u001B]title\u009Cafter \u001B(Bplain \u001B#8aligned \u001B🙂emoji";
+		const c1Result = await tool.execute("subagent-steer-c1-sequences", {
+			action: "steer",
+			ids: ["0-Adversarial"],
+			message: c1Message,
+		});
+		expect(c1Result.details?.subagents[0]?.steerMessage).toBe("red visible after plain aligned 🙂emoji");
+		const cancellationMessage =
+			"\u001B]hidden\u0018visible \u009Dhidden\u001Ac1 \u001B[31\u001Ared \u009B31\u0018c1red";
+		const cancellationResult = await tool.execute("subagent-steer-cancelled-controls", {
+			action: "steer",
+			ids: ["0-Adversarial"],
+			message: cancellationMessage,
+		});
+		expect(cancellationResult.details?.subagents[0]?.steerMessage).toBe("visible c1 red c1red");
+
+		const exactMessage = `a${"\u0301".repeat(279)}`;
+		const exactResult = await tool.execute("subagent-steer-exact-character-limit", {
+			action: "steer",
+			ids: ["0-Adversarial"],
+			message: exactMessage,
+		});
+		expect(exactResult.details?.subagents[0]?.steerMessage).toBe(exactMessage);
+		expect(exactResult.details?.subagents[0]?.steerMessageTruncated).toBe(false);
+		expect(delivered).toEqual([
+			...inputs,
+			...inputs,
+			...inputs,
+			"\u007F",
+			c1Message,
+			cancellationMessage,
+			exactMessage,
+		]);
+		await manager.dispose({ timeoutMs: 100 });
+	});
 
 	it("steer attributes the caller (nested parent) id, not main or the child id", async () => {
 		const manager = createManager();


### PR DESCRIPTION
## What

- Keep full steer messages unchanged on every child delivery and resume path.
- Bound only parent-facing steer echoes by receipt verbosity, character count, display width, line count, and finite source scanning.
- Strip terminal control sequences with a bounded single-pass collector and expose independent steer truncation metadata.
- Cover running, queued, paused, and terminal-resume delivery plus newline, zero-width, combining, ANSI, unterminated OSC, and unterminated DCS inputs.

## Why

Steer messages were copied without bounds into both parent text and structured details. Large or control-heavy input could amplify parent context or perform expensive unbounded sanitization even though subagent receipts advertise bounded output.

## Testing

- `bun test packages/coding-agent/test/tools/subagent.test.ts` — 25 passed, 222 assertions
- `bun --cwd=packages/coding-agent run check` — passed

---

- [x] Tested locally
- [x] CHANGELOG updated
