### PR TITLE
fix(coding-agent): scope capability provider policy to sessions

### DIFF
--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -41,6 +41,8 @@ const disabledProviders = new Set<string>();
 
 /** Settings manager for persistence (if set) */
 let settings: Settings | null = null;
+/** Session-local settings keyed by normalized working directory. */
+const settingsByCwd = new Map<string, Settings>();
 
 // =============================================================================
 // Registration API
@@ -208,8 +210,9 @@ async function loadImpl<T>(
  * Filter providers based on options and disabled state.
  */
 function filterProviders<T>(capability: Capability<T>, options: LoadOptions): Provider<T>[] {
-	let providers = (capability.providers as Provider<T>[]).filter(p => !disabledProviders.has(p.id));
-
+	const activeSettings = options.settings ?? settingsByCwd.get(path.normalize(options.cwd ?? getProjectDir()));
+	const activeDisabledProviders = new Set(activeSettings?.get("disabledProviders") ?? disabledProviders);
+	let providers = (capability.providers as Provider<T>[]).filter(p => !activeDisabledProviders.has(p.id));
 	if (options.providers) {
 		const allowed = new Set(options.providers);
 		providers = providers.filter(p => allowed.has(p.id));
@@ -249,63 +252,68 @@ export async function loadCapability<T>(capabilityId: string, options: LoadOptio
  * Call this once on startup to enable persistent provider state.
  */
 export function initializeWithSettings(activeSettings: Settings): void {
+	settingsByCwd.set(path.normalize(activeSettings.getCwd()), activeSettings);
 	settings = activeSettings;
-	// Load disabled providers from settings
-	const disabled = settings.get("disabledProviders");
+	const disabled = activeSettings.get("disabledProviders");
 	disabledProviders.clear();
-	for (const id of disabled) {
-		disabledProviders.add(id);
-	}
+	for (const id of disabled) disabledProviders.add(id);
 }
 
 /**
  * Persist current disabled providers to settings.
  */
-function persistDisabledProviders(): void {
-	if (settings) {
-		settings.set("disabledProviders", Array.from(disabledProviders));
-	}
+function persistDisabledProviders(activeSettings: Settings, providers: ReadonlySet<string>): void {
+	activeSettings.set("disabledProviders", Array.from(providers));
 }
 
-/**
- * Disable a provider globally (across all capabilities).
- */
-export function disableProvider(providerId: string): void {
-	disabledProviders.add(providerId);
-	persistDisabledProviders();
+/** Disable a provider for the supplied session settings. */
+export function disableProvider(
+	providerId: string,
+	activeSettings: Settings = settings ??
+		(() => {
+			throw new Error("Capability settings unavailable");
+		})(),
+): void {
+	const providers = new Set(activeSettings.get("disabledProviders"));
+	providers.add(providerId);
+	persistDisabledProviders(activeSettings, providers);
 }
 
-/**
- * Enable a previously disabled provider.
- */
-export function enableProvider(providerId: string): void {
-	disabledProviders.delete(providerId);
-	persistDisabledProviders();
+/** Enable a provider for the supplied session settings. */
+export function enableProvider(
+	providerId: string,
+	activeSettings: Settings = settings ??
+		(() => {
+			throw new Error("Capability settings unavailable");
+		})(),
+): void {
+	const providers = new Set(activeSettings.get("disabledProviders"));
+	providers.delete(providerId);
+	persistDisabledProviders(activeSettings, providers);
 }
 
-/**
- * Check if a provider is enabled.
- */
-export function isProviderEnabled(providerId: string): boolean {
-	return !disabledProviders.has(providerId);
+/** Check whether a provider is enabled by the supplied session settings. */
+export function isProviderEnabled(
+	providerId: string,
+	activeSettings: Settings | undefined = settings ?? undefined,
+): boolean {
+	return !new Set(activeSettings?.get("disabledProviders") ?? disabledProviders).has(providerId);
 }
 
-/**
- * Get list of all disabled provider IDs.
- */
-export function getDisabledProviders(): string[] {
-	return Array.from(disabledProviders);
+/** Get disabled providers from the supplied session settings. */
+export function getDisabledProviders(activeSettings: Settings | undefined = settings ?? undefined): string[] {
+	return [...(activeSettings?.get("disabledProviders") ?? disabledProviders)];
 }
 
-/**
- * Set disabled providers from a list (replaces current set).
- */
-export function setDisabledProviders(providerIds: string[]): void {
-	disabledProviders.clear();
-	for (const id of providerIds) {
-		disabledProviders.add(id);
-	}
-	persistDisabledProviders();
+/** Replace disabled providers for the supplied session settings. */
+export function setDisabledProviders(
+	providerIds: string[],
+	activeSettings: Settings = settings ??
+		(() => {
+			throw new Error("Capability settings unavailable");
+		})(),
+): void {
+	persistDisabledProviders(activeSettings, new Set(providerIds));
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -6,6 +6,7 @@
  * and get back a unified array of MCP servers.
  */
 
+import type { Settings } from "../config/settings";
 /**
  * Context passed to every provider loader.
  */
@@ -72,6 +73,8 @@ export interface LoadOptions {
 	includeDisabled?: boolean;
 	/** Explicit disabled extension IDs to apply instead of settings. */
 	disabledExtensions?: string[];
+	/** Session settings whose provider policy applies to this load. */
+	settings?: Settings;
 }
 
 /**

--- a/packages/coding-agent/test/discovery/session-provider-policy.test.ts
+++ b/packages/coding-agent/test/discovery/session-provider-policy.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+	defineCapability,
+	initializeWithSettings,
+	loadCapability,
+	registerProvider,
+} from "@gajae-code/coding-agent/capability";
+import type { Settings } from "@gajae-code/coding-agent/config/settings";
+
+const capability = defineCapability<{ name: string }>({
+	id: "session-provider-policy-regression",
+	displayName: "Session provider policy regression",
+	description: "Verifies provider policy remains session-local",
+	key: item => item.name,
+});
+registerProvider(capability.id, {
+	id: "session-policy-a",
+	displayName: "Session policy A",
+	description: "Test provider A",
+	priority: 1,
+	load: async () => ({
+		items: [{ name: "a", _source: { provider: "session-policy-a", path: "a", level: "native" } }],
+	}),
+});
+registerProvider(capability.id, {
+	id: "session-policy-b",
+	displayName: "Session policy B",
+	description: "Test provider B",
+	priority: 1,
+	load: async () => ({
+		items: [{ name: "b", _source: { provider: "session-policy-b", path: "b", level: "native" } }],
+	}),
+});
+
+describe("session-local disabled provider policy", () => {
+	test("keeps concurrent session capability reloads isolated", async () => {
+		const first = {
+			get: (key: string) => (key === "disabledProviders" ? ["session-policy-a"] : []),
+			getCwd: () => "/session-a",
+		} as unknown as Settings;
+		const second = {
+			get: (key: string) => (key === "disabledProviders" ? ["session-policy-b"] : []),
+			getCwd: () => "/session-b",
+		} as unknown as Settings;
+		initializeWithSettings(first);
+		initializeWithSettings(second);
+
+		const firstResult = await loadCapability<{ name: string }>(capability.id, { settings: first });
+		const secondResult = await loadCapability<{ name: string }>(capability.id, { settings: second });
+
+		expect(firstResult.items.map(item => item.name)).toEqual(["b"]);
+		expect(secondResult.items.map(item => item.name)).toEqual(["a"]);
+	});
+});


### PR DESCRIPTION
Closes #2774.

Scopes provider filtering to session settings supplied by each capability load and retains cwd-keyed session settings for existing callers. Includes a deterministic two-session reload regression.

Verification: `bun test packages/coding-agent/test/discovery/session-provider-policy.test.ts`; Biome; `git diff --check`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*