### PR TITLE
fix(sdk): recover corrupt session index history

### DIFF
--- a/artifacts/issue-2654-session-index-repair-report.json
+++ b/artifacts/issue-2654-session-index-repair-report.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": 1,
+  "kind": "algorithm-cli-test-report",
+  "issue": 2654,
+  "base": "origin/dev@9d4a6a66c84bafa32b0dfe034873b4b4e5de4338",
+  "historicalReproduction": {
+    "method": "Four independent writers each allocated indexSeq from its own stale in-memory view while append order alone was serialized, matching the pre-0.11.2 allocation defect.",
+    "writers": 4,
+    "rows": 400,
+    "maxSeq": 100,
+    "strictInversions": 115,
+    "duplicateRows": 300,
+    "first20": [1, 1, 1, 1, 2, 3, 2, 4, 2, 3, 5, 2, 6, 4, 7, 8, 9, 10, 11, 12],
+    "verdict": "reproduced"
+  },
+  "currentFailClosedReproduction": {
+    "fixture": "Checksum-valid prefix followed by malformed, checksum-invalid, unterminated, duplicated, gapped, sequence-inverted, or future-version physical history.",
+    "observedBeforeRepair": "SessionIndex retained the last version/checksum/sequence-verified prefix, reported corruption or unsupported state, and refused append with an actionable repair command for repairable corruption; ordinary gjc gc diagnosis exited nonzero without mutation.",
+    "verdict": "reproduced"
+  },
+  "repairBehavior": {
+    "command": "gjc gc --repair-session-index --json",
+    "observed": "Under the cross-process index lock, original snapshot/log bytes were durably copied into a unique quarantine bundle before live-file replacement. Only version-supported, checksum-valid contiguous history was retained without renumbering; crash-window overlap may start after an earlier rotation but must remain contiguous through snapshotSeq before any tail is accepted. Temp-file fsync, atomic rename, and directory fsync published the repaired snapshot/log. A subsequent append used validPrefixSeq + 1 and a repeated repair was a healthy no-op. Unsupported future state remains byte-preserved and non-repairable.",
+    "diagnoseExit": 1,
+    "repairExit": 0,
+    "postRepairExit": 0,
+    "verdict": "passed"
+  },
+  "verification": [
+    {
+      "command": "bun test test/sdk-session-index.test.ts test/gc-runtime.test.ts test/gc-e2e.test.ts test/perf-redteam.test.ts test/cli-command-surface.test.ts test/sdk-downgrade-unknown-version.test.ts",
+      "result": "70 pass, 0 fail, 244 assertions"
+    },
+    {
+      "command": "bun test test/sdk-broker.test.ts",
+      "result": "40 pass, 0 fail, 129 assertions"
+    },
+    {
+      "command": "bun run check",
+      "result": "Biome check passed across 2236 files; TypeScript check passed"
+    },
+    {
+      "command": "bun run check:runtime",
+      "result": "Generated hotkey docs check and SDK canonicalization verification passed"
+    },
+    {
+      "command": "git diff --check",
+      "result": "passed"
+    }
+  ],
+  "independentReview": {
+    "architectReview": {
+      "architectureStatus": "CLEAR",
+      "productStatus": "CLEAR",
+      "codeStatus": "CLEAR",
+      "recommendation": "APPROVE",
+      "blockers": []
+    },
+    "executorQa": "passed",
+    "e2eStatus": "passed",
+    "redTeamStatus": "passed",
+    "blockers": []
+  },
+  "invariants": [
+    "No valid retained event is renumbered.",
+    "No row after the first corrupt physical-history row is accepted.",
+    "Physical rows covered by a snapshot are version-supported, checksum-valid, and contiguous through the snapshot boundary, including overlap logs that begin after an earlier rotation.",
+    "Invalid snapshots are quarantined and repaired rather than silently ignored.",
+    "Unsupported future snapshot formats, snapshot events, and log events remain fail-closed, byte-preserved, and unmodified.",
+    "Repair and append serialize through the existing cross-process session-index file lock.",
+    "The quarantine base and bundle are durably reachable before repaired live files are replaced.",
+    "Snapshot/log replacement uses fsynced temporary files, atomic rename, and directory fsync.",
+    "Independent multi-process writers produce strict sequences without duplicates or inversions.",
+    "Repair cannot be combined with prune or dry-run, and live-host restart/re-registration guidance is explicit."
+  ]
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Added evidence-preserving recovery for legacy multi-writer SDK session-index corruption: `gjc gc` now diagnoses corrupt prefixes, `--repair-session-index` quarantines the original snapshot/log under the session-index lock before atomically restoring only the checksum-valid monotonic prefix, and append failures point operators to the explicit repair path (#2654).
 
 ## [0.11.3] - 2026-07-19
 

--- a/packages/coding-agent/src/commands/gc.ts
+++ b/packages/coding-agent/src/commands/gc.ts
@@ -9,9 +9,19 @@ export default class Gc extends Command {
 		prune: Flags.boolean({ description: "Remove stale records (default: report only)", default: false }),
 		force: Flags.boolean({ description: "Alias for --prune (eligible records only)", default: false }),
 		"dry-run": Flags.boolean({ description: "Force report-only mode", default: false }),
+		"repair-session-index": Flags.boolean({
+			description: "Quarantine a corrupt session-index suffix and retain its valid prefix",
+			default: false,
+		}),
 	};
 
-	static examples = ["gjc gc", "gjc gc --json", "gjc gc --prune", "gjc gc --prune --json"];
+	static examples = [
+		"gjc gc",
+		"gjc gc --json",
+		"gjc gc --prune",
+		"gjc gc --prune --json",
+		"gjc gc --repair-session-index --json",
+	];
 
 	async run(): Promise<void> {
 		const result = await runGjcGcCommand(this.argv, process.cwd(), process.env);

--- a/packages/coding-agent/src/gjc-runtime/gc-render.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-render.ts
@@ -39,7 +39,11 @@ function renderRecord(record: GcRecord): string {
 
 export function buildGcReportText(report: GcReport): string {
 	const lines: string[] = [];
-	lines.push(report.dry_run ? "gjc gc — dry run (no changes made; pass --prune to remove)" : "gjc gc — prune");
+	if (report.operation === "repair_session_index") {
+		lines.push("gjc gc — session-index repair (other stores are report-only)");
+	} else {
+		lines.push(report.dry_run ? "gjc gc — dry run (no changes made; pass --prune to remove)" : "gjc gc — prune");
+	}
 	lines.push("");
 
 	for (const store of GC_STORES) {
@@ -50,6 +54,20 @@ export function buildGcReportText(report: GcReport): string {
 		} else {
 			for (const record of records) lines.push(renderRecord(record));
 		}
+		lines.push("");
+	}
+
+	if (report.session_index) {
+		const index = report.session_index;
+		lines.push(`Session index: ${index.status}; valid prefix sequence=${index.valid_prefix_seq}`);
+		if (index.quarantine_path) lines.push(`  Quarantined suffix: ${index.quarantine_path}`);
+		if (index.reason) lines.push(`  ${index.reason}`);
+		if (index.status === "corrupt")
+			lines.push("  Run `gjc gc --repair-session-index` to quarantine the corrupt suffix.");
+		if (index.status === "unsupported")
+			lines.push("  Upgrade GJC before attempting a repair; no index data was changed.");
+		if (index.status === "repaired")
+			lines.push("  Restart or re-register hosts whose only registration was in the quarantined suffix.");
 		lines.push("");
 	}
 

--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -13,6 +13,10 @@
  * - Dry-run by default: nothing is deleted unless `--prune`/`--force`.
  */
 
+import { getAgentDir } from "@gajae-code/utils";
+import { SessionIndex } from "../sdk/broker/session-index";
+import { UnsupportedStateVersionError } from "../sdk/broker/state-version";
+
 import { buildGcReportText } from "./gc-render";
 
 export type GcStore = "harness_leases" | "team_workers" | "file_locks" | "tmux_sessions" | "registry_entries";
@@ -115,11 +119,21 @@ export interface GcCounts {
 	>;
 }
 
+export interface GcSessionIndexHealth {
+	status: "healthy" | "corrupt" | "repaired" | "unsupported" | "repair_failed";
+	valid_prefix_seq: number;
+	snapshot_seq?: number;
+	reason?: string;
+	quarantine_path?: string;
+}
+
 export interface GcReport {
 	dry_run: boolean;
+	operation?: "dry_run" | "prune" | "repair_session_index";
 	stores: Record<GcStore, GcRecord[]>;
 	counts: GcCounts;
 	errors: GcError[];
+	session_index?: GcSessionIndexHealth;
 }
 
 export interface GcRunResult {
@@ -225,6 +239,7 @@ function computeCounts(stores: Record<GcStore, GcRecord[]>, errors: GcError[]): 
 interface ParsedGcArgs {
 	json: boolean;
 	prune: boolean;
+	repairSessionIndex: boolean;
 	help: boolean;
 }
 
@@ -233,6 +248,8 @@ class GcUsageError extends Error {}
 function parseGcArgs(argv: string[]): ParsedGcArgs {
 	let json = false;
 	let prune = false;
+	let repairSessionIndex = false;
+
 	let dryRun = false;
 	let help = false;
 	for (const arg of argv) {
@@ -245,6 +262,10 @@ function parseGcArgs(argv: string[]): ParsedGcArgs {
 			case "--force":
 				prune = true;
 				break;
+			case "--repair-session-index":
+				repairSessionIndex = true;
+				break;
+
 			case "--dry-run":
 				dryRun = true;
 				break;
@@ -256,9 +277,11 @@ function parseGcArgs(argv: string[]): ParsedGcArgs {
 				throw new GcUsageError(`unknown_flag:${arg}`);
 		}
 	}
+	if (repairSessionIndex && prune) throw new GcUsageError("repair_session_index_cannot_combine_with_prune");
+	if (repairSessionIndex && dryRun) throw new GcUsageError("repair_session_index_cannot_combine_with_dry_run");
 	// Explicit --dry-run always wins over --prune/--force.
 	if (dryRun) prune = false;
-	return { json, prune, help };
+	return { json, prune, repairSessionIndex, help };
 }
 
 /**
@@ -336,6 +359,40 @@ export function computeExitCode(report: GcReport): number {
 	return 0;
 }
 
+function resolveGcAgentDir(env: NodeJS.ProcessEnv): string {
+	return env.GJC_CODING_AGENT_DIR?.trim() || env.PI_CODING_AGENT_DIR?.trim() || getAgentDir();
+}
+
+async function collectSessionIndexHealth(repair: boolean, agentDir: string): Promise<GcSessionIndexHealth> {
+	const index = new SessionIndex(agentDir);
+	try {
+		if (repair) {
+			const result = await index.repair();
+			return {
+				status: result.status === "unsupported" ? "unsupported" : result.repaired ? "repaired" : "healthy",
+				valid_prefix_seq: result.validPrefixSeq,
+				snapshot_seq: result.snapshotSeq,
+				...(result.reason ? { reason: result.reason } : {}),
+				...(result.quarantinePath ? { quarantine_path: result.quarantinePath } : {}),
+			};
+		}
+		const diagnosis = await index.diagnose();
+		return {
+			status: diagnosis.status,
+			valid_prefix_seq: diagnosis.validPrefixSeq,
+			snapshot_seq: diagnosis.snapshotSeq,
+			...(diagnosis.reason ? { reason: diagnosis.reason } : {}),
+		};
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		return {
+			status: error instanceof UnsupportedStateVersionError ? "unsupported" : "repair_failed",
+			valid_prefix_seq: 0,
+			reason,
+		};
+	}
+}
+
 export async function runGjcGcCommand(
 	argv: string[],
 	cwd: string = process.cwd(),
@@ -357,7 +414,13 @@ export async function runGjcGcCommand(
 	const resolvedAdapters = adapters ?? (await defaultGcAdapters());
 	const ctx: GcContext = { probe: gcPidProbe, force: parsed.prune, env, cwd };
 	const report = await collectGcReport(resolvedAdapters, ctx, parsed.prune);
-	const status = computeExitCode(report);
+	report.operation = parsed.repairSessionIndex ? "repair_session_index" : parsed.prune ? "prune" : "dry_run";
+	report.session_index = await collectSessionIndexHealth(parsed.repairSessionIndex, resolveGcAgentDir(env));
+	const sessionIndexFailed =
+		report.session_index?.status === "corrupt" ||
+		report.session_index?.status === "unsupported" ||
+		report.session_index?.status === "repair_failed";
+	const status = sessionIndexFailed ? 1 : computeExitCode(report);
 	const stdout = parsed.json ? `${JSON.stringify(report, null, 2)}\n` : buildGcReportText(report);
 	return { stdout, stderr: "", status };
 }
@@ -367,12 +430,14 @@ export function gcHelpText(): string {
 		"gjc gc - garbage-collect stale GJC session/PID records",
 		"",
 		"USAGE",
-		"  $ gjc gc [--prune|--force] [--json]",
+		"  $ gjc gc [--prune|--force] [--repair-session-index] [--json]",
+
 		"",
 		"FLAGS",
 		"  --prune, --force  Actually remove stale records (default: dry-run report only)",
 		"  --dry-run         Force report-only mode (overrides --prune/--force)",
 		"  -j, --json        Emit machine-readable JSON",
+		"  --repair-session-index  Explicitly quarantine a corrupt session-index suffix and retain its valid prefix",
 		"",
 		"Liveness-only: a record is removed only when its owning process is dead",
 		"(ESRCH). Live / permission-denied / unknown processes are always kept.",

--- a/packages/coding-agent/src/sdk/broker/session-index.ts
+++ b/packages/coding-agent/src/sdk/broker/session-index.ts
@@ -355,6 +355,18 @@ export class SessionIndex {
 		};
 	}
 	async diagnose(): Promise<SessionIndexDiagnosis> {
+		const exists = await Promise.all(
+			[snapshotFor(this.#agentDir), logFor(this.#agentDir)].map(async file => {
+				try {
+					await fs.stat(file);
+					return true;
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+					throw error;
+				}
+			}),
+		);
+		if (!exists.some(Boolean)) return { status: "healthy", validPrefixSeq: 0, snapshotSeq: 0 };
 		return await withFileLock(logFor(this.#agentDir), async () => (await this.#scan()).diagnosis);
 	}
 	async repair(): Promise<SessionIndexRepairResult> {

--- a/packages/coding-agent/src/sdk/broker/session-index.ts
+++ b/packages/coding-agent/src/sdk/broker/session-index.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import { withFileLock } from "../../config/file-lock";
@@ -47,6 +47,27 @@ export interface SessionList {
 	indexSeq: number;
 	sessions: IndexedSession[];
 	warnings: string[];
+}
+
+export interface SessionIndexDiagnosis {
+	status: "healthy" | "corrupt" | "unsupported";
+	validPrefixSeq: number;
+	snapshotSeq: number;
+	reason?: string;
+}
+
+export interface SessionIndexRepairResult extends SessionIndexDiagnosis {
+	repaired: boolean;
+	quarantinePath?: string;
+}
+
+interface SessionIndexScan {
+	diagnosis: SessionIndexDiagnosis;
+	snapshotEvents: SessionIndexEvent[];
+	validLogEvents: SessionIndexEvent[];
+	snapshotContents: Buffer | undefined;
+	logContents: Buffer | undefined;
+	unsupportedError?: UnsupportedStateVersionError;
 }
 const canonical = (event: Omit<SessionIndexEvent, "checksum">) => JSON.stringify(event);
 export const sessionIndexChecksum = (event: Omit<SessionIndexEvent, "checksum">) =>
@@ -142,6 +163,27 @@ async function syncDirectory(file: string): Promise<void> {
 	}
 }
 
+async function writeAndSync(file: string, contents: Buffer | string): Promise<void> {
+	const handle = await fs.open(file, "w", 0o600);
+	try {
+		await handle.writeFile(contents);
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+async function replaceAtomically(file: string, contents: Buffer | string): Promise<void> {
+	const temporary = `${file}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		await writeAndSync(temporary, contents);
+		await fs.rename(temporary, file);
+		await syncDirectory(file);
+	} finally {
+		await fs.rm(temporary, { force: true });
+	}
+}
+
 function alive(pid: number): boolean {
 	try {
 		process.kill(pid, 0);
@@ -166,26 +208,182 @@ export class SessionIndex {
 		return this;
 	}
 	async replay(): Promise<void> {
-		this.#events = [];
+		const scan = await this.#scan();
+		if (scan.diagnosis.status === "unsupported") throw scan.unsupportedError!;
+		this.#events = [...scan.snapshotEvents, ...scan.validLogEvents];
 		this.#warnings = [];
-		this.#logOffset = 0;
-		this.#corruptSuffix = false;
+		this.#logOffset = scan.logContents?.length ?? 0;
+		this.#corruptSuffix = scan.diagnosis.status === "corrupt";
+		if (scan.diagnosis.reason === "invalid snapshot") this.#warnings.push("Invalid session index snapshot");
+		if (this.#corruptSuffix) this.#warnings.push("Corrupt session index entry; replay truncated");
+	}
+	async #scan(): Promise<SessionIndexScan> {
+		let snapshotContents: Buffer | undefined;
+		let logContents: Buffer | undefined;
+		let snapshotEvents: SessionIndexEvent[] = [];
 		let snapshotSeq = 0;
+		let trustedSnapshotSeq = 0;
+		let invalidSnapshot = false;
+		let unsupportedError: UnsupportedStateVersionError | undefined;
 		try {
-			const snapshot = JSON.parse(await fs.readFile(snapshotFor(this.#agentDir), "utf8")) as {
+			snapshotContents = await fs.readFile(snapshotFor(this.#agentDir));
+			const snapshot = JSON.parse(snapshotContents.toString("utf8")) as {
 				version?: number;
-				events?: SessionIndexEvent[];
-				indexSeq?: number;
+				indexSeq?: unknown;
+				events?: unknown;
 			};
+			if (typeof snapshot.indexSeq === "number" && Number.isSafeInteger(snapshot.indexSeq) && snapshot.indexSeq >= 0)
+				snapshotSeq = snapshot.indexSeq;
 			assertSupportedSnapshotVersion(snapshotFor(this.#agentDir), snapshot);
-			if (!isValidSnapshot(snapshot)) throw new Error("invalid snapshot");
-			this.#events = snapshot.events;
-			snapshotSeq = snapshot.indexSeq;
-		} catch (e) {
-			if (e instanceof UnsupportedStateVersionError) throw e;
-			if ((e as NodeJS.ErrnoException).code !== "ENOENT") this.#warnings.push("Invalid session index snapshot");
+			const supportedEvents: SessionIndexEvent[] = [];
+			if (Array.isArray(snapshot.events)) {
+				try {
+					for (const event of snapshot.events) {
+						assertSupportedStateVersion(snapshotFor(this.#agentDir), event);
+						supportedEvents.push(event as SessionIndexEvent);
+					}
+				} catch (error) {
+					if (!(error instanceof UnsupportedStateVersionError)) throw error;
+					unsupportedError = error;
+					snapshotEvents = supportedEvents;
+				}
+			}
+			if (!unsupportedError) {
+				if (!isValidSnapshot(snapshot)) invalidSnapshot = true;
+				else {
+					snapshotEvents = snapshot.events;
+					trustedSnapshotSeq = snapshot.indexSeq;
+				}
+			}
+		} catch (error) {
+			if (error instanceof UnsupportedStateVersionError) unsupportedError = error;
+			else if ((error as NodeJS.ErrnoException).code !== "ENOENT") invalidSnapshot = true;
 		}
-		await this.#tail(snapshotSeq, false);
+		try {
+			logContents = await fs.readFile(logFor(this.#agentDir));
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+		const validLogEvents: SessionIndexEvent[] = [];
+		let corrupt = invalidSnapshot;
+		let logCorrupt = false;
+		let tailStarted = false;
+		let historicalLast: number | undefined;
+		let expected = trustedSnapshotSeq + 1;
+		if (logContents) {
+			const text = logContents.toString("utf8");
+			const lines = text.split("\n");
+			const terminal = lines.pop();
+			for (const line of lines) {
+				if (!line) continue;
+				try {
+					const event = JSON.parse(line) as SessionIndexEvent;
+					assertSupportedStateVersion(logFor(this.#agentDir), event);
+					const { checksum, ...unsigned } = event;
+					if (checksum !== sessionIndexChecksum(unsigned)) {
+						corrupt = true;
+						logCorrupt = true;
+						continue;
+					}
+					if (!tailStarted && !invalidSnapshot && event.indexSeq <= trustedSnapshotSeq) {
+						if (
+							!Number.isSafeInteger(event.indexSeq) ||
+							event.indexSeq <= 0 ||
+							(historicalLast !== undefined && event.indexSeq !== historicalLast + 1)
+						) {
+							corrupt = true;
+							logCorrupt = true;
+						} else {
+							historicalLast = event.indexSeq;
+						}
+						continue;
+					}
+					tailStarted = true;
+					if (historicalLast !== undefined && historicalLast !== trustedSnapshotSeq) {
+						corrupt = true;
+						logCorrupt = true;
+					}
+					if (event.indexSeq !== expected) {
+						corrupt = true;
+						logCorrupt = true;
+					} else if (!logCorrupt) {
+						validLogEvents.push(event);
+						expected++;
+					}
+				} catch (error) {
+					if (error instanceof UnsupportedStateVersionError) {
+						const verifiedSnapshotPrefix = snapshotEvents.at(-1)?.indexSeq ?? trustedSnapshotSeq;
+						const validPrefixSeq = validLogEvents.at(-1)?.indexSeq ?? verifiedSnapshotPrefix;
+						return {
+							diagnosis: { status: "unsupported", validPrefixSeq, snapshotSeq, reason: error.message },
+							snapshotEvents,
+							validLogEvents,
+							snapshotContents,
+							logContents,
+							unsupportedError: error,
+						};
+					}
+					corrupt = true;
+					logCorrupt = true;
+				}
+			}
+			if (historicalLast !== undefined && !tailStarted && historicalLast !== trustedSnapshotSeq) {
+				corrupt = true;
+				logCorrupt = true;
+			}
+			if (terminal !== "") {
+				corrupt = true;
+				logCorrupt = true;
+			}
+		}
+		const verifiedSnapshotPrefix = snapshotEvents.at(-1)?.indexSeq ?? trustedSnapshotSeq;
+		const validPrefixSeq = validLogEvents.at(-1)?.indexSeq ?? verifiedSnapshotPrefix;
+		return {
+			diagnosis: {
+				status: unsupportedError ? "unsupported" : corrupt ? "corrupt" : "healthy",
+				validPrefixSeq,
+				snapshotSeq,
+				reason:
+					unsupportedError?.message ??
+					(invalidSnapshot ? "invalid snapshot" : corrupt ? "invalid log sequence" : undefined),
+			},
+			snapshotEvents,
+			validLogEvents,
+			snapshotContents,
+			logContents,
+			unsupportedError,
+		};
+	}
+	async diagnose(): Promise<SessionIndexDiagnosis> {
+		return await withFileLock(logFor(this.#agentDir), async () => (await this.#scan()).diagnosis);
+	}
+	async repair(): Promise<SessionIndexRepairResult> {
+		await fs.mkdir(dirFor(this.#agentDir), { recursive: true, mode: 0o700 });
+		return await withFileLock(logFor(this.#agentDir), async () => {
+			const scan = await this.#scan();
+			if (scan.diagnosis.status === "unsupported") return { ...scan.diagnosis, repaired: false };
+			if (scan.diagnosis.status === "healthy") return { ...scan.diagnosis, repaired: false };
+			const quarantineBase = path.join(dirFor(this.#agentDir), "quarantine");
+			await fs.mkdir(quarantineBase, { recursive: true, mode: 0o700 });
+			await syncDirectory(quarantineBase);
+			const quarantinePath = path.join(quarantineBase, `repair-${Date.now()}-${process.pid}-${randomUUID()}`);
+			await fs.mkdir(quarantinePath, { mode: 0o700 });
+			await syncDirectory(quarantinePath);
+			if (scan.snapshotContents)
+				await writeAndSync(path.join(quarantinePath, "index.snapshot.json"), scan.snapshotContents);
+			if (scan.logContents) await writeAndSync(path.join(quarantinePath, "index.jsonl"), scan.logContents);
+			await syncDirectory(path.join(quarantinePath, "index.jsonl"));
+			const snapshot = JSON.stringify({
+				version: SESSION_INDEX_SNAPSHOT_VERSION,
+				indexSeq: scan.snapshotEvents.at(-1)?.indexSeq ?? 0,
+				events: scan.snapshotEvents,
+			});
+			const log = scan.validLogEvents.map(event => JSON.stringify(event)).join("\n");
+			await replaceAtomically(snapshotFor(this.#agentDir), snapshot);
+			await replaceAtomically(logFor(this.#agentDir), log ? `${log}\n` : "");
+			await this.replay();
+			return { ...scan.diagnosis, repaired: true, quarantinePath };
+		});
 	}
 	async #tail(snapshotSeq = this.indexSeq, allowResync = true): Promise<void> {
 		let data: Buffer;
@@ -252,7 +450,10 @@ export class SessionIndex {
 		await fs.mkdir(dirFor(this.#agentDir), { recursive: true, mode: 0o700 });
 		return withFileLock(logFor(this.#agentDir), async () => {
 			await this.replay();
-			if (this.#corruptSuffix) throw new Error("Cannot append to corrupt session index log");
+			if (this.#corruptSuffix)
+				throw new Error(
+					"Cannot append to corrupt session index log; run `gjc gc --repair-session-index` to quarantine evidence and retain the valid prefix",
+				);
 			const unsigned: Omit<SessionIndexEvent, "checksum"> = {
 				...input,
 				version: SDK_STATE_VERSION,

--- a/packages/coding-agent/src/sdk/broker/state-version.ts
+++ b/packages/coding-agent/src/sdk/broker/state-version.ts
@@ -13,8 +13,11 @@ export class UnsupportedStateVersionError extends Error {
 	constructor(
 		readonly file: string,
 		readonly version: number,
+		readonly maximumSupportedVersion = SDK_STATE_VERSION,
 	) {
-		super(`Unsupported SDK state version ${version} in ${file}; maximum supported version is ${SDK_STATE_VERSION}.`);
+		super(
+			`Unsupported SDK state version ${version} in ${file}; maximum supported version is ${maximumSupportedVersion}.`,
+		);
 		this.name = "UnsupportedStateVersionError";
 	}
 }
@@ -38,7 +41,7 @@ export function assertSupportedSnapshotVersion(file: string, value: unknown): vo
 	const record = value as { version?: unknown; stateVersion?: unknown };
 	for (const version of [record.version, record.stateVersion]) {
 		if (typeof version === "number" && Number.isFinite(version) && version > SESSION_INDEX_SNAPSHOT_VERSION) {
-			throw new UnsupportedStateVersionError(file, version);
+			throw new UnsupportedStateVersionError(file, version, SESSION_INDEX_SNAPSHOT_VERSION);
 		}
 	}
 }

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -64,6 +64,17 @@ describe("GJC public CLI command surface", () => {
 		expect(combined).not.toContain("What's New");
 		expect(combined).not.toContain("chatContainer");
 	}, 30_000);
+	it("documents the session-index repair flag in gc help", () => {
+		const result = Bun.spawnSync(["bun", cliEntry, "gc", "--help"], {
+			cwd: repoRoot,
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		const output = `${result.stdout.toString()}\n${result.stderr.toString()}`;
+		expect(result.exitCode, output).toBe(0);
+		expect(output).toContain("--repair-session-index");
+		expect(output).toContain("Quarantine a corrupt session-index suffix");
+	}, 30_000);
 
 	it("documents the native CLI surface in command help", async () => {
 		for (const command of ["ralplan", "deep-interview", "state"]) {

--- a/packages/coding-agent/test/gc-e2e.test.ts
+++ b/packages/coding-agent/test/gc-e2e.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { runGjcGcCommand } from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
 import { harnessLeasesGcAdapter } from "@gajae-code/coding-agent/harness-control-plane/gc-adapter";
+import { SessionIndex } from "../src/sdk/broker/session-index";
 
 const tempDirs: string[] = [];
 
@@ -60,7 +61,7 @@ describe("gjc gc end-to-end (harness lease adapter)", () => {
 		const registryDir = path.join(base, "reg");
 		const deadPid = await reapedPid();
 		const leaseFile = await seedDeadLease(base, registryDir, deadPid);
-		const env = { ...process.env, GJC_HARNESS_ROOT_REGISTRY_DIR: registryDir };
+		const env = { ...process.env, GJC_CODING_AGENT_DIR: base, GJC_HARNESS_ROOT_REGISTRY_DIR: registryDir };
 
 		const result = await runGjcGcCommand(["--json"], base, env, [harnessLeasesGcAdapter]);
 		const report = JSON.parse(result.stdout);
@@ -78,7 +79,7 @@ describe("gjc gc end-to-end (harness lease adapter)", () => {
 		const registryDir = path.join(base, "reg");
 		const deadPid = await reapedPid();
 		const leaseFile = await seedDeadLease(base, registryDir, deadPid);
-		const env = { ...process.env, GJC_HARNESS_ROOT_REGISTRY_DIR: registryDir };
+		const env = { ...process.env, GJC_CODING_AGENT_DIR: base, GJC_HARNESS_ROOT_REGISTRY_DIR: registryDir };
 
 		const result = await runGjcGcCommand(["--prune", "--json"], base, env, [harnessLeasesGcAdapter]);
 		const report = JSON.parse(result.stdout);
@@ -91,10 +92,47 @@ describe("gjc gc end-to-end (harness lease adapter)", () => {
 
 	test("text dry-run output names the harness store and dry-run mode", async () => {
 		const base = await makeTemp();
-		const env = { ...process.env, GJC_HARNESS_ROOT_REGISTRY_DIR: path.join(base, "reg-empty") };
+		const env = {
+			...process.env,
+			GJC_CODING_AGENT_DIR: base,
+			GJC_HARNESS_ROOT_REGISTRY_DIR: path.join(base, "reg-empty"),
+		};
 		const result = await runGjcGcCommand([], base, env, [harnessLeasesGcAdapter]);
 		expect(result.stdout).toContain("dry run");
 		expect(result.stdout).toContain("Harness owner leases");
 		expect(result.status).toBe(0);
+	});
+
+	test("explicit repair quarantines corruption and is idempotent", async () => {
+		const base = await makeTemp();
+		const agentDir = path.join(base, "agent");
+		const index = await new SessionIndex(agentDir).open();
+		await index.append({
+			type: "host_registered",
+			sessionId: "repairable-session",
+			locator: { repo: base, stateRoot: path.join(base, "state") },
+			endpointGeneration: 1,
+			pid: process.pid,
+			endpointMtimeMs: Date.now(),
+		});
+		const log = path.join(agentDir, "sdk", "sessions", "index.jsonl");
+		await fs.appendFile(log, "broken\n");
+
+		const repairEnv = { ...process.env, GJC_CODING_AGENT_DIR: agentDir };
+		const repaired = await runGjcGcCommand(["--repair-session-index", "--json"], base, repairEnv, [
+			harnessLeasesGcAdapter,
+		]);
+		const repairReport = JSON.parse(repaired.stdout);
+		expect(repairReport.session_index).toMatchObject({ status: "repaired", valid_prefix_seq: 1 });
+		expect(repairReport.session_index.quarantine_path).toEqual(expect.any(String));
+		expect(await fs.exists(repairReport.session_index.quarantine_path)).toBe(true);
+		expect(repaired.status).toBe(0);
+
+		const retry = await runGjcGcCommand(["--repair-session-index", "--json"], base, repairEnv, [
+			harnessLeasesGcAdapter,
+		]);
+		expect(JSON.parse(retry.stdout).session_index).toMatchObject({ status: "healthy", valid_prefix_seq: 1 });
+		expect(JSON.parse(retry.stdout).session_index.quarantine_path).toBeUndefined();
+		expect(retry.status).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/gc-runtime.test.ts
+++ b/packages/coding-agent/test/gc-runtime.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
 	collectGcReport,
 	computeExitCode,
@@ -10,11 +13,41 @@ import {
 	gcProbeToLeasePidStatus,
 	runGjcGcCommand,
 } from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
+import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+import { SessionIndex } from "../src/sdk/broker/session-index";
+
+const originalAgentDir = getAgentDir();
+let perTestAgentDir: string;
+
+beforeEach(async () => {
+	perTestAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gc-runtime-agent-"));
+	setAgentDir(perTestAgentDir);
+});
+
+async function sessionIndexAgentDir(): Promise<string> {
+	const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gc-session-index-"));
+	setAgentDir(agentDir);
+	return agentDir;
+}
+
+async function appendSessionIndexEvent(agentDir: string): Promise<void> {
+	const index = await new SessionIndex(agentDir).open();
+	await index.append({
+		type: "host_registered",
+		sessionId: "gc-session",
+		locator: { repo: "/tmp/repo", stateRoot: "/tmp/state" },
+		endpointGeneration: 1,
+		pid: process.pid,
+		endpointMtimeMs: Date.now(),
+	});
+}
 
 const originalKill = process.kill.bind(process);
 
-afterEach(() => {
+afterEach(async () => {
 	process.kill = originalKill;
+	setAgentDir(originalAgentDir);
+	await fs.rm(perTestAgentDir, { recursive: true, force: true });
 });
 
 function stubKill(impl: (pid: number) => void): void {
@@ -209,12 +242,23 @@ describe("runGjcGcCommand", () => {
 		expect(result.status).toBe(2);
 		expect(result.stderr).toContain("unknown_flag");
 	});
+	test("rejects repair combined with prune or dry-run", async () => {
+		for (const args of [
+			["--repair-session-index", "--prune"],
+			["--repair-session-index", "--dry-run"],
+		]) {
+			const result = await runGjcGcCommand(args, "/tmp", {}, adapters);
+			expect(result.status).toBe(2);
+			expect(result.stderr).toContain("repair_session_index_cannot_combine");
+		}
+	});
 
 	test("--json emits a report with all five store arrays", async () => {
 		const result = await runGjcGcCommand(["--json"], "/tmp", {}, adapters);
 		expect(result.status).toBe(0);
 		const parsed = JSON.parse(result.stdout);
 		expect(parsed.dry_run).toBe(true);
+		expect(parsed.operation).toBe("dry_run");
 		expect(Object.keys(parsed.stores).sort()).toEqual([
 			"file_locks",
 			"harness_leases",
@@ -252,5 +296,42 @@ describe("runGjcGcCommand", () => {
 		expect(parsed.dry_run).toBe(false);
 		expect(parsed.counts.removed).toBe(1);
 		expect(result.status).toBe(0);
+	});
+
+	test("includes healthy session-index diagnosis in ordinary JSON output", async () => {
+		const agentDir = await sessionIndexAgentDir();
+		await appendSessionIndexEvent(agentDir);
+		const result = await runGjcGcCommand(["--json"], "/tmp", {}, adapters);
+		const report = JSON.parse(result.stdout);
+		expect(report.session_index).toMatchObject({ status: "healthy", valid_prefix_seq: 1 });
+		expect(result.status).toBe(0);
+		await fs.rm(agentDir, { recursive: true, force: true });
+	});
+
+	test("reports corrupt session-index diagnostics without repairing", async () => {
+		const agentDir = await sessionIndexAgentDir();
+		await appendSessionIndexEvent(agentDir);
+		const log = path.join(agentDir, "sdk", "sessions", "index.jsonl");
+		await fs.appendFile(log, "broken\n");
+		const before = await fs.readFile(log, "utf8");
+		const result = await runGjcGcCommand(["--json"], "/tmp", {}, adapters);
+		const report = JSON.parse(result.stdout);
+		expect(report.session_index).toMatchObject({ status: "corrupt", valid_prefix_seq: 1 });
+		expect(await fs.readFile(log, "utf8")).toBe(before);
+		expect(result.status).toBe(1);
+		await fs.rm(agentDir, { recursive: true, force: true });
+	});
+
+	test("fails closed for unsupported session-index versions", async () => {
+		const agentDir = await sessionIndexAgentDir();
+		const log = path.join(agentDir, "sdk", "sessions", "index.jsonl");
+		await fs.mkdir(path.dirname(log), { recursive: true });
+		await fs.writeFile(log, `${JSON.stringify({ version: 99 })}\n`);
+		const result = await runGjcGcCommand(["--json"], "/tmp", {}, adapters);
+		const report = JSON.parse(result.stdout);
+		expect(report.session_index.status).toBe("unsupported");
+		expect(report.session_index.reason).toContain("Unsupported SDK state version");
+		expect(result.status).toBe(1);
+		await fs.rm(agentDir, { recursive: true, force: true });
 	});
 });

--- a/packages/coding-agent/test/sdk-session-index.test.ts
+++ b/packages/coding-agent/test/sdk-session-index.test.ts
@@ -12,6 +12,15 @@ const event = (sessionId: string) => ({
 	pid: process.pid,
 });
 describe("SDK session index", () => {
+	it("diagnoses a missing index without creating session directories", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-missing-"));
+		expect(await new SessionIndex(dir).diagnose()).toEqual({
+			status: "healthy",
+			validPrefixSeq: 0,
+			snapshotSeq: 0,
+		});
+		expect(await fs.exists(path.join(dir, "sdk", "sessions"))).toBe(false);
+	});
 	it("replays only rows after the snapshotted prefix", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
 		const index = await new SessionIndex(dir).open();

--- a/packages/coding-agent/test/sdk-session-index.test.ts
+++ b/packages/coding-agent/test/sdk-session-index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import path from "node:path";
-import { SessionIndex, sessionIndexChecksum } from "../src/sdk/broker/session-index";
+import { SessionIndex, type SessionIndexEvent, sessionIndexChecksum } from "../src/sdk/broker/session-index";
 import { SDK_STATE_VERSION } from "../src/sdk/broker/state-version";
 
 const event = (sessionId: string) => ({
@@ -21,6 +21,37 @@ describe("SDK session index", () => {
 		const replay = await new SessionIndex(dir).open();
 		expect(replay.listSessions().sessions.map(session => session.sessionId)).toEqual(["one", "two"]);
 		expect(replay.indexSeq).toBe(2);
+	});
+	it("accepts a contiguous crash-window overlap that starts after an earlier rotation", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-overlap-"));
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("one"));
+		await index.snapshot();
+		const log = path.join(dir, "sdk", "sessions", "index.jsonl");
+		await fs.writeFile(log, "");
+		await index.append(event("two"));
+		await index.append(event("three"));
+		await index.snapshot();
+		expect(await index.diagnose()).toMatchObject({ status: "healthy", snapshotSeq: 3, validPrefixSeq: 3 });
+		expect((await index.append(event("four"))).indexSeq).toBe(4);
+	});
+	it("does not resynchronize after an incomplete pre-watermark overlap", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-overlap-gap-"));
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("one"));
+		await index.append(event("two"));
+		await index.append(event("three"));
+		await index.snapshot();
+		const log = path.join(dir, "sdk", "sessions", "index.jsonl");
+		const rowOne = (await fs.readFile(log, "utf8")).split("\n")[0]!;
+		const four = { ...event("four"), version: SDK_STATE_VERSION, indexSeq: 4, ts: 1 };
+		await fs.writeFile(
+			log,
+			`${rowOne}\n${JSON.stringify({ ...four, checksum: sessionIndexChecksum(four as Parameters<typeof sessionIndexChecksum>[0]) })}\n`,
+		);
+		const diagnosis = await index.diagnose();
+		expect(diagnosis).toMatchObject({ status: "corrupt", snapshotSeq: 3, validPrefixSeq: 3 });
+		await expect(index.append(event("not-accepted"))).rejects.toThrow("--repair-session-index");
 	});
 	it("retains the valid prefix and warns on corrupt post-snapshot data", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
@@ -58,12 +89,14 @@ describe("SDK session index", () => {
 		const snapshot = JSON.parse(await fs.readFile(path.join(dir, "sdk", "sessions", "index.snapshot.json"), "utf8"));
 		expect(snapshot.indexSeq).toBe(2);
 	});
-	it("replaces a corrupt snapshot while rotating the log", async () => {
+	it("repairs a corrupt snapshot before rotating the retained log", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
 		const index = await new SessionIndex(dir).open();
 		await index.append(event("before"));
 		const sessionsDir = path.join(dir, "sdk", "sessions");
 		await fs.writeFile(path.join(sessionsDir, "index.snapshot.json"), "{");
+		await expect(index.append(event("blocked-before-repair"))).rejects.toThrow("--repair-session-index");
+		expect(await index.repair()).toMatchObject({ status: "corrupt", repaired: true, validPrefixSeq: 1 });
 		await index.append({
 			...event("after"),
 			locator: { repo: "r".repeat(4 * 1024 * 1024), stateRoot: "q" },
@@ -74,7 +107,7 @@ describe("SDK session index", () => {
 		expect(replay.indexSeq).toBe(2);
 		expect(replay.listSessions().warnings).toEqual([]);
 	});
-	it("replaces a structurally invalid high-sequence snapshot before rotating an oversized log", async () => {
+	it("repairs a structurally invalid high-sequence snapshot before rotating an oversized log", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
 		const index = await new SessionIndex(dir).open();
 		const sessionsDir = path.join(dir, "sdk", "sessions");
@@ -95,6 +128,8 @@ describe("SDK session index", () => {
 			path.join(sessionsDir, "index.jsonl"),
 			`${JSON.stringify({ ...oversized, checksum: sessionIndexChecksum(oversized as Parameters<typeof sessionIndexChecksum>[0]) })}\n`,
 		);
+		await expect(index.append(event("blocked-before-repair"))).rejects.toThrow("--repair-session-index");
+		expect(await index.repair()).toMatchObject({ status: "corrupt", repaired: true, validPrefixSeq: 2 });
 
 		await index.append(event("after"));
 
@@ -183,6 +218,42 @@ describe("SDK session index", () => {
 				.map(line => JSON.parse(line).indexSeq),
 		).toEqual(Array.from({ length: 20 }, (_, i) => i + 1));
 	});
+	it("serializes independent writer processes without duplicate or inverted sequences", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-processes-"));
+		const modulePath = path.resolve(import.meta.dir, "../src/sdk/broker/session-index.ts");
+		const script = `
+			import { SessionIndex } from ${JSON.stringify(modulePath)};
+			const index = await new SessionIndex(process.env.AGENT_DIR).open();
+			for (let i = 0; i < 5; i++) {
+				await index.append({
+					type: "host_registered",
+					sessionId: process.env.WRITER_ID + "-" + i,
+					locator: { repo: "r", stateRoot: "q" },
+					endpointGeneration: 1,
+					pid: process.pid,
+				});
+			}
+		`;
+		const children = Array.from({ length: 3 }, (_, writer) =>
+			Bun.spawn([process.execPath, "-e", script], {
+				env: { ...process.env, AGENT_DIR: dir, WRITER_ID: `writer-${writer}` },
+				stdout: "ignore",
+				stderr: "pipe",
+			}),
+		);
+		for (const child of children) {
+			const stderr = await new Response(child.stderr).text();
+			expect(await child.exited, stderr).toBe(0);
+		}
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.indexSeq).toBe(15);
+		expect(replay.listSessions().sessions).toHaveLength(15);
+		const sequences = (await fs.readFile(path.join(dir, "sdk", "sessions", "index.jsonl"), "utf8"))
+			.trim()
+			.split("\n")
+			.map(line => (JSON.parse(line) as { indexSeq: number }).indexSeq);
+		expect(sequences).toEqual(Array.from({ length: 15 }, (_, index) => index + 1));
+	}, 30_000);
 	it("refuses to append after an unterminated suffix while retaining the valid prefix", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
 		const index = await new SessionIndex(dir).open();
@@ -302,8 +373,55 @@ describe("SDK session index", () => {
 		const sessionsDir = path.join(dir, "sdk", "sessions");
 		await fs.mkdir(sessionsDir, { recursive: true });
 		const snapshotFile = path.join(sessionsDir, "index.snapshot.json");
-		await fs.writeFile(snapshotFile, JSON.stringify({ version: 3, indexSeq: 0, events: [] }));
+		await fs.writeFile(snapshotFile, JSON.stringify({ version: 3, indexSeq: 7, events: [] }));
+		const unsupported = new SessionIndex(dir);
+		expect(await unsupported.diagnose()).toMatchObject({ status: "unsupported", validPrefixSeq: 0, snapshotSeq: 7 });
+		expect(await unsupported.repair()).toMatchObject({ status: "unsupported", repaired: false });
 		await expect(new SessionIndex(dir).open()).rejects.toThrow(/Unsupported SDK state version/);
+		const futureOne = { ...event("supported-prefix"), version: SDK_STATE_VERSION, indexSeq: 1, ts: 1 };
+		const futureTwo = { ...event("future-event"), version: 2, indexSeq: 2, ts: 2 };
+		await fs.writeFile(
+			snapshotFile,
+			JSON.stringify({
+				version: 2,
+				indexSeq: 2,
+				events: [
+					{
+						...futureOne,
+						checksum: sessionIndexChecksum(futureOne as Parameters<typeof sessionIndexChecksum>[0]),
+					},
+					{
+						...futureTwo,
+						checksum: sessionIndexChecksum(futureTwo as Parameters<typeof sessionIndexChecksum>[0]),
+					},
+				],
+			}),
+		);
+		const futureSnapshot = new SessionIndex(dir);
+		expect(await futureSnapshot.diagnose()).toMatchObject({
+			status: "unsupported",
+			validPrefixSeq: 1,
+			snapshotSeq: 2,
+		});
+		expect(await futureSnapshot.repair()).toMatchObject({ status: "unsupported", repaired: false });
+		await expect(futureSnapshot.open()).rejects.toThrow(/maximum supported version is 1/);
+		const invalidFutureSnapshot = JSON.stringify({
+			version: 2,
+			indexSeq: 99,
+			events: [
+				{ ...futureOne, checksum: sessionIndexChecksum(futureOne as Parameters<typeof sessionIndexChecksum>[0]) },
+				{ ...futureTwo, checksum: "invalid" },
+			],
+		});
+		await fs.writeFile(snapshotFile, invalidFutureSnapshot);
+		const invalidFuture = new SessionIndex(dir);
+		expect(await invalidFuture.diagnose()).toMatchObject({
+			status: "unsupported",
+			validPrefixSeq: 1,
+			snapshotSeq: 99,
+		});
+		expect(await invalidFuture.repair()).toMatchObject({ status: "unsupported", repaired: false });
+		expect(await fs.readFile(snapshotFile, "utf8")).toBe(invalidFutureSnapshot);
 		const legacy = { ...event("legacy"), version: 1 as const, indexSeq: 1, ts: 1 };
 		const legacyEvent = {
 			...legacy,
@@ -334,5 +452,110 @@ describe("SDK session index", () => {
 		await reopened.snapshot();
 		const second = await fs.readFile(snapshotFile, "utf8");
 		expect(second).toBe(first);
+	});
+	it("diagnoses and repairs legacy sequence inversion without mutating dry evidence", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("snapshot"));
+		await index.snapshot();
+		await index.append(event("valid-prefix"));
+		const log = path.join(dir, "sdk", "sessions", "index.jsonl");
+		const inverted = { ...event("inverted"), version: SDK_STATE_VERSION, indexSeq: 1, ts: 1 };
+		await fs.appendFile(
+			log,
+			`${JSON.stringify({ ...inverted, checksum: sessionIndexChecksum(inverted as Parameters<typeof sessionIndexChecksum>[0]) })}\n`,
+		);
+		const before = await fs.readFile(log, "utf8");
+		const corrupt = await new SessionIndex(dir).open();
+		expect(await corrupt.diagnose()).toMatchObject({ status: "corrupt", snapshotSeq: 1, validPrefixSeq: 2 });
+		expect(await fs.readFile(log, "utf8")).toBe(before);
+
+		const repair = await corrupt.repair();
+		expect(repair).toMatchObject({ status: "corrupt", repaired: true, validPrefixSeq: 2 });
+		expect(repair.quarantinePath).toBeDefined();
+		expect(await fs.readFile(path.join(repair.quarantinePath!, "index.jsonl"), "utf8")).toBe(before);
+		expect((await new SessionIndex(dir).open()).indexSeq).toBe(2);
+		const resumed = await new SessionIndex(dir).open();
+		expect((await resumed.append(event("resumed"))).indexSeq).toBe(3);
+		expect(await resumed.repair()).toMatchObject({ status: "healthy", repaired: false, validPrefixSeq: 3 });
+	});
+	it("quarantines an invalid snapshot and rebuilds from a valid log prefix", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-invalid-snapshot-"));
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("log-prefix"));
+		const snapshot = path.join(dir, "sdk", "sessions", "index.snapshot.json");
+		await fs.writeFile(snapshot, "not-json");
+		const before = await fs.readFile(snapshot);
+		const diagnosis = await index.diagnose();
+		expect(diagnosis).toMatchObject({ status: "corrupt", reason: "invalid snapshot", validPrefixSeq: 1 });
+		const repair = await index.repair();
+		expect(repair).toMatchObject({ status: "corrupt", repaired: true, validPrefixSeq: 1 });
+		expect(await fs.readFile(path.join(repair.quarantinePath!, "index.snapshot.json"))).toEqual(before);
+		expect((await new SessionIndex(dir).open()).indexSeq).toBe(1);
+	});
+	it("detects checksum corruption in physical log history covered by a valid snapshot", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-covered-history-"));
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("snapshotted"));
+		await index.snapshot();
+		const log = path.join(dir, "sdk", "sessions", "index.jsonl");
+		const rows = (await fs.readFile(log, "utf8")).trim().split("\n");
+		const tampered = { ...(JSON.parse(rows[0]!) as SessionIndexEvent), checksum: "0".repeat(64) };
+		await fs.writeFile(log, `${JSON.stringify(tampered)}\n`);
+		const before = await fs.readFile(log);
+		const diagnosis = await index.diagnose();
+		expect(diagnosis).toMatchObject({ status: "corrupt", validPrefixSeq: 1 });
+		const repair = await index.repair();
+		expect(repair).toMatchObject({ status: "corrupt", repaired: true, validPrefixSeq: 1 });
+		expect(await fs.readFile(path.join(repair.quarantinePath!, "index.jsonl"))).toEqual(before);
+		expect((await new SessionIndex(dir).open()).indexSeq).toBe(1);
+	});
+	it("persists quarantine evidence before replacing the live snapshot or log", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-quarantine-order-"));
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("prefix"));
+		const sessionsDir = path.join(dir, "sdk", "sessions");
+		const log = path.join(sessionsDir, "index.jsonl");
+		await fs.appendFile(log, "broken\n");
+		const originalRename = fs.rename.bind(fs);
+		let replacementChecks = 0;
+		const rename = vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+			if (to === path.join(sessionsDir, "index.snapshot.json") || to === log) {
+				const repairs = await fs.readdir(path.join(sessionsDir, "quarantine"));
+				expect(repairs).toHaveLength(1);
+				expect(await fs.readFile(path.join(sessionsDir, "quarantine", repairs[0]!, "index.jsonl"))).toEqual(
+					await fs.readFile(log),
+				);
+				replacementChecks++;
+			}
+			await originalRename(from, to);
+		});
+		try {
+			expect(await index.repair()).toMatchObject({ repaired: true });
+		} finally {
+			rename.mockRestore();
+		}
+		expect(replacementChecks).toBe(2);
+	});
+	it("serializes repair with a racing writer and resumes after the retained prefix", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
+		const seed = await new SessionIndex(dir).open();
+		await seed.append(event("snapshot"));
+		await seed.snapshot();
+		await seed.append(event("prefix"));
+		const inverted = { ...event("inverted"), version: SDK_STATE_VERSION, indexSeq: 1, ts: 1 };
+		await fs.appendFile(
+			path.join(dir, "sdk", "sessions", "index.jsonl"),
+			`${JSON.stringify({ ...inverted, checksum: sessionIndexChecksum(inverted as Parameters<typeof sessionIndexChecksum>[0]) })}\n`,
+		);
+		const corrupt = await new SessionIndex(dir).open();
+		const repairing = corrupt.repair();
+		const writer = new SessionIndex(dir);
+		const appended = await writer.append(event("racing-writer"));
+		expect((await repairing).validPrefixSeq).toBe(2);
+		expect(appended.indexSeq).toBe(3);
+		const replay = await new SessionIndex(dir).open();
+		expect(replay.indexSeq).toBe(3);
+		expect((await replay.diagnose()).status).toBe("healthy");
 	});
 });


### PR DESCRIPTION
## Summary
- independently reproduces the pre-0.11.2 stale multi-writer sequence allocator and current fail-closed behavior
- adds version/checksum/sequence-aware diagnosis plus explicit `gjc gc --repair-session-index`
- quarantines original snapshot/log bytes durably under the cross-process index lock before atomic repaired snapshot/log replacement
- preserves only the verified prefix without renumbering and never accepts a corrupt or future-version suffix
- adds actionable CLI/help/restart guidance, legacy corruption coverage, overlap boundaries, idempotency, repair races, and multi-process stress

## Verification
- `bun test test/sdk-session-index.test.ts test/gc-runtime.test.ts test/gc-e2e.test.ts test/perf-redteam.test.ts test/cli-command-surface.test.ts test/sdk-downgrade-unknown-version.test.ts` — 70 pass
- `bun test test/sdk-broker.test.ts` — 40 pass
- `bun run check`
- `bun run check:runtime`
- independent executor QA/red-team: passed
- independent architect review: CLEAR / APPROVE

Evidence: `artifacts/issue-2654-session-index-repair-report.json`

Closes #2654

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*