### PR TITLE
fix(resource-gc): advance earlier sweep deadlines

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 - Team worker launches now receive the validated owning `GJC_SESSION_ID` for sanctioned session-scoped writes while preserving absent identity, fail-closed resolution, and separate spawn provenance (#2597).
 - Managed and explicit session directories now canonicalize benign ancestor symlinks (e.g. macOS `/var -> /private/var`, a symlinked `$HOME` or project directory) to a symlink-free trusted root before the strict owner-only and reparse guards run, so session creation, moves, resume, and writes no longer fail with `reparse_point` / `Unsafe reparse storage path` under a symlinked temp root or home. The native primitive stays strict and continues to reject symlinked components at or below the trusted root.
+- Resource GC now advances an already scheduled sweep when a newly registered session requires an earlier deadline without postponing existing earlier sweeps.
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).

--- a/packages/coding-agent/src/tools/resource-gc.ts
+++ b/packages/coding-agent/src/tools/resource-gc.ts
@@ -76,11 +76,13 @@ const defaultDeps: ResourceGcDeps = {
 // ── Controller state (process-global; tabs/browsers are module-global too) ──────────────────
 const activeSessions = new Map<string, Settings>();
 let timer: ReturnType<typeof setTimeout> | null = null;
+let pendingSweepDeadline: number | null = null;
 let stopped = false;
 // Bumped on every stop so an in-flight tick from a previous schedule cannot reschedule after a
 // stop+re-register and leak a duplicate timer.
 let timerGeneration = 0;
 let inProgress = false;
+let rescheduleAfterProgress = false;
 let rssWarningActive = false;
 let lastScreenshotScanAt = 0;
 let deps: ResourceGcDeps = defaultDeps;
@@ -114,43 +116,63 @@ function currentSweepIntervalMs(): number {
 }
 
 function ensureTimerStarted(): void {
-	if (timer) return;
 	stopped = false;
 	scheduleNextSweep();
 }
 
 // Recursive setTimeout (not setInterval) so the cadence is recomputed every cycle and later
-// session register/unregister changes to resourceGc.sweepIntervalMs are honored live.
+// session register/unregister changes to resourceGc.sweepIntervalMs are honored live. A newly
+// registered shorter policy may pull the sweep forward, but longer policies never delay it.
 function scheduleNextSweep(): void {
 	if (stopped || activeSessions.size === 0) {
 		timer = null;
+		pendingSweepDeadline = null;
 		return;
 	}
+	if (inProgress) {
+		rescheduleAfterProgress = true;
+		return;
+	}
+
+	const deadline = Date.now() + currentSweepIntervalMs();
+	if (timer && pendingSweepDeadline !== null && pendingSweepDeadline <= deadline) return;
+
+	if (timer) clearTimeout(timer);
 	const generation = timerGeneration;
-	timer = setTimeout(() => {
-		void tickAndReschedule(generation);
-	}, currentSweepIntervalMs());
+	pendingSweepDeadline = deadline;
+	timer = setTimeout(
+		() => {
+			timer = null;
+			pendingSweepDeadline = null;
+			void tickAndReschedule(generation);
+		},
+		Math.max(0, deadline - Date.now()),
+	);
 	timer.unref?.();
 }
 
 async function tickAndReschedule(generation: number): Promise<void> {
-	await runTick();
-	// A stop (and possible re-register) happened during the tick: a newer cycle owns the timer now.
-	if (generation !== timerGeneration) return;
+	const ran = await runTick(true);
+	if (!ran) return;
+	// A stop without a replacement session invalidates this cycle. When a session re-registers
+	// during the sweep, its scheduling attempt is deferred until the sweep finishes.
+	if (generation !== timerGeneration && (stopped || activeSessions.size === 0)) return;
 	scheduleNextSweep();
 }
 
 function stopTimer(): void {
 	stopped = true;
 	timerGeneration++;
-	if (timer) {
-		clearTimeout(timer);
-		timer = null;
-	}
+	if (timer) clearTimeout(timer);
+	timer = null;
+	pendingSweepDeadline = null;
 }
 
-async function runTick(): Promise<void> {
-	if (inProgress) return;
+async function runTick(rescheduleIfSkipped = false): Promise<boolean> {
+	if (inProgress) {
+		if (rescheduleIfSkipped) rescheduleAfterProgress = true;
+		return false;
+	}
 	inProgress = true;
 	try {
 		await sweepOnce(deps);
@@ -158,7 +180,12 @@ async function runTick(): Promise<void> {
 		logger.debug("resource GC sweep failed", { error: (err as Error).message });
 	} finally {
 		inProgress = false;
+		if (rescheduleAfterProgress) {
+			rescheduleAfterProgress = false;
+			scheduleNextSweep();
+		}
 	}
+	return true;
 }
 
 export async function sweepOnce(d: ResourceGcDeps = deps): Promise<void> {
@@ -285,6 +312,7 @@ export function __resetResourceGcForTest(): void {
 	stopTimer();
 	activeSessions.clear();
 	inProgress = false;
+	rescheduleAfterProgress = false;
 	rssWarningActive = false;
 	lastScreenshotScanAt = 0;
 	deps = defaultDeps;

--- a/packages/coding-agent/test/tools/resource-gc.test.ts
+++ b/packages/coding-agent/test/tools/resource-gc.test.ts
@@ -47,11 +47,15 @@ function baseDeps(over: Partial<ResourceGcDeps> = {}): ResourceGcDeps {
 		...over,
 	};
 }
+function gcSettings(sweepIntervalMs: number): Settings {
+	return Settings.isolated({ "resourceGc.sweepIntervalMs": sweepIntervalMs, "browser.gc.idleMs": 1_000 });
+}
 
 describe("resource GC controller", () => {
 	afterEach(() => {
 		__resetResourceGcForTest();
 		vi.restoreAllMocks();
+		vi.useRealTimers();
 	});
 
 	it("idle sweep evicts idle tabs oldest-first and spares recent ones", async () => {
@@ -220,6 +224,113 @@ describe("resource GC controller", () => {
 		expect(__getResourceGcStateForTest().sessionCount).toBe(0);
 	});
 
+	it("reschedules a pending long sweep when a session policy becomes shorter", () => {
+		vi.useFakeTimers({ now: 0 });
+		const listTabs = vi.fn(() => []);
+		__setResourceGcDepsForTest({ listTabs });
+		registerResourceGcSession({ sessionId: "s1", settings: gcSettings(1_000) });
+
+		vi.advanceTimersByTime(100);
+		registerResourceGcSession({ sessionId: "s1", settings: gcSettings(200) });
+		expect(vi.getTimerCount()).toBe(1);
+
+		vi.advanceTimersByTime(199);
+		expect(listTabs).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(listTabs).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not postpone a pending short sweep when a session policy becomes longer", () => {
+		vi.useFakeTimers({ now: 0 });
+		const listTabs = vi.fn(() => []);
+		__setResourceGcDepsForTest({ listTabs });
+		registerResourceGcSession({ sessionId: "s1", settings: gcSettings(200) });
+
+		vi.advanceTimersByTime(100);
+		registerResourceGcSession({ sessionId: "s1", settings: gcSettings(1_000) });
+		expect(vi.getTimerCount()).toBe(1);
+
+		vi.advanceTimersByTime(99);
+		expect(listTabs).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(listTabs).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not postpone a pending sweep when the shortest session unregisters", () => {
+		vi.useFakeTimers({ now: 0 });
+		const listTabs = vi.fn(() => []);
+		__setResourceGcDepsForTest({ listTabs });
+		const unregisterShort = registerResourceGcSession({ sessionId: "short", settings: gcSettings(200) });
+		registerResourceGcSession({ sessionId: "long", settings: gcSettings(1_000) });
+
+		vi.advanceTimersByTime(100);
+		unregisterShort();
+		expect(vi.getTimerCount()).toBe(1);
+
+		vi.advanceTimersByTime(99);
+		expect(listTabs).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(listTabs).toHaveBeenCalledTimes(1);
+	});
+
+	it("defers scheduling when a session registers during an in-flight tick", async () => {
+		vi.useFakeTimers({ now: 0 });
+		let releaseSweep: (() => void) | undefined;
+		const releaseTab = vi.fn(
+			() =>
+				new Promise<boolean>(resolve => {
+					releaseSweep = () => resolve(true);
+				}),
+		);
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			listTabs: () => [snapshot("busy", "initial", NOW - 5_000)],
+			releaseTab,
+		});
+		registerResourceGcSession({ sessionId: "initial", settings: gcSettings(100) });
+
+		vi.advanceTimersByTime(100);
+		expect(__getResourceGcStateForTest().inProgress).toBe(true);
+		registerResourceGcSession({ sessionId: "new", settings: gcSettings(1_000) });
+		expect(vi.getTimerCount()).toBe(0);
+
+		vi.advanceTimersByTime(10_000);
+		expect(releaseTab).toHaveBeenCalledTimes(1);
+		expect(vi.getTimerCount()).toBe(0);
+
+		releaseSweep?.();
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+		expect(__getResourceGcStateForTest().inProgress).toBe(false);
+		expect(vi.getTimerCount()).toBe(1);
+	});
+
+	it("fences an in-flight tick across stop and re-registration", async () => {
+		vi.useFakeTimers({ now: 0 });
+		let releaseSweep: (() => void) | undefined;
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			listTabs: () => [snapshot("busy", "initial", NOW - 5_000)],
+			releaseTab: vi.fn(
+				() =>
+					new Promise<boolean>(resolve => {
+						releaseSweep = () => resolve(true);
+					}),
+			),
+		});
+		const unregister = registerResourceGcSession({ sessionId: "initial", settings: gcSettings(100) });
+
+		vi.advanceTimersByTime(100);
+		expect(__getResourceGcStateForTest().inProgress).toBe(true);
+		unregister();
+		registerResourceGcSession({ sessionId: "replacement", settings: gcSettings(1_000) });
+		expect(vi.getTimerCount()).toBe(0);
+
+		releaseSweep?.();
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+		expect(__getResourceGcStateForTest().inProgress).toBe(false);
+		expect(vi.getTimerCount()).toBe(1);
+	});
+
 	it("does not run overlapping ticks", async () => {
 		const settings = Settings.isolated({
 			"browser.gc.enabled": true,
@@ -248,6 +359,106 @@ describe("resource GC controller", () => {
 
 		resolveRelease?.();
 		await first;
+	});
+
+	it("reschedules after a timer fires during an externally started tick", async () => {
+		vi.useFakeTimers({ now: 0 });
+		let releaseSweep: (() => void) | undefined;
+		let releaseCalls = 0;
+		const releaseTab = vi.fn(() => {
+			releaseCalls++;
+			if (releaseCalls > 1) return Promise.resolve(true);
+			return new Promise<boolean>(resolve => {
+				releaseSweep = () => resolve(true);
+			});
+		});
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			listTabs: () => [snapshot("busy", "initial", NOW - 5_000)],
+			releaseTab,
+		});
+		registerResourceGcSession({ sessionId: "initial", settings: gcSettings(100) });
+
+		const externalTick = __runResourceGcTickForTest();
+		await Promise.resolve();
+		expect(__getResourceGcStateForTest().inProgress).toBe(true);
+
+		vi.advanceTimersByTime(100);
+		expect(vi.getTimerCount()).toBe(0);
+		expect(releaseTab).toHaveBeenCalledTimes(1);
+
+		releaseSweep?.();
+		await externalTick;
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+		expect(__getResourceGcStateForTest().inProgress).toBe(false);
+		expect(vi.getTimerCount()).toBe(1);
+
+		vi.advanceTimersByTime(100);
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+		expect(releaseTab).toHaveBeenCalledTimes(2);
+	});
+
+	it("rearms after stop and re-registration during an externally started tick", async () => {
+		vi.useFakeTimers({ now: 0 });
+		let releaseSweep: (() => void) | undefined;
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			listTabs: () => [snapshot("busy", "initial", NOW - 5_000)],
+			releaseTab: vi.fn(
+				() =>
+					new Promise<boolean>(resolve => {
+						releaseSweep = () => resolve(true);
+					}),
+			),
+		});
+		const unregister = registerResourceGcSession({ sessionId: "initial", settings: gcSettings(100) });
+
+		const externalTick = __runResourceGcTickForTest();
+		await Promise.resolve();
+		unregister();
+		registerResourceGcSession({ sessionId: "replacement", settings: gcSettings(1_000) });
+		expect(vi.getTimerCount()).toBe(0);
+
+		releaseSweep?.();
+		await externalTick;
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+		expect(__getResourceGcStateForTest()).toMatchObject({ inProgress: false, sessionCount: 1, timerActive: true });
+		expect(vi.getTimerCount()).toBe(1);
+	});
+
+	it("advances a pending deadline after a shorter policy registers during an external tick", async () => {
+		vi.useFakeTimers({ now: 0 });
+		let releaseSweep: (() => void) | undefined;
+		let releaseCalls = 0;
+		const releaseTab = vi.fn(() => {
+			releaseCalls++;
+			if (releaseCalls > 1) return Promise.resolve(true);
+			return new Promise<boolean>(resolve => {
+				releaseSweep = () => resolve(true);
+			});
+		});
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			listTabs: () => [snapshot("busy", "initial", NOW - 5_000)],
+			releaseTab,
+		});
+		registerResourceGcSession({ sessionId: "initial", settings: gcSettings(1_000) });
+
+		const externalTick = __runResourceGcTickForTest();
+		await Promise.resolve();
+		vi.advanceTimersByTime(100);
+		registerResourceGcSession({ sessionId: "short", settings: gcSettings(200) });
+		expect(vi.getTimerCount()).toBe(1);
+
+		releaseSweep?.();
+		await externalTick;
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+
+		vi.advanceTimersByTime(199);
+		expect(releaseTab).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(1);
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+		expect(releaseTab).toHaveBeenCalledTimes(2);
 	});
 
 	it("lazy-arms and throttles stale screenshot cleanup", async () => {


### PR DESCRIPTION
## What

- Track the pending resource-GC sweep deadline.
- Replace an existing timer only when a registered session requires an earlier sweep.
- Preserve an already scheduled earlier deadline across longer-policy registration and unregister operations.
- Defer scheduling requests made during an active sweep and apply them exactly once after completion.
- Preserve generation fencing, non-overlap, stop/re-register safety, and a single pending timer.

## Why

The effective minimum interval was recomputed only after the current timer fired. A newly registered short-interval session could therefore wait for a previously scheduled long interval before its first eligible sweep. Scheduling requests made while an externally initiated sweep was active could also be lost, leaving no successor timer or retaining a stale later deadline.

## Testing

- `bun test packages/coding-agent/test/tools/resource-gc.test.ts` — 20 passed
- `bun --cwd=packages/coding-agent run check` — passed
- `gpt-5.6-sol` with `xhigh` final review — CLEAR

---

- [x] Tested locally
- [x] CHANGELOG updated