### PR TITLE
fix(tui): suppress autocomplete in backtick spans

### DIFF
--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -248,6 +248,13 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 
 		return this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol);
 	}
+	getForceFileSuggestions(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+		return this.#baseProvider.getForceFileSuggestions(lines, cursorLine, cursorCol);
+	}
 
 	applyCompletion(
 		lines: string[],

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Suppressed slash-command and skill autocomplete inside line-local single-backtick code spans while preserving path completion and ordinary slash matching outside literals (#2619).
 
 ## [0.11.0] - 2026-07-15
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -190,10 +190,38 @@ function normalizeSlashCommandText(value: string): string {
 		.replace(/\s+/g, " ");
 }
 const NON_COMMAND_SLASH_PREFIX_PRECEDERS = new Set(["/", "\\", ":", ".", "~"]);
+function findOpenInlineCodeSpanStart(text: string): number | null {
+	let openDelimiter: number | null = null;
+
+	for (let i = 0; i < text.length; ) {
+		if (text[i] !== "`") {
+			i += 1;
+			continue;
+		}
+
+		let runEnd = i + 1;
+		while (text[runEnd] === "`") runEnd += 1;
+		if (runEnd - i !== 1) {
+			i = runEnd;
+			continue;
+		}
+
+		let backslashCount = 0;
+		for (let j = i - 1; j >= 0 && text[j] === "\\"; j -= 1) backslashCount += 1;
+		if (backslashCount % 2 === 0) openDelimiter = openDelimiter === null ? i : null;
+		i = runEnd;
+	}
+
+	return openDelimiter;
+}
+export function isInsideInlineCodeSpan(text: string): boolean {
+	return findOpenInlineCodeSpanStart(text) !== null;
+}
 
 export function extractSlashCommandTokenPrefix(text: string): string | null {
 	const slashIndex = text.lastIndexOf("/");
 	if (slashIndex === -1) return null;
+	if (isInsideInlineCodeSpan(text.slice(0, slashIndex + 1))) return null;
 
 	const token = text.slice(slashIndex);
 	if (/[\s]/.test(token)) return null;
@@ -556,7 +584,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 
 		const lastDelimiterIndex = findLastDelimiter(text);
-		const pathPrefix = lastDelimiterIndex === -1 ? text : text.slice(lastDelimiterIndex + 1);
+		const inlineCodeStart = findOpenInlineCodeSpanStart(text);
+		const prefixStart = Math.max(lastDelimiterIndex, inlineCodeStart ?? -1);
+		const pathPrefix = prefixStart === -1 ? text : text.slice(prefixStart + 1);
 
 		// For forced extraction (Tab key), always return something
 		if (forceExtract) {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -3,6 +3,7 @@ import {
 	type AutocompleteProvider,
 	type CombinedAutocompleteProvider,
 	extractSlashCommandTokenPrefix,
+	isInsideInlineCodeSpan,
 } from "../autocomplete";
 import { BracketedPasteHandler } from "../bracketed-paste";
 import { getKeybindings, type KeybindingsManager } from "../keybindings";
@@ -459,6 +460,7 @@ export class Editor implements Component, Focusable {
 	#autocompleteState: "regular" | "force" | null = null;
 	#autocompletePrefix: string = "";
 	#autocompleteRequestId: number = 0;
+	#autocompleteOrigin?: { docVersion: number; cursorLine: number; cursorCol: number };
 	#autocompleteMaxVisible: number = 5;
 	onAutocompleteUpdate?: () => void;
 
@@ -1201,6 +1203,11 @@ export class Editor implements Component, Focusable {
 
 				// If Tab was pressed, always apply the selection
 				if (kb.matches(data, "tui.input.tab")) {
+					if (!this.#isAutocompleteSelectionCurrent()) {
+						this.#cancelAutocomplete();
+						this.#handleTabCompletion();
+						return;
+					}
 					const selected = this.#autocompleteList.getSelectedItem();
 					if (selected && this.#autocompleteProvider) {
 						const shouldChainSlashCommandAutocomplete = this.#isSlashCommandNameAutocompleteSelection();
@@ -1234,36 +1241,38 @@ export class Editor implements Component, Focusable {
 				}
 
 				// If Enter was pressed on a slash command, apply completion and submit
-				if ((kb.matches(data, "tui.input.submit") || data === "\n") && this.#autocompletePrefix.startsWith("/")) {
-					// Check for stale autocomplete state due to debounce
-					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
-					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-					if (!currentTextBeforeCursor.endsWith(this.#autocompletePrefix)) {
-						// Autocomplete is stale - cancel and fall through to normal submission
+				if (
+					(kb.matches(data, "tui.input.submit") || data === "\n") &&
+					this.#autocompleteState === "regular" &&
+					this.#autocompletePrefix.startsWith("/")
+				) {
+					const selected = this.#autocompleteList.getSelectedItem();
+					if (!this.#isAutocompleteSelectionCurrent()) {
 						this.#cancelAutocomplete();
-					} else {
-						const selected = this.#autocompleteList.getSelectedItem();
-						if (selected && this.#autocompleteProvider) {
-							const result = this.#autocompleteProvider.applyCompletion(
-								this.#state.lines,
-								this.#state.cursorLine,
-								this.#state.cursorCol,
-								selected,
-								this.#autocompletePrefix,
-							);
+					} else if (selected && this.#autocompleteProvider) {
+						const result = this.#autocompleteProvider.applyCompletion(
+							this.#state.lines,
+							this.#state.cursorLine,
+							this.#state.cursorCol,
+							selected,
+							this.#autocompletePrefix,
+						);
 
-							this.#state.lines = result.lines;
-							this.#bumpDocumentVersion();
-							this.#state.cursorLine = result.cursorLine;
-							this.#setCursorCol(result.cursorCol);
-							result.onApplied?.();
-						}
+						this.#state.lines = result.lines;
+						this.#bumpDocumentVersion();
+						this.#state.cursorLine = result.cursorLine;
+						this.#setCursorCol(result.cursorCol);
+						result.onApplied?.();
 						this.#cancelAutocomplete();
 					}
 					// Don't return - fall through to submission logic
 				}
 				// If Enter was pressed on a file path, apply completion
 				else if (kb.matches(data, "tui.input.submit") || data === "\n") {
+					if (!this.#isAutocompleteSelectionCurrent()) {
+						this.#cancelAutocomplete();
+						return;
+					}
 					const selected = this.#autocompleteList.getSelectedItem();
 					if (selected && this.#autocompleteProvider) {
 						const result = this.#autocompleteProvider.applyCompletion(
@@ -1863,9 +1872,17 @@ export class Editor implements Component, Focusable {
 
 		// Check if we should trigger or update autocomplete
 		if (!this.#autocompleteState) {
-			// Auto-trigger for slash command tokens.
-			if (char === "/" && (this.#isAtStartOfSubmittedMessage() || this.#isInSlashTokenContext())) {
-				this.#tryTriggerAutocomplete();
+			// Auto-trigger slash commands, or path-only completion inside inline code.
+			if (char === "/") {
+				const currentLine = this.#state.lines[this.#state.cursorLine] || "";
+				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
+				if (this.#isInSubmittedSlashCommandContext()) {
+					this.#tryTriggerAutocomplete();
+				} else if (isInsideInlineCodeSpan(textBeforeCursor)) {
+					this.#forceFileAutocomplete();
+				} else if (this.#isInSlashTokenContext()) {
+					this.#tryTriggerAutocomplete();
+				}
 			}
 			// Auto-trigger for "@" file reference (fuzzy search)
 			else if (char === "@") {
@@ -2771,14 +2788,6 @@ export class Editor implements Component, Focusable {
 		return true;
 	}
 
-	// Slash commands execute only when the submitted prompt starts with the command.
-	#isAtStartOfSubmittedMessage(): boolean {
-		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
-		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
-
-		return this.#hasOnlyWhitespaceBeforeCursorLine() && (beforeCursor.trim() === "" || beforeCursor.trim() === "/");
-	}
-
 	#isInSubmittedSlashCommandContext(): boolean {
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
@@ -2793,6 +2802,30 @@ export class Editor implements Component, Focusable {
 
 	#isInSlashTokenContext(): boolean {
 		return this.#getSlashTokenBeforeCursor() !== null;
+	}
+	#isAutocompleteSelectionCurrent(): boolean {
+		if (!this.#isAutocompleteOriginCurrent()) return false;
+		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
+		const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
+		if (!textBeforeCursor.endsWith(this.#autocompletePrefix)) return false;
+		if (this.#autocompleteState !== "regular" || !this.#autocompletePrefix.startsWith("/")) return true;
+		return extractSlashCommandTokenPrefix(textBeforeCursor) === this.#autocompletePrefix;
+	}
+	#captureAutocompleteOrigin(): { docVersion: number; cursorLine: number; cursorCol: number } {
+		return {
+			docVersion: this.#docVersion,
+			cursorLine: this.#state.cursorLine,
+			cursorCol: this.#state.cursorCol,
+		};
+	}
+
+	#isAutocompleteOriginCurrent(origin = this.#autocompleteOrigin): boolean {
+		return (
+			origin !== undefined &&
+			origin.docVersion === this.#docVersion &&
+			origin.cursorLine === this.#state.cursorLine &&
+			origin.cursorCol === this.#state.cursorCol
+		);
 	}
 
 	#isSlashCommandNameAutocompleteSelection(): boolean {
@@ -2835,6 +2868,7 @@ export class Editor implements Component, Focusable {
 			}
 		}
 
+		const origin = this.#captureAutocompleteOrigin();
 		const requestId = ++this.#autocompleteRequestId;
 
 		const suggestions = await this.#autocompleteProvider.getSuggestions(
@@ -2842,12 +2876,13 @@ export class Editor implements Component, Focusable {
 			this.#state.cursorLine,
 			this.#state.cursorCol,
 		);
-		if (requestId !== this.#autocompleteRequestId) return;
+		if (requestId !== this.#autocompleteRequestId || !this.#isAutocompleteOriginCurrent(origin)) return;
 
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
 			this.#autocompletePrefix = suggestions.prefix;
 			this.#autocompleteList = this.#createAutocompleteList(suggestions.prefix, suggestions.items);
 			this.#autocompleteState = "regular";
+			this.#autocompleteOrigin = origin;
 			this.onAutocompleteUpdate?.();
 		} else {
 			this.#cancelAutocomplete();
@@ -2907,13 +2942,14 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 			return;
 		}
 
+		const origin = this.#captureAutocompleteOrigin();
 		const requestId = ++this.#autocompleteRequestId;
 		const suggestions = await provider.getForceFileSuggestions(
 			this.#state.lines,
 			this.#state.cursorLine,
 			this.#state.cursorCol,
 		);
-		if (requestId !== this.#autocompleteRequestId) return;
+		if (requestId !== this.#autocompleteRequestId || !this.#isAutocompleteOriginCurrent(origin)) return;
 
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
 			// If there's exactly one suggestion and this was an explicit Tab press, apply it immediately
@@ -2941,6 +2977,7 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 			this.#autocompletePrefix = suggestions.prefix;
 			this.#autocompleteList = this.#createAutocompleteList(suggestions.prefix, suggestions.items);
 			this.#autocompleteState = "force";
+			this.#autocompleteOrigin = origin;
 			this.onAutocompleteUpdate?.();
 		} else {
 			this.#cancelAutocomplete();
@@ -2955,6 +2992,7 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 		this.#autocompleteRequestId += 1;
 		this.#autocompleteState = null;
 		this.#autocompleteList = undefined;
+		this.#autocompleteOrigin = undefined;
 		this.#autocompletePrefix = "";
 		if (notifyCancel && wasAutocompleting) {
 			this.onAutocompleteCancel?.();
@@ -2974,6 +3012,7 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 			return;
 		}
 
+		const origin = this.#captureAutocompleteOrigin();
 		const requestId = ++this.#autocompleteRequestId;
 
 		const suggestions = await this.#autocompleteProvider.getSuggestions(
@@ -2981,12 +3020,13 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 			this.#state.cursorLine,
 			this.#state.cursorCol,
 		);
-		if (requestId !== this.#autocompleteRequestId) return;
+		if (requestId !== this.#autocompleteRequestId || !this.#isAutocompleteOriginCurrent(origin)) return;
 
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
 			this.#autocompletePrefix = suggestions.prefix;
 			// Always create new SelectList to ensure update
 			this.#autocompleteList = this.#createAutocompleteList(suggestions.prefix, suggestions.items);
+			this.#autocompleteOrigin = origin;
 			this.onAutocompleteUpdate?.();
 		} else {
 			this.#cancelAutocomplete();

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { CombinedAutocompleteProvider } from "@gajae-code/tui/autocomplete";
+import { CombinedAutocompleteProvider, extractSlashCommandTokenPrefix } from "@gajae-code/tui/autocomplete";
 
 describe("CombinedAutocompleteProvider", () => {
 	describe("extractPathPrefix", () => {
@@ -166,6 +166,62 @@ describe("CombinedAutocompleteProvider", () => {
 			const values = result?.items.map(item => item.value) ?? [];
 			expect(values).toContain("./src/");
 		});
+	});
+});
+
+describe("inline backtick slash classification", () => {
+	it.each([
+		["open span", "please use `/mo", null],
+		["closed span", "please use `/mo` then /he", "/he"],
+		["multiple spans", "`/mo` and `/he", null],
+		["odd escaped delimiter", "please use \\`/mo", "/mo"],
+		["even escaped delimiter", "please use \\\\`/mo", null],
+		["double-backtick run", "please use ``/mo", "/mo"],
+		["triple-backtick run", "please use ```/mo", "/mo"],
+	])("handles %s", (_name, text, expected) => {
+		expect(extractSlashCommandTokenPrefix(text)).toBe(expected);
+	});
+
+	it("resets literal state at line boundaries", () => {
+		expect(extractSlashCommandTokenPrefix("/mo")).toBe("/mo");
+	});
+
+	it("preserves path suggestions inside an open inline-code span", async () => {
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-backtick-test-"));
+		try {
+			fs.mkdirSync(path.join(baseDir, "src", "foo"), { recursive: true });
+			fs.writeFileSync(path.join(baseDir, "src", "foo", "bar.ts"), "export {};\n");
+			const provider = new CombinedAutocompleteProvider(
+				[{ name: "model", description: "Switch AI model", value: "model" }],
+				baseDir,
+			);
+			const line = "please read `src/foo/";
+			const result = await provider.getSuggestions([line], 0, line.length);
+
+			expect(result?.prefix).toBe("src/foo/");
+			expect(result?.items.map(item => item.value)).toContain("src/foo/bar.ts");
+			expect(result?.items.map(item => item.value)).not.toContain("model");
+		} finally {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+	it("preserves submitted command argument completion inside backticks", async () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{
+					name: "read",
+					getArgumentCompletions: argumentPrefix => [
+						{ value: argumentPrefix, label: "existing argument completion" },
+					],
+				},
+			],
+			"/tmp",
+		);
+		const line = "/read `src/foo/";
+		const result = await provider.getSuggestions([line], 0, line.length);
+
+		expect(result?.prefix).toBe("`src/foo/");
+		expect(result?.items).toEqual([{ value: "`src/foo/", label: "existing argument completion" }]);
 	});
 });
 

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
 	type AutocompleteItem,
 	type AutocompleteProvider,
@@ -106,6 +109,64 @@ class SyncSlashProvider implements AutocompleteProvider {
 	callCount = 0;
 }
 
+class DelayedSlashProvider implements AutocompleteProvider {
+	async getSuggestions(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+		await Bun.sleep(30);
+		const textBeforeCursor = (lines[cursorLine] || "").slice(0, cursorCol);
+		const prefix = textBeforeCursor.slice(textBeforeCursor.lastIndexOf("/"));
+		return { prefix, items: [{ value: "model", label: "/model" }] };
+	}
+
+	applyCompletion(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+		item: AutocompleteItem,
+		prefix: string,
+	): { lines: string[]; cursorLine: number; cursorCol: number } {
+		this.applyCalls += 1;
+		const line = lines[cursorLine] || "";
+		const beforePrefix = line.slice(0, cursorCol - prefix.length);
+		const nextLines = [...lines];
+		nextLines[cursorLine] = `${beforePrefix}/${item.value}`;
+		return { lines: nextLines, cursorLine, cursorCol: beforePrefix.length + item.value.length + 1 };
+	}
+
+	applyCalls = 0;
+}
+
+class DelayedFileProvider implements AutocompleteProvider {
+	async getSuggestions(): Promise<null> {
+		return null;
+	}
+
+	async getForceFileSuggestions(): Promise<{ items: AutocompleteItem[]; prefix: string }> {
+		await Bun.sleep(30);
+		return { prefix: "src/", items: [{ value: "src/file.ts", label: "file.ts" }] };
+	}
+
+	applyCompletion(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+		item: AutocompleteItem,
+		prefix: string,
+	): { lines: string[]; cursorLine: number; cursorCol: number } {
+		this.applyCalls += 1;
+		const line = lines[cursorLine] || "";
+		const beforePrefix = line.slice(0, cursorCol - prefix.length);
+		const nextLines = [...lines];
+		nextLines[cursorLine] = beforePrefix + item.value + line.slice(cursorCol);
+		return { lines: nextLines, cursorLine, cursorCol: beforePrefix.length + item.value.length };
+	}
+
+	applyCalls = 0;
+}
+
 class InlineSkillProvider implements AutocompleteProvider {
 	async getSuggestions(
 		lines: string[],
@@ -125,6 +186,12 @@ class InlineSkillProvider implements AutocompleteProvider {
 			prefix,
 			items: [{ value: "skill:team", label: "skill:team" }],
 		};
+	}
+	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
+		this.syncCallCount += 1;
+		const prefix = textBeforeCursor.slice(textBeforeCursor.lastIndexOf("/"));
+		if (!prefix.startsWith("/skill")) return null;
+		return { prefix, items: [{ value: "skill:team", label: "skill:team" }] };
 	}
 
 	applyCompletion(
@@ -147,6 +214,7 @@ class InlineSkillProvider implements AutocompleteProvider {
 	}
 
 	suggestionCalls = 0;
+	syncCallCount = 0;
 }
 describe("Editor Enter handler sync slash completion", () => {
 	it("auto-triggers slash command autocomplete from an inline slash after prompt text", async () => {
@@ -169,6 +237,127 @@ describe("Editor Enter handler sync slash completion", () => {
 
 		editor.handleInput("explain this/");
 		await Bun.sleep(0);
+
+		expect(editor.isShowingAutocomplete()).toBe(true);
+	});
+	it("opens path-only autocomplete inside inline code", async () => {
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-backtick-path-"));
+		try {
+			fs.mkdirSync(path.join(baseDir, "src"), { recursive: true });
+			fs.writeFileSync(path.join(baseDir, "src", "file.ts"), "export {};\n");
+			const editor = new Editor(defaultEditorTheme);
+			editor.setAutocompleteProvider(
+				new CombinedAutocompleteProvider([{ name: "model", description: "Switch model", value: "model" }], baseDir),
+			);
+			let submitted = "";
+			editor.onSubmit = text => {
+				submitted = text;
+			};
+			editor.setText("please read `src");
+
+			editor.handleInput("/");
+			await Bun.sleep(20);
+
+			expect(editor.isShowingAutocomplete()).toBe(true);
+			editor.handleInput("\r");
+			editor.handleInput("\r");
+			expect(submitted).toBe("please read `src/file.ts");
+			expect(submitted).not.toContain("model");
+		} finally {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+	it("does not submit a forced absolute-path popup on the first Enter", async () => {
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-backtick-absolute-"));
+		try {
+			fs.mkdirSync(path.join(baseDir, "child"), { recursive: true });
+			const editor = new Editor(defaultEditorTheme);
+			editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], baseDir));
+			let submitted = "";
+			editor.onSubmit = text => {
+				submitted = text;
+			};
+			editor.setText(`please read \`${baseDir}`);
+
+			editor.handleInput("/");
+			await Bun.sleep(20);
+			expect(editor.isShowingAutocomplete()).toBe(true);
+			editor.handleInput("\r");
+
+			expect(submitted).toBe("");
+			expect(editor.getText()).toBe(`please read \`${baseDir}/child/`);
+			editor.handleInput("\r");
+			expect(submitted).toBe(`please read \`${baseDir}/child/`);
+		} finally {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+	it("rejects a forced absolute-path popup after cursor relocation", async () => {
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-backtick-absolute-origin-"));
+		try {
+			fs.mkdirSync(path.join(baseDir, "child"), { recursive: true });
+			const editor = new Editor(defaultEditorTheme);
+			editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], baseDir));
+			let submitted = "";
+			editor.onSubmit = text => {
+				submitted = text;
+			};
+			const original = `please read \`${baseDir}/`;
+			editor.setText(`please read \`${baseDir}`);
+
+			editor.handleInput("/");
+			await Bun.sleep(20);
+			expect(editor.isShowingAutocomplete()).toBe(true);
+			editor.moveToLineStart();
+			editor.handleInput("\r");
+
+			expect(submitted).toBe("");
+			expect(editor.getText()).toBe(original);
+		} finally {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a settled forced relative-path popup after cursor relocation", async () => {
+		const provider = new DelayedFileProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		editor.setText("please read `src");
+
+		editor.handleInput("/");
+		await Bun.sleep(50);
+		expect(editor.isShowingAutocomplete()).toBe(true);
+		editor.moveToLineStart();
+		editor.handleInput("\t");
+
+		expect(provider.applyCalls).toBe(0);
+		expect(editor.getText()).toBe("please read `src/");
+	});
+
+	it("discards a delayed forced path result after cursor relocation", async () => {
+		const provider = new DelayedFileProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		editor.setText("please read `src");
+
+		editor.handleInput("/");
+		editor.moveToLineStart();
+		await Bun.sleep(50);
+
+		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(provider.applyCalls).toBe(0);
+		expect(editor.getText()).toBe("please read `src/");
+	});
+
+	it("restores command autocomplete after a closed inline-code span", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider([{ name: "model", description: "Switch model", value: "model" }], "/tmp"),
+		);
+
+		editor.setText("`/literal` then /m");
+		editor.handleInput("o");
+		await Bun.sleep(20);
 
 		expect(editor.isShowingAutocomplete()).toBe(true);
 	});
@@ -199,6 +388,104 @@ describe("Editor Enter handler sync slash completion", () => {
 		editor.handleInput("\r");
 
 		expect(submitted).toBe("explain with /skill:team");
+	});
+	it("submits an inline-code skill token without synchronous Enter completion", () => {
+		const provider = new InlineSkillProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("please use `/skill-te");
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("please use `/skill-te");
+		expect(provider.syncCallCount).toBe(0);
+	});
+	it("preserves submitted-command argument completion inside inline code", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider(
+				[
+					{
+						name: "read",
+						getArgumentCompletions: () => [{ value: "argument-choice", label: "argument choice" }],
+					},
+				],
+				"/tmp",
+			),
+		);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+		editor.setText("/read `src/foo");
+
+		editor.handleInput("/");
+		await Bun.sleep(20);
+		expect(editor.isShowingAutocomplete()).toBe(true);
+		editor.handleInput("\r");
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("/read argument-choice");
+	});
+	it("rejects a stale command selection after an opening backtick is inserted", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider([{ name: "model", description: "Switch model", value: "model" }], "/tmp"),
+		);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.setText("/m");
+		editor.handleInput("o");
+		await Bun.sleep(20);
+		expect(editor.isShowingAutocomplete()).toBe(true);
+		editor.moveToLineStart();
+		editor.handleInput("`");
+		editor.moveToLineEnd();
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("`/mo");
+	});
+	it("rejects a stale command selection on Tab after a backtick insertion", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider([{ name: "model", description: "Switch model", value: "model" }], "/tmp"),
+		);
+
+		editor.setText("/m");
+		editor.handleInput("o");
+		await Bun.sleep(20);
+		expect(editor.isShowingAutocomplete()).toBe(true);
+		editor.moveToLineStart();
+		editor.handleInput("`");
+		editor.moveToLineEnd();
+		editor.handleInput("\t");
+		await Bun.sleep(20);
+
+		expect(editor.getText()).toBe("`/mo");
+	});
+
+	it("rejects a command popup that resolves after literal context changes", async () => {
+		const provider = new DelayedSlashProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+
+		editor.setText("/m");
+		editor.handleInput("o");
+		editor.moveToLineStart();
+		editor.handleInput("`");
+		editor.moveToLineEnd();
+		await Bun.sleep(50);
+		expect(editor.isShowingAutocomplete()).toBe(false);
+
+		expect(provider.applyCalls).toBe(0);
+		expect(editor.getText()).toBe("`/mo");
 	});
 
 	it("completes slash command synchronously before async resolves and submits", () => {


### PR DESCRIPTION
## Summary
- classify line-local single-backtick spans with escape-parity and delimiter-run handling
- suppress command/skill matching and stale Enter/Tab dispatch inside literals while preserving submitted-command argument completers
- preserve origin-bound relative and absolute path completion inside literals
- add hostile tokenizer, popup, async race, Enter, Tab, and path regression coverage

Closes #2619

## Verification
- focused regression suite — 85 pass
- TUI package check and complete suite — 811 pass
- coding-agent package check
- GJC visible-definition, G002, strict rebrand, and default-definition gates
- fresh exact-diff architect review: CLEAR, no P0/P1/P2 findings

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*