### PR TITLE
feat(tui): safely attach multiple pasted image paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ## [0.11.3] - 2026-07-19
+### Added
+- Bracketed pastes containing complete lists of saved static-image paths can now attach up to 16 images in source order after explicit confirmation. Paste transactions are cancellation-safe, disabled in command modes, enforce source, encoded-output, dimension, and decoded-memory budgets before commit, reject animated, remote, linked, or path-swapped sources, and restore the literal paste on cancellation or failure.
 
 ### Changed
 - Updated the Kimi Coding Plan Eco, Medium, and Pro presets to Kimi K3 with its supported `low`, `high`, and `max` reasoning efforts.

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -59,8 +59,21 @@ const DEFAULT_ACTION_KEYS = Object.fromEntries(
 
 const PASTE_DECISION_TIMEOUT_MS = 5_000;
 const PENDING_PASTE_INPUT_MAX = 64;
+const PENDING_PASTE_INPUT_MAX_BYTES = 256 * 1024;
 
 type PastePendingClearReason = "timeout" | "queue-limit";
+
+export interface PasteTextContext {
+	readonly signal: AbortSignal;
+	/** Run one synchronous composer mutation only while this paste transaction is current. */
+	commit(commit: () => boolean): boolean;
+}
+
+interface PendingPasteDecision {
+	readonly controller: AbortController;
+	readonly pasteContent: string;
+	readonly remaining: string;
+}
 
 /**
  * Custom editor that handles configurable app-level shortcuts for coding-agent.
@@ -94,9 +107,9 @@ export class CustomEditor extends Editor {
 	/** Called when the configured image-paste shortcut is pressed. */
 	onPasteImage?: () => Promise<boolean>;
 	/** Called before bracketed paste content is inserted. Return true to consume it. */
-	onPasteText?: (text: string) => boolean | Promise<boolean>;
-	/** Called when async paste handling drops queued input instead of replaying it. */
-	onPastePendingInputCleared?: (reason: PastePendingClearReason, droppedInputCount: number) => void;
+	onPasteText?: (text: string, context: PasteTextContext) => boolean | Promise<boolean>;
+	/** Called when pending paste handling is cancelled after restoring queued input. */
+	onPastePendingInputCleared?: (reason: PastePendingClearReason, restoredInputCount: number) => void;
 	/** Called when the configured dequeue shortcut is pressed. */
 	onDequeue?: () => void;
 	/** Called when the configured queue shortcut is pressed. */
@@ -117,7 +130,9 @@ export class CustomEditor extends Editor {
 	#pasteDecisionPending = false;
 	#pasteDecisionToken = 0;
 	#pasteDecisionTimeout: NodeJS.Timeout | undefined;
+	#pendingPasteDecision: PendingPasteDecision | undefined;
 	#pendingPasteInput: string[] = [];
+	#pendingPasteInputBytes = 0;
 
 	setActionKeys(action: ConfigurableEditorAction, keys: KeyId[]): void {
 		this.#actionKeys.set(action, [...keys]);
@@ -165,75 +180,127 @@ export class CustomEditor extends Editor {
 		}
 	}
 
-	#clearPendingPasteState(): number {
+	#resetPendingPasteState(abortReason?: Error): string[] {
 		this.#clearPasteDecisionTimeout();
+		if (abortReason) this.#pendingPasteDecision?.controller.abort(abortReason);
 		this.#pasteDecisionPending = false;
 		this.#pasteDecisionToken += 1;
-		const droppedInputCount = this.#pendingPasteInput.length;
+		this.#pendingPasteDecision = undefined;
+		const queuedInput = this.#pendingPasteInput;
 		this.#pendingPasteInput = [];
-		return droppedInputCount;
+		this.#pendingPasteInputBytes = 0;
+		return queuedInput;
+	}
+
+	#pendingPasteEventCount(): number {
+		return this.#pendingPasteInput.length + (this.#pendingPasteDecision?.remaining ? 1 : 0);
+	}
+
+	#restoreCancelledPaste(reason: PastePendingClearReason, overflowInput?: string): void {
+		const decision = this.#pendingPasteDecision;
+		const queuedInput = this.#resetPendingPasteState(new Error(`Paste handling cancelled: ${reason}`));
+		if (decision) {
+			super.handleInput(`\x1b[200~${decision.pasteContent}\x1b[201~`);
+			this.#drainPendingPasteInput(decision.remaining, queuedInput);
+			if (overflowInput !== undefined) this.handleInput(overflowInput);
+		}
+		this.onPastePendingInputCleared?.(
+			reason,
+			queuedInput.length + (decision?.remaining ? 1 : 0) + (overflowInput === undefined ? 0 : 1),
+		);
 	}
 
 	#startPasteDecisionTimeout(token: number): void {
 		this.#clearPasteDecisionTimeout();
 		this.#pasteDecisionTimeout = setTimeout(() => {
 			if (token !== this.#pasteDecisionToken) return;
-			const droppedInputCount = this.#clearPendingPasteState();
-			this.onPastePendingInputCleared?.("timeout", droppedInputCount);
+			this.#restoreCancelledPaste("timeout");
 		}, PASTE_DECISION_TIMEOUT_MS);
 		this.#pasteDecisionTimeout.unref?.();
 	}
 
 	dispose(): void {
-		this.#clearPendingPasteState();
+		this.#resetPendingPasteState(new Error("Editor disposed during paste handling"));
 		this.#pasteHandler = new BracketedPasteHandler();
 		super.dispose();
 	}
 
-	#drainPendingPasteInput(initialInput?: string): void {
+	#drainPendingPasteInput(initialInput: string | undefined, queuedInput: readonly string[]): void {
 		if (initialInput && initialInput.length > 0) {
 			this.handleInput(initialInput);
 		}
-		while (!this.#pasteDecisionPending) {
-			const nextInput = this.#pendingPasteInput.shift();
-			if (nextInput === undefined) break;
-			this.handleInput(nextInput);
+		for (const input of queuedInput) {
+			this.handleInput(input);
 		}
 	}
 
 	#handleBracketedPaste(pasteContent: string, remaining: string): void {
-		const applyPasteResult = (token: number, handled: boolean | undefined) => {
+		const remainingBytes = Buffer.byteLength(remaining);
+		if (remainingBytes > PENDING_PASTE_INPUT_MAX_BYTES) {
+			super.handleInput(`\x1b[200~${pasteContent}\x1b[201~`);
+			if (remaining.length > 0) this.handleInput(remaining);
+			this.onPastePendingInputCleared?.("queue-limit", 1);
+			return;
+		}
+		const token = this.#pasteDecisionToken + 1;
+		const controller = new AbortController();
+		this.#pasteDecisionToken = token;
+		this.#pasteDecisionPending = true;
+		this.#pendingPasteDecision = { controller, pasteContent, remaining };
+		this.#pendingPasteInputBytes = remainingBytes;
+		let commitUsed = false;
+
+		const applyPasteResult = (handled: boolean | undefined) => {
 			if (token !== this.#pasteDecisionToken) return;
-			this.#clearPasteDecisionTimeout();
+			const queuedInput = this.#resetPendingPasteState();
 			if (!handled) {
 				super.handleInput(`\x1b[200~${pasteContent}\x1b[201~`);
 			}
-			this.#pasteDecisionPending = false;
-			this.#drainPendingPasteInput(remaining);
+			this.#drainPendingPasteInput(remaining, queuedInput);
 		};
-		const pasteResult = this.onPasteText?.(pasteContent);
+
+		let pasteResult: boolean | Promise<boolean> | undefined;
+		try {
+			pasteResult = this.onPasteText?.(pasteContent, {
+				signal: controller.signal,
+				commit: commit => {
+					if (
+						commitUsed ||
+						token !== this.#pasteDecisionToken ||
+						!this.#pasteDecisionPending ||
+						controller.signal.aborted
+					) {
+						return false;
+					}
+					commitUsed = true;
+					return commit();
+				},
+			});
+		} catch {
+			applyPasteResult(false);
+			return;
+		}
 
 		if (pasteResult instanceof Promise) {
-			const token = this.#pasteDecisionToken + 1;
-			this.#pasteDecisionToken = token;
-			this.#pasteDecisionPending = true;
 			this.#startPasteDecisionTimeout(token);
-			void pasteResult.then(
-				handled => applyPasteResult(token, handled),
-				() => applyPasteResult(token, false),
-			);
+			void pasteResult.then(applyPasteResult, () => applyPasteResult(false));
 		} else {
-			applyPasteResult(this.#pasteDecisionToken, pasteResult);
+			applyPasteResult(pasteResult);
 		}
 	}
 
 	handleInput(data: string): void {
 		if (this.#pasteDecisionPending) {
-			this.#pendingPasteInput.push(data);
-			if (this.#pendingPasteInput.length > PENDING_PASTE_INPUT_MAX) {
-				const droppedInputCount = this.#clearPendingPasteState();
-				this.onPastePendingInputCleared?.("queue-limit", droppedInputCount);
+			const inputBytes = Buffer.byteLength(data);
+			if (
+				this.#pendingPasteEventCount() >= PENDING_PASTE_INPUT_MAX ||
+				this.#pendingPasteInputBytes + inputBytes > PENDING_PASTE_INPUT_MAX_BYTES
+			) {
+				this.#restoreCancelledPaste("queue-limit", data);
+				return;
 			}
+			this.#pendingPasteInput.push(data);
+			this.#pendingPasteInputBytes += inputBytes;
 			return;
 		}
 
@@ -245,8 +312,12 @@ export class CustomEditor extends Editor {
 		}
 
 		if (this.onPasteText) {
-			const paste = this.#pasteHandler.process(data);
+			const paste =
+				data === "\x1b" && !this.#pasteHandler.hasPendingFrame
+					? ({ handled: false } as const)
+					: this.#pasteHandler.process(data);
 			if (paste.handled) {
+				if (paste.leading.length > 0) this.handleInput(paste.leading);
 				if (paste.pasteContent !== undefined) {
 					this.onViewportFollowLive?.();
 					this.#handleBracketedPaste(paste.pasteContent, paste.remaining);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@gajae-code/tui";
-import { $env, sanitizeText } from "@gajae-code/utils";
+import { $env, logger, sanitizeText } from "@gajae-code/utils";
 import { type AppKeybinding, KEYBINDINGS } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
@@ -22,12 +22,14 @@ import { getUserMessageViewportAnchorIds } from "../../session/session-manager";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { copyToClipboard, readImageFromClipboard } from "../../utils/clipboard";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
-import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } from "../../utils/image-loading";
+import { ensureSupportedImageInput, ImageInputTooLargeError } from "../../utils/image-loading";
 import { resizeImage } from "../../utils/image-resize";
-import { formatPastedImageReference, resolvePastedImagePath } from "../../utils/pasted-image-path";
+import { loadPastedImageBatch, PastedImageBatchError } from "../../utils/pasted-image-loading";
+import { formatPastedImageReference, parsePastedImagePaths } from "../../utils/pasted-image-path";
 import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 import { ActionRegistry, APP_ACTION_METADATA } from "../action-registry";
 import { CommandPalette, type CommandPaletteAction, type CommandPaletteEntry } from "../components/command-palette";
+import type { PasteTextContext } from "../components/custom-editor";
 import { QueuePaneComponent } from "../components/queue-pane";
 import { type QueuedMessageMoveDirection, QueuedMessageSelectorComponent } from "../components/queued-message-selector";
 
@@ -44,14 +46,23 @@ const EMPTY_EDITOR_DOUBLE_ESCAPE_WINDOW_MS = 500;
 const IMAGE_PLACEHOLDER_PATTERN = /\[image ([1-9]\d*)\]/g;
 const IMAGE_PLACEHOLDER_PRESENT_PATTERN = /\[image [1-9]\d*\]/;
 
+interface InputControllerDependencies {
+	loadPastedImageBatch?: typeof loadPastedImageBatch;
+}
+
 function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
 }
 
 export class InputController {
 	readonly actionRegistry: ActionRegistry<void>;
+	readonly #loadPastedImageBatch: typeof loadPastedImageBatch;
 
-	constructor(private ctx: InteractiveModeContext) {
+	constructor(
+		private ctx: InteractiveModeContext,
+		dependencies: InputControllerDependencies = {},
+	) {
+		this.#loadPastedImageBatch = dependencies.loadPastedImageBatch ?? loadPastedImageBatch;
 		this.actionRegistry = new ActionRegistry({
 			context: undefined,
 			showError: actionId => this.ctx.showError(actionId),
@@ -585,11 +596,11 @@ export class InputController {
 		);
 		this.ctx.editor.onCopyPrompt = () => this.#executeAction("app.clipboard.copyPrompt");
 		this.#registerCommandPaletteAction("app.clipboard.copyPrompt", copyPrompt);
-		this.ctx.editor.onPasteText = text => this.handleTextPaste(text);
-		this.ctx.editor.onPastePendingInputCleared = (reason, droppedInputCount) => {
+		this.ctx.editor.onPasteText = (text, context) => this.handleTextPaste(text, context);
+		this.ctx.editor.onPastePendingInputCleared = (reason, restoredInputCount) => {
 			const reasonText = reason === "timeout" ? "timed out" : "exceeded the input queue limit";
 			this.ctx.showWarning(
-				`Paste handling ${reasonText}; discarded ${droppedInputCount} buffered input event${droppedInputCount === 1 ? "" : "s"}.`,
+				`Paste handling ${reasonText}; restored the original paste and ${restoredInputCount} buffered input event${restoredInputCount === 1 ? "" : "s"}.`,
 			);
 		};
 		const expandTools = () => this.toggleToolOutputExpansion();
@@ -1522,46 +1533,96 @@ export class InputController {
 		return true;
 	}
 
-	handleTextPaste(text: string): boolean | Promise<boolean> {
-		const imagePath = resolvePastedImagePath(text, { cwd: this.ctx.sessionManager.getCwd() });
-		return imagePath ? this.#attachPastedImagePath(imagePath) : false;
+	handleTextPaste(text: string, context: PasteTextContext): boolean | Promise<boolean> {
+		if (this.ctx.isBashMode || this.ctx.isPythonMode) return false;
+		const parsed = parsePastedImagePaths(text, { cwd: this.ctx.sessionManager.getCwd() });
+		if (!parsed) return false;
+		if (parsed.kind === "too-many") {
+			this.ctx.showStatus(`Cannot attach more than ${parsed.maxCandidates} pasted images.`);
+			return false;
+		}
+		return this.#attachPastedImagePaths(parsed.paths, parsed.requiresConfirmation, context);
 	}
 
-	/**
-	 * Returns `false` on every failure path so the editor replays the original
-	 * bracketed paste — the raw path text must never be lost when attachment
-	 * is impossible (unsupported content, oversized image, load error).
-	 */
-	async #attachPastedImagePath(imagePath: string): Promise<boolean> {
+	/** Return false on every failure so CustomEditor restores the exact paste. */
+	async #attachPastedImagePaths(
+		imagePaths: readonly string[],
+		requiresConfirmation: boolean,
+		context: PasteTextContext,
+	): Promise<boolean> {
+		const signal = context.signal;
+		const editor = this.ctx.editor;
+		const editorText = editor.getText();
+		const pendingImages = this.ctx.pendingImages;
+		const pendingImageCount = pendingImages.length;
 		try {
-			const image = await loadImageInput({
-				path: imagePath,
-				cwd: this.ctx.sessionManager.getCwd(),
-				autoResize: this.ctx.settings.get("images.autoResize"),
-			});
-			if (!image) {
-				this.ctx.showStatus("Unsupported pasted image file");
-				return false;
+			if (requiresConfirmation) {
+				const selection = await this.ctx.showHookSelector(
+					`Attach ${imagePaths.length} pasted images?\nOnly attach files you intend to send to the model.`,
+					["Attach images", "Paste paths literally"],
+					{ signal, helpText: "Enter: choose · Esc: paste paths literally" },
+				);
+				signal.throwIfAborted();
+				if (selection !== "Attach images") return false;
 			}
 
-			this.ctx.pendingImages = [
-				...this.ctx.pendingImages,
-				{
-					type: "image",
-					data: image.data,
-					mimeType: image.mimeType,
-				},
-			];
-			this.ctx.editor.insertText(`${formatPastedImageReference(this.#nextImagePlaceholder(), image.resolvedPath)} `);
-			this.ctx.showStatus(`Attached image: ${path.basename(image.resolvedPath)}`, { dim: true });
-			this.ctx.ui.requestRender();
-			return true;
+			const loaded = await this.#loadPastedImageBatch({
+				paths: imagePaths,
+				autoResize: this.ctx.settings.get("images.autoResize"),
+				sourcePolicy: requiresConfirmation ? "confirmed" : "automatic-temp",
+				signal,
+			});
+			signal.throwIfAborted();
+			return context.commit(() => {
+				if (
+					this.ctx.editor !== editor ||
+					editor.getText() !== editorText ||
+					this.ctx.pendingImages !== pendingImages ||
+					pendingImages.length !== pendingImageCount
+				) {
+					return false;
+				}
+
+				const firstImageNumber = pendingImages.length + 1;
+				const references = loaded.sourcePaths.map((sourcePath, index) =>
+					formatPastedImageReference(`[image ${firstImageNumber + index}]`, sourcePath),
+				);
+				try {
+					editor.insertText(`${references.join(" ")} `);
+					this.ctx.pendingImages = [...pendingImages, ...loaded.images];
+				} catch (error) {
+					try {
+						editor.setText(editorText);
+					} catch {
+						// Preserve the original mutation error when rollback itself fails.
+					} finally {
+						this.ctx.pendingImages = pendingImages;
+					}
+					throw error;
+				}
+
+				try {
+					this.ctx.showStatus(
+						loaded.images.length === 1
+							? `Attached image: ${path.basename(loaded.sourcePaths[0] ?? "")}`
+							: `Attached ${loaded.images.length} images`,
+						{ dim: true },
+					);
+					this.ctx.ui.requestRender();
+				} catch (error) {
+					logger.warn("Pasted images attached but status rendering failed", { error: String(error) });
+				}
+				return true;
+			});
 		} catch (error) {
-			if (error instanceof ImageInputTooLargeError) {
+			if (signal.aborted) return false;
+			if (error instanceof ImageInputTooLargeError || error instanceof PastedImageBatchError) {
 				this.ctx.showStatus(error.message);
 				return false;
 			}
-			this.ctx.showStatus("Failed to attach pasted image");
+			this.ctx.showStatus(
+				imagePaths.length === 1 ? "Failed to attach pasted image" : "Failed to attach pasted images",
+			);
 			return false;
 		}
 	}

--- a/packages/coding-agent/src/utils/image-loading.ts
+++ b/packages/coding-agent/src/utils/image-loading.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import type { ImageContent } from "@gajae-code/ai";
 import { formatBytes, readImageMetadata, SUPPORTED_IMAGE_MIME_TYPES } from "@gajae-code/utils";
 import { resolveReadPath } from "../tools/path-utils";
-import { formatDimensionNote, resizeImage } from "./image-resize";
+import { formatDimensionNote, resizeImageBuffer } from "./image-resize";
 
 export const MAX_IMAGE_INPUT_BYTES = 20 * 1024 * 1024;
 export const SUPPORTED_INPUT_IMAGE_MIME_TYPES = SUPPORTED_IMAGE_MIME_TYPES;
@@ -14,6 +14,26 @@ export interface LoadImageInputOptions {
 	maxBytes?: number;
 	resolvedPath?: string;
 	detectedMimeType?: string;
+	signal?: AbortSignal;
+}
+
+export interface LoadImageInputBytesOptions {
+	inputBuffer: Buffer;
+	resolvedPath: string;
+	mimeType: string;
+	autoResize: boolean;
+	maxBytes?: number;
+	maxOutputBytes?: number;
+	signal?: AbortSignal;
+}
+
+export interface TransformedImageInput {
+	resolvedPath: string;
+	mimeType: string;
+	buffer: Uint8Array;
+	textNote: string;
+	dimensionNote?: string;
+	bytes: number;
 }
 
 export interface LoadedImageInput {
@@ -38,9 +58,7 @@ export class ImageInputTooLargeError extends Error {
 }
 
 export async function ensureSupportedImageInput(image: ImageContent): Promise<ImageContent | null> {
-	if (SUPPORTED_INPUT_IMAGE_MIME_TYPES.has(image.mimeType)) {
-		return image;
-	}
+	if (SUPPORTED_INPUT_IMAGE_MIME_TYPES.has(image.mimeType)) return image;
 	try {
 		const bytes = Buffer.from(image.data, "base64");
 		const data = await new Bun.Image(bytes).png().toBase64();
@@ -50,53 +68,86 @@ export async function ensureSupportedImageInput(image: ImageContent): Promise<Im
 	}
 }
 
+/** Transform trusted source bytes without materializing a base64 payload. */
+export async function transformImageInputBytes(options: LoadImageInputBytesOptions): Promise<TransformedImageInput> {
+	const maxBytes = options.maxBytes ?? MAX_IMAGE_INPUT_BYTES;
+	options.signal?.throwIfAborted();
+	if (options.inputBuffer.byteLength > maxBytes) {
+		throw new ImageInputTooLargeError(options.inputBuffer.byteLength, maxBytes);
+	}
+
+	let outputBuffer: Uint8Array = options.inputBuffer;
+	let outputMimeType = options.mimeType;
+	let dimensionNote: string | undefined;
+
+	if (options.autoResize) {
+		options.signal?.throwIfAborted();
+		try {
+			const resized = await resizeImageBuffer(
+				options.inputBuffer,
+				options.mimeType,
+				options.maxOutputBytes === undefined ? undefined : { maxBytes: options.maxOutputBytes },
+			);
+			options.signal?.throwIfAborted();
+			outputBuffer = resized.buffer;
+			outputMimeType = resized.mimeType;
+			dimensionNote = formatDimensionNote(resized);
+		} catch {
+			options.signal?.throwIfAborted();
+			// Keep the original image when optional resize fails.
+		}
+	}
+
+	options.signal?.throwIfAborted();
+	let textNote = `Read image file [${outputMimeType}]`;
+	if (dimensionNote) textNote += `\n${dimensionNote}`;
+	return {
+		resolvedPath: options.resolvedPath,
+		mimeType: outputMimeType,
+		buffer: outputBuffer,
+		textNote,
+		dimensionNote,
+		bytes: outputBuffer.byteLength,
+	};
+}
+
+export function materializeImageInput(transformed: TransformedImageInput): LoadedImageInput {
+	return {
+		resolvedPath: transformed.resolvedPath,
+		mimeType: transformed.mimeType,
+		data: Buffer.from(transformed.buffer).toBase64(),
+		textNote: transformed.textNote,
+		dimensionNote: transformed.dimensionNote,
+		bytes: transformed.bytes,
+	};
+}
+
+/** Build a model image payload from bytes already read through a trusted descriptor. */
+export async function loadImageInputBytes(options: LoadImageInputBytesOptions): Promise<LoadedImageInput> {
+	return materializeImageInput(await transformImageInputBytes(options));
+}
+
 export async function loadImageInput(options: LoadImageInputOptions): Promise<LoadedImageInput | null> {
 	const maxBytes = options.maxBytes ?? MAX_IMAGE_INPUT_BYTES;
 	const resolvedPath = options.resolvedPath ?? resolveReadPath(options.path, options.cwd);
+	options.signal?.throwIfAborted();
 	const metadata = options.detectedMimeType
 		? { mimeType: options.detectedMimeType }
 		: await readImageMetadata(resolvedPath);
 	const mimeType = metadata?.mimeType;
 	if (!mimeType) return null;
 
+	options.signal?.throwIfAborted();
 	const stat = await Bun.file(resolvedPath).stat();
-	if (stat.size > maxBytes) {
-		throw new ImageInputTooLargeError(stat.size, maxBytes);
-	}
+	if (stat.size > maxBytes) throw new ImageInputTooLargeError(stat.size, maxBytes);
 
-	const inputBuffer = await fs.readFile(resolvedPath);
-	if (inputBuffer.byteLength > maxBytes) {
-		throw new ImageInputTooLargeError(inputBuffer.byteLength, maxBytes);
-	}
-
-	let outputData = Buffer.from(inputBuffer).toBase64();
-	let outputMimeType = mimeType;
-	let outputBytes = inputBuffer.byteLength;
-	let dimensionNote: string | undefined;
-
-	if (options.autoResize) {
-		try {
-			const resized = await resizeImage({ type: "image", data: outputData, mimeType });
-			outputData = resized.data;
-			outputMimeType = resized.mimeType;
-			outputBytes = resized.buffer.byteLength;
-			dimensionNote = formatDimensionNote(resized);
-		} catch {
-			// keep original image when resize fails
-		}
-	}
-
-	let textNote = `Read image file [${outputMimeType}]`;
-	if (dimensionNote) {
-		textNote += `\n${dimensionNote}`;
-	}
-
-	return {
+	const inputBuffer = await fs.readFile(resolvedPath, { signal: options.signal });
+	return loadImageInputBytes({
+		inputBuffer,
 		resolvedPath,
-		mimeType: outputMimeType,
-		data: outputData,
-		textNote,
-		dimensionNote,
-		bytes: outputBytes,
-	};
+		mimeType,
+		autoResize: options.autoResize,
+		maxBytes,
+		signal: options.signal,
+	});
 }

--- a/packages/coding-agent/src/utils/image-resize.ts
+++ b/packages/coding-agent/src/utils/image-resize.ts
@@ -21,14 +21,14 @@ export interface ResizedImage {
 
 // 500KB target — aggressive compression; Anthropic's 5MB per-image cap is rarely the
 // binding constraint once images are downsized to 1568px (Anthropic's internal threshold).
-const DEFAULT_MAX_BYTES = 500 * 1024;
+export const DEFAULT_IMAGE_RESIZE_MAX_BYTES = 500 * 1024;
 
 const DEFAULT_OPTIONS: Required<Omit<ImageResizeOptions, "excludeWebP">> = {
 	// Anthropic's "internal recommended size" — Anthropic model internally caps images at
 	// 1568px on the longest edge before vision processing.
 	maxWidth: 1568,
 	maxHeight: 1568,
-	maxBytes: DEFAULT_MAX_BYTES,
+	maxBytes: DEFAULT_IMAGE_RESIZE_MAX_BYTES,
 	jpegQuality: 80,
 };
 
@@ -72,14 +72,17 @@ Buffer.prototype.toBase64 = function (this: Buffer) {
  * Backed by `Bun.Image`: a chainable native pipeline that runs decode/transform/encode
  * off the JS thread when the terminal (`.bytes()`) is awaited.
  */
-export async function resizeImage(img: ImageContent, options?: ImageResizeOptions): Promise<ResizedImage> {
+export async function resizeImageBuffer(
+	inputBuffer: Buffer,
+	inputMimeType: string,
+	options?: ImageResizeOptions,
+): Promise<ResizedImage> {
 	const excludeWebP = options?.excludeWebP ?? isWebPExcluded();
 	const opts = { ...DEFAULT_OPTIONS, ...options, excludeWebP };
-	const inputBuffer = Buffer.from(img.data, "base64");
 
 	try {
 		const { width: originalWidth, height: originalHeight, format } = await new Bun.Image(inputBuffer).metadata();
-		const sourceMime = img.mimeType ?? `image/${format}`;
+		const sourceMime = inputMimeType ?? `image/${format}`;
 
 		// Fast path: already within dimensions AND well under budget.
 		// Threshold is 1/4 of budget — if already that compact, don't re-encode.
@@ -102,7 +105,7 @@ export async function resizeImage(img: ImageContent, options?: ImageResizeOption
 				height: originalHeight,
 				wasResized: false,
 				get data() {
-					return img.data;
+					return inputBuffer.toBase64();
 				},
 			};
 		}
@@ -272,22 +275,26 @@ export async function resizeImage(img: ImageContent, options?: ImageResizeOption
 		// When the caller demanded WebP exclusion AND the original is WebP,
 		// returning the original buffer would silently violate that contract,
 		// so surface an explicit error instead.
-		if (excludeWebP && (img.mimeType === "image/webp" || !img.mimeType)) {
+		if (excludeWebP && (inputMimeType === "image/webp" || !inputMimeType)) {
 			throw new Error("resizeImage: failed to decode image and cannot honor excludeWebP for a WebP source");
 		}
 		return {
 			buffer: inputBuffer,
-			mimeType: img.mimeType,
+			mimeType: inputMimeType,
 			originalWidth: 0,
 			originalHeight: 0,
 			width: 0,
 			height: 0,
 			wasResized: false,
 			get data() {
-				return img.data;
+				return inputBuffer.toBase64();
 			},
 		};
 	}
+}
+
+export function resizeImage(img: ImageContent, options?: ImageResizeOptions): Promise<ResizedImage> {
+	return resizeImageBuffer(Buffer.from(img.data, "base64"), img.mimeType, options);
 }
 
 /**

--- a/packages/coding-agent/src/utils/pasted-image-loading.ts
+++ b/packages/coding-agent/src/utils/pasted-image-loading.ts
@@ -1,0 +1,514 @@
+import * as nodeFs from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ImageContent } from "@gajae-code/ai";
+import { formatBytes, parseImageMetadata } from "@gajae-code/utils";
+import {
+	ImageInputTooLargeError,
+	type LoadedImageInput,
+	MAX_IMAGE_INPUT_BYTES,
+	materializeImageInput,
+	type TransformedImageInput,
+	transformImageInputBytes,
+} from "./image-loading";
+import { DEFAULT_IMAGE_RESIZE_MAX_BYTES } from "./image-resize";
+import { MAX_PASTED_IMAGE_COUNT } from "./pasted-image-path";
+
+export const MAX_PASTED_IMAGE_SOURCE_BYTES = 64 * 1024 * 1024;
+export const MAX_PASTED_IMAGE_OUTPUT_BYTES = 64 * 1024 * 1024;
+export const MAX_PASTED_IMAGE_DIMENSION = 20_000;
+export const MAX_PASTED_IMAGE_PIXELS = 40_000_000;
+export const MAX_PASTED_IMAGE_DECODED_BYTES = 160 * 1024 * 1024;
+
+export type PastedImageBatchErrorCode =
+	| "too-many"
+	| "unsafe-path"
+	| "unsupported-image"
+	| "source-aggregate-too-large"
+	| "output-aggregate-too-large"
+	| "dimensions-too-large";
+
+export class PastedImageBatchError extends Error {
+	constructor(
+		readonly code: PastedImageBatchErrorCode,
+		message: string,
+		readonly imagePath?: string,
+	) {
+		super(message);
+		this.name = "PastedImageBatchError";
+	}
+}
+
+export interface LoadedPastedImageBatch {
+	images: ImageContent[];
+	loadedInputs: LoadedImageInput[];
+	sourcePaths: string[];
+}
+
+export interface PastedImageLoadingDependencies {
+	/** Synchronization hook used to exercise pathname swaps after descriptor open. */
+	afterDescriptorOpen?: (imagePath: string, index: number) => Promise<void> | void;
+	beforeDescriptorRead?: (imagePath: string, index: number) => Promise<void> | void;
+	transformImageBytes?: typeof transformImageInputBytes;
+}
+
+export type PastedImageSourcePolicy = "confirmed" | "automatic-temp";
+
+interface StableFileState {
+	dev: bigint;
+	ino: bigint;
+	mode: bigint;
+	size: bigint;
+	mtimeNs: bigint;
+	ctimeNs: bigint;
+	nlink: bigint;
+}
+
+interface OpenPastedImage {
+	sourcePath: string;
+	canonicalPath: string;
+	handle: fs.FileHandle;
+	state: StableFileState;
+}
+
+const PASTED_IMAGE_OPEN_FLAGS =
+	nodeFs.constants.O_RDONLY | (process.platform === "win32" ? 0 : (nodeFs.constants.O_NOFOLLOW ?? 0));
+
+function stableFileState(stat: nodeFs.BigIntStats): StableFileState | null {
+	if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1n) return null;
+	return {
+		dev: stat.dev,
+		ino: stat.ino,
+		mode: stat.mode,
+		size: stat.size,
+		mtimeNs: stat.mtimeNs,
+		ctimeNs: stat.ctimeNs,
+		nlink: stat.nlink,
+	};
+}
+
+function sameStableFileState(expected: StableFileState, actual: StableFileState | null): boolean {
+	return (
+		actual !== null &&
+		expected.dev === actual.dev &&
+		expected.ino === actual.ino &&
+		expected.mode === actual.mode &&
+		expected.size === actual.size &&
+		expected.mtimeNs === actual.mtimeNs &&
+		expected.ctimeNs === actual.ctimeNs &&
+		expected.nlink === actual.nlink
+	);
+}
+
+function unsafePath(imagePath: string): PastedImageBatchError {
+	return new PastedImageBatchError("unsafe-path", `Unsafe pasted image path: ${path.basename(imagePath)}`, imagePath);
+}
+
+function isRemoteWindowsPath(imagePath: string): boolean {
+	return process.platform === "win32" && (imagePath.startsWith("\\\\") || imagePath.startsWith("//"));
+}
+
+async function exactPathState(imagePath: string): Promise<StableFileState | null> {
+	return stableFileState(await fs.lstat(imagePath, { bigint: true }));
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+	const relative = path.relative(root, candidate);
+	return relative !== "" && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+async function hasLinkedWindowsAncestor(imagePath: string, signal: AbortSignal): Promise<boolean> {
+	if (process.platform !== "win32") return false;
+	const root = path.parse(imagePath).root;
+	const parent = path.dirname(imagePath);
+	const relativeParent = path.relative(root, parent);
+	let current = root;
+	for (const component of relativeParent.split(path.sep).filter(Boolean)) {
+		current = path.join(current, component);
+		const state = await fs.lstat(current);
+		signal.throwIfAborted();
+		if (state.isSymbolicLink()) return true;
+	}
+	return false;
+}
+
+async function hasLinkedPathBelowRoot(root: string, imagePath: string, signal: AbortSignal): Promise<boolean> {
+	const relativeParent = path.relative(root, path.dirname(imagePath));
+	if (relativeParent === "" || relativeParent === ".") return false;
+	if (relativeParent === ".." || relativeParent.startsWith(`..${path.sep}`) || path.isAbsolute(relativeParent)) {
+		return true;
+	}
+	let current = root;
+	for (const component of relativeParent.split(path.sep).filter(Boolean)) {
+		current = path.join(current, component);
+		const state = await fs.lstat(current);
+		signal.throwIfAborted();
+		if (state.isSymbolicLink()) return true;
+	}
+	return false;
+}
+
+async function openStablePastedImage(
+	imagePath: string,
+	index: number,
+	dependencies: PastedImageLoadingDependencies,
+	signal: AbortSignal,
+	sourcePolicy: PastedImageSourcePolicy,
+	canonicalTempRoot: string | undefined,
+	lexicalTempRoot: string | undefined,
+): Promise<OpenPastedImage> {
+	signal.throwIfAborted();
+	if (!path.isAbsolute(imagePath) || isRemoteWindowsPath(imagePath)) throw unsafePath(imagePath);
+	if (await hasLinkedWindowsAncestor(imagePath, signal)) throw unsafePath(imagePath);
+	if (
+		sourcePolicy === "automatic-temp" &&
+		(!lexicalTempRoot ||
+			!isPathInside(lexicalTempRoot, imagePath) ||
+			(await hasLinkedPathBelowRoot(lexicalTempRoot, imagePath, signal)))
+	) {
+		throw unsafePath(imagePath);
+	}
+
+	const initialSourceState = await exactPathState(imagePath);
+	signal.throwIfAborted();
+	if (!initialSourceState) throw unsafePath(imagePath);
+	const canonicalPath = await fs.realpath(imagePath);
+	signal.throwIfAborted();
+	if (isRemoteWindowsPath(canonicalPath)) throw unsafePath(imagePath);
+	if (sourcePolicy === "automatic-temp" && (!canonicalTempRoot || !isPathInside(canonicalTempRoot, canonicalPath))) {
+		throw unsafePath(imagePath);
+	}
+	const initialCanonicalState = await exactPathState(canonicalPath);
+	signal.throwIfAborted();
+	if (!sameStableFileState(initialSourceState, initialCanonicalState)) throw unsafePath(imagePath);
+
+	const handle = await fs.open(canonicalPath, PASTED_IMAGE_OPEN_FLAGS);
+	try {
+		signal.throwIfAborted();
+		await dependencies.afterDescriptorOpen?.(imagePath, index);
+		signal.throwIfAborted();
+		const openedState = stableFileState(await handle.stat({ bigint: true }));
+		signal.throwIfAborted();
+		const currentSourceState = await exactPathState(imagePath);
+		signal.throwIfAborted();
+		const currentCanonicalPath = await fs.realpath(imagePath);
+		signal.throwIfAborted();
+		if (
+			!sameStableFileState(initialSourceState, openedState) ||
+			!sameStableFileState(initialSourceState, currentSourceState) ||
+			currentCanonicalPath !== canonicalPath
+		) {
+			throw unsafePath(imagePath);
+		}
+		return { sourcePath: imagePath, canonicalPath, handle, state: initialSourceState };
+	} catch (error) {
+		await handle.close().catch(() => {});
+		throw error;
+	}
+}
+
+async function readExactDescriptor(opened: OpenPastedImage, signal: AbortSignal): Promise<Buffer> {
+	if (opened.state.size > BigInt(Number.MAX_SAFE_INTEGER)) throw unsafePath(opened.sourcePath);
+	const size = Number(opened.state.size);
+	const bytes = Buffer.allocUnsafe(size);
+	let offset = 0;
+	while (offset < size) {
+		signal.throwIfAborted();
+		const result = await opened.handle.read(bytes, offset, size - offset, offset);
+		signal.throwIfAborted();
+		if (result.bytesRead === 0) {
+			throw new PastedImageBatchError(
+				"unsupported-image",
+				`Incomplete pasted image file: ${path.basename(opened.sourcePath)}`,
+				opened.sourcePath,
+			);
+		}
+		offset += result.bytesRead;
+	}
+
+	signal.throwIfAborted();
+	const afterReadState = stableFileState(await opened.handle.stat({ bigint: true }));
+	signal.throwIfAborted();
+	const currentSourceState = await exactPathState(opened.sourcePath);
+	signal.throwIfAborted();
+	const currentCanonicalPath = await fs.realpath(opened.sourcePath);
+	signal.throwIfAborted();
+	if (
+		!sameStableFileState(opened.state, afterReadState) ||
+		!sameStableFileState(opened.state, currentSourceState) ||
+		currentCanonicalPath !== opened.canonicalPath
+	) {
+		throw unsafePath(opened.sourcePath);
+	}
+	return bytes;
+}
+
+function mimeTypeForFormat(format: string): string | undefined {
+	if (format === "png") return "image/png";
+	if (format === "jpeg" || format === "jpg") return "image/jpeg";
+	if (format === "gif") return "image/gif";
+	if (format === "webp") return "image/webp";
+	return undefined;
+}
+
+function skipGifSubBlocks(bytes: Buffer, startOffset: number): number | undefined {
+	let offset = startOffset;
+	while (offset < bytes.length) {
+		const length = bytes[offset] ?? 0;
+		offset += 1;
+		if (length === 0) return offset;
+		if (offset + length > bytes.length) return undefined;
+		offset += length;
+	}
+	return undefined;
+}
+
+function gifFrameCount(bytes: Buffer): number | undefined {
+	if (bytes.length < 13) return undefined;
+	const header = bytes.toString("latin1", 0, 6);
+	if (header !== "GIF87a" && header !== "GIF89a") return undefined;
+	let offset = 13;
+	const globalPacked = bytes[10] ?? 0;
+	if ((globalPacked & 0x80) !== 0) offset += 3 * 2 ** ((globalPacked & 0x07) + 1);
+	let frames = 0;
+	while (offset < bytes.length) {
+		const marker = bytes[offset];
+		if (marker === 0x3b) return frames;
+		if (marker === 0x21) {
+			if (offset + 2 > bytes.length) return undefined;
+			const nextOffset = skipGifSubBlocks(bytes, offset + 2);
+			if (nextOffset === undefined) return undefined;
+			offset = nextOffset;
+			continue;
+		}
+		if (marker !== 0x2c || offset + 10 > bytes.length) return undefined;
+		frames += 1;
+		const localPacked = bytes[offset + 9] ?? 0;
+		offset += 10;
+		if ((localPacked & 0x80) !== 0) offset += 3 * 2 ** ((localPacked & 0x07) + 1);
+		if (offset >= bytes.length) return undefined;
+		offset += 1;
+		const nextOffset = skipGifSubBlocks(bytes, offset);
+		if (nextOffset === undefined) return undefined;
+		offset = nextOffset;
+	}
+	return undefined;
+}
+
+function hasPngAnimation(bytes: Buffer): boolean {
+	let offset = 8;
+	while (offset + 12 <= bytes.length) {
+		const length = bytes.readUInt32BE(offset);
+		const end = offset + 12 + length;
+		if (end > bytes.length) return false;
+		if (bytes.toString("latin1", offset + 4, offset + 8) === "acTL") return true;
+		offset = end;
+	}
+	return false;
+}
+
+function hasWebpAnimation(bytes: Buffer): boolean {
+	let offset = 12;
+	while (offset + 8 <= bytes.length) {
+		const chunkType = bytes.toString("latin1", offset, offset + 4);
+		const length = bytes.readUInt32LE(offset + 4);
+		if (chunkType === "ANIM" || chunkType === "ANMF") return true;
+		offset += 8 + length + (length % 2);
+	}
+	return false;
+}
+
+function isAnimatedImage(bytes: Buffer, mimeType: string): boolean | undefined {
+	if (mimeType === "image/gif") {
+		const frames = gifFrameCount(bytes);
+		return frames === undefined ? undefined : frames > 1;
+	}
+	if (mimeType === "image/png") return hasPngAnimation(bytes);
+	if (mimeType === "image/webp") return hasWebpAnimation(bytes);
+	return false;
+}
+
+interface ValidatedImageStructure {
+	mimeType: string;
+	decodedBytes: number;
+}
+
+async function validateImageStructure(
+	bytes: Buffer,
+	imagePath: string,
+	signal: AbortSignal,
+	maxDimension: number,
+	maxPixels: number,
+	maxDecodedBytes: number,
+): Promise<ValidatedImageStructure> {
+	signal.throwIfAborted();
+	const parsed = parseImageMetadata(bytes);
+	const width = parsed?.width;
+	const height = parsed?.height;
+	if (!parsed || width === undefined || height === undefined || width <= 0 || height <= 0) {
+		throw new PastedImageBatchError(
+			"unsupported-image",
+			`Unsupported or incomplete pasted image: ${path.basename(imagePath)}`,
+			imagePath,
+		);
+	}
+	if (width > maxDimension || height > maxDimension || width * height > maxPixels) {
+		throw new PastedImageBatchError(
+			"dimensions-too-large",
+			`Pasted image dimensions are too large: ${path.basename(imagePath)} (${width}×${height})`,
+			imagePath,
+		);
+	}
+	const decodedBytes = width * height * 4;
+	if (decodedBytes > maxDecodedBytes) {
+		throw new PastedImageBatchError(
+			"dimensions-too-large",
+			`Pasted image decoded size is too large: ${path.basename(imagePath)} (${formatBytes(decodedBytes)})`,
+			imagePath,
+		);
+	}
+	const animated = isAnimatedImage(bytes, parsed.mimeType);
+	if (animated !== false) {
+		throw new PastedImageBatchError(
+			"unsupported-image",
+			`${animated ? "Animated" : "Malformed"} pasted images are not supported: ${path.basename(imagePath)}`,
+			imagePath,
+		);
+	}
+
+	try {
+		const decoded = await new Bun.Image(bytes).metadata();
+		signal.throwIfAborted();
+		const decodedMimeType = mimeTypeForFormat(decoded.format);
+		if (decoded.width !== width || decoded.height !== height || decodedMimeType !== parsed.mimeType) {
+			throw new Error("Image metadata mismatch");
+		}
+		await new Bun.Image(bytes).resize(1, 1).png().bytes();
+		signal.throwIfAborted();
+	} catch {
+		signal.throwIfAborted();
+		throw new PastedImageBatchError(
+			"unsupported-image",
+			`Unsupported or incomplete pasted image: ${path.basename(imagePath)}`,
+			imagePath,
+		);
+	}
+	return { mimeType: parsed.mimeType, decodedBytes };
+}
+
+export interface LoadPastedImageBatchOptions {
+	paths: readonly string[];
+	autoResize: boolean;
+	signal: AbortSignal;
+	sourcePolicy?: PastedImageSourcePolicy;
+	maxImageBytes?: number;
+	maxSourceBytes?: number;
+	maxOutputBytes?: number;
+	maxDimension?: number;
+	maxPixels?: number;
+	maxDecodedBytes?: number;
+	dependencies?: PastedImageLoadingDependencies;
+}
+
+export async function loadPastedImageBatch(options: LoadPastedImageBatchOptions): Promise<LoadedPastedImageBatch> {
+	const dependencies = options.dependencies ?? {};
+	const maxImageBytes = options.maxImageBytes ?? MAX_IMAGE_INPUT_BYTES;
+	const maxSourceBytes = options.maxSourceBytes ?? MAX_PASTED_IMAGE_SOURCE_BYTES;
+	const maxOutputBytes = options.maxOutputBytes ?? MAX_PASTED_IMAGE_OUTPUT_BYTES;
+	const maxDimension = options.maxDimension ?? MAX_PASTED_IMAGE_DIMENSION;
+	const maxPixels = options.maxPixels ?? MAX_PASTED_IMAGE_PIXELS;
+	const maxDecodedBytes = options.maxDecodedBytes ?? MAX_PASTED_IMAGE_DECODED_BYTES;
+	const transformImageBytes = dependencies.transformImageBytes ?? transformImageInputBytes;
+	const sourcePaths = [...options.paths];
+	if (sourcePaths.length > MAX_PASTED_IMAGE_COUNT) {
+		throw new PastedImageBatchError("too-many", `Cannot attach more than ${MAX_PASTED_IMAGE_COUNT} pasted images.`);
+	}
+	const sourcePolicy = options.sourcePolicy ?? "confirmed";
+	const lexicalTempRoot = sourcePolicy === "automatic-temp" ? path.resolve(os.tmpdir()) : undefined;
+	let canonicalTempRoot: string | undefined;
+	if (sourcePolicy === "automatic-temp") {
+		canonicalTempRoot = await fs.realpath(os.tmpdir());
+		options.signal.throwIfAborted();
+		if (isRemoteWindowsPath(canonicalTempRoot)) throw unsafePath(os.tmpdir());
+	}
+	const openedFiles: OpenPastedImage[] = [];
+	try {
+		let sourceBytes = 0;
+		for (const [index, imagePath] of sourcePaths.entries()) {
+			const opened = await openStablePastedImage(
+				imagePath,
+				index,
+				dependencies,
+				options.signal,
+				sourcePolicy,
+				canonicalTempRoot,
+				lexicalTempRoot,
+			);
+			openedFiles.push(opened);
+			if (opened.state.size > BigInt(maxImageBytes)) {
+				throw new ImageInputTooLargeError(Number(opened.state.size), maxImageBytes);
+			}
+			sourceBytes += Number(opened.state.size);
+			if (sourceBytes > maxSourceBytes) {
+				throw new PastedImageBatchError(
+					"source-aggregate-too-large",
+					`Pasted image sources total ${formatBytes(sourceBytes)}, exceeding the ${formatBytes(maxSourceBytes)} aggregate limit.`,
+				);
+			}
+		}
+
+		const loadedInputs: LoadedImageInput[] = [];
+		const images: ImageContent[] = [];
+		let outputPayloadBytes = 0;
+		let decodedBytes = 0;
+		for (const [index, opened] of openedFiles.entries()) {
+			options.signal.throwIfAborted();
+			await dependencies.beforeDescriptorRead?.(opened.sourcePath, index);
+			options.signal.throwIfAborted();
+			const bytes = await readExactDescriptor(opened, options.signal);
+			const validated = await validateImageStructure(
+				bytes,
+				opened.sourcePath,
+				options.signal,
+				maxDimension,
+				maxPixels,
+				maxDecodedBytes - decodedBytes,
+			);
+			decodedBytes += validated.decodedBytes;
+			const remainingPayloadBytes = maxOutputBytes - outputPayloadBytes;
+			const remainingRawBytes = Math.floor(remainingPayloadBytes / 4) * 3;
+			if (remainingRawBytes <= 0) {
+				throw new PastedImageBatchError(
+					"output-aggregate-too-large",
+					`Pasted image payloads exceed the ${formatBytes(maxOutputBytes)} aggregate limit.`,
+				);
+			}
+			const transformed: TransformedImageInput = await transformImageBytes({
+				inputBuffer: bytes,
+				resolvedPath: opened.sourcePath,
+				mimeType: validated.mimeType,
+				autoResize: options.autoResize,
+				maxBytes: maxImageBytes,
+				maxOutputBytes: Math.min(DEFAULT_IMAGE_RESIZE_MAX_BYTES, remainingRawBytes),
+				signal: options.signal,
+			});
+			options.signal.throwIfAborted();
+			const payloadBytes = Math.ceil(transformed.bytes / 3) * 4;
+			if (outputPayloadBytes + payloadBytes > maxOutputBytes) {
+				throw new PastedImageBatchError(
+					"output-aggregate-too-large",
+					`Pasted image payloads total ${formatBytes(outputPayloadBytes + payloadBytes)}, exceeding the ${formatBytes(maxOutputBytes)} aggregate limit.`,
+				);
+			}
+			outputPayloadBytes += payloadBytes;
+			const loaded = materializeImageInput(transformed);
+			loadedInputs.push(loaded);
+			images.push({ type: "image", data: loaded.data, mimeType: loaded.mimeType });
+		}
+		options.signal.throwIfAborted();
+		return { images, loadedInputs, sourcePaths };
+	} finally {
+		await Promise.all(openedFiles.map(file => file.handle.close().catch(() => {})));
+	}
+}

--- a/packages/coding-agent/src/utils/pasted-image-path.ts
+++ b/packages/coding-agent/src/utils/pasted-image-path.ts
@@ -1,14 +1,3 @@
-/**
- * Resolve pasted editor text to an image file path.
- *
- * Some terminal/clipboard integrations paste a temporary filesystem path after a
- * copied image is pasted into the editor (for example `/tmp/clipboard-...png`).
- * Only those recognized clipboard temp files are auto-attached and replaced with
- * an `[image N] source="/path"` reference so the model receives both the image
- * payload and the raw temp file path. Ordinary image paths remain literal prompt
- * text; users attach saved files explicitly with `@path/to/image.png`.
- */
-import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,12 +5,12 @@ import { fileURLToPath } from "node:url";
 const IMAGE_FILE_EXTENSION_PATTERN = /\.(?:png|jpe?g|gif|webp)$/i;
 const CLIPBOARD_TEMP_BASENAME_PATTERN = /^clipboard-\d{4}-\d{2}-\d{2}-\d{6}-[A-Za-z0-9-]+\.(?:png|jpe?g|gif|webp)$/i;
 
+export const MAX_PASTED_IMAGE_COUNT = 16;
+export const MAX_PASTED_IMAGE_PASTE_CHARACTERS = 1024 * 1024;
+export const MAX_PASTED_IMAGE_PATH_CHARACTERS = 32 * 1024;
+
 export interface DecodePastedPathOptions {
-	/**
-	 * Platform whose path semantics apply when decoding (shell unescaping,
-	 * `file://` drive letters / UNC hosts). Defaults to `process.platform`;
-	 * injectable so tests can pin the win32 contract from any host.
-	 */
+	/** Platform whose path and shell semantics apply. Defaults to `process.platform`. */
 	platform?: NodeJS.Platform;
 	/** Home directory for `~/` expansion. Defaults to `os.homedir()`. */
 	homedir?: string;
@@ -32,17 +21,30 @@ export interface ResolvePastedImagePathOptions extends DecodePastedPathOptions {
 	cwd?: string;
 }
 
-/**
- * Convert a `file://` URI to a filesystem path for the given platform, or
- * `undefined` when the URI is invalid.
- *
- * The production path (injected platform === host platform, always true
- * outside tests) delegates to Node's `fileURLToPath`. When tests inject a
- * foreign platform, a mirror of `fileURLToPath`'s rules is applied instead —
- * Bun (1.3) accepts but ignores `fileURLToPath`'s `windows` option, so the
- * native call cannot emulate a foreign platform.
- */
-function decodeFileUrl(candidate: string, platform: NodeJS.Platform): string | undefined {
+export type PastedImagePathParseResult =
+	| {
+			kind: "paths";
+			paths: string[];
+			requiresConfirmation: boolean;
+	  }
+	| {
+			kind: "too-many";
+			maxCandidates: number;
+	  };
+
+type PastedPathListState = "normal" | "escape" | "single-quote" | "double-quote";
+type EscapeReturnState = "normal" | "double-quote";
+
+type TokenizePastedPathsResult =
+	| { kind: "candidates"; candidates: string[] }
+	| { kind: "too-many"; maxCandidates: number; candidates: string[] }
+	| { kind: "invalid" };
+
+function pathApi(platform: NodeJS.Platform): typeof path.posix | typeof path.win32 {
+	return platform === "win32" ? path.win32 : path.posix;
+}
+
+function decodeFileUrl(candidate: string, platform: NodeJS.Platform, allowRemoteHost: boolean): string | undefined {
 	let url: URL;
 	try {
 		url = new URL(candidate);
@@ -50,6 +52,7 @@ function decodeFileUrl(candidate: string, platform: NodeJS.Platform): string | u
 		return undefined;
 	}
 	if (url.protocol !== "file:") return undefined;
+	if (!allowRemoteHost && url.hostname && url.hostname !== "localhost") return undefined;
 
 	if (platform === process.platform) {
 		try {
@@ -59,7 +62,6 @@ function decodeFileUrl(candidate: string, platform: NodeJS.Platform): string | u
 		}
 	}
 
-	// Foreign-platform mirror of fileURLToPath (tests only).
 	if (/%2f/i.test(url.pathname) || (platform === "win32" && /%5c/i.test(url.pathname))) return undefined;
 	let pathname: string;
 	try {
@@ -69,10 +71,8 @@ function decodeFileUrl(candidate: string, platform: NodeJS.Platform): string | u
 	}
 	if (platform === "win32") {
 		if (url.hostname && url.hostname !== "localhost") {
-			// UNC: file://server/share/img.png -> \\server\share\img.png
-			return `\\\\${url.hostname}${pathname.replaceAll("/", "\\")}`;
+			return allowRemoteHost ? `\\\\${url.hostname}${pathname.replaceAll("/", "\\")}` : undefined;
 		}
-		// Drive letter required: file:///C:/x -> C:\x
 		if (!/^\/[A-Za-z]:/.test(pathname)) return undefined;
 		return pathname.slice(1).replaceAll("/", "\\");
 	}
@@ -80,103 +80,228 @@ function decodeFileUrl(candidate: string, platform: NodeJS.Platform): string | u
 	return pathname;
 }
 
-/**
- * Decode pasted text into a filesystem path candidate. No filesystem access.
- *
- * Handles terminal drag-drop shell escaping (`\ `, `\(`, ...; skipped on
- * win32 where `\` is the path separator), quoted paths, `file://` URIs
- * (drive-letter, `file://localhost`, and UNC forms on win32), and `~/`
- * expansion. Returns `undefined` when the text is empty, spans multiple
- * lines, or is an invalid `file://` URI.
- */
-export function decodePastedPathCandidate(text: string, options?: DecodePastedPathOptions): string | undefined {
-	const platform = options?.platform ?? process.platform;
+function isRemoteWindowsPath(candidate: string): boolean {
+	return candidate.startsWith("\\\\") || candidate.startsWith("//");
+}
+
+function expandHome(candidate: string, options: DecodePastedPathOptions, platform: NodeJS.Platform): string {
+	if (!candidate.startsWith("~/")) return candidate;
+	return pathApi(platform).join(options.homedir ?? os.homedir(), candidate.slice(2));
+}
+
+/** Decode one pasted path candidate without filesystem access. */
+export function decodePastedPathCandidate(text: string, options: DecodePastedPathOptions = {}): string | undefined {
+	const platform = options.platform ?? process.platform;
 	let candidate = text.trim();
 	if (!candidate || /[\r\n]/.test(candidate)) return undefined;
 
-	// Quoted paths (some terminals quote instead of escaping).
 	if (
 		candidate.length >= 2 &&
 		(candidate.startsWith('"') || candidate.startsWith("'")) &&
-		candidate.endsWith(candidate[0])
+		candidate.endsWith(candidate[0] ?? "")
 	) {
 		candidate = candidate.slice(1, -1);
 	}
 
 	if (candidate.startsWith("file://")) {
-		const decoded = decodeFileUrl(candidate, platform);
+		const decoded = decodeFileUrl(candidate, platform, true);
 		if (decoded === undefined) return undefined;
 		candidate = decoded;
 	} else if (platform !== "win32") {
-		// Terminal drag-drop escapes shell-special characters (`\ `, `\(`, ...).
-		// Skipped on Windows where `\` is the path separator.
 		candidate = candidate.replace(/\\(.)/g, "$1");
 	}
+	return expandHome(candidate, options, platform);
+}
 
-	if (candidate.startsWith("~/")) {
-		candidate = path.join(options?.homedir ?? os.homedir(), candidate.slice(2));
+function isAsciiWhitespace(character: string): boolean {
+	return (
+		character === " " ||
+		character === "\t" ||
+		character === "\n" ||
+		character === "\r" ||
+		character === "\v" ||
+		character === "\f"
+	);
+}
+
+function decodeListToken(
+	candidate: string,
+	options: DecodePastedPathOptions,
+	platform: NodeJS.Platform,
+): string | undefined {
+	if (candidate.startsWith("file://")) {
+		const decoded = decodeFileUrl(candidate, platform, false);
+		if (decoded === undefined) return undefined;
+		candidate = decoded;
 	}
-
+	candidate = expandHome(candidate, options, platform);
+	if (platform === "win32" && isRemoteWindowsPath(candidate)) return undefined;
 	return candidate;
 }
 
-/**
- * Sniff the file header for a supported image signature (PNG, JPEG, GIF,
- * WEBP). Prevents existing non-image files with image-looking extensions
- * (e.g. a text file named `not-image.png`) from being treated as image
- * candidates — consuming such a paste would lose the raw path when the
- * image loader later rejects the content.
- */
-function hasSupportedImageMagic(filePath: string): boolean {
-	let fd: number;
-	try {
-		fd = fs.openSync(filePath, "r");
-	} catch {
-		return false;
+function tokenizePastedPathCandidates(
+	text: string,
+	options: DecodePastedPathOptions,
+	maxCandidates: number,
+): TokenizePastedPathsResult {
+	if (text.length > MAX_PASTED_IMAGE_PASTE_CHARACTERS) return { kind: "invalid" };
+	const platform = options.platform ?? process.platform;
+	const candidates: string[] = [];
+	let state: PastedPathListState = "normal";
+	let escapeReturnState: EscapeReturnState = "normal";
+	let candidate = "";
+	let candidateStarted = false;
+
+	const startCandidate = (): TokenizePastedPathsResult | undefined => {
+		if (candidateStarted) return undefined;
+		if (candidates.length >= maxCandidates) return { kind: "too-many", maxCandidates, candidates: [...candidates] };
+		candidateStarted = true;
+		return undefined;
+	};
+
+	const appendCandidate = (character: string): boolean => {
+		candidate += character;
+		return candidate.length <= MAX_PASTED_IMAGE_PATH_CHARACTERS;
+	};
+
+	const finishCandidate = (): TokenizePastedPathsResult | undefined => {
+		if (!candidateStarted) return undefined;
+		if (!candidate) return { kind: "invalid" };
+		if (candidates.length >= maxCandidates) return { kind: "too-many", maxCandidates, candidates: [...candidates] };
+		const decoded = decodeListToken(candidate, options, platform);
+		if (decoded === undefined) return { kind: "invalid" };
+		candidates.push(decoded);
+		candidate = "";
+		candidateStarted = false;
+		return undefined;
+	};
+
+	for (const character of text) {
+		if (state === "escape") {
+			if (!appendCandidate(character)) return { kind: "invalid" };
+			state = escapeReturnState;
+			continue;
+		}
+		if (state === "single-quote") {
+			if (character === "'") state = "normal";
+			else if (!appendCandidate(character)) return { kind: "invalid" };
+			continue;
+		}
+		if (state === "double-quote") {
+			if (character === '"') {
+				state = "normal";
+			} else if (character === "\\" && platform !== "win32") {
+				escapeReturnState = "double-quote";
+				state = "escape";
+			} else if (!appendCandidate(character)) {
+				return { kind: "invalid" };
+			}
+			continue;
+		}
+
+		if (isAsciiWhitespace(character)) {
+			const result = finishCandidate();
+			if (result) return result;
+		} else if (character === "'") {
+			const result = startCandidate();
+			if (result) return result;
+			state = "single-quote";
+		} else if (character === '"') {
+			const result = startCandidate();
+			if (result) return result;
+			state = "double-quote";
+		} else if (character === "\\" && platform !== "win32") {
+			const result = startCandidate();
+			if (result) return result;
+			escapeReturnState = "normal";
+			state = "escape";
+		} else {
+			const result = startCandidate();
+			if (result) return result;
+			if (!appendCandidate(character)) return { kind: "invalid" };
+		}
 	}
-	try {
-		// Zero-filled; short reads leave trailing zeros so comparisons fail safely.
-		const header = Buffer.alloc(12);
-		fs.readSync(fd, header, 0, 12, 0);
-		if (header[0] === 0x89 && header[1] === 0x50 && header[2] === 0x4e && header[3] === 0x47) return true; // PNG
-		if (header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff) return true; // JPEG
-		const ascii6 = header.toString("latin1", 0, 6);
-		if (ascii6 === "GIF87a" || ascii6 === "GIF89a") return true; // GIF
-		if (header.toString("latin1", 0, 4) === "RIFF" && header.toString("latin1", 8, 12) === "WEBP") return true; // WEBP
-		return false;
-	} catch {
-		return false;
-	} finally {
-		fs.closeSync(fd);
-	}
+
+	if (state !== "normal") return { kind: "invalid" };
+	const finalResult = finishCandidate();
+	if (finalResult) return finalResult;
+	return candidates.length === 0 ? { kind: "invalid" } : { kind: "candidates", candidates };
 }
 
-function isRecognizedClipboardTempPath(filePath: string): boolean {
-	const resolved = path.resolve(filePath);
-	const tempRoot = path.resolve(os.tmpdir());
-	if (resolved !== tempRoot && !resolved.startsWith(`${tempRoot}${path.sep}`)) return false;
-	return CLIPBOARD_TEMP_BASENAME_PATTERN.test(path.basename(resolved));
+/** Tokenize a bounded complete path list without filesystem access. */
+export function decodePastedPathCandidates(
+	text: string,
+	options: DecodePastedPathOptions = {},
+	maxCandidates = MAX_PASTED_IMAGE_COUNT,
+): string[] | undefined {
+	const result = tokenizePastedPathCandidates(text, options, maxCandidates);
+	return result.kind === "candidates" ? result.candidates : undefined;
 }
 
-/**
- * Returns the resolved path when the whole pasted text is a recognized clipboard
- * temp path to an existing image file, otherwise `undefined` (the paste is
- * inserted as text). Arbitrary saved image paths are not auto-attached here;
- * users attach them explicitly with `@path/to/image.png`.
- */
-export function resolvePastedImagePath(text: string, options?: ResolvePastedImagePathOptions): string | undefined {
+function resolveCandidate(
+	candidate: string,
+	options: ResolvePastedImagePathOptions,
+	platform: NodeJS.Platform,
+): string {
+	return pathApi(platform).resolve(options.cwd ?? process.cwd(), candidate);
+}
+
+function isRecognizedClipboardTempPath(filePath: string, platform: NodeJS.Platform): boolean {
+	const api = pathApi(platform);
+	const resolved = api.resolve(filePath);
+	const tempRoot = api.resolve(os.tmpdir());
+	if (resolved !== tempRoot && !resolved.startsWith(`${tempRoot}${api.sep}`)) return false;
+	return CLIPBOARD_TEMP_BASENAME_PATTERN.test(api.basename(resolved));
+}
+
+/** Resolve one recognized clipboard-temp image path lexically, before any filesystem access. */
+export function resolvePastedImagePath(text: string, options: ResolvePastedImagePathOptions = {}): string | undefined {
+	const platform = options.platform ?? process.platform;
 	const candidate = decodePastedPathCandidate(text, options);
 	if (!candidate || !IMAGE_FILE_EXTENSION_PATTERN.test(candidate)) return undefined;
+	if (platform === "win32" && isRemoteWindowsPath(candidate)) return undefined;
+	const resolved = resolveCandidate(candidate, options, platform);
+	return isRecognizedClipboardTempPath(resolved, platform) ? resolved : undefined;
+}
 
-	const resolved = path.resolve(options?.cwd ?? process.cwd(), candidate);
-	if (!isRecognizedClipboardTempPath(resolved)) return undefined;
-	try {
-		if (!fs.statSync(resolved).isFile()) return undefined;
-	} catch {
-		return undefined;
+/**
+ * Parse a complete image path paste without filesystem access. A single path
+ * keeps the clipboard-temp-only policy; multi-path saved-image pastes require
+ * explicit confirmation before any path is opened.
+ */
+export function parsePastedImagePaths(
+	text: string,
+	options: ResolvePastedImagePathOptions = {},
+): PastedImagePathParseResult | undefined {
+	const platform = options.platform ?? process.platform;
+	const tokenized = tokenizePastedPathCandidates(text, options, MAX_PASTED_IMAGE_COUNT);
+	if (tokenized.kind === "too-many") {
+		if (
+			tokenized.candidates.length !== MAX_PASTED_IMAGE_COUNT ||
+			tokenized.candidates.some(
+				candidate =>
+					!IMAGE_FILE_EXTENSION_PATTERN.test(candidate) ||
+					(platform === "win32" && isRemoteWindowsPath(candidate)),
+			)
+		) {
+			return undefined;
+		}
+		return { kind: "too-many", maxCandidates: tokenized.maxCandidates };
 	}
-	if (!hasSupportedImageMagic(resolved)) return undefined;
-	return resolved;
+	if (tokenized.kind !== "candidates") return undefined;
+
+	if (tokenized.candidates.length === 1) {
+		const resolved = resolvePastedImagePath(text, options);
+		return resolved ? { kind: "paths", paths: [resolved], requiresConfirmation: false } : undefined;
+	}
+
+	const paths: string[] = [];
+	for (const candidate of tokenized.candidates) {
+		if (!IMAGE_FILE_EXTENSION_PATTERN.test(candidate)) return undefined;
+		if (platform === "win32" && isRemoteWindowsPath(candidate)) return undefined;
+		paths.push(resolveCandidate(candidate, options, platform));
+	}
+	return { kind: "paths", paths, requiresConfirmation: true };
 }
 
 export function formatPastedImageReference(placeholder: string, imagePath: string): string {

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -289,6 +289,17 @@ describe("CustomEditor pasteImage default sourced from KEYBINDINGS", () => {
 });
 
 describe("CustomEditor bracketed paste interception", () => {
+	it("does not retain a standalone Escape as a possible paste prefix", () => {
+		const editor = createEditor();
+		const onEscape = vi.fn();
+		editor.onEscape = onEscape;
+		editor.onPasteText = vi.fn(() => false);
+
+		editor.handleInput("\x1b");
+
+		expect(onEscape).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("");
+	});
 	it("lets coding-agent consume pasted content before the base editor stores it", async () => {
 		const editor = createEditor();
 		const onPasteText = vi.fn(() => true);
@@ -297,7 +308,10 @@ describe("CustomEditor bracketed paste interception", () => {
 		editor.handleInput("\x1b[200~/tmp/clipboard-2026-06-04-120441-CAC144E7.png\x1b[201~");
 		await Bun.sleep(0);
 
-		expect(onPasteText).toHaveBeenCalledWith("/tmp/clipboard-2026-06-04-120441-CAC144E7.png");
+		expect(onPasteText).toHaveBeenCalledWith(
+			"/tmp/clipboard-2026-06-04-120441-CAC144E7.png",
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
 		expect(editor.getText()).toBe("");
 	});
 
@@ -309,8 +323,25 @@ describe("CustomEditor bracketed paste interception", () => {
 		editor.handleInput("\x1b[200~hello\x1b[201~");
 		await Bun.sleep(0);
 
-		expect(onPasteText).toHaveBeenCalledWith("hello");
+		expect(onPasteText).toHaveBeenCalledWith("hello", expect.objectContaining({ signal: expect.any(AbortSignal) }));
 		expect(editor.getText()).toBe("hello");
+	});
+
+	it("processes leading command text before a split bracketed paste marker", async () => {
+		const editor = createEditor();
+		const observedDrafts: string[] = [];
+		editor.onPasteText = vi.fn(() => {
+			observedDrafts.push(editor.getText());
+			return false;
+		});
+
+		editor.handleInput("!command \x1b[20");
+		expect(editor.getText()).toBe("");
+		editor.handleInput("0~/tmp/one.png /tmp/two.png\x1b[201~ tail");
+		await Bun.sleep(0);
+
+		expect(observedDrafts).toEqual(["!command "]);
+		expect(editor.getText()).toBe("!command /tmp/one.png /tmp/two.png tail");
 	});
 
 	it("follows live before dispatching an async consumed paste and replays later input afterward", async () => {
@@ -361,12 +392,21 @@ describe("CustomEditor bracketed paste interception", () => {
 		expect(trace).toEqual(["follow", "paste", "follow"]);
 	});
 
-	it("drops queued input and ignores late async paste decisions after timeout", async () => {
+	it("aborts timed-out paste handling, restores exact input, and ignores late completion", async () => {
 		vi.useFakeTimers();
 		const editor = createEditor();
 		const pasteDecision = Promise.withResolvers<boolean>();
 		const onPastePendingInputCleared = vi.fn();
-		editor.onPasteText = vi.fn(() => pasteDecision.promise);
+		let pasteSignal: AbortSignal | undefined;
+		let committed = false;
+		editor.onPasteText = vi.fn(async (_text, context) => {
+			pasteSignal = context.signal;
+			await pasteDecision.promise;
+			return context.commit(() => {
+				committed = true;
+				return true;
+			});
+		});
 		editor.onPastePendingInputCleared = onPastePendingInputCleared;
 
 		editor.handleInput("before ");
@@ -374,51 +414,95 @@ describe("CustomEditor bracketed paste interception", () => {
 		editor.handleInput("after");
 
 		expect(editor.getText()).toBe("before ");
-
 		vi.advanceTimersByTime(5_000);
+
+		expect(pasteSignal?.aborted).toBe(true);
 		expect(onPastePendingInputCleared).toHaveBeenCalledWith("timeout", 1);
+		expect(editor.getText()).toBe("before middle after");
 
-		pasteDecision.resolve(false);
+		pasteDecision.resolve(true);
 		await Promise.resolve();
-
-		expect(editor.getText()).toBe("before ");
+		expect(committed).toBe(false);
+		expect(editor.getText()).toBe("before middle after");
 	});
 
-	it("bounds the async paste input queue and clears pending state", async () => {
+	it("aborts at the input queue bound and restores every bounded input event", async () => {
 		const editor = createEditor();
 		const pasteDecision = Promise.withResolvers<boolean>();
 		const onPastePendingInputCleared = vi.fn();
-		editor.onPasteText = vi.fn(() => pasteDecision.promise);
+		let pasteSignal: AbortSignal | undefined;
+		editor.onPasteText = vi.fn((_text, context) => {
+			pasteSignal = context.signal;
+			return pasteDecision.promise;
+		});
 		editor.onPastePendingInputCleared = onPastePendingInputCleared;
 
 		editor.handleInput("before ");
 		editor.handleInput("\x1b[200~middle \x1b[201~");
-		for (let index = 0; index < 65; index += 1) {
-			editor.handleInput(`queued-${index} `);
-		}
+		const queued = Array.from({ length: 65 }, (_, index) => `queued-${index} `);
+		for (const input of queued) editor.handleInput(input);
 
+		expect(pasteSignal?.aborted).toBe(true);
 		expect(onPastePendingInputCleared).toHaveBeenCalledWith("queue-limit", 65);
-		expect(editor.getText()).toBe("before ");
+		expect(editor.getText()).toBe(`before middle ${queued.join("")}`);
 
-		pasteDecision.resolve(false);
+		pasteDecision.resolve(true);
 		await Bun.sleep(0);
-
-		expect(editor.getText()).toBe("before ");
+		expect(editor.getText()).toBe(`before middle ${queued.join("")}`);
 	});
 
-	it("clears pending async paste state when disposed", async () => {
+	it("aborts before retaining a queued input event above the aggregate byte bound", async () => {
 		const editor = createEditor();
 		const pasteDecision = Promise.withResolvers<boolean>();
-		editor.onPasteText = vi.fn(() => pasteDecision.promise);
+		const onPastePendingInputCleared = vi.fn();
+		let pasteSignal: AbortSignal | undefined;
+		editor.onPasteText = vi.fn((_text, context) => {
+			pasteSignal = context.signal;
+			return pasteDecision.promise;
+		});
+		editor.onPastePendingInputCleared = onPastePendingInputCleared;
+		const oversizedInput = "x".repeat(256 * 1024 + 1);
+
+		editor.handleInput("\x1b[200~middle \x1b[201~");
+		editor.handleInput(oversizedInput);
+
+		expect(pasteSignal?.aborted).toBe(true);
+		expect(onPastePendingInputCleared).toHaveBeenCalledWith("queue-limit", 1);
+		expect(editor.getText()).toBe(`middle ${oversizedInput}`);
+	});
+
+	it("rejects oversized trailing input coalesced with the completed paste frame", () => {
+		const editor = createEditor();
+		const onPasteText = vi.fn(() => true);
+		const onPastePendingInputCleared = vi.fn();
+		editor.onPasteText = onPasteText;
+		editor.onPastePendingInputCleared = onPastePendingInputCleared;
+		const oversizedRemaining = "x".repeat(256 * 1024 + 1);
+
+		editor.handleInput(`\x1b[200~middle \x1b[201~${oversizedRemaining}`);
+
+		expect(onPasteText).not.toHaveBeenCalled();
+		expect(onPastePendingInputCleared).toHaveBeenCalledWith("queue-limit", 1);
+		expect(editor.getText()).toBe(`middle ${oversizedRemaining}`);
+	});
+
+	it("aborts pending async paste state when disposed and ignores late completion", async () => {
+		const editor = createEditor();
+		const pasteDecision = Promise.withResolvers<boolean>();
+		let pasteSignal: AbortSignal | undefined;
+		editor.onPasteText = vi.fn((_text, context) => {
+			pasteSignal = context.signal;
+			return pasteDecision.promise;
+		});
 
 		editor.handleInput("before ");
 		editor.handleInput("\x1b[200~middle \x1b[201~");
 		editor.handleInput("after");
 		editor.dispose();
 
+		expect(pasteSignal?.aborted).toBe(true);
 		pasteDecision.resolve(false);
 		await Bun.sleep(0);
-
 		expect(editor.getText()).toBe("before ");
 	});
 });

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -1,15 +1,25 @@
-import { beforeAll, describe, expect, it, type Mock, vi } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it, type Mock, vi } from "bun:test";
 
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-
+import { defaultEditorTheme } from "../../tui/test/test-themes";
+import { CustomEditor, type PasteTextContext } from "../src/modes/components/custom-editor";
 import { QueuedMessageSelectorComponent } from "../src/modes/components/queued-message-selector";
 import { InputController } from "../src/modes/controllers/input-controller";
 import { initTheme } from "../src/modes/theme/theme";
 import type { CompactionQueuedMessage, ComposerSubmissionOptions, InteractiveModeContext } from "../src/modes/types";
 import type { QueuedMessageEditEntry } from "../src/session/agent-session";
+import type { LoadedPastedImageBatch, LoadPastedImageBatchOptions } from "../src/utils/pasted-image-loading";
+import { formatPastedImageReference } from "../src/utils/pasted-image-path";
 
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function pasteTextContext(signal = new AbortController().signal): PasteTextContext {
+	return { signal, commit: commit => commit() };
+}
 type FakeEditor = {
 	onEscape?: () => void;
 	shouldBypassAutocompleteOnEscape?: () => boolean;
@@ -24,7 +34,7 @@ type FakeEditor = {
 	onHistorySearch?: () => void;
 	onShowHotkeys?: () => void;
 	onPasteImage?: () => Promise<boolean>;
-	onPasteText?: (text: string) => boolean | Promise<boolean>;
+	onPasteText?: (text: string, context: PasteTextContext) => boolean | Promise<boolean>;
 	onCopyPrompt?: () => void;
 	onExpandTools?: () => void;
 	onToggleThinking?: () => void;
@@ -66,6 +76,7 @@ async function createContext(options?: {
 	const handleBashCommand = vi.fn(async () => {});
 	const showStatus = vi.fn();
 	const onInputCallback = vi.fn();
+	const showHookSelector = vi.fn(async () => "Attach images" as string | undefined);
 	const toggleIrcSidebar = vi.fn();
 	const startPendingSubmission = vi.fn(
 		(
@@ -154,7 +165,12 @@ async function createContext(options?: {
 	};
 	const ctx = {
 		editor: editor as unknown as InteractiveModeContext["editor"],
-		ui: { requestRender: vi.fn(), setFocus: vi.fn() } as unknown as InteractiveModeContext["ui"],
+		ui: {
+			requestRender: vi.fn(),
+			setFocus: vi.fn(),
+			followLiveViewport: vi.fn(),
+			scrollViewportPages: vi.fn(),
+		} as unknown as InteractiveModeContext["ui"],
 		editorContainer: editorContainer as unknown as InteractiveModeContext["editorContainer"],
 		loadingAnimation: undefined,
 		autoCompactionLoader: undefined,
@@ -253,6 +269,7 @@ async function createContext(options?: {
 		showWarning: vi.fn(),
 		showStatus,
 		showError: vi.fn(),
+		showHookSelector,
 
 		hasActiveBtw: vi.fn(() => false),
 	} as unknown as InteractiveModeContext;
@@ -270,6 +287,7 @@ async function createContext(options?: {
 			updatePendingMessagesDisplay,
 			handleBashCommand,
 			showStatus,
+			showHookSelector,
 			queueCompactionMessage,
 			popLastQueuedMessage,
 			clearQueue,
@@ -923,37 +941,301 @@ describe("InputController keybinding setup", () => {
 	});
 });
 
-describe("InputController pasted clipboard image paths", () => {
+describe("InputController pasted image path transactions", () => {
 	const RED_1X1_PNG_BASE64 =
 		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
 
-	it("attaches terminal-pasted clipboard temp images and preserves the source path in the placeholder", async () => {
+	it("attaches one clipboard-temp image without confirmation", async () => {
 		const imagePath = path.join(os.tmpdir(), `clipboard-2026-06-04-120441-${process.pid.toString(36)}CAC144E7.png`);
 		await Bun.write(imagePath, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
 		try {
 			const { InputController, ctx, editor, spies } = await createContext();
 			const controller = new InputController(ctx);
-
 			controller.setupKeyHandlers();
-			const handled = await editor.onPasteText?.(`${imagePath}\n`);
+			const handled = await editor.onPasteText?.(`${imagePath}\n`, pasteTextContext());
 
 			expect(handled).toBe(true);
 			expect(editor.getText()).toBe(`[image 1] source=${JSON.stringify(imagePath)} `);
 			expect(ctx.pendingImages).toHaveLength(1);
 			expect(ctx.pendingImages[0]?.mimeType).toBe("image/png");
-			expect(spies.showStatus).toHaveBeenCalledWith(`Attached image: ${imagePath.split("/").at(-1)}`, { dim: true });
+			expect(spies.showHookSelector).not.toHaveBeenCalled();
+			expect(spies.showStatus).toHaveBeenCalledWith(`Attached image: ${path.basename(imagePath)}`, { dim: true });
 		} finally {
 			await fs.rm(imagePath, { force: true });
 		}
 	});
 
-	it("leaves ordinary pasted text for the editor", async () => {
+	it("confirms and atomically attaches saved-image batches in source order", async () => {
+		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-controller-pasted-images-"));
+		const first = path.join(directory, "first.png");
+		const second = path.join(directory, "second.png");
+		await Bun.write(first, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		await Bun.write(second, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		try {
+			const { InputController, ctx, editor, spies } = await createContext();
+			ctx.pendingImages = [{ type: "image", data: "existing", mimeType: "image/png" }];
+			const insertText = vi.spyOn(editor, "insertText");
+			const requestRender = vi.spyOn(ctx.ui, "requestRender");
+			const controller = new InputController(ctx);
+			controller.setupKeyHandlers();
+
+			const handled = await editor.onPasteText?.(`${first} ${second}`, pasteTextContext());
+
+			expect(handled).toBe(true);
+			expect(spies.showHookSelector).toHaveBeenCalledWith(
+				expect.stringContaining("Attach 2 pasted images?"),
+				["Attach images", "Paste paths literally"],
+				expect.objectContaining({ signal: expect.any(AbortSignal) }),
+			);
+			expect(editor.getText()).toBe(
+				`${formatPastedImageReference("[image 2]", first)} ${formatPastedImageReference("[image 3]", second)} `,
+			);
+			expect(ctx.pendingImages).toHaveLength(3);
+			expect(insertText).toHaveBeenCalledTimes(1);
+			expect(requestRender).toHaveBeenCalledTimes(1);
+			expect(spies.showStatus).toHaveBeenCalledWith("Attached 2 images", { dim: true });
+		} finally {
+			await fs.rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("rolls back composer state when the attachment commit throws", async () => {
+		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-controller-rollback-"));
+		const first = path.join(directory, "first.png");
+		const second = path.join(directory, "second.png");
+		await Bun.write(first, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		await Bun.write(second, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		try {
+			const { InputController, ctx, editor } = await createContext();
+			const existingImage: InteractiveModeContext["pendingImages"][number] = {
+				type: "image",
+				data: "existing",
+				mimeType: "image/png",
+			};
+			ctx.pendingImages = [existingImage];
+			editor.setText("draft ");
+			const controller = new InputController(ctx);
+			controller.setupKeyHandlers();
+			const setText = editor.setText.bind(editor);
+			vi.spyOn(editor, "setText").mockImplementation(text => {
+				setText(text);
+				editor.onChange?.(text);
+			});
+			vi.spyOn(editor, "insertText").mockImplementationOnce(text => {
+				editor.setText(`partial ${text}`);
+				throw new Error("commit failed");
+			});
+
+			const handled = await editor.onPasteText?.(`${first} ${second}`, pasteTextContext());
+
+			expect(handled).toBe(false);
+			expect(editor.getText()).toBe("draft ");
+			expect(ctx.pendingImages).toEqual([existingImage]);
+		} finally {
+			await fs.rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps a successful attachment consumed when status rendering fails", async () => {
+		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-controller-status-"));
+		const first = path.join(directory, "first.png");
+		const second = path.join(directory, "second.png");
+		await Bun.write(first, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		await Bun.write(second, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		try {
+			const { InputController, ctx, editor, spies } = await createContext();
+			spies.showStatus.mockImplementationOnce(() => {
+				throw new Error("render failed");
+			});
+			const controller = new InputController(ctx);
+			controller.setupKeyHandlers();
+
+			const handled = await editor.onPasteText?.(`${first} ${second}`, pasteTextContext());
+
+			expect(handled).toBe(true);
+			expect(editor.getText()).toContain("[image 1]");
+			expect(ctx.pendingImages).toHaveLength(2);
+		} finally {
+			await fs.rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("uses confirmation rejection as a literal-paste bypass without filesystem access", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		spies.showHookSelector.mockResolvedValueOnce("Paste paths literally");
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		const handled = await editor.onPasteText?.("/missing/first.png /missing/second.png", pasteTextContext());
+
+		expect(handled).toBe(false);
+		expect(editor.getText()).toBe("");
+		expect(ctx.pendingImages).toEqual([]);
+		expect(spies.showStatus).not.toHaveBeenCalled();
+	});
+
+	it("leaves image path lists literal in bash and Python composer modes", async () => {
+		for (const mode of ["bash", "python"] as const) {
+			const { InputController, ctx, editor, spies } = await createContext();
+			ctx.isBashMode = mode === "bash";
+			ctx.isPythonMode = mode === "python";
+			const controller = new InputController(ctx);
+			controller.setupKeyHandlers();
+			const handled = await editor.onPasteText?.("/tmp/first.png /tmp/second.png", pasteTextContext());
+			expect(handled).toBe(false);
+			expect(spies.showHookSelector).not.toHaveBeenCalled();
+		}
+	});
+
+	it("does not attach after the paste transaction is aborted", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		const abortController = new AbortController();
+		abortController.abort(new Error("expired"));
+
+		const handled = await editor.onPasteText?.(
+			"/tmp/first.png /tmp/second.png",
+			pasteTextContext(abortController.signal),
+		);
+
+		expect(handled).toBe(false);
+		expect(editor.getText()).toBe("");
+		expect(ctx.pendingImages).toEqual([]);
+		expect(spies.showStatus).not.toHaveBeenCalled();
+	});
+
+	it("integrates editor timeout abort with controller loading and exact replay", async () => {
+		vi.useFakeTimers();
+		const { InputController, ctx } = await createContext();
+		const realEditor = new CustomEditor(defaultEditorTheme);
+		ctx.editor = realEditor;
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const finished = Promise.withResolvers<void>();
+		const loadPastedImageBatch = vi.fn(
+			async (options: LoadPastedImageBatchOptions): Promise<LoadedPastedImageBatch> => {
+				started.resolve();
+				try {
+					await release.promise;
+					options.signal.throwIfAborted();
+					return { images: [], loadedInputs: [], sourcePaths: [] };
+				} finally {
+					finished.resolve();
+				}
+			},
+		);
+		const controller = new InputController(ctx, { loadPastedImageBatch });
+		controller.setupKeyHandlers();
+
+		realEditor.handleInput("before ");
+		realEditor.handleInput("\x1b[200~/tmp/first.png /tmp/second.png \x1b[201~");
+		realEditor.handleInput("after");
+		await started.promise;
+		expect(realEditor.getText()).toBe("before ");
+
+		vi.advanceTimersByTime(5_000);
+		expect(realEditor.getText()).toBe("before /tmp/first.png /tmp/second.png after");
+		expect(ctx.pendingImages).toEqual([]);
+
+		release.resolve();
+		await finished.promise;
+		expect(realEditor.getText()).toBe("before /tmp/first.png /tmp/second.png after");
+		expect(ctx.pendingImages).toEqual([]);
+		realEditor.dispose();
+	});
+
+	it("processes a command prefix before a coalesced image-path paste", async () => {
+		const { InputController, ctx, spies } = await createContext();
+		const realEditor = new CustomEditor(defaultEditorTheme);
+		ctx.editor = realEditor;
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		realEditor.handleInput("!echo \x1b[200~/tmp/first.png /tmp/second.png\x1b[201~");
+		await Bun.sleep(0);
+
+		expect(ctx.isBashMode).toBe(true);
+		expect(realEditor.getText()).toBe("!echo /tmp/first.png /tmp/second.png");
+		expect(spies.showHookSelector).not.toHaveBeenCalled();
+		expect(ctx.pendingImages).toEqual([]);
+		realEditor.dispose();
+	});
+
+	it("replays confirmed path text literally when the user declines attachment", async () => {
+		const { InputController, ctx, spies } = await createContext();
+		spies.showHookSelector.mockResolvedValueOnce("Paste paths literally");
+		const realEditor = new CustomEditor(defaultEditorTheme);
+		ctx.editor = realEditor;
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		realEditor.handleInput("before \x1b[200~/tmp/first.png /tmp/second.png\x1b[201~ after");
+		await Bun.sleep(0);
+
+		expect(realEditor.getText()).toBe("before /tmp/first.png /tmp/second.png after");
+		expect(ctx.pendingImages).toEqual([]);
+		realEditor.dispose();
+	});
+
+	it("does not commit into a successor composer", async () => {
+		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-controller-successor-"));
+		const first = path.join(directory, "first.png");
+		const second = path.join(directory, "second.png");
+		await Bun.write(first, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		await Bun.write(second, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		try {
+			const { InputController, ctx, editor, spies } = await createContext();
+			const successorInsertText = vi.fn();
+			const replacementImage: InteractiveModeContext["pendingImages"][number] = {
+				type: "image",
+				data: "replacement",
+				mimeType: "image/png",
+			};
+			const successor = {
+				...editor,
+				insertText: successorInsertText,
+			} as unknown as InteractiveModeContext["editor"];
+			spies.showHookSelector.mockImplementationOnce(async () => {
+				editor.setText("replacement draft");
+				ctx.pendingImages = [replacementImage];
+				ctx.editor = successor;
+				return "Attach images";
+			});
+			const controller = new InputController(ctx);
+			controller.setupKeyHandlers();
+
+			const handled = await editor.onPasteText?.(`${first} ${second}`, pasteTextContext());
+
+			expect(handled).toBe(false);
+			expect(editor.getText()).toBe("replacement draft");
+			expect(successorInsertText).not.toHaveBeenCalled();
+			expect(ctx.pendingImages).toEqual([replacementImage]);
+			expect(spies.showStatus).not.toHaveBeenCalled();
+		} finally {
+			await fs.rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects over-limit lists before opening paths", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		const text = Array.from({ length: 17 }, (_, index) => `/missing/${index}.png`).join(" ");
+
+		const handled = await editor.onPasteText?.(text, pasteTextContext());
+
+		expect(handled).toBe(false);
+		expect(ctx.pendingImages).toEqual([]);
+		expect(spies.showHookSelector).not.toHaveBeenCalled();
+		expect(spies.showStatus).toHaveBeenCalledWith("Cannot attach more than 16 pasted images.");
+	});
+
+	it("leaves ordinary single saved paths literal", async () => {
 		const { InputController, ctx, editor } = await createContext();
 		const controller = new InputController(ctx);
-
 		controller.setupKeyHandlers();
-		const handled = await editor.onPasteText?.("/tmp/not-a-clipboard-image.png");
-
+		const handled = await editor.onPasteText?.("/tmp/not-a-clipboard-image.png", pasteTextContext());
 		expect(handled).toBe(false);
 		expect(editor.getText()).toBe("");
 		expect(ctx.pendingImages).toHaveLength(0);

--- a/packages/coding-agent/test/pasted-image-loading.test.ts
+++ b/packages/coding-agent/test/pasted-image-loading.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { TransformedImageInput } from "../src/utils/image-loading";
+import { ImageInputTooLargeError } from "../src/utils/image-loading";
+import { loadPastedImageBatch, PastedImageBatchError } from "../src/utils/pasted-image-loading";
+
+const RED_1X1_PNG = Buffer.from(
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+	"base64",
+);
+
+describe("loadPastedImageBatch", () => {
+	let testDirectory: string;
+
+	beforeEach(async () => {
+		testDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-pasted-image-loading-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(testDirectory, { recursive: true, force: true });
+	});
+
+	async function writeImage(name: string, bytes = RED_1X1_PNG): Promise<string> {
+		const imagePath = path.join(testDirectory, name);
+		await Bun.write(imagePath, bytes);
+		return imagePath;
+	}
+
+	it("loads structurally valid images from stable descriptors in source order", async () => {
+		const first = await writeImage("first.png");
+		const second = await writeImage("second.png");
+		const result = await loadPastedImageBatch({
+			paths: [second, first],
+			autoResize: false,
+			signal: new AbortController().signal,
+		});
+
+		expect(result.sourcePaths).toEqual([second, first]);
+		expect(result.images.map(image => image.mimeType)).toEqual(["image/png", "image/png"]);
+	});
+
+	it("rejects over-limit direct calls before opening any path", async () => {
+		const afterDescriptorOpen = vi.fn();
+		const paths = Array.from({ length: 17 }, (_, index) => path.join(testDirectory, `${index}.png`));
+		await expect(
+			loadPastedImageBatch({
+				paths,
+				autoResize: false,
+				signal: new AbortController().signal,
+				dependencies: { afterDescriptorOpen },
+			}),
+		).rejects.toMatchObject({ code: "too-many" });
+		expect(afterDescriptorOpen).not.toHaveBeenCalled();
+	});
+
+	it("rejects leaf symlinks instead of following them", async () => {
+		const target = await writeImage("private.png");
+		const link = path.join(testDirectory, "clipboard-2026-07-19-123456-Ab3.png");
+		await fs.symlink(target, link);
+
+		await expect(
+			loadPastedImageBatch({ paths: [link], autoResize: false, signal: new AbortController().signal }),
+		).rejects.toMatchObject({ code: "unsafe-path" });
+	});
+
+	it("rejects hard-linked image leaves", async () => {
+		const target = await writeImage("private.png");
+		const link = path.join(testDirectory, "linked.png");
+		await fs.link(target, link);
+		await expect(
+			loadPastedImageBatch({ paths: [link], autoResize: false, signal: new AbortController().signal }),
+		).rejects.toMatchObject({ code: "unsafe-path" });
+	});
+
+	it("keeps automatic clipboard paths inside the canonical temp root", async () => {
+		const outsideDirectory = await fs.mkdtemp(path.join(os.homedir(), ".gjc-pasted-image-outside-"));
+		const outsideImage = path.join(outsideDirectory, "clipboard-2026-07-19-123456-Ab3.png");
+		const linkedParent = path.join(testDirectory, "linked-parent");
+		await Bun.write(outsideImage, RED_1X1_PNG);
+		await fs.symlink(outsideDirectory, linkedParent);
+		const escapedPath = path.join(linkedParent, path.basename(outsideImage));
+		try {
+			await expect(
+				loadPastedImageBatch({
+					paths: [escapedPath],
+					autoResize: false,
+					sourcePolicy: "automatic-temp",
+					signal: new AbortController().signal,
+				}),
+			).rejects.toMatchObject({ code: "unsafe-path" });
+			await expect(
+				loadPastedImageBatch({
+					paths: [escapedPath],
+					autoResize: false,
+					sourcePolicy: "confirmed",
+					signal: new AbortController().signal,
+				}),
+			).resolves.toMatchObject({ sourcePaths: [escapedPath] });
+		} finally {
+			await fs.rm(outsideDirectory, { recursive: true, force: true });
+		}
+	});
+
+	it("snapshots the confirmed path array before asynchronous preflight", async () => {
+		const first = await writeImage("first.png");
+		const paths = [first];
+		const result = await loadPastedImageBatch({
+			paths,
+			autoResize: false,
+			signal: new AbortController().signal,
+			dependencies: {
+				afterDescriptorOpen: () => {
+					paths.push(...Array.from({ length: 16 }, (_, index) => path.join(testDirectory, `${index}.png`)));
+				},
+			},
+		});
+		expect(result.sourcePaths).toEqual([first]);
+	});
+
+	it("rejects a pathname swap after opening instead of reading the replacement", async () => {
+		const original = await writeImage("original.png");
+		const replacement = await writeImage("replacement.png");
+		const movedOriginal = path.join(testDirectory, "moved-original.png");
+
+		await expect(
+			loadPastedImageBatch({
+				paths: [original],
+				autoResize: false,
+				signal: new AbortController().signal,
+				dependencies: {
+					afterDescriptorOpen: async () => {
+						await fs.rename(original, movedOriginal);
+						await fs.rename(replacement, original);
+					},
+				},
+			}),
+		).rejects.toMatchObject({ code: "unsafe-path" });
+	});
+
+	it("enforces source aggregate limits before reading any descriptor", async () => {
+		const first = await writeImage("first.png");
+		const second = await writeImage("second.png");
+		const beforeRead = vi.fn();
+		const exactBytes = RED_1X1_PNG.byteLength * 2;
+
+		await expect(
+			loadPastedImageBatch({
+				paths: [first, second],
+				autoResize: false,
+				signal: new AbortController().signal,
+				maxSourceBytes: exactBytes - 1,
+				dependencies: { beforeDescriptorRead: beforeRead },
+			}),
+		).rejects.toMatchObject({ code: "source-aggregate-too-large" });
+		expect(beforeRead).not.toHaveBeenCalled();
+
+		await expect(
+			loadPastedImageBatch({
+				paths: [first, second],
+				autoResize: false,
+				signal: new AbortController().signal,
+				maxSourceBytes: exactBytes,
+			}),
+		).resolves.toMatchObject({ sourcePaths: [first, second] });
+	});
+
+	it("enforces the per-image source limit before reading", async () => {
+		const imagePath = await writeImage("large.png");
+		const beforeRead = vi.fn();
+		await expect(
+			loadPastedImageBatch({
+				paths: [imagePath],
+				autoResize: false,
+				signal: new AbortController().signal,
+				maxImageBytes: RED_1X1_PNG.byteLength - 1,
+				dependencies: { beforeDescriptorRead: beforeRead },
+			}),
+		).rejects.toBeInstanceOf(ImageInputTooLargeError);
+		expect(beforeRead).not.toHaveBeenCalled();
+	});
+
+	it("retains a separate post-transform aggregate limit", async () => {
+		const first = await writeImage("first.png");
+		const second = await writeImage("second.png");
+		const transformImageBytes = vi.fn(
+			async (options): Promise<TransformedImageInput> => ({
+				resolvedPath: options.resolvedPath,
+				mimeType: options.mimeType,
+				buffer: Buffer.alloc(10),
+				textNote: "test",
+				bytes: 10,
+			}),
+		);
+
+		await expect(
+			loadPastedImageBatch({
+				paths: [first, second],
+				autoResize: true,
+				signal: new AbortController().signal,
+				maxOutputBytes: 31,
+				dependencies: { transformImageBytes },
+			}),
+		).rejects.toMatchObject({ code: "output-aggregate-too-large" });
+
+		await expect(
+			loadPastedImageBatch({
+				paths: [first, second],
+				autoResize: true,
+				signal: new AbortController().signal,
+				maxOutputBytes: 32,
+				dependencies: { transformImageBytes },
+			}),
+		).resolves.toMatchObject({ sourcePaths: [first, second] });
+	});
+
+	it("rejects a transform result produced after transaction cancellation", async () => {
+		const imagePath = await writeImage("cancelled-transform.png");
+		const controller = new AbortController();
+		const reason = new Error("cancelled during transform");
+		await expect(
+			loadPastedImageBatch({
+				paths: [imagePath],
+				autoResize: true,
+				signal: controller.signal,
+				dependencies: {
+					transformImageBytes: async options => {
+						controller.abort(reason);
+						return {
+							resolvedPath: options.resolvedPath,
+							mimeType: options.mimeType,
+							buffer: Buffer.alloc(1),
+							textNote: "test",
+							bytes: 1,
+						};
+					},
+				},
+			}),
+		).rejects.toBe(reason);
+	});
+
+	it("rejects signature-only truncated images", async () => {
+		const truncated = await writeImage("truncated.png", RED_1X1_PNG.subarray(0, 8));
+		await expect(
+			loadPastedImageBatch({ paths: [truncated], autoResize: false, signal: new AbortController().signal }),
+		).rejects.toMatchObject({ code: "unsupported-image" });
+	});
+
+	it("rejects metadata-bearing images without complete pixel structure", async () => {
+		const header = Buffer.alloc(26);
+		Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(header, 0);
+		Buffer.from("IHDR").copy(header, 12);
+		header.writeUInt32BE(1, 16);
+		header.writeUInt32BE(1, 20);
+		header[25] = 2;
+		const incomplete = await writeImage("incomplete.png", header);
+		await expect(
+			loadPastedImageBatch({ paths: [incomplete], autoResize: false, signal: new AbortController().signal }),
+		).rejects.toMatchObject({ code: "unsupported-image" });
+	});
+
+	it("rejects extreme dimensions before structural decode", async () => {
+		const header = Buffer.alloc(26);
+		Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(header, 0);
+		Buffer.from("IHDR").copy(header, 12);
+		header.writeUInt32BE(50_000, 16);
+		header.writeUInt32BE(50_000, 20);
+		header[25] = 2;
+		const extreme = await writeImage("extreme.png", header);
+
+		await expect(
+			loadPastedImageBatch({ paths: [extreme], autoResize: false, signal: new AbortController().signal }),
+		).rejects.toMatchObject({ code: "dimensions-too-large" });
+	});
+
+	it("accepts one-frame GIFs and rejects animated GIF batches", async () => {
+		const singleGif = Buffer.from("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==", "base64");
+		const imageMarker = singleGif.indexOf(0x2c);
+		const trailer = singleGif.lastIndexOf(0x3b);
+		const frame = singleGif.subarray(imageMarker, trailer);
+		const animatedGif = Buffer.concat([singleGif.subarray(0, imageMarker), frame, frame, Buffer.from([0x3b])]);
+		const singlePath = await writeImage("single.gif", singleGif);
+		const animatedPath = await writeImage("animated.gif", animatedGif);
+
+		await expect(
+			loadPastedImageBatch({ paths: [singlePath], autoResize: false, signal: new AbortController().signal }),
+		).resolves.toMatchObject({ sourcePaths: [singlePath] });
+		await expect(
+			loadPastedImageBatch({ paths: [animatedPath], autoResize: false, signal: new AbortController().signal }),
+		).rejects.toMatchObject({ code: "unsupported-image" });
+	});
+
+	it("enforces the cumulative decoded-byte budget before native decode", async () => {
+		const first = await writeImage("first.png");
+		const second = await writeImage("second.png");
+		await expect(
+			loadPastedImageBatch({
+				paths: [first, second],
+				autoResize: false,
+				signal: new AbortController().signal,
+				maxDecodedBytes: 7,
+			}),
+		).rejects.toMatchObject({ code: "dimensions-too-large" });
+		await expect(
+			loadPastedImageBatch({
+				paths: [first, second],
+				autoResize: false,
+				signal: new AbortController().signal,
+				maxDecodedBytes: 8,
+			}),
+		).resolves.toMatchObject({ sourcePaths: [first, second] });
+	});
+
+	it("aborts before descriptor reads and never returns a late batch", async () => {
+		const imagePath = await writeImage("cancelled.png");
+		const controller = new AbortController();
+		const reason = new Error("paste transaction expired");
+		const promise = loadPastedImageBatch({
+			paths: [imagePath],
+			autoResize: false,
+			signal: controller.signal,
+			dependencies: {
+				beforeDescriptorRead: () => controller.abort(reason),
+			},
+		});
+		await expect(promise).rejects.toBe(reason);
+	});
+
+	it("exposes bounded typed failures", () => {
+		const error = new PastedImageBatchError("unsafe-path", "unsafe", "/tmp/a.png");
+		expect(error.code).toBe("unsafe-path");
+		expect(error.imagePath).toBe("/tmp/a.png");
+	});
+});

--- a/packages/coding-agent/test/pasted-image-path.test.ts
+++ b/packages/coding-agent/test/pasted-image-path.test.ts
@@ -1,200 +1,180 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import * as fs from "node:fs";
+import { describe, expect, it } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
+import * as url from "node:url";
 import {
 	decodePastedPathCandidate,
+	decodePastedPathCandidates,
 	formatPastedImageReference,
+	MAX_PASTED_IMAGE_COUNT,
+	MAX_PASTED_IMAGE_PATH_CHARACTERS,
+	parsePastedImagePaths,
 	resolvePastedImagePath,
 } from "../src/utils/pasted-image-path";
 
-const NNBSP = "\u202f"; // narrow no-break space used by macOS screenshot names
+const NNBSP = "\u202f";
 
 describe("resolvePastedImagePath", () => {
-	let testDir: string;
-
-	beforeEach(() => {
-		testDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-pasted-image-"));
+	it("keeps ordinary single saved paths literal", () => {
+		expect(resolvePastedImagePath("/tmp/plain.png")).toBeUndefined();
+		expect(resolvePastedImagePath("'/tmp/quoted image.jpg'")).toBeUndefined();
+		expect(resolvePastedImagePath("~/home.webp", { homedir: "/tmp/home" })).toBeUndefined();
 	});
 
-	afterEach(() => {
-		fs.rmSync(testDir, { recursive: true, force: true });
+	it("recognizes clipboard-temp policy before filesystem access", () => {
+		const missing = path.join(os.tmpdir(), "clipboard-2026-07-19-123456-Ab3.png");
+		expect(resolvePastedImagePath(missing)).toBe(missing);
 	});
 
-	const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-
-	function writeImage(name: string): string {
-		const filePath = path.join(testDir, name);
-		fs.writeFileSync(filePath, PNG_SIGNATURE);
-		return filePath;
-	}
-
-	it("does not auto-attach arbitrary absolute image paths", () => {
-		const filePath = writeImage("plain.png");
-		expect(resolvePastedImagePath(filePath)).toBeUndefined();
-	});
-
-	it("does not auto-attach shell-escaped drag-drop image paths", () => {
-		// Saved image paths remain literal text; attach them explicitly with @path/to/image.png.
-		const filePath = writeImage(`Screenshot 2026-07-07 at 11.06.38${NNBSP}PM.png`);
-		const pasted = filePath.replaceAll(" ", "\\ ");
-		expect(pasted).not.toBe(filePath);
-		expect(resolvePastedImagePath(pasted)).toBeUndefined();
-	});
-
-	it("does not auto-attach quoted arbitrary image paths", () => {
-		const filePath = writeImage("quoted image.jpg");
-		expect(resolvePastedImagePath(`'${filePath}'`)).toBeUndefined();
-		expect(resolvePastedImagePath(`"${filePath}"`)).toBeUndefined();
-	});
-
-	it("does not auto-attach arbitrary file:// image URIs", () => {
-		const filePath = writeImage("uri image.webp");
-		const uri = `file://${filePath.split("/").map(encodeURIComponent).join("/")}`;
-		expect(resolvePastedImagePath(uri)).toBeUndefined();
-	});
-
-	it("does not auto-attach arbitrary ~/ or relative image paths", () => {
-		const homeImage = writeImage("home.png");
-		const relativeImage = writeImage("relative.png");
-		expect(resolvePastedImagePath("~/home.png", { homedir: testDir })).toBeUndefined();
-		expect(resolvePastedImagePath("./relative.png", { cwd: testDir })).toBeUndefined();
-		expect(homeImage).toBeTruthy();
-		expect(relativeImage).toBeTruthy();
-	});
-
-	it("still accepts legacy clipboard temp paths", () => {
-		const filePath = writeImage("clipboard-2026-07-07-123456-Ab3.png");
-		expect(resolvePastedImagePath(filePath)).toBe(filePath);
-	});
-
-	it("rejects nonexistent files", () => {
-		expect(resolvePastedImagePath(path.join(testDir, "missing.png"))).toBeUndefined();
-	});
-
-	it("rejects directories with image-like names", () => {
-		const dirPath = path.join(testDir, "dir.png");
-		fs.mkdirSync(dirPath);
-		expect(resolvePastedImagePath(dirPath)).toBeUndefined();
-	});
-
-	it("rejects non-image extensions", () => {
-		const filePath = path.join(testDir, "notes.txt");
-		fs.writeFileSync(filePath, "hello");
-		expect(resolvePastedImagePath(filePath)).toBeUndefined();
-	});
-
-	it("rejects existing non-image files with image extensions (content sniffing)", () => {
-		// Regression (#1841 review): consuming this paste would lose the raw
-		// path once the image loader rejects the content.
-		const filePath = path.join(testDir, "not-image.png");
-		fs.writeFileSync(filePath, "hello, I am a text file");
-		expect(resolvePastedImagePath(filePath)).toBeUndefined();
-	});
-
-	it("rejects empty files with image extensions", () => {
-		const filePath = path.join(testDir, "empty.png");
-		fs.writeFileSync(filePath, "");
-		expect(resolvePastedImagePath(filePath)).toBeUndefined();
-	});
-
-	it("accepts each supported image signature for recognized clipboard temp paths", () => {
-		const signatures: Array<[string, Buffer]> = [
-			["clipboard-2026-07-07-123456-png.png", Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])],
-			["clipboard-2026-07-07-123456-jpg.jpg", Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46])],
-			["clipboard-2026-07-07-123456-gif.gif", Buffer.from("GIF89a", "latin1")],
-			[
-				"clipboard-2026-07-07-123456-webp.webp",
-				Buffer.concat([Buffer.from("RIFF", "latin1"), Buffer.alloc(4), Buffer.from("WEBP", "latin1")]),
-			],
-		];
-		for (const [name, magic] of signatures) {
-			const filePath = path.join(testDir, name);
-			fs.writeFileSync(filePath, magic);
-			expect(resolvePastedImagePath(filePath)).toBe(filePath);
-		}
-	});
-
-	it("accepts mismatched extension when recognized clipboard temp content is a supported image", () => {
-		const filePath = path.join(testDir, "clipboard-2026-07-07-123456-actually-png.jpg");
-		fs.writeFileSync(filePath, PNG_SIGNATURE);
-		expect(resolvePastedImagePath(filePath)).toBe(filePath);
-	});
-
-	it("rejects multiline pastes", () => {
-		const filePath = writeImage("multi.png");
-		expect(resolvePastedImagePath(`${filePath}\nmore text`)).toBeUndefined();
-	});
-
-	it("rejects prose around a path (whole paste must be the path)", () => {
-		const filePath = writeImage("prose.png");
-		expect(resolvePastedImagePath(`look at ${filePath} please`)).toBeUndefined();
-	});
-
-	it("rejects empty and whitespace-only pastes", () => {
-		expect(resolvePastedImagePath("")).toBeUndefined();
+	it("rejects non-image extensions, prose, multiline text, and empty input", () => {
+		const clipboard = path.join(os.tmpdir(), "clipboard-2026-07-19-123456-Ab3.png");
+		expect(resolvePastedImagePath(clipboard.replace(/\.png$/, ".txt"))).toBeUndefined();
+		expect(resolvePastedImagePath(`look at ${clipboard}`)).toBeUndefined();
+		expect(resolvePastedImagePath(`${clipboard}\nmore`)).toBeUndefined();
 		expect(resolvePastedImagePath("   ")).toBeUndefined();
 	});
-});
 
-describe("formatPastedImageReference", () => {
-	it("keeps the image placeholder while preserving the exact source path", () => {
-		const imagePath = `/tmp/Screenshot 2026-07-09 at 10.00.00${NNBSP}PM.png`;
-		expect(formatPastedImageReference("[image 1]", imagePath)).toBe(
-			`[image 1] source="/tmp/Screenshot 2026-07-09 at 10.00.00${NNBSP}PM.png"`,
-		);
-	});
-
-	it("JSON-escapes paths so spaces, quotes, and backslashes stay model-readable", () => {
-		expect(formatPastedImageReference("[image 2]", String.raw`C:\Users\me\shot "final".png`)).toBe(
-			String.raw`[image 2] source="C:\\Users\\me\\shot \"final\".png"`,
-		);
+	it("rejects remote Windows paths before attachment policy", () => {
+		expect(
+			resolvePastedImagePath(String.raw`\\server\share\clipboard-2026-07-19-123456-Ab3.png`, {
+				platform: "win32",
+			}),
+		).toBeUndefined();
+		expect(
+			resolvePastedImagePath("file://server/share/clipboard-2026-07-19-123456-Ab3.png", {
+				platform: "win32",
+			}),
+		).toBeUndefined();
 	});
 });
 
-describe("decodePastedPathCandidate (win32 contract)", () => {
-	it("decodes drive-letter file:// URIs to win32 paths", () => {
-		expect(decodePastedPathCandidate("file:///C:/Users/me/Pictures/shot.png", { platform: "win32" })).toBe(
-			"C:\\Users\\me\\Pictures\\shot.png",
-		);
+describe("parsePastedImagePaths", () => {
+	it("parses the exact macOS multi-screenshot shape in source order", () => {
+		const first = `/Users/me/Desktop/Screenshot 2026-07-19 at 3.21.27${NNBSP}PM.png`;
+		const second = `/Users/me/Desktop/Screenshot 2026-07-19 at 3.21.29${NNBSP}PM.png`;
+		const paste = `${first.replaceAll(" ", "\\ ")} ${second.replaceAll(" ", "\\ ")}`;
+		expect(parsePastedImagePaths(paste)).toEqual({
+			kind: "paths",
+			paths: [first, second],
+			requiresConfirmation: true,
+		});
 	});
 
-	it("decodes file://localhost drive-letter URIs", () => {
+	it("supports quoted, escaped, relative, home-relative, and newline-separated paths", () => {
+		const parsed = parsePastedImagePaths(`./first\\ image.png\n'~/second image.jpg'`, {
+			cwd: "/workspace",
+			homedir: "/home/me",
+			platform: "linux",
+		});
+		expect(parsed).toEqual({
+			kind: "paths",
+			paths: ["/workspace/first image.png", "/home/me/second image.jpg"],
+			requiresConfirmation: true,
+		});
+	});
+
+	it("supports complete lists of local file URLs", () => {
+		const first = "/tmp/first uri.png";
+		const second = "/tmp/second uri.jpg";
+		const paste = `${url.pathToFileURL(first).href}\n${url.pathToFileURL(second).href}`;
+		expect(parsePastedImagePaths(paste)).toEqual({
+			kind: "paths",
+			paths: [first, second],
+			requiresConfirmation: true,
+		});
+	});
+
+	it("retains automatic handling only for a single clipboard-temp path", () => {
+		const clipboard = path.join(os.tmpdir(), "clipboard-2026-07-19-123456-Ab3.png");
+		expect(parsePastedImagePaths(clipboard)).toEqual({
+			kind: "paths",
+			paths: [clipboard],
+			requiresConfirmation: false,
+		});
+		expect(parsePastedImagePaths("/tmp/saved.png")).toBeUndefined();
+	});
+
+	it("stops at the count bound before accepting candidate 17", () => {
+		const paste = Array.from({ length: MAX_PASTED_IMAGE_COUNT + 1 }, (_, index) => `/tmp/${index}.png`).join(" ");
+		expect(parsePastedImagePaths(paste)).toEqual({
+			kind: "too-many",
+			maxCandidates: MAX_PASTED_IMAGE_COUNT,
+		});
+	});
+
+	it("does not classify ordinary over-token text as an image overflow", () => {
+		expect(parsePastedImagePaths(Array.from({ length: 17 }, (_, index) => `word${index}`).join(" "))).toBeUndefined();
+	});
+
+	it("rejects an oversized candidate before retaining the complete token", () => {
+		const oversized = `/tmp/${"a".repeat(MAX_PASTED_IMAGE_PATH_CHARACTERS)}.png /tmp/second.png`;
+		expect(parsePastedImagePaths(oversized)).toBeUndefined();
+	});
+
+	it("rejects malformed lists, prose, unsupported extensions, and empty candidates", () => {
+		expect(parsePastedImagePaths("'/tmp/first.png /tmp/second.png")).toBeUndefined();
+		expect(parsePastedImagePaths("/tmp/first.png prose")).toBeUndefined();
+		expect(parsePastedImagePaths("/tmp/first.png /tmp/second.txt")).toBeUndefined();
+		expect(parsePastedImagePaths("/tmp/first.png '' /tmp/second.png")).toBeUndefined();
+		expect(parsePastedImagePaths("/tmp/first.png /tmp/second.png\\", { platform: "linux" })).toBeUndefined();
+	});
+
+	it("rejects remote file hosts and UNC members before any attachment I/O", () => {
+		expect(
+			parsePastedImagePaths("C:\\one.png file://server/share/two.png", {
+				platform: "win32",
+				cwd: "C:\\",
+			}),
+		).toBeUndefined();
+		expect(
+			parsePastedImagePaths(String.raw`C:\one.png \\server\share\two.png`, {
+				platform: "win32",
+				cwd: "C:\\",
+			}),
+		).toBeUndefined();
+	});
+});
+
+describe("decodePastedPathCandidates", () => {
+	it("uses only ASCII whitespace as separators and preserves Windows backslashes", () => {
+		expect(decodePastedPathCandidates(`first${NNBSP}image.png\tsecond.jpg`)).toEqual([
+			`first${NNBSP}image.png`,
+			"second.jpg",
+		]);
+		expect(
+			decodePastedPathCandidates(String.raw`C:\Users\me\one.png "D:\Saved Images\two.jpg"`, {
+				platform: "win32",
+			}),
+		).toEqual([String.raw`C:\Users\me\one.png`, String.raw`D:\Saved Images\two.jpg`]);
+	});
+
+	it("returns undefined when the configured lexical count bound is exceeded", () => {
+		expect(decodePastedPathCandidates("one.png two.png three.png", {}, 2)).toBeUndefined();
+	});
+});
+
+describe("decodePastedPathCandidate platform contracts", () => {
+	it("decodes drive-letter, localhost, and UNC file URLs for explicit callers", () => {
+		expect(decodePastedPathCandidate("file:///C:/Users/me/shot.png", { platform: "win32" })).toBe(
+			"C:\\Users\\me\\shot.png",
+		);
 		expect(decodePastedPathCandidate("file://localhost/C:/x.png", { platform: "win32" })).toBe("C:\\x.png");
-	});
-
-	it("decodes UNC-host file:// URIs", () => {
 		expect(decodePastedPathCandidate("file://server/share/img.png", { platform: "win32" })).toBe(
 			"\\\\server\\share\\img.png",
 		);
 	});
 
-	it("decodes percent-encoded spaces in win32 file:// URIs", () => {
-		expect(decodePastedPathCandidate("file:///C:/My%20Pictures/shot.png", { platform: "win32" })).toBe(
-			"C:\\My Pictures\\shot.png",
-		);
-	});
-
-	it("rejects drive-letter-less file:// URIs on win32", () => {
+	it("rejects invalid foreign-platform file URLs", () => {
 		expect(decodePastedPathCandidate("file:///Users/me/shot.png", { platform: "win32" })).toBeUndefined();
-	});
-
-	it("rejects encoded path separators", () => {
 		expect(decodePastedPathCandidate("file:///C:/a%2Fb.png", { platform: "win32" })).toBeUndefined();
-		expect(decodePastedPathCandidate("file:///C:/a%5Cb.png", { platform: "win32" })).toBeUndefined();
-	});
-
-	it("does not shell-unescape win32 paths (backslash is the separator)", () => {
-		expect(decodePastedPathCandidate("C:\\Users\\me\\img.png", { platform: "win32" })).toBe("C:\\Users\\me\\img.png");
+		expect(decodePastedPathCandidate("file://server/share/img.png", { platform: "linux" })).toBeUndefined();
 	});
 });
 
-describe("decodePastedPathCandidate (posix contract)", () => {
-	it("rejects file:// URIs with non-localhost hosts", () => {
-		expect(decodePastedPathCandidate("file://server/share/img.png", { platform: "linux" })).toBeUndefined();
-	});
-
-	it("rejects encoded path separators", () => {
-		expect(decodePastedPathCandidate("file:///tmp/a%2Fb.png", { platform: "linux" })).toBeUndefined();
+describe("formatPastedImageReference", () => {
+	it("preserves and JSON-escapes source paths", () => {
+		expect(formatPastedImageReference("[image 2]", String.raw`C:\Users\me\shot "final".png`)).toBe(
+			String.raw`[image 2] source="C:\\Users\\me\\shot \"final\".png"`,
+		);
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Keybinding configuration arrays are now defensively copied so external mutations cannot diverge snapshots from resolved key matches.
 - Suppressed slash-command and skill autocomplete inside line-local single-backtick code spans while preserving path completion and ordinary slash matching outside literals (#2619).
 - Supplementary Unicode terminal input now crosses the stdin decoding boundary as complete code points instead of separate UTF-16 surrogate events.
+- Bracketed-paste framing now preserves ordinary input before coalesced or split start markers, retains split end markers byte-for-byte, and reprocesses multiple framed pastes in order instead of dropping command prefixes.
 
 ## [0.11.0] - 2026-07-15
 ### Fixed

--- a/packages/tui/src/bracketed-paste.ts
+++ b/packages/tui/src/bracketed-paste.ts
@@ -1,47 +1,124 @@
 const PASTE_START = "\x1b[200~";
 const PASTE_END = "\x1b[201~";
 
-export type PasteResult = { handled: false } | { handled: true; pasteContent?: string; remaining: string };
+export const BRACKETED_PASTE_FRAME_TIMEOUT_MS = 1_000;
+export const BRACKETED_PASTE_FRAME_MAX_BYTES = 1024 * 1024;
+
+export type PasteResult =
+	| { handled: false }
+	| { handled: true; leading: string; pasteContent?: string; remaining: string };
+
+function partialStartSuffixLength(value: string): number {
+	const maxLength = Math.min(value.length, PASTE_START.length - 1);
+	for (let length = maxLength; length > 0; length -= 1) {
+		if (value.endsWith(PASTE_START.slice(0, length))) return length;
+	}
+	return 0;
+}
 
 /**
- * Handles bracketed paste mode buffering for terminal input components.
- *
- * Bracketed paste mode wraps pasted content between start (\x1b[200~) and
- * end (\x1b[201~) markers, which may arrive split across multiple chunks.
- * This class buffers incoming data and assembles complete paste payloads.
+ * Handles bracketed paste framing with bounded buffering. Leading ordinary
+ * input and split markers are retained byte-for-byte; stale or oversized
+ * incomplete frames are released as ordinary input on the next event.
  */
 export class BracketedPasteHandler {
 	#buffer = "";
+	#leading = "";
 	#active = false;
+	#pendingSince: number | undefined;
 
-	/**
-	 * Process incoming terminal data for bracketed paste sequences.
-	 *
-	 * @returns `{ handled: false }` if the data contains no paste sequence and
-	 *          should be processed normally. `{ handled: true }` if the data was
-	 *          consumed by paste buffering — `pasteContent` is set when a complete
-	 *          paste has been assembled; omitted when still buffering.
-	 */
-	process(data: string): PasteResult {
-		if (data.includes(PASTE_START)) {
-			this.#active = true;
-			this.#buffer = "";
-			data = data.replace(PASTE_START, "");
+	get hasPendingFrame(): boolean {
+		return this.#active || this.#buffer.length > 0 || this.#leading.length > 0;
+	}
+
+	#reset(): void {
+		this.#buffer = "";
+		this.#leading = "";
+		this.#active = false;
+		this.#pendingSince = undefined;
+	}
+
+	#flushBuffered(): string {
+		const buffered = this.#active
+			? `${this.#leading}${PASTE_START}${this.#buffer}`
+			: `${this.#leading}${this.#buffer}`;
+		this.#reset();
+		return buffered;
+	}
+
+	#flushActive(remaining: string): PasteResult {
+		const leading = this.#leading;
+		const pasteContent = this.#buffer;
+		this.#reset();
+		return { handled: true, leading, pasteContent, remaining };
+	}
+
+	process(data: string, now = Date.now()): PasteResult {
+		if (
+			this.hasPendingFrame &&
+			this.#pendingSince !== undefined &&
+			now - this.#pendingSince >= BRACKETED_PASTE_FRAME_TIMEOUT_MS
+		) {
+			return this.#active
+				? this.#flushActive(data)
+				: { handled: true, leading: `${this.#flushBuffered()}${data}`, remaining: "" };
+		}
+		if (this.hasPendingFrame && data === "\x1b") {
+			return this.#active
+				? this.#flushActive(data)
+				: { handled: true, leading: `${this.#flushBuffered()}${data}`, remaining: "" };
 		}
 
-		if (!this.#active) return { handled: false };
+		if (!this.#active) {
+			const hadBufferedInput = this.hasPendingFrame;
+			const combined = this.#buffer + data;
+			this.#buffer = "";
+			const startIndex = combined.indexOf(PASTE_START);
+			if (startIndex === -1) {
+				const partialLength = partialStartSuffixLength(combined);
+				if (partialLength > 0) {
+					const nextLeading = this.#leading + combined.slice(0, -partialLength);
+					const nextBuffer = combined.slice(-partialLength);
+					if (Buffer.byteLength(nextLeading) + Buffer.byteLength(nextBuffer) > BRACKETED_PASTE_FRAME_MAX_BYTES) {
+						this.#reset();
+						return { handled: true, leading: `${nextLeading}${nextBuffer}`, remaining: "" };
+					}
+					this.#leading = nextLeading;
+					this.#buffer = nextBuffer;
+					this.#pendingSince ??= now;
+					return { handled: true, leading: "", remaining: "" };
+				}
+				if (hadBufferedInput || this.#leading.length > 0) {
+					const leading = this.#leading + combined;
+					this.#reset();
+					return { handled: true, leading, remaining: "" };
+				}
+				return { handled: false };
+			}
 
-		this.#buffer += data;
+			this.#leading += combined.slice(0, startIndex);
+			this.#buffer = combined.slice(startIndex + PASTE_START.length);
+			this.#active = true;
+			this.#pendingSince ??= now;
+		} else {
+			this.#buffer += data;
+		}
 
 		const endIndex = this.#buffer.indexOf(PASTE_END);
-		if (endIndex === -1) return { handled: true, remaining: "" };
+		if (endIndex === -1) {
+			if (
+				Buffer.byteLength(this.#leading) + Buffer.byteLength(PASTE_START) + Buffer.byteLength(this.#buffer) >
+				BRACKETED_PASTE_FRAME_MAX_BYTES
+			) {
+				return this.#flushActive("");
+			}
+			return { handled: true, leading: "", remaining: "" };
+		}
 
-		const pasteContent = this.#buffer.substring(0, endIndex);
-		const remaining = this.#buffer.substring(endIndex + PASTE_END.length);
-
-		this.#buffer = "";
-		this.#active = false;
-
-		return { handled: true, pasteContent, remaining };
+		const leading = this.#leading;
+		const pasteContent = this.#buffer.slice(0, endIndex);
+		const remaining = this.#buffer.slice(endIndex + PASTE_END.length);
+		this.#reset();
+		return { handled: true, leading, pasteContent, remaining };
 	}
 }

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1142,8 +1142,12 @@ export class Editor implements Component, Focusable {
 		}
 
 		// Handle bracketed paste mode
-		const paste = this.#pasteHandler.process(data);
+		const paste =
+			data === "\x1b" && !this.#pasteHandler.hasPendingFrame
+				? ({ handled: false } as const)
+				: this.#pasteHandler.process(data);
 		if (paste.handled) {
+			if (paste.leading.length > 0) this.handleInput(paste.leading);
 			if (paste.pasteContent !== undefined) {
 				this.#handlePaste(paste.pasteContent);
 				if (paste.remaining.length > 0) {

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -64,8 +64,12 @@ export class Input implements Component, Focusable {
 
 	handleInput(data: string): void {
 		// Handle bracketed paste mode
-		const paste = this.#pasteHandler.process(data);
+		const paste =
+			data === "\x1b" && !this.#pasteHandler.hasPendingFrame
+				? ({ handled: false } as const)
+				: this.#pasteHandler.process(data);
 		if (paste.handled) {
+			if (paste.leading.length > 0) this.handleInput(paste.leading);
 			if (paste.pasteContent !== undefined) {
 				this.#handlePaste(paste.pasteContent);
 				if (paste.remaining.length > 0) {

--- a/packages/tui/src/components/secret-input.ts
+++ b/packages/tui/src/components/secret-input.ts
@@ -90,8 +90,12 @@ export class SecretInput implements Component, Focusable {
 			return;
 		}
 
-		const paste = this.#pasteHandler.process(data);
+		const paste =
+			data === "\x1b" && !this.#pasteHandler.hasPendingFrame
+				? ({ handled: false } as const)
+				: this.#pasteHandler.process(data);
 		if (paste.handled) {
+			if (paste.leading.length > 0) this.handleInput(paste.leading);
 			if (paste.pasteContent !== undefined) {
 				this.#handlePaste(paste.pasteContent);
 				if (paste.remaining.length > 0) {

--- a/packages/tui/test/bracketed-paste.test.ts
+++ b/packages/tui/test/bracketed-paste.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { BRACKETED_PASTE_FRAME_TIMEOUT_MS, BracketedPasteHandler } from "../src/bracketed-paste";
+
+describe("BracketedPasteHandler", () => {
+	it("leaves ordinary input unhandled", () => {
+		expect(new BracketedPasteHandler().process("hello")).toEqual({ handled: false });
+	});
+
+	it("retains leading input when the start marker is split across chunks", () => {
+		const handler = new BracketedPasteHandler();
+		expect(handler.process("!echo before\n\x1b[20")).toEqual({ handled: true, leading: "", remaining: "" });
+		expect(handler.process("0~/tmp/one.png /tmp/two.png\x1b[201~after")).toEqual({
+			handled: true,
+			leading: "!echo before\n",
+			pasteContent: "/tmp/one.png /tmp/two.png",
+			remaining: "after",
+		});
+	});
+
+	it("retains a split end marker without changing paste bytes", () => {
+		const handler = new BracketedPasteHandler();
+		expect(handler.process("\x1b[200~화면 기록\x1b[20")).toEqual({ handled: true, leading: "", remaining: "" });
+		expect(handler.process("1~tail")).toEqual({
+			handled: true,
+			leading: "",
+			pasteContent: "화면 기록",
+			remaining: "tail",
+		});
+	});
+
+	it("returns coalesced input before the first marker separately", () => {
+		const handler = new BracketedPasteHandler();
+		expect(handler.process("\r\x1b[200~pasted\x1b[201~")).toEqual({
+			handled: true,
+			leading: "\r",
+			pasteContent: "pasted",
+			remaining: "",
+		});
+	});
+
+	it("releases a false partial marker as ordinary leading input", () => {
+		const handler = new BracketedPasteHandler();
+		expect(handler.process("abc\x1b[2")).toEqual({ handled: true, leading: "", remaining: "" });
+		expect(handler.process("x")).toEqual({ handled: true, leading: "abc\x1b[2x", remaining: "" });
+	});
+
+	it("releases a false split prefix beginning at byte zero", () => {
+		const handler = new BracketedPasteHandler();
+		expect(handler.process("\x1b[2")).toEqual({ handled: true, leading: "", remaining: "" });
+		expect(handler.process("x")).toEqual({ handled: true, leading: "\x1b[2x", remaining: "" });
+	});
+
+	it("flushes a stale incomplete paste as paste content before later input", () => {
+		const handler = new BracketedPasteHandler();
+		expect(handler.process("\x1b[200~unfinished", 0)).toEqual({ handled: true, leading: "", remaining: "" });
+		expect(handler.process("next", BRACKETED_PASTE_FRAME_TIMEOUT_MS)).toEqual({
+			handled: true,
+			leading: "",
+			pasteContent: "unfinished",
+			remaining: "next",
+		});
+	});
+
+	it("leaves subsequent framed pastes in remaining for ordered reprocessing", () => {
+		const handler = new BracketedPasteHandler();
+		expect(handler.process("\x1b[200~one\x1b[201~\x1b[200~two\x1b[201~")).toEqual({
+			handled: true,
+			leading: "",
+			pasteContent: "one",
+			remaining: "\x1b[200~two\x1b[201~",
+		});
+	});
+});


### PR DESCRIPTION
## What

Adds terminal-agnostic bracketed-paste handling for attaching up to 16 image paths in source order.

Saved multi-image path lists require an explicit **Attach images** / **Paste paths literally** choice. A single recognized clipboard-temp image keeps the existing automatic behavior, while Bash and Python composer modes remain literal.

Supersedes #2647 and addresses every blocking review finding from that PR.

## Why

Terminals already deliver copied file paths as bracketed text. Handling complete path lists in the composer enables multi-image prompts without terminal-specific clipboard integrations, while the redesigned pipeline prevents late async commits, accidental uploads, path races, and resource-amplification attacks.

## Review finding resolution

| Blocking finding from #2647 | Resolution |
|---|---|
| Async work could commit after timeout, overflow, or disposal | `CustomEditor` owns an abortable, one-shot commit lease; stale completion cannot mutate the composer. Exact paste and queued input are replayed on cancellation. |
| Queue count was bypassable and unbounded by bytes | Pending input, including coalesced trailing data, is bounded to 64 events and 256 KiB. Incomplete bracketed-paste framing is also timeout- and size-bounded. |
| Limits were checked after reading/resizing/base64 | Per-image and aggregate source sizes are preflighted before descriptor reads. Transformed bytes are admitted against the remaining encoded-payload budget before base64 materialization. |
| Candidate 17 could trigger prior filesystem work | Parsing is pure and bounded by total text, per-token length, and count; candidate 17 is rejected before filesystem access. |
| Validation reopened pathnames and was TOCTOU-prone | Sources are opened once through stable descriptors, read from those descriptors, and checked for identity/path swaps before and after reads. |
| Symlink, hardlink, temp escape, and network-path exposure | Leaf/ancestor links, hardlinks, canonical temp-root escapes, UNC paths, remote `file://` hosts, canonical remote paths, and pathname swaps are rejected. |
| Saved files uploaded without consent | Saved multi-image lists require confirmation and expose an explicit literal-paste option. |
| Bash/Python commands could consume image arguments | Image-path interception is disabled in Bash and Python composer modes. |
| Signature-only validation accepted hostile/truncated images | Static images receive structural decode validation plus animation, dimension, pixel, cumulative decoded-memory, source-size, and output-size limits. |
| Partial mutation could be followed by literal replay | Placeholder/image mutation is rollback-capable; nonessential status/render failures cannot turn a successful commit into replay. |

## Testing

- `bun test` across 11 focused TUI, parser, loader, controller, image-input, and resize suites: **297 passed, 0 failed**
- `bun run check` in `packages/coding-agent`: passed
- `bun run check` in `packages/tui`: passed
- `bun scripts/ci-release-publish.ts --check-types`: passed for all packages
- `git diff --check`: passed
- CLI smoke test: `gjc/0.11.2`
- Manually tested terminal behavior locally
- Hosted Dev CI affected-path validation: all required jobs passed

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)