### PR TITLE
fix(coding-agent): restore /branch and /fork commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Team worker launches now receive the validated owning `GJC_SESSION_ID` for sanctioned session-scoped writes while preserving absent identity, fail-closed resolution, and separate spawn provenance (#2597).
+- Restored the documented `/branch` and `/fork` session commands in slash-command completion and dispatch.
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).

--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -257,6 +257,8 @@ const SEAM_TO_SDK: Readonly<Record<string, string>> = {
 	"slash_command:new": "session.new",
 	"slash_command:compact": "compaction.run",
 	"slash_command:resume": "session.resume",
+	"slash_command:branch": "session.branch",
+	"slash_command:fork": "session.fork",
 	"slash_command:retry": "retry.last",
 	"slash_command:background": "bash.background",
 	"slash_command:rename": "session.rename",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -1950,6 +1950,42 @@
 		}
 	},
 	{
+		"sourceId": "slash_command:branch",
+		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
+		"sourceKind": "slash_command",
+		"decision": "include",
+		"sdkId": "session.branch",
+		"adapterMappings": {
+			"telegram": "generic_safe",
+			"discord": "generic_safe",
+			"slack": "generic_safe",
+			"mcp": "generic_safe",
+			"acp": "generic_safe",
+			"daemonCli": "generic_safe"
+		},
+		"testIds": [
+			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
+		]
+	},
+	{
+		"sourceId": "slash_command:fork",
+		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
+		"sourceKind": "slash_command",
+		"decision": "include",
+		"sdkId": "session.fork",
+		"adapterMappings": {
+			"telegram": "generic_safe",
+			"discord": "generic_safe",
+			"slack": "generic_safe",
+			"mcp": "generic_safe",
+			"acp": "generic_safe",
+			"daemonCli": "generic_safe"
+		},
+		"testIds": [
+			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
+		]
+	},
+	{
 		"sourceId": "slash_command:provider",
 		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
 		"sourceKind": "slash_command",

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1179,6 +1179,44 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			runtime.ctx.editor.setText("");
 		},
 	},
+	{
+		name: "branch",
+		description: "Branch from an earlier user message into a new session",
+		// Keep invalid argument forms inside the TUI command path so session
+		// control typos cannot fall through as literal model prompts.
+		allowArgs: true,
+		handleTui: (command, runtime) => {
+			if (command.args.trim().length > 0) {
+				runtime.ctx.showError("Usage: /branch");
+				if (canClearComposer(runtime)) {
+					runtime.ctx.editor.setText("");
+				}
+				return;
+			}
+			runtime.ctx.showUserMessageSelector();
+			if (canClearComposer(runtime)) {
+				runtime.ctx.editor.setText("");
+			}
+		},
+	},
+	{
+		name: "fork",
+		description: "Fork the current session",
+		allowArgs: true,
+		handleTui: async (command, runtime) => {
+			if (command.args.trim().length > 0) {
+				runtime.ctx.showError("Usage: /fork");
+				if (canClearComposer(runtime)) {
+					runtime.ctx.editor.setText("");
+				}
+				return;
+			}
+			if (canClearComposer(runtime)) {
+				runtime.ctx.editor.setText("");
+			}
+			await runtime.ctx.handleForkCommand();
+		},
+	},
 
 	{
 		name: "provider",

--- a/packages/coding-agent/test/slash-command-builtin-registry.test.ts
+++ b/packages/coding-agent/test/slash-command-builtin-registry.test.ts
@@ -152,6 +152,71 @@ describe("builtin /copy slash command", () => {
 		expect(sessionCommand?.description).toBe("Show session info or delete the current session transcript/artifacts");
 		expect(sessionCommand?.subcommands?.map(command => command.name)).toEqual(["info", "delete"]);
 	});
+	it("discovers and dispatches session branch and fork commands without clearing unowned drafts", async () => {
+		const events: string[] = [];
+		const showUserMessageSelector = vi.fn();
+		const setText = vi.fn(() => events.push("clear"));
+		const handleForkCommand = vi.fn(async () => {
+			events.push("fork");
+		});
+		const editor = { setText } as unknown as InteractiveModeContext["editor"];
+		const ctx = {
+			showUserMessageSelector,
+			handleForkCommand,
+			editor,
+		} as unknown as InteractiveModeContext;
+		const runtime = { ctx, handleBackgroundCommand: () => undefined };
+
+		const branchCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "branch");
+		const forkCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "fork");
+		expect(branchCommand?.description).toBe("Branch from an earlier user message into a new session");
+		expect(forkCommand?.description).toBe("Fork the current session");
+
+		expect(await executeBuiltinSlashCommand("/branch", runtime)).toBe(true);
+		expect(showUserMessageSelector).toHaveBeenCalledTimes(1);
+		expect(setText).toHaveBeenCalledTimes(1);
+
+		setText.mockClear();
+		expect(await executeBuiltinSlashCommand("/fork", runtime)).toBe(true);
+		expect(handleForkCommand).toHaveBeenCalledTimes(1);
+		expect(setText).toHaveBeenCalledTimes(1);
+		expect(events.slice(-2)).toEqual(["clear", "fork"]);
+
+		setText.mockClear();
+		const paletteRuntime = {
+			...runtime,
+			composer: { ownsComposer: false, editor },
+		};
+		expect(await executeBuiltinSlashCommand("/branch", paletteRuntime)).toBe(true);
+		expect(await executeBuiltinSlashCommand("/fork", paletteRuntime)).toBe(true);
+		expect(setText).not.toHaveBeenCalled();
+	});
+	it("consumes invalid branch and fork argument forms with usage feedback", async () => {
+		const showError = vi.fn();
+		const showUserMessageSelector = vi.fn();
+		const handleForkCommand = vi.fn(async () => {});
+		const setText = vi.fn();
+		const ctx = {
+			showError,
+			showUserMessageSelector,
+			handleForkCommand,
+			editor: { setText },
+		} as unknown as InteractiveModeContext;
+		const runtime = { ctx, handleBackgroundCommand: () => undefined };
+
+		for (const command of ["/branch extra", "/branch:extra"]) {
+			expect(await executeBuiltinSlashCommand(command, runtime)).toBe(true);
+			expect(showError).toHaveBeenLastCalledWith("Usage: /branch");
+		}
+		for (const command of ["/fork extra", "/fork:extra"]) {
+			expect(await executeBuiltinSlashCommand(command, runtime)).toBe(true);
+			expect(showError).toHaveBeenLastCalledWith("Usage: /fork");
+		}
+
+		expect(showUserMessageSelector).not.toHaveBeenCalled();
+		expect(handleForkCommand).not.toHaveBeenCalled();
+		expect(setText).toHaveBeenCalledTimes(4);
+	});
 
 	it("dispatches zero-argument /copy to the existing copy controller path", async () => {
 		const { runtime, handleCopyCommand, showError, setText } = createTuiRuntime();


### PR DESCRIPTION
## What

- restore the documented `/branch` and `/fork` commands in TUI slash completion and dispatch
- consume invalid whitespace and colon argument forms (`/branch x`, `/branch:x`, `/fork x`, `/fork:x`) with local `Usage:` errors instead of leaking them into model prompts
- preserve palette drafts through composer-ownership checks and retain clear-before-fork ordering
- map the command seams to the existing `session.branch` and `session.fork` SDK operations
- regenerate the SDK inventory against current `dev`, including the current `exclusionMetadata` schema
- add focused discovery, dispatch, invalid-input, action-suppression, ordering, palette-safety, ACP, and inventory coverage

## Why

This replaces closed PR #2571. That PR restored the missing commands but was based on stale `dev` and had three integration defects identified in owner review:

1. invalid argument forms fell through as model prompts;
2. `slash_command:branch` was incorrectly excluded instead of mapping to `session.branch`;
3. its generated inventory used the obsolete exclusion metadata shape.

This branch was rebased onto current `dev` (`81938ce9`) before applying the corrections. All three review findings are covered directly by source changes and focused tests.

## Testing

- `bun test packages/coding-agent/test/slash-command-builtin-registry.test.ts packages/coding-agent/test/sdk-operation-inventory.test.ts` — 38 passed
- `bun test packages/coding-agent/test/acp-builtins.test.ts --test-name-pattern 'TUI-only and dropped commands return false'` — passed
- `bun run --cwd packages/coding-agent check` — passed
- `bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts --check` — passed
- `bun run check:tools` — passed
- `git diff --check origin/dev...HEAD` — passed

Independent read-only review of the rebased final diff returned `CLEAR` with no findings.

---

- [x] `bun check` passes (package-scoped `bun run --cwd packages/coding-agent check`)
- [x] Tested locally
- [x] CHANGELOG updated