### PR TITLE
fix(tui): preserve scrollback on completion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -183,7 +183,7 @@
       "devDependencies": {
         "@xterm/headless": "catalog:",
         "chalk": "catalog:",
-        "node-pty": "^1.0.0",
+        "node-pty": "1.2.0-beta.14",
       },
     },
     "packages/typescript-edit-benchmark": {
@@ -960,7 +960,7 @@
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
-    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+    "node-pty": ["node-pty@1.2.0-beta.14", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-XORU9BQgpxVgqr7WivjJ17mLenOHUgKKWzuZZNaw3NDYgHc/wPJQMSaoLDrpEgqV6aU1nNwil1o/OqYj6lWmUA=="],
 
     "nth-check": ["nth-check@3.0.1", "", { "dependencies": { "boolbase": "^2.0.0" } }, "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ=="],
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - The Python eval runtime now honors the documented `GJC_*` environment variables instead of silently reading only legacy `PI_*` names. `GJC_PY` (tokens `0`/`bash`, `1`/`py`, `js`, `mix`/`both`) overrides the eval backend allowance with precedence over legacy `PI_PY`/`PI_JS`; `GJC_PYTHON_SKIP_CHECK`, `GJC_PYTHON_IPC_TRACE`, and `GJC_PYTHON_INTEGRATION` are read first with `PI_*` fallback (OR semantics, so either truthy name wins). Operators following `docs/environment-variables.md` and `docs/python-repl.md` who set `GJC_PY=py` previously saw no effect — a silent docs/runtime contract break. Legacy `PI_*` names remain supported for backward compatibility.
+- Interactive completion no longer contracts the transient status slot while a user is browsing native terminal scrollback, preventing completion-time viewport repaint from jumping away from the viewed transcript rows.
 
 ### Fixed
 - Team worker launches now receive the validated owning `GJC_SESSION_ID` for sanctioned session-scoped writes while preserving absent identity, fail-closed resolution, and separate spawn provenance (#2597).

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -811,9 +811,16 @@ export class EventController {
 
 	async #handleAgentEnd(_event: Extract<AgentSessionEvent, { type: "agent_end" }>): Promise<void> {
 		if (this.ctx.loadingAnimation) {
-			this.ctx.loadingAnimation.stop();
+			const loader = this.ctx.loadingAnimation;
+			loader.stop();
 			this.ctx.loadingAnimation = undefined;
+			// Process terminals do not expose native scrollback position. Preserve
+			// the loader's actual footprint so completion cannot contract and repaint
+			// a viewport the user is browsing.
 			this.ctx.statusContainer.clear();
+			if (this.ctx.ui.terminal.isProcessTerminal) {
+				this.ctx.statusContainer.addChild(loader.createFootprint());
+			}
 		}
 		if (this.ctx.streamingComponent) {
 			this.ctx.chatContainer.removeChild(this.ctx.streamingComponent);

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -118,6 +118,8 @@ export class EventController {
 	#toolIntentCache = new Map<string, { args: unknown; intent: string | undefined }>();
 	#thinkingContentIndices = new Set<number>();
 	#handlers: AgentSessionEventHandlers;
+	#completionFootprint: Component | undefined = undefined;
+	#suspendedLoadingAnimation: Loader | undefined = undefined;
 
 	constructor(private ctx: InteractiveModeContext) {
 		this.#handlers = {
@@ -241,20 +243,29 @@ export class EventController {
 		if (this.ctx.isTranscriptViewerOpen?.()) this.ctx.refreshTranscriptViewer?.();
 	}
 
+	#clearCompletionFootprint(): void {
+		if (!this.#completionFootprint) return;
+		this.ctx.statusContainer.removeChild(this.#completionFootprint);
+		this.#completionFootprint = undefined;
+	}
+
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
 		this.#lastIntent = undefined;
 		this.#readToolCallArgs.clear();
 		this.#readToolCallAssistantComponents.clear();
 		this.#lastAssistantComponent = undefined;
+		this.#clearCompletionFootprint();
+		this.#suspendedLoadingAnimation = undefined;
 		if (this.ctx.retryEscapeHandler) {
 			this.ctx.editor.onEscape = this.ctx.retryEscapeHandler;
 			this.ctx.retryEscapeHandler = undefined;
 		}
 		if (this.ctx.retryLoader) {
-			this.ctx.retryLoader.stop();
+			const retryLoader = this.ctx.retryLoader;
+			retryLoader.stop();
 			this.#clearRetryCountdown();
 			this.ctx.retryLoader = undefined;
-			this.ctx.statusContainer.clear();
+			this.ctx.statusContainer.removeChild(retryLoader);
 		}
 		this.ctx.retryEscapePrimed = false;
 		this.#cancelIdleCompaction();
@@ -810,16 +821,19 @@ export class EventController {
 	}
 
 	async #handleAgentEnd(_event: Extract<AgentSessionEvent, { type: "agent_end" }>): Promise<void> {
-		if (this.ctx.loadingAnimation) {
-			const loader = this.ctx.loadingAnimation;
+		const loader = this.ctx.loadingAnimation ?? this.#suspendedLoadingAnimation;
+		this.ctx.loadingAnimation = undefined;
+		this.#suspendedLoadingAnimation = undefined;
+		if (loader) {
 			loader.stop();
-			this.ctx.loadingAnimation = undefined;
 			// Process terminals do not expose native scrollback position. Preserve
 			// the loader's actual footprint so completion cannot contract and repaint
 			// a viewport the user is browsing.
-			this.ctx.statusContainer.clear();
+			this.#clearCompletionFootprint();
+			this.ctx.statusContainer.removeChild(loader);
 			if (this.ctx.ui.terminal.isProcessTerminal) {
-				this.ctx.statusContainer.addChild(loader.createFootprint());
+				this.#completionFootprint = loader.createFootprint();
+				this.ctx.statusContainer.addChild(this.#completionFootprint);
 			}
 		}
 		if (this.ctx.streamingComponent) {
@@ -946,9 +960,19 @@ export class EventController {
 				this.ctx.session.abortRetry();
 			}
 		};
-		this.ctx.statusContainer.clear();
-		// Stop any prior retry loader/timer before installing a new one.
-		this.ctx.retryLoader?.stop();
+		// Hide the working loader during backoff while retaining its completion footprint.
+		const loadingAnimation = this.ctx.loadingAnimation;
+		if (loadingAnimation) {
+			loadingAnimation.stop();
+			this.ctx.statusContainer.detachChild(loadingAnimation);
+			this.#suspendedLoadingAnimation = loadingAnimation;
+			this.ctx.loadingAnimation = undefined;
+		}
+		const previousRetryLoader = this.ctx.retryLoader;
+		if (previousRetryLoader) {
+			previousRetryLoader.stop();
+			this.ctx.statusContainer.removeChild(previousRetryLoader);
+		}
 		this.#clearRetryCountdown();
 		const reason = friendlyRetryReason(event.errorMessage);
 		const attemptLabel = event.unbounded ? `attempt ${event.attempt}` : `${event.attempt}/${event.maxAttempts}`;
@@ -980,10 +1004,11 @@ export class EventController {
 			this.ctx.retryEscapeHandler = undefined;
 		}
 		if (this.ctx.retryLoader) {
-			this.ctx.retryLoader.stop();
+			const retryLoader = this.ctx.retryLoader;
+			retryLoader.stop();
 			this.#clearRetryCountdown();
 			this.ctx.retryLoader = undefined;
-			this.ctx.statusContainer.clear();
+			this.ctx.statusContainer.removeChild(retryLoader);
 		}
 		this.ctx.retryEscapePrimed = false;
 		if (!event.success) {

--- a/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
@@ -80,6 +80,13 @@ describe("EventController completion viewport", () => {
 			resizeHeight?: number;
 			nativeWindows?: boolean;
 			isProcessTerminal?: boolean;
+			initialLoaderMessage?: string;
+			noInitialLoader?: boolean;
+			initialSpinnerFrames?: string[];
+			residualStatus?: boolean;
+			expectEmptyLoader?: boolean;
+			initialRetryLoader?: boolean;
+			testActiveLoaderRetry?: boolean;
 		}> = [
 			{ label: "plain-ssh", env: { SSH_CONNECTION: "client server", TERM: "xterm-256color" } },
 			{ label: "tmux-default", env: { TMUX: "/tmp/tmux,1,0", TERM: "tmux-256color" } },
@@ -94,6 +101,40 @@ describe("EventController completion viewport", () => {
 			},
 			{ label: "native-windows-selector", env: { TERM: "xterm-256color" }, nativeWindows: true },
 			{ label: "virtual-terminal", env: { TERM: "xterm-256color" }, isProcessTerminal: false },
+			{
+				label: "empty-loader",
+				env: { TERM: "xterm-256color" },
+				initialLoaderMessage: "",
+				initialSpinnerFrames: [""],
+				expectEmptyLoader: true,
+			},
+			{ label: "loader-unrelated-status", env: { TERM: "xterm-256color" }, residualStatus: true },
+			{
+				label: "active-loader-retry-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				residualStatus: true,
+				testActiveLoaderRetry: true,
+			},
+			{
+				label: "virtual-loader-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				isProcessTerminal: false,
+				residualStatus: true,
+			},
+			{ label: "empty-status", env: { TERM: "xterm-256color" }, noInitialLoader: true },
+			{
+				label: "no-loader-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				noInitialLoader: true,
+				residualStatus: true,
+			},
+			{
+				label: "retry-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				noInitialLoader: true,
+				residualStatus: true,
+				initialRetryLoader: true,
+			},
 		];
 
 		for (const testCase of cases) {
@@ -123,14 +164,31 @@ describe("EventController completion viewport", () => {
 					});
 					const pendingMessagesContainer = new Container();
 					const statusContainer = new Container();
-					const loadingAnimation = new Loader(
-						ui,
-						value => value,
-						value => value,
-						"working",
-						["|"],
+					const loadingAnimation = testCase.noInitialLoader
+						? undefined
+						: new Loader(
+								ui,
+								value => value,
+								value => value,
+								testCase.initialLoaderMessage ?? "working",
+								testCase.initialSpinnerFrames ?? ["|"],
+							);
+					if (loadingAnimation) statusContainer.addChild(loadingAnimation);
+					const residualStatus = testCase.residualStatus ? new Text("independent status", 0, 0) : undefined;
+					if (residualStatus) statusContainer.addChild(residualStatus);
+					const retryLoader = testCase.initialRetryLoader
+						? new Loader(
+								ui,
+								value => value,
+								value => value,
+								"retrying",
+								["|"],
+							)
+						: undefined;
+					if (retryLoader) statusContainer.addChild(retryLoader);
+					const retainedStatus = [residualStatus, retryLoader].filter(
+						(component): component is Text | Loader => component !== undefined,
 					);
-					statusContainer.addChild(loadingAnimation);
 					const todoContainer = new Container();
 					const btwContainer = new Container();
 					const statusLine = new Text("status", 0, 0);
@@ -144,12 +202,12 @@ describe("EventController completion viewport", () => {
 					ui.addChild(statusLine);
 					ui.addChild(editor);
 					ui.setBottomPinnedComponent(statusLine);
-					const initialFootprint = loadingAnimation.render(term.columns).map(() => "");
+					const initialFootprint = loadingAnimation?.render(term.columns).map(() => "");
+					if (testCase.expectEmptyLoader) expect(initialFootprint).toEqual([""]);
 					let replacementLoader: Loader | undefined;
 					let ctx: InteractiveModeContext;
 					const ensureLoadingAnimation = (): void => {
 						if (ctx.loadingAnimation) return;
-						statusContainer.clear();
 						replacementLoader = new Loader(
 							ui,
 							value => value,
@@ -175,6 +233,7 @@ describe("EventController completion viewport", () => {
 						streamingMessage: startMessage,
 						loadingAnimation,
 						ensureLoadingAnimation,
+						retryLoader,
 						pendingTools: new Map(),
 						planModeController: { flushPendingModelSwitch: async () => {} },
 						updateEditorTopBorder: () => {},
@@ -182,6 +241,8 @@ describe("EventController completion viewport", () => {
 						session: {
 							isTtsrAbortPending: false,
 							retryAttempt: 0,
+							retryNow: () => {},
+							abortRetry: () => {},
 							isCompacting: true,
 							getLastAssistantMessage: () => message,
 						},
@@ -209,6 +270,29 @@ describe("EventController completion viewport", () => {
 						);
 						expect(beforeHistory.length, JSON.stringify(before)).toBeGreaterThanOrEqual(3);
 						term.clearWriteLog();
+						if (testCase.testActiveLoaderRetry) {
+							if (!loadingAnimation || !residualStatus) {
+								throw new Error("active retry case requires loading and residual status");
+							}
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 1,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const activeRetryLoader = ctx.retryLoader;
+							expect(activeRetryLoader).toBeDefined();
+							if (!activeRetryLoader) throw new Error("retry start did not install a loader");
+							expect(ctx.loadingAnimation).toBeUndefined();
+							expect(statusContainer.children).toEqual([residualStatus, activeRetryLoader]);
+
+							await controller.handleEvent({ type: "auto_retry_end", success: true, attempt: 1 });
+							await term.waitForRender();
+							expect(ctx.retryLoader).toBeUndefined();
+							expect(statusContainer.children).toEqual([residualStatus]);
+						}
 						await controller.handleEvent({ type: "message_end", message });
 						expect(getSessionMessageViewportAnchorId(message)).toBe(anchorId);
 						await term.waitForRender();
@@ -216,11 +300,15 @@ describe("EventController completion viewport", () => {
 						await controller.handleEvent({ type: "agent_end", messages: [message] });
 						await term.waitForRender();
 						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBeUndefined();
-						if (term.isProcessTerminal) {
-							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(1);
-							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual(
-								initialFootprint,
+						if (term.isProcessTerminal && initialFootprint) {
+							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(
+								residualStatus ? 2 : 1,
 							);
+							if (residualStatus) expect(statusContainer.children[0]).toBe(residualStatus);
+							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual([
+								...(residualStatus ? residualStatus.render(term.columns) : []),
+								...initialFootprint,
+							]);
 							const after = term.getViewport().map(line => line.trimEnd());
 							for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
 							const writes = term.getWriteLog().join("");
@@ -238,10 +326,56 @@ describe("EventController completion viewport", () => {
 								expect(writes).not.toMatch(new RegExp(`history-${index}(?!\\d)`));
 							}
 						} else {
-							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(0);
-							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual(
-								[],
+							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toEqual(
+								retainedStatus,
 							);
+							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual(
+								retainedStatus.flatMap(component => component.render(term.columns)),
+							);
+						}
+						if (retryLoader) {
+							if (!residualStatus) throw new Error("retry ownership case requires residual status");
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 1,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const firstRetryLoader = ctx.retryLoader;
+							expect(firstRetryLoader).toBeDefined();
+							if (!firstRetryLoader) throw new Error("retry start did not install a loader");
+							expect(statusContainer.children).toEqual([residualStatus, firstRetryLoader]);
+
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 2,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const secondRetryLoader = ctx.retryLoader;
+							expect(secondRetryLoader).toBeDefined();
+							if (!secondRetryLoader) throw new Error("repeated retry start did not replace the loader");
+							expect(secondRetryLoader).not.toBe(firstRetryLoader);
+							expect(statusContainer.children).toEqual([residualStatus, secondRetryLoader]);
+
+							await controller.handleEvent({ type: "auto_retry_end", success: true, attempt: 2 });
+							await term.waitForRender();
+							expect(ctx.retryLoader).toBeUndefined();
+							expect(statusContainer.children).toEqual([residualStatus]);
+						}
+
+						if (term.isProcessTerminal && initialFootprint) {
+							const completionChildren = [...statusContainer.children];
+							await controller.handleEvent({ type: "agent_end", messages: [message] });
+							await term.waitForRender();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} duplicate completion`,
+							).toEqual(completionChildren);
 						}
 						term.clearWriteLog();
 						await controller.handleEvent({ type: "agent_start" });
@@ -249,10 +383,44 @@ describe("EventController completion viewport", () => {
 						expect(replacementLoader, `${testCase.label} clear=${clearOnShrink}`).toBeDefined();
 						if (!replacementLoader) throw new Error("agent start did not replace the completion footprint");
 						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBe(replacementLoader);
-						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toEqual([
-							replacementLoader,
-						]);
-						replacementLoader.stop();
+						if (retryLoader) expect(ctx.retryLoader).toBeUndefined();
+						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toEqual(
+							residualStatus ? [residualStatus, replacementLoader] : [replacementLoader],
+						);
+						const rapidEnd = controller.handleEvent({ type: "agent_end", messages: [message] });
+						const rapidStart = controller.handleEvent({ type: "agent_start" });
+						await Promise.all([rapidEnd, rapidStart]);
+						await term.waitForRender();
+						expect(
+							ctx.loadingAnimation,
+							`${testCase.label} clear=${clearOnShrink} rapid lifecycle`,
+						).toBeDefined();
+						expect(
+							statusContainer.children,
+							`${testCase.label} clear=${clearOnShrink} rapid lifecycle`,
+						).toHaveLength(residualStatus ? 2 : 1);
+
+						for (let cycle = 0; cycle < 3; cycle++) {
+							await controller.handleEvent({ type: "agent_end", messages: [message] });
+							await term.waitForRender();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} completion`,
+							).toHaveLength((term.isProcessTerminal ? 1 : 0) + (residualStatus ? 1 : 0));
+
+							await controller.handleEvent({ type: "agent_start" });
+							await term.waitForRender();
+							expect(
+								ctx.loadingAnimation,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} restart`,
+							).toBeDefined();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} restart`,
+							).toHaveLength(residualStatus ? 2 : 1);
+						}
+
+						ctx.loadingAnimation?.stop();
 						term.clearWriteLog();
 						ui.requestRender();
 						await term.waitForRender();
@@ -265,5 +433,5 @@ describe("EventController completion viewport", () => {
 				}
 			}
 		}
-	});
+	}, 30_000);
 });

--- a/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@gajae-code/ai";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
@@ -12,7 +12,7 @@ import {
 	associateSessionMessageViewportAnchorId,
 	getSessionMessageViewportAnchorId,
 } from "@gajae-code/coding-agent/session/session-manager";
-import { Container, shouldUseViewportRepaintForHost, Text, TUI } from "@gajae-code/tui";
+import { Container, Loader, shouldUseViewportRepaintForHost, Text, TUI } from "@gajae-code/tui";
 import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
 
 function assistantMessage(text: string): AssistantMessage {
@@ -79,6 +79,7 @@ describe("EventController completion viewport", () => {
 			env: Partial<Record<(typeof envKeys)[number], string>>;
 			resizeHeight?: number;
 			nativeWindows?: boolean;
+			isProcessTerminal?: boolean;
 		}> = [
 			{ label: "plain-ssh", env: { SSH_CONNECTION: "client server", TERM: "xterm-256color" } },
 			{ label: "tmux-default", env: { TMUX: "/tmp/tmux,1,0", TERM: "tmux-256color" } },
@@ -92,6 +93,7 @@ describe("EventController completion viewport", () => {
 				env: { WT_SESSION: "forwarded", TERM_PROGRAM: "Windows_Terminal", TERM: "xterm-256color" },
 			},
 			{ label: "native-windows-selector", env: { TERM: "xterm-256color" }, nativeWindows: true },
+			{ label: "virtual-terminal", env: { TERM: "xterm-256color" }, isProcessTerminal: false },
 		];
 
 		for (const testCase of cases) {
@@ -105,7 +107,7 @@ describe("EventController completion viewport", () => {
 						expect(shouldUseViewportRepaintForHost({}, "win32", { includeNativeWindows: true })).toBe(true);
 					}
 
-					const term = new VirtualTerminal(40, 18, { isProcessTerminal: true });
+					const term = new VirtualTerminal(40, 18, { isProcessTerminal: testCase.isProcessTerminal ?? true });
 					const ui = new TUI(term);
 					ui.setClearOnShrink(clearOnShrink);
 					const chatContainer = new Container();
@@ -121,8 +123,14 @@ describe("EventController completion viewport", () => {
 					});
 					const pendingMessagesContainer = new Container();
 					const statusContainer = new Container();
-					statusContainer.addChild(new Text("", 0, 0));
-					statusContainer.addChild(new Text("working", 0, 0));
+					const loadingAnimation = new Loader(
+						ui,
+						value => value,
+						value => value,
+						"working",
+						["|"],
+					);
+					statusContainer.addChild(loadingAnimation);
 					const todoContainer = new Container();
 					const btwContainer = new Container();
 					const statusLine = new Text("status", 0, 0);
@@ -136,11 +144,23 @@ describe("EventController completion viewport", () => {
 					ui.addChild(statusLine);
 					ui.addChild(editor);
 					ui.setBottomPinnedComponent(statusLine);
-					const stopLoading = vi.fn();
-					const createFootprint = vi.fn(() => ({
-						render: () => ["", ""],
-					}));
-					const ctx = {
+					const initialFootprint = loadingAnimation.render(term.columns).map(() => "");
+					let replacementLoader: Loader | undefined;
+					let ctx: InteractiveModeContext;
+					const ensureLoadingAnimation = (): void => {
+						if (ctx.loadingAnimation) return;
+						statusContainer.clear();
+						replacementLoader = new Loader(
+							ui,
+							value => value,
+							value => value,
+							"working",
+							["|"],
+						);
+						ctx.loadingAnimation = replacementLoader;
+						statusContainer.addChild(replacementLoader);
+					};
+					ctx = {
 						isInitialized: true,
 						ui,
 						chatContainer,
@@ -153,7 +173,8 @@ describe("EventController completion viewport", () => {
 						getUserMessageText: (userMessage: { content: string }) => userMessage.content,
 						streamingComponent,
 						streamingMessage: startMessage,
-						loadingAnimation: { stop: stopLoading, createFootprint },
+						loadingAnimation,
+						ensureLoadingAnimation,
 						pendingTools: new Map(),
 						planModeController: { flushPendingModelSwitch: async () => {} },
 						updateEditorTopBorder: () => {},
@@ -194,26 +215,44 @@ describe("EventController completion viewport", () => {
 						term.clearWriteLog();
 						await controller.handleEvent({ type: "agent_end", messages: [message] });
 						await term.waitForRender();
-						expect(stopLoading, `${testCase.label} clear=${clearOnShrink}`).toHaveBeenCalledTimes(1);
-						expect(createFootprint, `${testCase.label} clear=${clearOnShrink}`).toHaveBeenCalledTimes(1);
 						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBeUndefined();
-						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(1);
-						const after = term.getViewport().map(line => line.trimEnd());
-						for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
-						const writes = term.getWriteLog().join("");
-						expect(writes).not.toContain("\x1b[2J\x1b[H");
-						expect(writes).not.toContain("\x1b[3J");
-						for (const entry of beforeHistory) {
-							expect(writes, `${testCase.label} clear=${clearOnShrink}`).not.toContain(entry.line);
+						if (term.isProcessTerminal) {
+							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(1);
+							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual(
+								initialFootprint,
+							);
+							const after = term.getViewport().map(line => line.trimEnd());
+							for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
+							const writes = term.getWriteLog().join("");
+							expect(writes).not.toContain("\x1b[2J\x1b[H");
+							expect(writes).not.toContain("\x1b[3J");
+							for (const entry of beforeHistory) {
+								expect(writes, `${testCase.label} clear=${clearOnShrink}`).not.toContain(entry.line);
+							}
+							const visibleHistoryNumbers = beforeHistory.flatMap(entry => {
+								const match = /history-(\d+)/.exec(entry.line);
+								return match ? [Number(match[1])] : [];
+							});
+							const firstVisibleHistory = Math.min(...visibleHistoryNumbers);
+							for (let index = 0; index < firstVisibleHistory; index++) {
+								expect(writes).not.toMatch(new RegExp(`history-${index}(?!\\d)`));
+							}
+						} else {
+							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(0);
+							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual(
+								[],
+							);
 						}
-						const visibleHistoryNumbers = beforeHistory.flatMap(entry => {
-							const match = /history-(\d+)/.exec(entry.line);
-							return match ? [Number(match[1])] : [];
-						});
-						const firstVisibleHistory = Math.min(...visibleHistoryNumbers);
-						for (let index = 0; index < firstVisibleHistory; index++) {
-							expect(writes).not.toMatch(new RegExp(`history-${index}(?!\\d)`));
-						}
+						term.clearWriteLog();
+						await controller.handleEvent({ type: "agent_start" });
+						await term.waitForRender();
+						expect(replacementLoader, `${testCase.label} clear=${clearOnShrink}`).toBeDefined();
+						if (!replacementLoader) throw new Error("agent start did not replace the completion footprint");
+						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBe(replacementLoader);
+						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toEqual([
+							replacementLoader,
+						]);
+						replacementLoader.stop();
 						term.clearWriteLog();
 						ui.requestRender();
 						await term.waitForRender();

--- a/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
@@ -121,6 +121,7 @@ describe("EventController completion viewport", () => {
 					});
 					const pendingMessagesContainer = new Container();
 					const statusContainer = new Container();
+					statusContainer.addChild(new Text("", 0, 0));
 					statusContainer.addChild(new Text("working", 0, 0));
 					const todoContainer = new Container();
 					const btwContainer = new Container();
@@ -136,6 +137,9 @@ describe("EventController completion viewport", () => {
 					ui.addChild(editor);
 					ui.setBottomPinnedComponent(statusLine);
 					const stopLoading = vi.fn();
+					const createFootprint = vi.fn(() => ({
+						render: () => ["", ""],
+					}));
 					const ctx = {
 						isInitialized: true,
 						ui,
@@ -149,7 +153,7 @@ describe("EventController completion viewport", () => {
 						getUserMessageText: (userMessage: { content: string }) => userMessage.content,
 						streamingComponent,
 						streamingMessage: startMessage,
-						loadingAnimation: { stop: stopLoading },
+						loadingAnimation: { stop: stopLoading, createFootprint },
 						pendingTools: new Map(),
 						planModeController: { flushPendingModelSwitch: async () => {} },
 						updateEditorTopBorder: () => {},
@@ -187,16 +191,21 @@ describe("EventController completion viewport", () => {
 						await controller.handleEvent({ type: "message_end", message });
 						expect(getSessionMessageViewportAnchorId(message)).toBe(anchorId);
 						await term.waitForRender();
+						term.clearWriteLog();
 						await controller.handleEvent({ type: "agent_end", messages: [message] });
 						await term.waitForRender();
 						expect(stopLoading, `${testCase.label} clear=${clearOnShrink}`).toHaveBeenCalledTimes(1);
+						expect(createFootprint, `${testCase.label} clear=${clearOnShrink}`).toHaveBeenCalledTimes(1);
 						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBeUndefined();
-						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(0);
+						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(1);
 						const after = term.getViewport().map(line => line.trimEnd());
 						for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
 						const writes = term.getWriteLog().join("");
 						expect(writes).not.toContain("\x1b[2J\x1b[H");
 						expect(writes).not.toContain("\x1b[3J");
+						for (const entry of beforeHistory) {
+							expect(writes, `${testCase.label} clear=${clearOnShrink}`).not.toContain(entry.line);
+						}
 						const visibleHistoryNumbers = beforeHistory.flatMap(entry => {
 							const match = /history-(\d+)/.exec(entry.line);
 							return match ? [Number(match[1])] : [];

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2028,7 +2028,14 @@ for (const eventType of ["session_switch", "session_branch"] as const) {
 			sessionManager: {
 				getSessionId: () => activeSessionId,
 				getSessionName: () => "SDK rotate",
-				getUsageStatistics: () => ({ input: 1, output: 2, cacheRead: 0, cacheWrite: 0, premiumRequests: 0, cost: 0 }),
+				getUsageStatistics: () => ({
+					input: 1,
+					output: 2,
+					cacheRead: 0,
+					cacheWrite: 0,
+					premiumRequests: 0,
+					cost: 0,
+				}),
 			},
 		};
 		// Fail A's owner release exactly once so the rotate-time stopSession(prevId)

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added `Loader.createFootprint()` so callers can retain a stopped loader's exact, width-dependent blank render footprint instead of coupling transient layout stability to a fixed row count.
 ## [0.11.0] - 2026-07-15
 ### Fixed
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -42,9 +42,9 @@
 		"marked": "catalog:"
 	},
 	"devDependencies": {
-		"chalk": "catalog:",
 		"@xterm/headless": "catalog:",
-		"node-pty": "^1.0.0"
+		"chalk": "catalog:",
+		"node-pty": "1.2.0-beta.14"
 	},
 	"engines": {
 		"bun": ">=1.3.14"

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -1,5 +1,5 @@
 import { type AnimationRegistration, registerAnimationCallback } from "../animation-scheduler";
-import type { TUI } from "../tui";
+import type { Component, TUI } from "../tui";
 import { sliceByColumn, visibleWidth } from "../utils";
 import { Text } from "./text";
 
@@ -43,6 +43,18 @@ export class Loader extends Text {
 			this.#frames = spinnerFrames;
 		}
 		this.start();
+	}
+
+	/**
+	 * Retains this loader's current render footprint without retaining its visible
+	 * status text. Use after stopping a loader when removing rows would repaint an
+	 * inline terminal viewport.
+	 */
+	createFootprint(): Component {
+		return {
+			render: width => this.render(width).map(() => ""),
+			invalidate: () => {},
+		};
 	}
 
 	render(width: number): string[] {

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -51,8 +51,9 @@ export class Loader extends Text {
 	 * inline terminal viewport.
 	 */
 	createFootprint(): Component {
+		const snapshot = new Text(this.getText(), 1, 0);
 		return {
-			render: width => this.render(width).map(() => ""),
+			render: width => ["", ...snapshot.render(width)].map(() => ""),
 			invalidate: () => {},
 		};
 	}

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -28,27 +28,36 @@ describe("Loader component", () => {
 		loader.stop();
 		tui.stop();
 	});
-	it("preserves its dynamic render footprint without visible status text", () => {
+	it("preserves a frozen ANSI and Unicode footprint through resize reflow", () => {
 		const term = new VirtualTerminal(40, 4);
 		const tui = new TUI(term);
 		const loader = new Loader(
 			tui,
-			text => text,
-			text => text,
-			"A long status message that wraps",
+			text => `\x1b[36m${text}\x1b[0m`,
+			text => `\x1b[35m${text}\x1b[0m`,
+			"한글🙂 e\u0301 café — wrapping status",
 			["|"],
 		);
 
 		const footprint = loader.createFootprint();
-		const expectedFootprints = new Map<number, string[]>();
-		for (const width of [4, 40]) {
-			const expected = loader.render(width).map(() => "");
-			expectedFootprints.set(width, expected);
-			expect(footprint.render(width)).toEqual(expected);
+		const expectedLineCounts = new Map([
+			[1, 30],
+			[2, 30],
+			[3, 30],
+			[4, 17],
+			[7, 10],
+			[16, 5],
+			[40, 2],
+		]);
+		for (const [width, count] of expectedLineCounts) {
+			term.resize(width, 4);
+			expect(footprint.render(term.columns)).toEqual(Array.from({ length: count }, () => ""));
 		}
+
 		loader.setMessage("A different status that would wrap differently");
-		for (const [width, expected] of expectedFootprints) {
-			expect(footprint.render(width)).toEqual(expected);
+		for (const [width, count] of expectedLineCounts) {
+			term.resize(width, 4);
+			expect(footprint.render(term.columns)).toEqual(Array.from({ length: count }, () => ""));
 		}
 
 		loader.stop();

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -40,8 +40,15 @@ describe("Loader component", () => {
 		);
 
 		const footprint = loader.createFootprint();
+		const expectedFootprints = new Map<number, string[]>();
 		for (const width of [4, 40]) {
-			expect(footprint.render(width)).toEqual(loader.render(width).map(() => ""));
+			const expected = loader.render(width).map(() => "");
+			expectedFootprints.set(width, expected);
+			expect(footprint.render(width)).toEqual(expected);
+		}
+		loader.setMessage("A different status that would wrap differently");
+		for (const [width, expected] of expectedFootprints) {
+			expect(footprint.render(width)).toEqual(expected);
 		}
 
 		loader.stop();

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -28,6 +28,25 @@ describe("Loader component", () => {
 		loader.stop();
 		tui.stop();
 	});
+	it("preserves its dynamic render footprint without visible status text", () => {
+		const term = new VirtualTerminal(40, 4);
+		const tui = new TUI(term);
+		const loader = new Loader(
+			tui,
+			text => text,
+			text => text,
+			"A long status message that wraps",
+			["|"],
+		);
+
+		const footprint = loader.createFootprint();
+		for (const width of [4, 40]) {
+			expect(footprint.render(width)).toEqual(loader.render(width).map(() => ""));
+		}
+
+		loader.stop();
+		tui.stop();
+	});
 
 	it("unrefs its animation interval so it does not keep the event loop alive", () => {
 		const term = new VirtualTerminal(20, 4);

--- a/packages/tui/test/pty/mouse-pty-driver.mjs
+++ b/packages/tui/test/pty/mouse-pty-driver.mjs
@@ -8,19 +8,24 @@ const bunBinary = process.env.BUN_BINARY;
 const testDir = path.dirname(url.fileURLToPath(import.meta.url));
 const fixture = path.join(testDir, "mouse-pty-fixture.ts");
 const baseEnv = Object.fromEntries(Object.entries(process.env).filter(([, value]) => value !== undefined));
+const MULTIPLEXER_ENV_KEYS = ["TMUX", "TMUX_PANE", "STY", "ZELLIJ", "GJC_TMUX_LAUNCHED"];
+
 
 if (!bunBinary) throw new Error("BUN_BINARY must identify the Bun executable that runs the PTY fixture.");
 if (!scenario) throw new Error("A PTY scenario is required.");
 
 
 function launchFixture(env = {}) {
+	const scenarioEnv = { ...baseEnv, TERM: "xterm-256color" };
+	for (const key of MULTIPLEXER_ENV_KEYS) delete scenarioEnv[key];
+
 	let captured = "";
 	const terminal = pty.spawn("/bin/sh", ["-c", 'exec "$1" "$2"', "pty-fixture", bunBinary, fixture], {
 		name: "xterm-256color",
 		cols: 80,
 		rows: 24,
 		cwd: process.cwd(),
-		env: { ...baseEnv, TERM: "xterm-256color", ...env },
+		env: { ...scenarioEnv, ...env },
 	});
 	terminal.onData(data => {
 		captured += data;

--- a/packages/tui/test/pty/mouse-pty-driver.mjs
+++ b/packages/tui/test/pty/mouse-pty-driver.mjs
@@ -1,0 +1,116 @@
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import * as url from "node:url";
+import * as pty from "node-pty";
+
+const scenario = process.argv[2];
+const bunBinary = process.env.BUN_BINARY;
+const testDir = path.dirname(url.fileURLToPath(import.meta.url));
+const fixture = path.join(testDir, "mouse-pty-fixture.ts");
+const baseEnv = Object.fromEntries(Object.entries(process.env).filter(([, value]) => value !== undefined));
+
+if (!bunBinary) throw new Error("BUN_BINARY must identify the Bun executable that runs the PTY fixture.");
+if (!scenario) throw new Error("A PTY scenario is required.");
+
+
+function launchFixture(env = {}) {
+	let captured = "";
+	const terminal = pty.spawn("/bin/sh", ["-c", 'exec "$1" "$2"', "pty-fixture", bunBinary, fixture], {
+		name: "xterm-256color",
+		cols: 80,
+		rows: 24,
+		cwd: process.cwd(),
+		env: { ...baseEnv, TERM: "xterm-256color", ...env },
+	});
+	terminal.onData(data => {
+		captured += data;
+	});
+	terminal.onExit(event => {
+		captured += `\nPTY_FIXTURE_EXIT:${event.exitCode}:${event.signal}\n`;
+	});
+	return { terminal, output: () => captured };
+}
+
+
+async function waitForOutput(output, marker) {
+	const deadline = Date.now() + 3_000;
+	while (!output().includes(marker)) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${JSON.stringify(marker)}; output: ${JSON.stringify(output())}`);
+		await new Promise(resolve => setTimeout(resolve, 10));
+	}
+}
+
+async function run() {
+	if (scenario === "plain-enable") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			assert.match(output(), /\x1b\[\?1000h/);
+			assert.match(output(), /\x1b\[\?1006h/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "graceful-stop") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.write("__exit__\r");
+			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
+			assert.match(output(), /\x1b\[\?1000l/);
+			assert.match(output(), /\x1b\[\?1006l/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "sigterm") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.kill("SIGTERM");
+			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
+			assert.match(output(), /\x1b\[\?1000l/);
+			assert.match(output(), /\x1b\[\?1006l/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "multiplexer") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1", TMUX: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			assert.doesNotMatch(output(), /\x1b\[\?1000h/);
+			assert.doesNotMatch(output(), /\x1b\[\?1006h/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "composer") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		const mouse = "\x1b[<0;3;4M";
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.write("composer");
+			await waitForOutput(output, 'EDITOR:"composer"');
+			terminal.write(mouse);
+			terminal.write("!");
+			await waitForOutput(output, 'EDITOR:"composer!"');
+			assert.equal(output().includes(mouse), false);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	throw new Error(`Unknown PTY scenario: ${scenario}`);
+}
+
+await run();

--- a/packages/tui/test/pty/mouse-pty-matrix.test.ts
+++ b/packages/tui/test/pty/mouse-pty-matrix.test.ts
@@ -5,10 +5,10 @@ const enabled = process.env.PI_TUI_PTY_TESTS === "1";
 const driver = path.resolve(import.meta.dir, "mouse-pty-driver.mjs");
 const nodeBinary = process.env.NODE_BINARY ?? "node";
 
-async function runScenario(scenario: string): Promise<void> {
+async function runScenario(scenario: string, environment: Record<string, string> = {}): Promise<void> {
 	const child = Bun.spawn([nodeBinary, driver, scenario], {
 		cwd: process.cwd(),
-		env: { ...process.env, BUN_BINARY: process.execPath },
+		env: { ...process.env, ...environment, BUN_BINARY: process.execPath },
 		stdout: "pipe",
 		stderr: "pipe",
 	});
@@ -27,6 +27,15 @@ async function runScenario(scenario: string): Promise<void> {
 describe.skipIf(!enabled || process.platform === "win32")("mouse PTY matrix", () => {
 	test("emits SGR mouse enable bytes in a plain xterm PTY", async () => {
 		await runScenario("plain-enable");
+	});
+	test("isolates plain scenarios from inherited multiplexer markers", async () => {
+		await runScenario("plain-enable", {
+			TMUX: "/tmp/tmux,1,0",
+			TMUX_PANE: "%42",
+			STY: "screen",
+			ZELLIJ: "zellij",
+			GJC_TMUX_LAUNCHED: "1",
+		});
 	});
 
 	test("emits SGR mouse disable bytes on graceful stop", async () => {

--- a/packages/tui/test/pty/mouse-pty-matrix.test.ts
+++ b/packages/tui/test/pty/mouse-pty-matrix.test.ts
@@ -1,148 +1,47 @@
 import { describe, expect, test } from "bun:test";
-import { resolve } from "node:path";
-import type { IPty } from "node-pty";
+import * as path from "node:path";
 
 const enabled = process.env.PI_TUI_PTY_TESTS === "1";
-const fixture = resolve(import.meta.dir, "mouse-pty-fixture.ts");
-const baseEnv = Object.fromEntries(
-	Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-);
+const driver = path.resolve(import.meta.dir, "mouse-pty-driver.mjs");
+const nodeBinary = process.env.NODE_BINARY ?? "node";
 
-type PtyModule = typeof import("node-pty");
-
-let pty: PtyModule | undefined;
-let capabilityReason = "PTY capability probe was not run.";
-
-async function probePtyCapability(): Promise<boolean> {
-	try {
-		pty = await import("node-pty");
-		const probe = pty.spawn("/bin/sh", ["-c", "exit 0"], {
-			name: "xterm-256color",
-			cols: 80,
-			rows: 24,
-			cwd: process.cwd(),
-			env: { ...baseEnv, TERM: "xterm-256color" },
-		});
-		const exited = await new Promise<boolean>(resolveProbe => {
-			const timeout = setTimeout(() => resolveProbe(false), 1_000);
-			probe.onExit(() => {
-				clearTimeout(timeout);
-				resolveProbe(true);
-			});
-		});
-		if (!exited) {
-			probe.kill();
-			capabilityReason = "node-pty capability probe timed out waiting for /bin/sh to exit.";
-			return false;
-		}
-		return true;
-	} catch (error) {
-		capabilityReason = `node-pty capability probe failed: ${error instanceof Error ? error.message : String(error)}`;
-		return false;
-	}
-}
-
-const ptyAvailable = enabled && process.platform !== "win32" ? await probePtyCapability() : false;
-
-function launchFixture(env: Record<string, string> = {}): { terminal: IPty; output: () => string } {
-	if (!pty) throw new Error(capabilityReason);
-	let captured = "";
-	const terminal = pty.spawn("/bin/sh", ["-c", 'exec "$1" "$2"', "pty-fixture", process.execPath, fixture], {
-		name: "xterm-256color",
-		cols: 80,
-		rows: 24,
+async function runScenario(scenario: string): Promise<void> {
+	const child = Bun.spawn([nodeBinary, driver, scenario], {
 		cwd: process.cwd(),
-		env: { ...baseEnv, TERM: "xterm-256color", ...env },
+		env: { ...process.env, BUN_BINARY: process.execPath },
+		stdout: "pipe",
+		stderr: "pipe",
 	});
-	terminal.onData(data => {
-		captured += data;
-	});
-	terminal.onExit(event => {
-		captured += `\nPTY_FIXTURE_EXIT:${event.exitCode}:${event.signal}\n`;
-	});
-	return { terminal, output: () => captured };
-}
-
-async function waitForOutput(output: () => string, marker: string): Promise<void> {
-	const deadline = Date.now() + 3_000;
-	while (!output().includes(marker)) {
-		if (Date.now() >= deadline)
-			throw new Error(`Timed out waiting for ${JSON.stringify(marker)}; output: ${JSON.stringify(output())}`);
-		await Bun.sleep(10);
-	}
+	const [exitCode, stdout, stderr] = await Promise.all([
+		child.exited,
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	expect(exitCode, `${stderr}\n${stdout}`).toBe(0);
 }
 
 /**
- * POSIX-only integration lane. Terminal ownership is intentionally exercised in
- * CI where node-pty can allocate a real pseudo terminal; normal unit tests do
- * not require native PTY bindings.
+ * POSIX-only integration lane. node-pty's native callbacks are driven by Node,
+ * while the fixture itself runs under Bun and exercises ProcessTerminal.
  */
 describe.skipIf(!enabled || process.platform === "win32")("mouse PTY matrix", () => {
-	test("requires a usable PTY capability when explicitly enabled", () => {
-		expect(ptyAvailable, capabilityReason).toBe(true);
-	});
 	test("emits SGR mouse enable bytes in a plain xterm PTY", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			expect(output()).toContain("\x1b[?1000h");
-			expect(output()).toContain("\x1b[?1006h");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("plain-enable");
 	});
 
 	test("emits SGR mouse disable bytes on graceful stop", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.write("__exit__\r");
-			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
-			expect(output()).toContain("\x1b[?1000l");
-			expect(output()).toContain("\x1b[?1006l");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("graceful-stop");
 	});
 
 	test("restores SGR mouse modes when SIGTERM detaches the TUI", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.kill("SIGTERM");
-			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
-			expect(output()).toContain("\x1b[?1000l");
-			expect(output()).toContain("\x1b[?1006l");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("sigterm");
 	});
 
 	test("emits no SGR mouse enable bytes under a multiplexer", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1", TMUX: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			expect(output()).not.toContain("\x1b[?1000h");
-			expect(output()).not.toContain("\x1b[?1006h");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("multiplexer");
 	});
 
 	test("does not leak SGR mouse reports into composer text", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		const mouse = "\x1b[<0;3;4M";
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.write("composer");
-			await waitForOutput(output, 'EDITOR:"composer"');
-			terminal.write(mouse);
-			terminal.write("!");
-			await waitForOutput(output, 'EDITOR:"composer!"');
-			expect(output()).toContain('EDITOR:"composer!"');
-			expect(output()).not.toContain(mouse);
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("composer");
 	});
 });


### PR DESCRIPTION
## Problem

On a native `ProcessTerminal`, the TUI cannot query the user's scrollback position. When an assistant turn finished, removing a wrapped working loader contracted the bottom status area. That contraction forces a repaint and can replace transcript rows a user is currently browsing, making the viewport appear to jump.

A fixed blank-row placeholder is not sufficient: the loader can reflow after a resize and its visible width is affected by ANSI sequences, CJK/full-width characters, emoji, and combining marks. Clearing the shared status container also disposed unrelated status components and made retry transitions depend on accidental single-child ownership.

## Implementation

- Add `Loader.createFootprint()`, which snapshots the current loader text and renders the same number of blank rows at each terminal width. The visible status text disappears while its exact reflow footprint remains.
- On process-terminal completion, replace only the owned working loader with that footprint; virtual terminals continue to remove it normally. The footprint is cleared at the next real `agent_start`.
- Replace broad `statusContainer.clear()` calls in completion/retry paths with identity-based removal, preserving independently owned status components.
- During retry backoff, suspend the working loader, render only the retry countdown, and retain the suspended loader solely to create the final completion footprint. Repeated retry starts replace only the prior retry loader and countdown.
- Make duplicate `agent_end` delivery idempotent: an already-retained footprint is not removed.
- Move native PTY behavior into a Node-driven `node-pty` scenario driver while keeping the fixture under Bun; each scenario removes inherited multiplexer markers before launch, so plain-terminal and multiplexer cases cannot contaminate one another.

## Behavior

| Lifecycle | Status area behavior |
| --- | --- |
| Working → completion in a native process terminal | Working text is replaced by an invisible, width-aware footprint; scrollback rows remain stable. |
| Working → completion in a virtual terminal | Working loader is removed normally. |
| Working → retry backoff | The working loader is hidden; only the retry countdown and unrelated statuses remain. |
| Retry end / terminal completion | Retry UI is removed without disposing unrelated statuses; completion uses the suspended loader footprint when needed. |
| Next turn | The prior completion footprint is removed before a new working loader is installed. |

No public API or configuration behavior changes.

## Coverage

- Completion viewport matrix across SSH, tmux, legacy multiplexer, Termux-height, Windows-marker, native-Windows-selector, and virtual terminal hosts.
- Empty loader, residual independent status, retry ownership/replacement, active-loader retry, repeated completion, rapid end/start, and repeated lifecycle transitions.
- Frozen loader footprint reflow at widths 1, 2, 3, 4, 7, 16, and 40 using ANSI color, Korean text, emoji, and combining characters.
- POSIX PTY scenarios for mouse-mode enable/disable, SIGTERM cleanup, multiplexer suppression, composer input filtering, and inherited multiplexer-environment isolation.

## Verification

- `bun test packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts packages/tui/test/loader.test.ts`
  - 6 passed, 0 failed.
- `bunx biome check packages/coding-agent/src/modes/controllers/event-controller.ts packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts`
  - Passed.
- `git diff --check`
  - Passed.

The opt-in native PTY lane (`PI_TUI_PTY_TESTS=1`) was not run in this session.