### PR TITLE
fix(coding-agent): fail fast or auto-print on non-TTY stdin instead of hanging in the TUI (#2507 refile)

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -100,6 +100,51 @@ export function classifyStartupUpdateRoute(
 	return parsed.mode === "acp" ? "acp" : "text";
 }
 
+export const NON_TTY_NO_INPUT_ERROR =
+	"stdin is not a TTY and no prompt was provided; pass a prompt or @file, pipe input, or use -p/--print for non-interactive runs.";
+
+export interface LaunchDisposition {
+	autoPrint: boolean;
+	isInteractive: boolean;
+	/** Set when an interactive launch is impossible (non-TTY stdin, nothing to run). */
+	nonInteractiveError?: string;
+}
+
+/**
+ * Decides between interactive, auto-print, and fail-fast launches.
+ *
+ * A non-TTY stdin means the TUI can never receive input, so an interactive
+ * launch would execute the initial prompt (real token spend) and then block in
+ * the event loop forever — observed as orphaned `gjc <words> </dev/null`
+ * processes holding session transcripts and sqlite handles for hours.
+ *
+ * On non-TTY stdin, prepared input (positional messages or `@file`
+ * text/images) and piped content degrade to print mode; with nothing to run we
+ * fail fast instead of hanging. Explicit `--print` and `--mode` launches
+ * (rpc/acp/bridge run over non-TTY stdio) are untouched, and TTY launches keep
+ * their current interactive behavior.
+ */
+export function resolveLaunchDisposition(args: {
+	stdinIsTTY: boolean;
+	pipedInput: string | undefined;
+	hasPreparedInput: boolean;
+	print: boolean;
+	mode: string | undefined;
+}): LaunchDisposition {
+	const modeSet = args.mode !== undefined;
+	const autoPrint =
+		!args.print && !modeSet && !args.stdinIsTTY && (args.pipedInput !== undefined || args.hasPreparedInput);
+	const isInteractive = !args.print && !modeSet && !autoPrint;
+	if (isInteractive && !args.stdinIsTTY) {
+		return {
+			autoPrint: false,
+			isInteractive: false,
+			nonInteractiveError: NON_TTY_NO_INPUT_ERROR,
+		};
+	}
+	return { autoPrint, isInteractive };
+}
+
 /** Coordinates the non-blocking update check around the interactive UI lifecycle. */
 export class StartupUpdateOrchestrator {
 	#versionCheckPromise: Promise<string | undefined> | undefined;
@@ -281,8 +326,21 @@ export function resolveAcpStartupOptions(
 	};
 }
 
-async function readPipedInput(): Promise<string | undefined> {
-	if (process.stdin.isTTY !== false) return undefined;
+async function readPipedInput(context: {
+	hasPreparedInput: boolean;
+	protocolMode: boolean;
+	stdinIsTTY: boolean;
+}): Promise<string | undefined> {
+	// Bun reports `undefined` (not `false`) for every non-TTY stdin, so gate on
+	// the positive TTY check rather than `isTTY !== false`.
+	if (context.stdinIsTTY) return undefined;
+	// Protocol handlers (rpc/acp/bridge) own stdin — never consume their bytes.
+	if (context.protocolMode) return undefined;
+	// Prepared positional/@file input must run without waiting on an open pipe
+	// that may never reach EOF; stdin is only read when it is the sole possible
+	// input source. In that case blocking until the writer closes is standard
+	// filter semantics (same as `cat`).
+	if (context.hasPreparedInput) return undefined;
 	try {
 		const text = await Bun.stdin.text();
 		if (text.trim().length === 0) return undefined;
@@ -1014,6 +1072,7 @@ export interface RunRootCommandDependencies {
 	startupUpdate?: { check: () => Promise<string | undefined> };
 	initTheme?: typeof initTheme;
 	readPipedInput?: typeof readPipedInput;
+	stdinIsTTY?: () => boolean;
 	runStartupCredentialAutoImportIfNeeded?: typeof runStartupCredentialAutoImportIfNeeded;
 	getChangelogForDisplay?: typeof getChangelogForDisplay;
 	createInteractiveMode?: CreateInteractiveMode;
@@ -1164,8 +1223,14 @@ export async function runRootCommand(
 	if (parsedArgs.noTitle || parsedArgs.mode === "acp") {
 		Bun.env.PI_NO_TITLE = "1";
 	}
+	const stdinIsTTY = (deps.stdinIsTTY ?? (() => process.stdin.isTTY === true))();
+	const hasPreparedInput = parsedArgs.messages.length > 0 || parsedArgs.fileArgs.length > 0;
 	const { pipedInput, fileText, fileImages } = await logger.time("prepareInitialMessage", async () => {
-		const pipedInput = await (deps.readPipedInput ?? readPipedInput)();
+		const pipedInput = await (deps.readPipedInput ?? readPipedInput)({
+			hasPreparedInput,
+			protocolMode: parsedArgs.mode !== undefined,
+			stdinIsTTY,
+		});
 		if (parsedArgs.fileArgs.length === 0) {
 			return { pipedInput, fileText: undefined, fileImages: undefined };
 		}
@@ -1180,7 +1245,20 @@ export async function runRootCommand(
 		fileImages,
 		stdinContent: pipedInput,
 	});
-	const autoPrint = pipedInput !== undefined && !parsedArgs.print && parsedArgs.mode === undefined;
+	const disposition = resolveLaunchDisposition({
+		stdinIsTTY,
+		pipedInput,
+		hasPreparedInput,
+		print: Boolean(parsedArgs.print),
+		mode: parsedArgs.mode,
+	});
+	if (disposition.nonInteractiveError) {
+		process.stderr.write(`${chalk.red(disposition.nonInteractiveError)}\n`);
+		process.exitCode = 1;
+		if (!deps.suppressProcessExit) process.exit(1);
+		return;
+	}
+	const autoPrint = disposition.autoPrint;
 	const startupUpdateRoute = classifyStartupUpdateRoute(parsedArgs, autoPrint);
 	const startupUpdate = new StartupUpdateOrchestrator(
 		startupUpdateRoute,

--- a/packages/coding-agent/test/launch-disposition.test.ts
+++ b/packages/coding-agent/test/launch-disposition.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import { NON_TTY_NO_INPUT_ERROR, resolveLaunchDisposition } from "../src/main";
+
+const base = {
+	stdinIsTTY: true,
+	pipedInput: undefined as string | undefined,
+	hasPreparedInput: false,
+	print: false,
+	mode: undefined as string | undefined,
+};
+
+describe("resolveLaunchDisposition", () => {
+	it("launches interactive on a TTY with no flags", () => {
+		expect(resolveLaunchDisposition({ ...base })).toEqual({ autoPrint: false, isInteractive: true });
+	});
+
+	it("keeps a TTY launch with a positional prompt interactive (initial prompt runs inside the TUI)", () => {
+		expect(resolveLaunchDisposition({ ...base, hasPreparedInput: true })).toEqual({
+			autoPrint: false,
+			isInteractive: true,
+		});
+	});
+
+	it("auto-prints piped stdin content", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, pipedInput: "review this" })).toEqual({
+			autoPrint: true,
+			isInteractive: false,
+		});
+	});
+
+	it("auto-prints prepared positional/@file input on non-TTY stdin (the `gjc <words> </dev/null` orphan case)", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, hasPreparedInput: true })).toEqual({
+			autoPrint: true,
+			isInteractive: false,
+		});
+	});
+
+	it("auto-prints prepared input even when stdin never produced content (open pipe, no EOF)", () => {
+		// pipedInput is undefined here because the call site skips reading stdin
+		// entirely when prepared input exists — an open pipe must not block it.
+		expect(
+			resolveLaunchDisposition({ ...base, stdinIsTTY: false, pipedInput: undefined, hasPreparedInput: true }),
+		).toEqual({ autoPrint: true, isInteractive: false });
+	});
+
+	it("fails fast when stdin is non-TTY and there is nothing to run (previously: forever-hang in the TUI event loop)", () => {
+		const disposition = resolveLaunchDisposition({ ...base, stdinIsTTY: false });
+		expect(disposition.isInteractive).toBe(false);
+		expect(disposition.autoPrint).toBe(false);
+		expect(disposition.nonInteractiveError).toBe(NON_TTY_NO_INPUT_ERROR);
+	});
+
+	it("leaves explicit --print untouched on non-TTY stdin", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, print: true })).toEqual({
+			autoPrint: false,
+			isInteractive: false,
+		});
+	});
+
+	it("leaves --mode launches untouched (rpc/acp/bridge legitimately run over non-TTY stdio)", () => {
+		for (const mode of ["rpc", "acp", "bridge", "json", "text"]) {
+			expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, mode })).toEqual({
+				autoPrint: false,
+				isInteractive: false,
+			});
+		}
+	});
+
+	it("explicit --print wins over piped-input auto-print", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, pipedInput: "x", print: true })).toEqual({
+			autoPrint: false,
+			isInteractive: false,
+		});
+	});
+});

--- a/packages/coding-agent/test/non-tty-launch.e2e.test.ts
+++ b/packages/coding-agent/test/non-tty-launch.e2e.test.ts
@@ -1,0 +1,130 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { NON_TTY_NO_INPUT_ERROR } from "../src/main";
+
+/**
+ * Subprocess matrix for issue #2507: non-TTY stdin launch dispositions.
+ *
+ * Every case spawns the real CLI with non-TTY stdio (pipes), an isolated HOME,
+ * and a model pattern that cannot resolve — so prepared-input runs terminate
+ * deterministically at model resolution instead of hanging in the TUI or
+ * calling the network. The matrix axes are the ones from the #2010/#2508
+ * reviews: {empty EOF, piped content, open pipe without EOF} × {no input,
+ * positional prompt, @file}.
+ */
+
+const cliPath = path.resolve(import.meta.dir, "../src/cli.ts");
+let homeDir = "";
+let promptFile = "";
+
+beforeAll(async () => {
+	homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-nontty-e2e-"));
+	promptFile = path.join(homeDir, "prompt.txt");
+	await fs.writeFile(promptFile, "prepared prompt from a file\n");
+});
+
+afterAll(async () => {
+	if (homeDir) await fs.rm(homeDir, { recursive: true, force: true });
+});
+
+type LaunchResult = {
+	exitCode: number | "timeout";
+	stderr: string;
+	stdout: string;
+};
+
+function spawnCli(args: string[], stdin: "ignore" | "pipe") {
+	return Bun.spawn(["bun", cliPath, "--no-session", "--model", "no-such-provider/no-such-model", ...args], {
+		cwd: path.dirname(cliPath),
+		env: {
+			...process.env,
+			HOME: homeDir,
+			GJC_NOTIFICATIONS: "0",
+			GJC_SDK_DISABLE: "1",
+		},
+		stdin,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+}
+
+function pipedStdin(child: ReturnType<typeof spawnCli>): NonNullable<typeof child.stdin> {
+	if (!child.stdin) throw new Error("expected the child to be spawned with piped stdin");
+	return child.stdin;
+}
+
+async function collect(child: ReturnType<typeof spawnCli>, timeoutMs: number): Promise<LaunchResult> {
+	const exited = await Promise.race([child.exited, Bun.sleep(timeoutMs).then(() => "timeout" as const)]);
+	if (exited === "timeout") {
+		child.kill("SIGKILL");
+		await child.exited;
+		return { exitCode: "timeout", stderr: "", stdout: "" };
+	}
+	const [stderr, stdout] = await Promise.all([new Response(child.stderr).text(), new Response(child.stdout).text()]);
+	return { exitCode: exited, stderr, stdout };
+}
+
+describe("non-TTY launch disposition (subprocess matrix, issue #2507)", () => {
+	test("empty EOF stdin with nothing to run fails fast with the diagnostic", async () => {
+		const child = spawnCli([], "ignore"); // "ignore" = /dev/null: immediate EOF
+		const result = await collect(child, 30_000);
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain(NON_TTY_NO_INPUT_ERROR);
+	}, 40_000);
+
+	test("empty EOF stdin with a positional prompt runs non-interactively (no fail-fast, no hang)", async () => {
+		const child = spawnCli(["hello"], "ignore");
+		const result = await collect(child, 30_000);
+		expect(result.exitCode).not.toBe("timeout");
+		expect(result.stderr).not.toContain(NON_TTY_NO_INPUT_ERROR);
+	}, 40_000);
+
+	test("empty EOF stdin with @file input runs non-interactively (blocker 1 in the #2010 review)", async () => {
+		const child = spawnCli([`@${promptFile}`], "ignore");
+		const result = await collect(child, 30_000);
+		expect(result.exitCode).not.toBe("timeout");
+		expect(result.stderr).not.toContain(NON_TTY_NO_INPUT_ERROR);
+	}, 40_000);
+
+	test("open stdin without EOF must not block a positional prompt (open/no-EOF prepared-input case)", async () => {
+		const child = spawnCli(["hello"], "pipe"); // pipe held open, never closed by us
+		const result = await collect(child, 30_000);
+		expect(result.exitCode).not.toBe("timeout");
+		expect(result.stderr).not.toContain(NON_TTY_NO_INPUT_ERROR);
+	}, 40_000);
+
+	test("open stdin without EOF must not block @file input (open/no-EOF prepared-input case)", async () => {
+		const child = spawnCli([`@${promptFile}`], "pipe");
+		const result = await collect(child, 30_000);
+		expect(result.exitCode).not.toBe("timeout");
+		expect(result.stderr).not.toContain(NON_TTY_NO_INPUT_ERROR);
+	}, 40_000);
+
+	test("piped stdin content becomes the prompt (blocker 2 in the #2010 review: Bun isTTY === undefined)", async () => {
+		const child = spawnCli([], "pipe");
+		const stdin = pipedStdin(child);
+		stdin.write("what is 2+2\n");
+		await stdin.end();
+		const result = await collect(child, 30_000);
+		expect(result.exitCode).not.toBe("timeout");
+		// The piped bytes must be read and treated as prepared input — the
+		// launch must not fail fast claiming no prompt was provided.
+		expect(result.stderr).not.toContain(NON_TTY_NO_INPUT_ERROR);
+	}, 40_000);
+
+	test("open stdin with no other input waits for the writer (filter semantics), then runs the piped prompt", async () => {
+		const child = spawnCli([], "pipe");
+		// Give the CLI time to boot and reach the stdin read; it must still be
+		// alive (waiting for input like `cat`), not fail-fast and not in a TUI.
+		const early = await Promise.race([child.exited, Bun.sleep(5_000).then(() => "alive" as const)]);
+		expect(early).toBe("alive");
+		const stdin = pipedStdin(child);
+		stdin.write("late prompt\n");
+		await stdin.end();
+		const result = await collect(child, 30_000);
+		expect(result.exitCode).not.toBe("timeout");
+		expect(result.stderr).not.toContain(NON_TTY_NO_INPUT_ERROR);
+	}, 45_000);
+});

--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -405,6 +405,7 @@ describe("startup update contract", () => {
 				runRootCommand(rootArgs(), [], {
 					createAgentSession: async () => sessionResult,
 					discoverAuthStorage: async () => authStorage,
+					stdinIsTTY: () => true,
 					settings: Settings.isolated({ "marketplace.autoUpdate": "off", "startup.checkUpdate": false }),
 					initTheme: async () => {},
 					readPipedInput: async () => undefined,
@@ -488,6 +489,7 @@ describe("startup update contract", () => {
 				runRootCommand(rootArgs(), [], {
 					createAgentSession: async () => sessionResult,
 					discoverAuthStorage: async () => authStorage,
+					stdinIsTTY: () => true,
 					settings: Settings.isolated({ "marketplace.autoUpdate": "off", "startup.checkUpdate": false }),
 					initTheme: async () => {},
 					readPipedInput: async () => undefined,
@@ -520,6 +522,7 @@ describe("startup update contract", () => {
 			const root = runRootCommand(rootArgs(), [], {
 				createAgentSession: async () => fakeSessionResult(),
 				discoverAuthStorage: async () => authStorage,
+				stdinIsTTY: () => true,
 				settings: Settings.isolated({ "marketplace.autoUpdate": "off", "startup.checkUpdate": true }),
 				startupUpdate: {
 					check: async () => {
@@ -587,6 +590,7 @@ describe("startup update contract", () => {
 					runRootCommand(rootArgs(), [], {
 						createAgentSession: async () => fakeSessionResult(),
 						discoverAuthStorage: async () => authStorage,
+						stdinIsTTY: () => true,
 						settings: Settings.isolated({
 							"marketplace.autoUpdate": "off",
 							"startup.checkUpdate": testCase.enabled,
@@ -639,6 +643,7 @@ describe("startup update contract", () => {
 				runRootCommand(parsed, [], {
 					createAgentSession: async () => fakeSessionResult(),
 					discoverAuthStorage: async () => authStorage,
+					stdinIsTTY: () => true,
 					settings,
 					initTheme: async () => {},
 					readPipedInput: async () => undefined,
@@ -697,6 +702,7 @@ describe("startup update contract", () => {
 				runRootCommand(parsed, [], {
 					createAgentSession: async () => fakeSessionResult(),
 					discoverAuthStorage: async () => authStorage,
+					stdinIsTTY: () => true,
 					settings,
 					initTheme: async () => {},
 					readPipedInput: async () => undefined,


### PR DESCRIPTION
Closes #2507. Refile of #2010 / #2508 addressing every blocker from both reviews, targeting current `dev`.

## Blockers from the prior reviews → how each is fixed

**Blocker 1 (#2010) — `@file` input wrongly rejected.** `resolveLaunchDisposition` now takes `hasPreparedInput = messages.length > 0 || fileArgs.length > 0` instead of `hasMessages`. `gjc @notes.txt </dev/null` and `gjc @image.png </dev/null` run non-interactively; the misleading “no prompt was provided” diagnostic can no longer fire when a prompt *was* provided.

**Blocker 2 (#2010) — Bun's `isTTY === undefined` + unread piped bytes.** `readPipedInput` gates on the positive check (`stdinIsTTY === true` short-circuits) instead of `isTTY !== false`, which under Bun (1.3.14, Linux) never matched any non-TTY stdin. `printf 'what is 2+2' | gjc` now reads the piped bytes and auto-prints them as the prompt.

**#2508 close condition — “still blocks on open non-TTY stdin before prepared positional/`@file` input can be processed.”** Stdin is now read **only when it is the sole possible input source**: prepared positional/`@file` input skips the stdin read entirely, so an open pipe that never reaches EOF cannot block those launches.

**#2508 close condition — “preserve ACP as the protocol stdin owner.”** `readPipedInput` refuses to consume bytes when `--mode` is set (rpc/acp/bridge). Previously the call site invoked it unconditionally before mode dispatch — under a runtime where `isTTY === false` it would have swallowed protocol bytes.

**#2508 close condition — “prove the open/no-EOF prepared-input matrix.”** New bounded subprocess suite `test/non-tty-launch.e2e.test.ts` spawns the real CLI (isolated `HOME`, unresolvable `--model` so runs terminate deterministically offline) across the matrix `{empty EOF, piped content, open pipe/no EOF} × {no input, positional, @file}`:

- empty EOF + nothing → exit 1 with the diagnostic
- empty EOF + positional / `@file` → runs non-interactively, no diagnostic, no hang
- **open no-EOF + positional / `@file` → exits without waiting for EOF**
- piped content → becomes the prompt
- open no-EOF + nothing → waits for the writer (standard filter semantics, like `cat`), then runs the late-piped prompt

**#2508 close condition — “without changing the user-facing contract.”** TTY launches (with or without a positional prompt) stay interactive; `--print` and `--mode` dispositions are byte-identical (covered in `test/launch-disposition.test.ts`, including a per-mode sweep).

## Behavior table (non-TTY stdin only)

| stdin | prepared input | before (dev) | after |
|---|---|---|---|
| empty EOF | none | TUI hang forever (`exit 124` probe in #2507) | exit 1 + diagnostic |
| empty EOF | positional/`@file` | prompt executes, then TUI hang | auto-print |
| piped content | none | bytes never read under Bun → TUI hang | auto-print with piped prompt |
| open, no EOF | positional/`@file` | hang | auto-print, stdin untouched |
| open, no EOF | none | TUI hang | blocks reading until writer closes (filter semantics), then auto-print/fail-fast |

## Tests

- `test/launch-disposition.test.ts` — 9 unit cases for the disposition table (TTY, prepared input, piped, print, per-mode sweep, fail-fast).
- `test/non-tty-launch.e2e.test.ts` — 7 bounded subprocess matrix cases (above). All complete in ~12s; every child is reaped (kill on timeout budget).
- `test/startup-update-contract.test.ts` — interactive-route cases now inject `stdinIsTTY: () => true`, declaring the TTY scenario they simulate (the test runner's own stdin is a pipe).
- Focused suites at this head: launch-disposition 9/9, non-tty matrix 7/7, startup-update-contract 18/18, resume-confirm-continue 8/8, acp-stdout-hygiene/acp-startup-options/acp-lazy-startup/silent-abort-print-mode/launch-command 29/29. `tsc --noEmit` and `biome check` clean.
- Red baseline: the #2507 repro (`bun src/cli.ts --no-session </dev/null` → exit 124) reproduces on unmodified `dev`; the new suites fail there.

## Notes

- The fail-fast exit follows the existing bare-resume pattern (`stderr` + `exitCode`), honoring `suppressProcessExit` for in-process tests before the hard `process.exit(1)`.
- `deps.stdinIsTTY` is a new optional test seam alongside `deps.readPipedInput`; production default reads `process.stdin.isTTY === true`.