### PR TITLE
fix(coding-agent): restore maintenance and preset regressions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.
+- Restored `/models` preset landing navigation after the Image Generation row and made compaction/pruning regression fixtures use an explicit 200K context boundary instead of a mutable provider descriptor default.
 - Fixed Windows legacy session artifact migration by using native directory identity size, a traversable detached-path alias, and writable file handles for final durability sync.
 - `gjc setup credentials` now auto-imports only OAuth credentials with a finite expiry strictly in the future. Expired or malformed-expiry discoveries remain visible as non-importable records, and existing imported credentials remain recoverable through `/login`.
 - Resumed managed sessions now complete the verified legacy `local://` artifact migration before synchronous path resolution, preserving legacy scratch files instead of failing startup with a migration-order error.

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -973,8 +973,8 @@ export class ModelSelectorComponent extends Container {
 		} else {
 			rows.push({ kind: "createUnavailable", label: "Select a model before creating a custom preset" });
 		}
-		rows.push({ kind: "browse" });
 		rows.push({ kind: "imageGeneration" });
+		rows.push({ kind: "browse" });
 		return rows;
 	}
 

--- a/packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
@@ -93,8 +93,9 @@ describe("AgentSession auto-compaction continuation", () => {
 			sessionManager,
 			modelRegistry,
 		);
-		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
-		if (!model) throw new Error("Expected built-in anthropic model to exist");
+		const bundledModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!bundledModel) throw new Error("Expected built-in anthropic model to exist");
+		const model = { ...bundledModel, contextWindow: 200_000 };
 		const agent = new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } });
 		sessionManager.appendMessage({ role: "user", content: "hello", timestamp: Date.now() });
 		session = new AgentSession({

--- a/packages/coding-agent/test/pruning-cache-epoch.test.ts
+++ b/packages/coding-agent/test/pruning-cache-epoch.test.ts
@@ -88,8 +88,9 @@ describe("pruning cache-epoch invariant", () => {
 			sessionManager,
 			modelRegistry,
 		);
-		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
-		if (!model) throw new Error("Expected built-in anthropic model to exist");
+		const bundledModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!bundledModel) throw new Error("Expected built-in anthropic model to exist");
+		const model = { ...bundledModel, contextWindow: 200_000 };
 		const agent = new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } });
 		session = new AgentSession({
 			agent,


### PR DESCRIPTION
Closes #2866.

Restores Browse-all landing order after Image Generation and pins compaction/pruning regression fixtures to their intentional 200K context boundary instead of the live 1M provider descriptor.

Verification: focused baseline suite repeated 3x (78 pass); coding-agent typecheck; Biome; `git diff --check`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*