### PR TITLE
ci: shard Main CI with long-tail balancing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,89 @@ jobs:
          - name: Lint and type check (native-free)
            run: bun run ci:check:full
 
-   test:
+   # ---------------------------------------------------------------------------
+   # PR + main branch: sharded full test suite. Unlike dev CI (changed-path
+   # affected), Main CI runs the COMPLETE task union via CI_FORCE_FULL. Long-tail
+   # tasks are sub-split (coding-agent tests 16-way, rust-test 4 nextest
+   # partitions) so no single shard dominates wall-time. The `test` aggregate job
+   # keeps the stable branch-protection status name.
+   # ---------------------------------------------------------------------------
+   main_plan:
       if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       runs-on: ubuntu-22.04
-      timeout-minutes: 60
+      timeout-minutes: 10
+      env:
+         CI_FORCE_FULL: "1"
+         CI_CODING_AGENT_TEST_SHARDS: "16"
+         CI_RUST_TEST_PARTITIONS: "4"
+      outputs:
+         matrix: ${{ steps.plan.outputs.matrix }}
+         has_tasks: ${{ steps.plan.outputs.has_tasks }}
+         has_native: ${{ steps.plan.outputs.has_native }}
+      steps:
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+         - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+           with:
+              bun-version: "1.3"
+         - name: Compute full Main CI task matrix
+           id: plan
+           run: bun scripts/ci-dev-affected.ts --matrix-json
+
+   main_native:
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') && needs.main_plan.outputs.has_native == 'true' }}
+      needs: [main_plan]
+      runs-on: ubuntu-22.04
+      timeout-minutes: 30
+      steps:
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+         - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+           with:
+              node-version: "24"
+         - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+           with:
+              bun-version: "1.3"
+         - name: Cache bun dependencies
+           uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+           with:
+              path: ~/.bun/install/cache
+              key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+         - run: bun install --frozen-lockfile
+         - name: Build native addon (linux-x64 baseline + modern)
+           env:
+              TARGET_PLATFORM: linux
+              TARGET_ARCH: x64
+              TARGET_VARIANTS: baseline modern
+           run: bun run ci:build:native
+         - name: Verify required native addon variants
+           run: |
+              test -f packages/natives/native/pi_natives.linux-x64-baseline.node
+              test -f packages/natives/native/pi_natives.linux-x64-modern.node
+         - name: Upload native addon(s)
+           uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+           with:
+              name: main-native-${{ github.run_id }}
+              path: |
+                 packages/natives/native/pi_natives.linux-x64-baseline.node
+                 packages/natives/native/pi_natives.linux-x64-modern.node
+              if-no-files-found: error
+              retention-days: 1
+              overwrite: true
+
+   main_shards:
+      name: test-shard / ${{ matrix.key }}
+      if: ${{ always() && !startsWith(github.ref, 'refs/tags/v') && needs.main_plan.outputs.has_tasks == 'true' && needs.main_native.result != 'failure' && needs.main_native.result != 'cancelled' }}
+      needs: [main_plan, main_native]
+      runs-on: ubuntu-22.04
+      timeout-minutes: ${{ matrix.rust && 90 || 60 }}
+      strategy:
+         fail-fast: false
+         max-parallel: 16
+         matrix: ${{ fromJSON(needs.main_plan.outputs.matrix) }}
+      env:
+         CI_FORCE_FULL: "1"
+         CI_CODING_AGENT_TEST_SHARDS: "16"
+         CI_RUST_TEST_PARTITIONS: "4"
+         AFFECTED_TASK_KEY: ${{ matrix.key }}
       steps:
          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
          - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -54,11 +133,17 @@ jobs:
            with:
               bun-version: "1.3"
          - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+           if: ${{ matrix.rust }}
            with:
               toolchain: nightly-2026-04-29
-         - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+         - uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e  # v2
+           if: ${{ matrix.nextest }}
            with:
-              shared-key: test-linux-x64
+              tool: nextest
+         - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+           if: ${{ matrix.rust }}
+           with:
+              shared-key: main-rust-linux-x64
               save-if: ${{ github.ref == 'refs/heads/main' }}
               cache-workspace-crates: true
          - name: Cache bun dependencies
@@ -67,20 +152,33 @@ jobs:
               path: ~/.bun/install/cache
               key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
          - run: bun install --frozen-lockfile
-         - name: Build native addon (linux-x64)
-           env:
-              TARGET_PLATFORM: linux
-              TARGET_ARCH: x64
-              TARGET_VARIANTS: baseline
-           run: bun run ci:build:native
-         - name: Runtime checks (needs native addon)
-           run: bun --cwd=packages/coding-agent run check:runtime
-         - name: Test workspace
+         - name: Download native addon(s)
+           if: ${{ matrix.native }}
+           uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+           with:
+              name: main-native-${{ github.run_id }}
+              path: packages/natives/native
+         - name: Run task shard
            env:
               GITHUB_ACTIONS: ""
-           run: bun run test:ts
-         - name: CLI smoke test
-           run: bun run ci:test:smoke
+           run: bun scripts/ci-dev-affected.ts --task="$AFFECTED_TASK_KEY"
+
+   # Branch protection must keep requiring this stable aggregate status.
+   test:
+      if: ${{ always() && !startsWith(github.ref, 'refs/tags/v') }}
+      needs: [main_plan, main_native, main_shards]
+      runs-on: ubuntu-22.04
+      timeout-minutes: 5
+      steps:
+         - name: Fail closed unless every shard succeeded
+           run: |
+              plan='${{ needs.main_plan.result }}'
+              native='${{ needs.main_native.result }}'
+              shards='${{ needs.main_shards.result }}'
+              echo "main_plan=$plan main_native=$native main_shards=$shards"
+              test "$plan" = success
+              case "$native" in success|skipped) ;; *) echo "native gate failed"; exit 1;; esac
+              test "$shards" = success
 
    # ---------------------------------------------------------------------------
    # Tag (vX.Y.Z) only: build native addons for every published platform,

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describeTasks, expandWithDependents, isDarwinArm64TabWorkerSmokePath, loadBuildInventory, needsDarwinArm64TabWorkerSmoke, normalizeChangedPaths, packageScriptCommand, planTargetedTasks, planTasks, requiresCargoWorkspaceEmergency, resolvePackageCwd, runCommand, validateAffectedAggregate, type AffectedAggregateResults, type CargoInventoryUnit, type WorkspacePackage } from "./ci-dev-affected";
+import { describeTasks, expandWithDependents, isDarwinArm64TabWorkerSmokePath, loadBuildInventory, needsDarwinArm64TabWorkerSmoke, normalizeChangedPaths, packageScriptCommand, planFullTasks, planTargetedTasks, planTasks, requiresCargoWorkspaceEmergency, resolvePackageCwd, runCommand, validateAffectedAggregate, type AffectedAggregateResults, type CargoInventoryUnit, type WorkspacePackage } from "./ci-dev-affected";
 
 // Matrix planning validates live workspace and Cargo manifests in subprocesses.
 // Hosted runners can need more than Bun's 5s default during their first cold scan.
@@ -1260,5 +1260,115 @@ describe("Cargo workspace ambiguity", () => {
 		expect(requiresCargoWorkspaceEmergency([first], supported)).toBe(true);
 		expect(requiresCargoWorkspaceEmergency([first, second], supported)).toBe(true);
 		expect(requiresCargoWorkspaceEmergency([unique], supported)).toBe(false);
+	});
+});
+
+describe("planFullTasks — Main CI full mode (issue: shard main CI)", () => {
+	const fullModePackages: WorkspacePackage[] = [
+		{
+			name: "@gajae-code/coding-agent",
+			dir: "packages/coding-agent",
+			manifest: { name: "@gajae-code/coding-agent", scripts: { test: "true" } },
+		},
+		{
+			name: "@gajae-code/example",
+			dir: "packages/example",
+			manifest: { name: "@gajae-code/example", scripts: { check: "true", test: "true" } },
+		},
+	];
+
+	function withEnv<T>(env: Record<string, string | undefined>, run: () => T): T {
+		const previous = new Map<string, string | undefined>();
+		for (const [key, value] of Object.entries(env)) {
+			previous.set(key, process.env[key]);
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		try {
+			return run();
+		} finally {
+			for (const [key, value] of previous) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+		}
+	}
+
+	test("default env emits the complete task union and omits root-check", () => {
+		const keys = withEnv(
+			{ CI_CODING_AGENT_TEST_SHARDS: undefined, CI_RUST_TEST_PARTITIONS: undefined },
+			() => planFullTasks(fullModePackages).map(task => task.key),
+		);
+		// root-check is covered by the dedicated native-free `check` job.
+		expect(keys).not.toContain("root-check");
+		expect(keys).toContain("native-linux-x64");
+		expect(keys).toContain("root-test:release");
+		expect(keys).toContain("rust-check");
+		expect(keys).toContain("cli-smoke");
+		expect(keys).toContain("runtime-check");
+		expect(keys).toContain("test:@gajae-code/example");
+		// Default coding-agent shard count stays 8 (dev parity).
+		expect(keys.filter(key => key.startsWith("test:@gajae-code/coding-agent:shard-")).length).toBe(8);
+		expect(keys).toContain("test:@gajae-code/coding-agent:shard-1-of-8");
+		// Default rust-test stays a single unpartitioned task.
+		expect(keys).toContain("rust-test");
+		expect(keys.some(key => key.startsWith("rust-test:partition-"))).toBe(false);
+	});
+
+	test("no full-mode task uses the false-green standalone `bun --cwd` form (issue #622)", () => {
+		const tasks = withEnv({ CI_CODING_AGENT_TEST_SHARDS: "16", CI_RUST_TEST_PARTITIONS: "4" }, () =>
+			planFullTasks(fullModePackages),
+		);
+		for (const task of tasks) {
+			expect(task.command.some(arg => arg.startsWith("--cwd"))).toBe(false);
+		}
+		const runtimeCheck = tasks.find(task => task.key === "runtime-check");
+		expect(runtimeCheck?.command).toEqual(["bun", "run", "check:runtime"]);
+		expect(runtimeCheck?.cwd).toBe(resolvePackageCwd("packages/coding-agent"));
+	});
+
+	test("CI_CODING_AGENT_TEST_SHARDS overrides the coding-agent shard count", () => {
+		const keys = withEnv({ CI_CODING_AGENT_TEST_SHARDS: "16" }, () =>
+			planFullTasks(fullModePackages).map(task => task.key),
+		);
+		const shards = keys.filter(key => key.startsWith("test:@gajae-code/coding-agent:shard-"));
+		expect(shards.length).toBe(16);
+		expect(shards).toContain("test:@gajae-code/coding-agent:shard-1-of-16");
+		expect(shards).toContain("test:@gajae-code/coding-agent:shard-16-of-16");
+	});
+
+	test("CI_RUST_TEST_PARTITIONS splits rust-test into nextest partitions", () => {
+		const tasks = withEnv({ CI_RUST_TEST_PARTITIONS: "4" }, () => planFullTasks(fullModePackages));
+		const partitions = tasks.filter(task => task.key.startsWith("rust-test:partition-"));
+		expect(partitions.length).toBe(4);
+		expect(tasks.some(task => task.key === "rust-test")).toBe(false);
+		expect(partitions[0]?.command).toEqual(["bun", "scripts/run-rs-task.ts", "test:rs", "count:1/4"]);
+		expect(partitions[3]?.command).toEqual(["bun", "scripts/run-rs-task.ts", "test:rs", "count:4/4"]);
+		const described = describeTasks(partitions);
+		for (const entry of described) {
+			expect(entry.rust).toBe(true);
+			expect(entry.nextest).toBe(true);
+			expect(entry.native).toBe(false);
+		}
+	});
+
+	test("invalid env values fall back to safe defaults", () => {
+		const keys = withEnv(
+			{ CI_CODING_AGENT_TEST_SHARDS: "0", CI_RUST_TEST_PARTITIONS: "abc" },
+			() => planFullTasks(fullModePackages).map(task => task.key),
+		);
+		expect(keys.filter(key => key.startsWith("test:@gajae-code/coding-agent:shard-")).length).toBe(8);
+		expect(keys).toContain("rust-test");
+		expect(keys.some(key => key.startsWith("rust-test:partition-"))).toBe(false);
+	});
+
+	test("the native build task is the only nativeBuild entry and runtime consumers download it", () => {
+		const entries = withEnv({ CI_CODING_AGENT_TEST_SHARDS: "16", CI_RUST_TEST_PARTITIONS: "4" }, () =>
+			describeTasks(planFullTasks(fullModePackages)),
+		);
+		expect(entries.filter(entry => entry.nativeBuild).map(entry => entry.key)).toEqual(["native-linux-x64"]);
+		expect(entries.find(entry => entry.key === "cli-smoke")?.native).toBe(true);
+		expect(entries.find(entry => entry.key === "runtime-check")?.native).toBe(true);
+		expect(entries.find(entry => entry.key === "test:@gajae-code/coding-agent:shard-1-of-16")?.native).toBe(true);
 	});
 });

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -7,10 +7,37 @@ import * as fs from "node:fs/promises";
 const repoRoot = path.join(import.meta.dir, "..");
 const ZERO_SHA = /^0+$/;
 const PACKAGE_SCOPES = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
-// The coding-agent package has hundreds of test files; keep dev affected
-// validation below the shard timeout by splitting package-wide/full-workspace
-// TypeScript suites across the matrix instead of one root-test runner.
-const CODING_AGENT_TEST_SHARDS = 8;
+// The coding-agent package has hundreds of test files; keep affected validation
+// below the shard timeout by splitting package-wide/full-workspace TypeScript
+// suites across the matrix. Dev keeps the default; Main CI full mode overrides
+// via CI_CODING_AGENT_TEST_SHARDS to bound the long tail.
+const DEFAULT_CODING_AGENT_TEST_SHARDS = 8;
+
+function codingAgentTestShards(): number {
+	return positiveIntFromEnv("CI_CODING_AGENT_TEST_SHARDS", DEFAULT_CODING_AGENT_TEST_SHARDS);
+}
+
+// Number of nextest partitions the rust-test suite is split into. Dev runs one
+// unpartitioned rust-test task; Main CI full mode raises this to bound the
+// rust-test long tail.
+const DEFAULT_RUST_TEST_PARTITIONS = 1;
+
+function rustTestPartitions(): number {
+	return positiveIntFromEnv("CI_RUST_TEST_PARTITIONS", DEFAULT_RUST_TEST_PARTITIONS);
+}
+
+function positiveIntFromEnv(name: string, fallback: number): number {
+	const raw = Bun.env[name]?.trim();
+	if (!raw) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isInteger(parsed) && parsed >= 1 ? parsed : fallback;
+}
+
+// True when Main CI requests the deterministic full plan via `CI_FORCE_FULL`.
+function isForceFullMode(): boolean {
+	const raw = Bun.env.CI_FORCE_FULL?.trim();
+	return raw === "1" || raw === "true";
+}
 // SDK host lifecycle and coordinator prompt-control changes need the stable first
 // package shard in addition to targeted coverage. Keep this list limited to the
 // stateful surfaces whose regressions depend on broader package ordering.
@@ -199,7 +226,44 @@ export function resolvePlanMode(): PlanMode {
 // Resolve the plan for the current changed paths and CI mode. PR mode builds the
 // targeted plan from a filesystem index of test files (for source→test mapping);
 // push mode reuses the broad affected planner unchanged.
+// Main CI full mode: emit the complete task union regardless of changed paths so
+// every check runs on `main`, and short-circuit the changed-path / canonical-plan
+// machinery entirely. It is deterministic, so the planner and every shard resolve
+// the identical plan without a shared plan artifact.
+export function planFullTasks(packages: readonly WorkspacePackage[]): Task[] {
+	const tasks = new Map<string, Task>();
+	addNativeBuild(tasks);
+	addWorkspaceTestTasks(tasks, packages);
+	add(tasks, "rust-check", "Rust check", ["bun", "run", "check:rs"]);
+	addRustTestTasks(tasks);
+	add(tasks, "cli-smoke", "GJC CLI smoke test", ["bun", "run", "ci:test:smoke"]);
+	add(tasks, "runtime-check", "Runtime checks (needs native addon)", ["bun", "run", "check:runtime"], resolvePackageCwd("packages/coding-agent"));
+	// root-check (ci:check:full) is intentionally omitted: Main CI runs it in the
+	// dedicated native-free `check` job, so emitting it here would double-run it.
+	return Array.from(tasks.values());
+}
+
+// Emit the rust-test task, split into nextest partitions when configured. Each
+// partition shards the test set (not a repeated full run) via `cargo nextest run
+// --partition count:i/N`, wired through run-rs-task.ts.
+function addRustTestTasks(tasks: Map<string, Task>): void {
+	const partitions = rustTestPartitions();
+	if (partitions <= 1) {
+		add(tasks, "rust-test", "Rust tests", ["bun", "run", "test:rs"]);
+		return;
+	}
+	for (let index = 1; index <= partitions; index++) {
+		add(
+			tasks,
+			`rust-test:partition-${index}-of-${partitions}`,
+			`Rust tests partition ${index}/${partitions}`,
+			["bun", "scripts/run-rs-task.ts", "test:rs", `count:${index}/${partitions}`],
+		);
+	}
+}
+
 async function resolvePlannedTasks(paths: readonly string[]): Promise<Task[]> {
+	if (isForceFullMode()) return planFullTasks(await getWorkspacePackages());
 	const fromArtifact = await loadCanonicalPlan();
 	if (fromArtifact) return fromArtifact;
 	const normalizedPaths = normalizeChangedPaths(paths);
@@ -269,6 +333,7 @@ function taskNeedsNative(key: string): boolean {
 		key === "root-check" ||
 		key === "check:@gajae-code/coding-agent" ||
 		key === "cli-smoke" ||
+		key === "runtime-check" ||
 		key === "wrapper-version" ||
 		key === "deep-interview-definitions" ||
 		key === "deep-interview-runtime" ||
@@ -277,9 +342,15 @@ function taskNeedsNative(key: string): boolean {
 	);
 }
 
+// rust-test may be split into nextest partitions (`rust-test:partition-i-of-N`)
+// in Main CI full mode; treat every partition like the single rust-test task.
+function isRustTestKey(key: string): boolean {
+	return key === "rust-test" || key.startsWith("rust-test:partition-");
+}
+
 // Tasks that need the Rust toolchain (and nextest) provisioned on their shard.
 function taskNeedsRust(key: string): boolean {
-	return key === "rust-check" || key === "rust-test" || key === "ci-selftest" || key === "ci-dry-run" || key === "affected-selftest" || key === "affected-dry-run";
+	return key === "rust-check" || isRustTestKey(key) || key === "ci-selftest" || key === "ci-dry-run" || key === "affected-selftest" || key === "affected-dry-run";
 }
 
 // Build the machine-readable descriptor list for the current changed-path plan.
@@ -293,7 +364,7 @@ export function describeTasks(tasks: readonly Task[]): TaskMatrixEntry[] {
 		cwd: task.cwd ? path.relative(repoRoot, task.cwd) || "." : undefined,
 		native: task.capabilities?.nativeConsumer ?? taskNeedsNative(task.key),
 		rust: task.capabilities?.rust ?? taskNeedsRust(task.key),
-		nextest: task.capabilities?.nextest ?? task.key === "rust-test",
+		nextest: task.capabilities?.nextest ?? isRustTestKey(task.key),
 		nativeBuild: task.capabilities?.nativeProducer ?? isNativeBuildKey(task.key),
 	}));
 }
@@ -329,7 +400,33 @@ export function needsDarwinArm64TabWorkerSmoke(paths: readonly string[]): boolea
 	return paths.some(isDarwinArm64TabWorkerSmokePath);
 }
 
+// Main CI full mode: emit a lean matrix from the deterministic full plan. It
+// deliberately skips the dev source-sha/checkout asserts, the canonical plan
+// artifact, plan digest, and the Darwin smoke flag — Main CI re-derives the same
+// full plan on every shard and gates on a simple aggregate job, not evidence
+// receipts.
+async function emitFullMatrix(): Promise<void> {
+	const tasks = planFullTasks(await getWorkspacePackages());
+	const entries = describeTasks(tasks);
+	console.log(JSON.stringify(entries));
+
+	const githubOutput = process.env.GITHUB_OUTPUT;
+	if (!githubOutput) return;
+	const shards = entries
+		.filter(entry => !entry.nativeBuild)
+		.map(entry => ({ key: entry.key, identity: entry.identity, description: entry.description, native: entry.native, rust: entry.rust, nextest: entry.nextest }));
+	const hasNative = entries.some(entry => entry.nativeBuild);
+	const lines = [
+		`matrix=${JSON.stringify({ include: shards })}`,
+		`has_tasks=${shards.length > 0}`,
+		`has_native=${hasNative}`,
+		"",
+	];
+	await fs.appendFile(githubOutput, lines.join("\n"));
+}
+
 async function emitMatrix(): Promise<void> {
+	if (isForceFullMode()) return emitFullMatrix();
 	const sourceSha = await resolveSourceSha();
 	await requireCommitObject(sourceSha, "source head");
 	await assertCheckedOutSourceHead(sourceSha);
@@ -425,6 +522,7 @@ function printPlan(paths: readonly string[], plannedTasks: readonly Task[]): voi
 }
 
 async function getChangedPaths(): Promise<string[]> {
+	if (isForceFullMode()) return [];
 	const explicitPaths = Bun.env.CI_DEV_CHANGED_PATHS?.trim();
 	if (explicitPaths) {
 		return explicitPaths
@@ -783,17 +881,18 @@ function addPackageTestTasks(tasks: Map<string, Task>, workspacePackage: Workspa
 		return;
 	}
 
-	for (let shard = 1; shard <= CODING_AGENT_TEST_SHARDS; shard++) {
-		addCodingAgentTestShard(tasks, shard);
+	const total = codingAgentTestShards();
+	for (let shard = 1; shard <= total; shard++) {
+		addCodingAgentTestShard(tasks, shard, total);
 	}
 }
 
-function addCodingAgentTestShard(tasks: Map<string, Task>, shard: number): void {
+function addCodingAgentTestShard(tasks: Map<string, Task>, shard: number, total: number = codingAgentTestShards()): void {
 	add(
 		tasks,
-		`test:@gajae-code/coding-agent:shard-${shard}-of-${CODING_AGENT_TEST_SHARDS}`,
-		`Test @gajae-code/coding-agent shard ${shard}/${CODING_AGENT_TEST_SHARDS}`,
-		["bun", "test", `--shard=${shard}/${CODING_AGENT_TEST_SHARDS}`],
+		`test:@gajae-code/coding-agent:shard-${shard}-of-${total}`,
+		`Test @gajae-code/coding-agent shard ${shard}/${total}`,
+		["bun", "test", `--shard=${shard}/${total}`],
 		resolvePackageCwd("packages/coding-agent"),
 	);
 }
@@ -1297,7 +1396,7 @@ function serializeTasks(tasks: readonly Task[]): Task[] {
 			cwd,
 			capabilities: task.capabilities ?? {
 				rust: taskNeedsRust(task.key),
-				nextest: task.key === "rust-test",
+				nextest: isRustTestKey(task.key),
 				nativeConsumer: taskNeedsNative(task.key),
 				nativeProducer: isNativeBuildKey(task.key),
 			},

--- a/scripts/release-policy.test.ts
+++ b/scripts/release-policy.test.ts
@@ -71,8 +71,10 @@ describe("stable release policy", () => {
 
 	test("lint/typecheck and tests never run on release tags", async () => {
 		const ci = await workflow();
-		for (const job of ["check", "test"]) {
-			expect(jobSection(ci, job)).toContain("if: ${{ !startsWith(github.ref, 'refs/tags/v') }}");
+		// The monolithic `test` job is now a sharded graph; every job in that graph,
+		// plus the bounded `check` job, must stay excluded on release tags.
+		for (const job of ["check", "main_plan", "main_native", "main_shards", "test"]) {
+			expect(jobSection(ci, job)).toContain("!startsWith(github.ref, 'refs/tags/v')");
 		}
 	});
 

--- a/scripts/run-rs-task.ts
+++ b/scripts/run-rs-task.ts
@@ -61,10 +61,28 @@ if (taskName !== "fmt:rs" && !(isCI() || (await hasRustAffectingChanges()))) {
 }
 
 for (const command of TASK_COMMANDS[taskName]) {
-	const exitCode = await runCommand(command);
+	const exitCode = await runCommand(withPartition(taskName, command));
 	if (exitCode !== 0) {
 		process.exit(exitCode);
 	}
+}
+
+// Main CI splits rust-test into nextest partitions. An optional `count:i/N`
+// third argument shards the test set for `test:rs` by appending
+// `--partition count:i/N` to the nextest invocation. Other tasks ignore it.
+function withPartition(task: RustTaskName, command: readonly string[]): readonly string[] {
+	const partition = process.argv[3]?.trim();
+	if (task !== "test:rs" || !partition) {
+		return command;
+	}
+	if (!/^count:\d+\/\d+$/.test(partition)) {
+		console.error(`Invalid rust-test partition '${partition}'; expected count:<i>/<N>.`);
+		process.exit(1);
+	}
+	if (command[1] !== "nextest") {
+		return command;
+	}
+	return [...command, "--partition", partition];
 }
 
 function isRustTaskName(value: string | undefined): value is RustTaskName {


### PR DESCRIPTION
## What
Shards Main CI (.github/workflows/ci.yml), replacing the monolithic ~60-min test job with a parallel matrix, and bounds the long-tail tasks that dominate a full-suite run.

Unlike dev CI (changed-path affected), Main CI must run the complete suite. This reuses the existing dev planner (scripts/ci-dev-affected.ts) via a new explicit CI_FORCE_FULL mode that emits the full task union regardless of changed paths.

## How
- Full mode: CI_FORCE_FULL=1 short-circuits changed-path/canonical-plan machinery and emits a deterministic full task union (planFullTasks). Every shard re-derives the same plan, so no shared plan artifact/receipts are needed.
- Long-tail balancing: coding-agent tests split 16-way (CI_CODING_AGENT_TEST_SHARDS, default 8), and rust-test split into 4 nextest partitions (CI_RUST_TEST_PARTITIONS, default 1) via cargo nextest run --partition count:i/N wired through run-rs-task.ts.
- Job graph: main_plan -> main_native (build addon once, upload artifact) -> main_shards (matrix, max-parallel 16, downloads native, excludes root-check) -> test (stable aggregate, fail-closed).
- Branch protection: the required check stays named test; the native-free check job and tag-only native/binaries/publish jobs are unchanged.
- Coverage preserved: runtime-check (needs native addon) retained as a task; GITHUB_ACTIONS unset on test shards to keep full-suite coverage.

## Safety
- Default (no-env) behavior is byte-identical for dev CI (existing tests pin of-8 shards + single rust-test; all pass).
- dev-ci and the release pipeline are untouched.

## Verification
- bun test scripts/ci-dev-affected.test.ts (+6 new full-mode regression tests) and scripts/release-policy.test.ts pass.
- bunx tsc -p tsconfig.tools.json and bun run check:tools clean.
- bun scripts/check-workflow-yaml.ts parses ci.yml.
- Local CI_FORCE_FULL=1 planner dry-run emits the full union (16 coding-agent shards + 4 rust-test partitions, no root-check) and is deterministic across runs.

## Follow-ups (from ralplan consensus, non-blocking)
- Tune shard/partition counts and wall-time target against observed timings.
- Consider Windows/darwin coverage later (currently Linux-x64 only, matching prior Main CI test).

Spec: deep-interview -> ralplan consensus (pending-approval plan in .gjc).