### PR TITLE
feat(coding-agent): make status action hints configurable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 
 - `/btw` now opens an ephemeral multi-turn side chat: plain text continues the side thread until Esc returns to the main chat, while visible text-only context stays outside the main transcript and session observability/debug hooks and is scrubbed synchronously on close or abort.
+- Added `statusLine.showActionHints` (default: `true`) to hide contextual action hints while retaining configured status-line segments.
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -819,6 +819,15 @@ export const SETTINGS_SCHEMA = {
 		type: "boolean",
 		default: true,
 	},
+	"statusLine.showActionHints": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "appearance",
+			label: "Status Line Action Hints",
+			description: "Show contextual keyboard shortcuts in the status line",
+		},
+	},
 
 	"statusLine.leftSegments": { type: "array", default: [] as StatusLineSegmentId[] },
 
@@ -3740,6 +3749,7 @@ export interface StatusLineSettings {
 	maxRows: number;
 	showHookStatus: boolean;
 	showSkillHud: boolean;
+	showActionHints: boolean;
 	leftSegments: StatusLineSegmentId[];
 	rightSegments: StatusLineSegmentId[];
 	segmentOptions: Record<string, unknown>;

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -46,6 +46,7 @@ export interface StatusLineSettings {
 	previewHighlightSegment?: StatusLineSegmentId;
 	showHookStatus?: boolean;
 	showSkillHud?: boolean;
+	showActionHints?: boolean;
 	sessionAccent?: boolean;
 	maxRows?: number;
 }
@@ -199,6 +200,7 @@ export class StatusLineComponent implements Component {
 			separator: settings.get("statusLine.separator"),
 			showHookStatus: settings.get("statusLine.showHookStatus"),
 			showSkillHud: settings.get("statusLine.showSkillHud"),
+			showActionHints: settings.get("statusLine.showActionHints"),
 			segmentOptions: settings.getGroup("statusLine").segmentOptions,
 			sessionAccent: settings.get("statusLine.sessionAccent"),
 			maxRows: settings.get("statusLine.maxRows"),
@@ -791,7 +793,10 @@ export class StatusLineComponent implements Component {
 		}
 
 		const right: string[] = [];
-		const actionHints = getAvailableActionHints(this.#actionRegistry, this.#getKeybindings, width, this.#focusDomain);
+		const actionHints =
+			effectiveSettings.showActionHints === false
+				? []
+				: getAvailableActionHints(this.#actionRegistry, this.#getKeybindings, width, this.#focusDomain);
 		for (const segId of effectiveSettings.rightSegments) {
 			const rendered = renderSegment(segId, ctx);
 			if (rendered.visible && rendered.content) {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -190,6 +190,7 @@ export function buildStatusLineSettings(settingsInstance: Settings): StatusLineS
 		rightSegments: settingsInstance.get("statusLine.rightSegments"),
 		separator: settingsInstance.get("statusLine.separator"),
 		showHookStatus: settingsInstance.get("statusLine.showHookStatus"),
+		showActionHints: settingsInstance.get("statusLine.showActionHints"),
 		sessionAccent: settingsInstance.get("statusLine.sessionAccent"),
 		maxRows: settingsInstance.get("statusLine.maxRows"),
 		segmentOptions: settingsInstance.get("statusLine.segmentOptions"),
@@ -1516,6 +1517,7 @@ export class SelectorController {
 			case "statusLine.separator":
 			case "statusLineShowHooks":
 			case "statusLine.showHookStatus":
+			case "statusLine.showActionHints":
 			case "statusLine.sessionAccent":
 			case "statusLine.maxRows":
 			case "statusLine.leftSegments":

--- a/packages/coding-agent/test/status-line-hints.test.ts
+++ b/packages/coding-agent/test/status-line-hints.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, it } from "bun:test";
 import { visibleWidth } from "@gajae-code/tui";
 import { formatKeyHints, KEYBINDINGS, KeybindingsManager } from "../src/config/keybindings";
 import { resetSettingsForTest, Settings } from "../src/config/settings";
+import { SETTINGS_SCHEMA } from "../src/config/settings-schema";
 import { ActionRegistry } from "../src/modes/action-registry";
 import { getAvailableActionHints, StatusLineComponent } from "../src/modes/components/tool-status-header";
 import { initTheme } from "../src/modes/theme/theme";
@@ -110,6 +111,28 @@ describe("status line action hints", () => {
 		expect(streamingStatus).toContain("Queue message");
 		expect(streamingStatus).not.toContain("Open command palette");
 		expect(visibleWidth(streamingStatus)).toBeLessThanOrEqual(120);
+	});
+
+	it("hides contextual hints without suppressing configured status segments", () => {
+		expect(SETTINGS_SCHEMA["statusLine.showActionHints"].default).toBe(true);
+		const registry = new ActionRegistry<void>({ context: undefined, showError: () => {} });
+		registerAction(registry, "app.model.select", () => true);
+		const component = new StatusLineComponent(createSession(), {
+			actionRegistry: registry,
+			getKeybindings: () => KeybindingsManager.inMemory(),
+		});
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: [],
+			rightSegments: ["model"],
+			separator: "pipe",
+			showActionHints: false,
+			showSkillHud: false,
+		});
+
+		const rendered = component.render(120).join("\n");
+		expect(rendered).toContain("no-model");
+		expect(rendered).not.toContain("Select model");
 	});
 
 	it("uses the supplied focus domain when production availability spans composer and selector actions", () => {

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -432,6 +432,11 @@
 					"type": "boolean",
 					"default": true
 				},
+				"showActionHints": {
+					"type": "boolean",
+					"description": "Show contextual keyboard shortcuts in the status line",
+					"default": true
+				},
 				"leftSegments": {
 					"type": "array",
 					"items": true,


### PR DESCRIPTION
## Summary
- add `statusLine.showActionHints`, defaulting to `true`
- preserve configured status segments when contextual hints are hidden
- wire live setting updates and regenerate the public config schema

Closes #2793.

## Verification
- `bun test packages/coding-agent/test/status-line-hints.test.ts`
- `bunx biome check packages/coding-agent/src/config/settings-schema.ts packages/coding-agent/src/modes/components/tool-status-header.ts packages/coding-agent/src/modes/controllers/selector-controller.ts packages/coding-agent/test/status-line-hints.test.ts`
- `bun scripts/generate-json-schemas.ts --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*