### PR TITLE
fix(read): reject malformed internal URL selectors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Malformed selectors on internal read URLs now fail explicitly instead of silently falling back to an unbounded resource read.
+
 ## [0.11.3] - 2026-07-19
 
 ### Changed

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -10,13 +10,9 @@ const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const FILE_LINE_RANGE_RE = /^(?:L?\d+(?:[-+]L?\d+|-)?(?:,L?\d+(?:[-+]L?\d+|-)?)*|raw|conflicts)$/i;
 const FILE_LINE_RANGE_ONLY_RE = /^L?\d+(?:[-+]L?\d+|-)?(?:,L?\d+(?:[-+]L?\d+|-)?)*$/i;
 const FILE_RAW_ONLY_RE = /^raw$/i;
-// Permissive selector chunk for internal URLs — accepts well-formed selectors
-// plus common malformed shapes (e.g. `:-N`) so the read tool peels the entire
-// selector chain off before dispatching to a protocol handler.
-const INTERNAL_URL_SELECTOR_PART_RE =
-	/^(?:raw|conflicts|L?\d+(?:[-+]L?\d+|-)?(?:,L?\d+(?:[-+]L?\d+|-)?)*|-\d+(?:[-+]\d+)?)$/i;
-// Schemes whose host grammar is identifier-shaped, so any trailing
-// `:<selector-chunk>` is unambiguously a read-tool selector.
+// Schemes whose authority grammar is identifier-shaped and may therefore carry
+// a read selector immediately after the authority. Colons in a path, query, or
+// fragment remain part of the URL and are never considered selectors.
 const INTERNAL_SCHEMES_WITH_SELECTORS: Record<string, true> = {
 	agent: true,
 	artifact: true,
@@ -148,39 +144,50 @@ export function splitPathAndSel(rawPath: string): { path: string; sel?: string }
 /**
  * Variant of {@link splitPathAndSel} for internal URLs (`scheme://...`).
  *
- * The filesystem-path splitter is intentionally conservative: it refuses to
- * peel a trailing `:<chunk>` unless that chunk matches the strict selector
- * grammar. That rule is right for filesystem paths (a file named `a:1-50` is
- * legal) but wrong for internal URLs, where any trailing `:<chunk>` after the
- * scheme is unambiguously a read-tool selector — even if malformed (e.g.
- * `artifact://3:raw:-100`).
- *
- * This function iteratively peels selector-shaped chunks (well-formed plus
- * common malformed shapes like `:-N`) so the rest of the read tool can pass a
- * clean URL to the protocol handler and surface selector errors via parseSel
- * instead of as misleading "host invalid" errors from the handler.
- *
- * Falls back to the input unchanged when nothing matches.
+ * Artifact authorities are generated identifiers, so their complete tail is
+ * unambiguously a selector and malformed selectors can be rejected before
+ * resolving the artifact. Other resources may legitimately use colons in
+ * their identities, so they only lose strict, recognized selector suffixes.
+ * Skill authorities additionally use the active registry to distinguish a
+ * skill name from its selector without making path-utils depend on skills.
  */
-export function splitInternalUrlSel(rawPath: string): { path: string; sel?: string } {
+export function splitInternalUrlSel(
+	rawPath: string,
+	options: { activeSkillNames?: readonly string[] } = {},
+): { path: string; sel?: string } {
 	const schemeMatch = rawPath.match(INTERNAL_URL_SCHEME_RE);
 	if (!schemeMatch) return { path: rawPath };
-	if (!INTERNAL_SCHEMES_WITH_SELECTORS[schemeMatch[1].toLowerCase()]) return { path: rawPath };
+	const scheme = schemeMatch[1].toLowerCase();
+	if (!INTERNAL_SCHEMES_WITH_SELECTORS[scheme]) return { path: rawPath };
 
 	const schemeEnd = schemeMatch[0].length;
-	let path = rawPath;
-	const chunks: string[] = [];
-	while (true) {
-		const colon = path.lastIndexOf(":");
-		// Stop before crossing into the scheme separator `://`.
-		if (colon < schemeEnd) break;
-		const tail = path.slice(colon + 1);
-		if (!INTERNAL_URL_SELECTOR_PART_RE.test(tail)) break;
-		chunks.unshift(tail);
-		path = path.slice(0, colon);
+	const authorityTerminator = rawPath.slice(schemeEnd).search(/[/?#]/);
+	if (authorityTerminator !== -1) return { path: rawPath };
+	const authority = rawPath.slice(schemeEnd);
+	const firstColon = authority.indexOf(":");
+	if (firstColon === -1) return { path: rawPath };
+
+	if (scheme === "artifact") {
+		return { path: rawPath.slice(0, schemeEnd + firstColon), sel: authority.slice(firstColon + 1) };
 	}
-	if (chunks.length === 0) return { path: rawPath };
-	return { path, sel: chunks.join(":") };
+
+	if (scheme === "skill") {
+		const activeSkillNames = options.activeSkillNames ?? [];
+		if (activeSkillNames.includes(authority)) return { path: rawPath };
+		const skillName = activeSkillNames
+			.filter(name => authority.startsWith(`${name}:`))
+			.sort((a, b) => b.length - a.length)[0];
+		if (skillName) {
+			return {
+				path: `${rawPath.slice(0, schemeEnd)}${skillName}`,
+				sel: authority.slice(skillName.length + 1),
+			};
+		}
+	}
+
+	const strict = splitPathAndSel(authority);
+	if (strict.sel === undefined) return { path: rawPath };
+	return { path: `${rawPath.slice(0, schemeEnd)}${strict.path}`, sel: strict.sel };
 }
 
 function assertNotInternalUrl(expanded: string, original: string): void {

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -11,6 +11,7 @@ import * as z from "zod/v4";
 import { getFileReadCache } from "../edit/file-read-cache";
 import { isNotebookPath, readEditableNotebookText } from "../edit/notebook";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import { getActiveSkills } from "../extensibility/skills";
 import { formatHashLine, formatHashLines, formatLineHash, HL_BODY_SEP } from "../hashline/hash";
 import { InternalUrlRouter } from "../internal-urls";
 import { parseInternalUrl } from "../internal-urls/parse";
@@ -1585,8 +1586,13 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		// off the URL and surfaced via parseSel rather than confusing handlers.
 		const internalRouter = InternalUrlRouter.instance();
 		if (internalRouter.canHandle(readPath)) {
-			const internalTarget = splitInternalUrlSel(readPath);
+			const internalTarget = splitInternalUrlSel(readPath, {
+				activeSkillNames: getActiveSkills().map(skill => skill.name),
+			});
 			const parsed = parseSel(internalTarget.sel);
+			if (internalTarget.sel !== undefined && parsed.kind === "none") {
+				throw new ToolError(`Invalid internal URL selector "${internalTarget.sel}".`);
+			}
 			return this.#handleInternalUrl(internalTarget.path, parsed, signal);
 		}
 

--- a/packages/coding-agent/test/read-acp-fs.test.ts
+++ b/packages/coding-agent/test/read-acp-fs.test.ts
@@ -4,6 +4,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentToolResult } from "@gajae-code/agent-core";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { getActiveSkills, setActiveSkills } from "@gajae-code/coding-agent/extensibility/skills";
+import { InternalUrlRouter } from "@gajae-code/coding-agent/internal-urls";
 import type { ClientBridge } from "@gajae-code/coding-agent/session/client-bridge";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import type { ReadToolDetails } from "@gajae-code/coding-agent/tools/read";
@@ -109,5 +111,124 @@ describe("read tool ACP fs routing", () => {
 		expect(text).toContain("bridge two");
 		expect(text).not.toContain("Line 2 is beyond end");
 		expect(text).not.toContain("disk two");
+	});
+
+	it("rejects unknown and malformed internal selectors before resolving the resource", async () => {
+		const router = InternalUrlRouter.instance();
+		const previousSkillHandler = router.getHandler("skill");
+		router.register({
+			scheme: "skill",
+			immutable: true,
+			resolve: async () => ({ url: "skill://test", content: "", contentType: "text/markdown" }),
+		});
+		const resolveSpy = spyOn(router, "resolve").mockResolvedValue({
+			url: "artifact://3",
+			content: "one\ntwo\nthree\n",
+			contentType: "text/plain",
+		});
+		const tool = new ReadTool(createSession(tmpDir));
+		const previousSkills = getActiveSkills();
+		setActiveSkills([
+			{
+				name: "superpowers:brainstorming",
+				description: "",
+				filePath: "",
+				baseDir: "",
+				source: "test",
+			},
+		]);
+
+		try {
+			await expect(tool.execute("empty", { path: "artifact://3:" })).rejects.toThrow(
+				'Invalid internal URL selector "".',
+			);
+			await expect(tool.execute("unknown", { path: "artifact://3:bogus" })).rejects.toThrow(
+				'Invalid internal URL selector "bogus".',
+			);
+			await expect(tool.execute("unknown-compound", { path: "artifact://3:raw:bogus" })).rejects.toThrow(
+				'Invalid internal URL selector "raw:bogus".',
+			);
+			await expect(tool.execute("malformed-negative", { path: "artifact://3:-100" })).rejects.toThrow(
+				'Invalid internal URL selector "-100".',
+			);
+			await expect(tool.execute("malformed-compound", { path: "artifact://3:raw:-100" })).rejects.toThrow(
+				'Invalid internal URL selector "raw:-100".',
+			);
+			await expect(tool.execute("skill-empty", { path: "skill://superpowers:brainstorming:" })).rejects.toThrow(
+				'Invalid internal URL selector "".',
+			);
+			await expect(
+				tool.execute("skill-malformed", { path: "skill://superpowers:brainstorming:raw:-100" }),
+			).rejects.toThrow('Invalid internal URL selector "raw:-100".');
+
+			expect(resolveSpy).not.toHaveBeenCalled();
+		} finally {
+			resolveSpy.mockRestore();
+			if (previousSkillHandler) router.register(previousSkillHandler);
+			else router.unregister("skill");
+			setActiveSkills(previousSkills);
+		}
+	});
+
+	it("routes ordinary skill selectors after removing them from the resolver URL", async () => {
+		const router = InternalUrlRouter.instance();
+		const previousSkillHandler = router.getHandler("skill");
+		router.register({
+			scheme: "skill",
+			immutable: true,
+			resolve: async () => ({ url: "skill://test", content: "", contentType: "text/markdown" }),
+		});
+		const resolveSpy = spyOn(router, "resolve").mockResolvedValue({
+			url: "skill://brainstorming",
+			content: "one\ntwo\nthree\n",
+			contentType: "text/markdown",
+		});
+		const tool = new ReadTool(createSession(tmpDir));
+
+		try {
+			const raw = textOutput(await tool.execute("skill-raw", { path: "skill://brainstorming:raw" }));
+			const ranged = textOutput(await tool.execute("skill-range", { path: "skill://brainstorming:2-2" }));
+
+			expect(raw).toBe("one\ntwo\nthree\n");
+			expect(ranged).toContain("two");
+			expect(resolveSpy.mock.calls.map(([url]) => url)).toEqual(["skill://brainstorming", "skill://brainstorming"]);
+		} finally {
+			resolveSpy.mockRestore();
+			if (previousSkillHandler) router.register(previousSkillHandler);
+			else router.unregister("skill");
+		}
+	});
+
+	it("reads internal URLs without a selector and preserves valid selectors", async () => {
+		const router = InternalUrlRouter.instance();
+		const resolveSpy = spyOn(router, "resolve").mockResolvedValue({
+			url: "artifact://3",
+			content: "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\n",
+			contentType: "text/plain",
+		});
+		const tool = new ReadTool(createSession(tmpDir));
+
+		try {
+			const raw = textOutput(await tool.execute("raw", { path: "artifact://3:raw" }));
+			const bounded = textOutput(await tool.execute("range", { path: "artifact://3:4-4" }));
+			const boundedRaw = textOutput(await tool.execute("range-raw", { path: "artifact://3:4-4:raw" }));
+			expect(textOutput(await tool.execute("default", { path: "artifact://3" }))).toContain("one");
+			expect(raw).toBe("one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\n");
+			expect(bounded).toContain("four");
+			expect(bounded).not.toContain("one");
+			expect(boundedRaw).toContain("four");
+			expect(boundedRaw).not.toContain("one");
+			expect(boundedRaw).not.toContain("eight");
+
+			expect(resolveSpy).toHaveBeenCalledTimes(4);
+			expect(resolveSpy.mock.calls.map(([url]) => url)).toEqual([
+				"artifact://3",
+				"artifact://3",
+				"artifact://3",
+				"artifact://3",
+			]);
+		} finally {
+			resolveSpy.mockRestore();
+		}
 	});
 });

--- a/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
+++ b/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
@@ -2,74 +2,86 @@ import { describe, expect, it } from "bun:test";
 import { splitInternalUrlSel } from "@gajae-code/coding-agent/tools/path-utils";
 
 describe("splitInternalUrlSel", () => {
-	it("returns the input unchanged when there is no selector tail", () => {
-		expect(splitInternalUrlSel("artifact://3")).toEqual({ path: "artifact://3" });
-		expect(splitInternalUrlSel("agent://reviewer_0")).toEqual({ path: "agent://reviewer_0" });
-		expect(splitInternalUrlSel("memory://root")).toEqual({ path: "memory://root" });
-	});
-
-	it("peels a single line-range selector", () => {
+	it("peels strict artifact selectors, including compounds", () => {
 		expect(splitInternalUrlSel("artifact://3:1-100")).toEqual({ path: "artifact://3", sel: "1-100" });
-		expect(splitInternalUrlSel("artifact://3:50+150")).toEqual({ path: "artifact://3", sel: "50+150" });
-		expect(splitInternalUrlSel("artifact://3:50-")).toEqual({ path: "artifact://3", sel: "50-" });
+		expect(splitInternalUrlSel("artifact://3:raw:1-100")).toEqual({ path: "artifact://3", sel: "raw:1-100" });
+		expect(splitInternalUrlSel("artifact://3:1-100:raw")).toEqual({ path: "artifact://3", sel: "1-100:raw" });
 	});
 
-	it("peels a `raw` selector", () => {
-		expect(splitInternalUrlSel("artifact://3:raw")).toEqual({ path: "artifact://3", sel: "raw" });
+	it("peels every malformed artifact tail for pre-resolver rejection", () => {
+		for (const sel of ["", "bogus", "raw:bogus", "-100", "raw:-100"]) {
+			expect(splitInternalUrlSel(`artifact://3:${sel}`)).toEqual({ path: "artifact://3", sel });
+		}
 	});
 
-	it("peels compound `raw:range` selectors in either order", () => {
-		expect(splitInternalUrlSel("artifact://3:raw:1-100")).toEqual({
-			path: "artifact://3",
-			sel: "raw:1-100",
+	it("only peels strict selectors from ambiguous resource identities", () => {
+		for (const scheme of ["agent", "local", "memory", "rule", "gjc", "issue", "pr"]) {
+			expect(splitInternalUrlSel(`${scheme}://namespace:raw:bogus`)).toEqual({
+				path: `${scheme}://namespace:raw:bogus`,
+			});
+			expect(splitInternalUrlSel(`${scheme}://namespace:raw`)).toEqual({
+				path: `${scheme}://namespace`,
+				sel: "raw",
+			});
+			expect(splitInternalUrlSel(`${scheme}://namespace:raw:1-5`)).toEqual({
+				path: `${scheme}://namespace`,
+				sel: "raw:1-5",
+			});
+		}
+	});
+
+	it("does not classify path, query, or fragment data as selectors", () => {
+		expect(splitInternalUrlSel("agent://reviewer_0/result:summary")).toEqual({
+			path: "agent://reviewer_0/result:summary",
 		});
-		expect(splitInternalUrlSel("artifact://3:1-100:raw")).toEqual({
-			path: "artifact://3",
-			sel: "1-100:raw",
+		expect(splitInternalUrlSel('agent://reviewer_0?q=$.items[?(@.kind=="type:value")]')).toEqual({
+			path: 'agent://reviewer_0?q=$.items[?(@.kind=="type:value")]',
+		});
+		expect(splitInternalUrlSel("issue://owner/repo?label=type:bug#comment:2")).toEqual({
+			path: "issue://owner/repo?label=type:bug#comment:2",
+		});
+		expect(splitInternalUrlSel("pr://owner/repo?author=team:runtime")).toEqual({
+			path: "pr://owner/repo?author=team:runtime",
 		});
 	});
 
-	it("peels the malformed `:-N` selector that the strict splitter misses (the original bug)", () => {
-		expect(splitInternalUrlSel("artifact://3:raw:-100")).toEqual({
-			path: "artifact://3",
+	it("uses active skill names before interpreting selectors", () => {
+		const activeSkillNames = ["namespace:raw", "namespace:1-5", "superpowers:brainstorming"];
+		expect(splitInternalUrlSel("skill://namespace:raw", { activeSkillNames })).toEqual({
+			path: "skill://namespace:raw",
+		});
+		expect(splitInternalUrlSel("skill://namespace:1-5", { activeSkillNames })).toEqual({
+			path: "skill://namespace:1-5",
+		});
+		expect(splitInternalUrlSel("skill://superpowers:brainstorming:raw:-100", { activeSkillNames })).toEqual({
+			path: "skill://superpowers:brainstorming",
 			sel: "raw:-100",
 		});
-		expect(splitInternalUrlSel("artifact://3:-100")).toEqual({ path: "artifact://3", sel: "-100" });
-	});
-
-	it("peels selectors from skill URLs with namespaced hosts", () => {
-		expect(splitInternalUrlSel("skill://superpowers:brainstorming:1-5")).toEqual({
+		expect(splitInternalUrlSel("skill://superpowers:brainstorming:", { activeSkillNames })).toEqual({
 			path: "skill://superpowers:brainstorming",
-			sel: "1-5",
+			sel: "",
 		});
 	});
 
-	it("does not peel chunks that are not selector-shaped", () => {
-		// `name` is part of the host, not a selector.
-		expect(splitInternalUrlSel("skill://plugin:name")).toEqual({ path: "skill://plugin:name" });
-	});
-
-	it("stops at the scheme separator `://`", () => {
-		expect(splitInternalUrlSel("agent://1-50")).toEqual({ path: "agent://1-50" });
-	});
-
-	it("leaves mcp:// URLs alone (mcp resource URIs may legitimately contain colons)", () => {
-		expect(splitInternalUrlSel("mcp://some/resource:1234")).toEqual({
-			path: "mcp://some/resource:1234",
+	it("falls back to ordinary strict skill selectors without a registry", () => {
+		expect(splitInternalUrlSel("skill://brainstorming:raw")).toEqual({
+			path: "skill://brainstorming",
+			sel: "raw",
 		});
-		expect(splitInternalUrlSel("mcp://server://uri:1-50")).toEqual({
-			path: "mcp://server://uri:1-50",
+		expect(splitInternalUrlSel("skill://brainstorming:raw:1-5")).toEqual({
+			path: "skill://brainstorming",
+			sel: "raw:1-5",
+		});
+		expect(splitInternalUrlSel("skill://brainstorming:1-5:raw")).toEqual({
+			path: "skill://brainstorming",
+			sel: "1-5:raw",
 		});
 	});
 
-	it("returns the input unchanged for non-URL strings", () => {
+	it("leaves non-URL and unknown-scheme strings alone", () => {
 		expect(splitInternalUrlSel("/abs/path:1-50")).toEqual({ path: "/abs/path:1-50" });
-		expect(splitInternalUrlSel("plain-text")).toEqual({ path: "plain-text" });
-	});
-
-	it("does not peel for unknown schemes", () => {
-		expect(splitInternalUrlSel("http://example.com:1-50")).toEqual({
-			path: "http://example.com:1-50",
-		});
+		expect(splitInternalUrlSel("agent://1-50")).toEqual({ path: "agent://1-50" });
+		expect(splitInternalUrlSel("http://example.com:1-50")).toEqual({ path: "http://example.com:1-50" });
+		expect(splitInternalUrlSel("mcp://some/resource:1234")).toEqual({ path: "mcp://some/resource:1234" });
 	});
 });


### PR DESCRIPTION
## Summary
- reject every explicit malformed or unknown selector tail on selector-capable internal read URLs before router or handler resolution
- preserve selectorless, raw, bounded, namespaced skill, MCP, and unknown-scheme behavior
- place the changelog entry under the current Unreleased section

## Provenance
Owner-directed minimal salvage of the valuable product change from closed external PR #2590. This replacement explicitly credits and supersedes #2590; it was reapplied onto current dev without merging or cherry-picking stale metadata.

Original exact head: `ced138b0fec5422bd8980515c90e3e3169b5fc59`
Replacement exact head: `e5fbdb50a0a1268e5e0f397a186f0bd9f6959905`

## Verification
- `bun test test/read-acp-fs.test.ts test/tools/split-internal-url-sel.test.ts --rerun-each 3` — 42 pass, 0 fail
- `bun run check` in packages/coding-agent — passed
- `bun run check:tools` — passed
- `bun scripts/check-visible-definitions.ts` — passed
- `bun scripts/verify-g002-gates.ts` — passed

Broad-suite note: the full coding-agent suite was attempted and hit unrelated existing timeout/permission/SQLite failures; the monolithic root check:ts exceeded the 1200-second observation window after many SDK closure receipts passed. Changed-surface and relevant root/evidence gates are green.

## Review
A fresh hostile exact-head Architect/Security/QA verdict will be attached. Merge is gated on that signed verdict and exact-head hosted CI green.