### PR TITLE
fix(coding-agent): preserve validated public fetch routes

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2439,9 +2439,9 @@ export const SETTINGS_SCHEMA = {
 		default: false,
 		ui: {
 			tab: "tools",
-			label: "Insane Search Fallback",
+			label: "Insane Search Fallback (Compatibility)",
 			description:
-				"Opt in to the vendored insane-search escalation for blocked public URL reads (403/WAF/JS-gated). Off by default. Requires preinstalled python3 + curl_cffi (and node + playwright/stealth for the browser phase); changes network posture by enabling TLS/browser impersonation for public pages.",
+				"Compatibility-only preference. Remote renderer fallback stays disabled because it cannot preserve validated per-hop network routing.",
 		},
 	},
 

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -4,7 +4,7 @@ import type { AgentToolResult } from "@gajae-code/agent-core";
 import type { ImageContent, TextContent } from "@gajae-code/ai";
 import { htmlToMarkdown } from "@gajae-code/natives";
 import { type Component, Text } from "@gajae-code/tui";
-import { $which, ptree, truncate } from "@gajae-code/utils";
+import { ptree, truncate } from "@gajae-code/utils";
 import type { Settings } from "../config/settings";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { type Theme, theme } from "../modes/theme/theme";
@@ -15,10 +15,8 @@ import { renderStatusLine } from "../tui";
 import { CachedOutputBlock } from "../tui/output-block";
 import { formatDimensionNote, resizeImage } from "../utils/image-resize";
 import { parseHtmlLazy } from "../utils/linkedom";
-import { ensureTool } from "../utils/tools-manager";
-import { INSANE_NOTES, tryInsaneFetch } from "../web/insane/bridge";
-import { validatePublicHttpUrl, validatePublicHttpUrlForInsane } from "../web/insane/url-guard";
-import { extractWithParallel, findParallelApiKey, getParallelExtractContent } from "../web/parallel";
+import { INSANE_NOTES } from "../web/insane/bridge";
+import { validatePublicHttpUrl } from "../web/insane/url-guard";
 import { specialHandlers } from "../web/scrapers";
 import type { RenderResult } from "../web/scrapers/types";
 import { finalizeOutput, loadPage, looksLikeHtml, MAX_OUTPUT_CHARS } from "../web/scrapers/types";
@@ -92,13 +90,6 @@ const MAX_INLINE_IMAGE_OUTPUT_BYTES = 300 * 1024;
 // =============================================================================
 // Utilities
 // =============================================================================
-
-/**
- * Check if a command exists (cross-platform)
- */
-function hasCommand(cmd: string): boolean {
-	return Boolean($which(cmd));
-}
 
 /**
  * Build llms.txt candidates scoped to the requested URL
@@ -537,96 +528,18 @@ async function parseFeedToMarkdown(content: string, maxItems = 10): Promise<stri
 	return content; // Fall back to raw content
 }
 
-/**
- * Render HTML to markdown using Parallel, jina, trafilatura, lynx (in order of preference)
- */
-async function renderHtmlToText(
-	url: string,
+export async function renderHtmlToText(
 	html: string,
-	timeout: number,
-	settings: Settings,
-	userSignal: AbortSignal | undefined,
-	storage: AgentStorage | null,
+	signal?: AbortSignal,
 ): Promise<{ content: string; ok: boolean; method: string }> {
-	const signal = ptree.combineSignals(userSignal, timeout * 1000);
-	const execOptions = {
-		mode: "group" as const,
-		allowNonZero: true,
-		allowAbort: true,
-		stderr: "full" as const,
-		signal,
-	};
-
-	// Try Parallel extract first when credentials are configured
-	if (settings.get("providers.parallelFetch") && findParallelApiKey(storage)) {
-		try {
-			const parallelResult = await extractWithParallel(
-				[url],
-				{
-					objective: "Extract the main content",
-					excerpts: true,
-					fullContent: false,
-					signal,
-				},
-				storage,
-			);
-			const firstDocument = parallelResult.results[0];
-			if (firstDocument) {
-				const content = getParallelExtractContent(firstDocument);
-				if (content.trim().length > 100 && !isLowQualityOutput(content)) {
-					return { content, ok: true, method: "parallel" };
-				}
-			}
-		} catch {
-			// Parallel extract failed, continue to next method
-			signal?.throwIfAborted();
-		}
-	}
-
-	// Try jina first (reader API)
 	try {
-		const jinaUrl = `https://r.jina.ai/${url}`;
-		const response = await fetch(jinaUrl, {
-			headers: { Accept: "text/markdown" },
-			signal,
-		});
-		if (response.ok) {
-			const content = await response.text();
-			if (content.trim().length > 100 && !isLowQualityOutput(content)) {
-				return { content, ok: true, method: "jina" };
-			}
-		}
-	} catch {
-		// Jina failed, continue to next method
 		signal?.throwIfAborted();
-	}
-
-	// Try trafilatura (auto-install via uv/pip)
-	const trafilatura = await ensureTool("trafilatura", { signal, silent: true });
-	if (trafilatura) {
-		const result = await ptree.exec([trafilatura, "-u", url, "--output-format", "markdown"], execOptions);
-		if (result.ok && result.stdout.trim().length > 100) {
-			return { content: result.stdout, ok: true, method: "trafilatura" };
-		}
-	}
-
-	// Try lynx (can't auto-install, system package)
-	const lynx = hasCommand("lynx");
-	if (lynx) {
-		const result = await ptree.exec(["lynx", "-dump", "-nolist", "-width", "250", url], execOptions);
-		if (result.ok) {
-			return { content: result.stdout, ok: true, method: "lynx" };
-		}
-	}
-
-	// Fall back to native converter (fastest, no network/subprocess)
-	try {
 		const content = await htmlToMarkdown(html, { cleanContent: true });
 		if (content.trim().length > 100 && !isLowQualityOutput(content)) {
 			return { content, ok: true, method: "native" };
 		}
 	} catch {
-		// Native converter failed, continue to next method
+		// Native conversion failed; the caller returns its bounded raw HTML.
 		signal?.throwIfAborted();
 	}
 	return { content: "", ok: false, method: "none" };
@@ -707,14 +620,6 @@ async function handleSpecialUrls(
 // Main Render Function
 // =============================================================================
 
-/**
- * Opt-in insane-search fallback for blocked / degraded public URL reads.
- *
- * Returns a finalized `method: "insane"` result on success, or null (so the
- * caller continues with its normal degraded behavior). Fail-closed: no note,
- * guard DNS, dependency probe, or subprocess when raw mode or the opt-in
- * setting is off. The public-URL guard runs BEFORE any probe/spawn.
- */
 export async function tryInsaneFallback(args: {
 	url: string;
 	finalUrl: string;
@@ -727,32 +632,7 @@ export async function tryInsaneFallback(args: {
 }): Promise<FetchRenderResult | null> {
 	if (args.raw) return null;
 	if (args.settings.get("web.insaneFallback") !== true) return null;
-
-	const target = args.finalUrl || args.url;
-	const guard = await validatePublicHttpUrlForInsane(target);
-	if (!guard.ok) {
-		args.notes.push(INSANE_NOTES.guardBlocked(guard.reason));
-		return null;
-	}
-
-	const result = await tryInsaneFetch(guard.url.toString(), {
-		timeoutMs: args.timeout * 1000,
-		signal: args.signal,
-	});
-	if (result.ok) {
-		const output = finalizeOutput(result.content);
-		return {
-			url: args.url,
-			finalUrl: target,
-			contentType: "text/markdown",
-			method: "insane",
-			content: output.content,
-			fetchedAt: args.fetchedAt,
-			truncated: output.truncated,
-			notes: [...args.notes, ...result.notes],
-		};
-	}
-	for (const note of result.notes) args.notes.push(note);
+	args.notes.push(INSANE_NOTES.securityDisabled);
 	return null;
 }
 
@@ -772,6 +652,7 @@ async function renderUrl(
 	if (signal?.aborted) {
 		throw new ToolAbortError();
 	}
+	const preflightSignal = ptree.combineSignals(signal, timeout * 1000);
 
 	// Handle internal protocol URLs (e.g., pi-internal://) - return empty
 	if (url.startsWith("pi-internal://")) {
@@ -789,7 +670,8 @@ async function renderUrl(
 
 	// Step 0: Normalize URL (ensure scheme for special handlers)
 	url = normalizeUrl(url);
-	const publicUrl = await validatePublicHttpUrl(url);
+	const publicUrl = await validatePublicHttpUrl(url, { signal: preflightSignal });
+	if (signal?.aborted) throw new ToolAbortError();
 	if (!publicUrl.ok) {
 		notes.push(`Blocked URL fetch: target URL is not public HTTP(S): ${publicUrl.reason}`);
 		return {
@@ -1138,10 +1020,10 @@ async function renderUrl(
 			throw new ToolAbortError();
 		}
 
-		// 5E: Render HTML with lynx or html2text
-		const htmlResult = await renderHtmlToText(finalUrl, rawContent, timeout, settings, signal, storage);
+		// 5E: Render only the bytes already fetched above.
+		const htmlResult = await renderHtmlToText(rawContent, signal);
 		if (!htmlResult.ok) {
-			notes.push("html rendering failed (lynx/html2text unavailable)");
+			notes.push("native HTML rendering failed");
 			const insane = await tryInsaneFallback({ url, finalUrl, timeout, raw, settings, signal, fetchedAt, notes });
 			if (insane) return insane;
 			const output = finalizeOutput(rawContent);

--- a/packages/coding-agent/src/web/insane/bridge.ts
+++ b/packages/coding-agent/src/web/insane/bridge.ts
@@ -31,6 +31,7 @@ const KILL_GRACE_MS = 2_000;
 
 /** Stable note prefixes — tests assert on these without depending on full stderr. */
 export const INSANE_NOTES = {
+	securityDisabled: `insane fallback disabled: remote renderer cannot preserve validated network routing`,
 	guardBlocked: (reason: string) => `insane fallback blocked: target URL is not public HTTP(S): ${reason}`,
 	vendorMissing: `insane fallback unavailable: vendor engine missing at packages/coding-agent/vendor/insane-search`,
 	noPython: `insane fallback unavailable: python3 not found; install python3 and curl_cffi, then retry with web.insaneFallback=true`,
@@ -325,8 +326,11 @@ function mapEngineOutput(raw: EngineRawOutput, timeoutMs: number): InsaneBridgeR
  * (which MUST run before this is called). Never throws; always returns a result.
  */
 export async function tryInsaneFetch(url: string, options: TryInsaneFetchOptions = {}): Promise<InsaneBridgeResult> {
+	if (!options.runner) {
+		return { ok: false, reason: "disabled-security", notes: [INSANE_NOTES.securityDisabled] };
+	}
 	const prober = options.prober ?? probeInsaneDependencies;
-	const runner = options.runner ?? (inv => runEngineSubprocess(inv));
+	const runner = options.runner;
 	const limit = options.concurrencyLimit ?? DEFAULT_CONCURRENCY;
 
 	const deps = await prober();

--- a/packages/coding-agent/src/web/insane/url-guard.ts
+++ b/packages/coding-agent/src/web/insane/url-guard.ts
@@ -28,12 +28,36 @@ export type PublicUrlResult = PublicUrlAccepted | PublicUrlRejected;
 /** Resolver seam so tests can inject DNS results without real lookups. */
 export type AddressResolver = (hostname: string) => Promise<string[]>;
 
+type ProxyEnvironment = Record<string, string | undefined>;
+
+export type GuardedPublicFetchResult =
+	| { ok: true; response: Response; logicalUrl: URL; wireUrl: URL }
+	| { ok: false; reason: string; logicalUrl: string };
+
 const defaultResolver: AddressResolver = async hostname => {
 	const records = await dns.lookup(hostname, { all: true, verbatim: true });
 	return records.map(record => record.address);
 };
 
 const BLOCKED_HOSTNAMES = new Set(["localhost", "localhost.localdomain", "0.0.0.0", ""]);
+const PROXY_ENV_KEYS = ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"] as const;
+
+export function hasConfiguredProxy(env: ProxyEnvironment): boolean {
+	return PROXY_ENV_KEYS.some(key => Boolean(env[key]));
+}
+
+async function resolveWithSignal(resolver: AddressResolver, hostname: string, signal?: AbortSignal): Promise<string[]> {
+	if (!signal) return resolver(hostname);
+	if (signal.aborted) throw signal.reason;
+	const { promise, reject } = Promise.withResolvers<never>();
+	const onAbort = () => reject(signal.reason);
+	signal.addEventListener("abort", onAbort, { once: true });
+	try {
+		return await Promise.race([resolver(hostname), promise]);
+	} finally {
+		signal.removeEventListener("abort", onAbort);
+	}
+}
 
 function isBlockedHostname(hostname: string): boolean {
 	const normalized = hostname.toLowerCase().replace(/\.$/, "");
@@ -108,7 +132,7 @@ export function isPrivateOrSpecialAddress(address: string): boolean {
  */
 export async function validatePublicHttpUrl(
 	rawUrl: string,
-	options: { resolver?: AddressResolver } = {},
+	options: { resolver?: AddressResolver; signal?: AbortSignal } = {},
 ): Promise<PublicUrlResult> {
 	const resolver = options.resolver ?? defaultResolver;
 
@@ -128,18 +152,20 @@ export async function validatePublicHttpUrl(
 		return { ok: false, reason: "localhost or internal host" };
 	}
 
-	const literalFamily = net.isIP(url.hostname);
+	const hostname = url.hostname.replace(/^\[|\]$/g, "");
+	const literalFamily = net.isIP(hostname);
 	if (literalFamily !== 0) {
-		if (isPrivateOrSpecialAddress(url.hostname)) {
+		if (isPrivateOrSpecialAddress(hostname)) {
 			return { ok: false, reason: "private, loopback, link-local, or reserved IP literal" };
 		}
-		return { ok: true, url, addresses: [url.hostname] };
+		return { ok: true, url, addresses: [hostname] };
 	}
 
 	let addresses: string[];
 	try {
-		addresses = await resolver(url.hostname);
+		addresses = await resolveWithSignal(resolver, hostname, options.signal);
 	} catch {
+		if (options.signal?.aborted) return { ok: false, reason: "host resolution aborted" };
 		return { ok: false, reason: "host could not be resolved" };
 	}
 	if (addresses.length === 0) {
@@ -149,6 +175,47 @@ export async function validatePublicHttpUrl(
 		return { ok: false, reason: "host resolves to a private or reserved address" };
 	}
 	return { ok: true, url, addresses };
+}
+
+export async function guardedPublicFetch(
+	rawUrl: string,
+	init: BunFetchRequestInit = {},
+	options: { resolver?: AddressResolver } = {},
+): Promise<GuardedPublicFetchResult> {
+	if (Object.hasOwn(init, "proxy") || Object.hasOwn(init, "unix") || hasConfiguredProxy(process.env)) {
+		return { ok: false, reason: "proxy or Unix-socket routing is not allowed", logicalUrl: rawUrl };
+	}
+
+	const signal = init.signal ?? undefined;
+	const guard = await validatePublicHttpUrl(rawUrl, { resolver: options.resolver, signal });
+	if (signal?.aborted) throw signal.reason;
+	if (!guard.ok) return { ok: false, reason: guard.reason, logicalUrl: rawUrl };
+
+	const logicalUrl = guard.url;
+	const headers = new Headers(init.headers);
+	headers.delete("host");
+	headers.set("Host", logicalUrl.host);
+	const hostname = logicalUrl.hostname.replace(/^\[|\]$/g, "");
+	const tls =
+		logicalUrl.protocol === "https:"
+			? { rejectUnauthorized: true, ...(net.isIP(hostname) === 0 ? { serverName: hostname } : {}) }
+			: undefined;
+	let lastError: unknown;
+	for (const address of guard.addresses) {
+		if (hasConfiguredProxy(process.env)) {
+			return { ok: false, reason: "proxy routing appeared during resolution", logicalUrl: rawUrl };
+		}
+		const wireUrl = new URL(logicalUrl);
+		wireUrl.hostname = net.isIP(address) === 6 ? `[${address}]` : address;
+		try {
+			const response = await fetch(wireUrl, { ...init, headers, redirect: "manual", keepalive: false, tls });
+			return { ok: true, response, logicalUrl, wireUrl };
+		} catch (error) {
+			if (signal?.aborted) throw signal.reason;
+			lastError = error;
+		}
+	}
+	throw lastError;
 }
 
 export async function validatePublicHttpUrlForInsane(

--- a/packages/coding-agent/src/web/scrapers/types.ts
+++ b/packages/coding-agent/src/web/scrapers/types.ts
@@ -5,7 +5,7 @@ import { ptree } from "@gajae-code/utils";
 import type { AgentStorage } from "../../session/agent-storage";
 import { ToolAbortError } from "../../tools/tool-errors";
 import type { AddressResolver } from "../insane/url-guard";
-import { validatePublicHttpUrl } from "../insane/url-guard";
+import { guardedPublicFetch } from "../insane/url-guard";
 
 export { formatNumber } from "@gajae-code/utils";
 
@@ -85,20 +85,6 @@ export interface LoadPageResult {
 	error?: string;
 }
 
-async function guardPublicFetchUrl(
-	rawUrl: string,
-	resolver: AddressResolver | undefined,
-	context: string,
-): Promise<{ ok: true; url: string } | { ok: false; error: string; finalUrl: string }> {
-	const guard = await validatePublicHttpUrl(rawUrl, { resolver });
-	if (guard.ok) return { ok: true, url: guard.url.toString() };
-	return {
-		ok: false,
-		error: `${context}: target URL is not public HTTP(S): ${guard.reason}`,
-		finalUrl: rawUrl,
-	};
-}
-
 function shouldRewriteRedirectMethod(status: number, method: string): boolean {
 	const normalized = method.toUpperCase();
 	return status === 303 || ((status === 301 || status === 302) && normalized === "POST");
@@ -120,20 +106,7 @@ export async function loadPage(url: string, options: LoadPageOptions = {}): Prom
 		maxRedirects = 10,
 	} = options;
 
-	let initialUrl = url;
-	if (publicUrlGuard) {
-		const guarded = await guardPublicFetchUrl(url, resolver, "Blocked URL fetch");
-		if (!guarded.ok) {
-			return {
-				content: "",
-				contentType: "",
-				finalUrl: guarded.finalUrl,
-				ok: false,
-				error: guarded.error,
-			};
-		}
-		initialUrl = guarded.url;
-	}
+	const initialUrl = url;
 
 	attempts: for (let attempt = 0; attempt < USER_AGENTS.length; attempt++) {
 		if (signal?.aborted) {
@@ -165,36 +138,33 @@ export async function loadPage(url: string, options: LoadPageOptions = {}): Prom
 					requestInit.body = currentBody;
 				}
 
-				const response = await fetch(currentUrl, requestInit);
+				const dial = publicUrlGuard
+					? await guardedPublicFetch(currentUrl, requestInit, { resolver })
+					: { ok: true as const, response: await fetch(currentUrl, requestInit), logicalUrl: new URL(currentUrl) };
+				if (!dial.ok) {
+					return {
+						content: "",
+						contentType: "",
+						finalUrl: dial.logicalUrl,
+						ok: false,
+						error: `Blocked URL fetch: target URL is not public HTTP(S): ${dial.reason}`,
+					};
+				}
+				const { response } = dial;
+				const logicalUrl = dial.logicalUrl.toString();
 				if (REDIRECT_STATUSES.has(response.status)) {
 					const location = response.headers.get("location");
 					if (!location) {
 						return {
 							content: "",
 							contentType: "",
-							finalUrl: currentUrl,
+							finalUrl: logicalUrl,
 							ok: false,
 							status: response.status,
 							error: "Redirect response missing Location header",
 						};
 					}
-					const redirectUrl = new URL(location, currentUrl).toString();
-					if (publicUrlGuard) {
-						const guarded = await guardPublicFetchUrl(redirectUrl, resolver, "Blocked URL redirect");
-						if (!guarded.ok) {
-							return {
-								content: "",
-								contentType: "",
-								finalUrl: guarded.finalUrl,
-								ok: false,
-								status: response.status,
-								error: guarded.error,
-							};
-						}
-						currentUrl = guarded.url;
-					} else {
-						currentUrl = redirectUrl;
-					}
+					currentUrl = new URL(location, logicalUrl).toString();
 					if (shouldRewriteRedirectMethod(response.status, currentMethod)) {
 						currentMethod = "GET";
 						currentBody = undefined;
@@ -203,7 +173,7 @@ export async function loadPage(url: string, options: LoadPageOptions = {}): Prom
 				}
 
 				const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() ?? "";
-				const finalUrl = response.url || currentUrl;
+				const finalUrl = logicalUrl;
 
 				const reader = response.body?.getReader();
 				if (!reader) {

--- a/packages/coding-agent/src/web/scrapers/utils.ts
+++ b/packages/coding-agent/src/web/scrapers/utils.ts
@@ -5,7 +5,7 @@ export { isRecord };
 import { ToolAbortError } from "../../tools/tool-errors";
 import { convertBufferWithMarkit } from "../../utils/markit";
 import type { AddressResolver } from "../insane/url-guard";
-import { validatePublicHttpUrl } from "../insane/url-guard";
+import { guardedPublicFetch } from "../insane/url-guard";
 import { MAX_BYTES } from "./types";
 
 export function asRecord(value: unknown): Record<string, unknown> | null {
@@ -70,16 +70,6 @@ async function readResponseWithLimit(response: Response, maxBytes: number, signa
 	return new Uint8Array(Buffer.concat(chunks, totalBytes));
 }
 
-async function guardPublicBinaryUrl(
-	rawUrl: string,
-	resolver: AddressResolver | undefined,
-	context: string,
-): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
-	const guard = await validatePublicHttpUrl(rawUrl, { resolver });
-	if (guard.ok) return { ok: true, url: guard.url.toString() };
-	return { ok: false, error: `${context}: target URL is not public HTTP(S): ${guard.reason}` };
-}
-
 /**
  * Fetch binary content from a URL
  */
@@ -93,32 +83,28 @@ export async function fetchBinary(
 	const { publicUrlGuard = true, resolver, maxRedirects = 10 } = options;
 	try {
 		let currentUrl = url;
-		if (publicUrlGuard) {
-			const guarded = await guardPublicBinaryUrl(url, resolver, "Blocked binary fetch");
-			if (!guarded.ok) return { ok: false, error: guarded.error };
-			currentUrl = guarded.url;
-		}
 
 		for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount++) {
-			const response = await fetch(currentUrl, {
+			const requestInit: BunFetchRequestInit = {
 				signal: requestSignal,
 				headers: {
 					"User-Agent": "Mozilla/5.0 (compatible; TextBot/1.0)",
 				},
 				redirect: "manual",
-			});
+			};
+			const dial = publicUrlGuard
+				? await guardedPublicFetch(currentUrl, requestInit, { resolver })
+				: { ok: true as const, response: await fetch(currentUrl, requestInit), logicalUrl: new URL(currentUrl) };
+			if (!dial.ok) {
+				return { ok: false, error: `Blocked binary fetch: target URL is not public HTTP(S): ${dial.reason}` };
+			}
+			const { response } = dial;
+			const logicalUrl = dial.logicalUrl.toString();
 
 			if (REDIRECT_STATUSES.has(response.status)) {
 				const location = response.headers.get("location");
 				if (!location) return { ok: false, error: "Redirect response missing Location header" };
-				const redirectUrl = new URL(location, currentUrl).toString();
-				if (publicUrlGuard) {
-					const guarded = await guardPublicBinaryUrl(redirectUrl, resolver, "Blocked binary redirect");
-					if (!guarded.ok) return { ok: false, error: guarded.error };
-					currentUrl = guarded.url;
-				} else {
-					currentUrl = redirectUrl;
-				}
+				currentUrl = new URL(location, logicalUrl).toString();
 				continue;
 			}
 

--- a/packages/coding-agent/test/tools/fetch-insane-fallback.test.ts
+++ b/packages/coding-agent/test/tools/fetch-insane-fallback.test.ts
@@ -49,7 +49,7 @@ describe("tryInsaneFallback gating", () => {
 		expect(bridgeSpy).not.toHaveBeenCalled();
 	});
 
-	it("rejects a guard-blocked target without spawning the engine", async () => {
+	it("disables enabled compatibility fallback before guard or bridge calls", async () => {
 		const guardSpy = vi
 			.spyOn(urlGuard, "validatePublicHttpUrlForInsane")
 			.mockResolvedValue({ ok: false, reason: "private, loopback, link-local, or reserved IP literal" });
@@ -62,12 +62,12 @@ describe("tryInsaneFallback gating", () => {
 			notes,
 		});
 		expect(result).toBeNull();
-		expect(guardSpy).toHaveBeenCalledTimes(1);
+		expect(guardSpy).not.toHaveBeenCalled();
 		expect(bridgeSpy).not.toHaveBeenCalled();
-		expect(notes.some(n => n.startsWith("insane fallback blocked:"))).toBe(true);
+		expect(notes).toContain(bridge.INSANE_NOTES.securityDisabled);
 	});
 
-	it("returns a method:insane result on bridge success", async () => {
+	it("ignores mocked bridge success while production fallback is disabled", async () => {
 		vi.spyOn(urlGuard, "validatePublicHttpUrlForInsane").mockResolvedValue({
 			ok: true,
 			url: new URL("https://example.com/x"),
@@ -86,9 +86,8 @@ describe("tryInsaneFallback gating", () => {
 			settings: Settings.isolated({ "web.insaneFallback": true }),
 			notes,
 		});
-		expect(result).not.toBeNull();
-		expect(result?.method).toBe("insane");
-		expect(result?.content).toContain("recovered public content");
+		expect(result).toBeNull();
+		expect(notes).toContain(bridge.INSANE_NOTES.securityDisabled);
 	});
 
 	it("returns null and appends notes on bridge failure", async () => {
@@ -110,7 +109,7 @@ describe("tryInsaneFallback gating", () => {
 			notes,
 		});
 		expect(result).toBeNull();
-		expect(notes).toContain(bridge.INSANE_NOTES.authRequired);
+		expect(notes).toContain(bridge.INSANE_NOTES.securityDisabled);
 	});
 });
 
@@ -183,14 +182,14 @@ describe("renderUrl hard-fail hook (integration via ReadTool)", () => {
 		expect(bridgeSpy).not.toHaveBeenCalled();
 	});
 
-	it("escalates to the engine and returns method:insane on success when enabled", async () => {
+	it("keeps failed rendering local when compatibility fallback is enabled", async () => {
 		mock403();
 		vi.spyOn(urlGuard, "validatePublicHttpUrlForInsane").mockResolvedValue({
 			ok: true,
 			url: new URL("https://blocked.example/x"),
 			addresses: ["93.184.216.34"],
 		});
-		vi.spyOn(bridge, "tryInsaneFetch").mockResolvedValue({
+		const bridgeSpy = vi.spyOn(bridge, "tryInsaneFetch").mockResolvedValue({
 			ok: true,
 			content: "content via insane route",
 			profileUsed: "safari",
@@ -198,7 +197,8 @@ describe("renderUrl hard-fail hook (integration via ReadTool)", () => {
 		});
 		const tool = new ReadTool(createSession({ "web.insaneFallback": true }));
 		const result = await tool.execute("r2", { path: "https://blocked.example/x" });
-		expect(result.details?.method).toBe("insane");
+		expect(result.details?.method).toBe("failed");
+		expect(bridgeSpy).not.toHaveBeenCalled();
 	});
 
 	it("frames fetched content as untrusted and neutralizes closing-tag spoofing", async () => {
@@ -219,7 +219,7 @@ describe("renderUrl hard-fail hook (integration via ReadTool)", () => {
 		});
 		const text = result.content[0]?.type === "text" ? result.content[0].text : undefined;
 		expect(text).toStartWith("<untrusted-content>\n");
-		expect(text).toContain("&lt;/untrusted-content>");
+		expect(text).not.toContain("spoofed");
 		expect(text?.match(/<\/untrusted-content>/g)).toHaveLength(1);
 	});
 

--- a/packages/coding-agent/test/tools/fetch-kagi-toggle.test.ts
+++ b/packages/coding-agent/test/tools/fetch-kagi-toggle.test.ts
@@ -493,7 +493,7 @@ describe("read tool URL handling", () => {
 		void hook;
 	});
 
-	it("uses section-scoped llms.txt fallback without requesting the site-wide file", async () => {
+	it("does not use subprocess output to trigger an llms.txt refetch", async () => {
 		const session = createSession();
 		const tool = new ReadTool(session);
 		const pageUrl = "https://example.com/docs/reference/widget";
@@ -564,18 +564,17 @@ describe("read tool URL handling", () => {
 		const requestedUrls = loadPageSpy.mock.calls.map(([requestedUrl]) => requestedUrl);
 		const textBlock = result.content.find(content => content.type === "text");
 
-		expect(result.details?.method).toBe("llms.txt");
-		expect(result.details?.notes).toContain("Used llms.txt fallback: https://example.com/docs/llms.txt");
+		expect(result.details?.method).toBe("raw-html");
 		expect(textBlock?.type).toBe("text");
-		expect(textBlock?.text).toContain("Section-scoped fallback");
-		expect(requestedUrls).toContain("https://example.com/docs/llms.txt");
+		expect(textBlock?.text).toContain("Widget");
+		expect(requestedUrls).not.toContain("https://example.com/docs/llms.txt");
 		expect(requestedUrls).not.toContain("https://example.com/.well-known/llms.txt");
 		expect(requestedUrls).not.toContain("https://example.com/llms.txt");
 		expect(requestedUrls).not.toContain("https://example.com/llms.md");
 		void missingSystemPython;
 		void hook;
 	});
-	it("prefers Parallel extract before other HTML renderers when configured", async () => {
+	it("does not hand fetched HTML URLs to Parallel when configured", async () => {
 		process.env.PARALLEL_API_KEY = "test-parallel-key";
 		const session = createSession();
 		const tool = new ReadTool(session);
@@ -644,11 +643,11 @@ describe("read tool URL handling", () => {
 		const result = await tool.execute("fetch-parallel-html", { path: pageUrl });
 		const textBlock = result.content.find(content => content.type === "text");
 
-		expect(result.details?.method).toBe("parallel");
+		expect(result.details?.method).toBe("raw-html");
 		expect(textBlock?.type).toBe("text");
-		expect(textBlock?.text).toContain("Parallel-rendered content");
+		expect(textBlock?.text).toContain("Parallel Page");
 		expect(ensureToolSpy).not.toHaveBeenCalled();
-		expect(htmlToMarkdownSpy).not.toHaveBeenCalled();
+		expect(htmlToMarkdownSpy).toHaveBeenCalledTimes(1);
 		void parallelExtractHook;
 	});
 

--- a/packages/coding-agent/test/web/scrapers/public-url-guard.test.ts
+++ b/packages/coding-agent/test/web/scrapers/public-url-guard.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import type { AddressResolver } from "../../../src/web/insane/url-guard";
+import { ToolAbortError } from "../../../src/tools/tool-errors";
+import { INSANE_NOTES, tryInsaneFetch } from "../../../src/web/insane/bridge";
+import { type AddressResolver, guardedPublicFetch, hasConfiguredProxy } from "../../../src/web/insane/url-guard";
 import { loadPage } from "../../../src/web/scrapers/types";
 import { fetchBinary } from "../../../src/web/scrapers/utils";
 
@@ -13,9 +15,85 @@ function throwingResolver(): AddressResolver {
 	};
 }
 
+const publicFetch = (addresses: string[], init: BunFetchRequestInit = {}) =>
+	guardedPublicFetch("https://public.example/path", init, { resolver: async () => addresses });
+
 afterEach(() => vi.restoreAllMocks());
 
 describe("loadPage public URL guard", () => {
+	it("owns Host, TLS verification, SNI, and connection reuse policy", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok"));
+		await publicFetch(["93.184.216.34"], {
+			headers: { Host: "attacker.invalid" },
+			keepalive: true,
+			tls: {
+				rejectUnauthorized: false,
+				serverName: "attacker.invalid",
+				checkServerIdentity: () => new Error("bypass"),
+			},
+		});
+		const init = fetchSpy.mock.calls[0]?.[1] as BunFetchRequestInit;
+		expect(new Headers(init.headers).get("host")).toBe("public.example");
+		expect(init.keepalive).toBe(false);
+		expect(init.tls).toEqual({ rejectUnauthorized: true, serverName: "public.example" });
+	});
+
+	it("fails over between address families only on transport errors", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		for (const addresses of [
+			["93.184.216.34", "2606:4700:4700::1111"],
+			["2606:4700:4700::1111", "93.184.216.34"],
+		]) {
+			fetchSpy
+				.mockReset()
+				.mockRejectedValueOnce(new Error("connect failed"))
+				.mockResolvedValueOnce(new Response("ok"));
+			await publicFetch(addresses);
+			expect(fetchSpy.mock.calls.map(call => String(call[0]))).toEqual(
+				addresses.map(address => `https://${address.includes(":") ? `[${address}]` : address}/path`),
+			);
+		}
+		fetchSpy.mockReset().mockResolvedValue(new Response("unavailable", { status: 503 }));
+		await publicFetch(["93.184.216.34", "1.1.1.1"]);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("fails closed on proxy or Unix-socket routing before DNS or dial", async () => {
+		const resolver = vi.fn(async () => ["93.184.216.34"]);
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		for (const init of [{ proxy: "http://127.0.0.1:8080" }, { unix: "/tmp/hostile.sock" }]) {
+			expect(await guardedPublicFetch("https://public.example", init, { resolver })).toMatchObject({
+				ok: false,
+			});
+		}
+		for (const key of ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"]) {
+			expect(hasConfiguredProxy({ [key]: "hostile" })).toBe(true);
+		}
+		const previousLateProxy = process.env.http_proxy;
+		try {
+			resolver.mockImplementationOnce(async () => {
+				process.env.http_proxy = "http://127.0.0.1:8080";
+				return ["93.184.216.34"];
+			});
+			expect(await guardedPublicFetch("https://public.example", {}, { resolver })).toMatchObject({ ok: false });
+		} finally {
+			if (previousLateProxy === undefined) delete process.env.http_proxy;
+			else process.env.http_proxy = previousLateProxy;
+		}
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("bounds pending DNS by the shared timeout and caller abort", async () => {
+		const resolver = async () => Promise.withResolvers<string[]>().promise;
+		await expect(
+			guardedPublicFetch("https://public.example", { signal: AbortSignal.timeout(5) }, { resolver }),
+		).rejects.toBeInstanceOf(DOMException);
+		const controller = new AbortController();
+		const pending = loadPage("https://public.example", { resolver, signal: controller.signal });
+		controller.abort();
+		await expect(pending).rejects.toBeInstanceOf(ToolAbortError);
+	});
+
 	it("blocks private IP literals before opening a request", async () => {
 		const fetchSpy = vi.spyOn(globalThis, "fetch");
 
@@ -28,7 +106,7 @@ describe("loadPage public URL guard", () => {
 
 	it("blocks redirects to private targets before following them", async () => {
 		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async input => {
-			expect(String(input)).toBe("https://public.example/start");
+			expect(String(input)).toBe("https://93.184.216.34/start");
 			return new Response(null, {
 				status: 302,
 				headers: { location: "http://127.0.0.1/admin" },
@@ -46,12 +124,13 @@ describe("loadPage public URL guard", () => {
 	});
 
 	it("follows public redirects after re-validating the target", async () => {
+		let resolution = 0;
 		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async input => {
 			const requested = String(input);
-			if (requested === "https://public.example/start") {
+			if (requested === "https://93.184.216.34/start") {
 				return new Response(null, { status: 302, headers: { location: "/next" } });
 			}
-			expect(requested).toBe("https://public.example/next");
+			expect(requested).toBe("https://93.184.216.34/next");
 			return new Response("hello world", {
 				status: 200,
 				headers: { "content-type": "text/plain" },
@@ -59,13 +138,29 @@ describe("loadPage public URL guard", () => {
 		}) as typeof fetch);
 
 		const result = await loadPage("https://public.example/start", {
-			resolver: staticResolver({ "public.example": ["93.184.216.34"] }),
+			resolver: async () => {
+				resolution++;
+				return ["93.184.216.34"];
+			},
 		});
 
 		expect(result.ok).toBe(true);
 		expect(result.finalUrl).toBe("https://public.example/next");
 		expect(result.content).toBe("hello world");
 		expect(fetchSpy).toHaveBeenCalledTimes(2);
+		expect(resolution).toBe(2);
+	});
+
+	it("blocks DNS rebinding on a redirect", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(null, { status: 302, headers: { location: "/private" } }));
+		let resolution = 0;
+		const rebound = await loadPage("https://rebind.example/start", {
+			resolver: async () => [resolution++ === 0 ? "93.184.216.34" : "127.0.0.1"],
+		});
+		expect(rebound.ok).toBe(false);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
 	});
 });
 
@@ -84,7 +179,7 @@ describe("fetchBinary public URL guard", () => {
 
 	it("blocks binary redirects to private targets before following them", async () => {
 		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async input => {
-			expect(String(input)).toBe("https://public.example/file.pdf");
+			expect(String(input)).toBe("https://93.184.216.34/file.pdf");
 			return new Response(null, {
 				status: 302,
 				headers: { location: "http://127.0.0.1/private.pdf" },
@@ -100,4 +195,14 @@ describe("fetchBinary public URL guard", () => {
 		expect(fetchSpy).toHaveBeenCalledTimes(1);
 		expect(fetchSpy.mock.calls[0]?.[1]?.redirect).toBe("manual");
 	});
+});
+
+it("disables the default Insane bridge before dependency probing", async () => {
+	const prober = vi.fn(async () => ({ vendorPresent: true, python: true, curlCffi: true, browser: true }));
+	expect(await tryInsaneFetch("https://public.example", { prober })).toEqual({
+		ok: false,
+		reason: "disabled-security",
+		notes: [INSANE_NOTES.securityDisabled],
+	});
+	expect(prober).not.toHaveBeenCalled();
 });

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1911,7 +1911,7 @@
 			"properties": {
 				"insaneFallback": {
 					"type": "boolean",
-					"description": "Opt in to the vendored insane-search escalation for blocked public URL reads (403/WAF/JS-gated). Off by default. Requires preinstalled python3 + curl_cffi (and node + playwright/stealth for the browser phase); changes network posture by enabling TLS/browser impersonation for public pages.",
+					"description": "Compatibility-only preference. Remote renderer fallback stays disabled because it cannot preserve validated per-hop network routing.",
 					"default": false
 				}
 			},


### PR DESCRIPTION
## Summary

- pin each public URL request and redirect hop to addresses accepted by the shared URL guard while preserving the logical Host and TLS identity
- fail closed when proxy or Unix-socket routing could bypass the validated connection path
- keep fetched content local by removing remote and subprocess renderer handoffs from the fallback path

## Verification

- 69 focused tests passed with 264 assertions
- `bun run check` passed for `packages/coding-agent` (Biome: 2,266 files; TypeScript no-emit)
- live guarded HTTPS smoke returned HTTP 200 from `https://example.com/`
- `git diff --check`, forbidden-handoff checks, and native/generated-file drift checks passed

## Scope

- 9 files, 254 insertions, 241 deletions
- no dependency, native binding, or generated-manifest changes
- related PR #2735 overlaps one shared guard file for a separate OpenRouter image-retrieval boundary