### PR TITLE
fix(coding-agent): make worktree cleanup report-only and containment-safe

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -29,6 +29,7 @@ jobs:
       plan_mode: ${{ steps.plan.outputs.plan_mode }}
       plan_digest: ${{ steps.plan.outputs.plan_digest }}
       plan_source_sha: ${{ steps.plan.outputs.plan_source_sha }}
+      worktree_safety_required: ${{ steps.plan.outputs.worktree_safety_required }}
     env:
       GITHUB_EVENT_BEFORE: ${{ github.event.before }}
       GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -65,6 +66,44 @@ jobs:
           retention-days: 1
           overwrite: true
 
+  worktree-safety:
+    name: Worktree safety / ${{ matrix.os }}
+    needs: [affected-plan]
+    if: ${{ needs.affected-plan.outputs.worktree_safety_required == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    env:
+      CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      CI_DEV_AFFECTED_PLAN: .ci-dev-affected-plan.json
+      CI_DEV_PLAN_DIGEST: ${{ needs.affected-plan.outputs.plan_digest }}
+      CI_DEV_PLAN_SOURCE_SHA: ${{ needs.affected-plan.outputs.plan_source_sha }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify checked-out source head
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          test "$head" = "$CI_DEV_SOURCE_SHA" || { echo "Checked-out SHA $head does not match $CI_DEV_SOURCE_SHA"; exit 1; }
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3"
+      - run: bun install --frozen-lockfile
+      - name: Download canonical affected plan
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: dev-affected-plan-${{ github.run_id }}
+      - run: bun scripts/ci-dev-affected.ts --validate-plan
+      - run: bun test packages/coding-agent/test/worktree-cli.test.ts
+      - run: bun test scripts/check-worktree-report-capabilities.test.ts
+      - run: bun scripts/check-worktree-report-capabilities.ts
+      - working-directory: packages/coding-agent
+        run: bun run check
   windows-dev-doctor:
     name: Windows dev:doctor
     needs: [affected-plan]
@@ -301,7 +340,7 @@ jobs:
   affected-evidence-producer:
     name: Affected path validation / evidence producer
     if: ${{ always() }}
-    needs: [affected-plan, affected-native, affected-shards, windows-dev-doctor]
+    needs: [affected-plan, affected-native, affected-shards, windows-dev-doctor, worktree-safety]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
@@ -315,6 +354,8 @@ jobs:
       CI_DEV_SHARD_RECEIPTS: .ci-dev-shard-receipts
       CI_DEV_EVIDENCE_ROOT: .
       CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      CI_DEV_WORKTREE_SAFETY_RESULT: ${{ needs.worktree-safety.result }}
+      CI_DEV_WORKTREE_SAFETY_REQUIRED: ${{ needs.affected-plan.outputs.worktree_safety_required }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -367,7 +408,7 @@ jobs:
   affected:
     name: Affected path validation
     if: ${{ always() }}
-    needs: [affected-evidence-producer, affected-plan, affected-native, affected-shards, windows-dev-doctor]
+    needs: [affected-evidence-producer, affected-plan, affected-native, affected-shards, windows-dev-doctor, worktree-safety]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     env:
@@ -382,6 +423,8 @@ jobs:
       CI_DEV_HAS_TASKS: ${{ needs.affected-plan.outputs.has_tasks }}
       CI_DEV_WINDOWS_DOCTOR_RESULT: ${{ needs.windows-dev-doctor.result }}
       CI_DEV_WINDOWS_DOCTOR_REQUIRED: ${{ contains(needs.affected-plan.outputs.changed_paths, 'scripts/dev-link') }}
+      CI_DEV_WORKTREE_SAFETY_RESULT: ${{ needs.worktree-safety.result }}
+      CI_DEV_WORKTREE_SAFETY_REQUIRED: ${{ needs.affected-plan.outputs.worktree_safety_required }}
     steps:
       - name: Fail closed on producer and live dependency results
         env:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -103,7 +103,7 @@ jobs:
       - run: bun test scripts/check-worktree-report-capabilities.test.ts
       - run: bun scripts/check-worktree-report-capabilities.ts
       - working-directory: packages/coding-agent
-        run: bun run check
+        run: bun run check:types
   windows-dev-doctor:
     name: Windows dev:doctor
     needs: [affected-plan]

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Team worker launches now receive the validated owning `GJC_SESSION_ID` for sanctioned session-scoped writes while preserving absent identity, fail-closed resolution, and separate spawn provenance (#2597).
 - Managed and explicit session directories now canonicalize benign ancestor symlinks (e.g. macOS `/var -> /private/var`, a symlinked `$HOME` or project directory) to a symlink-free trusted root before the strict owner-only and reparse guards run, so session creation, moves, resume, and writes no longer fail with `reparse_point` / `Unsafe reparse storage path` under a symlinked temp root or home. The native primitive stays strict and continues to reject symlinked components at or below the trusted root.
+- Worktree cleanup is report-only: `clear` removes zero entries and every `--all` form is disabled.
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -6,7 +6,7 @@
  */
 import "@gajae-code/utils/postmortem";
 import { Args, type CliConfig, Command, type CommandEntry, Flags, run } from "@gajae-code/utils/cli";
-import { APP_NAME, formatBunRuntimeError, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
+import { APP_NAME, formatBunRuntimeError, getWorktreesDir, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
 import { runFixtureReport } from "./cli/fixture-report";
 import { isTmuxOwnerIsolationCliArgv, runTmuxOwnerIsolationCliFromStdin } from "./gjc-runtime/tmux-owner-isolation-cli";
 
@@ -59,6 +59,14 @@ export const commands: CommandEntry[] = [
 	{ name: "plugin", load: () => import("./commands/plugin").then(m => m.default) },
 	{ name: "completion", load: () => import("./commands/completion").then(m => m.default) },
 	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },
+	{
+		name: "worktree",
+		aliases: ["wt"],
+		load: async () => {
+			const { createWorktreeCommand } = await import("./commands/worktree");
+			return createWorktreeCommand(getWorktreesDir);
+		},
+	},
 ];
 
 async function showHelp(config: CliConfig): Promise<void> {

--- a/packages/coding-agent/src/cli/worktree-cli.ts
+++ b/packages/coding-agent/src/cli/worktree-cli.ts
@@ -1,291 +1,71 @@
-/**
- * CLI handler for `gjc worktree` — list and clean up agent-managed worktrees.
- *
- * Layout under `~/.gjc/wt/`:
- *
- *   - **PR-checkout worktrees** (`tools/gh.ts`): a regular git worktree dir
- *     containing a `.git` *file* that points back at
- *     `<parent-repo>/.git/worktrees/<name>/`.
- *   - **Task-isolation dirs** (`task/worktree.ts`): a wrapper dir with a
- *     `merged` subdir mounted/cloned by `natives.isoStart`. These are ephemeral
- *     — `ensureIsolation` always `rm -rf`s the base before re-creating it, so
- *     any leftover on disk is a leak from a crashed run.
- *
- * Legacy entries from before the encoding change keep working because git still
- * tracks them by branch name. This command exists to GC them on demand.
- */
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
-import { getWorktreesDir, isEnoent } from "@gajae-code/utils";
-import chalk from "chalk";
-import * as git from "../utils/git";
+import {
+	scanWorktrees,
+	type WorktreeDiagnostic,
+	WorktreeRootError,
+	type WorktreeScannerPlatform,
+} from "./worktree-scanner";
 
-type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray";
-
-export interface WorktreeEntry {
-	/** Absolute path to the worktree dir (or stray container) under `~/.gjc/wt/`. */
-	path: string;
-	/** Classification of what we found on disk. */
-	kind: WorktreeKind;
-	/** Parent repo root, when this is a registered git worktree. */
-	parentRepo?: string;
-	/** Branch name extracted from the parent's tracking file, when available. */
-	branch?: string;
-	/** When set, the entry is unhealthy and `gjc worktree clear` will remove it. */
-	orphanReason?: string;
-}
-
-export interface ListWorktreesOptions {
+export interface RunWorktreeCommandOptions {
+	root: string;
+	platform: WorktreeScannerPlatform;
+	action: "list" | "clear";
 	json: boolean;
-}
-
-export interface ClearWorktreesOptions {
-	/** Remove every entry, including live PR-checkout worktrees. */
-	all: boolean;
-	/** Print what would be removed without touching the filesystem. */
 	dryRun: boolean;
-	json: boolean;
 }
 
-export async function listWorktrees(options: ListWorktreesOptions): Promise<void> {
-	const entries = await scanWorktrees();
-	if (options.json) {
-		console.log(JSON.stringify(entries, null, 2));
-		return;
-	}
-	if (entries.length === 0) {
-		console.log(chalk.dim(`No agent-managed worktrees found under ${getWorktreesDir()}.`));
-		return;
-	}
-	let live = 0;
-	let orphaned = 0;
-	for (const entry of entries) {
-		const tag = entry.orphanReason ? chalk.yellow("orphaned") : chalk.green("live    ");
-		const detail = formatEntryDetail(entry);
-		console.log(`${tag}  ${entry.path}`);
-		if (detail) console.log(`          ${chalk.dim(detail)}`);
-		if (entry.orphanReason) orphaned += 1;
-		else live += 1;
-	}
-	console.log(chalk.dim(`\n${live} live · ${orphaned} orphaned · ${entries.length} total`));
+export interface RunWorktreeCommandResult {
+	stdout: string;
+	stderr: string;
+	exitCode: 0 | 1;
 }
 
-export async function clearWorktrees(options: ClearWorktreesOptions): Promise<void> {
-	const entries = await scanWorktrees();
-	const targets = options.all ? entries : entries.filter(entry => entry.orphanReason !== undefined);
+const SCAN_ERROR_TEXT = "managed worktree root cannot be read";
 
-	if (targets.length === 0) {
-		if (options.json) {
-			console.log(JSON.stringify({ removed: 0, kept: entries.length }));
-		} else {
-			console.log(chalk.dim(options.all ? "No worktrees to remove." : "No orphaned worktrees to remove."));
-		}
-		return;
-	}
-
-	if (options.dryRun) {
-		if (options.json) {
-			console.log(JSON.stringify({ wouldRemove: targets.map(t => t.path) }, null, 2));
-		} else {
-			for (const target of targets) {
-				console.log(`${chalk.yellow("would remove")}  ${target.path}`);
-			}
-			console.log(chalk.dim(`\n${targets.length} dir${targets.length === 1 ? "" : "s"} would be removed.`));
-		}
-		return;
-	}
-
-	const results: { path: string; ok: boolean; error?: string }[] = [];
-	const parentsToPrune = new Set<string>();
-	for (const target of targets) {
-		try {
-			if (target.kind === "pr-checkout" && target.parentRepo && !target.orphanReason) {
-				// Live worktree: ask git to remove it cleanly. If git refuses (locked,
-				// dirty, etc.), fall back to fs.rm and rely on `worktree prune` to
-				// clean the bookkeeping on the parent side.
-				const removed = await git.worktree.tryRemove(target.parentRepo, target.path, { force: true });
-				if (!removed) {
-					await fs.rm(target.path, { recursive: true, force: true });
-					parentsToPrune.add(target.parentRepo);
+export async function runWorktreeCommand(options: RunWorktreeCommandOptions): Promise<RunWorktreeCommandResult> {
+	let diagnostics: WorktreeDiagnostic[];
+	try {
+		diagnostics = await scanWorktrees({ root: options.root, platform: options.platform });
+	} catch (error) {
+		if (!(error instanceof WorktreeRootError)) throw error;
+		return options.json
+			? {
+					stdout: `${JSON.stringify({ error: { code: "worktree_scan_failed", message: SCAN_ERROR_TEXT } })}\n`,
+					stderr: "",
+					exitCode: 1,
 				}
-			} else {
-				await fs.rm(target.path, { recursive: true, force: true });
-				if (target.parentRepo) parentsToPrune.add(target.parentRepo);
-			}
-			results.push({ path: target.path, ok: true });
-		} catch (err) {
-			results.push({ path: target.path, ok: false, error: err instanceof Error ? err.message : String(err) });
-		}
+			: { stdout: "", stderr: `error: ${SCAN_ERROR_TEXT}\n`, exitCode: 1 };
+	}
+	if (options.action === "list") {
+		if (options.json) return { stdout: `${JSON.stringify(diagnostics)}\n`, stderr: "", exitCode: 0 };
+		if (diagnostics.length === 0) return { stdout: "No agent-managed worktrees found.\n", stderr: "", exitCode: 0 };
+		return {
+			stdout: `${diagnostics.map(formatDiagnostic).join("\n")}\n\n${diagnostics.length} total\n`,
+			stderr: "",
+			exitCode: 0,
+		};
 	}
 
-	// Best-effort: drop stale entries from each affected parent's `.git/worktrees/`.
-	for (const parent of parentsToPrune) {
-		try {
-			await git.worktree.prune(parent);
-		} catch {
-			/* parent repo may already be gone or pruned — ignore */
+	if (options.dryRun || diagnostics.length === 0) {
+		if (options.json) {
+			return {
+				stdout: `${JSON.stringify(options.dryRun ? { wouldRemove: [] } : { removed: 0, kept: 0 })}\n`,
+				stderr: "",
+				exitCode: 0,
+			};
 		}
+		return { stdout: "No worktrees are eligible for removal; cleanup is report-only.\n", stderr: "", exitCode: 0 };
 	}
-
-	const succeeded = results.filter(r => r.ok).length;
-	const failed = results.length - succeeded;
 
 	if (options.json) {
-		console.log(JSON.stringify({ removed: succeeded, failed, results }, null, 2));
-		if (failed > 0) process.exitCode = 1;
-		return;
+		return { stdout: `${JSON.stringify({ removed: 0, kept: diagnostics.length })}\n`, stderr: "", exitCode: 0 };
 	}
-
-	for (const result of results) {
-		if (result.ok) {
-			console.log(`${chalk.green("removed")}  ${result.path}`);
-		} else {
-			console.log(`${chalk.red("failed ")}  ${result.path}`);
-			if (result.error) console.log(`          ${chalk.dim(result.error)}`);
-		}
-	}
-	console.log(chalk.dim(`\n${succeeded} removed${failed > 0 ? ` · ${chalk.red(`${failed} failed`)}` : ""}`));
-	if (failed > 0) process.exitCode = 1;
+	return {
+		stdout: `${diagnostics.map(diagnostic => `kept    ${diagnostic.path}`).join("\n")}\n\n0 removed · ${diagnostics.length} kept\n`,
+		stderr: "",
+		exitCode: 0,
+	};
 }
 
-// ───────────────────────────────────────────────────────────────────────────
-// Scanner
-// ───────────────────────────────────────────────────────────────────────────
-
-async function scanWorktrees(): Promise<WorktreeEntry[]> {
-	const root = getWorktreesDir();
-	let topLevel: string[];
-	try {
-		topLevel = await fs.readdir(root);
-	} catch (err) {
-		if (isEnoent(err)) return [];
-		throw err;
-	}
-
-	const entries: WorktreeEntry[] = [];
-	for (const name of topLevel) {
-		const dir = path.join(root, name);
-		const stat = await fs.stat(dir).catch(() => null);
-		if (!stat?.isDirectory()) continue;
-
-		const direct = await classifyDir(dir);
-		if (direct) {
-			entries.push(direct);
-			continue;
-		}
-
-		// Legacy nesting: ~/.gjc/wt/<encoded-project>/<branch-or-id>
-		let children: string[];
-		try {
-			children = await fs.readdir(dir);
-		} catch {
-			continue;
-		}
-		let nested = 0;
-		for (const child of children) {
-			const childDir = path.join(dir, child);
-			const childStat = await fs.stat(childDir).catch(() => null);
-			if (!childStat?.isDirectory()) continue;
-			const childClassified = await classifyDir(childDir);
-			if (childClassified) {
-				entries.push(childClassified);
-				nested += 1;
-			}
-		}
-		if (nested === 0) {
-			entries.push({
-				path: dir,
-				kind: children.length === 0 ? "empty" : "stray",
-				orphanReason: children.length === 0 ? "empty directory" : "no recognizable worktree contents",
-			});
-		}
-	}
-	return entries;
-}
-
-async function classifyDir(dir: string): Promise<WorktreeEntry | null> {
-	const gitEntry = path.join(dir, ".git");
-	const gitStat = await fs.stat(gitEntry).catch(() => null);
-	if (gitStat?.isFile()) {
-		return classifyPrCheckout(dir, gitEntry);
-	}
-	const mergedStat = await fs.stat(path.join(dir, "merged")).catch(() => null);
-	if (mergedStat?.isDirectory()) {
-		return {
-			path: dir,
-			kind: "task-isolation",
-			orphanReason: "task-isolation leftover (no live task owns it)",
-		};
-	}
-	return null;
-}
-
-async function classifyPrCheckout(dir: string, gitEntry: string): Promise<WorktreeEntry> {
-	let contents: string;
-	try {
-		contents = await fs.readFile(gitEntry, "utf8");
-	} catch (err) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			orphanReason: `cannot read .git file: ${err instanceof Error ? err.message : String(err)}`,
-		};
-	}
-	const match = /^gitdir:\s*(.+?)\s*$/m.exec(contents);
-	const parentGitDir = match?.[1];
-	if (!parentGitDir) {
-		return { path: dir, kind: "pr-checkout", orphanReason: "malformed .git file (no gitdir line)" };
-	}
-	// parentGitDir is `<parent-repo>/.git/worktrees/<name>`; back out the repo root.
-	const parentRepo = path.dirname(path.dirname(path.dirname(parentGitDir)));
-	const branch = await readWorktreeBranch(path.join(parentGitDir, "HEAD"));
-
-	const parentDirStat = await fs.stat(parentGitDir).catch(() => null);
-	if (!parentDirStat?.isDirectory()) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			parentRepo,
-			branch,
-			orphanReason: "parent repo no longer tracks this worktree",
-		};
-	}
-	const parentRepoStat = await fs.stat(parentRepo).catch(() => null);
-	if (!parentRepoStat?.isDirectory()) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			parentRepo,
-			branch,
-			orphanReason: "parent repo missing",
-		};
-	}
-	return { path: dir, kind: "pr-checkout", parentRepo, branch };
-}
-
-async function readWorktreeBranch(headFile: string): Promise<string | undefined> {
-	try {
-		const head = (await fs.readFile(headFile, "utf8")).trim();
-		const refMatch = /^ref:\s*refs\/heads\/(.+)$/.exec(head);
-		return refMatch?.[1];
-	} catch {
-		return undefined;
-	}
-}
-
-function formatEntryDetail(entry: WorktreeEntry): string {
-	const parts: string[] = [];
-	if (entry.kind === "pr-checkout") {
-		const repo = entry.parentRepo ? path.basename(entry.parentRepo) : "unknown repo";
-		const branch = entry.branch ?? "unknown branch";
-		parts.push(`${repo} · ${branch}`);
-	} else if (entry.kind === "task-isolation") {
-		parts.push("task-isolation sandbox");
-	} else if (entry.kind === "empty") {
-		parts.push("legacy project shell");
-	} else {
-		parts.push("unrecognized contents");
-	}
-	if (entry.orphanReason) parts.push(entry.orphanReason);
-	return parts.join(" — ");
+function formatDiagnostic(diagnostic: WorktreeDiagnostic): string {
+	return `diagnostic  ${diagnostic.path}  ${diagnostic.message}`;
 }

--- a/packages/coding-agent/src/cli/worktree-scanner.ts
+++ b/packages/coding-agent/src/cli/worktree-scanner.ts
@@ -1,0 +1,698 @@
+import { type BigIntStats, constants } from "node:fs";
+import { type FileHandle, lstat, open, readdir } from "node:fs/promises";
+import * as path from "node:path";
+
+export const MAX_ENTRIES = 1024;
+export type WorktreeRootErrorCode = "root-unreadable" | "root-invalid";
+export class WorktreeRootError extends Error {
+	constructor(readonly code: WorktreeRootErrorCode) {
+		super(code === "root-invalid" ? "managed worktree root is invalid" : "managed worktree root cannot be read");
+	}
+}
+export const MAX_DEPTH = 2;
+export const MAX_NAME_UTF8_BYTES = 255;
+export const MAX_METADATA_BYTES = 65536;
+export const METADATA_RESERVATION_BYTES = 65537;
+export const MAX_TOTAL_METADATA_BYTES = 1048576;
+const CHUNK_BYTES = 8192;
+const DISPLAY_BYTES = 512;
+const TRUNCATED_SUFFIX = "…[truncated]";
+
+export type WorktreeScannerPlatform = "posix" | "win32";
+type ComponentResult = "ok" | "outside" | "link" | "race" | "io" | "not-directory";
+type MetadataFamily = "git" | "head" | "commondir" | "gitdir";
+type MetadataFailure = "link" | "race" | "unreadable" | "oversize" | "invalid-utf8" | "nul";
+export interface ScanWorktreesOptions {
+	root: string;
+	platform: WorktreeScannerPlatform;
+}
+export type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray" | "overflow" | "unsupported";
+export interface WorktreeDiagnostic {
+	path: string;
+	kind: WorktreeKind;
+	reasonCode: string;
+	message: string;
+}
+interface Identity {
+	dev: bigint;
+	ino: bigint;
+}
+interface ScanState {
+	visited: number;
+	reserved: number;
+	halted: boolean;
+	platform: WorktreeScannerPlatform;
+	diagnostics: WorktreeDiagnostic[];
+	root: string;
+	rootIdentity: Identity;
+}
+type RawDirectoryEntry = string | Uint8Array | { name: string | Uint8Array };
+
+function nameBytes(name: string | Buffer): Buffer {
+	return Buffer.isBuffer(name) ? name : Buffer.from(name);
+}
+function rawEscapeUnits(raw: string | Buffer, oversize: boolean): string[] {
+	const bytes = nameBytes(raw);
+	const bounded = oversize ? bytes.subarray(0, MAX_NAME_UTF8_BYTES) : bytes;
+	const units: string[] = [];
+	for (const b of bounded) {
+		if (b >= 0x20 && b <= 0x7e && b !== 0x5c) units.push(String.fromCharCode(b));
+		else if (b === 0x5c) units.push("\\\\");
+		else if (b === 0x0a) units.push("\\n");
+		else if (b === 0x0d) units.push("\\r");
+		else if (b === 0x09) units.push("\\t");
+		else units.push(`%${b.toString(16).toUpperCase().padStart(2, "0")}`);
+	}
+	return units;
+}
+function stringEscapeUnits(value: string): string[] {
+	const units: string[] = [];
+	for (const ch of value) {
+		const code = ch.codePointAt(0) as number;
+		if (code >= 0x20 && code <= 0x7e && code !== 0x5c) units.push(ch);
+		else if (code === 0x5c) units.push("\\\\");
+		else if (code === 0x0a) units.push("\\n");
+		else if (code === 0x0d) units.push("\\r");
+		else if (code === 0x09) units.push("\\t");
+		else {
+			for (let index = 0; index < ch.length; index++) {
+				const unit = ch.charCodeAt(index);
+				units.push(`\\u${unit.toString(16).toUpperCase().padStart(4, "0")}`);
+			}
+		}
+	}
+	return units;
+}
+function stringPathUnits(value: string): string[] {
+	if (value === "/") return ["/"];
+	const units: string[] = [];
+	const components = value.split("/");
+	for (const [index, component] of components.entries()) {
+		if (index > 0) units.push("/");
+		units.push(...stringEscapeUnits(component));
+	}
+	return units;
+}
+function truncateEscaped(units: readonly string[], forceSuffix = false): string {
+	const encoded = units.join("");
+	if (!forceSuffix && Buffer.byteLength(encoded) <= DISPLAY_BYTES) return encoded;
+	const kept: string[] = [];
+	let bytes = Buffer.byteLength(TRUNCATED_SUFFIX);
+	for (const unit of units) {
+		const unitBytes = Buffer.byteLength(unit);
+		if (bytes + unitBytes > DISPLAY_BYTES) break;
+		kept.push(unit);
+		bytes += unitBytes;
+	}
+	return kept.join("") + TRUNCATED_SUFFIX;
+}
+function displayPath(value: string): string {
+	return truncateEscaped(stringPathUnits(value));
+}
+function displayRawPath(dir: string, raw: string | Buffer, oversize: boolean): string {
+	const units = stringPathUnits(dir);
+	if (dir !== "/") units.push("/");
+	units.push(...rawEscapeUnits(raw, oversize));
+	return truncateEscaped(units, oversize);
+}
+function invalidName(name: string | Buffer): "oversize" | "invalid" | null {
+	const bytes = nameBytes(name);
+	if (bytes.length === 0 || bytes.length > MAX_NAME_UTF8_BYTES) return "oversize";
+	if (bytes.includes(0) || bytes.includes(0x2f) || bytes.includes(0x5c)) return "invalid";
+	try {
+		const decoded = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+		if ([...decoded].some(ch => ch === "\0" || ch === "/" || ch === "\\")) return "invalid";
+	} catch {
+		return "invalid";
+	}
+	return null;
+}
+function addDiagnostic(state: ScanState, p: string, kind: WorktreeKind, reasonCode: string, message: string): void {
+	state.diagnostics.push({ path: displayPath(p), kind, reasonCode, message });
+}
+function addRawNameDiagnostic(
+	state: ScanState,
+	dir: string,
+	raw: string | Buffer,
+	oversize: boolean,
+	kind: WorktreeKind,
+	reasonCode: string,
+	message: string,
+): void {
+	state.diagnostics.push({ path: displayRawPath(dir, raw, oversize), kind, reasonCode, message });
+}
+function chargeEntry(state: ScanState): boolean {
+	if (state.visited >= MAX_ENTRIES) {
+		if (!state.halted)
+			addDiagnostic(state, state.root, "overflow", "overflow", "scan limit exceeded: 1024 entries; preserved");
+		state.halted = true;
+		return false;
+	}
+	state.visited++;
+	return true;
+}
+function isRegular(stat: { isFile(): boolean; isDirectory(): boolean; isSymbolicLink(): boolean }): boolean {
+	return stat.isFile() && !stat.isSymbolicLink();
+}
+function sameIdentity(a: Identity, b: { dev: bigint; ino: bigint }): boolean {
+	return a.dev === b.dev && a.ino === b.ino;
+}
+function metadataIoFailure(phase: "open" | "stat" | "read", code: string | undefined): MetadataFailure {
+	if (phase === "open") {
+		if (code === "ELOOP") return "link";
+		if (code === "ENOENT" || code === "ENOTDIR" || code === "EISDIR") return "race";
+		return "unreadable";
+	}
+	return code === "ENOENT" || code === "EBADF" || code === "EISDIR" ? "race" : "unreadable";
+}
+function codeOf(error: unknown): string | undefined {
+	return (error as { code?: string }).code;
+}
+function addDirectoryFailure(state: ScanState, dir: string, error: unknown): void {
+	const code = codeOf(error);
+	if (code === "ENOENT" || code === "ENOTDIR" || code === "ERACE") {
+		addDiagnostic(state, dir, "unsupported", "metadata-raced", "filesystem metadata changed during scan; preserved");
+		return;
+	}
+	addDiagnostic(state, dir, "unsupported", "scan-error", "cannot inspect directory; preserved");
+}
+
+function metadataFailure(family: MetadataFamily, failure: MetadataFailure): [WorktreeKind, string, string] {
+	if (failure === "link") return ["unsupported", "unsupported-link", "link or reparse point encountered; preserved"];
+	if (failure === "race")
+		return ["unsupported", "metadata-raced", "filesystem metadata changed during scan; preserved"];
+	if (family === "git") {
+		if (failure === "unreadable") return ["pr-checkout", "unreadable-gitfile", "cannot read .git file; preserved"];
+		if (failure === "oversize")
+			return ["pr-checkout", "oversize-gitfile", ".git file exceeds 65536 bytes; preserved"];
+		if (failure === "invalid-utf8")
+			return ["pr-checkout", "invalid-utf8-gitfile", ".git file is not valid UTF-8; preserved"];
+		return ["pr-checkout", "nul-gitfile", ".git file contains NUL; preserved"];
+	}
+	if (family === "head") {
+		if (failure === "unreadable") return ["pr-checkout", "unreadable-head", "cannot read HEAD; preserved"];
+		if (failure === "oversize") return ["pr-checkout", "oversize-head", "HEAD exceeds 65536 bytes; preserved"];
+		if (failure === "invalid-utf8") return ["pr-checkout", "invalid-utf8-head", "HEAD is not valid UTF-8; preserved"];
+		return ["pr-checkout", "nul-head", "HEAD contains NUL; preserved"];
+	}
+	const label = family === "commondir" ? "common-dir" : "reciprocal gitdir";
+	const reason = family === "commondir" ? "commondir" : "gitdir";
+	if (failure === "unreadable")
+		return ["pr-checkout", `unreadable-${reason}`, `cannot read ${label} metadata; preserved`];
+	if (failure === "oversize")
+		return ["pr-checkout", `oversize-${reason}`, `${label} metadata exceeds 65536 bytes; preserved`];
+	if (failure === "invalid-utf8")
+		return ["pr-checkout", `invalid-utf8-${reason}`, `${label} metadata is not valid UTF-8; preserved`];
+	return ["pr-checkout", `nul-${reason}`, `${label} metadata contains NUL; preserved`];
+}
+
+function addMetadataFailure(state: ScanState, display: string, family: MetadataFamily, failure: MetadataFailure): void {
+	const [kind, reasonCode, message] = metadataFailure(family, failure);
+	addDiagnostic(state, display, kind, reasonCode, message);
+}
+async function readBoundedMetadata(
+	filePath: string,
+	family: MetadataFamily,
+	display: string,
+	state: ScanState,
+	preflight?: BigIntStats,
+): Promise<string | null> {
+	let stat = preflight;
+	if (!stat) {
+		try {
+			stat = await lstat(filePath, { bigint: true });
+		} catch (error) {
+			const code = codeOf(error);
+			addMetadataFailure(state, display, family, code === "ENOENT" || code === "ENOTDIR" ? "race" : "unreadable");
+			return null;
+		}
+	}
+	if (stat.isSymbolicLink()) {
+		addMetadataFailure(state, display, family, "link");
+		return null;
+	}
+	if (!isRegular(stat)) {
+		addMetadataFailure(state, display, family, "race");
+		return null;
+	}
+	const before: Identity = { dev: stat.dev, ino: stat.ino };
+	if (state.reserved + METADATA_RESERVATION_BYTES > MAX_TOTAL_METADATA_BYTES) {
+		addDiagnostic(state, display, "overflow", "overflow", "metadata budget exceeded; preserved");
+		state.halted = true;
+		return null;
+	}
+	state.reserved += METADATA_RESERVATION_BYTES;
+	if (typeof constants.O_NOFOLLOW !== "number") {
+		addDiagnostic(
+			state,
+			display,
+			"unsupported",
+			"unsupported-platform-proof",
+			"no-follow metadata proof unavailable; preserved",
+		);
+		return null;
+	}
+	if (typeof constants.O_NONBLOCK !== "number") {
+		addDiagnostic(
+			state,
+			display,
+			"unsupported",
+			"unsupported-platform-proof",
+			"non-blocking metadata proof unavailable; preserved",
+		);
+		return null;
+	}
+	let handle: FileHandle;
+	try {
+		handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+	} catch (error) {
+		addMetadataFailure(state, display, family, metadataIoFailure("open", codeOf(error)));
+		return null;
+	}
+	let result: string | null = null;
+	let successful = false;
+	try {
+		let stat: BigIntStats;
+		try {
+			stat = await handle.stat({ bigint: true });
+		} catch (error) {
+			addMetadataFailure(state, display, family, metadataIoFailure("stat", codeOf(error)));
+			return null;
+		}
+		if (!isRegular(stat) || !sameIdentity(before, stat)) {
+			addMetadataFailure(state, display, family, "race");
+			return null;
+		}
+		const buffer = Buffer.allocUnsafe(MAX_METADATA_BYTES + 1);
+		let offset = 0;
+		try {
+			while (offset < buffer.length) {
+				const read = await handle.read(buffer, offset, Math.min(CHUNK_BYTES, buffer.length - offset), offset);
+				if (read.bytesRead === 0) break;
+				offset += read.bytesRead;
+			}
+		} catch (error) {
+			addMetadataFailure(state, display, family, metadataIoFailure("read", codeOf(error)));
+			return null;
+		}
+		if (offset > MAX_METADATA_BYTES) {
+			addMetadataFailure(state, display, family, "oversize");
+			return null;
+		}
+		try {
+			result = new TextDecoder("utf-8", { fatal: true }).decode(buffer.subarray(0, offset));
+			if (result.includes("\0")) {
+				addMetadataFailure(state, display, family, "nul");
+				return null;
+			}
+		} catch {
+			addMetadataFailure(state, display, family, "invalid-utf8");
+			return null;
+		}
+		successful = true;
+	} finally {
+		try {
+			await handle.close();
+		} catch {
+			if (successful) addMetadataFailure(state, display, family, "unreadable");
+			successful = false;
+		}
+	}
+	return successful ? result : null;
+}
+function pointerValue(text: string): string | null {
+	const end = text.replace(/[\r\n]*$/, "");
+	if (!end.startsWith("gitdir: ")) return null;
+	const value = end.slice(8);
+	return value.length > 0 && !/[\r\n]/.test(value) ? value : null;
+}
+function metadataLine(text: string): string | null {
+	const value = text.replace(/[\r\n]+$/, "");
+	return value.length > 0 && !/[\r\n\0]/.test(value) ? value : null;
+}
+
+function validHead(text: string): boolean {
+	const value = metadataLine(text);
+	return (
+		value !== null && (/^ref: refs\/heads\/[^\r\n\0]+$/.test(value) || /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(value))
+	);
+}
+function contained(base: string, target: string): boolean {
+	const relative = path.relative(base, target);
+	return relative === "" || (!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`));
+}
+async function safeComponents(state: ScanState, target: string): Promise<ComponentResult> {
+	if (!contained(state.root, target)) return "outside";
+	try {
+		const rootStat = await lstat(state.root, { bigint: true });
+		if (rootStat.isSymbolicLink()) return "link";
+		if (!rootStat.isDirectory() || !sameIdentity(state.rootIdentity, rootStat)) return "race";
+	} catch (error) {
+		const code = codeOf(error);
+		return code === "ENOENT" || code === "ENOTDIR" ? "race" : "io";
+	}
+	const relative = path.relative(state.root, target);
+	let current = state.root;
+	for (const part of relative ? relative.split(path.sep) : []) {
+		current = path.join(current, part);
+		try {
+			const stat = await lstat(current, { bigint: true });
+			if (stat.isSymbolicLink()) return "link";
+			if (!stat.isDirectory()) return "not-directory";
+		} catch (error) {
+			const code = codeOf(error);
+			return code === "ENOENT" || code === "ENOTDIR" ? "race" : "io";
+		}
+	}
+	return "ok";
+}
+function addComponentDiagnostic(state: ScanState, candidate: string, result: Exclude<ComponentResult, "ok">): void {
+	if (result === "outside") {
+		addDiagnostic(
+			state,
+			candidate,
+			"pr-checkout",
+			"pointer-outside-root",
+			"gitdir pointer outside managed root; preserved",
+		);
+		return;
+	}
+	if (result === "link") {
+		addDiagnostic(
+			state,
+			candidate,
+			"unsupported",
+			"unsupported-link",
+			"link or reparse point encountered; preserved",
+		);
+		return;
+	}
+	if (result === "race") {
+		addDiagnostic(
+			state,
+			candidate,
+			"unsupported",
+			"metadata-raced",
+			"filesystem metadata changed during scan; preserved",
+		);
+		return;
+	}
+	if (result === "not-directory") {
+		addDiagnostic(state, candidate, "pr-checkout", "separate-git-dir", "gitdir target is not a directory; preserved");
+		return;
+	}
+	addDiagnostic(state, candidate, "pr-checkout", "unreadable-gitfile", "cannot read .git file; preserved");
+}
+async function readContainedMetadata(
+	container: string,
+	filePath: string,
+	family: MetadataFamily,
+	candidate: string,
+	state: ScanState,
+	preflight?: BigIntStats,
+): Promise<string | null> {
+	const before = await safeComponents(state, container);
+	if (before !== "ok") {
+		addComponentDiagnostic(state, candidate, before);
+		return null;
+	}
+	const text = await readBoundedMetadata(filePath, family, candidate, state, preflight);
+	if (state.halted) return null;
+	const after = await safeComponents(state, container);
+	if (after !== "ok") {
+		addComponentDiagnostic(state, candidate, after);
+		return null;
+	}
+	return text;
+}
+async function inspectPointer(candidate: string, gitFile: string, text: string, state: ScanState): Promise<boolean> {
+	const pointer = pointerValue(text);
+	if (!pointer) {
+		addDiagnostic(state, candidate, "pr-checkout", "malformed-gitfile", "malformed .git file; preserved");
+		return false;
+	}
+	const target = path.normalize(path.isAbsolute(pointer) ? pointer : path.join(path.dirname(gitFile), pointer));
+	if (/^(?:\\\\|\/\/|[A-Za-z]:[\\/]{2})/.test(pointer)) {
+		addDiagnostic(state, candidate, "pr-checkout", "unc-network", "network gitdir pointer unsupported; preserved");
+		return false;
+	}
+	const commondir = await readContainedMetadata(target, path.join(target, "commondir"), "commondir", candidate, state);
+	if (state.halted || commondir === null) return false;
+	const commonValue = metadataLine(commondir);
+	if (commonValue === null) {
+		addDiagnostic(state, candidate, "pr-checkout", "common-dir", "common-dir metadata observed; preserved");
+		return false;
+	}
+	const common = path.normalize(path.isAbsolute(commonValue) ? commonValue : path.join(target, commonValue));
+	const commonResult = await safeComponents(state, common);
+	if (commonResult !== "ok") {
+		addComponentDiagnostic(state, candidate, commonResult);
+		return false;
+	}
+	const head = await readContainedMetadata(target, path.join(target, "HEAD"), "head", candidate, state);
+	if (state.halted || head === null) return false;
+	if (!validHead(head)) {
+		addDiagnostic(state, candidate, "pr-checkout", "malformed-head", "malformed HEAD; preserved");
+		return false;
+	}
+	const reciprocal = await readContainedMetadata(target, path.join(target, "gitdir"), "gitdir", candidate, state);
+	if (state.halted || reciprocal === null) return false;
+	const reciprocalValue = metadataLine(reciprocal);
+	if (reciprocalValue === null) {
+		addDiagnostic(
+			state,
+			candidate,
+			"pr-checkout",
+			"invalid-pointer",
+			"worktree metadata pointer is not reciprocal; preserved",
+		);
+		return false;
+	}
+	const reciprocalPath = path.normalize(
+		path.isAbsolute(reciprocalValue) ? reciprocalValue : path.join(target, reciprocalValue),
+	);
+	if (
+		reciprocalPath !== path.normalize(gitFile) ||
+		!contained(state.root, reciprocalPath) ||
+		(await safeComponents(state, path.dirname(reciprocalPath))) !== "ok"
+	) {
+		addDiagnostic(
+			state,
+			candidate,
+			"pr-checkout",
+			"invalid-pointer",
+			"worktree metadata pointer is not reciprocal; preserved",
+		);
+		return false;
+	}
+	return true;
+}
+async function inspectCandidate(candidate: string, state: ScanState, depth: number): Promise<boolean> {
+	let stat: BigIntStats;
+	try {
+		stat = await lstat(candidate, { bigint: true });
+	} catch (error) {
+		addDirectoryFailure(state, candidate, error);
+		return false;
+	}
+	if (stat.isSymbolicLink()) {
+		addDiagnostic(
+			state,
+			candidate,
+			"unsupported",
+			"unsupported-link",
+			"link or reparse point encountered; preserved",
+		);
+		return false;
+	}
+	if (!stat.isDirectory()) return false;
+	if (state.platform === "win32") {
+		addDiagnostic(
+			state,
+			candidate,
+			"unsupported",
+			"unsupported-platform-proof",
+			"no-follow metadata proof unavailable on Windows; preserved",
+		);
+		return true;
+	}
+	const git = path.join(candidate, ".git");
+	let gitStat: BigIntStats | undefined;
+	try {
+		gitStat = await lstat(git, { bigint: true });
+	} catch (error) {
+		const code = codeOf(error);
+		if (code !== "ENOENT") {
+			addDiagnostic(
+				state,
+				candidate,
+				code === "ENOTDIR" ? "unsupported" : "pr-checkout",
+				code === "ENOTDIR" ? "metadata-raced" : "unreadable-gitfile",
+				code === "ENOTDIR"
+					? "filesystem metadata changed during scan; preserved"
+					: "cannot read .git file; preserved",
+			);
+			return true;
+		}
+	}
+	if (gitStat) {
+		if (gitStat.isSymbolicLink()) {
+			addDiagnostic(
+				state,
+				candidate,
+				"unsupported",
+				"unsupported-link",
+				"link or reparse point encountered; preserved",
+			);
+			return true;
+		}
+		if (gitStat.isFile()) {
+			const text = await readContainedMetadata(candidate, git, "git", candidate, state, gitStat);
+			if (state.halted) return true;
+			if (text === null || !(await inspectPointer(candidate, git, text, state))) return true;
+			addDiagnostic(state, candidate, "pr-checkout", "normal-pr", "worktree metadata observed; preserved");
+			return true;
+		}
+		if (gitStat.isDirectory()) {
+			addDiagnostic(state, candidate, "pr-checkout", "bare-repository", ".git directory observed; preserved");
+			return true;
+		}
+	}
+	let merged = false;
+	try {
+		const mergedStat = await lstat(path.join(candidate, "merged"), { bigint: true });
+		merged = mergedStat.isDirectory() && !mergedStat.isSymbolicLink();
+	} catch (error) {
+		const code = codeOf(error);
+		if (code !== "ENOENT") {
+			addDiagnostic(
+				state,
+				candidate,
+				code === "ENOTDIR" ? "unsupported" : "stray",
+				code === "ENOTDIR" ? "metadata-raced" : "merged-unreadable",
+				code === "ENOTDIR"
+					? "filesystem metadata changed during scan; preserved"
+					: "unrecognized directory contents; preserved",
+			);
+			return true;
+		}
+	}
+	if (merged) {
+		addDiagnostic(state, candidate, "task-isolation", "task-isolation", "task-isolation directory; preserved");
+		return true;
+	}
+	const nestedCount = await scanLevel(candidate, state, depth + 1);
+	if (nestedCount === 0 && !state.halted)
+		addDiagnostic(state, candidate, "empty", "empty", "empty directory; preserved");
+	else if (nestedCount === -2 && !state.halted)
+		addDiagnostic(state, candidate, "stray", "stray", "unrecognized directory contents; preserved");
+	return true;
+}
+function rawEntryName(entry: RawDirectoryEntry): string | Buffer {
+	if (typeof entry === "string") return entry;
+	if (entry instanceof Uint8Array) return Buffer.from(entry);
+	return entry.name instanceof Uint8Array ? Buffer.from(entry.name) : entry.name;
+}
+async function scanLevel(dir: string, state: ScanState, depth: number): Promise<number> {
+	if (state.visited >= MAX_ENTRIES) {
+		chargeEntry(state);
+		return -1;
+	}
+	let before: Identity | undefined;
+	try {
+		const stat = await lstat(dir, { bigint: true });
+		if (
+			!stat.isDirectory() ||
+			stat.isSymbolicLink() ||
+			(dir === state.root && !sameIdentity(state.rootIdentity, stat))
+		)
+			throw Object.assign(new Error("directory changed"), { code: "ERACE" });
+		before = { dev: stat.dev, ino: stat.ino };
+	} catch (error) {
+		if (dir === state.root) {
+			const code = codeOf(error);
+			throw new WorktreeRootError(code === "ERACE" || code === "ENOTDIR" ? "root-invalid" : "root-unreadable");
+		}
+		addDirectoryFailure(state, dir, error);
+		return -1;
+	}
+	let entries: ReadonlyArray<RawDirectoryEntry>;
+	try {
+		entries = (await readdir(dir, {
+			withFileTypes: true,
+			encoding: "buffer",
+		})) as unknown as ReadonlyArray<RawDirectoryEntry>;
+	} catch (error) {
+		if (dir === state.root) throw new WorktreeRootError("root-unreadable");
+		addDirectoryFailure(state, dir, error);
+		return -1;
+	}
+	try {
+		const after = await lstat(dir, { bigint: true });
+		if (!before || !sameIdentity(before, after)) {
+			if (dir === state.root) throw new WorktreeRootError("root-invalid");
+			addDiagnostic(
+				state,
+				dir,
+				"unsupported",
+				"metadata-raced",
+				"filesystem metadata changed during scan; preserved",
+			);
+			return -1;
+		}
+	} catch (error) {
+		if (error instanceof WorktreeRootError) throw error;
+		if (dir === state.root) throw new WorktreeRootError("root-unreadable");
+		addDirectoryFailure(state, dir, error);
+		return -1;
+	}
+	let count = 0;
+	let entriesSeen = 0;
+	for (const entry of entries) {
+		if (!chargeEntry(state)) break;
+		entriesSeen++;
+		if (depth > MAX_DEPTH) continue;
+		const raw = rawEntryName(entry);
+		const invalid = invalidName(raw);
+		if (invalid) {
+			addRawNameDiagnostic(
+				state,
+				dir,
+				raw,
+				invalid === "oversize",
+				"unsupported",
+				invalid === "oversize" ? "oversize-name" : "invalid-name",
+				invalid === "oversize"
+					? "directory name exceeds 255 bytes; preserved"
+					: "invalid UTF-8 directory name; preserved",
+			);
+			continue;
+		}
+		const child = path.join(dir, Buffer.isBuffer(raw) ? raw.toString("utf8") : raw);
+		if (await inspectCandidate(child, state, depth)) count++;
+		if (state.halted) break;
+	}
+	if (count === 0 && entriesSeen > 0 && !state.halted) return -2;
+	return count;
+}
+export async function scanWorktrees(options: ScanWorktreesOptions): Promise<WorktreeDiagnostic[]> {
+	let rootStat: BigIntStats;
+	try {
+		rootStat = await lstat(options.root, { bigint: true });
+	} catch (error) {
+		if (codeOf(error) === "ENOENT") return [];
+		throw new WorktreeRootError("root-unreadable");
+	}
+	if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) throw new WorktreeRootError("root-invalid");
+	const state: ScanState = {
+		visited: 0,
+		reserved: 0,
+		halted: false,
+		platform: options.platform,
+		diagnostics: [],
+		root: options.root,
+		rootIdentity: { dev: rootStat.dev, ino: rootStat.ino },
+	};
+	await scanLevel(options.root, state, 1);
+	return state.diagnostics;
+}

--- a/packages/coding-agent/src/commands/worktree.ts
+++ b/packages/coding-agent/src/commands/worktree.ts
@@ -1,56 +1,68 @@
 /**
- * List and clean up agent-managed git worktrees under `~/.gjc/wt`.
+ * Report-only diagnostics for agent-managed worktrees.
  */
-import { Args, Command, Flags } from "@gajae-code/utils/cli";
-import { clearWorktrees, listWorktrees } from "../cli/worktree-cli";
+import { Args, Command, type CommandCtor, Flags } from "@gajae-code/utils/cli";
 
-export default class Worktree extends Command {
-	static description = "List or clear agent-managed git worktrees (~/.gjc/wt)";
+export type WorktreeRootGetter = () => string;
 
-	static aliases = ["wt"];
+export function createWorktreeCommand(getWorktreesDir: WorktreeRootGetter): CommandCtor {
+	return class Worktree extends Command {
+		static description = "List report-only diagnostics for agent-managed worktrees";
+		static aliases = ["wt"];
 
-	static args = {
-		// `list` (default) inspects the worktree dir; `clear` removes entries.
-		// A positional action keeps `gjc worktree` (the no-arg form) useful.
-		action: Args.string({
-			description: "list (default) or clear",
-			required: false,
-			options: ["list", "clear"],
-			default: "list",
-		}),
-	};
+		static args = {
+			action: Args.string({
+				description: "list (default) or clear",
+				required: false,
+				options: ["list", "clear"],
+				default: "list",
+			}),
+		};
 
-	static flags = {
-		all: Flags.boolean({
-			description: "Clear every entry, including live PR-checkout worktrees (clear)",
-			default: false,
-		}),
-		"dry-run": Flags.boolean({
-			char: "n",
-			description: "Print what would be removed without touching the filesystem (clear)",
-			default: false,
-		}),
-		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: false }),
-	};
+		static flags = {
+			all: Flags.boolean({ description: "Unavailable: cleanup is report-only", default: false }),
+			"dry-run": Flags.boolean({ char: "n", description: "Preview the report-only clear summary", default: false }),
+			json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: false }),
+		};
 
-	static examples = [
-		"gjc worktree",
-		"gjc worktree list --json",
-		"gjc worktree clear",
-		"gjc worktree clear --dry-run",
-		"gjc worktree clear --all",
-	];
+		static examples = [
+			"gjc worktree",
+			"gjc worktree list --json",
+			"gjc worktree clear",
+			"gjc worktree clear --dry-run",
+		];
 
-	async run(): Promise<void> {
-		const { args, flags } = await this.parse(Worktree);
-		if (args.action === "clear") {
-			await clearWorktrees({
-				all: flags.all ?? false,
-				dryRun: flags["dry-run"] ?? false,
-				json: flags.json ?? false,
+		async run(): Promise<void> {
+			const { args, flags, argv } = await this.parse(Worktree);
+			const action = args.action === "clear" ? "clear" : "list";
+			const all = flags.all ?? false;
+			const dryRun = flags["dry-run"] ?? false;
+			const json = flags.json ?? false;
+			const validPositionals = argv.length <= 1 && (argv.length === 0 || argv[0] === action);
+			const valid = validPositionals && ((action === "clear" && !all) || (action === "list" && !all && !dryRun));
+			if (!valid) {
+				if (json) {
+					process.stdout.write(
+						'{"error":{"code":"worktree_cleanup_disabled","message":"worktree cleanup is report-only"}}\n',
+					);
+				} else {
+					process.stderr.write("error: worktree cleanup is report-only\n");
+				}
+				process.exitCode = 2;
+				return;
+			}
+			const root = getWorktreesDir();
+			const { runWorktreeCommand } = await import("../cli/worktree-cli");
+			const result = await runWorktreeCommand({
+				root,
+				platform: process.platform === "win32" ? "win32" : "posix",
+				action,
+				json,
+				dryRun,
 			});
-			return;
+			if (result.stdout.length > 0) process.stdout.write(result.stdout);
+			if (result.stderr.length > 0) process.stderr.write(result.stderr);
+			if (result.exitCode !== 0) process.exitCode = result.exitCode;
 		}
-		await listWorktrees({ json: flags.json ?? false });
-	}
+	};
 }

--- a/packages/coding-agent/test/worktree-cli.test.ts
+++ b/packages/coding-agent/test/worktree-cli.test.ts
@@ -63,6 +63,7 @@ function renderedPath(value: string): string {
 	return value.replaceAll("\\", "\\\\");
 }
 const CHUNK_BYTES_FOR_TEST = 8192;
+const posixTest = test.skipIf(process.platform === "win32");
 
 describe("bounded worktree scanner", () => {
 	test("publishes fixed limits and preserves missing roots", async () => {
@@ -75,7 +76,7 @@ describe("bounded worktree scanner", () => {
 		expect(await scanWorktrees({ root: join(tmpdir(), "gjc-no-such-root"), platform: "posix" })).toEqual([]);
 	});
 
-	test("recognizes a valid pointer and reads bounded metadata in order", async () => {
+	posixTest("recognizes a valid pointer and reads bounded metadata in order", async () => {
 		await withRoot(async root => {
 			const candidate = join(root, "candidate");
 			const target = join(candidate, "meta", "worktrees", "one");
@@ -187,7 +188,7 @@ describe("bounded worktree scanner", () => {
 		});
 	});
 
-	test("classifies an empty gitfile as malformed", async () => {
+	posixTest("classifies an empty gitfile as malformed", async () => {
 		await withRoot(async root => {
 			const candidate = join(root, "empty-gitfile");
 			await mkdir(candidate);
@@ -202,14 +203,14 @@ describe("bounded worktree scanner", () => {
 			]);
 		});
 	});
-	test("rejects malformed metadata without exposing raw content", async () => {
+	posixTest("rejects malformed metadata without exposing raw content", async () => {
 		await withRoot(async root => {
 			const candidate = join(root, "bad");
 			await mkdir(candidate);
 			await writeFile(join(candidate, ".git"), Buffer.from([0xff, 0xfe]));
 			const result = await scanWorktrees({ root, platform: "posix" });
 			expect(result[0]?.message).toBe(".git file is not valid UTF-8; preserved");
-			expect(JSON.stringify(result)).not.toContain("ff");
+			expect(JSON.stringify(result)).not.toContain("\uFFFD");
 		});
 	});
 	test("preserves exact worker streams for empty list and root failure", async () => {
@@ -268,7 +269,7 @@ describe("bounded worktree scanner", () => {
 		});
 	});
 
-	test("rejects pointers outside the managed root and non-reciprocal metadata", async () => {
+	posixTest("rejects pointers outside the managed root and non-reciprocal metadata", async () => {
 		await withRoot(async root => {
 			const candidate = join(root, "candidate");
 			const target = join(tmpdir(), "gjc-worktree-outside-target");
@@ -364,7 +365,7 @@ describe("bounded worktree scanner", () => {
 		});
 	});
 
-	test("requires exact reciprocal metadata inside the managed root", async () => {
+	posixTest("requires exact reciprocal metadata inside the managed root", async () => {
 		await withRoot(async root => {
 			const candidate = join(root, "candidate");
 			const target = join(candidate, "meta", "worktrees", "one");
@@ -489,7 +490,7 @@ describe("bounded worktree scanner", () => {
 			}
 		});
 	});
-	test("never opens final-component links and revalidates pointer ancestors", async () => {
+	posixTest("never opens final-component links and revalidates pointer ancestors", async () => {
 		await withRoot(async root => {
 			const candidate = join(root, "linked-git");
 			const external = join(root, "external-metadata");
@@ -596,7 +597,7 @@ describe("bounded worktree scanner", () => {
 		});
 	});
 
-	test("proves exact 15-of-16 metadata reservation operations", async () => {
+	posixTest("proves exact 15-of-16 metadata reservation operations", async () => {
 		await withRoot(async root => {
 			for (let index = 0; index < 16; index++) {
 				const candidate = join(root, `protocol-${String(index).padStart(2, "0")}`);
@@ -690,7 +691,7 @@ describe("bounded worktree scanner", () => {
 		});
 	});
 
-	test("does not refund a reservation after an open failure", async () => {
+	posixTest("does not refund a reservation after an open failure", async () => {
 		await withRoot(async root => {
 			for (let index = 0; index < 16; index++) {
 				const candidate = join(root, `nonrefundable-${String(index).padStart(2, "0")}`);
@@ -787,7 +788,7 @@ describe("bounded worktree scanner", () => {
 		},
 	);
 
-	test("maps open, stat, read, identity, and close failures by phase", async () => {
+	posixTest("maps open, stat, read, identity, and close failures by phase", async () => {
 		const scenarios: Array<{
 			name: string;
 			openCode?: string;
@@ -864,90 +865,93 @@ describe("bounded worktree scanner", () => {
 			});
 		}
 	});
-	test("covers every hostile HEAD, commondir, and reciprocal gitdir family failure in precedence order", async () => {
-		const families = [
-			{
-				name: "HEAD",
-				file: "HEAD",
-				failures: [
-					["unreadable", "unreadable-head", "unreadable"],
-					["oversize", "oversize-head", Buffer.alloc(MAX_METADATA_BYTES + 1, 0x61)],
-					["invalid-utf8", "invalid-utf8-head", Buffer.from([0xff])],
-					["NUL", "nul-head", Buffer.from("ref: refs/heads/topic\0")],
-					["malformed", "malformed-head", "not-a-head"],
-				],
-				later: ["unreadable-gitdir", "oversize-gitdir", "invalid-utf8-gitdir", "nul-gitdir", "invalid-pointer"],
-			},
-			{
-				name: "commondir",
-				file: "commondir",
-				failures: [
-					["unreadable", "unreadable-commondir", "unreadable"],
-					["oversize", "oversize-commondir", Buffer.alloc(MAX_METADATA_BYTES + 1, 0x61)],
-					["invalid-utf8", "invalid-utf8-commondir", Buffer.from([0xff])],
-					["NUL", "nul-commondir", Buffer.from("../..\0")],
-					["malformed", "common-dir", ""],
-				],
-				later: [
-					"unreadable-head",
-					"oversize-head",
-					"invalid-utf8-head",
-					"nul-head",
-					"malformed-head",
-					"unreadable-gitdir",
-				],
-			},
-			{
-				name: "gitdir",
-				file: "gitdir",
-				failures: [
-					["unreadable", "unreadable-gitdir", "unreadable"],
-					["oversize", "oversize-gitdir", Buffer.alloc(MAX_METADATA_BYTES + 1, 0x61)],
-					["invalid-utf8", "invalid-utf8-gitdir", Buffer.from([0xff])],
-					["NUL", "nul-gitdir", Buffer.from(`${join("/tmp", "candidate", ".git")}\0`)],
-					["malformed", "invalid-pointer", ""],
-				],
-				later: [],
-			},
-		] as const;
-		for (const family of families) {
-			for (const [label, expected, content] of family.failures) {
-				await withRoot(async root => {
-					const candidate = join(root, `${family.name}-${label}`);
-					const target = join(candidate, "meta", "worktrees", "one");
-					await mkdir(target, { recursive: true });
-					await writeFile(join(candidate, ".git"), `gitdir: ${target}\n`);
-					await writeFile(join(target, "commondir"), "../..\n");
-					await writeFile(join(target, "HEAD"), "ref: refs/heads/topic\n");
-					await writeFile(join(target, "gitdir"), `${join(candidate, ".git")}\n`);
-					await writeFile(join(target, family.file), content);
-					if (family.name === "commondir") {
-						await writeFile(join(target, "HEAD"), "not-a-head");
-						await writeFile(join(target, "gitdir"), "");
-					} else if (family.name === "HEAD") {
-						await writeFile(join(target, "gitdir"), "");
-					}
-					const actualOpen = fsPromises.open;
-					const openSpy = spyOn(fsPromises, "open").mockImplementation(async (filePath, flags) => {
-						if (label === "unreadable" && String(filePath) === join(target, family.file))
-							throw Object.assign(new Error("synthetic unreadable metadata"), { code: "EACCES" });
-						return actualOpen(filePath, flags);
+	posixTest(
+		"covers every hostile HEAD, commondir, and reciprocal gitdir family failure in precedence order",
+		async () => {
+			const families = [
+				{
+					name: "HEAD",
+					file: "HEAD",
+					failures: [
+						["unreadable", "unreadable-head", "unreadable"],
+						["oversize", "oversize-head", Buffer.alloc(MAX_METADATA_BYTES + 1, 0x61)],
+						["invalid-utf8", "invalid-utf8-head", Buffer.from([0xff])],
+						["NUL", "nul-head", Buffer.from("ref: refs/heads/topic\0")],
+						["malformed", "malformed-head", "not-a-head"],
+					],
+					later: ["unreadable-gitdir", "oversize-gitdir", "invalid-utf8-gitdir", "nul-gitdir", "invalid-pointer"],
+				},
+				{
+					name: "commondir",
+					file: "commondir",
+					failures: [
+						["unreadable", "unreadable-commondir", "unreadable"],
+						["oversize", "oversize-commondir", Buffer.alloc(MAX_METADATA_BYTES + 1, 0x61)],
+						["invalid-utf8", "invalid-utf8-commondir", Buffer.from([0xff])],
+						["NUL", "nul-commondir", Buffer.from("../..\0")],
+						["malformed", "common-dir", ""],
+					],
+					later: [
+						"unreadable-head",
+						"oversize-head",
+						"invalid-utf8-head",
+						"nul-head",
+						"malformed-head",
+						"unreadable-gitdir",
+					],
+				},
+				{
+					name: "gitdir",
+					file: "gitdir",
+					failures: [
+						["unreadable", "unreadable-gitdir", "unreadable"],
+						["oversize", "oversize-gitdir", Buffer.alloc(MAX_METADATA_BYTES + 1, 0x61)],
+						["invalid-utf8", "invalid-utf8-gitdir", Buffer.from([0xff])],
+						["NUL", "nul-gitdir", Buffer.from(`${join("/tmp", "candidate", ".git")}\0`)],
+						["malformed", "invalid-pointer", ""],
+					],
+					later: [],
+				},
+			] as const;
+			for (const family of families) {
+				for (const [label, expected, content] of family.failures) {
+					await withRoot(async root => {
+						const candidate = join(root, `${family.name}-${label}`);
+						const target = join(candidate, "meta", "worktrees", "one");
+						await mkdir(target, { recursive: true });
+						await writeFile(join(candidate, ".git"), `gitdir: ${target}\n`);
+						await writeFile(join(target, "commondir"), "../..\n");
+						await writeFile(join(target, "HEAD"), "ref: refs/heads/topic\n");
+						await writeFile(join(target, "gitdir"), `${join(candidate, ".git")}\n`);
+						await writeFile(join(target, family.file), content);
+						if (family.name === "commondir") {
+							await writeFile(join(target, "HEAD"), "not-a-head");
+							await writeFile(join(target, "gitdir"), "");
+						} else if (family.name === "HEAD") {
+							await writeFile(join(target, "gitdir"), "");
+						}
+						const actualOpen = fsPromises.open;
+						const openSpy = spyOn(fsPromises, "open").mockImplementation(async (filePath, flags) => {
+							if (label === "unreadable" && String(filePath) === join(target, family.file))
+								throw Object.assign(new Error("synthetic unreadable metadata"), { code: "EACCES" });
+							return actualOpen(filePath, flags);
+						});
+						try {
+							const result = await scanWorktrees({ root, platform: "posix" });
+							const candidateResult = result.find(entry => entry.path === renderedPath(candidate));
+							expect(candidateResult?.reasonCode, `${family.name}/${label}`).toBe(expected);
+							expect(result.some(entry => family.later.some(reason => reason === entry.reasonCode))).toBe(false);
+							expect(result.some(entry => entry.reasonCode === "normal-pr")).toBe(false);
+						} finally {
+							openSpy.mockRestore();
+						}
 					});
-					try {
-						const result = await scanWorktrees({ root, platform: "posix" });
-						const candidateResult = result.find(entry => entry.path === renderedPath(candidate));
-						expect(candidateResult?.reasonCode, `${family.name}/${label}`).toBe(expected);
-						expect(result.some(entry => family.later.some(reason => reason === entry.reasonCode))).toBe(false);
-						expect(result.some(entry => entry.reasonCode === "normal-pr")).toBe(false);
-					} finally {
-						openSpy.mockRestore();
-					}
-				});
+				}
 			}
-		}
-	});
+		},
+	);
 
-	test("distinguishes 65536-byte metadata from a 65537-byte overflow read", async () => {
+	posixTest("distinguishes 65536-byte metadata from a 65537-byte overflow read", async () => {
 		await withRoot(async root => {
 			const exact = join(root, "exact");
 			const oversized = join(root, "oversized");
@@ -1036,7 +1040,7 @@ describe("bounded worktree scanner", () => {
 				const result = await scanWorktrees({ root, platform: "posix" });
 				expect(result).toEqual([
 					{
-						path: renderedPath(join(root, "%FF")),
+						path: `${renderedPath(root)}/%FF`,
 						kind: "unsupported",
 						reasonCode: "invalid-name",
 						message: "invalid UTF-8 directory name; preserved",
@@ -1061,7 +1065,7 @@ describe("bounded worktree scanner", () => {
 		},
 	);
 
-	test("accepts relative CRLF pointers and detached HEAD metadata", async () => {
+	posixTest("accepts relative CRLF pointers and detached HEAD metadata", async () => {
 		await withRoot(async root => {
 			const candidate = join(root, "relative");
 			const target = join(candidate, "meta", "worktrees", "one");
@@ -1081,7 +1085,7 @@ describe("bounded worktree scanner", () => {
 		});
 	});
 
-	test("uses frozen diagnostics for NUL, network pointers, and bare repositories", async () => {
+	posixTest("uses frozen diagnostics for NUL, network pointers, and bare repositories", async () => {
 		await withRoot(async root => {
 			const nul = join(root, "nul");
 			const network = join(root, "network");
@@ -1110,7 +1114,7 @@ describe("bounded worktree scanner", () => {
 		});
 	});
 
-	test("shares one exact 15-of-16 reservation protocol across metadata categories", async () => {
+	posixTest("shares one exact 15-of-16 reservation protocol across metadata categories", async () => {
 		await withRoot(async root => {
 			const metadataPaths: string[] = [];
 			for (let index = 0; index < 4; index++) {
@@ -1151,7 +1155,7 @@ describe("bounded worktree scanner", () => {
 		});
 	});
 
-	test("renders exact list and clear report-only output contracts", async () => {
+	posixTest("renders exact list and clear report-only output contracts", async () => {
 		await withRoot(async root => {
 			const candidate = join(root, "bare");
 			await mkdir(join(candidate, ".git"), { recursive: true });

--- a/packages/coding-agent/test/worktree-cli.test.ts
+++ b/packages/coding-agent/test/worktree-cli.test.ts
@@ -1,0 +1,1420 @@
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+import { type BigIntStats, constants } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import * as fsPromises from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type CommandEntry, run } from "@gajae-code/utils/cli";
+import { runWorktreeCommand } from "../src/cli/worktree-cli";
+import {
+	MAX_DEPTH,
+	MAX_ENTRIES,
+	MAX_METADATA_BYTES,
+	MAX_NAME_UTF8_BYTES,
+	MAX_TOTAL_METADATA_BYTES,
+	METADATA_RESERVATION_BYTES,
+	scanWorktrees,
+	type WorktreeDiagnostic,
+	WorktreeRootError,
+} from "../src/cli/worktree-scanner";
+import { createWorktreeCommand } from "../src/commands/worktree";
+
+async function withRoot(run: (root: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "gjc-worktree-scanner-"));
+	try {
+		await run(root);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+function symbolicDirectory(stat: BigIntStats): BigIntStats {
+	return {
+		dev: stat.dev,
+		ino: stat.ino,
+		isFile: () => false,
+		isDirectory: () => true,
+		isSymbolicLink: () => true,
+	} as BigIntStats;
+}
+const originalNoFollowDescriptor = Object.getOwnPropertyDescriptor(constants, "O_NOFOLLOW");
+const originalNonBlockDescriptor = Object.getOwnPropertyDescriptor(constants, "O_NONBLOCK");
+beforeAll(() => {
+	if (typeof constants.O_NOFOLLOW !== "number" || constants.O_NOFOLLOW === 0)
+		Object.defineProperty(constants, "O_NOFOLLOW", {
+			value: constants.O_SYNC,
+			configurable: true,
+			writable: true,
+		});
+	if (typeof constants.O_NONBLOCK !== "number" || constants.O_NONBLOCK === 0)
+		Object.defineProperty(constants, "O_NONBLOCK", {
+			value: constants.O_APPEND,
+			configurable: true,
+			writable: true,
+		});
+});
+afterAll(() => {
+	if (originalNoFollowDescriptor) Object.defineProperty(constants, "O_NOFOLLOW", originalNoFollowDescriptor);
+	else Reflect.deleteProperty(constants, "O_NOFOLLOW");
+	if (originalNonBlockDescriptor) Object.defineProperty(constants, "O_NONBLOCK", originalNonBlockDescriptor);
+	else Reflect.deleteProperty(constants, "O_NONBLOCK");
+});
+function renderedPath(value: string): string {
+	return value.replaceAll("\\", "\\\\");
+}
+const CHUNK_BYTES_FOR_TEST = 8192;
+
+describe("bounded worktree scanner", () => {
+	test("publishes fixed limits and preserves missing roots", async () => {
+		expect(MAX_ENTRIES).toBe(1024);
+		expect(MAX_DEPTH).toBe(2);
+		expect(MAX_NAME_UTF8_BYTES).toBe(255);
+		expect(MAX_METADATA_BYTES).toBe(65536);
+		expect(METADATA_RESERVATION_BYTES).toBe(65537);
+		expect(MAX_TOTAL_METADATA_BYTES).toBe(1048576);
+		expect(await scanWorktrees({ root: join(tmpdir(), "gjc-no-such-root"), platform: "posix" })).toEqual([]);
+	});
+
+	test("recognizes a valid pointer and reads bounded metadata in order", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "candidate");
+			const target = join(candidate, "meta", "worktrees", "one");
+			await mkdir(candidate, { recursive: true });
+			await mkdir(target, { recursive: true });
+			await writeFile(join(candidate, ".git"), `gitdir: ${target}\n`);
+			await writeFile(join(target, "HEAD"), "ref: refs/heads/topic\n");
+			await writeFile(join(target, "commondir"), "../..\n");
+			await writeFile(join(target, "gitdir"), `${join(candidate, ".git")}\n`);
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result).toEqual([
+				{
+					path: renderedPath(join(root, "candidate")),
+					kind: "pr-checkout",
+					reasonCode: "normal-pr",
+					message: "worktree metadata observed; preserved",
+				},
+			]);
+		});
+	});
+
+	test("does not follow root or candidate symlinks and has no Windows child traversal", async () => {
+		await withRoot(async root => {
+			const real = join(root, "real");
+			await mkdir(real);
+			await symlink(real, join(root, "link"));
+			const result = await scanWorktrees({ root, platform: "win32" });
+			expect(result.some(entry => entry.reasonCode === "unsupported-link")).toBe(true);
+		});
+	});
+
+	test("charges returned-order entries globally and emits one terminal overflow", async () => {
+		await withRoot(async root => {
+			await Promise.all(
+				Array.from({ length: MAX_ENTRIES + 1 }, (_, index) =>
+					mkdir(join(root, `entry-${String(index).padStart(4, "0")}`)),
+				),
+			);
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result.at(-1)).toEqual({
+				path: renderedPath(root),
+				kind: "overflow",
+				reasonCode: "overflow",
+				message: "scan limit exceeded: 1024 entries; preserved",
+			});
+			expect(result.filter(entry => entry.reasonCode === "overflow")).toHaveLength(1);
+		});
+	});
+	test("does not list the directory that consumes the final entry charge", async () => {
+		await withRoot(async root => {
+			const boundary = join(root, "entry-1023");
+			await mkdir(boundary);
+			await Promise.all(
+				Array.from({ length: MAX_ENTRIES - 1 }, (_, index) =>
+					writeFile(join(root, `entry-${String(index).padStart(4, "0")}`), ""),
+				),
+			);
+			const actualReaddir = fsPromises.readdir;
+			const readdirSpy = spyOn(fsPromises, "readdir").mockImplementation(async (directory, options) => {
+				if (String(directory) === root) {
+					return Array.from({ length: MAX_ENTRIES }, (_, index) => ({
+						name: `entry-${String(index).padStart(4, "0")}`,
+					})) as never;
+				}
+				return actualReaddir(directory, options as never) as never;
+			});
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				expect(result.at(-1)).toMatchObject({ kind: "overflow", reasonCode: "overflow" });
+				expect(readdirSpy.mock.calls.some(call => String(call[0]) === boundary)).toBe(false);
+			} finally {
+				readdirSpy.mockRestore();
+			}
+		});
+	});
+
+	test("shares the metadata reservation budget across candidates", async () => {
+		await withRoot(async root => {
+			await Promise.all(
+				Array.from({ length: 16 }, async (_, index) => {
+					const candidate = join(root, `candidate-${String(index).padStart(2, "0")}`);
+					await mkdir(candidate);
+					await writeFile(join(candidate, ".git"), `gitdir: ${join(root, "missing", String(index))}\n`);
+				}),
+			);
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result.some(entry => entry.kind === "overflow" && entry.reasonCode === "overflow")).toBe(true);
+		});
+	});
+
+	test("classifies empty and unrecognized directories without conflation", async () => {
+		await withRoot(async root => {
+			const empty = join(root, "empty");
+			const stray = join(root, "stray");
+			await mkdir(empty);
+			await mkdir(stray);
+			await writeFile(join(stray, "note.txt"), "content");
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result.find(entry => entry.path === renderedPath(empty))).toMatchObject({
+				kind: "empty",
+				reasonCode: "empty",
+				message: "empty directory; preserved",
+			});
+			expect(result.find(entry => entry.path === renderedPath(stray))).toMatchObject({
+				kind: "stray",
+				reasonCode: "stray",
+				message: "unrecognized directory contents; preserved",
+			});
+		});
+	});
+
+	test("classifies an empty gitfile as malformed", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "empty-gitfile");
+			await mkdir(candidate);
+			await writeFile(join(candidate, ".git"), "");
+			await expect(scanWorktrees({ root, platform: "posix" })).resolves.toEqual([
+				{
+					path: renderedPath(candidate),
+					kind: "pr-checkout",
+					reasonCode: "malformed-gitfile",
+					message: "malformed .git file; preserved",
+				},
+			]);
+		});
+	});
+	test("rejects malformed metadata without exposing raw content", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "bad");
+			await mkdir(candidate);
+			await writeFile(join(candidate, ".git"), Buffer.from([0xff, 0xfe]));
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result[0]?.message).toBe(".git file is not valid UTF-8; preserved");
+			expect(JSON.stringify(result)).not.toContain("ff");
+		});
+	});
+	test("preserves exact worker streams for empty list and root failure", async () => {
+		await withRoot(async root => {
+			await expect(
+				runWorktreeCommand({ root, platform: "posix", action: "list", json: false, dryRun: false }),
+			).resolves.toEqual({
+				stdout: "No agent-managed worktrees found.\n",
+				stderr: "",
+				exitCode: 0,
+			});
+		});
+		const missing = join(tmpdir(), "gjc-worktree-worker-missing");
+		await expect(
+			runWorktreeCommand({ root: missing, platform: "posix", action: "list", json: false, dryRun: false }),
+		).resolves.toEqual({
+			stdout: "No agent-managed worktrees found.\n",
+			stderr: "",
+			exitCode: 0,
+		});
+	});
+
+	test("rejects a linked managed root at the worker boundary", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "gjc-worktree-root-link-"));
+		const target = join(directory, "target");
+		const linked = join(directory, "linked");
+		await mkdir(target);
+		await symlink(target, linked);
+		try {
+			await expect(
+				runWorktreeCommand({ root: linked, platform: "posix", action: "list", json: false, dryRun: false }),
+			).resolves.toEqual({
+				stdout: "",
+				stderr: "error: managed worktree root cannot be read\n",
+				exitCode: 1,
+			});
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+	test("processes every sibling at maximum depth", async () => {
+		await withRoot(async root => {
+			const parent = join(root, "parent");
+			await mkdir(join(parent, "left"), { recursive: true });
+			await mkdir(join(parent, "right"), { recursive: true });
+			await mkdir(join(parent, "occupied"), { recursive: true });
+			await writeFile(join(parent, "occupied", "note.txt"), "content");
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(new Map(result.map(entry => [entry.path, entry.reasonCode]))).toEqual(
+				new Map([
+					[renderedPath(join(parent, "left")), "empty"],
+					[renderedPath(join(parent, "right")), "empty"],
+					[renderedPath(join(parent, "occupied")), "stray"],
+				]),
+			);
+		});
+	});
+
+	test("rejects pointers outside the managed root and non-reciprocal metadata", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "candidate");
+			const target = join(tmpdir(), "gjc-worktree-outside-target");
+			await mkdir(candidate);
+			await writeFile(join(candidate, ".git"), `gitdir: ${target}\n`);
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result[0]?.reasonCode).toBe("pointer-outside-root");
+			expect(JSON.stringify(result)).not.toContain(target);
+		});
+	});
+
+	test("exposes typed root-invalid and root-unreadable failures", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "gjc-worktree-file-"));
+		const file = join(directory, "root");
+		await writeFile(file, "not a directory");
+		try {
+			const invalid = await scanWorktrees({ root: file, platform: "posix" }).catch(error => error);
+			expect(invalid).toBeInstanceOf(WorktreeRootError);
+			expect((invalid as WorktreeRootError).code).toBe("root-invalid");
+			const root = join(directory, "unreadable");
+			await mkdir(root);
+			const actualLstat = fsPromises.lstat;
+			const lstatImplementation = (async (target: Parameters<typeof fsPromises.lstat>[0]) => {
+				if (String(target) === root) throw Object.assign(new Error("synthetic root failure"), { code: "EPERM" });
+				return actualLstat(target, { bigint: true });
+			}) as typeof fsPromises.lstat;
+			const lstatSpy = spyOn(fsPromises, "lstat").mockImplementation(lstatImplementation);
+			try {
+				const unreadable = await scanWorktrees({ root, platform: "posix" }).catch(error => error);
+				expect(unreadable).toBeInstanceOf(WorktreeRootError);
+				expect((unreadable as WorktreeRootError).code).toBe("root-unreadable");
+			} finally {
+				lstatSpy.mockRestore();
+			}
+			const racedRoot = join(directory, "raced");
+			await mkdir(racedRoot);
+			let rootChecks = 0;
+			const raceImplementation = (async (target: Parameters<typeof fsPromises.lstat>[0]) => {
+				const stat = await actualLstat(target, { bigint: true });
+				if (String(target) !== racedRoot || ++rootChecks < 2) return stat;
+				return symbolicDirectory(stat);
+			}) as typeof fsPromises.lstat;
+			const raceSpy = spyOn(fsPromises, "lstat").mockImplementation(raceImplementation);
+			try {
+				const raced = await scanWorktrees({ root: racedRoot, platform: "posix" }).catch(error => error);
+				expect(raced).toBeInstanceOf(WorktreeRootError);
+				expect((raced as WorktreeRootError).code).toBe("root-invalid");
+			} finally {
+				raceSpy.mockRestore();
+			}
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("performs zero child-path inspection for Windows candidates", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "candidate");
+			const external = join(root, "external");
+			await mkdir(candidate);
+			await mkdir(external);
+			await symlink(external, join(candidate, ".git"), process.platform === "win32" ? "junction" : "dir");
+			await symlink(external, join(candidate, "merged"), process.platform === "win32" ? "junction" : "dir");
+			const candidatePrefix = join(candidate, "child").slice(0, -"child".length);
+			const externalPrefix = join(external, "child").slice(0, -"child".length);
+			const lstatSpy = spyOn(fsPromises, "lstat");
+			try {
+				const result = await scanWorktrees({ root, platform: "win32" });
+				expect(result).toEqual([
+					{
+						path: renderedPath(candidate),
+						kind: "unsupported",
+						reasonCode: "unsupported-platform-proof",
+						message: "no-follow metadata proof unavailable on Windows; preserved",
+					},
+					{
+						path: renderedPath(external),
+						kind: "unsupported",
+						reasonCode: "unsupported-platform-proof",
+						message: "no-follow metadata proof unavailable on Windows; preserved",
+					},
+				]);
+				expect(result.some(entry => entry.reasonCode === "unsupported-link")).toBe(false);
+				expect(
+					lstatSpy.mock.calls.some(call => {
+						const inspected = String(call[0]);
+						return inspected.startsWith(candidatePrefix) || inspected.startsWith(externalPrefix);
+					}),
+				).toBe(false);
+			} finally {
+				lstatSpy.mockRestore();
+			}
+		});
+	});
+
+	test("requires exact reciprocal metadata inside the managed root", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "candidate");
+			const target = join(candidate, "meta", "worktrees", "one");
+			await mkdir(target, { recursive: true });
+			await writeFile(join(candidate, ".git"), `gitdir: ${target}\n`);
+			await writeFile(join(target, "HEAD"), "ref: refs/heads/topic\n");
+			await writeFile(join(target, "commondir"), "../..\n");
+			const missing = await scanWorktrees({ root, platform: "posix" });
+			expect(missing.some(entry => entry.reasonCode === "metadata-raced")).toBe(true);
+			await writeFile(join(target, "gitdir"), `${join(candidate, "wrong")}\n`);
+			const mismatched = await scanWorktrees({ root, platform: "posix" });
+			expect(mismatched.some(entry => entry.reasonCode === "invalid-pointer")).toBe(true);
+		});
+		await withRoot(async root => {
+			const candidate = join(root, "outside-reciprocal");
+			const target = join(candidate, "meta", "worktrees", "one");
+			const outside = join(tmpdir(), "gjc-outside-reciprocal");
+			await mkdir(target, { recursive: true });
+			await writeFile(join(candidate, ".git"), `gitdir: ${target}\n`);
+			await writeFile(join(target, "HEAD"), "ref: refs/heads/topic\n");
+			await writeFile(join(target, "commondir"), "../..\n");
+			await writeFile(join(target, "gitdir"), `${outside}\n`);
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result.some(entry => entry.reasonCode === "invalid-pointer")).toBe(true);
+			expect(JSON.stringify(result)).not.toContain(outside);
+		});
+	});
+
+	test("stops at the sixteenth metadata reservation", async () => {
+		await withRoot(async root => {
+			for (let index = 0; index < 16; index++) {
+				const candidate = join(root, `candidate-${String(index).padStart(2, "0")}`);
+				await mkdir(candidate);
+				await writeFile(join(candidate, ".git"), `gitdir: ${join(root, "missing", String(index))}\n`);
+			}
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result).toHaveLength(16);
+			expect(result.slice(0, 15).every(entry => entry.reasonCode !== "overflow")).toBe(true);
+			expect(result[15]).toMatchObject({ kind: "overflow", reasonCode: "overflow" });
+		});
+	});
+
+	test("fails closed when O_NOFOLLOW is unavailable", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "no-follow-unavailable");
+			await mkdir(candidate);
+			await writeFile(join(candidate, ".git"), "malformed");
+			const original = constants.O_NOFOLLOW;
+			Object.defineProperty(constants, "O_NOFOLLOW", { value: undefined, configurable: true, writable: true });
+			try {
+				await expect(scanWorktrees({ root, platform: "posix" })).resolves.toEqual([
+					{
+						path: renderedPath(candidate),
+						kind: "unsupported",
+						reasonCode: "unsupported-platform-proof",
+						message: "no-follow metadata proof unavailable; preserved",
+					},
+				]);
+			} finally {
+				Object.defineProperty(constants, "O_NOFOLLOW", { value: original, configurable: true, writable: true });
+			}
+		});
+	});
+	test("fails closed when O_NONBLOCK is unavailable", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "non-blocking-unavailable");
+			await mkdir(candidate);
+			await writeFile(join(candidate, ".git"), "malformed");
+			const originalNoFollow = constants.O_NOFOLLOW;
+			const originalNonBlock = constants.O_NONBLOCK;
+			const safeNoFollow = typeof originalNoFollow === "number" ? originalNoFollow : 0;
+			Object.defineProperty(constants, "O_NOFOLLOW", { value: safeNoFollow, configurable: true, writable: true });
+			Object.defineProperty(constants, "O_NONBLOCK", { value: undefined, configurable: true, writable: true });
+			let statCalls = 0;
+			let readCalls = 0;
+			let closeCalls = 0;
+			const openSpy = spyOn(fsPromises, "open").mockImplementation(async () => {
+				return {
+					stat: async () => {
+						statCalls++;
+						throw new Error("unexpected stat call");
+					},
+					read: async () => {
+						readCalls++;
+						throw new Error("unexpected read call");
+					},
+					close: async () => {
+						closeCalls++;
+					},
+				} as unknown as FileHandle;
+			});
+			const allocationSpy = spyOn(Buffer, "allocUnsafe");
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				expect(result).toEqual([
+					{
+						path: renderedPath(candidate),
+						kind: "unsupported",
+						reasonCode: "unsupported-platform-proof",
+						message: "non-blocking metadata proof unavailable; preserved",
+					},
+				]);
+				expect(result.filter(entry => entry.reasonCode === "unsupported-platform-proof")).toHaveLength(1);
+				expect(openSpy).not.toHaveBeenCalled();
+				expect(statCalls).toBe(0);
+				expect(readCalls).toBe(0);
+				expect(closeCalls).toBe(0);
+				expect(allocationSpy).not.toHaveBeenCalled();
+			} finally {
+				allocationSpy.mockRestore();
+				openSpy.mockRestore();
+				Object.defineProperty(constants, "O_NOFOLLOW", {
+					value: originalNoFollow,
+					configurable: true,
+					writable: true,
+				});
+				Object.defineProperty(constants, "O_NONBLOCK", {
+					value: originalNonBlock,
+					configurable: true,
+					writable: true,
+				});
+			}
+		});
+	});
+	test("never opens final-component links and revalidates pointer ancestors", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "linked-git");
+			const external = join(root, "external-metadata");
+			await mkdir(candidate);
+			await writeFile(external, "malformed");
+			await symlink(external, join(candidate, ".git"));
+			const openSpy = spyOn(fsPromises, "open");
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				expect(result.find(entry => entry.path === renderedPath(candidate))?.reasonCode).toBe("unsupported-link");
+				expect(openSpy).not.toHaveBeenCalled();
+			} finally {
+				openSpy.mockRestore();
+			}
+		});
+		await withRoot(async root => {
+			const candidate = join(root, "ancestor-race");
+			const target = join(candidate, "meta", "worktrees", "one");
+			await mkdir(target, { recursive: true });
+			await writeFile(join(candidate, ".git"), `gitdir: ${target}\n`);
+			await writeFile(join(target, "commondir"), "../..\n");
+			await writeFile(join(target, "HEAD"), "ref: refs/heads/topic\n");
+			await writeFile(join(target, "gitdir"), `${join(candidate, ".git")}\n`);
+			const actualLstat = fsPromises.lstat;
+			let targetChecks = 0;
+			const lstatImplementation = (async (inspected: Parameters<typeof fsPromises.lstat>[0]) => {
+				const stat = await actualLstat(inspected, { bigint: true });
+				if (String(inspected) !== target || ++targetChecks < 2) return stat;
+				return symbolicDirectory(stat);
+			}) as typeof fsPromises.lstat;
+			const lstatSpy = spyOn(fsPromises, "lstat").mockImplementation(lstatImplementation);
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				expect(result.some(entry => entry.reasonCode === "unsupported-link")).toBe(true);
+				expect(result.some(entry => entry.reasonCode === "normal-pr")).toBe(false);
+			} finally {
+				lstatSpy.mockRestore();
+			}
+		});
+		await withRoot(async root => {
+			const candidate = join(root, "primary-ancestor-race");
+			await mkdir(candidate);
+			await writeFile(join(candidate, ".git"), "malformed");
+			const actualLstat = fsPromises.lstat;
+			let candidateChecks = 0;
+			const lstatImplementation = (async (inspected: Parameters<typeof fsPromises.lstat>[0]) => {
+				const stat = await actualLstat(inspected, { bigint: true });
+				if (String(inspected) !== candidate || ++candidateChecks < 3) return stat;
+				return symbolicDirectory(stat);
+			}) as typeof fsPromises.lstat;
+			const lstatSpy = spyOn(fsPromises, "lstat").mockImplementation(lstatImplementation);
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				expect(result.find(entry => entry.path === renderedPath(candidate))?.reasonCode).toBe("unsupported-link");
+				expect(result.some(entry => entry.reasonCode === "malformed-gitfile")).toBe(false);
+			} finally {
+				lstatSpy.mockRestore();
+			}
+		});
+	});
+
+	test("distinguishes directory I/O failures from path races", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "candidate-io");
+			await mkdir(candidate);
+			const actualLstat = fsPromises.lstat;
+			const lstatImplementation = (async (inspected: Parameters<typeof fsPromises.lstat>[0]) => {
+				if (String(inspected) === candidate)
+					throw Object.assign(new Error("synthetic candidate failure"), { code: "EPERM" });
+				return actualLstat(inspected, { bigint: true });
+			}) as typeof fsPromises.lstat;
+			const lstatSpy = spyOn(fsPromises, "lstat").mockImplementation(lstatImplementation);
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				expect(result.find(entry => entry.path === renderedPath(candidate))).toMatchObject({
+					kind: "unsupported",
+					reasonCode: "scan-error",
+					message: "cannot inspect directory; preserved",
+				});
+			} finally {
+				lstatSpy.mockRestore();
+			}
+		});
+		await withRoot(async root => {
+			const nested = join(root, "nested-io");
+			await mkdir(nested);
+			const actualReaddir = fsPromises.readdir;
+			const readdirImplementation = (async (inspected: Parameters<typeof fsPromises.readdir>[0]) => {
+				if (String(inspected) === nested)
+					throw Object.assign(new Error("synthetic nested failure"), { code: "EIO" });
+				return actualReaddir(inspected, { withFileTypes: true, encoding: "buffer" });
+			}) as unknown as typeof fsPromises.readdir;
+			const readdirSpy = spyOn(fsPromises, "readdir").mockImplementation(readdirImplementation);
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				expect(result.find(entry => entry.path === renderedPath(nested))).toMatchObject({
+					kind: "unsupported",
+					reasonCode: "scan-error",
+					message: "cannot inspect directory; preserved",
+				});
+			} finally {
+				readdirSpy.mockRestore();
+			}
+		});
+	});
+
+	test("proves exact 15-of-16 metadata reservation operations", async () => {
+		await withRoot(async root => {
+			for (let index = 0; index < 16; index++) {
+				const candidate = join(root, `protocol-${String(index).padStart(2, "0")}`);
+				await mkdir(candidate);
+				await writeFile(join(candidate, ".git"), `gitdir: ${join(root, "missing", String(index))}\n`);
+			}
+			const operations: string[] = [];
+			const reads: Array<{ file: string; offset: number; length: number; position: number }> = [];
+			const actualAllocUnsafe = Buffer.allocUnsafe;
+			const allocationSpy = spyOn(Buffer, "allocUnsafe").mockImplementation(size => {
+				operations.push("allocate");
+				return actualAllocUnsafe(size);
+			});
+			const lstatSpy = spyOn(fsPromises, "lstat");
+			const actualOpen = fsPromises.open;
+			const openFlags: unknown[] = [];
+			const openSpy = spyOn(fsPromises, "open").mockImplementation(async (target, flags) => {
+				const file = String(target);
+				operations.push(`open:${file}`);
+				openFlags.push(flags);
+				const handle = await actualOpen(target, flags);
+				return {
+					stat: async (_options: { bigint: true }) => {
+						operations.push(`stat:${file}`);
+						return handle.stat({ bigint: true });
+					},
+					read: async (buffer: Buffer, offset: number, length: number, position: number) => {
+						operations.push(`read:${file}`);
+						reads.push({ file, offset, length, position });
+						return handle.read(buffer, offset, length, position);
+					},
+					close: async () => {
+						operations.push(`close:${file}`);
+						await handle.close();
+					},
+				} as unknown as FileHandle;
+			});
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				const overflowPath = result.find(entry => entry.kind === "overflow")?.path;
+				expect(overflowPath).toBeDefined();
+				const gitLstatCalls = lstatSpy.mock.calls.filter(call => String(call[0]).endsWith("/.git"));
+				expect(gitLstatCalls).toHaveLength(16);
+				expect(new Set(gitLstatCalls.map(call => String(call[0])))).toHaveLength(16);
+				expect(gitLstatCalls.every(call => String(call[0]).endsWith("/.git"))).toBe(true);
+				expect(operations.filter(operation => operation.startsWith("open:"))).toHaveLength(15);
+				expect(
+					openFlags.every(flags => flags === (constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK)),
+				).toBe(true);
+				expect(operations.filter(operation => operation.startsWith("stat:"))).toHaveLength(15);
+				expect(
+					new Set(
+						operations.filter(operation => operation.startsWith("read:")).map(operation => operation.slice(5)),
+					),
+				).toHaveLength(15);
+				expect(operations.filter(operation => operation.startsWith("close:"))).toHaveLength(15);
+				expect(allocationSpy).toHaveBeenCalledTimes(15);
+				expect(allocationSpy.mock.calls.every(call => call[0] === MAX_METADATA_BYTES + 1)).toBe(true);
+				expect(operations).toHaveLength(90);
+				for (let index = 0; index < 15; index++) {
+					const sequence = operations.slice(index * 6, index * 6 + 6);
+					expect(sequence.map(operation => operation.split(":")[0])).toEqual([
+						"open",
+						"stat",
+						"allocate",
+						"read",
+						"read",
+						"close",
+					]);
+					const file = sequence[0]!.slice("open:".length);
+					expect(sequence[1]).toBe(`stat:${file}`);
+					expect(sequence[3]).toBe(`read:${file}`);
+					expect(sequence[4]).toBe(`read:${file}`);
+					expect(sequence[5]).toBe(`close:${file}`);
+					const fileReads = reads.filter(read => read.file === file);
+					expect(fileReads).toHaveLength(2);
+					expect(fileReads[0]).toMatchObject({ offset: 0, position: 0, length: CHUNK_BYTES_FOR_TEST });
+					expect(fileReads[1]!.offset).toBe(fileReads[1]!.position);
+					expect(fileReads[1]!.offset).toBeGreaterThan(0);
+					expect(fileReads[1]!.length).toBeGreaterThan(0);
+					expect(fileReads[1]!.length).toBeLessThanOrEqual(CHUNK_BYTES_FOR_TEST);
+				}
+				const overflowGit = `${overflowPath}/.git`;
+				expect(gitLstatCalls.some(call => String(call[0]) === overflowGit)).toBe(true);
+				expect(operations).not.toContain(`open:${overflowGit}`);
+			} finally {
+				lstatSpy.mockRestore();
+				openSpy.mockRestore();
+				allocationSpy.mockRestore();
+			}
+		});
+	});
+
+	test("does not refund a reservation after an open failure", async () => {
+		await withRoot(async root => {
+			for (let index = 0; index < 16; index++) {
+				const candidate = join(root, `nonrefundable-${String(index).padStart(2, "0")}`);
+				await mkdir(candidate);
+				await writeFile(join(candidate, ".git"), `gitdir: ${join(root, "missing", String(index))}\n`);
+			}
+			const actualOpen = fsPromises.open;
+			let openCalls = 0;
+			const openSpy = spyOn(fsPromises, "open").mockImplementation(async (target, flags) => {
+				openCalls++;
+				if (openCalls === 1) throw Object.assign(new Error("synthetic open failure"), { code: "EPERM" });
+				return actualOpen(target, flags);
+			});
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				expect(openCalls).toBe(15);
+				expect(result.filter(entry => entry.reasonCode === "unreadable-gitfile")).toHaveLength(1);
+				expect(result.at(-1)).toMatchObject({ kind: "overflow", reasonCode: "overflow" });
+			} finally {
+				openSpy.mockRestore();
+			}
+		});
+	});
+	test.skipIf(process.platform === "win32")(
+		"does not block when metadata is replaced by a FIFO before open",
+		async () => {
+			await withRoot(async root => {
+				const candidate = join(root, "fifo-race");
+				const gitFile = join(candidate, ".git");
+				await mkdir(candidate);
+				await writeFile(gitFile, "malformed");
+
+				const actualOpen = fsPromises.open;
+				let swapped = false;
+				const openSpy = spyOn(fsPromises, "open").mockImplementation(async (target, flags) => {
+					if (String(target) === gitFile && !swapped) {
+						expect(flags).toBe(constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+						swapped = true;
+						await rm(gitFile, { force: true });
+						const mkfifo = Bun.spawnSync(["mkfifo", gitFile], {
+							stdout: "ignore",
+							stderr: "ignore",
+						});
+						if (mkfifo.exitCode !== 0) throw new Error("mkfifo failed");
+					}
+					return actualOpen(target, flags);
+				});
+
+				let timeout: NodeJS.Timeout | undefined;
+				let scan: Promise<WorktreeDiagnostic[]> | undefined;
+				const started = performance.now();
+				try {
+					scan = scanWorktrees({ root, platform: "posix" });
+					const result = await Promise.race([
+						scan,
+						new Promise<never>((_, reject) => {
+							timeout = setTimeout(() => reject(new Error("FIFO metadata open hung")), 2_000);
+						}),
+					]).catch(async error => {
+						if (!(error instanceof Error) || error.message !== "FIFO metadata open hung") throw error;
+						const rescue = await actualOpen(gitFile, constants.O_WRONLY | constants.O_NONBLOCK);
+						let cleanupError: unknown;
+						try {
+							await scan;
+						} catch (cause) {
+							cleanupError = cause;
+						}
+						try {
+							await rescue.close();
+						} catch (cause) {
+							cleanupError ??= cause;
+						}
+						if (cleanupError !== undefined) throw new AggregateError([error, cleanupError], error.message);
+						throw error;
+					});
+					expect(performance.now() - started).toBeLessThan(2_000);
+					expect(result).toEqual([
+						{
+							path: renderedPath(candidate),
+							kind: "unsupported",
+							reasonCode: "metadata-raced",
+							message: "filesystem metadata changed during scan; preserved",
+						},
+					]);
+					expect(swapped).toBe(true);
+					expect((await fsPromises.lstat(gitFile)).isFIFO()).toBe(true);
+					expect(await fsPromises.readdir(candidate)).toEqual([".git"]);
+					expect(JSON.stringify(result)).not.toContain("malformed");
+				} finally {
+					if (timeout !== undefined) clearTimeout(timeout);
+					openSpy.mockRestore();
+				}
+			});
+		},
+	);
+
+	test("maps open, stat, read, identity, and close failures by phase", async () => {
+		const scenarios: Array<{
+			name: string;
+			openCode?: string;
+			statCode?: string;
+			readCodeAfterChunk?: string;
+			identitySwap?: boolean;
+			closeCode?: string;
+			expected: string;
+		}> = [
+			{ name: "open link", openCode: "ELOOP", expected: "unsupported-link" },
+			{ name: "open missing", openCode: "ENOENT", expected: "metadata-raced" },
+			{ name: "open denied", openCode: "EPERM", expected: "unreadable-gitfile" },
+			{ name: "handle stat race", statCode: "EBADF", expected: "metadata-raced" },
+			{ name: "handle stat denied", statCode: "EPERM", expected: "unreadable-gitfile" },
+			{ name: "identity swap", identitySwap: true, expected: "metadata-raced" },
+			{ name: "read race", readCodeAfterChunk: "EBADF", expected: "metadata-raced" },
+			{ name: "partial read failure", readCodeAfterChunk: "EPERM", expected: "unreadable-gitfile" },
+			{
+				name: "read race and close failure",
+				readCodeAfterChunk: "EBADF",
+				closeCode: "EIO",
+				expected: "metadata-raced",
+			},
+			{ name: "close failure", closeCode: "EIO", expected: "unreadable-gitfile" },
+		];
+		for (const scenario of scenarios) {
+			await withRoot(async root => {
+				const candidate = join(root, scenario.name.replaceAll(" ", "-"));
+				const gitFile = join(candidate, ".git");
+				await mkdir(candidate);
+				await writeFile(gitFile, "malformed");
+				const stat = await fsPromises.lstat(gitFile, { bigint: true });
+				let reads = 0;
+				const openSpy = spyOn(fsPromises, "open").mockImplementation(async () => {
+					if (scenario.openCode)
+						throw Object.assign(new Error("synthetic open error"), { code: scenario.openCode });
+					return {
+						stat: async (_options: { bigint: true }) => {
+							if (scenario.statCode)
+								throw Object.assign(new Error("synthetic stat error"), { code: scenario.statCode });
+							if (!scenario.identitySwap) return stat;
+							return {
+								dev: stat.dev,
+								ino: stat.ino + 1n,
+								isFile: () => true,
+								isDirectory: () => false,
+								isSymbolicLink: () => false,
+							};
+						},
+						read: async (buffer: Buffer, offset: number) => {
+							reads++;
+							if (scenario.readCodeAfterChunk && reads > 1)
+								throw Object.assign(new Error("synthetic read error"), {
+									code: scenario.readCodeAfterChunk,
+								});
+							if (reads > 1) return { bytesRead: 0, buffer };
+							const content = Buffer.from("malformed");
+							content.copy(buffer, offset);
+							return { bytesRead: content.length, buffer };
+						},
+						close: async () => {
+							if (scenario.closeCode)
+								throw Object.assign(new Error("synthetic close error"), { code: scenario.closeCode });
+						},
+					} as unknown as FileHandle;
+				});
+				try {
+					const result = await scanWorktrees({ root, platform: "posix" });
+					expect(result, scenario.name).toHaveLength(1);
+					expect(result[0]?.reasonCode, scenario.name).toBe(scenario.expected);
+				} finally {
+					openSpy.mockRestore();
+				}
+			});
+		}
+	});
+	test("covers every hostile HEAD, commondir, and reciprocal gitdir family failure in precedence order", async () => {
+		const families = [
+			{
+				name: "HEAD",
+				file: "HEAD",
+				failures: [
+					["unreadable", "unreadable-head", "unreadable"],
+					["oversize", "oversize-head", Buffer.alloc(MAX_METADATA_BYTES + 1, 0x61)],
+					["invalid-utf8", "invalid-utf8-head", Buffer.from([0xff])],
+					["NUL", "nul-head", Buffer.from("ref: refs/heads/topic\0")],
+					["malformed", "malformed-head", "not-a-head"],
+				],
+				later: ["unreadable-gitdir", "oversize-gitdir", "invalid-utf8-gitdir", "nul-gitdir", "invalid-pointer"],
+			},
+			{
+				name: "commondir",
+				file: "commondir",
+				failures: [
+					["unreadable", "unreadable-commondir", "unreadable"],
+					["oversize", "oversize-commondir", Buffer.alloc(MAX_METADATA_BYTES + 1, 0x61)],
+					["invalid-utf8", "invalid-utf8-commondir", Buffer.from([0xff])],
+					["NUL", "nul-commondir", Buffer.from("../..\0")],
+					["malformed", "common-dir", ""],
+				],
+				later: [
+					"unreadable-head",
+					"oversize-head",
+					"invalid-utf8-head",
+					"nul-head",
+					"malformed-head",
+					"unreadable-gitdir",
+				],
+			},
+			{
+				name: "gitdir",
+				file: "gitdir",
+				failures: [
+					["unreadable", "unreadable-gitdir", "unreadable"],
+					["oversize", "oversize-gitdir", Buffer.alloc(MAX_METADATA_BYTES + 1, 0x61)],
+					["invalid-utf8", "invalid-utf8-gitdir", Buffer.from([0xff])],
+					["NUL", "nul-gitdir", Buffer.from(`${join("/tmp", "candidate", ".git")}\0`)],
+					["malformed", "invalid-pointer", ""],
+				],
+				later: [],
+			},
+		] as const;
+		for (const family of families) {
+			for (const [label, expected, content] of family.failures) {
+				await withRoot(async root => {
+					const candidate = join(root, `${family.name}-${label}`);
+					const target = join(candidate, "meta", "worktrees", "one");
+					await mkdir(target, { recursive: true });
+					await writeFile(join(candidate, ".git"), `gitdir: ${target}\n`);
+					await writeFile(join(target, "commondir"), "../..\n");
+					await writeFile(join(target, "HEAD"), "ref: refs/heads/topic\n");
+					await writeFile(join(target, "gitdir"), `${join(candidate, ".git")}\n`);
+					await writeFile(join(target, family.file), content);
+					if (family.name === "commondir") {
+						await writeFile(join(target, "HEAD"), "not-a-head");
+						await writeFile(join(target, "gitdir"), "");
+					} else if (family.name === "HEAD") {
+						await writeFile(join(target, "gitdir"), "");
+					}
+					const actualOpen = fsPromises.open;
+					const openSpy = spyOn(fsPromises, "open").mockImplementation(async (filePath, flags) => {
+						if (label === "unreadable" && String(filePath) === join(target, family.file))
+							throw Object.assign(new Error("synthetic unreadable metadata"), { code: "EACCES" });
+						return actualOpen(filePath, flags);
+					});
+					try {
+						const result = await scanWorktrees({ root, platform: "posix" });
+						const candidateResult = result.find(entry => entry.path === renderedPath(candidate));
+						expect(candidateResult?.reasonCode, `${family.name}/${label}`).toBe(expected);
+						expect(result.some(entry => family.later.some(reason => reason === entry.reasonCode))).toBe(false);
+						expect(result.some(entry => entry.reasonCode === "normal-pr")).toBe(false);
+					} finally {
+						openSpy.mockRestore();
+					}
+				});
+			}
+		}
+	});
+
+	test("distinguishes 65536-byte metadata from a 65537-byte overflow read", async () => {
+		await withRoot(async root => {
+			const exact = join(root, "exact");
+			const oversized = join(root, "oversized");
+			const invalidUtf8 = join(root, "invalid-utf8");
+			await mkdir(exact);
+			await mkdir(oversized);
+			await mkdir(invalidUtf8);
+			await writeFile(join(exact, ".git"), Buffer.alloc(MAX_METADATA_BYTES, 0x61));
+			await writeFile(join(oversized, ".git"), Buffer.alloc(MAX_METADATA_BYTES + 1, 0x61));
+			await writeFile(join(invalidUtf8, ".git"), Buffer.from([0xff]));
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result.find(entry => entry.path === renderedPath(exact))?.reasonCode).toBe("malformed-gitfile");
+			expect(result.find(entry => entry.path === renderedPath(oversized))?.reasonCode).toBe("oversize-gitfile");
+			expect(result.find(entry => entry.path === renderedPath(invalidUtf8))?.reasonCode).toBe(
+				"invalid-utf8-gitfile",
+			);
+		});
+	});
+
+	test("maps a non-ENOENT root failure to fixed text and JSON errors", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "gjc-worktree-worker-file-"));
+		const file = join(dir, "root");
+		await writeFile(file, "not a directory");
+		try {
+			await expect(
+				runWorktreeCommand({ root: file, platform: "posix", action: "list", json: false, dryRun: false }),
+			).resolves.toEqual({
+				stdout: "",
+				stderr: "error: managed worktree root cannot be read\n",
+				exitCode: 1,
+			});
+			await expect(
+				runWorktreeCommand({ root: file, platform: "posix", action: "list", json: true, dryRun: false }),
+			).resolves.toEqual({
+				stdout: '{"error":{"code":"worktree_scan_failed","message":"managed worktree root cannot be read"}}\n',
+				stderr: "",
+				exitCode: 1,
+			});
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("escapes non-ASCII display paths and caps them at 512 bytes", async () => {
+		await withRoot(async root => {
+			const part = "한".repeat(50);
+			await mkdir(join(root, part, part), { recursive: true });
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result.some(entry => entry.path.includes("\\uD55C"))).toBe(true);
+			expect(result.every(entry => Buffer.byteLength(entry.path) <= 512)).toBe(true);
+			expect(result.some(entry => entry.path.endsWith("…[truncated]"))).toBe(true);
+			for (const entry of result.filter(candidate => candidate.path.endsWith("…[truncated]"))) {
+				const prefix = entry.path.slice(0, -"…[truncated]".length);
+				expect(prefix.replace(/\\(?:\\|n|r|t|u[0-9A-F]{4})/g, "")).not.toContain("\\");
+			}
+		});
+	});
+
+	test.skipIf(process.platform === "win32")("renders invalid raw names once without double escaping", async () => {
+		await withRoot(async root => {
+			await mkdir(join(root, "bad\\name"));
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result.find(entry => entry.path.includes("bad"))?.path).toBe(`${root}/bad\\\\name`);
+		});
+	});
+	test("renders synthetic oversized raw names with an unambiguous truncation suffix", async () => {
+		await withRoot(async root => {
+			const raw = Buffer.alloc(MAX_NAME_UTF8_BYTES + 1, 0x61);
+			const readdirSpy = spyOn(fsPromises, "readdir").mockResolvedValue([{ name: raw }] as never);
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				expect(result).toHaveLength(1);
+				expect(result[0]?.reasonCode).toBe("oversize-name");
+				expect(result[0]?.path.endsWith("…[truncated]")).toBe(true);
+				expect(Buffer.byteLength(result[0]?.path ?? "")).toBeLessThanOrEqual(512);
+			} finally {
+				readdirSpy.mockRestore();
+			}
+		});
+	});
+
+	test("renders synthetic invalid UTF-8 bytes as uppercase percent escapes", async () => {
+		await withRoot(async root => {
+			const readdirSpy = spyOn(fsPromises, "readdir").mockResolvedValue([{ name: Buffer.from([0xff]) }] as never);
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				expect(result).toEqual([
+					{
+						path: renderedPath(join(root, "%FF")),
+						kind: "unsupported",
+						reasonCode: "invalid-name",
+						message: "invalid UTF-8 directory name; preserved",
+					},
+				]);
+			} finally {
+				readdirSpy.mockRestore();
+			}
+		});
+	});
+	test.skipIf(process.platform !== "linux")(
+		"renders invalid UTF-8 directory bytes as uppercase percent escapes",
+		async () => {
+			await withRoot(async root => {
+				const invalidBytePath = Buffer.concat([Buffer.from(`${root}/`), Buffer.from([0xff])]);
+				await mkdir(invalidBytePath);
+				const result = await scanWorktrees({ root, platform: "posix" });
+				expect(
+					result.some(entry => entry.path === renderedPath(`${root}/%FF`) && entry.reasonCode === "invalid-name"),
+				).toBe(true);
+			});
+		},
+	);
+
+	test("accepts relative CRLF pointers and detached HEAD metadata", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "relative");
+			const target = join(candidate, "meta", "worktrees", "one");
+			await mkdir(target, { recursive: true });
+			await writeFile(join(candidate, ".git"), "gitdir: meta/worktrees/one\r\n");
+			await writeFile(join(target, "commondir"), "../..\r\n");
+			await writeFile(join(target, "HEAD"), `${"a".repeat(40)}\r\n`);
+			await writeFile(join(target, "gitdir"), `${join(candidate, ".git")}\r\n`);
+			await expect(scanWorktrees({ root, platform: "posix" })).resolves.toEqual([
+				{
+					path: renderedPath(candidate),
+					kind: "pr-checkout",
+					reasonCode: "normal-pr",
+					message: "worktree metadata observed; preserved",
+				},
+			]);
+		});
+	});
+
+	test("uses frozen diagnostics for NUL, network pointers, and bare repositories", async () => {
+		await withRoot(async root => {
+			const nul = join(root, "nul");
+			const network = join(root, "network");
+			const bare = join(root, "bare");
+			await mkdir(nul);
+			await mkdir(network);
+			await mkdir(join(bare, ".git"), { recursive: true });
+			await writeFile(join(nul, ".git"), "gitdir: inside\0\n");
+			await writeFile(join(network, ".git"), "gitdir: //server/share\n");
+			const result = await scanWorktrees({ root, platform: "posix" });
+			expect(result.find(entry => entry.path === renderedPath(nul))).toMatchObject({
+				kind: "pr-checkout",
+				reasonCode: "nul-gitfile",
+				message: ".git file contains NUL; preserved",
+			});
+			expect(result.find(entry => entry.path === renderedPath(network))).toMatchObject({
+				kind: "pr-checkout",
+				reasonCode: "unc-network",
+				message: "network gitdir pointer unsupported; preserved",
+			});
+			expect(result.find(entry => entry.path === renderedPath(bare))).toMatchObject({
+				kind: "pr-checkout",
+				reasonCode: "bare-repository",
+				message: ".git directory observed; preserved",
+			});
+		});
+	});
+
+	test("shares one exact 15-of-16 reservation protocol across metadata categories", async () => {
+		await withRoot(async root => {
+			const metadataPaths: string[] = [];
+			for (let index = 0; index < 4; index++) {
+				const candidate = join(root, `multi-${index}`);
+				const target = join(candidate, "meta", "worktrees", "one");
+				const git = join(candidate, ".git");
+				const commondir = join(target, "commondir");
+				const head = join(target, "HEAD");
+				const reciprocal = join(target, "gitdir");
+				metadataPaths.push(git, commondir, head, reciprocal);
+				await mkdir(target, { recursive: true });
+				await writeFile(git, `gitdir: ${target}\n`);
+				await writeFile(commondir, "../..\n");
+				await writeFile(head, "ref: refs/heads/topic\n");
+				await writeFile(reciprocal, `${git}\n`);
+			}
+			const metadataSet = new Set(metadataPaths);
+			const lstatSpy = spyOn(fsPromises, "lstat");
+			const openSpy = spyOn(fsPromises, "open");
+			const allocationSpy = spyOn(Buffer, "allocUnsafe");
+			try {
+				const result = await scanWorktrees({ root, platform: "posix" });
+				const metadataLstats = lstatSpy.mock.calls.filter(call => metadataSet.has(String(call[0])));
+				expect(metadataLstats).toHaveLength(16);
+				const openedMetadataPaths = openSpy.mock.calls.map(call => String(call[0]));
+				expect(openedMetadataPaths).toHaveLength(15);
+				expect(allocationSpy).toHaveBeenCalledTimes(15);
+				expect(openedMetadataPaths).toEqual(metadataLstats.slice(0, 15).map(call => String(call[0])));
+				const rejectedMetadataPath = String(metadataLstats[15]?.[0]);
+				expect(openedMetadataPaths).not.toContain(rejectedMetadataPath);
+				expect(result.at(-1)).toMatchObject({ kind: "overflow", reasonCode: "overflow" });
+				expect(result.filter(entry => entry.reasonCode === "normal-pr")).toHaveLength(3);
+			} finally {
+				lstatSpy.mockRestore();
+				openSpy.mockRestore();
+				allocationSpy.mockRestore();
+			}
+		});
+	});
+
+	test("renders exact list and clear report-only output contracts", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "bare");
+			await mkdir(join(candidate, ".git"), { recursive: true });
+			await expect(
+				runWorktreeCommand({ root, platform: "posix", action: "list", json: false, dryRun: false }),
+			).resolves.toEqual({
+				stdout: `diagnostic  ${candidate}  .git directory observed; preserved\n\n1 total\n`,
+				stderr: "",
+				exitCode: 0,
+			});
+			await expect(
+				runWorktreeCommand({ root, platform: "posix", action: "clear", json: false, dryRun: false }),
+			).resolves.toEqual({
+				stdout: `kept    ${candidate}\n\n0 removed · 1 kept\n`,
+				stderr: "",
+				exitCode: 0,
+			});
+			await expect(
+				runWorktreeCommand({ root, platform: "posix", action: "clear", json: true, dryRun: false }),
+			).resolves.toEqual({
+				stdout: '{"removed":0,"kept":1}\n',
+				stderr: "",
+				exitCode: 0,
+			});
+			await expect(
+				runWorktreeCommand({ root, platform: "posix", action: "clear", json: true, dryRun: true }),
+			).resolves.toEqual({
+				stdout: '{"wouldRemove":[]}\n',
+				stderr: "",
+				exitCode: 0,
+			});
+		});
+	});
+});
+
+describe("worktree command factory", () => {
+	test("does not resolve the root for disabled cleanup modes", async () => {
+		let getterCalls = 0;
+		const Command = createWorktreeCommand(() => {
+			getterCalls += 1;
+			return "/should-not-be-read";
+		});
+		const stdout: string[] = [];
+		const stderr: string[] = [];
+		const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(chunk => {
+			stdout.push(String(chunk));
+			return true;
+		});
+		const stderrSpy = spyOn(process.stderr, "write").mockImplementation(chunk => {
+			stderr.push(String(chunk));
+			return true;
+		});
+		const previousExitCode = process.exitCode;
+		try {
+			await new Command(["list", "--all", "--json"], {
+				bin: "gjc",
+				version: "test",
+				commands: new Map(),
+			}).run();
+			expect(getterCalls).toBe(0);
+			expect(stdout.join("")).toBe(
+				'{"error":{"code":"worktree_cleanup_disabled","message":"worktree cleanup is report-only"}}\n',
+			);
+			expect(stderr).toEqual([]);
+			expect(process.exitCode).toBe(2);
+		} finally {
+			process.exitCode = previousExitCode ?? 0;
+			stdoutSpy.mockRestore();
+			stderrSpy.mockRestore();
+		}
+	});
+
+	test("resolves the root exactly once for every valid form", async () => {
+		await withRoot(async root => {
+			const cases: Array<{ argv: string[]; stdout: string }> = [
+				{ argv: [], stdout: "No agent-managed worktrees found.\n" },
+				{ argv: ["list"], stdout: "No agent-managed worktrees found.\n" },
+				{ argv: ["list", "--json"], stdout: "[]\n" },
+				{ argv: ["clear"], stdout: "No worktrees are eligible for removal; cleanup is report-only.\n" },
+				{
+					argv: ["clear", "--dry-run"],
+					stdout: "No worktrees are eligible for removal; cleanup is report-only.\n",
+				},
+				{ argv: ["clear", "--json"], stdout: '{"removed":0,"kept":0}\n' },
+				{ argv: ["clear", "--dry-run", "--json"], stdout: '{"wouldRemove":[]}\n' },
+			];
+			for (const item of cases) {
+				let getterCalls = 0;
+				const Command = createWorktreeCommand(() => {
+					getterCalls++;
+					return root;
+				});
+				const stdout: string[] = [];
+				const stderr: string[] = [];
+				const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(chunk => {
+					stdout.push(String(chunk));
+					return true;
+				});
+				const stderrSpy = spyOn(process.stderr, "write").mockImplementation(chunk => {
+					stderr.push(String(chunk));
+					return true;
+				});
+				try {
+					await new Command(item.argv, { bin: "gjc", version: "test", commands: new Map() }).run();
+					expect(getterCalls, item.argv.join(" ")).toBe(1);
+					expect(stdout.join(""), item.argv.join(" ")).toBe(item.stdout);
+					expect(stderr, item.argv.join(" ")).toEqual([]);
+				} finally {
+					stdoutSpy.mockRestore();
+					stderrSpy.mockRestore();
+				}
+			}
+		});
+	});
+
+	test("rejects every disabled flag combination before resolving the root", async () => {
+		for (const argv of [
+			["--all"],
+			["--dry-run"],
+			["--all", "--dry-run"],
+			["list", "--dry-run"],
+			["list", "--all"],
+			["list", "--all", "--dry-run"],
+			["clear", "--all"],
+			["clear", "--all", "--dry-run"],
+			["list", "--", "--all"],
+			["clear", "--", "--all"],
+			["list", "--", "--dry-run"],
+			["clear", "list"],
+			["--all", "list"],
+			["-n", "list"],
+			["list", "clear"],
+			["clear", "clear"],
+		]) {
+			let getterCalls = 0;
+			const Command = createWorktreeCommand(() => {
+				getterCalls++;
+				return "/must-not-be-read";
+			});
+			const stdout: string[] = [];
+			const stderr: string[] = [];
+			const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(chunk => {
+				stdout.push(String(chunk));
+				return true;
+			});
+			const stderrSpy = spyOn(process.stderr, "write").mockImplementation(chunk => {
+				stderr.push(String(chunk));
+				return true;
+			});
+			const previousExitCode = process.exitCode;
+			try {
+				await new Command(argv, { bin: "gjc", version: "test", commands: new Map() }).run();
+				expect(getterCalls).toBe(0);
+				expect(stdout).toEqual([]);
+				expect(stderr.join("")).toBe("error: worktree cleanup is report-only\n");
+				expect(process.exitCode).toBe(2);
+			} finally {
+				process.exitCode = previousExitCode ?? 0;
+				stdoutSpy.mockRestore();
+				stderrSpy.mockRestore();
+			}
+		}
+	});
+
+	test("renders every disabled JSON form without resolving the root", async () => {
+		for (const argv of [
+			["--all", "--json"],
+			["--dry-run", "--json"],
+			["--all", "--dry-run", "--json"],
+			["list", "--dry-run", "--json"],
+			["list", "--all", "--json"],
+			["list", "--all", "--dry-run", "--json"],
+			["clear", "--all", "--json"],
+			["clear", "--all", "--dry-run", "--json"],
+		]) {
+			let getterCalls = 0;
+			const Command = createWorktreeCommand(() => {
+				getterCalls++;
+				return "/must-not-be-read";
+			});
+			const stdout: string[] = [];
+			const stderr: string[] = [];
+			const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(chunk => {
+				stdout.push(String(chunk));
+				return true;
+			});
+			const stderrSpy = spyOn(process.stderr, "write").mockImplementation(chunk => {
+				stderr.push(String(chunk));
+				return true;
+			});
+			const previousExitCode = process.exitCode;
+			try {
+				await new Command(argv, { bin: "gjc", version: "test", commands: new Map() }).run();
+				expect(getterCalls, argv.join(" ")).toBe(0);
+				expect(stdout.join(""), argv.join(" ")).toBe(
+					'{"error":{"code":"worktree_cleanup_disabled","message":"worktree cleanup is report-only"}}\n',
+				);
+				expect(stderr, argv.join(" ")).toEqual([]);
+				expect(process.exitCode, argv.join(" ")).toBe(2);
+			} finally {
+				process.exitCode = previousExitCode ?? 0;
+				stdoutSpy.mockRestore();
+				stderrSpy.mockRestore();
+			}
+		}
+	});
+
+	test("framework parse errors never resolve the root", async () => {
+		let getterCalls = 0;
+		const Command = createWorktreeCommand(() => {
+			getterCalls++;
+			return "/must-not-be-read";
+		});
+		await expect(
+			new Command(["remove"], { bin: "gjc", version: "test", commands: new Map() }).run(),
+		).rejects.toBeTruthy();
+		expect(getterCalls).toBe(0);
+	});
+
+	test("publishes only report-only help and examples", () => {
+		const Command = createWorktreeCommand(() => "/unused");
+		expect(Command.description).toBe("List report-only diagnostics for agent-managed worktrees");
+		expect(Command.flags?.all).toMatchObject({ description: "Unavailable: cleanup is report-only" });
+		expect(Command.flags?.["dry-run"]).toMatchObject({ description: "Preview the report-only clear summary" });
+		expect(Command.examples).toEqual([
+			"gjc worktree",
+			"gjc worktree list --json",
+			"gjc worktree clear",
+			"gjc worktree clear --dry-run",
+		]);
+	});
+
+	test("renders the exact report-only help snapshot", async () => {
+		const Command = createWorktreeCommand(() => "/unused");
+		const stdout: string[] = [];
+		const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(chunk => {
+			stdout.push(String(chunk));
+			return true;
+		});
+		try {
+			const commands: CommandEntry[] = [{ name: "worktree", aliases: ["wt"], load: async () => Command }];
+			await run({ bin: "gjc", version: "test", argv: ["worktree", "--help"], commands });
+			expect(stdout.join("")).toBe(`List report-only diagnostics for agent-managed worktrees
+
+USAGE
+  $ gjc worktree [ACTION] [FLAGS]
+
+ARGUMENTS
+  ACTION   list (default) or clear (list|clear)
+
+FLAGS
+      --all      Unavailable: cleanup is report-only
+  -n, --dry-run  Preview the report-only clear summary
+  -j, --json     Emit machine-readable JSON
+
+EXAMPLES
+  gjc worktree
+  gjc worktree list --json
+  gjc worktree clear
+  gjc worktree clear --dry-run
+`);
+		} finally {
+			stdoutSpy.mockRestore();
+		}
+	});
+});

--- a/scripts/check-worktree-report-capabilities.test.ts
+++ b/scripts/check-worktree-report-capabilities.test.ts
@@ -1,0 +1,2248 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import * as path from "node:path";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import {
+	analyzeSource,
+	formatFinding,
+	main,
+	RULES,
+	sortFindings,
+	verifyWorktreeReportCapabilities,
+} from "./check-worktree-report-capabilities";
+
+const fixture = "scripts/fixtures/worktree-report-capabilities";
+const productionRoots = [
+	"packages/coding-agent/src/cli.ts",
+	"packages/coding-agent/src/commands/worktree.ts",
+	"packages/coding-agent/src/cli/worktree-cli.ts",
+	"packages/coding-agent/src/cli/worktree-scanner.ts",
+] as const;
+
+async function makeGraph(overrides: Record<string, string> = {}, config: Record<string, unknown> = {}) {
+	const repoRoot = await mkdtemp(path.join(path.dirname(import.meta.dir), "wtr-integration-"));
+	for (const relative of productionRoots) {
+		const target = path.join(repoRoot, relative);
+		await mkdir(path.dirname(target), { recursive: true });
+		const source = overrides[relative] ?? (await readFile(path.join(import.meta.dir, "..", relative), "utf8"));
+		await writeFile(target, source);
+	}
+	for (const [relative, source] of Object.entries(overrides)) {
+		if ((productionRoots as readonly string[]).includes(relative)) continue;
+		const target = path.join(repoRoot, relative);
+		await mkdir(path.dirname(target), { recursive: true });
+		await writeFile(target, source);
+	}
+	await writeFile(path.join(repoRoot, "tsconfig.json"), JSON.stringify({ compilerOptions: config }));
+	return repoRoot;
+}
+
+async function graphFindings(repoRoot: string, extra: { roots?: string[] } = {}) {
+	return verifyWorktreeReportCapabilities({ repoRoot, graphRoot: productionRoots[0], ...extra });
+}
+
+describe("worktree capability verifier", () => {
+	test("analyzes the canonical capability fixtures", async () => {
+		const readFixture = (name: string) =>
+			readFile(path.join(import.meta.dir, "fixtures/worktree-report-capabilities", name), "utf8");
+		const allowed = analyzeSource(await readFixture("allowed.ts"), `${fixture}/allowed.ts`);
+		const forbidden = analyzeSource(await readFixture("forbidden.ts"), `${fixture}/forbidden.ts`);
+		const reexport = analyzeSource(await readFixture("reexport.ts"), `${fixture}/reexport.ts`);
+		expect(allowed).toEqual([]);
+		expect(forbidden.map(formatFinding)).toEqual([
+			`${fixture}/forbidden.ts:1:1 WTR001_FORBIDDEN_IMPORT node:fs/promises`,
+			`${fixture}/forbidden.ts:2:1 WTR001_FORBIDDEN_IMPORT node:fs`,
+			`${fixture}/forbidden.ts:3:1 WTR001_FORBIDDEN_IMPORT node:fs/promises`,
+			`${fixture}/forbidden.ts:7:17 WTR009_SCANNER_API open`,
+			`${fixture}/forbidden.ts:7:17 WTR009_SCANNER_API open:write-mode`,
+			`${fixture}/forbidden.ts:8:8 WTR009_SCANNER_API FileHandle.write`,
+			`${fixture}/forbidden.ts:9:8 WTR009_SCANNER_API FileHandle.writev`,
+			`${fixture}/forbidden.ts:10:8 WTR009_SCANNER_API FileHandle.writeFile`,
+			`${fixture}/forbidden.ts:12:8 WTR006_WRITE_OR_MUTATION node:fs:writeFile`,
+			`${fixture}/forbidden.ts:13:8 WTR006_WRITE_OR_MUTATION node:fs/promises:rm`,
+			`${fixture}/forbidden.ts:13:8 WTR009_SCANNER_API rm`,
+			`${fixture}/forbidden.ts:14:2 WTR006_WRITE_OR_MUTATION member-assignment`,
+			`${fixture}/forbidden.ts:14:2 WTR007_UNAPPROVED_PROCESS process.env`,
+			`${fixture}/forbidden.ts:15:8 WTR002_FORBIDDEN_CALL fetch`,
+			`${fixture}/forbidden.ts:16:8 WTR003_FORBIDDEN_MEMBER Bun.write`,
+			`${fixture}/forbidden.ts:17:6 WTR002_FORBIDDEN_CALL WebSocket`,
+			`${fixture}/forbidden.ts:18:2 WTR003_FORBIDDEN_MEMBER console.log`,
+			`${fixture}/forbidden.ts:19:8 WTR009_SCANNER_API FileHandle.extraction`,
+			`${fixture}/forbidden.ts:19:37 WTR009_SCANNER_API open`,
+			`${fixture}/forbidden.ts:19:37 WTR009_SCANNER_API open:write-mode`,
+			`${fixture}/forbidden.ts:20:8 WTR009_SCANNER_API FileHandle.extraction`,
+			`${fixture}/forbidden.ts:20:28 WTR009_SCANNER_API open`,
+			`${fixture}/forbidden.ts:21:8 WTR009_SCANNER_API FileHandle.extraction`,
+			`${fixture}/forbidden.ts:21:15 WTR009_SCANNER_API open`,
+			`${fixture}/forbidden.ts:25:8 WTR009_SCANNER_API FileHandle.extraction`,
+			`${fixture}/forbidden.ts:26:8 WTR009_SCANNER_API FileHandle.extraction`,
+			`${fixture}/forbidden.ts:27:2 WTR009_SCANNER_API FileHandle.extraction`,
+			`${fixture}/forbidden.ts:30:8 WTR009_SCANNER_API FileHandle.extraction`,
+			`${fixture}/forbidden.ts:31:8 WTR009_SCANNER_API FileHandle.extraction`,
+			`${fixture}/forbidden.ts:32:8 WTR009_SCANNER_API FileHandle.extraction`,
+			`${fixture}/forbidden.ts:32:22 WTR004_UNKNOWN_BINDING indirect-invocation:bind`,
+			`${fixture}/forbidden.ts:32:22 WTR009_SCANNER_API FileHandle.extraction`,
+			`${fixture}/forbidden.ts:34:2 WTR009_SCANNER_API FileHandle.extraction`,
+			`${fixture}/forbidden.ts:39:9 WTR004_UNKNOWN_BINDING computed-member`,
+			`${fixture}/forbidden.ts:42:24 WTR005C_DYNAMIC_IMPORT_FORBIDDEN computed`,
+			`${fixture}/forbidden.ts:43:25 WTR005C_DYNAMIC_IMPORT_FORBIDDEN computed`,
+			`${fixture}/forbidden.ts:45:40 WTR005C_DYNAMIC_IMPORT_FORBIDDEN ./commands/worktree`,
+			`${fixture}/forbidden.ts:49:22 WTR003_FORBIDDEN_MEMBER reflective-member:constructor`,
+			`${fixture}/forbidden.ts:50:1 WTR004_UNKNOWN_BINDING indirect-invocation:call`,
+			`${fixture}/forbidden.ts:51:20 WTR003_FORBIDDEN_MEMBER reflective-member:constructor`,
+			`${fixture}/forbidden.ts:52:15 WTR003_FORBIDDEN_MEMBER reflective-member:prototype`,
+			`${fixture}/forbidden.ts:53:19 WTR003_FORBIDDEN_MEMBER reflective-member:__proto__`,
+			`${fixture}/forbidden.ts:53:19 WTR004_UNKNOWN_BINDING computed-member`,
+			`${fixture}/forbidden.ts:54:26 WTR003_FORBIDDEN_MEMBER reflective-member:constructor`,
+			`${fixture}/forbidden.ts:55:1 WTR004_UNKNOWN_BINDING indirect-invocation:apply`,
+			`${fixture}/forbidden.ts:56:1 WTR004_UNKNOWN_BINDING indirect-invocation:bind`,
+			`${fixture}/forbidden.ts:56:1 WTR004_UNKNOWN_BINDING unsupported-callee`,
+			`${fixture}/forbidden.ts:57:1 WTR003_FORBIDDEN_MEMBER reflective-member:__defineGetter__`,
+			`${fixture}/forbidden.ts:57:1 WTR004_UNKNOWN_BINDING indirect-invocation:call`,
+		]);
+		expect(reexport.map((finding) => finding.rule)).toEqual([RULES.unknownBinding, RULES.unknownBinding]);
+	});
+	test("rejects reflective authority in CLI, destructured, and optional-member forms", async () => {
+		const cli = await readFile(path.join(import.meta.dir, "../packages/coding-agent/src/cli.ts"), "utf8");
+		const cliExploit = `${cli}
+const FunctionCtor = [].filter.constructor;
+FunctionCtor("return process.getBuiltinModule('node:fs').rmSync('/target',{force:true})").call(null);`;
+		expect(
+			analyzeSource(cliExploit, "packages/coding-agent/src/cli.ts").some(
+				finding =>
+					finding.rule === RULES.forbiddenMember &&
+					finding.symbol === "reflective-member:constructor",
+			),
+		).toBe(true);
+		for (const source of [
+			`const { constructor: FunctionCtor } = [].filter;
+FunctionCtor("return process.getBuiltinModule('node:fs').rmSync('/target',{force:true})").call(null);`,
+			`const FunctionCtor = []?.filter.constructor;
+FunctionCtor("return process.getBuiltinModule('node:fs').rmSync('/target',{force:true})").call(null);`,
+			`const { ["__proto__"]: inherited } = {};
+void inherited;`,
+		]) {
+			expect(
+				analyzeSource(source, `${fixture}/allowed.ts`).some(
+					finding => finding.rule === RULES.forbiddenMember && finding.symbol.startsWith("reflective-member:"),
+				),
+			).toBe(true);
+		}
+	});
+	test("rejects reflective global acquisition and composite aliases in every role", async () => {
+		const cli = await readFile(path.join(import.meta.dir, "../packages/coding-agent/src/cli.ts"), "utf8");
+		const cliExploit = `${cli}
+const evil = Reflect.get(globalThis, "eval");
+evil("process.getBuiltinModule('node:fs').rmSync('/target',{force:true})");`;
+		expect(
+			analyzeSource(cliExploit, "packages/coding-agent/src/cli.ts").some(
+				finding =>
+					finding.rule === RULES.forbiddenMember &&
+					["reflective-global:Reflect", "reflective-global:globalThis"].includes(finding.symbol),
+			),
+		).toBe(true);
+		for (const source of [
+			`const [R] = [Reflect];
+const evil = R.get(globalThis, "eval");
+evil("process.getBuiltinModule('node:fs').rmSync('/target',{force:true})");`,
+			`const processAlias = global.process;
+processAlias.getBuiltinModule("node:fs").rmSync("/target", { force: true });`,
+		]) {
+			expect(
+				analyzeSource(source, `${fixture}/allowed.ts`).some(
+					finding => finding.rule === RULES.forbiddenMember && finding.symbol.startsWith("reflective-global:"),
+				),
+			).toBe(true);
+		}
+	});
+	test("rejects Object reflection in command code while preserving scanner error annotation", () => {
+		const exploit = `import { Command } from "@gajae-code/utils/cli";
+const { getPrototypeOf, getOwnPropertyDescriptor } = Object;
+const prototype = getPrototypeOf(Command);
+const FunctionCtor = getOwnPropertyDescriptor(prototype, "constructor")?.value;
+FunctionCtor("process.getBuiltinModule('node:fs').rmSync('/target',{force:true})")();`;
+		expect(
+			analyzeSource(exploit, "packages/coding-agent/src/commands/worktree.ts").some(
+				finding => finding.rule === RULES.forbiddenMember && finding.symbol === "reflective-global:Object",
+			),
+		).toBe(true);
+		const scannerAnnotation = `throw Object.assign(new Error("directory changed"), { code: "ERACE" });`;
+		expect(
+			analyzeSource(scannerAnnotation, "packages/coding-agent/src/cli/worktree-scanner.ts").some(
+				finding => finding.symbol === "reflective-global:Object",
+			),
+		).toBe(false);
+	});
+	test("rejects statically computed reflective destructuring keys", () => {
+		const source = `const { ["con" + "structor"]: FunctionCtor } = [].filter;
+const evil = FunctionCtor("process.getBuiltinModule('node:fs').rmSync('/target',{force:true})");
+evil();`;
+		expect(
+			analyzeSource(source, `${fixture}/allowed.ts`).some(
+				finding => finding.rule === RULES.unknownBinding && finding.symbol === "computed-pattern",
+			),
+		).toBe(true);
+	});
+	test("rejects statically computed reflective member keys", () => {
+		const source = `const FunctionCtor = [].filter["con" + "structor"];
+const evil = FunctionCtor("process.getBuiltinModule('node:fs').rmSync('/target',{force:true})");
+evil();`;
+		expect(
+			analyzeSource(source, "packages/coding-agent/src/cli.ts").some(
+				finding =>
+					finding.rule === RULES.forbiddenMember &&
+					finding.symbol === "reflective-member:constructor",
+			),
+		).toBe(true);
+	});
+	test("rejects dynamic computed member acquisition in the CLI role", () => {
+		const source = `const member = "constructor";
+const FunctionCtor = [].filter[member];
+const evil = FunctionCtor("process.getBuiltinModule('node:fs').rmSync('/target',{force:true})");
+evil();`;
+		expect(
+			analyzeSource(source, "packages/coding-agent/src/cli.ts").some(
+				finding => finding.rule === RULES.unknownBinding && finding.symbol === "computed-member",
+			),
+		).toBe(true);
+	});
+	test("rejects CLI descriptor extraction of process authority", () => {
+		const source = `const descriptor = Object.getOwnPropertyDescriptor(process, "getBuiltinModule");
+const evil = descriptor?.value;
+evil("node:fs").rmSync("/target", { force: true });`;
+		expect(
+			analyzeSource(source, "packages/coding-agent/src/cli.ts").some(
+				finding =>
+					finding.rule === RULES.forbiddenMember &&
+					finding.symbol === "reflective-global:Object",
+			),
+		).toBe(true);
+	});
+	test("rejects optional and composite transfers of privileged CLI authority", () => {
+		const cases = [
+			{
+				source: `const write = Bun?.write;
+await write("/target", "x");`,
+				rule: RULES.unknownBinding,
+				symbol: "optional-privileged-member:write",
+			},
+			{
+				source: `const getBuiltinModule = process?.getBuiltinModule;
+getBuiltinModule("node:fs").rmSync("/target", { force: true });`,
+				rule: RULES.unknownBinding,
+				symbol: "optional-privileged-member:getBuiltinModule",
+			},
+			{
+				source: `const [p] = [process];
+p.getBuiltinModule("node:fs").rmSync("/target", { force: true });`,
+				rule: RULES.process,
+				symbol: "process-transfer:process",
+			},
+			{
+				source: `const { write } = Bun;
+await write("/target", "x");`,
+				rule: RULES.forbiddenCall,
+				symbol: "capability-transfer:Bun",
+			},
+		] as const;
+		for (const testCase of cases) {
+			expect(
+				analyzeSource(testCase.source, "packages/coding-agent/src/cli.ts").some(
+					finding => finding.rule === testCase.rule && finding.symbol === testCase.symbol,
+				),
+			).toBe(true);
+		}
+	});
+	test("rejects direct, destructured, and optional import.meta authority while allowing the main guard", () => {
+		const direct = `import.meta.require("node:fs").rmSync("/target", { force: true });`;
+		expect(
+			analyzeSource(direct, "packages/coding-agent/src/cli.ts").some(
+				finding => finding.rule === RULES.forbiddenMember && finding.symbol === "import-meta:require",
+			),
+		).toBe(true);
+		for (const source of [
+			`const { require } = import.meta;
+require("node:fs").rmSync("/target", { force: true });`,
+			`const require = import.meta?.require;
+require("node:fs").rmSync("/target", { force: true });`,
+		]) {
+			expect(
+				analyzeSource(source, "packages/coding-agent/src/cli.ts").some(
+					finding => finding.rule === RULES.unknownBinding && finding.symbol === "import-meta-transfer",
+				),
+			).toBe(true);
+		}
+		expect(
+			analyzeSource("if (import.meta.main) {}", "packages/coding-agent/src/cli.ts").some(
+				finding => finding.symbol.startsWith("import-meta"),
+			),
+		).toBe(false);
+	});
+	test("requires the complete immediate registry factory edge", () => {
+		const findings = analyzeSource(
+			`import { getWorktreesDir } from "@gajae-code/utils/dirs";
+			 const commands = [{ name: "worktree", load: async () => {
+			   const { createWorktreeCommand } = await import("./commands/worktree");
+			   return createWorktreeCommand;
+			 }}];`,
+			"packages/coding-agent/src/cli.ts",
+		);
+		expect(findings.some((finding) => finding.rule === RULES.registryEdge)).toBe(true);
+	});
+
+	test("rejects duplicate worktree registry entries", () => {
+		const load = `async () => { const { createWorktreeCommand } = await import("./commands/worktree"); return createWorktreeCommand(getWorktreesDir); }`;
+		const findings = analyzeSource(
+			`import { getWorktreesDir } from "@gajae-code/utils/dirs"; export const commands = [{ name: "worktree", load: ${load} }, { name: "worktree", load: ${load} }];`,
+			"packages/coding-agent/src/cli.ts",
+		);
+		expect(findings.some((finding) => finding.rule === RULES.registryEdge && finding.symbol === "count:2")).toBe(true);
+	});
+
+	test("rejects hostile dynamic forms", () => {
+		const findings = analyzeSource(
+			`const a = import("./third"); const b = import(name); const c = import(\`./\${name}\`); const d = Promise.resolve(import("./commands/worktree"));`,
+			`${fixture}/forbidden.ts`,
+		);
+		expect(findings.filter((finding) => finding.rule === RULES.dynamicImport)).toHaveLength(4);
+	});
+
+	test("rejects open flags that omit O_NOFOLLOW", () => {
+		const findings = analyzeSource(
+			`import { constants } from "node:fs";
+			 import { open } from "node:fs/promises";
+			 export async function unsafe(path: string) { const handle = await open(path, constants.O_RDONLY); await handle.close(); }`,
+			`${fixture}/allowed.ts`,
+		);
+		expect(findings.some((finding) => finding.rule === RULES.scannerApi && finding.symbol === "open:write-mode")).toBe(
+			true,
+		);
+	});
+	test("requires the exact source shape for metadata open flags", () => {
+		const variants = [
+			"constants.O_RDONLY | constants.O_NOFOLLOW",
+			"constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK | constants.O_SYNC",
+			"constants.O_RDONLY | constants.O_NONBLOCK | constants.O_NOFOLLOW",
+			"(() => { const readonlyFlag = constants.O_RDONLY; return readonlyFlag | constants.O_NOFOLLOW | constants.O_NONBLOCK; })()",
+			"c.O_RDONLY | c.O_NOFOLLOW | c.O_NONBLOCK",
+			"getFlags()",
+			"(constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK) as number",
+			"constants['O_RDONLY'] | constants.O_NOFOLLOW | constants.O_NONBLOCK",
+			"1 | constants.O_NOFOLLOW | constants.O_NONBLOCK",
+			"condition ? constants.O_RDONLY : constants.O_NOFOLLOW",
+			"constants.O_RDONLY | (constants.O_NOFOLLOW | constants.O_NONBLOCK)",
+		];
+		for (const flags of variants) {
+			const findings = analyzeSource(
+				`import { constants } from "node:fs";
+				 import { open } from "node:fs/promises";
+				 const c = constants;
+				 export async function unsafe(path: string) { const handle = await open(path, ${flags}); await handle.close(); }
+				 function getFlags() { return constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK; }`,
+				`${fixture}/allowed.ts`,
+			);
+			expect(findings.some((finding) => finding.rule === RULES.scannerApi && finding.symbol === "open:write-mode")).toBe(
+				true,
+			);
+		}
+		const findings = analyzeSource(
+			`import { constants } from "node:fs";
+			 import { open } from "node:fs/promises";
+			 export async function safe(path: string) { const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK); await handle.close(); }`,
+			`${fixture}/allowed.ts`,
+		);
+		expect(findings.some((finding) => finding.rule === RULES.scannerApi && finding.symbol === "open:write-mode")).toBe(false);
+	});
+	test("rejects imported capability rebinding and flag mutation", () => {
+		const cases: Array<{ hostile: string; symbol: string }> = [
+			{ hostile: "open = open;", symbol: "assignment" },
+			{ hostile: "open += open;", symbol: "assignment" },
+			{ hostile: "open++;", symbol: "assignment" },
+			{ hostile: "for (open in [open]) break;", symbol: "assignment" },
+			{ hostile: "for (open of [open]) break;", symbol: "assignment" },
+			{ hostile: "constants = constants;", symbol: "assignment" },
+			{ hostile: "constants += constants;", symbol: "assignment" },
+			{ hostile: "constants++;", symbol: "assignment" },
+			{ hostile: "for (constants in [constants]) break;", symbol: "assignment" },
+			{ hostile: "for (constants of [constants]) break;", symbol: "assignment" },
+			{ hostile: "constants.O_RDONLY = 1;", symbol: "member-assignment" },
+			{ hostile: "constants.O_NOFOLLOW++;", symbol: "member-assignment" },
+			{ hostile: "for (constants.O_RDONLY in [1]) break;", symbol: "member-assignment" },
+			{ hostile: "for (constants.O_NONBLOCK of [1]) break;", symbol: "member-assignment" },
+			{ hostile: "const c = constants; delete (c as typeof constants).O_RDONLY;", symbol: "member-assignment" },
+		];
+		for (const { hostile, symbol } of cases) {
+			const findings = analyzeSource(
+				`import { constants } from "node:fs"; import { open } from "node:fs/promises";
+				 export async function safe(path: string) {
+				   ${hostile}
+				   const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+				   await handle.close();
+				 }`,
+				`${fixture}/allowed.ts`,
+			);
+			expect(findings.filter((finding) => finding.rule === RULES.mutation && finding.symbol === symbol)).toHaveLength(1);
+		}
+	});
+	test("captures capability mutations when imports follow declarations", () => {
+		const findings = analyzeSource(
+			`function beforeImports() { open += open; }
+			 export async function safe(path: string) {
+			   const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+			   await handle.close();
+			 }
+			 import { constants } from "node:fs"; import { open } from "node:fs/promises";`,
+			`${fixture}/allowed.ts`,
+		);
+		expect(findings.filter((finding) => finding.rule === RULES.mutation && finding.symbol === "assignment")).toHaveLength(1);
+	});
+
+	test("rejects omitted open flag forms in isolation", () => {
+		const variants = [
+			{
+				setup: "const flags = constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK;",
+				flagsExpression: "flags",
+			},
+			{
+				setup: "",
+				flagsExpression: "(constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK) || 0",
+			},
+			{
+				setup: "",
+				flagsExpression: "{ ...{ value: constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK } }",
+			},
+			{
+				setup: "",
+				flagsExpression: "constants.O_RDONLY | constants.O_NOFOLLOW",
+			},
+		];
+		for (const { setup, flagsExpression } of variants) {
+			const findings = analyzeSource(
+				`import { constants } from "node:fs"; import { open } from "node:fs/promises";
+				 export async function unsafe(path: string) { ${setup}
+				   const handle = await open(path, ${flagsExpression});
+				   await handle.close();
+				 }`,
+				`${fixture}/allowed.ts`,
+			);
+			const openFindings = findings.filter(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "open:write-mode",
+			);
+			expect(openFindings).toHaveLength(1);
+			expect(findings.filter((finding) => finding.rule !== RULES.scannerApi || finding.symbol !== "open:write-mode")).toEqual([]);
+		}
+	});
+
+	test("accepts parenthesized exact open flags silently", () => {
+		const findings = analyzeSource(
+			`import { constants } from "node:fs"; import { open } from "node:fs/promises";
+			 export async function safe(path: string) {
+			   const handle = await open(path, ((constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK)));
+			   await handle.close();
+			 }`,
+			`${fixture}/allowed.ts`,
+		);
+		expect(findings).toEqual([]);
+	});
+
+	test("rejects scanner path APIs outside the lexical allowlist", () => {
+		const findings = analyzeSource(
+			'import * as path from "node:path";\nexport const escaped = path.resolve("x");\n',
+			`${fixture}/allowed.ts`,
+		);
+		expect(findings.some((finding) => finding.rule === RULES.scannerApi && finding.symbol === "path.resolve")).toBe(
+			true,
+		);
+	});
+
+	test("resolves imported aliases to their capabilities", () => {
+		const findings = analyzeSource(
+			`import * as fs from "node:fs"; import { rm as remove } from "node:fs/promises"; const erase = remove; fs.writeFileSync("x", "y"); erase("x"); process.env.X = "1";`,
+			`${fixture}/forbidden.ts`,
+		);
+		const rules = new Set(findings.map((finding) => finding.rule));
+		expect(rules).toEqual(
+			new Set([RULES.forbiddenImport, RULES.mutation, RULES.process, RULES.scannerApi, RULES.unknownBinding]),
+		);
+	});
+
+	test("rejects reexports and dirs imports outside the CLI boundary", () => {
+		const findings = analyzeSource(
+			`export * from "./reexport"; import { getWorktreesDir } from "@gajae-code/utils/dirs";`,
+			`${fixture}/reexport.ts`,
+		);
+		const rules = new Set(findings.map((finding) => finding.rule));
+		expect(rules).toEqual(new Set([RULES.unknownBinding, RULES.dirsBaseline]));
+	});
+
+	test("requires parse-valid-getter-import-call order", () => {
+		const findings = analyzeSource(
+			`import { Args, Command, type CommandCtor, Flags } from "@gajae-code/utils/cli";
+			 export function createWorktreeCommand(getWorktreesDir: () => string): CommandCtor {
+			   return class Worktree extends Command { async run() {
+			     const root = getWorktreesDir();
+			     const { runWorktreeCommand } = await import("../cli/worktree-cli");
+			     const { args, flags } = await this.parse(Worktree);
+			     const valid = true; if (!valid) return;
+			     const result = await runWorktreeCommand({ root, platform: "posix", action: args.action, json: flags.json, dryRun: false });
+			   }};
+			 }`,
+			"packages/coding-agent/src/commands/worktree.ts",
+		);
+		expect(findings.some((finding) => finding.rule === RULES.getterTiming)).toBe(true);
+	});
+	test("rejects positional validation omissions, broadening, alternate indexes, and aliases", async () => {
+		const command = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/commands/worktree.ts"),
+			"utf8",
+		);
+		const canonical =
+			'const validPositionals = argv.length <= 1 && (argv.length === 0 || argv[0] === action);';
+		const variants = [
+			command.replace(canonical, "const validPositionals = true;"),
+			command.replace(
+				canonical,
+				"const validPositionals = argv.length <= 1 || (argv.length === 0 || argv[0] === action);",
+			),
+			command.replace(
+				canonical,
+				"const validPositionals = argv.length <= 1 && (argv.length === 0 || argv[1] === action);",
+			),
+			command.replace(
+				canonical,
+				"const positionalAlias = argv; const validPositionals = positionalAlias.length <= 1 && (positionalAlias.length === 0 || positionalAlias[0] === action);",
+			),
+		];
+		for (const source of variants) {
+			const findings = analyzeSource(source, "packages/coding-agent/src/commands/worktree.ts");
+			expect(
+				findings.some(
+					finding =>
+						finding.rule === RULES.getterTiming && finding.symbol === "parse-valid-getter-import-call",
+				),
+			).toBe(true);
+		}
+	});
+
+	test("sorts numerically and deduplicates receipts", () => {
+		const a = {
+			path: "a.ts",
+			line: 10,
+			column: 1,
+			rule: RULES.forbiddenCall,
+			symbol: "rm",
+		};
+		const b = {
+			path: "a.ts",
+			line: 2,
+			column: 1,
+			rule: RULES.forbiddenCall,
+			symbol: "rm",
+		};
+		expect(sortFindings([a, b, a]).map(formatFinding)).toEqual([
+			"a.ts:2:1 WTR002_FORBIDDEN_CALL rm",
+			"a.ts:10:1 WTR002_FORBIDDEN_CALL rm",
+		]);
+	});
+
+	test("emits an exact sorted hostile receipt", async () => {
+		const relativePath = `${fixture}/receipt.ts`;
+		const source = 'import { rm } from "node:fs/promises";\nrm("x");\nfetch("https://example.invalid");\n';
+		const findings = analyzeSource(source, relativePath);
+		const receipt = findings.map(formatFinding);
+		expect(receipt).toEqual([
+			`${relativePath}:1:1 WTR001_FORBIDDEN_IMPORT node:fs/promises`,
+			`${relativePath}:2:1 WTR006_WRITE_OR_MUTATION node:fs/promises:rm`,
+			`${relativePath}:2:1 WTR009_SCANNER_API rm`,
+			`${relativePath}:3:1 WTR002_FORBIDDEN_CALL fetch`,
+		]);
+		expect(analyzeSource(source, relativePath).map(formatFinding)).toEqual(receipt);
+		const emitted: string[] = [];
+		expect(
+			await main([], {
+				verify: async () => findings,
+				write: (text) => emitted.push(text),
+			}),
+		).toBe(1);
+		expect(emitted.join("")).toBe(`${receipt.join("\n")}\n`);
+	});
+
+	test("fails closed when an authoritative root is missing", async () => {
+		const findings = await verifyWorktreeReportCapabilities({
+			repoRoot: path.resolve(import.meta.dir, ".."),
+			roots: ["packages/coding-agent/src/cli/does-not-exist.ts"],
+		});
+		expect(findings).toEqual([
+			{
+				path: "packages/coding-agent/src/cli/does-not-exist.ts",
+				line: 1,
+				column: 1,
+				rule: RULES.unknownBinding,
+				symbol: "unresolved-root",
+			},
+		]);
+	});
+
+	test("approved production graph and CLI command are silent", async () => {
+		const repoRoot = path.resolve(import.meta.dir, "..");
+		expect(await verifyWorktreeReportCapabilities({ repoRoot })).toEqual([]);
+		const stderr = spyOn(process.stderr, "write").mockImplementation(() => true);
+		const stdout = spyOn(process.stdout, "write").mockImplementation(() => true);
+		try {
+			expect(await main([])).toBe(0);
+			expect(stderr).not.toHaveBeenCalled();
+			expect(stdout).not.toHaveBeenCalled();
+		} finally {
+			stdout.mockRestore();
+			stderr.mockRestore();
+		}
+	});
+
+	test("rejects direct CLI scanner edges outside the registry", async () => {
+		const cli = await readFile(path.join(import.meta.dir, "../packages/coding-agent/src/cli.ts"), "utf8");
+		const staticFindings = analyzeSource(
+			`${cli}\nimport { scanWorktrees } from "./cli/worktree-scanner";\n`,
+			"packages/coding-agent/src/cli.ts",
+		);
+		expect(
+			staticFindings.some(
+				(finding) => finding.rule === RULES.forbiddenImport && finding.symbol === "./cli/worktree-scanner",
+			),
+		).toBe(true);
+		const dynamicFindings = analyzeSource(
+			`${cli}\nconst directScanner = import("./cli/worktree-scanner");\n`,
+			"packages/coding-agent/src/cli.ts",
+		);
+		expect(
+			dynamicFindings.some(
+				(finding) => finding.rule === RULES.dynamicImport && finding.symbol === "./cli/worktree-scanner",
+			),
+		).toBe(true);
+		const directCapabilities = analyzeSource(
+			`${cli}
+require("node:fs");
+eval("0");
+process.getBuiltinModule("node:fs");
+new Function("return 0");`,
+			"packages/coding-agent/src/cli.ts",
+		);
+		for (const symbol of ["require", "eval", "process.getBuiltinModule", "Function"]) {
+			expect(
+				directCapabilities.some((finding) => finding.rule === RULES.forbiddenCall && finding.symbol === symbol),
+			).toBe(true);
+		}
+	});
+	test("rejects detached registry decoys", () => {
+		const findings = analyzeSource(
+			`import { getWorktreesDir } from "@gajae-code/utils/dirs"; const decoy = [{ name: "worktree", load: async () => { const { createWorktreeCommand } = await import("./commands/worktree"); return createWorktreeCommand(getWorktreesDir); }}]; export const commands = [];`,
+			"packages/coding-agent/src/cli.ts",
+		);
+		expect(findings.some((finding) => finding.rule === RULES.registryEdge)).toBe(true);
+	});
+
+	test("rejects ignored getter and bypassed worker root", () => {
+		const source = `import { Args, Command, type CommandCtor, Flags } from "@gajae-code/utils/cli"; export function createWorktreeCommand(getWorktreesDir: () => string): CommandCtor { return class Worktree extends Command { async run() { const { args, flags } = await this.parse(Worktree); const action = args.action; const json = flags.json; const dryRun = flags["dry-run"]; const valid = true; if (!valid) return; const root = "arbitrary"; const { runWorktreeCommand } = await import("../cli/worktree-cli"); await runWorktreeCommand({ root: "arbitrary", platform: process.platform === "win32" ? "win32" : "posix", action, json, dryRun }); }}; }`;
+		expect(
+			analyzeSource(source, "packages/coding-agent/src/commands/worktree.ts").some(
+				(finding) => finding.rule === RULES.getterTiming,
+			),
+		).toBe(true);
+	});
+
+	test("rejects aliased worker selection and shadowed factory getters", () => {
+		const aliasedWorker = `import { Args, Command, type CommandCtor, Flags } from "@gajae-code/utils/cli";
+      export function createWorktreeCommand(getWorktreesDir: () => string): CommandCtor {
+        return class Worktree extends Command { async run() {
+          const { args, flags } = await this.parse(Worktree);
+          const action = args.action === "clear" ? "clear" : "list";
+          const all = flags.all ?? false;
+          const dryRun = flags["dry-run"] ?? false;
+          const json = flags.json ?? false;
+          const valid = (action === "clear" && !all) || (action === "list" && !all && !dryRun);
+          if (!valid) { return; }
+          const root = getWorktreesDir();
+          const { runWorktreeCommand: run } = await import("../cli/worktree-cli");
+          const result = await run({ root, platform: process.platform === "win32" ? "win32" : "posix", action, json, dryRun });
+        }};
+      }`;
+		expect(
+			analyzeSource(aliasedWorker, "packages/coding-agent/src/commands/worktree.ts").some(
+				(finding) => finding.rule === RULES.getterTiming || finding.rule === RULES.workerEdge,
+			),
+		).toBe(true);
+
+		const shadowedGetter = aliasedWorker
+			.replace(
+				"const root = getWorktreesDir();",
+				"const getWorktreesDir = () => '/decoy'; const root = getWorktreesDir();",
+			)
+			.replace("const { runWorktreeCommand: run }", "const { runWorktreeCommand }")
+			.replace("const result = await run(", "const result = await runWorktreeCommand(");
+		expect(
+			analyzeSource(shadowedGetter, "packages/coding-agent/src/commands/worktree.ts").some(
+				(finding) => finding.rule === RULES.getterTiming,
+			),
+		).toBe(true);
+	});
+
+	test("rejects worker scanner root or platform substitution", () => {
+		const source = `import { scanWorktrees } from "./worktree-scanner";
+			export async function runWorktreeCommand(options: { root: string; platform: "posix" | "win32" }) {
+				return scanWorktrees({ root: "/substituted", platform: options.platform });
+			}`;
+		expect(
+			analyzeSource(source, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+			),
+		).toBe(true);
+	});
+	test("fails closed on unknown CLI dynamic edges and non-exact payloads", () => {
+		const cli = analyzeSource(
+			`import { getWorktreesDir } from "@gajae-code/utils/dirs"; export const commands = [{ name: "worktree", aliases: ["wt"], load: async () => { const { createWorktreeCommand, extra } = await import("./commands/worktree"); return createWorktreeCommand(getWorktreesDir); } }]; const x = import("./new-command");`,
+			"packages/coding-agent/src/cli.ts",
+		);
+		expect(cli.some((finding) => finding.rule === RULES.dynamicImport)).toBe(true);
+
+		const command = analyzeSource(
+			`import { Args, Command, type CommandCtor, Flags } from "@gajae-code/utils/cli";
+			export function createWorktreeCommand(getWorktreesDir: () => string): CommandCtor {
+				return class Worktree extends Command { async run() {
+					const { args, flags } = await this.parse(Worktree);
+					const action = args.action === "clear" ? "clear" : "list";
+					const all = flags.all ?? false; const dryRun = flags["dry-run"] ?? false; const json = flags.json ?? false;
+					const valid = (action === "clear" && !all) || (action === "list" && !all && !dryRun); if (!valid) return;
+					const root = getWorktreesDir(); const { runWorktreeCommand } = await import("../cli/worktree-cli");
+					await runWorktreeCommand({ root, platform: process.platform === "win32" ? "win32" : "posix", action, json, dryRun, ...{} });
+				}};
+			}`,
+			"packages/coding-agent/src/commands/worktree.ts",
+		);
+		expect(command.some((finding) => finding.rule === RULES.getterTiming)).toBe(true);
+	});
+
+	test("rejects scanner signature and nested handle escape bypasses", () => {
+		const source = `import { constants } from "node:fs"; import { open, lstat } from "node:fs/promises";
+			export async function scan() { const h = await open("x", constants.O_RDONLY); lstat("x"); const box = { nested: h }; return box; }`;
+		const findings = analyzeSource(source, `${fixture}/allowed.ts`);
+		expect(findings.some((finding) => finding.rule === RULES.scannerApi && finding.symbol === "open:write-mode")).toBe(
+			true,
+		);
+		expect(
+			findings.some((finding) => finding.rule === RULES.scannerApi && finding.symbol === "FileHandle.extraction"),
+		).toBe(true);
+	});
+	test("scanner flow follows only the exported reachable binding, not dead decoys", async () => {
+		const scanner = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/cli/worktree-scanner.ts"),
+			"utf8",
+		);
+		const hostile = scanner
+			.replace("export async function scanWorktrees", "async function originalScanWorktrees")
+			.concat(`
+export async function scanWorktrees(_options: ScanWorktreesOptions): Promise<WorktreeDiagnostic[]> {
+	return [];
+}
+function deadDecoy() {
+	const lstat = () => ({ isSymbolicLink: () => false });
+	const readdir = () => [];
+	const open = () => ({ stat() {}, read() {}, close() {} });
+	const handle = { stat() {}, read() {}, close() {} };
+	void lstat; void readdir; void open; void handle;
+	lstat("x"); readdir("x");
+	const result = open("x"); result.stat(); result.read(); result.close();
+	handle.stat(); handle.read(); handle.close();
+}`);
+		const receipts = analyzeSource(hostile, "packages/coding-agent/src/cli/worktree-scanner.ts")
+			.filter((finding) => finding.rule === RULES.scannerApi && finding.symbol.startsWith("scanner-flow:"))
+			.map((finding) => finding.symbol);
+		expect(receipts).toEqual([
+			"scanner-flow:handle.close",
+			"scanner-flow:handle.read",
+			"scanner-flow:handle.stat",
+			"scanner-flow:lstat",
+			"scanner-flow:open",
+			"scanner-flow:readdir",
+		]);
+	});
+
+	test("statically unreachable scanner calls cannot satisfy the reachable flow contract", () => {
+		const source = `import { lstat, open, readdir } from "node:fs/promises";
+export async function scanWorktrees() {
+	if (false) {
+		await lstat("x");
+		await readdir("x");
+		const handle = await open("x", 0);
+		await handle.stat();
+		await handle.read();
+		await handle.close();
+	}
+	return [];
+}`;
+		const receipts = analyzeSource(source, "packages/coding-agent/src/cli/worktree-scanner.ts")
+			.filter((finding) => finding.rule === RULES.scannerApi && finding.symbol.startsWith("scanner-flow:"))
+			.map((finding) => finding.symbol);
+		expect(receipts).toEqual([
+			"scanner-flow:handle.close",
+			"scanner-flow:handle.read",
+			"scanner-flow:handle.stat",
+			"scanner-flow:lstat",
+			"scanner-flow:open",
+			"scanner-flow:readdir",
+		]);
+	});
+
+	test("local same-named functions and object methods cannot satisfy imported scanner bindings", () => {
+		const source = `export async function scanWorktrees() {
+	const lstat = () => ({});
+	const readdir = () => [];
+	const open = () => ({ stat() {}, read() {}, close() {} });
+	const handle = { stat() {}, read() {}, close() {} };
+	lstat("x");
+	readdir("x");
+	const result = await open("x");
+	await result.stat();
+	await result.read();
+	await result.close();
+	void handle;
+	return [];
+}`;
+		const receipts = analyzeSource(source, "packages/coding-agent/src/cli/worktree-scanner.ts")
+			.filter((finding) => finding.rule === RULES.scannerApi && finding.symbol.startsWith("scanner-flow:"))
+			.map((finding) => finding.symbol);
+		expect(receipts).toEqual([
+			"scanner-flow:handle.close",
+			"scanner-flow:handle.read",
+			"scanner-flow:handle.stat",
+			"scanner-flow:lstat",
+			"scanner-flow:open",
+			"scanner-flow:readdir",
+		]);
+	});
+
+	test("a closure declared before assignment still extracts the later-open FileHandle binding", () => {
+		const findings = analyzeSource(
+			`import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+export async function scan() {
+	const leak = () => handle;
+	let handle;
+	handle = await open("x", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+	return leak();
+}`,
+			`${fixture}/allowed.ts`,
+		);
+		const receipts = findings
+			.filter((finding) => finding.rule === RULES.scannerApi && finding.symbol === "FileHandle.extraction")
+			.map((finding) => finding.symbol);
+		expect(receipts).toEqual(["FileHandle.extraction"]);
+	});
+
+	test("backward aliases declared before open assignment reach the FileHandle fixed point", () => {
+		const findings = analyzeSource(
+			`import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+export async function scan() {
+	let handle;
+	let alias;
+	alias = handle;
+	handle = await open("x", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+	return alias;
+}`,
+			`${fixture}/allowed.ts`,
+		);
+		const receipts = findings
+			.filter((finding) => finding.rule === RULES.scannerApi && finding.symbol === "FileHandle.extraction")
+			.map((finding) => finding.symbol);
+		expect(receipts).toEqual(["FileHandle.extraction", "FileHandle.extraction"]);
+	});
+
+	test("sibling block-local handles do not cross binding identity while the outer leak does", () => {
+		const findings = analyzeSource(
+			`import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+export async function scan() {
+	let handle;
+	const leak = () => handle;
+	{
+		const handle = { stat() {}, read() {}, close() {} };
+		const unrelated = () => handle;
+		void unrelated;
+	}
+	handle = await open("x", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+	return leak();
+}`,
+			`${fixture}/allowed.ts`,
+		);
+		const receipts = findings
+			.filter((finding) => finding.rule === RULES.scannerApi && finding.symbol === "FileHandle.extraction")
+			.map((finding) => finding.symbol);
+		expect(receipts).toEqual(["FileHandle.extraction"]);
+	});
+	test("rejects unassigned open flags, shadowed constants, and unsafe read bounds", () => {
+		const source = `import { constants } from "node:fs"; import { open } from "node:fs/promises";
+			export async function scan() {
+				open("unassigned", constants.O_WRONLY);
+				const handle = await open("safe", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+				await handle.read(Buffer.alloc(9001), 0, 9001, 0);
+				await (await open("nested", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK)).stat({ bigint: true });
+			}
+			export async function shadow(constants: { O_RDONLY: number; O_NOFOLLOW: number; O_NONBLOCK: number }) {
+				await open("shadowed", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+			}
+			export async function indirect() {
+				open.call(null, "indirect", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+			}`;
+		const findings = analyzeSource(source, `${fixture}/allowed.ts`);
+		expect(findings.filter((finding) => finding.symbol === "open:write-mode")).toHaveLength(2);
+		expect(
+			findings.some((finding) => finding.rule === RULES.scannerApi && finding.symbol === "FileHandle.read:signature"),
+		).toBe(true);
+		expect(findings.filter((finding) => finding.symbol === "FileHandle.extraction").length).toBeGreaterThanOrEqual(2);
+		expect(
+			findings.some(
+				finding =>
+					finding.rule === RULES.unknownBinding && finding.symbol === "indirect-invocation:call",
+			),
+		).toBe(true);
+	});
+
+	test("freezes baseline CLI dynamic import selections and multiplicity", async () => {
+		const cli = await readFile(path.join(import.meta.dir, "../packages/coding-agent/src/cli.ts"), "utf8");
+		const alteredSelection = analyzeSource(
+			cli.replace('import("./commands/acp").then(m => m.default)', 'import("./commands/acp").then(m => m.Command)'),
+			"packages/coding-agent/src/cli.ts",
+		);
+		expect(
+			alteredSelection.some((finding) => finding.rule === RULES.dynamicImport && finding.symbol === "./commands/acp"),
+		).toBe(true);
+		const duplicated = analyzeSource(
+			`${cli}\nconst duplicateAcp = import("./commands/acp").then(m => m.default);\nvoid duplicateAcp;\n`,
+			"packages/coding-agent/src/cli.ts",
+		);
+		expect(
+			duplicated.some(
+				(finding) => finding.rule === RULES.dynamicImport && finding.symbol === "baseline-count:./commands/acp:2",
+			),
+		).toBe(true);
+	});
+	test("rejects global aliases and worker parameter or scanner aliases", () => {
+		const globalAlias = analyzeSource(
+			`export function unsafe() { const request = fetch; return request("https://example.invalid"); }`,
+			`${fixture}/allowed.ts`,
+		);
+		expect(globalAlias.some((finding) => finding.rule === RULES.forbiddenCall && finding.symbol === "fetch")).toBe(
+			true,
+		);
+		const assignedGlobal = analyzeSource(
+			`export function unsafe() { let request; request = fetch; return request("https://example.invalid"); }`,
+			`${fixture}/allowed.ts`,
+		);
+		expect(assignedGlobal.some((finding) => finding.rule === RULES.forbiddenCall && finding.symbol === "fetch")).toBe(
+			true,
+		);
+		const wrappedGlobal = analyzeSource(
+			`export function unsafe() { return (fetch as typeof fetch)("https://example.invalid"); }`,
+			`${fixture}/allowed.ts`,
+		);
+		expect(wrappedGlobal.some((finding) => finding.rule === RULES.forbiddenCall && finding.symbol === "fetch")).toBe(
+			true,
+		);
+
+		const shadowedOptions = `import { scanWorktrees } from "./worktree-scanner";
+			export async function runWorktreeCommand(options: { root: string; platform: "posix" | "win32" }) {
+				{ const options = { root: "/hostile", platform: "posix" as const };
+				  return scanWorktrees({ root: options.root, platform: options.platform }); }
+			}`;
+		expect(
+			analyzeSource(shadowedOptions, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+			),
+		).toBe(true);
+		const reassignedOptions = `import { scanWorktrees } from "./worktree-scanner";
+			export async function runWorktreeCommand(options: { root: string; platform: "posix" | "win32" }) {
+				options = { root: "/hostile", platform: "posix" };
+				return scanWorktrees({ root: options.root, platform: options.platform });
+			}`;
+		expect(
+			analyzeSource(reassignedOptions, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+			),
+		).toBe(true);
+		const iteratedOptions = `import { scanWorktrees } from "./worktree-scanner";
+			export async function runWorktreeCommand(options: { root: string; platform: "posix" | "win32" }) {
+				for (options of [{ root: "/hostile", platform: "posix" as const }]) {}
+				return scanWorktrees({ root: options.root, platform: options.platform });
+			}`;
+		expect(
+			analyzeSource(iteratedOptions, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+			),
+		).toBe(true);
+
+		const aliasedScanner = `import { scanWorktrees } from "./worktree-scanner";
+			export async function runWorktreeCommand(options: { root: string; platform: "posix" | "win32" }) {
+				const direct = await scanWorktrees({ root: options.root, platform: options.platform });
+				const scan = scanWorktrees;
+				await scan({ root: "/hostile", platform: "posix" });
+				return direct;
+			}`;
+		expect(
+			analyzeSource(aliasedScanner, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+			),
+		).toBe(true);
+		const assignedScanner = `import { scanWorktrees } from "./worktree-scanner";
+			export async function runWorktreeCommand(options: { root: string; platform: "posix" | "win32" }) {
+				const direct = await scanWorktrees({ root: options.root, platform: options.platform });
+				let scan;
+				scan = scanWorktrees;
+				await scan({ root: "/hostile", platform: "posix" });
+				return direct;
+			}`;
+		expect(
+			analyzeSource(assignedScanner, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+				(finding) => finding.rule === RULES.unknownBinding && finding.symbol.includes("alias-assignment"),
+			),
+		).toBe(true);
+	});
+	test("rejects optional and tagged calls as unapproved call shapes", () => {
+		const findings = analyzeSource(
+			"const run = () => 1; run?.(); const tag = (parts: TemplateStringsArray) => parts[0]; tag`x`;",
+			`${fixture}/allowed.ts`,
+		);
+		expect(
+			findings.some((finding) => finding.rule === RULES.unknownBinding && finding.symbol === "optional-call"),
+		).toBe(true);
+		expect(
+			findings.some((finding) => finding.rule === RULES.forbiddenCall && finding.symbol === "tagged-template"),
+		).toBe(true);
+	});
+
+	test("rejects shadowed process payloads and extra worker invocations", async () => {
+		const command = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/commands/worktree.ts"),
+			"utf8",
+		);
+		const shadowedProcess = command.replace(
+			"const root = getWorktreesDir();",
+			'const process = { platform: "win32", stdout: { write() {} }, stderr: { write() {} } }; const root = getWorktreesDir();',
+		);
+		expect(
+			analyzeSource(shadowedProcess, "packages/coding-agent/src/commands/worktree.ts").some(
+				(finding) => finding.rule === RULES.getterTiming,
+			),
+		).toBe(true);
+		const reassignedProcess = command.replace(
+			"const root = getWorktreesDir();",
+			'process = { platform: "win32" } as typeof process; const root = getWorktreesDir();',
+		);
+		expect(
+			analyzeSource(reassignedProcess, "packages/coding-agent/src/commands/worktree.ts").some(
+				(finding) => finding.rule === RULES.getterTiming,
+			),
+		).toBe(true);
+		const extraCall = command.replace(
+			"if (result.stdout.length > 0)",
+			`await runWorktreeCommand({
+				root,
+				platform: process.platform === "win32" ? "win32" : "posix",
+				action,
+				json,
+				dryRun,
+			});
+			if (result.stdout.length > 0)`,
+		);
+		expect(
+			analyzeSource(extraCall, "packages/coding-agent/src/commands/worktree.ts").some(
+				(finding) => finding.rule === RULES.getterTiming,
+			),
+		).toBe(true);
+		const nestedCall = command.replace(
+			"const result = await runWorktreeCommand({",
+			`const nested = () => runWorktreeCommand({
+				root,
+				platform: process.platform === "win32" ? "win32" : "posix",
+				action,
+				json,
+				dryRun,
+			});
+			await nested();
+			const result = await runWorktreeCommand({`,
+		);
+		expect(
+			analyzeSource(nestedCall, "packages/coding-agent/src/commands/worktree.ts").some(
+				(finding) => finding.rule === RULES.getterTiming,
+			),
+		).toBe(true);
+	});
+	test("rejects exported handles, transfer escapes, and mutable read limits", () => {
+		const source = `import { constants } from "node:fs"; import { open } from "node:fs/promises";
+			const CHUNK_BYTES = 9000;
+			export const leaked = await open("top", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+			let outer;
+			export default { leaked };
+			class Leak {
+				field = leaked;
+				#privateField = leaked;
+			}
+			export async function* scan() {
+				outer = await open("outer", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+				const handle = await open("local", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+				const buffer = Buffer.alloc(9001);
+				let offset = 0;
+				const read = await handle.read(buffer, offset, Math.min(CHUNK_BYTES, buffer.length - offset), offset);
+				offset += read.bytesRead;
+				yield handle;
+				throw handle;
+			}`;
+		const findings = analyzeSource(source, `${fixture}/allowed.ts`);
+		expect(findings.filter((finding) => finding.symbol === "FileHandle.extraction").length).toBeGreaterThanOrEqual(4);
+		expect(
+			findings.some((finding) => finding.rule === RULES.scannerApi && finding.symbol === "FileHandle.read:signature"),
+		).toBe(true);
+	});
+
+	test("rejects worker scanner decoys outside exported body", () => {
+		const source = `import { scanWorktrees } from "./worktree-scanner";
+			function decoy(options: { root: string; platform: "posix" | "win32" }) { return scanWorktrees({ root: options.root, platform: options.platform }); }
+			export async function runWorktreeCommand(options: { root: string; platform: "posix" | "win32" }) { return 1; }`;
+		expect(
+			analyzeSource(source, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+			),
+		).toBe(true);
+	});
+	test("rejects hostile capability graph forms", async () => {
+		const cli = analyzeSource(
+			"fetch('x'); Bun.write('x', 'y'); new WebSocket('x'); process.env.X = '1';",
+			"packages/coding-agent/src/cli.ts",
+		);
+		expect(cli.some((finding) => finding.rule === RULES.forbiddenCall && finding.symbol === "fetch")).toBe(true);
+		expect(cli.some((finding) => finding.rule === RULES.forbiddenMember && finding.symbol === "Bun.write")).toBe(true);
+		expect(cli.some((finding) => finding.rule === RULES.forbiddenCall && finding.symbol === "WebSocket")).toBe(true);
+		expect(cli.some((finding) => finding.rule === RULES.process && finding.symbol === "process.env")).toBe(true);
+		const unsupported = analyzeSource("(0, open)('x', O_WRONLY);", `${fixture}/allowed.ts`);
+		expect(
+			unsupported.some((finding) => finding.rule === RULES.unknownBinding && finding.symbol === "unsupported-callee"),
+		).toBe(true);
+		const roots = await verifyWorktreeReportCapabilities({
+			repoRoot: path.resolve(import.meta.dir, ".."),
+			roots: [
+				"",
+				"packages/../outside.ts",
+				"/absolute.ts",
+				"scripts/fixtures/worktree-report-capabilities/allowed.ts",
+				"scripts/fixtures/worktree-report-capabilities/allowed.ts",
+			],
+		});
+		expect(roots.some((finding) => finding.symbol === "invalid-replacement-root")).toBe(true);
+		expect(roots.some((finding) => finding.symbol === "duplicate-root")).toBe(true);
+	});
+	test("rejects privileged value transfer and unsupported callee families", () => {
+		const transfers = analyzeSource(
+			`import { constants } from "node:fs"; import { open } from "node:fs/promises";
+			const invoke = (fn: typeof open) => fn("x", constants.O_WRONLY);
+			void invoke(open);
+			const api = { open };
+			void api;
+			export { open };
+			export default open;`,
+			`${fixture}/allowed.ts`,
+		);
+		expect(
+			transfers.filter(
+				(finding) => finding.rule === RULES.unknownBinding && finding.symbol === "capability-transfer:open",
+			).length,
+		).toBeGreaterThanOrEqual(4);
+
+		const unsupported = analyzeSource(
+			`import { constants } from "node:fs"; import { open } from "node:fs/promises";
+			(0, open)("sequence", constants.O_WRONLY);
+			(true ? open : open)("conditional", constants.O_WRONLY);
+			(open || open)("logical", constants.O_WRONLY);`,
+			`${fixture}/allowed.ts`,
+		);
+		expect(unsupported.filter((finding) => finding.symbol === "unsupported-callee")).toHaveLength(3);
+	});
+
+	test("rejects unreachable command flow, getter transfer, and mutation helpers", async () => {
+		const command = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/commands/worktree.ts"),
+			"utf8",
+		);
+		for (const terminal of ["return;", 'throw new Error("decoy");']) {
+			const hostile = command.replace(
+				"const { args, flags, argv } = await this.parse(Worktree);",
+				`${terminal}\n\t\t\tconst { args, flags, argv } = await this.parse(Worktree);`,
+			);
+			expect(
+				analyzeSource(hostile, "packages/coding-agent/src/commands/worktree.ts").some(
+					(finding) => finding.rule === RULES.getterTiming,
+				),
+			).toBe(true);
+		}
+
+		const getterTransfer = command.replace(
+			"const root = getWorktreesDir();",
+			"const getterAlias = getWorktreesDir; const getterBox = { getWorktreesDir }; void getterAlias; void getterBox; const root = getWorktreesDir();",
+		);
+		expect(
+			analyzeSource(getterTransfer, "packages/coding-agent/src/commands/worktree.ts").some(
+				(finding) => finding.rule === RULES.getterTiming,
+			),
+		).toBe(true);
+
+		const helperMutation = command.replace(
+			'const action = args.action === "clear" ? "clear" : "list";',
+			`Object.assign(args, { action: "clear" });
+			Object.assign(flags, { all: false });
+			Object.assign(process, { platform: "win32" });
+			const action = args.action === "clear" ? "clear" : "list";`,
+		);
+		expect(
+			analyzeSource(helperMutation, "packages/coding-agent/src/commands/worktree.ts").some(
+				(finding) => finding.rule === RULES.forbiddenMember && finding.symbol === "Object.assign",
+			),
+		).toBe(true);
+	});
+
+	test("rejects unreachable, post-return, and unconsumed worker scans", async () => {
+		const worker = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/cli/worktree-cli.ts"),
+			"utf8",
+		);
+		const falseBranch = worker.replace(
+			"diagnostics = await scanWorktrees({ root: options.root, platform: options.platform });",
+			"if (false) diagnostics = await scanWorktrees({ root: options.root, platform: options.platform }); else diagnostics = [];",
+		);
+		expect(
+			analyzeSource(falseBranch, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+			),
+		).toBe(true);
+
+		for (const body of [
+			`let diagnostics; return []; diagnostics = await scanWorktrees({ root: options.root, platform: options.platform });`,
+			`await scanWorktrees({ root: options.root, platform: options.platform }); return [];`,
+		]) {
+			const hostile = `import { scanWorktrees } from "./worktree-scanner";
+				export async function runWorktreeCommand(options: { root: string; platform: "posix" | "win32" }) { ${body} }`;
+			expect(
+				analyzeSource(hostile, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+					(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+				),
+			).toBe(true);
+		}
+	});
+	test("rejects closed-world CLI capability and registry mutations", async () => {
+		const cli = await readFile(path.join(import.meta.dir, "../packages/coding-agent/src/cli.ts"), "utf8");
+		const mutants = [
+			`${cli}\ncommands.length = 0;`,
+			`${cli}\n(0, eval)("payload");`,
+			`${cli}\n(true ? eval : eval)("payload");`,
+			`${cli}\n(eval || eval)("payload");`,
+			`${cli}\neval?.("payload");`,
+			`${cli}\neval\`payload\`;`,
+			`${cli}\nlet request; request = fetch; request("https://example.invalid");`,
+			`${cli}\nFunction("return process")();`,
+			`${cli}\nprocess.exit(0);`,
+		];
+		for (const source of mutants) {
+			expect(analyzeSource(source, "packages/coding-agent/src/cli.ts").length).toBeGreaterThan(0);
+		}
+	});
+
+	test("rejects privileged scanner wrapper exports", async () => {
+		const scanner = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/cli/worktree-scanner.ts"),
+			"utf8",
+		);
+		for (const source of [
+			`${scanner}\nexport const leaked = (candidate: string) => lstat(candidate, { bigint: true });`,
+			`${scanner}\nconst leaked = { inspect: (candidate: string) => lstat(candidate, { bigint: true }) }; export default leaked;`,
+		]) {
+			expect(
+				analyzeSource(source, "packages/coding-agent/src/cli/worktree-scanner.ts").some(
+					(finding) => finding.rule === RULES.scannerApi && finding.symbol === "export-surface",
+				),
+			).toBe(true);
+		}
+	});
+
+	test("rejects duplicate and unreachable command authority", async () => {
+		const command = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/commands/worktree.ts"),
+			"utf8",
+		);
+		const duplicateRun = command.replace("\n\t};\n}", "\n\t\tasync run(): Promise<void> { return; }\n\t};\n}");
+		const nestedTerminal = command.replace(
+			"const { args, flags, argv } = await this.parse(Worktree);",
+			"if (true) return;\n\t\t\tconst { args, flags, argv } = await this.parse(Worktree);",
+		);
+		const terminalAlternate = command.replace(
+			"\t\t\t}\n\t\t\tconst root = getWorktreesDir();",
+			"\t\t\t} else { return; }\n\t\t\tconst root = getWorktreesDir();",
+		);
+		const fakeRender = command.replace(
+			"if (result.stdout.length > 0) process.stdout.write(result.stdout);",
+			"void result.stdout;",
+		);
+		for (const source of [duplicateRun, nestedTerminal, terminalAlternate, fakeRender]) {
+			expect(
+				analyzeSource(source, "packages/coding-agent/src/commands/worktree.ts").some(
+					(finding) => finding.rule === RULES.getterTiming,
+				),
+			).toBe(true);
+		}
+	});
+
+	test("rejects nested, looped, and semantically unconsumed scans", async () => {
+		const worker = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/cli/worktree-cli.ts"),
+			"utf8",
+		);
+		const nestedTerminal = worker.replace(
+			"diagnostics = await scanWorktrees({ root: options.root, platform: options.platform });",
+			'if (true) return { stdout: "forged", stderr: "", exitCode: 0 }; diagnostics = await scanWorktrees({ root: options.root, platform: options.platform });',
+		);
+		const looped = worker.replace(
+			"diagnostics = await scanWorktrees({ root: options.root, platform: options.platform });",
+			"while (false) { diagnostics = await scanWorktrees({ root: options.root, platform: options.platform }); }",
+		);
+		const unconsumed = `import { scanWorktrees } from "./worktree-scanner";
+			export async function runWorktreeCommand(options: { root: string; platform: "posix" | "win32" }) {
+				let diagnostics;
+				try { diagnostics = await scanWorktrees({ root: options.root, platform: options.platform }); } catch {}
+				void diagnostics;
+				return { stdout: "forged", stderr: "", exitCode: 0 };
+			}`;
+		for (const source of [nestedTerminal, looped, unconsumed]) {
+			expect(
+				analyzeSource(source, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+					(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+				),
+			).toBe(true);
+		}
+	});
+
+	test("rejects noncanonical and authoritative-duplicate additive roots", async () => {
+		const findings = await verifyWorktreeReportCapabilities({
+			repoRoot: path.resolve(import.meta.dir, ".."),
+			roots: [
+				"scripts/fixtures/worktree-report-capabilities/../worktree-report-capabilities/allowed.ts",
+				"packages/coding-agent/src/cli.ts",
+			],
+		});
+		expect(
+			findings.some(
+				(finding) =>
+					finding.path === "scripts/fixtures/worktree-report-capabilities/../worktree-report-capabilities/allowed.ts" &&
+					finding.symbol === "invalid-replacement-root",
+			),
+		).toBe(true);
+		expect(
+			findings.some(
+				(finding) => finding.path === "packages/coding-agent/src/cli.ts" && finding.symbol === "duplicate-root",
+			),
+		).toBe(true);
+	});
+	test("rejects computed command authority and fake terminal sinks", async () => {
+		const command = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/commands/worktree.ts"),
+			"utf8",
+		);
+		const computedRun = command.replace("\n\t};\n}", '\n\t\tasync ["run"](): Promise<void> { return; }\n\t};\n}');
+		const runField = command.replace("\n\t};\n}", "\n\t\trun = async (): Promise<void> => {};\n\t};\n}");
+		const reassignedFactory = `${command}
+createWorktreeCommand = () => class Worktree extends Command { async run(): Promise<void> {} };`;
+		const loopReassignedFactory = `${command}
+for ({ createWorktreeCommand } of [{
+	createWorktreeCommand: () => class Worktree extends Command { async run(): Promise<void> {} },
+}]) {}`;
+		const nonNullReassignedFactory = `${command}
+createWorktreeCommand! = () => class Worktree extends Command { async run(): Promise<void> {} };`;
+		const fakeReads = command
+			.replace("if (result.stdout.length > 0) process.stdout.write(result.stdout);", "result.stdout.length;")
+			.replace("if (result.stderr.length > 0) process.stderr.write(result.stderr);", "result.stderr.length;")
+			.replace("if (result.exitCode !== 0) process.exitCode = result.exitCode;", "result.exitCode;");
+		const throwing = command.replace(
+			"if (result.stdout.length > 0) process.stdout.write(result.stdout);",
+			'if (result.stdout.length >= 0) throw new Error("stop");',
+		);
+		for (const source of [computedRun, runField]) {
+			expect(
+				analyzeSource(source, "packages/coding-agent/src/commands/worktree.ts").some(
+					(finding) => finding.rule === RULES.getterTiming && finding.symbol === "run-count",
+				),
+			).toBe(true);
+		}
+		for (const source of [reassignedFactory, loopReassignedFactory, nonNullReassignedFactory]) {
+			expect(
+				analyzeSource(source, "packages/coding-agent/src/commands/worktree.ts").some(
+					(finding) => finding.rule === RULES.getterTiming,
+				),
+			).toBe(true);
+		}
+		for (const source of [fakeReads, throwing]) {
+			expect(
+				analyzeSource(source, "packages/coding-agent/src/commands/worktree.ts").some(
+					(finding) => finding.rule === RULES.getterTiming,
+				),
+			).toBe(true);
+		}
+	});
+
+	test("rejects finalizer and forged worker result dataflow", async () => {
+		const worker = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/cli/worktree-cli.ts"),
+			"utf8",
+		);
+		const finalizer = worker.replace(
+			'\n\t}\n\tif (options.action === "list")',
+			'\n\t} finally { return { stdout: "forged", stderr: "", exitCode: 0 }; }\n\tif (options.action === "list")',
+		);
+		const forged = worker.replace(
+			"0 removed · ${diagnostics.length} kept",
+			'${diagnostics.length >= 0 ? "forged" : "forged"}',
+		);
+		const reassignedWorker = `${worker}
+runWorktreeCommand = async () => ({ stdout: "forged", stderr: "", exitCode: 0 });`;
+		const loopReassignedWorker = `${worker}
+for ({ runWorktreeCommand } of [{
+	runWorktreeCommand: async () => ({ stdout: "forged", stderr: "", exitCode: 0 }),
+}]) {}`;
+		const nonNullReassignedWorker = `${worker}
+runWorktreeCommand! = async () => ({ stdout: "forged", stderr: "", exitCode: 0 });`;
+		for (const source of [finalizer, forged]) {
+			expect(
+				analyzeSource(source, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+					(finding) => finding.rule === RULES.scannerApi,
+				),
+			).toBe(true);
+		}
+		for (const source of [reassignedWorker, loopReassignedWorker, nonNullReassignedWorker]) {
+			expect(
+				analyzeSource(source, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+					(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+				),
+			).toBe(true);
+		}
+	});
+
+	test("rejects bound registry mutation and scanner export facade", async () => {
+		const cli = await readFile(path.join(import.meta.dir, "../packages/coding-agent/src/cli.ts"), "utf8");
+		const registryMutation = `${cli}
+commands.unshift({ name: "worktree", aliases: ["wt"], load: async () => class Worktree extends Command { async run() {} } });`;
+		const escapedRegistry = `${cli}
+const box = { commands };
+box.commands.unshift({ name: "worktree", load: async () => class Worktree extends Command { async run() {} } });`;
+		expect(
+			analyzeSource(registryMutation, "packages/coding-agent/src/cli.ts").some(
+				(finding) => finding.rule === RULES.mutation && finding.symbol === "registry-mutation",
+			),
+		).toBe(true);
+		expect(
+			analyzeSource(escapedRegistry, "packages/coding-agent/src/cli.ts").some(
+				(finding) => finding.rule === RULES.mutation && finding.symbol === "registry-mutation",
+			),
+		).toBe(true);
+
+		const scanner = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/cli/worktree-scanner.ts"),
+			"utf8",
+		);
+		const facade = scanner
+			.replace("export async function scanWorktrees", "async function originalScanWorktrees")
+			.concat(`
+const facade = async (options: ScanWorktreesOptions): Promise<WorktreeDiagnostic[]> => {
+	void lstat(options.root, { bigint: true });
+	return [];
+};
+export { facade as scanWorktrees };`);
+		const directFacade = scanner
+			.replace("export async function scanWorktrees", "async function originalScanWorktrees")
+			.concat(`
+export async function scanWorktrees(_options: ScanWorktreesOptions): Promise<WorktreeDiagnostic[]> {
+	return [];
+}`);
+		expect(
+			analyzeSource(facade, "packages/coding-agent/src/cli/worktree-scanner.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "export-surface",
+			),
+		).toBe(true);
+		expect(
+			analyzeSource(directFacade, "packages/coding-agent/src/cli/worktree-scanner.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "scanner-flow:open",
+			),
+		).toBe(true);
+	});
+	test("rejects process aliases, scanner rebinding, and top-level command sinks", async () => {
+		const cli = await readFile(path.join(import.meta.dir, "../packages/coding-agent/src/cli.ts"), "utf8");
+		const processAlias = `${cli}
+const terminate = process.exit;
+terminate(0);`;
+		const destructuredProcess = `${cli}
+const { exit: terminate } = process;
+terminate(0);`;
+		const shorthandCapabilities = `${cli}
+const leaked = { fetch, eval, process };
+void leaked;`;
+		expect(
+			analyzeSource(processAlias, "packages/coding-agent/src/cli.ts").some(
+				(finding) => finding.rule === RULES.process && finding.symbol === "process-transfer:exit",
+			),
+		).toBe(true);
+		expect(
+			analyzeSource(destructuredProcess, "packages/coding-agent/src/cli.ts").some(
+				(finding) => finding.rule === RULES.process && finding.symbol === "process-transfer:process",
+			),
+		).toBe(true);
+		const shorthandFindings = analyzeSource(shorthandCapabilities, "packages/coding-agent/src/cli.ts");
+		expect(
+			shorthandFindings.some((finding) => finding.rule === RULES.forbiddenCall && finding.symbol === "fetch"),
+		).toBe(true);
+		expect(shorthandFindings.some((finding) => finding.rule === RULES.forbiddenCall && finding.symbol === "eval")).toBe(
+			true,
+		);
+		expect(
+			shorthandFindings.some(
+				(finding) => finding.rule === RULES.process && finding.symbol === "process-transfer:process",
+			),
+		).toBe(true);
+		const scannerShorthandFindings = analyzeSource(
+			"const leaked = { fetch, eval, process }; void leaked;",
+			`${fixture}/allowed.ts`,
+		);
+		for (const [rule, symbol] of [
+			[RULES.forbiddenCall, "fetch"],
+			[RULES.forbiddenCall, "eval"],
+			[RULES.process, "process"],
+		] as const) {
+			expect(scannerShorthandFindings.some((finding) => finding.rule === rule && finding.symbol === symbol)).toBe(true);
+		}
+
+		const scanner = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/cli/worktree-scanner.ts"),
+			"utf8",
+		);
+		const reboundScanner = `${scanner}
+scanWorktrees = async (_options: ScanWorktreesOptions): Promise<WorktreeDiagnostic[]> => [];`;
+		const satisfiesReboundScanner = `${scanner}
+for ((scanWorktrees satisfies typeof scanWorktrees) of [
+	async (_options: ScanWorktreesOptions): Promise<WorktreeDiagnostic[]> => [],
+]) {}`;
+		expect(
+			analyzeSource(reboundScanner, "packages/coding-agent/src/cli/worktree-scanner.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "scanner-binding-mutation",
+			),
+		).toBe(true);
+		expect(
+			analyzeSource(satisfiesReboundScanner, "packages/coding-agent/src/cli/worktree-scanner.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "scanner-binding-mutation",
+			),
+		).toBe(true);
+
+		const command = await readFile(
+			path.join(import.meta.dir, "../packages/coding-agent/src/commands/worktree.ts"),
+			"utf8",
+		);
+		const topLevelSink = `${command}
+process.stdout.write("forged before run\\n");`;
+		const forgedRunClass = `${command}
+class Forged {
+	run(): void {
+		process.stdout.write("forged\\n");
+		process.exitCode = 0;
+	}
+}`;
+		expect(
+			analyzeSource(topLevelSink, "packages/coding-agent/src/commands/worktree.ts").some(
+				(finding) => finding.rule === RULES.process && finding.symbol === "process.stdout",
+			),
+		).toBe(true);
+		expect(
+			analyzeSource(forgedRunClass, "packages/coding-agent/src/commands/worktree.ts").some(
+				(finding) => finding.rule === RULES.getterTiming,
+			),
+		).toBe(true);
+	});
+	test("graphRoot integration reports ambiguous selected leaves deterministically", async () => {
+		const repoRoot = await mkdtemp(path.join(path.dirname(import.meta.dir), "wtr-graph-"));
+		try {
+			await mkdir(path.join(repoRoot, "packages/coding-agent/src/commands"), { recursive: true });
+			await writeFile(path.join(repoRoot, "tsconfig.json"), JSON.stringify({ compilerOptions: {} }));
+			await writeFile(
+				path.join(repoRoot, "packages/coding-agent/src/cli.ts"),
+				`export const commands = [{ name: "worktree", load: async () => { const { createWorktreeCommand } = await import("./commands/worktree"); return createWorktreeCommand; } }];`,
+			);
+			await writeFile(path.join(repoRoot, "packages/coding-agent/src/commands/worktree.ts"), "export const createWorktreeCommand = () => class Worktree {};");
+			await mkdir(path.join(repoRoot, "packages/coding-agent/src/commands/worktree"), { recursive: true });
+			await writeFile(path.join(repoRoot, "packages/coding-agent/src/commands/worktree/index.tsx"), "export const createWorktreeCommand = () => class Worktree {};");
+			const findings = await verifyWorktreeReportCapabilities({
+				repoRoot,
+				graphRoot: "packages/coding-agent/src/cli.ts",
+			});
+			const receipts = findings.map(formatFinding);
+			expect(findings).toEqual(sortFindings(findings));
+			expect(receipts.some((receipt) => receipt.includes("ambiguous-edge:./commands/worktree"))).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("graphRoot integration fails closed on malformed alias configuration", async () => {
+		const repoRoot = await mkdtemp(path.join(path.dirname(import.meta.dir), "wtr-config-"));
+		try {
+			await mkdir(path.join(repoRoot, "packages/coding-agent/src"), { recursive: true });
+			await writeFile(path.join(repoRoot, "tsconfig.json"), JSON.stringify({ compilerOptions: { paths: { "@fixture/*": ["outside/*", "other/*"] } } }));
+			await writeFile(path.join(repoRoot, "packages/coding-agent/src/cli.ts"), "export const commands = [];");
+			const findings = await verifyWorktreeReportCapabilities({
+				repoRoot,
+				graphRoot: "packages/coding-agent/src/cli.ts",
+			});
+			expect(findings.some((finding) => finding.symbol.startsWith("tsconfig:"))).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("graphRoot integration accepts the copied direct production graph", async () => {
+		const repoRoot = await makeGraph();
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings.filter((finding) => finding.symbol.includes("edge") || finding.symbol.includes("reachable"))).toEqual([]);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("graphRoot integration resolves wildcard aliases before external skip", async () => {
+		const repoRoot = await makeGraph({}, { paths: { "@fixture/*": ["packages/coding-agent/src/*"] } });
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings.some((finding) => finding.symbol.startsWith("tsconfig:"))).toBe(false);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("graphRoot integration resolves index-only selected modules", async () => {
+		const commandSource = await readFile(
+			path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"),
+			"utf8",
+		);
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": "export * from './barrel';",
+			"packages/coding-agent/src/commands/barrel/index.ts": "export * from '../command-leaf';",
+			"packages/coding-agent/src/commands/command-leaf.ts": commandSource,
+		});
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings).toEqual([]);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("same-file selected binding ambiguity cannot hide hostile decoy", async () => {
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": "export const decoy = () => class Worktree {}; export const createWorktreeCommand = process;",
+		});
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings.some((finding) => finding.rule === RULES.unknownBinding || finding.rule === RULES.process)).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("graphRoot integration rejects wrong selected export", async () => {
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": "export const other = () => class Worktree {};",
+		});
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings.some((finding) => finding.symbol === "selected-command-ambiguous")).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("graphRoot integration rejects wrong importer and phase", async () => {
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/cli.ts": "export const commands = [{ name: 'worktree', load: async () => import('./commands/worktree') }];",
+		});
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings.some((finding) => finding.rule === RULES.registryEdge)).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("graphRoot integration reports unresolved dynamic wrapper", async () => {
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/cli.ts": "const moduleName = './commands/worktree'; export const commands = [{ name: 'worktree', load: async () => import(moduleName) }];",
+		});
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings.some((finding) => finding.symbol === "selected-edge-count:0")).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("graphRoot integration rejects authority-bearing bridge", async () => {
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": "export const forged = 1; export const createWorktreeCommand = () => class Worktree {};",
+		});
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings.some((finding) => finding.rule === RULES.getterTiming || finding.rule === RULES.unknownBinding)).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("named barrel resolves copied production command leaf", async () => {
+		const command = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"), "utf8");
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `export { createWorktreeCommand } from "./worktree-leaf";`,
+			"packages/coding-agent/src/commands/worktree-leaf.ts": command,
+		});
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings).toEqual([]);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("default reexport resolves binding and fails closed for unapproved default leaf", async () => {
+		const command = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"), "utf8");
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `export { default as createWorktreeCommand } from "./default-leaf";`,
+			"packages/coding-agent/src/commands/default-leaf.ts": command.replace(
+				"export function createWorktreeCommand",
+				"export default function notApprovedWorktreeCommand",
+			),
+		});
+		try {
+			const receipts = (await graphFindings(repoRoot)).map(formatFinding);
+			expect(receipts.some((value) => value.includes("selected-command"))).toBe(false);
+			expect(receipts.length).toBeGreaterThan(0);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("namespace reexport fails closed with exact namespace-selection receipt", async () => {
+		const command = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"), "utf8");
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `import * as leaf from "./namespace-leaf"; export { leaf as createWorktreeCommand };`,
+			"packages/coding-agent/src/commands/namespace-leaf.ts": command,
+		});
+		try {
+			const receipts = (await graphFindings(repoRoot)).map(formatFinding);
+			expect(receipts.filter((value) => value.includes("namespace-selection"))).toHaveLength(1);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("export-star barrel cycle resolves one copied production leaf", async () => {
+		const command = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"), "utf8");
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `export * from "./barrel-a";`,
+			"packages/coding-agent/src/commands/barrel-a.ts": `export * from "./barrel-b";`,
+			"packages/coding-agent/src/commands/barrel-b.ts": `export * from "./barrel-a"; export * from "./star-leaf";`,
+			"packages/coding-agent/src/commands/star-leaf.ts": command,
+		});
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings).toEqual([]);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("ambiguous export-star leaves produce selected-command ambiguity", async () => {
+		const command = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"), "utf8");
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `export * from "./star-a"; export * from "./star-b";`,
+			"packages/coding-agent/src/commands/star-a.ts": command,
+			"packages/coding-agent/src/commands/star-b.ts": command,
+		});
+		try {
+			const receipts = (await graphFindings(repoRoot)).map(formatFinding);
+			expect(receipts.some((value) => value.includes("selected-command-ambiguous"))).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("authority-bearing bridge emits unsafe-bridge", async () => {
+		const command = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"), "utf8");
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `export * from "./authority-bridge";`,
+			"packages/coding-agent/src/commands/authority-bridge.ts": `export * from "./authority-leaf"; const leak = process;`,
+			"packages/coding-agent/src/commands/authority-leaf.ts": command,
+		});
+		try {
+			const receipts = (await graphFindings(repoRoot)).map(formatFinding);
+			expect(receipts.some((value) => value.includes("unsafe-bridge"))).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("type-only bridge edges are safe and selected type exports fail closed", async () => {
+		const command = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"), "utf8");
+		const safeRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `export { createWorktreeCommand } from "./bridge";`,
+			"packages/coding-agent/src/commands/bridge.ts": `import { type Foo } from "./types"; export { createWorktreeCommand } from "./leaf";`,
+			"packages/coding-agent/src/commands/types.ts": "export type Foo = string;",
+			"packages/coding-agent/src/commands/leaf.ts": command,
+		});
+		try {
+			const safeFindings = await graphFindings(safeRoot);
+			expect(safeFindings.some((finding) => finding.symbol === "unsafe-bridge")).toBe(false);
+		} finally {
+			await rm(safeRoot, { recursive: true, force: true });
+		}
+		const hostileRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `export { createWorktreeCommand } from "./bridge";`,
+			"packages/coding-agent/src/commands/bridge.ts": `export { type createWorktreeCommand } from "./leaf";`,
+			"packages/coding-agent/src/commands/leaf.ts": command,
+		});
+		try {
+			const hostileFindings = await graphFindings(hostileRoot);
+			expect(hostileFindings.filter((finding) => finding.symbol === "type-only-selection")).toHaveLength(1);
+		} finally {
+			await rm(hostileRoot, { recursive: true, force: true });
+		}
+	});
+	test("selected command leaf receives command role override by filename", async () => {
+		const command = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"), "utf8");
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `export { createWorktreeCommand } from "./renamed-leaf";`,
+			"packages/coding-agent/src/commands/renamed-leaf.ts": command.replace("const root = getWorktreesDir();", "const eager = getWorktreesDir(); const root = getWorktreesDir();"),
+		});
+		try {
+			const receipts = (await graphFindings(repoRoot)).map(formatFinding);
+			expect(receipts.some((value) => value.includes("WTR008_FACTORY_GETTER_TIMING"))).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("additive decoy roots cannot mask the production authoritative graph", async () => {
+		const repoRoot = path.resolve(import.meta.dir, "..");
+		const findings = await verifyWorktreeReportCapabilities({
+			repoRoot,
+			roots: ["scripts/fixtures/worktree-report-capabilities/allowed.ts"],
+		});
+		expect(findings.filter((finding) => finding.path === "packages/coding-agent/src/cli.ts")).toEqual([]);
+	});
+	test("graphRoot integration emits deterministic multi-finding receipts", async () => {
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/cli.ts": "export const commands = [{ name: 'worktree', load: async () => import(name) }];",
+		});
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings).toEqual(sortFindings(findings));
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("handle references distinguish keys, members, shorthand, and computed escapes", () => {
+		const source = `import { open } from "node:fs/promises"; import { constants } from "node:fs";
+export async function scanWorktrees() {
+	const handle = await open("x", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+	const other = { handle: 1 };
+	other.handle;
+	const leaked = { handle };
+	const computed = { [handle]: 1 };
+	void leaked;
+	void computed;
+	await handle.close(); await handle.stat(); await handle.read(Buffer.alloc(1));
+}`;
+		const findings = analyzeSource(source, "packages/coding-agent/src/cli/worktree-scanner.ts");
+		expect(findings.some((finding) => finding.symbol === "FileHandle.extraction")).toBe(true);
+	});
+	test("reachable bridges analyze unselected runtime reexports", async () => {
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `export { createWorktreeCommand } from "./safe"; export * from "./hostile";`,
+			"packages/coding-agent/src/commands/safe.ts": `export { createWorktreeCommand } from "./leaf";`,
+			"packages/coding-agent/src/commands/hostile.ts": `import "node:fs"; export const leak = process;`,
+		});
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings.some((finding) => finding.symbol === "unsafe-bridge")).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("selected malformed and unreadable leaves fail closed", async () => {
+		const malformed = await makeGraph({
+			"packages/coding-agent/src/cli/worktree-cli.ts": "export function runWorktreeCommand( {",
+		});
+		try {
+			const findings = await graphFindings(malformed);
+			expect(findings.some((finding) => finding.symbol === "parse")).toBe(true);
+		} finally {
+			await rm(malformed, { recursive: true, force: true });
+		}
+		const missing = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `export { createWorktreeCommand } from "./missing-leaf";`,
+		});
+		try {
+			const findings = await graphFindings(missing);
+			expect(findings.some((finding) => finding.symbol.startsWith("unresolved-edge"))).toBe(true);
+		} finally {
+			await rm(missing, { recursive: true, force: true });
+		}
+	});
+	test("root and config symlink escapes fail closed", async () => {
+		const repoRoot = await makeGraph();
+		try {
+			const outside = await mkdtemp(path.join(path.dirname(repoRoot), "wtr-outside-"));
+			await writeFile(path.join(outside, "evil.ts"), "process.env.X = '1';");
+			await symlink(path.join(outside, "evil.ts"), path.join(repoRoot, "evil.ts"));
+			const findings = await verifyWorktreeReportCapabilities({ repoRoot, roots: ["evil.ts"] });
+			expect(findings.some((finding) => finding.path === "evil.ts" && finding.symbol === "unresolved-root")).toBe(true);
+			await rm(outside, { recursive: true, force: true });
+			await rm(path.join(repoRoot, "tsconfig.json"), { force: true });
+			await symlink(path.join(outside, "evil.ts"), path.join(repoRoot, "tsconfig.json"));
+			const configFindings = await graphFindings(repoRoot);
+			expect(configFindings.some((finding) => finding.symbol.startsWith("tsconfig:"))).toBe(true);
+			await rm(path.join(repoRoot, "tsconfig.json"), { force: true });
+			await symlink(outside, path.join(repoRoot, "linked-dir"));
+			const directoryFindings = await verifyWorktreeReportCapabilities({ repoRoot, roots: ["linked-dir"] });
+			expect(directoryFindings.some((finding) => finding.path === "linked-dir")).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("scanner flow ignores all statically dead call sites", () => {
+		const source = `import { lstat, open, readdir } from "node:fs/promises";
+export async function scanWorktrees() {
+	return;
+	lstat("x"); throw new Error(); open("x", 0); readdir("x");
+	if (true) {} else { lstat("x"); } false && readdir("x"); true || open("x", 0);
+	while (false) { lstat("x"); } for (;false;) { readdir("x"); }
+}`;
+		const receipts = analyzeSource(source, "packages/coding-agent/src/cli/worktree-scanner.ts")
+			.filter((finding) => finding.symbol.startsWith("scanner-flow:"));
+		expect(receipts).toHaveLength(6);
+	});
+	test("tsconfig inherited baseUrl and paths use the effective owner and selected leaf", async () => {
+		const command = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"), "utf8");
+		const cases = [
+			{
+				name: "parent-paths-child-base",
+				config: { extends: "./configs/child.json" },
+				files: {
+					"configs/child.json": JSON.stringify({ extends: "./parent.json", compilerOptions: { baseUrl: ".." } }),
+					"configs/parent.json": JSON.stringify({ compilerOptions: { paths: { "@leaf/*": ["../packages/coding-agent/src/commands/*"] } } }),
+					"packages/coding-agent/src/commands/command.ts": command,
+					"decoy/command.ts": "export const createWorktreeCommand = process;",
+					"packages/coding-agent/src/commands/worktree.ts": `export { createWorktreeCommand } from "@leaf/command";`,
+				},
+			},
+			{
+				name: "parent-base-child-paths",
+				config: { extends: "./configs/child.json" },
+				files: {
+					"configs/child.json": JSON.stringify({ extends: "./parent.json", compilerOptions: { paths: { "@leaf/*": ["packages/coding-agent/src/commands/*"] } } }),
+					"configs/parent.json": JSON.stringify({ compilerOptions: { baseUrl: ".." } }),
+					"packages/coding-agent/src/commands/command.ts": command,
+					"decoy/command.ts": "export const createWorktreeCommand = process;",
+					"packages/coding-agent/src/commands/worktree.ts": `export { createWorktreeCommand } from "@leaf/command";`,
+				},
+			},
+		] as const;
+		for (const scenario of cases) {
+			const repoRoot = await makeGraph(scenario.files);
+			await writeFile(path.join(repoRoot, "tsconfig.json"), JSON.stringify(scenario.config));
+			try {
+				const findings = await graphFindings(repoRoot);
+				expect(findings.filter((finding) => finding.symbol.startsWith("tsconfig:"))).toEqual([]);
+				expect(
+					findings.filter((finding) => finding.rule === RULES.process || finding.rule === RULES.unknownBinding),
+				).toEqual([]);
+			} finally {
+				await rm(repoRoot, { recursive: true, force: true });
+			}
+		}
+	});
+	test("live out-of-repo file, directory, and tsconfig symlinks fail closed", async () => {
+		const repoRoot = await makeGraph();
+		const outside = await mkdtemp(path.join(path.dirname(repoRoot), "wtr-live-outside-"));
+		try {
+			await writeFile(path.join(outside, "evil.ts"), "export const commands = [];");
+			await mkdir(path.join(outside, "dir"), { recursive: true });
+			await writeFile(path.join(outside, "dir", "evil.ts"), "export const commands = [];");
+			await symlink(path.join(outside, "evil.ts"), path.join(repoRoot, "evil.ts"));
+			await symlink(path.join(outside, "dir"), path.join(repoRoot, "linked-dir"));
+			const fileFindings = await verifyWorktreeReportCapabilities({ repoRoot, roots: ["evil.ts"] });
+			const dirFindings = await verifyWorktreeReportCapabilities({ repoRoot, roots: ["linked-dir"] });
+			expect(fileFindings.some((finding) => finding.path === "evil.ts" && finding.symbol === "unresolved-root")).toBe(true);
+			expect(dirFindings.some((finding) => finding.path === "linked-dir" && finding.symbol === "unresolved-root")).toBe(true);
+			await rm(path.join(repoRoot, "tsconfig.json"));
+			await symlink(path.join(outside, "config.json"), path.join(repoRoot, "tsconfig.json"));
+			await writeFile(path.join(outside, "config.json"), JSON.stringify({ extends: "./parent.json" }));
+			await writeFile(path.join(outside, "parent.json"), JSON.stringify({ compilerOptions: {} }));
+			const configFindings = await graphFindings(repoRoot);
+			expect(configFindings.some((finding) => finding.symbol === "tsconfig:tsconfig-out-of-repo")).toBe(true);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+			await rm(outside, { recursive: true, force: true });
+		}
+	});
+	test("scanner flow excludes terminal branches and non-falling loops but keeps do-while body", () => {
+		const required = ["handle.close", "handle.read", "handle.stat", "lstat", "open", "readdir"];
+		const cases: Array<[string, string[]]> = [
+			["if-true-return", required],
+			["both-terminal-if", required],
+			["false-loops", ["handle.close", "handle.read", "handle.stat", "lstat", "readdir"]],
+			["infinite-loop", ["handle.close", "handle.read", "handle.stat", "lstat", "readdir"]],
+			["do-while-false", []],
+			["for-infinite", ["handle.close", "handle.read", "handle.stat", "lstat", "readdir"]],
+			["infinite-do-while", ["handle.close", "handle.read", "handle.stat", "lstat", "readdir"]],
+			["terminal-do-while", required],
+			["while-break", ["handle.close", "handle.read", "handle.stat"]],
+			["continue-break", ["handle.close", "handle.read", "handle.stat"]],
+		];
+		const prefix = `import { lstat, open, readdir } from "node:fs/promises";
+			export async function scanWorktrees() {`;
+		for (const [name, expectedMissing] of cases) {
+			const body =
+				name === "if-true-return"
+					? `if (true) return; lstat("x"); readdir("x"); open("x", 0);`
+					: name === "both-terminal-if"
+						? `if (x) { return; } else { throw new Error(); } lstat("x"); readdir("x"); open("x", 0);`
+						: name === "false-loops"
+							? `while (false) lstat("x"); for (;false;) readdir("x"); open("x", 0);`
+							: name === "infinite-loop"
+								? `while (true) { open("x", 0); } lstat("x"); readdir("x");`
+								: name === "for-infinite"
+									? `for (;;) { open("x", 0); } lstat("x"); readdir("x");`
+									: name === "infinite-do-while"
+										? `do { open("x", 0); } while (true); lstat("x"); readdir("x");`
+										: name === "terminal-do-while"
+											? `do { return; } while (true); lstat("x"); readdir("x"); open("x", 0);`
+											: name === "while-break"
+												? `while (true) { open("x", 0); break; } lstat("x"); readdir("x");`
+												: name === "continue-break"
+													? `while (true) { if (x) continue; open("x", 0); break; } lstat("x"); readdir("x");`
+													: `do { await lstat("x"); await readdir("x"); const h = await open("x", 0); await h.stat(); await h.read(); await h.close(); } while (false);`;
+			const receipts = analyzeSource(`${prefix}${body}}`, "packages/coding-agent/src/cli/worktree-scanner.ts")
+				.filter((finding) => finding.rule === RULES.scannerApi && finding.symbol.startsWith("scanner-flow:"))
+				.map((finding) => finding.symbol.replace("scanner-flow:", ""));
+			expect(receipts).toEqual(expectedMissing);
+		}
+	});
+	test("scanner flow preserves mandatory and optional loop completion", () => {
+		const required = ["handle.close", "handle.read", "handle.stat", "lstat", "open", "readdir"];
+		const nestedInfinite = `import { lstat, open, readdir } from "node:fs/promises";
+			export async function scanWorktrees() {
+				do { for (;;) {} } while (false);
+				lstat("x"); readdir("x"); open("x", 0);
+			}`;
+		const nestedReceipts = analyzeSource(nestedInfinite, "packages/coding-agent/src/cli/worktree-scanner.ts")
+			.filter((finding) => finding.rule === RULES.scannerApi && finding.symbol.startsWith("scanner-flow:"))
+			.map((finding) => finding.symbol.replace("scanner-flow:", ""));
+		expect(nestedReceipts).toEqual(required);
+
+		const optionalEntry = `import { lstat, open, readdir } from "node:fs/promises";
+			export async function scanWorktrees() {
+				while (condition) { return; }
+				lstat("x"); readdir("x"); open("x", 0);
+			}`;
+		const optionalReceipts = analyzeSource(optionalEntry, "packages/coding-agent/src/cli/worktree-scanner.ts")
+			.filter((finding) => finding.rule === RULES.scannerApi && finding.symbol.startsWith("scanner-flow:"))
+			.map((finding) => finding.symbol.replace("scanner-flow:", ""));
+		expect(optionalReceipts).toEqual(["handle.close", "handle.read", "handle.stat"]);
+	});
+	test("scanner flow keeps labeled breaks attached to their target loop", () => {
+		const source = `import { lstat, open, readdir } from "node:fs/promises";
+			export async function scanWorktrees() {
+				outer: while (true) {
+					while (true) { break outer; }
+					lstat("x"); readdir("x"); open("x", 0);
+				}
+			}`;
+		const receipts = analyzeSource(source, "packages/coding-agent/src/cli/worktree-scanner.ts")
+			.filter((finding) => finding.rule === RULES.scannerApi && finding.symbol.startsWith("scanner-flow:"))
+			.map((finding) => finding.symbol.replace("scanner-flow:", ""));
+		expect(receipts).toEqual(["handle.close", "handle.read", "handle.stat", "lstat", "open", "readdir"]);
+	});
+	test("handle reference facts exclude safe static and erased contexts, while shorthand/computed values extract", () => {
+		const safe = `import { open } from "node:fs/promises"; import { constants } from "node:fs";
+			export async function scan() {
+				const handle = await open("x", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+				const other = { handle: 1 }; other.handle;
+				class C { static handle = 1; handle() {} }
+				type T = typeof handle;
+				await handle.close(); await handle.stat(); await handle.read(Buffer.alloc(1));
+			}`;
+		const safeFindings = analyzeSource(safe, "packages/coding-agent/src/cli/worktree-scanner.ts");
+		expect(safeFindings.filter((finding) => finding.symbol === "FileHandle.extraction")).toHaveLength(0);
+		const hostile = `import { open } from "node:fs/promises"; import { constants } from "node:fs";
+			export async function scan() {
+				const handle = await open("x", constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+				const shorthand = { handle }; const computed = { [handle]: 1 }; void shorthand; void computed;
+				await handle.close(); await handle.stat(); await handle.read(Buffer.alloc(1));
+			}`;
+		const hostileFindings = analyzeSource(hostile, "packages/coding-agent/src/cli/worktree-scanner.ts");
+		expect(hostileFindings.filter((finding) => finding.symbol === "FileHandle.extraction")).toHaveLength(2);
+	});
+	test("rejects reachable runtime node reexports", async () => {
+		const command = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"), "utf8");
+		const repoRoot = await makeGraph({
+			"packages/coding-agent/src/commands/worktree.ts": `export { createWorktreeCommand } from "./bridge";`,
+			"packages/coding-agent/src/commands/bridge.ts": `export { createWorktreeCommand } from "./leaf"; export { readFile } from "node:fs"; export * from "node:fs";`,
+			"packages/coding-agent/src/commands/leaf.ts": command,
+		});
+		try {
+			const findings = await graphFindings(repoRoot);
+			const unsafe = findings.filter(
+				(finding) => finding.path === "packages/coding-agent/src/commands/bridge.ts" && finding.symbol === "unsafe-bridge",
+			);
+			expect(unsafe).toHaveLength(2);
+			expect(unsafe.map((finding) => `${finding.line}:${finding.column}`)).toEqual(["1:49", "1:85"]);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects unsupported terminal scanner control flow", () => {
+		const scanner = analyzeSource(
+			`import { lstat, open, readdir } from "node:fs/promises";
+			export async function scanWorktrees() {
+				switch (true) { case true: return; default: lstat("x"); readdir("x"); open("x", 0); }
+			}`,
+			"packages/coding-agent/src/cli/worktree-scanner.ts",
+		);
+		expect(scanner.some((finding) => finding.symbol === "scanner-flow:unsupported-control-flow")).toBe(true);
+	});
+	test("accepts the production worker conditional catch receipts", async () => {
+		const source = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/cli/worktree-cli.ts"), "utf8");
+		expect(
+			analyzeSource(source, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+			),
+		).toBe(false);
+	});
+	test("rejects guarded forged worker receipts", () => {
+		const source = `import { scanWorktrees } from "./worktree-scanner";
+			export async function runWorktreeCommand(options: { root: string; platform: "posix" | "win32"; json: boolean }) {
+				const diagnostics = await scanWorktrees({ root: options.root, platform: options.platform });
+				return options.json
+					? { stdout: "forged", stderr: "", exitCode: 0 }
+					: { stdout: \`${"${diagnostics.length}"}\`, stderr: "", exitCode: 0 };
+			}`;
+		expect(
+			analyzeSource(source, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+			),
+		).toBe(true);
+	});
+	test("rejects forged worker receipts without authoritative returned dataflow", () => {
+		const source = `import { scanWorktrees } from "./worktree-scanner";
+			export async function runWorktreeCommand(options: { root: string; platform: "posix" | "win32" }) {
+				const diagnostics = await scanWorktrees({ root: options.root, platform: options.platform });
+				const decoy = \`${"${diagnostics.length}"}\`;
+				return { stdout: "forged", stderr: "", exitCode: 0 };
+			}`;
+		expect(
+			analyzeSource(source, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+				(finding) => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+			),
+		).toBe(true);
+	});
+	test("models terminal scanner try forms without accepting dead calls", () => {
+		const cases = [
+			`try { return; } catch {} lstat("x"); readdir("x"); open("x", 0);`,
+			`try {} finally { return; } lstat("x"); readdir("x"); open("x", 0);`,
+		];
+		for (const body of cases) {
+			const findings = analyzeSource(
+				`import { lstat, open, readdir } from "node:fs/promises"; export async function scanWorktrees() { ${body} }`,
+				"packages/coding-agent/src/cli/worktree-scanner.ts",
+			);
+			expect(
+				findings
+					.filter((finding) => finding.rule === RULES.scannerApi && finding.symbol.startsWith("scanner-flow:"))
+					.map((finding) => finding.symbol.replace("scanner-flow:", "")),
+			).toEqual(["handle.close", "handle.read", "handle.stat", "lstat", "open", "readdir"]);
+		}
+	});
+	test("rejects node reexports even through a catch-all alias graph", async () => {
+		const command = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/commands/worktree.ts"), "utf8");
+		const repoRoot = await makeGraph(
+			{
+				"packages/coding-agent/src/commands/worktree.ts": `export { createWorktreeCommand } from "./barrel";`,
+				"packages/coding-agent/src/commands/barrel.ts": `export { createWorktreeCommand } from "./leaf"; export { fs } from "@fixture/*"; export * from "@fixture/*";`,
+				"packages/coding-agent/src/commands/leaf.ts": command,
+			},
+			{ "@fixture/*": ["node:*"] },
+		);
+		try {
+			const findings = await graphFindings(repoRoot);
+			expect(findings.filter((finding) => finding.symbol === "unsafe-bridge").length).toBeGreaterThanOrEqual(2);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+	test("rejects mutations and shadows of authoritative worker receipts", async () => {
+		const worker = await readFile(path.join(import.meta.dir, "..", "packages/coding-agent/src/cli/worktree-cli.ts"), "utf8");
+		const mutants = [
+			worker.replace(
+				'if (options.action === "list") {',
+				'if (options.action === "list") { const JSON = { stringify: () => "forged" };',
+			),
+			worker.replace(
+				'if (options.action === "list") {',
+				'if (options.action === "list") { const formatDiagnostic = () => "forged";',
+			),
+			worker.replace(
+				'if (options.action === "list") {',
+				'if (options.action === "list") { const diagnostics = [];',
+			),
+			worker.replace(
+				'if (!(error instanceof WorktreeRootError)) throw error;',
+				'if (!(error instanceof WorktreeRootError)) throw error; const SCAN_ERROR_TEXT = "forged";',
+			),
+			worker.replace(
+				'const SCAN_ERROR_TEXT = "managed worktree root cannot be read";',
+				'const SCAN_ERROR_TEXT = "forged";',
+			),
+			worker.replace(
+				'return `diagnostic  ${diagnostic.path}  ${diagnostic.message}`;',
+				'return `forged  ${diagnostic.path}  ${diagnostic.message}`;',
+			),
+			worker.replace(
+				'if (!(error instanceof WorktreeRootError)) throw error;',
+				'if (false) throw error;',
+			),
+			worker.replace(
+				'{ stdout: "No agent-managed worktrees found.\\n", stderr: "", exitCode: 0 }',
+				'{ stdout: "", stderr: "No agent-managed worktrees found.\\n", exitCode: 0 }',
+			),
+			worker.replace(
+				'{ stdout: "No agent-managed worktrees found.\\n", stderr: "", exitCode: 0 }',
+				'{ stdout: "No agent-managed worktrees found.\\n", stderr: "", exitCode: 1 }',
+			),
+			worker.replace(
+				"function formatDiagnostic(diagnostic: WorktreeDiagnostic): string {",
+				"async function formatDiagnostic(diagnostic: WorktreeDiagnostic): Promise<string> {",
+			),
+			worker.replace(
+				"function formatDiagnostic(diagnostic: WorktreeDiagnostic): string {",
+				"function* formatDiagnostic(diagnostic: WorktreeDiagnostic): Generator<string> {",
+			),
+			worker.replace(
+				'\t}\n\tif (options.action === "list") {',
+				'\t} finally { return { stdout: "No agent-managed worktrees found.\\n", stderr: "", exitCode: 0 }; }\n\tif (options.action === "list") {',
+			),
+			worker.replace('options.action === "list"', 'options.action === "clear"'),
+			worker.replace(
+				"options.dryRun || diagnostics.length === 0",
+				"options.json || diagnostics.length === 0",
+			),
+			worker.replace("if (options.json) return", "if (options.dryRun) return"),
+			worker.replace("diagnostics = await scanWorktrees", "diagnostics = scanWorktrees"),
+		];
+		for (const source of mutants) {
+			expect(
+				analyzeSource(source, "packages/coding-agent/src/cli/worktree-cli.ts").some(
+					finding => finding.rule === RULES.scannerApi && finding.symbol === "worker-scan-contract",
+				),
+			).toBe(true);
+		}
+	});
+});

--- a/scripts/check-worktree-report-capabilities.ts
+++ b/scripts/check-worktree-report-capabilities.ts
@@ -1,0 +1,3683 @@
+#!/usr/bin/env bun
+
+import { parse } from "@babel/parser";
+import traverse, { type NodePath, type Scope } from "@babel/traverse";
+import * as t from "@babel/types";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+export const RULES = {
+	forbiddenImport: "WTR001_FORBIDDEN_IMPORT",
+	forbiddenCall: "WTR002_FORBIDDEN_CALL",
+	forbiddenMember: "WTR003_FORBIDDEN_MEMBER",
+	unknownBinding: "WTR004_UNKNOWN_BINDING",
+	registryEdge: "WTR005A_REGISTRY_FACTORY_EDGE",
+	workerEdge: "WTR005B_VALID_RUN_WORKER_EDGE",
+	dynamicImport: "WTR005C_DYNAMIC_IMPORT_FORBIDDEN",
+	mutation: "WTR006_WRITE_OR_MUTATION",
+	process: "WTR007_UNAPPROVED_PROCESS",
+	getterTiming: "WTR008_FACTORY_GETTER_TIMING",
+	scannerApi: "WTR009_SCANNER_API",
+	dirsBaseline: "WTR010_BASELINE_DIRS_EDGE",
+} as const;
+
+export interface Finding {
+	path: string;
+	line: number;
+	column: number;
+	rule: string;
+	symbol: string;
+}
+
+export interface VerifyOptions {
+	repoRoot?: string;
+	roots?: string[];
+	graphRoot?: string;
+}
+
+type Role = "cli" | "command" | "worker" | "scanner" | "fixture";
+interface Origin {
+	source: string;
+	name: string;
+}
+
+const DEFAULT_ROOTS = [
+	"packages/coding-agent/src/cli.ts",
+	"packages/coding-agent/src/commands/worktree.ts",
+	"packages/coding-agent/src/cli/worktree-cli.ts",
+	"packages/coding-agent/src/cli/worktree-scanner.ts",
+];
+const CLI_STATIC_IMPORTS: Readonly<Record<string, ReadonlySet<string>>> = {
+	"@gajae-code/utils/postmortem": new Set(),
+	"@gajae-code/utils/cli": new Set(["Args", "CliConfig", "Command", "CommandEntry", "Flags", "run"]),
+	"@gajae-code/utils/dirs": new Set([
+		"APP_NAME",
+		"formatBunRuntimeError",
+		"getWorktreesDir",
+		"MIN_BUN_VERSION",
+		"VERSION",
+	]),
+	"./cli/fixture-report": new Set(["runFixtureReport"]),
+	"./gjc-runtime/tmux-owner-isolation-cli": new Set([
+		"isTmuxOwnerIsolationCliArgv",
+		"runTmuxOwnerIsolationCliFromStdin",
+	]),
+};
+const CLI_DEFAULT_COMMAND_IMPORTS = new Set([
+	"./commands/codex-native-hook",
+	"./commands/state",
+	"./commands/setup",
+	"./commands/acp",
+	"./commands/skills",
+	"./commands/session",
+	"./commands/harness",
+	"./commands/coordinator",
+	"./commands/team",
+	"./commands/ultragoal",
+	"./commands/gc",
+	"./commands/ralplan",
+	"./commands/config",
+	"./commands/stats",
+	"./commands/notify",
+	"./commands/sdk",
+	"./commands/daemon",
+	"./commands/web-search",
+	"./commands/local-provider",
+	"./commands/mcp-serve",
+	"./commands/mcp",
+	"./commands/contribution-prep",
+	"./commands/deep-interview",
+	"./commands/migrate",
+	"./commands/rlm",
+	"./commands/update",
+	"./commands/plugin",
+	"./commands/completion",
+	"./commands/launch",
+]);
+interface DynamicImportBaseline {
+	count: number;
+	signature: string;
+}
+const CLI_DYNAMIC_IMPORT_BASELINE: ReadonlyMap<string, DynamicImportBaseline> = new Map([
+	["@gajae-code/utils/cli", { count: 2, signature: "destructure:renderRootHelp" }],
+	["./cli/fast-help", { count: 2, signature: "destructure:getExtraHelpText" }],
+	["@gajae-code/ai/utils/h2-fetch", { count: 1, signature: "destructure:installH2Fetch" }],
+	["./cli/nofile-limit", { count: 1, signature: "destructure:warnIfMacOSNoFileLimitTooLow" }],
+	["./cli/notify-cli", { count: 1, signature: "destructure:parseNotifyArgs,runNotifyCommand" }],
+	["./sdk/bus/chat-daemon-cli", { count: 1, signature: "destructure:runChatDaemonInternal" }],
+	["@gajae-code/stats", { count: 1, signature: "destructure:smokeTestSyncWorker" }],
+	[
+		"@gajae-code/natives",
+		{
+			count: 1,
+			signature: "destructure:h01FindBestFuzzyMatch,h02ScoreSequenceFuzzy,h06FormatHashLines",
+		},
+	],
+	["./cli/malloc-env-guard", { count: 1, signature: "destructure:reexecWithScrubbedMallocEnv" }],
+]);
+const SCANNER_FS_PROMISES = new Set(["FileHandle", "lstat", "open", "readdir"]);
+const SCANNER_FS = new Set(["BigIntStats", "constants"]);
+const MUTATING_MEMBERS = new Set([
+	"appendFile",
+	"appendFileSync",
+	"chmod",
+	"copyFile",
+	"copyFileSync",
+	"exec",
+	"execFile",
+	"fork",
+	"mkdir",
+	"mkdirSync",
+	"prune",
+	"rename",
+	"renameSync",
+	"rm",
+	"rmSync",
+	"rmdir",
+	"rmdirSync",
+	"spawn",
+	"truncate",
+	"unlink",
+	"unlinkSync",
+	"write",
+	"writeFile",
+	"writeFileSync",
+	"writev",
+]);
+const FORBIDDEN_SCANNER_MEMBERS = new Set([
+	"close",
+	"opendir",
+	"opendirSync",
+	"read",
+	"readFile",
+	"readFileSync",
+	"realpath",
+	"realpathSync",
+	"stat",
+	"statSync",
+	"write",
+	"writeFile",
+	"writev",
+]);
+const REFLECTIVE_MEMBERS = new Set([
+	"constructor",
+	"prototype",
+	"__proto__",
+	"__defineGetter__",
+	"__defineSetter__",
+	"__lookupGetter__",
+	"__lookupSetter__",
+]);
+const SCANNER_PATH_CALLS = new Set(["dirname", "isAbsolute", "join", "normalize", "relative"]);
+const SCANNER_PATH_MEMBERS = new Set(["sep"]);
+const SAFE_GLOBAL_MEMBERS: Readonly<Record<string, ReadonlySet<string>>> = {
+	Buffer: new Set(["alloc", "allocUnsafe", "byteLength", "from", "isBuffer"]),
+	JSON: new Set(["stringify"]),
+	Math: new Set(["min"]),
+	Promise: new Set(["resolve"]),
+	String: new Set(["fromCharCode"]),
+};
+const SAFE_GLOBAL_CONSTRUCTORS = new Set(["Error", "Map", "Set", "TextDecoder"]);
+
+function rootIdentifier(expression: t.Expression | t.Super): t.Identifier | undefined {
+	let current: t.Expression | t.Super = expression;
+	while (t.isMemberExpression(current) || t.isOptionalMemberExpression(current)) current = current.object;
+	return t.isIdentifier(current) ? current : undefined;
+}
+
+function roleFor(relativePath: string): Role {
+	if (relativePath === "packages/coding-agent/src/cli.ts") return "cli";
+	if (relativePath === "packages/coding-agent/src/commands/worktree.ts") return "command";
+	if (relativePath === "packages/coding-agent/src/cli/worktree-cli.ts") return "worker";
+	if (relativePath === "packages/coding-agent/src/cli/worktree-scanner.ts") return "scanner";
+	if (relativePath.endsWith("/fixtures/worktree-report-capabilities/allowed.ts")) return "scanner";
+	return "fixture";
+}
+function isCommandRunPath(pathNode: NodePath<t.Node>): boolean {
+	const functionNode = pathNode.getFunctionParent()?.node;
+	return t.isClassMethod(functionNode) && !functionNode.computed && t.isIdentifier(functionNode.key, { name: "run" });
+}
+
+function location(node: t.Node): { line: number; column: number } {
+	return {
+		line: node.loc?.start.line ?? 1,
+		column: (node.loc?.start.column ?? 0) + 1,
+	};
+}
+
+function addFinding(findings: Finding[], file: string, node: t.Node, rule: string, symbol: string): void {
+	const { line, column } = location(node);
+	findings.push({ path: file, line, column, rule, symbol });
+}
+
+function parseSource(source: string): t.File | undefined {
+	try {
+		return parse(source, {
+			sourceType: "module",
+			plugins: ["typescript", "importAttributes", "dynamicImport", "classProperties", "topLevelAwait"],
+		});
+	} catch {
+		return undefined;
+	}
+}
+
+function importedName(specifier: t.ImportSpecifier | t.ImportDefaultSpecifier | t.ImportNamespaceSpecifier): string {
+	if (t.isImportDefaultSpecifier(specifier)) return "default";
+	if (t.isImportNamespaceSpecifier(specifier)) return "namespace";
+	return t.isIdentifier(specifier.imported) ? specifier.imported.name : specifier.imported.value;
+}
+
+function bindingOrigin(scope: Scope, name: string, seen = new Set<t.Node>()): Origin | undefined {
+	const binding = scope.getBinding(name);
+	if (!binding || seen.has(binding.path.node)) return undefined;
+	seen.add(binding.path.node);
+	const node = binding.path.node;
+	if (t.isImportSpecifier(node) || t.isImportDefaultSpecifier(node) || t.isImportNamespaceSpecifier(node)) {
+		const declaration = binding.path.parent;
+		return t.isImportDeclaration(declaration)
+			? { source: declaration.source.value, name: importedName(node) }
+			: undefined;
+	}
+	if (!t.isVariableDeclarator(node) || !node.init) return undefined;
+	const init = unwrapTransparentExpression(node.init);
+	if (t.isIdentifier(init)) return bindingOrigin(binding.path.scope, init.name, seen);
+	if (t.isMemberExpression(init) && !init.computed && t.isIdentifier(init.object)) {
+		const object = bindingOrigin(binding.path.scope, init.object.name, seen);
+		const name = memberName(init);
+		return object?.name === "namespace" && name ? { source: object.source, name } : undefined;
+	}
+	return undefined;
+}
+
+function unwrapTransparentExpression(node: t.Node | null | undefined): t.Node | undefined {
+	let current = node ?? undefined;
+	while (
+		current &&
+		(t.isTSAsExpression(current) ||
+			t.isTSTypeAssertion(current) ||
+			t.isTSNonNullExpression(current) ||
+			t.isTypeCastExpression(current) ||
+			t.isParenthesizedExpression(current) ||
+			t.isTSSatisfiesExpression(current))
+	) {
+		current = current.expression;
+	}
+	return current;
+}
+
+function scopedExpressionOrigin(expression: t.Node | null | undefined, scope: Scope): Origin | undefined {
+	const unwrapped = unwrapTransparentExpression(expression);
+	if (t.isIdentifier(unwrapped)) return bindingOrigin(scope, unwrapped.name);
+	if (!t.isMemberExpression(unwrapped)) return undefined;
+	const object = scopedExpressionOrigin(unwrapped.object, scope);
+	const name = memberName(unwrapped);
+	return object && name ? { source: object.source, name } : undefined;
+}
+
+type OpenFlag = "O_RDONLY" | "O_NOFOLLOW" | "O_NONBLOCK";
+
+function openFlag(expression: t.Node | null | undefined, scope: Scope, expected: OpenFlag): boolean {
+	if (!t.isMemberExpression(expression) || expression.computed) return false;
+	if (!t.isIdentifier(expression.object, { name: "constants" })) return false;
+	if (!t.isIdentifier(expression.property, { name: expected })) return false;
+	const origin = bindingOrigin(scope, "constants");
+	return origin?.source === "node:fs" && origin.name === "constants";
+}
+
+function isReadonlyOpenFlags(expression: t.Node | null | undefined, scope: Scope): boolean {
+	if (!t.isBinaryExpression(expression, { operator: "|" })) return false;
+	if (!t.isBinaryExpression(expression.left, { operator: "|" })) return false;
+	return (
+		openFlag(expression.left.left, scope, "O_RDONLY") &&
+		openFlag(expression.left.right, scope, "O_NOFOLLOW") &&
+		openFlag(expression.right, scope, "O_NONBLOCK")
+	);
+}
+
+function staticImportSource(call: t.CallExpression): string | undefined {
+	if (!t.isImport(call.callee) || call.arguments.length !== 1) return undefined;
+	const argument = call.arguments[0];
+	return t.isStringLiteral(argument) ? argument.value : undefined;
+}
+
+function staticStringValue(node: t.Node | null | undefined): string | undefined {
+	if (t.isStringLiteral(node)) return node.value;
+	if (t.isTemplateLiteral(node) && node.expressions.length === 0) return node.quasis[0]?.value.cooked ?? undefined;
+	if (t.isBinaryExpression(node, { operator: "+" })) {
+		const left = staticStringValue(node.left);
+		const right = staticStringValue(node.right);
+		if (left !== undefined && right !== undefined) return left + right;
+	}
+	return undefined;
+}
+
+function memberName(member: t.MemberExpression | t.OptionalMemberExpression): string | undefined {
+	if (member.computed) return staticStringValue(member.property);
+	return t.isIdentifier(member.property) ? member.property.name : undefined;
+}
+
+function isAllowedScannerImport(statement: t.ImportDeclaration): boolean {
+	if (statement.source.value === "node:path") {
+		return statement.specifiers.length === 1 && t.isImportNamespaceSpecifier(statement.specifiers[0]);
+	}
+	const allowed = statement.source.value === "node:fs" ? SCANNER_FS : SCANNER_FS_PROMISES;
+	if (statement.source.value !== "node:fs" && statement.source.value !== "node:fs/promises") return false;
+	return statement.specifiers.every((specifier) => {
+		if (!t.isImportSpecifier(specifier)) return false;
+		const name = importedName(specifier);
+		return allowed.has(name) && specifier.local.name === name;
+	});
+}
+
+function isAllowedCommandImport(statement: t.ImportDeclaration): boolean {
+	if (statement.source.value !== "@gajae-code/utils/cli") return false;
+	const allowed = new Set(["Args", "Command", "CommandCtor", "Flags"]);
+	return statement.specifiers.every((specifier) => {
+		if (!t.isImportSpecifier(specifier)) return false;
+		const name = importedName(specifier);
+		return allowed.has(name) && specifier.local.name === name;
+	});
+}
+
+function isAllowedWorkerImport(statement: t.ImportDeclaration): boolean {
+	if (statement.source.value !== "./worktree-scanner") return false;
+	const allowed = new Set(["scanWorktrees", "WorktreeDiagnostic", "WorktreeScannerPlatform", "WorktreeRootError"]);
+	return statement.specifiers.every((specifier) => {
+		if (!t.isImportSpecifier(specifier)) return false;
+		const name = importedName(specifier);
+		return allowed.has(name) && specifier.local.name === name;
+	});
+}
+function exactNamedImports(statement: t.ImportDeclaration, expected: ReadonlySet<string>): boolean {
+	if (statement.specifiers.length !== expected.size) return false;
+	const actual = new Set<string>();
+	for (const specifier of statement.specifiers) {
+		if (!t.isImportSpecifier(specifier)) return false;
+		const name = importedName(specifier);
+		if (specifier.local.name !== name) return false;
+		actual.add(name);
+	}
+	return actual.size === expected.size && [...expected].every((name) => actual.has(name));
+}
+
+function validateImports(ast: t.File, file: string, role: Role, findings: Finding[]): void {
+	if (role === "cli") {
+		const seen = new Set<string>();
+		for (const statement of ast.program.body) {
+			if (t.isExportAllDeclaration(statement) || (t.isExportNamedDeclaration(statement) && statement.source)) {
+				addFinding(findings, file, statement, RULES.unknownBinding, "cli-reexport");
+				continue;
+			}
+			if (!t.isImportDeclaration(statement)) continue;
+			const source = statement.source.value;
+			const expected = CLI_STATIC_IMPORTS[source];
+			const valid = expected !== undefined && !seen.has(source) && exactNamedImports(statement, expected);
+			if (!valid) {
+				const rule = source === "@gajae-code/utils/dirs" ? RULES.dirsBaseline : RULES.forbiddenImport;
+				addFinding(findings, file, statement, rule, source);
+			}
+			seen.add(source);
+		}
+		for (const source of Object.keys(CLI_STATIC_IMPORTS)) {
+			if (!seen.has(source))
+				addFinding(
+					findings,
+					file,
+					ast.program,
+					source === "@gajae-code/utils/dirs" ? RULES.dirsBaseline : RULES.forbiddenImport,
+					`missing:${source}`,
+				);
+		}
+		return;
+	}
+	for (const statement of ast.program.body) {
+		if (t.isExportAllDeclaration(statement) || (t.isExportNamedDeclaration(statement) && statement.source)) {
+			addFinding(findings, file, statement, RULES.unknownBinding, "reexport");
+			continue;
+		}
+		if (!t.isImportDeclaration(statement)) continue;
+		const allowed =
+			role === "scanner"
+				? isAllowedScannerImport(statement)
+				: role === "command"
+					? isAllowedCommandImport(statement)
+					: role === "worker"
+						? isAllowedWorkerImport(statement)
+						: false;
+		if (!allowed) {
+			const rule = statement.source.value.includes("dirs") ? RULES.dirsBaseline : RULES.forbiddenImport;
+			addFinding(findings, file, statement, rule, statement.source.value);
+		}
+	}
+}
+
+function findAuthoritativeRegistryEntry(ast: t.File): t.ObjectExpression[] {
+	const entries: t.ObjectExpression[] = [];
+	for (const statement of ast.program.body) {
+		if (!t.isExportNamedDeclaration(statement) || !t.isVariableDeclaration(statement.declaration)) continue;
+		for (const declaration of statement.declaration.declarations) {
+			if (!t.isIdentifier(declaration.id, { name: "commands" }) || !t.isArrayExpression(declaration.init)) continue;
+			for (const element of declaration.init.elements) {
+				if (!t.isObjectExpression(element)) continue;
+				const name = element.properties.find(
+					(property) =>
+						t.isObjectProperty(property) &&
+						!property.computed &&
+						((t.isIdentifier(property.key) && property.key.name === "name") ||
+							(t.isStringLiteral(property.key) && property.key.value === "name")),
+				);
+				if (t.isObjectProperty(name) && t.isStringLiteral(name.value) && name.value.value === "worktree")
+					entries.push(element);
+			}
+		}
+	}
+	return entries;
+}
+
+function validateRegistry(ast: t.File, file: string, findings: Finding[]): void {
+	const entries = findAuthoritativeRegistryEntry(ast);
+	if (entries.length !== 1) {
+		addFinding(findings, file, ast.program, RULES.registryEdge, `count:${entries.length}`);
+		return;
+	}
+	const entry = entries[0]!;
+	const aliases = entry.properties.find(
+		(property) =>
+			t.isObjectProperty(property) &&
+			!property.computed &&
+			((t.isIdentifier(property.key) && property.key.name === "aliases") ||
+				(t.isStringLiteral(property.key) && property.key.value === "aliases")),
+	);
+	const exactAliases =
+		t.isObjectProperty(aliases) &&
+		t.isArrayExpression(aliases.value) &&
+		aliases.value.elements.length === 1 &&
+		t.isStringLiteral(aliases.value.elements[0], { value: "wt" });
+	const exactEntry = entry.properties.length === 3 && exactAliases;
+	const load = entry.properties.find(
+		(property) =>
+			(t.isObjectProperty(property) || t.isObjectMethod(property)) &&
+			!property.computed &&
+			((t.isIdentifier(property.key) && property.key.name === "load") ||
+				(t.isStringLiteral(property.key) && property.key.value === "load")),
+	);
+	const loadFunction = t.isObjectProperty(load) && t.isArrowFunctionExpression(load.value) ? load.value : undefined;
+	const body = loadFunction?.body;
+	if (
+		!exactEntry ||
+		!loadFunction?.async ||
+		loadFunction.params.length !== 0 ||
+		!t.isBlockStatement(body) ||
+		body.body.length !== 2
+	) {
+		addFinding(findings, file, load ?? entry, RULES.registryEdge, "load-shape");
+		return;
+	}
+	const declaration = body.body[0];
+	const returned = body.body[1];
+	const declarator =
+		t.isVariableDeclaration(declaration) && declaration.kind === "const" && declaration.declarations.length === 1
+			? declaration.declarations[0]
+			: undefined;
+	const awaited = declarator && t.isAwaitExpression(declarator.init) ? declarator.init.argument : undefined;
+	const source = t.isCallExpression(awaited) ? staticImportSource(awaited) : undefined;
+	const selected = declarator?.id;
+	const exactSelection =
+		t.isObjectPattern(selected) &&
+		selected.properties.length === 1 &&
+		t.isObjectProperty(selected.properties[0]) &&
+		!selected.properties[0].computed &&
+		t.isIdentifier(selected.properties[0].key, {
+			name: "createWorktreeCommand",
+		}) &&
+		t.isIdentifier(selected.properties[0].value, {
+			name: "createWorktreeCommand",
+		});
+	const call = t.isReturnStatement(returned) && t.isCallExpression(returned.argument) ? returned.argument : undefined;
+	const exactCall =
+		call &&
+		t.isIdentifier(call.callee, { name: "createWorktreeCommand" }) &&
+		call.arguments.length === 1 &&
+		t.isIdentifier(call.arguments[0], { name: "getWorktreesDir" });
+	if (source !== "./commands/worktree" || !exactSelection || !exactCall) {
+		addFinding(findings, file, load ?? entry, RULES.registryEdge, "load-contract");
+	}
+	let edgeCount = 0;
+	traverse(ast, {
+		CallExpression(pathNode) {
+			if (staticImportSource(pathNode.node) === "./commands/worktree") edgeCount += 1;
+		},
+	});
+	if (edgeCount !== 1) addFinding(findings, file, entry, RULES.dynamicImport, `registry-count:${edgeCount}`);
+}
+
+function namedInitializer(statements: readonly t.Statement[], name: string): t.Expression | null | undefined {
+	for (const statement of statements) {
+		if (!t.isVariableDeclaration(statement) || statement.kind !== "const") continue;
+		for (const declaration of statement.declarations) {
+			if (t.isIdentifier(declaration.id, { name })) return declaration.init;
+		}
+	}
+	return undefined;
+}
+
+function isMemberOf(expression: t.Node | null | undefined, object: string, property: string): boolean {
+	return (
+		t.isMemberExpression(expression) &&
+		t.isIdentifier(expression.object, { name: object }) &&
+		memberName(expression) === property
+	);
+}
+
+function isCoalescedFlag(expression: t.Node | null | undefined, property: string): boolean {
+	return (
+		t.isLogicalExpression(expression, { operator: "??" }) &&
+		isMemberOf(expression.left, "flags", property) &&
+		t.isBooleanLiteral(expression.right, { value: false })
+	);
+}
+
+function isActionSelection(expression: t.Node | null | undefined): boolean {
+	return (
+		t.isConditionalExpression(expression) &&
+		t.isBinaryExpression(expression.test, { operator: "===" }) &&
+		isMemberOf(expression.test.left, "args", "action") &&
+		t.isStringLiteral(expression.test.right, { value: "clear" }) &&
+		t.isStringLiteral(expression.consequent, { value: "clear" }) &&
+		t.isStringLiteral(expression.alternate, { value: "list" })
+	);
+}
+
+function isNegatedIdentifier(expression: t.Node | null | undefined, name: string): boolean {
+	return t.isUnaryExpression(expression, { operator: "!" }) && t.isIdentifier(expression.argument, { name });
+}
+
+function isActionComparison(expression: t.Node | null | undefined, value: string): boolean {
+	return (
+		t.isBinaryExpression(expression, { operator: "===" }) &&
+		t.isIdentifier(expression.left, { name: "action" }) &&
+		t.isStringLiteral(expression.right, { value })
+	);
+}
+function isValidPositionals(expression: t.Node | null | undefined): boolean {
+	return (
+		t.isLogicalExpression(expression, { operator: "&&" }) &&
+		t.isBinaryExpression(expression.left, { operator: "<=" }) &&
+		isMemberOf(expression.left.left, "argv", "length") &&
+		t.isNumericLiteral(expression.left.right, { value: 1 }) &&
+		t.isLogicalExpression(expression.right, { operator: "||" }) &&
+		t.isBinaryExpression(expression.right.left, { operator: "===" }) &&
+		isMemberOf(expression.right.left.left, "argv", "length") &&
+		t.isNumericLiteral(expression.right.left.right, { value: 0 }) &&
+		t.isBinaryExpression(expression.right.right, { operator: "===" }) &&
+		t.isMemberExpression(expression.right.right.left) &&
+		expression.right.right.left.computed &&
+		t.isIdentifier(expression.right.right.left.object, { name: "argv" }) &&
+		t.isNumericLiteral(expression.right.right.left.property, { value: 0 }) &&
+		t.isIdentifier(expression.right.right.right, { name: "action" })
+	);
+}
+
+function isValidSelection(expression: t.Node | null | undefined): boolean {
+	if (!t.isLogicalExpression(expression, { operator: "&&" })) return false;
+	const right = expression.right;
+	return (
+		t.isIdentifier(expression.left, { name: "validPositionals" }) &&
+		t.isLogicalExpression(right, { operator: "||" }) &&
+		t.isLogicalExpression(right.left, { operator: "&&" }) &&
+		isActionComparison(right.left.left, "clear") &&
+		isNegatedIdentifier(right.left.right, "all") &&
+		t.isLogicalExpression(right.right, { operator: "&&" }) &&
+		t.isLogicalExpression(right.right.left, { operator: "&&" }) &&
+		isActionComparison(right.right.left.left, "list") &&
+		isNegatedIdentifier(right.right.left.right, "all") &&
+		isNegatedIdentifier(right.right.right, "dryRun")
+	);
+}
+
+function callUsesBinding(ast: t.File, call: t.CallExpression, identifier: t.Identifier): boolean {
+	let matches = false;
+	traverse(ast, {
+		CallExpression(pathNode) {
+			if (pathNode.node !== call || !t.isIdentifier(pathNode.node.callee)) return;
+			matches = pathNode.scope.getBinding(pathNode.node.callee.name)?.identifier === identifier;
+		},
+	});
+	return matches;
+}
+function bindingReferencedOnlyByCall(ast: t.File, call: t.CallExpression, identifier: t.Identifier): boolean {
+	let matches = false;
+	traverse(ast, {
+		CallExpression(pathNode) {
+			if (pathNode.node !== call || !t.isIdentifier(pathNode.node.callee)) return;
+			const binding = pathNode.scope.getBinding(pathNode.node.callee.name);
+			matches =
+				binding?.identifier === identifier &&
+				binding.referencePaths.length === 1 &&
+				binding.referencePaths[0]?.node === pathNode.node.callee;
+		},
+	});
+	return matches;
+}
+function callUsesUnboundIdentifier(ast: t.File, call: t.CallExpression, name: string): boolean {
+	let unbound = false;
+	traverse(ast, {
+		CallExpression(pathNode) {
+			if (pathNode.node === call) unbound = pathNode.scope.getBinding(name) === undefined;
+		},
+	});
+	return unbound;
+}
+
+function countCallsUsingBinding(ast: t.File, functionNode: t.Function, identifier: t.Identifier): number {
+	let count = 0;
+	traverse(ast, {
+		CallExpression(pathNode) {
+			if (
+				pathNode.getFunctionParent()?.node === functionNode &&
+				t.isIdentifier(pathNode.node.callee) &&
+				pathNode.scope.getBinding(pathNode.node.callee.name)?.identifier === identifier
+			)
+				count++;
+		},
+	});
+	return count;
+}
+function hasBindingAlias(ast: t.File, functionNode: t.Function, identifier: t.Identifier): boolean {
+	let aliased = false;
+	traverse(ast, {
+		VariableDeclarator(pathNode) {
+			if (
+				pathNode.getFunctionParent()?.node === functionNode &&
+				t.isIdentifier(pathNode.node.init) &&
+				pathNode.scope.getBinding(pathNode.node.init.name)?.identifier === identifier
+			)
+				aliased = true;
+		},
+	});
+	return aliased;
+}
+function assignmentTargetContainsName(node: t.Node | null | undefined, names: ReadonlySet<string>): boolean {
+	if (!node) return false;
+	if (t.isIdentifier(node)) return names.has(node.name);
+	if (t.isAssignmentPattern(node)) return assignmentTargetContainsName(node.left, names);
+	if (t.isRestElement(node)) return assignmentTargetContainsName(node.argument, names);
+	if (t.isArrayPattern(node)) return node.elements.some((element) => assignmentTargetContainsName(element, names));
+	if (t.isObjectPattern(node))
+		return node.properties.some((property) =>
+			t.isRestElement(property)
+				? assignmentTargetContainsName(property.argument, names)
+				: assignmentTargetContainsName(property.value, names),
+		);
+	if (t.isVariableDeclaration(node))
+		return node.declarations.some((declaration) => assignmentTargetContainsName(declaration.id, names));
+	if (
+		t.isTSAsExpression(node) ||
+		t.isTSTypeAssertion(node) ||
+		t.isTypeCastExpression(node) ||
+		t.isTSNonNullExpression(node) ||
+		t.isTSSatisfiesExpression(node)
+	)
+		return assignmentTargetContainsName(node.expression, names);
+	return false;
+}
+
+function hasIdentifierMutation(ast: t.File, names: ReadonlySet<string>): boolean {
+	let mutated = false;
+	traverse(ast, {
+		AssignmentExpression(pathNode) {
+			if (assignmentTargetContainsName(pathNode.node.left, names)) mutated = true;
+		},
+		UpdateExpression(pathNode) {
+			if (t.isIdentifier(pathNode.node.argument) && names.has(pathNode.node.argument.name)) mutated = true;
+		},
+		ForOfStatement(pathNode) {
+			if (assignmentTargetContainsName(pathNode.node.left, names)) mutated = true;
+		},
+		ForInStatement(pathNode) {
+			if (assignmentTargetContainsName(pathNode.node.left, names)) mutated = true;
+		},
+	});
+	return mutated;
+}
+
+function validateScannerCapabilityBindings(ast: t.File, file: string, findings: Finding[]): void {
+	let openBinding: Scope["bindings"][string] | undefined;
+	let constantsBinding: Scope["bindings"][string] | undefined;
+	traverse(ast, {
+		ImportSpecifier(pathNode) {
+			const declaration = pathNode.parentPath.node;
+			if (!t.isImportDeclaration(declaration) || declaration.importKind === "type" || pathNode.node.importKind === "type") return;
+			const imported = importedName(pathNode.node);
+			const source = declaration.source.value;
+			if (source === "node:fs/promises" && imported === "open")
+				openBinding = pathNode.scope.getBinding(pathNode.node.local.name);
+			if (source === "node:fs" && imported === "constants")
+				constantsBinding = pathNode.scope.getBinding(pathNode.node.local.name);
+		},
+	});
+	const mutationTarget = (
+		node: t.Node | null | undefined,
+		scope: Scope,
+	): { open: boolean; member: boolean } => {
+		if (!node) return { open: false, member: false };
+		const unwrapped = unwrapTransparentExpression(node);
+		if (unwrapped !== node) return mutationTarget(unwrapped, scope);
+		if (t.isIdentifier(node)) {
+			const binding = scope.getBinding(node.name);
+			const origin = bindingOrigin(scope, node.name);
+			return {
+				open:
+					binding === openBinding ||
+					(origin?.source === "node:fs/promises" && origin.name === "open") ||
+					binding === constantsBinding ||
+					(origin?.source === "node:fs" && origin.name === "constants"),
+				member:
+					origin?.source === "node:fs" &&
+					["O_RDONLY", "O_NOFOLLOW", "O_NONBLOCK"].includes(origin.name),
+			};
+		}
+		if (t.isMemberExpression(node)) {
+			const objectOrigin = scopedExpressionOrigin(node.object, scope);
+			return {
+				open: false,
+				member:
+					objectOrigin?.source === "node:fs" &&
+					objectOrigin.name === "constants" &&
+					["O_RDONLY", "O_NOFOLLOW", "O_NONBLOCK"].includes(memberName(node) ?? ""),
+			};
+		}
+		if (t.isAssignmentPattern(node)) return mutationTarget(node.left, scope);
+		if (t.isRestElement(node)) return mutationTarget(node.argument, scope);
+		if (t.isArrayPattern(node)) {
+			return node.elements.reduce<{ open: boolean; member: boolean }>(
+				(result, element) => {
+					const target = mutationTarget(element, scope);
+					return { open: result.open || target.open, member: result.member || target.member };
+				},
+				{ open: false, member: false },
+			);
+		}
+		if (t.isObjectPattern(node)) {
+			return node.properties.reduce<{ open: boolean; member: boolean }>(
+				(result, property) => {
+					const target = mutationTarget(t.isRestElement(property) ? property.argument : property.value, scope);
+					return { open: result.open || target.open, member: result.member || target.member };
+				},
+				{ open: false, member: false },
+			);
+		}
+		return { open: false, member: false };
+	};
+	traverse(ast, {
+		AssignmentExpression(pathNode) {
+			const target = mutationTarget(pathNode.node.left, pathNode.scope);
+			if (target.open) addFinding(findings, file, pathNode.node, RULES.mutation, "assignment");
+			if (target.member) addFinding(findings, file, pathNode.node, RULES.mutation, "member-assignment");
+		},
+		UpdateExpression(pathNode) {
+			const target = mutationTarget(pathNode.node.argument, pathNode.scope);
+			if (target.open) addFinding(findings, file, pathNode.node, RULES.mutation, "assignment");
+			if (target.member) addFinding(findings, file, pathNode.node, RULES.mutation, "member-assignment");
+		},
+		ForOfStatement(pathNode) {
+			const target = mutationTarget(pathNode.node.left, pathNode.scope);
+			if (target.open) addFinding(findings, file, pathNode.node, RULES.mutation, "assignment");
+			if (target.member) addFinding(findings, file, pathNode.node, RULES.mutation, "member-assignment");
+		},
+		ForInStatement(pathNode) {
+			const target = mutationTarget(pathNode.node.left, pathNode.scope);
+			if (target.open) addFinding(findings, file, pathNode.node, RULES.mutation, "assignment");
+			if (target.member) addFinding(findings, file, pathNode.node, RULES.mutation, "member-assignment");
+		},
+		UnaryExpression(pathNode) {
+			if (pathNode.node.operator !== "delete") return;
+			const target = mutationTarget(pathNode.node.argument, pathNode.scope);
+			if (target.member) addFinding(findings, file, pathNode.node, RULES.mutation, "member-assignment");
+		},
+	});
+}
+function hasTypeReference(annotation: t.Node | null | undefined, name: string): boolean {
+	return (
+		t.isTSTypeAnnotation(annotation) &&
+		t.isTSTypeReference(annotation.typeAnnotation) &&
+		t.isIdentifier(annotation.typeAnnotation.typeName, { name })
+	);
+}
+
+function validateCommandFlow(ast: t.File, file: string, findings: Finding[]): void {
+	let factory: t.FunctionDeclaration | undefined;
+	let factoryParam: t.Identifier | undefined;
+	let factoryCount = 0;
+	for (const statement of ast.program.body) {
+		if (!t.isExportNamedDeclaration(statement) || !t.isFunctionDeclaration(statement.declaration)) continue;
+		const candidate = statement.declaration;
+		if (
+			t.isIdentifier(candidate.id, { name: "createWorktreeCommand" }) &&
+			candidate.params.length === 1 &&
+			t.isIdentifier(candidate.params[0], { name: "getWorktreesDir" })
+		) {
+			factory = candidate;
+			factoryParam = candidate.params[0];
+			factoryCount++;
+		}
+	}
+	const factoryContractOkay =
+		factoryCount === 1 &&
+		!!factory &&
+		!factory.async &&
+		!factory.generator &&
+		factory.body.body.length === 1 &&
+		!!factoryParam &&
+		hasTypeReference(factoryParam.typeAnnotation, "WorktreeRootGetter") &&
+		hasTypeReference(factory.returnType, "CommandCtor");
+	const returned = factory?.body.body.find((statement) => t.isReturnStatement(statement));
+	const commandClass =
+		returned &&
+		t.isReturnStatement(returned) &&
+		t.isClassExpression(returned.argument) &&
+		t.isIdentifier(returned.argument.id, { name: "Worktree" }) &&
+		t.isIdentifier(returned.argument.superClass, { name: "Command" })
+			? returned.argument
+			: undefined;
+	let commandSuperclassBindingOkay = false;
+	if (commandClass) {
+		traverse(ast, {
+			ClassExpression(pathNode) {
+				if (pathNode.node !== commandClass || !t.isIdentifier(commandClass.superClass)) return;
+				const binding = pathNode.scope.getBinding(commandClass.superClass.name);
+				const bindingNode = binding?.path.node;
+				commandSuperclassBindingOkay =
+					t.isImportSpecifier(bindingNode) &&
+					t.isImportDeclaration(binding?.path.parent) &&
+					binding.path.parent.source.value === "@gajae-code/utils/cli" &&
+					importedName(bindingNode) === "Command";
+			},
+		});
+	}
+	const hasComputedAuthority = commandClass?.body.body.some(
+		(member) => (t.isClassMethod(member) || t.isClassProperty(member)) && member.computed,
+	);
+	const hasRunField = commandClass?.body.body.some(
+		(member) =>
+			t.isClassProperty(member) &&
+			((t.isIdentifier(member.key) && member.key.name === "run") ||
+				(t.isStringLiteral(member.key) && member.key.value === "run")),
+	);
+	const runMethods =
+		commandClass?.body.body.filter(
+			(member): member is t.ClassMethod =>
+				t.isClassMethod(member) && !member.computed && t.isIdentifier(member.key, { name: "run" }),
+		) ?? [];
+	const runMethod = runMethods[0];
+	traverse(ast, {
+		ClassMethod(pathNode) {
+			if (pathNode.node === runMethod || pathNode.node.computed || !t.isIdentifier(pathNode.node.key, { name: "run" })) return;
+			addFinding(findings, file, pathNode.node, RULES.getterTiming, "run-count");
+		},
+		CallExpression(pathNode) {
+			if (pathNode.getFunctionParent()) return;
+			if (
+				t.isMemberExpression(pathNode.node.callee) &&
+				t.isIdentifier(pathNode.node.callee.object, { name: "process" }) &&
+				["write"].includes(memberName(pathNode.node.callee) ?? "")
+			)
+				addFinding(findings, file, pathNode.node, RULES.getterTiming, "terminal-sink");
+		},
+	});
+	if (runMethods.length !== 1 || hasComputedAuthority || hasRunField)
+		addFinding(findings, file, commandClass ?? factory ?? ast.program, RULES.getterTiming, "run-count");
+	if (!runMethod) {
+		addFinding(findings, file, factory ?? ast.program, RULES.workerEdge, "missing-run");
+		return;
+	}
+	const statements = runMethod.body.body;
+	if (statements.length !== 14) addFinding(findings, file, runMethod, RULES.getterTiming, "phase-shape");
+	let commandShapeOkay = true;
+	traverse(ast, {
+		ReturnStatement(pathNode) {
+			if (pathNode.getFunctionParent()?.node !== runMethod) return;
+			const guard = statements[7];
+			if (!t.isIfStatement(guard) || pathNode.parentPath?.node !== guard.consequent) commandShapeOkay = false;
+		},
+		UnaryExpression(pathNode) {
+			if (
+				pathNode.getFunctionParent()?.node === runMethod &&
+				pathNode.node.operator === "void" &&
+				t.isMemberExpression(pathNode.node.argument) &&
+				t.isIdentifier(pathNode.node.argument.object, { name: "result" })
+			)
+				commandShapeOkay = false;
+		},
+		ThrowStatement(pathNode) {
+			if (pathNode.getFunctionParent()?.node === runMethod) commandShapeOkay = false;
+		},
+	});
+	const terminalSinks = { stdout: 0, stderr: 0, exitCode: 0 };
+	traverse(ast, {
+		CallExpression(pathNode) {
+			if (pathNode.getFunctionParent()?.node !== runMethod || !t.isMemberExpression(pathNode.node.callee)) return;
+			const object = pathNode.node.callee.object;
+			const member = memberName(pathNode.node.callee);
+			if (t.isMemberExpression(object) && t.isIdentifier(object.object, { name: "process" })) {
+				if (member === "write" && t.isIdentifier(object.property)) terminalSinks[object.property.name as "stdout" | "stderr"]++;
+			}
+		},
+		AssignmentExpression(pathNode) {
+			if (pathNode.getFunctionParent()?.node !== runMethod || !t.isMemberExpression(pathNode.node.left)) return;
+			const member = memberName(pathNode.node.left);
+			if (t.isIdentifier(pathNode.node.left.object, { name: "process" }) && member === "exitCode") terminalSinks.exitCode++;
+		},
+	});
+	if (terminalSinks.stdout !== 2 || terminalSinks.stderr !== 2 || terminalSinks.exitCode !== 2)
+		commandShapeOkay = false;
+	if (!commandShapeOkay) addFinding(findings, file, runMethod, RULES.getterTiming, "phase-shape");
+	const indexOf = (predicate: (statement: t.Statement) => boolean) => statements.findIndex(predicate);
+	let parseCall: t.CallExpression | undefined;
+	const parseIndex = indexOf((statement) => {
+		if (!t.isVariableDeclaration(statement) || statement.kind !== "const" || statement.declarations.length !== 1)
+			return false;
+		const declaration = statement.declarations[0];
+		if (
+			!t.isObjectPattern(declaration?.id) ||
+			declaration.id.properties.length !== 3 ||
+			!t.isAwaitExpression(declaration.init) ||
+			!t.isCallExpression(declaration.init.argument)
+		)
+			return false;
+		const names = declaration.id.properties.map((property) =>
+			t.isObjectProperty(property) &&
+			t.isIdentifier(property.key) &&
+			t.isIdentifier(property.value, { name: property.key.name })
+				? property.key.name
+				: "",
+		);
+		if (names.length !== 3 || !["args", "flags", "argv"].every((name) => names.includes(name))) return false;
+		const call = declaration.init.argument;
+		if (
+			!t.isMemberExpression(call.callee) ||
+			!t.isThisExpression(call.callee.object) ||
+			memberName(call.callee) !== "parse" ||
+			call.arguments.length !== 1 ||
+			!t.isIdentifier(call.arguments[0], { name: "Worktree" })
+		)
+			return false;
+		parseCall = call;
+		return true;
+	});
+	const positionalsIndex = indexOf(
+		(statement) =>
+			t.isVariableDeclaration(statement) &&
+			statement.kind === "const" &&
+			statement.declarations.length === 1 &&
+			t.isIdentifier(statement.declarations[0].id, { name: "validPositionals" }) &&
+			isValidPositionals(statement.declarations[0].init),
+	);
+	const validIndex = indexOf(
+		(statement) =>
+			t.isVariableDeclaration(statement) &&
+			statement.kind === "const" &&
+			statement.declarations.some(
+				(declaration) => t.isIdentifier(declaration.id, { name: "valid" }) && isValidSelection(declaration.init),
+			),
+	);
+	const guardIndex = indexOf(
+		(statement) =>
+			t.isIfStatement(statement) &&
+			t.isUnaryExpression(statement.test, { operator: "!" }) &&
+			t.isIdentifier(statement.test.argument, { name: "valid" }) &&
+			t.isBlockStatement(statement.consequent) &&
+			statement.alternate === null &&
+			t.isReturnStatement(statement.consequent.body.at(-1)),
+	);
+	let getterCall: t.CallExpression | undefined;
+	const getterIndex = indexOf(
+		(statement) =>
+			t.isVariableDeclaration(statement) &&
+			statement.kind === "const" &&
+			statement.declarations.some((declaration) => {
+				if (
+					!t.isIdentifier(declaration.id, { name: "root" }) ||
+					!t.isCallExpression(declaration.init) ||
+					!t.isIdentifier(declaration.init.callee, { name: "getWorktreesDir" }) ||
+					declaration.init.arguments.length !== 0
+				)
+					return false;
+				getterCall = declaration.init;
+				return true;
+			}),
+	);
+	const parsedValuesOkay =
+		isActionSelection(namedInitializer(statements, "action")) &&
+		isCoalescedFlag(namedInitializer(statements, "all"), "all") &&
+		isCoalescedFlag(namedInitializer(statements, "dryRun"), "dry-run") &&
+		isCoalescedFlag(namedInitializer(statements, "json"), "json");
+	let workerName: string | undefined;
+	const importIndex = indexOf((statement) => {
+		if (!t.isVariableDeclaration(statement) || statement.kind !== "const") return false;
+		return statement.declarations.some((declaration) => {
+			const init = declaration.init;
+			if (
+				!t.isAwaitExpression(init) ||
+				!t.isCallExpression(init.argument) ||
+				staticImportSource(init.argument) !== "../cli/worktree-cli" ||
+				!t.isObjectPattern(declaration.id)
+			)
+				return false;
+			const property = declaration.id.properties.find(
+				(item) =>
+					t.isObjectProperty(item) &&
+					!item.computed &&
+					t.isIdentifier(item.key, { name: "runWorktreeCommand" }) &&
+					t.isIdentifier(item.value, { name: "runWorktreeCommand" }),
+			);
+			if (declaration.id.properties.length !== 1) return false;
+			if (t.isObjectProperty(property) && t.isIdentifier(property.value)) {
+				workerName = property.value.name;
+				return true;
+			}
+			return false;
+		});
+	});
+	let resultIdentifier: t.Identifier | undefined;
+	const callIndex = indexOf(
+		(statement) =>
+			t.isVariableDeclaration(statement) &&
+			statement.kind === "const" &&
+			statement.declarations.some((declaration) => {
+				const init = t.isAwaitExpression(declaration.init) ? declaration.init.argument : declaration.init;
+				if (
+					!workerName ||
+					!t.isIdentifier(declaration.id, { name: "result" }) ||
+					!t.isCallExpression(init) ||
+					!t.isIdentifier(init.callee, { name: workerName }) ||
+					init.arguments.length !== 1 ||
+					!t.isObjectExpression(init.arguments[0])
+				)
+					return false;
+				resultIdentifier = declaration.id;
+				const properties = new Map<string, t.ObjectProperty>();
+				for (const property of init.arguments[0].properties) {
+					if (!t.isObjectProperty(property) || property.computed || !t.isIdentifier(property.key)) return false;
+					if (properties.has(property.key.name)) return false;
+					properties.set(property.key.name, property);
+				}
+				const required = ["root", "platform", "action", "json", "dryRun"];
+				if (properties.size !== required.length || required.some((name) => !properties.has(name))) return false;
+				const value = (name: string) => properties.get(name)!.value;
+				const platform = value("platform");
+				const platformOkay =
+					t.isConditionalExpression(platform) &&
+					t.isBinaryExpression(platform.test, { operator: "===" }) &&
+					t.isMemberExpression(platform.test.left) &&
+					t.isIdentifier(platform.test.left.object, { name: "process" }) &&
+					memberName(platform.test.left) === "platform" &&
+					t.isStringLiteral(platform.test.right, { value: "win32" }) &&
+					t.isStringLiteral(platform.consequent, { value: "win32" }) &&
+					t.isStringLiteral(platform.alternate, { value: "posix" });
+				return (
+					t.isIdentifier(value("root"), { name: "root" }) &&
+					t.isIdentifier(value("action"), { name: "action" }) &&
+					t.isIdentifier(value("json"), { name: "json" }) &&
+					t.isIdentifier(value("dryRun"), { name: "dryRun" }) &&
+					platformOkay
+				);
+			}),
+	);
+	let workerCall: t.CallExpression | undefined;
+	for (const statement of statements) {
+		if (!t.isVariableDeclaration(statement)) continue;
+		for (const declaration of statement.declarations) {
+			const init = t.isAwaitExpression(declaration.init) ? declaration.init.argument : declaration.init;
+			if (t.isCallExpression(init) && workerName && t.isIdentifier(init.callee, { name: workerName }))
+				workerCall = init;
+		}
+	}
+	const shadowed =
+		workerName &&
+		statements.some((statement) => {
+			if (t.isFunctionDeclaration(statement) && t.isIdentifier(statement.id, { name: workerName })) return true;
+			if (
+				t.isVariableDeclaration(statement) &&
+				statement.declarations.some((declaration) => t.isIdentifier(declaration.id, { name: workerName }))
+			)
+				return true;
+			return (
+				t.isExpressionStatement(statement) &&
+				t.isAssignmentExpression(statement.expression) &&
+				t.isIdentifier(statement.expression.left, { name: workerName })
+			);
+		});
+	const getterBindingOkay =
+		!!getterCall &&
+		!!factoryParam &&
+		callUsesBinding(ast, getterCall, factoryParam) &&
+		bindingReferencedOnlyByCall(ast, getterCall, factoryParam);
+	let workerBindingOkay = false;
+	let workerIdentifier: t.Identifier | undefined;
+	if (workerCall && workerName) {
+		const importStatement = statements[importIndex];
+		const declaration = t.isVariableDeclaration(importStatement) ? importStatement.declarations[0] : undefined;
+		const property = t.isObjectPattern(declaration?.id) ? declaration.id.properties[0] : undefined;
+		if (t.isObjectProperty(property) && t.isIdentifier(property.value)) {
+			workerIdentifier = property.value;
+			workerBindingOkay = callUsesBinding(ast, workerCall, property.value);
+		}
+	}
+	const workerCallCount = workerIdentifier ? countCallsUsingBinding(ast, runMethod, workerIdentifier) : 0;
+	const workerAliased = workerIdentifier ? hasBindingAlias(ast, runMethod, workerIdentifier) : false;
+	const globalProcessOkay = !!workerCall && callUsesUnboundIdentifier(ast, workerCall, "process");
+	const workerReferencesOkay =
+		!!workerCall && !!workerIdentifier && bindingReferencedOnlyByCall(ast, workerCall, workerIdentifier);
+	const frozenArguments = !hasIdentifierMutation(
+		ast,
+		new Set([
+			"action",
+			"all",
+			"createWorktreeCommand",
+			"dryRun",
+			"getWorktreesDir",
+			"json",
+			"process",
+			"root",
+			"runWorktreeCommand",
+			"valid",
+			"argv",
+			"validPositionals",
+		]),
+	);
+	let parseCalls = 0;
+	traverse(ast, {
+		CallExpression(pathNode) {
+			if (
+				pathNode.getFunctionParent()?.node === runMethod &&
+				t.isMemberExpression(pathNode.node.callee) &&
+				t.isThisExpression(pathNode.node.callee.object) &&
+				memberName(pathNode.node.callee) === "parse"
+			)
+				parseCalls++;
+		},
+	});
+	let resultRendered = false;
+	if (resultIdentifier) {
+		traverse(ast, {
+			MemberExpression(pathNode) {
+				if (
+					t.isIdentifier(pathNode.node.object, { name: resultIdentifier!.name }) &&
+					pathNode.scope.getBinding(resultIdentifier!.name)?.identifier === resultIdentifier &&
+					["stdout", "stderr", "exitCode"].includes(memberName(pathNode.node) ?? "")
+				)
+					resultRendered = true;
+			},
+		});
+	}
+	const noEarlyTerminal =
+		parseIndex < 0 ||
+		statements
+			.slice(0, parseIndex)
+			.every((statement) => !t.isReturnStatement(statement) && !t.isThrowStatement(statement));
+	const ordered =
+		parseCalls === 1 &&
+		factoryContractOkay &&
+		commandSuperclassBindingOkay &&
+		!!factoryParam &&
+		!!parseCall &&
+		parsedValuesOkay &&
+		parseIndex === 0 &&
+		noEarlyTerminal &&
+		positionalsIndex === 5 &&
+		validIndex === 6 &&
+		guardIndex === 7 &&
+		getterIndex === 8 &&
+		importIndex === 9 &&
+		callIndex === 10 &&
+		statements.length === 14 &&
+		getterBindingOkay &&
+		workerBindingOkay &&
+		workerCallCount === 1 &&
+		!workerAliased &&
+		resultRendered &&
+		globalProcessOkay &&
+		workerReferencesOkay &&
+		frozenArguments &&
+		!shadowed;
+	if (!ordered) addFinding(findings, file, runMethod, RULES.getterTiming, "parse-valid-getter-import-call");
+	let getterCalls = 0;
+	let workerImports = 0;
+	traverse(ast, {
+		CallExpression(pathNode) {
+			if (t.isIdentifier(pathNode.node.callee, { name: "getWorktreesDir" })) getterCalls += 1;
+			if (staticImportSource(pathNode.node) === "../cli/worktree-cli") workerImports += 1;
+		},
+	});
+	if (getterCalls !== 1) addFinding(findings, file, runMethod, RULES.getterTiming, `getter-count:${getterCalls}`);
+	if (workerImports !== 1) addFinding(findings, file, runMethod, RULES.workerEdge, `count:${workerImports}`);
+}
+function workerOptionMember(
+	node: t.Node | null | undefined,
+	property: "root" | "platform",
+	scope: Scope,
+	optionsParameter: t.Identifier,
+): boolean {
+	return (
+		t.isMemberExpression(node) &&
+		!node.computed &&
+		t.isIdentifier(node.object, { name: optionsParameter.name }) &&
+		scope.getBinding(node.object.name)?.identifier === optionsParameter &&
+		t.isIdentifier(node.property, { name: property })
+	);
+}
+
+function containsIdentifier(node: t.Node | null | undefined, names: ReadonlySet<string>): boolean {
+	if (!node) return false;
+	if (t.isIdentifier(node) && names.has(node.name)) return true;
+	for (const key of t.VISITOR_KEYS[node.type] ?? []) {
+		const value = (node as unknown as Record<string, unknown>)[key];
+		if (Array.isArray(value) && value.some((item) => containsIdentifier(childNode(item), names))) return true;
+		if (!Array.isArray(value) && containsIdentifier(childNode(value), names)) return true;
+	}
+	return false;
+}
+function validateWorkerFlow(ast: t.File, file: string, findings: Finding[]): void {
+	const exportedRun = ast.program.body.find(
+		(statement) =>
+			t.isExportNamedDeclaration(statement) &&
+			t.isFunctionDeclaration(statement.declaration) &&
+			t.isIdentifier(statement.declaration.id, { name: "runWorktreeCommand" }),
+	);
+	const authoritativeRun =
+		exportedRun && t.isExportNamedDeclaration(exportedRun) && t.isFunctionDeclaration(exportedRun.declaration)
+			? exportedRun.declaration
+			: undefined;
+	if (!authoritativeRun) {
+		addFinding(findings, file, ast.program, RULES.scannerApi, "worker-scan-contract");
+		return;
+	}
+	const optionsParameter =
+		authoritativeRun.params.length === 1 && t.isIdentifier(authoritativeRun.params[0])
+			? authoritativeRun.params[0]
+			: undefined;
+	if (!optionsParameter) {
+		addFinding(findings, file, authoritativeRun, RULES.scannerApi, "worker-scan-contract");
+		return;
+	}
+	const bodyStatements = authoritativeRun.body.body;
+	const tryStatement = bodyStatements[1];
+	const returnKeys = new Set(["stdout", "stderr", "exitCode"]);
+	const diagnosticsDeclaration = bodyStatements[0];
+	const diagnosticsIdentity =
+		t.isVariableDeclaration(diagnosticsDeclaration) &&
+		diagnosticsDeclaration.declarations.length === 1 &&
+		t.isIdentifier(diagnosticsDeclaration.declarations[0]?.id, { name: "diagnostics" })
+			? diagnosticsDeclaration.declarations[0].id
+			: undefined;
+	const scanErrorDeclaration = ast.program.body
+		.flatMap(statement => t.isVariableDeclaration(statement) ? statement.declarations : [])
+		.find(declaration => t.isIdentifier(declaration.id, { name: "SCAN_ERROR_TEXT" }));
+	const scanErrorIdentity =
+		scanErrorDeclaration && t.isIdentifier(scanErrorDeclaration.id)
+			? scanErrorDeclaration.id
+			: undefined;
+	const formatDeclaration = ast.program.body
+		.map(statement => t.isFunctionDeclaration(statement) ? statement : undefined)
+		.find(declaration => declaration?.id?.name === "formatDiagnostic");
+	const formatIdentity =
+		formatDeclaration && t.isIdentifier(formatDeclaration.id)
+			? formatDeclaration.id
+			: undefined;
+	const rootErrorSpecifier = ast.program.body
+		.filter((statement): statement is t.ImportDeclaration =>
+			t.isImportDeclaration(statement) && statement.source.value === "./worktree-scanner",
+		)
+		.flatMap(statement => statement.specifiers)
+		.find(
+			(specifier): specifier is t.ImportSpecifier =>
+				t.isImportSpecifier(specifier) &&
+				(t.isIdentifier(specifier.imported)
+					? specifier.imported.name === "WorktreeRootError"
+					: specifier.imported.value === "WorktreeRootError"),
+		);
+	const rootErrorIdentity = rootErrorSpecifier?.local;
+	const exactIdentifier = (
+		node: t.Node | null | undefined,
+		name: string,
+		identity: t.Identifier | undefined,
+	): boolean =>
+		t.isIdentifier(node, { name }) &&
+		identity !== undefined &&
+		(node === identity || BINDING_IDENTITIES.get(node) === identity);
+	const exactOptionsMember = (
+		node: t.Node | null | undefined,
+		property: "action" | "json" | "dryRun",
+	): boolean =>
+		t.isMemberExpression(node) &&
+		!node.computed &&
+		exactIdentifier(node.object, optionsParameter.name, optionsParameter) &&
+		memberName(node) === property;
+	const scanErrorDefinitionOkay =
+		scanErrorDeclaration?.init !== null &&
+		t.isStringLiteral(scanErrorDeclaration?.init, { value: "managed worktree root cannot be read" });
+	const formatDefinitionOkay = (() => {
+		if (
+			!formatDeclaration ||
+			formatDeclaration.async ||
+			formatDeclaration.generator ||
+			formatDeclaration.params.length !== 1 ||
+			!t.isIdentifier(formatDeclaration.params[0]) ||
+			formatDeclaration.body.body.length !== 1
+		)
+			return false;
+		const returned = formatDeclaration.body.body[0];
+		if (!t.isReturnStatement(returned) || !t.isTemplateLiteral(returned.argument)) return false;
+		const template = returned.argument;
+		const parameter = formatDeclaration.params[0];
+		const member = (node: t.Expression | t.TSType, property: "path" | "message"): boolean =>
+			t.isMemberExpression(node) &&
+			!node.computed &&
+			exactIdentifier(node.object, parameter.name, parameter) &&
+			memberName(node) === property;
+		return (
+			template.quasis.length === 3 &&
+			template.expressions.length === 2 &&
+			(template.quasis[0]?.value.cooked ?? "") === "diagnostic  " &&
+			(template.quasis[1]?.value.cooked ?? "") === "  " &&
+			(template.quasis[2]?.value.cooked ?? "") === "" &&
+			member(template.expressions[0]!, "path") &&
+			member(template.expressions[1]!, "message")
+		);
+	})();
+	const isJsonCall = (node: t.Node | null | undefined, argument: t.Node | null | undefined): boolean =>
+		t.isCallExpression(node) &&
+		t.isMemberExpression(node.callee) &&
+		!node.callee.computed &&
+		t.isIdentifier(node.callee.object, { name: "JSON" }) &&
+		BINDING_IDENTITIES.get(node.callee.object) === undefined &&
+		memberName(node.callee) === "stringify" &&
+		node.arguments.length === 1 &&
+		node.arguments[0] === argument;
+	const isDiagnosticsLength = (node: t.Node | null | undefined): boolean =>
+		t.isMemberExpression(node) &&
+		!node.computed &&
+		exactIdentifier(node.object, "diagnostics", diagnosticsIdentity) &&
+		memberName(node) === "length";
+	const isDiagnosticsLengthOrZero = (node: t.Node | null | undefined): boolean =>
+		t.isNumericLiteral(node, { value: 0 }) || isDiagnosticsLength(node);
+	const isExactJsonValue = (node: t.Node | null | undefined): boolean => {
+		if (t.isConditionalExpression(node)) {
+			return (
+				exactOptionsMember(node.test, "dryRun") &&
+				isExactJsonValue(node.consequent) &&
+				isExactJsonValue(node.alternate)
+			);
+		}
+		if (exactIdentifier(node, "diagnostics", diagnosticsIdentity)) return true;
+		if (!t.isObjectExpression(node)) return false;
+		const fields = new Map(
+			node.properties.flatMap((item) =>
+				t.isObjectProperty(item) && !item.computed && t.isIdentifier(item.key) ? [[item.key.name, item.value] as const] : [],
+			),
+		);
+		if (fields.size !== node.properties.length) return false;
+		if (fields.size === 1 && fields.has("wouldRemove")) {
+			const wouldRemove = fields.get("wouldRemove");
+			return t.isArrayExpression(wouldRemove) && wouldRemove.elements.length === 0;
+		}
+		if (fields.size === 2 && fields.has("removed") && fields.has("kept")) {
+			return t.isNumericLiteral(fields.get("removed"), { value: 0 }) && isDiagnosticsLengthOrZero(fields.get("kept"));
+		}
+		if (fields.size === 1 && fields.has("kept")) return isDiagnosticsLength(fields.get("kept"));
+		if (fields.size === 1 && fields.has("removed")) return t.isNumericLiteral(fields.get("removed"), { value: 0 });
+		if (fields.size !== 1 || !fields.has("error")) return false;
+		const errorObject = fields.get("error");
+		if (!t.isObjectExpression(errorObject)) return false;
+		const errorFields = new Map(
+			errorObject.properties.flatMap((item) =>
+				t.isObjectProperty(item) && !item.computed && t.isIdentifier(item.key) ? [[item.key.name, item.value] as const] : [],
+			),
+		);
+		return errorFields.size === 2 && t.isStringLiteral(errorFields.get("code"), { value: "worktree_scan_failed" }) && exactIdentifier(errorFields.get("message"), "SCAN_ERROR_TEXT", scanErrorIdentity);
+	};
+	const isDiagnosticMapJoin = (node: t.Node | null | undefined): boolean => {
+		if (!t.isCallExpression(node) || !t.isMemberExpression(node.callee) || node.callee.computed || memberName(node.callee) !== "join") return false;
+		if (node.arguments.length !== 1 || !t.isStringLiteral(node.arguments[0], { value: "\n" })) return false;
+		const map = node.callee.object;
+		return (
+			t.isCallExpression(map) &&
+			t.isMemberExpression(map.callee) &&
+			!map.callee.computed &&
+			memberName(map.callee) === "map" &&
+			exactIdentifier(map.callee.object, "diagnostics", diagnosticsIdentity) &&
+			map.arguments.length === 1 &&
+			exactIdentifier(map.arguments[0], "formatDiagnostic", formatIdentity)
+		);
+	};
+	const isKeptMapJoin = (node: t.Node | null | undefined): boolean => {
+		if (!t.isCallExpression(node) || !t.isMemberExpression(node.callee) || node.callee.computed || memberName(node.callee) !== "join") return false;
+		if (node.arguments.length !== 1 || !t.isStringLiteral(node.arguments[0], { value: "\n" })) return false;
+		const map = node.callee.object;
+		if (!t.isCallExpression(map) || !t.isMemberExpression(map.callee) || map.callee.computed || memberName(map.callee) !== "map") return false;
+		const callback = map.arguments[0];
+		if (!exactIdentifier(map.callee.object, "diagnostics", diagnosticsIdentity) || map.arguments.length !== 1 || !t.isArrowFunctionExpression(callback) || callback.params.length !== 1 || !t.isIdentifier(callback.params[0])) return false;
+		return (
+			t.isTemplateLiteral(callback.body) &&
+			callback.body.quasis.length === 2 &&
+			(callback.body.quasis[0]?.value.cooked ?? "") === "kept    " &&
+			(callback.body.quasis[1]?.value.cooked ?? "") === "" &&
+			callback.body.expressions.length === 1 &&
+			t.isMemberExpression(callback.body.expressions[0]) &&
+			!callback.body.expressions[0].computed &&
+			t.isIdentifier(callback.body.expressions[0].object, { name: callback.params[0].name }) &&
+			memberName(callback.body.expressions[0]) === "path"
+		);
+	};
+	const isApprovedTemplate = (node: t.TemplateLiteral, key: string): boolean => {
+		const quasis = node.quasis.map((quasi) => quasi.value.cooked ?? "");
+		const expression = node.expressions[0];
+		if (key === "stdout" && quasis.length === 2 && node.expressions.length === 1 && quasis[0] === "" && quasis[1] === "\n") {
+			const argument = t.isCallExpression(expression) ? expression.arguments[0] : undefined;
+			return isJsonCall(expression, argument) && isExactJsonValue(argument);
+		}
+		if (key === "stderr" && quasis.length === 2 && node.expressions.length === 1 && quasis[0] === "error: " && quasis[1] === "\n" && exactIdentifier(expression, "SCAN_ERROR_TEXT", scanErrorIdentity)) return true;
+		if (key === "stdout" && quasis.length === 3 && node.expressions.length === 2 && quasis[0] === "" && quasis[1] === "\n\n" && quasis[2] === " total\n")
+			return isDiagnosticMapJoin(expression) && isDiagnosticsLength(node.expressions[1]);
+		if (key === "stdout" && quasis.length === 3 && node.expressions.length === 2 && quasis[0] === "" && quasis[1] === "\n\n0 removed · " && quasis[2] === " kept\n")
+			return isKeptMapJoin(expression) && isDiagnosticsLength(node.expressions[1]);
+		return false;
+	};
+	const jsonTemplatePayload = (node: t.Node | null | undefined): t.Node | undefined => {
+		if (!t.isTemplateLiteral(node) || node.quasis.length !== 2 || node.expressions.length !== 1) return undefined;
+		if ((node.quasis[0]?.value.cooked ?? "") !== "" || (node.quasis[1]?.value.cooked ?? "") !== "\n")
+			return undefined;
+		const expression = node.expressions[0];
+		if (!t.isCallExpression(expression)) return undefined;
+		const argument = expression.arguments[0];
+		return isJsonCall(expression, argument) ? childNode(argument) : undefined;
+	};
+	const isErrorJsonValue = (node: t.Node | null | undefined): boolean => {
+		if (!t.isObjectExpression(node) || node.properties.length !== 1) return false;
+		const errorProperty = node.properties[0];
+		if (!t.isObjectProperty(errorProperty) || errorProperty.computed || !t.isIdentifier(errorProperty.key, { name: "error" }))
+			return false;
+		const error = errorProperty.value;
+		if (!t.isObjectExpression(error) || error.properties.length !== 2) return false;
+		const fields = new Map<string, t.Node>();
+		for (const property of error.properties) {
+			if (!t.isObjectProperty(property) || property.computed || !t.isIdentifier(property.key)) return false;
+			fields.set(property.key.name, property.value);
+		}
+		return (
+			t.isStringLiteral(fields.get("code"), { value: "worktree_scan_failed" }) &&
+			exactIdentifier(fields.get("message"), "SCAN_ERROR_TEXT", scanErrorIdentity)
+		);
+	};
+	const isErrorStdout = (node: t.Node): boolean => isErrorJsonValue(jsonTemplatePayload(node));
+	const isErrorStderr = (node: t.Node): boolean =>
+		t.isTemplateLiteral(node) && isApprovedTemplate(node, "stderr");
+	const isSuccessStdout = (node: t.Node): boolean =>
+		(t.isStringLiteral(node) &&
+			(node.value === "No agent-managed worktrees found.\n" ||
+				node.value === "No worktrees are eligible for removal; cleanup is report-only.\n")) ||
+		(t.isTemplateLiteral(node) &&
+			isApprovedTemplate(node, "stdout") &&
+			!isErrorJsonValue(jsonTemplatePayload(node)));
+	const validReturnObject = (
+		node: t.Node | null | undefined,
+		expected: "error" | "success",
+	): boolean => {
+		if (t.isConditionalExpression(node))
+			return (
+				expected === "error" &&
+				exactOptionsMember(node.test, "json") &&
+				validReturnObject(node.consequent, expected) &&
+				validReturnObject(node.alternate, expected)
+			);
+		if (!t.isObjectExpression(node) || node.properties.length !== 3) return false;
+		const properties = new Map<string, t.ObjectProperty>();
+		for (const property of node.properties) {
+			if (!t.isObjectProperty(property) || property.computed || !t.isIdentifier(property.key) || properties.has(property.key.name)) return false;
+			properties.set(property.key.name, property);
+		}
+		if (properties.size !== returnKeys.size || [...returnKeys].some(key => !properties.has(key))) return false;
+		const stdout = properties.get("stdout")!.value;
+		const stderr = properties.get("stderr")!.value;
+		const exitCode = properties.get("exitCode")!.value;
+		if (expected === "error") {
+			if (!t.isNumericLiteral(exitCode, { value: 1 })) return false;
+			return (
+				(isErrorStdout(stdout) && t.isStringLiteral(stderr, { value: "" })) ||
+				(t.isStringLiteral(stdout, { value: "" }) && isErrorStderr(stderr))
+			);
+		}
+		return (
+			t.isNumericLiteral(exitCode, { value: 0 }) &&
+			t.isStringLiteral(stderr, { value: "" }) &&
+			isSuccessStdout(stdout)
+		);
+	};
+	const singleReturn = (statement: t.Statement | null | undefined): t.ReturnStatement | undefined => {
+		if (t.isReturnStatement(statement)) return statement;
+		if (t.isBlockStatement(statement) && statement.body.length === 1 && t.isReturnStatement(statement.body[0]))
+			return statement.body[0];
+		return undefined;
+	};
+	const objectFields = (node: t.Node | null | undefined): Map<string, t.Node> | undefined => {
+		if (!t.isObjectExpression(node)) return undefined;
+		const fields = new Map<string, t.Node>();
+		for (const property of node.properties) {
+			if (!t.isObjectProperty(property) || property.computed || !t.isIdentifier(property.key) || fields.has(property.key.name))
+				return undefined;
+			fields.set(property.key.name, property.value);
+		}
+		return fields.size === node.properties.length ? fields : undefined;
+	};
+	const returnStdout = (statement: t.Statement | null | undefined): t.Node | undefined => {
+		const returned = singleReturn(statement);
+		if (!returned || !validReturnObject(returned.argument, "success")) return undefined;
+		return objectFields(returned.argument)?.get("stdout");
+	};
+	const jsonStdoutPayload = (statement: t.Statement | null | undefined): t.Node | undefined => {
+		const stdout = returnStdout(statement);
+		return jsonTemplatePayload(stdout);
+	};
+	const isWouldRemoveValue = (node: t.Node | null | undefined): boolean => {
+		const fields = objectFields(node);
+		const wouldRemove = fields?.get("wouldRemove");
+		return fields?.size === 1 && t.isArrayExpression(wouldRemove) && wouldRemove.elements.length === 0;
+	};
+	const isRemovedKeptValue = (
+		node: t.Node | null | undefined,
+		kept: (value: t.Node | undefined) => boolean,
+	): boolean => {
+		const fields = objectFields(node);
+		return (
+			fields?.size === 2 &&
+			t.isNumericLiteral(fields.get("removed"), { value: 0 }) &&
+			kept(fields.get("kept"))
+		);
+	};
+	const isExactIf = (
+		statement: t.Statement | undefined,
+		test: (node: t.Expression) => boolean,
+	): statement is t.IfStatement =>
+		t.isIfStatement(statement) && statement.alternate === null && test(statement.test);
+	const isDiagnosticsZero = (node: t.Node): boolean =>
+		t.isBinaryExpression(node, { operator: "===" }) &&
+		isDiagnosticsLength(node.left) &&
+		t.isNumericLiteral(node.right, { value: 0 });
+	const listStatement = bodyStatements[2];
+	const clearStatement = bodyStatements[3];
+	const jsonStatement = bodyStatements[4];
+	const finalStatement = bodyStatements[5];
+	const listBlock =
+		isExactIf(
+			listStatement,
+			test =>
+				t.isBinaryExpression(test, { operator: "===" }) &&
+				exactOptionsMember(test.left, "action") &&
+				t.isStringLiteral(test.right, { value: "list" }),
+		) && t.isBlockStatement(listStatement.consequent)
+			? listStatement.consequent.body
+			: undefined;
+	const clearBlock =
+		isExactIf(
+			clearStatement,
+			test =>
+				t.isLogicalExpression(test, { operator: "||" }) &&
+				exactOptionsMember(test.left, "dryRun") &&
+				isDiagnosticsZero(test.right),
+		) && t.isBlockStatement(clearStatement.consequent)
+			? clearStatement.consequent.body
+			: undefined;
+	const jsonBlock =
+		isExactIf(jsonStatement, test => exactOptionsMember(test, "json")) &&
+		t.isBlockStatement(jsonStatement.consequent)
+			? jsonStatement.consequent.body
+			: undefined;
+	const listJsonReturn =
+		listBlock &&
+		isExactIf(listBlock[0], test => exactOptionsMember(test, "json"))
+			? singleReturn(listBlock[0].consequent)
+			: undefined;
+	const listEmptyReturn =
+		listBlock && isExactIf(listBlock[1], isDiagnosticsZero)
+			? singleReturn(listBlock[1].consequent)
+			: undefined;
+	const clearJsonReturn =
+		clearBlock && isExactIf(clearBlock[0], test => exactOptionsMember(test, "json"))
+			? singleReturn(clearBlock[0].consequent)
+			: undefined;
+	const clearPayload = jsonStdoutPayload(clearJsonReturn);
+	const branchShapeOkay =
+		listBlock?.length === 3 &&
+		clearBlock?.length === 2 &&
+		jsonBlock?.length === 1 &&
+		exactIdentifier(jsonStdoutPayload(listJsonReturn), "diagnostics", diagnosticsIdentity) &&
+		t.isStringLiteral(returnStdout(listEmptyReturn), { value: "No agent-managed worktrees found.\n" }) &&
+		t.isTemplateLiteral(returnStdout(listBlock[2])) &&
+		(returnStdout(listBlock[2]) as t.TemplateLiteral).quasis[1]?.value.cooked === "\n\n" &&
+		t.isConditionalExpression(clearPayload) &&
+		exactOptionsMember(clearPayload.test, "dryRun") &&
+		isWouldRemoveValue(clearPayload.consequent) &&
+		isRemovedKeptValue(clearPayload.alternate, value => t.isNumericLiteral(value, { value: 0 })) &&
+		t.isStringLiteral(returnStdout(clearBlock[1]), {
+			value: "No worktrees are eligible for removal; cleanup is report-only.\n",
+		}) &&
+		isRemovedKeptValue(jsonStdoutPayload(jsonBlock[0]), value => isDiagnosticsLength(value)) &&
+		t.isTemplateLiteral(returnStdout(finalStatement)) &&
+		(returnStdout(finalStatement) as t.TemplateLiteral).quasis[1]?.value.cooked === "\n\n0 removed · ";
+	let invalidReturn = false;
+	traverse(ast, {
+		ReturnStatement(pathNode) {
+			if (pathNode.getFunctionParent()?.node !== authoritativeRun) return;
+			const inHandler =
+				tryStatement &&
+				t.isTryStatement(tryStatement) &&
+				tryStatement.handler !== null &&
+				pathNode.findParent(candidate => candidate.node === tryStatement.handler) !== null;
+			if (!validReturnObject(pathNode.node.argument, inHandler ? "error" : "success"))
+				invalidReturn = true;
+		},
+	});
+	const catchGuardOkay = (() => {
+		if (!t.isTryStatement(tryStatement) || !tryStatement.handler) return false;
+		const handler = tryStatement.handler;
+		if (!t.isIdentifier(handler.param) || handler.body.body.length !== 2) return false;
+		const guard = handler.body.body[0];
+		if (
+			!t.isIfStatement(guard) ||
+			guard.alternate !== null ||
+			!t.isUnaryExpression(guard.test, { operator: "!" }) ||
+			!t.isBinaryExpression(guard.test.argument, { operator: "instanceof" }) ||
+			!exactIdentifier(guard.test.argument.left, handler.param.name, handler.param) ||
+			!exactIdentifier(guard.test.argument.right, "WorktreeRootError", rootErrorIdentity)
+		)
+			return false;
+		const thrown = t.isBlockStatement(guard.consequent)
+			? guard.consequent.body.length === 1 ? guard.consequent.body[0] : undefined
+			: guard.consequent;
+		return (
+			t.isThrowStatement(thrown) &&
+			exactIdentifier(thrown.argument, handler.param.name, handler.param) &&
+			t.isReturnStatement(handler.body.body[1])
+		);
+	})();
+	const scanExpression = tryStatement && t.isTryStatement(tryStatement)
+		? tryStatement.block.body[0]
+		: undefined;
+	const scanAssignment =
+		t.isExpressionStatement(scanExpression) && t.isAssignmentExpression(scanExpression.expression)
+			? scanExpression.expression
+			: undefined;
+	let scanShapeOkay =
+		bodyStatements.length === 6 &&
+		scanErrorDefinitionOkay &&
+		formatDefinitionOkay &&
+		rootErrorIdentity !== undefined &&
+		t.isTryStatement(tryStatement) &&
+		tryStatement.finalizer === null &&
+		catchGuardOkay &&
+		tryStatement.block.body.length === 1 &&
+		scanAssignment !== undefined &&
+		exactIdentifier(scanAssignment.left, "diagnostics", diagnosticsIdentity) &&
+		t.isAwaitExpression(scanAssignment.right) &&
+		t.isCallExpression(scanAssignment.right.argument) &&
+		t.isIdentifier(scanAssignment.right.argument.callee, { name: "scanWorktrees" });
+	let diagnosticsReferencesOkay = true;
+	let finalReturnHasDiagnostics = false;
+	traverse(ast, {
+		Identifier(pathNode) {
+			if (
+				pathNode.node.name !== "diagnostics" ||
+				BINDING_IDENTITIES.get(pathNode.node) !== diagnosticsIdentity ||
+				!pathNode.isReferencedIdentifier()
+			)
+				return;
+			const parent = pathNode.parentPath;
+			const approved =
+				(parent?.isMemberExpression() &&
+					parent.node.object === pathNode.node &&
+					["length", "map"].includes(memberName(parent.node) ?? "")) ||
+				(parent?.isCallExpression() &&
+					t.isMemberExpression(parent.node.callee) &&
+					t.isIdentifier(parent.node.callee.object, { name: "JSON" }) &&
+					memberName(parent.node.callee) === "stringify" &&
+					parent.node.arguments[0] === pathNode.node);
+			if (!approved) diagnosticsReferencesOkay = false;
+			if (pathNode.findParent((candidate) => candidate.isReturnStatement())?.node === bodyStatements.at(-1))
+				finalReturnHasDiagnostics = true;
+		},
+	});
+	if (!scanShapeOkay || !branchShapeOkay || !diagnosticsReferencesOkay || !finalReturnHasDiagnostics || invalidReturn)
+		addFinding(findings, file, authoritativeRun, RULES.scannerApi, "worker-scan-contract");
+	const authoritativeMutated = hasIdentifierMutation(
+		ast,
+		new Set([optionsParameter.name, "runWorktreeCommand", "scanWorktrees", "SCAN_ERROR_TEXT", "formatDiagnostic"]),
+	);
+	if (authoritativeMutated) addFinding(findings, file, authoritativeRun, RULES.scannerApi, "worker-scan-contract");
+	let validCalls = 0;
+	let totalCalls = 0;
+	let consumedCalls = 0;
+	traverse(ast, {
+		CallExpression(pathNode) {
+			const callOrigin = scopedExpressionOrigin(pathNode.node.callee, pathNode.scope);
+			if (callOrigin?.source !== "./worktree-scanner" || callOrigin.name !== "scanWorktrees") return;
+			totalCalls++;
+			if (
+				pathNode.getFunctionParent()?.node !== authoritativeRun ||
+				!t.isIdentifier(pathNode.node.callee, { name: "scanWorktrees" }) ||
+				pathNode.findParent((parent) => parent.isIfStatement()) !== null
+			)
+				return;
+			if (
+				authoritativeRun.body.body.some(
+					(statement) =>
+						t.isReturnStatement(statement) && (statement.start ?? Number.MAX_SAFE_INTEGER) < (pathNode.node.start ?? 0),
+				)
+			)
+				return;
+			const binding = pathNode.scope.getBinding("scanWorktrees");
+			const directImport =
+				binding &&
+				t.isImportSpecifier(binding.path.node) &&
+				t.isImportDeclaration(binding.path.parent) &&
+				binding.path.parent.source.value === "./worktree-scanner" &&
+				importedName(binding.path.node) === "scanWorktrees" &&
+				binding.referencePaths.length === 1 &&
+				binding.referencePaths[0]?.node === pathNode.node.callee;
+			const argument = pathNode.node.arguments[0];
+			if (
+				!directImport ||
+				pathNode.node.arguments.length !== 1 ||
+				!t.isObjectExpression(argument) ||
+				argument.properties.length !== 2
+			)
+				return;
+			const properties = new Map<string, t.ObjectProperty>();
+			for (const property of argument.properties) {
+				if (t.isObjectProperty(property) && !property.computed && t.isIdentifier(property.key))
+					properties.set(property.key.name, property);
+			}
+			if (
+				properties.size === 2 &&
+				workerOptionMember(properties.get("root")?.value, "root", pathNode.scope, optionsParameter) &&
+				workerOptionMember(properties.get("platform")?.value, "platform", pathNode.scope, optionsParameter)
+			) {
+				validCalls++;
+				const awaitPath = pathNode.parentPath;
+				const assignmentPath = awaitPath.isAwaitExpression() ? awaitPath.parentPath : undefined;
+				const diagnosticsBinding = pathNode.scope.getBinding("diagnostics");
+				if (
+					assignmentPath?.isAssignmentExpression() &&
+					assignmentPath.node.operator === "=" &&
+					t.isIdentifier(assignmentPath.node.left, { name: "diagnostics" }) &&
+					diagnosticsBinding &&
+					t.isVariableDeclarator(diagnosticsBinding.path.node) &&
+					t.isIdentifier(diagnosticsBinding.path.node.id, { name: "diagnostics" }) &&
+					diagnosticsBinding.constantViolations.length === 1 &&
+					diagnosticsBinding.constantViolations[0]?.node === assignmentPath.node &&
+					diagnosticsBinding.referencePaths.some(
+						(reference) => (reference.node.start ?? 0) > (pathNode.node.end ?? Number.MAX_SAFE_INTEGER),
+					)
+				)
+					consumedCalls++;
+			}
+		},
+	});
+	if (totalCalls !== 1 || validCalls !== 1 || consumedCalls !== 1)
+		addFinding(findings, file, ast.program, RULES.scannerApi, "worker-scan-contract");
+}
+
+function destructuredImportSignature(pathNode: NodePath<t.CallExpression>): string | undefined {
+	const awaited = pathNode.parentPath;
+	if (!awaited.isAwaitExpression() || !awaited.parentPath?.isVariableDeclarator()) return undefined;
+	const pattern = awaited.parentPath.node.id;
+	if (!t.isObjectPattern(pattern) || pattern.properties.length === 0) return undefined;
+	const names: string[] = [];
+	for (const property of pattern.properties) {
+		if (
+			!t.isObjectProperty(property) ||
+			property.computed ||
+			!t.isIdentifier(property.key) ||
+			!t.isIdentifier(property.value, { name: property.key.name }) ||
+			names.includes(property.key.name)
+		)
+			return undefined;
+		names.push(property.key.name);
+	}
+	return `destructure:${names.sort().join(",")}`;
+}
+
+function defaultImportSignature(pathNode: NodePath<t.CallExpression>): string | undefined {
+	const member = pathNode.parentPath;
+	if (
+		!member.isMemberExpression() ||
+		member.node.object !== pathNode.node ||
+		member.node.computed ||
+		!t.isIdentifier(member.node.property, { name: "then" }) ||
+		!member.parentPath?.isCallExpression() ||
+		member.parentPath.node.callee !== member.node ||
+		member.parentPath.node.arguments.length !== 1
+	)
+		return undefined;
+	const callback = member.parentPath.node.arguments[0];
+	if (
+		!t.isArrowFunctionExpression(callback) ||
+		callback.params.length !== 1 ||
+		!t.isIdentifier(callback.params[0]) ||
+		!t.isMemberExpression(callback.body) ||
+		callback.body.computed ||
+		!t.isIdentifier(callback.body.object, { name: callback.params[0].name }) ||
+		!t.isIdentifier(callback.body.property, { name: "default" })
+	)
+		return undefined;
+	return "then:default";
+}
+
+function dynamicImportBaseline(source: string): DynamicImportBaseline | undefined {
+	return CLI_DEFAULT_COMMAND_IMPORTS.has(source)
+		? { count: 1, signature: "then:default" }
+		: CLI_DYNAMIC_IMPORT_BASELINE.get(source);
+}
+
+function validateDynamicImports(ast: t.File, file: string, role: Role, findings: Finding[]): void {
+	const observedBaseline = new Map<string, number>();
+	traverse(ast, {
+		CallExpression(pathNode) {
+			if (!t.isImport(pathNode.node.callee)) return;
+			const source = staticImportSource(pathNode.node);
+			if (role === "cli") {
+				if (source === "./commands/worktree") {
+					const parent = pathNode.parentPath;
+					const awaitExpression = parent.isAwaitExpression() ? parent.parentPath : parent;
+					const declaration = awaitExpression?.isVariableDeclarator() ? awaitExpression.node : undefined;
+					const pattern = declaration?.id;
+					const exact =
+						t.isObjectPattern(pattern) &&
+						pattern.properties.length === 1 &&
+						t.isObjectProperty(pattern.properties[0]) &&
+						!pattern.properties[0].computed &&
+						t.isIdentifier(pattern.properties[0].key, { name: "createWorktreeCommand" }) &&
+						t.isIdentifier(pattern.properties[0].value, { name: "createWorktreeCommand" });
+					if (!exact) addFinding(findings, file, pathNode.node, RULES.dynamicImport, source);
+					return;
+				}
+				const baseline = source ? dynamicImportBaseline(source) : undefined;
+				const signature = destructuredImportSignature(pathNode) ?? defaultImportSignature(pathNode);
+				if (!source || !baseline || signature !== baseline.signature) {
+					addFinding(findings, file, pathNode.node, RULES.dynamicImport, source ?? "computed");
+					return;
+				}
+				observedBaseline.set(source, (observedBaseline.get(source) ?? 0) + 1);
+				return;
+			}
+			const allowed = role === "command" && source === "../cli/worktree-cli";
+			if (!allowed) addFinding(findings, file, pathNode.node, RULES.dynamicImport, source ?? "computed");
+		},
+	});
+	if (role !== "cli") return;
+	for (const source of CLI_DEFAULT_COMMAND_IMPORTS) {
+		const actual = observedBaseline.get(source) ?? 0;
+		if (actual !== 1)
+			addFinding(findings, file, ast.program, RULES.dynamicImport, `baseline-count:${source}:${actual}`);
+	}
+	for (const [source, baseline] of CLI_DYNAMIC_IMPORT_BASELINE) {
+		const actual = observedBaseline.get(source) ?? 0;
+		if (actual !== baseline.count)
+			addFinding(findings, file, ast.program, RULES.dynamicImport, `baseline-count:${source}:${actual}`);
+	}
+}
+function directOpenCall(node: t.Node | null | undefined, scope: Scope): t.CallExpression | undefined {
+	const expression = t.isAwaitExpression(node) ? node.argument : node;
+	if (!t.isCallExpression(expression)) return undefined;
+	const origin = scopedExpressionOrigin(expression.callee, scope);
+	return origin?.source === "node:fs/promises" && origin.name === "open" ? expression : undefined;
+}
+function hasDirectOpenOwner(pathNode: NodePath<t.CallExpression>): boolean {
+	const awaited = pathNode.parentPath;
+	const ownerFunction = pathNode.getFunctionParent();
+	if (!awaited.isAwaitExpression() || !ownerFunction) return false;
+	const owner = awaited.parentPath;
+	if (
+		owner.isVariableDeclarator() &&
+		owner.node.init === awaited.node &&
+		t.isIdentifier(owner.node.id) &&
+		!owner.parentPath?.parentPath?.isExportNamedDeclaration()
+	) {
+		const binding = owner.scope.getBinding(owner.node.id.name);
+		return binding?.path.getFunctionParent()?.node === ownerFunction.node;
+	}
+	if (owner.isAssignmentExpression() && owner.node.right === awaited.node && t.isIdentifier(owner.node.left)) {
+		const binding = owner.scope.getBinding(owner.node.left.name);
+		return binding?.path.getFunctionParent()?.node === ownerFunction.node;
+	}
+	return false;
+}
+
+function directOpenMember(node: t.Node | null | undefined, scope: Scope): boolean {
+	return t.isMemberExpression(node) && directOpenCall(node.object, scope) !== undefined;
+}
+function childNode(value: unknown): t.Node | undefined {
+	return typeof value === "object" && value !== null && typeof (value as { type?: unknown }).type === "string"
+		? (value as t.Node)
+		: undefined;
+}
+
+const BINDING_IDENTITIES = new WeakMap<t.Identifier, t.Identifier>();
+const HANDLE_VALUE_REFERENCES = new WeakSet<t.Identifier>();
+function containsHandleReference(node: t.Node | null | undefined, handles: ReadonlySet<t.Identifier>): boolean {
+	if (!node) return false;
+	if (
+		t.isIdentifier(node) &&
+		HANDLE_VALUE_REFERENCES.has(node) &&
+		handles.has(BINDING_IDENTITIES.get(node) ?? node)
+	)
+		return true;
+	for (const key of t.VISITOR_KEYS[node.type] ?? []) {
+		const value = (node as unknown as Record<string, unknown>)[key];
+		if (Array.isArray(value)) {
+			if (value.some((item) => containsHandleReference(childNode(item), handles))) return true;
+		} else if (containsHandleReference(childNode(value), handles)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function isAllowedHandleCall(node: t.Node | null | undefined, handles: ReadonlySet<t.Identifier>): boolean {
+	const expression = t.isAwaitExpression(node) ? node.argument : node;
+	return (
+		t.isCallExpression(expression) &&
+		t.isMemberExpression(expression.callee) &&
+		t.isIdentifier(expression.callee.object) &&
+		handles.has(BINDING_IDENTITIES.get(expression.callee.object) ?? expression.callee.object) &&
+		["stat", "read", "close"].includes(memberName(expression.callee) ?? "")
+	);
+}
+function exactBigintOptions(node: t.Node | null | undefined): boolean {
+	if (!t.isObjectExpression(node) || node.properties.length !== 1) return false;
+	const property = node.properties[0];
+	return (
+		t.isObjectProperty(property) &&
+		!property.computed &&
+		t.isIdentifier(property.key, { name: "bigint" }) &&
+		t.isBooleanLiteral(property.value, { value: true })
+	);
+}
+
+function exactReaddirOptions(node: t.Node | null | undefined): boolean {
+	if (!t.isObjectExpression(node) || node.properties.length !== 2) return false;
+	const properties = new Map<string, t.Node>();
+	for (const property of node.properties) {
+		if (
+			!t.isObjectProperty(property) ||
+			property.computed ||
+			!t.isIdentifier(property.key) ||
+			properties.has(property.key.name)
+		)
+			return false;
+		properties.set(property.key.name, property.value);
+	}
+	return (
+		t.isBooleanLiteral(properties.get("withFileTypes"), { value: true }) &&
+		t.isStringLiteral(properties.get("encoding"), { value: "buffer" })
+	);
+}
+
+function sameReadPosition(left: t.Node, right: t.Node): boolean {
+	return (
+		(t.isNumericLiteral(left) && t.isNumericLiteral(right) && left.value === right.value) ||
+		(t.isIdentifier(left) && t.isIdentifier(right) && left.name === right.name)
+	);
+}
+
+function immutableNumericBinding(scope: Scope, name: string, value: number): boolean {
+	const binding = scope.getBinding(name);
+	const declaration = binding?.path.node;
+	return (
+		binding?.constant === true &&
+		t.isVariableDeclarator(declaration) &&
+		t.isIdentifier(declaration.id, { name }) &&
+		t.isNumericLiteral(declaration.init, { value }) &&
+		t.isVariableDeclaration(binding.path.parent) &&
+		binding.path.parent.kind === "const"
+	);
+}
+
+function validReadOffset(node: t.Node, scope: Scope): boolean {
+	if (t.isNumericLiteral(node)) return Number.isSafeInteger(node.value) && node.value >= 0;
+	if (!t.isIdentifier(node)) return false;
+	const binding = scope.getBinding(node.name);
+	const declaration = binding?.path.node;
+	if (
+		!binding ||
+		!t.isVariableDeclarator(declaration) ||
+		!t.isIdentifier(declaration.id, { name: node.name }) ||
+		!t.isNumericLiteral(declaration.init, { value: 0 }) ||
+		!t.isVariableDeclaration(binding.path.parent) ||
+		binding.path.parent.kind !== "let" ||
+		binding.constantViolations.length === 0
+	)
+		return false;
+	return binding.constantViolations.every((violation) => {
+		if (!violation.isAssignmentExpression()) return false;
+		const assignment = violation.node;
+		return (
+			assignment.operator === "+=" &&
+			t.isIdentifier(assignment.left, { name: node.name }) &&
+			t.isMemberExpression(assignment.right) &&
+			!assignment.right.computed &&
+			t.isIdentifier(assignment.right.property, { name: "bytesRead" })
+		);
+	});
+}
+
+function exactReadLength(node: t.Node, buffer: t.Identifier, offset: t.Node, scope: Scope): boolean {
+	if (t.isNumericLiteral(node)) return Number.isSafeInteger(node.value) && node.value > 0 && node.value <= 8192;
+	if (
+		!t.isCallExpression(node) ||
+		!t.isMemberExpression(node.callee) ||
+		node.callee.computed ||
+		!t.isIdentifier(node.callee.object, { name: "Math" }) ||
+		scope.getBinding("Math") ||
+		!t.isIdentifier(node.callee.property, { name: "min" }) ||
+		node.arguments.length !== 2 ||
+		!t.isIdentifier(node.arguments[0], { name: "CHUNK_BYTES" }) ||
+		!immutableNumericBinding(scope, "CHUNK_BYTES", 8192)
+	)
+		return false;
+	const remaining = node.arguments[1];
+	return (
+		t.isBinaryExpression(remaining, { operator: "-" }) &&
+		t.isMemberExpression(remaining.left) &&
+		!remaining.left.computed &&
+		t.isIdentifier(remaining.left.object, { name: buffer.name }) &&
+		t.isIdentifier(remaining.left.property, { name: "length" }) &&
+		((t.isIdentifier(offset) && t.isIdentifier(remaining.right, { name: offset.name })) ||
+			(t.isNumericLiteral(offset) && t.isNumericLiteral(remaining.right) && remaining.right.value === offset.value))
+	);
+}
+
+function exactReadCall(args: readonly t.Node[], scope: Scope): boolean {
+	if (args.length !== 4 || !t.isIdentifier(args[0]) || !sameReadPosition(args[1], args[3])) return false;
+	const offset = args[1];
+	if (!validReadOffset(offset, scope)) return false;
+	return exactReadLength(args[2], args[0], offset, scope);
+}
+
+function exactScannerCallSignature(name: string, args: readonly t.Node[], scope: Scope): boolean {
+	if (name === "lstat") return args.length === 2 && exactBigintOptions(args[1]);
+	if (name === "readdir") return args.length === 2 && exactReaddirOptions(args[1]);
+	if (name === "open") return args.length === 2 && isReadonlyOpenFlags(args[1], scope);
+	if (name === "stat") return args.length === 1 && exactBigintOptions(args[0]);
+	if (name === "close") return args.length === 0;
+	if (name === "read") return exactReadCall(args, scope);
+	return false;
+}
+
+function allowedObjectAssign(node: t.CallExpression): boolean {
+	return (
+		t.isMemberExpression(node.callee) &&
+		!node.callee.computed &&
+		t.isIdentifier(node.callee.object, { name: "Object" }) &&
+		memberName(node.callee) === "assign" &&
+		node.arguments.length === 2 &&
+		t.isNewExpression(node.arguments[0]) &&
+		t.isIdentifier(node.arguments[0].callee, { name: "Error" }) &&
+		t.isObjectExpression(node.arguments[1])
+	);
+}
+function validatePrivilegedImportReferences(ast: t.File, file: string, findings: Finding[]): void {
+	traverse(ast, {
+		ImportSpecifier(pathNode) {
+			const declaration = pathNode.parentPath.node;
+			if (
+				!t.isImportDeclaration(declaration) ||
+				declaration.source.value !== "node:fs/promises" ||
+				declaration.importKind === "type" ||
+				pathNode.node.importKind === "type"
+			)
+				return;
+			const binding = pathNode.scope.getBinding(pathNode.node.local.name);
+			if (!binding) {
+				addFinding(findings, file, pathNode.node, RULES.unknownBinding, "unresolved-privileged-import");
+				return;
+			}
+			const capability = importedName(pathNode.node);
+			for (const reference of binding.referencePaths) {
+				const directCall =
+					reference.parentPath?.isCallExpression() && reference.parentPath.node.callee === reference.node;
+				if (!directCall)
+					addFinding(findings, file, reference.node, RULES.unknownBinding, `capability-transfer:${capability}`);
+			}
+		},
+	});
+}
+function reflectivePatternKey(property: t.ObjectProperty): string | undefined {
+	if (property.computed) return staticStringValue(property.key);
+	return t.isIdentifier(property.key) ? property.key.name : t.isStringLiteral(property.key) ? property.key.value : undefined;
+}
+
+function validateReflectiveAccess(ast: t.File, file: string, role: Role, findings: Finding[]): void {
+	const reject = (node: t.Node, name: string | undefined): void => {
+		if (name && REFLECTIVE_MEMBERS.has(name))
+			addFinding(findings, file, node, RULES.forbiddenMember, `reflective-member:${name}`);
+	};
+	traverse(ast, {
+		MemberExpression(pathNode) {
+			reject(pathNode.node, memberName(pathNode.node));
+			if (
+				role === "cli" &&
+				t.isMetaProperty(pathNode.node.object) &&
+				t.isIdentifier(pathNode.node.object.meta, { name: "import" }) &&
+				t.isIdentifier(pathNode.node.object.property, { name: "meta" }) &&
+				memberName(pathNode.node) !== "main"
+			)
+				addFinding(
+					findings,
+					file,
+					pathNode.node,
+					RULES.forbiddenMember,
+					`import-meta:${memberName(pathNode.node) ?? "computed"}`,
+				);
+			if (
+				role === "cli" &&
+				pathNode.node.computed &&
+				!(
+					t.isIdentifier(pathNode.node.object) &&
+					["argv", "normalizedArgv"].includes(pathNode.node.object.name)
+				)
+			)
+				addFinding(findings, file, pathNode.node, RULES.unknownBinding, "computed-member");
+		},
+		OptionalMemberExpression(pathNode) {
+			const name = memberName(pathNode.node);
+			reject(pathNode.node, name);
+			const root = rootIdentifier(pathNode.node);
+			if (
+				role === "cli" &&
+				root &&
+				["Bun", "process"].includes(root.name) &&
+				!pathNode.scope.getBinding(root.name)
+			)
+				addFinding(
+					findings,
+					file,
+					pathNode.node,
+					RULES.unknownBinding,
+					`optional-privileged-member:${name ?? "computed"}`,
+				);
+			if (role === "cli" && pathNode.node.computed)
+				addFinding(findings, file, pathNode.node, RULES.unknownBinding, "computed-member");
+		},
+		MetaProperty(pathNode) {
+			if (
+				role !== "cli" ||
+				!t.isIdentifier(pathNode.node.meta, { name: "import" }) ||
+				!t.isIdentifier(pathNode.node.property, { name: "meta" })
+			)
+				return;
+			const parent = pathNode.parentPath;
+			const allowedMain =
+				parent?.isMemberExpression() &&
+				parent.node.object === pathNode.node &&
+				memberName(parent.node) === "main";
+			if (!allowedMain)
+				addFinding(findings, file, pathNode.node, RULES.unknownBinding, "import-meta-transfer");
+		},
+		ObjectProperty(pathNode) {
+			if (!pathNode.parentPath?.isObjectPattern()) return;
+			if (pathNode.node.computed && !t.isStringLiteral(pathNode.node.key))
+				addFinding(findings, file, pathNode.node, RULES.unknownBinding, "computed-pattern");
+			reject(pathNode.node, reflectivePatternKey(pathNode.node));
+		},
+		Identifier(pathNode) {
+			const reflectiveGlobal = ["Object", "Reflect", "globalThis", "global"].includes(pathNode.node.name);
+			const parent = pathNode.parentPath;
+			const allowedScannerObjectAssign =
+				role === "scanner" &&
+				pathNode.node.name === "Object" &&
+				parent?.isMemberExpression() &&
+				parent.node.object === pathNode.node &&
+				parent.parentPath?.isCallExpression() &&
+				parent.parentPath.node.callee === parent.node &&
+				allowedObjectAssign(parent.parentPath.node);
+			if (
+				reflectiveGlobal &&
+				!allowedScannerObjectAssign &&
+				!pathNode.scope.getBinding(pathNode.node.name) &&
+				pathNode.isReferencedIdentifier()
+			)
+				addFinding(
+					findings,
+					file,
+					pathNode.node,
+					RULES.forbiddenMember,
+					`reflective-global:${pathNode.node.name}`,
+				);
+		},
+	});
+}
+
+function validateCapabilities(ast: t.File, file: string, role: Role, findings: Finding[]): void {
+	validateReflectiveAccess(ast, file, role, findings);
+	if (role === "cli") {
+		let processTitleAssignments = 0;
+		let processExitCodeAssignments = 0;
+		let processExitCalls = 0;
+		traverse(ast, {
+			Identifier(pathNode) {
+				const name = pathNode.node.name;
+				if (
+					["Bun", "process"].includes(name) &&
+					!pathNode.scope.getBinding(name) &&
+					pathNode.isReferencedIdentifier()
+				) {
+					const parent = pathNode.parentPath;
+					const directMemberObject =
+						((parent?.isMemberExpression() || parent?.isOptionalMemberExpression()) &&
+							parent.node.object === pathNode.node);
+					if (!directMemberObject)
+						addFinding(
+							findings,
+							file,
+							pathNode.node,
+							name === "process" ? RULES.process : RULES.forbiddenCall,
+							`${name === "process" ? "process-transfer" : "capability-transfer"}:${name}`,
+						);
+				}
+				if (name === "commands" && pathNode.isReferencedIdentifier()) {
+					const parent = pathNode.parentPath;
+					const allowedSome =
+						parent?.isMemberExpression() &&
+						parent.node.object === pathNode.node &&
+						!parent.node.computed &&
+						t.isIdentifier(parent.node.property, { name: "some" });
+					const payloadObject = parent?.parentPath;
+					const payloadCall = payloadObject?.parentPath;
+					const payloadOrigin = payloadCall?.isCallExpression()
+						? scopedExpressionOrigin(payloadCall.node.callee, pathNode.scope)
+						: undefined;
+					const allowedPayload =
+						parent?.isObjectProperty() &&
+						parent.node.value === pathNode.node &&
+						!parent.node.computed &&
+						t.isIdentifier(parent.node.key, { name: "commands" }) &&
+						payloadObject?.isObjectExpression() &&
+						payloadCall?.isCallExpression() &&
+						payloadCall.node.arguments.includes(payloadObject.node) &&
+						payloadOrigin?.source === "@gajae-code/utils/cli" &&
+						payloadOrigin.name === "run";
+					if (!allowedSome && !allowedPayload)
+						addFinding(findings, file, pathNode.node, RULES.mutation, "registry-mutation");
+				}
+				if (pathNode.scope.getBinding(name) || !["eval", "require", "fetch", "Function", "WebSocket"].includes(name))
+					return;
+				const parent = pathNode.parentPath;
+				const propertyKey =
+					parent?.isMemberExpression() && parent.node.property === pathNode.node && !parent.node.computed;
+				const declarationKey =
+					parent?.isObjectProperty() &&
+					parent.node.key === pathNode.node &&
+					parent.node.value !== pathNode.node &&
+					!parent.node.computed;
+				if (!propertyKey && !declarationKey) addFinding(findings, file, pathNode.node, RULES.forbiddenCall, name);
+			},
+			CallExpression(pathNode) {
+				const callee = unwrapTransparentExpression(pathNode.node.callee);
+				if (t.isImport(callee)) return;
+				if (!t.isIdentifier(callee) && !t.isMemberExpression(callee) && !t.isSuper(callee))
+					addFinding(findings, file, pathNode.node, RULES.unknownBinding, "unsupported-callee");
+				if (
+					t.isMemberExpression(callee) &&
+					t.isIdentifier(callee.object, { name: "process" }) &&
+					!pathNode.scope.getBinding("process") &&
+					memberName(callee) === "exit"
+				) {
+					processExitCalls++;
+					if (pathNode.node.arguments.length !== 1 || !t.isNumericLiteral(pathNode.node.arguments[0], { value: 1 }))
+						addFinding(findings, file, pathNode.node, RULES.process, "process.exit");
+				}
+				const root = t.isMemberExpression(callee) ? rootIdentifier(callee) : undefined;
+				if (
+					t.isMemberExpression(callee) &&
+					t.isIdentifier(root, { name: "commands" }) &&
+					["copyWithin", "fill", "pop", "push", "reverse", "shift", "sort", "splice", "unshift"].includes(
+						memberName(callee) ?? "",
+					)
+				)
+					addFinding(findings, file, callee, RULES.mutation, "registry-mutation");
+				if (
+					t.isMemberExpression(callee) &&
+					t.isIdentifier(callee.object, { name: "process" }) &&
+					!pathNode.scope.getBinding("process") &&
+					memberName(callee) === "getBuiltinModule"
+				)
+					addFinding(findings, file, callee, RULES.forbiddenCall, "process.getBuiltinModule");
+				if (t.isMemberExpression(callee) && ["apply", "bind", "call"].includes(memberName(callee) ?? ""))
+					addFinding(
+						findings,
+						file,
+						callee,
+						RULES.unknownBinding,
+						`indirect-invocation:${memberName(callee)}`,
+					);
+			},
+			MemberExpression(pathNode) {
+				const node = pathNode.node;
+				if (t.isIdentifier(node.object, { name: "process" }) && !pathNode.scope.getBinding("process")) {
+					const allowed = [
+						"argv",
+						"env",
+						"execPath",
+						"exit",
+						"exitCode",
+						"platform",
+						"stderr",
+						"stdout",
+						"title",
+					].includes(memberName(node) ?? "");
+					if (!allowed) addFinding(findings, file, node, RULES.process, `process.${memberName(node) ?? "computed"}`);
+					const processMember = memberName(node);
+					if (["exit", "getBuiltinModule", "stderr", "stdout"].includes(processMember ?? "")) {
+						const parent = pathNode.parentPath;
+						const directCall = parent?.isCallExpression() && parent.node.callee === node;
+						const directWrite =
+							(processMember === "stderr" || processMember === "stdout") &&
+							parent?.isMemberExpression() &&
+							parent.node.object === node &&
+							!parent.node.computed &&
+							t.isIdentifier(parent.node.property, { name: "write" });
+						if (!directCall && !directWrite)
+							addFinding(findings, file, node, RULES.process, `process-transfer:${processMember}`);
+					}
+				}
+				if (t.isIdentifier(node.object, { name: "Bun" }) && !pathNode.scope.getBinding("Bun")) {
+					const allowed = memberName(node) === "version" || memberName(node) === "semver";
+					if (!allowed)
+						addFinding(findings, file, node, RULES.forbiddenMember, `Bun.${memberName(node) ?? "computed"}`);
+				}
+				const root = rootIdentifier(node);
+				if (
+					(t.isIdentifier(root, { name: "globalThis" }) || t.isIdentifier(root, { name: "Deno" })) &&
+					!pathNode.scope.getBinding(root.name)
+				)
+					addFinding(findings, file, node, RULES.forbiddenMember, `${root.name}.${memberName(node) ?? "computed"}`);
+			},
+			AssignmentExpression(pathNode) {
+				const left = pathNode.node.left;
+				const directProcessMember =
+					t.isMemberExpression(left) &&
+					t.isIdentifier(left.object, { name: "process" }) &&
+					!pathNode.scope.getBinding("process")
+						? memberName(left)
+						: undefined;
+				const nestedProcessMember =
+					t.isMemberExpression(left) &&
+					t.isMemberExpression(left.object) &&
+					t.isIdentifier(left.object.object, { name: "process" }) &&
+					!pathNode.scope.getBinding("process")
+						? memberName(left.object)
+						: undefined;
+				if (pathNode.node.operator === "=" && (directProcessMember === "title" || directProcessMember === "exitCode")) {
+					if (directProcessMember === "title") processTitleAssignments++;
+					else processExitCodeAssignments++;
+					return;
+				}
+				const root = t.isMemberExpression(left) ? rootIdentifier(left) : undefined;
+				if (t.isIdentifier(root, { name: "process" }) && !pathNode.scope.getBinding("process"))
+					addFinding(
+						findings,
+						file,
+						left,
+						RULES.process,
+						`process.${directProcessMember ?? nestedProcessMember ?? "nested"}`,
+					);
+				addFinding(findings, file, left, RULES.mutation, "assignment");
+			},
+			NewExpression(pathNode) {
+				if (!t.isIdentifier(pathNode.node.callee) || pathNode.scope.getBinding(pathNode.node.callee.name)) return;
+				if (["Function", "WebSocket"].includes(pathNode.node.callee.name))
+					addFinding(findings, file, pathNode.node.callee, RULES.forbiddenCall, pathNode.node.callee.name);
+			},
+			OptionalCallExpression(pathNode) {
+				const callee = pathNode.node.callee;
+				const allowed =
+					t.isOptionalMemberExpression(callee) &&
+					!callee.computed &&
+					t.isIdentifier(callee.property, { name: "includes" });
+				if (!allowed) addFinding(findings, file, pathNode.node, RULES.unknownBinding, "optional-call");
+			},
+			TaggedTemplateExpression(pathNode) {
+				addFinding(findings, file, pathNode.node, RULES.forbiddenCall, "tagged-template");
+			},
+			UpdateExpression(pathNode) {
+				if (!t.isIdentifier(pathNode.node.argument))
+					addFinding(findings, file, pathNode.node, RULES.mutation, "update");
+			},
+		});
+		if (processTitleAssignments !== 1 || processExitCodeAssignments !== 3 || processExitCalls !== 1)
+			addFinding(findings, file, ast.program, RULES.process, "process-assignment-baseline");
+		return;
+	}
+	validatePrivilegedImportReferences(ast, file, findings);
+	validateScannerCapabilityBindings(ast, file, findings);
+	const handles = new Set<t.Identifier>();
+	traverse(ast, {
+		Identifier(pathNode) {
+			const identity = pathNode.scope.getBinding(pathNode.node.name)?.identifier;
+			if (identity) BINDING_IDENTITIES.set(pathNode.node, identity);
+			if (identity && pathNode.isReferencedIdentifier() && !pathNode.findParent((parent) => parent.isTSType()))
+				HANDLE_VALUE_REFERENCES.add(pathNode.node);
+		},
+	});
+	// Discover handle bindings to a fixed point before checking any use. This is
+	// deliberately independent of source order: closures and backward aliases
+	// must see assignments that occur later in the module.
+	let changed = true;
+	while (changed) {
+		changed = false;
+		traverse(ast, {
+			VariableDeclarator(pathNode) {
+				if (!t.isIdentifier(pathNode.node.id)) return;
+				const identity = pathNode.scope.getBinding(pathNode.node.id.name)?.identifier;
+				const init = unwrapTransparentExpression(pathNode.node.init);
+				const sourceIdentity =
+					t.isIdentifier(init) ? BINDING_IDENTITIES.get(init) ?? pathNode.scope.getBinding(init.name)?.identifier : undefined;
+				if (
+					identity &&
+					(directOpenCall(pathNode.node.init, pathNode.scope) || (sourceIdentity && handles.has(sourceIdentity))) &&
+					!handles.has(identity)
+				) {
+					handles.add(identity);
+					changed = true;
+				}
+			},
+			AssignmentExpression(pathNode) {
+				if (!t.isIdentifier(pathNode.node.left)) return;
+				const identity = pathNode.scope.getBinding(pathNode.node.left.name)?.identifier;
+				const right = unwrapTransparentExpression(pathNode.node.right);
+				const sourceIdentity =
+					t.isIdentifier(right) ? BINDING_IDENTITIES.get(right) ?? pathNode.scope.getBinding(right.name)?.identifier : undefined;
+				if (
+					identity &&
+					(directOpenCall(pathNode.node.right, pathNode.scope) || (sourceIdentity && handles.has(sourceIdentity))) &&
+					!handles.has(identity)
+				) {
+					handles.add(identity);
+					changed = true;
+				}
+			},
+		});
+	}
+	traverse(ast, {
+		Identifier(pathNode) {
+			const name = pathNode.node.name;
+			const identity = pathNode.scope.getBinding(name)?.identifier;
+			if (identity) BINDING_IDENTITIES.set(pathNode.node, identity);
+			if (identity) return;
+			const parent = pathNode.parentPath;
+			const nonValuePropertyKey =
+				parent?.isObjectProperty() &&
+				parent.node.key === pathNode.node &&
+				parent.node.value !== pathNode.node &&
+				!parent.node.computed;
+			const memberProperty =
+				parent?.isMemberExpression() && parent.node.property === pathNode.node && !parent.node.computed;
+			const memberObject = parent?.isMemberExpression() && parent.node.object === pathNode.node;
+			if (nonValuePropertyKey || memberProperty) return;
+			if (name === "process") {
+				if (!memberObject) addFinding(findings, file, pathNode.node, RULES.process, "process");
+				return;
+			}
+			if (name === "Bun" && memberObject) return;
+			if (["Bun", "eval", "fetch", "Function", "require", "WebSocket"].includes(name))
+				addFinding(findings, file, pathNode.node, RULES.forbiddenCall, name);
+		},
+		VariableDeclarator(pathNode) {
+			const init = pathNode.node.init;
+			if (t.isIdentifier(init) && !pathNode.scope.getBinding(init.name))
+				addFinding(findings, file, init, RULES.forbiddenCall, init.name);
+			const privileged = scopedExpressionOrigin(init, pathNode.scope);
+			if (privileged?.source === "node:fs/promises")
+				addFinding(findings, file, pathNode.node, RULES.unknownBinding, `capability-transfer:${privileged.name}`);
+			const openCall = directOpenCall(init, pathNode.scope);
+			if (openCall) {
+				const flags = openCall.arguments[1];
+				if (!isReadonlyOpenFlags(flags, pathNode.scope))
+					addFinding(findings, file, openCall, RULES.scannerApi, "open:write-mode");
+				if (t.isIdentifier(pathNode.node.id)) {
+					const identity = pathNode.scope.getBinding(pathNode.node.id.name)?.identifier;
+					if (identity) handles.add(identity);
+				}
+				else addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+			}
+			if (t.isIdentifier(init) && handles.has(BINDING_IDENTITIES.get(init) ?? init))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+			if (t.isObjectPattern(pathNode.node.id) && t.isIdentifier(init) && handles.has(BINDING_IDENTITIES.get(init) ?? init))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+			if (
+				t.isMemberExpression(init) &&
+				((t.isIdentifier(init.object) && handles.has(BINDING_IDENTITIES.get(init.object) ?? init.object)) || directOpenMember(init, pathNode.scope))
+			)
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+			if (
+				containsHandleReference(init, handles) &&
+				!isAllowedHandleCall(init, handles) &&
+				!t.isIdentifier(init) &&
+				!t.isMemberExpression(init)
+			)
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+		},
+		AssignmentExpression(pathNode) {
+			const left = pathNode.node.left;
+			const right = pathNode.node.right;
+			const unwrappedRight = unwrapTransparentExpression(right);
+			if (t.isIdentifier(unwrappedRight) && !pathNode.scope.getBinding(unwrappedRight.name))
+				addFinding(findings, file, unwrappedRight, RULES.forbiddenCall, unwrappedRight.name);
+			const aliasedOrigin = scopedExpressionOrigin(right, pathNode.scope);
+			if (aliasedOrigin)
+				addFinding(
+					findings,
+					file,
+					pathNode.node,
+					RULES.unknownBinding,
+					`alias-assignment:${aliasedOrigin.source}:${aliasedOrigin.name}`,
+				);
+			if (
+				(t.isIdentifier(right) && handles.has(BINDING_IDENTITIES.get(right) ?? right)) ||
+				(t.isMemberExpression(right) &&
+					(t.isIdentifier(right.object) && handles.has(BINDING_IDENTITIES.get(right.object) ?? right.object) || directOpenMember(right, pathNode.scope)))
+			)
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+			if (containsHandleReference(right, handles) && !isAllowedHandleCall(right, handles))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+			const openCall = directOpenCall(right, pathNode.scope);
+			if (!openCall) return;
+			const flags = openCall.arguments[1];
+			if (!isReadonlyOpenFlags(flags, pathNode.scope))
+				addFinding(findings, file, openCall, RULES.scannerApi, "open:write-mode");
+			if (t.isIdentifier(left)) {
+				const identity = pathNode.scope.getBinding(left.name)?.identifier;
+				if (identity) handles.add(identity);
+			}
+			else addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+		},
+	});
+	traverse(ast, {
+		CallExpression(pathNode) {
+			const callee = unwrapTransparentExpression(pathNode.node.callee);
+			if (t.isImport(callee)) return;
+			if (!t.isIdentifier(callee) && !t.isMemberExpression(callee) && !t.isSuper(callee))
+				addFinding(findings, file, pathNode.node, RULES.unknownBinding, "unsupported-callee");
+			if (pathNode.node.arguments.some((argument) => containsHandleReference(childNode(argument), handles)))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+			for (const argument of pathNode.node.arguments) {
+				const origin = scopedExpressionOrigin(argument, pathNode.scope);
+				if (origin?.source === "node:fs/promises")
+					addFinding(findings, file, pathNode.node, RULES.unknownBinding, `capability-transfer:${origin.name}`);
+			}
+			if (t.isIdentifier(callee)) {
+				const binding = pathNode.scope.getBinding(callee.name);
+				if (!binding) addFinding(findings, file, callee, RULES.forbiddenCall, callee.name);
+				const origin = scopedExpressionOrigin(callee, pathNode.scope);
+				if (origin && MUTATING_MEMBERS.has(origin.name))
+					addFinding(findings, file, callee, RULES.mutation, `${origin.source}:${origin.name}`);
+				if (origin?.source === "node:fs/promises") {
+					if (role !== "scanner") {
+						addFinding(findings, file, callee, RULES.scannerApi, origin.name);
+					} else if (origin.name === "open" && !isReadonlyOpenFlags(pathNode.node.arguments[1], pathNode.scope)) {
+						addFinding(findings, file, pathNode.node, RULES.scannerApi, "open:write-mode");
+					} else if (!exactScannerCallSignature(origin.name, pathNode.node.arguments, pathNode.scope)) {
+						addFinding(findings, file, pathNode.node, RULES.scannerApi, `${origin.name}:signature`);
+					}
+					if (role === "scanner" && origin.name === "open" && !hasDirectOpenOwner(pathNode))
+						addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+				}
+				return;
+			}
+			if (!t.isMemberExpression(callee)) return;
+			if (directOpenMember(callee, pathNode.scope))
+				addFinding(findings, file, callee, RULES.scannerApi, "FileHandle.extraction");
+			const allowedDryRunCall =
+				role === "command" &&
+				t.isIdentifier(callee.object, { name: "flags" }) &&
+				t.isStringLiteral(callee.property, { value: "dry-run" });
+			if (callee.computed && !allowedDryRunCall)
+				addFinding(findings, file, callee, RULES.unknownBinding, "computed-call");
+			const name = memberName(callee);
+			if (!name) {
+				return;
+			}
+			const root = rootIdentifier(callee);
+			if (root && !pathNode.scope.getBinding(root.name) && root.name !== "process") {
+				const allowed =
+					(root.name === "Bun" &&
+						t.isMemberExpression(callee.object) &&
+						memberName(callee.object) === "semver" &&
+						name === "order") ||
+					(root.name === "Object" && name === "assign" && allowedObjectAssign(pathNode.node)) ||
+					SAFE_GLOBAL_MEMBERS[root.name]?.has(name) === true;
+				if (!allowed) addFinding(findings, file, callee, RULES.forbiddenMember, `${root.name}.${name}`);
+			}
+			if (t.isIdentifier(callee.object, { name: "process" }) && !pathNode.scope.getBinding("process")) {
+				const allowed = role === "command" && isCommandRunPath(pathNode) && ["stdout", "stderr"].includes(name);
+				if (!allowed) addFinding(findings, file, callee, RULES.process, `process.${name}`);
+			}
+			const objectOrigin = scopedExpressionOrigin(callee.object, pathNode.scope);
+			const indirectInvocation = ["apply", "bind", "call"].includes(name);
+			if (indirectInvocation)
+				addFinding(findings, file, callee, RULES.unknownBinding, `indirect-invocation:${name}`);
+			if (
+				indirectInvocation &&
+				t.isMemberExpression(callee.object) &&
+				t.isIdentifier(callee.object.object) &&
+				handles.has(BINDING_IDENTITIES.get(callee.object.object) ?? callee.object.object)
+			)
+				addFinding(findings, file, callee, RULES.scannerApi, "FileHandle.extraction");
+			if (objectOrigin && MUTATING_MEMBERS.has(name))
+				addFinding(findings, file, callee, RULES.mutation, `${objectOrigin.source}:${name}`);
+			if (role === "scanner" && objectOrigin?.source === "node:path" && !SCANNER_PATH_CALLS.has(name))
+				addFinding(findings, file, callee, RULES.scannerApi, `path.${name}`);
+			if (
+				name === "bind" &&
+				t.isMemberExpression(callee.object) &&
+				t.isIdentifier(callee.object.object) &&
+				handles.has(BINDING_IDENTITIES.get(callee.object.object) ?? callee.object.object)
+			)
+				addFinding(findings, file, callee, RULES.scannerApi, "FileHandle.extraction");
+			if (t.isIdentifier(callee.object) && handles.has(BINDING_IDENTITIES.get(callee.object) ?? callee.object)) {
+				if (role !== "scanner" || !["stat", "read", "close"].includes(name))
+					addFinding(findings, file, callee, RULES.scannerApi, `FileHandle.${name}`);
+				if (role === "scanner" && !exactScannerCallSignature(name, pathNode.node.arguments, pathNode.scope))
+					addFinding(findings, file, pathNode.node, RULES.scannerApi, `FileHandle.${name}:signature`);
+			} else if (role === "scanner" && FORBIDDEN_SCANNER_MEMBERS.has(name)) {
+				addFinding(findings, file, callee, RULES.scannerApi, name);
+			}
+		},
+		ReturnStatement(pathNode) {
+			if (containsHandleReference(pathNode.node.argument, handles))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+			const origin = scopedExpressionOrigin(pathNode.node.argument, pathNode.scope);
+			if (origin?.source === "node:fs/promises")
+				addFinding(findings, file, pathNode.node, RULES.unknownBinding, `capability-transfer:${origin.name}`);
+		},
+		ThrowStatement(pathNode) {
+			if (containsHandleReference(pathNode.node.argument, handles))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+		},
+		YieldExpression(pathNode) {
+			if (containsHandleReference(pathNode.node.argument, handles))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+		},
+		ForOfStatement(pathNode) {
+			if (containsHandleReference(pathNode.node.right, handles))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+		},
+		ForInStatement(pathNode) {
+			if (containsHandleReference(pathNode.node.right, handles))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+		},
+		ExportNamedDeclaration(pathNode) {
+			const leaked =
+				(t.isVariableDeclaration(pathNode.node.declaration) &&
+					containsHandleReference(pathNode.node.declaration, handles)) ||
+				pathNode.node.specifiers.some(
+					(specifier) => t.isExportSpecifier(specifier) && handles.has(BINDING_IDENTITIES.get(specifier.local) ?? specifier.local),
+				);
+			if (leaked) addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+			for (const specifier of pathNode.node.specifiers) {
+				if (!t.isExportSpecifier(specifier) || !t.isIdentifier(specifier.local)) continue;
+				const origin = bindingOrigin(pathNode.scope, specifier.local.name);
+				if (origin?.source === "node:fs/promises")
+					addFinding(findings, file, specifier, RULES.unknownBinding, `capability-transfer:${origin.name}`);
+			}
+		},
+		ExportDefaultDeclaration(pathNode) {
+			if (containsHandleReference(pathNode.node.declaration, handles))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+			const origin = scopedExpressionOrigin(pathNode.node.declaration, pathNode.scope);
+			if (origin?.source === "node:fs/promises")
+				addFinding(findings, file, pathNode.node, RULES.unknownBinding, `capability-transfer:${origin.name}`);
+		},
+		ClassProperty(pathNode) {
+			if (containsHandleReference(pathNode.node.value, handles))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+		},
+		ClassPrivateProperty(pathNode) {
+			if (containsHandleReference(pathNode.node.value, handles))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+		},
+		NewExpression(pathNode) {
+			if (pathNode.node.arguments.some((argument) => containsHandleReference(childNode(argument), handles)))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, "FileHandle.extraction");
+			const callee = pathNode.node.callee;
+			if (
+				t.isIdentifier(callee) &&
+				!pathNode.scope.getBinding(callee.name) &&
+				!SAFE_GLOBAL_CONSTRUCTORS.has(callee.name)
+			)
+				addFinding(findings, file, callee, RULES.forbiddenCall, callee.name);
+		},
+		MemberExpression(pathNode) {
+			if (t.isCallExpression(pathNode.parent) && pathNode.parent.callee === pathNode.node) return;
+			const allowedDryRunMember =
+				role === "command" &&
+				t.isIdentifier(pathNode.node.object, { name: "flags" }) &&
+				t.isStringLiteral(pathNode.node.property, { value: "dry-run" });
+			const allowedArgvMember =
+				role === "command" &&
+				isCommandRunPath(pathNode) &&
+				t.isIdentifier(pathNode.node.object, { name: "argv" }) &&
+				pathNode.scope.getBinding("argv") !== undefined &&
+				pathNode.node.computed &&
+				t.isNumericLiteral(pathNode.node.property, { value: 0 });
+			if (pathNode.node.computed && !allowedDryRunMember && !allowedArgvMember)
+				addFinding(findings, file, pathNode.node, RULES.unknownBinding, "computed-member");
+			const name = memberName(pathNode.node);
+			if (!name) return;
+			const root = rootIdentifier(pathNode.node);
+			if (root && !pathNode.scope.getBinding(root.name) && root.name !== "process") {
+				const allowed = SAFE_GLOBAL_MEMBERS[root.name]?.has(name) === true;
+				if (!allowed) addFinding(findings, file, pathNode.node, RULES.forbiddenMember, `${root.name}.${name}`);
+			}
+			const objectOrigin = scopedExpressionOrigin(pathNode.node.object, pathNode.scope);
+			if (role === "scanner" && objectOrigin?.source === "node:path" && !SCANNER_PATH_MEMBERS.has(name))
+				addFinding(findings, file, pathNode.node, RULES.scannerApi, `path.${name}`);
+			if (t.isIdentifier(pathNode.node.object, { name: "process" }) && !pathNode.scope.getBinding("process")) {
+				const allowed =
+					role === "command" &&
+					isCommandRunPath(pathNode) &&
+					["exitCode", "platform", "stderr", "stdout"].includes(name);
+				if (!allowed) addFinding(findings, file, pathNode.node, RULES.process, `process.${name}`);
+			}
+		},
+		AssignmentExpression(pathNode) {
+			if (t.isIdentifier(pathNode.node.left)) return;
+			if (!t.isMemberExpression(pathNode.node.left)) {
+				addFinding(findings, file, pathNode.node, RULES.mutation, "assignment");
+				return;
+			}
+			const name = memberName(pathNode.node.left);
+			const allowedScannerState =
+				role === "scanner" &&
+				t.isIdentifier(pathNode.node.left.object, { name: "state" }) &&
+				["halted", "reserved", "visited"].includes(name ?? "");
+			const allowedExit =
+				role === "command" &&
+				isCommandRunPath(pathNode) &&
+				t.isIdentifier(pathNode.node.left.object, { name: "process" }) &&
+				name === "exitCode";
+			if (!allowedScannerState && !allowedExit)
+				addFinding(findings, file, pathNode.node, RULES.mutation, "member-assignment");
+		},
+		OptionalCallExpression(pathNode) {
+			addFinding(findings, file, pathNode.node, RULES.unknownBinding, "optional-call");
+		},
+		TaggedTemplateExpression(pathNode) {
+			addFinding(findings, file, pathNode.node, RULES.forbiddenCall, "tagged-template");
+		},
+		UpdateExpression(pathNode) {
+			const argument = pathNode.node.argument;
+			const allowed =
+				t.isIdentifier(argument) ||
+				(role === "scanner" &&
+					t.isMemberExpression(argument) &&
+					t.isIdentifier(argument.object, { name: "state" }) &&
+					memberName(argument) === "visited");
+			if (!allowed) addFinding(findings, file, pathNode.node, RULES.mutation, "update");
+		},
+	});
+}
+function validateScannerExportSurface(ast: t.File, file: string, findings: Finding[]): void {
+	const expected = new Set([
+		"MAX_ENTRIES",
+		"WorktreeRootErrorCode",
+		"WorktreeRootError",
+		"MAX_DEPTH",
+		"MAX_NAME_UTF8_BYTES",
+		"MAX_METADATA_BYTES",
+		"METADATA_RESERVATION_BYTES",
+		"MAX_TOTAL_METADATA_BYTES",
+		"WorktreeScannerPlatform",
+		"ScanWorktreesOptions",
+		"WorktreeKind",
+		"WorktreeDiagnostic",
+		"scanWorktrees",
+	]);
+	const actual = new Set<string>();
+	let scanDeclaration: t.FunctionDeclaration | undefined;
+	for (const statement of ast.program.body) {
+		if (
+			t.isExportDefaultDeclaration(statement) ||
+			t.isExportAllDeclaration(statement) ||
+			(t.isExportNamedDeclaration(statement) && statement.source)
+		) {
+			addFinding(findings, file, statement, RULES.scannerApi, "export-surface");
+			continue;
+		}
+		if (!t.isExportNamedDeclaration(statement)) continue;
+		if (statement.declaration) {
+			const declaration = statement.declaration;
+			if (t.isFunctionDeclaration(declaration) && t.isIdentifier(declaration.id, { name: "scanWorktrees" }))
+				scanDeclaration = declaration;
+			if (t.isVariableDeclaration(declaration)) {
+				for (const variable of declaration.declarations) {
+					if (t.isIdentifier(variable.id)) actual.add(variable.id.name);
+					else addFinding(findings, file, variable, RULES.scannerApi, "export-surface");
+				}
+			} else if (
+				t.isFunctionDeclaration(declaration) ||
+				t.isClassDeclaration(declaration) ||
+				t.isTSTypeAliasDeclaration(declaration) ||
+				t.isTSInterfaceDeclaration(declaration)
+			) {
+				if (declaration.id) actual.add(declaration.id.name);
+			}
+		}
+		if (statement.specifiers.length > 0) {
+			for (const specifier of statement.specifiers) {
+				addFinding(findings, file, specifier, RULES.scannerApi, "export-surface");
+			}
+		}
+	}
+	if (actual.size !== expected.size || [...expected].some((name) => !actual.has(name))) {
+		addFinding(findings, file, ast.program, RULES.scannerApi, "export-surface");
+	}
+	if (scanDeclaration) {
+		const calls = new Set<string>();
+		const functions = new Map<t.Identifier, t.Function>();
+		const handleBindings = new Set<t.Identifier>();
+		traverse(ast, {
+			FunctionDeclaration(pathNode) {
+				if (pathNode.node.id) {
+					const identity = pathNode.scope.getBinding(pathNode.node.id.name)?.identifier;
+					if (identity) functions.set(identity, pathNode.node);
+				}
+			},
+			VariableDeclarator(pathNode) {
+				if (!t.isIdentifier(pathNode.node.id)) return;
+				const identity = pathNode.scope.getBinding(pathNode.node.id.name)?.identifier;
+				if (identity && directOpenCall(pathNode.node.init, pathNode.scope)) handleBindings.add(identity);
+				if (
+					!t.isArrowFunctionExpression(pathNode.node.init) &&
+					!t.isFunctionExpression(pathNode.node.init)
+				)
+					return;
+				functions.set(identity!, pathNode.node.init);
+			},
+			AssignmentExpression(pathNode) {
+				if (!t.isIdentifier(pathNode.node.left)) return;
+				const identity = pathNode.scope.getBinding(pathNode.node.left.name)?.identifier;
+				if (identity && directOpenCall(pathNode.node.right, pathNode.scope)) handleBindings.add(identity);
+			},
+		});
+		// The graph uses binding identities, not source names. Thus shadowed or
+		// unrelated objects cannot contribute capabilities.
+		let changed = true;
+		while (changed) {
+			changed = false;
+			traverse(ast, {
+				VariableDeclarator(pathNode) {
+					if (!t.isIdentifier(pathNode.node.id)) return;
+					const target = pathNode.scope.getBinding(pathNode.node.id.name)?.identifier;
+					const init = unwrapTransparentExpression(pathNode.node.init);
+					const source = t.isIdentifier(init)
+						? BINDING_IDENTITIES.get(init) ?? pathNode.scope.getBinding(init.name)?.identifier
+						: undefined;
+					if (target && source && handleBindings.has(source) && !handleBindings.has(target)) {
+						handleBindings.add(target);
+						changed = true;
+					}
+				},
+				AssignmentExpression(pathNode) {
+					if (!t.isIdentifier(pathNode.node.left)) return;
+					const target = pathNode.scope.getBinding(pathNode.node.left.name)?.identifier;
+					const right = unwrapTransparentExpression(pathNode.node.right);
+					const source = t.isIdentifier(right)
+						? BINDING_IDENTITIES.get(right) ?? pathNode.scope.getBinding(right.name)?.identifier
+						: undefined;
+					if (target && source && handleBindings.has(source) && !handleBindings.has(target)) {
+						handleBindings.add(target);
+						changed = true;
+					}
+				},
+			});
+		}
+		let scanIdentity: t.Identifier | undefined;
+		traverse(ast, {
+			Program(pathNode) {
+				scanIdentity = pathNode.scope.getBinding("scanWorktrees")?.identifier;
+				pathNode.stop();
+			},
+		});
+		const seen = new Set<t.Node>();
+		type Completion =
+			| "normal"
+			| "return"
+			| "throw"
+			| "break"
+			| "continue"
+			| `break:${string}`
+			| `continue:${string}`;
+		type CompletionSet = Set<Completion>;
+		const normal = (): CompletionSet => new Set<Completion>(["normal"]);
+		const labeledCompletion = (kind: "break" | "continue", label: string): Completion =>
+			`${kind}:${label}`;
+		const statementCompletion = (statement: t.Statement): CompletionSet => {
+			if (t.isReturnStatement(statement)) return new Set(["return"]);
+			if (t.isThrowStatement(statement)) return new Set(["throw"]);
+			if (t.isBreakStatement(statement))
+				return new Set([statement.label ? labeledCompletion("break", statement.label.name) : "break"]);
+			if (t.isContinueStatement(statement))
+				return new Set([statement.label ? labeledCompletion("continue", statement.label.name) : "continue"]);
+			if (t.isBlockStatement(statement)) return blockCompletion(statement.body);
+			if (t.isIfStatement(statement)) {
+				const branches =
+					t.isBooleanLiteral(statement.test) ? (statement.test.value ? [statement.consequent] : statement.alternate ? [statement.alternate] : []) :
+					[statement.consequent, ...(statement.alternate ? [statement.alternate] : [])];
+				if (!branches.length) return normal();
+				const result = new Set<Completion>();
+				for (const branch of branches) for (const completion of statementCompletion(branch)) result.add(completion);
+				if (!statement.alternate && !t.isBooleanLiteral(statement.test, { value: true })) result.add("normal");
+				return result;
+			}
+			if (t.isTryStatement(statement)) {
+				const tryResult = statementCompletion(statement.block);
+				const baseResult = new Set<Completion>();
+				for (const completion of tryResult) {
+					if (completion === "throw" && statement.handler) {
+						for (const caught of statementCompletion(statement.handler.body)) baseResult.add(caught);
+					} else {
+						baseResult.add(completion);
+					}
+				}
+				if (!statement.finalizer) return baseResult;
+				const finalizerResult = statementCompletion(statement.finalizer);
+				if (!finalizerResult.has("normal"))
+					return new Set([...finalizerResult].filter((completion) => completion !== "normal"));
+				const result = new Set<Completion>(baseResult);
+				for (const completion of finalizerResult) if (completion !== "normal") result.add(completion);
+				return result;
+			}
+			const loopBody = (
+				body: t.Statement,
+				test: t.Expression | null,
+				doWhile: boolean,
+				label?: string,
+			): CompletionSet => {
+				if (!doWhile && t.isBooleanLiteral(test, { value: false })) return normal();
+				const bodyResult = statementCompletion(body);
+				const result = new Set<Completion>();
+				if (!doWhile && test !== null && !t.isBooleanLiteral(test, { value: true })) result.add("normal");
+				if (bodyResult.has("return")) result.add("return");
+				if (bodyResult.has("throw")) result.add("throw");
+				if (bodyResult.has("break") || (label && bodyResult.has(labeledCompletion("break", label))))
+					result.add("normal");
+				for (const completion of bodyResult) {
+					if (
+						(completion.startsWith("break:") && completion !== labeledCompletion("break", label ?? "")) ||
+						(completion.startsWith("continue:") && completion !== labeledCompletion("continue", label ?? ""))
+					)
+						result.add(completion);
+				}
+				if (test === null || t.isBooleanLiteral(test, { value: true })) return result;
+				if (
+					bodyResult.has("normal") ||
+					bodyResult.has("continue") ||
+					(label !== undefined && bodyResult.has(labeledCompletion("continue", label)))
+				)
+					result.add("normal");
+				return result;
+			};
+			const labeledLoop = (body: t.Statement, label: string): CompletionSet | undefined => {
+				if (t.isWhileStatement(body)) return loopBody(body.body, body.test, false, label);
+				if (t.isForStatement(body)) return loopBody(body.body, body.test ?? null, false, label);
+				if (t.isDoWhileStatement(body)) return loopBody(body.body, body.test, true, label);
+				return undefined;
+			};
+			if (t.isLabeledStatement(statement)) {
+				const loopResult = labeledLoop(statement.body, statement.label.name);
+				if (loopResult) return loopResult;
+				const result = new Set<Completion>();
+				for (const completion of statementCompletion(statement.body)) {
+					if (completion === labeledCompletion("break", statement.label.name)) result.add("normal");
+					else result.add(completion);
+				}
+				return result;
+			}
+			if (t.isWhileStatement(statement)) return loopBody(statement.body, statement.test, false);
+			if (t.isForStatement(statement)) return loopBody(statement.body, statement.test ?? null, false);
+			if (t.isDoWhileStatement(statement)) return loopBody(statement.body, statement.test, true);
+			return normal();
+		};
+		function blockCompletion(statements: readonly t.Statement[]): CompletionSet {
+			const result = new Set<Completion>();
+			let fallsThrough = true;
+			for (const statement of statements) {
+				if (!fallsThrough) break;
+				const completion = statementCompletion(statement);
+				for (const value of completion) if (value !== "normal") result.add(value);
+				fallsThrough = completion.has("normal");
+			}
+			if (fallsThrough) result.add("normal");
+			return result;
+		}
+		const isDefinitelyDead = (pathNode: NodePath<t.CallExpression>): boolean => {
+			let current: NodePath<t.Node> | null = pathNode;
+			while (current?.parentPath) {
+				const parent: NodePath<t.Node> = current.parentPath;
+				if (parent.isBlockStatement()) {
+					const index = parent.node.body.indexOf(current.node as t.Statement);
+					if (index >= 0 && !blockCompletion(parent.node.body.slice(0, index)).has("normal")) return true;
+				}
+				if (parent.isIfStatement()) {
+					if (parent.node.consequent === current.node && t.isBooleanLiteral(parent.node.test, { value: false })) return true;
+					if (parent.node.alternate === current.node && t.isBooleanLiteral(parent.node.test, { value: true })) return true;
+				}
+				if (parent.isWhileStatement() || parent.isForStatement()) {
+					if (parent.node.body === current.node && t.isBooleanLiteral(parent.node.test, { value: false })) return true;
+				}
+				if (parent.isLogicalExpression() && parent.node.right === current.node) {
+					if ((parent.node.operator === "&&" && t.isBooleanLiteral(parent.node.left, { value: false })) ||
+						(parent.node.operator === "||" && t.isBooleanLiteral(parent.node.left, { value: true }))) return true;
+				}
+				if (parent.isConditionalExpression()) {
+					if (parent.node.consequent === current.node && t.isBooleanLiteral(parent.node.test, { value: false })) return true;
+					if (parent.node.alternate === current.node && t.isBooleanLiteral(parent.node.test, { value: true })) return true;
+				}
+				current = parent;
+			}
+			return false;
+		};
+		const collect = (node: t.Function): void => {
+			if (seen.has(node)) return;
+			seen.add(node);
+			let unsupportedControlFlow = false;
+			traverse(ast, {
+				SwitchStatement(pathNode) {
+					if (pathNode.getFunctionParent()?.node === node) unsupportedControlFlow = true;
+				},
+			});
+			if (unsupportedControlFlow)
+				addFinding(findings, file, node, RULES.scannerApi, "scanner-flow:unsupported-control-flow");
+			traverse(ast, {
+				CallExpression(pathNode) {
+					if (pathNode.getFunctionParent()?.node !== node || isDefinitelyDead(pathNode)) return;
+					const callee = unwrapTransparentExpression(pathNode.node.callee);
+					if (t.isIdentifier(callee)) {
+						const binding = pathNode.scope.getBinding(callee.name)?.identifier;
+						const target = binding ? functions.get(binding) : undefined;
+						if (target) collect(target);
+						const origin = scopedExpressionOrigin(callee, pathNode.scope);
+						if (origin?.source === "node:fs/promises" && ["lstat", "readdir", "open"].includes(origin.name))
+							calls.add(origin.name);
+					} else if (t.isMemberExpression(callee) && !callee.computed && t.isIdentifier(callee.object)) {
+						const origin = scopedExpressionOrigin(callee, pathNode.scope);
+						if (origin?.source === "node:fs/promises" && ["lstat", "readdir", "open"].includes(origin.name))
+							calls.add(origin.name);
+						const object = pathNode.scope.getBinding(callee.object.name)?.identifier;
+						const member = memberName(callee);
+						if (object && handleBindings.has(object) && member && ["stat", "read", "close"].includes(member))
+							calls.add(`handle.${member}`);
+					}
+				},
+			});
+		};
+		if (scanIdentity) {
+			const target = functions.get(scanIdentity);
+			if (target) collect(target);
+		}
+		for (const required of ["lstat", "readdir", "open", "handle.stat", "handle.read", "handle.close"]) {
+			if (!calls.has(required)) addFinding(findings, file, scanDeclaration, RULES.scannerApi, `scanner-flow:${required}`);
+		}
+	}
+	if (hasIdentifierMutation(ast, new Set(["scanWorktrees"])))
+		addFinding(findings, file, scanDeclaration ?? ast.program, RULES.scannerApi, "scanner-binding-mutation");
+}
+
+function localSpecifier(specifier: string): boolean {
+	return specifier.startsWith(".") || specifier.startsWith("/");
+}
+
+interface GraphConfig {
+	aliases: Array<{ pattern: string; target: string }>;
+	error?: string;
+}
+type JsonRecord = { [key: string]: unknown };
+function isRecord(value: unknown): value is JsonRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+async function workspacePathAliases(repoRoot: string): Promise<GraphConfig> {
+	const aliases: Array<{ pattern: string; target: string }> = [];
+	const repoAbsolute = path.resolve(repoRoot);
+	const repoReal = await fs.realpath(repoAbsolute).catch(() => undefined);
+	const readConfig = async (file: string, seen = new Set<string>()): Promise<string> => {
+		const absolute = path.resolve(file);
+		if (seen.has(absolute)) throw new Error("tsconfig-extends-cycle");
+		const nextSeen = new Set(seen).add(absolute);
+		const real = await fs.realpath(absolute).catch(() => undefined);
+		if (!real || !repoReal || (real !== repoReal && !real.startsWith(repoReal + path.sep))) throw new Error("tsconfig-out-of-repo");
+		let raw: string;
+		try {
+			raw = await fs.readFile(real, "utf8");
+		} catch {
+			throw new Error("tsconfig-read");
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			throw new Error("tsconfig-parse");
+		}
+		if (!isRecord(parsed)) throw new Error("invalid-tsconfig");
+		const options = parsed.compilerOptions;
+		if (options !== undefined && !isRecord(options)) throw new Error("invalid-tsconfig-options");
+		const compilerOptions = (options ?? {}) as JsonRecord;
+		let inheritedBase = path.dirname(real);
+		if (parsed.extends !== undefined) {
+			if (typeof parsed.extends !== "string" || !parsed.extends.startsWith(".")) throw new Error("unsupported-tsconfig-extends");
+			inheritedBase = await readConfig(
+				path.resolve(path.dirname(real), parsed.extends.endsWith(".json") ? parsed.extends : `${parsed.extends}.json`),
+				nextSeen,
+			);
+		}
+		const rawBaseUrl = compilerOptions.baseUrl;
+		if (rawBaseUrl !== undefined && typeof rawBaseUrl !== "string") throw new Error("invalid-tsconfig-baseUrl");
+		const base = rawBaseUrl === undefined ? inheritedBase : path.resolve(path.dirname(real), rawBaseUrl);
+		const baseReal = await fs.realpath(base).catch(() => undefined);
+		if (!baseReal || !repoReal || (baseReal !== repoReal && !baseReal.startsWith(repoReal + path.sep))) throw new Error("out-of-repo-baseUrl");
+		const paths = compilerOptions.paths;
+		if (paths !== undefined && !isRecord(paths)) throw new Error("invalid-tsconfig-paths");
+		for (const [pattern, rawTargets] of Object.entries(paths ?? {})) {
+			if (!pattern.includes("*") || !Array.isArray(rawTargets) || rawTargets.length !== 1 || typeof rawTargets[0] !== "string")
+				throw new Error("unsupported-path-alias");
+			const target = rawTargets[0];
+			if (!target.includes("*")) throw new Error("unsupported-path-alias");
+			const targetBase = path.resolve(base, target.replace("*", ""));
+			const targetReal = await fs.realpath(path.dirname(targetBase)).catch(() => undefined);
+			if (!targetReal || (targetReal !== repoReal && !targetReal.startsWith(repoReal + path.sep)))
+				throw new Error("out-of-repo-path-alias");
+			for (let index = aliases.length - 1; index >= 0; index--) if (aliases[index]?.pattern === pattern) aliases.splice(index, 1);
+			aliases.push({ pattern, target: path.resolve(base, target) });
+		}
+		return base;
+	};
+	try {
+		await readConfig(path.join(repoAbsolute, "tsconfig.json"));
+		return { aliases };
+	} catch (error) {
+		const finiteCodes = new Set([
+			"tsconfig-out-of-repo",
+			"tsconfig-extends-cycle",
+			"invalid-tsconfig",
+			"invalid-tsconfig-options",
+			"unsupported-tsconfig-extends",
+			"invalid-tsconfig-baseUrl",
+			"out-of-repo-baseUrl",
+			"invalid-tsconfig-paths",
+			"unsupported-path-alias",
+			"out-of-repo-path-alias",
+			"tsconfig-read",
+			"tsconfig-parse",
+		]);
+		const code = error instanceof Error && finiteCodes.has(error.message) ? error.message : "invalid-tsconfig";
+		return { aliases: [], error: code };
+	}
+}
+async function containedRegularFile(repoRoot: string, relativeOrAbsolute: string): Promise<string | undefined> {
+	const repoReal = await fs.realpath(repoRoot).catch(() => undefined);
+	const candidate = path.isAbsolute(relativeOrAbsolute) ? relativeOrAbsolute : path.resolve(repoRoot, relativeOrAbsolute);
+	const real = await fs.realpath(candidate).catch(() => undefined);
+	if (!repoReal || !real || (real !== repoReal && !real.startsWith(repoReal + path.sep))) return undefined;
+	try {
+		return (await fs.stat(real)).isFile() ? real : undefined;
+	} catch {
+		return undefined;
+	}
+}
+function graphCandidates(base: string): string[] {
+	const extensions = [".ts", ".tsx", ".js", ".jsx"];
+	return [base, ...extensions.map((ext) => `${base}${ext}`), ...extensions.map((ext) => path.join(base, `index${ext}`))];
+}
+async function resolveGraphPaths(repoRoot: string, importer: string, specifier: string, config: GraphConfig): Promise<string[]> {
+	if (specifier.startsWith("node:")) return [];
+	const importerAbsolute = path.resolve(repoRoot, importer);
+	let bases: string[] = [];
+	if (localSpecifier(specifier)) bases = [path.resolve(path.dirname(importerAbsolute), specifier)];
+	else {
+		for (const alias of config.aliases) {
+			const [prefix, suffix] = alias.pattern.split("*");
+			if (specifier.startsWith(prefix) && specifier.endsWith(suffix ?? "")) {
+				const wildcard = specifier.slice(prefix.length, suffix ? -suffix.length : undefined);
+				bases.push(alias.target.replace("*", wildcard));
+			}
+		}
+	}
+	const repoReal = await fs.realpath(repoRoot).catch(() => undefined);
+	if (!repoReal) return [];
+	const safe: string[] = [];
+	let escaped = false;
+	for (const candidate of [...new Set(bases.flatMap((base) => graphCandidates(base)))]) {
+		const real = await fs.realpath(candidate).catch(() => undefined);
+		if (!real) continue;
+		if (real !== repoReal && !real.startsWith(repoReal + path.sep)) {
+			escaped = true;
+			continue;
+		}
+		if ((await fs.stat(real).catch(() => undefined))?.isFile()) safe.push(candidate);
+	}
+	return escaped ? [] : safe;
+}
+
+interface SelectedGraphItem {
+	path: string;
+	exportName: string;
+	role: Role;
+	binding?: BindingDescriptor;
+}
+interface BindingDescriptor {
+	file: string;
+	localName: string;
+	declarationStart: number;
+	valueKind: "function" | "class" | "variable" | "default" | "unknown";
+}
+type ExpectedRoleMap = Map<string, Role>;
+function isTypeOnlyImport(statement: t.ImportDeclaration): boolean {
+	return (
+		statement.importKind === "type" ||
+		(statement.specifiers.length > 0 &&
+			statement.specifiers.every((specifier) => t.isImportSpecifier(specifier) && specifier.importKind === "type"))
+	);
+}
+function isTypeOnlyExport(statement: t.ExportNamedDeclaration | t.ExportAllDeclaration): boolean {
+	if (statement.exportKind === "type") return true;
+	return (
+		t.isExportNamedDeclaration(statement) &&
+		statement.specifiers.length > 0 &&
+		statement.specifiers.every((specifier) => t.isExportSpecifier(specifier) && specifier.exportKind === "type")
+	);
+}
+function validateGraphBridge(
+	ast: t.File,
+	file: string,
+	findings: Finding[],
+	approvedAliases: ReadonlyArray<{ pattern: string; target: string }> = [],
+): void {
+	const approvedAlias = (source: string): boolean =>
+		approvedAliases.some(({ pattern, target }) => {
+			if (target.startsWith("node:")) return false;
+			const [prefix, suffix = ""] = pattern.split("*");
+			return source.startsWith(prefix ?? "") && source.endsWith(suffix);
+		});
+	for (const statement of ast.program.body) {
+		let safe = false;
+		if (t.isImportDeclaration(statement)) {
+			safe = isTypeOnlyImport(statement);
+		} else if (t.isExportNamedDeclaration(statement)) {
+			const source = statement.source?.value;
+			safe =
+				source !== undefined &&
+				!source.startsWith("node:") &&
+				(localSpecifier(source) || approvedAlias(source)) &&
+				statement.specifiers.length > 0 &&
+				statement.specifiers.every(
+					(specifier) =>
+						t.isExportSpecifier(specifier) &&
+						t.isIdentifier(specifier.local) &&
+						t.isIdentifier(specifier.exported) &&
+						specifier.exported.name !== "default" &&
+						specifier.exportKind !== "type",
+				);
+			if (isTypeOnlyExport(statement)) safe = true;
+		} else if (t.isExportAllDeclaration(statement)) {
+			safe = isTypeOnlyExport(statement) || (!statement.source.value.startsWith("node:") && (localSpecifier(statement.source.value) || approvedAlias(statement.source.value)));
+		} else {
+			safe = t.isTSInterfaceDeclaration(statement) || t.isTSTypeAliasDeclaration(statement);
+		}
+		if (!safe) addFinding(findings, file, statement, RULES.unknownBinding, "unsafe-bridge");
+	}
+}
+async function validateReachableGraph(
+	repoRoot: string,
+	cliRoot: string,
+	findings: Finding[],
+): Promise<{ reachable: Set<string>; expectedRoles: ExpectedRoleMap }> {
+	const config = await workspacePathAliases(repoRoot);
+	if (config.error) {
+		findings.push({ path: cliRoot, line: 1, column: 1, rule: RULES.unknownBinding, symbol: "tsconfig:" + config.error });
+		return { reachable: new Set(), expectedRoles: new Map() };
+	}
+	const modules = new Map<string, t.File | null>();
+	const loadErrors = new Set<string>();
+	const load = async (file: string): Promise<t.File | undefined> => {
+		if (modules.has(file)) return modules.get(file) ?? undefined;
+		try {
+			const contained = await containedRegularFile(repoRoot, file);
+			if (!contained) throw new Error("module-realpath-escape");
+			const source = await fs.readFile(contained, "utf8");
+			const ast = parseSource(source);
+			if (!ast) {
+				modules.set(file, null);
+				if (!loadErrors.has(file)) {
+					loadErrors.add(file);
+					findings.push({ path: file, line: 1, column: 1, rule: RULES.unknownBinding, symbol: "parse" });
+				}
+				return undefined;
+			}
+			modules.set(file, ast);
+			return ast;
+		} catch {
+			modules.set(file, null);
+			if (!loadErrors.has(file)) {
+				loadErrors.add(file);
+				findings.push({ path: file, line: 1, column: 1, rule: RULES.unknownBinding, symbol: "read-error" });
+			}
+			return undefined;
+		}
+	};
+	const resolve = async (importer: string, specifier: string, node: t.Node): Promise<string | undefined> => {
+		if (specifier.startsWith("node:")) return undefined;
+		const candidates = await resolveGraphPaths(repoRoot, importer, specifier, config);
+		if (candidates.length !== 1) {
+			addFinding(findings, importer, node, RULES.unknownBinding, candidates.length ? `ambiguous-edge:${specifier}` : `unresolved-edge:${specifier}`);
+			return undefined;
+		}
+		return path.relative(repoRoot, candidates[0]!).split(path.sep).join("/");
+	};
+	const exportedBinding = async (file: string, name: string, seen = new Set<string>()): Promise<BindingDescriptor[]> => {
+		const key = `${file}\0${name}`;
+		if (seen.has(key)) return [];
+		seen.add(key);
+		const ast = await load(file);
+		if (!ast) return [];
+		resolutionVisited.add(file);
+		const candidates = new Map<string, BindingDescriptor>();
+		const addCandidate = (candidate: BindingDescriptor): void => {
+			candidates.set(`${candidate.file}\0${candidate.declarationStart}\0${candidate.localName}`, candidate);
+		};
+		for (const statement of ast.program.body) {
+			const declaration = t.isExportNamedDeclaration(statement) ? statement.declaration : statement;
+			if (t.isExportNamedDeclaration(statement) && statement.source) {
+				if (isTypeOnlyExport(statement)) {
+					if (statement.specifiers.some((specifier) => t.isExportSpecifier(specifier) && t.isIdentifier(specifier.exported) && specifier.exported.name === name))
+						addFinding(findings, file, statement, RULES.unknownBinding, "type-only-selection");
+					continue;
+				}
+				const specifier = statement.specifiers.find(
+					(item) => t.isExportSpecifier(item) && t.isIdentifier(item.exported) && item.exported.name === name,
+				);
+				if (specifier && t.isExportSpecifier(specifier)) {
+					if (specifier.exportKind === "type") {
+						addFinding(findings, file, statement, RULES.unknownBinding, "type-only-selection");
+						continue;
+					}
+					const target = await resolve(file, statement.source.value, statement);
+					for (const result of target ? await exportedBinding(target, t.isIdentifier(specifier.local) ? specifier.local.name : name, seen) : [])
+						addCandidate(result);
+				}
+			}
+			if (t.isExportAllDeclaration(statement)) {
+				if (isTypeOnlyExport(statement)) {
+					continue;
+				}
+				const target = await resolve(file, statement.source.value, statement);
+				for (const result of target ? await exportedBinding(target, name, new Set(seen)) : []) addCandidate(result);
+			}
+			if (t.isExportNamedDeclaration(statement) && !statement.source && statement.specifiers.length) {
+				const specifier = statement.specifiers.find(
+					(item) => t.isExportSpecifier(item) && t.isIdentifier(item.exported) && item.exported.name === name,
+				);
+				if (specifier && t.isExportSpecifier(specifier)) {
+					if (specifier.exportKind === "type") {
+						addFinding(findings, file, statement, RULES.unknownBinding, "type-only-selection");
+						continue;
+					}
+					if (isTypeOnlyExport(statement)) {
+						addFinding(findings, file, statement, RULES.unknownBinding, "type-only-selection");
+						continue;
+					}
+					const localName = t.isIdentifier(specifier.local) ? specifier.local.name : undefined;
+					const localDeclaration = localName
+						? ast.program.body.find((candidate) => {
+								const declaration = t.isExportNamedDeclaration(candidate) ? candidate.declaration : candidate;
+								return (
+									(t.isFunctionDeclaration(declaration) || t.isClassDeclaration(declaration)) &&
+									declaration.id?.name === localName
+								) || (t.isVariableDeclaration(declaration) &&
+									declaration.declarations.some((item) => t.isIdentifier(item.id, { name: localName })));
+							})
+						: undefined;
+					if (localDeclaration && localName) {
+						const declaration = t.isExportNamedDeclaration(localDeclaration) ? localDeclaration.declaration : localDeclaration;
+						addCandidate({
+							file,
+							localName,
+							declarationStart: declaration?.start ?? localDeclaration.start ?? 0,
+							valueKind: t.isFunctionDeclaration(declaration) ? "function" : t.isClassDeclaration(declaration) ? "class" : "variable",
+						});
+						continue;
+					}
+					const imported = ast.program.body.find(
+						(item): item is t.ImportDeclaration =>
+							t.isImportDeclaration(item) && item.specifiers.some((s) => t.isIdentifier(s.local, { name: specifier.local.name })),
+					);
+					if (imported) {
+						const local = imported.specifiers.find((s) => t.isIdentifier(s.local, { name: specifier.local.name }));
+						const target = await resolve(file, imported.source.value, imported);
+						const selected = local && t.isImportSpecifier(local) ? importedName(local) : local && t.isImportDefaultSpecifier(local) ? "default" : "namespace";
+						if (isTypeOnlyImport(imported) || (local && "importKind" in local && local.importKind === "type") || selected === "namespace") {
+							addFinding(findings, file, statement, RULES.unknownBinding, selected === "namespace" ? "namespace-selection" : "type-only-selection");
+						} else {
+							for (const result of target ? await exportedBinding(target, selected, new Set(seen)) : []) addCandidate(result);
+						}
+					} else addCandidate({ file, localName: specifier.local.name, declarationStart: statement.start ?? 0, valueKind: "unknown" });
+				}
+			}
+			if (
+				t.isExportNamedDeclaration(statement) &&
+				((t.isFunctionDeclaration(declaration) || t.isClassDeclaration(declaration)) && declaration.id?.name === name ||
+					t.isVariableDeclaration(declaration) && declaration.declarations.some((item) => t.isIdentifier(item.id, { name })))
+			)
+				addCandidate({
+					file,
+					localName: name,
+					declarationStart: declaration.start ?? statement.start ?? 0,
+					valueKind: t.isFunctionDeclaration(declaration) ? "function" : t.isClassDeclaration(declaration) ? "class" : "variable",
+				});
+		}
+		if (name === "default" && ast.program.body.some((statement) => t.isExportDefaultDeclaration(statement)))
+			addCandidate({ file, localName: "default", declarationStart: ast.program.body.find((statement) => t.isExportDefaultDeclaration(statement))?.start ?? 0, valueKind: "default" });
+		return [...candidates.values()];
+	};
+	const queue: SelectedGraphItem[] = [{ path: cliRoot, exportName: "commands", role: "cli" }];
+	const expectedRoles: ExpectedRoleMap = new Map([[cliRoot, "cli"]]);
+	const enqueue = (item: SelectedGraphItem): void => {
+		const prior = expectedRoles.get(item.path);
+		if (prior && prior !== item.role) {
+			addFinding(findings, item.path, { type: "Program", loc: undefined } as t.Node, RULES.unknownBinding, `conflicting-role:${prior},${item.role}`);
+			return;
+		}
+		expectedRoles.set(item.path, item.role);
+		queue.push(item);
+	};
+	const seenItems = new Set<string>();
+	const resolutionVisited = new Set<string>();
+	const reachable = new Set<string>();
+	while (queue.length) {
+		const item = queue.shift()!;
+		const key = `${item.path}\0${item.exportName}\0${item.role}`;
+		if (seenItems.has(key)) continue;
+		seenItems.add(key);
+		const ast = await load(item.path);
+		if (!ast) {
+			if (!loadErrors.has(item.path)) addFinding(findings, item.path, { type: "Program", loc: undefined } as t.Node, RULES.unknownBinding, "unresolved-root");
+			continue;
+		}
+		if (item.binding) {
+			const exact = ast.program.body.some((statement) => {
+				const declaration = t.isExportNamedDeclaration(statement) ? statement.declaration : undefined;
+				if (!declaration || (declaration.start ?? -1) !== item.binding!.declarationStart) return false;
+				if (t.isFunctionDeclaration(declaration) || t.isClassDeclaration(declaration))
+					return declaration.id?.name === item.binding!.localName &&
+						item.binding!.valueKind === (t.isFunctionDeclaration(declaration) ? "function" : "class");
+				if (t.isVariableDeclaration(declaration))
+					return declaration.declarations.length === 1 &&
+						t.isIdentifier(declaration.declarations[0]?.id, { name: item.binding!.localName }) &&
+						item.binding!.valueKind === "variable";
+				return false;
+			});
+			if (!exact) {
+				addFinding(findings, item.path, ast.program, RULES.unknownBinding, "selected-binding-mismatch");
+				continue;
+			}
+		}
+		reachable.add(item.path);
+		if (item.role === "cli") {
+			const edges: t.CallExpression[] = [];
+			traverse(ast, { CallExpression(p) { if (staticImportSource(p.node) === "./commands/worktree") edges.push(p.node); } });
+			if (edges.length !== 1) addFinding(findings, item.path, ast.program, RULES.registryEdge, `selected-edge-count:${edges.length}`);
+			if (edges.length === 1) {
+				const target = await resolve(item.path, "./commands/worktree", edges[0]!);
+				const targets = target ? await exportedBinding(target, "createWorktreeCommand") : [];
+
+				if (targets.length === 1) enqueue({ path: targets[0]!.file, exportName: "createWorktreeCommand", role: "command", binding: targets[0]! });
+				else addFinding(findings, item.path, edges[0]!, RULES.registryEdge, "selected-command-ambiguous");
+			}
+		} else if (item.role === "command" || item.role === "worker") {
+			const specifier = item.role === "command" ? "../cli/worktree-cli" : "./worktree-scanner";
+			const name = item.role === "command" ? "runWorktreeCommand" : "scanWorktrees";
+			const target = await resolve(item.path, specifier, ast.program);
+			const targets = target ? await exportedBinding(target, name) : [];
+			if (targets.length === 1) enqueue({ path: targets[0]!.file, exportName: name, role: item.role === "command" ? "worker" : "scanner", binding: targets[0]! });
+			else addFinding(findings, item.path, ast.program, RULES.workerEdge, `selected-${name}-ambiguous`);
+		}
+	}
+	for (const role of ["cli", "command", "worker", "scanner"] as Role[]) {
+		const count = [...seenItems].filter((item) => item.endsWith(`\0${role}`)).length;
+		if (count !== 1) findings.push({ path: cliRoot, line: 1, column: 1, rule: RULES.workerEdge, symbol: `reachable-${role}:${count}` });
+	}
+	for (const file of resolutionVisited) {
+		if (expectedRoles.has(file)) continue;
+		const ast = await load(file);
+		if (!ast) continue;
+		validateGraphBridge(ast, file, findings, config.aliases);
+		for (const statement of ast.program.body) {
+			if (
+				(t.isImportDeclaration(statement) && isTypeOnlyImport(statement)) ||
+				((t.isExportNamedDeclaration(statement) || t.isExportAllDeclaration(statement)) && isTypeOnlyExport(statement))
+			)
+				continue;
+			const source =
+				t.isImportDeclaration(statement) || t.isExportNamedDeclaration(statement) || t.isExportAllDeclaration(statement)
+					? statement.source?.value
+					: undefined;
+			if (!source || source.startsWith("node:")) continue;
+			const target = await resolve(file, source, statement);
+			if (target) {
+				resolutionVisited.add(target);
+				await load(target);
+			} else {
+				addFinding(findings, file, statement, RULES.unknownBinding, `unresolved-edge:${source}`);
+			}
+		}
+	}
+	return { reachable, expectedRoles };
+}
+export function sortFindings(findings: readonly Finding[]): Finding[] {
+	const unique = new Map<string, Finding>();
+	for (const finding of findings) {
+		unique.set(`${finding.path}\0${finding.line}\0${finding.column}\0${finding.rule}\0${finding.symbol}`, finding);
+	}
+	return [...unique.values()].sort(
+		(a, b) =>
+			compareText(a.path, b.path) ||
+			a.line - b.line ||
+			a.column - b.column ||
+			compareText(a.rule, b.rule) ||
+			compareText(a.symbol, b.symbol),
+	);
+}
+
+function compareText(a: string, b: string): number {
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export function formatFinding(finding: Finding): string {
+	return `${finding.path}:${finding.line}:${finding.column} ${finding.rule} ${finding.symbol}`;
+}
+
+export function analyzeSource(source: string, relativePath: string): Finding[] {
+	return analyzeSourceWithRole(source, relativePath);
+}
+function analyzeSourceWithRole(source: string, relativePath: string, roleOverride?: Role): Finding[] {
+	const ast = parseSource(source);
+	if (!ast) {
+		return [
+			{
+				path: relativePath,
+				line: 1,
+				column: 1,
+				rule: RULES.unknownBinding,
+				symbol: "parse",
+			},
+		];
+	}
+	const role = roleOverride ?? roleFor(relativePath);
+	const findings: Finding[] = [];
+	validateImports(ast, relativePath, role, findings);
+	validateDynamicImports(ast, relativePath, role, findings);
+	validateCapabilities(ast, relativePath, role, findings);
+	if (role === "scanner" && relativePath === "packages/coding-agent/src/cli/worktree-scanner.ts")
+		validateScannerExportSurface(ast, relativePath, findings);
+	if (role === "cli") validateRegistry(ast, relativePath, findings);
+	if (role === "command") validateCommandFlow(ast, relativePath, findings);
+	if (role === "worker") validateWorkerFlow(ast, relativePath, findings);
+	return sortFindings(findings);
+}
+
+export async function verifyWorktreeReportCapabilities(options: VerifyOptions = {}): Promise<Finding[]> {
+	const repoRoot = path.resolve(options.repoRoot ?? path.join(import.meta.dir, ".."));
+	const requestedRoots = options.roots ?? [];
+	const isolatedGraphRoot = options.graphRoot;
+	const roots = isolatedGraphRoot ? [isolatedGraphRoot] : [...DEFAULT_ROOTS];
+	const findings: Finding[] = [];
+	const seenRequested = new Set<string>(roots.map((root) => path.resolve(repoRoot, root)));
+	for (const root of requestedRoots) {
+		const canonical = root.split("/").join("/");
+		const segments = canonical.split("/");
+		const valid =
+			canonical.length > 0 &&
+			canonical === path.posix.normalize(canonical) &&
+			!canonical.startsWith("/") &&
+			!canonical.includes("\\") &&
+			!segments.includes(".") &&
+			!segments.includes("..") &&
+			!path.posix.isAbsolute(canonical);
+		const absolute = path.resolve(repoRoot, canonical);
+		if (!valid || seenRequested.has(absolute)) {
+			findings.push({
+				path: root,
+				line: 1,
+				column: 1,
+				rule: RULES.unknownBinding,
+				symbol: seenRequested.has(absolute) ? "duplicate-root" : "invalid-replacement-root",
+			});
+			continue;
+		}
+		seenRequested.add(absolute);
+		roots.push(canonical);
+	}
+	const cliRoot = isolatedGraphRoot ?? DEFAULT_ROOTS[0]!;
+	const repoReal = await fs.realpath(repoRoot).catch(() => undefined);
+	const cliReal = await fs.realpath(path.resolve(repoRoot, cliRoot)).catch(() => undefined);
+	if (!repoReal || !cliReal || !(cliReal === repoReal || cliReal.startsWith(repoReal + path.sep))) {
+		findings.push({ path: cliRoot, line: 1, column: 1, rule: RULES.unknownBinding, symbol: "root-realpath-escape" });
+	}
+	const { reachable, expectedRoles } = await validateReachableGraph(repoRoot, cliRoot, findings);
+	for (const root of roots) {
+		if (root !== cliRoot && reachable.has(root)) continue;
+		const absolute = await containedRegularFile(repoRoot, root);
+		if (!absolute) {
+			findings.push({ path: root, line: 1, column: 1, rule: RULES.unknownBinding, symbol: "unresolved-root" });
+			continue;
+		}
+		let source: string;
+		try {
+			source = await fs.readFile(absolute, "utf8");
+		} catch {
+			findings.push({ path: root, line: 1, column: 1, rule: RULES.unknownBinding, symbol: "unresolved-root" });
+			continue;
+		}
+		findings.push(...analyzeSourceWithRole(source, root.replaceAll(path.sep, "/"), expectedRoles.get(root)));
+	}
+	for (const root of reachable) {
+		const absolute = await containedRegularFile(repoRoot, root);
+		if (!absolute) {
+			findings.push({ path: root, line: 1, column: 1, rule: RULES.unknownBinding, symbol: "unresolved-root" });
+			continue;
+		}
+		let source: string;
+		try {
+			source = await fs.readFile(absolute, "utf8");
+		} catch {
+			findings.push({ path: root, line: 1, column: 1, rule: RULES.unknownBinding, symbol: "read-error" });
+			continue;
+		}
+		findings.push(...analyzeSourceWithRole(source, root, expectedRoles.get(root)));
+	}
+	return sortFindings(findings);
+}
+
+export interface MainOptions {
+	verify?: () => Promise<Finding[]>;
+	write?: (text: string) => unknown;
+}
+
+export async function main(_argv: readonly string[] = process.argv, options: MainOptions = {}): Promise<number> {
+	const findings = await (options.verify ?? verifyWorktreeReportCapabilities)();
+	const write = options.write ?? ((text: string) => process.stderr.write(text));
+	for (const finding of findings) write(`${formatFinding(finding)}\n`);
+	return findings.length === 0 ? 0 : 1;
+}
+
+if (import.meta.main) process.exitCode = await main();

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -918,7 +918,7 @@ process.stdout.write(${JSON.stringify(output)});
 					`${mode}:${focusedPath}`,
 				).toBe(true);
 				if (focusedPath.startsWith("packages/coding-agent/"))
-					expect(entries.find((entry) => entry.key === "check:coding-agent")?.command).toEqual(["bun", "run", "check"]);
+					expect(entries.find((entry) => entry.key === "check:coding-agent")?.command).toEqual(["bun", "run", "check:types"]);
 				expect(entries.some((entry) => entry.key === "lint:coding-agent")).toBe(false);
 				const output = await Bun.file(outputFile).text();
 				expect(output).toContain("worktree_safety_required=true");

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -2,7 +2,27 @@ import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describeTasks, expandWithDependents, loadBuildInventory, normalizeChangedPaths, packageScriptCommand, planTargetedTasks, planTasks, requiresCargoWorkspaceEmergency, resolvePackageCwd, runCommand, validateAffectedAggregate, type AffectedAggregateResults, type CargoInventoryUnit, type WorkspacePackage } from "./ci-dev-affected";
+import {
+	describeTasks,
+	expandWithDependents,
+	hasWorktreeSafetyChange,
+	isFocusedWorktreeOnly,
+	loadBuildInventory,
+	normalizeChangedPaths,
+	normalizeTaskCwdSeparators,
+	packageScriptCommand,
+	planFocusedWorktreeTasks,
+	planTargetedTasks,
+	planTasks,
+	requiresCargoWorkspaceEmergency,
+	resolvePackageCwd,
+	runCommand,
+	validateAffectedAggregate,
+	validateCanonicalWorktreeSafetyRequirement,
+	type AffectedAggregateResults,
+	type CargoInventoryUnit,
+	type WorkspacePackage,
+} from "./ci-dev-affected";
 
 // Matrix planning validates live workspace and Cargo manifests in subprocesses.
 // Hosted runners can need more than Bun's 5s default during their first cold scan.
@@ -26,15 +46,14 @@ describe("planTasks command shape (issue #622)", () => {
 		expect(tasks.length).toBeGreaterThan(0);
 		for (const task of tasks) {
 			expect(task.command).not.toContain("--cwd");
-			expect(task.command.some(arg => arg.startsWith("--cwd"))).toBe(false);
+			expect(task.command.some((arg) => arg.startsWith("--cwd"))).toBe(false);
 		}
 	});
 
-
 	test("package check/test tasks run `bun run <script>` in the package cwd", () => {
 		const tasks = planForPaths(["packages/example/src/index.ts"]);
-		const check = tasks.find(task => task.key === "check:@gajae-code/example");
-		const runTest = tasks.find(task => task.key === "test:@gajae-code/example");
+		const check = tasks.find((task) => task.key === "check:@gajae-code/example");
+		const runTest = tasks.find((task) => task.key === "test:@gajae-code/example");
 		expect(check).toBeDefined();
 		expect(runTest).toBeDefined();
 		expect(check?.command).toEqual(["bun", "run", "check"]);
@@ -42,27 +61,28 @@ describe("planTasks command shape (issue #622)", () => {
 		expect(check?.cwd).toBe(resolvePackageCwd("packages/example"));
 		expect(runTest?.cwd).toBe(resolvePackageCwd("packages/example"));
 	});
-
 });
 
 describe("dev-ci canonical-plan workflow contract", () => {
 	test("pins independent no-shard and multi-shard detached-document byte oracles", () => {
-		const noShardManifest = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"planMode\":\"pr\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"},\"aggregateResults\":{\"plan\":\"success\",\"native\":\"skipped\",\"shards\":\"skipped\",\"windowsDoctor\":\"skipped\",\"windowsDoctorRequired\":\"false\",\"hasNative\":\"false\",\"hasTasks\":\"false\"},\"taskIdentities\":[],\"childEvidence\":[{\"name\":\".ci-dev-affected-plan.json\",\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}]}\n";
-		const multiShardManifest = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"planMode\":\"push\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"},\"aggregateResults\":{\"plan\":\"success\",\"native\":\"success\",\"shards\":\"success\",\"windowsDoctor\":\"success\",\"windowsDoctorRequired\":\"true\",\"hasNative\":\"true\",\"hasTasks\":\"true\"},\"taskIdentities\":[{\"key\":\"one\",\"identity\":\"id-one\"},{\"key\":\"two\",\"identity\":\"id-two\"}],\"childEvidence\":[{\"name\":\".ci-dev-affected-plan.json\",\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},{\"name\":\".ci-dev-shard-receipts/0.json\",\"sha256\":\"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"},{\"name\":\".ci-dev-shard-receipts/1.json\",\"sha256\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}]}\n";
-		const noShardReceipt = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"manifestSha256\":\"588c6fef9fe2fd488a5f511c7e02e620c6c55a165d10997fa2d9aad24f5db746\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"}}\n";
-		const multiShardReceipt = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"manifestSha256\":\"276923dd0acb537de815b14eab377a2740224a4063679738cfd3bbae87324ba6\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"}}\n";
+		const noShardManifest = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"planMode\":\"pr\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"},\"aggregateResults\":{\"plan\":\"success\",\"native\":\"skipped\",\"shards\":\"skipped\",\"windowsDoctor\":\"skipped\",\"windowsDoctorRequired\":\"false\",\"worktreeSafety\":\"skipped\",\"worktreeSafetyRequired\":\"false\",\"hasNative\":\"false\",\"hasTasks\":\"false\"},\"taskIdentities\":[],\"childEvidence\":[{\"name\":\".ci-dev-affected-plan.json\",\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}]}\n";
+		const multiShardManifest = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"planMode\":\"push\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"},\"aggregateResults\":{\"plan\":\"success\",\"native\":\"success\",\"shards\":\"success\",\"windowsDoctor\":\"success\",\"windowsDoctorRequired\":\"true\",\"worktreeSafety\":\"success\",\"worktreeSafetyRequired\":\"true\",\"hasNative\":\"true\",\"hasTasks\":\"true\"},\"taskIdentities\":[{\"key\":\"one\",\"identity\":\"id-one\"},{\"key\":\"two\",\"identity\":\"id-two\"}],\"childEvidence\":[{\"name\":\".ci-dev-affected-plan.json\",\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},{\"name\":\".ci-dev-shard-receipts/0.json\",\"sha256\":\"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"},{\"name\":\".ci-dev-shard-receipts/1.json\",\"sha256\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}]}\n";
+		const noShardReceipt = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"manifestSha256\":\"26d9210f873dd0d4dffdfa54d904ed106e1bbf055da8f74ef04818c7859e7dfd\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"}}\n";
+		const multiShardReceipt = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"manifestSha256\":\"7c0abfa3dcda96c4d50e582c07cf551b08785a6deccc52b31ac33a96160035f1\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"}}\n";
 		const hash = (value: string) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
-		expect(hash(noShardManifest)).toBe("588c6fef9fe2fd488a5f511c7e02e620c6c55a165d10997fa2d9aad24f5db746");
-		expect(hash(multiShardManifest)).toBe("276923dd0acb537de815b14eab377a2740224a4063679738cfd3bbae87324ba6");
-		expect(hash(noShardReceipt)).toBe("39f209e20824bec9839b6e9ffa8ce6a5f894b4190e80061c1635c46a645faa56");
-		expect(hash(multiShardReceipt)).toBe("0d939ebfb8e87300b3c8433e2a7e4499072f89f28fee1b3b164156b554d08eda");
+		expect(hash(noShardManifest)).toBe("26d9210f873dd0d4dffdfa54d904ed106e1bbf055da8f74ef04818c7859e7dfd");
+		expect(hash(multiShardManifest)).toBe("7c0abfa3dcda96c4d50e582c07cf551b08785a6deccc52b31ac33a96160035f1");
+		expect(hash(noShardReceipt)).toBe("2f1b1b5fa0bd5d9d548d7e250c2c30ae34f2d2977dc592003dc69a6275688a8b");
+		expect(hash(multiShardReceipt)).toBe("920294ff0d3b7fd6d92875f736979ad921eacb2a11492f60c2b759d72bb0a94b");
 	});
 	test("uses a detached finalized evidence producer and artifact-ID consumer", async () => {
 		const workflow = await Bun.file(path.join(import.meta.dir, "..", ".github", "workflows", "dev-ci.yml")).text();
 		expect(workflow).toContain("affected-evidence-producer:");
 		expect(workflow).toContain("name: Affected path validation / evidence producer");
 		expect(workflow).toContain("  affected:\n    name: Affected path validation\n    if: ${{ always() }}");
-		expect(workflow).toContain("needs: [affected-evidence-producer, affected-plan, affected-native, affected-shards, windows-dev-doctor]");
+		expect(workflow).toContain(
+			"needs: [affected-evidence-producer, affected-plan, affected-native, affected-shards, windows-dev-doctor, worktree-safety]",
+		);
 		expect(workflow).toContain("artifact_id: ${{ steps.upload-evidence.outputs.artifact-id }}");
 		expect(workflow).toContain("artifact_digest: ${{ steps.upload-evidence.outputs.artifact-digest }}");
 		expect(workflow).toContain("artifact-ids: ${{ needs.affected-evidence-producer.outputs.artifact_id }}");
@@ -97,24 +117,74 @@ describe("dev-ci canonical-plan workflow contract", () => {
 		expect(protectedJob.slice(preparationStart, preparationEnd)).toContain("CI_DEV_EVIDENCE_ROOT: ${{ runner.temp }}/ci-dev-affected-evidence");
 		expect(protectedJob.slice(validationStart)).toContain("CI_DEV_EVIDENCE_ROOT: ${{ runner.temp }}/ci-dev-affected-evidence");
 	});
+	test("runs focused worktree safety on macOS and Windows and binds it into finalized evidence", async () => {
+		const workflow = await Bun.file(path.join(import.meta.dir, "..", ".github", "workflows", "dev-ci.yml")).text();
+		const safetyJob = workflow.slice(
+			workflow.indexOf("  worktree-safety:\n"),
+			workflow.indexOf("  windows-dev-doctor:\n"),
+		);
+		expect(safetyJob).toContain("name: Worktree safety / ${{ matrix.os }}");
+		expect(safetyJob).toContain("os: [macos-14, windows-latest]");
+		expect(safetyJob).toContain("if: ${{ needs.affected-plan.outputs.worktree_safety_required == 'true' }}");
+		for (const step of [
+			"run: bun install --frozen-lockfile",
+			"run: bun scripts/ci-dev-affected.ts --validate-plan",
+			"run: bun test packages/coding-agent/test/worktree-cli.test.ts",
+			"run: bun test scripts/check-worktree-report-capabilities.test.ts",
+			"run: bun scripts/check-worktree-report-capabilities.ts",
+			"run: bun run check",
+		])
+			expect(safetyJob, step).toContain(step);
+		for (const forbidden of ["dtolnay/rust-toolchain", "cargo ", "packages/natives", "--native-build"])
+			expect(safetyJob, forbidden).not.toContain(forbidden);
+		const producerJob = workflow.slice(
+			workflow.indexOf("  affected-evidence-producer:\n"),
+			workflow.indexOf("\n  affected:\n"),
+		);
+		const consumerJob = workflow.slice(workflow.indexOf("  affected:\n"), workflow.indexOf("\n  gjc-state-gates-matrix:"));
+		for (const job of [producerJob, consumerJob]) {
+			expect(job).toContain("CI_DEV_WORKTREE_SAFETY_RESULT: ${{ needs.worktree-safety.result }}");
+			expect(job).toContain(
+				"CI_DEV_WORKTREE_SAFETY_REQUIRED: ${{ needs.affected-plan.outputs.worktree_safety_required }}",
+			);
+		}
+	});
 
 	describe("detached evidence subprocess contract", () => {
 		const scriptPath = path.join(import.meta.dir, "ci-dev-affected.ts");
 		const repoRoot = path.join(import.meta.dir, "..");
 		const sourceSha = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repoRoot }).stdout.toString().trim();
-		const baseAggregate = { plan: "success", native: "skipped", shards: "skipped", windowsDoctor: "skipped", windowsDoctorRequired: "false", hasNative: "false", hasTasks: "false" };
+		const baseAggregate = {
+			plan: "success",
+			native: "skipped",
+			shards: "skipped",
+			windowsDoctor: "skipped",
+			windowsDoctorRequired: "false",
+			worktreeSafety: "skipped",
+			worktreeSafetyRequired: "false",
+			hasNative: "false",
+			hasTasks: "false",
+		};
 		type EvidenceFixture = { root: string; env: Record<string, string>; plan: string; digest: string };
 
 		async function fixture(tasks: unknown[] = []): Promise<EvidenceFixture> {
 			const root = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-evidence-"));
-			const plan = JSON.stringify({ schemaVersion: 1, sourceSha, mode: "pr", paths: [], tasks });
+			const plan = JSON.stringify({
+				schemaVersion: 1,
+				sourceSha,
+				mode: "pr",
+				paths: [],
+				worktreeSafetyRequired: false,
+				tasks,
+			});
 			const digest = new Bun.CryptoHasher("sha256").update(plan).digest("hex");
 			await fs.writeFile(path.join(root, ".ci-dev-affected-plan.json"), plan);
 			const env: Record<string, string> = {
 				CI_DEV_EVIDENCE_ROOT: root, CI_DEV_AFFECTED_PLAN: path.join(root, ".ci-dev-affected-plan.json"), CI_DEV_PLAN_SOURCE_SHA: sourceSha,
 				CI_DEV_SOURCE_SHA: sourceSha, CI_DEV_PLAN_DIGEST: digest, CI_DEV_PLAN_MODE: "pr", GITHUB_REPOSITORY: "owner/repo", GITHUB_WORKFLOW: "Dev CI", GITHUB_RUN_ID: "42",
 				CI_DEV_PLAN_RESULT: baseAggregate.plan, CI_DEV_NATIVE_RESULT: baseAggregate.native, CI_DEV_SHARDS_RESULT: baseAggregate.shards, CI_DEV_WINDOWS_DOCTOR_RESULT: baseAggregate.windowsDoctor,
-				CI_DEV_WINDOWS_DOCTOR_REQUIRED: baseAggregate.windowsDoctorRequired, CI_DEV_HAS_NATIVE: baseAggregate.hasNative, CI_DEV_HAS_TASKS: baseAggregate.hasTasks,
+				CI_DEV_WINDOWS_DOCTOR_REQUIRED: baseAggregate.windowsDoctorRequired, CI_DEV_WORKTREE_SAFETY_RESULT: baseAggregate.worktreeSafety,
+				CI_DEV_WORKTREE_SAFETY_REQUIRED: baseAggregate.worktreeSafetyRequired, CI_DEV_HAS_NATIVE: baseAggregate.hasNative, CI_DEV_HAS_TASKS: baseAggregate.hasTasks,
 			};
 			return { root, env, plan, digest };
 		}
@@ -254,6 +324,20 @@ describe("dev-ci canonical-plan workflow contract", () => {
 				expect((await invoke({ ...env, CI_DEV_HAS_TASKS: "false", CI_DEV_SHARDS_RESULT: "skipped" }, "--write-affected-evidence")).exitCode).toBe(1);
 			}, [regularTask]);
 		});
+		test("rejects worktree safety evidence that disagrees with the canonical plan", async () => {
+			await withFixture(async ({ env }) => {
+				const result = await invoke(
+					{
+						...env,
+						CI_DEV_WORKTREE_SAFETY_RESULT: "success",
+						CI_DEV_WORKTREE_SAFETY_REQUIRED: "true",
+					},
+					"--write-affected-evidence",
+				);
+				expect(result.exitCode).toBe(1);
+				expect(result.stderr).toContain("worktree safety flag does not match canonical plan");
+			});
+		});
 
 		test("rejects unknown nested schemas, pair swaps, and receipt-side disagreement", async () => {
 			await withFixture(async ({ root, env }) => {
@@ -292,10 +376,50 @@ describe("dev-ci canonical-plan workflow contract", () => {
 
 	test("aggregate result truth table rejects every missing, failed, cancelled, and unplanned dependency", () => {
 		const valid: AffectedAggregateResults[] = [
-			{ plan: "success", native: "success", shards: "success", windowsDoctor: "success", windowsDoctorRequired: "true", hasNative: "true", hasTasks: "true" },
-			{ plan: "success", native: "skipped", shards: "skipped", windowsDoctor: "skipped", windowsDoctorRequired: "false", hasNative: "false", hasTasks: "false" },
-			{ plan: "success", native: "success", shards: "skipped", windowsDoctor: "skipped", windowsDoctorRequired: "false", hasNative: "true", hasTasks: "false" },
-			{ plan: "success", native: "skipped", shards: "success", windowsDoctor: "success", windowsDoctorRequired: "true", hasNative: "false", hasTasks: "true" },
+			{
+				plan: "success",
+				native: "success",
+				shards: "success",
+				windowsDoctor: "success",
+				windowsDoctorRequired: "true",
+				worktreeSafety: "success",
+				worktreeSafetyRequired: "true",
+				hasNative: "true",
+				hasTasks: "true",
+			},
+			{
+				plan: "success",
+				native: "skipped",
+				shards: "skipped",
+				windowsDoctor: "skipped",
+				windowsDoctorRequired: "false",
+				worktreeSafety: "skipped",
+				worktreeSafetyRequired: "false",
+				hasNative: "false",
+				hasTasks: "false",
+			},
+			{
+				plan: "success",
+				native: "success",
+				shards: "skipped",
+				windowsDoctor: "skipped",
+				windowsDoctorRequired: "false",
+				worktreeSafety: "skipped",
+				worktreeSafetyRequired: "false",
+				hasNative: "true",
+				hasTasks: "false",
+			},
+			{
+				plan: "success",
+				native: "skipped",
+				shards: "success",
+				windowsDoctor: "success",
+				windowsDoctorRequired: "true",
+				worktreeSafety: "success",
+				worktreeSafetyRequired: "true",
+				hasNative: "false",
+				hasTasks: "true",
+			},
 		];
 		for (const results of valid) expect(() => validateAffectedAggregate(results)).not.toThrow();
 
@@ -310,6 +434,8 @@ describe("dev-ci canonical-plan workflow contract", () => {
 			{ ...valid[0]!, windowsDoctor: "failure" },
 			{ ...valid[0]!, windowsDoctor: "cancelled" },
 			{ ...valid[0]!, windowsDoctor: "skipped" },
+			{ ...valid[0]!, worktreeSafety: "failure" },
+			{ ...valid[0]!, worktreeSafety: "cancelled" },
 			{ ...valid[1]!, windowsDoctor: "success" },
 			{ ...valid[1]!, windowsDoctorRequired: "" },
 			{ ...valid[1]!, windowsDoctorRequired: "maybe" },
@@ -317,36 +443,94 @@ describe("dev-ci canonical-plan workflow contract", () => {
 			{ ...valid[1]!, hasTasks: "maybe" },
 			{ ...valid[1]!, native: "success" },
 			{ ...valid[1]!, shards: "success" },
-		]) expect(() => validateAffectedAggregate(results)).toThrow();
+			{ ...valid[1]!, worktreeSafety: "success" },
+			{ ...valid[0]!, worktreeSafety: "skipped" },
+			{ ...valid[1]!, worktreeSafetyRequired: "" },
+			{ ...valid[1]!, worktreeSafetyRequired: "maybe" },
+		])
+			expect(() => validateAffectedAggregate(results)).toThrow();
+		expect(() => validateCanonicalWorktreeSafetyRequirement({ worktreeSafetyRequired: "true" }, true)).not.toThrow();
+		expect(() => validateCanonicalWorktreeSafetyRequirement({ worktreeSafetyRequired: "false" }, false)).not.toThrow();
+		expect(() => validateCanonicalWorktreeSafetyRequirement({ worktreeSafetyRequired: "false" }, true)).toThrow(
+			"worktree safety flag does not match canonical plan",
+		);
+		expect(() => validateCanonicalWorktreeSafetyRequirement({ worktreeSafetyRequired: "true" }, false)).toThrow(
+			"worktree safety flag does not match canonical plan",
+		);
+	});
+});
+describe("focused worktree report-only selector", () => {
+	test("recognizes focused paths and excludes inventory or mixed changes", () => {
+		expect(isFocusedWorktreeOnly(["packages/coding-agent/src/cli.ts"])).toBe(true);
+		expect(isFocusedWorktreeOnly(["scripts/check-worktree-report-capabilities.test.ts"])).toBe(true);
+		expect(isFocusedWorktreeOnly(["scripts/fixtures/worktree-report-capabilities/hostile.ts"])).toBe(true);
+		expect(isFocusedWorktreeOnly(["scripts/ci-dev-affected.ts"])).toBe(true);
+		expect(isFocusedWorktreeOnly([".github/workflows/dev-ci.yml"])).toBe(true);
+		expect(isFocusedWorktreeOnly(["scripts/ci-dev-affected-build-inventory.json"])).toBe(false);
+		expect(isFocusedWorktreeOnly(["packages/coding-agent/src/cli.ts", "packages/example/src/index.ts"])).toBe(false);
+		expect(hasWorktreeSafetyChange(["packages/coding-agent/src/cli.ts", "packages/example/src/index.ts"])).toBe(false);
+		expect(hasWorktreeSafetyChange(["packages/coding-agent/CHANGELOG.md"])).toBe(true);
+		expect(planFocusedWorktreeTasks(["packages/coding-agent/CHANGELOG.md"]).map((task) => task.key)).toEqual([
+			"test:worktree-cli",
+			"check:coding-agent",
+		]);
+	});
+	test("normalizes canonical task cwd separators for cross-platform plans", () => {
+		expect(normalizeTaskCwdSeparators("packages\\coding-agent")).toBe("packages/coding-agent");
+		const codingAgentCheck = describeTasks(planFocusedWorktreeTasks(["packages/coding-agent/CHANGELOG.md"])).find(
+			(entry) => entry.key === "check:coding-agent",
+		);
+		expect(codingAgentCheck?.cwd).toBe("packages/coding-agent");
+		expect(codingAgentCheck?.identity).toBeDefined();
+	});
+	test("focused tasks are ordered, deduplicated, and native-free", () => {
+		const tasks = planFocusedWorktreeTasks([
+			"packages/coding-agent/src/cli.ts",
+			"scripts/check-worktree-report-capabilities.ts",
+			"scripts/ci-dev-affected.test.ts",
+			".github/workflows/dev-ci.yml",
+		]);
+		expect(tasks.map((task) => task.key)).toEqual([
+			"test:worktree-cli",
+			"check:coding-agent",
+			"test:worktree-capabilities",
+			"verify:worktree-capabilities",
+			"ci-selftest",
+			"ci-dry-run",
+			"workflow-yaml-parse",
+		]);
+		expect(describeTasks(tasks).every((task) => !task.native && !task.rust && !task.nextest && !task.nativeBuild)).toBe(
+			true,
+		);
 	});
 });
 
-	describe("deep-interview selector narrowing", () => {
-		test("deep-interview-only changes avoid full workspace validation but still provide native artifacts", () => {
-			const tasks = planForPaths([
-				"packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md",
-				"packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts",
-				"packages/coding-agent/test/default-gjc-definitions.test.ts",
-				"packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts",
-			]);
-			expect(tasks.map(task => task.key)).toEqual([
-				"native-linux-x64",
-				"deep-interview-definitions",
-				"deep-interview-runtime",
-			]);
-			const entries = describeTasks(tasks);
-			expect(entries.find(entry => entry.key === "native-linux-x64")?.nativeBuild).toBe(true);
-			expect(entries.find(entry => entry.key === "deep-interview-definitions")?.native).toBe(true);
-			expect(entries.find(entry => entry.key === "deep-interview-runtime")?.native).toBe(true);
-			expect(tasks.some(task => task.key === "root-test")).toBe(false);
-		});
+describe("deep-interview selector narrowing", () => {
+	test("deep-interview-only changes avoid full workspace validation but still provide native artifacts", () => {
+		const tasks = planForPaths([
+			"packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md",
+			"packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts",
+			"packages/coding-agent/test/default-gjc-definitions.test.ts",
+			"packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts",
+		]);
+		expect(tasks.map((task) => task.key)).toEqual([
+			"native-linux-x64",
+			"deep-interview-definitions",
+			"deep-interview-runtime",
+		]);
+		const entries = describeTasks(tasks);
+		expect(entries.find((entry) => entry.key === "native-linux-x64")?.nativeBuild).toBe(true);
+		expect(entries.find((entry) => entry.key === "deep-interview-definitions")?.native).toBe(true);
+		expect(entries.find((entry) => entry.key === "deep-interview-runtime")?.native).toBe(true);
+		expect(tasks.some((task) => task.key === "root-test")).toBe(false);
 	});
+});
 
 describe("runCommand executes package scripts in the target cwd (issue #622)", () => {
 	const tempDirs: string[] = [];
 
 	afterAll(async () => {
-		await Promise.all(tempDirs.map(dir => fs.rm(dir, { recursive: true, force: true })));
+		await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
 	});
 
 	async function makePackage(): Promise<{ pkgDir: string; markerPath: string }> {
@@ -361,7 +545,7 @@ describe("runCommand executes package scripts in the target cwd (issue #622)", (
 				name: "marker-pkg",
 				scripts: {
 					check: `node -e "require('node:fs').writeFileSync('${marker}','ran')"`,
-					fail: "node -e \"process.exit(3)\"",
+					fail: 'node -e "process.exit(3)"',
 				},
 			}),
 		);
@@ -405,9 +589,9 @@ describe("runCommand executes package scripts in the target cwd (issue #622)", (
 describe("describeTasks matrix emission", () => {
 	test("package test task needs native, native build task is flagged, check does not", () => {
 		const entries = describeTasks(planForPaths(["packages/example/src/index.ts"]));
-		const nativeBuild = entries.find(entry => entry.key === "native-linux-x64");
-		const pkgTest = entries.find(entry => entry.key === "test:@gajae-code/example");
-		const pkgCheck = entries.find(entry => entry.key === "check:@gajae-code/example");
+		const nativeBuild = entries.find((entry) => entry.key === "native-linux-x64");
+		const pkgTest = entries.find((entry) => entry.key === "test:@gajae-code/example");
+		const pkgCheck = entries.find((entry) => entry.key === "check:@gajae-code/example");
 
 		expect(nativeBuild?.nativeBuild).toBe(true);
 		expect(nativeBuild?.native).toBe(false);
@@ -427,8 +611,8 @@ describe("describeTasks matrix emission", () => {
 
 	test("full-workspace root-check downloads the native artifact used by generated checks", () => {
 		const entries = describeTasks(planTasks(["tsconfig.json"], packages));
-		const nativeBuild = entries.find(entry => entry.key === "native-linux-x64");
-		const rootCheck = entries.find(entry => entry.key === "root-check");
+		const nativeBuild = entries.find((entry) => entry.key === "native-linux-x64");
+		const rootCheck = entries.find((entry) => entry.key === "root-check");
 
 		expect(nativeBuild?.nativeBuild).toBe(true);
 		expect(rootCheck).toMatchObject({ command: ["bun", "run", "ci:check:full"], native: true, nativeBuild: false });
@@ -436,13 +620,13 @@ describe("describeTasks matrix emission", () => {
 
 	test("rust tasks are flagged rust and need no native addon", () => {
 		const entries = describeTasks(planTasks(["crates/pi-natives/src/lib.rs"], packages));
-		const check = entries.find(entry => entry.key === "rust-check");
-		const runTest = entries.find(entry => entry.key === "rust-test");
+		const check = entries.find((entry) => entry.key === "rust-check");
+		const runTest = entries.find((entry) => entry.key === "rust-test");
 
 		expect(check?.rust).toBe(true);
 		expect(check?.native).toBe(false);
 		expect(runTest?.rust).toBe(true);
-		expect(entries.every(entry => !entry.nativeBuild)).toBe(true);
+		expect(entries.every((entry) => !entry.nativeBuild)).toBe(true);
 	});
 
 	test("selector self-check shards provision Rust without nextest in PR and push plans", () => {
@@ -451,13 +635,13 @@ describe("describeTasks matrix emission", () => {
 			...describeTasks(planTasks(["scripts/ci-dev-affected.ts"], packages)),
 		];
 		for (const key of ["ci-selftest", "ci-dry-run", "affected-selftest", "affected-dry-run"]) {
-			expect(entries.find(entry => entry.key === key)).toMatchObject({ rust: true, nextest: false });
+			expect(entries.find((entry) => entry.key === key)).toMatchObject({ rust: true, nextest: false });
 		}
 	});
 
 	test("cwd is emitted repo-relative for package-scoped tasks", () => {
 		const entries = describeTasks(planForPaths(["packages/example/src/index.ts"]));
-		const pkgCheck = entries.find(entry => entry.key === "check:@gajae-code/example");
+		const pkgCheck = entries.find((entry) => entry.key === "check:@gajae-code/example");
 		expect(pkgCheck?.cwd).toBe("packages/example");
 	});
 });
@@ -469,41 +653,175 @@ describe("--matrix-json and --task CLI fan-out", () => {
 	const sourceSha = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repoRoot }).stdout.toString().trim();
 
 	afterAll(async () => {
-		await Promise.all(tempDirs.map(dir => fs.rm(dir, { recursive: true, force: true })));
+		await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
 		await fs.rm(path.join(repoRoot, ".ci-dev-affected-plan.json"), { force: true });
 	});
+
+	function shellQuote(value: string): string {
+		return `'${value.replace(/'/g, "'\\''")}'`;
+	}
+
+	async function createCargoMetadataShim(
+		mode: "normal" | "json" | "schema" | "failure" = "normal",
+	): Promise<{ directory: string; receipt: string }> {
+		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-fake-cargo-"));
+		tempDirs.push(directory);
+		const receipt = path.join(directory, "cargo-receipt.jsonl");
+		await Bun.write(receipt, "");
+		const rawInventory = JSON.parse(
+			await fs.readFile(path.join(repoRoot, "scripts/ci-dev-affected-build-inventory.json"), "utf8"),
+		) as { cargo: Array<{ id: string; name: string; manifestPath: string }> };
+		const inventoryIds = new Set<string>();
+		const packageNames = new Set<string>();
+		const packages: Array<{
+			id: string;
+			name: string;
+			manifest_path: string;
+			dependencies: Array<{ name: string; path: string }>;
+		}> = [];
+		const manifestByDirectory = new Map<string, (typeof packages)[number]>();
+
+		for (const [index, unit] of rawInventory.cargo.entries()) {
+			if (inventoryIds.has(unit.id) || packageNames.has(unit.name))
+				throw new Error(`test fixture drift: duplicate Cargo inventory member ${unit.id}/${unit.name}`);
+			inventoryIds.add(unit.id);
+			packageNames.add(unit.name);
+			const manifestPath = path.resolve(repoRoot, unit.manifestPath);
+			if (manifestByDirectory.has(path.dirname(manifestPath)))
+				throw new Error(`test fixture drift: duplicate Cargo manifest endpoint ${manifestPath}`);
+			const parsed = Bun.TOML.parse(await fs.readFile(manifestPath, "utf8")) as {
+				package?: { name?: unknown };
+			};
+			if (parsed.package?.name !== unit.name)
+				throw new Error(`test fixture drift: ${unit.manifestPath} declares ${String(parsed.package?.name)}`);
+			const entry = {
+				id: `fixture-package-${index}`,
+				name: unit.name,
+				manifest_path: manifestPath,
+				dependencies: [] as Array<{ name: string; path: string }>,
+			};
+			packages.push(entry);
+			manifestByDirectory.set(path.dirname(manifestPath), entry);
+		}
+
+		for (const entry of packages) {
+			const manifest = Bun.TOML.parse(await fs.readFile(entry.manifest_path, "utf8")) as unknown;
+			const visit = (value: unknown): void => {
+				if (!value || typeof value !== "object") return;
+				const record = value as Record<string, unknown>;
+				if (typeof record.path === "string") {
+					const endpoint = manifestByDirectory.get(path.resolve(path.dirname(entry.manifest_path), record.path));
+					if (!endpoint) throw new Error(`test fixture drift: missing path endpoint ${entry.name}->${record.path}`);
+					if (entry.dependencies.some((dependency) => dependency.path === endpoint.manifest_path))
+						throw new Error(`test fixture drift: duplicate path edge ${entry.name}->${endpoint.name}`);
+					entry.dependencies.push({ name: endpoint.name, path: path.dirname(endpoint.manifest_path) });
+				}
+				for (const child of Object.values(record)) visit(child);
+			};
+			visit(manifest);
+		}
+
+		const output =
+			mode === "json"
+				? "{"
+				: mode === "schema"
+					? JSON.stringify({ packages: [] })
+					: JSON.stringify({
+							packages,
+							workspace_members: packages.map((entry) => entry.id),
+						});
+		const shimScript = path.join(directory, "cargo-shim.ts");
+		await Bun.write(
+			shimScript,
+			`const receipt = ${JSON.stringify(receipt)};
+const mode = ${JSON.stringify(mode)};
+const args = Bun.argv.slice(2);
+await Bun.write(receipt, (await Bun.file(receipt).text()) + JSON.stringify(args) + "\\n");
+if (args.length !== 3 || args[0] !== "metadata" || args[1] !== "--format-version=1" || args[2] !== "--no-deps") {
+	console.error("cargo shim rejected unexpected argv: " + JSON.stringify(args));
+	process.exit(64);
+}
+if (mode === "failure") {
+	console.error("metadata failed");
+	process.exit(17);
+}
+process.stdout.write(${JSON.stringify(output)});
+`,
+		);
+		await writeExecutableWrappers(directory, {
+			bun: process.execPath,
+			git: Bun.which("git") ?? undefined,
+			node: Bun.which("node") ?? undefined,
+			cargo: process.execPath,
+		}, { cargoScript: shimScript });
+		return { directory, receipt };
+	}
+
+	async function writeExecutableWrappers(
+		directory: string,
+		targets: { bun: string; git: string | undefined; node: string | undefined; cargo: string },
+		options: { cargoScript?: string } = {},
+	): Promise<void> {
+		if (!targets.git || !targets.node) throw new Error("test setup requires git and node executables");
+		const wrappers = [
+			["bun", targets.bun],
+			["git", targets.git],
+			["node", targets.node],
+		] as const;
+		if (process.platform === "win32") {
+			for (const [name, target] of wrappers)
+				await Bun.write(path.join(directory, `${name}.cmd`), `@echo off\r\n@"${target}" %*\r\n`);
+			await Bun.write(
+				path.join(directory, "cargo.cmd"),
+				`@echo off\r\n@"${targets.cargo}" "${options.cargoScript}" %*\r\n`,
+			);
+		} else {
+			for (const [name, target] of wrappers) {
+				const file = path.join(directory, name);
+				await Bun.write(file, `#!/bin/sh\nexec ${shellQuote(target)} "$@"\n`);
+				await fs.chmod(file, 0o755);
+			}
+			const cargo = path.join(directory, "cargo");
+			await Bun.write(cargo, `#!/bin/sh\nexec ${shellQuote(targets.cargo)} ${shellQuote(options.cargoScript ?? "")} "$@"\n`);
+			await fs.chmod(cargo, 0o755);
+		}
+	}
 
 	async function runScript(
 		args: readonly string[],
 		changedPaths: string,
 		extraEnv: Record<string, string | undefined> = {},
-	): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-		const proc = Bun.spawn(["bun", scriptPath, ...args], {
+	): Promise<{ stdout: string; stderr: string; exitCode: number; cargoArgs: string[][] }> {
+		const mode = (extraEnv.CI_DEV_TEST_CARGO_MODE ?? "normal") as "normal" | "json" | "schema" | "failure";
+		const shim = await createCargoMetadataShim(mode);
+		const childEnv = { ...extraEnv };
+		delete childEnv.PATH;
+		delete childEnv.CI_DEV_TEST_CARGO_MODE;
+		const inheritedToolchain = Object.keys(process.env).filter((key) => /^(CARGO|RUST|RUSTUP)/.test(key));
+		const env: Record<string, string | undefined> = {
+			CI_DEV_AFFECTED_PLAN: undefined,
+			CI_DEV_PLAN_DIGEST: undefined,
+			CI_DEV_PLAN_SOURCE_SHA: undefined,
+			GITHUB_SHA: undefined,
+			CI_DEV_SOURCE_SHA: sourceSha,
+			CI_DEV_MATRIX_IDENTITY: undefined,
+			CI_DEV_MATRIX_KEY: undefined,
+			CI_DEV_MATRIX_NATIVE: undefined,
+			CI_DEV_MATRIX_NEXTEST: undefined,
+			CI_DEV_MATRIX_RUST: undefined,
+			CI_DEV_SHARD_INDEX: undefined,
+			CI_DEV_SHARD_RECEIPTS: undefined,
+			AFFECTED_TASK_KEY: undefined,
+			GITHUB_EVENT_NAME: "push",
+			CI_DEV_PLAN_MODE: "push",
+			CI_DEV_CHANGED_PATHS: changedPaths,
+			...childEnv,
+			PATH: shim.directory,
+		};
+		for (const key of inheritedToolchain) delete env[key];
+		const proc = Bun.spawn([process.execPath, scriptPath, ...args], {
 			cwd: repoRoot,
-			// Default to push (broad) mode so these CLI cases stay deterministic
-			// regardless of the GITHUB_EVENT_NAME/CI_DEV_PLAN_MODE of the CI run
-			// executing them; PR-mode behavior is asserted via planTargetedTasks unit
-			// tests and explicit shard-mode cases.
-			env: {
-				...process.env,
-				CI_DEV_AFFECTED_PLAN: undefined,
-				CI_DEV_PLAN_DIGEST: undefined,
-				CI_DEV_PLAN_SOURCE_SHA: undefined,
-				GITHUB_SHA: undefined,
-				CI_DEV_SOURCE_SHA: sourceSha,
-				CI_DEV_MATRIX_IDENTITY: undefined,
-				CI_DEV_MATRIX_KEY: undefined,
-				CI_DEV_MATRIX_NATIVE: undefined,
-				CI_DEV_MATRIX_NEXTEST: undefined,
-				CI_DEV_MATRIX_RUST: undefined,
-				CI_DEV_SHARD_INDEX: undefined,
-				CI_DEV_SHARD_RECEIPTS: undefined,
-				AFFECTED_TASK_KEY: undefined,
-				GITHUB_EVENT_NAME: "push",
-				CI_DEV_PLAN_MODE: "push",
-				CI_DEV_CHANGED_PATHS: changedPaths,
-				...extraEnv,
-			},
+			env,
 			stdout: "pipe",
 			stderr: "pipe",
 		});
@@ -512,22 +830,39 @@ describe("--matrix-json and --task CLI fan-out", () => {
 			new Response(proc.stderr).text(),
 			proc.exited,
 		]);
-		return { stdout, stderr, exitCode };
+		const cargoArgs = (await Bun.file(shim.receipt).text())
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line) as string[]);
+		return { stdout, stderr, exitCode, cargoArgs };
 	}
+
 
 	test("--matrix-json emits JSON descriptors and GitHub planner outputs", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-matrix-"));
 		tempDirs.push(tempDir);
 		const outputFile = path.join(tempDir, "github-output.txt");
 
-		const { stdout, exitCode } = await runScript(["--matrix-json"], "crates/pi-natives/src/lib.rs", {
+		const { stdout, exitCode, cargoArgs } = await runScript(["--matrix-json"], "crates/pi-natives/src/lib.rs", {
 			GITHUB_OUTPUT: outputFile,
 		});
+		expect(cargoArgs).toEqual(Array.from({ length: 2 }, () => ["metadata", "--format-version=1", "--no-deps"]));
 		expect(exitCode).toBe(0);
 
 		const entries = JSON.parse(stdout.trim());
-		expect(entries.some((entry: { key: string; rust: boolean; native: boolean }) => entry.key === "rust-check" && entry.rust === true && entry.native === false)).toBe(true);
-		expect(entries.some((entry: { key: string; rust: boolean; nativeBuild: boolean }) => entry.key.startsWith("cargo-build:") && entry.rust === true && entry.nativeBuild === false)).toBe(true);
+		expect(
+			entries.some(
+				(entry: { key: string; rust: boolean; native: boolean }) =>
+					entry.key === "rust-check" && entry.rust === true && entry.native === false,
+			),
+		).toBe(true);
+		expect(
+			entries.some(
+				(entry: { key: string; rust: boolean; nativeBuild: boolean }) =>
+					entry.key.startsWith("cargo-build:") && entry.rust === true && entry.nativeBuild === false,
+			),
+		).toBe(true);
 		expect(entries.filter((entry: { key: string }) => entry.key === "native-linux-x64")).toHaveLength(1);
 
 		const output = await Bun.file(outputFile).text();
@@ -535,13 +870,118 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(output).toContain("has_native=true");
 		expect(output).toContain("changed_paths<<");
 
-		const matrixLine = output.split("\n").find(line => line.startsWith("matrix="));
+		const matrixLine = output.split("\n").find((line) => line.startsWith("matrix="));
 		expect(matrixLine).toBeDefined();
 		const matrix = JSON.parse((matrixLine as string).slice("matrix=".length));
 		expect(matrix.include.some((shard: { key: string }) => shard.key === "rust-check")).toBe(true);
 		expect(matrix.include.some((shard: { key: string }) => shard.key.startsWith("cargo-build:"))).toBe(true);
 		// Native build tasks never appear as shards.
 		expect(matrix.include.every((shard: { key: string }) => shard.key !== "native-linux-x64")).toBe(true);
+	});
+	test("focused PR/push matrix routes are canonical, native-free, and fall back on mixed/inventory paths", async () => {
+		const focusedPaths = [
+			"packages/coding-agent/src/cli.ts",
+			"packages/coding-agent/src/commands/worktree.ts",
+			"packages/coding-agent/src/cli/worktree-cli.ts",
+			"packages/coding-agent/src/cli/worktree-scanner.ts",
+			"packages/coding-agent/test/worktree-cli.test.ts",
+			"packages/coding-agent/CHANGELOG.md",
+			"scripts/check-worktree-report-capabilities.ts",
+			"scripts/check-worktree-report-capabilities.test.ts",
+			"scripts/fixtures/worktree-report-capabilities/forbidden.ts",
+			"scripts/ci-dev-affected.ts",
+			"scripts/ci-dev-affected.test.ts",
+			".github/workflows/dev-ci.yml",
+		];
+		for (const mode of ["pr", "push"] as const) {
+			for (const focusedPath of focusedPaths) {
+				const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), `ci-dev-focused-${mode}-`));
+				tempDirs.push(tempDir);
+				const outputFile = path.join(tempDir, "github-output.txt");
+				const result = await runScript(["--matrix-json"], focusedPath, {
+					CI_DEV_PLAN_MODE: mode,
+					GITHUB_EVENT_NAME: mode === "pr" ? "pull_request" : "push",
+					GITHUB_OUTPUT: outputFile,
+				});
+				expect(result.exitCode, `${mode}:${focusedPath}`).toBe(0);
+				const entries = JSON.parse(result.stdout.trim()) as Array<{
+					key: string;
+					command: string[];
+					native: boolean;
+					rust: boolean;
+					nextest: boolean;
+					nativeBuild: boolean;
+				}>;
+				expect(entries.length, `${mode}:${focusedPath}`).toBeGreaterThan(0);
+				expect(
+					entries.every((entry) => !entry.native && !entry.rust && !entry.nextest && !entry.nativeBuild),
+					`${mode}:${focusedPath}`,
+				).toBe(true);
+				if (focusedPath.startsWith("packages/coding-agent/"))
+					expect(entries.find((entry) => entry.key === "check:coding-agent")?.command).toEqual(["bun", "run", "check"]);
+				expect(entries.some((entry) => entry.key === "lint:coding-agent")).toBe(false);
+				const output = await Bun.file(outputFile).text();
+				expect(output).toContain("worktree_safety_required=true");
+				expect(result.cargoArgs, `${mode}:${focusedPath}`).toEqual([]);
+				expect(output).toMatch(/plan_digest=[0-9a-f]{64}/);
+				const plan = (await Bun.file(path.join(repoRoot, ".ci-dev-affected-plan.json")).json()) as {
+					schemaVersion: number;
+					mode: string;
+					worktreeSafetyRequired: boolean;
+					tasks: Array<Record<string, unknown>>;
+				};
+				expect(plan).toMatchObject({ schemaVersion: 1, mode, worktreeSafetyRequired: true });
+				for (const task of plan.tasks)
+					expect(Object.keys(task).sort()).toEqual([
+						"capabilities",
+						"command",
+						"cwd",
+						"description",
+						"identity",
+						"key",
+						"phase",
+					]);
+			}
+		}
+		for (const changedPaths of [
+			"packages/coding-agent/src/cli.ts\npackages/example/src/index.ts",
+			"packages/coding-agent/src/cli.ts\nscripts/ci-dev-affected-build-inventory.json",
+		]) {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-mixed-"));
+			tempDirs.push(tempDir);
+			const outputFile = path.join(tempDir, "github-output.txt");
+			const result = await runScript(["--matrix-json"], changedPaths, {
+				GITHUB_OUTPUT: outputFile,
+			});
+			expect(result.exitCode).toBe(0);
+			expect(result.cargoArgs).toEqual([["metadata", "--format-version=1", "--no-deps"]]);
+			const mixedEntries = JSON.parse(result.stdout.trim()) as Array<{
+				key: string;
+				native: boolean;
+				rust: boolean;
+				nativeBuild: boolean;
+			}>;
+			expect(mixedEntries.some((entry) => entry.native || entry.rust || entry.nativeBuild)).toBe(true);
+			expect(await Bun.file(path.join(repoRoot, ".ci-dev-affected-plan.json")).json()).toMatchObject({
+				worktreeSafetyRequired: false,
+			});
+			expect(await Bun.file(outputFile).text()).toContain("worktree_safety_required=false");
+		}
+	});
+	test("focused matrix remains Bun-only when ambient Cargo is unusable", async () => {
+		const result = await runScript(["--matrix-json"], "packages/coding-agent/src/cli.ts", {
+			CI_DEV_TEST_CARGO_MODE: "failure",
+		});
+		expect(result.cargoArgs).toEqual([]);
+		expect(result.exitCode).toBe(0);
+		const entries = JSON.parse(result.stdout.trim()) as Array<{
+			native: boolean;
+			rust: boolean;
+			nextest: boolean;
+			nativeBuild: boolean;
+		}>;
+		expect(entries.length).toBeGreaterThan(0);
+		expect(entries.every((entry) => !entry.native && !entry.rust && !entry.nextest && !entry.nativeBuild)).toBe(true);
 	});
 
 	test("changed-path ranges use the canonical source head instead of ambient PR merge SHA", async () => {
@@ -552,20 +992,29 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		const base = head;
 		const missingMergeSha = "1".repeat(40);
 		const pr = await runScript(["--matrix-json"], "", {
-			GITHUB_EVENT_NAME: "pull_request", GITHUB_BASE_REF: "", GITHUB_BASE_SHA: base,
-			GITHUB_SHA: missingMergeSha, CI_DEV_SOURCE_SHA: head,
+			GITHUB_EVENT_NAME: "pull_request",
+			GITHUB_BASE_REF: "",
+			GITHUB_BASE_SHA: base,
+			GITHUB_SHA: missingMergeSha,
+			CI_DEV_SOURCE_SHA: head,
 		});
 		expect(pr.exitCode).toBe(0);
 
 		const push = await runScript(["--matrix-json"], "", {
-			GITHUB_EVENT_NAME: "push", GITHUB_EVENT_BEFORE: base, GITHUB_BASE_SHA: "",
-			GITHUB_SHA: missingMergeSha, CI_DEV_SOURCE_SHA: head,
+			GITHUB_EVENT_NAME: "push",
+			GITHUB_EVENT_BEFORE: base,
+			GITHUB_BASE_SHA: "",
+			GITHUB_SHA: missingMergeSha,
+			CI_DEV_SOURCE_SHA: head,
 		});
 		expect(push.exitCode).toBe(0);
 
 		const missingHead = await runScript(["--matrix-json"], "", {
-			GITHUB_EVENT_NAME: "pull_request", GITHUB_BASE_REF: "", GITHUB_BASE_SHA: base,
-			GITHUB_SHA: head, CI_DEV_SOURCE_SHA: "2".repeat(40),
+			GITHUB_EVENT_NAME: "pull_request",
+			GITHUB_BASE_REF: "",
+			GITHUB_BASE_SHA: base,
+			GITHUB_SHA: head,
+			CI_DEV_SOURCE_SHA: "2".repeat(40),
 		});
 		expect(missingHead.exitCode).toBe(1);
 		expect(missingHead.stderr).toContain("source head");
@@ -599,25 +1048,71 @@ describe("--matrix-json and --task CLI fan-out", () => {
 	test("Cargo selection includes transitive dependents and never emits vendored shards", async () => {
 		const sdk = await runScript(["--matrix-json"], "crates/gjc-sdk/src/lib.rs");
 		expect(sdk.exitCode).toBe(0);
-		const sdkKeys = (JSON.parse(sdk.stdout.trim()) as Array<{ key: string }>).map(entry => entry.key);
-		expect(sdkKeys.filter(key => key.startsWith("cargo-build:"))).toEqual([
+		expect(sdk.cargoArgs).toEqual(Array.from({ length: 2 }, () => ["metadata", "--format-version=1", "--no-deps"]));
+		const sdkKeys = (JSON.parse(sdk.stdout.trim()) as Array<{ key: string }>).map((entry) => entry.key);
+		expect(sdkKeys.filter((key) => key.startsWith("cargo-build:"))).toEqual([
 			"cargo-build:cargo:Z2pjLXNkaw:Y3JhdGVzL2dqYy1zZGsvQ2FyZ28udG9tbA",
 			"cargo-build:cargo:cGktbmF0aXZlcw:Y3JhdGVzL3BpLW5hdGl2ZXMvQ2FyZ28udG9tbA",
 		]);
-		expect(sdkKeys.filter(key => key === "native-linux-x64")).toHaveLength(1);
+		expect(sdkKeys.filter((key) => key === "native-linux-x64")).toHaveLength(1);
 
 		const vendored = await runScript(["--matrix-json"], "crates/brush-core-vendored/src/lib.rs");
 		expect(vendored.exitCode).toBe(0);
-		const vendoredKeys = (JSON.parse(vendored.stdout.trim()) as Array<{ key: string }>).map(entry => entry.key);
-		expect(vendoredKeys.filter(key => key.startsWith("cargo-build:"))).toHaveLength(5);
-		expect(vendoredKeys.some(key => key.includes("brush"))).toBe(false);
+		expect(vendored.cargoArgs).toEqual([["metadata", "--format-version=1", "--no-deps"]]);
+		const vendoredKeys = (JSON.parse(vendored.stdout.trim()) as Array<{ key: string }>).map((entry) => entry.key);
+		expect(vendoredKeys.filter((key) => key.startsWith("cargo-build:"))).toHaveLength(5);
+		expect(vendoredKeys.some((key) => key.includes("brush"))).toBe(false);
+	});
+	test("Cargo metadata fallback diagnostics are exercised in fresh subprocesses", async () => {
+		const source = JSON.parse(
+			await fs.readFile(path.join(repoRoot, "scripts/ci-dev-affected-build-inventory.json"), "utf8"),
+		) as { cargo: CargoInventoryUnit[] };
+		const supportedIds = source.cargo.map((unit) => unit.id);
+		for (const mode of ["failure", "json", "schema"] as const) {
+			const shim = await createCargoMetadataShim(mode);
+			const child = Bun.spawn(
+				[
+					process.execPath,
+					"-e",
+					`const module = await import("./scripts/ci-dev-affected.ts");
+const inventory = await Bun.file("./scripts/ci-dev-affected-build-inventory.json").json();
+const selected = await module.expandCargoDependents([inventory.cargo[0]], inventory.cargo, true);
+console.log(JSON.stringify(selected.map((unit) => unit.id)));`,
+				],
+				{
+					cwd: repoRoot,
+					env: { PATH: shim.directory, CI_DEV_SOURCE_SHA: sourceSha },
+					stdout: "pipe",
+					stderr: "pipe",
+				},
+			);
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(child.stdout).text(),
+				new Response(child.stderr).text(),
+				child.exited,
+			]);
+			expect(exitCode).toBe(0);
+			expect(JSON.parse(stdout.trim())).toEqual(supportedIds);
+			expect(stderr).toContain(
+				mode === "failure"
+					? "cargo metadata command failure"
+					: mode === "json"
+						? "cargo metadata malformed JSON"
+						: "cargo metadata malformed workspace schema",
+			);
+			expect(stderr.length).toBeLessThanOrEqual(400);
+			expect(stderr).not.toContain(shim.directory);
+			expect(await Bun.file(shim.receipt).text()).toBe(
+				'["metadata","--format-version=1","--no-deps"]\n',
+			);
+		}
 	});
 
 	test("root/shared build inputs select every inventory TypeScript build in stable order", async () => {
 		const { stdout, exitCode } = await runScript(["--matrix-json"], "bun.lock");
 		expect(exitCode).toBe(0);
 		const entries = JSON.parse(stdout.trim()) as Array<{ key: string }>;
-		expect(entries.filter(entry => entry.key.startsWith("ts-build:")).map(entry => entry.key)).toEqual([
+		expect(entries.filter((entry) => entry.key.startsWith("ts-build:")).map((entry) => entry.key)).toEqual([
 			"ts-build:ts:Y29kaW5nLWFnZW50:cGFja2FnZXMvY29kaW5nLWFnZW50",
 			"ts-build:ts:c3RhdHM:cGFja2FnZXMvc3RhdHM",
 		]);
@@ -626,7 +1121,6 @@ describe("--matrix-json and --task CLI fan-out", () => {
 	test("package documentation changes do not schedule build shards", async () => {
 		const { stdout, exitCode } = await runScript(["--matrix-json"], "packages/coding-agent/README.md", {
 			CI_DEV_PLAN_MODE: "pr",
-			PATH: `${path.dirname(Bun.which("bun") ?? process.execPath)}${path.delimiter}${process.env.PATH ?? ""}`,
 		});
 		expect(exitCode).toBe(0);
 		expect(JSON.parse(stdout.trim())).toEqual([]);
@@ -634,19 +1128,20 @@ describe("--matrix-json and --task CLI fan-out", () => {
 
 	test("unknown unowned inputs fail open to every TypeScript and Cargo build family", async () => {
 		for (const changedPath of ["Makefile", "packages/new-workspace/src/index.ts"]) {
-			const { stdout, exitCode } = await runScript(["--matrix-json"], changedPath);
+			const { stdout, exitCode, cargoArgs } = await runScript(["--matrix-json"], changedPath);
+			expect(cargoArgs).toEqual([["metadata", "--format-version=1", "--no-deps"]]);
 			expect(exitCode).toBe(0);
 			const entries = JSON.parse(stdout.trim()) as Array<{ key: string }>;
-			expect(entries.filter(entry => entry.key.startsWith("ts-build:")).map(entry => entry.key)).toHaveLength(2);
-			expect(entries.filter(entry => entry.key.startsWith("cargo-build:")).map(entry => entry.key)).toHaveLength(5);
-			expect(entries.filter(entry => entry.key === "native-linux-x64")).toHaveLength(1);
+			expect(entries.filter((entry) => entry.key.startsWith("ts-build:")).map((entry) => entry.key)).toHaveLength(2);
+			expect(entries.filter((entry) => entry.key.startsWith("cargo-build:")).map((entry) => entry.key)).toHaveLength(5);
+			expect(entries.filter((entry) => entry.key === "native-linux-x64")).toHaveLength(1);
 		}
 	});
 
 	test("native workspace changes have exact PR and push plans", async () => {
 		const pr = await runScript(["--matrix-json"], "packages/natives/src/index.ts", { CI_DEV_PLAN_MODE: "pr" });
 		expect(pr.exitCode).toBe(0);
-		expect((JSON.parse(pr.stdout.trim()) as Array<{ key: string }>).map(entry => entry.key)).toEqual([
+		expect((JSON.parse(pr.stdout.trim()) as Array<{ key: string }>).map((entry) => entry.key)).toEqual([
 			"check:@gajae-code/natives",
 			"native-linux-x64",
 			"ts-build:ts:Y29kaW5nLWFnZW50:cGFja2FnZXMvY29kaW5nLWFnZW50",
@@ -655,16 +1150,22 @@ describe("--matrix-json and --task CLI fan-out", () => {
 
 		const push = await runScript(["--matrix-json"], "packages/natives/src/index.ts", { CI_DEV_PLAN_MODE: "push" });
 		expect(push.exitCode).toBe(0);
-		expect((JSON.parse(push.stdout.trim()) as Array<{ key: string }>).map(entry => entry.key)).toEqual([
-			"check:@gajae-code/agent-core", "test:@gajae-code/agent-core",
-			"check:@gajae-code/ai", "test:@gajae-code/ai",
+		expect((JSON.parse(push.stdout.trim()) as Array<{ key: string }>).map((entry) => entry.key)).toEqual([
+			"check:@gajae-code/agent-core",
+			"test:@gajae-code/agent-core",
+			"check:@gajae-code/ai",
+			"test:@gajae-code/ai",
 			"check:@gajae-code/coding-agent",
 			...Array.from({ length: 8 }, (_, index) => `test:@gajae-code/coding-agent:shard-${index + 1}-of-8`),
-			"check:@gajae-code/natives", "test:@gajae-code/natives",
+			"check:@gajae-code/natives",
+			"test:@gajae-code/natives",
 			"check:@gajae-code/stats",
-			"check:@gajae-code/tui", "test:@gajae-code/tui",
-			"check:@gajae-code/typescript-edit-benchmark", "test:@gajae-code/typescript-edit-benchmark",
-			"check:@gajae-code/utils", "test:@gajae-code/utils",
+			"check:@gajae-code/tui",
+			"test:@gajae-code/tui",
+			"check:@gajae-code/typescript-edit-benchmark",
+			"test:@gajae-code/typescript-edit-benchmark",
+			"check:@gajae-code/utils",
+			"test:@gajae-code/utils",
 			"native-linux-x64",
 			"ts-build:ts:Y29kaW5nLWFnZW50:cGFja2FnZXMvY29kaW5nLWFnZW50",
 			"ts-build:ts:c3RhdHM:cGFja2FnZXMvc3RhdHM",
@@ -684,7 +1185,10 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(generated.exitCode).toBe(0);
 		await Bun.write(planFile, Bun.file(path.join(repoRoot, ".ci-dev-affected-plan.json")));
 		const output = await Bun.file(outputFile).text();
-		const digest = output.split("\n").find(line => line.startsWith("plan_digest="))?.slice("plan_digest=".length);
+		const digest = output
+			.split("\n")
+			.find((line) => line.startsWith("plan_digest="))
+			?.slice("plan_digest=".length);
 		expect(digest).toBeDefined();
 		const valid = await runScript(["--validate-plan"], "packages/stats/src/index.ts", {
 			CI_DEV_AFFECTED_PLAN: planFile,
@@ -694,10 +1198,15 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(valid.exitCode).toBe(0);
 		const receiptDir = path.join(tempDir, "receipts");
 		await fs.mkdir(receiptDir);
-		const plan = JSON.parse(await Bun.file(planFile).text()) as { tasks: Array<{ key: string; identity: string; capabilities: { nativeProducer: boolean } }> };
-		const expectedShards = plan.tasks.filter(task => !task.capabilities.nativeProducer);
+		const plan = JSON.parse(await Bun.file(planFile).text()) as {
+			tasks: Array<{ key: string; identity: string; capabilities: { nativeProducer: boolean } }>;
+		};
+		const expectedShards = plan.tasks.filter((task) => !task.capabilities.nativeProducer);
 		for (const [index, task] of expectedShards.entries()) {
-			await Bun.write(path.join(receiptDir, `${index}.json`), JSON.stringify({ key: task.key, identity: task.identity }));
+			await Bun.write(
+				path.join(receiptDir, `${index}.json`),
+				JSON.stringify({ key: task.key, identity: task.identity }),
+			);
 		}
 		const receiptsValid = await runScript(["--validate-shard-receipts"], "packages/stats/src/index.ts", {
 			CI_DEV_AFFECTED_PLAN: planFile,
@@ -715,7 +1224,10 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		});
 		expect(receiptMissing.exitCode).toBe(1);
 		expect(receiptMissing.stderr).toContain("shard receipt set does not match canonical plan");
-		await Bun.write(path.join(receiptDir, "0.json"), JSON.stringify({ key: expectedShards[0]!.key, identity: expectedShards[0]!.identity }));
+		await Bun.write(
+			path.join(receiptDir, "0.json"),
+			JSON.stringify({ key: expectedShards[0]!.key, identity: expectedShards[0]!.identity }),
+		);
 		await Bun.write(path.join(receiptDir, "stale-extra.json"), JSON.stringify({ key: "stale", identity: "stale" }));
 		const receiptExtra = await runScript(["--validate-shard-receipts"], "packages/stats/src/index.ts", {
 			CI_DEV_AFFECTED_PLAN: planFile,
@@ -726,7 +1238,10 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(receiptExtra.exitCode).toBe(1);
 		expect(receiptExtra.stderr).toContain("shard receipt set does not match canonical plan");
 		await fs.rm(path.join(receiptDir, "stale-extra.json"));
-		await Bun.write(path.join(receiptDir, "duplicate.json"), JSON.stringify({ key: expectedShards[0]!.key, identity: expectedShards[0]!.identity }));
+		await Bun.write(
+			path.join(receiptDir, "duplicate.json"),
+			JSON.stringify({ key: expectedShards[0]!.key, identity: expectedShards[0]!.identity }),
+		);
 		const receiptDuplicate = await runScript(["--validate-shard-receipts"], "packages/stats/src/index.ts", {
 			CI_DEV_AFFECTED_PLAN: planFile,
 			CI_DEV_PLAN_DIGEST: digest as string,
@@ -736,7 +1251,10 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(receiptDuplicate.exitCode).toBe(1);
 		expect(receiptDuplicate.stderr).toContain("shard receipt set does not match canonical plan");
 		await fs.rm(path.join(receiptDir, "duplicate.json"));
-		await Bun.write(path.join(receiptDir, "0.json"), JSON.stringify({ key: expectedShards[0]!.key, identity: "wrong" }));
+		await Bun.write(
+			path.join(receiptDir, "0.json"),
+			JSON.stringify({ key: expectedShards[0]!.key, identity: "wrong" }),
+		);
 		const receiptWrongIdentity = await runScript(["--validate-shard-receipts"], "packages/stats/src/index.ts", {
 			CI_DEV_AFFECTED_PLAN: planFile,
 			CI_DEV_PLAN_DIGEST: digest as string,
@@ -753,7 +1271,10 @@ describe("--matrix-json and --task CLI fan-out", () => {
 			CI_DEV_SHARD_RECEIPTS: receiptDir,
 		});
 		expect(receiptMalformedJson.exitCode).toBe(1);
-		await Bun.write(path.join(receiptDir, "0.json"), JSON.stringify({ key: expectedShards[0]!.key, identity: expectedShards[0]!.identity, extra: true }));
+		await Bun.write(
+			path.join(receiptDir, "0.json"),
+			JSON.stringify({ key: expectedShards[0]!.key, identity: expectedShards[0]!.identity, extra: true }),
+		);
 		const receiptMalformedObject = await runScript(["--validate-shard-receipts"], "packages/stats/src/index.ts", {
 			CI_DEV_AFFECTED_PLAN: planFile,
 			CI_DEV_PLAN_DIGEST: digest as string,
@@ -770,19 +1291,40 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(wrongSource.exitCode).toBe(1);
 		expect(wrongSource.stderr).toContain("source SHA mismatch");
 
-		const matrixEntry = (JSON.parse(generated.stdout.trim()) as Array<{ key: string; rust: boolean; nextest: boolean; native: boolean }>).find(entry => !entry.key.startsWith("native-linux-x64"));
+		const matrixEntry = (
+			JSON.parse(generated.stdout.trim()) as Array<{
+				key: string;
+				identity: string;
+				rust: boolean;
+				nextest: boolean;
+				native: boolean;
+			}>
+		).find((entry) => !entry.key.startsWith("native-linux-x64"));
 		expect(matrixEntry).toBeDefined();
 		const wrongCapabilities = await runScript(["--validate-plan"], "packages/stats/src/index.ts", {
 			CI_DEV_AFFECTED_PLAN: planFile,
 			CI_DEV_PLAN_DIGEST: digest as string,
 			CI_DEV_PLAN_SOURCE_SHA: head,
 			CI_DEV_MATRIX_KEY: matrixEntry?.key as string,
+			CI_DEV_MATRIX_IDENTITY: matrixEntry?.identity as string,
 			CI_DEV_MATRIX_RUST: String(!(matrixEntry?.rust ?? false)),
 			CI_DEV_MATRIX_NEXTEST: String(matrixEntry?.nextest ?? false),
 			CI_DEV_MATRIX_NATIVE: String(matrixEntry?.native ?? false),
 		});
 		expect(wrongCapabilities.exitCode).toBe(1);
 		expect(wrongCapabilities.stderr).toContain("matrix capabilities mismatch");
+		const wrongIdentity = await runScript(["--validate-plan"], "packages/stats/src/index.ts", {
+			CI_DEV_AFFECTED_PLAN: planFile,
+			CI_DEV_PLAN_DIGEST: digest as string,
+			CI_DEV_PLAN_SOURCE_SHA: head,
+			CI_DEV_MATRIX_KEY: matrixEntry?.key as string,
+			CI_DEV_MATRIX_IDENTITY: "wrong-identity",
+			CI_DEV_MATRIX_RUST: String(matrixEntry?.rust ?? false),
+			CI_DEV_MATRIX_NEXTEST: String(matrixEntry?.nextest ?? false),
+			CI_DEV_MATRIX_NATIVE: String(matrixEntry?.native ?? false),
+		});
+		expect(wrongIdentity.exitCode).toBe(1);
+		expect(wrongIdentity.stderr).toContain("matrix identity mismatch");
 		await Bun.write(planFile, `${await Bun.file(planFile).text()}\n`);
 		const tampered = await runScript(["--validate-plan"], "packages/stats/src/index.ts", {
 			CI_DEV_AFFECTED_PLAN: planFile,
@@ -793,23 +1335,136 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(tampered.stderr).toContain("digest mismatch");
 	});
 
+	test("matching digests do not authorize malformed canonical task records", async () => {
+		const focusedPath = "packages/coding-agent/src/cli.ts";
+		const generated = await runScript(["--matrix-json"], focusedPath, { CI_DEV_SOURCE_SHA: sourceSha });
+		expect(generated.exitCode).toBe(0);
+		const original = (await Bun.file(path.join(repoRoot, ".ci-dev-affected-plan.json")).json()) as {
+			tasks: Array<Record<string, unknown>>;
+			[key: string]: unknown;
+		};
+		const malformedPlans: Array<{ label: string; mutate: (task: Record<string, unknown>) => void }> = [
+			{
+				label: "missing-cwd",
+				mutate: (task) => {
+					delete task.cwd;
+				},
+			},
+			{
+				label: "extra-field",
+				mutate: (task) => {
+					task.extra = true;
+				},
+			},
+			{
+				label: "parent",
+				mutate: (task) => {
+					task.cwd = "..";
+				},
+			},
+			{
+				label: "absolute",
+				mutate: (task) => {
+					task.cwd = "/tmp";
+				},
+			},
+			{
+				label: "empty",
+				mutate: (task) => {
+					task.cwd = "";
+				},
+			},
+			{
+				label: "escaping",
+				mutate: (task) => {
+					task.cwd = "packages/../../tmp";
+				},
+			},
+			{
+				label: "empty-command",
+				mutate: (task) => {
+					task.command = [];
+				},
+			},
+			{
+				label: "changed-command",
+				mutate: (task) => {
+					task.command = ["bun", "--version"];
+				},
+			},
+			{
+				label: "changed-identity",
+				mutate: (task) => {
+					task.identity = "forged";
+				},
+			},
+			{
+				label: "capabilities-extra-field",
+				mutate: (task) => {
+					(task.capabilities as Record<string, unknown>).extra = true;
+				},
+			},
+			{
+				label: "capabilities-missing-field",
+				mutate: (task) => {
+					delete (task.capabilities as Record<string, unknown>).nativeProducer;
+				},
+			},
+		];
+		for (const { label, mutate } of malformedPlans) {
+			const plan = JSON.parse(JSON.stringify(original)) as typeof original;
+			mutate(plan.tasks[0]!);
+			const raw = JSON.stringify(plan);
+			const dir = await fs.mkdtemp(path.join(os.tmpdir(), `ci-dev-malformed-${label}-`));
+			tempDirs.push(dir);
+			const planFile = path.join(dir, "plan.json");
+			await Bun.write(planFile, raw);
+			const result = await runScript(["--validate-plan"], focusedPath, {
+				CI_DEV_AFFECTED_PLAN: planFile,
+				CI_DEV_PLAN_DIGEST: new Bun.CryptoHasher("sha256").update(raw).digest("hex"),
+				CI_DEV_PLAN_SOURCE_SHA: sourceSha,
+			});
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toContain("affected-plan-invalid");
+		}
+	});
 	test("--task runs exactly the selected planned task", async () => {
-		const { stdout, exitCode } = await runScript(["--task=affected-dry-run"], "scripts/ci-dev-affected.ts");
-		expect(exitCode).toBe(0);
-		// The selected task's group header proves the right single task was chosen,
-		// and the nested --dry-run output proves it actually executed.
-		expect(stdout).toContain("Affected CI selector self-check");
-		expect(stdout).toContain("Dev affected-path CI");
+		const outputFile = path.join(await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-task-")), "github-output.txt");
+		const generated = await runScript(["--matrix-json"], "scripts/ci-dev-affected.ts", { GITHUB_OUTPUT: outputFile });
+		expect(generated.exitCode).toBe(0);
+		const rawPlan = await Bun.file(path.join(repoRoot, ".ci-dev-affected-plan.json")).text();
+		const consumed = await runScript(["--task=ci-dry-run"], "scripts/ci-dev-affected.ts", {
+			CI_DEV_AFFECTED_PLAN: path.join(repoRoot, ".ci-dev-affected-plan.json"),
+			CI_DEV_PLAN_DIGEST: new Bun.CryptoHasher("sha256").update(rawPlan).digest("hex"),
+			CI_DEV_PLAN_SOURCE_SHA: sourceSha,
+		});
+		expect(consumed.exitCode).toBe(0);
+		expect(consumed.stdout).toContain("Affected CI selector dry-run");
+		expect(consumed.stdout).toContain("Dev affected-path CI");
 	});
 
 	test("--task fails loudly on a key absent from the current plan", async () => {
-		const { stderr, exitCode } = await runScript(["--task=does-not-exist"], "docs/readme.md");
+		const outputFile = path.join(await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-missing-")), "github-output.txt");
+		await runScript(["--matrix-json"], "docs/readme.md", { GITHUB_OUTPUT: outputFile });
+		const rawPlan = await Bun.file(path.join(repoRoot, ".ci-dev-affected-plan.json")).text();
+		const { stderr, exitCode } = await runScript(["--task=does-not-exist"], "docs/readme.md", {
+			CI_DEV_AFFECTED_PLAN: path.join(repoRoot, ".ci-dev-affected-plan.json"),
+			CI_DEV_PLAN_DIGEST: new Bun.CryptoHasher("sha256").update(rawPlan).digest("hex"),
+			CI_DEV_PLAN_SOURCE_SHA: sourceSha,
+		});
 		expect(exitCode).toBe(1);
 		expect(stderr).toContain("not in the current plan");
 	});
 
 	test("--native-build is a no-op when the plan has no native build task", async () => {
-		const { stdout, exitCode } = await runScript(["--native-build"], "docs/readme.md");
+		const outputFile = path.join(await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-native-")), "github-output.txt");
+		await runScript(["--matrix-json"], "docs/readme.md", { GITHUB_OUTPUT: outputFile });
+		const rawPlan = await Bun.file(path.join(repoRoot, ".ci-dev-affected-plan.json")).text();
+		const { stdout, exitCode } = await runScript(["--native-build"], "docs/readme.md", {
+			CI_DEV_AFFECTED_PLAN: path.join(repoRoot, ".ci-dev-affected-plan.json"),
+			CI_DEV_PLAN_DIGEST: new Bun.CryptoHasher("sha256").update(rawPlan).digest("hex"),
+			CI_DEV_PLAN_SOURCE_SHA: sourceSha,
+		});
 		expect(exitCode).toBe(0);
 		expect(stdout).toContain("no native build tasks in plan");
 	});
@@ -845,12 +1500,12 @@ describe("planTargetedTasks PR-mode targeting", () => {
 
 	test("a single coding-agent test change runs only that test, not the whole package suite", () => {
 		const tasks = targeted(["packages/coding-agent/test/edit/foo.test.ts"]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 		expect(keys).toContain("test:packages/coding-agent/test/edit/foo.test.ts");
 		// No broad package-wide test, and no other coding-agent test file.
 		expect(keys).not.toContain("test:@gajae-code/coding-agent");
 		expect(keys).not.toContain("test:packages/coding-agent/test/edit/bar.test.ts");
-		const testTask = tasks.find(task => task.key === "test:packages/coding-agent/test/edit/foo.test.ts");
+		const testTask = tasks.find((task) => task.key === "test:packages/coding-agent/test/edit/foo.test.ts");
 		expect(testTask?.command).toEqual(["bun", "test", "packages/coding-agent/test/edit/foo.test.ts"]);
 	});
 
@@ -864,21 +1519,21 @@ describe("planTargetedTasks PR-mode targeting", () => {
 			"packages/coding-agent/test/coordinator-mcp/send-prompt-concurrency.test.ts",
 		]) {
 			const tasks = targeted([changedPath]);
-			const keys = tasks.map(task => task.key);
+			const keys = tasks.map((task) => task.key);
 			expect(keys).toContain(shardOne);
-			expect(tasks.find(task => task.key === shardOne)?.command).toEqual(["bun", "test", "--shard=1/8"]);
-			expect(keys.filter(key => key.startsWith("test:@gajae-code/coding-agent:shard-"))).toEqual([shardOne]);
+			expect(tasks.find((task) => task.key === shardOne)?.command).toEqual(["bun", "test", "--shard=1/8"]);
+			expect(keys.filter((key) => key.startsWith("test:@gajae-code/coding-agent:shard-"))).toEqual([shardOne]);
 		}
 	});
 
 	test("basename collisions fall back to package checks instead of arbitrary tests", () => {
 		const tasks = targeted(["packages/coding-agent/src/sdk/bus/index.ts"]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 		expect(keys).toContain("check:@gajae-code/coding-agent");
 		expect(keys).toContain("test:@gajae-code/coding-agent:shard-1-of-8");
 		expect(keys).not.toContain("test:packages/coding-agent/test/sdk/index.test.ts");
 		expect(keys).not.toContain("test:packages/coding-agent/test/other/index.test.ts");
-		expect(describeTasks(tasks).find(entry => entry.key === "check:@gajae-code/coding-agent")).toMatchObject({
+		expect(describeTasks(tasks).find((entry) => entry.key === "check:@gajae-code/coding-agent")).toMatchObject({
 			native: true,
 			nativeBuild: false,
 		});
@@ -886,24 +1541,26 @@ describe("planTargetedTasks PR-mode targeting", () => {
 
 	test("a deleted test path is not scheduled as a runnable test shard", () => {
 		const tasks = targeted(["packages/coding-agent/test/edit/deleted.test.ts"]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 		expect(keys).not.toContain("test:packages/coding-agent/test/edit/deleted.test.ts");
 		expect(keys).not.toContain("test:@gajae-code/coding-agent");
 		expect(keys).toContain("check:@gajae-code/coding-agent");
 		expect(keys).toContain("cli-smoke");
-		expect(keys.filter(key => key === "native-linux-x64" || key === "native-build")).toEqual(["native-linux-x64"]);
+		expect(keys.filter((key) => key === "native-linux-x64" || key === "native-build")).toEqual(["native-linux-x64"]);
 	});
 
 	test("the live RLM e2e test gets native artifacts for skipped import-time setup", () => {
 		const tasks = targeted(["packages/coding-agent/test/rlm-live-model-e2e.test.ts"]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 		expect(keys).toContain("test:packages/coding-agent/test/rlm-live-model-e2e.test.ts");
-		expect(keys.filter(key => key === "native-linux-x64" || key === "native-build")).toEqual(["native-linux-x64"]);
+		expect(keys.filter((key) => key === "native-linux-x64" || key === "native-build")).toEqual(["native-linux-x64"]);
 		expect(keys).not.toContain("test:@gajae-code/coding-agent");
 		expect(keys).not.toContain("check:@gajae-code/coding-agent");
 
 		const entries = describeTasks(tasks);
-		const liveShard = entries.find(entry => entry.key === "test:packages/coding-agent/test/rlm-live-model-e2e.test.ts");
+		const liveShard = entries.find(
+			(entry) => entry.key === "test:packages/coding-agent/test/rlm-live-model-e2e.test.ts",
+		);
 		expect(liveShard).toEqual({
 			key: "test:packages/coding-agent/test/rlm-live-model-e2e.test.ts",
 			identity: "legacy:dGVzdDpwYWNrYWdlcy9jb2RpbmctYWdlbnQvdGVzdC9ybG0tbGl2ZS1tb2RlbC1lMmUudGVzdC50cw:Lg",
@@ -915,12 +1572,12 @@ describe("planTargetedTasks PR-mode targeting", () => {
 			nextest: false,
 			nativeBuild: false,
 		});
-		expect(entries.find(entry => entry.key === "native-linux-x64")?.nativeBuild).toBe(true);
+		expect(entries.find((entry) => entry.key === "native-linux-x64")?.nativeBuild).toBe(true);
 	});
 
 	test("a source file with a directly-named test maps exclusively to that test", () => {
 		const tasks = targeted(["packages/coding-agent/src/edit/foo.ts"]);
-		expect(tasks.map(task => task.key)).toEqual([
+		expect(tasks.map((task) => task.key)).toEqual([
 			"test:packages/coding-agent/test/edit/foo.test.ts",
 			"native-linux-x64",
 		]);
@@ -928,15 +1585,15 @@ describe("planTargetedTasks PR-mode targeting", () => {
 
 	test("a source file with no mapped test runs the owning package check, not its test suite", () => {
 		const tasks = targeted(["packages/coding-agent/src/edit/unmapped.ts"]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 		expect(keys).toContain("check:@gajae-code/coding-agent");
 		expect(keys).toContain("cli-smoke"); // coding-agent runtime smoke
-		expect(keys.some(key => key.startsWith("test:"))).toBe(false);
+		expect(keys.some((key) => key.startsWith("test:"))).toBe(false);
 	});
 
 	test("main entrypoint adds its behavioral contract test without replacing owner fallback coverage", () => {
 		const tasks = targeted(["packages/coding-agent/src/main.ts"]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 		expect(keys).toEqual([
 			"test:packages/coding-agent/test/startup-update-contract.test.ts",
 			"check:@gajae-code/coding-agent",
@@ -949,55 +1606,59 @@ describe("planTargetedTasks PR-mode targeting", () => {
 			cwd: resolvePackageCwd("packages/coding-agent"),
 		});
 		expect(tasks[2]?.command).toEqual(["bun", "run", "ci:test:smoke"]);
-		expect(keys.filter(key => key === "native-linux-x64")).toHaveLength(1);
+		expect(keys.filter((key) => key === "native-linux-x64")).toHaveLength(1);
 	});
 
 	test("a CI workflow change plans yaml-parse + ci-selftest + ci-dry-run only", () => {
 		const tasks = targeted([".github/workflows/dev-ci.yml"]);
-		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest", "yaml-parse"]);
+		expect(tasks.map((task) => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest", "yaml-parse"]);
 	});
 
 	test("a CI harness script change plans ci-selftest + ci-dry-run (no yaml-parse)", () => {
 		const tasks = targeted(["scripts/ci-dev-affected.ts"]);
-		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest"]);
+		expect(tasks.map((task) => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest"]);
 	});
 
 	test("native platform package changes plan release publish validation", () => {
 		const tasks = targeted(["packages/natives-linux-x64/package.json"]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 		expect(keys).toContain("release-publish-contract");
 		expect(keys).toContain("release-publish-dry-run");
 	});
 
 	test("bridge-client changes retain package validation alongside release publish coverage", () => {
 		const tasks = targeted(["packages/bridge-client/src/client.ts"]);
-		const keys = tasks.map(task => task.key);
-		expect(keys.filter(key => key === "check:@gajae-code/bridge-client")).toHaveLength(1);
-		expect(keys.filter(key => key === "release-publish-contract")).toHaveLength(1);
-		expect(keys.filter(key => key === "release-publish-dry-run")).toHaveLength(1);
-		expect(keys.filter(key => key === "test:scripts/release-evidence.test.ts")).toHaveLength(1);
-		expect(keys.filter(key => key === "bridge-client-sdk-package-smoke")).toHaveLength(1);
-		expect(keys.filter(key => key === "test:packages/bridge-client/test/client.test.ts")).toHaveLength(1);
-		expect(tasks.find(task => task.key === "bridge-client-sdk-package-smoke")?.command).toEqual([
+		const keys = tasks.map((task) => task.key);
+		expect(keys.filter((key) => key === "check:@gajae-code/bridge-client")).toHaveLength(1);
+		expect(keys.filter((key) => key === "release-publish-contract")).toHaveLength(1);
+		expect(keys.filter((key) => key === "release-publish-dry-run")).toHaveLength(1);
+		expect(keys.filter((key) => key === "test:scripts/release-evidence.test.ts")).toHaveLength(1);
+		expect(keys.filter((key) => key === "bridge-client-sdk-package-smoke")).toHaveLength(1);
+		expect(keys.filter((key) => key === "test:packages/bridge-client/test/client.test.ts")).toHaveLength(1);
+		expect(tasks.find((task) => task.key === "bridge-client-sdk-package-smoke")?.command).toEqual([
 			"bun",
 			"packages/coding-agent/scripts/build-sdk-package-smoke.ts",
 		]);
-		expect(describeTasks(tasks).find(task => task.key === "bridge-client-sdk-package-smoke")?.native).toBe(true);
-		expect(keys.filter(key => key === "native-linux-x64")).toHaveLength(1);
+		expect(describeTasks(tasks).find((task) => task.key === "bridge-client-sdk-package-smoke")?.native).toBe(true);
+		expect(keys.filter((key) => key === "native-linux-x64")).toHaveLength(1);
 	});
 
 	test("release evidence source changes select contract, dry-run, and focused evidence coverage once", () => {
 		const tasks = targeted(["scripts/release-evidence.ts", "scripts/ci-release-publish.ts"]);
-		const keys = tasks.map(task => task.key);
-		expect(keys.filter(key => key === "release-publish-contract")).toHaveLength(1);
-		expect(keys.filter(key => key === "release-publish-dry-run")).toHaveLength(1);
-		expect(keys.filter(key => key === "test:scripts/release-evidence.test.ts")).toHaveLength(1);
-		expect(tasks.find(task => task.key === "test:scripts/release-evidence.test.ts")?.command).toEqual(["bun", "test", "scripts/release-evidence.test.ts"]);
+		const keys = tasks.map((task) => task.key);
+		expect(keys.filter((key) => key === "release-publish-contract")).toHaveLength(1);
+		expect(keys.filter((key) => key === "release-publish-dry-run")).toHaveLength(1);
+		expect(keys.filter((key) => key === "test:scripts/release-evidence.test.ts")).toHaveLength(1);
+		expect(tasks.find((task) => task.key === "test:scripts/release-evidence.test.ts")?.command).toEqual([
+			"bun",
+			"test",
+			"scripts/release-evidence.test.ts",
+		]);
 	});
 
 	test("unscoped wrapper package changes keep wrapper-version smoke with release validation", () => {
 		const tasks = targeted(["packages/gajae-code/bin/gjc.js"]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 		expect(keys).toContain("release-publish-contract");
 		expect(keys).toContain("release-publish-dry-run");
 		expect(keys).toContain("wrapper-version");
@@ -1005,11 +1666,11 @@ describe("planTargetedTasks PR-mode targeting", () => {
 
 	test("root-level codeish fallback plans the native artifact required by the bounded check", () => {
 		const tasks = targeted(["scripts/unmapped-tool.ts"]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 		expect(keys).toContain("root-check");
 		expect(keys).toContain("native-linux-x64");
 
-		const rootCheck = describeTasks(tasks).find(entry => entry.key === "root-check");
+		const rootCheck = describeTasks(tasks).find((entry) => entry.key === "root-check");
 		expect(rootCheck).toMatchObject({ command: ["bun", "run", "ci:check:full"], native: true, nativeBuild: false });
 	});
 
@@ -1017,16 +1678,15 @@ describe("planTargetedTasks PR-mode targeting", () => {
 		expect(targeted(["docs/guide.md", "CHANGELOG.md", "packages/coding-agent/README.md"])).toEqual([]);
 	});
 
-
 	test("native-consuming test files pull in a single native build task", () => {
 		const tasks = targeted(["packages/coding-agent/test/cli.test.ts"]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 		expect(keys).toContain("test:packages/coding-agent/test/cli.test.ts");
 		// ensureNativeBuild adds exactly one native build task (built once, shared).
-		expect(keys.filter(key => key === "native-linux-x64" || key === "native-build")).toEqual(["native-linux-x64"]);
+		expect(keys.filter((key) => key === "native-linux-x64" || key === "native-build")).toEqual(["native-linux-x64"]);
 
 		const entries = describeTasks(tasks);
-		const cliShard = entries.find(entry => entry.key === "test:packages/coding-agent/test/cli.test.ts");
+		const cliShard = entries.find((entry) => entry.key === "test:packages/coding-agent/test/cli.test.ts");
 		expect(cliShard?.native).toBe(true);
 	});
 });
@@ -1045,10 +1705,10 @@ describe("push-mode broad planning still runs the fuller suite", () => {
 	};
 	test("push mode splits the package-wide coding-agent test across bounded shards", () => {
 		const tasks = planTasks(["packages/coding-agent/src/edit/foo.ts"], [codingAgent]);
-		const keys = tasks.map(task => task.key);
-		const testShards = tasks.filter(task => task.key.startsWith("test:@gajae-code/coding-agent:shard-"));
+		const keys = tasks.map((task) => task.key);
+		const testShards = tasks.filter((task) => task.key.startsWith("test:@gajae-code/coding-agent:shard-"));
 		// Broad planner keeps the post-merge fuller suite, but not as one 30m shard.
-		expect(testShards.map(task => task.key)).toEqual([
+		expect(testShards.map((task) => task.key)).toEqual([
 			"test:@gajae-code/coding-agent:shard-1-of-8",
 			"test:@gajae-code/coding-agent:shard-2-of-8",
 			"test:@gajae-code/coding-agent:shard-3-of-8",
@@ -1064,25 +1724,29 @@ describe("push-mode broad planning still runs the fuller suite", () => {
 		expect(keys).toContain("check:@gajae-code/coding-agent");
 
 		const entries = describeTasks(tasks);
-		expect(entries.find(entry => entry.key === "test:@gajae-code/coding-agent:shard-1-of-8")?.native).toBe(true);
+		expect(entries.find((entry) => entry.key === "test:@gajae-code/coding-agent:shard-1-of-8")?.native).toBe(true);
 	});
 
 	test("push mode schedules release evidence contract, dry-run, and focused coverage once", () => {
 		const tasks = planTasks(["scripts/release-evidence.ts", "scripts/ci-release-publish.ts"], [codingAgent]);
-		const keys = tasks.map(task => task.key);
-		expect(keys.filter(key => key === "release-publish-contract")).toHaveLength(1);
-		expect(keys.filter(key => key === "release-publish-dry-run")).toHaveLength(1);
-		expect(keys.filter(key => key === "test:scripts/release-evidence.test.ts")).toHaveLength(1);
-		expect(tasks.find(task => task.key === "test:scripts/release-evidence.test.ts")?.command).toEqual(["bun", "test", "scripts/release-evidence.test.ts"]);
+		const keys = tasks.map((task) => task.key);
+		expect(keys.filter((key) => key === "release-publish-contract")).toHaveLength(1);
+		expect(keys.filter((key) => key === "release-publish-dry-run")).toHaveLength(1);
+		expect(keys.filter((key) => key === "test:scripts/release-evidence.test.ts")).toHaveLength(1);
+		expect(tasks.find((task) => task.key === "test:scripts/release-evidence.test.ts")?.command).toEqual([
+			"bun",
+			"test",
+			"scripts/release-evidence.test.ts",
+		]);
 	});
 
 	test("tooling-script root-check marks the bounded check as a native consumer", () => {
 		const tasks = planTasks(["scripts/unmapped-tool.ts"], [codingAgent]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 		expect(keys).toContain("root-check");
-		expect(keys.filter(key => key === "native-linux-x64" || key === "native-build")).toEqual([]);
+		expect(keys.filter((key) => key === "native-linux-x64" || key === "native-build")).toEqual([]);
 
-		const rootCheck = describeTasks(tasks).find(entry => entry.key === "root-check");
+		const rootCheck = describeTasks(tasks).find((entry) => entry.key === "root-check");
 		expect(rootCheck).toMatchObject({ command: ["bun", "run", "ci:check:full"], native: true, nativeBuild: false });
 	});
 
@@ -1091,26 +1755,28 @@ describe("push-mode broad planning still runs the fuller suite", () => {
 			["packages/bridge-client/package.json", "packages/coding-agent/src/sdk/client/client.ts"],
 			[codingAgent, bridgeClient],
 		);
-		const keys = tasks.map(task => task.key);
-		expect(keys.filter(key => key === "bridge-client-sdk-package-smoke")).toHaveLength(1);
-		expect(tasks.find(task => task.key === "bridge-client-sdk-package-smoke")?.command).toEqual([
+		const keys = tasks.map((task) => task.key);
+		expect(keys.filter((key) => key === "bridge-client-sdk-package-smoke")).toHaveLength(1);
+		expect(tasks.find((task) => task.key === "bridge-client-sdk-package-smoke")?.command).toEqual([
 			"bun",
 			"packages/coding-agent/scripts/build-sdk-package-smoke.ts",
 		]);
-		expect(describeTasks(tasks).find(task => task.key === "bridge-client-sdk-package-smoke")?.native).toBe(true);
-		expect(keys.filter(key => key === "native-linux-x64")).toHaveLength(1);
-		expect(keys.filter(key => key === "release-publish-contract")).toHaveLength(1);
-		expect(keys.filter(key => key === "release-publish-dry-run")).toHaveLength(1);
+		expect(describeTasks(tasks).find((task) => task.key === "bridge-client-sdk-package-smoke")?.native).toBe(true);
+		expect(keys.filter((key) => key === "native-linux-x64")).toHaveLength(1);
+		expect(keys.filter((key) => key === "release-publish-contract")).toHaveLength(1);
+		expect(keys.filter((key) => key === "release-publish-dry-run")).toHaveLength(1);
 	});
 
 	test("full-workspace changes partition root tests into matrix shards", () => {
 		const tasks = planTasks(["tsconfig.json"], [codingAgent]);
-		const keys = tasks.map(task => task.key);
+		const keys = tasks.map((task) => task.key);
 
 		expect(keys).toContain("root-check");
 		expect(keys).toContain("root-test:release");
 		expect(keys).not.toContain("root-test");
-		expect(tasks.filter(task => task.key.startsWith("test:@gajae-code/coding-agent:shard-")).map(task => task.key)).toEqual([
+		expect(
+			tasks.filter((task) => task.key.startsWith("test:@gajae-code/coding-agent:shard-")).map((task) => task.key),
+		).toEqual([
 			"test:@gajae-code/coding-agent:shard-1-of-8",
 			"test:@gajae-code/coding-agent:shard-2-of-8",
 			"test:@gajae-code/coding-agent:shard-3-of-8",
@@ -1125,7 +1791,9 @@ describe("push-mode broad planning still runs the fuller suite", () => {
 
 describe("normalizeChangedPaths", () => {
 	test("normalizes, deduplicates, and orders safe repository-relative paths", () => {
-		expect(normalizeChangedPaths(["packages\\stats/src/index.ts", "./packages/stats/src/index.ts"])).toEqual(["packages/stats/src/index.ts"]);
+		expect(normalizeChangedPaths(["packages\\stats/src/index.ts", "./packages/stats/src/index.ts"])).toEqual([
+			"packages/stats/src/index.ts",
+		]);
 	});
 
 	test("rejects absolute and escaping paths", () => {
@@ -1139,7 +1807,9 @@ describe("build inventory validation", () => {
 	test("rejects unknown fields and duplicate Cargo names without the typed emergency", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-inventory-"));
 		try {
-			const source = JSON.parse(await Bun.file(path.join(import.meta.dir, "ci-dev-affected-build-inventory.json")).text()) as {
+			const source = JSON.parse(
+				await Bun.file(path.join(import.meta.dir, "ci-dev-affected-build-inventory.json")).text(),
+			) as {
 				schemaVersion: number;
 				typescript: Array<Record<string, unknown>>;
 				cargo: Array<Record<string, unknown>>;
@@ -1150,9 +1820,13 @@ describe("build inventory validation", () => {
 			await expect(loadBuildInventory(unknownPath)).rejects.toThrow("unexpected build inventory field");
 
 			const duplicatePath = path.join(root, "duplicate.json");
-			const duplicateCargo = source.cargo.map((unit, index) => index === 1 ? { ...unit, name: source.cargo[0]?.name } : unit);
+			const duplicateCargo = source.cargo.map((unit, index) =>
+				index === 1 ? { ...unit, name: source.cargo[0]?.name } : unit,
+			);
 			await Bun.write(duplicatePath, JSON.stringify({ ...source, cargo: duplicateCargo, emergency: {} }));
-			await expect(loadBuildInventory(duplicatePath)).rejects.toThrow("duplicate Cargo names require workspace emergency");
+			await expect(loadBuildInventory(duplicatePath)).rejects.toThrow(
+				"duplicate Cargo names require workspace emergency",
+			);
 		} finally {
 			await fs.rm(root, { recursive: true, force: true });
 		}
@@ -1160,21 +1834,51 @@ describe("build inventory validation", () => {
 });
 
 describe("workspace dependent closure", () => {
-	const leaf: WorkspacePackage = { name: "leaf", dir: "packages/leaf", manifest: { name: "leaf", dependencies: { top: "workspace:*" } } };
-	const middle: WorkspacePackage = { name: "middle", dir: "packages/middle", manifest: { name: "middle", dependencies: { leaf: "workspace:*" } } };
-	const top: WorkspacePackage = { name: "top", dir: "packages/top", manifest: { name: "top", dependencies: { middle: "workspace:*" } } };
+	const leaf: WorkspacePackage = {
+		name: "leaf",
+		dir: "packages/leaf",
+		manifest: { name: "leaf", dependencies: { top: "workspace:*" } },
+	};
+	const middle: WorkspacePackage = {
+		name: "middle",
+		dir: "packages/middle",
+		manifest: { name: "middle", dependencies: { leaf: "workspace:*" } },
+	};
+	const top: WorkspacePackage = {
+		name: "top",
+		dir: "packages/top",
+		manifest: { name: "top", dependencies: { middle: "workspace:*" } },
+	};
 	const graph = [leaf, middle, top];
 
 	test("selects direct and transitive dependents through a cycle without duplicates", () => {
-		expect(expandWithDependents([leaf], graph).map(unit => unit.name)).toEqual(["leaf", "middle", "top"]);
-		expect(expandWithDependents([middle], graph).map(unit => unit.name)).toEqual(["leaf", "middle", "top"]);
+		expect(expandWithDependents([leaf], graph).map((unit) => unit.name)).toEqual(["leaf", "middle", "top"]);
+		expect(expandWithDependents([middle], graph).map((unit) => unit.name)).toEqual(["leaf", "middle", "top"]);
 	});
 });
 
 describe("Cargo workspace ambiguity", () => {
-	const first: CargoInventoryUnit = { id: "first", name: "duplicate", manifestPath: "crates/first/Cargo.toml", supported: true, nativeAddonSource: false };
-	const second: CargoInventoryUnit = { id: "second", name: "duplicate", manifestPath: "crates/second/Cargo.toml", supported: true, nativeAddonSource: false };
-	const unique: CargoInventoryUnit = { id: "unique", name: "unique", manifestPath: "crates/unique/Cargo.toml", supported: true, nativeAddonSource: false };
+	const first: CargoInventoryUnit = {
+		id: "first",
+		name: "duplicate",
+		manifestPath: "crates/first/Cargo.toml",
+		supported: true,
+		nativeAddonSource: false,
+	};
+	const second: CargoInventoryUnit = {
+		id: "second",
+		name: "duplicate",
+		manifestPath: "crates/second/Cargo.toml",
+		supported: true,
+		nativeAddonSource: false,
+	};
+	const unique: CargoInventoryUnit = {
+		id: "unique",
+		name: "unique",
+		manifestPath: "crates/unique/Cargo.toml",
+		supported: true,
+		nativeAddonSource: false,
+	};
 	const supported = [first, second, unique];
 
 	test("uses the workspace emergency when any selected name is globally duplicated", () => {

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -132,7 +132,7 @@ describe("dev-ci canonical-plan workflow contract", () => {
 			"run: bun test packages/coding-agent/test/worktree-cli.test.ts",
 			"run: bun test scripts/check-worktree-report-capabilities.test.ts",
 			"run: bun scripts/check-worktree-report-capabilities.ts",
-			"run: bun run check",
+			"run: bun run check:types",
 		])
 			expect(safetyJob, step).toContain(step);
 		for (const forbidden of ["dtolnay/rust-toolchain", "cargo ", "packages/natives", "--native-build"])

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { $ } from "bun";
+import type { Stats } from "node:fs";
 import * as path from "node:path";
 import * as fs from "node:fs/promises";
 
@@ -22,7 +23,112 @@ const CODING_AGENT_SHARD_ONE_COVERAGE_PATHS = [
 	"packages/coding-agent/test/coordinator-mcp/send-prompt-concurrency.test.ts",
 ] as const;
 
+const WORKTREE_FOCUSED_PATHS: ReadonlySet<string> = new Set([
+	"packages/coding-agent/src/cli.ts",
+	"packages/coding-agent/src/commands/worktree.ts",
+	"packages/coding-agent/src/cli/worktree-cli.ts",
+	"packages/coding-agent/src/cli/worktree-scanner.ts",
+	"packages/coding-agent/test/worktree-cli.test.ts",
+	"packages/coding-agent/CHANGELOG.md",
+	"scripts/check-worktree-report-capabilities.ts",
+	"scripts/check-worktree-report-capabilities.test.ts",
+	"scripts/ci-dev-affected.ts",
+	"scripts/ci-dev-affected.test.ts",
+	".github/workflows/dev-ci.yml",
+]);
+const WORKTREE_FIXTURE_PREFIX = "scripts/fixtures/worktree-report-capabilities/";
 
+export function hasWorktreeSafetyChange(paths: readonly string[]): boolean {
+	return isFocusedWorktreeOnly(paths);
+}
+
+export function isFocusedWorktreeOnly(paths: readonly string[]): boolean {
+	return (
+		paths.length > 0 &&
+		paths.every((candidate) => WORKTREE_FOCUSED_PATHS.has(candidate) || candidate.startsWith(WORKTREE_FIXTURE_PREFIX))
+	);
+}
+
+function addFocusedTask(
+	tasks: Map<string, Task>,
+	key: string,
+	description: string,
+	command: readonly string[],
+	cwd?: string,
+): void {
+	if (tasks.has(key)) return;
+	tasks.set(key, {
+		key,
+		description,
+		command,
+		cwd,
+		capabilities: {
+			rust: false,
+			nextest: false,
+			nativeConsumer: false,
+			nativeProducer: false,
+		},
+		phase: "legacy",
+	});
+}
+
+export function planFocusedWorktreeTasks(paths: readonly string[]): Task[] {
+	const tasks = new Map<string, Task>();
+	const codingAgent = paths.some((candidate) => candidate.startsWith("packages/coding-agent/"));
+	const verifier = paths.some(
+		(candidate) =>
+			candidate === "scripts/check-worktree-report-capabilities.ts" ||
+			candidate === "scripts/check-worktree-report-capabilities.test.ts" ||
+			candidate.startsWith(WORKTREE_FIXTURE_PREFIX),
+	);
+	const selector = paths.some(
+		(candidate) => candidate === "scripts/ci-dev-affected.ts" || candidate === "scripts/ci-dev-affected.test.ts",
+	);
+	const workflow = paths.includes(".github/workflows/dev-ci.yml");
+	if (codingAgent) {
+		addFocusedTask(tasks, "test:worktree-cli", "Test packages/coding-agent/test/worktree-cli.test.ts", [
+			"bun",
+			"test",
+			"packages/coding-agent/test/worktree-cli.test.ts",
+		]);
+		addFocusedTask(
+			tasks,
+			"check:coding-agent",
+			"Check @gajae-code/coding-agent",
+			["bun", "run", "check"],
+			resolvePackageCwd("packages/coding-agent"),
+		);
+	}
+	if (verifier) {
+		addFocusedTask(tasks, "test:worktree-capabilities", "Test scripts/check-worktree-report-capabilities.test.ts", [
+			"bun",
+			"test",
+			"scripts/check-worktree-report-capabilities.test.ts",
+		]);
+		addFocusedTask(tasks, "verify:worktree-capabilities", "Verify worktree report capabilities", [
+			"bun",
+			"scripts/check-worktree-report-capabilities.ts",
+		]);
+	}
+	if (selector || workflow) {
+		addFocusedTask(tasks, "ci-selftest", "Affected CI selector unit tests", [
+			"bun",
+			"test",
+			"scripts/ci-dev-affected.test.ts",
+		]);
+		addFocusedTask(tasks, "ci-dry-run", "Affected CI selector dry-run", [
+			"bun",
+			"scripts/ci-dev-affected.ts",
+			"--dry-run",
+		]);
+	}
+	if (workflow)
+		addFocusedTask(tasks, "workflow-yaml-parse", "Workflow YAML parse check", [
+			"bun",
+			"scripts/check-workflow-yaml.ts",
+		]);
+	return Array.from(tasks.values());
+}
 // Keys for tasks that compile the @gajae-code/natives addon. They run once in
 // the dedicated dev-ci native-build job (not as matrix shards) and publish the
 // built `.node` files as an artifact the runtime-dependent shards download.
@@ -122,10 +228,6 @@ export interface TaskMatrixEntry {
 async function main(): Promise<void> {
 	const dryRun = process.argv.includes("--dry-run");
 
-	if (process.argv.includes("--emit-flags")) {
-		await emitAffectedFlags();
-		return;
-	}
 	if (process.argv.includes("--matrix-json")) {
 		await emitMatrix();
 		return;
@@ -154,7 +256,7 @@ async function main(): Promise<void> {
 		await runNativeBuild();
 		return;
 	}
-	const taskArg = process.argv.find(arg => arg.startsWith("--task="));
+	const taskArg = process.argv.find((arg) => arg.startsWith("--task="));
 	if (taskArg) {
 		await runSingleTask(taskArg.slice("--task=".length));
 		return;
@@ -178,7 +280,6 @@ async function main(): Promise<void> {
 	}
 }
 
-
 // CI runs in one of two planning modes:
 //   - "pr": pull_request runs get a fast, narrowly targeted plan (run only the
 //     tests/checks directly relevant to the changed paths).
@@ -199,14 +300,16 @@ export function resolvePlanMode(): PlanMode {
 // Resolve the plan for the current changed paths and CI mode. PR mode builds the
 // targeted plan from a filesystem index of test files (for source→test mapping);
 // push mode reuses the broad affected planner unchanged.
-async function resolvePlannedTasks(paths: readonly string[]): Promise<Task[]> {
+async function resolvePlannedTasks(paths: string[]): Promise<Task[]> {
+	const normalizedPaths = normalizeChangedPaths(paths);
 	const fromArtifact = await loadCanonicalPlan();
 	if (fromArtifact) return fromArtifact;
-	const normalizedPaths = normalizeChangedPaths(paths);
+	if (isFocusedWorktreeOnly(normalizedPaths)) return planFocusedWorktreeTasks(normalizedPaths);
 	const packages = await getWorkspacePackages();
-	const legacy = resolvePlanMode() === "pr"
-		? planTargetedTasks(normalizedPaths, packages, await gatherTestFiles())
-		: planTasks(normalizedPaths, packages);
+	const legacy =
+		resolvePlanMode() === "pr"
+			? planTargetedTasks(normalizedPaths, packages, await gatherTestFiles())
+			: planTasks(normalizedPaths, packages);
 	if (normalizedPaths.length > 0 && normalizedPaths.every(isDocOrChangelogPath)) return legacy;
 	return appendBuildTasks(legacy, normalizedPaths, packages, await loadBuildInventory());
 }
@@ -228,32 +331,6 @@ async function gatherTestFiles(): Promise<string[]> {
 	}
 	return Array.from(found).sort();
 }
-// `--emit-flags` resolves changed paths exactly as a normal run does, then
-// reports whether the resulting plan needs the Rust toolchain (rust-check /
-// rust-test) and/or a native build, so dev-ci can gate its Rust setup. It
-// fails open (rust=true native=true) on any error or unresolved base so CI
-// never skips Rust setup it actually needs.
-async function emitAffectedFlags(): Promise<void> {
-	let rust = true;
-	let native = true;
-	try {
-		const paths = await getChangedPaths();
-		const packages = await getWorkspacePackages();
-		const planned = planTasks(paths, packages);
-		const keys = new Set(planned.map(task => task.key));
-		rust = keys.has("rust-check") || keys.has("rust-test");
-		native = keys.has("native-build") || keys.has("native-linux-x64");
-		console.log(`ci-dev-affected: rust=${rust} native=${native} (changed paths: ${paths.length})`);
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		console.log(`ci-dev-affected: flag computation failed (${message}); failing open to rust=true native=true`);
-		rust = true;
-		native = true;
-	}
-	if (process.env.GITHUB_OUTPUT) {
-		await fs.appendFile(process.env.GITHUB_OUTPUT, `rust=${rust}\nnative=${native}\n`);
-	}
-}
 
 function isNativeBuildKey(key: string): boolean {
 	return NATIVE_BUILD_KEYS.has(key);
@@ -273,24 +350,39 @@ function taskNeedsNative(key: string): boolean {
 		key === "deep-interview-definitions" ||
 		key === "deep-interview-runtime" ||
 		key === "bridge-client-sdk-package-smoke" ||
-		key.startsWith("test:")
+		(key.startsWith("test:") && !["test:worktree-cli", "test:worktree-capabilities"].includes(key))
 	);
 }
 
 // Tasks that need the Rust toolchain (and nextest) provisioned on their shard.
 function taskNeedsRust(key: string): boolean {
-	return key === "rust-check" || key === "rust-test" || key === "ci-selftest" || key === "ci-dry-run" || key === "affected-selftest" || key === "affected-dry-run";
+	return (
+		key === "rust-check" ||
+		key === "rust-test" ||
+		key === "ci-selftest" ||
+		key === "ci-dry-run" ||
+		key === "affected-selftest" ||
+		key === "affected-dry-run"
+	);
+}
+export function normalizeTaskCwdSeparators(value: string): string {
+	return value.replaceAll("\\", "/");
+}
+
+function canonicalTaskCwd(cwd: string | undefined): string {
+	const relative = cwd ? path.relative(repoRoot, cwd) || "." : ".";
+	return normalizeTaskCwdSeparators(relative);
 }
 
 // Build the machine-readable descriptor list for the current changed-path plan.
 // `cwd` is emitted repo-relative so the JSON stays portable across runners.
 export function describeTasks(tasks: readonly Task[]): TaskMatrixEntry[] {
-	return tasks.map(task => ({
+	return tasks.map((task) => ({
 		key: task.key,
 		identity: canonicalTaskIdentity(task),
 		description: task.description,
 		command: task.command,
-		cwd: task.cwd ? path.relative(repoRoot, task.cwd) || "." : undefined,
+		cwd: task.cwd ? canonicalTaskCwd(task.cwd) : undefined,
 		native: task.capabilities?.nativeConsumer ?? taskNeedsNative(task.key),
 		rust: task.capabilities?.rust ?? taskNeedsRust(task.key),
 		nextest: task.capabilities?.nextest ?? task.key === "rust-test",
@@ -312,7 +404,15 @@ async function emitMatrix(): Promise<void> {
 	const mode = resolvePlanMode();
 	const tasks = await resolvePlannedTasks(paths);
 	const entries = describeTasks(tasks);
-	const canonical = JSON.stringify({ schemaVersion: 1, sourceSha, mode, paths, tasks: serializeTasks(tasks) });
+	const worktreeSafetyRequired = hasWorktreeSafetyChange(paths);
+	const canonical = JSON.stringify({
+		schemaVersion: 1,
+		sourceSha,
+		mode,
+		paths,
+		worktreeSafetyRequired,
+		tasks: serializeTasks(tasks),
+	});
 	const digest = new Bun.CryptoHasher("sha256").update(canonical).digest("hex");
 	await Bun.write(path.join(repoRoot, ".ci-dev-affected-plan.json"), canonical);
 	console.log(JSON.stringify(entries));
@@ -320,13 +420,21 @@ async function emitMatrix(): Promise<void> {
 	const githubOutput = process.env.GITHUB_OUTPUT;
 	if (!githubOutput) return;
 	const shards = entries
-		.filter(entry => !entry.nativeBuild)
-		.map(entry => ({ key: entry.key, identity: entry.identity, description: entry.description, native: entry.native, rust: entry.rust, nextest: entry.nextest }));
-	const hasNative = entries.some(entry => entry.nativeBuild);
+		.filter((entry) => !entry.nativeBuild)
+		.map((entry) => ({
+			key: entry.key,
+			identity: entry.identity,
+			description: entry.description,
+			native: entry.native,
+			rust: entry.rust,
+			nextest: entry.nextest,
+		}));
+	const hasNative = entries.some((entry) => entry.nativeBuild);
 	const lines = [
 		`matrix=${JSON.stringify({ include: shards })}`,
 		`has_tasks=${shards.length > 0}`,
 		`has_native=${hasNative}`,
+		`worktree_safety_required=${worktreeSafetyRequired}`,
 		`plan_digest=${digest}`,
 		`plan_source_sha=${sourceSha}`,
 		`plan_mode=${mode}`,
@@ -342,8 +450,8 @@ async function emitMatrix(): Promise<void> {
 // once. The dedicated dev-ci native-build job uses it so the expensive native
 // compile happens a single time per run instead of on each runtime shard.
 async function runNativeBuild(): Promise<void> {
-	const paths = await getChangedPaths();
-	const tasks = (await resolvePlannedTasks(paths)).filter(task => isNativeBuildKey(task.key));
+	const tasks = (await loadCanonicalPlan())?.filter((task) => isNativeBuildKey(task.key));
+	if (!tasks) throw new Error("affected-plan-invalid: native build requires a canonical plan");
 	if (tasks.length === 0) {
 		console.log("ci-dev-affected: no native build tasks in plan; nothing to build.");
 		return;
@@ -363,11 +471,11 @@ async function runNativeBuild(): Promise<void> {
 // error so plan drift between the planner and a shard fails loudly instead of
 // silently skipping validation.
 async function runSingleTask(key: string): Promise<void> {
-	const paths = await getChangedPaths();
-	const tasks = await resolvePlannedTasks(paths);
-	const task = tasks.find(candidate => candidate.key === key);
+	const tasks = await loadCanonicalPlan();
+	if (!tasks) throw new Error("affected-plan-invalid: task execution requires a canonical plan");
+	const task = tasks.find((candidate) => candidate.key === key);
 	if (!task) {
-		const known = tasks.map(candidate => candidate.key).join(", ") || "(none)";
+		const known = tasks.map((candidate) => candidate.key).join(", ") || "(none)";
 		console.error(`ci-dev-affected: task '${key}' is not in the current plan. Planned tasks: ${known}`);
 		process.exit(1);
 		return;
@@ -392,7 +500,7 @@ function printPlan(paths: readonly string[], plannedTasks: readonly Task[]): voi
 	}
 	console.log("Planned tasks:");
 	for (const task of plannedTasks) {
-		const where = task.cwd ? ` (cwd: ${path.relative(repoRoot, task.cwd) || "."})` : "";
+		const where = task.cwd ? ` (cwd: ${canonicalTaskCwd(task.cwd)})` : "";
 		console.log(` - ${task.description}: ${task.command.join(" ")}${where}`);
 	}
 }
@@ -402,7 +510,7 @@ async function getChangedPaths(): Promise<string[]> {
 	if (explicitPaths) {
 		return explicitPaths
 			.split(/[\n,]/)
-			.map(entry => entry.trim())
+			.map((entry) => entry.trim())
 			.filter(Boolean)
 			.sort();
 	}
@@ -498,7 +606,7 @@ async function getWorkspaceDirs(): Promise<string[]> {
 		if (pattern.endsWith("/*")) {
 			const parent = pattern.slice(0, -2);
 			const entries = await Array.fromAsync(new Bun.Glob(`${parent}/*/package.json`).scan({ cwd: repoRoot }));
-			dirs.push(...entries.map(entry => path.dirname(entry)));
+			dirs.push(...entries.map((entry) => path.dirname(entry)));
 		} else if (await Bun.file(path.join(repoRoot, pattern, "package.json")).exists()) {
 			dirs.push(pattern);
 		}
@@ -542,14 +650,23 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	const wrapperChanged = paths.some(isUnscopedWrapperPath);
 	const toolingScriptChanged = paths.some(isToolingScriptPath);
 	const deepInterviewOnly = isDeepInterviewOnly(paths);
-	const needsNativeRuntime = !deepInterviewOnly && (paths.some(isCodingAgentRuntimePath) || wrapperChanged || fullWorkspace);
+	const needsNativeRuntime =
+		!deepInterviewOnly && (paths.some(isCodingAgentRuntimePath) || wrapperChanged || fullWorkspace);
 	const workflowHarnessOnly = paths.length > 0 && paths.every(isWorkflowHarnessPath);
-	const ciOnly = paths.length > 0 && paths.every(changedPath => changedPath.startsWith(".github/"));
+	const ciOnly = paths.length > 0 && paths.every((changedPath) => changedPath.startsWith(".github/"));
 
 	if (deepInterviewOnly) {
 		addNativeBuild(tasks);
-		add(tasks, "deep-interview-definitions", "Deep interview default definition tests", ["bun", "test", "packages/coding-agent/test/default-gjc-definitions.test.ts"]);
-		add(tasks, "deep-interview-runtime", "Deep interview runtime tests", ["bun", "test", "packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts"]);
+		add(tasks, "deep-interview-definitions", "Deep interview default definition tests", [
+			"bun",
+			"test",
+			"packages/coding-agent/test/default-gjc-definitions.test.ts",
+		]);
+		add(tasks, "deep-interview-runtime", "Deep interview runtime tests", [
+			"bun",
+			"test",
+			"packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts",
+		]);
 		return Array.from(tasks.values());
 	}
 
@@ -563,12 +680,18 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 		addWorkspaceTestTasks(tasks, packages);
 	} else if (!ciOnly && !workflowHarnessOnly) {
 		const affectedPackages = expandWithDependents(touchedPackages, packages);
-		if (affectedPackages.some(workspacePackage => workspacePackage.manifest.scripts?.test)) {
+		if (affectedPackages.some((workspacePackage) => workspacePackage.manifest.scripts?.test)) {
 			addNativeBuild(tasks);
 		}
 		for (const workspacePackage of affectedPackages) {
 			if (workspacePackage.manifest.scripts?.check) {
-				add(tasks, `check:${workspacePackage.name}`, `Check ${workspacePackage.name}`, packageScriptCommand("check"), resolvePackageCwd(workspacePackage.dir));
+				add(
+					tasks,
+					`check:${workspacePackage.name}`,
+					`Check ${workspacePackage.name}`,
+					packageScriptCommand("check"),
+					resolvePackageCwd(workspacePackage.dir),
+				);
 			}
 			if (workspacePackage.manifest.scripts?.test) {
 				addPackageTestTasks(tasks, workspacePackage);
@@ -580,13 +703,20 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 		add(tasks, "root-check", "Root TypeScript/tooling check", ["bun", "run", "ci:check:full"]);
 	}
 	if (wrapperChanged) {
-		add(tasks, "wrapper-version", "Unscoped wrapper CLI version smoke", ["bun", "packages/gajae-code/bin/gjc.js", "--version"]);
+		add(tasks, "wrapper-version", "Unscoped wrapper CLI version smoke", [
+			"bun",
+			"packages/gajae-code/bin/gjc.js",
+			"--version",
+		]);
 	}
 	if (publishChanged) {
 		addReleasePublishTasks(tasks);
 	}
 	if (paths.some(isBridgeClientSdkPackageSmokePath)) {
-		add(tasks, "bridge-client-sdk-package-smoke", "Bridge-client SDK package smoke", ["bun", "packages/coding-agent/scripts/build-sdk-package-smoke.ts"]);
+		add(tasks, "bridge-client-sdk-package-smoke", "Bridge-client SDK package smoke", [
+			"bun",
+			"packages/coding-agent/scripts/build-sdk-package-smoke.ts",
+		]);
 	}
 
 	if (rustChanged) {
@@ -600,8 +730,16 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 		add(tasks, "cli-smoke", "GJC CLI smoke test", ["bun", "run", "ci:test:smoke"]);
 	}
 	if (paths.some(isWorkflowOrScriptPath)) {
-		add(tasks, "affected-dry-run", "Affected CI selector self-check", ["bun", "scripts/ci-dev-affected.ts", "--dry-run"]);
-		add(tasks, "affected-selftest", "Affected CI selector unit tests", ["bun", "test", "scripts/ci-dev-affected.test.ts"]);
+		add(tasks, "affected-dry-run", "Affected CI selector self-check", [
+			"bun",
+			"scripts/ci-dev-affected.ts",
+			"--dry-run",
+		]);
+		add(tasks, "affected-selftest", "Affected CI selector unit tests", [
+			"bun",
+			"test",
+			"scripts/ci-dev-affected.test.ts",
+		]);
 		if (paths.some(isWorkflowPath)) {
 			add(tasks, "workflow-yaml-parse", "Workflow YAML parse check", ["bun", "scripts/check-workflow-yaml.ts"]);
 		}
@@ -622,9 +760,13 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 // Native builds are added once (native-linux-x64) only when a planned task needs
 // the addon at runtime; the dedicated job restores it from cache when no native
 // source changed, so PRs never rebuild native per shard.
-export function planTargetedTasks(paths: readonly string[], packages: readonly WorkspacePackage[], testFiles: readonly string[]): Task[] {
+export function planTargetedTasks(
+	paths: readonly string[],
+	packages: readonly WorkspacePackage[],
+	testFiles: readonly string[],
+): Task[] {
 	const tasks = new Map<string, Task>();
-	const relevant = paths.filter(changedPath => !isDocOrChangelogPath(changedPath));
+	const relevant = paths.filter((changedPath) => !isDocOrChangelogPath(changedPath));
 	if (relevant.length === 0) {
 		return [];
 	}
@@ -662,11 +804,18 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 		if (isReleasePublishPath(changedPath)) {
 			addReleasePublishTasks(tasks);
 			if (isUnscopedWrapperPath(changedPath)) {
-				add(tasks, "wrapper-version", "Unscoped wrapper CLI version smoke", ["bun", "packages/gajae-code/bin/gjc.js", "--version"]);
+				add(tasks, "wrapper-version", "Unscoped wrapper CLI version smoke", [
+					"bun",
+					"packages/gajae-code/bin/gjc.js",
+					"--version",
+				]);
 			}
 		}
 		if (isBridgeClientSdkPackageSmokePath(changedPath)) {
-			add(tasks, "bridge-client-sdk-package-smoke", "Bridge-client SDK package smoke", ["bun", "packages/coding-agent/scripts/build-sdk-package-smoke.ts"]);
+			add(tasks, "bridge-client-sdk-package-smoke", "Bridge-client SDK package smoke", [
+				"bun",
+				"packages/coding-agent/scripts/build-sdk-package-smoke.ts",
+			]);
 			const bridgeClientOwner = owningPackage(changedPath, packages);
 			if (bridgeClientOwner?.manifest.scripts?.check) {
 				add(
@@ -678,7 +827,6 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 				);
 			}
 		}
-
 
 		const mappedTests = mappedTestsFor(changedPath, packages, testFiles);
 		for (const testFile of mappedTests) {
@@ -698,13 +846,23 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 		const owner = owningPackage(changedPath, packages);
 		if (owner) {
 			if (owner.manifest.scripts?.check) {
-				add(tasks, `check:${owner.name}`, `Check ${owner.name}`, packageScriptCommand("check"), resolvePackageCwd(owner.dir));
+				add(
+					tasks,
+					`check:${owner.name}`,
+					`Check ${owner.name}`,
+					packageScriptCommand("check"),
+					resolvePackageCwd(owner.dir),
+				);
 			}
 			if (isCodingAgentRuntimePath(changedPath)) {
 				add(tasks, "cli-smoke", "GJC CLI smoke test", ["bun", "run", "ci:test:smoke"]);
 			}
 			if (isUnscopedWrapperPath(changedPath)) {
-				add(tasks, "wrapper-version", "Unscoped wrapper CLI version smoke", ["bun", "packages/gajae-code/bin/gjc.js", "--version"]);
+				add(tasks, "wrapper-version", "Unscoped wrapper CLI version smoke", [
+					"bun",
+					"packages/gajae-code/bin/gjc.js",
+					"--version",
+				]);
 			}
 			continue;
 		}
@@ -746,7 +904,13 @@ function addWorkspaceTestTasks(tasks: Map<string, Task>, packages: readonly Work
 
 function addPackageTestTasks(tasks: Map<string, Task>, workspacePackage: WorkspacePackage): void {
 	if (workspacePackage.name !== "@gajae-code/coding-agent") {
-		add(tasks, `test:${workspacePackage.name}`, `Test ${workspacePackage.name}`, packageScriptCommand("test"), resolvePackageCwd(workspacePackage.dir));
+		add(
+			tasks,
+			`test:${workspacePackage.name}`,
+			`Test ${workspacePackage.name}`,
+			packageScriptCommand("test"),
+			resolvePackageCwd(workspacePackage.dir),
+		);
 		return;
 	}
 
@@ -770,7 +934,11 @@ function addCodingAgentTestShard(tasks: Map<string, Task>, shard: number): void 
 // which live within the changed file's owning package (or its directory for
 // root-level files). Returns [] when there is no unique direct mapping, so basename
 // collisions fall back to package-level checks instead of selecting arbitrary tests.
-function mappedTestsFor(changedPath: string, packages: readonly WorkspacePackage[], testFiles: readonly string[]): string[] {
+function mappedTestsFor(
+	changedPath: string,
+	packages: readonly WorkspacePackage[],
+	testFiles: readonly string[],
+): string[] {
 	if (isTestFilePath(changedPath)) {
 		return testFiles.includes(changedPath) ? [changedPath] : [];
 	}
@@ -782,7 +950,7 @@ function mappedTestsFor(changedPath: string, packages: readonly WorkspacePackage
 	const owner = owningPackage(changedPath, packages);
 	const scopePrefix = owner ? `${owner.dir}/` : `${path.posix.dirname(changedPath)}/`;
 	const matches = testFiles.filter(
-		testFile => wanted.has(path.posix.basename(testFile)) && testFile.startsWith(scopePrefix),
+		(testFile) => wanted.has(path.posix.basename(testFile)) && testFile.startsWith(scopePrefix),
 	);
 	return matches.length === 1 ? matches : [];
 }
@@ -795,13 +963,15 @@ function behavioralTestsFor(changedPath: string): readonly string[] {
 }
 
 function isCodingAgentShardOneCoveragePath(changedPath: string): boolean {
-	return CODING_AGENT_SHARD_ONE_COVERAGE_PATHS.some(coveragePath =>
+	return CODING_AGENT_SHARD_ONE_COVERAGE_PATHS.some((coveragePath) =>
 		coveragePath.endsWith("/") ? changedPath.startsWith(coveragePath) : changedPath === coveragePath,
 	);
 }
 
 function owningPackage(changedPath: string, packages: readonly WorkspacePackage[]): WorkspacePackage | undefined {
-	return packages.find(workspacePackage => changedPath === workspacePackage.dir || changedPath.startsWith(`${workspacePackage.dir}/`));
+	return packages.find(
+		(workspacePackage) => changedPath === workspacePackage.dir || changedPath.startsWith(`${workspacePackage.dir}/`),
+	);
 }
 
 // Ensure a single native build task is present whenever any planned task loads
@@ -823,20 +993,32 @@ function isTestFilePath(changedPath: string): boolean {
 }
 
 function isCiHarnessScriptPath(changedPath: string): boolean {
-	return changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/ci-dev-affected.test.ts" || changedPath === "scripts/check-workflow-yaml.ts";
+	return (
+		changedPath === "scripts/ci-dev-affected.ts" ||
+		changedPath === "scripts/ci-dev-affected.test.ts" ||
+		changedPath === "scripts/check-workflow-yaml.ts"
+	);
 }
-
 
 function isCodeIshPath(changedPath: string): boolean {
 	return /\.(tsx?|jsx?|mts|cts|mjs|cjs|json|jsonc|toml|ya?ml|sh)$/.test(changedPath) || changedPath === "bun.lock";
 }
 
-
 function addNativeBuild(tasks: Map<string, Task>): void {
-	add(tasks, "native-linux-x64", "Build linux x64 native addons", ["bash", "-lc", 'TARGET_VARIANTS="baseline modern" bun scripts/ci-build-native.ts']);
+	add(tasks, "native-linux-x64", "Build linux x64 native addons", [
+		"bash",
+		"-lc",
+		'TARGET_VARIANTS="baseline modern" bun scripts/ci-build-native.ts',
+	]);
 }
 
-function add(tasks: Map<string, Task>, key: string, description: string, command: readonly string[], cwd?: string): void {
+function add(
+	tasks: Map<string, Task>,
+	key: string,
+	description: string,
+	command: readonly string[],
+	cwd?: string,
+): void {
 	if (!tasks.has(key)) {
 		tasks.set(key, { key, description, command, cwd });
 	}
@@ -853,7 +1035,6 @@ export function packageScriptCommand(script: string): readonly string[] {
 	return ["bun", "run", script];
 }
 
-
 // Resolve a workspace-relative package directory to an absolute path used as
 // the spawned task's process cwd.
 export function resolvePackageCwd(dir: string): string {
@@ -861,13 +1042,20 @@ export function resolvePackageCwd(dir: string): string {
 }
 
 function findTouchedPackages(paths: readonly string[], packages: readonly WorkspacePackage[]): WorkspacePackage[] {
-	return packages.filter(workspacePackage => paths.some(changedPath => changedPath === workspacePackage.dir || changedPath.startsWith(`${workspacePackage.dir}/`)));
+	return packages.filter((workspacePackage) =>
+		paths.some(
+			(changedPath) => changedPath === workspacePackage.dir || changedPath.startsWith(`${workspacePackage.dir}/`),
+		),
+	);
 }
 
-export function expandWithDependents(touched: readonly WorkspacePackage[], packages: readonly WorkspacePackage[]): WorkspacePackage[] {
-	const workspaceByName = new Map(packages.map(workspacePackage => [workspacePackage.name, workspacePackage]));
-	const selected = new Map(touched.map(workspacePackage => [workspacePackage.name, workspacePackage]));
-	const queue = [...touched.map(workspacePackage => workspacePackage.name)];
+export function expandWithDependents(
+	touched: readonly WorkspacePackage[],
+	packages: readonly WorkspacePackage[],
+): WorkspacePackage[] {
+	const workspaceByName = new Map(packages.map((workspacePackage) => [workspacePackage.name, workspacePackage]));
+	const selected = new Map(touched.map((workspacePackage) => [workspacePackage.name, workspacePackage]));
+	const queue = [...touched.map((workspacePackage) => workspacePackage.name)];
 	while (queue.length > 0) {
 		const currentName = queue.shift();
 		if (!currentName) continue;
@@ -882,7 +1070,11 @@ export function expandWithDependents(touched: readonly WorkspacePackage[], packa
 	return Array.from(selected.values()).sort((left, right) => left.dir.localeCompare(right.dir));
 }
 
-function dependsOnWorkspace(manifest: PackageManifest, dependencyName: string, workspaceByName: ReadonlyMap<string, WorkspacePackage>): boolean {
+function dependsOnWorkspace(
+	manifest: PackageManifest,
+	dependencyName: string,
+	workspaceByName: ReadonlyMap<string, WorkspacePackage>,
+): boolean {
 	for (const scope of PACKAGE_SCOPES) {
 		const dependencies = manifest[scope];
 		if (!dependencies) continue;
@@ -908,11 +1100,12 @@ function isFullWorkspacePath(changedPath: string): boolean {
 function isRootPackageReleaseHarnessOnly(paths: readonly string[]): boolean {
 	return (
 		paths.includes("package.json") &&
-		paths.every(changedPath =>
-			changedPath === "package.json" ||
-			isReleasePublishPath(changedPath) ||
-			isReleaseHarnessScriptPath(changedPath) ||
-			isUnscopedWrapperPath(changedPath),
+		paths.every(
+			(changedPath) =>
+				changedPath === "package.json" ||
+				isReleasePublishPath(changedPath) ||
+				isReleaseHarnessScriptPath(changedPath) ||
+				isUnscopedWrapperPath(changedPath),
 		)
 	);
 }
@@ -929,32 +1122,51 @@ function isReleaseHarnessScriptPath(changedPath: string): boolean {
 
 function addReleasePublishTasks(tasks: Map<string, Task>): void {
 	add(tasks, "release-publish-contract", "Release publish contract tests", ["bun", "run", "test:release"]);
-	add(tasks, "release-publish-dry-run", "Release publish dry-run", ["bun", "scripts/ci-release-publish.ts", "--dry-run"]);
+	add(tasks, "release-publish-dry-run", "Release publish dry-run", [
+		"bun",
+		"scripts/ci-release-publish.ts",
+		"--dry-run",
+	]);
 	addTestFileTask(tasks, "scripts/release-evidence.test.ts");
 }
-
 
 function isRustPath(changedPath: string): boolean {
 	const fileName = path.basename(changedPath);
 	return (
 		changedPath.startsWith("crates/") ||
 		changedPath.startsWith(".cargo/") ||
-		["Cargo.toml", "Cargo.lock", "rust-toolchain", "rust-toolchain.toml", "rustfmt.toml", ".rustfmt.toml", "clippy.toml", ".clippy.toml"].includes(fileName)
+		[
+			"Cargo.toml",
+			"Cargo.lock",
+			"rust-toolchain",
+			"rust-toolchain.toml",
+			"rustfmt.toml",
+			".rustfmt.toml",
+			"clippy.toml",
+			".clippy.toml",
+		].includes(fileName)
 	);
 }
 
 function isInstallPath(changedPath: string): boolean {
-	return changedPath.startsWith("scripts/install") || changedPath === "Dockerfile" || changedPath === "Dockerfile.dockerignore";
+	return (
+		changedPath.startsWith("scripts/install") ||
+		changedPath === "Dockerfile" ||
+		changedPath === "Dockerfile.dockerignore"
+	);
 }
 
 function isCodingAgentRuntimePath(changedPath: string): boolean {
-	return changedPath.startsWith("packages/coding-agent/") || changedPath.startsWith("packages/agent/") || changedPath.startsWith("packages/ai/");
+	return (
+		changedPath.startsWith("packages/coding-agent/") ||
+		changedPath.startsWith("packages/agent/") ||
+		changedPath.startsWith("packages/ai/")
+	);
 }
 
 function isBridgeClientSdkPackageSmokePath(changedPath: string): boolean {
 	return (
-		changedPath.startsWith("packages/bridge-client/") ||
-		changedPath.startsWith("packages/coding-agent/src/sdk/client/")
+		changedPath.startsWith("packages/bridge-client/") || changedPath.startsWith("packages/coding-agent/src/sdk/client/")
 	);
 }
 
@@ -965,7 +1177,7 @@ function isDeepInterviewOnly(paths: readonly string[]): boolean {
 		"packages/coding-agent/test/default-gjc-definitions.test.ts",
 		"packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts",
 	]);
-	return paths.length > 0 && paths.every(changedPath => allowed.has(changedPath));
+	return paths.length > 0 && paths.every((changedPath) => allowed.has(changedPath));
 }
 
 function isWorkflowOrScriptPath(changedPath: string): boolean {
@@ -975,7 +1187,6 @@ function isWorkflowOrScriptPath(changedPath: string): boolean {
 function isWorkflowPath(changedPath: string): boolean {
 	return changedPath.startsWith(".github/workflows/");
 }
-
 
 const BUILD_INVENTORY_PATH = path.join(repoRoot, "scripts/ci-dev-affected-build-inventory.json");
 const NATIVE_PRODUCER: Task = {
@@ -989,9 +1200,19 @@ const NATIVE_PRODUCER: Task = {
 };
 
 export function normalizeChangedPaths(paths: readonly string[]): string[] {
-	const normalized = paths.map(entry => entry.replaceAll("\\", "/").trim()).map(entry => entry.replace(/^\.\//, ""));
+	const normalized = paths
+		.map((entry) => entry.replaceAll("\\", "/").trim())
+		.map((entry) => entry.replace(/^\.\//, ""));
 	for (const entry of normalized) {
-		if (!entry || entry.startsWith("/") || /^[A-Za-z]:\//.test(entry) || entry === ".." || entry.startsWith("../") || entry.includes("/../") || entry.split("/").some(part => part === "." || part === "")) {
+		if (
+			!entry ||
+			entry.startsWith("/") ||
+			/^[A-Za-z]:\//.test(entry) ||
+			entry === ".." ||
+			entry.startsWith("../") ||
+			entry.includes("/../") ||
+			entry.split("/").some((part) => part === "." || part === "")
+		) {
 			throw new Error(`affected-path-invalid: unsafe changed path '${entry}'`);
 		}
 	}
@@ -1003,9 +1224,17 @@ export async function loadBuildInventory(inventoryPath = BUILD_INVENTORY_PATH): 
 	try {
 		parsed = JSON.parse(await Bun.file(inventoryPath).text());
 	} catch (error) {
-		throw new Error(`inventory-invalid: cannot read build inventory (${error instanceof Error ? error.message : String(error)})`);
+		throw new Error(
+			`inventory-invalid: cannot read build inventory (${error instanceof Error ? error.message : String(error)})`,
+		);
 	}
-	if (!isRecord(parsed) || parsed.schemaVersion !== 1 || !Array.isArray(parsed.typescript) || !Array.isArray(parsed.cargo) || !isRecord(parsed.emergency)) {
+	if (
+		!isRecord(parsed) ||
+		parsed.schemaVersion !== 1 ||
+		!Array.isArray(parsed.typescript) ||
+		!Array.isArray(parsed.cargo) ||
+		!isRecord(parsed.emergency)
+	) {
 		throw new Error("inventory-invalid: malformed build inventory");
 	}
 	assertExactKeys(parsed, ["schemaVersion", "typescript", "cargo", "emergency"], "build inventory");
@@ -1022,125 +1251,291 @@ export async function loadBuildInventory(inventoryPath = BUILD_INVENTORY_PATH): 
 }
 
 function parseTsInventoryUnit(value: unknown): TsInventoryUnit {
-	if (!isRecord(value) || !isString(value.id) || !isString(value.name) || !isString(value.dir) || typeof value.nativeConsumer !== "boolean" || typeof value.nativeProducer !== "boolean") throw new Error("inventory-invalid: malformed TypeScript unit");
+	if (
+		!isRecord(value) ||
+		!isString(value.id) ||
+		!isString(value.name) ||
+		!isString(value.dir) ||
+		typeof value.nativeConsumer !== "boolean" ||
+		typeof value.nativeProducer !== "boolean"
+	)
+		throw new Error("inventory-invalid: malformed TypeScript unit");
 	assertExactKeys(value, ["id", "name", "dir", "nativeConsumer", "nativeProducer"], "TypeScript unit");
-	return { id: value.id, name: value.name, dir: normalizeInventoryPath(value.dir), nativeConsumer: value.nativeConsumer, nativeProducer: value.nativeProducer };
+	return {
+		id: value.id,
+		name: value.name,
+		dir: normalizeInventoryPath(value.dir),
+		nativeConsumer: value.nativeConsumer,
+		nativeProducer: value.nativeProducer,
+	};
 }
 function parseCargoInventoryUnit(value: unknown): CargoInventoryUnit {
-	if (!isRecord(value) || !isString(value.id) || !isString(value.name) || !isString(value.manifestPath) || value.supported !== true || typeof value.nativeAddonSource !== "boolean") throw new Error("inventory-invalid: malformed Cargo unit");
+	if (
+		!isRecord(value) ||
+		!isString(value.id) ||
+		!isString(value.name) ||
+		!isString(value.manifestPath) ||
+		value.supported !== true ||
+		typeof value.nativeAddonSource !== "boolean"
+	)
+		throw new Error("inventory-invalid: malformed Cargo unit");
 	assertExactKeys(value, ["id", "name", "manifestPath", "supported", "nativeAddonSource"], "Cargo unit");
-	return { id: value.id, name: value.name, manifestPath: normalizeInventoryPath(value.manifestPath), supported: true, nativeAddonSource: value.nativeAddonSource };
+	return {
+		id: value.id,
+		name: value.name,
+		manifestPath: normalizeInventoryPath(value.manifestPath),
+		supported: true,
+		nativeAddonSource: value.nativeAddonSource,
+	};
 }
 function parseEmergency(value: Record<string, unknown>): BuildInventory["emergency"] {
-	if (Object.keys(value).some(key => key !== "cargoWorkspaceBuild")) throw new Error("inventory-invalid: unexpected emergency field");
+	if (Object.keys(value).some((key) => key !== "cargoWorkspaceBuild"))
+		throw new Error("inventory-invalid: unexpected emergency field");
 	const emergency = value.cargoWorkspaceBuild;
 	if (emergency === undefined) return {};
-	if (!isRecord(emergency) || emergency.id !== "cargo-workspace-emergency" || emergency.key !== "cargo-build:emergency:workspace" || emergency.identity !== "emergency:cargo-workspace:root" || !Array.isArray(emergency.command) || emergency.command.join("\0") !== "cargo\0build\0--workspace" || emergency.cwd !== "." || !isRecord(emergency.capabilities) || emergency.allowedReasons === undefined || !Array.isArray(emergency.allowedReasons) || emergency.allowedReasons.join("\0") !== "cargo-name-ambiguity") throw new Error("inventory-invalid: malformed cargo workspace emergency");
-	assertExactKeys(emergency, ["id", "key", "identity", "command", "cwd", "capabilities", "allowedReasons"], "cargo workspace emergency");
+	if (
+		!isRecord(emergency) ||
+		emergency.id !== "cargo-workspace-emergency" ||
+		emergency.key !== "cargo-build:emergency:workspace" ||
+		emergency.identity !== "emergency:cargo-workspace:root" ||
+		!Array.isArray(emergency.command) ||
+		emergency.command.join("\0") !== "cargo\0build\0--workspace" ||
+		emergency.cwd !== "." ||
+		!isRecord(emergency.capabilities) ||
+		emergency.allowedReasons === undefined ||
+		!Array.isArray(emergency.allowedReasons) ||
+		emergency.allowedReasons.join("\0") !== "cargo-name-ambiguity"
+	)
+		throw new Error("inventory-invalid: malformed cargo workspace emergency");
+	assertExactKeys(
+		emergency,
+		["id", "key", "identity", "command", "cwd", "capabilities", "allowedReasons"],
+		"cargo workspace emergency",
+	);
 	const capabilities = emergency.capabilities;
-	if (capabilities.rust !== true || capabilities.nextest !== false || capabilities.nativeConsumer !== false || capabilities.nativeProducer !== false) throw new Error("inventory-invalid: malformed cargo workspace emergency capabilities");
-	assertExactKeys(capabilities, ["rust", "nextest", "nativeConsumer", "nativeProducer"], "cargo workspace emergency capabilities");
-	return { cargoWorkspaceBuild: { id: "cargo-workspace-emergency", key: "cargo-build:emergency:workspace", identity: "emergency:cargo-workspace:root", command: ["cargo", "build", "--workspace"], cwd: ".", capabilities: { rust: true, nextest: false, nativeConsumer: false, nativeProducer: false }, allowedReasons: ["cargo-name-ambiguity"] } };
+	if (
+		capabilities.rust !== true ||
+		capabilities.nextest !== false ||
+		capabilities.nativeConsumer !== false ||
+		capabilities.nativeProducer !== false
+	)
+		throw new Error("inventory-invalid: malformed cargo workspace emergency capabilities");
+	assertExactKeys(
+		capabilities,
+		["rust", "nextest", "nativeConsumer", "nativeProducer"],
+		"cargo workspace emergency capabilities",
+	);
+	return {
+		cargoWorkspaceBuild: {
+			id: "cargo-workspace-emergency",
+			key: "cargo-build:emergency:workspace",
+			identity: "emergency:cargo-workspace:root",
+			command: ["cargo", "build", "--workspace"],
+			cwd: ".",
+			capabilities: { rust: true, nextest: false, nativeConsumer: false, nativeProducer: false },
+			allowedReasons: ["cargo-name-ambiguity"],
+		},
+	};
 }
 function normalizeInventoryPath(value: string): string {
 	const normalized = value.replaceAll("\\", "/").replace(/^\.\//, "");
-	if (!normalized || normalized.startsWith("/") || normalized.includes("../") || normalized.split("/").some(part => !part || part === ".")) throw new Error("inventory-invalid: unsafe inventory path");
+	if (
+		!normalized ||
+		normalized.startsWith("/") ||
+		normalized.includes("../") ||
+		normalized.split("/").some((part) => !part || part === ".")
+	)
+		throw new Error("inventory-invalid: unsafe inventory path");
 	return normalized;
 }
 function assertInventory(inventory: BuildInventory): void {
-	const unique = (values: readonly string[], label: string) => { if (new Set(values).size !== values.length) throw new Error(`inventory-invalid: duplicate ${label}`); };
-	unique(inventory.typescript.map(unit => unit.id), "TypeScript id");
-	unique(inventory.typescript.map(unit => unit.name), "TypeScript name");
-	unique(inventory.typescript.map(unit => unit.dir), "TypeScript directory");
-	unique(inventory.cargo.map(unit => unit.id), "Cargo id");
-	unique(inventory.cargo.map(unit => unit.manifestPath), "Cargo manifest path");
-	const nativeSources = inventory.cargo.filter(unit => unit.nativeAddonSource);
-	if (nativeSources.length !== 1 || nativeSources[0]?.id !== "pi-natives") throw new Error("inventory-invalid: pi-natives must be the sole native addon source");
+	const unique = (values: readonly string[], label: string) => {
+		if (new Set(values).size !== values.length) throw new Error(`inventory-invalid: duplicate ${label}`);
+	};
+	unique(
+		inventory.typescript.map((unit) => unit.id),
+		"TypeScript id",
+	);
+	unique(
+		inventory.typescript.map((unit) => unit.name),
+		"TypeScript name",
+	);
+	unique(
+		inventory.typescript.map((unit) => unit.dir),
+		"TypeScript directory",
+	);
+	unique(
+		inventory.cargo.map((unit) => unit.id),
+		"Cargo id",
+	);
+	unique(
+		inventory.cargo.map((unit) => unit.manifestPath),
+		"Cargo manifest path",
+	);
+	const nativeSources = inventory.cargo.filter((unit) => unit.nativeAddonSource);
+	if (nativeSources.length !== 1 || nativeSources[0]?.id !== "pi-natives")
+		throw new Error("inventory-invalid: pi-natives must be the sole native addon source");
 	const counts = new Map<string, number>();
 	for (const unit of inventory.cargo) counts.set(unit.name, (counts.get(unit.name) ?? 0) + 1);
-	if (Array.from(counts.values()).some(count => count > 1) && !inventory.emergency.cargoWorkspaceBuild) throw new Error("inventory-invalid: duplicate Cargo names require workspace emergency");
+	if (Array.from(counts.values()).some((count) => count > 1) && !inventory.emergency.cargoWorkspaceBuild)
+		throw new Error("inventory-invalid: duplicate Cargo names require workspace emergency");
 }
 
 async function assertTypeScriptInventoryLive(inventory: BuildInventory): Promise<void> {
 	const workspaces = await getWorkspacePackages();
-	const buildable = workspaces.filter(workspacePackage => workspacePackage.name !== "@gajae-code/natives" && workspacePackage.manifest.scripts?.build);
-	const classified = inventory.typescript.filter(unit => !unit.nativeProducer);
-	const buildableNames = new Set(buildable.map(workspacePackage => workspacePackage.name));
-	const classifiedNames = new Set(classified.map(unit => unit.name));
-	if (buildableNames.size !== classifiedNames.size || Array.from(buildableNames).some(name => !classifiedNames.has(name))) {
+	const buildable = workspaces.filter(
+		(workspacePackage) => workspacePackage.name !== "@gajae-code/natives" && workspacePackage.manifest.scripts?.build,
+	);
+	const classified = inventory.typescript.filter((unit) => !unit.nativeProducer);
+	const buildableNames = new Set(buildable.map((workspacePackage) => workspacePackage.name));
+	const classifiedNames = new Set(classified.map((unit) => unit.name));
+	if (
+		buildableNames.size !== classifiedNames.size ||
+		Array.from(buildableNames).some((name) => !classifiedNames.has(name))
+	) {
 		throw new Error("inventory-drift: TypeScript build-capable workspaces are not fully classified");
 	}
 	for (const unit of inventory.typescript) {
 		const manifest = await readPackageManifest(path.join(repoRoot, unit.dir, "package.json"));
-		if (!manifest || manifest.name !== unit.name || (!unit.nativeProducer && !manifest.scripts?.build)) throw new Error(`inventory-drift: TypeScript build unit ${unit.id} does not match its package manifest`);
+		if (!manifest || manifest.name !== unit.name || (!unit.nativeProducer && !manifest.scripts?.build))
+			throw new Error(`inventory-drift: TypeScript build unit ${unit.id} does not match its package manifest`);
 	}
 }
 
-async function appendBuildTasks(legacy: readonly Task[], paths: readonly string[], packages: readonly WorkspacePackage[], inventory: BuildInventory): Promise<Task[]> {
-	const withoutNative = legacy.filter(task => !isNativeBuildKey(task.key));
-	const buildPaths = paths.filter(changedPath => !isDocOrChangelogPath(changedPath));
+async function appendBuildTasks(
+	legacy: readonly Task[],
+	paths: readonly string[],
+	packages: readonly WorkspacePackage[],
+	inventory: BuildInventory,
+): Promise<Task[]> {
+	const withoutNative = legacy.filter((task) => !isNativeBuildKey(task.key));
+	const buildPaths = paths.filter((changedPath) => !isDocOrChangelogPath(changedPath));
 	const selectedTs = selectTsBuildUnits(buildPaths, packages, inventory);
 	const cargo = await selectCargoBuildTasks(buildPaths, inventory, packages);
-	const legacyNeedsProducer = legacy.some(task => isNativeBuildKey(task.key)) || legacy.some(task => taskNeedsNative(task.key));
+	const legacyNeedsProducer =
+		legacy.some((task) => isNativeBuildKey(task.key)) || legacy.some((task) => taskNeedsNative(task.key));
 	const cargoNeedsProducer = inventory.cargo
-		.filter(unit => unit.nativeAddonSource)
-		.some(unit => cargo.some(task => task.key === inventory.emergency.cargoWorkspaceBuild?.key || task.identity === stableIdentity("cargo", unit.id, unit.manifestPath)));
-	const needsProducer = legacyNeedsProducer || selectedTs.some(unit => unit.nativeConsumer || unit.nativeProducer) || cargoNeedsProducer;
-	const tsTasks = selectedTs.map(unit => ({ key: `ts-build:${stableIdentity("ts", unit.id, unit.dir)}`, identity: stableIdentity("ts", unit.id, unit.dir), description: `Build ${unit.name}`, command: ["bun", "run", "build"] as const, cwd: resolvePackageCwd(unit.dir), capabilities: { rust: false, nextest: false, nativeConsumer: unit.nativeConsumer, nativeProducer: unit.nativeProducer }, phase: "ts-build" as const }));
+		.filter((unit) => unit.nativeAddonSource)
+		.some((unit) =>
+			cargo.some(
+				(task) =>
+					task.key === inventory.emergency.cargoWorkspaceBuild?.key ||
+					task.identity === stableIdentity("cargo", unit.id, unit.manifestPath),
+			),
+		);
+	const needsProducer =
+		legacyNeedsProducer || selectedTs.some((unit) => unit.nativeConsumer || unit.nativeProducer) || cargoNeedsProducer;
+	const tsTasks = selectedTs.map((unit) => ({
+		key: `ts-build:${stableIdentity("ts", unit.id, unit.dir)}`,
+		identity: stableIdentity("ts", unit.id, unit.dir),
+		description: `Build ${unit.name}`,
+		command: ["bun", "run", "build"] as const,
+		cwd: resolvePackageCwd(unit.dir),
+		capabilities: {
+			rust: false,
+			nextest: false,
+			nativeConsumer: unit.nativeConsumer,
+			nativeProducer: unit.nativeProducer,
+		},
+		phase: "ts-build" as const,
+	}));
 	return [...withoutNative, ...(needsProducer ? [NATIVE_PRODUCER] : []), ...tsTasks, ...cargo];
 }
-function selectTsBuildUnits(paths: readonly string[], packages: readonly WorkspacePackage[], inventory: BuildInventory): TsInventoryUnit[] {
+function selectTsBuildUnits(
+	paths: readonly string[],
+	packages: readonly WorkspacePackage[],
+	inventory: BuildInventory,
+): TsInventoryUnit[] {
 	const selected = allBuildFallback(paths, packages)
 		? packages
 		: expandWithDependents(findTouchedPackages(paths, packages), packages);
-	const names = new Set(selected.map(unit => unit.name));
-	return inventory.typescript.filter(unit => names.has(unit.name)).sort(compareTsUnits);
+	const names = new Set(selected.map((unit) => unit.name));
+	return inventory.typescript.filter((unit) => names.has(unit.name)).sort(compareTsUnits);
 }
 function allBuildFallback(paths: readonly string[], packages: readonly WorkspacePackage[]): boolean {
-	return paths.some(changedPath =>
-		isFullWorkspacePath(changedPath) ||
-		changedPath === "bun.lock" ||
-		changedPath.startsWith("tsconfig") ||
-		isWorkflowHarnessPath(changedPath) ||
-		changedPath === "scripts/ci-dev-affected-build-inventory.json" ||
-		(!isDocOrChangelogPath(changedPath) && !owningPackage(changedPath, packages)),
+	return paths.some(
+		(changedPath) =>
+			isFullWorkspacePath(changedPath) ||
+			changedPath === "bun.lock" ||
+			changedPath.startsWith("tsconfig") ||
+			isWorkflowHarnessPath(changedPath) ||
+			changedPath === "scripts/ci-dev-affected-build-inventory.json" ||
+			(!isDocOrChangelogPath(changedPath) && !owningPackage(changedPath, packages)),
 	);
 }
-function compareTsUnits(left: TsInventoryUnit, right: TsInventoryUnit): number { return left.dir.localeCompare(right.dir) || left.name.localeCompare(right.name) || left.id.localeCompare(right.id); }
-function stableIdentity(domain: string, id: string, location: string): string { return `${domain}:${toBase64Url(id)}:${toBase64Url(location)}`; }
-function toBase64Url(value: string): string { return Buffer.from(value).toString("base64url"); }
+function compareTsUnits(left: TsInventoryUnit, right: TsInventoryUnit): number {
+	return left.dir.localeCompare(right.dir) || left.name.localeCompare(right.name) || left.id.localeCompare(right.id);
+}
+function stableIdentity(domain: string, id: string, location: string): string {
+	return `${domain}:${toBase64Url(id)}:${toBase64Url(location)}`;
+}
+function toBase64Url(value: string): string {
+	return Buffer.from(value).toString("base64url");
+}
 
-async function selectCargoBuildTasks(paths: readonly string[], inventory: BuildInventory, packages: readonly WorkspacePackage[]): Promise<Task[]> {
-	const supported = inventory.cargo.filter(unit => unit.supported);
-	const fallbackAll = paths.some(changedPath =>
-		changedPath === "Cargo.toml" ||
-		changedPath === "Cargo.lock" ||
-		changedPath === "rust-toolchain.toml" ||
-		changedPath.startsWith(".cargo/") ||
-		isFullWorkspacePath(changedPath) ||
-		isWorkflowHarnessPath(changedPath) ||
-		changedPath === "scripts/ci-dev-affected-build-inventory.json" ||
-		(!isDocOrChangelogPath(changedPath) && !changedPath.startsWith("crates/") && !owningPackage(changedPath, packages)),
+async function selectCargoBuildTasks(
+	paths: readonly string[],
+	inventory: BuildInventory,
+	packages: readonly WorkspacePackage[],
+): Promise<Task[]> {
+	const supported = inventory.cargo.filter((unit) => unit.supported);
+	const fallbackAll = paths.some(
+		(changedPath) =>
+			changedPath === "Cargo.toml" ||
+			changedPath === "Cargo.lock" ||
+			changedPath === "rust-toolchain.toml" ||
+			changedPath.startsWith(".cargo/") ||
+			isFullWorkspacePath(changedPath) ||
+			isWorkflowHarnessPath(changedPath) ||
+			changedPath === "scripts/ci-dev-affected-build-inventory.json" ||
+			(!isDocOrChangelogPath(changedPath) &&
+				!changedPath.startsWith("crates/") &&
+				!owningPackage(changedPath, packages)),
 	);
 	if (!fallbackAll && !paths.some(isRustPath)) return [];
 	const cargoChanged = paths.filter(isRustPath);
-	const fallback = fallbackAll || cargoChanged.some(changed => !supported.some(unit => changed === unit.manifestPath || changed.startsWith(`${path.posix.dirname(unit.manifestPath)}/`)));
-	let selected = fallback ? supported : supported.filter(unit => cargoChanged.some(changed => changed === unit.manifestPath || changed.startsWith(`${path.posix.dirname(unit.manifestPath)}/`)));
+	const fallback =
+		fallbackAll ||
+		cargoChanged.some(
+			(changed) =>
+				!supported.some(
+					(unit) => changed === unit.manifestPath || changed.startsWith(`${path.posix.dirname(unit.manifestPath)}/`),
+				),
+		);
+	let selected = fallback
+		? supported
+		: supported.filter((unit) =>
+				cargoChanged.some(
+					(changed) => changed === unit.manifestPath || changed.startsWith(`${path.posix.dirname(unit.manifestPath)}/`),
+				),
+			);
 	if (!fallback) selected = await expandCargoDependents(selected, supported, true);
 	if (requiresCargoWorkspaceEmergency(selected, supported)) {
 		const emergency = inventory.emergency.cargoWorkspaceBuild;
 		if (!emergency) throw new Error("inventory-invalid: duplicate selected Cargo name has no emergency");
-		return [{
-			key: emergency.key,
-			identity: emergency.identity,
-			description: "Build Cargo workspace",
-			command: emergency.command,
-			cwd: repoRoot,
-			capabilities: emergency.capabilities,
-			phase: "cargo-build",
-		}];
+		return [
+			{
+				key: emergency.key,
+				identity: emergency.identity,
+				description: "Build Cargo workspace",
+				command: emergency.command,
+				cwd: repoRoot,
+				capabilities: emergency.capabilities,
+				phase: "cargo-build",
+			},
+		];
 	}
-	return selected.sort((left, right) => left.manifestPath.localeCompare(right.manifestPath) || left.id.localeCompare(right.id)).map(unit => ({ key: `cargo-build:${stableIdentity("cargo", unit.id, unit.manifestPath)}`, identity: stableIdentity("cargo", unit.id, unit.manifestPath), description: `Build Cargo crate ${unit.name}`, command: ["cargo", "build", "--package", unit.name] as const, cwd: repoRoot, capabilities: { rust: true, nextest: false, nativeConsumer: false, nativeProducer: false }, phase: "cargo-build" as const }));
+	return selected
+		.sort((left, right) => left.manifestPath.localeCompare(right.manifestPath) || left.id.localeCompare(right.id))
+		.map((unit) => ({
+			key: `cargo-build:${stableIdentity("cargo", unit.id, unit.manifestPath)}`,
+			identity: stableIdentity("cargo", unit.id, unit.manifestPath),
+			description: `Build Cargo crate ${unit.name}`,
+			command: ["cargo", "build", "--package", unit.name] as const,
+			cwd: repoRoot,
+			capabilities: { rust: true, nextest: false, nativeConsumer: false, nativeProducer: false },
+			phase: "cargo-build" as const,
+		}));
 }
 
 export function requiresCargoWorkspaceEmergency(
@@ -1149,28 +1544,45 @@ export function requiresCargoWorkspaceEmergency(
 ): boolean {
 	const counts = new Map<string, number>();
 	for (const unit of supported) counts.set(unit.name, (counts.get(unit.name) ?? 0) + 1);
-	return selected.some(unit => (counts.get(unit.name) ?? 0) > 1);
+	return selected.some((unit) => (counts.get(unit.name) ?? 0) > 1);
 }
 
-async function expandCargoDependents(
+export async function expandCargoDependents(
 	initial: readonly CargoInventoryUnit[],
 	supported: readonly CargoInventoryUnit[],
 	fallbackOnMetadataFailure: boolean,
 ): Promise<CargoInventoryUnit[]> {
 	const metadata = await $`cargo metadata --format-version=1 --no-deps`.cwd(repoRoot).quiet().nothrow();
 	if (metadata.exitCode !== 0) {
-		if (fallbackOnMetadataFailure) return [...supported];
-		throw new Error(`inventory-drift: cargo metadata failed: ${metadata.stderr.toString().trim()}`);
+		if (fallbackOnMetadataFailure) {
+			reportCargoMetadataFallback(
+				"command failure",
+				`exit code ${metadata.exitCode}; ${boundDiagnostic(metadata.stderr.toString())}`,
+			);
+			return [...supported];
+		}
+		throw new Error(`inventory-drift: cargo metadata failed: ${boundDiagnostic(metadata.stderr.toString())}`);
 	}
 	let decoded: unknown;
 	try {
 		decoded = JSON.parse(metadata.stdout.toString());
 	} catch {
-		if (fallbackOnMetadataFailure) return [...supported];
+		if (fallbackOnMetadataFailure) {
+			reportCargoMetadataFallback("malformed JSON");
+			return [...supported];
+		}
 		throw new Error("inventory-drift: cargo metadata was not JSON");
 	}
-	if (!isRecord(decoded) || !Array.isArray(decoded.packages) || !Array.isArray(decoded.workspace_members) || !decoded.workspace_members.every(isString)) {
-		if (fallbackOnMetadataFailure) return [...supported];
+	if (
+		!isRecord(decoded) ||
+		!Array.isArray(decoded.packages) ||
+		!Array.isArray(decoded.workspace_members) ||
+		!decoded.workspace_members.every(isString)
+	) {
+		if (fallbackOnMetadataFailure) {
+			reportCargoMetadataFallback("malformed workspace schema");
+			return [...supported];
+		}
 		throw new Error("inventory-drift: cargo metadata workspace inventory missing");
 	}
 	const byManifest = new Map<string, CargoInventoryUnit>();
@@ -1180,13 +1592,18 @@ async function expandCargoDependents(
 		if (!isRecord(entry) || !isString(entry.id) || !isString(entry.name) || !isString(entry.manifest_path)) continue;
 		const unit = byManifest.get(path.resolve(entry.manifest_path));
 		if (unit) {
-			if (unit.name !== entry.name || byPackageId.has(entry.id)) throw new Error("inventory-drift: Cargo registry mapping mismatch");
+			if (unit.name !== entry.name || byPackageId.has(entry.id))
+				throw new Error("inventory-drift: Cargo registry mapping mismatch");
 			byPackageId.set(entry.id, unit);
 		}
 	}
-	if (byPackageId.size !== supported.length) throw new Error("inventory-drift: supported Cargo inventory does not match metadata");
+	if (byPackageId.size !== supported.length)
+		throw new Error("inventory-drift: supported Cargo inventory does not match metadata");
 	const workspaceMemberIds = new Set(decoded.workspace_members as string[]);
-	if (workspaceMemberIds.size !== supported.length || Array.from(workspaceMemberIds).some(id => !byPackageId.has(id))) {
+	if (
+		workspaceMemberIds.size !== supported.length ||
+		Array.from(workspaceMemberIds).some((id) => !byPackageId.has(id))
+	) {
 		throw new Error("inventory-drift: Cargo workspace contains unclassified members");
 	}
 	const reverse = new Map<string, string[]>();
@@ -1198,16 +1615,35 @@ async function expandCargoDependents(
 			if (dependencyUnit) reverse.set(dependencyUnit.id, [...(reverse.get(dependencyUnit.id) ?? []), entry.id]);
 		}
 	}
-	const selected = new Map(initial.map(unit => [unit.id, unit]));
+	const selected = new Map(initial.map((unit) => [unit.id, unit]));
 	const queue = [...selected.keys()];
 	while (queue.length > 0) {
-		const current = queue.shift(); if (!current) continue;
-		for (const packageId of reverse.get(current) ?? []) { const unit = byPackageId.get(packageId); if (unit && !selected.has(unit.id)) { selected.set(unit.id, unit); queue.push(unit.id); } }
+		const current = queue.shift();
+		if (!current) continue;
+		for (const packageId of reverse.get(current) ?? []) {
+			const unit = byPackageId.get(packageId);
+			if (unit && !selected.has(unit.id)) {
+				selected.set(unit.id, unit);
+				queue.push(unit.id);
+			}
+		}
 	}
 	return Array.from(selected.values());
 }
+function boundDiagnostic(value: string): string {
+	const normalized = value.replace(/\s+/g, " ").trim().replace(/(?:\/|[A-Za-z]:[\\/])\S+/g, "<path>");
+	return normalized.length > 160 ? `${normalized.slice(0, 160)}…` : normalized || "no error detail";
+}
+
+function reportCargoMetadataFallback(reason: string, detail?: string): void {
+	console.error(`ci-dev-affected: cargo metadata ${reason}; selecting all supported Cargo units${detail ? ` (${detail})` : ""}`);
+}
 function isWorkflowHarnessPath(changedPath: string): boolean {
-	return isWorkflowPath(changedPath) || changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/check-workflow-yaml.ts";
+	return (
+		isWorkflowPath(changedPath) ||
+		changedPath === "scripts/ci-dev-affected.ts" ||
+		changedPath === "scripts/check-workflow-yaml.ts"
+	);
 }
 
 function isToolingScriptPath(changedPath: string): boolean {
@@ -1233,8 +1669,14 @@ function isString(value: unknown): value is string {
 	return typeof value === "string";
 }
 
-function assertExactKeys(value: Record<string, unknown>, keys: readonly string[], label: string): void {
-	if (Object.keys(value).length !== keys.length || Object.keys(value).some(key => !keys.includes(key))) throw new Error(`inventory-invalid: unexpected ${label} field`);
+function assertExactKeys(
+	value: Record<string, unknown>,
+	keys: readonly string[],
+	label: string,
+	errorNamespace = "inventory-invalid",
+): void {
+	if (Object.keys(value).length !== keys.length || Object.keys(value).some((key) => !keys.includes(key)))
+		throw new Error(`${errorNamespace}: unexpected ${label} field`);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -1254,8 +1696,8 @@ export async function runCommand(command: readonly string[], cwd: string): Promi
 }
 
 function serializeTasks(tasks: readonly Task[]): Task[] {
-	return tasks.map(task => {
-		const cwd = task.cwd ? path.relative(repoRoot, task.cwd) || "." : ".";
+	return tasks.map((task) => {
+		const cwd = canonicalTaskCwd(task.cwd);
 		return {
 			key: task.key,
 			identity: canonicalTaskIdentity(task),
@@ -1274,7 +1716,7 @@ function serializeTasks(tasks: readonly Task[]): Task[] {
 }
 
 function canonicalTaskIdentity(task: Task): string {
-	const cwd = task.cwd ? path.relative(repoRoot, task.cwd) || "." : ".";
+	const cwd = canonicalTaskCwd(task.cwd);
 	return task.identity ?? `legacy:${toBase64Url(task.key)}:${toBase64Url(cwd)}`;
 }
 
@@ -1284,18 +1726,52 @@ export interface AffectedAggregateResults {
 	shards: string;
 	windowsDoctor: string;
 	windowsDoctorRequired: string;
+	worktreeSafety: string;
+	worktreeSafetyRequired: string;
 	hasNative: string;
 	hasTasks: string;
 }
 
 export function validateAffectedAggregate(results: AffectedAggregateResults): void {
 	if (results.plan !== "success") throw new Error("planner did not succeed");
-	if (results.hasNative !== "true" && results.hasNative !== "false") throw new Error(`planner emitted invalid has_native=${results.hasNative}`);
-	if (results.hasTasks !== "true" && results.hasTasks !== "false") throw new Error(`planner emitted invalid has_tasks=${results.hasTasks}`);
-	if (results.native !== (results.hasNative === "true" ? "success" : "skipped")) throw new Error(results.hasNative === "true" ? "required native build did not succeed" : "unplanned native build was not skipped");
-	if (results.shards !== (results.hasTasks === "true" ? "success" : "skipped")) throw new Error(results.hasTasks === "true" ? "required affected shards did not succeed" : "unplanned affected shards were not skipped");
-	if (results.windowsDoctorRequired !== "true" && results.windowsDoctorRequired !== "false") throw new Error(`planner emitted invalid windows_doctor_required=${results.windowsDoctorRequired}`);
-	if (results.windowsDoctor !== (results.windowsDoctorRequired === "true" ? "success" : "skipped")) throw new Error(results.windowsDoctorRequired === "true" ? "required Windows dev:doctor did not succeed" : "unplanned Windows dev:doctor was not skipped");
+	if (results.hasNative !== "true" && results.hasNative !== "false")
+		throw new Error(`planner emitted invalid has_native=${results.hasNative}`);
+	if (results.hasTasks !== "true" && results.hasTasks !== "false")
+		throw new Error(`planner emitted invalid has_tasks=${results.hasTasks}`);
+	if (results.native !== (results.hasNative === "true" ? "success" : "skipped"))
+		throw new Error(
+			results.hasNative === "true" ? "required native build did not succeed" : "unplanned native build was not skipped",
+		);
+	if (results.shards !== (results.hasTasks === "true" ? "success" : "skipped"))
+		throw new Error(
+			results.hasTasks === "true"
+				? "required affected shards did not succeed"
+				: "unplanned affected shards were not skipped",
+		);
+	if (results.windowsDoctorRequired !== "true" && results.windowsDoctorRequired !== "false")
+		throw new Error(`planner emitted invalid windows_doctor_required=${results.windowsDoctorRequired}`);
+	if (results.windowsDoctor !== (results.windowsDoctorRequired === "true" ? "success" : "skipped"))
+		throw new Error(
+			results.windowsDoctorRequired === "true"
+				? "required Windows dev:doctor did not succeed"
+				: "unplanned Windows dev:doctor was not skipped",
+		);
+	if (results.worktreeSafetyRequired !== "true" && results.worktreeSafetyRequired !== "false")
+		throw new Error(`planner emitted invalid worktree_safety_required=${results.worktreeSafetyRequired}`);
+	if (results.worktreeSafety !== (results.worktreeSafetyRequired === "true" ? "success" : "skipped"))
+		throw new Error(
+			results.worktreeSafetyRequired === "true"
+				? "required worktree safety did not succeed"
+				: "unplanned worktree safety was not skipped",
+		);
+}
+export function validateCanonicalWorktreeSafetyRequirement(
+	results: Pick<AffectedAggregateResults, "worktreeSafetyRequired">,
+	canonicalWorktreeSafetyRequired: boolean,
+): void {
+	if (results.worktreeSafetyRequired !== String(canonicalWorktreeSafetyRequired)) {
+		throw new Error("affected-plan-invalid: worktree safety flag does not match canonical plan");
+	}
 }
 
 async function validateAggregate(): Promise<void> {
@@ -1305,6 +1781,8 @@ async function validateAggregate(): Promise<void> {
 		shards: Bun.env.CI_DEV_SHARDS_RESULT?.trim() || "",
 		windowsDoctor: Bun.env.CI_DEV_WINDOWS_DOCTOR_RESULT?.trim() || "",
 		windowsDoctorRequired: Bun.env.CI_DEV_WINDOWS_DOCTOR_REQUIRED?.trim() || "",
+		worktreeSafety: Bun.env.CI_DEV_WORKTREE_SAFETY_RESULT?.trim() || "",
+		worktreeSafetyRequired: Bun.env.CI_DEV_WORKTREE_SAFETY_REQUIRED?.trim() || "",
 		hasNative: Bun.env.CI_DEV_HAS_NATIVE?.trim() || "",
 		hasTasks: Bun.env.CI_DEV_HAS_TASKS?.trim() || "",
 	};
@@ -1318,9 +1796,10 @@ async function validateAggregate(): Promise<void> {
 	console.log(`windows-dev-doctor: ${results.windowsDoctor}`);
 	console.log(`planned Windows dev:doctor: ${results.windowsDoctorRequired}`);
 	validateAffectedAggregate(results);
-	const tasks = await loadCanonicalPlan();
-	if (!tasks) throw new Error("affected-plan-invalid: aggregate requires a canonical plan");
-	validatePlanCapabilities(tasks, results, Bun.env.CI_DEV_PLAN_MODE?.trim() || resolvePlanMode());
+	const canonical = await loadCanonicalPlanDocument();
+	if (!canonical) throw new Error("affected-plan-invalid: aggregate requires a canonical plan");
+	validatePlanCapabilities(canonical.tasks, results, Bun.env.CI_DEV_PLAN_MODE?.trim() || resolvePlanMode());
+	validateCanonicalWorktreeSafetyRequirement(results, canonical.worktreeSafetyRequired);
 	console.log("Affected path validation: all required shards passed");
 }
 
@@ -1363,14 +1842,14 @@ async function checkedEvidencePath(root: string, relative: string, finalKind: "f
 	const resolvedRoot = path.resolve(root);
 	const target = path.resolve(resolvedRoot, relative);
 	if (!target.startsWith(`${resolvedRoot}${path.sep}`)) throw evidenceError("path escaped staging root");
-	let rootStat: import("node:fs").Stats;
+	let rootStat: Stats;
 	try { rootStat = await fs.lstat(resolvedRoot); } catch (error) { if (isMissingError(error)) throw evidenceError("missing staging root"); throw error; }
 	if (rootStat.isSymbolicLink()) throw evidenceError("symlink staging root");
 	if (!rootStat.isDirectory()) throw evidenceError("non-directory staging root");
 	let current = resolvedRoot;
 	for (const piece of path.relative(resolvedRoot, target).split(path.sep)) {
 		current = path.join(current, piece);
-		let stat: import("node:fs").Stats;
+		let stat: Stats;
 		try { stat = await fs.lstat(current); } catch (error) { if (isMissingError(error)) throw evidenceError("missing evidence object"); throw error; }
 		if (stat.isSymbolicLink()) throw evidenceError("symlink evidence object");
 		const final = current === target;
@@ -1395,13 +1874,47 @@ function canonicalReplayScope(): ReplayScope {
 	return { repository: requiredEnv("GITHUB_REPOSITORY"), workflow: requiredEnv("GITHUB_WORKFLOW"), runId: requiredEnv("GITHUB_RUN_ID") };
 }
 function aggregateFromEnv(): AffectedAggregateResults {
-	return { plan: requiredEnv("CI_DEV_PLAN_RESULT"), native: requiredEnv("CI_DEV_NATIVE_RESULT"), shards: requiredEnv("CI_DEV_SHARDS_RESULT"), windowsDoctor: requiredEnv("CI_DEV_WINDOWS_DOCTOR_RESULT"), windowsDoctorRequired: requiredEnv("CI_DEV_WINDOWS_DOCTOR_REQUIRED"), hasNative: requiredEnv("CI_DEV_HAS_NATIVE"), hasTasks: requiredEnv("CI_DEV_HAS_TASKS") };
+	return {
+		plan: requiredEnv("CI_DEV_PLAN_RESULT"),
+		native: requiredEnv("CI_DEV_NATIVE_RESULT"),
+		shards: requiredEnv("CI_DEV_SHARDS_RESULT"),
+		windowsDoctor: requiredEnv("CI_DEV_WINDOWS_DOCTOR_RESULT"),
+		windowsDoctorRequired: requiredEnv("CI_DEV_WINDOWS_DOCTOR_REQUIRED"),
+		worktreeSafety: requiredEnv("CI_DEV_WORKTREE_SAFETY_RESULT"),
+		worktreeSafetyRequired: requiredEnv("CI_DEV_WORKTREE_SAFETY_REQUIRED"),
+		hasNative: requiredEnv("CI_DEV_HAS_NATIVE"),
+		hasTasks: requiredEnv("CI_DEV_HAS_TASKS"),
+	};
 }
 function parseAggregate(value: unknown): AffectedAggregateResults {
 	if (!isRecord(value)) throw evidenceError("malformed aggregate results");
-	exactKeys(value, ["plan", "native", "shards", "windowsDoctor", "windowsDoctorRequired", "hasNative", "hasTasks"], "unexpected aggregate results field");
+	exactKeys(
+		value,
+		[
+			"plan",
+			"native",
+			"shards",
+			"windowsDoctor",
+			"windowsDoctorRequired",
+			"worktreeSafety",
+			"worktreeSafetyRequired",
+			"hasNative",
+			"hasTasks",
+		],
+		"unexpected aggregate results field",
+	);
 	if (!Object.values(value).every(isString)) throw evidenceError("malformed aggregate results");
-	return { plan: value.plan as string, native: value.native as string, shards: value.shards as string, windowsDoctor: value.windowsDoctor as string, windowsDoctorRequired: value.windowsDoctorRequired as string, hasNative: value.hasNative as string, hasTasks: value.hasTasks as string };
+	return {
+		plan: value.plan as string,
+		native: value.native as string,
+		shards: value.shards as string,
+		windowsDoctor: value.windowsDoctor as string,
+		windowsDoctorRequired: value.windowsDoctorRequired as string,
+		worktreeSafety: value.worktreeSafety as string,
+		worktreeSafetyRequired: value.worktreeSafetyRequired as string,
+		hasNative: value.hasNative as string,
+		hasTasks: value.hasTasks as string,
+	};
 }
 function parseReplayScope(value: unknown): ReplayScope {
 	if (!isRecord(value)) throw evidenceError("malformed replay scope");
@@ -1436,15 +1949,34 @@ function parseCanonicalReceipt(raw: string): DetachedEvidenceReceipt {
 	return receipt;
 }
 
-async function readValidatedEvidencePlan(root: string): Promise<{ tasks: Task[]; raw: Uint8Array; mode: PlanMode }> {
+async function readValidatedEvidencePlan(
+	root: string,
+): Promise<{ tasks: Task[]; raw: Uint8Array; mode: PlanMode; worktreeSafetyRequired: boolean }> {
 	const raw = await readEvidenceBytes(root, AFFECTED_PLAN_NAME);
-	let decoded: unknown; try { decoded = JSON.parse(decodeEvidenceJson(raw)); } catch { throw evidenceError("malformed canonical plan"); }
-	if (!isRecord(decoded) || (decoded.mode !== "pr" && decoded.mode !== "push")) throw evidenceError("malformed canonical plan");
+	let decoded: unknown;
+	try {
+		decoded = JSON.parse(decodeEvidenceJson(raw));
+	} catch {
+		throw evidenceError("malformed canonical plan");
+	}
+	if (!isRecord(decoded) || (decoded.mode !== "pr" && decoded.mode !== "push"))
+		throw evidenceError("malformed canonical plan");
 	const planPath = path.join(root, AFFECTED_PLAN_NAME);
 	const original = Bun.env.CI_DEV_AFFECTED_PLAN;
 	Bun.env.CI_DEV_AFFECTED_PLAN = planPath;
-	try { const tasks = await loadCanonicalPlan(); if (!tasks) throw evidenceError("missing canonical plan"); return { tasks, raw, mode: decoded.mode }; }
-	finally { if (original === undefined) delete Bun.env.CI_DEV_AFFECTED_PLAN; else Bun.env.CI_DEV_AFFECTED_PLAN = original; }
+	try {
+		const canonical = await loadCanonicalPlanDocument();
+		if (!canonical) throw evidenceError("missing canonical plan");
+		return {
+			tasks: canonical.tasks,
+			raw,
+			mode: decoded.mode,
+			worktreeSafetyRequired: canonical.worktreeSafetyRequired,
+		};
+	} finally {
+		if (original === undefined) delete Bun.env.CI_DEV_AFFECTED_PLAN;
+		else Bun.env.CI_DEV_AFFECTED_PLAN = original;
+	}
 }
 async function collectChildEvidence(root: string, tasks: readonly Task[]): Promise<EvidenceChild[]> {
 	const expected = expectedEvidenceNames(tasks);
@@ -1471,13 +2003,14 @@ async function collectChildEvidence(root: string, tasks: readonly Task[]): Promi
 }
 async function writeAffectedEvidence(): Promise<void> {
 	const root = evidenceRoot();
-	const { tasks, raw: planRaw, mode: planMode } = await readValidatedEvidencePlan(root);
+	const { tasks, raw: planRaw, mode: planMode, worktreeSafetyRequired } = await readValidatedEvidencePlan(root);
 	const results = aggregateFromEnv(); validateAffectedAggregate(results);
 	const digest = requiredEnv("CI_DEV_PLAN_DIGEST");
 	const mode = requiredEnv("CI_DEV_PLAN_MODE");
 	if (mode !== "pr" && mode !== "push") throw evidenceError("invalid CI_DEV_PLAN_MODE");
 	if (mode !== planMode) throw evidenceError("plan mode mismatch");
 	validatePlanCapabilities(tasks, results, mode);
+	validateCanonicalWorktreeSafetyRequirement(results, worktreeSafetyRequired);
 	if (sha256(planRaw) !== digest) throw evidenceError("plan digest mismatch");
 	const manifestPath = path.join(root, AFFECTED_EVIDENCE_MANIFEST); const receiptPath = path.join(root, AFFECTED_EVIDENCE_RECEIPT);
 	for (const target of [manifestPath, receiptPath]) { try { await fs.lstat(target); throw evidenceError("evidence target already exists"); } catch (error) { if (error instanceof Error && error.message.startsWith("affected-evidence-invalid")) throw error; if (!isMissingError(error)) throw error; } }
@@ -1500,7 +2033,7 @@ async function validateAffectedEvidence(): Promise<void> {
 	const receipt = parseCanonicalReceipt(receiptRaw);
 	if (receipt.manifestSha256 !== sha256(manifestBytes)) throw evidenceError("manifest digest mismatch");
 	const manifest = parseCanonicalManifest(manifestRaw);
-	const { tasks, raw: planRaw, mode: planMode } = await readValidatedEvidencePlan(root);
+	const { tasks, raw: planRaw, mode: planMode, worktreeSafetyRequired } = await readValidatedEvidencePlan(root);
 	const expectedReplay = canonicalReplayScope(); const expectedSource = requiredEnv("CI_DEV_SOURCE_SHA"); const expectedDigest = requiredEnv("CI_DEV_PLAN_DIGEST");
 	if (manifest.sourceSha !== expectedSource || receipt.sourceSha !== expectedSource || manifest.planDigest !== expectedDigest || receipt.planDigest !== expectedDigest || JSON.stringify(manifest.replayScope) !== JSON.stringify(expectedReplay) || JSON.stringify(receipt.replayScope) !== JSON.stringify(expectedReplay)) throw evidenceError("replay binding mismatch");
 	if (manifest.planMode !== requiredEnv("CI_DEV_PLAN_MODE") || manifest.planMode !== planMode || sha256(planRaw) !== expectedDigest) throw evidenceError("plan binding mismatch");
@@ -1508,6 +2041,7 @@ async function validateAffectedEvidence(): Promise<void> {
 	const liveAggregate = aggregateFromEnv();
 	if (JSON.stringify(manifest.aggregateResults) !== JSON.stringify(liveAggregate)) throw evidenceError("aggregate result mismatch");
 	validatePlanCapabilities(tasks, liveAggregate, manifest.planMode);
+	validateCanonicalWorktreeSafetyRequirement(liveAggregate, worktreeSafetyRequired);
 	const expectedTasks = expectedEvidenceTasks(tasks);
 	if (JSON.stringify(manifest.taskIdentities) !== JSON.stringify(expectedTasks)) throw evidenceError("task identity mismatch");
 	const children = await collectChildEvidence(root, tasks);
@@ -1519,21 +2053,33 @@ async function validateShardReceipts(): Promise<void> {
 	const tasks = await loadCanonicalPlan();
 	if (!tasks) throw new Error("affected-plan-invalid: shard receipt validation requires a canonical plan");
 	const expected = tasks
-		.filter(task => task.capabilities?.nativeProducer !== true)
-		.map(task => ({ key: task.key, identity: canonicalTaskIdentity(task) }))
+		.filter((task) => task.capabilities?.nativeProducer !== true)
+		.map((task) => ({ key: task.key, identity: canonicalTaskIdentity(task) }))
 		.sort((left, right) => left.key.localeCompare(right.key));
 	const receiptDir = path.resolve(repoRoot, Bun.env.CI_DEV_SHARD_RECEIPTS?.trim() || ".ci-dev-shard-receipts");
 	const actual: Array<{ key: string; identity: string }> = [];
 	for await (const entry of new Bun.Glob("*.json").scan({ cwd: receiptDir })) {
 		const value = await Bun.file(path.join(receiptDir, entry)).json();
-		if (!isRecord(value) || !isString(value.key) || !isString(value.identity) || Object.keys(value).length !== 2) throw new Error("affected-plan-invalid: malformed shard receipt");
+		if (!isRecord(value) || !isString(value.key) || !isString(value.identity) || Object.keys(value).length !== 2)
+			throw new Error("affected-plan-invalid: malformed shard receipt");
 		actual.push({ key: value.key, identity: value.identity });
 	}
 	actual.sort((left, right) => left.key.localeCompare(right.key));
-	if (JSON.stringify(actual) !== JSON.stringify(expected)) throw new Error("affected-plan-invalid: shard receipt set does not match canonical plan");
+	if (JSON.stringify(actual) !== JSON.stringify(expected))
+		throw new Error("affected-plan-invalid: shard receipt set does not match canonical plan");
+}
+
+interface LoadedCanonicalPlan {
+	tasks: Task[];
+	worktreeSafetyRequired: boolean;
 }
 
 async function loadCanonicalPlan(): Promise<Task[] | null> {
+	const canonical = await loadCanonicalPlanDocument();
+	return canonical?.tasks ?? null;
+}
+
+async function loadCanonicalPlanDocument(): Promise<LoadedCanonicalPlan | null> {
 	const planFile = Bun.env.CI_DEV_AFFECTED_PLAN?.trim();
 	if (!planFile) return null;
 	let rawPlan: string;
@@ -1544,48 +2090,107 @@ async function loadCanonicalPlan(): Promise<Task[] | null> {
 	} catch {
 		throw new Error("affected-plan-invalid: cannot read canonical plan");
 	}
-	if (!isRecord(decoded) || decoded.schemaVersion !== 1 || !isString(decoded.sourceSha) || (decoded.mode !== "pr" && decoded.mode !== "push") || !Array.isArray(decoded.paths) || !decoded.paths.every(isString) || !Array.isArray(decoded.tasks)) throw new Error("affected-plan-invalid: malformed canonical plan");
-	if (Object.keys(decoded).length !== 5 || Object.keys(decoded).some(key => !["schemaVersion", "sourceSha", "mode", "paths", "tasks"].includes(key))) throw new Error("affected-plan-invalid: unexpected top-level field");
+	if (
+		!isRecord(decoded) ||
+		decoded.schemaVersion !== 1 ||
+		!isString(decoded.sourceSha) ||
+		(decoded.mode !== "pr" && decoded.mode !== "push") ||
+		!Array.isArray(decoded.paths) ||
+		!decoded.paths.every(isString) ||
+		typeof decoded.worktreeSafetyRequired !== "boolean" ||
+		!Array.isArray(decoded.tasks)
+	)
+		throw new Error("affected-plan-invalid: malformed canonical plan");
+	if (
+		Object.keys(decoded).length !== 6 ||
+		Object.keys(decoded).some(
+			(key) => !["schemaVersion", "sourceSha", "mode", "paths", "worktreeSafetyRequired", "tasks"].includes(key),
+		)
+	)
+		throw new Error("affected-plan-invalid: unexpected top-level field");
 	const decodedPaths = decoded.paths as string[];
 	const paths = normalizeChangedPaths(decodedPaths);
-	if (paths.length !== decodedPaths.length || paths.some((entry, index) => entry !== decodedPaths[index])) throw new Error("affected-plan-invalid: paths are not canonical");
+	if (paths.length !== decodedPaths.length || paths.some((entry, index) => entry !== decodedPaths[index]))
+		throw new Error("affected-plan-invalid: paths are not canonical");
+	if (decoded.worktreeSafetyRequired !== hasWorktreeSafetyChange(paths))
+		throw new Error("affected-plan-invalid: worktree safety requirement mismatch");
 	const expectedSha = Bun.env.CI_DEV_PLAN_SOURCE_SHA?.trim();
 	const expectedDigest = Bun.env.CI_DEV_PLAN_DIGEST?.trim();
 	if (!expectedSha || !expectedDigest) throw new Error("affected-plan-invalid: missing expected digest or source SHA");
 	if (decoded.sourceSha !== expectedSha) throw new Error("affected-plan-invalid: source SHA mismatch");
 	const checkedOut = await $`git rev-parse HEAD`.cwd(repoRoot).quiet().nothrow();
-	if (checkedOut.exitCode !== 0 || checkedOut.stdout.toString().trim() !== expectedSha) throw new Error("affected-plan-invalid: checked-out SHA mismatch");
+	if (checkedOut.exitCode !== 0 || checkedOut.stdout.toString().trim() !== expectedSha)
+		throw new Error("affected-plan-invalid: checked-out SHA mismatch");
 	const actual = new Bun.CryptoHasher("sha256").update(rawPlan).digest("hex");
 	if (actual !== expectedDigest) throw new Error("affected-plan-invalid: digest mismatch");
 	const tasks = decoded.tasks.map(deserializeTask);
+	if (decoded.worktreeSafetyRequired) {
+		const expectedFocusedTasks = serializeTasks(planFocusedWorktreeTasks(paths));
+		if (JSON.stringify(decoded.tasks) !== JSON.stringify(expectedFocusedTasks))
+			throw new Error("affected-plan-invalid: focused task set mismatch");
+	}
 	if (
-		new Set(tasks.map(task => task.key)).size !== tasks.length ||
-		new Set(tasks.map(task => task.identity)).size !== tasks.length
-	) throw new Error("affected-plan-invalid: duplicate task key or identity");
+		new Set(tasks.map((task) => task.key)).size !== tasks.length ||
+		new Set(tasks.map((task) => task.identity)).size !== tasks.length
+	)
+		throw new Error("affected-plan-invalid: duplicate task key or identity");
 	const matrixKey = Bun.env.CI_DEV_MATRIX_KEY?.trim();
 	if (matrixKey) {
-		const task = tasks.find(candidate => candidate.key === matrixKey);
+		const task = tasks.find((candidate) => candidate.key === matrixKey);
 		if (!task || !task.capabilities) throw new Error("affected-plan-invalid: matrix task mismatch");
-		if (task.capabilities.rust !== (Bun.env.CI_DEV_MATRIX_RUST === "true") || task.capabilities.nextest !== (Bun.env.CI_DEV_MATRIX_NEXTEST === "true") || task.capabilities.nativeConsumer !== (Bun.env.CI_DEV_MATRIX_NATIVE === "true")) throw new Error("affected-plan-invalid: matrix capabilities mismatch");
+		const matrixIdentity = Bun.env.CI_DEV_MATRIX_IDENTITY?.trim();
+		if (!matrixIdentity || task.identity !== matrixIdentity)
+			throw new Error("affected-plan-invalid: matrix identity mismatch");
+		if (
+			task.capabilities.rust !== (Bun.env.CI_DEV_MATRIX_RUST === "true") ||
+			task.capabilities.nextest !== (Bun.env.CI_DEV_MATRIX_NEXTEST === "true") ||
+			task.capabilities.nativeConsumer !== (Bun.env.CI_DEV_MATRIX_NATIVE === "true")
+		)
+			throw new Error("affected-plan-invalid: matrix capabilities mismatch");
 	}
-	return tasks;
+	return { tasks, worktreeSafetyRequired: decoded.worktreeSafetyRequired };
 }
 function deserializeTask(value: unknown): Task {
-	if (!isRecord(value) || !isString(value.key) || !isString(value.description) || !Array.isArray(value.command) || !value.command.every(isString) || (value.cwd !== undefined && !isString(value.cwd))) throw new Error("affected-plan-invalid: malformed task");
+	if (!isRecord(value)) throw new Error("affected-plan-invalid: malformed task");
 	assertTaskKeys(value);
-	if (!isString(value.identity) || value.identity.length === 0) throw new Error("affected-plan-invalid: missing task identity");
+	if (
+		!isString(value.key) ||
+		value.key.length === 0 ||
+		!isString(value.identity) ||
+		value.identity.length === 0 ||
+		!isString(value.description) ||
+		value.description.length === 0 ||
+		!Array.isArray(value.command) ||
+		value.command.length === 0 ||
+		!value.command.every((entry) => isString(entry) && entry.length > 0) ||
+		!isString(value.cwd)
+	)
+		throw new Error("affected-plan-invalid: malformed task");
 	const capabilities = value.capabilities;
-	if (!isRecord(capabilities) || typeof capabilities.rust !== "boolean" || typeof capabilities.nextest !== "boolean" || typeof capabilities.nativeConsumer !== "boolean" || typeof capabilities.nativeProducer !== "boolean") throw new Error("affected-plan-invalid: missing task capabilities");
-	assertExactKeys(capabilities, ["rust", "nextest", "nativeConsumer", "nativeProducer"], "task capabilities");
-	if (value.cwd !== undefined && value.cwd !== ".") normalizeInventoryPath(value.cwd);
+	if (
+		!isRecord(capabilities) ||
+		typeof capabilities.rust !== "boolean" ||
+		typeof capabilities.nextest !== "boolean" ||
+		typeof capabilities.nativeConsumer !== "boolean" ||
+		typeof capabilities.nativeProducer !== "boolean"
+	)
+		throw new Error("affected-plan-invalid: missing task capabilities");
+	assertExactKeys(
+		capabilities,
+		["rust", "nextest", "nativeConsumer", "nativeProducer"],
+		"task capabilities",
+		"affected-plan-invalid",
+	);
+	const cwd = validateCanonicalTaskCwd(value.cwd);
 	const phase = value.phase;
-	if (phase !== "legacy" && phase !== "native-producer" && phase !== "ts-build" && phase !== "cargo-build") throw new Error("affected-plan-invalid: missing task phase");
+	if (phase !== "legacy" && phase !== "native-producer" && phase !== "ts-build" && phase !== "cargo-build")
+		throw new Error("affected-plan-invalid: missing task phase");
 	return {
 		key: value.key,
 		identity: value.identity,
 		description: value.description,
 		command: value.command,
-		cwd: isString(value.cwd) ? path.resolve(repoRoot, value.cwd) : undefined,
+		cwd: path.resolve(repoRoot, cwd),
 		capabilities: {
 			rust: capabilities.rust as boolean,
 			nextest: capabilities.nextest as boolean,
@@ -1596,8 +2201,26 @@ function deserializeTask(value: unknown): Task {
 	};
 }
 function assertTaskKeys(value: Record<string, unknown>): void {
-	const allowed = ["key", "identity", "description", "command", "cwd", "capabilities", "phase"];
-	if (Object.keys(value).some(key => !allowed.includes(key))) throw new Error("affected-plan-invalid: malformed task");
+	const expected = ["key", "identity", "description", "command", "cwd", "capabilities", "phase"];
+	const keys = Object.keys(value);
+	if (keys.length !== expected.length || keys.some((key) => !expected.includes(key)))
+		throw new Error("affected-plan-invalid: malformed task");
+}
+
+function validateCanonicalTaskCwd(value: string): string {
+	if (value.length === 0 || value.includes("\\") || path.posix.isAbsolute(value) || /^[A-Za-z]:/.test(value))
+		throw new Error("affected-plan-invalid: unsafe task cwd");
+	if (value === ".") return value;
+	const segments = value.split("/");
+	if (segments.some((segment) => segment.length === 0 || segment === "." || segment === ".."))
+		throw new Error("affected-plan-invalid: unsafe task cwd");
+	const normalized = path.posix.normalize(value);
+	if (normalized !== value) throw new Error("affected-plan-invalid: non-canonical task cwd");
+	const resolved = path.resolve(repoRoot, ...segments);
+	const relative = path.relative(repoRoot, resolved);
+	if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative))
+		throw new Error("affected-plan-invalid: unsafe task cwd");
+	return value;
 }
 
 if (import.meta.main) {

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -95,7 +95,7 @@ export function planFocusedWorktreeTasks(paths: readonly string[]): Task[] {
 			tasks,
 			"check:coding-agent",
 			"Check @gajae-code/coding-agent",
-			["bun", "run", "check"],
+			["bun", "run", "check:types"],
 			resolvePackageCwd("packages/coding-agent"),
 		);
 	}

--- a/scripts/fixtures/worktree-report-capabilities/allowed.ts
+++ b/scripts/fixtures/worktree-report-capabilities/allowed.ts
@@ -1,0 +1,11 @@
+import { constants } from "node:fs";
+import { type FileHandle, open } from "node:fs/promises";
+
+export async function allowed(path: string): Promise<void> {
+	let handle: FileHandle;
+	handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+	await handle.stat({ bigint: true });
+	const buffer = Buffer.alloc(1);
+	await handle.read(buffer, 0, 1, 0);
+	await handle.close();
+}

--- a/scripts/fixtures/worktree-report-capabilities/forbidden.ts
+++ b/scripts/fixtures/worktree-report-capabilities/forbidden.ts
@@ -1,0 +1,61 @@
+import { open } from "node:fs/promises";
+import * as fs from "node:fs";
+import { rm } from "node:fs/promises";
+
+export async function forbidden(input: string) {
+	let handle;
+	handle = await open(input, "w");
+	await handle.write("x");
+	await handle.writev([]);
+	await handle.writeFile("x");
+	const value = input;
+	await fs.promises.writeFile(value, "x");
+	await rm(value);
+	process.env.WTR = "1";
+	await fetch("https://example.invalid");
+	await Bun.write("forbidden", "x");
+	new WebSocket("wss://example.invalid");
+	console.log("forbidden");
+	const { stat: directStat } = await open(input, "r");
+	const directRead = (await open(input, "r")).read;
+	await (await open(input, "r")).stat();
+	void directStat;
+	void directRead;
+	const sink = (value: unknown) => value;
+	const container = [handle];
+	const closure = () => handle;
+	sink(handle);
+	void container;
+	void closure;
+	const { write: extractedWrite } = handle;
+	const extractedMethod = handle.write;
+	const boundMethod = handle.write.bind(handle);
+	let assignedMethod;
+	assignedMethod = handle.write;
+	void extractedWrite;
+	void extractedMethod;
+	void boundMethod;
+	void assignedMethod;
+	return (fs as Record<string, unknown>)["stat"];
+}
+
+export const dynamic = import(`./${inputName()}`);
+export const computed = import(inputName());
+// @ts-expect-error Verifier fixture intentionally targets a synthetic forbidden edge.
+export const wrapped = Promise.resolve(import("./commands/worktree"));
+function inputName(): string {
+	return "x";
+}
+const FunctionCtor = [].filter.constructor;
+FunctionCtor("return process.getBuiltinModule('node:fs').rmSync('/target',{force:true})").call(null);
+const DirectCtor = [].filter.constructor("return process.getBuiltinModule('node:fs').rmSync('/target',{force:true})");
+const proto = { prototype: undefined }.prototype;
+const inherited = { __proto__: undefined }["__proto__"];
+const ConstructorAlias = [].filter.constructor;
+ConstructorAlias.apply(null, ["return process.getBuiltinModule('node:fs').rmSync('/target',{force:true})"]);
+ConstructorAlias.bind(null, "return process.getBuiltinModule('node:fs').rmSync('/target',{force:true})")();
+({} as { __defineGetter__(property: PropertyKey, getter: () => unknown): void }).__defineGetter__.call(
+	fs.constants,
+	"O_RDONLY",
+	() => fs.constants.O_WRONLY | fs.constants.O_TRUNC,
+);

--- a/scripts/fixtures/worktree-report-capabilities/reexport.ts
+++ b/scripts/fixtures/worktree-report-capabilities/reexport.ts
@@ -1,0 +1,2 @@
+export * from "./allowed";
+export { dynamic as hidden } from "./forbidden";


### PR DESCRIPTION
## What

- make `gjc worktree clear` report-only: it never removes a worktree, and every `--all` form fails closed
- add a bounded, no-follow worktree scanner that emits deterministic diagnostics without granting deletion authority
- require exact `O_RDONLY | O_NOFOLLOW | O_NONBLOCK` metadata opens, with fail-closed unsupported-platform reporting when non-blocking proof is unavailable
- add an AST capability verifier for the command → worker → scanner graph and focused macOS/Windows worktree-safety CI
- preserve the existing CLI surface while separating diagnostics from any future deletion design

## Why

This is a clean replacement for closed PR #2510, not a continuation or cherry-pick of it. The maintainer review on #2510 showed that advisory scanner states could flow directly into recursive deletion, `--all` could bypass Git refusal, identity/path proof was incomplete, and hostile QA reproduced deletion of a spoofed target.

This change removes that authority boundary entirely for phase 1:

| #2510 blocking finding | Resolution here |
| --- | --- |
| Advisory or ambiguous entries could be deleted | Scanner output is diagnostic only; `clear` removes zero entries |
| `--all` bypassed Git refusal through raw recursive deletion | Every `--all` spelling is rejected before scanner import; no deletion API is reachable |
| Pointer/path proof was incomplete | Bounded no-follow reads, canonical managed-root containment, reciprocal identity diagnostics, invalid UTF-8/NUL/oversize handling, and platform-specific preservation |
| Hostile QA deleted a spoofed record | Sentinel and adversarial tests prove zero removals across malformed, raced, symlinked, FIFO, and task-isolation inputs |
| Repair lacked exact hosted proof | Dedicated capability verifier and focused macOS/Windows CI bind the report-only graph to the affected-task receipt |

Actual deletion authority is deliberately out of scope. Reintroducing deletion requires a separate design with fresh mutation-boundary identity proof; this PR does not provide a fallback removal path.

## Testing

- `bun test packages/coding-agent/test/worktree-cli.test.ts scripts/check-worktree-report-capabilities.test.ts scripts/ci-dev-affected.test.ts` — 213 pass, 1 skip, 0 fail, 1,430 assertions
- `bun scripts/check-worktree-report-capabilities.ts` — silent success
- `bun scripts/check-workflow-yaml.ts` — all workflows parsed
- `bun run check:tools`
- `bun run --cwd=packages/coding-agent check` — Biome, generated hotkey docs, SDK canonicalization, TypeScript
- `git diff --check`
- source-CLI dogfood: `worktree clear --all --json` exited 2 with `worktree_cleanup_disabled`; sentinel remained present and zero entries were removed
- independent post-rebase core review: `CLEAR / APPROVE`
- independent hostile verifier review: `CLEAR / APPROVE`
- hosted Dev CI: affected-path aggregate/evidence, coding-agent type check, capability tests/verifier, macOS and Windows worktree-safety jobs, workflow parsing, and state gates all pass

The root `bun check` cannot complete on this workstation because Cargo is not installed; its TypeScript lane also hit unrelated production SDK-host startup timeouts. The affected package check and every required hosted PR check pass.

---

- [ ] `bun check` passes (local Cargo unavailable; every required hosted PR check passes)
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)
