### PR TITLE
fix(session): keep Windows resident cache paths Bun-writable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Newly registered earlier resource-GC policies advance the pending sweep without postponing an already earlier sweep.
 - Provider onboarding wizard completion is now deterministic under CI load: duplicate in-flight confirmation is suppressed, success tests await the real refresh/notification/status boundary instead of fixed sleeps, and the newly configured model is verified through the subsequent model selector.
 - OpenAI-compatible web search now turns malformed successful response bodies into bounded provider errors while preserving normal provider fallback (#2593).
+- Windows session storage now keeps a symlink-resolved drive-letter path for Bun filesystem I/O instead of a native Volume GUID identity path, preventing `ENOENT` failures during resident-cache writes that could drop the final assistant message at turn completion.
 
 ## [0.11.3] - 2026-07-19
 ### Added

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -99,6 +99,7 @@ export type ManagedDeleteCandidateResult =
 type NativeIdentity =
 	| { ok: true; platform: "posix" | "win32"; canonicalPath: string }
 	| { ok: false; code: NativeIdentityFailureCode };
+type CanonicalNativeIdentity = Extract<NativeIdentity, { ok: true }>;
 
 type NativeIdentityFailureCode =
 	| "not_found"
@@ -149,6 +150,18 @@ function identityFor(cwd: string): NativeIdentity {
 	return canonicalExistingDirectoryIdentity(cwd) as NativeIdentity;
 }
 
+function canonicalExistingPathForIo(base: string, identity: CanonicalNativeIdentity): string {
+	if (identity.platform !== "win32") return identity.canonicalPath;
+	try {
+		// Native identity uses a stable Volume GUID path on Windows. Bun 1.3.14
+		// cannot reliably create/read files through that path, so retain the
+		// symlink-resolved DOS path for JavaScript filesystem I/O.
+		return fs.realpathSync.native(base);
+	} catch {
+		return path.resolve(base);
+	}
+}
+
 /**
  * Resolve benign symlinks in the deepest existing ancestor of a trusted storage
  * root (e.g. macOS `/var -> /private/var`, or a symlinked `$HOME`) while keeping
@@ -164,7 +177,8 @@ export function canonicalizeTrustedPath(target: string): string {
 	for (;;) {
 		const identity = canonicalExistingDirectoryIdentity(base) as NativeIdentity;
 		if (identity.ok) {
-			return suffix.length === 0 ? identity.canonicalPath : path.join(identity.canonicalPath, ...suffix);
+			const canonicalBase = canonicalExistingPathForIo(base, identity);
+			return suffix.length === 0 ? canonicalBase : path.join(canonicalBase, ...suffix);
 		}
 		if (identity.code !== "not_found" && identity.code !== "not_directory") return path.resolve(target);
 		const parent = path.dirname(base);

--- a/packages/coding-agent/test/session-manager/windows-canonical-path.test.ts
+++ b/packages/coding-agent/test/session-manager/windows-canonical-path.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -22,5 +23,26 @@ describe.skipIf(process.platform !== "win32")("Windows trusted storage canonical
 		expect(canonical).not.toStartWith("\\\\?\\Volume{");
 		await Bun.write(canonical, "resident-cache-ok");
 		expect(await Bun.file(canonical).text()).toBe("resident-cache-ok");
+	});
+
+	it("keeps the resident-cache blob write mechanism working through node:fs", async () => {
+		// Reproduces the exact operation that broke on Windows: `EphemeralBlobStore.putSync`
+		// runs `fs.mkdirSync(dir, { recursive: true })` then `fs.writeFileSync(blobPath, data)`.
+		// Bun's node:fs `writeFileSync`/`readFileSync` fail with ENOENT on the native
+		// `\\?\Volume{GUID}\...` identity path even though `mkdirSync` succeeds, so a resident
+		// blob write on that path drops the entry mid-turn/compaction. The canonicalized DOS
+		// path must round-trip the same synchronous write and read.
+		const root = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-windows-canonical-fs-"));
+		testRoots.push(root);
+		const residentDir = path.join(root, "sessions", "sess-id", "resident-cache", "sess-id-1234-1");
+		const canonicalDir = canonicalizeTrustedPath(residentDir);
+
+		expect(canonicalDir).toMatch(/^[A-Za-z]:\\/);
+		expect(canonicalDir).not.toStartWith("\\\\?\\Volume{");
+
+		const blobPath = path.join(canonicalDir, "blobhash");
+		fs.mkdirSync(canonicalDir, { recursive: true });
+		fs.writeFileSync(blobPath, "resident-blob-ok");
+		expect(fs.readFileSync(blobPath, "utf8")).toBe("resident-blob-ok");
 	});
 });

--- a/packages/coding-agent/test/session-manager/windows-canonical-path.test.ts
+++ b/packages/coding-agent/test/session-manager/windows-canonical-path.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { canonicalizeTrustedPath } from "../../src/session/internal/managed-session-scope";
+
+const testRoots: string[] = [];
+
+afterEach(async () => {
+	for (const root of testRoots.splice(0)) await fsp.rm(root, { recursive: true, force: true });
+});
+
+describe.skipIf(process.platform !== "win32")("Windows trusted storage canonicalization", () => {
+	it("keeps a missing resident-cache tail writable through Bun", async () => {
+		const root = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-windows-canonical-"));
+		testRoots.push(root);
+		const missingTail = path.join(root, "sessions", "resident-cache", "instance", "blob");
+		const canonical = canonicalizeTrustedPath(missingTail);
+
+		expect(canonical).toMatch(/^[A-Za-z]:\\/);
+		expect(canonical).not.toStartWith("\\\\?\\Volume{");
+		await Bun.write(canonical, "resident-cache-ok");
+		expect(await Bun.file(canonical).text()).toBe("resident-cache-ok");
+	});
+});


### PR DESCRIPTION
## Problem

GJC 0.11.2 and 0.11.3 can lose the final assistant message on native Windows. The trusted-session canonicalization introduced for strict owner/reparse guards converts the session root to a stable `\\?\Volume{GUID}\...` identity path. Bun 1.3.14 can create directories through that path but fails file writes with `ENOENT`, so resident-cache materialization throws from the `message_end` handler before the final message is persisted/rendered.

This is separate from the completion viewport/scrollback issue in #2637: that PR preserves terminal layout, while this failure is session persistence I/O.

## Fix

- Keep the native canonical identity path for identity/digest/security decisions.
- On Windows only, use `fs.realpathSync.native()` to obtain a symlink-resolved DOS drive path for JavaScript/Bun filesystem I/O.
- Preserve the existing native canonical path behavior on POSIX.
- Add a Windows regression test that exercises a missing resident-cache tail and verifies Bun can write/read it.
- Document the user-visible fix in the coding-agent changelog.

## Direct reproduction and verification

Before the patch, writing below the native identity path reproduced:

```json
{"canonicalPath":"\\\\?\\Volume{...}\\tmp\\gjc-win-enoent\\.volume-repro","outcome":"ENOENT"}
```

After the patch, the same logical path resolves to a drive-letter path and writes successfully:

```json
{"file":"C:\\tmp\\gjc-win-enoent\\.patched-repro\\resident-cache\\blob","contents":"patched-ok"}
```

A real patched checkout turn was also run with a large assistant response. The final assistant message was persisted in the session JSONL (`finalTextLength: 255658`) with no handler error for that verification session.

## Verification

- `bun run dev:doctor`
- `bun run dev --smoke-test`
- `bun test packages/coding-agent/test/session-manager/windows-canonical-path.test.ts packages/coding-agent/test/session-resident-cache.test.ts packages/coding-agent/test/session-manager-resident-cache.test.ts`
  - 11 passed, 0 failed
- `bun --cwd=packages/coding-agent run check:types`
- `bun run check:tools`
- `bunx biome check packages/coding-agent/src/session/internal/managed-session-scope.ts packages/coding-agent/test/session-manager/windows-canonical-path.test.ts`
- `git diff --check`
