### PR TITLE
fix(cli): route managed owner supervisor before root launch parsing

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -8,6 +8,7 @@ import "@gajae-code/utils/postmortem";
 import { Args, type CliConfig, Command, type CommandEntry, Flags, run } from "@gajae-code/utils/cli";
 import { APP_NAME, formatBunRuntimeError, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
 import { runFixtureReport } from "./cli/fixture-report";
+import { isManagedOwnerSupervisorArgv, runManagedOwnerSupervisor } from "./gjc-runtime/managed-owner-supervisor";
 import { isTmuxOwnerIsolationCliArgv, runTmuxOwnerIsolationCliFromStdin } from "./gjc-runtime/tmux-owner-isolation-cli";
 import { smokeTestTabWorker } from "./tools/browser/tab-worker-smoke";
 
@@ -348,6 +349,10 @@ export async function runCli(argv: string[]): Promise<void> {
 	}
 	if (isTmuxOwnerIsolationCliArgv(argv)) {
 		await runTmuxOwnerIsolationCliFromStdin();
+		return;
+	}
+	if (isManagedOwnerSupervisorArgv(argv)) {
+		await runManagedOwnerSupervisor();
 		return;
 	}
 	if (isNotifyDaemonInternalFastPath(argv)) {

--- a/packages/coding-agent/test/gjc-runtime/managed-owner-supervisor.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/managed-owner-supervisor.test.ts
@@ -22,6 +22,7 @@ const admissionModule = path.join(
 	"gjc-runtime",
 	"managed-owner-admission.ts",
 );
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
 
 async function runSupervisor(
 	stateDir: string,
@@ -101,6 +102,36 @@ describe("managed owner supervisor", () => {
 			expect(result.exitCode).toBe(23);
 			const root = lifecyclePaths(stateDir, "session-2681", "generation-2681").root;
 			expect((await fs.readdir(root)).some(file => file.startsWith("sigabrt-"))).toBe(false);
+		} finally {
+			await fs.rm(stateDir, { recursive: true, force: true });
+		}
+	});
+	it("routes the internal supervisor flag before root launch argument parsing", async () => {
+		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-owner-cli-"));
+		const marker = path.join(stateDir, "child-ran.txt");
+		try {
+			const child = Bun.spawn({
+				cmd: [process.execPath, cliEntry, "--internal-managed-owner-supervisor"],
+				cwd: repoRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+				env: {
+					...process.env,
+					GJC_TMUX_OWNER_STATE_DIR: stateDir,
+					GJC_COORDINATOR_SESSION_ID: "session-cli",
+					GJC_TMUX_OWNER_GENERATION: "generation-cli",
+					GJC_MANAGED_OWNER_RUN_ID: "run-cli",
+					GJC_MANAGED_OWNER_INCARNATION: "incarnation-cli",
+					GJC_MANAGED_OWNER_COMMAND_JSON: JSON.stringify([
+						process.execPath,
+						"-e",
+						`await Bun.write(${JSON.stringify(marker)}, "ok");`,
+					]),
+				},
+			});
+			const [stderr, exitCode] = await Promise.all([new Response(child.stderr).text(), child.exited]);
+			expect(exitCode, stderr).toBe(0);
+			expect(await fs.readFile(marker, "utf8")).toBe("ok");
 		} finally {
 			await fs.rm(stateDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

- route `--internal-managed-owner-supervisor` through the root CLI fast path
- prevent lifecycle cold resumes from treating the supervisor flag as a normal launch
- add an entrypoint regression test that verifies the supervisor executes its configured child command

## Problem

Telegram `/session_resume <sessionId>` correctly prepared:

```text
GJC_MANAGED_OWNER_COMMAND_JSON=["gjc","--resume","<sessionId>"]
```

but the root CLI routed `--internal-managed-owner-supervisor` through normal launch argument parsing. The process therefore opened a fresh GJC session inside the correctly named `gjc_lc_<sessionId>` tmux session instead of executing the configured resume command.

## Verification

- `bun test packages/coding-agent/test/gjc-runtime/managed-owner-supervisor.test.ts`
- `bun run check:tools`
- `git diff --check`

The full repository suites were also attempted from a clean GJC environment. Unrelated upstream failures remain:

- two `gjc-sdk` oversized WebSocket frame tests fail when the peer resets the connection before the oversized send completes
- one Telegram daemon async cleanup test intermittently misses the expected `deleteForumTopic` call

Neither failing test imports or executes the changed CLI/supervisor path.
