### PR TITLE
Fix misleading branch action label

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -68,6 +68,10 @@
 - SDK host shutdown now retries a failed broker unregister instead of short-circuiting with a stale broker-index entry, while retained startup-cleanup owner-release failures remain isolated from the red extension-error path (#2625).
 - Non-TTY launches now fail fast when stdin is empty and automatically use print mode for positional prompts and `@file` inputs, preventing orphaned interactive TUI processes (#2507).
 
+### Fixed
+
+- The command palette now labels `app.session.fork` as “Branch from message,” matching its user-message selector and `AgentSession.branch()` behavior while preserving the existing action ID for keybinding compatibility.
+
 ## [0.11.2] - 2026-07-19
 
 ### Changed

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -172,7 +172,7 @@ export const KEYBINDINGS = {
 	},
 	"app.session.fork": {
 		defaultKeys: [],
-		description: "Fork session",
+		description: "Branch from message",
 	},
 	"app.session.resume": {
 		defaultKeys: [],

--- a/packages/coding-agent/src/modes/action-registry.ts
+++ b/packages/coding-agent/src/modes/action-registry.ts
@@ -49,7 +49,7 @@ export const APP_ACTION_METADATA: readonly ActionMetadata[] = [
 	action("app.clipboard.copyPrompt", "Copy prompt", "Clipboard", ["composer"]),
 	action("app.session.new", "New session", "Session", ["composer"]),
 	action("app.session.tree", "Session tree", "Session", ["composer"]),
-	action("app.session.fork", "Fork session", "Session", ["composer"]),
+	action("app.session.fork", "Branch from message", "Session", ["composer"]),
 	action("app.session.resume", "Resume session", "Session", ["composer"]),
 	action("app.session.observe", "Observe sessions", "Session", ["composer"]),
 	action("app.session.dashboard", "Show sessions dashboard", "Session", ["composer"]),

--- a/packages/coding-agent/test/keybinding-domains.test.ts
+++ b/packages/coding-agent/test/keybinding-domains.test.ts
@@ -17,6 +17,11 @@ describe("application keybinding domains", () => {
 		expect(APP_ACTION_METADATA.filter(action => !(action.id in KEYBINDINGS))).toEqual([]);
 	});
 
+	it("labels the legacy fork action by its message-branch behavior", () => {
+		expect(metadataById.get("app.session.fork")?.title).toBe("Branch from message");
+		expect(KEYBINDINGS["app.session.fork"].description).toBe("Branch from message");
+	});
+
 	it("rejects default chord collisions within a focus domain", () => {
 		const owners = new Map<string, AppKeybinding[]>();
 		for (const action of APP_ACTION_METADATA) {


### PR DESCRIPTION
## What

Rename the command-palette and keybinding descriptions for `app.session.fork` from “Fork session” to “Branch from message.” Preserve the legacy action ID for keybinding compatibility and add regression coverage for both user-facing labels.

## Why

The action opens the user-message selector and dispatches to `AgentSession.branch()`, which creates a new session from the selected message. “Fork session” therefore misstates the observable behavior.

This does not restore `/fork` or `/branch` slash commands or change branching behavior.

## Testing

- `bun test packages/coding-agent/test/keybinding-domains.test.ts packages/coding-agent/test/input-controller-escape.test.ts` — 59 passed
- `git diff --check` — passed
- `bun check` — TypeScript/package checks completed successfully, but the unchanged Rust lane fails on `origin/dev` code because Clippy reports `crates/pi-shell/src/process.rs:1339` (`signal_root`) could be a `const fn` under `-D warnings`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)