### PR TITLE
feat(coding-agent): add live Codex usage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,18 @@ gjc ultragoal complete-goals
 
 Add `gjc team ...` only when coordinated tmux workers materially help.
 
+### Live Codex usage
+
+For stored OpenAI Codex credentials, `gjc usage` provides a script-friendly live quota probe:
+
+```sh
+gjc usage --live --json
+```
+
+The command is intentionally narrow: it checks only stored `openai-codex` credentials, requires the explicit `--live` flag, and probes accounts sequentially with a bounded per-account timeout (`--timeout <ms>`, 1000-30000, default 10000). Malformed invocations fail before credential discovery.
+
+JSON output is a closed v1 document containing only account identity, status, and normalized quota limits. It does not expose credential row ids, raw provider payloads, metadata, scopes, raw error strings, access tokens, refresh tokens, or API keys.
+
 ## Core capabilities
 
 - **Interview before guessing**: `deep-interview` turns vague requests into concrete requirements.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Added provider pre-filtering to `AuthStorage.checkCredentials()` so diagnostic probes can restrict stored credentials before refresh or network side effects.
 
 ## [0.11.4] - 2026-07-20
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -121,6 +121,8 @@ export interface CheckCredentialsOptions {
 	signal?: AbortSignal;
 	/** Per-credential probe timeout (ms). Defaults to the configured usage request timeout. */
 	timeoutMs?: number;
+	/** Restrict checks to these providers before any resolver, refresh, or network probe runs. */
+	providers?: readonly Provider[];
 	/** Provider → base URL override, same shape as {@link AuthStorage.fetchUsageReports}. */
 	baseUrlResolver?: (provider: Provider) => string | undefined;
 }
@@ -2525,7 +2527,9 @@ export class AuthStorage {
 	 */
 	async checkCredentials(options?: CheckCredentialsOptions): Promise<CredentialHealthResult[]> {
 		options?.signal?.throwIfAborted();
-		const stored = this.#store.listAuthCredentials();
+		const stored = this.#store
+			.listAuthCredentials()
+			.filter(row => !options?.providers || options.providers.includes(row.provider as Provider));
 		const resolver = this.#usageProviderResolver;
 		const timeoutMs = options?.timeoutMs ?? this.#usageRequestTimeoutMs;
 		const ctx: UsageFetchContext = { fetch: this.#usageFetch, logger: this.#usageLogger };

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2608,7 +2608,7 @@ export class AuthStorage {
 			}
 
 			try {
-				const report = await providerImpl.fetchUsage(params, ctx);
+				const report = await raceUsageWithSignal(providerImpl.fetchUsage(params, ctx), probeSignal);
 				if (report === null) {
 					base.reason = "usage probe returned no data for this credential";
 				} else {

--- a/packages/ai/test/auth-storage-check-credentials.test.ts
+++ b/packages/ai/test/auth-storage-check-credentials.test.ts
@@ -23,6 +23,7 @@ import {
 	AuthStorage,
 	type StoredAuthCredential,
 } from "../src/auth-storage";
+import type { UsageProvider } from "../src/usage";
 import * as claudeUsage from "../src/usage/claude";
 
 function oauthRow(id: number, email: string, opts?: { expired?: boolean }): StoredAuthCredential {
@@ -35,6 +36,15 @@ function oauthRow(id: number, email: string, opts?: { expired?: boolean }): Stor
 		email,
 	};
 	return { id, provider: "anthropic", credential, disabledCause: null };
+}
+function providerOauthRow(
+	id: number,
+	provider: string,
+	email: string,
+	opts?: { expired?: boolean },
+): StoredAuthCredential {
+	const row = oauthRow(id, email, opts);
+	return { ...row, provider };
 }
 
 function makeStore(
@@ -249,6 +259,46 @@ describe("AuthStorage.checkCredentials", () => {
 			// failed (the second one) or returned no data (the third one).
 			expect(results[1].email).toBe("beta@example.com");
 			expect(results[2].email).toBe("gamma@example.com");
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("filters providers before resolver lookup, refresh, or probe side effects", async () => {
+		const refreshSpy = vi.fn<NonNullable<AuthCredentialStore["refreshOAuthCredential"]>>();
+		const store = makeStore(
+			[
+				providerOauthRow(1, "anthropic", "excluded@example.com", { expired: true }),
+				providerOauthRow(2, "openai-codex", "codex@example.com"),
+			],
+			refreshSpy,
+		);
+		const fetchUsage = vi.fn<UsageProvider["fetchUsage"]>().mockResolvedValue({
+			provider: "openai-codex",
+			fetchedAt: Date.now(),
+			limits: [],
+			metadata: { email: "codex@example.com", accountId: "account-2" },
+		});
+		const provider: UsageProvider = { id: "openai-codex", fetchUsage };
+		const resolver = vi.fn((candidate: string) => (candidate === "openai-codex" ? provider : undefined));
+
+		const storage = new AuthStorage(store, { usageProviderResolver: resolver });
+		await storage.reload();
+
+		try {
+			const results = await storage.checkCredentials({ providers: ["openai-codex"] });
+
+			expect(results).toHaveLength(1);
+			expect(results[0]).toMatchObject({
+				id: 2,
+				provider: "openai-codex",
+				email: "codex@example.com",
+				ok: true,
+			});
+			expect(resolver).toHaveBeenCalledTimes(1);
+			expect(resolver).toHaveBeenCalledWith("openai-codex");
+			expect(fetchUsage).toHaveBeenCalledTimes(1);
+			expect(refreshSpy).not.toHaveBeenCalled();
 		} finally {
 			storage.close();
 		}

--- a/packages/ai/test/auth-storage-check-credentials.test.ts
+++ b/packages/ai/test/auth-storage-check-credentials.test.ts
@@ -264,6 +264,41 @@ describe("AuthStorage.checkCredentials", () => {
 		}
 	});
 
+	it("bounds an uncooperative usage probe and continues to the next credential", async () => {
+		const store = makeStore([
+			providerOauthRow(1, "openai-codex", "timed-out@example.com"),
+			providerOauthRow(2, "openai-codex", "healthy@example.com"),
+		]);
+		const neverSettles = Promise.withResolvers<null>();
+		const fetchUsage = vi
+			.fn<UsageProvider["fetchUsage"]>()
+			.mockImplementationOnce(() => neverSettles.promise)
+			.mockResolvedValueOnce({
+				provider: "openai-codex",
+				fetchedAt: Date.now(),
+				limits: [],
+				metadata: { email: "healthy@example.com", accountId: "account-2" },
+			});
+		const provider: UsageProvider = { id: "openai-codex", fetchUsage };
+		const storage = new AuthStorage(store, { usageProviderResolver: () => provider });
+		await storage.reload();
+
+		try {
+			const startedAt = performance.now();
+			const results = await storage.checkCredentials({ timeoutMs: 10 });
+			const elapsedMs = performance.now() - startedAt;
+
+			expect(results).toMatchObject([
+				{ id: 1, provider: "openai-codex", ok: false, reason: "usage fetch aborted" },
+				{ id: 2, provider: "openai-codex", email: "healthy@example.com", ok: true },
+			]);
+			expect(fetchUsage).toHaveBeenCalledTimes(2);
+			expect(elapsedMs).toBeLessThan(1_000);
+		} finally {
+			storage.close();
+		}
+	});
+
 	it("filters providers before resolver lookup, refresh, or probe side effects", async () => {
 		const refreshSpy = vi.fn<NonNullable<AuthCredentialStore["refreshOAuthCredential"]>>();
 		const store = makeStore(

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Fixed
 
 - Internal transcript PageUp/PageDown now keeps moving through tool-output and other non-semantic rows instead of intermittently becoming a no-op after scrolling through anchored conversation content.
+### Added
+- Added `gjc usage --live --json` for live, per-account OpenAI Codex quota probes from stored credentials, with a closed secret-free JSON v1 output and strict invalid-invocation handling.
 
 ## [0.11.5] - 2026-07-20
 ### Changed

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -41,6 +41,7 @@ export const commands: CommandEntry[] = [
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },
 	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
 	{ name: "stats", load: () => import("./commands/stats").then(m => m.default) },
+	{ name: "usage", load: () => import("./commands/usage").then(m => m.default) },
 	{ name: "notify", load: () => import("./commands/notify").then(m => m.default) },
 	{ name: "sdk", load: () => import("./commands/sdk").then(m => m.default) },
 	{ name: "daemon", load: () => import("./commands/daemon").then(m => m.default) },

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -1,0 +1,228 @@
+import type { CredentialHealthResult, Provider, UsageLimit, UsageStatus, UsageUnit } from "@gajae-code/ai";
+import { discoverAuthStorage } from "../sdk";
+
+export const USAGE_PROVIDER = "openai-codex" satisfies Provider;
+export const DEFAULT_USAGE_TIMEOUT_MS = 10_000;
+export const MIN_USAGE_TIMEOUT_MS = 1_000;
+export const MAX_USAGE_TIMEOUT_MS = 30_000;
+
+export interface UsageCommandArgs {
+	json: boolean;
+	live: true;
+	timeoutMs: number;
+}
+
+export type UsageParseResult =
+	| { kind: "args"; args: UsageCommandArgs }
+	| { kind: "help" }
+	| { kind: "error"; message: string };
+
+interface UsageAuthStorage {
+	checkCredentials(options: { timeoutMs: number; providers: readonly Provider[] }): Promise<CredentialHealthResult[]>;
+	close(): void;
+}
+
+interface UsageCommandDeps {
+	discoverAuthStorage: () => Promise<UsageAuthStorage>;
+	now: () => number;
+	write: (value: string) => void;
+}
+
+export interface UsageJsonV1 {
+	schemaVersion: 1;
+	fetchedAt: number;
+	provider: typeof USAGE_PROVIDER;
+	live: true;
+	accounts: UsageAccountV1[];
+}
+
+export interface UsageAccountV1 {
+	identity: { email: string | null; accountId: string | null };
+	status: "ok" | "error" | "unavailable";
+	error: null | "probe_failed" | "probe_unavailable";
+	limits: UsageLimitV1[];
+}
+
+export interface UsageLimitV1 {
+	id: string;
+	label: string;
+	status: UsageStatus | null;
+	window: { id: string; label: string; durationMs: number | null; resetsAt: number | null } | null;
+	amount: {
+		unit: UsageUnit;
+		used: number | null;
+		limit: number | null;
+		remaining: number | null;
+		usedFraction: number | null;
+		remainingFraction: number | null;
+	};
+}
+
+const defaultDeps: UsageCommandDeps = {
+	discoverAuthStorage,
+	now: Date.now,
+	write: value => process.stdout.write(value),
+};
+
+function isHelpArg(arg: string): boolean {
+	return arg === "--help" || arg === "-h";
+}
+
+function isDecimalInteger(value: string): boolean {
+	return /^[0-9]+$/.test(value);
+}
+
+function validateTimeout(value: string | undefined): { ok: true; value: number } | { ok: false; message: string } {
+	if (value === undefined) return { ok: false, message: "--timeout requires a value" };
+	if (!isDecimalInteger(value)) return { ok: false, message: "--timeout must be an integer number of milliseconds" };
+	const timeoutMs = Number.parseInt(value, 10);
+	if (timeoutMs < MIN_USAGE_TIMEOUT_MS || timeoutMs > MAX_USAGE_TIMEOUT_MS) {
+		return {
+			ok: false,
+			message: `--timeout must be between ${MIN_USAGE_TIMEOUT_MS} and ${MAX_USAGE_TIMEOUT_MS} milliseconds`,
+		};
+	}
+	return { ok: true, value: timeoutMs };
+}
+
+export function parseUsageRawArgv(argv: readonly string[]): UsageParseResult {
+	if (argv.length === 1 && isHelpArg(argv[0])) return { kind: "help" };
+	if (argv.some(isHelpArg)) return { kind: "error", message: "usage help cannot be combined with other arguments" };
+
+	let live = false;
+	let json = false;
+	let timeoutMs = DEFAULT_USAGE_TIMEOUT_MS;
+	let timeoutSeen = false;
+
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--") return { kind: "error", message: "usage does not accept positional arguments" };
+		if (arg === "--live") {
+			if (live) return { kind: "error", message: "duplicate --live flag" };
+			live = true;
+			continue;
+		}
+		if (arg === "--json" || arg === "-j") {
+			if (json) return { kind: "error", message: "duplicate --json flag" };
+			json = true;
+			continue;
+		}
+		if (arg === "--timeout") {
+			if (timeoutSeen) return { kind: "error", message: "duplicate --timeout flag" };
+			timeoutSeen = true;
+			const parsed = validateTimeout(argv[i + 1]);
+			if (!parsed.ok) return { kind: "error", message: parsed.message };
+			timeoutMs = parsed.value;
+			i++;
+			continue;
+		}
+		if (arg.startsWith("--timeout=")) {
+			return { kind: "error", message: "use --timeout <milliseconds>" };
+		}
+		if (arg === "--provider" || arg.startsWith("--provider=")) {
+			return { kind: "error", message: "usage is fixed to openai-codex and does not accept --provider" };
+		}
+		if (arg.startsWith("-")) return { kind: "error", message: `unknown usage flag: ${arg}` };
+		return { kind: "error", message: "usage does not accept positional arguments" };
+	}
+
+	if (!live) return { kind: "error", message: "usage requires --live" };
+	return { kind: "args", args: { json, live: true, timeoutMs } };
+}
+
+function nullableNumber(value: number | undefined): number | null {
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function toUsageLimit(limit: UsageLimit): UsageLimitV1 {
+	return {
+		id: limit.id,
+		label: limit.label,
+		status: limit.status ?? null,
+		window: limit.window
+			? {
+					id: limit.window.id,
+					label: limit.window.label,
+					durationMs: nullableNumber(limit.window.durationMs),
+					resetsAt: nullableNumber(limit.window.resetsAt),
+				}
+			: null,
+		amount: {
+			unit: limit.amount.unit,
+			used: nullableNumber(limit.amount.used),
+			limit: nullableNumber(limit.amount.limit),
+			remaining: nullableNumber(limit.amount.remaining),
+			usedFraction: nullableNumber(limit.amount.usedFraction),
+			remainingFraction: nullableNumber(limit.amount.remainingFraction),
+		},
+	};
+}
+
+export function toUsageAccount(result: CredentialHealthResult): UsageAccountV1 {
+	if (result.ok === true) {
+		return {
+			identity: { email: result.email ?? null, accountId: result.accountId ?? null },
+			status: "ok",
+			error: null,
+			limits: (result.report?.limits ?? []).map(toUsageLimit),
+		};
+	}
+	return {
+		identity: { email: result.email ?? null, accountId: result.accountId ?? null },
+		status: result.ok === false ? "error" : "unavailable",
+		error: result.ok === false ? "probe_failed" : "probe_unavailable",
+		limits: [],
+	};
+}
+
+export function formatUsageText(result: UsageJsonV1): string {
+	if (result.accounts.length === 0) return `No stored ${USAGE_PROVIDER} credentials found.\n`;
+	const lines = result.accounts.map((account, index) => {
+		const identity = account.identity.email ?? account.identity.accountId ?? `account ${index + 1}`;
+		if (account.status !== "ok") return `${identity}: ${account.status} (${account.error})`;
+		const limits = account.limits
+			.map(limit => {
+				const remaining = limit.amount.remaining;
+				return `${limit.label}: ${remaining === null ? "unknown" : `${remaining}%`} remaining`;
+			})
+			.join(", ");
+		return `${identity}: ${limits || "usage available"}`;
+	});
+	return `${lines.join("\n")}\n`;
+}
+
+export function renderUsageHelp(bin: string): string {
+	return `View live OpenAI Codex usage for stored GJC credentials\n\nUSAGE\n  $ ${bin} usage --live [FLAGS]\n\nFLAGS\n  -j, --json             Output one JSON v1 document\n      --live             Probe stored openai-codex credentials live (required)\n      --timeout <ms>     Per-account probe timeout, ${MIN_USAGE_TIMEOUT_MS}-${MAX_USAGE_TIMEOUT_MS} ms (default: ${DEFAULT_USAGE_TIMEOUT_MS})\n  -h, --help             Show this help\n`;
+}
+
+export function writeUsageError(
+	message: string,
+	writeStderr: (value: string) => void = value => process.stderr.write(value),
+): void {
+	writeStderr(`Error: ${message}\n`);
+}
+
+export async function runUsageCommand(
+	args: UsageCommandArgs,
+	deps: UsageCommandDeps = defaultDeps,
+): Promise<UsageJsonV1> {
+	if (args.live !== true) throw new Error("usage requires --live");
+	if (args.timeoutMs < MIN_USAGE_TIMEOUT_MS || args.timeoutMs > MAX_USAGE_TIMEOUT_MS) {
+		throw new Error(`usage timeout must be between ${MIN_USAGE_TIMEOUT_MS} and ${MAX_USAGE_TIMEOUT_MS} ms`);
+	}
+	const storage = await deps.discoverAuthStorage();
+	try {
+		const checks = await storage.checkCredentials({ timeoutMs: args.timeoutMs, providers: [USAGE_PROVIDER] });
+		const result: UsageJsonV1 = {
+			schemaVersion: 1,
+			fetchedAt: deps.now(),
+			provider: USAGE_PROVIDER,
+			live: true,
+			accounts: checks.filter(check => check.provider === USAGE_PROVIDER).map(toUsageAccount),
+		};
+		deps.write(args.json ? `${JSON.stringify(result)}\n` : formatUsageText(result));
+		return result;
+	} finally {
+		storage.close();
+	}
+}

--- a/packages/coding-agent/src/commands/usage.ts
+++ b/packages/coding-agent/src/commands/usage.ts
@@ -1,0 +1,22 @@
+import { Command } from "@gajae-code/utils/cli";
+import { parseUsageRawArgv, renderUsageHelp, runUsageCommand, writeUsageError } from "../cli/usage-cli";
+
+export default class Usage extends Command {
+	static description = "View live OpenAI Codex usage for stored GJC credentials";
+	static delegateHelp = true;
+	static strict = false;
+
+	async run(): Promise<void> {
+		const parsed = parseUsageRawArgv(this.argv);
+		if (parsed.kind === "help") {
+			process.stdout.write(renderUsageHelp(this.config.bin));
+			return;
+		}
+		if (parsed.kind === "error") {
+			writeUsageError(parsed.message);
+			process.exitCode = 2;
+			return;
+		}
+		await runUsageCommand(parsed.args);
+	}
+}

--- a/packages/coding-agent/test/cli-command-registry.test.ts
+++ b/packages/coding-agent/test/cli-command-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { commands } from "../src/cli";
+import { commands, routeRootArgv } from "../src/cli";
 
 describe("CLI command registry", () => {
 	it("registers the `plugin` command so `gjc plugin …` resolves instead of routing to launch", () => {
@@ -48,5 +48,22 @@ describe("CLI command registry", () => {
 		const cmd = (await entry?.load()) as { description?: string } | undefined;
 		expect(cmd).toBeDefined();
 		expect(cmd?.description ?? "").toMatch(/usage statistics/i);
+	});
+
+	it("registers the `usage` command so live usage probes do not route to launch", () => {
+		const entry = commands.find(c => c.name === "usage");
+		expect(entry).toBeDefined();
+		expect(routeRootArgv(["usage", "--live", "--json"])).toEqual(["usage", "--live", "--json"]);
+		expect(routeRootArgv(["usage please summarize this code"])).toEqual([
+			"launch",
+			"usage please summarize this code",
+		]);
+	});
+
+	it("lazily resolves the registered `usage` entry to the Usage command class", async () => {
+		const entry = commands.find(c => c.name === "usage");
+		const cmd = (await entry?.load()) as { description?: string } | undefined;
+		expect(cmd).toBeDefined();
+		expect(cmd?.description ?? "").toMatch(/Codex usage/i);
 	});
 });

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -32,6 +32,7 @@ describe("GJC public CLI command surface", () => {
 			"ralplan",
 			"config",
 			"stats",
+			"usage",
 			"notify",
 			"sdk",
 			"daemon",
@@ -116,6 +117,59 @@ describe("GJC public CLI command surface", () => {
 		expect(stdout).toContain("Check for and install updates");
 		expect(combined).not.toContain("What's New");
 		expect(combined).not.toContain("chatContainer");
+	}, 30_000);
+	it("exposes the usage command help without probing credentials", async () => {
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-usage-help-home-"));
+		try {
+			const result = Bun.spawnSync(["bun", cliEntry, "usage", "--help"], {
+				cwd: repoRoot,
+				env: { ...process.env, HOME: home, GJC_CODING_AGENT_DIR: path.join(home, ".gjc", "agent") },
+				stderr: "pipe",
+				stdout: "pipe",
+			});
+			const stdout = result.stdout.toString();
+			const stderr = result.stderr.toString();
+
+			expect(result.exitCode, stderr).toBe(0);
+			expect(stdout).toContain("gjc usage --live");
+			expect(stdout).toContain("--timeout");
+			expect(stderr).toBe("");
+		} finally {
+			await fs.rm(home, { recursive: true, force: true });
+		}
+	}, 30_000);
+
+	it("rejects invalid usage invocations with empty stdout", async () => {
+		for (const argv of [
+			["usage"],
+			["usage", "--json"],
+			["usage", "extra", "--live"],
+			["usage", "--live", "--provider", "anthropic"],
+			["usage", "--live", "--provider=anthropic"],
+			["usage", "--live", "--unknown"],
+			["usage", "--live", "--timeout", "999"],
+			["usage", "--live", "--timeout=1000"],
+			["usage", "--live", "--help"],
+		] as const) {
+			const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-usage-invalid-home-"));
+			try {
+				const result = Bun.spawnSync(["bun", cliEntry, ...argv], {
+					cwd: repoRoot,
+					env: { ...process.env, HOME: home, GJC_CODING_AGENT_DIR: path.join(home, ".gjc", "agent") },
+					stderr: "pipe",
+					stdout: "pipe",
+				});
+				const stdout = result.stdout.toString();
+				const stderr = result.stderr.toString();
+
+				expect(result.exitCode, argv.join(" ")).not.toBe(0);
+				expect(stdout, argv.join(" ")).toBe("");
+				expect(stderr, argv.join(" ")).toContain("Error:");
+				expect(stderr, argv.join(" ")).not.toContain("USAGE");
+			} finally {
+				await fs.rm(home, { recursive: true, force: true });
+			}
+		}
 	}, 30_000);
 	it("documents the session-index repair flag in gc help", () => {
 		const result = Bun.spawnSync(["bun", cliEntry, "gc", "--help"], {

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { CredentialHealthResult } from "@gajae-code/ai";
+import {
+	DEFAULT_USAGE_TIMEOUT_MS,
+	MAX_USAGE_TIMEOUT_MS,
+	MIN_USAGE_TIMEOUT_MS,
+	parseUsageRawArgv,
+	runUsageCommand,
+	toUsageAccount,
+	USAGE_PROVIDER,
+} from "../src/cli/usage-cli";
+
+function collectKeys(value: unknown, keys = new Set<string>()): Set<string> {
+	if (Array.isArray(value)) {
+		for (const item of value) collectKeys(item, keys);
+		return keys;
+	}
+	if (value !== null && typeof value === "object") {
+		for (const [key, nested] of Object.entries(value)) {
+			keys.add(key);
+			collectKeys(nested, keys);
+		}
+	}
+	return keys;
+}
+
+describe("parseUsageRawArgv", () => {
+	it("accepts only the explicit live Codex usage forms", () => {
+		expect(parseUsageRawArgv(["--live"])).toEqual({
+			kind: "args",
+			args: { json: false, live: true, timeoutMs: DEFAULT_USAGE_TIMEOUT_MS },
+		});
+		expect(parseUsageRawArgv(["--live", "--json", "--timeout", String(MIN_USAGE_TIMEOUT_MS)])).toEqual({
+			kind: "args",
+			args: { json: true, live: true, timeoutMs: MIN_USAGE_TIMEOUT_MS },
+		});
+		expect(parseUsageRawArgv(["-j", "--timeout", String(MAX_USAGE_TIMEOUT_MS), "--live"])).toEqual({
+			kind: "args",
+			args: { json: true, live: true, timeoutMs: MAX_USAGE_TIMEOUT_MS },
+		});
+	});
+
+	it("routes standalone help without accepting mixed help", () => {
+		expect(parseUsageRawArgv(["--help"])).toEqual({ kind: "help" });
+		expect(parseUsageRawArgv(["-h"])).toEqual({ kind: "help" });
+		expect(parseUsageRawArgv(["--live", "--help"]).kind).toBe("error");
+	});
+
+	it("rejects malformed input before storage discovery can run", () => {
+		for (const argv of [
+			[],
+			["--json"],
+			["extra", "--live"],
+			["--live", "extra"],
+			["--live", "--provider", "anthropic"],
+			["--live", "--provider=anthropic"],
+			["--live", "--unknown"],
+			["--live", "--live"],
+			["--live", "--json", "-j"],
+			["--live", "--timeout"],
+			["--live", "--timeout=1000"],
+			["--live", "--timeout", "999"],
+			["--live", "--timeout", "30001"],
+			["--live", "--timeout", "abc"],
+			["--live", "--"],
+		] as const) {
+			expect(parseUsageRawArgv(argv).kind, argv.join(" ")).toBe("error");
+		}
+	});
+});
+
+describe("usage DTO mapping", () => {
+	it("maps credential health to a closed secret-free public DTO", () => {
+		const sentinel = "Bearer SECRET_ACCESS_TOKEN.abc.def";
+		const health = {
+			id: 42,
+			provider: USAGE_PROVIDER,
+			type: "oauth",
+			email: "user@example.com",
+			accountId: "acct_123",
+			remoteRefresh: true,
+			ok: true,
+			reason: sentinel,
+			report: {
+				provider: USAGE_PROVIDER,
+				fetchedAt: 123,
+				metadata: { accessToken: sentinel, tier: "pro" },
+				raw: { refreshToken: sentinel },
+				limits: [
+					{
+						id: "openai-codex:primary",
+						label: "7 days",
+						scope: { provider: USAGE_PROVIDER, accountId: "acct_123", tier: "pro" },
+						window: { id: "7d", label: "7 days", durationMs: 604_800_000, resetsAt: 1_800_000_000_000 },
+						amount: {
+							unit: "percent",
+							used: 18,
+							limit: 100,
+							remaining: 82,
+							usedFraction: 0.18,
+							remainingFraction: 0.82,
+						},
+						status: "ok",
+						notes: [sentinel],
+					},
+				],
+			},
+		} as unknown as CredentialHealthResult;
+
+		const dto = toUsageAccount(health);
+		expect(dto).toEqual({
+			identity: { email: "user@example.com", accountId: "acct_123" },
+			status: "ok",
+			error: null,
+			limits: [
+				{
+					id: "openai-codex:primary",
+					label: "7 days",
+					status: "ok",
+					window: { id: "7d", label: "7 days", durationMs: 604_800_000, resetsAt: 1_800_000_000_000 },
+					amount: {
+						unit: "percent",
+						used: 18,
+						limit: 100,
+						remaining: 82,
+						usedFraction: 0.18,
+						remainingFraction: 0.82,
+					},
+				},
+			],
+		});
+		for (const key of ["type", "remoteRefresh", "reason", "metadata", "raw", "scope", "notes"]) {
+			expect(collectKeys(dto).has(key), key).toBe(false);
+		}
+		expect(JSON.stringify(dto)).not.toContain("42");
+		expect(JSON.stringify(dto)).not.toContain("SECRET_ACCESS_TOKEN");
+	});
+
+	it("maps failed and unavailable probes to deterministic public errors", () => {
+		expect(
+			toUsageAccount({ provider: USAGE_PROVIDER, id: 1, type: "oauth", ok: false, reason: "401 token" }),
+		).toEqual({
+			identity: { email: null, accountId: null },
+			status: "error",
+			error: "probe_failed",
+			limits: [],
+		});
+		expect(toUsageAccount({ provider: USAGE_PROVIDER, id: 2, type: "oauth", ok: null })).toEqual({
+			identity: { email: null, accountId: null },
+			status: "unavailable",
+			error: "probe_unavailable",
+			limits: [],
+		});
+	});
+});
+
+describe("runUsageCommand", () => {
+	it("checks only openai-codex credentials and closes storage", async () => {
+		const write = vi.fn();
+		const close = vi.fn();
+		const checkCredentials = vi.fn().mockResolvedValue([]);
+		const discoverAuthStorage = vi.fn().mockResolvedValue({ checkCredentials, close });
+
+		const result = await runUsageCommand(
+			{ json: true, live: true, timeoutMs: 1_500 },
+			{ discoverAuthStorage, now: () => 99, write },
+		);
+
+		expect(result).toEqual({ schemaVersion: 1, fetchedAt: 99, provider: USAGE_PROVIDER, live: true, accounts: [] });
+		expect(checkCredentials).toHaveBeenCalledWith({ timeoutMs: 1_500, providers: [USAGE_PROVIDER] });
+		expect(write).toHaveBeenCalledWith(`${JSON.stringify(result)}\n`);
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## What
- Add `gjc usage --live [--json] [--timeout <ms>]` for live OpenAI Codex usage checks from stored credentials.
- Add provider pre-filtering to `AuthStorage.checkCredentials()` so non-Codex credentials are not resolved, refreshed, or probed.
- Emit a closed JSON v1 DTO that omits raw provider payloads, credential row ids, scopes, metadata, raw errors, and token-shaped secrets.
- Keep malformed `usage` invocations command-owned: nonzero, stderr diagnostic, empty stdout, and no storage discovery.

## Why
SwiftBar and other automation need a stable, official live quota surface. Without a real `usage` command, `gjc usage --live --json` can be misrouted as a launch prompt or depend on local-only patches.

## Duplicate search
Repeated immediately before PR creation with `dgk-dev` credentials:
- `gh search prs --repo Yeachan-Heo/gajae-code --state open -- 'usage OR quota OR "Codex usage" OR "openai-codex"'`
- `gh search issues --repo Yeachan-Heo/gajae-code --state open -- 'usage OR quota OR "live quota" OR "Codex usage" OR "openai-codex"'`
- `gh search prs --repo Yeachan-Heo/gajae-code --state closed -- '"Codex usage" OR quota OR "openai-codex"'`

No overlapping open PR/issue or incompatible closed PR was returned.

## Testing
- `bun test packages/ai/test/auth-storage-check-credentials.test.ts packages/coding-agent/test/usage-cli.test.ts packages/coding-agent/test/cli-command-registry.test.ts packages/coding-agent/test/cli-command-surface.test.ts packages/ai/test/openai-codex-usage.test.ts`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`
- Manual empty-store smoke: `HOME=$(mktemp -d) GJC_CODING_AGENT_DIR=$HOME/.gjc/agent bun packages/coding-agent/src/cli.ts usage --live --json`