### PR TITLE
fix(plugins): confine remote MCP endpoints to public network

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Ordinary `ask` calls now normalize a provider-emitted `deepInterview: null` placeholder instead of misclassifying it as malformed Round-0 intent recovery data and rejecting it before coercion.
+- Plugin-bundle HTTP and SSE MCP requests now bind every connection to a validated public address and revalidate bounded redirects before following them.
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.
 - Restored `/models` preset landing navigation after the Image Generation row and made compaction/pruning regression fixtures use an explicit 200K context boundary instead of a mutable provider descriptor default.
 - Fixed Windows legacy session artifact migration by using native directory identity size, a traversable detached-path alias, and writable file handles for final durability sync.

--- a/packages/coding-agent/src/extensibility/gjc-plugins/runtime-adapters.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/runtime-adapters.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { bindPluginMcpToPublicNetwork } from "../../runtime-mcp/plugin-network-boundary";
 import { loadCustomTools } from "../custom-tools/loader";
 import type { CustomTool } from "../custom-tools/types";
 import { loadEffectiveGjcPluginRegistry, registryPathForScope } from "./registry";
@@ -330,7 +331,7 @@ export async function buildPluginMcpConfigs(input: { cwd: string }): Promise<{
 					// resolution path expands ${env:...}/shell templates, which would let
 					// a third-party bundle exfiltrate host secrets. Plugin-bundle MCP
 					// servers connect without bundle-declared headers.
-					configs[m.name] = { type: cfg.transport, url: cfg.url };
+					configs[m.name] = bindPluginMcpToPublicNetwork({ type: cfg.transport, url: url.toString() });
 				}
 			} catch (error) {
 				quarantine.push({

--- a/packages/coding-agent/src/runtime-mcp/plugin-network-boundary.ts
+++ b/packages/coding-agent/src/runtime-mcp/plugin-network-boundary.ts
@@ -1,0 +1,108 @@
+import { type AddressResolver, guardedPublicFetch } from "../web/insane/url-guard";
+import { cancelMCPStream } from "./content-limits";
+import type { MCPHttpServerConfig, MCPSseServerConfig } from "./types";
+
+const PLUGIN_MCP_PUBLIC_NETWORK_BOUNDARY: unique symbol = Symbol("plugin-mcp-public-network-boundary");
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const MAX_REDIRECTS = 20;
+const CROSS_ORIGIN_SENSITIVE_HEADERS = [
+	"authorization",
+	"cookie",
+	"cookie2",
+	"mcp-session-id",
+	"proxy-authorization",
+] as const;
+const REQUEST_BODY_HEADERS = [
+	"content-encoding",
+	"content-language",
+	"content-length",
+	"content-location",
+	"content-type",
+] as const;
+
+/** Mark an in-memory plugin-bundle remote MCP config for connection-bound public-network enforcement. */
+export function bindPluginMcpToPublicNetwork<T extends MCPHttpServerConfig | MCPSseServerConfig>(config: T): T {
+	return Object.assign(config, { [PLUGIN_MCP_PUBLIC_NETWORK_BOUNDARY]: true });
+}
+
+/** The marker is an internal symbol, so persisted user MCP configs cannot opt into or forge this path. */
+export function isPluginMcpPublicNetworkBound(config: MCPHttpServerConfig | MCPSseServerConfig): boolean {
+	return (
+		(config as MCPHttpServerConfig & { [PLUGIN_MCP_PUBLIC_NETWORK_BOUNDARY]?: boolean })[
+			PLUGIN_MCP_PUBLIC_NETWORK_BOUNDARY
+		] === true
+	);
+}
+
+function blocked(reason: string): Error {
+	return new Error(`Plugin MCP network request blocked: ${reason}`);
+}
+
+function parseHttpsUrl(rawUrl: string): URL {
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		throw blocked("invalid URL");
+	}
+	if (url.protocol !== "https:") throw blocked("HTTPS is required");
+	return url;
+}
+
+function rewritesToGet(status: number, method: string): boolean {
+	return (
+		((status === 301 || status === 302) && method === "POST") ||
+		(status === 303 && method !== "GET" && method !== "HEAD")
+	);
+}
+
+/**
+ * Fetch a plugin-bundle MCP request through a DNS-pinned public address. Every
+ * redirect is handled manually and revalidated before the next connection.
+ */
+export async function fetchPluginMcpRequest(
+	rawUrl: string,
+	init: BunFetchRequestInit,
+	options: { resolver?: AddressResolver; maxRedirects?: number } = {},
+): Promise<Response> {
+	let currentUrl = parseHttpsUrl(rawUrl);
+	let currentInit: BunFetchRequestInit = { ...init };
+	const maxRedirects = options.maxRedirects ?? MAX_REDIRECTS;
+
+	for (let redirectCount = 0; ; redirectCount++) {
+		const dial = await guardedPublicFetch(currentUrl.toString(), currentInit, { resolver: options.resolver });
+		if (!dial.ok) throw blocked(dial.reason);
+		const { response, logicalUrl } = dial;
+		if (!REDIRECT_STATUSES.has(response.status)) return response;
+
+		const location = response.headers.get("location");
+		if (!location) return response;
+		if (redirectCount >= maxRedirects) {
+			cancelMCPStream(response.body);
+			throw blocked("redirect limit exceeded");
+		}
+
+		let nextUrl: URL;
+		try {
+			nextUrl = parseHttpsUrl(new URL(location, logicalUrl).toString());
+		} catch (error) {
+			cancelMCPStream(response.body);
+			throw error;
+		}
+
+		const headers = new Headers(currentInit.headers);
+		if (logicalUrl.origin !== nextUrl.origin) {
+			for (const name of CROSS_ORIGIN_SENSITIVE_HEADERS) headers.delete(name);
+		}
+
+		const method = (currentInit.method ?? "GET").toUpperCase();
+		if (rewritesToGet(response.status, method)) {
+			for (const name of REQUEST_BODY_HEADERS) headers.delete(name);
+			currentInit = { ...currentInit, method: "GET", headers, body: undefined };
+		} else {
+			currentInit = { ...currentInit, headers };
+		}
+		currentUrl = nextUrl;
+		cancelMCPStream(response.body);
+	}
+}

--- a/packages/coding-agent/src/runtime-mcp/transports/http.ts
+++ b/packages/coding-agent/src/runtime-mcp/transports/http.ts
@@ -24,6 +24,7 @@ import {
 	MCP_MAX_SSE_REQUEST_MESSAGES,
 	readMCPResponseText,
 } from "../content-limits";
+import { fetchPluginMcpRequest, isPluginMcpPublicNetworkBound } from "../plugin-network-boundary";
 
 /**
  * HTTP transport for MCP servers.
@@ -62,6 +63,12 @@ export class HttpTransport implements MCPTransport {
 		this.#connected = true;
 	}
 
+	#fetch(init: BunFetchRequestInit): Promise<Response> {
+		return isPluginMcpPublicNetworkBound(this.config)
+			? fetchPluginMcpRequest(this.config.url, init)
+			: fetch(this.config.url, init);
+	}
+
 	#trackReader(promise: Promise<void>, controller?: AbortController): void {
 		if (controller) this.#streamControllers.add(controller);
 		this.#streamReaders.add(promise);
@@ -96,7 +103,7 @@ export class HttpTransport implements MCPTransport {
 
 		let response: Response;
 		try {
-			response = await fetch(this.config.url, {
+			response = await this.#fetch({
 				method: "GET",
 				headers,
 				signal: AbortSignal.any([sseConnection.signal, headerController.signal]),
@@ -227,7 +234,7 @@ export class HttpTransport implements MCPTransport {
 			: abortController.signal;
 
 		try {
-			const response = await fetch(this.config.url, {
+			const response = await this.#fetch({
 				method: "POST",
 				headers,
 				body: JSON.stringify(body),
@@ -423,7 +430,7 @@ export class HttpTransport implements MCPTransport {
 			headers["Mcp-Session-Id"] = this.#sessionId;
 		}
 		try {
-			const resp = await fetch(this.config.url, {
+			const resp = await this.#fetch({
 				method: "POST",
 				headers,
 				body: JSON.stringify(body),
@@ -437,7 +444,7 @@ export class HttpTransport implements MCPTransport {
 					this.config.headers ??= {};
 					Object.assign(this.config.headers, newHeaders);
 					Object.assign(headers, newHeaders);
-					const retry = await fetch(this.config.url, {
+					const retry = await this.#fetch({
 						method: "POST",
 						headers,
 						body: JSON.stringify(body),
@@ -480,7 +487,7 @@ export class HttpTransport implements MCPTransport {
 		const timeoutId = setTimeout(() => abortController.abort(), timeout);
 
 		try {
-			const response = await fetch(this.config.url, {
+			const response = await this.#fetch({
 				method: "POST",
 				headers,
 				body: JSON.stringify(body),
@@ -542,7 +549,7 @@ export class HttpTransport implements MCPTransport {
 					"Mcp-Session-Id": this.#sessionId,
 				};
 
-				await fetch(this.config.url, {
+				await this.#fetch({
 					method: "DELETE",
 					headers,
 					signal: AbortSignal.timeout(timeout),

--- a/packages/coding-agent/test/gjc-plugin-mcp-configs.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-mcp-configs.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { buildPluginMcpConfigs, installGjcPluginBundle } from "../src/extensibility/gjc-plugins";
+import { isPluginMcpPublicNetworkBound } from "../src/runtime-mcp/plugin-network-boundary";
 
 const fixturesRoot = path.join(import.meta.dir, "fixtures", "gjc-plugins");
 const sixSurface = path.join(fixturesRoot, "valid-six-surface-bundle");
@@ -33,5 +34,29 @@ describe("plugin MCP runtime config conversion", () => {
 		tempDirs.push(cwd);
 		const { configs } = await buildPluginMcpConfigs({ cwd });
 		expect(configs).toEqual({});
+	});
+
+	test("binds bundled remote MCP configs to the public-network transport", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-mcp-remote-"));
+		const bundle = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-mcp-remote-bundle-"));
+		tempDirs.push(cwd, bundle);
+		const url = "https://8.8.8.8/mcp";
+		await fs.writeFile(
+			path.join(bundle, "gajae-plugin.json"),
+			JSON.stringify({
+				kind: "gajae-code-plugin",
+				name: "remote-mcp-bundle",
+				version: "1.0.0",
+				mcps: [{ name: "remote_docs", transport: "http", url }],
+			}),
+		);
+
+		await installGjcPluginBundle(bundle, { scope: "project", cwd });
+		const { configs, quarantine } = await buildPluginMcpConfigs({ cwd });
+
+		expect(quarantine).toHaveLength(0);
+		expect(configs.remote_docs).toMatchObject({ type: "http", url });
+		expect(isPluginMcpPublicNetworkBound(configs.remote_docs)).toBe(true);
+		expect(isPluginMcpPublicNetworkBound({ ...configs.remote_docs })).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/runtime-mcp/plugin-network-boundary.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/plugin-network-boundary.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { bindPluginMcpToPublicNetwork, fetchPluginMcpRequest } from "../../src/runtime-mcp/plugin-network-boundary";
+import { HttpTransport } from "../../src/runtime-mcp/transports/http";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("plugin MCP public-network boundary", () => {
+	test("pins and revalidates every public redirect hop", async () => {
+		const resolved: string[] = [];
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async input => {
+			if (String(input) === "https://93.184.216.34/start") {
+				return new Response(null, {
+					status: 307,
+					headers: { location: "https://second.example/next" },
+				});
+			}
+			return new Response("ok");
+		}) as typeof fetch);
+
+		const response = await fetchPluginMcpRequest(
+			"https://first.example/start",
+			{
+				method: "POST",
+				headers: {
+					Authorization: "Bearer secret",
+					Cookie: "session=secret",
+					"Content-Type": "application/json",
+					"Mcp-Session-Id": "origin-session",
+				},
+				body: "{}",
+			},
+			{
+				resolver: async hostname => {
+					resolved.push(hostname);
+					return hostname === "first.example" ? ["93.184.216.34"] : ["1.1.1.1"];
+				},
+			},
+		);
+
+		expect(await response.text()).toBe("ok");
+		expect(resolved).toEqual(["first.example", "second.example"]);
+		expect(fetchSpy.mock.calls.map(call => String(call[0]))).toEqual([
+			"https://93.184.216.34/start",
+			"https://1.1.1.1/next",
+		]);
+		const firstInit = fetchSpy.mock.calls[0]?.[1] as BunFetchRequestInit;
+		const secondInit = fetchSpy.mock.calls[1]?.[1] as BunFetchRequestInit;
+		expect(firstInit.redirect).toBe("manual");
+		expect(firstInit.tls).toMatchObject({ rejectUnauthorized: true, serverName: "first.example" });
+		expect(new Headers(firstInit.headers).get("host")).toBe("first.example");
+		expect(secondInit.method).toBe("POST");
+		expect(secondInit.body).toBe("{}");
+		expect(secondInit.tls).toMatchObject({ rejectUnauthorized: true, serverName: "second.example" });
+		const redirectedHeaders = new Headers(secondInit.headers);
+		expect(redirectedHeaders.get("host")).toBe("second.example");
+		expect(redirectedHeaders.get("authorization")).toBeNull();
+		expect(redirectedHeaders.get("cookie")).toBeNull();
+		expect(redirectedHeaders.get("mcp-session-id")).toBeNull();
+	});
+
+	test("blocks DNS rebinding before the redirected connection", async () => {
+		let resolutions = 0;
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(null, { status: 302, headers: { location: "/private" } }));
+
+		await expect(
+			fetchPluginMcpRequest(
+				"https://rebind.example/start",
+				{ method: "POST", body: "{}" },
+				{ resolver: async () => [resolutions++ === 0 ? "93.184.216.34" : "127.0.0.1"] },
+			),
+		).rejects.toThrow("Plugin MCP network request blocked");
+
+		expect(resolutions).toBe(2);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	test("preserves standard redirect methods and bounds redirect chains", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async input => {
+			if (String(input).endsWith("/start")) {
+				return new Response(null, { status: 302, headers: { location: "/next" } });
+			}
+			return new Response("ok");
+		}) as typeof fetch);
+
+		const response = await fetchPluginMcpRequest("https://8.8.8.8/start", {
+			method: "POST",
+			headers: { Authorization: "Bearer same-origin", "Content-Type": "application/json" },
+			body: "{}",
+		});
+
+		expect(await response.text()).toBe("ok");
+		const redirectedInit = fetchSpy.mock.calls[1]?.[1] as BunFetchRequestInit;
+		expect(redirectedInit.method).toBe("GET");
+		expect(redirectedInit.body).toBeUndefined();
+		const redirectedHeaders = new Headers(redirectedInit.headers);
+		expect(redirectedHeaders.get("authorization")).toBe("Bearer same-origin");
+		expect(redirectedHeaders.get("content-type")).toBeNull();
+
+		fetchSpy.mockClear();
+		fetchSpy.mockResolvedValue(new Response(null, { status: 307, headers: { location: "/loop" } }));
+		await expect(
+			fetchPluginMcpRequest("https://8.8.8.8/loop", { method: "GET" }, { maxRedirects: 0 }),
+		).rejects.toThrow("redirect limit exceeded");
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	test("wires plugin configs through the boundary and blocks redirect downgrades", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(null, {
+				status: 307,
+				headers: { location: "http://127.0.0.1/private" },
+			}),
+		);
+		const transport = new HttpTransport(
+			bindPluginMcpToPublicNetwork({
+				type: "http",
+				url: "https://93.184.216.34/mcp",
+				timeout: 500,
+			}),
+		);
+		await transport.connect();
+
+		await expect(transport.request("tools/list")).rejects.toThrow("Plugin MCP network request blocked");
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(fetchSpy.mock.calls[0]?.[1]?.redirect).toBe("manual");
+		await transport.close();
+	});
+
+	test("leaves ordinary user-configured HTTP transports unchanged", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async (_input, init) => {
+			const request = JSON.parse(String(init?.body)) as { id: string | number };
+			return Response.json({ jsonrpc: "2.0", id: request.id, result: { ok: true } });
+		}) as typeof fetch);
+		const transport = new HttpTransport({ type: "http", url: "http://127.0.0.1/mcp", timeout: 500 });
+		await transport.connect();
+
+		await expect(transport.request("tools/list")).resolves.toEqual({ ok: true });
+		expect(String(fetchSpy.mock.calls[0]?.[0])).toBe("http://127.0.0.1/mcp");
+		expect(fetchSpy.mock.calls[0]?.[1]?.redirect).toBeUndefined();
+		await transport.close();
+	});
+});


### PR DESCRIPTION
## Summary
- mark only plugin-declared remote MCP configs for connection-time public-network enforcement
- route every marked GET, POST, retry, notification, and DELETE through DNS-pinned public fetches
- revalidate each redirect, require HTTPS, cap redirect count, and strip sensitive headers on cross-origin hops
- leave ordinary user-configured MCP transports unchanged

## Reproduction
Plugin MCP URLs had an install/session DNS preflight, but the generic HTTP transport later resolved and followed redirects independently. A hostname could therefore pass the preflight and then rebind or redirect a runtime request to a loopback, private, link-local, or otherwise blocked address.

## Scope
6 files, 293 additions, 7 deletions. Production changes are 123 additions and 7 deletions; 169 additions are focused boundary and plugin-config regression tests. The marker is an in-memory symbol available only to validated plugin configs. No dependency, public API, schema, persistence, or ordinary MCP-config behavior changes.

## Verification
- exact base: `a9b91589d208fe168156bf753839b38343005646`
- exact head: `b1b60d9493e1a2e9771a648552c3cf5ee140784c`
- focused plugin MCP boundary/config suites — 8 passed, 39 assertions
- coding-agent Biome and TypeScript check
- coding-agent binary build
- publish declaration check for all publishable packages
- `git diff --check upstream/dev...HEAD`
- current open-PR file overlap audit: no source or test overlap
- independent exact-head adversarial review: no blocking defect; documented WATCH items below

## Known limits
- Environments that require a configured outbound HTTP proxy fail closed on this plugin-only path because the public-address pinning boundary connects directly.
- Live interoperability with a third-party remote MCP service was not exercised; tests cover the production request and redirect paths with controlled DNS/fetch behavior.
- The implementation reuses the existing web public-network guard; separating that shared guard into a neutral networking layer is follow-up architecture work, not part of this fix.

---

- [x] `bun --cwd=packages/coding-agent run check` passes
- [x] Tested locally
- [x] CHANGELOG updated
