### PR TITLE
fix(acp): restore live assistant chunks over SDK

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -74,7 +74,7 @@ interface PromptWaiter {
 	/** Highest inbound frame sequence already observed when the prompt was acknowledged. */
 	boundary: number;
 	correlation: PromptCorrelation;
-	messageProgress: { textEmitted: boolean; thoughtEmitted: boolean };
+	messageProgress?: { textEmitted: boolean; thoughtEmitted: boolean };
 	pendingTerminal?: PromptCorrelation;
 	resolve: (response: PromptResponse) => void;
 	reject: (error: Error) => void;
@@ -828,7 +828,6 @@ export class AcpAgent implements Agent {
 				steeringAtAcknowledgement: record.busy,
 				boundary: record.inboundSequence,
 				correlation: {},
-				messageProgress: { textEmitted: false, thoughtEmitted: false },
 				resolve,
 				reject,
 			};
@@ -1300,10 +1299,16 @@ export class AcpAgent implements Agent {
 		if (wirePayload) {
 			for (const notification of mapAgentWireEventPayloadToAcpSessionUpdates(wirePayload as never, id, {
 				cwd: record.cwd,
-				getMessageProgress: () => activePrompt?.messageProgress,
+				getMessageProgress: message => {
+					if (!activePrompt || !object(message)) return undefined;
+					activePrompt.messageProgress ??= { textEmitted: false, thoughtEmitted: false };
+					return activePrompt.messageProgress;
+				},
 			}))
 				await this.#publishSessionUpdate(id, notification, adapter);
 		}
+		if (event.type === "message_end" && object(event.message)?.role === "assistant" && activePrompt)
+			activePrompt.messageProgress = undefined;
 		if (event.type === "agent_end") await this.#emitEndOfTurnUpdates(id, adapter);
 		if (activePrompt) this.#settlePrompt(record, activePrompt);
 	}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -74,6 +74,7 @@ interface PromptWaiter {
 	/** Highest inbound frame sequence already observed when the prompt was acknowledged. */
 	boundary: number;
 	correlation: PromptCorrelation;
+	messageProgress: { textEmitted: boolean; thoughtEmitted: boolean };
 	pendingTerminal?: PromptCorrelation;
 	resolve: (response: PromptResponse) => void;
 	reject: (error: Error) => void;
@@ -827,6 +828,7 @@ export class AcpAgent implements Agent {
 				steeringAtAcknowledgement: record.busy,
 				boundary: record.inboundSequence,
 				correlation: {},
+				messageProgress: { textEmitted: false, thoughtEmitted: false },
 				resolve,
 				reject,
 			};
@@ -1298,6 +1300,7 @@ export class AcpAgent implements Agent {
 		if (wirePayload) {
 			for (const notification of mapAgentWireEventPayloadToAcpSessionUpdates(wirePayload as never, id, {
 				cwd: record.cwd,
+				getMessageProgress: () => activePrompt?.messageProgress,
 			}))
 				await this.#publishSessionUpdate(id, notification, adapter);
 		}

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -3210,11 +3210,12 @@ export function createNotificationsExtension(
 			const correlation = runtime.activePromptCorrelation;
 			const submission = promptSubmissions.get(promptSubmissionKey(correlation));
 			if (!submission || submission.abandoned) return;
-			const frame = runtime.host.emitEvent({
+			const frame = {
+				type: "event",
 				kind: event.type,
 				payload: toAgentWireEventPayload(event),
 				...correlation,
-			});
+			};
 			if (!submission.acknowledged) {
 				submission.bufferedFrames.push(frame);
 				return;

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -999,6 +999,7 @@ type SessionStartResult = {
 	status: SessionStartStatus;
 	runtime?: SessionRuntime;
 	failure?: SdkStartupFailure;
+	suppressExtensionError?: boolean;
 };
 
 function pushSessionFrame(
@@ -4265,6 +4266,7 @@ export function createNotificationsExtension(
 			logger.warn(`notifications: failed to start server: ${String(e)}`);
 			const result = failLifecycleStartup("failed", e);
 			finishStartup(result);
+			let suppressExtensionError = false;
 			let stopped = false;
 			try {
 				stopped = await stopSession(id, "session", runtime);
@@ -4274,9 +4276,10 @@ export function createNotificationsExtension(
 				// than letting it escape startSession and surface a red extension error
 				// through session_start / session_switch / session_branch.
 				logger.error(`notifications: SDK notification runtime cleanup failed: ${String(error)}`);
+				suppressExtensionError = true;
 			}
 			if (!stopped) await cleanupAbandonedStartup();
-			return { ...result, runtime };
+			return { ...result, runtime, suppressExtensionError };
 		}
 	}
 
@@ -4416,7 +4419,17 @@ export function createNotificationsExtension(
 
 	const startAndReconcileSession = async (ctx: ExtensionContext): Promise<void> => {
 		const result = await startSession(ctx);
-		if (result.status === "started" || result.status === "already") await controller.reconcileCurrentSession(ctx);
+		if (result.status === "started" || result.status === "already") {
+			await controller.reconcileCurrentSession(ctx);
+			return;
+		}
+		if (
+			!lifecycleStartupCapability &&
+			result.status === "failed" &&
+			!extensionShuttingDown &&
+			!result.suppressExtensionError
+		)
+			throw new Error(`notifications: SDK startup failed: ${result.failure?.message ?? "Unknown startup failure."}`);
 	};
 
 	api.on("session_start", async (_event, ctx) => {

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -33,6 +33,7 @@ import { NotificationServer, nativeBuildInfo } from "@gajae-code/natives";
 import { logger, postmortem, prompt, VERSION } from "@gajae-code/utils";
 import { Settings } from "../../config/settings";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../../extensibility/extensions";
+import { toAgentWireEventPayload } from "../../modes/shared/agent-wire/event-envelope";
 import {
 	NotificationGatePolicyChangedError,
 	type WorkflowGateEmitter,
@@ -40,6 +41,7 @@ import {
 	type WorkflowGateTerminalProof,
 } from "../../modes/shared/agent-wire/workflow-gate-broker";
 import btwUserPrompt from "../../prompts/system/btw-user.md" with { type: "text" };
+import type { AgentSessionEvent } from "../../session/agent-session";
 import { parseThinkingLevel } from "../../thinking";
 import type {
 	AskAnswerRequest,
@@ -918,6 +920,8 @@ interface SessionRuntime {
 					error: { code: string; message: string };
 			  },
 	) => void;
+	/** Publishes one canonical agent-wire event to the client that owns the active prompt. */
+	emitPromptEvent: (event: AgentSessionEvent) => void;
 	/** Inbound Telegram update ids injected but not yet consumed by a turn. */
 	pendingInbound: Set<number>;
 	/** Latest assistant text of the in-flight turn (from message_update). */
@@ -3137,7 +3141,7 @@ export function createNotificationsExtension(
 			error: unknown;
 			terminal: boolean;
 			createdAt: number;
-			bufferedLifecycle: PromptLifecycleFrame[];
+			bufferedFrames: Array<PromptLifecycleFrame | Record<string, unknown>>;
 		};
 		const promptSubmissions = new Map<string, PromptSubmission>();
 		const promptTerminalTombstones = new Map<string, number>();
@@ -3169,7 +3173,7 @@ export function createNotificationsExtension(
 		};
 		const abandonPrompt = (submission: PromptSubmission) => {
 			submission.abandoned = true;
-			submission.bufferedLifecycle.length = 0;
+			submission.bufferedFrames.length = 0;
 		};
 		const emitPromptLifecycle = (
 			correlation: { commandId: string; turnId: string } | undefined,
@@ -3189,7 +3193,7 @@ export function createNotificationsExtension(
 				return;
 			}
 			if (!submission.acknowledged) {
-				submission.bufferedLifecycle.push(frame);
+				submission.bufferedFrames.push(frame);
 				return;
 			}
 			try {
@@ -3200,8 +3204,30 @@ export function createNotificationsExtension(
 			}
 			if (submission.terminal) finalizePrompt(key, correlation);
 		};
+		const emitPromptEvent = (event: AgentSessionEvent) => {
+			if (!runtime?.activePromptCorrelation) return;
+			cleanupPromptRecords();
+			const correlation = runtime.activePromptCorrelation;
+			const submission = promptSubmissions.get(promptSubmissionKey(correlation));
+			if (!submission || submission.abandoned) return;
+			const frame = runtime.host.emitEvent({
+				kind: event.type,
+				payload: toAgentWireEventPayload(event),
+				...correlation,
+			});
+			if (!submission.acknowledged) {
+				submission.bufferedFrames.push(frame);
+				return;
+			}
+			try {
+				runtime.server.sendTo(submission.connectionId, JSON.stringify(frame));
+			} catch (error) {
+				logger.warn(`sdk: correlated agent event delivery failed: ${String(error)}`);
+				abandonPrompt(submission);
+			}
+		};
 		const flushPromptLifecycle = (key: string, submission: PromptSubmission) => {
-			for (const frame of submission.bufferedLifecycle.splice(0)) {
+			for (const frame of submission.bufferedFrames.splice(0)) {
 				try {
 					server.sendTo(submission.connectionId, JSON.stringify(frame));
 				} catch (error) {
@@ -3237,7 +3263,7 @@ export function createNotificationsExtension(
 				error: undefined,
 				terminal: false,
 				createdAt: Date.now(),
-				bufferedLifecycle: [],
+				bufferedFrames: [],
 			});
 		};
 		const recordPromptTerminal = (correlation: { commandId: string; turnId: string } | undefined) => {
@@ -3519,6 +3545,7 @@ export function createNotificationsExtension(
 			activePromptCorrelation: undefined,
 			recordPromptTerminal,
 			emitPromptLifecycle,
+			emitPromptEvent,
 			pendingInbound: new Set<number>(),
 			inFlightTools: new Map<string, { toolName: string; args: unknown }>(),
 			deferredGatePresentations: [],
@@ -4849,6 +4876,7 @@ export function createNotificationsExtension(
 	api.on("message_update", (event, ctx) => {
 		const id = sessionId(ctx);
 		const rt = runtimes.get(id);
+		rt?.emitPromptEvent(event);
 		if (!rt?.notificationsActive || !rt.stream || rt.redact || rt.turnClosed) return;
 		if ((event.message as { role?: unknown }).role !== "assistant") return;
 		if (rt.liveRef === undefined && rt.turnSeq !== undefined) {
@@ -4872,6 +4900,7 @@ export function createNotificationsExtension(
 	api.on("message_end", (event, ctx) => {
 		const id = sessionId(ctx);
 		const rt = runtimes.get(id);
+		rt?.emitPromptEvent(event);
 		if (!rt?.notificationsActive || rt.redact) return;
 		// Capture the in-flight ASSISTANT text here (message_end is on the awaited
 		// extension path and ordered before tool_execution_start) so the pre-ask

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -4416,12 +4416,7 @@ export function createNotificationsExtension(
 
 	const startAndReconcileSession = async (ctx: ExtensionContext): Promise<void> => {
 		const result = await startSession(ctx);
-		if (result.status === "started" || result.status === "already") {
-			await controller.reconcileCurrentSession(ctx);
-			return;
-		}
-		if (!lifecycleStartupCapability && result.status === "failed")
-			throw new Error(`notifications: SDK startup failed: ${result.failure?.message ?? "Unknown startup failure."}`);
+		if (result.status === "started" || result.status === "already") await controller.reconcileCurrentSession(ctx);
 	};
 
 	api.on("session_start", async (_event, ctx) => {

--- a/packages/coding-agent/test/sdk-acp-production-path.test.ts
+++ b/packages/coding-agent/test/sdk-acp-production-path.test.ts
@@ -333,6 +333,42 @@ test("production ACP preserves lifecycle, turn, replay, and connection ownership
 	promptSocket!.send(JSON.stringify({ type: "activity", sessionId: created.sessionId, state: "idle" }));
 	await Bun.sleep(20);
 	expect(firstSettled).toBe(false);
+	promptSocket!.send(
+		JSON.stringify({
+			type: "event",
+			payload: {
+				event_type: "message_update",
+				event: {
+					type: "message_update",
+					message: { role: "assistant", content: [{ type: "text", text: "first" }] },
+					assistantMessageEvent: { type: "text_delta", delta: "first" },
+				},
+			},
+		}),
+	);
+	for (const text of ["first", "second"]) {
+		promptSocket!.send(
+			JSON.stringify({
+				type: "event",
+				payload: {
+					event_type: "message_end",
+					event: {
+						type: "message_end",
+						message: { role: "assistant", content: [{ type: "text", text }] },
+					},
+				},
+			}),
+		);
+	}
+	await waitFor(
+		() => updates.filter(update => update.update.sessionUpdate === "agent_message_chunk").length === 2,
+		"per-message ACP chunks",
+	);
+	expect(
+		updates
+			.filter(update => update.update.sessionUpdate === "agent_message_chunk")
+			.map(update => (update.update as { content: { text: string } }).content.text),
+	).toEqual(["first", "second"]);
 	promptSocket!.send(JSON.stringify({ type: "activity", sessionId: created.sessionId, state: "busy" }));
 	promptSocket!.send(JSON.stringify({ type: "activity", sessionId: created.sessionId, state: "idle" }));
 	expect(await bounded(firstPrompt, "first prompt completion")).toEqual({ stopReason: "end_turn" });
@@ -358,12 +394,9 @@ test("production ACP preserves lifecycle, turn, replay, and connection ownership
 		updates.filter(update => {
 			const payload = update.update as {
 				sessionUpdate?: string;
-				content?: Array<{ content?: { text?: string } }>;
+				content?: { text?: string };
 			};
-			return (
-				payload.sessionUpdate === "agent_message_chunk" &&
-				payload.content?.some(item => /failed/i.test(item.content?.text ?? ""))
-			);
+			return payload.sessionUpdate === "agent_message_chunk" && /failed/i.test(payload.content?.text ?? "");
 		}),
 	).toHaveLength(0);
 	const abortFailurePrompt = agent.prompt({

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -1363,6 +1363,14 @@ test("SDK host directly delivers correlated lifecycle frames for an accepted pro
 			),
 		"correlated assistant message event",
 	);
+	observer.send(JSON.stringify({ type: "event_replay", id: "observer-replay", sinceSeq: 0 }));
+	await waitFor(
+		() => observerFrames.some(frame => frame.type === "event_replay_result" && frame.id === "observer-replay"),
+		"observer event replay",
+	);
+	const observerReplay = observerFrames.find(
+		frame => frame.type === "event_replay_result" && frame.id === "observer-replay",
+	) as { events?: Array<Record<string, unknown>> };
 	const correlation = {
 		commandId: acknowledgement.result?.commandId,
 		turnId: acknowledgement.result?.turnId,
@@ -1375,6 +1383,7 @@ test("SDK host directly delivers correlated lifecycle frames for an accepted pro
 	]);
 	expect(observerFrames.some(frame => frame.type === "agent_start" || frame.type === "agent_end")).toBe(false);
 	expect(observerFrames.some(frame => frame.type === "event" && frame.kind === "message_update")).toBe(false);
+	expect(observerReplay.events?.some(frame => frame.kind === "message_update")).toBe(false);
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
 });
 

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -1323,6 +1323,14 @@ test("SDK host directly delivers correlated lifecycle frames for an accepted pro
 		result: { accepted: true, commandId: expect.any(String), turnId: expect.any(String) },
 	});
 	await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+	await handlers.get("message_update")?.(
+		{
+			type: "message_update",
+			message: { role: "assistant", content: [{ type: "text", text: "hi" }] },
+			assistantMessageEvent: { type: "text_delta", delta: "hi" },
+		},
+		sessionContext,
+	);
 	socket.send(
 		JSON.stringify({
 			type: "control_request",
@@ -1344,6 +1352,17 @@ test("SDK host directly delivers correlated lifecycle frames for an accepted pro
 		() => frames.some(frame => frame.type === "agent_start") && frames.some(frame => frame.type === "agent_end"),
 		"correlated accepted prompt lifecycle",
 	);
+	await waitFor(
+		() =>
+			frames.some(
+				frame =>
+					frame.type === "event" &&
+					frame.kind === "message_update" &&
+					(frame.payload as { event?: { assistantMessageEvent?: { delta?: unknown } } })?.event
+						?.assistantMessageEvent?.delta === "hi",
+			),
+		"correlated assistant message event",
+	);
 	const correlation = {
 		commandId: acknowledgement.result?.commandId,
 		turnId: acknowledgement.result?.turnId,
@@ -1355,6 +1374,7 @@ test("SDK host directly delivers correlated lifecycle frames for an accepted pro
 		expect.objectContaining({ type: "agent_end", sessionId, ...correlation }),
 	]);
 	expect(observerFrames.some(frame => frame.type === "agent_start" || frame.type === "agent_end")).toBe(false);
+	expect(observerFrames.some(frame => frame.type === "event" && frame.kind === "message_update")).toBe(false);
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
 });
 

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -504,7 +504,7 @@
     "crates/pi-natives/src/path_identity.rs": "527099aac379b2be9ffdbbd07930b875c9015c7e9e326ebb4eeb45121f668652",
     "crates/pi-natives/src/ps.rs": "3c8a28d1daf84e91c3db0d29fa05a6231b871903800428ca1acbb2ddecea5f6b",
     "crates/pi-shell/src/process.rs": "3f74458492c16fff24ecc234c74efd29d2a7f5f5c5a7c879c68b00a2e4f08274",
-    "packages/natives/native/index.d.ts": "7c8e4663d370aa125c5e41eeaf44639c420995db9014384b89d8d3031a2ba410",
+    "packages/natives/native/index.d.ts": "c31d34369e12d2c3ade0b4b24411a666b3252152d549455c5fa0cb59390d46e0",
     "packages/coding-agent/src/sdk/broker/process-incarnation.ts": "72aac66e149e8a5e411728e2e17469a7c444b252e4fd776316461b8672de68c5"
   }
 }


### PR DESCRIPTION
## Summary

- deliver canonical `message_update` and `message_end` agent-wire events to the SDK connection that owns an accepted prompt
- buffer those events behind the prompt acknowledgement boundary alongside lifecycle frames
- track ACP per-prompt message progress so terminal/done frames do not duplicate streamed deltas

## Problem

ACP 0.10.2 subscribed directly to `AgentSession` events. After the 0.11.x SDK-backed ACP migration, production session hosts delivered correlated `agent_start`/`agent_end` frames but did not deliver canonical `message_update` frames to the requesting SDK connection. `AcpAgent` therefore completed `session/prompt` at `end_turn` while its existing event mapper never received input that could produce `agent_message_chunk` notifications.

No additional ACP client capability or subscription is required; this restores the production bridge expected by the existing mapper.

## Safety

Assistant events are directed only to the connection that submitted the accepted prompt. Observer connections do not receive the live frames. Pre-ack events use the existing correlated prompt buffer.

## Verification

- `bun run check:types`
- `bun test test/sdk-host-wiring.test.ts -t 'SDK host directly delivers correlated lifecycle frames for an accepted prompt'`
- `bun test test/acp-event-mapper.test.ts`

The full `sdk-host-wiring.test.ts` run also reaches 58 passing tests locally, but three unrelated notification startup/teardown tests fail against the local native runtime; the new focused regression test passes.