### PR TITLE
fix(coding-agent): reject stale OAuth auto-imports

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.
+- `gjc setup credentials` now auto-imports only OAuth credentials with a finite expiry strictly in the future. Expired or malformed-expiry discoveries remain visible as non-importable records, and existing imported credentials remain recoverable through `/login`.
 - Resumed managed sessions now complete the verified legacy `local://` artifact migration before synchronous path resolution, preserving legacy scratch files instead of failing startup with a migration-order error.
 - Corrected Telegram's uncertain lifecycle guidance so create, close, and resume commands describe their own possible outcome; close and resume no longer display the create-only duplicate-start warning.
 

--- a/packages/coding-agent/src/cli/setup-cli.ts
+++ b/packages/coding-agent/src/cli/setup-cli.ts
@@ -18,7 +18,11 @@ import {
 } from "../hooks/codex-native-hooks-config";
 import { theme } from "../modes/theme/theme";
 import { formatCredentialAutoImportResult, runExternalCredentialAutoImport } from "../setup/credential-auto-import";
-import { filterAutoImportOAuthCredentials, formatDiscoverySummary } from "../setup/credential-import";
+import {
+	formatDiscoverySummary,
+	getAutoImportOAuthCredentialSkips,
+	isAutoImportOAuthCredential,
+} from "../setup/credential-import";
 import {
 	formatHermesSetupResult,
 	type HermesSetupFlags,
@@ -596,8 +600,10 @@ export async function handleCredentialsSetup(
 			trigger: "setup-cli",
 		});
 		const result = preview.discovery ?? { importable: [], skipped: [], environment: [] };
-		const candidates = filterAutoImportOAuthCredentials(result.importable);
-		const filteredResult = { ...result, importable: candidates };
+		const now = Date.now();
+		const candidates = result.importable.filter(credential => isAutoImportOAuthCredential(credential, now));
+		const autoImportSkips = getAutoImportOAuthCredentialSkips(result.importable, now);
+		const filteredResult = { ...result, importable: candidates, skipped: [...result.skipped, ...autoImportSkips] };
 		const redactedPlan = {
 			importable: candidates.map(c => ({
 				provider: c.provider,
@@ -607,7 +613,7 @@ export async function handleCredentialsSetup(
 				expiresAt: c.expiresAt,
 				redactedToken: c.redactedToken,
 			})),
-			skipped: result.skipped,
+			skipped: filteredResult.skipped,
 			environment: result.environment,
 			keychainChecked: flags.keychain === true,
 		};

--- a/packages/coding-agent/src/setup/credential-import.ts
+++ b/packages/coding-agent/src/setup/credential-import.ts
@@ -391,7 +391,7 @@ export function formatCredentialSummary(credential: ImportableCredential): strin
 	const identityPart = identity ? ` ${identity}` : "";
 	let expiry = "";
 	if (credential.kind === "oauth" && credential.expiresAt !== undefined) {
-		expiry = credential.expiresAt < Date.now() ? " [expired]" : "";
+		expiry = credential.expiresAt <= Date.now() ? " [expired]" : "";
 	}
 	return `${provider} · ${kind}${identityPart} · token ${credential.redactedToken}${expiry} (from ${credential.source})`;
 }
@@ -413,7 +413,10 @@ export function formatDiscoverySummary(result: CredentialDiscoveryResult): strin
 	return lines;
 }
 
-export function isAutoImportOAuthCredential(credential: ImportableCredential): boolean {
+/** Reason shown when automatic OAuth import rejects an unusable discovery record. */
+export const INVALID_AUTO_IMPORT_OAUTH_EXPIRY_REASON = "OAuth credential has no valid future expiry";
+
+function hasAutoImportOAuthProviderOrigin(credential: ImportableCredential): boolean {
 	return (
 		AUTO_IMPORT_OAUTH_PROVIDER_ORIGINS[credential.provider]?.has(credential.origin) === true &&
 		credential.kind === "oauth" &&
@@ -421,8 +424,30 @@ export function isAutoImportOAuthCredential(credential: ImportableCredential): b
 	);
 }
 
+export function isAutoImportOAuthCredential(credential: ImportableCredential, now: number = Date.now()): boolean {
+	return (
+		hasAutoImportOAuthProviderOrigin(credential) &&
+		typeof credential.expiresAt === "number" &&
+		Number.isFinite(credential.expiresAt) &&
+		credential.expiresAt > now
+	);
+}
+
+/** Keep rejected OAuth discoveries visible to operators without offering them for automatic import. */
+export function getAutoImportOAuthCredentialSkips(
+	credentials: readonly ImportableCredential[],
+	now: number = Date.now(),
+): SkippedCredential[] {
+	return credentials.flatMap(credential =>
+		hasAutoImportOAuthProviderOrigin(credential) && !isAutoImportOAuthCredential(credential, now)
+			? [{ origin: credential.origin, source: credential.source, reason: INVALID_AUTO_IMPORT_OAUTH_EXPIRY_REASON }]
+			: [],
+	);
+}
+
 export function filterAutoImportOAuthCredentials(credentials: readonly ImportableCredential[]): ImportableCredential[] {
-	return credentials.filter(isAutoImportOAuthCredential);
+	const now = Date.now();
+	return credentials.filter(credential => isAutoImportOAuthCredential(credential, now));
 }
 
 /**

--- a/packages/coding-agent/test/credential-auto-import-flows.test.ts
+++ b/packages/coding-agent/test/credential-auto-import-flows.test.ts
@@ -41,6 +41,7 @@ function oauthCredential(overrides: Partial<ImportableCredential> = {}): Importa
 		origin: "claude-code-file",
 		source: "Claude Code (test)",
 		kind: "oauth",
+		expiresAt: Date.now() + 60_000,
 		redactedToken: "sk-a…oken",
 		credential: { type: "oauth", access: "a", refresh: "r", expires: Date.now() + 60_000 },
 		...overrides,
@@ -793,6 +794,24 @@ describe("setup credentials keychain and preview behavior", () => {
 		const payload = JSON.parse(stdout.trim());
 		expect(payload.importable).toEqual([]);
 		expect(JSON.stringify(payload)).not.toContain("api_key");
+	});
+
+	test("setup dry-run keeps expired OAuth discoveries visible but non-importable", async () => {
+		const reads = { discover: 0, keychain: 0 };
+		const expired = oauthCredential({
+			expiresAt: 0,
+			credential: { type: "oauth", access: "expired-access", refresh: "expired-refresh", expires: 0 },
+		});
+		await handleCredentialsSetup({ json: true, dryRun: true }, deps(reads, discovery([expired])));
+		const payload = JSON.parse(stdout.trim());
+		expect(payload.importable).toEqual([]);
+		expect(payload.skipped).toEqual([
+			expect.objectContaining({
+				source: "Claude Code (test)",
+				reason: "OAuth credential has no valid future expiry",
+			}),
+		]);
+		expect(payload.imported).toEqual([]);
 	});
 
 	test("denied keychain read records sanitized skip and continues", async () => {

--- a/packages/coding-agent/test/credential-import.test.ts
+++ b/packages/coding-agent/test/credential-import.test.ts
@@ -16,6 +16,7 @@ import {
 	filterAutoImportOAuthCredentials,
 	formatCredentialSummary,
 	formatDiscoverySummary,
+	getAutoImportOAuthCredentialSkips,
 	importCredentials,
 	isAutoImportOAuthCredential,
 } from "../src/setup/credential-import";
@@ -419,47 +420,34 @@ describe("auto-import OAuth filter and orchestrator", () => {
 			origin: "claude-code-file" as const,
 			source: "Claude Code (test)",
 			kind: "oauth" as const,
+			expiresAt: Date.now() + 60_000,
 			redactedToken: "sk-a…oken",
-			credential: { type: "oauth" as const, access: "a", refresh: "r", expires: Date.now() },
+			credential: { type: "oauth" as const, access: "a", refresh: "r", expires: Date.now() + 60_000 },
 			...overrides,
 		};
 	}
 
-	test("OAuth-only accept/reject matrix", () => {
-		const accepted = [
-			oauthCredential(),
-			oauthCredential({ origin: "claude-code-keychain", source: "Claude Code (macOS Keychain)" }),
-			oauthCredential({ provider: "openai-codex", origin: "codex-file", source: "Codex CLI (~/.codex/auth.json)" }),
-		];
+	test("auto-import requires a finite OAuth expiry strictly after the captured clock", () => {
+		const now = 1_000;
+		const futureClaude = oauthCredential();
+		const futureCodex = oauthCredential({ provider: "openai-codex", origin: "codex-file" });
 		const rejected = [
-			oauthCredential({
-				provider: "openai-codex",
-				origin: "codex-file",
-				kind: "api_key",
-				credential: { type: "api_key", key: "k" },
-			}),
-			oauthCredential({
-				provider: "anthropic",
-				origin: "claude-code-file",
-				kind: "oauth",
-				credential: { type: "api_key", key: "k" },
-			}),
-			oauthCredential({
-				provider: "anthropic",
-				origin: "claude-code-keychain",
-				kind: "api_key",
-				credential: { type: "api_key", key: "k" },
-			}),
-			oauthCredential({
-				provider: "openai-codex",
-				origin: "codex-file",
-				kind: "oauth",
-				credential: { type: "api_key", key: "k" },
-			}),
+			oauthCredential({ expiresAt: undefined }),
+			oauthCredential({ expiresAt: Number.NaN }),
+			oauthCredential({ expiresAt: 0 }),
+			oauthCredential({ expiresAt: now }),
+			oauthCredential({ expiresAt: now - 1 }),
+			oauthCredential({ provider: "openai-codex", origin: "codex-file", expiresAt: undefined }),
 		];
-		for (const credential of accepted) expect(isAutoImportOAuthCredential(credential)).toBe(true);
-		for (const credential of rejected) expect(isAutoImportOAuthCredential(credential)).toBe(false);
-		expect(filterAutoImportOAuthCredentials([...accepted, ...rejected])).toEqual(accepted);
+
+		for (const credential of [futureClaude, futureCodex])
+			expect(isAutoImportOAuthCredential(credential, now)).toBe(true);
+		for (const credential of rejected) expect(isAutoImportOAuthCredential(credential, now)).toBe(false);
+		expect(getAutoImportOAuthCredentialSkips([...rejected, futureClaude], now)).toHaveLength(rejected.length);
+		expect(filterAutoImportOAuthCredentials([...rejected, futureClaude, futureCodex])).toEqual([
+			futureClaude,
+			futureCodex,
+		]);
 	});
 
 	test("provider-origin pairings reject impossible source/provider combinations", () => {
@@ -470,12 +458,12 @@ describe("auto-import OAuth filter and orchestrator", () => {
 		const invalidCodexClaudeFile = oauthCredential({ provider: "openai-codex", origin: "claude-code-file" });
 		const invalidCodexClaudeKeychain = oauthCredential({ provider: "openai-codex", origin: "claude-code-keychain" });
 
-		expect(isAutoImportOAuthCredential(validAnthropicFile)).toBe(true);
-		expect(isAutoImportOAuthCredential(validAnthropicKeychain)).toBe(true);
-		expect(isAutoImportOAuthCredential(validCodexFile)).toBe(true);
-		expect(isAutoImportOAuthCredential(invalidAnthropicCodexFile)).toBe(false);
-		expect(isAutoImportOAuthCredential(invalidCodexClaudeFile)).toBe(false);
-		expect(isAutoImportOAuthCredential(invalidCodexClaudeKeychain)).toBe(false);
+		expect(isAutoImportOAuthCredential(validAnthropicFile, 1_000)).toBe(true);
+		expect(isAutoImportOAuthCredential(validAnthropicKeychain, 1_000)).toBe(true);
+		expect(isAutoImportOAuthCredential(validCodexFile, 1_000)).toBe(true);
+		expect(isAutoImportOAuthCredential(invalidAnthropicCodexFile, 1_000)).toBe(false);
+		expect(isAutoImportOAuthCredential(invalidCodexClaudeFile, 1_000)).toBe(false);
+		expect(isAutoImportOAuthCredential(invalidCodexClaudeKeychain, 1_000)).toBe(false);
 		expect(
 			filterAutoImportOAuthCredentials([
 				validAnthropicFile,
@@ -504,6 +492,26 @@ describe("auto-import OAuth filter and orchestrator", () => {
 		expect(calls).toEqual(["anthropic"]);
 		expect(result.imported).toEqual([credential]);
 		expect(result.discovered).toBe(true);
+	});
+	test("orchestrator leaves expired discoveries available for UI inspection without importing them", async () => {
+		const expired = oauthCredential({
+			expiresAt: 0,
+			credential: { type: "oauth", access: "a", refresh: "r", expires: 0 },
+		});
+		const calls: string[] = [];
+		const result = await runExternalCredentialAutoImport({
+			authStorage: {
+				importCredentialIfAbsent: async (provider: string) => {
+					calls.push(provider);
+					return { inserted: true, reason: "inserted", provider, entries: [] };
+				},
+			},
+			discover: async () => ({ importable: [expired], skipped: [], environment: [] }),
+			trigger: "startup",
+		});
+		expect(calls).toEqual([]);
+		expect(result.imported).toEqual([]);
+		expect(result.discovery?.importable).toEqual([expired]);
 	});
 
 	test("notice is emitted only when imported and includes exact rotation warning", () => {


### PR DESCRIPTION
## Summary
- require a finite OAuth expiry strictly after one captured clock for automatic Claude/Codex imports
- retain rejected discoveries as redacted non-importable records in setup dry-run JSON/text and the TUI-facing discovery result
- cover missing, non-finite, zero, equal, expired, and future expiry states

Closes #2817.

## Verification
- `bun test packages/coding-agent/test/credential-import.test.ts packages/coding-agent/test/credential-auto-import-flows.test.ts`
- `bunx biome check packages/coding-agent/src/setup/credential-import.ts packages/coding-agent/src/cli/setup-cli.ts packages/coding-agent/test/credential-import.test.ts packages/coding-agent/test/credential-auto-import-flows.test.ts`

Signed-off-by: GJC <gjc@local>