### PR TITLE
fix(tmux): recover durably after owner SIGABRT

### DIFF
--- a/crates/pi-natives/src/lib.rs
+++ b/crates/pi-natives/src/lib.rs
@@ -49,6 +49,7 @@ pub mod path_identity;
 pub mod prof;
 pub mod ps;
 pub mod pty;
+pub mod recovery_fs;
 pub mod shell;
 pub mod summary;
 pub mod task;

--- a/crates/pi-natives/src/recovery_fs.rs
+++ b/crates/pi-natives/src/recovery_fs.rs
@@ -1,0 +1,551 @@
+//! Linux-only descriptor-relative filesystem authority for crash recovery.
+//!
+//! Every operation is rooted in the directory descriptor acquired by
+//! [`open_recovery_fs_root`]. Relative names are walked one component at a
+//! time without following symlinks, and regular files must be single-linked.
+
+use std::{
+	ffi::CString,
+	fs::File,
+	io::{Read, Write},
+	path::{Component, Path},
+};
+
+use napi::bindgen_prelude::Uint8Array;
+use napi_derive::napi;
+use parking_lot::Mutex;
+
+const MAX_CONTENT_BYTES: u64 = 1024 * 1024;
+
+#[napi(object)]
+pub struct RecoveryFsIdentity {
+	pub dev:      String,
+	pub ino:      String,
+	pub size:     String,
+	pub mtime_ns: String,
+}
+
+#[napi(object)]
+pub struct RecoveryFsResult {
+	pub ok:       bool,
+	pub code:     Option<String>,
+	pub identity: Option<RecoveryFsIdentity>,
+	pub data:     Option<Uint8Array>,
+}
+
+impl RecoveryFsResult {
+	const fn success(identity: RecoveryFsIdentity) -> Self {
+		Self { ok: true, code: None, identity: Some(identity), data: None }
+	}
+
+	fn data(identity: RecoveryFsIdentity, data: Vec<u8>) -> Self {
+		Self {
+			ok:       true,
+			code:     None,
+			identity: Some(identity),
+			data:     Some(Uint8Array::from(data)),
+		}
+	}
+
+	fn failure(code: &str) -> Self {
+		Self { ok: false, code: Some(code.to_owned()), identity: None, data: None }
+	}
+}
+
+/// Retained trusted-root authority for Linux recovery artifacts.
+#[napi]
+pub struct RecoveryFsRoot {
+	#[cfg(target_os = "linux")]
+	root: Mutex<Option<File>>,
+}
+
+#[napi]
+impl RecoveryFsRoot {
+	/// Return the stable identity of the retained root descriptor.
+	#[napi]
+	pub fn identity(&self) -> RecoveryFsResult {
+		#[cfg(target_os = "linux")]
+		{
+			self.root.lock().as_ref().map_or_else(
+				|| RecoveryFsResult::failure("closed"),
+				|root| identity(root).map_or_else(RecoveryFsResult::failure, RecoveryFsResult::success),
+			)
+		}
+		#[cfg(not(target_os = "linux"))]
+		RecoveryFsResult::failure("unsupported_platform")
+	}
+
+	/// Stat one existing regular, single-linked file without following links.
+	#[napi]
+	pub fn stat(&self, relative_path: String) -> RecoveryFsResult {
+		#[cfg(target_os = "linux")]
+		{
+			with_root(&self.root, |root| {
+				let file = open_existing(root, &relative_path, false)?;
+				regular_identity(&file).map(RecoveryFsResult::success)
+			})
+		}
+		#[cfg(not(target_os = "linux"))]
+		{
+			let _ = relative_path;
+			RecoveryFsResult::failure("unsupported_platform")
+		}
+	}
+
+	/// Read one existing regular, single-linked file without following links.
+	#[napi]
+	pub fn read(&self, relative_path: String, max_bytes: u32) -> RecoveryFsResult {
+		#[cfg(target_os = "linux")]
+		{
+			with_root(&self.root, |root| {
+				let max_bytes = u64::from(max_bytes).min(MAX_CONTENT_BYTES);
+				let file = open_existing(root, &relative_path, false)?;
+				let identity = regular_identity(&file)?;
+				if identity
+					.size
+					.parse::<u64>()
+					.ok()
+					.is_none_or(|size| size > max_bytes)
+				{
+					return Err("content_too_large");
+				}
+				let mut file = file;
+				let mut data = Vec::with_capacity(identity.size.parse::<usize>().unwrap_or(0));
+				file.read_to_end(&mut data).map_err(|_| "io_error")?;
+				if data.len() as u64 > max_bytes || regular_identity(&file)?.ino != identity.ino {
+					return Err("identity_mismatch");
+				}
+				Ok(RecoveryFsResult::data(identity, data))
+			})
+		}
+		#[cfg(not(target_os = "linux"))]
+		{
+			let _ = (relative_path, max_bytes);
+			RecoveryFsResult::failure("unsupported_platform")
+		}
+	}
+
+	/// Create one previously absent regular, owner-only file and synchronously
+	/// persist its contents. Existing entries are never replaced.
+	#[napi]
+	pub fn create(&self, relative_path: String, data: Uint8Array) -> RecoveryFsResult {
+		#[cfg(target_os = "linux")]
+		{
+			with_root(&self.root, |root| create(root, &relative_path, data.as_ref()))
+		}
+		#[cfg(not(target_os = "linux"))]
+		{
+			let _ = (relative_path, data);
+			RecoveryFsResult::failure("unsupported_platform")
+		}
+	}
+
+	/// Atomically install an already-created regular file at an absent name.
+	/// Both names remain relative to this retained root and are never resolved
+	/// through a pathname after their parent descriptors are acquired.
+	#[napi]
+	pub fn install(
+		&self,
+		source_relative_path: String,
+		destination_relative_path: String,
+	) -> RecoveryFsResult {
+		#[cfg(target_os = "linux")]
+		{
+			with_root(&self.root, |root| {
+				install(root, &source_relative_path, &destination_relative_path)
+			})
+		}
+		#[cfg(not(target_os = "linux"))]
+		{
+			let _ = (source_relative_path, destination_relative_path);
+			RecoveryFsResult::failure("unsupported_platform")
+		}
+	}
+
+	/// Synchronize the retained root directory, making a preceding create or
+	/// install durable when the filesystem supports directory fsync.
+	#[napi]
+	pub fn fsync(&self) -> RecoveryFsResult {
+		#[cfg(target_os = "linux")]
+		{
+			with_root(&self.root, |root| {
+				root.sync_all().map_err(|_| "fsync_failed")?;
+				identity(root).map(RecoveryFsResult::success)
+			})
+		}
+		#[cfg(not(target_os = "linux"))]
+		RecoveryFsResult::failure("unsupported_platform")
+	}
+
+	#[napi]
+	pub fn close(&self) -> RecoveryFsResult {
+		#[cfg(target_os = "linux")]
+		{
+			let mut root = self.root.lock();
+			let Some(root) = root.take() else {
+				return RecoveryFsResult::failure("closed");
+			};
+			identity(&root).map_or_else(RecoveryFsResult::failure, RecoveryFsResult::success)
+		}
+		#[cfg(not(target_os = "linux"))]
+		RecoveryFsResult::failure("unsupported_platform")
+	}
+}
+
+/// Acquire an immutable trusted-root descriptor. Linux is required; every
+/// other platform returns a durable unsupported-platform result.
+#[napi]
+pub fn open_recovery_fs_root(path: String) -> napi::Result<RecoveryFsRoot> {
+	#[cfg(target_os = "linux")]
+	{
+		let root = open_root(Path::new(&path)).map_err(napi::Error::from_reason)?;
+		Ok(RecoveryFsRoot { root: Mutex::new(Some(root)) })
+	}
+	#[cfg(not(target_os = "linux"))]
+	{
+		let _ = path;
+		Err(napi::Error::from_reason("unsupported_platform"))
+	}
+}
+
+#[cfg(target_os = "linux")]
+fn with_root(
+	root: &Mutex<Option<File>>,
+	operation: impl FnOnce(&File) -> Result<RecoveryFsResult, &'static str>,
+) -> RecoveryFsResult {
+	let guard = root.lock();
+	guard.as_ref().map_or_else(
+		|| RecoveryFsResult::failure("closed"),
+		|root| operation(root).unwrap_or_else(RecoveryFsResult::failure),
+	)
+}
+
+#[cfg(target_os = "linux")]
+fn stat_mtime_ns(stat: &libc::stat) -> i128 {
+	i128::from(stat.st_mtime) * 1_000_000_000 + i128::from(stat.st_mtime_nsec)
+}
+
+#[cfg(target_os = "linux")]
+fn identity(file: &File) -> Result<RecoveryFsIdentity, &'static str> {
+	use std::os::fd::AsRawFd;
+	// SAFETY: `libc::stat` may be zero-initialized before `fstat` fills its output
+	// storage.
+	let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+	// SAFETY: `file` owns a valid fd and `stat` is valid writable output storage
+	// for `fstat`.
+	if unsafe { libc::fstat(file.as_raw_fd(), &mut stat) } != 0 {
+		return Err("io_error");
+	}
+	Ok(RecoveryFsIdentity {
+		dev:      stat.st_dev.to_string(),
+		ino:      stat.st_ino.to_string(),
+		size:     (stat.st_size as u64).to_string(),
+		mtime_ns: stat_mtime_ns(&stat).to_string(),
+	})
+}
+
+#[cfg(target_os = "linux")]
+fn regular_identity(file: &File) -> Result<RecoveryFsIdentity, &'static str> {
+	use std::os::fd::AsRawFd;
+	// SAFETY: `libc::stat` may be zero-initialized before `fstat` fills its output
+	// storage.
+	let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+	// SAFETY: `file` owns a valid fd and `stat` is valid writable output storage
+	// for `fstat`.
+	if unsafe { libc::fstat(file.as_raw_fd(), &mut stat) } != 0 {
+		return Err("io_error");
+	}
+	if stat.st_mode & libc::S_IFMT != libc::S_IFREG {
+		return Err("not_regular_file");
+	}
+	if stat.st_nlink != 1 {
+		return Err("hard_link");
+	}
+	Ok(RecoveryFsIdentity {
+		dev:      stat.st_dev.to_string(),
+		ino:      stat.st_ino.to_string(),
+		size:     (stat.st_size as u64).to_string(),
+		mtime_ns: stat_mtime_ns(&stat).to_string(),
+	})
+}
+
+#[cfg(target_os = "linux")]
+fn segments(relative_path: &str) -> Result<Vec<CString>, &'static str> {
+	let path = Path::new(relative_path);
+	if path.is_absolute() || relative_path.contains('\0') {
+		return Err("invalid_path");
+	}
+	let mut names = Vec::new();
+	for component in path.components() {
+		match component {
+			Component::Normal(name) => {
+				names.push(CString::new(name.as_encoded_bytes()).map_err(|_| "invalid_path")?);
+			},
+			Component::CurDir | Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+				return Err("invalid_path");
+			},
+		}
+	}
+	if names.is_empty() {
+		Err("invalid_path")
+	} else {
+		Ok(names)
+	}
+}
+
+#[cfg(target_os = "linux")]
+fn open_root(path: &Path) -> Result<File, String> {
+	use std::os::{fd::FromRawFd, unix::ffi::OsStrExt};
+	if !path.is_absolute() {
+		return Err("invalid_path".to_owned());
+	}
+	let mut fd =
+	// SAFETY: the static C string is NUL-terminated and remains valid for this call.
+		unsafe { libc::open(c"/".as_ptr(), libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC) };
+	if fd < 0 {
+		return Err("io_error".to_owned());
+	}
+	for component in path.components() {
+		let Component::Normal(name) = component else {
+			continue;
+		};
+		let name = CString::new(name.as_bytes()).map_err(|_| "invalid_path".to_owned())?;
+		// SAFETY: `libc::stat` may be zero-initialized before `fstatat` fills its
+		// output storage.
+		let mut named: libc::stat = unsafe { std::mem::zeroed() };
+		// SAFETY: `fd` is open, `name` remains NUL-terminated and live, and `named` is
+		// writable output storage.
+		if unsafe { libc::fstatat(fd, name.as_ptr(), &mut named, libc::AT_SYMLINK_NOFOLLOW) } != 0
+			|| named.st_mode & libc::S_IFMT == libc::S_IFLNK
+		{
+			// SAFETY: `fd` is the currently owned open descriptor and is not used after
+			// this close.
+			unsafe { libc::close(fd) };
+			return Err("untrusted_root".to_owned());
+		}
+		// SAFETY: `fd` is open and `name` is a live NUL-terminated path component for
+		// the duration of the call.
+		let next = unsafe {
+			libc::openat(
+				fd,
+				name.as_ptr(),
+				libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+			)
+		};
+		// SAFETY: `fd` is the currently owned open descriptor and `next` has already
+		// received any replacement fd.
+		unsafe { libc::close(fd) };
+		if next < 0 {
+			return Err("untrusted_root".to_owned());
+		}
+		// SAFETY: `libc::stat` may be zero-initialized before `fstat` fills its output
+		// storage.
+		let mut opened: libc::stat = unsafe { std::mem::zeroed() };
+		// SAFETY: `next` is an open fd and `opened` is valid writable output storage
+		// for `fstat`.
+		if unsafe { libc::fstat(next, &mut opened) } != 0
+			|| opened.st_mode & libc::S_IFMT != libc::S_IFDIR
+			|| opened.st_dev != named.st_dev
+			|| opened.st_ino != named.st_ino
+		{
+			// SAFETY: `next` is the currently owned open descriptor and is not used after
+			// this close.
+			unsafe { libc::close(next) };
+			return Err("untrusted_root".to_owned());
+		}
+		fd = next;
+	}
+	// SAFETY: `fd` is an owned open descriptor whose ownership is transferred
+	// exactly once to `File`.
+	Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(target_os = "linux")]
+fn open_parent(root: &File, relative_path: &str) -> Result<(File, CString), &'static str> {
+	use std::os::fd::{AsRawFd, FromRawFd};
+	let names = segments(relative_path)?;
+	let (name, ancestors) = names.split_last().ok_or("invalid_path")?;
+	// SAFETY: `root` owns a valid fd; `dup` returns an independently owned
+	// descriptor on success.
+	let mut fd = unsafe { libc::dup(root.as_raw_fd()) };
+	if fd < 0 {
+		return Err("io_error");
+	}
+	for ancestor in ancestors {
+		// SAFETY: `libc::stat` may be zero-initialized before `fstatat` fills its
+		// output storage.
+		let mut named: libc::stat = unsafe { std::mem::zeroed() };
+		// SAFETY: `fd` is open, `ancestor` remains NUL-terminated and live, and `named`
+		// is writable output storage.
+		if unsafe { libc::fstatat(fd, ancestor.as_ptr(), &mut named, libc::AT_SYMLINK_NOFOLLOW) } != 0
+			|| named.st_mode & libc::S_IFMT != libc::S_IFDIR
+		{
+			// SAFETY: `fd` is the currently owned open descriptor and is not used after
+			// this close.
+			unsafe { libc::close(fd) };
+			return Err("reparse_point");
+		}
+		// SAFETY: `fd` is open and `ancestor` is a live NUL-terminated path component
+		// for the duration of the call.
+		let next = unsafe {
+			libc::openat(
+				fd,
+				ancestor.as_ptr(),
+				libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+			)
+		};
+		// SAFETY: `fd` is the currently owned open descriptor and `next` has already
+		// received any replacement fd.
+		unsafe { libc::close(fd) };
+		if next < 0 {
+			return Err("reparse_point");
+		}
+		// SAFETY: `libc::stat` may be zero-initialized before `fstat` fills its output
+		// storage.
+		let mut opened: libc::stat = unsafe { std::mem::zeroed() };
+		// SAFETY: `next` is an open fd and `opened` is valid writable output storage
+		// for `fstat`.
+		if unsafe { libc::fstat(next, &mut opened) } != 0
+			|| opened.st_mode & libc::S_IFMT != libc::S_IFDIR
+			|| opened.st_dev != named.st_dev
+			|| opened.st_ino != named.st_ino
+		{
+			// SAFETY: `next` is the currently owned open descriptor and is not used after
+			// this close.
+			unsafe { libc::close(next) };
+			return Err("identity_mismatch");
+		}
+		fd = next;
+	}
+	// SAFETY: `fd` is an owned open descriptor whose ownership is transferred
+	// exactly once to `File`.
+	Ok((unsafe { File::from_raw_fd(fd) }, name.clone()))
+}
+
+#[cfg(target_os = "linux")]
+fn open_existing(root: &File, relative_path: &str, writable: bool) -> Result<File, &'static str> {
+	use std::os::fd::{AsRawFd, FromRawFd};
+	let (parent, name) = open_parent(root, relative_path)?;
+	// SAFETY: `libc::stat` may be zero-initialized before `fstatat` fills its
+	// output storage.
+	let mut named: libc::stat = unsafe { std::mem::zeroed() };
+	// SAFETY: `parent` owns a valid fd, `name` is live and NUL-terminated, and
+	// `named` is writable output storage.
+	if unsafe {
+		libc::fstatat(parent.as_raw_fd(), name.as_ptr(), &mut named, libc::AT_SYMLINK_NOFOLLOW)
+	} != 0
+	{
+		return Err("not_found");
+	}
+	if named.st_mode & libc::S_IFMT == libc::S_IFLNK {
+		return Err("reparse_point");
+	}
+	if named.st_mode & libc::S_IFMT != libc::S_IFREG {
+		return Err("not_regular_file");
+	}
+	if named.st_nlink != 1 {
+		return Err("hard_link");
+	}
+	let flags = libc::O_CLOEXEC
+		| libc::O_NOFOLLOW
+		| if writable {
+			libc::O_RDWR
+		} else {
+			libc::O_RDONLY
+		};
+	// SAFETY: `parent` owns a valid fd and `name` is a live NUL-terminated path for
+	// the duration of the call.
+	let fd = unsafe { libc::openat(parent.as_raw_fd(), name.as_ptr(), flags) };
+	if fd < 0 {
+		return Err("io_error");
+	}
+	// SAFETY: `fd` is an owned open descriptor whose ownership is transferred
+	// exactly once to `File`.
+	let file = unsafe { File::from_raw_fd(fd) };
+	let actual = regular_identity(&file)?;
+	if actual.dev != named.st_dev.to_string() || actual.ino != named.st_ino.to_string() {
+		return Err("identity_mismatch");
+	}
+	Ok(file)
+}
+
+#[cfg(target_os = "linux")]
+fn create(root: &File, relative_path: &str, data: &[u8]) -> Result<RecoveryFsResult, &'static str> {
+	use std::os::fd::{AsRawFd, FromRawFd};
+	if data.len() as u64 > MAX_CONTENT_BYTES {
+		return Err("content_too_large");
+	}
+	let (parent, name) = open_parent(root, relative_path)?;
+	// SAFETY: `parent` owns a valid fd and `name` is a live NUL-terminated path for
+	// the duration of the call.
+	let fd = unsafe {
+		libc::openat(
+			parent.as_raw_fd(),
+			name.as_ptr(),
+			libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+			0o600,
+		)
+	};
+	if fd < 0 {
+		return Err(match std::io::Error::last_os_error().raw_os_error() {
+			Some(libc::EEXIST) => "already_exists",
+			_ => "io_error",
+		});
+	}
+	// SAFETY: `fd` is an owned open descriptor whose ownership is transferred
+	// exactly once to `File`.
+	let mut file = unsafe { File::from_raw_fd(fd) };
+	file.write_all(data).map_err(|_| "io_error")?;
+	file.sync_all().map_err(|_| "fsync_failed")?;
+	let identity = regular_identity(&file)?;
+	// SAFETY: `libc::stat` may be zero-initialized before `fstatat` fills its
+	// output storage.
+	let mut named: libc::stat = unsafe { std::mem::zeroed() };
+	// SAFETY: `parent` owns a valid fd, `name` is live and NUL-terminated, and
+	// `named` is writable output storage.
+	if unsafe {
+		libc::fstatat(parent.as_raw_fd(), name.as_ptr(), &mut named, libc::AT_SYMLINK_NOFOLLOW)
+	} != 0
+		|| identity.dev != named.st_dev.to_string()
+		|| identity.ino != named.st_ino.to_string()
+	{
+		return Err("identity_mismatch");
+	}
+	Ok(RecoveryFsResult::success(identity))
+}
+
+#[cfg(target_os = "linux")]
+fn install(root: &File, source: &str, destination: &str) -> Result<RecoveryFsResult, &'static str> {
+	use std::os::fd::AsRawFd;
+	let source_file = open_existing(root, source, false)?;
+	let source_identity = regular_identity(&source_file)?;
+	let (source_parent, source_name) = open_parent(root, source)?;
+	let (destination_parent, destination_name) = open_parent(root, destination)?;
+	// SAFETY: both parents own valid fds and both names are live NUL-terminated
+	// strings for this syscall.
+	let result = unsafe {
+		libc::syscall(
+			libc::SYS_renameat2,
+			source_parent.as_raw_fd(),
+			source_name.as_ptr(),
+			destination_parent.as_raw_fd(),
+			destination_name.as_ptr(),
+			libc::RENAME_NOREPLACE,
+		)
+	};
+	if result != 0 {
+		return Err(match std::io::Error::last_os_error().raw_os_error() {
+			Some(libc::EEXIST) => "already_exists",
+			Some(libc::ENOSYS | libc::EINVAL) => "atomic_unavailable",
+			_ => "io_error",
+		});
+	}
+	let installed = open_existing(root, destination, false)?;
+	let installed_identity = regular_identity(&installed)?;
+	if installed_identity.dev != source_identity.dev || installed_identity.ino != source_identity.ino
+	{
+		return Err("identity_mismatch");
+	}
+	destination_parent.sync_all().map_err(|_| "fsync_failed")?;
+	Ok(RecoveryFsResult::success(installed_identity))
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- Added fail-closed managed tmux owner SIGABRT recovery: exact-child supervisor receipts and pre-CLI admission now bind replacement ownership, strict durable Ultragoal/transcript evidence reconciles terminal child yields over stale nonterminal runtime state, recovery hydration remains write-free until an ownership fence, and hostile identity, corruption, concurrency, and path boundaries preserve dirty product files (#2681).
 - Restored the canonical public CLI command-surface contract for the independently documented `gjc memory` filesystem/MAP command after its feature merge omitted the expected command-list update.
 - Filesystem/MAP `memory doctor` now treats intentionally uninitialized scopes as absent instead of making partial-scope opt-in permanently unhealthy; explicit policy denials and real document/MAP safety findings remain reported.
 - Added evidence-preserving recovery for legacy multi-writer SDK session-index corruption: `gjc gc` now diagnoses corrupt prefixes, `--repair-session-index` quarantines the original snapshot/log under the session-index lock before atomically restoring only the checksum-valid monotonic prefix, and append failures point operators to the explicit repair path (#2654).

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -6,6 +5,18 @@ import { VERSION } from "@gajae-code/utils/dirs";
 import { safeStderrWrite } from "@gajae-code/utils/safe-stderr";
 import type { Args } from "../cli/args";
 import { readLinuxProcStartTimeSync } from "./linux-proc";
+import {
+	MANAGED_OWNER_PREDECESSOR_GENERATION_ENV,
+	MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV,
+	MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV,
+	MANAGED_OWNER_PREDECESSOR_TOKEN_ENV,
+	MANAGED_OWNER_TRANSCRIPT_PATH_ENV,
+} from "./managed-owner-admission";
+import {
+	MANAGED_OWNER_INCARNATION_ENV,
+	MANAGED_OWNER_RUN_ID_ENV,
+	MANAGED_OWNER_SUPERVISOR_ARG,
+} from "./managed-owner-supervisor";
 import { tmuxRuntimeSessionPath } from "./session-layout";
 import {
 	GJC_COORDINATOR_SESSION_BRANCH_ENV,
@@ -42,6 +53,7 @@ import {
 	type OwnerIsolationProbeSync,
 	planTmuxOwnerIsolationSync,
 	replaceOwnerGenerationSync,
+	resolveManagedOwnerPredecessorSync,
 	type TmuxServerProof,
 } from "./tmux-owner-isolation";
 import {
@@ -152,6 +164,9 @@ export interface TmuxLaunchPlan {
 	sessionStateFile?: string | null;
 	/** Immutable Linux-managed owner provenance, assigned immediately before creation. */
 	ownerGeneration?: string;
+	/** Immutable run and endpoint identities bound into the supervised command. */
+	ownerRunId?: string;
+	ownerIncarnation?: string;
 	/** Generation state captured before owner-isolation planning; required for publication CAS. */
 	ownerGenerationBaseline?: import("./tmux-owner-isolation").OwnerGenerationBaseline;
 	/** Native tmux session identity emitted atomically by `new-session -P -F`. */
@@ -334,6 +349,7 @@ interface CommandResolutionContext {
 	extraEnv?: Record<string, string>;
 	tmuxExitMarkerPath?: string;
 	platform?: NodeJS.Platform;
+	managedOwnerSupervisor?: boolean;
 }
 
 function parseLaunchPolicy(env: NodeJS.ProcessEnv): LaunchPolicy {
@@ -553,8 +569,15 @@ function buildInnerCommand(context: CommandResolutionContext, rawArgs: string[])
 			tmuxExitMarkerPath: context.tmuxExitMarkerPath,
 		});
 	const command = resolveCurrentGjcCommand(context);
-	const quoted = [...command, ...stripRootTmuxFlag(rawArgs)].map(shellQuote).join(" ");
-	const invocation = `env ${GJC_TMUX_LAUNCHED_ENV}=1${buildEnvAssignments(context.extraEnv)} ${quoted}`;
+	const childArgs = stripRootTmuxFlag(rawArgs);
+	const supervisorEnv: Record<string, string> = context.managedOwnerSupervisor
+		? { GJC_MANAGED_OWNER_COMMAND_JSON: JSON.stringify([...command, ...childArgs]) }
+		: {};
+	const invocationArgs = context.managedOwnerSupervisor
+		? [...command, MANAGED_OWNER_SUPERVISOR_ARG]
+		: [...command, ...childArgs];
+	const quoted = invocationArgs.map(shellQuote).join(" ");
+	const invocation = `env ${GJC_TMUX_LAUNCHED_ENV}=1${buildEnvAssignments({ ...context.extraEnv, ...supervisorEnv })} ${quoted}`;
 	if (!context.tmuxExitMarkerPath) return `exec ${invocation}`;
 	return `${buildPosixTmuxExitMarkerPrefix(context.tmuxExitMarkerPath)}; ${invocation}; exit $?`;
 }
@@ -1026,15 +1049,29 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 	};
 }
 
+function trustedReplacementAuthority(
+	stateDir: string,
+	sessionId: string,
+	baseline: ReturnType<typeof captureOwnerGenerationBaselineSync>,
+): ReturnType<typeof resolveManagedOwnerPredecessorSync> {
+	return resolveManagedOwnerPredecessorSync(stateDir, sessionId, baseline);
+}
+
 function prepareManagedOwnerLifecycle(plan: TmuxLaunchPlan, context: TmuxLaunchContext): void {
 	if (plan.ownerGeneration) return;
 	const sessionId = plan.sessionId ?? plan.sessionName;
 	const stateDir = path.dirname(plan.sessionStateFile ?? path.join(plan.cwd, ".gjc", "runtime"));
+	const baseline = captureOwnerGenerationBaselineSync(stateDir, sessionId);
+	const replacement = trustedReplacementAuthority(stateDir, sessionId, baseline);
 	const generation = crypto.randomUUID();
-	// Stage the generation in the child command. It becomes current only after
+	const runId = crypto.randomUUID();
+	const incarnation = crypto.randomUUID();
+	plan.ownerGenerationBaseline = baseline;
+	// Stage immutable identity in the child command. It becomes current only after
 	// immutable creation proof and ownership tagging complete.
-
 	plan.ownerGeneration = generation;
+	plan.ownerRunId = runId;
+	plan.ownerIncarnation = incarnation;
 	const innerCommand = buildInnerCommand(
 		{
 			cwd: plan.cwd,
@@ -1047,11 +1084,24 @@ function prepareManagedOwnerLifecycle(plan: TmuxLaunchPlan, context: TmuxLaunchC
 				[GJC_TMUX_OWNER_GENERATION_ENV]: generation,
 				[GJC_TMUX_OWNER_STATE_DIR_ENV]: stateDir,
 				[GJC_TMUX_OWNER_SERVER_KEY_ENV]: plan.tmuxCommand,
+				[MANAGED_OWNER_RUN_ID_ENV]: runId,
+				[MANAGED_OWNER_INCARNATION_ENV]: incarnation,
+				...(replacement
+					? {
+							[MANAGED_OWNER_PREDECESSOR_TOKEN_ENV]: replacement.predecessorToken,
+							[MANAGED_OWNER_PREDECESSOR_GENERATION_ENV]: replacement.generation,
+							[MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV]: replacement.runId,
+							[MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV]: replacement.incarnation,
+							[MANAGED_OWNER_TRANSCRIPT_PATH_ENV]:
+								context.env?.GJC_SESSION_FILE ?? process.env.GJC_SESSION_FILE ?? "",
+						}
+					: {}),
 			},
 			// Linux managed owner close signals the pane PID. Do not place the exit-marker shell
 			// in front of it; `buildInnerCommand` therefore execs the GJC owner directly.
 			tmuxExitMarkerPath: plan.platform === "linux" ? undefined : tmuxExitMarkerPath(plan.sessionStateFile ?? ""),
 			platform: plan.platform,
+			managedOwnerSupervisor: plan.platform === "linux",
 		},
 		context.rawArgs,
 	);
@@ -1182,7 +1232,7 @@ function createIsolatedTmuxSession(
 ): TmuxSpawnResult {
 	const sessionId = plan.sessionId ?? plan.sessionName;
 	const stateDir = path.dirname(plan.sessionStateFile ?? path.join(plan.cwd, ".gjc", "runtime"));
-	const baseline = captureOwnerGenerationBaselineSync(stateDir, sessionId);
+	const baseline = plan.ownerGenerationBaseline ?? captureOwnerGenerationBaselineSync(stateDir, sessionId);
 	plan.ownerGenerationBaseline = baseline;
 	const ownerPlan = planTmuxOwnerIsolationSync(
 		{
@@ -1572,6 +1622,11 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		return true;
 	}
 	try {
+		resolveManagedOwnerPredecessorSync(
+			path.dirname(plan.sessionStateFile!),
+			plan.sessionId!,
+			plan.ownerGenerationBaseline!,
+		);
 		replaceOwnerGenerationSync(
 			path.dirname(plan.sessionStateFile!),
 			plan.sessionId!,

--- a/packages/coding-agent/src/gjc-runtime/managed-owner-admission.ts
+++ b/packages/coding-agent/src/gjc-runtime/managed-owner-admission.ts
@@ -1,0 +1,352 @@
+import { Buffer } from "node:buffer";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { openRecoveryFsRoot } from "@gajae-code/natives";
+import {
+	MANAGED_OWNER_CHILD_TOKEN_ENV,
+	MANAGED_OWNER_GENERATION_ENV,
+	MANAGED_OWNER_INCARNATION_ENV,
+	MANAGED_OWNER_RUN_ID_ENV,
+	MANAGED_OWNER_SESSION_ID_ENV,
+	MANAGED_OWNER_STATE_DIR_ENV,
+	type ManagedOwnerBinding,
+	type ManagedOwnerSigabrtReceipt,
+} from "./managed-owner-supervisor";
+import { assertSafePathComponent } from "./session-layout";
+import { lifecyclePaths } from "./tmux-owner-isolation";
+import {
+	persistUltragoalRecoveryDecision,
+	planUltragoalOwnerLossRecovery,
+	type UltragoalRecoveryDecision,
+} from "./ultragoal-owner-loss-recovery";
+
+export const MANAGED_OWNER_PREDECESSOR_TOKEN_ENV = "GJC_MANAGED_OWNER_PREDECESSOR_TOKEN";
+export const MANAGED_OWNER_PREDECESSOR_GENERATION_ENV = "GJC_MANAGED_OWNER_PREDECESSOR_GENERATION";
+export const MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV = "GJC_MANAGED_OWNER_PREDECESSOR_RUN_ID";
+export const MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV = "GJC_MANAGED_OWNER_PREDECESSOR_INCARNATION";
+export const MANAGED_OWNER_TRANSCRIPT_PATH_ENV = "GJC_MANAGED_OWNER_TRANSCRIPT_PATH";
+
+export interface ManagedOwnerRecoveryContext {
+	root: string;
+	binding: ManagedOwnerBinding;
+	receipt: ManagedOwnerSigabrtReceipt;
+	admission: { session_id: string; endpoint_incarnation: string; owner_generation: string; admitted: true };
+	decision: UltragoalRecoveryDecision;
+}
+export type ManagedOwnerAdmission =
+	| { kind: "fresh" | "supervised" }
+	| { kind: "recovery"; context: ManagedOwnerRecoveryContext }
+	| { kind: "blocked" };
+
+function ownerEnvironment(): {
+	root: string;
+	generation: string;
+	sessionId: string;
+	runId: string;
+	incarnation: string;
+} | null {
+	const stateDir = process.env[MANAGED_OWNER_STATE_DIR_ENV]?.trim();
+	const sessionId = process.env[MANAGED_OWNER_SESSION_ID_ENV]?.trim();
+	const generation = process.env[MANAGED_OWNER_GENERATION_ENV]?.trim();
+	const runId = process.env[MANAGED_OWNER_RUN_ID_ENV]?.trim();
+	const incarnation = process.env[MANAGED_OWNER_INCARNATION_ENV]?.trim();
+	if (!stateDir && !sessionId && !generation && !runId && !incarnation) return null;
+	if (!stateDir || !sessionId || !generation || !runId || !incarnation || !path.isAbsolute(stateDir))
+		throw new Error("managed_owner_admission_metadata_invalid");
+	for (const [value, label] of [
+		[sessionId, "managed owner session id"],
+		[generation, "managed owner generation"],
+		[runId, "managed owner run id"],
+		[incarnation, "managed owner incarnation"],
+	] as const)
+		assertSafePathComponent(value, label);
+	const root = lifecyclePaths(stateDir, sessionId, generation).root;
+	if (!root.startsWith(`${path.resolve(stateDir)}${path.sep}`)) throw new Error("managed_owner_admission_path_unsafe");
+	return { root, generation, sessionId, runId, incarnation };
+}
+
+function isCommand(command: unknown): command is string[] {
+	return (
+		Array.isArray(command) &&
+		command.length > 0 &&
+		command.every(value => typeof value === "string" && value.length > 0)
+	);
+}
+
+function isBinding(
+	value: unknown,
+	expected: { generation: string; sessionId: string; runId: string; incarnation: string; token: string },
+): value is ManagedOwnerBinding {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const binding = value as Partial<ManagedOwnerBinding>;
+	return (
+		binding.schema_version === 2 &&
+		binding.generation === expected.generation &&
+		binding.session_id === expected.sessionId &&
+		binding.run_id === expected.runId &&
+		binding.endpoint_incarnation === expected.incarnation &&
+		binding.child_token === expected.token &&
+		isCommand(binding.command) &&
+		typeof binding.command_sha256 === "string" &&
+		binding.command_sha256 === crypto.createHash("sha256").update(JSON.stringify(binding.command)).digest("hex") &&
+		typeof binding.supervisor_pid === "number" &&
+		Number.isSafeInteger(binding.supervisor_pid) &&
+		binding.supervisor_pid > 0 &&
+		typeof binding.supervisor_start_time === "string" &&
+		typeof binding.created_at === "string"
+	);
+}
+
+function isReceipt(value: unknown, binding: ManagedOwnerBinding): value is ManagedOwnerSigabrtReceipt {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const receipt = value as Partial<ManagedOwnerSigabrtReceipt>;
+	return (
+		receipt.schema_version === 2 &&
+		receipt.generation === binding.generation &&
+		receipt.session_id === binding.session_id &&
+		receipt.run_id === binding.run_id &&
+		receipt.endpoint_incarnation === binding.endpoint_incarnation &&
+		receipt.child_token === binding.child_token &&
+		receipt.command_sha256 === binding.command_sha256 &&
+		receipt.supervisor_pid === binding.supervisor_pid &&
+		receipt.supervisor_start_time === binding.supervisor_start_time &&
+		typeof receipt.child_pid === "number" &&
+		Number.isSafeInteger(receipt.child_pid) &&
+		receipt.child_pid > 0 &&
+		typeof receipt.child_start_time === "string" &&
+		receipt.signal === "SIGABRT" &&
+		receipt.signal_number === 6 &&
+		(receipt.exit_code === null || Number.isSafeInteger(receipt.exit_code)) &&
+		typeof receipt.received_at === "string"
+	);
+}
+
+function safeChildToken(value: string): boolean {
+	try {
+		assertSafePathComponent(value, "managed owner child token");
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function readExactJsons(root: string, files: readonly string[]): Promise<unknown[] | null> {
+	if (process.platform !== "linux") return null;
+	try {
+		const authority = openRecoveryFsRoot(root);
+		try {
+			const values: unknown[] = [];
+			for (const file of files) {
+				const result = authority.read(file, 64 * 1024);
+				if (!result.ok || !result.data) return null;
+				const content = Buffer.from(result.data).toString("utf8");
+				if (!content.endsWith("\n") || content.indexOf("\n") !== content.length - 1) return null;
+				values.push(JSON.parse(content));
+			}
+			return values;
+		} finally {
+			authority.close();
+		}
+	} catch {
+		return null;
+	}
+}
+
+async function durableHandoff(
+	root: string,
+	generation: string,
+	sessionId: string,
+	reason: string,
+	details: Record<string, unknown> = {},
+): Promise<void> {
+	await fs.mkdir(root, { recursive: true, mode: 0o700 });
+	const file = path.join(root, `admission-handoff-${crypto.randomUUID()}.json`);
+	const record = {
+		schema_version: 2,
+		generation,
+		session_id: sessionId,
+		state: "fail_closed_handoff",
+		reason,
+		...details,
+		created_at: new Date().toISOString(),
+	};
+	const handle = await fs.open(file, "wx", 0o600);
+	try {
+		await handle.writeFile(`${JSON.stringify(record)}\n`);
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+	const directory = await fs.open(root, "r");
+	try {
+		await directory.sync();
+	} finally {
+		await directory.close();
+	}
+}
+
+/**
+ * This is the pre-CLI barrier. A replacement is identified only by the exact
+ * predecessor token supplied by its launch binding; directory enumeration is
+ * deliberately never an authority source.
+ */
+export async function admitManagedOwnerBeforeCli(): Promise<ManagedOwnerAdmission> {
+	const owner = ownerEnvironment();
+	if (!owner) return { kind: "fresh" };
+	const childToken = process.env[MANAGED_OWNER_CHILD_TOKEN_ENV]?.trim();
+	const predecessorToken = process.env[MANAGED_OWNER_PREDECESSOR_TOKEN_ENV]?.trim();
+	if (childToken && !predecessorToken) {
+		if (!safeChildToken(childToken)) {
+			await durableHandoff(owner.root, owner.generation, owner.sessionId, "exact_child_binding_unavailable");
+			process.exitCode = 75;
+			return { kind: "blocked" };
+		}
+		const [binding] = (await readExactJsons(owner.root, [`child-${childToken}.binding.json`])) ?? [];
+		if (
+			isBinding(binding, {
+				generation: owner.generation,
+				sessionId: owner.sessionId,
+				runId: owner.runId,
+				incarnation: owner.incarnation,
+				token: childToken,
+			})
+		)
+			return { kind: "supervised" };
+		await durableHandoff(owner.root, owner.generation, owner.sessionId, "exact_child_binding_unavailable");
+		process.exitCode = 75;
+		return { kind: "blocked" };
+	}
+	const predecessorGeneration = process.env[MANAGED_OWNER_PREDECESSOR_GENERATION_ENV]?.trim();
+	const predecessorRunId = process.env[MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV]?.trim();
+	const predecessorIncarnation = process.env[MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV]?.trim();
+	if (!predecessorGeneration || !predecessorRunId || !predecessorIncarnation) {
+		await durableHandoff(owner.root, owner.generation, owner.sessionId, "replacement_predecessor_identity_missing");
+		process.exitCode = 75;
+		return { kind: "blocked" };
+	}
+	if (!predecessorToken) {
+		await durableHandoff(owner.root, owner.generation, owner.sessionId, "replacement_predecessor_binding_missing");
+		process.exitCode = 75;
+		return { kind: "blocked" };
+	}
+	if (!safeChildToken(predecessorToken)) {
+		await durableHandoff(owner.root, owner.generation, owner.sessionId, "replacement_predecessor_binding_untrusted");
+		process.exitCode = 75;
+		return { kind: "blocked" };
+	}
+	const [binding, receipt] =
+		(await readExactJsons(owner.root, [
+			`child-${predecessorToken}.binding.json`,
+			`sigabrt-${predecessorToken}.receipt.json`,
+		])) ?? [];
+	if (
+		!isBinding(binding, {
+			generation: predecessorGeneration,
+			sessionId: owner.sessionId,
+			runId: predecessorRunId,
+			incarnation: predecessorIncarnation,
+			token: predecessorToken,
+		})
+	) {
+		await durableHandoff(owner.root, owner.generation, owner.sessionId, "replacement_predecessor_binding_untrusted");
+		process.exitCode = 75;
+		return { kind: "blocked" };
+	}
+	if (!isReceipt(receipt, binding)) {
+		await durableHandoff(owner.root, owner.generation, owner.sessionId, "exact_sigabrt_receipt_untrusted");
+		process.exitCode = 75;
+		return { kind: "blocked" };
+	}
+	const admission = {
+		session_id: owner.sessionId,
+		endpoint_incarnation: predecessorIncarnation,
+		owner_generation: predecessorGeneration,
+		admitted: true,
+	} as const;
+	const decision = await planUltragoalOwnerLossRecovery({
+		binding: {
+			sessionId: owner.sessionId,
+			endpointIncarnation: predecessorIncarnation,
+			ownerGeneration: predecessorGeneration,
+			cwd: process.cwd(),
+		},
+		receipt,
+		admission,
+		transcriptPath: process.env[MANAGED_OWNER_TRANSCRIPT_PATH_ENV] ?? "",
+	});
+	await persistUltragoalRecoveryDecision({
+		cwd: process.cwd(),
+		sessionId: owner.sessionId,
+		binding: {
+			sessionId: owner.sessionId,
+			endpointIncarnation: predecessorIncarnation,
+			ownerGeneration: predecessorGeneration,
+			cwd: process.cwd(),
+		},
+		decision,
+	});
+	if (decision.disposition !== "resume") {
+		await durableHandoff(owner.root, owner.generation, owner.sessionId, decision.reason);
+		process.exitCode = 75;
+		return { kind: "blocked" };
+	}
+	return { kind: "recovery", context: { root: owner.root, binding, receipt, admission, decision } };
+}
+
+/**
+ * The ordinary CLI factory has no recovery-owned writer-lease or exact-child
+ * reconciliation capability.  Do not route a recovered owner through it: first
+ * revalidate the immutable evidence and B0, then publish a terminal handoff.
+ */
+export async function completeManagedOwnerRecovery(
+	context: ManagedOwnerRecoveryContext,
+): Promise<{ kind: "handoff"; exitCode: 75 }> {
+	const recoveryBinding = {
+		sessionId: context.binding.session_id,
+		endpointIncarnation: context.binding.endpoint_incarnation,
+		ownerGeneration: context.binding.generation,
+		cwd: process.cwd(),
+	};
+	const revalidated = await planUltragoalOwnerLossRecovery({
+		binding: recoveryBinding,
+		receipt: context.receipt,
+		admission: context.admission,
+		transcriptPath: process.env[MANAGED_OWNER_TRANSCRIPT_PATH_ENV] ?? "",
+		protectedPaths: context.decision.snapshot?.protectedPaths,
+		sanctionedDeltas: context.decision.snapshot?.sanctionedDeltas,
+		absentArtifacts: context.decision.snapshot?.absentArtifacts,
+		transientHistory: context.decision.snapshot?.transientHistory,
+	});
+	const b0Unchanged =
+		context.decision.snapshot !== undefined &&
+		revalidated.snapshot !== undefined &&
+		context.decision.snapshot.b0.planSha256 === revalidated.snapshot.b0.planSha256 &&
+		context.decision.snapshot.b0.ledgerSha256 === revalidated.snapshot.b0.ledgerSha256;
+	const transcriptUnchanged =
+		context.decision.terminal?.yieldId !== undefined &&
+		revalidated.terminal?.yieldId === context.decision.terminal.yieldId;
+	const reason =
+		revalidated.disposition !== "resume"
+			? `recovery_authority_changed:${revalidated.reason}`
+			: !b0Unchanged
+				? "recovery_b0_changed"
+				: !transcriptUnchanged
+					? "recovery_transcript_changed"
+					: "safe_session_resume_seam_unavailable";
+	const decision: UltragoalRecoveryDecision = { disposition: "handoff", reason };
+	await persistUltragoalRecoveryDecision({
+		cwd: recoveryBinding.cwd,
+		sessionId: recoveryBinding.sessionId,
+		binding: recoveryBinding,
+		decision,
+	});
+	await durableHandoff(context.root, context.binding.generation, context.binding.session_id, reason, {
+		predecessor_child_token: context.binding.child_token,
+		predecessor_run_id: context.binding.run_id,
+		terminal_reconciliation: "unavailable_without_owning_store_cas",
+		b0_preserved: b0Unchanged,
+	});
+	process.exitCode = 75;
+	return { kind: "handoff", exitCode: 75 };
+}

--- a/packages/coding-agent/src/gjc-runtime/managed-owner-supervisor.ts
+++ b/packages/coding-agent/src/gjc-runtime/managed-owner-supervisor.ts
@@ -1,0 +1,162 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { readLinuxProcStartTime } from "./linux-proc";
+import { assertSafePathComponent } from "./session-layout";
+import { lifecyclePaths } from "./tmux-owner-isolation";
+
+export const MANAGED_OWNER_SUPERVISOR_ARG = "--internal-managed-owner-supervisor";
+export const MANAGED_OWNER_CHILD_TOKEN_ENV = "GJC_MANAGED_OWNER_CHILD_TOKEN";
+export const MANAGED_OWNER_COMMAND_ENV = "GJC_MANAGED_OWNER_COMMAND_JSON";
+export const MANAGED_OWNER_SESSION_ID_ENV = "GJC_COORDINATOR_SESSION_ID";
+export const MANAGED_OWNER_GENERATION_ENV = "GJC_TMUX_OWNER_GENERATION";
+export const MANAGED_OWNER_STATE_DIR_ENV = "GJC_TMUX_OWNER_STATE_DIR";
+export const MANAGED_OWNER_RUN_ID_ENV = "GJC_MANAGED_OWNER_RUN_ID";
+export const MANAGED_OWNER_INCARNATION_ENV = "GJC_MANAGED_OWNER_INCARNATION";
+
+export interface ManagedOwnerBinding {
+	schema_version: 2;
+	generation: string;
+	session_id: string;
+	run_id: string;
+	endpoint_incarnation: string;
+	child_token: string;
+	command: string[];
+	command_sha256: string;
+	supervisor_pid: number;
+	supervisor_start_time: string;
+	created_at: string;
+}
+
+export interface ManagedOwnerSigabrtReceipt {
+	schema_version: 2;
+	generation: string;
+	session_id: string;
+	run_id: string;
+	endpoint_incarnation: string;
+	child_token: string;
+	command_sha256: string;
+	supervisor_pid: number;
+	supervisor_start_time: string;
+	child_pid: number;
+	child_start_time: string;
+	signal: "SIGABRT";
+	signal_number: 6;
+	exit_code: number | null;
+	received_at: string;
+}
+
+function requiredEnvironment(name: string): string {
+	const value = process.env[name]?.trim();
+	if (!value) throw new Error(`managed_owner_${name.toLowerCase()}_missing`);
+	return value;
+}
+
+function lifecycleRoot(): { root: string; generation: string; sessionId: string; runId: string; incarnation: string } {
+	const stateDir = requiredEnvironment(MANAGED_OWNER_STATE_DIR_ENV);
+	const sessionId = requiredEnvironment(MANAGED_OWNER_SESSION_ID_ENV);
+	const generation = requiredEnvironment(MANAGED_OWNER_GENERATION_ENV);
+	const runId = requiredEnvironment(MANAGED_OWNER_RUN_ID_ENV);
+	const incarnation = requiredEnvironment(MANAGED_OWNER_INCARNATION_ENV);
+	for (const [value, label] of [
+		[sessionId, "managed owner session id"],
+		[generation, "managed owner generation"],
+		[runId, "managed owner run id"],
+		[incarnation, "managed owner incarnation"],
+	] as const)
+		assertSafePathComponent(value, label);
+	if (!path.isAbsolute(stateDir)) throw new Error("managed_owner_lifecycle_path_unsafe");
+	const root = lifecyclePaths(stateDir, sessionId, generation).root;
+	if (!root.startsWith(`${path.resolve(stateDir)}${path.sep}`)) throw new Error("managed_owner_lifecycle_path_unsafe");
+	return { root, generation, sessionId, runId, incarnation };
+}
+
+function commandDigest(command: readonly string[]): string {
+	return crypto.createHash("sha256").update(JSON.stringify(command)).digest("hex");
+}
+
+async function writeDurableExclusive(file: string, value: object): Promise<void> {
+	const handle = await fs.open(file, "wx", 0o600);
+	try {
+		await handle.writeFile(`${JSON.stringify(value)}\n`);
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+	const directory = await fs.open(path.dirname(file), "r");
+	try {
+		await directory.sync();
+	} finally {
+		await directory.close();
+	}
+	const persisted = JSON.parse(await fs.readFile(file, "utf8")) as unknown;
+	if (JSON.stringify(persisted) !== JSON.stringify(value)) throw new Error("managed_owner_durable_reread_failed");
+}
+
+function childCommand(): string[] {
+	const command = JSON.parse(requiredEnvironment(MANAGED_OWNER_COMMAND_ENV)) as unknown;
+	if (!Array.isArray(command) || command.length === 0 || command.some(value => typeof value !== "string" || !value))
+		throw new Error("managed_owner_command_invalid");
+	return command;
+}
+
+export function isManagedOwnerSupervisorArgv(args: readonly string[]): boolean {
+	return args.length === 1 && args[0] === MANAGED_OWNER_SUPERVISOR_ARG;
+}
+
+/** Runs one exact child and publishes authority only for a directly observed Linux signal 6. */
+export async function runManagedOwnerSupervisor(): Promise<void> {
+	const { root, generation, sessionId, runId, incarnation } = lifecycleRoot();
+	const command = childCommand();
+	const supervisorStartTime = await readLinuxProcStartTime(process.pid);
+	if (!supervisorStartTime) throw new Error("managed_owner_supervisor_start_time_unavailable");
+	await fs.mkdir(root, { recursive: true, mode: 0o700 });
+	const childToken = crypto.randomUUID();
+	const binding: ManagedOwnerBinding = {
+		schema_version: 2,
+		generation,
+		session_id: sessionId,
+		run_id: runId,
+		endpoint_incarnation: incarnation,
+		child_token: childToken,
+		command,
+		command_sha256: commandDigest(command),
+		supervisor_pid: process.pid,
+		supervisor_start_time: supervisorStartTime,
+		created_at: new Date().toISOString(),
+	};
+	await writeDurableExclusive(path.join(root, `child-${childToken}.binding.json`), binding);
+	const child = Bun.spawn({
+		cmd: command,
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+		env: { ...process.env, [MANAGED_OWNER_CHILD_TOKEN_ENV]: childToken },
+	});
+	const childStartTime = await readLinuxProcStartTime(child.pid);
+	if (!childStartTime) throw new Error("managed_owner_child_start_time_unavailable");
+	const exitCode = await child.exited;
+	if (child.signalCode === "SIGABRT") {
+		const receipt: ManagedOwnerSigabrtReceipt = {
+			schema_version: 2,
+			generation,
+			session_id: sessionId,
+			run_id: runId,
+			endpoint_incarnation: incarnation,
+			child_token: childToken,
+			command_sha256: binding.command_sha256,
+			supervisor_pid: process.pid,
+			supervisor_start_time: supervisorStartTime,
+			child_pid: child.pid,
+			child_start_time: childStartTime,
+			signal: "SIGABRT",
+			signal_number: 6,
+			exit_code: exitCode,
+			received_at: new Date().toISOString(),
+		};
+		await writeDurableExclusive(path.join(root, `sigabrt-${childToken}.receipt.json`), receipt);
+		process.exitCode = 134;
+		return;
+	}
+	process.exitCode = exitCode;
+}

--- a/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation.ts
@@ -11,6 +11,7 @@ import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 
 import * as path from "node:path";
+import { openRecoveryFsRoot } from "@gajae-code/natives";
 import { isCompiledBinary } from "@gajae-code/utils/env";
 import { parseLinuxProcStartTime } from "./linux-proc";
 
@@ -1044,6 +1045,122 @@ function sameOwnerGenerationBaseline(left: OwnerGenerationBaseline, right: Owner
 				left.session_id === right.session_id &&
 				left.published_at === right.published_at))
 	);
+}
+
+export interface ManagedOwnerPredecessorEvidence {
+	generation: string;
+	sessionId: string;
+	runId: string;
+	incarnation: string;
+	predecessorToken: string;
+}
+
+function exactManagedOwnerJson(authority: ReturnType<typeof openRecoveryFsRoot>, name: string): unknown {
+	const first = authority.read(name, 64 * 1024);
+	if (!first.ok || !first.data) throw new Error("managed_owner_replacement_evidence_unavailable");
+	const second = authority.read(name, 64 * 1024);
+	if (
+		!second.ok ||
+		!second.data ||
+		Buffer.compare(Buffer.from(first.data), Buffer.from(second.data)) !== 0 ||
+		JSON.stringify(first.identity) !== JSON.stringify(second.identity)
+	)
+		throw new Error("managed_owner_replacement_evidence_changed");
+	const content = Buffer.from(first.data).toString("utf8");
+	if (!content.endsWith("\n") || content.indexOf("\n") !== content.length - 1)
+		throw new Error("managed_owner_replacement_evidence_untrusted");
+	return JSON.parse(content);
+}
+
+/** Resolve one SIGABRT predecessor from the retained exact prior-generation root. */
+export function resolveManagedOwnerPredecessorSync(
+	stateDir: string,
+	sessionId: string,
+	baseline: OwnerGenerationBaseline,
+): ManagedOwnerPredecessorEvidence | undefined {
+	if (baseline.state === "absent") return undefined;
+	const root = lifecyclePaths(stateDir, sessionId, baseline.generation).root;
+	let entries: string[];
+	try {
+		entries = fsSync.readdirSync(root);
+	} catch {
+		throw new Error("managed_owner_replacement_evidence_unavailable");
+	}
+	const bindings = new Set<string>();
+	const receipts = new Set<string>();
+	for (const entry of entries) {
+		const binding = /^child-([^/]+)\.binding\.json$/.exec(entry);
+		const receipt = /^sigabrt-([^/]+)\.receipt\.json$/.exec(entry);
+		if (entry.startsWith("child-") && !binding) throw new Error("managed_owner_replacement_evidence_untrusted");
+		if (entry.startsWith("sigabrt-") && !receipt) throw new Error("managed_owner_replacement_evidence_untrusted");
+		if (binding) bindings.add(binding[1]!);
+		if (receipt) receipts.add(receipt[1]!);
+	}
+	if (bindings.size === 0 && receipts.size === 0) return undefined;
+	const tokens = [...bindings].filter(token => receipts.has(token));
+	if (tokens.length !== 1 || receipts.size !== 1) throw new Error("managed_owner_replacement_evidence_ambiguous");
+	const predecessorToken = tokens[0]!;
+	if (!/^[A-Za-z0-9._-]+$/.test(predecessorToken)) throw new Error("managed_owner_replacement_evidence_untrusted");
+	const authority = openRecoveryFsRoot(root);
+	try {
+		const binding = exactManagedOwnerJson(authority, `child-${predecessorToken}.binding.json`) as Record<
+			string,
+			unknown
+		>;
+		const receipt = exactManagedOwnerJson(authority, `sigabrt-${predecessorToken}.receipt.json`) as Record<
+			string,
+			unknown
+		>;
+		const command = binding.command;
+		const runId = binding.run_id;
+		const incarnation = binding.endpoint_incarnation;
+		const commandDigest =
+			Array.isArray(command) && command.length > 0 && command.every(value => typeof value === "string" && value)
+				? crypto.createHash("sha256").update(JSON.stringify(command)).digest("hex")
+				: "";
+		const valid =
+			binding.schema_version === 2 &&
+			binding.generation === baseline.generation &&
+			binding.session_id === sessionId &&
+			typeof runId === "string" &&
+			runId.length > 0 &&
+			typeof incarnation === "string" &&
+			incarnation.length > 0 &&
+			binding.child_token === predecessorToken &&
+			binding.command_sha256 === commandDigest &&
+			typeof binding.supervisor_pid === "number" &&
+			Number.isSafeInteger(binding.supervisor_pid) &&
+			binding.supervisor_pid > 0 &&
+			typeof binding.supervisor_start_time === "string" &&
+			typeof binding.created_at === "string" &&
+			receipt.schema_version === 2 &&
+			receipt.generation === binding.generation &&
+			receipt.session_id === binding.session_id &&
+			receipt.run_id === runId &&
+			receipt.endpoint_incarnation === incarnation &&
+			receipt.child_token === binding.child_token &&
+			receipt.command_sha256 === binding.command_sha256 &&
+			receipt.supervisor_pid === binding.supervisor_pid &&
+			receipt.supervisor_start_time === binding.supervisor_start_time &&
+			typeof receipt.child_pid === "number" &&
+			Number.isSafeInteger(receipt.child_pid) &&
+			receipt.child_pid > 0 &&
+			typeof receipt.child_start_time === "string" &&
+			typeof receipt.received_at === "string" &&
+			(receipt.exit_code === null || Number.isSafeInteger(receipt.exit_code)) &&
+			receipt.signal === "SIGABRT" &&
+			receipt.signal_number === 6;
+		if (!valid) throw new Error("managed_owner_replacement_evidence_untrusted");
+		return {
+			generation: baseline.generation,
+			sessionId,
+			runId,
+			incarnation,
+			predecessorToken,
+		};
+	} finally {
+		authority.close();
+	}
 }
 
 export async function captureOwnerGenerationBaseline(

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-owner-loss-recovery.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-owner-loss-recovery.ts
@@ -1,0 +1,328 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { openRecoveryFsRoot } from "@gajae-code/natives";
+import type { ManagedOwnerSigabrtReceipt } from "./managed-owner-supervisor";
+import { sessionStateDir, sessionUltragoalDir } from "./session-layout";
+import { appendJsonlIdempotent, writeJsonAtomic } from "./state-writer";
+
+/** Immutable identity supplied by the owner-loss monitor and coordinator admission. */
+export interface UltragoalRecoveryBinding {
+	sessionId: string;
+	endpointIncarnation: string;
+	ownerGeneration: string;
+	cwd: string;
+}
+
+export interface UltragoalOwnerLossReceipt {
+	schema_version: 1;
+	session_id: string;
+	generation: string;
+	classification: "unexpected_owner_loss";
+	result: "signal" | "exit" | "unknown_terminal";
+	observed_at: string;
+}
+
+export type AuthoritativeOwnerLossReceipt = UltragoalOwnerLossReceipt | ManagedOwnerSigabrtReceipt;
+
+export interface UltragoalRecoverySnapshot {
+	/** B0 is captured once before recovery writes. P is protected and never rewritten. */
+	b0: { planSha256: string; ledgerSha256: string; capturedAt: string };
+	protectedPaths: string[];
+	/** Exact sanctioned deltas, never inferred from a worktree scan. */
+	sanctionedDeltas: string[];
+	/** Durable baseline-absent artifacts. */
+	absentArtifacts: string[];
+	/** Transient paths deliberately excluded from provenance. */
+	transientHistory: string[];
+}
+
+export type UltragoalRecoveryDisposition = "resume" | "handoff";
+export interface UltragoalRecoveryDecision {
+	disposition: UltragoalRecoveryDisposition;
+	reason: string;
+	snapshot?: UltragoalRecoverySnapshot;
+	terminal?: { yieldId: string; result: Record<string, unknown> };
+}
+
+interface TranscriptYield {
+	type: "yield";
+	id: string;
+	parentId: string | null;
+	result: Record<string, unknown>;
+}
+
+function nonEmpty(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function exactChild(
+	entry: Record<string, unknown>,
+	parentId: string | null,
+): entry is Record<string, unknown> & { id: string } {
+	return entry.parentId === parentId && nonEmpty(entry.id);
+}
+
+function digest(bytes: Uint8Array): string {
+	return createHash("sha256").update(bytes).digest("hex");
+}
+
+function safeRelativePath(root: string, candidate: string): string | null {
+	const relative = path.relative(root, candidate);
+	if (!relative || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return null;
+	return relative;
+}
+
+async function bytesOrAbsent(filePath: string): Promise<Uint8Array | null> {
+	try {
+		return await fs.readFile(filePath);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw error;
+	}
+}
+
+/**
+ * Parse the complete transcript; partial rows, alternate terminal spellings, and
+ * duplicate/conflicting yields are intentionally invalid authority.
+ */
+export function parseStrictTerminalTranscript(content: string): TranscriptYield | null {
+	if (!content?.endsWith("\n")) return null;
+	const entries: Array<Record<string, unknown> & { id: string }> = [];
+	let parentId: string | null = null;
+	for (const line of content.slice(0, -1).split("\n")) {
+		if (!line) return null;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			return null;
+		}
+		if (!isRecord(parsed) || !nonEmpty(parsed.type) || !exactChild(parsed, parentId)) return null;
+		if (
+			parsed.type !== "yield" &&
+			parsed.type !== "toolResult" &&
+			parsed.type !== "tool_call" &&
+			parsed.type !== "message" &&
+			parsed.type !== "mode_change"
+		)
+			return null;
+		entries.push(parsed);
+		parentId = parsed.id;
+	}
+	if (entries.length < 2) return null;
+	if (entries.filter(entry => entry.type === "yield").length !== 1) return null;
+	const yieldEntry = entries[entries.length - 2]!;
+	const resultEntry = entries[entries.length - 1]!;
+	if (yieldEntry.type !== "yield" || !isRecord(yieldEntry.result) || resultEntry.type !== "toolResult") return null;
+	if (resultEntry.toolCallId !== yieldEntry.id || !Array.isArray(resultEntry.content)) return null;
+	return {
+		type: "yield",
+		id: yieldEntry.id,
+		parentId: yieldEntry.parentId as string | null,
+		result: yieldEntry.result,
+	};
+}
+
+/** Read through a retained root descriptor; pathname resolution never authorizes recovery input. */
+async function readRecoveryFile(root: string, candidate: string): Promise<string | null> {
+	if (process.platform !== "linux") return null;
+	const relative = safeRelativePath(path.resolve(root), path.resolve(candidate));
+	if (!relative) return null;
+	try {
+		const authority = openRecoveryFsRoot(root);
+		try {
+			const result = authority.read(relative, 4 * 1024 * 1024);
+			return result.ok && result.data ? new TextDecoder().decode(result.data) : null;
+		} finally {
+			authority.close();
+		}
+	} catch {
+		return null;
+	}
+}
+
+/** Validate a path through a retained native root descriptor; path strings alone are never authority. */
+export async function validateRecoveryPath(root: string, candidate: string): Promise<string | null> {
+	return (await readRecoveryFile(root, candidate)) === null ? null : candidate;
+}
+
+export function validateOwnerLossBinding(
+	binding: UltragoalRecoveryBinding,
+	receipt: unknown,
+): receipt is AuthoritativeOwnerLossReceipt {
+	if (!isRecord(receipt) || receipt.session_id !== binding.sessionId || receipt.generation !== binding.ownerGeneration)
+		return false;
+	if (receipt.schema_version === 2)
+		return (
+			receipt.signal === "SIGABRT" &&
+			receipt.signal_number === 6 &&
+			nonEmpty(receipt.run_id) &&
+			receipt.endpoint_incarnation === binding.endpointIncarnation &&
+			nonEmpty(receipt.child_token) &&
+			nonEmpty(receipt.command_sha256) &&
+			typeof receipt.supervisor_pid === "number" &&
+			Number.isSafeInteger(receipt.supervisor_pid) &&
+			receipt.supervisor_pid > 0 &&
+			typeof receipt.child_pid === "number" &&
+			Number.isSafeInteger(receipt.child_pid) &&
+			receipt.child_pid > 0 &&
+			nonEmpty(receipt.supervisor_start_time) &&
+			nonEmpty(receipt.child_start_time) &&
+			(receipt.exit_code === null || Number.isSafeInteger(receipt.exit_code)) &&
+			nonEmpty(receipt.received_at) &&
+			Number.isFinite(Date.parse(receipt.received_at))
+		);
+	return false;
+}
+
+/** Admission is valid only for this immutable coordinator endpoint incarnation. */
+export function validateRecoveryAdmission(binding: UltragoalRecoveryBinding, admission: unknown): boolean {
+	if (!isRecord(admission)) return false;
+	return (
+		admission.session_id === binding.sessionId &&
+		admission.endpoint_incarnation === binding.endpointIncarnation &&
+		admission.owner_generation === binding.ownerGeneration &&
+		admission.admitted === true
+	);
+}
+
+/** Raw plan and ledger evidence must be complete before their B0 hashes are trusted. */
+export function validateRawUltragoalEvidence(plan: Uint8Array, ledger: Uint8Array): boolean {
+	try {
+		const parsedPlan: unknown = JSON.parse(new TextDecoder().decode(plan));
+		if (!isRecord(parsedPlan) || !Array.isArray(parsedPlan.goals)) return false;
+		const content = new TextDecoder().decode(ledger);
+		if (!content.endsWith("\n")) return false;
+		for (const line of content.slice(0, -1).split("\n")) {
+			if (!line || !isRecord(JSON.parse(line))) return false;
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Build a B0 snapshot without consulting unrelated paths or mutable sidecars. */
+export async function captureUltragoalRecoverySnapshot(input: {
+	cwd: string;
+	sessionId: string;
+	protectedPaths: readonly string[];
+	sanctionedDeltas: readonly string[];
+	absentArtifacts: readonly string[];
+	transientHistory: readonly string[];
+}): Promise<UltragoalRecoverySnapshot | null> {
+	const root = sessionUltragoalDir(input.cwd, input.sessionId);
+	const [plan, ledger] = await Promise.all([
+		bytesOrAbsent(path.join(root, "goals.json")),
+		bytesOrAbsent(path.join(root, "ledger.jsonl")),
+	]);
+	if (!plan || !ledger || !validateRawUltragoalEvidence(plan, ledger)) return null;
+	const allPaths = [
+		...input.protectedPaths,
+		...input.sanctionedDeltas,
+		...input.absentArtifacts,
+		...input.transientHistory,
+	];
+	if (allPaths.some(value => !nonEmpty(value) || path.isAbsolute(value) || value.split(/[\\/]/).includes("..")))
+		return null;
+	const sets = [input.protectedPaths, input.sanctionedDeltas, input.absentArtifacts, input.transientHistory].map(
+		values => new Set(values),
+	);
+	if (
+		sets.some((set, index) =>
+			sets.some((other, otherIndex) => otherIndex > index && [...set].some(value => other.has(value))),
+		)
+	)
+		return null;
+	return {
+		b0: { planSha256: digest(plan), ledgerSha256: digest(ledger), capturedAt: new Date().toISOString() },
+		protectedPaths: [...input.protectedPaths],
+		sanctionedDeltas: [...input.sanctionedDeltas],
+		absentArtifacts: [...input.absentArtifacts],
+		transientHistory: [...input.transientHistory],
+	};
+}
+
+/**
+ * Decide only from direct owner evidence plus a complete terminal transcript.
+ * All ambiguity maps to durable handoff; callers never guess a resume.
+ */
+export async function planUltragoalOwnerLossRecovery(input: {
+	binding: UltragoalRecoveryBinding;
+	receipt: unknown;
+	admission: unknown;
+
+	transcriptPath: string;
+	protectedPaths?: readonly string[];
+	sanctionedDeltas?: readonly string[];
+	absentArtifacts?: readonly string[];
+	transientHistory?: readonly string[];
+}): Promise<UltragoalRecoveryDecision> {
+	if (!validateOwnerLossBinding(input.binding, input.receipt))
+		return { disposition: "handoff", reason: "owner_receipt_untrusted" };
+	const content = await readRecoveryFile(input.binding.cwd, input.transcriptPath);
+	if (!validateRecoveryAdmission(input.binding, input.admission))
+		return { disposition: "handoff", reason: "coordinator_admission_untrusted" };
+	if (content === null) return { disposition: "handoff", reason: "transcript_path_untrusted" };
+	const terminal = parseStrictTerminalTranscript(content);
+	if (!terminal) return { disposition: "handoff", reason: "terminal_transcript_missing_or_invalid" };
+	if (terminal.result.status !== "success") return { disposition: "handoff", reason: "terminal_aborted_errored" };
+	const snapshot = await captureUltragoalRecoverySnapshot({
+		cwd: input.binding.cwd,
+		sessionId: input.binding.sessionId,
+		protectedPaths: input.protectedPaths ?? ["goals.json", "ledger.jsonl"],
+		sanctionedDeltas: input.sanctionedDeltas ?? [],
+		absentArtifacts: input.absentArtifacts ?? [],
+		transientHistory: input.transientHistory ?? [],
+	});
+	if (!snapshot) return { disposition: "handoff", reason: "baseline_or_path_invariant_failed" };
+	return {
+		disposition: "resume",
+		reason: "terminal_transcript_authoritative",
+		snapshot,
+		terminal: { yieldId: terminal.id, result: terminal.result },
+	};
+}
+
+/** Persist a monotonic replay journal and fail-closed handoff through sanctioned state writers. */
+export async function persistUltragoalRecoveryDecision(input: {
+	cwd: string;
+	sessionId: string;
+	binding: UltragoalRecoveryBinding;
+	decision: UltragoalRecoveryDecision;
+}): Promise<{ handoffPath: string; journalPath: string }> {
+	const stateDir = sessionStateDir(input.cwd, input.sessionId);
+	const handoffPath = path.join(stateDir, "ultragoal-owner-loss-recovery.json");
+	const journalPath = path.join(stateDir, "ultragoal-owner-loss-recovery.jsonl");
+	const record = {
+		schema_version: 1,
+		binding: input.binding,
+		disposition: input.decision.disposition,
+		reason: input.decision.reason,
+		snapshot: input.decision.snapshot ?? null,
+		terminal: input.decision.terminal ?? null,
+		created_at: new Date().toISOString(),
+	};
+	await writeJsonAtomic(handoffPath, record, {
+		cwd: input.cwd,
+		audit: { category: "state", verb: "write", owner: "gjc-runtime", sessionId: input.sessionId },
+	});
+	await appendJsonlIdempotent(
+		journalPath,
+		{ ...record, event: "owner_loss_recovery_decision" },
+		{
+			cwd: input.cwd,
+			audit: { category: "state", verb: "write", owner: "gjc-runtime", sessionId: input.sessionId },
+			key: entry => {
+				if (!isRecord(entry) || entry.event !== "owner_loss_recovery_decision") return undefined;
+				return `${entry.binding === undefined ? "" : JSON.stringify(entry.binding)}:${String(entry.disposition)}:${String(entry.reason)}`;
+			},
+		},
+	);
+	return { handoffPath, journalPath };
+}

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -33,6 +33,20 @@ import {
 	writeGuardedJsonAtomic,
 } from "./state-writer";
 
+export {
+	captureUltragoalRecoverySnapshot,
+	parseStrictTerminalTranscript,
+	persistUltragoalRecoveryDecision,
+	planUltragoalOwnerLossRecovery,
+	type UltragoalOwnerLossReceipt,
+	type UltragoalRecoveryBinding,
+	type UltragoalRecoveryDecision,
+	type UltragoalRecoverySnapshot,
+	validateOwnerLossBinding,
+	validateRawUltragoalEvidence,
+	validateRecoveryAdmission,
+	validateRecoveryPath,
+} from "./ultragoal-owner-loss-recovery";
 export type UltragoalGjcGoalMode = "aggregate" | "per-story";
 export type UltragoalGoalStatus =
 	| "pending"

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -20,6 +20,7 @@ import {
 	VERSION,
 } from "@gajae-code/utils";
 import chalk from "chalk";
+import { runCli } from "./cli";
 import type { Args } from "./cli/args";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
@@ -36,6 +37,8 @@ import { BUNDLED_GROK_BUILD_EXTENSION_ID, getBundledGrokBuildExtensionFactory } 
 import { initializeWithSettings } from "./discovery";
 import { exportFromFile } from "./export/html";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
+import { admitManagedOwnerBeforeCli, completeManagedOwnerRecovery } from "./gjc-runtime/managed-owner-admission";
+import { isManagedOwnerSupervisorArgv, runManagedOwnerSupervisor } from "./gjc-runtime/managed-owner-supervisor";
 import { persistCoordinatorRuntimeInputReady } from "./gjc-runtime/session-state-sidecar";
 import { isTmuxOwnerIsolationCliArgv, runTmuxOwnerIsolationCliFromStdin } from "./gjc-runtime/tmux-owner-isolation-cli";
 import type { AcpStartupOptions } from "./modes/acp/startup-options";
@@ -1604,6 +1607,15 @@ export async function main(args: string[]): Promise<void> {
 		await runTmuxOwnerIsolationCliFromStdin();
 		return;
 	}
-	const { runCli } = await import("./cli");
+	if (isManagedOwnerSupervisorArgv(args)) {
+		await runManagedOwnerSupervisor();
+		return;
+	}
+	const admission = await admitManagedOwnerBeforeCli();
+	if (admission.kind === "blocked") return;
+	if (admission.kind === "recovery") {
+		await completeManagedOwnerRecovery(admission.context);
+		return;
+	}
 	await runCli(args.length === 0 ? ["launch"] : args);
 }

--- a/packages/coding-agent/src/modes/controllers/goal-mode-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/goal-mode-controller.ts
@@ -227,19 +227,37 @@ export class GoalModeController {
 		this.scheduleContinuation();
 	}
 
-	async restoreFromSession(sessionContext: SessionContext): Promise<boolean> {
+	/**
+	 * Restore durable goal state. Recovery hydration deliberately performs only
+	 * in-memory restoration: it neither consumes a pending request nor repairs
+	 * invalid persisted state by writing a fallback mode entry.
+	 */
+	async restoreFromSession(
+		sessionContext: SessionContext,
+		options?: { recoveryHydration?: boolean },
+	): Promise<boolean> {
+		const recoveryHydration = options?.recoveryHydration === true;
 		const goalEnabled = this.ctx.session.settings.get("goal.enabled");
 		if (!goalEnabled && (sessionContext.mode === "goal" || sessionContext.mode === "goal_paused")) {
+			if (recoveryHydration) return false;
 			this.ctx.sessionManager.appendModeChange("none");
 			return true;
 		}
 		if (sessionContext.mode === "goal" || sessionContext.mode === "goal_paused") {
 			const goal = normalizeGoal(sessionContext.modeData?.goal) ?? undefined;
 			if (!goal) {
+				if (recoveryHydration) throw new Error("Recovery hydration rejected an invalid persisted goal state.");
 				this.ctx.sessionManager.appendModeChange("none");
 				return true;
 			}
 			this.ctx.session.setGoalModeState({ enabled: sessionContext.mode === "goal", mode: "active", goal });
+			if (recoveryHydration) {
+				this.#enabled = sessionContext.mode === "goal";
+				this.#paused = sessionContext.mode === "goal_paused";
+				if (this.#enabled || this.#paused) this.ctx.modeGate.enter("goal");
+				this.#updateStatus();
+				return true;
+			}
 			const restored = await this.ctx.session.goalRuntime.onThreadResumed();
 			this.#enabled = restored?.enabled === true;
 			this.#paused = restored?.enabled !== true && restored?.goal.status === "paused";
@@ -251,6 +269,7 @@ export class GoalModeController {
 			this.#updateStatus();
 			return true;
 		}
+		if (recoveryHydration) return false;
 		const pendingGoal = goalEnabled
 			? await consumePendingGoalModeRequest(this.ctx.sessionManager.getCwd(), this.ctx.sessionManager.getSessionId())
 			: null;

--- a/packages/coding-agent/src/sdk/bus/lifecycle-control-runtime.ts
+++ b/packages/coding-agent/src/sdk/bus/lifecycle-control-runtime.ts
@@ -13,6 +13,18 @@ import * as path from "node:path";
 import type { NotificationControlServer as NativeNotificationControlServer } from "@gajae-code/natives";
 import { logger } from "@gajae-code/utils";
 import { readLinuxProcStartTime } from "../../gjc-runtime/linux-proc";
+import {
+	MANAGED_OWNER_PREDECESSOR_GENERATION_ENV,
+	MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV,
+	MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV,
+	MANAGED_OWNER_PREDECESSOR_TOKEN_ENV,
+	MANAGED_OWNER_TRANSCRIPT_PATH_ENV,
+} from "../../gjc-runtime/managed-owner-admission";
+import {
+	MANAGED_OWNER_INCARNATION_ENV,
+	MANAGED_OWNER_RUN_ID_ENV,
+	MANAGED_OWNER_SUPERVISOR_ARG,
+} from "../../gjc-runtime/managed-owner-supervisor";
 import { tmuxRuntimeSessionPath } from "../../gjc-runtime/session-layout";
 import {
 	GJC_COORDINATOR_SESSION_ID_ENV,
@@ -35,6 +47,7 @@ import {
 	type OwnerIsolationProbe,
 	planTmuxOwnerIsolation,
 	replaceOwnerGeneration,
+	resolveManagedOwnerPredecessorSync,
 	type TmuxServerProof,
 } from "../../gjc-runtime/tmux-owner-isolation";
 import {
@@ -768,8 +781,10 @@ async function completeLifecycleSpawnTransaction(input: {
 	argv: string[];
 	ownerIsolationProbe?: OwnerIsolationProbe;
 	prepareSpawn?: () => void;
+	previousBaseline?: OwnerGenerationBaseline;
 }): Promise<void> {
-	const previousBaseline = await captureOwnerGenerationBaseline(input.stateDir, input.sessionId);
+	const previousBaseline =
+		input.previousBaseline ?? (await captureOwnerGenerationBaseline(input.stateDir, input.sessionId));
 	let ownerExecution: LifecycleAttemptExecution | undefined;
 	try {
 		ownerExecution = await executeLifecycleTmuxOwnerPlan({
@@ -817,6 +832,7 @@ async function completeLifecycleSpawnTransaction(input: {
 			throw new Error("gjc_lifecycle_owner_server_unverifiable");
 		if (!(await isLifecycleGenerationUnchanged(input.stateDir, input.sessionId, previousBaseline)))
 			throw new Error("gjc_lifecycle_owner_generation_changed");
+		resolveManagedOwnerPredecessorSync(input.stateDir, input.sessionId, previousBaseline);
 		await replaceOwnerGeneration(input.stateDir, input.sessionId, input.generation, previousBaseline);
 	} catch (error) {
 		let cleanupFailure: unknown;
@@ -857,7 +873,11 @@ export function daemonSpawnCreate(
 		const { cwd, args } = buildCreateArgv(frame, ids);
 		const sessionStateFile = lifecycleRuntimeStateFile(cwd, ids.intendedSessionId, name);
 		const stateDir = path.dirname(sessionStateFile);
+		const previousBaseline = await captureOwnerGenerationBaseline(stateDir, ids.intendedSessionId);
+		const predecessor = resolveManagedOwnerPredecessorSync(stateDir, ids.intendedSessionId, previousBaseline);
 		const generation = crypto.randomUUID();
+		const runId = crypto.randomUUID();
+		const incarnation = crypto.randomUUID();
 		// Detached: no interactive TTY needed (daemon-safe). These values contain
 		// only opaque ids and paths needed by the resident sidecar to publish its
 		// exact-owner terminal verdict.
@@ -871,12 +891,24 @@ export function daemonSpawnCreate(
 			[GJC_TMUX_OWNER_GENERATION_ENV]: generation,
 			[GJC_TMUX_OWNER_STATE_DIR_ENV]: stateDir,
 			[GJC_TMUX_OWNER_SERVER_KEY_ENV]: "default",
+			GJC_MANAGED_OWNER_COMMAND_JSON: JSON.stringify(["gjc", ...args]),
+			[MANAGED_OWNER_RUN_ID_ENV]: runId,
+			[MANAGED_OWNER_INCARNATION_ENV]: incarnation,
+			...(predecessor
+				? {
+						[MANAGED_OWNER_PREDECESSOR_TOKEN_ENV]: predecessor.predecessorToken,
+						[MANAGED_OWNER_PREDECESSOR_GENERATION_ENV]: predecessor.generation,
+						[MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV]: predecessor.runId,
+						[MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV]: predecessor.incarnation,
+						[MANAGED_OWNER_TRANSCRIPT_PATH_ENV]: env.GJC_SESSION_FILE ?? "",
+					}
+				: {}),
 		};
 		if (ids.startupPromptRef) childEnv.GJC_STARTUP_PROMPT_REF = ids.startupPromptRef;
 		const envPairs = Object.entries(childEnv)
 			.map(([key, value]) => `${key}=${shellQuote(value)}`)
 			.join(" ");
-		const command = `cd ${shellQuote(cwd)} && exec env ${envPairs} gjc ${args.map(shellQuote).join(" ")}`;
+		const command = `cd ${shellQuote(cwd)} && exec env ${envPairs} gjc ${shellQuote(MANAGED_OWNER_SUPERVISOR_ARG)}`;
 		await completeLifecycleSpawnTransaction({
 			tmux,
 			env,
@@ -891,6 +923,7 @@ export function daemonSpawnCreate(
 			prepareSpawn: () => {
 				if (frame.target.kind === "plain_dir") fs.mkdirSync(cwd, { recursive: true });
 			},
+			previousBaseline,
 		});
 
 		return {
@@ -1053,7 +1086,11 @@ export function daemonResumeSession(
 		const name = tmuxSessionNameFor(resumeId);
 		const sessionStateFile = lifecycleRuntimeStateFile(resolvedResumeCwd, resumeId, name);
 		const stateDir = path.dirname(sessionStateFile);
+		const previousBaseline = await captureOwnerGenerationBaseline(stateDir, resumeId);
+		const predecessor = resolveManagedOwnerPredecessorSync(stateDir, resumeId, previousBaseline);
 		const generation = crypto.randomUUID();
+		const runId = crypto.randomUUID();
+		const incarnation = crypto.randomUUID();
 		const childEnv: Record<string, string> = {
 			GJC_TMUX_LAUNCHED: "1",
 			GJC_NOTIFICATIONS: "1",
@@ -1062,11 +1099,23 @@ export function daemonResumeSession(
 			[GJC_TMUX_OWNER_GENERATION_ENV]: generation,
 			[GJC_TMUX_OWNER_STATE_DIR_ENV]: stateDir,
 			[GJC_TMUX_OWNER_SERVER_KEY_ENV]: "default",
+			GJC_MANAGED_OWNER_COMMAND_JSON: JSON.stringify(["gjc", "--resume", resumeId]),
+			[MANAGED_OWNER_RUN_ID_ENV]: runId,
+			[MANAGED_OWNER_INCARNATION_ENV]: incarnation,
+			...(predecessor
+				? {
+						[MANAGED_OWNER_PREDECESSOR_TOKEN_ENV]: predecessor.predecessorToken,
+						[MANAGED_OWNER_PREDECESSOR_GENERATION_ENV]: predecessor.generation,
+						[MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV]: predecessor.runId,
+						[MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV]: predecessor.incarnation,
+						[MANAGED_OWNER_TRANSCRIPT_PATH_ENV]: env.GJC_SESSION_FILE ?? "",
+					}
+				: {}),
 		};
 		const envPairs = Object.entries(childEnv)
 			.map(([key, value]) => `${key}=${shellQuote(value)}`)
 			.join(" ");
-		const command = `cd ${shellQuote(resolvedResumeCwd)} && exec env ${envPairs} gjc --resume ${shellQuote(resumeId)}`;
+		const command = `cd ${shellQuote(resolvedResumeCwd)} && exec env ${envPairs} gjc ${shellQuote(MANAGED_OWNER_SUPERVISOR_ARG)}`;
 		await completeLifecycleSpawnTransaction({
 			tmux,
 			env,
@@ -1078,6 +1127,7 @@ export function daemonResumeSession(
 			sessionStateFile,
 			argv: [tmux, "new-session", "-d", "-P", "-F", "#{session_id}", "-s", name, "sh", "-c", command],
 			ownerIsolationProbe: opts.ownerIsolationProbe,
+			previousBaseline,
 		});
 
 		return {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -366,6 +366,8 @@ import type {
 	CompactionEntry,
 	DefaultModelSelectionStage,
 	NewSessionOptions,
+	RecoveryHydrationContext,
+	RecoveryHydrationPromotionFence,
 	SessionContext,
 	SessionEntry,
 	SessionManager,
@@ -531,6 +533,8 @@ export interface AgentSessionConfig {
 	initialSelectedMCPToolNames?: string[];
 	/** Whether constructor-provided MCP defaults should be persisted immediately. */
 	persistInitialMCPToolSelection?: boolean;
+	/** Immutable predecessor authority while a recovery host is read-only. */
+	recoveryHydrationContext?: RecoveryHydrationContext;
 	/** MCP server names whose tools should seed discovery-mode sessions whenever those servers are connected. */
 	defaultSelectedMCPServerNames?: string[];
 	/** MCP tool names that should seed brand-new sessions created from this AgentSession. */
@@ -1618,6 +1622,7 @@ export class AgentSession {
 	#defaultSelectedMCPServerNames = new Set<string>();
 	#defaultSelectedMCPToolNames = new Set<string>();
 	#sessionDefaultSelectedMCPToolNames = new Map<string, string[]>();
+	#recoveryHydrationContext: RecoveryHydrationContext | undefined;
 
 	// TTSR manager for time-traveling stream rules
 	#ttsrManager: TtsrManager | undefined = undefined;
@@ -2021,6 +2026,7 @@ export class AgentSession {
 		});
 		// Power assertions are taken per turn (see #beginInFlight); nothing acquired here.
 		this.#evalKernelOwnerId = config.evalKernelOwnerId ?? `agent-session:${Snowflake.next()}`;
+		this.#recoveryHydrationContext = config.recoveryHydrationContext;
 		this.#ownedAsyncJobManager = config.ownedAsyncJobManager;
 		this.#retainedMemorySampler = config.retainedMemorySampler;
 		this.#ownedMcpManager = config.ownedMcpManager;
@@ -2120,6 +2126,7 @@ export class AgentSession {
 		const persistInitialMCPToolSelection =
 			config.persistInitialMCPToolSelection ?? this.sessionManager.getBranch().length === 0;
 		if (
+			!this.#recoveryHydrationContext &&
 			this.#mcpDiscoveryEnabled &&
 			persistInitialMCPToolSelection &&
 			!this.#selectedMCPToolNamesMatch(persistedSelectedMCPToolNames, currentSelectedMCPToolNames)
@@ -6035,8 +6042,29 @@ export class AgentSession {
 		return this.#promptGeneration;
 	}
 
+	/** The immutable recovery authority, present only before external ownership promotion. */
+	get recoveryHydrationContext(): RecoveryHydrationContext | undefined {
+		return this.#recoveryHydrationContext;
+	}
+
+	/** Enables normal session mutations after the owner has published its durable fence and writer lease. */
+	async promoteRecoveryHydrationAfterOwnershipReadyFence(fence: RecoveryHydrationPromotionFence): Promise<void> {
+		const context = this.#recoveryHydrationContext;
+		if (!context) throw new Error("Agent session is not awaiting recovery hydration promotion.");
+		await this.sessionManager.promoteRecoveryHydrationAfterOwnershipReadyFence(context, fence);
+		this.#recoveryHydrationContext = undefined;
+	}
+
+	/** Recovery hydration must not start a continuation before ownership promotion. */
+	#assertRecoveryHydrationPromoted(): void {
+		if (this.#recoveryHydrationContext) {
+			throw new Error("Recovery hydration has not been promoted to a writer-owning session.");
+		}
+	}
+
 	/** Main startup calls this exactly once, after a strict open returned `kind: "opened"`. */
 	async continuePersistedHistory(): Promise<void> {
+		this.#assertRecoveryHydrationPromoted();
 		this.#removeEphemeralCustomMessages();
 
 		if (!canContinuePersistedHistory(this.agent.state.messages)) {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -521,7 +521,7 @@ export interface StrictSessionOpenSuccess {
 
 export interface StrictSessionOpenFailure {
 	kind: "error";
-	reason: ResumeTailError["reason"] | "identity-mismatch";
+	reason: ResumeTailError["reason"] | "identity-mismatch" | "migration-required";
 }
 
 /** Exact transcript bytes and authority captured from one descriptor-bound read. */
@@ -540,6 +540,27 @@ export type StrictSessionForkResult = { kind: "forked"; manager: SessionManager 
 
 /** Result of opening an inspected session without create-or-rewrite fallback. */
 export type StrictSessionOpenResult = StrictSessionOpenSuccess | StrictSessionOpenFailure;
+
+/**
+ * Capability returned only by a strict recovery hydration open. It represents
+ * immutable transcript authority and is consumed by the promotion seam.
+ */
+export interface RecoveryHydrationContext {
+	readonly identity: ResumeSessionIdentity;
+}
+
+export interface RecoveryHydrationOpenSuccess {
+	readonly kind: "hydrated";
+	readonly manager: SessionManager;
+	readonly context: RecoveryHydrationContext;
+}
+
+export type RecoveryHydrationOpenResult = RecoveryHydrationOpenSuccess | StrictSessionOpenFailure;
+
+export interface RecoveryHydrationPromotionFence {
+	/** The caller has durably published ownership and acquired its writer lease. */
+	readonly ownershipReady: true;
+}
 
 export interface SessionInfo {
 	path: string;
@@ -3653,6 +3674,7 @@ export class SessionManager {
 	#flushed: boolean = false;
 	#needsFullRewriteOnNextPersist: boolean = false;
 	#ensuredOnDisk: boolean = false;
+	#recoveryHydrationContext: RecoveryHydrationContext | undefined;
 	#fileEntries: FileEntry[] = [];
 	#byId: Map<string, SessionEntry> = new Map();
 	#labelsById: Map<string, string> = new Map();
@@ -6671,6 +6693,62 @@ export class SessionManager {
 		return canContinuePersistedHistory(inspected.context.messages)
 			? { kind: "resumable", identity: inspected.identity }
 			: { kind: "terminal", identity: inspected.identity };
+	}
+
+	/**
+	 * Hydrate an existing predecessor transcript for recovery without taking any
+	 * write-capable action. The caller must retain the returned context and use
+	 * the explicit promotion seam only after its ownership-ready fence and writer
+	 * lease are durable.
+	 */
+	static async openExistingForRecoveryHydrationStrict(
+		identity: ResumeSessionIdentity,
+		sessionDir?: string,
+		storage: SessionStorage = new FileSessionStorage(),
+	): Promise<RecoveryHydrationOpenResult> {
+		const inspected = inspectResumeSessionFile(identity.canonicalPath, storage);
+		if ("kind" in inspected) return inspected;
+		if (!sameResumeIdentity(identity, inspected.identity)) return { kind: "error", reason: "identity-mismatch" };
+		if (inspected.migrationApplied) return { kind: "error", reason: "migration-required" };
+
+		const header = inspected.entries[0] as SessionHeader;
+		const manager = new SessionManager(
+			header.cwd || getProjectDir(),
+			sessionDir ?? path.resolve(identity.canonicalPath, ".."),
+			true,
+			storage,
+		);
+		await manager.#hydrateExistingSession(identity.canonicalPath, inspected.entries, false);
+		const revalidated = inspectResumeSessionFile(identity.canonicalPath, storage);
+		if ("kind" in revalidated || !sameResumeIdentity(identity, revalidated.identity)) {
+			await manager.close();
+			return "kind" in revalidated ? revalidated : { kind: "error", reason: "identity-mismatch" };
+		}
+		const context: RecoveryHydrationContext = Object.freeze({
+			identity: Object.freeze({ ...identity }),
+		});
+		manager.#recoveryHydrationContext = context;
+		return { kind: "hydrated", manager, context };
+	}
+
+	/**
+	 * Allows the normal post-open metadata sanitation only after the caller has
+	 * fsynced its external ownership-ready fence and acquired the writer lease.
+	 */
+	async promoteRecoveryHydrationAfterOwnershipReadyFence(
+		context: RecoveryHydrationContext,
+		fence: RecoveryHydrationPromotionFence,
+	): Promise<void> {
+		if (fence.ownershipReady !== true || this.#recoveryHydrationContext !== context) {
+			throw new Error("Recovery hydration promotion requires the original ownership-ready context.");
+		}
+		const inspected = inspectResumeSessionFile(context.identity.canonicalPath, this.storage);
+		if ("kind" in inspected || !sameResumeIdentity(context.identity, inspected.identity)) {
+			throw new Error("Recovery transcript authority changed before promotion.");
+		}
+		await this.#sanitizeLoadedOpenAIResponsesReplayMetadataAndPersist();
+		writeTerminalBreadcrumb(this.cwd, context.identity.canonicalPath);
+		this.#recoveryHydrationContext = undefined;
 	}
 
 	/**

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn, vi } from "bun:test";
 import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -22,6 +23,7 @@ import { persistCoordinatorRuntimeStateFromPostmortem } from "@gajae-code/coding
 import {
 	captureOwnerGenerationBaselineSync,
 	isExactScopedBootstrapSuccessReceipt,
+	lifecyclePaths,
 	replaceOwnerGenerationSync,
 } from "@gajae-code/coding-agent/gjc-runtime/tmux-owner-isolation";
 import {
@@ -3057,11 +3059,74 @@ describe("tmux owner isolation launch gate", () => {
 			expect(innerCommand).toContain(`GJC_TMUX_OWNER_STATE_DIR='${root}'`);
 			expect(innerCommand).toContain("GJC_TMUX_OWNER_SERVER_KEY='tmux'");
 			expect(innerCommand).toStartWith("exec env GJC_TMUX_LAUNCHED=1");
+			expect(innerCommand).toMatch(/GJC_MANAGED_OWNER_RUN_ID='[0-9a-f-]{36}'/i);
+			expect(innerCommand).toMatch(/GJC_MANAGED_OWNER_INCARNATION='[0-9a-f-]{36}'/i);
+			expect(innerCommand).not.toContain("GJC_MANAGED_OWNER_PREDECESSOR_TOKEN");
 			expect(innerCommand).not.toContain("tmux-exit.json");
 			expect(
 				calls.some(call => call.includes("@gjc-owner-generation") && call.at(-1) === generation.generation),
 			).toBe(true);
 			expect(calls.some(call => call.includes("@gjc-owner-server-key") && call.at(-1) === "tmux")).toBe(true);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("propagates only an exact durable SIGABRT predecessor token into a replacement launch", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-tmux-replacement-"));
+		try {
+			const sessionId = "replacement-session";
+			const generation = "replacement-generation";
+			const runId = "replacement-run";
+			const incarnation = "replacement-incarnation";
+			const predecessorToken = "exact-predecessor";
+			const ownerRoot = lifecyclePaths(root, sessionId, generation).root;
+			fs.mkdirSync(ownerRoot, { recursive: true });
+			fs.writeFileSync(
+				lifecyclePaths(root, sessionId, generation).generationFile,
+				`${JSON.stringify({ schema_version: 1, generation, session_id: sessionId, published_at: "2026-07-19T00:00:00.000Z" })}\n`,
+			);
+			const command = ["gjc", "--resume"];
+			const commandSha256 = createHash("sha256").update(JSON.stringify(command)).digest("hex");
+			fs.writeFileSync(
+				path.join(ownerRoot, `child-${predecessorToken}.binding.json`),
+				`${JSON.stringify({ schema_version: 2, generation, session_id: sessionId, run_id: runId, endpoint_incarnation: incarnation, child_token: predecessorToken, command, command_sha256: commandSha256, supervisor_pid: 1, supervisor_start_time: "1", created_at: "2026-07-19T00:00:00.000Z" })}\n`,
+			);
+			fs.writeFileSync(
+				path.join(ownerRoot, `sigabrt-${predecessorToken}.receipt.json`),
+				`${JSON.stringify({ schema_version: 2, generation, session_id: sessionId, run_id: runId, endpoint_incarnation: incarnation, child_token: predecessorToken, command_sha256: commandSha256, supervisor_pid: 1, supervisor_start_time: "1", child_pid: 2, child_start_time: "2", signal: "SIGABRT", signal_number: 6, exit_code: null, received_at: "2026-07-19T00:00:00.000Z" })}\n`,
+			);
+			const calls: string[][] = [];
+			const handled = launchDefaultTmuxIfNeeded({
+				parsed: args({ messages: ["hello"], tmux: true }),
+				rawArgs: ["--tmux", "hello"],
+				cwd: root,
+				env: {
+					GJC_COORDINATOR_SESSION_ID: sessionId,
+					GJC_COORDINATOR_SESSION_STATE_FILE: path.join(root, "runtime-state.json"),
+					GJC_TMUX_OWNER_STATE_DIR: root,
+					GJC_TMUX_OWNER_GENERATION: generation,
+					GJC_MANAGED_OWNER_RUN_ID: runId,
+					GJC_MANAGED_OWNER_INCARNATION: incarnation,
+					GJC_MANAGED_OWNER_PREDECESSOR_TOKEN: predecessorToken,
+				},
+				argv: ["bun", "cli.ts"],
+				execPath: "/bin/bun",
+				platform: "linux",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				existingBranchSessionName: null,
+				spawnSync: (_command, spawnArgs) => {
+					calls.push(spawnArgs);
+					return { exitCode: 0, stdout: NATIVE_SESSION_ID };
+				},
+			});
+			expect(handled).toBe(true);
+			const innerCommand = calls.find(call => call[0] === "new-session")?.at(-1);
+			expect(innerCommand).toContain(`GJC_MANAGED_OWNER_PREDECESSOR_TOKEN='${predecessorToken}'`);
+			expect(innerCommand).toMatch(/GJC_TMUX_OWNER_GENERATION='[0-9a-f-]{36}'/i);
+			expect(innerCommand).toMatch(/GJC_MANAGED_OWNER_RUN_ID='[0-9a-f-]{36}'/i);
+			expect(innerCommand).toMatch(/GJC_MANAGED_OWNER_INCARNATION='[0-9a-f-]{36}'/i);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/gjc-runtime/managed-owner-admission.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/managed-owner-admission.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "bun:test";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { sessionUltragoalDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import { lifecyclePaths } from "@gajae-code/coding-agent/gjc-runtime/tmux-owner-isolation";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
+const admissionModule = path.join(
+	repoRoot,
+	"packages",
+	"coding-agent",
+	"src",
+	"gjc-runtime",
+	"managed-owner-admission.ts",
+);
+
+async function admit(stateDir: string, token?: string): Promise<{ admitted: boolean; exitCode: number; root: string }> {
+	const script = `import { admitManagedOwnerBeforeCli } from ${JSON.stringify(admissionModule)}; const admission = await admitManagedOwnerBeforeCli(); console.log(JSON.stringify({ admitted: admission.kind !== "blocked", exitCode: process.exitCode ?? 0 }));`;
+	const child = Bun.spawn({
+		cmd: [process.execPath, "-e", script],
+		cwd: repoRoot,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			...process.env,
+			GJC_TMUX_OWNER_STATE_DIR: stateDir,
+			GJC_COORDINATOR_SESSION_ID: "session-2681",
+			GJC_TMUX_OWNER_GENERATION: "generation-2681",
+			GJC_MANAGED_OWNER_RUN_ID: "run-2681",
+			GJC_MANAGED_OWNER_INCARNATION: "incarnation-2681",
+			...(token ? { GJC_MANAGED_OWNER_CHILD_TOKEN: token } : {}),
+		},
+	});
+	const [stdout, exitCode] = await Promise.all([new Response(child.stdout).text(), child.exited]);
+	return {
+		...(JSON.parse(stdout) as { admitted: boolean; exitCode: number }),
+		exitCode,
+		root: lifecyclePaths(stateDir, "session-2681", "generation-2681").root,
+	};
+}
+
+async function writeBinding(root: string, token: string, patch: Record<string, unknown> = {}): Promise<void> {
+	await fs.mkdir(root, { recursive: true });
+	const command = ["gjc", "--resume"];
+	await fs.writeFile(
+		path.join(root, `child-${token}.binding.json`),
+		`${JSON.stringify({ schema_version: 2, generation: "generation-2681", session_id: "session-2681", run_id: "run-2681", endpoint_incarnation: "incarnation-2681", child_token: token, command, command_sha256: crypto.createHash("sha256").update(JSON.stringify(command)).digest("hex"), supervisor_pid: 1, supervisor_start_time: "1", created_at: new Date().toISOString(), ...patch })}\n`,
+	);
+}
+
+async function recover(
+	stateDir: string,
+	cwd: string,
+	token: string,
+	transcriptPath: string,
+): Promise<{ kind: string; exitCode: number }> {
+	const script = `import { admitManagedOwnerBeforeCli, completeManagedOwnerRecovery } from ${JSON.stringify(admissionModule)}; const admission = await admitManagedOwnerBeforeCli(); const terminal = admission.kind === "recovery" ? await completeManagedOwnerRecovery(admission.context) : admission; console.log(JSON.stringify({ kind: terminal.kind, exitCode: process.exitCode ?? 0 }));`;
+	const child = Bun.spawn({
+		cmd: [process.execPath, "-e", script],
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			...process.env,
+			GJC_TMUX_OWNER_STATE_DIR: stateDir,
+			GJC_COORDINATOR_SESSION_ID: "session-2681",
+			GJC_TMUX_OWNER_GENERATION: "replacement-generation-2681",
+			GJC_MANAGED_OWNER_RUN_ID: "replacement-run-2681",
+			GJC_MANAGED_OWNER_INCARNATION: "replacement-incarnation-2681",
+			GJC_MANAGED_OWNER_CHILD_TOKEN: "replacement-child-token",
+			GJC_MANAGED_OWNER_PREDECESSOR_TOKEN: token,
+			GJC_MANAGED_OWNER_PREDECESSOR_GENERATION: "generation-2681",
+			GJC_MANAGED_OWNER_PREDECESSOR_RUN_ID: "run-2681",
+			GJC_MANAGED_OWNER_PREDECESSOR_INCARNATION: "incarnation-2681",
+			GJC_MANAGED_OWNER_TRANSCRIPT_PATH: transcriptPath,
+		},
+	});
+	const [stdout, exitCode] = await Promise.all([new Response(child.stdout).text(), child.exited]);
+	return { ...(JSON.parse(stdout) as { kind: string; exitCode: number }), exitCode };
+}
+
+async function writeSigabrtReceipt(root: string, token: string): Promise<void> {
+	await fs.writeFile(
+		path.join(root, `sigabrt-${token}.receipt.json`),
+		`${JSON.stringify({
+			schema_version: 2,
+			generation: "generation-2681",
+			session_id: "session-2681",
+			run_id: "run-2681",
+			endpoint_incarnation: "incarnation-2681",
+			child_token: token,
+			command_sha256: crypto
+				.createHash("sha256")
+				.update(JSON.stringify(["gjc", "--resume"]))
+				.digest("hex"),
+			supervisor_pid: 1,
+			supervisor_start_time: "1",
+			child_pid: 2,
+			child_start_time: "2",
+			signal: "SIGABRT",
+			signal_number: 6,
+			exit_code: null,
+			received_at: new Date().toISOString(),
+		})}\n`,
+	);
+}
+
+async function writeRecoveryEvidence(cwd: string): Promise<string> {
+	const ultragoal = sessionUltragoalDir(cwd, "session-2681");
+	await fs.mkdir(ultragoal, { recursive: true });
+	await fs.writeFile(path.join(ultragoal, "goals.json"), '{"goals":[]}');
+	await fs.writeFile(path.join(ultragoal, "ledger.jsonl"), '{"event":"started"}\n');
+	const transcript = path.join(cwd, "predecessor.jsonl");
+	await fs.writeFile(
+		transcript,
+		'{"id":"one","parentId":null,"type":"message"}\n{"id":"two","parentId":"one","type":"yield","result":{"status":"success"}}\n{"id":"three","parentId":"two","type":"toolResult","toolCallId":"two","content":[]}\n',
+	);
+	return transcript;
+}
+
+describe("managed owner admission", () => {
+	it("admits only the exact token binding for the current session and generation", async () => {
+		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-admission-"));
+		try {
+			const root = lifecyclePaths(stateDir, "session-2681", "generation-2681").root;
+			await writeBinding(root, "exact-token");
+			const result = await admit(stateDir, "exact-token");
+			expect(result.admitted).toBe(true);
+			expect(result.exitCode).toBe(0);
+			for (const patch of [
+				{ child_token: "other-token" },
+				{ session_id: "unrelated-session" },
+				{ generation: "stale-generation" },
+				{ command: ["replacement", 1] },
+			]) {
+				await writeBinding(root, "bad-token", patch);
+				const rejected = await admit(stateDir, "bad-token");
+				expect(rejected.admitted).toBe(false);
+				expect(rejected.exitCode).toBe(75);
+			}
+		} finally {
+			await fs.rm(stateDir, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed with a durable recovery handoff for missing, traversal, and corrupt binding attempts", async () => {
+		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-admission-"));
+		try {
+			const root = lifecyclePaths(stateDir, "session-2681", "generation-2681").root;
+			await fs.mkdir(root, { recursive: true });
+			for (const token of [undefined, "../escaped", "corrupt"]) {
+				if (token === "corrupt") await fs.writeFile(path.join(root, "child-corrupt.binding.json"), "{bad json\n");
+				const rejected = await admit(stateDir, token);
+				expect(rejected.admitted).toBe(false);
+				expect(rejected.exitCode).toBe(75);
+			}
+			const handoffs = (await fs.readdir(root)).filter(file => file.startsWith("admission-handoff-"));
+			expect(handoffs.length).toBeGreaterThan(0);
+			const latest = JSON.parse(
+				await fs.readFile(path.join(root, handoffs[handoffs.length - 1]!), "utf8"),
+			) as Record<string, unknown>;
+			expect(latest).toMatchObject({
+				schema_version: 2,
+				session_id: "session-2681",
+				generation: "generation-2681",
+				state: "fail_closed_handoff",
+			});
+		} finally {
+			await fs.rm(stateDir, { recursive: true, force: true });
+		}
+	});
+
+	it("turns a recovery admission into a durable terminal handoff without changing B0 or dirty files", async () => {
+		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-recovery-"));
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-recovery-cwd-"));
+		try {
+			const root = lifecyclePaths(stateDir, "session-2681", "generation-2681").root;
+			await writeBinding(root, "predecessor");
+			await writeSigabrtReceipt(root, "predecessor");
+			const transcript = await writeRecoveryEvidence(cwd);
+			const goals = path.join(sessionUltragoalDir(cwd, "session-2681"), "goals.json");
+			const ledger = path.join(sessionUltragoalDir(cwd, "session-2681"), "ledger.jsonl");
+			const [beforeGoals, beforeLedger] = await Promise.all([
+				fs.readFile(goals, "utf8"),
+				fs.readFile(ledger, "utf8"),
+			]);
+			const dirty = path.join(cwd, "dirty.ts");
+			await fs.writeFile(dirty, "export const dirty = true;\n");
+			const result = await recover(stateDir, cwd, "predecessor", transcript);
+			expect(result).toEqual({ kind: "handoff", exitCode: 75 });
+			expect(await fs.readFile(dirty, "utf8")).toBe("export const dirty = true;\n");
+			expect(await fs.readFile(goals, "utf8")).toBe(beforeGoals);
+			expect(await fs.readFile(ledger, "utf8")).toBe(beforeLedger);
+			const handoffs = (await fs.readdir(root)).filter(file => file.startsWith("admission-handoff-"));
+			expect(handoffs).toHaveLength(1);
+			expect(JSON.parse(await fs.readFile(path.join(root, handoffs[0]!), "utf8"))).toMatchObject({
+				state: "fail_closed_handoff",
+				reason: "safe_session_resume_seam_unavailable",
+				terminal_reconciliation: "unavailable_without_owning_store_cas",
+				b0_preserved: true,
+			});
+		} finally {
+			await fs.rm(stateDir, { recursive: true, force: true });
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/managed-owner-supervisor.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/managed-owner-supervisor.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { sessionUltragoalDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import { lifecyclePaths } from "@gajae-code/coding-agent/gjc-runtime/tmux-owner-isolation";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
+const supervisorModule = path.join(
+	repoRoot,
+	"packages",
+	"coding-agent",
+	"src",
+	"gjc-runtime",
+	"managed-owner-supervisor.ts",
+);
+const admissionModule = path.join(
+	repoRoot,
+	"packages",
+	"coding-agent",
+	"src",
+	"gjc-runtime",
+	"managed-owner-admission.ts",
+);
+
+async function runSupervisor(
+	stateDir: string,
+	command: string[],
+	env: Record<string, string> = {},
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const script = `import { runManagedOwnerSupervisor } from ${JSON.stringify(supervisorModule)}; await runManagedOwnerSupervisor();`;
+	const child = Bun.spawn({
+		cmd: [process.execPath, "-e", script],
+		cwd: repoRoot,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			...process.env,
+			GJC_TMUX_OWNER_STATE_DIR: stateDir,
+			GJC_COORDINATOR_SESSION_ID: "session-2681",
+			GJC_TMUX_OWNER_GENERATION: "generation-2681",
+			GJC_MANAGED_OWNER_RUN_ID: "run-2681",
+			GJC_MANAGED_OWNER_INCARNATION: "incarnation-2681",
+			GJC_MANAGED_OWNER_COMMAND_JSON: JSON.stringify(command),
+			...env,
+		},
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+	return { exitCode, stdout, stderr };
+}
+
+describe("managed owner supervisor", () => {
+	it("records one exact durable SIGABRT receipt and exits with the abort status", async () => {
+		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-owner-"));
+		try {
+			const result = await runSupervisor(stateDir, [process.execPath, "-e", "process.kill(process.pid, 'SIGABRT')"]);
+			expect(result.exitCode).toBe(134);
+			const root = lifecyclePaths(stateDir, "session-2681", "generation-2681").root;
+			const files = await fs.readdir(root);
+			const bindingFile = files.find(file => file.startsWith("child-") && file.endsWith(".binding.json"));
+			const receiptFile = files.find(file => file.startsWith("sigabrt-") && file.endsWith(".receipt.json"));
+			expect(bindingFile).toBeDefined();
+			expect(receiptFile).toBeDefined();
+			const binding = JSON.parse(await fs.readFile(path.join(root, bindingFile!), "utf8")) as Record<
+				string,
+				unknown
+			>;
+			const receipt = JSON.parse(await fs.readFile(path.join(root, receiptFile!), "utf8")) as Record<
+				string,
+				unknown
+			>;
+			expect(receipt).toMatchObject({
+				schema_version: 2,
+				session_id: "session-2681",
+				generation: "generation-2681",
+				signal: "SIGABRT",
+				child_token: binding.child_token,
+				signal_number: 6,
+				run_id: "run-2681",
+				endpoint_incarnation: "incarnation-2681",
+			});
+			expect(files.filter(file => file.startsWith("sigabrt-")).length).toBe(1);
+		} finally {
+			await fs.rm(stateDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not mint a SIGABRT receipt for a normally exiting child", async () => {
+		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-owner-"));
+		try {
+			const result = await runSupervisor(stateDir, [process.execPath, "-e", "process.exit(23)"]);
+			expect(result.exitCode).toBe(23);
+			const root = lifecyclePaths(stateDir, "session-2681", "generation-2681").root;
+			expect((await fs.readdir(root)).some(file => file.startsWith("sigabrt-"))).toBe(false);
+		} finally {
+			await fs.rm(stateDir, { recursive: true, force: true });
+		}
+	});
+	it("routes a replacement supervisor child through predecessor recovery before normal CLI", async () => {
+		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-owner-"));
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-owner-cwd-"));
+		try {
+			const predecessor = await runSupervisor(stateDir, [
+				process.execPath,
+				"-e",
+				"process.kill(process.pid, 'SIGABRT')",
+			]);
+			expect(predecessor.exitCode).toBe(134);
+			const root = lifecyclePaths(stateDir, "session-2681", "generation-2681").root;
+			const bindingFile = (await fs.readdir(root)).find(
+				file => file.startsWith("child-") && file.endsWith(".binding.json"),
+			);
+			expect(bindingFile).toBeDefined();
+			const predecessorToken = bindingFile!.slice("child-".length, -".binding.json".length);
+			const ultragoal = sessionUltragoalDir(cwd, "session-2681");
+			await fs.mkdir(ultragoal, { recursive: true });
+			await fs.writeFile(path.join(ultragoal, "goals.json"), '{"goals":[]}');
+			await fs.writeFile(path.join(ultragoal, "ledger.jsonl"), '{"event":"started"}\n');
+			const transcript = path.join(cwd, "predecessor.jsonl");
+			await fs.writeFile(
+				transcript,
+				'{"id":"yield-1","parentId":null,"type":"yield","result":{"status":"success"}}\n{"id":"result-1","parentId":"yield-1","type":"toolResult","toolCallId":"yield-1","content":[]}\n',
+			);
+			const childScript = `import { admitManagedOwnerBeforeCli, completeManagedOwnerRecovery } from ${JSON.stringify(admissionModule)}; process.chdir(${JSON.stringify(cwd)}); const admission = await admitManagedOwnerBeforeCli(); const terminal = admission.kind === "recovery" ? await completeManagedOwnerRecovery(admission.context) : admission; console.log(JSON.stringify({ kind: terminal.kind }));`;
+			const replacement = await runSupervisor(stateDir, [process.execPath, "-e", childScript], {
+				GJC_TMUX_OWNER_GENERATION: "replacement-generation-2681",
+				GJC_MANAGED_OWNER_RUN_ID: "replacement-run-2681",
+				GJC_MANAGED_OWNER_INCARNATION: "replacement-incarnation-2681",
+				GJC_MANAGED_OWNER_PREDECESSOR_TOKEN: predecessorToken,
+				GJC_MANAGED_OWNER_PREDECESSOR_GENERATION: "generation-2681",
+				GJC_MANAGED_OWNER_PREDECESSOR_RUN_ID: "run-2681",
+				GJC_MANAGED_OWNER_PREDECESSOR_INCARNATION: "incarnation-2681",
+				GJC_MANAGED_OWNER_TRANSCRIPT_PATH: transcript,
+			});
+			expect(replacement.exitCode).toBe(75);
+			expect(replacement.stdout).toContain('"kind":"handoff"');
+			const handoffFile = (await fs.readdir(root)).find(
+				file => file.startsWith("admission-handoff-") && file.endsWith(".json"),
+			);
+			expect(handoffFile).toBeDefined();
+			expect(JSON.parse(await fs.readFile(path.join(root, handoffFile!), "utf8"))).toMatchObject({
+				state: "fail_closed_handoff",
+				reason: "safe_session_resume_seam_unavailable",
+			});
+		} finally {
+			await fs.rm(stateDir, { recursive: true, force: true });
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-owner-loss-recovery.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-owner-loss-recovery.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { sessionUltragoalDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import {
+	captureUltragoalRecoverySnapshot,
+	parseStrictTerminalTranscript,
+	persistUltragoalRecoveryDecision,
+	planUltragoalOwnerLossRecovery,
+	validateOwnerLossBinding,
+	validateRecoveryAdmission,
+	validateRecoveryPath,
+} from "@gajae-code/coding-agent/gjc-runtime/ultragoal-runtime";
+
+const sessionId = "session-2681";
+const binding = {
+	sessionId,
+	endpointIncarnation: "incarnation-current",
+	ownerGeneration: "generation-current",
+	cwd: "",
+};
+
+function receipt(patch: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		schema_version: 2,
+		session_id: sessionId,
+		generation: "generation-current",
+		run_id: "run-current",
+		endpoint_incarnation: "incarnation-current",
+		child_token: "child-current",
+		command_sha256: "a".repeat(64),
+		supervisor_pid: 1,
+		supervisor_start_time: "1",
+		child_pid: 2,
+		child_start_time: "2",
+		signal: "SIGABRT",
+		signal_number: 6,
+		exit_code: null,
+		received_at: "2026-07-19T00:00:00.000Z",
+		...patch,
+	};
+}
+
+function admission(patch: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		session_id: sessionId,
+		endpoint_incarnation: "incarnation-current",
+		owner_generation: "generation-current",
+		admitted: true,
+		...patch,
+	};
+}
+
+async function setup(cwd: string): Promise<string> {
+	const ultragoal = sessionUltragoalDir(cwd, sessionId);
+	await fs.mkdir(ultragoal, { recursive: true });
+	await fs.writeFile(
+		path.join(ultragoal, "goals.json"),
+		JSON.stringify({
+			goals: [
+				{ id: "active", status: "active" },
+				{ id: "review", status: "review_blocked" },
+			],
+		}),
+	);
+	await fs.writeFile(path.join(ultragoal, "ledger.jsonl"), '{"event":"goal_started","goal":"active"}\n');
+	const transcript = path.join(cwd, "transcript.jsonl");
+	await fs.writeFile(
+		transcript,
+		'{"id":"one","parentId":null,"type":"message"}\n{"id":"two","parentId":"one","type":"yield","result":{"status":"success"}}\n{"id":"three","parentId":"two","type":"toolResult","toolCallId":"two","content":[]}\n',
+	);
+	return transcript;
+}
+
+describe("Ultragoal owner-loss recovery", () => {
+	it("resumes only from exact durable terminal JSONL, preserving dirty product files despite live sidecars", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-owner-loss-"));
+		try {
+			const transcriptPath = await setup(cwd);
+			const product = path.join(cwd, "product.ts");
+			await fs.writeFile(product, "export const dirtyProductFile = true;\n");
+			await fs.mkdir(path.join(cwd, ".gjc", "projection"), { recursive: true });
+			await fs.writeFile(
+				path.join(cwd, ".gjc", "projection", "runtime.json"),
+				'{"state":"running","owner":"live"}\n',
+			);
+			const decision = await planUltragoalOwnerLossRecovery({
+				binding: { ...binding, cwd },
+				receipt: receipt(),
+				admission: admission(),
+				transcriptPath,
+			});
+			expect(decision).toMatchObject({
+				disposition: "resume",
+				reason: "terminal_transcript_authoritative",
+				terminal: { yieldId: "two", result: { status: "success" } },
+			});
+			expect(await fs.readFile(product, "utf8")).toBe("export const dirtyProductFile = true;\n");
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed for stale identity, unrelated sessions, missing terminal output, corrupt rows, and conflicting yields", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-owner-loss-"));
+		try {
+			const transcriptPath = await setup(cwd);
+			for (const [badReceipt, badAdmission] of [
+				[receipt({ generation: "stale-generation" }), admission()],
+				[receipt({ session_id: "unrelated" }), admission()],
+				[receipt(), admission({ endpoint_incarnation: "stale-incarnation" })],
+				[receipt(), admission({ owner_generation: "stale-generation" })],
+			] as const) {
+				const decision = await planUltragoalOwnerLossRecovery({
+					binding: { ...binding, cwd },
+					receipt: badReceipt,
+					admission: badAdmission,
+					transcriptPath,
+				});
+				expect(decision.disposition).toBe("handoff");
+			}
+			for (const content of [
+				"",
+				'{"id":"one","parentId":null,"type":"yield","result":{"status":"aborted"}}',
+				"{bad}\n",
+				'{"id":"one","parentId":null,"type":"yield","result":{}}\n{"id":"two","parentId":"one","type":"yield","result":{}}\n',
+			]) {
+				await fs.writeFile(transcriptPath, content);
+				const decision = await planUltragoalOwnerLossRecovery({
+					binding: { ...binding, cwd },
+					receipt: receipt(),
+					admission: admission(),
+					transcriptPath,
+				});
+				expect(decision).toMatchObject({
+					disposition: "handoff",
+					reason: "terminal_transcript_missing_or_invalid",
+				});
+			}
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("never resumes aborted, errored, unknown, or malformed terminal results", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-owner-loss-"));
+		try {
+			const transcriptPath = await setup(cwd);
+			for (const status of ["aborted", "error", "unknown", "completed", ""] as const) {
+				await fs.writeFile(
+					transcriptPath,
+					`{"id":"one","parentId":null,"type":"message"}\n{"id":"two","parentId":"one","type":"yield","result":{"status":"${status}"}}\n{"id":"three","parentId":"two","type":"toolResult","toolCallId":"two","content":[]}\n`,
+				);
+				expect(
+					await planUltragoalOwnerLossRecovery({
+						binding: { ...binding, cwd },
+						receipt: receipt(),
+						admission: admission(),
+						transcriptPath,
+					}),
+				).toMatchObject({ disposition: "handoff", reason: "terminal_aborted_errored" });
+			}
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects reserved-artifact collisions and symlink traversal before snapshot or recovery authority", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-owner-loss-"));
+		const outside = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-owner-loss-outside-"));
+		try {
+			await setup(cwd);
+			expect(
+				await captureUltragoalRecoverySnapshot({
+					cwd,
+					sessionId,
+					protectedPaths: ["goals.json"],
+					sanctionedDeltas: ["goals.json"],
+					absentArtifacts: [],
+					transientHistory: [],
+				}),
+			).toBeNull();
+			const linked = path.join(cwd, "escaped.jsonl");
+			await fs.symlink(path.join(outside, "outside.jsonl"), linked);
+			await fs.writeFile(path.join(outside, "outside.jsonl"), "outside\n");
+			expect(await validateRecoveryPath(cwd, linked)).toBeNull();
+			expect(
+				parseStrictTerminalTranscript(
+					'{"id":"one","parentId":null,"type":"yield","result":{"status":"aborted"}}\n',
+				),
+			).toBeNull();
+			expect(
+				parseStrictTerminalTranscript(
+					'{"id":"y1","parentId":null,"type":"yield","result":{"status":"success"}}\n{"id":"r1","parentId":"y1","type":"toolResult","toolCallId":"y1","content":[]}\n{"id":"y2","parentId":"r1","type":"yield","result":{"status":"success"}}\n{"id":"r2","parentId":"y2","type":"toolResult","toolCallId":"y2","content":[]}\n',
+				),
+			).toBeNull();
+			const decision = await planUltragoalOwnerLossRecovery({
+				binding: { ...binding, cwd },
+				receipt: receipt(),
+				admission: admission(),
+				transcriptPath: linked,
+			});
+			expect(decision).toMatchObject({ disposition: "handoff", reason: "transcript_path_untrusted" });
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+			await fs.rm(outside, { recursive: true, force: true });
+		}
+	});
+
+	it("persists a recovery decision idempotently and validates strict receipt/admission boundaries", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-owner-loss-"));
+		try {
+			const stableBinding = { ...binding, cwd };
+			expect(validateOwnerLossBinding(stableBinding, receipt())).toBe(true);
+			expect(validateOwnerLossBinding(stableBinding, receipt({ generation: "old" }))).toBe(false);
+			expect(validateRecoveryAdmission(stableBinding, admission())).toBe(true);
+			expect(validateRecoveryAdmission(stableBinding, admission({ admitted: false }))).toBe(false);
+			const decision = { disposition: "handoff" as const, reason: "terminal_transcript_missing_or_invalid" };
+			const [first] = await Promise.all([
+				persistUltragoalRecoveryDecision({ cwd, sessionId, binding: stableBinding, decision }),
+				persistUltragoalRecoveryDecision({ cwd, sessionId, binding: stableBinding, decision }),
+			]);
+			const journal = await fs.readFile(first.journalPath, "utf8");
+			expect(journal.trim().split("\n")).toHaveLength(1);
+			expect(JSON.parse(await fs.readFile(first.handoffPath, "utf8"))).toMatchObject({
+				disposition: "handoff",
+				reason: decision.reason,
+			});
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
@@ -1242,7 +1242,8 @@ describe("lifecycle control runtime", () => {
 		expect(calls).toContain("@gjc-owner-generation");
 		expect(calls).toContain("@gjc-owner-server-key");
 		expect(calls).not.toContain("GJC_OWNER_");
-		expect(calls).toContain(`gjc --resume 'abc123'`);
+		expect(calls).toContain("GJC_MANAGED_OWNER_COMMAND_JSON=");
+		expect(calls).toContain("abc123");
 		expect(calls).not.toContain("gjc-lifecycle-owner-isolation");
 		expect(calls).toContain("@gjc-project");
 		expect(fs.existsSync(serverState)).toBe(true);
@@ -1387,6 +1388,8 @@ describe("lifecycle control runtime", () => {
 			expect(calls).toContain(`GJC_TMUX_OWNER_GENERATION='${generation}'`);
 			expect(calls).toContain(`GJC_TMUX_OWNER_STATE_DIR='${path.dirname(result.sessionStateFile!)}'`);
 			expect(calls).toContain("GJC_TMUX_OWNER_SERVER_KEY='default'");
+			expect(calls).toMatch(/GJC_MANAGED_OWNER_RUN_ID='[0-9a-f-]{36}'/i);
+			expect(calls).toMatch(/GJC_MANAGED_OWNER_INCARNATION='[0-9a-f-]{36}'/i);
 			expect(calls).toContain("@gjc-owner-generation");
 			expect(calls).toContain("@gjc-owner-server-key");
 			expect(calls).not.toContain("GJC_OWNER_");

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Linux-only descriptor-relative recovery filesystem authority with no-follow trusted-root stat, bounded read, exclusive create, no-replace install, fsync, and stable identity operations. Unsupported platforms and unsafe traversal, symlink, special-file, hard-link, oversized-content, or identity-swap evidence fail closed (#2681).
+
 ## [0.11.2] - 2026-07-19
 
 ### Fixed

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -350,6 +350,33 @@ export declare class PtySession {
   kill(): void
 }
 
+/** Retained trusted-root authority for Linux recovery artifacts. */
+export declare class RecoveryFsRoot {
+  /** Return the stable identity of the retained root descriptor. */
+  identity(): RecoveryFsResult
+  /** Stat one existing regular, single-linked file without following links. */
+  stat(relativePath: string): RecoveryFsResult
+  /** Read one existing regular, single-linked file without following links. */
+  read(relativePath: string, maxBytes: number): RecoveryFsResult
+  /**
+   * Create one previously absent regular, owner-only file and synchronously
+   * persist its contents. Existing entries are never replaced.
+   */
+  create(relativePath: string, data: Uint8Array): RecoveryFsResult
+  /**
+   * Atomically install an already-created regular file at an absent name.
+   * Both names remain relative to this retained root and are never resolved
+   * through a pathname after their parent descriptors are acquired.
+   */
+  install(sourceRelativePath: string, destinationRelativePath: string): RecoveryFsResult
+  /**
+   * Synchronize the retained root directory, making a preceding create or
+   * install durable when the filesystem supports directory fsync.
+   */
+  fsync(): RecoveryFsResult
+  close(): RecoveryFsResult
+}
+
 /** Persistent brush-core shell session. */
 export declare class Shell {
   /**
@@ -1640,6 +1667,12 @@ export interface NotificationEndpoint {
   sessionId: string
 }
 
+/**
+ * Acquire an immutable trusted-root descriptor. Linux is required; every
+ * other platform returns a durable unsupported-platform result.
+ */
+export declare function openRecoveryFsRoot(path: string): RecoveryFsRoot
+
 /** Parsed Kitty keyboard protocol sequence result for a Kitty input sequence. */
 export interface ParsedKittyResult {
   /** Primary codepoint associated with the key. */
@@ -1755,6 +1788,20 @@ export declare function ptyTimeoutCount(): bigint
  * Returns an error if clipboard access fails or image encoding fails.
  */
 export declare function readImageFromClipboard(): Promise<ClipboardImage | undefined | null>
+
+export interface RecoveryFsIdentity {
+  dev: string
+  ino: string
+  size: string
+  mtimeNs: string
+}
+
+export interface RecoveryFsResult {
+  ok: boolean
+  code?: string
+  identity?: RecoveryFsIdentity
+  data?: Uint8Array
+}
 
 export declare function renameNoReplacePath(sourcePath: string, destinationPath: string): NativeExactUnlinkResult
 

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -25,6 +25,7 @@ export const NotificationControlServer = nativeBindings.NotificationControlServe
 export const NotificationServer = nativeBindings.NotificationServer;
 export const Process = nativeBindings.Process;
 export const PtySession = nativeBindings.PtySession;
+export const RecoveryFsRoot = nativeBindings.RecoveryFsRoot;
 export const Shell = nativeBindings.Shell;
 
 // functions
@@ -69,6 +70,7 @@ export const matchesKey = nativeBindings.matchesKey;
 export const matchesKittySequence = nativeBindings.matchesKittySequence;
 export const matchesLegacySequence = nativeBindings.matchesLegacySequence;
 export const nativeBuildInfo = nativeBindings.nativeBuildInfo;
+export const openRecoveryFsRoot = nativeBindings.openRecoveryFsRoot;
 export const parseKey = nativeBindings.parseKey;
 export const parseKittySequence = nativeBindings.parseKittySequence;
 export const ptyTimeoutCount = nativeBindings.ptyTimeoutCount;

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -146,6 +146,15 @@ async function installGeneratedBindings(outputDir: string): Promise<void> {
 	}
 }
 
+async function validateRecoveryFsBindings(): Promise<void> {
+	const bindings = await Bun.file(path.join(nativeDir, "index.d.ts")).text();
+	for (const symbol of ["RecoveryFsRoot", "RecoveryFsIdentity", "RecoveryFsResult", "openRecoveryFsRoot"]) {
+		if (!bindings.includes(symbol)) {
+			throw new Error(`napi build did not generate the required recovery filesystem binding: ${symbol}`);
+		}
+	}
+}
+
 type NativeBuildProfile = "local" | "ci" | "dist";
 
 export function resolveNativeBuildProfile(options: {
@@ -231,6 +240,7 @@ try {
 	}
 
 	await installGeneratedBindings(buildOutputDir);
+	await validateRecoveryFsBindings();
 
 	await Bun.write(
 		`${canonicalAddonPath}.build.json`,

--- a/packages/natives/test/recovery-fs.test.ts
+++ b/packages/natives/test/recovery-fs.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { openRecoveryFsRoot } from "../native/index.js";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+	const directory = await fs.mkdtemp(path.join(os.tmpdir(), "pi-recovery-fs-"));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })),
+	);
+});
+
+describe.skipIf(process.platform !== "linux")("native recovery filesystem authority", () => {
+	it("creates, installs, fsyncs, and reports descriptor identities", async () => {
+		const root = await temporaryDirectory();
+		const authority = openRecoveryFsRoot(root);
+
+		const created = authority.create("state.tmp", Buffer.from('{"generation":1}\n'));
+		expect(created).toMatchObject({ ok: true, identity: { size: "17" } });
+		expect(authority.install("state.tmp", "state.json")).toMatchObject({ ok: true });
+		expect(authority.stat("state.json")).toMatchObject({ ok: true, identity: created.identity });
+		const read = authority.read("state.json", 1024);
+		expect(read.ok).toBe(true);
+		expect(Buffer.from(read.data ?? [])).toEqual(Buffer.from('{"generation":1}\n'));
+		expect(authority.fsync()).toMatchObject({ ok: true });
+		expect(authority.close()).toMatchObject({ ok: true });
+		expect(authority.stat("state.json")).toEqual({ ok: false, code: "closed" });
+	});
+
+	it("rejects traversal, symlinks, special files, hard links, and oversized content", async () => {
+		const root = await temporaryDirectory();
+		const authority = openRecoveryFsRoot(root);
+		await fs.writeFile(path.join(root, "regular"), "trusted");
+		await fs.link(path.join(root, "regular"), path.join(root, "hard-link"));
+		await fs.symlink("regular", path.join(root, "link"));
+		const fifo = path.join(root, "receipt.fifo");
+		const mkfifo = Bun.spawn(["mkfifo", fifo], { stdout: "ignore", stderr: "ignore" });
+		expect(await mkfifo.exited).toBe(0);
+
+		expect(authority.stat("../outside")).toMatchObject({ ok: false, code: "invalid_path" });
+		expect(authority.read("link", 1024)).toMatchObject({ ok: false, code: "reparse_point" });
+		expect(authority.stat("receipt.fifo")).toMatchObject({ ok: false, code: "not_regular_file" });
+		expect(authority.stat("hard-link")).toMatchObject({ ok: false, code: "hard_link" });
+		expect(authority.create("too-large", Buffer.alloc(1024 * 1024 + 1))).toMatchObject({
+			ok: false,
+			code: "content_too_large",
+		});
+		expect(authority.close()).toMatchObject({ ok: true });
+	});
+
+	it("continues to use the retained root descriptor after the root pathname is swapped", async () => {
+		const parent = await temporaryDirectory();
+		const root = path.join(parent, "root");
+		const retained = path.join(parent, "retained");
+		const replacement = path.join(parent, "replacement");
+		await fs.mkdir(root);
+		await fs.mkdir(replacement);
+		const authority = openRecoveryFsRoot(root);
+		await fs.rename(root, retained);
+		await fs.symlink(replacement, root, "dir");
+
+		expect(authority.create("receipt.tmp", Buffer.from("receipt"))).toMatchObject({ ok: true });
+		expect(await fs.readFile(path.join(retained, "receipt.tmp"), "utf8")).toBe("receipt");
+		expect(await fs.readdir(replacement)).toEqual([]);
+		expect(authority.close()).toMatchObject({ ok: true });
+	});
+
+	it("refuses to replace an existing install destination", async () => {
+		const root = await temporaryDirectory();
+		const authority = openRecoveryFsRoot(root);
+		expect(authority.create("candidate", Buffer.from("candidate"))).toMatchObject({ ok: true });
+		expect(authority.create("receipt", Buffer.from("existing"))).toMatchObject({ ok: true });
+		expect(authority.install("candidate", "receipt")).toMatchObject({ ok: false, code: "already_exists" });
+		expect(await fs.readFile(path.join(root, "candidate"), "utf8")).toBe("candidate");
+		expect(await fs.readFile(path.join(root, "receipt"), "utf8")).toBe("existing");
+		expect(authority.close()).toMatchObject({ ok: true });
+	});
+});


### PR DESCRIPTION
## Summary
- add exact-child managed-owner supervisor receipts for SIGABRT
- discover the authoritative predecessor from the captured prior generation and block replacement CLI startup until recovery disposition
- reconcile strict terminal transcript evidence into a durable dirty-preserving fail-closed handoff when safe session resume is unavailable
- add retained-descriptor native filesystem authority and hostile crash/path/identity tests

## Verification
- `bun run --cwd packages/coding-agent check`
- `bun run --cwd packages/coding-agent lint`
- `bun run --cwd packages/natives check`
- `cargo check -p pi-natives`
- native recovery tests: 4 passed
- focused coding recovery/workflow/session suites: 411 passed, 1590 assertions
- fresh Architect review: CLEAR / APPROVE
- fresh executor QA: passed

Closes #2681

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*