### PR TITLE
refactor(coding-agent): replace inferred return types

### DIFF
--- a/packages/coding-agent/src/cli/setup-cli.ts
+++ b/packages/coding-agent/src/cli/setup-cli.ts
@@ -564,7 +564,7 @@ async function confirmImport(count: number): Promise<boolean> {
  */
 export interface CredentialsSetupDependencies {
 	openStore?: typeof SqliteAuthCredentialStore.open;
-	createAuthStorage?: (store: Awaited<ReturnType<typeof SqliteAuthCredentialStore.open>>) => AuthStorage;
+	createAuthStorage?: (store: SqliteAuthCredentialStore) => AuthStorage;
 	discover?: Parameters<typeof runExternalCredentialAutoImport>[0]["discover"];
 }
 

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -9,7 +9,7 @@ import { APP_NAME, setProjectDir } from "@gajae-code/utils";
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { parseArgs } from "../cli/args";
 import { launchDefaultTmuxIfNeeded } from "../gjc-runtime/launch-tmux";
-import { prepareLaunchWorktree } from "../gjc-runtime/launch-worktree";
+import { type PreparedLaunchWorktree, prepareLaunchWorktree } from "../gjc-runtime/launch-worktree";
 import {
 	GJC_COORDINATOR_SESSION_ID_ENV,
 	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
@@ -214,7 +214,7 @@ export default class Index extends Command {
 			return;
 		}
 
-		let launch: ReturnType<typeof prepareLaunchWorktree>;
+		let launch: PreparedLaunchWorktree;
 		try {
 			launch = prepareLaunchWorktree(process.cwd(), args);
 		} catch (error) {

--- a/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
@@ -299,14 +299,14 @@ export function ensureReusableNodeModules(sourceRoot: string, worktreePath: stri
 	return "symlink";
 }
 
-export function prepareLaunchWorktree(
-	cwd: string,
-	args: string[],
-): {
+/** Result of {@link prepareLaunchWorktree}: the effective working directory, remaining args, and resolved worktree plan. */
+export interface PreparedLaunchWorktree {
 	cwd: string;
 	args: string[];
 	worktree: GjcLaunchWorktreeResult | { enabled: false };
-} {
+}
+
+export function prepareLaunchWorktree(cwd: string, args: string[]): PreparedLaunchWorktree {
 	const parsed = parseLaunchWorktreeMode(args);
 	const planned = planLaunchWorktree(cwd, parsed.mode);
 	const ensured = ensureLaunchWorktree(planned);

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -14,6 +14,7 @@ import {
 	brokerProcessIncarnation,
 	isPidAlive,
 	newBrokerToken,
+	type RedactedBrokerDiscovery,
 	readBrokerDiscovery,
 	redactBrokerDiscovery,
 	writeBrokerDiscovery,
@@ -373,7 +374,7 @@ export class Broker {
 	#chains = new Map<string, Promise<void>>();
 	#stopping = false;
 	#transport: BrokerTransport | null = null;
-	#heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+	#heartbeatTimer: NodeJS.Timeout | null = null;
 	#heartbeatWrite: Promise<void> = Promise.resolve();
 	constructor(settings: BrokerSettings) {
 		this.settings = {
@@ -560,7 +561,7 @@ export class Broker {
 	get ownsDiscovery(): boolean {
 		return this.discovery?.ownerId === this.#owner;
 	}
-	status(): ReturnType<typeof redactBrokerDiscovery> | null {
+	status(): RedactedBrokerDiscovery | null {
 		return this.discovery ? redactBrokerDiscovery(this.discovery) : null;
 	}
 	async heartbeat(): Promise<void> {

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import path from "node:path";
+import type { NativeExactUnlinkResult } from "@gajae-code/natives";
 import * as native from "@gajae-code/natives";
 import { resolveEquivalentPath } from "@gajae-code/utils";
 
@@ -944,7 +945,7 @@ function exactUnlinkLifecycleFile(
 	file: string,
 	identity: { dev: bigint; ino: bigint; size: bigint; mtimeNs: bigint; sha256: string },
 	plannedPath: string,
-): ReturnType<typeof native.exactUnlink> {
+): NativeExactUnlinkResult {
 	return native.exactUnlink(file, { ...identity, quarantineName: path.basename(plannedPath) });
 }
 
@@ -1565,7 +1566,7 @@ async function reconcileLifecycleCleanup(
 			continue;
 		}
 		let activePath: string | undefined;
-		let captured: ReturnType<typeof captureLifecycleFile>;
+		let captured: LifecycleFileCapture | undefined;
 		let foundUnauthorized = false;
 		for (const candidate of candidates) {
 			try {

--- a/packages/coding-agent/src/sdk/broker/transport.ts
+++ b/packages/coding-agent/src/sdk/broker/transport.ts
@@ -43,7 +43,7 @@ export class BrokerTransport {
 	readonly #broker: Broker;
 	readonly #token: string;
 	readonly #requestedPort: number;
-	#server: ReturnType<typeof Bun.serve> | null = null;
+	#server: Bun.Server<undefined> | null = null;
 	#port = 0;
 	constructor(broker: Broker, token: string, port = 0) {
 		this.#broker = broker;


### PR DESCRIPTION
## Summary

Repairs and integrates the useful portion of external PR #2531 on the current `dev` base.

- replaces the six scoped `ReturnType<>` annotations with authoritative concrete types
- uses `Bun.Server<undefined>` instead of a duplicate structural server interface
- excludes the brittle fixed-file source-scanner test and its cross-PR `harness.ts` assertion
- preserves runtime behavior and security/privacy boundaries

Original contribution: #2531 by @vkehfdl1, exact reviewed source `5e527f15cd9c6358950d8fe152440b1712f79937`.

## Verification

- `bun run check` in `packages/coding-agent`
- `bun test test/setup-cli.test.ts test/launch-command.test.ts test/gjc-runtime/launch-worktree.test.ts` (29 pass)
- `bun test test/sdk-broker-transport.test.ts test/sdk-broker.test.ts test/sdk-broker-lifecycle-e2e.test.ts` (98 pass)

No `main`, release, publish, workflow, provider, routing, prompt, or harness-contract changes.