### PR TITLE
fix(python-sdk): correlate protocol responses

### DIFF
--- a/python/gjc-sdk/gjc_sdk/client.py
+++ b/python/gjc-sdk/gjc_sdk/client.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
+import asyncio
+from collections import deque
 from pathlib import Path
 from typing import Sequence
 from uuid import uuid4
 
 from .discovery import Endpoint, list_session_endpoints, select_live_endpoint
-from .frames import ControlRequest, Frame, JSONValue, control_request_frame, parse_frame, reply_frame, serialize_frame
+from .frames import (
+    ControlRequest,
+    ControlResponse,
+    Frame,
+    JSONValue,
+    QueryRequest,
+    QueryResponse,
+    control_request_frame,
+    parse_frame,
+    query_request_frame,
+    reply_frame,
+    serialize_frame,
+)
 from .transport import SocketTransport, StdioTransport, Transport, WsTransport
 
 
@@ -17,6 +31,9 @@ class SdkClient:
     def __init__(self, transport: Transport, token: str) -> None:
         self._transport = transport
         self._token: str | None = token
+        self._receive_lock = asyncio.Lock()
+        self._events: deque[Frame] = deque()
+        self._responses: dict[str, ControlResponse | QueryResponse] = {}
 
     def __repr__(self) -> str:
         return f"SdkClient(transport={type(self._transport).__name__}, token=***)"
@@ -59,7 +76,43 @@ class SdkClient:
         return cls(transport, token)
 
     async def recv(self) -> Frame:
+        while True:
+            if self._events:
+                return self._events.popleft()
+            async with self._receive_lock:
+                if self._events:
+                    return self._events.popleft()
+                frame = await self._receive_frame()
+                if isinstance(frame, (ControlResponse, QueryResponse)):
+                    self._responses[frame.id] = frame
+                else:
+                    return frame
+
+    async def _receive_frame(self) -> Frame:
         return parse_frame(await self._transport.receive_text())
+
+    async def _wait_for_response(self, identifier: str, response_type: type[ControlResponse] | type[QueryResponse]) -> ControlResponse | QueryResponse:
+        response = self._responses.pop(identifier, None)
+        if response is not None:
+            if not isinstance(response, response_type):
+                raise ValueError(f"unexpected response type for request {identifier}")
+            return response
+        async with self._receive_lock:
+            response = self._responses.pop(identifier, None)
+            if response is not None:
+                if not isinstance(response, response_type):
+                    raise ValueError(f"unexpected response type for request {identifier}")
+                return response
+            while True:
+                frame = await self._receive_frame()
+                if isinstance(frame, (ControlResponse, QueryResponse)):
+                    if frame.id == identifier:
+                        if not isinstance(frame, response_type):
+                            raise ValueError(f"unexpected response type for request {identifier}")
+                        return frame
+                    self._responses[frame.id] = frame
+                else:
+                    self._events.append(frame)
 
     def _require_token(self) -> str:
         if self._token is None:
@@ -69,15 +122,25 @@ class SdkClient:
     async def send_reply(self, action_id: str, answer: JSONValue) -> None:
         await self._transport.send_text(serialize_frame(reply_frame(action_id, answer, self._require_token())))
 
-    async def control(self, operation: str, input: dict[str, JSONValue], *, id: str | None = None) -> None:
+    async def control(self, operation: str, input: dict[str, JSONValue], *, id: str | None = None) -> ControlResponse:
         request: ControlRequest = control_request_frame(id or str(uuid4()), operation, input)
         await self._transport.send_text(serialize_frame(request))
+        response = await self._wait_for_response(request.id, ControlResponse)
+        assert isinstance(response, ControlResponse)
+        return response
 
-    async def answer_gate(self, gate_id: str, response: JSONValue, *, expected_session_id: str | None = None) -> None:
+    async def query(self, query: str, input: dict[str, JSONValue], *, cursor: str | None = None, id: str | None = None) -> QueryResponse:
+        request: QueryRequest = query_request_frame(id or str(uuid4()), query, input, cursor)
+        await self._transport.send_text(serialize_frame(request))
+        response = await self._wait_for_response(request.id, QueryResponse)
+        assert isinstance(response, QueryResponse)
+        return response
+
+    async def answer_gate(self, gate_id: str, response: JSONValue, *, expected_session_id: str | None = None) -> ControlResponse:
         input: dict[str, JSONValue] = {"id": gate_id, "response": response}
         if expected_session_id is not None:
             input["expectedSessionId"] = expected_session_id
-        await self.control("workflow.gate_answer", input)
+        return await self.control("workflow.gate_answer", input)
 
     async def close(self) -> None:
         try:

--- a/python/gjc-sdk/gjc_sdk/frames.py
+++ b/python/gjc-sdk/gjc_sdk/frames.py
@@ -27,7 +27,7 @@ class ActionNeeded:
 @dataclass(frozen=True)
 class ActionResolved:
     id: str
-    session_id: str
+    session_id: str | None = None
     resolved_by: str | None = None
 
 
@@ -59,13 +59,38 @@ class ControlResponse:
     result: JSONValue | None = None
     error: dict[str, JSONValue] | None = None
 
+@dataclass(frozen=True)
+class QueryRequest:
+    id: str
+    query: str
+    input: dict[str, JSONValue]
+    cursor: str | None = None
+
+
+@dataclass(frozen=True)
+class QueryPage:
+    items: list[JSONValue]
+    complete: bool
+    revision: str
+    continuation_cursor: str | None = None
+    preview: bool | None = None
+
+
+@dataclass(frozen=True)
+class QueryResponse:
+    id: str
+    ok: bool
+    result: JSONValue | None = None
+    page: QueryPage | None = None
+    error: dict[str, JSONValue] | None = None
+
 
 @dataclass(frozen=True)
 class GenericFrame:
     raw: dict[str, JSONValue]
 
 
-Frame = ActionNeeded | ActionResolved | ReplyRejected | Reply | ControlRequest | ControlResponse | GenericFrame
+Frame = ActionNeeded | ActionResolved | ReplyRejected | Reply | ControlRequest | ControlResponse | QueryRequest | QueryResponse | GenericFrame
 
 
 def _string(value: dict[str, JSONValue], name: str) -> str | None:
@@ -84,8 +109,8 @@ def parse_frame(text: str) -> Frame:
         options = raw.get("options")
         parsed_options = options if isinstance(options, list) and all(isinstance(item, str) for item in options) else None
         return ActionNeeded(identifier, _string(raw, "kind") or "", session_id, _string(raw, "question"), cast(list[str] | None, parsed_options), _string(raw, "workflowGateId"))
-    if frame_type == "action_resolved" and identifier is not None and (session_id := _string(raw, "sessionId")) is not None:
-        return ActionResolved(identifier, session_id, _string(raw, "resolvedBy"))
+    if frame_type == "action_resolved" and identifier is not None:
+        return ActionResolved(identifier, _string(raw, "sessionId"), _string(raw, "resolvedBy"))
     if frame_type == "reply_rejected" and identifier is not None and (reason := _string(raw, "reason")) is not None:
         return ReplyRejected(identifier, reason)
     if frame_type == "reply" and identifier is not None and "answer" in raw and (token := _string(raw, "token")) is not None:
@@ -100,7 +125,55 @@ def parse_frame(text: str) -> Frame:
             result = raw.get("result")
             error = raw.get("error")
             return ControlResponse(identifier, ok, result, cast(dict[str, JSONValue] | None, error) if isinstance(error, dict) else None)
+    if frame_type == "query_request" and identifier is not None and (query := _string(raw, "query")) is not None:
+        input_value = raw.get("input")
+        if isinstance(input_value, dict):
+            return QueryRequest(identifier, query, input_value, _string(raw, "cursor"))
+    if frame_type == "query_response" and identifier is not None:
+        ok = raw.get("ok")
+        if isinstance(ok, bool):
+            result = raw.get("result")
+            error = raw.get("error")
+            page_value = raw.get("page")
+            page = None
+            if isinstance(page_value, dict):
+                items = page_value.get("items")
+                complete = page_value.get("complete")
+                revision = page_value.get("revision")
+                continuation_cursor = page_value.get("continuationCursor")
+                preview = page_value.get("preview")
+                if (
+                    isinstance(items, list)
+                    and isinstance(complete, bool)
+                    and isinstance(revision, str)
+                    and (continuation_cursor is None or isinstance(continuation_cursor, str))
+                    and (preview is None or isinstance(preview, bool))
+                ):
+                    page = QueryPage(items, complete, revision, continuation_cursor, preview)
+            return QueryResponse(
+                identifier,
+                ok,
+                result,
+                page,
+                cast(dict[str, JSONValue] | None, error) if isinstance(error, dict) else None,
+            )
     return GenericFrame(raw)
+
+
+def _wire_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            "sessionId" if key == "session_id" else
+            "workflowGateId" if key == "workflow_gate_id" else
+            "idempotencyKey" if key == "idempotency_key" else
+            "resolvedBy" if key == "resolved_by" else
+            "continuationCursor" if key == "continuation_cursor" else key: _wire_value(item)
+            for key, item in value.items()
+            if item is not None
+        }
+    if isinstance(value, list):
+        return [_wire_value(item) for item in value]
+    return value
 
 
 def serialize_frame(frame: Frame) -> str:
@@ -108,8 +181,8 @@ def serialize_frame(frame: Frame) -> str:
         value: dict[str, JSONValue] = frame.raw
     else:
         value = asdict(frame)
-        value["type"] = {ActionNeeded: "action_needed", ActionResolved: "action_resolved", ReplyRejected: "reply_rejected", Reply: "reply", ControlRequest: "control_request", ControlResponse: "control_response"}[type(frame)]
-        value = {"sessionId" if key == "session_id" else "workflowGateId" if key == "workflow_gate_id" else "idempotencyKey" if key == "idempotency_key" else "resolvedBy" if key == "resolved_by" else key: item for key, item in value.items() if item is not None}
+        value["type"] = {ActionNeeded: "action_needed", ActionResolved: "action_resolved", ReplyRejected: "reply_rejected", Reply: "reply", ControlRequest: "control_request", ControlResponse: "control_response", QueryRequest: "query_request", QueryResponse: "query_response"}[type(frame)]
+        value = _wire_value(value)
     return json.dumps(value, separators=(",", ":"))
 
 
@@ -119,3 +192,7 @@ def reply_frame(action_id: str, answer: JSONValue, token: str) -> Reply:
 
 def control_request_frame(identifier: str, operation: str, input: dict[str, JSONValue]) -> ControlRequest:
     return ControlRequest(identifier, operation, input)
+
+
+def query_request_frame(identifier: str, query: str, input: dict[str, JSONValue], cursor: str | None = None) -> QueryRequest:
+    return QueryRequest(identifier, query, input, cursor)

--- a/python/gjc-sdk/gjc_sdk/frames.py
+++ b/python/gjc-sdk/gjc_sdk/frames.py
@@ -160,20 +160,14 @@ def parse_frame(text: str) -> Frame:
     return GenericFrame(raw)
 
 
-def _wire_value(value: Any) -> Any:
-    if isinstance(value, dict):
-        return {
-            "sessionId" if key == "session_id" else
-            "workflowGateId" if key == "workflow_gate_id" else
-            "idempotencyKey" if key == "idempotency_key" else
-            "resolvedBy" if key == "resolved_by" else
-            "continuationCursor" if key == "continuation_cursor" else key: _wire_value(item)
-            for key, item in value.items()
-            if item is not None
-        }
-    if isinstance(value, list):
-        return [_wire_value(item) for item in value]
-    return value
+def _wire_key(key: str) -> str:
+    return {
+        "session_id": "sessionId",
+        "workflow_gate_id": "workflowGateId",
+        "idempotency_key": "idempotencyKey",
+        "resolved_by": "resolvedBy",
+        "continuation_cursor": "continuationCursor",
+    }.get(key, key)
 
 
 def serialize_frame(frame: Frame) -> str:
@@ -181,8 +175,11 @@ def serialize_frame(frame: Frame) -> str:
         value: dict[str, JSONValue] = frame.raw
     else:
         value = asdict(frame)
+        if isinstance(frame, QueryResponse) and frame.page is not None:
+            page = cast(dict[str, JSONValue], value["page"])
+            value["page"] = {_wire_key(key): item for key, item in page.items() if item is not None}
         value["type"] = {ActionNeeded: "action_needed", ActionResolved: "action_resolved", ReplyRejected: "reply_rejected", Reply: "reply", ControlRequest: "control_request", ControlResponse: "control_response", QueryRequest: "query_request", QueryResponse: "query_response"}[type(frame)]
-        value = _wire_value(value)
+        value = {_wire_key(key): item for key, item in value.items() if item is not None}
     return json.dumps(value, separators=(",", ":"))
 
 

--- a/python/gjc-sdk/tests/test_client.py
+++ b/python/gjc-sdk/tests/test_client.py
@@ -11,9 +11,65 @@ from typing import Any
 import pytest
 
 from gjc_sdk import SdkClient
-from gjc_sdk.frames import ActionNeeded, parse_frame
+from gjc_sdk.frames import ActionNeeded, ControlResponse, QueryResponse, parse_frame
 from gjc_sdk.discovery import Endpoint, EndpointSelectionError
 
+
+class FakeTransport:
+    def __init__(self, received: list[str]) -> None:
+        self.received = asyncio.Queue[str]()
+        for frame in received:
+            self.received.put_nowait(frame)
+        self.sent: list[dict[str, Any]] = []
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(json.loads(text))
+
+    async def receive_text(self) -> str:
+        return await self.received.get()
+
+    async def close(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_control_correlates_out_of_order_and_preserves_actions() -> None:
+    transport = FakeTransport(
+        [
+            '{"type":"action_needed","id":"a1","kind":"ask","sessionId":"s1"}',
+            '{"type":"control_response","id":"second","ok":false,"error":{"code":"conflict"}}',
+            '{"type":"control_response","id":"first","ok":true,"result":{"accepted":true}}',
+        ]
+    )
+    client = SdkClient(transport, "secret")
+
+    first = asyncio.create_task(client.control("first.operation", {}, id="first"))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(client.control("second.operation", {}, id="second"))
+
+    assert await first == ControlResponse("first", True, {"accepted": True})
+    assert await second == ControlResponse("second", False, error={"code": "conflict"})
+    assert await client.recv() == ActionNeeded("a1", "ask", "s1")
+
+
+@pytest.mark.asyncio
+async def test_query_returns_paginated_response() -> None:
+    transport = FakeTransport(
+        [
+            '{"type":"query_response","id":"q1","ok":true,"page":{"items":[{"id":"one"}],"complete":false,"continuationCursor":"next","revision":"r1"}}'
+        ]
+    )
+    client = SdkClient(transport, "secret")
+
+    response = await client.query("todo.list", {}, cursor="previous", id="q1")
+
+    assert isinstance(response, QueryResponse)
+    assert response.page is not None
+    assert response.page.items == [{"id": "one"}]
+    assert response.page.continuation_cursor == "next"
+    assert transport.sent == [
+        {"type": "query_request", "id": "q1", "query": "todo.list", "input": {}, "cursor": "previous"}
+    ]
 
 @pytest.mark.parametrize(
     ("endpoint", "code"),

--- a/python/gjc-sdk/tests/test_frames.py
+++ b/python/gjc-sdk/tests/test_frames.py
@@ -1,11 +1,18 @@
 import json
 
-from gjc_sdk.frames import ActionNeeded, ActionResolved, GenericFrame, QueryPage, QueryResponse, Reply, parse_frame, reply_frame, serialize_frame
+from gjc_sdk.frames import ActionNeeded, ActionResolved, ControlRequest, GenericFrame, QueryPage, QueryResponse, Reply, parse_frame, reply_frame, serialize_frame
 
 
 def test_reply_serialization_includes_token() -> None:
     raw = json.loads(serialize_frame(reply_frame("action-1", {"choice": "yes"}, "secret")))
     assert raw == {"type": "reply", "id": "action-1", "answer": {"choice": "yes"}, "token": "secret"}
+
+
+def test_serialization_preserves_nested_user_payload() -> None:
+    raw = json.loads(
+        serialize_frame(ControlRequest("request-1", "status", {"filter": {"session_id": "s", "include": None}}))
+    )
+    assert raw["input"] == {"filter": {"session_id": "s", "include": None}}
 
 
 def test_unknown_frame_is_preserved() -> None:

--- a/python/gjc-sdk/tests/test_frames.py
+++ b/python/gjc-sdk/tests/test_frames.py
@@ -1,6 +1,6 @@
 import json
 
-from gjc_sdk.frames import ActionNeeded, GenericFrame, Reply, parse_frame, reply_frame, serialize_frame
+from gjc_sdk.frames import ActionNeeded, ActionResolved, GenericFrame, QueryPage, QueryResponse, Reply, parse_frame, reply_frame, serialize_frame
 
 
 def test_reply_serialization_includes_token() -> None:
@@ -26,3 +26,13 @@ def test_action_needed_round_trip() -> None:
 
 def test_reply_repr_hides_token() -> None:
     assert "secret-token" not in repr(Reply("action-1", "yes", "secret-token"))
+
+
+def test_action_resolved_without_session_id_is_typed() -> None:
+    frame = parse_frame('{"type":"action_resolved","id":"a1","resolvedBy":"local"}')
+    assert frame == ActionResolved("a1", resolved_by="local")
+
+
+def test_query_page_round_trip() -> None:
+    original = QueryResponse("q1", True, page=QueryPage([{"id": "one"}], False, "r1", "next", True))
+    assert parse_frame(serialize_frame(original)) == original


### PR DESCRIPTION
## Summary
- correlate control and query responses by request ID, including out-of-order responses
- preserve action frames received while awaiting request responses
- add typed v3 query request/response pagination support
- decode canonical `action_resolved` frames without `sessionId`

## Verification
- `GJC_REAL_SESSION_TESTS=1 uv run --extra test pytest tests/test_client.py` (8 passed; WebSocket, Unix socket, and stdio real-session paths)
- `uv run --extra test pytest tests/test_frames.py tests/test_discovery.py tests/test_transport.py tests/test_vectors.py` (22 passed)
- `uv run --extra test mypy gjc_sdk`
- `git diff --check`