### PR TITLE
test: repair locked-intent deep-interview fixtures

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import type { Skill } from "@gajae-code/coding-agent/extensibility/skills";
+import { appendOrMergeDeepInterviewRound } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
 import { runNativeDeepInterviewCommand } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
 import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
 import { modeStatePath } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
@@ -156,9 +157,42 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 			"{"skill":"deep-interview","resolution":"standard","threshold":0.05,"threshold_source":"flag:explicit","idea":"clarify this idea","state_path":"/tmp/SCRUBBED","handoff":"/skill:deep-interview"}
 			"
 			`);
+		const blockedDeepWrite = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "matrix", "--spec", "# Spec", "--deliberate", "--json"],
+			root,
+		);
+		expect(blockedDeepWrite.status).toBe(2);
+		expect(blockedDeepWrite.stderr).toContain("missing Round 0 intent contract");
+		await appendOrMergeDeepInterviewRound(
+			root,
+			modeStatePath(root, TEST_SESSION_ID, "deep-interview"),
+			{
+				round: 0,
+				questionId: "intent-confirmation",
+				questionText: "Confirm locked intent",
+				component: "review-topology",
+				dimension: "topology",
+				selectedOptions: ["Confirm"],
+				intent_contract: {
+					items: [{ id: "artifact:matrix", category: "artifact", statement: "Preserve the handoff matrix" }],
+					confirmation_options: ["Confirm"],
+				},
+			},
+			{ sessionId: TEST_SESSION_ID },
+		);
 
 		const deepWrite = await runNativeDeepInterviewCommand(
-			["--write", "--stage", "final", "--slug", "matrix", "--spec", "# Spec", "--deliberate", "--json"],
+			[
+				"--write",
+				"--stage",
+				"final",
+				"--slug",
+				"matrix",
+				"--spec",
+				"# Spec\n\nartifact:matrix",
+				"--deliberate",
+				"--json",
+			],
 			root,
 		);
 		expect(deepWrite.status).toBe(0);

--- a/packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { appendOrMergeDeepInterviewRound } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
 import { runNativeDeepInterviewCommand } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
 import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
 import { auditPath, modeStatePath, sessionStateDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
@@ -224,9 +225,32 @@ describe("workflow state writer drift guard", () => {
 		expect(seed.status).toBe(0);
 		const statePath = modeStatePath(root, TEST_SESSION_ID, "deep-interview");
 		await expectPersistedEnvelope(statePath);
+		const blockedWrite = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "drift", "--spec", "# Spec", "--json"],
+			root,
+		);
+		expect(blockedWrite.status).toBe(2);
+		expect(blockedWrite.stderr).toContain("missing Round 0 intent contract");
+		await appendOrMergeDeepInterviewRound(
+			root,
+			statePath,
+			{
+				round: 0,
+				questionId: "intent-confirmation",
+				questionText: "Confirm locked intent",
+				component: "review-topology",
+				dimension: "topology",
+				selectedOptions: ["Confirm"],
+				intent_contract: {
+					items: [{ id: "artifact:drift", category: "artifact", statement: "Persist the writer envelope" }],
+					confirmation_options: ["Confirm"],
+				},
+			},
+			{ sessionId: TEST_SESSION_ID },
+		);
 
 		const write = await runNativeDeepInterviewCommand(
-			["--write", "--stage", "final", "--slug", "drift", "--spec", "# Spec", "--json"],
+			["--write", "--stage", "final", "--slug", "drift", "--spec", "# Spec\n\nartifact:drift", "--json"],
 			root,
 		);
 		expect(write.status).toBe(0);


### PR DESCRIPTION
## Summary
- reproduce the post-#2514 status-2 failures caused by missing Round-0 intent contracts
- assert the fail-closed rejection, then establish canonical recorder-backed Round-0 locked intent in both legacy writer fixtures
- keep runtime validation and Telegram behavior unchanged

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts`
- `bun test packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts`
- 217 affected deep-interview/state-handoff/state-writer/ralplan tests
- `bun --cwd=packages/coding-agent run check`
- `bun run build`
- `bun test scripts/ci-dev-affected.test.ts`
- bound affected-plan generation/validation at exact head with source SHA and digest; generated plan cleaned; untracked gate clean
- `git diff --check`

Related inherited failure: PR #2581 run 29648028049 at `de276b4013bf48cfc777f54fef99a49eca588d86` likely shares the same shard-2 producer. This PR intentionally does not change Telegram behavior.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*