### PR TITLE
fix(ask): coerce optional null metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Ordinary `ask` calls now normalize a provider-emitted `deepInterview: null` placeholder instead of misclassifying it as malformed Round-0 intent recovery data and rejecting it before coercion.
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.
 - Fixed Windows legacy session artifact migration by using native directory identity size, a traversable detached-path alias, and writable file handles for final durability sync.
 - `gjc setup credentials` now auto-imports only OAuth credentials with a finite expiry strictly in the future. Expired or malformed-expiry discoveries remain visible as non-importable records, and existing imported credentials remain recoverable through `/login`.

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -317,7 +317,7 @@ function isRoundZeroRecoveryCandidate(value: unknown): boolean {
 		const question = parseEncodedContainer(rawQuestion);
 		if (typeof question !== "object" || question === null || !Object.hasOwn(question, "deepInterview")) return false;
 		const deepInterview = parseEncodedContainer((question as Record<string, unknown>).deepInterview);
-		if (typeof deepInterview !== "object" || deepInterview === null) return deepInterview === null;
+		if (typeof deepInterview !== "object" || deepInterview === null) return false;
 		const metadata = deepInterview as Record<string, unknown>;
 		return Object.hasOwn(metadata, "intent_contract") || Object.hasOwn(metadata, "intent_review");
 	});

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -3038,6 +3038,21 @@ describe("AskTool Round-0 intent recovery", () => {
 		expect(question).not.toHaveProperty("workflowGate");
 	});
 
+	it("normalizes a null optional deepInterview field on an ordinary ask", () => {
+		const result = validateAsk({
+			questions: [
+				{
+					id: "ordinary",
+					question: "Choose one",
+					options: [{ label: "First" }, { label: "Second" }],
+					deepInterview: null,
+				},
+			],
+		});
+
+		expect(result.questions[0]).not.toHaveProperty("deepInterview");
+	});
+
 	it("terminally rejects every recovery-shaped near-miss before coercion", () => {
 		const recorder = spyOn(deepInterviewRecorder, "appendOrMergeDeepInterviewRound");
 		const gateEmitter = { isUnattended: () => true, emitGate: vi.fn() };
@@ -3088,8 +3103,6 @@ describe("AskTool Round-0 intent recovery", () => {
 			encodedDeepInterview.questions[0].deepInterview,
 		) as never;
 		const nullQuestions = { questions: null } as unknown as Record<string, unknown>;
-		const nullDeepInterview = roundZeroPair();
-		nullDeepInterview.questions[0].deepInterview = null as never;
 		const malformedContractOnly = roundZeroPair();
 		Reflect.deleteProperty(malformedContractOnly.questions[0].deepInterview, "intent_review");
 		malformedContractOnly.questions[0].deepInterview.round = 1;
@@ -3134,7 +3147,6 @@ describe("AskTool Round-0 intent recovery", () => {
 			encodedQuestion,
 			encodedDeepInterview,
 			nullQuestions,
-			nullDeepInterview,
 			malformedContractOnly,
 			malformedReviewOnly,
 			sparseAdapterContext,


### PR DESCRIPTION
## Summary

- allow ordinary `ask` calls to pass provider-emitted `deepInterview: null` through the existing optional-field normalization
- keep the pre-coercion Round-0 recovery fence limited to payloads that actually contain `intent_contract` or `intent_review`
- preserve terminal rejection for malformed, authority-bearing Round-0 recovery candidates

## Regression

PR #2652 added a raw-argument recovery fence for malformed Deep Interview Round-0 intent calls. `isRoundZeroRecoveryCandidate()` also classified any question with `deepInterview: null` as a recovery candidate, even though `deepInterview` is optional in the canonical Ask schema.

Strict providers commonly emit `null` placeholders for optional fields. Because raw validation runs before the shared optional-null normalizer, this valid ordinary Ask shape failed with:

```text
Validation failed for tool "ask": raw arguments rejected before coercion
```

Reproduction input:

```json
{
  "questions": [
    {
      "id": "ordinary",
      "question": "Choose one",
      "options": [{ "label": "First" }, { "label": "Second" }],
      "deepInterview": null
    }
  ]
}
```

Before this change, the focused regression test deterministically failed at `validateToolArguments()` with the pre-coercion rejection. After this change, shared normalization removes `deepInterview` and validates the ordinary Ask normally.

## Why this is minimal

The candidate detector now returns false for null/non-object `deepInterview` values. It still recognizes only object metadata carrying an own `intent_contract` or `intent_review` property, so malformed intent-bearing payloads retain the stricter pre-coercion rejection introduced by #2652. No execution, workflow-gate, SDK transport, or recorder behavior changes.

## Verification

- `bun test packages/ai/test/tool-argument-coercion.test.ts packages/coding-agent/test/tools/ask.test.ts` — 122 pass, 0 fail
- `bunx biome check packages/coding-agent/src/tools/ask.ts packages/coding-agent/test/tools/ask.test.ts` — clean
- `git diff --check` — clean
