### PR TITLE
test(coding-agent): isolate managed session move regression

### DIFF
--- a/packages/coding-agent/test/sdk-move-cwd.test.ts
+++ b/packages/coding-agent/test/sdk-move-cwd.test.ts
@@ -36,7 +36,7 @@ describe("createAgentSession cwd after /move", () => {
 		fs.mkdirSync(cwdA, { recursive: true });
 		fs.mkdirSync(cwdB, { recursive: true });
 
-		const sessionManager = SessionManager.create(cwdA, path.join(tempDir, "sessions"));
+		const sessionManager = SessionManager.create(cwdA, SessionManager.managedDestination(cwdA, tempDir));
 		const { session } = await createAgentSession({
 			cwd: cwdA,
 			agentDir: tempDir,


### PR DESCRIPTION
## Summary
- create the SDK move regression fixture with a managed destination bound to its temporary agent directory
- keep source and destination under the same retained managed root rather than exercising unsupported cross-device explicit-to-managed migration

Closes #2792.

## Verification
- `bun test packages/coding-agent/test/sdk-move-cwd.test.ts packages/coding-agent/test/session-resident-lifecycle.test.ts`
- `bunx biome check packages/coding-agent/test/sdk-move-cwd.test.ts`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*