### PR TITLE
fix(session): reuse scoped settings in resume picker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Bare `gjc --resume` picker selections now reuse the workspace-scoped settings instance when resolving managed session storage, instead of failing before global settings initialization (#2812).
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.
 - Resumed managed sessions now complete the verified legacy `local://` artifact migration before synchronous path resolution, preserving legacy scratch files instead of failing startup with a migration-order error.
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1108,19 +1108,16 @@ export async function runRootCommand(
 		if (selection.kind === "cancelled") {
 			return;
 		}
+		const resumeSettings = await (deps.loadSettingsForScope ?? Settings.loadForScope)({ cwd: resumeCwd });
 		const resumeMigrationPolicy =
-			(await (deps.loadSettingsForScope ?? Settings.loadForScope)({ cwd: resumeCwd })).get(
-				"session.directoryMigration",
-			) === "disabled"
-				? "disabled"
-				: "copy-retain";
+			resumeSettings.get("session.directoryMigration") === "disabled" ? "disabled" : "copy-retain";
 		let opened: StrictSessionOpenResult;
 		try {
 			opened = await (deps.openExistingSessionStrict ?? SessionManager.openExistingStrict)(
 				selection.identity,
 				parsedArgs.sessionDir
 					? SessionManager.explicitDestination(parsedArgs.sessionDir)
-					: SessionManager.managedDestination(resumeCwd, settings.getAgentDir()),
+					: SessionManager.managedDestination(resumeCwd, resumeSettings.getAgentDir()),
 				undefined,
 				resumeMigrationPolicy,
 			);


### PR DESCRIPTION
## What

- Reuse the workspace-scoped `Settings` instance already loaded by the bare resume picker when resolving managed session storage.
- Document the user-facing fix in the coding-agent changelog.

## Why

We independently reproduced and traced this failure locally before discovering that #2812 had subsequently been filed for the same behavior.

The bare `gjc --resume` picker runs before the global `Settings` singleton is initialized. It correctly loads a scoped settings instance to resolve the session migration policy, but then reads the managed-session agent directory from the uninitialized global `settings` proxy. That exception is caught by the strict-open boundary and rendered as the generic:

```text
Could not open the selected session. Use --resume <id>.
```

Reusing the same scoped instance for both values keeps the early picker path independent of global settings initialization and preserves workspace-specific agent-directory overrides.

Fixes #2812

## Testing

- `bun test packages/coding-agent/test/resume-confirm-continue.test.ts packages/coding-agent/test/cli-resume-alias.test.ts packages/coding-agent/test/session-manager-resume-readonly.test.ts packages/coding-agent/test/modes/components/session-selector-resume-confirm.test.ts` (45 passed)
- `bun --cwd=packages/coding-agent run check`
- `TMPDIR=<user-owned-temp-dir> bun check`
- `git diff --check`

The focused custom-agent-root regression resets the global `Settings` singleton, verifies that it remains uninitialized, and asserts that the workspace-scoped agent directory and migration policy reach managed destination resolution and strict open.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
