### PR TITLE
fix(coding-agent): make provider onboarding completion deterministic

### DIFF
--- a/artifacts/provider-onboarding-ci-race-report.json
+++ b/artifacts/provider-onboarding-ci-race-report.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "kind": "api-package-test-report",
+  "story": "Deterministic provider onboarding wizard completion under CI load",
+  "classification": {
+    "verdict": "latent fixed-sleep race exposed by scheduler pressure",
+    "baseline": "Focused pre-change rerun passed 600/600, while CI shard run 29695908337 observed refreshModes=[] after a fixed 50 ms sleep; tombstone commit ac23d6baa did not modify onboarding code.",
+    "productionFinding": "The controller already ordered provider write, offline refresh, config notification, formatted status, completion, and render, but the wizard discarded the returned asynchronous operation and allowed duplicate confirmation while it was pending."
+  },
+  "changes": [
+    "CustomProviderWizardComponent tracks the real Promise returned by submission and suppresses duplicate Enter until settlement while preserving synchronous callbacks and retries.",
+    "SelectorController returns its existing submit Promise to the wizard.",
+    "Success tests await an exact formatted status after refresh and notification instead of Bun.sleep(50)/Bun.sleep(1000).",
+    "Red-team coverage proves rejected notification cannot emit success and the subsequent real ModelSelectorComponent exposes the configured model."
+  ],
+  "verification": [
+    {"command":"bun test test/provider-onboarding-wizard-redteam.test.ts --rerun-each 100","cwd":"packages/coding-agent","result":"700 pass, 0 fail"},
+    {"command":"bun test test/provider-onboarding-wizard.test.ts --rerun-each 100","cwd":"packages/coding-agent","result":"700 pass, 0 fail"},
+    {"command":"bun test test/provider-onboarding-wizard-redteam.test.ts test/provider-onboarding-wizard.test.ts test/provider-onboarding.test.ts","cwd":"packages/coding-agent","result":"30 pass, 0 fail"},
+    {"command":"bun run check","cwd":"packages/coding-agent","result":"Biome clean; TypeScript check passed"},
+    {"command":"bun test --shard=7/8","cwd":"packages/coding-agent","result":"1332 pass, 32 skip; 2 unrelated local failures in gjc-plugin-mcp-connect.test.ts caused by MCP startup timeout"}
+  ],
+  "reviews": {
+    "architect": {"status":"CLEAR","recommendation":"APPROVE","receipt":"agent://5-ProviderWizardArchitectFinal","cleanerBlockingCount":0},
+    "executorQa": {"status":"passed","e2eStatus":"passed","redTeamStatus":"passed","receipt":"agent://6-ProviderWizardQAFinal","blockers":[]}
+  },
+  "limitations": [
+    "The local shard-7 environment could not start the unrelated bundled MCP fixture and timed out in two existing plugin tests; focused onboarding coverage and all package checks passed. PR Dev CI is the authoritative shard environment."
+  ]
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - Malformed selectors on internal read URLs now fail explicitly instead of silently falling back to an unbounded resource read.
 - Newly registered earlier resource-GC policies advance the pending sweep without postponing an already earlier sweep.
+- Provider onboarding wizard completion is now deterministic under CI load: duplicate in-flight confirmation is suppressed, success tests await the real refresh/notification/status boundary instead of fixed sleeps, and the newly configured model is verified through the subsequent model selector.
 
 ## [0.11.3] - 2026-07-19
 ### Added

--- a/packages/coding-agent/src/modes/components/custom-provider-wizard.ts
+++ b/packages/coding-agent/src/modes/components/custom-provider-wizard.ts
@@ -41,6 +41,7 @@ export class CustomProviderWizardComponent extends Container {
 		credential: "",
 		models: "",
 	};
+	#submitInFlight = false;
 	#onSubmit: (input: CustomProviderWizardSubmit) => void;
 	#onCancel: () => void;
 	#onRender: () => void;
@@ -294,13 +295,37 @@ export class CustomProviderWizardComponent extends Container {
 			this.#step = "credential";
 		} else if (this.#step === "confirm" || this.#step === "force-confirm") {
 			if (this.#selectedIndex === 0) {
-				this.#onSubmit(this.#buildInput(this.#step === "force-confirm"));
+				this.#submit();
 				return;
 			}
 			this.#step = "models";
 		}
 		this.#renderStep();
 		this.#onRender();
+	}
+
+	#submit(): void {
+		if (this.#submitInFlight) return;
+		this.#submitInFlight = true;
+		let submission: unknown;
+		try {
+			submission = this.#onSubmit(this.#buildInput(this.#step === "force-confirm"));
+		} catch (error) {
+			this.#submitInFlight = false;
+			throw error;
+		}
+		if (!(submission instanceof Promise)) {
+			this.#submitInFlight = false;
+			return;
+		}
+		void submission.then(
+			() => {
+				this.#submitInFlight = false;
+			},
+			() => {
+				this.#submitInFlight = false;
+			},
+		);
 	}
 
 	#buildInput(force: boolean): CustomProviderWizardSubmit {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1060,7 +1060,7 @@ export class SelectorController {
 			};
 			wizard = new CustomProviderWizardComponent(
 				input => {
-					void submit(input);
+					return submit(input);
 				},
 				() => {
 					done();

--- a/packages/coding-agent/test/provider-onboarding-wizard-redteam.test.ts
+++ b/packages/coding-agent/test/provider-onboarding-wizard-redteam.test.ts
@@ -106,12 +106,36 @@ describe("provider onboarding wizard red-team", () => {
 		controller.showCustomProviderWizard();
 		const wizard = ctx.ui.focused as CustomProviderWizardComponent;
 		driveWizard(wizard, { providerId: "insecure-wizard", baseUrl: "http://api.example.com/v1" });
+		const errorRendered = Promise.withResolvers<void>();
+		ctx.ui.requestRender = () => errorRendered.resolve();
 		wizard.handleInput("\n");
-		await Bun.sleep(20);
+		await errorRendered.promise;
 
 		const rendered = visibleText(wizard);
 		expect(rendered).toContain("Provider setup failed");
 		expect(rendered).toContain("Base URL must use https unless it targets localhost or a loopback address");
+	});
+
+	it("does not report success when config notification rejects and renders the wizard error", async () => {
+		await withRegistry(async registry => {
+			let notificationAttempts = 0;
+			const ctx = createControllerContext(registry, async () => {
+				notificationAttempts++;
+				throw new Error("notification unavailable");
+			});
+			const controller = new SelectorController(ctx);
+			controller.showCustomProviderWizard();
+			const wizard = ctx.ui.focused as CustomProviderWizardComponent;
+			driveWizard(wizard, { providerId: "notify-failure", models: "notify-model" });
+			const errorRendered = Promise.withResolvers<void>();
+			ctx.ui.requestRender = () => errorRendered.resolve();
+			wizard.handleInput("\n");
+			await errorRendered.promise;
+
+			expect(notificationAttempts).toBe(1);
+			expect(ctx.statuses).toEqual([]);
+			expect(visibleText(wizard)).toContain("Provider setup failed: notification unavailable");
+		});
 	});
 
 	it("rejects empty provider id and empty model lists", async () => {
@@ -187,32 +211,59 @@ describe("provider onboarding wizard red-team", () => {
 	it("refreshes offline, notifies config change, shows formatted result, and exposes new provider in a subsequent model selector read", async () => {
 		await withRegistry(async registry => {
 			const refreshModes: (string | undefined)[] = [];
+			const events: string[] = [];
 			const originalRefresh = registry.refresh.bind(registry);
 			registry.refresh = async mode => {
 				refreshModes.push(mode);
 				await originalRefresh(mode);
+				events.push(`refresh:${mode}`);
 			};
 			let configChanged = 0;
 			const ctx = createControllerContext(registry, () => {
 				configChanged++;
+				events.push("notify");
 			});
+			const successStatus = [
+				"Provider 'visible-provider' configured as openai-compatible.",
+				"Models: visible-model",
+				"Base URL: https://api.example.com/v1",
+				"API key: CUST…_KEY (environment variable)",
+				`Config: ${path.join(tempAgentDir!, "models.yml")}`,
+			].join("\n");
+			const { promise: completion, resolve: resolveCompletion } = Promise.withResolvers<void>();
+			ctx.showStatus = message => {
+				ctx.statuses.push(message);
+				if (message === successStatus) {
+					events.push("success-status");
+					resolveCompletion();
+				}
+			};
 			const controller = new SelectorController(ctx);
 
 			controller.showCustomProviderWizard();
 			const wizard = ctx.ui.focused as CustomProviderWizardComponent;
 			driveWizard(wizard, { providerId: "visible-provider", models: "visible-model" });
 			wizard.handleInput("\n");
-			await Bun.sleep(50);
+			await completion;
 
-			expect(refreshModes).toContain("offline");
+			expect(events).toEqual(["refresh:offline", "notify", "success-status"]);
+			expect(refreshModes).toEqual(["offline"]);
 			expect(configChanged).toBe(1);
-			const status = ctx.statuses.join("\n");
-			expect(status).toContain("Provider 'visible-provider' configured as openai-compatible.");
-			expect(status).toContain("Models: visible-model");
-			expect(status).toContain("API key: CUST…_KEY (environment variable)");
-
-			await registry.refresh("offline");
+			expect(ctx.statuses).toEqual([successStatus]);
 			expect(registry.find("visible-provider", "visible-model")).toBeDefined();
+
+			const selectorLoaded = Promise.withResolvers<void>();
+			let selectorRenderRequests = 0;
+			ctx.ui.requestRender = () => {
+				selectorRenderRequests++;
+				if (selectorRenderRequests === 2) selectorLoaded.resolve();
+			};
+			controller.showModelSelector({ temporaryOnly: true });
+			await selectorLoaded.promise;
+			const selector = ctx.ui.focused as { handleInput(input: string): void; render(width: number): string[] };
+			for (const char of "visible-model") selector.handleInput(char);
+			const selectorText = visibleText(selector);
+			expect(selectorText).toContain("visible-model");
 		});
 	});
 
@@ -274,7 +325,13 @@ function createControllerContext(
 				children.push(child);
 			},
 		},
-		session: { modelRegistry, scopedModels: [] },
+		session: {
+			modelRegistry,
+			scopedModels: [],
+			isFastForProvider: () => false,
+			isFastForSubagentProvider: () => false,
+			isFastModeActive: () => false,
+		},
 		sessionManager: { getCwd: () => process.cwd() },
 		settings: createSettingsStub(),
 		showStatus: (message: string) => statuses.push(message),

--- a/packages/coding-agent/test/provider-onboarding-wizard.test.ts
+++ b/packages/coding-agent/test/provider-onboarding-wizard.test.ts
@@ -95,6 +95,28 @@ describe("provider onboarding wizard", () => {
 		]);
 	});
 
+	it("ignores duplicate Enter while a submit is pending and permits retry after rejection", async () => {
+		const submissions: CustomProviderWizardSubmit[] = [];
+		const deferred = Promise.withResolvers<void>();
+		const wizard = new CustomProviderWizardComponent(
+			input => {
+				submissions.push(input);
+				return submissions.length === 1 ? deferred.promise : undefined;
+			},
+			() => undefined,
+		);
+
+		driveEnvWizard(wizard);
+		wizard.handleInput("\n");
+		wizard.handleInput("\n");
+		expect(submissions).toHaveLength(1);
+
+		deferred.reject(new Error("submit failed"));
+		await deferred.promise.catch(() => undefined);
+		wizard.handleInput("\n");
+		expect(submissions).toHaveLength(2);
+	});
+
 	it("preserves literal credentials for force confirmation and clears them on completion", () => {
 		const submissions: CustomProviderWizardSubmit[] = [];
 		const wizard = new CustomProviderWizardComponent(
@@ -157,28 +179,42 @@ describe("provider onboarding wizard", () => {
 		try {
 			const authStorage = new AuthStorage(store);
 			const registry = new ModelRegistry(authStorage, path.join(tempAgentDir, "models.yml"));
-			let refreshedMode: string | undefined;
+			const refreshModes: (string | undefined)[] = [];
 			const originalRefresh = registry.refresh.bind(registry);
 			registry.refresh = async mode => {
-				refreshedMode = mode;
+				refreshModes.push(mode);
 				await originalRefresh(mode);
 			};
 			let configChanged = false;
 			const ctx = createControllerContext(registry, () => {
 				configChanged = true;
 			});
+			const successStatus = [
+				"Provider 'live-provider' configured as openai-compatible.",
+				"Models: live-model",
+				"Base URL: https://api.example.com/v1",
+				"API key: CUST…_KEY (environment variable)",
+				`Config: ${path.join(tempAgentDir!, "models.yml")}`,
+			].join("\n");
+			const { promise: completion, resolve: resolveCompletion } = Promise.withResolvers<void>();
+			ctx.showStatus = message => {
+				ctx.statuses.push(message);
+				if (message === successStatus) {
+					resolveCompletion();
+				}
+			};
 			const controller = new SelectorController(ctx);
 
 			controller.showCustomProviderWizard();
 			const wizard = ctx.ui.focused as CustomProviderWizardComponent;
 			driveEnvWizard(wizard, { providerId: "live-provider", model: "live-model" });
 			wizard.handleInput("\n");
-			await Bun.sleep(1_000);
+			await completion;
 
-			expect(refreshedMode).toBe("offline");
+			expect(refreshModes).toEqual(["offline"]);
 			expect(configChanged).toBe(true);
 			expect(registry.find("live-provider", "live-model")).toBeDefined();
-			expect(ctx.statuses.join("\n")).toContain("Provider 'live-provider' configured");
+			expect(ctx.statuses).toEqual([successStatus]);
 		} finally {
 			store.close();
 		}


### PR DESCRIPTION
## Summary
- replace fixed provider-wizard success sleeps with an exact refresh/notification/formatted-status completion condition
- propagate the real async submit promise and suppress duplicate confirmation while it is in flight
- prove rejected config notification cannot report success and verify the new model through the subsequent real model selector

## Classification
The tombstone merge changed scheduling pressure but did not touch provider onboarding. Focused baseline passed 600/600, so the CI failure is a latent fixed-sleep race rather than changed production ordering. The review also found and fixed a real duplicate-Enter lifecycle gap.

## Verification
- red-team focused repeat: 700/700
- normal wizard focused repeat: 700/700
- combined onboarding suite: 30/30
- coding-agent check/types: passed
- local shard 7: 1332 passed, 32 skipped; 2 unrelated bundled MCP startup timeouts in the local environment
- architect: CLEAR / APPROVE
- hostile executor QA: passed

Evidence: artifacts/provider-onboarding-ci-race-report.json

Base: dev. No main usage.