### PR TITLE
fix(utils): stop parseFrontmatter from consuming body on non-frontmatter documents

### DIFF
--- a/packages/coding-agent/test/discovery/helpers.test.ts
+++ b/packages/coding-agent/test/discovery/helpers.test.ts
@@ -208,4 +208,32 @@ Body content`;
 		});
 		expect(result.body).toBe("Body content");
 	});
+
+	test("does not treat a dashed banner as frontmatter and preserve the body", () => {
+		const content = "----\nhello\n----\nworld";
+		const result = parse(content);
+		expect(result.frontmatter).toEqual({});
+		expect(result.body).toBe(content);
+	});
+
+	test("does not treat a '--- text' heading line as a frontmatter opener", () => {
+		const content = "--- not frontmatter\nkeep me\n--- also text\nand me";
+		const result = parse(content);
+		expect(result.frontmatter).toEqual({});
+		expect(result.body).toBe(content);
+	});
+
+	test("keeps a markdown '---' horizontal rule inside the body", () => {
+		const content = "---\ntitle: post\n---\nfirst\n\n---\n\nsecond";
+		const result = parse(content);
+		expect(result.frontmatter).toEqual({ title: "post" });
+		expect(result.body).toBe("first\n\n---\n\nsecond");
+	});
+
+	test("closes frontmatter at a delimiter with no trailing newline", () => {
+		const content = "---\nname: x\n---";
+		const result = parse(content);
+		expect(result.frontmatter).toEqual({ name: "x" });
+		expect(result.body).toBe("");
+	});
 });

--- a/packages/utils/src/frontmatter.ts
+++ b/packages/utils/src/frontmatter.ts
@@ -125,17 +125,26 @@ export function parseFrontmatter(
 	const frontmatter: Record<string, unknown> = { ...fallback };
 
 	const normalized = normalize ? stripHtmlComments(content.replace(/\r\n?/g, "\n")) : content;
-	if (!normalized.startsWith("---")) {
+	// A frontmatter block opens with a line that is exactly `---` (trailing
+	// spaces/tabs allowed). A bare `----` banner or a `--- text` heading is not
+	// an opener, so a document without frontmatter keeps its body intact rather
+	// than having content silently consumed by the fixed-offset slicing below.
+	const open = normalized.match(/^---[ \t]*(?:\n|$)/);
+	if (!open) {
 		return { frontmatter, body: normalized };
 	}
 
-	const endIndex = normalized.indexOf("\n---", 3);
-	if (endIndex === -1) {
+	// The block closes at the next line that is exactly `---`. Searching from the
+	// end of the opening `---` (offset 3, not the whole opener) keeps an empty
+	// block (`---\n---`) matching as empty frontmatter.
+	const afterOpen = normalized.slice(3);
+	const close = afterOpen.match(/\n---[ \t]*(?:\n|$)/);
+	if (!close || close.index === undefined) {
 		return { frontmatter, body: normalized };
 	}
 
-	const metadata = normalized.slice(4, endIndex);
-	const body = normalized.slice(endIndex + 4).trim();
+	const metadata = afterOpen.slice(open[0].length - 3, close.index);
+	const body = afterOpen.slice(close.index + close[0].length).trim();
 
 	try {
 		// Replace tabs with spaces for YAML compatibility, use failsafe mode for robustness


### PR DESCRIPTION
## What

`parseFrontmatter` (`packages/utils/src/frontmatter.ts`) is the shared loader for skills, agents, commands, and prompts. It detected a frontmatter block with `normalized.startsWith("---")` and `indexOf("\n---", 3)`, then sliced metadata/body at **fixed 4-char offsets**. Any document whose first line merely *starts with* `---` — a dashed banner (`----`) or a `--- text` heading — was misdetected as frontmatter, and the fixed offsets silently deleted body content.

### Reproduction (current `dev`)

```js
import { parseFrontmatter } from "@gajae-code/utils";
parseFrontmatter("----\nhello\n----\nworld");
// { frontmatter: {}, body: "-\nworld" }   ← "hello" is silently dropped
```

Because this is the shared markdown loader, that is silent prompt/skill corruption, not just a display glitch.

## Fix

Match the opener and closer as lines that are **exactly** `---` (trailing spaces/tabs allowed) and compute the metadata/body slices from the actual regex match offsets instead of hardcoded `4`:

- opener: `/^---[ \t]*(?:\n|$)/`
- closer: `/\n---[ \t]*(?:\n|$)/` searched from the end of the opening `---`

This only makes detection **stricter**, so it can never turn currently-valid frontmatter into non-frontmatter incorrectly. The empty-block (`---\n---`) and closer-at-EOF cases are preserved.

## Tests

`packages/coding-agent/test/discovery/helpers.test.ts` — added regression cases for the dashed banner, the `--- text` heading, a markdown `---` horizontal rule inside the body, and an EOF closer. All 14 existing cases still pass.

```
bun test packages/coding-agent/test/discovery/helpers.test.ts   # 18 pass, 0 fail
# regression-safety across the real shared loader:
bun test packages/coding-agent/test/default-gjc-definitions.test.ts   # 25 pass
bun test packages/coding-agent/test/skills.test.ts .../gjc-plugin-compiler.test.ts \
  .../gjc-plugin-loader.test.ts .../slash-command-format.test.ts \
  .../task/autoload-skills.test.ts .../discovery/monorepo-skills.test.ts \
  .../discovery/agents-monorepo-skills.test.ts                          # 73 pass
```

`bunx biome check` — clean.
