### PR TITLE
fix(cli): preserve root version fast paths

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -373,12 +373,7 @@ export async function runCli(argv: string[]): Promise<void> {
 		process.exitCode = await runFixtureReport(id);
 		return;
 	}
-	const runArgv = routeRootArgv(argv);
-	if (isStatsHelpFastPath(runArgv)) {
-		showStatsFastHelp();
-		return;
-	}
-	if (hasRootHelpFlag(runArgv)) {
+	if (hasRootHelpFlag(argv)) {
 		const { renderRootHelp } = await import("@gajae-code/utils/cli");
 		const { getExtraHelpText } = await import("./cli/fast-help");
 		renderRootHelp({ bin: APP_NAME, version: VERSION, commands: new Map([["launch", RootHelpCommand]]) });
@@ -388,8 +383,13 @@ export async function runCli(argv: string[]): Promise<void> {
 		}
 		return;
 	}
-	if (hasRootVersionFlag(runArgv)) {
+	if (hasRootVersionFlag(argv)) {
 		process.stdout.write(`${APP_NAME}/${VERSION}\n`);
+		return;
+	}
+	const runArgv = routeRootArgv(argv);
+	if (isStatsHelpFastPath(runArgv)) {
+		showStatsFastHelp();
 		return;
 	}
 	await installRuntimeGlobals();

--- a/packages/coding-agent/test/cli-help-load-order.test.ts
+++ b/packages/coding-agent/test/cli-help-load-order.test.ts
@@ -275,30 +275,32 @@ describe("CLI help load order", () => {
 		await fs.mkdir(xdg, { recursive: true });
 		await fs.mkdir(agentDir, { recursive: true });
 
-		const proc = Bun.spawn([process.execPath, cliEntry, "--tmux", "--version"], {
-			cwd: repoRoot,
-			stdout: "pipe",
-			stderr: "pipe",
-			env: {
-				...process.env,
-				HOME: home,
-				XDG_CONFIG_HOME: xdg,
-				XDG_DATA_HOME: xdg,
-				PI_CODING_AGENT_DIR: agentDir,
-				PI_NO_TITLE: "1",
-				NO_COLOR: "1",
-			},
-		});
+		for (const versionFlag of ["--version", "-v"]) {
+			const proc = Bun.spawn([process.execPath, cliEntry, "--tmux", versionFlag], {
+				cwd: repoRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+				env: {
+					...process.env,
+					HOME: home,
+					XDG_CONFIG_HOME: xdg,
+					XDG_DATA_HOME: xdg,
+					PI_CODING_AGENT_DIR: agentDir,
+					PI_NO_TITLE: "1",
+					NO_COLOR: "1",
+				},
+			});
 
-		const [stdout, stderr, exitCode] = await Promise.all([
-			readStream(proc.stdout as ReadableStream<Uint8Array>),
-			readStream(proc.stderr as ReadableStream<Uint8Array>),
-			proc.exited,
-		]);
+			const [stdout, stderr, exitCode] = await Promise.all([
+				readStream(proc.stdout as ReadableStream<Uint8Array>),
+				readStream(proc.stderr as ReadableStream<Uint8Array>),
+				proc.exited,
+			]);
 
-		expect(exitCode).toBe(0);
-		expect(stdout).toMatch(/^gjc\/\d+\.\d+\.\d+\n$/);
-		expect(stderr).toBe("");
+			expect(exitCode).toBe(0);
+			expect(stdout).toMatch(/^gjc\/\d+\.\d+\.\d+\n$/);
+			expect(stderr).toBe("");
+		}
 	}, 15_000);
 	it("package bin wrapper executes CLI help when imported by a Bun global shim", async () => {
 		if (Bun.semver.order(Bun.version, "1.3.14") < 0) {

--- a/packages/coding-agent/test/resume-headless-process.test.ts
+++ b/packages/coding-agent/test/resume-headless-process.test.ts
@@ -71,10 +71,12 @@ describe("headless bare resume", () => {
 	}, 10_000);
 
 	it("preserves version and help fast paths when resume is also present", async () => {
-		const version = await runHeadlessBareResume(["--resume", "--version"]);
-		expect(version.exitCode).toBe(0);
-		expect(version.stdout).toMatch(/^gjc\/\d+\.\d+\.\d+\n$/);
-		expect(version.stderr).toBe("");
+		for (const versionFlag of ["--version", "-v"]) {
+			const version = await runHeadlessBareResume(["--resume", versionFlag]);
+			expect(version.exitCode).toBe(0);
+			expect(version.stdout).toMatch(/^gjc\/\d+\.\d+\.\d+\n$/);
+			expect(version.stderr).toBe("");
+		}
 
 		const help = await runHeadlessBareResume(["--resume", "--help"]);
 		expect(help.exitCode).toBe(0);


### PR DESCRIPTION
Repairs the Dev CI baseline regression exposed at d72654f8105c2e1974fd75e83bd4f55c1459f335. Root help/version flags are evaluated before default-launch routing, so `--tmux --version` and `--resume --version` retain `gjc/<version>` output. Extends both focused suites to cover `--version` and `-v` variants.

Verification:
- Reproduced both original failures twice with isolated HOME/TMPDIR/GJC_CONFIG_DIR.
- `bun test packages/coding-agent/test/cli-help-load-order.test.ts packages/coding-agent/test/resume-headless-process.test.ts` twice under isolated environment.
- `bun --cwd=packages/coding-agent run check`
- CLI fast-path smoke for both affected argv shapes.
- `git diff --check`.