### PR TITLE
fix(ai): degrade a non-base64 Anthropic image payload to text

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -604,6 +604,16 @@ export const stripClaudeToolPrefix = (name: string, prefixOverride: string = cla
 	return name.slice(prefixOverride.length);
 };
 
+// Anthropic base64 image payloads use the standard alphabet only. A resident
+// image whose blob went missing carries a human-readable placeholder in `data`
+// (e.g. "[Session resident imageData blob missing: …]"); sending that as an
+// image yields a 400 `invalid base64 data` that rejects the whole request and
+// bricks the session. Guard the wire format so such payloads degrade to text.
+const ANTHROPIC_BASE64_IMAGE_DATA = /^[A-Za-z0-9+/]+={0,2}$/;
+function isAnthropicBase64ImageData(data: string): boolean {
+	return data.length > 0 && ANTHROPIC_BASE64_IMAGE_DATA.test(data);
+}
+
 /**
  * Convert content blocks to Anthropic API format
  */
@@ -627,7 +637,18 @@ function convertContentBlocks(
 		.filter((block): block is TextContent => block.type === "text")
 		.map(block => block.text.toWellFormed())
 		.filter(text => text.trim().length > 0);
-	const imageBlocks = content.filter((block): block is ImageContent => block.type === "image");
+	const imageBlocks: ImageContent[] = [];
+	for (const block of content) {
+		if (block.type !== "image") continue;
+		if (isAnthropicBase64ImageData(block.data)) {
+			imageBlocks.push(block);
+			continue;
+		}
+		// Non-base64 image payload (e.g. a missing-blob placeholder): degrade to
+		// text so one lost image cannot invalidate the entire request.
+		const text = block.data.toWellFormed().trim();
+		if (text.length > 0) textBlocks.push(text);
+	}
 	const omittedImages = !supportsImages && imageBlocks.length > 0;
 	if (imageBlocks.length === 0 || !supportsImages) {
 		if (omittedImages) {

--- a/packages/ai/test/missing-image-blob-degrade.test.ts
+++ b/packages/ai/test/missing-image-blob-degrade.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { convertAnthropicMessages } from "@gajae-code/ai/providers/anthropic";
+import type { AssistantMessage, Model, ToolResultMessage } from "@gajae-code/ai/types";
+
+/**
+ * A resident image externalized to a content-addressed blob is referenced by a
+ * `blob:sha256:` sentinel. When the blob goes missing, session materialization
+ * bakes a human-readable placeholder into the image block's `data`. The
+ * Anthropic adapter previously forwarded that placeholder as `source.data`,
+ * yielding `400 invalid base64 data` on every request — the session bricks,
+ * even for a plain text turn. A non-base64 image payload must degrade to text.
+ */
+
+const model: Model<"anthropic-messages"> = {
+	api: "anthropic-messages",
+	id: "claude-3-5-sonnet-20241022",
+	name: "Claude 3.5 Sonnet",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	maxTokens: 8192,
+	contextWindow: 200000,
+	reasoning: false,
+};
+
+const MISSING_IMAGE_PLACEHOLDER = `[Session resident imageData blob missing: sha256:${"0".repeat(64)}; original content unavailable]`;
+
+function assistantCall(id: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id, name: "read", arguments: {} }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-3-5-sonnet-20241022",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	};
+}
+
+function toolResult(id: string, content: ToolResultMessage["content"]): ToolResultMessage {
+	return { role: "toolResult", toolCallId: id, toolName: "read", content, isError: false, timestamp: Date.now() };
+}
+
+function lastToolResultBlock(params: ReturnType<typeof convertAnthropicMessages>): Record<string, unknown> {
+	const last = params.at(-1);
+	expect(last?.role).toBe("user");
+	const blocks = last?.content as unknown as Array<Record<string, unknown>>;
+	expect(Array.isArray(blocks)).toBe(true);
+	const block = blocks.find(b => b.type === "tool_result");
+	expect(block).toBeDefined();
+	return block as Record<string, unknown>;
+}
+
+describe("missing resident image blob degrades to text (no invalid base64 image)", () => {
+	it("degrades a non-base64 image payload to text so the request stays valid", () => {
+		const id = "toolu_missing";
+		const params = convertAnthropicMessages(
+			[
+				assistantCall(id),
+				toolResult(id, [
+					{ type: "text", text: "Read image file [image/webp]" },
+					{ type: "image", data: MISSING_IMAGE_PLACEHOLDER, mimeType: "image/webp" },
+				]),
+			],
+			model,
+			false,
+		);
+		const block = lastToolResultBlock(params);
+		const serialized = JSON.stringify(block.content);
+		// No image block survives, and no placeholder leaks into a base64 source.
+		expect(serialized).not.toContain('"type":"image"');
+		expect(serialized).not.toContain('"source"');
+		// The placeholder is preserved as text so the model still sees the context.
+		expect(serialized).toContain("blob missing");
+	});
+
+	it("preserves a valid base64 image as an image block", () => {
+		const id = "toolu_ok";
+		const data = Buffer.from("fake image bytes").toString("base64");
+		const params = convertAnthropicMessages(
+			[assistantCall(id), toolResult(id, [{ type: "image", data, mimeType: "image/png" }])],
+			model,
+			false,
+		);
+		const block = lastToolResultBlock(params);
+		const inner = block.content as Array<Record<string, unknown>>;
+		expect(Array.isArray(inner)).toBe(true);
+		const image = inner.find(b => b.type === "image") as { source: Record<string, unknown> } | undefined;
+		expect(image).toBeDefined();
+		expect(image?.source.type).toBe("base64");
+		expect(image?.source.data).toBe(data);
+		expect(image?.source.media_type).toBe("image/png");
+	});
+});


### PR DESCRIPTION
## Problem

A session that once contained an image whose content-addressed blob has since gone missing is **bricked**: every request fails with an Anthropic 400, even a plain text turn.

```
400 invalid_request_error:
messages.335.content.0.tool_result.content.1.image.source.base64: invalid base64 data
```

### Root cause

Resident images are externalized to a content-addressed blob and referenced by a `blob:sha256:` sentinel. When the blob goes missing, session materialization bakes a human-readable placeholder into the **internal** image block's `data`:

```jsonc
{ "type": "image",
  "data": "[Session resident imageData blob missing: sha256:<hash>; original content unavailable]",
  "mimeType": "image/webp" }
```

`convertContentBlocks` (in `providers/anthropic.ts`) maps that straight onto the wire block:

```ts
source: { type: "base64", media_type: block.mimeType, data: block.data }
```

so the request carries a non-base64 image payload → the API rejects the entire request. The poisoned image lives in the persisted `tool_result`, so every subsequent turn re-sends it and fails identically — the session can never make progress again.

Reproduced from a real 400 capture: the internal block held the placeholder string above with `mimeType: image/webp`, and `~/.gjc/agent/blobs/<hash>` was genuinely absent.

## Fix

Guard the Anthropic wire format in `convertContentBlocks`: an image whose `data` is not standard base64 is degraded to a **text** block (its placeholder is preserved so the model still sees the context) instead of being emitted as an image. Valid base64 images are unchanged.

This unbricks affected sessions on the next request without touching persisted session data, and is a pure, provider-boundary guard.

## Tests

`test/missing-image-blob-degrade.test.ts` (drives the exported `convertAnthropicMessages`):
- a missing-blob placeholder image degrades to text — the outgoing `tool_result` contains no `image`/`source`, and the placeholder survives as text
- a valid base64 image is preserved as an image block (`source.data` / `media_type` intact)

Verified end-to-end against the real crashing capture: feeding the exact internal `toolResult` message (paired with its `tool_use`) through `convertAnthropicMessages` now yields a valid text-only `tool_result` — no invalid base64. `bun test` (new + `issue-814-repro`) and `tsc --noEmit` pass.

## Note

This is the provider-boundary guard for Anthropic (the observed failure). Other provider adapters that forward `ImageContent.data` verbatim (OpenAI/Google) could exhibit the same class of failure and may warrant the same guard; scoped here to the reproduced bug.
