### PR TITLE
fix(coding-agent): log runtime state persist failures

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -535,7 +535,7 @@ function assertPreviousRuntimeStateIdentity(previous: Record<string, unknown>, i
 		throw new PreviousRuntimeStateReadError();
 }
 
-function runtimeStateFileForContext(context: RuntimeStateContext): string | null {
+export function runtimeStateFileForContext(context: RuntimeStateContext): string | null {
 	const explicit = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim();
 	if (explicit) return explicit;
 	if (!context.sessionId.trim()) return null;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -244,6 +244,7 @@ import {
 import {
 	persistCoordinatorRuntimeStateFromEvent,
 	registerCoordinatorRuntimeStateFinalizer,
+	runtimeStateFileForContext,
 } from "../gjc-runtime/session-state-sidecar";
 import { writeArtifact } from "../gjc-runtime/state-writer";
 import { requestGjcWorkerIntegrationAttempt } from "../gjc-runtime/team-runtime";
@@ -2782,13 +2783,24 @@ export class AgentSession {
 	};
 
 	#persistRuntimeStateInBackground(event: AgentSessionEvent): void {
-		void persistCoordinatorRuntimeStateFromEvent(event, {
+		const context = {
 			sessionId: this.sessionId,
 			cwd: this.sessionManager.getCwd(),
 			sessionFile: this.sessionManager.getSessionFile(),
-		}).catch(() => {
-			logger.warn("Failed to persist coordinator runtime state", { event: event.type });
-		});
+		};
+		let stateFile: string | null = null;
+		void Promise.resolve()
+			.then(async () => {
+				stateFile = runtimeStateFileForContext(context);
+				await persistCoordinatorRuntimeStateFromEvent(event, context);
+			})
+			.catch(error => {
+				logger.warn("Failed to persist coordinator runtime state", {
+					event: event.type,
+					error: String(error),
+					stateFile,
+				});
+			});
 	}
 
 	async #emitSessionEvent(event: AgentSessionEvent): Promise<void> {

--- a/packages/coding-agent/test/agent-session-goal-reminder.test.ts
+++ b/packages/coding-agent/test/agent-session-goal-reminder.test.ts
@@ -347,7 +347,15 @@ describe("AgentSession active goal reminders", () => {
 					throw new Error("Timed out waiting for coordinator runtime-state failure containment");
 				}),
 			]);
-			expect(warnSpy).toHaveBeenCalledWith("Failed to persist coordinator runtime state", { event: "turn_start" });
+			expect(warnSpy).toHaveBeenCalledWith(
+				"Failed to persist coordinator runtime state",
+				expect.objectContaining({
+					error: expect.stringContaining("Existing runtime state marker is invalid or unreadable"),
+					event: "turn_start",
+					stateFile,
+				}),
+			);
+			expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("private_payload");
 		} finally {
 			if (previousStateFile === undefined) delete process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV];
 			else process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = previousStateFile;


### PR DESCRIPTION
## Summary

- include the rejected error reason and resolved coordinator runtime-state file path when background runtime-state persistence fails
- reuse the sidecar's state-file resolver in `AgentSession` so the diagnostic reports the exact env-designated or session-local marker path
- tighten the existing containment regression so corrupt sidecar payloads still do not leak private payload data while preserving actionable diagnostics

Fixes the invisible failure mode observed in #2549 where the log only emitted `{event}` while the state marker stopped advancing.

## Verification

- `bun --cwd=packages/coding-agent run check`
- `PATH="/opt/homebrew/opt/rustup/bin:$PATH" bun --cwd=packages/natives run build`
- `PATH="/opt/homebrew/opt/rustup/bin:$PATH" TMPDIR=/private/tmp bun test packages/coding-agent/test/agent-session-goal-reminder.test.ts packages/coding-agent/test/session-state-sidecar.test.ts packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts`

Local note: the isolated worktree initially lacked Rust/Cargo and the darwin-arm64 native addon. Installed Homebrew `rustup`, installed the repository-pinned `nightly-2026-04-29` toolchain, built `@gajae-code/natives`, then ran the focused tests. `TMPDIR=/private/tmp` avoids macOS `/var` symlink rejection in the session-storage reparse guard.
