### PR TITLE
fix(session): repair Windows artifact migration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.
+- Fixed Windows legacy session artifact migration by using native directory identity size, a traversable detached-path alias, and writable file handles for final durability sync.
 - `gjc setup credentials` now auto-imports only OAuth credentials with a finite expiry strictly in the future. Expired or malformed-expiry discoveries remain visible as non-importable records, and existing imported credentials remain recoverable through `/login`.
 - Resumed managed sessions now complete the verified legacy `local://` artifact migration before synchronous path resolution, preserving legacy scratch files instead of failing startup with a migration-order error.
 - Corrected Telegram's uncertain lifecycle guidance so create, close, and resume commands describe their own possible outcome; close and resume no longer display the create-only duplicate-start warning.

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -1836,11 +1836,19 @@ function planArtifactRootForMigration(sourceTranscript: string, operation: strin
 		throw error;
 	}
 	if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("unsafe_artifacts");
+	const tree = snapshotArtifactTree(originalPath);
+	const root = tree.entries.find(entry => entry.relativePath === "" && entry.kind === "directory");
+	if (!root) throw new Error("unsafe_artifacts");
 	return {
 		originalPath,
 		detachedPath: path.join(path.dirname(originalPath), `.gjc-migrate-${operation}-artifacts`),
-		identity: { dev: stat.dev, ino: stat.ino, size: stat.size, mtimeNs: stat.mtimeNs },
-		tree: snapshotArtifactTree(originalPath),
+		identity: {
+			dev: stat.dev,
+			ino: stat.ino,
+			size: process.platform === "win32" ? BigInt(root.size) : stat.size,
+			mtimeNs: stat.mtimeNs,
+		},
+		tree,
 	};
 }
 
@@ -1887,7 +1895,10 @@ function detachArtifactRootForMigration(plan: DetachedArtifactRoot): DetachedArt
 	});
 	if (!result.ok || !result.detachedPath || !matchesDetachedArtifactRoot(result.detachedPath, plan))
 		throw new Error("durability_failed");
-	return { ...plan, detachedPath: result.detachedPath };
+	const detachedPath =
+		process.platform === "win32" ? fs.realpathSync.native(result.detachedPath) : result.detachedPath;
+	if (!matchesDetachedArtifactRoot(detachedPath, plan)) throw new Error("durability_failed");
+	return { ...plan, detachedPath };
 }
 
 function restorePreparedArtifactRoot(scope: ManagedScope, source: ManagedCandidate): void {

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -1621,7 +1621,10 @@ export function fsyncManagedArtifactTree(root: string): NativeDirectoryTreeSnaps
 		const stat = fs.lstatSync(pathname);
 		if (stat.isSymbolicLink()) throw new Error("unsafe_artifacts");
 		if (stat.isFile()) {
-			const fd = fs.openSync(pathname, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+			const fd = fs.openSync(
+				pathname,
+				(process.platform === "win32" ? fs.constants.O_WRONLY : fs.constants.O_RDONLY) | fs.constants.O_NOFOLLOW,
+			);
 			try {
 				fs.fsyncSync(fd);
 			} finally {


### PR DESCRIPTION
Closes #2776.

Windows migration now uses native directory size, normalizes the detached traversal alias, and opens files writable for fsync.

Verification: `bun test packages/coding-agent/test/session-manager/session-directory.test.ts` (33 pass, 1 skip); Biome; `git diff --check`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*