### PR TITLE
Harden plugin cache deletion authority

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -12,12 +12,11 @@ import * as path from "node:path";
 
 import { isEnoent, logger, pathIsWithin } from "@gajae-code/utils";
 
-import { cachePlugin } from "./cache";
+import { cachePlugin, getCachedPluginPath } from "./cache";
 import { classifySource, fetchMarketplace, parseMarketplaceCatalog, promoteCloneToCache } from "./fetcher";
 import {
 	addInstalledPlugin,
 	addMarketplaceEntry,
-	collectReferencedPaths,
 	getInstalledPlugin,
 	getMarketplaceEntry,
 	readInstalledPluginsRegistry,
@@ -255,6 +254,7 @@ export class MarketplaceManager {
 		if (existing && existing.length > 0 && !force) {
 			throw new Error(`Plugin "${pluginId}" is already installed. Use force option to reinstall.`);
 		}
+		const existingCachePaths = existing ? await this.#validateCacheDeletionTargets(pluginId, existing) : [];
 
 		// 4. Resolve source path.
 		// marketplaceClonePath is the marketplace root — the directory containing .Anthropic model-plugin/
@@ -289,6 +289,9 @@ export class MarketplaceManager {
 		let cachePath!: string;
 		try {
 			version = await this.#resolvePluginVersion(pluginEntry, sourcePath);
+			if ([marketplace, name, version].some(component => /[. ]$/.test(component))) {
+				throw new Error(`Invalid cache identity for plugin "${pluginId}"`);
+			}
 			cachePath = await cachePlugin(sourcePath, this.#opts.pluginsCacheDir, marketplace, name, version);
 			await this.#writeEmbeddedLspConfig(pluginEntry, cachePath);
 		} finally {
@@ -311,11 +314,13 @@ export class MarketplaceManager {
 					? readInstalledPluginsRegistry(this.#opts.projectInstalledRegistryPath)
 					: Promise.resolve({ version: 2 as const, plugins: {} as Record<string, InstalledPluginEntry[]> }),
 			]);
-			const referenced = collectReferencedPaths(userReg, projectReg);
+			const referenced = this.#collectReferencedCacheIdentities(userReg, projectReg);
+			const cachePathIdentity = this.#cacheDeletionIdentity(cachePath);
 
-			for (const entry of existing) {
-				if (entry.installPath !== cachePath && !referenced.has(entry.installPath)) {
-					await fs.rm(entry.installPath, { recursive: true, force: true });
+			for (const existingCachePath of existingCachePaths) {
+				const existingIdentity = this.#cacheDeletionIdentity(existingCachePath);
+				if (existingIdentity !== cachePathIdentity && !referenced.has(existingIdentity)) {
+					await fs.rm(existingCachePath, { recursive: true, force: true });
 				}
 			}
 		}
@@ -395,6 +400,84 @@ export class MarketplaceManager {
 		return "0.0.0";
 	}
 
+	async #validateCacheDeletionTargets(pluginId: string, entries: readonly InstalledPluginEntry[]): Promise<string[]> {
+		const parsed = parsePluginId(pluginId);
+		if (!parsed) {
+			throw new Error(`Invalid plugin ID format: "${pluginId}". Expected "name@marketplace".`);
+		}
+
+		const targets: string[] = [];
+		for (const entry of entries) {
+			if ([parsed.marketplace, parsed.name, entry.version].some(component => /[. ]$/.test(component))) {
+				throw new Error(`Refusing to remove plugin "${pluginId}": invalid recorded cache identity`);
+			}
+
+			let targetPath: string;
+			try {
+				targetPath = getCachedPluginPath(
+					this.#opts.pluginsCacheDir,
+					parsed.marketplace,
+					parsed.name,
+					entry.version,
+				);
+			} catch (error) {
+				throw new Error(`Refusing to remove plugin "${pluginId}": invalid recorded cache identity`, {
+					cause: error,
+				});
+			}
+
+			if (entry.installPath !== targetPath) {
+				throw new Error(`Refusing to remove plugin "${pluginId}": recorded install path is not its cache path`);
+			}
+
+			try {
+				const stat = await fs.lstat(targetPath);
+				if (stat.isSymbolicLink()) {
+					throw new Error(`Refusing to remove plugin "${pluginId}": cache path is a symbolic link or junction`);
+				}
+			} catch (error) {
+				if (!isEnoent(error)) throw error;
+			}
+
+			targets.push(targetPath);
+		}
+		return targets;
+	}
+
+	#cacheDeletionIdentity(cachePath: string): string {
+		// Model Windows path identity on every host so reference protection is
+		// deterministic: case is ignored and trailing dots/spaces are discarded.
+		return path
+			.resolve(cachePath)
+			.split(path.sep)
+			.map(component => component.replace(/[. ]+$/, "").toLowerCase())
+			.join(path.sep);
+	}
+
+	#collectReferencedCacheIdentities(...registries: InstalledPluginsRegistry[]): Set<string> {
+		const identities = new Set<string>();
+		for (const registry of registries) {
+			for (const [pluginId, entries] of Object.entries(registry.plugins)) {
+				const parsed = parsePluginId(pluginId);
+				if (!parsed) continue;
+				for (const entry of entries) {
+					try {
+						const cachePath = getCachedPluginPath(
+							this.#opts.pluginsCacheDir,
+							parsed.marketplace,
+							parsed.name,
+							entry.version,
+						);
+						identities.add(this.#cacheDeletionIdentity(cachePath));
+					} catch {
+						// Invalid registry entries cannot identify a permitted cache target.
+					}
+				}
+			}
+		}
+		return identities;
+	}
+
 	async uninstallPlugin(pluginId: string, scope?: "user" | "project"): Promise<void> {
 		const parsed = parsePluginId(pluginId);
 		if (!parsed) {
@@ -434,6 +517,7 @@ export class MarketplaceManager {
 		const targetEntries = targetScope === "project" ? projectEntries! : userEntries!;
 		const targetReg = targetScope === "project" ? projectReg : userReg;
 		const registryPath = this.#registryPath(targetScope);
+		const targetCachePaths = await this.#validateCacheDeletionTargets(pluginId, targetEntries);
 
 		const updatedReg = removeInstalledPlugin(targetReg, pluginId);
 		await writeInstalledPluginsRegistry(registryPath, updatedReg);
@@ -445,11 +529,11 @@ export class MarketplaceManager {
 				? readInstalledPluginsRegistry(this.#opts.projectInstalledRegistryPath)
 				: Promise.resolve({ version: 2 as const, plugins: {} as Record<string, InstalledPluginEntry[]> }),
 		]);
-		const referenced = collectReferencedPaths(freshUserReg, freshProjectReg);
+		const referenced = this.#collectReferencedCacheIdentities(freshUserReg, freshProjectReg);
 
-		for (const entry of targetEntries) {
-			if (!referenced.has(entry.installPath)) {
-				await fs.rm(entry.installPath, { recursive: true, force: true });
+		for (const targetCachePath of targetCachePaths) {
+			if (!referenced.has(this.#cacheDeletionIdentity(targetCachePath))) {
+				await fs.rm(targetCachePath, { recursive: true, force: true });
 			}
 		}
 

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -20,6 +20,19 @@ interface TestContext {
 	clearCount: () => number;
 }
 
+const TEST_PLUGIN_ID = "hello-plugin@test-marketplace";
+
+async function overwriteInstalledEntry(
+	ctx: TestContext,
+	patch: { installPath?: string; version?: string },
+): Promise<string> {
+	const registryPath = path.join(ctx.tmpDir, "installed_plugins.json");
+	const registry = await readInstalledPluginsRegistry(registryPath);
+	Object.assign(registry.plugins[TEST_PLUGIN_ID]![0], patch);
+	await Bun.write(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+	return registryPath;
+}
+
 function createTestContext(): TestContext {
 	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-mgr-test-"));
 
@@ -227,6 +240,40 @@ describe("MarketplaceManager", () => {
 		expect(installed).toHaveLength(1);
 	});
 
+	it("installPlugin with force:true rejects an external registry path without changing the registry", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+		const externalDir = path.join(ctx.tmpDir, "outside-cache");
+		const sentinelPath = path.join(externalDir, "sentinel.txt");
+		await fs.promises.mkdir(externalDir);
+		await Bun.write(sentinelPath, "keep");
+		const registryPath = await overwriteInstalledEntry(ctx, { installPath: externalDir });
+		const registryBefore = await Bun.file(registryPath).text();
+
+		await expect(ctx.manager.installPlugin("hello-plugin", "test-marketplace", { force: true })).rejects.toThrow(
+			/recorded install path is not its cache path/,
+		);
+
+		expect(await Bun.file(sentinelPath).text()).toBe("keep");
+		expect(await Bun.file(registryPath).text()).toBe(registryBefore);
+	});
+
+	it("installPlugin rejects a version with Windows-lossy trailing punctuation", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		const [marketplace] = await ctx.manager.listMarketplaces();
+		const catalog = (await Bun.file(marketplace.catalogPath).json()) as {
+			plugins: Array<Record<string, unknown>>;
+		};
+		catalog.plugins[0] = { ...catalog.plugins[0], version: "1.0.0." };
+		await Bun.write(marketplace.catalogPath, `${JSON.stringify(catalog, null, 2)}\n`);
+
+		await expect(ctx.manager.installPlugin("hello-plugin", "test-marketplace")).rejects.toThrow(
+			/Invalid cache identity/,
+		);
+		const registry = await readInstalledPluginsRegistry(path.join(ctx.tmpDir, "installed_plugins.json"));
+		expect(registry.plugins).toEqual({});
+	});
+
 	it("installPlugin with nonexistent marketplace → clear error", async () => {
 		await expect(ctx.manager.installPlugin("hello-plugin", "no-such-market")).rejects.toThrow(
 			/Marketplace "no-such-market" not found/,
@@ -260,6 +307,85 @@ describe("MarketplaceManager", () => {
 
 	it("uninstallPlugin with invalid ID format → throws clear error", async () => {
 		await expect(ctx.manager.uninstallPlugin("no-at-sign")).rejects.toThrow(/Invalid plugin ID format/);
+	});
+
+	it("uninstallPlugin rejects an external registry path without deleting it or deregistering", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+		const externalDir = path.join(ctx.tmpDir, "outside-cache");
+		const sentinelPath = path.join(externalDir, "sentinel.txt");
+		await fs.promises.mkdir(externalDir);
+		await Bun.write(sentinelPath, "keep");
+		const registryPath = await overwriteInstalledEntry(ctx, { installPath: externalDir });
+		const registryBefore = await Bun.file(registryPath).text();
+
+		await expect(ctx.manager.uninstallPlugin(TEST_PLUGIN_ID)).rejects.toThrow(
+			/recorded install path is not its cache path/,
+		);
+
+		expect(await Bun.file(sentinelPath).text()).toBe("keep");
+		expect(await Bun.file(registryPath).text()).toBe(registryBefore);
+	});
+
+	it("uninstallPlugin rejects an aliased cache path", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		const entry = await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+		const cacheDir = path.dirname(entry.installPath);
+		const aliasedPath = `${cacheDir}${path.sep}..${path.sep}plugins${path.sep}${path.basename(entry.installPath)}`;
+		const registryPath = await overwriteInstalledEntry(ctx, { installPath: aliasedPath });
+		const registryBefore = await Bun.file(registryPath).text();
+
+		await expect(ctx.manager.uninstallPlugin(TEST_PLUGIN_ID)).rejects.toThrow(
+			/recorded install path is not its cache path/,
+		);
+
+		expect(fs.existsSync(entry.installPath)).toBe(true);
+		expect(await Bun.file(registryPath).text()).toBe(registryBefore);
+	});
+
+	it("uninstallPlugin rejects a malformed recorded version", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		const entry = await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+		const registryPath = await overwriteInstalledEntry(ctx, { version: "../outside" });
+		const registryBefore = await Bun.file(registryPath).text();
+
+		await expect(ctx.manager.uninstallPlugin(TEST_PLUGIN_ID)).rejects.toThrow(/invalid recorded cache identity/);
+
+		expect(fs.existsSync(entry.installPath)).toBe(true);
+		expect(await Bun.file(registryPath).text()).toBe(registryBefore);
+	});
+
+	it("uninstallPlugin rejects a version with Windows-lossy trailing punctuation", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		const entry = await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+		const registryPath = await overwriteInstalledEntry(ctx, {
+			installPath: `${entry.installPath}.`,
+			version: `${entry.version}.`,
+		});
+		const registryBefore = await Bun.file(registryPath).text();
+
+		await expect(ctx.manager.uninstallPlugin(TEST_PLUGIN_ID)).rejects.toThrow(/invalid recorded cache identity/);
+
+		expect(fs.existsSync(entry.installPath)).toBe(true);
+		expect(await Bun.file(registryPath).text()).toBe(registryBefore);
+	});
+
+	it("uninstallPlugin rejects a symbolic-link or junction cache entry", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		const entry = await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+		const externalDir = path.join(ctx.tmpDir, "outside-cache");
+		const sentinelPath = path.join(externalDir, "sentinel.txt");
+		await fs.promises.mkdir(externalDir);
+		await Bun.write(sentinelPath, "keep");
+		fs.rmSync(entry.installPath, { recursive: true, force: true });
+		fs.symlinkSync(externalDir, entry.installPath, process.platform === "win32" ? "junction" : "dir");
+		const registryPath = path.join(ctx.tmpDir, "installed_plugins.json");
+		const registryBefore = await Bun.file(registryPath).text();
+
+		await expect(ctx.manager.uninstallPlugin(TEST_PLUGIN_ID)).rejects.toThrow(/symbolic link or junction/);
+
+		expect(await Bun.file(sentinelPath).text()).toBe("keep");
+		expect(await Bun.file(registryPath).text()).toBe(registryBefore);
 	});
 
 	// ── setPluginEnabled ───────────────────────────────────────────────────
@@ -373,6 +499,40 @@ describe("MarketplaceManager", () => {
 
 		// Cache must still exist — project scope still references it.
 		expect(fs.existsSync(userEntry.installPath)).toBe(true);
+	});
+
+	it("uninstallPlugin preserves a shared cache referenced by a case-variant version", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		const userEntry = await ctx.manager.installPlugin("hello-plugin", "test-marketplace", { scope: "user" });
+		const uppercasePath = `${userEntry.installPath}-RC`;
+		const lowercasePath = `${userEntry.installPath}-rc`;
+		fs.renameSync(userEntry.installPath, uppercasePath);
+		await overwriteInstalledEntry(ctx, { installPath: uppercasePath, version: "1.0.0-RC" });
+
+		const projectRegistryPath = path.join(ctx.tmpDir, "project_installed_plugins.json");
+		await Bun.write(
+			projectRegistryPath,
+			`${JSON.stringify(
+				{
+					version: 2,
+					plugins: {
+						[TEST_PLUGIN_ID]: [
+							{ ...userEntry, scope: "project", installPath: lowercasePath, version: "1.0.0-rc" },
+						],
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+
+		await ctx.manager.uninstallPlugin(TEST_PLUGIN_ID, "user");
+
+		expect(fs.existsSync(uppercasePath)).toBe(true);
+		const userRegistry = await readInstalledPluginsRegistry(path.join(ctx.tmpDir, "installed_plugins.json"));
+		expect(userRegistry.plugins[TEST_PLUGIN_ID]).toBeUndefined();
+		const projectRegistry = await readInstalledPluginsRegistry(projectRegistryPath);
+		expect(projectRegistry.plugins[TEST_PLUGIN_ID]).toHaveLength(1);
 	});
 
 	it("setPluginEnabled with plugin in both scopes, no scope arg → throws disambiguation error", async () => {
@@ -499,6 +659,25 @@ describe("MarketplaceManager", () => {
 			const installed = await ctx.manager.listInstalledPlugins();
 			expect(installed).toHaveLength(1);
 			expect(installed[0].entries[0].version).toBe("2.0.0");
+		});
+
+		it("upgradePlugin rejects an external registry path without changing the registry", async () => {
+			await ctx.manager.addMarketplace(FIXTURE_DIR);
+			await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+			const externalDir = path.join(ctx.tmpDir, "outside-cache");
+			const sentinelPath = path.join(externalDir, "sentinel.txt");
+			await fs.promises.mkdir(externalDir);
+			await Bun.write(sentinelPath, "keep");
+			const registryPath = await overwriteInstalledEntry(ctx, { installPath: externalDir });
+			const registryBefore = await Bun.file(registryPath).text();
+			await bumpCatalogVersion("2.0.0");
+
+			await expect(ctx.manager.upgradePlugin(TEST_PLUGIN_ID)).rejects.toThrow(
+				/recorded install path is not its cache path/,
+			);
+
+			expect(await Bun.file(sentinelPath).text()).toBe("keep");
+			expect(await Bun.file(registryPath).text()).toBe(registryBefore);
 		});
 
 		it("upgradePlugin rejects invalid plugin ID", async () => {


### PR DESCRIPTION
## Summary

- Reconstruct plugin deletion targets from the configured cache root and validated plugin identity.
- Reject mismatched or unsafe registry entries before registry mutation or filesystem deletion.
- Preserve shared cache entries using Windows-equivalent identity comparison.

## Scope

This PR addresses one security finding in the marketplace plugin cache lifecycle. It contains no unrelated behavior changes.

## Tests

- bun test packages/coding-agent/test/marketplace/manager.test.ts — 50 passed
- bun run --cwd packages/coding-agent check — Biome checked 2,266 files; TypeScript noEmit passed
- bun run check:plugins — all 16 plugin gates passed
- git diff --cached --check — passed

## Validation gap

- Real Windows CI was not run locally.