### PR TITLE
fix(pi-iso): stop plain diffs following symlinks

### DIFF
--- a/crates/pi-iso/src/diff.rs
+++ b/crates/pi-iso/src/diff.rs
@@ -8,8 +8,9 @@
 //!   file. Binary entries surface as `diff: None`.
 //! - **Plain mode.** No `.git`; we walk both trees in parallel, short-circuit
 //!   on `(size, mtime-truncated-to-seconds)` equality, and emit a unified diff
-//!   for each surviving pair via `similar`. NUL within the first 8 KiB
-//!   classifies the file as binary → `diff: None`.
+//!   for each surviving pair via `similar`. Symlinks are represented by their
+//!   link payload without following them. NUL within the first 8 KiB classifies
+//!   the file as binary → `diff: None`.
 //!
 //! Per the PAL contract: for binary files we don't materialize the bytes
 //! in the patch — callers that want them read directly from `merged`
@@ -17,7 +18,8 @@
 
 use std::{
 	collections::BTreeMap,
-	fs::Metadata,
+	fs::{Metadata, OpenOptions},
+	io::Read,
 	path::{Path, PathBuf},
 	time::SystemTime,
 };
@@ -272,18 +274,24 @@ fn walk_diff_blocking(lower: &Path, merged: &Path) -> IsoResult<Diff> {
 
 	for (rel, m_meta) in &merged_index {
 		match lower_index.get(rel) {
-			None => files.push(plain_change(merged, rel, ChangeKind::Added, None)?),
+			None => files.push(plain_change(merged, rel, ChangeKind::Added, m_meta, None)?),
 			Some(l_meta) => {
 				if metas_equal(l_meta, m_meta) {
 					continue;
 				}
-				files.push(plain_change(merged, rel, ChangeKind::Modified, Some(lower))?);
+				files.push(plain_change(
+					merged,
+					rel,
+					ChangeKind::Modified,
+					m_meta,
+					Some((lower, l_meta)),
+				)?);
 			},
 		}
 	}
-	for rel in lower_index.keys() {
+	for (rel, l_meta) in &lower_index {
 		if !merged_index.contains_key(rel) {
-			files.push(plain_change(lower, rel, ChangeKind::Removed, None)?);
+			files.push(plain_change(lower, rel, ChangeKind::Removed, l_meta, None)?);
 		}
 	}
 
@@ -291,12 +299,26 @@ fn walk_diff_blocking(lower: &Path, merged: &Path) -> IsoResult<Diff> {
 	Ok(Diff { files })
 }
 
-fn metas_equal(a: &Metadata, b: &Metadata) -> bool {
-	if a.len() != b.len() {
-		return false;
-	}
-	match (a.modified(), b.modified()) {
-		(Ok(ma), Ok(mb)) => systime_eq(ma, mb),
+#[derive(Debug)]
+enum PlainEntryMetadata {
+	Regular(Metadata),
+	Symlink(PathBuf),
+}
+
+fn metas_equal(a: &PlainEntryMetadata, b: &PlainEntryMetadata) -> bool {
+	match (a, b) {
+		(PlainEntryMetadata::Symlink(a_target), PlainEntryMetadata::Symlink(b_target)) => {
+			a_target == b_target
+		},
+		(PlainEntryMetadata::Regular(a_meta), PlainEntryMetadata::Regular(b_meta)) => {
+			if a_meta.len() != b_meta.len() {
+				return false;
+			}
+			match (a_meta.modified(), b_meta.modified()) {
+				(Ok(ma), Ok(mb)) => systime_eq(ma, mb),
+				_ => false,
+			}
+		},
 		_ => false,
 	}
 }
@@ -313,7 +335,7 @@ fn systime_eq(a: SystemTime, b: SystemTime) -> bool {
 	to_secs(a) == to_secs(b)
 }
 
-fn index_tree(root: &Path) -> IsoResult<BTreeMap<PathBuf, Metadata>> {
+fn index_tree(root: &Path) -> IsoResult<BTreeMap<PathBuf, PlainEntryMetadata>> {
 	let mut out = BTreeMap::new();
 	if !root.exists() {
 		return Ok(out);
@@ -322,7 +344,7 @@ fn index_tree(root: &Path) -> IsoResult<BTreeMap<PathBuf, Metadata>> {
 	Ok(out)
 }
 
-fn walk(root: &Path, dir: &Path, out: &mut BTreeMap<PathBuf, Metadata>) -> IsoResult<()> {
+fn walk(root: &Path, dir: &Path, out: &mut BTreeMap<PathBuf, PlainEntryMetadata>) -> IsoResult<()> {
 	let entries = std::fs::read_dir(dir)
 		.map_err(|err| IsoError::other(format!("read_dir {}: {err}", dir.display())))?;
 	for entry in entries {
@@ -334,7 +356,9 @@ fn walk(root: &Path, dir: &Path, out: &mut BTreeMap<PathBuf, Metadata>) -> IsoRe
 			.map_err(|err| IsoError::other(format!("metadata {}: {err}", path.display())))?;
 		if meta.is_symlink() {
 			let rel = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
-			out.insert(rel, meta);
+			let target = std::fs::read_link(&path)
+				.map_err(|err| IsoError::other(format!("read_link {}: {err}", path.display())))?;
+			out.insert(rel, PlainEntryMetadata::Symlink(target));
 			continue;
 		}
 		if meta.is_dir() {
@@ -342,39 +366,43 @@ fn walk(root: &Path, dir: &Path, out: &mut BTreeMap<PathBuf, Metadata>) -> IsoRe
 			continue;
 		}
 		let rel = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
-		out.insert(rel, meta);
+		out.insert(rel, PlainEntryMetadata::Regular(meta));
 	}
 	Ok(())
 }
 
 /// Build a [`FileChange`] for an entry observed by [`walk_diff_blocking`].
 ///
-/// `op == Modified` requires `peer_root = Some(lower)` so we can read the
-/// counterpart; `Added`/`Removed` only need the side we already know about.
+/// `op == Modified` requires `peer = Some((lower, metadata))` so we can read
+/// the counterpart; `Added`/`Removed` only need the side we already know about.
 fn plain_change(
 	side: &Path,
 	rel: &Path,
 	op: ChangeKind,
-	peer_root: Option<&Path>,
+	entry: &PlainEntryMetadata,
+	peer: Option<(&Path, &PlainEntryMetadata)>,
 ) -> IsoResult<FileChange> {
 	let full = side.join(rel);
-	let primary = std::fs::read(&full)
-		.map_err(|err| IsoError::other(format!("read {}: {err}", full.display())))?;
+	let primary = read_plain_entry(&full, entry)?;
 	if looks_binary(&primary) {
 		return Ok(FileChange { path: rel.to_path_buf(), op, diff: None });
 	}
-	let (old_bytes, new_bytes) = match op {
-		ChangeKind::Added => (Vec::new(), primary),
-		ChangeKind::Removed => (primary, Vec::new()),
+	let primary_is_symlink = matches!(entry, PlainEntryMetadata::Symlink(_));
+	let (old_bytes, new_bytes, old_is_symlink, new_is_symlink) = match op {
+		ChangeKind::Added => (Vec::new(), primary, false, primary_is_symlink),
+		ChangeKind::Removed => (primary, Vec::new(), primary_is_symlink, false),
 		ChangeKind::Modified => {
-			let peer = peer_root.expect("modified change requires peer root");
-			let peer_full = peer.join(rel);
-			let peer_bytes = std::fs::read(&peer_full)
-				.map_err(|err| IsoError::other(format!("read {}: {err}", peer_full.display())))?;
+			let (peer_root, peer_entry) = peer.expect("modified change requires peer metadata");
+			let peer_bytes = read_plain_entry(&peer_root.join(rel), peer_entry)?;
 			if looks_binary(&peer_bytes) {
 				return Ok(FileChange { path: rel.to_path_buf(), op, diff: None });
 			}
-			(peer_bytes, primary)
+			(
+				peer_bytes,
+				primary,
+				matches!(peer_entry, PlainEntryMetadata::Symlink(_)),
+				primary_is_symlink,
+			)
 		},
 	};
 	let (Ok(old_text), Ok(new_text)) =
@@ -385,11 +413,48 @@ fn plain_change(
 	Ok(FileChange {
 		path: rel.to_path_buf(),
 		op,
-		diff: Some(render_unified(rel, op, old_text, new_text)),
+		diff: Some(render_unified(rel, op, old_text, new_text, old_is_symlink, new_is_symlink)),
 	})
 }
 
-fn render_unified(rel: &Path, op: ChangeKind, old: &str, new: &str) -> String {
+fn read_plain_entry(path: &Path, entry: &PlainEntryMetadata) -> IsoResult<Vec<u8>> {
+	if let PlainEntryMetadata::Symlink(target) = entry {
+		return Ok(target.as_os_str().as_encoded_bytes().to_vec());
+	}
+
+	let mut options = OpenOptions::new();
+	options.read(true);
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::OpenOptionsExt as _;
+		options.custom_flags(libc::O_NOFOLLOW);
+	}
+	#[cfg(windows)]
+	{
+		use std::os::windows::fs::OpenOptionsExt as _;
+
+		use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
+		options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+	}
+
+	let mut file = options.open(path).map_err(|err| {
+		IsoError::other(format!("open {} without following links: {err}", path.display()))
+	})?;
+	let mut bytes = Vec::new();
+	file
+		.read_to_end(&mut bytes)
+		.map_err(|err| IsoError::other(format!("read {}: {err}", path.display())))?;
+	Ok(bytes)
+}
+
+fn render_unified(
+	rel: &Path,
+	op: ChangeKind,
+	old: &str,
+	new: &str,
+	old_is_symlink: bool,
+	new_is_symlink: bool,
+) -> String {
 	let rel_str = rel.to_string_lossy();
 	let (from_label, to_label) = match op {
 		ChangeKind::Added => (String::from("/dev/null"), format!("b/{rel_str}")),
@@ -401,10 +466,14 @@ fn render_unified(rel: &Path, op: ChangeKind, old: &str, new: &str) -> String {
 	let _ = writeln!(out, "diff --git a/{rel_str} b/{rel_str}");
 	match op {
 		ChangeKind::Added => {
-			let _ = writeln!(out, "new file mode 100644");
+			let _ = writeln!(out, "new file mode {}", plain_mode(new_is_symlink));
 		},
 		ChangeKind::Removed => {
-			let _ = writeln!(out, "deleted file mode 100644");
+			let _ = writeln!(out, "deleted file mode {}", plain_mode(old_is_symlink));
+		},
+		ChangeKind::Modified if old_is_symlink != new_is_symlink => {
+			let _ = writeln!(out, "old mode {}", plain_mode(old_is_symlink));
+			let _ = writeln!(out, "new mode {}", plain_mode(new_is_symlink));
 		},
 		ChangeKind::Modified => {},
 	}
@@ -418,6 +487,10 @@ fn render_unified(rel: &Path, op: ChangeKind, old: &str, new: &str) -> String {
 		out.push('\n');
 	}
 	out
+}
+
+const fn plain_mode(is_symlink: bool) -> &'static str {
+	if is_symlink { "120000" } else { "100644" }
 }
 
 fn looks_binary(bytes: &[u8]) -> bool {

--- a/crates/pi-iso/tests/plain_diff_symlink.rs
+++ b/crates/pi-iso/tests/plain_diff_symlink.rs
@@ -1,0 +1,138 @@
+#![cfg(unix)]
+
+use std::{
+	fs,
+	os::unix::fs::symlink,
+	path::{Path, PathBuf},
+	sync::atomic::{AtomicU64, Ordering},
+};
+
+use pi_iso::{BackendKind, ChangeKind, backend};
+
+static NEXT_FIXTURE: AtomicU64 = AtomicU64::new(0);
+
+struct Fixture {
+	root:    PathBuf,
+	lower:   PathBuf,
+	merged:  PathBuf,
+	outside: PathBuf,
+}
+
+impl Fixture {
+	fn new() -> Self {
+		let sequence = NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed);
+		let root =
+			std::env::temp_dir().join(format!("pi-iso-plain-diff-{}-{sequence}", std::process::id()));
+		let lower = root.join("lower");
+		let merged = root.join("merged");
+		let outside = root.join("outside");
+		fs::create_dir_all(&lower).unwrap();
+		fs::create_dir_all(&merged).unwrap();
+		fs::create_dir_all(&outside).unwrap();
+		Self { root, lower, merged, outside }
+	}
+
+	fn write_secret(&self, name: &str, contents: &str) -> PathBuf {
+		let path = self.outside.join(name);
+		fs::write(&path, contents).unwrap();
+		path
+	}
+}
+
+impl Drop for Fixture {
+	fn drop(&mut self) {
+		let _ = fs::remove_dir_all(&self.root);
+	}
+}
+
+fn assert_link_payload(diff: &str, target: &Path, secret: &str) {
+	assert!(diff.contains(&target.to_string_lossy().into_owned()));
+	assert!(!diff.contains(secret));
+}
+
+#[tokio::test]
+async fn added_symlink_diffs_its_payload_without_reading_the_target() {
+	let fixture = Fixture::new();
+	let target = fixture.write_secret("added-secret.txt", "added operator secret");
+	symlink(&target, fixture.merged.join("escape.txt")).unwrap();
+
+	let diff = backend(BackendKind::Rcopy)
+		.diff(&fixture.lower, &fixture.merged)
+		.await
+		.unwrap();
+
+	assert_eq!(diff.files.len(), 1);
+	assert_eq!(diff.files[0].op, ChangeKind::Added);
+	let file_diff = diff.files[0].diff.as_deref().unwrap();
+	let unified = diff.unified_text();
+	assert!(unified.contains("new file mode 120000"));
+	assert_link_payload(file_diff, &target, "added operator secret");
+	assert_link_payload(&unified, &target, "added operator secret");
+}
+
+#[tokio::test]
+async fn modified_symlink_compares_payloads_without_reading_either_target() {
+	let fixture = Fixture::new();
+	let old_target = fixture.write_secret("old-secret.txt", "old operator secret");
+	let new_target = fixture.write_secret("new-secret.txt", "new operator secret");
+	symlink(&old_target, fixture.lower.join("escape.txt")).unwrap();
+	symlink(&new_target, fixture.merged.join("escape.txt")).unwrap();
+
+	let diff = backend(BackendKind::Rcopy)
+		.diff(&fixture.lower, &fixture.merged)
+		.await
+		.unwrap();
+
+	assert_eq!(diff.files.len(), 1);
+	assert_eq!(diff.files[0].op, ChangeKind::Modified);
+	let file_diff = diff.files[0].diff.as_deref().unwrap();
+	let unified = diff.unified_text();
+	assert_link_payload(file_diff, &old_target, "old operator secret");
+	assert_link_payload(file_diff, &new_target, "new operator secret");
+	assert_link_payload(&unified, &old_target, "old operator secret");
+	assert_link_payload(&unified, &new_target, "new operator secret");
+}
+
+#[tokio::test]
+async fn file_replaced_by_symlink_records_the_type_change_without_reading_the_target() {
+	let fixture = Fixture::new();
+	let target = fixture.write_secret("replacement.txt", "replacement operator secret");
+	let path = Path::new("escape.txt");
+	let old_contents = "x".repeat(target.as_os_str().as_encoded_bytes().len());
+	fs::write(fixture.lower.join(path), old_contents).unwrap();
+	symlink(&target, fixture.merged.join(path)).unwrap();
+
+	let diff = backend(BackendKind::Rcopy)
+		.diff(&fixture.lower, &fixture.merged)
+		.await
+		.unwrap();
+
+	assert_eq!(diff.files.len(), 1);
+	assert_eq!(diff.files[0].op, ChangeKind::Modified);
+	let file_diff = diff.files[0].diff.as_deref().unwrap();
+	let unified = diff.unified_text();
+	assert!(unified.contains("old mode 100644"));
+	assert!(unified.contains("new mode 120000"));
+	assert_link_payload(file_diff, &target, "replacement operator secret");
+	assert_link_payload(&unified, &target, "replacement operator secret");
+}
+
+#[tokio::test]
+async fn removed_symlink_diffs_its_payload_without_reading_the_target() {
+	let fixture = Fixture::new();
+	let target = fixture.write_secret("removed-secret.txt", "removed operator secret");
+	symlink(&target, fixture.lower.join("escape.txt")).unwrap();
+
+	let diff = backend(BackendKind::Rcopy)
+		.diff(&fixture.lower, &fixture.merged)
+		.await
+		.unwrap();
+
+	assert_eq!(diff.files.len(), 1);
+	assert_eq!(diff.files[0].op, ChangeKind::Removed);
+	let file_diff = diff.files[0].diff.as_deref().unwrap();
+	let unified = diff.unified_text();
+	assert!(unified.contains("deleted file mode 120000"));
+	assert_link_payload(file_diff, &target, "removed operator secret");
+	assert_link_payload(&unified, &target, "removed operator secret");
+}


### PR DESCRIPTION
## Summary
- index plain-diff paths with file type and symlink payload instead of following the target
- render symlink additions, changes, removals, and type transitions with Git-style modes
- preserve the public Diff API and ordinary-file output

## Reproduction
A workspace symlink was classified during indexing but later reopened through its joined path. Plain diff generation could therefore read the symlink target and include content outside the workspace.

## Scope
2 files, 245 additions, 34 deletions. 138 additions are regression tests. No dependency, public API, schema, or persistence changes.

## Verification
- exact base: `730e174e235eaf41346e0b8a4e7052c7ec21c1ca`
- exact head: `ee4f69fc156c6817abf240a25d6df42b98066c19`
- `cargo test -p pi-iso` — 6 passed
- `cargo clippy -p pi-iso --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check upstream/dev...HEAD`
- open-PR file overlap audit: no non-changelog overlap
- independent exact-head adversarial review: no blocking code finding
- prior exact head on `5beb6bb30` passed all 22 hosted checks before this base-only rebase

## Known limits
- Windows reparse-point behavior was not exercised locally.
- Final-component no-follow does not make concurrent intermediate-directory replacement descriptor-atomic.
- Hosted Linux CI remains the full-workspace verdict.