### PR TITLE
fix(tui): preserve inline scrollback and status on completion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -183,7 +183,7 @@
       "devDependencies": {
         "@xterm/headless": "catalog:",
         "chalk": "catalog:",
-        "node-pty": "^1.0.0",
+        "node-pty": "1.2.0-beta.14",
       },
     },
     "packages/typescript-edit-benchmark": {
@@ -960,7 +960,7 @@
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
-    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+    "node-pty": ["node-pty@1.2.0-beta.14", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-XORU9BQgpxVgqr7WivjJ17mLenOHUgKKWzuZZNaw3NDYgHc/wPJQMSaoLDrpEgqV6aU1nNwil1o/OqYj6lWmUA=="],
 
     "nth-check": ["nth-check@3.0.1", "", { "dependencies": { "boolbase": "^2.0.0" } }, "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ=="],
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - The Python eval runtime now honors the documented `GJC_*` environment variables instead of silently reading only legacy `PI_*` names. `GJC_PY` (tokens `0`/`bash`, `1`/`py`, `js`, `mix`/`both`) overrides the eval backend allowance with precedence over legacy `PI_PY`/`PI_JS`; `GJC_PYTHON_SKIP_CHECK`, `GJC_PYTHON_IPC_TRACE`, and `GJC_PYTHON_INTEGRATION` are read first with `PI_*` fallback (OR semantics, so either truthy name wins). Operators following `docs/environment-variables.md` and `docs/python-repl.md` who set `GJC_PY=py` previously saw no effect — a silent docs/runtime contract break. Legacy `PI_*` names remain supported for backward compatibility.
+- Interactive completion no longer contracts the transient status slot while a user is browsing native terminal scrollback, preventing completion-time viewport repaint from jumping away from the viewed transcript rows.
 
 ### Fixed
 - SDK host shutdown now retries a failed broker unregister instead of short-circuiting with a stale broker-index entry, while retained startup-cleanup owner-release failures remain isolated from the red extension-error path (#2625).

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -118,6 +118,9 @@ export class EventController {
 	#toolIntentCache = new Map<string, { args: unknown; intent: string | undefined }>();
 	#thinkingContentIndices = new Set<number>();
 	#handlers: AgentSessionEventHandlers;
+	#completionFootprints: Component[] = [];
+	#eventQueue: Promise<void> = Promise.resolve();
+	#completionHandled = false;
 
 	constructor(private ctx: InteractiveModeContext) {
 		this.#handlers = {
@@ -228,7 +231,18 @@ export class EventController {
 		});
 	}
 
-	async handleEvent(event: AgentSessionEvent): Promise<void> {
+	/**
+	 * Serializes session events so a completion cannot interleave with a
+	 * successor turn's start. Handlers must never await handleEvent themselves:
+	 * a nested call would queue behind the current event and deadlock.
+	 */
+	handleEvent(event: AgentSessionEvent): Promise<void> {
+		const completion = this.#eventQueue.then(() => this.#handleEvent(event));
+		this.#eventQueue = completion.catch(() => {});
+		return completion;
+	}
+
+	async #handleEvent(event: AgentSessionEvent): Promise<void> {
 		if (!this.ctx.isInitialized) {
 			await this.ctx.init();
 		}
@@ -241,20 +255,42 @@ export class EventController {
 		if (this.ctx.isTranscriptViewerOpen?.()) this.ctx.refreshTranscriptViewer?.();
 	}
 
+	#clearCompletionFootprints(): void {
+		for (const footprint of this.#completionFootprints) {
+			this.ctx.statusContainer.removeChild(footprint);
+		}
+		this.#completionFootprints = [];
+	}
+	/**
+	 * Retains the exact render footprint of a loader that is being removed
+	 * while visible. Footprints accumulate within a turn so the status area
+	 * never contracts (a contraction repaints the inline viewport the user may
+	 * be browsing); the next agent_start clears them.
+	 */
+	#retainCompletionFootprint(loader: Loader): void {
+		if (!this.ctx.ui.terminal.isProcessTerminal) return;
+		const footprint = loader.createFootprint();
+		this.#completionFootprints.push(footprint);
+		this.ctx.statusContainer.addChild(footprint);
+	}
+
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
+		this.#completionHandled = false;
 		this.#lastIntent = undefined;
 		this.#readToolCallArgs.clear();
 		this.#readToolCallAssistantComponents.clear();
 		this.#lastAssistantComponent = undefined;
+		this.#clearCompletionFootprints();
 		if (this.ctx.retryEscapeHandler) {
 			this.ctx.editor.onEscape = this.ctx.retryEscapeHandler;
 			this.ctx.retryEscapeHandler = undefined;
 		}
 		if (this.ctx.retryLoader) {
-			this.ctx.retryLoader.stop();
+			const retryLoader = this.ctx.retryLoader;
+			retryLoader.stop();
 			this.#clearRetryCountdown();
 			this.ctx.retryLoader = undefined;
-			this.ctx.statusContainer.clear();
+			this.ctx.statusContainer.removeChild(retryLoader);
 		}
 		this.ctx.retryEscapePrimed = false;
 		this.#cancelIdleCompaction();
@@ -810,11 +846,28 @@ export class EventController {
 	}
 
 	async #handleAgentEnd(_event: Extract<AgentSessionEvent, { type: "agent_end" }>): Promise<void> {
-		if (this.ctx.loadingAnimation) {
-			this.ctx.loadingAnimation.stop();
-			this.ctx.loadingAnimation = undefined;
-			this.ctx.statusContainer.clear();
+		if (this.#completionHandled) return;
+		this.#completionHandled = true;
+
+		if (this.ctx.retryEscapeHandler) {
+			this.ctx.editor.onEscape = this.ctx.retryEscapeHandler;
+			this.ctx.retryEscapeHandler = undefined;
 		}
+		this.#clearRetryCountdown();
+		const retryLoader = this.ctx.retryLoader;
+		this.ctx.retryLoader = undefined;
+		const workingLoader = this.ctx.loadingAnimation;
+		this.ctx.loadingAnimation = undefined;
+		// Process terminals do not expose native scrollback position. Preserve
+		// each visible status's actual footprint so completion cannot contract
+		// and repaint a viewport the user is browsing.
+		for (const loader of [retryLoader, workingLoader]) {
+			if (!loader) continue;
+			loader.stop();
+			this.ctx.statusContainer.removeChild(loader);
+			this.#retainCompletionFootprint(loader);
+		}
+		this.ctx.retryEscapePrimed = false;
 		if (this.ctx.streamingComponent) {
 			this.ctx.chatContainer.removeChild(this.ctx.streamingComponent);
 			this.ctx.streamingComponent = undefined;
@@ -939,9 +992,20 @@ export class EventController {
 				this.ctx.session.abortRetry();
 			}
 		};
-		this.ctx.statusContainer.clear();
-		// Stop any prior retry loader/timer before installing a new one.
-		this.ctx.retryLoader?.stop();
+		// Hide the working loader during backoff. The retry loader added in this
+		// same frame replaces its rows; auto_retry_end retains the retry
+		// loader's footprint, so the status area never contracts on completion.
+		const loadingAnimation = this.ctx.loadingAnimation;
+		if (loadingAnimation) {
+			loadingAnimation.stop();
+			this.ctx.statusContainer.removeChild(loadingAnimation);
+			this.ctx.loadingAnimation = undefined;
+		}
+		const previousRetryLoader = this.ctx.retryLoader;
+		if (previousRetryLoader) {
+			previousRetryLoader.stop();
+			this.ctx.statusContainer.removeChild(previousRetryLoader);
+		}
 		this.#clearRetryCountdown();
 		const reason = friendlyRetryReason(event.errorMessage);
 		const attemptLabel = event.unbounded ? `attempt ${event.attempt}` : `${event.attempt}/${event.maxAttempts}`;
@@ -973,10 +1037,12 @@ export class EventController {
 			this.ctx.retryEscapeHandler = undefined;
 		}
 		if (this.ctx.retryLoader) {
-			this.ctx.retryLoader.stop();
+			const retryLoader = this.ctx.retryLoader;
+			retryLoader.stop();
 			this.#clearRetryCountdown();
 			this.ctx.retryLoader = undefined;
-			this.ctx.statusContainer.clear();
+			this.ctx.statusContainer.removeChild(retryLoader);
+			this.#retainCompletionFootprint(retryLoader);
 		}
 		this.ctx.retryEscapePrimed = false;
 		if (!event.success) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1497,7 +1497,6 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	ensureLoadingAnimation(): void {
 		if (!this.loadingAnimation) {
-			this.statusContainer.clear();
 			this.loadingAnimation = new Loader(
 				this.ui,
 				spinner => {

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -663,4 +663,16 @@ describe("InteractiveMode.setEditorComponent", () => {
 			setTerminalImageProtocol(originalProtocol);
 		}
 	});
+	it("preserves independently owned status components when starting the real working loader", () => {
+		const independentStatus = new Text("independent status", 0, 0);
+		mode.statusContainer.addChild(independentStatus);
+
+		mode.ensureLoadingAnimation();
+
+		const loadingAnimation = mode.loadingAnimation;
+		expect(loadingAnimation).toBeDefined();
+		if (!loadingAnimation) throw new Error("Expected the working loader");
+		expect(mode.statusContainer.children).toEqual([independentStatus, loadingAnimation]);
+		loadingAnimation.stop();
+	});
 });

--- a/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@gajae-code/ai";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
@@ -12,7 +12,7 @@ import {
 	associateSessionMessageViewportAnchorId,
 	getSessionMessageViewportAnchorId,
 } from "@gajae-code/coding-agent/session/session-manager";
-import { Container, shouldUseViewportRepaintForHost, Text, TUI } from "@gajae-code/tui";
+import { Container, Loader, shouldUseViewportRepaintForHost, Text, TUI } from "@gajae-code/tui";
 import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
 
 function assistantMessage(text: string): AssistantMessage {
@@ -79,6 +79,14 @@ describe("EventController completion viewport", () => {
 			env: Partial<Record<(typeof envKeys)[number], string>>;
 			resizeHeight?: number;
 			nativeWindows?: boolean;
+			isProcessTerminal?: boolean;
+			initialLoaderMessage?: string;
+			noInitialLoader?: boolean;
+			initialSpinnerFrames?: string[];
+			residualStatus?: boolean;
+			expectEmptyLoader?: boolean;
+			initialRetryLoader?: boolean;
+			testActiveLoaderRetry?: boolean;
 		}> = [
 			{ label: "plain-ssh", env: { SSH_CONNECTION: "client server", TERM: "xterm-256color" } },
 			{ label: "tmux-default", env: { TMUX: "/tmp/tmux,1,0", TERM: "tmux-256color" } },
@@ -92,6 +100,41 @@ describe("EventController completion viewport", () => {
 				env: { WT_SESSION: "forwarded", TERM_PROGRAM: "Windows_Terminal", TERM: "xterm-256color" },
 			},
 			{ label: "native-windows-selector", env: { TERM: "xterm-256color" }, nativeWindows: true },
+			{ label: "virtual-terminal", env: { TERM: "xterm-256color" }, isProcessTerminal: false },
+			{
+				label: "empty-loader",
+				env: { TERM: "xterm-256color" },
+				initialLoaderMessage: "",
+				initialSpinnerFrames: [""],
+				expectEmptyLoader: true,
+			},
+			{ label: "loader-unrelated-status", env: { TERM: "xterm-256color" }, residualStatus: true },
+			{
+				label: "active-loader-retry-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				residualStatus: true,
+				testActiveLoaderRetry: true,
+			},
+			{
+				label: "virtual-loader-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				isProcessTerminal: false,
+				residualStatus: true,
+			},
+			{ label: "empty-status", env: { TERM: "xterm-256color" }, noInitialLoader: true },
+			{
+				label: "no-loader-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				noInitialLoader: true,
+				residualStatus: true,
+			},
+			{
+				label: "retry-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				noInitialLoader: true,
+				residualStatus: true,
+				initialRetryLoader: true,
+			},
 		];
 
 		for (const testCase of cases) {
@@ -105,7 +148,7 @@ describe("EventController completion viewport", () => {
 						expect(shouldUseViewportRepaintForHost({}, "win32", { includeNativeWindows: true })).toBe(true);
 					}
 
-					const term = new VirtualTerminal(40, 18, { isProcessTerminal: true });
+					const term = new VirtualTerminal(40, 18, { isProcessTerminal: testCase.isProcessTerminal ?? true });
 					const ui = new TUI(term);
 					ui.setClearOnShrink(clearOnShrink);
 					const chatContainer = new Container();
@@ -121,7 +164,31 @@ describe("EventController completion viewport", () => {
 					});
 					const pendingMessagesContainer = new Container();
 					const statusContainer = new Container();
-					statusContainer.addChild(new Text("working", 0, 0));
+					const loadingAnimation = testCase.noInitialLoader
+						? undefined
+						: new Loader(
+								ui,
+								value => value,
+								value => value,
+								testCase.initialLoaderMessage ?? "working",
+								testCase.initialSpinnerFrames ?? ["|"],
+							);
+					if (loadingAnimation) statusContainer.addChild(loadingAnimation);
+					const residualStatus = testCase.residualStatus ? new Text("independent status", 0, 0) : undefined;
+					if (residualStatus) statusContainer.addChild(residualStatus);
+					const retryLoader = testCase.initialRetryLoader
+						? new Loader(
+								ui,
+								value => value,
+								value => value,
+								"retrying",
+								["|"],
+							)
+						: undefined;
+					if (retryLoader) statusContainer.addChild(retryLoader);
+					const retainedStatus = [residualStatus, retryLoader].filter(
+						(component): component is Text | Loader => component !== undefined,
+					);
 					const todoContainer = new Container();
 					const btwContainer = new Container();
 					const statusLine = new Text("status", 0, 0);
@@ -135,8 +202,25 @@ describe("EventController completion viewport", () => {
 					ui.addChild(statusLine);
 					ui.addChild(editor);
 					ui.setBottomPinnedComponent(statusLine);
-					const stopLoading = vi.fn();
-					const ctx = {
+					const initialFootprint = loadingAnimation?.render(term.columns).map(() => "");
+					let expectedFootprint = initialFootprint ?? retryLoader?.render(term.columns).map(() => "");
+					let expectedFootprintCount = 1;
+					if (testCase.expectEmptyLoader) expect(initialFootprint).toEqual([""]);
+					let replacementLoader: Loader | undefined;
+					let ctx: InteractiveModeContext;
+					const ensureLoadingAnimation = (): void => {
+						if (ctx.loadingAnimation) return;
+						replacementLoader = new Loader(
+							ui,
+							value => value,
+							value => value,
+							"working",
+							["|"],
+						);
+						ctx.loadingAnimation = replacementLoader;
+						statusContainer.addChild(replacementLoader);
+					};
+					ctx = {
 						isInitialized: true,
 						ui,
 						chatContainer,
@@ -149,7 +233,9 @@ describe("EventController completion viewport", () => {
 						getUserMessageText: (userMessage: { content: string }) => userMessage.content,
 						streamingComponent,
 						streamingMessage: startMessage,
-						loadingAnimation: { stop: stopLoading },
+						loadingAnimation,
+						ensureLoadingAnimation,
+						retryLoader,
 						pendingTools: new Map(),
 						planModeController: { flushPendingModelSwitch: async () => {} },
 						updateEditorTopBorder: () => {},
@@ -157,6 +243,8 @@ describe("EventController completion viewport", () => {
 						session: {
 							isTtsrAbortPending: false,
 							retryAttempt: 0,
+							retryNow: () => {},
+							abortRetry: () => {},
 							isCompacting: true,
 							getLastAssistantMessage: () => message,
 						},
@@ -184,27 +272,199 @@ describe("EventController completion viewport", () => {
 						);
 						expect(beforeHistory.length, JSON.stringify(before)).toBeGreaterThanOrEqual(3);
 						term.clearWriteLog();
+						if (testCase.testActiveLoaderRetry) {
+							if (!loadingAnimation || !residualStatus) {
+								throw new Error("active retry case requires loading and residual status");
+							}
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 1,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const activeRetryLoader = ctx.retryLoader;
+							expect(activeRetryLoader).toBeDefined();
+							if (!activeRetryLoader) throw new Error("retry start did not install a loader");
+							expect(ctx.loadingAnimation).toBeUndefined();
+							expect(statusContainer.children).toEqual([residualStatus, activeRetryLoader]);
+							term.clearWriteLog();
+
+							await controller.handleEvent({ type: "auto_retry_end", success: true, attempt: 1 });
+							await term.waitForRender();
+							expect(ctx.retryLoader).toBeUndefined();
+							const retryFootprint = activeRetryLoader.render(term.columns).map(() => "");
+							if (term.isProcessTerminal) {
+								expectedFootprint = retryFootprint;
+								expect(statusContainer.render(term.columns)).toEqual([
+									...residualStatus.render(term.columns),
+									...retryFootprint,
+								]);
+								const afterRetryEnd = term.getViewport().map(line => line.trimEnd());
+								for (const entry of beforeHistory) expect(afterRetryEnd[entry.index]).toBe(entry.line);
+								for (const entry of beforeHistory) {
+									expect(term.getWriteLog().join("")).not.toContain(entry.line);
+								}
+								// Resumed turn after a successful retry: a fresh working
+								// loader appears; completion must retain both the retry
+								// footprint and the resumed loader's footprint so the
+								// status area never contracts.
+								ctx.ensureLoadingAnimation();
+								await term.waitForRender();
+								const resumedLoader = ctx.loadingAnimation;
+								expect(resumedLoader).toBeDefined();
+								if (!resumedLoader) throw new Error("resume did not install a loader");
+								expect(statusContainer.children).toHaveLength(3);
+								expectedFootprint = [...retryFootprint, ...resumedLoader.render(term.columns).map(() => "")];
+								expectedFootprintCount = 2;
+							} else {
+								expect(statusContainer.children).toEqual([residualStatus]);
+							}
+						}
 						await controller.handleEvent({ type: "message_end", message });
 						expect(getSessionMessageViewportAnchorId(message)).toBe(anchorId);
 						await term.waitForRender();
+						term.clearWriteLog();
 						await controller.handleEvent({ type: "agent_end", messages: [message] });
 						await term.waitForRender();
-						expect(stopLoading, `${testCase.label} clear=${clearOnShrink}`).toHaveBeenCalledTimes(1);
 						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBeUndefined();
-						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(0);
-						const after = term.getViewport().map(line => line.trimEnd());
-						for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
-						const writes = term.getWriteLog().join("");
-						expect(writes).not.toContain("\x1b[2J\x1b[H");
-						expect(writes).not.toContain("\x1b[3J");
-						const visibleHistoryNumbers = beforeHistory.flatMap(entry => {
-							const match = /history-(\d+)/.exec(entry.line);
-							return match ? [Number(match[1])] : [];
-						});
-						const firstVisibleHistory = Math.min(...visibleHistoryNumbers);
-						for (let index = 0; index < firstVisibleHistory; index++) {
-							expect(writes).not.toMatch(new RegExp(`history-${index}(?!\\d)`));
+						if (term.isProcessTerminal && expectedFootprint) {
+							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(
+								(residualStatus ? 1 : 0) + expectedFootprintCount,
+							);
+							if (residualStatus) expect(statusContainer.children[0]).toBe(residualStatus);
+							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual([
+								...(residualStatus ? residualStatus.render(term.columns) : []),
+								...expectedFootprint,
+							]);
+							const after = term.getViewport().map(line => line.trimEnd());
+							for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
+							const writes = term.getWriteLog().join("");
+							expect(writes).not.toContain("\x1b[2J\x1b[H");
+							expect(writes).not.toContain("\x1b[3J");
+							for (const entry of beforeHistory) {
+								expect(writes, `${testCase.label} clear=${clearOnShrink}`).not.toContain(entry.line);
+							}
+							const visibleHistoryNumbers = beforeHistory.flatMap(entry => {
+								const match = /history-(\d+)/.exec(entry.line);
+								return match ? [Number(match[1])] : [];
+							});
+							const firstVisibleHistory = Math.min(...visibleHistoryNumbers);
+							for (let index = 0; index < firstVisibleHistory; index++) {
+								expect(writes).not.toMatch(new RegExp(`history-${index}(?!\\d)`));
+							}
+						} else {
+							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toEqual(
+								retryLoader
+									? [residualStatus].filter((component): component is Text => component !== undefined)
+									: retainedStatus,
+							);
+							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual(
+								(retryLoader ? [residualStatus] : retainedStatus)
+									.filter((component): component is Text | Loader => component !== undefined)
+									.flatMap(component => component.render(term.columns)),
+							);
 						}
+						if (retryLoader) {
+							await controller.handleEvent({ type: "agent_start" });
+							await term.waitForRender();
+							if (!residualStatus) throw new Error("retry ownership case requires residual status");
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 1,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const firstRetryLoader = ctx.retryLoader;
+							expect(firstRetryLoader).toBeDefined();
+							if (!firstRetryLoader) throw new Error("retry start did not install a loader");
+							expect(statusContainer.children).toEqual([residualStatus, firstRetryLoader]);
+
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 2,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const secondRetryLoader = ctx.retryLoader;
+							expect(secondRetryLoader).toBeDefined();
+							if (!secondRetryLoader) throw new Error("repeated retry start did not replace the loader");
+							expect(secondRetryLoader).not.toBe(firstRetryLoader);
+							expect(statusContainer.children).toEqual([residualStatus, secondRetryLoader]);
+
+							await controller.handleEvent({ type: "auto_retry_end", success: true, attempt: 2 });
+							await term.waitForRender();
+							expect(ctx.retryLoader).toBeUndefined();
+							const retryFootprint = secondRetryLoader.render(term.columns).map(() => "");
+							if (term.isProcessTerminal) {
+								expectedFootprint = retryFootprint;
+								expect(statusContainer.render(term.columns)).toEqual([
+									...residualStatus.render(term.columns),
+									...retryFootprint,
+								]);
+							} else {
+								expect(statusContainer.children).toEqual([residualStatus]);
+							}
+						}
+
+						if (term.isProcessTerminal && expectedFootprint) {
+							const completionChildren = [...statusContainer.children];
+							await controller.handleEvent({ type: "agent_end", messages: [message] });
+							await term.waitForRender();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} duplicate completion`,
+							).toEqual(completionChildren);
+						}
+						term.clearWriteLog();
+						await controller.handleEvent({ type: "agent_start" });
+						await term.waitForRender();
+						expect(replacementLoader, `${testCase.label} clear=${clearOnShrink}`).toBeDefined();
+						if (!replacementLoader) throw new Error("agent start did not replace the completion footprint");
+						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBe(replacementLoader);
+						if (retryLoader) expect(ctx.retryLoader).toBeUndefined();
+						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toEqual(
+							residualStatus ? [residualStatus, replacementLoader] : [replacementLoader],
+						);
+						const rapidEnd = controller.handleEvent({ type: "agent_end", messages: [message] });
+						const rapidStart = controller.handleEvent({ type: "agent_start" });
+						await Promise.all([rapidEnd, rapidStart]);
+						await term.waitForRender();
+						expect(
+							ctx.loadingAnimation,
+							`${testCase.label} clear=${clearOnShrink} rapid lifecycle`,
+						).toBeDefined();
+						expect(
+							statusContainer.children,
+							`${testCase.label} clear=${clearOnShrink} rapid lifecycle`,
+						).toHaveLength(residualStatus ? 2 : 1);
+
+						for (let cycle = 0; cycle < 3; cycle++) {
+							await controller.handleEvent({ type: "agent_end", messages: [message] });
+							await term.waitForRender();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} completion`,
+							).toHaveLength((term.isProcessTerminal ? 1 : 0) + (residualStatus ? 1 : 0));
+
+							await controller.handleEvent({ type: "agent_start" });
+							await term.waitForRender();
+							expect(
+								ctx.loadingAnimation,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} restart`,
+							).toBeDefined();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} restart`,
+							).toHaveLength(residualStatus ? 2 : 1);
+						}
+
+						ctx.loadingAnimation?.stop();
 						term.clearWriteLog();
 						ui.requestRender();
 						await term.waitForRender();
@@ -217,5 +477,142 @@ describe("EventController completion viewport", () => {
 				}
 			}
 		}
+	}, 30_000);
+	it("serializes completion before a successor start and ignores duplicate completion effects", async () => {
+		const term = new VirtualTerminal(40, 18, { isProcessTerminal: false });
+		const ui = new TUI(term);
+		const statusContainer = new Container();
+		const loadingAnimation = new Loader(
+			ui,
+			value => value,
+			value => value,
+			"working",
+			["|"],
+		);
+		statusContainer.addChild(loadingAnimation);
+		const flushStarted = Promise.withResolvers<void>();
+		const flushGate = Promise.withResolvers<void>();
+		let flushes = 0;
+		let ctx: InteractiveModeContext;
+		const successorTool = new Text("successor tool", 0, 0);
+		const ensureLoadingAnimation = (): void => {
+			if (ctx.loadingAnimation) return;
+			ctx.loadingAnimation = new Loader(
+				ui,
+				value => value,
+				value => value,
+				"successor working",
+				["|"],
+			);
+			statusContainer.addChild(ctx.loadingAnimation);
+			ctx.pendingTools.set("successor", successorTool as never);
+		};
+		ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer,
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "" },
+			loadingAnimation,
+			ensureLoadingAnimation,
+			pendingTools: new Map([["predecessor", new Text("predecessor tool", 0, 0) as never]]),
+			planModeController: {
+				flushPendingModelSwitch: async () => {
+					flushes++;
+					flushStarted.resolve();
+					await flushGate.promise;
+				},
+			},
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			session: {
+				isCompacting: true,
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+
+		const controller = new EventController(ctx);
+		const ending = controller.handleEvent({ type: "agent_end", messages: [] });
+		await flushStarted.promise;
+		const starting = controller.handleEvent({ type: "agent_start" });
+		await Promise.resolve();
+		expect(ctx.loadingAnimation).toBeUndefined();
+
+		flushGate.resolve();
+		await Promise.all([ending, starting]);
+		expect(ctx.loadingAnimation).toBeDefined();
+		expect(ctx.pendingTools.has("predecessor")).toBe(false);
+		expect(ctx.pendingTools.has("successor")).toBe(true);
+
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		expect(flushes).toBe(2);
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		expect(flushes).toBe(2);
+		ctx.loadingAnimation?.stop();
+	});
+	it("uses the active retry loader for direct completion cleanup and footprint", async () => {
+		const term = new VirtualTerminal(20, 8, { isProcessTerminal: true });
+		const ui = new TUI(term);
+		const statusContainer = new Container();
+		const residualStatus = new Text("independent status", 0, 0);
+		const loadingAnimation = new Loader(
+			ui,
+			value => value,
+			value => value,
+			"working",
+			["|"],
+		);
+		statusContainer.addChild(loadingAnimation);
+		statusContainer.addChild(residualStatus);
+		const originalEscape = (): void => {};
+		const ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer,
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "", onEscape: originalEscape },
+			loadingAnimation,
+			ensureLoadingAnimation: () => {},
+			pendingTools: new Map(),
+			planModeController: { flushPendingModelSwitch: async () => {} },
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			session: {
+				isCompacting: true,
+				retryNow: () => {},
+				abortRetry: () => {},
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+
+		const controller = new EventController(ctx);
+		await controller.handleEvent({
+			type: "auto_retry_start",
+			attempt: 1,
+			maxAttempts: 3,
+			delayMs: 10_000,
+			errorMessage: "retry",
+		});
+		const retryLoader = ctx.retryLoader;
+		expect(retryLoader).toBeDefined();
+		if (!retryLoader) throw new Error("retry start did not install a loader");
+		const retryFootprint = retryLoader.render(term.columns).map(() => "");
+		expect(ctx.retryCountdownTimer).toBeDefined();
+		expect(ctx.editor.onEscape).not.toBe(originalEscape);
+
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+
+		expect(ctx.retryLoader).toBeUndefined();
+		expect(ctx.retryCountdownTimer).toBeUndefined();
+		expect(ctx.editor.onEscape).toBe(originalEscape);
+		expect(statusContainer.render(term.columns)).toEqual([...residualStatus.render(term.columns), ...retryFootprint]);
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 - Suppressed slash-command and skill autocomplete inside line-local single-backtick code spans while preserving path completion and ordinary slash matching outside literals (#2619).
 
+### Fixed
+
+- Added `Loader.createFootprint()` so callers can retain a stopped loader's exact, width-dependent blank render footprint instead of coupling transient layout stability to a fixed row count.
 ## [0.11.0] - 2026-07-15
 ### Fixed
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -42,9 +42,9 @@
 		"marked": "catalog:"
 	},
 	"devDependencies": {
-		"chalk": "catalog:",
 		"@xterm/headless": "catalog:",
-		"node-pty": "^1.0.0"
+		"chalk": "catalog:",
+		"node-pty": "1.2.0-beta.14"
 	},
 	"engines": {
 		"bun": ">=1.3.14"

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -1,5 +1,5 @@
 import { type AnimationRegistration, registerAnimationCallback } from "../animation-scheduler";
-import type { TUI } from "../tui";
+import type { Component, TUI } from "../tui";
 import { sliceByColumn, visibleWidth } from "../utils";
 import { Text } from "./text";
 
@@ -43,6 +43,19 @@ export class Loader extends Text {
 			this.#frames = spinnerFrames;
 		}
 		this.start();
+	}
+
+	/**
+	 * Retains this loader's current render footprint without retaining its visible
+	 * status text. Use after stopping a loader when removing rows would repaint an
+	 * inline terminal viewport.
+	 */
+	createFootprint(): Component {
+		const snapshot = new Text(this.getText(), 1, 0);
+		return {
+			render: width => ["", ...snapshot.render(width)].map(() => ""),
+			invalidate: () => {},
+		};
 	}
 
 	render(width: number): string[] {

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -28,6 +28,41 @@ describe("Loader component", () => {
 		loader.stop();
 		tui.stop();
 	});
+	it("preserves a frozen ANSI and Unicode footprint through resize reflow", () => {
+		const term = new VirtualTerminal(40, 4);
+		const tui = new TUI(term);
+		const loader = new Loader(
+			tui,
+			text => `\x1b[36m${text}\x1b[0m`,
+			text => `\x1b[35m${text}\x1b[0m`,
+			"한글🙂 e\u0301 café — wrapping status",
+			["|"],
+		);
+
+		const footprint = loader.createFootprint();
+		const expectedLineCounts = new Map([
+			[1, 30],
+			[2, 30],
+			[3, 30],
+			[4, 17],
+			[7, 10],
+			[16, 5],
+			[40, 2],
+		]);
+		for (const [width, count] of expectedLineCounts) {
+			term.resize(width, 4);
+			expect(footprint.render(term.columns)).toEqual(Array.from({ length: count }, () => ""));
+		}
+
+		loader.setMessage("A different status that would wrap differently");
+		for (const [width, count] of expectedLineCounts) {
+			term.resize(width, 4);
+			expect(footprint.render(term.columns)).toEqual(Array.from({ length: count }, () => ""));
+		}
+
+		loader.stop();
+		tui.stop();
+	});
 
 	it("unrefs its animation interval so it does not keep the event loop alive", () => {
 		const term = new VirtualTerminal(20, 4);

--- a/packages/tui/test/pty/mouse-pty-driver.mjs
+++ b/packages/tui/test/pty/mouse-pty-driver.mjs
@@ -1,0 +1,121 @@
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import * as url from "node:url";
+import * as pty from "node-pty";
+
+const scenario = process.argv[2];
+const bunBinary = process.env.BUN_BINARY;
+const testDir = path.dirname(url.fileURLToPath(import.meta.url));
+const fixture = path.join(testDir, "mouse-pty-fixture.ts");
+const baseEnv = Object.fromEntries(Object.entries(process.env).filter(([, value]) => value !== undefined));
+const MULTIPLEXER_ENV_KEYS = ["TMUX", "TMUX_PANE", "STY", "ZELLIJ", "GJC_TMUX_LAUNCHED"];
+
+
+if (!bunBinary) throw new Error("BUN_BINARY must identify the Bun executable that runs the PTY fixture.");
+if (!scenario) throw new Error("A PTY scenario is required.");
+
+
+function launchFixture(env = {}) {
+	const scenarioEnv = { ...baseEnv, TERM: "xterm-256color" };
+	for (const key of MULTIPLEXER_ENV_KEYS) delete scenarioEnv[key];
+
+	let captured = "";
+	const terminal = pty.spawn("/bin/sh", ["-c", 'exec "$1" "$2"', "pty-fixture", bunBinary, fixture], {
+		name: "xterm-256color",
+		cols: 80,
+		rows: 24,
+		cwd: process.cwd(),
+		env: { ...scenarioEnv, ...env },
+	});
+	terminal.onData(data => {
+		captured += data;
+	});
+	terminal.onExit(event => {
+		captured += `\nPTY_FIXTURE_EXIT:${event.exitCode}:${event.signal}\n`;
+	});
+	return { terminal, output: () => captured };
+}
+
+
+async function waitForOutput(output, marker) {
+	const deadline = Date.now() + 3_000;
+	while (!output().includes(marker)) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${JSON.stringify(marker)}; output: ${JSON.stringify(output())}`);
+		await new Promise(resolve => setTimeout(resolve, 10));
+	}
+}
+
+async function run() {
+	if (scenario === "plain-enable") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			assert.match(output(), /\x1b\[\?1000h/);
+			assert.match(output(), /\x1b\[\?1006h/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "graceful-stop") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.write("__exit__\r");
+			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
+			assert.match(output(), /\x1b\[\?1000l/);
+			assert.match(output(), /\x1b\[\?1006l/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "sigterm") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.kill("SIGTERM");
+			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
+			assert.match(output(), /\x1b\[\?1000l/);
+			assert.match(output(), /\x1b\[\?1006l/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "multiplexer") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1", TMUX: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			assert.doesNotMatch(output(), /\x1b\[\?1000h/);
+			assert.doesNotMatch(output(), /\x1b\[\?1006h/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "composer") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		const mouse = "\x1b[<0;3;4M";
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.write("composer");
+			await waitForOutput(output, 'EDITOR:"composer"');
+			terminal.write(mouse);
+			terminal.write("!");
+			await waitForOutput(output, 'EDITOR:"composer!"');
+			assert.equal(output().includes(mouse), false);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	throw new Error(`Unknown PTY scenario: ${scenario}`);
+}
+
+await run();

--- a/packages/tui/test/pty/mouse-pty-matrix.test.ts
+++ b/packages/tui/test/pty/mouse-pty-matrix.test.ts
@@ -1,148 +1,56 @@
 import { describe, expect, test } from "bun:test";
-import { resolve } from "node:path";
-import type { IPty } from "node-pty";
+import * as path from "node:path";
 
 const enabled = process.env.PI_TUI_PTY_TESTS === "1";
-const fixture = resolve(import.meta.dir, "mouse-pty-fixture.ts");
-const baseEnv = Object.fromEntries(
-	Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-);
+const driver = path.resolve(import.meta.dir, "mouse-pty-driver.mjs");
+const nodeBinary = process.env.NODE_BINARY ?? "node";
 
-type PtyModule = typeof import("node-pty");
-
-let pty: PtyModule | undefined;
-let capabilityReason = "PTY capability probe was not run.";
-
-async function probePtyCapability(): Promise<boolean> {
-	try {
-		pty = await import("node-pty");
-		const probe = pty.spawn("/bin/sh", ["-c", "exit 0"], {
-			name: "xterm-256color",
-			cols: 80,
-			rows: 24,
-			cwd: process.cwd(),
-			env: { ...baseEnv, TERM: "xterm-256color" },
-		});
-		const exited = await new Promise<boolean>(resolveProbe => {
-			const timeout = setTimeout(() => resolveProbe(false), 1_000);
-			probe.onExit(() => {
-				clearTimeout(timeout);
-				resolveProbe(true);
-			});
-		});
-		if (!exited) {
-			probe.kill();
-			capabilityReason = "node-pty capability probe timed out waiting for /bin/sh to exit.";
-			return false;
-		}
-		return true;
-	} catch (error) {
-		capabilityReason = `node-pty capability probe failed: ${error instanceof Error ? error.message : String(error)}`;
-		return false;
-	}
-}
-
-const ptyAvailable = enabled && process.platform !== "win32" ? await probePtyCapability() : false;
-
-function launchFixture(env: Record<string, string> = {}): { terminal: IPty; output: () => string } {
-	if (!pty) throw new Error(capabilityReason);
-	let captured = "";
-	const terminal = pty.spawn("/bin/sh", ["-c", 'exec "$1" "$2"', "pty-fixture", process.execPath, fixture], {
-		name: "xterm-256color",
-		cols: 80,
-		rows: 24,
+async function runScenario(scenario: string, environment: Record<string, string> = {}): Promise<void> {
+	const child = Bun.spawn([nodeBinary, driver, scenario], {
 		cwd: process.cwd(),
-		env: { ...baseEnv, TERM: "xterm-256color", ...env },
+		env: { ...process.env, ...environment, BUN_BINARY: process.execPath },
+		stdout: "pipe",
+		stderr: "pipe",
 	});
-	terminal.onData(data => {
-		captured += data;
-	});
-	terminal.onExit(event => {
-		captured += `\nPTY_FIXTURE_EXIT:${event.exitCode}:${event.signal}\n`;
-	});
-	return { terminal, output: () => captured };
-}
-
-async function waitForOutput(output: () => string, marker: string): Promise<void> {
-	const deadline = Date.now() + 3_000;
-	while (!output().includes(marker)) {
-		if (Date.now() >= deadline)
-			throw new Error(`Timed out waiting for ${JSON.stringify(marker)}; output: ${JSON.stringify(output())}`);
-		await Bun.sleep(10);
-	}
+	const [exitCode, stdout, stderr] = await Promise.all([
+		child.exited,
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	expect(exitCode, `${stderr}\n${stdout}`).toBe(0);
 }
 
 /**
- * POSIX-only integration lane. Terminal ownership is intentionally exercised in
- * CI where node-pty can allocate a real pseudo terminal; normal unit tests do
- * not require native PTY bindings.
+ * POSIX-only integration lane. node-pty's native callbacks are driven by Node,
+ * while the fixture itself runs under Bun and exercises ProcessTerminal.
  */
 describe.skipIf(!enabled || process.platform === "win32")("mouse PTY matrix", () => {
-	test("requires a usable PTY capability when explicitly enabled", () => {
-		expect(ptyAvailable, capabilityReason).toBe(true);
-	});
 	test("emits SGR mouse enable bytes in a plain xterm PTY", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			expect(output()).toContain("\x1b[?1000h");
-			expect(output()).toContain("\x1b[?1006h");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("plain-enable");
+	});
+	test("isolates plain scenarios from inherited multiplexer markers", async () => {
+		await runScenario("plain-enable", {
+			TMUX: "/tmp/tmux,1,0",
+			TMUX_PANE: "%42",
+			STY: "screen",
+			ZELLIJ: "zellij",
+			GJC_TMUX_LAUNCHED: "1",
+		});
 	});
 
 	test("emits SGR mouse disable bytes on graceful stop", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.write("__exit__\r");
-			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
-			expect(output()).toContain("\x1b[?1000l");
-			expect(output()).toContain("\x1b[?1006l");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("graceful-stop");
 	});
 
 	test("restores SGR mouse modes when SIGTERM detaches the TUI", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.kill("SIGTERM");
-			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
-			expect(output()).toContain("\x1b[?1000l");
-			expect(output()).toContain("\x1b[?1006l");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("sigterm");
 	});
 
 	test("emits no SGR mouse enable bytes under a multiplexer", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1", TMUX: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			expect(output()).not.toContain("\x1b[?1000h");
-			expect(output()).not.toContain("\x1b[?1006h");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("multiplexer");
 	});
 
 	test("does not leak SGR mouse reports into composer text", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		const mouse = "\x1b[<0;3;4M";
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.write("composer");
-			await waitForOutput(output, 'EDITOR:"composer"');
-			terminal.write(mouse);
-			terminal.write("!");
-			await waitForOutput(output, 'EDITOR:"composer!"');
-			expect(output()).toContain('EDITOR:"composer!"');
-			expect(output()).not.toContain(mouse);
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("composer");
 	});
 });


### PR DESCRIPTION
## Problem

On a native `ProcessTerminal` the TUI cannot query the user's scrollback position. When a turn completed, the status container was cleared, contracting the bottom status area. That contraction forces a repaint that can replace transcript rows the user is currently browsing.

Previous attempts (#2627, #2628, #2633, #2637) fixed surfaces of this one at a time and each left a path that still contracted. This PR fixes the root causes together:

## Fix

- **Serialize session events** (`EventController.handleEvent` chains on an internal queue) so a completion can no longer interleave with a successor turn's start, and duplicate `agent_end` events are ignored (`#completionHandled`).
- **Accumulating completion footprints**: every working/retry loader that is removed while visible leaves an exact blank footprint (`Loader.createFootprint()`, width-aware snapshot). Footprints accumulate within a turn — including turns that resume after a successful auto-retry — so the status area never contracts; the next `agent_start` clears them.
- `ensureLoadingAnimation` no longer clears the status container, so independently owned status components survive completion and loader restarts.
- Removed the suspended-loader bookkeeping that previously dropped the resumed working loader's rows after auto-retry recovery.

## Tests

- `event-controller-completion-viewport.test.ts`: full completion lifecycle across terminal hosts (ssh/tmux/legacy/termux/windows/virtual), resize reflow, duplicate completion, rapid end/start, retry recovery with turn resume (regression for the auto-retry contraction), independent status ownership.
- `loader.test.ts`: frozen ANSI/Unicode footprint through resize reflow (CJK/emoji/combining chars).
- PTY matrix rewritten onto a reusable Node driver (`mouse-pty-driver.mjs`); requires `node-pty@1.2.0-beta.14` (devDependency pin, opt-in lane via `PI_TUI_PTY_TESTS=1` — passes 6/6 locally).

## Verification

- tui package: 812 pass / 0 fail
- event-controller + interactive-mode adjacent suites: 156 pass / 0 fail
- biome clean, declaration typecheck across all packages
