### PR TITLE
test(coding-agent): join fixture daemon shutdown

### DIFF
--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -8,6 +8,7 @@ import { createNotificationsExtension } from "../src/sdk/bus/index";
 import type { NotificationSessionContext } from "../src/sdk/bus/session-control";
 import { NotificationSessionController } from "../src/sdk/bus/session-control";
 import { type EnsureDaemonResult, TelegramNotificationDaemon } from "../src/sdk/bus/telegram-daemon";
+import { TelegramDaemonController } from "../src/sdk/bus/telegram-daemon-control";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
 import { renderThreadedFrame } from "../src/sdk/bus/threaded-render";
 import {
@@ -157,6 +158,10 @@ async function bootSession(
 		key: `notification-session:${sid}`,
 		shutdown: async () => {
 			await handlers.get("session_shutdown")!({ type: "session_shutdown" }, ctx);
+			if (typeof botToken === "string" && typeof chatId === "string") {
+				const stopped = await new TelegramDaemonController(settings).stop();
+				if (!stopped.ok) throw new Error(`Failed to stop fixture Telegram daemon: ${stopped.message}`);
+			}
 		},
 	});
 	await handlers.get("session_start")!({ type: "session_start" }, ctx);


### PR DESCRIPTION
## Summary
- after production `session_shutdown`, request owner-scoped Telegram daemon stop through `TelegramDaemonController`
- await verified stop completion before fixture-broker root cleanup
- fail closed when the exact configured fixture daemon cannot be stopped

Refs #2692
Refs #2733
Refs #2739

## Exact failure
Replacement Dev CI 29763476402 at `4deada4573e243573f61a409bbcdd6eccf713e8b` passed 1503 shard-7 tests and failed only the durable-disable live-stream case because the real child daemon recreated the root after broker cleanup. The merged 20ms fixture idle policy was necessary but not a joined shutdown guarantee.

## Authority boundary
`TelegramDaemonController(settings).stop()` reads the isolated fixture agent directory, validates the configured token/chat fingerprint and exact live owner PID/incarnation, writes an owner-targeted control request, and waits for terminal process/ownership release. A replacement or mismatched owner is not signaled. Cleanup throws if stop is unverified; the broker's root-recreation check remains unchanged and fail-closed.

## Verification
- live-stream file passed 10 consecutive runs (180/180 tests)
- fixture-broker cleanup + Telegram daemon lifecycle: 340 passed
- coding-agent check/types passed

No arbitrary sleep, retry, broker weakening, production timeout change, global daemon interference, main, release, or publish scope.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*