### PR TITLE
test(coding-agent): pin pruning fixture context window

### DIFF
--- a/packages/coding-agent/test/pruning-cache-epoch.test.ts
+++ b/packages/coding-agent/test/pruning-cache-epoch.test.ts
@@ -88,8 +88,11 @@ describe("pruning cache-epoch invariant", () => {
 			sessionManager,
 			modelRegistry,
 		);
-		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
-		if (!model) throw new Error("Expected built-in anthropic model to exist");
+		const bundledModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!bundledModel) throw new Error("Expected built-in anthropic model to exist");
+		// This suite exercises fixed 200k maintenance thresholds, not mutable
+		// provider catalog metadata (Claude Sonnet 4.5 now advertises 1M).
+		const model = { ...bundledModel, contextWindow: 200_000 };
 		const agent = new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } });
 		session = new AgentSession({
 			agent,


### PR DESCRIPTION
## Summary

- make the pruning cache-epoch regression use the 200k context window its token thresholds and comments are written against
- stop mutable provider catalog metadata from silently changing the maintenance boundary under test

Addresses the pruning failure tracked in #2866.

## Root cause

`pruning-cache-epoch.test.ts` obtains `claude-sonnet-4-5` from the generated model catalog, then drives turns at 50k, 188k, and 190k tokens under an explicitly documented 200k context assumption.

The refreshed catalog now advertises a 1,000,000-token context window for that model. Therefore 190k is no longer over the automatic compaction threshold, context maintenance correctly does not run, and the test observes zero pruned entries:

```text
Expected: > 0
Received: 0
pruning cache-epoch invariant > prunes tool outputs at the compaction maintenance boundary
```

This is test-fixture drift, not a pruning runtime regression. The test is intended to lock cache-epoch behavior at known maintenance boundaries, so it must own that boundary rather than inherit changing provider metadata.

## Fix

Clone the bundled model fixture with `contextWindow: 200_000` before constructing `Agent`. No production behavior or generated model metadata changes.

## Verification

Before the patch, the focused test fails deterministically at the maintenance-boundary assertion. After the patch:

```text
bun test packages/coding-agent/test/pruning-cache-epoch.test.ts
# 3 pass, 0 fail, 5 assertions

bunx biome check packages/coding-agent/test/pruning-cache-epoch.test.ts
# Checked 1 file. No fixes applied.

git diff --check
# pass
```

This was also the sole real test failure behind PR #2868's prior shard failure. Its two additional downstream failures (`evidence producer` and aggregate `Affected path validation`) were fail-closed consequences of the red shard. The two formatter failures in that run were pre-existing dev baseline drift and are already fixed by upstream PR #2867.
