### PR TITLE
fix(coding-agent): safely refresh owned cmux titles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Workflow-state handoff no longer self-locks the active-state cache, so a same-turn skill handoff (e.g. ultragoal → ralplan) completes instead of stalling behind a lock the handoff itself still holds (#2638).
 - SDK host shutdown now retries a failed broker unregister instead of short-circuiting with a stale broker-index entry, while retained startup-cleanup owner-release failures remain isolated from the red extension-error path (#2625).
+- cmux workspace titles now follow later session renames within the GJC process that claimed the default-titled workspace. Claims are memory-only, successful renames are read back, peer claim attempts are cross-process serialized, and user/peer title changes revoke ownership.
 - Non-TTY launches now fail fast when stdin is empty and automatically use print mode for positional prompts and `@file` inputs, preventing orphaned interactive TUI processes (#2507).
 
 ## [0.11.2] - 2026-07-19

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -24,7 +24,7 @@ For simple local side effects that do not need a full extension, set the user-le
 gjc config set completion.notifyCommand 'cmux notify --title "$GJC_NOTIFICATION_TITLE" --body "$GJC_NOTIFICATION_BODY"'
 ```
 
-When GJC runs inside a cmux terminal (`CMUX_WORKSPACE_ID` is set), GJC best-effort renames that cmux workspace to the current GJC session name (with a `GJC: ` prefix) — but only when the workspace still has its default title, so a name you pinned (or one set by a peer session sharing the workspace) is never overwritten. Opt out with `GJC_NO_CMUX_RENAME=1`.
+When GJC runs inside a cmux terminal (`CMUX_WORKSPACE_ID` is set), it best-effort names a default-titled workspace after the current GJC session with a `GJC: ` prefix. While that GJC process remains active, later session renames update the workspace only if its title still exactly matches GJC's last verified rename. User or peer changes revoke the claim, and a restarted GJC process does not reclaim a custom title. Opt out with `GJC_NO_CMUX_RENAME=1`.
 
 Windows Terminal may keep BEL (`[Console]::Write([char]7)`) silent depending on profile and system sound settings even when `notifications.terminalBell` is enabled. For an audible Windows completion beep, configure a user-level PowerShell command hook instead:
 

--- a/packages/coding-agent/src/utils/cmux-workspace.ts
+++ b/packages/coding-agent/src/utils/cmux-workspace.ts
@@ -1,4 +1,9 @@
-import { logger } from "@gajae-code/utils";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { getAgentDir, logger } from "@gajae-code/utils";
+import { withFileLock } from "../config/file-lock";
 
 const CMUX_COMMAND = "cmux";
 const CMUX_WORKSPACE_ID_ENV = "CMUX_WORKSPACE_ID";
@@ -7,6 +12,10 @@ const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
 const CMUX_WORKSPACE_TITLE_PREFIX = "GJC: ";
 const CMUX_WORKSPACE_RENAME_TIMEOUT_MS = 1500;
 const CMUX_WORKSPACE_LIST_TIMEOUT_MS = 1500;
+const CMUX_WORKSPACE_LOCK_DIR_MODE = 0o700;
+const CMUX_WORKSPACE_LOCK_FILE_MODE_MASK = 0o077;
+const processClaims = new Map<string, string>();
+const MAX_PROCESS_CLAIMS = 32;
 
 export interface CmuxWorkspaceRenameCommand {
 	command: string;
@@ -23,13 +32,15 @@ export interface CmuxWorkspaceOwnership {
 
 export interface CmuxWorkspaceRenameProcess {
 	exited: Promise<number>;
-	kill(): void;
+	kill(signal?: number | NodeJS.Signals): void;
 	unref(): void;
 }
 
 export interface CmuxWorkspaceTitleSyncOptions {
 	env?: NodeJS.ProcessEnv;
 	isTty?: boolean;
+	lockDir?: string;
+	claims?: Map<string, string>;
 	which?: (command: string) => string | null;
 	spawn?: (
 		command: string[],
@@ -48,6 +59,25 @@ function defaultSpawn(
 	options: { env: NodeJS.ProcessEnv; stdin: "ignore"; stdout: "ignore"; stderr: "ignore" },
 ): CmuxWorkspaceRenameProcess {
 	return Bun.spawn(command, options);
+}
+async function withProcessDeadline<T>(
+	proc: Pick<CmuxWorkspaceRenameProcess, "kill">,
+	operation: Promise<T>,
+	timeoutMs: number,
+): Promise<{ timedOut: false; value: T } | { timedOut: true }> {
+	const timeout = Promise.withResolvers<{ timedOut: true }>();
+	const timer = setTimeout(() => {
+		try {
+			proc.kill("SIGKILL");
+		} catch {}
+		timeout.resolve({ timedOut: true });
+	}, timeoutMs);
+	timer.unref?.();
+	try {
+		return await Promise.race([operation.then(value => ({ timedOut: false as const, value })), timeout.promise]);
+	} finally {
+		clearTimeout(timer);
+	}
 }
 
 function isEnvSet(value: string | undefined): boolean {
@@ -114,17 +144,19 @@ export function parseCmuxWorkspaceOwnership(jsonText: string, workspaceId: strin
 	return null;
 }
 
-/** Only rename when GJC owns the name:
- * - unknown ownership (read failed) → skip (fail safe, never clobber)
- * - already the desired title → skip (no-op)
- * - workspace still on its default title → rename
- * - any custom title (user- or peer-set) → skip
- * This makes GJC name a fresh workspace once and then leave it alone, so it
- * never overwrites a user-pinned name and multiple sessions sharing one
- * CMUX_WORKSPACE_ID do not thrash the workspace title. */
-export function shouldRenameCmuxWorkspace(ownership: CmuxWorkspaceOwnership | null, desiredTitle: string): boolean {
+/** Decide whether this process may rename the workspace.
+ * A default-titled workspace may be claimed. Once claimed, updates require the
+ * current title to exactly match the last title this process verified after a
+ * successful rename. A prefix is never ownership evidence. */
+export function shouldRenameCmuxWorkspace(
+	ownership: CmuxWorkspaceOwnership | null,
+	desiredTitle: string,
+	lastVerifiedTitle?: string,
+): boolean {
 	if (!ownership) return false;
-	if ((sanitizeCmuxWorkspaceTitle(ownership.title) ?? "") === desiredTitle) return false;
+	const currentTitle = ownership.title;
+	if (currentTitle === desiredTitle) return false;
+	if (lastVerifiedTitle !== undefined) return ownership.hasCustomTitle && currentTitle === lastVerifiedTitle;
 	return !ownership.hasCustomTitle;
 }
 
@@ -140,28 +172,118 @@ async function defaultReadOwnership(
 			stdout: "pipe",
 			stderr: "ignore",
 		});
-		const timer = setTimeout(() => {
-			try {
-				proc.kill();
-			} catch {}
-		}, CMUX_WORKSPACE_LIST_TIMEOUT_MS);
-		timer.unref?.();
-		const text = await new Response(proc.stdout).text();
-		await proc.exited;
-		clearTimeout(timer);
-		return parseCmuxWorkspaceOwnership(text, workspaceId);
+		const completed = await withProcessDeadline(
+			proc,
+			(async () => {
+				const text = await new Response(proc.stdout).text();
+				const exitCode = await proc.exited;
+				return { exitCode, text };
+			})(),
+			CMUX_WORKSPACE_LIST_TIMEOUT_MS,
+		);
+		if (completed.timedOut) {
+			logger.debug("cmux workspace list timed out");
+			return null;
+		}
+		if (completed.value.exitCode !== 0) {
+			logger.debug("cmux workspace list exited non-zero", { exitCode: completed.value.exitCode });
+			return null;
+		}
+		return parseCmuxWorkspaceOwnership(completed.value.text, workspaceId);
 	} catch (error) {
 		logger.debug("cmux workspace list failed", { error: String(error) });
 		return null;
 	}
 }
+function claimKey(workspaceId: string, env: NodeJS.ProcessEnv): string {
+	const socket = env.CMUX_SOCKET_PATH?.trim() || env.CMUX_SOCKET?.trim() || "default";
+	return `${socket}\u0000${workspaceId.trim().toLowerCase()}`;
+}
+
+function workspaceLockFile(lockDir: string, key: string): string {
+	return path.join(lockDir, `${crypto.createHash("sha256").update(key).digest("hex")}.guard`);
+}
+function rememberClaim(claims: Map<string, string>, key: string, title: string): void {
+	claims.delete(key);
+	claims.set(key, title);
+	while (claims.size > MAX_PROCESS_CLAIMS) {
+		const oldest = claims.keys().next().value;
+		if (oldest === undefined) return;
+		claims.delete(oldest);
+	}
+}
+
+async function assertOwnedCanonicalDirectory(directory: string, privateMode: boolean): Promise<string> {
+	const resolved = path.resolve(directory);
+	const [stat, canonical] = await Promise.all([fs.lstat(resolved), fs.realpath(resolved)]);
+	if (!stat.isDirectory() || stat.isSymbolicLink() || canonical !== resolved)
+		throw new Error("cmux workspace lock path is not a canonical directory");
+	if (typeof process.getuid === "function" && stat.uid !== process.getuid())
+		throw new Error("cmux workspace lock path is not owned by the current user");
+	if (privateMode && (stat.mode & CMUX_WORKSPACE_LOCK_FILE_MODE_MASK) !== 0)
+		await fs.chmod(resolved, CMUX_WORKSPACE_LOCK_DIR_MODE);
+	return resolved;
+}
+
+async function ensureOwnedChildDirectory(parent: string, name: string, privateMode: boolean): Promise<string> {
+	const canonicalParent = await assertOwnedCanonicalDirectory(parent, false);
+	const child = path.join(canonicalParent, name);
+	try {
+		await fs.mkdir(child, { mode: privateMode ? CMUX_WORKSPACE_LOCK_DIR_MODE : 0o700 });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+	}
+	return assertOwnedCanonicalDirectory(child, privateMode);
+}
+
+async function ensurePrivateLockDir(configuredLockDir?: string): Promise<string> {
+	if (configuredLockDir) {
+		const resolved = path.resolve(configuredLockDir);
+		return ensureOwnedChildDirectory(path.dirname(resolved), path.basename(resolved), true);
+	}
+	const agentDir = await assertOwnedCanonicalDirectory(await fs.realpath(getAgentDir()), false);
+	const stateDir = await ensureOwnedChildDirectory(agentDir, "state", false);
+	return ensureOwnedChildDirectory(stateDir, "cmux-workspace-locks", true);
+}
+
+async function renameAndVerify(
+	resolvedCommand: string,
+	workspaceId: string,
+	sessionName: string | undefined,
+	desired: string,
+	env: NodeJS.ProcessEnv,
+	readOwnership: NonNullable<CmuxWorkspaceTitleSyncOptions["readOwnership"]>,
+	spawn: NonNullable<CmuxWorkspaceTitleSyncOptions["spawn"]>,
+): Promise<boolean> {
+	const plan = buildCmuxWorkspaceRenameCommand(sessionName, env);
+	if (!plan) return false;
+
+	const proc = spawn([resolvedCommand, ...plan.args], {
+		env,
+		stdin: "ignore",
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+	proc.unref();
+	const completed = await withProcessDeadline(proc, proc.exited, CMUX_WORKSPACE_RENAME_TIMEOUT_MS);
+	if (completed.timedOut) {
+		logger.debug("cmux workspace rename timed out");
+		return false;
+	}
+	if (completed.value !== 0) {
+		logger.debug("cmux workspace rename exited non-zero", { exitCode: completed.value });
+		return false;
+	}
+	const verified = await readOwnership(resolvedCommand, workspaceId, env);
+	return verified?.hasCustomTitle === true && verified.title === desired;
+}
 
 /**
  * Best-effort sync of the containing cmux workspace title to the current GJC
- * session name. Ownership-guarded: GJC reads the current workspace title and
- * only renames a workspace that still has its default title, so it never
- * overwrites a name the user pinned or a name a peer session (sharing the same
- * CMUX_WORKSPACE_ID) set. Opt out with GJC_NO_CMUX_RENAME.
+ * process. Claims are process-lifetime only: a successful rename is read back,
+ * and subsequent updates require the exact last verified title. A guarded
+ * cross-process claim prevents peer GJC processes from simultaneously claiming
+ * a fresh workspace. User or peer changes revoke this process's claim.
  */
 export async function syncCmuxWorkspaceTitle(
 	sessionName: string | undefined,
@@ -189,45 +311,28 @@ export async function syncCmuxWorkspaceTitle(
 	}
 	if (!resolvedCommand) return;
 
-	let ownership: CmuxWorkspaceOwnership | null;
-	try {
-		const readOwnership = options.readOwnership ?? defaultReadOwnership;
-		ownership = await readOwnership(resolvedCommand, workspaceId, env);
-	} catch (error) {
-		logger.debug("cmux workspace ownership read failed", { error: String(error) });
-		return;
-	}
-
-	if (!shouldRenameCmuxWorkspace(ownership, desired)) return;
-
-	const plan = buildCmuxWorkspaceRenameCommand(sessionName, env);
-	if (!plan) return;
-
+	const key = claimKey(workspaceId, env);
+	const claims = options.claims ?? processClaims;
+	const readOwnership = options.readOwnership ?? defaultReadOwnership;
 	const spawn = options.spawn ?? defaultSpawn;
+	const configuredLockDir = options.lockDir;
+
 	try {
-		const proc = spawn([resolvedCommand, ...plan.args], {
-			env,
-			stdin: "ignore",
-			stdout: "ignore",
-			stderr: "ignore",
+		const lockDir = await ensurePrivateLockDir(configuredLockDir);
+		await withFileLock(workspaceLockFile(lockDir, key), async () => {
+			const ownership = await readOwnership(resolvedCommand, workspaceId, env);
+			const lastVerifiedTitle = claims.get(key);
+			if (lastVerifiedTitle !== undefined && ownership?.title !== lastVerifiedTitle) {
+				claims.delete(key);
+				return;
+			}
+			if (!shouldRenameCmuxWorkspace(ownership, desired, lastVerifiedTitle)) return;
+
+			if (await renameAndVerify(resolvedCommand, workspaceId, sessionName, desired, env, readOwnership, spawn))
+				rememberClaim(claims, key, desired);
+			else claims.delete(key);
 		});
-		proc.unref();
-		const timer = setTimeout(() => {
-			try {
-				proc.kill();
-			} catch {}
-		}, CMUX_WORKSPACE_RENAME_TIMEOUT_MS);
-		timer.unref?.();
-		void proc.exited
-			.then(exitCode => {
-				clearTimeout(timer);
-				if (exitCode !== 0) logger.debug("cmux workspace rename exited non-zero", { exitCode });
-			})
-			.catch(error => {
-				clearTimeout(timer);
-				logger.debug("cmux workspace rename failed", { error: String(error) });
-			});
 	} catch (error) {
-		logger.debug("cmux workspace rename failed to start", { error: String(error) });
+		logger.debug("cmux workspace title sync failed", { error: String(error) });
 	}
 }

--- a/packages/coding-agent/test/cmux-workspace.test.ts
+++ b/packages/coding-agent/test/cmux-workspace.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
 	buildCmuxWorkspaceRenameCommand,
 	type CmuxWorkspaceOwnership,
@@ -10,7 +14,7 @@ import {
 } from "../src/utils/cmux-workspace";
 
 function cmuxEnv(workspaceId = "workspace-123", extra: Record<string, string> = {}): NodeJS.ProcessEnv {
-	return { CMUX_WORKSPACE_ID: workspaceId, ...extra } as NodeJS.ProcessEnv;
+	return { CMUX_WORKSPACE_ID: workspaceId, CMUX_SOCKET_PATH: "/tmp/cmux-test.sock", ...extra } as NodeJS.ProcessEnv;
 }
 
 const LIST_JSON = JSON.stringify({
@@ -22,6 +26,18 @@ const LIST_JSON = JSON.stringify({
 });
 
 describe("cmux workspace title sync", () => {
+	let root: string;
+	let lockDir: string;
+
+	beforeEach(async () => {
+		root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "gjc-cmux-workspace-test-")));
+		lockDir = path.join(root, "locks");
+	});
+
+	afterEach(async () => {
+		await fs.rm(root, { recursive: true, force: true });
+	});
+
 	it("builds an explicit workspace rename command with the GJC prefix", () => {
 		expect(buildCmuxWorkspaceRenameCommand("Investigate Resolver", cmuxEnv())).toEqual({
 			command: "cmux",
@@ -57,147 +73,354 @@ describe("cmux workspace title sync", () => {
 			});
 		});
 
-		it("returns null when the workspace is not present", () => {
+		it("returns null for missing or malformed data", () => {
 			expect(parseCmuxWorkspaceOwnership(LIST_JSON, "missing")).toBeNull();
-		});
-
-		it("returns null on unparseable output", () => {
 			expect(parseCmuxWorkspaceOwnership("not json", "df98857c")).toBeNull();
 		});
 	});
 
 	describe("shouldRenameCmuxWorkspace", () => {
-		const owned = (over: Partial<CmuxWorkspaceOwnership>): CmuxWorkspaceOwnership => ({
+		const current = (over: Partial<CmuxWorkspaceOwnership>): CmuxWorkspaceOwnership => ({
 			hasCustomTitle: true,
 			title: "current",
 			...over,
 		});
 
-		it("skips when ownership is unknown (read failed)", () => {
+		it("fails closed when ownership is unknown or the title already matches", () => {
 			expect(shouldRenameCmuxWorkspace(null, "GJC: Desired")).toBe(false);
+			expect(shouldRenameCmuxWorkspace(current({ title: "GJC: Desired" }), "GJC: Desired")).toBe(false);
 		});
 
-		it("skips when the title already matches", () => {
-			expect(shouldRenameCmuxWorkspace(owned({ title: "GJC: Desired" }), "GJC: Desired")).toBe(false);
+		it("allows a default workspace to be claimed", () => {
+			expect(shouldRenameCmuxWorkspace(current({ hasCustomTitle: false }), "GJC: Desired")).toBe(true);
 		});
 
-		it("renames when the workspace still has the default title", () => {
-			expect(shouldRenameCmuxWorkspace(owned({ hasCustomTitle: false }), "GJC: Desired")).toBe(true);
-		});
-
-		it("skips a user- or peer-owned custom title", () => {
-			expect(shouldRenameCmuxWorkspace(owned({ title: "My Pinned Name" }), "GJC: Desired")).toBe(false);
-			expect(shouldRenameCmuxWorkspace(owned({ title: "GJC: Session A" }), "GJC: Session B")).toBe(false);
+		it("requires an exact last verified title for custom-title updates", () => {
+			const ownership = current({ title: "GJC: Session A" });
+			expect(shouldRenameCmuxWorkspace(ownership, "GJC: Session B")).toBe(false);
+			expect(shouldRenameCmuxWorkspace(ownership, "GJC: Session B", "GJC: Other")).toBe(false);
+			expect(shouldRenameCmuxWorkspace(ownership, "GJC: Session B", "GJC: Session A")).toBe(true);
+			expect(
+				shouldRenameCmuxWorkspace(current({ title: "GJC: Session A " }), "GJC: Session B", "GJC: Session A"),
+			).toBe(false);
 		});
 	});
 
-	it("does not spawn outside a tty", async () => {
+	it("skips outside a tty and honors GJC_NO_CMUX_RENAME", async () => {
 		let spawned = false;
-		await syncCmuxWorkspaceTitle("Investigate Resolver", {
+		const options = {
 			env: cmuxEnv(),
 			isTty: false,
+			lockDir,
 			which: () => "/usr/local/bin/cmux",
 			readOwnership: async () => ({ hasCustomTitle: false, title: "default" }),
 			spawn: () => {
 				spawned = true;
 				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
 			},
-		});
-		expect(spawned).toBe(false);
-	});
-
-	it("does not spawn when GJC_NO_CMUX_RENAME is set", async () => {
-		let spawned = false;
-		await syncCmuxWorkspaceTitle("Investigate Resolver", {
-			env: cmuxEnv("ws-optout", { GJC_NO_CMUX_RENAME: "1" }),
-			isTty: true,
-			which: () => "/usr/local/bin/cmux",
-			readOwnership: async () => ({ hasCustomTitle: false, title: "default" }),
-			spawn: () => {
-				spawned = true;
-				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
-			},
-		});
-		expect(spawned).toBe(false);
-	});
-
-	it("renames a default-titled workspace inside a tty cmux workspace", async () => {
-		const unref = vi.fn(() => {});
-		const kill = vi.fn(() => {});
-		const calls: string[][] = [];
-
-		await syncCmuxWorkspaceTitle("Investigate Resolver", {
-			env: cmuxEnv("ws-default"),
-			isTty: true,
-			which: command => (command === "cmux" ? "/usr/local/bin/cmux" : null),
-			readOwnership: async () => ({ hasCustomTitle: false, title: "~/dev/x" }),
-			spawn: command => {
-				calls.push(command);
-				return { exited: Promise.resolve(0), kill, unref };
-			},
-		});
-
-		expect(calls).toEqual([
-			["/usr/local/bin/cmux", "workspace", "rename", "ws-default", "--title", "GJC: Investigate Resolver"],
-		]);
-		expect(unref).toHaveBeenCalledTimes(1);
-		expect(kill).not.toHaveBeenCalled();
-	});
-
-	it("does not clobber a user-pinned workspace title", async () => {
-		let spawned = false;
-		await syncCmuxWorkspaceTitle("Investigate Resolver", {
-			env: cmuxEnv("ws-userpinned"),
-			isTty: true,
-			which: () => "/usr/local/bin/cmux",
-			readOwnership: async () => ({ hasCustomTitle: true, title: "My Pinned Name" }),
-			spawn: () => {
-				spawned = true;
-				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
-			},
-		});
-		expect(spawned).toBe(false);
-	});
-
-	it("skips renaming when ownership cannot be read", async () => {
-		let spawned = false;
-		await syncCmuxWorkspaceTitle("Investigate Resolver", {
-			env: cmuxEnv("ws-unreadable"),
-			isTty: true,
-			which: () => "/usr/local/bin/cmux",
-			readOwnership: async () => null,
-			spawn: () => {
-				spawned = true;
-				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
-			},
-		});
-		expect(spawned).toBe(false);
-	});
-
-	it("does not thrash a workspace shared by multiple sessions", async () => {
-		// Two sessions share one CMUX_WORKSPACE_ID. Session A names the still-default
-		// workspace; session B then sees a custom title and must not overwrite it.
-		const calls: string[][] = [];
-		const spawn = (command: string[]) => {
-			calls.push(command);
-			return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
 		};
-		await syncCmuxWorkspaceTitle("Session A task", {
-			env: cmuxEnv("ws-shared"),
+		await syncCmuxWorkspaceTitle("Investigate Resolver", options);
+		await syncCmuxWorkspaceTitle("Investigate Resolver", {
+			...options,
 			isTty: true,
-			which: () => "/usr/local/bin/cmux",
-			readOwnership: async () => ({ hasCustomTitle: false, title: "~/dev/x" }),
-			spawn,
+			env: cmuxEnv("workspace-123", { GJC_NO_CMUX_RENAME: "1" }),
 		});
-		await syncCmuxWorkspaceTitle("Session B task", {
-			env: cmuxEnv("ws-shared"),
+		expect(spawned).toBe(false);
+	});
+
+	it("claims a default workspace, verifies it, and follows later renames in the same process", async () => {
+		const claims = new Map<string, string>();
+		const calls: string[][] = [];
+		let title = "~/dev/x";
+		let hasCustomTitle = false;
+		const options = {
+			env: cmuxEnv("ws-owned"),
 			isTty: true,
+			lockDir,
+			claims,
 			which: () => "/usr/local/bin/cmux",
-			readOwnership: async () => ({ hasCustomTitle: true, title: "GJC: Session A task" }),
-			spawn,
-		});
+			readOwnership: async () => ({ hasCustomTitle, title }),
+			spawn: (command: string[]) => {
+				calls.push(command);
+				title = command.at(-1) ?? "";
+				hasCustomTitle = true;
+				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+			},
+		};
+
+		await syncCmuxWorkspaceTitle("Session A", options);
+		await syncCmuxWorkspaceTitle("Session A renamed", options);
+
 		expect(calls).toEqual([
-			["/usr/local/bin/cmux", "workspace", "rename", "ws-shared", "--title", "GJC: Session A task"],
+			["/usr/local/bin/cmux", "workspace", "rename", "ws-owned", "--title", "GJC: Session A"],
+			["/usr/local/bin/cmux", "workspace", "rename", "ws-owned", "--title", "GJC: Session A renamed"],
 		]);
+		expect(claims.size).toBe(1);
+		expect((await fs.stat(lockDir)).mode & 0o777).toBe(0o700);
+	});
+	it("bounds process-lifetime claims", async () => {
+		const claims = new Map<string, string>();
+		for (let index = 0; index < 40; index++) {
+			let reads = 0;
+			const desired = `GJC: Session ${index}`;
+			await syncCmuxWorkspaceTitle(`Session ${index}`, {
+				env: cmuxEnv(`workspace-${index}`),
+				isTty: true,
+				lockDir,
+				claims,
+				which: () => "/usr/local/bin/cmux",
+				readOwnership: async () => {
+					reads++;
+					return reads === 1
+						? { hasCustomTitle: false, title: "default" }
+						: { hasCustomTitle: true, title: desired };
+				},
+				spawn: () => ({ exited: Promise.resolve(0), kill: () => {}, unref: () => {} }),
+			});
+		}
+		expect(claims.size).toBe(32);
+	});
+
+	it("keeps ownership across fork or branch identity changes in the same process", async () => {
+		const claims = new Map<string, string>();
+		const calls: string[][] = [];
+		let title = "default";
+		let hasCustomTitle = false;
+		const options = {
+			env: cmuxEnv("ws-fork"),
+			isTty: true,
+			lockDir,
+			claims,
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => ({ hasCustomTitle, title }),
+			spawn: (command: string[]) => {
+				calls.push(command);
+				title = command.at(-1) ?? "";
+				hasCustomTitle = true;
+				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+			},
+		};
+
+		await syncCmuxWorkspaceTitle("Parent session", options);
+		await syncCmuxWorkspaceTitle("Branched session", options);
+		expect(calls).toHaveLength(2);
+	});
+
+	it("revokes its claim after a user or peer changes the title, including a GJC-prefixed title", async () => {
+		const claims = new Map<string, string>();
+		const calls: string[][] = [];
+		let title = "default";
+		let hasCustomTitle = false;
+		const options = {
+			env: cmuxEnv("ws-pinned"),
+			isTty: true,
+			lockDir,
+			claims,
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => ({ hasCustomTitle, title }),
+			spawn: (command: string[]) => {
+				calls.push(command);
+				title = command.at(-1) ?? "";
+				hasCustomTitle = true;
+				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+			},
+		};
+
+		await syncCmuxWorkspaceTitle("Owned", options);
+		title = "GJC: Peer desired";
+		await syncCmuxWorkspaceTitle("Peer desired", options);
+		title = "GJC: Owned";
+		await syncCmuxWorkspaceTitle("Claim stays revoked", options);
+
+		expect(calls).toHaveLength(1);
+		expect(claims.size).toBe(0);
+	});
+
+	it("does not claim on exit-zero without an exact post-rename readback", async () => {
+		const claims = new Map<string, string>();
+		let reads = 0;
+		await syncCmuxWorkspaceTitle("Desired", {
+			env: cmuxEnv("ws-noop"),
+			isTty: true,
+			lockDir,
+			claims,
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => {
+				reads++;
+				return reads === 1
+					? { hasCustomTitle: false, title: "default" }
+					: { hasCustomTitle: true, title: "Wrong target" };
+			},
+			spawn: () => ({ exited: Promise.resolve(0), kill: () => {}, unref: () => {} }),
+		});
+		expect(reads).toBe(2);
+		expect(claims.size).toBe(0);
+	});
+	it("rejects parseable workspace-list output from a non-zero process", async () => {
+		const fakeCmux = path.join(root, "failing-cmux.ts");
+		await Bun.write(
+			fakeCmux,
+			`#!/usr/bin/env bun
+process.stdout.write(JSON.stringify({ workspaces: [{ id: "ws-list-fail", title: "default", has_custom_title: false }] }));
+process.exit(1);
+`,
+		);
+		await fs.chmod(fakeCmux, 0o700);
+		let renamed = false;
+		await syncCmuxWorkspaceTitle("Must not rename", {
+			env: cmuxEnv("ws-list-fail"),
+			isTty: true,
+			lockDir,
+			claims: new Map(),
+			which: () => fakeCmux,
+			spawn: () => {
+				renamed = true;
+				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+			},
+		});
+		expect(renamed).toBe(false);
+	});
+	it("force-kills a timed-out rename, releases the lock, and records no claim", async () => {
+		const claims = new Map<string, string>();
+		const exited = new Promise<number>(() => {});
+		let killedWith: number | NodeJS.Signals | undefined;
+		const started = Date.now();
+		await syncCmuxWorkspaceTitle("Timeout", {
+			env: cmuxEnv("ws-timeout"),
+			isTty: true,
+			lockDir,
+			claims,
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => ({ hasCustomTitle: false, title: "default" }),
+			spawn: () => ({
+				exited,
+				kill: signal => {
+					killedWith = signal;
+				},
+				unref: () => {},
+			}),
+		});
+		expect(killedWith).toBe("SIGKILL");
+		expect(Date.now() - started).toBeLessThan(2_500);
+		expect(claims.size).toBe(0);
+		expect(await fs.readdir(lockDir)).toEqual([]);
+	});
+
+	it("refuses a symlinked lock directory", async () => {
+		const target = path.join(root, "real-locks");
+		const symlink = path.join(root, "linked-locks");
+		await fs.mkdir(target);
+		await fs.symlink(target, symlink);
+		let spawned = false;
+		await syncCmuxWorkspaceTitle("Desired", {
+			env: cmuxEnv("ws-symlink"),
+			isTty: true,
+			lockDir: symlink,
+			claims: new Map(),
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => ({ hasCustomTitle: false, title: "default" }),
+			spawn: () => {
+				spawned = true;
+				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+			},
+		});
+		expect(spawned).toBe(false);
+	});
+
+	it("serializes real peer processes and leaves no durable ownership claim after restart", async () => {
+		const fakeCmux = path.join(root, "fake-cmux.ts");
+		const stateFile = path.join(root, "workspace.json");
+		const logFile = path.join(root, "renames.log");
+		await Bun.write(stateFile, JSON.stringify({ title: "default", hasCustomTitle: false }));
+		await Bun.write(
+			fakeCmux,
+			`#!/usr/bin/env bun
+const fs = await import("node:fs/promises");
+const args = process.argv.slice(2);
+const stateFile = process.env.FAKE_CMUX_STATE;
+const logFile = process.env.FAKE_CMUX_LOG;
+if (!stateFile || !logFile) process.exit(2);
+const state = JSON.parse(await Bun.file(stateFile).text());
+if (args[0] === "workspace" && args[1] === "list") {
+  process.stdout.write(JSON.stringify({ workspaces: [{ id: "ws-real", ref: "workspace:1", title: state.title, has_custom_title: state.hasCustomTitle }] }));
+  process.exit(0);
+}
+if (args[0] === "workspace" && args[1] === "rename") {
+  const title = args.at(-1);
+  await Bun.sleep(75);
+  await Bun.write(stateFile, JSON.stringify({ title, hasCustomTitle: true }));
+  await fs.appendFile(logFile, title + "\\n");
+  process.exit(0);
+}
+process.exit(3);
+`,
+		);
+		await fs.chmod(fakeCmux, 0o700);
+
+		const modulePath = path.resolve(import.meta.dir, "../src/utils/cmux-workspace.ts");
+		const childCode = `import { syncCmuxWorkspaceTitle } from ${JSON.stringify(modulePath)};
+await syncCmuxWorkspaceTitle(process.env.SESSION_NAME, { isTty: true, lockDir: process.env.CMUX_LOCK_DIR, which: () => process.env.FAKE_CMUX, env: process.env });`;
+		const childEnv = (name: string): NodeJS.ProcessEnv => ({
+			...process.env,
+			SESSION_NAME: name,
+			CMUX_WORKSPACE_ID: "ws-real",
+			CMUX_SOCKET_PATH: path.join(root, "cmux.sock"),
+			CMUX_LOCK_DIR: lockDir,
+			FAKE_CMUX: fakeCmux,
+			FAKE_CMUX_STATE: stateFile,
+			FAKE_CMUX_LOG: logFile,
+		});
+		const runChild = (name: string) =>
+			Bun.spawn([process.execPath, "-e", childCode], {
+				env: childEnv(name),
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+		await fs.mkdir(lockDir, { mode: 0o700 });
+		const key = `${path.join(root, "cmux.sock")}\u0000ws-real`;
+		const guardFile = path.join(lockDir, `${crypto.createHash("sha256").update(key).digest("hex")}.guard`);
+		const readyFile = path.join(root, "stale-lock-ready");
+		const fileLockPath = path.resolve(import.meta.dir, "../src/config/file-lock.ts");
+		const staleOwner = Bun.spawn(
+			[
+				process.execPath,
+				"-e",
+				`import { withFileLock } from ${JSON.stringify(fileLockPath)};
+await withFileLock(process.env.GUARD_FILE, async () => {
+	await Bun.write(process.env.READY_FILE, "ready");
+	await Bun.sleep(60_000);
+});`,
+			],
+			{
+				env: { ...process.env, GUARD_FILE: guardFile, READY_FILE: readyFile },
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		const readyDeadline = Date.now() + 5_000;
+		while (!(await Bun.file(readyFile).exists())) {
+			if (Date.now() > readyDeadline) throw new Error("stale lock owner did not acquire the guard");
+			await Bun.sleep(10);
+		}
+		staleOwner.kill();
+		await staleOwner.exited;
+		const recovered = runChild("Recovered session");
+		expect(await recovered.exited).toBe(0);
+		expect((await Bun.file(logFile).text()).trim().split("\n")).toHaveLength(1);
+		expect(await fs.readdir(lockDir)).toEqual([]);
+		await Bun.write(stateFile, JSON.stringify({ title: "default", hasCustomTitle: false }));
+		await Bun.write(logFile, "");
+
+		const first = runChild("Session A");
+		const second = runChild("Session B");
+		expect(await Promise.all([first.exited, second.exited])).toEqual([0, 0]);
+		const initialRenames = (await Bun.file(logFile).text()).trim().split("\n");
+		expect(initialRenames).toHaveLength(1);
+
+		const restarted = runChild("Restarted session");
+		expect(await restarted.exited).toBe(0);
+		const finalRenames = (await Bun.file(logFile).text()).trim().split("\n");
+		expect(finalRenames).toEqual(initialRenames);
+		expect(await fs.readdir(lockDir)).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary
- keep cmux title ownership in a bounded process-lifetime map instead of durable claim JSON
- claim only default-titled workspaces and require byte-exact equality with the last verified title for subsequent refreshes
- serialize initial claims across GJC processes with the existing file-lock protocol under a canonical, current-user-owned `0700` directory
- force-kill timed-out cmux subprocesses, reject non-zero list output, and record ownership only after an exact post-rename readback
- revoke ownership on any observed user/peer title change; restart never reclaims an existing custom title

## Prior review closure
Supersedes closed PR #2644 and addresses its exact-head hostile review:
- no persistent workspace claim records, so there is no claim migration/expiry/GC lifecycle
- process claims are capped at 32 and disappear on exit
- fork/branch stays in the same process and therefore retains safe ownership without session-ID stranding
- public `GJC: ` prefixes are never ownership evidence
- exit 0 alone is insufficient; exact raw title readback is required
- stale desired-title matches revoke the previous claim
- lock paths reject symlinks/non-canonical paths/wrong owners and enforce private permissions
- real child-process tests cover peer contention, dead-owner recovery, restart no-reclaim, and lock cleanup

## QA
- `bun test packages/coding-agent/test/cmux-workspace.test.ts packages/coding-agent/test/title-generator.test.ts` — 28 pass
- `bun test --rerun-each 20 packages/coding-agent/test/cmux-workspace.test.ts` — 400 pass
- `bun --cwd=packages/coding-agent run check` — Biome and TypeScript pass
- live `cmux workspace list --json --id-format both` parser check against cmux 0.64.19-nightly
- independent hostile review found and drove fixes for raw-title equality, stale-claim revocation, hard process deadlines, and non-zero list handling
- final independent blocker review: APPROVE, no critical/high findings
- `git diff --check`

## Residual upstream limitation
cmux currently exposes read and rename as separate operations and has no compare-and-swap/expected-title rename API. Therefore an external rename in the interval between the final read and rename remains an unavoidable pre-existing best-effort race. This patch does not claim atomicity; it narrows ownership to exact process-observed state, serializes cooperating GJC writers, and verifies the postcondition. An atomic guarantee requires a cmux API addition.
