### PR TITLE
fix(tui): idle-timeout bracketed paste so long pastes are not truncated

### DIFF
--- a/packages/tui/src/bracketed-paste.ts
+++ b/packages/tui/src/bracketed-paste.ts
@@ -1,8 +1,11 @@
 const PASTE_START = "\x1b[200~";
 const PASTE_END = "\x1b[201~";
 
-export const BRACKETED_PASTE_FRAME_TIMEOUT_MS = 1_000;
-export const BRACKETED_PASTE_FRAME_MAX_BYTES = 1024 * 1024;
+// Idle timeout between chunks (not total paste duration). Long pastes on
+// Windows Terminal / ConPTY can take many seconds to stream; resetting the
+// timer on each chunk avoids truncating mid-paste.
+export const BRACKETED_PASTE_FRAME_TIMEOUT_MS = 5_000;
+export const BRACKETED_PASTE_FRAME_MAX_BYTES = 8 * 1024 * 1024;
 
 export type PasteResult =
 	| { handled: false }
@@ -63,7 +66,10 @@ export class BracketedPasteHandler {
 				? this.#flushActive(data)
 				: { handled: true, leading: `${this.#flushBuffered()}${data}`, remaining: "" };
 		}
-		if (this.hasPendingFrame && data === "\x1b") {
+		// Lone ESC while waiting for more paste data can mean the user cancelled,
+		// but only treat it as cancel when we are not mid-frame of a multi-chunk
+		// paste that already has content (Windows can deliver odd splits).
+		if (this.hasPendingFrame && data === "\x1b" && !(this.#active && this.#buffer.length > 0)) {
 			return this.#active
 				? this.#flushActive(data)
 				: { handled: true, leading: `${this.#flushBuffered()}${data}`, remaining: "" };
@@ -99,9 +105,12 @@ export class BracketedPasteHandler {
 			this.#leading += combined.slice(0, startIndex);
 			this.#buffer = combined.slice(startIndex + PASTE_START.length);
 			this.#active = true;
-			this.#pendingSince ??= now;
+			this.#pendingSince = now;
 		} else {
 			this.#buffer += data;
+			// Refresh idle clock on each chunk so total paste duration is unbounded
+			// as long as the terminal keeps streaming content.
+			this.#pendingSince = now;
 		}
 
 		const endIndex = this.#buffer.indexOf(PASTE_END);

--- a/packages/tui/test/bracketed-paste.test.ts
+++ b/packages/tui/test/bracketed-paste.test.ts
@@ -85,7 +85,7 @@ describe("BracketedPasteHandler", () => {
 		expect(handler.process("\x1b[201~", now + 10)).toEqual({
 			handled: true,
 			leading: "",
-			pasteContent: "line1\n" + Array.from({ length: 30 }, (_, i) => `chunk-${i}\n`).join(""),
+			pasteContent: `line1\n${Array.from({ length: 30 }, (_, i) => `chunk-${i}\n`).join("")}`,
 			remaining: "",
 		});
 	});
@@ -113,5 +113,4 @@ describe("BracketedPasteHandler", () => {
 			remaining: "more",
 		});
 	});
-
 });

--- a/packages/tui/test/bracketed-paste.test.ts
+++ b/packages/tui/test/bracketed-paste.test.ts
@@ -70,4 +70,48 @@ describe("BracketedPasteHandler", () => {
 			remaining: "\x1b[200~two\x1b[201~",
 		});
 	});
+
+	it("keeps buffering a slow multi-chunk paste when idle gaps stay under the timeout", () => {
+		const handler = new BracketedPasteHandler();
+		let now = 1_000_000;
+		expect(handler.process("\x1b[200~line1\n", now)).toEqual({ handled: true, leading: "", remaining: "" });
+
+		// Stream for >1s total with small idle gaps (old wall-clock timer would truncate).
+		for (let i = 0; i < 30; i++) {
+			now += 100;
+			expect(handler.process(`chunk-${i}\n`, now)).toEqual({ handled: true, leading: "", remaining: "" });
+		}
+
+		expect(handler.process("\x1b[201~", now + 10)).toEqual({
+			handled: true,
+			leading: "",
+			pasteContent: "line1\n" + Array.from({ length: 30 }, (_, i) => `chunk-${i}\n`).join(""),
+			remaining: "",
+		});
+	});
+
+	it("refreshes the idle timer so a 1.1s gap after recent chunks does not flush early", () => {
+		const handler = new BracketedPasteHandler();
+		const t0 = 2_000_000;
+		expect(handler.process("\x1b[200~a", t0)).toEqual({ handled: true, leading: "", remaining: "" });
+		expect(handler.process("b", t0 + 1_100)).toEqual({ handled: true, leading: "", remaining: "" });
+		expect(handler.process("\x1b[201~", t0 + 1_200)).toEqual({
+			handled: true,
+			leading: "",
+			pasteContent: "ab",
+			remaining: "",
+		});
+	});
+
+	it("still flushes when no chunk arrives for the full idle timeout", () => {
+		const handler = new BracketedPasteHandler();
+		expect(handler.process("\x1b[200~partial", 0)).toEqual({ handled: true, leading: "", remaining: "" });
+		expect(handler.process("more", BRACKETED_PASTE_FRAME_TIMEOUT_MS + 1)).toEqual({
+			handled: true,
+			leading: "",
+			pasteContent: "partial",
+			remaining: "more",
+		});
+	});
+
 });


### PR DESCRIPTION
## Summary
- Bracketed paste used a **1s wall-clock** timer from the first chunk. On Windows Terminal / ConPTY, long pastes (e.g. multi-line `/todo` markdown) stream for several seconds, so the frame was flushed early and the tail was dropped.
- Treat the timeout as **per-chunk idle** (reset `#pendingSince` on every chunk), raise idle to **5s**, raise max frame size to **8MB**.
- Soften lone-ESC cancel so mid-paste multi-chunk frames with content are not aborted on odd Windows splits.

## Test plan
- [x] `bun test packages/tui/test/bracketed-paste.test.ts` (11 pass)
- [x] New cases: slow multi-chunk stream (>1s total, idle < timeout), 1.1s gap after refresh, idle flush still works
- [x] Manual: paste a long multi-line todo markdown into interactive composer on Windows Terminal; full content should land (marker or expanded)

## Notes
Reproduced as “paste into todo is chewed/truncated” on Windows. Local global install was patched the same way for immediate relief; this PR lands the fix upstream.