### PR TITLE
feat(tui): attach multiple pasted image paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Bracketed pastes containing complete lists of saved image paths now attach up to 16 images atomically in source order, with a 64 MiB aggregate loaded-image limit and exact text replay when any attachment fails.
+
 ### Changed
 - The `read` tool is now receipt-by-default: bare and unparseable reads return a bounded receipt (≤50 lines / 10 KiB) with a re-read-with-selector footer only when truncated, `:raw` stays pure verbatim up to a max(2 MiB, spill threshold) ceiling, structural summaries cap unit-granularly at 20 KiB while preserving elision and source-recovery footers, and directories are byte/line capped and never spill. Only an explicit full-content selector (`:raw` or an explicit range) with real content is spill-eligible. Subagent previews now enforce a real byte/code-point cap via per-shape render budgets plus a shape-aware artifact-eligibility tag enforced centrally in output-meta.
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@gajae-code/tui";
-import { $env, sanitizeText } from "@gajae-code/utils";
+import { $env, formatBytes, sanitizeText } from "@gajae-code/utils";
 import { type AppKeybinding, KEYBINDINGS } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
@@ -24,7 +24,7 @@ import { copyToClipboard, readImageFromClipboard } from "../../utils/clipboard";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } from "../../utils/image-loading";
 import { resizeImage } from "../../utils/image-resize";
-import { formatPastedImageReference, resolvePastedImagePath } from "../../utils/pasted-image-path";
+import { formatPastedImageReference, resolvePastedImagePaths } from "../../utils/pasted-image-path";
 import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 import { ActionRegistry, APP_ACTION_METADATA } from "../action-registry";
 import { CommandPalette, type CommandPaletteAction, type CommandPaletteEntry } from "../components/command-palette";
@@ -43,6 +43,8 @@ const DRAFT_CLEAR_DOUBLE_ESCAPE_WINDOW_MS = 800;
 const EMPTY_EDITOR_DOUBLE_ESCAPE_WINDOW_MS = 500;
 const IMAGE_PLACEHOLDER_PATTERN = /\[image ([1-9]\d*)\]/g;
 const IMAGE_PLACEHOLDER_PRESENT_PATTERN = /\[image [1-9]\d*\]/;
+export const MAX_PASTED_IMAGE_COUNT = 16;
+export const MAX_PASTED_IMAGE_AGGREGATE_BYTES = 64 * 1024 * 1024;
 
 function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
@@ -1523,8 +1525,8 @@ export class InputController {
 	}
 
 	handleTextPaste(text: string): boolean | Promise<boolean> {
-		const imagePath = resolvePastedImagePath(text, { cwd: this.ctx.sessionManager.getCwd() });
-		return imagePath ? this.#attachPastedImagePath(imagePath) : false;
+		const imagePaths = resolvePastedImagePaths(text, { cwd: this.ctx.sessionManager.getCwd() });
+		return imagePaths && imagePaths.length > 0 ? this.#attachPastedImagePaths(imagePaths) : false;
 	}
 
 	/**
@@ -1532,28 +1534,59 @@ export class InputController {
 	 * bracketed paste — the raw path text must never be lost when attachment
 	 * is impossible (unsupported content, oversized image, load error).
 	 */
-	async #attachPastedImagePath(imagePath: string): Promise<boolean> {
-		try {
-			const image = await loadImageInput({
-				path: imagePath,
-				cwd: this.ctx.sessionManager.getCwd(),
-				autoResize: this.ctx.settings.get("images.autoResize"),
-			});
-			if (!image) {
-				this.ctx.showStatus("Unsupported pasted image file");
-				return false;
-			}
+	async #attachPastedImagePaths(imagePaths: readonly string[]): Promise<boolean> {
+		if (imagePaths.length > MAX_PASTED_IMAGE_COUNT) {
+			this.ctx.showStatus(`Cannot attach ${imagePaths.length} pasted images; maximum is ${MAX_PASTED_IMAGE_COUNT}.`);
+			return false;
+		}
 
-			this.ctx.pendingImages = [
-				...this.ctx.pendingImages,
-				{
+		try {
+			const loadedImages: InteractiveModeContext["pendingImages"] = [];
+			const resolvedPaths: string[] = [];
+			let aggregateBytes = 0;
+			for (const imagePath of imagePaths) {
+				const image = await loadImageInput({
+					path: imagePath,
+					cwd: this.ctx.sessionManager.getCwd(),
+					autoResize: this.ctx.settings.get("images.autoResize"),
+				});
+				if (!image) {
+					const status =
+						imagePaths.length === 1
+							? "Unsupported pasted image file"
+							: `Unsupported pasted image file: ${path.basename(imagePath)}`;
+					this.ctx.showStatus(status);
+					return false;
+				}
+
+				aggregateBytes += image.bytes;
+				if (aggregateBytes > MAX_PASTED_IMAGE_AGGREGATE_BYTES) {
+					this.ctx.showStatus(
+						`Pasted images total ${formatBytes(aggregateBytes)}, exceeding the ${formatBytes(MAX_PASTED_IMAGE_AGGREGATE_BYTES)} aggregate limit.`,
+					);
+					return false;
+				}
+				loadedImages.push({
 					type: "image",
 					data: image.data,
 					mimeType: image.mimeType,
-				},
-			];
-			this.ctx.editor.insertText(`${formatPastedImageReference(this.#nextImagePlaceholder(), image.resolvedPath)} `);
-			this.ctx.showStatus(`Attached image: ${path.basename(image.resolvedPath)}`, { dim: true });
+				});
+				resolvedPaths.push(image.resolvedPath);
+			}
+
+			const pendingImages = this.ctx.pendingImages;
+			const firstImageNumber = pendingImages.length + 1;
+			const references = resolvedPaths.map((resolvedPath, index) =>
+				formatPastedImageReference(`[image ${firstImageNumber + index}]`, resolvedPath),
+			);
+			this.ctx.editor.insertText(`${references.join(" ")} `);
+			this.ctx.pendingImages = [...pendingImages, ...loadedImages];
+			const singularResolvedPath = resolvedPaths.length === 1 ? resolvedPaths[0] : undefined;
+			if (singularResolvedPath) {
+				this.ctx.showStatus(`Attached image: ${path.basename(singularResolvedPath)}`, { dim: true });
+			} else {
+				this.ctx.showStatus(`Attached ${resolvedPaths.length} images`, { dim: true });
+			}
 			this.ctx.ui.requestRender();
 			return true;
 		} catch (error) {
@@ -1561,7 +1594,9 @@ export class InputController {
 				this.ctx.showStatus(error.message);
 				return false;
 			}
-			this.ctx.showStatus("Failed to attach pasted image");
+			this.ctx.showStatus(
+				imagePaths.length === 1 ? "Failed to attach pasted image" : "Failed to attach pasted images",
+			);
 			return false;
 		}
 	}

--- a/packages/coding-agent/src/utils/pasted-image-path.ts
+++ b/packages/coding-agent/src/utils/pasted-image-path.ts
@@ -1,12 +1,10 @@
 /**
- * Resolve pasted editor text to an image file path.
+ * Resolve pasted editor text to one or more image file paths.
  *
- * Some terminal/clipboard integrations paste a temporary filesystem path after a
- * copied image is pasted into the editor (for example `/tmp/clipboard-...png`).
- * Only those recognized clipboard temp files are auto-attached and replaced with
- * an `[image N] source="/path"` reference so the model receives both the image
- * payload and the raw temp file path. Ordinary image paths remain literal prompt
- * text; users attach saved files explicitly with `@path/to/image.png`.
+ * A single path is auto-attached only when it names a recognized clipboard
+ * temporary image. A complete list of at least two valid images may also use
+ * ordinary saved paths. This keeps ordinary single saved paths as literal
+ * prompt text while supporting terminal drag-and-drop of multiple images.
  */
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -120,6 +118,104 @@ export function decodePastedPathCandidate(text: string, options?: DecodePastedPa
 	return candidate;
 }
 
+type PastedPathListState = "normal" | "escape" | "single-quote" | "double-quote";
+type EscapeReturnState = "normal" | "double-quote";
+
+function isAsciiWhitespace(character: string): boolean {
+	return (
+		character === " " ||
+		character === "\t" ||
+		character === "\n" ||
+		character === "\r" ||
+		character === "\v" ||
+		character === "\f"
+	);
+}
+
+function decodeTokenPathCandidate(candidate: string, options?: DecodePastedPathOptions): string | undefined {
+	const platform = options?.platform ?? process.platform;
+	if (candidate.startsWith("file://")) {
+		const decoded = decodeFileUrl(candidate, platform);
+		if (decoded === undefined) return undefined;
+		candidate = decoded;
+	}
+	if (candidate.startsWith("~/")) {
+		candidate = path.join(options?.homedir ?? os.homedir(), candidate.slice(2));
+	}
+	return candidate;
+}
+
+/**
+ * Tokenize a complete pasted path list using shell-like quoting and escaping.
+ * Only unescaped ASCII whitespace separates paths, so Unicode spacing used in
+ * screenshot names (notably U+202F) remains part of a path. On win32,
+ * backslashes are always preserved as path separators rather than interpreted
+ * as POSIX escapes.
+ */
+export function decodePastedPathCandidates(text: string, options?: DecodePastedPathOptions): string[] | undefined {
+	const platform = options?.platform ?? process.platform;
+	const candidates: string[] = [];
+	let state: PastedPathListState = "normal";
+	let escapeReturnState: EscapeReturnState = "normal";
+	let candidate = "";
+	let candidateStarted = false;
+
+	const finishCandidate = (): boolean => {
+		if (!candidateStarted) return true;
+		if (!candidate) return false;
+		const decoded = decodeTokenPathCandidate(candidate, options);
+		if (decoded === undefined) return false;
+		candidates.push(decoded);
+		candidate = "";
+		candidateStarted = false;
+		return true;
+	};
+
+	for (const character of text) {
+		if (state === "escape") {
+			candidate += character;
+			state = escapeReturnState;
+			continue;
+		}
+		if (state === "single-quote") {
+			if (character === "'") state = "normal";
+			else candidate += character;
+			continue;
+		}
+		if (state === "double-quote") {
+			if (character === '"') {
+				state = "normal";
+			} else if (character === "\\" && platform !== "win32") {
+				escapeReturnState = "double-quote";
+				state = "escape";
+			} else {
+				candidate += character;
+			}
+			continue;
+		}
+
+		if (isAsciiWhitespace(character)) {
+			if (!finishCandidate()) return undefined;
+		} else if (character === "'") {
+			candidateStarted = true;
+			state = "single-quote";
+		} else if (character === '"') {
+			candidateStarted = true;
+			state = "double-quote";
+		} else if (character === "\\" && platform !== "win32") {
+			candidateStarted = true;
+			escapeReturnState = "normal";
+			state = "escape";
+		} else {
+			candidateStarted = true;
+			candidate += character;
+		}
+	}
+
+	if (state !== "normal" || !finishCandidate() || candidates.length === 0) return undefined;
+	return candidates;
+}
+
 /**
  * Sniff the file header for a supported image signature (PNG, JPEG, GIF,
  * WEBP). Prevents existing non-image files with image-looking extensions
@@ -158,6 +254,18 @@ function isRecognizedClipboardTempPath(filePath: string): boolean {
 	return CLIPBOARD_TEMP_BASENAME_PATTERN.test(path.basename(resolved));
 }
 
+function resolveImagePathCandidate(candidate: string, options?: ResolvePastedImagePathOptions): string | undefined {
+	if (!IMAGE_FILE_EXTENSION_PATTERN.test(candidate)) return undefined;
+	const resolved = path.resolve(options?.cwd ?? process.cwd(), candidate);
+	try {
+		if (!fs.statSync(resolved).isFile()) return undefined;
+	} catch {
+		return undefined;
+	}
+	if (!hasSupportedImageMagic(resolved)) return undefined;
+	return resolved;
+}
+
 /**
  * Returns the resolved path when the whole pasted text is a recognized clipboard
  * temp path to an existing image file, otherwise `undefined` (the paste is
@@ -166,17 +274,33 @@ function isRecognizedClipboardTempPath(filePath: string): boolean {
  */
 export function resolvePastedImagePath(text: string, options?: ResolvePastedImagePathOptions): string | undefined {
 	const candidate = decodePastedPathCandidate(text, options);
-	if (!candidate || !IMAGE_FILE_EXTENSION_PATTERN.test(candidate)) return undefined;
-
-	const resolved = path.resolve(options?.cwd ?? process.cwd(), candidate);
-	if (!isRecognizedClipboardTempPath(resolved)) return undefined;
-	try {
-		if (!fs.statSync(resolved).isFile()) return undefined;
-	} catch {
-		return undefined;
-	}
-	if (!hasSupportedImageMagic(resolved)) return undefined;
+	if (!candidate) return undefined;
+	const resolved = resolveImagePathCandidate(candidate, options);
+	if (!resolved || !isRecognizedClipboardTempPath(resolved)) return undefined;
 	return resolved;
+}
+
+/**
+ * Resolve a complete pasted list of image paths. A single candidate retains the
+ * legacy clipboard-temp-only policy. Lists of at least two candidates may
+ * contain saved image paths, but every path must resolve to a regular supported
+ * image or the whole paste is rejected.
+ */
+export function resolvePastedImagePaths(text: string, options?: ResolvePastedImagePathOptions): string[] | undefined {
+	const candidates = decodePastedPathCandidates(text, options);
+	if (!candidates) return undefined;
+	if (candidates.length === 1) {
+		const resolved = resolvePastedImagePath(text, options);
+		return resolved ? [resolved] : undefined;
+	}
+
+	const resolvedPaths: string[] = [];
+	for (const candidate of candidates) {
+		const resolved = resolveImagePathCandidate(candidate, options);
+		if (!resolved) return undefined;
+		resolvedPaths.push(resolved);
+	}
+	return resolvedPaths;
 }
 
 export function formatPastedImageReference(placeholder: string, imagePath: string): string {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -5,10 +5,16 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { QueuedMessageSelectorComponent } from "../src/modes/components/queued-message-selector";
-import { InputController } from "../src/modes/controllers/input-controller";
+import {
+	InputController,
+	MAX_PASTED_IMAGE_AGGREGATE_BYTES,
+	MAX_PASTED_IMAGE_COUNT,
+} from "../src/modes/controllers/input-controller";
 import { initTheme } from "../src/modes/theme/theme";
 import type { CompactionQueuedMessage, ComposerSubmissionOptions, InteractiveModeContext } from "../src/modes/types";
 import type { QueuedMessageEditEntry } from "../src/session/agent-session";
+import { MAX_IMAGE_INPUT_BYTES } from "../src/utils/image-loading";
+import { formatPastedImageReference } from "../src/utils/pasted-image-path";
 
 type FakeEditor = {
 	onEscape?: () => void;
@@ -923,7 +929,7 @@ describe("InputController keybinding setup", () => {
 	});
 });
 
-describe("InputController pasted clipboard image paths", () => {
+describe("InputController pasted image paths", () => {
 	const RED_1X1_PNG_BASE64 =
 		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
 
@@ -944,6 +950,117 @@ describe("InputController pasted clipboard image paths", () => {
 			expect(spies.showStatus).toHaveBeenCalledWith(`Attached image: ${imagePath.split("/").at(-1)}`, { dim: true });
 		} finally {
 			await fs.rm(imagePath, { force: true });
+		}
+	});
+
+	it("atomically attaches multiple saved image paths in source order with one editor update", async () => {
+		const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-pasted-images-"));
+		const firstPath = path.join(tempDirectory, "first.png");
+		const secondPath = path.join(tempDirectory, "second.gif");
+		await Bun.write(firstPath, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		await Bun.write(secondPath, Buffer.from("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==", "base64"));
+		try {
+			const { InputController, ctx, editor, spies } = await createContext();
+			ctx.pendingImages = [{ type: "image", data: "existing", mimeType: "image/png" }];
+			const insertText = vi.spyOn(editor, "insertText");
+			const requestRender = vi.spyOn(ctx.ui, "requestRender");
+			const controller = new InputController(ctx);
+
+			controller.setupKeyHandlers();
+			const handled = await editor.onPasteText?.(`${firstPath} ${secondPath}`);
+
+			expect(handled).toBe(true);
+			expect(editor.getText()).toBe(
+				`${formatPastedImageReference("[image 2]", firstPath)} ${formatPastedImageReference("[image 3]", secondPath)} `,
+			);
+			expect(ctx.pendingImages.map(image => image.mimeType)).toEqual(["image/png", "image/png", "image/gif"]);
+			expect(insertText).toHaveBeenCalledTimes(1);
+			expect(requestRender).toHaveBeenCalledTimes(1);
+			expect(spies.showStatus).toHaveBeenCalledWith("Attached 2 images", { dim: true });
+		} finally {
+			await fs.rm(tempDirectory, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects pasted image lists above the count limit without loading or attaching any image", async () => {
+		const imagePath = path.join(os.tmpdir(), `saved-count-limit-${process.pid.toString(36)}.png`);
+		await Bun.write(imagePath, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		try {
+			const { InputController, ctx, editor, spies } = await createContext();
+			const requestRender = vi.spyOn(ctx.ui, "requestRender");
+			const controller = new InputController(ctx);
+			controller.setupKeyHandlers();
+			const pastedText = Array.from({ length: MAX_PASTED_IMAGE_COUNT + 1 }, () => imagePath).join(" ");
+
+			const handled = await editor.onPasteText?.(pastedText);
+
+			expect(handled).toBe(false);
+			expect(editor.getText()).toBe("");
+			expect(ctx.pendingImages).toEqual([]);
+			expect(requestRender).not.toHaveBeenCalled();
+			expect(spies.showStatus).toHaveBeenCalledWith(
+				`Cannot attach ${MAX_PASTED_IMAGE_COUNT + 1} pasted images; maximum is ${MAX_PASTED_IMAGE_COUNT}.`,
+			);
+		} finally {
+			await fs.rm(imagePath, { force: true });
+		}
+	});
+
+	it("rejects pasted images above the aggregate loaded-byte limit without attaching any image", async () => {
+		const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-pasted-images-aggregate-"));
+		const imageBytes = MAX_PASTED_IMAGE_AGGREGATE_BYTES / 4 + 1;
+		const imagePaths = Array.from({ length: 4 }, (_, index) => path.join(tempDirectory, `image-${index}.png`));
+		for (const imagePath of imagePaths) {
+			await Bun.write(imagePath, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+			await fs.truncate(imagePath, imageBytes);
+		}
+		try {
+			const { InputController, ctx, editor, spies } = await createContext();
+			const requestRender = vi.spyOn(ctx.ui, "requestRender");
+			const controller = new InputController(ctx);
+			controller.setupKeyHandlers();
+
+			const handled = await editor.onPasteText?.(imagePaths.join(" "));
+
+			expect(handled).toBe(false);
+			expect(editor.getText()).toBe("");
+			expect(ctx.pendingImages).toEqual([]);
+			expect(requestRender).not.toHaveBeenCalled();
+			expect(spies.showStatus.mock.calls.at(-1)?.[0]).toContain("aggregate limit");
+		} finally {
+			await fs.rm(tempDirectory, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps an existing draft and attachments unchanged when any pasted image load fails", async () => {
+		const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-pasted-images-atomic-"));
+		const validPath = path.join(tempDirectory, "valid.png");
+		const oversizedPath = path.join(tempDirectory, "oversized.png");
+		await Bun.write(validPath, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		await Bun.write(oversizedPath, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		await fs.truncate(oversizedPath, MAX_IMAGE_INPUT_BYTES + 1);
+		try {
+			const { InputController, ctx, editor, spies } = await createContext();
+			const existingImage: InteractiveModeContext["pendingImages"][number] = {
+				type: "image",
+				data: "existing",
+				mimeType: "image/png",
+			};
+			ctx.pendingImages = [existingImage];
+			editor.setText("existing draft ");
+			const requestRender = vi.spyOn(ctx.ui, "requestRender");
+			const controller = new InputController(ctx);
+			controller.setupKeyHandlers();
+
+			const handled = await editor.onPasteText?.(`${validPath} ${oversizedPath}`);
+
+			expect(handled).toBe(false);
+			expect(editor.getText()).toBe("existing draft ");
+			expect(ctx.pendingImages).toEqual([existingImage]);
+			expect(requestRender).not.toHaveBeenCalled();
+			expect(spies.showStatus.mock.calls.at(-1)?.[0]).toContain("Image file too large");
+		} finally {
+			await fs.rm(tempDirectory, { recursive: true, force: true });
 		}
 	});
 

--- a/packages/coding-agent/test/pasted-image-path.test.ts
+++ b/packages/coding-agent/test/pasted-image-path.test.ts
@@ -2,10 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import * as url from "node:url";
 import {
 	decodePastedPathCandidate,
+	decodePastedPathCandidates,
 	formatPastedImageReference,
 	resolvePastedImagePath,
+	resolvePastedImagePaths,
 } from "../src/utils/pasted-image-path";
 
 const NNBSP = "\u202f"; // narrow no-break space used by macOS screenshot names
@@ -134,6 +137,152 @@ describe("resolvePastedImagePath", () => {
 	it("rejects empty and whitespace-only pastes", () => {
 		expect(resolvePastedImagePath("")).toBeUndefined();
 		expect(resolvePastedImagePath("   ")).toBeUndefined();
+	});
+});
+
+describe("resolvePastedImagePaths", () => {
+	let testDir: string;
+
+	beforeEach(() => {
+		testDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-pasted-images-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(testDir, { recursive: true, force: true });
+	});
+
+	const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+	function writeImage(name: string): string {
+		const filePath = path.join(testDir, name);
+		fs.writeFileSync(filePath, PNG_SIGNATURE);
+		return filePath;
+	}
+
+	it("accepts at least two saved image paths and preserves source order", () => {
+		const first = writeImage("first.png");
+		const second = writeImage("second.jpg");
+		expect(resolvePastedImagePaths(`${second} ${first} ${second}`)).toEqual([second, first, second]);
+	});
+
+	it("supports POSIX escapes plus single-quoted and double-quoted paths", () => {
+		const escaped = writeImage("escaped path.png");
+		const singleQuoted = writeImage("single quoted.jpg");
+		const doubleQuoted = writeImage("double quoted.webp");
+		const paste = `${escaped.replaceAll(" ", "\\ ")} '${singleQuoted}' "${doubleQuoted}"`;
+		expect(resolvePastedImagePaths(paste)).toEqual([escaped, singleQuoted, doubleQuoted]);
+	});
+
+	it("resolves a macOS multi-screenshot paste with escaped spaces and U+202F", () => {
+		const first = writeImage(`Screenshot 2026-07-19 at 3.21.27${NNBSP}PM.png`);
+		const second = writeImage(`Screenshot 2026-07-19 at 3.21.29${NNBSP}PM.png`);
+		const paste = `${first.replaceAll(" ", "\\ ")} ${second.replaceAll(" ", "\\ ")}`;
+		expect(resolvePastedImagePaths(paste)).toEqual([first, second]);
+	});
+
+	it("resolves complete lists of local file URLs", () => {
+		const first = writeImage("first uri.png");
+		const second = writeImage("second uri.jpg");
+		const paste = `${url.pathToFileURL(first).href}\n${url.pathToFileURL(second).href}`;
+		expect(resolvePastedImagePaths(paste)).toEqual([first, second]);
+	});
+
+	it("splits on ASCII whitespace while retaining U+202F inside screenshot names", () => {
+		const first = writeImage(`Screenshot${NNBSP}AM.png`);
+		const second = writeImage(`Screenshot${NNBSP}PM.png`);
+		expect(resolvePastedImagePaths(`\t${first}\r\n\f\v${second} `)).toEqual([first, second]);
+	});
+
+	it("resolves relative and home-relative paths for saved-image lists", () => {
+		const relative = writeImage("relative.png");
+		const homeRelative = writeImage("home.jpg");
+		expect(resolvePastedImagePaths("./relative.png ~/home.jpg", { cwd: testDir, homedir: testDir })).toEqual([
+			relative,
+			homeRelative,
+		]);
+	});
+
+	it("retains the single-candidate clipboard-temp policy", () => {
+		const saved = writeImage("saved.png");
+		const clipboard = writeImage("clipboard-2026-07-19-095500-A1.png");
+		expect(resolvePastedImagePaths(saved)).toBeUndefined();
+		expect(resolvePastedImagePaths(clipboard)).toEqual([clipboard]);
+	});
+
+	it("rejects the complete list when any candidate is missing or unsupported", () => {
+		const valid = writeImage("valid.png");
+		const missing = path.join(testDir, "missing.png");
+		const textFile = path.join(testDir, "not-an-image.jpg");
+		fs.writeFileSync(textFile, "not an image");
+		expect(resolvePastedImagePaths(`${valid} ${missing}`)).toBeUndefined();
+		expect(resolvePastedImagePaths(`${valid} ${textFile}`)).toBeUndefined();
+	});
+
+	it("rejects directories, non-image extensions, and prose anywhere in the list", () => {
+		const valid = writeImage("valid.png");
+		const directory = path.join(testDir, "directory.png");
+		const textFile = path.join(testDir, "notes.txt");
+		fs.mkdirSync(directory);
+		fs.writeFileSync(textFile, PNG_SIGNATURE);
+		expect(resolvePastedImagePaths(`${valid} ${directory}`)).toBeUndefined();
+		expect(resolvePastedImagePaths(`${valid} ${textFile}`)).toBeUndefined();
+		expect(resolvePastedImagePaths(`${valid} explanatory text`)).toBeUndefined();
+	});
+
+	it("rejects malformed quoting and dangling POSIX escapes", () => {
+		const first = writeImage("first.png");
+		const second = writeImage("second.png");
+		expect(resolvePastedImagePaths(`'${first} ${second}`)).toBeUndefined();
+		expect(resolvePastedImagePaths(`"${first} ${second}`)).toBeUndefined();
+		expect(resolvePastedImagePaths(`${first} ${second}\\`)).toBeUndefined();
+		expect(resolvePastedImagePaths(`${first} '' ${second}`)).toBeUndefined();
+	});
+});
+
+describe("decodePastedPathCandidates", () => {
+	it("decodes shell-like quoting, escaping, and concatenated quoted segments", () => {
+		expect(
+			decodePastedPathCandidates(`alpha\\ beta.png 'gamma delta'.jpg "epsilon zeta".webp`, {
+				platform: "linux",
+			}),
+		).toEqual(["alpha beta.png", "gamma delta.jpg", "epsilon zeta.webp"]);
+	});
+
+	it("uses only ASCII whitespace as separators", () => {
+		expect(decodePastedPathCandidates(`first${NNBSP}image.png\tsecond.jpg\nthird.webp`)).toEqual([
+			`first${NNBSP}image.png`,
+			"second.jpg",
+			"third.webp",
+		]);
+	});
+
+	it("preserves Windows path-separator backslashes", () => {
+		expect(
+			decodePastedPathCandidates(String.raw`C:\Users\me\one.png "D:\Saved Images\two.jpg"`, {
+				platform: "win32",
+			}),
+		).toEqual([String.raw`C:\Users\me\one.png`, String.raw`D:\Saved Images\two.jpg`]);
+	});
+
+	it("decodes file URLs independently and rejects an invalid member", () => {
+		expect(
+			decodePastedPathCandidates("file:///tmp/first%20image.png file:///tmp/second.jpg", {
+				platform: "linux",
+			}),
+		).toEqual(["/tmp/first image.png", "/tmp/second.jpg"]);
+		expect(
+			decodePastedPathCandidates("file:///tmp/first.png file://server/share/second.jpg", {
+				platform: "linux",
+			}),
+		).toBeUndefined();
+	});
+
+	it("rejects empty input, empty candidates, and unfinished tokenizer states", () => {
+		expect(decodePastedPathCandidates(" \t\r\n")).toBeUndefined();
+		expect(decodePastedPathCandidates("first.png '' second.png")).toBeUndefined();
+		expect(decodePastedPathCandidates("first.png 'second.png")).toBeUndefined();
+		expect(decodePastedPathCandidates('first.png "second.png')).toBeUndefined();
+		expect(decodePastedPathCandidates("first.png second.png\\", { platform: "linux" })).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## What

- Parse complete bracketed-paste lists of quoted, shell-escaped, newline-separated, and local `file://` image paths without relying on terminal-specific clipboard APIs.
- Preserve the existing single clipboard-temp attachment policy while allowing complete batches of at least two saved image paths.
- Load batches atomically, preserve source order and existing `[image N]` numbering, and replay the exact original paste when any member cannot be attached.
- Bound path-list attachment to 16 images and 64 MiB aggregate loaded image data.

## Why

Copying or dragging several image files into a terminal produces one bracketed paste containing textual paths. GJC previously treated that path list as prompt text instead of attaching the images. This adds terminal-agnostic multi-image handling while retaining the conservative single-saved-path behavior introduced after the orphan-placeholder regressions.

## Testing

- `bun test packages/coding-agent/test/pasted-image-path.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/custom-editor-keybindings.test.ts` — 106 passed, 0 failed
- `bun --cwd=packages/coding-agent run check` — passed
- `bun scripts/ci-release-publish.ts --check-types` — passed
- Manual macOS terminal test — selecting and pasting multiple image paths attached them in order with source-preserving placeholders
- `bun check` — the feature and Rust checks passed, but the unrelated `sdk-downgrade-rollback.test.ts` gate failed because its pinned old native build exceeded the hardcoded 300-second timeout; reproduced twice with exit 137 while the build itself completed in about 7m48s

---

- [ ] `bun check` passes — blocked locally by the unrelated rollback native-build timeout described above
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)