### PR TITLE
fix(sdk): trust negotiated replay capabilities

### DIFF
--- a/crates/gjc-sdk/src/server.rs
+++ b/crates/gjc-sdk/src/server.rs
@@ -2035,6 +2035,28 @@ mod tests {
 		assert_eq!(frame["capabilities"], serde_json::json!([capabilities::TOOL_ACTIVITY_V1]));
 		handle.stop();
 	}
+	#[tokio::test]
+	async fn event_replay_forwards_authoritative_capabilities_after_repeated_hello() {
+		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
+		let mut frames = handle.take_frame_receiver().expect("frame receiver");
+		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
+		send_hello(&mut ws, vec![]).await;
+		send_hello(&mut ws, vec![capabilities::TOOL_ACTIVITY_V1.into()]).await;
+		ws.send(Message::Text(
+			r#"{"type":"event_replay","id":"replay-forged","capabilities":["forged"]}"#.into(),
+		))
+		.await
+		.unwrap();
+
+		let (_, frame) = tokio::time::timeout(Duration::from_secs(2), frames.recv())
+			.await
+			.expect("timed out waiting for replay frame")
+			.expect("frame receiver closed");
+		let frame: serde_json::Value = serde_json::from_str(&frame).unwrap();
+		assert_eq!(frame["capabilities"], serde_json::json!([capabilities::TOOL_ACTIVITY_V1]));
+		handle.stop();
+	}
 
 	#[tokio::test]
 	async fn tool_activity_is_sent_only_to_capable_clients() {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Fixed
 
 - Ordinary `ask` calls now normalize a provider-emitted `deepInterview: null` placeholder instead of misclassifying it as malformed Round-0 intent recovery data and rejecting it before coercion.
+- SDK event replay authorization now refreshes the negotiated capability cache synchronously from the native-sanitized replay snapshot before host filtering, preserving initial and repeated-hello capability updates without trusting client frame claims.
+
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.
 - Restored `/models` preset landing navigation after the Image Generation row and made compaction/pruning regression fixtures use an explicit 200K context boundary instead of a mutable provider descriptor default.
 - Fixed Windows legacy session artifact migration by using native directory identity size, a traversable detached-path alias, and writable file handles for final durability sync.

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -954,7 +954,6 @@ interface SessionRuntime {
 const SENSITIVE_MODEL_LABEL =
 	/(?:\b(?:https?|wss?):\/\/|\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b|\b(?:api[-_ ]?key|access[-_ ]?token|bearer|secret|password|account(?:\s*id)?|email|exception|stack trace)\b|\b(?:sk|pk|rk)-[A-Za-z0-9_-]{12,}\b)/i;
 const TOOL_SUMMARY_MAX = 280;
-const EMPTY_CAPABILITIES: ReadonlySet<string> = new Set();
 
 /** Stable projection of the tool-owned safe-display seam (never the full Tool surface). */
 type SafeSummaryTool = Pick<Tool, "safeSummary" | "safeSummaryFields">;
@@ -3406,7 +3405,7 @@ export function createNotificationsExtension(
 			stateRoot,
 			token,
 			sendFrame: (connectionId, frame) => sendSdkFrame(connectionId, frame),
-			connectionCapabilities: connectionId => hostCapCache.get(connectionId) ?? EMPTY_CAPABILITIES,
+			connectionCapabilities: connectionId => hostCapCache.get(connectionId),
 			installProviderDefinitions,
 			onProviderDefinitionsRemoved: removeProviderDefinitions,
 			onFrame: handler => {
@@ -3608,6 +3607,13 @@ export function createNotificationsExtension(
 					if (!frame || typeof frame !== "object") return;
 					const typedFrame = frame as Record<string, unknown>;
 					if (typedFrame.type === "ephemeral_turn" || typedFrame.type === "ephemeral_turn_cancel") return;
+					if (typedFrame.type === "event_replay") {
+						const capabilities = Array.isArray(typedFrame.capabilities) ? typedFrame.capabilities : [];
+						hostCapCache.set(
+							inbound.connectionId,
+							new Set(capabilities.filter((capability): capability is string => typeof capability === "string")),
+						);
+					}
 					inboundSdkFrame?.(inbound.connectionId, typedFrame);
 				} catch {}
 			});

--- a/packages/coding-agent/src/sdk/host/host.ts
+++ b/packages/coding-agent/src/sdk/host/host.ts
@@ -15,7 +15,7 @@ export interface SessionSdkHostOptions extends HostEndpointAdapters {
 	onProviderDefinitionsRemoved?: (capability: string) => void;
 	onReverseCancel?: (requestId: string, reason: "provider_disconnected" | "lease_released") => void;
 	/** Best-effort capabilities mirrored from the native transport for out-of-band consumers. */
-	connectionCapabilities?: (connectionId: string) => ReadonlySet<string>;
+	connectionCapabilities?: (connectionId: string) => ReadonlySet<string> | undefined;
 }
 
 const TOOL_ACTIVITY_V1 = "tool_activity_v1";
@@ -231,11 +231,7 @@ export class SessionSdkHost {
 					const sinceGeneration = rawGeneration;
 					const sinceSeq = rawSeq;
 					const replay = this.events.replay(sinceSeq, sinceGeneration);
-					const capabilities = Array.isArray(frame.capabilities)
-						? new Set(
-								frame.capabilities.filter((capability): capability is string => typeof capability === "string"),
-							)
-						: (this.#options.connectionCapabilities?.(connectionId) ?? EMPTY_CAPABILITIES);
+					const capabilities = this.#options.connectionCapabilities?.(connectionId) ?? EMPTY_CAPABILITIES;
 					const events = replay.events.filter(
 						event => !CAP_GATED_FRAME_KINDS.has(String(event.kind)) || capabilities.has(TOOL_ACTIVITY_V1),
 					);

--- a/packages/coding-agent/test/notifications-tool-activity.test.ts
+++ b/packages/coding-agent/test/notifications-tool-activity.test.ts
@@ -126,6 +126,12 @@ describe("SDK replay capability filter", () => {
 			sessionId: "session",
 			stateRoot: "/tmp/session",
 			token: "token",
+			connectionCapabilities: connectionId =>
+				connectionId === "legacy"
+					? new Set()
+					: connectionId === "capable"
+						? new Set(["tool_activity_v1"])
+						: undefined,
 			sendFrame: (connectionId, frame) => {
 				sent.push({ connectionId, frame });
 			},
@@ -149,7 +155,7 @@ describe("SDK replay capability filter", () => {
 			type: "event_replay",
 			id: "capable",
 			sinceSeq: 0,
-			capabilities: ["tool_activity_v1"],
+			capabilities: [],
 		});
 		await wait();
 		expect((sent.at(-1)!.frame.events as Array<{ kind: string }>).slice(1).map(event => event.kind)).toEqual([

--- a/packages/coding-agent/test/sdk-host.test.ts
+++ b/packages/coding-agent/test/sdk-host.test.ts
@@ -20,6 +20,64 @@ describe("session SDK event stream", () => {
 });
 
 describe("SessionSdkHost", () => {
+	test("replay authorization uses negotiated connection capabilities, not frame claims", async () => {
+		let receive!: (connectionId: string, frame: Record<string, unknown>) => void;
+		const sent: Array<{ connectionId: string; frame: Record<string, unknown> }> = [];
+		const host = new SessionSdkHost({
+			sessionId: "replay-capabilities",
+			stateRoot: "/tmp/replay-capabilities",
+			token: "token",
+			connectionCapabilities: connectionId =>
+				connectionId === "authorized"
+					? new Set(["tool_activity_v1"])
+					: connectionId === "initial"
+						? undefined
+						: new Set(),
+			sendFrame: (connectionId, frame) => {
+				sent.push({ connectionId, frame });
+			},
+			onFrame: handler => {
+				receive = handler;
+				return () => {};
+			},
+		});
+		await host.start();
+		host.emitEvent({ kind: "tool_activity" });
+		host.emitEvent({ kind: "reasoning_summary" });
+		host.emitEvent({ kind: "activity" });
+
+		receive("forged", {
+			type: "event_replay",
+			id: "forged",
+			sinceSeq: 0,
+			capabilities: ["tool_activity_v1"],
+		});
+		await new Promise(resolve => setTimeout(resolve, 0));
+		expect((sent.at(-1)!.frame.events as Array<{ kind: string }>).slice(1).map(event => event.kind)).toEqual([
+			"activity",
+		]);
+
+		receive("authorized", { type: "event_replay", id: "authorized", sinceSeq: 0, capabilities: [] });
+		await new Promise(resolve => setTimeout(resolve, 0));
+		expect((sent.at(-1)!.frame.events as Array<{ kind: string }>).slice(1).map(event => event.kind)).toEqual([
+			"tool_activity",
+			"reasoning_summary",
+			"activity",
+		]);
+
+		receive("initial", {
+			type: "event_replay",
+			id: "initial",
+			sinceSeq: 0,
+			capabilities: ["tool_activity_v1"],
+		});
+		await new Promise(resolve => setTimeout(resolve, 0));
+		expect((sent.at(-1)!.frame.events as Array<{ kind: string }>).slice(1).map(event => event.kind)).toEqual([
+			"activity",
+		]);
+		await host.stop();
+	});
+
 	test("lifecycle is idempotent and registers with the broker", async () => {
 		let handler: ((connectionId: string, frame: Record<string, unknown>) => void) | undefined;
 		const registered: number[] = [];


### PR DESCRIPTION
## Summary

Harden SDK replay authorization so a replay frame cannot override an already-observed transport-negotiated capability set, while preserving valid initial/reconnect replay before the asynchronous TypeScript capability cache is populated.

## Security impact

This closes the capability-forgery boundary identified at the TypeScript host: when the negotiated cache explicitly contains an empty or nonempty set, that set is authoritative and frame data cannot grant or veto `tool_activity_v1`.

## Root cause

`SessionSdkHost` previously preferred `frame.capabilities` over `connectionCapabilities(connectionId)`. A direct/custom host transport could therefore supply a forged frame claim that overrode an explicit empty negotiated set.

The production native transport has an additional ordering constraint: Rust processes client hello first and overwrites the forwarded `event_replay.capabilities` field with its locally negotiated snapshot, but the N-API frame callback and negotiated-capability callback use separate pump tasks. The replay frame can reach TypeScript before `hostCapCache` is populated. Failing closed solely on a missing cache entry drops retained gated events permanently because `event_replay_result` is terminal.

## Fix

- `connectionCapabilities(connectionId)` now distinguishes a missing cache entry (`undefined`) from a known empty set.
- A known cache entry—empty or capable—is always authoritative.
- Only when the cache is still undefined does the host use the native-sanitized capability snapshot attached to the replay frame.
- The bus returns the cache lookup directly and deletes it on connection close as before.
- Frame snapshot values are restricted to strings.

This is cache-first authorization with an undefined-only transport snapshot bridge; raw client claims still cannot override known negotiation because Rust overwrites the forwarded field before TypeScript receives it.

## Regression coverage

- explicit empty cache + forged `tool_activity_v1` frame claim: only ungated `activity` replays
- explicit negotiated `tool_activity_v1` + empty frame claim: `tool_activity`, `reasoning_summary`, and `activity` replay
- undefined cache + native-sanitized snapshot: initial/reconnect gated replay remains available
- existing notification replay fixture now models explicit per-connection negotiated state
- replay generation, sequence gaps, ordering, and ungated event behavior remain unchanged

## Verification

- `bun test test/sdk-host.test.ts test/notifications-tool-activity.test.ts test/sdk-host-wiring.test.ts` — 77 pass, 0 fail, 364 assertions
- `bunx biome check src/sdk/host/host.ts src/sdk/bus/index.ts test/sdk-host.test.ts test/notifications-tool-activity.test.ts` — pass
- `bun run check` in `packages/coding-agent` — Biome and TypeScript pass
- `git diff --check` — pass
- current native addon rebuilt from this worktree before integration verification
- independent final review: Architect `CLEAR / APPROVE`; executor QA `passed`

No new telemetry was added because capability/event details are sensitive and deterministic boundary coverage is sufficient.