### PR TITLE
fix(ai): survive OAuth refresh-token rotation races across processes

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -459,6 +459,16 @@ const DEFAULT_OAUTH_REFRESH_TIMEOUT_MS = 10_000;
  */
 const OAUTH_REFRESH_SKEW_MS = 60_000;
 /**
+ * When an OAuth refresh fails with a definitive auth error, the stored row is
+ * re-read before disabling it: a peer process that just rotated the token may
+ * not have persisted its success yet (its success write trails our failure by
+ * the token endpoint's round-trip). Poll a few times with a short delay so an
+ * in-flight peer rotation gets a chance to land before we conclude the stored
+ * refresh token is genuinely dead.
+ */
+const OAUTH_ROTATION_RECHECK_ATTEMPTS = 3;
+const OAUTH_ROTATION_RECHECK_DELAY_MS = 150;
+/**
  * Cap on the buffered credential_disabled backlog held while no handler is attached.
  * In practice the backlog is 0–N where N ≈ active providers (≤ ~20). The cap exists so
  * pathological detach-without-reattach loops can't grow memory unboundedly.
@@ -3001,12 +3011,36 @@ export class AuthStorage {
 		credentialId: number | undefined,
 		signal?: AbortSignal,
 	): Promise<OAuthCredentials> {
+		// Adopt a peer rotation before burning a refresh: providers with rotating
+		// refresh tokens (e.g. Anthropic) invalidate the previous refresh token on
+		// use, so firing the network refresh with a token another process already
+		// rotated is guaranteed to fail with invalid_grant. Re-read the persisted
+		// row and prefer it over our in-memory snapshot. The broker/override path
+		// below is exempt: the broker server is the single refresh authority and
+		// resolves the credential by id on its side.
 		let refreshPromise: Promise<OAuthCredentials>;
 		// Caller override > store-level hook > local per-provider refresh.
 		// `RemoteAuthCredentialStore` exposes the hook so a broker-backed gateway
 		// routes refresh through the broker without explicit wiring.
 		const storeRefresh = this.#store.refreshOAuthCredential?.bind(this.#store);
 		const overrideRefresh = this.#refreshOAuthCredentialOverride ?? storeRefresh;
+		if (!overrideRefresh && credentialId !== undefined) {
+			try {
+				const latest = this.#store.listAuthCredentials(provider).find(row => row.id === credentialId)?.credential;
+				if (latest?.type === "oauth" && latest.refresh !== credential.refresh) {
+					logger.debug("OAuth refresh adopting peer-rotated credential instead of stale snapshot", {
+						provider,
+						credentialId,
+					});
+					if (Date.now() + OAUTH_REFRESH_SKEW_MS < latest.expires) {
+						return latest;
+					}
+					credential = latest;
+				}
+			} catch {
+				// Best-effort re-read; fall through to refreshing with the snapshot.
+			}
+		}
 		if (overrideRefresh && credentialId !== undefined) {
 			refreshPromise = overrideRefresh(provider, credentialId, credential, signal);
 		} else {
@@ -3222,19 +3256,25 @@ export class AuthStorage {
 				// Re-read the row from disk before marking it disabled — if the persisted
 				// refresh token has changed, the peer rotation succeeded and we should pick
 				// up the new credential instead of soft-deleting the row that the peer just
-				// updated.
+				// updated. The peer's success write can trail our failure by its token
+				// endpoint round-trip, so poll briefly instead of reading once.
 				const credentialId = this.#getStoredCredentials(provider)[selection.index]?.id;
 				if (credentialId !== undefined) {
-					const latestRow = this.#store.listAuthCredentials(provider).find(row => row.id === credentialId);
-					const latestCredential = latestRow?.credential;
-					if (latestCredential?.type === "oauth" && latestCredential.refresh !== selection.credential.refresh) {
-						logger.debug("OAuth refresh race detected; another process rotated token first", {
-							provider,
-							index: selection.index,
-							credentialId,
-						});
-						await this.reload();
-						return this.#resolveOAuthSelection(provider, sessionId, options);
+					for (let attempt = 0; attempt < OAUTH_ROTATION_RECHECK_ATTEMPTS; attempt++) {
+						if (attempt > 0) {
+							await new Promise(resolve => setTimeout(resolve, OAUTH_ROTATION_RECHECK_DELAY_MS));
+						}
+						const latestRow = this.#store.listAuthCredentials(provider).find(row => row.id === credentialId);
+						const latestCredential = latestRow?.credential;
+						if (latestCredential?.type === "oauth" && latestCredential.refresh !== selection.credential.refresh) {
+							logger.debug("OAuth refresh race detected; another process rotated token first", {
+								provider,
+								index: selection.index,
+								credentialId,
+							});
+							await this.reload();
+							return this.#resolveOAuthSelection(provider, sessionId, options);
+						}
 					}
 				}
 				// Permanently disable invalid credentials with an explicit cause for inspection/debugging.
@@ -3866,6 +3906,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#listDisabledByProviderStmt: Statement;
 	#insertStmt: Statement;
 	#updateStmt: Statement;
+	#updateReviveStmt: Statement;
 	#deleteStmt: Statement;
 	#deleteIfMatchesStmt: Statement;
 	#deleteByProviderStmt: Statement;
@@ -3895,6 +3936,16 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		);
 		this.#updateStmt = this.#db.prepare(
 			`UPDATE auth_credentials SET credential_type = ?, data = ?, identity_key = ?, updated_at = ${SQLITE_NOW_EPOCH} WHERE id = ?`,
+		);
+		// Persisting a successful OAuth refresh is proof-of-life: the rotated
+		// token is the only valid one from now on. If a racing peer lost the
+		// rotation and CAS-disabled this row with a refresh-failure cause in the
+		// window before our success write landed, un-disable it — otherwise the
+		// freshly-rotated (only valid) token stays trapped in a soft-deleted row
+		// and every process is signed out until a manual re-login. Rows disabled
+		// for any other reason (e.g. "deleted by user") are never revived.
+		this.#updateReviveStmt = this.#db.prepare(
+			`UPDATE auth_credentials SET credential_type = ?, data = ?, identity_key = ?, updated_at = ${SQLITE_NOW_EPOCH}, disabled_cause = CASE WHEN disabled_cause LIKE 'oauth refresh failed%' THEN NULL ELSE disabled_cause END WHERE id = ?`,
 		);
 		this.#deleteStmt = this.#db.prepare(
 			`UPDATE auth_credentials SET disabled_cause = ?, updated_at = ${SQLITE_NOW_EPOCH} WHERE id = ?`,
@@ -4375,7 +4426,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			const provider = providerRow?.provider ?? "";
 			const serialized = serializeCredential(provider, credential);
 			if (!serialized) return;
-			this.#updateStmt.run(serialized.credentialType, serialized.data, serialized.identityKey, id);
+			this.#updateReviveStmt.run(serialized.credentialType, serialized.data, serialized.identityKey, id);
 			if (provider) {
 				this.#purgeSupersededDisabledRows(provider, this.listAuthCredentials(provider));
 			}
@@ -4525,6 +4576,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		this.#listDisabledByProviderStmt.finalize();
 		this.#insertStmt.finalize();
 		this.#updateStmt.finalize();
+		this.#updateReviveStmt.finalize();
 		this.#deleteStmt.finalize();
 		this.#deleteIfMatchesStmt.finalize();
 		this.#deleteByProviderStmt.finalize();

--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -327,4 +327,203 @@ describe("AuthStorage OAuth refresh race", () => {
 		const retryKey = await authStorage.getApiKey("unit-oauth-rotation", sessionId);
 		expect(retryKey).toBe("access-b");
 	});
+
+	test("adopts a peer-rotated credential without firing a doomed refresh", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		const refreshedExpires = Date.now() + 60 * 60_000;
+		let staleRefreshCalls = 0;
+		oauthUtils.registerOAuthProvider({
+			id: "unit-oauth-adopt",
+			name: "Unit OAuth Adopt",
+			sourceId: "auth-storage-oauth-refresh-race-test",
+			async login() {
+				return { access: "unused", refresh: "unused", expires: refreshedExpires };
+			},
+			async refreshToken(credentials) {
+				if (credentials.refresh === "stale-refresh") {
+					staleRefreshCalls += 1;
+					throw new Error('invalid_grant {"error":"invalid_grant"}');
+				}
+				return { ...credentials, expires: refreshedExpires };
+			},
+			getApiKey(credentials) {
+				return credentials.access;
+			},
+		});
+
+		await authStorage.set("unit-oauth-adopt", [
+			{ type: "oauth", access: "stale-access", refresh: "stale-refresh", expires: Date.now() - 60_000 },
+		]);
+		const credentialId = store.listAuthCredentials("unit-oauth-adopt")[0]!.id;
+
+		// Peer rotated the row after we loaded our snapshot but before we needed a
+		// refresh. The pre-refresh re-read must adopt the persisted rotation and
+		// never burn the (already-invalidated) stale refresh token on the network.
+		store.updateAuthCredential(credentialId, {
+			type: "oauth",
+			access: "fresh-access-from-peer",
+			refresh: "fresh-refresh-from-peer",
+			expires: Date.now() + 60 * 60_000,
+		});
+
+		const apiKey = await authStorage.getApiKey("unit-oauth-adopt", "session-adopt");
+		expect(apiKey).toBe("fresh-access-from-peer");
+		expect(staleRefreshCalls).toBe(0);
+		expect(events).toHaveLength(0);
+	});
+
+	test("recovers when the peer's rotation persists shortly after our refresh failure", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		oauthUtils.registerOAuthProvider({
+			id: "unit-oauth-late-peer",
+			name: "Unit OAuth Late Peer",
+			sourceId: "auth-storage-oauth-refresh-race-test",
+			async login() {
+				return { access: "unused", refresh: "unused", expires: Date.now() + 60 * 60_000 };
+			},
+			async refreshToken(credentials) {
+				if (credentials.refresh === "stale-refresh") {
+					throw new Error('invalid_grant {"error":"invalid_grant"}');
+				}
+				return { ...credentials, expires: Date.now() + 60 * 60_000 };
+			},
+			getApiKey(credentials) {
+				return credentials.access;
+			},
+		});
+
+		await authStorage.set("unit-oauth-late-peer", [
+			{ type: "oauth", access: "stale-access", refresh: "stale-refresh", expires: Date.now() - 60_000 },
+		]);
+		const sharedStore = store;
+		const credentialId = sharedStore.listAuthCredentials("unit-oauth-late-peer")[0]!.id;
+
+		// The peer that won the rotation persists its success ~100ms after our
+		// refresh fails: its success write trails the token endpoint round-trip.
+		// The delayed re-check must observe it instead of disabling the row.
+		const peerPersist = setTimeout(() => {
+			sharedStore.updateAuthCredential(credentialId, {
+				type: "oauth",
+				access: "fresh-access-from-peer",
+				refresh: "fresh-refresh-from-peer",
+				expires: Date.now() + 60 * 60_000,
+			});
+		}, 100);
+
+		try {
+			const apiKey = await authStorage.getApiKey("unit-oauth-late-peer", "session-late-peer");
+			expect(apiKey).toBe("fresh-access-from-peer");
+			expect(events).toHaveLength(0);
+
+			const stored = sharedStore.listAuthCredentials("unit-oauth-late-peer");
+			expect(stored).toHaveLength(1);
+			expect(stored[0]?.credential.type).toBe("oauth");
+			if (stored[0]?.credential.type === "oauth") {
+				expect(stored[0].credential.refresh).toBe("fresh-refresh-from-peer");
+			}
+		} finally {
+			clearTimeout(peerPersist);
+		}
+	});
+
+	test("winner's rotation revives a row a racing loser disabled mid-flight", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		const refreshStarted = Promise.withResolvers<void>();
+		const allowRefresh = Promise.withResolvers<void>();
+		oauthUtils.registerOAuthProvider({
+			id: "unit-oauth-revive",
+			name: "Unit OAuth Revive",
+			sourceId: "auth-storage-oauth-refresh-race-test",
+			async login() {
+				return { access: "unused", refresh: "unused", expires: Date.now() + 60 * 60_000 };
+			},
+			async refreshToken(credentials) {
+				refreshStarted.resolve();
+				await allowRefresh.promise;
+				return {
+					...credentials,
+					access: "access-rotated",
+					refresh: "refresh-rotated",
+					expires: Date.now() + 60 * 60_000,
+				};
+			},
+			getApiKey(credentials) {
+				return credentials.access;
+			},
+		});
+
+		await authStorage.set("unit-oauth-revive", [
+			{ type: "oauth", access: "access-old", refresh: "refresh-old", expires: Date.now() - 60_000 },
+		]);
+		const credentialId = store.listAuthCredentials("unit-oauth-revive")[0]!.id;
+
+		// We are the winner: the provider has already rotated the token (our
+		// refresh call is in flight). A racing loser that still held the previous
+		// token hits invalid_grant and CAS-disables the row before our success
+		// write lands. Without revival the only-valid rotated token would be
+		// trapped in a soft-deleted row and every process would be signed out.
+		const pending = authStorage.getApiKey("unit-oauth-revive", "session-revive");
+		await refreshStarted.promise;
+		store.deleteAuthCredential(credentialId, "oauth refresh failed: invalid_grant (racing loser)");
+		expect(store.listAuthCredentials("unit-oauth-revive")).toHaveLength(0);
+		allowRefresh.resolve();
+
+		const apiKey = await pending;
+		expect(apiKey).toBe("access-rotated");
+
+		const stored = store.listAuthCredentials("unit-oauth-revive");
+		expect(stored).toHaveLength(1);
+		expect(stored[0]?.id).toBe(credentialId);
+		expect(stored[0]?.credential.type).toBe("oauth");
+		if (stored[0]?.credential.type === "oauth") {
+			expect(stored[0].credential.access).toBe("access-rotated");
+			expect(stored[0].credential.refresh).toBe("refresh-rotated");
+		}
+	});
+
+	test("winner's rotation does not revive a row the user deleted mid-flight", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		const refreshStarted = Promise.withResolvers<void>();
+		const allowRefresh = Promise.withResolvers<void>();
+		oauthUtils.registerOAuthProvider({
+			id: "unit-oauth-no-revive",
+			name: "Unit OAuth No Revive",
+			sourceId: "auth-storage-oauth-refresh-race-test",
+			async login() {
+				return { access: "unused", refresh: "unused", expires: Date.now() + 60 * 60_000 };
+			},
+			async refreshToken(credentials) {
+				refreshStarted.resolve();
+				await allowRefresh.promise;
+				return {
+					...credentials,
+					access: "access-rotated",
+					refresh: "refresh-rotated",
+					expires: Date.now() + 60 * 60_000,
+				};
+			},
+			getApiKey(credentials) {
+				return credentials.access;
+			},
+		});
+
+		await authStorage.set("unit-oauth-no-revive", [
+			{ type: "oauth", access: "access-old", refresh: "refresh-old", expires: Date.now() - 60_000 },
+		]);
+		const credentialId = store.listAuthCredentials("unit-oauth-no-revive")[0]!.id;
+
+		// Only refresh-failure disables are revived; an explicit user deletion
+		// that lands while a refresh is in flight must stay deleted.
+		const pending = authStorage.getApiKey("unit-oauth-no-revive", "session-no-revive");
+		await refreshStarted.promise;
+		store.deleteAuthCredential(credentialId, "deleted by user");
+		allowRefresh.resolve();
+		await pending;
+
+		expect(store.listAuthCredentials("unit-oauth-no-revive")).toHaveLength(0);
+	});
 });


### PR DESCRIPTION
Retarget of #2604 (closed — was opened against `main`). Same fix, rebased onto current `dev` (`02c93b74`); cherry-pick applied cleanly and all tests re-verified on the `dev` base.

## Problem

With several `gjc` processes sharing `~/.gjc/agent/agent.db` (multiple TUIs, subagents, embedding hosts), providers that rotate refresh tokens on every use (Anthropic, xAI, Kimi) end up in a mass sign-out that only a manual re-login fixes. Observed in the field as day-long `invalid_grant: "Refresh token not found or invalid"` storms with repeated `OAuth refresh race detected; another process rotated token first` log entries, and credentials soft-deleted with `disabled_cause = 'oauth refresh failed: …'`.

### Root cause — a TOCTOU the existing defenses don't cover

The failure path already re-reads the row and uses a CAS disable (great!), but the fatal interleaving slips between them:

1. P1 and P2 both hold refresh token **R1** in memory.
2. P1 fires the network refresh; the provider rotates **R1 → R2** (R1 is now dead) while P1's response is still in flight.
3. P2 refreshes with R1 → `invalid_grant`. Its re-read still sees **R1** on disk (P1 hasn't persisted yet) → race not detected → **CAS disable succeeds** (row still matches R1).
4. P1's response lands → `updateAuthCredential(id, R2)` writes the only-valid token **into the now-disabled row** — `#updateStmt` never touches `disabled_cause`.

The freshly-rotated token is trapped in a soft-deleted row; every process is signed out. There is no self-healing: only re-login recovers.

## Fix (3 targeted changes in `packages/ai/src/auth-storage.ts`)

1. **Pre-refresh adoption** — `#refreshOAuthCredentialUnshared` re-reads the persisted row before firing a network refresh and adopts a peer-rotated credential instead of burning an already-invalidated refresh token. (Broker/override path exempt: the broker server is already the single refresh authority.)
2. **Delayed re-check before disable** — the definitive-failure path now polls the row 3× over ~300 ms instead of reading once, giving the winner's success write (which trails its token-endpoint round-trip) time to land.
3. **Proof-of-life revival** — persisting a successful refresh un-disables a row that a racing loser disabled with an `oauth refresh failed%` cause (new `#updateReviveStmt`). Rows disabled for any other reason (e.g. `deleted by user`) are never revived, so explicit user deletions stay deleted even mid-flight.

(1) and (2) shrink the race window; (3) makes the system self-healing if the window is still hit — the winner's write now resurrects the row, so the worst case is a transient failure instead of a terminal sign-out.

## Tests

4 new tests in `test/auth-storage-oauth-refresh-race.test.ts`:

- `adopts a peer-rotated credential without firing a doomed refresh` — asserts the stale refresh token is never sent to the network (fails on unmodified base: 2 doomed calls)
- `recovers when the peer's rotation persists shortly after our refresh failure` — peer persists 100 ms after our `invalid_grant` (fails on unmodified base: credential disabled, apiKey undefined)
- `winner's rotation revives a row a racing loser disabled mid-flight` — the terminal interleaving above (fails on unmodified base: row stays soft-deleted)
- `winner's rotation does not revive a row the user deleted mid-flight` — guard for the revival scope

Verified on this `dev`-based branch:

- `bun test test/auth-storage-oauth-refresh-race.test.ts`: **10/10 pass**
- Full `packages/ai` suite: **1812 pass / 337 skip / 1 fail** — the failing `provider-credential-error.test.ts` case fails identically on unmodified `dev` (`02c93b74`) in this environment (pre-existing, unrelated; verified by re-running that file with the fix reverted)
- `tsc --noEmit` and `biome check` clean

## Notes

- `RemoteAuthCredentialStore` is intentionally unchanged: broker-backed clients route refresh through the broker server, which serializes refreshes in one process and hits the fixed SQLite path.
- The disable-cause prefix (`oauth refresh failed`) is the exact string the failure path writes; `normalizeDisabledCause` only trims, so the `LIKE` match is stable.
