### PR TITLE
fix(coding-agent): refresh GJC-managed cmux titles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - The Python eval runtime now honors the documented `GJC_*` environment variables instead of silently reading only legacy `PI_*` names. `GJC_PY` (tokens `0`/`bash`, `1`/`py`, `js`, `mix`/`both`) overrides the eval backend allowance with precedence over legacy `PI_PY`/`PI_JS`; `GJC_PYTHON_SKIP_CHECK`, `GJC_PYTHON_IPC_TRACE`, and `GJC_PYTHON_INTEGRATION` are read first with `PI_*` fallback (OR semantics, so either truthy name wins). Operators following `docs/environment-variables.md` and `docs/python-repl.md` who set `GJC_PY=py` previously saw no effect — a silent docs/runtime contract break. Legacy `PI_*` names remain supported for backward compatibility.
+- cmux workspace titles already managed by GJC (identified by the `GJC: ` prefix) now update when the GJC session name changes, while unrelated user-pinned titles remain preserved.
 
 ### Fixed
 - Team worker launches now receive the validated owning `GJC_SESSION_ID` for sanctioned session-scoped writes while preserving absent identity, fail-closed resolution, and separate spawn provenance (#2597).

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -24,7 +24,7 @@ For simple local side effects that do not need a full extension, set the user-le
 gjc config set completion.notifyCommand 'cmux notify --title "$GJC_NOTIFICATION_TITLE" --body "$GJC_NOTIFICATION_BODY"'
 ```
 
-When GJC runs inside a cmux terminal (`CMUX_WORKSPACE_ID` is set), GJC best-effort renames that cmux workspace to the current GJC session name (with a `GJC: ` prefix) — but only when the workspace still has its default title, so a name you pinned (or one set by a peer session sharing the workspace) is never overwritten. Opt out with `GJC_NO_CMUX_RENAME=1`.
+When GJC runs inside a cmux terminal (`CMUX_WORKSPACE_ID` is set), GJC best-effort keeps that cmux workspace synchronized to the current GJC session name with a `GJC: ` prefix. Existing `GJC: ` titles are treated as GJC-managed and may be updated; other custom titles you pinned are preserved. Opt out with `GJC_NO_CMUX_RENAME=1`.
 
 Windows Terminal may keep BEL (`[Console]::Write([char]7)`) silent depending on profile and system sound settings even when `notifications.terminalBell` is enabled. For an audible Windows completion beep, configure a user-level PowerShell command hook instead:
 

--- a/packages/coding-agent/src/utils/cmux-workspace.ts
+++ b/packages/coding-agent/src/utils/cmux-workspace.ts
@@ -118,14 +118,15 @@ export function parseCmuxWorkspaceOwnership(jsonText: string, workspaceId: strin
  * - unknown ownership (read failed) → skip (fail safe, never clobber)
  * - already the desired title → skip (no-op)
  * - workspace still on its default title → rename
- * - any custom title (user- or peer-set) → skip
- * This makes GJC name a fresh workspace once and then leave it alone, so it
- * never overwrites a user-pinned name and multiple sessions sharing one
- * CMUX_WORKSPACE_ID do not thrash the workspace title. */
+ * - existing `GJC: ` title → rename, because GJC set it
+ * - any other custom title → skip
+ * The prefix distinguishes GJC-managed titles from user-pinned titles, allowing
+ * session renames to stay synchronized without clobbering unrelated names. */
 export function shouldRenameCmuxWorkspace(ownership: CmuxWorkspaceOwnership | null, desiredTitle: string): boolean {
 	if (!ownership) return false;
-	if ((sanitizeCmuxWorkspaceTitle(ownership.title) ?? "") === desiredTitle) return false;
-	return !ownership.hasCustomTitle;
+	const currentTitle = sanitizeCmuxWorkspaceTitle(ownership.title) ?? "";
+	if (currentTitle === desiredTitle) return false;
+	return !ownership.hasCustomTitle || currentTitle.startsWith(CMUX_WORKSPACE_TITLE_PREFIX);
 }
 
 async function defaultReadOwnership(
@@ -158,10 +159,9 @@ async function defaultReadOwnership(
 
 /**
  * Best-effort sync of the containing cmux workspace title to the current GJC
- * session name. Ownership-guarded: GJC reads the current workspace title and
- * only renames a workspace that still has its default title, so it never
- * overwrites a name the user pinned or a name a peer session (sharing the same
- * CMUX_WORKSPACE_ID) set. Opt out with GJC_NO_CMUX_RENAME.
+ * session name. Ownership-guarded: GJC updates default or `GJC: `-prefixed
+ * workspace titles while preserving other custom titles. Opt out with
+ * GJC_NO_CMUX_RENAME.
  */
 export async function syncCmuxWorkspaceTitle(
 	sessionName: string | undefined,

--- a/packages/coding-agent/test/cmux-workspace.test.ts
+++ b/packages/coding-agent/test/cmux-workspace.test.ts
@@ -85,9 +85,9 @@ describe("cmux workspace title sync", () => {
 			expect(shouldRenameCmuxWorkspace(owned({ hasCustomTitle: false }), "GJC: Desired")).toBe(true);
 		});
 
-		it("skips a user- or peer-owned custom title", () => {
+		it("preserves user-pinned titles and updates GJC-managed titles", () => {
 			expect(shouldRenameCmuxWorkspace(owned({ title: "My Pinned Name" }), "GJC: Desired")).toBe(false);
-			expect(shouldRenameCmuxWorkspace(owned({ title: "GJC: Session A" }), "GJC: Session B")).toBe(false);
+			expect(shouldRenameCmuxWorkspace(owned({ title: "GJC: Session A" }), "GJC: Session B")).toBe(true);
 		});
 	});
 
@@ -174,9 +174,7 @@ describe("cmux workspace title sync", () => {
 		expect(spawned).toBe(false);
 	});
 
-	it("does not thrash a workspace shared by multiple sessions", async () => {
-		// Two sessions share one CMUX_WORKSPACE_ID. Session A names the still-default
-		// workspace; session B then sees a custom title and must not overwrite it.
+	it("updates a GJC-managed title when the session name changes", async () => {
 		const calls: string[][] = [];
 		const spawn = (command: string[]) => {
 			calls.push(command);
@@ -198,6 +196,7 @@ describe("cmux workspace title sync", () => {
 		});
 		expect(calls).toEqual([
 			["/usr/local/bin/cmux", "workspace", "rename", "ws-shared", "--title", "GJC: Session A task"],
+			["/usr/local/bin/cmux", "workspace", "rename", "ws-shared", "--title", "GJC: Session B task"],
 		]);
 	});
 });


### PR DESCRIPTION
## Summary
- treat existing `GJC: ` cmux workspace titles as GJC-managed
- refresh the workspace title when the GJC session name changes
- preserve unrelated custom workspace titles and the existing opt-out
- update regression coverage and user-facing documentation

## QA
- `bun test packages/coding-agent/test/cmux-workspace.test.ts packages/coding-agent/test/title-generator.test.ts` (26 pass)
- `bun test --rerun-each 25 packages/coding-agent/test/cmux-workspace.test.ts` (450 pass)
- `bun --cwd=packages/coding-agent run check`
- live `cmux workspace list --json --id-format both` parser check against cmux 0.64.19-nightly
- `git diff --check origin/dev...HEAD`

## Additional full-gate result
- `bun run check:ts` reached the SDK closure manifest and then failed because every `AD-M-*` production-host case timed out waiting for its SDK state file (91 failures). The focused coding-agent check, type check, formatting, canonicalization, and all cmux/title tests pass; the timeout suite is unrelated to these four changed files.
