### PR TITLE
fix(tui): drop unsolicited capability-probe replies from stdin

### DIFF
--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -10,6 +10,47 @@ const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
 const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
 
 /**
+ * Capability-probe reply shapes that GJC itself solicits from the terminal
+ * (OSC 11 background color, the DA1 sentinel, the Mode 2031 appearance DSR, and
+ * the Kitty keyboard-flags report). Each entry pairs the query GJC issues with
+ * the exact anchored reply shape it produces.
+ *
+ * These are terminal->host replies and are NEVER legitimate user input on the
+ * TUI's own stdin (child-tool stdout goes to the tool's own PTY, not here), so
+ * a reply that arrives outside its pending-query window - a late or duplicate
+ * reply, or a probe that straddled a foreground-tool suspend/resume - can be
+ * dropped without ever swallowing a real keystroke. Bracketed-paste content is
+ * routed through StdinBuffer's separate 'paste' event and never reaches the
+ * 'data' handler, so pasted reply-shaped bytes are structurally unaffected.
+ *
+ * This registry is the single source of truth shared by the defensive strip in
+ * #setupStdinBuffer and the probe-coverage regression test: adding a new probe
+ * query without a matching reply entry fails that test.
+ */
+export const PROBE_REPLY_PATTERNS: ReadonlyArray<{ name: string; issuedProbe: string; pattern: RegExp }> = [
+	{
+		name: "osc11-background",
+		issuedProbe: "\x1b]11;?\x07",
+		pattern: /^\x1b\]11;rgba?:[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}(?:\x07|\x1b\\)$/,
+	},
+	{ name: "da1-primary", issuedProbe: "\x1b[c", pattern: /^\x1b\[\?[\d;]*c$/ },
+	{ name: "mode2031-dsr", issuedProbe: "\x1b[?2031h", pattern: /^\x1b\[\?997;[12]n$/ },
+	{ name: "kitty-flags", issuedProbe: "\x1b[?u", pattern: /^\x1b\[\?\d+u$/ },
+];
+
+/**
+ * True when `sequence` is a capability-probe reply GJC solicited (see
+ * PROBE_REPLY_PATTERNS). Used as a defensive backstop before forwarding stdin
+ * sequences to the input handler.
+ */
+export function isUnsolicitedProbeReply(sequence: string): boolean {
+	for (const entry of PROBE_REPLY_PATTERNS) {
+		if (entry.pattern.test(sequence)) return true;
+	}
+	return false;
+}
+
+/**
  * Whether GJC may reprogram the keyboard with enhanced input protocols
  * (the Kitty keyboard protocol and the xterm modifyOtherKeys fallback).
  *
@@ -514,6 +555,18 @@ export class ProcessTerminal implements Terminal {
 					this.#mode2031DebounceTimer = undefined;
 					this.#queryBackgroundColor();
 				}, 100);
+				return;
+			}
+			// Defensive backstop against the otty input-freeze: a capability-probe
+			// reply that reaches this point arrived outside its pending-query window
+			// (late/duplicate reply, or a probe that straddled a foreground-tool
+			// suspend/resume), so the pending-window handlers above did not consume
+			// it. Some shapes (Mode 2031 DSR) are also caught by dedicated handlers
+			// earlier; this backstop guarantees none can leak into the editor
+			// regardless of handler ordering or reply timing. These shapes are never
+			// user input and paste content never reaches this handler, so dropping
+			// is always safe.
+			if (isUnsolicitedProbeReply(sequence)) {
 				return;
 			}
 			if (this.#inputHandler) {

--- a/packages/tui/test/probe-reply-strip.test.ts
+++ b/packages/tui/test/probe-reply-strip.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { isUnsolicitedProbeReply, PROBE_REPLY_PATTERNS, ProcessTerminal } from "@gajae-code/tui/terminal";
+
+// Regression coverage for the otty input-freeze: unsolicited capability-probe
+// replies (OSC 11 / DA1 / Mode 2031 DSR / Kitty flags) that arrive outside their
+// pending-query window must be dropped instead of leaking into the input handler,
+// while real keystrokes and pasted content are preserved.
+
+const stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+const stdinSetRawModeDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
+
+function restoreProperty(target: object, key: string, descriptor: PropertyDescriptor | undefined): void {
+	if (descriptor) {
+		Object.defineProperty(target, key, descriptor);
+		return;
+	}
+	delete (target as Record<string, unknown>)[key];
+}
+
+describe("ProcessTerminal unsolicited probe-reply strip", () => {
+	beforeEach(() => {
+		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdin, "setRawMode", { value: vi.fn(), configurable: true });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		restoreProperty(process.stdin, "isTTY", stdinIsTtyDescriptor);
+		restoreProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
+		restoreProperty(process.stdin, "setRawMode", stdinSetRawModeDescriptor);
+	});
+
+	function setupTerminal() {
+		const writes: string[] = [];
+		const received: string[] = [];
+		const appearances: Array<"dark" | "light"> = [];
+		vi.spyOn(process, "kill").mockReturnValue(true);
+		vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdin, "setEncoding").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+
+		const terminal = new ProcessTerminal();
+		terminal.onAppearanceChange(mode => appearances.push(mode));
+		terminal.start(
+			data => received.push(data),
+			() => {},
+		);
+
+		// Drain the initial startup OSC 11 + DA1 probe so the pending counters
+		// return to 0 and subsequent replies count as unsolicited.
+		const feed = (data: string) => process.stdin.emit("data", data);
+		return { terminal, writes, received, appearances, feed };
+	}
+
+	function drainInitialProbe(feed: (data: string) => void, received: string[]): void {
+		feed("\x1b]11;rgb:ffff/ffff/ffff\x07"); // solicited OSC 11 reply (consumed)
+		feed("\x1b[?1;2c"); // solicited DA1 sentinel (consumed, counter -> 0)
+		expect(received).toEqual([]); // nothing leaked while draining
+	}
+
+	it("case 1: drops an unsolicited OSC 11 reply split across chunk boundaries", () => {
+		const { received, feed } = setupTerminal();
+		drainInitialProbe(feed, received);
+		// Split mid-sequence; StdinBuffer reassembles the complete OSC before the strip.
+		feed("\x1b]11;rgb:0a0a/0e0e/");
+		feed("1414\x07");
+		expect(received).toEqual([]);
+	});
+
+	it("case 2: drops an unsolicited DA1 reply", () => {
+		const { received, feed } = setupTerminal();
+		drainInitialProbe(feed, received);
+		feed("\x1b[?62;22c");
+		expect(received).toEqual([]);
+	});
+
+	it("case 3: drops interleaved unsolicited OSC 11 + DA1 but forwards a real keystroke", () => {
+		const { received, feed } = setupTerminal();
+		drainInitialProbe(feed, received);
+		feed("\x1b]11;rgb:0a0a/0e0e/1414\x07");
+		feed("\x1b[?62;22c");
+		feed("a"); // real keystroke
+		expect(received).toEqual(["a"]);
+	});
+
+	it("case 4: preserves bracketed-paste content even when it contains reply-shaped bytes", () => {
+		const { received, feed } = setupTerminal();
+		drainInitialProbe(feed, received);
+		const payload = "before\x1b]11;rgb:0a0a/0e0e/1414\x07after";
+		feed(`\x1b[200~${payload}\x1b[201~`);
+		// Paste is re-wrapped by terminal.ts and forwarded intact via the paste path.
+		expect(received).toHaveLength(1);
+		expect(received[0]).toBe(`\x1b[200~${payload}\x1b[201~`);
+	});
+
+	it("case 5: still consumes a solicited in-window reply and fires the appearance callback", () => {
+		const { received, appearances, feed } = setupTerminal();
+		// Initial startup probe is still pending; a dark reply must be consumed
+		// (not forwarded) and must drive the dark/light callback.
+		feed("\x1b]11;rgb:0000/0000/0000\x07");
+		expect(received).toEqual([]);
+		expect(appearances).toEqual(["dark"]);
+	});
+
+	it("case 6: distinguishes Kitty flags report (stripped) from Kitty key input (forwarded)", () => {
+		// Unit-level guard on the disambiguation: the `?` private marker separates
+		// the flags REPORT from CSI-u key INPUT.
+		expect(isUnsolicitedProbeReply("\x1b[?7u")).toBe(true); // flags report
+		expect(isUnsolicitedProbeReply("\x1b[97;5u")).toBe(false); // key input (no `?`)
+		expect(isUnsolicitedProbeReply("\x1b[97u")).toBe(false); // key input (no `?`)
+
+		// Integration: once the Kitty protocol is already active, a further flags
+		// report is unsolicited and must be dropped rather than forwarded.
+		const { received, feed } = setupTerminal();
+		drainInitialProbe(feed, received);
+		feed("\x1b[?1u"); // first report enables the protocol (consumed by enable path)
+		feed("\x1b[?1u"); // second report is now unsolicited -> stripped
+		expect(received).toEqual([]);
+	});
+
+	it("case 7: self-checking probe coverage - every issued probe has a strip entry", () => {
+		const sourcePath = fileURLToPath(new URL("../src/terminal.ts", import.meta.url));
+		const source = readFileSync(sourcePath, "utf8");
+
+		// Every registry entry must correspond to a probe query the TUI actually
+		// issues. Render control bytes in the same `\xHH` form the TS source uses.
+		const toSourceEscaped = (s: string): string =>
+			[...s]
+				.map(ch => {
+					const code = ch.charCodeAt(0);
+					return code < 0x20 || code === 0x7f ? `\\x${code.toString(16).padStart(2, "0")}` : ch;
+				})
+				.join("");
+		for (const entry of PROBE_REPLY_PATTERNS) {
+			expect(source.includes(toSourceEscaped(entry.issuedProbe))).toBe(true);
+		}
+
+		// Drift guard: the known reply-bearing probe query markers the TUI issues.
+		// If a new capability probe is added to terminal.ts, add it here AND to
+		// PROBE_REPLY_PATTERNS; this pinned set makes the omission fail loudly.
+		const KNOWN_PROBE_QUERY_MARKERS = [
+			"\\x1b]11;?\\x07", // OSC 11 background color
+			"\\x1b[c", // DA1 sentinel
+			"\\x1b[?2031h", // Mode 2031 appearance notifications
+			"\\x1b[?u", // Kitty keyboard flags query
+		];
+		expect(PROBE_REPLY_PATTERNS.map(p => p.issuedProbe).sort()).toEqual(
+			KNOWN_PROBE_QUERY_MARKERS.map(m => m.replace(/\\x1b/g, "\x1b").replace(/\\x07/g, "\x07")).sort(),
+		);
+
+		// Each registry pattern must reject plainly non-reply input.
+		for (const nonReply of ["a", "\x1b[200~", "\x1b[201~", "\x1b[97;5u"]) {
+			expect(isUnsolicitedProbeReply(nonReply)).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION
## Problem

During a long-running foreground tool (e.g. a `docker build`) in the **otty** terminal, unsolicited terminal capability-probe replies were injected into the GJC input line, freezing keyboard input mid-escape-parse.

Captured trace from the reported otty session (the bytes that leaked into the prompt):

```
]11;rgb:0a0a/0e0e/1414^G   <- OSC 11 background-color reply
^[[?62;22c                 <- Primary DA (VT220 + ANSI color) reply
```

## Root cause

In `packages/tui/src/terminal.ts`, the `#stdinBuffer.on("data")` handler strips probe replies **only while their pending-query counters are set**:

- DA1 is swallowed only when `#pendingDa1Sentinels > 0`
- OSC 11 is consumed only when `#osc11Pending`
- the Kitty flags report is consumed only when `!#kittyProtocolActive`

A reply that arrives with those counters at 0 - a **late or duplicate reply**, or a probe that **straddled a foreground-tool suspend/resume** - falls through to `#inputHandler` and is typed into the editor. otty reliably triggers this because a probe issued around the long build lands its reply outside the pending window.

## Fix

Add a shared `PROBE_REPLY_PATTERNS` registry (the four reply shapes GJC actually solicits: OSC 11, DA1, Mode 2031 DSR, Kitty flags) and `isUnsolicitedProbeReply()`, then drop any matching reply defensively **before** forwarding stdin sequences to the input handler.

Why this is safe:

- These are terminal->host replies and are **never** legitimate user input on the TUI's own stdin (child-tool stdout goes to the tool's own PTY, not here).
- **Bracketed paste is unaffected**: `StdinBuffer` routes paste content through a separate `paste` event, so pasted reply-shaped bytes never reach this handler. No `#inBracketedPaste` flag is needed - the guarantee is structural.
- The registry is the single source of truth shared by the strip and a self-checking coverage test, so adding a new probe query without a matching reply entry fails CI.

Scope note: `XTVersion` DCS and sixel `XTSMGRAPHICS` are intentionally **excluded** - `terminal.ts` never issues those queries, so stripping their replies would be speculative surface. The coverage test pins the issued-probe set.

## Tests

New `packages/tui/test/probe-reply-strip.test.ts` (7 cases):

1. unsolicited OSC 11 split across chunk boundaries -> dropped
2. unsolicited DA1 -> dropped
3. interleaved unsolicited OSC 11 + DA1, then a real keystroke -> replies dropped, keystroke forwarded
4. bracketed paste containing an OSC-11-shaped payload -> preserved byte-for-byte
5. solicited in-window reply -> still consumed **and** dark/light appearance callback fires (no regression)
6. Kitty flags report (`\x1b[?7u`) stripped vs Kitty key input (`\x1b[97;5u`) forwarded - `?` marker disambiguation
7. self-checking probe-coverage guard - fails if a new issued probe lacks a strip entry

```
bun test test/probe-reply-strip.test.ts        -> 7 pass
bun test terminal-appearance/stdin-buffer/...  -> 82 pass (no regression)
bun run check:types                            -> clean
biome check                                    -> clean
```

## Follow-up

This PR is the root-elimination + regression test. A local `~/.gjc/patches` mitigation carrying the same strip has been deployed on the reporting machine and will be retired once this merges.
