### PR TITLE
fix(team): propagate owning GJC session to workers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - The Python eval runtime now honors the documented `GJC_*` environment variables instead of silently reading only legacy `PI_*` names. `GJC_PY` (tokens `0`/`bash`, `1`/`py`, `js`, `mix`/`both`) overrides the eval backend allowance with precedence over legacy `PI_PY`/`PI_JS`; `GJC_PYTHON_SKIP_CHECK`, `GJC_PYTHON_IPC_TRACE`, and `GJC_PYTHON_INTEGRATION` are read first with `PI_*` fallback (OR semantics, so either truthy name wins). Operators following `docs/environment-variables.md` and `docs/python-repl.md` who set `GJC_PY=py` previously saw no effect — a silent docs/runtime contract break. Legacy `PI_*` names remain supported for backward compatibility.
 
 ### Fixed
+- Team worker launches now receive the validated owning `GJC_SESSION_ID` for sanctioned session-scoped writes while preserving absent identity, fail-closed resolution, and separate spawn provenance (#2597).
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).

--- a/packages/coding-agent/src/gjc-runtime/team-launch.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-launch.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { SPAWN_PROVENANCE_ENV } from "../sdk/bus/config";
+import { resolveSessionIdFromSources } from "./session-resolution";
 import type {
 	GjcTeamConfig,
 	GjcTeamSnapshot,
@@ -60,14 +61,21 @@ export function buildWorkerCommand(
 		envAssignment("GJC_TEAM_NAME", config.team_name),
 		envAssignment("GJC_TEAM_WORKER_ID", worker.id),
 		envAssignment("GJC_TEAM_STATE_ROOT", config.state_root),
+		...(config.gjc_session_id ? [envAssignment("GJC_SESSION_ID", config.gjc_session_id)] : []),
 		envAssignment("GJC_TEAM_LEADER_CWD", config.leader.cwd),
 		envAssignment("GJC_TEAM_DISPLAY_NAME", config.display_name),
 		envAssignment(SPAWN_PROVENANCE_ENV, config.leader.session_id.trim() || config.team_name),
 		...(worker.worktree_path ? [envAssignment("GJC_TEAM_WORKTREE_PATH", worker.worktree_path)] : []),
 	];
 	const joined = envLines.join(" ");
-	if (platform === "win32") return `& { ${joined} & ${config.worker_command} ${quote(prompt)} }`;
-	return `${joined} ${config.worker_command} ${quote(prompt)}`;
+	const clearInheritedSession = config.gjc_session_id
+		? ""
+		: platform === "win32"
+			? "$env:GJC_SESSION_ID = $null; "
+			: "unset GJC_SESSION_ID; ";
+	if (platform === "win32")
+		return `& { ${clearInheritedSession}${joined} & ${config.worker_command} ${quote(prompt)} }`;
+	return `${clearInheritedSession}${joined} ${config.worker_command} ${quote(prompt)}`;
 }
 
 interface GjcTmuxBinary {
@@ -171,6 +179,7 @@ export async function startGjcTeamLaunch(
 ): Promise<GjcTeamSnapshot> {
 	const cwd = options.cwd ?? process.cwd();
 	const env = options.env ?? process.env;
+	const gjcSessionId = resolveSessionIdFromSources({ envSessionId: env.GJC_SESSION_ID })?.gjcSessionId;
 	if (!Number.isInteger(options.workerCount) || options.workerCount < 1 || options.workerCount > runtime.maxWorkers)
 		throw new Error(`invalid_team_worker_count:${options.workerCount}:expected_1_${runtime.maxWorkers}`);
 	const workerCliPlan = runtime.resolveWorkerCliPlan(options.workerCount, env);
@@ -218,6 +227,7 @@ export async function startGjcTeamLaunch(
 		max_workers: runtime.maxWorkers,
 		state_root: stateRoot,
 		worker_command: runtime.resolveWorkerCommand(cwd, env),
+		...(gjcSessionId ? { gjc_session_id: gjcSessionId } : {}),
 		worker_cli_plan: workerCliPlan,
 		tmux_command: tmuxCommand,
 		tmux_session: tmuxContext.sessionName,

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -158,6 +158,7 @@ export interface GjcTeamConfig {
 	worker_count: number;
 	max_workers: number;
 	state_root: string;
+	gjc_session_id?: string;
 	worker_command: string;
 	worker_cli_plan: GjcTeamWorkerCli[];
 	tmux_command: string;

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -442,6 +442,7 @@ describe("native gjc team runtime", () => {
 		const telemetry = await Bun.file(path.join(snapshot.state_dir, "telemetry.jsonl")).text();
 
 		expect(config.worker_command).toBe("bun ./packages/coding-agent/src/cli.ts");
+		expect(config.gjc_session_id).toBe(TEST_SESSION_ID);
 		expect(manifest.worker_command).toBe("bun ./packages/coding-agent/src/cli.ts");
 		expect(telemetry).toContain("bun ./packages/coding-agent/src/cli.ts");
 		expect(resolveGjcWorkerCommand(cleanupRoot, { GJC_TEAM_WORKER_COMMAND: "gjc-dev" })).toBe("gjc-dev");
@@ -537,6 +538,181 @@ describe("native gjc team runtime", () => {
 
 		// Windows env assignment form is emitted too.
 		expect(buildWorkerCommand(base, worker, "win32")).toContain("$env:GJC_SPAWNED_BY_SESSION = 'leader-xyz';");
+	});
+
+	it("exports only the owning GJC session identity with platform-safe quoting", () => {
+		const config = {
+			team_name: "identity-team",
+			display_name: "identity-team",
+			requested_name: "identity-team",
+			task: "Do work",
+			agent_type: "executor",
+			worker_count: 1,
+			max_workers: 1,
+			state_root: "/state",
+			gjc_session_id: "owner-'$(echo hostile)",
+			worker_command: "gjc",
+			worker_cli_plan: ["gjc"],
+			tmux_command: "tmux",
+			tmux_session: "sess",
+			tmux_session_name: "sess",
+			tmux_target: "sess:0",
+			workspace_mode: "direct",
+			dry_run: false,
+			leader: { session_id: "foreign-session", pane_id: "%1", cwd: "/repo" },
+			leader_cwd: "/repo",
+			team_state_root: "/state",
+			workers: [],
+			created_at: "2026-01-01T00:00:00.000Z",
+			updated_at: "2026-01-01T00:00:00.000Z",
+		} satisfies GjcTeamConfig;
+		const worker = {
+			id: "worker-1",
+			name: "worker-1",
+			index: 1,
+			agent_type: "executor",
+			role: "executor",
+			status: "starting",
+			last_heartbeat: "2026-01-01T00:00:00.000Z",
+			assigned_tasks: [],
+		} satisfies GjcTeamWorker;
+
+		const posix = buildWorkerCommand(config, worker, "linux");
+		expect(posix).toContain("GJC_SESSION_ID='owner-'\\''$(echo hostile)'");
+		expect(posix).toContain("GJC_SPAWNED_BY_SESSION='foreign-session'");
+
+		const windows = buildWorkerCommand(config, worker, "win32");
+		expect(windows).toContain("$env:GJC_SESSION_ID = 'owner-''$(echo hostile)';");
+		expect(windows).toContain("$env:GJC_SPAWNED_BY_SESSION = 'foreign-session';");
+	});
+
+	it("omits owning session identity instead of falling back to foreign provenance", () => {
+		const config = {
+			team_name: "identity-team",
+			display_name: "identity-team",
+			requested_name: "identity-team",
+			task: "Do work",
+			agent_type: "executor",
+			worker_count: 1,
+			max_workers: 1,
+			state_root: "/state",
+			worker_command: "gjc",
+			worker_cli_plan: ["gjc"],
+			tmux_command: "tmux",
+			tmux_session: "sess",
+			tmux_session_name: "sess",
+			tmux_target: "sess:0",
+			workspace_mode: "direct",
+			dry_run: false,
+			leader: { session_id: "foreign-session", pane_id: "%1", cwd: "/repo" },
+			leader_cwd: "/repo",
+			team_state_root: "/state",
+			workers: [],
+			created_at: "2026-01-01T00:00:00.000Z",
+			updated_at: "2026-01-01T00:00:00.000Z",
+		} satisfies GjcTeamConfig;
+		const worker = {
+			id: "worker-1",
+			name: "worker-1",
+			index: 1,
+			agent_type: "executor",
+			role: "executor",
+			status: "starting",
+			last_heartbeat: "2026-01-01T00:00:00.000Z",
+			assigned_tasks: [],
+		} satisfies GjcTeamWorker;
+
+		const command = buildWorkerCommand(config, worker, "linux");
+		expect(command).toContain("unset GJC_SESSION_ID;");
+		expect(command).not.toContain("GJC_SESSION_ID='");
+		expect(command).toContain("GJC_SPAWNED_BY_SESSION='foreign-session'");
+		expect(buildWorkerCommand(config, worker, "win32")).toContain("$env:GJC_SESSION_ID = $null;");
+	});
+
+	it("clears a foreign ambient session identity before executing a worker", () => {
+		const config = {
+			team_name: "identity-team",
+			display_name: "identity-team",
+			requested_name: "identity-team",
+			task: "Do work",
+			agent_type: "executor",
+			worker_count: 1,
+			max_workers: 1,
+			state_root: "/state",
+			worker_command:
+				"bun -e \"process.stdout.write((process.env.GJC_SESSION_ID ?? '<unset>') + '|' + (process.env.GJC_TEAM_WORKER ?? '<missing>'))\"",
+			worker_cli_plan: ["gjc"],
+			tmux_command: "tmux",
+			tmux_session: "sess",
+			tmux_session_name: "sess",
+			tmux_target: "sess:0",
+			workspace_mode: "direct",
+			dry_run: false,
+			leader: { session_id: "foreign-session", pane_id: "%1", cwd: "/repo" },
+			leader_cwd: "/repo",
+			team_state_root: "/state",
+			workers: [],
+			created_at: "2026-01-01T00:00:00.000Z",
+			updated_at: "2026-01-01T00:00:00.000Z",
+		} satisfies GjcTeamConfig;
+		const worker = {
+			id: "worker-1",
+			name: "worker-1",
+			index: 1,
+			agent_type: "executor",
+			role: "executor",
+			status: "starting",
+			last_heartbeat: "2026-01-01T00:00:00.000Z",
+			assigned_tasks: [],
+		} satisfies GjcTeamWorker;
+
+		const result = Bun.spawnSync(["sh", "-c", buildWorkerCommand(config, worker, "linux")], {
+			env: { ...process.env, GJC_SESSION_ID: "foreign-ambient-session" },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString().trim()).toBe("<unset>|identity-team/worker-1");
+	});
+
+	it("rejects unsafe owning session identities even with an explicit team state root", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await expect(
+			startGjcTeam({
+				workerCount: 1,
+				agentType: "executor",
+				task: "Reject unsafe identity",
+				teamName: "unsafe-identity-team",
+				cwd: cleanupRoot,
+				dryRun: true,
+				env: {
+					GJC_SESSION_ID: "../foreign-session",
+					GJC_TEAM_STATE_ROOT: path.join(cleanupRoot, "team-state"),
+					PATH: "",
+				},
+			}),
+		).rejects.toThrow("session id must be a single path component");
+	});
+
+	it("does not persist a foreign session fallback when the owning GJC identity is absent", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Preserve missing identity",
+			teamName: "missing-identity-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: {
+				CODEX_SESSION_ID: "foreign-session",
+				GJC_TEAM_STATE_ROOT: path.join(cleanupRoot, ".gjc", "team-state"),
+				PATH: "",
+			},
+		});
+
+		const config = await Bun.file(path.join(snapshot.state_dir, "config.json")).json();
+		expect(config.gjc_session_id).toBeUndefined();
+		expect(config.leader.session_id).toBe("foreign-session");
 	});
 
 	it("resolves Windows JavaScript entrypoints through an executable runtime", async () => {


### PR DESCRIPTION
## Summary
- validate and retain the owning GJC session separately from Team spawn provenance
- export the owning `GJC_SESSION_ID` to worker commands on POSIX and PowerShell
- explicitly clear inherited session identity when Team has no owner, preserving fail-closed writes
- add malformed, foreign, hostile quoting, and ambient-leak regressions

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts` (100 pass)
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- independent architect review: CLEAR / APPROVE
- executor adversarial package QA: passed

Closes #2597

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*