### PR TITLE
fix(coding-agent): break compiled startup import cycle

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -20,7 +20,6 @@ import {
 	VERSION,
 } from "@gajae-code/utils";
 import chalk from "chalk";
-import { runCli } from "./cli";
 import type { Args } from "./cli/args";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
@@ -1629,5 +1628,6 @@ export async function main(args: string[]): Promise<void> {
 		await completeManagedOwnerRecovery(admission.context);
 		return;
 	}
+	const { runCli } = await import("./cli");
 	await runCli(args.length === 0 ? ["launch"] : args);
 }

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -2036,7 +2036,9 @@ async function reclaimDeadDaemonOwner(input: {
 	if (!state || pidAlive(state.pid)) return false;
 	const lock = await readOwnershipLock(fsImpl, paths.lock);
 	if (lock.kind === "missing") return false;
-	if (!(await ownershipLockIsReclaimable({ fs: fsImpl, path: paths.lock, lock, now: now(), pidAlive, pidIncarnation })))
+	if (
+		!(await ownershipLockIsReclaimable({ fs: fsImpl, path: paths.lock, lock, now: now(), pidAlive, pidIncarnation }))
+	)
 		return false;
 	const transition = await acquireDaemonTransitionLock({
 		fs: fsImpl,

--- a/packages/coding-agent/test/issue-2778-repro.test.ts
+++ b/packages/coding-agent/test/issue-2778-repro.test.ts
@@ -1,5 +1,5 @@
-import * as path from "node:path";
 import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
 
 const mainPath = path.resolve(import.meta.dir, "../src/main.ts");
 

--- a/packages/coding-agent/test/issue-2778-repro.test.ts
+++ b/packages/coding-agent/test/issue-2778-repro.test.ts
@@ -1,0 +1,16 @@
+import * as path from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const mainPath = path.resolve(import.meta.dir, "../src/main.ts");
+
+describe("issue #2778 — compiled startup entrypoint", () => {
+	test("keeps the cli import out of main's static module graph", async () => {
+		const source = await Bun.file(mainPath).text();
+
+		// cli.ts registers commands that import main.ts. A static main -> cli edge
+		// closes that cycle; Bun 1.3.14 standalone binaries spin in the cycle before
+		// request/session startup, even though source-mode ESM happens to complete.
+		expect(source).not.toMatch(/import\s+\{\s*runCli\s*\}\s+from\s+["']\.\/cli["']/);
+		expect(source).toContain('const { runCli } = await import("./cli");');
+	});
+});

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -471,7 +471,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:confirmTelegramDaemonSpawn": "0a1326ba8971e774f8f1a42ac1e10ba682f02460646d73dd340da5739ca777a2",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:defaultPidIncarnation": "377afc123d25710c634df1fcc7f39a0c24d2034e0c31e8ed407435cc4c55a313",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:ensureTelegramDaemonRunning": "0dbc6e3450ee72827d720cf492b69c4659e2f366d4d2ff4c008cc19f793a5a19",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:ensureTelegramDaemonRunningDetailed": "294073d5188e33bb4830e223c09d5da0fca6d7bd35b5fabef94a1577de38f48a",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:ensureTelegramDaemonRunningDetailed": "2110f8dd201799eeaf7e2b7965b1964e8f5743e4392a07602d322d90f27871a5",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:hasSafeDaemonStateShape": "9cbc3723dec8704b55e2350c9679f7de9219affc99b2820de0a03fb72ee4172b",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:isCurrentCompatibleOwner": "a1952b6356fd090a4f2031b3ffdfc090448bf3f2ced243a473c81f33f222da50",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:isFreshLiveOwner": "e6ae047ab6c06d2fbfd1f534f13db6d81ab390ff91feb02f75296be28e94163a",
@@ -501,7 +501,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:writeJsonAtomic": "a768c87646d56cf28b0adbd596884c964aed54ea40775517fa385c111af05a5b"
   },
   "nativeAuthoritySha256": {
-    "crates/pi-natives/src/path_identity.rs": "dd3bec63d7c862664f7adfba0d661b4408d2f0f14acd3d93f64ab8697c30fab9",
+    "crates/pi-natives/src/path_identity.rs": "04e0c4c1e7024752f6cc9d2d74dd8514c9b5fdc18ab7897332750f3f90b3cb54",
     "crates/pi-natives/src/ps.rs": "3c8a28d1daf84e91c3db0d29fa05a6231b871903800428ca1acbb2ddecea5f6b",
     "crates/pi-shell/src/process.rs": "3f74458492c16fff24ecc234c74efd29d2a7f5f5c5a7c879c68b00a2e4f08274",
     "packages/natives/native/index.d.ts": "86ac7c64960e28daad9b9ff1d1512d3916a7855c0aa5c814745dbfe0135be4fe",


### PR DESCRIPTION
## Summary

- restore the lazy `main.ts -> cli.ts` boundary that existed in v0.11.4
- keep managed-owner admission ahead of CLI loading
- add an issue-specific regression guard preventing a static `runCli` import from returning

Closes #2778.

## Root cause

v0.11.5 changed `main.ts` from a dynamic `await import("./cli")` to a top-level static import. The CLI command registry includes `launch.ts`, `acp.ts`, and `sdk.ts`, which import exports from `main.ts`, so that change created a real cycle:

```
main.ts -> cli.ts -> command registry -> launch.ts/sdk.ts -> main.ts
```

Source-mode Bun 1.3.14 happens to evaluate this graph successfully. Bun 1.3.14 `--compile` does not: the standalone binary enters a JS/JIT busy loop before request/session startup. This explains the complete isolation matrix from #2778: v0.11.4 compiled works, v0.11.5 source works, and only v0.11.5 compiled hangs. It also explains why `--version`/`--help` work: those fast paths return before loading the request/session graph.

The fix is intentionally one behavioral line: load `./cli` dynamically after the managed-owner preflight. No session, SDK, native, provider, or daemon behavior changes.

## Reproduction and verification

Reproduced on `snowyserver-n100` (Ubuntu x86_64):

- official v0.11.5 compiled binary: `gjc -p --no-session "Reply ok"` timed out repeatedly (including with a clean agent directory)
- v0.11.4 compiled binary: returned `ok`, exit 0
- v0.11.5 source via Bun: returned `ok`, exit 0
- locally rebuilt v0.11.5 compiled binary before this patch: timed out, exit 124
- same source rebuilt with this patch: returned `ok`, exit 0

Automated check run:

```
bun test packages/coding-agent/test/issue-2778-repro.test.ts
# 1 pass, 0 fail
```

The regression test documents the compile-only cycle and enforces the lazy boundary.
