### PR TITLE
fix(coding-agent): repair dev lifecycle CI

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -4609,12 +4609,14 @@ export class SessionManager {
 		const previousDestination = this.destination;
 		const previousArtifactDir = previousSessionFile?.slice(0, -6);
 
-		const nextDestination = (() => {
-			if (this.destination.kind === "managed") {
-				return managedDestination(resolvedCwd, this.storage, this.destination.securityContext.agentDir);
-			}
-			return this.destination;
-		})();
+		const nextDestination =
+			this.storage instanceof FileSessionStorage
+				? managedDestination(
+						resolvedCwd,
+						this.storage,
+						this.destination.kind === "managed" ? this.destination.securityContext.agentDir : undefined,
+					)
+				: this.destination;
 		const newSessionDir = nextDestination.directory;
 		let hadSessionFile = false;
 		const managedMove = this.destination.kind === "managed" && nextDestination.kind === "managed";

--- a/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
@@ -22,7 +22,7 @@ import {
 import type { LedgerEntry, OrchestratorDeps } from "@gajae-code/coding-agent/sdk/bus/lifecycle-orchestrator";
 import { startDaemonLifecycleControl } from "@gajae-code/coding-agent/sdk/bus/telegram-daemon";
 import * as native from "@gajae-code/natives";
-import { logger } from "@gajae-code/utils";
+import { getConfigRootDir, logger } from "@gajae-code/utils";
 import { Settings } from "../src/config/settings";
 import { tokenFingerprint } from "../src/sdk/bus/config";
 import { acquireDaemonOwnership, TelegramNotificationDaemon } from "../src/sdk/bus/telegram-daemon";
@@ -38,6 +38,14 @@ function secureOwnerOnlyFile(pathname: string): void {
 	if (!applied.ok) throw new Error(`Owner-only security rejected ${pathname}: ${applied.code}`);
 	const verified = native.verifyOwnerOnlyPathSecurity(pathname, "file") as NativeSecurity;
 	if (!verified.ok) throw new Error(`Owner-only security rejected ${pathname}: ${verified.code}`);
+}
+
+function managedFixtureRoot(prefix: string): string {
+	const fixturesRoot = path.join(getConfigRootDir(), "test-fixtures");
+	fs.mkdirSync(fixturesRoot, { recursive: true, mode: 0o700 });
+	const applied = native.applyOwnerOnlyPathSecurity(fixturesRoot, "directory") as NativeSecurity;
+	if (!applied.ok) throw new Error(`Owner-only security rejected ${fixturesRoot}: ${applied.code}`);
+	return fs.mkdtempSync(path.join(fixturesRoot, prefix));
 }
 
 function writeManagedSession(sessionsRoot: string, cwd: string, sessionId: string): void {
@@ -1134,7 +1142,7 @@ describe("lifecycle control runtime", () => {
 	});
 
 	posixTmuxIt("daemonResumeSession fails closed against saved history (notFound / ambiguous)", async () => {
-		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-resume-"));
+		const root = managedFixtureRoot("gjc-resume-");
 		const proj = path.join(root, "proj");
 		fs.mkdirSync(proj, { recursive: true });
 		await writeManagedSession(root, proj, "abc111");
@@ -1164,7 +1172,7 @@ describe("lifecycle control runtime", () => {
 	});
 
 	posixTmuxIt("daemonResumeSession cold-restarts saved sessions from their recorded cwd", async () => {
-		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-resume-cwd-"));
+		const root = managedFixtureRoot("gjc-resume-cwd-");
 		const proj = path.join(root, "saved-project");
 		const callsFile = path.join(root, "tmux-calls.log");
 		const serverState = path.join(root, "tmux-server-started");
@@ -1529,7 +1537,7 @@ describe("lifecycle control runtime", () => {
 	posixTmuxIt(
 		"refuses unsafe or unverifiable servers before daemon create or cold-resume can mutate tmux",
 		async () => {
-			const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-pre-mutation-refusal-"));
+			const root = managedFixtureRoot("gjc-pre-mutation-refusal-");
 			const project = path.join(root, "project");
 			const callsFile = path.join(root, "tmux-calls.log");
 			const tmux = path.join(root, "fake-tmux.sh");
@@ -1643,7 +1651,7 @@ describe("lifecycle control runtime", () => {
 	posixTmuxIt(
 		"writes no cold-resume ownership tags when a replacement server reuses the native session before metadata",
 		async () => {
-			const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-cold-resume-metadata-"));
+			const root = managedFixtureRoot("gjc-cold-resume-metadata-");
 			const project = path.join(root, "project");
 			const callsFile = path.join(root, "tmux-calls.log");
 			const tmux = path.join(root, "fake-tmux.sh");
@@ -1702,7 +1710,7 @@ describe("lifecycle control runtime", () => {
 	);
 
 	posixTmuxIt("refuses psmux before create or cold-resume can mutate lifecycle state", async () => {
-		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-lifecycle-psmux-"));
+		const root = managedFixtureRoot("gjc-lifecycle-psmux-");
 		const project = path.join(root, "project");
 		const psmux = path.join(root, "psmux");
 		const plain = path.join(root, "plain");

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -11,6 +11,14 @@ import { SessionManager } from "@gajae-code/coding-agent/session/session-manager
 import { Snowflake } from "@gajae-code/utils";
 import * as z from "zod/v4";
 
+const authStorages: AuthStorage[] = [];
+
+async function createIsolatedAuthStorage(tempDir: string): Promise<AuthStorage> {
+	const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+	authStorages.push(authStorage);
+	return authStorage;
+}
+
 const toolActivationExtension: ExtensionFactory = pi => {
 	pi.registerTool({
 		name: "default_inactive_tool",
@@ -61,10 +69,12 @@ async function createMinimalSession(
 	// outside this activation contract. Keep the focused harness process-free and
 	// cover recipe discovery in its dedicated suite.
 	settings.override("recipe.enabled", false);
+	const authStorage = await createIsolatedAuthStorage(tempDir);
 	return createAgentSession({
 		cwd: tempDir,
 		agentDir: tempDir,
 		sessionManager,
+		authStorage,
 		settings,
 		model: getBundledModel("openai", "gpt-4o-mini"),
 		disableExtensionDiscovery: true,
@@ -84,14 +94,13 @@ async function createMinimalSession(
 
 describe("createAgentSession defaultInactive tool activation", () => {
 	const tempDirs: string[] = [];
-	const authStorages: AuthStorage[] = [];
 
 	afterEach(() => {
-		for (const tempDir of tempDirs.splice(0)) {
-			fs.rmSync(tempDir, { recursive: true, force: true });
-		}
 		for (const authStorage of authStorages.splice(0)) {
 			authStorage.close();
+		}
+		for (const tempDir of tempDirs.splice(0)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
 		vi.restoreAllMocks();
 	});
@@ -334,6 +343,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
+			authStorage: await createIsolatedAuthStorage(tempDir),
 			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated(),
 			model: getBundledModel("openai", "gpt-4o-mini"),
@@ -368,6 +378,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
+			authStorage: await createIsolatedAuthStorage(tempDir),
 			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated(),
 			model: getBundledModel("openai", "gpt-4o-mini"),
@@ -400,6 +411,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		const { session, mcpManager } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
+			authStorage: await createIsolatedAuthStorage(tempDir),
 			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated({
 				"astGrep.enabled": true,
@@ -448,6 +460,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
+			authStorage: await createIsolatedAuthStorage(tempDir),
 			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated({ "edit.mode": "vim" }),
 			model: getBundledModel("openai", "gpt-4o-mini"),

--- a/packages/coding-agent/test/session-resident-lifecycle.test.ts
+++ b/packages/coding-agent/test/session-resident-lifecycle.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import type { AssistantMessage } from "@gajae-code/ai";
 import { exportSessionToHtml } from "@gajae-code/coding-agent/export/html";
 import { SessionManager, type SessionMessageEntry } from "@gajae-code/coding-agent/session/session-manager";
 import * as native from "@gajae-code/natives";
+import { getConfigRootDir } from "@gajae-code/utils";
 
 const tempDirs: string[] = [];
 afterEach(async () => {
@@ -14,7 +14,9 @@ afterEach(async () => {
 });
 
 function tempRoot(prefix = "gjc-resident-life-"): string {
-	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	const parent = getConfigRootDir();
+	fs.mkdirSync(parent, { recursive: true, mode: 0o700 });
+	const dir = fs.mkdtempSync(path.join(parent, prefix));
 	tempDirs.push(dir);
 	return dir;
 }


### PR DESCRIPTION
## Summary
- restore managed destination publication for file-backed session moves
- isolate owner-only lifecycle and resident fixtures beneath owner-controlled ancestry
- isolate and close auth SQLite stores in defaultInactive activation coverage

## Verification
- bun test test/notifications-lifecycle-control-runtime.test.ts test/session-manager/move-to.test.ts test/session-resident-lifecycle.test.ts
- bun test test/sdk-tool-activation.test.ts (3 runs)
- bun test test/session-manager
- bun test test/auth-storage-if-absent.test.ts test/issue-490-repro.test.ts
- bun run check