### PR TITLE
fix(coding-agent): repair legacy local scratch migration retirement and lifecycle audit-key startup

### DIFF
--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -169,7 +169,12 @@ async function snapshotDirectory(directoryPath: string, relativePath: string): P
 	return { relativePath, dev: stat.dev, ino: stat.ino, size: stat.size };
 }
 
-async function canonicalLegacyRoot(artifactsDir: string): Promise<string> {
+interface CanonicalLegacyRoot {
+	readonly root: string;
+	readonly identity: LegacyEntrySnapshot;
+}
+
+async function canonicalLegacyRoot(artifactsDir: string): Promise<CanonicalLegacyRoot> {
 	const lexicalRoot = path.resolve(artifactsDir, "local");
 	const lexicalIdentity = await snapshotDirectory(lexicalRoot, "");
 	const [canonicalArtifactsDir, canonicalRoot] = await Promise.all([
@@ -181,7 +186,7 @@ async function canonicalLegacyRoot(artifactsDir: string): Promise<string> {
 	const canonicalIdentity = await snapshotDirectory(canonicalRoot, "");
 	if (!matchesSnapshot(canonicalIdentity, lexicalIdentity))
 		throw new Error("Legacy local:// migration source changed during capture");
-	return canonicalRoot;
+	return { root: canonicalRoot, identity: lexicalIdentity };
 }
 
 async function snapshotRegularFile(filePath: string, relativePath: string): Promise<LegacyEntrySnapshot> {
@@ -217,11 +222,16 @@ function manifestsMatch(left: readonly LegacyEntrySnapshot[], right: readonly Le
 	);
 }
 
-async function captureLegacyManifest(root: string): Promise<readonly LegacyEntrySnapshot[]> {
+async function captureLegacyManifest(
+	root: string,
+	expectedRootIdentity: LegacyEntrySnapshot,
+): Promise<readonly LegacyEntrySnapshot[]> {
 	const manifest: LegacyEntrySnapshot[] = [];
 	let copiedBytes = 0n;
 	const captureDirectory = async (directoryPath: string, relativePath: string): Promise<void> => {
 		const directory = await snapshotDirectory(directoryPath, relativePath);
+		if (relativePath === "" && !matchesSnapshot(directory, expectedRootIdentity))
+			throw new Error("Legacy local:// migration source changed during capture");
 		manifest.push(directory);
 		const entries = (await fs.readdir(directoryPath, { withFileTypes: true })).sort((a, b) =>
 			a.name.localeCompare(b.name),
@@ -399,11 +409,11 @@ async function migrateLegacyLocal(
 		await fs.writeFile(marker, "absent\n", { mode: 0o600, flag: "wx" });
 		return;
 	}
-	let legacyRoot: string;
+	let legacySource: CanonicalLegacyRoot;
 	let manifest: readonly LegacyEntrySnapshot[];
 	try {
-		legacyRoot = await canonicalLegacyRoot(artifactsDir);
-		manifest = await captureLegacyManifest(legacyRoot);
+		legacySource = await canonicalLegacyRoot(artifactsDir);
+		manifest = await captureLegacyManifest(legacySource.root, legacySource.identity);
 	} catch (error) {
 		if (isEnoent(error)) {
 			await fs.writeFile(marker, "absent\n", { mode: 0o600, flag: "wx" });
@@ -413,8 +423,8 @@ async function migrateLegacyLocal(
 	}
 	const staging = path.join(scratchParent, `.gjc-local-migration-${randomUUID()}`);
 	try {
-		await copyLegacyManifest(legacyRoot, staging, manifest);
-		const verifiedManifest = await captureLegacyManifest(legacyRoot);
+		await copyLegacyManifest(legacySource.root, staging, manifest);
+		const verifiedManifest = await captureLegacyManifest(legacySource.root, legacySource.identity);
 		if (!manifestsMatch(verifiedManifest, manifest))
 			throw new Error("Legacy local:// migration source changed during capture");
 		for (const entry of await fs.readdir(staging)) {
@@ -426,7 +436,7 @@ async function migrateLegacyLocal(
 			}
 			await fs.rename(path.join(staging, entry), path.join(localRoot, entry));
 		}
-		await retireLegacyTree(legacyRoot, manifest);
+		await retireLegacyTree(legacySource.root, manifest);
 		await fs.writeFile(marker, "verified\n", { mode: 0o600, flag: "wx" });
 	} finally {
 		await fs.rm(staging, { recursive: true, force: true });

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -169,6 +169,21 @@ async function snapshotDirectory(directoryPath: string, relativePath: string): P
 	return { relativePath, dev: stat.dev, ino: stat.ino, size: stat.size };
 }
 
+async function canonicalLegacyRoot(artifactsDir: string): Promise<string> {
+	const lexicalRoot = path.resolve(artifactsDir, "local");
+	const lexicalIdentity = await snapshotDirectory(lexicalRoot, "");
+	const [canonicalArtifactsDir, canonicalRoot] = await Promise.all([
+		fs.realpath(path.resolve(artifactsDir)),
+		fs.realpath(lexicalRoot),
+	]);
+	if (canonicalRoot === canonicalArtifactsDir) throw new Error("Unsafe legacy local:// migration source");
+	ensureWithinRoot(canonicalRoot, canonicalArtifactsDir);
+	const canonicalIdentity = await snapshotDirectory(canonicalRoot, "");
+	if (!matchesSnapshot(canonicalIdentity, lexicalIdentity))
+		throw new Error("Legacy local:// migration source changed during capture");
+	return canonicalRoot;
+}
+
 async function snapshotRegularFile(filePath: string, relativePath: string): Promise<LegacyEntrySnapshot> {
 	const before = await fs.lstat(filePath, { bigint: true });
 	if (!before.isFile() || before.isSymbolicLink()) throw new Error("Unsafe legacy local:// migration source");
@@ -384,9 +399,10 @@ async function migrateLegacyLocal(
 		await fs.writeFile(marker, "absent\n", { mode: 0o600, flag: "wx" });
 		return;
 	}
-	const legacyRoot = path.resolve(artifactsDir, "local");
+	let legacyRoot: string;
 	let manifest: readonly LegacyEntrySnapshot[];
 	try {
+		legacyRoot = await canonicalLegacyRoot(artifactsDir);
 		manifest = await captureLegacyManifest(legacyRoot);
 	} catch (error) {
 		if (isEnoent(error)) {

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
@@ -25,7 +25,8 @@ export const NOTIFICATION_PROTOCOL_VERSION = 3;
  * incarnation recheck, replacing the darwin no-op) in generation 13, retained
  * legacy stopped-lock reclamation in generation 14, Windows expected-identity
  * ACL verification and repair in generation 15, identity-fenced stale endpoint
- * startup recovery in generation 16, and Telegram topic recovery authority
- * fencing in generation 17.
+ * startup recovery in generation 16, Telegram topic recovery authority fencing
+ * in generation 17, and fail-closed blank-token validation plus lifecycle-startup
+ * stop fencing in generation 18.
  */
-export const DAEMON_GENERATION = 17;
+export const DAEMON_GENERATION = 18;

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -7801,6 +7801,7 @@ export class TelegramNotificationDaemon {
 		// Runtime callers can bypass TypeScript's option type. Without a valid bot
 		// token, there is no authenticated daemon identity or lifecycle authority.
 		if (!validBotToken(this.opts.botToken)) return;
+		let ownershipProved = false;
 		try {
 			const renewed = await renewDaemonHeartbeat({
 				settings: this.opts.settings,
@@ -7813,7 +7814,9 @@ export class TelegramNotificationDaemon {
 				pid: this.opts.pid ?? process.pid,
 				pidIncarnation: this.opts.pidIncarnation,
 			});
-			this.running = !this.stopRequested && renewed;
+			if (!renewed) return;
+			ownershipProved = true;
+			this.running = !this.stopRequested;
 			if (!this.running) return;
 			// Owner-only: start lifecycle control immediately after ownership proof,
 			// before timers or pre-poll startup work can invalidate this run.
@@ -7885,61 +7888,64 @@ export class TelegramNotificationDaemon {
 				await this.runtime.sleep(10);
 			}
 		} finally {
-			let toolShutdownError: unknown;
-			try {
-				await this.beginToolActivityShutdown();
-			} catch (error) {
-				toolShutdownError = error;
-			}
-			this.effects.beginShutdown();
-			this.#deliveryAbort.abort();
-			let persisted = false;
-			const shutdown = this.effects.allowTerminal(async () => {
-				if (toolShutdownError) throw toolShutdownError;
-				await this.#drainBtwTurns();
-				await this.toolTerminalizationChain;
-				this.runtime.stop();
-				this.stopOwnershipHeartbeatTimer();
-				this.stopFlushTimer();
-				this.stopScanTimer();
-				this.stopTypingTimer();
-				this.stopLifecycleControl();
-				await this.cleanupAllAttachmentDirs();
-				await this.persistAliases();
-				await this.persistTopics();
-				await this.persistSeenUpdateIds();
-				await this.opts.control?.clear?.(this.opts.ownerId);
-				persisted = true;
-			});
-			const deadline = Promise.withResolvers<boolean>();
-			const deadlineTimer = setTimeout(() => deadline.resolve(false), BTW_SHUTDOWN_JOIN_MS);
-			const completed = await Promise.race([
-				shutdown.then(
-					() => true,
-					error => {
-						logger.warn(`notifications: shutdown persistence failed: ${sanitizeDiagnostic(String(error))}`);
-						return false;
-					},
-				),
-				deadline.promise,
-			]);
-			clearTimeout(deadlineTimer);
-			const quiesced = completed && (await this.effects.join(BTW_SHUTDOWN_JOIN_MS));
-			if (!quiesced || !persisted) {
-				logger.warn("notifications: shutdown was not durably quiesced; retaining daemon ownership");
-			} else {
-				await releaseDaemonOwnership({
-					settings: this.opts.settings,
-					ownerId: this.opts.ownerId,
-					acquisitionId: this.opts.ownerId,
-					tokenFingerprint: tokenFingerprint(this.opts.botToken),
-					chatId: this.opts.chatId,
-					pid: this.opts.pid ?? process.pid,
-					generation: DAEMON_GENERATION,
-					pidIncarnation: this.opts.pidIncarnation,
-					fs: this.fsImpl,
-					now: this.opts.now,
+			// A contender must not mutate durable owner state while unwinding startup.
+			if (ownershipProved) {
+				let toolShutdownError: unknown;
+				try {
+					await this.beginToolActivityShutdown();
+				} catch (error) {
+					toolShutdownError = error;
+				}
+				this.effects.beginShutdown();
+				this.#deliveryAbort.abort();
+				let persisted = false;
+				const shutdown = this.effects.allowTerminal(async () => {
+					if (toolShutdownError) throw toolShutdownError;
+					await this.#drainBtwTurns();
+					await this.toolTerminalizationChain;
+					this.runtime.stop();
+					this.stopOwnershipHeartbeatTimer();
+					this.stopFlushTimer();
+					this.stopScanTimer();
+					this.stopTypingTimer();
+					this.stopLifecycleControl();
+					await this.cleanupAllAttachmentDirs();
+					await this.persistAliases();
+					await this.persistTopics();
+					await this.persistSeenUpdateIds();
+					await this.opts.control?.clear?.(this.opts.ownerId);
+					persisted = true;
 				});
+				const deadline = Promise.withResolvers<boolean>();
+				const deadlineTimer = setTimeout(() => deadline.resolve(false), BTW_SHUTDOWN_JOIN_MS);
+				const completed = await Promise.race([
+					shutdown.then(
+						() => true,
+						error => {
+							logger.warn(`notifications: shutdown persistence failed: ${sanitizeDiagnostic(String(error))}`);
+							return false;
+						},
+					),
+					deadline.promise,
+				]);
+				clearTimeout(deadlineTimer);
+				const quiesced = completed && (await this.effects.join(BTW_SHUTDOWN_JOIN_MS));
+				if (!quiesced || !persisted) {
+					logger.warn("notifications: shutdown was not durably quiesced; retaining daemon ownership");
+				} else {
+					await releaseDaemonOwnership({
+						settings: this.opts.settings,
+						ownerId: this.opts.ownerId,
+						acquisitionId: this.opts.ownerId,
+						tokenFingerprint: tokenFingerprint(this.opts.botToken),
+						chatId: this.opts.chatId,
+						pid: this.opts.pid ?? process.pid,
+						generation: DAEMON_GENERATION,
+						pidIncarnation: this.opts.pidIncarnation,
+						fs: this.fsImpl,
+						now: this.opts.now,
+					});
+				}
 			}
 		}
 	}

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -871,7 +871,7 @@ function notificationRootForCwd(cwd: string): string {
 }
 
 function validBotToken(token: unknown): token is string {
-	return typeof token === "string" && token.length > 0;
+	return typeof token === "string" && token.trim().length > 0;
 }
 
 function isExplicitlyStoppedDaemonState(state: unknown): state is DaemonState {
@@ -7812,6 +7812,12 @@ export class TelegramNotificationDaemon {
 		// before timers or pre-poll startup work can invalidate this run.
 		// Best-effort; notification delivery remains available on failure.
 		await this.startLifecycleControl();
+		// A stop may arrive while lifecycle startup awaits its control endpoint.
+		// Do not re-enable runtime work after that stop; close the partial server.
+		if (!this.running) {
+			this.stopLifecycleControl();
+			return;
+		}
 		this.runtime.start();
 		this.startOwnershipHeartbeatTimer();
 		this.startFlushTimer();

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -2956,6 +2956,9 @@ export class TelegramNotificationDaemon {
 	private readonly pollConflictBackoff = new OperatorBackoffPolicy({ initialMs: 500, maxMs: 5_000 });
 	private readonly loopBackoff = new OperatorBackoffPolicy({ initialMs: 250, maxMs: 4_000 });
 	private running = false;
+	/** Once set, a concurrent startup await can never restore a running daemon. */
+	private stopRequested = false;
+
 	private readonly fsImpl: TelegramDaemonFs;
 	private readonly botApi: BotApi;
 	private readonly effects = new TelegramEffectSupervisor();
@@ -3073,6 +3076,8 @@ export class TelegramNotificationDaemon {
 	 * ~25s getUpdates timeout. Safe to call from a signal handler.
 	 */
 	requestStop(_reason?: "reload" | "stop" | "signal"): void {
+		this.stopRequested = true;
+
 		const toolShutdown = this.beginToolActivityShutdown();
 		void toolShutdown
 			.finally(() => {
@@ -7796,34 +7801,32 @@ export class TelegramNotificationDaemon {
 		// Runtime callers can bypass TypeScript's option type. Without a valid bot
 		// token, there is no authenticated daemon identity or lifecycle authority.
 		if (!validBotToken(this.opts.botToken)) return;
-		this.running = await renewDaemonHeartbeat({
-			settings: this.opts.settings,
-			ownerId: this.opts.ownerId,
-			acquisitionId: this.opts.ownerId,
-			tokenFingerprint: tokenFingerprint(this.opts.botToken),
-			chatId: this.opts.chatId,
-			fs: this.fsImpl,
-			now: this.opts.now,
-			pid: this.opts.pid ?? process.pid,
-			pidIncarnation: this.opts.pidIncarnation,
-		});
-		if (!this.running) return;
-		// Owner-only: start lifecycle control immediately after ownership proof,
-		// before timers or pre-poll startup work can invalidate this run.
-		// Best-effort; notification delivery remains available on failure.
-		await this.startLifecycleControl();
-		// A stop may arrive while lifecycle startup awaits its control endpoint.
-		// Do not re-enable runtime work after that stop; close the partial server.
-		if (!this.running) {
-			this.stopLifecycleControl();
-			return;
-		}
-		this.runtime.start();
-		this.startOwnershipHeartbeatTimer();
-		this.startFlushTimer();
-		this.startScanTimer();
-		this.startTypingTimer();
 		try {
+			const renewed = await renewDaemonHeartbeat({
+				settings: this.opts.settings,
+				ownerId: this.opts.ownerId,
+				acquisitionId: this.opts.ownerId,
+				tokenFingerprint: tokenFingerprint(this.opts.botToken),
+				chatId: this.opts.chatId,
+				fs: this.fsImpl,
+				now: this.opts.now,
+				pid: this.opts.pid ?? process.pid,
+				pidIncarnation: this.opts.pidIncarnation,
+			});
+			this.running = !this.stopRequested && renewed;
+			if (!this.running) return;
+			// Owner-only: start lifecycle control immediately after ownership proof,
+			// before timers or pre-poll startup work can invalidate this run.
+			// Best-effort; notification delivery remains available on failure.
+			await this.startLifecycleControl();
+			// A stop may arrive while lifecycle startup awaits its control endpoint.
+			// Do not re-enable runtime work after that stop; close the partial server.
+			if (!this.running) return;
+			this.runtime.start();
+			this.startOwnershipHeartbeatTimer();
+			this.startFlushTimer();
+			this.startScanTimer();
+			this.startTypingTimer();
 			await this.refreshBotIdentity();
 			await this.registerBotCommands();
 			await this.loadAliases();

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -7793,13 +7793,9 @@ export class TelegramNotificationDaemon {
 	}
 
 	async run(): Promise<void> {
-		// Runtime callers can bypass TypeScript's option type. Do not derive an
-		// ownership identity from absent credentials; lifecycle startup still owns
-		// cleanup of a factory-created server on this fail-closed path.
-		if (!validBotToken(this.opts.botToken)) {
-			await this.startLifecycleControl();
-			return;
-		}
+		// Runtime callers can bypass TypeScript's option type. Without a valid bot
+		// token, there is no authenticated daemon identity or lifecycle authority.
+		if (!validBotToken(this.opts.botToken)) return;
 		this.running = await renewDaemonHeartbeat({
 			settings: this.opts.settings,
 			ownerId: this.opts.ownerId,
@@ -7812,6 +7808,10 @@ export class TelegramNotificationDaemon {
 			pidIncarnation: this.opts.pidIncarnation,
 		});
 		if (!this.running) return;
+		// Owner-only: start lifecycle control immediately after ownership proof,
+		// before timers or pre-poll startup work can invalidate this run.
+		// Best-effort; notification delivery remains available on failure.
+		await this.startLifecycleControl();
 		this.runtime.start();
 		this.startOwnershipHeartbeatTimer();
 		this.startFlushTimer();
@@ -7825,9 +7825,6 @@ export class TelegramNotificationDaemon {
 			await this.loadSeenUpdateIds();
 			await this.replyStore.load();
 			await this.runScan();
-			// Owner-only: start the session-lifecycle control server now that
-			// ownership is confirmed (singleton-safe). Best-effort; degrades.
-			await this.startLifecycleControl();
 			let idleSince = this.runtime.now();
 			while (this.running) {
 				if (await this.controlStopRequested()) break;

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -265,6 +266,46 @@ describe("LocalProtocolHandler", () => {
 				await initializeLocalRoot(LocalProtocolHandler.resolveOptions()!);
 				expect(await fs.readFile(path.join(localRoot, "legacy.json"), "utf8")).toBe('{"legacy":true}');
 				await expect(fs.lstat(path.join(artifactsDir, "local"))).rejects.toMatchObject({ code: "ENOENT" });
+			});
+		});
+	});
+
+	it("aborts legacy migration when the canonical root changes at manifest capture", async () => {
+		await withTempDir(async artifactsDir => {
+			const sessionId = `legacy-capture-swap-${path.basename(artifactsDir)}`;
+			const legacy = path.join(artifactsDir, "local");
+			const displacedLegacy = path.join(artifactsDir, "displaced-local");
+			await fs.mkdir(legacy, { recursive: true });
+			await Bun.write(path.join(legacy, "legacy.json"), '{"legacy":true}');
+			await withLocalRoot(sessionId, async localRoot => {
+				const lstat = fs.lstat.bind(fs);
+				let rootSnapshots = 0;
+				const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation((async (
+					target: nodeFs.PathLike,
+					options?: nodeFs.StatOptions,
+				) => {
+					if (path.resolve(String(target)) === legacy && ++rootSnapshots === 3) {
+						await fs.rename(legacy, displacedLegacy);
+						await fs.mkdir(legacy);
+						await Bun.write(path.join(legacy, "replacement.json"), '{"replacement":true}');
+					}
+					return lstat(target, options);
+				}) as unknown as typeof fs.lstat);
+				try {
+					LocalProtocolHandler.setOverride(localOptions(sessionId, artifactsDir));
+					await expect(initializeLocalRoot(LocalProtocolHandler.resolveOptions()!)).rejects.toThrow(
+						"Legacy local:// migration source changed during capture",
+					);
+				} finally {
+					lstatSpy.mockRestore();
+				}
+
+				expect(await fs.readFile(path.join(legacy, "replacement.json"), "utf8")).toBe('{"replacement":true}');
+				expect(await fs.readFile(path.join(displacedLegacy, "legacy.json"), "utf8")).toBe('{"legacy":true}');
+				await expect(fs.lstat(path.join(localRoot, ".gjc-local-legacy-migrated-v1"))).rejects.toMatchObject({
+					code: "ENOENT",
+				});
+				await expect(fs.lstat(path.join(localRoot, "legacy.json"))).rejects.toMatchObject({ code: "ENOENT" });
 			});
 		});
 	});

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -240,12 +240,53 @@ describe("LocalProtocolHandler", () => {
 				const resource = await InternalUrlRouter.instance().resolve("local://");
 
 				expect(localRoot).toBe(path.join(os.tmpdir(), "gjc-local", sessionId));
-				expect(resource.sourcePath).toBe(localRoot);
+				expect(resource.sourcePath).toBe(await fs.realpath(localRoot));
 				expect(resource.content).toContain("handoff.json");
 				expect(resource.content).toContain("legacy.json");
 				expect(resource.sourcePath?.startsWith(`${path.resolve(artifactsDir)}${path.sep}`)).toBe(false);
 				await expect(fs.lstat(path.join(artifactsDir, "local"))).rejects.toMatchObject({ code: "ENOENT" });
 				expect((await InternalUrlRouter.instance().resolve("local://legacy.json")).content).toBe('{"legacy":true}');
+			});
+		});
+	});
+
+	it("migrates through a benign ancestor symlink while retaining a canonical migration authority", async () => {
+		if (process.platform === "win32") return;
+		await withTempDir(async tempDir => {
+			const canonicalParent = path.join(tempDir, "canonical");
+			const artifactsDir = path.join(canonicalParent, "artifacts");
+			const aliasedArtifactsDir = path.join(tempDir, "alias", "artifacts");
+			const sessionId = `legacy-ancestor-symlink-${path.basename(tempDir)}`;
+			await fs.mkdir(path.join(artifactsDir, "local"), { recursive: true });
+			await fs.symlink(canonicalParent, path.join(tempDir, "alias"));
+			await Bun.write(path.join(artifactsDir, "local", "legacy.json"), '{"legacy":true}');
+			await withLocalRoot(sessionId, async localRoot => {
+				LocalProtocolHandler.setOverride(localOptions(sessionId, aliasedArtifactsDir));
+				await initializeLocalRoot(LocalProtocolHandler.resolveOptions()!);
+				expect(await fs.readFile(path.join(localRoot, "legacy.json"), "utf8")).toBe('{"legacy":true}');
+				await expect(fs.lstat(path.join(artifactsDir, "local"))).rejects.toMatchObject({ code: "ENOENT" });
+			});
+		});
+	});
+
+	it("fails closed when artifacts/local itself is a symlink during legacy migration", async () => {
+		if (process.platform === "win32") return;
+		await withTempDir(async artifactsDir => {
+			const sessionId = `legacy-root-symlink-${path.basename(artifactsDir)}`;
+			const legacySource = path.join(artifactsDir, "legacy-source");
+			const legacy = path.join(artifactsDir, "local");
+			await fs.mkdir(legacySource, { recursive: true });
+			await Bun.write(path.join(legacySource, "legacy.json"), '{"legacy":true}');
+			await fs.symlink(legacySource, legacy);
+			await withLocalRoot(sessionId, async localRoot => {
+				LocalProtocolHandler.setOverride(localOptions(sessionId, artifactsDir));
+				await expect(InternalUrlRouter.instance().resolve("local://")).rejects.toThrow(
+					"Unsafe legacy local:// migration source",
+				);
+				expect((await fs.lstat(legacy)).isSymbolicLink()).toBe(true);
+				await expect(fs.lstat(path.join(localRoot, ".gjc-local-legacy-migrated-v1"))).rejects.toMatchObject({
+					code: "ENOENT",
+				});
 			});
 		});
 	});

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -271,12 +271,19 @@ describe("LocalProtocolHandler", () => {
 	});
 
 	it("aborts legacy migration when the canonical root changes at manifest capture", async () => {
-		await withTempDir(async artifactsDir => {
-			const sessionId = `legacy-capture-swap-${path.basename(artifactsDir)}`;
+		if (process.platform === "win32") return;
+		await withTempDir(async tempDir => {
+			const canonicalParent = path.join(tempDir, "canonical");
+			const canonicalArtifactsDir = path.join(canonicalParent, "artifacts");
+			const artifactsDir = path.join(tempDir, "alias", "artifacts");
+			const sessionId = `legacy-capture-swap-${path.basename(tempDir)}`;
 			const legacy = path.join(artifactsDir, "local");
 			const displacedLegacy = path.join(artifactsDir, "displaced-local");
+			await fs.mkdir(canonicalArtifactsDir, { recursive: true });
+			await fs.symlink(canonicalParent, path.join(tempDir, "alias"));
 			await fs.mkdir(legacy, { recursive: true });
 			await Bun.write(path.join(legacy, "legacy.json"), '{"legacy":true}');
+			const legacyRootPaths = new Set([path.resolve(legacy), await fs.realpath(legacy)]);
 			await withLocalRoot(sessionId, async localRoot => {
 				const lstat = fs.lstat.bind(fs);
 				let rootSnapshots = 0;
@@ -284,7 +291,7 @@ describe("LocalProtocolHandler", () => {
 					target: nodeFs.PathLike,
 					options?: nodeFs.StatOptions,
 				) => {
-					if (path.resolve(String(target)) === legacy && ++rootSnapshots === 3) {
+					if (legacyRootPaths.has(path.resolve(String(target))) && ++rootSnapshots === 3) {
 						await fs.rename(legacy, displacedLegacy);
 						await fs.mkdir(legacy);
 						await Bun.write(path.join(legacy, "replacement.json"), '{"replacement":true}');

--- a/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
@@ -455,6 +455,60 @@ it("does not restore running state after stop during deferred initial heartbeat 
 	expect([lifecycleFactories, intervalsStarted, apiCalls]).toEqual([0, 0, 0]);
 });
 
+it("does not clean up foreign durable state when initial heartbeat renewal rejects ownership", async () => {
+	const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-daemon-foreign-renewal-"));
+	const settings = daemonSettings(agentDir);
+	await startAsOwner(settings, "foreign-owner", "123456:secret-token");
+	const paths = daemonPaths(agentDir);
+	const durableFiles = [paths.aliases, path.join(paths.dir, "telegram-topics.json"), paths.seenUpdates];
+	const contents = ['{"version":1,"aliases":{}}\n', '{"version":1,"topics":{}}\n', '{"version":1,"updateIds":[42]}\n'];
+	for (let index = 0; index < durableFiles.length; index++)
+		fs.writeFileSync(durableFiles[index]!, contents[index]!, { mode: 0o600 });
+
+	let stateReads = 0;
+	const daemonFs: TelegramDaemonFs = {
+		mkdir: async (directory, opts) => {
+			await fs.promises.mkdir(directory, opts);
+		},
+		readFile: async (file, encoding) => {
+			if (file === paths.state) stateReads++;
+			return await fs.promises.readFile(file, encoding);
+		},
+		writeFile: fs.promises.writeFile.bind(fs.promises),
+		rename: fs.promises.rename.bind(fs.promises),
+		unlink: fs.promises.unlink.bind(fs.promises),
+		open: fs.promises.open.bind(fs.promises),
+		readdir: async file => await fs.promises.readdir(file),
+		chmod: fs.promises.chmod.bind(fs.promises),
+		readEndpointFile: readNotificationEndpointFile,
+		exactUnlink: async (file, identity) =>
+			await exactUnlinkNotificationFile(file, identity, ".gjc-test-daemon-transition.json"),
+	};
+
+	let controlsCleared = 0;
+	const daemon = new TelegramNotificationDaemon({
+		settings,
+		ownerId: "contending-owner",
+		botToken: "123456:secret-token",
+		chatId: PAIRED,
+		fs: daemonFs,
+		botApi: { call: async () => ({ ok: true, result: [] }) } as never,
+		control: {
+			shouldStop: async () => false,
+			clear: async () => {
+				controlsCleared++;
+			},
+		},
+	});
+
+	await daemon.run();
+
+	expect(durableFiles.map(file => fs.readFileSync(file, "utf8"))).toEqual(contents);
+	expect(controlsCleared).toBe(0);
+	expect(stateReads).toBe(1);
+	expect(fs.existsSync(paths.lock)).toBe(true);
+});
+
 describe("lifecycle control runtime", () => {
 	it("buildCreateArgv emits only launcher-supported flags (no --session-id)", () => {
 		expect(buildCreateArgv(createFrame(), { intendedSessionId: "x" })).toEqual({

--- a/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
@@ -264,15 +264,15 @@ it("passes the daemon-derived audit key through real lifecycle startup without a
 	expect(registered).toBe(1);
 });
 
-it("does not attach lifecycle audit dependencies or fall back when daemon key derivation has no token", async () => {
-	const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-daemon-missing-audit-key-"));
+it("rejects a whitespace-only token before lifecycle, timer, or Bot API activity", async () => {
+	const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-daemon-whitespace-token-"));
 	const settings = daemonSettings(agentDir);
-	await startAsOwner(settings, "missing-audit-key-owner", "bot-token");
-
 	let dependenciesBuilt = 0;
 	let registered = 0;
 	let started = 0;
 	let stopped = 0;
+	let intervalsStarted = 0;
+	let apiCalls = 0;
 	const factory: LifecycleControlServerFactory = () =>
 		({
 			onLifecycleRequest: () => {
@@ -288,16 +288,19 @@ it("does not attach lifecycle audit dependencies or fall back when daemon key de
 		}) as LifecycleControlServer;
 	const daemon = new TelegramNotificationDaemon({
 		settings,
-		ownerId: "missing-audit-key-owner",
-		botToken: undefined as unknown as string,
+		ownerId: "whitespace-token-owner",
+		botToken: " \t\n ",
 		chatId: PAIRED,
-		botApi: { call: async () => ({ ok: true, result: [] }) } as never,
-		idleTimeoutMs: 10,
-		now: (() => {
-			let now = 0;
-			return () => (now += 11);
-		})(),
-		setTimeoutImpl: immediateTimeout(),
+		botApi: {
+			call: async () => {
+				apiCalls++;
+				return { ok: true, result: [] };
+			},
+		} as never,
+		setIntervalImpl: ((..._args: unknown[]) => {
+			intervalsStarted++;
+			return 0;
+		}) as unknown as typeof setInterval,
 		createLifecycleControlServer: factory,
 		createLifecycleOrchestratorDeps: () => {
 			dependenciesBuilt++;
@@ -307,7 +310,59 @@ it("does not attach lifecycle audit dependencies or fall back when daemon key de
 
 	await daemon.run();
 
-	expect([dependenciesBuilt, registered, started, stopped]).toEqual([0, 0, 0, 0]);
+	expect([dependenciesBuilt, registered, started, stopped, intervalsStarted, apiCalls]).toEqual([0, 0, 0, 0, 0, 0]);
+});
+
+it("does not resume daemon startup after stop during deferred lifecycle startup", async () => {
+	const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-daemon-lifecycle-stop-"));
+	const settings = daemonSettings(agentDir);
+	await startAsOwner(settings, "lifecycle-stop-owner", "123456:secret-token");
+	const lifecycleStarted = Promise.withResolvers<void>();
+	const releaseLifecycleStart = Promise.withResolvers<void>();
+	let registered = 0;
+	let stopped = 0;
+	let intervalsStarted = 0;
+	let apiCalls = 0;
+	const factory: LifecycleControlServerFactory = () =>
+		({
+			onLifecycleRequest: () => {
+				registered++;
+			},
+			respond: () => {},
+			start: async () => {
+				lifecycleStarted.resolve();
+				await releaseLifecycleStart.promise;
+			},
+			stop: () => {
+				stopped++;
+			},
+		}) as LifecycleControlServer;
+	const daemon = new TelegramNotificationDaemon({
+		settings,
+		ownerId: "lifecycle-stop-owner",
+		botToken: "123456:secret-token",
+		chatId: PAIRED,
+		botApi: {
+			call: async () => {
+				apiCalls++;
+				return { ok: true, result: [] };
+			},
+		} as never,
+		setIntervalImpl: ((..._args: unknown[]) => {
+			intervalsStarted++;
+			return 0;
+		}) as unknown as typeof setInterval,
+		createLifecycleControlServer: factory,
+		createLifecycleOrchestratorDeps: () => stubDeps(),
+	});
+
+	const run = daemon.run();
+	await lifecycleStarted.promise;
+	daemon.requestStop();
+	releaseLifecycleStart.resolve();
+	await run;
+
+	expect([registered, stopped, intervalsStarted, apiCalls]).toEqual([1, 1, 0, 0]);
 });
 
 describe("lifecycle control runtime", () => {

--- a/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
@@ -25,7 +25,7 @@ import * as native from "@gajae-code/natives";
 import { getConfigRootDir, logger } from "@gajae-code/utils";
 import { Settings } from "../src/config/settings";
 import { tokenFingerprint } from "../src/sdk/bus/config";
-import { acquireDaemonOwnership, TelegramNotificationDaemon } from "../src/sdk/bus/telegram-daemon";
+import { acquireDaemonOwnership, daemonPaths, TelegramNotificationDaemon } from "../src/sdk/bus/telegram-daemon";
 import {
 	prepareManagedSessionScopeForWriteSync,
 	resolveManagedScope,
@@ -198,21 +198,28 @@ function immediateTimeout(): typeof setTimeout {
 }
 
 async function startAsOwner(settings: Settings, ownerId: string, botToken: string): Promise<void> {
-	await acquireDaemonOwnership({
+	const acquisition = await acquireDaemonOwnership({
 		settings,
 		tokenFingerprint: tokenFingerprint(botToken),
 		chatId: PAIRED,
 		pid: process.pid,
 		randomId: () => ownerId,
 	});
+	if (!acquisition.acquired) throw new Error(`ownership acquisition failed: ${JSON.stringify(acquisition)}`);
+	const paths = daemonPaths(settings.getAgentDir());
+	const state = JSON.parse(fs.readFileSync(paths.state, "utf8")) as { ownershipPhase: string };
+	state.ownershipPhase = "ready";
+	fs.writeFileSync(paths.state, `${JSON.stringify(state)}\n`, { mode: 0o600 });
+	fs.rmSync(paths.steal, { force: true });
 }
 
 it("passes the daemon-derived audit key through real lifecycle startup without a fallback", async () => {
 	const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-daemon-audit-key-"));
 	const settings = daemonSettings(agentDir);
-	await startAsOwner(settings, "audit-key-owner", "bot-token");
+	await startAsOwner(settings, "audit-key-owner", "123456:secret-token");
 
 	let capturedKey: Uint8Array | undefined;
+	const startupOrder: string[] = [];
 	let registered = 0;
 	const factory: LifecycleControlServerFactory = () =>
 		({
@@ -226,9 +233,14 @@ it("passes the daemon-derived audit key through real lifecycle startup without a
 	const daemon = new TelegramNotificationDaemon({
 		settings,
 		ownerId: "audit-key-owner",
-		botToken: "bot-token",
+		botToken: "123456:secret-token",
 		chatId: PAIRED,
-		botApi: { call: async () => ({ ok: true, result: [] }) } as never,
+		botApi: {
+			call: async (method: string) => {
+				startupOrder.push(`bot:${method}`);
+				return { ok: true, result: [] };
+			},
+		} as never,
 		idleTimeoutMs: 10,
 		now: (() => {
 			let now = 0;
@@ -237,6 +249,7 @@ it("passes the daemon-derived audit key through real lifecycle startup without a
 		setTimeoutImpl: immediateTimeout(),
 		createLifecycleControlServer: factory,
 		createLifecycleOrchestratorDeps: input => {
+			startupOrder.push("lifecycle-deps");
 			capturedKey = input.auditRedactionKey;
 			return { ...stubDeps(), auditRedactionKey: input.auditRedactionKey };
 		},
@@ -245,8 +258,9 @@ it("passes the daemon-derived audit key through real lifecycle startup without a
 	await daemon.run();
 
 	expect(Buffer.from(capturedKey ?? []).toString("hex")).toBe(
-		"03936c8324cc679ecdc4bca97b2a88acaedf993ec45a8e6b3196033a6f9727a6",
+		"ff2063f913d83ae42436a9e33c8bdd86ae77006c5a3fe4980dc7062ba4d95aca",
 	);
+	expect(startupOrder[0]).toBe("lifecycle-deps");
 	expect(registered).toBe(1);
 });
 
@@ -293,7 +307,7 @@ it("does not attach lifecycle audit dependencies or fall back when daemon key de
 
 	await daemon.run();
 
-	expect([dependenciesBuilt, registered, started, stopped]).toEqual([0, 0, 0, 1]);
+	expect([dependenciesBuilt, registered, started, stopped]).toEqual([0, 0, 0, 0]);
 });
 
 describe("lifecycle control runtime", () => {

--- a/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
@@ -25,7 +25,14 @@ import * as native from "@gajae-code/natives";
 import { getConfigRootDir, logger } from "@gajae-code/utils";
 import { Settings } from "../src/config/settings";
 import { tokenFingerprint } from "../src/sdk/bus/config";
-import { acquireDaemonOwnership, daemonPaths, TelegramNotificationDaemon } from "../src/sdk/bus/telegram-daemon";
+import { exactUnlinkNotificationFile, readNotificationEndpointFile } from "../src/sdk/bus/notification-service";
+import {
+	acquireDaemonOwnership,
+	daemonPaths,
+	type TelegramDaemonFs,
+	TelegramNotificationDaemon,
+} from "../src/sdk/bus/telegram-daemon";
+
 import {
 	prepareManagedSessionScopeForWriteSync,
 	resolveManagedScope,
@@ -323,6 +330,8 @@ it("does not resume daemon startup after stop during deferred lifecycle startup"
 	let stopped = 0;
 	let intervalsStarted = 0;
 	let apiCalls = 0;
+	let controlsCleared = 0;
+
 	const factory: LifecycleControlServerFactory = () =>
 		({
 			onLifecycleRequest: () => {
@@ -354,6 +363,12 @@ it("does not resume daemon startup after stop during deferred lifecycle startup"
 		}) as unknown as typeof setInterval,
 		createLifecycleControlServer: factory,
 		createLifecycleOrchestratorDeps: () => stubDeps(),
+		control: {
+			shouldStop: async () => false,
+			clear: async () => {
+				controlsCleared++;
+			},
+		},
 	});
 
 	const run = daemon.run();
@@ -362,7 +377,82 @@ it("does not resume daemon startup after stop during deferred lifecycle startup"
 	releaseLifecycleStart.resolve();
 	await run;
 
-	expect([registered, stopped, intervalsStarted, apiCalls]).toEqual([1, 1, 0, 0]);
+	expect([registered, stopped, intervalsStarted, apiCalls, controlsCleared]).toEqual([1, 1, 0, 0, 1]);
+	const paths = daemonPaths(agentDir);
+	const state = JSON.parse(fs.readFileSync(paths.state, "utf8")) as { stoppedAt?: number };
+	expect(state.stoppedAt).toEqual(expect.any(Number));
+	expect(fs.existsSync(paths.lock)).toBe(false);
+});
+
+it("does not restore running state after stop during deferred initial heartbeat renewal", async () => {
+	const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-daemon-renewal-stop-"));
+	const settings = daemonSettings(agentDir);
+	await startAsOwner(settings, "renewal-stop-owner", "123456:secret-token");
+	const renewalStarted = Promise.withResolvers<void>();
+	const releaseRenewal = Promise.withResolvers<void>();
+	let delayStateRead = true;
+	let lifecycleFactories = 0;
+	let intervalsStarted = 0;
+	let apiCalls = 0;
+	const paths = daemonPaths(agentDir);
+
+	const daemonFs: TelegramDaemonFs = {
+		mkdir: async (directory, opts) => {
+			await fs.promises.mkdir(directory, opts);
+		},
+		readFile: async (file, encoding) => {
+			if (delayStateRead && file === paths.state) {
+				delayStateRead = false;
+				renewalStarted.resolve();
+				await releaseRenewal.promise;
+			}
+			return await fs.promises.readFile(file, encoding);
+		},
+		writeFile: fs.promises.writeFile.bind(fs.promises),
+		rename: fs.promises.rename.bind(fs.promises),
+		unlink: fs.promises.unlink.bind(fs.promises),
+		open: fs.promises.open.bind(fs.promises),
+		readdir: async file => await fs.promises.readdir(file),
+		chmod: fs.promises.chmod.bind(fs.promises),
+		stat: fs.promises.stat.bind(fs.promises),
+		readEndpointFile: readNotificationEndpointFile,
+		exactUnlink: async (file, identity) =>
+			await exactUnlinkNotificationFile(file, identity, ".gjc-test-daemon-transition.json"),
+	};
+	const daemon = new TelegramNotificationDaemon({
+		settings,
+		ownerId: "renewal-stop-owner",
+		botToken: "123456:secret-token",
+		chatId: PAIRED,
+		fs: daemonFs,
+		botApi: {
+			call: async () => {
+				apiCalls++;
+				return { ok: true, result: [] };
+			},
+		} as never,
+		setIntervalImpl: ((..._args: unknown[]) => {
+			intervalsStarted++;
+			return 0;
+		}) as unknown as typeof setInterval,
+		createLifecycleControlServer: () => {
+			lifecycleFactories++;
+			return {
+				onLifecycleRequest: () => {},
+				respond: () => {},
+				start: async () => {},
+				stop: () => {},
+			} as LifecycleControlServer;
+		},
+		createLifecycleOrchestratorDeps: () => stubDeps(),
+	});
+	const run = daemon.run();
+	await renewalStarted.promise;
+	daemon.requestStop();
+	releaseRenewal.resolve();
+	await run;
+
+	expect([lifecycleFactories, intervalsStarted, apiCalls]).toEqual([0, 0, 0]);
 });
 
 describe("lifecycle control runtime", () => {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -2120,9 +2120,9 @@ describe("telegram daemon", () => {
 			}),
 		);
 	}
-	test("keeps wire protocol 3 while Windows ACL and stale startup recovery use generation 17", () => {
+	test("keeps wire protocol 3 while topic recovery, blank-token validation, and lifecycle stop fencing use generation 18", () => {
 		expect(NOTIFICATION_PROTOCOL_VERSION).toBe(3);
-		expect(DAEMON_GENERATION).toBe(17);
+		expect(DAEMON_GENERATION).toBe(18);
 	});
 
 	test("#2028 acquire flags a reload for a live pre-upgrade owner missing the generation field", async () => {

--- a/scripts/telegram-daemon-generation-guard.test.ts
+++ b/scripts/telegram-daemon-generation-guard.test.ts
@@ -427,11 +427,16 @@ test("requires mapped generation bumps for Telegram lease, chat CLI, and configu
 		delete moved.telegram[telegramContract];
 		expect(() => validateManifest({ contractVersion: GUARD_CONTRACT_VERSION, inventory: moved })).toThrow("does not match the protected inventory");
 		const narrowed = mutableInventory();
-		narrowed.telegram[telegramDaemon]!.pop();
+		narrowed.telegram[telegramDaemon] = narrowed.telegram[telegramDaemon]!.filter(name => name !== "writeJsonAtomic");
 		expect(() => validateManifest({ contractVersion: GUARD_CONTRACT_VERSION, inventory: narrowed })).toThrow("Telegram owner-lock handoff primitives");
 	});
 
-	test("rejects inventories missing required Telegram lease, chat CLI, or provider configuration authorities", () => {
+	test("rejects inventories missing required Telegram lifecycle, lease, chat CLI, or provider configuration authorities", () => {
+		for (const symbol of ["validBotToken", "requestStop", "startLifecycleControl", "run"] as const) {
+			const telegram = mutableInventory();
+			telegram.telegram[telegramDaemon] = telegram.telegram[telegramDaemon]!.filter(name => name !== symbol);
+			expect(() => validateInventory(telegram)).toThrow("Telegram authentication and lifecycle primitives");
+		}
 		const telegram = mutableInventory();
 		telegram.telegram[telegramDaemon] = telegram.telegram[telegramDaemon]!.filter(name => name !== "writeJsonAtomic");
 		expect(() => validateInventory(telegram)).toThrow("Telegram owner-lock handoff primitives");
@@ -461,6 +466,10 @@ test("requires mapped generation bumps for Telegram lease, chat CLI, and configu
 				"waitForTelegramDaemonReady",
 				"hasSafeDaemonStateShape",
 				"isPhysicalMatchingOwner",
+				"validBotToken",
+				"requestStop",
+				"startLifecycleControl",
+				"run",
 				"writeJsonAtomic",
 				"ownershipLockMatchesState",
 				"ownershipLockMatchesMetadata",

--- a/scripts/telegram-daemon-generation-guard.ts
+++ b/scripts/telegram-daemon-generation-guard.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 
 const root = path.join(import.meta.dir, "..");
 const SHA = /^[0-9a-f]{40}$/i;
-export const GUARD_CONTRACT_VERSION = 19;
+export const GUARD_CONTRACT_VERSION = 20;
 const telegramContract = "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts";
 const telegramDaemon = "packages/coding-agent/src/sdk/bus/telegram-daemon.ts";
 const chatControl = "packages/coding-agent/src/sdk/bus/chat-daemon-control.ts";
@@ -42,7 +42,7 @@ type GuardManifest = {
  * endpoint or provider generations: they do not replace daemon owners.
  */
 export const protectedInventory = manifest.inventory as Inventory;
-const PROTECTED_INVENTORY_SHA256 = "c4afe2731edb029ea970dd57d2ba57bd1393bc296e0c223da372d7f457c68ee2";
+const PROTECTED_INVENTORY_SHA256 = "ce4a074f34c7f455be235a3c01b10a3ff45e1ba0936c6c5e16ffa6d1db1c8cd8";
 
 /** Transition-marker generations fence every daemon lifecycle mutation. */
 export const TRANSITION_TOKEN_PROTECTED_DECLARATIONS = [
@@ -69,6 +69,9 @@ export const TELEGRAM_OWNER_LOCK_PROTECTED_DECLARATIONS = [
 	"rebindOwnershipLock",
 	"rollbackOwnershipLockRebind",
 ] as const;
+
+/** Telegram authentication and lifecycle control must remain generation-fenced. */
+export const TELEGRAM_LIFECYCLE_PROTECTED_DECLARATIONS = ["validBotToken", "requestStop", "startLifecycleControl", "run"] as const;
 
 /** Chat daemon CLI helpers determine whether a prior owner can be replaced. */
 export const CHAT_CLI_PROTECTED_DECLARATIONS = ["defaultPidAlive", "loadConfig", "ownerPid"] as const;
@@ -131,6 +134,12 @@ function validateTelegramOwnerLockInventory(inventory: Inventory): void {
 		throw new Error("telegram-daemon-generation-guard: Telegram owner-lock handoff primitives must be protected by the Telegram generation contract");
 }
 
+function validateTelegramLifecycleInventory(inventory: Inventory): void {
+	const symbols = inventory.telegram[telegramDaemon];
+	if (!symbols || TELEGRAM_LIFECYCLE_PROTECTED_DECLARATIONS.some(symbol => !symbols.includes(symbol)))
+		throw new Error("telegram-daemon-generation-guard: Telegram authentication and lifecycle primitives must be protected by the Telegram generation contract");
+}
+
 function validateTransitionTokenInventory(inventory: Inventory): void {
 	const symbols = inventory.telegram["packages/coding-agent/src/sdk/bus/notification-service.ts"];
 	if (!symbols || TRANSITION_TOKEN_PROTECTED_DECLARATIONS.some(symbol => !symbols.includes(symbol)))
@@ -144,7 +153,7 @@ function inventoryHash(inventory: Inventory): string {
 }
 
 export function validateInventory(inventory: Inventory = protectedInventory): void {
-	if (GUARD_CONTRACT_VERSION !== 19) throw new Error("telegram-daemon-generation-guard: unsupported guard contract version");
+	if (GUARD_CONTRACT_VERSION !== 20) throw new Error("telegram-daemon-generation-guard: unsupported guard contract version");
 	for (const [family, files] of Object.entries(inventory)) {
 		for (const [file, symbols] of Object.entries(files)) {
 			if (!file || symbols.length === 0 || new Set(symbols).size !== symbols.length)
@@ -153,6 +162,7 @@ export function validateInventory(inventory: Inventory = protectedInventory): vo
 	}
 	validateTransitionTokenInventory(inventory);
 	validateTelegramOwnerLockInventory(inventory);
+	validateTelegramLifecycleInventory(inventory);
 	validateChatOwnerLockInventory(inventory);
 	validateChatCliInventory(inventory);
 	validateChatConfigInventory(inventory);

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -503,7 +503,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:restoreNotificationRootRegistration": "5e3fb78dc9176da05a4392e59d9c9872293534415fc4dc6f74df35eb9ee95daf",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:retireProvisionalDaemonOwnership": "bc126da72ba546ff911bfa5fd8ca8c0918795a8e2c00bf896e4ea5bf335b71eb",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:rollbackOwnershipLockRebind": "7e9bc148e69268c393051e0b87417c20ce44824e777d4be050b9e91607c410a1",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:run": "3bb67be0cfe55ae85f69493212b3645fa9c7d820f1a83c60399ce376b79f0af6",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:run": "bb2d14db3dcf64a86dfab835dc83d523beaadbb59bccd09e7ea8c4346231ad71",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:spawnTelegramDaemonOwner": "66ac27ec9493bc8325003fb2a23bdef7e99908083c59597b609a17f22a03834e",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:startLifecycleControl": "237cf7c7881048e0e4329650567c8a47f597abe43206fe2f29376eb912cd6d1c",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:tryCreateOwnershipLock": "774856cf9f50be869cc3d087d78469e6db719a73ca1d8fc57d388dfbad4c0b81",

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -447,7 +447,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:ownerPidFromOwnerId": "46691373b2bee01f28f3817a6aa6a7efffe880c2cea337c89155582c98d952bf",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonInternal": "4d61235b0c32bf9afc63e1af29eaeca05368607c4997257c15febe071b30b582",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonSmoke": "6f085a667aa5c83de46d2d8945fb845c355fcbb43c46872342a44489203a5830",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "785c0d84869f5427da7ac5056c1961eb7220d1c2452c458f28c2d19d25a20081",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "812ec150e1feda2691afd9e1f57336d92a9f04955729d85872b8651dbafa76c9",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:NOTIFICATION_PROTOCOL_VERSION": "b99289f651fedcf020d28dbaf6f07dd37e7e4a5f6dc1f5118b872112325f1e81",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:TelegramDaemonController": "315d6d63d05d0217e2eb5ec57bcc89e93317f2ce36f2fff0348328b3396941a1",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:clearOwnRequest": "5f02e8a6d69b7400db8aa5f6e33a4efcc29d9b36aa0d71aaeab151b9dbe710c3",

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": 19,
+  "contractVersion": 20,
   "inventory": {
     "telegram": {
       "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts": [
@@ -63,7 +63,11 @@
         "ownershipLockIsReclaimable",
         "reclaimDeadDaemonOwner",
         "isLegacyParentDaemonState",
-        "legacyParentHandoffDecision"
+        "legacyParentHandoffDecision",
+        "validBotToken",
+        "requestStop",
+        "startLifecycleControl",
+        "run"
       ],
       "packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts": [
         "defaultProcessReference",
@@ -495,12 +499,16 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:registerNotificationRoot": "6038d64ecde4ed7c783779c5b35feae1989043abb5bc144fb22121110d117466",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:releaseDaemonOwnership": "686806cf54020ed79dba3d963a53bf35293d6f6add8e256297b5fccdce14c274",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:renewDaemonHeartbeat": "a4a230cadcde2a1f2b7083931d4c7b6eeefb904e9607c0c8b06bd9a846a7cda7",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:requestStop": "09541e49e39af232b571d29d8eac79cfa71eb142ae0d8f0d2d34c731fa41b57a",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:restoreNotificationRootRegistration": "5e3fb78dc9176da05a4392e59d9c9872293534415fc4dc6f74df35eb9ee95daf",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:retireProvisionalDaemonOwnership": "bc126da72ba546ff911bfa5fd8ca8c0918795a8e2c00bf896e4ea5bf335b71eb",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:rollbackOwnershipLockRebind": "7e9bc148e69268c393051e0b87417c20ce44824e777d4be050b9e91607c410a1",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:run": "3bb67be0cfe55ae85f69493212b3645fa9c7d820f1a83c60399ce376b79f0af6",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:spawnTelegramDaemonOwner": "66ac27ec9493bc8325003fb2a23bdef7e99908083c59597b609a17f22a03834e",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:startLifecycleControl": "237cf7c7881048e0e4329650567c8a47f597abe43206fe2f29376eb912cd6d1c",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:tryCreateOwnershipLock": "774856cf9f50be869cc3d087d78469e6db719a73ca1d8fc57d388dfbad4c0b81",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:unregisterNotificationRoot": "f29a0e6c318d283d56ea54888af48724faa64f21f4d1399e3d5fd2c099239d4a",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:validBotToken": "aad5ee94c6b599c43fd087cd133ee07d11601b94091b9e5e8f58b5bf27429afa",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:waitForTelegramDaemonReady": "fe21962bdcf6501a7ba4ea7e04bf442394e35cba4f296fd3469c680730b1cdfb",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:writeJsonAtomic": "a768c87646d56cf28b0adbd596884c964aed54ea40775517fa385c111af05a5b"
   },


### PR DESCRIPTION
## Summary

Fixes two validation-coupled release blockers found during post-0.11.6 changelog validation on macOS. Both preserve strict fail-closed security; `packages/natives` is intentionally untouched.

### 1. Legacy `'/var/folders/yl/ndsjfsl95t781x9qyjrqyqc80000gn/T/gjc-local/019f8750-737c-7000-98b7-ddc65aa4739d'` migration retirement
`retireLegacyTree()` passed a lexical path containing a benign macOS ancestor alias (`/var -> /private/var`) into the strict native no-follow snapshot, which rejected it as `reparse_point` even though the migrated tree had no unsafe component at or below its trusted root (capture used `lstat` and succeeded, retirement failed — an asymmetry).

- New `canonicalLegacyRoot()` canonicalizes only benign ancestor aliases before native operations, requires the lexical `local` endpoint to be a real directory, verifies canonical containment and stable directory identity, then threads the single canonical authority through copy, revalidation, and retirement.
- Symlinks **at or below** the trusted migration root still fail closed.

### 2. Telegram lifecycle audit-key startup
Lifecycle control could be created before owner proof on the invalid-token path, and the derived audit key was not reaching the orchestrator under realistic startup timing.

- `run()` returns immediately for an invalid/absent bot token (no server, deps, or key — no fallback).
- Lifecycle control now starts after successful ownership renewal and before timer/pre-poll work, passing only the real HMAC-derived 32-byte audit key. Startup failure remains nonfatal for notification delivery.

## Tests
- `test/internal-urls/local-protocol.test.ts`: benign ancestor alias accepted; `artifacts/local` symlink and descendant symlinks rejected. 16 pass.
- `test/notifications-lifecycle-control-runtime.test.ts`: exact HMAC key with lifecycle-deps-before-bot ordering; invalid/missing token creates no lifecycle activity `[0,0,0,0]`. 47 pass.
- `bun run check:types` clean; source `bun run dev` version/print smoke ok; release-surface gates (public-sync, schemas, visible-definitions, G002, rebrand `--strict`, default-definitions, release-publish-order) pass.

## Notes
Some sibling lifecycle/ownership suites report pre-existing environment failures (`reparse_point` / "managed sessions root is not a safe directory") that reproduce identically on a clean `dev` tree and are unrelated to this change set.
