### PR TITLE
fix(coding-agent): preserve inline scrollback and status through lifecycle transitions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -183,7 +183,7 @@
       "devDependencies": {
         "@xterm/headless": "catalog:",
         "chalk": "catalog:",
-        "node-pty": "^1.0.0",
+        "node-pty": "1.2.0-beta.14",
       },
     },
     "packages/typescript-edit-benchmark": {
@@ -960,7 +960,7 @@
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
-    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+    "node-pty": ["node-pty@1.2.0-beta.14", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-XORU9BQgpxVgqr7WivjJ17mLenOHUgKKWzuZZNaw3NDYgHc/wPJQMSaoLDrpEgqV6aU1nNwil1o/OqYj6lWmUA=="],
 
     "nth-check": ["nth-check@3.0.1", "", { "dependencies": { "boolbase": "^2.0.0" } }, "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ=="],
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Newly registered earlier resource-GC policies advance the pending sweep without postponing an already earlier sweep.
 - Provider onboarding wizard completion is now deterministic under CI load: duplicate in-flight confirmation is suppressed, success tests await the real refresh/notification/status boundary instead of fixed sleeps, and the newly configured model is verified through the subsequent model selector.
 - OpenAI-compatible web search now turns malformed successful response bodies into bounded provider errors while preserving normal provider fallback (#2593).
+- Transient status-slot install and teardown now flow through a single `StatusArea` owner that reserves the slot's high-water row count on native process terminals: completion, cancel, error, auto-retry backoff/recovery, auto/manual compaction, handoff, branch-summary, and debug-report transitions never contract the bottom status area and repaint scrollback the user is browsing, and independently owned status components survive every one of those teardowns. `statusContainer.clear()` is now reserved for whole-session resets. Session lifecycle events are ordered on a dedicated completion/start lane (live events are never queued behind a handler awaiting user interaction), and stale completions from superseded runs are ignored via turn-generation identity.
 
 ## [0.11.3] - 2026-07-19
 ### Added

--- a/packages/coding-agent/src/debug/index.ts
+++ b/packages/coding-agent/src/debug/index.ts
@@ -161,7 +161,7 @@ export class DebugSelectorComponent extends Container {
 			"Generating report...",
 			getSymbolTheme().spinnerFrames,
 		);
-		this.ctx.statusContainer.addChild(loader);
+		this.ctx.statusArea.addLoader(loader);
 		this.ctx.ui.requestRender();
 
 		try {
@@ -174,8 +174,7 @@ export class DebugSelectorComponent extends Container {
 				workProfile,
 			});
 
-			loader.stop();
-			this.ctx.statusContainer.clear();
+			this.ctx.statusArea.removeLoader(loader);
 
 			this.ctx.chatContainer.addChild(new Spacer(1));
 			this.ctx.chatContainer.addChild(
@@ -184,8 +183,7 @@ export class DebugSelectorComponent extends Container {
 			this.ctx.chatContainer.addChild(new Text(theme.fg("dim", formatFileHyperlink(result.path)), 1, 0));
 			this.ctx.chatContainer.addChild(new Text(theme.fg("dim", `Files: ${result.files.length}`), 1, 0));
 		} catch (err) {
-			loader.stop();
-			this.ctx.statusContainer.clear();
+			this.ctx.statusArea.removeLoader(loader);
 			this.ctx.showError(`Failed to create report: ${err instanceof Error ? err.message : String(err)}`);
 		}
 
@@ -226,7 +224,7 @@ export class DebugSelectorComponent extends Container {
 			"Creating report bundle...",
 			getSymbolTheme().spinnerFrames,
 		);
-		this.ctx.statusContainer.addChild(loader);
+		this.ctx.statusArea.addLoader(loader);
 		this.ctx.ui.requestRender();
 
 		try {
@@ -235,8 +233,7 @@ export class DebugSelectorComponent extends Container {
 				settings: this.#getResolvedSettings(),
 			});
 
-			loader.stop();
-			this.ctx.statusContainer.clear();
+			this.ctx.statusArea.removeLoader(loader);
 
 			this.ctx.chatContainer.addChild(new Spacer(1));
 			this.ctx.chatContainer.addChild(
@@ -245,8 +242,7 @@ export class DebugSelectorComponent extends Container {
 			this.ctx.chatContainer.addChild(new Text(theme.fg("dim", formatFileHyperlink(result.path)), 1, 0));
 			this.ctx.chatContainer.addChild(new Text(theme.fg("dim", `Files: ${result.files.length}`), 1, 0));
 		} catch (err) {
-			loader.stop();
-			this.ctx.statusContainer.clear();
+			this.ctx.statusArea.removeLoader(loader);
 			this.ctx.showError(`Failed to create report: ${err instanceof Error ? err.message : String(err)}`);
 		}
 
@@ -261,7 +257,7 @@ export class DebugSelectorComponent extends Container {
 			"Generating heap snapshot...",
 			getSymbolTheme().spinnerFrames,
 		);
-		this.ctx.statusContainer.addChild(loader);
+		this.ctx.statusArea.addLoader(loader);
 		this.ctx.ui.requestRender();
 
 		try {
@@ -274,8 +270,7 @@ export class DebugSelectorComponent extends Container {
 				heapSnapshot,
 			});
 
-			loader.stop();
-			this.ctx.statusContainer.clear();
+			this.ctx.statusArea.removeLoader(loader);
 
 			this.ctx.chatContainer.addChild(new Spacer(1));
 			this.ctx.chatContainer.addChild(
@@ -284,8 +279,7 @@ export class DebugSelectorComponent extends Container {
 			this.ctx.chatContainer.addChild(new Text(theme.fg("dim", formatFileHyperlink(result.path)), 1, 0));
 			this.ctx.chatContainer.addChild(new Text(theme.fg("dim", `Files: ${result.files.length}`), 1, 0));
 		} catch (err) {
-			loader.stop();
-			this.ctx.statusContainer.clear();
+			this.ctx.statusArea.removeLoader(loader);
 			this.ctx.showError(`Failed to create report: ${err instanceof Error ? err.message : String(err)}`);
 		}
 
@@ -412,14 +406,13 @@ export class DebugSelectorComponent extends Container {
 			"Clearing artifact cache...",
 			getSymbolTheme().spinnerFrames,
 		);
-		this.ctx.statusContainer.addChild(loader);
+		this.ctx.statusArea.addLoader(loader);
 		this.ctx.ui.requestRender();
 
 		try {
 			const result = await clearArtifactCache(sessionsDir, 30);
 
-			loader.stop();
-			this.ctx.statusContainer.clear();
+			this.ctx.statusArea.removeLoader(loader);
 
 			this.ctx.chatContainer.addChild(new Spacer(1));
 			this.ctx.chatContainer.addChild(
@@ -430,8 +423,7 @@ export class DebugSelectorComponent extends Container {
 				),
 			);
 		} catch (err) {
-			loader.stop();
-			this.ctx.statusContainer.clear();
+			this.ctx.statusArea.removeLoader(loader);
 			this.ctx.showError(`Failed to clear cache: ${err instanceof Error ? err.message : String(err)}`);
 		}
 

--- a/packages/coding-agent/src/modes/components/status-row-reserve.ts
+++ b/packages/coding-agent/src/modes/components/status-row-reserve.ts
@@ -1,0 +1,43 @@
+import type { Component } from "@gajae-code/tui";
+
+/**
+ * Reserves bottom-status rows on process terminals, which cannot report the
+ * user's scrollback position. The component tracks the high-water row count of
+ * the transient status slot (working / retry / auto-compaction loaders) at the
+ * current width and renders enough blank lines to keep the slot at that
+ * height. Removing or swapping a loader therefore never contracts the status
+ * area, so completion and retry transitions cannot repaint inline-viewport
+ * scrollback the user may be browsing.
+ *
+ * A resize resets the reservation (the viewport reflows and repaints anyway).
+ * Dropping the component (e.g. a full status clear on session switch) drops
+ * the reservation with it; the event controller re-creates it lazily.
+ */
+export class StatusRowReserve implements Component {
+	#width = -1;
+	#reservedLines = 0;
+
+	constructor(private measureLiveLines: (width: number) => number) {}
+
+	/**
+	 * Records the current live transient rows into the high-water mark. Call
+	 * before removing a loader so rows that never got a render frame (or are
+	 * about to disappear) still count toward the reservation.
+	 */
+	capture(width: number): number {
+		if (width !== this.#width) {
+			this.#width = width;
+			this.#reservedLines = 0;
+		}
+		const live = this.measureLiveLines(width);
+		if (live > this.#reservedLines) this.#reservedLines = live;
+		return live;
+	}
+
+	render(width: number): string[] {
+		const live = this.capture(width);
+		return Array.from({ length: this.#reservedLines - live }, () => "");
+	}
+
+	invalidate(): void {}
+}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1205,11 +1205,8 @@ export class CommandController {
 		customInstructionsOrOptions?: string | CompactOptions,
 		isAuto = false,
 	): Promise<CompactionOutcome> {
-		if (this.ctx.loadingAnimation) {
-			this.ctx.loadingAnimation.stop();
-			this.ctx.loadingAnimation = undefined;
-		}
-		this.ctx.statusContainer.clear();
+		this.ctx.statusArea.removeLoader(this.ctx.loadingAnimation);
+		this.ctx.loadingAnimation = undefined;
 
 		const originalOnEscape = this.ctx.editor.onEscape;
 		this.ctx.editor.onEscape = () => {
@@ -1225,7 +1222,7 @@ export class CommandController {
 			label,
 			getSymbolTheme().spinnerFrames,
 		);
-		this.ctx.statusContainer.addChild(compactingLoader);
+		this.ctx.statusArea.addLoader(compactingLoader);
 		this.ctx.ui.requestRender();
 
 		let outcome: CompactionOutcome = "ok";
@@ -1251,8 +1248,7 @@ export class CommandController {
 				this.ctx.showError(`Compaction failed: ${message}`);
 			}
 		} finally {
-			compactingLoader.stop();
-			this.ctx.statusContainer.clear();
+			this.ctx.statusArea.removeLoader(compactingLoader);
 			this.ctx.editor.onEscape = originalOnEscape;
 		}
 		await this.ctx.flushCompactionQueue({ willRetry: false });
@@ -1268,11 +1264,8 @@ export class CommandController {
 			return;
 		}
 
-		if (this.ctx.loadingAnimation) {
-			this.ctx.loadingAnimation.stop();
-			this.ctx.loadingAnimation = undefined;
-		}
-		this.ctx.statusContainer.clear();
+		this.ctx.statusArea.removeLoader(this.ctx.loadingAnimation);
+		this.ctx.loadingAnimation = undefined;
 
 		const originalOnEscape = this.ctx.editor.onEscape;
 		this.ctx.editor.onEscape = () => {
@@ -1286,7 +1279,7 @@ export class CommandController {
 			"Generating handoff… (esc to cancel)",
 			getSymbolTheme().spinnerFrames,
 		);
-		this.ctx.statusContainer.addChild(handoffLoader);
+		this.ctx.statusArea.addLoader(handoffLoader);
 		this.ctx.ui.requestRender();
 
 		try {
@@ -1322,8 +1315,7 @@ export class CommandController {
 				this.ctx.showError(`Handoff failed: ${message}`);
 			}
 		} finally {
-			handoffLoader.stop();
-			this.ctx.statusContainer.clear();
+			this.ctx.statusArea.removeLoader(handoffLoader);
 			this.ctx.editor.onEscape = originalOnEscape;
 		}
 	}

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -14,6 +14,7 @@ import {
 import { TodoReminderComponent } from "../../modes/components/todo-reminder";
 import { ToolExecutionComponent } from "../../modes/components/tool-execution";
 import { TtsrNotificationComponent } from "../../modes/components/ttsr-notification";
+import { StatusArea } from "../../modes/status-area";
 import { getSymbolTheme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext, TodoPhase } from "../../modes/types";
 import type { PlanApprovalDetails } from "../../plan-mode/approved-plan";
@@ -118,8 +119,13 @@ export class EventController {
 	#toolIntentCache = new Map<string, { args: unknown; intent: string | undefined }>();
 	#thinkingContentIndices = new Set<number>();
 	#handlers: AgentSessionEventHandlers;
+	#statusArea: StatusArea;
+	#lifecycleQueue: Promise<void> = Promise.resolve();
+	#turnGeneration = 0;
+	#completedGeneration = -1;
 
 	constructor(private ctx: InteractiveModeContext) {
+		this.#statusArea = ctx.statusArea ?? new StatusArea(ctx);
 		this.#handlers = {
 			agent_start: e => this.#handleAgentStart(e),
 			agent_end: e => this.#handleAgentEnd(e),
@@ -228,7 +234,24 @@ export class EventController {
 		});
 	}
 
-	async handleEvent(event: AgentSessionEvent): Promise<void> {
+	/**
+	 * Orders lifecycle events so a completion cannot interleave with a
+	 * successor turn's start. Only agent_start/agent_end are serialized:
+	 * queuing the whole stream would let a handler that awaits user
+	 * interaction (e.g. plan approval inside tool_execution_end) starve live
+	 * events. Handlers must never await handleEvent for a lifecycle event: a
+	 * nested call would queue behind the current one and deadlock.
+	 */
+	handleEvent(event: AgentSessionEvent): Promise<void> {
+		if (event.type === "agent_start" || event.type === "agent_end") {
+			const completion = this.#lifecycleQueue.then(() => this.#handleEvent(event));
+			this.#lifecycleQueue = completion.catch(() => {});
+			return completion;
+		}
+		return this.#handleEvent(event);
+	}
+
+	async #handleEvent(event: AgentSessionEvent): Promise<void> {
 		if (!this.ctx.isInitialized) {
 			await this.ctx.init();
 		}
@@ -242,6 +265,7 @@ export class EventController {
 	}
 
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
+		this.#turnGeneration++;
 		this.#lastIntent = undefined;
 		this.#readToolCallArgs.clear();
 		this.#readToolCallAssistantComponents.clear();
@@ -251,15 +275,15 @@ export class EventController {
 			this.ctx.retryEscapeHandler = undefined;
 		}
 		if (this.ctx.retryLoader) {
-			this.ctx.retryLoader.stop();
 			this.#clearRetryCountdown();
+			this.#statusArea.removeLoader(this.ctx.retryLoader);
 			this.ctx.retryLoader = undefined;
-			this.ctx.statusContainer.clear();
 		}
 		this.ctx.retryEscapePrimed = false;
 		this.#cancelIdleCompaction();
 		this.ctx.updateEditorBorderColor();
 		this.ctx.ensureLoadingAnimation();
+		this.#statusArea.capture();
 		this.ctx.ui.requestRender();
 	}
 
@@ -810,11 +834,29 @@ export class EventController {
 	}
 
 	async #handleAgentEnd(_event: Extract<AgentSessionEvent, { type: "agent_end" }>): Promise<void> {
-		if (this.ctx.loadingAnimation) {
-			this.ctx.loadingAnimation.stop();
-			this.ctx.loadingAnimation = undefined;
-			this.ctx.statusContainer.clear();
+		if (this.#completedGeneration === this.#turnGeneration) return;
+		// A stale completion from a superseded run must not complete the active
+		// turn: the agent flips isStreaming to false before emitting a
+		// legitimate agent_end, so a streaming session here means an active run
+		// owns the next completion (or a queued follow-up chained runs without
+		// an idle gap — no completion should be shown either way).
+		if (this.ctx.session.isStreaming) return;
+		this.#completedGeneration = this.#turnGeneration;
+
+		if (this.ctx.retryEscapeHandler) {
+			this.ctx.editor.onEscape = this.ctx.retryEscapeHandler;
+			this.ctx.retryEscapeHandler = undefined;
 		}
+		this.#clearRetryCountdown();
+		// Process terminals do not expose native scrollback position. The
+		// reserve records the visible rows before each removal so completion
+		// cannot contract the status area and repaint a viewport the user is
+		// browsing.
+		this.#statusArea.removeLoader(this.ctx.retryLoader);
+		this.ctx.retryLoader = undefined;
+		this.#statusArea.removeLoader(this.ctx.loadingAnimation);
+		this.ctx.loadingAnimation = undefined;
+		this.ctx.retryEscapePrimed = false;
 		if (this.ctx.streamingComponent) {
 			this.ctx.chatContainer.removeChild(this.ctx.streamingComponent);
 			this.ctx.streamingComponent = undefined;
@@ -847,7 +889,10 @@ export class EventController {
 		this.ctx.editor.onEscape = () => {
 			this.ctx.session.abortCompaction();
 		};
-		this.ctx.statusContainer.clear();
+		if (this.ctx.autoCompactionLoader) {
+			this.#statusArea.removeLoader(this.ctx.autoCompactionLoader);
+			this.ctx.autoCompactionLoader = undefined;
+		}
 		const reasonText =
 			event.reason === "overflow" ? "Context overflow detected, " : event.reason === "idle" ? "Idle " : "";
 		const actionLabel = event.action === "handoff" ? "Auto-handoff" : "Auto context-full maintenance";
@@ -858,7 +903,7 @@ export class EventController {
 			`${reasonText}${actionLabel}… (esc to cancel)`,
 			getSymbolTheme().spinnerFrames,
 		);
-		this.ctx.statusContainer.addChild(this.ctx.autoCompactionLoader);
+		this.#statusArea.addLoader(this.ctx.autoCompactionLoader);
 		this.ctx.ui.requestRender();
 	}
 
@@ -869,9 +914,8 @@ export class EventController {
 			this.ctx.autoCompactionEscapeHandler = undefined;
 		}
 		if (this.ctx.autoCompactionLoader) {
-			this.ctx.autoCompactionLoader.stop();
+			this.#statusArea.removeLoader(this.ctx.autoCompactionLoader);
 			this.ctx.autoCompactionLoader = undefined;
-			this.ctx.statusContainer.clear();
 		}
 		this.ctx.updateEditorBorderColor();
 		const isHandoffAction = event.action === "handoff";
@@ -939,9 +983,13 @@ export class EventController {
 				this.ctx.session.abortRetry();
 			}
 		};
-		this.ctx.statusContainer.clear();
-		// Stop any prior retry loader/timer before installing a new one.
-		this.ctx.retryLoader?.stop();
+		// Hide the working loader during backoff. The reserve records the rows
+		// before removal, so the swap never contracts even when the
+		// replacement retry status is shorter (e.g. narrow terminals).
+		this.#statusArea.removeLoader(this.ctx.loadingAnimation);
+		this.ctx.loadingAnimation = undefined;
+		this.#statusArea.removeLoader(this.ctx.retryLoader);
+		this.ctx.retryLoader = undefined;
 		this.#clearRetryCountdown();
 		const reason = friendlyRetryReason(event.errorMessage);
 		const attemptLabel = event.unbounded ? `attempt ${event.attempt}` : `${event.attempt}/${event.maxAttempts}`;
@@ -963,7 +1011,7 @@ export class EventController {
 		this.ctx.retryCountdownTimer = setInterval(() => {
 			retryLoader.setMessage(buildMessage());
 		}, 1000);
-		this.ctx.statusContainer.addChild(retryLoader);
+		this.#statusArea.addLoader(retryLoader);
 		this.ctx.ui.requestRender();
 	}
 
@@ -973,10 +1021,9 @@ export class EventController {
 			this.ctx.retryEscapeHandler = undefined;
 		}
 		if (this.ctx.retryLoader) {
-			this.ctx.retryLoader.stop();
 			this.#clearRetryCountdown();
+			this.#statusArea.removeLoader(this.ctx.retryLoader);
 			this.ctx.retryLoader = undefined;
-			this.ctx.statusContainer.clear();
 		}
 		this.ctx.retryEscapePrimed = false;
 		if (!event.success) {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1942,7 +1942,7 @@ export class SelectorController {
 							"Summarizing branch... (esc to cancel)",
 							getSymbolTheme().spinnerFrames,
 						);
-						this.ctx.statusContainer.addChild(summaryLoader);
+						this.ctx.statusArea.addLoader(summaryLoader);
 						this.ctx.ui.requestRender();
 					}
 
@@ -1973,10 +1973,7 @@ export class SelectorController {
 					} catch (error) {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
 					} finally {
-						if (summaryLoader) {
-							summaryLoader.stop();
-							this.ctx.statusContainer.clear();
-						}
+						this.ctx.statusArea.removeLoader(summaryLoader);
 						this.ctx.editor.onEscape = originalOnEscape;
 					}
 				},

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -86,6 +86,7 @@ import { OAuthManualInputManager } from "./oauth-manual-input";
 import { SessionObserverRegistry } from "./session-observer-registry";
 import { interruptHint } from "./shared";
 import { shouldShowExtensionCommand } from "./slash-command-visibility";
+import { StatusArea } from "./status-area";
 import { TasksAggregator } from "./tasks-aggregator";
 import { type ShimmerPalette, shimmerSegments, shimmerText } from "./theme/shimmer";
 import type { Theme } from "./theme/theme";
@@ -277,6 +278,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	chatContainer: Container;
 	pendingMessagesContainer: Container;
 	statusContainer: Container;
+	// Initialized before ui/statusContainer are assigned in the constructor:
+	// StatusArea must only read its context lazily inside its methods.
+	readonly statusArea: StatusArea = new StatusArea(this);
 	todoContainer: Container;
 	btwContainer: Container;
 	editor: CustomEditor;
@@ -963,9 +967,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#pendingWorkingMessage = undefined;
 		this.#goalModeController.onPendingSubmissionFinished(submission.customType);
 		if (this.loadingAnimation) {
-			this.loadingAnimation.stop();
+			this.statusArea.removeLoader(this.loadingAnimation);
 			this.loadingAnimation = undefined;
-			this.statusContainer.clear();
 		}
 		if (!submission.customType) {
 			this.pendingImages = submission.images ? [...submission.images] : [];
@@ -999,9 +1002,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			pendingSubmissionDispose?.();
 			this.#pendingWorkingMessage = undefined;
 			if (this.loadingAnimation) {
-				this.loadingAnimation.stop();
+				this.statusArea.removeLoader(this.loadingAnimation);
 				this.loadingAnimation = undefined;
-				this.statusContainer.clear();
 			}
 		}
 	}
@@ -1447,9 +1449,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#pendingSubmissionDispose = undefined;
 		this.#pendingWorkingMessage = undefined;
 		if (this.loadingAnimation) {
-			this.loadingAnimation.stop();
+			this.statusArea.removeLoader(this.loadingAnimation);
 			this.loadingAnimation = undefined;
-			this.statusContainer.clear();
 		}
 		this.#uiHelpers.showError(message);
 	}
@@ -1498,7 +1499,6 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	ensureLoadingAnimation(): void {
 		if (!this.loadingAnimation) {
-			this.statusContainer.clear();
 			this.loadingAnimation = new Loader(
 				this.ui,
 				spinner => {
@@ -1510,7 +1510,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				getSymbolTheme().spinnerFrames,
 				{ timeDependentColor: true },
 			);
-			this.statusContainer.addChild(this.loadingAnimation);
+			this.statusArea.addLoader(this.loadingAnimation);
 		}
 
 		this.applyPendingWorkingMessage();

--- a/packages/coding-agent/src/modes/status-area.ts
+++ b/packages/coding-agent/src/modes/status-area.ts
@@ -1,0 +1,80 @@
+import type { Loader } from "@gajae-code/tui";
+import { StatusRowReserve } from "./components/status-row-reserve";
+import type { InteractiveModeContext } from "./types";
+
+type StatusAreaContext = Pick<InteractiveModeContext, "ui" | "statusContainer">;
+
+/**
+ * Single owner of transient status-slot install and teardown.
+ *
+ * Process terminals cannot report the user's scrollback position, so removing
+ * status rows contracts the bottom area and forces a repaint that can replace
+ * transcript rows the user is browsing. Every transient loader (working,
+ * retry, compaction, handoff, summary, debug-report) MUST be installed with
+ * {@link addLoader} and torn down with {@link removeLoader}: teardown records
+ * the visible rows into a high-water {@link StatusRowReserve} before removing
+ * only that loader, so completion, cancel, error, retry, and compaction
+ * transitions never contract the status area.
+ *
+ * `statusContainer.clear()` remains reserved for whole-session resets —
+ * switching, creating, or forking a session, replacing the transcript
+ * identity, and shutdown — where the entire screen is legitimately rebuilt
+ * and the reservation must die with it. Clearing drops the reserve component;
+ * the next capture lazily re-creates it and stale registry entries are pruned
+ * on the next measure.
+ */
+export class StatusArea {
+	#reserve: StatusRowReserve | undefined = undefined;
+	#transient = new Set<Loader>();
+
+	constructor(private ctx: StatusAreaContext) {}
+
+	#measureLiveLines = (width: number): number => {
+		let lines = 0;
+		for (const loader of this.#transient) {
+			// Prune loaders removed behind our back (e.g. a full-session clear).
+			if (!this.ctx.statusContainer.children.includes(loader)) {
+				this.#transient.delete(loader);
+				continue;
+			}
+			lines += loader.render(width).length;
+		}
+		return lines;
+	};
+
+	/** Installs a transient loader and records its rows into the reserve. */
+	addLoader(loader: Loader): void {
+		this.#transient.add(loader);
+		this.ctx.statusContainer.addChild(loader);
+		this.capture();
+	}
+
+	/**
+	 * Records the current transient rows into the high-water reserve. Called
+	 * automatically by {@link addLoader} and {@link removeLoader}.
+	 */
+	capture(): void {
+		if (!this.ctx.ui.terminal?.isProcessTerminal) return;
+		const width = this.ctx.ui.terminal.columns;
+		if (!this.#reserve || !this.ctx.statusContainer.children.includes(this.#reserve)) {
+			// Nothing to reserve yet: avoid installing an empty component.
+			if (this.#measureLiveLines(width) === 0) return;
+			this.#reserve = new StatusRowReserve(this.#measureLiveLines);
+			this.ctx.statusContainer.addChild(this.#reserve);
+		}
+		this.#reserve.capture(width);
+	}
+
+	/**
+	 * Targeted teardown for one transient loader: stop it, record its rows
+	 * into the reserve, then remove only that child. Never contracts the
+	 * status area and never touches sibling components.
+	 */
+	removeLoader(loader: Loader | undefined): void {
+		if (!loader) return;
+		loader.stop();
+		if (this.#transient.has(loader)) this.capture();
+		this.#transient.delete(loader);
+		this.ctx.statusContainer.removeChild(loader);
+	}
+}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -32,6 +32,7 @@ import type { ToolExecutionHandle } from "./components/tool-execution";
 import type { StatusLineComponent } from "./components/tool-status-header";
 import type { IrcObservationLedger } from "./irc-observation-ledger";
 import type { OAuthManualInputManager } from "./oauth-manual-input";
+import type { StatusArea } from "./status-area";
 import type { Theme } from "./theme/theme";
 import type { ParsedIrcMessage } from "./utils/irc-message";
 
@@ -90,6 +91,8 @@ export interface InteractiveModeContext {
 	chatContainer: Container;
 	pendingMessagesContainer: Container;
 	statusContainer: Container;
+	/** Single owner of transient status-slot teardown; see StatusArea docs. */
+	statusArea: StatusArea;
 	todoContainer: Container;
 	btwContainer: Container;
 	editor: CustomEditor;

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -663,4 +663,49 @@ describe("InteractiveMode.setEditorComponent", () => {
 			setTerminalImageProtocol(originalProtocol);
 		}
 	});
+	it("preserves independently owned status components when starting the real working loader", () => {
+		const independentStatus = new Text("independent status", 0, 0);
+		mode.statusContainer.addChild(independentStatus);
+
+		mode.ensureLoadingAnimation();
+
+		const loadingAnimation = mode.loadingAnimation;
+		expect(loadingAnimation).toBeDefined();
+		if (!loadingAnimation) throw new Error("Expected the working loader");
+		expect(mode.statusContainer.children).toContain(independentStatus);
+		expect(mode.statusContainer.children).toContain(loadingAnimation);
+		loadingAnimation.stop();
+	});
+	it("error teardown removes only the working loader and keeps independent status", () => {
+		vi.spyOn(mode, "renderSessionContext").mockImplementation(() => undefined);
+		const independentStatus = new Text("independent status", 0, 0);
+		mode.statusContainer.addChild(independentStatus);
+
+		mode.ensureLoadingAnimation();
+		const workingLoader = mode.loadingAnimation;
+		expect(workingLoader).toBeDefined();
+
+		mode.showError("boom");
+
+		expect(mode.loadingAnimation).toBeUndefined();
+		expect(mode.statusContainer.children).not.toContain(workingLoader);
+		expect(mode.statusContainer.children).toContain(independentStatus);
+	});
+	it("cancel teardown removes only the working loader and keeps independent status", () => {
+		vi.spyOn(mode, "renderSessionContext").mockImplementation(() => undefined);
+		const independentStatus = new Text("independent status", 0, 0);
+		mode.statusContainer.addChild(independentStatus);
+
+		mode.startPendingSubmission({ text: "hello" });
+		mode.ensureLoadingAnimation();
+		const workingLoader = mode.loadingAnimation;
+		expect(workingLoader).toBeDefined();
+
+		expect(mode.cancelPendingSubmission()).toBe(true);
+
+		expect(mode.loadingAnimation).toBeUndefined();
+		expect(mode.statusContainer.children).not.toContain(workingLoader);
+		expect(mode.statusContainer.children).toContain(independentStatus);
+		expect(mode.editor.getText()).toBe("hello");
+	});
 });

--- a/packages/coding-agent/test/issue-927-repro.test.ts
+++ b/packages/coding-agent/test/issue-927-repro.test.ts
@@ -9,6 +9,7 @@ import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { Loader } from "@gajae-code/tui";
 import { TempDir } from "@gajae-code/utils";
 
 describe("issue #927 optimistic pending spinner", () => {
@@ -69,6 +70,7 @@ describe("issue #927 optimistic pending spinner", () => {
 		expect(mode.loadingAnimation).toBeUndefined();
 		expect(mode.optimisticUserMessageSignature).toBeUndefined();
 		expect(mode.locallySubmittedUserSignatures.has("/extension-no-turn\u00000")).toBe(false);
-		expect(mode.statusContainer.children.length).toBe(0);
+		// The status row reserve may legitimately remain; no loader may.
+		expect(mode.statusContainer.children.filter(child => child instanceof Loader)).toHaveLength(0);
 	});
 });

--- a/packages/coding-agent/test/modes/components/status-row-reserve.test.ts
+++ b/packages/coding-agent/test/modes/components/status-row-reserve.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { StatusRowReserve } from "@gajae-code/coding-agent/modes/components/status-row-reserve";
+import { Loader, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
+
+describe("StatusRowReserve", () => {
+	it("pads to the high-water mark and never contracts at a stable width", () => {
+		let live = 3;
+		const reserve = new StatusRowReserve(() => live);
+		expect(reserve.render(40)).toEqual([]);
+		live = 5;
+		expect(reserve.render(40)).toEqual([]);
+		live = 2;
+		expect(reserve.render(40)).toEqual(["", "", ""]);
+		live = 0;
+		expect(reserve.render(40)).toEqual(["", "", "", "", ""]);
+	});
+
+	it("captures rows outside render frames and resets the reservation on resize", () => {
+		let live = 4;
+		const reserve = new StatusRowReserve(() => live);
+		reserve.capture(40);
+		live = 0;
+		expect(reserve.render(40)).toHaveLength(4);
+		// A resize reflows and repaints the viewport anyway; the reservation
+		// restarts from the post-resize live rows.
+		live = 1;
+		expect(reserve.render(20)).toHaveLength(0);
+		live = 0;
+		expect(reserve.render(20)).toHaveLength(1);
+	});
+
+	it("reserves the wrapped row count of ANSI and Unicode status text per width", () => {
+		const term = new VirtualTerminal(40, 4);
+		const tui = new TUI(term);
+		const loader = new Loader(
+			tui,
+			text => `\x1b[36m${text}\x1b[0m`,
+			text => `\x1b[35m${text}\x1b[0m`,
+			"한글🙂 e\u0301 café — wrapping status",
+			["|"],
+		);
+		let removed = false;
+		const reserve = new StatusRowReserve(width => (removed ? 0 : loader.render(width).length));
+		for (const width of [4, 7, 16, 40]) {
+			removed = false;
+			const liveRows = loader.render(width).length;
+			expect(liveRows, `width=${width}`).toBeGreaterThan(1);
+			reserve.capture(width);
+			removed = true;
+			expect(reserve.render(width), `width=${width}`).toEqual(Array.from({ length: liveRows }, () => ""));
+		}
+		loader.stop();
+		tui.stop();
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/completion-fixtures.ts
+++ b/packages/coding-agent/test/modes/controllers/completion-fixtures.ts
@@ -1,0 +1,22 @@
+import type { AssistantMessage } from "@gajae-code/ai";
+
+/** Minimal assistant message fixture for completion lifecycle tests. */
+export function assistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}

--- a/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
@@ -13,7 +13,7 @@ type AutoCompactionFixture = {
 	showWarning: Mock<(message: string) => void>;
 	flushCompactionQueue: Mock<(options: { willRetry: boolean }) => Promise<void>>;
 	loaderStop: Mock<() => void>;
-	statusContainerClear: Mock<() => void>;
+	statusContainerRemoveChild: Mock<(component: unknown) => void>;
 	rebuildChatFromMessages: Mock<(policy: "replace-identity" | "reconcile-same-transcript") => void>;
 };
 
@@ -22,8 +22,8 @@ function createFixture(): AutoCompactionFixture {
 	const loaderStop = vi.fn(() => {
 		order.push("loader.stop");
 	});
-	const statusContainerClear = vi.fn(() => {
-		order.push("statusContainer.clear");
+	const statusContainerRemoveChild = vi.fn(() => {
+		order.push("statusContainer.removeChild");
 	});
 	const showStatus = vi.fn(() => {
 		order.push("showStatus");
@@ -45,7 +45,7 @@ function createFixture(): AutoCompactionFixture {
 		autoCompactionEscapeHandler: () => order.push("originalEscape"),
 		autoCompactionLoader: { stop: loaderStop },
 		editor: { onEscape: () => order.push("temporaryEscape") },
-		statusContainer: { clear: statusContainerClear },
+		statusContainer: { removeChild: statusContainerRemoveChild, children: [] },
 		statusLine: {
 			invalidate: vi.fn(() => {
 				order.push("statusLine.invalidate");
@@ -81,7 +81,7 @@ function createFixture(): AutoCompactionFixture {
 		showWarning,
 		flushCompactionQueue,
 		loaderStop,
-		statusContainerClear,
+		statusContainerRemoveChild,
 		rebuildChatFromMessages,
 	};
 }
@@ -111,7 +111,7 @@ describe("EventController auto-compaction overflow status", () => {
 		});
 
 		expect(fixture.loaderStop).toHaveBeenCalledTimes(1);
-		expect(fixture.statusContainerClear).toHaveBeenCalledTimes(1);
+		expect(fixture.statusContainerRemoveChild).toHaveBeenCalledTimes(1);
 		expect(fixture.ctx.autoCompactionLoader).toBeUndefined();
 		expect(fixture.showStatus).toHaveBeenCalledWith("Context overflow maintenance completed");
 		expect(fixture.showWarning).not.toHaveBeenCalled();
@@ -134,7 +134,7 @@ describe("EventController auto-compaction overflow status", () => {
 		expect(fixture.ctx.autoCompactionLoader).toBeUndefined();
 		expect(fixture.showStatus).toHaveBeenCalledWith("Context overflow maintenance skipped");
 		expect(fixture.showWarning).not.toHaveBeenCalled();
-		expect(fixture.order.indexOf("statusContainer.clear")).toBeLessThan(fixture.order.indexOf("showStatus"));
+		expect(fixture.order.indexOf("statusContainer.removeChild")).toBeLessThan(fixture.order.indexOf("showStatus"));
 		expect(fixture.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: true });
 	});
 

--- a/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
@@ -379,7 +379,11 @@ describe("EventController completion viewport", () => {
 							const firstRetryLoader = ctx.retryLoader;
 							expect(firstRetryLoader).toBeDefined();
 							if (!firstRetryLoader) throw new Error("retry start did not install a loader");
-							expect(statusContainer.children).toEqual([residualStatus, reserve, firstRetryLoader]);
+							expect(statusContainer.children).toEqual([
+								residualStatus,
+								...(reserve ? [reserve] : []),
+								firstRetryLoader,
+							]);
 
 							await controller.handleEvent({
 								type: "auto_retry_start",
@@ -393,7 +397,11 @@ describe("EventController completion viewport", () => {
 							expect(secondRetryLoader).toBeDefined();
 							if (!secondRetryLoader) throw new Error("repeated retry start did not replace the loader");
 							expect(secondRetryLoader).not.toBe(firstRetryLoader);
-							expect(statusContainer.children).toEqual([residualStatus, reserve, secondRetryLoader]);
+							expect(statusContainer.children).toEqual([
+								residualStatus,
+								...(reserve ? [reserve] : []),
+								secondRetryLoader,
+							]);
 
 							await controller.handleEvent({ type: "auto_retry_end", success: true, attempt: 2 });
 							await term.waitForRender();

--- a/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
@@ -1,10 +1,11 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
-import type { AssistantMessage } from "@gajae-code/ai";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
 import { IrcSplitViewComponent } from "@gajae-code/coding-agent/modes/components/irc-sidebar";
+import { StatusRowReserve } from "@gajae-code/coding-agent/modes/components/status-row-reserve";
 import { EventController } from "@gajae-code/coding-agent/modes/controllers/event-controller";
 import { IrcObservationLedger } from "@gajae-code/coding-agent/modes/irc-observation-ledger";
+import { StatusArea } from "@gajae-code/coding-agent/modes/status-area";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
 import { UiHelpers } from "@gajae-code/coding-agent/modes/utils/ui-helpers";
@@ -12,28 +13,10 @@ import {
 	associateSessionMessageViewportAnchorId,
 	getSessionMessageViewportAnchorId,
 } from "@gajae-code/coding-agent/session/session-manager";
-import { Container, shouldUseViewportRepaintForHost, Text, TUI } from "@gajae-code/tui";
+import { Container, Loader, shouldUseViewportRepaintForHost, Text, TUI } from "@gajae-code/tui";
 import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
 
-function assistantMessage(text: string): AssistantMessage {
-	return {
-		role: "assistant",
-		content: [{ type: "text", text }],
-		api: "anthropic-messages",
-		provider: "anthropic",
-		model: "mock",
-		usage: {
-			input: 0,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
-			totalTokens: 0,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-		},
-		stopReason: "stop",
-		timestamp: Date.now(),
-	};
-}
+import { assistantMessage } from "./completion-fixtures";
 
 beforeAll(async () => {
 	await Settings.init({ inMemory: true, cwd: process.cwd() });
@@ -79,6 +62,15 @@ describe("EventController completion viewport", () => {
 			env: Partial<Record<(typeof envKeys)[number], string>>;
 			resizeHeight?: number;
 			nativeWindows?: boolean;
+			isProcessTerminal?: boolean;
+			initialLoaderMessage?: string;
+			noInitialLoader?: boolean;
+			initialSpinnerFrames?: string[];
+			residualStatus?: boolean;
+			expectEmptyLoader?: boolean;
+			initialRetryLoader?: boolean;
+			testActiveLoaderRetry?: boolean;
+			width?: number;
 		}> = [
 			{ label: "plain-ssh", env: { SSH_CONNECTION: "client server", TERM: "xterm-256color" } },
 			{ label: "tmux-default", env: { TMUX: "/tmp/tmux,1,0", TERM: "tmux-256color" } },
@@ -92,6 +84,48 @@ describe("EventController completion viewport", () => {
 				env: { WT_SESSION: "forwarded", TERM_PROGRAM: "Windows_Terminal", TERM: "xterm-256color" },
 			},
 			{ label: "native-windows-selector", env: { TERM: "xterm-256color" }, nativeWindows: true },
+			{ label: "virtual-terminal", env: { TERM: "xterm-256color" }, isProcessTerminal: false },
+			{
+				label: "empty-loader",
+				env: { TERM: "xterm-256color" },
+				initialLoaderMessage: "",
+				initialSpinnerFrames: [""],
+				expectEmptyLoader: true,
+			},
+			{ label: "loader-unrelated-status", env: { TERM: "xterm-256color" }, residualStatus: true },
+			{
+				label: "active-loader-retry-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				residualStatus: true,
+				testActiveLoaderRetry: true,
+			},
+			{
+				label: "virtual-loader-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				isProcessTerminal: false,
+				residualStatus: true,
+			},
+			{ label: "empty-status", env: { TERM: "xterm-256color" }, noInitialLoader: true },
+			{
+				label: "no-loader-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				noInitialLoader: true,
+				residualStatus: true,
+			},
+			{
+				label: "retry-unrelated-status",
+				env: { TERM: "xterm-256color" },
+				noInitialLoader: true,
+				residualStatus: true,
+				initialRetryLoader: true,
+			},
+			{
+				label: "narrow-tall-retry-short-replacement",
+				env: { TERM: "xterm-256color" },
+				residualStatus: true,
+				testActiveLoaderRetry: true,
+				width: 26,
+			},
 		];
 
 		for (const testCase of cases) {
@@ -105,7 +139,9 @@ describe("EventController completion viewport", () => {
 						expect(shouldUseViewportRepaintForHost({}, "win32", { includeNativeWindows: true })).toBe(true);
 					}
 
-					const term = new VirtualTerminal(40, 18, { isProcessTerminal: true });
+					const term = new VirtualTerminal(testCase.width ?? 40, 18, {
+						isProcessTerminal: testCase.isProcessTerminal ?? true,
+					});
 					const ui = new TUI(term);
 					ui.setClearOnShrink(clearOnShrink);
 					const chatContainer = new Container();
@@ -121,7 +157,32 @@ describe("EventController completion viewport", () => {
 					});
 					const pendingMessagesContainer = new Container();
 					const statusContainer = new Container();
-					statusContainer.addChild(new Text("working", 0, 0));
+					const statusArea = new StatusArea({ ui, statusContainer });
+					const loadingAnimation = testCase.noInitialLoader
+						? undefined
+						: new Loader(
+								ui,
+								value => value,
+								value => value,
+								testCase.initialLoaderMessage ?? "working",
+								testCase.initialSpinnerFrames ?? ["|"],
+							);
+					const residualStatus = testCase.residualStatus ? new Text("independent status", 0, 0) : undefined;
+					if (residualStatus) statusContainer.addChild(residualStatus);
+					if (loadingAnimation) statusArea.addLoader(loadingAnimation);
+					const retryLoader = testCase.initialRetryLoader
+						? new Loader(
+								ui,
+								value => value,
+								value => value,
+								"retrying",
+								["|"],
+							)
+						: undefined;
+					if (retryLoader) statusArea.addLoader(retryLoader);
+					const retainedStatus = [residualStatus, retryLoader].filter(
+						(component): component is Text | Loader => component !== undefined,
+					);
 					const todoContainer = new Container();
 					const btwContainer = new Container();
 					const statusLine = new Text("status", 0, 0);
@@ -135,13 +196,30 @@ describe("EventController completion viewport", () => {
 					ui.addChild(statusLine);
 					ui.addChild(editor);
 					ui.setBottomPinnedComponent(statusLine);
-					const stopLoading = vi.fn();
-					const ctx = {
+					const initialFootprint = loadingAnimation?.render(term.columns).map(() => "");
+					let expectedFootprint = initialFootprint ?? retryLoader?.render(term.columns).map(() => "");
+					if (testCase.expectEmptyLoader) expect(initialFootprint).toEqual([""]);
+					let replacementLoader: Loader | undefined;
+					let ctx: InteractiveModeContext;
+					const ensureLoadingAnimation = (): void => {
+						if (ctx.loadingAnimation) return;
+						replacementLoader = new Loader(
+							ui,
+							value => value,
+							value => value,
+							"working",
+							["|"],
+						);
+						ctx.loadingAnimation = replacementLoader;
+						statusArea.addLoader(replacementLoader);
+					};
+					ctx = {
 						isInitialized: true,
 						ui,
 						chatContainer,
 						pendingMessagesContainer,
 						statusContainer,
+						statusArea,
 						todoContainer,
 						btwContainer,
 						statusLine,
@@ -149,7 +227,9 @@ describe("EventController completion viewport", () => {
 						getUserMessageText: (userMessage: { content: string }) => userMessage.content,
 						streamingComponent,
 						streamingMessage: startMessage,
-						loadingAnimation: { stop: stopLoading },
+						loadingAnimation,
+						ensureLoadingAnimation,
+						retryLoader,
 						pendingTools: new Map(),
 						planModeController: { flushPendingModelSwitch: async () => {} },
 						updateEditorTopBorder: () => {},
@@ -157,6 +237,8 @@ describe("EventController completion viewport", () => {
 						session: {
 							isTtsrAbortPending: false,
 							retryAttempt: 0,
+							retryNow: () => {},
+							abortRetry: () => {},
 							isCompacting: true,
 							getLastAssistantMessage: () => message,
 						},
@@ -184,27 +266,221 @@ describe("EventController completion viewport", () => {
 						);
 						expect(beforeHistory.length, JSON.stringify(before)).toBeGreaterThanOrEqual(3);
 						term.clearWriteLog();
+						if (testCase.testActiveLoaderRetry) {
+							if (!loadingAnimation || !residualStatus) {
+								throw new Error("active retry case requires loading and residual status");
+							}
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 1,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const activeRetryLoader = ctx.retryLoader;
+							expect(activeRetryLoader).toBeDefined();
+							if (!activeRetryLoader) throw new Error("retry start did not install a loader");
+							expect(ctx.loadingAnimation).toBeUndefined();
+							const activeReserve = statusContainer.children.find(child => child instanceof StatusRowReserve);
+							expect(activeReserve).toBeDefined();
+							if (!activeReserve) throw new Error("retry start did not install a status reserve");
+							expect(statusContainer.children).toEqual([residualStatus, activeReserve, activeRetryLoader]);
+							term.clearWriteLog();
+
+							await controller.handleEvent({ type: "auto_retry_end", success: true, attempt: 1 });
+							await term.waitForRender();
+							expect(ctx.retryLoader).toBeUndefined();
+							const retryFootprint = activeRetryLoader.render(term.columns).map(() => "");
+							if (term.isProcessTerminal) {
+								expectedFootprint = retryFootprint;
+								expect(statusContainer.render(term.columns)).toEqual([
+									...residualStatus.render(term.columns),
+									...retryFootprint,
+								]);
+								const afterRetryEnd = term.getViewport().map(line => line.trimEnd());
+								for (const entry of beforeHistory) expect(afterRetryEnd[entry.index]).toBe(entry.line);
+								for (const entry of beforeHistory) {
+									expect(term.getWriteLog().join("")).not.toContain(entry.line);
+								}
+								// Resumed turn after a successful retry: a fresh working
+								// loader appears; the high-water reserve keeps the row
+								// budget so neither the resume nor the completion after it
+								// contracts the status area.
+								ctx.ensureLoadingAnimation();
+								await term.waitForRender();
+								const resumedLoader = ctx.loadingAnimation;
+								expect(resumedLoader).toBeDefined();
+								if (!resumedLoader) throw new Error("resume did not install a loader");
+								expect(statusContainer.children).toHaveLength(3);
+							} else {
+								expect(statusContainer.children).toEqual([residualStatus]);
+							}
+						}
 						await controller.handleEvent({ type: "message_end", message });
 						expect(getSessionMessageViewportAnchorId(message)).toBe(anchorId);
 						await term.waitForRender();
+						term.clearWriteLog();
 						await controller.handleEvent({ type: "agent_end", messages: [message] });
 						await term.waitForRender();
-						expect(stopLoading, `${testCase.label} clear=${clearOnShrink}`).toHaveBeenCalledTimes(1);
 						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBeUndefined();
-						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(0);
-						const after = term.getViewport().map(line => line.trimEnd());
-						for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
-						const writes = term.getWriteLog().join("");
-						expect(writes).not.toContain("\x1b[2J\x1b[H");
-						expect(writes).not.toContain("\x1b[3J");
-						const visibleHistoryNumbers = beforeHistory.flatMap(entry => {
-							const match = /history-(\d+)/.exec(entry.line);
-							return match ? [Number(match[1])] : [];
-						});
-						const firstVisibleHistory = Math.min(...visibleHistoryNumbers);
-						for (let index = 0; index < firstVisibleHistory; index++) {
-							expect(writes).not.toMatch(new RegExp(`history-${index}(?!\\d)`));
+						const reserve = statusContainer.children.find(child => child instanceof StatusRowReserve);
+						if (term.isProcessTerminal && expectedFootprint) {
+							expect(reserve, `${testCase.label} clear=${clearOnShrink}`).toBeDefined();
+							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(
+								residualStatus ? 2 : 1,
+							);
+							if (residualStatus) expect(statusContainer.children[0]).toBe(residualStatus);
+							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual([
+								...(residualStatus ? residualStatus.render(term.columns) : []),
+								...expectedFootprint,
+							]);
+							const after = term.getViewport().map(line => line.trimEnd());
+							for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
+							const writes = term.getWriteLog().join("");
+							expect(writes).not.toContain("\x1b[2J\x1b[H");
+							expect(writes).not.toContain("\x1b[3J");
+							for (const entry of beforeHistory) {
+								expect(writes, `${testCase.label} clear=${clearOnShrink}`).not.toContain(entry.line);
+							}
+							const visibleHistoryNumbers = beforeHistory.flatMap(entry => {
+								const match = /history-(\d+)/.exec(entry.line);
+								return match ? [Number(match[1])] : [];
+							});
+							const firstVisibleHistory = Math.min(...visibleHistoryNumbers);
+							for (let index = 0; index < firstVisibleHistory; index++) {
+								expect(writes).not.toMatch(new RegExp(`history-${index}(?!\\d)`));
+							}
+						} else {
+							expect(reserve, `${testCase.label} clear=${clearOnShrink}`).toBeUndefined();
+							expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toEqual(
+								retryLoader
+									? [residualStatus].filter((component): component is Text => component !== undefined)
+									: retainedStatus,
+							);
+							expect(statusContainer.render(term.columns), `${testCase.label} clear=${clearOnShrink}`).toEqual(
+								(retryLoader ? [residualStatus] : retainedStatus)
+									.filter((component): component is Text | Loader => component !== undefined)
+									.flatMap(component => component.render(term.columns)),
+							);
 						}
+						if (retryLoader) {
+							await controller.handleEvent({ type: "agent_start" });
+							await term.waitForRender();
+							if (!residualStatus) throw new Error("retry ownership case requires residual status");
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 1,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const firstRetryLoader = ctx.retryLoader;
+							expect(firstRetryLoader).toBeDefined();
+							if (!firstRetryLoader) throw new Error("retry start did not install a loader");
+							expect(statusContainer.children).toEqual([residualStatus, reserve, firstRetryLoader]);
+
+							await controller.handleEvent({
+								type: "auto_retry_start",
+								attempt: 2,
+								maxAttempts: 3,
+								delayMs: 10_000,
+								errorMessage: "retry",
+							});
+							await term.waitForRender();
+							const secondRetryLoader = ctx.retryLoader;
+							expect(secondRetryLoader).toBeDefined();
+							if (!secondRetryLoader) throw new Error("repeated retry start did not replace the loader");
+							expect(secondRetryLoader).not.toBe(firstRetryLoader);
+							expect(statusContainer.children).toEqual([residualStatus, reserve, secondRetryLoader]);
+
+							await controller.handleEvent({ type: "auto_retry_end", success: true, attempt: 2 });
+							await term.waitForRender();
+							expect(ctx.retryLoader).toBeUndefined();
+							const retryFootprint = secondRetryLoader.render(term.columns).map(() => "");
+							if (term.isProcessTerminal) {
+								expectedFootprint = retryFootprint;
+								expect(statusContainer.render(term.columns)).toEqual([
+									...residualStatus.render(term.columns),
+									...retryFootprint,
+								]);
+							} else {
+								expect(statusContainer.children).toEqual([residualStatus]);
+							}
+						}
+
+						if (term.isProcessTerminal && expectedFootprint) {
+							const completionChildren = [...statusContainer.children];
+							await controller.handleEvent({ type: "agent_end", messages: [message] });
+							await term.waitForRender();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} duplicate completion`,
+							).toEqual(completionChildren);
+						}
+						term.clearWriteLog();
+						await controller.handleEvent({ type: "agent_start" });
+						await term.waitForRender();
+						expect(replacementLoader, `${testCase.label} clear=${clearOnShrink}`).toBeDefined();
+						if (!replacementLoader) throw new Error("agent start did not replace the completion footprint");
+						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBe(replacementLoader);
+						if (retryLoader) expect(ctx.retryLoader).toBeUndefined();
+						const startReserve = statusContainer.children.find(child => child instanceof StatusRowReserve);
+						if (term.isProcessTerminal) {
+							expect(startReserve, `${testCase.label} clear=${clearOnShrink} start reserve`).toBeDefined();
+						} else {
+							expect(startReserve, `${testCase.label} clear=${clearOnShrink} start reserve`).toBeUndefined();
+						}
+						expect(
+							statusContainer.children.filter(child => !(child instanceof StatusRowReserve)),
+							`${testCase.label} clear=${clearOnShrink}`,
+						).toEqual([...(residualStatus ? [residualStatus] : []), replacementLoader]);
+						if (term.isProcessTerminal) {
+							// Starting a successor turn must not contract the status area
+							// (the fresh short loader can replace a taller reserved
+							// status) and must not repaint browsed transcript rows.
+							const afterStart = term.getViewport().map(line => line.trimEnd());
+							for (const entry of beforeHistory) expect(afterStart[entry.index]).toBe(entry.line);
+							const startWrites = term.getWriteLog().join("");
+							for (const entry of beforeHistory) {
+								expect(startWrites, `${testCase.label} clear=${clearOnShrink} start`).not.toContain(entry.line);
+							}
+						}
+						const rapidEnd = controller.handleEvent({ type: "agent_end", messages: [message] });
+						const rapidStart = controller.handleEvent({ type: "agent_start" });
+						await Promise.all([rapidEnd, rapidStart]);
+						await term.waitForRender();
+						expect(
+							ctx.loadingAnimation,
+							`${testCase.label} clear=${clearOnShrink} rapid lifecycle`,
+						).toBeDefined();
+						expect(
+							statusContainer.children,
+							`${testCase.label} clear=${clearOnShrink} rapid lifecycle`,
+						).toHaveLength((term.isProcessTerminal ? 1 : 0) + (residualStatus ? 1 : 0) + 1);
+
+						for (let cycle = 0; cycle < 3; cycle++) {
+							await controller.handleEvent({ type: "agent_end", messages: [message] });
+							await term.waitForRender();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} completion`,
+							).toHaveLength((term.isProcessTerminal ? 1 : 0) + (residualStatus ? 1 : 0));
+
+							await controller.handleEvent({ type: "agent_start" });
+							await term.waitForRender();
+							expect(
+								ctx.loadingAnimation,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} restart`,
+							).toBeDefined();
+							expect(
+								statusContainer.children,
+								`${testCase.label} clear=${clearOnShrink} cycle=${cycle} restart`,
+							).toHaveLength((term.isProcessTerminal ? 1 : 0) + (residualStatus ? 1 : 0) + 1);
+						}
+
+						ctx.loadingAnimation?.stop();
 						term.clearWriteLog();
 						ui.requestRender();
 						await term.waitForRender();
@@ -217,5 +493,5 @@ describe("EventController completion viewport", () => {
 				}
 			}
 		}
-	});
+	}, 30_000);
 });

--- a/packages/coding-agent/test/modes/controllers/event-controller-lifecycle-ordering.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-lifecycle-ordering.test.ts
@@ -1,0 +1,223 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { EventController } from "@gajae-code/coding-agent/modes/controllers/event-controller";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { Container, Loader, Text, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
+import { assistantMessage } from "./completion-fixtures";
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+	await initTheme();
+});
+
+afterAll(() => resetSettingsForTest());
+
+describe("EventController lifecycle ordering", () => {
+	it("serializes completion before a successor start and ignores duplicate completion effects", async () => {
+		const term = new VirtualTerminal(40, 18, { isProcessTerminal: false });
+		const ui = new TUI(term);
+		const statusContainer = new Container();
+		const loadingAnimation = new Loader(
+			ui,
+			value => value,
+			value => value,
+			"working",
+			["|"],
+		);
+		statusContainer.addChild(loadingAnimation);
+		const flushStarted = Promise.withResolvers<void>();
+		const flushGate = Promise.withResolvers<void>();
+		let flushes = 0;
+		let ctx: InteractiveModeContext;
+		const successorTool = new Text("successor tool", 0, 0);
+		const ensureLoadingAnimation = (): void => {
+			if (ctx.loadingAnimation) return;
+			ctx.loadingAnimation = new Loader(
+				ui,
+				value => value,
+				value => value,
+				"successor working",
+				["|"],
+			);
+			statusContainer.addChild(ctx.loadingAnimation);
+			ctx.pendingTools.set("successor", successorTool as never);
+		};
+		ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer,
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "" },
+			loadingAnimation,
+			ensureLoadingAnimation,
+			pendingTools: new Map([["predecessor", new Text("predecessor tool", 0, 0) as never]]),
+			planModeController: {
+				flushPendingModelSwitch: async () => {
+					flushes++;
+					flushStarted.resolve();
+					await flushGate.promise;
+				},
+			},
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			session: {
+				isCompacting: true,
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+
+		const controller = new EventController(ctx);
+		const ending = controller.handleEvent({ type: "agent_end", messages: [] });
+		await flushStarted.promise;
+		const starting = controller.handleEvent({ type: "agent_start" });
+		await Promise.resolve();
+		expect(ctx.loadingAnimation).toBeUndefined();
+
+		flushGate.resolve();
+		await Promise.all([ending, starting]);
+		expect(ctx.loadingAnimation).toBeDefined();
+		expect(ctx.pendingTools.has("predecessor")).toBe(false);
+		expect(ctx.pendingTools.has("successor")).toBe(true);
+
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		expect(flushes).toBe(2);
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		expect(flushes).toBe(2);
+		ctx.loadingAnimation?.stop();
+	});
+	it("does not starve live events while a tool handler awaits plan approval", async () => {
+		const term = new VirtualTerminal(40, 12, { isProcessTerminal: false });
+		const ui = new TUI(term);
+		const approvalGate = Promise.withResolvers<void>();
+		const ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer: new Container(),
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "" },
+			ensureLoadingAnimation: () => {},
+			pendingTools: new Map(),
+			planModeController: {
+				flushPendingModelSwitch: async () => {},
+				handleApproval: async () => {
+					await approvalGate.promise;
+				},
+			},
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			toolOutputExpanded: false,
+			session: {
+				isCompacting: true,
+				getToolByName: () => undefined,
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+		const controller = new EventController(ctx);
+
+		const approval = controller.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: "approval-1",
+			toolName: "resolve",
+			isError: false,
+			result: {
+				content: [],
+				details: {
+					sourceToolName: "plan_approval",
+					action: "apply",
+					sourceResultDetails: { planFilePath: "local://PLAN.md" },
+				},
+			},
+		} as never);
+		let approvalSettled = false;
+		approval.then(() => {
+			approvalSettled = true;
+		});
+
+		// While the approval handler is parked on user interaction, live events
+		// and the lifecycle lane must still be processed to completion.
+		await controller.handleEvent({
+			type: "tool_execution_update",
+			toolCallId: "other",
+			partialResult: { content: [] },
+		} as never);
+		await controller.handleEvent({ type: "agent_start" } as never);
+		await controller.handleEvent({ type: "agent_end", messages: [] } as never);
+		expect(approvalSettled).toBe(false);
+
+		approvalGate.resolve();
+		await approval;
+	});
+	it("ignores a stale completion that arrives after a successor turn starts", async () => {
+		const term = new VirtualTerminal(40, 12, { isProcessTerminal: true });
+		const ui = new TUI(term);
+		const statusContainer = new Container();
+		const sessionState = { isStreaming: false };
+		let ctx: InteractiveModeContext;
+		const ensureLoadingAnimation = (): void => {
+			if (ctx.loadingAnimation) return;
+			ctx.loadingAnimation = new Loader(
+				ui,
+				value => value,
+				value => value,
+				"working",
+				["|"],
+			);
+			statusContainer.addChild(ctx.loadingAnimation);
+		};
+		ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer,
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "" },
+			ensureLoadingAnimation,
+			pendingTools: new Map(),
+			planModeController: { flushPendingModelSwitch: async () => {} },
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			session: {
+				isCompacting: true,
+				get isStreaming() {
+					return sessionState.isStreaming;
+				},
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		await controller.handleEvent({ type: "agent_start" });
+		const successorLoader = ctx.loadingAnimation;
+		expect(successorLoader).toBeDefined();
+		const successorTool = new Text("successor tool", 0, 0);
+		ctx.pendingTools.set("successor", successorTool as never);
+
+		// A duplicate of the previous turn's completion arrives after the
+		// successor already started and is actively streaming.
+		sessionState.isStreaming = true;
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		expect(ctx.loadingAnimation, "stale end must not stop the successor loader").toBe(successorLoader);
+		expect(ctx.pendingTools.has("successor")).toBe(true);
+
+		// The successor's own completion still lands normally.
+		sessionState.isStreaming = false;
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		expect(ctx.loadingAnimation).toBeUndefined();
+		expect(ctx.pendingTools.has("successor")).toBe(false);
+		successorLoader?.stop();
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/event-controller-status-teardown.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-status-teardown.test.ts
@@ -1,0 +1,224 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { IrcSplitViewComponent } from "@gajae-code/coding-agent/modes/components/irc-sidebar";
+import { EventController } from "@gajae-code/coding-agent/modes/controllers/event-controller";
+import { IrcObservationLedger } from "@gajae-code/coding-agent/modes/irc-observation-ledger";
+import { StatusArea } from "@gajae-code/coding-agent/modes/status-area";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { UiHelpers } from "@gajae-code/coding-agent/modes/utils/ui-helpers";
+import { Container, Loader, Text, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
+import { assistantMessage } from "./completion-fixtures";
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+	await initTheme();
+});
+
+afterAll(() => resetSettingsForTest());
+
+describe("EventController status teardown ownership", () => {
+	it("uses the active retry loader for direct completion cleanup and footprint", async () => {
+		const term = new VirtualTerminal(20, 8, { isProcessTerminal: true });
+		const ui = new TUI(term);
+		const statusContainer = new Container();
+		const residualStatus = new Text("independent status", 0, 0);
+		const loadingAnimation = new Loader(
+			ui,
+			value => value,
+			value => value,
+			"working",
+			["|"],
+		);
+		statusContainer.addChild(loadingAnimation);
+		statusContainer.addChild(residualStatus);
+		const originalEscape = (): void => {};
+		const ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer,
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "", onEscape: originalEscape },
+			loadingAnimation,
+			ensureLoadingAnimation: () => {},
+			pendingTools: new Map(),
+			planModeController: { flushPendingModelSwitch: async () => {} },
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			session: {
+				isCompacting: true,
+				retryNow: () => {},
+				abortRetry: () => {},
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+
+		const controller = new EventController(ctx);
+		await controller.handleEvent({
+			type: "auto_retry_start",
+			attempt: 1,
+			maxAttempts: 3,
+			delayMs: 10_000,
+			errorMessage: "retry",
+		});
+		const retryLoader = ctx.retryLoader;
+		expect(retryLoader).toBeDefined();
+		if (!retryLoader) throw new Error("retry start did not install a loader");
+		const retryFootprint = retryLoader.render(term.columns).map(() => "");
+		expect(ctx.retryCountdownTimer).toBeDefined();
+		expect(ctx.editor.onEscape).not.toBe(originalEscape);
+
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+
+		expect(ctx.retryLoader).toBeUndefined();
+		expect(ctx.retryCountdownTimer).toBeUndefined();
+		expect(ctx.editor.onEscape).toBe(originalEscape);
+		expect(statusContainer.render(term.columns)).toEqual([...residualStatus.render(term.columns), ...retryFootprint]);
+	});
+	it("auto compaction preserves independent status and the reserved row budget", async () => {
+		const term = new VirtualTerminal(40, 12, { isProcessTerminal: true });
+		const ui = new TUI(term);
+		const statusContainer = new Container();
+		const residualStatus = new Text("independent status", 0, 0);
+		const loadingAnimation = new Loader(
+			ui,
+			value => value,
+			value => value,
+			"working",
+			["|"],
+		);
+		statusContainer.addChild(loadingAnimation);
+		statusContainer.addChild(residualStatus);
+		const ctx = {
+			isInitialized: true,
+			ui,
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			statusContainer,
+			statusLine: { invalidate: () => {} },
+			editor: { getText: () => "", onEscape: undefined },
+			loadingAnimation,
+			ensureLoadingAnimation: () => {},
+			pendingTools: new Map(),
+			planModeController: { flushPendingModelSwitch: async () => {} },
+			updateEditorTopBorder: () => {},
+			updateEditorBorderColor: () => {},
+			showStatus: () => {},
+			showWarning: () => {},
+			flushCompactionQueue: async () => {},
+			session: {
+				isCompacting: true,
+				abortCompaction: () => {},
+				getLastAssistantMessage: () => assistantMessage("completed"),
+			},
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+			isBackgrounded: false,
+		} as unknown as InteractiveModeContext;
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({
+			type: "auto_compaction_start",
+			reason: "overflow",
+			action: "compact",
+		} as never);
+		expect(ctx.autoCompactionLoader).toBeDefined();
+		expect(statusContainer.children).toContain(loadingAnimation);
+		expect(statusContainer.children).toContain(residualStatus);
+		const peakRows = statusContainer.render(term.columns).length;
+
+		await controller.handleEvent({
+			type: "auto_compaction_end",
+			action: "compact",
+			aborted: true,
+		} as never);
+		expect(ctx.autoCompactionLoader).toBeUndefined();
+		expect(statusContainer.children).toContain(loadingAnimation);
+		expect(statusContainer.children).toContain(residualStatus);
+		// The reserve keeps the compaction loader's rows as blanks: the status
+		// area must not contract below its peak height.
+		expect(statusContainer.render(term.columns).length).toBeGreaterThanOrEqual(peakRows);
+		loadingAnimation.stop();
+	});
+	it("keeps browsed scrollback stable through an error or cancel loader teardown", async () => {
+		const previousTerm = Bun.env.TERM;
+		const previousNotify = Bun.env.GJC_NOTIFY;
+		Bun.env.TERM = "xterm-256color";
+		Bun.env.GJC_NOTIFY = "off";
+		const term = new VirtualTerminal(40, 18, { isProcessTerminal: true });
+		const ui = new TUI(term);
+		const chatContainer = new Container();
+		const split = new IrcSplitViewComponent(chatContainer, new IrcObservationLedger(), {
+			fg: (_color: "dim" | "accent", text: string) => text,
+			bold: (text: string) => text,
+			boxSharp: { vertical: "│" },
+		});
+		const statusContainer = new Container();
+		const statusArea = new StatusArea({ ui, statusContainer });
+		const residualStatus = new Text("independent status", 0, 0);
+		statusContainer.addChild(residualStatus);
+		const loader = new Loader(
+			ui,
+			value => value,
+			value => value,
+			"working on a long wrapped status message",
+			["|"],
+		);
+		statusArea.addLoader(loader);
+		const statusLine = new Text("status", 0, 0);
+		const editor = new Text("editor", 0, 0);
+		ui.addChild(split);
+		ui.setViewportAnchorComponent(split);
+		ui.addChild(statusContainer);
+		ui.addChild(statusLine);
+		ui.addChild(editor);
+		ui.setBottomPinnedComponent(statusLine);
+		const ctx = {
+			ui,
+			chatContainer,
+			pendingMessagesContainer: new Container(),
+			statusContainer,
+			getUserMessageText: (userMessage: { content: string }) => userMessage.content,
+			sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+		} as unknown as InteractiveModeContext;
+		const uiHelpers = new UiHelpers(ctx);
+		for (let index = 0; index < 30; index++) {
+			uiHelpers.addMessageToChat({ role: "user", content: `history-${index}`, timestamp: index + 1 });
+		}
+		try {
+			ui.start();
+			await term.waitForRender();
+			expect(ui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			const before = term.getViewport().map(line => line.trimEnd());
+			const beforeHistory = before.flatMap((line, index) => (line.includes("history-") ? [{ index, line }] : []));
+			expect(beforeHistory.length, JSON.stringify(before)).toBeGreaterThanOrEqual(3);
+			const rowsBefore = statusContainer.render(term.columns).length;
+			term.clearWriteLog();
+
+			// The exact teardown showError / cancelPendingSubmission /
+			// finishPendingSubmission perform on the shared status area.
+			statusArea.removeLoader(loader);
+			ui.requestRender();
+			await term.waitForRender();
+
+			expect(statusContainer.children).toContain(residualStatus);
+			// Non-contracting: the reserve keeps the removed loader's rows.
+			expect(statusContainer.render(term.columns).length).toBeGreaterThanOrEqual(rowsBefore);
+			const after = term.getViewport().map(line => line.trimEnd());
+			for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
+			const writes = term.getWriteLog().join("");
+			for (const entry of beforeHistory) expect(writes).not.toContain(entry.line);
+		} finally {
+			ui.stop();
+			if (previousTerm === undefined) delete Bun.env.TERM;
+			else Bun.env.TERM = previousTerm;
+			if (previousNotify === undefined) delete Bun.env.GJC_NOTIFY;
+			else Bun.env.GJC_NOTIFY = previousNotify;
+		}
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { CompactionCancelledError } from "@gajae-code/agent-core/compaction";
 import { CommandController } from "@gajae-code/coding-agent/modes/controllers/command-controller";
+import { StatusArea } from "@gajae-code/coding-agent/modes/status-area";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
 
@@ -8,6 +10,9 @@ function createContainer() {
 		children: [] as unknown[],
 		addChild(child: unknown) {
 			this.children.push(child);
+		},
+		removeChild(child: unknown) {
+			this.children = this.children.filter(existing => existing !== child);
 		},
 		clear() {
 			this.children = [];
@@ -47,6 +52,7 @@ describe("/handoff command", () => {
 			},
 			loadingAnimation: undefined,
 			statusContainer,
+			statusArea: new StatusArea({ ui: { requestRender } as never, statusContainer: statusContainer as never }),
 			chatContainer,
 			ui: { requestRender },
 			editor: { onEscape: originalOnEscape },
@@ -95,6 +101,7 @@ describe("/handoff command", () => {
 				})),
 			},
 			statusContainer,
+			statusArea: new StatusArea({ ui: { requestRender } as never, statusContainer: statusContainer as never }),
 			chatContainer,
 			ui: { requestRender },
 			editor: { setText: vi.fn() },
@@ -117,5 +124,83 @@ describe("/handoff command", () => {
 		expect(ctx.showStatus).toHaveBeenCalledWith(expect.stringContaining("separate terminal"));
 		expect(chatContainer.children).toHaveLength(1);
 		expect(requestRender).toHaveBeenCalled();
+	});
+	it("compaction teardown removes only its own loader and keeps independent status", async () => {
+		const compactStarted = Promise.withResolvers<void>();
+		const compactDone = Promise.withResolvers<void>();
+		const statusContainer = createContainer();
+		const chatContainer = createContainer();
+		const requestRender = vi.fn();
+		const independentStatus = { render: () => [], invalidate: () => {} };
+		statusContainer.addChild(independentStatus);
+		const staleWorkingLoader = { stop: vi.fn() };
+		statusContainer.addChild(staleWorkingLoader);
+		const ctx = {
+			session: {
+				compact: vi.fn(() => {
+					compactStarted.resolve();
+					return compactDone.promise;
+				}),
+				abortCompaction: vi.fn(),
+			},
+			loadingAnimation: staleWorkingLoader,
+			statusContainer,
+			statusArea: new StatusArea({ ui: { requestRender } as never, statusContainer: statusContainer as never }),
+			chatContainer,
+			ui: { requestRender },
+			editor: { onEscape: vi.fn() },
+			rebuildChatFromMessages: vi.fn(),
+			statusLine: { invalidate: vi.fn() },
+			updateEditorTopBorder: vi.fn(),
+			showError: vi.fn(),
+			flushCompactionQueue: vi.fn(async () => undefined),
+		} as unknown as InteractiveModeContext;
+		const controller = new CommandController(ctx);
+
+		const outcomePromise = controller.executeCompaction();
+		await compactStarted.promise;
+
+		// The stale working loader was torn down and its own loader installed;
+		// the independently owned status component survives throughout.
+		expect(staleWorkingLoader.stop).toHaveBeenCalledTimes(1);
+		expect(statusContainer.children).not.toContain(staleWorkingLoader);
+		expect(statusContainer.children).toContain(independentStatus);
+		expect(statusContainer.children).toHaveLength(2);
+
+		compactDone.resolve();
+		expect(await outcomePromise).toBe("ok");
+		expect(statusContainer.children).toEqual([independentStatus]);
+		expect(ctx.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false });
+	});
+	it("cancelled compaction still tears down only its own loader", async () => {
+		const statusContainer = createContainer();
+		const chatContainer = createContainer();
+		const requestRender = vi.fn();
+		const independentStatus = { render: () => [], invalidate: () => {} };
+		statusContainer.addChild(independentStatus);
+		const ctx = {
+			session: {
+				compact: vi.fn(async () => {
+					throw new CompactionCancelledError();
+				}),
+				abortCompaction: vi.fn(),
+			},
+			loadingAnimation: undefined,
+			statusContainer,
+			statusArea: new StatusArea({ ui: { requestRender } as never, statusContainer: statusContainer as never }),
+			chatContainer,
+			ui: { requestRender },
+			editor: { onEscape: vi.fn() },
+			rebuildChatFromMessages: vi.fn(),
+			statusLine: { invalidate: vi.fn() },
+			updateEditorTopBorder: vi.fn(),
+			showError: vi.fn(),
+			flushCompactionQueue: vi.fn(async () => undefined),
+		} as unknown as InteractiveModeContext;
+		const controller = new CommandController(ctx);
+
+		expect(await controller.executeCompaction()).toBe("cancelled");
+		expect(ctx.showError).toHaveBeenCalledWith("Compaction cancelled");
+		expect(statusContainer.children).toEqual([independentStatus]);
 	});
 });

--- a/packages/coding-agent/test/modes/status-area-ownership.test.ts
+++ b/packages/coding-agent/test/modes/status-area-ownership.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+
+/**
+ * Source-level ownership gate for the transient status slot.
+ *
+ * Every transient loader install/teardown must go through StatusArea
+ * (addLoader/removeLoader) so the reserved row budget survives and sibling
+ * status components are never dropped. `statusContainer.clear()` is reserved
+ * for whole-session resets. This gate pins both rules so a new call site
+ * cannot silently bypass the ownership contract: adding a legitimate
+ * full-session reset requires updating the allowlist below with its
+ * classification.
+ */
+const SRC_ROOT = path.resolve(import.meta.dir, "../../src");
+
+/** file (relative to src) -> expected number of full-session-reset clears */
+const CLEAR_ALLOWLIST = new Map<string, number>([
+	// New session (/new, /clear), context clear, and fork all rebuild the
+	// entire transcript identity.
+	["modes/controllers/command-controller.ts", 3],
+	// Extension-driven session switch flows reset the whole session UI.
+	["modes/controllers/extension-ui-controller.ts", 2],
+	// Interactive-mode dispose/shutdown.
+	["modes/controllers/input-controller.ts", 1],
+	// Session switching via the sessions selector replaces the transcript.
+	["modes/controllers/selector-controller.ts", 1],
+]);
+
+/** Only StatusArea itself may install children into the status container. */
+const ADD_CHILD_ALLOWLIST = new Set<string>(["modes/status-area.ts"]);
+
+function countMatches(text: string, pattern: RegExp): number {
+	let count = 0;
+	for (const line of text.split("\n")) {
+		const trimmed = line.trimStart();
+		// Doc comments may reference the pattern when documenting the policy.
+		if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) continue;
+		count += line.match(pattern)?.length ?? 0;
+	}
+	return count;
+}
+
+async function collectSourceFiles(): Promise<Map<string, string>> {
+	const files = new Map<string, string>();
+	const glob = new Bun.Glob("**/*.ts");
+	for await (const relative of glob.scan({ cwd: SRC_ROOT })) {
+		files.set(relative, await Bun.file(path.join(SRC_ROOT, relative)).text());
+	}
+	return files;
+}
+
+describe("status area ownership gate", () => {
+	it("statusContainer.clear() appears only in classified full-session resets", async () => {
+		const files = await collectSourceFiles();
+		expect(files.size).toBeGreaterThan(100);
+		for (const [relative, text] of files) {
+			const clears = countMatches(text, /statusContainer\.clear\(\)/g);
+			const allowed = CLEAR_ALLOWLIST.get(relative) ?? 0;
+			expect(
+				clears,
+				`${relative}: statusContainer.clear() must only be used for whole-session resets; ` +
+					"transient loader teardown goes through StatusArea.removeLoader (update the allowlist " +
+					"with a classification if this is a genuine new session reset)",
+			).toBe(allowed);
+		}
+	});
+
+	it("only StatusArea installs children into the status container", async () => {
+		const files = await collectSourceFiles();
+		for (const [relative, text] of files) {
+			if (ADD_CHILD_ALLOWLIST.has(relative)) continue;
+			expect(
+				countMatches(text, /statusContainer\.addChild\(/g),
+				`${relative}: install transient loaders with StatusArea.addLoader so their rows are reserved`,
+			).toBe(0);
+		}
+	});
+});

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -42,9 +42,9 @@
 		"marked": "catalog:"
 	},
 	"devDependencies": {
-		"chalk": "catalog:",
 		"@xterm/headless": "catalog:",
-		"node-pty": "^1.0.0"
+		"chalk": "catalog:",
+		"node-pty": "1.2.0-beta.14"
 	},
 	"engines": {
 		"bun": ">=1.3.14"

--- a/packages/tui/test/pty/mouse-pty-driver.mjs
+++ b/packages/tui/test/pty/mouse-pty-driver.mjs
@@ -1,0 +1,121 @@
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import * as url from "node:url";
+import * as pty from "node-pty";
+
+const scenario = process.argv[2];
+const bunBinary = process.env.BUN_BINARY;
+const testDir = path.dirname(url.fileURLToPath(import.meta.url));
+const fixture = path.join(testDir, "mouse-pty-fixture.ts");
+const baseEnv = Object.fromEntries(Object.entries(process.env).filter(([, value]) => value !== undefined));
+const MULTIPLEXER_ENV_KEYS = ["TMUX", "TMUX_PANE", "STY", "ZELLIJ", "GJC_TMUX_LAUNCHED"];
+
+
+if (!bunBinary) throw new Error("BUN_BINARY must identify the Bun executable that runs the PTY fixture.");
+if (!scenario) throw new Error("A PTY scenario is required.");
+
+
+function launchFixture(env = {}) {
+	const scenarioEnv = { ...baseEnv, TERM: "xterm-256color" };
+	for (const key of MULTIPLEXER_ENV_KEYS) delete scenarioEnv[key];
+
+	let captured = "";
+	const terminal = pty.spawn("/bin/sh", ["-c", 'exec "$1" "$2"', "pty-fixture", bunBinary, fixture], {
+		name: "xterm-256color",
+		cols: 80,
+		rows: 24,
+		cwd: process.cwd(),
+		env: { ...scenarioEnv, ...env },
+	});
+	terminal.onData(data => {
+		captured += data;
+	});
+	terminal.onExit(event => {
+		captured += `\nPTY_FIXTURE_EXIT:${event.exitCode}:${event.signal}\n`;
+	});
+	return { terminal, output: () => captured };
+}
+
+
+async function waitForOutput(output, marker) {
+	const deadline = Date.now() + 3_000;
+	while (!output().includes(marker)) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${JSON.stringify(marker)}; output: ${JSON.stringify(output())}`);
+		await new Promise(resolve => setTimeout(resolve, 10));
+	}
+}
+
+async function run() {
+	if (scenario === "plain-enable") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			assert.match(output(), /\x1b\[\?1000h/);
+			assert.match(output(), /\x1b\[\?1006h/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "graceful-stop") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.write("__exit__\r");
+			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
+			assert.match(output(), /\x1b\[\?1000l/);
+			assert.match(output(), /\x1b\[\?1006l/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "sigterm") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.kill("SIGTERM");
+			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
+			assert.match(output(), /\x1b\[\?1000l/);
+			assert.match(output(), /\x1b\[\?1006l/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "multiplexer") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1", TMUX: "1" });
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			assert.doesNotMatch(output(), /\x1b\[\?1000h/);
+			assert.doesNotMatch(output(), /\x1b\[\?1006h/);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	if (scenario === "composer") {
+		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
+		const mouse = "\x1b[<0;3;4M";
+		try {
+			await waitForOutput(output, "PTY_FIXTURE_READY");
+			terminal.write("composer");
+			await waitForOutput(output, 'EDITOR:"composer"');
+			terminal.write(mouse);
+			terminal.write("!");
+			await waitForOutput(output, 'EDITOR:"composer!"');
+			assert.equal(output().includes(mouse), false);
+		} finally {
+			terminal.kill();
+		}
+		return;
+	}
+
+	throw new Error(`Unknown PTY scenario: ${scenario}`);
+}
+
+await run();

--- a/packages/tui/test/pty/mouse-pty-matrix.test.ts
+++ b/packages/tui/test/pty/mouse-pty-matrix.test.ts
@@ -1,148 +1,56 @@
 import { describe, expect, test } from "bun:test";
-import { resolve } from "node:path";
-import type { IPty } from "node-pty";
+import * as path from "node:path";
 
 const enabled = process.env.PI_TUI_PTY_TESTS === "1";
-const fixture = resolve(import.meta.dir, "mouse-pty-fixture.ts");
-const baseEnv = Object.fromEntries(
-	Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-);
+const driver = path.resolve(import.meta.dir, "mouse-pty-driver.mjs");
+const nodeBinary = process.env.NODE_BINARY ?? "node";
 
-type PtyModule = typeof import("node-pty");
-
-let pty: PtyModule | undefined;
-let capabilityReason = "PTY capability probe was not run.";
-
-async function probePtyCapability(): Promise<boolean> {
-	try {
-		pty = await import("node-pty");
-		const probe = pty.spawn("/bin/sh", ["-c", "exit 0"], {
-			name: "xterm-256color",
-			cols: 80,
-			rows: 24,
-			cwd: process.cwd(),
-			env: { ...baseEnv, TERM: "xterm-256color" },
-		});
-		const exited = await new Promise<boolean>(resolveProbe => {
-			const timeout = setTimeout(() => resolveProbe(false), 1_000);
-			probe.onExit(() => {
-				clearTimeout(timeout);
-				resolveProbe(true);
-			});
-		});
-		if (!exited) {
-			probe.kill();
-			capabilityReason = "node-pty capability probe timed out waiting for /bin/sh to exit.";
-			return false;
-		}
-		return true;
-	} catch (error) {
-		capabilityReason = `node-pty capability probe failed: ${error instanceof Error ? error.message : String(error)}`;
-		return false;
-	}
-}
-
-const ptyAvailable = enabled && process.platform !== "win32" ? await probePtyCapability() : false;
-
-function launchFixture(env: Record<string, string> = {}): { terminal: IPty; output: () => string } {
-	if (!pty) throw new Error(capabilityReason);
-	let captured = "";
-	const terminal = pty.spawn("/bin/sh", ["-c", 'exec "$1" "$2"', "pty-fixture", process.execPath, fixture], {
-		name: "xterm-256color",
-		cols: 80,
-		rows: 24,
+async function runScenario(scenario: string, environment: Record<string, string> = {}): Promise<void> {
+	const child = Bun.spawn([nodeBinary, driver, scenario], {
 		cwd: process.cwd(),
-		env: { ...baseEnv, TERM: "xterm-256color", ...env },
+		env: { ...process.env, ...environment, BUN_BINARY: process.execPath },
+		stdout: "pipe",
+		stderr: "pipe",
 	});
-	terminal.onData(data => {
-		captured += data;
-	});
-	terminal.onExit(event => {
-		captured += `\nPTY_FIXTURE_EXIT:${event.exitCode}:${event.signal}\n`;
-	});
-	return { terminal, output: () => captured };
-}
-
-async function waitForOutput(output: () => string, marker: string): Promise<void> {
-	const deadline = Date.now() + 3_000;
-	while (!output().includes(marker)) {
-		if (Date.now() >= deadline)
-			throw new Error(`Timed out waiting for ${JSON.stringify(marker)}; output: ${JSON.stringify(output())}`);
-		await Bun.sleep(10);
-	}
+	const [exitCode, stdout, stderr] = await Promise.all([
+		child.exited,
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	expect(exitCode, `${stderr}\n${stdout}`).toBe(0);
 }
 
 /**
- * POSIX-only integration lane. Terminal ownership is intentionally exercised in
- * CI where node-pty can allocate a real pseudo terminal; normal unit tests do
- * not require native PTY bindings.
+ * POSIX-only integration lane. node-pty's native callbacks are driven by Node,
+ * while the fixture itself runs under Bun and exercises ProcessTerminal.
  */
 describe.skipIf(!enabled || process.platform === "win32")("mouse PTY matrix", () => {
-	test("requires a usable PTY capability when explicitly enabled", () => {
-		expect(ptyAvailable, capabilityReason).toBe(true);
-	});
 	test("emits SGR mouse enable bytes in a plain xterm PTY", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			expect(output()).toContain("\x1b[?1000h");
-			expect(output()).toContain("\x1b[?1006h");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("plain-enable");
+	});
+	test("isolates plain scenarios from inherited multiplexer markers", async () => {
+		await runScenario("plain-enable", {
+			TMUX: "/tmp/tmux,1,0",
+			TMUX_PANE: "%42",
+			STY: "screen",
+			ZELLIJ: "zellij",
+			GJC_TMUX_LAUNCHED: "1",
+		});
 	});
 
 	test("emits SGR mouse disable bytes on graceful stop", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.write("__exit__\r");
-			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
-			expect(output()).toContain("\x1b[?1000l");
-			expect(output()).toContain("\x1b[?1006l");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("graceful-stop");
 	});
 
 	test("restores SGR mouse modes when SIGTERM detaches the TUI", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.kill("SIGTERM");
-			await waitForOutput(output, "PTY_FIXTURE_STOPPED");
-			expect(output()).toContain("\x1b[?1000l");
-			expect(output()).toContain("\x1b[?1006l");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("sigterm");
 	});
 
 	test("emits no SGR mouse enable bytes under a multiplexer", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1", TMUX: "1" });
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			expect(output()).not.toContain("\x1b[?1000h");
-			expect(output()).not.toContain("\x1b[?1006h");
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("multiplexer");
 	});
 
 	test("does not leak SGR mouse reports into composer text", async () => {
-		const { terminal, output } = launchFixture({ PTY_FIXTURE_MOUSE: "1" });
-		const mouse = "\x1b[<0;3;4M";
-		try {
-			await waitForOutput(output, "PTY_FIXTURE_READY");
-			terminal.write("composer");
-			await waitForOutput(output, 'EDITOR:"composer"');
-			terminal.write(mouse);
-			terminal.write("!");
-			await waitForOutput(output, 'EDITOR:"composer!"');
-			expect(output()).toContain('EDITOR:"composer!"');
-			expect(output()).not.toContain(mouse);
-		} finally {
-			terminal.kill();
-		}
+		await runScenario("composer");
 	});
 });


### PR DESCRIPTION
## Scope

Follow-up to the #2666 maintainer review (REQUEST_CHANGES: "terminal lifecycle ownership remains incomplete"). This PR addresses that blocking finding 1:1, preserves everything the #2666 review did not object to, and is rebased onto current `dev`.

## Maintainer finding → change

**"Status ownership needs one coherent targeted-removal API used by every loader teardown path, with process-terminal viewport/write-log regression tests for cancel and error transitions. The scattered remaining `statusContainer.clear()` calls should be audited and explicitly classified."**

- **One owner, install and teardown**: `StatusArea` (registry + high-water `StatusRowReserve`). Every transient loader goes through `addLoader`/`removeLoader` — the three cited sites (`cancelPendingSubmission`, pending-submission cleanup, `showError`) plus every other transient site found in the audit: manual compact, handoff, branch-summary, and the four debug-report loaders. `removeLoader` records the visible rows into the reserve before removing only that loader, so no teardown contracts the slot or touches sibling components.
- **Audit, executable**: the remaining seven `statusContainer.clear()` calls are all whole-session resets (`/new`, `/clear`, context-clear, fork, session switch ×2, shutdown). The classification is not just documented — `test/modes/status-area-ownership.test.ts` scans `src` and pins (a) the per-file clear() allowlist with counts and (b) the StatusArea `addChild` install monopoly. A new unclassified call site fails the gate.
- **Cancel/error regression tests**:
  - Real-path (`interactive-mode-editor-component.test.ts`): `showError` and `cancelPendingSubmission` on a real `InteractiveMode` remove only the working loader and preserve independent status (both fail against the previous head).
  - Process-terminal viewport/write-log (`event-controller-status-teardown.test.ts`): browsed transcript rows and the write log stay untouched through the exact error/cancel teardown, and the status area does not contract.
  - Compaction ownership: `executeCompaction` success/cancelled paths and `auto_compaction_start/end` tested for own-loader-only teardown.

## Carried over from #2666 (unobjected)

Lifecycle lane scoped to `agent_start`/`agent_end` (no starvation via approval-awaiting handlers), turn-generation identity with the `isStreaming` discriminator for stale completions, narrow-terminal tall-to-short replacement coverage, and the PTY matrix driver (node-pty `1.2.0-beta.14` pin, opt-in via `PI_TUI_PTY_TESTS=1`).

Test layout is split by domain: completion-viewport matrix, lifecycle-ordering, status-teardown, ownership gate, StatusRowReserve units.

## Known tradeoffs (deliberate)

- Reserved blank rows persist until a resize or a full-session reset. Native scrollback browsing is undetectable from the app, so there is no safe collapse point; the reservation is bounded by the tallest single status seen, not cumulative.
- Chained runs (queued follow-ups) show continuous loader activity and emit one completion at true idle.

## Verification (rebased head on current dev)

- coding-agent full package suite: 11,707 pass; remaining failures verified unrelated (coordinator identity, tmux/lsp env, one order-dependent flake that passes in isolation)
- modes + interactive-mode adjacent suites: 357 pass / 0 fail on the rebased base
- tui package incl. PTY matrix: 839 pass / 0 fail
- biome clean; declaration typecheck across all packages
- Cross-checks: the new cancel/error tests fail against the previous head; the completion matrix fails against `dev`'s controller (5/6)
