### PR TITLE
fix(tools): explain skill_discovery empty results caused by disabled config

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - `/btw` now opens an ephemeral multi-turn side chat: plain text continues the side thread until Esc returns to the main chat, while visible text-only context stays outside the main transcript and session observability/debug hooks and is scrubbed synchronously on close or abort.
 - Added `statusLine.showActionHints` (default: `true`) to hide contextual action hints while retaining configured status-line segments.
+- `skill_discovery` empty results now carry a `notice` when discovery config caused the emptiness — naming the exact disabled setting (`skills.enabled`, `skills.enablePiProject`, or `skills.enablePiUser`) and the `gjc config set` command to enable it. Previously a disabled config was indistinguishable from "no skills exist", silently hiding freshly written user/project skills.
 
 ### Fixed
 

--- a/packages/coding-agent/src/prompts/tools/skill-discovery.md
+++ b/packages/coding-agent/src/prompts/tools/skill-discovery.md
@@ -3,6 +3,7 @@ Discover project and user runtime skills without loading full skill content.
 <instruction>
 - Searches only custom runtime skill locations: nearest project `.gjc/skills`; then, under the home directory, canonical `<config>/agent/skills`, configured legacy `<config>/skills`, and historical legacy `.gjc/skills`. `<config>` is the home-relative directory name from `GJC_CONFIG_DIR`, then `PI_CONFIG_DIR`, then `.gjc`; even an absolute-looking configured name is joined beneath `<home>`. Duplicate names use that exact precedence. Built-in, bundled, and internal workflow skills are intentionally excluded.
 - Returns thin metadata only: name, description, source scope, path, and use conditions when present.
+- When zero candidates are returned because discovery config is disabled (`skills.enabled`, `skills.enablePiProject`, `skills.enablePiUser`), the result carries a `notice` explaining which setting blocked the search — an empty result without a `notice` means the searched scopes genuinely contain no matching skills.
 - To load a selected skill's full `SKILL.md`, invoke it through the existing `skill` tool with the exact `name` returned here.
 </instruction>
 

--- a/packages/coding-agent/src/tools/skill-discovery.ts
+++ b/packages/coding-agent/src/tools/skill-discovery.ts
@@ -21,6 +21,13 @@ export type SkillDiscoveryToolInput = z.infer<typeof skillDiscoverySchema>;
 export interface SkillDiscoveryToolDetails {
 	candidates: RuntimeSkillDiscoveryCandidate[];
 	count: number;
+	/**
+	 * Present only when zero candidates were returned AND discovery config gates
+	 * (`skills.enabled` / `skills.enablePiProject` / `skills.enablePiUser`)
+	 * prevented some or all of the requested scope from being searched. Without
+	 * this, a disabled config is indistinguishable from "no skills exist".
+	 */
+	notice?: string;
 }
 
 export class SkillDiscoveryTool implements AgentTool<typeof skillDiscoverySchema, SkillDiscoveryToolDetails> {
@@ -57,17 +64,43 @@ export class SkillDiscoveryTool implements AgentTool<typeof skillDiscoverySchema
 		signal?: AbortSignal,
 	): Promise<AgentToolResult<SkillDiscoveryToolDetails>> {
 		return untilAborted(signal, async () => {
+			const source = input.source ?? "all";
 			const candidates = await discoverRuntimeSkills({
 				cwd: this.#session.cwd,
 				query: input.query,
-				source: input.source ?? "all",
+				source,
 				limit: input.limit,
 				policy: this.#getRuntimeSkillPolicy(),
 			});
+			const details: SkillDiscoveryToolDetails = { candidates, count: candidates.length };
+			if (candidates.length === 0) {
+				const notice = this.#disabledPolicyNotice(source);
+				if (notice) details.notice = notice;
+			}
 			return {
-				content: [{ type: "text", text: JSON.stringify({ candidates, count: candidates.length }, null, 2) }],
-				details: { candidates, count: candidates.length },
+				content: [{ type: "text", text: JSON.stringify(details, null, 2) }],
+				details,
 			};
 		});
+	}
+
+	/**
+	 * Explain an empty result that is caused by disabled discovery config rather
+	 * than by an actually empty skill catalog.
+	 */
+	#disabledPolicyNotice(source: "all" | "project" | "user"): string | undefined {
+		const policy = this.#getRuntimeSkillPolicy();
+		if (policy.enabled !== true) {
+			return "Runtime skill discovery is disabled: `skills.enabled` is false, so no skill directories were searched. Enable it with `gjc config set skills.enabled true` (project and user scopes additionally require `skills.enablePiProject` / `skills.enablePiUser`).";
+		}
+		const skipped: string[] = [];
+		if ((source === "all" || source === "project") && policy.enablePiProject !== true) {
+			skipped.push("project (`skills.enablePiProject` is false)");
+		}
+		if ((source === "all" || source === "user") && policy.enablePiUser !== true) {
+			skipped.push("user (`skills.enablePiUser` is false)");
+		}
+		if (skipped.length === 0) return undefined;
+		return `Skill discovery skipped disabled scope(s): ${skipped.join(", ")}. Enable the corresponding setting with \`gjc config set <setting> true\` to search them.`;
 	}
 }

--- a/packages/coding-agent/test/tools/skill-discovery.test.ts
+++ b/packages/coding-agent/test/tools/skill-discovery.test.ts
@@ -218,6 +218,7 @@ describe("SkillDiscoveryTool", () => {
 
 		const discovery = await new SkillDiscoveryTool(createSession(cwd, { settings })).execute("call", {});
 		expect(discovery.details?.candidates).toEqual([]);
+		expect(discovery.details?.notice).toContain("`skills.enabled` is false");
 
 		const sent: Array<{ content: string; details?: unknown }> = [];
 		const tool = new SkillTool(
@@ -231,6 +232,42 @@ describe("SkillDiscoveryTool", () => {
 		);
 		await expect(tool.execute("call", { name: "project-helper" })).rejects.toThrow(/unknown skill/);
 		expect(sent).toHaveLength(0);
+	});
+
+	it("explains empty results caused by disabled discovery scopes, and stays silent for genuine emptiness", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-skills-notice-"));
+		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill");
+
+		// Requested scope is fully disabled: empty result carries a scope notice.
+		const userOff = runtimeSkillSettings({ "skills.enablePiUser": false });
+		const userScope = await new SkillDiscoveryTool(createSession(cwd, { settings: userOff })).execute("call", {
+			source: "user",
+		});
+		expect(userScope.details?.candidates).toEqual([]);
+		expect(userScope.details?.notice).toContain("`skills.enablePiUser` is false");
+
+		// A disabled scope is mentioned even under source "all" when nothing was found.
+		const projectOff = runtimeSkillSettings({ "skills.enablePiProject": false });
+		const allScope = await new SkillDiscoveryTool(createSession(cwd, { settings: projectOff })).execute("call", {
+			query: "no-such-skill-anywhere",
+		});
+		expect(allScope.details?.candidates).toEqual([]);
+		expect(allScope.details?.notice).toContain("`skills.enablePiProject` is false");
+
+		// Fully enabled policy with a non-matching query: genuinely empty, no notice.
+		const enabled = runtimeSkillSettings();
+		const genuine = await new SkillDiscoveryTool(createSession(cwd, { settings: enabled })).execute("call", {
+			query: "no-such-skill-anywhere",
+		});
+		expect(genuine.details?.candidates).toEqual([]);
+		expect(genuine.details?.notice).toBeUndefined();
+
+		// Found results never carry a notice.
+		const found = await new SkillDiscoveryTool(createSession(cwd, { settings: enabled })).execute("call", {
+			query: "project helper",
+		});
+		expect(found.details?.count).toBe(1);
+		expect(found.details?.notice).toBeUndefined();
 	});
 
 	it("discovers canonical and legacy user roots in native precedence order", async () => {


### PR DESCRIPTION
## Problem (hit during real dogfooding, 2026-07-22)

`skills.enabled` defaults to `false`. With it off, `skill_discovery` returns a bare `{"candidates": [], "count": 0}` — indistinguishable from an actually empty skill catalog. Concretely: I wrote a valid user skill to `~/.gjc/agent/skills/<name>/SKILL.md`, ran discovery twice, got silent empties, and had to read `runtime-skill-discovery.ts` source to find the `sourceEnabled` policy gate before realizing the feature flag was off. An agent (or human) has no signal that config — not the filesystem — is the cause.

## Fix

Empty results now carry an optional `notice` field that names the exact disabled setting and the enable command:

- `skills.enabled` false → notice pointing at `gjc config set skills.enabled true` (plus the scope flags).
- enabled, but a requested scope is gated (`skills.enablePiProject` / `skills.enablePiUser`) → notice listing the skipped scope(s).
- Fully enabled policy with a genuinely empty/non-matching result → **no notice** (unchanged shape).
- Results with candidates → never a notice.

Tool prompt (`prompts/tools/skill-discovery.md`) documents the contract: empty **without** notice = genuinely no matching skills. Changelog entry under `[Unreleased]`.

## Verification

- `bun test test/tools/skill-discovery.test.ts` → 12 pass, 0 fail (2 new/extended cases: skills.enabled-off notice, scope-off notices, genuine-empty silence, found-results silence).
- `biome check` clean, `bun run check:types` clean.