### PR TITLE
Refresh Telegram native authority manifest

### DIFF
--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -504,7 +504,7 @@
     "crates/pi-natives/src/path_identity.rs": "527099aac379b2be9ffdbbd07930b875c9015c7e9e326ebb4eeb45121f668652",
     "crates/pi-natives/src/ps.rs": "3c8a28d1daf84e91c3db0d29fa05a6231b871903800428ca1acbb2ddecea5f6b",
     "crates/pi-shell/src/process.rs": "3f74458492c16fff24ecc234c74efd29d2a7f5f5c5a7c879c68b00a2e4f08274",
-    "packages/natives/native/index.d.ts": "7c8e4663d370aa125c5e41eeaf44639c420995db9014384b89d8d3031a2ba410",
+    "packages/natives/native/index.d.ts": "c31d34369e12d2c3ade0b4b24411a666b3252152d549455c5fa0cb59390d46e0",
     "packages/coding-agent/src/sdk/broker/process-incarnation.ts": "72aac66e149e8a5e411728e2e17469a7c444b252e4fd776316461b8672de68c5"
   }
 }


### PR DESCRIPTION
## Summary

- Refresh the generated native-authority digest for packages/natives/native/index.d.ts after upstream commit 97ffd0d90 regenerated that declaration.
- Keep the guard contract, protected inventory, declaration digests, and daemon generations unchanged.
- Restore current-tree validation so the shared Telegram generation guard no longer blocks current-dev pull request CI.

## Scope

This is a maintenance synchronization of one generated manifest field. It does not change product behavior, guard policy, or security semantics.

## Tests

- bun scripts/telegram-daemon-generation-guard.ts --validate-current-tree — passed
- bun test scripts/telegram-daemon-generation-guard.test.ts — 32 passed
- Policy, inventory, and declaration digest hash matched base: e6a78e5e8d68731451ae7083a506e97166f9dc76d8fad734e2e432121ff075e3
- Manifest content excluding the refreshed digest matched base: f678c77e9cc541038e59477a71ecea2b6010ab69e4a31352eb57ba98defe1f3
- git diff --cached --check — passed

## Validation gap

- The full repository suite was not run because this PR refreshes one generated attestation only.