### PR TITLE
fix(session): degrade a missing resident image blob to a text block

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2493,6 +2493,43 @@ function residentBlobMissingPlaceholder(error: ResidentBlobMissingError): string
 	return `[Session resident ${error.kind} blob missing: sha256:${error.hash}; original content unavailable]`;
 }
 
+const RESIDENT_BLOB_MISSING_PLACEHOLDER_PREFIX = "[Session resident ";
+const RESIDENT_BLOB_MISSING_PLACEHOLDER_SUFFIX = "original content unavailable]";
+
+function isResidentBlobMissingPlaceholder(value: unknown): value is string {
+	return (
+		typeof value === "string" &&
+		value.startsWith(RESIDENT_BLOB_MISSING_PLACEHOLDER_PREFIX) &&
+		value.includes(" blob missing: sha256:") &&
+		value.endsWith(RESIDENT_BLOB_MISSING_PLACEHOLDER_SUFFIX)
+	);
+}
+
+/**
+ * A missing resident *image* blob would otherwise leave an image content block
+ * whose base64/URL payload is the human-readable "blob missing" placeholder —
+ * which providers reject outright (e.g. Anthropic 400 `invalid base64 data`),
+ * bricking every subsequent request in the session. Degrade such a block to a
+ * text block so one lost image can never poison the whole request.
+ */
+function degradeMissingResidentImageBlock(block: Record<string, unknown>): Record<string, unknown> | undefined {
+	if (block.type === "image" && block.source && typeof block.source === "object") {
+		const source = block.source as Record<string, unknown>;
+		if (isResidentBlobMissingPlaceholder(source.data)) return { type: "text", text: source.data };
+	}
+	if (block.type === "image_url") {
+		const image = block.image_url;
+		const url =
+			typeof image === "string"
+				? image
+				: image && typeof image === "object"
+					? (image as Record<string, unknown>).url
+					: undefined;
+		if (isResidentBlobMissingPlaceholder(url)) return { type: "text", text: url };
+	}
+	return undefined;
+}
+
 function externalizeResidentValueSync(obj: unknown, stores: ResidentBlobStores, key?: string): unknown {
 	if (obj === null || obj === undefined) return obj;
 	if (typeof obj === "string") {
@@ -2591,7 +2628,12 @@ function materializeResidentValueSync(
 			if (newValue !== value) changed = true;
 			return [childKey, newValue] as const;
 		});
-		return changed ? Object.fromEntries(entries) : obj;
+		const next = changed ? Object.fromEntries(entries) : obj;
+		if (missingPolicy === "placeholder" && next && typeof next === "object") {
+			const degraded = degradeMissingResidentImageBlock(next as Record<string, unknown>);
+			if (degraded) return degraded;
+		}
+		return next;
 	}
 	return obj;
 }

--- a/packages/coding-agent/test/resident-materialization.test.ts
+++ b/packages/coding-agent/test/resident-materialization.test.ts
@@ -127,6 +127,67 @@ describe("resident byte-sensitive IMAGE/PROVIDER materialization is fail-closed"
 	});
 });
 
+function messageEntry(content: unknown[]): Record<string, unknown> {
+	return {
+		type: "message",
+		id: "missing-image-entry",
+		parentId: null,
+		timestamp: new Date(0).toISOString(),
+		message: { role: "user", content, timestamp: 0 },
+	};
+}
+
+function materializedContent(entry: Record<string, unknown>, store: EphemeralBlobStore): unknown[] {
+	const [out] = materializeResidentEntriesForPersistenceForTests([entry], store);
+	return ((out as { message: { content: unknown[] } }).message.content ?? []) as unknown[];
+}
+
+// A missing resident IMAGE blob must never leave an image block whose base64/URL
+// payload is the "blob missing" placeholder: providers reject it (e.g. Anthropic
+// 400 `invalid base64 data`), bricking the whole session. The block is degraded
+// to a text block so one lost image cannot poison the request.
+describe("missing resident IMAGE blocks degrade to a valid text block", () => {
+	test("base64 image block with a missing imageData blob becomes a text block", () => {
+		const store = makeStore();
+		const entry = messageEntry([
+			{ type: "text", text: "screenshot:" },
+			{
+				type: "image",
+				source: { type: "base64", media_type: "image/webp", data: residentBlobSentinelForTests("imageData", MISSING_REF) },
+			},
+		]);
+		const [text, image] = materializedContent(entry, store) as Array<Record<string, unknown>>;
+		expect(text).toEqual({ type: "text", text: "screenshot:" });
+		expect(image.type).toBe("text");
+		expect(image.source).toBeUndefined();
+		expect(String(image.text)).toContain("Session resident imageData blob missing");
+		expect(JSON.stringify(image)).not.toContain(MISSING_REF);
+	});
+
+	test("image_url block with a missing imageUrl blob becomes a text block", () => {
+		const store = makeStore();
+		const entry = messageEntry([
+			{ type: "image_url", image_url: { url: residentBlobSentinelForTests("imageUrl", MISSING_REF) } },
+		]);
+		const [block] = materializedContent(entry, store) as Array<Record<string, unknown>>;
+		expect(block.type).toBe("text");
+		expect(block.image_url).toBeUndefined();
+		expect(String(block.text)).toContain("Session resident imageUrl blob missing");
+	});
+
+	test("a present image blob is preserved as an image block (no false degrade)", () => {
+		const store = makeStore();
+		const raw = Buffer.from("rawimagebytes");
+		const ref = store.putSync(raw).ref;
+		const entry = messageEntry([
+			{ type: "image", source: { type: "base64", media_type: "image/webp", data: residentBlobSentinelForTests("imageData", ref) } },
+		]);
+		const [block] = materializedContent(entry, store) as Array<Record<string, unknown>>;
+		expect(block.type).toBe("image");
+		expect((block.source as Record<string, unknown>).data).toBe(raw.toString("base64"));
+	});
+});
+
 describe("EphemeralBlobStore bounded cache + reset", () => {
 	test("getSync round-trips and dispose() clears disk + buffer cache (blob missing afterwards)", () => {
 		const store = makeStore();


### PR DESCRIPTION
## Problem

A session with an image whose content-addressed blob has gone missing is **bricked** — every request fails with an Anthropic 400, even a plain text message:

```
400 invalid_request_error:
messages.335.content.0.tool_result.content.1.image.source.base64: invalid base64 data
```

### Root cause

Resident images are externalized to a content-addressed blob and referenced in the session by a `blob:sha256:` sentinel. When that blob later goes missing from the store, request materialization (`materializeResidentValueSync`, policy `"placeholder"`) resolves the sentinel by substituting the human-readable placeholder

```
[Session resident imageData blob missing: sha256:<hash>; original content unavailable]
```

directly into the image block's `source.data` (or `image_url.url`). The block is still an **image** block, but its payload is not valid base64, so the provider rejects the whole request. Because the poisoned image lives in the persisted history, every subsequent turn re-sends message 335 and fails identically — the session can never make progress again.

Reproduced from a real 400 capture: `image.source.data` held the placeholder string above for `media_type: image/webp`, and `~/.gjc/agent/blobs/<hash>` was genuinely absent.

## Fix

During placeholder materialization, degrade a missing-image content block to a **text** block, so one lost image can never invalidate the request:

- Anthropic base64 image: `{type:"image", source:{type:"base64", …, data:<placeholder>}}` → `{type:"text", text:<placeholder>}`
- OpenAI-style: `{type:"image_url", image_url:{url:<placeholder>}}` → `{type:"text", text:<placeholder>}`

Only blocks whose payload is the "blob missing" placeholder are converted; present image blobs still materialize as image blocks (no false degrade). Text/other content and the `"throw"` policy are unchanged.

This unbricks existing sessions on the next request without touching persisted session data.

## Tests

`test/resident-materialization.test.ts`:
- missing `imageData` base64 block → text block (no `source`, no invalid base64, ref not leaked)
- missing `imageUrl` block → text block (no `image_url`)
- present image blob → preserved as an image block whose `source.data` is the real base64

Verified locally: `bun test test/resident-materialization.test.ts` (16 pass) and `tsc --noEmit` clean. Also reproduced end-to-end against the real crashing capture — the offending block now materializes to a valid text block and the request no longer 400s.
