### PR TITLE
fix(coding-agent): bind marketplace catalog requests

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Fixed
 - SQLite `read` raw queries now accept exactly one explicit `SELECT` statement, reject comments and statement tails before opening the database, recheck the invariant at execution, and enable SQLite query-only mode as defense in depth.
+- Direct HTTP(S) marketplace catalogs now use connection-bound public-address validation, bounded redirects, and a 2 MiB response limit before parsing or caching.
 - Fixed the `subagent` tool's `resume` action silently swallowing manager failures. Resume outcomes other than `context_unavailable`/`not_found` (`no_runner`, `resume_failed`, `owner_shutdown_in_progress`, …) were dropped and the stale terminal subagent snapshot was returned as if the resume had succeeded, so ralplan's re-review loop believed the persisted Planner had resumed when it had not and never fell back correctly. The resume action now surfaces every non-ok reason (matching the `steer` branch), and the task resume runner marks a resumed subprocess that aborted or exited non-zero as a `failed` job (carrying its rendered failure summary) instead of reporting it `completed`.
 - Daemon timeout flags now reject missing, malformed, non-positive, fractional, whitespace-containing, and unsafe integer values before daemon command side effects instead of partially parsing them.
 - Hardened standalone HTML session exports so session identifiers, provider/model labels, and embedded raster images remain confined to their intended HTML contexts; malformed image payloads are omitted.

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/fetcher.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/fetcher.ts
@@ -5,10 +5,14 @@
  */
 
 import * as fs from "node:fs/promises";
+import * as http from "node:http";
+import * as https from "node:https";
+import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import { isEnoent, logger } from "@gajae-code/utils";
 import * as git from "../../../utils/git";
+import { isPrivateOrSpecialAddress, validatePublicHttpUrl } from "../../../web/insane/url-guard";
 
 import type { MarketplaceCatalog, MarketplaceSourceType } from "./types";
 import { isValidNameSegment } from "./types";
@@ -194,6 +198,192 @@ export function parseMarketplaceCatalog(content: string, filePath: string): Mark
 
 /** Relative path from a marketplace root to its catalog file. */
 const CATALOG_RELATIVE_PATH = path.join(".claude-plugin", "marketplace.json");
+const URL_FETCH_TIMEOUT_MS = 60_000;
+const URL_FETCH_MAX_REDIRECTS = 5;
+const URL_FETCH_MAX_HEADER_BYTES = 16 * 1024;
+/** Direct JSON catalogs are metadata; 2 MiB leaves ample room without permitting unbounded buffering. */
+const URL_FETCH_MAX_BYTES = 2 * 1024 * 1024;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+function withAbortSignal<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+	if (signal.aborted) return Promise.reject(signal.reason);
+	const deferred = Promise.withResolvers<T>();
+	const abort = () => deferred.reject(signal.reason);
+	signal.addEventListener("abort", abort, { once: true });
+	operation.then(deferred.resolve, deferred.reject).finally(() => signal.removeEventListener("abort", abort));
+	return deferred.promise;
+}
+
+function normalizePeerAddress(address: string): string {
+	const normalized = address.toLowerCase();
+	return normalized.startsWith("::ffff:") ? normalized.slice(7) : normalized;
+}
+
+function normalizeUrlHostname(hostname: string): string {
+	return hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+}
+
+async function validateCatalogUrl(rawUrl: string, signal: AbortSignal) {
+	const url = new URL(rawUrl);
+	const hostname = normalizeUrlHostname(url.hostname);
+	// URL.hostname retains IPv6 brackets in Node/Bun, while net.isIP expects the bare literal.
+	if (net.isIP(hostname) === 6) {
+		if (url.protocol !== "http:" && url.protocol !== "https:")
+			return { ok: false as const, reason: `unsupported scheme ${url.protocol}` };
+		if (url.username || url.password) return { ok: false as const, reason: "URL credentials are not allowed" };
+		if (isPrivateOrSpecialAddress(hostname))
+			return { ok: false as const, reason: "private, loopback, link-local, or reserved IP literal" };
+		return { ok: true as const, url, addresses: [hostname] };
+	}
+	return withAbortSignal(validatePublicHttpUrl(rawUrl), signal);
+}
+
+function openCatalogResponse(url: URL, addresses: string[], signal: AbortSignal): Promise<http.IncomingMessage> {
+	const hostname = normalizeUrlHostname(url.hostname);
+	const approved = addresses.map(address => ({ address, family: net.isIP(address) }));
+	const approvedPeers = new Set(approved.map(record => normalizePeerAddress(record.address)));
+	const lookup: net.LookupFunction = (requestedHostname, options, callback) => {
+		const requestedFamily = options.family === "IPv4" ? 4 : options.family === "IPv6" ? 6 : (options.family ?? 0);
+		const matching = approved.filter(record => requestedFamily === 0 || record.family === requestedFamily);
+		if (normalizeUrlHostname(requestedHostname) !== hostname || matching.length === 0) {
+			const error = Object.assign(new Error("No approved address for marketplace host"), { code: "ENOTFOUND" });
+			callback(error, options.all ? [] : "", 0);
+			return;
+		}
+		if (options.all) callback(null, matching);
+		else callback(null, matching[0].address, matching[0].family);
+	};
+	const deferred = Promise.withResolvers<http.IncomingMessage>();
+	const options: https.RequestOptions = {
+		protocol: url.protocol,
+		hostname,
+		port: url.port || undefined,
+		path: `${url.pathname}${url.search}`,
+		method: "GET",
+		headers: { Accept: "application/json", "Accept-Encoding": "identity", Connection: "close", Host: url.host },
+		agent: false,
+		insecureHTTPParser: false,
+		lookup,
+		maxHeaderSize: URL_FETCH_MAX_HEADER_BYTES,
+		signal,
+		...(url.protocol === "https:"
+			? { rejectUnauthorized: true, servername: net.isIP(hostname) === 0 ? hostname : undefined }
+			: {}),
+	};
+	const requestFn = url.protocol === "https:" ? https.request : http.request;
+	const request = requestFn(options, response => {
+		const peer = response.socket.remoteAddress;
+		if (!peer || isPrivateOrSpecialAddress(peer) || !approvedPeers.has(normalizePeerAddress(peer))) {
+			response.destroy();
+			deferred.reject(
+				new Error(`Refusing marketplace catalog response from unapproved connected peer ${peer ?? "unknown"}`),
+			);
+			return;
+		}
+		deferred.resolve(response);
+	});
+	request.once("error", deferred.reject);
+	const abort = () => {
+		request.destroy(signal.reason);
+		deferred.reject(signal.reason);
+	};
+	if (signal.aborted) abort();
+	else signal.addEventListener("abort", abort, { once: true });
+	request.once("close", () => signal.removeEventListener("abort", abort));
+	request.end();
+	return deferred.promise;
+}
+
+async function readCatalogResponse(
+	response: http.IncomingMessage,
+	source: string,
+	signal: AbortSignal,
+): Promise<string> {
+	const rawContentLengths: string[] = [];
+	let hasTransferEncoding = false;
+	for (let index = 0; index < response.rawHeaders.length; index += 2) {
+		const name = response.rawHeaders[index]?.toLowerCase();
+		if (name === "content-length") rawContentLengths.push(response.rawHeaders[index + 1] ?? "");
+		if (name === "transfer-encoding") hasTransferEncoding = true;
+	}
+	if (rawContentLengths.length > 1 || (rawContentLengths.length > 0 && hasTransferEncoding)) {
+		response.destroy();
+		throw new Error(`Marketplace catalog from ${source} has ambiguous response framing`);
+	}
+	const contentLength = response.headers["content-length"];
+	if (contentLength !== undefined) {
+		const declaredBytes =
+			typeof contentLength === "string" && /^\d+$/.test(contentLength) ? Number(contentLength) : NaN;
+		if (!Number.isSafeInteger(declaredBytes)) {
+			response.destroy();
+			throw new Error(`Marketplace catalog from ${source} has an invalid Content-Length`);
+		}
+		if (declaredBytes > URL_FETCH_MAX_BYTES) {
+			response.destroy();
+			throw new Error(`Marketplace catalog from ${source} exceeds the maximum size of 2 MiB`);
+		}
+	}
+
+	const abort = () => response.destroy(signal.reason);
+	if (signal.aborted) {
+		abort();
+		throw signal.reason;
+	}
+	signal.addEventListener("abort", abort, { once: true });
+	const chunks: Buffer[] = [];
+	let receivedBytes = 0;
+	try {
+		for await (const chunk of response) {
+			const bytes = Buffer.from(chunk);
+			receivedBytes += bytes.byteLength;
+			if (receivedBytes > URL_FETCH_MAX_BYTES) {
+				response.destroy();
+				throw new Error(`Marketplace catalog from ${source} exceeds the maximum size of 2 MiB`);
+			}
+			chunks.push(bytes);
+		}
+		return Buffer.concat(chunks, receivedBytes).toString("utf8");
+	} finally {
+		signal.removeEventListener("abort", abort);
+	}
+}
+
+async function fetchMarketplaceCatalogUrl(source: string): Promise<string> {
+	const deadline = AbortSignal.timeout(URL_FETCH_TIMEOUT_MS);
+	let currentUrl = source;
+	try {
+		for (let redirectCount = 0; ; redirectCount++) {
+			const guard = await validateCatalogUrl(currentUrl, deadline);
+			if (!guard.ok) {
+				throw new Error(`Refusing marketplace catalog URL: target URL is not public HTTP(S): ${guard.reason}`);
+			}
+			const response = await openCatalogResponse(guard.url, guard.addresses, deadline);
+			const status = response.statusCode ?? 0;
+			if (REDIRECT_STATUSES.has(status)) {
+				if (redirectCount >= URL_FETCH_MAX_REDIRECTS) {
+					response.destroy();
+					throw new Error(`Too many redirects fetching marketplace catalog from ${source}`);
+				}
+				const location = response.headers.location;
+				response.destroy();
+				if (!location)
+					throw new Error(`Marketplace catalog redirect from ${currentUrl} is missing a Location header`);
+				currentUrl = new URL(location, guard.url).toString();
+				continue;
+			}
+			if (status < 200 || status >= 300) {
+				response.destroy();
+				throw new Error(
+					`Failed to fetch marketplace catalog from ${currentUrl}: HTTP ${status} ${response.statusMessage ?? ""}`,
+				);
+			}
+			return await readCatalogResponse(response, currentUrl, deadline);
+		}
+	} catch (err) {
+		if (deadline.aborted) throw new Error(`Timed out fetching marketplace catalog from ${source}`);
+		throw err;
+	}
+}
 
 /**
  * Expand a `~/...` path to an absolute path using os.homedir().
@@ -249,13 +439,7 @@ export async function fetchMarketplace(source: string, cacheDir: string): Promis
 	}
 
 	// type === "url"
-	const response = await fetch(source, { signal: AbortSignal.timeout(60_000) });
-	if (!response.ok) {
-		throw new Error(
-			`Failed to fetch marketplace catalog from ${source}: HTTP ${response.status} ${response.statusText}`,
-		);
-	}
-	const text = await response.text();
+	const text = await fetchMarketplaceCatalogUrl(source);
 	const catalog = parseMarketplaceCatalog(text, source);
 
 	const catalogDir = path.join(cacheDir, catalog.name);

--- a/packages/coding-agent/test/marketplace/fetcher.test.ts
+++ b/packages/coding-agent/test/marketplace/fetcher.test.ts
@@ -1,7 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as dns from "node:dns/promises";
+import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
+import * as http from "node:http";
+import * as https from "node:https";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Readable } from "node:stream";
 
 import {
 	classifySource,
@@ -11,6 +16,37 @@ import {
 
 // Fixture lives at test/marketplace/fixtures/valid-marketplace/
 const FIXTURE_DIR = path.join(import.meta.dir, "fixtures", "valid-marketplace");
+const MAX_CATALOG_BYTES = 2 * 1024 * 1024;
+const CORE_HTTP_REQUEST = http.request;
+
+function response(
+	body: string | Uint8Array,
+	options: { status?: number; headers?: http.IncomingHttpHeaders; peer?: string; rawHeaders?: string[] } = {},
+) {
+	const message = Readable.from([body]) as unknown as http.IncomingMessage;
+	Object.defineProperties(message, {
+		headers: { value: options.headers ?? {} },
+		rawHeaders: { value: options.rawHeaders ?? [] },
+		socket: { value: { remoteAddress: options.peer ?? "8.8.8.8" } },
+		statusCode: { value: options.status ?? 200 },
+		statusMessage: { value: "Test" },
+	});
+	return message;
+}
+
+function mockHttpRequests(nextResponse: (options: https.RequestOptions, call: number) => http.IncomingMessage) {
+	const requests: https.RequestOptions[] = [];
+	const request = ((options: https.RequestOptions, callback?: (message: http.IncomingMessage) => void) => {
+		requests.push(options);
+		const client = new EventEmitter() as EventEmitter & { destroy: () => void; end: () => void };
+		client.destroy = () => {};
+		client.end = () => queueMicrotask(() => callback?.(nextResponse(options, requests.length)));
+		return client as unknown as http.ClientRequest;
+	}) as typeof http.request;
+	vi.spyOn(http, "request").mockImplementation(request);
+	vi.spyOn(https, "request").mockImplementation(request as typeof https.request);
+	return requests;
+}
 
 // ── classifySource ────────────────────────────────────────────────────
 
@@ -153,9 +189,11 @@ describe("fetchMarketplace", () => {
 
 	beforeEach(() => {
 		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-fetcher-test-"));
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ordinary fetch must not run"));
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -178,6 +216,212 @@ describe("fetchMarketplace", () => {
 		// Use a path that resolves within tmpDir but doesn't exist
 		const fakeSrc = path.join(tmpDir, "ghost-marketplace");
 		await expect(fetchMarketplace(fakeSrc, tmpDir)).rejects.toThrow(/Marketplace catalog not found/);
+	});
+
+	it("binds a hostname request to the single approved DNS answer", async () => {
+		let resolution = 0;
+		const dnsLookup = vi
+			.spyOn(dns, "lookup")
+			.mockImplementation((async () => [
+				{ address: resolution++ === 0 ? "8.8.8.8" : "127.0.0.1", family: 4 },
+			]) as unknown as typeof dns.lookup);
+		const requests = mockHttpRequests(() =>
+			response(JSON.stringify({ name: "remote-market", owner: { name: "x" }, plugins: [] }), {
+				peer: "::ffff:8.8.8.8",
+			}),
+		);
+
+		await fetchMarketplace("https://rebind.example/marketplace.json", tmpDir);
+
+		expect(dnsLookup).toHaveBeenCalledTimes(1);
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+		expect(requests[0]?.agent).toBe(false);
+		expect(requests[0]?.headers).toMatchObject({ Connection: "close", Host: "rebind.example" });
+		expect(requests[0]).toMatchObject({
+			insecureHTTPParser: false,
+			maxHeaderSize: 16 * 1024,
+			rejectUnauthorized: true,
+			servername: "rebind.example",
+		});
+		expect(requests[0]?.lookup).toBeFunction();
+		const allCallback = vi.fn();
+		requests[0]?.lookup?.("rebind.example", { all: true }, allCallback);
+		expect(allCallback).toHaveBeenCalledWith(null, [{ address: "8.8.8.8", family: 4 }]);
+		for (const [hostname, family] of [
+			["other.example", 4],
+			["rebind.example", 6],
+		] as const) {
+			const rejectedCallback = vi.fn();
+			requests[0]?.lookup?.(hostname, { family }, rejectedCallback);
+			expect(rejectedCallback.mock.calls[0]?.[0]).toMatchObject({ code: "ENOTFOUND" });
+		}
+	});
+
+	it("passes the pinned lookup and original Host through core http.request", async () => {
+		vi.spyOn(dns, "lookup").mockImplementation((async () => [
+			{ address: "8.8.8.8", family: 4 },
+		]) as unknown as typeof dns.lookup);
+		const requests = mockHttpRequests(() =>
+			response(JSON.stringify({ name: "core-proof", owner: { name: "x" }, plugins: [] })),
+		);
+		await fetchMarketplace("http://pinned.example/marketplace.json", tmpDir);
+
+		const hostSeen = Promise.withResolvers<string>();
+		const server = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch(request) {
+				hostSeen.resolve(request.headers.get("host") ?? "");
+				return new Response();
+			},
+		});
+		const finished = Promise.withResolvers<void>();
+		const coreRequest = CORE_HTTP_REQUEST(
+			{
+				...requests[0],
+				port: server.port,
+				lookup: (hostname, options, callback) =>
+					requests[0]?.lookup?.(hostname, options, (error, approved, family) => {
+						const selected = typeof approved === "string" ? approved : approved[0]?.address;
+						expect(selected).toBe("8.8.8.8");
+						const local = typeof approved === "string" ? "127.0.0.1" : [{ address: "127.0.0.1", family: 4 }];
+						callback(error, local, family);
+					}),
+			},
+			response => {
+				response.resume();
+				response.once("end", finished.resolve);
+			},
+		);
+		try {
+			coreRequest.once("error", finished.reject);
+			coreRequest.end();
+			await finished.promise;
+			expect(await hostSeen.promise).toBe("pinned.example");
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	it("preserves public IP literals and omits SNI for HTTPS literals", async () => {
+		const requests = mockHttpRequests((_options, call) =>
+			response(JSON.stringify({ name: `literal-${call}`, owner: { name: "x" }, plugins: [] }), {
+				peer: call === 1 ? "8.8.8.8" : "2606:4700:4700::1111",
+			}),
+		);
+		await fetchMarketplace("https://8.8.8.8/marketplace.json", tmpDir);
+		await fetchMarketplace("http://[2606:4700:4700::1111]/marketplace.json", tmpDir);
+		expect(requests[0]).toMatchObject({ hostname: "8.8.8.8", servername: undefined });
+		expect(requests[1]).toMatchObject({ hostname: "2606:4700:4700::1111" });
+		expect(requests[1]?.headers).toMatchObject({ Host: "[2606:4700:4700::1111]" });
+	});
+
+	it("rejects a connected peer outside the approved DNS answers before caching", async () => {
+		vi.spyOn(dns, "lookup").mockImplementation((async () => [
+			{ address: "8.8.8.8", family: 4 },
+		]) as unknown as typeof dns.lookup);
+		const message = response(JSON.stringify({ name: "peer-mismatch", owner: { name: "x" }, plugins: [] }), {
+			peer: "127.0.0.1",
+		});
+		const destroy = vi.spyOn(message, "destroy");
+		mockHttpRequests(() => message);
+
+		await expect(fetchMarketplace("http://rebind.example/marketplace.json", tmpDir)).rejects.toThrow(
+			/connected peer/,
+		);
+
+		expect(destroy).toHaveBeenCalled();
+		expect(fs.readdirSync(tmpDir)).toEqual([]);
+	});
+
+	it("rejects credentialed and private targets before opening a request", async () => {
+		const requests = mockHttpRequests(() => response(""));
+
+		for (const source of ["http://user@8.8.8.8/marketplace.json", "http://127.0.0.1/marketplace.json"]) {
+			await expect(fetchMarketplace(source, tmpDir)).rejects.toThrow(/not public HTTP\(S\)/);
+		}
+		expect(requests).toHaveLength(0);
+	});
+
+	it("revalidates redirects before opening the next request", async () => {
+		const requests = mockHttpRequests(() =>
+			response("", { status: 302, headers: { location: "http://127.0.0.1/marketplace.json" } }),
+		);
+
+		await expect(fetchMarketplace("http://8.8.8.8/marketplace.json", tmpDir)).rejects.toThrow(/not public HTTP\(S\)/);
+		expect(requests).toHaveLength(1);
+	});
+
+	it("rejects missing redirect locations and excessive redirect chains", async () => {
+		let requests = mockHttpRequests(() => response("", { status: 302 }));
+		await expect(fetchMarketplace("http://8.8.8.8/marketplace.json", tmpDir)).rejects.toThrow(/Location/);
+		expect(requests).toHaveLength(1);
+
+		vi.restoreAllMocks();
+		requests = mockHttpRequests(() => response("", { status: 302, headers: { location: "/marketplace.json" } }));
+		await expect(fetchMarketplace("http://8.8.8.8/marketplace.json", tmpDir)).rejects.toThrow(/redirects/);
+		expect(requests).toHaveLength(6);
+	});
+
+	it("rejects declared and chunked bodies above two MiB", async () => {
+		let message = response("", { headers: { "content-length": String(MAX_CATALOG_BYTES + 1) } });
+		let destroy = vi.spyOn(message, "destroy");
+		mockHttpRequests(() => message);
+		await expect(fetchMarketplace("http://8.8.8.8/marketplace.json", tmpDir)).rejects.toThrow(/2 MiB/);
+		expect(destroy).toHaveBeenCalled();
+
+		vi.restoreAllMocks();
+		message = response(new Uint8Array(MAX_CATALOG_BYTES + 1));
+		destroy = vi.spyOn(message, "destroy");
+		mockHttpRequests(() => message);
+		await expect(fetchMarketplace("http://8.8.8.8/marketplace.json", tmpDir)).rejects.toThrow(/2 MiB/);
+		expect(destroy).toHaveBeenCalled();
+	});
+
+	it("rejects duplicate Content-Length and Content-Length plus Transfer-Encoding", async () => {
+		const framingCases: Array<[string[], string, RegExp]> = [
+			[["Content-Length", "1", "Content-Length", "1"], "1", /framing/],
+			[["Content-Length", "1", "Transfer-Encoding", "chunked"], "1", /framing/],
+			[["Content-Length", "invalid"], "invalid", /Content-Length/],
+		];
+		for (const [rawHeaders, contentLength, expected] of framingCases) {
+			const message = response("x", { headers: { "content-length": contentLength }, rawHeaders });
+			mockHttpRequests(() => message);
+			await expect(fetchMarketplace("http://8.8.8.8/marketplace.json", tmpDir)).rejects.toThrow(expected);
+			vi.restoreAllMocks();
+		}
+	});
+
+	it("destroys an in-flight request when the single deadline aborts", async () => {
+		const controller = new AbortController();
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+		const opened = Promise.withResolvers<void>();
+		const client = new EventEmitter() as EventEmitter & { destroy: () => void; end: () => void };
+		client.destroy = vi.fn();
+		client.end = opened.resolve;
+		vi.spyOn(http, "request").mockReturnValue(client as unknown as http.ClientRequest);
+		const operation = fetchMarketplace("http://8.8.8.8/marketplace.json", tmpDir);
+		await opened.promise;
+		controller.abort(new DOMException("deadline", "TimeoutError"));
+		await expect(operation).rejects.toThrow(/Timed out/);
+		expect(client.destroy).toHaveBeenCalled();
+		expect(fs.readdirSync(tmpDir)).toEqual([]);
+	});
+
+	it("follows a bounded public redirect and caches a valid catalog", async () => {
+		const catalog = JSON.stringify({ name: "redirect-market", owner: { name: "x" }, plugins: [] });
+		const requests = mockHttpRequests((_options, call) =>
+			call === 1
+				? response("", { status: 302, headers: { location: "http://1.1.1.1/catalog.json" } })
+				: response(catalog, { peer: "1.1.1.1" }),
+		);
+
+		const result = await fetchMarketplace("http://8.8.8.8/marketplace.json", tmpDir);
+
+		expect(result.catalog.name).toBe("redirect-market");
+		expect(requests).toHaveLength(2);
+		expect(requests[1]?.signal).toBe(requests[0]?.signal);
+		expect(fs.readFileSync(path.join(tmpDir, "redirect-market", "marketplace.json"), "utf8")).toBe(catalog);
 	});
 
 	// Network-dependent tests — skip in CI / offline environments.


### PR DESCRIPTION
## Summary

This supersedes the transport design from closed PR #2691 and addresses its maintainer feedback: marketplace catalog validation is now bound to the actual network connection instead of validating and then calling ordinary `fetch`, which could re-resolve DNS.

The exact three-file scope is:
- `packages/coding-agent/src/extensibility/plugins/marketplace/fetcher.ts`
- `packages/coding-agent/test/marketplace/fetcher.test.ts`
- `packages/coding-agent/CHANGELOG.md`

## Behavior

- Validate the initial URL and every redirect, then use a one-shot core HTTP(S) request whose lookup returns only approved addresses.
- Preserve the original Host header and HTTPS SNI/certificate verification; disable pooling/proxy discovery and verify the connected peer is in the approved public-address set.
- Enforce five redirects, one 60-second deadline, 16 KiB response headers, unambiguous response framing, and a streamed 2 MiB body cap before parsing or caching.
- Preserve direct public IPv4/IPv6 catalog URLs and omit SNI for HTTPS IP literals.

## Verification

- Focused fetcher tests: 33 passed, 3 skipped
- Full marketplace tests: 201 passed, 5 skipped
- Coding-agent typecheck: passed
- Changed-file Biome check: passed
- `git diff --check`: passed

## Non-scope

- Git and GitHub clone transport paths are unchanged.
- Existing marketplace manager/cache promotion behavior is unchanged.