### PR TITLE
feat(notifications): add topics.enabled toggle for flat Telegram delivery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - `/btw` now opens an ephemeral multi-turn side chat: plain text continues the side thread until Esc returns to the main chat, while visible text-only context stays outside the main transcript and session observability/debug hooks and is scrubbed synchronously on close or abort.
 - Added `statusLine.showActionHints` (default: `true`) to hide contextual action hints while retaining configured status-line segments.
+- Added `notifications.telegram.topics.enabled` (default: `true`). Off skips per-session Telegram forum-topic creation entirely and delivers every notification frame flat to the paired chat — useful for private-chat pairings where thread-addressed messages render as noisy quote-replies of the topic service message (#2855). Existing topic records are ignored (not deleted) while disabled, and the Threaded Mode nudge is suppressed since flat delivery is the requested mode.
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -317,6 +317,16 @@ export const SETTINGS_SCHEMA = {
 			editing: "notification-atomic",
 		},
 	},
+	"notifications.telegram.topics.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "notifications",
+			label: "Telegram Topic Threads",
+			description: "Create per-session Telegram forum topics. Off delivers every frame flat to the paired chat.",
+			editing: "notification-atomic",
+		},
+	},
 	"notifications.telegram.topics.nameTemplate": { type: "string", default: undefined },
 	"notifications.discord.botToken": { type: "string", default: undefined },
 	"notifications.discord.applicationId": { type: "string", default: undefined },
@@ -3809,6 +3819,7 @@ export interface NotificationsSettings {
 			enabled: boolean;
 		};
 		topics: {
+			enabled: boolean;
 			nameTemplate: string | undefined;
 		};
 	};

--- a/packages/coding-agent/src/sdk/bus/chat-daemon-cli.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-daemon-cli.ts
@@ -68,7 +68,7 @@ async function loadConfig(agentDir: string, kind: ChatDaemonKind): Promise<ChatD
 				rich: { enabled: true },
 				richDraft: { enabled: false },
 				toolActivity: { enabled: true },
-				topics: { nameTemplate: undefined },
+				topics: { enabled: true, nameTemplate: undefined },
 				btw: { enabled: true },
 				streaming: { enabled: true },
 			})
@@ -103,7 +103,7 @@ async function loadConfig(agentDir: string, kind: ChatDaemonKind): Promise<ChatD
 			rich: { enabled: true },
 			richDraft: { enabled: false },
 			toolActivity: { enabled: true },
-			topics: { nameTemplate: undefined },
+			topics: { enabled: true, nameTemplate: undefined },
 			btw: { enabled: true },
 			streaming: { enabled: true },
 		})

--- a/packages/coding-agent/src/sdk/bus/config.ts
+++ b/packages/coding-agent/src/sdk/bus/config.ts
@@ -71,6 +71,7 @@ export interface NotificationSettingsSnapshot {
 			enabled: boolean;
 		};
 		topics: {
+			enabled: boolean;
 			nameTemplate?: string;
 		};
 	};
@@ -176,6 +177,7 @@ export function parseNotificationSettingsSnapshot(rawConfig?: unknown): Notifica
 				enabled: notificationSettingsBoolean(streaming.enabled, true),
 			},
 			topics: {
+				enabled: notificationSettingsBoolean(topics.enabled, true),
 				nameTemplate: notificationSettingsString(topics.nameTemplate),
 			},
 		},
@@ -245,6 +247,12 @@ export interface NotificationConfig {
 		enabled: boolean;
 	};
 	topics: {
+		/**
+		 * Master switch for per-session Telegram forum topics. `true` (default)
+		 * preserves Threaded Mode; `false` skips topic creation entirely and
+		 * delivers every frame flat to the paired chat.
+		 */
+		enabled: boolean;
 		/**
 		 * Optional Telegram forum-topic name template with `{repo}`, `{branch}`,
 		 * and `{title}` placeholders. Unset preserves the built-in

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -1069,7 +1069,7 @@ const defaultConfig: NotificationConfig = {
 	richDraft: { enabled: false },
 	toolActivity: { enabled: true },
 	streaming: { enabled: true },
-	topics: {},
+	topics: { enabled: true },
 	btw: { enabled: true },
 };
 

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts
@@ -101,6 +101,8 @@ export function createLightweightDaemonSettings(input: {
 					return snapshot.slack.channelId;
 				case "notifications.slack.authorizedUserId":
 					return snapshot.slack.authorizedUserId;
+				case "notifications.telegram.topics.enabled":
+					return snapshot.telegram.topics.enabled;
 				case "notifications.telegram.topics.nameTemplate":
 					return snapshot.telegram.topics.nameTemplate;
 				case "notifications.telegram.rich.enabled":

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -2710,11 +2710,13 @@ export interface TelegramDaemonOptions {
 	/** Tool start/completion messages (enabled by default). */
 	toolActivity?: { enabled: boolean };
 	/**
-	 * Per-session Telegram forum-topic naming. `nameTemplate` supports the
-	 * `{repo}`, `{branch}`, and `{title}` placeholders; unset preserves the
-	 * built-in `{repo}/{branch} - {title}` composition and its fallbacks.
+	 * Per-session Telegram forum-topic behavior. `enabled: false` skips topic
+	 * creation entirely and delivers every frame flat to the paired chat;
+	 * `nameTemplate` supports the `{repo}`, `{branch}`, and `{title}`
+	 * placeholders; unset preserves the built-in `{repo}/{branch} - {title}`
+	 * composition and its fallbacks.
 	 */
-	topics?: { nameTemplate?: string };
+	topics?: { enabled?: boolean; nameTemplate?: string };
 }
 
 interface SessionSocket {
@@ -4477,6 +4479,9 @@ export class TelegramNotificationDaemon {
 	}
 
 	private async existingTopicForPrivateChat(sessionId: string): Promise<string | undefined> {
+		// With topics disabled, ignore previously created topic records so every
+		// frame (including sessions with an existing topic) routes flat.
+		if (!this.topicsEnabled()) return undefined;
 		return (await this.topicAuthorityLease(sessionId))?.topicId;
 	}
 
@@ -4562,13 +4567,20 @@ export class TelegramNotificationDaemon {
 		}
 	}
 
+	/** Operator switch: `notifications.telegram.topics.enabled` (default on). */
+	private topicsEnabled(): boolean {
+		return this.opts.topics?.enabled !== false;
+	}
+
 	/**
 	 * Resolve (creating once via `createForumTopic`) the forum topic for a
 	 * session. On capability failure (e.g. Threaded Mode off) this returns
 	 * `undefined`; callers then flat-deliver to a private paired chat (with a
-	 * one-time nudge) or drop fail-closed for a non-private chat.
+	 * one-time nudge) or drop fail-closed for a non-private chat. When topics
+	 * are disabled by config, every caller takes the same flat path.
 	 */
 	private async ensureTopic(sessionId: string, name: string): Promise<string | undefined> {
+		if (!this.topicsEnabled()) return undefined;
 		if (!(await this.pairedChatIsPrivate())) return undefined;
 		const existing = this.topics.get(sessionId);
 		if (existing?.authorityState === "delete_pending") return undefined;
@@ -5269,6 +5281,9 @@ export class TelegramNotificationDaemon {
 
 	/** Tell the user once (per daemon run) how to enable Threaded Mode. */
 	private async notifyThreadedFallback(): Promise<void> {
+		// Flat delivery is the explicitly requested mode when topics are disabled;
+		// nudging the operator to enable Threaded Mode would be wrong.
+		if (!this.topicsEnabled()) return;
 		if (this.threadedFallbackNoticeSent || !(await this.pairedChatIsPrivate())) return;
 		this.threadedFallbackNoticeSent = true;
 		try {
@@ -5347,6 +5362,17 @@ export class TelegramNotificationDaemon {
 
 	/** Send a single `typing` chat action into a busy session's topic (best-effort). */
 	private async sendTyping(sessionId: string): Promise<void> {
+		if (!this.topicsEnabled()) {
+			// Flat mode: keep the typing indicator, but never target a stale topic
+			// record left over from a previous topics-enabled run.
+			if (!(await this.pairedChatIsPrivate())) return;
+			try {
+				await this.botApi.call("sendChatAction", { chat_id: this.opts.chatId, action: "typing" });
+			} catch {
+				// Best-effort: a failed chat action must never stop the daemon.
+			}
+			return;
+		}
 		const topicLease = await this.topicAuthorityLease(sessionId);
 		if (!topicLease || !this.topicLeaseIsCurrent(topicLease)) return;
 		const topicId = topicLease.topicId;

--- a/packages/coding-agent/test/notification-settings-controller.test.ts
+++ b/packages/coding-agent/test/notification-settings-controller.test.ts
@@ -50,7 +50,7 @@ function snapshot(overrides: Partial<NotificationSettingsSnapshot> = {}): Notifi
 			richDraft: { enabled: false },
 			toolActivity: { enabled: true },
 			streaming: { enabled: true },
-			topics: {},
+			topics: { enabled: true },
 		},
 		discord: {},
 		slack: {},

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -87,6 +87,7 @@ const BASE_CFG: NotificationConfig = {
 		enabled: true,
 	},
 	topics: {
+		enabled: true,
 		nameTemplate: undefined,
 	},
 	idleTimeoutMs: 60000,
@@ -228,6 +229,7 @@ describe("notifications config", () => {
 				enabled: false,
 			},
 			topics: {
+				enabled: true,
 				nameTemplate: undefined,
 			},
 			idleTimeoutMs: 1234,

--- a/packages/coding-agent/test/notifications-session-control.test.ts
+++ b/packages/coding-agent/test/notifications-session-control.test.ts
@@ -33,7 +33,7 @@ const BASE_CONFIG: NotificationConfig = {
 	richDraft: { enabled: false },
 	toolActivity: { enabled: true },
 	streaming: { enabled: true },
-	topics: { nameTemplate: undefined },
+	topics: { enabled: true, nameTemplate: undefined },
 	btw: { enabled: true },
 };
 

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -7712,6 +7712,109 @@ test("threaded mode off: frames fall back to the flat paired chat with a one-tim
 	expect(ask).toBeTruthy();
 	expect(ask!.body.reply_markup?.inline_keyboard?.length).toBeGreaterThan(0);
 });
+
+test("topics disabled by config: no createForumTopic, frames deliver flat without a nudge", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "createForumTopic")
+			throw new Error("createForumTopic must not be called when topics are disabled");
+		if (method === "getChat") return { ok: true, result: { type: "private" } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		rich: { enabled: false },
+		topics: { enabled: false },
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	await daemon.handleSessionMessage(session as any, {
+		type: "context_update",
+		sessionId: "S",
+		lastMessage: "hello world",
+	});
+	await daemon.handleSessionMessage(session as any, {
+		type: "action_needed",
+		sessionId: "S",
+		id: "ask1",
+		kind: "ask",
+		question: "Proceed?",
+		options: ["Yes", "No"],
+	});
+
+	expect(bot.calls.filter(c => c.method === "createForumTopic")).toHaveLength(0);
+	const sends = bot.calls.filter(c => c.method === "sendMessage");
+	expect(sends.length).toBeGreaterThan(0);
+	expect(sends.every(c => c.body.message_thread_id === undefined)).toBe(true);
+	// Explicitly disabled topics are the requested mode, not a capability failure:
+	// the Threaded Mode nudge must not be sent.
+	expect(sends.filter(c => String(c.body.text).includes(THREADED_FALLBACK_NOTICE))).toHaveLength(0);
+	const ask = sends.find(c => String(c.body.text).includes("Proceed?"));
+	expect(ask).toBeTruthy();
+	expect(ask!.body.reply_markup?.inline_keyboard?.length).toBeGreaterThan(0);
+});
+
+test("topics disabled by config: an existing topic record is ignored and delivery goes flat", async () => {
+	// Seed a topic registry record with an enabled daemon, then restart disabled:
+	// the stale record must not resurrect threaded delivery.
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const enabledDaemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	await enabledDaemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	expect(bot.calls.some(c => c.method === "createForumTopic")).toBe(true);
+
+	const bot2 = new FakeBotApi();
+	const disabledDaemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot2,
+		topics: { enabled: false },
+	});
+	await disabledDaemon.loadTopics();
+	await disabledDaemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	await disabledDaemon.handleSessionMessage(session as any, {
+		type: "context_update",
+		sessionId: "S",
+		lastMessage: "flat now",
+	});
+
+	expect(bot2.calls.filter(c => c.method === "createForumTopic")).toHaveLength(0);
+	const sends = bot2.calls.filter(c => c.method === "sendMessage");
+	expect(sends.length).toBeGreaterThan(0);
+	expect(sends.every(c => c.body.message_thread_id === undefined)).toBe(true);
+});
 test("topic creation transport failures fail closed without flat delivery", async () => {
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();


### PR DESCRIPTION
Closes #2855

## What

Adds `notifications.telegram.topics.enabled` (boolean, default `true` — no behavior change for existing setups). When `false`, the Telegram daemon:

- skips `createForumTopic` entirely (config gate in `ensureTopic`),
- ignores existing topic registry records (`existingTopicForPrivateChat` returns undefined), so a stale record from a previous topics-enabled run cannot resurrect threaded delivery — records are ignored, not deleted,
- suppresses the Threaded Mode nudge (flat delivery is the requested mode, not a capability failure),
- delivers every frame flat to the paired private chat through the existing flat-fallback path — asks keep their inline keyboards,
- keeps the typing indicator, but sends it without `message_thread_id` so it can never target a stale topic.

## Why

Real dogfooding session (2026-07-22, details + screenshots in #2855): with a private-chat pairing, every threaded frame renders as a quote-reply of the `The topic … was created` service message on clients that show bot-DM topics as reply threads, and the `t.me/c/0/<id>` deep link is dead in private chats. `toolActivity.enabled=false` (#2685) removes the ⚙ spam but every remaining frame still drags the quoted anchor along. There was no operator switch to opt out of Threaded Mode.

## Wiring

settings-schema → notification settings snapshot → `NotificationConfig` → daemon opts (`telegram-daemon-cli`, `chat-daemon-cli` parity literals) → daemon gates. Changelog entry under `[Unreleased]`.

## Verification

- `bun run check:types` clean; `biome check` clean on all touched files.
- New focused tests in `test/notifications-telegram-daemon.test.ts`:
  - `topics disabled by config: no createForumTopic, frames deliver flat without a nudge` — identity/context/ask frames, fake bot throws if `createForumTopic` is ever called, asserts no `message_thread_id`, no nudge, ask keyboard preserved.
  - `topics disabled by config: an existing topic record is ignored and delivery goes flat` — seeds a topic registry with an enabled daemon, restarts disabled, asserts flat delivery.
- `bun test test/notifications-telegram-daemon.test.ts -t 'topics disabled'` → 2 pass.
- Affected config suites (`notifications-config`, `notification-settings-controller`, `notifications-session-control`) → 73/74 pass; the single failure (`captured /notify on uses the production daemon ensurer…`) reproduces identically on a clean checkout of `dev` on this machine (a live local Telegram daemon interferes with ownership tests), i.e. pre-existing and unrelated.