### PR TITLE
test(ai): refresh Anthropic cache evidence

### DIFF
--- a/artifacts/architecture-2383-eval.json
+++ b/artifacts/architecture-2383-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "009b09e7486f3fd2f58476776a82d822e7629e42",
-		"providerSourceSha256": "5bcae1bfedc0f8330f53bb8ae8e1c11e8bc2874a2c8b52f5f588f3b15b8c1c59",
+		"providerSourceBlobOid": "f695ccbc6492ba21374a878e260a14da1fb78147",
+		"providerSourceSha256": "69d4b0235aa465a9e30bb4bf060be6387a3cd63311fcc0148cd89b6668ffb70a",
 		"inputFixtureSha256": "b1ca8d3183ca168140774f848ed414252178f7c5788d61243069862ae59c129b"
 	},
 	"derivationCommands": [


### PR DESCRIPTION
Repairs the post-merge `dev` CI failure introduced by #2813's required `anthropic.ts` source-identity change.

`architecture-2383-eval.json` intentionally fingerprints that provider source. The artifact was not regenerated in #2813, so the full AI test shard failed only after the squash merge. This mechanically refreshes its blob OID and SHA-256 with the test's documented write mode.

Verification:
- `WRITE_ARCHITECTURE_2383_EVAL=1 bun test packages/ai/test/anthropic-cache-eval.integration.test.ts`
- `bun test packages/ai/test/anthropic-cache-eval.integration.test.ts packages/ai/test/missing-image-blob-degrade.test.ts`
- `bun run --cwd packages/ai check`
- `git diff --check`