### PR TITLE
fix(resource-gc): advance earlier sweep deadlines

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Malformed selectors on internal read URLs now fail explicitly instead of silently falling back to an unbounded resource read.
+- Newly registered earlier resource-GC policies advance the pending sweep without postponing an already earlier sweep.
 
 ## [0.11.3] - 2026-07-19
 ### Added

--- a/packages/coding-agent/src/tools/resource-gc.ts
+++ b/packages/coding-agent/src/tools/resource-gc.ts
@@ -75,12 +75,31 @@ const defaultDeps: ResourceGcDeps = {
 
 // ── Controller state (process-global; tabs/browsers are module-global too) ──────────────────
 const activeSessions = new Map<string, Settings>();
-let timer: ReturnType<typeof setTimeout> | null = null;
+
+interface ScheduleOwner {
+	generation: number;
+	token: number;
+}
+
+interface DeferredSchedule {
+	generation: number;
+	deadline: number;
+}
+
+interface WorkOwner {
+	generation: number;
+	source: "timer" | "external";
+}
+
+let pendingTimer: NodeJS.Timeout | null = null;
+let pendingDeadline: number | null = null;
+let pendingOwner: ScheduleOwner | null = null;
+let deferredSchedule: DeferredSchedule | null = null;
+let inProgressOwner: WorkOwner | null = null;
 let stopped = false;
-// Bumped on every stop so an in-flight tick from a previous schedule cannot reschedule after a
-// stop+re-register and leak a duplicate timer.
 let timerGeneration = 0;
-let inProgress = false;
+let nextTimerToken = 0;
+let schedulerNow = (): number => performance.now();
 let rssWarningActive = false;
 let lastScreenshotScanAt = 0;
 let deps: ResourceGcDeps = defaultDeps;
@@ -96,8 +115,20 @@ export interface ResourceGcRegistration {
  * session unregisters.
  */
 export function registerResourceGcSession(reg: ResourceGcRegistration): () => void {
+	const isNewSession = !activeSessions.has(reg.sessionId);
 	activeSessions.set(reg.sessionId, reg.settings);
-	ensureTimerStarted();
+	stopped = false;
+	if (isNewSession) {
+		const deadline = schedulerNow() + resolveSweepIntervalMs(reg.settings);
+		if (
+			inProgressOwner?.generation === timerGeneration &&
+			(pendingDeadline === null || pendingDeadline <= deadline)
+		) {
+			deferSchedule(timerGeneration, deadline);
+		} else {
+			requestSchedule(deadline);
+		}
+	}
 	let unregistered = false;
 	return () => {
 		if (unregistered) return;
@@ -113,51 +144,78 @@ function currentSweepIntervalMs(): number {
 	return Number.isFinite(min) ? min : DEFAULT_SWEEP_INTERVAL_MS;
 }
 
-function ensureTimerStarted(): void {
-	if (timer) return;
-	stopped = false;
-	scheduleNextSweep();
+function clearPendingSchedule(): void {
+	if (pendingTimer) clearTimeout(pendingTimer);
+	pendingTimer = null;
+	pendingDeadline = null;
+	pendingOwner = null;
 }
 
-// Recursive setTimeout (not setInterval) so the cadence is recomputed every cycle and later
-// session register/unregister changes to resourceGc.sweepIntervalMs are honored live.
-function scheduleNextSweep(): void {
-	if (stopped || activeSessions.size === 0) {
-		timer = null;
+function requestSchedule(deadline: number): void {
+	if (stopped || activeSessions.size === 0) return;
+	if (pendingDeadline !== null && pendingDeadline <= deadline) return;
+	clearPendingSchedule();
+	const owner = { generation: timerGeneration, token: ++nextTimerToken };
+	pendingDeadline = deadline;
+	pendingOwner = owner;
+	pendingTimer = setTimeout(
+		() => {
+			void handleTimerCallback(owner, deadline);
+		},
+		Math.max(0, deadline - schedulerNow()),
+	);
+	pendingTimer.unref?.();
+}
+
+function deferSchedule(generation: number, deadline: number): void {
+	if (generation !== timerGeneration) return;
+	if (deferredSchedule?.generation === generation) {
+		deferredSchedule.deadline = Math.min(deferredSchedule.deadline, deadline);
 		return;
 	}
-	const generation = timerGeneration;
-	timer = setTimeout(() => {
-		void tickAndReschedule(generation);
-	}, currentSweepIntervalMs());
-	timer.unref?.();
+	deferredSchedule = { generation, deadline };
 }
 
-async function tickAndReschedule(generation: number): Promise<void> {
-	await runTick();
-	// A stop (and possible re-register) happened during the tick: a newer cycle owns the timer now.
-	if (generation !== timerGeneration) return;
-	scheduleNextSweep();
+async function handleTimerCallback(owner: ScheduleOwner, deadline: number): Promise<void> {
+	if (pendingOwner?.generation !== owner.generation || pendingOwner.token !== owner.token) return;
+	pendingTimer = null;
+	pendingDeadline = null;
+	pendingOwner = null;
+	if (inProgressOwner) {
+		deferSchedule(owner.generation, deadline);
+		return;
+	}
+	await runTick(owner.generation, "timer");
+}
+
+function reconcileCurrentSchedule(): void {
+	if (stopped || activeSessions.size === 0 || inProgressOwner) return;
+	const normalDeadline = schedulerNow() + currentSweepIntervalMs();
+	const deferredDeadline = deferredSchedule?.generation === timerGeneration ? deferredSchedule.deadline : null;
+	if (deferredDeadline !== null) deferredSchedule = null;
+	requestSchedule(deferredDeadline === null ? normalDeadline : Math.min(deferredDeadline, normalDeadline));
 }
 
 function stopTimer(): void {
 	stopped = true;
 	timerGeneration++;
-	if (timer) {
-		clearTimeout(timer);
-		timer = null;
-	}
+	clearPendingSchedule();
+	deferredSchedule = null;
 }
 
-async function runTick(): Promise<void> {
-	if (inProgress) return;
-	inProgress = true;
+async function runTick(generation = timerGeneration, source: WorkOwner["source"] = "external"): Promise<void> {
+	if (inProgressOwner || activeSessions.size === 0) return;
+	const owner: WorkOwner = { generation, source };
+	inProgressOwner = owner;
 	try {
 		await sweepOnce(deps);
 	} catch (err) {
 		logger.debug("resource GC sweep failed", { error: (err as Error).message });
 	} finally {
-		inProgress = false;
+		if (inProgressOwner === owner) inProgressOwner = null;
+		// A stale completion only releases its own work lock. Once that lock is released, current
+		// generation demand (which may have deferred behind it) can be reconciled independently.
+		reconcileCurrentSchedule();
 	}
 }
 
@@ -268,8 +326,19 @@ export function __setResourceGcDepsForTest(overrides: Partial<ResourceGcDeps>): 
 	deps = { ...defaultDeps, ...overrides };
 }
 
+export function __setResourceGcSchedulerNowForTest(now: () => number): void {
+	schedulerNow = now;
+}
+
 export async function __runResourceGcTickForTest(): Promise<void> {
 	await runTick();
+}
+
+export async function __runResourceGcTimerCallbackForTest(
+	owner: { generation: number; token: number },
+	deadline: number,
+): Promise<void> {
+	await handleTimerCallback(owner, deadline);
 }
 
 export function __getResourceGcStateForTest(): {
@@ -277,15 +346,35 @@ export function __getResourceGcStateForTest(): {
 	sessionCount: number;
 	rssWarningActive: boolean;
 	inProgress: boolean;
+	generation: number;
+	pendingDeadline: number | null;
+	pendingOwner: { generation: number; token: number } | null;
+	deferredDeadline: number | null;
+	deferredGeneration: number | null;
+	activeGeneration: number | null;
 } {
-	return { timerActive: timer !== null, sessionCount: activeSessions.size, rssWarningActive, inProgress };
+	return {
+		timerActive: pendingTimer !== null,
+		sessionCount: activeSessions.size,
+		rssWarningActive,
+		inProgress: inProgressOwner !== null,
+		generation: timerGeneration,
+		pendingDeadline,
+		pendingOwner: pendingOwner ? { ...pendingOwner } : null,
+		deferredDeadline: deferredSchedule?.deadline ?? null,
+		deferredGeneration: deferredSchedule?.generation ?? null,
+		activeGeneration: inProgressOwner?.generation ?? null,
+	};
 }
 
 export function __resetResourceGcForTest(): void {
 	stopTimer();
 	activeSessions.clear();
-	inProgress = false;
+	inProgressOwner = null;
+	deferredSchedule = null;
 	rssWarningActive = false;
 	lastScreenshotScanAt = 0;
+	nextTimerToken = 0;
+	schedulerNow = (): number => performance.now();
 	deps = defaultDeps;
 }

--- a/packages/coding-agent/test/tools/resource-gc.test.ts
+++ b/packages/coding-agent/test/tools/resource-gc.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -10,7 +10,9 @@ import {
 	__getResourceGcStateForTest,
 	__resetResourceGcForTest,
 	__runResourceGcTickForTest,
+	__runResourceGcTimerCallbackForTest,
 	__setResourceGcDepsForTest,
+	__setResourceGcSchedulerNowForTest,
 	type ResourceGcDeps,
 	registerResourceGcSession,
 	resolveBrowserGcPolicy,
@@ -45,6 +47,65 @@ function baseDeps(over: Partial<ResourceGcDeps> = {}): ResourceGcDeps {
 		cleanupScreenshots: vi.fn(async () => ({ scanned: 0, removed: 0 })),
 		screenshotArmed: () => false,
 		...over,
+	};
+}
+
+function gcSettings(interval: number): Settings {
+	return Settings.isolated({
+		"resourceGc.sweepIntervalMs": interval,
+		"browser.gc.enabled": true,
+		"browser.gc.idleMs": 1,
+		"browser.gc.rssLimitMb": 1_000_000,
+		"computer.screenshotGc.enabled": false,
+	});
+}
+async function flushMicrotasks(turns = 6): Promise<void> {
+	for (let turn = 0; turn < turns; turn += 1) {
+		await Promise.resolve();
+	}
+}
+function controlledScheduler(): { advance: (ms: number) => Promise<void> } {
+	let now = 1000;
+	vi.useFakeTimers({ now });
+	__setResourceGcSchedulerNowForTest(() => now);
+	return {
+		advance: async (ms: number) => {
+			now += ms;
+			vi.advanceTimersByTime(ms);
+			await flushMicrotasks();
+			expect(vi.getTimerCount()).toBeLessThanOrEqual(1);
+		},
+	};
+}
+
+function expectSchedulerStopped(): void {
+	expect(__getResourceGcStateForTest()).toMatchObject({
+		sessionCount: 0,
+		timerActive: false,
+		pendingDeadline: null,
+		pendingOwner: null,
+		deferredDeadline: null,
+		deferredGeneration: null,
+		activeGeneration: null,
+		inProgress: false,
+	});
+	expect(vi.getTimerCount()).toBe(0);
+}
+
+function controlledReleases(): { releaseTab: Mock<ResourceGcDeps["releaseTab"]>; resolve: (call: number) => void } {
+	const resolvers: Array<() => void> = [];
+	const releaseTab = vi.fn(() => {
+		const { promise, resolve } = Promise.withResolvers<boolean>();
+		resolvers.push(() => resolve(true));
+		return promise;
+	});
+	return {
+		releaseTab,
+		resolve: call => {
+			const resolve = resolvers[call];
+			expect(resolve).toBeDefined();
+			resolve?.();
+		},
 	};
 }
 
@@ -288,6 +349,372 @@ describe("resource GC controller", () => {
 			scanIntervalMs: 1_800_000,
 		});
 		expect(resolveSweepIntervalMs(settings)).toBe(30_000);
+	});
+});
+
+describe("resource GC monotonic scheduler", () => {
+	afterEach(() => {
+		__resetResourceGcForTest();
+		expectSchedulerStopped();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("A: rearms only for an earlier distinct registration", async () => {
+		const clock = controlledScheduler();
+		const sweepStarts = vi.fn();
+		const sweepCompletions = vi.fn();
+		const releaseTab = vi.fn(async () => {
+			sweepStarts();
+			sweepCompletions();
+			return true;
+		});
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			releaseTab,
+			listTabs: () => [snapshot("short", "short", NOW - 5000)],
+		});
+		const unregisterLong = registerResourceGcSession({ sessionId: "long", settings: gcSettings(1000) });
+		await clock.advance(100);
+		const unregisterShort = registerResourceGcSession({ sessionId: "short", settings: gcSettings(100) });
+		expect(__getResourceGcStateForTest()).toMatchObject({ pendingDeadline: 1200, timerActive: true });
+		expect(vi.getTimerCount()).toBe(1);
+		await clock.advance(99);
+		expect(sweepStarts).toHaveBeenCalledTimes(0);
+		expect(sweepCompletions).toHaveBeenCalledTimes(0);
+		await clock.advance(1);
+		expect(sweepStarts).toHaveBeenCalledTimes(1);
+		expect(sweepCompletions).toHaveBeenCalledTimes(1);
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			pendingDeadline: 1300,
+			timerActive: true,
+			inProgress: false,
+		});
+		unregisterShort();
+		unregisterLong();
+		expectSchedulerStopped();
+	});
+
+	it("keeps unsupported duplicate session IDs from advancing the pending deadline", async () => {
+		const clock = controlledScheduler();
+		const unregisterOriginal = registerResourceGcSession({ sessionId: "same", settings: gcSettings(1000) });
+		const originalState = __getResourceGcStateForTest();
+		await clock.advance(100);
+		const unregisterReplacement = registerResourceGcSession({ sessionId: "same", settings: gcSettings(100) });
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			pendingDeadline: 2000,
+			pendingOwner: originalState.pendingOwner,
+			sessionCount: 1,
+		});
+		expect(vi.getTimerCount()).toBe(1);
+		unregisterReplacement();
+		unregisterOriginal();
+		expectSchedulerStopped();
+	});
+
+	it("B: equal and later registrations preserve the existing timer", async () => {
+		const clock = controlledScheduler();
+		const releaseTab = vi.fn(async () => true);
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			releaseTab,
+			listTabs: () => [snapshot("fast", "fast", NOW - 5000)],
+		});
+		const unregisterFast = registerResourceGcSession({ sessionId: "fast", settings: gcSettings(100) });
+		const owner = __getResourceGcStateForTest().pendingOwner;
+		await clock.advance(20);
+		const unregisterEqual = registerResourceGcSession({ sessionId: "equal", settings: gcSettings(100) });
+		await clock.advance(10);
+		const unregisterSlow = registerResourceGcSession({ sessionId: "slow", settings: gcSettings(500) });
+		expect(__getResourceGcStateForTest()).toMatchObject({ pendingDeadline: 1100, pendingOwner: owner });
+		expect(vi.getTimerCount()).toBe(1);
+		await clock.advance(70);
+		expect(releaseTab).toHaveBeenCalledTimes(1);
+		expect(__getResourceGcStateForTest().pendingDeadline).toBe(1200);
+		unregisterSlow();
+		unregisterEqual();
+		unregisterFast();
+		expectSchedulerStopped();
+	});
+
+	it("C: unregistering the shortest session never postpones pending work", async () => {
+		const clock = controlledScheduler();
+		const releaseTab = vi.fn(async () => true);
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			releaseTab,
+			listTabs: () => [snapshot("slow", "slow", NOW - 5000)],
+		});
+		const unregisterFast = registerResourceGcSession({ sessionId: "fast", settings: gcSettings(100) });
+		const unregisterSlow = registerResourceGcSession({ sessionId: "slow", settings: gcSettings(1000) });
+		await clock.advance(50);
+		unregisterFast();
+		expect(__getResourceGcStateForTest().pendingDeadline).toBe(1100);
+		await clock.advance(50);
+		expect(releaseTab).toHaveBeenCalledTimes(1);
+		expect(__getResourceGcStateForTest().pendingDeadline).toBe(2100);
+		unregisterSlow();
+		expectSchedulerStopped();
+	});
+
+	it("D: retains an expired deferred deadline from timer-owned blocked work", async () => {
+		const clock = controlledScheduler();
+		const controlled = controlledReleases();
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			releaseTab: controlled.releaseTab,
+			listTabs: () => [snapshot("a", "a", NOW - 5000)],
+		});
+		const unregisterA = registerResourceGcSession({ sessionId: "a", settings: gcSettings(100) });
+		await clock.advance(100);
+		expect(controlled.releaseTab).toHaveBeenCalledTimes(1);
+		await clock.advance(20);
+		const unregisterB = registerResourceGcSession({ sessionId: "b", settings: gcSettings(25) });
+		await clock.advance(80);
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			deferredDeadline: 1145,
+			timerActive: false,
+			inProgress: true,
+		});
+		expect(vi.getTimerCount()).toBe(0);
+		controlled.resolve(0);
+		await flushMicrotasks();
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			pendingDeadline: 1145,
+			deferredDeadline: null,
+			inProgress: false,
+		});
+		expect(vi.getTimerCount()).toBe(1);
+		await clock.advance(0);
+		expect(controlled.releaseTab).toHaveBeenCalledTimes(2);
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			inProgress: true,
+			timerActive: false,
+			deferredDeadline: null,
+		});
+		expect(vi.getTimerCount()).toBe(0);
+		controlled.resolve(1);
+		await flushMicrotasks();
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			inProgress: false,
+			deferredDeadline: null,
+			pendingDeadline: 1225,
+		});
+		unregisterB();
+		unregisterA();
+		expectSchedulerStopped();
+	});
+
+	it("E: defers a consumed timer while externally initiated work owns the lock", async () => {
+		const clock = controlledScheduler();
+		const controlled = controlledReleases();
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			releaseTab: controlled.releaseTab,
+			listTabs: () => [snapshot("a", "a", NOW - 5000)],
+		});
+		const unregister = registerResourceGcSession({ sessionId: "a", settings: gcSettings(100) });
+		await clock.advance(50);
+		const external = __runResourceGcTickForTest();
+		await flushMicrotasks();
+		expect(controlled.releaseTab).toHaveBeenCalledTimes(1);
+		await clock.advance(50);
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			deferredDeadline: 1100,
+			timerActive: false,
+			inProgress: true,
+		});
+		expect(vi.getTimerCount()).toBe(0);
+		await clock.advance(100);
+		controlled.resolve(0);
+		await external;
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			pendingDeadline: 1100,
+			deferredDeadline: null,
+			inProgress: false,
+		});
+		await clock.advance(0);
+		expect(controlled.releaseTab).toHaveBeenCalledTimes(2);
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			inProgress: true,
+			timerActive: false,
+			deferredDeadline: null,
+		});
+		expect(vi.getTimerCount()).toBe(0);
+		controlled.resolve(1);
+		await flushMicrotasks();
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			inProgress: false,
+			deferredDeadline: null,
+			pendingDeadline: 1300,
+		});
+		unregister();
+		expectSchedulerStopped();
+	});
+
+	it("F: preserves a short registration deadline during external work", async () => {
+		const clock = controlledScheduler();
+		const controlled = controlledReleases();
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			releaseTab: controlled.releaseTab,
+			listTabs: () => [snapshot("long", "long", NOW - 5000)],
+		});
+		const unregisterLong = registerResourceGcSession({ sessionId: "long", settings: gcSettings(1000) });
+		await clock.advance(50);
+		const external = __runResourceGcTickForTest();
+		await flushMicrotasks();
+		expect(controlled.releaseTab).toHaveBeenCalledTimes(1);
+		await clock.advance(50);
+		const unregisterShort = registerResourceGcSession({ sessionId: "short", settings: gcSettings(100) });
+		expect(__getResourceGcStateForTest().pendingDeadline).toBe(1200);
+		await clock.advance(100);
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			deferredDeadline: 1200,
+			timerActive: false,
+			inProgress: true,
+		});
+		await clock.advance(100);
+		controlled.resolve(0);
+		await external;
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			pendingDeadline: 1200,
+			deferredDeadline: null,
+			inProgress: false,
+		});
+		await clock.advance(0);
+		expect(controlled.releaseTab).toHaveBeenCalledTimes(2);
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			inProgress: true,
+			timerActive: false,
+			deferredDeadline: null,
+		});
+		expect(vi.getTimerCount()).toBe(0);
+		controlled.resolve(1);
+		await flushMicrotasks();
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			inProgress: false,
+			deferredDeadline: null,
+			pendingDeadline: 1400,
+		});
+		unregisterShort();
+		unregisterLong();
+		expectSchedulerStopped();
+	});
+
+	it("G: fences stale completion after stop and re-registration", async () => {
+		const clock = controlledScheduler();
+		const controlled = controlledReleases();
+		let ownerId = "old";
+		__setResourceGcDepsForTest({
+			now: () => NOW,
+			releaseTab: controlled.releaseTab,
+			listTabs: () => [snapshot(ownerId, ownerId, NOW - 5000)],
+		});
+		const unregisterOld = registerResourceGcSession({ sessionId: "old", settings: gcSettings(100) });
+		await clock.advance(50);
+		const oldWork = __runResourceGcTickForTest();
+		await flushMicrotasks();
+		expect(controlled.releaseTab).toHaveBeenCalledTimes(1);
+		const oldGeneration = __getResourceGcStateForTest().generation;
+		expect(__getResourceGcStateForTest().activeGeneration).toBe(oldGeneration);
+		unregisterOld();
+		const newGeneration = __getResourceGcStateForTest().generation;
+		expect(newGeneration).toBe(oldGeneration + 1);
+		expect(__getResourceGcStateForTest().activeGeneration).toBe(oldGeneration);
+		await clock.advance(20);
+		ownerId = "new";
+		const unregisterNew = registerResourceGcSession({ sessionId: "new", settings: gcSettings(200) });
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			generation: newGeneration,
+			pendingDeadline: 1270,
+			pendingOwner: expect.objectContaining({ generation: newGeneration }),
+		});
+		await clock.advance(200);
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			deferredDeadline: 1270,
+			deferredGeneration: newGeneration,
+			timerActive: false,
+			inProgress: true,
+		});
+		expect(vi.getTimerCount()).toBe(0);
+		await clock.advance(30);
+		controlled.resolve(0);
+		await oldWork;
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			pendingDeadline: 1270,
+			pendingOwner: expect.objectContaining({ generation: newGeneration }),
+			activeGeneration: null,
+			deferredDeadline: null,
+		});
+		await clock.advance(0);
+		expect(controlled.releaseTab).toHaveBeenCalledTimes(2);
+		expect(controlled.releaseTab.mock.calls.map(call => call[0])).toEqual(["old", "new"]);
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			activeGeneration: newGeneration,
+			inProgress: true,
+			timerActive: false,
+			deferredDeadline: null,
+		});
+		expect(vi.getTimerCount()).toBe(0);
+		controlled.resolve(1);
+		await flushMicrotasks();
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			activeGeneration: null,
+			inProgress: false,
+			deferredDeadline: null,
+			pendingDeadline: 1500,
+		});
+		unregisterNew();
+		expectSchedulerStopped();
+	});
+
+	it("H: ignores a queued callback from a superseded same-generation timer", async () => {
+		const clock = controlledScheduler();
+		const releaseTab = vi.fn(async () => true);
+		const sweepStarts = vi.fn(() => [snapshot("short", "short", NOW - 5000)]);
+		__setResourceGcDepsForTest({ now: () => NOW, releaseTab, listTabs: sweepStarts });
+		const unregisterLong = registerResourceGcSession({ sessionId: "long", settings: gcSettings(1000) });
+		const staleOwner = __getResourceGcStateForTest().pendingOwner;
+		await clock.advance(100);
+		const unregisterShort = registerResourceGcSession({ sessionId: "short", settings: gcSettings(100) });
+		const replacement = __getResourceGcStateForTest();
+		expect(staleOwner).not.toBeNull();
+		await __runResourceGcTimerCallbackForTest(staleOwner!, 2000);
+		await flushMicrotasks();
+		expect(releaseTab).not.toHaveBeenCalled();
+		expect(sweepStarts).not.toHaveBeenCalled();
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			pendingDeadline: 1200,
+			pendingOwner: replacement.pendingOwner,
+			deferredDeadline: null,
+		});
+		expect(vi.getTimerCount()).toBe(1);
+		unregisterShort();
+		unregisterLong();
+		expectSchedulerStopped();
+	});
+
+	it("keeps scheduler time separate from eligibility time and resets all scheduler state", async () => {
+		const clock = controlledScheduler();
+		const releaseTab = vi.fn(async () => true);
+		__setResourceGcDepsForTest({
+			now: () => NOW - 10_000,
+			releaseTab,
+			listTabs: () => [snapshot("a", "a", NOW - 5000)],
+		});
+		const unregister = registerResourceGcSession({ sessionId: "a", settings: gcSettings(100) });
+		await clock.advance(100);
+		expect(releaseTab).not.toHaveBeenCalled();
+		unregister();
+		__resetResourceGcForTest();
+		expect(__getResourceGcStateForTest()).toMatchObject({
+			sessionCount: 0,
+			timerActive: false,
+			pendingDeadline: null,
+			deferredDeadline: null,
+			activeGeneration: null,
+		});
 	});
 });
 


### PR DESCRIPTION
## What
- rearm the shared resource-GC timeout when a newly registered distinct session has an earlier monotonic deadline
- preserve earlier pending work for equal/later policies, unregisters, and the unsupported duplicate-ID edge
- fence blocked, stale-generation, and stale-token callbacks while keeping exactly one non-overlapping recursive timeout
- add deterministic A-H scheduler race coverage plus duplicate-ID no-rearm coverage and one current Unreleased changelog bullet

## Why
This is the owner-directed clean replacement for closed PR #2594. It credits and supersedes #2594 while salvaging only its valuable product behavior and regression intent onto current `dev`; stale commits and conflicting changelog metadata were not merged or cherry-picked.

Original contributor/source: #2594 by `datell1357`, source head `720cba232c5d2424336bc9c0a17b9ec4e40d561f`.

## Exact candidate
- head: `a414d9a44d21f8f0b2d1b55bd82a608ceeba2758`
- reviewed base/direct parent: `48e3ecd9705af5f930a393c14177082a233dbb6a`
- tree: `e22daf0b17a744f85148318cd3ac9a19ba3119ee`
- target: `dev`

## Testing
- `bun test packages/coding-agent/test/tools/resource-gc.test.ts packages/coding-agent/test/tools/resource-gc-redteam.test.ts` — 28 pass, 0 fail, 176 assertions
- `bun --cwd=packages/coding-agent run check` — pass (Biome + types)
- `bun run check:tools` — pass
- AI slop cleanup gate — PASS, zero blockers
- hostile Architect/Product/Code/Security review — scheduler/security model accepted; final exact-head/current-base binding required before merge
- hostile executor QA/red-team — A-H, duplicate-ID, owner safety, and integration reviewed

## Scope and safety
- exactly three product files changed
- no settings/schema, lifecycle, ownership, collector eligibility, release, publish, tag, or `main` changes
- trusted positive tiny intervals remain the explicitly accepted residual process-local cadence risk

Supersedes #2594.