### PR TITLE
fix(coding-agent): isolate pet guidance environment

### DIFF
--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -669,6 +669,8 @@ export interface SettingsRuntimeContext {
 	cwd: string;
 	/** Whether this terminal can render the pet overlay. */
 	petAvailable?: boolean;
+	/** Terminal environment used to select unavailable-pet guidance. Omitted in production to use Bun.env. */
+	terminalEnv?: NodeJS.ProcessEnv;
 }
 
 /** Status line settings subset for preview */
@@ -896,7 +898,7 @@ export class SettingsSelectorComponent extends Container {
 			options = createPetSelectItems(options, currentValue, petAvailable);
 			// Unsupported terminals must see the same actionable guidance the
 			// startup notice and /pet show, not only dimmed option descriptions.
-			if (!petAvailable) description = getPetUnavailableWarning();
+			if (!petAvailable) description = getPetUnavailableWarning(this.context.terminalEnv);
 		}
 		// Preview handlers
 		let onPreview: ((value: string) => void | Promise<void>) | undefined;

--- a/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
@@ -17,7 +17,11 @@ afterEach(() => {
 	resetSettingsForTest();
 });
 
-function makeComponent(petAvailable: boolean, callbacks: Record<string, unknown>): SettingsSelectorComponent {
+function makeComponent(
+	petAvailable: boolean,
+	callbacks: Record<string, unknown>,
+	terminalEnv?: NodeJS.ProcessEnv,
+): SettingsSelectorComponent {
 	return new SettingsSelectorComponent(
 		{
 			availableThinkingLevels: [],
@@ -26,6 +30,7 @@ function makeComponent(petAvailable: boolean, callbacks: Record<string, unknown>
 			availableModelProfiles: [],
 			cwd: process.cwd(),
 			petAvailable,
+			terminalEnv,
 		},
 		{ onChange: () => {}, onCancel: () => {}, ...callbacks },
 	);
@@ -75,7 +80,7 @@ describe("SettingsSelectorComponent pet capability", () => {
 
 	it("shows the actionable unavailable warning inside the pet submenu", () => {
 		settings.set("pet.mode", "red");
-		const component = makeComponent(false, {});
+		const component = makeComponent(false, {}, {});
 
 		openPetSetting(component);
 		const submenu = stripVTControlCharacters(component.render(200).join("\n"));
@@ -83,6 +88,21 @@ describe("SettingsSelectorComponent pet capability", () => {
 		// Same guidance as startup and /pet (normal-terminal variant in tests);
 		// dimmed option descriptions alone are not sufficient.
 		expect(submenu).toContain("Ghostty");
+	});
+
+	it.each([
+		["TMUX", { TMUX: "/tmp/host,1,0" }],
+		["tmux TERM", { TERM: "tmux-256color" }],
+	])("shows multiplexer recovery guidance for %s without normal-terminal guidance", (_name, terminalEnv) => {
+		settings.set("pet.mode", "red");
+		const component = makeComponent(false, {}, terminalEnv);
+
+		openPetSetting(component);
+		const submenu = stripVTControlCharacters(component.render(200).join("\n"));
+
+		expect(submenu).toContain("outside the multiplexer");
+		expect(submenu).toContain("PI_FORCE_IMAGE_PROTOCOL=sixel");
+		expect(submenu).not.toContain("Ghostty");
 	});
 
 	it("does not persist pet.mode when the commit policy rejects at select time", () => {


### PR DESCRIPTION
## Summary
- classify the remaining #2692 Ghostty baseline failure as environment-dependent terminal detection leakage
- inject an optional terminal environment only at the Settings unavailable-pet guidance boundary
- keep omitted production behavior on real `Bun.env`
- add deterministic rendered hostile coverage for explicit normal, `TMUX`, and `TERM=tmux-*` contexts without mutating global environment

Refs #2692

## Root cause
At pinned dev `30edc148618bcc9714a5cec30914b4dbce0a438a`, the focused Settings pet test passed with every multiplexer marker cleared and failed under ambient/explicit `TMUX` and `TERM=tmux-256color`. `SettingsSelectorComponent` accepted deterministic `petAvailable: false` but selected warning copy through `getPetUnavailableWarning()`'s ambient `Bun.env`, so tests run inside tmux rendered the valid multiplexer warning instead of the normal-terminal guidance containing `Ghostty`.

This is not a stale navigation fixture or product-copy regression. Merged #2694 already resolved the independent SDK inventory failure; merged #2693 is unrelated broker-fixture context.

## Repair
- add `terminalEnv?: NodeJS.ProcessEnv` to `SettingsRuntimeContext`
- pass it only to `getPetUnavailableWarning()` for unavailable `pet.mode`
- explicit `{}` deterministically selects normal guidance
- explicit recognized multiplexer markers select the existing recovery guidance
- omission preserves production ambient detection

## Verification at head `db980f5d2eb97cb6b2ae52cb378a99c408c923b5`
- focused Settings pet selector: 5 passed
- related pet selector: 3 passed
- terminal/Sixel predicate suite: 15 passed
- coding-agent check: passed
- coding-agent build: passed
- root `ci:check:full`: passed
- root build: passed
- exact shard 8 ran: 1,559 passed / 27 skipped; 7 unrelated load/timing failures plus 2 errors; no Settings pet/Ghostty failure
- full coding-agent test also exposed unrelated broker/session load/time/memory baselines; the focused repaired contract and deterministic checks/builds pass

## Review
Fresh hostile exact-diff Architect review: `CLEAR` / `APPROVE`; no assertion weakening, global environment mutation, warning-policy drift, or scope expansion. Candidate changes exactly two files.

## Scope boundaries
No SDK inventory, broker, CI workflow, warning-copy, shared terminal predicate, main, release, version, or publish changes.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*