### PR TITLE
fix: route notification BTW through side-turn contract

### DIFF
--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -30,7 +30,7 @@ import { promisify } from "node:util";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { ImageContent, TextContent, Tool } from "@gajae-code/ai";
 import { NotificationServer, nativeBuildInfo } from "@gajae-code/natives";
-import { logger, postmortem, prompt, VERSION } from "@gajae-code/utils";
+import { logger, postmortem, VERSION } from "@gajae-code/utils";
 import { Settings } from "../../config/settings";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../../extensibility/extensions";
 import { toAgentWireEventPayload } from "../../modes/shared/agent-wire/event-envelope";
@@ -40,7 +40,6 @@ import {
 	type WorkflowGateTerminalController,
 	type WorkflowGateTerminalProof,
 } from "../../modes/shared/agent-wire/workflow-gate-broker";
-import btwUserPrompt from "../../prompts/system/btw-user.md" with { type: "text" };
 import type { AgentSessionEvent } from "../../session/agent-session";
 import { parseThinkingLevel } from "../../thinking";
 import type {
@@ -2778,7 +2777,7 @@ export function createNotificationsExtension(
 		sdkHostModeSupported?: boolean;
 
 		onSdkRequest?: (kind: "control" | "query", connectionId: string, frame: Record<string, unknown>) => void;
-		runEphemeralTurn?: (promptText: string, signal: AbortSignal) => Promise<{ replyText: string }>;
+		runBtwTurn?: (question: string, signal: AbortSignal) => Promise<{ replyText: string }>;
 		/** Observes settlement of optional session-branch startup after reconciliation completes. */
 		onBranchStartupSettled?: (receipt: { sessionId: string; status: SessionStartResult["status"] }) => void;
 		readNotificationFile?: (path: string) => Promise<Buffer>;
@@ -3587,10 +3586,10 @@ export function createNotificationsExtension(
 		};
 
 		const ephemeralTurns = new EphemeralTurnHost(sendSdkFrame, async (question, signal) => {
-			if (!options.runEphemeralTurn) throw new Error("Ephemeral turns are unavailable.");
+			if (!options.runBtwTurn) throw new Error("Ephemeral turns are unavailable.");
 			const generation = initializedRuntime.policyGeneration;
 			if (initializedRuntime.policySuspended) throw new Error("Notification policy is provisional.");
-			const result = await options.runEphemeralTurn(prompt.render(btwUserPrompt, { question }), signal);
+			const result = await options.runBtwTurn(question, signal);
 			if (
 				initializedRuntime.policySuspended ||
 				initializedRuntime.policyGeneration !== generation ||

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -92,6 +92,7 @@ import type { FileSlashCommand } from "../extensibility/slash-commands";
 import type { HindsightSessionState } from "../hindsight/state";
 import { initializeLocalRoot, LocalProtocolHandler, type LocalProtocolOptions } from "../internal-urls";
 import { resolveMemoryBackend } from "../memory-backend";
+import btwUserPrompt from "../prompts/system/btw-user.md" with { type: "text" };
 import asyncResultTemplate from "../prompts/tools/async-result.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
 import { MCPManager } from "../runtime-mcp";
@@ -1855,9 +1856,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						spawnedByGjc,
 						sdkHostModeSupported: options.sdkHostModeSupported,
 						ensureProviderDaemon: options.ensureNotificationProviderDaemon,
-						runEphemeralTurn: async (promptText, signal) => {
+						runBtwTurn: async (question, signal) => {
 							if (!session) throw new Error("Ephemeral turns are unavailable.");
-							const { replyText } = await session.runEphemeralTurn({ promptText, signal });
+							const { replyText } = await session.runEphemeralTurn({
+								purpose: "btw",
+								turn: { question, scope: session.createBtwConversationScope(btwUserPrompt) },
+								signal,
+							});
 							return { replyText };
 						},
 					});

--- a/packages/coding-agent/test/command-palette.test.ts
+++ b/packages/coding-agent/test/command-palette.test.ts
@@ -58,6 +58,7 @@ function createInputControllerContext(options: {
 		historyStorage: { getRecent: () => [] },
 		skillCommands: new Map(),
 		pendingImages: options.pendingImages ?? [],
+		hasActiveBtw: () => false,
 		getSlashCommands: () => [{ name: "changelog", description: "Show changelog" }],
 	} as unknown as InteractiveModeContext;
 	if (options.delegated) {
@@ -205,6 +206,7 @@ describe("CommandPalette", () => {
 			showStatus: () => {},
 			historyStorage: { getRecent: () => [] },
 			skillCommands: new Map([["skill:demo", { description: "Demo skill" }]]),
+			hasActiveBtw: () => false,
 			getSlashCommands: () => liveCommands,
 		} as unknown as InteractiveModeContext;
 		new InputController(ctx).openCommandPalette();
@@ -253,6 +255,7 @@ describe("CommandPalette", () => {
 			showStatus: () => {},
 			historyStorage: { getRecent: () => [] },
 			skillCommands: new Map(),
+			hasActiveBtw: () => false,
 			getSlashCommands: () => [{ name: "clear", description: "Clear the session" }],
 		} as unknown as InteractiveModeContext;
 		new InputController(ctx).openCommandPalette();
@@ -296,6 +299,7 @@ describe("CommandPalette", () => {
 			showStatus: () => {},
 			historyStorage: { getRecent: () => [] },
 			skillCommands: new Map(),
+			hasActiveBtw: () => false,
 			getSlashCommands: () => [{ name: "changelog", description: "Show changelog" }],
 		} as unknown as InteractiveModeContext;
 		new InputController(ctx).openCommandPalette();

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -132,6 +132,7 @@ function createStubInputControllerContext(opts: {
 		},
 		showError,
 		updatePendingMessagesDisplay,
+		hasActiveBtw: () => false,
 		// Defaults that InputController touches on submit but don't matter here.
 		isBashMode: false,
 		isPythonMode: false,
@@ -591,6 +592,7 @@ function createStubInteractiveModeContextForUiHelpers(session: AgentSession) {
 			getDisplayString: (_action: string) => "Alt+Up",
 		},
 		updatePendingMessagesDisplay,
+		hasActiveBtw: () => false,
 		locallySubmittedUserSignatures: new Set<string>(),
 	} as unknown as InteractiveModeContext;
 

--- a/packages/coding-agent/test/notifications-telegram-btw-e2e.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-btw-e2e.test.ts
@@ -71,12 +71,12 @@ function isolatedSettings(agentDir: string): Settings {
 		},
 	}) as Settings;
 }
-test("real notifications extension rebinds /btw without provider replay or main-session injection", async () => {
+test("real notifications extension rebinds /btw with raw-question delegation and no main-session injection", async () => {
 	const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-btw-extension-e2e-"));
 	const cwd = path.join(agentDir, "repo");
 	const sessionId = "btw-extension-e2e";
 	const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>();
-	const providerCalls: Array<{ prompt: string; signal?: AbortSignal }> = [];
+	const btwCalls: Array<{ question: string; signal?: AbortSignal }> = [];
 	const providerResponse = Promise.withResolvers<{ replyText: string }>();
 	let mainSessionInjections = 0;
 	const settings = isolatedSettings(agentDir);
@@ -115,8 +115,8 @@ test("real notifications extension rebinds /btw without provider replay or main-
 			} as never,
 			{
 				settings,
-				runEphemeralTurn: async (prompt, signal) => {
-					providerCalls.push({ prompt, signal });
+				runBtwTurn: async (question, signal) => {
+					btwCalls.push({ question, signal });
 					if (signal?.aborted) throw signal.reason;
 					return await providerResponse.promise;
 				},
@@ -147,7 +147,7 @@ test("real notifications extension rebinds /btw without provider replay or main-
 				text: "/btw exact side question",
 			},
 		});
-		await waitFor(() => providerCalls.length === 1, "EphemeralTurnHost provider invocation");
+		await waitFor(() => btwCalls.length === 1, "raw-question BTW invocation");
 		daemon.sessions.get(sessionId)!.ws.close();
 		await waitFor(() => !daemon.sessions.has(sessionId), "extension transient transport loss");
 		await daemon.scanRoots();
@@ -158,19 +158,12 @@ test("real notifications extension rebinds /btw without provider replay or main-
 			"extension replacement capability replay",
 		);
 		await sleep(80);
-		expect(providerCalls).toHaveLength(1);
+		expect(btwCalls).toHaveLength(1);
 		providerResponse.resolve({ replyText: "| Formula | Value |\n| --- | --- |\n| $x^2$ | 4 |" });
 		await waitFor(() => bot.count("sendRichMessage") === richBefore + 1, "correlated rich /btw delivery");
-		expect(providerCalls).toHaveLength(1);
-		expect(providerCalls[0]!.prompt).toBe(`<btw>
-This is an ephemeral side question for the current interactive session.
-Answer briefly and directly using the conversation context already provided.
-Do not use tools.
-Do not ask follow-up questions.
-Question:
-exact side question
-</btw>`);
-		expect(providerCalls[0]!.signal).toBeInstanceOf(AbortSignal);
+		expect(btwCalls).toHaveLength(1);
+		expect(btwCalls[0]!.question).toBe("exact side question");
+		expect(btwCalls[0]!.signal).toBeInstanceOf(AbortSignal);
 		expect(mainSessionInjections).toBe(0);
 		expect(bot.count("sendMessage")).toBe(sendMessageBefore);
 		const richCalls = bot.calls.filter(call => call.method === "sendRichMessage");


### PR DESCRIPTION
## Summary
- preserve the raw Telegram `/btw` question through the notification seam
- route the request through AgentSession’s structured BTW side-turn path
- repair stale inactive-BTW InputController test fixtures without weakening production routing

Fixes #2835.

## Verification
- `bun --cwd=packages/coding-agent test test/notifications-telegram-btw-e2e.test.ts test/command-palette.test.ts test/input-controller-skill-queue.test.ts` — 32 passed
- nine focused BTW/privacy tests — 55 passed
- `bun --cwd=packages/coding-agent run check` — passed

`/tmp` owner-security and `notifications-lifecycle-control-runtime.test.ts` remain untouched; #2818 stays separate.

Reviewed head: `72d49d3dcae44f49e16112612de38b04fbe7f1ad`

— GJC