### PR TITLE
fix(notifications): reclaim retained legacy stopped locks

### DIFF
--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
@@ -21,7 +21,8 @@ export const NOTIFICATION_PROTOCOL_VERSION = 3;
  * confirmed-dead owner's lock in generation 10, legacy stopped-tombstone
  * reclamation in generation 11, force-escalated SIGKILL of an unresponsive
  * older-generation owner during automatic generation-upgrade reload in
- * generation 12, and restored macOS daemon signaling (kill(2) with a start-time
- * incarnation recheck, replacing the darwin no-op) in generation 13.
+ * generation 12, restored macOS daemon signaling (kill(2) with a start-time
+ * incarnation recheck, replacing the darwin no-op) in generation 13, and
+ * retained legacy stopped-lock reclamation in generation 14.
  */
-export const DAEMON_GENERATION = 13;
+export const DAEMON_GENERATION = 14;

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -591,8 +591,15 @@ function ownershipLockMatchesState(lock: OwnershipLockRead, state: DaemonState |
 	);
 }
 
-function ownershipLockMatchesStoppedState(lock: OwnershipLockRead, state: DaemonState | undefined): boolean {
-	return Boolean(state && isExplicitlyStoppedDaemonState(state) && ownershipLockMatchesState(lock, state));
+function ownershipLockMatchesStoppedState(lock: OwnershipLockRead, state: unknown): boolean {
+	if (isExplicitlyStoppedDaemonState(state)) return ownershipLockMatchesState(lock, state);
+	if (!isLegacyStoppedDaemonState(state) || lock.kind !== "legacy") return false;
+	const legacyState = state as Pick<DaemonState, "pid" | "startedAt"> & { stoppedAt: number };
+	return (
+		lock.metadata.pid === legacyState.pid &&
+		lock.metadata.startedAt <= legacyState.startedAt &&
+		legacyState.startedAt <= legacyState.stoppedAt
+	);
 }
 
 async function transitionLockIsHeldByCaller(input: {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -924,6 +924,44 @@ describe("telegram daemon", () => {
 		).resolves.toMatchObject({ acquired: true, ownerId: "replacement" });
 		expect(JSON.parse(fs.readFileSync(paths.state, "utf8"))).not.toHaveProperty("stoppedAt");
 	});
+	test.each([
+		["matching", { pid: 111, startedAt: 0 }, { acquired: true, ownerId: "replacement" }],
+		["newer-start-time", { pid: 111, startedAt: 3 }, { acquired: false, blocked: true }],
+		["different-pid", { pid: 112, startedAt: 0 }, { acquired: false, blocked: true }],
+	] as const)("handles a %s retained legacy lock without reclaiming a newer reservation", async (_case, lock, expected) => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const paths = daemonPaths(agentDir);
+		fs.mkdirSync(paths.dir, { recursive: true });
+		fs.writeFileSync(
+			paths.state,
+			JSON.stringify({
+				pid: 111,
+				ownerId: "legacy-stopped",
+				tokenFingerprint: "fp",
+				chatId: "42",
+				startedAt: 1,
+				heartbeatAt: 1,
+				stoppedAt: 2,
+				roots: [],
+				version: DAEMON_VERSION,
+			}),
+		);
+		fs.writeFileSync(paths.lock, JSON.stringify(lock));
+
+		await expect(
+			acquireDaemonOwnership({
+				settings: s,
+				tokenFingerprint: "fp",
+				chatId: "42",
+				pid: 222,
+				ownerId: "replacement",
+				pidAlive: pid => pid === lock.pid || pid === process.pid,
+				pidIncarnation: pid =>
+					pid === 222 ? "linux:101" : pid === process.pid ? `linux:${process.pid}` : undefined,
+			}),
+		).resolves.toMatchObject(expected);
+	});
 	test("keeps a live malformed legacy tombstone blocked when launcherPid is invalid", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
@@ -2016,9 +2054,9 @@ describe("telegram daemon", () => {
 			}),
 		);
 	}
-	test("keeps the wire protocol at 3 while restored macOS daemon signaling uses generation 13", () => {
+	test("keeps the wire protocol at 3 while retained legacy stopped-lock reclamation uses generation 14", () => {
 		expect(NOTIFICATION_PROTOCOL_VERSION).toBe(3);
-		expect(DAEMON_GENERATION).toBe(13);
+		expect(DAEMON_GENERATION).toBe(14);
 	});
 
 	test("#2028 acquire flags a reload for a live pre-upgrade owner missing the generation field", async () => {

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -445,7 +445,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:ownerPidFromOwnerId": "46691373b2bee01f28f3817a6aa6a7efffe880c2cea337c89155582c98d952bf",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonInternal": "4d61235b0c32bf9afc63e1af29eaeca05368607c4997257c15febe071b30b582",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonSmoke": "6f085a667aa5c83de46d2d8945fb845c355fcbb43c46872342a44489203a5830",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "450f1fc7b357b00edde2b04ff2d169768e159294fc8bc613ad40f2f3e60d8d93",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "06faeeda807e16c14b782ad2a35d0d2c6ab1a1b7f52cb1ee30ef7b4352f9a681",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:NOTIFICATION_PROTOCOL_VERSION": "b99289f651fedcf020d28dbaf6f07dd37e7e4a5f6dc1f5118b872112325f1e81",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:TelegramDaemonController": "315d6d63d05d0217e2eb5ec57bcc89e93317f2ce36f2fff0348328b3396941a1",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:clearOwnRequest": "5f02e8a6d69b7400db8aa5f6e33a4efcc29d9b36aa0d71aaeab151b9dbe710c3",


### PR DESCRIPTION
## Summary

- recognize an exact pre-incarnation `{ pid, startedAt }` ownership lock as belonging to its legacy stopped tombstone
- retain fail-closed behavior for different-PID and different-start-time legacy locks
- bump `DAEMON_GENERATION` to 12 and refresh the lifecycle guard manifest

Follow-up to #2780 and addresses the post-merge review at https://github.com/Yeachan-Heo/gajae-code/pull/2780#pullrequestreview-4740734325.

## Root cause

#2780 made legacy stopped state reclaimable, but `ownershipLockMatchesStoppedState()` only matched canonical acquisition locks. If an older daemon crashed before unlinking its `{ pid, startedAt }` lock, the retained lock was still treated as a live ambiguous reservation and takeover returned provisional.

The fix accepts only an exact legacy lock/state pair while holding the existing transition fence. Any mismatch remains protected.

## Verification

- deterministic regression reproduced the matching retained-lock failure before the fix
- focused Telegram daemon tests: 7 pass
- Biome on affected source/tests: clean
- Telegram daemon generation authority and policy guards: pass