### PR TITLE
fix(coding-agent): reject prose in singular pasted-image paths

### DIFF
--- a/packages/coding-agent/src/utils/pasted-image-path.ts
+++ b/packages/coding-agent/src/utils/pasted-image-path.ts
@@ -257,8 +257,10 @@ function isRecognizedClipboardTempPath(filePath: string, platform: NodeJS.Platfo
 /** Resolve one recognized clipboard-temp image path lexically, before any filesystem access. */
 export function resolvePastedImagePath(text: string, options: ResolvePastedImagePathOptions = {}): string | undefined {
 	const platform = options.platform ?? process.platform;
-	const candidate = decodePastedPathCandidate(text, options);
-	if (!candidate || !IMAGE_FILE_EXTENSION_PATTERN.test(candidate)) return undefined;
+	const candidates = decodePastedPathCandidates(text, options, 1);
+	if (candidates?.length !== 1) return undefined;
+	const candidate = candidates[0];
+	if (!IMAGE_FILE_EXTENSION_PATTERN.test(candidate)) return undefined;
 	if (platform === "win32" && isRemoteWindowsPath(candidate)) return undefined;
 	const resolved = resolveCandidate(candidate, options, platform);
 	return isRecognizedClipboardTempPath(resolved, platform) ? resolved : undefined;

--- a/packages/coding-agent/src/utils/pasted-image-path.ts
+++ b/packages/coding-agent/src/utils/pasted-image-path.ts
@@ -257,6 +257,7 @@ function isRecognizedClipboardTempPath(filePath: string, platform: NodeJS.Platfo
 /** Resolve one recognized clipboard-temp image path lexically, before any filesystem access. */
 export function resolvePastedImagePath(text: string, options: ResolvePastedImagePathOptions = {}): string | undefined {
 	const platform = options.platform ?? process.platform;
+	if (/[\r\n]/.test(text)) return undefined;
 	const candidates = decodePastedPathCandidates(text, options, 1);
 	if (candidates?.length !== 1) return undefined;
 	const candidate = candidates[0];

--- a/packages/coding-agent/test/pasted-image-path.test.ts
+++ b/packages/coding-agent/test/pasted-image-path.test.ts
@@ -33,6 +33,8 @@ describe("resolvePastedImagePath", () => {
 		expect(resolvePastedImagePath(`${clipboard}\nmore`)).toBeUndefined();
 		expect(resolvePastedImagePath("   ")).toBeUndefined();
 		expect(resolvePastedImagePath(`${clipboard} please`)).toBeUndefined();
+		expect(resolvePastedImagePath(`\n${clipboard}`)).toBeUndefined();
+		expect(resolvePastedImagePath(`${clipboard}\n`)).toBeUndefined();
 		expect(resolvePastedImagePath(`"${clipboard}"`)).toBe(clipboard);
 		expect(resolvePastedImagePath(`./${path.basename(clipboard)}`, { cwd: os.tmpdir() })).toBe(clipboard);
 	});

--- a/packages/coding-agent/test/pasted-image-path.test.ts
+++ b/packages/coding-agent/test/pasted-image-path.test.ts
@@ -32,6 +32,9 @@ describe("resolvePastedImagePath", () => {
 		expect(resolvePastedImagePath(`look at ${clipboard}`)).toBeUndefined();
 		expect(resolvePastedImagePath(`${clipboard}\nmore`)).toBeUndefined();
 		expect(resolvePastedImagePath("   ")).toBeUndefined();
+		expect(resolvePastedImagePath(`${clipboard} please`)).toBeUndefined();
+		expect(resolvePastedImagePath(`"${clipboard}"`)).toBe(clipboard);
+		expect(resolvePastedImagePath(`./${path.basename(clipboard)}`, { cwd: os.tmpdir() })).toBe(clipboard);
 	});
 
 	it("rejects remote Windows paths before attachment policy", () => {


### PR DESCRIPTION
Extracts the isolated pasted-image fix from #2789 without its public SDK changes. This unblocks repeated dev push CI failures by rejecting prose around a singular pasted-image path while preserving valid quoted and relative path handling.