### PR TITLE
test(coding-agent): stop live-stream fixture daemons promptly

### DIFF
--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -131,7 +131,7 @@ async function bootSession(
 	if (typeof botToken === "string" && typeof chatId === "string") {
 		fs.writeFileSync(
 			path.join(agentDir, "config.yml"),
-			`notifications:\n  enabled: true\n  telegram:\n    botToken: ${JSON.stringify(botToken)}\n    chatId: ${JSON.stringify(chatId)}\n`,
+			`notifications:\n  enabled: true\n  daemon:\n    idleTimeoutMs: 20\n  telegram:\n    botToken: ${JSON.stringify(botToken)}\n    chatId: ${JSON.stringify(chatId)}\n`,
 		);
 	}
 	const settings = isolatedNotificationSettings(agentDir, settingsOverrides);


### PR DESCRIPTION
## Summary
- persist the established 20ms fixture-only Telegram daemon idle timeout alongside live-stream fixture credentials
- let session/root deregistration deterministically stop the real spawned fixture daemon before broker cleanup removes the root
- preserve the cleanup broker's fail-closed root-recreation detection and full production daemon readiness/ownership coverage

Refs #2692
Refs #2733
Refs #2739

## Exact failure
Replacement Dev CI 29758651174 at `e710e14a6dc66fafeef8853838e1b5eff4b82ca0` passed 1503 tests and failed only `a durable Telegram streaming disable before the first live frame leaves the final keyless`: the real fixture daemon remained alive long enough to recreate the fixture root after cleanup removed it.

## Verification
- `notifications-live-stream.test.ts` passed 5 consecutive runs (90/90 tests)
- `fixture-broker-cleanup.test.ts` + `notifications-telegram-daemon.test.ts`: 340 passed
- coding-agent check/types passed

The 20ms value matches existing daemon fixture convention; no arbitrary sleep, cleanup relaxation, retry, timeout inflation, production lifecycle change, main, release, or publish scope.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*