### PR TITLE
fix(ai): classify Fable 5 as adaptive thinking and opt into summarized display

### DIFF
--- a/artifacts/architecture-2383-eval.json
+++ b/artifacts/architecture-2383-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "59955056d1120403917d633051a37698cd157c73",
-		"providerSourceSha256": "22abd82c2a3740c6ad77bc84d28b1c62946b856d761a1dc70eb38ef2c74f8884",
+		"providerSourceBlobOid": "009b09e7486f3fd2f58476776a82d822e7629e42",
+		"providerSourceSha256": "5bcae1bfedc0f8330f53bb8ae8e1c11e8bc2874a2c8b52f5f588f3b15b8c1c59",
 		"inputFixtureSha256": "b1ca8d3183ca168140774f848ed414252178f7c5788d61243069862ae59c129b"
 	},
 	"derivationCommands": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -32,6 +32,9 @@
 ### Fixed
 
 - Fixed frequent `Request blocked (code=invalid_prompt)` failures on gpt-5.6 (Sol/Terra/Luna) subagent, default-agent, and compaction turns (ref openai/codex#32028, oh-my-pi#5184). Leaked Harmony control-token markers (e.g. `<|channel|>analysis`) were only neutralized on the replayed-history payload path, so markers in assistant reasoning summaries, live-converted message/tool-output text, and user-authored content reached the OpenAI Responses and OpenAI-codex-responses transports verbatim and wedged the session (the poisoned item was re-sent every turn). Both transports now neutralize reserved control tokens across the entire outgoing `input` array at the request boundary via an idempotent zero-width-space insertion that keeps the text human-readable.
+### Fixed
+
+- Fixed Fable 5 adaptive thinking being billed but never displayed: model discovery now classifies `claude-fable-*` as `anthropic-adaptive` (was cached as `budget`, sending `enabled`+`budget_tokens` that Fable answers with signature-only thinking), and `supportsAdaptiveThinkingDisplay` opts Fable into `display: "summarized"` on both Anthropic Messages and Bedrock Converse transports (#2791).
 
 ## [0.10.0] - 2026-07-12
 ### Fixed

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -62,7 +62,7 @@ type SemVer = {
 };
 
 type GeminiKind = "pro" | "flash";
-type AnthropicKind = "opus" | "sonnet";
+type AnthropicKind = "opus" | "sonnet" | "fable";
 type OpenAIVariant =
 	| "base"
 	| "codex"
@@ -638,6 +638,11 @@ function inferAnthropicSupportedEfforts<TApi extends Api>(
 		(model.api === "anthropic-messages" || model.api === "bedrock-converse-stream") &&
 		semverGte(parsedModel.version, "4.6")
 	) {
+		if (parsedModel.kind === "fable") {
+			// Fable exposes Anthropic's Messages-only xhigh preset; Bedrock
+			// Converse lacks it (same split as Opus 4.7+ below).
+			return model.api === "anthropic-messages" ? DEFAULT_REASONING_EFFORTS_WITH_XHIGH : DEFAULT_REASONING_EFFORTS;
+		}
 		if (parsedModel.kind !== "opus") return DEFAULT_REASONING_EFFORTS;
 		return anthropicModelHasRealXHighEffort(model)
 			? DEFAULT_REASONING_EFFORTS_WITH_XHIGH_AND_MAX
@@ -697,7 +702,10 @@ function inferThinkingControlMode<TApi extends Api>(
 
 		case "bedrock-converse-stream":
 			if (parsedModel.family === "anthropic") {
-				if (semverGte(parsedModel.version, "4.6") && parsedModel.kind === "opus") {
+				if (
+					semverGte(parsedModel.version, "4.6") &&
+					(parsedModel.kind === "opus" || parsedModel.kind === "fable")
+				) {
 					return "anthropic-adaptive";
 				}
 				if (semverGte(parsedModel.version, "4.5")) {
@@ -737,7 +745,7 @@ function parseGeminiModel(modelId: string): GeminiModel | null {
 }
 
 function parseAnthropicModel(modelId: string): AnthropicModel | null {
-	const match = /claude-(opus|sonnet)-(\d{1,2}(?:[.-]\d{1,2}){0,2})\b/.exec(modelId);
+	const match = /claude-(opus|sonnet|fable)-(\d{1,2}(?:[.-]\d{1,2}){0,2})\b/.exec(modelId);
 	if (!match) {
 		return null;
 	}

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -910,11 +910,15 @@ function buildAdditionalModelRequestFields(
 /**
  * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
  * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
+ * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
+ * "omitted" — thinking tokens are billed but no content streams back — so it
+ * must opt in like Opus 4.7+ (issue #2791).
  * Bedrock model ids are prefixed with region/inference-profile slugs (e.g.
  * `eu.anthropic.Anthropic model-opus-4-7-...`); the regex matches the `Anthropic model-opus-X-Y`
  * fragment regardless of prefix.
  */
 function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
+	if (/claude-fable-\d/.test(modelId)) return true;
 	const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
 	if (!match) return false;
 	const major = Number(match[1]);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -306,8 +306,12 @@ let warnedStopSequencesTrim = false;
 /**
  * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
  * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
+ * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
+ * "omitted" — thinking tokens are billed but no content streams back — so it
+ * must opt in like Opus 4.7+ (issue #2791).
  */
 function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
+	if (/claude-fable-\d/.test(modelId)) return true;
 	const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
 	if (!match) return false;
 	const major = Number(match[1]);

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1137,6 +1137,35 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.output_config).toEqual({ effort: "high" });
 	});
 
+	it("requests summarized adaptive thinking for Fable 5 (issue #2791)", async () => {
+		const payload = (await captureAnthropicPayload(
+			{
+				...ANTHROPIC_MODEL,
+				id: "claude-fable-5",
+				name: "Anthropic Fable 5",
+				thinking: {
+					mode: "anthropic-adaptive",
+					minLevel: Effort.Minimal,
+					maxLevel: Effort.XHigh,
+				},
+			},
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				thinkingEnabled: true,
+				reasoning: Effort.High,
+			},
+		)) as {
+			thinking?: { type?: string; display?: string };
+			output_config?: { effort?: string };
+		};
+
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toEqual({ effort: "high" });
+	});
+
 	it("maps Opus max reasoning to Anthropic adaptive max", async () => {
 		const payload = (await captureAnthropicPayload(
 			{

--- a/packages/ai/test/issue-1373-repro.test.ts
+++ b/packages/ai/test/issue-1373-repro.test.ts
@@ -90,6 +90,16 @@ describe("issue #1373: Bedrock Claude thinkingDisplay", () => {
 		});
 	});
 
+	it("defaults adaptive thinking to display=summarized on Fable 5", async () => {
+		const payload = await captureBedrockPayload(adaptiveModel("us.anthropic.claude-fable-5"), {
+			reasoning: Effort.High,
+		});
+		expect(payload.additionalModelRequestFields?.thinking).toMatchObject({
+			type: "adaptive",
+			display: "summarized",
+		});
+	});
+
 	it("respects explicit thinkingDisplay='omitted' on Opus 4.7+", async () => {
 		const payload = await captureBedrockPayload(adaptiveModel("eu.anthropic.claude-opus-4-7"), {
 			reasoning: Effort.High,

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -155,6 +155,35 @@ describe("model thinking metadata", () => {
 		expect(() => mapEffortToAnthropicAdaptiveEffort(sonnet46, Effort.Max)).toThrow(/not supported/);
 		expect(mapEffortToAnthropicAdaptiveEffort(sonnet5, Effort.High)).toBe("high");
 	});
+
+	it("classifies Fable 5 as adaptive thinking with xhigh support (discovery metadata regression)", () => {
+		const fable = createModel({
+			id: "claude-fable-5",
+			api: "anthropic-messages",
+			provider: "anthropic",
+		});
+		const fableBedrock = createModel({
+			id: "us.anthropic.claude-fable-5",
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+		});
+
+		// Discovery previously parsed Fable as an unknown family and cached
+		// mode:"budget", which made requests send `enabled`+budget_tokens —
+		// Fable then returned signature-only thinking (billed, nothing shown).
+		expect(fable.thinking?.mode).toBe("anthropic-adaptive");
+		expect(fable.thinking?.minLevel).toBe(Effort.Minimal);
+		expect(fable.thinking?.maxLevel).toBe(Effort.XHigh);
+		expect(mapEffortToAnthropicAdaptiveEffort(fable, Effort.XHigh)).toBe("xhigh");
+		expect(() => mapEffortToAnthropicAdaptiveEffort(fable, Effort.Max)).toThrow(/not supported/);
+
+		// Bedrock Converse lacks the Messages-only xhigh preset (same split
+		// as Opus 4.7+), so Bedrock Fable stays clamped to high.
+		expect(fableBedrock.thinking?.mode).toBe("anthropic-adaptive");
+		expect(fableBedrock.thinking?.maxLevel).toBe(Effort.High);
+		expect(mapEffortToAnthropicAdaptiveEffort(fableBedrock, Effort.High)).toBe("high");
+		expect(() => mapEffortToAnthropicAdaptiveEffort(fableBedrock, Effort.XHigh)).toThrow(/not supported/);
+	});
 });
 
 describe("generated model policies", () => {


### PR DESCRIPTION
Closes #2791.

## Summary

`claude-fable-5` adaptive thinking was billed but never displayed. Two compounding bugs:

1. **Discovery misclassified Fable as `budget` thinking.** `parseAnthropicModel` only matched `claude-(opus|sonnet)-…`, so Fable parsed as family `unknown` and `inferThinkingControlMode` fell through to `"budget"`. Live `/v1/models` discovery cached that into `models.db`, overriding the bundled `anthropic-adaptive` metadata, and requests went out as `thinking: { type: "enabled", budget_tokens: … }` — Fable (adaptive-only) answers that with a signature-only thinking block: tokens billed, zero content, zero `thinking_delta`s.
2. **`display` opt-in missed Fable.** `supportsAdaptiveThinkingDisplay` only matched `claude-opus-X-Y`. Fable postdates Opus 4.7 and defaults `display` to `omitted`, so even a correct `type: "adaptive"` request returns no thinking content without the `display: "summarized"` opt-in.

## Changes

- `packages/ai/src/model-thinking.ts`
  - `parseAnthropicModel` regex now accepts `fable` as an Anthropic kind (`AnthropicKind` extended).
  - `anthropic-messages`: Fable ≥ 4.6 classifies as `anthropic-adaptive` (via the existing family/version branch).
  - `bedrock-converse-stream`: adaptive branch accepts `fable` alongside `opus`.
  - `inferAnthropicSupportedEfforts`: Fable keeps xhigh on the Messages API (`DEFAULT_REASONING_EFFORTS_WITH_XHIGH`, matching the bundled catalog's `maxLevel: xhigh`); Bedrock Converse stays clamped to `high` since it lacks the Messages-only xhigh preset — same split the existing Opus 4.7+ branch encodes (`opus47Bedrock` throws on XHigh in `model-thinking.test.ts`).
- `packages/ai/src/providers/anthropic.ts`, `packages/ai/src/providers/amazon-bedrock.ts`
  - `supportsAdaptiveThinkingDisplay` returns true for `claude-fable-\d` (covers Bedrock region/inference-profile prefixed ids).
- Tests: fable classification regression in `model-thinking.test.ts`; request-payload assertions for Fable `display: "summarized"` in `anthropic-alignment.test.ts` and `issue-1373-repro.test.ts`.
- `packages/ai/CHANGELOG.md`: Unreleased/Fixed entry.
- `artifacts/architecture-2383-eval.json`: regenerated via the sanctioned `WRITE_ARCHITECTURE_2383_EVAL=1` flow because `providers/anthropic.ts` changed (the eval pins its blob oid/sha256).

## Root-cause evidence (live, gjc 0.11.6 + Anthropic OAuth)

- Captured request before fix: `{"type":"enabled","budget_tokens":16384,"display":"summarized"}` → response contains `thinking_start` → empty `reasoning_summary_end` (`content:""`, `summaryText:""`) → `thinking_end`, **zero** `thinking_delta`/`reasoning_summary_delta`, while usage bills thinking output tokens. `models.db` `model_cache` row for `anthropic` held `{"id":"claude-fable-5","thinking":{"mode":"budget",…}}`.
- Control: raw `POST /v1/messages` with `{"type":"adaptive","display":"summarized"}` + `output_config:{"effort":"high"}` on the same account streams `thinking_delta`s with real text — identical event shape to `claude-opus-4-8`.
- After fix (patched install, discovery cache invalidated): request goes out as `{"type":"adaptive","display":"summarized"}` + `output_config:{"effort":"high"}` and real summary text streams (`reasoning_summary_delta`: "I'm working through a classic chickens-and-rabbits problem…").

## Verification

- Full `packages/ai` suite on this branch (rebased on `dev`): **1814 pass, 0 fail** (337 env-gated e2e skips)
- `bun --cwd=packages/coding-agent test test/model-profiles-catalog.test.ts test/model-selector-batch-thinking.test.ts` (fable-selector consumers) → 14 pass, 0 fail
- `bun --cwd=packages/ai run check` (biome full-package + `tsc --noEmit`) → clean
- Live end-to-end on a patched 0.11.6 install as described above.

## Notes

- Stale `models.db` caches keep the wrong `budget` classification until the anthropic provider row is re-discovered; entries refresh on the next discovery pass since the inferred metadata changes. No migration is included — flagging in case maintainers want a cache-version bump.
- `hasOpus47ApiRestrictions` (sampling-param stripping) intentionally stays opus-only: no observed evidence Fable rejects sampling params, and widening it without evidence risks silently dropping user-set temperature.
