### PR TITLE
fix(tui): isolate keybinding configuration arrays

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 
 - Suppressed slash-command and skill autocomplete inside line-local single-backtick code spans while preserving path completion and ordinary slash matching outside literals (#2619).
+### Fixed
+
+- Keybinding configuration arrays are now defensively copied so external mutations cannot diverge snapshots from resolved key matches.
 
 ## [0.11.0] - 2026-07-15
 ### Fixed

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -186,6 +186,13 @@ function normalizeKeys(keys: KeyId | KeyId[] | undefined): KeyId[] {
 	}
 	return result;
 }
+function cloneKeybindingsConfig(config: KeybindingsConfig): KeybindingsConfig {
+	const clone: KeybindingsConfig = {};
+	for (const [keybinding, keys] of Object.entries(config)) {
+		clone[keybinding] = Array.isArray(keys) ? [...keys] : keys;
+	}
+	return clone;
+}
 
 export class KeybindingsManager {
 	#definitions: KeybindingDefinitions;
@@ -195,7 +202,7 @@ export class KeybindingsManager {
 
 	constructor(definitions: KeybindingDefinitions, userBindings: KeybindingsConfig = {}) {
 		this.#definitions = definitions;
-		this.#userBindings = userBindings;
+		this.#userBindings = cloneKeybindingsConfig(userBindings);
 		this.#rebuild();
 	}
 
@@ -253,12 +260,12 @@ export class KeybindingsManager {
 	}
 
 	setUserBindings(userBindings: KeybindingsConfig): void {
-		this.#userBindings = userBindings;
+		this.#userBindings = cloneKeybindingsConfig(userBindings);
 		this.#rebuild();
 	}
 
 	getUserBindings(): KeybindingsConfig {
-		return { ...this.#userBindings };
+		return cloneKeybindingsConfig(this.#userBindings);
 	}
 
 	getResolvedBindings(): KeybindingsConfig {

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -34,6 +34,57 @@ describe("KeybindingsManager", () => {
 		]);
 		expect(keybindings.getKeys("tui.editor.cursorLeft")).toEqual(["left", "ctrl+b"]);
 	});
+
+	describe("user binding ownership", () => {
+		it("clones array bindings passed to the constructor", () => {
+			const bindings = { "tui.select.up": ["down"] as ("down" | "up")[] };
+			const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, bindings);
+
+			bindings["tui.select.up"].push("up");
+
+			expect(keybindings.getUserBindings()["tui.select.up"]).toEqual(["down"]);
+			expect(keybindings.getKeys("tui.select.up")).toEqual(["down"]);
+			expect(keybindings.matches("\x1b[B", "tui.select.up")).toBe(true);
+			expect(keybindings.matches("\x1b[A", "tui.select.up")).toBe(false);
+		});
+
+		it("clones array bindings passed to setUserBindings and rebuilds from them", () => {
+			const keybindings = new KeybindingsManager(TUI_KEYBINDINGS);
+			expect(keybindings.getKeys("tui.select.up")).toEqual(["up"]);
+			const bindings = { "tui.select.up": ["down"] as ("down" | "up")[] };
+
+			keybindings.setUserBindings(bindings);
+			bindings["tui.select.up"].push("up");
+
+			expect(keybindings.getKeys("tui.select.up")).toEqual(["down"]);
+			expect(keybindings.getUserBindings()["tui.select.up"]).toEqual(["down"]);
+			expect(keybindings.matches("\x1b[B", "tui.select.up")).toBe(true);
+			expect(keybindings.matches("\x1b[A", "tui.select.up")).toBe(false);
+		});
+
+		it("clones array bindings returned from getUserBindings", () => {
+			const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+				"tui.select.up": ["down"],
+				"tui.select.confirm": [],
+				"tui.input.submit": "ctrl+x",
+				"tui.editor.cursorUp": undefined,
+			});
+			const bindings = keybindings.getUserBindings();
+			(bindings["tui.select.up"] as string[]).push("up");
+			(bindings["tui.select.confirm"] as string[]).push("enter");
+
+			expect(keybindings.getUserBindings()).toEqual({
+				"tui.select.up": ["down"],
+				"tui.select.confirm": [],
+				"tui.input.submit": "ctrl+x",
+				"tui.editor.cursorUp": undefined,
+			});
+			expect(keybindings.getKeys("tui.select.up")).toEqual(["down"]);
+			expect(keybindings.getKeys("tui.select.confirm")).toEqual([]);
+			expect(keybindings.matches("\x1b[A", "tui.select.up")).toBe(false);
+			expect(keybindings.matches("\r", "tui.select.confirm")).toBe(false);
+		});
+	});
 });
 
 describe("detectDefaultKeyCollisions", () => {


### PR DESCRIPTION
## What

- Defensively copy array-valued keybinding configuration on constructor and setter input.
- Return independent array snapshots from `getUserBindings()`.
- Preserve scalar, `undefined`, empty-array, rebuild, matching, and conflict semantics.

## Why

External mutation of an input or returned array could change the public configuration snapshot without rebuilding the manager's resolved lookup maps, making `getUserBindings()` disagree with `getKeys()` and `matches()`.

## Testing

- `bun test packages/tui/test/keybindings.test.ts` — 11 passed
- `bun --cwd=packages/tui run check` — passed

---

- [x] Tested locally
- [x] CHANGELOG updated
