### PR TITLE
fix(coding-agent): honor documented GJC_{SMOL,SLOW,PLAN}_MODEL env overrides

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -13,6 +13,7 @@ import type { ImageContent } from "@gajae-code/ai";
 import {
 	$env,
 	getAgentDir,
+	$pickenv,
 	getProjectDir,
 	logger,
 	normalizePathForComparison,
@@ -1284,15 +1285,17 @@ export async function runRootCommand(
 	// Initialize discovery system with settings for provider persistence
 	logger.time("initializeWithSettings", initializeWithSettings, settingsInstance);
 
-	// Apply model role overrides from CLI args or env vars (ephemeral, not persisted)
-	const smolModel = parsedArgs.smol ?? $env.PI_SMOL_MODEL;
-	const slowModel = parsedArgs.slow ?? $env.PI_SLOW_MODEL;
-	const planModel = parsedArgs.plan ?? $env.PI_PLAN_MODEL;
+	// Apply model role overrides from CLI args or env vars (ephemeral, not persisted).
+	// Documented and help-advertised as GJC_*, with the legacy PI_* name kept as a
+	// fallback to match the repo-wide GJC_-first/PI_-fallback convention.
+	const smolModel = parsedArgs.smol ?? $pickenv("GJC_SMOL_MODEL", "PI_SMOL_MODEL");
+	const slowModel = parsedArgs.slow ?? $pickenv("GJC_SLOW_MODEL", "PI_SLOW_MODEL");
+	const planModel = parsedArgs.plan ?? $pickenv("GJC_PLAN_MODEL", "PI_PLAN_MODEL");
 	if (smolModel || slowModel || planModel) {
 		settingsInstance.overrideModelRoles({
-			smol: smolModel,
-			slow: slowModel,
-			plan: planModel,
+			...(smolModel ? { smol: smolModel } : {}),
+			...(slowModel ? { slow: slowModel } : {}),
+			...(planModel ? { plan: planModel } : {}),
 		});
 	}
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -12,8 +12,8 @@ import { createInterface } from "node:readline/promises";
 import type { ImageContent } from "@gajae-code/ai";
 import {
 	$env,
-	getAgentDir,
 	$pickenv,
+	getAgentDir,
 	getProjectDir,
 	logger,
 	normalizePathForComparison,
@@ -1092,6 +1092,33 @@ export interface RunRootCommandDependencies {
 	loadSettingsForScope?: typeof Settings.loadForScope;
 }
 
+export interface ModelRoleOverrides {
+	smol?: string;
+	slow?: string;
+	plan?: string;
+}
+
+/**
+ * Resolve the ephemeral `smol`/`slow`/`plan` model-role overrides.
+ *
+ * Precedence per role is CLI flag > documented `GJC_*_MODEL` > legacy
+ * `PI_*_MODEL`, matching the repo-wide GJC-first/PI-fallback convention.
+ * Resolution reads the process environment via `$pickenv`, which trims values
+ * and treats empty/whitespace as unset; it is deliberately kept separate from
+ * credential env resolution (`$credentialEnv`/`$pickCredentialEnv`). The
+ * function is pure and stateless, so it reads fresh each call and a later
+ * invocation never inherits an earlier one's values.
+ */
+export function resolveModelRoleOverrides(parsed: Pick<Args, "smol" | "slow" | "plan">): ModelRoleOverrides {
+	const overrides: ModelRoleOverrides = {};
+	const smol = parsed.smol ?? $pickenv("GJC_SMOL_MODEL", "PI_SMOL_MODEL");
+	const slow = parsed.slow ?? $pickenv("GJC_SLOW_MODEL", "PI_SLOW_MODEL");
+	const plan = parsed.plan ?? $pickenv("GJC_PLAN_MODEL", "PI_PLAN_MODEL");
+	if (smol) overrides.smol = smol;
+	if (slow) overrides.slow = slow;
+	if (plan) overrides.plan = plan;
+	return overrides;
+}
 export async function runRootCommand(
 	parsed: Args,
 	rawArgs: string[],
@@ -1286,16 +1313,13 @@ export async function runRootCommand(
 	logger.time("initializeWithSettings", initializeWithSettings, settingsInstance);
 
 	// Apply model role overrides from CLI args or env vars (ephemeral, not persisted).
-	// Documented and help-advertised as GJC_*, with the legacy PI_* name kept as a
-	// fallback to match the repo-wide GJC_-first/PI_-fallback convention.
-	const smolModel = parsedArgs.smol ?? $pickenv("GJC_SMOL_MODEL", "PI_SMOL_MODEL");
-	const slowModel = parsedArgs.slow ?? $pickenv("GJC_SLOW_MODEL", "PI_SLOW_MODEL");
-	const planModel = parsedArgs.plan ?? $pickenv("GJC_PLAN_MODEL", "PI_PLAN_MODEL");
-	if (smolModel || slowModel || planModel) {
+	// Precedence per role: CLI flag > documented GJC_*_MODEL > legacy PI_*_MODEL.
+	const roleOverrides = resolveModelRoleOverrides(parsedArgs);
+	if (roleOverrides.smol || roleOverrides.slow || roleOverrides.plan) {
 		settingsInstance.overrideModelRoles({
-			...(smolModel ? { smol: smolModel } : {}),
-			...(slowModel ? { slow: slowModel } : {}),
-			...(planModel ? { plan: planModel } : {}),
+			...(roleOverrides.smol ? { smol: roleOverrides.smol } : {}),
+			...(roleOverrides.slow ? { slow: roleOverrides.slow } : {}),
+			...(roleOverrides.plan ? { plan: roleOverrides.plan } : {}),
 		});
 	}
 

--- a/packages/coding-agent/test/model-role-env-overrides.test.ts
+++ b/packages/coding-agent/test/model-role-env-overrides.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { resolveModelRoleOverrides } from "../src/main";
+
+const ENV_KEYS = [
+	"GJC_SMOL_MODEL",
+	"PI_SMOL_MODEL",
+	"GJC_SLOW_MODEL",
+	"PI_SLOW_MODEL",
+	"GJC_PLAN_MODEL",
+	"PI_PLAN_MODEL",
+] as const;
+
+function clearEnv(): void {
+	for (const key of ENV_KEYS) delete Bun.env[key];
+}
+
+// Snapshot any ambient values so the suite never mutates the real environment.
+const original = new Map(ENV_KEYS.map(key => [key, Bun.env[key]] as const));
+afterEach(() => {
+	for (const [key, value] of original) {
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+	}
+});
+
+const noFlags = {} as Pick<Parameters<typeof resolveModelRoleOverrides>[0], "smol" | "slow" | "plan">;
+
+describe("resolveModelRoleOverrides", () => {
+	test("returns no overrides when neither CLI flags nor env vars are set", () => {
+		clearEnv();
+		expect(resolveModelRoleOverrides(noFlags)).toEqual({});
+	});
+
+	test("reads the documented GJC_*_MODEL names for all three roles", () => {
+		clearEnv();
+		Bun.env.GJC_SMOL_MODEL = "prov/smol";
+		Bun.env.GJC_SLOW_MODEL = "prov/slow";
+		Bun.env.GJC_PLAN_MODEL = "prov/plan";
+		expect(resolveModelRoleOverrides(noFlags)).toEqual({
+			smol: "prov/smol",
+			slow: "prov/slow",
+			plan: "prov/plan",
+		});
+	});
+
+	test("falls back to the legacy PI_*_MODEL name when GJC_* is unset", () => {
+		clearEnv();
+		Bun.env.PI_SLOW_MODEL = "prov/legacy-slow";
+		expect(resolveModelRoleOverrides(noFlags)).toEqual({ slow: "prov/legacy-slow" });
+	});
+
+	test("prefers GJC_* over the legacy PI_* when both are set", () => {
+		clearEnv();
+		Bun.env.GJC_SMOL_MODEL = "prov/new";
+		Bun.env.PI_SMOL_MODEL = "prov/legacy";
+		expect(resolveModelRoleOverrides(noFlags).smol).toBe("prov/new");
+	});
+
+	test("lets the CLI flag win over both env names", () => {
+		clearEnv();
+		Bun.env.GJC_PLAN_MODEL = "prov/env";
+		Bun.env.PI_PLAN_MODEL = "prov/legacy";
+		expect(resolveModelRoleOverrides({ plan: "prov/cli" }).plan).toBe("prov/cli");
+	});
+
+	test("treats empty or whitespace-only env values as unset", () => {
+		clearEnv();
+		Bun.env.GJC_SMOL_MODEL = "   ";
+		Bun.env.PI_SMOL_MODEL = "prov/legacy";
+		expect(resolveModelRoleOverrides(noFlags).smol).toBe("prov/legacy");
+		Bun.env.PI_SMOL_MODEL = "";
+		expect(resolveModelRoleOverrides(noFlags).smol).toBeUndefined();
+	});
+
+	test("passes an arbitrary model id through unchanged (validation is downstream)", () => {
+		clearEnv();
+		Bun.env.GJC_SMOL_MODEL = "not-a-real/model-id";
+		expect(resolveModelRoleOverrides(noFlags).smol).toBe("not-a-real/model-id");
+	});
+
+	test("resolves fresh per call, so a later invocation does not inherit an earlier one", () => {
+		clearEnv();
+		Bun.env.GJC_SMOL_MODEL = "prov/first";
+		expect(resolveModelRoleOverrides(noFlags).smol).toBe("prov/first");
+		clearEnv();
+		expect(resolveModelRoleOverrides(noFlags).smol).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What

The ephemeral model-role overrides are documented and advertised as `GJC_SMOL_MODEL` / `GJC_SLOW_MODEL` / `GJC_PLAN_MODEL`:

- `docs/environment-variables.md:439-441`
- `gjc --help` flag descriptions (`packages/coding-agent/src/cli.ts:180-182`)
- `packages/coding-agent/src/cli/fast-help.ts:78-80`
- `packages/coding-agent/src/cli/args.ts:303-305`

But `packages/coding-agent/src/main.ts:1256-1258` read only the legacy `PI_*` names:

```ts
const smolModel = parsedArgs.smol ?? $env.PI_SMOL_MODEL;
const slowModel = parsedArgs.slow ?? $env.PI_SLOW_MODEL;
const planModel = parsedArgs.plan ?? $env.PI_PLAN_MODEL;
```

So every documented and help-advertised `GJC_*_MODEL` override is a silent no-op (`GJC_PLAN_MODEL=… gjc` does nothing; only the undocumented `PI_PLAN_MODEL` works).

## Fix

Resolve `GJC_*` first with `PI_*` as a fallback via the existing `$pickenv` helper — the same GJC-first / PI-fallback convention already used throughout the repo:

- `config.ts:23` — `GJC_PACKAGE_DIR ?? PI_PACKAGE_DIR`
- `utils/src/dirs.ts:152` — `GJC_CONFIG_DIR ?? PI_CONFIG_DIR`
- `gjc-runtime/gc-runtime.ts:363` — `GJC_CODING_AGENT_DIR ?? PI_CODING_AGENT_DIR`
- `eval/py/env.ts` — `resolvePythonFlag(env, "GJC_…", "PI_…")`
- `lsp/lspmux.ts:173` — `$flag("GJC_DISABLE_LSPMUX") || $flag("PI_DISABLE_LSPMUX")`

```ts
const smolModel = parsedArgs.smol ?? $pickenv("GJC_SMOL_MODEL", "PI_SMOL_MODEL");
const slowModel = parsedArgs.slow ?? $pickenv("GJC_SLOW_MODEL", "PI_SLOW_MODEL");
const planModel = parsedArgs.plan ?? $pickenv("GJC_PLAN_MODEL", "PI_PLAN_MODEL");
```

`main.ts:1256-1258` is the sole read site for these variables (verified by search). The variable types are unchanged (`string | undefined`).

## Verification

`bunx biome check packages/coding-agent/src/main.ts` — clean. CLI boots clean with the env set (`GJC_SMOL_MODEL=… bun packages/coding-agent/src/cli.ts --version`). No new test is added because `$pickenv` first-non-empty resolution is already covered; asserting it again here would be a tautology, which `AGENTS.md` explicitly discourages.


---

**Supersedes #2823** (closed pending regression coverage). This head adds the requested tests:
- extracted the resolution into a pure, exported `resolveModelRoleOverrides()` so precedence is unit-testable without booting `runRootCommand`.
- `packages/coding-agent/test/model-role-env-overrides.test.ts` covers: no-flag/no-env, documented GJC_* read, legacy PI_* fallback, GJC_>PI_ precedence, CLI>env precedence, empty/whitespace-as-unset, arbitrary-id pass-through (validation is downstream), and fresh-per-call resolution with no leakage into a later invocation.
- resolution stays on `$pickenv` (process env), kept separate from credential env (`$credentialEnv`).

Strict `tsc -p packages/coding-agent/tsconfig.json --noEmit` → 0 errors; `bun test .../model-role-env-overrides.test.ts` → 8 pass; biome clean.