### PR TITLE
fix(coding-agent): bound remote MCP responses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Secret obfuscation now uses authenticated process-local placeholders that remain stable within a running process and opaque after restart.
 - Workspace-wide LSP diagnostics now fail closed instead of launching build or typecheck subprocesses outside execution-tool authorization; concrete-file and glob diagnostics remain available.
 - Clean, side-effect-free canonical provider stream first-event and next-event watchdog failures now retry on bare single-model legacy sessions; explicit legacy disable, managed fallback, and fail-closed structured, non-watchdog, or unsafe attempts are unchanged.
+- Remote MCP HTTP and SSE responses now enforce finite content and message budgets before parsing or dispatch.
 - Added fail-closed managed tmux owner SIGABRT recovery: exact-child supervisor receipts and pre-CLI admission now bind replacement ownership, strict durable Ultragoal/transcript evidence reconciles terminal child yields over stale nonterminal runtime state, recovery hydration remains write-free until an ownership fence, and hostile identity, corruption, concurrency, and path boundaries preserve dirty product files (#2681).
 - Restored non-root startup on Synology and other Linux container filesystems that definitively report POSIX ACL storage unsupported for managed session paths; explicit `--session-dir` semantics and all owner, mode, type, symlink, identity, and scope-binding checks remain unchanged and fail closed (#2687).
 - Preserved access to legal SQLite table names beginning with `sqlite` but not reserved `sqlite_`.

--- a/packages/coding-agent/src/runtime-mcp/content-limits.ts
+++ b/packages/coding-agent/src/runtime-mcp/content-limits.ts
@@ -1,0 +1,71 @@
+export const MCP_MAX_CONTENT_BYTES = 16 * 1024 * 1024;
+export const MCP_MAX_ERROR_BYTES = 16 * 1024;
+export const MCP_MAX_SSE_REQUEST_MESSAGES = 1024;
+export const MCP_MAX_SSE_BATCH_MESSAGES = 1024;
+export const MCP_HTTP_TIMEOUT_MS = 30_000;
+
+function ignoreCancellation(cancel: () => Promise<unknown>): void {
+	try {
+		void cancel().catch(() => {});
+	} catch {}
+}
+
+export function cancelMCPStream(stream: ReadableStream<Uint8Array> | null): void {
+	if (stream) ignoreCancellation(() => stream.cancel());
+}
+
+type ByteReader = Pick<ReadableStreamDefaultReader<Uint8Array>, "read">;
+
+async function readChunk(reader: ByteReader, signal?: AbortSignal) {
+	if (!signal) return reader.read();
+	signal.throwIfAborted();
+	const aborted = Promise.withResolvers<never>();
+	const onAbort = () => aborted.reject(signal.reason);
+	signal.addEventListener("abort", onAbort, { once: true });
+	try {
+		return await Promise.race([reader.read(), aborted.promise]);
+	} finally {
+		signal.removeEventListener("abort", onAbort);
+	}
+}
+
+export async function readMCPResponseText(response: Response, limit: number, truncate = false, signal?: AbortSignal) {
+	const declared = response.headers.get("Content-Length");
+	if (!truncate && declared && /^\d+$/.test(declared) && Number(declared) > limit) {
+		cancelMCPStream(response.body);
+		throw new Error("MCP response exceeds size limit");
+	}
+	if (!response.body) return "";
+	const reader = response.body.getReader();
+	let buffer = new Uint8Array(Math.min(limit, 64 * 1024));
+	let total = 0;
+	try {
+		while (true) {
+			const { value, done } = await readChunk(reader, signal);
+			if (done) break;
+			if (value.length === 0) continue;
+			const remaining = limit - total;
+			if (value.length > remaining) {
+				if (truncate && remaining > 0) buffer.set(value.subarray(0, remaining), total);
+				ignoreCancellation(() => reader.cancel());
+				if (!truncate) throw new Error("MCP response exceeds size limit");
+				return `${new TextDecoder().decode(buffer)}\u2026`;
+			}
+			if (total + value.length > buffer.length) {
+				const grown = new Uint8Array(Math.min(limit, Math.max(total + value.length, buffer.length * 2)));
+				grown.set(buffer);
+				buffer = grown;
+			}
+			buffer.set(value, total);
+			total += value.length;
+		}
+		return new TextDecoder().decode(buffer.subarray(0, total));
+	} catch (error) {
+		ignoreCancellation(() => reader.cancel());
+		throw error;
+	} finally {
+		try {
+			reader.releaseLock();
+		} catch {}
+	}
+}

--- a/packages/coding-agent/src/runtime-mcp/json-rpc.ts
+++ b/packages/coding-agent/src/runtime-mcp/json-rpc.ts
@@ -4,8 +4,9 @@
  * Lightweight utilities for calling MCP servers directly via HTTP
  * without maintaining persistent connections.
  */
-import { logger } from "@gajae-code/utils";
+// biome-ignore assist/source/organizeImports: Keep independent MCP security imports on separate merge anchors.
 import { cancelMCPStream, MCP_HTTP_TIMEOUT_MS, MCP_MAX_CONTENT_BYTES, readMCPResponseText } from "./content-limits";
+import { logger } from "@gajae-code/utils";
 
 /** Parse SSE response format (lines starting with "data: ") */
 export function parseSSE(text: string): unknown {
@@ -23,6 +24,15 @@ export function parseSSE(text: string): unknown {
 		return JSON.parse(text);
 	} catch {
 		return null;
+	}
+}
+
+async function translateMCPTimeout<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+	try {
+		return await operation;
+	} catch (error) {
+		if (signal.aborted && error === signal.reason) throw new Error("MCP request timed out");
+		throw error;
 	}
 }
 
@@ -58,38 +68,31 @@ export async function callMCP<T = unknown>(
 		params: params ?? {},
 	};
 
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), MCP_HTTP_TIMEOUT_MS);
-	let response: Response;
-	try {
-		response = await fetch(url, {
+	const signal = AbortSignal.timeout(MCP_HTTP_TIMEOUT_MS);
+	const response = await translateMCPTimeout(
+		fetch(url, {
 			method: "POST",
 			headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
 			body: JSON.stringify(body),
-			signal: controller.signal,
-		});
+			signal,
+		}),
+		signal,
+	);
 
-		if (!response.ok) {
-			const errorMsg = `MCP request failed: ${response.status} ${response.statusText}`;
-			logger.error(errorMsg, { url, method, params });
-			cancelMCPStream(response.body);
-			throw new Error(errorMsg);
-		}
-
-		const result = parseSSE(
-			await readMCPResponseText(response, MCP_MAX_CONTENT_BYTES, false, controller.signal),
-		) as JsonRpcResponse<T> | null;
-
-		if (!result) {
-			logger.error("Failed to parse MCP response", { url, method });
-			throw new Error("Failed to parse MCP response");
-		}
-
-		return result;
-	} catch (error) {
-		if (error instanceof Error && error.name === "AbortError") throw new Error("MCP request timed out");
-		throw error;
-	} finally {
-		clearTimeout(timeout);
+	if (!response.ok) {
+		cancelMCPStream(response.body);
+		const errorMsg = `MCP request failed: ${response.status} ${response.statusText}`;
+		logger.error(errorMsg, { url, method, params });
+		throw new Error(errorMsg);
 	}
+
+	const text = await translateMCPTimeout(readMCPResponseText(response, MCP_MAX_CONTENT_BYTES, false, signal), signal);
+	const result = parseSSE(text) as JsonRpcResponse<T> | null;
+
+	if (!result) {
+		logger.error("Failed to parse MCP response", { url, method, responseText: text.slice(0, 500) });
+		throw new Error("Failed to parse MCP response");
+	}
+
+	return result;
 }

--- a/packages/coding-agent/src/runtime-mcp/json-rpc.ts
+++ b/packages/coding-agent/src/runtime-mcp/json-rpc.ts
@@ -5,6 +5,7 @@
  * without maintaining persistent connections.
  */
 import { logger } from "@gajae-code/utils";
+import { cancelMCPStream, MCP_HTTP_TIMEOUT_MS, MCP_MAX_CONTENT_BYTES, readMCPResponseText } from "./content-limits";
 
 /** Parse SSE response format (lines starting with "data: ") */
 export function parseSSE(text: string): unknown {
@@ -57,28 +58,38 @@ export async function callMCP<T = unknown>(
 		params: params ?? {},
 	};
 
-	const response = await fetch(url, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Accept: "application/json, text/event-stream",
-		},
-		body: JSON.stringify(body),
-	});
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), MCP_HTTP_TIMEOUT_MS);
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+			body: JSON.stringify(body),
+			signal: controller.signal,
+		});
 
-	if (!response.ok) {
-		const errorMsg = `MCP request failed: ${response.status} ${response.statusText}`;
-		logger.error(errorMsg, { url, method, params });
-		throw new Error(errorMsg);
+		if (!response.ok) {
+			const errorMsg = `MCP request failed: ${response.status} ${response.statusText}`;
+			logger.error(errorMsg, { url, method, params });
+			cancelMCPStream(response.body);
+			throw new Error(errorMsg);
+		}
+
+		const result = parseSSE(
+			await readMCPResponseText(response, MCP_MAX_CONTENT_BYTES, false, controller.signal),
+		) as JsonRpcResponse<T> | null;
+
+		if (!result) {
+			logger.error("Failed to parse MCP response", { url, method });
+			throw new Error("Failed to parse MCP response");
+		}
+
+		return result;
+	} catch (error) {
+		if (error instanceof Error && error.name === "AbortError") throw new Error("MCP request timed out");
+		throw error;
+	} finally {
+		clearTimeout(timeout);
 	}
-
-	const text = await response.text();
-	const result = parseSSE(text) as JsonRpcResponse<T> | null;
-
-	if (!result) {
-		logger.error("Failed to parse MCP response", { url, method, responseText: text.slice(0, 500) });
-		throw new Error("Failed to parse MCP response");
-	}
-
-	return result;
 }

--- a/packages/coding-agent/src/runtime-mcp/transports/http.ts
+++ b/packages/coding-agent/src/runtime-mcp/transports/http.ts
@@ -16,6 +16,14 @@ import type {
 	MCPTransport,
 } from "../../runtime-mcp/types";
 import { MCPExpectedFailure, toJsonRpcError } from "../../runtime-mcp/types";
+import {
+	cancelMCPStream,
+	MCP_MAX_CONTENT_BYTES,
+	MCP_MAX_ERROR_BYTES,
+	MCP_MAX_SSE_BATCH_MESSAGES,
+	MCP_MAX_SSE_REQUEST_MESSAGES,
+	readMCPResponseText,
+} from "../content-limits";
 
 /**
  * HTTP transport for MCP servers.
@@ -73,6 +81,9 @@ export class HttpTransport implements MCPTransport {
 		if (this.#sseConnection) return;
 
 		const sseConnection = new AbortController();
+		const headerController = new AbortController();
+		const headerTimeout = this.config.timeout ?? 30000;
+		const headerTimeoutId = setTimeout(() => headerController.abort(), headerTimeout);
 		this.#sseConnection = sseConnection;
 		const headers: Record<string, string> = {
 			Accept: "text/event-stream",
@@ -88,18 +99,22 @@ export class HttpTransport implements MCPTransport {
 			response = await fetch(this.config.url, {
 				method: "GET",
 				headers,
-				signal: sseConnection.signal,
+				signal: AbortSignal.any([sseConnection.signal, headerController.signal]),
 			});
 		} catch (error) {
 			this.#sseConnection = this.#sseConnection === sseConnection ? null : this.#sseConnection;
-			if (error instanceof Error && error.name !== "AbortError") {
+			if (headerController.signal.aborted && !sseConnection.signal.aborted) {
+				this.onError?.(new Error(`SSE connection timeout after ${headerTimeout}ms`));
+			} else if (error instanceof Error && error.name !== "AbortError") {
 				this.onError?.(error);
 			}
 			return;
+		} finally {
+			clearTimeout(headerTimeoutId);
 		}
 
 		if (response.status === 405 || !response.ok || !response.body) {
-			await response.body?.cancel().catch(() => {});
+			cancelMCPStream(response.body);
 			this.#sseConnection = this.#sseConnection === sseConnection ? null : this.#sseConnection;
 			return;
 		}
@@ -117,8 +132,13 @@ export class HttpTransport implements MCPTransport {
 	}
 	async #readSSEStream(body: ReadableStream<Uint8Array>, signal: AbortSignal): Promise<void> {
 		try {
-			for await (const message of readSseJson<JsonRpcMessage>(body, signal)) {
+			for await (const message of readSseJson<JsonRpcMessage>(body, signal, undefined, {
+				maxEventBytes: MCP_MAX_CONTENT_BYTES,
+			})) {
 				if (!this.#connected) break;
+				if (Array.isArray(message) && message.length > MCP_MAX_SSE_BATCH_MESSAGES) {
+					throw new Error("MCP SSE batch exceeds message limit");
+				}
 				this.#dispatchSSEMessage(message);
 			}
 		} catch (error) {
@@ -221,7 +241,7 @@ export class HttpTransport implements MCPTransport {
 			}
 
 			if (!response.ok) {
-				const text = await response.text();
+				const text = await readMCPResponseText(response, MCP_MAX_ERROR_BYTES, true, operationSignal);
 				const wwwAuthenticate = response.headers.get("WWW-Authenticate");
 				const mcpAuthServer = response.headers.get("Mcp-Auth-Server");
 				const authHints = [
@@ -245,7 +265,9 @@ export class HttpTransport implements MCPTransport {
 			if (!response.body) {
 				throw new MCPExpectedFailure();
 			}
-			const parsedResult = await response.json();
+			const parsedResult = JSON.parse(
+				await readMCPResponseText(response, MCP_MAX_CONTENT_BYTES, false, operationSignal),
+			) as unknown;
 
 			if (
 				typeof parsedResult !== "object" ||
@@ -293,6 +315,7 @@ export class HttpTransport implements MCPTransport {
 
 		const { promise, resolve, reject } = Promise.withResolvers<T>();
 		let captured = false;
+		let messageCount = 0;
 
 		// Drain this per-request SSE response from a single iterator. Once the
 		// matching response arrives, resolve/reject and abort the reader so the
@@ -304,8 +327,20 @@ export class HttpTransport implements MCPTransport {
 		this.#streamControllers.add(drainController);
 		const drain = async (): Promise<void> => {
 			try {
-				for await (const raw of readSseJson<JsonRpcMessage | JsonRpcMessage[]>(response.body!, operationSignal)) {
+				for await (const raw of readSseJson<JsonRpcMessage | JsonRpcMessage[]>(
+					response.body!,
+					operationSignal,
+					undefined,
+					{
+						maxEventBytes: MCP_MAX_CONTENT_BYTES,
+						maxTotalBytes: MCP_MAX_CONTENT_BYTES,
+					},
+				)) {
 					const messages = Array.isArray(raw) ? raw : [raw];
+					if (messages.length > MCP_MAX_SSE_BATCH_MESSAGES) throw new Error("MCP SSE batch exceeds message limit");
+					messageCount += messages.length;
+					if (messageCount > MCP_MAX_SSE_REQUEST_MESSAGES)
+						throw new Error("MCP SSE response exceeds message limit");
 					for (const message of messages) {
 						if (
 							!captured &&
@@ -352,7 +387,7 @@ export class HttpTransport implements MCPTransport {
 			} finally {
 				clearTimeout(timeoutId);
 				this.#streamControllers.delete(drainController);
-				await response.body?.cancel().catch(() => {});
+				cancelMCPStream(response.body);
 			}
 		};
 
@@ -396,7 +431,7 @@ export class HttpTransport implements MCPTransport {
 			});
 			// Retry once on auth failure if onAuthError is wired
 			if (this.onAuthError && (resp.status === 401 || resp.status === 403)) {
-				await resp.body?.cancel();
+				cancelMCPStream(resp.body);
 				const newHeaders = await this.onAuthError();
 				if (newHeaders) {
 					this.config.headers ??= {};
@@ -408,11 +443,11 @@ export class HttpTransport implements MCPTransport {
 						body: JSON.stringify(body),
 						signal: AbortSignal.timeout(this.config.timeout ?? 30000),
 					});
-					await retry.body?.cancel();
+					cancelMCPStream(retry.body);
 					return;
 				}
 			}
-			await resp.body?.cancel();
+			cancelMCPStream(resp.body);
 		} catch {
 			// Best-effort response delivery — server may have disconnected
 		}
@@ -452,11 +487,9 @@ export class HttpTransport implements MCPTransport {
 				signal: abortController.signal,
 			});
 
-			clearTimeout(timeoutId);
-
 			// 202 Accepted is success for notifications
 			if (!response.ok && response.status !== 202) {
-				const text = await response.text();
+				const text = await readMCPResponseText(response, MCP_MAX_ERROR_BYTES, true, abortController.signal);
 				throw new Error(`HTTP ${response.status}: ${text}`);
 			}
 
@@ -472,14 +505,15 @@ export class HttpTransport implements MCPTransport {
 				const reader = this.#readSSEStream(response.body, AbortSignal.any(signals));
 				this.#trackReader(reader, streamController);
 			} else {
-				await response.body?.cancel();
+				cancelMCPStream(response.body);
 			}
 		} catch (error) {
-			clearTimeout(timeoutId);
 			if (error instanceof Error && error.name === "AbortError") {
 				throw new MCPExpectedFailure(new Error(`Notify timeout after ${timeout}ms`));
 			}
 			throw error instanceof MCPExpectedFailure ? error : new MCPExpectedFailure(error);
+		} finally {
+			clearTimeout(timeoutId);
 		}
 	}
 

--- a/packages/coding-agent/test/runtime-mcp/remote-content-limits.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/remote-content-limits.test.ts
@@ -197,4 +197,51 @@ describe("MCP remote content limits", () => {
 		);
 		expect(cancelled).toBe(1);
 	});
+
+	test("legacy callMCP keeps one deadline across headers and body reads", async () => {
+		const headerTimeout = new AbortController();
+		const bodyTimeout = new AbortController();
+		const bodyStarted = Promise.withResolvers<void>();
+		vi.spyOn(AbortSignal, "timeout")
+			.mockReturnValueOnce(headerTimeout.signal)
+			.mockReturnValueOnce(bodyTimeout.signal);
+		vi.spyOn(globalThis, "fetch")
+			.mockImplementationOnce(
+				fetchImplementation(async (_url, init) => {
+					const { promise, reject } = Promise.withResolvers<Response>();
+					init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+					return promise;
+				}),
+			)
+			.mockImplementationOnce(
+				fetchImplementation(
+					async (_url, _init) =>
+						new Response(
+							new ReadableStream({
+								start() {
+									bodyStarted.resolve();
+								},
+							}),
+						),
+				),
+			);
+
+		const pendingHeaders = callMCP("https://example.invalid", "tools/list");
+		headerTimeout.abort(new DOMException("The operation timed out", "TimeoutError"));
+		await expect(pendingHeaders).rejects.toThrow("MCP request timed out");
+
+		const pendingBody = callMCP("https://example.invalid", "tools/list");
+		await bodyStarted.promise;
+		bodyTimeout.abort(new DOMException("The operation timed out", "TimeoutError"));
+		await expect(pendingBody).rejects.toThrow("MCP request timed out");
+	});
+
+	test("legacy callMCP preserves errors unrelated to an expired deadline", async () => {
+		const timeout = new AbortController();
+		timeout.abort(new DOMException("The operation timed out", "TimeoutError"));
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network failed before timeout"));
+
+		await expect(callMCP("https://example.invalid", "tools/list")).rejects.toThrow("network failed before timeout");
+	});
 });

--- a/packages/coding-agent/test/runtime-mcp/remote-content-limits.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/remote-content-limits.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import {
+	cancelMCPStream,
+	MCP_MAX_CONTENT_BYTES,
+	MCP_MAX_SSE_BATCH_MESSAGES,
+	MCP_MAX_SSE_REQUEST_MESSAGES,
+	readMCPResponseText,
+} from "../../src/runtime-mcp/content-limits";
+import { callMCP } from "../../src/runtime-mcp/json-rpc";
+import { HttpTransport } from "../../src/runtime-mcp/transports/http";
+
+const transports: HttpTransport[] = [];
+
+function fetchImplementation(implementation: (...args: Parameters<typeof fetch>) => Promise<Response>): typeof fetch {
+	return Object.assign(implementation, { preconnect() {} });
+}
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(transports.splice(0).map(transport => transport.close()));
+});
+
+function responseStream(chunks: Uint8Array[], onCancel?: () => void, keepOpen = false): ReadableStream<Uint8Array> {
+	let index = 0;
+	return new ReadableStream({
+		pull(controller) {
+			const chunk = chunks[index++];
+			if (chunk) controller.enqueue(chunk);
+			else if (!keepOpen) controller.close();
+		},
+		cancel: onCancel,
+	});
+}
+
+const throwCleanup = () => {
+	throw new Error("cleanup");
+};
+
+async function createTransport(timeout = 30_000): Promise<HttpTransport> {
+	const transport = new HttpTransport({ type: "http", url: "https://example.invalid", timeout });
+	transports.push(transport);
+	await transport.connect();
+	return transport;
+}
+
+describe("MCP remote content limits", () => {
+	test("bounded reader handles exact limits, tiny chunks, and hostile cancellation", async () => {
+		const body = new TextEncoder().encode('{"ok":true}');
+		const tiny = Array.from(body, byte => Uint8Array.of(byte));
+		await expect(readMCPResponseText(new Response(responseStream(tiny)), body.length)).resolves.toBe('{"ok":true}');
+		let cancelled = 0;
+		const oversized = new ReadableStream<Uint8Array>({ cancel: () => void cancelled++ });
+		await expect(
+			readMCPResponseText(
+				new Response(oversized, { headers: { "Content-Length": String(body.length + 1) } }),
+				body.length,
+			),
+		).rejects.toThrow("MCP response exceeds size limit");
+		expect(cancelled).toBe(1);
+		cancelMCPStream(new ReadableStream({ cancel: () => Promise.reject(new Error("async")) }));
+		cancelMCPStream(new ReadableStream({ cancel: () => Promise.withResolvers<void>().promise }));
+		const controller = new AbortController();
+		const pending = readMCPResponseText(
+			new Response(new ReadableStream({ cancel: throwCleanup })),
+			1,
+			false,
+			controller.signal,
+		);
+		controller.abort();
+		await expect(pending).rejects.toHaveProperty("name", "AbortError");
+	});
+
+	test("HTTP transport rejects Content-Length and chunked JSON overflow before parsing and cancels", async () => {
+		let cancelled = 0;
+		vi.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(
+				new Response("{}", { headers: { "Content-Length": String(MCP_MAX_CONTENT_BYTES + 1) } }),
+			)
+			.mockResolvedValueOnce(
+				new Response(
+					responseStream([new Uint8Array(MCP_MAX_CONTENT_BYTES), Uint8Array.of(1)], () => cancelled++, true),
+				),
+			);
+		const transport = await createTransport();
+		await expect(transport.request("resources/read")).rejects.toThrow("MCP response exceeds size limit");
+		await expect(transport.request("resources/read")).rejects.toThrow("MCP response exceeds size limit");
+		expect(cancelled).toBe(1);
+	});
+
+	test("per-request SSE rejects oversized batches and message floods", async () => {
+		const batch = Array.from({ length: MCP_MAX_SSE_BATCH_MESSAGES + 1 }, () => ({ jsonrpc: "2.0", method: "ping" }));
+		const events = Array.from(
+			{ length: MCP_MAX_SSE_REQUEST_MESSAGES + 1 },
+			() => 'data: {"jsonrpc":"2.0","method":"ping"}\n\n',
+		).join("");
+		vi.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(
+				new Response(`data: ${JSON.stringify(batch)}\n\n`, { headers: { "Content-Type": "text/event-stream" } }),
+			)
+			.mockResolvedValueOnce(new Response(events, { headers: { "Content-Type": "text/event-stream" } }));
+		const transport = await createTransport(1_000);
+		await expect(transport.request("tools/list")).rejects.toThrow("MCP SSE batch exceeds message limit");
+		await expect(transport.request("tools/list")).rejects.toThrow("MCP SSE response exceeds message limit");
+	});
+
+	test("background SSE reports a payload-free size error", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(new Uint8Array(MCP_MAX_CONTENT_BYTES + 1), { headers: { "Content-Type": "text/event-stream" } }),
+		);
+		const transport = await createTransport();
+		const error = Promise.withResolvers<Error>();
+		transport.onError = error.resolve;
+		await transport.startSSEListener();
+		expect((await error.promise).message).toBe("SSE event exceeds size limit");
+	});
+
+	test("persistent SSE times out headers without expiring an established body", async () => {
+		let attempt = 0;
+		vi.spyOn(globalThis, "fetch").mockImplementation(
+			fetchImplementation(async (_url, init) => {
+				if (attempt++ === 0) {
+					const { promise, reject } = Promise.withResolvers<Response>();
+					init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+					return promise;
+				}
+				return new Response(
+					new ReadableStream({
+						async start(controller) {
+							await Bun.sleep(50);
+							if (init?.signal?.aborted) return controller.error(init.signal.reason);
+							controller.enqueue(new TextEncoder().encode('data: {"jsonrpc":"2.0","method":"late"}\n\n'));
+							controller.close();
+						},
+					}),
+					{ headers: { "Content-Type": "text/event-stream" } },
+				);
+			}),
+		);
+		const transport = await createTransport(25);
+		const error = Promise.withResolvers<Error>();
+		transport.onError = error.resolve;
+		await transport.startSSEListener();
+		expect((await error.promise).message).toBe("SSE connection timeout after 25ms");
+		const notification = Promise.withResolvers<string>();
+		transport.onNotification = method => notification.resolve(method);
+		await transport.startSSEListener();
+		await expect(notification.promise).resolves.toBe("late");
+	});
+
+	test("bounded HTTP errors still trigger 401 refresh and truncate other error bodies", async () => {
+		vi.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(new Response("denied", { status: 401 }))
+			.mockImplementationOnce(
+				fetchImplementation(async (_url, init) => {
+					const request = JSON.parse(String(init?.body)) as { id: string | number };
+					return Response.json({ jsonrpc: "2.0", id: request.id, result: { ok: true } });
+				}),
+			)
+			.mockResolvedValueOnce(new Response("x".repeat(20_000), { status: 500 }));
+		const transport = await createTransport();
+		transport.onAuthError = async () => ({ Authorization: "Bearer refreshed" });
+		await expect(transport.request("tools/list")).resolves.toEqual({ ok: true });
+		await expect(transport.request("tools/list")).rejects.toThrow(/^HTTP 500: x+\u2026$/);
+	});
+
+	test("notify keeps its deadline while reading a stalled error body", async () => {
+		vi.spyOn(globalThis, "fetch").mockImplementation(
+			fetchImplementation(
+				async (_url, init) =>
+					new Response(
+						new ReadableStream({
+							start: controller =>
+								init?.signal?.addEventListener("abort", () => controller.error(init.signal?.reason)),
+						}),
+						{ status: 500 },
+					),
+			),
+		);
+		const transport = await createTransport(25);
+		await expect(transport.notify("notifications/initialized")).rejects.toThrow("Notify timeout after 25ms");
+	});
+
+	test("legacy callMCP accepts JSON and SSE but rejects oversized bodies and cancels", async () => {
+		let cancelled = 0;
+		vi.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(Response.json({ jsonrpc: "2.0", id: 1, result: { ok: true } }))
+			.mockResolvedValueOnce(new Response('data: {"jsonrpc":"2.0","id":1,"result":{"sse":true}}\n\n'))
+			.mockResolvedValueOnce(
+				new Response(
+					responseStream([new Uint8Array(MCP_MAX_CONTENT_BYTES), Uint8Array.of(1)], () => cancelled++, true),
+				),
+			);
+		await expect(callMCP("https://example.invalid", "tools/list")).resolves.toMatchObject({ result: { ok: true } });
+		await expect(callMCP("https://example.invalid", "tools/list")).resolves.toMatchObject({ result: { sse: true } });
+		await expect(callMCP("https://example.invalid", "resources/read")).rejects.toThrow(
+			"MCP response exceeds size limit",
+		);
+		expect(cancelled).toBe(1);
+	});
+});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- SSE readers now accept optional per-event and cumulative UTF-8 byte budgets without changing existing defaults.
 
 ## [0.11.2] - 2026-07-19
 

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -125,16 +125,22 @@ class ConcatSink {
 		this.#length = 0;
 	}
 
-	*appendAndFlushLines(chunk: Uint8Array) {
+	*appendAndFlushLines(chunk: Uint8Array, maxLineBytes?: () => number) {
 		let pos = 0;
 		while (pos < chunk.length) {
 			const nl = chunk.indexOf(LF, pos);
 			if (nl === -1) {
+				if (maxLineBytes && this.#length + chunk.length - pos > maxLineBytes()) {
+					throw new Error("SSE event exceeds size limit");
+				}
 				this.append(chunk.subarray(pos));
 				return;
 			}
 			const suffix = chunk.subarray(pos, nl);
 			pos = nl + 1;
+			if (maxLineBytes && this.#length + suffix.length + 1 > maxLineBytes()) {
+				throw new Error("SSE event exceeds size limit");
+			}
 			if (this.isEmpty) {
 				yield suffix;
 			} else {
@@ -201,6 +207,11 @@ class ConcatSink {
  */
 export type SseEventObserver = (event: ServerSentEvent) => void;
 
+export interface SseReadOptions {
+	maxEventBytes?: number;
+	maxTotalBytes?: number;
+}
+
 function notifySseEventObserver(observer: SseEventObserver | undefined, event: ServerSentEvent): void {
 	if (!observer) return;
 	try {
@@ -214,8 +225,9 @@ export async function* readSseJson<T>(
 	stream: ReadableStream<Uint8Array>,
 	signal?: AbortSignal,
 	onEvent?: SseEventObserver,
+	options?: SseReadOptions,
 ): AsyncGenerator<T> {
-	for await (const sse of readSseEvents(stream, signal)) {
+	for await (const sse of readSseEvents(stream, signal, options)) {
 		notifySseEventObserver(onEvent, sse);
 		const data = sse.data;
 		if (data === "" || data === "[DONE]") {
@@ -336,14 +348,26 @@ function pushSseLine(line: Uint8Array, state: SseEventState): ServerSentEvent | 
 export async function* readSseEvents(
 	stream: ReadableStream<Uint8Array>,
 	signal?: AbortSignal,
+	options?: SseReadOptions,
 ): AsyncGenerator<ServerSentEvent> {
 	const lineBuffer = new ConcatSink();
 	const state: SseEventState = { event: null, data: null, raw: [] };
 	const source = createAbortableStream(stream, signal);
+	let eventBytes = 0;
+	let totalBytes = 0;
 	try {
 		for await (const chunk of source) {
-			for (const line of lineBuffer.appendAndFlushLines(chunk)) {
+			totalBytes += chunk.length;
+			if (options?.maxTotalBytes !== undefined && totalBytes > options.maxTotalBytes) {
+				throw new Error("SSE stream exceeds size limit");
+			}
+			for (const line of lineBuffer.appendAndFlushLines(
+				chunk,
+				() => (options?.maxEventBytes ?? Infinity) - eventBytes,
+			)) {
+				eventBytes += line.length + 1;
 				const event = pushSseLine(line, state);
+				if (line.length === 0 || (line.length === 1 && line[0] === 0x0d)) eventBytes = 0;
 				if (event) yield event;
 			}
 		}

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -195,6 +195,31 @@ function bytesStreamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array>
 }
 
 describe("readSseEvents", () => {
+	it("applies optional UTF-8 event and stream byte budgets without changing defaults", async () => {
+		const payload = encoder.encode("data: \ud55c\n\n");
+		await expect(
+			collectAsync(readSseEvents(bytesStreamFromChunks([payload]), undefined, { maxEventBytes: payload.length })),
+		).resolves.toHaveLength(1);
+		await expect(
+			collectAsync(
+				readSseEvents(bytesStreamFromChunks([payload]), undefined, { maxEventBytes: payload.length - 1 }),
+			),
+		).rejects.toThrow("SSE event exceeds size limit");
+		await expect(
+			collectAsync(
+				readSseEvents(bytesStreamFromChunks([payload]), undefined, { maxTotalBytes: payload.length - 1 }),
+			),
+		).rejects.toThrow("SSE stream exceeds size limit");
+		await expect(collectAsync(readSseEvents(bytesStreamFromChunks([payload])))).resolves.toHaveLength(1);
+	});
+
+	it("rejects an oversized event before buffering split and multi-line data", async () => {
+		const chunks = [encoder.encode("data: 12\ndata:"), encoder.encode(" 3456\n\n")];
+		await expect(
+			collectAsync(readSseEvents(bytesStreamFromChunks(chunks), undefined, { maxEventBytes: 20 })),
+		).rejects.toThrow("SSE event exceeds size limit");
+	});
+
 	it("dispatches events on blank-line boundaries", async () => {
 		const stream = bytesStreamFromChunks([
 			encoder.encode('event: message_start\ndata: {"id":1}\n\n'),
@@ -221,8 +246,8 @@ describe("readSseEvents", () => {
 	});
 
 	it("does not carry pure comment keepalives into the next event raw lines", async () => {
-		const stream = bytesStreamFromChunks([encoder.encode(": keepalive\n\nevent: ping\ndata: ok\n\n")]);
-		const [evt] = await collectAsync(readSseEvents(stream));
+		const stream = bytesStreamFromChunks([encoder.encode(": 1\r\n\r\n: 2\r\n\r\nevent: ping\r\ndata: ok\r\n\r\n")]);
+		const [evt] = await collectAsync(readSseEvents(stream, undefined, { maxEventBytes: 25 }));
 		expect(evt.raw).toEqual(["event: ping", "data: ok"]);
 	});
 


### PR DESCRIPTION
## Summary

- Bound remote MCP HTTP bodies before buffering or parsing.
- Added opt-in SSE event, response, and message budgets without changing non-MCP defaults.
- Kept established SSE listeners alive after the header deadline and made cleanup nonblocking.

## Scope

- Network HTTP MCP only.
- `resources/read` is protected by the generic transport budget.
- Per-resource semantic limits and stdio are out of scope.

## Validation

- 86 runtime-MCP and stream tests.
- Coding-agent and utils type checks.
- Focused Biome checks.
- Independent code review: APPROVE.
- Architecture review: CLEAR.
- Verification: PASS.
- Exact scope: 8 files, 450 total changed lines, 218 production changed lines.
