### PR TITLE
fix(computer): keypress arrays survive union validation; modifiers, F-keys, chars, and chords in the key map

### DIFF
--- a/crates/pi-natives/src/computer/input.rs
+++ b/crates/pi-natives/src/computer/input.rs
@@ -88,7 +88,8 @@ impl std::error::Error for InputError {}
 /// Returns `None` for unrecognized names.
 #[must_use]
 pub fn key_code_for(name: &str) -> Option<u16> {
-	let code = match name.to_ascii_lowercase().as_str() {
+	let lowered = name.to_ascii_lowercase();
+	let code = match lowered.as_str() {
 		"return" | "enter" => 36,
 		"tab" => 48,
 		"space" => 49,
@@ -98,9 +99,130 @@ pub fn key_code_for(name: &str) -> Option<u16> {
 		"right" | "arrowright" => 124,
 		"down" | "arrowdown" => 125,
 		"up" | "arrowup" => 126,
+		// Modifiers (left-side codes; combos are expressed as "cmd+q").
+		"cmd" | "command" | "meta" | "super" => 55,
+		"shift" => 56,
+		"capslock" => 57,
+		"option" | "alt" => 58,
+		"ctrl" | "control" => 59,
+		"fn" | "function" => 63,
+		// Navigation cluster.
+		"home" => 115,
+		"end" => 119,
+		"pageup" => 116,
+		"pagedown" => 121,
+		"forwarddelete" => 117,
+		"help" | "insert" => 114,
+		// Function keys.
+		"f1" => 122,
+		"f2" => 120,
+		"f3" => 99,
+		"f4" => 118,
+		"f5" => 96,
+		"f6" => 97,
+		"f7" => 98,
+		"f8" => 100,
+		"f9" => 101,
+		"f10" => 109,
+		"f11" => 103,
+		"f12" => 111,
+		"f13" => 105,
+		"f14" => 107,
+		"f15" => 113,
+		"f16" => 106,
+		"f17" => 64,
+		"f18" => 79,
+		"f19" => 80,
+		"f20" => 90,
+		_ => return single_char_key_code(&lowered),
+	};
+	Some(code)
+}
+
+/// ANSI-layout virtual key code for a single printable character.
+#[must_use]
+fn single_char_key_code(name: &str) -> Option<u16> {
+	let mut chars = name.chars();
+	let ch = chars.next()?;
+	if chars.next().is_some() {
+		return None;
+	}
+	let code = match ch {
+		'a' => 0,
+		's' => 1,
+		'd' => 2,
+		'f' => 3,
+		'h' => 4,
+		'g' => 5,
+		'z' => 6,
+		'x' => 7,
+		'c' => 8,
+		'v' => 9,
+		'b' => 11,
+		'q' => 12,
+		'w' => 13,
+		'e' => 14,
+		'r' => 15,
+		'y' => 16,
+		't' => 17,
+		'1' => 18,
+		'2' => 19,
+		'3' => 20,
+		'4' => 21,
+		'6' => 22,
+		'5' => 23,
+		'=' => 24,
+		'9' => 25,
+		'7' => 26,
+		'-' => 27,
+		'8' => 28,
+		'0' => 29,
+		']' => 30,
+		'o' => 31,
+		'u' => 32,
+		'[' => 33,
+		'i' => 34,
+		'p' => 35,
+		'l' => 37,
+		'j' => 38,
+		'\'' => 39,
+		'k' => 40,
+		';' => 41,
+		'\\' => 42,
+		',' => 43,
+		'/' => 44,
+		'n' => 45,
+		'm' => 46,
+		'.' => 47,
+		'`' => 50,
 		_ => return None,
 	};
 	Some(code)
+}
+
+/// Resolve one `keys` entry into the chord of key codes it presses together.
+///
+/// A bare name (`"escape"`) is a single-code chord; a `+`-joined name
+/// (`"cmd+shift+q"`) holds every part in order and releases in reverse, which
+/// is how shortcuts like Cmd-Q are expressed.
+///
+/// # Errors
+/// Returns [`InputError::UnknownKey`] carrying the original entry when any
+/// part is unrecognized or the entry is empty.
+pub fn key_chord_for(name: &str) -> Result<Vec<u16>, InputError> {
+	// A literal "+" key (or a chord ending in one, e.g. "shift+=") would split
+	// into an empty part, so resolve exact single-character names first.
+	if let Some(code) = key_code_for(name) {
+		return Ok(vec![code]);
+	}
+	let parts: Vec<&str> = name.split('+').map(str::trim).collect();
+	if parts.len() < 2 || parts.iter().any(|part| part.is_empty()) {
+		return Err(InputError::UnknownKey(name.to_string()));
+	}
+	parts
+		.iter()
+		.map(|part| key_code_for(part).ok_or_else(|| InputError::UnknownKey(name.to_string())))
+		.collect()
 }
 
 /// Orchestrates input actions over an [`EventSink`], tracking held buttons so
@@ -255,16 +377,27 @@ impl<S: EventSink> InputController<S> {
 		self.sink.type_unicode(text);
 	}
 
-	/// Press and release each named key in order.
+	/// Press and release each named entry in order. A `+`-joined entry
+	/// (`"cmd+q"`) is a chord: every part is held down in order and released
+	/// in reverse, so modifier shortcuts work; a bare entry keeps the original
+	/// press/release behavior.
 	///
 	/// # Errors
-	/// Returns [`InputError::UnknownKey`] when a name is unrecognized; keys
-	/// before the failure have already been sent.
+	/// Returns [`InputError::UnknownKey`] when an entry is unrecognized; every
+	/// entry is resolved before anything is sent, so a failing entry emits no
+	/// events at all.
 	pub fn keypress(&mut self, keys: &[String]) -> Result<(), InputError> {
-		for name in keys {
-			let code = key_code_for(name).ok_or_else(|| InputError::UnknownKey(name.clone()))?;
-			self.sink.key(code, true);
-			self.sink.key(code, false);
+		let chords: Vec<Vec<u16>> = keys
+			.iter()
+			.map(|name| key_chord_for(name))
+			.collect::<Result<_, _>>()?;
+		for chord in chords {
+			for code in &chord {
+				self.sink.key(*code, true);
+			}
+			for code in chord.iter().rev() {
+				self.sink.key(*code, false);
+			}
 		}
 		Ok(())
 	}
@@ -494,7 +627,9 @@ mod mac {
 
 #[cfg(test)]
 mod tests {
-	use super::{EventSink, InputController, InputError, MouseButton, SinkOp, key_code_for};
+	use super::{
+		EventSink, InputController, InputError, MouseButton, SinkOp, key_chord_for, key_code_for,
+	};
 	use crate::computer::coords::{LogicalPoint, NormalizedDisplay};
 
 	#[derive(Default)]
@@ -650,6 +785,57 @@ mod tests {
 		assert_eq!(key_code_for("ESC"), Some(53));
 		assert_eq!(key_code_for("up"), Some(126));
 		assert_eq!(key_code_for("nope"), None);
+	}
+
+	#[test]
+	fn key_code_table_covers_modifiers_function_and_character_keys() {
+		assert_eq!(key_code_for("cmd"), Some(55));
+		assert_eq!(key_code_for("Command"), Some(55));
+		assert_eq!(key_code_for("meta"), Some(55));
+		assert_eq!(key_code_for("shift"), Some(56));
+		assert_eq!(key_code_for("option"), Some(58));
+		assert_eq!(key_code_for("alt"), Some(58));
+		assert_eq!(key_code_for("ctrl"), Some(59));
+		assert_eq!(key_code_for("F15"), Some(113));
+		assert_eq!(key_code_for("f1"), Some(122));
+		assert_eq!(key_code_for("home"), Some(115));
+		assert_eq!(key_code_for("pagedown"), Some(121));
+		assert_eq!(key_code_for("q"), Some(12));
+		assert_eq!(key_code_for("A"), Some(0));
+		assert_eq!(key_code_for("0"), Some(29));
+		assert_eq!(key_code_for("/"), Some(44));
+		assert_eq!(key_code_for("qq"), None);
+	}
+
+	#[test]
+	fn keypress_chords_hold_modifiers_and_release_in_reverse() {
+		let mut c = InputController::new(RecordingSink::default());
+		c.keypress(&["cmd+q".to_string()]).unwrap();
+		assert_eq!(c.ops_ref(), &[
+			SinkOp::Key { code: 55, down: true },
+			SinkOp::Key { code: 12, down: true },
+			SinkOp::Key { code: 12, down: false },
+			SinkOp::Key { code: 55, down: false },
+		]);
+	}
+
+	#[test]
+	fn keypress_chord_with_unknown_part_emits_nothing() {
+		let mut c = InputController::new(RecordingSink::default());
+		let err = c
+			.keypress(&["escape".to_string(), "cmd+nope".to_string()])
+			.unwrap_err();
+		assert!(matches!(err, InputError::UnknownKey(name) if name == "cmd+nope"));
+		assert!(c.ops_ref().is_empty());
+	}
+
+	#[test]
+	fn key_chord_rejects_dangling_plus_and_resolves_bare_names() {
+		assert_eq!(key_chord_for("escape").unwrap(), vec![53]);
+		assert_eq!(key_chord_for("cmd+shift+q").unwrap(), vec![55, 56, 12]);
+		assert!(matches!(key_chord_for("cmd+"), Err(InputError::UnknownKey(_))));
+		assert!(matches!(key_chord_for("+q"), Err(InputError::UnknownKey(_))));
+		assert!(matches!(key_chord_for(""), Err(InputError::UnknownKey(_))));
 	}
 
 	// Test-only helpers on the controller.

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -825,8 +825,24 @@ function coerceArgsFromIssues(args: unknown, issues: FlatIssue[]): { value: unkn
 	let owned = false;
 	let nextArgs: unknown = args;
 
+	// Union branches are flattened into one issue pool, so a pointer can be
+	// "unrecognized" for one branch while another branch types it (e.g. a
+	// root union of a keypress variant with `keys: string[]` and a batch
+	// variant without `keys`: a JSON-stringified `keys` array yields a type
+	// issue from the keypress branch AND an unrecognized issue from the batch
+	// branch). Deleting such a pointer destroys the field the matching branch
+	// needs before type coercion can repair it, so pointers that any branch
+	// recognizes as a typed field are exempt from unrecognized-key deletion.
+	const typedPointers = new Set<string>();
+	for (const issue of issues) {
+		if (issue.keyword === "type" && issue.expectedTypes.length > 0) {
+			typedPointers.add(issue.instancePath);
+		}
+	}
+
 	for (const issue of issues) {
 		if (issue.keyword === "unrecognized") {
+			if (typedPointers.has(issue.instancePath)) continue;
 			const previous = nextArgs;
 			nextArgs = deleteValueAtPointer(nextArgs, issue.instancePath);
 			if (nextArgs !== previous) changed = true;

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -992,4 +992,46 @@ describe("Tool argument coercion", () => {
 		).toThrow("raw arguments rejected before coercion");
 		expect(observed).toBe("null");
 	});
+
+	describe("union cross-branch repair", () => {
+		// Root unions flatten every branch's issues into one pool. A field the
+		// matching branch types (keypress `keys: string[]`) must never be
+		// destroyed by another branch's unrecognized-key deletion (batch has no
+		// `keys`). Live regression: the computer tool rejected every top-level
+		// keypress with "root: Invalid input" because the batch branch deleted
+		// `keys` before array coercion could run.
+		const single = z.discriminatedUnion("action", [
+			z.object({ action: z.literal("screenshot") }).strict(),
+			z.object({ action: z.literal("keypress"), keys: z.array(z.string()).min(1) }).strict(),
+		]);
+		const batch = z.object({ action: z.literal("batch"), actions: z.array(single).min(1) }).strict();
+		const computerLike = z.union([single, batch]);
+		const tool: Tool = { name: "computer-like", description: "", parameters: computerLike };
+		const call = (arguments_: unknown): ToolCall => ({
+			type: "toolCall",
+			id: "call-union",
+			name: "computer-like",
+			arguments: arguments_ as ToolCall["arguments"],
+		});
+
+		it("accepts a proper top-level string array", () => {
+			expect(validateToolArguments(tool, call({ action: "keypress", keys: ["Escape"] }))).toEqual({
+				action: "keypress",
+				keys: ["Escape"],
+			});
+		});
+
+		it("coerces a JSON-stringified array without another branch deleting the field", () => {
+			expect(validateToolArguments(tool, call({ action: "keypress", keys: '["Escape"]' }))).toEqual({
+				action: "keypress",
+				keys: ["Escape"],
+			});
+		});
+
+		it("still deletes keys that no branch recognizes as typed fields", () => {
+			expect(validateToolArguments(tool, call({ action: "screenshot", hallucinated: null }))).toEqual({
+				action: "screenshot",
+			});
+		});
+	});
 });

--- a/packages/coding-agent/src/prompts/tools/computer.md
+++ b/packages/coding-agent/src/prompts/tools/computer.md
@@ -27,7 +27,14 @@ The model action object uses exactly these snake_case actions and fields:
 - `drag` — `x`, `y`, `to_x`, `to_y`, optional `button`.
 - `scroll` — `x`, `y`, `scroll_x`, `scroll_y`.
 - `type` — `text`.
-- `keypress` — `keys` string array.
+- `keypress` — `keys` string array. Each entry is pressed and released in
+  order. Key names are case-insensitive: named keys (`Return`/`Enter`, `Tab`,
+  `Space`, `Delete`/`Backspace`, `Escape`, arrows, `Home`, `End`, `PageUp`,
+  `PageDown`, `F1`–`F20`), modifiers (`Cmd`/`Command`/`Meta`, `Shift`,
+  `Option`/`Alt`, `Ctrl`/`Control`, `Fn`), and single characters (`a`–`z`,
+  `0`–`9`, common punctuation). Join names with `+` for a held shortcut chord,
+  e.g. `["cmd+q"]` or `["cmd+shift+s"]` — modifiers stay held until the chord
+  completes and release in reverse order.
 - `wait` — `ms`.
 - `batch` — `actions`: a non-empty array of the single actions above. Steps run in order and the result includes per-step status and the last screenshot captured inside the batch.
 


### PR DESCRIPTION
## What

Two independent defects made the `computer` tool's `keypress` action nearly unusable in live sessions (found while driving a full desktop-app GUI smoke through gjc computer use on macOS arm64, v0.11.3):

### 1. `fix(ai)`: union branches must not delete fields another branch types

`validateToolArguments` flattens every union branch's issues into one coercion pool. The computer schema is `z.union([singleComputerSchema, batchSchema])`, so when a model sends `keys` as a JSON-stringified array (a quirk the coercion pipeline explicitly exists to repair):

- the keypress branch raises a `/keys` **type** issue → repairable by JSON coercion,
- the batch branch raises a `/keys` **unrecognized-key** issue → the deletion repair removes the field first.

Result: every top-level keypress fails with `root: Invalid input` and the diagnostic shows `"normalized": {"action":"keypress"}` — the field is destroyed before coercion can run. Batch-nested keypress works, which is how this shipped unnoticed.

Fix: pointers that **any** branch recognizes as a typed field are exempt from unrecognized-key deletion. Genuinely unknown keys are still dropped (covered by a regression test).

### 2. `feat(natives)`: modifiers, F-keys, characters, and chords for keypress

`key_code_for` knew only 9 named keys, and `keypress` pressed entries strictly sequentially — `cmd`, `Command`, `Meta`, `super`, `F15`, single characters etc. all returned `COMPUTER_UNKNOWN_KEY`, and there was no way to express Cmd-Q at all.

- `key_code_for` now covers modifiers, `F1`–`F20`, the navigation cluster, and single ANSI-layout characters.
- New `key_chord_for`: a `+`-joined entry (`"cmd+shift+q"`) is a chord — parts are held in order and released in reverse, so shortcuts actually fire. Bare names keep the existing press/release behavior byte-for-byte.
- `keypress` resolves every entry before emitting anything, so an unknown entry no longer sends partial input (previously keys before the failure had already been sent).
- The tool prompt documents the key names and chord syntax.

## Verification

- `bun test packages/ai/test/tool-argument-coercion.test.ts` — 42 pass (3 new union cross-branch regression tests).
- `cargo test -p pi-natives computer::input` — 13 pass (4 new: extended map, chord order, all-or-nothing resolution, dangling-`+` rejection).
- `bunx biome check` clean on the touched TS files; `cargo fmt`/clippy clean for the touched ranges.
- Live root-cause transcripts: top-level `{"action":"keypress","keys":["f15"]}` → `root: Invalid input` on v0.11.3 while the identical payload nested in `batch` reached the native layer; `cmd`/`command`/`Command`/`COMMAND`/`Meta`/`super`/`CommandOrControl` each → `COMPUTER_UNKNOWN_KEY`.

## Notes

- The chord release-in-reverse order matches how macOS shortcuts expect modifiers to unwind.
- `keypress` becoming all-or-nothing on unknown entries is a deliberate behavior change (no partial input on invalid calls); flagging it for review.