### PR TITLE
fix(cli): preserve legacy routing before root fast paths

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -373,7 +373,9 @@ export async function runCli(argv: string[]): Promise<void> {
 		process.exitCode = await runFixtureReport(id);
 		return;
 	}
-	if (hasRootHelpFlag(argv)) {
+	const normalizedArgv = normalizeResumeAlias(argv);
+	const legacyArgv = routeLegacyRootArgv(normalizedArgv);
+	if (!legacyArgv && hasRootHelpFlag(normalizedArgv)) {
 		const { renderRootHelp } = await import("@gajae-code/utils/cli");
 		const { getExtraHelpText } = await import("./cli/fast-help");
 		renderRootHelp({ bin: APP_NAME, version: VERSION, commands: new Map([["launch", RootHelpCommand]]) });
@@ -383,11 +385,11 @@ export async function runCli(argv: string[]): Promise<void> {
 		}
 		return;
 	}
-	if (hasRootVersionFlag(argv)) {
+	if (!legacyArgv && hasRootVersionFlag(normalizedArgv)) {
 		process.stdout.write(`${APP_NAME}/${VERSION}\n`);
 		return;
 	}
-	const runArgv = routeRootArgv(argv);
+	const runArgv = legacyArgv ?? routeRootArgv(normalizedArgv);
 	if (isStatsHelpFastPath(runArgv)) {
 		showStatsFastHelp();
 		return;

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -191,6 +191,31 @@ describe("GJC public CLI command surface", () => {
 		expect(output).toContain(".gjc/_session-{sessionid}/state/team");
 	}, 30_000);
 
+	it("preserves root fast-path and legacy team-help precedence", () => {
+		const cases = [
+			{ args: ["--tmux", "--version"], output: /^gjc\/\d+\.\d+\.\d+\n$/ },
+			{ args: ["--tmux", "-v"], output: /^gjc\/\d+\.\d+\.\d+\n$/ },
+			{ args: ["--resume", "--version"], output: /^gjc\/\d+\.\d+\.\d+\n$/ },
+			{ args: ["--resume", "-v"], output: /^gjc\/\d+\.\d+\.\d+\n$/ },
+			{ args: ["--help"], output: "USAGE" },
+			{ args: ["--team", "--team-size", "2", "--help"], output: "--dry-run" },
+		];
+
+		for (const { args, output } of cases) {
+			const result = Bun.spawnSync(["bun", cliEntry, ...args], {
+				cwd: repoRoot,
+				stderr: "pipe",
+				stdout: "pipe",
+			});
+			const stdout = result.stdout.toString();
+			const stderr = result.stderr.toString();
+
+			expect(result.exitCode, stderr).toBe(0);
+			if (typeof output === "string") expect(stdout).toContain(output);
+			else expect(stdout).toMatch(output);
+		}
+	}, 30_000);
+
 	it("does not capture absolute-path prompts as startup slash commands", () => {
 		const parsed = parseArgs(["/tmp/request.md", "--model", "opus", "summarize"]);
 

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -198,7 +198,11 @@ describe("GJC public CLI command surface", () => {
 			{ args: ["--resume", "--version"], output: /^gjc\/\d+\.\d+\.\d+\n$/ },
 			{ args: ["--resume", "-v"], output: /^gjc\/\d+\.\d+\.\d+\n$/ },
 			{ args: ["--help"], output: "USAGE" },
+			{ args: ["--tmux", "--help"], output: "USAGE" },
+			{ args: ["--resume", "--help"], output: "USAGE" },
 			{ args: ["--team", "--team-size", "2", "--help"], output: "--dry-run" },
+			{ args: ["--team", "--team-size=2", "--help"], output: "--dry-run" },
+			{ args: ["--team", "--team-size", "2", "-h"], output: "--dry-run" },
 		];
 
 		for (const { args, output } of cases) {


### PR DESCRIPTION
Repairs the merged-dev Dev CI failure on 3b5d21a66dbc17cf4e9ab0974a73d0f7b9b81a19. The prior root version fast-path repair intercepted legacy `--team --team-size 2 --help` before conversion to `team`. This change applies legacy routing first, then applies root help/version only when no legacy route exists.

The public CLI precedence matrix now covers root `--help`, tmux/resume version forms with `--version` and `-v`, and legacy team help.

Verification:
- Reproduced the original legacy-team failure twice with isolated HOME/TMPDIR/GJC_CONFIG_DIR.
- `bun test packages/coding-agent/test/cli-command-surface.test.ts` twice with isolated environment.
- `bun test packages/coding-agent/test/cli-help-load-order.test.ts packages/coding-agent/test/resume-headless-process.test.ts`
- Direct CLI smoke for tmux/resume versions and legacy team help.
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`.