### PR TITLE
fix(agent): preserve reasoning summary fallback events

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Managed model fallback now accepts `reasoning_summary_start`, `reasoning_summary_delta`, and `reasoning_summary_end` assistant events instead of failing them as local snapshot errors.
+
 ## [0.11.3] - 2026-07-19
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -644,14 +644,24 @@ function managedAssistantEventSnapshot(event: AssistantMessageEvent, message: As
 		return contentIndex as number;
 	};
 	if (type === "start") return { type, partial: message };
-	if (type === "text_start" || type === "thinking_start" || type === "toolcall_start")
+	if (
+		type === "text_start" ||
+		type === "thinking_start" ||
+		type === "reasoning_summary_start" ||
+		type === "toolcall_start"
+	)
 		return { type, contentIndex: indexed(), partial: message };
-	if (type === "text_delta" || type === "thinking_delta" || type === "toolcall_delta") {
+	if (
+		type === "text_delta" ||
+		type === "thinking_delta" ||
+		type === "reasoning_summary_delta" ||
+		type === "toolcall_delta"
+	) {
 		const delta = managedProperty(snapshot, "delta");
 		if (typeof delta !== "string") throw new ManagedAttemptSnapshotError();
 		return { type, contentIndex: indexed(), delta, partial: message };
 	}
-	if (type === "text_end" || type === "thinking_end") {
+	if (type === "text_end" || type === "thinking_end" || type === "reasoning_summary_end") {
 		const content = managedProperty(snapshot, "content");
 		if (typeof content !== "string") throw new ManagedAttemptSnapshotError();
 		return { type, contentIndex: indexed(), content, partial: message };

--- a/packages/agent/test/managed-attempt-transaction.test.ts
+++ b/packages/agent/test/managed-attempt-transaction.test.ts
@@ -982,6 +982,61 @@ describe("managed attempt transaction", () => {
 		expect(message.content).toEqual([]);
 	});
 
+	it("preserves reasoning summary events through managed replay", async () => {
+		const mock = createMockModel();
+		const callbacks: AssistantMessageEvent[] = [];
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["test"], tools: [], messages: [] },
+			streamFn: () => {
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const partial = assistantMessage(mock.model);
+					partial.content.push({ type: "thinking", thinking: "safe summary" });
+					stream.push({ type: "start", partial });
+					stream.push({ type: "reasoning_summary_start", contentIndex: 0, partial });
+					stream.push({
+						type: "reasoning_summary_delta",
+						contentIndex: 0,
+						delta: "safe summary",
+						partial,
+					});
+					stream.push({
+						type: "reasoning_summary_end",
+						contentIndex: 0,
+						content: "safe summary",
+						partial,
+					});
+					stream.push({ type: "done", reason: "stop", message: partial });
+				});
+				return stream;
+			},
+			onAssistantMessageEvent: (_message, event) => callbacks.push(event),
+		});
+
+		await agent.prompt("run", { fallbackManaged: true });
+
+		expect(agent.state.error).toBeUndefined();
+		expect(callbacks.map(event => event.type)).toEqual([
+			"reasoning_summary_start",
+			"reasoning_summary_delta",
+			"reasoning_summary_end",
+		]);
+		expect(callbacks[0]).toMatchObject({ type: "reasoning_summary_start", contentIndex: 0 });
+		expect(callbacks[1]).toMatchObject({
+			type: "reasoning_summary_delta",
+			contentIndex: 0,
+			delta: "safe summary",
+		});
+		expect(callbacks[2]).toMatchObject({
+			type: "reasoning_summary_end",
+			contentIndex: 0,
+			content: "safe summary",
+		});
+		expect(agent.state.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			content: [{ type: "thinking", thinking: "safe summary" }],
+		});
+	});
 	it("preserves a complete detached toolcall_end event", async () => {
 		const mock = createMockModel();
 		const toolCall = {


### PR DESCRIPTION
## What

- Accept `reasoning_summary_start`, `reasoning_summary_delta`, and `reasoning_summary_end` in managed fallback snapshots.
- Replay those events without converting them into local snapshot failures.
- Add focused regression coverage and an Unreleased changelog entry.

## Why

Providers can emit reasoning-summary events during a managed fallback attempt. The snapshot transaction rejected those valid event variants, aborting otherwise healthy turns with `Managed fallback attempt could not produce a serializable event snapshot`.

## Testing

- `bun test packages/agent/test/managed-attempt-transaction.test.ts` — 37 pass, 0 fail.
- `bun run check:ts` — pass.
- `bun run check:rs` — this is a TS-only change; no Rust touched. Locally it trips a macOS-only Clippy artifact (`missing_const_for_fn` on `pi-shell`'s `signal_root`, whose `target_os = "macos"` body never reads `self`). CI lints the pinned `rust-toolchain.toml` targets (linux-gnu, windows-msvc), where the same fn calls `self.inner.kill(signal)` and the lint does not fire — so this does not affect CI and must not be "fixed" by adding `const` (that would break the non-macOS build).
- `git diff --check` — pass.

---

- [x] Tested locally (focused suite + `check:ts`)
- [x] CHANGELOG updated (user-facing)