### PR TITLE
fix(coordinator-mcp): observe broker --worktree turn completion via runtime-authored state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Coordinator MCP `await_turn`/`read_turn` now observe completion for broker-managed `--worktree` sessions. An SDK broker hosts many sessions in one process, so the runtime state sidecar cannot receive a per-session `GJC_COORDINATOR_SESSION_STATE_FILE` env and instead writes its authoritative `agent_end` record to the worktree-local `<cwd>/.gjc/_session-<id>/runtime/runtime-state.json`; the coordinator polled only its own `session-states/<id>.json`, which stayed at the `source: "coordinator"` `running` write from prompt delivery. The durable turn therefore never reached a terminal status, so `await_turn` always timed out and callers fell back to doing the work themselves even though the agent had already answered. When the coordinator's own state is non-terminal, `read_turn` now reads the runtime-authored terminal record directly (path-canonicalized and confined to the session workdir) and surfaces its `state`/`final_response`/`error`, guarding against adopting a stale earlier-turn completion by requiring the runtime completion timestamp to be at or after the turn's start.
+
 ## [0.11.6] - 2026-07-21
 ## [0.11.5] - 2026-07-20
 ### Changed

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -12,6 +12,7 @@ import {
 	type CoordinatorToolName,
 } from "../coordinator/contract";
 import { readLinuxProcStartTimeSync } from "../gjc-runtime/linux-proc";
+import { sessionRuntimeDir } from "../gjc-runtime/session-layout";
 import type { WorkflowGate, WorkflowGateQueryRecord } from "../modes/shared/agent-wire/workflow-gate-types";
 import type { BrokerDiscovery } from "../sdk/broker/discovery";
 import { type EnsureBrokerSettings, ensureBroker } from "../sdk/broker/ensure";
@@ -1584,6 +1585,83 @@ async function markTurnTerminalFromSessionState(
 	return resolved;
 }
 
+/**
+ * Adopt the runtime's authoritative terminal state for a broker-hosted session.
+ *
+ * SDK broker sessions run many sessions inside one broker process, so the runtime
+ * sidecar cannot receive a per-session `GJC_COORDINATOR_SESSION_STATE_FILE` env and
+ * instead writes its `agent_end` record to the worktree-local
+ * `<cwd>/.gjc/_session-<id>/runtime/runtime-state.json`. The coordinator polls its
+ * own `session-states/<id>.json`, which only ever holds the `source: "coordinator"`
+ * `running` write from prompt delivery — so `await_turn`/`read_turn` would never
+ * observe completion and hang until timeout. Read the runtime-authored record
+ * directly and surface it as a coordinator session-state so the normal
+ * terminal-transition path fires with the real `final_response`.
+ */
+async function readAgentAuthoredTerminalSessionState(
+	session: Record<string, unknown>,
+	sessionId: string,
+	turnId: string,
+	notBefore: string | null,
+	canonicalize: (value: string) => Promise<string>,
+): Promise<RuntimeSessionStatePayload | null> {
+	const cwd = optionalString(session.cwd) ?? optionalString(session.broker_workspace);
+	if (!cwd) return null;
+	const candidate = path.join(sessionRuntimeDir(cwd, sessionId), "runtime-state.json");
+	let canonicalRoot: string;
+	let canonicalFile: string;
+	try {
+		canonicalRoot = await canonicalize(cwd);
+		canonicalFile = await canonicalize(candidate);
+	} catch {
+		return null;
+	}
+	if (canonicalFile !== canonicalRoot && !canonicalFile.startsWith(canonicalRoot + path.sep)) return null;
+	const record = asRecord(await readJsonFile(canonicalFile));
+	if (!record) return null;
+	if (optionalString(record.session_id) !== sessionId) return null;
+	if (record.source !== "agent_session_event") return null;
+	const state = optionalString(record.state);
+	if (state !== "completed" && state !== "errored") return null;
+	const endedAt = optionalString(record.ended_at) ?? optionalString(record.updated_at);
+	if (!endedAt) return null;
+	// The runtime-authored record carries no coordinator turn id, so guard against
+	// adopting a stale completion from an earlier turn on a reused session: require
+	// its completion timestamp to be at or after this turn's start (ISO-8601 UTC
+	// strings compare lexicographically).
+	if (notBefore && endedAt < notBefore) return null;
+	const finalResponse = asRecord(record.final_response);
+	const errorRecord = asRecord(record.error);
+	return {
+		schema_version: 1,
+		session_id: sessionId,
+		state,
+		ready_for_input: state === "completed",
+		current_turn_id: turnId,
+		last_turn_id: optionalString(record.last_turn_id),
+		updated_at: endedAt,
+		source: "agent_session_event",
+		live: typeof record.live === "boolean" ? record.live : false,
+		reason: optionalString(record.reason),
+		final_response: finalResponse
+			? {
+					text: optionalString(finalResponse.text),
+					format: "markdown",
+					source: optionalString(finalResponse.source) ?? "agent_session_event",
+					artifact_path: optionalString(finalResponse.artifact_path),
+					truncated: finalResponse.truncated === true,
+				}
+			: undefined,
+		error:
+			state === "errored"
+				? {
+						code: optionalString(errorRecord?.code) ?? "runtime_errored",
+						message: optionalString(errorRecord?.message) ?? "runtime_errored",
+						recoverable: errorRecord?.recoverable !== false,
+					}
+				: null,
+	};
+}
 function runtimeStateAcknowledgesTurn(turn: TurnRecord, sessionState: CoordinatorSessionState | null): boolean {
 	return (
 		sessionState?.source === "agent_session_event" &&
@@ -3060,6 +3138,20 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			resolvedTurn = { ...resolvedTurn, status: "waiting_for_answer", updated_at: timestamp };
 			await writeTurnRecord(namespaceDir, resolvedTurn);
 			await writeActiveTurn(namespaceDir, resolvedTurn);
+		}
+		if (
+			session &&
+			ACTIVE_TURN_STATUSES.has(resolvedTurn.status) &&
+			!(sessionState?.state === "completed" || sessionState?.state === "errored")
+		) {
+			const agentTerminal = await readAgentAuthoredTerminalSessionState(
+				session,
+				resolvedTurn.session_id,
+				resolvedTurn.turn_id,
+				resolvedTurn.started_at ?? resolvedTurn.created_at,
+				services.canonicalizePath ?? (value => fs.realpath(value)),
+			);
+			if (agentTerminal) sessionState = agentTerminal;
 		}
 		if (
 			sessionState &&

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createCoordinatorMcpServer } from "../src/coordinator-mcp/server";
+import { sessionRuntimeDir } from "../src/gjc-runtime/session-layout";
 import { schemaHash } from "../src/modes/shared/agent-wire/workflow-gate-schema";
 import {
 	buildAskGateAnswerSchema,
@@ -2191,4 +2192,137 @@ it("repairs one terminal session without deleting another session's projections"
 		`${String(second.turn_id)}.json`,
 	);
 	await expect(fs.readFile(secondTurnPath, "utf8")).resolves.toContain("other-session");
+});
+
+async function seedBrokerSessionWithActiveTurn(root: string, controls: SdkControl[]) {
+	const server = await createSdkControlServer(root, controls);
+	await registerSdkSession(server, root);
+	// Merge the worktree cwd into the registered session record without clobbering the
+	// incarnation binding that send_prompt requires.
+	const sessionFilePath = path.join(
+		root,
+		".gjc",
+		"coordinator-state",
+		"local",
+		"repo",
+		"sessions",
+		"visible-session.json",
+	);
+	const sessionRecord = JSON.parse(await fs.readFile(sessionFilePath, "utf8")) as Record<string, unknown>;
+	await Bun.write(
+		sessionFilePath,
+		JSON.stringify({
+			...sessionRecord,
+			cwd: sessionRecord.cwd ?? root,
+			broker_workspace: sessionRecord.broker_workspace ?? root,
+		}),
+	);
+	const sent = await server.callTool("gjc_coordinator_send_prompt", {
+		session_id: "visible-session",
+		prompt: "read one file and summarize",
+		idempotency_key: "broker-complete-prompt",
+		allow_mutation: true,
+	});
+	expect(sent).toMatchObject({ ok: true });
+	const turnId = sent.turn_id;
+	if (typeof turnId !== "string") throw new Error("missing durable coordinator turn id");
+	return { server, turnId };
+}
+
+async function writeRuntimeAuthoredState(root: string, overrides: Record<string, unknown>) {
+	await Bun.write(
+		path.join(sessionRuntimeDir(root, "visible-session"), "runtime-state.json"),
+		JSON.stringify({
+			schema_version: 1,
+			session_id: "visible-session",
+			state: "completed",
+			ready_for_input: true,
+			current_turn_id: null,
+			last_turn_id: null,
+			updated_at: "2099-01-01T00:00:00.000Z",
+			ended_at: "2099-01-01T00:00:00.000Z",
+			source: "agent_session_event",
+			event: "agent_end",
+			live: false,
+			reason: null,
+			final_response: {
+				text: "utils/walletSync.ts summary",
+				format: "markdown",
+				source: "agent_end",
+				artifact_path: null,
+				truncated: false,
+			},
+			...overrides,
+		}),
+	);
+}
+
+describe("Coordinator MCP broker turn completion reconciliation", () => {
+	it("adopts the runtime-authored terminal state when the coordinator state is stuck at running", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const { server, turnId } = await seedBrokerSessionWithActiveTurn(root, controls);
+
+		// SDK broker sessions can't receive a per-session state-file env, so the runtime
+		// writes agent_end worktree-local while the coordinator's file stays at running.
+		await writeRuntimeAuthoredState(root, {});
+
+		const read = await server.callTool("gjc_coordinator_read_turn", {
+			turn_id: turnId,
+			session_id: "visible-session",
+		});
+		expect(read).toMatchObject({
+			ok: true,
+			turn: {
+				status: "completed",
+				final_response: { text: "utils/walletSync.ts summary" },
+			},
+		});
+	});
+
+	it("surfaces a runtime-authored errored terminal state as a failed turn", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const { server, turnId } = await seedBrokerSessionWithActiveTurn(root, controls);
+
+		await writeRuntimeAuthoredState(root, {
+			state: "errored",
+			ready_for_input: false,
+			final_response: {
+				text: null,
+				format: "markdown",
+				source: "launch_error",
+				artifact_path: null,
+				truncated: false,
+			},
+			error: { code: "fatal", message: "not a git repository", recoverable: true },
+		});
+
+		const read = await server.callTool("gjc_coordinator_read_turn", {
+			turn_id: turnId,
+			session_id: "visible-session",
+		});
+		expect(read).toMatchObject({
+			ok: true,
+			turn: { status: "failed", error: { code: "fatal" } },
+		});
+	});
+
+	it("ignores a stale runtime completion from an earlier turn on a reused session", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const { server, turnId } = await seedBrokerSessionWithActiveTurn(root, controls);
+
+		// A completion that ended before this turn started must not be adopted.
+		await writeRuntimeAuthoredState(root, {
+			updated_at: "2000-01-01T00:00:00.000Z",
+			ended_at: "2000-01-01T00:00:00.000Z",
+		});
+
+		const read = await server.callTool("gjc_coordinator_read_turn", {
+			turn_id: turnId,
+			session_id: "visible-session",
+		});
+		expect(read).toMatchObject({ ok: true, turn: { status: "active" } });
+	});
 });


### PR DESCRIPTION
## What

Coordinator MCP `await_turn`/`read_turn` now observe completion for broker-managed `--worktree` sessions. Previously the durable turn stayed `active` forever: `await_turn` always timed out and external callers fell back to doing the work themselves **even though the agent had already produced the answer** (~6s in).

## Why

An SDK broker hosts many sessions in **one** process, so the runtime state sidecar cannot receive a per-session `GJC_COORDINATOR_SESSION_STATE_FILE` env — that env-handoff only works for the one-process-per-session tmux path. `runtimeStateFileForContext` therefore falls back to writing the authoritative `agent_end` record to the **worktree-local** `<cwd>/.gjc/_session-<id>/runtime/runtime-state.json`. The coordinator polls only its own `session-states/<id>.json`, which holds just the `source: "coordinator"` `running` write from prompt delivery, so `markTurnTerminalFromSessionState` never fires and the turn never reaches a terminal status.

Observed end-to-end (Slack → Hermes → GJC bridge):

| | coordinator polls | agent actually wrote |
|---|---|---|
| path | `session-states/<id>.json` | `<cwd>/.gjc/_session-<id>/runtime/runtime-state.json` |
| state | `running` (source: coordinator) | **`completed`, event `agent_end`, with `final_response`** |

## How

When the coordinator's own session-state is non-terminal, `read_turn` now reads the runtime-authored record directly and surfaces it as a coordinator session-state so the **existing** terminal-transition path runs with the real `final_response`/`error`:

- New `readAgentAuthoredTerminalSessionState` computes the canonical `sessionRuntimeDir(session.cwd, id)/runtime-state.json`, canonicalizes it, and confines it within the session workdir (rejects symlink escapes).
- Adopts only `source: "agent_session_event"` records in a terminal (`completed`/`errored`) state whose completion timestamp is **at or after the turn's start**, guarding against adopting a stale earlier-turn completion on a reused session (the runtime record carries no coordinator turn id).
- Runtime turn/session identity checks and downstream terminal projection (`markTurnTerminalFromSessionState` → `projectTerminalTransition`) are unchanged; the fix only feeds the gate an authoritative terminal state it otherwise never receives on the broker path.

## Testing

- New regression tests in `test/coordinator-mcp-server.test.ts`:
  - broker session stuck at `running` is adopted as `completed` with the runtime `final_response`;
  - a runtime `errored` record surfaces as a `failed` turn;
  - a stale earlier-turn completion is ignored (turn stays `active`).
- Confirmed load-bearing: reverting the fix fails the two adoption tests.
- `bun test test/coordinator-mcp-server.test.ts` → 55 pass; `bun run check` (biome + `tsc --noEmit`) clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)