### PR TITLE
fix(coding-agent): preserve terminal newline image paste

### DIFF
--- a/packages/coding-agent/src/utils/pasted-image-path.ts
+++ b/packages/coding-agent/src/utils/pasted-image-path.ts
@@ -257,8 +257,9 @@ function isRecognizedClipboardTempPath(filePath: string, platform: NodeJS.Platfo
 /** Resolve one recognized clipboard-temp image path lexically, before any filesystem access. */
 export function resolvePastedImagePath(text: string, options: ResolvePastedImagePathOptions = {}): string | undefined {
 	const platform = options.platform ?? process.platform;
-	if (/[\r\n]/.test(text)) return undefined;
-	const candidates = decodePastedPathCandidates(text, options, 1);
+	const terminalNewlinesTrimmed = text.replace(/(?:\r\n|\r|\n)+$/, "");
+	if (/\r|\n/.test(terminalNewlinesTrimmed)) return undefined;
+	const candidates = decodePastedPathCandidates(terminalNewlinesTrimmed, options, 1);
 	if (candidates?.length !== 1) return undefined;
 	const candidate = candidates[0];
 	if (!IMAGE_FILE_EXTENSION_PATTERN.test(candidate)) return undefined;

--- a/packages/coding-agent/test/pasted-image-path.test.ts
+++ b/packages/coding-agent/test/pasted-image-path.test.ts
@@ -26,7 +26,7 @@ describe("resolvePastedImagePath", () => {
 		expect(resolvePastedImagePath(missing)).toBe(missing);
 	});
 
-	it("rejects non-image extensions, prose, multiline text, and empty input", () => {
+	it("accepts terminal line endings but rejects non-path multiline text", () => {
 		const clipboard = path.join(os.tmpdir(), "clipboard-2026-07-19-123456-Ab3.png");
 		expect(resolvePastedImagePath(clipboard.replace(/\.png$/, ".txt"))).toBeUndefined();
 		expect(resolvePastedImagePath(`look at ${clipboard}`)).toBeUndefined();
@@ -34,7 +34,8 @@ describe("resolvePastedImagePath", () => {
 		expect(resolvePastedImagePath("   ")).toBeUndefined();
 		expect(resolvePastedImagePath(`${clipboard} please`)).toBeUndefined();
 		expect(resolvePastedImagePath(`\n${clipboard}`)).toBeUndefined();
-		expect(resolvePastedImagePath(`${clipboard}\n`)).toBeUndefined();
+		expect(resolvePastedImagePath(`${clipboard}\n`)).toBe(clipboard);
+		expect(resolvePastedImagePath(`${clipboard}\r\n`)).toBe(clipboard);
 		expect(resolvePastedImagePath(`"${clipboard}"`)).toBe(clipboard);
 		expect(resolvePastedImagePath(`./${path.basename(clipboard)}`, { cwd: os.tmpdir() })).toBe(clipboard);
 	});


### PR DESCRIPTION
Fixes #2814.

The affected-path parser now removes terminal CR/LF delimiters before enforcing its no-embedded-newline rule. This preserves automatic attachment for exactly one recognized clipboard-temp image path pasted with a terminal newline, while leading or embedded newlines, additional tokens, prose, and multiple paths remain rejected by the single-candidate boundary.

Validation:
- `bun test packages/coding-agent/test/pasted-image-path.test.ts` — 18 pass.
- `bun test packages/coding-agent/test/input-controller-keybindings.test.ts` could not start in this worktree because `chalk` is absent from the workspace dependency installation; exact-head CI will exercise the controller regression.

—
*[repo owner’s gaebal-gajae (clawdbot) 🦞]*