### PR TITLE
test(coding-agent): fix stale local override disposal test (postmerge Dev CI, refs #2772)

### DIFF
--- a/packages/coding-agent/test/sdk-session-isolation.test.ts
+++ b/packages/coding-agent/test/sdk-session-isolation.test.ts
@@ -6,7 +6,7 @@ import { type AssistantMessage, getBundledModel } from "@gajae-code/ai";
 import type { Rule } from "@gajae-code/coding-agent/capability/rule";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import type { ExtensionFactory } from "@gajae-code/coding-agent/extensibility/extensions";
-import { LocalProtocolHandler, resolveLocalUrlToPath } from "@gajae-code/coding-agent/internal-urls";
+import { LocalProtocolHandler, resolveLocalRoot, resolveLocalUrlToPath } from "@gajae-code/coding-agent/internal-urls";
 import { AgentRegistry } from "@gajae-code/coding-agent/registry/agent-registry";
 import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import { createSecretObfuscator } from "@gajae-code/coding-agent/secrets";
@@ -181,7 +181,7 @@ describe("createAgentSession session storage isolation", () => {
 				})
 			).session;
 			expect(resolveLocalUrlToPath("local://note.md", LocalProtocolHandler.resolveOptions()!)).toBe(
-				path.join(os.tmpdir(), "gjc-local", "first-local-session", "note.md"),
+				path.join(firstArtifactsDir, "local", "note.md"),
 			);
 
 			secondSession = (
@@ -194,14 +194,89 @@ describe("createAgentSession session storage isolation", () => {
 				})
 			).session;
 			expect(resolveLocalUrlToPath("local://note.md", LocalProtocolHandler.resolveOptions()!)).toBe(
-				path.join(os.tmpdir(), "gjc-local", "second-local-session", "note.md"),
+				path.join(secondArtifactsDir, "local", "note.md"),
 			);
 
+			// Dispose the first (bottom-of-stack) override while the second remains installed;
+			// only the first session's override may be removed and the second must still resolve.
+			await firstSession.dispose();
+			firstSession = undefined;
+			expect(resolveLocalUrlToPath("local://note.md", LocalProtocolHandler.resolveOptions()!)).toBe(
+				path.join(secondArtifactsDir, "local", "note.md"),
+			);
+
+			// Disposing the remaining second override restores the default/fallback resolution.
+			await secondSession.dispose();
+			secondSession = undefined;
+			expect(LocalProtocolHandler.resolveOptions()).toBeUndefined();
+
+			// Managed-destination sessions retain their owner-only external gjc-local root.
+			expect(
+				resolveLocalRoot({
+					getArtifactsDir: () => firstArtifactsDir,
+					isManagedDestination: () => true,
+					getSessionId: () => "managed-owner-session",
+				}),
+			).toBe(path.join(os.tmpdir(), "gjc-local", "managed-owner-session"));
+		} finally {
+			await secondSession?.dispose();
+			await firstSession?.dispose();
+		}
+	});
+
+	it("restores the previous session's local:// override when the top override is disposed (LIFO)", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-local-protocol-lifo-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const cwd = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		const firstArtifactsDir = path.join(tempDir, "first-artifacts");
+		const secondArtifactsDir = path.join(tempDir, "second-artifacts");
+		fs.mkdirSync(cwd, { recursive: true });
+		const sessionOptions = {
+			cwd,
+			agentDir,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		};
+		let firstSession: AgentSession | undefined;
+		let secondSession: AgentSession | undefined;
+		try {
+			firstSession = (
+				await createAgentSession({
+					...sessionOptions,
+					localProtocolOptions: {
+						getArtifactsDir: () => firstArtifactsDir,
+						getSessionId: () => "first-local-session",
+					},
+				})
+			).session;
+			secondSession = (
+				await createAgentSession({
+					...sessionOptions,
+					localProtocolOptions: {
+						getArtifactsDir: () => secondArtifactsDir,
+						getSessionId: () => "second-local-session",
+					},
+				})
+			).session;
+			expect(resolveLocalUrlToPath("local://note.md", LocalProtocolHandler.resolveOptions()!)).toBe(
+				path.join(secondArtifactsDir, "local", "note.md"),
+			);
+
+			// Dispose the top-of-stack (second) override; the previous (first) override must be restored.
 			await secondSession.dispose();
 			secondSession = undefined;
 			expect(resolveLocalUrlToPath("local://note.md", LocalProtocolHandler.resolveOptions()!)).toBe(
-				path.join(os.tmpdir(), "gjc-local", "first-local-session", "note.md"),
+				path.join(firstArtifactsDir, "local", "note.md"),
 			);
+
+			// Disposing the last remaining override restores the default/fallback resolution.
 			await firstSession.dispose();
 			firstSession = undefined;
 			expect(LocalProtocolHandler.resolveOptions()).toBeUndefined();


### PR DESCRIPTION
## Summary

Repairs the postmerge Dev CI failure in
`createAgentSession session storage isolation > releases each session's owned local:// override on dispose`.

**Classification: stale test expectation, not a production leak.**

### Failing runs
- postmerge Dev CI: https://github.com/Yeachan-Heo/gajae-code/actions/runs/29783183699
- PR #2746 Dev CI (same failure): https://github.com/Yeachan-Heo/gajae-code/actions/runs/29784175502
- Base dev commit: `06bad4dd` (#2772, "restore destination-aware local artifacts")

## Root cause (resolved from source + git history, not the failure narrative)

The failure occurs at the **first assertion, before any disposal**:

```
Expected: "/tmp/gjc-local/first-local-session/note.md"
Received: "/tmp/<tmp>/first-artifacts/local/note.md"
```

#2772 **intentionally** made non-managed sessions that supply `getArtifactsDir`
resolve `local://` to `<artifactsDir>/local`, while **managed** destinations
(`isManagedDestination() === true`) keep the owner-only external
`gjc-local/<sessionId>` root. #2772 added the routing contract test in
`test/internal-urls/local-protocol.test.ts` asserting exactly this.

`test/sdk-session-isolation.test.ts` predates #2772 and was **not** updated by
it, so it still hardcoded the pre-#2772 `gjc-local/<sessionId>` paths for
non-managed sessions — the identical input now has a different, intended output.

## Why this is not a production leak

Ownership/stacking/unregister/dispose was verified correct by direct
instrumentation:

- `LocalProtocolHandler.installOverride` pushes onto a `#ownedOverrides` stack
  and returns a disposer that splices out **only its own** registration.
- `resolveOptions()` returns the top of stack (`.at(-1)`), else the live main
  session, else `undefined`.
- Installing `[first, second]`, disposing the **bottom** (first) leaves the top
  (second) intact; disposing the top (second) restores the previous (first);
  disposing the last restores the default/fallback. Disposal is idempotent.
- `session.dispose()` → `releaseLocalProtocolOverride()` → the installer's
  disposer. No registry leak exists.

Therefore the fix is **test-only**; no production behavior change is warranted.
Changing production to satisfy the stale expectation would reverse #2772 and
contradict its routing test.

## Change

`test/sdk-session-isolation.test.ts` only:

- Align the isolation test with the #2772 destination-aware contract:
  each non-managed session resolves to its **own distinct** `<artifactsDir>/local`.
- Strengthen the disposal-isolation guard with **both** stack orderings:
  - **bottom-of-stack:** dispose the first (non-top) override while the second
    remains, prove the second still resolves to its own root, then dispose the
    second and prove the default/fallback resolution is restored.
  - **LIFO/top-of-stack:** dispose the second (top) override and prove the
    previous (first) override is restored, then dispose the first and prove the
    default/fallback resolution is restored.
- Retain managed-destination owner-only external `gjc-local/<sessionId>` coverage.

This keeps the regression guard meaningful: a real disposal leak (whole-stack
clear, wrong-registration removal, or missing fallback) fails at least one
ordering.

## Verification

- Focused: `bun test test/sdk-session-isolation.test.ts` → **8 pass / 0 fail**.
- Package check: `bun run check` (biome 2267 files clean + `tsc --noEmit` clean).
- Shard-equivalent: `bun test --shard=6/8` (the shard containing the file) →
  1144 pass; the only failures are pre-existing infra-dependent tests unrelated
  to this change (`always-on plugin-bundle MCP in a live session`, `offline
  stealth benchmark`).

Refs #2772
