### PR TITLE
fix(coding-agent): attempt-scoped subagent live state + manager-owned control barriers (#2558 refile)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).
 - Coordinator MCP question polling now requires a session, reconciles pending workflow gates into bounded public questions, diagnostics, and reconciliation state, and submits bound idempotent answers through `workflow.gate_answer` without exposing private gate payloads (#2550).
 - Runtime skill discovery now follows native user config-root precedence: nearest project, canonical `GJC_CONFIG_DIR`/`PI_CONFIG_DIR`/`.gjc` `agent/skills`, configured legacy `<config>/skills`, then historical legacy `~/.gjc/skills`, preserving exact fallback precedence (#2572).
+- Detached-subagent live handles and progress are now attempt-scoped: a stale cancelled/resumed attempt can no longer overwrite or remove the current attempt's live control or progress, cancellation is immediately authoritative for the side channels, jobs are inserted before their runner starts, steering runs through a manager-owned compare-and-act barrier that never pauses a superseding attempt, and liveness never falls back to a raw handle or running backing job (#2558 follow-up).
 
 ### Fixed
 - SDK host response delivery to a disconnected client no longer escalates a second structured-error send failure into a process-level unhandled rejection; failures stay local to that connection.

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -133,6 +133,16 @@ export interface SubagentLiveHandle {
 	): Promise<void>;
 }
 
+interface AttemptLiveHandle {
+	jobId: string;
+	handle: SubagentLiveHandle;
+}
+
+interface AttemptSubagentProgress {
+	jobId: string;
+	progress: AgentProgress;
+}
+
 /**
  * Canonical, stable-id-keyed record for a subagent. Survives `AsyncJob`
  * eviction so resume stays addressable by subagent id, and is the single source
@@ -374,8 +384,8 @@ export class AsyncJobManager {
 	#deliveryLoop: Promise<void> | undefined;
 	#disposed = false;
 	readonly #subagentRecords = new Map<string, SubagentRecord>();
-	readonly #liveHandles = new Map<string, SubagentLiveHandle>();
-	readonly #subagentProgress = new Map<string, AgentProgress>();
+	readonly #liveHandles = new Map<string, AttemptLiveHandle>();
+	readonly #subagentProgress = new Map<string, AttemptSubagentProgress>();
 	readonly #resumeQueue: ResumeQueueEntry[] = [];
 	#resumeSeq = 0;
 	#resumeRunner?: ResumeRunner;
@@ -492,6 +502,9 @@ export class AsyncJobManager {
 				});
 			}
 		};
+		this.#jobs.set(id, job);
+		this.#notifyChange();
+
 		job.promise = (async () => {
 			try {
 				const result = await run({ jobId: id, signal: abortController.signal, reportProgress });
@@ -546,9 +559,6 @@ export class AsyncJobManager {
 				this.#drainResumeQueue();
 			}
 		})();
-
-		this.#jobs.set(id, job);
-		this.#notifyChange();
 		return id;
 	}
 
@@ -575,6 +585,7 @@ export class AsyncJobManager {
 		this.#runLifecycle(id, "cancel");
 		job.status = "cancelled";
 		this.#freezeEndTime(job);
+		this.#markRecordTerminal(id, "cancelled");
 		job.abortController.abort();
 		return true;
 	}
@@ -710,16 +721,26 @@ export class AsyncJobManager {
 		return out;
 	}
 
-	registerLiveHandle(subagentId: string, handle: SubagentLiveHandle): void {
-		this.#liveHandles.set(subagentId, handle);
+	registerLiveHandle(subagentId: string, attemptJobId: string, handle: SubagentLiveHandle): boolean {
+		const record = this.#subagentRecords.get(subagentId);
+		const job = this.#jobs.get(attemptJobId);
+		if (!record || record.currentJobId !== attemptJobId || record.status !== "running" || job?.status !== "running") {
+			return false;
+		}
+		this.#liveHandles.set(subagentId, { jobId: attemptJobId, handle });
+		return true;
 	}
 
 	getLiveHandle(subagentId: string): SubagentLiveHandle | undefined {
-		return this.#liveHandles.get(subagentId);
+		const record = this.#subagentRecords.get(subagentId);
+		const entry = this.#liveHandles.get(subagentId);
+		if (!record || record.status !== "running" || !entry || entry.jobId !== record.currentJobId) return undefined;
+		return entry.handle;
 	}
 
-	removeLiveHandle(subagentId: string): void {
-		this.#liveHandles.delete(subagentId);
+	removeLiveHandle(subagentId: string, attemptJobId: string): void {
+		const entry = this.#liveHandles.get(subagentId);
+		if (entry?.jobId === attemptJobId) this.#liveHandles.delete(subagentId);
 	}
 
 	/**
@@ -731,27 +752,46 @@ export class AsyncJobManager {
 	 * task runs that share the executor path) so the map only holds detached
 	 * subagent progress and never accumulates untracked foreground task state.
 	 */
-	recordSubagentProgress(subagentId: string, progress: AgentProgress): void {
-		if (!this.#subagentRecords.has(subagentId)) return;
-		this.#subagentProgress.set(subagentId, structuredClone(progress));
+	recordSubagentProgress(subagentId: string, attemptJobId: string, progress: AgentProgress): void {
+		const record = this.#subagentRecords.get(subagentId);
+		if (!record || record.currentJobId !== attemptJobId || record.status !== "running") return;
+		this.#subagentProgress.set(subagentId, { jobId: attemptJobId, progress: structuredClone(progress) });
 	}
 
 	getSubagentProgress(subagentId: string): AgentProgress | undefined {
-		return this.#subagentProgress.get(subagentId);
+		const record = this.#subagentRecords.get(subagentId);
+		const entry = this.#subagentProgress.get(subagentId);
+		if (!record || entry?.jobId !== record.currentJobId) return undefined;
+		return entry.progress;
 	}
 
 	/**
-	 * True only when a live, in-session progress producer exists for this id: a
-	 * canonical registered record with a live handle or an in-memory running job.
-	 * False for `SubagentTool` backward-compat job synthesis and resumed-from-disk
-	 * records, which have no live producer to stream from.
+	 * True only when the canonical running record has a live handle for its
+	 * current attempt.
 	 */
 	hasLiveSubagent(subagentId: string, filter?: AsyncJobFilter): boolean {
-		const rec = this.getSubagentRecord(subagentId, filter);
-		if (!rec) return false;
-		if (this.#liveHandles.has(rec.subagentId)) return true;
-		const job = rec.currentJobId ? this.#jobs.get(rec.currentJobId) : undefined;
-		return job?.status === "running";
+		const record = this.getSubagentRecord(subagentId, filter);
+		const entry = record && this.#liveHandles.get(record.subagentId);
+		return record?.status === "running" && entry?.jobId === record.currentJobId;
+	}
+
+	async steerSubagent(
+		subagentId: string,
+		message: string,
+		opts: { filter?: AsyncJobFilter; pause?: boolean; fromAgentId?: string } = {},
+	): Promise<"delivered" | "no-live-handle" | "superseded" | "not-running"> {
+		const record = this.getSubagentRecord(subagentId, opts.filter);
+		if (!record || record.status !== "running") return "not-running";
+		const attemptJobId = record.currentJobId;
+		const entry = this.#liveHandles.get(record.subagentId);
+		if (!attemptJobId || !entry || entry.jobId !== attemptJobId) return "no-live-handle";
+
+		await entry.handle.injectMessage(message, "steer", { fromAgentId: opts.fromAgentId });
+
+		const current = this.getSubagentRecord(subagentId, opts.filter);
+		if (!current || current.status !== "running" || current.currentJobId !== attemptJobId) return "superseded";
+		if (opts.pause === true) this.pauseSubagent(subagentId, opts.filter);
+		return "delivered";
 	}
 
 	/** Install the TaskTool-owned resume runner. Returns the new job id, or undefined on failure. */
@@ -1039,9 +1079,10 @@ export class AsyncJobManager {
 		const rec = this.getSubagentRecord(subagentId, filter);
 		if (!rec) return { ok: false, reason: "not_found" };
 		if (rec.status !== "running") return { ok: false, status: rec.status, reason: "not_running" };
-		const handle = this.#liveHandles.get(rec.subagentId);
-		if (!handle) return { ok: false, status: rec.status, reason: "no_live_handle" };
-		handle.requestPause();
+		const entry = this.#liveHandles.get(rec.subagentId);
+		if (!entry || entry.jobId !== rec.currentJobId)
+			return { ok: false, status: rec.status, reason: "no_live_handle" };
+		entry.handle.requestPause();
 		return { ok: true, status: rec.status };
 	}
 
@@ -1092,8 +1133,9 @@ export class AsyncJobManager {
 			return { ok: false, status: rec.status, reason: "owner_shutdown_in_progress" };
 		}
 		const prevJobId = rec.currentJobId;
-		// Clear any retained progress from the previous run so a resumed subagent
-		// never renders the prior run's tool/output as live before it emits again.
+		// Clear state from the previous run so a resumed subagent never exposes
+		// prior-attempt control or progress before the new attempt registers.
+		this.#liveHandles.delete(rec.subagentId);
 		this.#subagentProgress.delete(rec.subagentId);
 		const runner = this.#resolveResumeRunner(rec.subagentId);
 		const newJobId = runner?.(rec.subagentId, message, this.#resumeDescriptors.get(rec.subagentId));

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -182,6 +182,8 @@ export interface ExecutorOptions {
 	runMode?: "initial" | "resume" | "message";
 	resumeMessage?: string;
 	subagentId?: string;
+	/** Async job id for this detached subagent attempt. */
+	attemptJobId?: string;
 	/**
 	 * Active model selector of the parent session, used as an auth-aware fallback
 	 * if the resolved subagent model has no working credentials. See #985.
@@ -1529,8 +1531,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 			const liveSubagentId = options.subagentId ?? id;
 			const manager = AsyncJobManager.instance();
-			if (manager) {
-				manager.registerLiveHandle(liveSubagentId, {
+			if (manager && options.attemptJobId) {
+				manager.registerLiveHandle(liveSubagentId, options.attemptJobId, {
 					requestPause: () => {
 						pauseRequested = true;
 					},
@@ -1839,7 +1841,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				if (exitCode === 0) exitCode = 1;
 			}
 			sessionAbortController.abort();
-			AsyncJobManager.instance()?.removeLiveHandle(options.subagentId ?? id);
+			if (options.attemptJobId)
+				AsyncJobManager.instance()?.removeLiveHandle(options.subagentId ?? id, options.attemptJobId);
 			if (unsubscribe) {
 				try {
 					unsubscribe();

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -564,7 +564,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				return manager.register(
 					"task",
 					descriptor.task.id,
-					async ({ signal: runSignal }) => {
+					async ({ jobId: attemptJobId, signal: runSignal }) => {
 						const result = await this.#executeSync(
 							descriptor.toolCallId,
 							{ ...descriptor.params, tasks: [descriptor.task] },
@@ -576,6 +576,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								runMode: message ? "message" : "resume",
 								resumeMessage: message,
 								sessionFiles: new Map([[descriptor.task.id, descriptor.sessionFile]]),
+								attemptJobId,
 								suppressRoiReconciliation: true,
 							},
 						);
@@ -656,7 +657,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				const jobId = manager.register(
 					"task",
 					label,
-					async ({ signal: runSignal, reportProgress }) => {
+					async ({ jobId: attemptJobId, signal: runSignal, reportProgress }) => {
 						const startedAt = Date.now();
 						const progress = progressByTaskId.get(taskItem.id);
 						await semaphore.acquire();
@@ -684,6 +685,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								frozenForkSeeds,
 								{
 									sessionFiles: new Map([[uniqueId, subtaskSessionFile]]),
+									attemptJobId,
 									suppressRoiReconciliation: true,
 								},
 							);
@@ -892,6 +894,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			runMode?: "initial" | "resume" | "message";
 			resumeMessage?: string;
 			sessionFiles?: ReadonlyMap<string, string | null>;
+			attemptJobId?: string;
 			/**
 			 * Set for per-child async runs: the spawnPlan is carried for gate
 			 * consistency, but batch-level ROI reconciliation must not be computed
@@ -1321,6 +1324,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						runMode: overrides?.runMode ?? executionOverrides?.runMode,
 						resumeMessage: overrides?.resumeMessage ?? executionOverrides?.resumeMessage,
 						subagentId: task.id,
+						attemptJobId: executionOverrides?.attemptJobId,
 						taskDepth,
 						modelOverride,
 						parentActiveModelPattern,
@@ -1339,7 +1343,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							progressMap.set(index, {
 								...structuredClone(progress),
 							});
-							AsyncJobManager.instance()?.recordSubagentProgress(task.id, progress);
+							if (executionOverrides?.attemptJobId) {
+								AsyncJobManager.instance()?.recordSubagentProgress(
+									task.id,
+									executionOverrides.attemptJobId,
+									progress,
+								);
+							}
 							emitProgress();
 						},
 						authStorage: this.session.authStorage,
@@ -1385,6 +1395,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						runMode: overrides?.runMode ?? executionOverrides?.runMode,
 						resumeMessage: overrides?.resumeMessage ?? executionOverrides?.resumeMessage,
 						subagentId: task.id,
+						attemptJobId: executionOverrides?.attemptJobId,
 						taskDepth,
 						modelOverride,
 						parentActiveModelPattern,
@@ -1403,7 +1414,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							progressMap.set(index, {
 								...structuredClone(progress),
 							});
-							AsyncJobManager.instance()?.recordSubagentProgress(task.id, progress);
+							if (executionOverrides?.attemptJobId) {
+								AsyncJobManager.instance()?.recordSubagentProgress(
+									task.id,
+									executionOverrides.attemptJobId,
+									progress,
+								);
+							}
 							emitProgress();
 						},
 						authStorage: this.session.authStorage,

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -262,11 +262,20 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			} else {
 				if (!record.sessionFile) throw new ToolError(`Subagent ${record.subagentId} has no session file.`);
 				if (record.status === "running") {
-					const handle = manager.getLiveHandle(record.subagentId);
-					if (!handle) throw new ToolError(`Subagent ${record.subagentId} has no live handle.`);
-					const fromAgentId = this.session.getAgentId?.() ?? undefined;
-					await handle.injectMessage(message, "steer", { fromAgentId });
-					if (params.pause === true) manager.pauseSubagent(record.subagentId, ownerFilter);
+					const result = await manager.steerSubagent(record.subagentId, message, {
+						filter: ownerFilter,
+						pause: params.pause === true,
+						fromAgentId: this.session.getAgentId?.() ?? undefined,
+					});
+					if (result === "no-live-handle") {
+						throw new ToolError(`Subagent ${record.subagentId} is still initializing and has no live handle.`);
+					}
+					if (result === "superseded") {
+						throw new ToolError(`Subagent ${record.subagentId} was superseded while steering.`);
+					}
+					if (result === "not-running") {
+						throw new ToolError(`Subagent ${record.subagentId} is no longer running.`);
+					}
 					records.push(manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record);
 					steerStates.set(record.subagentId, "queued");
 				} else {

--- a/packages/coding-agent/test/async/job-manager-bounds.test.ts
+++ b/packages/coding-agent/test/async/job-manager-bounds.test.ts
@@ -165,11 +165,11 @@ describe("AsyncJobManager bounded dispose and delivery", () => {
 		const terminalJobId = manager.register("task", "terminal", async () => "done", { id: "terminal-job" });
 		manager.registerSubagentRecord(subagentRecord("terminal-sub", terminalJobId, "running"));
 		manager.registerResumeDescriptor(resumeDescriptor("terminal-sub"));
-		manager.registerLiveHandle("terminal-sub", {
+		manager.registerLiveHandle("terminal-sub", terminalJobId, {
 			requestPause: () => {},
 			injectMessage: async () => {},
 		});
-		manager.recordSubagentProgress("terminal-sub", { currentTool: "test" } as never);
+		manager.recordSubagentProgress("terminal-sub", terminalJobId, { currentTool: "test" } as never);
 
 		await manager.waitForAll();
 		expect(manager.getSubagentRecord("terminal-sub")?.resumable).toBe(true);
@@ -182,11 +182,11 @@ describe("AsyncJobManager bounded dispose and delivery", () => {
 		});
 		manager.registerSubagentRecord(subagentRecord("paused-sub", pausedJobId, "running"));
 		manager.registerResumeDescriptor(resumeDescriptor("paused-sub"));
-		manager.registerLiveHandle("paused-sub", {
+		manager.registerLiveHandle("paused-sub", pausedJobId, {
 			requestPause: () => {},
 			injectMessage: async () => {},
 		});
-		manager.recordSubagentProgress("paused-sub", { currentTool: "test" } as never);
+		manager.recordSubagentProgress("paused-sub", pausedJobId, { currentTool: "test" } as never);
 
 		await manager.waitForAll();
 		expect(manager.getSubagentRecord("paused-sub")?.status).toBe("paused");

--- a/packages/coding-agent/test/async/job-manager-redteam.test.ts
+++ b/packages/coding-agent/test/async/job-manager-redteam.test.ts
@@ -156,8 +156,8 @@ describe("AsyncJobManager red-team invariants", () => {
 		);
 		manager.registerSubagentRecord(record("terminal-sub", terminalJobId, "running"));
 		manager.registerResumeDescriptor(descriptor("terminal-sub"));
-		manager.registerLiveHandle("terminal-sub", { requestPause() {}, async injectMessage() {} });
-		manager.recordSubagentProgress("terminal-sub", { currentTool: "terminal" } as never);
+		manager.registerLiveHandle("terminal-sub", terminalJobId, { requestPause() {}, async injectMessage() {} });
+		manager.recordSubagentProgress("terminal-sub", terminalJobId, { currentTool: "terminal" } as never);
 
 		await manager.waitForAll();
 		expect(manager.getJob(terminalJobId)).toBeUndefined();
@@ -174,8 +174,8 @@ describe("AsyncJobManager red-team invariants", () => {
 		);
 		manager.registerSubagentRecord(record("paused-sub", pausedJobId, "running"));
 		manager.registerResumeDescriptor(descriptor("paused-sub"));
-		manager.registerLiveHandle("paused-sub", { requestPause() {}, async injectMessage() {} });
-		manager.recordSubagentProgress("paused-sub", { currentTool: "paused" } as never);
+		manager.registerLiveHandle("paused-sub", pausedJobId, { requestPause() {}, async injectMessage() {} });
+		manager.recordSubagentProgress("paused-sub", pausedJobId, { currentTool: "paused" } as never);
 
 		await manager.waitForAll();
 		expect(manager.getJob(pausedJobId)?.status).toBe("paused");

--- a/packages/coding-agent/test/async/job-manager-resume-queue.test.ts
+++ b/packages/coding-agent/test/async/job-manager-resume-queue.test.ts
@@ -41,7 +41,7 @@ function spawnControllable(manager: AsyncJobManager, subagentId: string, ownerId
 		sessionFile: `/tmp/${subagentId}.jsonl`,
 		resumable: true,
 	});
-	manager.registerLiveHandle(subagentId, {
+	manager.registerLiveHandle(subagentId, jobId, {
 		requestPause() {
 			pauseRequested = true;
 		},

--- a/packages/coding-agent/test/async/subagent-attempt-scope.test.ts
+++ b/packages/coding-agent/test/async/subagent-attempt-scope.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { AsyncJobManager, type SubagentLiveHandle, type SubagentRecord } from "../../src/async";
+
+function createManager(): AsyncJobManager {
+	return new AsyncJobManager({ onJobComplete: async () => {}, retentionMs: 10_000 });
+}
+
+function runningJob(manager: AsyncJobManager, id: string): string {
+	return manager.register(
+		"task",
+		id,
+		async ({ signal }) => {
+			await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+			throw new Error("cancelled");
+		},
+		{ id },
+	);
+}
+
+function record(subagentId: string, jobId: string, status: SubagentRecord["status"] = "running"): SubagentRecord {
+	return {
+		subagentId,
+		currentJobId: jobId,
+		historicalJobIds: [],
+		status,
+		sessionFile: "/tmp/subagent.jsonl",
+		resumable: true,
+	};
+}
+
+function handle(requestPause = () => {}): SubagentLiveHandle {
+	return { requestPause, async injectMessage() {} };
+}
+
+describe("subagent attempt-scoped live state", () => {
+	afterEach(() => AsyncJobManager.resetForTests());
+
+	it("rejects stale handle/progress writers and retains only the current attempt", () => {
+		const manager = createManager();
+		const oldJobId = runningJob(manager, "old");
+		const newJobId = runningJob(manager, "new");
+		manager.registerSubagentRecord(record("0-Child", oldJobId, "paused"));
+		manager.setResumeRunner(() => newJobId);
+		expect(manager.resumeSubagent("0-Child").jobId).toBe(newJobId);
+
+		const current = handle();
+		expect(manager.registerLiveHandle("0-Child", newJobId, current)).toBe(true);
+		expect(manager.hasLiveSubagent("0-Child")).toBe(true);
+		expect(manager.registerLiveHandle("0-Child", oldJobId, handle())).toBe(false);
+		manager.removeLiveHandle("0-Child", oldJobId);
+		expect(manager.getLiveHandle("0-Child")).toBe(current);
+
+		manager.recordSubagentProgress("0-Child", oldJobId, { currentTool: "stale" } as never);
+		expect(manager.getSubagentProgress("0-Child")).toBeUndefined();
+		manager.recordSubagentProgress("0-Child", newJobId, { currentTool: "current" } as never);
+		expect(manager.getSubagentProgress("0-Child")?.currentTool).toBe("current");
+	});
+
+	it("rejects late handle registration after cancellation and does not infer liveness from a job", () => {
+		const manager = createManager();
+		const jobId = runningJob(manager, "cancelled");
+		manager.registerSubagentRecord(record("0-Child", jobId));
+		expect(manager.hasLiveSubagent("0-Child")).toBe(false);
+		expect(manager.cancel(jobId)).toBe(true);
+		expect(manager.registerLiveHandle("0-Child", jobId, handle())).toBe(false);
+		expect(manager.hasLiveSubagent("0-Child")).toBe(false);
+	});
+
+	it("does not pause a superseding attempt after steering the captured attempt", async () => {
+		const manager = createManager();
+		const oldJobId = runningJob(manager, "steer-old");
+		const newJobId = runningJob(manager, "steer-new");
+		let newAttemptPaused = false;
+		manager.registerSubagentRecord(record("0-Child", oldJobId));
+		manager.setResumeRunner(() => newJobId);
+		manager.registerLiveHandle("0-Child", oldJobId, {
+			requestPause() {},
+			async injectMessage() {
+				manager.cancel(oldJobId);
+				manager.resumeSubagent("0-Child");
+				manager.registerLiveHandle(
+					"0-Child",
+					newJobId,
+					handle(() => {
+						newAttemptPaused = true;
+					}),
+				);
+			},
+		});
+
+		expect(await manager.steerSubagent("0-Child", "keep going", { pause: true })).toBe("superseded");
+		expect(newAttemptPaused).toBe(false);
+		expect(manager.getSubagentRecord("0-Child")?.currentJobId).toBe(newJobId);
+	});
+});

--- a/packages/coding-agent/test/tools/subagent-live-progress.test.ts
+++ b/packages/coding-agent/test/tools/subagent-live-progress.test.ts
@@ -50,6 +50,12 @@ function runningRecord(subagentId: string, jobId: string): SubagentRecord {
 		resumable: false,
 	};
 }
+function registerLiveHandle(manager: AsyncJobManager, subagentId: string, jobId: string): void {
+	manager.registerLiveHandle(subagentId, jobId, {
+		requestPause() {},
+		async injectMessage() {},
+	});
+}
 
 describe("subagent await live progress", () => {
 	afterEach(() => {
@@ -76,8 +82,10 @@ describe("subagent await live progress", () => {
 		// Record progress BEFORE await; no further progress event will fire.
 		manager.recordSubagentProgress(
 			"0-Live",
+			jobId,
 			makeProgress({ id: "0-Live", currentTool: "read", recentOutput: ["scanning files"] }),
 		);
+		registerLiveHandle(manager, "0-Live", jobId);
 
 		const result = await tool.execute("await", { action: "await", ids: ["0-Live"], timeout_ms: 5 });
 		const snap = result.details?.subagents.find(s => s.id === "0-Live");
@@ -122,8 +130,10 @@ describe("subagent await live progress", () => {
 		);
 		manager.registerSubagentRecord(runningRecord("0-A", jobA));
 		manager.registerSubagentRecord(runningRecord("0-B", jobB));
-		manager.recordSubagentProgress("0-A", makeProgress({ id: "0-A", currentTool: "read" }));
-		manager.recordSubagentProgress("0-B", makeProgress({ id: "0-B", currentTool: "bash" }));
+		registerLiveHandle(manager, "0-A", jobA);
+		registerLiveHandle(manager, "0-B", jobB);
+		manager.recordSubagentProgress("0-A", jobA, makeProgress({ id: "0-A", currentTool: "read" }));
+		manager.recordSubagentProgress("0-B", jobB, makeProgress({ id: "0-B", currentTool: "bash" }));
 
 		const result = await tool.execute("await", { action: "await", ids: ["0-A", "0-B"], timeout_ms: 5 });
 		const a = result.details?.subagents.find(s => s.id === "0-A");
@@ -184,7 +194,11 @@ describe("subagent await live progress", () => {
 			},
 		);
 		// Retained progress exists for the id, but there is no live producer for it.
-		manager.recordSubagentProgress("0-Stale", makeProgress({ id: "0-Stale", currentTool: "should-not-render" }));
+		manager.recordSubagentProgress(
+			"0-Stale",
+			"job-stale",
+			makeProgress({ id: "0-Stale", currentTool: "should-not-render" }),
+		);
 
 		const result = await tool.execute("await", { action: "await", ids: ["0-Stale"], timeout_ms: 5 });
 		const snap = result.details?.subagents.find(s => s.id === "0-Stale");
@@ -218,6 +232,7 @@ describe("AsyncJobManager subagent progress retention", () => {
 			},
 		);
 		manager.registerSubagentRecord(runningRecord("0-Live", jobId));
+		registerLiveHandle(manager, "0-Live", jobId);
 
 		expect(manager.hasLiveSubagent("0-Live")).toBe(true);
 		expect(manager.hasLiveSubagent("0-Absent")).toBe(false);
@@ -241,7 +256,7 @@ describe("AsyncJobManager subagent progress retention", () => {
 			},
 		);
 		manager.registerSubagentRecord(runningRecord("0-Clean", jobId));
-		manager.recordSubagentProgress("0-Clean", makeProgress({ id: "0-Clean", currentTool: "read" }));
+		manager.recordSubagentProgress("0-Clean", jobId, makeProgress({ id: "0-Clean", currentTool: "read" }));
 		expect(manager.getSubagentProgress("0-Clean")).toBeDefined();
 
 		manager.cancelSubagent("0-Clean", { ownerId: "0-Main" });
@@ -253,7 +268,11 @@ describe("AsyncJobManager subagent progress retention", () => {
 
 	it("ignores progress for ids without a canonical subagent record (foreground task isolation)", () => {
 		const manager = createManager();
-		manager.recordSubagentProgress("0-Foreground", makeProgress({ id: "0-Foreground", currentTool: "read" }));
+		manager.recordSubagentProgress(
+			"0-Foreground",
+			"no-job",
+			makeProgress({ id: "0-Foreground", currentTool: "read" }),
+		);
 		expect(manager.getSubagentProgress("0-Foreground")).toBeUndefined();
 	});
 
@@ -277,11 +296,12 @@ describe("AsyncJobManager subagent progress retention", () => {
 			ownerId: "0-Main",
 			currentJobId: firstJob,
 			historicalJobIds: [],
-			status: "paused",
+			status: "running",
 			sessionFile: "/tmp/0-Resume.jsonl",
 			resumable: true,
 		});
-		manager.recordSubagentProgress("0-Resume", makeProgress({ id: "0-Resume", currentTool: "old-tool" }));
+		manager.recordSubagentProgress("0-Resume", firstJob, makeProgress({ id: "0-Resume", currentTool: "old-tool" }));
+		manager.getSubagentRecord("0-Resume")!.status = "paused";
 		expect(manager.getSubagentProgress("0-Resume")).toBeDefined();
 
 		manager.setResumeRunner(() =>
@@ -308,9 +328,18 @@ describe("AsyncJobManager subagent progress retention", () => {
 
 	it("deep-clones retained progress so later mutation cannot corrupt it", () => {
 		const manager = createManager();
-		manager.registerSubagentRecord(runningRecord("0-Clone", "job-clone"));
+		const cloneJob = manager.register(
+			"task",
+			"clone",
+			async () => {
+				await Bun.sleep(100);
+				return "done";
+			},
+			{ id: "job-clone" },
+		);
+		manager.registerSubagentRecord(runningRecord("0-Clone", cloneJob));
 		const live = makeProgress({ id: "0-Clone", recentOutput: ["one"] });
-		manager.recordSubagentProgress("0-Clone", live);
+		manager.recordSubagentProgress("0-Clone", cloneJob, live);
 		live.recentOutput.push("two");
 		live.currentTool = "mutated";
 
@@ -506,7 +535,8 @@ describe("subagent await emit gating", () => {
 				},
 			);
 			manager.registerSubagentRecord(runningRecord(id, jobId));
-			manager.recordSubagentProgress(id, makeProgress({ id, currentTool: "read", recentOutput: ["scan"] }));
+			registerLiveHandle(manager, id, jobId);
+			manager.recordSubagentProgress(id, jobId, makeProgress({ id, currentTool: "read", recentOutput: ["scan"] }));
 		});
 
 		const ac = new AbortController();
@@ -524,7 +554,11 @@ describe("subagent await emit gating", () => {
 		for (const spy of spies) expect(spy).toHaveBeenCalledTimes(1);
 
 		// A real progress change on 0-A emits exactly once; idle peers stay quiet.
-		manager.recordSubagentProgress("0-A", makeProgress({ id: "0-A", currentTool: "bash", recentOutput: ["scan"] }));
+		manager.recordSubagentProgress(
+			"0-A",
+			"job-0-A",
+			makeProgress({ id: "0-A", currentTool: "bash", recentOutput: ["scan"] }),
+		);
 		vi.advanceTimersByTime(500);
 		expect(spies[0]).toHaveBeenCalledTimes(2);
 		expect(spies[1]).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -25,6 +25,21 @@ function createManager(): AsyncJobManager {
 	AsyncJobManager.setInstance(manager);
 	return manager;
 }
+function registerRunningAttempt(manager: AsyncJobManager, subagentId: string, ownerId: string): string {
+	return manager.register(
+		"task",
+		subagentId,
+		async ({ signal }) => {
+			await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+			throw new Error("cancelled");
+		},
+		{
+			id: `job-${subagentId}`,
+			ownerId,
+			metadata: { subagent: { id: subagentId, agent: "executor", agentSource: "bundled" } },
+		},
+	);
+}
 
 function getText(result: { content: Array<{ type: string; text?: string }> }): string {
 	return result.content.find(part => part.type === "text")?.text ?? "";
@@ -349,16 +364,17 @@ describe("SubagentTool", () => {
 		const manager = createManager();
 		const tool = new SubagentTool(createSession());
 		let pauseRequested = false;
+		const pauseJobId = registerRunningAttempt(manager, "0-Pause", "0-Main");
 		manager.registerSubagentRecord({
 			subagentId: "0-Pause",
 			ownerId: "0-Main",
-			currentJobId: null,
+			currentJobId: pauseJobId,
 			historicalJobIds: [],
 			status: "running",
 			sessionFile: "/tmp/0-Pause.jsonl",
 			resumable: true,
 		});
-		manager.registerLiveHandle("0-Pause", {
+		manager.registerLiveHandle("0-Pause", pauseJobId, {
 			requestPause() {
 				pauseRequested = true;
 			},
@@ -447,16 +463,17 @@ describe("SubagentTool", () => {
 		let injected: string | undefined;
 		let injectedFrom: string | undefined;
 		let pauseRequested = false;
+		const steerJobId = registerRunningAttempt(manager, "0-Steer", "0-Main");
 		manager.registerSubagentRecord({
 			subagentId: "0-Steer",
 			ownerId: "0-Main",
-			currentJobId: null,
+			currentJobId: steerJobId,
 			historicalJobIds: [],
 			status: "running",
 			sessionFile: "/tmp/0-Steer.jsonl",
 			resumable: true,
 		});
-		manager.registerLiveHandle("0-Steer", {
+		manager.registerLiveHandle("0-Steer", steerJobId, {
 			requestPause() {
 				pauseRequested = true;
 			},
@@ -493,16 +510,17 @@ describe("SubagentTool", () => {
 		const manager = createManager();
 		const tool = new SubagentTool(createSession("1-Parent"));
 		let injectedFrom: string | undefined;
+		const childJobId = registerRunningAttempt(manager, "2-Child", "1-Parent");
 		manager.registerSubagentRecord({
 			subagentId: "2-Child",
 			ownerId: "1-Parent",
-			currentJobId: null,
+			currentJobId: childJobId,
 			historicalJobIds: [],
 			status: "running",
 			sessionFile: "/tmp/2-Child.jsonl",
 			resumable: true,
 		});
-		manager.registerLiveHandle("2-Child", {
+		manager.registerLiveHandle("2-Child", childJobId, {
 			requestPause() {},
 			async injectMessage(_content, _deliverAs, opts) {
 				injectedFrom = opts?.fromAgentId;
@@ -525,17 +543,23 @@ describe("SubagentTool", () => {
 		const manager = createManager();
 		const tool = new SubagentTool(createSession());
 		const injected: string[] = [];
+		const attemptJobIds = new Map(
+			["0-SteerA", "0-SteerB"].map(subagentId => [
+				subagentId,
+				registerRunningAttempt(manager, subagentId, "0-Main"),
+			]),
+		);
 		for (const subagentId of ["0-SteerA", "0-SteerB"]) {
 			manager.registerSubagentRecord({
 				subagentId,
 				ownerId: "0-Main",
-				currentJobId: null,
+				currentJobId: attemptJobIds.get(subagentId)!,
 				historicalJobIds: [],
 				status: "running",
 				sessionFile: `/tmp/${subagentId}.jsonl`,
 				resumable: true,
 			});
-			manager.registerLiveHandle(subagentId, {
+			manager.registerLiveHandle(subagentId, attemptJobIds.get(subagentId)!, {
 				requestPause() {},
 				async injectMessage(content) {
 					injected.push(`${subagentId}:${content}`);


### PR DESCRIPTION
Refile for the review that closed #2558 (and its predecessor #2276), targeting current `dev`. This drops the presentation-phase approach entirely and implements what the closing review asked for: “attempt-scoped registration/removal/progress and manager-owned compare-and-act control barriers.”

## The five blockers → remediation

**1. Current-attempt identity absent from live side channels.** Live handles and progress are now stored as `{ jobId, … }` entries and the APIs carry the attempt's backing job id: `registerLiveHandle(subagentId, attemptJobId, handle): boolean`, `removeLiveHandle(subagentId, attemptJobId)`, `recordSubagentProgress(subagentId, attemptJobId, progress)`. Registration is accepted only when the canonical record's `currentJobId` matches the attempt, the record is `running`, and the backing job is `running`. Removal and progress writes are conditional on the same attempt; `getSubagentProgress` returns progress only when its jobId still equals `record.currentJobId`. Production callers (`task/executor.ts`, `task/index.ts`) thread the real jobId from the `register()` run callback — no caller passes a bare subagentId anymore.

**2. Handle-before-record startup ordering.** `register()` now inserts the job into the job table (and fires the change notification) **before** starting the async runner, and the attempt-scoped registration gate rejects any registration that arrives before its canonical record/attempt binding exists — the ordering is fenced, not raced.

**3. Cancellation not authoritative before settle.** `cancel()` marks the canonical record terminal immediately (running-job path), so the side channels are closed the moment cancellation is requested: a startup callback that fires in the cancel→settle interval has its registration rejected (`false`) and `hasLiveSubagent` stays false. Runner settle re-marks terminally — idempotent.

**4. Control dispatch not compare-and-act fenced.** New manager-owned `steerSubagent(subagentId, message, { filter, pause, fromAgentId })` → `"delivered" | "no-live-handle" | "superseded" | "not-running"`. It captures the attempt before `injectMessage` and re-validates record existence, running status, and the captured attempt after injection; on supersession the pause is never applied to the new attempt. `SubagentTool` steering delegates to it and surfaces explicit errors per outcome; it no longer touches `getLiveHandle`.

**5. Legacy liveness fallback.** `hasLiveSubagent` is now exactly: running canonical record ∧ live handle registered for the current attempt. The raw-handle / running-backing-job fallback is deleted. `getLiveHandle` validates the current attempt and has no production callers left.

## Compatibility

- Public `SubagentLifecycle` union unchanged (`running|paused|queued|completed|failed|cancelled`) — the #2276 blocker is not reintroduced; no exported status/phase members were added.
- `resumeSubagent` clears prior-attempt handles and progress before the new attempt registers, so a resumed subagent can never expose prior-attempt control or progress.
- Existing subagent suites were updated to register current-attempt handles explicitly where live rendering is expected — that is the new contract, not a test accommodation.

## Tests

New `test/async/subagent-attempt-scope.test.ts`:
- stale-attempt `registerLiveHandle`/`removeLiveHandle`/`recordSubagentProgress` after a resume swaps `currentJobId` — rejected/ignored; current attempt retained
- `cancel()` → late startup registration rejected; no liveness inferred from the running backing job
- steer supersession: the captured attempt's `injectMessage` cancels + resumes + registers the new attempt's handle mid-dispatch → result `"superseded"`, the new attempt is **not** paused

All three fail on unmodified `dev`. Focused suites at this head: `subagent-attempt-scope` + `subagent-live-progress` + `subagent` + `subagent-render` + `job-manager-bounds` + `job-manager-redteam` + `job-manager-resume-queue` — **86 pass / 0 fail (365 expects)**. Full package gate `bun run check` (biome + hotkeys-docs + SDK canonicalization + `tsc --noEmit`) clean.