### PR TITLE
fix(coding-agent): restore /fork slash command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### Fixed
 - MCP OAuth discovery now treats transport error hints as classification-only and uses one public-network-validated, redirect-aware, issuer/resource-bound traversal budget across metadata aliases and cycles.
+- Restored the documented interactive `/fork` slash command to autocomplete and dispatch so persisted sessions can be duplicated from the TUI again.
 - Telegram `/btw` rich-delivery E2E coverage now awaits native and daemon teardown ownership, records exact per-iteration lifecycle phases, and uses an internal exact-tuple terminal-delivery receipt to keep fallback stress deterministic under shard load without extending the original test timeout.
 - Malformed spurious Round-0 review metadata no longer blocks an otherwise valid locked-intent question/gate, while durable intent safety remains fail-closed (#2643).
 - Restricted role-agent `gjc state` command authorization now fails closed on argv-classification disagreement: one shared manifest-aware native state argv grammar (action names, flag arity, positionals, effective modifiers, selector candidates) is consumed by both runtime dispatch and the policy boundary, which rejects ambiguous selectors, malformed flags, destructive actions, and file-backed input (#2665).

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1179,6 +1179,14 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			runtime.ctx.editor.setText("");
 		},
 	},
+	{
+		name: "fork",
+		description: "Fork the current session",
+		handleTui: async (_command, runtime) => {
+			await runtime.ctx.handleForkCommand();
+			runtime.ctx.editor.setText("");
+		},
+	},
 
 	{
 		name: "provider",

--- a/packages/coding-agent/test/slash-command-builtin-registry.test.ts
+++ b/packages/coding-agent/test/slash-command-builtin-registry.test.ts
@@ -153,6 +153,26 @@ describe("builtin /copy slash command", () => {
 		expect(sessionCommand?.subcommands?.map(command => command.name)).toEqual(["info", "delete"]);
 	});
 
+	it("discovers and dispatches /fork to the session controller", async () => {
+		const forkCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "fork");
+		const handleForkCommand = vi.fn(async () => {});
+		const setText = vi.fn();
+		const ctx = {
+			handleForkCommand,
+			editor: { setText },
+		} as unknown as InteractiveModeContext;
+
+		const result = await executeBuiltinSlashCommand("/fork", {
+			ctx,
+			handleBackgroundCommand: () => undefined,
+		});
+
+		expect(forkCommand?.description).toBe("Fork the current session");
+		expect(result).toBe(true);
+		expect(handleForkCommand).toHaveBeenCalledTimes(1);
+		expect(setText).toHaveBeenCalledWith("");
+	});
+
 	it("dispatches zero-argument /copy to the existing copy controller path", async () => {
 		const { runtime, handleCopyCommand, showError, setText } = createTuiRuntime();
 


### PR DESCRIPTION
## Summary
- restore the documented `/fork` command to the builtin slash-command registry
- route it through the existing interactive session fork controller
- add autocomplete/dispatch regression coverage and an Unreleased changelog entry

## Verification
- `bun test packages/coding-agent/test/slash-command-builtin-registry.test.ts` (23 pass, 0 fail)
- `git diff --check origin/main...HEAD`