### PR TITLE
fix(tui): isolate keybinding configuration arrays

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,9 +5,8 @@
 ## [0.11.3] - 2026-07-19
 ### Fixed
 
+- Keybinding configuration arrays are now defensively copied so external mutations cannot diverge snapshots from resolved key matches.
 - Suppressed slash-command and skill autocomplete inside line-local single-backtick code spans while preserving path completion and ordinary slash matching outside literals (#2619).
-### Fixed
-
 - Supplementary Unicode terminal input now crosses the stdin decoding boundary as complete code points instead of separate UTF-16 surrogate events.
 
 ## [0.11.0] - 2026-07-15

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -187,6 +187,14 @@ function normalizeKeys(keys: KeyId | KeyId[] | undefined): KeyId[] {
 	return result;
 }
 
+function cloneKeybindingsConfig(config: KeybindingsConfig): KeybindingsConfig {
+	const clone: KeybindingsConfig = {};
+	for (const [keybinding, keys] of Object.entries(config)) {
+		clone[keybinding] = Array.isArray(keys) ? [...keys] : keys;
+	}
+	return clone;
+}
+
 export class KeybindingsManager {
 	#definitions: KeybindingDefinitions;
 	#userBindings: KeybindingsConfig;
@@ -195,7 +203,7 @@ export class KeybindingsManager {
 
 	constructor(definitions: KeybindingDefinitions, userBindings: KeybindingsConfig = {}) {
 		this.#definitions = definitions;
-		this.#userBindings = userBindings;
+		this.#userBindings = cloneKeybindingsConfig(userBindings);
 		this.#rebuild();
 	}
 
@@ -253,12 +261,12 @@ export class KeybindingsManager {
 	}
 
 	setUserBindings(userBindings: KeybindingsConfig): void {
-		this.#userBindings = userBindings;
+		this.#userBindings = cloneKeybindingsConfig(userBindings);
 		this.#rebuild();
 	}
 
 	getUserBindings(): KeybindingsConfig {
-		return { ...this.#userBindings };
+		return cloneKeybindingsConfig(this.#userBindings);
 	}
 
 	getResolvedBindings(): KeybindingsConfig {

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -34,6 +34,43 @@ describe("KeybindingsManager", () => {
 		]);
 		expect(keybindings.getKeys("tui.editor.cursorLeft")).toEqual(["left", "ctrl+b"]);
 	});
+
+	describe("user binding ownership", () => {
+		it("clones array bindings passed to the constructor", () => {
+			const bindings = { "tui.select.up": ["down"] as ("down" | "up")[] };
+			const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, bindings);
+
+			bindings["tui.select.up"].push("up");
+
+			expect(keybindings.getUserBindings()["tui.select.up"]).toEqual(["down"]);
+			expect(keybindings.getKeys("tui.select.up")).toEqual(["down"]);
+			expect(keybindings.matches("\x1b[B", "tui.select.up")).toBe(true);
+			expect(keybindings.matches("\x1b[A", "tui.select.up")).toBe(false);
+		});
+
+		it("clones array bindings passed to setUserBindings", () => {
+			const keybindings = new KeybindingsManager(TUI_KEYBINDINGS);
+			const bindings = { "tui.select.up": ["down"] as ("down" | "up")[] };
+
+			keybindings.setUserBindings(bindings);
+			bindings["tui.select.up"].push("up");
+
+			expect(keybindings.getUserBindings()["tui.select.up"]).toEqual(["down"]);
+			expect(keybindings.getKeys("tui.select.up")).toEqual(["down"]);
+		});
+
+		it("does not share returned configuration arrays between instances", () => {
+			const bindings = { "tui.select.up": ["down"] as ("down" | "up")[] };
+			const first = new KeybindingsManager(TUI_KEYBINDINGS, bindings);
+			const second = new KeybindingsManager(TUI_KEYBINDINGS, bindings);
+			(first.getUserBindings()["tui.select.up"] as string[]).push("up");
+
+			expect(first.getUserBindings()["tui.select.up"]).toEqual(["down"]);
+			expect(second.getUserBindings()["tui.select.up"]).toEqual(["down"]);
+			expect(first.getKeys("tui.select.up")).toEqual(["down"]);
+			expect(second.getKeys("tui.select.up")).toEqual(["down"]);
+		});
+	});
 });
 
 describe("detectDefaultKeyCollisions", () => {


### PR DESCRIPTION
## What

- Defensively copy array-valued keybinding configuration at constructor and setter boundaries.
- Return independent array snapshots from `getUserBindings()`.
- Add regression coverage for input, output, and cross-instance aliasing.
- Consolidate the existing Unreleased changelog section instead of duplicating headings.

## Provenance

Owner-directed minimal salvage of the valuable implementation from closed PR #2592 by @datell1357 (mini_yeoreum). This replacement explicitly credits and supersedes #2592; stale branch metadata was not merged or cherry-picked.

## Verification

- `bun test test/keybindings.test.ts` in `packages/tui`: 11 passed, 0 failed
- `bun run check` in `packages/tui`: Biome and TypeScript passed
- `bun scripts/rebrand-inventory.ts --strict`: passed
- Root `bun run check:ts`: all observed gates passed through the long SDK closure lane; the local command hit the 20-minute execution cap without an observed test failure
- Hostile architect/security review: CLEAR / APPROVE, no blockers
- Adversarial executor QA: passed, no blockers

## Scope

Targets `dev` only. No main, release, or publish actions.