### PR TITLE
fix(notifications): tailor uncertain lifecycle guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,8 +5,6 @@
 
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.
 - Resumed managed sessions now complete the verified legacy `local://` artifact migration before synchronous path resolution, preserving legacy scratch files instead of failing startup with a migration-order error.
-
-### Fixed
 - Corrected Telegram's uncertain lifecycle guidance so create, close, and resume commands describe their own possible outcome; close and resume no longer display the create-only duplicate-start warning.
 
 ## [0.11.6] - 2026-07-21

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.
 - Resumed managed sessions now complete the verified legacy `local://` artifact migration before synchronous path resolution, preserving legacy scratch files instead of failing startup with a migration-order error.
 
+### Fixed
+- Corrected Telegram's uncertain lifecycle guidance so create, close, and resume commands describe their own possible outcome; close and resume no longer display the create-only duplicate-start warning.
+
 ## [0.11.6] - 2026-07-21
 ## [0.11.5] - 2026-07-20
 ### Fixed

--- a/packages/coding-agent/src/sdk/bus/lifecycle-commands.ts
+++ b/packages/coding-agent/src/sdk/bus/lifecycle-commands.ts
@@ -238,11 +238,12 @@ function isSafeBranch(value: string): boolean {
 /**
  * Map a lifecycle response/error to a user-facing Telegram message (G010).
  *
- * Only derives text from sessionId, mode, reason, a safe message, and candidate
- * {sessionId,path} — never a token or prompt. Each error reason gets tailored,
- * actionable copy; an "in progress" pending response is surfaced distinctly.
+ * Only derives text from sessionId, mode, reason, a safe message, the originating
+ * lifecycle verb, and candidate {sessionId,path} — never a token or prompt. Each
+ * error reason gets tailored, actionable copy; an "in progress" pending response
+ * is surfaced distinctly.
  */
-export function formatLifecycleOutcome(r: SessionLifecycleResponse): string {
+export function formatLifecycleOutcome(r: SessionLifecycleResponse, verb?: LifecycleCommandVerb): string {
 	switch (r.type) {
 		case "session_create_response":
 			return `\u{1f680} Launching session ${r.sessionId} in tmux. It will appear once ready \u2014 check /session_recent.`;
@@ -282,9 +283,17 @@ export function formatLifecycleOutcome(r: SessionLifecycleResponse): string {
 		case "unsupported_platform":
 			return "Remote session lifecycle is unavailable on this psmux host because GJC cannot prove immutable session identity. No lifecycle action was performed. Use a local GJC terminal with a supported tmux provider.";
 		case "terminal_uncertain":
-			return /in progress/i.test(r.message)
-				? "\u23f3 That request is already in progress \u2014 hold on."
-				: "\u26a0\ufe0f Outcome uncertain. Check /session_recent before retrying so you don't double-spawn.";
+			if (/in progress/i.test(r.message)) return "\u23f3 That request is already in progress \u2014 hold on.";
+			switch (verb) {
+				case "session_create":
+					return "\u26a0\ufe0f Create outcome uncertain. The session may already be starting \u2014 check /session_recent before retrying to avoid starting it twice.";
+				case "session_close":
+					return "\u26a0\ufe0f Close outcome uncertain. The session may already be closed \u2014 check /session_recent before retrying.";
+				case "session_resume":
+					return "\u26a0\ufe0f Resume outcome uncertain. The session may already be reattached or restarting \u2014 check /session_recent before retrying.";
+				default:
+					return "\u26a0\ufe0f Outcome uncertain. Check /session_recent before retrying.";
+			}
 		default:
 			return `\u26a0\ufe0f ${r.reason}: ${r.message}`;
 	}

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -60,6 +60,7 @@ import {
 	formatLifecycleOutcome,
 	isLifecycleCommandLikeText,
 	isLifecycleCommandText,
+	type LifecycleCommandVerb,
 	lifecycleUsage,
 	parseLifecycleCommand,
 	validateLifecycleTarget,
@@ -3238,7 +3239,7 @@ export class TelegramNotificationDaemon {
 
 		const frame = this.buildLifecycleFrame(parsed, updateId ?? Date.now());
 		const response = await this.submitLifecycleFrame(frame);
-		await reply(this.formatLifecycleResponse(response));
+		await reply(this.formatLifecycleResponse(response, verb));
 		return true;
 	}
 
@@ -3254,8 +3255,8 @@ export class TelegramNotificationDaemon {
 	}
 
 	/** Map a lifecycle response/error to a user-facing message (G010 surfacing). */
-	private formatLifecycleResponse(r: SessionLifecycleResponse): string {
-		return formatLifecycleOutcome(r);
+	private formatLifecycleResponse(r: SessionLifecycleResponse, verb: LifecycleCommandVerb): string {
+		return formatLifecycleOutcome(r, verb);
 	}
 
 	constructor(private readonly opts: TelegramDaemonOptions) {

--- a/packages/coding-agent/test/notifications-lifecycle-commands.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-commands.test.ts
@@ -225,6 +225,28 @@ describe("lifecycle command parser (G009)", () => {
 			}),
 		).toMatch(/in progress/i);
 
+		const uncertain = {
+			type: "session_lifecycle_error",
+			requestId: "r",
+			status: "error",
+			reason: "terminal_uncertain",
+			message: "outcome unknown",
+		} as const;
+		const createUncertain = formatLifecycleOutcome(uncertain, "session_create");
+		expect(createUncertain).toContain("already be starting");
+		expect(createUncertain).toContain("starting it twice");
+
+		const closeUncertain = formatLifecycleOutcome(uncertain, "session_close");
+		expect(closeUncertain).toContain("already be closed");
+		expect(closeUncertain).not.toContain("starting it twice");
+
+		const resumeUncertain = formatLifecycleOutcome(uncertain, "session_resume");
+		expect(resumeUncertain).toContain("reattached or restarting");
+		expect(resumeUncertain).not.toContain("starting it twice");
+
+		const genericUncertain = formatLifecycleOutcome(uncertain);
+		expect(genericUncertain).not.toContain("starting it twice");
+
 		// ambiguous_target lists candidates.
 		const amb = formatLifecycleOutcome({
 			type: "session_lifecycle_error",


### PR DESCRIPTION
## Summary

- pass the originating lifecycle verb into Telegram outcome formatting
- keep duplicate-start guidance specific to uncertain create requests
- tell close users that the session may already be closed
- cover both reattach and cold-restart possibilities for uncertain resume requests
- retain neutral fallback guidance when the originating verb is unavailable

## Rationale

`terminal_uncertain` is shared by create, close, and resume requests, but its Telegram message previously always warned about a double spawn. That warning is useful for create but factually incorrect for close and incomplete for resume.

This changes only user-facing outcome guidance. Lifecycle execution, idempotency, ledger state, protocol frames, and retry behavior are unchanged.

## Tests

- `bun test packages/coding-agent/test/notifications-lifecycle-commands.test.ts packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts packages/coding-agent/test/notifications-lifecycle-orchestrator.test.ts` (51 passed, 274 assertions)
- `bunx biome check packages/coding-agent/CHANGELOG.md packages/coding-agent/src/sdk/bus/lifecycle-commands.ts packages/coding-agent/src/sdk/bus/telegram-daemon.ts packages/coding-agent/test/notifications-lifecycle-commands.test.ts`
- `git diff upstream/dev...HEAD --check`
