### PR TITLE
fix(tui): preserve scrollback on completion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -183,7 +183,7 @@
       "devDependencies": {
         "@xterm/headless": "catalog:",
         "chalk": "catalog:",
-        "node-pty": "^1.0.0",
+        "node-pty": "1.2.0-beta.14",
       },
     },
     "packages/typescript-edit-benchmark": {
@@ -960,7 +960,7 @@
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
-    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+    "node-pty": ["node-pty@1.2.0-beta.14", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-XORU9BQgpxVgqr7WivjJ17mLenOHUgKKWzuZZNaw3NDYgHc/wPJQMSaoLDrpEgqV6aU1nNwil1o/OqYj6lWmUA=="],
 
     "nth-check": ["nth-check@3.0.1", "", { "dependencies": { "boolbase": "^2.0.0" } }, "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ=="],
 

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -811,9 +811,16 @@ export class EventController {
 
 	async #handleAgentEnd(_event: Extract<AgentSessionEvent, { type: "agent_end" }>): Promise<void> {
 		if (this.ctx.loadingAnimation) {
-			this.ctx.loadingAnimation.stop();
+			const loader = this.ctx.loadingAnimation;
+			loader.stop();
 			this.ctx.loadingAnimation = undefined;
+			// Process terminals do not expose native scrollback position. Preserve
+			// the loader's actual footprint so completion cannot contract and repaint
+			// a viewport the user is browsing.
 			this.ctx.statusContainer.clear();
+			if (this.ctx.ui.terminal.isProcessTerminal) {
+				this.ctx.statusContainer.addChild(loader.createFootprint());
+			}
 		}
 		if (this.ctx.streamingComponent) {
 			this.ctx.chatContainer.removeChild(this.ctx.streamingComponent);

--- a/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
@@ -121,6 +121,7 @@ describe("EventController completion viewport", () => {
 					});
 					const pendingMessagesContainer = new Container();
 					const statusContainer = new Container();
+					statusContainer.addChild(new Text("", 0, 0));
 					statusContainer.addChild(new Text("working", 0, 0));
 					const todoContainer = new Container();
 					const btwContainer = new Container();
@@ -136,6 +137,9 @@ describe("EventController completion viewport", () => {
 					ui.addChild(editor);
 					ui.setBottomPinnedComponent(statusLine);
 					const stopLoading = vi.fn();
+					const createFootprint = vi.fn(() => ({
+						render: () => ["", ""],
+					}));
 					const ctx = {
 						isInitialized: true,
 						ui,
@@ -149,7 +153,7 @@ describe("EventController completion viewport", () => {
 						getUserMessageText: (userMessage: { content: string }) => userMessage.content,
 						streamingComponent,
 						streamingMessage: startMessage,
-						loadingAnimation: { stop: stopLoading },
+						loadingAnimation: { stop: stopLoading, createFootprint },
 						pendingTools: new Map(),
 						planModeController: { flushPendingModelSwitch: async () => {} },
 						updateEditorTopBorder: () => {},
@@ -187,16 +191,21 @@ describe("EventController completion viewport", () => {
 						await controller.handleEvent({ type: "message_end", message });
 						expect(getSessionMessageViewportAnchorId(message)).toBe(anchorId);
 						await term.waitForRender();
+						term.clearWriteLog();
 						await controller.handleEvent({ type: "agent_end", messages: [message] });
 						await term.waitForRender();
 						expect(stopLoading, `${testCase.label} clear=${clearOnShrink}`).toHaveBeenCalledTimes(1);
+						expect(createFootprint, `${testCase.label} clear=${clearOnShrink}`).toHaveBeenCalledTimes(1);
 						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBeUndefined();
-						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(0);
+						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(1);
 						const after = term.getViewport().map(line => line.trimEnd());
 						for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
 						const writes = term.getWriteLog().join("");
 						expect(writes).not.toContain("\x1b[2J\x1b[H");
 						expect(writes).not.toContain("\x1b[3J");
+						for (const entry of beforeHistory) {
+							expect(writes, `${testCase.label} clear=${clearOnShrink}`).not.toContain(entry.line);
+						}
 						const visibleHistoryNumbers = beforeHistory.flatMap(entry => {
 							const match = /history-(\d+)/.exec(entry.line);
 							return match ? [Number(match[1])] : [];

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2028,7 +2028,14 @@ for (const eventType of ["session_switch", "session_branch"] as const) {
 			sessionManager: {
 				getSessionId: () => activeSessionId,
 				getSessionName: () => "SDK rotate",
-				getUsageStatistics: () => ({ input: 1, output: 2, cacheRead: 0, cacheWrite: 0, premiumRequests: 0, cost: 0 }),
+				getUsageStatistics: () => ({
+					input: 1,
+					output: 2,
+					cacheRead: 0,
+					cacheWrite: 0,
+					premiumRequests: 0,
+					cost: 0,
+				}),
 			},
 		};
 		// Fail A's owner release exactly once so the rotate-time stopSession(prevId)

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -42,9 +42,9 @@
 		"marked": "catalog:"
 	},
 	"devDependencies": {
-		"chalk": "catalog:",
 		"@xterm/headless": "catalog:",
-		"node-pty": "^1.0.0"
+		"chalk": "catalog:",
+		"node-pty": "1.2.0-beta.14"
 	},
 	"engines": {
 		"bun": ">=1.3.14"

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -1,5 +1,5 @@
 import { type AnimationRegistration, registerAnimationCallback } from "../animation-scheduler";
-import type { TUI } from "../tui";
+import type { Component, TUI } from "../tui";
 import { sliceByColumn, visibleWidth } from "../utils";
 import { Text } from "./text";
 
@@ -43,6 +43,18 @@ export class Loader extends Text {
 			this.#frames = spinnerFrames;
 		}
 		this.start();
+	}
+
+	/**
+	 * Retains this loader's current render footprint without retaining its visible
+	 * status text. Use after stopping a loader when removing rows would repaint an
+	 * inline terminal viewport.
+	 */
+	createFootprint(): Component {
+		return {
+			render: width => this.render(width).map(() => ""),
+			invalidate: () => {},
+		};
 	}
 
 	render(width: number): string[] {

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -28,6 +28,25 @@ describe("Loader component", () => {
 		loader.stop();
 		tui.stop();
 	});
+	it("preserves its dynamic render footprint without visible status text", () => {
+		const term = new VirtualTerminal(40, 4);
+		const tui = new TUI(term);
+		const loader = new Loader(
+			tui,
+			text => text,
+			text => text,
+			"A long status message that wraps",
+			["|"],
+		);
+
+		const footprint = loader.createFootprint();
+		for (const width of [4, 40]) {
+			expect(footprint.render(width)).toEqual(loader.render(width).map(() => ""));
+		}
+
+		loader.stop();
+		tui.stop();
+	});
 
 	it("unrefs its animation interval so it does not keep the event loop alive", () => {
 		const term = new VirtualTerminal(20, 4);

--- a/packages/tui/test/pty/mouse-pty-driver.mjs
+++ b/packages/tui/test/pty/mouse-pty-driver.mjs
@@ -1,0 +1,116 @@
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import * as url from "node:url";
+import * as pty from "node-pty";
+
+const scenario = process.argv[2];
+const bunBinary = process.env.BUN_BINARY;
+const testDir = path.dirname(url.fileURLToPath(import.meta.url));
+const fixture = path.join(testDir, "mouse-pty-fixture.ts");
+const baseEnv = Object.fromEntries(Object.entries(process.env).filter(([, value]) => value !== undefined));
+
+if (!bunBinary) throw new Error("BUN_BINARY must identify the Bun executable that runs the PTY fixture.");
+if (!scenario) throw new Error("A PTY scenario is required.");
+
+
+function launchFixture(env = {}) {
+	let captured = "";
+	const terminal = pty.spawn("/bin/sh", ["-c", 'exec "$1" "$2"', "pty-fixture", bunBinary, fixture], {
+		name: "xterm-256color",
+		cols: 80,
+		rows: 24,
+		cwd: process.cwd(),
+		env: { ...baseEnv, TERM: "xterm-256color", ...env },
+	});
+	terminal.onData(data => {
+		captured += data;
+	});
+	terminal.onExit(event => {
+		captured += `\nPTY_FIXTURE_EXIT:${event.exitCode}:${event.signal}\n`;
+	});
+	return { terminal, output: () => captured };
+}
+
+
+async function waitForOutput(output, marker) {
+	const deadline = Date.now() + 3_000;
+	while (!output().includes(marker)) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${JSON.stringify(marker)}; output: ${JSON.stringify(output())}`);
+		await new Promise(resolve => setTimeout(resolve, 10));
+	}
+}
+
+async function run() {
+	if (scenario === "plain-enable") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			assert.match(output(), /\x1b\[\?1000h/);
+			assert.match(output(), /\x1b\[\?1006h/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "graceful-stop") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.write("__exit__\r");
+			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
+			assert.match(output(), /\x1b\[\?1000l/);
+			assert.match(output(), /\x1b\[\?1006l/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "sigterm") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.kill("SIGTERM");
+			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
+			assert.match(output(), /\x1b\[\?1000l/);
+			assert.match(output(), /\x1b\[\?1006l/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "multiplexer") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1", TMUX: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			assert.doesNotMatch(output(), /\x1b\[\?1000h/);
+			assert.doesNotMatch(output(), /\x1b\[\?1006h/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "composer") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		const mouse = "\x1b[<0;3;4M";
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.write("composer");
+			await waitForOutput(output, 'EDITOR:"composer"');
+			terminal.write(mouse);
+			terminal.write("!");
+			await waitForOutput(output, 'EDITOR:"composer!"');
+			assert.equal(output().includes(mouse), false);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	throw new Error(`Unknown PTY scenario: ${scenario}`);
+}
+
+await run();

--- a/packages/tui/test/pty/mouse-pty-matrix.test.ts
+++ b/packages/tui/test/pty/mouse-pty-matrix.test.ts
@@ -1,148 +1,47 @@
 import { describe, expect, test } from "bun:test";
-import { resolve } from "node:path";
-import type { IPty } from "node-pty";
+import * as path from "node:path";
 
 const enabled = process.env.PI_TUI_PTY_TESTS === "1";
-const fixture = resolve(import.meta.dir, "mouse-pty-fixture.ts");
-const baseEnv = Object.fromEntries(
-	Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-);
+const driver = path.resolve(import.meta.dir, "mouse-pty-driver.mjs");
+const nodeBinary = process.env.NODE_BINARY ?? "node";
 
-type PtyModule = typeof import("node-pty");
-
-let pty: PtyModule | undefined;
-let capabilityReason = "PTY capability probe was not run.";
-
-async function probePtyCapability(): Promise<boolean> {
-	try {
-		pty = await import("node-pty");
-		const probe = pty.spawn("/bin/sh", ["-c", "exit 0"], {
-			name: "xterm-256color",
-			cols: 80,
-			rows: 24,
-			cwd: process.cwd(),
-			env: { ...baseEnv, TERM: "xterm-256color" },
-		});
-		const exited = await new Promise<boolean>(resolveProbe => {
-			const timeout = setTimeout(() => resolveProbe(false), 1_000);
-			probe.onExit(() => {
-				clearTimeout(timeout);
-				resolveProbe(true);
-			});
-		});
-		if (!exited) {
-			probe.kill();
-			capabilityReason = "node-pty capability probe timed out waiting for /bin/sh to exit.";
-			return false;
-		}
-		return true;
-	} catch (error) {
-		capabilityReason = `node-pty capability probe failed: ${error instanceof Error ? error.message : String(error)}`;
-		return false;
-	}
-}
-
-const ptyAvailable = enabled && process.platform !== "win32" ? await probePtyCapability() : false;
-
-function launchFixture(env: Record<string, string> = {}): { terminal: IPty; output: () => string } {
-	if (!pty) throw new Error(capabilityReason);
-	let captured = "";
-	const terminal = pty.spawn("/bin/sh", ["-c", 'exec "$1" "$2"', "pty-fixture", process.execPath, fixture], {
-		name: "xterm-256color",
-		cols: 80,
-		rows: 24,
+async function runScenario(scenario: string): Promise<void> {
+	const child = Bun.spawn([nodeBinary, driver, scenario], {
 		cwd: process.cwd(),
-		env: { ...baseEnv, TERM: "xterm-256color", ...env },
+		env: { ...process.env, BUN_BINARY: process.execPath },
+		stdout: "pipe",
+		stderr: "pipe",
 	});
-	terminal.onData(data => {
-		captured += data;
-	});
-	terminal.onExit(event => {
-		captured += `\nPTY_FIXTURE_EXIT:${event.exitCode}:${event.signal}\n`;
-	});
-	return { terminal, output: () => captured };
-}
-
-async function waitForOutput(output: () => string, marker: string): Promise<void> {
-	const deadline = Date.now() + 3_000;
-	while (!output().includes(marker)) {
-		if (Date.now() >= deadline)
-			throw new Error(`Timed out waiting for ${JSON.stringify(marker)}; output: ${JSON.stringify(output())}`);
-		await Bun.sleep(10);
-	}
+	const [exitCode, stdout, stderr] = await Promise.all([
+		child.exited,
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	expect(exitCode, `${stderr}\n${stdout}`).toBe(0);
 }
 
 /**
- * POSIX-only integration lane. Terminal ownership is intentionally exercised in
- * CI where node-pty can allocate a real pseudo terminal; normal unit tests do
- * not require native PTY bindings.
+ * POSIX-only integration lane. node-pty's native callbacks are driven by Node,
+ * while the fixture itself runs under Bun and exercises ProcessTerminal.
  */
 describe.skipIf(!enabled || process.platform === "win32")("mouse PTY matrix", () => {
-	test("requires a usable PTY capability when explicitly enabled", () => {
-		expect(ptyAvailable, capabilityReason).toBe(true);
-	});
 	test("emits SGR mouse enable bytes in a plain xterm PTY", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			expect(output()).toContain("\x1b[?1000h");
-			expect(output()).toContain("\x1b[?1006h");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("plain-enable");
 	});
 
 	test("emits SGR mouse disable bytes on graceful stop", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.write("__exit__\r");
-			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
-			expect(output()).toContain("\x1b[?1000l");
-			expect(output()).toContain("\x1b[?1006l");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("graceful-stop");
 	});
 
 	test("restores SGR mouse modes when SIGTERM detaches the TUI", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.kill("SIGTERM");
-			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
-			expect(output()).toContain("\x1b[?1000l");
-			expect(output()).toContain("\x1b[?1006l");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("sigterm");
 	});
 
 	test("emits no SGR mouse enable bytes under a multiplexer", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1", TMUX: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			expect(output()).not.toContain("\x1b[?1000h");
-			expect(output()).not.toContain("\x1b[?1006h");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("multiplexer");
 	});
 
 	test("does not leak SGR mouse reports into composer text", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		const mouse = "\x1b[<0;3;4M";
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.write("composer");
-			await waitForOutput(output, 'EDITOR:"composer"');
-			terminal.write(mouse);
-			terminal.write("!");
-			await waitForOutput(output, 'EDITOR:"composer!"');
-			expect(output()).toContain('EDITOR:"composer!"');
-			expect(output()).not.toContain(mouse);
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("composer");
 	});
 });


### PR DESCRIPTION
## Problem

When an agent turn ended while a user was browsing inline terminal scrollback, removing the transient loader reduced the rendered transcript height. The differential TUI then repainted the live viewport, which could pull the terminal view away from the rows the user was reading.

Process terminals do not expose native scrollback position, so the renderer cannot safely decide whether this completion-time contraction is visible to the user.

## Root cause

`EventController.#handleAgentEnd()` stopped and removed the loader unconditionally. `Loader.render()` reserves a leading blank line and can wrap its status text, but the prior mitigation replaced it with a hard-coded `Spacer(2)`. That avoided the common case while coupling correctness to an implementation detail and failed to model narrow-terminal wrapping.

The PTY regression tests also had to self-`chmod` node-pty's Darwin `spawn-helper` because stable `node-pty@1.1.0` shipped it without execute permissions.

## Solution

- Add `Loader.createFootprint()`, a blank component whose row count exactly follows the stopped loader at every terminal width.
- At agent completion on a process terminal, replace the loader with that footprint rather than contracting the status slot. The next turn clears the transient slot before creating its new loader.
- Keep non-process terminal behavior unchanged: the status container is cleared.
- Run the native `node-pty` parent under Node while continuing to run the fixture and `ProcessTerminal` under Bun. This uses node-pty's supported native callback runtime.
- Pin the test-only dependency to `node-pty@1.2.0-beta.14`, which contains the upstream Darwin executable-bit fix, and remove the runtime chmod workaround.

## Behavior and scope

This preserves inline scrollback geometry only for the completion transition. It does not switch to an alternate screen, alter transcript history, or change normal virtual-terminal behavior. `node-pty` remains a TUI test-only dev dependency and is not bundled into the GJC runtime.

The beta pin is deliberately exact to prevent automatic pre-release drift. The existing `tui-pty-matrix` CI job runs these tests on Ubuntu and macOS; the dependency should move to the first stable node-pty release containing the same fix.

## Regression coverage

- Loader footprint test checks both narrow and wide widths, including wrapped status text, and asserts every footprint row is blank.
- Completion viewport regression covers plain SSH, tmux default/legacy, Termux resize, Windows host-selection markers, both clear-on-shrink settings, and verifies historical viewport rows are neither cleared nor replayed after completion.
- POSIX PTY matrix verifies mouse enable, graceful disable, SIGTERM cleanup, multiplexer suppression, and composer-input isolation.

## Verification

- `bun test test` in `packages/tui`: **791 passed, 5 skipped, 0 failed**.
- `PI_TUI_PTY_TESTS=1 bun test test/loader.test.ts test/pty/mouse-pty-matrix.test.ts`: **10 passed, 0 failed**.
- `bun --cwd=packages/coding-agent test test/modes/controllers/event-controller-completion-viewport.test.ts`: **1 passed, 502 assertions**.
- `bun run check:types` in `packages/tui` and `packages/coding-agent`: passed.
- Targeted Biome checks: passed.
- `git diff --check`: passed.