### PR TITLE
fix(coding-agent): share restricted state argv classification

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/state-argv.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-argv.ts
@@ -1,0 +1,292 @@
+import { CANONICAL_GJC_WORKFLOW_SKILLS, type CanonicalGjcWorkflowSkill } from "../skill-state/canonical-skills";
+import { typedArgsFor } from "./workflow-manifest";
+
+export type StateAction =
+	| "read"
+	| "write"
+	| "clear"
+	| "contract"
+	| "handoff"
+	| "graph"
+	| "prune"
+	| "gc"
+	| "migrate"
+	| "status"
+	| "doctor";
+
+export const STATE_ACTION_NAMES: ReadonlySet<StateAction> = new Set([
+	"read",
+	"write",
+	"clear",
+	"contract",
+	"handoff",
+	"graph",
+	"prune",
+	"gc",
+	"migrate",
+	"status",
+	"doctor",
+]);
+
+export const STATE_FLAGS_WITH_VALUES: ReadonlySet<string> = new Set([
+	"--input",
+	"--mode",
+	"--session-id",
+	"--thread-id",
+	"--turn-id",
+	"--to",
+	"--skill",
+	"--format",
+	"--older-than",
+	"--status",
+	"--fields",
+	"--since",
+	"--limit",
+]);
+
+export const STATE_BOOLEAN_FLAGS: ReadonlySet<string> = new Set([
+	"--json",
+	"--replace",
+	"--hard",
+	"--dry-run",
+	"--migrate",
+	"--compact",
+	"--history",
+	"--force",
+]);
+
+export interface StateFlagOccurrence {
+	name: string;
+	index: number;
+	value?: string;
+	arity: "boolean" | "value";
+	form: "separate" | "attached";
+	malformed: boolean;
+}
+
+export interface StateSelectorCandidate {
+	source: "mode" | "positional" | "input.mode" | "input.skill";
+	value: string | undefined;
+	index: number;
+}
+
+export type StateInputKind = "empty" | "inline" | "file" | "invalid";
+
+export interface StateInputClassification {
+	index: number;
+	raw: string;
+	kind: StateInputKind;
+	selectors: StateSelectorCandidate[];
+}
+
+export interface StateArgvClassification {
+	argv: readonly string[];
+	action: StateAction;
+	effectiveAction: StateAction;
+	positionalSkill?: string;
+	positionals: readonly string[];
+	flags: readonly StateFlagOccurrence[];
+	unknownFlags: readonly string[];
+	inputs: readonly StateInputClassification[];
+	runtimeSelectorCandidates: readonly StateSelectorCandidate[];
+	selectorCandidates: readonly StateSelectorCandidate[];
+}
+
+function normalizedFlagName(arg: string): string | undefined {
+	if (!arg.startsWith("--")) return undefined;
+	const equalsIndex = arg.indexOf("=");
+	return equalsIndex < 0 ? arg : arg.slice(0, equalsIndex);
+}
+
+function normalizedSelector(value: unknown): string | undefined {
+	return typeof value === "string" ? value.trim() || undefined : undefined;
+}
+
+interface StatePositional {
+	value: string;
+	index: number;
+}
+
+function parseRuntimePositionals(argv: readonly string[]): StatePositional[] {
+	const positionals: StatePositional[] = [];
+	let skipNext = false;
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index]!;
+		if (skipNext) {
+			skipNext = false;
+			continue;
+		}
+		if (STATE_FLAGS_WITH_VALUES.has(arg)) {
+			skipNext = true;
+			continue;
+		}
+		if (!arg.startsWith("-")) positionals.push({ value: arg, index });
+	}
+	return positionals;
+}
+
+function parseAction(positionals: readonly StatePositional[]): {
+	action: StateAction;
+	positionalSkill?: string;
+	positionalSkillIndex: number;
+} {
+	const [first, second] = positionals;
+	if (first?.value && STATE_ACTION_NAMES.has(first.value as StateAction)) {
+		return {
+			action: first.value as StateAction,
+			...(second?.value ? { positionalSkill: second.value } : {}),
+			positionalSkillIndex: second?.value ? second.index : -1,
+		};
+	}
+	if (first?.value && second?.value && STATE_ACTION_NAMES.has(second.value as StateAction)) {
+		return { action: second.value as StateAction, positionalSkill: first.value, positionalSkillIndex: first.index };
+	}
+	if (first?.value && !second?.value) {
+		return { action: "read", positionalSkill: first.value, positionalSkillIndex: first.index };
+	}
+	return { action: "read", positionalSkillIndex: -1 };
+}
+
+function stateFlagArities(
+	action: StateAction,
+	positionalSkill: string | undefined,
+): ReadonlyMap<string, "boolean" | "value"> {
+	const arities = new Map<string, "boolean" | "value">();
+	for (const flag of STATE_FLAGS_WITH_VALUES) arities.set(flag, "value");
+	for (const flag of STATE_BOOLEAN_FLAGS) arities.set(flag, "boolean");
+
+	const skills =
+		positionalSkill && CANONICAL_GJC_WORKFLOW_SKILLS.includes(positionalSkill as CanonicalGjcWorkflowSkill)
+			? [positionalSkill as CanonicalGjcWorkflowSkill]
+			: CANONICAL_GJC_WORKFLOW_SKILLS;
+	for (const skill of skills) {
+		for (const arg of typedArgsFor(skill, action)) {
+			const name = `--${arg.name}`;
+			if (!arities.has(name)) arities.set(name, arg.type === "boolean" ? "boolean" : "value");
+		}
+	}
+	return arities;
+}
+
+function classifyInput(occurrence: StateFlagOccurrence): StateInputClassification {
+	const raw = occurrence.value ?? "";
+	const trimmed = raw.trim();
+	if (!trimmed) return { index: occurrence.index, raw, kind: "empty", selectors: [] };
+	if (trimmed.startsWith("@")) return { index: occurrence.index, raw, kind: "file", selectors: [] };
+	try {
+		const payload = JSON.parse(trimmed) as unknown;
+		if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+			return { index: occurrence.index, raw, kind: "invalid", selectors: [] };
+		}
+		const record = payload as Record<string, unknown>;
+		return {
+			index: occurrence.index,
+			raw,
+			kind: "inline",
+			selectors: [
+				{ source: "input.mode", value: normalizedSelector(record.mode), index: occurrence.index },
+				{ source: "input.skill", value: normalizedSelector(record.skill), index: occurrence.index },
+			],
+		};
+	} catch {
+		return { index: occurrence.index, raw, kind: "invalid", selectors: [] };
+	}
+}
+
+export function firstStateFlagValue(classification: StateArgvClassification, name: string): string | undefined {
+	const index = classification.argv.indexOf(name);
+	return index < 0 ? undefined : classification.argv[index + 1];
+}
+
+export function classifyStateArgv(argv: readonly string[]): StateArgvClassification {
+	const preservedArgv = [...argv];
+	const positionalEntries = parseRuntimePositionals(preservedArgv);
+	const positionals = positionalEntries.map(positional => positional.value);
+	const { action, positionalSkill, positionalSkillIndex } = parseAction(positionalEntries);
+	const flagArities = stateFlagArities(action, positionalSkill);
+	const flags: StateFlagOccurrence[] = [];
+	const unknownFlags: string[] = [];
+
+	for (let index = 0; index < preservedArgv.length; index += 1) {
+		const arg = preservedArgv[index]!;
+		const name = normalizedFlagName(arg);
+		if (!name) continue;
+		const arity = flagArities.get(name);
+		if (!arity) {
+			unknownFlags.push(name);
+			continue;
+		}
+		if (arg !== name) {
+			flags.push({
+				name,
+				index,
+				value: arg.slice(name.length + 1),
+				arity,
+				form: "attached",
+				malformed: true,
+			});
+			continue;
+		}
+		if (arity === "boolean") {
+			flags.push({ name, index, arity, form: "separate", malformed: false });
+			continue;
+		}
+		const value = preservedArgv[index + 1];
+		flags.push({
+			name,
+			index,
+			...(value === undefined ? {} : { value }),
+			arity,
+			form: "separate",
+			malformed: value === undefined || value.startsWith("--"),
+		});
+	}
+	const effectiveAction = action === "read" && preservedArgv.includes("--migrate") ? "migrate" : action;
+
+	const modeFlags = flags.filter(flag => flag.name === "--mode" && flag.form === "separate");
+	const inputFlags = flags.filter(flag => flag.name === "--input" && flag.form === "separate");
+	const inputs = inputFlags.map(classifyInput);
+	const positionalCandidate: StateSelectorCandidate = {
+		source: "positional",
+		value: normalizedSelector(positionalSkill),
+		index: positionalSkillIndex,
+	};
+	const modeCandidates = modeFlags.map(flag => ({
+		source: "mode" as const,
+		value: normalizedSelector(flag.value),
+		index: flag.index,
+	}));
+	const selectorCandidates = [positionalCandidate, ...modeCandidates, ...inputs.flatMap(input => input.selectors)];
+	const firstModeIndex = preservedArgv.indexOf("--mode");
+	const firstModeCandidate: StateSelectorCandidate = {
+		source: "mode",
+		value: normalizedSelector(firstModeIndex < 0 ? undefined : preservedArgv[firstModeIndex + 1]),
+		index: firstModeIndex,
+	};
+	const firstInputIndex = preservedArgv.indexOf("--input");
+	const firstInput =
+		firstInputIndex < 0
+			? undefined
+			: classifyInput({
+					name: "--input",
+					index: firstInputIndex,
+					value: preservedArgv[firstInputIndex + 1],
+					arity: "value",
+					form: "separate",
+					malformed: false,
+				});
+	const runtimeSelectorCandidates = [firstModeCandidate, positionalCandidate, ...(firstInput?.selectors ?? [])];
+
+	return {
+		argv: preservedArgv,
+		action,
+		effectiveAction,
+		...(positionalSkill === undefined ? {} : { positionalSkill }),
+		positionals,
+		flags,
+		unknownFlags,
+		inputs,
+		runtimeSelectorCandidates,
+		selectorCandidates,
+	};
+}

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -42,6 +42,7 @@ import {
 	SessionResolutionError,
 	writeSessionActivityMarker,
 } from "./session-resolution";
+import { classifyStateArgv, firstStateFlagValue, type StateAction, type StateArgvClassification } from "./state-argv";
 import { renderStateGraph, type StateGraphFormat } from "./state-graph";
 import { migrateAndPersistLegacyState, migrateWorkflowState } from "./state-migrations";
 import {
@@ -72,7 +73,7 @@ import {
 	writeGuardedWorkflowEnvelopeAtomic,
 } from "./state-writer";
 import { assertSafePathComponent, CommandError, flagValue, hasFlag, isPlainObject } from "./workflow-cli-common";
-import { getSkillManifest, isKnownWorkflowState, isValidTransition, typedArgsFor } from "./workflow-manifest";
+import { getSkillManifest, isKnownWorkflowState, isValidTransition } from "./workflow-manifest";
 
 /**
  * Native implementation of the `gjc state read|write|clear` command surface.
@@ -99,136 +100,9 @@ class StateCommandError extends CommandError {
 }
 
 const GRAPH_FORMATS = new Set(["ascii", "mermaid", "dot"]);
-const FLAGS_WITH_VALUES = new Set([
-	"--input",
-	"--mode",
-	"--session-id",
-	"--thread-id",
-	"--turn-id",
-	"--to",
-	"--skill",
-	"--format",
-	"--older-than",
-	"--status",
-	"--fields",
-	"--since",
-	"--limit",
-]);
-const ACTION_NAMES = new Set([
-	"read",
-	"write",
-	"clear",
-	"contract",
-	"handoff",
-	"graph",
-	"prune",
-	"gc",
-	"migrate",
-	"status",
-	"doctor",
-]);
-const BOOLEAN_FLAGS = new Set([
-	"--json",
-	"--replace",
-	"--hard",
-	"--dry-run",
-	"--migrate",
-	"--compact",
-	"--history",
-	"--force",
-]);
-const VERB_SPECIFIC_FLAGS = new Set([
-	"--skill",
-	"--format",
-	"--older-than",
-	"--status",
-	"--fields",
-	"--since",
-	"--limit",
-	"--history",
-]);
-
-function flagName(arg: string): string | undefined {
-	if (!arg.startsWith("--")) return undefined;
-	const equalsIndex = arg.indexOf("=");
-	return equalsIndex >= 0 ? arg.slice(0, equalsIndex) : arg;
-}
-
-function manifestFlagNames(action: ParsedInvocation["action"], positionalSkill: string | undefined): Set<string> {
-	const names = new Set<string>();
-	const skills =
-		positionalSkill && KNOWN_MODES.includes(positionalSkill)
-			? [positionalSkill as CanonicalGjcWorkflowSkill]
-			: CANONICAL_GJC_WORKFLOW_SKILLS;
-	for (const skill of skills) {
-		for (const arg of typedArgsFor(skill, action)) names.add(`--${arg.name}`);
-	}
-	return names;
-}
-
-function assertKnownFlags(args: readonly string[], parsed: ParsedInvocation): void {
-	const manifestFlags = manifestFlagNames(parsed.action, parsed.positionalSkill);
-	for (const arg of args) {
-		const flag = flagName(arg);
-		if (!flag) continue;
-		if (
-			FLAGS_WITH_VALUES.has(flag) ||
-			BOOLEAN_FLAGS.has(flag) ||
-			VERB_SPECIFIC_FLAGS.has(flag) ||
-			manifestFlags.has(flag)
-		) {
-			continue;
-		}
-		throw new StateCommandError(2, `unknown gjc state flag: ${flag}`);
-	}
-}
-
-interface ParsedInvocation {
-	action:
-		| "read"
-		| "write"
-		| "clear"
-		| "contract"
-		| "handoff"
-		| "graph"
-		| "prune"
-		| "gc"
-		| "migrate"
-		| "status"
-		| "doctor";
-	positionalSkill?: string;
-}
-
-function parsePositionalArgs(args: readonly string[]): ParsedInvocation {
-	let skipNext = false;
-	const positional: string[] = [];
-	for (const arg of args) {
-		if (skipNext) {
-			skipNext = false;
-			continue;
-		}
-		if (FLAGS_WITH_VALUES.has(arg)) {
-			skipNext = true;
-			continue;
-		}
-		if (!arg.startsWith("-")) positional.push(arg);
-	}
-	// Documented argv shapes:
-	//   gjc state read|write|clear|contract ...
-	//   gjc state <skill> read|write|contract ...
-	const first = positional[0];
-	const second = positional[1];
-	if (first && ACTION_NAMES.has(first)) {
-		return { action: first as ParsedInvocation["action"], positionalSkill: second };
-	}
-	if (first && second && ACTION_NAMES.has(second)) {
-		return { action: second as ParsedInvocation["action"], positionalSkill: first };
-	}
-	// `gjc state <skill>` alone defaults to read for that skill.
-	if (first && !second) {
-		return { action: "read", positionalSkill: first };
-	}
-	return { action: "read" };
+function assertKnownFlags(classification: StateArgvClassification): void {
+	const [unknownFlag] = classification.unknownFlags;
+	if (unknownFlag) throw new StateCommandError(2, `unknown gjc state flag: ${unknownFlag}`);
 }
 
 function isKnownMode(mode: string): mode is CanonicalGjcWorkflowSkill {
@@ -279,19 +153,16 @@ interface ResolvedSelectors {
 // `clear` resolves like a read (explicit -> payload -> env -> latest-activity marker)
 // per the spec: read/status/clear may fall back to the most-recent session. Commands
 // that create or mutate new state roots still require an explicit/env session id.
-const WRITE_SESSION_ACTIONS = new Set<ParsedInvocation["action"]>(["write", "handoff", "prune", "migrate"]);
+const WRITE_SESSION_ACTIONS = new Set<StateAction>(["write", "handoff", "prune", "migrate"]);
 
-async function resolveSelectors(
-	args: readonly string[],
-	cwd: string,
-	positionalSkill: string | undefined,
-	action: ParsedInvocation["action"],
-): Promise<ResolvedSelectors> {
-	const payload = await readInputJson(flagValue(args, "--input"), cwd);
+async function resolveSelectors(args: readonly string[], cwd: string, action: StateAction): Promise<ResolvedSelectors> {
+	const classification = classifyStateArgv(args);
+	const payload = await readInputJson(firstStateFlagValue(classification, "--input"), cwd);
 
+	const [modeCandidate, positionalCandidate] = classification.runtimeSelectorCandidates;
 	const candidates: Array<string | undefined> = [
-		flagValue(args, "--mode")?.trim() || undefined,
-		positionalSkill?.trim() || undefined,
+		modeCandidate?.value,
+		positionalCandidate?.value,
 		typeof payload?.mode === "string" ? (payload.mode as string).trim() || undefined : undefined,
 		typeof payload?.skill === "string" ? (payload.skill as string).trim() || undefined : undefined,
 	];
@@ -1232,12 +1103,8 @@ export async function readWorkflowStateJson(
 	return (await readJsonFile(modeStateFile(cwd, skill, session.gjcSessionId))) ?? {};
 }
 
-async function handleRead(
-	args: readonly string[],
-	cwd: string,
-	positionalSkill: string | undefined,
-): Promise<StateCommandResult> {
-	const selectors = await resolveSelectors(args, cwd, positionalSkill, "read");
+async function handleRead(args: readonly string[], cwd: string): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, "read");
 	const mode = selectors.mode ?? (await inferModeFromActiveState(cwd, selectors.gjcSessionId));
 	const fields = parseFieldsFlag(args);
 	if (mode) {
@@ -1276,12 +1143,8 @@ async function handleRead(
 	return { status: 0, stdout: `${JSON.stringify(existing ?? {}, null, 2)}\n` };
 }
 
-async function handleStatus(
-	args: readonly string[],
-	cwd: string,
-	positionalSkill: string | undefined,
-): Promise<StateCommandResult> {
-	const selectors = await resolveSelectors(args, cwd, positionalSkill, "read");
+async function handleStatus(args: readonly string[], cwd: string): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, "read");
 	const mode = selectors.mode ?? (await inferModeFromActiveState(cwd, selectors.gjcSessionId));
 	if (!mode) {
 		throw new StateCommandError(
@@ -1303,12 +1166,8 @@ async function handleStatus(
 	};
 }
 
-async function handleWrite(
-	args: readonly string[],
-	cwd: string,
-	positionalSkill: string | undefined,
-): Promise<StateCommandResult> {
-	const selectors = await resolveSelectors(args, cwd, positionalSkill, "write");
+async function handleWrite(args: readonly string[], cwd: string): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, "write");
 	const { gjcSessionId: sessionId, threadId, turnId, payload } = selectors;
 	if (!payload) throw new StateCommandError(2, "gjc state write requires --input '<json>'");
 	const mode = selectors.mode ?? (await inferModeFromActiveState(cwd, sessionId));
@@ -1465,12 +1324,8 @@ async function handleWrite(
 	);
 }
 
-async function handleClear(
-	args: readonly string[],
-	cwd: string,
-	positionalSkill: string | undefined,
-): Promise<StateCommandResult> {
-	const selectors = await resolveSelectors(args, cwd, positionalSkill, "clear");
+async function handleClear(args: readonly string[], cwd: string): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, "clear");
 	const { gjcSessionId: sessionId, threadId, turnId } = selectors;
 	const mode = selectors.mode ?? (await inferModeFromActiveState(cwd, sessionId));
 	if (!mode)
@@ -1631,12 +1486,8 @@ async function assertDeepInterviewHandoffReady(state: Record<string, unknown>): 
  * the phase remains in `skill-active-state.json` until a chain call (or
  * explicit `clear`) demotes it.
  */
-async function handleHandoffUnlocked(
-	args: readonly string[],
-	cwd: string,
-	positionalSkill: string | undefined,
-): Promise<StateCommandResult> {
-	const selectors = await resolveSelectors(args, cwd, positionalSkill, "handoff");
+async function handleHandoffUnlocked(args: readonly string[], cwd: string): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, "handoff");
 	const { gjcSessionId: sessionId, threadId, turnId } = selectors;
 	const caller = selectors.mode ?? (await inferModeFromActiveState(cwd, sessionId));
 	if (!caller) {
@@ -1944,12 +1795,8 @@ async function handleHandoffUnlocked(
 	};
 }
 
-async function handleHandoff(
-	args: readonly string[],
-	cwd: string,
-	positionalSkill: string | undefined,
-): Promise<StateCommandResult> {
-	const selectors = await resolveSelectors(args, cwd, positionalSkill, "handoff");
+async function handleHandoff(args: readonly string[], cwd: string): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, "handoff");
 	// Serialize concurrent handoffs on a dedicated sentinel lock, NOT on the
 	// derived `skill-active-state.json` cache. The inner transaction
 	// (applyHandoffToActiveState / syncSkillActiveState -> rebuildActiveSnapshot)
@@ -1959,15 +1806,11 @@ async function handleHandoff(
 	// `{ cwd }` so the sentinel resolves against the handoff cwd rather than
 	// `process.cwd()`.
 	const handoffLock = path.join(sessionStateDir(cwd, selectors.gjcSessionId), "handoff");
-	return withWorkflowStateLock(handoffLock, async () => handleHandoffUnlocked(args, cwd, positionalSkill), { cwd });
+	return withWorkflowStateLock(handoffLock, async () => handleHandoffUnlocked(args, cwd), { cwd });
 }
 
-async function handleContract(
-	args: readonly string[],
-	cwd: string,
-	positionalSkill: string | undefined,
-): Promise<StateCommandResult> {
-	const { mode } = await resolveSelectors(args, cwd, positionalSkill, "read");
+async function handleContract(args: readonly string[], cwd: string): Promise<StateCommandResult> {
+	const { mode } = await resolveSelectors(args, cwd, "read");
 	if (!mode) {
 		throw new StateCommandError(2, "gjc state contract requires --mode <skill>, positional <skill>, or input.skill");
 	}
@@ -2195,12 +2038,8 @@ async function handleGraph(
 	};
 }
 
-async function handlePrune(
-	args: readonly string[],
-	cwd: string,
-	positionalSkill: string | undefined,
-): Promise<StateCommandResult> {
-	const selectors = await resolveSelectors(args, cwd, positionalSkill, "prune");
+async function handlePrune(args: readonly string[], cwd: string): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, "prune");
 	const mode = selectors.mode ?? (await inferModeFromActiveState(cwd, selectors.gjcSessionId));
 	if (!mode) {
 		throw new StateCommandError(
@@ -2265,12 +2104,8 @@ async function handleGc(
 	return { status: 0, stdout: `${JSON.stringify(summary, null, 2)}\n` };
 }
 
-async function handleMigrate(
-	args: readonly string[],
-	cwd: string,
-	positionalSkill: string | undefined,
-): Promise<StateCommandResult> {
-	const selectors = await resolveSelectors(args, cwd, positionalSkill, "migrate");
+async function handleMigrate(args: readonly string[], cwd: string): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, "migrate");
 	const mode = selectors.mode ?? (await inferModeFromActiveState(cwd, selectors.gjcSessionId));
 	if (!mode) {
 		throw new StateCommandError(
@@ -2301,34 +2136,31 @@ async function handleMigrate(
 
 export async function runNativeStateCommand(args: string[], cwd = process.cwd()): Promise<StateCommandResult> {
 	try {
-		const parsed = parsePositionalArgs(args);
-		assertKnownFlags(args, parsed);
-		switch (parsed.action) {
+		const parsed = classifyStateArgv(args);
+		assertKnownFlags(parsed);
+		switch (parsed.effectiveAction) {
 			case "read":
-				if (hasFlag(args, "--migrate")) return await handleMigrate(args, cwd, parsed.positionalSkill);
-				return await handleRead(args, cwd, parsed.positionalSkill);
+				return await handleRead(args, cwd);
 			case "write":
-				return await handleWrite(args, cwd, parsed.positionalSkill);
+				return await handleWrite(args, cwd);
 			case "clear":
-				return await handleClear(args, cwd, parsed.positionalSkill);
+				return await handleClear(args, cwd);
 			case "contract":
-				return await handleContract(args, cwd, parsed.positionalSkill);
+				return await handleContract(args, cwd);
 			case "status":
-				return await handleStatus(args, cwd, parsed.positionalSkill);
+				return await handleStatus(args, cwd);
 			case "doctor":
 				return await handleDoctor(args, cwd, parsed.positionalSkill);
 			case "handoff":
-				return await handleHandoff(args, cwd, parsed.positionalSkill);
+				return await handleHandoff(args, cwd);
 			case "graph":
 				return await handleGraph(args, cwd, parsed.positionalSkill);
 			case "prune":
-				return await handlePrune(args, cwd, parsed.positionalSkill);
+				return await handlePrune(args, cwd);
 			case "gc":
 				return await handleGc(args, cwd, parsed.positionalSkill);
 			case "migrate":
-				return await handleMigrate(args, cwd, parsed.positionalSkill);
-			default:
-				return { status: 2, stderr: `Unknown gjc state command: ${parsed.action}\n` };
+				return await handleMigrate(args, cwd);
 		}
 	} catch (error) {
 		if (error instanceof CommandError) return { status: error.exitStatus, stderr: `${error.message}\n` };

--- a/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
+++ b/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
@@ -1,3 +1,11 @@
+import {
+	classifyStateArgv,
+	STATE_ACTION_NAMES,
+	type StateAction,
+	type StateArgvClassification,
+} from "../gjc-runtime/state-argv";
+import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../skill-state/canonical-skills";
+
 export interface BashAllowedPrefixesCheck {
 	allowed: boolean;
 	reason?: string;
@@ -11,9 +19,8 @@ export interface BashRestrictionOptions {
 
 const SHELL_CONTROL_CHARS = new Set([";", "|", "&", "<", ">", "(", ")"]);
 const UNSAFE_UNQUOTED_EXPANSION_CHARS = new Set(["$", "*", "?", "[", "]", "{", "}", "~"]);
-const STATE_FLAGS_WITH_VALUES = new Set(["--input", "--mode", "--session-id", "--thread-id", "--turn-id", "--to"]);
-const STATE_ACTIONS = new Set(["read", "write", "clear", "contract", "handoff"]);
 const ALLOWED_STATE_ACTIONS = new Set(["read", "write", "contract"]);
+const CANONICAL_STATE_TARGETS = new Set<string>(CANONICAL_GJC_WORKFLOW_SKILLS);
 const READ_ONLY_COMMANDS = new Set(["grep", "rg", "tree", "ls", "pwd", "wc", "du", "file", "stat"]);
 
 function parseShellWords(command: string): { words: string[]; reason?: string } {
@@ -21,6 +28,7 @@ function parseShellWords(command: string): { words: string[]; reason?: string } 
 	let current = "";
 	let quote: "single" | "double" | null = null;
 
+	let wordStarted = false;
 	for (let index = 0; index < command.length; index += 1) {
 		const char = command[index]!;
 		const next = command[index + 1];
@@ -54,10 +62,12 @@ function parseShellWords(command: string): { words: string[]; reason?: string } 
 
 		if (char === "'") {
 			quote = "single";
+			wordStarted = true;
 			continue;
 		}
 		if (char === '"') {
 			quote = "double";
+			wordStarted = true;
 			continue;
 		}
 		if (char === "`" || (char === "$" && next === "(")) {
@@ -73,9 +83,10 @@ function parseShellWords(command: string): { words: string[]; reason?: string } 
 			return { words, reason: `shell expansion character '${char}' is not allowed in restricted bash commands` };
 		}
 		if (/\s/u.test(char)) {
-			if (current.length > 0) {
+			if (wordStarted) {
 				words.push(current);
 				current = "";
+				wordStarted = false;
 			}
 			continue;
 		}
@@ -83,12 +94,13 @@ function parseShellWords(command: string): { words: string[]; reason?: string } 
 			return { words, reason: "backslash escapes are not allowed in restricted bash commands" };
 		}
 		current += char;
+		wordStarted = true;
 	}
 
 	if (quote !== null) {
 		return { words, reason: "unterminated quote in restricted bash command" };
 	}
-	if (current.length > 0) words.push(current);
+	if (wordStarted) words.push(current);
 	return { words };
 }
 
@@ -101,28 +113,62 @@ function wordsStartWith(words: readonly string[], prefix: readonly string[]): bo
 	return prefix.every((word, index) => words[index] === word);
 }
 
-function parseStateAction(words: readonly string[]): string | undefined {
-	const args = words.slice(2);
-	const positional: string[] = [];
-	let skipNext = false;
-	for (const arg of args) {
-		if (skipNext) {
-			skipNext = false;
-			continue;
-		}
-		if (STATE_FLAGS_WITH_VALUES.has(arg)) {
-			skipNext = true;
-			continue;
-		}
-		if (!arg.startsWith("-")) positional.push(arg);
+function malformedStateShape(): StateActionClassification {
+	return { reason: "restricted role-agent bash only allows documented `gjc state` action shapes" };
+}
+
+interface ParsedStateAction {
+	action: string;
+	target: string;
+}
+
+interface StateActionClassification {
+	parsed?: ParsedStateAction;
+	reason?: string;
+}
+
+function hasDocumentedStatePositionals(classification: StateArgvClassification): boolean {
+	const [first, second, third] = classification.positionals;
+	if (third) return false;
+	if (!second) return true;
+	return STATE_ACTION_NAMES.has(first as StateAction) || STATE_ACTION_NAMES.has(second as StateAction);
+}
+
+function classifyStateAction(words: readonly string[]): StateActionClassification {
+	const classification = classifyStateArgv(words.slice(2));
+	if (
+		classification.unknownFlags.length > 0 ||
+		classification.flags.some(flag => flag.malformed) ||
+		!hasDocumentedStatePositionals(classification)
+	) {
+		return malformedStateShape();
 	}
 
-	const [first, second, third] = positional;
-	if (!first) return "read";
-	if (STATE_ACTIONS.has(first)) return second ? undefined : first;
-	if (!second) return "read";
-	if (!STATE_ACTIONS.has(second)) return undefined;
-	return third ? undefined : second;
+	const modeFlags = classification.flags.filter(flag => flag.name === "--mode");
+	const inputFlags = classification.flags.filter(flag => flag.name === "--input");
+	if (modeFlags.length > 1 || inputFlags.length > 1) {
+		return { reason: "restricted role-agent bash rejects repeated or conflicting `gjc state` target selectors" };
+	}
+	if (classification.inputs.some(input => input.kind === "file")) {
+		return { reason: "restricted role-agent bash does not allow file-backed `gjc state --input` values" };
+	}
+	if (classification.inputs.some(input => input.kind === "invalid")) return malformedStateShape();
+
+	const runtimeTarget = classification.runtimeSelectorCandidates.find(candidate => candidate.value)?.value;
+	const suppliedTargets = classification.selectorCandidates
+		.map(candidate => candidate.value)
+		.filter((target): target is string => target !== undefined);
+	const distinctTargets = new Set(suppliedTargets);
+	if (distinctTargets.size > 1 || (runtimeTarget && suppliedTargets.some(target => target !== runtimeTarget))) {
+		return {
+			reason:
+				"restricted role-agent bash rejects conflicting `gjc state` selectors that disagree with runtime precedence",
+		};
+	}
+	if (!runtimeTarget || !CANONICAL_STATE_TARGETS.has(runtimeTarget)) {
+		return { reason: "restricted role-agent bash requires a canonical workflow skill for `gjc state` commands" };
+	}
+	return { parsed: { action: classification.effectiveAction, target: runtimeTarget } };
 }
 
 function optionWords(words: readonly string[]): string[] {
@@ -189,15 +235,19 @@ function validateMatchedGjcCommand(words: readonly string[]): BashAllowedPrefixe
 	}
 
 	if (words[1] === "state") {
-		const action = parseStateAction(words);
-		if (!action) {
+		const classification = classifyStateAction(words);
+		if (!classification.parsed) {
 			return {
 				allowed: false,
-				reason: "restricted role-agent bash only allows documented `gjc state` action shapes",
+				reason:
+					classification.reason ?? "restricted role-agent bash only allows documented `gjc state` action shapes",
 			};
 		}
-		if (!ALLOWED_STATE_ACTIONS.has(action)) {
-			return { allowed: false, reason: `restricted role-agent bash does not allow \`gjc state ${action}\`` };
+		if (!ALLOWED_STATE_ACTIONS.has(classification.parsed.action)) {
+			return {
+				allowed: false,
+				reason: `restricted role-agent bash does not allow \`gjc state ${classification.parsed.action}\``,
+			};
 		}
 		return { allowed: true };
 	}

--- a/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
@@ -52,6 +52,34 @@ describe("native gjc state runtime", () => {
 		expect(result.status).toBe(0);
 		expect(envelopeState(result.stdout)).toEqual({});
 	});
+	it("treats an empty first positional as absent instead of clearing state", async () => {
+		const root = await tempDir();
+		const seed = await runNativeStateCommand(
+			["write", "--mode", "ralplan", "--input", JSON.stringify({ marker: "seed" })],
+			root,
+		);
+		expect(seed.status).toBe(0);
+
+		const result = await runNativeStateCommand(["", "clear", "--mode", "ralplan", "--json"], root);
+		expect(result.status).toBe(0);
+		expect(envelopeState(result.stdout).marker).toBe("seed");
+
+		const retained = await runNativeStateCommand(["read", "--mode", "ralplan", "--json"], root);
+		expect(envelopeState(retained.stdout).marker).toBe("seed");
+	});
+
+	it("treats an empty second positional as absent for an explicit skill read", async () => {
+		const root = await tempDir();
+		const seed = await runNativeStateCommand(
+			["write", "--mode", "ralplan", "--input", JSON.stringify({ marker: "seed" })],
+			root,
+		);
+		expect(seed.status).toBe(0);
+
+		const result = await runNativeStateCommand(["ralplan", "", "--json"], root);
+		expect(result.status).toBe(0);
+		expect(envelopeState(result.stdout).marker).toBe("seed");
+	});
 
 	it("reads corrupt mode-state fail-open as empty state", async () => {
 		const root = await tempDir();
@@ -104,6 +132,64 @@ describe("native gjc state runtime", () => {
 		// verify CLI flag won by reading the underlying file path
 		const ralplanFile = modeStatePath(root, TEST_SESSION_ID, "ralplan");
 		expect(JSON.parse(await fs.readFile(ralplanFile, "utf-8")).active).toBe(true);
+	});
+	it("preserves first-occurrence selector precedence for repeated mode flags", async () => {
+		const root = await tempDir();
+		const seed = await runNativeStateCommand(
+			["write", "--mode", "ralplan", "--input", JSON.stringify({ marker: "seed" })],
+			root,
+		);
+		expect(seed.status).toBe(0);
+
+		const repeated = await runNativeStateCommand(
+			["write", "--mode", "", "--mode", "team", "--input", JSON.stringify({ marker: "runtime-first" })],
+			root,
+		);
+		expect(repeated.status).toBe(0);
+
+		const ralplan = await runNativeStateCommand(["read", "--mode", "ralplan", "--json"], root);
+		const team = await runNativeStateCommand(["read", "--mode", "team", "--json"], root);
+		expect(envelopeState(ralplan.stdout).marker).toBe("runtime-first");
+		expect(envelopeState(team.stdout)).toEqual({});
+	});
+
+	it("preserves first-occurrence selector precedence for repeated input flags", async () => {
+		const root = await tempDir();
+		const seed = await runNativeStateCommand(
+			["write", "--mode", "ralplan", "--input", JSON.stringify({ marker: "seed" })],
+			root,
+		);
+		expect(seed.status).toBe(0);
+
+		const repeated = await runNativeStateCommand(
+			["write", "--input", "{}", "--input", JSON.stringify({ mode: "ralplan", current_phase: "handoff" }), "--json"],
+			root,
+		);
+		expect(repeated.status).toBe(0);
+
+		const result = await runNativeStateCommand(["read", "--mode", "ralplan", "--json"], root);
+		expect(envelopeState(result.stdout)).toMatchObject({ marker: "seed" });
+		expect(envelopeState(result.stdout).current_phase).not.toBe("handoff");
+	});
+
+	it("continues to accept known manifest flags", async () => {
+		const root = await tempDir();
+		const result = await runNativeStateCommand(
+			[
+				"write",
+				"--mode",
+				"ralplan",
+				"--input",
+				JSON.stringify({ marker: "manifest-compatible" }),
+				"--args",
+				"legacy-value",
+			],
+			root,
+		);
+
+		expect(result.status).toBe(0);
+		const state = await runNativeStateCommand(["read", "--mode", "ralplan", "--json"], root);
+		expect(envelopeState(state.stdout).marker).toBe("manifest-compatible");
 	});
 
 	it("merges write payloads while preserving long-lived keys", async () => {

--- a/packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts
+++ b/packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts
@@ -1,7 +1,91 @@
 import { describe, expect, it } from "bun:test";
+import { classifyStateArgv } from "../../src/gjc-runtime/state-argv";
 import { checkBashAllowedPrefixes } from "../../src/tools/bash-allowed-prefixes";
 
 const ROLE_AGENT_PREFIXES = ["gjc ralplan --write", "gjc state"] as const;
+describe("shared state argv classification", () => {
+	it("preserves argv and runtime first-occurrence precedence", () => {
+		const argv = ["write", "--mode", "", "--mode", "ralplan", "--input", "{}"];
+		const classification = classifyStateArgv(argv);
+
+		expect(classification.argv).toEqual(argv);
+		expect(classification.action).toBe("write");
+		expect(classification.effectiveAction).toBe("write");
+		expect(classification.runtimeSelectorCandidates.map(candidate => candidate.value)).toEqual([
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+		]);
+	});
+
+	it("classifies read migration by its runtime-effective action", () => {
+		const classification = classifyStateArgv(["ralplan", "read", "--migrate", "--force"]);
+
+		expect(classification.action).toBe("read");
+		expect(classification.effectiveAction).toBe("migrate");
+		expect(classification.runtimeSelectorCandidates.find(candidate => candidate.value)?.value).toBe("ralplan");
+	});
+	it("retains positional metadata while ignoring empty positional selectors", () => {
+		const explicitSkill = classifyStateArgv(["ralplan", "", "--json"]);
+		expect(explicitSkill.runtimeSelectorCandidates[1]).toEqual({
+			source: "positional",
+			value: "ralplan",
+			index: 0,
+		});
+
+		const emptyActionSelector = classifyStateArgv(["read", "", "--json"]);
+		expect(emptyActionSelector.positionalSkill).toBeUndefined();
+		expect(emptyActionSelector.runtimeSelectorCandidates[1]).toEqual({
+			source: "positional",
+			value: undefined,
+			index: -1,
+		});
+	});
+
+	it("classifies known manifest flags with their declared arity", () => {
+		const classification = classifyStateArgv(["write", "--mode", "ralplan", "--args", "manifest-value", "--json"]);
+
+		expect(classification.unknownFlags).toEqual([]);
+		expect(classification.flags.find(flag => flag.name === "--args")).toMatchObject({
+			arity: "value",
+			value: "manifest-value",
+			malformed: false,
+		});
+		expect(classification.flags.find(flag => flag.name === "--json")).toMatchObject({
+			arity: "boolean",
+			malformed: false,
+		});
+	});
+
+	it("keeps classifier-effective actions and restricted policy decisions conformant", () => {
+		const cases = [
+			{
+				command: "gjc state read --mode ralplan --json",
+				argv: ["read", "--mode", "ralplan", "--json"],
+				effectiveAction: "read",
+				allowed: true,
+			},
+			{
+				command: "gjc state ralplan read --migrate --force --json",
+				argv: ["ralplan", "read", "--migrate", "--force", "--json"],
+				effectiveAction: "migrate",
+				allowed: false,
+			},
+			{
+				command: "gjc state clear --mode ralplan --json",
+				argv: ["clear", "--mode", "ralplan", "--json"],
+				effectiveAction: "clear",
+				allowed: false,
+			},
+		] as const;
+
+		for (const testCase of cases) {
+			expect(classifyStateArgv(testCase.argv).effectiveAction).toBe(testCase.effectiveAction);
+			expect(checkBashAllowedPrefixes(testCase.command, ROLE_AGENT_PREFIXES).allowed).toBe(testCase.allowed);
+		}
+	});
+});
 
 describe("checkBashAllowedPrefixes", () => {
 	it("allows ralplan artifact writes for role agents", () => {
@@ -37,6 +121,34 @@ describe("checkBashAllowedPrefixes", () => {
 			),
 		).toEqual({ allowed: true });
 	});
+	it("allows canonical GJC state reads, writes, and contracts", () => {
+		const commands = [
+			"gjc state deep-interview",
+			"gjc state read --mode ralplan --json",
+			'gjc state ultragoal write --input \'{"current_phase":"handoff"}\' --json',
+			"gjc state team contract",
+		];
+
+		for (const command of commands) {
+			expect(checkBashAllowedPrefixes(command, ROLE_AGENT_PREFIXES)).toEqual({ allowed: true });
+		}
+	});
+
+	it("blocks bare or unknown GJC state targets", () => {
+		const commands = ["gjc state", "gjc state unknown write --json", "gjc state write --mode unknown --input '{}'"];
+
+		for (const command of commands) {
+			const result = checkBashAllowedPrefixes(command, ROLE_AGENT_PREFIXES);
+			expect(result.allowed).toBe(false);
+			expect(result.reason).toContain("canonical workflow skill");
+		}
+	});
+	it("blocks equals-form state modes that the runtime does not recognize", () => {
+		const result = checkBashAllowedPrefixes("gjc state write --mode=ralplan --input '{}'", ROLE_AGENT_PREFIXES);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("documented `gjc state` action shapes");
+	});
 
 	it("blocks destructive state clears", () => {
 		const result = checkBashAllowedPrefixes("gjc state ralplan clear --json", ROLE_AGENT_PREFIXES);
@@ -50,6 +162,114 @@ describe("checkBashAllowedPrefixes", () => {
 
 		expect(result.allowed).toBe(false);
 		expect(result.reason).toContain("gjc state handoff");
+	});
+	it("preserves empty quoted argv values when classifying destructive state actions", () => {
+		const commands = [
+			'gjc state --thread-id "" handoff ralplan --to team --session-id SESSION --json',
+			"gjc state --thread-id '' clear ralplan --session-id SESSION --json",
+		];
+
+		for (const command of commands) {
+			const direct = command.replace(/--thread-id (?:''|"") /u, "");
+			expect(checkBashAllowedPrefixes(command, ROLE_AGENT_PREFIXES).allowed).toBe(false);
+			expect(checkBashAllowedPrefixes(direct, ROLE_AGENT_PREFIXES).allowed).toBe(false);
+		}
+	});
+
+	it("blocks state modifiers that change the runtime-effective action", () => {
+		const result = checkBashAllowedPrefixes("gjc state ralplan read --migrate --force --json", ROLE_AGENT_PREFIXES);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("gjc state migrate");
+	});
+
+	it("allows agreeing canonical state targets across distinct selector sources", () => {
+		const result = checkBashAllowedPrefixes(
+			`gjc state ralplan write --input '{"mode":"ralplan","current_phase":"handoff"}' --json`,
+			ROLE_AGENT_PREFIXES,
+		);
+
+		expect(result).toEqual({ allowed: true });
+	});
+	it("fails closed when canonical state target selectors conflict", () => {
+		const commands = [
+			"gjc state ralplan write --mode team --input '{}'",
+			"gjc state write --mode ralplan --mode team --input '{}'",
+		];
+
+		for (const command of commands) {
+			const result = checkBashAllowedPrefixes(command, ROLE_AGENT_PREFIXES);
+			expect(result.allowed).toBe(false);
+			expect(result.reason).toContain("conflicting");
+		}
+	});
+	it("rejects repeated selectors when runtime first-occurrence precedence differs", () => {
+		const commands = [
+			`gjc state write --mode "" --mode ralplan --input '{"current_phase":"handoff"}' --json`,
+			`gjc state write --input '{}' --input '{"mode":"ralplan","current_phase":"handoff"}' --json`,
+			"gjc state write --mode '' --mode ralplan --input '{}'",
+			"gjc state write --mode ralplan --mode ralplan --input '{}'",
+			"gjc state write --mode ralplan --input '{}' --input '{}'",
+			"gjc state write --mode ralplan --input \"\" --input '{}'",
+			"gjc state write --mode ralplan --input '' --input '{}'",
+		];
+
+		for (const command of commands) {
+			const result = checkBashAllowedPrefixes(command, ROLE_AGENT_PREFIXES);
+			expect(result.allowed).toBe(false);
+			expect(result.reason).toContain("repeated");
+		}
+	});
+
+	it("rejects selectors that disagree with runtime precedence", () => {
+		const commands = [
+			"gjc state write team --mode ralplan --input '{}'",
+			'gjc state write --mode ralplan --input \'{"mode":"team"}\'',
+		];
+
+		for (const command of commands) {
+			const result = checkBashAllowedPrefixes(command, ROLE_AGENT_PREFIXES);
+			expect(result.allowed).toBe(false);
+			expect(result.reason).toContain("disagree");
+		}
+	});
+
+	it("rejects unknown and malformed state flags", () => {
+		const commands = [
+			"gjc state ralplan read --unknown",
+			"gjc state ralplan write --mode",
+			"gjc state ralplan write --input",
+		];
+
+		for (const command of commands) {
+			const result = checkBashAllowedPrefixes(command, ROLE_AGENT_PREFIXES);
+			expect(result.allowed).toBe(false);
+			expect(result.reason).toContain("documented `gjc state` action shapes");
+		}
+	});
+	it("rejects file-backed state input", () => {
+		const result = checkBashAllowedPrefixes(
+			"gjc state write --mode ralplan --input @payload.json",
+			ROLE_AGENT_PREFIXES,
+		);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("file-backed");
+	});
+
+	it("blocks destructive actions after every empty quoted selector value", () => {
+		const quoteForms = ['""', "''"];
+		const selectors = ["--thread-id", "--turn-id", "--session-id"];
+
+		for (const action of ["clear", "handoff"]) {
+			for (const selector of selectors) {
+				for (const empty of quoteForms) {
+					const suffix = action === "handoff" ? "--to team" : "--json";
+					const command = `gjc state ${selector} ${empty} ${action} ralplan ${suffix}`;
+					expect(checkBashAllowedPrefixes(command, ROLE_AGENT_PREFIXES).allowed).toBe(false);
+				}
+			}
+		}
 	});
 
 	it("blocks shell expansion that could synthesize a state action", () => {


### PR DESCRIPTION
## Summary

- Supersedes #2653 because GitHub could not reopen it after the corrected branch was force-updated.
- Resolves the owner REQUEST_CHANGES blockers by using one argv-preserving classifier for runtime dispatch and restricted Bash policy, evaluating runtime-effective actions and modifiers, and failing closed on malformed or conflicting selectors.
- Keeps the correction to one Lore commit across five files.

## Review evidence

- Independent code review: APPROVE
- Independent architecture review: CLEAR
- Targeted adversarial review: 9 cases, 0 unsafe and 0 clears
- Generated adversarial matrix: 1,512 cases, 0 destructive

## Validation

- Focused state-runtime and Bash allowlist tests: 58 passed
- Expanded prior-reviewer suite: 81 passed
- `bun --cwd=packages/coding-agent run check`
- `bun run check:tools`
- Biome check on all five changed files
- `git diff --check upstream/dev...HEAD`