### PR TITLE
test(coding-agent): order late-yield timeout deterministically

### DIFF
--- a/packages/coding-agent/test/task/executor-wall-clock.test.ts
+++ b/packages/coding-agent/test/task/executor-wall-clock.test.ts
@@ -290,12 +290,14 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 	});
 
 	it("a late successful yield does not flip a timed-out run to success", async () => {
+		vi.useFakeTimers();
 		// A hung subagent emits a successful `yield` event during teardown (after
 		// the timer has already aborted). Without the fix, `hasYield=true` would
 		// make finalizeSubprocessOutput zero the exit code and `wasAborted`
 		// would resolve to false — silently masking the runtime-limit breach.
 		const settings = Settings.isolated({ "task.maxRuntimeMs": 30 });
 		const { promise: hang, resolve: releaseHang } = Promise.withResolvers<void>();
+		const promptStarted = Promise.withResolvers<void>();
 		let listenerRef: ((event: AgentSessionEvent) => void) | undefined;
 		let abortCount = 0;
 		const session: Partial<AgentSession> = {
@@ -313,6 +315,7 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				return () => {};
 			},
 			prompt: async (_text: string, _options?: PromptOptions) => {
+				promptStarted.resolve();
 				await hang;
 			},
 			waitForIdle: async () => {
@@ -339,11 +342,14 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		};
 		mockCreateAgentSession(session as AgentSession);
 
-		const result = await runSubprocess({
+		const pending = runSubprocess({
 			...baseOptions,
 			id: "subagent-late-yield",
 			settings,
 		});
+		await promptStarted.promise;
+		vi.advanceTimersByTime(30);
+		const result = await pending;
 
 		expect(abortCount).toBeGreaterThanOrEqual(1);
 		expect(result.aborted).toBe(true);


### PR DESCRIPTION
## Summary
- freeze the late-yield wall-clock regression with fake timers
- wait until the mocked live subagent has entered `prompt()` before advancing `task.maxRuntimeMs`
- preserve the load-bearing assertions that timeout wins, the live session aborts, exit stays nonzero, and late yield payload remains inspectable

Refs #2692
Refs #2739

## Exact failure
Replacement Dev CI 29761193435 at `50256eb3b8daf18da2a130545affdff3b262a224` passed 1422 tests in shard 2 and failed only the late-yield timeout test because the real 30ms timer expired during CI setup before the mocked session was live; the timeout result was correct, but no live session yet existed to abort.

## Verification
- executor wall-clock file passed 20 consecutive runs (640/640 tests)
- seven executor/subprocess lifecycle files: 75 passed
- coding-agent check/types passed

No production behavior change, assertion weakening, timeout inflation, arbitrary sleep, retry, main, release, or publish scope.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*