### PR TITLE
fix(session): migrate legacy local root before resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Resumed managed sessions now complete the verified legacy `local://` artifact migration before synchronous path resolution, preserving legacy scratch files instead of failing startup with a migration-order error.
 
 ## [0.11.6] - 2026-07-21
 ## [0.11.5] - 2026-07-20

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1590,13 +1590,19 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// which collapses to the parent's dir for subagents (they adopt the
 		// parent's ArtifactManager) so one lookup hits everything.
 		const getArtifactsDir = () => sessionManager.getArtifactsDir();
+		const localProtocolOptions = options.localProtocolOptions ?? {
+			getArtifactsDir,
+			isManagedDestination: () => sessionManager.isManagedDestination(),
+			getManagedLegacyLocalMigrationSource: () => sessionManager.getManagedLegacyLocalMigrationSource(),
+			getSessionId: () => sessionManager.getSessionId(),
+		};
 		if (!options.parentTaskPrefix) {
 			setActiveSkills(skills);
 			setActiveRules([...rulebookRules, ...alwaysApplyRules]);
 			if (asyncJobManager) AsyncJobManager.setInstance(asyncJobManager);
 		}
+		await initializeLocalRoot(localProtocolOptions);
 		if (options.localProtocolOptions) {
-			await initializeLocalRoot(options.localProtocolOptions);
 			disposeLocalProtocolOverride = LocalProtocolHandler.installOverride(options.localProtocolOptions);
 		}
 		toolSession.getArtifactsDir = getArtifactsDir;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -5552,7 +5552,8 @@ export class SessionManager {
 	getManagedLegacyLocalMigrationSource(): ManagedLegacyLocalMigrationSource | null {
 		if (this.destination.kind !== "managed" || !this.#sessionFile || this.#adoptedArtifactManager) return null;
 		const store = this.#managedTranscriptStore();
-		const legacyLocalRoot = path.posix.join(path.basename(this.#sessionFile.slice(0, -6)), "local");
+		const legacyArtifactsRoot = path.basename(this.#sessionFile.slice(0, -6));
+		const legacyLocalRoot = path.posix.join(legacyArtifactsRoot, "local");
 		return {
 			capture: async () => {
 				let snapshot: native.NativeDirectoryTreeSnapshot;
@@ -5560,6 +5561,13 @@ export class SessionManager {
 					snapshot = store.captureTree(legacyLocalRoot);
 				} catch (error) {
 					if (error instanceof Error && error.message === "not_found") return null;
+					if (error instanceof Error && error.message === "reparse_point") {
+						try {
+							store.captureTree(legacyArtifactsRoot);
+						} catch (artifactsError) {
+							if (artifactsError instanceof Error && artifactsError.message === "not_found") return null;
+						}
+					}
 					throw error;
 				}
 				let totalBytes = 0;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -5552,11 +5552,12 @@ export class SessionManager {
 	getManagedLegacyLocalMigrationSource(): ManagedLegacyLocalMigrationSource | null {
 		if (this.destination.kind !== "managed" || !this.#sessionFile || this.#adoptedArtifactManager) return null;
 		const store = this.#managedTranscriptStore();
+		const legacyLocalRoot = path.posix.join(path.basename(this.#sessionFile.slice(0, -6)), "local");
 		return {
 			capture: async () => {
 				let snapshot: native.NativeDirectoryTreeSnapshot;
 				try {
-					snapshot = store.captureTree("local");
+					snapshot = store.captureTree(legacyLocalRoot);
 				} catch (error) {
 					if (error instanceof Error && error.message === "not_found") return null;
 					throw error;
@@ -5566,7 +5567,7 @@ export class SessionManager {
 				if (totalBytes > 64 * 1024 * 1024) throw new Error("Legacy local:// migration exceeds the safe size limit");
 				const entries = snapshot.entries.map(entry => {
 					if (entry.kind === "directory") return { relativePath: entry.relativePath, kind: "directory" as const };
-					const captured = store.readExpected(path.posix.join("local", entry.relativePath));
+					const captured = store.readExpected(path.posix.join(legacyLocalRoot, entry.relativePath));
 					if (
 						!captured ||
 						captured.identity.dev.toString() !== entry.dev ||
@@ -5582,12 +5583,12 @@ export class SessionManager {
 						sha256: entry.sha256,
 					};
 				});
-				const verified = store.captureTree("local");
+				const verified = store.captureTree(legacyLocalRoot);
 				if (JSON.stringify(verified) !== JSON.stringify(snapshot))
 					throw new Error("Legacy local:// migration source changed during capture");
 				return { snapshot, entries };
 			},
-			retire: snapshot => store.removeTreeExpected("local", snapshot),
+			retire: snapshot => store.removeTreeExpected(legacyLocalRoot, snapshot),
 		};
 	}
 

--- a/packages/coding-agent/test/sdk-session-isolation.test.ts
+++ b/packages/coding-agent/test/sdk-session-isolation.test.ts
@@ -105,6 +105,93 @@ describe("createAgentSession session storage isolation", () => {
 			await session.dispose();
 		}
 	});
+	it("migrates a resumed managed session's legacy local root before synchronous path resolution", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `gjc-sdk-local-resume-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const cwd = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const destination = SessionManager.managedDestination(cwd, agentDir);
+		const initialManager = SessionManager.create(cwd, destination);
+		initialManager.appendMessage({ role: "user", content: "legacy local migration", timestamp: Date.now() });
+		await initialManager.flush();
+		const sessionFile = initialManager.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persisted managed session path");
+		await initialManager.close();
+
+		const resumedManager = await SessionManager.open(sessionFile, destination);
+		const artifactsDir = resumedManager.getArtifactsDir();
+		if (!artifactsDir) throw new Error("Expected resumed managed artifacts path");
+		const legacyLocalRoot = path.join(artifactsDir, "local");
+		fs.mkdirSync(legacyLocalRoot, { recursive: true, mode: 0o700 });
+		fs.writeFileSync(path.join(legacyLocalRoot, "resume.md"), "preserved", { mode: 0o600 });
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			sessionManager: resumedManager,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			const localOptions = {
+				getArtifactsDir: () => resumedManager.getArtifactsDir(),
+				isManagedDestination: () => resumedManager.isManagedDestination(),
+				getManagedLegacyLocalMigrationSource: () => resumedManager.getManagedLegacyLocalMigrationSource(),
+				getSessionId: () => resumedManager.getSessionId(),
+			};
+			const resumedPath = resolveLocalUrlToPath("local://resume.md", localOptions);
+			expect(resumedPath).toBe(path.join(resolveLocalRoot(localOptions), "resume.md"));
+			expect(fs.readFileSync(resumedPath, "utf8")).toBe("preserved");
+			expect(fs.existsSync(legacyLocalRoot)).toBe(false);
+		} finally {
+			await session.dispose();
+		}
+	});
+	it("initializes a default local root without shadowing an explicit owner", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `gjc-sdk-local-owner-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const cwd = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		fs.mkdirSync(cwd, { recursive: true });
+		const owned = {
+			getArtifactsDir: () => path.join(tempDir, "owned-artifacts"),
+			getSessionId: () => "owned-local-session",
+		};
+		const disposeOwned = LocalProtocolHandler.installOverride(owned);
+
+		let session: AgentSession | undefined;
+		try {
+			session = (
+				await createAgentSession({
+					cwd,
+					agentDir,
+					settings: Settings.isolated(),
+					disableExtensionDiscovery: true,
+					skills: [],
+					contextFiles: [],
+					promptTemplates: [],
+					slashCommands: [],
+					enableMCP: false,
+					enableLsp: false,
+				})
+			).session;
+			expect(LocalProtocolHandler.resolveOptions()).toBe(owned);
+			await session.dispose();
+			session = undefined;
+			expect(LocalProtocolHandler.resolveOptions()).toBe(owned);
+		} finally {
+			await session?.dispose();
+			disposeOwned();
+		}
+	});
 	it("keeps settings storage usable while default sessions dispose independently", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-shared-storage-${Snowflake.next()}-`));
 		tempDirs.push(tempDir);

--- a/packages/coding-agent/test/sdk-session-isolation.test.ts
+++ b/packages/coding-agent/test/sdk-session-isolation.test.ts
@@ -154,7 +154,7 @@ describe("createAgentSession session storage isolation", () => {
 		} finally {
 			await session.dispose();
 		}
-	});
+	}, 20_000);
 	it("initializes a default local root without shadowing an explicit owner", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `gjc-sdk-local-owner-${Snowflake.next()}-`));
 		tempDirs.push(tempDir);


### PR DESCRIPTION
## What

- initialize each session's `/var/folders/l_/96t5smw134jg1f2n_p1vbg5m0000gn/T/gjc-local/019f82f8-bed6-7000-b851-0d286abe8903` root before synchronous path resolution and tool setup
- bind managed legacy migration to the actual `<session-artifacts>/local` subtree
- preserve verified legacy files in the external session scratch root, then retire only the exact captured source
- keep process-global local protocol overrides explicit so default/concurrent sessions cannot shadow another owner
- add managed-resume and override-isolation regressions

## Why

GJC 0.11.5/0.11.6 can fail when resuming an older managed session with:

```
/var/folders/l_/96t5smw134jg1f2n_p1vbg5m0000gn/T/gjc-local/019f82f8-bed6-7000-b851-0d286abe8903 legacy migration must complete before path resolution
```

The default SDK startup path did not await local-root initialization, while the managed migration capability looked for `local` at the transcript-store root instead of inside the session artifact directory. This left the legacy source unmigrated and allowed synchronous resume-time resolution to fail closed.

## Testing

- `bun test packages/coding-agent/test/sdk-session-isolation.test.ts packages/coding-agent/test/internal-urls/local-protocol.test.ts` — 24 pass
- `bun --cwd=packages/coding-agent run check` — pass (Biome + TypeScript)
- `bun run check` — TypeScript/workspace checks pass; the Rust lane stops on an unrelated existing Clippy `missing_const_for_fn` finding at `crates/pi-shell/src/process.rs:1339` (this PR does not modify that file)
- independent architecture re-review: CLEAR / APPROVE

---

- [ ] `bun check` passes (blocked by the unrelated existing Rust lint noted above)
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)