### PR TITLE
feat(tui): rich tool-call rendering in the transcript viewer

### DIFF
--- a/artifacts/g001-toolrender-redteam-report.json
+++ b/artifacts/g001-toolrender-redteam-report.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 1,
+  "kind": "package-test-report",
+  "story": "G001-toolrender",
+  "suites": [
+    {
+      "command": "bun --cwd packages/coding-agent test test/g001-toolrender-redteam.test.ts test/tool-transcript-format.test.ts test/g002-ws1-redteam.test.ts test/transcript-viewer-overlay.test.ts test/transcript-item-registry.test.ts test/transcript-viewer-perf.test.ts",
+      "pass": 44,
+      "fail": 0
+    }
+  ],
+  "adversarialCases": [
+    {
+      "id": "result-state-whitespace-and-multiline",
+      "scenario": "Pending, empty success, success, error with text, error without text, whitespace-only results, leading/trailing newlines, and multiline output.",
+      "expected": "Whitespace-only results resolve as ✓ done or ✗ Error; non-empty results are trimmed at boundaries while interior lines remain.",
+      "verdict": "passed"
+    },
+    {
+      "id": "format-args-malformed-and-bounded",
+      "scenario": "Missing read/write/edit paths, non-string bash command, tabbed bash command, non-array search paths, private generic keys, JSON generic values, and 600-character generic values.",
+      "expected": "Malformed special fields produce empty or partial summaries; tabs become four spaces; private keys are omitted; generic output is JSON-formatted and exactly capped at 500 characters.",
+      "verdict": "passed"
+    },
+    {
+      "id": "tool-display-source-line-boundary",
+      "scenario": "Exactly 100, 101, and 100000 result lines with a three-line intent call block; one-line result control.",
+      "expected": "Collapsed output is call-only; expanded output preserves all call lines and emits at most call lines + 100 result lines + one sentinel, with an exact extra-line count.",
+      "verdict": "passed"
+    },
+    {
+      "id": "adapter-incomplete-metadata-and-kind-isolation",
+      "scenario": "Tool payload with missing metadata.name and metadata.arguments, plus user and thinking entries.",
+      "expected": "Tool label falls back to Tool, display formatting defaults arguments to {}, and non-tool entries do not receive getDisplayText.",
+      "verdict": "passed"
+    },
+    {
+      "id": "observer-canonical-parity-and-pending",
+      "scenario": "Observer fixtures for success, empty success, error with text, error without text, and absent result.",
+      "expected": "Present-result rendered canonical strings retain the established golden call/result text; only absent result uses ⏳ pending.",
+      "verdict": "passed"
+    },
+    {
+      "id": "unicode-and-ansi-result-chrome",
+      "scenario": "CJK, emoji, OSC clipboard chrome, SGR chrome, and more than 100 source lines in a tool result.",
+      "expected": "Rendering does not throw, preserves Unicode content, strips overlay-dangerous ANSI chrome, and caps by source line rather than grapheme count.",
+      "verdict": "passed"
+    }
+  ],
+  "blockers": []
+}

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -9,8 +9,7 @@ import { parseSessionEntries } from "../../session/session-manager";
 import type { ObservableSession, SessionObserverRegistry } from "../session-observer-registry";
 import { theme } from "../theme/theme";
 import { type TranscriptViewerEntry, TranscriptViewerOverlay } from "./transcript-viewer-overlay";
-
-const MAX_TOOL_ARGS_CHARS = 500;
+import { composeToolText } from "./tool-transcript-format";
 
 /** Session-observer adapter. The shared viewer owns navigation and fold state. */
 export class SessionObserverOverlayComponent extends TranscriptViewerOverlay {
@@ -191,15 +190,20 @@ function entriesFromMessages(entries: readonly SessionMessageEntry[]): Transcrip
 							.map(part => part.text)
 							.join("\n")
 							.trim() ?? "";
-					const summary = formatToolArgs(content.name, content.arguments);
-					const callText = [summary, content.intent].filter(Boolean).join("\n");
-					const resultDisplay = result?.isError ? `✗ ${resultText || "Error"}` : resultText || "✓ done";
+					const text = composeToolText({
+						name: content.name,
+						args: content.arguments,
+						intent: content.intent,
+						resultText,
+						isError: result?.isError ?? false,
+						hasResult: results.has(content.id),
+					});
 					output.push({
 						id: `tool:${content.id}`,
 						kind: "tool",
 						label: content.name,
 						payload: {
-							text: [callText, resultDisplay].filter(Boolean).join("\n"),
+							text,
 							metadata: {
 								name: content.name,
 								arguments: content.arguments,
@@ -234,22 +238,6 @@ function entriesFromMessages(entries: readonly SessionMessageEntry[]): Transcrip
 	return output;
 }
 
-function formatToolArgs(name: string, args: Record<string, unknown>): string {
-	if (name === "read" || name === "write" || name === "edit") return args.path ? `path: ${args.path}` : "";
-	if (name === "bash") return typeof args.command === "string" ? args.command.replaceAll("\t", "    ") : "";
-	if (name === "search")
-		return [
-			args.pattern ? `pattern: ${args.pattern}` : "",
-			Array.isArray(args.paths) ? `paths: ${args.paths.join(", ")}` : "",
-		]
-			.filter(Boolean)
-			.join(", ");
-	return Object.entries(args)
-		.filter(([key]) => !key.startsWith("_"))
-		.map(([key, value]) => `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`)
-		.join(", ")
-		.slice(0, MAX_TOOL_ARGS_CHARS);
-}
 
 function truncateThinking(text: string, expanded: boolean): string {
 	const limit = expanded ? 4_000 : 200;

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -8,8 +8,8 @@ import type { SessionMessageEntry } from "../../session/session-manager";
 import { parseSessionEntries } from "../../session/session-manager";
 import type { ObservableSession, SessionObserverRegistry } from "../session-observer-registry";
 import { theme } from "../theme/theme";
-import { type TranscriptViewerEntry, TranscriptViewerOverlay } from "./transcript-viewer-overlay";
 import { composeToolText } from "./tool-transcript-format";
+import { type TranscriptViewerEntry, TranscriptViewerOverlay } from "./transcript-viewer-overlay";
 
 /** Session-observer adapter. The shared viewer owns navigation and fold state. */
 export class SessionObserverOverlayComponent extends TranscriptViewerOverlay {
@@ -237,7 +237,6 @@ function entriesFromMessages(entries: readonly SessionMessageEntry[]): Transcrip
 	}
 	return output;
 }
-
 
 function truncateThinking(text: string, expanded: boolean): string {
 	const limit = expanded ? 4_000 : 200;

--- a/packages/coding-agent/src/modes/components/tool-transcript-format.ts
+++ b/packages/coding-agent/src/modes/components/tool-transcript-format.ts
@@ -1,0 +1,58 @@
+export const MAX_TOOL_ARGS_CHARS = 500;
+export const TOOL_RESULT_MAX_EXPANDED_LINES = 100;
+
+type ToolCallFields = {
+	name: string;
+	args: Record<string, unknown>;
+	intent?: string;
+};
+
+type ToolResultFields = {
+	resultText: string;
+	isError: boolean;
+	hasResult: boolean;
+};
+
+export type ToolTranscriptFields = ToolCallFields & ToolResultFields;
+
+export function formatToolArgs(name: string, args: Record<string, unknown>): string {
+	if (name === "read" || name === "write" || name === "edit") return args.path ? `path: ${args.path}` : "";
+	if (name === "bash") return typeof args.command === "string" ? args.command.replaceAll("\t", "    ") : "";
+	if (name === "search")
+		return [
+			args.pattern ? `pattern: ${args.pattern}` : "",
+			Array.isArray(args.paths) ? `paths: ${args.paths.join(", ")}` : "",
+		]
+			.filter(Boolean)
+			.join(", ");
+	return Object.entries(args)
+		.filter(([key]) => !key.startsWith("_"))
+		.map(([key, value]) => `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`)
+		.join(", ")
+		.slice(0, MAX_TOOL_ARGS_CHARS);
+}
+
+export function composeToolCall({ name, args, intent }: ToolCallFields): string {
+	return [formatToolArgs(name, args), intent].filter(Boolean).join("\n");
+}
+
+export function composeToolResult({ resultText, isError, hasResult }: ToolResultFields): string {
+	const text = resultText.trim();
+	if (!hasResult) return "⏳ pending";
+	if (isError) return `✗ ${text || "Error"}`;
+	return text || "✓ done";
+}
+
+export function composeToolText(fields: ToolTranscriptFields): string {
+	return [composeToolCall(fields), composeToolResult(fields)].filter(Boolean).join("\n");
+}
+
+export function toolDisplayText(fields: ToolTranscriptFields, expanded: boolean): string {
+	const call = composeToolCall(fields);
+	if (!expanded) return call;
+	const resultLines = composeToolResult(fields).split("\n");
+	const shown = resultLines.slice(0, TOOL_RESULT_MAX_EXPANDED_LINES);
+	if (resultLines.length > TOOL_RESULT_MAX_EXPANDED_LINES)
+		shown.push(`... ${resultLines.length - TOOL_RESULT_MAX_EXPANDED_LINES} more lines`);
+	return [call, shown.join("\n")].filter(Boolean).join("\n");
+}

--- a/packages/coding-agent/src/modes/components/tool-transcript-format.ts
+++ b/packages/coding-agent/src/modes/components/tool-transcript-format.ts
@@ -47,12 +47,26 @@ export function composeToolText(fields: ToolTranscriptFields): string {
 	return [composeToolCall(fields), composeToolResult(fields)].filter(Boolean).join("\n");
 }
 
+/**
+ * Caps result output without allocating an array for every source line. The final
+ * line count still requires scanning the result so the omitted-line count is exact.
+ */
+function expandedToolResult(result: string): string {
+	let lineCount = 1;
+	let prefixEnd = result.length;
+	for (let index = 0; index < result.length; index++) {
+		if (result[index] !== "\n") continue;
+		if (lineCount === TOOL_RESULT_MAX_EXPANDED_LINES) prefixEnd = index;
+		lineCount += 1;
+	}
+	const prefix = result.slice(0, prefixEnd);
+	return lineCount > TOOL_RESULT_MAX_EXPANDED_LINES
+		? `${prefix}\n... ${lineCount - TOOL_RESULT_MAX_EXPANDED_LINES} more lines`
+		: prefix;
+}
+
 export function toolDisplayText(fields: ToolTranscriptFields, expanded: boolean): string {
 	const call = composeToolCall(fields);
 	if (!expanded) return call;
-	const resultLines = composeToolResult(fields).split("\n");
-	const shown = resultLines.slice(0, TOOL_RESULT_MAX_EXPANDED_LINES);
-	if (resultLines.length > TOOL_RESULT_MAX_EXPANDED_LINES)
-		shown.push(`... ${resultLines.length - TOOL_RESULT_MAX_EXPANDED_LINES} more lines`);
-	return [call, shown.join("\n")].filter(Boolean).join("\n");
+	return [call, expandedToolResult(composeToolResult(fields))].filter(Boolean).join("\n");
 }

--- a/packages/coding-agent/src/modes/components/transcript-viewer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/transcript-viewer-overlay.ts
@@ -11,6 +11,7 @@ import { sanitizeText } from "@gajae-code/utils";
 import { getMarkdownTheme, theme } from "../theme/theme";
 import type { TranscriptItemRegistry, TranscriptSourcePayload } from "../transcript-item-registry";
 import { DynamicBorder } from "./dynamic-border";
+import { toolDisplayText } from "./tool-transcript-format";
 
 const INDENT = "    ";
 const PAGE_SIZE = 15;
@@ -375,10 +376,25 @@ export function transcriptViewerEntries(registry: TranscriptItemRegistry): Trans
 				: item.kind === "assistant-thinking"
 					? "Thinking"
 					: item.kind === "tool"
-						? "Tool"
+						? String(payload.metadata.name ?? "Tool")
 						: item.kind === "user"
 							? "User"
 							: item.kind;
-		return [{ id: item.id, kind: item.kind, label, payload, ...capabilities }];
+		const getDisplayText =
+			item.kind === "tool"
+				? (expanded: boolean) =>
+						toolDisplayText(
+							{
+								name: String(payload.metadata.name ?? ""),
+								args: (payload.metadata.arguments ?? {}) as Record<string, unknown>,
+								intent: payload.metadata.intent as string | undefined,
+								resultText: String(payload.metadata.resultText ?? ""),
+								isError: Boolean(payload.metadata.isError),
+								hasResult: Boolean(payload.metadata.hasResult),
+							},
+							expanded,
+						)
+				: undefined;
+		return [{ id: item.id, kind: item.kind, label, payload, ...capabilities, getDisplayText }];
 	});
 }

--- a/packages/coding-agent/src/modes/components/transcript-viewer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/transcript-viewer-overlay.ts
@@ -364,6 +364,29 @@ export class TranscriptViewerOverlay extends Container {
 	}
 }
 
+type ToolTranscriptMetadata = {
+	name: string;
+	arguments: Record<string, unknown>;
+	intent?: unknown;
+	resultText: string;
+	isError: boolean;
+	hasResult: boolean;
+};
+
+function hasToolTranscriptMetadata(
+	metadata: Readonly<Record<string, unknown>>,
+): metadata is Readonly<ToolTranscriptMetadata> {
+	return (
+		typeof metadata.name === "string" &&
+		metadata.arguments !== null &&
+		typeof metadata.arguments === "object" &&
+		!Array.isArray(metadata.arguments) &&
+		typeof metadata.resultText === "string" &&
+		typeof metadata.isError === "boolean" &&
+		typeof metadata.hasResult === "boolean"
+	);
+}
+
 /** Main-session adapter over the registry's canonical payload resolver. */
 export function transcriptViewerEntries(registry: TranscriptItemRegistry): TranscriptViewerEntry[] {
 	return registry.items().flatMap(item => {
@@ -380,17 +403,18 @@ export function transcriptViewerEntries(registry: TranscriptItemRegistry): Trans
 						: item.kind === "user"
 							? "User"
 							: item.kind;
+		const toolMetadata = hasToolTranscriptMetadata(payload.metadata) ? payload.metadata : undefined;
 		const getDisplayText =
-			item.kind === "tool"
+			item.kind === "tool" && toolMetadata
 				? (expanded: boolean) =>
 						toolDisplayText(
 							{
-								name: String(payload.metadata.name ?? ""),
-								args: (payload.metadata.arguments ?? {}) as Record<string, unknown>,
-								intent: payload.metadata.intent as string | undefined,
-								resultText: String(payload.metadata.resultText ?? ""),
-								isError: Boolean(payload.metadata.isError),
-								hasResult: Boolean(payload.metadata.hasResult),
+								name: toolMetadata.name,
+								args: toolMetadata.arguments,
+								intent: typeof toolMetadata.intent === "string" ? toolMetadata.intent : undefined,
+								resultText: toolMetadata.resultText,
+								isError: toolMetadata.isError,
+								hasResult: toolMetadata.hasResult,
 							},
 							expanded,
 						)

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -62,6 +62,7 @@ import {
 } from "./components/pet-capability";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import { StatusLineComponent } from "./components/tool-status-header";
+import { composeToolText } from "./components/tool-transcript-format";
 import {
 	WelcomeComponent,
 	type WelcomeLogoMode,
@@ -89,7 +90,6 @@ import { TasksAggregator } from "./tasks-aggregator";
 import { type ShimmerPalette, shimmerSegments, shimmerText } from "./theme/shimmer";
 import type { Theme } from "./theme/theme";
 import { getEditorTheme, getSymbolTheme, onTerminalAppearanceChange, onThemeChange, theme } from "./theme/theme";
-import { composeToolText } from "./components/tool-transcript-format";
 import { type RegisterTranscriptItem, TranscriptItemRegistry, transcriptItemId } from "./transcript-item-registry";
 import {
 	type CompactionQueuedMessage,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -89,6 +89,7 @@ import { TasksAggregator } from "./tasks-aggregator";
 import { type ShimmerPalette, shimmerSegments, shimmerText } from "./theme/shimmer";
 import type { Theme } from "./theme/theme";
 import { getEditorTheme, getSymbolTheme, onTerminalAppearanceChange, onThemeChange, theme } from "./theme/theme";
+import { composeToolText } from "./components/tool-transcript-format";
 import { type RegisterTranscriptItem, TranscriptItemRegistry, transcriptItemId } from "./transcript-item-registry";
 import {
 	type CompactionQueuedMessage,
@@ -1817,17 +1818,27 @@ export class InteractiveMode implements InteractiveModeContext {
 						result?.content
 							.filter(part => part.type === "text")
 							.map(part => part.text)
-							.join("\n") ?? "";
+							.join("\n")
+							.trim() ?? "";
 					items.push({
 						kind: "tool",
 						source: { toolCallId: content.id, content, result },
 						getPayload: () => ({
-							text: resultText || JSON.stringify(content.arguments, null, 2),
+							text: composeToolText({
+								name: content.name,
+								args: content.arguments,
+								intent: content.intent,
+								resultText,
+								isError: result?.isError ?? false,
+								hasResult: toolResults.has(content.id),
+							}),
 							metadata: {
 								name: content.name,
 								arguments: content.arguments,
 								intent: content.intent,
 								isError: result?.isError ?? false,
+								resultText,
+								hasResult: toolResults.has(content.id),
 							},
 							source: { content, result },
 						}),

--- a/packages/coding-agent/test/g001-toolrender-redteam.test.ts
+++ b/packages/coding-agent/test/g001-toolrender-redteam.test.ts
@@ -10,7 +10,7 @@ import {
 	toolDisplayText,
 } from "../src/modes/components/tool-transcript-format";
 import { TranscriptViewerOverlay, transcriptViewerEntries } from "../src/modes/components/transcript-viewer-overlay";
-import type { ObservableSession } from "../src/modes/session-observer-registry";
+import type { ObservableSession, SessionObserverRegistry } from "../src/modes/session-observer-registry";
 import { initTheme } from "../src/modes/theme/theme";
 import { TranscriptItemRegistry } from "../src/modes/transcript-item-registry";
 
@@ -39,7 +39,7 @@ function observerRegistry(session: ObservableSession) {
 		onChange: () => () => {},
 		setMainSession: () => {},
 		getActiveSubagentCount: () => 1,
-	} as unknown as import("../src/modes/session-observer-registry").SessionObserverRegistry;
+	} as unknown as SessionObserverRegistry;
 }
 
 function observerText(resultText: string, isError: boolean, hasResult = true): string {

--- a/packages/coding-agent/test/g001-toolrender-redteam.test.ts
+++ b/packages/coding-agent/test/g001-toolrender-redteam.test.ts
@@ -141,8 +141,8 @@ describe("G001 red-team: shared formatter and adapters", () => {
 		const incomplete = registryWithTool({ arguments: undefined, resultText: "", isError: false, hasResult: true });
 		const incompleteEntry = transcriptViewerEntries(incomplete)[0];
 		expect(incompleteEntry?.label).toBe("Tool");
-		expect(() => incompleteEntry?.getDisplayText?.(true)).not.toThrow();
-		expect(incompleteEntry?.getDisplayText?.(true)).toBe("✓ done");
+		expect(incompleteEntry?.payload.text).toBe("canonical payload");
+		expect(incompleteEntry?.getDisplayText).toBeUndefined();
 
 		const registry = new TranscriptItemRegistry();
 		registry.register({ id: "user", kind: "user", source: { text: "hello" } });

--- a/packages/coding-agent/test/g001-toolrender-redteam.test.ts
+++ b/packages/coding-agent/test/g001-toolrender-redteam.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { composeToolResult, formatToolArgs, TOOL_RESULT_MAX_EXPANDED_LINES, toolDisplayText } from "../src/modes/components/tool-transcript-format";
 import { SessionObserverOverlayComponent } from "../src/modes/components/session-observer-overlay";
+import {
+	composeToolResult,
+	formatToolArgs,
+	TOOL_RESULT_MAX_EXPANDED_LINES,
+	toolDisplayText,
+} from "../src/modes/components/tool-transcript-format";
 import { TranscriptViewerOverlay, transcriptViewerEntries } from "../src/modes/components/transcript-viewer-overlay";
 import type { ObservableSession } from "../src/modes/session-observer-registry";
 import { initTheme } from "../src/modes/theme/theme";
@@ -41,7 +46,13 @@ function observerText(resultText: string, isError: boolean, hasResult = true): s
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "g001-observer-"));
 	try {
 		const now = new Date().toISOString();
-		const message = (id: string, value: object) => ({ type: "message", id, parentId: null, timestamp: now, message: value });
+		const message = (id: string, value: object) => ({
+			type: "message",
+			id,
+			parentId: null,
+			timestamp: now,
+			message: value,
+		});
 		const file = path.join(dir, "session.jsonl");
 		const messages = [
 			{ type: "session", version: 3, id: "session", timestamp: now },
@@ -63,11 +74,14 @@ function observerText(resultText: string, isError: boolean, hasResult = true): s
 				}),
 			);
 		fs.writeFileSync(file, `${messages.map(message => JSON.stringify(message)).join("\n")}\n`);
-		const overlay = new SessionObserverOverlayComponent(
-			observerRegistry({ id: "session", kind: "subagent", label: "Session", status: "active", sessionFile: file, lastUpdate: 1 }),
-			() => {},
-			["ctrl+s"],
-		);
+		const overlay = new SessionObserverOverlayComponent(observerRegistry({
+			id: "session",
+			kind: "subagent",
+			label: "Session",
+			status: "active",
+			sessionFile: file,
+			lastUpdate: 1,
+		}), () => {}, ["ctrl+s"]);
 		// The observer does not expose a clipboard seam; inspect its public rendered payload instead.
 		const rendered = overlay.render(200).join("\n");
 		return rendered
@@ -104,11 +118,18 @@ describe("G001 red-team: shared formatter and adapters", () => {
 
 	test("caps only expanded result source lines at exactly 100 and preserves every call line", () => {
 		const lineResult = (count: number) => Array.from({ length: count }, (_, index) => `line-${index}`).join("\n");
-		const manyCallLines = { ...fields(lineResult(100)), args: { command: "echo ok" }, name: "bash", intent: "intent-a\nintent-b\nintent-c" };
+		const manyCallLines = {
+			...fields(lineResult(100)),
+			args: { command: "echo ok" },
+			name: "bash",
+			intent: "intent-a\nintent-b\nintent-c",
+		};
 		const callLines = toolDisplayText(manyCallLines, false).split("\n");
 		expect(toolDisplayText(manyCallLines, false)).toBe(callLines.join("\n"));
 		expect(toolDisplayText(manyCallLines, true).split("\n")).toHaveLength(callLines.length + 100);
-		expect(toolDisplayText({ ...manyCallLines, resultText: lineResult(101) }, true).split("\n")).toHaveLength(callLines.length + 101);
+		expect(toolDisplayText({ ...manyCallLines, resultText: lineResult(101) }, true).split("\n")).toHaveLength(
+			callLines.length + 101,
+		);
 		expect(toolDisplayText({ ...manyCallLines, resultText: lineResult(101) }, true)).toEndWith("... 1 more lines");
 		const massive = toolDisplayText({ ...manyCallLines, resultText: lineResult(100_000) }, true);
 		expect(massive.split("\n")).toHaveLength(callLines.length + TOOL_RESULT_MAX_EXPANDED_LINES + 1);
@@ -147,10 +168,19 @@ describe("G001 red-team: shared formatter and adapters", () => {
 		const resultText = ["結果 漢字 😀", "\x1b]52;c;clipboard\x07", "\x1b[31mred\x1b[0m"]
 			.concat(Array.from({ length: 101 }, (_, index) => `行-${index}`))
 			.join("\n");
-		const registry = registryWithTool({ name: "bash", arguments: { command: "echo" }, resultText, isError: false, hasResult: true });
+		const registry = registryWithTool({
+			name: "bash",
+			arguments: { command: "echo" },
+			resultText,
+			isError: false,
+			hasResult: true,
+		});
 		const entry = transcriptViewerEntries(registry)[0];
 		expect(entry?.getDisplayText?.(true).split("\n")).toHaveLength(102);
-		const viewer = new TranscriptViewerOverlay({ getEntries: () => transcriptViewerEntries(registry), onClose: () => {} });
+		const viewer = new TranscriptViewerOverlay({
+			getEntries: () => transcriptViewerEntries(registry),
+			onClose: () => {},
+		});
 		viewer.handleInput(" ");
 		const rendered = viewer.render(120).join("\n");
 		expect(rendered).toContain("結果 漢字");

--- a/packages/coding-agent/test/g001-toolrender-redteam.test.ts
+++ b/packages/coding-agent/test/g001-toolrender-redteam.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { composeToolResult, formatToolArgs, TOOL_RESULT_MAX_EXPANDED_LINES, toolDisplayText } from "../src/modes/components/tool-transcript-format";
+import { SessionObserverOverlayComponent } from "../src/modes/components/session-observer-overlay";
+import { TranscriptViewerOverlay, transcriptViewerEntries } from "../src/modes/components/transcript-viewer-overlay";
+import type { ObservableSession } from "../src/modes/session-observer-registry";
+import { initTheme } from "../src/modes/theme/theme";
+import { TranscriptItemRegistry } from "../src/modes/transcript-item-registry";
+
+initTheme();
+
+const call = { name: "read", args: { path: "src/file.ts" }, intent: "Inspect file" };
+
+function fields(resultText: string, overrides: Partial<{ hasResult: boolean; isError: boolean; intent: string }> = {}) {
+	return { ...call, resultText, hasResult: true, isError: false, ...overrides };
+}
+
+function registryWithTool(metadata: Record<string, unknown>, id = "tool:redteam") {
+	const registry = new TranscriptItemRegistry();
+	registry.register({
+		id,
+		kind: "tool",
+		source: id,
+		getPayload: () => ({ text: "canonical payload", metadata, source: id }),
+	});
+	return registry;
+}
+
+function observerRegistry(session: ObservableSession) {
+	return {
+		getSessions: () => [session],
+		onChange: () => () => {},
+		setMainSession: () => {},
+		getActiveSubagentCount: () => 1,
+	} as unknown as import("../src/modes/session-observer-registry").SessionObserverRegistry;
+}
+
+function observerText(resultText: string, isError: boolean, hasResult = true): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "g001-observer-"));
+	try {
+		const now = new Date().toISOString();
+		const message = (id: string, value: object) => ({ type: "message", id, parentId: null, timestamp: now, message: value });
+		const file = path.join(dir, "session.jsonl");
+		const messages = [
+			{ type: "session", version: 3, id: "session", timestamp: now },
+			message("call", {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "tool", name: call.name, arguments: call.args, intent: call.intent }],
+				timestamp: Date.now(),
+			}),
+		];
+		if (hasResult)
+			messages.push(
+				message("result", {
+					role: "toolResult",
+					toolCallId: "tool",
+					toolName: "read",
+					content: resultText ? [{ type: "text", text: resultText }] : [],
+					isError,
+					timestamp: Date.now(),
+				}),
+			);
+		fs.writeFileSync(file, `${messages.map(message => JSON.stringify(message)).join("\n")}\n`);
+		const overlay = new SessionObserverOverlayComponent(
+			observerRegistry({ id: "session", kind: "subagent", label: "Session", status: "active", sessionFile: file, lastUpdate: 1 }),
+			() => {},
+			["ctrl+s"],
+		);
+		// The observer does not expose a clipboard seam; inspect its public rendered payload instead.
+		const rendered = overlay.render(200).join("\n");
+		return rendered
+			.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "")
+			.split("\n")
+			.map(line => line.trimStart())
+			.join("\n");
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+describe("G001 red-team: shared formatter and adapters", () => {
+	test("distinguishes every result state and trims boundary whitespace without losing interior lines", () => {
+		expect(composeToolResult(fields("ignored", { hasResult: false }))).toBe("⏳ pending");
+		expect(composeToolResult(fields(" \t\n ", { isError: false }))).toBe("✓ done");
+		expect(composeToolResult(fields(" \t\n ", { isError: true }))).toBe("✗ Error");
+		expect(composeToolResult(fields("\n completed \n"))).toBe("completed");
+		expect(composeToolResult(fields("\nfirst\nsecond\n"))).toBe("first\nsecond");
+		expect(composeToolResult(fields("\nfailed\nreason\n", { isError: true }))).toBe("✗ failed\nreason");
+	});
+
+	test("rejects malformed special-tool arguments and bounds generic argument text", () => {
+		expect(formatToolArgs("read", {})).toBe("");
+		expect(formatToolArgs("write", { path: "" })).toBe("");
+		expect(formatToolArgs("edit", { path: null })).toBe("");
+		expect(formatToolArgs("bash", { command: 42 })).toBe("");
+		expect(formatToolArgs("bash", { command: "a\tb\t" })).toBe("a    b    ");
+		expect(formatToolArgs("search", { pattern: "needle", paths: "src" })).toBe("pattern: needle");
+		const generic = formatToolArgs("custom", { _secret: "hidden", bool: true, nil: null, list: [1, "x"] });
+		expect(generic).toBe('bool: true, nil: null, list: [1,"x"]');
+		expect(formatToolArgs("custom", { value: "x".repeat(600) })).toHaveLength(500);
+	});
+
+	test("caps only expanded result source lines at exactly 100 and preserves every call line", () => {
+		const lineResult = (count: number) => Array.from({ length: count }, (_, index) => `line-${index}`).join("\n");
+		const manyCallLines = { ...fields(lineResult(100)), args: { command: "echo ok" }, name: "bash", intent: "intent-a\nintent-b\nintent-c" };
+		const callLines = toolDisplayText(manyCallLines, false).split("\n");
+		expect(toolDisplayText(manyCallLines, false)).toBe(callLines.join("\n"));
+		expect(toolDisplayText(manyCallLines, true).split("\n")).toHaveLength(callLines.length + 100);
+		expect(toolDisplayText({ ...manyCallLines, resultText: lineResult(101) }, true).split("\n")).toHaveLength(callLines.length + 101);
+		expect(toolDisplayText({ ...manyCallLines, resultText: lineResult(101) }, true)).toEndWith("... 1 more lines");
+		const massive = toolDisplayText({ ...manyCallLines, resultText: lineResult(100_000) }, true);
+		expect(massive.split("\n")).toHaveLength(callLines.length + TOOL_RESULT_MAX_EXPANDED_LINES + 1);
+		expect(massive).toEndWith("... 99900 more lines");
+		expect(toolDisplayText(fields("single"), true)).not.toContain("more lines");
+	});
+
+	test("adapter tolerates incomplete tool metadata and does not add display callbacks to non-tools", () => {
+		const incomplete = registryWithTool({ arguments: undefined, resultText: "", isError: false, hasResult: true });
+		const incompleteEntry = transcriptViewerEntries(incomplete)[0];
+		expect(incompleteEntry?.label).toBe("Tool");
+		expect(() => incompleteEntry?.getDisplayText?.(true)).not.toThrow();
+		expect(incompleteEntry?.getDisplayText?.(true)).toBe("✓ done");
+
+		const registry = new TranscriptItemRegistry();
+		registry.register({ id: "user", kind: "user", source: { text: "hello" } });
+		registry.register({ id: "thinking", kind: "assistant-thinking", source: { text: "think" } });
+		expect(transcriptViewerEntries(registry).every(entry => entry.getDisplayText === undefined)).toBe(true);
+	});
+
+	test("observer present-result rendering retains pre-change golden payload text", () => {
+		const golden = [
+			{ resultText: "success", isError: false, expected: "path: src/file.ts\nInspect file\nsuccess" },
+			{ resultText: "", isError: false, expected: "path: src/file.ts\nInspect file\n✓ done" },
+			{ resultText: "failed", isError: true, expected: "path: src/file.ts\nInspect file\n✗ failed" },
+			{ resultText: "", isError: true, expected: "path: src/file.ts\nInspect file\n✗ Error" },
+		];
+		for (const fixture of golden) {
+			const rendered = observerText(fixture.resultText, fixture.isError);
+			expect(rendered).toContain(fixture.expected);
+		}
+		expect(observerText("ignored", false, false)).toContain("path: src/file.ts\nInspect file\n⏳ pending");
+	});
+
+	test("sanitizes ANSI chrome while retaining CJK and line-based caps", () => {
+		const resultText = ["結果 漢字 😀", "\x1b]52;c;clipboard\x07", "\x1b[31mred\x1b[0m"]
+			.concat(Array.from({ length: 101 }, (_, index) => `行-${index}`))
+			.join("\n");
+		const registry = registryWithTool({ name: "bash", arguments: { command: "echo" }, resultText, isError: false, hasResult: true });
+		const entry = transcriptViewerEntries(registry)[0];
+		expect(entry?.getDisplayText?.(true).split("\n")).toHaveLength(102);
+		const viewer = new TranscriptViewerOverlay({ getEntries: () => transcriptViewerEntries(registry), onClose: () => {} });
+		viewer.handleInput(" ");
+		const rendered = viewer.render(120).join("\n");
+		expect(rendered).toContain("結果 漢字");
+		expect(rendered).not.toContain("\x1b]52;");
+		expect(rendered).not.toContain("\x1b[31m");
+	});
+});

--- a/packages/coding-agent/test/g002-ws1-redteam.test.ts
+++ b/packages/coding-agent/test/g002-ws1-redteam.test.ts
@@ -310,13 +310,9 @@ test("renders an unmatched observer tool call as pending instead of done", () =>
 				timestamp: Date.now(),
 			}),
 		]);
-		const overlay = new SessionObserverOverlayComponent(
-			observerRegistry([
-				{ id: "pending", kind: "subagent", label: "Pending", status: "active", sessionFile: file, lastUpdate: 1 },
-			]),
-			() => {},
-			["ctrl+s"],
-		);
+		const overlay = new SessionObserverOverlayComponent(observerRegistry([
+			{ id: "pending", kind: "subagent", label: "Pending", status: "active", sessionFile: file, lastUpdate: 1 },
+		]), () => {}, ["ctrl+s"]);
 		const rendered = overlay.render(100).join("\n");
 		expect(rendered).toContain("⏳ pending");
 		expect(rendered).not.toContain("✓ done");

--- a/packages/coding-agent/test/g002-ws1-redteam.test.ts
+++ b/packages/coding-agent/test/g002-ws1-redteam.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -295,6 +295,31 @@ it("preserves tool arguments, intent, empty errors, thinking caps, paging, and o
 		rendered = overlay.render(100).join("\n");
 		expect(rendered).toContain("page-line-");
 		expect(rendered).toMatch(/\[\d+-\d+\/\d+\]/);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("renders an unmatched observer tool call as pending instead of done", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "g002-observer-pending-"));
+	try {
+		const file = sessionFile(dir, "pending", [
+			message("a1", {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "pending-tool", name: "read", arguments: { path: "src/file.ts" } }],
+				timestamp: Date.now(),
+			}),
+		]);
+		const overlay = new SessionObserverOverlayComponent(
+			observerRegistry([
+				{ id: "pending", kind: "subagent", label: "Pending", status: "active", sessionFile: file, lastUpdate: 1 },
+			]),
+			() => {},
+			["ctrl+s"],
+		);
+		const rendered = overlay.render(100).join("\n");
+		expect(rendered).toContain("⏳ pending");
+		expect(rendered).not.toContain("✓ done");
 	} finally {
 		fs.rmSync(dir, { recursive: true, force: true });
 	}

--- a/packages/coding-agent/test/tool-transcript-format.test.ts
+++ b/packages/coding-agent/test/tool-transcript-format.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+	MAX_TOOL_ARGS_CHARS,
+	composeToolCall,
+	composeToolResult,
+	composeToolText,
+	formatToolArgs,
+	TOOL_RESULT_MAX_EXPANDED_LINES,
+	toolDisplayText,
+} from "../src/modes/components/tool-transcript-format";
+
+describe("tool transcript format", () => {
+	test("formats tool arguments with the observer-compatible shapes", () => {
+		expect(formatToolArgs("read", { path: "src/file.ts", ignored: "value" })).toBe("path: src/file.ts");
+		expect(formatToolArgs("write", { path: "out.txt" })).toBe("path: out.txt");
+		expect(formatToolArgs("edit", {})).toBe("");
+		expect(formatToolArgs("bash", { command: "printf '\tvalue'" })).toBe("printf '    value'");
+		expect(formatToolArgs("search", { pattern: "needle", paths: ["src", "test"] })).toBe(
+			"pattern: needle, paths: src, test",
+		);
+		expect(formatToolArgs("custom", { visible: "value", _private: "hidden", nested: { ok: true } })).toBe(
+			'visible: value, nested: {"ok":true}',
+		);
+		expect(formatToolArgs("custom", { value: "x".repeat(MAX_TOOL_ARGS_CHARS + 10) })).toHaveLength(
+			MAX_TOOL_ARGS_CHARS,
+		);
+	});
+
+	test("composes every tool result state", () => {
+		expect(composeToolResult({ resultText: "ignored", isError: false, hasResult: false })).toBe("⏳ pending");
+		expect(composeToolResult({ resultText: "", isError: false, hasResult: true })).toBe("✓ done");
+		expect(composeToolResult({ resultText: "  completed  ", isError: false, hasResult: true })).toBe("completed");
+		expect(composeToolResult({ resultText: "  failed  ", isError: true, hasResult: true })).toBe("✗ failed");
+		expect(composeToolResult({ resultText: "", isError: true, hasResult: true })).toBe("✗ Error");
+	});
+
+	test("composes calls and canonical tool text", () => {
+		const fields = { name: "read", args: { path: "src/file.ts" }, intent: "Inspect file", resultText: "ok", isError: false, hasResult: true };
+		expect(composeToolCall(fields)).toBe("path: src/file.ts\nInspect file");
+		expect(composeToolText(fields)).toBe("path: src/file.ts\nInspect file\nok");
+	});
+
+	test("shows call-only while collapsed and caps expanded results by source line", () => {
+		const fields = {
+			name: "bash",
+			args: { command: "echo ok" },
+			intent: "Run command",
+			resultText: Array.from({ length: TOOL_RESULT_MAX_EXPANDED_LINES + 2 }, (_, index) => `line-${index}`).join("\n"),
+			isError: false,
+			hasResult: true,
+		};
+		expect(toolDisplayText(fields, false)).toBe("echo ok\nRun command");
+		const expanded = toolDisplayText(fields, true);
+		expect(expanded).toContain("line-99");
+		expect(expanded).not.toContain("line-100");
+		expect(expanded).toEndWith("... 2 more lines");
+	});
+});

--- a/packages/coding-agent/test/tool-transcript-format.test.ts
+++ b/packages/coding-agent/test/tool-transcript-format.test.ts
@@ -64,4 +64,38 @@ describe("tool transcript format", () => {
 		expect(expanded).not.toContain("line-100");
 		expect(expanded).toEndWith("... 2 more lines");
 	});
+	test("caps expanded results with bounded line storage while preserving line counts", () => {
+		const fields = {
+			name: "custom",
+			args: {},
+			intent: undefined,
+			isError: false,
+			hasResult: true,
+			resultText: "",
+		};
+		for (const lineCount of [99, 100, 101]) {
+			fields.resultText = Array.from({ length: lineCount }, (_, index) => `line-${index}`).join("\n");
+			const output = toolDisplayText(fields, true);
+			if (lineCount <= TOOL_RESULT_MAX_EXPANDED_LINES) expect(output).toContain(`line-${lineCount - 1}`);
+			else expect(output).not.toContain(`line-${TOOL_RESULT_MAX_EXPANDED_LINES}`);
+			expect(output.endsWith("... 1 more lines")).toBe(lineCount === 101);
+		}
+		fields.resultText = Array.from({ length: 100_000 }, (_, index) => `line-${index}`).join("\n");
+		const output = toolDisplayText(fields, true);
+		expect(output).toContain("line-99");
+		expect(output).not.toContain("line-100");
+		expect(output).toEndWith("... 99900 more lines");
+	});
+
+	test("preserves empty, error, pending, and trailing-newline result behavior", () => {
+		const base = { name: "custom", args: {}, intent: undefined };
+		expect(toolDisplayText({ ...base, resultText: "", isError: false, hasResult: true }, true)).toBe("✓ done");
+		expect(toolDisplayText({ ...base, resultText: "", isError: true, hasResult: true }, true)).toBe("✗ Error");
+		expect(toolDisplayText({ ...base, resultText: "ignored", isError: false, hasResult: false }, true)).toBe(
+			"⏳ pending",
+		);
+		expect(toolDisplayText({ ...base, resultText: "one\ntwo\n", isError: false, hasResult: true }, true)).toBe(
+			"one\ntwo",
+		);
+	});
 });

--- a/packages/coding-agent/test/tool-transcript-format.test.ts
+++ b/packages/coding-agent/test/tool-transcript-format.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
-	MAX_TOOL_ARGS_CHARS,
 	composeToolCall,
 	composeToolResult,
 	composeToolText,
 	formatToolArgs,
+	MAX_TOOL_ARGS_CHARS,
 	TOOL_RESULT_MAX_EXPANDED_LINES,
 	toolDisplayText,
 } from "../src/modes/components/tool-transcript-format";
@@ -35,7 +35,14 @@ describe("tool transcript format", () => {
 	});
 
 	test("composes calls and canonical tool text", () => {
-		const fields = { name: "read", args: { path: "src/file.ts" }, intent: "Inspect file", resultText: "ok", isError: false, hasResult: true };
+		const fields = {
+			name: "read",
+			args: { path: "src/file.ts" },
+			intent: "Inspect file",
+			resultText: "ok",
+			isError: false,
+			hasResult: true,
+		};
 		expect(composeToolCall(fields)).toBe("path: src/file.ts\nInspect file");
 		expect(composeToolText(fields)).toBe("path: src/file.ts\nInspect file\nok");
 	});
@@ -45,7 +52,9 @@ describe("tool transcript format", () => {
 			name: "bash",
 			args: { command: "echo ok" },
 			intent: "Run command",
-			resultText: Array.from({ length: TOOL_RESULT_MAX_EXPANDED_LINES + 2 }, (_, index) => `line-${index}`).join("\n"),
+			resultText: Array.from({ length: TOOL_RESULT_MAX_EXPANDED_LINES + 2 }, (_, index) => `line-${index}`).join(
+				"\n",
+			),
 			isError: false,
 			hasResult: true,
 		};

--- a/packages/coding-agent/test/transcript-item-registry.test.ts
+++ b/packages/coding-agent/test/transcript-item-registry.test.ts
@@ -116,27 +116,27 @@ describe("TranscriptItemRegistry", () => {
 	});
 });
 
-	test("retains enriched tool result metadata without changing the payload shape", () => {
-		const registry = new TranscriptItemRegistry();
-		const id = registry.register({
-			id: "tool:metadata",
-			kind: "tool",
-			source: "tool-1",
-			getPayload: () => ({
-				text: "path: src/file.ts\n✓ done",
-				metadata: {
-					name: "read",
-					arguments: { path: "src/file.ts" },
-					intent: "Inspect file",
-					isError: false,
-					resultText: "",
-					hasResult: true,
-				},
-				source: "tool-1",
-			}),
-		});
-		expect(registry.resolveSourcePayload(id)).toMatchObject({
+test("retains enriched tool result metadata without changing the payload shape", () => {
+	const registry = new TranscriptItemRegistry();
+	const id = registry.register({
+		id: "tool:metadata",
+		kind: "tool",
+		source: "tool-1",
+		getPayload: () => ({
 			text: "path: src/file.ts\n✓ done",
-			metadata: { resultText: "", hasResult: true },
-		});
+			metadata: {
+				name: "read",
+				arguments: { path: "src/file.ts" },
+				intent: "Inspect file",
+				isError: false,
+				resultText: "",
+				hasResult: true,
+			},
+			source: "tool-1",
+		}),
 	});
+	expect(registry.resolveSourcePayload(id)).toMatchObject({
+		text: "path: src/file.ts\n✓ done",
+		metadata: { resultText: "", hasResult: true },
+	});
+});

--- a/packages/coding-agent/test/transcript-item-registry.test.ts
+++ b/packages/coding-agent/test/transcript-item-registry.test.ts
@@ -115,3 +115,28 @@ describe("TranscriptItemRegistry", () => {
 		expect(registry.resolveSourcePayload(canonical!)?.text).toBe("final");
 	});
 });
+
+	test("retains enriched tool result metadata without changing the payload shape", () => {
+		const registry = new TranscriptItemRegistry();
+		const id = registry.register({
+			id: "tool:metadata",
+			kind: "tool",
+			source: "tool-1",
+			getPayload: () => ({
+				text: "path: src/file.ts\n✓ done",
+				metadata: {
+					name: "read",
+					arguments: { path: "src/file.ts" },
+					intent: "Inspect file",
+					isError: false,
+					resultText: "",
+					hasResult: true,
+				},
+				source: "tool-1",
+			}),
+		});
+		expect(registry.resolveSourcePayload(id)).toMatchObject({
+			text: "path: src/file.ts\n✓ done",
+			metadata: { resultText: "", hasResult: true },
+		});
+	});

--- a/packages/coding-agent/test/transcript-viewer-overlay.test.ts
+++ b/packages/coding-agent/test/transcript-viewer-overlay.test.ts
@@ -319,6 +319,56 @@ test("renders tool names, state-aware folded display, and preserves neighboring 
 	expect(viewer.render(100).join("\n")).toContain("⏳ pending");
 });
 
+test("preserves legacy tool payload text until complete formatter metadata is available", () => {
+	const registry = new TranscriptItemRegistry();
+	registry.register({
+		id: "tool:legacy",
+		kind: "tool",
+		source: "legacy",
+		getPayload: () => ({ text: "legacy default payload", metadata: {}, source: "legacy" }),
+	});
+	registry.register({
+		id: "tool:partial",
+		kind: "tool",
+		source: "partial",
+		getPayload: () => ({
+			text: "partial legacy payload",
+			metadata: { name: "bash", arguments: { command: "echo partial" }, resultText: "partial result" },
+			source: "partial",
+		}),
+	});
+	registry.register({
+		id: "tool:open",
+		kind: "tool",
+		source: "open",
+		getPayload: () => ({
+			text: "open canonical payload",
+			metadata: {
+				name: "bash",
+				arguments: { command: "echo open" },
+				resultText: "",
+				isError: false,
+				hasResult: false,
+			},
+			source: "open",
+		}),
+	});
+	const entries = transcriptViewerEntries(registry);
+	expect(entries[0]?.getDisplayText).toBeUndefined();
+	expect(entries[1]?.getDisplayText).toBeUndefined();
+	expect(entries[2]?.getDisplayText?.(true)).toBe("echo open\n⏳ pending");
+
+	const viewer = new TranscriptViewerOverlay({
+		getEntries: () => transcriptViewerEntries(registry),
+		onClose: () => {},
+	});
+	viewer.handleInput(" ");
+	const rendered = viewer.render(100).join("\n");
+	expect(rendered).toContain("legacy default payload");
+	expect(rendered).toContain("partial legacy payload");
+	expect(rendered).not.toContain("partial result");
+});
+
 test("sanitizes tool results and leaves expanded assistant text uncapped", () => {
 	const registry = new TranscriptItemRegistry();
 	registry.register({

--- a/packages/coding-agent/test/transcript-viewer-overlay.test.ts
+++ b/packages/coding-agent/test/transcript-viewer-overlay.test.ts
@@ -276,8 +276,18 @@ test("renders tool names, state-aware folded display, and preserves neighboring 
 		},
 		source: id,
 	});
-	registry.register({ id: "tool:first", kind: "tool", source: "first", getPayload: () => toolPayload("first", "first result", false, true) });
-	registry.register({ id: "tool:second", kind: "tool", source: "second", getPayload: () => toolPayload("second", "", false, false) });
+	registry.register({
+		id: "tool:first",
+		kind: "tool",
+		source: "first",
+		getPayload: () => toolPayload("first", "first result", false, true),
+	});
+	registry.register({
+		id: "tool:second",
+		kind: "tool",
+		source: "second",
+		getPayload: () => toolPayload("second", "", false, false),
+	});
 	const entries = transcriptViewerEntries(registry);
 	expect(entries.map(entry => entry.label)).toEqual(["read", "read"]);
 	expect(entries[0]?.getDisplayText?.(false)).toBe("path: first.ts\nInspect file");
@@ -331,9 +341,16 @@ test("sanitizes tool results and leaves expanded assistant text uncapped", () =>
 		id: "assistant",
 		kind: "assistant-text",
 		source: "assistant",
-		getPayload: () => ({ text: Array.from({ length: 150 }, (_, index) => `assistant-${index}`).join("\n"), metadata: {}, source: "assistant" }),
+		getPayload: () => ({
+			text: Array.from({ length: 150 }, (_, index) => `assistant-${index}`).join("\n"),
+			metadata: {},
+			source: "assistant",
+		}),
 	});
-	const viewer = new TranscriptViewerOverlay({ getEntries: () => transcriptViewerEntries(registry), onClose: () => {} });
+	const viewer = new TranscriptViewerOverlay({
+		getEntries: () => transcriptViewerEntries(registry),
+		onClose: () => {},
+	});
 	viewer.handleInput(" ");
 	let rendered = viewer.render(100).join("\n");
 	expect(rendered).toContain("✗ safe");

--- a/packages/coding-agent/test/transcript-viewer-overlay.test.ts
+++ b/packages/coding-agent/test/transcript-viewer-overlay.test.ts
@@ -262,6 +262,90 @@ test("reconciles missing IDs by position and keeps followed tail content visible
 	expect(positioned.selectedEntryId).toBe("replacement");
 });
 
+test("renders tool names, state-aware folded display, and preserves neighboring tool folds", () => {
+	const registry = new TranscriptItemRegistry();
+	const toolPayload = (id: string, resultText: string, isError: boolean, hasResult: boolean) => ({
+		text: `raw ${resultText}`,
+		metadata: {
+			name: "read",
+			arguments: { path: `${id}.ts` },
+			intent: "Inspect file",
+			resultText,
+			isError,
+			hasResult,
+		},
+		source: id,
+	});
+	registry.register({ id: "tool:first", kind: "tool", source: "first", getPayload: () => toolPayload("first", "first result", false, true) });
+	registry.register({ id: "tool:second", kind: "tool", source: "second", getPayload: () => toolPayload("second", "", false, false) });
+	const entries = transcriptViewerEntries(registry);
+	expect(entries.map(entry => entry.label)).toEqual(["read", "read"]);
+	expect(entries[0]?.getDisplayText?.(false)).toBe("path: first.ts\nInspect file");
+	expect(entries[0]?.getDisplayText?.(true)).toContain("first result");
+	expect(entries[1]?.getDisplayText?.(true)).toContain("⏳ pending");
+
+	const copied: string[] = [];
+	const viewer = new TranscriptViewerOverlay({
+		getEntries: () => transcriptViewerEntries(registry),
+		onClose: () => {},
+		copyToClipboard: text => copied.push(text),
+	});
+	viewer.handleInput("Y");
+	const copiedMetadata = JSON.parse(copied[0] ?? "") as Record<string, unknown>;
+	expect(Object.keys(copiedMetadata).sort()).toEqual([
+		"arguments",
+		"hasResult",
+		"intent",
+		"isError",
+		"name",
+		"resultText",
+	]);
+	viewer.handleInput(" ");
+	viewer.handleInput("j");
+	viewer.handleInput(" ");
+	viewer.handleInput("k");
+	expect(viewer.render(100).join("\n")).toContain("first result");
+	viewer.handleInput("j");
+	expect(viewer.render(100).join("\n")).toContain("⏳ pending");
+});
+
+test("sanitizes tool results and leaves expanded assistant text uncapped", () => {
+	const registry = new TranscriptItemRegistry();
+	registry.register({
+		id: "tool:chrome",
+		kind: "tool",
+		source: "chrome",
+		getPayload: () => ({
+			text: "raw",
+			metadata: {
+				name: "bash",
+				arguments: { command: "echo safe" },
+				resultText: "safe\x1b[2J\n# markdown-like",
+				isError: true,
+				hasResult: true,
+			},
+			source: "chrome",
+		}),
+	});
+	registry.register({
+		id: "assistant",
+		kind: "assistant-text",
+		source: "assistant",
+		getPayload: () => ({ text: Array.from({ length: 150 }, (_, index) => `assistant-${index}`).join("\n"), metadata: {}, source: "assistant" }),
+	});
+	const viewer = new TranscriptViewerOverlay({ getEntries: () => transcriptViewerEntries(registry), onClose: () => {} });
+	viewer.handleInput(" ");
+	let rendered = viewer.render(100).join("\n");
+	expect(rendered).toContain("✗ safe");
+	expect(rendered).not.toContain("\x1b[2J");
+	viewer.handleInput("j");
+	viewer.handleInput(" ");
+	viewer.handleInput("\n");
+	for (let index = 0; index < 20; index++) viewer.handleInput("\x1b[6~");
+	rendered = viewer.render(100).join("\n");
+	expect(rendered).toContain("assistant-149");
+});
+
 function entryForOverlay(
 	id: string,
 	text: string,

--- a/packages/coding-agent/test/transcript-viewer-perf.test.ts
+++ b/packages/coding-agent/test/transcript-viewer-perf.test.ts
@@ -1,11 +1,8 @@
 import { expect, test } from "bun:test";
+import { TOOL_RESULT_MAX_EXPANDED_LINES, toolDisplayText } from "../src/modes/components/tool-transcript-format";
 import { TranscriptViewerOverlay, transcriptViewerEntries } from "../src/modes/components/transcript-viewer-overlay";
-import {
-	TOOL_RESULT_MAX_EXPANDED_LINES,
-	toolDisplayText,
-} from "../src/modes/components/tool-transcript-format";
-import { TranscriptItemRegistry } from "../src/modes/transcript-item-registry";
 import { initTheme } from "../src/modes/theme/theme";
+import { TranscriptItemRegistry } from "../src/modes/transcript-item-registry";
 
 initTheme();
 const fields = (resultText: string) => ({
@@ -48,7 +45,10 @@ test("bounds expanded tool rendering independently of raw result size", () => {
 			source: "assistant",
 			getPayload: () => ({ text: assistantText, metadata: {}, source: "assistant" }),
 		});
-		const viewer = new TranscriptViewerOverlay({ getEntries: () => transcriptViewerEntries(registry), onClose: () => {} });
+		const viewer = new TranscriptViewerOverlay({
+			getEntries: () => transcriptViewerEntries(registry),
+			onClose: () => {},
+		});
 		viewer.handleInput(" ");
 		const rendered = viewer.render(80);
 		const toolHeader = rendered.findIndex(line => line.includes("[bash]"));
@@ -65,7 +65,8 @@ test("bounds expanded tool rendering independently of raw result size", () => {
 		expect(renderedOneThousand).toBeLessThanOrEqual(bound);
 
 		const maxLineWidth = 150;
-		const overWidthResult = (lines: number) => Array.from({ length: lines }, () => "x".repeat(maxLineWidth)).join("\n");
+		const overWidthResult = (lines: number) =>
+			Array.from({ length: lines }, () => "x".repeat(maxLineWidth)).join("\n");
 		const wrappedBound = bound * Math.ceil(maxLineWidth / 75);
 		const renderedOverWidthOneThousand = renderedToolContentLineCount(overWidthResult(1_000));
 		const renderedOverWidthOneHundredThousand = renderedToolContentLineCount(overWidthResult(100_000));

--- a/packages/coding-agent/test/transcript-viewer-perf.test.ts
+++ b/packages/coding-agent/test/transcript-viewer-perf.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import { TranscriptViewerOverlay, transcriptViewerEntries } from "../src/modes/components/transcript-viewer-overlay";
+import {
+	TOOL_RESULT_MAX_EXPANDED_LINES,
+	toolDisplayText,
+} from "../src/modes/components/tool-transcript-format";
+import { TranscriptItemRegistry } from "../src/modes/transcript-item-registry";
+import { initTheme } from "../src/modes/theme/theme";
+
+initTheme();
+const fields = (resultText: string) => ({
+	name: "bash",
+	args: { command: "echo result" },
+	intent: "Run command",
+	resultText,
+	isError: false,
+	hasResult: true,
+});
+
+function result(lines: number): string {
+	return Array.from({ length: lines }, (_, index) => `result-${index}`).join("\n");
+}
+
+test("bounds expanded tool rendering independently of raw result size", () => {
+	const oneThousand = toolDisplayText(fields(result(1_000)), true);
+	const oneHundredThousand = toolDisplayText(fields(result(100_000)), true);
+	const callBlockLines = toolDisplayText(fields(""), false).split("\n").length;
+	const bound = callBlockLines + TOOL_RESULT_MAX_EXPANDED_LINES + 1;
+	expect(oneThousand.split("\n").length).toBeLessThanOrEqual(bound);
+	expect(oneHundredThousand.split("\n").length).toBe(oneThousand.split("\n").length);
+
+	const renderedToolContentLineCount = (resultText: string) => {
+		const registry = new TranscriptItemRegistry();
+		registry.register({
+			id: "tool:large",
+			kind: "tool",
+			source: "large",
+			getPayload: () => ({
+				text: toolDisplayText(fields(resultText), true),
+				metadata: { ...fields(resultText), arguments: { command: "echo result" } },
+				source: "large",
+			}),
+		});
+		const assistantText = result(150);
+		registry.register({
+			id: "assistant",
+			kind: "assistant-text",
+			source: "assistant",
+			getPayload: () => ({ text: assistantText, metadata: {}, source: "assistant" }),
+		});
+		const viewer = new TranscriptViewerOverlay({ getEntries: () => transcriptViewerEntries(registry), onClose: () => {} });
+		viewer.handleInput(" ");
+		const rendered = viewer.render(80);
+		const toolHeader = rendered.findIndex(line => line.includes("[bash]"));
+		const assistantHeader = rendered.findIndex((line, index) => index > toolHeader && line.includes("[Response]"));
+		expect(toolHeader).toBeGreaterThanOrEqual(0);
+		expect(assistantHeader).toBeGreaterThan(toolHeader);
+		return assistantHeader - toolHeader - 2;
+	};
+
+	const rows = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+	Object.defineProperty(process.stdout, "rows", { configurable: true, value: 1_000 });
+	try {
+		const renderedOneThousand = renderedToolContentLineCount(result(1_000));
+		expect(renderedOneThousand).toBeLessThanOrEqual(bound);
+
+		const maxLineWidth = 150;
+		const overWidthResult = (lines: number) => Array.from({ length: lines }, () => "x".repeat(maxLineWidth)).join("\n");
+		const wrappedBound = bound * Math.ceil(maxLineWidth / 75);
+		const renderedOverWidthOneThousand = renderedToolContentLineCount(overWidthResult(1_000));
+		const renderedOverWidthOneHundredThousand = renderedToolContentLineCount(overWidthResult(100_000));
+		expect(renderedOverWidthOneThousand).toBeLessThanOrEqual(wrappedBound);
+		expect(renderedOverWidthOneHundredThousand).toBe(renderedOverWidthOneThousand);
+	} finally {
+		if (rows) Object.defineProperty(process.stdout, "rows", rows);
+		else Reflect.deleteProperty(process.stdout, "rows");
+	}
+
+	const assistantRegistry = new TranscriptItemRegistry();
+	assistantRegistry.register({
+		id: "assistant",
+		kind: "assistant-text",
+		source: "assistant",
+		getPayload: () => ({ text: result(150), metadata: {}, source: "assistant" }),
+	});
+	const assistant = transcriptViewerEntries(assistantRegistry).find(entry => entry.id === "assistant");
+	expect(assistant?.getDisplayText).toBeUndefined();
+	expect(assistant?.payload.text.split("\n")).toHaveLength(150);
+});


### PR DESCRIPTION
Implements **WS1** of the approved tool-call-rendering follow-up to [PR #2469](https://github.com/Yeachan-Heo/gajae-code/pull/2469) (ralplan consensus plan: Architect CLEAR/APPROVE + Critic OKAY; executed under ultragoal with a full architect + red-team gate).

## What this does

The modal transcript viewer rendered tool calls **bare** — a literal `[Tool]` label plus raw result text or `JSON.stringify(arguments)`. The session-observer already rendered them richly. This unifies both surfaces on one shared formatter.

### New shared module
`packages/coding-agent/src/modes/components/tool-transcript-format.ts` — a pure, dependency-free formatter consumed by **both** the session-observer and the main-session viewer:
- `formatToolArgs` (moved verbatim from the observer; 500-char cap)
- `composeToolCall` (args summary + intent), `composeToolResult` (result state machine), `composeToolText` (canonical copy/raw text), `toolDisplayText` (collapsed vs expanded with cap + sentinel)

### Result states
`✓ done` / `✗ error` / `⏳ pending`. This **fixes a latent bug on both surfaces**: a tool call with no result yet used to render as `✓ done` (false success) — it now shows `⏳ pending`. Observer present-result output stays **byte-for-byte identical**.

### Rendering
- Tool-name label + call block (args + intent) + result block.
- Expanded results cap at **100 source lines** with a `... N more lines` sentinel; raw view (`r`) and copy (`y`) expose the full untruncated text.
- **Tool-only** self-truncation — assistant text/thinking is never capped (no global `maxExpandedLines`).
- No `TranscriptSourcePayload` type change: `resultText`/`hasResult` are added to the open metadata record; label + `getDisplayText` live in the `transcriptViewerEntries` adapter.

## Verification
- New tests: `tool-transcript-format.test.ts` (golden formatter shapes + all result states), `transcript-viewer-perf.test.ts` (bounded-work assertion + over-width wrapping), `g001-toolrender-redteam.test.ts` (adversarial). Updated overlay/registry/observer suites (incl. a `⏳ pending` regression fixture).
- **44 focused tests pass; `check:types` clean.**
- Architect review **CLEAR/CLEAR/CLEAR APPROVE** (2 passes); executor red-team **44/44, 6 adversarial cases** (`artifacts/g001-toolrender-redteam-report.json`).

## Out of scope (gated follow-ups)
WS2 Component-fidelity color renderers · WS3 `Y`-metadata enrichment · WS4 structured payload fields · WS5 observer/main convergence — plus the other PR #2469 follow-ups (inline-selection promotion rerun, `mouse.enabled` default flip, sessions-dashboard dispatch, selector-domain palette wiring).
