### PR TITLE
fix(coding-agent): repair postmerge local artifact compatibility

### DIFF
--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -28,6 +28,7 @@ export interface ManagedLegacyLocalMigrationSource {
 
 export interface LocalProtocolOptions {
 	getArtifactsDir?: () => string | null;
+	isManagedDestination?: () => boolean;
 	getManagedLegacyLocalMigrationSource?: () => ManagedLegacyLocalMigrationSource | null;
 	getSessionId?: () => string | null;
 }
@@ -422,7 +423,33 @@ const initializedLocalRoots = new Set<string>();
  * Completes the mandatory legacy migration gate for a local root.
  * Call and await this before using the synchronous path resolver for reads or writes.
  */
+function explicitLocalRoot(options: LocalProtocolOptions): string | null {
+	if (options.isManagedDestination?.()) return null;
+	const artifactsDir = options.getArtifactsDir?.();
+	return artifactsDir ? path.resolve(artifactsDir, "local") : null;
+}
+
+async function initializeExplicitLocalRoot(localRoot: string): Promise<string> {
+	await fs.mkdir(path.dirname(localRoot), { recursive: true });
+	await assertDirectoryNotSymlink(path.dirname(localRoot));
+	await fs.mkdir(localRoot, { recursive: true });
+	await assertDirectoryNotSymlink(localRoot);
+	return await fs.realpath(localRoot);
+}
+
+function initializeExplicitLocalRootSync(localRoot: string): string {
+	fsSync.mkdirSync(path.dirname(localRoot), { recursive: true });
+	const parentStat = fsSync.lstatSync(path.dirname(localRoot));
+	if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) throw new Error("Unsafe local:// root");
+	fsSync.mkdirSync(localRoot, { recursive: true });
+	const rootStat = fsSync.lstatSync(localRoot);
+	if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw new Error("Unsafe local:// root");
+	return fsSync.realpathSync(localRoot);
+}
+
 export async function initializeLocalRoot(options: LocalProtocolOptions): Promise<string> {
+	const explicitRoot = explicitLocalRoot(options);
+	if (explicitRoot) return await initializeExplicitLocalRoot(explicitRoot);
 	const localRoot = path.resolve(resolveLocalRoot(options));
 	const scratchParent = path.dirname(localRoot);
 
@@ -451,6 +478,11 @@ export async function initializeLocalRoot(options: LocalProtocolOptions): Promis
 }
 
 function initializeLocalRootSyncWhenLegacyAbsent(options: LocalProtocolOptions, localRoot: string): void {
+	const explicitRoot = explicitLocalRoot(options);
+	if (explicitRoot) {
+		initializeExplicitLocalRootSync(explicitRoot);
+		return;
+	}
 	if (initializedLocalRoots.has(localRoot)) return;
 	const scratchParent = path.dirname(localRoot);
 	fsSync.mkdirSync(scratchParent, { recursive: true, mode: 0o700 });
@@ -489,7 +521,7 @@ function initializeLocalRootSyncWhenLegacyAbsent(options: LocalProtocolOptions, 
 }
 
 export function resolveLocalRoot(options: LocalProtocolOptions): string {
-	return path.join(os.tmpdir(), "gjc-local", safeSessionId(options));
+	return explicitLocalRoot(options) ?? path.join(os.tmpdir(), "gjc-local", safeSessionId(options));
 }
 
 export function resolveLocalUrlToPath(input: string | InternalUrl, options: LocalProtocolOptions): string {
@@ -574,6 +606,7 @@ export class LocalProtocolHandler implements ProtocolHandler {
 		if (!sessionManager) return undefined;
 		return {
 			getArtifactsDir: () => sessionManager.getArtifactsDir(),
+			isManagedDestination: () => sessionManager.isManagedDestination(),
 			getManagedLegacyLocalMigrationSource: () => sessionManager.getManagedLegacyLocalMigrationSource(),
 			getSessionId: () => sessionManager.getSessionId(),
 		};

--- a/packages/coding-agent/src/modes/controllers/plan-mode-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/plan-mode-controller.ts
@@ -334,6 +334,7 @@ export class PlanModeController {
 		return planFilePath.startsWith("local:")
 			? resolveLocalUrlToPath(normalizeLocalScheme(planFilePath), {
 					getArtifactsDir: () => this.ctx.sessionManager.getArtifactsDir(),
+					isManagedDestination: () => this.ctx.sessionManager.isManagedDestination(),
 					getSessionId: () => this.ctx.sessionManager.getSessionId(),
 				})
 			: path.resolve(this.ctx.sessionManager.getCwd(), planFilePath);
@@ -448,6 +449,7 @@ export class PlanModeController {
 					await Bun.write(
 						resolveLocalUrlToPath(options.finalPlanFilePath, {
 							getArtifactsDir: () => this.ctx.sessionManager.getArtifactsDir(),
+							isManagedDestination: () => this.ctx.sessionManager.isManagedDestination(),
 							getSessionId: () => this.ctx.sessionManager.getSessionId(),
 						}),
 						planContent,

--- a/packages/coding-agent/src/plan-mode/approved-plan.ts
+++ b/packages/coding-agent/src/plan-mode/approved-plan.ts
@@ -114,6 +114,7 @@ interface RenameApprovedPlanFileOptions {
 	planFilePath: string;
 	finalPlanFilePath: string;
 	getArtifactsDir: () => string | null;
+	isManagedDestination?: () => boolean;
 	getSessionId: () => string | null;
 }
 
@@ -124,12 +125,13 @@ function assertLocalUrl(path: string, label: "source" | "destination"): void {
 }
 
 export async function renameApprovedPlanFile(options: RenameApprovedPlanFileOptions): Promise<void> {
-	const { planFilePath, finalPlanFilePath, getArtifactsDir, getSessionId } = options;
+	const { planFilePath, finalPlanFilePath, getArtifactsDir, getSessionId, isManagedDestination } = options;
 	assertLocalUrl(planFilePath, "source");
 	assertLocalUrl(finalPlanFilePath, "destination");
 
 	const resolveOptions = {
 		getArtifactsDir: () => getArtifactsDir(),
+		isManagedDestination,
 		getSessionId: () => getSessionId(),
 	};
 	const resolvedSource = resolveLocalUrlToPath(normalizeLocalScheme(planFilePath), resolveOptions);

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1506,6 +1506,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			trackEvalExecution: (execution, abortController) =>
 				session ? session.trackEvalExecution(execution, abortController) : execution,
 			getSessionId: () => sessionManager.getSessionId?.() ?? null,
+			isManagedSessionDestination: () => sessionManager.isManagedDestination(),
 			getActiveSkillState: () => session?.getActiveSkillState(),
 			getActiveSkillPhase: () => session?.getActiveSkillPhase(),
 			getHindsightSessionState: () => session?.getHindsightSessionState(),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4444,6 +4444,7 @@ export class AgentSession {
 	#localProtocolOptions(): LocalProtocolOptions {
 		return {
 			getArtifactsDir: () => this.sessionManager.getArtifactsDir(),
+			isManagedDestination: () => this.sessionManager.isManagedDestination(),
 			getSessionId: () => this.sessionManager.getSessionId(),
 		};
 	}

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -5478,6 +5478,10 @@ export class SessionManager {
 		return sessionFile ? sessionFile.slice(0, -6) : null;
 	}
 
+	isManagedDestination(): boolean {
+		return this.destination.kind === "managed";
+	}
+
 	/** Supplies opaque retained authority for mandatory managed legacy local migration. */
 	getManagedLegacyLocalMigrationSource(): ManagedLegacyLocalMigrationSource | null {
 		if (this.destination.kind !== "managed" || !this.#sessionFile || this.#adoptedArtifactManager) return null;

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -638,6 +638,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		if (!batchArtifactsDir) {
 			const asyncLocalOptions: LocalProtocolOptions = {
 				getArtifactsDir: this.session.getArtifactsDir ?? (() => null),
+				isManagedDestination: this.session.isManagedSessionDestination,
 				getSessionId: this.session.getSessionId ?? (() => null),
 			};
 			await initializeLocalRoot(asyncLocalOptions);
@@ -1156,6 +1157,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		// Share the parent session's local:// root with subagents so they read/write the same scratch space
 		const localProtocolOptions: LocalProtocolOptions = {
 			getArtifactsDir: this.session.getArtifactsDir ?? (() => null),
+			isManagedDestination: this.session.isManagedSessionDestination,
 			getSessionId: this.session.getSessionId ?? (() => null),
 		};
 

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -636,6 +636,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			internalRouter: InternalUrlRouter.instance(),
 			localOptions: {
 				getArtifactsDir: this.session.getArtifactsDir,
+				isManagedDestination: this.session.isManagedSessionDestination,
 				getSessionId: this.session.getSessionId,
 			},
 		};

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -264,6 +264,8 @@ export interface ToolSession {
 	requestForegroundBashBackground?: () => boolean;
 	/** Get session ID */
 	getSessionId?: () => string | null;
+	/** Whether local:// must use external managed scratch instead of artifacts/local. */
+	isManagedSessionDestination?: () => boolean;
 	/** Get Hindsight runtime state for this agent session. */
 	getHindsightSessionState?: () => HindsightSessionState | undefined;
 	/** Agent identity used for IRC routing. Returns the registry id (e.g. "0-Main", "0-AuthLoader"). */

--- a/packages/coding-agent/src/tools/plan-mode-guard.ts
+++ b/packages/coding-agent/src/tools/plan-mode-guard.ts
@@ -11,6 +11,7 @@ function resolveRawPath(session: ToolSession, targetPath: string): string {
 	if (normalized.startsWith(LOCAL_SCHEME_PREFIX)) {
 		return resolveLocalUrlToPath(normalized, {
 			getArtifactsDir: session.getArtifactsDir,
+			isManagedDestination: session.isManagedSessionDestination,
 			getSessionId: session.getSessionId,
 		});
 	}

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -588,10 +588,12 @@ describe("AgentSession handoff", () => {
 		vi.spyOn(compactionModule, "generateHandoff").mockResolvedValue(handoffText);
 
 		const result = await session.handoff(undefined, { autoTriggered: true });
-		expect(result?.savedPath).toBeDefined();
-		if (!result?.savedPath) throw new Error("Expected handoff document path");
-		expect(result.savedPath.endsWith(".md")).toBe(true);
-		const savedText = await Bun.file(result.savedPath).text();
+		expect(result?.savedPath).toMatch(/^artifact:\/\/\d+$/);
+		if (!result?.savedPath) throw new Error("Expected handoff artifact URI");
+		const artifactPath = await session.sessionManager.getArtifactPath(result.savedPath.slice("artifact://".length));
+		expect(artifactPath).toBeDefined();
+		if (!artifactPath) throw new Error("Expected handoff artifact path");
+		const savedText = await Bun.file(artifactPath).text();
 		expect(savedText).toContain(handoffText);
 	});
 

--- a/packages/coding-agent/test/agent-session-pre-admission-artifact-spill.test.ts
+++ b/packages/coding-agent/test/agent-session-pre-admission-artifact-spill.test.ts
@@ -80,12 +80,13 @@ describe("AgentSession pre-admission artifact spill", () => {
 		});
 		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
 		sessionManager.appendMessage({ role: "user", content: "seed", timestamp: Date.now() });
-		const allocateArtifactPath = sessionManager.allocateArtifactPath.bind(sessionManager);
-		(
-			sessionManager as unknown as { allocateArtifactPath: typeof sessionManager.allocateArtifactPath }
-		).allocateArtifactPath = async toolType => {
+		const saveArtifact = sessionManager.saveArtifact.bind(sessionManager);
+		(sessionManager as unknown as { saveArtifact: typeof sessionManager.saveArtifact }).saveArtifact = async (
+			content,
+			toolType,
+		) => {
 			await writeGate;
-			return await allocateArtifactPath(toolType);
+			return await saveArtifact(content, toolType);
 		};
 		session = new AgentSession({
 			agent,

--- a/packages/coding-agent/test/helpers/sdk-lifecycle-fixture.ts
+++ b/packages/coding-agent/test/helpers/sdk-lifecycle-fixture.ts
@@ -62,7 +62,7 @@ async function managedWorkspace(
 		// This is setup only: parallel ingress requests never inherit these variables.
 		process.env.GJC_LIFECYCLE_REQUEST_ID = `prepare-${name.toLowerCase()}-${sessionId}`;
 		process.env.GJC_SESSION_ID = sessionId;
-		const session = SessionManager.create(cwd, scopeDir);
+		const session = SessionManager.create(cwd, SessionManager.managedDestination(cwd, agentDir));
 		await session.ensureOnDisk();
 		const sourcePath = session.getSessionFile();
 		if (!sourcePath) throw new Error("Product session API did not create a saved session path.");
@@ -282,7 +282,7 @@ export async function createLifecycleFixture(): Promise<LifecycleFixture> {
 			expect(resolved.kind).toBe("resolved");
 			if (resolved.kind !== "resolved") throw new Error(resolved.message);
 			expect(fixtureSessionDir).toBe(resolved.scope.directoryPath);
-			const savedSession = SessionManager.create(repo, fixtureSessionDir);
+			const savedSession = SessionManager.create(repo, SessionManager.managedDestination(repo, agentDir));
 			await savedSession.ensureOnDisk();
 			const sourceId = savedSession.getSessionId();
 			const sourcePath = savedSession.getSessionFile();

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -34,9 +34,24 @@ async function withLocalRoot<T>(sessionId: string, fn: (root: string) => Promise
 }
 
 function localOptions(sessionId: string, artifactsDir: string) {
-	return { getArtifactsDir: () => artifactsDir, getSessionId: () => sessionId };
+	return { getArtifactsDir: () => artifactsDir, isManagedDestination: () => true, getSessionId: () => sessionId };
 }
 
+it("keeps explicit local roots under artifacts while managed roots stay external", async () => {
+	await withTempDir(async artifactsDir => {
+		const sessionId = `routing-${path.basename(artifactsDir)}`;
+		expect(resolveLocalRoot({ getArtifactsDir: () => artifactsDir, getSessionId: () => sessionId })).toBe(
+			path.join(artifactsDir, "local"),
+		);
+		expect(
+			resolveLocalRoot({
+				getArtifactsDir: () => artifactsDir,
+				isManagedDestination: () => true,
+				getSessionId: () => sessionId,
+			}),
+		).toBe(path.join(os.tmpdir(), "gjc-local", sessionId));
+	});
+});
 it("migrates opaque managed legacy topology, retires exactly once, and verifies the marker", async () => {
 	const sessionId = `managed-${crypto.randomUUID()}`;
 	const snapshot = { rootDev: "1", rootIno: "2", entries: [] } as never;

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -337,7 +337,7 @@ test("lifecycle child ignores a stale marker until its current effect marker rep
 test("lifecycle host rejects a transcript replaced after strict authorization before it can be consumed", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-lifecycle-transcript-race-"));
 	const agentDir = path.join(root, "agent");
-	const session = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+	const session = SessionManager.create(root, SessionManager.managedDestination(root, agentDir));
 	try {
 		await session.ensureOnDisk();
 		const sessionPath = session.getSessionFile();
@@ -349,7 +349,7 @@ test("lifecycle host rejects a transcript replaced after strict authorization be
 		const candidate = inventory.candidates.find(item => item.path === sessionPath);
 		if (!candidate) throw new Error("Expected strict session candidate.");
 		const replacementPath = `${sessionPath}.replacement`;
-		await fs.writeFile(replacementPath, `${await fs.readFile(sessionPath, "utf8")}\n`);
+		await fs.writeFile(replacementPath, `${await fs.readFile(sessionPath, "utf8")}\n`, { mode: 0o600 });
 		const originalCapture = SessionManager.captureTranscriptStrict;
 		let replaced = false;
 		const replaceAfterAuthorization: typeof SessionManager.captureTranscriptStrict = (filePath, storage) => {
@@ -404,7 +404,7 @@ test("lifecycle fork rejects a source replaced after capture without destination
 	const targetCwd = path.join(root, "target");
 	await fs.mkdir(sourceCwd, { recursive: true });
 	await fs.mkdir(targetCwd, { recursive: true });
-	const source = SessionManager.create(sourceCwd, SessionManager.getDefaultSessionDir(sourceCwd, agentDir));
+	const source = SessionManager.create(sourceCwd, SessionManager.managedDestination(sourceCwd, agentDir));
 	try {
 		await source.ensureOnDisk();
 		const sourcePath = source.getSessionFile();
@@ -834,7 +834,7 @@ test("broker rejects a cross-workspace cold fork source before spawning", async 
 	try {
 		await fs.mkdir(sourceCwd, { recursive: true });
 		await fs.mkdir(targetCwd, { recursive: true });
-		const source = SessionManager.create(sourceCwd, SessionManager.getDefaultSessionDir(sourceCwd, agentDir));
+		const source = SessionManager.create(sourceCwd, SessionManager.managedDestination(sourceCwd, agentDir));
 		await source.ensureOnDisk();
 		const sourcePath = source.getSessionFile();
 		if (!sourcePath) throw new Error("Expected source session path.");
@@ -888,7 +888,7 @@ test("broker rejects duplicate owned source candidates before spawning", async (
 		const createDuplicate = async (suffix: string) => {
 			process.env.GJC_LIFECYCLE_REQUEST_ID = `duplicate-prepare-${suffix}`;
 			process.env.GJC_SESSION_ID = "duplicate-owned-source";
-			const session = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+			const session = SessionManager.create(root, SessionManager.managedDestination(root, agentDir));
 			await session.ensureOnDisk();
 			const sourcePath = session.getSessionFile();
 			if (!sourcePath) throw new Error("Expected duplicate owned source path.");
@@ -973,7 +973,7 @@ test("broker directly resumes and forks a canonical cold saved session with scop
 		if (scopeResult.kind !== "resolved") throw new Error(scopeResult.message);
 		const sourceDir = SessionManager.getDefaultSessionDir(root, agentDir);
 		expect(sourceDir).toBe(scopeResult.scope.directoryPath);
-		const source = SessionManager.create(root, sourceDir);
+		const source = SessionManager.create(root, SessionManager.managedDestination(root, agentDir));
 		await source.ensureOnDisk();
 		const sourceId = source.getSessionId();
 		const sourcePath = source.getSessionFile();
@@ -1152,7 +1152,7 @@ test("broker replays one identity-bound lifecycle metadata cleanup plan after th
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-delete-metadata-crash-"));
 	const agentDir = path.join(root, "agent");
 	const stateRoot = path.join(root, ".gjc", "state");
-	const saved = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+	const saved = SessionManager.create(root, SessionManager.managedDestination(root, agentDir));
 	let crashing: Broker | undefined;
 	let reopened: Broker | undefined;
 	try {
@@ -1248,7 +1248,7 @@ test("broker uses incarnation-aware observations before fresh lifecycle metadata
 			["matching", "closed-incarnation", false],
 			["unreadable", undefined, false],
 		] as const) {
-			const saved = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+			const saved = SessionManager.create(root, SessionManager.managedDestination(root, agentDir));
 			await saved.ensureOnDisk();
 			const sessionId = saved.getSessionId();
 			const sessionPath = saved.getSessionFile();
@@ -1296,7 +1296,7 @@ test("broker refuses fresh lifecycle cleanup when ready sibling has a different 
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-mismatched-ready-cleanup-"));
 	const agentDir = path.join(root, "agent");
 	const stateRoot = path.join(root, ".gjc", "state");
-	const saved = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+	const saved = SessionManager.create(root, SessionManager.managedDestination(root, agentDir));
 	const broker = new Broker({ agentDir });
 	try {
 		await saved.ensureOnDisk();
@@ -1305,8 +1305,10 @@ test("broker refuses fresh lifecycle cleanup when ready sibling has a different 
 		if (!sessionPath) throw new Error("Expected persisted delete transcript.");
 		await saved.close();
 		const artifactsPath = sessionPath.slice(0, -6);
-		await fs.mkdir(path.join(artifactsPath, "nested"), { recursive: true });
-		await fs.writeFile(path.join(artifactsPath, "nested", "preserve.txt"), "preserve mismatch artifacts");
+		await fs.mkdir(path.join(artifactsPath, "nested"), { recursive: true, mode: 0o700 });
+		await fs.writeFile(path.join(artifactsPath, "nested", "preserve.txt"), "preserve mismatch artifacts", {
+			mode: 0o600,
+		});
 
 		await broker.start();
 		await expect(
@@ -1374,7 +1376,7 @@ test("broker preserves ready-only lifecycle metadata without canonical marker au
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-ready-only-cleanup-"));
 	const agentDir = path.join(root, "agent");
 	const stateRoot = path.join(root, ".gjc", "state");
-	const saved = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+	const saved = SessionManager.create(root, SessionManager.managedDestination(root, agentDir));
 	const broker = new Broker({ agentDir });
 	try {
 		await saved.ensureOnDisk();
@@ -1383,8 +1385,10 @@ test("broker preserves ready-only lifecycle metadata without canonical marker au
 		if (!sessionPath) throw new Error("Expected persisted delete transcript.");
 		await saved.close();
 		const artifactsPath = sessionPath.slice(0, -6);
-		await fs.mkdir(path.join(artifactsPath, "nested"), { recursive: true });
-		await fs.writeFile(path.join(artifactsPath, "nested", "preserve.txt"), "preserve ready-only artifacts");
+		await fs.mkdir(path.join(artifactsPath, "nested"), { recursive: true, mode: 0o700 });
+		await fs.writeFile(path.join(artifactsPath, "nested", "preserve.txt"), "preserve ready-only artifacts", {
+			mode: 0o600,
+		});
 
 		const deadOwner = Bun.spawn([process.execPath, "-e", ""]);
 		await deadOwner.exited;
@@ -2185,7 +2189,7 @@ await fs.rm(endpoint);
 `,
 		);
 		process.env.GJC_SDK_SESSION_COMMAND = `${process.execPath} ${fixture}`;
-		const saved = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+		const saved = SessionManager.create(root, SessionManager.managedDestination(root, agentDir));
 		await saved.ensureOnDisk();
 		const sessionId = saved.getSessionId();
 		const sessionPath = saved.getSessionFile();
@@ -2255,7 +2259,7 @@ await fs.rm(endpoint);
 		const normalAgentDir = path.join(normalRoot, "agent");
 		const normalSaved = SessionManager.create(
 			normalRoot,
-			SessionManager.getDefaultSessionDir(normalRoot, normalAgentDir),
+			SessionManager.managedDestination(normalRoot, normalAgentDir),
 		);
 		try {
 			await normalSaved.ensureOnDisk();
@@ -2681,7 +2685,7 @@ test("broker atomically reuses the indexed live owner for distinct resume keys",
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-resume-live-"));
 	const agentDir = path.join(root, "agent");
 	const stateRoot = path.join(root, ".gjc", "state");
-	const savedSession = SessionManager.create(root, SessionManager.getDefaultSessionDir(root, agentDir));
+	const savedSession = SessionManager.create(root, SessionManager.managedDestination(root, agentDir));
 	await savedSession.ensureOnDisk();
 	const sessionId = savedSession.getSessionId();
 	const sessionPath = savedSession.getSessionFile();


### PR DESCRIPTION
## Summary

Repair the compatibility regressions exposed after #2724 while preserving #2745/#2768 and the owner-only file-descriptor security model.

## Failure classification and repair matrix

| Category | Classification | Resolution |
|---|---|---|
| A. Managed lifecycle destination/modes and owner isolation | Stale test topology exposed by stricter production checks | Keep managed roots external under `/tmp/gjc-local/` and all existing owner/mode/inode verification. Make replacement fixture files `0600` and directories `0700`; do not relax production security. |
| B. `'/home/bellman/.gjc/agent/sessions/v2-gqn3sqxo5qflkbsn4rjbhavbiooachvqvhgvg4rih5wposjlil4a/2026-07-20T00-26-08-845Z_019f7cea-784d-7000-b740-d7b967f9d289/local'` root and PLAN/hashline/write/mv behavior | Product compatibility regression | Carry managed-destination provenance through session/tool/plan/task call sites. Explicit destinations resolve under the artifact directory's `local` child; managed destinations retain external owner-only roots and guarded legacy migration. |
| C. Pre-admission artifact spill | Stale timing seam | Gate the current atomic `saveArtifact` API rather than the obsolete allocation seam, deterministically proving provider admission waits for durable spill completion. |
| D. Auto-handoff artifact save | Stale expectation | Assert the intentional secure artifact URI result, resolve through `SessionManager`, and verify exact persisted content instead of requiring an exposed markdown path. |
| E. Shard-8 failures | Covered by the same managed lifecycle and local-routing compatibility boundary | Focused owner-isolation, local protocol, lifecycle, and tool selectors are green; no security assertion or timeout was weakened. |

Failed base runs:
- https://github.com/Yeachan-Heo/gajae-code/actions/runs/29775434129
- https://github.com/Yeachan-Heo/gajae-code/actions/runs/29776346009

## Verification

- `bun --cwd=packages/coding-agent run check`: pass
- Permitted final focused compatibility/security batch: **263 pass, 0 fail**, 1417 expectations across 11 files
- Exact shard 2/8 selector: **1486 pass, 0 fail**
- Shard 3/8 is non-authoritative locally because it contains prohibited OpenAI Responses replay coverage plus unrelated load-dependent timeout/runtime failures; the replay file was not rerun after that classification and no timeout was weakened.
- Exact local shard attempts for 4/8, 5/8, and 6/8 cleared the repaired failure categories but encountered unrelated machine/environment failures (ACP/plugin MCP/browser runtime and load-sensitive message-pipeline tests). Hosted CI is the authority for those full shards.
- Shard 7/8 was already green in the failed base run and required no repair.

## Security invariants

- Managed destinations remain outside session artifact trees.
- Owner-only file and directory modes remain mandatory.
- FD-backed mode/owner/inode checks are unchanged.
- Managed legacy migration remains gated and symlink/root safety remains enforced.
