### PR TITLE
fix(coding-agent): keep managed resume persistence inside the origin scope

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -7747,7 +7747,7 @@ export class SessionManager {
 		destinationInput?: SessionDestinationInput,
 		storage: SessionStorage = new FileSessionStorage(),
 	): Promise<RecoveryHydrationOpenResult> {
-		const destination =
+		let destination =
 			destinationInput === undefined
 				? explicitDestination(path.dirname(identity.canonicalPath))
 				: destinationFor(getProjectDir(), destinationInput, storage);
@@ -7757,6 +7757,17 @@ export class SessionManager {
 		if (inspected.migrationApplied) return { kind: "error", reason: "migration-required" };
 
 		const header = inspected.entries[0] as SessionHeader;
+		if (
+			destination.kind === "managed" &&
+			storage instanceof FileSessionStorage &&
+			header.cwd &&
+			path.resolve(path.dirname(identity.canonicalPath)) !== path.resolve(destination.directory)
+		) {
+			// Retarget a cross-scope resume (e.g. teammate/worktree session opened from
+			// another directory) to the session file's own managed scope so persistence
+			// stays inside the session directory instead of aborting.
+			destination = managedDestination(header.cwd, storage, destination.securityContext.agentDir);
+		}
 		const manager = new SessionManager(
 			header.cwd || getProjectDir(),
 			destination.directory,
@@ -7808,7 +7819,7 @@ export class SessionManager {
 		storage: SessionStorage = new FileSessionStorage(),
 		migrationPolicy: SessionDirectoryMigrationPolicy = "copy-retain",
 	): Promise<StrictSessionOpenResult> {
-		const destination =
+		let destination =
 			destinationInput === undefined
 				? explicitDestination(path.dirname(identity.canonicalPath))
 				: destinationFor(getProjectDir(), destinationInput, storage);
@@ -7840,6 +7851,19 @@ export class SessionManager {
 
 		const entries = inspected.entries;
 		const header = entries[0] as SessionHeader;
+		if (
+			destination.kind === "managed" &&
+			storage instanceof FileSessionStorage &&
+			header.cwd &&
+			path.resolve(path.dirname(sessionPath)) !== path.resolve(destination.directory)
+		) {
+			// The resumed session file lives under its origin managed scope, which can
+			// differ from the scope derived from the current working directory (e.g. a
+			// teammate/worktree session resumed by a controller in a different directory).
+			// Retarget the destination to the file's own scope so managed-transcript
+			// persistence stays inside the session directory instead of aborting.
+			destination = managedDestination(header.cwd, storage, destination.securityContext.agentDir);
+		}
 		const dir = destination.directory;
 		const manager = new SessionManager(header.cwd || getProjectDir(), dir, true, storage, destination);
 		await manager.#hydrateExistingSession(sessionPath, entries, inspected.migrationApplied);

--- a/packages/coding-agent/test/session-manager-managed-cross-scope-resume.test.ts
+++ b/packages/coding-agent/test/session-manager-managed-cross-scope-resume.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import * as fsSync from "node:fs";
+import * as path from "node:path";
+import { type ConfiguredModelChain, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+
+function chain(entries: string[], origin = "startup-profile"): ConfiguredModelChain {
+	return {
+		role: "default",
+		entries,
+		origin,
+		identity: "profile-id",
+		explicitHead: true,
+	};
+}
+
+describe("SessionManager managed cross-scope resume", () => {
+	// Regression: resuming a managed session from a working directory whose
+	// managed scope differs from where the session file actually lives (e.g. a
+	// teammate/worktree session resumed by a controller in another directory)
+	// used to abort the process with "Managed transcript escaped its session
+	// directory" on the first persist (such as startup model-profile activation).
+	it("persists after resume from a different working directory", async () => {
+		using tempDir = TempDir.createSync("@pi-session-managed-cross-scope-resume-");
+		const agentDir = tempDir.path();
+		const cwdA = path.join(agentDir, "projA");
+		const cwdB = path.join(agentDir, "projB");
+		fsSync.mkdirSync(cwdA);
+		fsSync.mkdirSync(cwdB);
+
+		const originDestination = SessionManager.managedDestination(cwdA, agentDir);
+		const creator = SessionManager.create(cwdA, originDestination);
+		creator.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		await creator.ensureOnDisk();
+		await creator.flush();
+		const sessionFile = creator.getSessionFile();
+		if (!sessionFile) throw new Error("Expected managed session file");
+		await creator.close();
+
+		// The resume scope is derived from cwdB and does not own the session file.
+		const resumeDestination = SessionManager.managedDestination(cwdB, agentDir);
+		expect(path.resolve(path.dirname(sessionFile))).not.toBe(path.resolve(resumeDestination.directory));
+
+		const reopened = await SessionManager.open(sessionFile, resumeDestination);
+		try {
+			expect(() => reopened.appendConfiguredModelChain(chain(["anthropic/claude", "openai/gpt"]))).not.toThrow();
+			await reopened.flush();
+			// The record must land in the origin session file, not the resume scope.
+			expect(fsSync.readFileSync(sessionFile, "utf8")).toContain("configured_model_chain");
+		} finally {
+			await reopened.close();
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Team/subagent (and any separately-launched managed agent) processes crash at **startup** with an uncaught exception, so the launched agent dies before doing any work:

```
Error: Managed transcript escaped its session directory
  at #managedTranscriptStore   session-manager.ts
  at #appendManagedRecordSync
  at _persist
  at #appendEntry
  at appendConfiguredModelChain
  at setConfiguredModelChain    agent-session.ts
  at applyPreparedModelProfileActivation
  at activateModelProfile
  at applyStartupModelProfilesForRoot   main.ts
```

### Root cause

When a managed session is resumed, the destination is computed from `getProjectDir()` (the resuming process's working directory), e.g. in `main.ts`:

```ts
SessionManager.openExistingStrict(
  selection.identity,
  SessionManager.managedDestination(resumeCwd, settings.getAgentDir()),
  ...
)
```

But the resumed session file still lives under its **origin** managed scope (`v2-<digest(originCwd)>`). If `resumeCwd` maps to a different scope than the session's origin (e.g. a controller resuming a teammate's worktree session from another directory), then `path.dirname(sessionFile) !== destination.directory`.

The first persist — commonly startup model-profile activation appending a `configured_model_chain` entry — then hits the "Managed transcript escaped its session directory" authority guard in `#managedTranscriptStore`, which throws as an **uncaught exception** and kills the process.

## Fix

In `openExistingStrict` and `openExistingForRecoveryHydrationStrict`, when a managed resume would otherwise diverge from the session file's own directory, retarget the destination to the file's origin managed scope (derived from the header `cwd`). Managed-transcript persistence then stays inside the session directory. The authority guard remains as a backstop.

## Testing

Added `test/session-manager-managed-cross-scope-resume.test.ts`, which creates a managed session in scope A, resumes it from scope B, and asserts the first `appendConfiguredModelChain` persist succeeds with the record landing in the origin file.

- Without the fix: fails with `Managed transcript escaped its session directory`.
- With the fix: passes.

No regressions across the session-manager / resume suites — pre-existing pass/fail counts are identical with and without the change.
