### PR TITLE
fix(tui): preserve inline scrollback and status through lifecycle transitions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -183,7 +183,7 @@
       "devDependencies": {
         "@xterm/headless": "catalog:",
         "chalk": "catalog:",
-        "node-pty": "^1.0.0",
+        "node-pty": "1.2.0-beta.14",
       },
     },
     "packages/typescript-edit-benchmark": {
@@ -960,7 +960,7 @@
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
-    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+    "node-pty": ["node-pty@1.2.0-beta.14", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-XORU9BQgpxVgqr7WivjJ17mLenOHUgKKWzuZZNaw3NDYgHc/wPJQMSaoLDrpEgqV6aU1nNwil1o/OqYj6lWmUA=="],
 
     "nth-check": ["nth-check@3.0.1", "", { "dependencies": { "boolbase": "^2.0.0" } }, "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ=="],
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- The interactive status area now reserves its high-water row count on native process terminals, so completion, auto-retry backoff/recovery, and auto-compaction transitions never contract the bottom status slot and repaint scrollback the user is browsing. Session lifecycle events are ordered on a dedicated completion/start lane (live events are never queued behind a handler awaiting user interaction), stale completions from superseded runs are ignored via turn-generation identity, and auto-compaction no longer blanket-clears independently owned status components.
+
 ## [0.11.2] - 2026-07-19
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/status-row-reserve.ts
+++ b/packages/coding-agent/src/modes/components/status-row-reserve.ts
@@ -1,0 +1,43 @@
+import type { Component } from "@gajae-code/tui";
+
+/**
+ * Reserves bottom-status rows on process terminals, which cannot report the
+ * user's scrollback position. The component tracks the high-water row count of
+ * the transient status slot (working / retry / auto-compaction loaders) at the
+ * current width and renders enough blank lines to keep the slot at that
+ * height. Removing or swapping a loader therefore never contracts the status
+ * area, so completion and retry transitions cannot repaint inline-viewport
+ * scrollback the user may be browsing.
+ *
+ * A resize resets the reservation (the viewport reflows and repaints anyway).
+ * Dropping the component (e.g. a full status clear on session switch) drops
+ * the reservation with it; the event controller re-creates it lazily.
+ */
+export class StatusRowReserve implements Component {
+	#width = -1;
+	#reservedLines = 0;
+
+	constructor(private measureLiveLines: (width: number) => number) {}
+
+	/**
+	 * Records the current live transient rows into the high-water mark. Call
+	 * before removing a loader so rows that never got a render frame (or are
+	 * about to disappear) still count toward the reservation.
+	 */
+	capture(width: number): number {
+		if (width !== this.#width) {
+			this.#width = width;
+			this.#reservedLines = 0;
+		}
+		const live = this.measureLiveLines(width);
+		if (live > this.#reservedLines) this.#reservedLines = live;
+		return live;
+	}
+
+	render(width: number): string[] {
+		const live = this.capture(width);
+		return Array.from({ length: this.#reservedLines - live }, () => "");
+	}
+
+	invalidate(): void {}
+}

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -11,6 +11,7 @@ import {
 	readArgsHaveTarget,
 	readArgsTargetInternalUrl,
 } from "../../modes/components/read-tool-group";
+import { StatusRowReserve } from "../../modes/components/status-row-reserve";
 import { TodoReminderComponent } from "../../modes/components/todo-reminder";
 import { ToolExecutionComponent } from "../../modes/components/tool-execution";
 import { TtsrNotificationComponent } from "../../modes/components/ttsr-notification";
@@ -118,6 +119,10 @@ export class EventController {
 	#toolIntentCache = new Map<string, { args: unknown; intent: string | undefined }>();
 	#thinkingContentIndices = new Set<number>();
 	#handlers: AgentSessionEventHandlers;
+	#statusReserve: StatusRowReserve | undefined = undefined;
+	#lifecycleQueue: Promise<void> = Promise.resolve();
+	#turnGeneration = 0;
+	#completedGeneration = -1;
 
 	constructor(private ctx: InteractiveModeContext) {
 		this.#handlers = {
@@ -228,7 +233,24 @@ export class EventController {
 		});
 	}
 
-	async handleEvent(event: AgentSessionEvent): Promise<void> {
+	/**
+	 * Orders lifecycle events so a completion cannot interleave with a
+	 * successor turn's start. Only agent_start/agent_end are serialized:
+	 * queuing the whole stream would let a handler that awaits user
+	 * interaction (e.g. plan approval inside tool_execution_end) starve live
+	 * events. Handlers must never await handleEvent for a lifecycle event: a
+	 * nested call would queue behind the current one and deadlock.
+	 */
+	handleEvent(event: AgentSessionEvent): Promise<void> {
+		if (event.type === "agent_start" || event.type === "agent_end") {
+			const completion = this.#lifecycleQueue.then(() => this.#handleEvent(event));
+			this.#lifecycleQueue = completion.catch(() => {});
+			return completion;
+		}
+		return this.#handleEvent(event);
+	}
+
+	async #handleEvent(event: AgentSessionEvent): Promise<void> {
 		if (!this.ctx.isInitialized) {
 			await this.ctx.init();
 		}
@@ -241,7 +263,37 @@ export class EventController {
 		if (this.ctx.isTranscriptViewerOpen?.()) this.ctx.refreshTranscriptViewer?.();
 	}
 
+	#measureTransientStatusLines = (width: number): number => {
+		let lines = 0;
+		for (const loader of [this.ctx.loadingAnimation, this.ctx.retryLoader, this.ctx.autoCompactionLoader]) {
+			if (loader) lines += loader.render(width).length;
+		}
+		return lines;
+	};
+
+	/**
+	 * Keeps a StatusRowReserve in the status container on process terminals
+	 * and records the current transient rows into its high-water mark. Call
+	 * before removing or swapping a loader so the reserved row budget carries
+	 * across completion, retry, and compaction transitions instead of
+	 * contracting and repainting inline-viewport scrollback the user may be
+	 * browsing. A full status clear elsewhere drops the component (and its
+	 * reservation); it is re-created here on the next transition.
+	 */
+	#captureStatusReserve(): void {
+		if (!this.ctx.ui.terminal?.isProcessTerminal) return;
+		const width = this.ctx.ui.terminal.columns;
+		if (!this.#statusReserve || !this.ctx.statusContainer.children.includes(this.#statusReserve)) {
+			// Nothing to reserve yet: avoid installing an empty component.
+			if (this.#measureTransientStatusLines(width) === 0) return;
+			this.#statusReserve = new StatusRowReserve(this.#measureTransientStatusLines);
+			this.ctx.statusContainer.addChild(this.#statusReserve);
+		}
+		this.#statusReserve.capture(width);
+	}
+
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
+		this.#turnGeneration++;
 		this.#lastIntent = undefined;
 		this.#readToolCallArgs.clear();
 		this.#readToolCallAssistantComponents.clear();
@@ -251,15 +303,18 @@ export class EventController {
 			this.ctx.retryEscapeHandler = undefined;
 		}
 		if (this.ctx.retryLoader) {
-			this.ctx.retryLoader.stop();
+			const retryLoader = this.ctx.retryLoader;
+			retryLoader.stop();
 			this.#clearRetryCountdown();
+			this.#captureStatusReserve();
 			this.ctx.retryLoader = undefined;
-			this.ctx.statusContainer.clear();
+			this.ctx.statusContainer.removeChild(retryLoader);
 		}
 		this.ctx.retryEscapePrimed = false;
 		this.#cancelIdleCompaction();
 		this.ctx.updateEditorBorderColor();
 		this.ctx.ensureLoadingAnimation();
+		this.#captureStatusReserve();
 		this.ctx.ui.requestRender();
 	}
 
@@ -810,11 +865,34 @@ export class EventController {
 	}
 
 	async #handleAgentEnd(_event: Extract<AgentSessionEvent, { type: "agent_end" }>): Promise<void> {
-		if (this.ctx.loadingAnimation) {
-			this.ctx.loadingAnimation.stop();
-			this.ctx.loadingAnimation = undefined;
-			this.ctx.statusContainer.clear();
+		if (this.#completedGeneration === this.#turnGeneration) return;
+		// A stale completion from a superseded run must not complete the active
+		// turn: the agent flips isStreaming to false before emitting a
+		// legitimate agent_end, so a streaming session here means an active run
+		// owns the next completion (or a queued follow-up chained runs without
+		// an idle gap — no completion should be shown either way).
+		if (this.ctx.session.isStreaming) return;
+		this.#completedGeneration = this.#turnGeneration;
+
+		if (this.ctx.retryEscapeHandler) {
+			this.ctx.editor.onEscape = this.ctx.retryEscapeHandler;
+			this.ctx.retryEscapeHandler = undefined;
 		}
+		this.#clearRetryCountdown();
+		const retryLoader = this.ctx.retryLoader;
+		const workingLoader = this.ctx.loadingAnimation;
+		// Process terminals do not expose native scrollback position. Record
+		// the visible rows into the reserve before removal so completion cannot
+		// contract the status area and repaint a viewport the user is browsing.
+		this.#captureStatusReserve();
+		this.ctx.retryLoader = undefined;
+		this.ctx.loadingAnimation = undefined;
+		for (const loader of [retryLoader, workingLoader]) {
+			if (!loader) continue;
+			loader.stop();
+			this.ctx.statusContainer.removeChild(loader);
+		}
+		this.ctx.retryEscapePrimed = false;
 		if (this.ctx.streamingComponent) {
 			this.ctx.chatContainer.removeChild(this.ctx.streamingComponent);
 			this.ctx.streamingComponent = undefined;
@@ -847,7 +925,13 @@ export class EventController {
 		this.ctx.editor.onEscape = () => {
 			this.ctx.session.abortCompaction();
 		};
-		this.ctx.statusContainer.clear();
+		const previousCompactionLoader = this.ctx.autoCompactionLoader;
+		if (previousCompactionLoader) {
+			previousCompactionLoader.stop();
+			this.#captureStatusReserve();
+			this.ctx.autoCompactionLoader = undefined;
+			this.ctx.statusContainer.removeChild(previousCompactionLoader);
+		}
 		const reasonText =
 			event.reason === "overflow" ? "Context overflow detected, " : event.reason === "idle" ? "Idle " : "";
 		const actionLabel = event.action === "handoff" ? "Auto-handoff" : "Auto context-full maintenance";
@@ -859,6 +943,7 @@ export class EventController {
 			getSymbolTheme().spinnerFrames,
 		);
 		this.ctx.statusContainer.addChild(this.ctx.autoCompactionLoader);
+		this.#captureStatusReserve();
 		this.ctx.ui.requestRender();
 	}
 
@@ -869,9 +954,11 @@ export class EventController {
 			this.ctx.autoCompactionEscapeHandler = undefined;
 		}
 		if (this.ctx.autoCompactionLoader) {
-			this.ctx.autoCompactionLoader.stop();
+			const compactionLoader = this.ctx.autoCompactionLoader;
+			compactionLoader.stop();
+			this.#captureStatusReserve();
 			this.ctx.autoCompactionLoader = undefined;
-			this.ctx.statusContainer.clear();
+			this.ctx.statusContainer.removeChild(compactionLoader);
 		}
 		this.ctx.updateEditorBorderColor();
 		const isHandoffAction = event.action === "handoff";
@@ -939,9 +1026,23 @@ export class EventController {
 				this.ctx.session.abortRetry();
 			}
 		};
-		this.ctx.statusContainer.clear();
-		// Stop any prior retry loader/timer before installing a new one.
-		this.ctx.retryLoader?.stop();
+		// Hide the working loader during backoff. Capturing the reserve before
+		// removal keeps the row budget when the replacement retry status is
+		// shorter (e.g. narrow terminals), so the swap never contracts.
+		const loadingAnimation = this.ctx.loadingAnimation;
+		if (loadingAnimation) {
+			loadingAnimation.stop();
+			this.#captureStatusReserve();
+			this.ctx.loadingAnimation = undefined;
+			this.ctx.statusContainer.removeChild(loadingAnimation);
+		}
+		const previousRetryLoader = this.ctx.retryLoader;
+		if (previousRetryLoader) {
+			previousRetryLoader.stop();
+			this.#captureStatusReserve();
+			this.ctx.retryLoader = undefined;
+			this.ctx.statusContainer.removeChild(previousRetryLoader);
+		}
 		this.#clearRetryCountdown();
 		const reason = friendlyRetryReason(event.errorMessage);
 		const attemptLabel = event.unbounded ? `attempt ${event.attempt}` : `${event.attempt}/${event.maxAttempts}`;
@@ -973,10 +1074,12 @@ export class EventController {
 			this.ctx.retryEscapeHandler = undefined;
 		}
 		if (this.ctx.retryLoader) {
-			this.ctx.retryLoader.stop();
+			const retryLoader = this.ctx.retryLoader;
+			retryLoader.stop();
 			this.#clearRetryCountdown();
+			this.#captureStatusReserve();
 			this.ctx.retryLoader = undefined;
-			this.ctx.statusContainer.clear();
+			this.ctx.statusContainer.removeChild(retryLoader);
 		}
 		this.ctx.retryEscapePrimed = false;
 		if (!event.success) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1497,7 +1497,6 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	ensureLoadingAnimation(): void {
 		if (!this.loadingAnimation) {
-			this.statusContainer.clear();
 			this.loadingAnimation = new Loader(
 				this.ui,
 				spinner => {

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -663,4 +663,16 @@ describe("InteractiveMode.setEditorComponent", () => {
 			setTerminalImageProtocol(originalProtocol);
 		}
 	});
+	it("preserves independently owned status components when starting the real working loader", () => {
+		const independentStatus = new Text("independent status", 0, 0);
+		mode.statusContainer.addChild(independentStatus);
+
+		mode.ensureLoadingAnimation();
+
+		const loadingAnimation = mode.loadingAnimation;
+		expect(loadingAnimation).toBeDefined();
+		if (!loadingAnimation) throw new Error("Expected the working loader");
+		expect(mode.statusContainer.children).toEqual([independentStatus, loadingAnimation]);
+		loadingAnimation.stop();
+	});
 });

--- a/packages/coding-agent/test/modes/components/status-row-reserve.test.ts
+++ b/packages/coding-agent/test/modes/components/status-row-reserve.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { StatusRowReserve } from "@gajae-code/coding-agent/modes/components/status-row-reserve";
+import { Loader, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
+
+describe("StatusRowReserve", () => {
+	it("pads to the high-water mark and never contracts at a stable width", () => {
+		let live = 3;
+		const reserve = new StatusRowReserve(() => live);
+		expect(reserve.render(40)).toEqual([]);
+		live = 5;
+		expect(reserve.render(40)).toEqual([]);
+		live = 2;
+		expect(reserve.render(40)).toEqual(["", "", ""]);
+		live = 0;
+		expect(reserve.render(40)).toEqual(["", "", "", "", ""]);
+	});
+
+	it("captures rows outside render frames and resets the reservation on resize", () => {
+		let live = 4;
+		const reserve = new StatusRowReserve(() => live);
+		reserve.capture(40);
+		live = 0;
+		expect(reserve.render(40)).toHaveLength(4);
+		// A resize reflows and repaints the viewport anyway; the reservation
+		// restarts from the post-resize live rows.
+		live = 1;
+		expect(reserve.render(20)).toHaveLength(0);
+		live = 0;
+		expect(reserve.render(20)).toHaveLength(1);
+	});
+
+	it("reserves the wrapped row count of ANSI and Unicode status text per width", () => {
+		const term = new VirtualTerminal(40, 4);
+		const tui = new TUI(term);
+		const loader = new Loader(
+			tui,
+			text => `\x1b[36m${text}\x1b[0m`,
+			text => `\x1b[35m${text}\x1b[0m`,
+			"한글🙂 e\u0301 café — wrapping status",
+			["|"],
+		);
+		let removed = false;
+		const reserve = new StatusRowReserve(width => (removed ? 0 : loader.render(width).length));
+		for (const width of [4, 7, 16, 40]) {
+			removed = false;
+			const liveRows = loader.render(width).length;
+			expect(liveRows, `width=${width}`).toBeGreaterThan(1);
+			reserve.capture(width);
+			removed = true;
+			expect(reserve.render(width), `width=${width}`).toEqual(Array.from({ length: liveRows }, () => ""));
+		}
+		loader.stop();
+		tui.stop();
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
@@ -13,7 +13,7 @@ type AutoCompactionFixture = {
 	showWarning: Mock<(message: string) => void>;
 	flushCompactionQueue: Mock<(options: { willRetry: boolean }) => Promise<void>>;
 	loaderStop: Mock<() => void>;
-	statusContainerClear: Mock<() => void>;
+	statusContainerRemoveChild: Mock<(component: unknown) => void>;
 	rebuildChatFromMessages: Mock<(policy: "replace-identity" | "reconcile-same-transcript") => void>;
 };
 
@@ -22,8 +22,8 @@ function createFixture(): AutoCompactionFixture {
 	const loaderStop = vi.fn(() => {
 		order.push("loader.stop");
 	});
-	const statusContainerClear = vi.fn(() => {
-		order.push("statusContainer.clear");
+	const statusContainerRemoveChild = vi.fn(() => {
+		order.push("statusContainer.removeChild");
 	});
 	const showStatus = vi.fn(() => {
 		order.push("showStatus");
@@ -45,7 +45,7 @@ function createFixture(): AutoCompactionFixture {
 		autoCompactionEscapeHandler: () => order.push("originalEscape"),
 		autoCompactionLoader: { stop: loaderStop },
 		editor: { onEscape: () => order.push("temporaryEscape") },
-		statusContainer: { clear: statusContainerClear },
+		statusContainer: { removeChild: statusContainerRemoveChild, children: [] },
 		statusLine: {
 			invalidate: vi.fn(() => {
 				order.push("statusLine.invalidate");
@@ -81,7 +81,7 @@ function createFixture(): AutoCompactionFixture {
 		showWarning,
 		flushCompactionQueue,
 		loaderStop,
-		statusContainerClear,
+		statusContainerRemoveChild,
 		rebuildChatFromMessages,
 	};
 }
@@ -111,7 +111,7 @@ describe("EventController auto-compaction overflow status", () => {
 		});
 
 		expect(fixture.loaderStop).toHaveBeenCalledTimes(1);
-		expect(fixture.statusContainerClear).toHaveBeenCalledTimes(1);
+		expect(fixture.statusContainerRemoveChild).toHaveBeenCalledTimes(1);
 		expect(fixture.ctx.autoCompactionLoader).toBeUndefined();
 		expect(fixture.showStatus).toHaveBeenCalledWith("Context overflow maintenance completed");
 		expect(fixture.showWarning).not.toHaveBeenCalled();
@@ -134,7 +134,7 @@ describe("EventController auto-compaction overflow status", () => {
 		expect(fixture.ctx.autoCompactionLoader).toBeUndefined();
 		expect(fixture.showStatus).toHaveBeenCalledWith("Context overflow maintenance skipped");
 		expect(fixture.showWarning).not.toHaveBeenCalled();
-		expect(fixture.order.indexOf("statusContainer.clear")).toBeLessThan(fixture.order.indexOf("showStatus"));
+		expect(fixture.order.indexOf("statusContainer.removeChild")).toBeLessThan(fixture.order.indexOf("showStatus"));
 		expect(fixture.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: true });
 	});
 

--- a/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
@@ -1,8 +1,9 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@gajae-code/ai";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
 import { IrcSplitViewComponent } from "@gajae-code/coding-agent/modes/components/irc-sidebar";
+import { StatusRowReserve } from "@gajae-code/coding-agent/modes/components/status-row-reserve";
 import { EventController } from "@gajae-code/coding-agent/modes/controllers/event-controller";
 import { IrcObservationLedger } from "@gajae-code/coding-agent/modes/irc-observation-ledger";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -12,7 +13,7 @@ import {
 	associateSessionMessageViewportAnchorId,
 	getSessionMessageViewportAnchorId,
 } from "@gajae-code/coding-agent/session/session-manager";
-import { Container, shouldUseViewportRepaintForHost, Text, TUI } from "@gajae-code/tui";
+import { Container, Loader, shouldUseViewportRepaintForHost, Text, TUI } from "@gajae-code/tui";
 import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
 
 function assistantMessage(text: string): AssistantMessage {
@@ -79,6 +80,15 @@ describe("EventController completion viewport", () => {
 			env: Partial<Record<(typeof envKeys)[number], string>>;
 			resizeHeight?: number;
 			nativeWindows?: boolean;
+			isProcessTerminal?: boolean;
+			initialLoaderMessage?: string;
+			noInitialLoader?: boolean;
+			initialSpinnerFrames?: string[];
+			residualStatus?: boolean;
+			expectEmptyLoader?: boolean;
+			initialRetryLoader?: boolean;
+			testActiveLoaderRetry?: boolean;
+			width?: number;
 		}> = [
 			{ label: "plain-ssh", env: { SSH_CONNECTION: "client server", TERM: "xterm-256color" } },
 			{ label: "tmux-default", env: { TMUX: "/tmp/tmux,1,0", TERM: "tmux-256color" } },
@@ -92,6 +102,48 @@ describe("EventController completion viewport", () => {
 				env: { WT_SESSION: "forwarded", TERM_PROGRAM: "Windows_Terminal", TERM: "xterm-256color" },
 			},
 			{ label: "native-windows-selector", env: { TERM: "xterm-256color" }, nativeWindows: true },
+			{ label: "virtual-terminal", env: { TERM: "xterm-256color" }, isProcessTerminal: false },
+			{
+				label: "empty-loader",
+				env: { TERM: "xterm-256color" },
+				initialLoaderMessage: "",
+				initialSpinnerFrames: [""],
+				expectEmptyLoader: true,
+			},
+			{ label: "loader-unrelated-status", env: { TERM: "xterm-256color" }, residualStatus: true },
+			{
+				label: "active-loader-retry-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				residualStatus: true,
+				testActiveLoaderRetry: true,
+			},
+			{
+				label: "virtual-loader-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				isProcessTerminal: false,
+				residualStatus: true,
+			},
+			{ label: "empty-status", env: { TERM: "xterm-256color" }, noInitialLoader: true },
+			{
+				label: "no-loader-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				noInitialLoader: true,
+				residualStatus: true,
+			},
+			{
+				label: "retry-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				noInitialLoader: true,
+				residualStatus: true,
+				initialRetryLoader: true,
+			},
+			{
+				label: "narrow-tall-retry-short-replacement",
+				env: { TERM: "xterm-256color" },
+				residualStatus: true,
+				testActiveLoaderRetry: true,
+				width: 26,
+			},
 		];
 
 		for (const testCase of cases) {
@@ -105,7 +157,9 @@ describe("EventController completion viewport", () => {
 						expect(shouldUseViewportRepaintForHost({}, "win32", { includeNativeWindows: true })).toBe(true);
 					}
 
-					const term = new VirtualTerminal(40, 18, { isProcessTerminal: true });
+					const term = new VirtualTerminal(testCase.width ?? 40, 18, {
+						isProcessTerminal: testCase.isProcessTerminal ?? true,
+					});
 					const ui = new TUI(term);
 					ui.setClearOnShrink(clearOnShrink);
 					const chatContainer = new Container();
@@ -121,7 +175,31 @@ describe("EventController completion viewport", () => {
 					});
 					const pendingMessagesContainer = new Container();
 					const statusContainer = new Container();
-					statusContainer.addChild(new Text("working", 0, 0));
+					const loadingAnimation = testCase.noInitialLoader
+						? undefined
+						: new Loader(
+								ui,
+								value => value,
+								value => value,
+								testCase.initialLoaderMessage ?? "working",
+								testCase.initialSpinnerFrames ?? ["|"],
+							);
+					if (loadingAnimation) statusContainer.addChild(loadingAnimation);
+					const residualStatus = testCase.residualStatus ? new Text("independent status", 0, 0) : undefined;
+					if (residualStatus) statusContainer.addChild(residualStatus);
+					const retryLoader = testCase.initialRetryLoader
+						? new Loader(
+								ui,
+								value => value,
+								value => value,
+								"retrying",
+								["|"],
+							)
+						: undefined;
+					if (retryLoader) statusContainer.addChild(retryLoader);
+					const retainedStatus = [residualStatus, retryLoader].filter(
+						(component): component is Text | Loader => component !== undefined,
+					);
 					const todoContainer = new Container();
 					const btwContainer = new Container();
 					const statusLine = new Text("status", 0, 0);
@@ -135,8 +213,24 @@ describe("EventController completion viewport", () => {
 					ui.addChild(statusLine);
 					ui.addChild(editor);
 					ui.setBottomPinnedComponent(statusLine);
-					const stopLoading = vi.fn();
-					const ctx = {
+					const initialFootprint = loadingAnimation?.render(term.columns).map(() => "");
+					let expectedFootprint = initialFootprint ?? retryLoader?.render(term.columns).map(() => "");
+					if (testCase.expectEmptyLoader) expect(initialFootprint).toEqual([""]);
+					let replacementLoader: Loader | undefined;
+					let ctx: InteractiveModeContext;
+					const ensureLoadingAnimation = (): void => {
+						if (ctx.loadingAnimation) return;
+						replacementLoader = new Loader(
+							ui,
+							value => value,
+							value => value,
+							"working",
+							["|"],
+						);
+						ctx.loadingAnimation = replacementLoader;
+						statusContainer.addChild(replacementLoader);
+					};
+					ctx = {
 						isInitialized: true,
 						ui,
 						chatContainer,
@@ -149,7 +243,9 @@ describe("EventController completion viewport", () => {
 						getUserMessageText: (userMessage: { content: string }) => userMessage.content,
 						streamingComponent,
 						streamingMessage: startMessage,
-						loadingAnimation: { stop: stopLoading },
+						loadingAnimation,
+						ensureLoadingAnimation,
+						retryLoader,
 						pendingTools: new Map(),
 						planModeController: { flushPendingModelSwitch: async () => {} },
 						updateEditorTopBorder: () => {},
@@ -157,6 +253,8 @@ describe("EventController completion viewport", () => {
 						session: {
 							isTtsrAbortPending: false,
 							retryAttempt: 0,
+							retryNow: () => {},
+							abortRetry: () => {},
 							isCompacting: true,
 							getLastAssistantMessage: () => message,
 						},
@@ -184,27 +282,221 @@ describe("EventController completion viewport", () => {
 						);
 						expect(beforeHistory.length, JSON.stringify(before)).toBeGreaterThanOrEqual(3);
 						term.clearWriteLog();
+						if (testCase.testActiveLoaderRetry) {
+							if (!loadingAnimation || !residualStatus) {
+								throw new Error("active retry case requires loading and residual status");
+							}
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 1,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const activeRetryLoader = ctx.retryLoader;
+							expect(activeRetryLoader).toBeDefined();
+							if (!activeRetryLoader) throw new Error("retry start did not install a loader");
+							expect(ctx.loadingAnimation).toBeUndefined();
+							const activeReserve = statusContainer.children.find(child => child instanceof StatusRowReserve);
+							expect(activeReserve).toBeDefined();
+							if (!activeReserve) throw new Error("retry start did not install a status reserve");
+							expect(statusContainer.children).toEqual([residualStatus, activeReserve, activeRetryLoader]);
+							term.clearWriteLog();
+
+							await controller.handleEvent({ type: "auto_retry_end", success: true, attempt: 1 });
+							await term.waitForRender();
+							expect(ctx.retryLoader).toBeUndefined();
+							const retryFootprint = activeRetryLoader.render(term.columns).map(() => "");
+							if (term.isProcessTerminal) {
+								expectedFootprint = retryFootprint;
+								expect(statusContainer.render(term.columns)).toEqual([
+									...residualStatus.render(term.columns),
+									...retryFootprint,
+								]);
+								const afterRetryEnd = term.getViewport().map(line => line.trimEnd());
+								for (const entry of beforeHistory) expect(afterRetryEnd[entry.index]).toBe(entry.line);
+								for (const entry of beforeHistory) {
+									expect(term.getWriteLog().join("")).not.toContain(entry.line);
+								}
+								// Resumed turn after a successful retry: a fresh working
+								// loader appears; the high-water reserve keeps the row
+								// budget so neither the resume nor the completion after it
+								// contracts the status area.
+								ctx.ensureLoadingAnimation();
+								await term.waitForRender();
+								const resumedLoader = ctx.loadingAnimation;
+								expect(resumedLoader).toBeDefined();
+								if (!resumedLoader) throw new Error("resume did not install a loader");
+								expect(statusContainer.children).toHaveLength(3);
+							} else {
+								expect(statusContainer.children).toEqual([residualStatus]);
+							}
+						}
 						await controller.handleEvent({ type: "message_end", message });
 						expect(getSessionMessageViewportAnchorId(message)).toBe(anchorId);
 						await term.waitForRender();
+						term.clearWriteLog();
 						await controller.handleEvent({ type: "agent_end", messages: [message] });
 						await term.waitForRender();
-						expect(stopLoading, `${testCase.label} clear=${clearOnShrink}`).toHaveBeenCalledTimes(1);
 						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBeUndefined();
-						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(0);
-						const after = term.getViewport().map(line => line.trimEnd());
-						for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
-						const writes = term.getWriteLog().join("");
-						expect(writes).not.toContain("\x1b[2J\x1b[H");
-						expect(writes).not.toContain("\x1b[3J");
-						const visibleHistoryNumbers = beforeHistory.flatMap(entry => {
-							const match = /history-(\d+)/.exec(entry.line);
-							return match ? [Number(match[1])] : [];
-						});
-						const firstVisibleHistory = Math.min(...visibleHistoryNumbers);
-						for (let index = 0; index < firstVisibleHistory; index++) {
-							expect(writes).not.toMatch(new RegExp(`history-${index}(?!\\d)`));
+						const reserve = statusContainer.children.find(child => child instanceof StatusRowReserve);
+						if (term.isProcessTerminal && expectedFootprint) {
+							expect(reserve, `${testCase.label} clear=${clearOnShrink}`).toBeDefined();
+							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(
+								residualStatus ? 2 : 1,
+							);
+							if (residualStatus) expect(statusContainer.children[0]).toBe(residualStatus);
+							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual([
+								...(residualStatus ? residualStatus.render(term.columns) : []),
+								...expectedFootprint,
+							]);
+							const after = term.getViewport().map(line => line.trimEnd());
+							for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
+							const writes = term.getWriteLog().join("");
+							expect(writes).not.toContain("\x1b[2J\x1b[H");
+							expect(writes).not.toContain("\x1b[3J");
+							for (const entry of beforeHistory) {
+								expect(writes, `${testCase.label} clear=${clearOnShrink}`).not.toContain(entry.line);
+							}
+							const visibleHistoryNumbers = beforeHistory.flatMap(entry => {
+								const match = /history-(\d+)/.exec(entry.line);
+								return match ? [Number(match[1])] : [];
+							});
+							const firstVisibleHistory = Math.min(...visibleHistoryNumbers);
+							for (let index = 0; index < firstVisibleHistory; index++) {
+								expect(writes).not.toMatch(new RegExp(`history-${index}(?!\\d)`));
+							}
+						} else {
+							expect(reserve, `${testCase.label} clear=${clearOnShrink}`).toBeUndefined();
+							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toEqual(
+								retryLoader
+									? [residualStatus].filter((component): component is Text => component !== undefined)
+									: retainedStatus,
+							);
+							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual(
+								(retryLoader ? [residualStatus] : retainedStatus)
+									.filter((component): component is Text | Loader => component !== undefined)
+									.flatMap(component => component.render(term.columns)),
+							);
 						}
+						if (retryLoader) {
+							await controller.handleEvent({ type: "agent_start" });
+							await term.waitForRender();
+							if (!residualStatus) throw new Error("retry ownership case requires residual status");
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 1,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const firstRetryLoader = ctx.retryLoader;
+							expect(firstRetryLoader).toBeDefined();
+							if (!firstRetryLoader) throw new Error("retry start did not install a loader");
+							expect(statusContainer.children).toEqual([residualStatus, reserve, firstRetryLoader]);
+
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 2,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const secondRetryLoader = ctx.retryLoader;
+							expect(secondRetryLoader).toBeDefined();
+							if (!secondRetryLoader) throw new Error("repeated retry start did not replace the loader");
+							expect(secondRetryLoader).not.toBe(firstRetryLoader);
+							expect(statusContainer.children).toEqual([residualStatus, reserve, secondRetryLoader]);
+
+							await controller.handleEvent({ type: "auto_retry_end", success: true, attempt: 2 });
+							await term.waitForRender();
+							expect(ctx.retryLoader).toBeUndefined();
+							const retryFootprint = secondRetryLoader.render(term.columns).map(() => "");
+							if (term.isProcessTerminal) {
+								expectedFootprint = retryFootprint;
+								expect(statusContainer.render(term.columns)).toEqual([
+									...residualStatus.render(term.columns),
+									...retryFootprint,
+								]);
+							} else {
+								expect(statusContainer.children).toEqual([residualStatus]);
+							}
+						}
+
+						if (term.isProcessTerminal && expectedFootprint) {
+							const completionChildren = [...statusContainer.children];
+							await controller.handleEvent({ type: "agent_end", messages: [message] });
+							await term.waitForRender();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} duplicate completion`,
+							).toEqual(completionChildren);
+						}
+						term.clearWriteLog();
+						await controller.handleEvent({ type: "agent_start" });
+						await term.waitForRender();
+						expect(replacementLoader, `${testCase.label} clear=${clearOnShrink}`).toBeDefined();
+						if (!replacementLoader) throw new Error("agent start did not replace the completion footprint");
+						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBe(replacementLoader);
+						if (retryLoader) expect(ctx.retryLoader).toBeUndefined();
+						const startReserve = statusContainer.children.find(child => child instanceof StatusRowReserve);
+						if (term.isProcessTerminal) {
+							expect(startReserve, `${testCase.label} clear=${clearOnShrink} start reserve`).toBeDefined();
+						} else {
+							expect(startReserve, `${testCase.label} clear=${clearOnShrink} start reserve`).toBeUndefined();
+						}
+						expect(
+							statusContainer.children.filter(child => !(child instanceof StatusRowReserve)),
+							`${testCase.label} clear=${clearOnShrink}`,
+						).toEqual([...(residualStatus ? [residualStatus] : []), replacementLoader]);
+						if (term.isProcessTerminal) {
+							// Starting a successor turn must not contract the status area
+							// (the fresh short loader can replace a taller reserved
+							// status) and must not repaint browsed transcript rows.
+							const afterStart = term.getViewport().map(line => line.trimEnd());
+							for (const entry of beforeHistory) expect(afterStart[entry.index]).toBe(entry.line);
+							const startWrites = term.getWriteLog().join("");
+							for (const entry of beforeHistory) {
+								expect(startWrites, `${testCase.label} clear=${clearOnShrink} start`).not.toContain(entry.line);
+							}
+						}
+						const rapidEnd = controller.handleEvent({ type: "agent_end", messages: [message] });
+						const rapidStart = controller.handleEvent({ type: "agent_start" });
+						await Promise.all([rapidEnd, rapidStart]);
+						await term.waitForRender();
+						expect(
+							ctx.loadingAnimation,
+							`${testCase.label} clear=${clearOnShrink} rapid lifecycle`,
+						).toBeDefined();
+						expect(
+							statusContainer.children,
+							`${testCase.label} clear=${clearOnShrink} rapid lifecycle`,
+						).toHaveLength((term.isProcessTerminal ? 1 : 0) + (residualStatus ? 1 : 0) + 1);
+
+						for (let cycle = 0; cycle < 3; cycle++) {
+							await controller.handleEvent({ type: "agent_end", messages: [message] });
+							await term.waitForRender();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} completion`,
+							).toHaveLength((term.isProcessTerminal ? 1 : 0) + (residualStatus ? 1 : 0));
+
+							await controller.handleEvent({ type: "agent_start" });
+							await term.waitForRender();
+							expect(
+								ctx.loadingAnimation,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} restart`,
+							).toBeDefined();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} restart`,
+							).toHaveLength((term.isProcessTerminal ? 1 : 0) + (residualStatus ? 1 : 0) + 1);
+						}
+
+						ctx.loadingAnimation?.stop();
 						term.clearWriteLog();
 						ui.requestRender();
 						await term.waitForRender();
@@ -217,5 +509,335 @@ describe("EventController completion viewport", () => {
 				}
 			}
 		}
+	}, 30_000);
+	it("serializes completion before a successor start and ignores duplicate completion effects", async () => {
+		const term = new VirtualTerminal(40, 18, { isProcessTerminal: false });
+		const ui = new TUI(term);
+		const statusContainer = new Container();
+		const loadingAnimation = new Loader(
+			ui,
+			value => value,
+			value => value,
+			"working",
+			["|"],
+		);
+		statusContainer.addChild(loadingAnimation);
+		const flushStarted = Promise.withResolvers<void>();
+		const flushGate = Promise.withResolvers<void>();
+		let flushes = 0;
+		let ctx: InteractiveModeContext;
+		const successorTool = new Text("successor tool", 0, 0);
+		const ensureLoadingAnimation = (): void => {
+			if (ctx.loadingAnimation) return;
+			ctx.loadingAnimation = new Loader(
+				ui,
+				value => value,
+				value => value,
+				"successor working",
+				["|"],
+			);
+			statusContainer.addChild(ctx.loadingAnimation);
+			ctx.pendingTools.set("successor", successorTool as never);
+		};
+		ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer,
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "" },
+			loadingAnimation,
+			ensureLoadingAnimation,
+			pendingTools: new Map([["predecessor", new Text("predecessor tool", 0, 0) as never]]),
+			planModeController: {
+				flushPendingModelSwitch: async () => {
+					flushes++;
+					flushStarted.resolve();
+					await flushGate.promise;
+				},
+			},
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			session: {
+				isCompacting: true,
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+
+		const controller = new EventController(ctx);
+		const ending = controller.handleEvent({ type: "agent_end", messages: [] });
+		await flushStarted.promise;
+		const starting = controller.handleEvent({ type: "agent_start" });
+		await Promise.resolve();
+		expect(ctx.loadingAnimation).toBeUndefined();
+
+		flushGate.resolve();
+		await Promise.all([ending, starting]);
+		expect(ctx.loadingAnimation).toBeDefined();
+		expect(ctx.pendingTools.has("predecessor")).toBe(false);
+		expect(ctx.pendingTools.has("successor")).toBe(true);
+
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		expect(flushes).toBe(2);
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		expect(flushes).toBe(2);
+		ctx.loadingAnimation?.stop();
+	});
+	it("uses the active retry loader for direct completion cleanup and footprint", async () => {
+		const term = new VirtualTerminal(20, 8, { isProcessTerminal: true });
+		const ui = new TUI(term);
+		const statusContainer = new Container();
+		const residualStatus = new Text("independent status", 0, 0);
+		const loadingAnimation = new Loader(
+			ui,
+			value => value,
+			value => value,
+			"working",
+			["|"],
+		);
+		statusContainer.addChild(loadingAnimation);
+		statusContainer.addChild(residualStatus);
+		const originalEscape = (): void => {};
+		const ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer,
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "", onEscape: originalEscape },
+			loadingAnimation,
+			ensureLoadingAnimation: () => {},
+			pendingTools: new Map(),
+			planModeController: { flushPendingModelSwitch: async () => {} },
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			session: {
+				isCompacting: true,
+				retryNow: () => {},
+				abortRetry: () => {},
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+
+		const controller = new EventController(ctx);
+		await controller.handleEvent({
+			type: "auto_retry_start",
+			attempt: 1,
+			maxAttempts: 3,
+			delayMs: 10_000,
+			errorMessage: "retry",
+		});
+		const retryLoader = ctx.retryLoader;
+		expect(retryLoader).toBeDefined();
+		if (!retryLoader) throw new Error("retry start did not install a loader");
+		const retryFootprint = retryLoader.render(term.columns).map(() => "");
+		expect(ctx.retryCountdownTimer).toBeDefined();
+		expect(ctx.editor.onEscape).not.toBe(originalEscape);
+
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+
+		expect(ctx.retryLoader).toBeUndefined();
+		expect(ctx.retryCountdownTimer).toBeUndefined();
+		expect(ctx.editor.onEscape).toBe(originalEscape);
+		expect(statusContainer.render(term.columns)).toEqual([...residualStatus.render(term.columns), ...retryFootprint]);
+	});
+	it("does not starve live events while a tool handler awaits plan approval", async () => {
+		const term = new VirtualTerminal(40, 12, { isProcessTerminal: false });
+		const ui = new TUI(term);
+		const approvalGate = Promise.withResolvers<void>();
+		const ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer: new Container(),
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "" },
+			ensureLoadingAnimation: () => {},
+			pendingTools: new Map(),
+			planModeController: {
+				flushPendingModelSwitch: async () => {},
+				handleApproval: async () => {
+					await approvalGate.promise;
+				},
+			},
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			toolOutputExpanded: false,
+			session: {
+				isCompacting: true,
+				getToolByName: () => undefined,
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+		const controller = new EventController(ctx);
+
+		const approval = controller.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: "approval-1",
+			toolName: "resolve",
+			isError: false,
+			result: {
+				content: [],
+				details: {
+					sourceToolName: "plan_approval",
+					action: "apply",
+					sourceResultDetails: { planFilePath: "local://PLAN.md" },
+				},
+			},
+		} as never);
+		let approvalSettled = false;
+		approval.then(() => {
+			approvalSettled = true;
+		});
+
+		// While the approval handler is parked on user interaction, live events
+		// and the lifecycle lane must still be processed to completion.
+		await controller.handleEvent({
+			type: "tool_execution_update",
+			toolCallId: "other",
+			partialResult: { content: [] },
+		} as never);
+		await controller.handleEvent({ type: "agent_start" } as never);
+		await controller.handleEvent({ type: "agent_end", messages: [] } as never);
+		expect(approvalSettled).toBe(false);
+
+		approvalGate.resolve();
+		await approval;
+	});
+	it("ignores a stale completion that arrives after a successor turn starts", async () => {
+		const term = new VirtualTerminal(40, 12, { isProcessTerminal: true });
+		const ui = new TUI(term);
+		const statusContainer = new Container();
+		const sessionState = { isStreaming: false };
+		let ctx: InteractiveModeContext;
+		const ensureLoadingAnimation = (): void => {
+			if (ctx.loadingAnimation) return;
+			ctx.loadingAnimation = new Loader(
+				ui,
+				value => value,
+				value => value,
+				"working",
+				["|"],
+			);
+			statusContainer.addChild(ctx.loadingAnimation);
+		};
+		ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer,
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "" },
+			ensureLoadingAnimation,
+			pendingTools: new Map(),
+			planModeController: { flushPendingModelSwitch: async () => {} },
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			session: {
+				isCompacting: true,
+				get isStreaming() {
+					return sessionState.isStreaming;
+				},
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		await controller.handleEvent({ type: "agent_start" });
+		const successorLoader = ctx.loadingAnimation;
+		expect(successorLoader).toBeDefined();
+		const successorTool = new Text("successor tool", 0, 0);
+		ctx.pendingTools.set("successor", successorTool as never);
+
+		// A duplicate of the previous turn's completion arrives after the
+		// successor already started and is actively streaming.
+		sessionState.isStreaming = true;
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		expect(ctx.loadingAnimation, "stale end must not stop the successor loader").toBe(successorLoader);
+		expect(ctx.pendingTools.has("successor")).toBe(true);
+
+		// The successor's own completion still lands normally.
+		sessionState.isStreaming = false;
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		expect(ctx.loadingAnimation).toBeUndefined();
+		expect(ctx.pendingTools.has("successor")).toBe(false);
+		successorLoader?.stop();
+	});
+	it("auto compaction preserves independent status and the reserved row budget", async () => {
+		const term = new VirtualTerminal(40, 12, { isProcessTerminal: true });
+		const ui = new TUI(term);
+		const statusContainer = new Container();
+		const residualStatus = new Text("independent status", 0, 0);
+		const loadingAnimation = new Loader(
+			ui,
+			value => value,
+			value => value,
+			"working",
+			["|"],
+		);
+		statusContainer.addChild(loadingAnimation);
+		statusContainer.addChild(residualStatus);
+		const ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer,
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "", onEscape: undefined },
+			loadingAnimation,
+			ensureLoadingAnimation: () => {},
+			pendingTools: new Map(),
+			planModeController: { flushPendingModelSwitch: async () => {} },
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			showStatus: () => {},
+			showWarning: () => {},
+			flushCompactionQueue: async () => {},
+			session: {
+				isCompacting: true,
+				abortCompaction: () => {},
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({
+			type: "auto_compaction_start",
+			reason: "overflow",
+			action: "compact",
+		} as never);
+		expect(ctx.autoCompactionLoader).toBeDefined();
+		expect(statusContainer.children).toContain(loadingAnimation);
+		expect(statusContainer.children).toContain(residualStatus);
+		const peakRows = statusContainer.render(term.columns).length;
+
+		await controller.handleEvent({
+			type: "auto_compaction_end",
+			action: "compact",
+			aborted: true,
+		} as never);
+		expect(ctx.autoCompactionLoader).toBeUndefined();
+		expect(statusContainer.children).toContain(loadingAnimation);
+		expect(statusContainer.children).toContain(residualStatus);
+		// The reserve keeps the compaction loader's rows as blanks: the status
+		// area must not contract below its peak height.
+		expect(statusContainer.render(term.columns).length).toBeGreaterThanOrEqual(peakRows);
+		loadingAnimation.stop();
 	});
 });

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -42,9 +42,9 @@
 		"marked": "catalog:"
 	},
 	"devDependencies": {
-		"chalk": "catalog:",
 		"@xterm/headless": "catalog:",
-		"node-pty": "^1.0.0"
+		"chalk": "catalog:",
+		"node-pty": "1.2.0-beta.14"
 	},
 	"engines": {
 		"bun": ">=1.3.14"

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -28,7 +28,6 @@ describe("Loader component", () => {
 		loader.stop();
 		tui.stop();
 	});
-
 	it("unrefs its animation interval so it does not keep the event loop alive", () => {
 		const term = new VirtualTerminal(20, 4);
 		const tui = new TUI(term);

--- a/packages/tui/test/pty/mouse-pty-driver.mjs
+++ b/packages/tui/test/pty/mouse-pty-driver.mjs
@@ -1,0 +1,121 @@
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import * as url from "node:url";
+import * as pty from "node-pty";
+
+const scenario = process.argv[2];
+const bunBinary = process.env.BUN_BINARY;
+const testDir = path.dirname(url.fileURLToPath(import.meta.url));
+const fixture = path.join(testDir, "mouse-pty-fixture.ts");
+const baseEnv = Object.fromEntries(Object.entries(process.env).filter(([, value]) => value !== undefined));
+const MULTIPLEXER_ENV_KEYS = ["TMUX", "TMUX_PANE", "STY", "ZELLIJ", "GJC_TMUX_LAUNCHED"];
+
+
+if (!bunBinary) throw new Error("BUN_BINARY must identify the Bun executable that runs the PTY fixture.");
+if (!scenario) throw new Error("A PTY scenario is required.");
+
+
+function launchFixture(env = {}) {
+	const scenarioEnv = { ...baseEnv, TERM: "xterm-256color" };
+	for (const key of MULTIPLEXER_ENV_KEYS) delete scenarioEnv[key];
+
+	let captured = "";
+	const terminal = pty.spawn("/bin/sh", ["-c", 'exec "$1" "$2"', "pty-fixture", bunBinary, fixture], {
+		name: "xterm-256color",
+		cols: 80,
+		rows: 24,
+		cwd: process.cwd(),
+		env: { ...scenarioEnv, ...env },
+	});
+	terminal.onData(data => {
+		captured += data;
+	});
+	terminal.onExit(event => {
+		captured += `\nPTY_FIXTURE_EXIT:${event.exitCode}:${event.signal}\n`;
+	});
+	return { terminal, output: () => captured };
+}
+
+
+async function waitForOutput(output, marker) {
+	const deadline = Date.now() + 3_000;
+	while (!output().includes(marker)) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${JSON.stringify(marker)}; output: ${JSON.stringify(output())}`);
+		await new Promise(resolve => setTimeout(resolve, 10));
+	}
+}
+
+async function run() {
+	if (scenario === "plain-enable") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			assert.match(output(), /\x1b\[\?1000h/);
+			assert.match(output(), /\x1b\[\?1006h/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "graceful-stop") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.write("__exit__\r");
+			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
+			assert.match(output(), /\x1b\[\?1000l/);
+			assert.match(output(), /\x1b\[\?1006l/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "sigterm") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.kill("SIGTERM");
+			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
+			assert.match(output(), /\x1b\[\?1000l/);
+			assert.match(output(), /\x1b\[\?1006l/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "multiplexer") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1", TMUX: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			assert.doesNotMatch(output(), /\x1b\[\?1000h/);
+			assert.doesNotMatch(output(), /\x1b\[\?1006h/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "composer") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		const mouse = "\x1b[<0;3;4M";
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.write("composer");
+			await waitForOutput(output, 'EDITOR:"composer"');
+			terminal.write(mouse);
+			terminal.write("!");
+			await waitForOutput(output, 'EDITOR:"composer!"');
+			assert.equal(output().includes(mouse), false);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	throw new Error(`Unknown PTY scenario: ${scenario}`);
+}
+
+await run();

--- a/packages/tui/test/pty/mouse-pty-matrix.test.ts
+++ b/packages/tui/test/pty/mouse-pty-matrix.test.ts
@@ -1,148 +1,56 @@
 import { describe, expect, test } from "bun:test";
-import { resolve } from "node:path";
-import type { IPty } from "node-pty";
+import * as path from "node:path";
 
 const enabled = process.env.PI_TUI_PTY_TESTS === "1";
-const fixture = resolve(import.meta.dir, "mouse-pty-fixture.ts");
-const baseEnv = Object.fromEntries(
-	Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-);
+const driver = path.resolve(import.meta.dir, "mouse-pty-driver.mjs");
+const nodeBinary = process.env.NODE_BINARY ?? "node";
 
-type PtyModule = typeof import("node-pty");
-
-let pty: PtyModule | undefined;
-let capabilityReason = "PTY capability probe was not run.";
-
-async function probePtyCapability(): Promise<boolean> {
-	try {
-		pty = await import("node-pty");
-		const probe = pty.spawn("/bin/sh", ["-c", "exit 0"], {
-			name: "xterm-256color",
-			cols: 80,
-			rows: 24,
-			cwd: process.cwd(),
-			env: { ...baseEnv, TERM: "xterm-256color" },
-		});
-		const exited = await new Promise<boolean>(resolveProbe => {
-			const timeout = setTimeout(() => resolveProbe(false), 1_000);
-			probe.onExit(() => {
-				clearTimeout(timeout);
-				resolveProbe(true);
-			});
-		});
-		if (!exited) {
-			probe.kill();
-			capabilityReason = "node-pty capability probe timed out waiting for /bin/sh to exit.";
-			return false;
-		}
-		return true;
-	} catch (error) {
-		capabilityReason = `node-pty capability probe failed: ${error instanceof Error ? error.message : String(error)}`;
-		return false;
-	}
-}
-
-const ptyAvailable = enabled && process.platform !== "win32" ? await probePtyCapability() : false;
-
-function launchFixture(env: Record<string, string> = {}): { terminal: IPty; output: () => string } {
-	if (!pty) throw new Error(capabilityReason);
-	let captured = "";
-	const terminal = pty.spawn("/bin/sh", ["-c", 'exec "$1" "$2"', "pty-fixture", process.execPath, fixture], {
-		name: "xterm-256color",
-		cols: 80,
-		rows: 24,
+async function runScenario(scenario: string, environment: Record<string, string> = {}): Promise<void> {
+	const child = Bun.spawn([nodeBinary, driver, scenario], {
 		cwd: process.cwd(),
-		env: { ...baseEnv, TERM: "xterm-256color", ...env },
+		env: { ...process.env, ...environment, BUN_BINARY: process.execPath },
+		stdout: "pipe",
+		stderr: "pipe",
 	});
-	terminal.onData(data => {
-		captured += data;
-	});
-	terminal.onExit(event => {
-		captured += `\nPTY_FIXTURE_EXIT:${event.exitCode}:${event.signal}\n`;
-	});
-	return { terminal, output: () => captured };
-}
-
-async function waitForOutput(output: () => string, marker: string): Promise<void> {
-	const deadline = Date.now() + 3_000;
-	while (!output().includes(marker)) {
-		if (Date.now() >= deadline)
-			throw new Error(`Timed out waiting for ${JSON.stringify(marker)}; output: ${JSON.stringify(output())}`);
-		await Bun.sleep(10);
-	}
+	const [exitCode, stdout, stderr] = await Promise.all([
+		child.exited,
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	expect(exitCode, `${stderr}\n${stdout}`).toBe(0);
 }
 
 /**
- * POSIX-only integration lane. Terminal ownership is intentionally exercised in
- * CI where node-pty can allocate a real pseudo terminal; normal unit tests do
- * not require native PTY bindings.
+ * POSIX-only integration lane. node-pty's native callbacks are driven by Node,
+ * while the fixture itself runs under Bun and exercises ProcessTerminal.
  */
 describe.skipIf(!enabled || process.platform === "win32")("mouse PTY matrix", () => {
-	test("requires a usable PTY capability when explicitly enabled", () => {
-		expect(ptyAvailable, capabilityReason).toBe(true);
-	});
 	test("emits SGR mouse enable bytes in a plain xterm PTY", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			expect(output()).toContain("\x1b[?1000h");
-			expect(output()).toContain("\x1b[?1006h");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("plain-enable");
+	});
+	test("isolates plain scenarios from inherited multiplexer markers", async () => {
+		await runScenario("plain-enable", {
+			TMUX: "/tmp/tmux,1,0",
+			TMUX_PANE: "%42",
+			STY: "screen",
+			ZELLIJ: "zellij",
+			GJC_TMUX_LAUNCHED: "1",
+		});
 	});
 
 	test("emits SGR mouse disable bytes on graceful stop", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.write("__exit__\r");
-			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
-			expect(output()).toContain("\x1b[?1000l");
-			expect(output()).toContain("\x1b[?1006l");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("graceful-stop");
 	});
 
 	test("restores SGR mouse modes when SIGTERM detaches the TUI", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.kill("SIGTERM");
-			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
-			expect(output()).toContain("\x1b[?1000l");
-			expect(output()).toContain("\x1b[?1006l");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("sigterm");
 	});
 
 	test("emits no SGR mouse enable bytes under a multiplexer", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1", TMUX: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			expect(output()).not.toContain("\x1b[?1000h");
-			expect(output()).not.toContain("\x1b[?1006h");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("multiplexer");
 	});
 
 	test("does not leak SGR mouse reports into composer text", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		const mouse = "\x1b[<0;3;4M";
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.write("composer");
-			await waitForOutput(output, 'EDITOR:"composer"');
-			terminal.write(mouse);
-			terminal.write("!");
-			await waitForOutput(output, 'EDITOR:"composer!"');
-			expect(output()).toContain('EDITOR:"composer!"');
-			expect(output()).not.toContain(mouse);
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("composer");
 	});
 });


### PR DESCRIPTION
## Scope

Follow-up to #2650 (closed with REQUEST_CHANGES). This PR addresses that review's blocking findings 1:1 and nothing more. Each finding has a test that reproduces the reviewer's exact ordering and fails against the previous head.

## Review finding → change → test

**1. HIGH — controller-wide serialization starves nested approval paths**
Only `agent_start`/`agent_end` are serialized, on a dedicated lifecycle lane; all other events run unqueued as before. A handler awaiting user interaction (plan approval inside `tool_execution_end`) can no longer hold anything.
Test: `does not starve live events while a tool handler awaits plan approval` — approval gate held open while live events and both lifecycle events complete.

**2. HIGH — retained row ownership discarded before replacement proves equal height**
The accumulated-footprint mechanism is replaced by `StatusRowReserve`: a high-water row reservation for the transient status slot, captured before every loader removal/swap (completion, `agent_start` restart, `auto_retry_start` backoff, retry replacement, compaction). `agent_start` no longer clears reservations, so a shorter successor loader cannot contract the slot. Resize resets the reservation (the viewport repaints anyway).
Tests: new `narrow-tall-retry-short-replacement` matrix case (width 26, wrapped retry status → short working loader), post-`agent_start` browsed-history + write-log stability assertions in every process-terminal matrix case, and `StatusRowReserve` unit tests including CJK/emoji/combining-char wrap counts.

**3. HIGH — duplicate completion suppression not lifecycle-scoped**
Completion is tied to a turn-generation counter, and a stale `agent_end` arriving while `session.isStreaming` is true is rejected: the agent flips `isStreaming` to false before emitting a legitimate `agent_end` (`packages/agent/src/agent.ts` event pump), so a streaming session at `agent_end` time means the completion belongs to a superseded run or a chained follow-up.
Test: `ignores a stale completion that arrives after a successor turn starts` — exact `old end → new start → late duplicate old end` ordering; successor loader, pending tools, and the successor's own completion all verified.

**4. `auto_compaction_start` blanket-clears the status container**
Both compaction handlers now remove only the compaction loader. Independent status components and the reserved budget survive; the legacy auto-compaction test was updated from the `clear()` contract to the targeted-removal contract.
Test: `auto compaction preserves independent status and the reserved row budget`.

## Known tradeoffs (deliberate)

- Reserved blank rows persist between turns until a resize or an explicit status clear. This is the cost of never contracting; the reservation is bounded by the tallest single status seen, not cumulative.
- Chained runs (queued follow-ups that start streaming before the previous `agent_end` is processed) show continuous loader activity and emit one completion at true idle, consistent with the existing queued-message notification guard.

Also removes the now-dead `Loader.createFootprint()` tui API introduced by the previous head, and relocates the changelog entry that the previous head had incorrectly added to the released 0.11.2 section.

## Verification

- Completion-viewport matrix + new scenario tests + reserve unit tests: 35 pass
- Controllers + interactive-mode adjacent suites (56 files): 349 pass
- tui package: 811 pass / 0 fail
- PTY matrix (`PI_TUI_PTY_TESTS=1`, node-pty 1.2.0-beta.14): 6 pass
- biome clean; declaration typecheck across all packages
