### PR TITLE
feat(config): add toggleable Beginner Mode for non-developers

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1389,6 +1389,17 @@ export const SETTINGS_SCHEMA = {
 		ui: { tab: "interaction", label: "Collapse Changelog", description: "Show condensed changelog after updates" },
 	},
 
+	"beginnerMode.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			label: "Beginner Mode",
+			description:
+				"Explain in plain, jargon-free language with everyday analogies. Aimed at non-developers learning to code.",
+		},
+	},
+
 	// Notifications
 	"completion.notify": {
 		type: "enum",

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -131,6 +131,19 @@ Delegate by default for multi-file changes, refactors, new features, tests, and 
 {{/has}}
 {{/if}}
 
+{{#if beginnerMode}}
+<beginner-mode>
+The user is a non-developer who is learning. Explain everything as if to a smart beginner with no coding background:
+- Translate every technical term into plain language the moment you use it ("this is basically ~"). Never assume jargon is understood.
+- Anchor each concept with at least one everyday analogy (e.g. variable = a labeled box, function = a vending machine, API = a restaurant order slip).
+- Prefer short sentences and one idea at a time. Explain WHY something matters before HOW it works.
+- When you show code, add plain-language comments explaining what each meaningful line does.
+- Spell out acronyms on first use (HTTP, JSON, CLI, ...).
+- Stay encouraging and concrete; avoid showing off or dumping exhaustive detail unless the user asks to go deeper.
+This changes only HOW you explain — it never lowers correctness, and you still use tools and verify work normally.
+</beginner-mode>
+{{/if}}
+
 {{#has tools "task"}}
 <detached-subagents>
 - Normal `{{toolRefs.task}}` launches return immediately as detached background subagents.

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -2128,6 +2128,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 		const repeatToolDescriptions = settings.get("repeatToolDescriptions");
 		const eagerTasks = settings.get("task.eager");
+		const beginnerMode = settings.get("beginnerMode.enabled");
 		const intentTracingEnabled = resolveIntentTracingEnabled(
 			settings.get("tools.intentTracing"),
 			options.hasUI ?? false,
@@ -2176,6 +2177,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				intentField,
 				toolDiscoveryActive: effectiveDiscoveryMode === "all" || mcpDiscoveryEnabled,
 				eagerTasks,
+				beginnerMode,
 				secretsEnabled,
 				workspaceTree: workspaceTreePromise,
 				subagent: options.parentTaskPrefix !== undefined,

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -371,6 +371,8 @@ export interface BuildSystemPromptOptions {
 	toolDiscoveryActive?: boolean;
 	/** Encourage the agent to delegate via tasks unless changes are trivial. */
 	eagerTasks?: boolean;
+	/** Explain concepts in plain, jargon-free language with everyday analogies for non-developers. */
+	beginnerMode?: boolean;
 	/** Rules with alwaysApply=true — their full content is injected into the prompt. */
 	alwaysApplyRules?: AlwaysApplyRule[];
 	/** Whether secret obfuscation is active. When true, explains the redaction format in the prompt. */
@@ -438,6 +440,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		intentField,
 		toolDiscoveryActive = false,
 		eagerTasks = false,
+		beginnerMode = false,
 		secretsEnabled = false,
 		workspaceTree: providedWorkspaceTree,
 		subagent = false,
@@ -612,6 +615,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		intentField: intentField ?? "",
 		toolDiscoveryActive: toolDiscoveryActive && hasHiddenToolDiscoveryTool,
 		eagerTasks,
+		beginnerMode,
 		secretsEnabled,
 		subagent,
 	};

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1025,6 +1025,17 @@
 			"description": "Show condensed changelog after updates",
 			"default": false
 		},
+		"beginnerMode": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"type": "boolean",
+					"description": "Explain in plain, jargon-free language with everyday analogies. Aimed at non-developers learning to code.",
+					"default": false
+				}
+			},
+			"additionalProperties": false
+		},
 		"completion": {
 			"type": "object",
 			"properties": {


### PR DESCRIPTION
## What

Adds a toggleable **Beginner Mode** for non-developers. When enabled, GJC
explains concepts in plain, jargon-free language with everyday analogies —
without changing correctness or tool behavior.

## Why

Non-developers learning to code find the default answers dense. A single
opt-in toggle lets them get beginner-friendly explanations, then turn it
off once comfortable.

## How

Wired identically to the existing `task.eager` (`eagerTasks`) flag:

- `config/settings-schema.ts` — new `beginnerMode.enabled` boolean setting
  (default `false`, Interaction tab).
- `sdk/session.ts` — reads the setting and passes it into the prompt build.
- `system-prompt.ts` — new `BuildSystemPromptOptions.beginnerMode`, threaded
  into the template `data`.
- `prompts/system/system-prompt.md` — `{{#if beginnerMode}}` block with the
  beginner-friendly guidance (translate jargon, everyday analogies, one idea
  at a time, plain-language code comments, spell out acronyms).
- `schemas/config.schema.json` — regenerated.

## Usage

```
gjc config set beginnerMode.enabled true    # on
gjc config set beginnerMode.enabled false   # off
```
Or the "Beginner Mode" toggle in the settings Interaction tab.

## Verification

- `tsc -p packages/coding-agent/tsconfig.json --noEmit` — passes.
- `bun run check:schemas` — passes (schema regenerated).
- `biome check` on changed files — passes.
- Template render test: `<beginner-mode>` block appears only when
  `beginnerMode: true`, absent when `false`.
