### PR TITLE
fix(agent): preserve pruned error evidence

### DIFF
--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -48,6 +48,7 @@ export interface PruneResult {
 }
 
 const DIGEST_NOTICE_TOKEN_CAP_MULTIPLIER = 1.25;
+const ERROR_DIGEST_NOTICE_MIN_CHARS = 240;
 
 function createGenericPrunedNotice(tokens: number): string {
 	return `[Output truncated - ${tokens} tokens]`;
@@ -64,6 +65,27 @@ function firstErrorLine(text: string): string | undefined {
 		.split(/\r?\n/)
 		.find(line => /error|failed|exception|panic/i.test(line))
 		?.trim();
+}
+
+function firstNonEmptyLine(text: string): string | undefined {
+	return text
+		.split(/\r?\n/)
+		.find(line => line.trim().length > 0)
+		?.trim();
+}
+
+function lastNonEmptyLine(text: string): string | undefined {
+	return text.trim().split(/\r?\n/).filter(Boolean).at(-1)?.trim();
+}
+
+function errorResultDigest(message: ToolResultMessage): string | undefined {
+	if (message.isError !== true) return undefined;
+	const text = firstTextContent(message);
+	if (text.trim().length === 0) return "error=tool result failed without text";
+	const error = firstErrorLine(text);
+	if (error) return `error=${error}`;
+	const summary = firstNonEmptyLine(text) ?? lastNonEmptyLine(text);
+	return summary ? `summary=${summary}` : undefined;
 }
 
 function truncateField(value: string, maxLength: number): string {
@@ -99,7 +121,7 @@ function resultDigest(message: ToolResultMessage): string | undefined {
 				.join("; ") || "search digest unavailable"
 		);
 	}
-	return undefined;
+	return errorResultDigest(message);
 }
 
 function createPrunedNotice(tokens: number, message?: ToolResultMessage): string {
@@ -110,7 +132,9 @@ function createPrunedNotice(tokens: number, message?: ToolResultMessage): string
 	const maxTokens = Math.max(genericTokens, Math.floor(genericTokens * DIGEST_NOTICE_TOKEN_CAP_MULTIPLIER));
 	const prefix = `[Output truncated - ${tokens} tokens; `;
 	const suffix = "]";
-	const maxChars = Math.max(0, maxTokens * 4 - prefix.length - suffix.length);
+	const digestChars = maxTokens * 4 - prefix.length - suffix.length;
+	const maxChars =
+		message?.isError === true ? Math.max(ERROR_DIGEST_NOTICE_MIN_CHARS, digestChars) : Math.max(0, digestChars);
 	return `${prefix}${truncateField(digest, maxChars)}${suffix}`;
 }
 

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -9,8 +9,9 @@
  */
 
 import type { ToolCall, ToolResultMessage } from "@gajae-code/ai";
+import { sanitizeText } from "@gajae-code/utils";
 import type { AgentMessage } from "../types";
-import { estimateEntryTokens } from "./compaction";
+import { estimateEntryTokens, estimateTextTokensHeuristic } from "./compaction";
 import type { SessionEntry, SessionMessageEntry } from "./entries";
 
 export interface PruneConfig {
@@ -78,16 +79,6 @@ function lastNonEmptyLine(text: string): string | undefined {
 	return text.trim().split(/\r?\n/).filter(Boolean).at(-1)?.trim();
 }
 
-function errorResultDigest(message: ToolResultMessage): string | undefined {
-	if (message.isError !== true) return undefined;
-	const text = firstTextContent(message);
-	if (text.trim().length === 0) return "error=tool result failed without text";
-	const error = firstErrorLine(text);
-	if (error) return `error=${error}`;
-	const summary = firstNonEmptyLine(text) ?? lastNonEmptyLine(text);
-	return summary ? `summary=${summary}` : undefined;
-}
-
 function truncateField(value: string, maxLength: number): string {
 	if (value.length <= maxLength) return value;
 	if (maxLength <= 1) return "…";
@@ -96,7 +87,7 @@ function truncateField(value: string, maxLength: number): string {
 
 function resultDigest(message: ToolResultMessage): string | undefined {
 	const toolName = message.toolName.toLowerCase();
-	const text = firstTextContent(message);
+	const text = sanitizeText(firstTextContent(message));
 	if (toolName === "bash") {
 		const details = message as { details?: { exitCode?: unknown } };
 		const exitCode =
@@ -121,7 +112,12 @@ function resultDigest(message: ToolResultMessage): string | undefined {
 				.join("; ") || "search digest unavailable"
 		);
 	}
-	return errorResultDigest(message);
+	if (message.isError !== true) return undefined;
+	if (text.trim().length === 0) return "error=tool result failed without text";
+	const error = firstErrorLine(text);
+	if (error) return `error=${error}`;
+	const summary = firstNonEmptyLine(text) ?? lastNonEmptyLine(text);
+	return summary ? `summary=${summary}` : undefined;
 }
 
 function createPrunedNotice(tokens: number, message?: ToolResultMessage): string {
@@ -146,8 +142,7 @@ function getToolResultMessage(entry: SessionEntry): ToolResultMessage | undefine
 }
 
 function estimatePrunedSavings(tokens: number, notice: string): number {
-	const noticeTokens = Math.ceil(notice.length / 4);
-	return Math.max(0, tokens - noticeTokens);
+	return tokens - estimateTextTokensHeuristic(notice);
 }
 
 export interface AssistantArgumentPruneResult {
@@ -694,11 +689,17 @@ function collectToolOutputPruneCandidates(
 		}
 
 		const notice = createPrunedNotice(tokens, message);
+		const savings = estimatePrunedSavings(tokens, notice);
+		const errorNoticeGrows = message.isError === true && notice.length > firstTextContent(message).length;
+		if (savings <= 0 || errorNoticeGrows) {
+			accumulatedTokens += tokens;
+			continue;
+		}
 		candidates.push({
 			entry: entry as SessionMessageEntry,
 			tokens,
 			notice,
-			savings: estimatePrunedSavings(tokens, notice),
+			savings,
 		});
 		accumulatedTokens += tokens;
 	}

--- a/packages/agent/test/pruning-redteam.test.ts
+++ b/packages/agent/test/pruning-redteam.test.ts
@@ -206,6 +206,26 @@ describe("pruneToolOutputs red-team boundaries", () => {
 		}
 		expect(result.prunedEntries.every(entry => textOf(entry).startsWith("[Output truncated - "))).toBe(true);
 	});
+	test("pruned error results preserve actionable evidence for non-digested tools", () => {
+		const failure = toolEntry(
+			"edit-failure",
+			"edit",
+			[
+				"Patch application failed.",
+				"Edit rejected: 2 anchors do not match the current file.",
+				textForTokens("omitted-context", 80),
+			].join("\n"),
+		);
+		(failure.message as ToolResultMessage).isError = true;
+		const newest = toolEntry("newest", "bash", "newest");
+
+		const result = pruneToolOutputs([failure, newest], config({ protectTokens: tokens(newest), minimumSavings: 0 }));
+
+		expect(result.prunedEntries).toEqual([failure]);
+		expect(textOf(failure)).toContain("error=Patch application failed.");
+		expect(textOf(failure)).toContain("[Output truncated - ");
+		expect(typeof (failure.message as ToolResultMessage).prunedAt).toBe("number");
+	});
 
 	test("adversarial inputs: empty entries, non-messages, empty content, zero thresholds, and duplicate outputs", () => {
 		expect(pruneToolOutputs([], config())).toEqual({ prunedCount: 0, tokensSaved: 0, prunedEntries: [] });

--- a/packages/agent/test/pruning-redteam.test.ts
+++ b/packages/agent/test/pruning-redteam.test.ts
@@ -226,6 +226,157 @@ describe("pruneToolOutputs red-team boundaries", () => {
 		expect(textOf(failure)).toContain("[Output truncated - ");
 		expect(typeof (failure.message as ToolResultMessage).prunedAt).toBe("number");
 	});
+	test("mixed batches mutate and count only candidates with exact positive savings", () => {
+		const shortError = toolEntry("short-error", "edit", "Patch failed.");
+		(shortError.message as ToolResultMessage).isError = true;
+		const profitable = toolEntry("profitable", "edit", textForTokens("large-success", 80));
+		const shortErrorText = textOf(shortError);
+		const profitableBefore = tokens(profitable);
+
+		const result = pruneToolOutputs([shortError, profitable], config({ minimumSavings: 0 }));
+		const profitableAfter = tokens(profitable);
+
+		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["profitable"]);
+		expect(result.prunedCount).toBe(1);
+		expect(result.tokensSaved).toBe(profitableBefore - profitableAfter);
+		expect(textOf(shortError)).toBe(shortErrorText);
+		expect((shortError.message as ToolResultMessage).prunedAt).toBeUndefined();
+	});
+	test("deterministic mixed-script matrix preserves positive-delta and exact-accounting invariants", () => {
+		const scripts = ["ascii error", "오류 실패", "error 💥"] as const;
+		const entries = Array.from({ length: 24 }, (_, index) => {
+			const repetitions = index % 4 === 0 ? 2 : 20 + index;
+			const text = Array.from({ length: repetitions }, () => scripts[index % scripts.length]).join("\n");
+			const entry = toolEntry(`matrix-${index}`, index % 3 === 0 ? "bash" : "edit", text);
+			(entry.message as ToolResultMessage).isError = index % 2 === 0;
+			return entry;
+		});
+		const before = new Map(entries.map(entry => [entry.id, { text: textOf(entry), tokens: tokens(entry) }] as const));
+
+		const result = pruneToolOutputs(entries, config({ minimumSavings: 0 }));
+		let exactSavings = 0;
+		const changedIds = new Set(result.prunedEntries.map(entry => entry.id));
+		for (const entry of entries) {
+			const snapshot = before.get(entry.id);
+			expect(snapshot).toBeDefined();
+			if (!snapshot) continue;
+			if (!changedIds.has(entry.id)) {
+				expect(textOf(entry)).toBe(snapshot.text);
+				expect((entry.message as ToolResultMessage).prunedAt).toBeUndefined();
+				continue;
+			}
+			const delta = snapshot.tokens - tokens(entry);
+			expect(delta).toBeGreaterThan(0);
+			if ((entry.message as ToolResultMessage).isError === true) {
+				expect(textOf(entry).length).toBeLessThanOrEqual(snapshot.text.length);
+			}
+			exactSavings += delta;
+		}
+		expect(result.prunedCount).toBe(changedIds.size);
+		expect(result.tokensSaved).toBe(exactSavings);
+	});
+
+	test("script-dense and character-expanding error notices remain unchanged", () => {
+		for (const [id, text] of [
+			["cjk", `오류 ${"실패".repeat(40)}`],
+			["emoji", `error ${"💥".repeat(40)}`],
+		] as const) {
+			const failure = toolEntry(id, "edit", text);
+			(failure.message as ToolResultMessage).isError = true;
+			const beforeTokens = tokens(failure);
+
+			const result = pruneToolOutputs([failure], config({ minimumSavings: 0 }));
+
+			expect(result).toEqual({ prunedCount: 0, tokensSaved: 0, prunedEntries: [] });
+			expect(textOf(failure)).toBe(text);
+			expect(tokens(failure)).toBe(beforeTokens);
+			expect((failure.message as ToolResultMessage).prunedAt).toBeUndefined();
+		}
+	});
+
+	test("sanitizes retained error evidence and preserves generic success notice", () => {
+		const failure = toolEntry(
+			"hostile-error",
+			"edit",
+			`\u001b[31mPatch failed.\u001b[0m\u0000\n${textForTokens("context", 80)}`,
+		);
+		(failure.message as ToolResultMessage).isError = true;
+		const success = toolEntry("generic-success", "edit", textForTokens("success", 80));
+		const successTokens = tokens(success);
+
+		const result = pruneToolOutputs([failure, success], config({ minimumSavings: 0 }));
+
+		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["generic-success", "hostile-error"]);
+		expect(textOf(failure)).toContain("error=Patch failed.");
+		expect(textOf(failure)).not.toContain("\u001b");
+		expect(textOf(failure)).not.toContain("\u0000");
+		expect(textOf(success)).toBe(`[Output truncated - ${successTokens} tokens]`);
+	});
+	test("preserves special bash and search digest shapes after sanitization", () => {
+		const bash = toolEntry(
+			"bash-error",
+			"bash",
+			`\u001b[31mcommand failed\u001b[0m\n${textForTokens("bash-context", 80)}\nfinal failure`,
+		);
+		(bash.message as ToolResultMessage).isError = true;
+		(bash.message as ToolResultMessage & { details: { exitCode: number } }).details = { exitCode: 17 };
+		const search = toolEntry(
+			"search-error",
+			"search",
+			`12 matches in 3 files\nerror: engine failed\n${textForTokens("search-context", 80)}`,
+		);
+		(search.message as ToolResultMessage).isError = true;
+
+		const result = pruneToolOutputs([bash, search], config({ minimumSavings: 0 }));
+
+		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["search-error", "bash-error"]);
+		expect(textOf(bash)).toContain("exit=17");
+		expect(textOf(bash)).toContain("tail=final failure");
+		expect(textOf(bash)).toContain("error=command failed");
+		expect(textOf(bash)).not.toContain("\u001b");
+		expect(textOf(search)).toContain("matches=12");
+		expect(textOf(search)).toContain("files=3");
+		expect(textOf(search)).toContain("error=error: engine failed");
+	});
+
+	test("multi-block results keep first-text evidence and exact whole-entry savings", () => {
+		const failure = toolEntry("multi-block", "edit", "placeholder");
+		failure.message = {
+			...(failure.message as ToolResultMessage),
+			isError: true,
+			content: [
+				{ type: "image", data: "a".repeat(400), mimeType: "image/png" },
+				{ type: "text", text: `Patch failed.\n${textForTokens("first-text", 40)}` },
+				{ type: "text", text: textForTokens("later-text", 80) },
+			],
+		};
+		const beforeTokens = tokens(failure);
+		const firstTextLength = (
+			(failure.message as ToolResultMessage).content as Array<{ type: string; text?: string }>
+		).find(block => block.type === "text")?.text?.length;
+
+		const result = pruneToolOutputs([failure], config({ minimumSavings: 0 }));
+
+		expect(result.prunedEntries).toEqual([failure]);
+		expect(textOf(failure)).toContain("error=Patch failed.");
+		expect(textOf(failure).length).toBeLessThanOrEqual(firstTextLength ?? 0);
+		expect(result.tokensSaved).toBe(beforeTokens - tokens(failure));
+
+		const emptyFirst = toolEntry("empty-first", "edit", "placeholder");
+		emptyFirst.message = {
+			...(emptyFirst.message as ToolResultMessage),
+			isError: true,
+			content: [
+				{ type: "text", text: "" },
+				{ type: "text", text: textForTokens("later-error", 80) },
+			],
+		};
+		const emptyFirstContent = (emptyFirst.message as ToolResultMessage).content;
+		const excluded = pruneToolOutputs([emptyFirst], config({ minimumSavings: 0 }));
+		expect(excluded).toEqual({ prunedCount: 0, tokensSaved: 0, prunedEntries: [] });
+		expect((emptyFirst.message as ToolResultMessage).content).toEqual(emptyFirstContent);
+		expect((emptyFirst.message as ToolResultMessage).prunedAt).toBeUndefined();
+	});
 
 	test("adversarial inputs: empty entries, non-messages, empty content, zero thresholds, and duplicate outputs", () => {
 		expect(pruneToolOutputs([], config())).toEqual({ prunedCount: 0, tokensSaved: 0, prunedEntries: [] });
@@ -243,9 +394,10 @@ describe("pruneToolOutputs red-team boundaries", () => {
 		];
 		const result = pruneToolOutputs(entries, config({ protectTokens: 0, minimumSavings: 0 }));
 
-		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["dup-b", "dup-a", "empty"]);
-		expect(result.prunedCount).toBe(3);
-		expect(textOf(empty)).toStartWith("[Output truncated - 0 tokens");
+		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["dup-b", "dup-a"]);
+		expect(result.prunedCount).toBe(2);
+		expect(textOf(empty)).toBe("");
+		expect((empty.message as ToolResultMessage).prunedAt).toBeUndefined();
 		expect(textOf(duplicateA)).toStartWith("[Output truncated - ");
 		expect(textOf(duplicateB)).toStartWith("[Output truncated - ");
 	});


### PR DESCRIPTION
## Summary

- preserve bounded error evidence when old `isError` tool results are pruned
- add a generic error digest for non-special-cased tools such as `edit`/`write`
- keep successful generic tool results on the existing compact `[Output truncated - N tokens]` path

Fixes #2599.

## Verification

- `bun --cwd=packages/agent run check`
- `bun test packages/agent/test/pruning-redteam.test.ts packages/agent/test/pruning-staleness-redteam.test.ts packages/agent/test/compaction-estimate-cache.test.ts`

Made with [Orca](https://github.com/stablyai/orca) 🐋
