### PR TITLE
ci(dev): repair postmerge Biome formatting from #2624

### DIFF
--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2028,7 +2028,14 @@ for (const eventType of ["session_switch", "session_branch"] as const) {
 			sessionManager: {
 				getSessionId: () => activeSessionId,
 				getSessionName: () => "SDK rotate",
-				getUsageStatistics: () => ({ input: 1, output: 2, cacheRead: 0, cacheWrite: 0, premiumRequests: 0, cost: 0 }),
+				getUsageStatistics: () => ({
+					input: 1,
+					output: 2,
+					cacheRead: 0,
+					cacheWrite: 0,
+					premiumRequests: 0,
+					cost: 0,
+				}),
 			},
 		};
 		// Fail A's owner release exactly once so the rotate-time stopSession(prevId)


### PR DESCRIPTION
## Summary

Postmerge CI formatting repair for merged PR #2624 on current `dev`.

- applies only Biome's required multiline formatting to `getUsageStatistics` in `packages/coding-agent/test/sdk-host-wiring.test.ts`
- contains no #2625 or native-loader changes
- targets `dev`; does not touch `main`, release, or publish paths

## Evidence

- base before repair: `09e5263b1cbb08e54a5ddfeae3e5b04a0389c95a`
- repair head: `c89062245`
- `bunx @biomejs/biome@2.5.2 format packages/coding-agent/test/sdk-host-wiring.test.ts` — passed, no fixes required
- root `bun run ci:check:full` passed the repository-wide Biome check and all checks through the coding-agent workspace check; the latter could not finish locally because this dedicated worktree has no built `pi_natives` addon
- focused SDK host test was likewise blocked before test collection by the absent local `pi_natives` addon; hosted Dev CI provides the canonical native-backed verification

The failed Dev CI run `29670725586` identified this single formatter defect; its evidence-producer and aggregate failures were downstream.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
