### PR TITLE
test(coding-agent): lock always-on plugin MCP across newSession/resume (#2733)

### DIFF
--- a/packages/coding-agent/test/gjc-plugin-mcp-session.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-mcp-session.test.ts
@@ -80,6 +80,64 @@ describe("always-on plugin-bundle MCP in a live session", () => {
 		expect(mcpManager?.getConnectedServers()).toEqual([]);
 	}, 30_000);
 
+	test("keeps always-on plugin MCP tools active across newSession and switchSession resume", async () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-mcp-session-resume-"));
+		tempDirs.push(cwd);
+		await installGjcPluginBundle(mcpBundle, { scope: "project", cwd });
+
+		// File-backed manager so switchSession can resume a real session file. Generic
+		// discovery is fully enabled to prove the plugin tool is mandatory, not selectable.
+		const sessionManager = SessionManager.create(cwd, cwd);
+		const sessionSettings = Settings.isolated();
+		sessionSettings.set("tools.discoveryMode", "all");
+		const { session, mcpManager } = await createAgentSession({
+			cwd,
+			agentDir: cwd,
+			sessionManager,
+			settings: sessionSettings,
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			extensions: [],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		const lookup = "mcp__domain_docs_lookup";
+		try {
+			expect(mcpManager?.getConnectedServers()).toContain("domain_docs");
+			expect(session.getActiveToolNames()).toContain(lookup);
+			expect(session.getSelectedMCPToolNames()).not.toContain(lookup);
+
+			const originalSessionFile = session.sessionFile;
+			expect(originalSessionFile).toBeDefined();
+
+			// /new: a fresh session recomputes selection but keeps the plugin tool always-on.
+			expect(await session.newSession()).toBe(true);
+			expect(session.sessionFile).not.toBe(originalSessionFile);
+			expect(session.getActiveToolNames()).toContain(lookup);
+			expect(session.getSelectedMCPToolNames()).not.toContain(lookup);
+
+			// Resume: switchSession restores MCP selections; the always-on plugin tool
+			// must survive #restoreMCPSelectionsForSessionContext, not be gated behind
+			// the (empty) restored MCP selection.
+			expect(await session.switchSession(originalSessionFile as string)).toBe(true);
+			expect(session.getActiveToolNames()).toContain(lookup);
+			expect(session.getSelectedMCPToolNames()).not.toContain(lookup);
+
+			// The owned manager is not re-spawned or torn down by session lifecycle ops.
+			expect(mcpManager?.getConnectedServers()).toContain("domain_docs");
+		} finally {
+			await session.dispose();
+		}
+
+		// Only disposing the owner tears the manager down (no leaked processes).
+		expect(mcpManager?.getConnectedServers()).toEqual([]);
+	}, 30_000);
+
 	test("filters an explicitly requested mandatory plugin tool from persisted selection authority", async () => {
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-mcp-session-explicit-"));
 		tempDirs.push(cwd);


### PR DESCRIPTION
## Summary

Locks the always-on plugin-bundle MCP contract across the session **resume** path — the origin axis of #2733 (managed child-session resume, #2731).

The production fix already shipped to dev: connected plugin-bundle MCP tools are threaded as `mandatoryMCPToolNames` and force-included on **every** `AgentSession#applyActiveToolsByName`, and excluded from selectable-MCP semantics. Because `#restoreMCPSelectionsForSessionContext` (session switch / resume / branch / navigate-tree) routes through `#applyActiveToolsByName`, the tools now survive MCP-selection recomputation.

The existing `gjc-plugin-mcp-session.test.ts` suite already covers construction, `setActiveToolsByName([])` reset, `newSession`, inherited child, and caller-owned-not-mandatory — but there was **no explicit `switchSession`/resume regression**, which is exactly the lifecycle path that #2733 originated from. This PR adds that deterministic regression. It is test-only; no production change.

## What the new test asserts (`tools.discoveryMode = "all"`, file-backed manager)

- construction: `mcp__domain_docs_lookup` active, not in `getSelectedMCPToolNames()`
- `/new` (`newSession`): still active, still not selectable
- resume (`switchSession` back to the original session file): **still active, still not selectable** — survives `#restoreMCPSelectionsForSessionContext`
- ownership/teardown: owned manager not re-spawned or torn down by lifecycle ops; only owner `dispose()` disconnects it (no leaked processes)

Uses the real bundle fixture like its neighbors; no sleeps/timeouts, no global test-order hacks.

## Verification

- exact base = current dev `1553ecffccd478e290ca8660d94ebe6edf0ecaac`
- `packages/coding-agent` `tsc -p tsconfig.json --noEmit`: clean
- `biome check` on the changed file: clean
- new test verified green locally end-to-end (parent connect → `newSession` → `switchSession` resume; the local run needs a widened MCP startup window only because cold `bun` subprocess startup exceeds the 250ms warm-CI window — a harness/env limitation, not logic; the committed 250ms window and 30s budget are unchanged)
- hosted CI (focused, shard 5, neighboring MCP/session-lifecycle) to confirm at exact head

## Scope / non-goals

- No production change; the `mandatoryMCPToolNames` completion is already on dev.
- Preserves generic/exact-config MCP selection and owned-manager ownership/teardown.
- Does not touch main/release/publish.

Closes #2733 once this merges to dev and exact-head dev CI is green.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
