### PR TITLE
fix(coding-agent): unify Python env flag resolution

### DIFF
--- a/packages/coding-agent/src/eval/py/env.ts
+++ b/packages/coding-agent/src/eval/py/env.ts
@@ -1,0 +1,26 @@
+/** Environment values consulted by the Python subprocess integration. */
+export type PythonEnv = Record<string, string | undefined>;
+
+const PYTHON_TRUTHY = new Set(["1", "true", "yes", "on", "y"]);
+
+/** True when `value` is a non-empty string matching a truthy boolean token. */
+export function isTruthyPythonFlag(value: string | undefined): boolean {
+	return value !== undefined && PYTHON_TRUTHY.has(value.trim().toLowerCase());
+}
+
+/** Resolve paired GJC/legacy PI flags using OR semantics. */
+export function resolvePythonFlag(env: PythonEnv, gjcName: string, piName: string): boolean {
+	return isTruthyPythonFlag(env[gjcName]) || isTruthyPythonFlag(env[piName]);
+}
+
+export function resolvePythonSkipCheck(env: PythonEnv): boolean {
+	return resolvePythonFlag(env, "GJC_PYTHON_SKIP_CHECK", "PI_PYTHON_SKIP_CHECK");
+}
+
+export function resolvePythonIpcTrace(env: PythonEnv): boolean {
+	return resolvePythonFlag(env, "GJC_PYTHON_IPC_TRACE", "PI_PYTHON_IPC_TRACE");
+}
+
+export function resolvePythonIntegrationGate(env: PythonEnv): boolean {
+	return resolvePythonFlag(env, "GJC_PYTHON_INTEGRATION", "PI_PYTHON_INTEGRATION");
+}

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -16,6 +16,7 @@ import type { Subprocess } from "bun";
 import { $ } from "bun";
 import { Settings } from "../../config/settings";
 import { type KernelDisplayOutput, renderKernelDisplay } from "./display";
+import { resolvePythonIpcTrace, resolvePythonSkipCheck } from "./env";
 import { PYTHON_PRELUDE } from "./prelude";
 import RUNNER_SCRIPT from "./runner.py" with { type: "text" };
 import { ensurePythonRuntime, filterEnv, type PythonRuntimeOptions } from "./runtime";
@@ -23,30 +24,8 @@ import { ensurePythonRuntime, filterEnv, type PythonRuntimeOptions } from "./run
 export type { KernelDisplayOutput, PythonStatusEvent } from "./display";
 export { renderKernelDisplay } from "./display";
 
-/**
- * Truthy set for boolean-style Python env flags. Case-insensitive: `1`,
- * `true`, `yes` (and `on`/`y`) are treated as true; everything else is false.
- * Mirrors the canonical resolver in `tools/index.ts` so this module can
- * dual-read `GJC_*` / `PI_*` names without importing the tools barrel (which
- * would create a circular import at top-level `TRACE_IPC` evaluation).
- */
-const PYTHON_TRUTHY = new Set(["1", "true", "yes", "on", "y"]);
-
-/** True when `value` is a non-empty string matching a truthy boolean token. */
-function isTruthyPythonFlag(value: string | undefined): boolean {
-	return value !== undefined && PYTHON_TRUTHY.has(value.trim().toLowerCase());
-}
-
-/**
- * Resolve a boolean Python env flag preferring the `GJC_` name and falling back
- * to the legacy `PI_` name. Either truthy value wins (OR semantics).
- */
-function resolvePythonFlag(gjcName: string, piName: string): boolean {
-	return isTruthyPythonFlag($env[gjcName]) || isTruthyPythonFlag($env[piName]);
-}
-
 // Dual-read: `GJC_PYTHON_IPC_TRACE` is preferred, then legacy `PI_PYTHON_IPC_TRACE`.
-const TRACE_IPC = resolvePythonFlag("GJC_PYTHON_IPC_TRACE", "PI_PYTHON_IPC_TRACE");
+const TRACE_IPC = resolvePythonIpcTrace($env);
 
 // Cache the runner script on disk so the subprocess loads it normally. Cached
 // per script hash so installs don't race across versions.
@@ -148,7 +127,7 @@ export async function checkPythonKernelAvailability(
 	cwd: string,
 	runtimeOptions?: PythonRuntimeOptions,
 ): Promise<PythonKernelAvailability> {
-	if (isBunTestRuntime() || resolvePythonFlag("GJC_PYTHON_SKIP_CHECK", "PI_PYTHON_SKIP_CHECK")) {
+	if (isBunTestRuntime() || resolvePythonSkipCheck($env)) {
 		return { ok: true };
 	}
 	try {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -4,6 +4,7 @@ import { $env, logger } from "@gajae-code/utils";
 import type { PromptTemplate } from "../config/prompt-templates";
 import type { Settings } from "../config/settings";
 import { EditTool } from "../edit";
+import { isTruthyPythonFlag } from "../eval/py/env";
 import { checkPythonKernelAvailability } from "../eval/py/kernel";
 import type { Skill } from "../extensibility/skills";
 import type { GoalModeState, GoalRuntime } from "../goals";
@@ -500,17 +501,6 @@ export interface EvalBackendsAllowance {
 }
 
 /**
- * Truthy set for boolean-style Python env flags. Case-insensitive: `1`,
- * `true`, `yes` (and `on`/`y`) are treated as true; everything else is false.
- */
-const PYTHON_TRUTHY = new Set(["1", "true", "yes", "on", "y"]);
-
-/** True when `value` is a non-empty string matching a truthy boolean token. */
-function isTruthyFlag(value: string | undefined): boolean {
-	return value !== undefined && PYTHON_TRUTHY.has(value.trim().toLowerCase());
-}
-
-/**
  * Parse the `GJC_PY` multi-value token into per-backend booleans.
  *
  * Tokens (case-insensitive):
@@ -556,8 +546,8 @@ function parseLegacyEvalEnvFlags(env: Record<string, string | undefined>): EvalB
 	const jsEnv = env.PI_JS;
 	if (pyEnv === undefined && jsEnv === undefined) return null;
 	return {
-		python: pyEnv === undefined ? true : isTruthyFlag(pyEnv),
-		js: jsEnv === undefined ? true : isTruthyFlag(jsEnv),
+		python: pyEnv === undefined ? true : isTruthyPythonFlag(pyEnv),
+		js: jsEnv === undefined ? true : isTruthyPythonFlag(jsEnv),
 	};
 }
 
@@ -589,33 +579,11 @@ export function resolveEvalBackends(session: ToolSession): EvalBackendsAllowance
 	return resolveEvalBackendsFromEnv($env) ?? readEvalBackendsAllowance(session);
 }
 
-/**
- * Resolve the Python skip-check flag. `GJC_PYTHON_SKIP_CHECK` is preferred;
- * falls back to legacy `PI_PYTHON_SKIP_CHECK`. Truthy values: `1`, `true`,
- * `yes` (case-insensitive).
- */
-export function resolvePythonSkipCheck(env: Record<string, string | undefined>): boolean {
-	return isTruthyFlag(env.GJC_PYTHON_SKIP_CHECK) || isTruthyFlag(env.PI_PYTHON_SKIP_CHECK);
-}
-
-/**
- * Resolve the Python IPC trace flag. `GJC_PYTHON_IPC_TRACE` is preferred;
- * falls back to legacy `PI_PYTHON_IPC_TRACE`. Truthy values: `1`, `true`,
- * `yes` (case-insensitive).
- */
-export function resolvePythonIpcTrace(env: Record<string, string | undefined>): boolean {
-	return isTruthyFlag(env.GJC_PYTHON_IPC_TRACE) || isTruthyFlag(env.PI_PYTHON_IPC_TRACE);
-}
-
-/**
- * Resolve the gated Python integration-test gate. Uses OR semantics:
- * `GJC_PYTHON_INTEGRATION === "1"` OR `PI_PYTHON_INTEGRATION === "1"` enables
- * it. A truthy value on either name opts the tests in, so `GJC=0, PI=1` is
- * still true. Truthy values: `1`, `true`, `yes` (case-insensitive).
- */
-export function resolvePythonIntegrationGate(env: Record<string, string | undefined>): boolean {
-	return isTruthyFlag(env.GJC_PYTHON_INTEGRATION) || isTruthyFlag(env.PI_PYTHON_INTEGRATION);
-}
+export {
+	resolvePythonIntegrationGate,
+	resolvePythonIpcTrace,
+	resolvePythonSkipCheck,
+} from "../eval/py/env";
 
 /**
  * Create tools from BUILTIN_TOOLS registry.

--- a/packages/coding-agent/test/eval/python-env.test.ts
+++ b/packages/coding-agent/test/eval/python-env.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import {
+	resolvePythonIntegrationGate,
+	resolvePythonIpcTrace,
+	resolvePythonSkipCheck,
+} from "@gajae-code/coding-agent/tools";
+import {
+	resolvePythonIntegrationGate as resolveKernelIntegrationGate,
+	resolvePythonIpcTrace as resolveKernelIpcTrace,
+	resolvePythonSkipCheck as resolveKernelSkipCheck,
+} from "../../src/eval/py/env";
+
+const RESOLVERS = [
+	{
+		kernel: resolveKernelSkipCheck,
+		tool: resolvePythonSkipCheck,
+		gjc: "GJC_PYTHON_SKIP_CHECK",
+		pi: "PI_PYTHON_SKIP_CHECK",
+	},
+	{
+		kernel: resolveKernelIpcTrace,
+		tool: resolvePythonIpcTrace,
+		gjc: "GJC_PYTHON_IPC_TRACE",
+		pi: "PI_PYTHON_IPC_TRACE",
+	},
+	{
+		kernel: resolveKernelIntegrationGate,
+		tool: resolvePythonIntegrationGate,
+		gjc: "GJC_PYTHON_INTEGRATION",
+		pi: "PI_PYTHON_INTEGRATION",
+	},
+] as const;
+
+describe("Python environment flag resolvers", () => {
+	it("shares the kernel resolver with tool exports for hostile GJC/PI values", () => {
+		for (const { kernel, tool, gjc, pi } of RESOLVERS) {
+			expect(tool).toBe(kernel);
+			expect(tool({ [gjc]: "0", [pi]: "1" })).toBe(true);
+			expect(tool({ [gjc]: " \tYeS\n" })).toBe(true);
+			expect(tool({ [gjc]: "false", [pi]: " 0 " })).toBe(false);
+		}
+	});
+});

--- a/packages/coding-agent/test/eval/python-lifecycle.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
 import { disposeAllKernelSessions, executePython } from "@gajae-code/coding-agent/eval/py/executor";
 import type {
 	KernelExecuteOptions,
@@ -9,6 +10,18 @@ import { checkPythonKernelAvailability, PythonKernel } from "@gajae-code/coding-
 import { TempDir } from "@gajae-code/utils";
 
 const originalStart = PythonKernel.start;
+
+function snapshotEnv(keys: readonly string[]): Map<string, string | undefined> {
+	return new Map(keys.map(key => [key, Bun.env[key]]));
+}
+
+function restoreEnv(keys: readonly string[], snapshot: Map<string, string | undefined>): void {
+	for (const key of keys) {
+		const value = snapshot.get(key);
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+	}
+}
 
 const OK_RESULT: KernelExecuteResult = {
 	status: "ok",
@@ -62,9 +75,20 @@ async function waitForExit(pid: number, timeoutMs = 3000): Promise<boolean> {
 }
 
 describe("python eval lifecycle", () => {
+	const envKeys = ["PI_PYTHON_SKIP_CHECK"] as const;
+	let previousEnv = new Map<string, string | undefined>();
+
+	beforeEach(() => {
+		previousEnv = snapshotEnv(envKeys);
+	});
+
 	afterEach(async () => {
 		PythonKernel.start = originalStart;
-		await disposeAllKernelSessions();
+		try {
+			await disposeAllKernelSessions();
+		} finally {
+			restoreEnv(envKeys, previousEnv);
+		}
 	});
 
 	it("coalesces concurrent first acquires for the same session into one kernel", async () => {
@@ -208,17 +232,18 @@ describe("python kernel env-var dual-read (GJC_* preferred, PI_* fallback)", () 
 	// (NODE_ENV/BUN_ENV === "test"), which would mask the skip-check branch.
 	// These tests neutralize the test-runtime guard inside a scoped window and
 	// restore it in finally so the real GJC/PI skip-check branch is exercised.
-	const SKIP_ENV_KEYS = [
+	const envKeys = [
 		"GJC_PYTHON_SKIP_CHECK",
 		"PI_PYTHON_SKIP_CHECK",
 		"GJC_PYTHON_IPC_TRACE",
 		"PI_PYTHON_IPC_TRACE",
+		"NODE_ENV",
+		"BUN_ENV",
 	] as const;
-	const originalNodeEnv = Bun.env.NODE_ENV;
-	const originalBunEnv = Bun.env.BUN_ENV;
+	let previousEnv = new Map<string, string | undefined>();
 
 	function clearSkipEnv(): void {
-		for (const key of SKIP_ENV_KEYS) delete Bun.env[key];
+		for (const key of envKeys) delete Bun.env[key];
 	}
 
 	function neutralizeTestRuntime(): void {
@@ -228,16 +253,26 @@ describe("python kernel env-var dual-read (GJC_* preferred, PI_* fallback)", () 
 		delete Bun.env.BUN_ENV;
 	}
 
-	function restoreTestRuntime(): void {
-		Bun.env.NODE_ENV = originalNodeEnv;
-		Bun.env.BUN_ENV = originalBunEnv;
-	}
-
-	afterEach(() => {
-		clearSkipEnv();
-		restoreTestRuntime();
+	beforeEach(() => {
+		previousEnv = snapshotEnv(envKeys);
 	});
 
+	afterEach(() => {
+		restoreEnv(envKeys, previousEnv);
+	});
+
+	it("restores pre-existing environment values after cleanup", () => {
+		const suiteEnv = snapshotEnv(envKeys);
+		try {
+			for (const key of envKeys) Bun.env[key] = `hostile-${key}`;
+			const testEnv = snapshotEnv(envKeys);
+			clearSkipEnv();
+			restoreEnv(envKeys, testEnv);
+			for (const key of envKeys) expect(Bun.env[key]).toBe(`hostile-${key}`);
+		} finally {
+			restoreEnv(envKeys, suiteEnv);
+		}
+	});
 	it("honors GJC_PYTHON_SKIP_CHECK=1 and returns ok without spawning Python", async () => {
 		clearSkipEnv();
 		neutralizeTestRuntime();

--- a/packages/coding-agent/test/tools/eval-fallback.test.ts
+++ b/packages/coding-agent/test/tools/eval-fallback.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import * as evalIndex from "@gajae-code/coding-agent/eval";
 import * as pyKernel from "@gajae-code/coding-agent/eval/py/kernel";
@@ -28,12 +29,48 @@ const mockResult = {
 	displayOutputs: [],
 };
 
+const ENV_KEYS = ["GJC_PY", "PI_PY", "PI_JS"] as const;
+
+function snapshotEnv(): Map<string, string | undefined> {
+	return new Map(ENV_KEYS.map(key => [key, Bun.env[key]]));
+}
+
+function restoreEnv(snapshot: Map<string, string | undefined>): void {
+	for (const key of ENV_KEYS) {
+		const value = snapshot.get(key);
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+	}
+}
+
+function clearEnv(): void {
+	for (const key of ENV_KEYS) delete Bun.env[key];
+}
+
 describe("EvalTool language dispatch", () => {
-	afterEach(() => {
-		vi.restoreAllMocks();
-		delete Bun.env.GJC_PY;
+	let previousEnv = new Map<string, string | undefined>();
+
+	beforeEach(() => {
+		previousEnv = snapshotEnv();
+		clearEnv();
 	});
 
+	afterEach(() => {
+		restoreEnv(previousEnv);
+		vi.restoreAllMocks();
+	});
+	it("restores a pre-existing GJC_PY value after cleanup", () => {
+		const suiteEnv = snapshotEnv();
+		try {
+			Bun.env.GJC_PY = "hostile-value";
+			const testEnv = snapshotEnv();
+			delete Bun.env.GJC_PY;
+			restoreEnv(testEnv);
+			expect(String(Bun.env.GJC_PY)).toBe("hostile-value");
+		} finally {
+			restoreEnv(suiteEnv);
+		}
+	});
 	it('dispatches to the JS backend when cell.language === "js"', async () => {
 		const jsExecuteSpy = vi.spyOn(evalIndex.jsBackend, "execute").mockResolvedValue(mockResult);
 		const pythonExecuteSpy = vi.spyOn(evalIndex.pythonBackend, "execute");

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+
 import { type SettingPath, Settings } from "@gajae-code/coding-agent/config/settings";
 import {
 	BUILTIN_TOOLS,
@@ -13,7 +14,37 @@ import {
 	type ToolSession,
 } from "@gajae-code/coding-agent/tools";
 
-Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+const PY_ENV_KEYS = [
+	"GJC_PY",
+	"PI_PY",
+	"PI_JS",
+	"GJC_PYTHON_SKIP_CHECK",
+	"PI_PYTHON_SKIP_CHECK",
+	"GJC_PYTHON_IPC_TRACE",
+	"PI_PYTHON_IPC_TRACE",
+	"GJC_PYTHON_INTEGRATION",
+	"PI_PYTHON_INTEGRATION",
+] as const;
+
+function snapshotPyEnv(): Map<string, string | undefined> {
+	return new Map(PY_ENV_KEYS.map(key => [key, Bun.env[key]]));
+}
+
+function restorePyEnv(snapshot: Map<string, string | undefined>): void {
+	for (const key of PY_ENV_KEYS) {
+		const value = snapshot.get(key);
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+	}
+}
+
+let testPyEnv = new Map<string, string | undefined>();
+beforeEach(() => {
+	testPyEnv = snapshotPyEnv();
+	clearPyEnvKeys();
+	Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+});
+afterEach(() => restorePyEnv(testPyEnv));
 
 function createTestSession(overrides: Partial<ToolSession> = {}): ToolSession {
 	return {
@@ -337,18 +368,6 @@ describe("createTools", () => {
 
 // Env vars exercised below leak across tests via the shared `Bun.env`/`$env`
 // reference, so each block restores the keys it touches in afterEach.
-const PY_ENV_KEYS = [
-	"GJC_PY",
-	"PI_PY",
-	"PI_JS",
-	"GJC_PYTHON_SKIP_CHECK",
-	"PI_PYTHON_SKIP_CHECK",
-	"GJC_PYTHON_IPC_TRACE",
-	"PI_PYTHON_IPC_TRACE",
-	"GJC_PYTHON_INTEGRATION",
-	"PI_PYTHON_INTEGRATION",
-] as const;
-
 function clearPyEnvKeys(): void {
 	for (const key of PY_ENV_KEYS) delete Bun.env[key];
 }
@@ -433,8 +452,27 @@ describe("resolveEvalBackendsFromEnv", () => {
 });
 
 describe("resolveEvalBackends (session integration)", () => {
-	afterEach(() => clearPyEnvKeys());
+	let previousEnv = new Map<string, string | undefined>();
 
+	beforeEach(() => {
+		previousEnv = snapshotPyEnv();
+		clearPyEnvKeys();
+	});
+
+	afterEach(() => restorePyEnv(previousEnv));
+
+	it("restores pre-existing Python environment values after cleanup", () => {
+		const suiteEnv = snapshotPyEnv();
+		try {
+			for (const key of PY_ENV_KEYS) Bun.env[key] = `hostile-${key}`;
+			const testEnv = snapshotPyEnv();
+			clearPyEnvKeys();
+			restorePyEnv(testEnv);
+			for (const key of PY_ENV_KEYS) expect(Bun.env[key]).toBe(`hostile-${key}`);
+		} finally {
+			restorePyEnv(suiteEnv);
+		}
+	});
 	it("defers to settings when no env override is set", () => {
 		clearPyEnvKeys();
 		const session = createTestSession({


### PR DESCRIPTION
## Summary

Follow-up repair for postmerge regressions discovered while closing #2527:

- centralizes Python boolean env parsing in one leaf module used by the actual kernel IPC/skip-check paths and the public tools exports;
- preserves `GJC_*`/legacy `PI_*` OR semantics and module-load IPC trace timing;
- restores every test-mutated Python environment key to its exact inherited value or absence;
- neutralizes inherited `GJC_PY`/`PI_PY`/`PI_JS` selectors before dispatch/default-behavior tests.

## Root cause

#2527 initially kept a duplicate truthy parser in `eval/py/kernel.ts` to avoid a tools-barrel cycle, allowing production IPC behavior and tested tool helpers to drift. Its new tests also deleted shared `Bun.env` keys instead of restoring preexisting values, so inherited operator/test-runner settings could contaminate unrelated cases.

## Verification

- `bun test packages/coding-agent/test/eval/python-env.test.ts packages/coding-agent/test/eval/python-lifecycle.test.ts packages/coding-agent/test/tools/eval-fallback.test.ts packages/coding-agent/test/tools/index.test.ts` — 74 pass, 0 fail.
- Exact hostile inherited-environment replay — 74 pass, 0 fail.
- `GJC_PYTHON_INTEGRATION=1` integration suite — 6 pass.
- `PI_PYTHON_INTEGRATION=1` integration suite — 6 pass.
- `bun --cwd=packages/coding-agent run check` — pass.
- `bun --cwd=packages/coding-agent run build` — pass.
- Actual PythonKernel contradictory-alias run observed send/receive IPC traces and successful execution.
- AI slop cleanup — no blocking findings.
- Fresh Architect — CLEAR/PASS/APPROVE.
- Fresh adversarial QA — PASS/PASS/PASS.

## Scope

Internal `dev` follow-up only. No `main`, release, publish, or unrelated behavior changes.

References merged PR #2527 and merge commit `dd304faa49c122889adef7d314a5c86386dded2e`.
