### PR TITLE
fix(coding-agent): bound inbound Telegram attachments

### DIFF
--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -247,8 +247,13 @@ const BTW_USAGE_TEXT = "Usage: /btw <question>";
 const BTW_CAPACITY_TEXT = "Too many /btw questions are pending. Wait for one to finish and try again.";
 export const BTW_QUESTION_MAX_UNICODE_SCALARS = 4_096;
 export const BTW_QUESTION_MAX_UTF8_BYTES = 16_384;
+const TELEGRAM_ATTACHMENT_MAX_BYTES = 20 * 1024 * 1024;
+const TELEGRAM_SESSION_ATTACHMENT_MAX_COUNT = 20;
+const TELEGRAM_SESSION_ATTACHMENT_MAX_BYTES = 50 * 1024 * 1024;
+const TELEGRAM_ATTACHMENT_DOWNLOAD_TIMEOUT_MS = 60_000;
 const BTW_QUESTION_LIMIT_TEXT = "Question must be at most 4096 Unicode scalar values and 16384 UTF-8 bytes.";
 type ParsedBtwCommand = { kind: "question"; question: string } | { kind: "ignored" };
+type TelegramFileDownload = { bytes: Buffer } | { failure: "download_failed" | "too_large" };
 class ThreadedModeCapabilityRefusal extends Error {}
 
 /** Only an explicit Bot API capability refusal may enable flat private-chat delivery. */
@@ -4677,8 +4682,12 @@ export class TelegramNotificationDaemon {
 		if (raw && typeof raw === "object") this.topics.load(raw);
 	}
 
-	/** Download a Telegram file by its file_path (from getFile) into memory. */
-	private async downloadTelegramFile(filePath: string): Promise<Buffer | undefined> {
+	/** Download one Telegram file with the Bot API's 20 MiB ceiling and one end-to-end deadline. */
+	private async downloadTelegramFile(
+		filePath: string,
+		maxBytes = TELEGRAM_ATTACHMENT_MAX_BYTES,
+		deadlineController?: AbortController,
+	): Promise<TelegramFileDownload> {
 		const apiBase = this.opts.apiBase ?? "https://api.telegram.org";
 		const fetchImpl = this.opts.fetchImpl ?? fetch;
 		// `filePath` is remote metadata from getFile; reject suspicious segments
@@ -4686,17 +4695,68 @@ export class TelegramNotificationDaemon {
 		// composing the download URL.
 		if (filePath.includes("..") || filePath.startsWith("/") || filePath.includes("\\")) {
 			logger.warn("notifications: rejecting suspicious Telegram file_path");
-			return undefined;
+			return { failure: "download_failed" };
 		}
 		const encodedPath = filePath.split("/").map(encodeURIComponent).join("/");
 		const url = `${apiBase}/file/bot${this.opts.botToken}/${encodedPath}`;
+		const controller = deadlineController ?? new AbortController();
+		let cancelActiveReader: (() => Promise<void>) | undefined;
+		const setTimeoutImpl = this.opts.setTimeoutImpl ?? setTimeout;
+		const clearTimeoutImpl = this.opts.clearTimeoutImpl ?? clearTimeout;
+		const timeout = deadlineController
+			? undefined
+			: setTimeoutImpl(
+					() => controller.abort(new Error("Telegram attachment download timed out")),
+					TELEGRAM_ATTACHMENT_DOWNLOAD_TIMEOUT_MS,
+				);
+		const cancelReader = () => void cancelActiveReader?.();
+		controller.signal.addEventListener("abort", cancelReader, { once: true });
 		try {
-			const res = await fetchImpl(url);
-			if (!res.ok) return undefined;
-			return Buffer.from(await res.arrayBuffer());
+			const res = await fetchImpl(url, { signal: controller.signal });
+			if (!res.ok) {
+				await res.body?.cancel().catch(() => undefined);
+				controller.abort();
+				return { failure: "download_failed" };
+			}
+			const declaredLength = res.headers.get("content-length");
+			if (declaredLength !== null) {
+				const declaredBytes = Number(declaredLength);
+				if (!Number.isSafeInteger(declaredBytes) || declaredBytes < 0 || declaredBytes > maxBytes) {
+					await res.body?.cancel().catch(() => undefined);
+					controller.abort();
+					return { failure: "too_large" };
+				}
+			}
+			if (!res.body) {
+				controller.abort();
+				return { failure: "download_failed" };
+			}
+			const reader = res.body.getReader();
+			cancelActiveReader = () => reader.cancel().catch(() => undefined);
+			controller.signal.throwIfAborted();
+			const chunks: Buffer[] = [];
+			let total = 0;
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				total += value.byteLength;
+				if (total > maxBytes) {
+					await reader.cancel().catch(() => undefined);
+					controller.abort();
+					return { failure: "too_large" };
+				}
+				chunks.push(Buffer.from(value));
+			}
+			controller.signal.throwIfAborted();
+			return { bytes: Buffer.concat(chunks, total) };
 		} catch (e) {
+			await cancelActiveReader?.();
+			controller.abort();
 			logger.warn(`notifications: file download failed: ${sanitizeDiagnostic(String(e))}`);
-			return undefined;
+			return { failure: "download_failed" };
+		} finally {
+			controller.signal.removeEventListener("abort", cancelReader);
+			if (timeout !== undefined) clearTimeoutImpl(timeout);
 		}
 	}
 
@@ -4706,6 +4766,8 @@ export class TelegramNotificationDaemon {
 	 * removed when the daemon stops (see {@link cleanupAllAttachmentDirs}).
 	 */
 	private readonly attachmentDirs = new Map<string, string>();
+	readonly #attachmentUsage = new Map<string, { count: number; bytes: number }>();
+	readonly #attachmentChains = new Map<string, Promise<void>>();
 
 	/** Lazily create a private, unguessable 0700 temp dir for `sessionId`. */
 	private async ensureAttachmentDir(sessionId: string): Promise<string> {
@@ -4723,6 +4785,8 @@ export class TelegramNotificationDaemon {
 	private async cleanupAllAttachmentDirs(): Promise<void> {
 		const dirs = [...this.attachmentDirs.values()];
 		this.attachmentDirs.clear();
+		this.#attachmentUsage.clear();
+		this.#attachmentChains.clear();
 		await Promise.all(dirs.map(dir => fs.promises.rm(dir, { recursive: true, force: true }).catch(() => undefined)));
 	}
 
@@ -4739,21 +4803,82 @@ export class TelegramNotificationDaemon {
 		att: InboundAttachment,
 		sessionId: string,
 	): Promise<{ images: { data: string; mime?: string }[]; fileNotes: string[] }> {
+		const previous = this.#attachmentChains.get(sessionId) ?? Promise.resolve();
+		const task = previous.then(() => this.resolveInboundAttachmentSerial(att, sessionId));
+		const chain = task.then(
+			() => undefined,
+			() => undefined,
+		);
+		this.#attachmentChains.set(sessionId, chain);
+		return task.finally(() => {
+			if (this.#attachmentChains.get(sessionId) === chain) this.#attachmentChains.delete(sessionId);
+		});
+	}
+
+	private async resolveInboundAttachmentSerial(
+		att: InboundAttachment,
+		sessionId: string,
+	): Promise<{ images: { data: string; mime?: string }[]; fileNotes: string[] }> {
 		const images: { data: string; mime?: string }[] = [];
 		const fileNotes: string[] = [];
 		const label = att.fileName ?? att.kind;
+		let timeout: NodeJS.Timeout | undefined;
 		try {
-			const got = (await this.botApi.call("getFile", { file_id: att.fileId })) as {
-				result?: { file_path?: unknown };
+			const usage = this.#attachmentUsage.get(sessionId) ?? { count: 0, bytes: 0 };
+			if (
+				usage.count >= TELEGRAM_SESSION_ATTACHMENT_MAX_COUNT ||
+				usage.bytes >= TELEGRAM_SESSION_ATTACHMENT_MAX_BYTES
+			) {
+				fileNotes.push(`[attachment rejected: ${label}; session attachment limit reached]`);
+				return { images, fileNotes };
+			}
+			const controller = new AbortController();
+			timeout = (this.opts.setTimeoutImpl ?? setTimeout)(
+				() => controller.abort(new Error("Telegram attachment download timed out")),
+				TELEGRAM_ATTACHMENT_DOWNLOAD_TIMEOUT_MS,
+			);
+			const got = (await this.botApi.call("getFile", { file_id: att.fileId }, { signal: controller.signal })) as {
+				result?: { file_path?: unknown; file_size?: unknown };
 			};
 			const filePath = typeof got?.result?.file_path === "string" ? got.result.file_path : undefined;
 			if (!filePath) {
 				fileNotes.push(`[attachment unavailable: ${label}]`);
 				return { images, fileNotes };
 			}
-			const bytes = await this.downloadTelegramFile(filePath);
-			if (!bytes) {
-				fileNotes.push(`[attachment download failed: ${label}]`);
+			const declaredBytes = got.result?.file_size;
+			const remainingBytes = TELEGRAM_SESSION_ATTACHMENT_MAX_BYTES - usage.bytes;
+			if (
+				(typeof declaredBytes === "number" &&
+					(!Number.isSafeInteger(declaredBytes) ||
+						declaredBytes < 0 ||
+						declaredBytes > TELEGRAM_ATTACHMENT_MAX_BYTES ||
+						declaredBytes > remainingBytes)) ||
+				remainingBytes <= 0
+			) {
+				fileNotes.push(`[attachment rejected: ${label}; size limit exceeded]`);
+				return { images, fileNotes };
+			}
+			const downloaded = await this.downloadTelegramFile(
+				filePath,
+				Math.min(TELEGRAM_ATTACHMENT_MAX_BYTES, remainingBytes),
+				controller,
+			);
+			if ("failure" in downloaded) {
+				fileNotes.push(
+					downloaded.failure === "too_large"
+						? `[attachment rejected: ${label}; size limit exceeded]`
+						: `[attachment download failed: ${label}]`,
+				);
+				return { images, fileNotes };
+			}
+			const bytes = downloaded.bytes;
+			const accountedBytes = Math.max(bytes.byteLength, typeof declaredBytes === "number" ? declaredBytes : 0);
+			const current = this.#attachmentUsage.get(sessionId) ?? { count: 0, bytes: 0 };
+			if (
+				current.count >= TELEGRAM_SESSION_ATTACHMENT_MAX_COUNT ||
+				current.bytes + accountedBytes > TELEGRAM_SESSION_ATTACHMENT_MAX_BYTES
+			) {
+				fileNotes.push(`[attachment rejected: ${label}; session attachment limit reached]`);
 				return { images, fileNotes };
 			}
 			const isImage = att.kind === "photo" || (typeof att.mime === "string" && att.mime.startsWith("image/"));
@@ -4770,12 +4895,20 @@ export class TelegramNotificationDaemon {
 				// Unguessable, non-colliding name inside the private 0700 dir; the
 				// exclusive 0600 create (`wx`) refuses to follow a pre-existing file/symlink.
 				const dest = path.join(dir, `${crypto.randomBytes(8).toString("hex")}-${safeBase}`);
-				await fs.promises.writeFile(dest, bytes, { flag: "wx", mode: 0o600 });
+				try {
+					await fs.promises.writeFile(dest, bytes, { flag: "wx", mode: 0o600 });
+				} catch (e) {
+					await fs.promises.unlink(dest).catch(() => undefined);
+					throw e;
+				}
 				fileNotes.push(`[user attached a file, saved to ${dest}${att.mime ? ` (${att.mime})` : ""}]`);
 			}
+			this.#attachmentUsage.set(sessionId, { count: current.count + 1, bytes: current.bytes + accountedBytes });
 		} catch (e) {
 			logger.warn(`notifications: inbound attachment failed: ${String(e)}`);
 			fileNotes.push(`[attachment error: ${label}]`);
+		} finally {
+			if (timeout !== undefined) (this.opts.clearTimeoutImpl ?? clearTimeout)(timeout);
 		}
 		return { images, fileNotes };
 	}

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -54,9 +54,21 @@ import {
 } from "../src/sdk/bus/telegram-daemon";
 import { ownerPidFromOwnerId, runDaemonInternal, runDaemonSmoke } from "../src/sdk/bus/telegram-daemon-cli";
 import { NOTIFICATION_PROTOCOL_VERSION } from "../src/sdk/bus/telegram-daemon-contract";
+import type { InboundAttachment } from "../src/sdk/bus/threaded-inbound";
 
 const THREADED_FALLBACK_NOTICE =
 	"Flat Telegram private chat supports outbound notifications and inline ask buttons only. Enable Threaded Mode in @BotFather > Bot Settings > Threads Settings for free-text replies and session commands.";
+type AttachmentDownload = { bytes: Buffer } | { failure: "download_failed" | "too_large" };
+interface AttachmentTestAccess {
+	downloadTelegramFile(filePath: string, maxBytes?: number): Promise<AttachmentDownload>;
+	resolveInboundAttachment(
+		attachment: InboundAttachment,
+		sessionId: string,
+	): Promise<{ images: Array<{ data: string }>; fileNotes: string[] }>;
+}
+function attachmentAccess(daemon: TelegramNotificationDaemon): AttachmentTestAccess {
+	return daemon as unknown as AttachmentTestAccess;
+}
 
 test("endpoint authority digest canonicalizes endpoint presentation and binds authenticated identity", () => {
 	const canonical = endpointAuthorityDigest("ws://LOCALHOST:80/sdk?ignored=yes#ignored", "token");
@@ -8613,10 +8625,7 @@ test("inbound photo is downloaded and forwarded as an image in the user_message"
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();
-	const fetchImpl = (async () => ({
-		ok: true,
-		arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
-	})) as unknown as typeof fetch;
+	const fetchImpl = (async () => new Response(new Uint8Array([1, 2, 3, 4]))) as unknown as typeof fetch;
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
@@ -8650,6 +8659,198 @@ test("inbound photo is downloaded and forwarded as an image in the user_message"
 	expect(bot.calls.some(c => c.method === "getFile" && c.body.file_id === "large")).toBe(true);
 });
 
+test("inbound attachment download enforces declared and streamed byte ceilings", async () => {
+	let requests = 0;
+	let nonSuccessCancelled = false;
+	let oversizedCancelled = false;
+	let nonSuccessSignal: AbortSignal | undefined;
+	const nonSuccessBody = new ReadableStream<Uint8Array>({
+		cancel() {
+			nonSuccessCancelled = true;
+		},
+	});
+	const oversizedBody = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(new Uint8Array(4));
+			controller.enqueue(new Uint8Array([1]));
+		},
+		cancel() {
+			oversizedCancelled = true;
+		},
+	});
+	const responses = [
+		new Response(nonSuccessBody, { status: 503 }),
+		new Response(null, { headers: { "content-length": "5" } }),
+		new Response(oversizedBody),
+		new Response(new Uint8Array([1, 2, 3, 4]), { headers: { "content-length": "4" } }),
+	];
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		fetchImpl: (async (_url, init) => {
+			if (requests === 0) nonSuccessSignal = init?.signal ?? undefined;
+			return responses[requests++]!;
+		}) as typeof fetch,
+	});
+	const download = attachmentAccess(daemon).downloadTelegramFile.bind(daemon);
+
+	await expect(download("docs/unavailable.bin", 4)).resolves.toEqual({ failure: "download_failed" });
+	expect(nonSuccessCancelled).toBe(true);
+	expect(nonSuccessSignal?.aborted).toBe(true);
+	await expect(download("docs/declared.bin", 4)).resolves.toEqual({ failure: "too_large" });
+	await expect(download("docs/chunked.bin", 4)).resolves.toEqual({ failure: "too_large" });
+	expect(oversizedCancelled).toBe(true);
+	await expect(download("docs/exact.bin", 4)).resolves.toEqual({ bytes: Buffer.from([1, 2, 3, 4]) });
+});
+
+test("inbound attachment download aborts when its single deadline expires", async () => {
+	let expire: (() => void) | undefined;
+	let observedSignal: AbortSignal | undefined;
+	const fetchImpl = ((_url: string | URL | Request, init?: RequestInit) => {
+		observedSignal = init?.signal ?? undefined;
+		const pending = Promise.withResolvers<Response>();
+		observedSignal?.addEventListener("abort", () => pending.reject(observedSignal?.reason), { once: true });
+		return pending.promise;
+	}) as typeof fetch;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		fetchImpl,
+		setTimeoutImpl: ((callback: () => void) => {
+			expire = callback;
+			return 1;
+		}) as unknown as typeof setTimeout,
+		clearTimeoutImpl: (() => undefined) as unknown as typeof clearTimeout,
+	});
+	const pending = attachmentAccess(daemon).downloadTelegramFile("docs/slow.bin");
+	await Promise.resolve();
+	expire?.();
+	await expect(pending).resolves.toEqual({ failure: "download_failed" });
+	expect(observedSignal?.aborted).toBe(true);
+});
+
+test("one inbound attachment deadline covers getFile and a stalled response body read", async () => {
+	let expire: (() => void) | undefined;
+	let cancelled = false;
+	let getFileSignal: AbortSignal | undefined;
+	let fetchSignal: AbortSignal | undefined;
+	let timerCount = 0;
+	const body = new ReadableStream<Uint8Array>({
+		cancel() {
+			cancelled = true;
+		},
+	});
+	const botApi: BotApi = {
+		async call(method, _body, opts): Promise<unknown> {
+			if (method === "getFile") {
+				getFileSignal = opts?.signal;
+				return { ok: true, result: { file_path: "docs/stalled-body.bin", file_size: 1 } };
+			}
+			return { ok: true, result: true };
+		},
+	};
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi,
+		fetchImpl: (async (_url, init) => {
+			fetchSignal = init?.signal ?? undefined;
+			return new Response(body);
+		}) as typeof fetch,
+		setTimeoutImpl: ((callback: () => void) => {
+			timerCount++;
+			expire = callback;
+			return 1;
+		}) as unknown as typeof setTimeout,
+		clearTimeoutImpl: (() => undefined) as unknown as typeof clearTimeout,
+	});
+	const pending = attachmentAccess(daemon).resolveInboundAttachment(
+		{ fileId: "slow", kind: "photo", mime: "image/jpeg" },
+		"S",
+	);
+	while (!fetchSignal) await Promise.resolve();
+	expire?.();
+
+	const result = await pending;
+	expect(result.images).toHaveLength(0);
+	expect(result.fileNotes[0]).toContain("attachment download failed");
+	expect(timerCount).toBe(1);
+	expect(getFileSignal?.aborted).toBe(true);
+	expect(fetchSignal?.aborted).toBe(true);
+	expect(cancelled).toBe(true);
+});
+
+test("inbound attachments enforce per-session count and cumulative byte budgets", async () => {
+	const resolve = (daemon: TelegramNotificationDaemon, fileId: string, kind: "photo" | "document" = "photo") =>
+		attachmentAccess(daemon).resolveInboundAttachment(
+			{
+				fileId,
+				kind,
+				mime: kind === "photo" ? "image/jpeg" : "application/octet-stream",
+				fileName: kind === "document" ? "file.bin" : undefined,
+			},
+			"S",
+		);
+	const harness = (sizes: number[]) => {
+		let getFileCalls = 0;
+		let fetchCalls = 0;
+		const botApi: BotApi = {
+			async call(method: string): Promise<unknown> {
+				if (method === "getFile")
+					return { ok: true, result: { file_path: "photos/file.jpg", file_size: sizes[getFileCalls++] } };
+				return { ok: true, result: true };
+			},
+		};
+		const daemon = new TelegramNotificationDaemon({
+			settings: settings(tempAgentDir()),
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi,
+			fetchImpl: (async () => {
+				fetchCalls++;
+				return new Response(new Uint8Array([1]));
+			}) as unknown as typeof fetch,
+		});
+		return { daemon, calls: () => ({ getFileCalls, fetchCalls }) };
+	};
+
+	const count = harness([1, 20 * 1024 * 1024 + 1, ...Array<number>(20).fill(1)]);
+	const writeFile = fs.promises.writeFile.bind(fs.promises);
+	let partialPath: string | undefined;
+	const writeSpy = vi.spyOn(fs.promises, "writeFile").mockImplementationOnce(async (file, data, options) => {
+		partialPath = String(file);
+		await writeFile(file, data, options);
+		throw new Error("disk full after partial write");
+	});
+	const writeFailed = await resolve(count.daemon, "write-fails", "document");
+	writeSpy.mockRestore();
+	expect(writeFailed.images).toHaveLength(0);
+	expect(writeFailed.fileNotes[0]).toContain("attachment error");
+	expect(partialPath).toBeDefined();
+	expect(fs.existsSync(partialPath!)).toBe(false);
+	expect((await resolve(count.daemon, "oversize")).images).toHaveLength(0);
+	for (let i = 0; i < 20; i++) expect((await resolve(count.daemon, `ok-${i}`)).images).toHaveLength(1);
+	const countRejected = await resolve(count.daemon, "count-exhausted");
+	expect(countRejected.images).toHaveLength(0);
+	expect(countRejected.fileNotes[0]).toContain("session attachment limit");
+	expect(count.calls()).toEqual({ getFileCalls: 22, fetchCalls: 21 });
+
+	const mib = 1024 * 1024;
+	const total = harness([20 * mib, 20 * mib, 10 * mib]);
+	const results = await Promise.all(["a", "b", "c", "total-exhausted"].map(id => resolve(total.daemon, id)));
+	expect(results.slice(0, 3).every(result => result.images.length === 1)).toBe(true);
+	expect(results[3]!.images).toHaveLength(0);
+	expect(results[3]!.fileNotes[0]).toContain("session attachment limit");
+	expect(total.calls()).toEqual({ getFileCalls: 3, fetchCalls: 3 });
+});
+
 test("redacts token-shaped download URLs from attachment failure logs", async () => {
 	const botToken = "123456789:ABCDEF_ghijklmnopqrstuvwxyz012345";
 	let downloadedUrl = "";
@@ -8668,11 +8869,9 @@ test("redacts token-shaped download URLs from attachment failure logs", async ()
 	const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
 
 	try {
-		await expect(
-			(
-				daemon as unknown as { downloadTelegramFile(filePath: string): Promise<Buffer | undefined> }
-			).downloadTelegramFile("photos/file.jpg"),
-		).resolves.toBeUndefined();
+		await expect(attachmentAccess(daemon).downloadTelegramFile("photos/file.jpg")).resolves.toEqual({
+			failure: "download_failed",
+		});
 
 		const logged = JSON.stringify([...warnSpy.mock.calls, ...errorSpy.mock.calls]);
 		expect(downloadedUrl).toBe(`https://api.telegram.org/file/bot${botToken}/photos/file.jpg`);
@@ -8730,10 +8929,7 @@ test("inbound document is saved to a tmp file and its path injected into the tex
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();
-	const fetchImpl = (async () => ({
-		ok: true,
-		arrayBuffer: async () => new Uint8Array([9, 9, 9]).buffer,
-	})) as unknown as typeof fetch;
+	const fetchImpl = (async () => new Response(new Uint8Array([9, 9, 9]))) as unknown as typeof fetch;
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
@@ -8789,10 +8985,7 @@ test("inbound document with a path-traversal filename stays sandboxed in the pri
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();
-	const fetchImpl = (async () => ({
-		ok: true,
-		arrayBuffer: async () => new Uint8Array([7]).buffer,
-	})) as unknown as typeof fetch;
+	const fetchImpl = (async () => new Response(new Uint8Array([7]))) as unknown as typeof fetch;
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
@@ -8839,10 +9032,7 @@ test("daemon attachment temp dirs are removed by the shutdown cleanup path", asy
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();
-	const fetchImpl = (async () => ({
-		ok: true,
-		arrayBuffer: async () => new Uint8Array([1, 1]).buffer,
-	})) as unknown as typeof fetch;
+	const fetchImpl = (async () => new Response(new Uint8Array([1, 1]))) as unknown as typeof fetch;
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",


### PR DESCRIPTION
## Summary

- enforce Telegram's 20 MiB inbound attachment ceiling before and during streamed downloads
- apply one end-to-end deadline plus per-session attachment count and byte budgets
- preserve private temp-file permissions and avoid retaining rejected or failed attachments

## Verification

- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts` — 272 pass
- `bun x biome check packages/coding-agent/src/sdk/bus/telegram-daemon.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `git diff --check`
- `bun run check:publish-types`

Outbound Telegram upload behavior is unchanged.
