### PR TITLE
fix(ci): map cache evidence to focused AI test

### DIFF
--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -1096,6 +1096,17 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 		expect(tasks[2]?.command).toEqual(["bun", "run", "ci:test:smoke"]);
 		expect(keys.filter(key => key === "native-linux-x64")).toHaveLength(1);
 	});
+	test("cache-eval evidence artifact adds its focused AI test without bypassing root fallback coverage", () => {
+		const tasks = targeted(["artifacts/architecture-2383-eval.json"]);
+		expect(tasks.map(task => task.key)).toEqual([
+			"test:packages/ai/test/anthropic-cache-eval.integration.test.ts",
+			"root-check",
+			"native-linux-x64",
+		]);
+		expect(tasks[0]?.command).toEqual(["bun", "test", "packages/ai/test/anthropic-cache-eval.integration.test.ts"]);
+		expect(tasks[1]?.command).toEqual(["bun", "run", "ci:check:full"]);
+		expect(tasks[2]?.command).toEqual(["bash", "-lc", 'TARGET_VARIANTS="baseline modern" bun scripts/ci-build-native.ts']);
+	});
 
 	test("a CI workflow change plans yaml-parse + ci-selftest + ci-dry-run only", () => {
 		const tasks = targeted([".github/workflows/dev-ci.yml"]);

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -61,6 +61,7 @@ const NATIVE_BUILD_KEYS: ReadonlySet<string> = new Set(["native-build", "native-
 // not follow the source-file basename convention. They supplement, rather than
 // replace, direct-basename test selection and owner fallback tasks.
 const BEHAVIORAL_OWNER_TESTS: Readonly<Record<string, readonly string[]>> = {
+	"artifacts/architecture-2383-eval.json": ["packages/ai/test/anthropic-cache-eval.integration.test.ts"],
 	"packages/coding-agent/src/main.ts": ["packages/coding-agent/test/startup-update-contract.test.ts"],
 };
 


### PR DESCRIPTION
Fixes #2820.

Maps the immutable cache-eval artifact to its focused Anthropic cache-eval integration test in the affected-path planner and adds deterministic selector coverage. The artifact identity remains bound to provider blob OID f695ccbc6492ba21374a878e260a14da1fb78147 and SHA-256 69d4b0235aa465a9e30bb4bf060be6387a3cd63311fcc0148cd89b6668ffb70a.

Local evidence:
- focused cache-eval test: 2 pass, 43 expectations
- affected planner mapping test: 75 pass
- planned artifact path includes focused AI test, root check, native build, TypeScript builds, and Cargo builds
- combined selector task is deferred to exact-head CI because this workspace's shared dependencies lack yaml for scripts/dev-ci-guard-topology.test.ts; no install was performed.

Permission diagnosis: the earlier EACCES resulted from shell interpretation of Markdown backticks in the PR body, not file permissions. Target paths are writable; no permission changes were made.

No main/release/publish/install/sync/live rollout.