### PR TITLE
fix(coding-agent): skip expired external OAuth auto-imports

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- `gjc setup credentials` no longer auto-imports expired external OAuth credentials as successful Claude/Codex setup candidates; stale discovery entries remain visible as `[expired]`, but the setup/import path now leaves them out of the success path so provider availability and preset activation do not contradict the import result.
 
 - Resumed managed sessions now complete the verified legacy `local://` artifact migration before synchronous path resolution, preserving legacy scratch files instead of failing startup with a migration-order error.
 

--- a/packages/coding-agent/src/setup/credential-import.ts
+++ b/packages/coding-agent/src/setup/credential-import.ts
@@ -413,11 +413,16 @@ export function formatDiscoverySummary(result: CredentialDiscoveryResult): strin
 	return lines;
 }
 
+function isExpiredImportableOAuthCredential(credential: ImportableCredential): boolean {
+	return credential.kind === "oauth" && credential.expiresAt !== undefined && credential.expiresAt <= Date.now();
+}
+
 export function isAutoImportOAuthCredential(credential: ImportableCredential): boolean {
 	return (
 		AUTO_IMPORT_OAUTH_PROVIDER_ORIGINS[credential.provider]?.has(credential.origin) === true &&
 		credential.kind === "oauth" &&
-		credential.credential.type === "oauth"
+		credential.credential.type === "oauth" &&
+		!isExpiredImportableOAuthCredential(credential)
 	);
 }
 

--- a/packages/coding-agent/test/credential-import.test.ts
+++ b/packages/coding-agent/test/credential-import.test.ts
@@ -456,10 +456,24 @@ describe("auto-import OAuth filter and orchestrator", () => {
 				kind: "oauth",
 				credential: { type: "api_key", key: "k" },
 			}),
+			oauthCredential({
+				expiresAt: Date.now() - 1,
+				credential: { type: "oauth", access: "a", refresh: "r", expires: Date.now() - 1 },
+			}),
 		];
 		for (const credential of accepted) expect(isAutoImportOAuthCredential(credential)).toBe(true);
 		for (const credential of rejected) expect(isAutoImportOAuthCredential(credential)).toBe(false);
 		expect(filterAutoImportOAuthCredentials([...accepted, ...rejected])).toEqual(accepted);
+	});
+
+	test("expired OAuth credentials are excluded from auto-import candidates", () => {
+		const fresh = oauthCredential({ expiresAt: Date.now() + 60_000 });
+		const expired = oauthCredential({
+			expiresAt: Date.now() - 60_000,
+			credential: { type: "oauth", access: "a", refresh: "r", expires: Date.now() - 60_000 },
+		});
+
+		expect(filterAutoImportOAuthCredentials([fresh, expired])).toEqual([fresh]);
 	});
 
 	test("provider-origin pairings reject impossible source/provider combinations", () => {


### PR DESCRIPTION
## Summary

Fix expired external OAuth auto-import handling in `gjc setup credentials`.

This changes the auto-import candidate filter so expired Claude/Codex OAuth credentials are no longer treated as successful setup candidates. Stale discovery entries still render as `[expired]`, but the setup/import flow no longer reports a successful import that immediately leaves the provider unavailable.

Closes #2817.

## What changed

- reject expired OAuth entries in `isAutoImportOAuthCredential`
- add focused regression coverage for expired candidate filtering
- document the user-facing fix in the changelog

## Why

Before this patch, `gjc setup credentials --yes` could import an expired Claude Code OAuth credential, print a success line, and still leave Anthropic unusable (`/model` showed `✗ CLAUDE` / `Run /login anthropic`).

That made the setup result contradict the actual provider availability immediately afterward.

## Verification

- `bun test packages/coding-agent/test/credential-import.test.ts`
- `bun test packages/coding-agent/test/credential-auto-import-flows.test.ts`
- `bunx @biomejs/biome check packages/coding-agent/src/setup/credential-import.ts packages/coding-agent/test/credential-import.test.ts`
