### PR TITLE
fix(coding-agent): safely refresh owned cmux titles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Workflow-state handoff no longer self-locks the active-state cache, so a same-turn skill handoff (e.g. ultragoal → ralplan) completes instead of stalling behind a lock the handoff itself still holds (#2638).
 - SDK host shutdown now retries a failed broker unregister instead of short-circuiting with a stale broker-index entry, while retained startup-cleanup owner-release failures remain isolated from the red extension-error path (#2625).
 - Non-TTY launches now fail fast when stdin is empty and automatically use print mode for positional prompts and `@file` inputs, preventing orphaned interactive TUI processes (#2507).
+### Fixed
+- cmux workspace titles now follow later renames by the GJC session that originally claimed the workspace, using durable session/title ownership records and cross-process serialization so peer sessions and user-pinned titles remain preserved.
 
 ## [0.11.2] - 2026-07-19
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -24,7 +24,7 @@ For simple local side effects that do not need a full extension, set the user-le
 gjc config set completion.notifyCommand 'cmux notify --title "$GJC_NOTIFICATION_TITLE" --body "$GJC_NOTIFICATION_BODY"'
 ```
 
-When GJC runs inside a cmux terminal (`CMUX_WORKSPACE_ID` is set), GJC best-effort renames that cmux workspace to the current GJC session name (with a `GJC: ` prefix) — but only when the workspace still has its default title, so a name you pinned (or one set by a peer session sharing the workspace) is never overwritten. Opt out with `GJC_NO_CMUX_RENAME=1`.
+When GJC runs inside a cmux terminal (`CMUX_WORKSPACE_ID` is set), GJC best-effort keeps that cmux workspace synchronized to the owning GJC session name with a `GJC: ` prefix. GJC records successful renames by workspace and session, serializes peer writers, and only updates a custom title when it still exactly matches that ownership record; user-pinned titles and titles owned by peer sessions are preserved. Opt out with `GJC_NO_CMUX_RENAME=1`.
 
 Windows Terminal may keep BEL (`[Console]::Write([char]7)`) silent depending on profile and system sound settings even when `notifications.terminalBell` is enabled. For an audible Windows completion beep, configure a user-level PowerShell command hook instead:
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -926,7 +926,11 @@ export class CommandController {
 		this.ctx.statusContainer.clear();
 		this.ctx.resetIrcSidebarSession();
 		this.ctx.resetObserverRegistry();
-		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+		setSessionTerminalTitle(
+			this.ctx.sessionManager.getSessionName(),
+			this.ctx.sessionManager.getCwd(),
+			this.ctx.sessionManager.getSessionId?.(),
+		);
 
 		this.ctx.statusLine.invalidate();
 		this.ctx.statusLine.setSessionStartTime(Date.now());
@@ -966,7 +970,11 @@ export class CommandController {
 			}
 		}
 		if (!(await this.ctx.session.clearContext())) return;
-		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+		setSessionTerminalTitle(
+			this.ctx.sessionManager.getSessionName(),
+			this.ctx.sessionManager.getCwd(),
+			this.ctx.sessionManager.getSessionId?.(),
+		);
 
 		this.ctx.statusLine.invalidate();
 		this.ctx.statusLine.setSessionStartTime(Date.now());
@@ -1083,7 +1091,7 @@ export class CommandController {
 				return;
 			}
 			const name = this.ctx.sessionManager.getSessionName()!;
-			setSessionTerminalTitle(name, this.ctx.sessionManager.getCwd());
+			setSessionTerminalTitle(name, this.ctx.sessionManager.getCwd(), this.ctx.sessionManager.getSessionId?.());
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorBorderColor();
 			this.ctx.showStatus(`Session renamed to "${name}".`);

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -470,7 +470,11 @@ export class ExtensionUiController {
 				}
 				this.ctx.statusContainer.clear();
 				this.ctx.resetIrcSidebarSession();
-				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+				setSessionTerminalTitle(
+					this.ctx.sessionManager.getSessionName(),
+					this.ctx.sessionManager.getCwd(),
+					this.ctx.sessionManager.getSessionId?.(),
+				);
 
 				if (options?.setup) {
 					await options.setup(this.ctx.sessionManager);
@@ -540,7 +544,11 @@ export class ExtensionUiController {
 				const switchingToDifferentSession = previousSessionId !== this.ctx.sessionManager.getSessionId();
 				if (switchingToDifferentSession) this.ctx.resetIrcSidebarSession();
 
-				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+				setSessionTerminalTitle(
+					this.ctx.sessionManager.getSessionName(),
+					this.ctx.sessionManager.getCwd(),
+					this.ctx.sessionManager.getSessionId?.(),
+				);
 				this.ctx.rebuildInitialMessages(
 					switchingToDifferentSession ? "replace-identity" : "reconcile-same-transcript",
 				);
@@ -1361,7 +1369,11 @@ export class ExtensionUiController {
 
 	async #updateSessionName(name: string): Promise<void> {
 		await this.ctx.sessionManager.setSessionName(name, "user");
-		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+		setSessionTerminalTitle(
+			this.ctx.sessionManager.getSessionName(),
+			this.ctx.sessionManager.getCwd(),
+			this.ctx.sessionManager.getSessionId?.(),
+		);
 	}
 
 	#sendExtensionUserMessage: SendUserMessageHandler = (content, options) => {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -913,6 +913,7 @@ export class InputController {
 							setSessionTerminalTitle(
 								this.ctx.sessionManager.getSessionName()!,
 								this.ctx.sessionManager.getCwd(),
+								this.ctx.sessionManager.getSessionId?.(),
 							);
 							this.ctx.updateEditorBorderColor();
 						}

--- a/packages/coding-agent/src/modes/controllers/plan-mode-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/plan-mode-controller.ts
@@ -487,7 +487,11 @@ export class PlanModeController {
 			!this.ctx.sessionManager.getSessionName() &&
 			(await this.ctx.sessionManager.setSessionName(name, "auto"))
 		) {
-			setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+			setSessionTerminalTitle(
+				this.ctx.sessionManager.getSessionName(),
+				this.ctx.sessionManager.getCwd(),
+				this.ctx.sessionManager.getSessionId?.(),
+			);
 			this.ctx.updateEditorChrome();
 		}
 		try {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -2050,9 +2050,14 @@ export class SelectorController {
 		const sessionManager = this.ctx.sessionManager as {
 			getSessionName?: () => string | undefined;
 			getCwd: () => string;
+			getSessionId?: () => string;
 			titleSource?: "auto" | "user" | undefined;
 		};
-		setSessionTerminalTitle(sessionManager.getSessionName?.(), sessionManager.getCwd());
+		setSessionTerminalTitle(
+			sessionManager.getSessionName?.(),
+			sessionManager.getCwd(),
+			sessionManager.getSessionId?.(),
+		);
 	}
 
 	async #deleteSession(sessionPath: string): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -741,7 +741,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Start the UI
 		this.ui.start();
 		pushTerminalTitle();
-		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
+		setSessionTerminalTitle(
+			this.sessionManager.getSessionName(),
+			this.sessionManager.getCwd(),
+			this.sessionManager.getSessionId?.(),
+		);
 		this.updateEditorChrome();
 		this.#syncEditorMaxHeight();
 		this.isInitialized = true;

--- a/packages/coding-agent/src/utils/cmux-workspace.ts
+++ b/packages/coding-agent/src/utils/cmux-workspace.ts
@@ -1,4 +1,9 @@
-import { logger } from "@gajae-code/utils";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { getAgentDir, logger } from "@gajae-code/utils";
+import { withFileLock } from "../config/file-lock";
 
 const CMUX_COMMAND = "cmux";
 const CMUX_WORKSPACE_ID_ENV = "CMUX_WORKSPACE_ID";
@@ -7,6 +12,7 @@ const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
 const CMUX_WORKSPACE_TITLE_PREFIX = "GJC: ";
 const CMUX_WORKSPACE_RENAME_TIMEOUT_MS = 1500;
 const CMUX_WORKSPACE_LIST_TIMEOUT_MS = 1500;
+const CMUX_WORKSPACE_STATE_SCHEMA_VERSION = 1;
 
 export interface CmuxWorkspaceRenameCommand {
 	command: string;
@@ -21,6 +27,12 @@ export interface CmuxWorkspaceOwnership {
 	title: string;
 }
 
+export interface CmuxWorkspaceManagedOwnership {
+	schemaVersion: 1;
+	sessionId: string;
+	title: string;
+}
+
 export interface CmuxWorkspaceRenameProcess {
 	exited: Promise<number>;
 	kill(): void;
@@ -30,6 +42,7 @@ export interface CmuxWorkspaceRenameProcess {
 export interface CmuxWorkspaceTitleSyncOptions {
 	env?: NodeJS.ProcessEnv;
 	isTty?: boolean;
+	stateDir?: string;
 	which?: (command: string) => string | null;
 	spawn?: (
 		command: string[],
@@ -114,18 +127,25 @@ export function parseCmuxWorkspaceOwnership(jsonText: string, workspaceId: strin
 	return null;
 }
 
-/** Only rename when GJC owns the name:
+/** Only rename when the current session has durable ownership evidence:
  * - unknown ownership (read failed) → skip (fail safe, never clobber)
  * - already the desired title → skip (no-op)
- * - workspace still on its default title → rename
- * - any custom title (user- or peer-set) → skip
- * This makes GJC name a fresh workspace once and then leave it alone, so it
- * never overwrites a user-pinned name and multiple sessions sharing one
- * CMUX_WORKSPACE_ID do not thrash the workspace title. */
-export function shouldRenameCmuxWorkspace(ownership: CmuxWorkspaceOwnership | null, desiredTitle: string): boolean {
+ * - workspace still on its default title → rename and claim it
+ * - custom title matching this session's last successful rename → rename
+ * - any other custom title → skip
+ * The durable record distinguishes the owning session from peer GJC processes
+ * and user-pinned titles; a display prefix alone is never ownership proof. */
+export function shouldRenameCmuxWorkspace(
+	ownership: CmuxWorkspaceOwnership | null,
+	desiredTitle: string,
+	managedOwnership: CmuxWorkspaceManagedOwnership | null,
+	sessionId: string,
+): boolean {
 	if (!ownership) return false;
-	if ((sanitizeCmuxWorkspaceTitle(ownership.title) ?? "") === desiredTitle) return false;
-	return !ownership.hasCustomTitle;
+	const currentTitle = sanitizeCmuxWorkspaceTitle(ownership.title) ?? "";
+	if (currentTitle === desiredTitle) return false;
+	if (!ownership.hasCustomTitle) return true;
+	return managedOwnership?.sessionId === sessionId && managedOwnership.title === currentTitle;
 }
 
 async function defaultReadOwnership(
@@ -155,16 +175,53 @@ async function defaultReadOwnership(
 		return null;
 	}
 }
+function workspaceStateFile(workspaceId: string, stateDir: string): string {
+	const key = crypto.createHash("sha256").update(workspaceId.trim().toLowerCase()).digest("hex");
+	return path.join(stateDir, `${key}.json`);
+}
+
+async function readManagedOwnership(stateFile: string): Promise<CmuxWorkspaceManagedOwnership | null> {
+	try {
+		const parsed = JSON.parse(await Bun.file(stateFile).text()) as Record<string, unknown>;
+		const sessionId = typeof parsed.session_id === "string" ? parsed.session_id.trim() : "";
+		const title = sanitizeCmuxWorkspaceTitle(typeof parsed.title === "string" ? parsed.title : undefined);
+		if (parsed.schema_version !== CMUX_WORKSPACE_STATE_SCHEMA_VERSION || !sessionId || !title) return null;
+		return { schemaVersion: 1, sessionId, title };
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT")
+			logger.debug("cmux workspace managed ownership read failed", { error: String(error) });
+		return null;
+	}
+}
+
+async function writeManagedOwnership(stateFile: string, ownership: CmuxWorkspaceManagedOwnership): Promise<void> {
+	const temporary = `${stateFile}.${process.pid}.${crypto.randomUUID()}.tmp`;
+	await Bun.write(
+		temporary,
+		`${JSON.stringify({
+			schema_version: ownership.schemaVersion,
+			session_id: ownership.sessionId,
+			title: ownership.title,
+		})}\n`,
+	);
+	await fs.chmod(temporary, 0o600);
+	try {
+		await fs.rename(temporary, stateFile);
+	} catch (error) {
+		await fs.rm(temporary, { force: true });
+		throw error;
+	}
+}
 
 /**
  * Best-effort sync of the containing cmux workspace title to the current GJC
- * session name. Ownership-guarded: GJC reads the current workspace title and
- * only renames a workspace that still has its default title, so it never
- * overwrites a name the user pinned or a name a peer session (sharing the same
- * CMUX_WORKSPACE_ID) set. Opt out with GJC_NO_CMUX_RENAME.
+ * session name. A cross-process lock and durable session/title record serialize
+ * peer GJC writers and preserve unrelated custom titles. Opt out with
+ * GJC_NO_CMUX_RENAME.
  */
 export async function syncCmuxWorkspaceTitle(
 	sessionName: string | undefined,
+	sessionId: string | undefined,
 	options: CmuxWorkspaceTitleSyncOptions = {},
 ): Promise<void> {
 	const env = options.env ?? process.env;
@@ -174,7 +231,8 @@ export async function syncCmuxWorkspaceTitle(
 	if (!isTty) return;
 
 	const workspaceId = env[CMUX_WORKSPACE_ID_ENV]?.trim();
-	if (!workspaceId) return;
+	const normalizedSessionId = sessionId?.trim();
+	if (!workspaceId || !normalizedSessionId) return;
 
 	const desired = formatCmuxWorkspaceTitle(sessionName);
 	if (!desired) return;
@@ -189,45 +247,51 @@ export async function syncCmuxWorkspaceTitle(
 	}
 	if (!resolvedCommand) return;
 
-	let ownership: CmuxWorkspaceOwnership | null;
-	try {
-		const readOwnership = options.readOwnership ?? defaultReadOwnership;
-		ownership = await readOwnership(resolvedCommand, workspaceId, env);
-	} catch (error) {
-		logger.debug("cmux workspace ownership read failed", { error: String(error) });
-		return;
-	}
-
-	if (!shouldRenameCmuxWorkspace(ownership, desired)) return;
-
-	const plan = buildCmuxWorkspaceRenameCommand(sessionName, env);
-	if (!plan) return;
-
+	const stateDir = options.stateDir ?? path.join(getAgentDir(), "state", "cmux-workspaces");
+	const stateFile = workspaceStateFile(workspaceId, stateDir);
+	const readOwnership = options.readOwnership ?? defaultReadOwnership;
 	const spawn = options.spawn ?? defaultSpawn;
+
 	try {
-		const proc = spawn([resolvedCommand, ...plan.args], {
-			env,
-			stdin: "ignore",
-			stdout: "ignore",
-			stderr: "ignore",
-		});
-		proc.unref();
-		const timer = setTimeout(() => {
-			try {
-				proc.kill();
-			} catch {}
-		}, CMUX_WORKSPACE_RENAME_TIMEOUT_MS);
-		timer.unref?.();
-		void proc.exited
-			.then(exitCode => {
-				clearTimeout(timer);
-				if (exitCode !== 0) logger.debug("cmux workspace rename exited non-zero", { exitCode });
-			})
-			.catch(error => {
-				clearTimeout(timer);
-				logger.debug("cmux workspace rename failed", { error: String(error) });
+		await fs.mkdir(stateDir, { recursive: true, mode: 0o700 });
+		await withFileLock(stateFile, async () => {
+			const ownership = await readOwnership(resolvedCommand, workspaceId, env);
+			const managedOwnership = await readManagedOwnership(stateFile);
+			if (!shouldRenameCmuxWorkspace(ownership, desired, managedOwnership, normalizedSessionId)) return;
+
+			const plan = buildCmuxWorkspaceRenameCommand(sessionName, env);
+			if (!plan) return;
+
+			const proc = spawn([resolvedCommand, ...plan.args], {
+				env,
+				stdin: "ignore",
+				stdout: "ignore",
+				stderr: "ignore",
 			});
+			proc.unref();
+			const timer = setTimeout(() => {
+				try {
+					proc.kill();
+				} catch {}
+			}, CMUX_WORKSPACE_RENAME_TIMEOUT_MS);
+			timer.unref?.();
+
+			try {
+				const exitCode = await proc.exited;
+				if (exitCode !== 0) {
+					logger.debug("cmux workspace rename exited non-zero", { exitCode });
+					return;
+				}
+				await writeManagedOwnership(stateFile, {
+					schemaVersion: 1,
+					sessionId: normalizedSessionId,
+					title: desired,
+				});
+			} finally {
+				clearTimeout(timer);
+			}
+		});
 	} catch (error) {
-		logger.debug("cmux workspace rename failed to start", { error: String(error) });
+		logger.debug("cmux workspace title sync failed", { error: String(error) });
 	}
 }

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -217,9 +217,9 @@ export function setTerminalTitle(title: string): void {
 	process.stdout.write(`\x1b]0;${sanitizeTerminalTitlePart(title) ?? DEFAULT_TERMINAL_TITLE}\x07`);
 }
 
-export function setSessionTerminalTitle(sessionName: string | undefined, cwd?: string): void {
+export function setSessionTerminalTitle(sessionName: string | undefined, cwd?: string, sessionId?: string): void {
 	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd));
-	void syncCmuxWorkspaceTitle(sessionName);
+	void syncCmuxWorkspaceTitle(sessionName, sessionId);
 }
 
 /**

--- a/packages/coding-agent/test/cmux-workspace.test.ts
+++ b/packages/coding-agent/test/cmux-workspace.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
 	buildCmuxWorkspaceRenameCommand,
+	type CmuxWorkspaceManagedOwnership,
 	type CmuxWorkspaceOwnership,
 	formatCmuxWorkspaceTitle,
 	parseCmuxWorkspaceOwnership,
@@ -22,6 +26,16 @@ const LIST_JSON = JSON.stringify({
 });
 
 describe("cmux workspace title sync", () => {
+	let stateDir: string;
+
+	beforeEach(async () => {
+		stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-cmux-workspace-test-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(stateDir, { recursive: true, force: true });
+	});
+
 	it("builds an explicit workspace rename command with the GJC prefix", () => {
 		expect(buildCmuxWorkspaceRenameCommand("Investigate Resolver", cmuxEnv())).toEqual({
 			command: "cmux",
@@ -67,50 +81,74 @@ describe("cmux workspace title sync", () => {
 	});
 
 	describe("shouldRenameCmuxWorkspace", () => {
-		const owned = (over: Partial<CmuxWorkspaceOwnership>): CmuxWorkspaceOwnership => ({
+		const current = (over: Partial<CmuxWorkspaceOwnership>): CmuxWorkspaceOwnership => ({
 			hasCustomTitle: true,
 			title: "current",
 			...over,
 		});
+		const managed = (over: Partial<CmuxWorkspaceManagedOwnership> = {}): CmuxWorkspaceManagedOwnership => ({
+			schemaVersion: 1,
+			sessionId: "session-a",
+			title: "GJC: Session A",
+			...over,
+		});
 
-		it("skips when ownership is unknown (read failed)", () => {
-			expect(shouldRenameCmuxWorkspace(null, "GJC: Desired")).toBe(false);
+		it("fails closed when cmux ownership cannot be read", () => {
+			expect(shouldRenameCmuxWorkspace(null, "GJC: Desired", managed(), "session-a")).toBe(false);
 		});
 
 		it("skips when the title already matches", () => {
-			expect(shouldRenameCmuxWorkspace(owned({ title: "GJC: Desired" }), "GJC: Desired")).toBe(false);
+			expect(
+				shouldRenameCmuxWorkspace(current({ title: "GJC: Desired" }), "GJC: Desired", managed(), "session-a"),
+			).toBe(false);
 		});
 
-		it("renames when the workspace still has the default title", () => {
-			expect(shouldRenameCmuxWorkspace(owned({ hasCustomTitle: false }), "GJC: Desired")).toBe(true);
+		it("allows a default workspace to be claimed", () => {
+			expect(
+				shouldRenameCmuxWorkspace(
+					current({ hasCustomTitle: false, title: "~/dev/x" }),
+					"GJC: Desired",
+					null,
+					"session-a",
+				),
+			).toBe(true);
 		});
 
-		it("skips a user- or peer-owned custom title", () => {
-			expect(shouldRenameCmuxWorkspace(owned({ title: "My Pinned Name" }), "GJC: Desired")).toBe(false);
-			expect(shouldRenameCmuxWorkspace(owned({ title: "GJC: Session A" }), "GJC: Session B")).toBe(false);
+		it("requires matching durable session and title evidence for a custom title", () => {
+			const ownership = current({ title: "GJC: Session A" });
+			expect(shouldRenameCmuxWorkspace(ownership, "GJC: Desired", null, "session-a")).toBe(false);
+			expect(shouldRenameCmuxWorkspace(ownership, "GJC: Desired", managed(), "session-b")).toBe(false);
+			expect(
+				shouldRenameCmuxWorkspace(ownership, "GJC: Desired", managed({ title: "GJC: Stale title" }), "session-a"),
+			).toBe(false);
+			expect(shouldRenameCmuxWorkspace(ownership, "GJC: Desired", managed(), "session-a")).toBe(true);
 		});
 	});
 
-	it("does not spawn outside a tty", async () => {
+	it("does not spawn outside a tty or without a session identity", async () => {
 		let spawned = false;
-		await syncCmuxWorkspaceTitle("Investigate Resolver", {
+		const options = {
 			env: cmuxEnv(),
 			isTty: false,
+			stateDir,
 			which: () => "/usr/local/bin/cmux",
 			readOwnership: async () => ({ hasCustomTitle: false, title: "default" }),
 			spawn: () => {
 				spawned = true;
 				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
 			},
-		});
+		};
+		await syncCmuxWorkspaceTitle("Investigate Resolver", "session-a", options);
+		await syncCmuxWorkspaceTitle("Investigate Resolver", undefined, { ...options, isTty: true });
 		expect(spawned).toBe(false);
 	});
 
 	it("does not spawn when GJC_NO_CMUX_RENAME is set", async () => {
 		let spawned = false;
-		await syncCmuxWorkspaceTitle("Investigate Resolver", {
+		await syncCmuxWorkspaceTitle("Investigate Resolver", "session-a", {
 			env: cmuxEnv("ws-optout", { GJC_NO_CMUX_RENAME: "1" }),
 			isTty: true,
+			stateDir,
 			which: () => "/usr/local/bin/cmux",
 			readOwnership: async () => ({ hasCustomTitle: false, title: "default" }),
 			spawn: () => {
@@ -121,36 +159,42 @@ describe("cmux workspace title sync", () => {
 		expect(spawned).toBe(false);
 	});
 
-	it("renames a default-titled workspace inside a tty cmux workspace", async () => {
-		const unref = vi.fn(() => {});
-		const kill = vi.fn(() => {});
+	it("claims a default workspace and lets only that session update it", async () => {
 		const calls: string[][] = [];
-
-		await syncCmuxWorkspaceTitle("Investigate Resolver", {
-			env: cmuxEnv("ws-default"),
+		let title = "~/dev/x";
+		let hasCustomTitle = false;
+		const options = {
+			env: cmuxEnv("ws-owned"),
 			isTty: true,
-			which: command => (command === "cmux" ? "/usr/local/bin/cmux" : null),
-			readOwnership: async () => ({ hasCustomTitle: false, title: "~/dev/x" }),
-			spawn: command => {
+			stateDir,
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => ({ hasCustomTitle, title }),
+			spawn: (command: string[]) => {
 				calls.push(command);
-				return { exited: Promise.resolve(0), kill, unref };
+				title = command.at(-1) ?? "";
+				hasCustomTitle = true;
+				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
 			},
-		});
+		};
+
+		await syncCmuxWorkspaceTitle("Session A task", "session-a", options);
+		await syncCmuxWorkspaceTitle("Renamed A task", "session-a", options);
+		await syncCmuxWorkspaceTitle("Session B task", "session-b", options);
 
 		expect(calls).toEqual([
-			["/usr/local/bin/cmux", "workspace", "rename", "ws-default", "--title", "GJC: Investigate Resolver"],
+			["/usr/local/bin/cmux", "workspace", "rename", "ws-owned", "--title", "GJC: Session A task"],
+			["/usr/local/bin/cmux", "workspace", "rename", "ws-owned", "--title", "GJC: Renamed A task"],
 		]);
-		expect(unref).toHaveBeenCalledTimes(1);
-		expect(kill).not.toHaveBeenCalled();
 	});
 
-	it("does not clobber a user-pinned workspace title", async () => {
+	it("preserves user-pinned titles even when they begin with the public GJC prefix", async () => {
 		let spawned = false;
-		await syncCmuxWorkspaceTitle("Investigate Resolver", {
+		await syncCmuxWorkspaceTitle("Investigate Resolver", "session-a", {
 			env: cmuxEnv("ws-userpinned"),
 			isTty: true,
+			stateDir,
 			which: () => "/usr/local/bin/cmux",
-			readOwnership: async () => ({ hasCustomTitle: true, title: "My Pinned Name" }),
+			readOwnership: async () => ({ hasCustomTitle: true, title: "GJC: My Pinned Name" }),
 			spawn: () => {
 				spawned = true;
 				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
@@ -159,45 +203,55 @@ describe("cmux workspace title sync", () => {
 		expect(spawned).toBe(false);
 	});
 
-	it("skips renaming when ownership cannot be read", async () => {
-		let spawned = false;
-		await syncCmuxWorkspaceTitle("Investigate Resolver", {
-			env: cmuxEnv("ws-unreadable"),
-			isTty: true,
-			which: () => "/usr/local/bin/cmux",
-			readOwnership: async () => null,
-			spawn: () => {
-				spawned = true;
-				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
-			},
-		});
-		expect(spawned).toBe(false);
-	});
-
-	it("does not thrash a workspace shared by multiple sessions", async () => {
-		// Two sessions share one CMUX_WORKSPACE_ID. Session A names the still-default
-		// workspace; session B then sees a custom title and must not overwrite it.
+	it("does not claim ownership when the rename command fails", async () => {
+		let title = "~/dev/x";
+		let hasCustomTitle = false;
+		let exitCode = 1;
 		const calls: string[][] = [];
-		const spawn = (command: string[]) => {
-			calls.push(command);
-			return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+		const options = {
+			env: cmuxEnv("ws-failed"),
+			isTty: true,
+			stateDir,
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => ({ hasCustomTitle, title }),
+			spawn: (command: string[]) => {
+				calls.push(command);
+				return { exited: Promise.resolve(exitCode), kill: () => {}, unref: () => {} };
+			},
 		};
-		await syncCmuxWorkspaceTitle("Session A task", {
-			env: cmuxEnv("ws-shared"),
+
+		await syncCmuxWorkspaceTitle("First attempt", "session-a", options);
+		title = "GJC: First attempt";
+		hasCustomTitle = true;
+		exitCode = 0;
+		await syncCmuxWorkspaceTitle("Second attempt", "session-a", options);
+
+		expect(calls).toHaveLength(1);
+	});
+
+	it("serializes peer sessions so only the first claimant renames a default workspace", async () => {
+		const calls: string[][] = [];
+		let title = "~/dev/x";
+		let hasCustomTitle = false;
+		const options = {
+			env: cmuxEnv("ws-concurrent"),
 			isTty: true,
+			stateDir,
 			which: () => "/usr/local/bin/cmux",
-			readOwnership: async () => ({ hasCustomTitle: false, title: "~/dev/x" }),
-			spawn,
-		});
-		await syncCmuxWorkspaceTitle("Session B task", {
-			env: cmuxEnv("ws-shared"),
-			isTty: true,
-			which: () => "/usr/local/bin/cmux",
-			readOwnership: async () => ({ hasCustomTitle: true, title: "GJC: Session A task" }),
-			spawn,
-		});
-		expect(calls).toEqual([
-			["/usr/local/bin/cmux", "workspace", "rename", "ws-shared", "--title", "GJC: Session A task"],
+			readOwnership: async () => ({ hasCustomTitle, title }),
+			spawn: (command: string[]) => {
+				calls.push(command);
+				title = command.at(-1) ?? "";
+				hasCustomTitle = true;
+				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+			},
+		};
+
+		await Promise.all([
+			syncCmuxWorkspaceTitle("Session A", "session-a", options),
+			syncCmuxWorkspaceTitle("Session B", "session-b", options),
 		]);
+
+		expect(calls).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
## Summary
- persist successful cmux workspace claims by hashed workspace ID, GJC session ID, and exact title
- serialize read/compare/rename/write through the existing cross-process file lock
- allow only the recorded owning session to refresh a custom title that still exactly matches its last successful rename
- preserve peer-owned titles, user-pinned titles (including `GJC: ` prefixes), unreadable state, and failed rename attempts
- pass the current session identity through every terminal-title lifecycle path

## Review follow-up
This supersedes closed PR #2641 and addresses its blocking review. The public `GJC: ` prefix is no longer treated as ownership proof. Peer processes are serialized, ownership is written only after a successful cmux rename, and custom-title updates require both matching durable session identity and exact prior-title evidence.

## QA
- `bun test packages/coding-agent/test/cmux-workspace.test.ts packages/coding-agent/test/title-generator.test.ts packages/coding-agent/test/modes/controllers/issue-2261-new-session-fail-closed.test.ts` (31 pass)
- `bun test --rerun-each 25 packages/coding-agent/test/cmux-workspace.test.ts` (450 pass)
- `bun --cwd=packages/coding-agent run check` (Biome + type check)
- live `cmux workspace list --json --id-format both` parser check against cmux 0.64.19-nightly
- `git diff --check origin/dev...HEAD`

## Broader test note
`bun --cwd=packages/coding-agent test` exercised 12,092 tests. It reported 11,621 pass, 360 skip, and unrelated existing SDK/MCP/filesystem failures in this local environment. It also exposed two incomplete CommandController mocks lacking `getSessionId`; the title sync callsites now fail closed with optional session-ID access, and the exact failing regression file passes in the focused QA above.
