### PR TITLE
fix(sdk): classify recovery hydration seam

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -113,6 +113,8 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"agent_session:cancelAndSubmit": "interactive queue transaction plumbing, not an independent SDK control seam",
 	"agent_session:applyCompactionPostAppendForTests": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:continuePersistedHistory": "internal startup lifecycle plumbing, not a user-facing control seam",
+	"agent_session:promoteRecoveryHydrationAfterOwnershipReadyFence":
+		"internal owner-recovery authority transition after a durable writer fence, never a user-facing SDK operation",
 	"agent_session:setActiveModelProfile": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:getActiveModelProfile": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:getSessionDefaultModelSelector": "internal accessor/plumbing, not a user-facing control seam",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2810,6 +2810,17 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:promoteRecoveryHydrationAfterOwnershipReadyFence",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal owner-recovery authority transition after a durable writer fence, never a user-facing SDK operation",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:continuePersistedHistory",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",


### PR DESCRIPTION
## Summary
- classify `agent_session:promoteRecoveryHydrationAfterOwnershipReadyFence` as a locked private authority seam
- regenerate the canonical SDK operation inventory
- keep the durable ownership-ready/writer-lease transition out of the public SDK surface

## Root cause
Post-merge Dev CI run 29711351544 and exact-dev run 29711835774 failed shard 8 because PR #2688 added the AgentSession recovery promotion helper without an explicit inventory decision. This repair is independent of the valid PR #2679 compiled-broker work.

## Verification
- focused inventory test: 17 passed
- focused inventory + recovery suites: 28 passed
- coding-agent check and lint passed
- native build followed by coding-agent build passed
- hostile Architect review: CLEAR / APPROVE, no findings

Local full shard 8 reaches the repaired inventory test but has an unrelated environment-dependent pet capability assertion (`Ghostty`) that also fails alone in this Linux workspace; the hosted exact-dev shard passed that assertion and failed only the inventory seam. No pet or PR #2679 changes are included.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*