### PR TITLE
fix(web-search): bound malformed compatible responses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,11 +3,10 @@
 ## [Unreleased]
 ### Fixed
 - Added evidence-preserving recovery for legacy multi-writer SDK session-index corruption: `gjc gc` now diagnoses corrupt prefixes, `--repair-session-index` quarantines the original snapshot/log under the session-index lock before atomically restoring only the checksum-valid monotonic prefix, and append failures point operators to the explicit repair path (#2654).
-
-### Fixed
 - Malformed selectors on internal read URLs now fail explicitly instead of silently falling back to an unbounded resource read.
 - Newly registered earlier resource-GC policies advance the pending sweep without postponing an already earlier sweep.
 - Provider onboarding wizard completion is now deterministic under CI load: duplicate in-flight confirmation is suppressed, success tests await the real refresh/notification/status boundary instead of fixed sleeps, and the newly configured model is verified through the subsequent model selector.
+- OpenAI-compatible web search now turns malformed successful response bodies into bounded provider errors while preserving normal provider fallback (#2593).
 
 ## [0.11.3] - 2026-07-19
 ### Added

--- a/packages/coding-agent/src/web/search/providers/openai-compatible.ts
+++ b/packages/coding-agent/src/web/search/providers/openai-compatible.ts
@@ -5,16 +5,68 @@ import { SearchProvider } from "./base";
 import { extractTextSources } from "./text-citations";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
+type JsonObject = Record<string, unknown>;
+
+function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function malformedResponse(detail: string): never {
+	throw new SearchProviderError(
+		"openai-compatible",
+		`OpenAI-compatible web search returned malformed response body (${detail})`,
+		502,
+	);
+}
+
+function optionalArray(value: unknown, detail: string): unknown[] {
+	if (value === undefined) return [];
+	if (!Array.isArray(value)) malformedResponse(detail);
+	return value;
+}
+
+function normalizeResponseBody(value: unknown): JsonObject {
+	if (!isJsonObject(value)) malformedResponse("expected a JSON object");
+
+	const output = optionalArray(value.output, "output must be an array");
+	const choices = optionalArray(value.choices, "choices must be an array");
+
+	for (const item of output) {
+		if (!isJsonObject(item)) continue;
+		for (const content of optionalArray(item.content, "output content must be an array")) {
+			if (isJsonObject(content)) optionalArray(content.annotations, "output annotations must be an array");
+		}
+	}
+	for (const choice of choices) {
+		if (!isJsonObject(choice) || !isJsonObject(choice.message)) continue;
+		optionalArray(choice.message.annotations, "choice annotations must be an array");
+	}
+
+	return { ...value, output, choices };
+}
+
+function parseResponseBody(text: string): JsonObject {
+	let value: unknown;
+	try {
+		value = text ? JSON.parse(text) : {};
+	} catch {
+		throw new SearchProviderError("openai-compatible", "OpenAI-compatible web search returned invalid JSON", 502);
+	}
+	return normalizeResponseBody(value);
+}
+
 /**
  * Whether the response carries independent proof that a web search ran. Used to
  * gate inline-citation recovery so a stray prose URL in a non-search answer is
  * never promoted to a citation.
  */
-function webSearchPerformed(json: any): boolean {
-	if (Array.isArray(json?.output) && json.output.some((item: any) => item?.type === "web_search_call")) {
+function webSearchPerformed(json: JsonObject): boolean {
+	if (Array.isArray(json.output) && json.output.some(item => isJsonObject(item) && item.type === "web_search_call")) {
 		return true;
 	}
-	const numRequests = json?.tool_usage?.web_search?.num_requests;
+	const toolUsage = isJsonObject(json.tool_usage) ? json.tool_usage : undefined;
+	const webSearch = toolUsage && isJsonObject(toolUsage.web_search) ? toolUsage.web_search : undefined;
+	const numRequests = webSearch?.num_requests;
 	return typeof numRequests === "number" && numRequests > 0;
 }
 
@@ -23,16 +75,18 @@ function endpoint(baseUrl: string, api: string): string {
 	return api === "openai-completions" ? `${base}/chat/completions` : `${base}/responses`;
 }
 
-function textFromResponse(json: any): string | undefined {
+function textFromResponse(json: JsonObject): string | undefined {
 	if (typeof json.output_text === "string") return json.output_text;
 	const chunks: string[] = [];
-	for (const item of json.output ?? []) {
-		for (const content of item.content ?? []) {
-			if (typeof content.text === "string") chunks.push(content.text);
+	for (const item of optionalArray(json.output, "output must be an array")) {
+		if (!isJsonObject(item)) continue;
+		for (const content of optionalArray(item.content, "output content must be an array")) {
+			if (isJsonObject(content) && typeof content.text === "string") chunks.push(content.text);
 		}
 	}
-	const chat = json.choices?.[0]?.message?.content;
-	if (typeof chat === "string") chunks.push(chat);
+	const firstChoice = optionalArray(json.choices, "choices must be an array")[0];
+	const message = isJsonObject(firstChoice) && isJsonObject(firstChoice.message) ? firstChoice.message : undefined;
+	if (typeof message?.content === "string") chunks.push(message.content);
 	return chunks.join("\n") || undefined;
 }
 
@@ -55,24 +109,23 @@ function pushCitation(out: SearchCitation[], rawUrl: unknown, rawTitle: unknown,
 function collectCitationAnnotations(annotations: unknown, out: SearchCitation[]): void {
 	if (!Array.isArray(annotations)) return;
 	for (const annotation of annotations) {
-		if (!annotation || typeof annotation !== "object") continue;
-		const ann = annotation as Record<string, any>;
-		if (ann.type !== "url_citation") continue;
-		const cite =
-			ann.url_citation && typeof ann.url_citation === "object" ? (ann.url_citation as Record<string, any>) : ann;
-		pushCitation(out, cite.url ?? cite.uri, cite.title, cite.text ?? cite.quote ?? ann.text);
+		if (!isJsonObject(annotation) || annotation.type !== "url_citation") continue;
+		const cite = isJsonObject(annotation.url_citation) ? annotation.url_citation : annotation;
+		pushCitation(out, cite.url ?? cite.uri, cite.title, cite.text ?? cite.quote ?? annotation.text);
 	}
 }
 
-function parseCitations(json: any): SearchCitation[] {
+function parseCitations(json: JsonObject): SearchCitation[] {
 	const citations: SearchCitation[] = [];
-	for (const item of json?.output ?? []) {
-		for (const content of item?.content ?? []) {
-			collectCitationAnnotations(content?.annotations, citations);
+	for (const item of optionalArray(json.output, "output must be an array")) {
+		if (!isJsonObject(item)) continue;
+		for (const content of optionalArray(item.content, "output content must be an array")) {
+			if (isJsonObject(content)) collectCitationAnnotations(content.annotations, citations);
 		}
 	}
-	for (const choice of json?.choices ?? []) {
-		collectCitationAnnotations(choice?.message?.annotations, citations);
+	for (const choice of optionalArray(json.choices, "choices must be an array")) {
+		const message = isJsonObject(choice) && isJsonObject(choice.message) ? choice.message : undefined;
+		if (message) collectCitationAnnotations(message.annotations, citations);
 	}
 	const seen = new Set<string>();
 	return citations.filter(c => {
@@ -156,7 +209,7 @@ export class OpenAICompatibleSearchProvider extends SearchProvider {
 				response.status,
 			);
 		}
-		const json = text ? JSON.parse(text) : {};
+		const json = parseResponseBody(text);
 		const citations = parseCitations(json);
 		const answer = textFromResponse(json);
 		const limit = params.limit ?? params.numSearchResults ?? 10;
@@ -178,7 +231,7 @@ export class OpenAICompatibleSearchProvider extends SearchProvider {
 			sources,
 			citations: citations.length > 0 ? citations : undefined,
 			model,
-			requestId: json.id,
+			requestId: typeof json.id === "string" ? json.id : undefined,
 			authMode: "api-key",
 		};
 	}

--- a/packages/coding-agent/test/web/search/execute-search-fallback.test.ts
+++ b/packages/coding-agent/test/web/search/execute-search-fallback.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import { hookFetch } from "@gajae-code/utils";
 import type { AuthStorage } from "../../../src/session/auth-storage";
 import { ToolAbortError } from "../../../src/tools/tool-errors";
 import { runSearchQuery } from "../../../src/web/search";
 import * as provider from "../../../src/web/search/provider";
 import type { SearchParams } from "../../../src/web/search/providers/base";
+import { OpenAICompatibleSearchProvider } from "../../../src/web/search/providers/openai-compatible";
 import { SearchProviderError, type SearchProviderId, type SearchResponse } from "../../../src/web/search/types";
 
 function fakeProvider(
@@ -33,6 +35,44 @@ describe("executeSearch fallback", () => {
 		const result = await runSearchQuery({ query: "anything" }, { authStorage });
 		expect(calls).toEqual(["generic", "exa"]);
 		expect(result.content[0]?.text).toContain("https://exa.example");
+	});
+
+	it("falls through after a malformed OpenAI-compatible response without exposing its body", async () => {
+		const secret = "malformed-response-secret";
+		const calls: string[] = [];
+		const urls: string[] = [];
+		using _hook = hookFetch(async input => {
+			calls.push("openai-compatible");
+			urls.push(String(input));
+			return new Response(secret);
+		});
+		vi.spyOn(provider, "resolveProviderChain").mockResolvedValue([
+			new OpenAICompatibleSearchProvider(),
+			fakeProvider("exa", async () => {
+				calls.push("exa");
+				return {
+					provider: "exa",
+					sources: [{ title: "Exa", url: "https://exa.example" }],
+				};
+			}),
+		]);
+		const result = await runSearchQuery(
+			{ query: "anything" },
+			{
+				authStorage: { getApiKey: async () => "sk-custom" } as unknown as AuthStorage,
+				activeModelContext: {
+					provider: "custom",
+					modelId: "gpt-5-mini",
+					api: "openai-responses",
+					baseUrl: "https://llm.example/v1",
+				},
+			},
+		);
+		expect(urls).toEqual(["https://llm.example/v1/responses"]);
+		expect(calls).toEqual(["openai-compatible", "exa"]);
+		expect(result.content[0]?.text).toContain("https://exa.example");
+		expect(result.content[0]?.text).not.toContain(secret);
+		expect(result.details.warning).not.toContain(secret);
 	});
 
 	it("rethrows caller abort instead of falling through", async () => {

--- a/packages/coding-agent/test/web/search/openai-compatible-provider.test.ts
+++ b/packages/coding-agent/test/web/search/openai-compatible-provider.test.ts
@@ -26,9 +26,9 @@ afterEach(() => vi.restoreAllMocks());
 
 describe("OpenAI-compatible web search provider", () => {
 	it("sends Responses requests with the web_search tool", async () => {
-		let body: any;
+		let body: { model?: unknown; tools?: unknown } | undefined;
 		using _hook = hookFetch(async (_input, init) => {
-			body = JSON.parse(String(init?.body));
+			body = JSON.parse(String(init?.body)) as { model?: unknown; tools?: unknown };
 			return Response.json({
 				id: "r1",
 				output_text: "answer",
@@ -36,38 +36,48 @@ describe("OpenAI-compatible web search provider", () => {
 			});
 		});
 		await new OpenAICompatibleSearchProvider().search(params());
-		expect(body.tools).toEqual([{ type: "web_search" }]);
-		expect(body.model).toBe("gpt-5-mini");
+		expect(body?.tools).toEqual([{ type: "web_search" }]);
+		expect(body?.model).toBe("gpt-5-mini");
 	});
 
 	it("falls back to Chat Completions with web_search_options when /responses is absent", async () => {
-		let body: any;
-		const urls: string[] = [];
-		using _hook = hookFetch(async (input, init) => {
-			const url = String(input);
-			urls.push(url);
-			if (url.endsWith("/responses")) return new Response("not found", { status: 404 });
-			body = JSON.parse(String(init?.body));
-			return Response.json({
-				choices: [
-					{
-						message: {
-							content: "answer",
-							annotations: [{ type: "url_citation", url: "https://b.example", title: "B" }],
+		for (const status of [404, 405]) {
+			let body: { messages?: Array<{ content?: unknown }>; web_search_options?: unknown } | undefined;
+			const urls: string[] = [];
+			const requestHeaders: Headers[] = [];
+			using _hook = hookFetch(async (input, init) => {
+				const url = String(input);
+				urls.push(url);
+				requestHeaders.push(new Headers(init?.headers));
+				if (url.endsWith("/responses")) return new Response("unavailable", { status });
+				body = JSON.parse(String(init?.body)) as {
+					messages?: Array<{ content?: unknown }>;
+					web_search_options?: unknown;
+				};
+				return Response.json({
+					choices: [
+						{
+							message: {
+								content: "answer",
+								annotations: [{ type: "url_citation", url: "https://b.example", title: "B" }],
+							},
 						},
-					},
-				],
+					],
+				});
 			});
-		});
-		const result = await new OpenAICompatibleSearchProvider().search(
-			params({ ...baseCtx, api: "openai-completions" }),
-		);
-		// Tried /responses first, then fell back to /chat/completions.
-		expect(urls.some(u => u.endsWith("/responses"))).toBe(true);
-		expect(urls.some(u => u.endsWith("/chat/completions"))).toBe(true);
-		expect(body.web_search_options).toEqual({});
-		expect(body.messages[1].content).toBe("news");
-		expect(result.sources).toEqual([{ title: "B", url: "https://b.example", snippet: undefined }]);
+			const result = await new OpenAICompatibleSearchProvider().search(
+				params({ ...baseCtx, api: "openai-completions" }),
+			);
+			expect(urls).toEqual(["https://llm.example/v1/responses", "https://llm.example/v1/chat/completions"]);
+			expect(requestHeaders).toHaveLength(2);
+			for (const headers of requestHeaders) {
+				expect(headers.get("Authorization")).toBe("Bearer sk-custom");
+				expect(headers.get("X-Test")).toBe("yes");
+			}
+			expect(body?.web_search_options).toEqual({});
+			expect(body?.messages?.[1]?.content).toBe("news");
+			expect(result.sources).toEqual([{ title: "B", url: "https://b.example", snippet: undefined }]);
+		}
 	});
 
 	it("prefers /responses for search even when the model's chat wire is openai-completions", async () => {
@@ -126,6 +136,127 @@ describe("OpenAI-compatible web search provider", () => {
 			provider: "openai-compatible",
 			status: 424,
 		});
+	});
+
+	it("wraps invalid JSON success bodies without exposing their contents", async () => {
+		const body = `not-json-${"sensitive ".repeat(1_000)}`;
+		using _hook = hookFetch(async () => new Response(body));
+		try {
+			await new OpenAICompatibleSearchProvider().search(params());
+			throw new Error("Expected malformed response to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SearchProviderError);
+			expect(error).toMatchObject({ provider: "openai-compatible", status: 502 });
+			expect((error as Error).message).toContain("invalid JSON");
+			expect((error as Error).message).not.toContain("sensitive");
+			expect((error as Error).message.length).toBeLessThan(200);
+		}
+	});
+
+	it("rejects scalar and array success bodies as malformed provider responses", async () => {
+		for (const body of [null, 42, "scalar-root-secret", []]) {
+			using _hook = hookFetch(async () => Response.json(body));
+			try {
+				await new OpenAICompatibleSearchProvider().search(params());
+				throw new Error("Expected malformed response to fail");
+			} catch (error) {
+				expect(error).toMatchObject({ provider: "openai-compatible", status: 502 });
+				expect((error as Error).message).not.toContain("scalar-root-secret");
+				expect((error as Error).message.length).toBeLessThan(200);
+			}
+		}
+	});
+
+	it("rejects wrong-shaped consumed arrays without exposing response bodies", async () => {
+		const secret = "wrong-shaped-array-secret";
+		const malformedBodies = [
+			{ output: `${secret}-output` },
+			{ choices: `${secret}-choices` },
+			{ output: [{ content: `${secret}-content` }] },
+			{ output: [{ content: [{ annotations: `${secret}-output-annotations` }] }] },
+			{ choices: [{ message: { annotations: `${secret}-choice-annotations` } }] },
+		];
+
+		for (const body of malformedBodies) {
+			using _hook = hookFetch(async () => Response.json(body));
+			try {
+				await new OpenAICompatibleSearchProvider().search(params());
+				throw new Error("Expected malformed response to fail");
+			} catch (error) {
+				expect(error).toMatchObject({ provider: "openai-compatible", status: 502 });
+				expect((error as Error).message).not.toContain(secret);
+				expect((error as Error).message.length).toBeLessThan(200);
+			}
+		}
+	});
+
+	it("skips non-object response entries while retaining citations and string request ids", async () => {
+		using _hook = hookFetch(async () =>
+			Response.json({
+				id: "string-request-id",
+				output: [
+					null,
+					42,
+					{
+						content: [
+							null,
+							"text",
+							{
+								annotations: [null, { type: "url_citation", url: "https://entries.example", title: "Entries" }],
+							},
+						],
+					},
+				],
+				choices: [
+					null,
+					42,
+					{ message: null },
+					{
+						message: {
+							annotations: [null, { type: "url_citation", url: "https://entries.example", title: "Entries" }],
+						},
+					},
+				],
+			}),
+		);
+		const result = await new OpenAICompatibleSearchProvider().search(params());
+		expect(result.requestId).toBe("string-request-id");
+		expect(result.sources).toEqual([{ title: "Entries", url: "https://entries.example", snippet: undefined }]);
+	});
+
+	it("omits non-string response ids", async () => {
+		using _hook = hookFetch(async () =>
+			Response.json({
+				id: 42,
+				output: [
+					{ content: [{ annotations: [{ type: "url_citation", url: "https://id.example", title: "ID" }] }] },
+				],
+			}),
+		);
+		const result = await new OpenAICompatibleSearchProvider().search(params());
+		expect(result.requestId).toBeUndefined();
+	});
+
+	it("classifies non-success responses without parsing them as successful bodies", async () => {
+		const body = "non-success-body-secret";
+		using _hook = hookFetch(async () => new Response(body, { status: 500 }));
+		try {
+			await new OpenAICompatibleSearchProvider().search(params());
+			throw new Error("Expected HTTP failure");
+		} catch (error) {
+			expect(error).toMatchObject({ provider: "openai-compatible", status: 500 });
+			expect((error as Error).message).toContain(body);
+			expect((error as Error).message).not.toContain("invalid JSON");
+		}
+	});
+
+	it("preserves abort errors from fetch", async () => {
+		const abort = new Error("Aborted");
+		abort.name = "AbortError";
+		using _hook = hookFetch(async () => {
+			throw abort;
+		});
+		await expect(new OpenAICompatibleSearchProvider().search(params())).rejects.toBe(abort);
 	});
 
 	it("does not accept non-url_citation source metadata as a citation (no masking)", async () => {


### PR DESCRIPTION
## Summary
- semantically reapplies the useful malformed-success handling from closed PR #2593 onto current `dev`
- converts invalid JSON and wrong-shaped consumed response arrays into bounded `openai-compatible` 502 provider errors without response-body leakage
- preserves Responses/Chat citations, 404/405 compatibility fallback, non-2xx classification, 424 no-citation behavior, credentials/headers, concurrency, and caller-abort identity
- adds real provider-to-provider fallback coverage and places the changelog entry under `Unreleased / Fixed`

This replacement PR explicitly supersedes #2593. Credit for the original implementation and defect fix goes to @datell1357. The stale external head was used only as a behavioral specification; it was not merged, rebased, or cherry-picked.

## Changed files
1. `packages/coding-agent/src/web/search/providers/openai-compatible.ts`
2. `packages/coding-agent/test/web/search/openai-compatible-provider.test.ts`
3. `packages/coding-agent/test/web/search/execute-search-fallback.test.ts`
4. `packages/coding-agent/CHANGELOG.md`

## Local verification
- focused web-search tests: 68 pass, 0 fail
- coding-agent check: passed
- root `ci:check:full`: passed
- root `ci:test:smoke`: passed
- ai-slop-cleaner: PASS, zero blockers
- hostile Architect: CLEAR/CLEAR/CLEAR, APPROVE
- hostile executor QA/red-team: passed, zero blockers

## Evidence identity
- base: `4181e88ddc332eff0c34533174c3df65f86446b5`
- replacement head: `b999f68df58ceee2a93773690fe994654346fd04`
- diff SHA-256: `35b7c9fd72d21aa3692f4dd81cc9f037ee08b1619fef6bdf8d55cee43ede5672`

Hosted exact-head evidence and PR integration checks are separate gates. Merge is authorized only if the displayed PR head remains the reviewed SHA and all required hosted checks are green. No `main`, release, version, tag, or publish work is included.