### PR TITLE
fix(notifications): ignore stale session cwd warnings

### DIFF
--- a/packages/coding-agent/src/sdk/bus/recent-activity.ts
+++ b/packages/coding-agent/src/sdk/bus/recent-activity.ts
@@ -236,7 +236,7 @@ export async function listRecentSessions(deps: RecentActivityDeps): Promise<List
 		candidates.push(...listed.owned);
 		warnings.push(
 			...listed.invalid
-				.filter(invalid => invalid.code !== "invalid_cwd")
+				.filter(invalid => invalid.code !== "cwd_not_found" && invalid.code !== "cwd_not_directory")
 				.map(invalid => `Ignored invalid managed session candidate: ${invalid.code}`),
 		);
 	}

--- a/packages/coding-agent/src/sdk/bus/recent-activity.ts
+++ b/packages/coding-agent/src/sdk/bus/recent-activity.ts
@@ -236,7 +236,10 @@ export async function listRecentSessions(deps: RecentActivityDeps): Promise<List
 		candidates.push(...listed.owned);
 		warnings.push(
 			...listed.invalid
-				.filter(invalid => invalid.code !== "cwd_not_found" && invalid.code !== "cwd_not_directory")
+				.filter(
+					invalid =>
+						!deps.allWorkspaces || (invalid.code !== "cwd_not_found" && invalid.code !== "cwd_not_directory"),
+				)
 				.map(invalid => `Ignored invalid managed session candidate: ${invalid.code}`),
 		);
 	}

--- a/packages/coding-agent/src/sdk/bus/recent-activity.ts
+++ b/packages/coding-agent/src/sdk/bus/recent-activity.ts
@@ -154,10 +154,12 @@ async function resolveRecentScopes(
 			agentDir,
 			sessionsRoot,
 		});
-		if (
-			resolved.kind !== "resolved" ||
-			(expectedDirectory !== undefined && resolved.scope.directoryPath !== expectedDirectory)
-		) {
+		if (resolved.kind !== "resolved") {
+			if (resolved.code !== "cwd_missing" && resolved.code !== "cwd_not_directory")
+				warnings.push("Ignored invalid managed session scope binding.");
+			return;
+		}
+		if (expectedDirectory !== undefined && resolved.scope.directoryPath !== expectedDirectory) {
 			warnings.push("Ignored invalid managed session scope binding.");
 			return;
 		}
@@ -232,7 +234,11 @@ export async function listRecentSessions(deps: RecentActivityDeps): Promise<List
 			return { kind: "error", code: "managed_scan_failed", message: listed.message };
 		}
 		candidates.push(...listed.owned);
-		warnings.push(...listed.invalid.map(invalid => `Ignored invalid managed session candidate: ${invalid.code}`));
+		warnings.push(
+			...listed.invalid
+				.filter(invalid => invalid.code !== "invalid_cwd")
+				.map(invalid => `Ignored invalid managed session candidate: ${invalid.code}`),
+		);
 	}
 
 	const entries: RecentSessionEntry[] = [];

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -400,7 +400,8 @@ function inspectCandidate(filePath: string, provenance: "v2" | "legacy"): Manage
 		const header = value as Record<string, unknown>;
 		if (header.type !== "session" || typeof header.id !== "string" || typeof header.cwd !== "string")
 			return { code: "invalid_header" };
-		if (!identityFor(header.cwd).ok) return { code: "invalid_cwd" };
+		const cwdIdentity = identityFor(header.cwd);
+		if (!cwdIdentity.ok) return { code: `cwd_${cwdIdentity.code}` };
 		const named = fs.lstatSync(filePath, { bigint: true });
 		if (
 			!named.isFile() ||
@@ -551,7 +552,7 @@ export function listManagedCandidates(scope: ManagedScope): ManagedCandidateList
 				}
 				const candidateIdentity = identityFor(candidate.cwd);
 				if (!candidateIdentity.ok) {
-					invalid.push({ code: "invalid_cwd" });
+					invalid.push({ code: `cwd_${candidateIdentity.code}` });
 					continue;
 				}
 				if (

--- a/packages/coding-agent/test/notifications-recent-activity.test.ts
+++ b/packages/coding-agent/test/notifications-recent-activity.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -120,6 +120,31 @@ describe("recent-activity picker", () => {
 		const result = await listRecentSessions({ cwd, sessionsRoot: root, allWorkspaces: true });
 
 		expect(result).toMatchObject({ kind: "complete", entries: [], warnings: [] });
+	});
+
+	it("preserves warnings for non-stale cwd identity failures", async () => {
+		const root = tempRoot();
+		const cwd = path.join(root, "workspace");
+		const brokenCwd = path.join(root, "identity-error");
+		const directory = await managedDirectory(root, cwd);
+		writeSession(directory, "broken-candidate", brokenCwd, {}, 2_000);
+		const canonicalIdentity = native.canonicalExistingDirectoryIdentity;
+		const identity = vi
+			.spyOn(native, "canonicalExistingDirectoryIdentity")
+			.mockImplementation(pathname =>
+				pathname === brokenCwd ? { ok: false, code: "io_error" } : canonicalIdentity(pathname),
+			);
+		try {
+			const result = await listRecentSessions({ cwd, sessionsRoot: root });
+
+			expect(result).toMatchObject({
+				kind: "complete",
+				entries: [],
+				warnings: ["Ignored invalid managed session candidate: cwd_io_error"],
+			});
+		} finally {
+			identity.mockRestore();
+		}
 	});
 
 	it("fails closed for an unsafe all-workspace sessions root", async () => {

--- a/packages/coding-agent/test/notifications-recent-activity.test.ts
+++ b/packages/coding-agent/test/notifications-recent-activity.test.ts
@@ -108,6 +108,20 @@ describe("recent-activity picker", () => {
 		expect(result.entries.map(entry => entry.sessionId)).toEqual(["saved-elsewhere"]);
 	});
 
+	it("silently ignores sessions whose workspace directories were removed", async () => {
+		const root = tempRoot();
+		const cwd = path.join(root, "workspace");
+		const removedCwd = path.join(root, "removed-workspace");
+		const directory = await managedDirectory(root, cwd);
+		await managedDirectory(root, removedCwd);
+		writeSession(directory, "stale-candidate", removedCwd, {}, 2_000);
+		fs.rmSync(removedCwd, { recursive: true });
+
+		const result = await listRecentSessions({ cwd, sessionsRoot: root, allWorkspaces: true });
+
+		expect(result).toMatchObject({ kind: "complete", entries: [], warnings: [] });
+	});
+
 	it("fails closed for an unsafe all-workspace sessions root", async () => {
 		if (process.platform === "win32") return;
 		const root = tempRoot();

--- a/packages/coding-agent/test/notifications-recent-activity.test.ts
+++ b/packages/coding-agent/test/notifications-recent-activity.test.ts
@@ -147,6 +147,37 @@ describe("recent-activity picker", () => {
 		}
 	});
 
+	it("silently ignores workspace bindings replaced by files", async () => {
+		const root = tempRoot();
+		const cwd = path.join(root, "workspace");
+		const removedCwd = path.join(root, "removed-workspace");
+		await managedDirectory(root, cwd);
+		await managedDirectory(root, removedCwd);
+		fs.rmSync(removedCwd, { recursive: true });
+		fs.writeFileSync(removedCwd, "not a directory", { mode: 0o600 });
+
+		const result = await listRecentSessions({ cwd, sessionsRoot: root, allWorkspaces: true });
+
+		expect(result).toMatchObject({ kind: "complete", entries: [], warnings: [] });
+	});
+
+	it("warns about removed workspace candidates during direct scans", async () => {
+		const root = tempRoot();
+		const cwd = path.join(root, "workspace");
+		const removedCwd = path.join(root, "removed-workspace");
+		const directory = await managedDirectory(root, cwd);
+		fs.mkdirSync(removedCwd, { recursive: true, mode: 0o700 });
+		writeSession(directory, "stale-candidate", removedCwd, {}, 2_000);
+		fs.rmSync(removedCwd, { recursive: true });
+
+		const result = await listRecentSessions({ cwd, sessionsRoot: root });
+
+		expect(result).toMatchObject({
+			kind: "complete",
+			entries: [],
+			warnings: ["Ignored invalid managed session candidate: cwd_not_found"],
+		});
+	});
 	it("fails closed for an unsafe all-workspace sessions root", async () => {
 		if (process.platform === "win32") return;
 		const root = tempRoot();


### PR DESCRIPTION
## Summary

- Silently skip managed-session scope bindings whose workspace directory was removed or is no longer a directory.
- Preserve specific cwd identity failure codes for managed-session candidates and suppress only stale-path warnings in `/session_recent`.
- Add regression coverage for removed workspaces and non-stale identity failures.

## Problem

`/session_recent` scans managed sessions across workspaces. When saved sessions reference workspace directories that have since been removed, the response repeatedly includes warnings such as:

```text
Ignored invalid managed session scope binding.
Ignored invalid managed session candidate: cwd_not_found
```

A removed workspace is normal stale session state rather than actionable corruption, so these warnings create noise in Telegram responses.

## Behavior

Managed candidate cwd failures retain their underlying identity code as `cwd_<code>`. Only stale path cases are silenced:

- `cwd_not_found`
- `cwd_not_directory`

Failures such as `cwd_not_utf8`, `cwd_network_unsupported`, `cwd_identity_unavailable`, and `cwd_io_error` remain visible. Other binding, metadata, security, and file-integrity warnings are unchanged.

Stale sessions are ignored during listing; no session data or binding files are deleted.

## Tests

- `bun test packages/coding-agent/test/notifications-recent-activity.test.ts` — 15 passed
- `bunx biome check packages/coding-agent/src/sdk/bus/recent-activity.ts packages/coding-agent/src/session/internal/managed-session-scope.ts packages/coding-agent/test/notifications-recent-activity.test.ts`
- `git diff --check`