### PR TITLE
fix(ci): detach affected evidence receipt

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -296,21 +296,24 @@ jobs:
           overwrite: true
 
 
-  # Branch protection must keep requiring this stable aggregate status. It validates
-  # the canonical plan and receipts, then passes iff the planner, native build,
-  # every affected shard, and Windows doctor satisfy their planned contracts. The
-  # job name must stay exactly "Affected path validation".
-  affected:
-    name: Affected path validation
+  # This producer is deliberately not the protected status: the downstream job
+  # validates the finalized bundle downloaded by its immutable artifact ID.
+  affected-evidence-producer:
+    name: Affected path validation / evidence producer
     if: ${{ always() }}
     needs: [affected-plan, affected-native, affected-shards, windows-dev-doctor]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    outputs:
+      artifact_id: ${{ steps.upload-evidence.outputs.artifact-id }}
+      artifact_digest: ${{ steps.upload-evidence.outputs.artifact-digest }}
     env:
       CI_DEV_AFFECTED_PLAN: .ci-dev-affected-plan.json
       CI_DEV_PLAN_DIGEST: ${{ needs.affected-plan.outputs.plan_digest }}
       CI_DEV_PLAN_SOURCE_SHA: ${{ needs.affected-plan.outputs.plan_source_sha }}
+      CI_DEV_PLAN_MODE: ${{ needs.affected-plan.outputs.plan_mode }}
       CI_DEV_SHARD_RECEIPTS: .ci-dev-shard-receipts
+      CI_DEV_EVIDENCE_ROOT: .
       CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -329,8 +332,6 @@ jobs:
         with:
           name: dev-affected-plan-${{ github.run_id }}
           path: .
-      - name: Validate canonical affected plan
-        run: bun scripts/ci-dev-affected.ts --validate-plan
       - name: Download shard completion receipts
         if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' && needs.affected-shards.result == 'success' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -338,10 +339,7 @@ jobs:
           pattern: dev-affected-shard-${{ github.run_id }}-*
           path: .ci-dev-shard-receipts
           merge-multiple: true
-      - name: Validate canonical shard completion
-        if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' && needs.affected-shards.result == 'success' }}
-        run: bun scripts/ci-dev-affected.ts --validate-shard-receipts
-      - name: Aggregate affected path validation shards
+      - name: Produce affected evidence
         env:
           CI_DEV_PLAN_RESULT: ${{ needs.affected-plan.result }}
           CI_DEV_NATIVE_RESULT: ${{ needs.affected-native.result }}
@@ -350,7 +348,78 @@ jobs:
           CI_DEV_HAS_TASKS: ${{ needs.affected-plan.outputs.has_tasks }}
           CI_DEV_WINDOWS_DOCTOR_RESULT: ${{ needs.windows-dev-doctor.result }}
           CI_DEV_WINDOWS_DOCTOR_REQUIRED: ${{ contains(needs.affected-plan.outputs.changed_paths, 'scripts/dev-link') }}
-        run: bun scripts/ci-dev-affected.ts --validate-aggregate
+        run: bun scripts/ci-dev-affected.ts --write-affected-evidence
+      - name: Upload affected evidence
+        id: upload-evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: dev-affected-evidence-${{ github.run_id }}
+          path: |
+            .ci-dev-affected-evidence.json
+            .ci-dev-affected-evidence.receipt.json
+            .ci-dev-affected-plan.json
+            .ci-dev-shard-receipts
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
+
+  affected:
+    name: Affected path validation
+    if: ${{ always() }}
+    needs: [affected-evidence-producer, affected-plan, affected-native, affected-shards, windows-dev-doctor]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    env:
+      CI_DEV_PLAN_DIGEST: ${{ needs.affected-plan.outputs.plan_digest }}
+      CI_DEV_PLAN_SOURCE_SHA: ${{ needs.affected-plan.outputs.plan_source_sha }}
+      CI_DEV_PLAN_MODE: ${{ needs.affected-plan.outputs.plan_mode }}
+      CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      CI_DEV_PLAN_RESULT: ${{ needs.affected-plan.result }}
+      CI_DEV_NATIVE_RESULT: ${{ needs.affected-native.result }}
+      CI_DEV_SHARDS_RESULT: ${{ needs.affected-shards.result }}
+      CI_DEV_HAS_NATIVE: ${{ needs.affected-plan.outputs.has_native }}
+      CI_DEV_HAS_TASKS: ${{ needs.affected-plan.outputs.has_tasks }}
+      CI_DEV_WINDOWS_DOCTOR_RESULT: ${{ needs.windows-dev-doctor.result }}
+      CI_DEV_WINDOWS_DOCTOR_REQUIRED: ${{ contains(needs.affected-plan.outputs.changed_paths, 'scripts/dev-link') }}
+    steps:
+      - name: Fail closed on producer and live dependency results
+        env:
+          CI_DEV_EVIDENCE_ROOT: ${{ runner.temp }}/ci-dev-affected-evidence
+        shell: bash
+        run: |
+          test '${{ needs.affected-evidence-producer.result }}' = success
+          test '${{ needs.affected-plan.result }}' = success
+          test '${{ needs.affected-evidence-producer.outputs.artifact_id }}' != ''
+          test '${{ needs.affected-evidence-producer.outputs.artifact_digest }}' != ''
+          test "$CI_DEV_EVIDENCE_ROOT" != "$GITHUB_WORKSPACE"
+          case "$CI_DEV_EVIDENCE_ROOT" in "$GITHUB_WORKSPACE"/*) exit 1;; esac
+          rm -rf "$CI_DEV_EVIDENCE_ROOT"
+          mkdir -p "$CI_DEV_EVIDENCE_ROOT"
+      - name: Download finalized affected evidence
+      # download-artifact selects the immutable upload by artifact ID; the pinned
+      # action exposes no downloaded digest output to compare, so artifact_digest
+      # remains a required producer audit binding rather than a path selector.
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          artifact-ids: ${{ needs.affected-evidence-producer.outputs.artifact_id }}
+          path: ${{ runner.temp }}/ci-dev-affected-evidence
+          merge-multiple: true
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify checked-out source head
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          test "$head" = "$CI_DEV_SOURCE_SHA" || { echo "Checked-out SHA $head does not match $CI_DEV_SOURCE_SHA"; exit 1; }
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3"
+      - name: Validate finalized affected evidence
+        env:
+          CI_DEV_EVIDENCE_ROOT: ${{ runner.temp }}/ci-dev-affected-evidence
+        run: bun scripts/ci-dev-affected.ts --validate-affected-evidence
 
   gjc-state-gates-matrix:
     name: gjc-state-gates / ${{ matrix.group }}

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -46,63 +46,248 @@ describe("planTasks command shape (issue #622)", () => {
 });
 
 describe("dev-ci canonical-plan workflow contract", () => {
-	test("binds canonical artifacts to the run so attempt-2 consumers reuse attempt-1 producers safely", async () => {
+	test("pins independent no-shard and multi-shard detached-document byte oracles", () => {
+		const noShardManifest = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"planMode\":\"pr\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"},\"aggregateResults\":{\"plan\":\"success\",\"native\":\"skipped\",\"shards\":\"skipped\",\"windowsDoctor\":\"skipped\",\"windowsDoctorRequired\":\"false\",\"hasNative\":\"false\",\"hasTasks\":\"false\"},\"taskIdentities\":[],\"childEvidence\":[{\"name\":\".ci-dev-affected-plan.json\",\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}]}\n";
+		const multiShardManifest = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"planMode\":\"push\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"},\"aggregateResults\":{\"plan\":\"success\",\"native\":\"success\",\"shards\":\"success\",\"windowsDoctor\":\"success\",\"windowsDoctorRequired\":\"true\",\"hasNative\":\"true\",\"hasTasks\":\"true\"},\"taskIdentities\":[{\"key\":\"one\",\"identity\":\"id-one\"},{\"key\":\"two\",\"identity\":\"id-two\"}],\"childEvidence\":[{\"name\":\".ci-dev-affected-plan.json\",\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},{\"name\":\".ci-dev-shard-receipts/0.json\",\"sha256\":\"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"},{\"name\":\".ci-dev-shard-receipts/1.json\",\"sha256\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}]}\n";
+		const noShardReceipt = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"manifestSha256\":\"588c6fef9fe2fd488a5f511c7e02e620c6c55a165d10997fa2d9aad24f5db746\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"}}\n";
+		const multiShardReceipt = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"manifestSha256\":\"276923dd0acb537de815b14eab377a2740224a4063679738cfd3bbae87324ba6\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"}}\n";
+		const hash = (value: string) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
+		expect(hash(noShardManifest)).toBe("588c6fef9fe2fd488a5f511c7e02e620c6c55a165d10997fa2d9aad24f5db746");
+		expect(hash(multiShardManifest)).toBe("276923dd0acb537de815b14eab377a2740224a4063679738cfd3bbae87324ba6");
+		expect(hash(noShardReceipt)).toBe("39f209e20824bec9839b6e9ffa8ce6a5f894b4190e80061c1635c46a645faa56");
+		expect(hash(multiShardReceipt)).toBe("0d939ebfb8e87300b3c8433e2a7e4499072f89f28fee1b3b164156b554d08eda");
+	});
+	test("uses a detached finalized evidence producer and artifact-ID consumer", async () => {
 		const workflow = await Bun.file(path.join(import.meta.dir, "..", ".github", "workflows", "dev-ci.yml")).text();
-		expect(workflow.match(/ref: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/g)).toHaveLength(5);
-		expect(workflow.match(/Verify checked-out source head/g)).toHaveLength(5);
-		expect(workflow).toContain("name: dev-affected-plan-${{ github.run_id }}");
-		expect(workflow).toContain("name: dev-affected-native-${{ github.run_id }}");
-		expect(workflow).toContain("name: dev-affected-shard-${{ github.run_id }}-${{ strategy.job-index }}");
-		expect(workflow).toContain("pattern: dev-affected-shard-${{ github.run_id }}-*");
-		expect(workflow).not.toContain("github.run_attempt");
-		expect(workflow.match(/overwrite: true/g)).toHaveLength(3);
-		expect(workflow.match(/dev-affected-plan-\$\{\{ github\.run_id \}\}/g)).toHaveLength(4);
-		expect(workflow.match(/dev-affected-native-\$\{\{ github\.run_id \}\}/g)).toHaveLength(2);
-		expect(workflow.match(/dev-affected-shard-\$\{\{ github\.run_id \}\}/g)).toHaveLength(2);
-		expect(workflow).toContain("include-hidden-files: true");
-		expect(workflow.match(/include-hidden-files: true/g)).toHaveLength(2);
-		expect(workflow).toContain("CI_DEV_PLAN_DIGEST: ${{ needs.affected-plan.outputs.plan_digest }}");
-		expect(workflow).toContain("CI_DEV_PLAN_SOURCE_SHA: ${{ needs.affected-plan.outputs.plan_source_sha }}");
-		expect(workflow).toContain("CI_DEV_MATRIX_NEXTEST: ${{ matrix.nextest }}");
-		expect(workflow).toContain("timeout-minutes: ${{ matrix.key == 'root-check' && 30 || 90 }}");
-		expect(workflow.match(/run: bun scripts\/ci-dev-affected\.ts --validate-plan/g)).toHaveLength(3);
-		expect(workflow).toContain("if: ${{ matrix.nextest }}");
-		expect(workflow).toContain("affected-native.result != 'failure'");
-		expect(workflow).toContain("name: Affected path validation");
-		expect(workflow).toContain("CI_DEV_HAS_NATIVE: ${{ needs.affected-plan.outputs.has_native }}");
-		expect(workflow).toContain("CI_DEV_HAS_TASKS: ${{ needs.affected-plan.outputs.has_tasks }}");
-		expect(workflow).toContain("--validate-aggregate");
-		expect(workflow).toContain("CI_DEV_WINDOWS_DOCTOR_RESULT: ${{ needs.windows-dev-doctor.result }}");
-		expect(workflow).toContain("CI_DEV_WINDOWS_DOCTOR_REQUIRED: ${{ contains(needs.affected-plan.outputs.changed_paths, 'scripts/dev-link') }}");
-		expect(workflow).toContain("max-parallel: 8");
-		expect(workflow).toContain("CI_DEV_MATRIX_IDENTITY: ${{ matrix.identity }}");
-		expect(workflow).toContain("Upload shard completion receipt");
-		expect(workflow).toContain("Validate canonical shard completion");
-		expect(workflow).toContain("--validate-shard-receipts");
-		expect(workflow).toContain("pi_natives.linux-x64-baseline.node");
-		expect(workflow).toContain("pi_natives.linux-x64-modern.node");
-		expect(workflow).not.toContain("native-cache");
+		expect(workflow).toContain("affected-evidence-producer:");
+		expect(workflow).toContain("name: Affected path validation / evidence producer");
+		expect(workflow).toContain("  affected:\n    name: Affected path validation\n    if: ${{ always() }}");
+		expect(workflow).toContain("needs: [affected-evidence-producer, affected-plan, affected-native, affected-shards, windows-dev-doctor]");
+		expect(workflow).toContain("artifact_id: ${{ steps.upload-evidence.outputs.artifact-id }}");
+		expect(workflow).toContain("artifact_digest: ${{ steps.upload-evidence.outputs.artifact-digest }}");
+		expect(workflow).toContain("artifact-ids: ${{ needs.affected-evidence-producer.outputs.artifact_id }}");
+		const finalizedDownloadStart = workflow.indexOf("      - name: Download finalized affected evidence");
+		const finalizedDownloadEnd = workflow.indexOf("\n      - ", finalizedDownloadStart + 1);
+		expect(workflow.slice(finalizedDownloadStart, finalizedDownloadEnd)).toContain("merge-multiple: true");
+		const uploadStart = workflow.indexOf("      - name: Upload affected evidence");
+		const uploadEnd = workflow.indexOf("\n\n  affected:", uploadStart);
+		expect(workflow.slice(uploadStart, uploadEnd)).toContain("overwrite: true");
+		expect(workflow).toContain("CI_DEV_EVIDENCE_ROOT: ${{ runner.temp }}/ci-dev-affected-evidence");
+		expect(workflow).toContain("rm -rf \"$CI_DEV_EVIDENCE_ROOT\"");
+		expect(workflow).toContain("--write-affected-evidence");
+		expect(workflow).toContain("--validate-affected-evidence");
+		expect(workflow).toContain(".ci-dev-affected-evidence.json");
+		expect(workflow).toContain(".ci-dev-affected-evidence.receipt.json");
+		expect(workflow).not.toContain("evidencePath");
 		expect(workflow).not.toContain("pull_request_target");
-		expect(workflow).not.toContain("uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830");
-		expect(workflow.match(/uses: actions\/cache\/restore@0057852bfaa89a56745cba8c7296529d2fc39830/g)).toHaveLength(4);
-		expect(workflow.match(/save-if: \$\{\{ github\.event_name == 'push' && github\.ref == 'refs\/heads\/dev' \}\}/g)).toHaveLength(3);
-		const aggregateWorkflow = workflow.slice(workflow.indexOf("  affected:\n"));
-		expect(aggregateWorkflow).toContain("name: Validate canonical affected plan");
-		expect(aggregateWorkflow).toContain("run: bun scripts/ci-dev-affected.ts --validate-plan");
-		const receiptConsumerCondition = "if: ${{ needs.affected-plan.result == 'success' && needs.affected-plan.outputs.has_tasks == 'true' && needs.affected-shards.result == 'success' }}";
-		expect(workflow.match(new RegExp(receiptConsumerCondition.replace(/[.$|?*+(){}[\]\\]/g, "\\$&"), "g"))).toHaveLength(2);
-		for (const name of ["Download shard completion receipts", "Validate canonical shard completion"]) {
-			const step = workflow.slice(workflow.indexOf(`name: ${name}`), workflow.indexOf("\n      - name:", workflow.indexOf(`name: ${name}`) + 1));
-			expect(step).toContain(receiptConsumerCondition);
+		expect(workflow).not.toContain("github.run_attempt");
+		expect(workflow).toContain("artifact_digest");
+		expect(workflow).toContain("remains a required producer audit binding");
+		expect(workflow).not.toContain("continue-on-error");
+		const protectedJob = workflow.slice(workflow.indexOf("  affected:\n"), workflow.indexOf("\n  gjc-state-gates-matrix:"));
+		expect(protectedJob).toContain("if: ${{ always() }}");
+		expect(protectedJob).toContain("name: Validate finalized affected evidence");
+		expect(protectedJob).not.toContain("continue-on-error");
+		const validationStart = protectedJob.indexOf("name: Validate finalized affected evidence");
+		expect(protectedJob.slice(validationStart)).not.toContain("\n        if:");
+		const protectedJobEnv = protectedJob.slice(0, protectedJob.indexOf("    steps:"));
+		expect(protectedJobEnv).not.toContain("runner.temp");
+		const preparationStart = protectedJob.indexOf("name: Fail closed on producer and live dependency results");
+		const preparationEnd = protectedJob.indexOf("\n      - name:", preparationStart + 1);
+		expect(protectedJob.slice(preparationStart, preparationEnd)).toContain("CI_DEV_EVIDENCE_ROOT: ${{ runner.temp }}/ci-dev-affected-evidence");
+		expect(protectedJob.slice(validationStart)).toContain("CI_DEV_EVIDENCE_ROOT: ${{ runner.temp }}/ci-dev-affected-evidence");
+	});
+
+	describe("detached evidence subprocess contract", () => {
+		const scriptPath = path.join(import.meta.dir, "ci-dev-affected.ts");
+		const repoRoot = path.join(import.meta.dir, "..");
+		const sourceSha = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repoRoot }).stdout.toString().trim();
+		const baseAggregate = { plan: "success", native: "skipped", shards: "skipped", windowsDoctor: "skipped", windowsDoctorRequired: "false", hasNative: "false", hasTasks: "false" };
+		type EvidenceFixture = { root: string; env: Record<string, string>; plan: string; digest: string };
+
+		async function fixture(tasks: unknown[] = []): Promise<EvidenceFixture> {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-evidence-"));
+			const plan = JSON.stringify({ schemaVersion: 1, sourceSha, mode: "pr", paths: [], tasks });
+			const digest = new Bun.CryptoHasher("sha256").update(plan).digest("hex");
+			await fs.writeFile(path.join(root, ".ci-dev-affected-plan.json"), plan);
+			const env: Record<string, string> = {
+				CI_DEV_EVIDENCE_ROOT: root, CI_DEV_AFFECTED_PLAN: path.join(root, ".ci-dev-affected-plan.json"), CI_DEV_PLAN_SOURCE_SHA: sourceSha,
+				CI_DEV_SOURCE_SHA: sourceSha, CI_DEV_PLAN_DIGEST: digest, CI_DEV_PLAN_MODE: "pr", GITHUB_REPOSITORY: "owner/repo", GITHUB_WORKFLOW: "Dev CI", GITHUB_RUN_ID: "42",
+				CI_DEV_PLAN_RESULT: baseAggregate.plan, CI_DEV_NATIVE_RESULT: baseAggregate.native, CI_DEV_SHARDS_RESULT: baseAggregate.shards, CI_DEV_WINDOWS_DOCTOR_RESULT: baseAggregate.windowsDoctor,
+				CI_DEV_WINDOWS_DOCTOR_REQUIRED: baseAggregate.windowsDoctorRequired, CI_DEV_HAS_NATIVE: baseAggregate.hasNative, CI_DEV_HAS_TASKS: baseAggregate.hasTasks,
+			};
+			return { root, env, plan, digest };
 		}
-		expect(aggregateWorkflow).toContain("if: ${{ always() }}");
-		const aggregateValidationStart = aggregateWorkflow.indexOf("name: Aggregate affected path validation shards");
-		const aggregateValidationEnd = aggregateWorkflow.indexOf("\n      - name:", aggregateValidationStart + 1);
-		const aggregateValidationStep = aggregateWorkflow.slice(
-			aggregateValidationStart,
-			aggregateValidationEnd === -1 ? undefined : aggregateValidationEnd,
-		);
-		expect(aggregateValidationStep).not.toContain("\n        if:");
+		async function invoke(env: Record<string, string>, command: string) {
+			const proc = Bun.spawn(["bun", scriptPath, command], {
+				cwd: repoRoot,
+				env: {
+					...process.env,
+					CI_DEV_MATRIX_KEY: undefined,
+					CI_DEV_MATRIX_RUST: undefined,
+					CI_DEV_MATRIX_NEXTEST: undefined,
+					CI_DEV_MATRIX_NATIVE: undefined,
+					CI_DEV_MATRIX_IDENTITY: undefined,
+					CI_DEV_SHARD_INDEX: undefined,
+					AFFECTED_TASK_KEY: undefined,
+					...env,
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			return { exitCode: await proc.exited, stdout: await new Response(proc.stdout).text(), stderr: await new Response(proc.stderr).text() };
+		}
+		async function withFixture(body: (value: EvidenceFixture) => Promise<void>, tasks: unknown[] = []) {
+			const value = await fixture(tasks); try { await body(value); } finally { await fs.rm(value.root, { recursive: true, force: true }); }
+		}
+
+		test("produces deterministic no-shard evidence and validates it", async () => {
+			await withFixture(async ({ root, env, digest }) => {
+				const first = await invoke(env, "--write-affected-evidence");
+				expect(first.exitCode).toBe(0); expect(first.stdout).toContain("affected evidence produced: 1 child evidence file(s)");
+				const manifest = await fs.readFile(path.join(root, ".ci-dev-affected-evidence.json"), "utf8");
+				const receipt = await fs.readFile(path.join(root, ".ci-dev-affected-evidence.receipt.json"), "utf8");
+				const expectedManifest = `${JSON.stringify({ schemaVersion: 1, subject: "ci-dev-affected-evidence", sourceSha, planDigest: digest, planMode: "pr", replayScope: { repository: "owner/repo", workflow: "Dev CI", runId: "42" }, aggregateResults: baseAggregate, taskIdentities: [], childEvidence: [{ name: ".ci-dev-affected-plan.json", sha256: digest }] })}\n`;
+				expect(manifest).toBe(expectedManifest);
+				const expectedReceipt = `${JSON.stringify({ schemaVersion: 1, subject: "ci-dev-affected-evidence", manifestSha256: new Bun.CryptoHasher("sha256").update(expectedManifest).digest("hex"), sourceSha, planDigest: digest, replayScope: { repository: "owner/repo", workflow: "Dev CI", runId: "42" } })}\n`;
+				expect(receipt).toBe(expectedReceipt);
+				const validated = await invoke(env, "--validate-affected-evidence");
+				expect(validated.exitCode).toBe(0); expect(validated.stdout).toContain("affected evidence validated: 1 child evidence file(s)");
+				await fs.rm(path.join(root, ".ci-dev-affected-evidence.json")); await fs.rm(path.join(root, ".ci-dev-affected-evidence.receipt.json"));
+				expect((await invoke(env, "--write-affected-evidence")).exitCode).toBe(0);
+				expect(await fs.readFile(path.join(root, ".ci-dev-affected-evidence.json"), "utf8")).toBe(manifest);
+				expect(await fs.readFile(path.join(root, ".ci-dev-affected-evidence.receipt.json"), "utf8")).toBe(receipt);
+			});
+		});
+
+		test("produces and consumes a complete multi-shard bundle", async () => {
+			const task = { key: "fixture-task", identity: "fixture:task", description: "fixture", command: ["true"], cwd: ".", capabilities: { rust: false, nextest: false, nativeConsumer: false, nativeProducer: false }, phase: "legacy" };
+			await withFixture(async ({ root, env, digest }) => {
+				const multiAggregate = { ...baseAggregate, hasTasks: "true", shards: "success" };
+				const multiEnv = { ...env, CI_DEV_HAS_TASKS: multiAggregate.hasTasks, CI_DEV_SHARDS_RESULT: multiAggregate.shards };
+				await fs.mkdir(path.join(root, ".ci-dev-shard-receipts"));
+				const shardRaw = JSON.stringify({ key: task.key, identity: task.identity });
+				await fs.writeFile(path.join(root, ".ci-dev-shard-receipts", "0.json"), shardRaw);
+				expect((await invoke(multiEnv, "--write-affected-evidence")).stdout).toContain("affected evidence produced: 2 child evidence file(s)");
+				const manifest = await fs.readFile(path.join(root, ".ci-dev-affected-evidence.json"), "utf8");
+				const receipt = await fs.readFile(path.join(root, ".ci-dev-affected-evidence.receipt.json"), "utf8");
+				const expectedManifest = `${JSON.stringify({ schemaVersion: 1, subject: "ci-dev-affected-evidence", sourceSha, planDigest: digest, planMode: "pr", replayScope: { repository: "owner/repo", workflow: "Dev CI", runId: "42" }, aggregateResults: multiAggregate, taskIdentities: [{ key: task.key, identity: task.identity }], childEvidence: [{ name: ".ci-dev-affected-plan.json", sha256: digest }, { name: ".ci-dev-shard-receipts/0.json", sha256: new Bun.CryptoHasher("sha256").update(shardRaw).digest("hex") }] })}\n`;
+				expect(manifest).toBe(expectedManifest);
+				const expectedReceipt = `${JSON.stringify({ schemaVersion: 1, subject: "ci-dev-affected-evidence", manifestSha256: new Bun.CryptoHasher("sha256").update(expectedManifest).digest("hex"), sourceSha, planDigest: digest, replayScope: { repository: "owner/repo", workflow: "Dev CI", runId: "42" } })}\n`;
+				expect(receipt).toBe(expectedReceipt);
+				const consumed = await invoke(multiEnv, "--validate-affected-evidence");
+				expect(consumed.exitCode).toBe(0); expect(consumed.stdout).toContain("affected evidence validated: 2 child evidence file(s)");
+				await fs.writeFile(path.join(root, ".ci-dev-shard-receipts", "1.json"), "{}");
+				expect((await invoke(multiEnv, "--validate-affected-evidence")).exitCode).toBe(1);
+			}, [task]);
+		});
+
+		test("fails closed for canonical, replay, child, layout, and pair failures", async () => {
+			await withFixture(async ({ root, env }) => {
+				expect((await invoke(env, "--write-affected-evidence")).exitCode).toBe(0);
+				const manifest = path.join(root, ".ci-dev-affected-evidence.json"); const receipt = path.join(root, ".ci-dev-affected-evidence.receipt.json");
+				for (const mutate of [
+					async () => fs.writeFile(manifest, `${await fs.readFile(manifest, "utf8")}\n`),
+					async () => fs.writeFile(receipt, "{}\n"),
+					async () => fs.mkdir(path.join(root, ".ci-dev-shard-receipts")),
+					async () => fs.writeFile(manifest, Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(await fs.readFile(manifest))])),
+					async () => fs.writeFile(receipt, Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(await fs.readFile(receipt))])),
+				]) {
+					const originalManifest = await fs.readFile(manifest, "utf8"); const originalReceipt = await fs.readFile(receipt, "utf8"); await mutate();
+					expect((await invoke(env, "--validate-affected-evidence")).exitCode).toBe(1);
+					await fs.rm(path.join(root, ".ci-dev-shard-receipts"), { recursive: true, force: true }); await fs.writeFile(manifest, originalManifest); await fs.writeFile(receipt, originalReceipt);
+				}
+				await fs.writeFile(path.join(root, ".ci-dev-affected-plan.json"), "{}");
+				expect((await invoke(env, "--validate-affected-evidence")).exitCode).toBe(1);
+			}, []);
+		});
+
+		test("rejects pre-existing targets and removes its owned manifest after injected receipt failure", async () => {
+			await withFixture(async ({ root, env }) => {
+				await fs.writeFile(path.join(root, ".ci-dev-affected-evidence.json"), "occupied");
+				expect((await invoke(env, "--write-affected-evidence")).exitCode).toBe(1);
+				await fs.rm(path.join(root, ".ci-dev-affected-evidence.json"));
+				expect((await invoke({ ...env, CI_DEV_INJECT_EVIDENCE_POST_MANIFEST_FAILURE: "true" }, "--write-affected-evidence")).exitCode).toBe(1);
+				expect(await Bun.file(path.join(root, ".ci-dev-affected-evidence.json")).exists()).toBe(false);
+				expect(await Bun.file(path.join(root, ".ci-dev-affected-evidence.receipt.json")).exists()).toBe(false);
+			});
+		});
+
+		test("rejects replay, source, aggregate, task, child, and filesystem substitutions", async () => {
+			await withFixture(async ({ root, env }) => {
+				expect((await invoke(env, "--write-affected-evidence")).exitCode).toBe(0);
+				const manifestPath = path.join(root, ".ci-dev-affected-evidence.json"); const receiptPath = path.join(root, ".ci-dev-affected-evidence.receipt.json");
+				const originalManifest = await fs.readFile(manifestPath, "utf8"); const originalReceipt = await fs.readFile(receiptPath, "utf8");
+				async function resign(mutator: (manifest: Record<string, unknown>) => void) {
+					const manifest = JSON.parse(originalManifest) as Record<string, unknown>; mutator(manifest);
+					const raw = `${JSON.stringify(manifest)}\n`; const digest = new Bun.CryptoHasher("sha256").update(raw).digest("hex");
+					const receipt = JSON.parse(originalReceipt) as Record<string, unknown>; receipt.manifestSha256 = digest;
+					await fs.writeFile(manifestPath, raw); await fs.writeFile(receiptPath, `${JSON.stringify(receipt)}\n`);
+					expect((await invoke(env, "--validate-affected-evidence")).exitCode).toBe(1);
+					await fs.writeFile(manifestPath, originalManifest); await fs.writeFile(receiptPath, originalReceipt);
+				}
+				await resign(manifest => { (manifest.replayScope as Record<string, string>).runId = "stale"; });
+				await resign(manifest => { manifest.sourceSha = "abcdefabcdefabcdefabcdefabcdefabcdefabcd"; });
+				await resign(manifest => { (manifest.aggregateResults as Record<string, string>).plan = "failure"; });
+				await resign(manifest => { manifest.taskIdentities = [{ key: "extra", identity: "extra" }]; });
+				await resign(manifest => { (manifest.childEvidence as Array<Record<string, string>>)[0]!.sha256 = "a".repeat(64); });
+				await fs.rm(manifestPath); await fs.symlink(receiptPath, manifestPath);
+				expect((await invoke(env, "--validate-affected-evidence")).exitCode).toBe(1);
+				await fs.rm(manifestPath); await fs.mkdir(manifestPath);
+				expect((await invoke(env, "--validate-affected-evidence")).exitCode).toBe(1);
+			});
+		});
+
+		test("requires an explicit existing evidence root and rejects plan mode and capability drift", async () => {
+			const absent = path.join(os.tmpdir(), `ci-dev-evidence-absent-${Date.now()}`);
+			expect((await invoke({ CI_DEV_EVIDENCE_ROOT: absent }, "--validate-affected-evidence")).exitCode).toBe(1);
+			await withFixture(async ({ root, env }) => {
+				expect((await invoke({ ...env, CI_DEV_PLAN_MODE: "push" }, "--write-affected-evidence")).exitCode).toBe(1);
+			}, []);
+			const nativeTask = { key: "native-only", identity: "native-only", description: "native", command: ["true"], cwd: ".", capabilities: { rust: false, nextest: false, nativeConsumer: false, nativeProducer: true }, phase: "native-producer" };
+			await withFixture(async ({ root, env }) => {
+				expect((await invoke(env, "--write-affected-evidence")).exitCode).toBe(1);
+				expect((await invoke({ ...env, CI_DEV_HAS_NATIVE: "true", CI_DEV_NATIVE_RESULT: "success" }, "--write-affected-evidence")).exitCode).toBe(0);
+			}, [nativeTask]);
+			const regularTask = { key: "regular", identity: "regular", description: "regular", command: ["true"], cwd: ".", capabilities: { rust: false, nextest: false, nativeConsumer: false, nativeProducer: false }, phase: "legacy" };
+			await withFixture(async ({ root, env }) => {
+				expect((await invoke({ ...env, CI_DEV_HAS_TASKS: "false", CI_DEV_SHARDS_RESULT: "skipped" }, "--write-affected-evidence")).exitCode).toBe(1);
+			}, [regularTask]);
+		});
+
+		test("rejects unknown nested schemas, pair swaps, and receipt-side disagreement", async () => {
+			await withFixture(async ({ root, env }) => {
+				expect((await invoke(env, "--write-affected-evidence")).exitCode).toBe(0);
+				const manifestPath = path.join(root, ".ci-dev-affected-evidence.json"); const receiptPath = path.join(root, ".ci-dev-affected-evidence.receipt.json");
+				const manifest = await fs.readFile(manifestPath, "utf8"); const receipt = await fs.readFile(receiptPath, "utf8");
+				for (const mutate of [
+					async () => fs.writeFile(manifestPath, `${JSON.stringify({ ...JSON.parse(manifest), unknown: true })}\n`),
+					async () => {
+						const decoded = JSON.parse(manifest) as Record<string, unknown>;
+						decoded.replayScope = { ...(decoded.replayScope as Record<string, unknown>), unknown: true };
+						await fs.writeFile(manifestPath, `${JSON.stringify(decoded)}\n`);
+					},
+					async () => {
+						const decoded = JSON.parse(manifest) as Record<string, unknown>;
+						decoded.aggregateResults = { ...(decoded.aggregateResults as Record<string, unknown>), unknown: true };
+						await fs.writeFile(manifestPath, `${JSON.stringify(decoded)}\n`);
+					},
+					async () => fs.writeFile(receiptPath, `${JSON.stringify({ ...JSON.parse(receipt), sourceSha: "abcdefabcdefabcdefabcdefabcdefabcdefabcd" })}\n`),
+					async () => { await fs.writeFile(manifestPath, receipt); await fs.writeFile(receiptPath, manifest); },
+				]) {
+					await mutate(); expect((await invoke(env, "--validate-affected-evidence")).exitCode).toBe(1);
+					await fs.writeFile(manifestPath, manifest); await fs.writeFile(receiptPath, receipt);
+				}
+			});
+		});
+
+		test("rejects malformed UTF-8 evidence bytes", async () => {
+			await withFixture(async ({ root, env }) => {
+				expect((await invoke(env, "--write-affected-evidence")).exitCode).toBe(0);
+				await fs.writeFile(path.join(root, ".ci-dev-affected-evidence.json"), Uint8Array.from([0xff]));
+				expect((await invoke(env, "--validate-affected-evidence")).exitCode).toBe(1);
+			});
+		});
 	});
 
 	test("aggregate result truth table rejects every missing, failed, cancelled, and unplanned dependency", () => {

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -142,6 +142,14 @@ async function main(): Promise<void> {
 		await validateAggregate();
 		return;
 	}
+	if (process.argv.includes("--write-affected-evidence")) {
+		await writeAffectedEvidence();
+		return;
+	}
+	if (process.argv.includes("--validate-affected-evidence")) {
+		await validateAffectedEvidence();
+		return;
+	}
 	if (process.argv.includes("--native-build")) {
 		await runNativeBuild();
 		return;
@@ -1300,6 +1308,8 @@ async function validateAggregate(): Promise<void> {
 		hasNative: Bun.env.CI_DEV_HAS_NATIVE?.trim() || "",
 		hasTasks: Bun.env.CI_DEV_HAS_TASKS?.trim() || "",
 	};
+
+
 	console.log(`affected-plan: ${results.plan}`);
 	console.log(`affected-native: ${results.native}`);
 	console.log(`affected-shards: ${results.shards}`);
@@ -1310,12 +1320,199 @@ async function validateAggregate(): Promise<void> {
 	validateAffectedAggregate(results);
 	const tasks = await loadCanonicalPlan();
 	if (!tasks) throw new Error("affected-plan-invalid: aggregate requires a canonical plan");
+	validatePlanCapabilities(tasks, results, Bun.env.CI_DEV_PLAN_MODE?.trim() || resolvePlanMode());
+	console.log("Affected path validation: all required shards passed");
+}
+
+function validatePlanCapabilities(tasks: readonly Task[], results: Pick<AffectedAggregateResults, "hasNative" | "hasTasks">, mode: string): void {
+	if (mode !== "pr" && mode !== "push") throw new Error("affected-plan-invalid: invalid plan mode");
 	const expectedHasNative = String(tasks.some(task => task.capabilities?.nativeProducer === true));
 	const expectedHasTasks = String(tasks.some(task => task.capabilities?.nativeProducer !== true));
-	if (results.hasNative !== expectedHasNative || results.hasTasks !== expectedHasTasks) {
-		throw new Error("affected-plan-invalid: planner flags do not match canonical plan");
+	if (results.hasNative !== expectedHasNative || results.hasTasks !== expectedHasTasks) throw new Error("affected-plan-invalid: plan capability flags mismatch");
+}
+
+const AFFECTED_EVIDENCE_MANIFEST = ".ci-dev-affected-evidence.json";
+const AFFECTED_EVIDENCE_RECEIPT = ".ci-dev-affected-evidence.receipt.json";
+const AFFECTED_PLAN_NAME = ".ci-dev-affected-plan.json";
+const AFFECTED_SHARD_DIR = ".ci-dev-shard-receipts";
+const SHA256 = /^[a-f0-9]{64}$/;
+const SOURCE_SHA = /^[a-f0-9]{40}$/;
+
+type EvidenceChild = { name: string; sha256: string };
+type EvidenceTask = { key: string; identity: string };
+type ReplayScope = { repository: string; workflow: string; runId: string };
+type AffectedEvidenceManifest = {
+	schemaVersion: 1; subject: "ci-dev-affected-evidence"; sourceSha: string; planDigest: string; planMode: PlanMode;
+	replayScope: ReplayScope; aggregateResults: AffectedAggregateResults; taskIdentities: EvidenceTask[]; childEvidence: EvidenceChild[];
+};
+type DetachedEvidenceReceipt = {
+	schemaVersion: 1; subject: "ci-dev-affected-evidence"; manifestSha256: string; sourceSha: string; planDigest: string; replayScope: ReplayScope;
+};
+
+function sha256(value: string | Uint8Array): string { return new Bun.CryptoHasher("sha256").update(value).digest("hex"); }
+function canonicalEvidence(value: object): string { return `${JSON.stringify(value)}\n`; }
+function evidenceRoot(): string { return path.resolve(requiredEnv("CI_DEV_EVIDENCE_ROOT")); }
+function evidenceError(reason: string): Error { return new Error(`affected-evidence-invalid: ${reason}`); }
+function exactKeys(value: Record<string, unknown>, keys: readonly string[], reason: string): void {
+	if (Object.keys(value).length !== keys.length || Object.keys(value).some(key => !keys.includes(key))) throw evidenceError(reason);
+}
+function requiredEnv(name: string): string { const value = Bun.env[name]?.trim(); if (!value) throw evidenceError(`missing ${name}`); return value; }
+
+function isMissingError(error: unknown): boolean { return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"; }
+async function checkedEvidencePath(root: string, relative: string, finalKind: "file" | "directory"): Promise<string> {
+	const resolvedRoot = path.resolve(root);
+	const target = path.resolve(resolvedRoot, relative);
+	if (!target.startsWith(`${resolvedRoot}${path.sep}`)) throw evidenceError("path escaped staging root");
+	let rootStat: import("node:fs").Stats;
+	try { rootStat = await fs.lstat(resolvedRoot); } catch (error) { if (isMissingError(error)) throw evidenceError("missing staging root"); throw error; }
+	if (rootStat.isSymbolicLink()) throw evidenceError("symlink staging root");
+	if (!rootStat.isDirectory()) throw evidenceError("non-directory staging root");
+	let current = resolvedRoot;
+	for (const piece of path.relative(resolvedRoot, target).split(path.sep)) {
+		current = path.join(current, piece);
+		let stat: import("node:fs").Stats;
+		try { stat = await fs.lstat(current); } catch (error) { if (isMissingError(error)) throw evidenceError("missing evidence object"); throw error; }
+		if (stat.isSymbolicLink()) throw evidenceError("symlink evidence object");
+		const final = current === target;
+		if (final ? (finalKind === "file" ? !stat.isFile() : !stat.isDirectory()) : !stat.isDirectory()) {
+			throw evidenceError(final ? `non-${finalKind} evidence object` : "non-directory evidence parent");
+		}
 	}
-	console.log("Affected path validation: all required shards passed");
+	return target;
+}
+async function readEvidenceBytes(root: string, relative: string): Promise<Uint8Array> { return new Uint8Array(await fs.readFile(await checkedEvidencePath(root, relative, "file"))); }
+function decodeEvidenceJson(raw: Uint8Array): string { try { return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(raw); } catch { throw evidenceError("malformed UTF-8 evidence"); } }
+async function readEvidenceFile(root: string, relative: string): Promise<string> { return decodeEvidenceJson(await readEvidenceBytes(root, relative)); }
+async function checkEvidenceDirectory(root: string, relative: string): Promise<string> { return checkedEvidencePath(root, relative, "directory"); }
+
+function expectedEvidenceTasks(tasks: readonly Task[]): EvidenceTask[] {
+	return tasks.filter(task => task.capabilities?.nativeProducer !== true).map(task => ({ key: task.key, identity: canonicalTaskIdentity(task) }));
+}
+function expectedEvidenceNames(tasks: readonly Task[]): string[] {
+	return [AFFECTED_PLAN_NAME, ...expectedEvidenceTasks(tasks).map((_, index) => `${AFFECTED_SHARD_DIR}/${index}.json`)];
+}
+function canonicalReplayScope(): ReplayScope {
+	return { repository: requiredEnv("GITHUB_REPOSITORY"), workflow: requiredEnv("GITHUB_WORKFLOW"), runId: requiredEnv("GITHUB_RUN_ID") };
+}
+function aggregateFromEnv(): AffectedAggregateResults {
+	return { plan: requiredEnv("CI_DEV_PLAN_RESULT"), native: requiredEnv("CI_DEV_NATIVE_RESULT"), shards: requiredEnv("CI_DEV_SHARDS_RESULT"), windowsDoctor: requiredEnv("CI_DEV_WINDOWS_DOCTOR_RESULT"), windowsDoctorRequired: requiredEnv("CI_DEV_WINDOWS_DOCTOR_REQUIRED"), hasNative: requiredEnv("CI_DEV_HAS_NATIVE"), hasTasks: requiredEnv("CI_DEV_HAS_TASKS") };
+}
+function parseAggregate(value: unknown): AffectedAggregateResults {
+	if (!isRecord(value)) throw evidenceError("malformed aggregate results");
+	exactKeys(value, ["plan", "native", "shards", "windowsDoctor", "windowsDoctorRequired", "hasNative", "hasTasks"], "unexpected aggregate results field");
+	if (!Object.values(value).every(isString)) throw evidenceError("malformed aggregate results");
+	return { plan: value.plan as string, native: value.native as string, shards: value.shards as string, windowsDoctor: value.windowsDoctor as string, windowsDoctorRequired: value.windowsDoctorRequired as string, hasNative: value.hasNative as string, hasTasks: value.hasTasks as string };
+}
+function parseReplayScope(value: unknown): ReplayScope {
+	if (!isRecord(value)) throw evidenceError("malformed replay scope");
+	exactKeys(value, ["repository", "workflow", "runId"], "unexpected replay scope field");
+	if (!isString(value.repository) || !isString(value.workflow) || !isString(value.runId) || !value.repository || !value.workflow || !value.runId) throw evidenceError("malformed replay scope");
+	return { repository: value.repository, workflow: value.workflow, runId: value.runId };
+}
+function parseEvidenceTasks(value: unknown): EvidenceTask[] {
+	if (!Array.isArray(value)) throw evidenceError("malformed task identities");
+	return value.map(entry => { if (!isRecord(entry)) throw evidenceError("malformed task identity"); exactKeys(entry, ["key", "identity"], "unexpected task identity field"); if (!isString(entry.key) || !isString(entry.identity) || !entry.key || !entry.identity) throw evidenceError("malformed task identity"); return { key: entry.key, identity: entry.identity }; });
+}
+function parseEvidenceChildren(value: unknown): EvidenceChild[] {
+	if (!Array.isArray(value)) throw evidenceError("malformed child evidence");
+	return value.map(entry => { if (!isRecord(entry)) throw evidenceError("malformed child evidence"); exactKeys(entry, ["name", "sha256"], "unexpected child evidence field"); if (!isString(entry.name) || !isString(entry.sha256) || !SHA256.test(entry.sha256)) throw evidenceError("malformed child evidence"); return { name: entry.name, sha256: entry.sha256 }; });
+}
+function parseCanonicalManifest(raw: string): AffectedEvidenceManifest {
+	let decoded: unknown; try { decoded = JSON.parse(raw); } catch { throw evidenceError("malformed manifest"); }
+	if (!isRecord(decoded)) throw evidenceError("malformed manifest");
+	exactKeys(decoded, ["schemaVersion", "subject", "sourceSha", "planDigest", "planMode", "replayScope", "aggregateResults", "taskIdentities", "childEvidence"], "unexpected manifest field");
+	if (decoded.schemaVersion !== 1 || decoded.subject !== "ci-dev-affected-evidence" || !isString(decoded.sourceSha) || !SOURCE_SHA.test(decoded.sourceSha) || !isString(decoded.planDigest) || !SHA256.test(decoded.planDigest) || (decoded.planMode !== "pr" && decoded.planMode !== "push")) throw evidenceError("malformed manifest");
+	const manifest: AffectedEvidenceManifest = { schemaVersion: 1, subject: "ci-dev-affected-evidence", sourceSha: decoded.sourceSha, planDigest: decoded.planDigest, planMode: decoded.planMode, replayScope: parseReplayScope(decoded.replayScope), aggregateResults: parseAggregate(decoded.aggregateResults), taskIdentities: parseEvidenceTasks(decoded.taskIdentities), childEvidence: parseEvidenceChildren(decoded.childEvidence) };
+	if (raw !== canonicalEvidence(manifest)) throw evidenceError("non-canonical manifest bytes");
+	return manifest;
+}
+function parseCanonicalReceipt(raw: string): DetachedEvidenceReceipt {
+	let decoded: unknown; try { decoded = JSON.parse(raw); } catch { throw evidenceError("malformed receipt"); }
+	if (!isRecord(decoded)) throw evidenceError("malformed receipt");
+	exactKeys(decoded, ["schemaVersion", "subject", "manifestSha256", "sourceSha", "planDigest", "replayScope"], "unexpected receipt field");
+	if (decoded.schemaVersion !== 1 || decoded.subject !== "ci-dev-affected-evidence" || !isString(decoded.manifestSha256) || !SHA256.test(decoded.manifestSha256) || !isString(decoded.sourceSha) || !SOURCE_SHA.test(decoded.sourceSha) || !isString(decoded.planDigest) || !SHA256.test(decoded.planDigest)) throw evidenceError("malformed receipt");
+	const receipt: DetachedEvidenceReceipt = { schemaVersion: 1, subject: "ci-dev-affected-evidence", manifestSha256: decoded.manifestSha256, sourceSha: decoded.sourceSha, planDigest: decoded.planDigest, replayScope: parseReplayScope(decoded.replayScope) };
+	if (raw !== canonicalEvidence(receipt)) throw evidenceError("non-canonical receipt bytes");
+	return receipt;
+}
+
+async function readValidatedEvidencePlan(root: string): Promise<{ tasks: Task[]; raw: Uint8Array; mode: PlanMode }> {
+	const raw = await readEvidenceBytes(root, AFFECTED_PLAN_NAME);
+	let decoded: unknown; try { decoded = JSON.parse(decodeEvidenceJson(raw)); } catch { throw evidenceError("malformed canonical plan"); }
+	if (!isRecord(decoded) || (decoded.mode !== "pr" && decoded.mode !== "push")) throw evidenceError("malformed canonical plan");
+	const planPath = path.join(root, AFFECTED_PLAN_NAME);
+	const original = Bun.env.CI_DEV_AFFECTED_PLAN;
+	Bun.env.CI_DEV_AFFECTED_PLAN = planPath;
+	try { const tasks = await loadCanonicalPlan(); if (!tasks) throw evidenceError("missing canonical plan"); return { tasks, raw, mode: decoded.mode }; }
+	finally { if (original === undefined) delete Bun.env.CI_DEV_AFFECTED_PLAN; else Bun.env.CI_DEV_AFFECTED_PLAN = original; }
+}
+async function collectChildEvidence(root: string, tasks: readonly Task[]): Promise<EvidenceChild[]> {
+	const expected = expectedEvidenceNames(tasks);
+	const shardTasks = expectedEvidenceTasks(tasks);
+	if (shardTasks.length === 0) {
+		try { await fs.lstat(path.join(root, AFFECTED_SHARD_DIR)); throw evidenceError("unexpected shard receipt directory"); } catch (error) { if (error instanceof Error && error.message.startsWith("affected-evidence-invalid")) throw error; if (!isMissingError(error)) throw error; }
+	} else {
+		const directory = await checkEvidenceDirectory(root, AFFECTED_SHARD_DIR);
+		const entries = await fs.readdir(directory);
+		if (entries.length !== shardTasks.length || entries.some(entry => !/^\d+\.json$/.test(entry))) throw evidenceError("shard receipt set does not match canonical plan");
+	}
+	const children: EvidenceChild[] = [];
+	for (const [index, name] of expected.entries()) {
+		const rawBytes = await readEvidenceBytes(root, name);
+		const raw = decodeEvidenceJson(rawBytes);
+		if (index > 0) {
+			let value: unknown; try { value = JSON.parse(raw); } catch { throw evidenceError("malformed shard receipt"); }
+			const expectedTask = shardTasks[index - 1]!;
+			if (!isRecord(value) || Object.keys(value).length !== 2 || value.key !== expectedTask.key || value.identity !== expectedTask.identity) throw evidenceError("shard receipt set does not match canonical plan");
+		}
+		children.push({ name, sha256: sha256(rawBytes) });
+	}
+	return children;
+}
+async function writeAffectedEvidence(): Promise<void> {
+	const root = evidenceRoot();
+	const { tasks, raw: planRaw, mode: planMode } = await readValidatedEvidencePlan(root);
+	const results = aggregateFromEnv(); validateAffectedAggregate(results);
+	const digest = requiredEnv("CI_DEV_PLAN_DIGEST");
+	const mode = requiredEnv("CI_DEV_PLAN_MODE");
+	if (mode !== "pr" && mode !== "push") throw evidenceError("invalid CI_DEV_PLAN_MODE");
+	if (mode !== planMode) throw evidenceError("plan mode mismatch");
+	validatePlanCapabilities(tasks, results, mode);
+	if (sha256(planRaw) !== digest) throw evidenceError("plan digest mismatch");
+	const manifestPath = path.join(root, AFFECTED_EVIDENCE_MANIFEST); const receiptPath = path.join(root, AFFECTED_EVIDENCE_RECEIPT);
+	for (const target of [manifestPath, receiptPath]) { try { await fs.lstat(target); throw evidenceError("evidence target already exists"); } catch (error) { if (error instanceof Error && error.message.startsWith("affected-evidence-invalid")) throw error; if (!isMissingError(error)) throw error; } }
+	const manifest: AffectedEvidenceManifest = { schemaVersion: 1, subject: "ci-dev-affected-evidence", sourceSha: requiredEnv("CI_DEV_SOURCE_SHA"), planDigest: digest, planMode: mode, replayScope: canonicalReplayScope(), aggregateResults: results, taskIdentities: expectedEvidenceTasks(tasks), childEvidence: await collectChildEvidence(root, tasks) };
+	let wroteManifest = false;
+	try {
+		await fs.writeFile(manifestPath, canonicalEvidence(manifest), { flag: "wx" }); wroteManifest = true;
+		const finalized = await readEvidenceBytes(root, AFFECTED_EVIDENCE_MANIFEST);
+		if (Bun.env.CI_DEV_INJECT_EVIDENCE_POST_MANIFEST_FAILURE === "true") throw evidenceError("injected post-manifest failure");
+		const receipt: DetachedEvidenceReceipt = { schemaVersion: 1, subject: "ci-dev-affected-evidence", manifestSha256: sha256(finalized), sourceSha: manifest.sourceSha, planDigest: manifest.planDigest, replayScope: manifest.replayScope };
+		await fs.writeFile(receiptPath, canonicalEvidence(receipt), { flag: "wx" });
+		console.log(`affected evidence produced: ${manifest.childEvidence.length} child evidence file(s)`);
+	} catch (error) { if (wroteManifest) await fs.rm(manifestPath, { force: true }); throw error; }
+}
+async function validateAffectedEvidence(): Promise<void> {
+	const root = evidenceRoot();
+	const receiptRaw = await readEvidenceFile(root, AFFECTED_EVIDENCE_RECEIPT);
+	const manifestBytes = await readEvidenceBytes(root, AFFECTED_EVIDENCE_MANIFEST);
+	const manifestRaw = decodeEvidenceJson(manifestBytes);
+	const receipt = parseCanonicalReceipt(receiptRaw);
+	if (receipt.manifestSha256 !== sha256(manifestBytes)) throw evidenceError("manifest digest mismatch");
+	const manifest = parseCanonicalManifest(manifestRaw);
+	const { tasks, raw: planRaw, mode: planMode } = await readValidatedEvidencePlan(root);
+	const expectedReplay = canonicalReplayScope(); const expectedSource = requiredEnv("CI_DEV_SOURCE_SHA"); const expectedDigest = requiredEnv("CI_DEV_PLAN_DIGEST");
+	if (manifest.sourceSha !== expectedSource || receipt.sourceSha !== expectedSource || manifest.planDigest !== expectedDigest || receipt.planDigest !== expectedDigest || JSON.stringify(manifest.replayScope) !== JSON.stringify(expectedReplay) || JSON.stringify(receipt.replayScope) !== JSON.stringify(expectedReplay)) throw evidenceError("replay binding mismatch");
+	if (manifest.planMode !== requiredEnv("CI_DEV_PLAN_MODE") || manifest.planMode !== planMode || sha256(planRaw) !== expectedDigest) throw evidenceError("plan binding mismatch");
+	validateAffectedAggregate(manifest.aggregateResults);
+	const liveAggregate = aggregateFromEnv();
+	if (JSON.stringify(manifest.aggregateResults) !== JSON.stringify(liveAggregate)) throw evidenceError("aggregate result mismatch");
+	validatePlanCapabilities(tasks, liveAggregate, manifest.planMode);
+	const expectedTasks = expectedEvidenceTasks(tasks);
+	if (JSON.stringify(manifest.taskIdentities) !== JSON.stringify(expectedTasks)) throw evidenceError("task identity mismatch");
+	const children = await collectChildEvidence(root, tasks);
+	if (JSON.stringify(manifest.childEvidence) !== JSON.stringify(children)) throw evidenceError("child evidence mismatch");
+	console.log(`affected evidence validated: ${children.length} child evidence file(s)`);
 }
 
 async function validateShardReceipts(): Promise<void> {


### PR DESCRIPTION
## Summary

- finalize `.ci-dev-affected-evidence.json` without a self-digest, then hash its exact persisted bytes from `.ci-dev-affected-evidence.receipt.json`
- bind source SHA, canonical plan digest/mode, aggregate results, task identities, replay scope, and exact raw child evidence bytes
- move the stable protected `Affected path validation` status to a downstream artifact-ID consumer using clean `RUNNER_TEMP` staging
- fail closed on malformed/non-canonical/BOM evidence, tamper, replay and semantic mismatches, missing/extra shards, partial pairs, symlinks, non-regular objects, and ambiguous filesystem absence

## Contract

The producer is trusted/reviewed. The detached receipt provides post-production exact-byte integrity and semantic replay binding; it does not claim cryptographic attestation against malicious producer code. Existing canonical-plan and shard-receipt byte formats remain unchanged.

## Verification

- `bun test scripts/ci-dev-affected.test.ts` — 61 passed, 328 assertions
- `bun scripts/check-workflow-yaml.ts`
- `bun scripts/ci-dev-affected.ts --dry-run`
- `bun run ci:check:full`
- fresh independent adversarial exact-head GJC review: `CLEAR / APPROVE` at `9a228f5a6d99547a4baee44135e83e0b270221b0`
- executor QA/red-team: passed at the same exact head

Fixes #2614

Do not merge until hosted CI is terminal green at the reviewed exact head. No release, publish, or main merge is authorized.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*