### PR TITLE
fix(sdk): preserve repaired session-index watermark

### DIFF
--- a/packages/coding-agent/src/sdk/broker/session-index.ts
+++ b/packages/coding-agent/src/sdk/broker/session-index.ts
@@ -429,10 +429,11 @@ export class SessionIndex {
 					await writeAndSync(path.join(quarantinePath, "index.snapshot.json"), scan.snapshotContents);
 				if (scan.logContents) await writeAndSync(path.join(quarantinePath, "index.jsonl"), scan.logContents);
 				await syncDirectory(path.join(quarantinePath, "index.jsonl"));
+				const events = [...scan.snapshotEvents, ...scan.validLogEvents];
 				const snapshot = JSON.stringify({
 					version: SESSION_INDEX_SNAPSHOT_VERSION,
-					indexSeq: scan.snapshotEvents.at(-1)?.indexSeq ?? 0,
-					events: scan.snapshotEvents,
+					indexSeq: scan.diagnosis.validPrefixSeq,
+					events,
 				});
 				const log = scan.validLogEvents.map(event => JSON.stringify(event)).join("\n");
 				await replaceAtomically(snapshotFor(this.#agentDir), snapshot);

--- a/packages/coding-agent/test/sdk-session-index.test.ts
+++ b/packages/coding-agent/test/sdk-session-index.test.ts
@@ -231,6 +231,30 @@ describe("SDK session index", () => {
 		]);
 		expect(replay.indexSeq).toBe(3);
 	});
+	it("preserves the repaired valid-prefix watermark after a historical overlap", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-repair-watermark-"));
+		const index = await new SessionIndex(dir).open();
+		await index.append(event("one"));
+		await index.append(event("two"));
+		await index.append(event("three"));
+		await index.snapshot();
+		const sessionsDir = path.join(dir, "sdk", "sessions");
+		const snapshotFile = path.join(sessionsDir, "index.snapshot.json");
+		const snapshot = JSON.parse(await fs.readFile(snapshotFile, "utf8"));
+		snapshot.indexSeq = 99;
+		await fs.writeFile(snapshotFile, JSON.stringify(snapshot));
+		const log = path.join(sessionsDir, "index.jsonl");
+		await fs.appendFile(log, "broken\n");
+
+		const repair = await index.repair();
+		expect(repair).toMatchObject({ status: "corrupt", repaired: true, validPrefixSeq: 3 });
+		expect(JSON.parse(await fs.readFile(snapshotFile, "utf8"))).toMatchObject({
+			indexSeq: repair.validPrefixSeq,
+			events: [{ indexSeq: 1 }, { indexSeq: 2 }, { indexSeq: 3 }],
+		});
+		expect((await new SessionIndex(dir).open()).indexSeq).toBe(repair.validPrefixSeq);
+		expect((await index.append(event("after-repair"))).indexSeq).toBe(repair.validPrefixSeq + 1);
+	});
 	it("tolerates Windows permission errors while opening and syncing the snapshot directory", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));
 		const index = await new SessionIndex(dir).open();
@@ -497,6 +521,34 @@ describe("SDK session index", () => {
 		expect(replay.indexSeq).toBe(5);
 		const appended = await replay.append(event("c"));
 		expect(appended.indexSeq).toBe(6);
+	});
+	it("repairs a compacted high-watermark snapshot with historical overlap and remains appendable", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-repair-watermark-"));
+		const sessionsDir = path.join(dir, "sdk", "sessions");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		const signed = (indexSeq: number, sessionId: string) => {
+			const unsigned = { ...event(sessionId), version: SDK_STATE_VERSION, indexSeq, ts: 1 };
+			return { ...unsigned, checksum: sessionIndexChecksum(unsigned as Parameters<typeof sessionIndexChecksum>[0]) };
+		};
+		const history = Array.from({ length: 5 }, (_, index) => signed(index + 1, `history-${index + 1}`));
+		const tail = signed(6, "tail");
+		await fs.writeFile(
+			path.join(sessionsDir, "index.snapshot.json"),
+			JSON.stringify({ version: 2, indexSeq: 5, events: [history[0], history[2]] }),
+		);
+		await fs.writeFile(
+			path.join(sessionsDir, "index.jsonl"),
+			`${[...history, tail].map(row => JSON.stringify(row)).join("\n")}\nbroken\n`,
+		);
+
+		const index = await new SessionIndex(dir).open();
+		const repair = await index.repair();
+
+		expect(repair).toMatchObject({ status: "corrupt", repaired: true, validPrefixSeq: 6 });
+		expect(JSON.parse(await fs.readFile(path.join(sessionsDir, "index.snapshot.json"), "utf8"))).toMatchObject({
+			indexSeq: 6,
+		});
+		expect((await index.append(event("resumed"))).indexSeq).toBe(repair.validPrefixSeq + 1);
 	});
 	it("rejects a non-monotonic snapshot as invalid", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-"));


### PR DESCRIPTION
## Root cause

`SessionIndex.repair()` rewrote the verified log prefix but rebuilt its snapshot from only the pre-existing snapshot events. When a high-watermark snapshot was structurally invalid, this emitted an empty sequence-zero snapshot even though repair had retained a verified prefix. A later replay had to reconstruct the watermark from the historical overlap.

## Fix

Checkpoint the complete verified repair prefix (`snapshotEvents` plus `validLogEvents`) into the replacement snapshot and set its `indexSeq` to the diagnosed `validPrefixSeq`. The retained log is preserved for established rotation behavior.

## RED / GREEN evidence

- RED: `bun test packages/coding-agent/test/sdk-session-index.test.ts --test-name-pattern='preserves the repaired valid-prefix watermark after a historical overlap'` failed because repair wrote `{ indexSeq: 0, events: [] }` instead of the verified prefix through sequence 3.
- GREEN: the same focused regression passed after the fix.

## Verification

- `bun test packages/coding-agent/test/sdk-session-index.test.ts` — 32 passed.
- `bun --cwd=packages/coding-agent run lint` — passed.
- `bun --cwd=packages/coding-agent run check` — passed (Biome and TypeScript).
- `bun --cwd=packages/coding-agent run build` — passed after building the repository-native local addon.
- `packages/coding-agent/dist/gjc mcp-serve coordinator --check --json` — passed.
- Real detached-broker Coordinator lifecycle checks: 9 passed.
- Coordinator runtime readiness: 2 passed.
- `git diff --check` — passed.

## Remaining risks

The repair path now has focused coverage for invalid high-watermark snapshots, compacted historical overlap, corrupt suffixes, reopening, and post-repair append. The live provider-backed `start_session -> send_prompt -> read_tail -> terminal reconcile` sequence was not run because it requires an operator provider/model configuration; compiled Coordinator and real detached-broker lifecycle checks passed.