### PR TITLE
fix(tui): preserve supplementary Unicode input

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 
 - Suppressed slash-command and skill autocomplete inside line-local single-backtick code spans while preserving path completion and ordinary slash matching outside literals (#2619).
+### Fixed
+
+- Supplementary Unicode terminal input now crosses the stdin decoding boundary as complete code points instead of separate UTF-16 surrogate events.
 
 ## [0.11.0] - 2026-07-15
 ### Fixed

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -35,6 +35,19 @@ export function isSgrMouseSequence(sequence: string): boolean {
 function isSgrMousePrefix(sequence: string): boolean {
 	return sequence.startsWith(`${ESC}[<`);
 }
+function isHighSurrogate(codeUnit: number): boolean {
+	return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+	return codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
+}
+
+function singleCodePoint(sequence: string): number | undefined {
+	const codepoint = sequence.codePointAt(0);
+	if (codepoint === undefined) return undefined;
+	return sequence.length === (codepoint > 0xffff ? 2 : 1) ? codepoint : undefined;
+}
 
 function isUtf8LeadByte(byte: number): boolean {
 	return byte >= 0xc2 && byte <= 0xf4;
@@ -114,9 +127,9 @@ function isCompleteSequence(data: string): "complete" | "incomplete" | "not-esca
 		return afterEsc.length >= 2 ? "complete" : "incomplete";
 	}
 
-	// Meta key sequences: ESC followed by a single character
+	// Meta key sequences: ESC followed by a single Unicode code point
 	if (afterEsc.length === 1) {
-		return "complete";
+		return isHighSurrogate(afterEsc.charCodeAt(0)) ? "incomplete" : "complete";
 	}
 
 	// Unknown escape sequence - treat as complete
@@ -234,6 +247,18 @@ function extractCompleteSequences(buffer: string): { sequences: string[]; remain
 
 		// Try to extract a sequence starting at this position
 		if (remaining.startsWith(ESC)) {
+			// A split Meta + supplementary code point stays buffered after its high
+			// surrogate. If the next code unit cannot complete that pair, flush the
+			// malformed Meta sequence without consuming the following input.
+			if (
+				remaining.length >= 3 &&
+				isHighSurrogate(remaining.charCodeAt(1)) &&
+				!isLowSurrogate(remaining.charCodeAt(2))
+			) {
+				sequences.push(remaining.slice(0, 2));
+				pos += 2;
+				continue;
+			}
 			// Find the end of this escape sequence
 			let seqEnd = 1;
 			while (seqEnd <= remaining.length) {
@@ -258,7 +283,19 @@ function extractCompleteSequences(buffer: string): { sequences: string[]; remain
 				return { sequences, remainder: remaining };
 			}
 		} else {
-			// Not an escape sequence - take a single character
+			// Not an escape sequence - take a single Unicode code point. Keep a
+			// trailing high surrogate buffered so a following string chunk can
+			// complete it.
+			const firstCodeUnit = remaining.charCodeAt(0);
+			if (isHighSurrogate(firstCodeUnit)) {
+				if (remaining.length === 1) return { sequences, remainder: remaining };
+				const secondCodeUnit = remaining.charCodeAt(1);
+				if (isLowSurrogate(secondCodeUnit)) {
+					sequences.push(remaining.slice(0, 2));
+					pos += 2;
+					continue;
+				}
+			}
 			sequences.push(remaining[0]!);
 			pos++;
 		}
@@ -552,7 +589,7 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		return legacyMetaSequence(byte);
 	}
 	#emitDataSequence(sequence: string): void {
-		const rawCodepoint = sequence.length === 1 ? sequence.codePointAt(0) : undefined;
+		const rawCodepoint = singleCodePoint(sequence);
 		if (rawCodepoint !== undefined && rawCodepoint === this.#pendingKittyPrintableCodepoint) {
 			this.#pendingKittyPrintableCodepoint = undefined;
 			return;

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -32,6 +32,43 @@ describe("StdinBuffer", () => {
 			processInput("hello \u4e16\u754c");
 			expect(emittedSequences).toEqual(["h", "e", "l", "l", "o", " ", "\u4e16", "\u754c"]);
 		});
+		it("emits supplementary characters as complete code points", () => {
+			processInput("\u{1f389}");
+			expect(emittedSequences).toEqual(["\u{1f389}"]);
+		});
+
+		it("preserves ASCII, supplementary, and BMP character ordering", () => {
+			processInput("a\u{1f389}\u4e16b");
+			expect(emittedSequences).toEqual(["a", "\u{1f389}", "\u4e16", "b"]);
+		});
+
+		it("treats ESC plus a supplementary character as one Meta sequence", () => {
+			processInput("\x1b\u{1f389}");
+			expect(emittedSequences).toEqual(["\x1b\u{1f389}"]);
+		});
+		it("reassembles a Meta supplementary character split across string chunks", () => {
+			processInput("\x1b\ud83c");
+			expect(emittedSequences).toEqual([]);
+
+			processInput("\udf89");
+			expect(emittedSequences).toEqual(["\x1b\u{1f389}"]);
+		});
+
+		it("does not consume input following a malformed Meta high surrogate", () => {
+			processInput("\x1b\ud83c");
+			expect(emittedSequences).toEqual([]);
+
+			processInput("x");
+			expect(emittedSequences).toEqual(["\x1b\ud83c", "x"]);
+		});
+
+		it("reassembles a surrogate pair split across string chunks", () => {
+			processInput("\ud83c");
+			expect(emittedSequences).toEqual([]);
+
+			processInput("\udf89");
+			expect(emittedSequences).toEqual(["\u{1f389}"]);
+		});
 	});
 
 	describe("Partial Escape Sequences", () => {
@@ -138,6 +175,19 @@ describe("StdinBuffer", () => {
 			// Press 'a', release 'a' batched together (common over SSH)
 			processInput("\x1b[97u\x1b[97;1:3u");
 			expect(emittedSequences).toEqual(["\x1b[97u", "\x1b[97;1:3u"]);
+		});
+		it("deduplicates raw supplementary characters after matching Kitty events", () => {
+			processInput("\x1b[127881u\u{1f389}");
+			expect(emittedSequences).toEqual(["\x1b[127881u"]);
+		});
+		it("continues to deduplicate matching BMP characters after Kitty events", () => {
+			processInput("\x1b[97ua");
+			expect(emittedSequences).toEqual(["\x1b[97u"]);
+		});
+
+		it("does not deduplicate a different supplementary character after a Kitty event", () => {
+			processInput("\x1b[127881u\u{1f38a}");
+			expect(emittedSequences).toEqual(["\x1b[127881u", "\u{1f38a}"]);
 		});
 
 		it("should handle multiple batched Kitty events", () => {
@@ -258,6 +308,12 @@ describe("StdinBuffer", () => {
 			const flushed = buffer.flush();
 			expect(flushed).toEqual([]);
 		});
+		it("returns a malformed trailing high surrogate on flush", () => {
+			processInput("\ud83c");
+
+			expect(buffer.flush()).toEqual(["\ud83c"]);
+			expect(buffer.getBuffer()).toBe("");
+		});
 
 		it("should not emit incomplete SGR mouse reports via timeout", async () => {
 			processInput("\x1b[<35");
@@ -278,6 +334,13 @@ describe("StdinBuffer", () => {
 			buffer.clear();
 			expect(buffer.getBuffer()).toBe("");
 			expect(emittedSequences).toEqual([]);
+		});
+		it("drops a malformed trailing high surrogate on clear", () => {
+			processInput("\ud83c");
+			buffer.clear();
+
+			processInput("\udf89");
+			expect(emittedSequences).toEqual(["\udf89"]);
 		});
 	});
 


### PR DESCRIPTION
## What

- Emit ordinary terminal input as complete Unicode code points rather than UTF-16 code units.
- Reassemble surrogate pairs split across explicit string chunks and preserve defined flush/clear behavior for malformed input.
- Handle supplementary Meta input and Kitty printable-event deduplication correctly.

## Why

Supplementary characters such as emoji were emitted as separate high/low surrogate events after UTF-8 decoding, which could corrupt downstream editing and duplicate Kitty keyboard input.

## Testing

- `bun test packages/tui/test/stdin-buffer.test.ts` — 60 passed
- `bun --cwd=packages/tui run check` — passed

---

- [x] Tested locally
- [x] CHANGELOG updated
