### PR TITLE
fix(sdk): compact broker session index to bound RSS

### DIFF
--- a/packages/coding-agent/src/sdk/broker/session-index.ts
+++ b/packages/coding-agent/src/sdk/broker/session-index.ts
@@ -2,7 +2,13 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import { withFileLock } from "../../config/file-lock";
-import { assertSupportedStateVersion, SDK_STATE_VERSION, UnsupportedStateVersionError } from "./state-version";
+import {
+	assertSupportedSnapshotVersion,
+	assertSupportedStateVersion,
+	SDK_STATE_VERSION,
+	SESSION_INDEX_SNAPSHOT_VERSION,
+	UnsupportedStateVersionError,
+} from "./state-version";
 
 export type SessionIndexEventType =
 	| "host_registered"
@@ -52,18 +58,54 @@ const ROTATE_BYTES = 4 * 1024 * 1024;
 function isValidSnapshot(snapshot: unknown): snapshot is { indexSeq: number; events: SessionIndexEvent[] } {
 	if (!snapshot || typeof snapshot !== "object") return false;
 	const { indexSeq, events } = snapshot as { indexSeq?: unknown; events?: unknown };
-	return (
-		typeof indexSeq === "number" &&
-		Number.isSafeInteger(indexSeq) &&
-		indexSeq >= 0 &&
-		Array.isArray(events) &&
-		events.length === indexSeq &&
-		events.every((event, index) => {
-			if (!event || typeof event !== "object") return false;
-			const { checksum, ...unsigned } = event as SessionIndexEvent;
-			return event.indexSeq === index + 1 && checksum === sessionIndexChecksum(unsigned);
-		})
-	);
+	if (typeof indexSeq !== "number" || !Number.isSafeInteger(indexSeq) || indexSeq < 0) return false;
+	if (!Array.isArray(events)) return false;
+	if (events.length === 0) return indexSeq === 0;
+	// Accept strictly-increasing indexSeq (gaps allowed after compaction), preserving
+	// each event's original checksum. The old contiguous 1..N format is a special case.
+	let previous = 0;
+	for (const event of events) {
+		if (!event || typeof event !== "object") return false;
+		const { checksum, ...unsigned } = event as SessionIndexEvent;
+		if (typeof event.indexSeq !== "number" || !Number.isSafeInteger(event.indexSeq)) return false;
+		if (event.indexSeq <= previous) return false;
+		if (checksum !== sessionIndexChecksum(unsigned)) return false;
+		previous = event.indexSeq;
+	}
+	return previous === indexSeq;
+}
+
+// Compact the event history for a snapshot without renumbering: clients hold indexSeq
+// across calls, so retained events keep their original indexSeq and checksum. Drops
+// terminal+dead sessions entirely, collapses superseded heartbeats to the latest per
+// surviving session, and always retains the global-max indexSeq as the chain anchor.
+function compactEvents(events: SessionIndexEvent[]): SessionIndexEvent[] {
+	if (events.length === 0) return events;
+	const maxIndexSeq = events[events.length - 1]!.indexSeq;
+	const latestBySession = new Map<string, SessionIndexEvent>();
+	for (const event of events) latestBySession.set(event.sessionId, event);
+	const deadTerminal = new Set<string>();
+	for (const [sessionId, latest] of latestBySession) {
+		const terminal = latest.type === "host_unregistered" || latest.type === "session_closed";
+		if (terminal && !alive(latest.pid)) deadTerminal.add(sessionId);
+	}
+	const latestHeartbeatSeq = new Map<string, number>();
+	for (const event of events) {
+		if (event.type === "host_heartbeat" && !deadTerminal.has(event.sessionId)) {
+			latestHeartbeatSeq.set(event.sessionId, event.indexSeq);
+		}
+	}
+	const kept: SessionIndexEvent[] = [];
+	for (const event of events) {
+		if (event.indexSeq === maxIndexSeq) {
+			kept.push(event);
+			continue;
+		}
+		if (deadTerminal.has(event.sessionId)) continue;
+		if (event.type === "host_heartbeat" && latestHeartbeatSeq.get(event.sessionId) !== event.indexSeq) continue;
+		kept.push(event);
+	}
+	return kept;
 }
 
 async function appendSync(file: string, value: string): Promise<void> {
@@ -135,7 +177,7 @@ export class SessionIndex {
 				events?: SessionIndexEvent[];
 				indexSeq?: number;
 			};
-			assertSupportedStateVersion(snapshotFor(this.#agentDir), snapshot);
+			assertSupportedSnapshotVersion(snapshotFor(this.#agentDir), snapshot);
 			if (!isValidSnapshot(snapshot)) throw new Error("invalid snapshot");
 			this.#events = snapshot.events;
 			snapshotSeq = snapshot.indexSeq;
@@ -240,7 +282,11 @@ export class SessionIndex {
 		const tmp = `${file}.${process.pid}.tmp`;
 		await fs.writeFile(
 			tmp,
-			JSON.stringify({ version: SDK_STATE_VERSION, indexSeq: this.indexSeq, events: this.#events }),
+			JSON.stringify({
+				version: SESSION_INDEX_SNAPSHOT_VERSION,
+				indexSeq: this.indexSeq,
+				events: compactEvents(this.#events),
+			}),
 			{
 				mode: 0o600,
 			},

--- a/packages/coding-agent/src/sdk/broker/state-version.ts
+++ b/packages/coding-agent/src/sdk/broker/state-version.ts
@@ -1,5 +1,12 @@
 export const SDK_STATE_VERSION = 1;
 
+// The session-index snapshot carries its own format version, independent of the shared
+// SDK_STATE_VERSION used by discovery, the lifecycle ledger, and per-event records. Version 2
+// snapshots relax the on-disk schema to allow gaps in indexSeq (compaction drops terminal+dead
+// sessions and superseded heartbeats), so an older broker must hard-fail rather than silently
+// fall back to a truncated log. Bumping only this constant keeps the broker protocol untouched.
+export const SESSION_INDEX_SNAPSHOT_VERSION = 2;
+
 export class UnsupportedStateVersionError extends Error {
 	readonly code = "unsupported_state_version";
 
@@ -17,6 +24,20 @@ export function assertSupportedStateVersion(file: string, value: unknown): void 
 	const record = value as { version?: unknown; stateVersion?: unknown };
 	for (const version of [record.version, record.stateVersion]) {
 		if (typeof version === "number" && Number.isFinite(version) && version > SDK_STATE_VERSION) {
+			throw new UnsupportedStateVersionError(file, version);
+		}
+	}
+}
+
+// Fences the session-index snapshot format independently of SDK_STATE_VERSION. An older broker
+// (whose SESSION_INDEX_SNAPSHOT_VERSION is 1) trips assertSupportedStateVersion on a version-2
+// snapshot and refuses to start; a current broker accepts both the legacy contiguous format
+// (version 1 or absent) and the gapped version-2 format.
+export function assertSupportedSnapshotVersion(file: string, value: unknown): void {
+	if (!value || typeof value !== "object") return;
+	const record = value as { version?: unknown; stateVersion?: unknown };
+	for (const version of [record.version, record.stateVersion]) {
+		if (typeof version === "number" && Number.isFinite(version) && version > SESSION_INDEX_SNAPSHOT_VERSION) {
 			throw new UnsupportedStateVersionError(file, version);
 		}
 	}

--- a/packages/coding-agent/test/sdk-session-index.test.ts
+++ b/packages/coding-agent/test/sdk-session-index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import { SessionIndex, sessionIndexChecksum } from "../src/sdk/broker/session-index";
+import { SDK_STATE_VERSION } from "../src/sdk/broker/state-version";
 
 const event = (sessionId: string) => ({
 	type: "host_registered" as const,
@@ -86,13 +87,13 @@ describe("SDK session index", () => {
 		const oversized = {
 			...event("oversized"),
 			locator: { repo: "r".repeat(4 * 1024 * 1024), stateRoot: "q" },
-			version: invalidSnapshot.version,
+			version: SDK_STATE_VERSION,
 			indexSeq: 2,
 			ts: Date.now(),
 		};
 		await fs.appendFile(
 			path.join(sessionsDir, "index.jsonl"),
-			`${JSON.stringify({ ...oversized, checksum: sessionIndexChecksum(oversized) })}\n`,
+			`${JSON.stringify({ ...oversized, checksum: sessionIndexChecksum(oversized as Parameters<typeof sessionIndexChecksum>[0]) })}\n`,
 		);
 
 		await index.append(event("after"));
@@ -219,4 +220,119 @@ describe("SDK session index", () => {
 			indexSeq: expect.any(Number),
 		});
 	}, 30_000);
+
+	it("compaction drops terminal+dead sessions and keeps live sessions with their original indexSeq", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const deadPid = await (async () => {
+			const proc = Bun.spawn({ cmd: ["true"] });
+			await proc.exited;
+			return proc.pid;
+		})();
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("live"));
+		await index.append({ ...event("dead"), pid: deadPid });
+		await index.append({ ...event("dead"), type: "host_unregistered", pid: deadPid });
+		await index.append(event("live2"));
+		await index.snapshot();
+		const snapshot = JSON.parse(await fs.readFile(path.join(dir, "sdk", "sessions", "index.snapshot.json"), "utf8"));
+		expect(snapshot.events.map((e: { sessionId: string }) => e.sessionId)).toEqual(["live", "live2"]);
+		expect(snapshot.events[0].indexSeq).toBe(1);
+		expect(snapshot.indexSeq).toBe(4);
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.listSessions().sessions.map(s => s.sessionId)).toEqual(["live", "live2"]);
+		expect(replay.indexSeq).toBe(4);
+	});
+	it("collapses superseded heartbeats to the latest per surviving session", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("s"));
+		await index.append({ ...event("s"), type: "host_heartbeat" });
+		await index.append({ ...event("s"), type: "host_heartbeat" });
+		await index.append(event("other"));
+		const before = index.listSessions().sessions.map(session => session.sessionId);
+		await index.snapshot();
+		const snapshot = JSON.parse(await fs.readFile(path.join(dir, "sdk", "sessions", "index.snapshot.json"), "utf8"));
+		const heartbeats = snapshot.events.filter((e: { type: string }) => e.type === "host_heartbeat");
+		expect(heartbeats).toHaveLength(1);
+		expect(heartbeats[0].indexSeq).toBe(3);
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.listSessions().sessions.map(s => s.sessionId)).toEqual(before);
+	});
+	it("accepts a gapped-monotonic snapshot on replay and chains subsequent appends", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const sessionsDir = path.join(dir, "sdk", "sessions");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		const signed = (indexSeq: number, sessionId: string) => {
+			const unsigned = {
+				...event(sessionId),
+				version: SDK_STATE_VERSION,
+				indexSeq,
+				ts: 1,
+			};
+			return { ...unsigned, checksum: sessionIndexChecksum(unsigned as Parameters<typeof sessionIndexChecksum>[0]) };
+		};
+		await fs.writeFile(
+			path.join(sessionsDir, "index.snapshot.json"),
+			JSON.stringify({ version: 2, indexSeq: 5, events: [signed(1, "a"), signed(5, "b")] }),
+		);
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.listSessions().warnings).toEqual([]);
+		expect(replay.indexSeq).toBe(5);
+		const appended = await replay.append(event("c"));
+		expect(appended.indexSeq).toBe(6);
+	});
+	it("rejects a non-monotonic snapshot as invalid", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const sessionsDir = path.join(dir, "sdk", "sessions");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		const signed = (indexSeq: number, sessionId: string) => {
+			const unsigned = { ...event(sessionId), version: SDK_STATE_VERSION, indexSeq, ts: 1 };
+			return { ...unsigned, checksum: sessionIndexChecksum(unsigned as Parameters<typeof sessionIndexChecksum>[0]) };
+		};
+		await fs.writeFile(
+			path.join(sessionsDir, "index.snapshot.json"),
+			JSON.stringify({ version: 2, indexSeq: 3, events: [signed(3, "a"), signed(2, "b")] }),
+		);
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.listSessions().warnings).toContain("Invalid session index snapshot");
+		expect(replay.indexSeq).toBe(0);
+	});
+	it("guards state version: rejects a newer snapshot and reads an older one", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const sessionsDir = path.join(dir, "sdk", "sessions");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		const snapshotFile = path.join(sessionsDir, "index.snapshot.json");
+		await fs.writeFile(snapshotFile, JSON.stringify({ version: 3, indexSeq: 0, events: [] }));
+		await expect(new SessionIndex(dir).open()).rejects.toThrow(/Unsupported SDK state version/);
+		const legacy = { ...event("legacy"), version: 1 as const, indexSeq: 1, ts: 1 };
+		const legacyEvent = {
+			...legacy,
+			checksum: sessionIndexChecksum(legacy as unknown as Parameters<typeof sessionIndexChecksum>[0]),
+		};
+		await fs.writeFile(snapshotFile, JSON.stringify({ version: 1, indexSeq: 1, events: [legacyEvent] }));
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.listSessions().warnings).toEqual([]);
+		expect(replay.listSessions().sessions.map(s => s.sessionId)).toEqual(["legacy"]);
+	});
+	it("compacts idempotently: a second snapshot of the same history is byte-identical", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const deadPid = await (async () => {
+			const proc = Bun.spawn({ cmd: ["true"] });
+			await proc.exited;
+			return proc.pid;
+		})();
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("live"));
+		await index.append({ ...event("dead"), pid: deadPid });
+		await index.append({ ...event("dead"), type: "host_unregistered", pid: deadPid });
+		await index.append({ ...event("live"), type: "host_heartbeat" });
+		await index.append(event("live2"));
+		const snapshotFile = path.join(dir, "sdk", "sessions", "index.snapshot.json");
+		await index.snapshot();
+		const first = await fs.readFile(snapshotFile, "utf8");
+		const reopened = await new SessionIndex(dir).open();
+		await reopened.snapshot();
+		const second = await fs.readFile(snapshotFile, "utf8");
+		expect(second).toBe(first);
+	});
 });


### PR DESCRIPTION
## Summary

Fixes the v0.11.2 release blocker: the agent-global SDK broker's `SessionIndex` retained **every** event forever (in memory and on disk), so heartbeats (~76% of events) and terminal/dead sessions accumulated without bound. A live broker reached **~2 GB RSS** with a 244 MB `index.snapshot.json`.

The fix adds snapshot compaction and a gapped-snapshot on-disk format, scoped so the broker protocol is untouched.

## What changed

- **Compaction** in `#snapshotUnderLock()` (runs before every write, incl. `#rotate`): drops terminal+**dead** sessions, collapses superseded `host_heartbeat` events to the latest per surviving session, and always retains the global-max `indexSeq` as the chain anchor. Original `indexSeq` + checksums are preserved — **no renumber, no rechecksum** — so client references (`findHostRegistration` / `hostUnregisteredAfter`) stay valid.
- **Relaxed `isValidSnapshot`**: accepts strictly-increasing (gapped) `indexSeq` with `last === snapshot.indexSeq`, while still accepting the legacy contiguous `1..N` format. The existing 244 MB snapshot self-heals on the first compacting write — no migration step.
- **Scoped version bump**: new `SESSION_INDEX_SNAPSHOT_VERSION = 2` + `assertSupportedSnapshotVersion`, leaving the shared `SDK_STATE_VERSION` (discovery, lifecycle ledger, per-event records) at `1`. An older broker fails closed on a version-2 snapshot instead of silently falling back to a truncated log.

> Note: the initial recommendation was to bump the shared `SDK_STATE_VERSION` globally. That was rejected — empirically it regressed `sdk-broker.test.ts` (37 → 29 pass) because that constant also gates discovery/lifecycle cross-version reads. Scoping the bump to the snapshot achieves the same fail-closed guard with zero broker-protocol blast radius.

## Testing

- `bun test test/sdk-session-index.test.ts` → **17 pass / 0 fail** (6 new: terminal+dead compaction, heartbeat collapse, gapped-monotonic accept, non-monotonic reject, gapped round-trip + `M+1` chain, version guard, idempotent compaction).
- Broker suites verified at the clean baseline via stash-and-compare — **zero regressions**.
- `tsc -p tsconfig.json --noEmit` → exit 0; biome format/lint clean.

## Operational note

The running broker won't shrink until restarted; after restart the first rotate/snapshot compacts and the on-disk snapshot self-heals.