### PR TITLE
fix(ai): degrade non-standard-base64 Anthropic image payloads to text

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -604,14 +604,22 @@ export const stripClaudeToolPrefix = (name: string, prefixOverride: string = cla
 	return name.slice(prefixOverride.length);
 };
 
-// Anthropic base64 image payloads use the standard alphabet only. A resident
-// image whose blob went missing carries a human-readable placeholder in `data`
-// (e.g. "[Session resident imageData blob missing: …]"); sending that as an
-// image yields a 400 `invalid base64 data` that rejects the whole request and
-// bricks the session. Guard the wire format so such payloads degrade to text.
-const ANTHROPIC_BASE64_IMAGE_DATA = /^[A-Za-z0-9+/]+={0,2}$/;
+// Anthropic requires image `data` to be standard (RFC 4648) base64: the standard
+// alphabet only, correct quartet grouping, and padding (when present) confined to
+// a trailing `=`/`==`. A resident image whose blob went missing bakes a
+// human-readable placeholder into `data` (e.g. "[Session resident imageData blob
+// missing: …]"), and other callers can pass whitespace, data URLs, or URL-safe
+// variants — all of which the API rejects with a 400 `invalid base64 data` that
+// fails the *entire* request and bricks the session. Validate the wire format
+// strictly and degrade anything that is not standard base64 to text.
+//
+// Accepts canonical padded forms and their unpadded equivalents; rejects
+// length % 4 === 1, misplaced/overlong padding, whitespace, data URLs, URL-safe
+// (`-`/`_`) alphabets, prose, and empty input. The pattern has no nested
+// quantifier, so even oversized inputs are rejected in linear time.
+const ANTHROPIC_BASE64_IMAGE_DATA = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}(?:==)?|[A-Za-z0-9+/]{3}=?)?$/;
 function isAnthropicBase64ImageData(data: string): boolean {
-	return data.length > 0 && ANTHROPIC_BASE64_IMAGE_DATA.test(data);
+	return data.length > 0 && data.length % 4 !== 1 && ANTHROPIC_BASE64_IMAGE_DATA.test(data);
 }
 
 /**

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -604,6 +604,16 @@ export const stripClaudeToolPrefix = (name: string, prefixOverride: string = cla
 	return name.slice(prefixOverride.length);
 };
 
+// Anthropic base64 image payloads use the standard alphabet only. A resident
+// image whose blob went missing carries a human-readable placeholder in `data`
+// (e.g. "[Session resident imageData blob missing: …]"); sending that as an
+// image yields a 400 `invalid base64 data` that rejects the whole request and
+// bricks the session. Guard the wire format so such payloads degrade to text.
+const ANTHROPIC_BASE64_IMAGE_DATA = /^[A-Za-z0-9+/]+={0,2}$/;
+function isAnthropicBase64ImageData(data: string): boolean {
+	return data.length > 0 && ANTHROPIC_BASE64_IMAGE_DATA.test(data);
+}
+
 /**
  * Convert content blocks to Anthropic API format
  */
@@ -627,7 +637,18 @@ function convertContentBlocks(
 		.filter((block): block is TextContent => block.type === "text")
 		.map(block => block.text.toWellFormed())
 		.filter(text => text.trim().length > 0);
-	const imageBlocks = content.filter((block): block is ImageContent => block.type === "image");
+	const imageBlocks: ImageContent[] = [];
+	for (const block of content) {
+		if (block.type !== "image") continue;
+		if (isAnthropicBase64ImageData(block.data)) {
+			imageBlocks.push(block);
+			continue;
+		}
+		// Non-base64 image payload (e.g. a missing-blob placeholder): degrade to
+		// text so one lost image cannot invalidate the entire request.
+		const text = block.data.toWellFormed().trim();
+		if (text.length > 0) textBlocks.push(text);
+	}
 	const omittedImages = !supportsImages && imageBlocks.length > 0;
 	if (imageBlocks.length === 0 || !supportsImages) {
 		if (omittedImages) {

--- a/packages/ai/test/missing-image-blob-degrade.test.ts
+++ b/packages/ai/test/missing-image-blob-degrade.test.ts
@@ -93,7 +93,7 @@ const DEGRADE: Record<string, string> = {
 	"length % 4 === 1 (five chars)": "abcde",
 	"misplaced padding": "ab=c",
 	"overlong padding": "YQ===",
-	"prose": "not base64 at all!!",
+	prose: "not base64 at all!!",
 	"oversized invalid": `${"prose ".repeat(2000)}!!`,
 };
 
@@ -127,7 +127,10 @@ describe("Anthropic image data must be standard base64 (invalid payloads degrade
 	}
 
 	it("drops an empty image payload without emitting an image block", () => {
-		const content = convertToolResultContent([{ type: "text", text: "only text" }, { type: "image", data: "", mimeType: "image/png" }]);
+		const content = convertToolResultContent([
+			{ type: "text", text: "only text" },
+			{ type: "image", data: "", mimeType: "image/png" },
+		]);
 		expect(imageBlockOf(content)).toBeUndefined();
 		expect(JSON.stringify(content)).toContain("only text");
 	});

--- a/packages/ai/test/missing-image-blob-degrade.test.ts
+++ b/packages/ai/test/missing-image-blob-degrade.test.ts
@@ -5,10 +5,14 @@ import type { AssistantMessage, Model, ToolResultMessage } from "@gajae-code/ai/
 /**
  * A resident image externalized to a content-addressed blob is referenced by a
  * `blob:sha256:` sentinel. When the blob goes missing, session materialization
- * bakes a human-readable placeholder into the image block's `data`. The
- * Anthropic adapter previously forwarded that placeholder as `source.data`,
- * yielding `400 invalid base64 data` on every request — the session bricks,
- * even for a plain text turn. A non-base64 image payload must degrade to text.
+ * bakes a human-readable placeholder into the image content block's `data`
+ * (`{type:"image", data:"[Session resident imageData blob missing: …]", mimeType}`).
+ *
+ * The Anthropic adapter previously forwarded `data` straight into `source.data`,
+ * so a non-base64 payload triggered `400 invalid base64 data` on every request —
+ * the session bricks, even for a plain text turn. `convertContentBlocks` must
+ * accept only standard (RFC 4648) base64 image data and degrade anything else to
+ * text, without disturbing valid images (order / MIME preserved).
  */
 
 const model: Model<"anthropic-messages"> = {
@@ -50,54 +54,96 @@ function toolResult(id: string, content: ToolResultMessage["content"]): ToolResu
 	return { role: "toolResult", toolCallId: id, toolName: "read", content, isError: false, timestamp: Date.now() };
 }
 
-function lastToolResultBlock(params: ReturnType<typeof convertAnthropicMessages>): Record<string, unknown> {
+/** Run one tool_result through the production converter and return its content. */
+function convertToolResultContent(content: ToolResultMessage["content"]): string | Array<Record<string, unknown>> {
+	const id = "toolu_test";
+	const params = convertAnthropicMessages([assistantCall(id), toolResult(id, content)], model, false);
 	const last = params.at(-1);
 	expect(last?.role).toBe("user");
 	const blocks = last?.content as unknown as Array<Record<string, unknown>>;
 	expect(Array.isArray(blocks)).toBe(true);
 	const block = blocks.find(b => b.type === "tool_result");
 	expect(block).toBeDefined();
-	return block as Record<string, unknown>;
+	return block!.content as string | Array<Record<string, unknown>>;
 }
 
-describe("missing resident image blob degrades to text (no invalid base64 image)", () => {
-	it("degrades a non-base64 image payload to text so the request stays valid", () => {
-		const id = "toolu_missing";
-		const params = convertAnthropicMessages(
-			[
-				assistantCall(id),
-				toolResult(id, [
-					{ type: "text", text: "Read image file [image/webp]" },
-					{ type: "image", data: MISSING_IMAGE_PLACEHOLDER, mimeType: "image/webp" },
-				]),
-			],
-			model,
-			false,
-		);
-		const block = lastToolResultBlock(params);
-		const serialized = JSON.stringify(block.content);
-		// No image block survives, and no placeholder leaks into a base64 source.
-		expect(serialized).not.toContain('"type":"image"');
-		expect(serialized).not.toContain('"source"');
-		// The placeholder is preserved as text so the model still sees the context.
-		expect(serialized).toContain("blob missing");
+function imageBlockOf(content: string | Array<Record<string, unknown>>): Record<string, unknown> | undefined {
+	if (typeof content === "string") return undefined;
+	return content.find(b => b.type === "image");
+}
+
+// Legitimate base64 that must be forwarded unchanged as an image.
+const PADDED = Buffer.from("fake image bytes").toString("base64"); // e.g. "ZmFrZSBpbWFnZSBieXRlcw=="
+const UNPADDED = PADDED.replace(/=+$/, ""); // same payload, no padding
+const KEEP: Record<string, string> = {
+	"canonical padded": PADDED,
+	"unpadded equivalent": UNPADDED,
+	"single-byte padded (YQ==)": "YQ==",
+	"single-byte unpadded (YQ)": "YQ",
+	"oversized valid": Buffer.from("x".repeat(9000)).toString("base64"),
+};
+
+// Payloads that are NOT standard base64 and must degrade to text.
+const DEGRADE: Record<string, string> = {
+	"missing-blob placeholder": MISSING_IMAGE_PLACEHOLDER,
+	"embedded whitespace": "ZmFrZSBp bWFnZSBieXRlcw==",
+	"data URL": "data:image/png;base64,ZmFrZQ==",
+	"URL-safe alphabet": "abc-_def",
+	"length % 4 === 1 (one char)": "a",
+	"length % 4 === 1 (five chars)": "abcde",
+	"misplaced padding": "ab=c",
+	"overlong padding": "YQ===",
+	"prose": "not base64 at all!!",
+	"oversized invalid": `${"prose ".repeat(2000)}!!`,
+};
+
+describe("Anthropic image data must be standard base64 (invalid payloads degrade to text)", () => {
+	for (const [name, data] of Object.entries(KEEP)) {
+		it(`preserves a valid image payload: ${name}`, () => {
+			const content = convertToolResultContent([{ type: "image", data, mimeType: "image/png" }]);
+			const image = imageBlockOf(content);
+			expect(image).toBeDefined();
+			const source = image!.source as Record<string, unknown>;
+			expect(source.type).toBe("base64");
+			expect(source.media_type).toBe("image/png");
+			expect(source.data).toBe(data);
+		});
+	}
+
+	for (const [name, data] of Object.entries(DEGRADE)) {
+		it(`degrades a non-base64 image payload to text: ${name}`, () => {
+			const content = convertToolResultContent([
+				{ type: "text", text: "context" },
+				{ type: "image", data, mimeType: "image/webp" },
+			]);
+			const serialized = JSON.stringify(content);
+			expect(imageBlockOf(content)).toBeUndefined();
+			expect(serialized).not.toContain('"type":"image"');
+			expect(serialized).not.toContain('"source"');
+			expect(serialized).toContain("context");
+			// Non-empty placeholder text is preserved so the model keeps the context.
+			if (data.trim().length > 0) expect(serialized).toContain(data.slice(0, 12).replace(/"/g, ""));
+		});
+	}
+
+	it("drops an empty image payload without emitting an image block", () => {
+		const content = convertToolResultContent([{ type: "text", text: "only text" }, { type: "image", data: "", mimeType: "image/png" }]);
+		expect(imageBlockOf(content)).toBeUndefined();
+		expect(JSON.stringify(content)).toContain("only text");
 	});
 
-	it("preserves a valid base64 image as an image block", () => {
-		const id = "toolu_ok";
-		const data = Buffer.from("fake image bytes").toString("base64");
-		const params = convertAnthropicMessages(
-			[assistantCall(id), toolResult(id, [{ type: "image", data, mimeType: "image/png" }])],
-			model,
-			false,
-		);
-		const block = lastToolResultBlock(params);
-		const inner = block.content as Array<Record<string, unknown>>;
-		expect(Array.isArray(inner)).toBe(true);
-		const image = inner.find(b => b.type === "image") as { source: Record<string, unknown> } | undefined;
-		expect(image).toBeDefined();
-		expect(image?.source.type).toBe("base64");
-		expect(image?.source.data).toBe(data);
-		expect(image?.source.media_type).toBe("image/png");
+	it("preserves block order and MIME for a valid image alongside text", () => {
+		const data = PADDED;
+		const content = convertToolResultContent([
+			{ type: "text", text: "before" },
+			{ type: "image", data, mimeType: "image/gif" },
+		]);
+		expect(Array.isArray(content)).toBe(true);
+		const blocks = content as Array<Record<string, unknown>>;
+		const textIdx = blocks.findIndex(b => b.type === "text" && String(b.text).includes("before"));
+		const imageIdx = blocks.findIndex(b => b.type === "image");
+		expect(textIdx).toBeGreaterThanOrEqual(0);
+		expect(imageIdx).toBeGreaterThan(textIdx); // text precedes image (existing behavior)
+		expect((blocks[imageIdx].source as Record<string, unknown>).media_type).toBe("image/gif");
 	});
 });

--- a/packages/ai/test/missing-image-blob-degrade.test.ts
+++ b/packages/ai/test/missing-image-blob-degrade.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { convertAnthropicMessages } from "@gajae-code/ai/providers/anthropic";
+import type { AssistantMessage, Model, ToolResultMessage } from "@gajae-code/ai/types";
+
+/**
+ * A resident image externalized to a content-addressed blob is referenced by a
+ * `blob:sha256:` sentinel. When the blob goes missing, session materialization
+ * bakes a human-readable placeholder into the image block's `data`. The
+ * Anthropic adapter previously forwarded that placeholder as `source.data`,
+ * yielding `400 invalid base64 data` on every request — the session bricks,
+ * even for a plain text turn. A non-base64 image payload must degrade to text.
+ */
+
+const model: Model<"anthropic-messages"> = {
+	api: "anthropic-messages",
+	id: "claude-3-5-sonnet-20241022",
+	name: "Claude 3.5 Sonnet",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	maxTokens: 8192,
+	contextWindow: 200000,
+	reasoning: false,
+};
+
+const MISSING_IMAGE_PLACEHOLDER = `[Session resident imageData blob missing: sha256:${"0".repeat(64)}; original content unavailable]`;
+
+function assistantCall(id: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id, name: "read", arguments: {} }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-3-5-sonnet-20241022",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	};
+}
+
+function toolResult(id: string, content: ToolResultMessage["content"]): ToolResultMessage {
+	return { role: "toolResult", toolCallId: id, toolName: "read", content, isError: false, timestamp: Date.now() };
+}
+
+function lastToolResultBlock(params: ReturnType<typeof convertAnthropicMessages>): Record<string, unknown> {
+	const last = params.at(-1);
+	expect(last?.role).toBe("user");
+	const blocks = last?.content as unknown as Array<Record<string, unknown>>;
+	expect(Array.isArray(blocks)).toBe(true);
+	const block = blocks.find(b => b.type === "tool_result");
+	expect(block).toBeDefined();
+	return block as Record<string, unknown>;
+}
+
+describe("missing resident image blob degrades to text (no invalid base64 image)", () => {
+	it("degrades a non-base64 image payload to text so the request stays valid", () => {
+		const id = "toolu_missing";
+		const params = convertAnthropicMessages(
+			[
+				assistantCall(id),
+				toolResult(id, [
+					{ type: "text", text: "Read image file [image/webp]" },
+					{ type: "image", data: MISSING_IMAGE_PLACEHOLDER, mimeType: "image/webp" },
+				]),
+			],
+			model,
+			false,
+		);
+		const block = lastToolResultBlock(params);
+		const serialized = JSON.stringify(block.content);
+		// No image block survives, and no placeholder leaks into a base64 source.
+		expect(serialized).not.toContain('"type":"image"');
+		expect(serialized).not.toContain('"source"');
+		// The placeholder is preserved as text so the model still sees the context.
+		expect(serialized).toContain("blob missing");
+	});
+
+	it("preserves a valid base64 image as an image block", () => {
+		const id = "toolu_ok";
+		const data = Buffer.from("fake image bytes").toString("base64");
+		const params = convertAnthropicMessages(
+			[assistantCall(id), toolResult(id, [{ type: "image", data, mimeType: "image/png" }])],
+			model,
+			false,
+		);
+		const block = lastToolResultBlock(params);
+		const inner = block.content as Array<Record<string, unknown>>;
+		expect(Array.isArray(inner)).toBe(true);
+		const image = inner.find(b => b.type === "image") as { source: Record<string, unknown> } | undefined;
+		expect(image).toBeDefined();
+		expect(image?.source.type).toBe("base64");
+		expect(image?.source.data).toBe(data);
+		expect(image?.source.media_type).toBe("image/png");
+	});
+});


### PR DESCRIPTION
Supersedes #2806 (could not be reopened after close). Same fix, now addressing the `REQUEST_CHANGES` review with strict base64 validation.

## Problem

A session that once held an image whose content-addressed blob has gone missing is **bricked**: every request fails with Anthropic 400, even a plain text turn.

```
400 invalid_request_error:
messages.335.content.0.tool_result.content.1.image.source.base64: invalid base64 data
```

When a resident image blob goes missing, session materialization bakes a human-readable placeholder into the internal image block's `data` (`{type:"image", data:"[Session resident imageData blob missing: …]", mimeType}`). `convertContentBlocks` (in `providers/anthropic.ts`) forwarded that verbatim into `source.data`, so the request carried a non-base64 image payload. The poisoned image lives in the persisted `tool_result`, so every subsequent turn re-sends it and fails identically.

## Fix

Validate that image `data` is **standard (RFC 4648) base64** before emitting an image block, and degrade anything else to a text block (its text is preserved so the model keeps the context). Valid images keep their block order and MIME.

Validation (`isAnthropicBase64ImageData`):

```
^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}(?:==)?|[A-Za-z0-9+/]{3}=?)?$   +   length % 4 !== 1
```

- Accepts canonical **padded and unpadded** forms.
- Rejects `length % 4 === 1` (`"a"`, `"abcde"`), misplaced/overlong padding (`"ab=c"`, `"YQ==="`), whitespace, data URLs, URL-safe (`-`/`_`) alphabets, prose, and empty input.
- No nested quantifier → oversized inputs are rejected in linear time.

This is the stricter validation requested in the #2806 review, which correctly noted the earlier alphabet-only check still accepted malformed payloads that the API would reject.

## Tests

`test/missing-image-blob-degrade.test.ts` — 17 cases through the production `convertAnthropicMessages` converter:
- **Preserved:** canonical padded, unpadded equivalent, single-byte padded/unpadded, oversized valid → image block with `source.data`/`media_type` intact.
- **Degraded to text:** missing-blob placeholder, embedded whitespace, data URL, URL-safe alphabet, `length % 4 === 1`, misplaced/overlong padding, prose, empty, oversized invalid.
- Block-order + MIME preserved for a valid image alongside text.

Verified end-to-end against the real 400 capture (the exact internal `toolResult`, paired with its `tool_use`): the offending block now materializes to a valid text-only `tool_result`, no invalid base64. `bun test` + `tsc --noEmit` clean.
