### PR TITLE
fix(tools): explain disabled skill discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - `/btw` now opens an ephemeral multi-turn side chat: plain text continues the side thread until Esc returns to the main chat, while visible text-only context stays outside the main transcript and session observability/debug hooks and is scrubbed synchronously on close or abort.
 - Added `statusLine.showActionHints` (default: `true`) to hide contextual action hints while retaining configured status-line segments.
+- `skill_discovery` empty results now carry a `notice` when discovery config caused the emptiness — naming the exact disabled setting (`skills.enabled`, `skills.enablePiProject`, or `skills.enablePiUser`) and the `gjc config set` command to enable it. Previously a disabled config was indistinguishable from "no skills exist", silently hiding freshly written user/project skills.
 
 ### Fixed
 

--- a/packages/coding-agent/src/prompts/tools/skill-discovery.md
+++ b/packages/coding-agent/src/prompts/tools/skill-discovery.md
@@ -3,6 +3,7 @@ Discover project and user runtime skills without loading full skill content.
 <instruction>
 - Searches only custom runtime skill locations: nearest project `.gjc/skills`; then, under the home directory, canonical `<config>/agent/skills`, configured legacy `<config>/skills`, and historical legacy `.gjc/skills`. `<config>` is the home-relative directory name from `GJC_CONFIG_DIR`, then `PI_CONFIG_DIR`, then `.gjc`; even an absolute-looking configured name is joined beneath `<home>`. Duplicate names use that exact precedence. Built-in, bundled, and internal workflow skills are intentionally excluded.
 - Returns thin metadata only: name, description, source scope, path, and use conditions when present.
+- When zero candidates are returned because discovery config is disabled (`skills.enabled`, `skills.enablePiProject`, `skills.enablePiUser`), the result carries a `notice` explaining which setting blocked the search — an empty result without a `notice` means the searched scopes genuinely contain no matching skills.
 - To load a selected skill's full `SKILL.md`, invoke it through the existing `skill` tool with the exact `name` returned here.
 </instruction>
 

--- a/packages/coding-agent/src/tools/skill-discovery.ts
+++ b/packages/coding-agent/src/tools/skill-discovery.ts
@@ -21,6 +21,13 @@ export type SkillDiscoveryToolInput = z.infer<typeof skillDiscoverySchema>;
 export interface SkillDiscoveryToolDetails {
 	candidates: RuntimeSkillDiscoveryCandidate[];
 	count: number;
+	/**
+	 * Present only when zero candidates were returned AND discovery config gates
+	 * (`skills.enabled` / `skills.enablePiProject` / `skills.enablePiUser`)
+	 * prevented some or all of the requested scope from being searched. Without
+	 * this, a disabled config is indistinguishable from "no skills exist".
+	 */
+	notice?: string;
 }
 
 export class SkillDiscoveryTool implements AgentTool<typeof skillDiscoverySchema, SkillDiscoveryToolDetails> {
@@ -57,17 +64,46 @@ export class SkillDiscoveryTool implements AgentTool<typeof skillDiscoverySchema
 		signal?: AbortSignal,
 	): Promise<AgentToolResult<SkillDiscoveryToolDetails>> {
 		return untilAborted(signal, async () => {
+			const source = input.source ?? "all";
 			const candidates = await discoverRuntimeSkills({
 				cwd: this.#session.cwd,
 				query: input.query,
-				source: input.source ?? "all",
+				source,
 				limit: input.limit,
 				policy: this.#getRuntimeSkillPolicy(),
 			});
+			const details: SkillDiscoveryToolDetails = { candidates, count: candidates.length };
+			if (candidates.length === 0) {
+				const notice = this.#disabledPolicyNotice(source);
+				if (notice) details.notice = notice;
+			}
 			return {
-				content: [{ type: "text", text: JSON.stringify({ candidates, count: candidates.length }, null, 2) }],
-				details: { candidates, count: candidates.length },
+				content: [{ type: "text", text: JSON.stringify(details, null, 2) }],
+				details,
 			};
 		});
+	}
+
+	/**
+	 * Explain an empty result that is caused by disabled discovery config rather
+	 * than by an actually empty skill catalog.
+	 */
+	#disabledPolicyNotice(source: "all" | "project" | "user"): string | undefined {
+		const policy = this.#getRuntimeSkillPolicy();
+		if (policy.enabled !== true) {
+			return "Runtime skill discovery is disabled: `skills.enabled` is false, so no skill directories were searched. Enable it with `gjc config set skills.enabled true` (project and user scopes additionally require `skills.enablePiProject` / `skills.enablePiUser`).";
+		}
+		const skipped: string[] = [];
+		const commands: string[] = [];
+		if ((source === "all" || source === "project") && policy.enablePiProject !== true) {
+			skipped.push("project (`skills.enablePiProject` is false)");
+			commands.push("`gjc config set skills.enablePiProject true`");
+		}
+		if ((source === "all" || source === "user") && policy.enablePiUser !== true) {
+			skipped.push("user (`skills.enablePiUser` is false)");
+			commands.push("`gjc config set skills.enablePiUser true`");
+		}
+		if (skipped.length === 0) return undefined;
+		return `Skill discovery skipped disabled scope(s): ${skipped.join(", ")}. Enable them with ${commands.join(" and ")}.`;
 	}
 }

--- a/packages/coding-agent/test/tools/skill-discovery.test.ts
+++ b/packages/coding-agent/test/tools/skill-discovery.test.ts
@@ -218,6 +218,7 @@ describe("SkillDiscoveryTool", () => {
 
 		const discovery = await new SkillDiscoveryTool(createSession(cwd, { settings })).execute("call", {});
 		expect(discovery.details?.candidates).toEqual([]);
+		expect(discovery.details?.notice).toContain("`skills.enabled` is false");
 
 		const sent: Array<{ content: string; details?: unknown }> = [];
 		const tool = new SkillTool(
@@ -231,6 +232,42 @@ describe("SkillDiscoveryTool", () => {
 		);
 		await expect(tool.execute("call", { name: "project-helper" })).rejects.toThrow(/unknown skill/);
 		expect(sent).toHaveLength(0);
+	});
+
+	it("explains empty results caused by disabled discovery scopes, and stays silent for genuine emptiness", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-skills-notice-"));
+		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill");
+
+		// Requested scope is fully disabled: empty result carries a scope notice.
+		const userOff = runtimeSkillSettings({ "skills.enablePiUser": false });
+		const userScope = await new SkillDiscoveryTool(createSession(cwd, { settings: userOff })).execute("call", {
+			source: "user",
+		});
+		expect(userScope.details?.candidates).toEqual([]);
+		expect(userScope.details?.notice).toContain("`skills.enablePiUser` is false");
+
+		// A disabled scope is mentioned even under source "all" when nothing was found.
+		const projectOff = runtimeSkillSettings({ "skills.enablePiProject": false });
+		const allScope = await new SkillDiscoveryTool(createSession(cwd, { settings: projectOff })).execute("call", {
+			query: "no-such-skill-anywhere",
+		});
+		expect(allScope.details?.candidates).toEqual([]);
+		expect(allScope.details?.notice).toContain("`skills.enablePiProject` is false");
+
+		// Fully enabled policy with a non-matching query: genuinely empty, no notice.
+		const enabled = runtimeSkillSettings();
+		const genuine = await new SkillDiscoveryTool(createSession(cwd, { settings: enabled })).execute("call", {
+			query: "no-such-skill-anywhere",
+		});
+		expect(genuine.details?.candidates).toEqual([]);
+		expect(genuine.details?.notice).toBeUndefined();
+
+		// Found results never carry a notice.
+		const found = await new SkillDiscoveryTool(createSession(cwd, { settings: enabled })).execute("call", {
+			query: "project helper",
+		});
+		expect(found.details?.count).toBe(1);
+		expect(found.details?.notice).toBeUndefined();
 	});
 
 	it("discovers canonical and legacy user roots in native precedence order", async () => {


### PR DESCRIPTION
Closes #2716.\n\nAdds a diagnostic only when disabled skill policy caused an empty discovery result, including concrete commands for every disabled requested scope.\n\nVerification: focused skill-discovery tests, Biome, coding-agent typecheck.\n\n—\n*[repo owner's gaebal-gajae (clawdbot) 🦞]*