### PR TITLE
fix(ai): disable tool strict mode for DeepSeek models

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1246,7 +1246,7 @@ function buildParams(
 	}
 
 	if (context.tools?.length) {
-		const builtTools = convertTools(context.tools, compat, toolStrictModeOverride);
+		const builtTools = convertTools(context.tools, compat, model, toolStrictModeOverride);
 		params.tools = builtTools.tools;
 		toolStrictMode = builtTools.toolStrictMode;
 	} else if (context.tools === undefined && hasToolHistory(context.messages)) {
@@ -1897,14 +1897,15 @@ export function convertMessages(
 
 	return params;
 }
-
 function convertTools(
 	tools: Tool[],
 	compat: ResolvedOpenAICompat,
+	model: Model<"openai-completions">,
 	toolStrictModeOverride?: ToolStrictModeOverride,
 ): BuiltOpenAICompletionTools {
+	const isDeepseek = /deepseek/i.test(model.id);
 	const adaptedTools = tools.map(tool => {
-		const strict = !NO_STRICT && compat.supportsStrictMode !== false && tool.strict !== false;
+		const strict = !NO_STRICT && compat.supportsStrictMode !== false && tool.strict !== false && !isDeepseek;
 		const baseParameters = flattenToolRootCombinators(toolWireSchema(tool));
 		const adapted = adaptSchemaForStrict(baseParameters, strict);
 		return {

--- a/packages/ai/test/deepseek-strict-mode.test.ts
+++ b/packages/ai/test/deepseek-strict-mode.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// DeepSeek model-family detection (used by convertTools in openai-completions.ts)
+// ---------------------------------------------------------------------------
+
+const isDeepseek = (modelId: string): boolean => /deepseek/i.test(modelId);
+
+describe("DeepSeek model-family detection", () => {
+	it("matches deepseek/deepseek-v4-pro via OpenRouter", () => {
+		expect(isDeepseek("deepseek/deepseek-v4-pro")).toBe(true);
+	});
+
+	it("matches deepseek/deepseek-v4-flash via OpenRouter", () => {
+		expect(isDeepseek("deepseek/deepseek-v4-flash")).toBe(true);
+	});
+
+	it("matches deepseek-reasoner via direct API", () => {
+		expect(isDeepseek("deepseek-reasoner")).toBe(true);
+	});
+
+	it("matches deepseek-chat via direct API", () => {
+		expect(isDeepseek("deepseek-chat")).toBe(true);
+	});
+
+	it("matches case-insensitively (DeepSeek)", () => {
+		expect(isDeepseek("DeepSeek/deepseek-v4-pro")).toBe(true);
+	});
+
+	it("does NOT match claude-sonnet", () => {
+		expect(isDeepseek("anthropic/claude-sonnet-4-20250514")).toBe(false);
+	});
+
+	it("does NOT match gpt-5", () => {
+		expect(isDeepseek("openai/gpt-5")).toBe(false);
+	});
+
+	it("does NOT match empty string", () => {
+		expect(isDeepseek("")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem

DeepSeek V4 (via OpenRouter) rejects `strict: true` on function tool definitions with a 400 error:

```
"An object with no properties is not allowed."
```

This is triggered even when the tool parameter schema is valid JSON Schema draft 2020-12. The rejection is specific to the `strict` field -- without it, DeepSeek V4 accepts the same schemas.

The issue breaks `gjc -p`, `gjc auth status`, and any coordinator/MCP usage with DeepSeek models via OpenRouter Chat Completions.

## Fix

**1 file, 4 lines changed**: `packages/ai/src/providers/openai-completions.ts`

Add a model-family guard in `convertTools` that disables strict mode for any model whose ID matches `/deepseek/i`.

This covers:
- `deepseek/deepseek-v4-pro`
- `deepseek/deepseek-v4-flash`
- Any future DeepSeek model reachable via OpenRouter or direct API

## Design decisions (per maintainer feedback on #2752)

- **Single boundary**: Only `openai-completions.ts` (`convertTools`)
- **Single concern**: Disable `strict` for DeepSeek only -- no schema normalization
- **Provider-family scoped**: `isDeepseek` guard via model ID regex
- **No strict mode detection changes**: `supportsStrictMode` stays as-is in `openai-completions-compat.ts`

No schema normalization or other boundary changes are needed because the provider-agnostic tool schemas are already valid JSON Schema draft 2020-12.

## Verification

- `gjc auth status` with `deepseek/deepseek-v4-pro` -- no more 400 errors
- `gjc -p` with `deepseek/deepseek-v4-pro` -- works (was 400)
- No `PI_NO_STRICT` env var needed
- No `models.yml` config needed
- No side effects on other providers (DeepSeek-only guard)
