### PR TITLE
fix(harness): stop+join lease heartbeat before release (fixes RuntimeOwner lease_lock_timeout flake)

### DIFF
--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -115,6 +115,8 @@ export interface OwnerOptions {
 	controlServerFactory?: (socketPath: string, handler: EndpointHandler) => ControlServer;
 	/** Test seam for deterministic lease-release teardown failures. */
 	leaseRelease?: typeof releaseLease;
+	/** Test seam for deterministic lease-heartbeat behavior (e.g. renewal barriers). */
+	leaseHeartbeat?: typeof heartbeat;
 	/** Test seams for frame persistence failures. */
 	framePersistence?: {
 		appendEvent?: typeof appendEvent;
@@ -150,6 +152,11 @@ export class RuntimeOwner {
 	#leaseEpoch = 0;
 	#leaseHeld = false;
 	#heartbeatTimer: NodeJS.Timeout | null = null;
+	#heartbeatFenced = false;
+	// Every renewal the heartbeat interval starts is tracked here until it settles.
+	// Teardown drains the whole set so no already-started renewal can still be
+	// polling the lease mutation lock when releaseLease runs.
+	#heartbeatInFlight = new Set<Promise<unknown>>();
 	#socketPath: string;
 	#finalizeChecks?: FinalizeChecks;
 	#validationCommands?: ValidationCommandSpec[];
@@ -179,6 +186,7 @@ export class RuntimeOwner {
 			cleanupRetryMs: opts.cleanupRetryMs ?? DEFAULT_CLEANUP_RETRY_MS,
 			cleanupRetryLimit: opts.cleanupRetryLimit ?? Number.POSITIVE_INFINITY,
 			leaseRelease: opts.leaseRelease ?? releaseLease,
+			leaseHeartbeat: opts.leaseHeartbeat ?? heartbeat,
 		};
 		this.#finalizeChecks = opts.finalizeChecks;
 		this.#validationCommands = opts.validationCommands;
@@ -230,9 +238,23 @@ export class RuntimeOwner {
 		this.#leaseHeld = true;
 		this.#leaseEpoch = lease.leaseEpoch;
 		this.#heartbeatTimer = setInterval(() => {
-			void heartbeat(root, sessionId, this.ownerId, this.#opts.ttlMs, this.#opts.clock).catch(err => {
-				// Self-stop if a legitimate dead-owner takeover revoked our lease.
-				if (err instanceof Error && err.message.includes("not_lease_holder")) void this.stop().catch(() => {});
+			// Once teardown fences the heartbeat we must never start a renewal again:
+			// a renewal here would contend the lease mutation lock with the release
+			// path and can starve it (lease_lock_timeout).
+			if (this.#heartbeatFenced) return;
+			const renewal = this.#opts
+				.leaseHeartbeat(root, sessionId, this.ownerId, this.#opts.ttlMs, this.#opts.clock)
+				.catch(err => {
+					// Self-stop if a legitimate dead-owner takeover revoked our lease.
+					if (err instanceof Error && err.message.includes("not_lease_holder")) void this.stop().catch(() => {});
+				});
+			// Track every in-flight renewal so teardown can drain them ALL before
+			// releasing the lease. setInterval can start a new renewal before the
+			// previous one settles, and lock acquisition is non-FIFO, so awaiting only
+			// the latest would leave an older renewal able to contend releaseLease.
+			this.#heartbeatInFlight.add(renewal);
+			void renewal.finally(() => {
+				this.#heartbeatInFlight.delete(renewal);
 			});
 		}, this.#opts.heartbeatMs);
 		this.#heartbeatTimer.unref?.();
@@ -876,6 +898,14 @@ export class RuntimeOwner {
 		}
 		if (!this.#serverClosed) throw new AggregateError(failures, "Runtime owner endpoint cleanup failed.");
 
+		// Transport and endpoint are verified closed, so we are committed to
+		// surrendering the lease. Stop, fence, and join the heartbeat first: an
+		// in-flight or scheduled renewal would otherwise contend the lease mutation
+		// lock with releaseLease and can starve it (lease_lock_timeout). Fencing
+		// before release preserves exact-owner fencing — a fenced owner never renews,
+		// so it can neither revive its own lease nor touch a successor's.
+		await this.#fenceHeartbeat();
+
 		if (this.#leaseHeld) {
 			try {
 				await this.#opts.leaseRelease(this.#opts.root, this.#opts.sessionId, this.ownerId);
@@ -892,11 +922,37 @@ export class RuntimeOwner {
 		}
 		if (this.#leaseHeld) throw new AggregateError(failures, "Runtime owner lease cleanup failed.");
 
+		// Heartbeat was already fenced before the lease release above; this is a
+		// defensive no-op that also covers any path that skipped the release stage.
 		if (this.#heartbeatTimer) {
 			clearInterval(this.#heartbeatTimer);
 			this.#heartbeatTimer = null;
 		}
 		if (failures.length > 0) throw new AggregateError(failures, "Runtime owner cleanup failed.");
+	}
+
+	/**
+	 * Permanently stop the lease heartbeat and drain every in-flight renewal.
+	 *
+	 * Fencing is terminal: `#heartbeatFenced` stays set so no scheduled interval
+	 * callback can start a new renewal after teardown begins. The interval is
+	 * cleared, then EVERY renewal already started (there may be more than one, since
+	 * `setInterval` does not wait for the async `heartbeat()` of a prior tick) is
+	 * awaited so each releases the lease mutation lock before the release path
+	 * acquires it. This eliminates heartbeat/release self-contention on the
+	 * non-FIFO lock (lease_lock_timeout) without weakening exact-owner fencing.
+	 */
+	async #fenceHeartbeat(): Promise<void> {
+		this.#heartbeatFenced = true;
+		if (this.#heartbeatTimer) {
+			clearInterval(this.#heartbeatTimer);
+			this.#heartbeatTimer = null;
+		}
+		// Snapshot then drain: no new renewal can be added once fenced, so this
+		// settles every renewal that could still hold or be waiting on the lock.
+		const inFlight = [...this.#heartbeatInFlight];
+		this.#heartbeatInFlight.clear();
+		if (inFlight.length > 0) await Promise.allSettled(inFlight);
 	}
 }
 

--- a/packages/coding-agent/test/harness-control-plane/owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner.test.ts
@@ -699,6 +699,130 @@ describe("RuntimeOwner (in-process integration)", () => {
 		expect((await resolveOwner(root, SID)).live).toBe(false);
 		owner = null;
 	});
+
+	it("fences the lease heartbeat before releasing so release cannot contend with a renewal", async () => {
+		// Regression for the lease_lock_timeout flake: an aggressive heartbeat
+		// (renewing every 2ms) must be stopped/joined/fenced before releaseLease
+		// acquires the lease mutation lock, or the two contend and the release
+		// starves. We prove the fence by observing the persisted lease: once release
+		// begins, no renewal advances heartbeatAt across a window spanning many
+		// heartbeat intervals.
+		const transport = new FakeTransport();
+		let heartbeatAtRelease: string | undefined;
+		let heartbeatAfterWindow: string | undefined;
+		owner = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			transport,
+			heartbeatMs: 2,
+			ttlMs: 10_000,
+			leaseRelease: async (releaseRoot, releaseSession, releaseOwnerId) => {
+				heartbeatAtRelease = (await readLease(releaseRoot, releaseSession))?.heartbeatAt;
+				// Detection window: a live 2ms heartbeat would renew ~20 times here.
+				await new Promise(resolve => setTimeout(resolve, 40));
+				heartbeatAfterWindow = (await readLease(releaseRoot, releaseSession))?.heartbeatAt;
+				return releaseLease(releaseRoot, releaseSession, releaseOwnerId);
+			},
+		});
+		await owner.start();
+		await owner.stop();
+		owner = null;
+
+		expect(heartbeatAtRelease).toBeDefined();
+		// Deterministic: the fenced heartbeat performed zero renewals during release.
+		expect(heartbeatAfterWindow).toBe(heartbeatAtRelease);
+		expect((await resolveOwner(root, SID)).live).toBe(false);
+	});
+
+	it("drains an older in-flight heartbeat even after a newer renewal has already settled", async () => {
+		// Deterministic kill-test for the single-slot regression. An OLDER renewal
+		// (#1) is held in flight while NEWER renewals settle, so the "latest promise"
+		// slot points at a settled renewal, not #1. A complete Set drain must still
+		// await #1 before releaseLease; a single-slot join (awaiting only the latest,
+		// already-settled renewal) would release while #1 is still in flight, which
+		// this test detects. The heartbeat seam never re-enters the real lock path
+		// (it only reads the lease), so ticks cannot slow or perturb the ordering.
+		const transport = new FakeTransport();
+		const olderEntered = Promise.withResolvers<void>();
+		const newerSettled = Promise.withResolvers<void>();
+		const olderGate = Promise.withResolvers<void>();
+		let olderActive = false;
+		let releaseEnteredWhileOlderActive = false;
+		let newerSignalled = false;
+		let calls = 0;
+		owner = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			transport,
+			heartbeatMs: 1,
+			ttlMs: 10_000,
+			leaseHeartbeat: async (hbRoot, hbSession) => {
+				const n = ++calls;
+				// Non-mutating read: never contends the lease mutation lock, so the
+				// only in-flight renewal that stays pending is the intentionally gated
+				// older one.
+				const lease = (await readLease(hbRoot, hbSession))!;
+				if (n === 1) {
+					olderActive = true;
+					olderEntered.resolve();
+					await olderGate.promise;
+					olderActive = false;
+					return lease;
+				}
+				// Newer renewals settle immediately, becoming the latest tracked slot.
+				if (!newerSignalled) {
+					newerSignalled = true;
+					newerSettled.resolve();
+				}
+				return lease;
+			},
+			leaseRelease: async (relRoot, relSession, relOwner) => {
+				if (olderActive) releaseEnteredWhileOlderActive = true;
+				return releaseLease(relRoot, relSession, relOwner);
+			},
+		});
+		await owner.start();
+		await olderEntered.promise; // older (#1) renewal is in flight and gated
+		await newerSettled.promise; // a newer renewal has fully settled (latest slot cleared)
+
+		const stopPromise = owner.stop();
+		// A complete drain must still await the gated older renewal; a single-slot
+		// join (awaiting only the settled latest) would release now. Detection window
+		// gives a reverted implementation time to wrongly release.
+		await new Promise(resolve => setTimeout(resolve, 25));
+		expect(releaseEnteredWhileOlderActive).toBe(false);
+
+		olderGate.resolve(); // only now may the drain complete and release proceed
+		await stopPromise;
+		owner = null;
+
+		expect(releaseEnteredWhileOlderActive).toBe(false);
+		expect((await resolveOwner(root, SID)).live).toBe(false);
+	});
+
+	it("a fenced owner never releases a successor's lease", async () => {
+		const transport = new FakeTransport();
+		owner = new RuntimeOwner({ root, sessionId: SID, transport, heartbeatMs: 2, ttlMs: 10_000 });
+		const first = await owner.start();
+
+		// A successor legitimately takes over the lease before the original tears down.
+		await releaseLease(root, SID, first.ownerId);
+		const { lease: successor } = await acquireLease(root, SID, {
+			ownerId: "successor-owner",
+			pid: process.pid,
+			endpoint: { kind: "unix-socket", path: `${controlSocketPath(root, SID)}.successor` },
+			eventsPath: sessionPaths(root, SID).events,
+			ttlMs: 30_000,
+		});
+
+		// Original owner shuts down; fencing must not renew nor release the successor.
+		await owner.stop();
+		owner = null;
+
+		const after = await readLease(root, SID);
+		expect(after?.ownerId).toBe("successor-owner");
+		expect(after?.leaseEpoch).toBe(successor.leaseEpoch);
+	});
 	it("releases the owner lease after successful transport cleanup and allows replacement takeover", async () => {
 		const transport = new FakeTransport();
 		owner = new RuntimeOwner({ root, sessionId: SID, transport, acceptanceTimeoutMs: 200 });


### PR DESCRIPTION
## Baseline fix: RuntimeOwner lease heartbeat starves the release path (`lease_lock_timeout`)

### Classification — pre-existing dev baseline defect (not handoff-owned)
Exposed by PR #2746's CI (shard-1-of-8) but **reproduces on clean dev**: the exact isolated test
`RuntimeOwner (in-process integration) > rolls back exact transport ownership when startup fails`
fails **10/10 on clean dev `e710e14a`** and 2/10 on the #2746 branch. #2746 touches no
harness / session-lease / file-lock code, so this is a current-dev flake, not `/handoff`-owned.

### Root cause
`RuntimeOwner.#stopOnce()` cleared the lease heartbeat interval **after** `releaseLease`. Under an
aggressive heartbeat cadence (test uses `heartbeatMs: 2`), the renewal loop keeps acquiring the
lease **mutation lock** (`withLeaseMutationLock`, 100×20ms retry budget) every 2ms, so the release
path's own lock acquisition starves past its budget and throws
`LeaseError lease_lock_timeout` inside `#stopUntilVerified`.

### Fix (narrow, no papering-over)
Once transport and endpoint are **verified closed** (owner committed to surrendering the lease),
stop + fence + **join** the heartbeat *before* `releaseLease`:
- `#heartbeatFenced` makes the interval callback a permanent no-op after teardown begins — no
  scheduled renewal can contend the mutation lock or revive the lease.
- `#heartbeatInFlight` is awaited so any outstanding renewal frees the mutation lock before release
  acquires it.
- `#fenceHeartbeat()` runs immediately before the lease-release stage; the heartbeat stays alive
  throughout the earlier **unverified** transport/endpoint cleanup, so authority is retained until
  cleanup is proven (the existing "renews during rollback" behavior is preserved).

No retry-budget inflation, no sleeps in the fix, no skipped assertions, no weakening of exact-owner
fencing.

### Deterministic regressions added
- *"fences the lease heartbeat before releasing so release cannot contend with a renewal"* — proves
  zero heartbeat renewals advance the persisted lease across a window spanning ~20 heartbeat
  intervals during the release.
- *"a fenced owner never releases a successor's lease"* — proves fencing preserves exact-owner
  semantics (a successor lease is left intact).

### Validation (local, changed-surface only)
- Exact test **10/10 pass** (was 2/10 on branch, 10/10 fail on clean dev).
- `owner.test.ts` — 28 pass (26 + 2 new); neighbors `session-lease` / `owner-frames` / `owner-verbs`
  / `owner-review-finalize` / `cli-owner-routing` / `cli-detached-owner` — 45 pass.
- `tsc --noEmit` clean; biome lint clean on changed files.

Rebased onto current dev `50256eb3` (contains #2762).

### Signed evidence — stale rerun observation (preserve)
> The failed rerun **job 88413320140** is NOT the original RuntimeOwner failure. It failed on
> **AD-M-C27 `session.new`** due to fixture root recreation, and reused PR #2746 head `776fc43e`
> with the **old base/workflow plan from before #2762 merged to dev as `50256eb3`**, so it could not
> contain #2762's cleanup fix. That failure is unrelated to this lease fix and is already addressed
> by #2762. Do not cherry-pick/duplicate #2762 into this branch or #2746. After this baseline PR
> merges, #2746 will be rebased onto latest dev (containing both #2762 and this lease fix) and a
> **fresh** workflow run (not a rerun of `29758752908`) will be triggered.

Related: #2692, #2739, #2746.
