### PR TITLE
fix(ai): disable tool strict mode for DeepSeek models via OpenRouter

### DIFF
--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -244,7 +244,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		requiresAssistantContentForToolCalls: isKimiModel || isDirectDeepseekReasoning,
 		openRouterRouting: undefined,
 		vercelGatewayRouting: undefined,
-		supportsStrictMode: detectStrictModeSupport(provider, baseUrl),
+		supportsStrictMode: detectStrictModeSupport(provider, baseUrl) && !(isDeepseekFamily && isOpenRouter),
 		extraBody: isDirectDeepseekReasoning ? { thinking: { type: "enabled" } } : undefined,
 		toolStrictMode: isCerebras ? "all_strict" : "mixed",
 	};

--- a/packages/ai/test/deepseek-compat-strict.test.ts
+++ b/packages/ai/test/deepseek-compat-strict.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { resolveOpenAICompat } from "../src/providers/openai-completions-compat";
+import type { Model } from "../src/types";
+
+describe("DeepSeek strict mode via OpenRouter (compat boundary)", () => {
+	function model(provider: string, id: string, baseUrl: string): Model<"openai-completions"> {
+		return {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			provider,
+			id,
+			baseUrl,
+			reasoning: true,
+		} as Model<"openai-completions">;
+	}
+
+	// ── DeepSeek via OpenRouter → must be disabled ──
+
+	it("disables strict mode for DeepSeek V4 via OpenRouter", () => {
+		const compat = resolveOpenAICompat(
+			model("openrouter", "deepseek/deepseek-v4-pro", "https://openrouter.ai/api/v1"),
+		);
+		expect(compat.supportsStrictMode).toBe(false);
+	});
+
+	it("disables strict mode for DeepSeek V4 flash via OpenRouter", () => {
+		const compat = resolveOpenAICompat(
+			model("openrouter", "deepseek/deepseek-v4-flash", "https://openrouter.ai/api/v1"),
+		);
+		expect(compat.supportsStrictMode).toBe(false);
+	});
+
+	// ── Non-DeepSeek via OpenRouter → must remain enabled ──
+
+	it("keeps strict mode for Claude via OpenRouter", () => {
+		const compat = resolveOpenAICompat(
+			model("openrouter", "anthropic/claude-sonnet-4-20250514", "https://openrouter.ai/api/v1"),
+		);
+		expect(compat.supportsStrictMode).toBe(true);
+	});
+
+	it("keeps strict mode for GPT via OpenRouter", () => {
+		const compat = resolveOpenAICompat(model("openrouter", "openai/gpt-5", "https://openrouter.ai/api/v1"));
+		expect(compat.supportsStrictMode).toBe(true);
+	});
+
+	// ── DeepSeek via non-OpenRouter → must remain enabled ──
+
+	it("keeps strict mode for DeepSeek direct API", () => {
+		const compat = resolveOpenAICompat(model("deepseek", "deepseek-chat", "https://api.deepseek.com/v1"));
+		expect(compat.supportsStrictMode).toBe(true);
+	});
+
+	it("keeps strict mode disabled for DeepSeek via NVIDIA NIM (unchanged — nvidia does not support strict)", () => {
+		const compat = resolveOpenAICompat(
+			model("nvidia", "deepseek-ai/deepseek-v4-flash", "https://integrate.api.nvidia.com/v1"),
+		);
+		expect(compat.supportsStrictMode).toBe(false);
+	});
+});

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -789,6 +789,77 @@ describe("kimi model detection via detectCompat", () => {
 	});
 });
 
+describe("DeepSeek strict mode via OpenRouter", () => {
+	function deepseekModel(overrides: Partial<Model<"openai-completions">> = {}): Model<"openai-completions"> {
+		return {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			id: "deepseek/deepseek-v4-pro",
+			reasoning: true,
+			...overrides,
+		} as Model<"openai-completions">;
+	}
+
+	it("disables strict mode for DeepSeek V4 via OpenRouter", () => {
+		const model = deepseekModel({
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+		});
+		const compat = detectCompat(model);
+		expect(compat.supportsStrictMode).toBe(false);
+	});
+
+	it("disables strict mode for DeepSeek V4 flash via OpenRouter", () => {
+		const model = deepseekModel({
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			id: "deepseek/deepseek-v4-flash",
+		});
+		const compat = detectCompat(model);
+		expect(compat.supportsStrictMode).toBe(false);
+	});
+
+	it("keeps strict mode enabled for non-DeepSeek models via OpenRouter", () => {
+		const model = deepseekModel({
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			id: "anthropic/claude-sonnet-4-20250514",
+		});
+		const compat = detectCompat(model);
+		expect(compat.supportsStrictMode).toBe(true);
+	});
+
+	it("keeps strict mode enabled for GPT via OpenRouter", () => {
+		const model = deepseekModel({
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			id: "openai/gpt-5",
+		});
+		const compat = detectCompat(model);
+		expect(compat.supportsStrictMode).toBe(true);
+	});
+
+	it("keeps strict mode enabled for DeepSeek direct API", () => {
+		const model = deepseekModel({
+			provider: "deepseek",
+			baseUrl: "https://api.deepseek.com/v1",
+			id: "deepseek-chat",
+		});
+		const compat = detectCompat(model);
+		expect(compat.supportsStrictMode).toBe(true);
+	});
+
+	it("keeps strict mode disabled for DeepSeek via NVIDIA NIM (nvidia does not support strict)", () => {
+		const model = deepseekModel({
+			provider: "nvidia",
+			baseUrl: "https://integrate.api.nvidia.com/v1",
+			id: "deepseek-ai/deepseek-v4-flash",
+		});
+		const compat = detectCompat(model);
+		expect(compat.supportsStrictMode).toBe(false);
+	});
+});
+
 describe("NVIDIA NIM DeepSeek special-token stripping", () => {
 	function nvidiaDeepseekModel(): Model<"openai-completions"> {
 		return {


### PR DESCRIPTION
## Problem

DeepSeek V4 (accessed through OpenRouter Chat Completions) rejects `strict: true` on function tool definitions with a 400 error:

```
"An object with no properties is not allowed."
```

This is triggered even when the tool parameter schema is valid JSON Schema draft 2020-12. The rejection is specific to the `strict` field -- without it, DeepSeek V4 accepts the same schemas.

The issue breaks `gjc -p`, `gjc auth status`, and any coordinator/MCP usage with DeepSeek models via OpenRouter.

## Fix

**1 line changed**: `packages/ai/src/providers/openai-completions-compat.ts`

In `detectOpenAICompat`, suppress `supportsStrictMode` only when the model family is DeepSeek AND the provider is OpenRouter:

```ts
supportsStrictMode: detectStrictModeSupport(provider, baseUrl) && !(isDeepseekFamily && isOpenRouter),
```

Both `isDeepseekFamily` and `isOpenRouter` are already computed in the same function -- no new variables needed.

## Scope (narrowly targeted)

| Scenario | `supportsStrictMode` |
|---|---|
| DeepSeek V4 via **OpenRouter** | **false** (fixed) |
| DeepSeek V4 flash via **OpenRouter** | **false** (fixed) |
| Claude via OpenRouter | true (unchanged) |
| GPT via OpenRouter | true (unchanged) |
| DeepSeek **direct API** | true (unchanged) |
| DeepSeek via **NVIDIA NIM** | false (unchanged, nvidia never supported strict) |

## Design decisions

Per maintainer feedback on #2752 and #2757:

- **Canonical compatibility boundary**: `detectOpenAICompat`, not `convertTools`
- **Single concern**: disable strict mode only, no schema normalization
- **Narrow scoping**: `isDeepseekFamily && isOpenRouter`, not all DeepSeek models
- **Tests exercise production path**: `detectCompat()` and `resolveOpenAICompat()`, not copied regex

## Tests

Two test files, 12 tests total:

- `openai-completions-compat.test.ts` -- 6 tests via `detectCompat()` (exercises full production path)
- `deepseek-compat-strict.test.ts` -- 6 tests via `resolveOpenAICompat()` (standalone, no native addon dependency)

Coverage:
- OpenRouter + DeepSeek V4/V4-flash: `supportsStrictMode === false`
- OpenRouter + Claude/GPT: `supportsStrictMode === true` (regression proof)
- DeepSeek direct API: `supportsStrictMode === true` (scoping proof)
- NVIDIA NIM DeepSeek: `supportsStrictMode === false` (unchanged)

## Verification

- `gjc auth status` with `deepseek/deepseek-v4-pro` -- no more 400 errors
- `gjc -p` with `deepseek/deepseek-v4-pro` -- works (was 400)
- No `PI_NO_STRICT` env var needed
- No `models.yml` config needed
- No side effects on other providers (only OpenRouter + DeepSeek)
