### PR TITLE
fix(coding-agent): recover malformed global settings

### DIFF
--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -829,6 +829,15 @@ export class Settings implements NotificationSettingsReader {
 			}
 		}
 		await this.#refreshDurableSettings();
+		if (this.#modified.size > 0 && !this.#pendingSaveSlot) {
+			this.#queueSave();
+			this.#releasePendingSaveSlot();
+			try {
+				await this.#savePromise;
+			} catch {
+				// Keep dirty state for a later explicit flush or mutation.
+			}
+		}
 	}
 
 	/** Like {@link flush}, but reports a durable save failure to the caller. */
@@ -836,8 +845,20 @@ export class Settings implements NotificationSettingsReader {
 		this.#releasePendingSaveSlot();
 		if (this.#modified.size > 0 && !this.#pendingSaveSlot) this.#queueSave();
 		this.#releasePendingSaveSlot();
-		await this.#savePromise;
+		let saveError: unknown;
+		try {
+			await this.#savePromise;
+		} catch (error) {
+			saveError = error;
+		}
 		await this.#refreshDurableSettings();
+		if (this.#modified.size > 0 && !this.#pendingSaveSlot) {
+			this.#queueSave();
+			this.#releasePendingSaveSlot();
+			await this.#savePromise;
+			return;
+		}
+		if (saveError !== undefined) throw saveError;
 	}
 
 	async cloneForCwd(cwd: string): Promise<Settings> {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -524,6 +524,11 @@ export class Settings implements NotificationSettingsReader {
 		return structuredClone(this.#schemaReport);
 	}
 
+	/** Whether durable settings mutations are permitted for the loaded configuration. */
+	canWriteDurableConfig(): boolean {
+		return !this.#persist || !this.#hasRecoveredConfigSyntax;
+	}
+
 	/**
 	 * Set a setting value (sync).
 	 * Updates global settings and reserves its background persistence slot before
@@ -846,8 +851,13 @@ export class Settings implements NotificationSettingsReader {
 			inMemory: !this.#persist,
 		});
 		cloned.#storage = this.#storage;
+		cloned.#schemaReport = structuredClone(this.#schemaReport);
+		cloned.#schemaMigrationPending = this.#schemaMigrationPending;
 		cloned.#futureSchemaVersion = this.#futureSchemaVersion;
-
+		cloned.#hasMalformedConfigRoot = this.#hasMalformedConfigRoot;
+		cloned.#hasRecoveredConfigSyntax = this.#hasRecoveredConfigSyntax;
+		cloned.#hasInvalidNotificationConfiguration = this.#hasInvalidNotificationConfiguration;
+		cloned.#notificationValidationGeneration = this.#notificationValidationGeneration;
 		cloned.#global = structuredClone(this.#global);
 		cloned.#rawNotificationConfig = structuredClone(this.#rawNotificationConfig);
 		cloned.#durableRawNotificationConfig = structuredClone(this.#durableRawNotificationConfig);
@@ -1080,21 +1090,29 @@ export class Settings implements NotificationSettingsReader {
 		}
 	}
 
-	async #loadYaml(filePath: string): Promise<RawSettings> {
+	#resetYamlLoadState(): void {
 		this.#hasMalformedConfigRoot = false;
 		this.#hasRecoveredConfigSyntax = false;
 		this.#hasInvalidNotificationConfiguration = false;
+		this.#schemaReport = { issues: [], valid: true };
+		this.#schemaMigrationPending = false;
+		this.#futureSchemaVersion = false;
 		this.#captureRawNotificationConfig({});
+	}
+
+	async #loadYaml(filePath: string): Promise<RawSettings> {
 		let content: string;
 		try {
 			content = await Bun.file(filePath).text();
 		} catch (error) {
 			if (isEnoent(error)) {
-				this.#captureRawNotificationConfig({});
+				this.#resetYamlLoadState();
 				return {};
 			}
 			throw error;
 		}
+		this.#resetYamlLoadState();
+		if (content.trim() === "") return {};
 		let parsed: unknown;
 		try {
 			parsed = YAML.parse(content);
@@ -1752,7 +1770,7 @@ export class Settings implements NotificationSettingsReader {
 		this.#replaceGlobalWithDurable(current);
 	}
 	#assertDurableConfigWritable(): void {
-		if (!this.#persist || !this.#hasRecoveredConfigSyntax) return;
+		if (this.canWriteDurableConfig()) return;
 		throw new Error(
 			"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
 		);

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1014,7 +1014,9 @@ export class Settings implements NotificationSettingsReader {
 		this.#global = current;
 		for (const patch of this.#pendingPatchesInGenerationOrder()) {
 			applySettingsPatch(this.#global, { ...patch, value: structuredClone(patch.value) });
-			this.#applyNotificationMutationToRaw(patch.path, patch.value);
+			if (this.#rawNotificationConfig !== undefined) {
+				this.#applyNotificationMutationToRaw(patch.path, patch.value);
+			}
 		}
 		this.#rebuildMerged();
 		this.#recomputeNotificationValidationFromRaw();

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -373,6 +373,8 @@ export class Settings implements NotificationSettingsReader {
 	/** A newer config schema must never be rewritten by legacy migrations. */
 	#futureSchemaVersion = false;
 	#hasMalformedConfigRoot = false;
+	/** YAML syntax was unrecoverable, so the loaded defaults are read-only until config.yml is repaired. */
+	#hasRecoveredConfigSyntax = false;
 	#hasInvalidNotificationConfiguration = false;
 	#notificationValidationGeneration = 0;
 	/** Notification subtree fingerprint from the last raw durable config read. */
@@ -532,6 +534,7 @@ export class Settings implements NotificationSettingsReader {
 			this.unset(path);
 			return;
 		}
+		this.#assertDurableConfigWritable();
 		this.#set(path, value, true);
 	}
 
@@ -562,6 +565,7 @@ export class Settings implements NotificationSettingsReader {
 	 * `undefined` value. Defaults/project settings become visible immediately.
 	 */
 	unset<P extends SettingPath>(path: P): void {
+		this.#assertDurableConfigWritable();
 		const prev = this.get(path);
 		const patch: SettingsPatch = {
 			path,
@@ -586,6 +590,7 @@ export class Settings implements NotificationSettingsReader {
 	 * {@link set}, canonical state and hooks change only after the rename succeeds.
 	 */
 	async commitAtomicBatch(patches: readonly SettingsAtomicPatch[]): Promise<CasReceipt> {
+		this.#assertDurableConfigWritable();
 		if (!this.#persist || !this.#configPath) {
 			const notificationValidationGuard = this.#notificationValidationRestoreGuard();
 			const changes = new Map<string, { before: unknown; beforeHash: string; afterHash: string }>();
@@ -714,6 +719,7 @@ export class Settings implements NotificationSettingsReader {
 			current: Readonly<RawSettings>,
 		) => Promise<readonly SettingsAtomicPatch[]> | readonly SettingsAtomicPatch[],
 	): Promise<CasReceipt> {
+		this.#assertDurableConfigWritable();
 		if (!this.#persist || !this.#configPath) {
 			const patches = await buildPatches(structuredClone(this.#global));
 			return this.commitAtomicBatch(patches);
@@ -940,6 +946,7 @@ export class Settings implements NotificationSettingsReader {
 	}
 
 	setGlobalModelRole(role: ModelRole | string, modelId: ModelSelectorValue | undefined): void {
+		this.#assertDurableConfigWritable();
 		const revision = ++this.#nextRevision;
 		const patch: SettingsPatch = {
 			path: "modelRoles",
@@ -1075,6 +1082,7 @@ export class Settings implements NotificationSettingsReader {
 
 	async #loadYaml(filePath: string): Promise<RawSettings> {
 		this.#hasMalformedConfigRoot = false;
+		this.#hasRecoveredConfigSyntax = false;
 		this.#hasInvalidNotificationConfiguration = false;
 		this.#captureRawNotificationConfig({});
 		let content: string;
@@ -1091,13 +1099,34 @@ export class Settings implements NotificationSettingsReader {
 		try {
 			parsed = YAML.parse(content);
 		} catch {
+			this.#hasRecoveredConfigSyntax = true;
 			this.#hasMalformedConfigRoot = true;
+			this.#schemaReport = {
+				valid: false,
+				issues: [
+					{
+						path: "config.yml",
+						kind: "invalid",
+						detail: "Configuration YAML syntax is invalid; repair config.yml before changing settings.",
+					},
+				],
+			};
 			this.#captureRawNotificationConfig(undefined);
 			return {};
 		}
 		if (parsed === undefined) return {};
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
 			this.#hasMalformedConfigRoot = true;
+			this.#schemaReport = {
+				valid: false,
+				issues: [
+					{
+						path: "config.yml",
+						kind: "invalid",
+						detail: "Configuration root must be a YAML mapping.",
+					},
+				],
+			};
 			this.#captureRawNotificationConfig(undefined);
 			return {};
 		}
@@ -1526,7 +1555,7 @@ export class Settings implements NotificationSettingsReader {
 	// ─────────────────────────────────────────────────────────────────────────
 
 	#queueSave(): void {
-		if (!this.#persist || !this.#configPath) return;
+		if (!this.#persist || !this.#configPath || this.#hasRecoveredConfigSyntax) return;
 
 		const currentSlot = this.#pendingSaveSlot;
 		if (currentSlot && !currentSlot.captured && !currentSlot.released) {
@@ -1721,6 +1750,12 @@ export class Settings implements NotificationSettingsReader {
 		const current = await this.#loadYaml(this.#configPath);
 		if (previousFingerprint !== this.#durableNotificationFingerprint) this.#notificationValidationGeneration++;
 		this.#replaceGlobalWithDurable(current);
+	}
+	#assertDurableConfigWritable(): void {
+		if (!this.#persist || !this.#hasRecoveredConfigSyntax) return;
+		throw new Error(
+			"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+		);
 	}
 
 	// ─────────────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1077,49 +1077,9 @@ export class Settings implements NotificationSettingsReader {
 		this.#hasMalformedConfigRoot = false;
 		this.#hasInvalidNotificationConfiguration = false;
 		this.#captureRawNotificationConfig({});
+		let content: string;
 		try {
-			const content = await Bun.file(filePath).text();
-			const parsed = YAML.parse(content);
-			if (parsed === undefined) return {};
-			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-				this.#hasMalformedConfigRoot = true;
-				this.#captureRawNotificationConfig(undefined);
-				return {};
-			}
-			const parsedRaw = parsed as RawSettings;
-			if (filePath === this.#configPath) this.#captureRawNotificationConfig(parsedRaw);
-			if (filePath === this.#configPath) {
-				try {
-					parseNotificationSettingsSnapshot(parsedRaw);
-				} catch (error) {
-					if (!(error instanceof Error) || error.message !== "gjc_notify_daemon_invalid_configuration")
-						throw error;
-					this.#hasInvalidNotificationConfiguration = true;
-				}
-			}
-			this.#futureSchemaVersion =
-				filePath === this.#configPath &&
-				typeof parsedRaw.configSchemaVersion === "number" &&
-				parsedRaw.configSchemaVersion > CONFIG_SCHEMA_VERSION;
-
-			const configSchemaVersion = parsedRaw.configSchemaVersion;
-			if (
-				filePath === this.#configPath &&
-				(typeof configSchemaVersion !== "number" || configSchemaVersion < CONFIG_SCHEMA_VERSION)
-			) {
-				this.#schemaMigrationPending = true;
-			}
-			const migrated = this.#migrateRawSettings(parsedRaw);
-			const reconciled = reconcileSettingsSchema(migrated);
-			if (typeof configSchemaVersion === "number" && configSchemaVersion > CONFIG_SCHEMA_VERSION) {
-				reconciled.report.issues.push({
-					path: "configSchemaVersion",
-					kind: "pending-migration",
-					detail: `Configuration requires schema version ${configSchemaVersion}.`,
-				});
-			}
-			this.#schemaReport = reconciled.report;
-			return reconciled.settings;
+			content = await Bun.file(filePath).text();
 		} catch (error) {
 			if (isEnoent(error)) {
 				this.#captureRawNotificationConfig({});
@@ -1127,6 +1087,53 @@ export class Settings implements NotificationSettingsReader {
 			}
 			throw error;
 		}
+		let parsed: unknown;
+		try {
+			parsed = YAML.parse(content);
+		} catch {
+			this.#hasMalformedConfigRoot = true;
+			this.#captureRawNotificationConfig(undefined);
+			return {};
+		}
+		if (parsed === undefined) return {};
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			this.#hasMalformedConfigRoot = true;
+			this.#captureRawNotificationConfig(undefined);
+			return {};
+		}
+		const parsedRaw = parsed as RawSettings;
+		if (filePath === this.#configPath) this.#captureRawNotificationConfig(parsedRaw);
+		if (filePath === this.#configPath) {
+			try {
+				parseNotificationSettingsSnapshot(parsedRaw);
+			} catch (error) {
+				if (!(error instanceof Error) || error.message !== "gjc_notify_daemon_invalid_configuration") throw error;
+				this.#hasInvalidNotificationConfiguration = true;
+			}
+		}
+		this.#futureSchemaVersion =
+			filePath === this.#configPath &&
+			typeof parsedRaw.configSchemaVersion === "number" &&
+			parsedRaw.configSchemaVersion > CONFIG_SCHEMA_VERSION;
+
+		const configSchemaVersion = parsedRaw.configSchemaVersion;
+		if (
+			filePath === this.#configPath &&
+			(typeof configSchemaVersion !== "number" || configSchemaVersion < CONFIG_SCHEMA_VERSION)
+		) {
+			this.#schemaMigrationPending = true;
+		}
+		const migrated = this.#migrateRawSettings(parsedRaw);
+		const reconciled = reconcileSettingsSchema(migrated);
+		if (typeof configSchemaVersion === "number" && configSchemaVersion > CONFIG_SCHEMA_VERSION) {
+			reconciled.report.issues.push({
+				path: "configSchemaVersion",
+				kind: "pending-migration",
+				detail: `Configuration requires schema version ${configSchemaVersion}.`,
+			});
+		}
+		this.#schemaReport = reconciled.report;
+		return reconciled.settings;
 	}
 
 	async #loadProjectSettings(): Promise<RawSettings> {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -654,7 +654,7 @@ async function promptForkSession(session: SessionInfo): Promise<boolean> {
 	}
 }
 
-async function getChangelogForDisplay(parsed: Args): Promise<string | undefined> {
+export async function getChangelogForDisplay(parsed: Args): Promise<string | undefined> {
 	if (parsed.continue || parsed.resume) {
 		return undefined;
 	}
@@ -666,15 +666,19 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 
 	const lastVersion = settings.get("lastChangelogVersion");
 	if (!lastVersion) {
-		settings.set("lastChangelogVersion", VERSION);
-		await flushChangelogVersion();
+		if (settings.canWriteDurableConfig()) {
+			settings.set("lastChangelogVersion", VERSION);
+			await flushChangelogVersion();
+		}
 		return getInstalledVersionChangelogEntry(entries, VERSION)?.content;
 	}
 
 	if (lastVersion !== VERSION) {
 		const newEntries = getNewEntries(entries, lastVersion);
-		settings.set("lastChangelogVersion", VERSION);
-		await flushChangelogVersion();
+		if (settings.canWriteDurableConfig()) {
+			settings.set("lastChangelogVersion", VERSION);
+			await flushChangelogVersion();
+		}
 		if (newEntries.length > 0) {
 			return newEntries.map(e => e.content).join("\n\n");
 		}

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -235,18 +235,16 @@ function getSavedUsageMode(): UsageMode {
 	return segmentOptions.usage?.mode === "remaining" ? "remaining" : "used";
 }
 
-function setSavedUsageMode(mode: string): StatusLineSegmentOptions {
+function getUsageModeSettings(mode: string): StatusLineSegmentOptions {
 	const normalizedMode: UsageMode = mode === "remaining" ? "remaining" : "used";
 	const segmentOptions = settings.get("statusLine.segmentOptions") as StatusLineSegmentOptions;
-	const nextOptions: StatusLineSegmentOptions = {
+	return {
 		...segmentOptions,
 		usage: {
 			...(segmentOptions.usage ?? {}),
 			mode: normalizedMode,
 		},
 	};
-	settings.set("statusLine.segmentOptions", nextOptions as Record<string, unknown>);
-	return nextOptions;
 }
 
 function statusSegmentLabel(id: StatusLineSegmentId): string {
@@ -613,14 +611,17 @@ class StatusLineCustomEditor extends Container {
 	}
 
 	#save(): void {
-		settings.set("statusLine.preset", "custom");
-		settings.set("statusLine.leftSegments", [...this.#draft.leftSegments]);
-		settings.set("statusLine.rightSegments", [...this.#draft.rightSegments]);
-		settings.set("statusLine.separator", this.#draft.separator);
-		settings.set(
-			"statusLine.segmentOptions",
-			cloneSegmentOptions(this.#draft.segmentOptions) as Record<string, unknown>,
-		);
+		const saved = commitInteractiveSettings(this.callbacks, () => {
+			settings.set("statusLine.preset", "custom");
+			settings.set("statusLine.leftSegments", [...this.#draft.leftSegments]);
+			settings.set("statusLine.rightSegments", [...this.#draft.rightSegments]);
+			settings.set("statusLine.separator", this.#draft.separator);
+			settings.set(
+				"statusLine.segmentOptions",
+				cloneSegmentOptions(this.#draft.segmentOptions) as Record<string, unknown>,
+			);
+		});
+		if (!saved) return;
 		this.callbacks.onChange("statusLine.preset", "custom");
 		this.callbacks.onChange("statusLine.leftSegments", [...this.#draft.leftSegments]);
 		this.callbacks.onChange("statusLine.rightSegments", [...this.#draft.rightSegments]);
@@ -705,8 +706,28 @@ export interface SettingsCallbacks {
 	getStatusLinePreview?: (width?: number) => string;
 	/** Called when plugins change */
 	onPluginsChanged?: () => void;
+	/** Called when an interactive setting cannot be committed. */
+	onError?: (message: string) => void;
 	/** Called when settings panel is closed */
 	onCancel: () => void;
+}
+function commitInteractiveSettings(callbacks: SettingsCallbacks, commit: () => void): boolean {
+	if (!settings.canWriteDurableConfig()) {
+		callbacks.onError?.(
+			"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+		);
+		return false;
+	}
+	try {
+		commit();
+		return true;
+	} catch (error) {
+		if (!settings.canWriteDurableConfig()) {
+			callbacks.onError?.(error instanceof Error ? error.message : String(error));
+			return false;
+		}
+		throw error;
+	}
 }
 
 /**
@@ -996,7 +1017,7 @@ export class SettingsSelectorComponent extends Container {
 					done(accepted ? value : undefined);
 					return;
 				}
-				this.#setSettingValue(def.path, value);
+				if (!commitInteractiveSettings(this.callbacks, () => this.#setSettingValue(def.path, value))) return;
 				this.callbacks.onChange(def.path, value);
 				done(value);
 			},
@@ -1029,7 +1050,7 @@ export class SettingsSelectorComponent extends Container {
 			value => {
 				// Empty string clears the setting; undefined-typed string settings
 				// store "" which the browser.ts expandPath ignores (no-op fallback).
-				this.#setSettingValue(def.path, value);
+				if (!commitInteractiveSettings(this.callbacks, () => this.#setSettingValue(def.path, value))) return;
 				this.callbacks.onChange(def.path, value);
 				wrappedDone(value);
 			},
@@ -1087,7 +1108,15 @@ export class SettingsSelectorComponent extends Container {
 			getSettingsListTheme(),
 			(id, newValue) => {
 				if (id === STATUS_LINE_USAGE_MODE_ID) {
-					const segmentOptions = setSavedUsageMode(newValue);
+					const segmentOptions = getUsageModeSettings(newValue);
+					if (
+						!commitInteractiveSettings(this.callbacks, () => {
+							settings.set("statusLine.segmentOptions", segmentOptions as Record<string, unknown>);
+						})
+					) {
+						this.#refreshCurrentTabItems(defs);
+						return;
+					}
 					this.callbacks.onChange("statusLine.segmentOptions", segmentOptions);
 					if (tabId === "appearance") {
 						this.#triggerStatusLinePreview();
@@ -1103,14 +1132,20 @@ export class SettingsSelectorComponent extends Container {
 
 				if (def.type === "boolean") {
 					const boolValue = newValue === "true";
-					settings.set(path, boolValue as never);
+					if (!commitInteractiveSettings(this.callbacks, () => settings.set(path, boolValue as never))) {
+						this.#refreshCurrentTabItems(defs);
+						return;
+					}
 					this.callbacks.onChange(path, boolValue);
 
 					if (tabId === "appearance") {
 						this.#triggerStatusLinePreview();
 					}
 				} else if (def.type === "enum") {
-					settings.set(path, newValue as never);
+					if (!commitInteractiveSettings(this.callbacks, () => settings.set(path, newValue as never))) {
+						this.#refreshCurrentTabItems(defs);
+						return;
+					}
 					this.callbacks.onChange(path, newValue);
 				}
 				// Submenu/text types already persisted the value inside their own

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -1013,7 +1013,14 @@ export class SettingsSelectorComponent extends Container {
 					// The shared pet commit policy rechecks capability immediately
 					// before mutation and persists only on acceptance; the settings
 					// surface must not persist ahead of that result.
-					const accepted = this.callbacks.onPetCommit?.(value) ?? false;
+					let accepted = false;
+					if (
+						!commitInteractiveSettings(this.callbacks, () => {
+							accepted = this.callbacks.onPetCommit?.(value) ?? false;
+						})
+					) {
+						return;
+					}
 					done(accepted ? value : undefined);
 					return;
 				}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1129,6 +1129,7 @@ export class SelectorController {
 					},
 					{
 						onChange: (id, value) => this.handleSettingChange(id, value),
+						onError: message => this.ctx.showError(message),
 						onThemePreview: themeName => {
 							return previewTheme(themeName).then(result => {
 								if (!result.success && result.error && !isThemePreviewSuperseded(result)) {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1149,6 +1149,7 @@ export class SelectorController {
 						onPetPreview: mode => {
 							this.ctx.previewPetMode(mode as PetMode);
 						},
+						onPetCommit: mode => this.ctx.commitPetPreviewMode(mode as PetMode),
 						onStatusLinePreview: previewSettings => {
 							// Update status line with preview settings
 							this.ctx.statusLine.updateSettings({

--- a/packages/coding-agent/test/modes/components/settings-selector-memory-refresh.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-memory-refresh.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
 import { SettingsSelectorComponent } from "@gajae-code/coding-agent/modes/components/settings-selector";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -61,6 +64,55 @@ describe("SettingsSelectorComponent memory tab", () => {
 		expect(after).toContain("Memory Backend");
 		expect(after).toContain("Hindsight API URL");
 		expect(after).toContain("Hindsight Auto Recall");
+	});
+	it("reports malformed-YAML repair errors without changing an interactive control", async () => {
+		const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "settings-selector-recovery-"));
+		const agentDir = path.join(testDir, "agent");
+		fs.mkdirSync(agentDir, { recursive: true });
+		resetSettingsForTest();
+		await Bun.write(path.join(agentDir, "config.yml"), "theme: [");
+
+		const errors: string[] = [];
+		const changes: Array<{ path: string; value: unknown }> = [];
+		let cleanupError: unknown;
+		try {
+			await Settings.init({ cwd: testDir, agentDir });
+			const component = new SettingsSelectorComponent(
+				{
+					availableThinkingLevels: [],
+					thinkingLevel: undefined,
+					availableThemes: ["blue-crab"],
+					availableModelProfiles: [],
+					cwd: testDir,
+				},
+				{
+					onChange: (path, value) => changes.push({ path, value }),
+					onError: message => errors.push(message),
+					onCancel: () => {},
+				},
+			);
+
+			component.handleInput("\n");
+			component.handleInput("\n");
+
+			expect(errors).toEqual([
+				"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+			]);
+			expect(changes).toEqual([]);
+			expect(settings.get("theme.dark")).toBe("red-claw");
+			component.handleInput("\x1b");
+			expect(component.render(120).join("\n")).toContain("red-claw");
+		} finally {
+			Settings.instance.getStorage()?.close();
+			try {
+				fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+			} catch (error) {
+				if (process.platform !== "win32" || (error as NodeJS.ErrnoException).code !== "EBUSY") {
+					cleanupError = error;
+				}
+			}
+		}
+		if (cleanupError) throw cleanupError;
 	});
 
 	it("hides Hindsight rows again when the backend is switched back to off without leaving the tab", () => {

--- a/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
@@ -101,4 +101,26 @@ describe("SettingsSelectorComponent pet capability", () => {
 		expect(onChange).not.toHaveBeenCalled();
 		expect(settings.get("pet.mode")).toBe("off");
 	});
+	it("rejects read-only pet commits before the shared policy can mutate widget state", () => {
+		const canWrite = vi.spyOn(Settings.instance, "canWriteDurableConfig").mockReturnValue(false);
+		const onChange = vi.fn();
+		const onError = vi.fn();
+		const onPetCommit = vi.fn(() => true);
+		try {
+			const component = makeComponent(true, { onChange, onError, onPetCommit });
+
+			openPetSetting(component);
+			component.handleInput("\x1b[B");
+			component.handleInput("\n");
+
+			expect(onError).toHaveBeenCalledWith(
+				"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+			);
+			expect(onPetCommit).not.toHaveBeenCalled();
+			expect(onChange).not.toHaveBeenCalled();
+			expect(settings.get("pet.mode")).toBe("off");
+		} finally {
+			canWrite.mockRestore();
+		}
+	});
 });

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -880,6 +880,53 @@ describe("notifications config", () => {
 			missingSettings.getStorage()?.close();
 		}
 	});
+	test("recovered YAML syntax is read-only until config.yml is repaired", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-settings-syntax-recovery-"));
+		tempDirs.push(root);
+		const agentDir = path.join(root, "agent");
+		const configPath = path.join(agentDir, "config.yml");
+		const malformed = "notifications: [\n";
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.writeFileSync(configPath, malformed);
+
+		const settings = await Settings.loadForScope({ cwd: root, agentDir });
+		try {
+			expect(settings.getSchemaReport()).toEqual({
+				valid: false,
+				issues: [
+					{
+						path: "config.yml",
+						kind: "invalid",
+						detail: "Configuration YAML syntax is invalid; repair config.yml before changing settings.",
+					},
+				],
+			});
+			expect(() => settings.set("theme.dark", "blue-crab")).toThrow("Repair config.yml");
+			expect(() => settings.unset("theme.dark")).toThrow("Repair config.yml");
+			await expect(
+				settings.commitAtomicBatch([{ path: "theme.dark", op: "set", value: "blue-crab" }]),
+			).rejects.toThrow("Repair config.yml");
+			await expect(
+				settings.commitAtomicBatchWithCurrent(() => [{ path: "theme.dark", op: "set", value: "blue-crab" }]),
+			).rejects.toThrow("Repair config.yml");
+			expect(settings.get("theme.dark")).toBe("red-claw");
+			await settings.flush();
+			expect(fs.readFileSync(configPath, "utf8")).toBe(malformed);
+
+			fs.writeFileSync(configPath, "theme:\n  dark: blue-crab\n");
+			await settings.flush();
+			expect(settings.getSchemaReport()).toEqual({ issues: [], valid: true });
+			settings.set("theme.dark", "red-claw");
+			await settings.flushOrThrow();
+			expect(YAML.parse(fs.readFileSync(configPath, "utf8"))).toMatchObject({ theme: { dark: "red-claw" } });
+		} finally {
+			settings.getStorage()?.close();
+		}
+
+		const isolated = Settings.isolated();
+		isolated.set("theme.dark", "blue-crab");
+		expect(isolated.get("theme.dark")).toBe("blue-crab");
+	});
 
 	test("project notification settings are ignored without leaking credentials", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-project-boundary-"));

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -824,38 +824,60 @@ describe("notifications config", () => {
 			settings.getStorage()?.close();
 		}
 	});
-	test("full Settings rejects invalid or inaccessible config.yml like lightweight loading", async () => {
+	test("full Settings recovers defaults from invalid YAML while notifications remain fail-closed", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-btw-settings-load-"));
 		tempDirs.push(root);
-
-		const fixtures =
-			process.platform === "win32"
-				? (["notifications: [\n"] as const)
-				: (["notifications: [\n", "directory"] as const);
-		for (const [index, fixture] of fixtures.entries()) {
-			const agentDir = path.join(root, `agent-${index}`);
-			const configPath = path.join(agentDir, "config.yml");
-			fs.mkdirSync(agentDir, { recursive: true });
-			if (fixture === "directory") {
-				fs.mkdirSync(configPath);
-			} else {
-				fs.writeFileSync(configPath, fixture);
-			}
-
-			await expect(Settings.loadForScope({ cwd: root, agentDir })).rejects.toThrow();
-			await expect(loadLightweightDaemonSettings(agentDir)).rejects.toThrow();
+		const agentDir = path.join(root, "invalid-yaml");
+		const configPath = path.join(agentDir, "config.yml");
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.writeFileSync(configPath, "notifications: [\n");
+		resetSettingsForTest();
+		const initialized = await Settings.init({ cwd: root, agentDir });
+		try {
+			expect(initialized.get("theme.dark")).toBe("red-claw");
+			expect(() => initialized.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+		} finally {
+			resetSettingsForTest();
 		}
 
-		const agentDir = path.join(root, "missing-config");
-		fs.mkdirSync(agentDir, { recursive: true });
 		const settings = await Settings.loadForScope({ cwd: root, agentDir });
 		try {
-			expect(settings.getNotificationSettingsSnapshot().telegram.btw.enabled).toBe(true);
-			expect(
-				(await loadLightweightDaemonSettings(agentDir)).getNotificationSettingsSnapshot().telegram.btw.enabled,
-			).toBe(true);
+			expect(settings.get("theme.dark")).toBe("red-claw");
+			expect(() => settings.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			await expect(loadLightweightDaemonSettings(agentDir)).rejects.toThrow();
 		} finally {
 			settings.getStorage()?.close();
+		}
+
+		fs.writeFileSync(configPath, `${JSON.stringify({ notifications: { enabled: true } })}\n`);
+		const repaired = await Settings.loadForScope({ cwd: root, agentDir });
+		try {
+			expect(repaired.getNotificationSettingsSnapshot()).toMatchObject({ enabled: true });
+			expect(repaired.getNotificationSettingsSnapshot()).toEqual(
+				(await loadLightweightDaemonSettings(agentDir)).getNotificationSettingsSnapshot(),
+			);
+		} finally {
+			repaired.getStorage()?.close();
+		}
+
+		if (process.platform !== "win32") {
+			const inaccessibleAgentDir = path.join(root, "directory");
+			fs.mkdirSync(path.join(inaccessibleAgentDir, "config.yml"), { recursive: true });
+			await expect(Settings.loadForScope({ cwd: root, agentDir: inaccessibleAgentDir })).rejects.toThrow();
+			await expect(loadLightweightDaemonSettings(inaccessibleAgentDir)).rejects.toThrow();
+		}
+
+		const missingAgentDir = path.join(root, "missing-config");
+		fs.mkdirSync(missingAgentDir, { recursive: true });
+		const missingSettings = await Settings.loadForScope({ cwd: root, agentDir: missingAgentDir });
+		try {
+			expect(missingSettings.getNotificationSettingsSnapshot().telegram.btw.enabled).toBe(true);
+			expect(
+				(await loadLightweightDaemonSettings(missingAgentDir)).getNotificationSettingsSnapshot().telegram.btw
+					.enabled,
+			).toBe(true);
+		} finally {
+			missingSettings.getStorage()?.close();
 		}
 	});
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -593,6 +593,25 @@ describe("Settings", () => {
 		}
 	});
 
+	it("persists a retained dirty patch on the first flush after YAML repair", async () => {
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		try {
+			settings.set("theme.dark", "blue-crab");
+			await Bun.write(getConfigPath(), "theme: [");
+			await settings.flush();
+
+			expect(settings.canWriteDurableConfig()).toBe(false);
+			expect(settings.get("theme.dark")).toBe("blue-crab");
+
+			await Bun.write(getConfigPath(), "");
+			await settings.flushOrThrow();
+
+			expect(settings.canWriteDurableConfig()).toBe(true);
+			expect((await readSettings()).theme).toEqual({ dark: "blue-crab" });
+		} finally {
+			settings.getStorage()?.close();
+		}
+	});
 	it("retains fail-closed recovery state when a durable refresh read fails", async () => {
 		const malformed = "notifications: [";
 		await Bun.write(getConfigPath(), malformed);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -568,4 +568,66 @@ describe("Settings", () => {
 		expect(migration?.default).toBe("copy-retain");
 		expect(migration?.enum).toEqual(["copy-retain", "disabled"]);
 	});
+	it("clears recovered diagnostics and notification validation after an empty-file repair", async () => {
+		const malformed = "notifications: [";
+		await Bun.write(getConfigPath(), malformed);
+		const settings = await Settings.loadForScope({ cwd: projectDir, agentDir });
+		try {
+			expect(settings.canWriteDurableConfig()).toBe(false);
+			expect(settings.getSchemaReport()).toMatchObject({ valid: false });
+			expect(() => settings.set("theme.dark", "red-claw")).toThrow("Repair config.yml");
+			expect(await Bun.file(getConfigPath()).text()).toBe(malformed);
+
+			await Bun.write(getConfigPath(), "");
+			await settings.flush();
+
+			expect(settings.canWriteDurableConfig()).toBe(true);
+			expect(settings.getSchemaReport()).toEqual({ issues: [], valid: true });
+			expect(settings.getNotificationSettingsSnapshot()).toMatchObject({ enabled: false });
+			settings.set("notifications.redact", true);
+			expect(settings.get("notifications.redact")).toBe(true);
+			await settings.flushOrThrow();
+			expect(await readSettings()).toMatchObject({ notifications: { redact: true } });
+		} finally {
+			settings.getStorage()?.close();
+		}
+	});
+
+	it("retains fail-closed recovery state when a durable refresh read fails", async () => {
+		const malformed = "notifications: [";
+		await Bun.write(getConfigPath(), malformed);
+		const settings = await Settings.loadForScope({ cwd: projectDir, agentDir });
+		try {
+			expect(settings.canWriteDurableConfig()).toBe(false);
+			fs.rmSync(getConfigPath());
+			fs.mkdirSync(getConfigPath());
+
+			await expect(settings.flush()).rejects.toThrow();
+			expect(settings.canWriteDurableConfig()).toBe(false);
+			expect(settings.getSchemaReport()).toMatchObject({ valid: false });
+			expect(() => settings.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			expect(() => settings.set("notifications.redact", true)).toThrow("Repair config.yml");
+		} finally {
+			settings.getStorage()?.close();
+		}
+	});
+
+	it("keeps malformed global recovery and notification state in cwd clones", async () => {
+		const malformed = "notifications: [";
+		const clonedCwd = path.join(testDir, "cloned-project");
+		fs.mkdirSync(clonedCwd, { recursive: true });
+		await Bun.write(getConfigPath(), malformed);
+		const source = await Settings.loadForScope({ cwd: projectDir, agentDir });
+		try {
+			const cloned = await source.cloneForCwd(clonedCwd);
+			expect(cloned.canWriteDurableConfig()).toBe(false);
+			expect(cloned.getSchemaReport()).toEqual(source.getSchemaReport());
+			expect(() => source.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			expect(() => cloned.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			expect(() => cloned.set("notifications.redact", true)).toThrow("Repair config.yml");
+			expect(await Bun.file(getConfigPath()).text()).toBe(malformed);
+		} finally {
+			source.getStorage()?.close();
+		}
+	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -612,6 +612,28 @@ describe("Settings", () => {
 			settings.getStorage()?.close();
 		}
 	});
+	it("preserves fail-closed notifications while replaying dirty patches after external syntax corruption", async () => {
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		try {
+			settings.set("notifications.redact", true);
+			settings.set("theme.dark", "blue-crab");
+			await Bun.write(getConfigPath(), "notifications: [");
+			await settings.flush();
+
+			expect(() => settings.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			expect(settings.get("theme.dark")).toBe("blue-crab");
+
+			await Bun.write(getConfigPath(), "");
+			await settings.flushOrThrow();
+
+			expect(await readSettings()).toMatchObject({
+				notifications: { redact: true },
+				theme: { dark: "blue-crab" },
+			});
+		} finally {
+			settings.getStorage()?.close();
+		}
+	});
 	it("retains fail-closed recovery state when a durable refresh read fails", async () => {
 		const malformed = "notifications: [";
 		await Bun.write(getConfigPath(), malformed);

--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -3,10 +3,11 @@ import * as path from "node:path";
 import { getBundledModel } from "@gajae-code/ai";
 import { postmortem, TempDir } from "@gajae-code/utils";
 import { type Args, parseArgs } from "../src/cli/args";
-import { Settings } from "../src/config/settings";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
 import { SETTINGS_SCHEMA } from "../src/config/settings-schema";
 import {
 	classifyStartupUpdateRoute,
+	getChangelogForDisplay,
 	initializeInteractiveModeWithStartupUpdate,
 	runRootCommand,
 	StartupUpdateOrchestrator,
@@ -70,6 +71,22 @@ describe("startup update contract", () => {
 		expect(setting.ui.description).toContain("never install");
 		expect(setting.ui.description).toContain("Use `gjc update` only");
 		expect(setting.ui.description).toContain("source, linked, and unrecognized installs use their original method");
+	});
+	it("displays the changelog without rewriting malformed global YAML", async () => {
+		using tempDir = TempDir.createSync("@gjc-malformed-changelog-");
+		const agentDir = path.join(tempDir.path(), "agent");
+		const malformed = "notifications: [";
+		await Bun.write(path.join(agentDir, "config.yml"), malformed);
+		resetSettingsForTest();
+		const activeSettings = await Settings.init({ cwd: tempDir.path(), agentDir });
+		try {
+			expect(activeSettings.canWriteDurableConfig()).toBe(false);
+			expect(await getChangelogForDisplay(rootArgs())).toBeDefined();
+			expect(() => activeSettings.set("lastChangelogVersion", "0.0.0")).toThrow("Repair config.yml");
+			expect(await Bun.file(path.join(agentDir, "config.yml")).text()).toBe(malformed);
+		} finally {
+			resetSettingsForTest();
+		}
 	});
 
 	it("classifies every noninteractive launch route and starts no checker for them", () => {


### PR DESCRIPTION
## Summary

- keep `Settings.init()` and `Settings.loadForScope()` usable when global `config.yml` contains malformed YAML
- preserve fail-closed Telegram notification configuration until the file is explicitly repaired
- continue surfacing genuine config read/access failures
- add startup, notification safety, repair, reload, lightweight-reader parity, and directory-I/O regression coverage

Follow-up to the final review finding on #2581: https://github.com/Yeachan-Heo/gajae-code/pull/2581#discussion_r3608762709

## Verification

- `bun test test/notifications-config.test.ts` (44 pass)
- `bun run check`
- `git diff --check`