### PR TITLE
fix(coding-agent): format runner artifact cleanup

### DIFF
--- a/packages/coding-agent/src/eval/py/runner-artifact.ts
+++ b/packages/coding-agent/src/eval/py/runner-artifact.ts
@@ -1,8 +1,7 @@
-import { postmortem } from "@gajae-code/utils";
-
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { postmortem } from "@gajae-code/utils";
 import RUNNER_SCRIPT from "./runner.py" with { type: "text" };
 
 const DIRECTORY_MODE = 0o700;

--- a/packages/coding-agent/test/core/python-runner-artifact.test.ts
+++ b/packages/coding-agent/test/core/python-runner-artifact.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { createRunnerScriptCache, createRunnerScriptInitializer } from "@gajae-code/coding-agent/eval/py/runner-artifact";
+import {
+	createRunnerScriptCache,
+	createRunnerScriptInitializer,
+} from "@gajae-code/coding-agent/eval/py/runner-artifact";
 import RUNNER_SCRIPT from "../../src/eval/py/runner.py" with { type: "text" };
 
 describe("Python runner artifact", () => {


### PR DESCRIPTION
Repairs the two Biome violations introduced by the merged #2750 cleanup change. No behavior changes.