### PR TITLE
fix: reduce managed legacy-resume memory amplification

### DIFF
--- a/packages/coding-agent/bench/session-legacy-resume-rss.ts
+++ b/packages/coding-agent/bench/session-legacy-resume-rss.ts
@@ -1,0 +1,240 @@
+/**
+ * ISSUE #2834 synthetic legacy-resume RSS regression benchmark.
+ *
+ * This creates deterministic, privacy-safe v2 JSONL transcripts at three
+ * geometric record scales and opens each through the strict resume seam. On
+ * Linux with `/usr/bin/time`, every shape runs in its own Bun process and the
+ * report carries that external process's peak RSS; otherwise it reports only
+ * in-process samples and explicitly marks external isolation unavailable.
+ *
+ * Run with an exposed collector for meaningful worker GC baselines:
+ *   bun --expose-gc packages/coding-agent/bench/session-legacy-resume-rss.ts
+ */
+
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SessionManager } from "../src/session/session-manager";
+
+const DEFAULT_SEED = 0x2834;
+const DEFAULT_RECORD_COUNT = 64;
+const DEFAULT_BODY_BYTES = 32 * 1024;
+const SCALE_FACTORS = [1, 4, 16] as const;
+
+export type ShapeMeasurement = {
+	inputBytes: number;
+	baselineRssBytes: number;
+	strictOpenSampleRssBytes: number;
+	postCloseRssBytes: number | null;
+	contextMessageCount: number;
+	retainedEntryCount: number;
+};
+
+export type CliArgs = {
+	seed: number;
+	recordCount: number;
+	bodyBytes: number;
+	worker?: boolean;
+};
+
+export interface LegacyResumeRssReport {
+	issue: "#2834";
+	fixture: "synthetic-deterministic-legacy-v2-jsonl";
+	scope: "synthetic regression only; does not reproduce reporter artifacts, content, or RSS figures";
+	seed: number;
+	shapes: Array<{
+		factor: number;
+		recordCount: number;
+		measurement: ShapeMeasurement;
+		externalPeakRssBytes: number | null;
+	}>;
+	measurement: {
+		processIsolated: boolean;
+		externalPeak: "maxrss-kibibytes-from-/usr/bin/time" | "unavailable";
+		enforcement: "report-only";
+	};
+}
+
+function parsePositiveInteger(value: string, flag: string): number {
+	if (!/^\d+$/.test(value)) throw new Error(`${flag} must be a positive integer`);
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed < 1) throw new Error(`${flag} must be a positive integer`);
+	return parsed;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+	const args: CliArgs = { seed: DEFAULT_SEED, recordCount: DEFAULT_RECORD_COUNT, bodyBytes: DEFAULT_BODY_BYTES };
+	for (let index = 2; index < argv.length; index++) {
+		const flag = argv[index];
+		if (flag === "--worker") {
+			args.worker = true;
+			continue;
+		}
+		const value = argv[++index];
+		if (!value) throw new Error(`${flag} requires a value`);
+		switch (flag) {
+			case "--seed":
+				args.seed = parsePositiveInteger(value, flag);
+				break;
+			case "--records":
+				args.recordCount = parsePositiveInteger(value, flag);
+				break;
+			case "--body-bytes":
+				args.bodyBytes = parsePositiveInteger(value, flag);
+				break;
+			default:
+				throw new Error(`Unknown argument: ${flag}`);
+		}
+	}
+	return args;
+}
+
+function mulberry32(seed: number): () => number {
+	let state = seed;
+	return () => {
+		state |= 0;
+		state = (state + 0x6d2b79f5) | 0;
+		let value = Math.imul(state ^ (state >>> 15), 1 | state);
+		value = (value + Math.imul(value ^ (value >>> 7), 61 | value)) ^ value;
+		return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+function deterministicText(seed: number, bytes: number): string {
+	const next = mulberry32(seed);
+	const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
+	let text = "";
+	while (text.length < bytes) text += alphabet[Math.floor(next() * alphabet.length)] ?? "x";
+	return text;
+}
+
+function createTranscript(seed: number, recordCount: number, bodyBytes: number): string {
+	const lines: string[] = [
+		JSON.stringify({
+			type: "session",
+			version: 2,
+			id: `synthetic-legacy-${seed}`,
+			timestamp: "2020-01-01T00:00:00.000Z",
+			cwd: "/synthetic/issue-2834",
+		}),
+	];
+	let parentId: string | null = null;
+	for (let index = 0; index < recordCount; index++) {
+		const id = `message-${index}`;
+		const body = index === 0 ? "synthetic legacy resume seed" : deterministicText(seed + index, bodyBytes);
+		lines.push(
+			JSON.stringify({
+				type: "message",
+				id,
+				parentId,
+				timestamp: "2020-01-01T00:00:00.000Z",
+				message: { role: "user", content: body, timestamp: 0 },
+			}),
+		);
+		parentId = id;
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+function forceGc(): boolean {
+	const gc = (globalThis as { gc?: () => void }).gc;
+	if (!gc) return false;
+	gc();
+	return true;
+}
+
+async function measureShape(seed: number, recordCount: number, bodyBytes: number): Promise<ShapeMeasurement> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-issue-2834-rss-"));
+	try {
+		const sessionDir = path.join(root, "sessions");
+		const transcriptPath = path.join(sessionDir, "synthetic-legacy.jsonl");
+		await fs.mkdir(sessionDir, { recursive: true });
+		await fs.writeFile(transcriptPath, createTranscript(seed, recordCount, bodyBytes), "utf8");
+		const before = await fs.readFile(transcriptPath);
+		const inspection = await SessionManager.inspectSessionTailReadOnly(transcriptPath);
+		if (inspection.kind !== "resumable") throw new Error("Strict inspection did not produce a resumable session");
+		forceGc();
+		const baselineRssBytes = process.memoryUsage().rss;
+		const opened = await SessionManager.openExistingStrict(inspection.identity, sessionDir);
+		if (opened.kind !== "opened") throw new Error(`Strict open failed: ${opened.reason}`);
+		const strictOpenSampleRssBytes = process.memoryUsage().rss;
+		const contextMessageCount = opened.manager.buildSessionContext().messages.length;
+		const retainedEntryCount = opened.manager.getEntries().length;
+		if (contextMessageCount !== recordCount || retainedEntryCount !== recordCount)
+			throw new Error("Strict resume did not retain every synthetic legacy message");
+		await opened.manager.close();
+		if (!before.equals(await fs.readFile(transcriptPath))) throw new Error("Strict resume changed the synthetic legacy transcript");
+		return {
+			inputBytes: before.byteLength,
+			baselineRssBytes,
+			strictOpenSampleRssBytes,
+			postCloseRssBytes: forceGc() ? process.memoryUsage().rss : null,
+			contextMessageCount,
+			retainedEntryCount,
+		};
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}
+
+async function externalShape(args: CliArgs): Promise<{ measurement: ShapeMeasurement; externalPeakRssBytes: number | null }> {
+	const timePath = process.platform === "linux" ? "/usr/bin/time" : undefined;
+	if (!timePath) return { measurement: await measureShape(args.seed, args.recordCount, args.bodyBytes), externalPeakRssBytes: null };
+	try {
+		await fs.access(timePath);
+	} catch {
+		return { measurement: await measureShape(args.seed, args.recordCount, args.bodyBytes), externalPeakRssBytes: null };
+	}
+	const child = Bun.spawn([
+		timePath,
+		"-f",
+		"%M",
+		process.execPath,
+		"--expose-gc",
+		import.meta.path,
+		"--worker",
+		"--seed",
+		String(args.seed),
+		"--records",
+		String(args.recordCount),
+		"--body-bytes",
+		String(args.bodyBytes),
+	], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [exitCode, stdout, stderr] = await Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]);
+	if (exitCode !== 0) throw new Error(`Isolated benchmark failed: ${stderr}`);
+	const peakKibibytes = Number(stderr.trim().split(/\s+/).at(-1));
+	if (!Number.isSafeInteger(peakKibibytes) || peakKibibytes < 1) throw new Error(`Invalid /usr/bin/time peak RSS: ${stderr}`);
+	return { measurement: JSON.parse(stdout) as ShapeMeasurement, externalPeakRssBytes: peakKibibytes * 1024 };
+}
+
+export async function measureLegacyResumeRss(args: CliArgs = parseArgs(Bun.argv)): Promise<LegacyResumeRssReport> {
+	if (args.worker) throw new Error("Worker measurements are emitted only by the benchmark entrypoint.");
+	const shapes: LegacyResumeRssReport["shapes"] = [];
+	for (const factor of SCALE_FACTORS) {
+		const recordCount = args.recordCount * factor;
+		const result = await externalShape({ ...args, recordCount });
+		shapes.push({ factor, recordCount, ...result });
+	}
+	return {
+		issue: "#2834",
+		fixture: "synthetic-deterministic-legacy-v2-jsonl",
+		scope: "synthetic regression only; does not reproduce reporter artifacts, content, or RSS figures",
+		seed: args.seed,
+		shapes,
+		measurement: {
+			processIsolated: shapes.every(shape => shape.externalPeakRssBytes !== null),
+			externalPeak: shapes.every(shape => shape.externalPeakRssBytes !== null)
+				? "maxrss-kibibytes-from-/usr/bin/time"
+				: "unavailable",
+			enforcement: "report-only",
+		},
+	};
+}
+
+if (import.meta.main) {
+	const args = parseArgs(Bun.argv);
+	process.stdout.write(`${JSON.stringify(args.worker ? await measureShape(args.seed, args.recordCount, args.bodyBytes) : await measureLegacyResumeRss(args))}\n`);
+}

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1838,10 +1838,44 @@ function inspectResumeSessionFile(
 			mtimeNs: snapshot.mtimeNs,
 			sha256: crypto.createHash("sha256").update(bytes).digest("hex"),
 		};
-		return { identity, content: Uint8Array.from(bytes), entries, context, migrationApplied };
+		return { identity, content: bytes, entries, context, migrationApplied };
 	} catch {
 		return { kind: "error", reason: "malformed" };
 	}
+}
+
+/** Revalidate previously parsed authority without another decode, parse, migration, or context build. */
+function revalidateResumeSessionIdentity(
+	filePath: string,
+	storage: SessionStorage,
+	expected: ResumeSessionIdentity,
+): StrictSessionOpenFailure | { kind: "valid" } {
+	const canonicalPath = resolveEquivalentPath(path.resolve(filePath));
+	let before: SessionStorageStat;
+	let snapshot: SessionStorageSnapshot;
+	let after: SessionStorageStat;
+	try {
+		before = storage.statSync(canonicalPath);
+		if (!before.isFile || !storage.readSnapshotSync) return { kind: "error", reason: "read-failed" };
+		snapshot = storage.readSnapshotSync(canonicalPath);
+		after = storage.statSync(canonicalPath);
+	} catch (error) {
+		return resumeReadFailure(error, storage, canonicalPath);
+	}
+	if (!sameResumeStat(before, snapshot.stat) || !sameResumeStat(snapshot.stat, after)) {
+		return { kind: "error", reason: "unstable" };
+	}
+	const observed: ResumeSessionIdentity = {
+		canonicalPath,
+		sessionId: expected.sessionId,
+		dev: snapshot.stat.dev,
+		ino: snapshot.stat.ino,
+		size: snapshot.stat.size,
+		mtimeMs: snapshot.stat.mtimeMs,
+		mtimeNs: snapshot.stat.mtimeNs,
+		sha256: crypto.createHash("sha256").update(snapshot.bytes).digest("hex"),
+	};
+	return sameResumeIdentity(expected, observed) ? { kind: "valid" } : { kind: "error", reason: "identity-mismatch" };
 }
 
 /**
@@ -4181,15 +4215,16 @@ export class SessionManager {
 	}
 
 	async #hydrateExistingSession(sessionFile: string, entries: FileEntry[], migrationApplied: boolean): Promise<void> {
-		const ownedEntries = structuredClone(entries) as FileEntry[];
-		const header = ownedEntries[0] as SessionHeader;
+		// Strict inspection creates these entries solely for this hydration path. Adopt that
+		// final, validated representation instead of cloning the complete transcript again.
+		const header = entries[0] as SessionHeader;
 		this.#sessionFile = this.storage instanceof FileSessionStorage ? path.resolve(sessionFile) : sessionFile;
 		this.#sessionId = header.id;
 		this.#sessionName = header.title;
 		this.#titleSource = header.titleSource;
 		this.#needsFullRewriteOnNextPersist = migrationApplied;
-		await resolveBlobRefsInEntries(ownedEntries, this.#blobStore);
-		this.#fileEntries = ownedEntries;
+		await resolveBlobRefsInEntries(entries, this.#blobStore);
+		this.#fileEntries = entries;
 		this.#resetResidentTextBlobStore();
 		this.#fileEntries = this.#fileEntries.map(entry =>
 			prepareEntryForResidentSync(entry, this.#residentBlobStores()),
@@ -7719,14 +7754,10 @@ export class SessionManager {
 		const dir = destination.directory;
 		const manager = new SessionManager(header.cwd || getProjectDir(), dir, true, storage, destination);
 		await manager.#hydrateExistingSession(sessionPath, entries, inspected.migrationApplied);
-		const ownershipInspection = inspectResumeSessionFile(sessionPath, storage);
-		if ("kind" in ownershipInspection) {
+		const ownershipInspection = revalidateResumeSessionIdentity(sessionPath, storage, inspected.identity);
+		if (ownershipInspection.kind === "error") {
 			await manager.close();
 			return ownershipInspection;
-		}
-		if (!sameResumeIdentity(inspected.identity, ownershipInspection.identity)) {
-			await manager.close();
-			return { kind: "error", reason: "identity-mismatch" };
 		}
 		try {
 			await manager.#sanitizeLoadedOpenAIResponsesReplayMetadataAndPersist();

--- a/packages/coding-agent/test/command-palette.test.ts
+++ b/packages/coding-agent/test/command-palette.test.ts
@@ -59,6 +59,7 @@ function createInputControllerContext(options: {
 		skillCommands: new Map(),
 		pendingImages: options.pendingImages ?? [],
 		getSlashCommands: () => [{ name: "changelog", description: "Show changelog" }],
+		hasActiveBtw: () => false,
 	} as unknown as InteractiveModeContext;
 	if (options.delegated) {
 		ctx.showCommandPalette = (_commands, _actions, execute) => {
@@ -206,6 +207,7 @@ describe("CommandPalette", () => {
 			historyStorage: { getRecent: () => [] },
 			skillCommands: new Map([["skill:demo", { description: "Demo skill" }]]),
 			getSlashCommands: () => liveCommands,
+			hasActiveBtw: () => false,
 		} as unknown as InteractiveModeContext;
 		new InputController(ctx).openCommandPalette();
 		expect(overlay?.getEntries().map(entry => entry.label)).toEqual(
@@ -254,6 +256,7 @@ describe("CommandPalette", () => {
 			historyStorage: { getRecent: () => [] },
 			skillCommands: new Map(),
 			getSlashCommands: () => [{ name: "clear", description: "Clear the session" }],
+			hasActiveBtw: () => false,
 		} as unknown as InteractiveModeContext;
 		new InputController(ctx).openCommandPalette();
 		for (const key of "cycle mode") overlay?.handleInput(key);
@@ -297,6 +300,7 @@ describe("CommandPalette", () => {
 			historyStorage: { getRecent: () => [] },
 			skillCommands: new Map(),
 			getSlashCommands: () => [{ name: "changelog", description: "Show changelog" }],
+			hasActiveBtw: () => false,
 		} as unknown as InteractiveModeContext;
 		new InputController(ctx).openCommandPalette();
 		for (const key of "/changelog") overlay?.handleInput(key);

--- a/packages/coding-agent/test/command-palette.test.ts
+++ b/packages/coding-agent/test/command-palette.test.ts
@@ -58,7 +58,6 @@ function createInputControllerContext(options: {
 		historyStorage: { getRecent: () => [] },
 		skillCommands: new Map(),
 		pendingImages: options.pendingImages ?? [],
-		hasActiveBtw: () => false,
 		getSlashCommands: () => [{ name: "changelog", description: "Show changelog" }],
 		hasActiveBtw: () => false,
 	} as unknown as InteractiveModeContext;
@@ -207,7 +206,6 @@ describe("CommandPalette", () => {
 			showStatus: () => {},
 			historyStorage: { getRecent: () => [] },
 			skillCommands: new Map([["skill:demo", { description: "Demo skill" }]]),
-			hasActiveBtw: () => false,
 			getSlashCommands: () => liveCommands,
 			hasActiveBtw: () => false,
 		} as unknown as InteractiveModeContext;
@@ -257,7 +255,6 @@ describe("CommandPalette", () => {
 			showStatus: () => {},
 			historyStorage: { getRecent: () => [] },
 			skillCommands: new Map(),
-			hasActiveBtw: () => false,
 			getSlashCommands: () => [{ name: "clear", description: "Clear the session" }],
 			hasActiveBtw: () => false,
 		} as unknown as InteractiveModeContext;
@@ -302,7 +299,6 @@ describe("CommandPalette", () => {
 			showStatus: () => {},
 			historyStorage: { getRecent: () => [] },
 			skillCommands: new Map(),
-			hasActiveBtw: () => false,
 			getSlashCommands: () => [{ name: "changelog", description: "Show changelog" }],
 			hasActiveBtw: () => false,
 		} as unknown as InteractiveModeContext;

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -140,6 +140,7 @@ function createStubInputControllerContext(opts: {
 		compactionQueuedMessages: [],
 		locallySubmittedUserSignatures: new Set<string>(),
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
+		hasActiveBtw: () => false,
 	} as unknown as InteractiveModeContext;
 
 	return { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage, sendCustomMessage, prompt };
@@ -592,6 +593,7 @@ function createStubInteractiveModeContextForUiHelpers(session: AgentSession) {
 		},
 		updatePendingMessagesDisplay,
 		locallySubmittedUserSignatures: new Set<string>(),
+		hasActiveBtw: () => false,
 	} as unknown as InteractiveModeContext;
 
 	return { ctx, editor, pendingMessagesContainer };
@@ -705,6 +707,7 @@ function createEventControllerFixtureForE10() {
 		addMessageToChat,
 		updatePendingMessagesDisplay,
 		session: {},
+		hasActiveBtw: () => false,
 	} as unknown as InteractiveModeContext;
 
 	const controller = new EventController(ctx);

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -132,7 +132,6 @@ function createStubInputControllerContext(opts: {
 		},
 		showError,
 		updatePendingMessagesDisplay,
-		hasActiveBtw: () => false,
 		// Defaults that InputController touches on submit but don't matter here.
 		isBashMode: false,
 		isPythonMode: false,
@@ -593,7 +592,6 @@ function createStubInteractiveModeContextForUiHelpers(session: AgentSession) {
 			getDisplayString: (_action: string) => "Alt+Up",
 		},
 		updatePendingMessagesDisplay,
-		hasActiveBtw: () => false,
 		locallySubmittedUserSignatures: new Set<string>(),
 		hasActiveBtw: () => false,
 	} as unknown as InteractiveModeContext;

--- a/packages/coding-agent/test/notifications-telegram-btw-e2e.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-btw-e2e.test.ts
@@ -162,14 +162,11 @@ test("real notifications extension rebinds /btw without provider replay or main-
 		providerResponse.resolve({ replyText: "| Formula | Value |\n| --- | --- |\n| $x^2$ | 4 |" });
 		await waitFor(() => bot.count("sendRichMessage") === richBefore + 1, "correlated rich /btw delivery");
 		expect(providerCalls).toHaveLength(1);
-		expect(providerCalls[0]!.prompt).toBe(`<btw>
-This is an ephemeral side question for the current interactive session.
-Answer briefly and directly using the conversation context already provided.
-Do not use tools.
-Do not ask follow-up questions.
-Question:
-exact side question
-</btw>`);
+		expect(
+			providerCalls[0]!.prompt,
+		).toBe(`You are answering inside an ephemeral multi-turn side chat for the interactive session.
+Use only the sanitized visible-text conversation scope and prior side-chat turns provided as messages.
+Answer directly. Do not use tools or request hidden session state.`);
 		expect(providerCalls[0]!.signal).toBeInstanceOf(AbortSignal);
 		expect(mainSessionInjections).toBe(0);
 		expect(bot.count("sendMessage")).toBe(sendMessageBefore);

--- a/packages/coding-agent/test/resume-confirm-continue.test.ts
+++ b/packages/coding-agent/test/resume-confirm-continue.test.ts
@@ -414,6 +414,7 @@ it("bounds a rejected selected strict-open promise to one error before session s
 				action: "open-idle",
 			}),
 			openExistingSessionStrict: async () => {
+				strictOpens++;
 				throw new Error("injected strict-open rejection");
 			},
 			discoverAuthStorage: async () => {

--- a/packages/coding-agent/test/resume-confirm-continue.test.ts
+++ b/packages/coding-agent/test/resume-confirm-continue.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import * as path from "node:path";
 import type { Args } from "../src/cli/args";
 import { parseArgs } from "../src/cli/args";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
 import {
 	BARE_RESUME_CONFLICT_ERROR,
 	BARE_RESUME_INTERACTIVE_ERROR,
@@ -38,6 +39,7 @@ const sessionInfo: SessionInfo = {
 };
 
 afterEach(() => {
+	resetSettingsForTest();
 	process.exitCode = undefined;
 });
 
@@ -66,6 +68,11 @@ async function captureStderr(operation: () => Promise<void>): Promise<string> {
 		process.stderr.write = originalWrite;
 	}
 	return stderr;
+}
+
+/** Bare resume opens into the managed scope selected from the initialized settings singleton. */
+async function initializeBareResumeManagedScope(): Promise<void> {
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
 }
 
 async function expectEarlyBareResumeRejection(args: Args, isResumePickerTerminal: boolean): Promise<string> {
@@ -209,6 +216,7 @@ describe("bare resume startup gating", () => {
 		expect(stderrWrite).not.toHaveBeenCalled();
 		expect(opens).toBe(0);
 
+		await initializeBareResumeManagedScope();
 		await runRootCommand(bareArgs(), [], {
 			suppressProcessExit: true,
 			isResumePickerTerminal: () => true,
@@ -225,21 +233,28 @@ describe("bare resume startup gating", () => {
 	});
 });
 
-it("bounds a rejected strict-open promise to one error before session startup or fallback", async () => {
+it("bounds a rejected selected strict-open promise to one error before session startup or fallback", async () => {
 	let authDiscoveries = 0;
 	let sessionCreations = 0;
+	let strictOpens = 0;
 	const stderr = await captureStderr(async () => {
+		await initializeBareResumeManagedScope();
 		await runRootCommand(bareArgs(), [], {
 			suppressProcessExit: true,
 			isResumePickerTerminal: () => true,
 			listForResumePickerReadOnly: async () => [sessionInfo],
-			selectResumeSession: async () => ({
-				kind: "selected",
-				path: sessionInfo.path,
-				identity,
-				action: "open-idle",
-			}),
-			openExistingSessionStrict: async () => {
+			selectResumeSession: async inventory => {
+				expect(inventory).toEqual([sessionInfo]);
+				return {
+					kind: "selected",
+					path: sessionInfo.path,
+					identity,
+					action: "open-idle",
+				};
+			},
+			openExistingSessionStrict: async selected => {
+				strictOpens++;
+				expect(selected).toBe(identity);
 				throw new Error("injected strict-open rejection");
 			},
 			discoverAuthStorage: async () => {
@@ -253,6 +268,7 @@ it("bounds a rejected strict-open promise to one error before session startup or
 		});
 	});
 	expect(stderr).toBe(`${BARE_RESUME_OPEN_ERROR}\n`);
+	expect(strictOpens).toBe(1);
 	expect(authDiscoveries).toBe(0);
 	expect(sessionCreations).toBe(0);
 });

--- a/packages/coding-agent/test/session-manager-resume-readonly.test.ts
+++ b/packages/coding-agent/test/session-manager-resume-readonly.test.ts
@@ -84,7 +84,7 @@ class FixedMtimeStorage extends WriteTrackingStorage {
 	}
 }
 
-class HandoffMutationStorage extends MemorySessionStorage {
+class PostHydrationDigestMutationStorage extends FixedMtimeStorage {
 	reads = 0;
 
 	constructor(private readonly replacement: string) {
@@ -94,7 +94,8 @@ class HandoffMutationStorage extends MemorySessionStorage {
 	override readSnapshotSync(filePath: string): SessionStorageSnapshot {
 		const snapshot = super.readSnapshotSync(filePath);
 		this.reads++;
-		if (this.reads === 2) queueMicrotask(() => super.writeTextSync(filePath, this.replacement));
+		if (this.reads === 2)
+			queueMicrotask(() => MemorySessionStorage.prototype.writeTextSync.call(this, filePath, this.replacement));
 		return snapshot;
 	}
 }
@@ -199,6 +200,26 @@ function sessionText(id: string, role: "user" | "assistant" = "user"): string {
 	return `${JSON.stringify(header)}\n${JSON.stringify(message)}\n`;
 }
 
+function sanitizableSessionText(id: string): string {
+	const header = { type: "session", id, timestamp: new Date(0).toISOString(), cwd: "/cwd", version: 5 };
+	const message = {
+		type: "message",
+		id: "message",
+		parentId: null,
+		timestamp: new Date(0).toISOString(),
+		message: {
+			role: "assistant",
+			content: [{ type: "thinking", thinking: "stale reasoning", thinkingSignature: "stale-signature" }],
+			provider: "openai",
+			model: "test",
+			timestamp: 0,
+			providerPayload: { type: "openaiResponsesHistory", provider: "openai", items: [] },
+			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+		},
+	};
+	return `${JSON.stringify(header)}\n${JSON.stringify(message)}\n`;
+}
+
 describe("SessionManager read-only resume", () => {
 	it("keeps strict managed read resolution fail-closed on ACL verification failure", () => {
 		const root = makeTempDir();
@@ -249,6 +270,42 @@ describe("SessionManager read-only resume", () => {
 		if (opened.kind === "error") throw new Error("Expected strict open success");
 		expect(opened.manager.getSessionId()).toBe("session-a");
 		expect(storage.writes).toBe(0);
+	});
+
+	it("adopts strict inspection entries without cloning the hydrated transcript", async () => {
+		const storage = new WriteTrackingStorage();
+		const filePath = "/sessions/adopted.jsonl";
+		storage.writeTextSync(filePath, sessionText("session-a"));
+		const inspection = await SessionManager.inspectSessionTailReadOnly(filePath, storage);
+		if (inspection.kind === "error") throw new Error("Expected resumable inspection");
+
+		const clone = vi.spyOn(globalThis, "structuredClone");
+		const opened = await SessionManager.openExistingStrict(inspection.identity, "/sessions", storage);
+		expect(opened.kind).toBe("opened");
+		expect(clone).not.toHaveBeenCalled();
+		if (opened.kind === "opened") await opened.manager.close();
+	});
+	it("keeps adopted strict entries isolated from public entry aliases", async () => {
+		const storage = new WriteTrackingStorage();
+		const filePath = "/sessions/adopted-isolation.jsonl";
+		storage.writeTextSync(filePath, sessionText("session-a"));
+		const inspection = await SessionManager.inspectSessionTailReadOnly(filePath, storage);
+		if (inspection.kind === "error") throw new Error("Expected resumable inspection");
+
+		const opened = await SessionManager.openExistingStrict(inspection.identity, "/sessions", storage);
+		if (opened.kind === "error") throw new Error("Expected strict open");
+		const exposed = opened.manager.getEntries();
+		const message = exposed.find(entry => entry.type === "message");
+		if (message?.type !== "message" || !("content" in message.message))
+			throw new Error("Expected adopted message entry");
+		(message.message as { content: string }).content = "mutated public alias";
+
+		expect(opened.manager.getEntries().find(entry => entry.type === "message")).toMatchObject({
+			type: "message",
+			message: { content: "resume" },
+		});
+		expect(storage.readTextSync(filePath)).toBe(sessionText("session-a"));
+		await opened.manager.close();
 	});
 
 	it("opens an immutable v4 patch fixture with its final header and message state", async () => {
@@ -395,19 +452,51 @@ describe("SessionManager read-only resume", () => {
 		expect(storage.writes).toBe(0);
 	});
 
-	it("revalidates identity after async hydration before ownership", async () => {
+	it("rejects post-hydration same-identity byte mutations at the final SHA fence", async () => {
 		const filePath = "/sessions/handoff.jsonl";
-		const storage = new HandoffMutationStorage(sessionText("session-a", "assistant"));
-		storage.writeTextSync(filePath, sessionText("session-a"));
+		const original = sessionText("session-a");
+		const mutated = original.replace("resume", "resumf");
+		expect(mutated.length).toBe(original.length);
+		const storage = new PostHydrationDigestMutationStorage(mutated);
+		storage.writeTextSync(filePath, original);
 		const inspection = await SessionManager.inspectSessionTailReadOnly(filePath, storage);
 		if (inspection.kind === "error") throw new Error("Expected inspection identity");
+		const before = storage.statSync(filePath);
 
+		storage.writes = 0;
 		expectStrictFailure(
 			await SessionManager.openExistingStrict(inspection.identity, "/sessions", storage),
 			"identity-mismatch",
 		);
 		expect(storage.reads).toBe(3);
-		expect(storage.readTextSync(filePath)).toContain('"role":"assistant"');
+		expect(storage.statSync(filePath)).toMatchObject({
+			dev: before.dev,
+			ino: before.ino,
+			size: before.size,
+			mtimeMs: before.mtimeMs,
+			mtimeNs: before.mtimeNs,
+		});
+		expect(storage.readTextSync(filePath)).toBe(mutated);
+		expect(storage.writes).toBe(0);
+	});
+	it("does not sanitize or write a breadcrumb when final authority rejects sanitizable history", async () => {
+		const filePath = "/sessions/sanitizable-handoff.jsonl";
+		const original = sanitizableSessionText("session-a");
+		const replacement = original.replace("stale reasoning", "fresh reasoning");
+		expect(replacement.length).toBe(original.length);
+		const storage = new PostHydrationDigestMutationStorage(replacement);
+		storage.writeTextSync(filePath, original);
+		const inspection = await SessionManager.inspectSessionTailReadOnly(filePath, storage);
+		if (inspection.kind === "error") throw new Error("Expected inspection identity");
+
+		storage.writes = 0;
+		expectStrictFailure(
+			await SessionManager.openExistingStrict(inspection.identity, "/sessions", storage),
+			"identity-mismatch",
+		);
+		expect(storage.readTextSync(filePath)).toBe(replacement);
+		expect(storage.readTextSync(filePath)).toContain("stale-signature");
+		expect(storage.writes).toBe(0);
 	});
 
 	it("fails closed on invalid UTF-8 instead of parsing replacement text", async () => {
@@ -720,8 +809,8 @@ describe("readonly session artifact authority", () => {
 
 		expect("saveArtifact" in readonly).toBe(false);
 		const capability = sessionArtifactCapability(readonly);
-		expect(capability).toBeDefined();
-		const artifactId = await capability?.saveArtifact("full SDK tool output", "sdk-tool");
+		if (!capability) throw new Error("Expected artifact capability");
+		const artifactId = await capability.saveArtifact("full SDK tool output", "sdk-tool");
 		expect(artifactId).toBeDefined();
 		if (artifactId) {
 			const artifactPath = await manager.getArtifactPath(artifactId);

--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -100,6 +100,19 @@ describe("managed session write protocol", () => {
 			expect(coalesced.owned[0]?.migrationState).toBe("migrated_v2");
 		}
 		const receipts = path.join(scope.directoryPath, ".gjc-managed-session-internal", "receipts");
+		const committedReceipt = path.join(
+			receipts,
+			(await fs.readdir(receipts)).find(name => name.endsWith(".json")) ?? "",
+		);
+		const receipt = JSON.parse(await fs.readFile(committedReceipt, "utf8")) as Record<string, unknown>;
+		expect(receipt).toMatchObject({
+			state: "committed",
+			policy: "copy-retain",
+			source: { path: source, sessionId: "session-a" },
+			destination: { path: first.path, sessionId: "session-a" },
+			artifactManifest: [],
+		});
+
 		for (const receipt of await fs.readdir(receipts)) await fs.unlink(path.join(receipts, receipt));
 		const interruptedReplay = await openManagedCandidateForWrite(scope, legacyCandidate);
 		expect(interruptedReplay).toMatchObject({ kind: "opened", path: first.path, migrated: true });
@@ -142,6 +155,20 @@ describe("managed session write protocol", () => {
 		expect((await fs.stat(path.join(destinationArtifacts, "nested", "empty"))).isDirectory()).toBe(true);
 		expect(await fs.readFile(path.join(sourceArtifacts, "payload.txt"), "utf8")).toBe("root");
 		expect((await fs.stat(path.join(sourceArtifacts, "nested", "empty"))).isDirectory()).toBe(true);
+		const receipts = path.join(scope.directoryPath, ".gjc-managed-session-internal", "receipts");
+		const committedReceipt = path.join(
+			receipts,
+			(await fs.readdir(receipts)).find(name => name.endsWith(".json")) ?? "",
+		);
+		const receipt = JSON.parse(await fs.readFile(committedReceipt, "utf8")) as { artifactManifest?: unknown[] };
+		expect(receipt.artifactManifest).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ kind: "directory", path: "nested" }),
+				expect.objectContaining({ kind: "directory", path: "nested/empty" }),
+				expect.objectContaining({ kind: "file", path: "payload.txt" }),
+				expect.objectContaining({ kind: "file", path: "nested/payload.txt" }),
+			]),
+		);
 	});
 	it("retains a detached legacy artifact root when exact restoration collides", async () => {
 		const { cwd, sessionsRoot, scope } = await fixture();


### PR DESCRIPTION
Fixes #2834.\n\n- adopts strict-resume entries instead of structured cloning\n- uses final identity-only SHA revalidation instead of decode/parse/context rebuild\n- adds privacy-safe synthetic multi-scale RSS evidence and managed-path regressions\n\nVerification: focused session tests, package type check, Biome check, synthetic benchmark.