### PR TITLE
fix(utils): finite cleanup-deadline contract for exit-bound postmortem waits (#2556 refile)

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Consecutive termination signals now join the same in-flight postmortem cleanup instead of logging a spurious recursion error, and every exit-bound cleanup wait (signals, fatals, quiet broken-pipe exit, `quit()`) is bounded by an explicit finite deadline (default 5000 ms, `GJC_CLEANUP_DEADLINE_MS` override). On expiry the owner's exit code is preserved, a single diagnostic is emitted (suppressed during quiet shutdown), and late callback settlement becomes a no-op — a never-settling cleanup callback can no longer hang shutdown permanently (#2556).
+
 ## [0.10.1] - 2026-07-13
 
 ### Fixed

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -55,7 +55,11 @@ function runCleanup(reason: Reason, options: CleanupOptions = {}): Promise<void>
 			cleanupStage = "running";
 			break;
 		case "running":
-			if (reason !== Reason.EXIT && !shouldSuppressCleanupLogging(quiet)) {
+			// Exit-bound waiters (signals, fatals, quit) legitimately join the
+			// in-flight cleanup via `cleanupPromise`; only a genuine manual
+			// recursion (a cleanup callback calling cleanup()) is a bug worth a
+			// diagnostic.
+			if (reason === Reason.MANUAL && !shouldSuppressCleanupLogging(quiet)) {
 				logger.error("Cleanup invoked recursively", { stack: new Error().stack });
 			}
 			return Promise.resolve();
@@ -90,9 +94,65 @@ function runCleanup(reason: Reason, options: CleanupOptions = {}): Promise<void>
 	return promise;
 }
 
-async function runCleanupAndWait(reason: Reason, options: CleanupOptions = {}): Promise<void> {
+/**
+ * Finite cleanup-liveness contract for every exit-bound wait.
+ *
+ * Governed waits: signal handlers (SIGINT/SIGTERM/SIGHUP), fatal handlers
+ * (uncaught exception / unhandled rejection), the quiet stdout-EPIPE exit, and
+ * `quit()`. Each waits at most `resolveCleanupDeadlineMs()` for the shared
+ * in-flight cleanup before exiting with its own unchanged exit code (130/143/
+ * 129, 1 for fatals, BROKEN_PIPE_EXIT_CODE, or quit's `code`).
+ *
+ * Ungoverned: `cleanup()` (Reason.MANUAL without exit) is caller-owned and
+ * unbounded, and Reason.EXIT stays fire-and-forget (exit is imminent).
+ *
+ * On expiry the stage is forced to "complete" so late re-entries no-op, a
+ * single diagnostic goes to stderr and the error log (suppressed during quiet
+ * broken-pipe shutdown), and late callback settlement is ignored — rejections
+ * were already routed through Promise.allSettled, so none can become unhandled.
+ *
+ * The deadline defaults to 5000 ms and can be overridden with
+ * `GJC_CLEANUP_DEADLINE_MS` (finite values >= 0; anything else falls back to
+ * the default).
+ */
+const DEFAULT_CLEANUP_DEADLINE_MS = 5_000;
+
+function resolveCleanupDeadlineMs(): number {
+	const raw = process.env.GJC_CLEANUP_DEADLINE_MS;
+	if (raw === undefined || raw.trim() === "") return DEFAULT_CLEANUP_DEADLINE_MS;
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_CLEANUP_DEADLINE_MS;
+	return parsed;
+}
+
+async function awaitCleanupWithDeadline(reason: Reason, options: CleanupOptions = {}): Promise<void> {
+	const pending = cleanupPromise;
+	if (!pending || cleanupStage === "complete") return;
+	const deadlineMs = resolveCleanupDeadlineMs();
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timedOut = await Promise.race([
+		pending.then(() => false),
+		new Promise<boolean>(resolve => {
+			// Deliberately referenced: the timer is also the liveness floor that
+			// keeps the process alive until the bounded wait settles, so an
+			// otherwise-empty event loop cannot exit 0 underneath a governed wait.
+			timer = setTimeout(() => resolve(true), deadlineMs);
+		}),
+	]);
+	if (timer) clearTimeout(timer);
+	if (!timedOut) return;
+	// Force the terminal stage so late settlement and re-entries are no-ops.
+	cleanupStage = "complete";
+	if (!shouldSuppressCleanupLogging(options.quiet === true)) {
+		const diagnostic = `[postmortem] cleanup deadline (${deadlineMs}ms) expired for ${reason}; exiting without waiting for remaining callbacks.\n`;
+		safeStderrWrite(diagnostic);
+		logger.error("Cleanup deadline expired", { reason, deadlineMs });
+	}
+}
+
+async function runCleanupBounded(reason: Reason, options: CleanupOptions = {}): Promise<void> {
 	void runCleanup(reason, options);
-	await (cleanupPromise ?? Promise.resolve());
+	await awaitCleanupWithDeadline(reason, options);
 }
 
 function installProcessStdoutWriteClassifier(): void {
@@ -150,7 +210,7 @@ async function exitQuietlyForAttributableStdoutEpipe(reason: Reason): Promise<vo
 	quietShutdownStarted = true;
 	// Set the observable status before cleanup can await or trigger another error.
 	process.exitCode = BROKEN_PIPE_EXIT_CODE;
-	await runCleanupAndWait(reason, { quiet: true });
+	await runCleanupBounded(reason, { quiet: true });
 	// An ordinary fatal that arrived during quiet cleanup takes precedence.
 	if (process.exitCode === BROKEN_PIPE_EXIT_CODE) process.exit(BROKEN_PIPE_EXIT_CODE);
 }
@@ -173,7 +233,7 @@ async function handleFatalError(label: string, reason: unknown, cleanupReason: R
 			stack: err.stack,
 		});
 	}
-	await runCleanupAndWait(cleanupReason);
+	await runCleanupBounded(cleanupReason);
 	process.exit(1);
 }
 
@@ -181,7 +241,7 @@ if (isMainThread) {
 	installProcessStdoutWriteClassifier();
 	process
 		.on("SIGINT", async () => {
-			await runCleanupAndWait(Reason.SIGINT);
+			await runCleanupBounded(Reason.SIGINT);
 			process.exit(130); // 128 + SIGINT (2)
 		})
 		.on("SIGUSR1", () => {
@@ -201,11 +261,11 @@ if (isMainThread) {
 			void runCleanup(Reason.EXIT); // fire and forget (exit imminent)
 		})
 		.on("SIGTERM", async () => {
-			await runCleanupAndWait(Reason.SIGTERM);
+			await runCleanupBounded(Reason.SIGTERM);
 			process.exit(143); // 128 + SIGTERM (15)
 		})
 		.on("SIGHUP", async () => {
-			await runCleanupAndWait(Reason.SIGHUP);
+			await runCleanupBounded(Reason.SIGHUP);
 			process.exit(129); // 128 + SIGHUP (1)
 		});
 } else {
@@ -296,7 +356,7 @@ export async function quit(code: number = 0): Promise<void> {
 	}
 
 	const exitAfterCleanup = async (): Promise<void> => {
-		await completion;
+		await awaitCleanupWithDeadline(Reason.MANUAL);
 		if (process.stdout.writableLength > 0) {
 			const { promise, resolve } = Promise.withResolvers<void>();
 			process.stdout.once("drain", resolve);

--- a/packages/utils/test/postmortem-fixture.ts
+++ b/packages/utils/test/postmortem-fixture.ts
@@ -250,6 +250,50 @@ async function runNonPipeUnhandledRejection(): Promise<void> {
 	await Bun.sleep(2_000);
 }
 
+async function runConsecutiveSignalsShareCleanup(): Promise<void> {
+	let count = 0;
+	postmortem.register("fixture-consecutive-signals", async reason => {
+		count++;
+		await Bun.sleep(500);
+		writeResult({ count, reason });
+	});
+
+	setTimeout(() => process.kill(process.pid, "SIGTERM"), 20);
+	process.kill(process.pid, "SIGHUP");
+	await Bun.sleep(5_000);
+}
+
+async function runCleanupDeadlineSignal(): Promise<void> {
+	process.env.GJC_CLEANUP_DEADLINE_MS = "300";
+	postmortem.register("fixture-deadline-signal", async () => {
+		writeResult({ started: true });
+		await new Promise(() => {});
+	});
+
+	process.kill(process.pid, "SIGTERM");
+	await Bun.sleep(10_000);
+}
+
+async function runCleanupDeadlineQuit(): Promise<void> {
+	process.env.GJC_CLEANUP_DEADLINE_MS = "300";
+	postmortem.register("fixture-deadline-quit", async () => {
+		writeResult({ started: true });
+		await new Promise(() => {});
+	});
+
+	await postmortem.quit(7);
+}
+
+async function runCleanupDeadlineFatal(): Promise<void> {
+	process.env.GJC_CLEANUP_DEADLINE_MS = "300";
+	postmortem.register("fixture-deadline-fatal", async () => {
+		writeResult({ started: true });
+		await new Promise(() => {});
+	});
+
+	await throwFromTimer(new Error("fixture: fatal with hung cleanup"));
+}
+
 const scenario = process.argv[2];
 switch (scenario) {
 	case "exit-reentry-while-running":
@@ -257,6 +301,18 @@ switch (scenario) {
 		break;
 	case "non-exit-recursive-cleanup":
 		await runNonExitRecursiveCleanup();
+		break;
+	case "consecutive-signals-share-cleanup":
+		await runConsecutiveSignalsShareCleanup();
+		break;
+	case "cleanup-deadline-signal":
+		await runCleanupDeadlineSignal();
+		break;
+	case "cleanup-deadline-quit":
+		await runCleanupDeadlineQuit();
+		break;
+	case "cleanup-deadline-fatal":
+		await runCleanupDeadlineFatal();
 		break;
 	case "quit-reentry-waits-for-cleanup":
 		await runQuitReentryWaitsForCleanup();

--- a/packages/utils/test/postmortem.test.ts
+++ b/packages/utils/test/postmortem.test.ts
@@ -13,6 +13,7 @@ interface ScenarioResult {
 interface FixtureResult {
 	count: number;
 	exitBeforeCleanupFinished?: boolean;
+	started?: boolean;
 }
 
 const fixturePath = path.join(import.meta.dir, "postmortem-fixture.ts");
@@ -100,6 +101,44 @@ describe("postmortem cleanup re-entry", () => {
 		expect(result.exitCode).toBe(0);
 		expect(parseResult(result.stdout).count).toBe(1);
 		expect(hasRecursiveCleanupError(combinedOutput(result))).toBe(false);
+	});
+});
+
+describe("postmortem cleanup deadline contract (issue #2556)", () => {
+	it("a second termination signal joins the in-flight cleanup instead of truncating it", async () => {
+		const result = await runScenario("consecutive-signals-share-cleanup");
+
+		// The first signal (SIGHUP) owns the exit; the teardown callback runs
+		// exactly once and completes despite the SIGTERM 20ms later.
+		expect(result.exitCode).toBe(129);
+		expect(parseResult(result.stdout).count).toBe(1);
+		expect(result.stdout).toContain('"reason":"sighup"');
+		expect(hasRecursiveCleanupError(combinedOutput(result))).toBe(false);
+	});
+
+	it("a hung cleanup callback cannot outlive the deadline on a signal exit; owner code preserved", async () => {
+		const result = await runScenario("cleanup-deadline-signal");
+
+		expect(result.exitCode).toBe(143);
+		expect(parseResult(result.stdout).started).toBe(true);
+		expect(result.stderr).toContain("cleanup deadline (300ms) expired for sigterm");
+	});
+
+	it("a hung cleanup callback cannot hang quit(); quit's exit code is preserved", async () => {
+		const result = await runScenario("cleanup-deadline-quit");
+
+		expect(result.exitCode).toBe(7);
+		expect(parseResult(result.stdout).started).toBe(true);
+		expect(result.stderr).toContain("cleanup deadline (300ms) expired for manual");
+	});
+
+	it("a hung cleanup callback cannot hang a fatal exit; fatal diagnostic and status 1 preserved", async () => {
+		const result = await runScenario("cleanup-deadline-fatal");
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain("[Uncaught Exception]");
+		expect(result.stderr).toContain("fixture: fatal with hung cleanup");
+		expect(result.stderr).toContain("cleanup deadline (300ms) expired for uncaught_exception");
 	});
 });
 


### PR DESCRIPTION
Closes #2556. Refile of #2557 with the explicit, testable finite cleanup-liveness contract the closing review required.

## What the review blocked

> “neither this head nor current `dev` defines an enforceable finite production cleanup policy … A never-settling registered callback can therefore hang signal, fatal, manual, and quit cleanup permanently … duration/configuration, governed reasons, timeout diagnostic, owner exit code, lifecycle after expiry, late settlement/rejection, and MANUAL/EXIT/quit/fatal/EPIPE interactions are all unspecified.”

Each unspecified dimension is now specified, implemented, and tested:

| Dimension | Contract |
|---|---|
| Governed reasons | Every **exit-bound** wait: SIGINT/SIGTERM/SIGHUP handlers, uncaught-exception & unhandled-rejection fatals, the quiet stdout-EPIPE exit, `quit()` |
| Ungoverned by design | `cleanup()` (manual, non-exiting — caller-owned) and `Reason.EXIT` (fire-and-forget, exit imminent) |
| Duration / configuration | 5000 ms default; `GJC_CLEANUP_DEADLINE_MS` override, finite values ≥ 0; invalid → default |
| Owner exit code | Never changed by the deadline: 130/143/129 (signals), 1 (fatals), `BROKEN_PIPE_EXIT_CODE` (quiet EPIPE), `quit()`'s own code |
| Timeout diagnostic | One stderr line + one error-log entry (`Cleanup deadline expired`); suppressed during quiet broken-pipe shutdown, preserving the #2099 quiet contract |
| Lifecycle after expiry | `cleanupStage` forced to `complete`, so late re-entries no-op with existing post-complete semantics |
| Late settlement / rejection | Late settlement resolves an unobserved promise (no-op); rejections were already routed through `Promise.allSettled`, so none can become unhandled |
| Liveness floor | The deadline timer is deliberately kept referenced, so an otherwise-empty event loop cannot exit 0 underneath a governed wait |

## Signal re-entry semantics (the original #2556 symptom)

Consecutive termination signals join the shared in-flight `cleanupPromise` through the bounded wait. The `Cleanup invoked recursively` error is now reserved for genuine manual recursion (a cleanup callback re-entering `cleanup()`), exactly matching the issue's expected behavior; EXIT re-entry stays a silent no-op. On current `dev` the second signal still emitted the spurious error-level recursion log — the new consecutive-signal fixture fails there.

## Tests (subprocess fixtures, real kernel signals via `process.kill(process.pid, …)`)

New `postmortem cleanup deadline contract (issue #2556)` suite:

1. **Consecutive signals** — SIGHUP then SIGTERM +20 ms with a 500 ms teardown: exit `129` (first signal owns the exit), teardown runs exactly once to completion, no recursion error. *Fails on unmodified dev.*
2. **Hung cleanup + signal** — never-settling callback, 300 ms deadline: exit `143` with the deadline diagnostic. *Hangs → fails on dev.*
3. **Hung cleanup + `quit(7)`** — exit `7` preserved with the diagnostic. *Fails on dev.*
4. **Hung cleanup + fatal** — exit `1`, `[Uncaught Exception]` diagnostic retained, deadline diagnostic present. *Fails on dev.*

Full `packages/utils` suite at this head: **147 pass / 0 fail** (all existing re-entry, quit-re-entry, and stdout-EPIPE policy tests unchanged and green). `tsc --noEmit` and `biome check` clean.

## Interactions preserved

- **EPIPE quiet path (#2099/#2129)**: quiet shutdown keeps stderr silence — the deadline diagnostic honors `shouldSuppressCleanupLogging`; `BROKEN_PIPE_EXIT_CODE` preserved.
- **#1465 EXIT re-entry**: still a non-blocking no-op (existing test green).
- **Manual recursion diagnostic**: retained verbatim for `cleanup()` re-entry from inside a callback (existing test green).
- **`quit()` stdout drain**: the existing 5 s drain bound is untouched and now sits behind a bounded cleanup wait instead of an unbounded one.