### PR TITLE
fix(read): reject malformed internal URL selectors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 - Team worker launches now receive the validated owning `GJC_SESSION_ID` for sanctioned session-scoped writes while preserving absent identity, fail-closed resolution, and separate spawn provenance (#2597).
 - Managed and explicit session directories now canonicalize benign ancestor symlinks (e.g. macOS `/var -> /private/var`, a symlinked `$HOME` or project directory) to a symlink-free trusted root before the strict owner-only and reparse guards run, so session creation, moves, resume, and writes no longer fail with `reparse_point` / `Unsafe reparse storage path` under a symlinked temp root or home. The native primitive stays strict and continues to reject symlinked components at or below the trusted root.
+- Malformed selectors on internal read URLs now fail explicitly instead of silently falling back to an unbounded resource read.
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1587,6 +1587,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		if (internalRouter.canHandle(readPath)) {
 			const internalTarget = splitInternalUrlSel(readPath);
 			const parsed = parseSel(internalTarget.sel);
+			if (internalTarget.sel !== undefined && parsed.kind === "none") {
+				throw new ToolError(`Invalid internal URL selector "${internalTarget.sel}".`);
+			}
 			return this.#handleInternalUrl(internalTarget.path, parsed, signal);
 		}
 

--- a/packages/coding-agent/test/read-acp-fs.test.ts
+++ b/packages/coding-agent/test/read-acp-fs.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentToolResult } from "@gajae-code/agent-core";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { InternalUrlRouter } from "@gajae-code/coding-agent/internal-urls";
 import type { ClientBridge } from "@gajae-code/coding-agent/session/client-bridge";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import type { ReadToolDetails } from "@gajae-code/coding-agent/tools/read";
@@ -109,5 +110,54 @@ describe("read tool ACP fs routing", () => {
 		expect(text).toContain("bridge two");
 		expect(text).not.toContain("Line 2 is beyond end");
 		expect(text).not.toContain("disk two");
+	});
+	it("rejects malformed internal selectors before resolving the resource", async () => {
+		const router = InternalUrlRouter.instance();
+		const resolveSpy = spyOn(router, "resolve").mockResolvedValue({
+			url: "artifact://3",
+			content: "one\ntwo\nthree\n",
+			contentType: "text/plain",
+		});
+		const tool = new ReadTool(createSession(tmpDir));
+
+		try {
+			await expect(tool.execute("malformed-negative", { path: "artifact://3:-100" })).rejects.toThrow(
+				'Invalid internal URL selector "-100".',
+			);
+			await expect(tool.execute("malformed-compound", { path: "artifact://3:raw:-100" })).rejects.toThrow(
+				'Invalid internal URL selector "raw:-100".',
+			);
+
+			expect(resolveSpy).not.toHaveBeenCalled();
+		} finally {
+			resolveSpy.mockRestore();
+		}
+	});
+
+	it("reads internal URLs without a selector and preserves valid selectors", async () => {
+		const router = InternalUrlRouter.instance();
+		const resolveSpy = spyOn(router, "resolve").mockResolvedValue({
+			url: "artifact://3",
+			content: "one\ntwo\nthree\n",
+			contentType: "text/plain",
+		});
+		const tool = new ReadTool(createSession(tmpDir));
+
+		try {
+			expect(textOutput(await tool.execute("default", { path: "artifact://3" }))).toContain("one");
+			expect(textOutput(await tool.execute("raw", { path: "artifact://3:raw" }))).toBe("one\ntwo\nthree\n");
+			expect(textOutput(await tool.execute("range", { path: "artifact://3:2-2" }))).toContain("two");
+			expect(textOutput(await tool.execute("range-raw", { path: "artifact://3:2-2:raw" }))).toContain("two");
+
+			expect(resolveSpy).toHaveBeenCalledTimes(4);
+			expect(resolveSpy.mock.calls.map(([url]) => url)).toEqual([
+				"artifact://3",
+				"artifact://3",
+				"artifact://3",
+				"artifact://3",
+			]);
+		} finally {
+			resolveSpy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
## What

- Reject explicitly supplied internal-resource selectors that parse as invalid.
- Preserve selector-free reads and valid raw, range, and raw-range selectors.
- Keep archive, SQLite, and namespaced internal URL colon semantics unchanged.

## Why

A malformed selector suffix was peeled from an internal URL and then normalized to `none`, silently turning a bounded request into a full resource read.

## Testing

- `bun test packages/coding-agent/test/read-acp-fs.test.ts` — 17 passed
- `bun --cwd=packages/coding-agent run check` — passed

---

- [x] Tested locally
- [x] CHANGELOG updated
