### PR TITLE
fix(coding-agent): preserve caller MCP reuse in children

### DIFF
--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1752,17 +1752,20 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// product decision holds for subagent sessions too.
 			const singleton = MCPManager.instance();
 			const inherited = mcpManager ?? (singleton?.isToolsOnly() ? undefined : singleton);
-			const pluginServers = inherited ? pluginMcpManagerServers.get(inherited) : undefined;
-			if (inherited && pluginServers) {
+			if (inherited) {
 				try {
-					const inheritedTools = inherited.getTools().filter(tool => {
-						const serverName = tool.mcpServerName;
-						return serverName !== undefined && pluginServers.has(serverName);
-					});
+					const inheritedTools = inherited.getTools();
 					if (inheritedTools.length > 0) customTools.push(...(inheritedTools as CustomTool[]));
-					pluginMcpToolNames.push(...inheritedTools.map(tool => tool.name));
+					const pluginServers = pluginMcpManagerServers.get(inherited);
+					if (pluginServers) {
+						pluginMcpToolNames.push(
+							...inheritedTools
+								.filter(tool => tool.mcpServerName !== undefined && pluginServers.has(tool.mcpServerName))
+								.map(tool => tool.name),
+						);
+					}
 				} catch (error) {
-					logger.warn("Failed to inherit plugin MCP tools in subagent", { error });
+					logger.warn("Failed to inherit MCP tools in subagent", { error });
 				}
 			}
 		}

--- a/packages/coding-agent/test/gjc-plugin-mcp-session.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-mcp-session.test.ts
@@ -238,7 +238,12 @@ describe("always-on plugin-bundle MCP in a live session", () => {
 			mcpManager: callerManager,
 		});
 		try {
-			expect(child.session.getAllToolNames()).not.toContain("mcp__domain_docs_lookup");
+			expect(child.session.getAllToolNames()).toContain("mcp__domain_docs_lookup");
+			expect(child.session.getActiveToolNames()).not.toContain("mcp__domain_docs_lookup");
+			expect(callerManager.isConnectionSetSealed()).toBe(false);
+			await child.session.setActiveToolsByName(["mcp__domain_docs_lookup"]);
+			expect(child.session.getActiveToolNames()).toContain("mcp__domain_docs_lookup");
+			await child.session.setActiveToolsByName([]);
 			expect(child.session.getActiveToolNames()).not.toContain("mcp__domain_docs_lookup");
 			expect(child.mcpManager).toBe(callerManager);
 		} finally {


### PR DESCRIPTION
## Summary
- preserve normal singleton/caller-owned MCP manager tool catalog reuse in canonical child sessions
- keep those generic/caller tools non-mandatory and explicitly deselectable
- retain the merged #2727 module-private plugin authority boundary, sealed plugin manager, spoof rejection, and mandatory always-on lifecycle behavior

Refs #2692
Refs #2733
Refs #2739

## Replacement Dev CI diagnosis
Run 29755287152 at merged dev `b99621eabed4cadb4ad751f3ccca492799826b9f` failed only shard 4 because canonical child sessions no longer registered normal caller MCP tools. Exact failures:
- `preserves normal MCP singleton fallback in canonical sub-session shapes`
- `preserves caller-owned normal MCP manager reuse in canonical sub-session shapes`

The follow-up separates catalog inheritance from mandatory privilege: all inherited manager tools remain registered; only managers authenticated by #2727's module-private authority contribute mandatory names. Hostile caller-owned `gjc-plugins`/`custom` metadata cases prove the same canonical tool can be active normally, can be explicitly deselected, is not sealed, and is never promoted mandatory.

## Verification
- `sdk-mcp-discovery.test.ts`: 29 passed
- coding-agent check/types: passed
- coding-agent build: passed
- root `ci:check:full`: passed
- root build: passed
- local live plugin MCP subprocess suite remains host-environment-sensitive; exact hosted focused CI is the authoritative process surface

No assertion weakening, timeout change, main, release, or publish scope.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*