### PR TITLE
test(coding-agent): preserve coalesced self-exit frames

### DIFF
--- a/packages/coding-agent/test/fixtures/sdk-session-host-self-exit-entry.ts
+++ b/packages/coding-agent/test/fixtures/sdk-session-host-self-exit-entry.ts
@@ -68,10 +68,14 @@ export async function runSessionHostSelfExitFixture(): Promise<void> {
 		const expected = proof(token, "SSH1-accept", bootstrap.requestId);
 		const accepted =
 			received.subarray(0, 4).toString("ascii") === "ACK1" && timingSafeEqual(received.subarray(4, 36), expected);
+		const trailing = Buffer.from(received.subarray(36));
 		expected.fill(0);
 		received.fill(0);
 		received = Buffer.alloc(0);
-		if (!accepted) process.exit(1);
+		if (!accepted) {
+			trailing.fill(0);
+			process.exit(1);
+		}
 		socket.off("data", onHandshakeData);
 		clearTimeout(timer);
 		timer = setTimeout(() => process.exit(1), CONTROL_TTL_MS);
@@ -100,6 +104,7 @@ export async function runSessionHostSelfExitFixture(): Promise<void> {
 			socket.end("BYE1");
 		};
 		socket.on("data", onExitData);
+		if (trailing.length > 0) onExitData(trailing);
 	};
 	socket.on("data", onHandshakeData);
 	socket.once("end", () => {

--- a/packages/coding-agent/test/sdk-broker-self-reap-process.test.ts
+++ b/packages/coding-agent/test/sdk-broker-self-reap-process.test.ts
@@ -54,7 +54,10 @@ async function phase<T>(promise: Promise<T>, label: string, timeoutMs: number): 
 type FixtureCommand = { file: string; args: string[] };
 type FixtureCommandFactory = (root: string) => Promise<FixtureCommand>;
 
-async function assertAuthenticatedFixtureTopology(commandForRoot: FixtureCommandFactory): Promise<void> {
+async function assertAuthenticatedFixtureTopology(
+	commandForRoot: FixtureCommandFactory,
+	options: { coalesceExitWithAccept?: boolean } = {},
+): Promise<void> {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-self-reap-"));
 	const token = randomBytes(32);
 	const requestId = randomUUID();
@@ -62,9 +65,21 @@ async function assertAuthenticatedFixtureTopology(commandForRoot: FixtureCommand
 	const server = await listen();
 	const address = server.address();
 	if (!address || typeof address === "string") throw new Error("Expected IPv4 listener address.");
+	const expectBye = (candidate: net.Socket): Promise<void> =>
+		new Promise<void>((resolve, reject) => {
+			candidate.once("data", data => {
+				try {
+					expect(data.toString("ascii")).toBe("BYE1");
+					resolve();
+				} catch (error) {
+					reject(error);
+				}
+			});
+		});
 	let socket: net.Socket | undefined;
 	let childExited = false;
 	let childExit: Promise<void> | undefined;
+	let coalescedAcknowledged: Promise<void> | undefined;
 	const connected = new Promise<void>((resolve, reject) => {
 		server.once("connection", candidate => {
 			socket = candidate;
@@ -82,7 +97,14 @@ async function assertAuthenticatedFixtureTopology(commandForRoot: FixtureCommand
 					expect(hello.length).toBe(36);
 					expect(timingSafeEqual(hello.subarray(4), expected)).toBe(true);
 					const accept = proof(token, "SSH1-accept", requestId);
-					candidate.write(Buffer.concat([Buffer.from("ACK1"), accept]));
+					if (options.coalesceExitWithAccept) {
+						const exit = proof(token, "SSH1-exit", requestId);
+						coalescedAcknowledged = expectBye(candidate);
+						candidate.write(Buffer.concat([Buffer.from("ACK1"), accept, Buffer.from("EXT1"), exit]));
+						exit.fill(0);
+					} else {
+						candidate.write(Buffer.concat([Buffer.from("ACK1"), accept]));
+					}
 					accept.fill(0);
 					resolve();
 				} catch (error) {
@@ -112,23 +134,17 @@ async function assertAuthenticatedFixtureTopology(commandForRoot: FixtureCommand
 		// The broker naturally returns after dispatch; this observation is through
 		// its exact retained lease, not a child PID recovered from the protocol.
 		expect(await started.lease.waitForExit!(2_000)).toBe(true);
-		expect(childExited).toBe(false);
-		expect(socket?.destroyed).toBe(false);
-
-		const exit = proof(token, "SSH1-exit", requestId);
-		const acknowledged = new Promise<void>((resolve, reject) => {
-			socket!.once("data", data => {
-				try {
-					expect(data.toString("ascii")).toBe("BYE1");
-					resolve();
-				} catch (error) {
-					reject(error);
-				}
-			});
-		});
-		socket!.write(Buffer.concat([Buffer.from("EXT1"), exit]));
-		exit.fill(0);
-		await phase(acknowledged, "authenticated child self-exit acknowledgement", 10_000);
+		if (options.coalesceExitWithAccept) {
+			await phase(coalescedAcknowledged!, "coalesced authenticated child self-exit acknowledgement", 10_000);
+		} else {
+			expect(childExited).toBe(false);
+			expect(socket?.destroyed).toBe(false);
+			const exit = proof(token, "SSH1-exit", requestId);
+			const acknowledged = expectBye(socket!);
+			socket!.write(Buffer.concat([Buffer.from("EXT1"), exit]));
+			exit.fill(0);
+			await phase(acknowledged, "authenticated child self-exit acknowledgement", 10_000);
+		}
 		await phase(childExit!, "authenticated child socket close", 5_000);
 		expect(childExited).toBe(true);
 	} finally {
@@ -223,6 +239,16 @@ test.serial(
 	"source fixture broker exits naturally while its authenticated child remains alive until self-exit",
 	async () => {
 		await assertAuthenticatedFixtureTopology(async () => ({ file: process.execPath, args: [fixture] }));
+	},
+	10_000,
+);
+
+test.serial(
+	"source fixture preserves an authenticated exit frame coalesced with handshake acceptance",
+	async () => {
+		await assertAuthenticatedFixtureTopology(async () => ({ file: process.execPath, args: [fixture] }), {
+			coalesceExitWithAccept: true,
+		});
 	},
 	10_000,
 );


### PR DESCRIPTION
## Summary
- preserve trailing authenticated control bytes when ACK1 and EXT1 arrive in one TCP data event
- feed preserved bytes into the existing authenticated self-exit validator instead of zeroing/discarding them with the handshake frame
- add a deterministic coalesced ACK1+EXT1 protocol regression that fails before the fix

Refs #2692
Refs #2739

## Exact deterministic regression
Merged dev `54d314c32a62b96b478a8a97a0977238908d1e63` failed Dev CI run 29769661641 only in shard 6, job 88447693767: compiled broker/session self-exit timed out waiting for BYE1. Evidence producer/finalizer failed only downstream.

The server resolves `connected` immediately after queuing ACK1; after broker natural exit it may queue EXT1 before ACK1 is delivered. TCP may coalesce both authenticated frames. The child previously authenticated the first 36 bytes, then zeroed and discarded the entire receive buffer—including EXT1—before installing the exit handler. It then waited until TTL instead of acknowledging.

## Repair and proof
- copy trailing bytes after the exact 36-byte ACK1 frame before zeroing handshake memory
- reject and zero trailing bytes on invalid ACK1
- install the existing EXT1 handler, then synchronously feed preserved trailing bytes through its unchanged HMAC/length validation
- deterministic source regression sends ACK1+EXT1 in one write and requires exact BYE1 plus socket close
- full self-reap file passed 5 consecutive runs (30/30 tests)
- coding-agent check/types passed
- signed commit verified locally

No timeout inflation, sleep, retry, production broker change, sibling-path weakening, direct dev push, main, release, or publish scope.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*