### PR TITLE
fix(coding-agent): recover malformed Round 0 intent asks

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -709,10 +709,17 @@ export type TSchema = ZodType | TJsonSchema;
 /** Resolve parameter types for tool execution / handlers. */
 export type Static<S> = S extends ZodType ? z.infer<S> : S extends { static: infer T } ? T : unknown;
 
+export type RawArgumentValidationResult =
+	| { outcome: "passthrough" }
+	| { outcome: "accept"; arguments: ToolCall["arguments"] }
+	| { outcome: "reject" };
+
 export interface Tool<TParameters extends TSchema = TSchema> {
 	name: string;
 	description: string;
 	parameters: TParameters;
+	/** Optional pre-coercion adapter for narrowly scoped raw argument recovery or rejection. */
+	rawArgumentValidation?: (arguments_: ToolCall["arguments"]) => RawArgumentValidationResult;
 	/** If true, tool is strictly typed and validated against the parameters schema before execution */
 	strict?: boolean;
 	/**

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -967,13 +967,18 @@ export function validateToolCall(tools: Tool[], toolCall: ToolCall): ToolCall["a
  */
 export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall["arguments"] {
 	const originalArgs = toolCall.arguments;
+	const rawValidation = tool.rawArgumentValidation?.(originalArgs);
+	if (rawValidation?.outcome === "reject") {
+		throw new Error(`Validation failed for tool "${toolCall.name}": raw arguments rejected before coercion`);
+	}
+	const rawArgs = rawValidation?.outcome === "accept" ? rawValidation.arguments : originalArgs;
 	const ctx = getValidationContext(tool);
 	const { json } = ctx;
 
 	// Always normalize first — strip null and string "null" from optional
 	// fields and substitute defaults. Handles LLM outputting string "null"
 	// to mean "no value" even when validation would otherwise pass.
-	let normalizedArgs: unknown = originalArgs;
+	let normalizedArgs: unknown = rawArgs;
 	let changed = false;
 	const initialNormalization = normalizeOptionalNullsForSchema(json, normalizedArgs);
 	if (initialNormalization.changed) {

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -970,4 +970,26 @@ describe("Tool argument coercion", () => {
 		const result = validateToolArguments(tool, toolCall) as Record<string, unknown>;
 		expect(result.op).toBe("fix");
 	});
+	it("runs an opt-in raw argument adapter before null normalization and terminal rejection", () => {
+		let observed: unknown;
+		const tool: Tool = {
+			name: "raw-adapter",
+			description: "",
+			parameters: z.object({ value: z.string().optional() }),
+			rawArgumentValidation: arguments_ => {
+				observed = arguments_.value;
+				return arguments_.value === "null" ? { outcome: "reject" } : { outcome: "passthrough" };
+			},
+		};
+
+		expect(() =>
+			validateToolArguments(tool, {
+				type: "toolCall",
+				id: "call-raw-adapter",
+				name: "raw-adapter",
+				arguments: { value: "null" },
+			}),
+		).toThrow("raw arguments rejected before coercion");
+		expect(observed).toBe("null");
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Workflow-state handoff no longer self-locks the active-state cache, so a same-turn skill handoff (e.g. ultragoal → ralplan) completes instead of stalling behind a lock the handoff itself still holds (#2638).
+- Malformed spurious Round-0 review metadata no longer blocks an otherwise valid locked-intent question/gate, while durable intent safety remains fail-closed (#2643).
 - SDK host shutdown now retries a failed broker unregister instead of short-circuiting with a stale broker-index entry, while retained startup-cleanup owner-release failures remain isolated from the red extension-error path (#2625).
 - Non-TTY launches now fail fast when stdin is empty and automatically use print mode for positional prompts and `@file` inputs, preventing orphaned interactive TUI processes (#2507).
 

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -16,6 +16,7 @@
  */
 
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
+import type { RawArgumentValidationResult } from "@gajae-code/ai/types";
 import {
 	type Component,
 	Container,
@@ -109,36 +110,40 @@ const DeepInterviewIntentReview = z
 	.strict();
 
 /** Optional structured deep-interview round metadata; when present the round is recorded automatically. */
-const DeepInterviewMeta = z
-	.object({
-		round_id: z.string().max(128).describe("stable optional round identity").optional(),
-		round: z.number().int().nonnegative().describe("round number"),
-		component: z.string().min(1).max(128).describe("targeted topology component"),
-		dimension: z.string().min(1).max(128).describe("targeted clarity dimension"),
-		ambiguity: z.number().min(0).max(1).describe("ambiguity at ask time (0..1)"),
-		intent_contract: DeepInterviewIntentContract.describe("Round-0 locked intent contract").optional(),
-		intent_review: DeepInterviewIntentReview.describe("Locked-intent reduction review").optional(),
-	})
-	.strict()
-	.superRefine((value, context) => {
-		if (
-			value.intent_contract &&
-			(value.round !== 0 || value.component !== "review-topology" || value.dimension !== "topology")
-		)
-			context.addIssue({
-				code: "custom",
-				message: "intent_contract requires Round 0 review-topology metadata",
-				path: ["intent_contract"],
-			});
-		if (value.intent_review && value.round === 0)
-			context.addIssue({
-				code: "custom",
-				message: "intent_review requires a post-Round-0 answer",
-				path: ["intent_review"],
-			});
-		if (value.intent_contract && value.intent_review)
-			context.addIssue({ code: "custom", message: "intent_contract and intent_review are mutually exclusive" });
-	});
+const DeepInterviewMetadata = z.object({
+	round_id: z.string().max(128).describe("stable optional round identity").optional(),
+	round: z.number().int().nonnegative().describe("round number"),
+	component: z.string().min(1).max(128).describe("targeted topology component"),
+	dimension: z.string().min(1).max(128).describe("targeted clarity dimension"),
+	ambiguity: z.number().min(0).max(1).describe("ambiguity at ask time (0..1)"),
+});
+
+/** Provider-visible branches keep ordinary, contract, and review metadata mutually exclusive. */
+const DeepInterviewMeta = z.union([
+	DeepInterviewMetadata.strict(),
+	DeepInterviewMetadata.extend({
+		round: z.literal(0).describe("round number"),
+		component: z.literal("review-topology").describe("targeted topology component"),
+		dimension: z.literal("topology").describe("targeted clarity dimension"),
+		intent_contract: DeepInterviewIntentContract.describe("Round-0 locked intent contract"),
+	}).strict(),
+	DeepInterviewMetadata.extend({
+		round: z.number().int().positive().describe("round number"),
+		intent_review: DeepInterviewIntentReview.describe("Locked-intent reduction review"),
+	}).strict(),
+]);
+
+type DeepInterviewMeta = z.infer<typeof DeepInterviewMeta>;
+
+function intentContract(
+	metadata: DeepInterviewMeta | undefined,
+): z.infer<typeof DeepInterviewIntentContract> | undefined {
+	return metadata && "intent_contract" in metadata ? metadata.intent_contract : undefined;
+}
+
+function intentReview(metadata: DeepInterviewMeta | undefined): z.infer<typeof DeepInterviewIntentReview> | undefined {
+	return metadata && "intent_review" in metadata ? metadata.intent_review : undefined;
+}
 
 const WorkflowGateMeta = z.object({
 	stage: z.enum(["deep-interview", "ralplan", "ultragoal"]).describe("workflow gate stage"),
@@ -157,23 +162,25 @@ const QuestionItem = z
 	})
 	.superRefine((value, context) => {
 		const labels = new Set(value.options.map(option => option.label));
-		if ((value.deepInterview?.intent_contract || value.deepInterview?.intent_review) && value.multi === true)
+		const contract = intentContract(value.deepInterview);
+		const review = intentReview(value.deepInterview);
+		if ((contract || review) && value.multi === true)
 			context.addIssue({ code: "custom", message: "intent gates must be single-select", path: ["multi"] });
-		const confirmationOptions = value.deepInterview?.intent_contract?.confirmation_options ?? [];
+		const confirmationOptions = contract?.confirmation_options ?? [];
 		if (new Set(confirmationOptions).size !== confirmationOptions.length)
 			context.addIssue({
 				code: "custom",
 				message: "intent confirmation options must be unique",
 				path: ["deepInterview", "intent_contract"],
 			});
-		const approvalOptions = value.deepInterview?.intent_review?.approval_options ?? [];
+		const approvalOptions = review?.approval_options ?? [];
 		if (new Set(approvalOptions).size !== approvalOptions.length)
 			context.addIssue({
 				code: "custom",
 				message: "intent approval options must be unique",
 				path: ["deepInterview", "intent_review"],
 			});
-		for (const label of value.deepInterview?.intent_contract?.confirmation_options ?? []) {
+		for (const label of confirmationOptions) {
 			if (!labels.has(label))
 				context.addIssue({
 					code: "custom",
@@ -181,7 +188,7 @@ const QuestionItem = z
 					path: ["deepInterview", "intent_contract"],
 				});
 		}
-		for (const label of value.deepInterview?.intent_review?.approval_options ?? []) {
+		for (const label of approvalOptions) {
 			if (!labels.has(label))
 				context.addIssue({
 					code: "custom",
@@ -196,6 +203,173 @@ export const askSchema = z.object({
 });
 
 export type AskToolInput = z.infer<typeof askSchema>;
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+function isOnlyPlainData(value: unknown): boolean {
+	if (Array.isArray(value)) return value.every(isOnlyPlainData);
+	if (typeof value !== "object" || value === null) return true;
+	return isPlainRecord(value) && Object.values(value).every(isOnlyPlainData);
+}
+
+function hasExactOwnKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+	const keys = Reflect.ownKeys(value);
+	return keys.length === allowed.length && keys.every(key => typeof key === "string" && allowed.includes(key));
+}
+
+function hasOnlyAllowedOwnKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+	return Reflect.ownKeys(value).every(key => typeof key === "string" && allowed.includes(key));
+}
+
+function hasUniqueDisplayedLabels(labels: readonly string[], optionLabels: ReadonlySet<string>): boolean {
+	return new Set(labels).size === labels.length && labels.every(label => optionLabels.has(label));
+}
+
+/** Parse only to recognize a retired recovery shape; parsed values are never eligible for recovery. */
+function parseEncodedContainer(value: unknown): unknown {
+	if (typeof value !== "string") return value;
+	try {
+		return JSON.parse(value);
+	} catch {
+		return value;
+	}
+}
+
+/** Whether malformed input is close enough to the retired pair shape to require a terminal rejection. */
+function isRoundZeroRecoveryCandidate(value: unknown): boolean {
+	const root = parseEncodedContainer(value);
+	if (typeof root !== "object" || root === null || !Object.hasOwn(root, "questions")) return false;
+	const questionsValue = parseEncodedContainer((root as Record<string, unknown>).questions);
+	if (!Array.isArray(questionsValue)) return questionsValue === null;
+	return questionsValue.some(rawQuestion => {
+		const question = parseEncodedContainer(rawQuestion);
+		if (typeof question !== "object" || question === null || !Object.hasOwn(question, "deepInterview")) return false;
+		const deepInterview = parseEncodedContainer((question as Record<string, unknown>).deepInterview);
+		if (typeof deepInterview !== "object" || deepInterview === null) return deepInterview === null;
+		const metadata = deepInterview as Record<string, unknown>;
+		return Object.hasOwn(metadata, "intent_contract") || Object.hasOwn(metadata, "intent_review");
+	});
+}
+
+/** Remove only strict-provider null placeholders for fields optional in the canonical Ask contract. */
+function normalizeRoundZeroOptionalNulls(arguments_: Record<string, unknown>): Record<string, unknown> {
+	if (!isPlainRecord(arguments_) || !Array.isArray(arguments_.questions) || arguments_.questions.length !== 1)
+		return arguments_;
+	const question = arguments_.questions[0];
+	if (!isPlainRecord(question) || !isPlainRecord(question.deepInterview)) return arguments_;
+	const normalizedQuestion = { ...question };
+	let changed = false;
+	for (const key of ["multi", "recommended", "workflowGate"] as const) {
+		if (Object.hasOwn(normalizedQuestion, key) && normalizedQuestion[key] === null) {
+			delete normalizedQuestion[key];
+			changed = true;
+		}
+	}
+	const normalizedDeepInterview = { ...question.deepInterview };
+	if (Object.hasOwn(normalizedDeepInterview, "round_id") && normalizedDeepInterview.round_id === null) {
+		delete normalizedDeepInterview.round_id;
+		normalizedQuestion.deepInterview = normalizedDeepInterview;
+		changed = true;
+	}
+	return changed ? { ...arguments_, questions: [normalizedQuestion] } : arguments_;
+}
+function recoverRoundZeroIntentContract(arguments_: Record<string, unknown>): RawArgumentValidationResult {
+	if (!isRoundZeroRecoveryCandidate(arguments_)) return { outcome: "passthrough" };
+	const normalizedArguments = normalizeRoundZeroOptionalNulls(arguments_);
+	if (!isOnlyPlainData(normalizedArguments) || !isPlainRecord(normalizedArguments)) return { outcome: "reject" };
+	if (
+		!hasExactOwnKeys(normalizedArguments, ["questions"]) ||
+		!Array.isArray(normalizedArguments.questions) ||
+		normalizedArguments.questions.length !== 1
+	)
+		return { outcome: "reject" };
+
+	const question = normalizedArguments.questions[0];
+	if (!isPlainRecord(question)) return { outcome: "reject" };
+	const questionKeys = ["id", "question", "options", "multi", "recommended", "deepInterview", "workflowGate"];
+	if (!hasOnlyAllowedOwnKeys(question, questionKeys)) return { outcome: "reject" };
+	if (
+		typeof question.id !== "string" ||
+		typeof question.question !== "string" ||
+		!Array.isArray(question.options) ||
+		!Object.hasOwn(question, "deepInterview") ||
+		!isPlainRecord(question.deepInterview) ||
+		(Object.hasOwn(question, "multi") && question.multi !== false) ||
+		(Object.hasOwn(question, "recommended") && typeof question.recommended !== "number")
+	)
+		return { outcome: "reject" };
+	const deepInterview = question.deepInterview;
+	const hasIntentContract = Object.hasOwn(deepInterview, "intent_contract");
+	const hasIntentReview = Object.hasOwn(deepInterview, "intent_review");
+	if (hasIntentContract !== hasIntentReview && askSchema.safeParse(normalizedArguments).success)
+		return { outcome: "passthrough" };
+
+	if (
+		Object.hasOwn(question, "workflowGate") &&
+		(!isPlainRecord(question.workflowGate) ||
+			!hasExactOwnKeys(question.workflowGate, ["stage", "kind"]) ||
+			question.workflowGate.stage !== "deep-interview" ||
+			question.workflowGate.kind !== "question")
+	)
+		return { outcome: "reject" };
+
+	if (
+		!question.options.every(
+			option => isPlainRecord(option) && hasExactOwnKeys(option, ["label"]) && typeof option.label === "string",
+		)
+	)
+		return { outcome: "reject" };
+	const optionLabels = question.options.map(option => (option as { label: string }).label);
+	if (new Set(optionLabels).size !== optionLabels.length) return { outcome: "reject" };
+
+	const deepInterviewKeys = [
+		"round_id",
+		"round",
+		"component",
+		"dimension",
+		"ambiguity",
+		"intent_contract",
+		"intent_review",
+	];
+	if (
+		!hasOnlyAllowedOwnKeys(deepInterview, deepInterviewKeys) ||
+		!Object.hasOwn(deepInterview, "intent_contract") ||
+		!Object.hasOwn(deepInterview, "intent_review") ||
+		deepInterview.round !== 0 ||
+		typeof deepInterview.component !== "string" ||
+		deepInterview.component !== "review-topology" ||
+		typeof deepInterview.dimension !== "string" ||
+		deepInterview.dimension !== "topology" ||
+		typeof deepInterview.ambiguity !== "number" ||
+		(Object.hasOwn(deepInterview, "round_id") && typeof deepInterview.round_id !== "string")
+	)
+		return { outcome: "reject" };
+
+	const contract = DeepInterviewIntentContract.safeParse(deepInterview.intent_contract);
+	const review = DeepInterviewIntentReview.safeParse(deepInterview.intent_review);
+	if (!contract.success || !review.success) return { outcome: "reject" };
+	const displayedLabels = new Set(optionLabels);
+	if (
+		!hasUniqueDisplayedLabels(contract.data.confirmation_options, displayedLabels) ||
+		!hasUniqueDisplayedLabels(review.data.approval_options, displayedLabels)
+	)
+		return { outcome: "reject" };
+
+	const { intent_review: _intentReview, ...recoveredDeepInterview } = deepInterview;
+	const recovered = {
+		questions: [
+			{
+				...question,
+				deepInterview: { ...recoveredDeepInterview, intent_contract: contract.data },
+			},
+		],
+	};
+	return askSchema.safeParse(recovered).success ? { outcome: "accept", arguments: recovered } : { outcome: "reject" };
+}
 
 /** Result for a single question */
 export interface QuestionResult {
@@ -803,6 +977,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 	readonly summary = "Ask the user a clarifying question";
 	readonly description: string;
 	readonly parameters = askSchema;
+	readonly rawArgumentValidation = recoverRoundZeroIntentContract;
 	readonly strict = true;
 	readonly loadMode = "discoverable";
 
@@ -850,14 +1025,14 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 					ambiguity: meta.ambiguity,
 					selectedOptions,
 					customInput,
-					intent_contract: meta.intent_contract,
-					intent_review: meta.intent_review,
+					intent_contract: intentContract(meta),
+					intent_review: intentReview(meta),
 				},
 				{ sessionId },
 			).then(async () => {
 				await syncDeepInterviewRecorderHud(cwd, statePath, sessionId);
 			}),
-			meta.intent_contract !== undefined || meta.intent_review !== undefined,
+			intentContract(meta) !== undefined || intentReview(meta) !== undefined,
 		);
 	}
 
@@ -1190,7 +1365,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 					navigation: options?.navigation,
 					scrollTitleRows: isDeepInterviewQuestion ? DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS : undefined,
 					otherOptionLabel,
-					autoSelectOnTimeout: !q.deepInterview?.intent_contract && !q.deepInterview?.intent_review,
+					autoSelectOnTimeout: !intentContract(q.deepInterview) && !intentReview(q.deepInterview),
 					clarificationOptionLabel,
 					onRemoteState: state => {
 						activeRemoteRequest = {
@@ -1277,7 +1452,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 			}
 			if (
 				clarificationQuestion === undefined &&
-				!(timedOut && (q.deepInterview?.intent_contract || q.deepInterview?.intent_review))
+				!(timedOut && (intentContract(q.deepInterview) || intentReview(q.deepInterview)))
 			) {
 				await this.#recordDeepInterviewRound(q, selectedOptions, customInput);
 			}
@@ -1358,7 +1533,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 
 			if (
 				clarificationQuestion === undefined &&
-				!(timedOut && (q.deepInterview?.intent_contract || q.deepInterview?.intent_review))
+				!(timedOut && (intentContract(q.deepInterview) || intentReview(q.deepInterview)))
 			) {
 				await this.#recordDeepInterviewRound(q, selectedOptions, customInput);
 			}

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it, spyOn, vi } from "bun:test";
 import type { AgentToolContext } from "@gajae-code/agent-core";
+import { validateToolArguments } from "@gajae-code/ai/utils/validation";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import type { AppendOrMergeResult } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
 import * as deepInterviewRecorder from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
@@ -2613,5 +2614,248 @@ describe("AskTool deep-interview recorder persistence", () => {
 				],
 			}).success,
 		).toBe(false);
+	});
+});
+
+describe("AskTool Round-0 intent recovery", () => {
+	function roundZeroPair(workflowGate?: Record<string, unknown>) {
+		return {
+			questions: [
+				{
+					id: "round-0-intent",
+					question: "Confirm the locked intent",
+					options: [{ label: "Looks right" }, { label: "Approve reduction" }, { label: "Revise" }],
+					...(workflowGate === undefined ? {} : { workflowGate }),
+					deepInterview: {
+						round: 0,
+						component: "review-topology",
+						dimension: "topology",
+						ambiguity: 1,
+						intent_contract: {
+							items: [{ id: "artifact:report", category: "artifact", statement: "Produce a report" }],
+							confirmation_options: ["Looks right"],
+						},
+						intent_review: {
+							observed_items: [{ id: "artifact:report", category: "artifact", statement: "Produce a report" }],
+							supporting_substitutions: [],
+							approval_options: ["Approve reduction"],
+						},
+					},
+				},
+			],
+		};
+	}
+
+	function validateAsk(arguments_: Record<string, unknown>) {
+		return validateToolArguments(new AskTool(createSession()), {
+			type: "toolCall",
+			id: "ask-round-0",
+			name: "ask",
+			arguments: arguments_,
+		});
+	}
+
+	it("recovers only the canonical Round-0 pair and retains the contract", () => {
+		const result = validateAsk(roundZeroPair());
+		const deepInterview = (result.questions[0] as { deepInterview: Record<string, unknown> }).deepInterview;
+		expect(deepInterview.intent_contract).toMatchObject({ confirmation_options: ["Looks right"] });
+		expect(deepInterview.intent_review).toBeUndefined();
+	});
+
+	it("treats the explicit deep-interview question workflow gate as equivalent", () => {
+		const result = validateAsk(roundZeroPair({ stage: "deep-interview", kind: "question" }));
+		expect((result.questions[0] as { workflowGate: unknown }).workflowGate).toEqual({
+			stage: "deep-interview",
+			kind: "question",
+		});
+	});
+
+	it("normalizes strict-provider null placeholders before exact Round-0 recovery", () => {
+		const pair = roundZeroPair();
+		Object.assign(pair.questions[0], { multi: null, recommended: null, workflowGate: null });
+		Object.assign(pair.questions[0].deepInterview, { round_id: null });
+		const question = validateAsk(pair).questions[0];
+		expect(question).toMatchObject({ deepInterview: { intent_contract: expect.any(Object) } });
+		expect(question.deepInterview).not.toHaveProperty("intent_review");
+		expect(question.deepInterview).not.toHaveProperty("round_id");
+		expect(question).not.toHaveProperty("multi");
+		expect(question).not.toHaveProperty("recommended");
+		expect(question).not.toHaveProperty("workflowGate");
+	});
+
+	it("terminally rejects every recovery-shaped near-miss before coercion", () => {
+		const recorder = spyOn(deepInterviewRecorder, "appendOrMergeDeepInterviewRound");
+		const gateEmitter = { isUnattended: () => true, emitGate: vi.fn() };
+		const tool = new AskTool(
+			createSession({ hasUI: false, getWorkflowGateEmitter: () => gateEmitter } as Partial<ToolSession>),
+		);
+		const execute = spyOn(tool, "execute");
+		const validateCandidate = (arguments_: Record<string, unknown>) =>
+			validateToolArguments(tool, {
+				type: "toolCall",
+				id: "ask-round-0-rejected",
+				name: "ask",
+				arguments: arguments_,
+			});
+		const prototypeRoot = Object.assign(Object.create({ inherited: true }), roundZeroPair());
+		const prototypeQuestion = roundZeroPair();
+		prototypeQuestion.questions[0] = Object.assign(
+			Object.create({ inherited: true }),
+			prototypeQuestion.questions[0],
+		);
+		const prototypeDeep = roundZeroPair();
+		prototypeDeep.questions[0].deepInterview = Object.assign(
+			Object.create({ inherited: true }),
+			prototypeDeep.questions[0].deepInterview,
+		);
+		const extraRoot = { ...roundZeroPair(), extra: true };
+		const extraQuestion = roundZeroPair();
+		Object.assign(extraQuestion.questions[0], { extra: true });
+		const extraDeep = roundZeroPair();
+		Object.assign(extraDeep.questions[0].deepInterview, { extra: true });
+		const duplicateOptions = roundZeroPair();
+		duplicateOptions.questions[0].options = [{ label: "Looks right" }, { label: "Looks right" }];
+		const ownUndefinedGate = roundZeroPair();
+		ownUndefinedGate.questions[0].workflowGate = undefined;
+		const reviewOnlyRoundZero = roundZeroPair();
+		Reflect.deleteProperty(reviewOnlyRoundZero.questions[0].deepInterview, "intent_contract");
+		const multipleQuestions = roundZeroPair();
+		multipleQuestions.questions.push(structuredClone(multipleQuestions.questions[0]));
+		const invalidLabels = roundZeroPair();
+		invalidLabels.questions[0].deepInterview.intent_contract.confirmation_options = ["Looks right", "Looks right"];
+		const encodedRoot = JSON.stringify(roundZeroPair()) as unknown as Record<string, unknown>;
+		const encodedQuestions = roundZeroPair();
+		encodedQuestions.questions = JSON.stringify(encodedQuestions.questions) as never;
+		const encodedQuestion = roundZeroPair();
+		encodedQuestion.questions[0] = JSON.stringify(encodedQuestion.questions[0]) as never;
+		const encodedDeepInterview = roundZeroPair();
+		encodedDeepInterview.questions[0].deepInterview = JSON.stringify(
+			encodedDeepInterview.questions[0].deepInterview,
+		) as never;
+		const nullQuestions = { questions: null } as unknown as Record<string, unknown>;
+		const nullDeepInterview = roundZeroPair();
+		nullDeepInterview.questions[0].deepInterview = null as never;
+		const malformedContractOnly = roundZeroPair();
+		Reflect.deleteProperty(malformedContractOnly.questions[0].deepInterview, "intent_review");
+		malformedContractOnly.questions[0].deepInterview.round = 1;
+		const malformedReviewOnly = roundZeroPair();
+		Reflect.deleteProperty(malformedReviewOnly.questions[0].deepInterview, "intent_contract");
+		malformedReviewOnly.questions[0].deepInterview.round = 1;
+		malformedReviewOnly.questions[0].deepInterview.component = "locked-intent";
+		malformedReviewOnly.questions[0].deepInterview.dimension = "constraints";
+		malformedReviewOnly.questions[0].deepInterview.intent_review.approval_options = ["Not displayed"];
+
+		const invalidGates: unknown[] = [
+			"deep-interview/question",
+			[],
+			{ stage: "deep-interview" },
+			{ kind: "question" },
+			{ stage: "deep-interview", kind: "question", extra: true },
+			{ stage: "Deep-Interview", kind: "question" },
+			{ stage: "deep-interview ", kind: "question" },
+			{ stage: "ralplan", kind: "question" },
+			{ stage: "ralplan", kind: "approval" },
+			{ stage: "ultragoal", kind: "question" },
+			{ stage: "ultragoal", kind: "execution" },
+		];
+		const malformedIntentMetadata: unknown[] = [null, "{}", [], { items: [] }, { items: [], extra: true }];
+
+		for (const arguments_ of [
+			prototypeRoot,
+			prototypeQuestion,
+			prototypeDeep,
+			extraRoot,
+			extraQuestion,
+			extraDeep,
+			duplicateOptions,
+			ownUndefinedGate,
+			reviewOnlyRoundZero,
+			multipleQuestions,
+			invalidLabels,
+			encodedRoot,
+			encodedQuestions,
+			encodedQuestion,
+			encodedDeepInterview,
+			nullQuestions,
+			nullDeepInterview,
+			malformedContractOnly,
+			malformedReviewOnly,
+		]) {
+			expect(() => validateCandidate(arguments_)).toThrow("raw arguments rejected before coercion");
+		}
+		for (const workflowGate of invalidGates) {
+			const pair = roundZeroPair();
+			pair.questions[0].workflowGate = workflowGate as Record<string, unknown>;
+			expect(() => validateCandidate(pair)).toThrow("raw arguments rejected before coercion");
+		}
+		for (const intentContract of malformedIntentMetadata) {
+			const pair = roundZeroPair();
+			pair.questions[0].deepInterview.intent_contract = intentContract as never;
+			expect(() => validateCandidate(pair)).toThrow("raw arguments rejected before coercion");
+		}
+		for (const intentReview of malformedIntentMetadata) {
+			const pair = roundZeroPair();
+			pair.questions[0].deepInterview.intent_review = intentReview as never;
+			expect(() => validateCandidate(pair)).toThrow("raw arguments rejected before coercion");
+		}
+		expect(execute).not.toHaveBeenCalled();
+		expect(gateEmitter.emitGate).not.toHaveBeenCalled();
+		expect(recorder).not.toHaveBeenCalled();
+	});
+
+	it("recovers the canonical pair once, emits its exact gate, and records only the contract", async () => {
+		const recorder = spyOn(deepInterviewRecorder, "appendOrMergeDeepInterviewRound").mockResolvedValue({
+			action: "created",
+			record: {} as AppendOrMergeResult["record"],
+		});
+		spyOn(deepInterviewRecorder, "syncDeepInterviewRecorderHud").mockResolvedValue(undefined);
+		const gateEmitter = {
+			isUnattended: () => true,
+			emitGate: vi.fn(async () => ({ selected: ["Looks right"] })),
+		};
+		const tool = new AskTool(
+			createSession({ hasUI: false, getSessionId: () => "round-zero", getWorkflowGateEmitter: () => gateEmitter }),
+		);
+		const rawHook = spyOn(tool, "rawArgumentValidation");
+		const execute = spyOn(tool, "execute");
+		const recovered = askSchema.parse(
+			validateToolArguments(tool, {
+				type: "toolCall",
+				id: "ask-round-0-recovered",
+				name: "ask",
+				arguments: roundZeroPair(),
+			}),
+		);
+
+		await tool.execute("ask-round-0-recovered", recovered, undefined, undefined, undefined);
+
+		expect(rawHook).toHaveBeenCalledTimes(1);
+		expect(execute).toHaveBeenCalledTimes(1);
+		expect(gateEmitter.emitGate).toHaveBeenCalledTimes(1);
+		expect((gateEmitter.emitGate.mock.calls as unknown as Array<[unknown]>)[0]?.[0]).toMatchObject({
+			stage: "deep-interview",
+			kind: "question",
+		});
+		expect(recorder).toHaveBeenCalledTimes(1);
+		expect(recorder.mock.calls[0]?.[2]).toMatchObject({
+			intent_contract: { confirmation_options: ["Looks right"] },
+			intent_review: undefined,
+		});
+	});
+
+	it("leaves valid contract-only Round 0 and post-Round-0 review validation unchanged", () => {
+		const contractOnly = roundZeroPair();
+		Reflect.deleteProperty(contractOnly.questions[0].deepInterview, "intent_review");
+		expect(validateAsk(contractOnly).questions[0]).toMatchObject({
+			deepInterview: { intent_contract: expect.any(Object) },
+		});
+		const postRoundReview = roundZeroPair();
+		Reflect.deleteProperty(postRoundReview.questions[0].deepInterview, "intent_contract");
+		postRoundReview.questions[0].deepInterview.round = 1;
+		postRoundReview.questions[0].deepInterview.component = "locked-intent";
+		postRoundReview.questions[0].deepInterview.dimension = "constraints";
+		expect(validateAsk(postRoundReview).questions[0]).toMatchObject({
+			deepInterview: { intent_review: expect.any(Object) },
+		});
 	});
 });

--- a/packages/coding-agent/test/tools/issue-2643-openai-completions-wire.test.ts
+++ b/packages/coding-agent/test/tools/issue-2643-openai-completions-wire.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import { type Context, getBundledModel, type Model } from "@gajae-code/ai";
+import { streamOpenAICompletions } from "@gajae-code/ai/providers/openai-completions";
+import { toolWireSchema } from "@gajae-code/ai/utils/schema";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { createTools, type ToolSession } from "@gajae-code/coding-agent/tools";
+
+type JsonObject = Record<string, unknown>;
+
+function createTestSession(): ToolSession {
+	return {
+		cwd: "/tmp/test",
+		hasUI: true,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+	};
+}
+
+function isObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function objectsIn(value: unknown): JsonObject[] {
+	if (Array.isArray(value)) return value.flatMap(objectsIn);
+	if (!isObject(value)) return [];
+	return [value, ...Object.values(value).flatMap(objectsIn)];
+}
+
+function hasProperties(value: JsonObject, names: readonly string[]): boolean {
+	const properties = value.properties;
+	return isObject(properties) && names.every(name => Object.hasOwn(properties, name));
+}
+
+function assertMetadataBranches(schema: unknown): void {
+	const metadataBranches = objectsIn(schema).filter(branch =>
+		hasProperties(branch, ["round", "component", "dimension", "ambiguity"]),
+	);
+	const ordinary = metadataBranches.find(
+		branch => !hasProperties(branch, ["intent_contract"]) && !hasProperties(branch, ["intent_review"]),
+	);
+	const contract = metadataBranches.find(
+		branch => hasProperties(branch, ["intent_contract"]) && !hasProperties(branch, ["intent_review"]),
+	);
+	const review = metadataBranches.find(
+		branch => hasProperties(branch, ["intent_review"]) && !hasProperties(branch, ["intent_contract"]),
+	);
+
+	expect(ordinary).toBeDefined();
+	expect(contract).toBeDefined();
+	expect(review).toBeDefined();
+	expect(metadataBranches.some(branch => hasProperties(branch, ["intent_contract", "intent_review"]))).toBe(false);
+}
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+async function askTool() {
+	const tool = (await createTools(createTestSession(), ["ask"])).find(candidate => candidate.name === "ask");
+	if (!tool) throw new Error("Expected AskTool to be registered");
+	return tool;
+}
+
+async function capturePayload(): Promise<JsonObject> {
+	const { promise, resolve } = Promise.withResolvers<unknown>();
+	const model = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
+	const context: Context = {
+		messages: [{ role: "user", content: "Confirm locked intent", timestamp: Date.now() }],
+		tools: [await askTool()],
+	};
+	streamOpenAICompletions(model, context, {
+		apiKey: "test-key",
+		signal: abortedSignal(),
+		onPayload: payload => resolve(payload),
+	});
+	return (await promise) as JsonObject;
+}
+
+describe("issue #2643 — OpenAI completions AskTool wire contract", () => {
+	it("emits actual mutually exclusive ordinary, contract, and review metadata branches", async () => {
+		const tool = await askTool();
+		const wireSchema = toolWireSchema(tool);
+		assertMetadataBranches(wireSchema);
+		const payload = await capturePayload();
+		const tools = payload.tools;
+		expect(Array.isArray(tools)).toBe(true);
+		const ask = (tools as unknown[]).find(
+			candidate => isObject(candidate) && isObject(candidate.function) && candidate.function.name === "ask",
+		);
+		if (!isObject(ask) || !isObject(ask.function)) throw new Error("OpenAI payload omitted AskTool");
+
+		const parameters = ask.function.parameters;
+		assertMetadataBranches(parameters);
+		const schemas = objectsIn(parameters);
+		const question = schemas.find(schema => hasProperties(schema, ["id", "question", "options", "deepInterview"]));
+		expect(question).toBeDefined();
+		expect(hasProperties(question as JsonObject, ["workflowGate"])).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/tools/provider-schema-compatibility.test.ts
+++ b/packages/coding-agent/test/tools/provider-schema-compatibility.test.ts
@@ -78,9 +78,9 @@ function formatCompatibilityIssues(
 }
 
 describe("builtin tool schemas provider compatibility", () => {
-	it("keeps task and todo_write strict-compatible for OpenAI-style providers", async () => {
+	it("keeps ask, task, and todo_write strict-compatible for OpenAI-style providers", async () => {
 		const toolSchemas = await collectToolSchemas();
-		for (const toolName of ["task", "todo_write"]) {
+		for (const toolName of ["ask", "task", "todo_write"]) {
 			const entry = toolSchemas.find(tool => tool.name === toolName);
 			expect(entry).toBeDefined();
 			if (!entry) {


### PR DESCRIPTION
## Summary
- make provider-visible deep-interview metadata mutually exclusive across ordinary, Round-0 contract, and post-Round-0 review phases
- add a one-shot pre-coercion AskTool compatibility fence that preserves a strict-valid Round-0 contract and removes only the spurious review
- terminally reject encoded, authority-bearing, prototype-bearing, extra-key, and otherwise malformed recovery near-misses before generic coercion
- add actual AskTool/OpenAI wire, composed execute/gate/recorder, coercion, red-team, provider compatibility, and changelog coverage

## Root cause
The v0.11.2 runtime correctly rejected the impossible contract+review pair, but its provider-visible schema advertised both intent fields as optional siblings because Zod superRefine constraints were not represented on the wire. Some models therefore emitted a shape the runtime could never accept. The fix corrects the wire topology and narrowly recovers the already-observed malformed pair without weakening durable intent authority.

## Verification
- v0.11.2 detached-tag reproduction: exact reported validation errors; zero execute/gate/coordinator output
- focused issue/ask/wire/red-team/schema suite: 149 passed, 529 expectations
- broader recorder/state/runtime/handoff/gate/coordinator suite: 289 passed
- bun --cwd=packages/coding-agent run check:types
- bun --cwd=packages/coding-agent run check:runtime
- bun run ci:check:full
- bun run ci:test:smoke
- independent cleaner: CLEAR
- independent Architect: CLEAR / APPROVE
- independent Critic: OKAY
- independent QA/red-team: passed

A full workspace bun run test:ts attempt was inconclusive due unrelated existing coding-agent timeout, SQLite no-such-table failures, and session-compaction OOM after other workspace packages passed. Focused affected suites and the full static/runtime/smoke gates are green.

Fixes #2643

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*