### PR TITLE
feat(ai): add first-class alibaba-token-plan provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added first-class `alibaba-token-plan` provider for Alibaba Cloud Model Studio's "Token Plan" OpenAI-compatible gateway (`https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`), mirroring `alibaba-coding-plan`. Resolves credentials from `ALIBABA_TOKEN_PLAN_API_KEY`, seeds six chat models (`qwen3.7-max`, `qwen3.8-max-preview`, `qwen3.7-plus`, `qwen3.6-flash`, `glm-5.2`, `deepseek-v4-pro`), and disables the OpenAI `developer` role so GLM/Qwen models complete through the gateway
+
 ## [0.1.1] - 2026-05-28
 ### Breaking Changes
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1361,6 +1361,12 @@ export class AuthStorage {
 				await saveApiKeyCredential(apiKey);
 				return;
 			}
+			case "alibaba-token-plan": {
+				const { loginAlibabaTokenPlan } = await import("./utils/oauth/alibaba-token-plan");
+				const apiKey = await loginAlibabaTokenPlan(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
 			case "github-copilot": {
 				const { loginGitHubCopilot } = await import("./utils/oauth/github-copilot");
 				credentials = await loginGitHubCopilot({

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -1,4 +1,168 @@
 {
+	"alibaba-token-plan": {
+		"qwen3.7-max": {
+			"id": "qwen3.7-max",
+			"name": "Qwen3.7 Max",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen3.8-max-preview": {
+			"id": "qwen3.8-max-preview",
+			"name": "Qwen3.8 Max Preview",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 16384,
+			"compat": {
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen3.7-plus": {
+			"id": "qwen3.7-plus",
+			"name": "Qwen3.7 Plus",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen3.6-flash": {
+			"id": "qwen3.6-flash",
+			"name": "Qwen3.6 Flash",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"glm-5.2": {
+			"id": "glm-5.2",
+			"name": "GLM-5.2",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"deepseek-v4-pro": {
+			"id": "deepseek-v4-pro",
+			"name": "DeepSeek V4 Pro",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"compat": {
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		}
+	},
 	"alibaba-coding-plan": {
 		"glm-4.7": {
 			"id": "glm-4.7",

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -10,6 +10,7 @@ import { googleModelManagerOptions } from "./google";
 import { ollamaCloudModelManagerOptions } from "./ollama";
 import {
 	alibabaCodingPlanModelManagerOptions,
+	alibabaTokenPlanModelManagerOptions,
 	anthropicModelManagerOptions,
 	cerebrasModelManagerOptions,
 	cloudflareAiGatewayModelManagerOptions,
@@ -132,6 +133,12 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		"qwen3.5-plus",
 		config => alibabaCodingPlanModelManagerOptions(config),
 		catalog("Alibaba Coding Plan", ["ALIBABA_CODING_PLAN_API_KEY"]),
+	),
+	catalogDescriptor(
+		"alibaba-token-plan",
+		"qwen3.7-max",
+		config => alibabaTokenPlanModelManagerOptions(config),
+		catalog("Alibaba Token Plan", ["ALIBABA_TOKEN_PLAN_API_KEY"]),
 	),
 	descriptor("openai", "gpt-5.4", config => openaiModelManagerOptions(config)),
 	descriptor("groq", "openai/gpt-oss-120b", config => groqModelManagerOptions(config)),

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1061,6 +1061,37 @@ export function alibabaCodingPlanModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
+// Alibaba Token Plan
+// ---------------------------------------------------------------------------
+
+export interface AlibabaTokenPlanModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function alibabaTokenPlanModelManagerOptions(
+	config?: AlibabaTokenPlanModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1";
+	const references = createBundledReferenceMap<"openai-completions">("alibaba-token-plan");
+	return {
+		providerId: "alibaba-token-plan",
+		fetchDynamicModels: () =>
+			fetchOpenAICompatibleModels({
+				api: "openai-completions",
+				provider: "alibaba-token-plan",
+				baseUrl,
+				apiKey,
+				mapModel: (entry, defaults) => {
+					const reference = references.get(defaults.id);
+					return mapWithBundledReference(entry, defaults, reference);
+				},
+			}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 11. Vercel AI Gateway
 // ---------------------------------------------------------------------------
 
@@ -2178,6 +2209,17 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 		"alibaba-coding-plan",
 		"alibaba-coding-plan",
 		"https://coding-intl.dashscope.aliyuncs.com/v1",
+		{
+			compat: {
+				supportsDeveloperRole: false,
+			},
+		},
+	),
+	// --- Alibaba Token Plan ---
+	openAiCompletionsDescriptor(
+		"alibaba-token-plan",
+		"alibaba-token-plan",
+		"https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
 		{
 			compat: {
 				supportsDeveloperRole: false,

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -64,7 +64,11 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		baseUrl.includes("api.anthropic.com") ||
 		/(^|\/)claude[-.]/i.test(model.id) ||
 		/(^|\/)anthropic\//i.test(model.id);
-	const isAlibaba = provider === "alibaba-coding-plan" || baseUrl.includes("dashscope");
+	const isAlibaba =
+		provider === "alibaba-coding-plan" ||
+		provider === "alibaba-token-plan" ||
+		baseUrl.includes("dashscope") ||
+		baseUrl.includes("maas.aliyuncs.com");
 	const isQwen = model.id.toLowerCase().includes("qwen");
 	// DeepSeek V4 (and other reasoning-capable DeepSeek models) reject follow-up requests in
 	// thinking mode unless prior assistant tool-call turns include `reasoning_content`. The

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -77,6 +77,7 @@ type KeyResolver = string | (() => string | undefined);
 
 const serviceProviderMap: Record<string, KeyResolver> = {
 	"alibaba-coding-plan": "ALIBABA_CODING_PLAN_API_KEY",
+	"alibaba-token-plan": "ALIBABA_TOKEN_PLAN_API_KEY",
 	openai: "OPENAI_API_KEY",
 	google: "GEMINI_API_KEY",
 	groq: "GROQ_API_KEY",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -97,6 +97,7 @@ export interface ThinkingConfig {
 
 export type KnownProvider =
 	| "alibaba-coding-plan"
+	| "alibaba-token-plan"
 	| "amazon-bedrock"
 	| "anthropic"
 	| "google"

--- a/packages/ai/src/utils/oauth/alibaba-token-plan.ts
+++ b/packages/ai/src/utils/oauth/alibaba-token-plan.ts
@@ -1,0 +1,60 @@
+/**
+ * Alibaba Token Plan login flow.
+ *
+ * Alibaba Token Plan provides OpenAI-compatible models via
+ * https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1.
+ *
+ * This is not OAuth - it's a simple API key flow:
+ * 1. Open browser to Alibaba Cloud Model Studio API key settings
+ * 2. User copies their API key
+ * 3. User pastes the API key into the CLI
+ */
+
+import { validateOpenAICompatibleApiKey } from "./api-key-validation";
+import type { OAuthController } from "./types";
+
+const AUTH_URL = "https://modelstudio.console.alibabacloud.com/";
+const API_BASE_URL = "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1";
+const VALIDATION_MODEL = "qwen3.7-max";
+
+/**
+ * Login to Alibaba Token Plan.
+ *
+ * Opens browser to API keys page, prompts user to paste their API key.
+ * Returns the API key directly (not OAuthCredentials - this isn't OAuth).
+ */
+export async function loginAlibabaTokenPlan(options: OAuthController): Promise<string> {
+	if (!options.onPrompt) {
+		throw new Error("Alibaba Token Plan login requires onPrompt callback");
+	}
+
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: "Copy your API key from the Alibaba Cloud Model Studio console",
+	});
+
+	const apiKey = await options.onPrompt({
+		message: "Paste your Alibaba Token Plan API key",
+		placeholder: "sk-...",
+	});
+
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new Error("API key is required");
+	}
+
+	options.onProgress?.("Validating API key...");
+	await validateOpenAICompatibleApiKey({
+		provider: "Alibaba Token Plan",
+		apiKey: trimmed,
+		baseUrl: API_BASE_URL,
+		model: VALIDATION_MODEL,
+		signal: options.signal,
+	});
+
+	return trimmed;
+}

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -21,6 +21,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "alibaba-token-plan",
+		name: "Alibaba Token Plan",
+		available: true,
+	},
+	{
 		id: "openai-codex",
 		name: "ChatGPT Plus/Pro (Codex Subscription)",
 		available: true,

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -10,6 +10,7 @@ export type OAuthCredentials = {
 
 export type OAuthProvider =
 	| "alibaba-coding-plan"
+	| "alibaba-token-plan"
 	| "anthropic"
 	| "cerebras"
 	| "cloudflare-ai-gateway"

--- a/packages/ai/test/alibaba-token-plan-provider.test.ts
+++ b/packages/ai/test/alibaba-token-plan-provider.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import modelsJson from "../src/models.json" with { type: "json" };
+import { DEFAULT_MODEL_PER_PROVIDER, PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
+import { alibabaTokenPlanModelManagerOptions } from "../src/provider-models/openai-compat";
+import { detectOpenAICompat } from "../src/providers/openai-completions-compat";
+import { getEnvApiKey } from "../src/stream";
+import type { Model } from "../src/types";
+import { getOAuthProviders } from "../src/utils/oauth";
+import { loginAlibabaTokenPlan } from "../src/utils/oauth/alibaba-token-plan";
+
+const TOKEN_PLAN_BASE_URL = "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1";
+const CODING_PLAN_BASE_URL = "https://coding-intl.dashscope.aliyuncs.com/v1";
+const EXPECTED_MODEL_IDS = [
+	"qwen3.7-max",
+	"qwen3.8-max-preview",
+	"qwen3.7-plus",
+	"qwen3.6-flash",
+	"glm-5.2",
+	"deepseek-v4-pro",
+];
+
+const originalKey = Bun.env.ALIBABA_TOKEN_PLAN_API_KEY;
+const originalCodingKey = Bun.env.ALIBABA_CODING_PLAN_API_KEY;
+const originalFetch = global.fetch;
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete Bun.env[name];
+	} else {
+		Bun.env[name] = value;
+	}
+}
+
+afterEach(() => {
+	restoreEnv("ALIBABA_TOKEN_PLAN_API_KEY", originalKey);
+	restoreEnv("ALIBABA_CODING_PLAN_API_KEY", originalCodingKey);
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+function tokenPlanModel(id: string): Model<"openai-completions"> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "alibaba-token-plan",
+		baseUrl: TOKEN_PLAN_BASE_URL,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	} as Model<"openai-completions">;
+}
+
+describe("alibaba-token-plan provider support", () => {
+	test("resolves ALIBABA_TOKEN_PLAN_API_KEY from environment", () => {
+		Bun.env.ALIBABA_TOKEN_PLAN_API_KEY = "token-plan-test-key";
+		expect(getEnvApiKey("alibaba-token-plan")).toBe("token-plan-test-key");
+		// Red-team: the sibling coding-plan key must not be satisfied by the token-plan key.
+		delete Bun.env.ALIBABA_CODING_PLAN_API_KEY;
+		expect(getEnvApiKey("alibaba-coding-plan")).toBeUndefined();
+	});
+
+	test("registers built-in descriptor, default model, and env var", () => {
+		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "alibaba-token-plan");
+		expect(descriptor).toBeDefined();
+		expect(descriptor?.defaultModel).toBe("qwen3.7-max");
+		expect(descriptor?.catalogDiscovery?.envVars).toContain("ALIBABA_TOKEN_PLAN_API_KEY");
+		expect(DEFAULT_MODEL_PER_PROVIDER["alibaba-token-plan"]).toBe("qwen3.7-max");
+	});
+
+	test("registers Alibaba Token Plan in the OAuth provider selector", () => {
+		const provider = getOAuthProviders().find(item => item.id === "alibaba-token-plan");
+		expect(provider?.name).toBe("Alibaba Token Plan");
+		expect(provider?.available).toBe(true);
+		expect(typeof loginAlibabaTokenPlan).toBe("function");
+	});
+
+	test("model manager options target the token-plan endpoint", async () => {
+		const captured: string[] = [];
+		global.fetch = vi.fn(async (input: string | URL | Request) => {
+			captured.push(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+			return new Response(
+				JSON.stringify({ data: EXPECTED_MODEL_IDS.map(id => ({ id, object: "model", owned_by: "system" })) }),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const options = alibabaTokenPlanModelManagerOptions({ apiKey: "token-plan-test-key" });
+		expect(options.providerId).toBe("alibaba-token-plan");
+		expect(options.fetchDynamicModels).toBeDefined();
+
+		await options.fetchDynamicModels?.();
+		// The discovery call must hit the token-plan gateway, never the coding-plan dashscope host.
+		expect(captured.some(url => url.startsWith(TOKEN_PLAN_BASE_URL))).toBe(true);
+		expect(captured.some(url => url.includes("dashscope"))).toBe(false);
+	});
+
+	test("models.json seeds the six token-plan chat models correctly", () => {
+		const catalog = (modelsJson as Record<string, Record<string, Model<"openai-completions">>>)["alibaba-token-plan"];
+		expect(catalog).toBeDefined();
+		expect(Object.keys(catalog).sort()).toEqual([...EXPECTED_MODEL_IDS].sort());
+		for (const [id, model] of Object.entries(catalog)) {
+			expect(model.id).toBe(id);
+			expect(model.provider).toBe("alibaba-token-plan");
+			expect(model.api).toBe("openai-completions");
+			expect(model.baseUrl).toBe(TOKEN_PLAN_BASE_URL);
+			// Distinct from the sibling coding-plan provider.
+			expect(model.baseUrl).not.toBe(CODING_PLAN_BASE_URL);
+			// Compat fix so GLM and other models accept the request (no OpenAI "developer" role).
+			expect(model.compat?.supportsDeveloperRole).toBe(false);
+		}
+	});
+
+	test("detectOpenAICompat applies Alibaba (Qwen) shaping to token-plan models", () => {
+		const compat = detectOpenAICompat(tokenPlanModel("qwen3.7-max"));
+		// isAlibaba -> single system message + qwen thinking format.
+		expect(compat.supportsMultipleSystemMessages).toBe(false);
+		expect(compat.thinkingFormat).toBe("qwen");
+	});
+});


### PR DESCRIPTION
## What

Adds **`alibaba-token-plan`** as a first-class built-in OpenAI-compatible provider in `@gajae-code/ai`, mirroring the existing `alibaba-coding-plan` provider.

- **baseUrl:** `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`
- **transport:** `openai-completions`; API key from `ALIBABA_TOKEN_PLAN_API_KEY` (env) or the interactive login flow
- **default / validation model:** `qwen3.7-max`
- **seeded models (6):** `qwen3.7-max`, `qwen3.8-max-preview`, `qwen3.7-plus`, `qwen3.6-flash`, `glm-5.2`, `deepseek-v4-pro`
- `compat.supportsDeveloperRole: false` + `isAlibaba` detection so GLM/Qwen models accept requests through the gateway

Touchpoints (all mirror `alibaba-coding-plan`): `types.ts` (KnownProvider), `utils/oauth/types.ts` (OAuthProvider), `stream.ts` (serviceProviderMap), `provider-models/descriptors.ts` (catalogDescriptor + default model), `provider-models/openai-compat.ts` (model-manager options + models.dev descriptor), `providers/openai-completions-compat.ts` (isAlibaba), `utils/oauth/alibaba-token-plan.ts` (new login flow), `utils/oauth/index.ts` (selector registration), `auth-storage.ts` (login case), `models.json` (catalog seed). Plus a `## [Unreleased]` CHANGELOG entry and a focused test.

## Why

So GJC can use Alibaba Cloud Model Studio's **Token Plan** OpenAI-compatible gateway out of the box — the same way `alibaba-coding-plan` is integrated — instead of requiring a hand-written custom `models.yml` provider. No secret is committed; the API key is only ever read at runtime from the env var or the paste-key login flow.

## Testing

- `packages/ai` `bun run check` (biome check . + `tsgo` typecheck): **clean** (321 files, no fixes)
- `packages/ai` `bun test`: **1203 pass / 0 fail** (337 e2e skipped; native addon built locally)
- New `test/alibaba-token-plan-provider.test.ts` (6 tests): env-key resolution + cross-provider isolation, descriptor/default-model/env-var registration, OAuth selector, `fetchDynamicModels` hitting the token-plan URL (asserting no `dashscope` leakage), `models.json` seed invariants, and `detectOpenAICompat` Qwen shaping.
- Red-team: staged-diff and PR-diff scans confirm no API key/secret is present; only the env-var **name** appears.
- Metadata: `deepseek-v4-pro` `maxTokens` aligned to `384000` to match every other provider's entry for that model id.

---

- [x] `bun check` passes — TS gate (`ci:check:full` = `check:ts`, i.e. per-workspace `biome check . && check:types`) is clean for the touched package; the change is TS/JSON-only so `check:rs` (Rust) is unaffected.
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — `packages/ai/CHANGELOG.md` `## [Unreleased]` → `### Added`
