### PR TITLE
fix(gjc-runtime): stop handoff self-locking the active-state cache

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -1950,9 +1950,16 @@ async function handleHandoff(
 	positionalSkill: string | undefined,
 ): Promise<StateCommandResult> {
 	const selectors = await resolveSelectors(args, cwd, positionalSkill, "handoff");
-	return withWorkflowStateLock(path.relative(cwd, activeStateFile(cwd, selectors.gjcSessionId)), async () =>
-		handleHandoffUnlocked(args, cwd, positionalSkill),
-	);
+	// Serialize concurrent handoffs on a dedicated sentinel lock, NOT on the
+	// derived `skill-active-state.json` cache. The inner transaction
+	// (applyHandoffToActiveState / syncSkillActiveState -> rebuildActiveSnapshot)
+	// re-locks that cache file, and `withFileLock` is not reentrant: holding the
+	// active-state lock here made the inner rebuild self-contend and fail after
+	// all retries whenever `cwd === process.cwd()` (the real CLI case). Pass
+	// `{ cwd }` so the sentinel resolves against the handoff cwd rather than
+	// `process.cwd()`.
+	const handoffLock = path.join(sessionStateDir(cwd, selectors.gjcSessionId), "handoff");
+	return withWorkflowStateLock(handoffLock, async () => handleHandoffUnlocked(args, cwd, positionalSkill), { cwd });
 }
 
 async function handleContract(

--- a/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
@@ -461,6 +461,40 @@ describe("gjc state handoff", () => {
 		});
 	});
 
+	it("completes promptly when the handoff cwd equals process.cwd() (no self-locked active-state)", async () => {
+		await withTempCwd(async cwd => {
+			// Regression: handleHandoff must not hold the `skill-active-state.json`
+			// lock across the inner rebuild, which re-locks the same file. That
+			// self-contention only manifests when the handoff cwd is also the
+			// process cwd (the real CLI case) — otherwise the outer lock resolves
+			// against process.cwd() and lands on a different, unused path.
+			const priorCwd = process.cwd();
+			await writeJson(modeStatePath(cwd, TEST_SESSION_ID, "deep-interview"), {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+			});
+			process.chdir(cwd);
+			try {
+				const started = Date.now();
+				const result = await runNativeStateCommand(
+					["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+					cwd,
+				);
+				const elapsed = Date.now() - started;
+				expect(result.status).toBe(0);
+				// A self-locked rebuild would exhaust 50 retries (~5s) before failing.
+				expect(elapsed).toBeLessThan(3000);
+				const callee = await readJson(modeStatePath(cwd, TEST_SESSION_ID, "ralplan"));
+				expect(callee?.active).toBe(true);
+				expect(callee?.handoff_from).toBe("deep-interview");
+			} finally {
+				process.chdir(priorCwd);
+			}
+		});
+	});
+
 	it("supports backward chain ultragoal -> ralplan", async () => {
 		await withTempCwd(async cwd => {
 			await writeJson(modeStatePath(cwd, TEST_SESSION_ID, "ultragoal"), {


### PR DESCRIPTION
## Problem

Skill handoffs fail with `Failed to acquire lock for <...>/skill-active-state.json after 50 attempts` (~5s stall, non-zero status).

## Root cause

`handleHandoff` wrapped the entire transaction in `withWorkflowStateLock` on the `skill-active-state.json` file. But the inner transaction (`applyHandoffToActiveState` / `syncSkillActiveState` → `rebuildActiveSnapshot`) **re-locks that same file**. `withFileLock` is explicitly non-reentrant — a same-process re-acquire is indistinguishable from independent contention — so the inner acquire retried 50× (~5s) then threw.

This never surfaced in tests because `withWorkflowStateLock` resolves relative paths against `process.cwd()`, not the handoff `cwd`. Tests use a tmp `cwd` ≠ `process.cwd()`, so the outer lock accidentally landed on a different, unused path. In the real CLI, `cwd === process.cwd()`, so both locks resolved to the same path and self-deadlocked.

## Fix

Serialize concurrent handoffs on a dedicated sentinel lock (`<state>/handoff`) instead of the derived `skill-active-state.json` cache that inner writers need, and pass `{ cwd }` so it resolves against the handoff cwd. This makes handoff consistent with `write`/`clear`, which already lock their mode-state file rather than the active-state cache.

## Verification

- Manual repro: 5068ms / status 1 → 14ms / status 0.
- Added a regression test in `state-handoff.test.ts` that runs the handoff with `cwd === process.cwd()`; it times out at 5s without the fix and passes with it.
- All 282 tests across the handoff/runtime/ralplan/ultragoal/hooks suites pass; typecheck clean.