### PR TITLE
fix(tui): ignore same-dimension resize events instead of clearing scrollback and replaying the transcript

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Spurious resize events with unchanged terminal dimensions (iTerm2 tab switches and window focus changes deliver SIGWINCH without a size change) no longer trigger a forced full redraw. On hosts still using the full clear+replay path (legacy multiplexer opt-in, non-process terminals) that redraw cleared scrollback (`2J`/`H`/`3J`) and replayed the entire transcript, which could park the native viewport at the top of the thread when returning to the tab. `requestResizeRender()` now forces only when the grid size actually changed since the last committed frame; same-size events fall through to a no-op diff render.
+
 ## [0.11.4] - 2026-07-20
 ### Fixed
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1339,9 +1339,20 @@ export class TUI extends Container {
 	 * the transcript top during streaming redraws, so viewport-repaint sessions
 	 * keep force off and let `#doRender` repaint only the live viewport. Set
 	 * `PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER=1` to restore the legacy tmux redraw.
+	 *
+	 * Spurious resize events (SIGWINCH with unchanged dimensions — iTerm2 tab
+	 * switches and window focus changes, the self-sent SIGWINCH after resume)
+	 * must not force either: on hosts still using the `fullRender` path (legacy
+	 * multiplexer opt-in, non-process terminals) the forced redraw clears
+	 * scrollback (`2J`/`H`/`3J`) and replays the whole transcript, which can
+	 * park the native viewport at the transcript top. Only force when the grid
+	 * size actually changed since the last committed frame; a plain diff render
+	 * is a no-op otherwise.
 	 */
 	requestResizeRender(): void {
-		this.requestRender(!useViewportRepaintPath(this.terminal), "resize");
+		const dimensionsChanged =
+			this.#previousWidth !== this.terminal.columns || this.#previousHeight !== this.terminal.rows;
+		this.requestRender(dimensionsChanged && !useViewportRepaintPath(this.terminal), "resize");
 	}
 
 	requestRender(force = false, source = "unknown"): void {

--- a/packages/tui/test/resize-replay-storm.test.ts
+++ b/packages/tui/test/resize-replay-storm.test.ts
@@ -447,5 +447,30 @@ describe("multiplexer resize replay storm regression", () => {
 
 			tui.stop();
 		});
+
+		it("ignores same-dimension resize events instead of clearing scrollback and replaying (iTerm2 tab switch)", async () => {
+			const term = new VirtualTerminal(COLS, 30);
+			const tui = new TUI(term);
+			tui.start();
+			await term.waitForRender();
+
+			await buildTranscript(tui, term, 60);
+			term.clearWriteLog();
+
+			// iTerm2 delivers SIGWINCH-driven resize events on tab activation and
+			// window focus changes without changing the grid size. Forcing the
+			// 2J/H/3J clear+replay on those events rebuilds scrollback and can park
+			// the native viewport at the transcript top ("thread jumps to the top
+			// after switching tabs"). A same-size event must be a plain diff render.
+			term.resize(COLS, 30);
+			await term.waitForRender();
+
+			const out = term.getWriteLog().join("");
+			expect(out).not.toContain("\x1b[3J");
+			expect(out).not.toContain("\x1b[2J");
+			expect(distinctReplayedLineMarkers(out)).toBe(0);
+
+			tui.stop();
+		});
 	});
 });


### PR DESCRIPTION
## Symptom

While working in iTerm2, switching to another tab and coming back occasionally leaves the viewport scrolled to the very top of the thread, forcing the user to scroll all the way back down to the prompt.

## Root cause

iTerm2 delivers SIGWINCH-driven `resize` events on tab activation and window focus changes **without an actual grid size change**. `TUI.requestResizeRender()` treated every resize event as real and requested a forced render.

On the code base where the symptom was observed (pre-#2130), native terminals took the `fullRender(true)` path: `\x1b[2J\x1b[H\x1b[3J` (clear screen **and scrollback**) followed by a replay of the entire transcript. Rebuilding scrollback from scratch can leave iTerm's viewport parked at the top of the replayed transcript — exactly the reported symptom.

## Relationship to #2130 (current `main`)

After rebasing onto `main` I re-verified the landscape: #2130 already routes real process terminals through the viewport-repaint path, so the destructive clear+replay no longer fires there. This PR narrows to the remaining gap, which is still test-detectable on `main`:

- Hosts where `useViewportRepaintPath` is false (legacy `PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER=1` opt-in, non-process `Terminal` implementations) still get the full `2J/H/3J` clear+replay on a spurious same-size resize event.
- Viewport-repaint hosts still pay a pointless forced full-viewport repaint per spurious event.

`requestResizeRender()` now compares `terminal.columns/rows` against the last committed frame and only forces when the grid size actually changed. Same-size events fall through to a plain diff render (a no-op when nothing changed).

Unaffected paths:
- Genuine resizes (dimensions differ → existing behavior preserved)
- Ctrl+Z resume and external-editor return (they call `requestRender(true)` directly, not the resize path)
- First render / post-`stop()` states (`#previousWidth === 0` counts as changed)

## Verification

- New regression test in `resize-replay-storm.test.ts` ("ignores same-dimension resize events …"): with the guard reverted on current `main` it fails by catching the exact `2J/H/3J` + full 60-line transcript replay; with the guard it passes with zero replayed lines
- `bun test packages/tui/test/resize-replay-storm.test.ts` — 14/14 pass
- `bun test packages/tui/` — 834 pass, 0 fail
- `bun check` (biome + `tsc --noEmit`) in `packages/tui` — clean
- Changelog entry added under `packages/tui/CHANGELOG.md` `[Unreleased]` (released sections untouched)