### PR TITLE
fix(coding-agent): honor documented GJC_{SMOL,SLOW,PLAN}_MODEL env overrides

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -12,6 +12,7 @@ import { createInterface } from "node:readline/promises";
 import type { ImageContent } from "@gajae-code/ai";
 import {
 	$env,
+	$pickenv,
 	getProjectDir,
 	logger,
 	normalizePathForComparison,
@@ -1252,15 +1253,17 @@ export async function runRootCommand(
 	// Initialize discovery system with settings for provider persistence
 	logger.time("initializeWithSettings", initializeWithSettings, settingsInstance);
 
-	// Apply model role overrides from CLI args or env vars (ephemeral, not persisted)
-	const smolModel = parsedArgs.smol ?? $env.PI_SMOL_MODEL;
-	const slowModel = parsedArgs.slow ?? $env.PI_SLOW_MODEL;
-	const planModel = parsedArgs.plan ?? $env.PI_PLAN_MODEL;
+	// Apply model role overrides from CLI args or env vars (ephemeral, not persisted).
+	// Documented and help-advertised as GJC_*, with the legacy PI_* name kept as a
+	// fallback to match the repo-wide GJC_-first/PI_-fallback convention.
+	const smolModel = parsedArgs.smol ?? $pickenv("GJC_SMOL_MODEL", "PI_SMOL_MODEL");
+	const slowModel = parsedArgs.slow ?? $pickenv("GJC_SLOW_MODEL", "PI_SLOW_MODEL");
+	const planModel = parsedArgs.plan ?? $pickenv("GJC_PLAN_MODEL", "PI_PLAN_MODEL");
 	if (smolModel || slowModel || planModel) {
 		settingsInstance.overrideModelRoles({
-			smol: smolModel,
-			slow: slowModel,
-			plan: planModel,
+			...(smolModel ? { smol: smolModel } : {}),
+			...(slowModel ? { slow: slowModel } : {}),
+			...(planModel ? { plan: planModel } : {}),
 		});
 	}
 


### PR DESCRIPTION
## What

The ephemeral model-role overrides are documented and advertised as `GJC_SMOL_MODEL` / `GJC_SLOW_MODEL` / `GJC_PLAN_MODEL`:

- `docs/environment-variables.md:439-441`
- `gjc --help` flag descriptions (`packages/coding-agent/src/cli.ts:180-182`)
- `packages/coding-agent/src/cli/fast-help.ts:78-80`
- `packages/coding-agent/src/cli/args.ts:303-305`

But `packages/coding-agent/src/main.ts:1256-1258` read only the legacy `PI_*` names:

```ts
const smolModel = parsedArgs.smol ?? $env.PI_SMOL_MODEL;
const slowModel = parsedArgs.slow ?? $env.PI_SLOW_MODEL;
const planModel = parsedArgs.plan ?? $env.PI_PLAN_MODEL;
```

So every documented and help-advertised `GJC_*_MODEL` override is a silent no-op (`GJC_PLAN_MODEL=… gjc` does nothing; only the undocumented `PI_PLAN_MODEL` works).

## Fix

Resolve `GJC_*` first with `PI_*` as a fallback via the existing `$pickenv` helper — the same GJC-first / PI-fallback convention already used throughout the repo:

- `config.ts:23` — `GJC_PACKAGE_DIR ?? PI_PACKAGE_DIR`
- `utils/src/dirs.ts:152` — `GJC_CONFIG_DIR ?? PI_CONFIG_DIR`
- `gjc-runtime/gc-runtime.ts:363` — `GJC_CODING_AGENT_DIR ?? PI_CODING_AGENT_DIR`
- `eval/py/env.ts` — `resolvePythonFlag(env, "GJC_…", "PI_…")`
- `lsp/lspmux.ts:173` — `$flag("GJC_DISABLE_LSPMUX") || $flag("PI_DISABLE_LSPMUX")`

```ts
const smolModel = parsedArgs.smol ?? $pickenv("GJC_SMOL_MODEL", "PI_SMOL_MODEL");
const slowModel = parsedArgs.slow ?? $pickenv("GJC_SLOW_MODEL", "PI_SLOW_MODEL");
const planModel = parsedArgs.plan ?? $pickenv("GJC_PLAN_MODEL", "PI_PLAN_MODEL");
```

`main.ts:1256-1258` is the sole read site for these variables (verified by search). The variable types are unchanged (`string | undefined`).

## Verification

`bunx biome check packages/coding-agent/src/main.ts` — clean. CLI boots clean with the env set (`GJC_SMOL_MODEL=… bun packages/coding-agent/src/cli.ts --version`). No new test is added because `$pickenv` first-non-empty resolution is already covered; asserting it again here would be a tautology, which `AGENTS.md` explicitly discourages.
