### PR TITLE
fix(coding-agent): bound Hindsight responses

### DIFF
--- a/packages/coding-agent/src/hindsight/client.ts
+++ b/packages/coding-agent/src/hindsight/client.ts
@@ -12,6 +12,8 @@ import type { HindsightConfig } from "./config";
 
 const USER_AGENT = "oh-my-gajae-code";
 const DEFAULT_USER_AGENT = USER_AGENT;
+const REQUEST_TIMEOUT_MS = 30_000;
+const RESPONSE_MAX_BYTES = 8 * 1024 * 1024;
 
 export type Budget = "low" | "mid" | "high" | string;
 export type TagsMatch = "any" | "all" | "any_strict" | "all_strict";
@@ -208,6 +210,49 @@ interface RequestOptions {
 	query?: Record<string, unknown>;
 	/** Return null instead of throwing on a 404 response. */
 	allow404?: boolean;
+}
+
+class ResponseTooLargeError extends Error {}
+
+async function readResponseText(response: Response): Promise<string> {
+	const contentLength = response.headers.get("content-length");
+	if (contentLength !== null) {
+		const declaredBytes = Number(contentLength);
+		if (Number.isFinite(declaredBytes) && declaredBytes > RESPONSE_MAX_BYTES) {
+			void response.body?.cancel().catch(() => undefined);
+			throw new ResponseTooLargeError();
+		}
+	}
+
+	const reader = response.body?.getReader();
+	if (!reader) return "";
+
+	const chunks: Uint8Array[] = [];
+	let totalBytes = 0;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value || value.byteLength === 0) continue;
+
+			totalBytes += value.byteLength;
+			if (totalBytes > RESPONSE_MAX_BYTES) {
+				void reader.cancel().catch(() => undefined);
+				throw new ResponseTooLargeError();
+			}
+			chunks.push(value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	const bytes = new Uint8Array(totalBytes);
+	let offset = 0;
+	for (const chunk of chunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return new TextDecoder().decode(bytes);
 }
 
 export class HindsightApi {
@@ -489,7 +534,8 @@ export class HindsightApi {
 			if (qs) url += `?${qs}`;
 		}
 
-		const init: RequestInit = { method, headers: this.#headers };
+		const requestSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+		const init: RequestInit = { method, headers: this.#headers, signal: requestSignal };
 		if (opts?.body !== undefined) {
 			init.body = JSON.stringify(pruneUndefined(opts.body));
 		}
@@ -498,6 +544,9 @@ export class HindsightApi {
 		try {
 			response = await fetch(url, init);
 		} catch (err) {
+			if (requestSignal.aborted) {
+				throw new HindsightError(`${operation} request failed: timed out`);
+			}
 			throw new HindsightError(
 				`${operation} request failed: ${err instanceof Error ? err.message : String(err)}`,
 				undefined,
@@ -506,10 +555,21 @@ export class HindsightApi {
 		}
 
 		if (opts?.allow404 && response.status === 404) {
+			await response.body?.cancel().catch(() => undefined);
 			return null as T;
 		}
 
-		const text = await response.text();
+		let text: string;
+		try {
+			text = await readResponseText(response);
+		} catch (err) {
+			const reason = requestSignal.aborted
+				? "timed out"
+				: err instanceof ResponseTooLargeError
+					? "response exceeded size limit"
+					: "response could not be read";
+			throw new HindsightError(`${operation} request failed: ${reason}`);
+		}
 		const parsed = text ? safeJsonParse(text) : null;
 
 		if (!response.ok) {

--- a/packages/coding-agent/src/hindsight/client.ts
+++ b/packages/coding-agent/src/hindsight/client.ts
@@ -568,7 +568,10 @@ export class HindsightApi {
 				: err instanceof ResponseTooLargeError
 					? "response exceeded size limit"
 					: "response could not be read";
-			throw new HindsightError(`${operation} request failed: ${reason}`);
+			throw new HindsightError(`${operation} request failed: ${reason}`, response.status);
+		}
+		if (requestSignal.aborted) {
+			throw new HindsightError(`${operation} request failed: timed out`, response.status);
 		}
 		const parsed = text ? safeJsonParse(text) : null;
 

--- a/packages/coding-agent/test/hindsight-client.test.ts
+++ b/packages/coding-agent/test/hindsight-client.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { HindsightApi, HindsightError } from "@gajae-code/coding-agent/hindsight/client";
+
+const client = new HindsightApi({ baseUrl: "https://hindsight.test" });
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("HindsightApi response boundaries", () => {
+	it("parses a normal JSON response", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ results: [{ text: "remember this" }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		await expect(client.recall("bank", "query")).resolves.toEqual({
+			results: [{ text: "remember this" }],
+		});
+	});
+
+	it("preserves structured API error mapping", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ detail: "service unavailable" }), { status: 503 }),
+		);
+
+		const error = await client.recall("bank", "query").catch(value => value);
+		expect(error).toBeInstanceOf(HindsightError);
+		expect(error).toMatchObject({ statusCode: 503, details: "service unavailable" });
+		expect(error.message).toBe("recall failed: service unavailable");
+	});
+
+	it("rejects an oversized declared response before parsing it", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("sensitive-response-content", {
+				status: 200,
+				headers: { "Content-Length": String(Number.MAX_SAFE_INTEGER) },
+			}),
+		);
+
+		const error = await client.recall("bank", "query").catch(value => value);
+		expect(error).toBeInstanceOf(HindsightError);
+		expect(error.message).toContain("response exceeded size limit");
+		expect(error.message).not.toContain("sensitive-response-content");
+	});
+
+	it("rejects a chunked response that crosses the streaming byte cap", async () => {
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array(8 * 1024 * 1024 + 1));
+				controller.close();
+			},
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(body, { status: 200 }));
+
+		const error = await client.recall("bank", "query").catch(value => value);
+		expect(error).toBeInstanceOf(HindsightError);
+		expect(error.message).toContain("response exceeded size limit");
+	});
+
+	it("maps an aborted stalled body to a content-free timeout error", async () => {
+		const timeoutController = new AbortController();
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
+		vi.spyOn(globalThis, "fetch").mockImplementation((async (
+			_input: Parameters<typeof fetch>[0],
+			init?: Parameters<typeof fetch>[1],
+		) => {
+			expect(init?.signal).toBe(timeoutController.signal);
+			const body = new ReadableStream<Uint8Array>({
+				start(controller) {
+					init?.signal?.addEventListener("abort", () => {
+						controller.error(new DOMException("sensitive upstream detail", "AbortError"));
+					});
+					queueMicrotask(() => timeoutController.abort());
+				},
+			});
+			return new Response(body, { status: 200 });
+		}) as unknown as typeof fetch);
+
+		const error = await client.recall("bank", "query").catch(value => value);
+		expect(error).toBeInstanceOf(HindsightError);
+		expect(error.message).toBe("recall request failed: timed out");
+		expect(error.message).not.toContain("sensitive upstream detail");
+	});
+
+	it("keeps allow404 responses body-independent", async () => {
+		let cancelled = false;
+		const body = new ReadableStream<Uint8Array>({
+			cancel() {
+				cancelled = true;
+			},
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(body, {
+				status: 404,
+				headers: { "Content-Length": String(Number.MAX_SAFE_INTEGER) },
+			}),
+		);
+
+		await expect(client.getDocument("bank", "missing")).resolves.toBeNull();
+		expect(cancelled).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/hindsight-client.test.ts
+++ b/packages/coding-agent/test/hindsight-client.test.ts
@@ -85,6 +85,133 @@ describe("HindsightApi response boundaries", () => {
 		expect(error.message).not.toContain("sensitive upstream detail");
 	});
 
+	it("preserves the HTTP status for an oversized error response", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("oversized-error", {
+				status: 503,
+				headers: { "Content-Length": String(Number.MAX_SAFE_INTEGER) },
+			}),
+		);
+
+		const error = await client.recall("bank", "query").catch(value => value);
+		expect(error).toMatchObject({ statusCode: 503 });
+		expect(error.message).toBe("recall request failed: response exceeded size limit");
+	});
+
+	it("accepts a valid response exactly at the byte cap", async () => {
+		const text = "x".repeat(8 * 1024 * 1024 - 11);
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ text })));
+
+		await expect(client.reflect("bank", "query")).resolves.toEqual({ text });
+	});
+
+	it("decodes multibyte JSON split across body chunks", async () => {
+		const bytes = new TextEncoder().encode(JSON.stringify({ text: "😀" }));
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(bytes.subarray(0, 11));
+				controller.enqueue(bytes.subarray(11));
+				controller.close();
+			},
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(body));
+
+		await expect(client.reflect("bank", "query")).resolves.toEqual({ text: "😀" });
+	});
+
+	it("treats forged and duplicate Content-Length values as advisory", async () => {
+		const headers = new Headers();
+		headers.append("Content-Length", "1");
+		headers.append("Content-Length", "999999999");
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ results: [] }), { headers }));
+
+		await expect(client.recall("bank", "query")).resolves.toEqual({ results: [] });
+	});
+
+	it("counts expanded response bytes even when Content-Encoding is present", async () => {
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array(8 * 1024 * 1024 + 1));
+				controller.close();
+			},
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(body, { headers: { "Content-Encoding": "gzip", "Content-Length": "1" } }),
+		);
+
+		await expect(client.recall("bank", "query")).rejects.toThrow("response exceeded size limit");
+	});
+
+	it("propagates the deadline while waiting for response headers", async () => {
+		const timeoutController = new AbortController();
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
+		vi.spyOn(globalThis, "fetch").mockImplementation(
+			((_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
+				new Promise((_resolve, reject) => {
+					init?.signal?.addEventListener("abort", () => reject(new DOMException("late header", "AbortError")));
+					queueMicrotask(() => timeoutController.abort());
+				})) as unknown as typeof fetch,
+		);
+
+		await expect(client.recall("bank", "query")).rejects.toThrow("recall request failed: timed out");
+	});
+
+	it("cancels a 404 body without poisoning a later request", async () => {
+		let cancelled = false;
+		const body = new ReadableStream<Uint8Array>({
+			cancel() {
+				cancelled = true;
+			},
+		});
+		vi.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(new Response(body, { status: 404 }))
+			.mockResolvedValueOnce(new Response(JSON.stringify({ results: [] })));
+
+		await expect(client.getDocument("bank", "missing")).resolves.toBeNull();
+		await expect(client.recall("bank", "query")).resolves.toEqual({ results: [] });
+		expect(cancelled).toBe(true);
+	});
+
+	it("keeps concurrent request budgets isolated", async () => {
+		vi.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(new Response(JSON.stringify({ results: [] })))
+			.mockResolvedValueOnce(new Response(new Uint8Array(8 * 1024 * 1024 + 1)));
+
+		const [safe, oversized] = await Promise.allSettled([
+			client.recall("bank", "safe"),
+			client.recall("bank", "large"),
+		]);
+		expect(safe).toMatchObject({ status: "fulfilled", value: { results: [] } });
+		expect(oversized).toMatchObject({ status: "rejected" });
+	});
+
+	it("maps a partial body read failure without exposing its abort reason", async () => {
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode('{"results":'));
+				controller.error(new DOMException("sensitive partial-read reason", "AbortError"));
+			},
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(body, { status: 502 }));
+
+		const error = await client.recall("bank", "query").catch(value => value);
+		expect(error).toMatchObject({ statusCode: 502 });
+		expect(error.message).toBe("recall request failed: response could not be read");
+		expect(error.message).not.toContain("sensitive partial-read reason");
+	});
+
+	it("uses the configured URL with fetch's redirect handling", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ results: [] })));
+
+		await expect(client.recall("bank with spaces", "query")).resolves.toEqual({ results: [] });
+		expect(fetchSpy).toHaveBeenCalledWith(
+			"https://hindsight.test/v1/default/banks/bank%20with%20spaces/memories/recall",
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
+		const [, init] = fetchSpy.mock.calls[0]!;
+		expect(init?.redirect).toBeUndefined();
+	});
+
 	it("keeps allow404 responses body-independent", async () => {
 		let cancelled = false;
 		const body = new ReadableStream<Uint8Array>({


### PR DESCRIPTION
## Summary

- enforce a 30-second deadline across Hindsight requests and body reads
- cap responses at 8 MiB using both header and streaming checks
- cancel allowed 404 response bodies without consuming them
- add focused coverage for response boundaries and error mapping

## Verification

- `bun test packages/coding-agent/test/hindsight-client.test.ts`
- `bun test packages/coding-agent/test/hindsight-*.test.ts`
- `bunx biome check packages/coding-agent/src/hindsight/client.ts packages/coding-agent/test/hindsight-client.test.ts`
- `bun run --cwd packages/coding-agent check:types`
- `git diff --check upstream/dev..HEAD`