### PR TITLE
test(coding-agent): harden model profile red-team coverage

### DIFF
--- a/packages/coding-agent/test/model-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-profiles-redteam.test.ts
@@ -159,7 +159,7 @@ describe("model profile red-team schema and catalog cases", () => {
 		const merged = mergeModelProfiles(undefined);
 
 		expect(merged.size).toBe(BUILTIN_MODEL_PROFILES.length);
-		expect(merged.size).toBe(30);
+
 		expect([...merged.values()]).toEqual([...BUILTIN_MODEL_PROFILES]);
 	});
 

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -275,10 +275,20 @@ describe("model selector profile red-team", () => {
 	test("Browse all models switches to flat model rows", async () => {
 		const selector = createSelector(() => {});
 		await renderSelector(selector);
-		// Landing rows: [preset group, create custom preset, image generation, browse all models]
-		selector.handleInput("\x1b[B");
-		selector.handleInput("\x1b[B");
-		selector.handleInput("\x1b[B");
+
+		const visitedRowIdentities = new Set<string>();
+		while (true) {
+			const rowIdentity = selector.__testSelectedPresetRowIdentity();
+			if (!rowIdentity) throw new Error("Expected a selected preset landing row");
+			if (rowIdentity === "browse") break;
+			if (visitedRowIdentities.has(rowIdentity)) {
+				throw new Error(`Preset landing navigation repeated ${rowIdentity} before browse`);
+			}
+			visitedRowIdentities.add(rowIdentity);
+			selector.handleInput("\x1b[B");
+		}
+
+		expect(selector.__testSelectedPresetRowIdentity()).toBe("browse");
 		selector.handleInput("\n");
 		const rendered = normalizeRenderedText(selector.render(240).join("\n"));
 


### PR DESCRIPTION
## Summary
- navigate to the semantic `browse` preset row before testing Enter-to-model-list transition
- retain representative flat-model rendering assertions
- remove only the stale literal builtin-profile count while retaining canonical cardinality and exact ordered equivalence

Fixes #2880.

## Verification
- `bun test packages/coding-agent/test/model-selector-profiles-redteam.test.ts packages/coding-agent/test/model-profiles-redteam.test.ts`
- adjacent model selector/profile suites, including `model-preset-landing-redteam-qa.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

No production behavior, catalog, release, or deployment changes.