### PR TITLE
fix(session): preserve resume picker authority

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -12,6 +12,7 @@ import { createInterface } from "node:readline/promises";
 import type { ImageContent } from "@gajae-code/ai";
 import {
 	$env,
+	getAgentDir,
 	getProjectDir,
 	logger,
 	normalizePathForComparison,
@@ -534,7 +535,16 @@ interface InteractiveModeFactoryOptions {
 type CreateInteractiveMode = (options: InteractiveModeFactoryOptions) => InteractiveMode;
 
 type ResumePickerTerminalCheck = () => boolean;
-type ListForResumePickerReadOnly = (cwd: string, sessionDir?: string) => Promise<SessionInfo[]>;
+type ListForResumePickerReadOnly = (cwd: string, sessionDir?: string, storage?: undefined) => Promise<SessionInfo[]>;
+
+type ListManagedForResumePickerReadOnly = (
+	cwd: string,
+	managedAgentDir?: string,
+	storage?: undefined,
+) => Promise<SessionInfo[]>;
+
+type ResolveManagedAgentDirForScope = (cwd: string) => string;
+
 type SelectResumeSession = (sessions: SessionInfo[]) => Promise<SessionSelectionResult>;
 type OpenExistingSessionStrict = (
 	identity: ResumeSessionIdentity,
@@ -546,6 +556,11 @@ type OpenExistingSessionStrict = (
 export const BARE_RESUME_CONFLICT_ERROR =
 	"--resume without a session cannot be combined with --continue, --fork, or --no-session.";
 export const BARE_RESUME_INTERACTIVE_ERROR = "--resume requires an interactive terminal; use --resume <id>.";
+
+/** Resolves only the managed agent root needed for pre-consent picker inventory. */
+export function resolveManagedAgentDirForScope(_cwd: string): string {
+	return getAgentDir();
+}
 export const BARE_RESUME_OPEN_ERROR = "Could not open the selected session. Use --resume <id>.";
 
 function isBareResume(parsed: Args): boolean {
@@ -741,7 +756,13 @@ export async function createSessionManager(
 		if (forkSource.includes("/") || forkSource.includes("\\") || forkSource.endsWith(".jsonl")) {
 			return await SessionManager.forkFrom(forkSource, cwd, sessionDestination(), undefined, migrationPolicy);
 		}
-		const match = await resolveResumableSession(forkSource, cwd, parsed.sessionDir);
+		const match = await resolveResumableSession(
+			forkSource,
+			cwd,
+			parsed.sessionDir,
+			undefined,
+			parsed.sessionDir ? undefined : activeSettings.getAgentDir(),
+		);
 		if (!match) {
 			throw new Error(`Session "${forkSource}" not found.`);
 		}
@@ -754,14 +775,18 @@ export async function createSessionManager(
 	if (typeof parsed.resume === "string") {
 		const sessionArg = parsed.resume;
 		if (sessionArg.includes("/") || sessionArg.includes("\\") || sessionArg.endsWith(".jsonl")) {
-			return await SessionManager.open(
-				sessionArg,
-				SessionManager.explicitDestination(path.dirname(sessionArg)),
-				undefined,
-				migrationPolicy,
-			);
+			const destination = parsed.sessionDir
+				? SessionManager.explicitDestination(parsed.sessionDir)
+				: SessionManager.explicitDestination(path.dirname(sessionArg));
+			return await SessionManager.open(sessionArg, destination, undefined, migrationPolicy);
 		}
-		const match = await resolveResumableSession(sessionArg, cwd, parsed.sessionDir);
+		const match = await resolveResumableSession(
+			sessionArg,
+			cwd,
+			parsed.sessionDir,
+			undefined,
+			parsed.sessionDir ? undefined : activeSettings.getAgentDir(),
+		);
 		if (!match) {
 			throw new Error(`Session "${sessionArg}" not found.`);
 		}
@@ -1058,6 +1083,8 @@ export interface RunRootCommandDependencies {
 	runPrintMode?: RunPrintMode;
 	isResumePickerTerminal?: ResumePickerTerminalCheck;
 	listForResumePickerReadOnly?: ListForResumePickerReadOnly;
+	listManagedForResumePickerReadOnly?: ListManagedForResumePickerReadOnly;
+	resolveManagedAgentDirForScope?: ResolveManagedAgentDirForScope;
 	selectResumeSession?: SelectResumeSession;
 	openExistingSessionStrict?: OpenExistingSessionStrict;
 	initializeSettings?: typeof Settings.init;
@@ -1094,10 +1121,18 @@ export async function runRootCommand(
 		await logger.time("maybeAutoChdir", maybeAutoChdir, parsedArgs);
 		autoChdirApplied = true;
 		const resumeCwd = getProjectDir();
-		const sessions = await (deps.listForResumePickerReadOnly ?? SessionManager.listForResumePickerReadOnly)(
-			resumeCwd,
-			parsedArgs.sessionDir,
-		);
+		const managedAgentDir = parsedArgs.sessionDir
+			? undefined
+			: (deps.resolveManagedAgentDirForScope ?? resolveManagedAgentDirForScope)(resumeCwd);
+		const sessions = parsedArgs.sessionDir
+			? await (deps.listForResumePickerReadOnly ?? SessionManager.listForResumePickerReadOnly)(
+					resumeCwd,
+					parsedArgs.sessionDir,
+				)
+			: await (deps.listManagedForResumePickerReadOnly ?? SessionManager.listManagedForResumePickerReadOnly)(
+					resumeCwd,
+					managedAgentDir,
+				);
 		if (sessions.length === 0) {
 			process.stdout.write(`${chalk.dim("No sessions found")}\n`);
 			return;
@@ -1108,19 +1143,16 @@ export async function runRootCommand(
 		if (selection.kind === "cancelled") {
 			return;
 		}
+		const scopedSettings = await (deps.loadSettingsForScope ?? Settings.loadForScope)({ cwd: resumeCwd });
 		const resumeMigrationPolicy =
-			(await (deps.loadSettingsForScope ?? Settings.loadForScope)({ cwd: resumeCwd })).get(
-				"session.directoryMigration",
-			) === "disabled"
-				? "disabled"
-				: "copy-retain";
+			scopedSettings.get("session.directoryMigration") === "disabled" ? "disabled" : "copy-retain";
 		let opened: StrictSessionOpenResult;
 		try {
 			opened = await (deps.openExistingSessionStrict ?? SessionManager.openExistingStrict)(
 				selection.identity,
 				parsedArgs.sessionDir
 					? SessionManager.explicitDestination(parsedArgs.sessionDir)
-					: SessionManager.managedDestination(resumeCwd, settings.getAgentDir()),
+					: SessionManager.managedDestination(resumeCwd, scopedSettings.getAgentDir()),
 				undefined,
 				resumeMigrationPolicy,
 			);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -2057,10 +2057,7 @@ export class SelectorController {
 	}
 
 	async showSessionSelector(): Promise<void> {
-		const sessions = await SessionManager.listForResumePickerReadOnly(
-			this.ctx.sessionManager.getCwd(),
-			this.ctx.sessionManager.getSessionDir(),
-		);
+		const sessions = await this.ctx.sessionManager.listForResumePickerReadOnly();
 		this.showSelector(done => {
 			const selector = new SessionSelectorComponent(
 				sessions,
@@ -2156,8 +2153,16 @@ export class SelectorController {
 		this.#clearTransientSessionUi();
 		const migrationPolicy =
 			this.ctx.settings?.get("session.directoryMigration") === "disabled" ? "disabled" : "copy-retain";
-		const writableSessionPath = await SessionManager.prepareManagedCandidateForWrite(sessionPath, migrationPolicy);
-
+		let writableSessionPath = sessionPath;
+		if (this.ctx.sessionManager.isManagedDestination()) {
+			const inspection = await SessionManager.inspectSessionTailReadOnly(sessionPath);
+			if (inspection.kind === "error") throw new Error(`Could not inspect selected session: ${inspection.reason}`);
+			writableSessionPath = await this.ctx.sessionManager.prepareManagedCandidateForStrictAdoption(
+				sessionPath,
+				migrationPolicy,
+				inspection.identity,
+			);
+		}
 		// Switch session via AgentSession (emits hook and tool session events)
 		if (!(await this.ctx.session.switchSession(writableSessionPath))) return;
 		const switchingToDifferentSession = previousSessionId !== this.ctx.sessionManager.getSessionId();

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -17,11 +17,13 @@ import {
 } from "../session-storage";
 import {
 	acquireManagedLock,
+	assertManagedDirectoryRoot,
 	captureManagedFileNoFollow,
 	captureManagedFilePrefixNoFollow,
 	copyManagedFileNoReplace,
 	ensureManagedDirectory,
 	fsyncManagedArtifactTree,
+	type ManagedDirectoryRoot,
 	ManagedSessionDescendantStore,
 	type ManagedSessionSecurityPolicy,
 	type ManagedStorageLock,
@@ -50,9 +52,37 @@ export interface ManagedScope {
 	platform: "posix" | "win32";
 }
 
+/**
+ * Opaque managed writer authority captured by a trusted destination. The open
+ * transaction must use this authority rather than reacquiring its root from a
+ * pathname after resume inspection.
+ */
+export interface ManagedCandidateWriteAuthority {
+	readonly rootAuthority: ManagedDirectoryRoot;
+	readonly retainedAuthority?: native.RecoveryFsRoot;
+	readonly retainedDirectory?: string;
+}
+
 const managedRoots = new WeakMap<ManagedScope, ReturnType<typeof managedDirectoryRoot>>();
 const managedDirectoryIdentities = new WeakMap<ManagedScope, { dev: bigint; ino: bigint }>();
 const managedDirectoryAuthorities = new WeakMap<ManagedScope, native.RecoveryFsRoot | undefined>();
+const boundManagedWriteAuthorities = new WeakMap<ManagedScope, ManagedCandidateWriteAuthority>();
+
+function bindManagedWriteAuthority(scope: ManagedScope, authority: ManagedCandidateWriteAuthority): void {
+	assertManagedDirectoryRoot(authority.rootAuthority);
+	if (
+		authority.retainedAuthority &&
+		authority.retainedDirectory !== undefined &&
+		path.resolve(authority.retainedDirectory) === path.resolve(scope.directoryPath)
+	) {
+		new ManagedSessionDescendantStore(authority.rootAuthority, scope.directoryPath, {
+			authority: authority.retainedAuthority,
+			authorityBaseDir: scope.directoryPath,
+		}).assertBound();
+	}
+	managedRoots.set(scope, authority.rootAuthority);
+	boundManagedWriteAuthorities.set(scope, authority);
+}
 
 export function managedDirectoryAuthorityForScope(scope: ManagedScope): native.RecoveryFsRoot | undefined {
 	if (!managedDirectoryAuthorities.has(scope)) throw new Error("Managed session directory authority was not prepared");
@@ -82,6 +112,11 @@ function configuredRootPath(scope: ManagedScope): string {
 }
 
 function scopeRoot(scope: ManagedScope) {
+	const bound = boundManagedWriteAuthorities.get(scope);
+	if (bound) {
+		bindManagedWriteAuthority(scope, bound);
+		return bound.rootAuthority;
+	}
 	const retained = managedRoots.get(scope);
 	if (retained) return retained;
 	const root = managedDirectoryRoot(configuredRootPath(scope));
@@ -721,18 +756,25 @@ function isRecoverableOwnerOnlyModeDrift(error: unknown): boolean {
 export function prepareManagedSessionScopeForWriteSync(
 	scope: ManagedScope,
 	policy: ManagedSessionSecurityPolicy = "default",
+	authority?: ManagedCandidateWriteAuthority,
 ): ManagedScopeResolution {
 	try {
-		const root = scopeRoot(scope);
+		const root = authority?.rootAuthority ?? scopeRoot(scope);
+		if (authority) bindManagedWriteAuthority(scope, authority);
 		ensureManagedDirectory(scope.sessionsRoot, root, policy);
 		ensureManagedDirectory(scope.directoryPath, root, policy);
 		const preparedDirectory = fs.lstatSync(scope.directoryPath, { bigint: true });
 		if (!preparedDirectory.isDirectory() || preparedDirectory.isSymbolicLink())
 			throw new Error("Managed session directory changed");
-		const retainedAuthority = retainManagedDirectoryAuthority(root, scope.directoryPath, {
-			dev: preparedDirectory.dev,
-			ino: preparedDirectory.ino,
-		});
+		const retainedAuthority =
+			authority?.retainedAuthority &&
+			authority.retainedDirectory !== undefined &&
+			path.resolve(authority.retainedDirectory) === path.resolve(scope.directoryPath)
+				? authority.retainedAuthority
+				: retainManagedDirectoryAuthority(root, scope.directoryPath, {
+						dev: preparedDirectory.dev,
+						ino: preparedDirectory.ino,
+					});
 		const buildStore = () =>
 			new ManagedSessionDescendantStore(
 				root,
@@ -920,6 +962,29 @@ function sameCandidate(left: ManagedCandidate, right: ManagedCandidate): boolean
 		left.identity.mtimeNs === right.identity.mtimeNs &&
 		left.identity.sha256 === right.identity.sha256
 	);
+}
+
+function matchesExpectedResumeIdentity(candidate: ManagedCandidate, expected: ResumeSessionIdentity): boolean {
+	return (
+		path.resolve(candidate.identity.canonicalPath) === path.resolve(expected.canonicalPath) &&
+		candidate.identity.sessionId === expected.sessionId &&
+		candidate.identity.dev === expected.dev &&
+		candidate.identity.ino === expected.ino &&
+		candidate.identity.size === expected.size &&
+		candidate.identity.mtimeMs === expected.mtimeMs &&
+		candidate.identity.mtimeNs === expected.mtimeNs &&
+		candidate.identity.sha256 === expected.sha256
+	);
+}
+
+function revalidatePickerConsent(
+	scope: ManagedScope,
+	candidate: ManagedCandidate,
+	expectedIdentity: ResumeSessionIdentity,
+): ManagedCandidate {
+	const current = validateCandidateForScope(scope, candidate);
+	if (!current || !matchesExpectedResumeIdentity(current, expectedIdentity)) throw new Error("source_changed");
+	return current;
 }
 
 function receiptPathFor(
@@ -1903,6 +1968,8 @@ async function copyArtifacts(
 	destinationTranscript: string,
 	manifest: readonly ArtifactManifestEntry[],
 	lock: ManagedStorageLock,
+	expectedCandidate: ManagedCandidate,
+	expectedIdentity: ResumeSessionIdentity,
 	sourceRootOverride?: string,
 ): Promise<void> {
 	const root = scopeRoot(scope);
@@ -1911,12 +1978,18 @@ async function copyArtifacts(
 	if (!manifestMatches(sourceTranscript, manifest, sourceRoot)) throw new Error("source_changed");
 	const destinationRoot = destinationTranscript.slice(0, -6);
 	for (const entry of manifest) {
+		revalidatePickerConsent(scope, expectedCandidate, expectedIdentity);
 		lock.assertOwned();
 		const source = path.join(sourceRoot, entry.path);
 		const destination = path.join(destinationRoot, entry.path);
 		if (entry.kind === "directory") {
-			if (entry.path === "") ensureManagedDirectory(destinationRoot, root);
-			else ensureManagedDirectory(destination, root);
+			if (entry.path === "") {
+				revalidatePickerConsent(scope, expectedCandidate, expectedIdentity);
+				ensureManagedDirectory(destinationRoot, root);
+			} else {
+				revalidatePickerConsent(scope, expectedCandidate, expectedIdentity);
+				ensureManagedDirectory(destination, root);
+			}
 			continue;
 		}
 		const snapshot = captureManagedFileNoFollow(source);
@@ -1926,6 +1999,7 @@ async function copyArtifacts(
 		)
 			throw new Error("source_changed");
 		try {
+			revalidatePickerConsent(scope, expectedCandidate, expectedIdentity);
 			await copyManagedFileNoReplace(source, destination, snapshot, root);
 		} catch (error) {
 			if ((error as Error).message !== "destination_conflict") throw error;
@@ -2023,6 +2097,7 @@ function receiptPair(scope: ManagedScope, candidate: ManagedCandidate): ManagedC
 }
 
 function validateCandidateForScope(scope: ManagedScope, candidate: ManagedCandidate): ManagedCandidate | undefined {
+	scopeRoot(scope);
 	const inspected = inspectCandidate(candidate.path, candidate.provenance);
 	if ("code" in inspected || !sameCandidate(inspected, candidate)) return undefined;
 	const identity = identityFor(inspected.cwd);
@@ -2153,7 +2228,12 @@ export async function reconcileManagedTombstones(scope: ManagedScope): Promise<v
 export async function prepareManagedSessionScopeForWrite(
 	scope: ManagedScope,
 	policy: ManagedSessionSecurityPolicy = "default",
+	authority?: ManagedCandidateWriteAuthority,
+	expectedCandidate?: ManagedCandidate,
+	expectedIdentity?: ResumeSessionIdentity,
 ): Promise<ManagedScopeResolution> {
+	if (expectedCandidate && expectedIdentity) revalidatePickerConsent(scope, expectedCandidate, expectedIdentity);
+	if (authority) bindManagedWriteAuthority(scope, authority);
 	const prepared = await ensureManagedScope(scope, policy);
 	if (prepared.kind === "error") return prepared;
 	try {
@@ -2182,28 +2262,44 @@ export async function prepareManagedSessionScopeForWrite(
 export async function openManagedCandidateForWrite(
 	scope: ManagedScope,
 	candidate: ManagedCandidate,
-	migrationPolicy: ManagedMigrationPolicy = "copy-retain",
+	expectedIdentityOrMigrationPolicy: ResumeSessionIdentity | ManagedMigrationPolicy = "copy-retain",
+	migrationPolicy: ManagedMigrationPolicy = typeof expectedIdentityOrMigrationPolicy === "string"
+		? expectedIdentityOrMigrationPolicy
+		: "copy-retain",
+	authority?: ManagedCandidateWriteAuthority,
 ): Promise<ManagedOpenCandidateResult> {
+	const expectedIdentity =
+		typeof expectedIdentityOrMigrationPolicy === "string" ? candidate.identity : expectedIdentityOrMigrationPolicy;
 	if (migrationPolicy === "disabled" && candidate.provenance === "legacy")
 		return {
 			kind: "error",
 			code: "legacy_migration_disabled",
 			message: "Legacy session migration is disabled for this workspace.",
 		};
-	const prepared = await prepareManagedSessionScopeForWrite(scope);
-	if (prepared.kind === "error")
+	let prepared: ManagedScopeResolution;
+	let current: ManagedCandidate;
+	try {
+		prepared = await prepareManagedSessionScopeForWrite(
+			scope,
+			scope.platform === "win32" ? "windows-existing-verify-first" : "default",
+			authority,
+			candidate,
+			expectedIdentity,
+		);
+		if (prepared.kind === "error")
+			return {
+				kind: "error",
+				code: prepared.code === "binding_conflict" ? "binding_conflict" : "binding_invalid",
+				message: prepared.message,
+			};
+		current = revalidatePickerConsent(scope, candidate, expectedIdentity);
+	} catch (error) {
 		return {
 			kind: "error",
-			code: prepared.code === "binding_conflict" ? "binding_conflict" : "binding_invalid",
-			message: prepared.message,
+			code: expectedFailure(error),
+			message: error instanceof Error ? error.message : "Managed migration failed.",
 		};
-	const current = validateCandidateForScope(scope, candidate);
-	if (!current)
-		return {
-			kind: "error",
-			code: "source_changed",
-			message: "The managed candidate changed before it could be opened.",
-		};
+	}
 	if (isRetired(scope, current))
 		return { kind: "error", code: "migration_retired", message: "The managed session has been retired." };
 	if (current.provenance === "v2") return { kind: "opened", path: current.path, candidate: current, migrated: false };
@@ -2213,10 +2309,10 @@ export async function openManagedCandidateForWrite(
 	let lock: ManagedStorageLock | undefined;
 	let detachedArtifacts: DetachedArtifactRoot | undefined;
 	try {
+		revalidatePickerConsent(scope, current, expectedIdentity);
 		lock = await acquireManagedLock(path.join(internal, MANAGED_LOCKS_DIRECTORY), operation, scopeRoot(scope));
-		const afterLock = validateCandidateForScope(scope, current);
-		if (!afterLock)
-			return { kind: "error", code: "source_changed", message: "The legacy candidate changed during migration." };
+		const heldLock = lock;
+		const afterLock = revalidatePickerConsent(scope, current, expectedIdentity);
 		const listing = listManagedCandidates(scope);
 		if (listing.kind === "error") return { kind: "error", code: "binding_invalid", message: listing.message };
 		const destination = path.join(scope.directoryPath, path.basename(afterLock.path));
@@ -2228,11 +2324,18 @@ export async function openManagedCandidateForWrite(
 				code: "destination_conflict",
 				message: "A distinct v2 transcript already owns this session id.",
 			};
+		scopeRoot(scope);
+		revalidatePickerConsent(scope, afterLock, expectedIdentity);
 		restorePreparedArtifactRoot(scope, afterLock);
+		scopeRoot(scope);
 		const sourceSnapshot = captureManagedFileNoFollow(afterLock.path);
 		let manifest: readonly ArtifactManifestEntry[] = [];
 		const artifactPlan = planArtifactRootForMigration(afterLock.path, operation);
 		const intendedDestination = { path: destination, sessionId: afterLock.sessionId, cwd: afterLock.cwd };
+		const assertPublicationConsent = (): void => {
+			heldLock.assertOwned();
+			revalidatePickerConsent(scope, afterLock, expectedIdentity);
+		};
 		if (existing && existing.identity.sha256 !== afterLock.identity.sha256) {
 			return {
 				kind: "error",
@@ -2249,6 +2352,7 @@ export async function openManagedCandidateForWrite(
 		}
 		const preparedReceipt = receiptPathFor(scope, afterLock, "prepared");
 		try {
+			revalidatePickerConsent(scope, afterLock, expectedIdentity);
 			lock.assertOwned();
 			await publishManagedFileNoReplace(
 				preparedReceipt,
@@ -2268,7 +2372,8 @@ export async function openManagedCandidateForWrite(
 							}
 						: undefined,
 				),
-				lock.assertOwned,
+				assertPublicationConsent,
+				scopeRoot(scope),
 			);
 		} catch (error) {
 			if ((error as Error).message !== "destination_conflict") throw error;
@@ -2277,11 +2382,23 @@ export async function openManagedCandidateForWrite(
 		if (!preparedReceiptMatches(preparedReceipt, scope, afterLock, intendedDestination, artifactPlan))
 			throw new Error("durability_failed");
 		if (artifactPlan && fs.existsSync(artifactPlan.detachedPath)) throw new Error("destination_conflict");
+		revalidatePickerConsent(scope, afterLock, expectedIdentity);
+		scopeRoot(scope);
 		detachedArtifacts = artifactPlan ? detachArtifactRootForMigration(artifactPlan) : undefined;
 		manifest = detachedArtifacts ? artifactManifestFromSnapshot(detachedArtifacts.tree) : [];
-		await copyArtifacts(scope, afterLock.path, destination, manifest, lock, detachedArtifacts?.detachedPath);
+		await copyArtifacts(
+			scope,
+			afterLock.path,
+			destination,
+			manifest,
+			lock,
+			afterLock,
+			expectedIdentity,
+			detachedArtifacts?.detachedPath,
+		);
 		if (!existing) {
 			try {
+				revalidatePickerConsent(scope, afterLock, expectedIdentity);
 				lock.assertOwned();
 				await copyManagedFileNoReplace(afterLock.path, destination, sourceSnapshot, scopeRoot(scope));
 			} catch (error) {
@@ -2289,6 +2406,7 @@ export async function openManagedCandidateForWrite(
 			}
 		}
 		// Artifact files, directories, and the transcript must be durable before a receipt can grant shadow authority.
+		scopeRoot(scope);
 		if (manifest.length > 0) fsyncManagedArtifactTree(destination.slice(0, -6));
 		lock.assertOwned();
 		const migrated = inspectCandidate(destination, "v2");
@@ -2301,6 +2419,8 @@ export async function openManagedCandidateForWrite(
 		)
 			throw new Error("durability_failed");
 		if (detachedArtifacts) {
+			revalidatePickerConsent(scope, afterLock, expectedIdentity);
+			scopeRoot(scope);
 			restoreDetachedArtifactRoot(detachedArtifacts);
 			detachedArtifacts = undefined;
 		}
@@ -2314,11 +2434,13 @@ export async function openManagedCandidateForWrite(
 		for (const state of ["published", "committed"] as const) {
 			const receipt = receiptPathFor(scope, afterLock, state);
 			try {
+				revalidatePickerConsent(scope, afterLock, expectedIdentity);
 				lock.assertOwned();
 				await publishManagedFileNoReplace(
 					receipt,
 					migrationReceipt(scope, lock, state, afterLock, migrated, manifest),
-					lock.assertOwned,
+					assertPublicationConsent,
+					scopeRoot(scope),
 				);
 			} catch (error) {
 				if ((error as Error).message !== "destination_conflict") throw error;
@@ -2332,6 +2454,8 @@ export async function openManagedCandidateForWrite(
 				code: "durability_failed",
 				message: "The migration receipt does not bind the copied v2 transcript and artifacts.",
 			};
+		revalidatePickerConsent(scope, afterLock, expectedIdentity);
+		scopeRoot(scope);
 		await removeStagedReceipts(scope, afterLock);
 		return {
 			kind: "opened",

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -18,7 +18,6 @@ import * as native from "@gajae-code/natives";
 import { getTerminalId } from "@gajae-code/tui";
 import {
 	getBlobsDir,
-	getAgentDir as getDefaultAgentDir,
 	getProjectDir,
 	getSessionsDir,
 	getTerminalSessionsDir,
@@ -58,6 +57,7 @@ import {
 	canonicalizeTrustedPath,
 	deleteManagedSessionCandidate,
 	listManagedCandidates,
+	type ManagedCandidateWriteAuthority,
 	type ManagedMigrationPolicy,
 	type ManagedScope,
 	managedDirectoryAuthorityForScope,
@@ -68,6 +68,7 @@ import {
 	resolveManagedScopeForWrite,
 } from "./internal/managed-session-scope";
 import {
+	assertManagedDirectoryRoot,
 	type ManagedDirectoryRoot,
 	type ManagedFileSnapshot,
 	ManagedSessionDescendantStore,
@@ -3891,9 +3892,11 @@ export async function resolveResumableSession(
 	cwd: string,
 	sessionDir?: string,
 	storage: SessionStorage = new FileSessionStorage(),
+	managedAgentDir?: string,
 ): Promise<ResolvedSessionMatch | undefined> {
-	const localSessionDir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
-	const localSessions = await SessionManager.list(cwd, localSessionDir, storage);
+	const localSessions = sessionDir
+		? await SessionManager.list(cwd, sessionDir, storage)
+		: await SessionManager.listManagedForResumePickerReadOnly(cwd, managedAgentDir, storage);
 	const localMatch = localSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
 	if (localMatch) {
 		return { session: localMatch, scope: "local" };
@@ -3903,7 +3906,7 @@ export async function resolveResumableSession(
 		return undefined;
 	}
 
-	const globalSessions = await SessionManager.listAll(storage);
+	const globalSessions = await SessionManager.listAll(storage, managedAgentDir);
 	const globalMatch = globalSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
 	if (!globalMatch) {
 		return undefined;
@@ -3935,6 +3938,7 @@ export class SessionManager {
 	#ensuredOnDisk: boolean = false;
 	#recoveryHydrationContext: RecoveryHydrationContext | undefined;
 	#fileEntries: FileEntry[] = [];
+	#pendingStrictAdoption: { canonicalPath: string; identity: ResumeSessionIdentity } | undefined;
 	#byId: Map<string, SessionEntry> = new Map();
 	#labelsById: Map<string, string> = new Map();
 	#leafId: string | null = null;
@@ -4208,12 +4212,25 @@ export class SessionManager {
 
 	/** Switch to a different session file (used for resume and branching) */
 	async setSessionFile(sessionFile: string): Promise<void> {
+		const resolvedSessionFile = this.storage instanceof FileSessionStorage ? path.resolve(sessionFile) : sessionFile;
+		const strictAdoption = this.#pendingStrictAdoption;
+		this.#pendingStrictAdoption = undefined;
+		if (strictAdoption && resolvedSessionFile === strictAdoption.canonicalPath) {
+			const inspected = inspectResumeSessionFile(resolvedSessionFile, this.storage);
+			if ("kind" in inspected || !sameResumeIdentity(strictAdoption.identity, inspected.identity))
+				throw new Error("Prepared managed session changed before strict adoption.");
+		}
 		await this.#closePersistWriter();
 		this.#persistError = undefined;
 		this.#persistErrorReported = false;
-		this.#sessionFile = this.storage instanceof FileSessionStorage ? path.resolve(sessionFile) : sessionFile;
+		this.#sessionFile = resolvedSessionFile;
 		writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
 		this.#fileEntries = await loadEntriesFromFile(this.#sessionFile, this.storage);
+		if (strictAdoption) {
+			const inspected = inspectResumeSessionFile(this.#sessionFile, this.storage);
+			if ("kind" in inspected || !sameResumeIdentity(strictAdoption.identity, inspected.identity))
+				throw new Error("Prepared managed session changed during strict adoption.");
+		}
 		if (this.#fileEntries.length > 0) {
 			const header = this.#fileEntries.find(e => e.type === "session") as SessionHeader | undefined;
 			this.#sessionId = header?.id ?? createSessionId();
@@ -4561,12 +4578,7 @@ export class SessionManager {
 			if (this.destination.kind === "managed") {
 				return managedDestination(resolvedCwd, this.storage, this.destination.securityContext.agentDir);
 			}
-			if (!(this.storage instanceof FileSessionStorage)) return this.destination;
-			const managedSessionsRoot = resolveManagedSessionRoot(this.sessionDir, this.cwd);
-			const directory = managedSessionsRoot
-				? computeDefaultSessionDir(resolvedCwd, this.storage, managedSessionsRoot)
-				: computeDefaultSessionDir(resolvedCwd, this.storage);
-			return explicitDestination(directory);
+			return this.destination;
 		})();
 		const newSessionDir = nextDestination.directory;
 		let hadSessionFile = false;
@@ -5545,6 +5557,17 @@ export class SessionManager {
 
 	getSessionDir(): string {
 		return this.sessionDir;
+	}
+
+	/** Lists picker candidates within this manager's captured destination authority. */
+	async listForResumePickerReadOnly(): Promise<SessionInfo[]> {
+		return this.destination.kind === "managed"
+			? await SessionManager.listManagedForResumePickerReadOnly(
+					this.cwd,
+					this.destination.securityContext.agentDir,
+					this.storage,
+				)
+			: await SessionManager.listForResumePickerReadOnly(this.cwd, this.destination.directory, this.storage);
 	}
 
 	getSessionId(): string {
@@ -7155,20 +7178,59 @@ export class SessionManager {
 		return manager;
 	}
 
+	/** Prepare a selected candidate using this manager's captured managed destination authority. */
+	async prepareManagedCandidateForWrite(
+		filePath: string,
+		migrationPolicy: SessionDirectoryMigrationPolicy,
+		expectedIdentity?: ResumeSessionIdentity,
+	): Promise<string> {
+		return SessionManager.prepareManagedCandidateForWrite(
+			filePath,
+			migrationPolicy,
+			this.destination,
+			expectedIdentity,
+		);
+	}
+
+	/** Prepare a managed candidate and retain its exact post-preparation identity for the next adoption. */
+	async prepareManagedCandidateForStrictAdoption(
+		filePath: string,
+		migrationPolicy: SessionDirectoryMigrationPolicy,
+		expectedIdentity: ResumeSessionIdentity,
+	): Promise<string> {
+		const preparedPath = await this.prepareManagedCandidateForWrite(filePath, migrationPolicy, expectedIdentity);
+		const inspected = inspectResumeSessionFile(preparedPath, this.storage);
+		if ("kind" in inspected) throw new Error(`Could not inspect prepared managed session: ${inspected.reason}`);
+		this.#pendingStrictAdoption = { canonicalPath: inspected.identity.canonicalPath, identity: inspected.identity };
+		return preparedPath;
+	}
+
 	/** Resolve a default-managed candidate through binding validation and copy-retain migration before mutation. */
 	static async prepareManagedCandidateForWrite(
 		filePath: string,
 		migrationPolicy: SessionDirectoryMigrationPolicy,
+		destination: SessionDestination,
+		expectedIdentity?: ResumeSessionIdentity,
 	): Promise<string> {
+		if (!trustedSessionDestinations.has(destination) || destination.kind !== "managed")
+			throw new Error("Managed candidate preparation requires a trusted managed destination authority");
 		const storage = new FileSessionStorage();
+		const managedDestinationStore = managedStoreFromContext(destination.securityContext, destination.directory);
+		const assertManagedDestinationBound = (): void => {
+			assertManagedDirectoryRoot(destination.securityContext.rootAuthority);
+			managedDestinationStore.assertBound();
+		};
+		assertManagedDestinationBound();
 		const inspected = inspectResumeSessionFile(filePath, storage);
 		if ("kind" in inspected) {
 			if (inspected.reason === "missing") return filePath;
 			throw new Error(`Could not inspect managed session: ${inspected.reason}`);
 		}
+		if (expectedIdentity && !sameResumeIdentity(expectedIdentity, inspected.identity))
+			throw new Error("Managed session changed before migration authority was adopted.");
 		const header = inspected.entries.find(entry => entry.type === "session") as SessionHeader | undefined;
 		if (!header?.cwd) return filePath;
-		const sessionsRoot = getSessionsDir();
+		const sessionsRoot = destination.securityContext.sessionsRoot;
 		const resolvedPath = path.resolve(filePath);
 		const relativeToManagedRoot = path.relative(sessionsRoot, resolvedPath);
 		const isManagedPath =
@@ -7176,14 +7238,17 @@ export class SessionManager {
 			(!relativeToManagedRoot.startsWith("..") && !path.isAbsolute(relativeToManagedRoot));
 
 		if (!isManagedPath) return filePath;
+		assertManagedDestinationBound();
 		const resolved = resolveManagedScope({
 			cwd: header.cwd,
-			agentDir: path.resolve(sessionsRoot, ".."),
+			agentDir: destination.securityContext.agentDir,
 			sessionsRoot,
 		});
 		if (resolved.kind === "error") throw new Error(`Could not resolve managed session scope: ${resolved.message}`);
 
+		assertManagedDestinationBound();
 		const listing = listManagedCandidates(resolved.scope);
+		assertManagedDestinationBound();
 		if (listing.kind !== "complete") throw new Error(`Managed session scan failed: ${listing.message}`);
 
 		const candidate = listing.owned.find(item => path.resolve(item.path) === resolvedPath);
@@ -7200,7 +7265,24 @@ export class SessionManager {
 			candidate.identity.sha256 !== inspected.identity.sha256
 		)
 			throw new Error("Managed session changed before migration authority was adopted.");
-		const opened = await openManagedCandidateForWrite(resolved.scope, candidate, migrationPolicy);
+		assertManagedDestinationBound();
+		const authority: ManagedCandidateWriteAuthority = {
+			rootAuthority: destination.securityContext.rootAuthority,
+			...(path.resolve(destination.directory) === path.resolve(resolved.scope.directoryPath)
+				? {
+						retainedAuthority: destination.securityContext.retainedAuthority,
+						retainedDirectory: destination.directory,
+					}
+				: {}),
+		};
+		const opened = await openManagedCandidateForWrite(
+			resolved.scope,
+			candidate,
+			expectedIdentity ?? inspected.identity,
+			migrationPolicy,
+			authority,
+		);
+		assertManagedDestinationBound();
 		if (opened.kind === "error") {
 			if (opened.code === "legacy_migration_disabled") throw new SessionMigrationPolicyError();
 			throw new Error(`Could not open managed session: ${opened.message}`);
@@ -7222,7 +7304,7 @@ export class SessionManager {
 		const destination = destinationFor(cwd, destinationInput, storage);
 		const managedSourcePath =
 			destination.kind === "managed" && storage instanceof FileSessionStorage
-				? await SessionManager.prepareManagedCandidateForWrite(sourcePath, migrationPolicy)
+				? await SessionManager.prepareManagedCandidateForWrite(sourcePath, migrationPolicy, destination)
 				: sourcePath;
 		const dir = destination.directory;
 		const manager = new SessionManager(cwd, dir, true, storage, destination);
@@ -7286,10 +7368,9 @@ export class SessionManager {
 			return manager;
 		}
 
-		const managedPath = await SessionManager.prepareManagedCandidateForWrite(filePath, migrationPolicy);
-		const inspected = inspectResumeSessionFile(managedPath, storage);
+		const inspected = inspectResumeSessionFile(filePath, storage);
 		if ("kind" in inspected) {
-			if (inspected.reason === "missing" && path.resolve(managedPath) === path.resolve(filePath)) {
+			if (inspected.reason === "missing") {
 				const manager = new SessionManager(getProjectDir(), destination.directory, true, storage, destination);
 				await manager.#initSessionFile(filePath);
 				return manager;
@@ -7357,46 +7438,47 @@ export class SessionManager {
 		return manager;
 	}
 	/**
-	 * List sessions for the resume picker without recovery or other maintenance writes.
+	 * List default-managed sessions for the resume picker without recovery or other
+	 * maintenance writes. This is the only picker inventory that includes legacy
+	 * sibling directories.
+	 */
+	static async listManagedForResumePickerReadOnly(
+		cwd: string,
+		managedAgentDir?: string,
+		storage: SessionStorage = new FileSessionStorage(),
+	): Promise<SessionInfo[]> {
+		if (!(storage instanceof FileSessionStorage)) return [];
+		const sessionsRoot = getSessionsDir(managedAgentDir);
+		const resolved = resolveManagedScope({
+			cwd,
+			agentDir: managedAgentDir ?? path.resolve(sessionsRoot, ".."),
+			sessionsRoot,
+		});
+		if (resolved.kind === "error") return [];
+		const listing = listManagedCandidates(resolved.scope);
+		if (listing.kind === "error") return [];
+		return await collectSessionsFromFiles(
+			listing.owned.map(candidate => candidate.path),
+			storage,
+		);
+	}
+
+	/**
+	 * List sessions from an explicitly supplied picker directory without recovery
+	 * or other maintenance writes. Unlike managed inventory, this never scans
+	 * legacy sibling directories.
 	 */
 	static async listForResumePickerReadOnly(
 		cwd: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
 	): Promise<SessionInfo[]> {
-		if (!sessionDir && !(storage instanceof FileSessionStorage)) return [];
-		if (sessionDir && !resolveManagedSessionRoot(sessionDir, cwd)) {
-			try {
-				return await collectSessionsFromFiles(storage.listFilesSync(sessionDir, "*.jsonl"), storage);
-			} catch {
-				return [];
-			}
-		}
-		const sessionsRoot = sessionDir
-			? (resolveManagedSessionRoot(sessionDir, cwd) ?? getSessionsDir())
-			: getSessionsDir();
-		const resolved = resolveManagedScope({ cwd, agentDir: path.resolve(sessionsRoot, ".."), sessionsRoot });
-		if (resolved.kind === "error") return [];
-		if (storage instanceof FileSessionStorage) {
-			const listing = listManagedCandidates(resolved.scope);
-			if (listing.kind === "error") return [];
-			return await collectSessionsFromFiles(
-				listing.owned.map(candidate => candidate.path),
-				storage,
-			);
-		}
-		const legacyDirectory = `--${resolved.scope.canonicalCwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
-		const files = new Set<string>();
+		if (!sessionDir) return await SessionManager.listManagedForResumePickerReadOnly(cwd, undefined, storage);
 		try {
-			for (const directory of [resolved.scope.directoryPath, path.join(sessionsRoot, legacyDirectory)]) {
-				for (const file of storage.listFilesSync(directory, "*.jsonl")) files.add(file);
-			}
+			return await collectSessionsFromFiles(storage.listFilesSync(sessionDir, "*.jsonl"), storage);
 		} catch {
 			return [];
 		}
-		return (await collectSessionsFromFiles([...files], storage)).filter(
-			session => resolveEquivalentPath(session.cwd) === resolved.scope.canonicalCwd,
-		);
 	}
 
 	/** Tombstone and exact-delete a default-managed candidate. */
@@ -7698,22 +7780,29 @@ export class SessionManager {
 		let sessionPath = identity.canonicalPath;
 		if (destination.kind === "managed" && storage instanceof FileSessionStorage) {
 			try {
-				sessionPath = await SessionManager.prepareManagedCandidateForWrite(sessionPath, migrationPolicy);
+				sessionPath = await SessionManager.prepareManagedCandidateForWrite(
+					sessionPath,
+					migrationPolicy,
+					destination,
+					identity,
+				);
 			} catch (error) {
 				if (error instanceof SessionMigrationPolicyError)
 					return { kind: "error", reason: "legacy_migration_disabled" };
+				if (
+					error instanceof Error &&
+					(error.message.includes("source_changed") || error.message.includes("changed before migration"))
+				)
+					return { kind: "error", reason: "identity-mismatch" };
 				throw error;
 			}
 		}
 		const inspected = inspectResumeSessionFile(sessionPath, storage);
 		if ("kind" in inspected) return inspected;
-		if (
-			(sessionPath === identity.canonicalPath && !sameResumeIdentity(identity, inspected.identity)) ||
-			(sessionPath !== identity.canonicalPath &&
-				(identity.sessionId !== inspected.identity.sessionId || identity.sha256 !== inspected.identity.sha256))
-		) {
+		if (sessionPath === identity.canonicalPath && !sameResumeIdentity(identity, inspected.identity)) {
 			return { kind: "error", reason: "identity-mismatch" };
 		}
+
 		const entries = inspected.entries;
 		const header = entries[0] as SessionHeader;
 		const dir = destination.directory;
@@ -7771,9 +7860,20 @@ export class SessionManager {
 		const managedCandidates =
 			destination.kind === "explicit"
 				? []
-				: await SessionManager.listForResumePickerReadOnly(cwd, destination.directory, storage);
+				: await SessionManager.listManagedForResumePickerReadOnly(
+						cwd,
+						destination.securityContext.agentDir,
+						storage,
+					);
+
 		const terminalSession = await readTerminalBreadcrumb(cwd);
-		if (terminalSession) {
+		const terminalSessionIsInExplicitRoot = (() => {
+			if (destination.kind === "managed" || !terminalSession) return destination.kind === "managed";
+			const canonicalRoot = canonicalizeTrustedPath(destination.directory);
+			const canonicalSessionPath = canonicalizeTrustedPath(terminalSession);
+			return pathIsWithin(canonicalRoot, canonicalSessionPath);
+		})();
+		if (terminalSession && terminalSessionIsInExplicitRoot) {
 			const opened = await openSelectedStrictly(terminalSession);
 			if (opened) return opened;
 		}
@@ -7811,7 +7911,7 @@ export class SessionManager {
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
 	): Promise<SessionInfo[]> {
-		if (!sessionDir) return await SessionManager.listForResumePickerReadOnly(cwd, undefined, storage);
+		if (!sessionDir) return await SessionManager.listManagedForResumePickerReadOnly(cwd, undefined, storage);
 		try {
 			await recoverOrphanedBackups(sessionDir, storage);
 			return await collectSessionsFromFiles(storage.listFilesSync(sessionDir, "*.jsonl"), storage);
@@ -7823,9 +7923,12 @@ export class SessionManager {
 	/**
 	 * List all sessions across all project directories.
 	 */
-	static async listAll(storage: SessionStorage = new FileSessionStorage()): Promise<SessionInfo[]> {
+	static async listAll(
+		storage: SessionStorage = new FileSessionStorage(),
+		managedAgentDir?: string,
+	): Promise<SessionInfo[]> {
 		if (!(storage instanceof FileSessionStorage)) return [];
-		const sessionsRoot = path.join(getDefaultAgentDir(), "sessions");
+		const sessionsRoot = getSessionsDir(managedAgentDir);
 		try {
 			const directories = await fs.promises.readdir(sessionsRoot, { withFileTypes: true });
 			const seedFiles = directories
@@ -7862,6 +7965,19 @@ export class SessionManager {
 		}
 	}
 	/**
+	 * Strict inventory bound to this manager's captured session authority. Managed
+	 * managers include authorized legacy and current candidates; explicit managers
+	 * authorize only their exact directory.
+	 */
+	inventorySessionsStrict(): StrictInventoryResult {
+		return SessionManager.inventorySessionsStrict(this.cwd, {
+			sessionDir: this.destination.kind === "explicit" ? this.destination.directory : undefined,
+			storage: this.storage,
+			destination: this.destination,
+		});
+	}
+
+	/**
 	 * Strict raw scoped inventory for ACP authorization. Enumerates the scoped
 	 * session directory without suppressing any root/scan/lstat/read/parse/stat/
 	 * header/cwd/containment/identity failure. A failure result carries every
@@ -7870,10 +7986,55 @@ export class SessionManager {
 	 */
 	static inventorySessionsStrict(
 		cwd: string,
-		options?: { sessionDir?: string; storage?: SessionStorage },
+		options?: { sessionDir?: string; storage?: SessionStorage; destination?: SessionDestination },
 	): StrictInventoryResult {
 		const storage = options?.storage ?? new FileSessionStorage();
-		const dir = options?.sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
+		const destination = options?.destination;
+		const dir =
+			options?.sessionDir ?? destination?.directory ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
+		if (destination?.kind === "managed") {
+			if (!trustedSessionDestinations.has(destination) || !(storage instanceof FileSessionStorage)) {
+				return {
+					kind: "failure",
+					failures: [{ kind: "scan", message: "Managed strict inventory authority is unavailable", path: dir }],
+				};
+			}
+			try {
+				const store = managedStoreFromContext(destination.securityContext, destination.directory);
+				assertManagedDirectoryRoot(destination.securityContext.rootAuthority);
+				store.assertBound();
+				const resolved = resolveManagedScope({
+					cwd,
+					agentDir: destination.securityContext.agentDir,
+					sessionsRoot: destination.securityContext.sessionsRoot,
+				});
+				if (resolved.kind === "error")
+					return { kind: "failure", failures: [{ kind: "root", message: resolved.message, path: dir }] };
+				const listing = listManagedCandidates(resolved.scope);
+				if (listing.kind === "error")
+					return { kind: "failure", failures: [{ kind: "scan", message: listing.message, path: dir }] };
+				const failures: StrictInventoryFailure[] = [];
+				const candidates: StrictInventoryCandidate[] = [];
+				for (const managedCandidate of listing.owned) {
+					const candidate = inventoryReadCandidate(
+						storage,
+						managedCandidate.path,
+						cwd,
+						path.dirname(managedCandidate.path),
+					);
+					if ("failures" in candidate) failures.push(...candidate.failures);
+					else candidates.push(candidate.candidate);
+				}
+				assertManagedDirectoryRoot(destination.securityContext.rootAuthority);
+				store.assertBound();
+				return failures.length > 0 ? { kind: "failure", failures } : { kind: "complete", candidates };
+			} catch {
+				return {
+					kind: "failure",
+					failures: [{ kind: "root", message: "Managed strict inventory authority changed", path: dir }],
+				};
+			}
+		}
 		if (!storage.listFilesStrictSync) {
 			return {
 				kind: "failure",

--- a/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, type Mock, vi } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it, type Mock, vi } from "bun:test";
 import { SessionSelectorComponent } from "@gajae-code/coding-agent/modes/components/session-selector";
 import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -35,11 +35,15 @@ function createContext(currentSessionFile: string): {
 	calls: string[];
 	setCurrentSessionFile: (path: string) => void;
 	setCurrentSessionId: (id: string) => void;
+	setManagedDestination: (managed: boolean) => void;
 	showHookConfirm: (title: string, message: string) => Promise<boolean>;
 	newSession: () => Promise<boolean>;
+	prepareManagedCandidateForStrictAdoption: Mock<(targetPath: string) => Promise<string>>;
+	listForResumePickerReadOnly: Mock<() => Promise<SessionInfo[]>>;
 	switchSession: Mock<(targetPath: string) => Promise<boolean>>;
 } {
 	const calls: string[] = [];
+	let managedDestination = false;
 	let sessionFile = currentSessionFile;
 	let sessionId = currentSessionFile;
 	const editorContainer = {
@@ -65,6 +69,8 @@ function createContext(currentSessionFile: string): {
 		sessionId = targetPath;
 		return true;
 	});
+	const prepareManagedCandidateForStrictAdoption = vi.fn(async (targetPath: string) => targetPath);
+	const listForResumePickerReadOnly = vi.fn(async () => [] as SessionInfo[]);
 	const ctx = {
 		editorContainer,
 		editor: {},
@@ -90,6 +96,9 @@ function createContext(currentSessionFile: string): {
 			getSessionDir: () => "/tmp/project/sessions",
 			getSessionFile: () => sessionFile,
 			getSessionId: () => sessionId,
+			isManagedDestination: () => managedDestination,
+			prepareManagedCandidateForStrictAdoption,
+			listForResumePickerReadOnly,
 		},
 		chatContainer: {
 			clear: vi.fn(() => {
@@ -160,8 +169,13 @@ function createContext(currentSessionFile: string): {
 		setCurrentSessionId(id: string) {
 			sessionId = id;
 		},
+		setManagedDestination(managed: boolean) {
+			managedDestination = managed;
+		},
 		showHookConfirm,
 		newSession,
+		prepareManagedCandidateForStrictAdoption,
+		listForResumePickerReadOnly,
 		switchSession,
 	};
 }
@@ -175,10 +189,6 @@ beforeAll(() => {
 });
 
 describe("SelectorController session deletion", () => {
-	beforeEach(() => {
-		vi.spyOn(SessionManager, "listForResumePickerReadOnly").mockResolvedValue([]);
-	});
-
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
@@ -222,32 +232,89 @@ describe("SelectorController session deletion", () => {
 		expect(calls).not.toContain("rebuildInitialMessages:reconcile-same-transcript");
 	});
 
-	it("prepares a legacy managed candidate before switching", async () => {
+	it("prepares a legacy managed candidate against its inspected identity before switching", async () => {
 		const legacyPath = "/tmp/project/legacy/session.jsonl";
 		const migratedPath = "/tmp/project/v2/session.jsonl";
-		const { ctx, switchSession } = createContext("/tmp/project/sessions/a.jsonl");
-		vi.spyOn(SessionManager, "prepareManagedCandidateForWrite").mockResolvedValue(migratedPath);
+		const identity = {
+			canonicalPath: legacyPath,
+			sessionId: "legacy",
+			dev: 1n,
+			ino: 1n,
+			size: 1,
+			mtimeMs: 1,
+			mtimeNs: 1n,
+			sha256: "legacy",
+		};
+		const { ctx, switchSession, prepareManagedCandidateForStrictAdoption, setManagedDestination } = createContext(
+			"/tmp/project/sessions/a.jsonl",
+		);
+		setManagedDestination(true);
+		vi.spyOn(SessionManager, "inspectSessionTailReadOnly").mockResolvedValue({ kind: "resumable", identity });
+		prepareManagedCandidateForStrictAdoption.mockResolvedValue(migratedPath);
 		const controller = new SelectorController(ctx);
 
 		await controller.handleResumeSession(legacyPath);
 
-		expect(SessionManager.prepareManagedCandidateForWrite).toHaveBeenCalledWith(legacyPath, "copy-retain");
+		expect(prepareManagedCandidateForStrictAdoption).toHaveBeenCalledWith(legacyPath, "copy-retain", identity);
 		expect(switchSession).toHaveBeenCalledWith(migratedPath);
 	});
 
-	it("lists sessions from the active explicit session directory", async () => {
-		const { ctx } = createContext("/tmp/project/sessions/a.jsonl");
+	it("keeps explicit selections out of the managed migration fence", async () => {
+		const explicitPath = "/tmp/project/explicit/session.jsonl";
+		const { ctx, switchSession, prepareManagedCandidateForStrictAdoption } = createContext(
+			"/tmp/project/sessions/a.jsonl",
+		);
+		const inspection = vi.spyOn(SessionManager, "inspectSessionTailReadOnly");
+		const controller = new SelectorController(ctx);
+
+		await controller.handleResumeSession(explicitPath);
+
+		expect(inspection).not.toHaveBeenCalled();
+		expect(prepareManagedCandidateForStrictAdoption).not.toHaveBeenCalled();
+		expect(switchSession).toHaveBeenCalledWith(explicitPath);
+	});
+
+	it("does not switch after a managed replacement race rejects the inspected identity", async () => {
+		const selectedPath = "/tmp/project/legacy/session.jsonl";
+		const identity = {
+			canonicalPath: selectedPath,
+			sessionId: "selected",
+			dev: 1n,
+			ino: 1n,
+			size: 1,
+			mtimeMs: 1,
+			mtimeNs: 1n,
+			sha256: "before-replacement",
+		};
+		const { ctx, switchSession, prepareManagedCandidateForStrictAdoption, setManagedDestination } = createContext(
+			"/tmp/project/sessions/a.jsonl",
+		);
+		setManagedDestination(true);
+		vi.spyOn(SessionManager, "inspectSessionTailReadOnly").mockResolvedValue({ kind: "resumable", identity });
+		prepareManagedCandidateForStrictAdoption.mockRejectedValue(
+			new Error("Managed session changed before migration authority was adopted."),
+		);
+		const controller = new SelectorController(ctx);
+
+		await expect(controller.handleResumeSession(selectedPath)).rejects.toThrow("changed before migration");
+
+		expect(prepareManagedCandidateForStrictAdoption).toHaveBeenCalledWith(selectedPath, "copy-retain", identity);
+		expect(switchSession).not.toHaveBeenCalled();
+	});
+
+	it("lists sessions through the active manager's captured destination authority", async () => {
+		const { ctx, listForResumePickerReadOnly } = createContext("/tmp/project/sessions/a.jsonl");
 		const controller = new SelectorController(ctx);
 
 		await controller.showSessionSelector();
 
-		expect(SessionManager.listForResumePickerReadOnly).toHaveBeenCalledWith("/tmp/project", "/tmp/project/sessions");
+		expect(listForResumePickerReadOnly).toHaveBeenCalledWith();
 	});
 
 	it("detaches the active session before selector deletion removes it", async () => {
 		const activeSession = makeSessionInfo("/tmp/project/sessions/active.jsonl");
-		const { ctx, calls } = createContext(activeSession.path);
-		vi.spyOn(SessionManager, "listForResumePickerReadOnly").mockResolvedValue([activeSession]);
+		const { ctx, calls, listForResumePickerReadOnly } = createContext(activeSession.path);
+		listForResumePickerReadOnly.mockResolvedValue([activeSession]);
 		const dropSession = vi.fn(async (sessionPath: string) => {
 			calls.push(`deleteManaged:${sessionPath}`);
 		});
@@ -295,8 +362,8 @@ describe("SelectorController session deletion", () => {
 
 	it("shows inline selector errors when session deletion fails after detach", async () => {
 		const activeSession = makeSessionInfo("/tmp/project/sessions/active.jsonl");
-		const { ctx, newSession } = createContext(activeSession.path);
-		vi.spyOn(SessionManager, "listForResumePickerReadOnly").mockResolvedValue([activeSession]);
+		const { ctx, newSession, listForResumePickerReadOnly } = createContext(activeSession.path);
+		listForResumePickerReadOnly.mockResolvedValue([activeSession]);
 		const deleteSessionWithArtifacts = vi
 			.spyOn(FileSessionStorage.prototype, "deleteSessionWithArtifacts")
 			.mockRejectedValue(new Error("disk failed"));

--- a/packages/coding-agent/test/resume-confirm-continue.test.ts
+++ b/packages/coding-agent/test/resume-confirm-continue.test.ts
@@ -1,18 +1,27 @@
-import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { Args } from "../src/cli/args";
 import { parseArgs } from "../src/cli/args";
+import type { Settings } from "../src/config/settings";
 import {
 	BARE_RESUME_CONFLICT_ERROR,
 	BARE_RESUME_INTERACTIVE_ERROR,
 	BARE_RESUME_OPEN_ERROR,
+	createSessionManager,
 	runInteractiveMode,
 	runRootCommand,
 	StartupUpdateOrchestrator,
 } from "../src/main";
 import type { InteractiveMode } from "../src/modes/interactive-mode";
 import type { AgentSession } from "../src/session/agent-session";
-import type { ResumeSessionIdentity, SessionInfo } from "../src/session/session-manager";
+import {
+	type ResumeSessionIdentity,
+	type SessionDestination,
+	type SessionInfo,
+	SessionManager,
+} from "../src/session/session-manager";
 
 const identity: ResumeSessionIdentity = {
 	canonicalPath: "/sessions/selected.jsonl",
@@ -39,6 +48,7 @@ const sessionInfo: SessionInfo = {
 
 afterEach(() => {
 	process.exitCode = undefined;
+	vi.restoreAllMocks();
 });
 
 function bareArgs(overrides: Partial<Args> = {}): Args {
@@ -149,7 +159,7 @@ describe("bare resume startup gating", () => {
 		}
 	});
 
-	it("handles empty inventory, cancellation, and strict-open failure without fallback", async () => {
+	it("keeps cancellation from loading settings or touching managed settings/config/agent storage", async () => {
 		let pickerCalls = 0;
 		let opens = 0;
 		let listedCwd: string | undefined;
@@ -189,11 +199,11 @@ describe("bare resume startup gating", () => {
 			await runRootCommand(bareArgs(), [], {
 				suppressProcessExit: true,
 				isResumePickerTerminal: () => true,
-				listForResumePickerReadOnly: async () => [sessionInfo],
+				listManagedForResumePickerReadOnly: async () => [sessionInfo],
 				selectResumeSession: async () => ({ kind: "cancelled" }),
 				loadSettingsForScope: async () => {
 					settingsLoads++;
-					throw new Error("settings must not load after picker cancellation");
+					throw new Error("settings must not load before picker consent");
 				},
 				openExistingSessionStrict: async () => {
 					opens++;
@@ -212,7 +222,7 @@ describe("bare resume startup gating", () => {
 		await runRootCommand(bareArgs(), [], {
 			suppressProcessExit: true,
 			isResumePickerTerminal: () => true,
-			listForResumePickerReadOnly: async () => [sessionInfo],
+			listManagedForResumePickerReadOnly: async () => [sessionInfo],
 			selectResumeSession: async () => ({ kind: "selected", path: sessionInfo.path, identity, action: "open-idle" }),
 			openExistingSessionStrict: async selected => {
 				opens++;
@@ -223,6 +233,161 @@ describe("bare resume startup gating", () => {
 		expect(opens).toBe(1);
 		expect(BARE_RESUME_OPEN_ERROR).toBe("Could not open the selected session. Use --resume <id>.");
 	});
+
+	it("uses the scoped managed root for default inventory and strict-open authority", async () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-resume-managed-root-"));
+		let listedAgentDir: string | undefined;
+		let openedIdentity: ResumeSessionIdentity | undefined;
+		let openedDestination: SessionDestination | undefined;
+		await runRootCommand(bareArgs(), [], {
+			suppressProcessExit: true,
+			isResumePickerTerminal: () => true,
+			resolveManagedAgentDirForScope: () => agentDir,
+			loadSettingsForScope: async () =>
+				({
+					getAgentDir: () => agentDir,
+					get: () => "copy-retain",
+				}) as unknown as Settings,
+			listManagedForResumePickerReadOnly: async (_cwd, managedAgentDir) => {
+				listedAgentDir = managedAgentDir;
+				return [sessionInfo];
+			},
+			selectResumeSession: async () => ({ kind: "selected", path: sessionInfo.path, identity, action: "open-idle" }),
+			openExistingSessionStrict: async (selected, destination) => {
+				openedIdentity = selected;
+				openedDestination = destination;
+				return { kind: "error", reason: "identity-mismatch" };
+			},
+		});
+		expect(listedAgentDir).toBe(agentDir);
+		expect(openedIdentity).toBe(identity);
+		expect(openedDestination).toMatchObject({ kind: "managed" });
+		if (openedDestination?.kind !== "managed") throw new Error("Expected managed destination");
+		expect(openedDestination.securityContext.agentDir).toBe(agentDir);
+	});
+
+	it("keeps explicit picker directories out of managed destination handling", async () => {
+		let listedAgentDir: string | undefined;
+		let openedDestination: SessionDestination | undefined;
+		await runRootCommand(bareArgs({ sessionDir: "/explicit" }), [], {
+			suppressProcessExit: true,
+			isResumePickerTerminal: () => true,
+			resolveManagedAgentDirForScope: () => {
+				throw new Error("explicit picker inventory must not resolve a managed root");
+			},
+			loadSettingsForScope: async () =>
+				({ getAgentDir: () => "/custom-agent", get: () => "copy-retain" }) as unknown as Settings,
+			listForResumePickerReadOnly: async () => {
+				return [sessionInfo];
+			},
+			selectResumeSession: async () => ({ kind: "selected", path: sessionInfo.path, identity, action: "open-idle" }),
+			openExistingSessionStrict: async (_selected, destination) => {
+				openedDestination = destination;
+				return { kind: "error", reason: "identity-mismatch" };
+			},
+		});
+		expect(listedAgentDir).toBeUndefined();
+		expect(openedDestination).toEqual({ kind: "explicit", directory: "/explicit" });
+	});
+});
+
+describe("explicit resume destination authority", () => {
+	it("binds both direct resume path forms to the supplied explicit session directory", async () => {
+		const open = vi.spyOn(SessionManager, "open").mockResolvedValue({} as SessionManager);
+		const activeSettings = {
+			get: () => "copy-retain",
+			getAgentDir: () => "/managed-agent",
+		} as unknown as Settings;
+		for (const resume of ["/source/session.jsonl", "session.jsonl"]) {
+			await createSessionManager(
+				parseArgs(["--resume", resume, "--session-dir", "/explicit-destination"]),
+				"/workspace",
+				activeSettings,
+			);
+		}
+		expect(open).toHaveBeenNthCalledWith(
+			1,
+			"/source/session.jsonl",
+			expect.objectContaining({ kind: "explicit", directory: "/explicit-destination" }),
+			undefined,
+			"copy-retain",
+		);
+		expect(open).toHaveBeenNthCalledWith(
+			2,
+			"session.jsonl",
+			expect.objectContaining({ kind: "explicit", directory: "/explicit-destination" }),
+			undefined,
+			"copy-retain",
+		);
+	});
+
+	it("binds a direct resume path without --session-dir to its parent directory", async () => {
+		const open = vi.spyOn(SessionManager, "open").mockResolvedValue({} as SessionManager);
+		const activeSettings = {
+			get: () => "copy-retain",
+			getAgentDir: () => "/managed-agent",
+		} as unknown as Settings;
+
+		await createSessionManager(parseArgs(["--resume", "/source/session.jsonl"]), "/workspace", activeSettings);
+
+		expect(open).toHaveBeenCalledWith(
+			"/source/session.jsonl",
+			expect.objectContaining({ kind: "explicit", directory: "/source" }),
+			undefined,
+			"copy-retain",
+		);
+	});
+
+	it("resolves direct resume ids through the active managed root", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-resume-managed-root-"));
+		const cwd = path.join(root, "workspace");
+		const agentDir = path.join(root, "custom-agent");
+		fs.mkdirSync(cwd, { recursive: true });
+		const destination = SessionManager.managedDestination(cwd, agentDir);
+		const original = SessionManager.create(cwd, destination);
+		original.appendMessage({ role: "user", content: "custom root", timestamp: 1 });
+		await original.ensureOnDisk();
+		await original.flush();
+		const id = original.getSessionId();
+		await original.close();
+		try {
+			const resumed = await createSessionManager(parseArgs(["--resume", id]), cwd, {
+				get: () => "copy-retain",
+				getAgentDir: () => agentDir,
+			} as unknown as Settings);
+			expect(resumed?.getSessionId()).toBe(id);
+			await resumed?.close();
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("direct fork destination authority", () => {
+	it("resolves direct fork ids through the active managed root", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-fork-managed-root-"));
+		const cwd = path.join(root, "workspace");
+		const agentDir = path.join(root, "custom-agent");
+		fs.mkdirSync(cwd, { recursive: true });
+		const destination = SessionManager.managedDestination(cwd, agentDir);
+		const original = SessionManager.create(cwd, destination);
+		original.appendMessage({ role: "user", content: "custom root", timestamp: 1 });
+		await original.ensureOnDisk();
+		await original.flush();
+		const id = original.getSessionId();
+		await original.close();
+		try {
+			const fork = await createSessionManager(parseArgs(["--fork", id]), cwd, {
+				get: () => "copy-retain",
+				getAgentDir: () => agentDir,
+			} as unknown as Settings);
+			expect(fork?.getSessionId()).not.toBe(id);
+			expect(fork?.getSessionDir()).toBe(destination.directory);
+			await fork?.close();
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
 });
 
 it("bounds a rejected strict-open promise to one error before session startup or fallback", async () => {
@@ -232,7 +397,7 @@ it("bounds a rejected strict-open promise to one error before session startup or
 		await runRootCommand(bareArgs(), [], {
 			suppressProcessExit: true,
 			isResumePickerTerminal: () => true,
-			listForResumePickerReadOnly: async () => [sessionInfo],
+			listManagedForResumePickerReadOnly: async () => [sessionInfo],
 			selectResumeSession: async () => ({
 				kind: "selected",
 				path: sessionInfo.path,

--- a/packages/coding-agent/test/session-manager-resume-readonly.test.ts
+++ b/packages/coding-agent/test/session-manager-resume-readonly.test.ts
@@ -7,6 +7,7 @@ import {
 	createReadonlySessionManager,
 	parseSessionEntries,
 	type ResumeSessionIdentity,
+	resolveResumableSession,
 	SessionManager,
 	type StrictSessionOpenResult,
 	sessionArtifactCapability,
@@ -19,14 +20,16 @@ import {
 	type SessionStorageWriter,
 } from "@gajae-code/coding-agent/session/session-storage";
 import * as native from "@gajae-code/natives";
-import { getSessionsDir } from "@gajae-code/utils";
+import { getSessionsDir, getTerminalSessionsDir } from "@gajae-code/utils";
 import { resolveManagedScope } from "../src/session/internal/managed-session-scope";
+import { ManagedSessionDescendantStore } from "../src/session/internal/managed-session-storage";
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
 	vi.restoreAllMocks();
 	for (const dir of tempDirs.splice(0)) await fs.promises.rm(dir, { recursive: true, force: true });
+	vi.restoreAllMocks();
 });
 
 function makeTempDir(): string {
@@ -753,19 +756,258 @@ describe("CLI session picker deletion scope", () => {
 });
 
 describe("active managed picker root", () => {
-	it("lists from a custom agent root instead of the process-global root", async () => {
+	it("shares a custom managed root between default picker inventory and strict-open preparation", async () => {
 		const root = makeTempDir();
 		const agentDir = path.join(root, "custom-agent");
 		const cwd = path.join(root, "workspace");
 		fs.mkdirSync(cwd, { recursive: true });
-		const sessionDir = SessionManager.getDefaultSessionDir(cwd, agentDir);
-		const manager = SessionManager.create(cwd, sessionDir);
+		const destination = SessionManager.managedDestination(cwd, agentDir);
+		const manager = SessionManager.create(cwd, destination);
 		manager.appendMessage({ role: "user", content: "custom root", timestamp: 1 });
 		await manager.ensureOnDisk();
 		await manager.flush();
+		const sessionFile = manager.getSessionFile();
+		if (!sessionFile) throw new Error("Expected managed session file");
 
-		const listed = await SessionManager.listForResumePickerReadOnly(cwd, sessionDir);
-
+		const listed = await SessionManager.listManagedForResumePickerReadOnly(cwd, agentDir);
 		expect(listed.map(session => session.id)).toContain(manager.getSessionId());
+		const resolvedById = await resolveResumableSession(manager.getSessionId(), cwd, undefined, undefined, agentDir);
+		expect(resolvedById).toMatchObject({ scope: "local", session: { path: sessionFile } });
+		const inspection = await SessionManager.inspectSessionTailReadOnly(sessionFile);
+		if (inspection.kind === "error") throw new Error("Expected resumable inspection");
+		const opened = await SessionManager.openExistingStrict(inspection.identity, destination);
+		expect(opened.kind).toBe("opened");
+		if (opened.kind === "error") throw new Error("Expected strict open");
+		await opened.manager.close();
+	});
+	it("does not let an outside terminal breadcrumb override an explicit resume directory", async () => {
+		const root = makeTempDir();
+		const cwd = path.join(root, "workspace");
+		const explicitDirectory = path.join(root, "explicit");
+		const outsideDirectory = path.join(root, "outside");
+		fs.mkdirSync(cwd, { recursive: true });
+		fs.mkdirSync(explicitDirectory);
+		const outside = SessionManager.create(cwd, SessionManager.explicitDestination(outsideDirectory));
+		outside.appendMessage({ role: "user", content: "outside", timestamp: 1 });
+		await outside.ensureOnDisk();
+		await outside.flush();
+		const outsideFile = outside.getSessionFile();
+		if (!outsideFile) throw new Error("Expected outside session file");
+		await outside.close();
+		const originalTmux = process.env.TMUX;
+		const originalPane = process.env.TMUX_PANE;
+		const pane = `%explicit-resume-${Date.now()}-${Math.random()}`;
+		const breadcrumbFile = path.join(getTerminalSessionsDir(), `tmux-${pane}`);
+		process.env.TMUX = "/tmp/test-tmux,1,0";
+		process.env.TMUX_PANE = pane;
+		try {
+			fs.mkdirSync(getTerminalSessionsDir(), { recursive: true });
+			fs.symlinkSync(
+				outsideDirectory,
+				path.join(explicitDirectory, "escape"),
+				process.platform === "win32" ? "junction" : "dir",
+			);
+			fs.writeFileSync(
+				breadcrumbFile,
+				`${cwd}\n${path.join(explicitDirectory, "escape", path.basename(outsideFile))}\n`,
+			);
+			const resumed = await SessionManager.continueRecent(
+				cwd,
+				SessionManager.explicitDestination(explicitDirectory),
+			);
+			try {
+				expect(resumed.getSessionFile()).not.toBe(outsideFile);
+				expect(resumed.getSessionDir()).toBe(explicitDirectory);
+			} finally {
+				await resumed.close();
+			}
+		} finally {
+			fs.rmSync(breadcrumbFile, { force: true });
+			if (originalTmux === undefined) delete process.env.TMUX;
+			else process.env.TMUX = originalTmux;
+			if (originalPane === undefined) delete process.env.TMUX_PANE;
+			else process.env.TMUX_PANE = originalPane;
+		}
+	});
+	it("uses manager-bound picker inventory for explicit-only and managed legacy candidates", async () => {
+		const root = makeTempDir();
+		const agentDir = path.join(root, "custom-agent");
+		const cwd = path.join(root, "workspace");
+		const sessionsRoot = path.join(agentDir, "sessions");
+		fs.mkdirSync(cwd, { recursive: true });
+		const destination = SessionManager.managedDestination(cwd, agentDir);
+		const manager = SessionManager.create(cwd, destination);
+		manager.appendMessage({ role: "user", content: "current", timestamp: 1 });
+		await manager.ensureOnDisk();
+		await manager.flush();
+		const currentPath = manager.getSessionFile();
+		if (!currentPath) throw new Error("Expected managed current transcript");
+		await manager.close();
+
+		const legacyDirectory = path.join(
+			sessionsRoot,
+			`--${path
+				.resolve(cwd)
+				.replace(/^[/\\]/, "")
+				.replace(/[/\\:]/g, "-")}--`,
+		);
+		const legacyPath = path.join(legacyDirectory, "legacy.jsonl");
+		fs.mkdirSync(legacyDirectory, { recursive: true });
+		fs.writeFileSync(legacyPath, sessionText("legacy").replace('"cwd":"/cwd"', `"cwd":${JSON.stringify(cwd)}`));
+
+		const explicitManager = SessionManager.create(cwd, SessionManager.explicitDestination(destination.directory));
+		const explicit = await explicitManager.listForResumePickerReadOnly();
+		expect(explicit.map(session => session.path)).toEqual([currentPath]);
+
+		const managed = await manager.listForResumePickerReadOnly();
+		expect(managed.map(session => session.path)).toEqual(expect.arrayContaining([currentPath, legacyPath]));
+	});
+	it("rejects a replacement after managed preparation before strict adoption", async () => {
+		const root = makeTempDir();
+		const cwd = path.join(root, "workspace");
+		const agentDir = path.join(root, "agent");
+		fs.mkdirSync(cwd, { recursive: true });
+		const manager = SessionManager.create(cwd, SessionManager.managedDestination(cwd, agentDir));
+		manager.appendMessage({ role: "user", content: "original", timestamp: 1 });
+		await manager.ensureOnDisk();
+		await manager.flush();
+		const sessionFile = manager.getSessionFile();
+		if (!sessionFile) throw new Error("Expected session file");
+		const inspection = await SessionManager.inspectSessionTailReadOnly(sessionFile);
+		if (inspection.kind === "error") throw new Error("Expected session inspection");
+		const preparedPath = await manager.prepareManagedCandidateForStrictAdoption(
+			sessionFile,
+			"copy-retain",
+			inspection.identity,
+		);
+		const replacement = path.join(root, "replacement.jsonl");
+		fs.writeFileSync(replacement, fs.readFileSync(preparedPath));
+		fs.renameSync(replacement, preparedPath);
+		await expect(manager.setSessionFile(preparedPath)).rejects.toThrow("changed before strict adoption");
+		await manager.close();
+	});
+	it("rejects source identity drift at the final prepared migration receipt publication guard", async () => {
+		const root = makeTempDir();
+		const agentDir = path.join(root, "agent");
+		const cwd = path.join(root, "workspace");
+		const sessionsRoot = path.join(agentDir, "sessions");
+		const legacyDirectory = path.join(
+			sessionsRoot,
+			`--${path
+				.resolve(cwd)
+				.replace(/^[/\\]/, "")
+				.replace(/[/\\:]/g, "-")}--`,
+		);
+		const legacyPath = path.join(legacyDirectory, "legacy.jsonl");
+		const replacementPath = path.join(root, "same-bytes-replacement.jsonl");
+		fs.mkdirSync(cwd, { recursive: true });
+		const destination = SessionManager.managedDestination(cwd, agentDir);
+		fs.mkdirSync(legacyDirectory, { recursive: true });
+		fs.writeFileSync(legacyPath, sessionText("legacy").replace('"cwd":"/cwd"', `"cwd":${JSON.stringify(cwd)}`));
+		const inspection = await SessionManager.inspectSessionTailReadOnly(legacyPath);
+		if (inspection.kind === "error") throw new Error("Expected legacy inspection");
+		fs.writeFileSync(replacementPath, fs.readFileSync(legacyPath));
+		const protocolRoot = path.join(destination.directory, ".gjc-managed-session-internal");
+		const before = {
+			receipts: fs.readdirSync(path.join(protocolRoot, "receipts")),
+			tombstones: fs.readdirSync(path.join(protocolRoot, "tombstones")),
+		};
+		const assertBound = ManagedSessionDescendantStore.prototype.assertBound;
+		let publicationGuards = 0;
+		vi.spyOn(ManagedSessionDescendantStore.prototype, "assertBound").mockImplementation(function (
+			this: ManagedSessionDescendantStore,
+		) {
+			assertBound.call(this);
+			const stack = new Error().stack ?? "";
+			if (
+				stack.includes("publishManagedFileNoReplace") &&
+				stack.includes("assertPublicationConsent") &&
+				++publicationGuards === 2
+			)
+				fs.renameSync(replacementPath, legacyPath);
+		});
+
+		expectStrictFailure(
+			await SessionManager.openExistingStrict(inspection.identity, destination),
+			"identity-mismatch",
+		);
+		expect(publicationGuards).toBe(2);
+		expect(fs.readdirSync(path.join(protocolRoot, "receipts"))).toEqual(before.receipts);
+		expect(fs.readdirSync(path.join(protocolRoot, "tombstones"))).toEqual(before.tombstones);
+		expect(fs.existsSync(path.join(destination.directory, path.basename(legacyPath)))).toBe(false);
+		expect(fs.existsSync(path.join(destination.directory, path.basename(legacyPath).slice(0, -6)))).toBe(false);
+	});
+
+	it("keeps an explicit resume destination explicit without managed preparation or migration", async () => {
+		const root = makeTempDir();
+		const explicitDirectory = path.join(root, "explicit");
+		const selectedPath = path.join(explicitDirectory, "selected.jsonl");
+		fs.mkdirSync(explicitDirectory);
+		fs.writeFileSync(selectedPath, sessionText("explicit"));
+		const inspection = await SessionManager.inspectSessionTailReadOnly(selectedPath);
+		if (inspection.kind === "error") throw new Error("Expected explicit inspection");
+		const prepare = vi.spyOn(SessionManager, "prepareManagedCandidateForWrite");
+
+		const opened = await SessionManager.openExistingStrict(
+			inspection.identity,
+			SessionManager.explicitDestination(explicitDirectory),
+		);
+
+		expect(opened.kind).toBe("opened");
+		if (opened.kind === "opened") await opened.manager.close();
+		expect(prepare).not.toHaveBeenCalled();
+		expect(fs.existsSync(path.join(explicitDirectory, ".gjc-managed-session-scope.v2.json"))).toBe(false);
+		expect(fs.existsSync(path.join(explicitDirectory, ".gjc-managed-session-internal"))).toBe(false);
+	});
+
+	it("fails closed at the final migration seam when captured managed authority is replaced", async () => {
+		const root = makeTempDir();
+		const agentDir = path.join(root, "custom-agent");
+		const cwd = path.join(root, "workspace");
+		const sessionsRoot = path.join(agentDir, "sessions");
+		const legacyDirectory = path.join(
+			sessionsRoot,
+			`--${path
+				.resolve(cwd)
+				.replace(/^[/\\]/, "")
+				.replace(/[/\\:]/g, "-")}--`,
+		);
+		const legacyPath = path.join(legacyDirectory, "legacy.jsonl");
+		fs.mkdirSync(cwd, { recursive: true });
+		const destination = SessionManager.managedDestination(cwd, agentDir);
+		fs.mkdirSync(legacyDirectory, { recursive: true });
+		fs.writeFileSync(legacyPath, sessionText("legacy").replace('"cwd":"/cwd"', `"cwd":${JSON.stringify(cwd)}`));
+		const candidateBefore = fs.readFileSync(legacyPath);
+		const protocolRoot = path.join(destination.directory, ".gjc-managed-session-internal");
+		const bindingPath = path.join(destination.directory, ".gjc-managed-session-scope.v2.json");
+		const bindingBefore = fs.readFileSync(bindingPath);
+		const receiptsBefore = fs.readdirSync(path.join(protocolRoot, "receipts"));
+		const tombstonesBefore = fs.readdirSync(path.join(protocolRoot, "tombstones"));
+		const displacedAgentDir = path.join(root, "displaced-agent");
+		const assertBound = ManagedSessionDescendantStore.prototype.assertBound;
+		let assertions = 0;
+		vi.spyOn(ManagedSessionDescendantStore.prototype, "assertBound").mockImplementation(function (
+			this: ManagedSessionDescendantStore,
+		) {
+			assertBound.call(this);
+			assertions++;
+			if (assertions === 5) {
+				fs.renameSync(agentDir, displacedAgentDir);
+				fs.cpSync(displacedAgentDir, agentDir, { recursive: true });
+			}
+		});
+
+		await expect(
+			SessionManager.prepareManagedCandidateForWrite(legacyPath, "copy-retain", destination),
+		).rejects.toThrow("Managed descendant root binding changed");
+
+		expect(assertions).toBe(5);
+		expect(fs.readFileSync(legacyPath)).toEqual(candidateBefore);
+		expect(fs.readFileSync(bindingPath)).toEqual(bindingBefore);
+		expect(fs.readdirSync(path.join(protocolRoot, "receipts"))).toEqual(receiptsBefore);
+		expect(fs.readdirSync(path.join(protocolRoot, "tombstones"))).toEqual(tombstonesBefore);
+		expect(fs.existsSync(path.join(destination.directory, path.basename(legacyPath)))).toBe(false);
+		expect(fs.existsSync(path.join(destination.directory, path.basename(legacyPath).slice(0, -6)))).toBe(false);
+		expect(fs.existsSync(path.join(legacyDirectory, ".gjc-managed-session-scope.v2.json"))).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
- Preserve explicit versus managed resume authority across bare picker, selector, continue, direct resume, and fork flows.
- Bind managed migration and selector adoption to the inspected transcript identity and captured root authority.
- Add focused regressions for custom scoped agent roots, explicit containment, migration races, and portable breadcrumb links.

## Verification
- `git diff --check` passed.
- G008 fixture review: CLEAR.
- Focused test attempt was blocked before test execution by missing workspace resolution for `@gajae-code/coding-agent/session/internal/managed-session-storage`; `bun install --frozen-lockfile` was attempted but node-pty rebuild failed because system node-gyp cannot resolve `nopt`. CI is required for runnable focused checks.

Fixes #2812

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*