### PR TITLE
fix(stats): serve compiled dashboard assets from memory

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Compiled dashboard assets now remain in a validated in-memory archive map instead of being materialized in a predictable shared temporary cache.
+
 ## [0.5.1] - 2026-06-14
 
 - Version aligned with the 0.5.1 monorepo release; no functional changes in this package.

--- a/packages/stats/scripts/generate-client-bundle.ts
+++ b/packages/stats/scripts/generate-client-bundle.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import * as fs from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
 import { $ } from "bun";
 
@@ -45,17 +44,8 @@ async function buildArchiveBase64(dir: string): Promise<string> {
 		entries[relativePath] = await fs.readFile(filePath);
 	}
 
-	const tempArchivePath = path.join(
-		os.tmpdir(),
-		`gjc-stats-client-${Bun.hash(Date.now().toString() + Math.random().toString(16)).toString(16)}.tar.gz`,
-	);
-	try {
-		await Bun.Archive.write(tempArchivePath, entries, { compress: "gzip" });
-		const archiveBytes = await Bun.file(tempArchivePath).bytes();
-		return Buffer.from(archiveBytes).toString("base64");
-	} finally {
-		await fs.rm(tempArchivePath, { force: true });
-	}
+	const archiveBytes = await new Bun.Archive(entries, { compress: "gzip" }).bytes();
+	return Buffer.from(archiveBytes).toString("base64");
 }
 
 async function main(): Promise<void> {

--- a/packages/stats/src/compiled-client-assets.ts
+++ b/packages/stats/src/compiled-client-assets.ts
@@ -1,0 +1,96 @@
+import * as path from "node:path";
+
+const INDEX_ASSET = "index.html";
+const UNSAFE_ARCHIVE_NAME = /[\u0000-\u001f\u007f%?#]/u;
+const WINDOWS_ABSOLUTE_PATH = /^[a-zA-Z]:\//;
+
+const CONTENT_TYPES: Readonly<Record<string, string>> = Object.freeze({
+	".css": "text/css; charset=utf-8",
+	".gif": "image/gif",
+	".html": "text/html; charset=utf-8",
+	".ico": "image/x-icon",
+	".jpeg": "image/jpeg",
+	".jpg": "image/jpeg",
+	".js": "text/javascript; charset=utf-8",
+	".json": "application/json; charset=utf-8",
+	".map": "application/json; charset=utf-8",
+	".png": "image/png",
+	".svg": "image/svg+xml",
+	".ttf": "font/ttf",
+	".webp": "image/webp",
+	".woff": "font/woff",
+	".woff2": "font/woff2",
+});
+
+function normalizeArchiveName(archiveName: string): string {
+	const normalized = archiveName.normalize("NFC");
+	const segments = normalized.split("/");
+	if (
+		!normalized ||
+		normalized.startsWith("/") ||
+		WINDOWS_ABSOLUTE_PATH.test(normalized) ||
+		normalized.includes("\\") ||
+		UNSAFE_ARCHIVE_NAME.test(normalized) ||
+		segments.some(segment => !segment || segment === "." || segment === "..")
+	) {
+		throw new Error(`Unsafe compiled stats client archive entry: ${JSON.stringify(archiveName)}`);
+	}
+	return normalized;
+}
+
+function contentType(assetName: string): string {
+	return CONTENT_TYPES[path.posix.extname(assetName).toLowerCase()] ?? "application/octet-stream";
+}
+
+async function parseArchive(archiveBytes: Uint8Array): Promise<ReadonlyMap<string, Blob>> {
+	const files = await new Bun.Archive(archiveBytes).files();
+	const assets = new Map<string, Blob>();
+	for (const [archiveName, file] of files) {
+		const assetName = normalizeArchiveName(archiveName);
+		if (assets.has(assetName)) {
+			throw new Error(`Duplicate compiled stats client archive entry: ${JSON.stringify(assetName)}`);
+		}
+		assets.set(assetName, new Blob([file], { type: contentType(assetName) }));
+	}
+	if (!assets.has(INDEX_ASSET)) {
+		throw new Error("Compiled stats client archive is missing index.html");
+	}
+	return assets;
+}
+
+function responseForPath(assets: ReadonlyMap<string, Blob>, requestPath: string): Response {
+	const assetName = requestPath === "/" ? INDEX_ASSET : requestPath.replace(/^\//, "");
+	const asset = assets.get(assetName);
+	if (asset) return new Response(asset);
+	return new Response(assets.get(INDEX_ASSET));
+}
+
+export function createCompiledClientAssetHandler(
+	loadArchiveBytes: () => Uint8Array | null | Promise<Uint8Array | null>,
+): { response(requestPath: string): Promise<Response> } {
+	let initialization: Promise<ReadonlyMap<string, Blob>> | null = null;
+
+	async function getAssets(): Promise<ReadonlyMap<string, Blob>> {
+		if (initialization) return await initialization;
+		const attempt = (async () => {
+			const archiveBytes = await loadArchiveBytes();
+			if (!archiveBytes) {
+				throw new Error("Compiled stats client bundle missing. Rebuild binary with embedded stats assets.");
+			}
+			return await parseArchive(archiveBytes);
+		})();
+		initialization = attempt;
+		try {
+			return await attempt;
+		} catch (error) {
+			if (initialization === attempt) initialization = null;
+			throw error;
+		}
+	}
+
+	return {
+		async response(requestPath) {
+			return responseForPath(await getAssets(), requestPath);
+		},
+	};
+}

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -1,5 +1,4 @@
 import * as fs from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
 import { $ } from "bun";
 import {
@@ -14,6 +13,7 @@ import {
 	getTotalMessageCount,
 	syncAllSessions,
 } from "./aggregator";
+import { createCompiledClientAssetHandler } from "./compiled-client-assets";
 import embeddedClientArchiveTxt from "./embedded-client.generated.txt";
 
 const getEmbeddedClientArchive = (() => {
@@ -29,59 +29,7 @@ const IS_BUN_COMPILED =
 	import.meta.url.includes("$bunfs") ||
 	import.meta.url.includes("~BUN") ||
 	import.meta.url.includes("%7EBUN");
-
-const COMPILED_CLIENT_DIR_ROOT = path.join(os.tmpdir(), "gjc-stats-client");
-let compiledClientDirPromise: Promise<string> | null = null;
-
-function sanitizeArchivePath(archivePath: string): string | null {
-	const normalized = archivePath.replaceAll("\\", "/").replace(/^\.\//, "");
-	if (!normalized || normalized === ".") return null;
-	if (normalized.includes("..") || path.isAbsolute(normalized)) return null;
-	return normalized;
-}
-
-async function extractEmbeddedClientArchive(archiveBytes: Buffer, outputDir: string): Promise<void> {
-	const archive = new Bun.Archive(archiveBytes);
-	const files = await archive.files();
-	const extractRoot = path.resolve(outputDir);
-
-	for (const [archivePath, file] of files) {
-		const sanitizedPath = sanitizeArchivePath(archivePath);
-		if (!sanitizedPath) continue;
-		const destinationPath = path.resolve(extractRoot, sanitizedPath);
-		if (!destinationPath.startsWith(extractRoot + path.sep)) {
-			throw new Error(`Archive entry escapes extraction directory: ${archivePath}`);
-		}
-		await Bun.write(destinationPath, file);
-	}
-}
-
-async function getCompiledClientDir(): Promise<string> {
-	if (!IS_BUN_COMPILED) return STATIC_DIR;
-	if (compiledClientDirPromise) return compiledClientDirPromise;
-
-	const archiveBytes = getEmbeddedClientArchive?.();
-	if (!archiveBytes) {
-		throw new Error("Compiled stats client bundle missing. Rebuild binary with embedded stats assets.");
-	}
-
-	compiledClientDirPromise = (async () => {
-		const bundleHash = Bun.hash(archiveBytes).toString(16);
-		const outputDir = path.join(COMPILED_CLIENT_DIR_ROOT, bundleHash);
-		const markerPath = path.join(outputDir, "index.html");
-		try {
-			const marker = await fs.stat(markerPath);
-			if (marker.isFile()) return outputDir;
-		} catch {}
-
-		await fs.rm(outputDir, { recursive: true, force: true });
-		await fs.mkdir(outputDir, { recursive: true });
-		await extractEmbeddedClientArchive(archiveBytes, outputDir);
-		return outputDir;
-	})();
-
-	return compiledClientDirPromise;
-}
+const compiledClientAssets = createCompiledClientAssetHandler(() => getEmbeddedClientArchive?.() ?? null);
 
 async function getLatestMtime(dir: string): Promise<number> {
 	const entries = await fs.readdir(dir, { withFileTypes: true });
@@ -247,9 +195,10 @@ async function handleApi(req: Request): Promise<Response> {
  * Handle static file requests.
  */
 async function handleStatic(requestPath: string): Promise<Response> {
-	const staticDir = IS_BUN_COMPILED ? await getCompiledClientDir() : STATIC_DIR;
+	if (IS_BUN_COMPILED) return await compiledClientAssets.response(requestPath);
+
 	const filePath = requestPath === "/" ? "/index.html" : requestPath;
-	const fullPath = path.join(staticDir, filePath);
+	const fullPath = path.join(STATIC_DIR, filePath);
 
 	const file = Bun.file(fullPath);
 	if (await file.exists()) {
@@ -257,7 +206,7 @@ async function handleStatic(requestPath: string): Promise<Response> {
 	}
 
 	// SPA fallback
-	const index = Bun.file(path.join(staticDir, "index.html"));
+	const index = Bun.file(path.join(STATIC_DIR, "index.html"));
 	if (await index.exists()) {
 		return new Response(index);
 	}

--- a/packages/stats/test/compiled-client-assets.test.ts
+++ b/packages/stats/test/compiled-client-assets.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createCompiledClientAssetHandler } from "../src/compiled-client-assets";
+
+async function archiveBytes(entries: Record<string, string>): Promise<Uint8Array> {
+	return await new Bun.Archive(entries, { compress: "gzip" }).bytes();
+}
+
+describe("compiled stats client assets", () => {
+	it("serves trusted assets from memory with MIME types and SPA routing", async () => {
+		const bytes = await archiveBytes({
+			"index.html": "<main>dashboard</main>",
+			"index.js": "export const ready = true;",
+			"styles.css": "main { display: block; }",
+			"asset.data": "opaque",
+		});
+		const handler = createCompiledClientAssetHandler(() => bytes);
+
+		const html = await handler.response("/");
+		expect(html.status).toBe(200);
+		expect(html.headers.get("content-type")).toBe("text/html; charset=utf-8");
+		expect(await html.text()).toBe("<main>dashboard</main>");
+		expect((await handler.response("/index.js")).headers.get("content-type")).toBe("text/javascript; charset=utf-8");
+		expect((await handler.response("/styles.css")).headers.get("content-type")).toBe("text/css; charset=utf-8");
+		expect((await handler.response("/asset.data")).headers.get("content-type")).toBe("application/octet-stream");
+		expect(await (await handler.response("/requests/42")).text()).toBe("<main>dashboard</main>");
+		expect(await (await handler.response("/missing.js")).text()).toBe("<main>dashboard</main>");
+	});
+
+	it("fails closed for unsafe, duplicate, or incomplete archives", async () => {
+		for (const unsafeName of [
+			"/absolute.js",
+			"C:/absolute.js",
+			"assets\\app.js",
+			"../escape.js",
+			"assets/./app.js",
+			"assets//app.js",
+			"encoded%2fpath.js",
+			"control\u0001.js",
+		]) {
+			const handler = createCompiledClientAssetHandler(() =>
+				archiveBytes({ "index.html": "ok", [unsafeName]: "unsafe" }),
+			);
+			await expect(handler.response("/")).rejects.toThrow("Unsafe compiled stats client archive entry");
+		}
+
+		const duplicateAlias = createCompiledClientAssetHandler(() =>
+			archiveBytes({ "index.html": "one", "./index.html": "two" }),
+		);
+		await expect(duplicateAlias.response("/")).rejects.toThrow("Unsafe compiled stats client archive entry");
+
+		const missingIndex = createCompiledClientAssetHandler(() => archiveBytes({ "index.js": "missing html" }));
+		await expect(missingIndex.response("/")).rejects.toThrow("missing index.html");
+	});
+
+	it("coalesces concurrent initialization and retries after rejection", async () => {
+		const bytes = await archiveBytes({ "index.html": "ready" });
+		const gate = Promise.withResolvers<void>();
+		let loads = 0;
+		const concurrent = createCompiledClientAssetHandler(async () => {
+			loads += 1;
+			await gate.promise;
+			return bytes;
+		});
+		const first = concurrent.response("/");
+		const second = concurrent.response("/route");
+		expect(loads).toBe(1);
+		gate.resolve();
+		expect(
+			await Promise.all([first.then(response => response.text()), second.then(response => response.text())]),
+		).toEqual(["ready", "ready"]);
+
+		let attempts = 0;
+		const retrying = createCompiledClientAssetHandler(() => {
+			attempts += 1;
+			return attempts === 1 ? null : bytes;
+		});
+		await expect(retrying.response("/")).rejects.toThrow("bundle missing");
+		expect(await (await retrying.response("/")).text()).toBe("ready");
+		expect(attempts).toBe(2);
+	});
+
+	it("never references or mutates a legacy deterministic cache path", async () => {
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-stats-assets-test-"));
+		try {
+			const legacyTarget = path.join(tempRoot, "legacy-target");
+			const legacyPath = path.join(tempRoot, "gjc-stats-client");
+			await fs.mkdir(legacyTarget);
+			await Bun.write(path.join(legacyTarget, "sentinel"), "untouched");
+			await fs.symlink(legacyTarget, legacyPath, "dir");
+			const handler = createCompiledClientAssetHandler(() => archiveBytes({ "index.html": "memory only" }));
+
+			expect(await (await handler.response("/")).text()).toBe("memory only");
+			expect((await fs.lstat(legacyPath)).isSymbolicLink()).toBe(true);
+			expect(await Bun.file(path.join(legacyTarget, "sentinel")).text()).toBe("untouched");
+		} finally {
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

The compiled stats server previously materialized its embedded dashboard archive beneath a shared temporary filesystem location. This change validates archive entry names, loads the dashboard into an in-memory asset map, and serves compiled requests directly from that map. The bundle generator likewise creates its archive bytes in memory.

- eliminate the cross-process filesystem boundary from compiled dashboard serving
- preserve MIME types and SPA fallback routing
- fail closed on unsafe, duplicate, or incomplete archive entries
- coalesce archive initialization and retry after failed initialization
- leave build scripts, the checked-in generated placeholder, native outputs, and package manifests unchanged

## Verification

- focused `compiled-client-assets` suite — 4 passed, 0 failed
- all stats tests — 37 passed, 0 failed
- `bun run --cwd packages/stats check` — Biome and both TypeScript configurations passed
- `bun run check:public-sync` — passed
- generator `--generate` produced a 289,276-byte embedded payload; canonical `--reset` restored the exact original placeholder hash
- `git diff --cached --check` — passed before commit

## Known boundaries

- No end-to-end HTTP smoke was run through a compiled dashboard binary.
- Exact gzip bytes remain mtime-dependent, which is a pre-existing generator property; archive content and reset cleanliness were verified.