### PR TITLE
fix(utils): respect unit boundaries in formatBytes and formatDuration

### DIFF
--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -9,7 +9,9 @@ const DAY = 24 * HOUR;
  */
 export function formatDuration(ms: number): string {
 	if (ms < SEC) return `${ms}ms`;
-	if (ms < MIN) return `${(ms / SEC).toFixed(1)}s`;
+	// Truncate below 60.0s instead of rounding up into the next unit (the minute
+	// branch below), mirroring roundBelow/formatByteUnit: e.g. 59_999ms -> "59.9s".
+	if (ms < MIN) return `${(roundBelow(ms / 100, 600) / 10).toFixed(1)}s`;
 	if (ms < HOUR) {
 		const mins = Math.floor(ms / MIN);
 		const secs = Math.floor((ms % MIN) / SEC);
@@ -59,13 +61,21 @@ export function formatBytes(bytes: number): string {
 	if (bytes < 1024) return `${bytes}B`;
 	if (bytes < 1024 * 1024) return `${formatByteUnit(bytes, 1024)}KB`;
 	if (bytes < 1024 * 1024 * 1024) return `${formatByteUnit(bytes, 1024 * 1024)}MB`;
-	return `${formatByteUnit(bytes, 1024 * 1024 * 1024)}GB`;
+	// The GB branch is terminal (no larger unit), so it must not clamp below the
+	// next-unit boundary the way KB/MB do; clamping here reports every value >=
+	// 1 TiB as "1023.9GB" (e.g. 2 TiB -> "1023.9GB" instead of "2048.0GB").
+	return `${formatByteUnit(bytes, 1024 * 1024 * 1024, false)}GB`;
 }
 
-/** Format bytes to 1 decimal without rounding up into the next byte unit. */
-function formatByteUnit(bytes: number, unit: number): string {
-	const tenths = Math.min(Math.round((bytes / unit) * 10), 1024 * 10 - 1);
-	return (tenths / 10).toFixed(1);
+/**
+ * Format bytes to 1 decimal. Intermediate units (KB/MB) clamp just below the
+ * next-unit boundary so a value like 1023.95 KB never rounds up to "1024.0KB";
+ * the terminal GB unit passes `clampToNextUnit: false` because it has no next
+ * unit to protect against.
+ */
+function formatByteUnit(bytes: number, unit: number, clampToNextUnit = true): string {
+	const tenths = Math.round((bytes / unit) * 10);
+	return ((clampToNextUnit ? Math.min(tenths, 1024 * 10 - 1) : tenths) / 10).toFixed(1);
 }
 
 /**

--- a/packages/utils/test/format.test.ts
+++ b/packages/utils/test/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { formatBytes, formatNumber } from "../src/format";
+import { formatBytes, formatDuration, formatNumber } from "../src/format";
 
 describe("formatNumber", () => {
 	it("does not round K and M values into the next suffix", () => {
@@ -17,5 +17,27 @@ describe("formatBytes", () => {
 		expect(formatBytes(1024 * 1024)).toBe("1.0MB");
 		expect(formatBytes(1024 * 1024 * 1024 - 1)).toBe("1023.9MB");
 		expect(formatBytes(1024 * 1024 * 1024)).toBe("1.0GB");
+	});
+
+	it("does not clamp the terminal GB unit (no next unit to protect)", () => {
+		expect(formatBytes(1024 ** 4)).toBe("1024.0GB");
+		expect(formatBytes(2 * 1024 ** 4)).toBe("2048.0GB");
+		expect(formatBytes(1023 * 1024 ** 3)).toBe("1023.0GB");
+	});
+});
+
+describe("formatDuration", () => {
+	it("does not round seconds up into the minute unit", () => {
+		expect(formatDuration(59_949)).toBe("59.9s");
+		expect(formatDuration(59_950)).toBe("59.9s");
+		expect(formatDuration(59_999)).toBe("59.9s");
+		expect(formatDuration(60_000)).toBe("1m");
+	});
+
+	it("keeps existing sub-minute formatting", () => {
+		expect(formatDuration(999)).toBe("999ms");
+		expect(formatDuration(1_000)).toBe("1.0s");
+		expect(formatDuration(1_500)).toBe("1.5s");
+		expect(formatDuration(30_000)).toBe("30.0s");
 	});
 });


### PR DESCRIPTION
## What

Two compact formatters in `packages/utils/src/format.ts` emit values that cross a unit boundary they are supposed to respect:

- `formatBytes` clamps **every** unit through `formatByteUnit`'s `Math.min(..., 1024*10-1)`. That clamp is correct for the intermediate KB/MB units (so `1023.95 KB` never rounds up to `"1024.0KB"`), but the terminal **GB** branch has no larger unit, so the clamp turns every value `>= 1 TiB` into `"1023.9GB"`.
- `formatDuration`'s sub-minute branch uses `(ms / SEC).toFixed(1)`, which **rounds** any `ms` in `[59950, 59999]` up to `"60.0s"` instead of staying below the minute unit.

### Reproduction (current `dev`)

```js
import { formatBytes, formatDuration } from "@gajae-code/utils";
formatBytes(2 * 1024 ** 4); // "1023.9GB"  ← 2 TiB reported as ~1 TiB
formatDuration(59_999);     // "60.0s"     ← should never reach 60s
```

`formatBytes` is called on real values that exceed 1 TiB — e.g. RAM total in `system-info.ts` and file sizes in `file-processor.ts`.

## Fix

- Skip the clamp on the terminal GB unit (`formatByteUnit(bytes, GiB, /* clampToNextUnit */ false)`).
- Route the seconds branch through the existing `roundBelow` helper the file already uses for exactly this anti-round-up invariant (`formatNumber`).

Both changes are minimal and preserve every currently-correct output. The existing `formatBytes` KB/MB clamp behavior and all documented example outputs are unchanged.

## Tests

`packages/utils/test/format.test.ts` — added regression cases for the terminal GB unit (`1 TiB`, `2 TiB`) and the seconds→minute boundary (`59_949`/`59_950`/`59_999`/`60_000`), plus preserved sub-boundary values.

```
bun test packages/utils/test/format.test.ts
# 5 pass, 0 fail, 20 expect() calls
```

`bunx biome check packages/utils/src/format.ts packages/utils/test/format.test.ts` — clean.
