### PR TITLE
test(coding-agent): join compiled session self-exit

### DIFF
--- a/packages/coding-agent/test/fixtures/sdk-session-host-self-exit-entry.ts
+++ b/packages/coding-agent/test/fixtures/sdk-session-host-self-exit-entry.ts
@@ -52,7 +52,7 @@ export async function runSessionHostSelfExitFixture(): Promise<void> {
 	const bootstrap = parse(readFrame());
 	closeFd3();
 	const token = Buffer.from(bootstrap.token, "base64");
-	const timer = setTimeout(() => process.exit(1), CONTROL_TTL_MS);
+	let timer = setTimeout(() => process.exit(1), CONTROL_TTL_MS);
 	const socket = net.connect({ host: "127.0.0.1", port: bootstrap.port });
 	socket.once("error", () => process.exit(1));
 	socket.once("connect", () => {
@@ -61,6 +61,7 @@ export async function runSessionHostSelfExitFixture(): Promise<void> {
 		hello.fill(0);
 	});
 	let received = Buffer.alloc(0);
+	let exitAuthorized = false;
 	const onHandshakeData = (data: Buffer): void => {
 		received = Buffer.concat([received, data]);
 		if (received.length < 36) return;
@@ -72,6 +73,8 @@ export async function runSessionHostSelfExitFixture(): Promise<void> {
 		received = Buffer.alloc(0);
 		if (!accepted) process.exit(1);
 		socket.off("data", onHandshakeData);
+		clearTimeout(timer);
+		timer = setTimeout(() => process.exit(1), CONTROL_TTL_MS);
 		// The parent sends one authenticated self-exit capability after broker exit.
 		let exitReceived = Buffer.alloc(0);
 		const onExitData = (command: Buffer): void => {
@@ -88,14 +91,20 @@ export async function runSessionHostSelfExitFixture(): Promise<void> {
 			exitReceived.fill(0);
 			exitReceived = Buffer.alloc(0);
 			token.fill(0);
-			clearTimeout(timer);
 			if (!valid) process.exit(1);
-			socket.end("BYE1", () => process.exit(0));
+			exitAuthorized = true;
+			socket.once("close", () => {
+				clearTimeout(timer);
+				process.exit(0);
+			});
+			socket.end("BYE1");
 		};
 		socket.on("data", onExitData);
 	};
 	socket.on("data", onHandshakeData);
-	socket.once("end", () => process.exit(1));
+	socket.once("end", () => {
+		if (!exitAuthorized) process.exit(1);
+	});
 }
 if (path.basename(process.argv[1] ?? "") === "sdk-session-host-self-exit-entry.ts")
 	void runSessionHostSelfExitFixture().catch(() => process.exit(1));


### PR DESCRIPTION
## Summary
- reset the compiled session fixture's self-exit capability TTL only after authenticated ACK1 acceptance
- write BYE1 and join socket close before process exit instead of abruptly exiting from the write callback
- preserve pre-auth fail-closed TTL, exact HMAC domains, compiled sibling resolution, and missing/non-file/symlink rejection

Refs #2692
Refs #2739

## Exact failure
Replacement Dev CI 29764656890 at `da7e58bca31742f9dfa637123b7acfb917570270` passed 1167 shard-6 tests and failed only the compiled broker/session authenticated self-exit acknowledgement. The single process-wide 10s TTL began before compile-child startup, handshake, broker natural exit, and self-exit command; under shard load it could expire before the authenticated exit phase. Separately, abrupt `process.exit()` from the socket end callback could race BYE1 delivery.

## Deterministic lifecycle
The unchanged 10s TTL remains fail-closed before authentication. Once ACK1 is cryptographically verified, the fixture starts a fresh phase-local 10s self-exit capability TTL. After valid EXT1, it clears the TTL, marks exit authorized, sends BYE1, and exits only after socket close. Unauthorized peer end still exits failure.

## Verification
- self-reap process file passed 10 consecutive runs (50/50 compiled/source topology tests)
- nine neighboring SDK broker/session lifecycle files: 159 passed
- coding-agent check/types passed

No timer inflation, arbitrary sleep, retry, production broker change, sibling-path weakening, main, release, or publish scope.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*