### PR TITLE
test(coding-agent): stabilize compiled broker self-reap fixture

### DIFF
--- a/packages/coding-agent/test/fixtures/sdk-broker-self-reap-entry.ts
+++ b/packages/coding-agent/test/fixtures/sdk-broker-self-reap-entry.ts
@@ -4,6 +4,7 @@ import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import type { Writable } from "node:stream";
+import { runSessionHostSelfExitFixture } from "./sdk-session-host-self-exit-entry";
 
 const MAX_FRAME_BYTES = 4096;
 const SESSION_FIXTURE_BASENAME = `sdk-session-host-self-exit-fixture${process.platform === "win32" ? ".exe" : ""}`;
@@ -97,7 +98,11 @@ async function main(): Promise<void> {
 		closeFd3();
 	}
 }
-void main().catch(() => {
-	closeFd3();
-	process.exitCode = 1;
-});
+if (path.basename(process.execPath) === SESSION_FIXTURE_BASENAME) {
+	void runSessionHostSelfExitFixture().catch(() => process.exit(1));
+} else {
+	void main().catch(() => {
+		closeFd3();
+		process.exitCode = 1;
+	});
+}

--- a/packages/coding-agent/test/fixtures/sdk-session-host-self-exit-entry.ts
+++ b/packages/coding-agent/test/fixtures/sdk-session-host-self-exit-entry.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import * as fs from "node:fs";
 import net from "node:net";
+import path from "node:path";
 
 const MAX_FRAME_BYTES = 4096;
 const CONTROL_TTL_MS = 10_000;
@@ -47,7 +48,7 @@ function parse(frame: Buffer): Bootstrap {
 		frame.fill(0);
 	}
 }
-async function main(): Promise<void> {
+export async function runSessionHostSelfExitFixture(): Promise<void> {
 	const bootstrap = parse(readFrame());
 	closeFd3();
 	const token = Buffer.from(bootstrap.token, "base64");
@@ -72,21 +73,29 @@ async function main(): Promise<void> {
 		if (!accepted) process.exit(1);
 		socket.off("data", onHandshakeData);
 		// The parent sends one authenticated self-exit capability after broker exit.
-		socket.once("data", (command: Buffer) => {
+		let exitReceived = Buffer.alloc(0);
+		const onExitData = (command: Buffer): void => {
+			exitReceived = Buffer.concat([exitReceived, command]);
+			command.fill(0);
+			if (exitReceived.length < 36) return;
+			socket.off("data", onExitData);
 			const exit = proof(token, "SSH1-exit", bootstrap.requestId);
 			const valid =
-				command.length === 36 &&
-				command.subarray(0, 4).toString("ascii") === "EXT1" &&
-				timingSafeEqual(command.subarray(4), exit);
+				exitReceived.length === 36 &&
+				exitReceived.subarray(0, 4).toString("ascii") === "EXT1" &&
+				timingSafeEqual(exitReceived.subarray(4), exit);
 			exit.fill(0);
-			command.fill(0);
+			exitReceived.fill(0);
+			exitReceived = Buffer.alloc(0);
 			token.fill(0);
 			clearTimeout(timer);
 			if (!valid) process.exit(1);
 			socket.end("BYE1", () => process.exit(0));
-		});
+		};
+		socket.on("data", onExitData);
 	};
 	socket.on("data", onHandshakeData);
 	socket.once("end", () => process.exit(1));
 }
-void main().catch(() => process.exit(1));
+if (path.basename(process.argv[1] ?? "") === "sdk-session-host-self-exit-entry.ts")
+	void runSessionHostSelfExitFixture().catch(() => process.exit(1));

--- a/packages/coding-agent/test/sdk-broker-self-reap-process.test.ts
+++ b/packages/coding-agent/test/sdk-broker-self-reap-process.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { afterAll, expect, test } from "bun:test";
 import { createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import * as fs from "node:fs/promises";
 import net from "node:net";
@@ -9,15 +9,46 @@ import { startFixtureBrokerWithLeaseForTest } from "../src/sdk/broker/ensure";
 import { startFixtureBrokerCommandWithLeaseForTest } from "./helpers/fixture-broker-cleanup";
 
 const fixture = path.resolve(import.meta.dir, "fixtures/sdk-broker-self-reap-entry.ts");
-const sessionFixture = path.resolve(import.meta.dir, "fixtures/sdk-session-host-self-exit-entry.ts");
 const fixtureExecutableSuffix = process.platform === "win32" ? ".exe" : "";
+const compiledFixtureRoot = path.join(process.env.TMPDIR ?? "/tmp", `gjc-broker-compiled-fixtures-${process.pid}`);
+const compiledBrokerFixture = path.join(compiledFixtureRoot, `sdk-broker-self-reap-fixture${fixtureExecutableSuffix}`);
+const compiledSessionFixture = path.join(
+	compiledFixtureRoot,
+	`sdk-session-host-self-exit-fixture${fixtureExecutableSuffix}`,
+);
+let compiledFixturesReady: Promise<void> | undefined;
+
+afterAll(async () => {
+	await fs.rm(compiledFixtureRoot, { recursive: true, force: true });
+});
 
 async function compileFixture(entrypoint: string, outfile: string): Promise<void> {
-	const compile = Bun.spawn([process.execPath, "build", entrypoint, "--compile", "--outfile", outfile], {
+	const command = [process.execPath, "build", entrypoint, "--compile", "--outfile", outfile];
+	const compile = Bun.spawn(process.platform === "win32" ? command : ["nice", "-n", "19", ...command], {
 		stdout: "pipe",
 		stderr: "pipe",
 	});
 	if ((await compile.exited) !== 0) throw new Error(`Failed to compile self-reap fixture: ${entrypoint}`);
+}
+
+async function ensureCompiledFixtures(): Promise<void> {
+	if (!compiledFixturesReady) {
+		compiledFixturesReady = (async () => {
+			await fs.mkdir(compiledFixtureRoot, { recursive: true });
+			await compileFixture(fixture, compiledBrokerFixture);
+			await fs.copyFile(compiledBrokerFixture, compiledSessionFixture);
+		})();
+	}
+	await compiledFixturesReady;
+}
+
+async function phase<T>(promise: Promise<T>, label: string, timeoutMs: number): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(timeoutMs).then(() => {
+			throw new Error(`Timed out waiting for ${label}`);
+		}),
+	]);
 }
 
 type FixtureCommand = { file: string; args: string[] };
@@ -76,7 +107,7 @@ async function assertAuthenticatedFixtureTopology(commandForRoot: FixtureCommand
 		);
 		bootstrap.fill(0);
 		started.control.end();
-		await connected;
+		await phase(connected, "authenticated child connection", 10_000);
 
 		// The broker naturally returns after dispatch; this observation is through
 		// its exact retained lease, not a child PID recovered from the protocol.
@@ -97,8 +128,8 @@ async function assertAuthenticatedFixtureTopology(commandForRoot: FixtureCommand
 		});
 		socket!.write(Buffer.concat([Buffer.from("EXT1"), exit]));
 		exit.fill(0);
-		await acknowledged;
-		await childExit;
+		await phase(acknowledged, "authenticated child self-exit acknowledgement", 10_000);
+		await phase(childExit!, "authenticated child socket close", 5_000);
 		expect(childExited).toBe(true);
 	} finally {
 		token.fill(0);
@@ -113,7 +144,8 @@ async function assertAuthenticatedFixtureTopology(commandForRoot: FixtureCommand
 async function compiledFixtureCommand(root: string): Promise<FixtureCommand> {
 	const broker = path.join(root, `sdk-broker-self-reap-fixture${fixtureExecutableSuffix}`);
 	const session = path.join(root, `sdk-session-host-self-exit-fixture${fixtureExecutableSuffix}`);
-	await Promise.all([compileFixture(fixture, broker), compileFixture(sessionFixture, session)]);
+	await ensureCompiledFixtures();
+	await Promise.all([fs.copyFile(compiledBrokerFixture, broker), fs.copyFile(compiledSessionFixture, session)]);
 	return { file: broker, args: [] };
 }
 async function expectCompiledBrokerToRejectSibling(broker: string, root: string): Promise<void> {
@@ -196,6 +228,17 @@ test.serial(
 );
 
 test.serial(
+	"builds the compiled broker/session fixture pair outside the lifecycle assertion budget",
+	async () => {
+		// Keep the CPU-heavy compile out of the shard's short lifecycle/gate test window.
+		await Bun.sleep(20_000);
+		await ensureCompiledFixtures();
+		expect((await fs.stat(compiledBrokerFixture)).isFile()).toBe(true);
+		expect((await fs.stat(compiledSessionFixture)).isFile()).toBe(true);
+	},
+	120_000,
+);
+test.serial(
 	"compiled fixture broker resolves its compiled sibling and preserves authenticated child self-exit",
 	async () => {
 		await assertAuthenticatedFixtureTopology(compiledFixtureCommand);
@@ -207,12 +250,10 @@ test.serial(
 	"compiled fixture broker fails closed for missing, non-file, and symlink session siblings",
 	async () => {
 		const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-self-reap-"));
-		const broker = path.join(root, `sdk-broker-self-reap-fixture${fixtureExecutableSuffix}`);
+		const { file: broker } = await compiledFixtureCommand(root);
 		const session = path.join(root, `sdk-session-host-self-exit-fixture${fixtureExecutableSuffix}`);
 		const retainedSession = path.join(root, `retained-session${fixtureExecutableSuffix}`);
 		try {
-			await Promise.all([compileFixture(fixture, broker), compileFixture(sessionFixture, session)]);
-
 			await fs.rename(session, retainedSession);
 			await expectCompiledBrokerToRejectSibling(broker, root);
 			await fs.rename(retainedSession, session);


### PR DESCRIPTION
## Summary

- Repairs the post-merge Dev CI regression from #2679 where the compiled broker fixture timed out at 30 seconds under shard load.
- Builds one compiled fixture bundle and installs it under both exact broker/session sibling names, instead of compiling two independent binaries inside the lifecycle assertion.
- Prevents imported session-fixture code from auto-running inside the broker bundle and buffers fragmented authenticated `EXT1` self-exit frames before validation.
- Separates the CPU-heavy fixture build from the 30-second child-lifecycle assertion and runs the build at low priority after short shard lifecycle tests have quiesced; lifecycle timeouts remain unchanged.

## Root cause

The compiled fixture path bundled the session entry into the broker executable while the imported entry could also auto-run under compiled `import.meta.main` semantics. Under shard load, duplicate/competing session startup and fragmented TCP exit frames produced an authenticated child that intermittently never returned `BYE1`. Compiling two separate fixtures inside the 30-second lifecycle test also consumed the behavior budget under hosted CPU contention.

## Verification

- Compiled authenticated child behavior: 10/10 focused repeats passed.
- Full `sdk-broker-self-reap-process.test.ts`: 5/5 tests passed in repeated runs.
- Shard 8: the broker self-reap target and workflow-gate lifecycle tests pass; remaining failures are independently reproducible on current `dev` and tracked in #2692.
- `bun --cwd=packages/coding-agent run check`: passed.
- Schema/public-sync checks: passed.
- `bun run build`: passed.

## Delivery boundary

Targets `dev` only. No release, version, publish, workflow, or production broker-runtime change; this is a test fixture/lifecycle repair for the #2679 post-merge regression.