### PR TITLE
feat(git): add managed lifecycle lanes

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -38,6 +38,7 @@ export const commands: CommandEntry[] = [
 	{ name: "team", load: () => import("./commands/team").then(m => m.default) },
 	{ name: "ultragoal", load: () => import("./commands/ultragoal").then(m => m.default) },
 	{ name: "gc", load: () => import("./commands/gc").then(m => m.default) },
+	{ name: "lane", load: () => import("./commands/lane").then(m => m.default) },
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },
 	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
 	{ name: "stats", load: () => import("./commands/stats").then(m => m.default) },

--- a/packages/coding-agent/src/commands/lane.ts
+++ b/packages/coding-agent/src/commands/lane.ts
@@ -1,0 +1,176 @@
+import { Args, Command, Flags } from "@gajae-code/utils/cli";
+import { WorkType } from "../gjc-runtime/git-lifecycle";
+import {
+	defaultCommandRunner,
+	type GithubAdapter,
+	GitLifecycleController,
+	type LanePolicyMode,
+	type PullRequest,
+	type RequiredGate,
+} from "../gjc-runtime/git-lifecycle-controller";
+
+const workTypes = Object.values(WorkType);
+
+export default class Lane extends Command {
+	static description = "Manage typed, isolated git lifecycle lanes";
+	static args = {
+		action: Args.string({
+			required: true,
+			options: ["configure", "start", "status", "pr", "reconcile", "gc"],
+			description: "configure, start, status, pr, reconcile, or gc",
+		}),
+	};
+	static flags = {
+		json: Flags.boolean({ char: "j", default: false, description: "Emit machine-readable JSON" }),
+		mode: Flags.string({
+			options: ["pr-only", "local-controlled-merge"],
+			description: "Merge policy mode (configure)",
+		}),
+		remote: Flags.string({ description: "Git remote name (configure)" }),
+		base: Flags.string({ description: "Base branch (configure)" }),
+		"worktree-root": Flags.string({ description: "Managed worktree root (configure)" }),
+		"allowed-types": Flags.string({
+			description: "Comma-separated work types allowed for controlled merge (configure)",
+		}),
+		gates: Flags.string({ description: "Comma-separated required check@app pairs (configure)" }),
+		"retention-hours": Flags.integer({ description: "Cleanup retention hours, default 24 (configure)" }),
+		forbidden: Flags.string({ description: "Comma-separated forbidden path patterns (configure)" }),
+		"lane-id": Flags.string({ description: "Lane identifier (start, status, pr, reconcile, gc)" }),
+		type: Flags.string({ options: workTypes, description: "Typed work category (start)" }),
+		scope: Flags.string({ description: "Typed lane scope (start)" }),
+		purpose: Flags.string({ description: "Typed lane purpose (start)" }),
+		agent: Flags.string({ description: "Owning agent (start)" }),
+		session: Flags.string({ description: "Owning session (start)" }),
+		title: Flags.string({ description: "Pull request title (pr)" }),
+	};
+	static examples = [
+		"gjc lane configure --mode local-controlled-merge --remote origin --base main --worktree-root D:/worktrees --allowed-types fix,docs --gates build@CI",
+		"gjc lane start --lane-id lane-1 --type fix --scope auth --purpose timeout --agent gjc --session s1",
+		"gjc lane status --lane-id lane-1 --json",
+		"gjc lane pr --lane-id lane-1",
+		"gjc lane reconcile --lane-id lane-1",
+		"gjc lane gc --lane-id lane-1",
+	];
+	async run(): Promise<void> {
+		const { args, flags } = await this.parse(Lane);
+		const github = new GhAdapter(process.cwd());
+		const controller = new GitLifecycleController({ cwd: process.cwd(), github });
+		let result: unknown;
+		switch (args.action) {
+			case "configure":
+				result = await controller.configure({
+					mode: required(flags.mode, "--mode") as LanePolicyMode,
+					remote: required(flags.remote, "--remote"),
+					base: required(flags.base, "--base"),
+					worktreeRoot: required(flags["worktree-root"], "--worktree-root"),
+					allowedAutoMergeTypes: csv(flags["allowed-types"]) as typeof workTypes,
+					requiredGates: gates(flags.gates),
+					forbiddenPathPatterns: csv(flags.forbidden),
+					retentionHours: flags["retention-hours"],
+				});
+				break;
+			case "start":
+				result = await controller.start({
+					laneId: required(flags["lane-id"], "--lane-id"),
+					type: required(flags.type, "--type") as (typeof workTypes)[number],
+					scope: required(flags.scope, "--scope"),
+					purpose: required(flags.purpose, "--purpose"),
+					agent: required(flags.agent, "--agent"),
+					sessionId: required(flags.session, "--session"),
+				});
+				break;
+			case "status":
+				result = await controller.status(flags["lane-id"]);
+				break;
+			case "pr":
+				result = await controller.pr(required(flags["lane-id"], "--lane-id"), flags.title);
+				break;
+			case "reconcile":
+				result = await controller.reconcile(required(flags["lane-id"], "--lane-id"));
+				break;
+			case "gc":
+				result = await controller.gc(required(flags["lane-id"], "--lane-id"));
+				break;
+		}
+		console.log(flags.json ? JSON.stringify(result) : JSON.stringify(result, null, "\t"));
+	}
+}
+class GhAdapter implements GithubAdapter {
+	constructor(private readonly cwd: string) {}
+	async findPullRequest(head: string, base: string): Promise<PullRequest | undefined> {
+		const list = await this.gh(["pr", "list", "--head", head, "--base", base, "--state", "all", "--json", fields]);
+		const value = JSON.parse(list) as unknown[];
+		return value.length ? normalize(value[0]) : undefined;
+	}
+	async createPullRequest(head: string, base: string, title: string): Promise<PullRequest> {
+		await this.gh(["pr", "create", "--head", head, "--base", base, "--title", title, "--body", ""]);
+		const pull = await this.findPullRequest(head, base);
+		if (!pull) throw new Error("created pull request could not be resolved");
+		return pull;
+	}
+	async getPullRequest(number: number): Promise<PullRequest | undefined> {
+		try {
+			return normalize(JSON.parse(await this.gh(["pr", "view", String(number), "--json", fields])));
+		} catch {
+			return undefined;
+		}
+	}
+	async squashMergePullRequest(
+		number: number,
+		input: { matchHeadCommit: string; expectedBaseCommit: string },
+	): Promise<{ method: "SQUASH"; matchHeadCommit: string; expectedBaseCommit: string }> {
+		const current = await this.getPullRequest(number);
+		if (
+			current?.state !== "OPEN" ||
+			current.headRefOid !== input.matchHeadCommit ||
+			current.baseRefOid !== input.expectedBaseCommit
+		)
+			throw new Error("pull request head or base changed before controlled merge");
+		await this.gh(["pr", "merge", String(number), "--squash", "--match-head-commit", input.matchHeadCommit]);
+		return {
+			method: "SQUASH",
+			matchHeadCommit: input.matchHeadCommit,
+			expectedBaseCommit: input.expectedBaseCommit,
+		};
+	}
+	private async gh(args: string[]): Promise<string> {
+		const result = await defaultCommandRunner(["gh", ...args], this.cwd);
+		if (result.exitCode) throw new Error(result.stderr || "gh command failed");
+		return result.stdout;
+	}
+}
+const fields =
+	"number,url,state,isDraft,isCrossRepository,headRefName,headRefOid,baseRefName,baseRefOid,mergeable,reviewDecision,statusCheckRollup,mergedAt,mergeCommit,headRepository";
+function normalize(value: any): PullRequest {
+	return {
+		...value,
+		reviewDecision: value.reviewDecision || null,
+		checks: (value.statusCheckRollup ?? []).map((item: any) => ({
+			name: item.name ?? item.context,
+			app: item.app?.slug ?? item.app?.name ?? item.workflowName,
+			conclusion: item.conclusion ?? item.state,
+			headSha: value.headRefOid,
+		})),
+		mergeCommit: value.mergeCommit?.oid,
+		remoteBranchDeleted: value.headRepository === null,
+	};
+}
+function csv(value?: string): string[] {
+	return value
+		? value
+				.split(",")
+				.map(part => part.trim())
+				.filter(Boolean)
+		: [];
+}
+function gates(value?: string): RequiredGate[] {
+	return csv(value).map(entry => {
+		const separator = entry.lastIndexOf("@");
+		if (separator <= 0 || separator === entry.length - 1) throw new Error(`invalid required gate: ${entry}`);
+		return { name: entry.slice(0, separator), app: entry.slice(separator + 1) };
+	});
+}
+function required(value: string | undefined, name: string): string {
+	if (!value) throw new Error(`${name} is required`);
+	return value;
+}

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -81,6 +81,9 @@ GJC_TEAM_WORKER_COMMAND="bun packages/coding-agent/src/cli.ts" gjc team executor
 ```
 
 ## Preconditions
+### Managed lifecycle lanes
+
+When `<git-common-dir>/gjc/lifecycle/v1/policy.json` exists, Team is a worker layer inside one active managed **feature** lane. Launch only from that feature lane's recorded worktree path; never launch from `main` or a user checkout. Managed startup refuses any existing deterministic worker path or named worker branch and records exact common-dir, path, branch/detached mode, base HEAD, team, and worker ownership. It holds a renewable lane lease for the full run. Managed runtime never auto-checkpoints dirty worktrees, cherry-picks, or cross-rebases; under the lane lock it merges only the captured worker SHA into a clean, registered leader worktree. Unmanaged teams never integrate into the leader checkout automatically. Graceful managed shutdown requires each worker to write a matching `accepted` ACK, flush and commit its final work, then write a terminal `stopped` ACK containing runtime-captured clean final-HEAD evidence immediately before exiting. The leader does not kill managed panes during graceful shutdown. Missing terminal ACK or exit proof is nonterminal: preserve worktrees and lease. Cleanup is evidence-gated: only team-created, clean, registered worktrees exactly at their recorded integrated head and reachable from the leader HEAD are removed non-forcibly.
 
 Before running `$team`, confirm:
 
@@ -250,6 +253,7 @@ Semantics:
 - `.gjc/_session-{sessionid}/state/team/<team>/workers/<worker>/lifecycle.json`
 - `.gjc/_session-{sessionid}/state/team/<team>/workers/<worker>/heartbeat.json`
 - `.gjc/_session-{sessionid}/state/team/<team>/workers/<worker>/shutdown-request.json`
+- `.gjc/_session-{sessionid}/state/team/<team>/workers/<worker>/shutdown-ack.json`
 - `.gjc/_session-{sessionid}/state/team/<team>/workers/<worker>/nudges/<fingerprint>.json`
 - `.gjc/_session-{sessionid}/reports/team-commit-hygiene/<team>.ledger.json`
 
@@ -263,6 +267,8 @@ gjc team api claim-task --input '{"team_name":"my-team","worker_id":"worker-1"}'
 gjc team api transition-task-status --input '{"team_name":"my-team","task_id":"task-1","to":"completed","worker_id":"worker-1","claim_token":"<claim-token>","completion_evidence":{"summary":"Completed requested work and verified it locally.","items":[{"kind":"command","status":"passed","summary":"Focused test passed","command":"bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts"}],"files":["packages/coding-agent/test/gjc-runtime/team-runtime.test.ts"],"notes":"Include at least one passed command or verified inspection/artifact item."}}' --json
 gjc team api update-worker-status --input '{"team_name":"my-team","worker_id":"worker-1","status":"working","current_task_id":"task-1"}' --json
 gjc team api recover-stale-claims --input '{"team_name":"my-team"}' --json
+gjc team api write-shutdown-ack --input '{"team_name":"my-team","worker_id":"worker-1","request_id":"<shutdown-request-id>","status":"accepted"}' --json
+gjc team api write-shutdown-ack --input '{"team_name":"my-team","worker_id":"worker-1","request_id":"<shutdown-request-id>","status":"stopped"}' --json
 gjc team api read-traces --input '{"team_name":"my-team"}' --json
 gjc team api create-task --input '{"team_name":"my-team","subject":"Verify delivery","description":"Run verification","owner":"worker-1","lane":"verification","required_role":"executor","depends_on":["task-1"]}' --json
 ```
@@ -300,10 +306,11 @@ Forbidden assumptions: do not copy OMX paths, Codex notify payload formats, OMX 
 Worker protocol:
 
 - Send startup ACK with `worker-startup-ack` before task work.
+- On a graceful shutdown request, first acknowledge it with status `accepted`. After flushing and committing final work, write status `stopped` with the same request id immediately before exiting. The runtime captures final HEAD and cleanliness in the terminal ACK. Do not create ACK or stopped evidence on behalf of another worker.
 - Report worker activity with `update-worker-status`; this is the worker-reported status plane, not the runtime lifecycle state.
 - Claim pending work with `claim-task`.
 - Transition the task to `completed`, `failed`, or `blocked` with `transition-task-status`, including claim token and evidence for completion.
-- Commit or leave worktree changes in the worker worktree; the leader `monitor`/`resume` path will auto-checkpoint dirty worktrees and integrate committed history where possible.
+- Commit worktree changes explicitly. Managed leader `monitor`/`resume` integrates committed worker history under the lane lock; unmanaged teams report `integration_required` without mutating the leader checkout.
 - Record implementation/verification evidence in normal task output and state files; leader integration/conflict notifications are delivered through `.gjc/_session-{sessionid}/state/team/<team>/mailbox/leader-fixed.json`.
 
 ## Environment Knobs

--- a/packages/coding-agent/src/gjc-runtime/git-lifecycle-controller.ts
+++ b/packages/coding-agent/src/gjc-runtime/git-lifecycle-controller.ts
@@ -1,0 +1,683 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	acquireLifecycleLock,
+	appendLifecycleEvent,
+	createLaneName,
+	isCleanupEligible,
+	type LaneRecord,
+	LifecycleError,
+	ownershipMatches,
+	readLaneRecord,
+	WorkType,
+	writeLaneRecord,
+} from "./git-lifecycle";
+
+export type LanePolicyMode = "pr-only" | "local-controlled-merge";
+export interface RequiredGate {
+	name: string;
+	app: string;
+}
+export interface LanePolicy {
+	version: 1;
+	mode: LanePolicyMode;
+	remote: string;
+	base: string;
+	worktreeRoot: string;
+	allowedAutoMergeTypes: WorkType[];
+	requiredGates: RequiredGate[];
+	retentionHours: number;
+	forbiddenPathPatterns: string[];
+}
+export interface CommandResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+export type CommandRunner = (argv: string[], cwd: string) => Promise<CommandResult>;
+export interface PullRequest {
+	number: number;
+	url?: string;
+	state: "OPEN" | "MERGED" | "CLOSED";
+	isDraft: boolean;
+	isCrossRepository: boolean;
+	headRefName: string;
+	headRefOid: string;
+	baseRefName: string;
+	baseRefOid: string;
+	mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+	reviewDecision?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
+	checks?: Array<{ name: string; app?: string; conclusion?: string | null; headSha: string }>;
+	mergedAt?: string;
+	mergeCommit?: string;
+	remoteBranchDeleted?: boolean;
+}
+export interface SquashMergeEvidence {
+	method: "SQUASH";
+	matchHeadCommit: string;
+	expectedBaseCommit: string;
+}
+export interface GithubAdapter {
+	findPullRequest(head: string, base: string): Promise<PullRequest | undefined>;
+	createPullRequest(head: string, base: string, title: string): Promise<PullRequest>;
+	getPullRequest(number: number): Promise<PullRequest | undefined>;
+	squashMergePullRequest(
+		number: number,
+		input: { matchHeadCommit: string; expectedBaseCommit: string },
+	): Promise<SquashMergeEvidence>;
+}
+export interface ControllerOptions {
+	cwd: string;
+	runner?: CommandRunner;
+	github?: GithubAdapter;
+	now?: () => Date;
+}
+export interface StartInput {
+	laneId: string;
+	type: WorkType;
+	scope: string;
+	purpose: string;
+	agent: string;
+	sessionId: string;
+	realm?: "windows" | "wsl";
+}
+export interface LaneStatus {
+	policy?: LanePolicy;
+	record?: ManagedLaneRecord;
+}
+export interface ManagedLaneRecord extends LaneRecord {
+	remote?: string;
+	base?: string;
+	baseSha?: string;
+	headSha?: string;
+	prNumber?: number;
+	prUrl?: string;
+	mergedAt?: string;
+	mergeCommit?: string;
+	mergedHeadSha?: string;
+	mergedBaseSha?: string;
+	remoteBranchDeleted?: boolean;
+	leaseExpiresAt?: string;
+	gitCommonDir?: string;
+}
+
+const policyFile = "policy.json";
+const policyRoot = (commonDir: string) => path.join(commonDir, "gjc", "lifecycle", "v1");
+const policyPath = (commonDir: string) => path.join(policyRoot(commonDir), policyFile);
+const nowIso = (now: () => Date) => now().toISOString();
+
+export function defaultCommandRunner(argv: string[], cwd: string): Promise<CommandResult> {
+	const proc = Bun.spawn(argv, { cwd, stdout: "pipe", stderr: "pipe" });
+	return Promise.all([proc.exited, new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(
+		([exitCode, stdout, stderr]) => ({ exitCode, stdout, stderr }),
+	);
+}
+
+export class GitLifecycleController {
+	readonly cwd: string;
+	readonly runner: CommandRunner;
+	readonly github?: GithubAdapter;
+	readonly now: () => Date;
+	constructor(options: ControllerOptions) {
+		this.cwd = options.cwd;
+		this.runner = options.runner ?? defaultCommandRunner;
+		this.github = options.github;
+		this.now = options.now ?? (() => new Date());
+	}
+
+	async configure(
+		input: Omit<LanePolicy, "version" | "retentionHours"> & { retentionHours?: number },
+	): Promise<LanePolicy> {
+		if (input.mode !== "pr-only" && input.mode !== "local-controlled-merge")
+			throw new LifecycleError("policy mode must be pr-only or local-controlled-merge");
+		if (!input.remote || !input.base || !input.worktreeRoot)
+			throw new LifecycleError("remote, base, and worktree root are required");
+		const commonDir = await this.commonDir();
+		const worktreeRoot = await this.assertSafeWorktreeRoot(input.worktreeRoot);
+		const policy: LanePolicy = {
+			version: 1,
+			...input,
+			worktreeRoot,
+			retentionHours: input.retentionHours ?? 24,
+			allowedAutoMergeTypes: [...input.allowedAutoMergeTypes],
+			requiredGates: input.requiredGates.map(gate => ({ ...gate })),
+			forbiddenPathPatterns: [...input.forbiddenPathPatterns],
+		};
+		if (policy.mode === "local-controlled-merge" && policy.requiredGates.length === 0)
+			throw new LifecycleError("local-controlled-merge requires at least one required gate");
+		if (!isLanePolicy(policy)) throw new LifecycleError("lane policy has an invalid shape");
+		await fs.mkdir(policyRoot(commonDir), { recursive: true });
+		const destination = policyPath(commonDir);
+		const temporary = `${destination}.${process.pid}.${randomUUID()}.tmp`;
+		try {
+			await fs.writeFile(temporary, `${JSON.stringify(policy, null, "\t")}\n`, "utf8");
+			await fs.rename(temporary, destination);
+		} finally {
+			await fs.rm(temporary, { force: true });
+		}
+		return policy;
+	}
+
+	async status(laneId?: string): Promise<LaneStatus> {
+		const commonDir = await this.commonDir();
+		return {
+			policy: await this.readPolicy(commonDir),
+			record: laneId ? ((await readLaneRecord(commonDir, laneId)) as ManagedLaneRecord | undefined) : undefined,
+		};
+	}
+
+	async start(input: StartInput): Promise<ManagedLaneRecord> {
+		const commonDir = await this.commonDir();
+		const policy = await this.requirePolicy(commonDir);
+		const lock = await acquireLifecycleLock(commonDir, input.laneId);
+		let record: ManagedLaneRecord | undefined;
+		let worktreeMutationAttempted = false;
+		try {
+			if (await readLaneRecord(commonDir, input.laneId)) throw new LifecycleError("lane id already exists");
+			await this.git(["fetch", "--no-tags", policy.remote, policy.base]);
+			const baseSha = await this.gitText(["rev-parse", `${policy.remote}/${policy.base}`]);
+			const existingBranches = (await this.gitText(["branch", "--format=%(refname:short)"]))
+				.split("\n")
+				.filter(Boolean);
+			const existingWorktreeTokens = (await this.gitText(["worktree", "list", "--porcelain"]))
+				.split("\n")
+				.filter(line => line.startsWith("worktree "))
+				.map(line => path.basename(line.slice("worktree ".length)));
+			const name = createLaneName({ ...input, id: input.laneId, existingBranches, existingWorktreeTokens });
+			const repoName = path.basename(await this.gitText(["rev-parse", "--show-toplevel"]));
+			const worktreePath = path.join(policy.worktreeRoot, repoName, name.worktreeToken);
+			if (await exists(worktreePath)) throw new LifecycleError("managed worktree path already exists");
+			const ownership = {
+				repositoryId: await this.repositoryId(),
+				realm: input.realm ?? "windows",
+				branch: name.branch,
+				worktreeToken: name.worktreeToken,
+				worktreePath,
+				agent: input.agent,
+				sessionId: input.sessionId,
+			};
+			const at = nowIso(this.now);
+			record = {
+				version: 1,
+				laneId: input.laneId,
+				state: "planned",
+				createdAt: at,
+				updatedAt: at,
+				...ownership,
+				remote: policy.remote,
+				base: policy.base,
+				baseSha,
+				headSha: baseSha,
+				gitCommonDir: commonDir,
+			};
+			await writeLaneRecord(commonDir, record);
+			await this.event(commonDir, record, "planned", { baseSha });
+			worktreeMutationAttempted = true;
+			await this.assertSafeWorktreeRoot(policy.worktreeRoot);
+			await this.git(["worktree", "add", "-b", name.branch, worktreePath, baseSha]);
+			record.worktreeGitDir = path.resolve(
+				worktreePath,
+				await this.gitText(["rev-parse", "--git-dir"], worktreePath),
+			);
+			record.worktreeOwnershipToken = randomUUID();
+			await fs.writeFile(path.join(record.worktreeGitDir, "gjc-lane-owner"), record.worktreeOwnershipToken, {
+				encoding: "utf8",
+				flag: "wx",
+			});
+			record.state = "active";
+			record.updatedAt = nowIso(this.now);
+			await writeLaneRecord(commonDir, record);
+			await this.event(commonDir, record, "started", { baseSha });
+			return record;
+		} catch (error: unknown) {
+			if (record) {
+				record.state = "blocked";
+				record.updatedAt = nowIso(this.now);
+				await writeLaneRecord(commonDir, record);
+				await this.event(commonDir, record, "start_failed", {
+					worktreeMutationAttempted,
+					error: error instanceof Error ? error.message : "unknown error",
+				});
+			}
+			throw error;
+		} finally {
+			await lock.release();
+		}
+	}
+
+	async pr(laneId: string, title?: string): Promise<ManagedLaneRecord> {
+		const commonDir = await this.commonDir();
+		const lock = await acquireLifecycleLock(commonDir, laneId);
+		try {
+			const policy = await this.requirePolicy(commonDir);
+			const record = await this.requireRecord(commonDir, laneId);
+			this.assertPolicyBinding(record, policy);
+			this.assertNoActiveLease(record);
+			await this.assertManagedWorktree(record, commonDir);
+			const headSha = await this.gitText(["rev-parse", "HEAD"], record.worktreePath);
+			await this.git(["push", policy.remote, `HEAD:refs/heads/${record.branch}`], record.worktreePath);
+			const github = this.requireGithub();
+			let pull = await github.findPullRequest(record.branch, policy.base);
+			if (!pull) {
+				try {
+					pull = await github.createPullRequest(record.branch, policy.base, title ?? record.branch);
+				} catch (error) {
+					const raced = await github.findPullRequest(record.branch, policy.base);
+					if (!raced) throw error;
+					pull = raced;
+				}
+			}
+			if (
+				pull.isCrossRepository ||
+				pull.headRefName !== record.branch ||
+				pull.baseRefName !== policy.base ||
+				pull.headRefOid !== headSha
+			)
+				throw new LifecycleError("pull request does not match managed same-repository head and base");
+			Object.assign(record, {
+				state: "pr_open",
+				updatedAt: nowIso(this.now),
+				headSha,
+				prNumber: pull.number,
+				prUrl: pull.url,
+			});
+			await writeLaneRecord(commonDir, record);
+			await this.event(commonDir, record, "pr_opened", { prNumber: pull.number, headSha });
+			return record;
+		} finally {
+			await lock.release();
+		}
+	}
+
+	async reconcile(laneId: string): Promise<ManagedLaneRecord> {
+		const commonDir = await this.commonDir();
+		const lock = await acquireLifecycleLock(commonDir, laneId);
+		try {
+			const policy = await this.requirePolicy(commonDir);
+			const record = await this.requireRecord(commonDir, laneId);
+			this.assertPolicyBinding(record, policy);
+			this.assertNoActiveLease(record);
+			const pr = record.prNumber ? await this.requireGithub().getPullRequest(record.prNumber) : undefined;
+			if (!pr) throw new LifecycleError("managed pull request is unavailable");
+			if (pr.state === "MERGED") return this.recordMerged(commonDir, record, pr);
+			if (pr.state === "CLOSED") {
+				record.state = "closed_unmerged";
+				record.updatedAt = nowIso(this.now);
+				await writeLaneRecord(commonDir, record);
+				await this.event(commonDir, record, "closed_unmerged");
+				return record;
+			}
+			if (policy.mode === "pr-only") return record;
+			await this.assertManagedWorktree(record, commonDir);
+			await this.assertMergeEligible(record, policy, pr);
+			const merge = await this.requireGithub().squashMergePullRequest(pr.number, {
+				matchHeadCommit: pr.headRefOid,
+				expectedBaseCommit: pr.baseRefOid,
+			});
+			if (
+				merge.method !== "SQUASH" ||
+				merge.matchHeadCommit !== pr.headRefOid ||
+				merge.expectedBaseCommit !== pr.baseRefOid
+			)
+				throw new LifecycleError("provider did not confirm squash merge at the requested head and base");
+			record.state = "merge_requested";
+			record.updatedAt = nowIso(this.now);
+			await writeLaneRecord(commonDir, record);
+			await this.event(commonDir, record, "merge_requested", { prNumber: pr.number, headSha: pr.headRefOid });
+			return record;
+		} finally {
+			await lock.release();
+		}
+	}
+
+	async gc(laneId: string): Promise<ManagedLaneRecord> {
+		const commonDir = await this.commonDir();
+		const lock = await acquireLifecycleLock(commonDir, laneId);
+		try {
+			const policy = await this.requirePolicy(commonDir);
+			const record = await this.requireRecord(commonDir, laneId);
+			this.assertPolicyBinding(record, policy);
+			const pr = record.prNumber ? await this.requireGithub().getPullRequest(record.prNumber) : undefined;
+			if (pr?.state !== "MERGED" || !record.mergeCommit || !record.mergedHeadSha || !pr.mergedAt)
+				throw new LifecycleError("positive merged pull request tuple is required for cleanup");
+			if (pr.mergeCommit !== record.mergeCommit || pr.headRefOid !== record.mergedHeadSha)
+				throw new LifecycleError("merged pull request immutable tuple no longer matches the record");
+			if (this.now().getTime() - Date.parse(pr.mergedAt) < policy.retentionHours * 3600000)
+				throw new LifecycleError("retention period has not elapsed");
+			if (record.leaseOwner) throw new LifecycleError("lane has an active lease");
+			record.cleanupEvidence ??= {};
+			const evidence = record.cleanupEvidence;
+			if (record.state !== "gc_eligible" && record.state !== "cleanup_blocked") {
+				evidence.mergeCommit = record.mergeCommit;
+				evidence.retentionApprovedAt ??= nowIso(this.now);
+				evidence.explicitCleanupRequestedAt ??= nowIso(this.now);
+				evidence.gcApprovedAt ??= nowIso(this.now);
+			}
+			record.state = "gc_eligible";
+			await writeLaneRecord(commonDir, record);
+			if (!isCleanupEligible(record, record) || !ownershipMatches(record, record))
+				throw new LifecycleError("cleanup eligibility gate is not satisfied");
+
+			const worktreePresent = await exists(record.worktreePath);
+			if (worktreePresent) {
+				await this.assertManagedWorktree(record, commonDir);
+				await this.assertClean(record.worktreePath);
+				if ((await this.gitText(["rev-parse", "HEAD"], record.worktreePath)) !== record.headSha)
+					throw new LifecycleError("worktree head no longer matches the recorded head");
+			} else if (evidence.worktreeRemoveIntent?.path !== record.worktreePath || !evidence.worktreeRemoveIntent.at) {
+				throw new LifecycleError("worktree is absent without a matching recorded removal intent");
+			}
+
+			const localRef = `refs/heads/${record.branch}`;
+			const localRefPresent = (await this.gitExit(["rev-parse", "--verify", localRef])) === 0;
+			if (localRefPresent) {
+				if ((await this.gitText(["rev-parse", localRef])) !== record.headSha)
+					throw new LifecycleError("local branch no longer matches the recorded head");
+			} else if (
+				evidence.localRefDeleteIntent?.ref !== localRef ||
+				evidence.localRefDeleteIntent.headSha !== record.headSha
+			) {
+				throw new LifecycleError("local branch is absent without a matching recorded deletion intent");
+			}
+
+			await this.git(["fetch", "--no-tags", policy.remote, policy.base]);
+			const base = await this.gitText(["rev-parse", `${policy.remote}/${policy.base}`]);
+			if ((await this.gitExit(["merge-base", "--is-ancestor", record.mergeCommit, base])) !== 0)
+				throw new LifecycleError("recorded merge commit is not reachable from fresh target");
+
+			const remoteRef = await this.gitTextOptional([
+				"ls-remote",
+				"--heads",
+				policy.remote,
+				`refs/heads/${record.branch}`,
+			]);
+			if (remoteRef && remoteRef.split(/\s+/)[0] !== record.headSha)
+				throw new LifecycleError("remote feature branch advanced beyond the recorded head");
+
+			try {
+				if (remoteRef) {
+					evidence.remoteDeleteIntent ??= { headSha: record.headSha!, at: nowIso(this.now) };
+					await writeLaneRecord(commonDir, record);
+					await this.git([
+						"push",
+						`--force-with-lease=refs/heads/${record.branch}:${record.headSha}`,
+						policy.remote,
+						`:refs/heads/${record.branch}`,
+					]);
+					if (await this.gitTextOptional(["ls-remote", "--heads", policy.remote, `refs/heads/${record.branch}`]))
+						throw new LifecycleError("remote feature branch still exists after leased deletion");
+				}
+				evidence.remoteBranchDeletedAt ??= nowIso(this.now);
+				await writeLaneRecord(commonDir, record);
+
+				if (worktreePresent) {
+					evidence.worktreeRemoveIntent ??= { path: record.worktreePath, at: nowIso(this.now) };
+					await writeLaneRecord(commonDir, record);
+					await this.git(["worktree", "remove", record.worktreePath]);
+				}
+				evidence.worktreeRemovedAt ??= nowIso(this.now);
+				await writeLaneRecord(commonDir, record);
+
+				if (localRefPresent) {
+					evidence.localRefDeleteIntent ??= { ref: localRef, headSha: record.headSha!, at: nowIso(this.now) };
+					await writeLaneRecord(commonDir, record);
+					await this.git(["update-ref", "-d", localRef, record.headSha!]);
+				}
+				evidence.localRefDeletedAt ??= nowIso(this.now);
+				record.state = "cleaned";
+				record.updatedAt = nowIso(this.now);
+				record.remoteBranchDeleted = true;
+				await writeLaneRecord(commonDir, record);
+				await this.event(commonDir, record, "cleanup_completed", { remoteBranchDeleted: true });
+				return record;
+			} catch (error) {
+				record.state = "cleanup_blocked";
+				evidence.cleanupBlockedAt = nowIso(this.now);
+				evidence.cleanupBlockedReason = error instanceof Error ? error.message : "unknown error";
+				record.updatedAt = nowIso(this.now);
+				await writeLaneRecord(commonDir, record);
+				throw error;
+			}
+		} finally {
+			await lock.release();
+		}
+	}
+
+	private async recordMerged(
+		commonDir: string,
+		record: ManagedLaneRecord,
+		pr: PullRequest,
+	): Promise<ManagedLaneRecord> {
+		if (!pr.mergeCommit || !pr.mergedAt || !pr.headRefOid || !pr.baseRefOid || pr.headRefOid !== record.headSha)
+			throw new LifecycleError("merged pull request is missing its immutable merge tuple or recorded head");
+		record.state = "retention";
+		record.updatedAt = nowIso(this.now);
+		record.mergedAt = pr.mergedAt;
+		record.mergeCommit = pr.mergeCommit;
+		record.mergedHeadSha = pr.headRefOid;
+		record.mergedBaseSha = pr.baseRefOid;
+		record.remoteBranchDeleted = pr.remoteBranchDeleted === true;
+		await writeLaneRecord(commonDir, record);
+		await this.event(commonDir, record, "merged", {
+			mergeCommit: pr.mergeCommit,
+			headSha: pr.headRefOid,
+			baseSha: pr.baseRefOid,
+		});
+		return record;
+	}
+	private async assertMergeEligible(record: ManagedLaneRecord, policy: LanePolicy, pr: PullRequest): Promise<void> {
+		if (
+			pr.state !== "OPEN" ||
+			pr.isDraft ||
+			pr.isCrossRepository ||
+			pr.headRefName !== record.branch ||
+			pr.baseRefName !== policy.base
+		)
+			throw new LifecycleError("pull request is not an open same-repository managed pull request");
+		await this.git(["fetch", "--no-tags", policy.remote, policy.base]);
+		const head = await this.gitText(["rev-parse", "HEAD"], record.worktreePath);
+		const base = await this.gitText(["rev-parse", `${policy.remote}/${policy.base}`]);
+		if (head !== record.headSha || pr.headRefOid !== head || pr.baseRefOid !== base || pr.mergeable !== "MERGEABLE")
+			throw new LifecycleError("pull request head, base, or mergeability is not current");
+		if (!policy.allowedAutoMergeTypes.includes(record.branch.split("/", 1)[0] as WorkType))
+			throw new LifecycleError("work type is not allowed for controlled merge");
+		if (pr.reviewDecision === "CHANGES_REQUESTED" || pr.reviewDecision === "REVIEW_REQUIRED")
+			throw new LifecycleError("pull request has unresolved review decisions");
+		for (const gate of policy.requiredGates) {
+			if (
+				!pr.checks?.some(
+					check =>
+						check.name === gate.name &&
+						check.app === gate.app &&
+						check.headSha === head &&
+						check.conclusion === "SUCCESS",
+				)
+			)
+				throw new LifecycleError(`required check gate is missing or unsuccessful: ${gate.name}/${gate.app}`);
+		}
+		const changed = (await this.gitText(["diff", "--name-only", `${base}...${head}`], record.worktreePath))
+			.split("\n")
+			.filter(Boolean);
+		for (const pattern of policy.forbiddenPathPatterns)
+			if (changed.some(file => glob(pattern, file))) throw new LifecycleError(`forbidden path changed: ${pattern}`);
+	}
+	private async assertManagedWorktree(record: ManagedLaneRecord, controllerCommonDir: string): Promise<void> {
+		if (!record.gitCommonDir || path.resolve(record.gitCommonDir) !== path.resolve(controllerCommonDir))
+			throw new LifecycleError("lane record common git directory does not match the controller");
+		const top = await this.gitText(["rev-parse", "--show-toplevel"], record.worktreePath);
+		if (path.resolve(top) !== path.resolve(record.worktreePath))
+			throw new LifecycleError("lane worktree ownership does not match");
+		const worktreeCommonDir = path.resolve(
+			record.worktreePath,
+			await this.gitText(["rev-parse", "--git-common-dir"], record.worktreePath),
+		);
+		if (worktreeCommonDir !== path.resolve(controllerCommonDir))
+			throw new LifecycleError("lane worktree common git directory does not match the controller");
+		if (!record.worktreeGitDir) throw new LifecycleError("lane worktree administrative identity is missing");
+		const worktreeGitDir = path.resolve(
+			record.worktreePath,
+			await this.gitText(["rev-parse", "--git-dir"], record.worktreePath),
+		);
+		if (worktreeGitDir !== path.resolve(record.worktreeGitDir))
+			throw new LifecycleError("lane worktree administrative identity does not match");
+		if (
+			!record.worktreeOwnershipToken ||
+			(await fs.readFile(path.join(worktreeGitDir, "gjc-lane-owner"), "utf8")) !== record.worktreeOwnershipToken
+		)
+			throw new LifecycleError("lane worktree ownership nonce does not match");
+		const branch = await this.gitText(["branch", "--show-current"], record.worktreePath);
+		if (branch !== record.branch) throw new LifecycleError("lane branch ownership does not match");
+	}
+	private async assertClean(cwd: string): Promise<void> {
+		if ((await this.gitText(["status", "--porcelain", "--untracked-files=all"], cwd)).length)
+			throw new LifecycleError("worktree is dirty");
+	}
+	private requireGithub(): GithubAdapter {
+		if (!this.github) throw new LifecycleError("GitHub capability is unavailable");
+		return this.github;
+	}
+	private async commonDir(): Promise<string> {
+		return path.resolve(this.cwd, await this.gitText(["rev-parse", "--git-common-dir"]));
+	}
+	private async repositoryId(): Promise<string> {
+		return this.gitText(["config", "--get", "remote.origin.url"]).catch(() =>
+			this.gitText(["rev-parse", "--show-toplevel"]),
+		);
+	}
+	private async assertSafeWorktreeRoot(root: string): Promise<string> {
+		const canonicalRoot = await canonicalPath(root);
+		const protectedRoots = [
+			await canonicalPath(await this.gitText(["rev-parse", "--show-toplevel"])),
+			...(await this.gitText(["worktree", "list", "--porcelain"]))
+				.split("\n")
+				.filter(line => line.startsWith("worktree "))
+				.map(line => line.slice("worktree ".length)),
+		];
+		for (const protectedRoot of protectedRoots) {
+			const canonicalProtected = await canonicalPath(protectedRoot);
+			if (isInside(canonicalRoot, canonicalProtected))
+				throw new LifecycleError("worktree root must be external to every repository worktree");
+		}
+		return canonicalRoot;
+	}
+	private async readPolicy(commonDir: string): Promise<LanePolicy | undefined> {
+		try {
+			const policy: unknown = JSON.parse(await fs.readFile(policyPath(commonDir), "utf8"));
+			if (!isLanePolicy(policy)) throw new LifecycleError("lane policy has an invalid shape");
+			return policy;
+		} catch (error: unknown) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+			throw error;
+		}
+	}
+	private async requirePolicy(commonDir: string): Promise<LanePolicy> {
+		const policy = await this.readPolicy(commonDir);
+		if (!policy) throw new LifecycleError("lane policy is not configured");
+		return policy;
+	}
+	private async requireRecord(commonDir: string, laneId: string): Promise<ManagedLaneRecord> {
+		const record = (await readLaneRecord(commonDir, laneId)) as ManagedLaneRecord | undefined;
+		if (!record) throw new LifecycleError("lane record does not exist");
+		return record;
+	}
+	private assertPolicyBinding(record: ManagedLaneRecord, policy: LanePolicy): void {
+		if (!record.remote || !record.base || record.remote !== policy.remote || record.base !== policy.base)
+			throw new LifecycleError("lane policy remote or base drifted from the immutable lane binding");
+	}
+	private assertNoActiveLease(record: ManagedLaneRecord): void {
+		if (record.leaseOwner) throw new LifecycleError("lane has an active lease");
+	}
+	private async event(
+		commonDir: string,
+		record: ManagedLaneRecord,
+		type: string,
+		details?: Record<string, string | number | boolean | null>,
+	): Promise<void> {
+		await appendLifecycleEvent(commonDir, {
+			version: 1,
+			laneId: record.laneId,
+			at: nowIso(this.now),
+			type,
+			state: record.state,
+			details,
+		});
+	}
+	private async git(argv: string[], cwd = this.cwd): Promise<void> {
+		const result = await this.runner(["git", ...argv], cwd);
+		if (result.exitCode !== 0) throw new LifecycleError(result.stderr.trim() || `git ${argv[0]} failed`);
+	}
+	private async gitText(argv: string[], cwd = this.cwd): Promise<string> {
+		const result = await this.runner(["git", ...argv], cwd);
+		if (result.exitCode !== 0) throw new LifecycleError(result.stderr.trim() || `git ${argv[0]} failed`);
+		return result.stdout.trim();
+	}
+	private async gitTextOptional(argv: string[], cwd = this.cwd): Promise<string> {
+		const result = await this.runner(["git", ...argv], cwd);
+		if (result.exitCode !== 0) throw new LifecycleError(result.stderr.trim() || `git ${argv[0]} failed`);
+		return result.stdout.trim();
+	}
+	private async gitExit(argv: string[], cwd = this.cwd): Promise<number> {
+		return (await this.runner(["git", ...argv], cwd)).exitCode;
+	}
+}
+
+function isLanePolicy(value: unknown): value is LanePolicy {
+	if (typeof value !== "object" || value === null) return false;
+	const policy = value as Partial<LanePolicy>;
+	return (
+		policy.version === 1 &&
+		(policy.mode === "pr-only" || policy.mode === "local-controlled-merge") &&
+		typeof policy.remote === "string" &&
+		policy.remote.length > 0 &&
+		typeof policy.base === "string" &&
+		policy.base.length > 0 &&
+		typeof policy.worktreeRoot === "string" &&
+		policy.worktreeRoot.length > 0 &&
+		Array.isArray(policy.allowedAutoMergeTypes) &&
+		policy.allowedAutoMergeTypes.every(type => Object.values(WorkType).includes(type as WorkType)) &&
+		Array.isArray(policy.requiredGates) &&
+		policy.requiredGates.every(
+			gate =>
+				typeof gate === "object" &&
+				gate !== null &&
+				typeof gate.name === "string" &&
+				gate.name.length > 0 &&
+				typeof gate.app === "string" &&
+				gate.app.length > 0,
+		) &&
+		typeof policy.retentionHours === "number" &&
+		Number.isFinite(policy.retentionHours) &&
+		policy.retentionHours >= 0 &&
+		Array.isArray(policy.forbiddenPathPatterns) &&
+		policy.forbiddenPathPatterns.every(entry => typeof entry === "string")
+	);
+}
+function glob(pattern: string, value: string): boolean {
+	const escaped = pattern
+		.replace(/[.+^${}()|[\]\\]/g, "\\$&")
+		.replace(/\*\*/g, ".*")
+		.replace(/\*/g, "[^/]*")
+		.replace(/\?/g, "[^/]");
+	return new RegExp(`^${escaped}$`).test(value);
+}
+async function exists(target: string): Promise<boolean> {
+	try {
+		await fs.access(target);
+		return true;
+	} catch {
+		return false;
+	}
+}
+function isInside(candidate: string, parent: string): boolean {
+	const relative = path.relative(parent, candidate);
+	return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+async function canonicalPath(target: string): Promise<string> {
+	const resolved = path.resolve(target);
+	try {
+		return await fs.realpath(resolved);
+	} catch {
+		return resolved;
+	}
+}

--- a/packages/coding-agent/src/gjc-runtime/git-lifecycle.ts
+++ b/packages/coding-agent/src/gjc-runtime/git-lifecycle.ts
@@ -1,0 +1,370 @@
+import { randomUUID } from "node:crypto";
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+export const WorkType = {
+	hotfix: "hotfix",
+	fix: "fix",
+	dev: "dev",
+	refactor: "refactor",
+	perf: "perf",
+	test: "test",
+	docs: "docs",
+	chore: "chore",
+	release: "release",
+	spike: "spike",
+} as const;
+
+export type WorkType = (typeof WorkType)[keyof typeof WorkType];
+export const LifecycleStates = [
+	"planned",
+	"active",
+	"pushed",
+	"pr_open",
+	"verifying",
+	"eligible",
+	"merge_requested",
+	"merged",
+	"retention",
+	"gc_eligible",
+	"cleaned",
+	"blocked",
+	"stale",
+	"conflicted",
+	"closed_unmerged",
+	"quarantined",
+	"cleanup_blocked",
+] as const;
+export type LifecycleState = (typeof LifecycleStates)[number];
+export type ExecutionRealm = "windows" | "wsl";
+
+export interface LaneName {
+	branch: string;
+	worktreeToken: string;
+	scope: string;
+	purpose: string;
+}
+
+export interface LaneNameInput {
+	type: WorkType;
+	scope: string;
+	purpose: string;
+	agent: string;
+	id: string;
+	existingBranches?: readonly string[];
+	existingWorktreeTokens?: readonly string[];
+}
+
+export interface LaneOwnership {
+	repositoryId: string;
+	realm: ExecutionRealm;
+	branch: string;
+	worktreeToken: string;
+	worktreePath: string;
+	agent: string;
+	sessionId: string;
+}
+
+export interface CleanupEvidence {
+	mergeCommit?: string;
+	retentionApprovedAt?: string;
+	explicitCleanupRequestedAt?: string;
+	gcApprovedAt?: string;
+	remoteDeleteIntent?: { headSha: string; at: string };
+	remoteBranchDeletedAt?: string;
+	worktreeRemoveIntent?: { path: string; at: string };
+	worktreeRemovedAt?: string;
+	localRefDeleteIntent?: { ref: string; headSha: string; at: string };
+	localRefDeletedAt?: string;
+	cleanupBlockedAt?: string;
+	cleanupBlockedReason?: string;
+}
+
+export interface LaneRecord extends LaneOwnership {
+	version: 1;
+	laneId: string;
+	state: LifecycleState;
+	createdAt: string;
+	updatedAt: string;
+	cleanupEvidence?: CleanupEvidence;
+	gitCommonDir?: string;
+	remote?: string;
+	base?: string;
+	baseSha?: string;
+	headSha?: string;
+	worktreeGitDir?: string;
+	worktreeOwnershipToken?: string;
+	leaseOwner?: string;
+	leaseExpiresAt?: string;
+	leaseUpdatedAt?: string;
+}
+
+export interface LifecycleEvent {
+	version: 1;
+	laneId: string;
+	at: string;
+	type: string;
+	state: LifecycleState;
+	details?: Record<string, string | number | boolean | null>;
+}
+
+export class LifecycleError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "LifecycleError";
+	}
+}
+
+const WINDOWS_RESERVED = new Set([
+	"con",
+	"prn",
+	"aux",
+	"nul",
+	"clock$",
+	...Array.from({ length: 10 }, (_, index) => `com${index + 1}`),
+	...Array.from({ length: 10 }, (_, index) => `lpt${index + 1}`),
+]);
+const SAFE_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const MAX_BRANCH_LENGTH = 240;
+const MAX_WORKTREE_TOKEN_LENGTH = 120;
+
+function normalizePart(value: string, label: string): string {
+	const normalized = value
+		.trim()
+		.toLowerCase()
+		.replace(/[\s_]+/g, "-");
+	if (!SAFE_ID.test(normalized) || normalized.includes("--")) {
+		throw new LifecycleError(`${label} must be lowercase alphanumeric words separated by single hyphens`);
+	}
+	if (normalized.split("-").some(part => WINDOWS_RESERVED.has(part))) {
+		throw new LifecycleError(`${label} contains a Windows reserved filename`);
+	}
+	return normalized;
+}
+
+export function parseNormalizedPurpose(value: string): string {
+	return normalizePart(value, "purpose");
+}
+
+function isWorkType(value: string): value is WorkType {
+	return Object.values(WorkType).includes(value as WorkType);
+}
+
+function collides(value: string, existing: readonly string[] | undefined): boolean {
+	return (
+		existing?.some(candidate => candidate.toLocaleLowerCase("en-US") === value.toLocaleLowerCase("en-US")) ?? false
+	);
+}
+
+export function createLaneName(input: LaneNameInput): LaneName {
+	if (!isWorkType(input.type)) throw new LifecycleError("work type is not supported");
+	const scope = normalizePart(input.scope, "scope");
+	const purpose = parseNormalizedPurpose(input.purpose);
+	const agent = normalizePart(input.agent, "agent");
+	const id = normalizePart(input.id, "id");
+	const scopePurpose = `${scope}-${purpose}`;
+	const branch = `${input.type}/${scopePurpose}--${agent}-${id}`;
+	const worktreeToken = `${input.type.toUpperCase()})${scopePurpose}__${agent}-${id}`;
+	if (branch.length > MAX_BRANCH_LENGTH) throw new LifecycleError("branch name exceeds the supported length");
+	if (worktreeToken.length > MAX_WORKTREE_TOKEN_LENGTH)
+		throw new LifecycleError("worktree token exceeds the supported Windows length");
+	if (collides(branch, input.existingBranches))
+		throw new LifecycleError("branch collides case-insensitively with an existing branch");
+	if (collides(worktreeToken, input.existingWorktreeTokens))
+		throw new LifecycleError("worktree token collides case-insensitively with an existing worktree");
+	return { branch, worktreeToken, scope, purpose };
+}
+
+function lifecycleRoot(gitCommonDir: string): string {
+	return path.join(gitCommonDir, "gjc", "lifecycle", "v1");
+}
+
+function validateLaneId(laneId: string): string {
+	return normalizePart(laneId, "lane id");
+}
+
+function recordPath(gitCommonDir: string, laneId: string): string {
+	return path.join(lifecycleRoot(gitCommonDir), "records", `${validateLaneId(laneId)}.json`);
+}
+
+export async function writeLaneRecord(gitCommonDir: string, record: LaneRecord): Promise<void> {
+	const destination = recordPath(gitCommonDir, record.laneId);
+	await fs.mkdir(path.dirname(destination), { recursive: true });
+	const temporary = `${destination}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		await fs.writeFile(temporary, `${JSON.stringify(record, null, "\t")}\n`, "utf8");
+		await fs.rename(temporary, destination);
+	} finally {
+		await fs.rm(temporary, { force: true });
+	}
+}
+
+export async function readLaneRecord(gitCommonDir: string, laneId: string): Promise<LaneRecord | undefined> {
+	const normalizedLaneId = validateLaneId(laneId);
+	try {
+		const destination = recordPath(gitCommonDir, normalizedLaneId);
+		const parsed: unknown = JSON.parse(await fs.readFile(destination, "utf8"));
+		if (
+			!isLaneRecord(parsed) ||
+			parsed.laneId !== normalizedLaneId ||
+			path.basename(destination) !== `${parsed.laneId}.json`
+		)
+			throw new LifecycleError("lane record has an invalid shape or identity");
+		return parsed;
+	} catch (error: unknown) {
+		if (isNodeError(error, "ENOENT")) return undefined;
+		throw error;
+	}
+}
+export async function listLaneRecords(gitCommonDir: string): Promise<LaneRecord[]> {
+	const recordsDir = path.join(lifecycleRoot(gitCommonDir), "records");
+	let entries: Dirent[];
+	try {
+		entries = await fs.readdir(recordsDir, { withFileTypes: true });
+	} catch (error: unknown) {
+		if (isNodeError(error, "ENOENT")) return [];
+		throw error;
+	}
+	const records: LaneRecord[] = [];
+	for (const entry of entries) {
+		if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(await fs.readFile(path.join(recordsDir, entry.name), "utf8"));
+		} catch {
+			throw new LifecycleError(`lane record is unreadable: ${entry.name}`);
+		}
+		try {
+			validateLaneId(parsed && typeof parsed === "object" && "laneId" in parsed ? String(parsed.laneId) : "");
+		} catch {
+			throw new LifecycleError(`lane record has an invalid shape: ${entry.name}`);
+		}
+		if (!isLaneRecord(parsed) || entry.name !== `${parsed.laneId}.json`)
+			throw new LifecycleError(`lane record has an invalid shape: ${entry.name}`);
+		records.push(parsed);
+	}
+	return records;
+}
+
+export async function findLaneRecordByWorktreePath(
+	gitCommonDir: string,
+	worktreePath: string,
+): Promise<LaneRecord | undefined> {
+	const normalizedPath = path.resolve(worktreePath);
+	const matches = (await listLaneRecords(gitCommonDir)).filter(
+		record => path.resolve(record.worktreePath) === normalizedPath,
+	);
+	if (matches.length > 1) throw new LifecycleError(`multiple lane records match worktree path: ${normalizedPath}`);
+	return matches[0];
+}
+
+export async function appendLifecycleEvent(gitCommonDir: string, event: LifecycleEvent): Promise<void> {
+	validateLaneId(event.laneId);
+	const eventsPath = path.join(lifecycleRoot(gitCommonDir), "events.jsonl");
+	await fs.mkdir(path.dirname(eventsPath), { recursive: true });
+	await fs.appendFile(eventsPath, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+export interface LifecycleLock {
+	readonly laneId: string;
+	release(): Promise<void>;
+}
+
+export async function acquireLifecycleLock(gitCommonDir: string, laneId: string): Promise<LifecycleLock> {
+	const normalizedLaneId = validateLaneId(laneId);
+	const lockPath = path.join(lifecycleRoot(gitCommonDir), "locks", `${normalizedLaneId}.lock`);
+	await fs.mkdir(path.dirname(lockPath), { recursive: true });
+	let handle: fs.FileHandle;
+	try {
+		handle = await fs.open(lockPath, "wx");
+	} catch (error: unknown) {
+		if (isNodeError(error, "EEXIST")) throw new LifecycleError(`lane lock is already held: ${normalizedLaneId}`);
+		throw error;
+	}
+	let released = false;
+	return {
+		laneId: normalizedLaneId,
+		async release(): Promise<void> {
+			if (released) return;
+			released = true;
+			await handle.close();
+			await fs.rm(lockPath, { force: true });
+		},
+	};
+}
+
+export function ownershipMatches(record: LaneRecord, ownership: LaneOwnership): boolean {
+	return (
+		record.repositoryId === ownership.repositoryId &&
+		record.realm === ownership.realm &&
+		record.branch === ownership.branch &&
+		record.worktreeToken === ownership.worktreeToken &&
+		record.worktreePath === ownership.worktreePath &&
+		record.agent === ownership.agent &&
+		record.sessionId === ownership.sessionId
+	);
+}
+
+export function isCleanupEligible(record: LaneRecord, ownership: LaneOwnership): boolean {
+	const evidence = record.cleanupEvidence;
+	return (
+		record.state === "gc_eligible" &&
+		ownershipMatches(record, ownership) &&
+		record.realm === "windows" &&
+		typeof evidence?.mergeCommit === "string" &&
+		evidence.mergeCommit.length > 0 &&
+		typeof evidence.retentionApprovedAt === "string" &&
+		typeof evidence.explicitCleanupRequestedAt === "string" &&
+		typeof evidence.gcApprovedAt === "string"
+	);
+}
+
+function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+	return (
+		typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === code
+	);
+}
+
+function isLaneRecord(value: unknown): value is LaneRecord {
+	if (typeof value !== "object" || value === null) return false;
+	const record = value as Partial<LaneRecord>;
+	const nonEmpty = (field: unknown): field is string => typeof field === "string" && field.length > 0;
+	try {
+		if (!nonEmpty(record.laneId) || validateLaneId(record.laneId) !== record.laneId) return false;
+	} catch {
+		return false;
+	}
+	return (
+		record.version === 1 &&
+		typeof record.state === "string" &&
+		LifecycleStates.includes(record.state as LifecycleState) &&
+		nonEmpty(record.repositoryId) &&
+		(record.realm === "windows" || record.realm === "wsl") &&
+		nonEmpty(record.branch) &&
+		nonEmpty(record.worktreeToken) &&
+		nonEmpty(record.worktreePath) &&
+		(record.gitCommonDir === undefined || nonEmpty(record.gitCommonDir)) &&
+		(record.remote === undefined || nonEmpty(record.remote)) &&
+		(record.base === undefined || nonEmpty(record.base)) &&
+		(record.baseSha === undefined || nonEmpty(record.baseSha)) &&
+		(record.headSha === undefined || nonEmpty(record.headSha)) &&
+		(record.leaseOwner === undefined || nonEmpty(record.leaseOwner)) &&
+		(record.worktreeGitDir === undefined || nonEmpty(record.worktreeGitDir)) &&
+		(record.worktreeOwnershipToken === undefined || nonEmpty(record.worktreeOwnershipToken)) &&
+		(record.leaseExpiresAt === undefined ||
+			(typeof record.leaseExpiresAt === "string" && Number.isFinite(Date.parse(record.leaseExpiresAt)))) &&
+		(record.leaseUpdatedAt === undefined ||
+			(typeof record.leaseUpdatedAt === "string" && Number.isFinite(Date.parse(record.leaseUpdatedAt)))) &&
+		((record.leaseOwner === undefined &&
+			record.leaseExpiresAt === undefined &&
+			record.leaseUpdatedAt === undefined) ||
+			(nonEmpty(record.leaseOwner) &&
+				typeof record.leaseExpiresAt === "string" &&
+				typeof record.leaseUpdatedAt === "string")) &&
+		nonEmpty(record.agent) &&
+		nonEmpty(record.sessionId) &&
+		nonEmpty(record.createdAt) &&
+		nonEmpty(record.updatedAt)
+	);
+}

--- a/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
@@ -138,10 +138,6 @@ function hasBranchInUse(entries: GitWorktreeEntry[], branchName: string, worktre
 	return entries.some(entry => entry.branchRef === expectedRef && path.resolve(entry.path) !== resolvedPath);
 }
 
-function pruneStaleWorktreePath(repoRoot: string): void {
-	runGit(repoRoot, ["worktree", "prune"]);
-}
-
 function readWorktreeEntryFromPath(repoRoot: string, worktreePath: string): GitWorktreeEntry | null {
 	if (!fs.existsSync(worktreePath)) return null;
 	const repoCommonDir = tryRunGit(repoRoot, ["rev-parse", "--git-common-dir"]);
@@ -226,12 +222,10 @@ export function ensureLaunchWorktree(
 	plan: GjcLaunchWorktreePlan | { enabled: false },
 ): GjcLaunchWorktreeResult | { enabled: false } {
 	if (!plan.enabled) return { enabled: false };
-	let allWorktrees = listWorktrees(plan.repoRoot);
+	const allWorktrees = listWorktrees(plan.repoRoot);
 	const staleAtPath = findWorktreeByPath(allWorktrees, plan.worktreePath);
-	if (staleAtPath && !fs.existsSync(staleAtPath.path)) {
-		pruneStaleWorktreePath(plan.repoRoot);
-		allWorktrees = listWorktrees(plan.repoRoot);
-	}
+	if (staleAtPath && !fs.existsSync(staleAtPath.path))
+		throw new Error(`worktree_stale_registration:${plan.worktreePath}`);
 
 	const existingAtPath =
 		findWorktreeByPath(allWorktrees, plan.worktreePath) ??
@@ -239,27 +233,13 @@ export function ensureLaunchWorktree(
 	const expectedBranchRef = plan.branchName ? `refs/heads/${plan.branchName}` : null;
 
 	if (existingAtPath) {
-		let dirty = isWorktreeDirty(plan.worktreePath);
-		if (plan.detached) {
-			if (!existingAtPath.detached) {
-				throw new Error(formatWorktreeTargetMismatch(plan, existingAtPath));
-			}
-			if (existingAtPath.head !== plan.baseRef) {
-				if (dirty) throw new Error(`worktree_dirty:${plan.worktreePath}`);
-				runGit(plan.worktreePath, ["checkout", "--detach", plan.baseRef]);
-				dirty = false;
-			}
-		} else if (existingAtPath.branchRef !== expectedBranchRef) {
+		if (isWorktreeDirty(plan.worktreePath)) throw new Error(`worktree_dirty:${plan.worktreePath}`);
+		if (
+			(plan.detached && !existingAtPath.detached) ||
+			(!plan.detached && existingAtPath.branchRef !== expectedBranchRef)
+		)
 			throw new Error(formatWorktreeTargetMismatch(plan, existingAtPath));
-		}
-		return {
-			...plan,
-			worktreePath: path.resolve(plan.worktreePath),
-			created: false,
-			reused: true,
-			createdBranch: false,
-			...(dirty ? { dirty: true } : {}),
-		};
+		throw new Error(`worktree_ownership_required:${plan.worktreePath}`);
 	}
 
 	if (fs.existsSync(plan.worktreePath)) throw new Error(`worktree_path_conflict:${plan.worktreePath}`);
@@ -267,11 +247,11 @@ export function ensureLaunchWorktree(
 		throw new Error(`branch_in_use:${plan.branchName}`);
 	}
 
-	fs.mkdirSync(path.dirname(plan.worktreePath), { recursive: true });
 	const branchAlreadyExisted = plan.branchName ? branchExists(plan.repoRoot, plan.branchName) : false;
+	if (branchAlreadyExisted) throw new Error(`branch_unmanaged:${plan.branchName}`);
+	fs.mkdirSync(path.dirname(plan.worktreePath), { recursive: true });
 	const args = ["worktree", "add"];
 	if (plan.detached) args.push("--detach", plan.worktreePath, plan.baseRef);
-	else if (branchAlreadyExisted) args.push(plan.worktreePath, plan.branchName ?? "");
 	else args.push("-b", plan.branchName ?? "", plan.worktreePath, plan.baseRef);
 
 	const result = Bun.spawnSync(["git", ...args], { cwd: plan.repoRoot, stdout: "pipe", stderr: "pipe" });

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -7,6 +7,15 @@ import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildTeamHudSummary as buildWorkflowTeamHudSummary } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
 import type { GcPidProbe, GcRecord } from "./gc-runtime";
+import {
+	acquireLifecycleLock,
+	appendLifecycleEvent,
+	findLaneRecordByWorktreePath,
+	type LaneRecord,
+	readLaneRecord,
+	WorkType,
+	writeLaneRecord,
+} from "./git-lifecycle";
 import { applyGjcTmuxProfile } from "./launch-tmux";
 import { modeStatePath, sessionIdFromDirName, sessionReportsDir, teamStateRoot } from "./session-layout";
 import { resolveGjcSessionForWrite, writeSessionActivityMarker } from "./session-resolution";
@@ -68,12 +77,15 @@ export interface GjcTeamWorker {
 	status: "starting" | "idle" | "busy" | "stopped";
 	last_heartbeat: string;
 	assigned_tasks: string[];
+	auth_token?: string;
 	worktree_repo_root?: string;
 	worktree_path?: string;
 	worktree_branch?: string | null;
 	worktree_detached?: boolean;
 	worktree_created?: boolean;
 	worktree_base_ref?: string;
+	worktree_git_common_dir?: string;
+	worktree_base_head?: string;
 	team_state_root?: string;
 }
 
@@ -155,12 +167,16 @@ export interface GjcTeamConfig {
 	team_state_root: string;
 	workers: GjcTeamWorker[];
 	created_at: string;
+	lifecycle_mode?: "managed";
+	lifecycle_lane_id?: string;
+	lifecycle_git_common_dir?: string;
 	updated_at: string;
 }
 
 export type GjcTeamIntegrationStatus =
 	| "idle"
 	| "integrated"
+	| "integration_required"
 	| "integration_failed"
 	| "merge_conflict"
 	| "cherry_pick_conflict"
@@ -196,6 +212,9 @@ export interface GjcTeamWorkerLifecycle {
 	shutdown_acknowledged_at?: string;
 	shutdown_ack_status?: string;
 	shutdown_mode?: GjcTeamShutdownMode;
+	shutdown_final_head?: string;
+	shutdown_clean?: boolean;
+	shutdown_terminal_at?: string;
 }
 
 export type GjcTeamNotificationDeliveryState =
@@ -574,6 +593,7 @@ export const GJC_TEAM_API_OPERATIONS = [
 	"read-traces",
 	"await-event",
 	"write-shutdown-request",
+	"write-shutdown-ack",
 	"read-shutdown-ack",
 	"read-monitor-snapshot",
 	"write-monitor-snapshot",
@@ -1199,6 +1219,9 @@ async function readWorkerLifecycleRecord(dir: string, worker: GjcTeamWorker): Pr
 	if (typeof shutdownAck?.acknowledged_at === "string")
 		lifecycle.shutdown_acknowledged_at = shutdownAck.acknowledged_at;
 	if (typeof shutdownAck?.status === "string") lifecycle.shutdown_ack_status = shutdownAck.status;
+	if (typeof shutdownAck?.final_head === "string") lifecycle.shutdown_final_head = shutdownAck.final_head;
+	if (typeof shutdownAck?.clean === "boolean") lifecycle.shutdown_clean = shutdownAck.clean;
+	if (typeof shutdownAck?.terminal_at === "string") lifecycle.shutdown_terminal_at = shutdownAck.terminal_at;
 	return lifecycle;
 }
 
@@ -1742,6 +1765,7 @@ function buildWorkers(count: number, agentType: string, stateRoot?: string): Gjc
 			status: "starting",
 			last_heartbeat: now(),
 			assigned_tasks: [],
+			auth_token: randomUUID(),
 			team_state_root: stateRoot,
 		};
 	});
@@ -1785,6 +1809,174 @@ function tryRunGit(cwd: string, args: string[]): string | null {
 }
 function isGitRepository(cwd: string): boolean {
 	return tryRunGit(cwd, ["rev-parse", "--show-toplevel"]) != null;
+}
+function gitCommonDir(cwd: string): string | null {
+	const commonDir = tryRunGit(cwd, ["rev-parse", "--git-common-dir"]);
+	return commonDir ? path.resolve(cwd, commonDir) : null;
+}
+
+const MANAGED_DEVELOPMENT_STATES = new Set(["active", "pushed", "pr_open", "verifying", "eligible"]);
+const MANAGED_FEATURE_LANE_TYPES = new Set(Object.values(WorkType));
+function isManagedFeatureLaneBranch(branch: string): boolean {
+	const [type, name] = branch.split("/", 2);
+	return Boolean(name && type && MANAGED_FEATURE_LANE_TYPES.has(type as (typeof WorkType)[keyof typeof WorkType]));
+}
+
+async function resolveManagedTeamLane(cwd: string): Promise<{ lane: LaneRecord; gitCommonDir: string } | undefined> {
+	const commonDir = gitCommonDir(cwd);
+	if (!commonDir || !(await pathExists(path.join(commonDir, "gjc", "lifecycle", "v1", "policy.json"))))
+		return undefined;
+	const lane = await findLaneRecordByWorktreePath(commonDir, cwd);
+	if (
+		!lane ||
+		path.resolve(lane.worktreePath) !== path.resolve(cwd) ||
+		lane.branch !== tryRunGit(cwd, ["branch", "--show-current"]) ||
+		(lane.gitCommonDir && path.resolve(lane.gitCommonDir) !== commonDir) ||
+		!isManagedFeatureLaneBranch(lane.branch) ||
+		!MANAGED_DEVELOPMENT_STATES.has(lane.state)
+	)
+		throw new Error("managed_team_requires_active_feature_lane");
+	return { lane, gitCommonDir: commonDir };
+}
+const MANAGED_TEAM_LEASE_MS = 120_000;
+async function acquireManagedTeamLease(
+	commonDir: string,
+	laneId: string,
+	owner: string,
+	leaderCwd: string,
+	expectedHead: string | null,
+): Promise<void> {
+	const lock = await acquireLifecycleLock(commonDir, laneId);
+	try {
+		const lane = await readLaneRecord(commonDir, laneId);
+		if (!lane) throw new Error("managed_team_lane_missing");
+		if (
+			!MANAGED_DEVELOPMENT_STATES.has(lane.state) ||
+			!isManagedFeatureLaneBranch(lane.branch) ||
+			path.resolve(lane.worktreePath) !== path.resolve(leaderCwd) ||
+			lane.branch !== tryRunGit(leaderCwd, ["branch", "--show-current"]) ||
+			(lane.gitCommonDir && path.resolve(lane.gitCommonDir) !== commonDir) ||
+			commonDir !== gitCommonDir(leaderCwd) ||
+			worktreeIsDirty(leaderCwd) ||
+			!expectedHead ||
+			(lane as LaneRecord & { headSha?: string }).headSha !== expectedHead ||
+			resolveHead(leaderCwd) !== expectedHead
+		)
+			throw new Error("managed_team_lane_changed_before_lease");
+		if (lane.leaseOwner && lane.leaseOwner !== owner)
+			throw new Error(`managed_team_lease_conflict:${lane.leaseOwner}`);
+		const updatedAt = now();
+		await writeLaneRecord(commonDir, {
+			...lane,
+			leaseOwner: owner,
+			leaseUpdatedAt: updatedAt,
+			leaseExpiresAt: new Date(Date.now() + MANAGED_TEAM_LEASE_MS).toISOString(),
+			updatedAt,
+		});
+		await appendLifecycleEvent(commonDir, {
+			version: 1,
+			laneId,
+			at: updatedAt,
+			type: "team_lease_acquired",
+			state: lane.state,
+			details: { owner },
+		});
+	} finally {
+		await lock.release();
+	}
+}
+async function releaseManagedTeamLease(gitCommonDir: string, laneId: string, owner: string): Promise<void> {
+	const lock = await acquireLifecycleLock(gitCommonDir, laneId);
+	try {
+		const lane = await readLaneRecord(gitCommonDir, laneId);
+		if (!lane || lane.leaseOwner !== owner) return;
+		const updatedAt = now();
+		await writeLaneRecord(gitCommonDir, {
+			...lane,
+			leaseOwner: undefined,
+			leaseExpiresAt: undefined,
+			leaseUpdatedAt: undefined,
+			updatedAt,
+		});
+		await appendLifecycleEvent(gitCommonDir, {
+			version: 1,
+			laneId,
+			at: updatedAt,
+			type: "team_lease_released",
+			state: lane.state,
+			details: { owner },
+		});
+	} finally {
+		await lock.release();
+	}
+}
+async function renewManagedTeamLeaseUnderLock(config: GjcTeamConfig): Promise<LaneRecord> {
+	if (!config.lifecycle_git_common_dir || !config.lifecycle_lane_id)
+		throw new Error("managed_team_lifecycle_metadata_missing");
+	const lane = await readLaneRecord(config.lifecycle_git_common_dir, config.lifecycle_lane_id);
+	const owner = `team:${config.team_name}`;
+	const leaderHead = resolveHead(config.leader_cwd);
+	const recordedHead = (lane as (LaneRecord & { headSha?: string }) | undefined)?.headSha;
+	if (
+		!lane ||
+		lane.leaseOwner !== owner ||
+		!lane.leaseExpiresAt ||
+		!MANAGED_DEVELOPMENT_STATES.has(lane.state) ||
+		path.resolve(lane.worktreePath) !== path.resolve(config.leader_cwd) ||
+		lane.branch !== tryRunGit(config.leader_cwd, ["branch", "--show-current"]) ||
+		(lane.gitCommonDir && path.resolve(lane.gitCommonDir) !== path.resolve(config.lifecycle_git_common_dir)) ||
+		gitCommonDir(config.leader_cwd) !== path.resolve(config.lifecycle_git_common_dir) ||
+		worktreeIsDirty(config.leader_cwd) ||
+		!recordedHead ||
+		leaderHead !== recordedHead
+	)
+		throw new Error("managed_team_lease_not_renewable");
+	const updatedAt = now();
+	const updated = {
+		...lane,
+		leaseUpdatedAt: updatedAt,
+		leaseExpiresAt: new Date(Date.now() + MANAGED_TEAM_LEASE_MS).toISOString(),
+		updatedAt,
+	};
+	await writeLaneRecord(config.lifecycle_git_common_dir, updated);
+	return updated;
+}
+
+async function recordManagedTeamHeadUnderLock(
+	config: GjcTeamConfig,
+	expectedPreviousHead: string,
+	newHead: string,
+): Promise<void> {
+	if (!config.lifecycle_git_common_dir || !config.lifecycle_lane_id)
+		throw new Error("managed_team_lifecycle_metadata_missing");
+	const lane = await readLaneRecord(config.lifecycle_git_common_dir, config.lifecycle_lane_id);
+	const owner = `team:${config.team_name}`;
+	if (
+		!lane ||
+		lane.leaseOwner !== owner ||
+		(lane as LaneRecord & { headSha?: string }).headSha !== expectedPreviousHead ||
+		resolveHead(config.leader_cwd) !== newHead ||
+		worktreeIsDirty(config.leader_cwd)
+	)
+		throw new Error("managed_team_head_record_failed");
+	const updatedAt = now();
+	const updated: LaneRecord & { headSha: string } = {
+		...lane,
+		headSha: newHead,
+		updatedAt,
+	};
+	await writeLaneRecord(config.lifecycle_git_common_dir, updated);
+}
+function assertManagedLeaderReady(config: GjcTeamConfig, lane: LaneRecord, expectedHead: string | null): void {
+	const leader = config.leader_cwd;
+	if (
+		path.resolve(lane.worktreePath) !== path.resolve(leader) ||
+		lane.branch !== tryRunGit(leader, ["branch", "--show-current"]) ||
+		(lane.gitCommonDir && path.resolve(lane.gitCommonDir) !== gitCommonDir(leader)) ||
+		worktreeIsDirty(leader) ||
+		(expectedHead !== null && resolveHead(leader) !== expectedHead)
+	)
+		throw new Error("managed_team_leader_not_ready");
 }
 
 function parseWorktreeMode(args: string[]): { mode: GjcTeamWorktreeMode; remainingArgs: string[] } {
@@ -1888,20 +2080,16 @@ async function ensureWorkerWorktree(
 	const branchName = mode.detached
 		? null
 		: `${mode.name}/${sanitizePathToken(teamName)}/${sanitizePathToken(worker.id)}`;
-	if (existing) {
-		if (worktreeIsDirty(worktreePath)) throw new Error(`worktree_dirty:${worktreePath}`);
-		if (mode.detached && worktreeHead(worktreePath) !== baseRef) throw new Error(`worktree_stale:${worktreePath}`);
-	} else {
-		if (await pathExists(worktreePath)) throw new Error(`worktree_path_conflict:${worktreePath}`);
-		await fs.mkdir(path.dirname(worktreePath), { recursive: true });
-		const args = mode.detached
-			? ["worktree", "add", "--detach", worktreePath, baseRef]
-			: branchExists(repoRoot, branchName ?? "")
-				? ["worktree", "add", worktreePath, branchName ?? ""]
-				: ["worktree", "add", "-b", branchName ?? "", worktreePath, baseRef];
-		runGit(repoRoot, args);
-		created = true;
-	}
+	if (existing) throw new Error(`worktree_path_conflict:${worktreePath}`);
+	if (await pathExists(worktreePath)) throw new Error(`worktree_path_conflict:${worktreePath}`);
+	if (!mode.detached && branchExists(repoRoot, branchName ?? ""))
+		throw new Error(`worktree_branch_conflict:${branchName}`);
+	await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+	const args = mode.detached
+		? ["worktree", "add", "--detach", worktreePath, baseRef]
+		: ["worktree", "add", "-b", branchName ?? "", worktreePath, baseRef];
+	runGit(repoRoot, args);
+	created = true;
 	return {
 		...worker,
 		worktree_repo_root: repoRoot,
@@ -1910,6 +2098,8 @@ async function ensureWorkerWorktree(
 		worktree_detached: mode.detached,
 		worktree_created: created,
 		worktree_base_ref: baseRef,
+		worktree_git_common_dir: gitCommonDir(repoRoot) ?? undefined,
+		worktree_base_head: baseRef,
 	};
 }
 
@@ -2100,6 +2290,7 @@ export function buildWorkerCommand(
 		envAssignment("GJC_TEAM_INTERNAL_WORKER", `${config.team_name}/${worker.id}`),
 		envAssignment("GJC_TEAM_NAME", config.team_name),
 		envAssignment("GJC_TEAM_WORKER_ID", worker.id),
+		...(worker.auth_token ? [envAssignment("GJC_TEAM_WORKER_AUTH_TOKEN", worker.auth_token)] : []),
 		envAssignment("GJC_TEAM_STATE_ROOT", config.state_root),
 		envAssignment("GJC_TEAM_LEADER_CWD", config.leader.cwd),
 		envAssignment("GJC_TEAM_DISPLAY_NAME", config.display_name),
@@ -2363,6 +2554,17 @@ function paneBelongsToTeamTarget(config: GjcTeamConfig, paneId: string): boolean
 	const [target = "", detectedPaneId = ""] = result.stdout.toString().trim().split(/\s+/);
 	return target === config.tmux_target && detectedPaneId === paneId;
 }
+function paneIsPositivelyAbsent(config: GjcTeamConfig, paneId: string): boolean {
+	const result = Bun.spawnSync([config.tmux_command, "list-panes", "-a", "-F", "#{pane_id}"], {
+		stdout: "pipe",
+		stderr: "ignore",
+	});
+	if (result.exitCode !== 0) return false;
+	return !result.stdout
+		.toString()
+		.split(/\r?\n/)
+		.some(candidate => candidate.trim() === paneId);
+}
 function killWorkerPanes(config: GjcTeamConfig): void {
 	for (const worker of config.workers)
 		if (worker.pane_id?.startsWith("%") && paneBelongsToTeamTarget(config, worker.pane_id))
@@ -2372,22 +2574,87 @@ function killWorkerPanes(config: GjcTeamConfig): void {
 			});
 }
 async function rollbackCreatedWorktrees(workers: GjcTeamWorker[]): Promise<void> {
-	for (const worker of workers.filter(worker => worker.worktree_created).reverse())
-		if (worker.worktree_repo_root && worker.worktree_path)
-			Bun.spawnSync(["git", "worktree", "remove", "--force", worker.worktree_path], {
-				cwd: worker.worktree_repo_root,
-				stdout: "ignore",
-				stderr: "ignore",
-			});
+	for (const worker of workers.filter(worker => worker.worktree_created).reverse()) {
+		if (!worker.worktree_repo_root || !worker.worktree_path || !(await pathExists(worker.worktree_path))) continue;
+		const registered = findWorktreePath(worker.worktree_repo_root, worker.worktree_path);
+		const owned =
+			registered === path.resolve(worker.worktree_path) &&
+			worker.worktree_git_common_dir === gitCommonDir(worker.worktree_repo_root) &&
+			!worktreeIsDirty(worker.worktree_path) &&
+			worktreeHead(worker.worktree_path) === worker.worktree_base_head;
+		if (owned) runGitResult(worker.worktree_repo_root, ["worktree", "remove", worker.worktree_path]);
+	}
 }
 async function removeCleanCreatedWorktrees(workers: GjcTeamWorker[]): Promise<void> {
-	for (const worker of workers.filter(worker => worker.worktree_created).reverse())
-		if (worker.worktree_repo_root && worker.worktree_path && !worktreeIsDirty(worker.worktree_path))
-			Bun.spawnSync(["git", "worktree", "remove", worker.worktree_path], {
-				cwd: worker.worktree_repo_root,
-				stdout: "ignore",
-				stderr: "ignore",
+	for (const worker of workers.filter(worker => worker.worktree_created).reverse()) {
+		if (!worker.worktree_repo_root || !worker.worktree_path || !(await pathExists(worker.worktree_path))) continue;
+		const registered = findWorktreePath(worker.worktree_repo_root, worker.worktree_path);
+		const commonDir = gitCommonDir(worker.worktree_path);
+		const currentBranch = tryRunGit(worker.worktree_path, ["symbolic-ref", "-q", "--short", "HEAD"]);
+		const owned =
+			registered === path.resolve(worker.worktree_path) &&
+			Boolean(
+				worker.worktree_git_common_dir &&
+					commonDir === path.resolve(worker.worktree_git_common_dir) &&
+					commonDir === gitCommonDir(worker.worktree_repo_root),
+			) &&
+			(worker.worktree_detached ? currentBranch === null : currentBranch === worker.worktree_branch) &&
+			!worktreeIsDirty(worker.worktree_path) &&
+			worktreeHead(worker.worktree_path) === worker.worktree_base_head;
+		if (owned) runGitResult(worker.worktree_repo_root, ["worktree", "remove", worker.worktree_path]);
+	}
+}
+async function removeManagedCleanCreatedWorktrees(
+	dir: string,
+	config: GjcTeamConfig,
+	monitor: GjcTeamMonitorSnapshot | null,
+	pendingIntegration: boolean,
+): Promise<void> {
+	for (const worker of config.workers.filter(worker => worker.worktree_created).reverse()) {
+		const integration = monitor?.integration_by_worker?.[worker.id];
+		const head =
+			worker.worktree_path && (await pathExists(worker.worktree_path)) ? resolveHead(worker.worktree_path) : null;
+		const registered =
+			worker.worktree_repo_root && worker.worktree_path
+				? findWorktreePath(worker.worktree_repo_root, worker.worktree_path)
+				: null;
+		const currentCommonDir = worker.worktree_path ? gitCommonDir(worker.worktree_path) : null;
+		const currentBranch = worker.worktree_path
+			? tryRunGit(worker.worktree_path, ["symbolic-ref", "-q", "--short", "HEAD"])
+			: null;
+		const eligible = Boolean(
+			!pendingIntegration &&
+				worker.worktree_repo_root &&
+				worker.worktree_path &&
+				head &&
+				registered === path.resolve(worker.worktree_path) &&
+				worker.worktree_git_common_dir &&
+				currentCommonDir === path.resolve(worker.worktree_git_common_dir) &&
+				currentCommonDir === gitCommonDir(worker.worktree_repo_root) &&
+				(worker.worktree_detached ? currentBranch === null : currentBranch === worker.worktree_branch) &&
+				integration?.last_integrated_head === head &&
+				!worktreeIsDirty(worker.worktree_path) &&
+				isAncestor(config.leader_cwd, head, "HEAD"),
+		);
+		if (eligible) {
+			const removal = runGitResult(worker.worktree_repo_root ?? config.leader_cwd, [
+				"worktree",
+				"remove",
+				worker.worktree_path ?? "",
+			]);
+			await appendIntegrationEvent(dir, removal.ok ? "worker_cleanup_applied" : "worker_cleanup_blocked", worker, {
+				worktree_path: worker.worktree_path,
+				summary: removal.ok
+					? `removed integrated worker worktree ${worker.id}`
+					: `cleanup blocked for ${worker.id}: ${removal.stderr || removal.stdout}`,
 			});
+			continue;
+		}
+		await appendIntegrationEvent(dir, "worker_cleanup_blocked", worker, {
+			worktree_path: worker.worktree_path,
+			summary: `cleanup blocked for ${worker.id}; integration, reachability, or cleanliness evidence is missing`,
+		});
+	}
 }
 
 function monitorSnapshotPath(dir: string): string {
@@ -2631,10 +2898,47 @@ async function integrateGjcWorkerCommits(
 		...(previous?.integration_by_worker ?? {}),
 	};
 	const hygieneEntries: GjcTeamCommitHygieneEntry[] = [];
+	const dirtyWorkers = new Set<string>();
 	const leaderCwd = config.leader_cwd || cwd;
 	const cycleLeaderHead = resolveHead(leaderCwd);
+	if (config.lifecycle_mode !== "managed") {
+		for (const worker of config.workers) {
+			if (!worker.worktree_path || !(await pathExists(worker.worktree_path))) continue;
+			const workerHead = resolveHead(worker.worktree_path);
+			integrationByWorker[worker.id] = {
+				...(integrationByWorker[worker.id] ?? {}),
+				last_seen_head: workerHead ?? undefined,
+				last_leader_head: cycleLeaderHead ?? undefined,
+				...integrationNowState(
+					workerHead && cycleLeaderHead && isAncestor(leaderCwd, workerHead, "HEAD")
+						? "idle"
+						: "integration_required",
+				),
+			};
+			if (workerHead && cycleLeaderHead && !isAncestor(leaderCwd, workerHead, "HEAD"))
+				await appendIntegrationEvent(dir, "worker_integration_required", worker, {
+					commit_hash: workerHead,
+					worktree_path: worker.worktree_path,
+					summary: `worker ${worker.id} requires explicit integration into an owned feature lane`,
+				});
+		}
+		return integrationByWorker;
+	}
 	for (const worker of config.workers) {
 		if (!worker.worktree_path || !worker.worktree_repo_root || !(await pathExists(worker.worktree_path))) continue;
+		if (config.lifecycle_mode === "managed" && worktreeIsDirty(worker.worktree_path)) {
+			dirtyWorkers.add(worker.id);
+			integrationByWorker[worker.id] = {
+				...(integrationByWorker[worker.id] ?? {}),
+				last_seen_head: resolveHead(worker.worktree_path) ?? undefined,
+				...integrationNowState("integration_failed"),
+			};
+			await appendIntegrationEvent(dir, "worker_dirty_blocked", worker, {
+				worktree_path: worker.worktree_path,
+				summary: `blocked dirty worker ${worker.id}; commit explicitly before integration`,
+			});
+			continue;
+		}
 		const { committed, commit } = autoCommitDirtyWorker(worker);
 		if (!committed) continue;
 		await appendIntegrationEvent(dir, "worker_auto_commit", worker, {
@@ -2657,6 +2961,7 @@ async function integrateGjcWorkerCommits(
 
 	for (const worker of config.workers) {
 		if (!worker.worktree_path || !worker.worktree_repo_root || !(await pathExists(worker.worktree_path))) continue;
+		if (dirtyWorkers.has(worker.id)) continue;
 		const leaderHead = resolveHead(leaderCwd);
 		const workerHead = resolveHead(worker.worktree_path);
 		const state: GjcTeamWorkerIntegrationState = {
@@ -2676,12 +2981,20 @@ async function integrateGjcWorkerCommits(
 			};
 			continue;
 		}
-		if (isAncestor(worker.worktree_path, leaderHead, workerHead)) {
-			const mergeRef = workerMergeRef(worker, workerHead);
+		if (config.lifecycle_mode === "managed" || isAncestor(worker.worktree_path, leaderHead, workerHead)) {
+			const mergeRef = config.lifecycle_mode === "managed" ? workerHead : workerMergeRef(worker, workerHead);
+			if (config.lifecycle_mode === "managed") {
+				if (!config.lifecycle_git_common_dir || !config.lifecycle_lane_id)
+					throw new Error("managed_team_lifecycle_metadata_missing");
+				const lane = await renewManagedTeamLeaseUnderLock(config);
+				assertManagedLeaderReady(config, lane, leaderHead);
+			}
 			const merge = runGitResult(leaderCwd, ["merge", "--no-ff", "-m", `gjc(team): merge ${worker.id}`, mergeRef]);
 			if (merge.ok) {
 				const newLeaderHead = resolveHead(leaderCwd);
 				if (newLeaderHead && newLeaderHead !== leaderHead && isAncestor(leaderCwd, workerHead, "HEAD")) {
+					if (config.lifecycle_mode === "managed")
+						await recordManagedTeamHeadUnderLock(config, leaderHead, newLeaderHead);
 					integrationByWorker[worker.id] = {
 						...state,
 						last_integrated_head: workerHead,
@@ -2893,7 +3206,7 @@ async function integrateGjcWorkerCommits(
 	}
 
 	const newLeaderHead = resolveHead(leaderCwd);
-	if (cycleLeaderHead && newLeaderHead && cycleLeaderHead !== newLeaderHead) {
+	if (config.lifecycle_mode !== "managed" && cycleLeaderHead && newLeaderHead && cycleLeaderHead !== newLeaderHead) {
 		for (const worker of config.workers) {
 			if (!worker.worktree_path || !(await pathExists(worker.worktree_path))) continue;
 			const status = await readGjcWorkerStatus(config.team_name, worker.id, cwd, env);
@@ -3039,6 +3352,7 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 	if (!Number.isInteger(options.workerCount) || options.workerCount < 1 || options.workerCount > GJC_TEAM_MAX_WORKERS)
 		throw new Error(`invalid_team_worker_count:${options.workerCount}:expected_1_${GJC_TEAM_MAX_WORKERS}`);
 	const workerCliPlan = resolveGjcTeamWorkerCliPlan(options.workerCount, env);
+	const managedLane = await resolveManagedTeamLane(cwd);
 	const stateRoot = resolveGjcTeamStateRoot(cwd, env);
 	const teamName = sanitizeName(options.teamName ?? makeTeamName(options.task, env));
 	const displayName = sanitizeName(options.teamName ?? options.task).slice(0, 30) || teamName;
@@ -3054,6 +3368,16 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 	const initialWorkers = buildWorkers(options.workerCount, options.agentType, stateRoot);
 	const initialTasks = buildInitialTasks(options.task, initialWorkers);
 	const workers: GjcTeamWorker[] = [];
+	const managedLeaseOwner = managedLane ? `team:${teamName}` : undefined;
+	const managedLeaseHead = managedLane ? resolveHead(cwd) : null;
+	if (managedLane && managedLeaseOwner)
+		await acquireManagedTeamLease(
+			managedLane.gitCommonDir,
+			managedLane.lane.laneId,
+			managedLeaseOwner,
+			cwd,
+			managedLeaseHead,
+		);
 	try {
 		for (const worker of initialWorkers)
 			workers.push(
@@ -3063,6 +3387,8 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 			);
 	} catch (error) {
 		await rollbackCreatedWorktrees(workers);
+		if (managedLane && managedLeaseOwner)
+			await releaseManagedTeamLease(managedLane.gitCommonDir, managedLane.lane.laneId, managedLeaseOwner);
 		throw error;
 	}
 	const config: GjcTeamConfig = {
@@ -3088,6 +3414,13 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		workers,
 		created_at: createdAt,
 		updated_at: createdAt,
+		...(managedLane
+			? {
+					lifecycle_mode: "managed" as const,
+					lifecycle_lane_id: managedLane.lane.laneId,
+					lifecycle_git_common_dir: managedLane.gitCommonDir,
+				}
+			: {}),
 	};
 	await initializeStateDirs(dir, config.workers);
 	await writeJsonFile(path.join(dir, "config.json"), config);
@@ -3145,6 +3478,8 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		});
 		killWorkerPanes(config);
 		await rollbackCreatedWorktrees(config.workers);
+		if (managedLane && managedLeaseOwner)
+			await releaseManagedTeamLease(managedLane.gitCommonDir, managedLane.lane.laneId, managedLeaseOwner);
 		throw error;
 	}
 	const runningConfig = {
@@ -3323,9 +3658,23 @@ export async function monitorGjcTeam(
 	const dir = await findTeamDir(teamName, cwd, env);
 	const config = await readConfig(dir);
 	const previous = await readJsonFile<GjcTeamMonitorSnapshot>(monitorSnapshotPath(dir));
-	await reconcileGjcTeamStaleClaims(teamName, dir, config, env);
-	const integrationByWorker = await integrateGjcWorkerCommits(config, dir, previous, cwd, env);
-	await writeJsonFile(monitorSnapshotPath(dir), { integration_by_worker: integrationByWorker, updated_at: now() });
+	const runMonitor = async (): Promise<void> => {
+		await reconcileGjcTeamStaleClaims(teamName, dir, config, env);
+		const integrationByWorker = await integrateGjcWorkerCommits(config, dir, previous, cwd, env);
+		await writeJsonFile(monitorSnapshotPath(dir), { integration_by_worker: integrationByWorker, updated_at: now() });
+	};
+	if (config.lifecycle_mode === "managed") {
+		if (!config.lifecycle_git_common_dir || !config.lifecycle_lane_id)
+			throw new Error("managed_team_lifecycle_metadata_missing");
+		const lock = await acquireLifecycleLock(config.lifecycle_git_common_dir, config.lifecycle_lane_id);
+		try {
+			const lane = await renewManagedTeamLeaseUnderLock(config);
+			assertManagedLeaderReady(config, lane, resolveHead(config.leader_cwd));
+			await runMonitor();
+		} finally {
+			await lock.release();
+		}
+	} else await runMonitor();
 	await replayGjcTeamNotifications(teamName, cwd, env);
 	await computeLifecycleNudges(config, dir, cwd, env);
 	return readGjcTeamSnapshot(teamName, cwd, env);
@@ -3513,25 +3862,74 @@ export async function shutdownGjcTeam(
 			),
 		),
 	);
+	if (config.lifecycle_mode === "managed") {
+		const deadline = Date.now() + parseDurationEnv(env, "GJC_TEAM_SHUTDOWN_ACK_TIMEOUT_MS", 30_000);
+		let terminal = false;
+		while (!terminal && Date.now() <= deadline) {
+			terminal = (
+				await Promise.all(
+					config.workers.map(async worker => {
+						const ack = await readGjcShutdownAck(teamName, worker.id, cwd, env);
+						const currentHead =
+							worker.worktree_path && (await pathExists(worker.worktree_path))
+								? resolveHead(worker.worktree_path)
+								: null;
+						return (
+							ack?.request_id === shutdownRequestId &&
+							ack.status === "stopped" &&
+							ack.clean === true &&
+							typeof ack.final_head === "string" &&
+							ack.final_head === currentHead &&
+							Boolean(worker.worktree_path) &&
+							!worktreeIsDirty(worker.worktree_path ?? "") &&
+							typeof worker.pane_id === "string" &&
+							paneIsPositivelyAbsent(config, worker.pane_id)
+						);
+					}),
+				)
+			).every(Boolean);
+			if (!terminal) await Bun.sleep(100);
+		}
+		if (!terminal) {
+			await appendEvent(dir, {
+				type: "team_shutdown_blocked",
+				message: "Managed shutdown blocked: worker-authored terminal ACK or pane exit proof is missing",
+				data: { shutdown_request_id: shutdownRequestId },
+			});
+			throw new Error("managed_shutdown_blocked_missing_terminal_ack_or_exit");
+		}
+	}
 	const monitor = await readJsonFile<GjcTeamMonitorSnapshot>(monitorSnapshotPath(dir));
 	const completionVerified = tasks.length === 0 || tasks.every(isGjcTeamTaskCompletionVerified);
 	const pendingIntegration = completionVerified ? await hasPendingGjcTeamIntegration(dir, config, monitor) : false;
-	killWorkerPanes(config);
-	await removeCleanCreatedWorktrees(config.workers);
+	if (config.lifecycle_mode !== "managed") killWorkerPanes(config);
+	if (config.lifecycle_mode === "managed") {
+		if (!config.lifecycle_git_common_dir || !config.lifecycle_lane_id)
+			throw new Error("managed_team_lifecycle_metadata_missing");
+		const lock = await acquireLifecycleLock(config.lifecycle_git_common_dir, config.lifecycle_lane_id);
+		try {
+			const lane = await renewManagedTeamLeaseUnderLock(config);
+			assertManagedLeaderReady(config, lane, resolveHead(config.leader_cwd));
+			await removeManagedCleanCreatedWorktrees(dir, config, monitor, pendingIntegration);
+		} finally {
+			await lock.release();
+		}
+	} else await removeCleanCreatedWorktrees(config.workers);
 	const stopped = {
 		...config,
 		workers: config.workers.map(worker => ({ ...worker, status: "stopped" as const, last_heartbeat: now() })),
 		updated_at: now(),
 	};
 	await writeJsonFile(path.join(dir, "config.json"), stopped);
-	await writeWorkerLifecycleForConfig(dir, stopped, "stopped", worker => ({
-		pane_id: worker.pane_id,
-		stopped_at: stopped.updated_at,
-		stop_reason: "graceful_shutdown",
-		shutdown_request_id: shutdownRequestId,
-		shutdown_requested_at: shutdownRequestedAt,
-		shutdown_mode: "graceful",
-	}));
+	if (config.lifecycle_mode !== "managed")
+		await writeWorkerLifecycleForConfig(dir, stopped, "stopped", worker => ({
+			pane_id: worker.pane_id,
+			stopped_at: stopped.updated_at,
+			stop_reason: "graceful_shutdown",
+			shutdown_request_id: shutdownRequestId,
+			shutdown_requested_at: shutdownRequestedAt,
+			shutdown_mode: "graceful",
+		}));
 	const workerLifecycleById = await readWorkerLifecycleById(dir, stopped);
 	const gracefulShutdownComplete = stopped.workers.every(worker => {
 		const lifecycle = workerLifecycleById[worker.id];
@@ -3550,6 +3948,18 @@ export async function shutdownGjcTeam(
 				? "failed"
 				: "cancelled";
 	await writePhase(dir, shutdownPhase);
+	if (
+		config.lifecycle_mode === "managed" &&
+		shutdownPhase === "complete" &&
+		!pendingIntegration &&
+		config.lifecycle_git_common_dir &&
+		config.lifecycle_lane_id
+	)
+		await releaseManagedTeamLease(
+			config.lifecycle_git_common_dir,
+			config.lifecycle_lane_id,
+			`team:${config.team_name}`,
+		);
 	const shutdownData: Record<string, unknown> = {
 		phase: shutdownPhase,
 		shutdown_request_id: shutdownRequestId,
@@ -4426,6 +4836,74 @@ export async function writeGjcShutdownRequest(
 	});
 	return value;
 }
+export async function writeGjcShutdownAck(
+	teamName: string,
+	worker: string,
+	requestId: string,
+	status: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<Record<string, unknown>> {
+	if (!requestId.trim()) throw new Error("invalid_shutdown_ack_request_id");
+	if (status !== "accepted" && status !== "stopped") throw new Error(`invalid_shutdown_ack_status:${status}`);
+	const dir = await findTeamDir(teamName, cwd, env);
+	const config = await readConfig(dir);
+	const teamWorker = findKnownWorker(config, worker);
+	const authenticatedTeam = env.GJC_TEAM_NAME?.trim();
+	const authenticatedWorker = env.GJC_TEAM_WORKER_ID?.trim() || env.GJC_TEAM_INTERNAL_WORKER?.split("/").pop()?.trim();
+	const authenticatedToken = env.GJC_TEAM_WORKER_AUTH_TOKEN?.trim();
+	if (
+		authenticatedTeam !== teamName ||
+		authenticatedWorker !== worker ||
+		!teamWorker.auth_token ||
+		authenticatedToken !== teamWorker.auth_token
+	)
+		throw new Error("shutdown_ack_worker_identity_mismatch");
+	const request = await readJsonFile<Record<string, unknown>>(
+		path.join(workerDir(dir, worker), "shutdown-request.json"),
+	);
+	if (request?.request_id !== requestId) throw new Error("shutdown_ack_request_id_mismatch");
+	const prior = await readJsonFile<Record<string, unknown>>(path.join(workerDir(dir, worker), "shutdown-ack.json"));
+	if (status === "stopped" && (prior?.request_id !== requestId || prior.status !== "accepted"))
+		throw new Error("shutdown_terminal_ack_requires_acceptance");
+	const worktreePath = teamWorker.worktree_path;
+	const finalHead = worktreePath && (await pathExists(worktreePath)) ? resolveHead(worktreePath) : null;
+	const clean = worktreePath ? !worktreeIsDirty(worktreePath) : true;
+	if (status === "stopped" && config.lifecycle_mode === "managed" && (!finalHead || !clean))
+		throw new Error("managed_shutdown_terminal_ack_requires_clean_final_head");
+	const acknowledgedAt = now();
+	const ack = {
+		worker,
+		request_id: requestId,
+		status,
+		acknowledged_at: acknowledgedAt,
+		...(status === "stopped" ? { final_head: finalHead, clean, terminal_at: acknowledgedAt } : {}),
+	};
+	await writeJsonFile(path.join(workerDir(dir, worker), "shutdown-ack.json"), ack);
+	await writeWorkerLifecycleRecord(dir, teamWorker, status === "stopped" ? "stopped" : "draining", {
+		shutdown_request_id: requestId,
+		shutdown_acknowledged_at: acknowledgedAt,
+		shutdown_ack_status: status,
+		...(status === "stopped"
+			? {
+					stopped_at: acknowledgedAt,
+					stop_reason: "worker_terminal_ack",
+					shutdown_final_head: finalHead ?? undefined,
+					shutdown_clean: clean,
+					shutdown_terminal_at: acknowledgedAt,
+				}
+			: {}),
+	});
+	await appendEvent(dir, {
+		type: status === "stopped" ? "worker_shutdown_terminal" : "worker_shutdown_ack",
+		worker,
+		message:
+			status === "stopped"
+				? `Worker ${worker} reported terminal shutdown`
+				: `Worker ${worker} acknowledged shutdown`,
+	});
+	return ack;
+}
 export async function readGjcShutdownAck(
 	teamName: string,
 	worker: string,
@@ -4696,6 +5174,15 @@ export async function executeGjcTeamApiOperation(
 				parseGjcTeamShutdownMode(input.mode),
 			);
 		}
+		case "write-shutdown-ack":
+			return writeGjcShutdownAck(
+				teamName,
+				worker,
+				String(input.request_id ?? input.requestId ?? ""),
+				String(input.status ?? ""),
+				cwd,
+				env,
+			);
 		case "read-shutdown-ack":
 			return readGjcShutdownAck(teamName, worker, cwd, env);
 		default:

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
@@ -1004,6 +1004,7 @@
           "read-events",
           "await-event",
           "write-shutdown-request",
+          "write-shutdown-ack",
           "read-shutdown-ack",
           "read-monitor-snapshot",
           "write-monitor-snapshot",

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
@@ -458,6 +458,7 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 					"read-events",
 					"await-event",
 					"write-shutdown-request",
+					"write-shutdown-ack",
 					"read-shutdown-ack",
 					"read-monitor-snapshot",
 					"write-monitor-snapshot",

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -46,7 +46,6 @@ import {
 import "../tools/review";
 import type { LocalProtocolOptions } from "../internal-urls";
 import { generateCommitMessage } from "../utils/commit-message-generator";
-import * as git from "../utils/git";
 import { discoverAgents, filterVisibleAgents, getAgent } from "./discovery";
 import { runSubprocess } from "./executor";
 import { adviseForkContextMode } from "./fork-context-advisory";
@@ -61,11 +60,9 @@ import { reconcileSpawnRoi } from "./roi-reconciliation";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
 import { DEFAULT_SPAWN_THRESHOLD, evaluateSpawnGate } from "./spawn-gate";
 import {
-	applyNestedPatches,
 	captureBaseline,
 	captureDeltaPatch,
 	cleanupIsolation,
-	cleanupTaskBranches,
 	commitToBranch,
 	ensureIsolation,
 	getRepoRoot,
@@ -1348,6 +1345,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 
 				const taskStart = Date.now();
 				let isolationHandle: IsolationHandle | undefined;
+				let cleanupIsolationOnExit = true;
+				let recoveryArtifactName: string | undefined;
+				const preserveIsolationForRecovery = (): void => {
+					cleanupIsolationOnExit = false;
+					recoveryArtifactName = isolationHandle?.baseDir ? path.basename(isolationHandle.baseDir) : undefined;
+				};
 				try {
 					if (!repoRoot || !baseline) {
 						throw new Error("Isolated task execution not initialized.");
@@ -1433,18 +1436,33 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								commitMsg,
 							);
 							const producedChanges = Boolean(commitResult?.branchName || commitResult?.nestedPatches.length);
+							const artifactId = validateAllocatedTaskId(task.id);
+							const nestedPatches = await Promise.all(
+								(commitResult?.nestedPatches ?? []).map(async (nested, nestedIndex) => {
+									const repositoryToken =
+										nested.relativePath.replace(/[^a-zA-Z0-9.-]+/g, "-").replace(/^-+|-+$/g, "") || "nested";
+									const artifactPath = path.join(
+										effectiveArtifactsDir,
+										`${artifactId}.nested-${nestedIndex + 1}-${repositoryToken}.patch`,
+									);
+									await Bun.write(artifactPath, nested.patch);
+									return { ...nested, artifactPath };
+								}),
+							);
 							return {
 								...resultWithForkContext,
 								branchName: commitResult?.branchName,
-								nestedPatches: commitResult?.nestedPatches,
+								nestedPatches,
 								producedChanges,
 							};
 						} catch (mergeErr) {
-							// Agent succeeded but branch commit failed — clean up stale branch
-							const branchName = `gjc/task/${task.id}`;
-							await git.branch.tryDelete(repoRoot, branchName);
+							preserveIsolationForRecovery();
 							const msg = mergeErr instanceof Error ? mergeErr.message : String(mergeErr);
-							return { ...resultWithForkContext, error: `Merge failed: ${msg}` };
+							return {
+								...resultWithForkContext,
+								recoveryArtifactName,
+								error: `Merge failed: ${msg}`,
+							};
 						}
 					}
 					if (resultWithForkContext.exitCode === 0) {
@@ -1453,20 +1471,42 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							const artifactId = validateAllocatedTaskId(task.id);
 							const patchPath = path.join(effectiveArtifactsDir, `${artifactId}.patch`);
 							await Bun.write(patchPath, delta.rootPatch);
-							const producedChanges = Boolean(delta.rootPatch.trim() || delta.nestedPatches.length);
+							const nestedPatches = await Promise.all(
+								delta.nestedPatches.map(async (nested, nestedIndex) => {
+									const repositoryToken =
+										nested.relativePath.replace(/[^a-zA-Z0-9.-]+/g, "-").replace(/^-+|-+$/g, "") || "nested";
+									const artifactPath = path.join(
+										effectiveArtifactsDir,
+										`${artifactId}.nested-${nestedIndex + 1}-${repositoryToken}.patch`,
+									);
+									await Bun.write(artifactPath, nested.patch);
+									return { ...nested, artifactPath };
+								}),
+							);
+							const producedChanges = Boolean(delta.rootPatch.trim() || nestedPatches.length);
 							return {
 								...resultWithForkContext,
 								patchPath,
-								nestedPatches: delta.nestedPatches,
+								nestedPatches,
 								producedChanges,
 							};
 						} catch (patchErr) {
+							preserveIsolationForRecovery();
 							const msg = patchErr instanceof Error ? patchErr.message : String(patchErr);
-							return { ...resultWithForkContext, error: `Patch capture failed: ${msg}` };
+							return {
+								...resultWithForkContext,
+								recoveryArtifactName,
+								error: `Patch capture failed: ${msg}`,
+							};
 						}
+					}
+					if (resultWithForkContext.exitCode !== 0 || resultWithForkContext.aborted) {
+						preserveIsolationForRecovery();
+						return { ...resultWithForkContext, recoveryArtifactName };
 					}
 					return resultWithForkContext;
 				} catch (err) {
+					preserveIsolationForRecovery();
 					const message = err instanceof Error ? err.message : String(err);
 					const assignment = task.assignment.trim();
 					return {
@@ -1486,9 +1526,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						modelOverride,
 						forkContext,
 						error: message,
+						recoveryArtifactName,
 					};
 				} finally {
-					if (isolationHandle) {
+					if (isolationHandle && cleanupIsolationOnExit) {
 						await cleanupIsolation(isolationHandle);
 					}
 				}
@@ -1562,7 +1603,6 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			let mergeSummary = "";
 			let changesApplied: boolean | null = null;
 			let hadAnyChanges = false;
-			let mergedBranchesForNestedPatches: Set<string> | null = null;
 			if (isIsolated && repoRoot) {
 				try {
 					if (mergeMode === "branch") {
@@ -1577,7 +1617,6 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							mergeSummary = "\n\nNo changes to apply.";
 						} else {
 							const mergeResult = await mergeTaskBranches(repoRoot, branchEntries);
-							mergedBranchesForNestedPatches = new Set(mergeResult.merged);
 							changesApplied = mergeResult.failed.length === 0;
 							hadAnyChanges = changesApplied && mergeResult.merged.length > 0;
 
@@ -1593,54 +1632,19 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								mergeSummary = `\n\n<system-notification>Branch merge failed. ${mergedPart}${failedPart}${conflictPart}\nUnmerged branches remain for manual resolution.</system-notification>`;
 							}
 						}
-
-						// Clean up merged branches (keep failed ones for manual resolution)
-						const allBranches = branchEntries.map(b => b.branchName);
-						if (changesApplied) {
-							await cleanupTaskBranches(repoRoot, allBranches);
-						}
 					} else {
-						// Patch mode: combine and apply patches
+						// Patch mode preserves artifacts for explicit managed integration.
 						const patchesInOrder = results.map(result => result.patchPath).filter(Boolean) as string[];
-						const missingPatch = results.some(result => !result.patchPath);
-						if (missingPatch) {
-							changesApplied = false;
-							hadAnyChanges = false;
-						} else {
-							const patchStats = await Promise.all(
-								patchesInOrder.map(async patchPath => ({
-									patchPath,
-									size: (await fs.stat(patchPath)).size,
-								})),
-							);
-							const nonEmptyPatches = patchStats.filter(patch => patch.size > 0).map(patch => patch.patchPath);
-							if (nonEmptyPatches.length === 0) {
-								changesApplied = true;
-								hadAnyChanges = false;
-							} else {
-								const patchTexts = await Promise.all(
-									nonEmptyPatches.map(async patchPath => Bun.file(patchPath).text()),
-								);
-								const combinedPatch = patchTexts
-									.map(text => (text.endsWith("\n") ? text : `${text}\n`))
-									.join("");
-								if (!combinedPatch.trim()) {
-									changesApplied = true;
-									hadAnyChanges = false;
-								} else {
-									changesApplied = await git.patch.canApplyText(repoRoot, combinedPatch);
-									if (changesApplied) {
-										try {
-											await git.patch.applyText(repoRoot, combinedPatch);
-											hadAnyChanges = true;
-										} catch {
-											changesApplied = false;
-											hadAnyChanges = false;
-										}
-									}
-								}
-							}
-						}
+						const patchStats = await Promise.all(
+							patchesInOrder.map(async patchPath => ({
+								patchPath,
+								size: (await fs.stat(patchPath)).size,
+							})),
+						);
+						hadAnyChanges =
+							patchStats.some(patch => patch.size > 0) ||
+							results.some(result => (result.nestedPatches?.length ?? 0) > 0);
+						changesApplied = !hadAnyChanges;
 
 						if (changesApplied) {
 							mergeSummary = hadAnyChanges ? "\n\nApplied patches: yes" : "\n\nNo changes to apply.";
@@ -1662,44 +1666,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				}
 			}
 
-			// Apply nested repo patches (separate from parent git)
-			if (isIsolated && repoRoot && (mergeMode === "branch" || changesApplied !== false)) {
-				const allNestedPatches = results
-					.filter(r => {
-						if (!r.nestedPatches || r.nestedPatches.length === 0 || r.exitCode !== 0 || r.aborted) {
-							return false;
-						}
-						if (mergeMode !== "branch") {
-							return true;
-						}
-						if (!r.branchName || !mergedBranchesForNestedPatches) {
-							return false;
-						}
-						return mergedBranchesForNestedPatches.has(r.branchName);
-					})
-					.flatMap(r => r.nestedPatches!);
-				if (allNestedPatches.length > 0) {
-					try {
-						const commitMsg =
-							commitStyle === "ai" && this.session.modelRegistry
-								? async (diff: string) => {
-										return generateCommitMessage(
-											diff,
-											this.session.modelRegistry!,
-											this.session.settings,
-											this.session.getSessionId?.() ?? undefined,
-										);
-									}
-								: undefined;
-						await applyNestedPatches(repoRoot, allNestedPatches, commitMsg);
-					} catch {
-						// Nested patch failures are non-fatal to the parent merge
-						mergeSummary +=
-							"\n\n<system-notification>Some nested repository patches failed to apply.</system-notification>";
-					}
-				}
-			}
-
+			const nestedPatchCount = results.reduce((count, result) => count + (result.nestedPatches?.length ?? 0), 0);
+			if (nestedPatchCount > 0)
+				mergeSummary += `\n\n<system-notification>${nestedPatchCount} nested repository patch artifact${nestedPatchCount === 1 ? "" : "s"} preserved for explicit managed integration.</system-notification>`;
 			// Build final output - match plugin format
 			const cancelledCount = results.filter(r => r.aborted).length;
 			const successCount = results.filter(r => r.exitCode === 0 && !r.error && !r.aborted).length;
@@ -1738,9 +1707,15 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				mergeSummary,
 			});
 
-			// Cleanup temp directory if used
+			// Cleanup only when no patch artifact still requires explicit integration.
+			const hasPendingPatchArtifacts = results.some(
+				result =>
+					(mergeMode === "patch" && result.producedChanges === true) || (result.nestedPatches?.length ?? 0) > 0,
+			);
 			const shouldCleanupTempArtifacts =
-				tempArtifactsDir && (!isIsolated || changesApplied === true || changesApplied === null);
+				tempArtifactsDir &&
+				!hasPendingPatchArtifacts &&
+				(!isIsolated || changesApplied === true || changesApplied === null);
 			if (shouldCleanupTempArtifacts) {
 				await fs.rm(tempArtifactsDir, { recursive: true, force: true });
 			}

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -33,6 +33,8 @@ export interface TaskResultReceipt {
 	cost?: number;
 	usageCostBreakdownComplete?: true;
 	branchName?: string;
+	patchArtifacts?: Array<{ repositoryPath: string; name: string }>;
+	recoveryArtifactName?: string;
 	retryFailure?: { attempt: number; errorSummary: string };
 	errorSummary?: string;
 	abortSummary?: string;
@@ -225,6 +227,15 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 				]),
 			)
 		: undefined;
+	const patchArtifacts = [
+		...(raw.patchPath ? [{ repositoryPath: ".", name: raw.patchPath.split(/[\\/]/).pop() ?? "root.patch" }] : []),
+		...(raw.nestedPatches ?? [])
+			.filter(patch => Boolean(patch.artifactPath))
+			.map(patch => ({
+				repositoryPath: patch.relativePath,
+				name: patch.artifactPath?.split(/[\\/]/).pop() ?? "nested.patch",
+			})),
+	];
 	return {
 		index: raw.index,
 		id: raw.id,
@@ -249,6 +260,8 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 		usageCostBreakdownComplete:
 			raw.usageCostBreakdownComplete === true && hasCompleteUsageCostBreakdown(raw.usage) ? true : undefined,
 		branchName: raw.branchName,
+		recoveryArtifactName: raw.recoveryArtifactName,
+		patchArtifacts: patchArtifacts.length > 0 ? patchArtifacts : undefined,
 		retryFailure: raw.retryFailure
 			? { attempt: raw.retryFailure.attempt, errorSummary: "Retry failure recorded." }
 			: undefined,

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -326,6 +326,7 @@ export interface SingleResult {
 	outputPath?: string;
 	/** Patch path for isolated worktree output */
 	patchPath?: string;
+	recoveryArtifactName?: string;
 	/** Branch name for isolated branch-mode output */
 	branchName?: string;
 	/** Nested repo patches to apply after parent merge */

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -1,9 +1,17 @@
+import { randomUUID } from "node:crypto";
 import type { Dirent } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as natives from "@gajae-code/natives";
 import { getWorktreeDir, hashPath, logger, Snowflake } from "@gajae-code/utils";
+import {
+	acquireLifecycleLock,
+	findLaneRecordByWorktreePath,
+	type LifecycleLock,
+	readLaneRecord,
+	writeLaneRecord,
+} from "../gjc-runtime/git-lifecycle";
 import * as git from "../utils/git";
 
 const { IsoBackendKind } = natives;
@@ -158,6 +166,7 @@ async function captureRepoDeltaPatch(repoDir: string, rb: RepoBaseline): Promise
 export interface NestedRepoPatch {
 	relativePath: string;
 	patch: string;
+	artifactPath?: string;
 }
 
 export interface DeltaPatchResult {
@@ -181,47 +190,6 @@ export async function captureDeltaPatch(isolationDir: string, baseline: Worktree
 	}
 
 	return { rootPatch, nestedPatches };
-}
-
-/**
- * Apply nested repo patches directly to their working directories after parent merge.
- * @param commitMessage Optional async function to generate a commit message from the combined diff.
- *                      If omitted or returns null, falls back to a generic message.
- */
-export async function applyNestedPatches(
-	repoRoot: string,
-	patches: NestedRepoPatch[],
-	commitMessage?: (diff: string) => Promise<string | null>,
-): Promise<void> {
-	// Group patches by target repo to apply all at once and commit
-	const byRepo = new Map<string, NestedRepoPatch[]>();
-	for (const p of patches) {
-		if (!p.patch.trim()) continue;
-		const group = byRepo.get(p.relativePath) ?? [];
-		group.push(p);
-		byRepo.set(p.relativePath, group);
-	}
-
-	for (const [relativePath, repoPatches] of byRepo) {
-		const nestedDir = path.join(repoRoot, relativePath);
-		try {
-			await fs.access(path.join(nestedDir, ".git"));
-		} catch {
-			continue;
-		}
-
-		const combinedDiff = repoPatches.map(p => p.patch).join("\n");
-		for (const { patch } of repoPatches) {
-			await git.patch.applyText(nestedDir, patch);
-		}
-
-		// Commit so nested repo history reflects the task changes
-		if ((await git.status(nestedDir)).trim().length > 0) {
-			const msg = (await commitMessage?.(combinedDiff)) ?? "changes from isolated task(s)";
-			await git.stage.files(nestedDir);
-			await git.commit(nestedDir, msg);
-		}
-	}
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -287,6 +255,8 @@ export function parseIsolationMode(mode: TaskIsolationMode): IsoBackendKind | un
 export interface IsolationHandle {
 	/** Merged view materialised by the backend; pass this to the task. */
 	mergedDir: string;
+	baseDir?: string;
+	ownershipToken?: string;
 	/** Backend the PAL actually used. */
 	backend: IsoBackendKind;
 	/** True when the resolver downgraded from `preferred` to `backend`. */
@@ -312,38 +282,53 @@ export async function ensureIsolation(
 	preferred?: IsoBackendKind,
 ): Promise<IsolationHandle> {
 	const repoRoot = await getRepoRoot(baseCwd);
-	const baseDir = getWorktreeDir(`${id}-${hashPath(repoRoot)}`);
+	const ownershipToken = randomUUID();
+	const baseDir = getWorktreeDir(`${id}-${hashPath(repoRoot)}-${ownershipToken}`);
 	const mergedDir = path.join(baseDir, "merged");
+	const ownerPath = path.join(baseDir, ".gjc-isolation-owner");
+	await fs.mkdir(path.dirname(baseDir), { recursive: true });
+	await fs.mkdir(baseDir);
+	await fs.writeFile(ownerPath, ownershipToken, { encoding: "utf8", flag: "wx" });
 
 	const resolution = natives.isoResolve(preferred ?? null);
 	const candidates = resolution.candidates.length > 0 ? resolution.candidates : [resolution.kind];
 	let fallbackReason = resolution.reason ?? null;
 
 	for (const candidate of candidates) {
-		await fs.rm(baseDir, { recursive: true, force: true });
+		await fs.rm(mergedDir, { recursive: true, force: true });
 		try {
 			await natives.isoStart(candidate, repoRoot, mergedDir);
 			return {
 				mergedDir,
+				baseDir,
+				ownershipToken,
 				backend: candidate,
 				fellBack: candidate !== resolution.kind || resolution.fellBack,
 				fallbackReason,
 			};
 		} catch (err) {
-			await fs.rm(baseDir, { recursive: true, force: true });
+			await fs.rm(mergedDir, { recursive: true, force: true });
 			const message = errorMessage(err);
 			if (!natives.isoIsUnavailableError(message)) {
+				if ((await fs.readFile(ownerPath, "utf8")) === ownershipToken)
+					await fs.rm(baseDir, { recursive: true, force: true });
 				throw err;
 			}
 			fallbackReason ??= message;
 		}
 	}
 
+	if ((await fs.readFile(ownerPath, "utf8")) === ownershipToken)
+		await fs.rm(baseDir, { recursive: true, force: true });
 	throw new Error(fallbackReason ?? "No isolation backend is available.");
 }
 
 /** Tear down a handle returned by {@link ensureIsolation}. */
 export async function cleanupIsolation(handle: IsolationHandle): Promise<void> {
+	const baseDir = handle.baseDir ?? path.dirname(handle.mergedDir);
+	const ownerPath = path.join(baseDir, ".gjc-isolation-owner");
+	if (!handle.ownershipToken || (await fs.readFile(ownerPath, "utf8")) !== handle.ownershipToken)
+		throw new Error("Isolation cleanup ownership proof is missing or mismatched.");
 	try {
 		try {
 			await natives.isoStop(handle.backend, handle.mergedDir);
@@ -355,9 +340,8 @@ export async function cleanupIsolation(handle: IsolationHandle): Promise<void> {
 			});
 		}
 	} finally {
-		// baseDir is the parent of the merged directory
-		const baseDir = path.dirname(handle.mergedDir);
-		await fs.rm(baseDir, { recursive: true, force: true });
+		if ((await fs.readFile(ownerPath, "utf8")) === handle.ownershipToken)
+			await fs.rm(baseDir, { recursive: true, force: true });
 	}
 }
 
@@ -429,6 +413,51 @@ export interface MergeBranchResult {
 	conflict?: string;
 }
 
+const MANAGED_TASK_INTEGRATION_STATES = new Set(["active", "pushed", "pr_open", "verifying", "eligible"]);
+
+function gitText(cwd: string, args: string[]): string | undefined {
+	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	return result.exitCode === 0 ? result.stdout.toString().trim() : undefined;
+}
+
+async function acquireManagedTaskDestination(
+	repoRoot: string,
+): Promise<{ lock: LifecycleLock; commonDir: string; laneId: string } | undefined> {
+	const commonValue = gitText(repoRoot, ["rev-parse", "--git-common-dir"]);
+	if (!commonValue) return undefined;
+	const commonDir = path.resolve(repoRoot, commonValue);
+	try {
+		await fs.access(path.join(commonDir, "gjc", "lifecycle", "v1", "policy.json"));
+	} catch {
+		return undefined;
+	}
+	const lane = await findLaneRecordByWorktreePath(commonDir, repoRoot);
+	if (!lane || !MANAGED_TASK_INTEGRATION_STATES.has(lane.state)) return undefined;
+	const lock = await acquireLifecycleLock(commonDir, lane.laneId);
+	try {
+		const current = await readLaneRecord(commonDir, lane.laneId);
+		const branch = await git.branch.current(repoRoot);
+		const head = await git.head.sha(repoRoot);
+		if (
+			!current ||
+			!MANAGED_TASK_INTEGRATION_STATES.has(current.state) ||
+			current.leaseOwner ||
+			path.resolve(current.worktreePath) !== path.resolve(repoRoot) ||
+			current.branch !== branch ||
+			(current.gitCommonDir && path.resolve(current.gitCommonDir) !== commonDir) ||
+			!head ||
+			(current as typeof current & { headSha?: string }).headSha !== head
+		) {
+			await lock.release();
+			return undefined;
+		}
+		return { lock, commonDir, laneId: lane.laneId };
+	} catch (error) {
+		await lock.release();
+		throw error;
+	}
+}
+
 /**
  * Cherry-pick task branch commits sequentially onto HEAD.
  * Each branch has a single commit that gets replayed cleanly.
@@ -440,15 +469,52 @@ export async function mergeTaskBranches(
 ): Promise<MergeBranchResult> {
 	const merged: string[] = [];
 	const failed: string[] = [];
+	if (branches.length === 0) return { merged, failed };
+	const initialStatus = await git.status(repoRoot);
+	if (initialStatus.trim()) {
+		return {
+			merged,
+			failed: branches.map(branch => branch.branchName),
+			conflict: "Destination working tree is dirty; refusing to cherry-pick task branches.",
+		};
+	}
 
-	// Stash dirty working tree so cherry-pick can operate on a clean HEAD.
-	// Without this, cherry-pick refuses to run when uncommitted changes exist.
-	const didStash = await git.stash.push(repoRoot, "gjc-task-merge");
-
-	let conflictResult: MergeBranchResult | undefined;
+	const destination = await acquireManagedTaskDestination(repoRoot);
+	if (!destination) {
+		return {
+			merged,
+			failed: branches.map(branch => branch.branchName),
+			conflict: "Managed feature lane ownership is required; refusing to mutate the destination checkout.",
+		};
+	}
 
 	try {
+		let expectedHead = await git.head.sha(repoRoot);
+		if (!expectedHead) {
+			return {
+				merged,
+				failed: branches.map(branch => branch.branchName),
+				conflict: "Managed destination HEAD is unavailable; refusing to cherry-pick task branches.",
+			};
+		}
+		const status = await git.status(repoRoot);
+		if (status.trim()) {
+			return {
+				merged,
+				failed: branches.map(branch => branch.branchName),
+				conflict: "Destination working tree is dirty; refusing to cherry-pick task branches.",
+			};
+		}
+
 		for (const { branchName } of branches) {
+			if ((await git.head.sha(repoRoot)) !== expectedHead || (await git.status(repoRoot)).trim()) {
+				failed.push(branchName);
+				return {
+					merged,
+					failed: [...failed, ...branches.slice(merged.length + failed.length).map(branch => branch.branchName)],
+					conflict: "Managed destination changed during integration; refusing to continue.",
+				};
+			}
 			try {
 				await git.cherryPick(repoRoot, branchName);
 			} catch (err) {
@@ -464,43 +530,28 @@ export async function mergeTaskBranches(
 							? err.message
 							: String(err);
 				failed.push(branchName);
-				conflictResult = {
+				return {
 					merged,
-					failed: [...failed, ...branches.slice(merged.length + failed.length).map(b => b.branchName)],
+					failed: [...failed, ...branches.slice(merged.length + failed.length).map(branch => branch.branchName)],
 					conflict: `${branchName}: ${stderr}`,
 				};
-				break;
 			}
 
+			const nextHead = await git.head.sha(repoRoot);
+			if (!nextHead) throw new Error("Managed destination HEAD disappeared after task integration.");
+			expectedHead = nextHead;
 			merged.push(branchName);
 		}
+
+		const current = await readLaneRecord(destination.commonDir, destination.laneId);
+		if (!current) throw new Error("Managed destination lane disappeared after task integration.");
+		await writeLaneRecord(destination.commonDir, {
+			...current,
+			headSha: expectedHead,
+			updatedAt: new Date().toISOString(),
+		} as typeof current & { headSha: string });
+		return { merged, failed };
 	} finally {
-		if (didStash) {
-			try {
-				await git.stash.pop(repoRoot, { index: true });
-			} catch {
-				// Stash-pop conflicts mean the replayed changes clash with the user's
-				// uncommitted edits. Treat this as a merge failure so the caller preserves
-				// recovery branches instead of reporting success and deleting them.
-				logger.warn("Failed to restore stashed changes after task merge; stash entry preserved");
-				if (!conflictResult) {
-					conflictResult = {
-						merged,
-						failed: merged,
-						conflict:
-							"stash pop: cherry-picked changes conflict with uncommitted edits. Run `git stash pop` and resolve manually.",
-					};
-				}
-			}
-		}
-	}
-
-	return conflictResult ?? { merged, failed };
-}
-
-/** Clean up temporary task branches. */
-export async function cleanupTaskBranches(repoRoot: string, branches: string[]): Promise<void> {
-	for (const branch of branches) {
-		await git.branch.tryDelete(repoRoot, branch);
+		await destination.lock.release();
 	}
 }

--- a/packages/coding-agent/test/commands/lane.test.ts
+++ b/packages/coding-agent/test/commands/lane.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import Lane from "@gajae-code/coding-agent/commands/lane";
+
+describe("lane command", () => {
+	it("advertises the explicit lifecycle actions", () => {
+		expect(Lane.args.action.options).toEqual(["configure", "start", "status", "pr", "reconcile", "gc"]);
+		expect(Lane.flags.mode.options).toEqual(["pr-only", "local-controlled-merge"]);
+		expect(Lane.flags.json.description).toContain("machine-readable");
+		expect(Lane.flags.gates.description).toContain("check@app");
+	});
+	it("is registered for root CLI dispatch", async () => {
+		const cliSource = await Bun.file(path.resolve(import.meta.dir, "../../src/cli.ts")).text();
+		expect(cliSource).toContain('{ name: "lane", load: () => import("./commands/lane").then(m => m.default) }');
+	});
+});

--- a/packages/coding-agent/test/git-lifecycle-controller.test.ts
+++ b/packages/coding-agent/test/git-lifecycle-controller.test.ts
@@ -1,0 +1,393 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { writeLaneRecord } from "@gajae-code/coding-agent/gjc-runtime/git-lifecycle";
+import {
+	type CommandRunner,
+	type GithubAdapter,
+	GitLifecycleController,
+	type ManagedLaneRecord,
+} from "@gajae-code/coding-agent/gjc-runtime/git-lifecycle-controller";
+
+const directories: string[] = [];
+afterEach(async () => {
+	await Promise.all(directories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })));
+});
+async function disposable(): Promise<{ cwd: string; runner: CommandRunner }> {
+	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-lane-"));
+	directories.push(cwd);
+	await fs.mkdir(path.join(cwd, ".git"));
+	return {
+		cwd,
+		runner: async argv =>
+			argv.slice(1).join(" ") === "rev-parse --git-common-dir"
+				? { exitCode: 0, stdout: ".git\n", stderr: "" }
+				: { exitCode: 0, stdout: "", stderr: "" },
+	};
+}
+
+function git(cwd: string, args: string[]): string {
+	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	if (result.exitCode !== 0) throw new Error(result.stderr.toString());
+	return result.stdout.toString().trim();
+}
+
+describe("git lifecycle controller", () => {
+	it("persists only supported policy modes with a default retention in the disposable common git dir", async () => {
+		const { cwd, runner } = await disposable();
+		const controller = new GitLifecycleController({ cwd, runner });
+		const policy = await controller.configure({
+			mode: "pr-only",
+			remote: "origin",
+			base: "main",
+			worktreeRoot: "D:/worktrees",
+			allowedAutoMergeTypes: ["fix"],
+			requiredGates: [],
+			forbiddenPathPatterns: [],
+		});
+		expect(policy.retentionHours).toBe(24);
+		expect(await fs.stat(path.join(cwd, ".git", "gjc", "lifecycle", "v1", "policy.json"))).toBeDefined();
+	});
+	it("rejects a worktree root nested within the repository checkout", async () => {
+		const { cwd, runner: baseRunner } = await disposable();
+		const runner: CommandRunner = async argv => {
+			const command = argv.slice(1).join(" ");
+			if (command === "rev-parse --show-toplevel") return { exitCode: 0, stdout: `${cwd}\n`, stderr: "" };
+			if (command === "worktree list --porcelain")
+				return { exitCode: 0, stdout: `worktree ${cwd}\nHEAD head\nbranch refs/heads/main\n`, stderr: "" };
+			return baseRunner(argv, cwd);
+		};
+		const controller = new GitLifecycleController({ cwd, runner });
+		await expect(
+			controller.configure({
+				mode: "pr-only",
+				remote: "origin",
+				base: "main",
+				worktreeRoot: path.join(cwd, "nested"),
+				allowedAutoMergeTypes: [],
+				requiredGates: [],
+				forbiddenPathPatterns: [],
+			}),
+		).rejects.toThrow("external to every repository worktree");
+	});
+	it("rejects policy modes outside the two supported choices", async () => {
+		const { cwd, runner } = await disposable();
+		const controller = new GitLifecycleController({ cwd, runner });
+		expect(
+			controller.configure({
+				mode: "auto" as "pr-only",
+				remote: "origin",
+				base: "main",
+				worktreeRoot: "D:/worktrees",
+				allowedAutoMergeTypes: [],
+				requiredGates: [],
+				forbiddenPathPatterns: [],
+			}),
+		).rejects.toThrow("policy mode");
+	});
+	it("rejects empty required checks for local controlled merge", async () => {
+		const { cwd, runner } = await disposable();
+		const controller = new GitLifecycleController({ cwd, runner });
+		expect(
+			controller.configure({
+				mode: "local-controlled-merge",
+				remote: "origin",
+				base: "main",
+				worktreeRoot: "D:/worktrees",
+				allowedAutoMergeTypes: ["fix"],
+				requiredGates: [],
+				forbiddenPathPatterns: [],
+			}),
+		).rejects.toThrow("requires at least one required gate");
+	});
+	it("keeps a blocked planned record when worktree creation fails", async () => {
+		const { cwd } = await disposable();
+		const runner: CommandRunner = async argv => {
+			const command = argv.slice(1).join(" ");
+			const stdout: Record<string, string> = {
+				"rev-parse --git-common-dir": ".git\n",
+				"rev-parse origin/main": "base\n",
+				"branch --format=%(refname:short)": "",
+				"worktree list --porcelain": "",
+				"rev-parse --show-toplevel": cwd,
+				"config --get remote.origin.url": "origin-url\n",
+			};
+			if (command.startsWith("worktree add ")) return { exitCode: 1, stdout: "", stderr: "simulated add failure" };
+			return { exitCode: 0, stdout: stdout[command] ?? "", stderr: "" };
+		};
+		const controller = new GitLifecycleController({ cwd, runner });
+		await controller.configure({
+			mode: "pr-only",
+			remote: "origin",
+			base: "main",
+			worktreeRoot: path.dirname(cwd),
+			allowedAutoMergeTypes: [],
+			requiredGates: [],
+			forbiddenPathPatterns: [],
+		});
+		expect(
+			controller.start({
+				laneId: "lane-1",
+				type: "fix",
+				scope: "scope",
+				purpose: "purpose",
+				agent: "gjc",
+				sessionId: "session",
+			}),
+		).rejects.toThrow("simulated add failure");
+		expect(await controller.status("lane-1")).toMatchObject({
+			record: { state: "blocked", branch: "fix/scope-purpose--gjc-lane-1" },
+		});
+	});
+	it("creates and pushes an isolated typed lane without mutating the source checkout", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-lane-e2e-"));
+		directories.push(root);
+		const remote = path.join(root, "origin.git");
+		const source = path.join(root, "source");
+		await fs.mkdir(source);
+		git(root, ["init", "--bare", remote]);
+		git(source, ["init", "-b", "main"]);
+		git(source, ["config", "user.email", "gjc@example.test"]);
+		git(source, ["config", "user.name", "GJC Test"]);
+		await fs.writeFile(path.join(source, "README.md"), "# test\n");
+		git(source, ["add", "README.md"]);
+		git(source, ["commit", "-m", "initial"]);
+		git(source, ["remote", "add", "origin", remote]);
+		git(source, ["push", "-u", "origin", "main"]);
+
+		let lane: ManagedLaneRecord | undefined;
+		const github: GithubAdapter = {
+			findPullRequest: async () => undefined,
+			createPullRequest: async (head, base) => {
+				if (!lane) throw new Error("lane missing");
+				const headRefOid = git(lane.worktreePath, ["rev-parse", "HEAD"]);
+				return {
+					number: 1,
+					state: "OPEN",
+					isDraft: false,
+					isCrossRepository: false,
+					headRefName: head,
+					headRefOid,
+					baseRefName: base,
+					baseRefOid: git(source, ["rev-parse", "origin/main"]),
+					mergeable: "MERGEABLE",
+				};
+			},
+			getPullRequest: async () => undefined,
+			squashMergePullRequest: async (_number, input) => ({
+				method: "SQUASH",
+				matchHeadCommit: input.matchHeadCommit,
+				expectedBaseCommit: input.expectedBaseCommit,
+			}),
+		};
+		const controller = new GitLifecycleController({ cwd: source, github });
+		await controller.configure({
+			mode: "pr-only",
+			remote: "origin",
+			base: "main",
+			worktreeRoot: path.join(root, "worktrees"),
+			allowedAutoMergeTypes: [],
+			requiredGates: [],
+			forbiddenPathPatterns: [],
+		});
+		lane = await controller.start({
+			laneId: "e2e-1",
+			type: "dev",
+			scope: "git",
+			purpose: "isolation",
+			agent: "gjc",
+			sessionId: "session",
+		});
+		await fs.writeFile(path.join(lane.worktreePath, "feature.txt"), "feature\n");
+		git(lane.worktreePath, ["add", "feature.txt"]);
+		git(lane.worktreePath, ["commit", "-m", "feat: isolated"]);
+		const opened = await controller.pr(lane.laneId);
+
+		expect(opened).toMatchObject({ state: "pr_open", branch: "dev/git-isolation--gjc-e2e-1", prNumber: 1 });
+		if (!opened.headSha) throw new Error("opened lane is missing its head SHA");
+		expect(git(source, ["status", "--porcelain"])).toBe("");
+		expect(git(remote, ["rev-parse", "refs/heads/dev/git-isolation--gjc-e2e-1"])).toBe(opened.headSha);
+	});
+	it("cleans a squash-merged lane through exact local and remote ref deletion", async () => {
+		const { cwd } = await disposable();
+		const worktree = path.join(cwd, "lane");
+		await fs.mkdir(worktree);
+		const worktreeGitDir = path.join(cwd, ".git", "worktrees", "lane");
+		await fs.mkdir(worktreeGitDir, { recursive: true });
+		await fs.writeFile(path.join(worktreeGitDir, "gjc-lane-owner"), "owner-token");
+		const commands: string[] = [];
+		let remotePresent = true;
+		const runner: CommandRunner = async (argv, commandCwd) => {
+			const command = argv.slice(1).join(" ");
+			commands.push(command);
+			if (command === "rev-parse --git-common-dir")
+				return { exitCode: 0, stdout: commandCwd === cwd ? ".git\n" : `${path.join(cwd, ".git")}\n`, stderr: "" };
+			if (command === "rev-parse --show-toplevel") return { exitCode: 0, stdout: `${worktree}\n`, stderr: "" };
+			if (command === "rev-parse --git-dir") return { exitCode: 0, stdout: `${worktreeGitDir}\n`, stderr: "" };
+			if (command === "branch --show-current")
+				return { exitCode: 0, stdout: "fix/scope-purpose--gjc-lane-1\n", stderr: "" };
+			if (command === "status --porcelain --untracked-files=all") return { exitCode: 0, stdout: "", stderr: "" };
+			if (
+				command === "rev-parse HEAD" ||
+				command === "rev-parse fix/scope-purpose--gjc-lane-1" ||
+				command === "rev-parse --verify refs/heads/fix/scope-purpose--gjc-lane-1" ||
+				command === "rev-parse refs/heads/fix/scope-purpose--gjc-lane-1"
+			)
+				return { exitCode: 0, stdout: "head\n", stderr: "" };
+			if (command === "rev-parse origin/main") return { exitCode: 0, stdout: "target\n", stderr: "" };
+			if (command.startsWith("ls-remote "))
+				return {
+					exitCode: 0,
+					stdout: remotePresent ? "head\trefs/heads/fix/scope-purpose--gjc-lane-1\n" : "",
+					stderr: "",
+				};
+			if (command.startsWith("push --force-with-lease=refs/heads/")) {
+				remotePresent = false;
+				return { exitCode: 0, stdout: "", stderr: "" };
+			}
+			return { exitCode: 0, stdout: "", stderr: "" };
+		};
+		const github: GithubAdapter = {
+			findPullRequest: async () => undefined,
+			createPullRequest: async () => {
+				throw new Error("unused");
+			},
+			squashMergePullRequest: async (_number, input) => ({
+				method: "SQUASH",
+				matchHeadCommit: input.matchHeadCommit,
+				expectedBaseCommit: input.expectedBaseCommit,
+			}),
+			getPullRequest: async () => ({
+				number: 1,
+				state: "MERGED",
+				isDraft: false,
+				isCrossRepository: false,
+				headRefName: "fix/scope-purpose--gjc-lane-1",
+				headRefOid: "head",
+				baseRefName: "main",
+				baseRefOid: "base",
+				mergeable: "MERGEABLE",
+				mergedAt: "2020-01-01T00:00:00.000Z",
+				mergeCommit: "squash",
+			}),
+		};
+		const controller = new GitLifecycleController({
+			cwd,
+			runner,
+			github,
+			now: () => new Date("2026-01-01T00:00:00.000Z"),
+		});
+		await controller.configure({
+			mode: "pr-only",
+			remote: "origin",
+			base: "main",
+			worktreeRoot: path.dirname(cwd),
+			allowedAutoMergeTypes: [],
+			requiredGates: [],
+			forbiddenPathPatterns: [],
+			retentionHours: 0,
+		});
+		const record: ManagedLaneRecord = {
+			version: 1,
+			laneId: "lane-1",
+			state: "retention",
+			createdAt: "2020-01-01T00:00:00.000Z",
+			updatedAt: "2020-01-01T00:00:00.000Z",
+			repositoryId: "repo",
+			realm: "windows",
+			branch: "fix/scope-purpose--gjc-lane-1",
+			worktreeToken: "FIX)scope-purpose__gjc-lane-1",
+			worktreePath: worktree,
+			agent: "gjc",
+			sessionId: "session",
+			remote: "origin",
+			base: "main",
+			headSha: "head",
+			prNumber: 1,
+			mergeCommit: "squash",
+			mergedHeadSha: "head",
+			mergedBaseSha: "base",
+			gitCommonDir: path.join(cwd, ".git"),
+			worktreeGitDir,
+			worktreeOwnershipToken: "owner-token",
+		};
+		await writeLaneRecord(path.join(cwd, ".git"), record);
+		expect(await controller.gc("lane-1")).toMatchObject({ state: "cleaned", remoteBranchDeleted: true });
+		expect(commands).toContain("update-ref -d refs/heads/fix/scope-purpose--gjc-lane-1 head");
+		expect(commands).toContain(
+			"push --force-with-lease=refs/heads/fix/scope-purpose--gjc-lane-1:head origin :refs/heads/fix/scope-purpose--gjc-lane-1",
+		);
+	});
+	it("rejects PR mutation while a lane lease is active", async () => {
+		const { cwd, runner } = await disposable();
+		const controller = new GitLifecycleController({
+			cwd,
+			runner,
+			now: () => new Date("2026-01-01T00:00:00.000Z"),
+		});
+		await controller.configure({
+			mode: "pr-only",
+			remote: "origin",
+			base: "main",
+			worktreeRoot: "D:/worktrees",
+			allowedAutoMergeTypes: [],
+			requiredGates: [],
+			forbiddenPathPatterns: [],
+		});
+		const leasedRecord: ManagedLaneRecord = {
+			version: 1,
+			laneId: "leased-lane",
+			state: "active",
+			createdAt: "2025-01-01T00:00:00.000Z",
+			updatedAt: "2025-01-01T00:00:00.000Z",
+			repositoryId: "repo",
+			realm: "windows",
+			branch: "dev/scope-purpose--gjc-leased-lane",
+			worktreeToken: "DEV)scope-purpose__gjc-leased-lane",
+			worktreePath: path.join(cwd, "lane"),
+			agent: "gjc",
+			sessionId: "session",
+			remote: "origin",
+			base: "main",
+			leaseOwner: "team:active",
+			leaseExpiresAt: "2026-01-01T00:01:00.000Z",
+			leaseUpdatedAt: "2025-12-31T23:59:00.000Z",
+		};
+		await writeLaneRecord(path.join(cwd, ".git"), leasedRecord);
+
+		await expect(controller.pr("leased-lane")).rejects.toThrow("active lease");
+	});
+	it("rejects policy remote or base drift for an existing lane", async () => {
+		const { cwd, runner } = await disposable();
+		const controller = new GitLifecycleController({ cwd, runner });
+		await controller.configure({
+			mode: "pr-only",
+			remote: "origin",
+			base: "main",
+			worktreeRoot: "D:/worktrees",
+			allowedAutoMergeTypes: [],
+			requiredGates: [],
+			forbiddenPathPatterns: [],
+		});
+		const driftedRecord: ManagedLaneRecord = {
+			version: 1,
+			laneId: "bound-lane",
+			state: "active",
+			createdAt: "2025-01-01T00:00:00.000Z",
+			updatedAt: "2025-01-01T00:00:00.000Z",
+			repositoryId: "repo",
+			realm: "windows",
+			branch: "dev/scope-purpose--gjc-bound-lane",
+			worktreeToken: "DEV)scope-purpose__gjc-bound-lane",
+			worktreePath: path.join(cwd, "lane"),
+			agent: "gjc",
+			sessionId: "session",
+			remote: "upstream",
+			base: "dev",
+		};
+		await writeLaneRecord(path.join(cwd, ".git"), driftedRecord);
+
+		await expect(controller.pr("bound-lane")).rejects.toThrow("immutable lane binding");
+	});
+});

--- a/packages/coding-agent/test/git-lifecycle.test.ts
+++ b/packages/coding-agent/test/git-lifecycle.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	acquireLifecycleLock,
+	appendLifecycleEvent,
+	createLaneName,
+	isCleanupEligible,
+	type LaneRecord,
+	ownershipMatches,
+	parseNormalizedPurpose,
+	readLaneRecord,
+	writeLaneRecord,
+} from "@gajae-code/coding-agent/gjc-runtime/git-lifecycle";
+
+const tempDirs: string[] = [];
+
+async function makeGitCommonDir(): Promise<string> {
+	const directory = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-git-lifecycle-"));
+	tempDirs.push(directory);
+	return path.join(directory, ".git");
+}
+
+function record(overrides: Partial<LaneRecord> = {}): LaneRecord {
+	return {
+		version: 1,
+		laneId: "dev-runtime-a1",
+		state: "gc_eligible",
+		repositoryId: "repo-123",
+		realm: "windows",
+		branch: "dev/runtime-api--gjc-a1",
+		worktreeToken: "DEV)runtime-api__gjc-a1",
+		worktreePath: "D:\\worktrees\\repo\\DEV)runtime-api__gjc-a1",
+		agent: "gjc",
+		sessionId: "session-123",
+		createdAt: "2026-07-18T00:00:00.000Z",
+		updatedAt: "2026-07-18T00:00:00.000Z",
+		cleanupEvidence: {
+			mergeCommit: "abc123",
+			gcApprovedAt: "2026-07-18T00:01:00.000Z",
+			retentionApprovedAt: "2026-07-18T00:02:00.000Z",
+			explicitCleanupRequestedAt: "2026-07-18T00:03:00.000Z",
+		},
+		...overrides,
+	};
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })));
+});
+
+describe("git lifecycle names", () => {
+	it("normalizes names and creates branch and visual worktree tokens", () => {
+		const name = createLaneName({
+			type: "dev",
+			scope: "Git Runtime",
+			purpose: "lane_foundation",
+			agent: "GJC",
+			id: "A1",
+		});
+		expect(name).toEqual({
+			branch: "dev/git-runtime-lane-foundation--gjc-a1",
+			worktreeToken: "DEV)git-runtime-lane-foundation__gjc-a1",
+			scope: "git-runtime",
+			purpose: "lane-foundation",
+		});
+		expect(parseNormalizedPurpose("Purpose Name")).toBe("purpose-name");
+	});
+
+	it("rejects unsafe, reserved, overlong, and case-colliding names", () => {
+		expect(() => createLaneName({ type: "dev", scope: "con", purpose: "api", agent: "gjc", id: "a1" })).toThrow(
+			"reserved",
+		);
+		expect(() =>
+			createLaneName({ type: "dev", scope: "git", purpose: "api/escape", agent: "gjc", id: "a1" }),
+		).toThrow("lowercase");
+		expect(() =>
+			createLaneName({
+				type: "dev",
+				scope: "git",
+				purpose: "api",
+				agent: "gjc",
+				id: "a1",
+				existingBranches: ["DEV/GIT-API--GJC-A1"],
+			}),
+		).toThrow("case-insensitively");
+		expect(() =>
+			createLaneName({
+				type: "dev",
+				scope: "git",
+				purpose: "api",
+				agent: "gjc",
+				id: "a1",
+				existingWorktreeTokens: ["dev)GIT-API__GJC-A1"],
+			}),
+		).toThrow("case-insensitively");
+		expect(() =>
+			createLaneName({ type: "dev", scope: "x".repeat(100), purpose: "y".repeat(100), agent: "gjc", id: "a1" }),
+		).toThrow("length");
+	});
+});
+
+describe("git lifecycle registry", () => {
+	it("atomically persists state records and appends auditable events", async () => {
+		const gitCommonDir = await makeGitCommonDir();
+		const planned = record({ state: "planned" });
+		await writeLaneRecord(gitCommonDir, planned);
+		await writeLaneRecord(gitCommonDir, { ...planned, state: "active", updatedAt: "2026-07-18T00:04:00.000Z" });
+		expect(await readLaneRecord(gitCommonDir, planned.laneId)).toMatchObject({ state: "active", version: 1 });
+		await appendLifecycleEvent(gitCommonDir, {
+			version: 1,
+			laneId: planned.laneId,
+			at: planned.updatedAt,
+			type: "activated",
+			state: "active",
+		});
+		const root = path.join(gitCommonDir, "gjc", "lifecycle", "v1");
+		expect(await fs.readFile(path.join(root, "events.jsonl"), "utf8")).toContain('"type":"activated"');
+		expect((await fs.readdir(path.join(root, "records"))).every(entry => !entry.endsWith(".tmp"))).toBe(true);
+	});
+	it("fails closed when a record filename and lane ID disagree", async () => {
+		const gitCommonDir = await makeGitCommonDir();
+		const mismatched = record({ laneId: "other-lane" });
+		const records = path.join(gitCommonDir, "gjc", "lifecycle", "v1", "records");
+		await fs.mkdir(records, { recursive: true });
+		await fs.writeFile(path.join(records, "dev-runtime-a1.json"), JSON.stringify(mismatched));
+		await expect(readLaneRecord(gitCommonDir, "dev-runtime-a1")).rejects.toThrow("identity");
+	});
+
+	it("uses exclusive create-file locks", async () => {
+		const gitCommonDir = await makeGitCommonDir();
+		const lock = await acquireLifecycleLock(gitCommonDir, "dev-runtime-a1");
+		await expect(acquireLifecycleLock(gitCommonDir, "dev-runtime-a1")).rejects.toThrow("already held");
+		await lock.release();
+		await (await acquireLifecycleLock(gitCommonDir, "dev-runtime-a1")).release();
+	});
+});
+
+describe("managed ownership and cleanup eligibility", () => {
+	it("requires exact registry ownership, including the Windows realm", () => {
+		const managed = record();
+		expect(ownershipMatches(managed, managed)).toBe(true);
+		expect(ownershipMatches(managed, { ...managed, realm: "wsl" })).toBe(false);
+		expect(ownershipMatches(managed, { ...managed, worktreePath: "D:\\worktrees\\repo\\same-name" })).toBe(false);
+	});
+
+	it("fails closed without every cleanup evidence field and succeeds only with explicit evidence", () => {
+		const managed = record();
+		expect(isCleanupEligible(managed, { ...managed, realm: "wsl" })).toBe(false);
+		expect(isCleanupEligible(record({ cleanupEvidence: { mergeCommit: "abc123" } }), managed)).toBe(false);
+		expect(isCleanupEligible(record({ state: "retention" }), managed)).toBe(false);
+		expect(isCleanupEligible(managed, managed)).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
@@ -95,7 +95,7 @@ describe("default launch worktrees", () => {
 		});
 	});
 
-	it("creates and reuses a detached launch worktree beside the source repo", async () => {
+	it("creates a detached launch worktree and refuses unleased reuse", async () => {
 		const repo = await createRepo("gjc-launch-worktree-");
 		await fs.mkdir(path.join(repo, "node_modules"));
 
@@ -110,9 +110,9 @@ describe("default launch worktrees", () => {
 		expect(await Bun.file(path.join(expectedPath, ".git")).exists()).toBe(true);
 		expect((await fs.lstat(path.join(expectedPath, "node_modules"))).isSymbolicLink()).toBe(true);
 
-		const second = prepareLaunchWorktree(repo, ["--worktree", "--slow", "opus"]);
-		expect(await fs.realpath(second.cwd)).toBe(await fs.realpath(expectedPath));
-		expect(second.worktree.enabled && second.worktree.reused).toBe(true);
+		expect(() => prepareLaunchWorktree(repo, ["--worktree", "--slow", "opus"])).toThrow(
+			`worktree_ownership_required:${expectedPath}`,
+		);
 	});
 
 	it("creates launch worktrees beside the canonical source repo when launched from an existing worktree", async () => {
@@ -145,7 +145,7 @@ describe("default launch worktrees", () => {
 		);
 	});
 
-	it("updates a clean reused detached launch worktree when source HEAD advances", async () => {
+	it("refuses to advance an existing clean detached launch worktree without ownership", async () => {
 		const repo = await createRepo("gjc-launch-advance-worktree-");
 		const first = prepareLaunchWorktree(repo, ["--worktree"]);
 		expect(first.worktree.enabled && first.worktree.created).toBe(true);
@@ -155,9 +155,8 @@ describe("default launch worktrees", () => {
 		run("git", ["commit", "-m", "next"], repo);
 		const nextHead = run("git", ["rev-parse", "HEAD"], repo);
 
-		const second = prepareLaunchWorktree(repo, ["--worktree"]);
-		expect(second.worktree.enabled && second.worktree.reused).toBe(true);
-		expect(run("git", ["rev-parse", "HEAD"], second.cwd)).toBe(nextHead);
+		expect(() => prepareLaunchWorktree(repo, ["--worktree"])).toThrow(`worktree_ownership_required:${first.cwd}`);
+		expect(run("git", ["rev-parse", "HEAD"], first.cwd)).not.toBe(nextHead);
 	});
 
 	it("rejects dirty detached launch worktrees when source HEAD advances", async () => {
@@ -204,6 +203,30 @@ describe("default launch worktrees", () => {
 		expect(ensured.enabled && (await fs.realpath(ensured.worktreePath))).toBe(await fs.realpath(expectedPath));
 		expect(ensured.enabled && ensured.branchName).toBe("feature/demo");
 		expect(run("git", ["branch", "--show-current"], expectedPath)).toBe("feature/demo");
+	});
+	it("rejects reuse of a dirty named launch worktree", async () => {
+		const repo = await createRepo("gjc-launch-dirty-named-worktree-");
+		const first = prepareLaunchWorktree(repo, ["--worktree", "feature/dirty"]);
+		expect(first.worktree.enabled && first.worktree.created).toBe(true);
+		await Bun.write(path.join(first.cwd, "dirty.txt"), "dirty\n");
+
+		expect(() => prepareLaunchWorktree(repo, ["--worktree", "feature/dirty"])).toThrow(/worktree_dirty:/);
+		expect(await Bun.file(path.join(first.cwd, "dirty.txt")).text()).toBe("dirty\n");
+		expect(run("git", ["status", "--porcelain"], first.cwd)).toBe("?? dirty.txt");
+	});
+
+	it("rejects an unmanaged existing branch without changing the user checkout", async () => {
+		const repo = await createRepo("gjc-launch-unmanaged-branch-");
+		const branchName = "feature/unmanaged";
+		run("git", ["branch", branchName], repo);
+		const statusBefore = run("git", ["status", "--porcelain"], repo);
+		const readmeBefore = await Bun.file(path.join(repo, "README.md")).text();
+		const planned = planLaunchWorktree(repo, { enabled: true, detached: false, name: branchName });
+
+		expect(() => ensureLaunchWorktree(planned)).toThrow(`branch_unmanaged:${branchName}`);
+		expect(run("git", ["status", "--porcelain"], repo)).toBe(statusBefore);
+		expect(await Bun.file(path.join(repo, "README.md")).text()).toBe(readmeBefore);
+		expect(await Bun.file(planned.enabled ? path.join(planned.worktreePath, ".git") : "").exists()).toBe(false);
 	});
 
 	it("keeps launch worktree slugs collision-resistant for similar branch names", async () => {

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -161,18 +161,6 @@ async function commitFile(cwd: string, relativePath: string, content: string, me
 	runGit(cwd, ["commit", "-m", message]);
 	return runGit(cwd, ["rev-parse", "HEAD"]);
 }
-
-async function writeWorkerStatus(
-	stateDir: string,
-	worker: string,
-	state: "idle" | "working" | "blocked" | "done" | "failed" | "draining" | "unknown",
-): Promise<void> {
-	await Bun.write(
-		path.join(stateDir, "workers", worker, "status.json"),
-		`${JSON.stringify({ state, updated_at: new Date().toISOString() }, null, 2)}\n`,
-	);
-}
-
 async function readEvents(stateDir: string): Promise<string> {
 	return Bun.file(path.join(stateDir, "events.jsonl")).text();
 }
@@ -2569,7 +2557,7 @@ describe("native gjc team runtime", () => {
 		expect(events).toContain("auto_action_taken");
 	});
 
-	it("monitor integrates dirty detached worker worktrees and records GJC-scoped hygiene artifacts", async () => {
+	it("reports unmanaged worker integration without mutating either checkout", async () => {
 		cleanupRoot = await createGitRepo();
 		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
 		const snapshot = await startGjcTeam({
@@ -2596,19 +2584,16 @@ describe("native gjc team runtime", () => {
 			GJC_TEAM_TMUX_COMMAND: fakeTmux,
 		});
 
-		expect(await Bun.file(path.join(cleanupRoot, "worker-output.txt")).text()).toBe("from worker\n");
+		expect(await Bun.file(path.join(cleanupRoot, "worker-output.txt")).exists()).toBe(false);
+		expect(await Bun.file(path.join(worker.worktree_path, "worker-output.txt")).text()).toBe("from worker\n");
 		const workerState = monitored.integration_by_worker?.["worker-1"];
-		expect(workerState?.status).toBe("idle");
-		expect(workerState?.last_integrated_head).toBeTruthy();
+		expect(workerState?.status).toBe("integration_required");
+		expect(workerState?.last_integrated_head).toBeUndefined();
 		const events = await readEvents(snapshot.state_dir);
-		expect(events).toContain("worker_auto_commit");
-		expect(events).toContain("worker_merge_applied");
-		const leaderMailbox = await readMailbox(snapshot.state_dir, "leader-fixed");
-		expect(leaderMailbox).toContain("INTEGRATED: merged worker-1");
-		const ledger = await Bun.file(teamReportPath(cleanupRoot, "integrate-dirty-team.ledger.json")).json();
-		expect(JSON.stringify(ledger)).toContain("auto_checkpoint");
-		expect(JSON.stringify(ledger)).toContain("integration_merge");
-		expect(await Bun.file(path.join(cleanupRoot, ".omx", "reports", "team-commit-hygiene")).exists()).toBe(false);
+		expect(events).toContain("worker_integration_required");
+		expect(events).not.toContain("worker_auto_commit");
+		expect(events).not.toContain("worker_merge_applied");
+		expect(runGit(worker.worktree_path, ["status", "--porcelain"])).toContain("worker-output.txt");
 	});
 
 	it("checkpoint classification excludes GJC runtime paths from worker auto-commits", async () => {
@@ -2656,7 +2641,8 @@ describe("native gjc team runtime", () => {
 			GJC_TEAM_TMUX_COMMAND: fakeTmux,
 		});
 
-		expect(await Bun.file(path.join(cleanupRoot, "semantic.txt")).text()).toBe("semantic\n");
+		expect(await Bun.file(path.join(cleanupRoot, "semantic.txt")).exists()).toBe(false);
+		expect(await Bun.file(path.join(worker.worktree_path, "semantic.txt")).text()).toBe("semantic\n");
 		expect(await Bun.file(path.join(teamStateRoot(cleanupRoot, TEST_SESSION_ID), "runtime.json")).exists()).toBe(
 			false,
 		);
@@ -2769,235 +2755,7 @@ describe("native gjc team runtime", () => {
 		expect(stopped.phase).not.toBe("complete");
 	});
 
-	it("monitor cherry-picks diverged worker commits and stays idempotent on repeated status checks", async () => {
-		cleanupRoot = await createGitRepo();
-		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
-		const snapshot = await startGjcTeam({
-			workerCount: 1,
-			agentType: "executor",
-			task: "Integrate diverged worker",
-			teamName: "diverged-team",
-			cwd: cleanupRoot,
-			env: {
-				GJC_SESSION_ID: TEST_SESSION_ID,
-				PATH: process.env.PATH ?? "",
-				GJC_TEAM_WORKER_COMMAND: "true",
-				GJC_TEAM_TMUX_COMMAND: fakeTmux,
-			},
-		});
-		const config = await readTeamConfig(snapshot.state_dir);
-		const workerPath = config.workers[0]?.worktree_path;
-		if (!workerPath) throw new Error("missing worker worktree");
-		await commitFile(cleanupRoot, "leader.txt", "leader\n", "leader advances");
-		const workerHead = await commitFile(workerPath, "worker.txt", "worker\n", "worker diverges");
-
-		const first = await monitorGjcTeam("diverged-team", cleanupRoot, {
-			PATH: process.env.PATH ?? "",
-			GJC_SESSION_ID: TEST_SESSION_ID,
-			GJC_TEAM_TMUX_COMMAND: fakeTmux,
-		});
-		const leaderAfterFirst = runGit(cleanupRoot, ["rev-parse", "HEAD"]);
-		const second = await monitorGjcTeam("diverged-team", cleanupRoot, {
-			PATH: process.env.PATH ?? "",
-			GJC_SESSION_ID: TEST_SESSION_ID,
-			GJC_TEAM_TMUX_COMMAND: fakeTmux,
-		});
-
-		expect(await Bun.file(path.join(cleanupRoot, "worker.txt")).text()).toBe("worker\n");
-		expect(first.integration_by_worker?.["worker-1"]?.last_integrated_head).toBe(workerHead);
-		expect(second.integration_by_worker?.["worker-1"]?.last_integrated_head).toBeTruthy();
-		expect(runGit(cleanupRoot, ["rev-parse", "HEAD"])).toBe(leaderAfterFirst);
-		const events = await readEvents(snapshot.state_dir);
-		expect(events).toContain("worker_cherry_pick_applied");
-		const ledger = await Bun.file(teamReportPath(cleanupRoot, "diverged-team.ledger.json")).json();
-		expect(JSON.stringify(ledger)).toContain("integration_cherry_pick");
-	});
-
-	it("monitor reports merge conflicts without falsely advancing last integrated head", async () => {
-		cleanupRoot = await createGitRepo();
-		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
-		const snapshot = await startGjcTeam({
-			workerCount: 1,
-			agentType: "executor",
-			task: "Conflict worker",
-			teamName: "merge-conflict-team",
-			worktreeMode: { enabled: true, detached: false, name: "feature/conflict" },
-			cwd: cleanupRoot,
-			env: {
-				GJC_SESSION_ID: TEST_SESSION_ID,
-				PATH: process.env.PATH ?? "",
-				GJC_TEAM_WORKER_COMMAND: "true",
-				GJC_TEAM_TMUX_COMMAND: fakeTmux,
-			},
-		});
-		const config = await readTeamConfig(snapshot.state_dir);
-		const workerPath = config.workers[0]?.worktree_path;
-		if (!workerPath) throw new Error("missing worker worktree");
-		await commitFile(workerPath, "README.md", "# worker\n", "worker readme");
-		await Bun.write(path.join(cleanupRoot, "README.md"), "# leader dirty\n");
-
-		const monitored = await monitorGjcTeam("merge-conflict-team", cleanupRoot, {
-			PATH: process.env.PATH ?? "",
-			GJC_SESSION_ID: TEST_SESSION_ID,
-			GJC_TEAM_TMUX_COMMAND: fakeTmux,
-		});
-
-		const workerState = monitored.integration_by_worker?.["worker-1"];
-		expect(workerState?.status).toBe("merge_conflict");
-		expect(workerState?.last_integrated_head).toBeUndefined();
-		expect(runGit(cleanupRoot, ["status", "--porcelain", "--untracked-files=no"])).toBe("M README.md");
-		expect(await readEvents(snapshot.state_dir)).toContain("worker_merge_conflict");
-		expect(await Bun.file(path.join(snapshot.state_dir, "integration-report.md")).text()).toContain("merge");
-		expect(await readMailbox(snapshot.state_dir, "leader-fixed")).toContain("CONFLICT: merge failed");
-		expect(await readMailbox(snapshot.state_dir, "worker-1")).toContain("Manual resolution required");
-		const ledger = await Bun.file(teamReportPath(cleanupRoot, "merge-conflict-team.ledger.json")).json();
-		expect(JSON.stringify(ledger)).toContain('"status":"conflict"');
-		expect(JSON.stringify(ledger)).toContain("integration_merge");
-	});
-
-	it("keeps completed conflicting teams in awaiting integration instead of plain running", async () => {
-		cleanupRoot = await createGitRepo();
-		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
-		const snapshot = await startGjcTeam({
-			workerCount: 1,
-			agentType: "executor",
-			task: "Conflict after completion",
-			teamName: "awaiting-conflict-team",
-			worktreeMode: { enabled: true, detached: false, name: "feature/awaiting-conflict" },
-			cwd: cleanupRoot,
-			env: {
-				GJC_SESSION_ID: TEST_SESSION_ID,
-				PATH: process.env.PATH ?? "",
-				GJC_TEAM_WORKER_COMMAND: "true",
-				GJC_TEAM_TMUX_COMMAND: fakeTmux,
-			},
-		});
-		const config = await readTeamConfig(snapshot.state_dir);
-		const workerPath = config.workers[0]?.worktree_path;
-		if (!workerPath) throw new Error("missing worker worktree");
-		await commitFile(workerPath, "README.md", "# worker\n", "worker readme");
-		await Bun.write(path.join(cleanupRoot, "README.md"), "# leader dirty\n");
-		const claim = await claimGjcTeamTask("awaiting-conflict-team", "worker-1", cleanupRoot, {
-			PATH: process.env.PATH ?? "",
-			GJC_SESSION_ID: TEST_SESSION_ID,
-		});
-		await transitionGjcTeamTask(
-			"awaiting-conflict-team",
-			"task-1",
-			"completed",
-			cleanupRoot,
-			{
-				PATH: process.env.PATH ?? "",
-				GJC_SESSION_ID: TEST_SESSION_ID,
-			},
-			claim.claim_token,
-			commandCompletionEvidence("conflicting task completed before integration"),
-		);
-
-		const monitored = await monitorGjcTeam("awaiting-conflict-team", cleanupRoot, {
-			PATH: process.env.PATH ?? "",
-			GJC_SESSION_ID: TEST_SESSION_ID,
-			GJC_TEAM_TMUX_COMMAND: fakeTmux,
-		});
-
-		expect(monitored.task_counts.completed).toBe(1);
-		expect(monitored.integration_by_worker?.["worker-1"]?.status).toBe("merge_conflict");
-		expect(monitored.phase).toBe("awaiting_integration");
-		expect(monitored.phase).not.toBe("running");
-
-		const stopped = await shutdownGjcTeam("awaiting-conflict-team", cleanupRoot, {
-			PATH: process.env.PATH ?? "",
-			GJC_SESSION_ID: TEST_SESSION_ID,
-		});
-		expect(stopped.task_counts.completed).toBe(1);
-		expect(stopped.phase).toBe("awaiting_integration");
-		expect(stopped.phase).not.toBe("complete");
-	});
-
-	it("monitor reports cherry-pick conflicts and aborts cleanly", async () => {
-		cleanupRoot = await createGitRepo();
-		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
-		const snapshot = await startGjcTeam({
-			workerCount: 1,
-			agentType: "executor",
-			task: "Cherry pick conflict worker",
-			teamName: "pick-conflict-team",
-			cwd: cleanupRoot,
-			env: {
-				GJC_SESSION_ID: TEST_SESSION_ID,
-				PATH: process.env.PATH ?? "",
-				GJC_TEAM_WORKER_COMMAND: "true",
-				GJC_TEAM_TMUX_COMMAND: fakeTmux,
-			},
-		});
-		const config = await readTeamConfig(snapshot.state_dir);
-		const workerPath = config.workers[0]?.worktree_path;
-		if (!workerPath) throw new Error("missing worker worktree");
-		await commitFile(workerPath, "README.md", "# worker\n", "worker readme");
-		await fs.rm(path.join(cleanupRoot, "README.md"));
-		runGit(cleanupRoot, ["add", "README.md"]);
-		runGit(cleanupRoot, ["commit", "-m", "leader deletes readme"]);
-
-		const monitored = await monitorGjcTeam("pick-conflict-team", cleanupRoot, {
-			PATH: process.env.PATH ?? "",
-			GJC_SESSION_ID: TEST_SESSION_ID,
-			GJC_TEAM_TMUX_COMMAND: fakeTmux,
-		});
-
-		const workerState = monitored.integration_by_worker?.["worker-1"];
-		expect(workerState?.status).toBe("cherry_pick_conflict");
-		expect(workerState?.last_integrated_head).toBeUndefined();
-		expect(runGit(cleanupRoot, ["status", "--porcelain", "--untracked-files=no"])).toBe("");
-		expect(await readEvents(snapshot.state_dir)).toContain("worker_cherry_pick_conflict");
-		expect(await Bun.file(path.join(snapshot.state_dir, "integration-report.md")).text()).toContain("cherry-pick");
-		expect(await readMailbox(snapshot.state_dir, "leader-fixed")).toContain("CONFLICT: cherry-pick failed");
-		expect(await readMailbox(snapshot.state_dir, "worker-1")).toContain("Manual resolution required");
-		const ledger = await Bun.file(teamReportPath(cleanupRoot, "pick-conflict-team.ledger.json")).json();
-		expect(JSON.stringify(ledger)).toContain('"status":"conflict"');
-		expect(JSON.stringify(ledger)).toContain("integration_cherry_pick");
-	});
-
-	it("cross-rebases idle, done, and failed workers while skipping working workers", async () => {
-		cleanupRoot = await createGitRepo();
-		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
-		const snapshot = await startGjcTeam({
-			workerCount: 4,
-			agentType: "executor",
-			task: "Cross rebase workers",
-			teamName: "cross-rebase-team",
-			cwd: cleanupRoot,
-			env: {
-				GJC_SESSION_ID: TEST_SESSION_ID,
-				PATH: process.env.PATH ?? "",
-				GJC_TEAM_WORKER_COMMAND: "true",
-				GJC_TEAM_TMUX_COMMAND: fakeTmux,
-			},
-		});
-		await writeWorkerStatus(snapshot.state_dir, "worker-1", "idle");
-		await writeWorkerStatus(snapshot.state_dir, "worker-2", "done");
-		await writeWorkerStatus(snapshot.state_dir, "worker-3", "failed");
-		await writeWorkerStatus(snapshot.state_dir, "worker-4", "working");
-		await Bun.write(path.join(snapshot.workers[0]?.worktree_path ?? "", "worker-output.txt"), "integrate\n");
-
-		const monitored = await monitorGjcTeam("cross-rebase-team", cleanupRoot, {
-			PATH: process.env.PATH ?? "",
-			GJC_SESSION_ID: TEST_SESSION_ID,
-			GJC_TEAM_TMUX_COMMAND: fakeTmux,
-		});
-		const leaderHead = runGit(cleanupRoot, ["rev-parse", "HEAD"]);
-
-		expect(monitored.integration_by_worker?.["worker-1"]?.last_rebased_leader_head).toBe(leaderHead);
-		expect(monitored.integration_by_worker?.["worker-2"]?.last_rebased_leader_head).toBe(leaderHead);
-		expect(monitored.integration_by_worker?.["worker-3"]?.last_rebased_leader_head).toBe(leaderHead);
-		expect(monitored.integration_by_worker?.["worker-4"]?.last_rebased_leader_head).toBeUndefined();
-		const events = await readEvents(snapshot.state_dir);
-		expect(events).toContain("worker_cross_rebase_applied");
-		expect(events).toContain("worker_cross_rebase_skipped");
-		const ledger = await Bun.file(teamReportPath(cleanupRoot, "cross-rebase-team.ledger.json")).json();
-		expect(JSON.stringify(ledger)).toContain("cross_rebase");
-	});
-
-	it("pure team reads, status, and list operations stay read-only while monitor and resume can mutate", async () => {
+	it("pure team reads, status, list, and unmanaged monitor operations stay non-mutating", async () => {
 		cleanupRoot = await createGitRepo();
 		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
 		const snapshot = await startGjcTeam({
@@ -3220,5 +2978,243 @@ describe("resolveGjcWorkerCommand invocation authority", () => {
 
 		expect(command).toBe("'C:\\Program Files\\GJC\\gjc.exe'");
 		expect(command).not.toMatch(/B:\/~BUN|B:\\~BUN|\/\$bunfs|\\\$bunfs/i);
+	});
+	it("rejects managed lifecycle policy launches from an unregistered main worktree", async () => {
+		cleanupRoot = await createGitRepo();
+		const commonDir = path.resolve(cleanupRoot, runGit(cleanupRoot, ["rev-parse", "--git-common-dir"]));
+		await fs.mkdir(path.join(commonDir, "gjc", "lifecycle", "v1", "records"), { recursive: true });
+		await Bun.write(path.join(commonDir, "gjc", "lifecycle", "v1", "policy.json"), "{}\n");
+		await expect(
+			startGjcTeam({
+				workerCount: 1,
+				agentType: "executor",
+				task: "managed launch",
+				teamName: "managed-main-rejected",
+				cwd: cleanupRoot,
+				dryRun: true,
+				env: { GJC_SESSION_ID: TEST_SESSION_ID, PATH: "" },
+			}),
+		).rejects.toThrow("managed_team_requires_active_feature_lane");
+	});
+	it("accepts a registered managed dev lane", async () => {
+		cleanupRoot = await createGitRepo();
+		runGit(cleanupRoot, ["checkout", "-b", "dev/managed-team"]);
+		const commonDir = path.resolve(cleanupRoot, runGit(cleanupRoot, ["rev-parse", "--git-common-dir"]));
+		await fs.mkdir(path.join(commonDir, "gjc", "lifecycle", "v1", "records"), { recursive: true });
+		await Bun.write(path.join(commonDir, "gjc", "lifecycle", "v1", "policy.json"), "{}\n");
+		await Bun.write(
+			path.join(commonDir, "gjc", "lifecycle", "v1", "records", "managed-team.json"),
+			`${JSON.stringify({
+				version: 1,
+				laneId: "managed-team",
+				state: "active",
+				repositoryId: "test",
+				realm: "windows",
+				branch: "dev/managed-team",
+				worktreeToken: "dev-managed-team",
+				worktreePath: cleanupRoot,
+				gitCommonDir: commonDir,
+				agent: "gjc",
+				sessionId: "test",
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+				headSha: runGit(cleanupRoot, ["rev-parse", "HEAD"]),
+			})}\n`,
+		);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "managed launch",
+			teamName: "managed-dev-accepted",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { GJC_SESSION_ID: TEST_SESSION_ID, PATH: "", GJC_TEAM_WORKER_COMMAND: "true" },
+		});
+		expect((await readTeamConfig(snapshot.state_dir)).lifecycle_lane_id).toBe("managed-team");
+	});
+
+	it("keeps managed dirty workers byte-identical without an auto-checkpoint", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "managed dirty",
+			teamName: "managed-dirty",
+			cwd: cleanupRoot,
+			env: {
+				GJC_SESSION_ID: TEST_SESSION_ID,
+				PATH: process.env.PATH ?? "",
+				GJC_TEAM_WORKER_COMMAND: "true",
+				GJC_TEAM_TMUX_COMMAND: fakeTmux,
+			},
+		});
+		const config = await readTeamConfig(snapshot.state_dir);
+		config.lifecycle_mode = "managed";
+		await Bun.write(path.join(snapshot.state_dir, "config.json"), `${JSON.stringify(config)}\n`);
+		const workerPath = config.workers[0]?.worktree_path;
+		if (!workerPath) throw new Error("missing worker worktree");
+		await Bun.write(path.join(workerPath, "dirty.txt"), "unchanged\n");
+		const before = runGit(workerPath, ["status", "--porcelain"]);
+		await monitorGjcTeam("managed-dirty", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_SESSION_ID: TEST_SESSION_ID,
+			GJC_TEAM_TMUX_COMMAND: fakeTmux,
+		});
+		expect(runGit(workerPath, ["status", "--porcelain"])).toBe(before);
+		const events = await readEvents(snapshot.state_dir);
+		expect(events).toContain("worker_dirty_blocked");
+		expect(events).not.toContain("worker_auto_commit");
+	});
+
+	it("merges managed diverged worker history without cherry-picking or cross-rebasing", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "managed divergence",
+			teamName: "managed-diverged",
+			cwd: cleanupRoot,
+			env: {
+				GJC_SESSION_ID: TEST_SESSION_ID,
+				PATH: process.env.PATH ?? "",
+				GJC_TEAM_WORKER_COMMAND: "true",
+				GJC_TEAM_TMUX_COMMAND: fakeTmux,
+			},
+		});
+		const config = await readTeamConfig(snapshot.state_dir);
+		config.lifecycle_mode = "managed";
+		await Bun.write(path.join(snapshot.state_dir, "config.json"), `${JSON.stringify(config)}\n`);
+		const workerPath = config.workers[0]?.worktree_path;
+		if (!workerPath) throw new Error("missing worker worktree");
+		await commitFile(cleanupRoot, "leader.txt", "leader\n", "leader");
+		await commitFile(workerPath, "worker.txt", "worker\n", "worker");
+		await monitorGjcTeam("managed-diverged", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_SESSION_ID: TEST_SESSION_ID,
+			GJC_TEAM_TMUX_COMMAND: fakeTmux,
+		});
+		const events = await readEvents(snapshot.state_dir);
+		expect(events).toContain("worker_merge_applied");
+		expect(events).not.toContain("cherry_pick");
+		expect(events).not.toContain("cross_rebase");
+	});
+
+	it("gates managed shutdown cleanup on exact integrated clean evidence", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "managed cleanup",
+			teamName: "managed-cleanup",
+			cwd: cleanupRoot,
+			env: {
+				GJC_SESSION_ID: TEST_SESSION_ID,
+				PATH: process.env.PATH ?? "",
+				GJC_TEAM_WORKER_COMMAND: "true",
+				GJC_TEAM_TMUX_COMMAND: fakeTmux,
+			},
+		});
+		const config = await readTeamConfig(snapshot.state_dir);
+		config.lifecycle_mode = "managed";
+		await Bun.write(path.join(snapshot.state_dir, "config.json"), `${JSON.stringify(config)}\n`);
+		const workerPath = config.workers[0]?.worktree_path;
+		if (!workerPath) throw new Error("missing worker worktree");
+		await commitFile(workerPath, "worker.txt", "worker\n", "worker");
+		await monitorGjcTeam("managed-cleanup", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_SESSION_ID: TEST_SESSION_ID,
+			GJC_TEAM_TMUX_COMMAND: fakeTmux,
+		});
+		await shutdownGjcTeam("managed-cleanup", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_SESSION_ID: TEST_SESSION_ID,
+		});
+		expect(await Bun.file(workerPath).exists()).toBe(false);
+	});
+	it("preserves managed dirty unintegrated worker worktrees at shutdown", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "managed preserve",
+			teamName: "managed-preserve",
+			cwd: cleanupRoot,
+			env: {
+				GJC_SESSION_ID: TEST_SESSION_ID,
+				PATH: process.env.PATH ?? "",
+				GJC_TEAM_WORKER_COMMAND: "true",
+				GJC_TEAM_TMUX_COMMAND: fakeTmux,
+			},
+		});
+		const config = await readTeamConfig(snapshot.state_dir);
+		config.lifecycle_mode = "managed";
+		await Bun.write(path.join(snapshot.state_dir, "config.json"), `${JSON.stringify(config)}\n`);
+		const workerPath = config.workers[0]?.worktree_path;
+		if (!workerPath) throw new Error("missing worker worktree");
+		await Bun.write(path.join(workerPath, "dirty.txt"), "preserve\n");
+		await shutdownGjcTeam("managed-preserve", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_SESSION_ID: TEST_SESSION_ID,
+		});
+		expect(await Bun.file(path.join(workerPath, "dirty.txt")).text()).toBe("preserve\n");
+		expect(await readEvents(snapshot.state_dir)).toContain("worker_cleanup_blocked");
+	});
+	it("rejects shutdown ACKs that do not match the recorded request", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "ack validation",
+			teamName: "ack-validation",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+		});
+		await executeGjcTeamApiOperation(
+			"write-shutdown-request",
+			{ team_name: "ack-validation", worker_id: "worker-1", requested_by: "leader-fixed", request_id: "expected" },
+			cleanupRoot,
+			{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+		);
+		const workerEnv = {
+			PATH: "",
+			GJC_SESSION_ID: TEST_SESSION_ID,
+			GJC_TEAM_NAME: "ack-validation",
+			GJC_TEAM_WORKER_ID: "worker-1",
+			GJC_TEAM_WORKER_AUTH_TOKEN: snapshot.workers[0]?.auth_token ?? "",
+		};
+		await expect(
+			executeGjcTeamApiOperation(
+				"write-shutdown-ack",
+				{ team_name: "ack-validation", worker_id: "worker-1", request_id: "wrong", status: "accepted" },
+				cleanupRoot,
+				workerEnv,
+			),
+		).rejects.toThrow("shutdown_ack_request_id_mismatch");
+		await expect(
+			executeGjcTeamApiOperation(
+				"write-shutdown-ack",
+				{ team_name: "ack-validation", worker_id: "worker-1", request_id: "expected", status: "stopped" },
+				cleanupRoot,
+				workerEnv,
+			),
+		).rejects.toThrow("shutdown_terminal_ack_requires_acceptance");
+		await executeGjcTeamApiOperation(
+			"write-shutdown-ack",
+			{ team_name: "ack-validation", worker_id: "worker-1", request_id: "expected", status: "accepted" },
+			cleanupRoot,
+			workerEnv,
+		);
+		const terminal = (await executeGjcTeamApiOperation(
+			"write-shutdown-ack",
+			{ team_name: "ack-validation", worker_id: "worker-1", request_id: "expected", status: "stopped" },
+			cleanupRoot,
+			workerEnv,
+		)) as { clean?: boolean; status?: string };
+		expect(terminal).toMatchObject({ clean: true, status: "stopped" });
 	});
 });

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -3,9 +3,11 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as natives from "@gajae-code/natives";
+import { readLaneRecord, writeLaneRecord } from "../../src/gjc-runtime/git-lifecycle";
 import {
 	captureBaseline,
 	captureDeltaPatch,
+	cleanupIsolation,
 	ensureIsolation,
 	getGitNoIndexNullPath,
 	mergeTaskBranches,
@@ -46,6 +48,31 @@ async function createGitRepo(): Promise<{ baseBranch: string; repo: string }> {
 		baseBranch: await runGit(repo, ["branch", "--show-current"]),
 		repo,
 	};
+}
+
+async function registerManagedDestination(repo: string, baseBranch: string): Promise<string> {
+	const commonValue = await runGit(repo, ["rev-parse", "--git-common-dir"]);
+	const commonDir = path.resolve(repo, commonValue);
+	const now = new Date().toISOString();
+	await fs.mkdir(path.join(commonDir, "gjc", "lifecycle", "v1"), { recursive: true });
+	await fs.writeFile(path.join(commonDir, "gjc", "lifecycle", "v1", "policy.json"), "{}\n");
+	await writeLaneRecord(commonDir, {
+		version: 1,
+		laneId: "task-lane",
+		state: "active",
+		repositoryId: "test-repository",
+		realm: process.platform === "win32" ? "windows" : "wsl",
+		branch: baseBranch,
+		worktreeToken: path.basename(repo),
+		worktreePath: repo,
+		agent: "gjc",
+		sessionId: "test-session",
+		gitCommonDir: commonDir,
+		headSha: await runGit(repo, ["rev-parse", "HEAD"]),
+		createdAt: now,
+		updatedAt: now,
+	});
+	return commonDir;
 }
 
 afterEach(async () => {
@@ -102,7 +129,75 @@ describe("worktree isolation helpers", () => {
 		expect(handle.fallbackReason).toBe(unavailable.message);
 	});
 
-	it("does not pop an unrelated pre-existing stash when the working tree is clean", async () => {
+	it("allocates unique owned isolation directories and cleans only the matching handle", async () => {
+		const { repo } = await createGitRepo();
+		vi.spyOn(natives, "isoResolve").mockReturnValue({
+			kind: natives.IsoBackendKind.Rcopy,
+			candidates: [natives.IsoBackendKind.Rcopy],
+			fellBack: false,
+			reason: undefined,
+		});
+		vi.spyOn(natives, "isoStart").mockImplementation(async (_backend, _source, mergedDir) => {
+			await fs.mkdir(mergedDir, { recursive: true });
+		});
+		vi.spyOn(natives, "isoStop").mockResolvedValue(undefined);
+
+		const first = await ensureIsolation(repo, "same-task");
+		const second = await ensureIsolation(repo, "same-task");
+		expect(first.baseDir).not.toBe(second.baseDir);
+
+		await cleanupIsolation(first);
+		expect(await fs.stat(second.mergedDir)).toBeDefined();
+		await cleanupIsolation(second);
+	});
+
+	async function createTaskBranch(repo: string, baseBranch: string, branchName: string): Promise<void> {
+		await runGit(repo, ["checkout", "-b", branchName]);
+		await fs.writeFile(path.join(repo, "merged.txt"), "task branch change\n");
+		await runGit(repo, ["add", "merged.txt"]);
+		await runGit(repo, ["commit", "-m", "task change"]);
+		await runGit(repo, ["checkout", baseBranch]);
+	}
+
+	async function captureDestination(
+		repo: string,
+		files: string[],
+	): Promise<{
+		cachedDiff: string;
+		files: Uint8Array[];
+		head: string;
+		index: string;
+		refs: string;
+		stash: string;
+		status: string;
+		unstagedDiff: string;
+	}> {
+		return {
+			cachedDiff: await runGit(repo, ["diff", "--cached", "--binary"]),
+			files: await Promise.all(files.map(file => fs.readFile(path.join(repo, file)))),
+			head: await runGit(repo, ["rev-parse", "HEAD"]),
+			index: await runGit(repo, ["ls-files", "--stage"]),
+			refs: await runGit(repo, ["show-ref", "--head"]),
+			stash: await runGit(repo, ["stash", "list"]),
+			status: await runGit(repo, ["status", "--porcelain=v1"]),
+			unstagedDiff: await runGit(repo, ["diff", "--binary"]),
+		};
+	}
+
+	async function expectDirtyDestinationRejected(repo: string, taskBranch: string, files: string[]): Promise<void> {
+		const before = await captureDestination(repo, files);
+
+		const result = await mergeTaskBranches(repo, [{ branchName: taskBranch, taskId: "task-1" }]);
+
+		expect(result).toEqual({
+			merged: [],
+			failed: [taskBranch],
+			conflict: "Destination working tree is dirty; refusing to cherry-pick task branches.",
+		});
+		expect(await captureDestination(repo, files)).toEqual(before);
+	}
+
+	it("keeps an unrelated pre-existing stash when the destination is clean", async () => {
 		const { repo } = await createGitRepo();
 		await fs.writeFile(path.join(repo, "preexisting.txt"), "user stash\n");
 		await runGit(repo, ["stash", "push", "--include-untracked", "-m", "preexisting-user-stash"]);
@@ -115,25 +210,114 @@ describe("worktree isolation helpers", () => {
 		expect(await runGit(repo, ["status", "--porcelain=v1"])).toBe("");
 	});
 
-	it("restores staged changes with index preservation after merging task branches", async () => {
+	it("fails closed without changing a staged destination", async () => {
 		const { baseBranch, repo } = await createGitRepo();
 		const taskBranch = "task/merge-staged";
-		await runGit(repo, ["checkout", "-b", taskBranch]);
-		await fs.writeFile(path.join(repo, "merged.txt"), "task branch change\n");
-		await runGit(repo, ["add", "merged.txt"]);
-		await runGit(repo, ["commit", "-m", "task-change"]);
-		await runGit(repo, ["checkout", baseBranch]);
+		await createTaskBranch(repo, baseBranch, taskBranch);
+		await fs.writeFile(path.join(repo, "stash-seed.txt"), "user stash\n");
+		await runGit(repo, ["stash", "push", "--include-untracked", "-m", "preexisting-user-stash"]);
 		await fs.writeFile(path.join(repo, "staged.txt"), "local staged change\n");
 		await runGit(repo, ["add", "staged.txt"]);
-		expect(await runGit(repo, ["status", "--porcelain=v1"])).toBe("M  staged.txt");
 
+		await expectDirtyDestinationRejected(repo, taskBranch, ["staged.txt"]);
+	});
+
+	it("fails closed without changing an unstaged destination", async () => {
+		const { baseBranch, repo } = await createGitRepo();
+		const taskBranch = "task/merge-unstaged";
+		await createTaskBranch(repo, baseBranch, taskBranch);
+		await fs.writeFile(path.join(repo, "stash-seed.txt"), "user stash\n");
+		await runGit(repo, ["stash", "push", "--include-untracked", "-m", "preexisting-user-stash"]);
+		await fs.writeFile(path.join(repo, "staged.txt"), "local unstaged change\n");
+
+		await expectDirtyDestinationRejected(repo, taskBranch, ["staged.txt"]);
+	});
+
+	it("fails closed without changing an untracked destination", async () => {
+		const { baseBranch, repo } = await createGitRepo();
+		const taskBranch = "task/merge-untracked";
+		await createTaskBranch(repo, baseBranch, taskBranch);
+		await fs.writeFile(path.join(repo, "stash-seed.txt"), "user stash\n");
+		await runGit(repo, ["stash", "push", "--include-untracked", "-m", "preexisting-user-stash"]);
+		await fs.writeFile(path.join(repo, "untracked.txt"), "local untracked change\n");
+
+		await expectDirtyDestinationRejected(repo, taskBranch, ["untracked.txt"]);
+	});
+
+	it("cherry-picks a task branch onto a clean destination", async () => {
+		const { baseBranch, repo } = await createGitRepo();
+		const taskBranch = "task/merge-clean";
+		await createTaskBranch(repo, baseBranch, taskBranch);
+
+		await registerManagedDestination(repo, baseBranch);
 		const result = await mergeTaskBranches(repo, [{ branchName: taskBranch, taskId: "task-1" }]);
 
 		expect(result).toEqual({ failed: [], merged: [taskBranch] });
-		expect(await fs.readFile(path.join(repo, "merged.txt"), "utf8")).toBe("task branch change\n");
-		expect(await runGit(repo, ["status", "--porcelain=v1"])).toBe("M  staged.txt");
-		expect(await runGit(repo, ["diff", "--cached", "--", "staged.txt"])).toContain("+local staged change");
-		expect(await runGit(repo, ["stash", "list"])).toBe("");
+		expect((await fs.readFile(path.join(repo, "merged.txt"), "utf8")).replace(/\r\n/g, "\n")).toBe(
+			"task branch change\n",
+		);
+		expect(await runGit(repo, ["status", "--porcelain=v1"])).toBe("");
+		const commonDir = path.resolve(repo, await runGit(repo, ["rev-parse", "--git-common-dir"]));
+		expect((await readLaneRecord(commonDir, "task-lane"))?.headSha).toBe(await runGit(repo, ["rev-parse", "HEAD"]));
+	});
+
+	it("refuses to mutate a clean destination without managed lane ownership", async () => {
+		const { baseBranch, repo } = await createGitRepo();
+		const taskBranch = "task/merge-unmanaged";
+		await createTaskBranch(repo, baseBranch, taskBranch);
+		const before = await captureDestination(repo, ["merged.txt"]);
+
+		const result = await mergeTaskBranches(repo, [{ branchName: taskBranch, taskId: "task-1" }]);
+
+		expect(result).toEqual({
+			merged: [],
+			failed: [taskBranch],
+			conflict: "Managed feature lane ownership is required; refusing to mutate the destination checkout.",
+		});
+		expect(await captureDestination(repo, ["merged.txt"])).toEqual(before);
+	});
+
+	it("refuses task integration while the managed lane has an active lease", async () => {
+		const { baseBranch, repo } = await createGitRepo();
+		const taskBranch = "task/merge-leased";
+		await createTaskBranch(repo, baseBranch, taskBranch);
+		const commonDir = await registerManagedDestination(repo, baseBranch);
+		const lane = await readLaneRecord(commonDir, "task-lane");
+		if (!lane) throw new Error("missing managed lane");
+		await writeLaneRecord(commonDir, {
+			...lane,
+			leaseOwner: "team:other",
+			leaseUpdatedAt: new Date().toISOString(),
+			leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+		});
+		const before = await captureDestination(repo, ["merged.txt"]);
+
+		const result = await mergeTaskBranches(repo, [{ branchName: taskBranch, taskId: "task-1" }]);
+
+		expect(result).toEqual({
+			merged: [],
+			failed: [taskBranch],
+			conflict: "Managed feature lane ownership is required; refusing to mutate the destination checkout.",
+		});
+		expect(await captureDestination(repo, ["merged.txt"])).toEqual(before);
+	});
+
+	it("aborts a clean-destination cherry-pick conflict and preserves the task branch", async () => {
+		const { baseBranch, repo } = await createGitRepo();
+		const taskBranch = "task/merge-conflict";
+		await createTaskBranch(repo, baseBranch, taskBranch);
+		await fs.writeFile(path.join(repo, "merged.txt"), "destination change\n");
+		await runGit(repo, ["add", "merged.txt"]);
+		await runGit(repo, ["commit", "-m", "destination change"]);
+
+		await registerManagedDestination(repo, baseBranch);
+		const result = await mergeTaskBranches(repo, [{ branchName: taskBranch, taskId: "task-1" }]);
+
+		expect(result.merged).toEqual([]);
+		expect(result.failed).toEqual([taskBranch]);
+		expect(result.conflict).toContain(taskBranch);
+		expect(await runGit(repo, ["status", "--porcelain=v1"])).toBe("");
+		expect(await runGit(repo, ["rev-parse", taskBranch])).not.toBe("");
 	});
 
 	it("subtracts baseline dirty state even when the task commits it", async () => {


### PR DESCRIPTION
## Summary
- add typed isolated Git/worktree lifecycle lanes and the `gjc lane` CLI
- gate PR creation, controlled squash merge, retention, and cleanup on recorded ownership and exact evidence
- constrain Team and Task integration to managed lanes while preserving unmanaged output as explicit artifacts

## Verification
- `bun run check`
- `bun test test/git-lifecycle.test.ts test/git-lifecycle-controller.test.ts test/commands/lane.test.ts test/gjc-runtime/launch-worktree.test.ts test/task/worktree.test.ts test/task/receipt.test.ts` (61 pass)
- managed Team gate filter (3 pass)
- workflow manifest check passed

The full Team runtime test file remains blocked on this Windows checkout by the existing extensionless fake-tmux fixture resolution; focused managed lifecycle tests pass.