### PR TITLE
fix(test): repair stale model red-team assertions breaking dev CI

### DIFF
--- a/packages/coding-agent/test/model-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-profiles-redteam.test.ts
@@ -159,7 +159,7 @@ describe("model profile red-team schema and catalog cases", () => {
 		const merged = mergeModelProfiles(undefined);
 
 		expect(merged.size).toBe(BUILTIN_MODEL_PROFILES.length);
-		expect(merged.size).toBe(28);
+		expect(merged.size).toBe(30);
 		expect([...merged.values()]).toEqual([...BUILTIN_MODEL_PROFILES]);
 	});
 

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -275,6 +275,8 @@ describe("model selector profile red-team", () => {
 	test("Browse all models switches to flat model rows", async () => {
 		const selector = createSelector(() => {});
 		await renderSelector(selector);
+		// Landing rows: [preset group, create custom preset, image generation, browse all models]
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");


### PR DESCRIPTION
Dev CI on `dev` was red on two red-team tests. Root-caused both to stale assertions left behind by earlier feature merges (not by the alibaba-token-plan login work in #2876/#2877):

- **model-profiles-redteam.test.ts:162** — hardcoded `28` builtin profiles. #2864 added the Alibaba Token Plan `Balanced`/`QwenMaxxing` profiles → count is now `30`. Line 161 already asserts `=== BUILTIN_MODEL_PROFILES.length`, so the hardcoded literal is the only stale part.
- **model-selector-profiles-redteam.test.ts:275** — 'Browse all models switches to flat model rows' pressed Down twice. #2875 reordered the preset landing rows to `[group, create, imageGeneration, browse]`, moving 'Browse all models' from index 2 → 3. The test now presses Down three times; verified it opens the flat model view (`Models`, `provider-a/default`, `provider-b/zzz-flat-model`).

## Verification
- `bun test model-profiles-redteam model-selector-profiles-redteam` → 26 pass.
- `bun test model-preset-landing-redteam-qa model-selector-profiles custom-model-preset-creation` → 50 pass (no other landing-nav/count assumptions broken).
- Bisected against `12aa7ebd1` (dev before the alibaba PRs) to confirm both failures pre-date and are independent of the alibaba change.