### PR TITLE
fix(cli): include memory in public command contract

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- Restored the canonical public CLI command-surface contract for the independently documented `gjc memory` filesystem/MAP command after its feature merge omitted the expected command-list update.
 - Added evidence-preserving recovery for legacy multi-writer SDK session-index corruption: `gjc gc` now diagnoses corrupt prefixes, `--repair-session-index` quarantines the original snapshot/log under the session-index lock before atomically restoring only the checksum-valid monotonic prefix, and append failures point operators to the explicit repair path (#2654).
 - Malformed selectors on internal read URLs now fail explicitly instead of silently falling back to an unbounded resource read.
 - Newly registered earlier resource-GC policies advance the pending sweep without postponing an already earlier sweep.

--- a/packages/coding-agent/src/cli/fast-help.ts
+++ b/packages/coding-agent/src/cli/fast-help.ts
@@ -4,6 +4,7 @@ export function getExtraHelpText(): string {
 	return `Commands:
   ${APP_NAME} [prompt]             - Start an interactive coding session (default launch command)
   ${APP_NAME} launch               - Start an explicit launch/session workflow
+  ${APP_NAME} memory               - Operate the opt-in filesystem/MAP memory protocol
   ${APP_NAME} setup                - Install GJC defaults or optional dependencies
   ${APP_NAME} session              - List, inspect, create, remove, or attach sessions
   ${APP_NAME} state                - Inspect or manage persisted GJC state

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -47,6 +47,7 @@ describe("GJC public CLI command surface", () => {
 			"plugin",
 			"completion",
 			"launch",
+			"memory",
 		]);
 	});
 
@@ -101,6 +102,18 @@ describe("GJC public CLI command surface", () => {
 			await fs.rm(stageDir, { recursive: true, force: true });
 		}
 	}, 60_000);
+
+	it("lists the public memory command in root help", () => {
+		const result = Bun.spawnSync(["bun", cliEntry, "--help"], {
+			cwd: repoRoot,
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		const output = `${result.stdout.toString()}\n${result.stderr.toString()}`;
+		expect(result.exitCode, output).toBe(0);
+		expect(output).toContain("gjc memory");
+		expect(output).toContain("opt-in filesystem/MAP memory protocol");
+	}, 30_000);
 
 	it("exposes the update command help without launching the TUI", () => {
 		const result = Bun.spawnSync(["bun", cliEntry, "update", "--help"], {


### PR DESCRIPTION
## Summary
- add the intentionally public `memory` command to the exact canonical CLI command list
- advertise `gjc memory` in root help and lock that help contract with a focused subprocess test
- record the dev-CI regression repair in the coding-agent changelog

## Contract evidence
PR #2673 intentionally shipped `gjc memory`: it is registered in `src/cli.ts`, implemented by `commands/memory.ts`, documented in `packages/coding-agent/README.md` and `docs/memory.md`, and listed in the release changelog. The omission was the stale exact command-surface test plus root fast-help.

## Verification
- focused CLI and memory suite: 40 pass
- coding-agent check/types: pass
- CLI smoke: pass; root help shows `gjc memory`
- affected-CI planner tests: 70 pass
- PresentationArbiter isolated comparison: 5/5 pass on untouched dev and 5/5 pass on this branch; unrelated full-shard load behavior was not widened into this fix
- full local coding-agent shard8 reached the fixed command-surface test but later hit environment-local SQLite I/O failures in `sdk-workflow-gate-emitter`; latest hosted dev evidence shows shard8 otherwise green except this deterministic command-list omission

## Review
- fresh architect: CLEAR/CLEAR/CLEAR, APPROVE, no blockers
- fresh executor red-team: passed, no blockers
- cleanup sweep: zero blocking/advisory findings across the three changed files

Issue #2639 remains closed because the feature itself is working.