### PR TITLE
fix(coding-agent): bound marketplace catalog downloads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- Marketplace catalog URL downloads now reject private initial and redirect targets, cap redirect chains, share one operation deadline, and enforce response-size limits before parsing or caching.
 - Added fail-closed managed tmux owner SIGABRT recovery: exact-child supervisor receipts and pre-CLI admission now bind replacement ownership, strict durable Ultragoal/transcript evidence reconciles terminal child yields over stale nonterminal runtime state, recovery hydration remains write-free until an ownership fence, and hostile identity, corruption, concurrency, and path boundaries preserve dirty product files (#2681).
 - Restored the canonical public CLI command-surface contract for the independently documented `gjc memory` filesystem/MAP command after its feature merge omitted the expected command-list update.
 - Filesystem/MAP `memory doctor` now treats intentionally uninitialized scopes as absent instead of making partial-scope opt-in permanently unhealthy; explicit policy denials and real document/MAP safety findings remain reported.

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/fetcher.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/fetcher.ts
@@ -9,6 +9,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { isEnoent, logger } from "@gajae-code/utils";
 import * as git from "../../../utils/git";
+import { validatePublicHttpUrl } from "../../../web/insane/url-guard";
 
 import type { MarketplaceCatalog, MarketplaceSourceType } from "./types";
 import { isValidNameSegment } from "./types";
@@ -194,6 +195,123 @@ export function parseMarketplaceCatalog(content: string, filePath: string): Mark
 
 /** Relative path from a marketplace root to its catalog file. */
 const CATALOG_RELATIVE_PATH = path.join(".claude-plugin", "marketplace.json");
+const URL_FETCH_TIMEOUT_MS = 60_000;
+const URL_FETCH_MAX_REDIRECTS = 5;
+const URL_FETCH_MAX_BYTES = 5 * 1024 * 1024;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+function withAbortSignal<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+	if (signal.aborted) return Promise.reject(signal.reason);
+
+	const deferred = Promise.withResolvers<T>();
+	const abort = () => deferred.reject(signal.reason);
+	signal.addEventListener("abort", abort, { once: true });
+	operation.then(deferred.resolve, deferred.reject).finally(() => signal.removeEventListener("abort", abort));
+	return deferred.promise;
+}
+
+function cancelResponseBody(response: Response): void {
+	const body = response.body;
+	if (!body) return;
+
+	try {
+		void body.cancel().catch(() => {});
+	} catch {
+		// Preserve the policy error even if the transport cannot be cancelled.
+	}
+}
+
+function cancelReader(reader: { cancel(): Promise<void> }): void {
+	try {
+		void reader.cancel().catch(() => {});
+	} catch {
+		// Preserve the timeout or size-limit error even if the transport cannot be cancelled.
+	}
+}
+
+async function readBoundedResponseText(response: Response, source: string, signal: AbortSignal): Promise<string> {
+	const contentLength = response.headers.get("content-length");
+	if (contentLength !== null && /^\d+$/.test(contentLength)) {
+		const declaredBytes = Number(contentLength);
+		if (!Number.isSafeInteger(declaredBytes) || declaredBytes > URL_FETCH_MAX_BYTES) {
+			cancelResponseBody(response);
+			throw new Error(`Marketplace catalog from ${source} exceeds the maximum size of ${URL_FETCH_MAX_BYTES} bytes`);
+		}
+	}
+
+	if (!response.body) return "";
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	const chunks: string[] = [];
+	let receivedBytes = 0;
+
+	try {
+		while (true) {
+			const { done, value } = await withAbortSignal(reader.read(), signal);
+			if (done) break;
+			receivedBytes += value.byteLength;
+			if (receivedBytes > URL_FETCH_MAX_BYTES) {
+				throw new Error(
+					`Marketplace catalog from ${source} exceeds the maximum size of ${URL_FETCH_MAX_BYTES} bytes`,
+				);
+			}
+			chunks.push(decoder.decode(value, { stream: true }));
+		}
+		chunks.push(decoder.decode());
+		return chunks.join("");
+	} catch (err) {
+		cancelReader(reader);
+		throw err;
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+async function fetchMarketplaceCatalogUrl(source: string): Promise<string> {
+	const deadline = AbortSignal.timeout(URL_FETCH_TIMEOUT_MS);
+	let currentUrl = source;
+
+	try {
+		for (let redirectCount = 0; ; redirectCount++) {
+			const guard = await withAbortSignal(validatePublicHttpUrl(currentUrl), deadline);
+			if (!guard.ok) {
+				throw new Error(
+					`Refusing to fetch marketplace catalog from ${currentUrl}: target URL is not public HTTP(S): ${guard.reason}`,
+				);
+			}
+			currentUrl = guard.url.toString();
+
+			const response = await withAbortSignal(fetch(currentUrl, { redirect: "manual", signal: deadline }), deadline);
+			if (REDIRECT_STATUSES.has(response.status)) {
+				if (redirectCount >= URL_FETCH_MAX_REDIRECTS) {
+					cancelResponseBody(response);
+					throw new Error(`Too many redirects fetching marketplace catalog from ${source}`);
+				}
+				const location = response.headers.get("location");
+				if (!location) {
+					cancelResponseBody(response);
+					throw new Error(`Marketplace catalog redirect from ${currentUrl} is missing a Location header`);
+				}
+				cancelResponseBody(response);
+				currentUrl = new URL(location, currentUrl).toString();
+				continue;
+			}
+			if (!response.ok) {
+				cancelResponseBody(response);
+				throw new Error(
+					`Failed to fetch marketplace catalog from ${currentUrl}: HTTP ${response.status} ${response.statusText}`,
+				);
+			}
+			return await readBoundedResponseText(response, currentUrl, deadline);
+		}
+	} catch (err) {
+		if (deadline.aborted) {
+			throw new Error(`Timed out fetching marketplace catalog from ${source}`);
+		}
+		throw err;
+	}
+}
 
 /**
  * Expand a `~/...` path to an absolute path using os.homedir().
@@ -249,13 +367,7 @@ export async function fetchMarketplace(source: string, cacheDir: string): Promis
 	}
 
 	// type === "url"
-	const response = await fetch(source, { signal: AbortSignal.timeout(60_000) });
-	if (!response.ok) {
-		throw new Error(
-			`Failed to fetch marketplace catalog from ${source}: HTTP ${response.status} ${response.statusText}`,
-		);
-	}
-	const text = await response.text();
+	const text = await fetchMarketplaceCatalogUrl(source);
 	const catalog = parseMarketplaceCatalog(text, source);
 
 	const catalogDir = path.join(cacheDir, catalog.name);

--- a/packages/coding-agent/test/marketplace/fetcher.test.ts
+++ b/packages/coding-agent/test/marketplace/fetcher.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -11,6 +11,17 @@ import {
 
 // Fixture lives at test/marketplace/fixtures/valid-marketplace/
 const FIXTURE_DIR = path.join(import.meta.dir, "fixtures", "valid-marketplace");
+const MARKETPLACE_RESPONSE_MAX_BYTES = 5 * 1024 * 1024;
+
+async function settleWithin<T>(operation: Promise<T>, timeoutMs = 500): Promise<T> {
+	const timeout = Promise.withResolvers<T>();
+	const timeoutId = setTimeout(() => timeout.reject(new Error("Test operation did not settle")), timeoutMs);
+	try {
+		return await Promise.race([operation, timeout.promise]);
+	} finally {
+		clearTimeout(timeoutId);
+	}
+}
 
 // ── classifySource ────────────────────────────────────────────────────
 
@@ -156,6 +167,7 @@ describe("fetchMarketplace", () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -178,6 +190,201 @@ describe("fetchMarketplace", () => {
 		// Use a path that resolves within tmpDir but doesn't exist
 		const fakeSrc = path.join(tmpDir, "ghost-marketplace");
 		await expect(fetchMarketplace(fakeSrc, tmpDir)).rejects.toThrow(/Marketplace catalog not found/);
+	});
+
+	it("rejects private URL targets before opening a request", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+		await expect(fetchMarketplace("http://127.0.0.1/marketplace.json", tmpDir)).rejects.toThrow(
+			/not public HTTP\(S\)/,
+		);
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(fs.readdirSync(tmpDir)).toEqual([]);
+	});
+
+	it("rejects redirects to private URL targets before the next request", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(null, {
+				status: 302,
+				headers: { location: "http://127.0.0.1/marketplace.json" },
+			}),
+		);
+
+		await expect(fetchMarketplace("https://8.8.8.8/marketplace.json", tmpDir)).rejects.toThrow(
+			/not public HTTP\(S\)/,
+		);
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(fetchSpy.mock.calls[0]?.[1]?.redirect).toBe("manual");
+		expect(fs.readdirSync(tmpDir)).toEqual([]);
+	});
+
+	it("rejects redirect chains beyond the finite cap", async () => {
+		const cancel = vi.fn();
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async input => {
+			const url = new URL(String(input));
+			const step = Number.parseInt(url.searchParams.get("step") ?? "0", 10);
+			const cancellation = Promise.withResolvers<void>();
+			const body = new ReadableStream<Uint8Array>({
+				cancel() {
+					cancel();
+					return cancellation.promise;
+				},
+			});
+			return new Response(body, {
+				status: 302,
+				headers: { location: `/marketplace.json?step=${step + 1}` },
+			});
+		}) as typeof fetch);
+
+		await expect(settleWithin(fetchMarketplace("https://8.8.8.8/marketplace.json", tmpDir))).rejects.toThrow(
+			/Too many redirects/,
+		);
+
+		expect(fetchSpy).toHaveBeenCalledTimes(6);
+		expect(cancel).toHaveBeenCalledTimes(6);
+		expect(fs.readdirSync(tmpDir)).toEqual([]);
+	});
+
+	it("does not wait for response cleanup before reporting an HTTP error", async () => {
+		const cancel = vi.fn();
+		const cancellation = Promise.withResolvers<void>();
+		const body = new ReadableStream<Uint8Array>({
+			cancel() {
+				cancel();
+				return cancellation.promise;
+			},
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(body, { status: 503, statusText: "Unavailable" }));
+
+		await expect(settleWithin(fetchMarketplace("https://8.8.8.8/marketplace.json", tmpDir))).rejects.toThrow(
+			/HTTP 503 Unavailable/,
+		);
+
+		expect(cancel).toHaveBeenCalledTimes(1);
+		expect(fs.readdirSync(tmpDir)).toEqual([]);
+	});
+
+	it("rejects an oversized Content-Length before reading the body", async () => {
+		const cancel = vi.fn();
+		const cancellation = Promise.withResolvers<void>();
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode("should not be read"));
+			},
+			cancel() {
+				cancel();
+				return cancellation.promise;
+			},
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(body, {
+				status: 200,
+				headers: { "content-length": String(MARKETPLACE_RESPONSE_MAX_BYTES + 1) },
+			}),
+		);
+
+		await expect(settleWithin(fetchMarketplace("https://8.8.8.8/marketplace.json", tmpDir))).rejects.toThrow(
+			/maximum size/,
+		);
+
+		expect(cancel).toHaveBeenCalledTimes(1);
+		expect(fs.readdirSync(tmpDir)).toEqual([]);
+	});
+
+	it("cancels a streamed response at the byte cap plus one", async () => {
+		const cancel = vi.fn();
+		const cancellation = Promise.withResolvers<void>();
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array(MARKETPLACE_RESPONSE_MAX_BYTES + 1));
+			},
+			cancel() {
+				cancel();
+				return cancellation.promise;
+			},
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(body, { status: 200 }));
+
+		await expect(settleWithin(fetchMarketplace("https://8.8.8.8/marketplace.json", tmpDir))).rejects.toThrow(
+			/maximum size/,
+		);
+
+		expect(cancel).toHaveBeenCalledTimes(1);
+		expect(fs.readdirSync(tmpDir)).toEqual([]);
+	});
+
+	it("requests reader cancellation before releasing it when the operation deadline expires", async () => {
+		const deadline = new AbortController();
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(deadline.signal);
+		const readStarted = Promise.withResolvers<void>();
+		const readResult = Promise.withResolvers<never>();
+		const cancellation = Promise.withResolvers<void>();
+		const cleanupOrder: string[] = [];
+		const reader = {
+			read: vi.fn(() => {
+				readStarted.resolve();
+				return readResult.promise;
+			}),
+			cancel: vi.fn(() => {
+				cleanupOrder.push("cancel");
+				return cancellation.promise;
+			}),
+			releaseLock: vi.fn(() => cleanupOrder.push("release")),
+		} as unknown as ReadableStreamDefaultReader<Uint8Array>;
+		const response = {
+			body: { getReader: () => reader },
+			headers: new Headers(),
+			ok: true,
+			status: 200,
+			statusText: "OK",
+		} as unknown as Response;
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+
+		const operation = fetchMarketplace("https://8.8.8.8/marketplace.json", tmpDir);
+		await readStarted.promise;
+		deadline.abort(new DOMException("deadline expired", "TimeoutError"));
+
+		await expect(settleWithin(operation)).rejects.toThrow(/Timed out fetching marketplace catalog/);
+		expect(reader.cancel).toHaveBeenCalledTimes(1);
+		expect(cleanupOrder).toEqual(["cancel", "release"]);
+		expect(fs.readdirSync(tmpDir)).toEqual([]);
+	});
+
+	it("counts multibyte response content by encoded bytes", async () => {
+		const multibyteCatalog = JSON.stringify({
+			name: "multibyte-market",
+			owner: { name: "x" },
+			plugins: [],
+			metadata: { description: "💥".repeat(Math.ceil(MARKETPLACE_RESPONSE_MAX_BYTES / 4)) },
+		});
+		expect(multibyteCatalog.length).toBeLessThan(MARKETPLACE_RESPONSE_MAX_BYTES);
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(multibyteCatalog, { status: 200 }));
+
+		await expect(fetchMarketplace("https://8.8.8.8/marketplace.json", tmpDir)).rejects.toThrow(/maximum size/);
+	});
+
+	it("follows public redirects and caches a catalog at the exact byte limit", async () => {
+		const catalogPrefix = JSON.stringify({ name: "remote-market", owner: { name: "x" }, plugins: [] });
+		const validCatalog = `${catalogPrefix}${" ".repeat(MARKETPLACE_RESPONSE_MAX_BYTES - catalogPrefix.length)}`;
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async input => {
+			if (String(input) === "https://8.8.8.8/marketplace.json") {
+				return new Response(null, { status: 302, headers: { location: "/catalog.json" } });
+			}
+			return new Response(validCatalog, {
+				status: 200,
+				headers: { "content-length": String(MARKETPLACE_RESPONSE_MAX_BYTES) },
+			});
+		}) as typeof fetch);
+
+		const result = await fetchMarketplace("https://8.8.8.8/marketplace.json", tmpDir);
+
+		expect(result.catalog.name).toBe("remote-market");
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+		expect(fetchSpy.mock.calls.every(call => call[1]?.redirect === "manual")).toBe(true);
+		expect(fetchSpy.mock.calls[1]?.[1]?.signal).toBe(fetchSpy.mock.calls[0]?.[1]?.signal);
+		expect(fs.readFileSync(path.join(tmpDir, "remote-market", "marketplace.json"), "utf8")).toBe(validCatalog);
 	});
 
 	// Network-dependent tests — skip in CI / offline environments.


### PR DESCRIPTION
## Summary

- Validate the initial direct marketplace JSON URL and every redirect target as public HTTP(S) before issuing the request.
- Follow redirects manually with a five-redirect cap under one 60-second operation deadline.
- Reject responses larger than 5 MiB from either declared `Content-Length` or streamed bytes before parsing or caching.
- Keep response cleanup nonblocking on error and deadline paths.

## Scope

- This change applies only to the direct marketplace JSON URL path.
- Local and git source behavior is unchanged.
- Shared DNS validation-to-connect pinning is explicitly out of scope.

## Review evidence

- Independent code review: **APPROVE**
- Architecture review: **CLEAR**

## Validation

- Focused fetcher tests: **31 pass / 3 skipped / 0 fail**
- Marketplace suite: **199 pass / 5 skipped / 0 fail**
- Coding-agent TypeScript check: pass
- Focused Biome check: pass
- `git diff --check`: pass

The skipped cases require live network access: remote GitHub/git marketplace failures, a remote non-2xx URL response, and two remote source-resolution clones.
