### PR TITLE
fix(coding-agent): make worktree cleanup strictly report-only

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Team worker launches now receive the validated owning `GJC_SESSION_ID` for sanctioned session-scoped writes while preserving absent identity, fail-closed resolution, and separate spawn provenance (#2597).
 - Managed and explicit session directories now canonicalize benign ancestor symlinks (e.g. macOS `/var -> /private/var`, a symlinked `$HOME` or project directory) to a symlink-free trusted root before the strict owner-only and reparse guards run, so session creation, moves, resume, and writes no longer fail with `reparse_point` / `Unsafe reparse storage path` under a symlinked temp root or home. The native primitive stays strict and continues to reject symlinked components at or below the trusted root.
+- Worktree cleanup is report-only: `clear` removes zero entries and every `--all` form is disabled.
 - Skill invocation failures now list available skill names so agents can recover from typos without a blind retry loop.
 - Workflow state receipts now use canonical session-layout paths, require resolved session identity, and report a `state_path` that matches native write/clear output (#2393).
 - Coordinator MCP operational calls now canonically bootstrap or reuse the agent-global SDK broker when discovery is absent or stale, while coordinator/hermes JSON checks report catalog and broker-discovery readiness separately without mutating broker state (#2552).

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -6,7 +6,7 @@
  */
 import "@gajae-code/utils/postmortem";
 import { Args, type CliConfig, Command, type CommandEntry, Flags, run } from "@gajae-code/utils/cli";
-import { APP_NAME, formatBunRuntimeError, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
+import { APP_NAME, formatBunRuntimeError, getWorktreesDir, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
 import { runFixtureReport } from "./cli/fixture-report";
 import { isTmuxOwnerIsolationCliArgv, runTmuxOwnerIsolationCliFromStdin } from "./gjc-runtime/tmux-owner-isolation-cli";
 
@@ -59,6 +59,14 @@ export const commands: CommandEntry[] = [
 	{ name: "plugin", load: () => import("./commands/plugin").then(m => m.default) },
 	{ name: "completion", load: () => import("./commands/completion").then(m => m.default) },
 	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },
+	{
+		name: "worktree",
+		aliases: ["wt"],
+		load: async () => {
+			const { createWorktreeCommand } = await import("./commands/worktree");
+			return createWorktreeCommand(getWorktreesDir);
+		},
+	},
 ];
 
 async function showHelp(config: CliConfig): Promise<void> {

--- a/packages/coding-agent/src/cli/worktree-cli.ts
+++ b/packages/coding-agent/src/cli/worktree-cli.ts
@@ -1,291 +1,65 @@
-/**
- * CLI handler for `gjc worktree` — list and clean up agent-managed worktrees.
- *
- * Layout under `~/.gjc/wt/`:
- *
- *   - **PR-checkout worktrees** (`tools/gh.ts`): a regular git worktree dir
- *     containing a `.git` *file* that points back at
- *     `<parent-repo>/.git/worktrees/<name>/`.
- *   - **Task-isolation dirs** (`task/worktree.ts`): a wrapper dir with a
- *     `merged` subdir mounted/cloned by `natives.isoStart`. These are ephemeral
- *     — `ensureIsolation` always `rm -rf`s the base before re-creating it, so
- *     any leftover on disk is a leak from a crashed run.
- *
- * Legacy entries from before the encoding change keep working because git still
- * tracks them by branch name. This command exists to GC them on demand.
- */
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
-import { getWorktreesDir, isEnoent } from "@gajae-code/utils";
-import chalk from "chalk";
-import * as git from "../utils/git";
+import { scanWorktrees, type WorktreeDiagnostic, WorktreeRootError } from "./worktree-scanner";
 
-type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray";
-
-export interface WorktreeEntry {
-	/** Absolute path to the worktree dir (or stray container) under `~/.gjc/wt/`. */
-	path: string;
-	/** Classification of what we found on disk. */
-	kind: WorktreeKind;
-	/** Parent repo root, when this is a registered git worktree. */
-	parentRepo?: string;
-	/** Branch name extracted from the parent's tracking file, when available. */
-	branch?: string;
-	/** When set, the entry is unhealthy and `gjc worktree clear` will remove it. */
-	orphanReason?: string;
-}
-
-export interface ListWorktreesOptions {
+export interface RunWorktreeCommandOptions {
+	root: string;
+	action: "list" | "clear";
 	json: boolean;
-}
-
-export interface ClearWorktreesOptions {
-	/** Remove every entry, including live PR-checkout worktrees. */
-	all: boolean;
-	/** Print what would be removed without touching the filesystem. */
 	dryRun: boolean;
-	json: boolean;
 }
 
-export async function listWorktrees(options: ListWorktreesOptions): Promise<void> {
-	const entries = await scanWorktrees();
-	if (options.json) {
-		console.log(JSON.stringify(entries, null, 2));
-		return;
-	}
-	if (entries.length === 0) {
-		console.log(chalk.dim(`No agent-managed worktrees found under ${getWorktreesDir()}.`));
-		return;
-	}
-	let live = 0;
-	let orphaned = 0;
-	for (const entry of entries) {
-		const tag = entry.orphanReason ? chalk.yellow("orphaned") : chalk.green("live    ");
-		const detail = formatEntryDetail(entry);
-		console.log(`${tag}  ${entry.path}`);
-		if (detail) console.log(`          ${chalk.dim(detail)}`);
-		if (entry.orphanReason) orphaned += 1;
-		else live += 1;
-	}
-	console.log(chalk.dim(`\n${live} live · ${orphaned} orphaned · ${entries.length} total`));
+export interface RunWorktreeCommandResult {
+	stdout: string;
+	stderr: string;
+	exitCode: 0 | 1;
 }
 
-export async function clearWorktrees(options: ClearWorktreesOptions): Promise<void> {
-	const entries = await scanWorktrees();
-	const targets = options.all ? entries : entries.filter(entry => entry.orphanReason !== undefined);
+const SCAN_ERROR_TEXT = "managed worktree root cannot be read";
 
-	if (targets.length === 0) {
-		if (options.json) {
-			console.log(JSON.stringify({ removed: 0, kept: entries.length }));
-		} else {
-			console.log(chalk.dim(options.all ? "No worktrees to remove." : "No orphaned worktrees to remove."));
-		}
-		return;
-	}
-
-	if (options.dryRun) {
-		if (options.json) {
-			console.log(JSON.stringify({ wouldRemove: targets.map(t => t.path) }, null, 2));
-		} else {
-			for (const target of targets) {
-				console.log(`${chalk.yellow("would remove")}  ${target.path}`);
-			}
-			console.log(chalk.dim(`\n${targets.length} dir${targets.length === 1 ? "" : "s"} would be removed.`));
-		}
-		return;
-	}
-
-	const results: { path: string; ok: boolean; error?: string }[] = [];
-	const parentsToPrune = new Set<string>();
-	for (const target of targets) {
-		try {
-			if (target.kind === "pr-checkout" && target.parentRepo && !target.orphanReason) {
-				// Live worktree: ask git to remove it cleanly. If git refuses (locked,
-				// dirty, etc.), fall back to fs.rm and rely on `worktree prune` to
-				// clean the bookkeeping on the parent side.
-				const removed = await git.worktree.tryRemove(target.parentRepo, target.path, { force: true });
-				if (!removed) {
-					await fs.rm(target.path, { recursive: true, force: true });
-					parentsToPrune.add(target.parentRepo);
+export async function runWorktreeCommand(options: RunWorktreeCommandOptions): Promise<RunWorktreeCommandResult> {
+	let diagnostics: WorktreeDiagnostic[];
+	try {
+		diagnostics = await scanWorktrees({ root: options.root });
+	} catch (error) {
+		if (!(error instanceof WorktreeRootError)) throw error;
+		return options.json
+			? {
+					stdout: `${JSON.stringify({ error: { code: "worktree_scan_failed", message: SCAN_ERROR_TEXT } })}\n`,
+					stderr: "",
+					exitCode: 1,
 				}
-			} else {
-				await fs.rm(target.path, { recursive: true, force: true });
-				if (target.parentRepo) parentsToPrune.add(target.parentRepo);
-			}
-			results.push({ path: target.path, ok: true });
-		} catch (err) {
-			results.push({ path: target.path, ok: false, error: err instanceof Error ? err.message : String(err) });
-		}
+			: { stdout: "", stderr: `error: ${SCAN_ERROR_TEXT}\n`, exitCode: 1 };
+	}
+	if (options.action === "list") {
+		if (options.json) return { stdout: `${JSON.stringify(diagnostics)}\n`, stderr: "", exitCode: 0 };
+		if (diagnostics.length === 0) return { stdout: "No agent-managed worktrees found.\n", stderr: "", exitCode: 0 };
+		return {
+			stdout: `${diagnostics.map(formatDiagnostic).join("\n")}\n\n${diagnostics.length} total\n`,
+			stderr: "",
+			exitCode: 0,
+		};
 	}
 
-	// Best-effort: drop stale entries from each affected parent's `.git/worktrees/`.
-	for (const parent of parentsToPrune) {
-		try {
-			await git.worktree.prune(parent);
-		} catch {
-			/* parent repo may already be gone or pruned — ignore */
+	if (options.dryRun || diagnostics.length === 0) {
+		if (options.json) {
+			return {
+				stdout: `${JSON.stringify(options.dryRun ? { wouldRemove: [] } : { removed: 0, kept: 0 })}\n`,
+				stderr: "",
+				exitCode: 0,
+			};
 		}
+		return { stdout: "No worktrees are eligible for removal; cleanup is report-only.\n", stderr: "", exitCode: 0 };
 	}
-
-	const succeeded = results.filter(r => r.ok).length;
-	const failed = results.length - succeeded;
 
 	if (options.json) {
-		console.log(JSON.stringify({ removed: succeeded, failed, results }, null, 2));
-		if (failed > 0) process.exitCode = 1;
-		return;
+		return { stdout: `${JSON.stringify({ removed: 0, kept: diagnostics.length })}\n`, stderr: "", exitCode: 0 };
 	}
-
-	for (const result of results) {
-		if (result.ok) {
-			console.log(`${chalk.green("removed")}  ${result.path}`);
-		} else {
-			console.log(`${chalk.red("failed ")}  ${result.path}`);
-			if (result.error) console.log(`          ${chalk.dim(result.error)}`);
-		}
-	}
-	console.log(chalk.dim(`\n${succeeded} removed${failed > 0 ? ` · ${chalk.red(`${failed} failed`)}` : ""}`));
-	if (failed > 0) process.exitCode = 1;
+	return {
+		stdout: `${diagnostics.map(diagnostic => `kept    ${diagnostic.path}`).join("\n")}\n\n0 removed · ${diagnostics.length} kept\n`,
+		stderr: "",
+		exitCode: 0,
+	};
 }
 
-// ───────────────────────────────────────────────────────────────────────────
-// Scanner
-// ───────────────────────────────────────────────────────────────────────────
-
-async function scanWorktrees(): Promise<WorktreeEntry[]> {
-	const root = getWorktreesDir();
-	let topLevel: string[];
-	try {
-		topLevel = await fs.readdir(root);
-	} catch (err) {
-		if (isEnoent(err)) return [];
-		throw err;
-	}
-
-	const entries: WorktreeEntry[] = [];
-	for (const name of topLevel) {
-		const dir = path.join(root, name);
-		const stat = await fs.stat(dir).catch(() => null);
-		if (!stat?.isDirectory()) continue;
-
-		const direct = await classifyDir(dir);
-		if (direct) {
-			entries.push(direct);
-			continue;
-		}
-
-		// Legacy nesting: ~/.gjc/wt/<encoded-project>/<branch-or-id>
-		let children: string[];
-		try {
-			children = await fs.readdir(dir);
-		} catch {
-			continue;
-		}
-		let nested = 0;
-		for (const child of children) {
-			const childDir = path.join(dir, child);
-			const childStat = await fs.stat(childDir).catch(() => null);
-			if (!childStat?.isDirectory()) continue;
-			const childClassified = await classifyDir(childDir);
-			if (childClassified) {
-				entries.push(childClassified);
-				nested += 1;
-			}
-		}
-		if (nested === 0) {
-			entries.push({
-				path: dir,
-				kind: children.length === 0 ? "empty" : "stray",
-				orphanReason: children.length === 0 ? "empty directory" : "no recognizable worktree contents",
-			});
-		}
-	}
-	return entries;
-}
-
-async function classifyDir(dir: string): Promise<WorktreeEntry | null> {
-	const gitEntry = path.join(dir, ".git");
-	const gitStat = await fs.stat(gitEntry).catch(() => null);
-	if (gitStat?.isFile()) {
-		return classifyPrCheckout(dir, gitEntry);
-	}
-	const mergedStat = await fs.stat(path.join(dir, "merged")).catch(() => null);
-	if (mergedStat?.isDirectory()) {
-		return {
-			path: dir,
-			kind: "task-isolation",
-			orphanReason: "task-isolation leftover (no live task owns it)",
-		};
-	}
-	return null;
-}
-
-async function classifyPrCheckout(dir: string, gitEntry: string): Promise<WorktreeEntry> {
-	let contents: string;
-	try {
-		contents = await fs.readFile(gitEntry, "utf8");
-	} catch (err) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			orphanReason: `cannot read .git file: ${err instanceof Error ? err.message : String(err)}`,
-		};
-	}
-	const match = /^gitdir:\s*(.+?)\s*$/m.exec(contents);
-	const parentGitDir = match?.[1];
-	if (!parentGitDir) {
-		return { path: dir, kind: "pr-checkout", orphanReason: "malformed .git file (no gitdir line)" };
-	}
-	// parentGitDir is `<parent-repo>/.git/worktrees/<name>`; back out the repo root.
-	const parentRepo = path.dirname(path.dirname(path.dirname(parentGitDir)));
-	const branch = await readWorktreeBranch(path.join(parentGitDir, "HEAD"));
-
-	const parentDirStat = await fs.stat(parentGitDir).catch(() => null);
-	if (!parentDirStat?.isDirectory()) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			parentRepo,
-			branch,
-			orphanReason: "parent repo no longer tracks this worktree",
-		};
-	}
-	const parentRepoStat = await fs.stat(parentRepo).catch(() => null);
-	if (!parentRepoStat?.isDirectory()) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			parentRepo,
-			branch,
-			orphanReason: "parent repo missing",
-		};
-	}
-	return { path: dir, kind: "pr-checkout", parentRepo, branch };
-}
-
-async function readWorktreeBranch(headFile: string): Promise<string | undefined> {
-	try {
-		const head = (await fs.readFile(headFile, "utf8")).trim();
-		const refMatch = /^ref:\s*refs\/heads\/(.+)$/.exec(head);
-		return refMatch?.[1];
-	} catch {
-		return undefined;
-	}
-}
-
-function formatEntryDetail(entry: WorktreeEntry): string {
-	const parts: string[] = [];
-	if (entry.kind === "pr-checkout") {
-		const repo = entry.parentRepo ? path.basename(entry.parentRepo) : "unknown repo";
-		const branch = entry.branch ?? "unknown branch";
-		parts.push(`${repo} · ${branch}`);
-	} else if (entry.kind === "task-isolation") {
-		parts.push("task-isolation sandbox");
-	} else if (entry.kind === "empty") {
-		parts.push("legacy project shell");
-	} else {
-		parts.push("unrecognized contents");
-	}
-	if (entry.orphanReason) parts.push(entry.orphanReason);
-	return parts.join(" — ");
+function formatDiagnostic(diagnostic: WorktreeDiagnostic): string {
+	return `diagnostic  ${diagnostic.path}  ${diagnostic.message}`;
 }

--- a/packages/coding-agent/src/cli/worktree-scanner.ts
+++ b/packages/coding-agent/src/cli/worktree-scanner.ts
@@ -1,0 +1,266 @@
+import type { BigIntStats, Dir } from "node:fs";
+import { lstat, opendir } from "node:fs/promises";
+import * as path from "node:path";
+
+export const MAX_ENTRIES = 1024;
+export const MAX_DEPTH = 2;
+
+export type WorktreeRootErrorCode = "root-unreadable" | "root-invalid";
+
+export class WorktreeRootError extends Error {
+	constructor(readonly code: WorktreeRootErrorCode) {
+		super(code);
+		this.name = "WorktreeRootError";
+	}
+}
+
+export interface ScanWorktreesOptions {
+	root: string;
+}
+
+export type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray" | "overflow" | "unsupported";
+
+export interface WorktreeDiagnostic {
+	path: string;
+	kind: WorktreeKind;
+	reasonCode: string;
+	message: string;
+}
+
+interface Identity {
+	dev: bigint;
+	ino: bigint;
+}
+
+interface ScanState {
+	visited: number;
+	halted: boolean;
+	diagnostics: WorktreeDiagnostic[];
+	root: string;
+}
+
+interface LevelResult {
+	seen: number;
+	handled: number;
+}
+
+function codeOf(error: unknown): string | undefined {
+	return (error as { code?: string }).code;
+}
+
+function displayPath(value: string): string {
+	return value.replace(/[\u0000-\u001f\u007f]/g, character => {
+		const code = character.charCodeAt(0);
+		return `\\x${code.toString(16).padStart(2, "0").toUpperCase()}`;
+	});
+}
+
+function addDiagnostic(
+	state: ScanState,
+	candidate: string,
+	kind: WorktreeKind,
+	reasonCode: string,
+	message: string,
+): void {
+	state.diagnostics.push({ path: displayPath(candidate), kind, reasonCode, message });
+}
+
+function chargeEntry(state: ScanState): boolean {
+	if (state.visited >= MAX_ENTRIES) {
+		if (!state.halted)
+			addDiagnostic(
+				state,
+				state.root,
+				"overflow",
+				"overflow",
+				`scan limit exceeded: ${MAX_ENTRIES} entries; preserved`,
+			);
+		state.halted = true;
+		return false;
+	}
+	state.visited++;
+	return true;
+}
+
+function sameIdentity(identity: Identity, stat: BigIntStats): boolean {
+	return identity.dev === stat.dev && identity.ino === stat.ino;
+}
+
+async function stableDirectory(candidate: string, identity: Identity): Promise<boolean> {
+	try {
+		const stat = await lstat(candidate, { bigint: true });
+		return stat.isDirectory() && !stat.isSymbolicLink() && sameIdentity(identity, stat);
+	} catch {
+		return false;
+	}
+}
+
+function replaceWithRaceDiagnostic(state: ScanState, candidate: string, diagnosticStart: number): void {
+	state.diagnostics.splice(diagnosticStart);
+	addDiagnostic(
+		state,
+		candidate,
+		"unsupported",
+		"metadata-raced",
+		"filesystem metadata changed during scan; preserved",
+	);
+}
+
+async function markerStat(marker: string): Promise<BigIntStats | undefined> {
+	try {
+		return await lstat(marker, { bigint: true });
+	} catch (error) {
+		const code = codeOf(error);
+		if (code === "ENOENT" || code === "ENOTDIR") return undefined;
+		throw error;
+	}
+}
+
+async function inspectCandidate(candidate: string, state: ScanState, depth: number): Promise<boolean> {
+	const diagnosticStart = state.diagnostics.length;
+	let stat: BigIntStats;
+	try {
+		stat = await lstat(candidate, { bigint: true });
+	} catch (error) {
+		addDiagnostic(
+			state,
+			candidate,
+			"unsupported",
+			codeOf(error) === "ENOENT" || codeOf(error) === "ENOTDIR" ? "metadata-raced" : "scan-error",
+			"cannot inspect directory; preserved",
+		);
+		return true;
+	}
+	if (stat.isSymbolicLink()) {
+		addDiagnostic(
+			state,
+			candidate,
+			"unsupported",
+			"unsupported-link",
+			"link or reparse point encountered; preserved",
+		);
+		return true;
+	}
+	if (!stat.isDirectory()) return false;
+	const identity: Identity = { dev: stat.dev, ino: stat.ino };
+
+	try {
+		const git = await markerStat(path.join(candidate, ".git"));
+		if (git?.isSymbolicLink() || git?.isFile() || git?.isDirectory()) {
+			if (!(await stableDirectory(candidate, identity))) {
+				replaceWithRaceDiagnostic(state, candidate, diagnosticStart);
+				return true;
+			}
+			if (git.isSymbolicLink())
+				addDiagnostic(
+					state,
+					candidate,
+					"unsupported",
+					"unsupported-link",
+					"link or reparse point encountered; preserved",
+				);
+			else addDiagnostic(state, candidate, "pr-checkout", "worktree-metadata", ".git metadata observed; preserved");
+			return true;
+		}
+
+		const merged = await markerStat(path.join(candidate, "merged"));
+		if (merged?.isSymbolicLink() || merged?.isDirectory()) {
+			if (!(await stableDirectory(candidate, identity))) {
+				replaceWithRaceDiagnostic(state, candidate, diagnosticStart);
+				return true;
+			}
+			if (merged.isSymbolicLink())
+				addDiagnostic(
+					state,
+					candidate,
+					"unsupported",
+					"unsupported-link",
+					"link or reparse point encountered; preserved",
+				);
+			else
+				addDiagnostic(state, candidate, "task-isolation", "task-isolation", "task-isolation directory; preserved");
+			return true;
+		}
+	} catch {
+		addDiagnostic(state, candidate, "unsupported", "scan-error", "cannot inspect directory; preserved");
+		return true;
+	}
+
+	if (!(await stableDirectory(candidate, identity))) {
+		replaceWithRaceDiagnostic(state, candidate, diagnosticStart);
+		return true;
+	}
+
+	if (depth >= MAX_DEPTH) {
+		const level = await scanLevel(candidate, state, depth + 1);
+		if (!(await stableDirectory(candidate, identity))) {
+			replaceWithRaceDiagnostic(state, candidate, diagnosticStart);
+			return true;
+		}
+		if (level.handled === 0 && !state.halted)
+			addDiagnostic(
+				state,
+				candidate,
+				level.seen === 0 ? "empty" : "stray",
+				level.seen === 0 ? "empty" : "stray",
+				level.seen === 0 ? "empty directory; preserved" : "unrecognized directory contents; preserved",
+			);
+		return true;
+	}
+
+	const level = await scanLevel(candidate, state, depth + 1);
+	if (!(await stableDirectory(candidate, identity))) {
+		replaceWithRaceDiagnostic(state, candidate, diagnosticStart);
+		return true;
+	}
+	if (level.handled === 0 && !state.halted)
+		addDiagnostic(
+			state,
+			candidate,
+			level.seen === 0 ? "empty" : "stray",
+			level.seen === 0 ? "empty" : "stray",
+			level.seen === 0 ? "empty directory; preserved" : "unrecognized directory contents; preserved",
+		);
+	return true;
+}
+
+async function scanLevel(dir: string, state: ScanState, depth: number): Promise<LevelResult> {
+	let directory: Dir;
+	try {
+		directory = await opendir(dir);
+	} catch (error) {
+		if (dir === state.root)
+			throw new WorktreeRootError(codeOf(error) === "ENOTDIR" ? "root-invalid" : "root-unreadable");
+		addDiagnostic(state, dir, "unsupported", "scan-error", "cannot inspect directory; preserved");
+		return { seen: 0, handled: 1 };
+	}
+
+	let seen = 0;
+	let handled = 0;
+	for await (const entry of directory) {
+		seen++;
+		if (!chargeEntry(state)) break;
+		if (depth <= MAX_DEPTH && (entry.isDirectory() || entry.isSymbolicLink())) {
+			if (await inspectCandidate(path.join(dir, entry.name), state, depth)) handled++;
+		}
+		if (state.halted) break;
+	}
+	return { seen, handled };
+}
+
+export async function scanWorktrees(options: ScanWorktreesOptions): Promise<WorktreeDiagnostic[]> {
+	let root: BigIntStats;
+	try {
+		root = await lstat(options.root, { bigint: true });
+	} catch (error) {
+		if (codeOf(error) === "ENOENT") return [];
+		throw new WorktreeRootError("root-unreadable");
+	}
+	if (root.isSymbolicLink() || !root.isDirectory()) throw new WorktreeRootError("root-invalid");
+
+	const rootIdentity: Identity = { dev: root.dev, ino: root.ino };
+	const state: ScanState = { visited: 0, halted: false, diagnostics: [], root: options.root };
+	await scanLevel(options.root, state, 1);
+	if (!(await stableDirectory(options.root, rootIdentity))) throw new WorktreeRootError("root-invalid");
+	return state.diagnostics;
+}

--- a/packages/coding-agent/src/commands/worktree.ts
+++ b/packages/coding-agent/src/commands/worktree.ts
@@ -1,56 +1,84 @@
 /**
- * List and clean up agent-managed git worktrees under `~/.gjc/wt`.
+ * Report-only diagnostics for agent-managed worktrees.
  */
-import { Args, Command, Flags } from "@gajae-code/utils/cli";
-import { clearWorktrees, listWorktrees } from "../cli/worktree-cli";
+import { Args, Command, type CommandCtor, Flags, renderCommandHelp } from "@gajae-code/utils/cli";
+import { runWorktreeCommand } from "../cli/worktree-cli";
 
-export default class Worktree extends Command {
-	static description = "List or clear agent-managed git worktrees (~/.gjc/wt)";
+export type WorktreeRootGetter = () => string;
 
-	static aliases = ["wt"];
-
-	static args = {
-		// `list` (default) inspects the worktree dir; `clear` removes entries.
-		// A positional action keeps `gjc worktree` (the no-arg form) useful.
-		action: Args.string({
-			description: "list (default) or clear",
-			required: false,
-			options: ["list", "clear"],
-			default: "list",
-		}),
-	};
-
-	static flags = {
-		all: Flags.boolean({
-			description: "Clear every entry, including live PR-checkout worktrees (clear)",
-			default: false,
-		}),
-		"dry-run": Flags.boolean({
-			char: "n",
-			description: "Print what would be removed without touching the filesystem (clear)",
-			default: false,
-		}),
-		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: false }),
-	};
-
-	static examples = [
-		"gjc worktree",
-		"gjc worktree list --json",
-		"gjc worktree clear",
-		"gjc worktree clear --dry-run",
-		"gjc worktree clear --all",
-	];
-
-	async run(): Promise<void> {
-		const { args, flags } = await this.parse(Worktree);
-		if (args.action === "clear") {
-			await clearWorktrees({
-				all: flags.all ?? false,
-				dryRun: flags["dry-run"] ?? false,
-				json: flags.json ?? false,
-			});
-			return;
-		}
-		await listWorktrees({ json: flags.json ?? false });
+function rejectCleanup(json: boolean): void {
+	if (json) {
+		process.stdout.write(
+			'{"error":{"code":"worktree_cleanup_disabled","message":"worktree cleanup is report-only"}}\n',
+		);
+	} else {
+		process.stderr.write("error: worktree cleanup is report-only\n");
 	}
+	process.exitCode = 2;
+}
+
+function hasAllFlag(argv: readonly string[]): boolean {
+	return argv.some(argument => argument === "--all" || argument.startsWith("--all="));
+}
+
+export function createWorktreeCommand(getWorktreesDir: WorktreeRootGetter): CommandCtor {
+	return class Worktree extends Command {
+		static description = "List report-only diagnostics for agent-managed worktrees";
+		static aliases = ["wt"];
+		static delegateHelp = true;
+
+		static args = {
+			action: Args.string({
+				description: "list (default) or clear",
+				required: false,
+				options: ["list", "clear"],
+				default: "list",
+			}),
+		};
+
+		static flags = {
+			all: Flags.boolean({ description: "Unavailable: cleanup is report-only", default: false }),
+			"dry-run": Flags.boolean({ char: "n", description: "Preview the report-only clear summary", default: false }),
+			json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: false }),
+		};
+
+		static examples = [
+			"gjc worktree",
+			"gjc worktree list --json",
+			"gjc worktree clear",
+			"gjc worktree clear --dry-run",
+		];
+
+		async run(): Promise<void> {
+			if (hasAllFlag(this.argv)) {
+				rejectCleanup(this.argv.includes("--json") || this.argv.includes("-j"));
+				return;
+			}
+			if (this.argv.includes("--help") || this.argv.includes("-h")) {
+				renderCommandHelp(this.config.bin, "worktree", Worktree);
+				return;
+			}
+			const { args, flags, argv } = await this.parse(Worktree);
+			const action = args.action === "clear" ? "clear" : "list";
+			const all = flags.all ?? false;
+			const dryRun = flags["dry-run"] ?? false;
+			const json = flags.json ?? false;
+			const validPositionals = argv.length <= 1 && (argv.length === 0 || argv[0] === action);
+			const valid = validPositionals && ((action === "clear" && !all) || (action === "list" && !all && !dryRun));
+			if (!valid) {
+				rejectCleanup(json);
+				return;
+			}
+			const root = getWorktreesDir();
+			const result = await runWorktreeCommand({
+				root,
+				action,
+				json,
+				dryRun,
+			});
+			if (result.stdout.length > 0) process.stdout.write(result.stdout);
+			if (result.stderr.length > 0) process.stderr.write(result.stderr);
+			if (result.exitCode !== 0) process.exitCode = result.exitCode;
+		}
+	};
 }

--- a/packages/coding-agent/test/worktree-cli.test.ts
+++ b/packages/coding-agent/test/worktree-cli.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type CommandCtor, type CommandEntry, run } from "@gajae-code/utils/cli";
+import { runWorktreeCommand } from "../src/cli/worktree-cli";
+import {
+	MAX_DEPTH,
+	MAX_ENTRIES,
+	scanWorktrees,
+	type WorktreeDiagnostic,
+	WorktreeRootError,
+} from "../src/cli/worktree-scanner";
+import { createWorktreeCommand } from "../src/commands/worktree";
+
+const posixTest = test.skipIf(process.platform === "win32");
+
+async function withRoot(callback: (root: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "gjc-worktree-report-"));
+	try {
+		await callback(root);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+function diagnostic(result: WorktreeDiagnostic[], candidate: string): WorktreeDiagnostic | undefined {
+	return result.find(entry => entry.path === candidate);
+}
+
+async function captureOutput(
+	callback: () => Promise<void>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const stdout: string[] = [];
+	const stderr: string[] = [];
+	const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(chunk => {
+		stdout.push(String(chunk));
+		return true;
+	});
+	const stderrSpy = spyOn(process.stderr, "write").mockImplementation(chunk => {
+		stderr.push(String(chunk));
+		return true;
+	});
+	const previousExitCode = process.exitCode;
+	process.exitCode = 0;
+	try {
+		await callback();
+		return { stdout: stdout.join(""), stderr: stderr.join(""), exitCode: Number(process.exitCode ?? 0) };
+	} finally {
+		process.exitCode = previousExitCode;
+		stdoutSpy.mockRestore();
+		stderrSpy.mockRestore();
+	}
+}
+
+async function capture(
+	Command: CommandCtor,
+	argv: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	return captureOutput(async () => {
+		await new Command(argv, { bin: "gjc", version: "test", commands: new Map() }).run();
+	});
+}
+
+async function captureCli(
+	commands: CommandEntry[],
+	argv: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	return captureOutput(async () => {
+		await run({ bin: "gjc", version: "test", argv, commands });
+	});
+}
+
+describe("bounded worktree scanner", () => {
+	test("keeps traversal bounds and handles missing or invalid roots", async () => {
+		expect({ MAX_ENTRIES, MAX_DEPTH }).toEqual({ MAX_ENTRIES: 1024, MAX_DEPTH: 2 });
+		expect(await scanWorktrees({ root: join(tmpdir(), "gjc-missing-worktree-root") })).toEqual([]);
+
+		await withRoot(async root => {
+			const file = join(root, "file");
+			await writeFile(file, "not a directory");
+			const error = await scanWorktrees({ root: file }).catch(cause => cause);
+			expect(error).toBeInstanceOf(WorktreeRootError);
+			expect((error as WorktreeRootError).code).toBe("root-invalid");
+		});
+	});
+
+	posixTest("rejects a symlinked managed root", async () => {
+		await withRoot(async root => {
+			const target = join(root, "target");
+			const linkedRoot = join(root, "linked-root");
+			await mkdir(join(target, ".git"), { recursive: true });
+			await symlink(target, linkedRoot);
+			const error = await scanWorktrees({ root: linkedRoot }).catch(cause => cause);
+			expect(error).toBeInstanceOf(WorktreeRootError);
+			expect((error as WorktreeRootError).code).toBe("root-invalid");
+		});
+	});
+
+	test("classifies only local marker types", async () => {
+		await withRoot(async root => {
+			const gitFile = join(root, "git-file");
+			const gitDirectory = join(root, "git-directory");
+			const task = join(root, "task");
+			const empty = join(root, "empty");
+			const stray = join(root, "stray");
+			for (const candidate of [gitFile, gitDirectory, task, empty, stray]) await mkdir(candidate);
+			await writeFile(join(gitFile, ".git"), "gitdir: /outside/the/managed/root\n");
+			await mkdir(join(gitDirectory, ".git"));
+			await mkdir(join(task, "merged"));
+			await writeFile(join(stray, "note"), "content");
+
+			const result = await scanWorktrees({ root });
+			expect(diagnostic(result, gitFile)).toMatchObject({ kind: "pr-checkout", reasonCode: "worktree-metadata" });
+			expect(diagnostic(result, gitDirectory)).toMatchObject({
+				kind: "pr-checkout",
+				reasonCode: "worktree-metadata",
+			});
+			expect(diagnostic(result, task)).toMatchObject({ kind: "task-isolation", reasonCode: "task-isolation" });
+			expect(diagnostic(result, empty)).toMatchObject({ kind: "empty", reasonCode: "empty" });
+			expect(diagnostic(result, stray)).toMatchObject({ kind: "stray", reasonCode: "stray" });
+			expect(JSON.stringify(result)).not.toContain("/outside/the/managed/root");
+		});
+	});
+
+	test("does not parse repository-controlled .git contents", async () => {
+		await withRoot(async root => {
+			const contents = [Buffer.alloc(0), Buffer.from([0xff, 0x00]), Buffer.alloc(70_000, 0x61)];
+			for (const [index, content] of contents.entries()) {
+				const candidate = join(root, `candidate-${index}`);
+				await mkdir(candidate);
+				await writeFile(join(candidate, ".git"), content);
+			}
+			const result = await scanWorktrees({ root });
+			expect(result).toHaveLength(contents.length);
+			expect(result.every(entry => entry.reasonCode === "worktree-metadata")).toBe(true);
+		});
+	});
+
+	posixTest("does not follow candidate or marker symlinks", async () => {
+		await withRoot(async root => {
+			const target = join(root, "target");
+			const linkedCandidate = join(root, "linked-candidate");
+			const linkedMarker = join(root, "linked-marker");
+			const linkedMerged = join(root, "linked-merged");
+			await mkdir(target);
+			await symlink(target, linkedCandidate);
+			await mkdir(linkedMarker);
+			await symlink(target, join(linkedMarker, ".git"));
+			await mkdir(linkedMerged);
+			await symlink(target, join(linkedMerged, "merged"));
+
+			const result = await scanWorktrees({ root });
+			expect(diagnostic(result, linkedCandidate)?.reasonCode).toBe("unsupported-link");
+			expect(diagnostic(result, linkedMarker)?.reasonCode).toBe("unsupported-link");
+			expect(diagnostic(result, linkedMerged)?.reasonCode).toBe("unsupported-link");
+		});
+	});
+
+	test("supports legacy nesting without descending beyond the limit", async () => {
+		await withRoot(async root => {
+			const wrapper = join(root, "wrapper");
+			const recognized = join(wrapper, "recognized");
+			const bounded = join(wrapper, "bounded");
+			const tooDeep = join(bounded, "too-deep");
+			await mkdir(join(recognized, ".git"), { recursive: true });
+			await mkdir(tooDeep, { recursive: true });
+			await writeFile(join(tooDeep, ".git"), "ignored");
+
+			const result = await scanWorktrees({ root });
+			expect(diagnostic(result, recognized)).toMatchObject({
+				kind: "pr-checkout",
+				reasonCode: "worktree-metadata",
+			});
+			expect(diagnostic(result, bounded)).toMatchObject({ kind: "stray", reasonCode: "stray" });
+			expect(diagnostic(result, wrapper)).toBeUndefined();
+			expect(diagnostic(result, tooDeep)).toBeUndefined();
+		});
+	});
+
+	test("reports the exact entry-limit boundary", async () => {
+		await withRoot(async root => {
+			for (let index = 0; index < MAX_ENTRIES; index++)
+				await mkdir(join(root, `candidate-${String(index).padStart(4, "0")}`));
+
+			const boundary = await scanWorktrees({ root });
+			expect(boundary.filter(entry => entry.reasonCode === "empty")).toHaveLength(MAX_ENTRIES);
+			expect(boundary.some(entry => entry.reasonCode === "overflow")).toBe(false);
+
+			await mkdir(join(root, "candidate-overflow"));
+			const overflow = await scanWorktrees({ root });
+			expect(overflow.filter(entry => entry.reasonCode === "empty")).toHaveLength(MAX_ENTRIES);
+			expect(overflow.filter(entry => entry.reasonCode === "overflow")).toHaveLength(1);
+		});
+	});
+
+	posixTest("escapes control characters in displayed paths", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "line\nbreak");
+			await mkdir(join(candidate, ".git"), { recursive: true });
+			const result = await scanWorktrees({ root });
+			expect(result).toHaveLength(1);
+			expect(result[0]?.path).toContain("line\\x0Abreak");
+			expect(result[0]?.path).not.toContain("\n");
+		});
+	});
+});
+
+describe("report-only worktree command", () => {
+	test("public clear forms report zero removals and leave entries unchanged", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "candidate");
+			const marker = join(candidate, ".git");
+			await mkdir(candidate);
+			await writeFile(marker, "gitdir: /outside\n");
+			const beforeEntries = await readdir(candidate);
+			const beforeMarker = await readFile(marker);
+			const Command = createWorktreeCommand(() => root);
+
+			expect(await capture(Command, ["clear"])).toEqual({
+				stdout: `kept    ${candidate}\n\n0 removed · 1 kept\n`,
+				stderr: "",
+				exitCode: 0,
+			});
+			expect(await capture(Command, ["clear", "--json"])).toEqual({
+				stdout: '{"removed":0,"kept":1}\n',
+				stderr: "",
+				exitCode: 0,
+			});
+			expect(await capture(Command, ["clear", "--dry-run"])).toEqual({
+				stdout: "No worktrees are eligible for removal; cleanup is report-only.\n",
+				stderr: "",
+				exitCode: 0,
+			});
+			expect(await capture(Command, ["clear", "--dry-run", "--json"])).toEqual({
+				stdout: '{"wouldRemove":[]}\n',
+				stderr: "",
+				exitCode: 0,
+			});
+			expect(await readdir(candidate)).toEqual(beforeEntries);
+			expect(await readFile(marker)).toEqual(beforeMarker);
+		});
+	});
+
+	test("list emits text and JSON diagnostics", async () => {
+		await withRoot(async root => {
+			const candidate = join(root, "candidate");
+			await mkdir(join(candidate, ".git"), { recursive: true });
+			const Command = createWorktreeCommand(() => root);
+			expect(await capture(Command, [])).toEqual({
+				stdout: `diagnostic  ${candidate}  .git metadata observed; preserved\n\n1 total\n`,
+				stderr: "",
+				exitCode: 0,
+			});
+			expect(await capture(Command, ["list", "--json"])).toEqual({
+				stdout: `${JSON.stringify([
+					{
+						path: candidate,
+						kind: "pr-checkout",
+						reasonCode: "worktree-metadata",
+						message: ".git metadata observed; preserved",
+					},
+				])}\n`,
+				stderr: "",
+				exitCode: 0,
+			});
+		});
+	});
+
+	test("maps invalid roots to stable text and JSON errors", async () => {
+		await withRoot(async root => {
+			const file = join(root, "file");
+			await writeFile(file, "not a directory");
+			expect(await runWorktreeCommand({ root: file, action: "list", json: false, dryRun: false })).toEqual({
+				stdout: "",
+				stderr: "error: managed worktree root cannot be read\n",
+				exitCode: 1,
+			});
+			expect(await runWorktreeCommand({ root: file, action: "list", json: true, dryRun: false })).toEqual({
+				stdout: '{"error":{"code":"worktree_scan_failed","message":"managed worktree root cannot be read"}}\n',
+				stderr: "",
+				exitCode: 1,
+			});
+		});
+	});
+
+	test("rejects every cleanup flag form before resolving the root", async () => {
+		let rootCalls = 0;
+		const Command = createWorktreeCommand(() => {
+			rootCalls++;
+			return "/must-not-be-read";
+		});
+		for (const argv of [
+			["--all"],
+			["--dry-run"],
+			["list", "--all"],
+			["clear", "--all"],
+			["--all", "clear"],
+			["clear", "--all", "--dry-run"],
+			["--all=true"],
+		])
+			expect(await capture(Command, argv)).toEqual({
+				stdout: "",
+				stderr: "error: worktree cleanup is report-only\n",
+				exitCode: 2,
+			});
+		for (const argv of [
+			["clear", "--all", "--json"],
+			["--all", "-j", "clear"],
+			["--all=false", "-j", "clear"],
+		])
+			expect(await capture(Command, argv)).toEqual({
+				stdout: '{"error":{"code":"worktree_cleanup_disabled","message":"worktree cleanup is report-only"}}\n',
+				stderr: "",
+				exitCode: 2,
+			});
+		expect(rootCalls).toBe(0);
+	});
+
+	test("resolves the root once for valid forms", async () => {
+		await withRoot(async root => {
+			for (const argv of [[], ["list", "--json"], ["clear", "--json"]]) {
+				let rootCalls = 0;
+				const Command = createWorktreeCommand(() => {
+					rootCalls++;
+					return root;
+				});
+				const result = await capture(Command, argv);
+				expect(result.exitCode).toBe(0);
+				expect(result.stderr).toBe("");
+				expect(rootCalls).toBe(1);
+			}
+		});
+	});
+
+	test("publishes help while rejecting all even on help fast paths", async () => {
+		let rootCalls = 0;
+		const Command = createWorktreeCommand(() => {
+			rootCalls++;
+			return "/must-not-be-read";
+		});
+		expect(Command.description).toBe("List report-only diagnostics for agent-managed worktrees");
+		expect(Command.delegateHelp).toBe(true);
+		expect(Command.examples).toEqual([
+			"gjc worktree",
+			"gjc worktree list --json",
+			"gjc worktree clear",
+			"gjc worktree clear --dry-run",
+		]);
+		const commands: CommandEntry[] = [{ name: "worktree", aliases: ["wt"], load: async () => Command }];
+		const help = await captureCli(commands, ["worktree", "--help"]);
+		expect(help.stdout).toContain("Unavailable: cleanup is report-only");
+		expect(help.exitCode).toBe(0);
+		expect(await captureCli(commands, ["worktree", "clear", "--all", "--help"])).toEqual({
+			stdout: "",
+			stderr: "error: worktree cleanup is report-only\n",
+			exitCode: 2,
+		});
+		expect(await captureCli(commands, ["wt", "--all", "-j", "-h"])).toEqual({
+			stdout: '{"error":{"code":"worktree_cleanup_disabled","message":"worktree cleanup is report-only"}}\n',
+			stderr: "",
+			exitCode: 2,
+		});
+		expect(await captureCli(commands, ["worktree", "--all=true", "--help"])).toEqual({
+			stdout: "",
+			stderr: "error: worktree cleanup is report-only\n",
+			exitCode: 2,
+		});
+		expect(await captureCli(commands, ["wt", "--all=false", "-j", "-h"])).toEqual({
+			stdout: '{"error":{"code":"worktree_cleanup_disabled","message":"worktree cleanup is report-only"}}\n',
+			stderr: "",
+			exitCode: 2,
+		});
+		expect(rootCalls).toBe(0);
+	});
+});


### PR DESCRIPTION
## Context

`gjc worktree clear` currently combines inspection with destructive cleanup.

The existing flow classifies managed worktree directories by reading `.git` metadata, infers whether entries are orphaned or live, and then removes directories or runs Git worktree pruning. `--all` expands that behavior to live worktrees.

That makes a classification error, stale filesystem observation, malformed metadata file, or path replacement race capable of influencing an irreversible cleanup decision.

## Decision

Keep the existing `worktree`, `worktree list`, and `worktree clear` command surface, but make it strictly report-only.

This preserves command discovery and automation compatibility while removing automatic deletion from the CLI.

## User-visible behavior

| Command | New behavior |
|---|---|
| `gjc worktree` | Lists preservation diagnostics |
| `gjc worktree list` | Same as the default command |
| `gjc worktree clear` | Scans entries, removes nothing, and reports `0 removed` |
| `gjc worktree clear --dry-run` | Reports that no entries are eligible for removal |
| `gjc worktree clear --json` | Returns `{"removed":0,"kept":N}` |
| Any `--all` form | Rejected with exit code 2 before resolving the managed root |

The rejection includes exact and assigned forms, reordered flags, the `wt` alias, JSON mode, and help fast paths such as `clear --all --help`.

Operators who need to remove a worktree must inspect it and perform the relevant Git or filesystem operation explicitly. This PR intentionally provides no automatic deletion replacement.

## Scanner trust boundary

The replacement scanner uses local filesystem marker types only:

- `.git` file or directory → preserved worktree metadata
- `merged` directory → preserved task-isolation directory
- empty or unrecognized directory → preserved diagnostic
- symlink or reparse point → unsupported and preserved

It does **not**:

- read `.git` contents
- parse or follow `gitdir` pointers
- inspect an external parent repository
- invoke Git
- delete, rename, prune, or modify files
- execute repository-controlled content

Traversal is limited to depth 2 and 1,024 entries. Root and candidate directory identities are rechecked around traversal, symlinks fail closed, and terminal control characters in displayed paths are escaped.

## Output compatibility

The command names and `wt` alias remain available, but the listing payload is now diagnostic-oriented.

`list --json` returns entries shaped as:

```json
{
  "path": "/path/to/entry",
  "kind": "pr-checkout",
  "reasonCode": "worktree-metadata",
  "message": ".git metadata observed; preserved"
}
```

Consumers of the previous `parentRepo`, `branch`, or `orphanReason` fields must migrate to the diagnostic fields. Those previous fields depended on reading and interpreting external Git metadata, which this change deliberately removes.

## Verification

- `bun test packages/coding-agent/test/worktree-cli.test.ts` — 14 passed
- `bun test scripts/ci-dev-affected.test.ts` — 61 passed
- Biome checks passed
- TypeScript LSP diagnostics are clean
- independent runtime review: `CLEAR`
- independent contract review: `CLEAR`

Coverage includes populated clear/list text and JSON forms, marker-byte preservation, exact/assigned/alias/reordered/help-path `--all` rejection, root/candidate/marker symlinks, legacy nesting, and the exact 1,024-entry boundary.

## Scope

This PR contains no workflow changes, custom CI jobs, bespoke static-analysis gates, or general worktree lifecycle redesign.