### PR TITLE
fix(sdk): reclaim repeated stale broker locks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `skill_discovery` empty results now carry a `notice` when discovery config caused the emptiness — naming the exact disabled setting (`skills.enabled`, `skills.enablePiProject`, or `skills.enablePiUser`) and the `gjc config set` command to enable it. Previously a disabled config was indistinguishable from "no skills exist", silently hiding freshly written user/project skills.
 
 ### Fixed
+- Repeated byte-identical stale SDK broker locks no longer cause startup to loop when a prior tombstone exists.
 
 - Ordinary `ask` calls now normalize a provider-emitted `deepInterview: null` placeholder instead of misclassifying it as malformed Round-0 intent recovery data and rejecting it before coercion.
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
+import type { BigIntStats } from "node:fs";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import type { NativeDirectoryTreeSnapshot } from "@gajae-code/natives";
@@ -362,6 +363,7 @@ type BrokerLockSnapshot = {
 	ownerId?: string;
 	pid: number;
 	identity: string;
+	lockIdentity: string;
 };
 
 const BROKER_PUBLICATION_CADENCE_MS = 5_000;
@@ -415,7 +417,7 @@ export class Broker {
 	#lockRecordPath(): string {
 		return path.join(this.#lock, BROKER_LOCK_RECORD);
 	}
-	#lockSnapshot(raw: string): BrokerLockSnapshot {
+	async #lockSnapshot(raw: string, lockIdentity: string): Promise<BrokerLockSnapshot> {
 		try {
 			const lock = JSON.parse(raw) as { ownerId?: unknown; pid?: unknown };
 			if (
@@ -425,32 +427,37 @@ export class Broker {
 				Number.isInteger(lock.pid) &&
 				lock.pid > 0
 			)
-				return { ownerId: lock.ownerId, pid: lock.pid, identity: `owner:${lock.ownerId}` };
+				return { ownerId: lock.ownerId, pid: lock.pid, identity: `owner:${lock.ownerId}`, lockIdentity };
 		} catch {}
-		return { pid: 0, identity: `contents:${createHash("sha256").update(raw).digest("hex")}` };
+		return { pid: 0, identity: `contents:${createHash("sha256").update(raw).digest("hex")}`, lockIdentity };
 	}
 	async #readLock(): Promise<BrokerLockSnapshot | null> {
+		let lock: BigIntStats;
 		try {
-			return this.#lockSnapshot(await fs.readFile(this.#lockRecordPath(), "utf8"));
-		} catch (e) {
-			const code = (e as NodeJS.ErrnoException).code;
-			if (code === "ENOTDIR") {
-				try {
-					return this.#lockSnapshot(await fs.readFile(this.#lock, "utf8"));
-				} catch (legacyError) {
-					if ((legacyError as NodeJS.ErrnoException).code === "ENOENT") return null;
-					throw legacyError;
-				}
-			}
-			if (code !== "ENOENT") throw e;
-		}
-		try {
-			const lock = await fs.stat(this.#lock);
-			return lock.isDirectory() ? { pid: 0, identity: `directory:${lock.dev}:${lock.ino}` } : null;
+			lock = await fs.lstat(this.#lock, { bigint: true });
 		} catch (e) {
 			if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
 			throw e;
 		}
+		const lockIdentity = `${lock.dev}:${lock.ino}`;
+		let raw: string;
+		try {
+			raw = lock.isDirectory()
+				? await fs.readFile(path.join(this.#lock, BROKER_LOCK_RECORD), "utf8")
+				: await fs.readFile(this.#lock, "utf8");
+		} catch (e) {
+			if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+			raw = "";
+		}
+		try {
+			const current = await fs.lstat(this.#lock, { bigint: true });
+			if (`${current.dev}:${current.ino}` !== lockIdentity || current.isDirectory() !== lock.isDirectory())
+				return null;
+		} catch (e) {
+			if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
+			throw e;
+		}
+		return this.#lockSnapshot(raw, lockIdentity);
 	}
 	async #createLock(): Promise<void> {
 		await fs.mkdir(this.#lock, { mode: 0o700 });
@@ -478,13 +485,18 @@ export class Broker {
 	}
 	async #reclaimStaleLock(snapshot: BrokerLockSnapshot): Promise<void> {
 		const current = await this.#readLock();
-		if (!current || current.identity !== snapshot.identity || (current.pid > 0 && isPidAlive(current.pid))) return;
+		if (
+			!current ||
+			current.identity !== snapshot.identity ||
+			current.lockIdentity !== snapshot.lockIdentity ||
+			(current.pid > 0 && isPidAlive(current.pid))
+		)
+			return;
 
-		// Keep the tombstone: its immutable-owner-derived pathname prevents a contender
-		// holding an old snapshot from renaming a newly-created directory lock.
+		// Snapshot validation and the deterministic instance suffix protect successor locks.
 		const tombstone = path.join(
 			path.dirname(this.#lock),
-			`.broker.lock.stale-${createHash("sha256").update(snapshot.identity).digest("hex")}`,
+			`.broker.lock.stale-${createHash("sha256").update(snapshot.lockIdentity).digest("hex")}`,
 		);
 		try {
 			await fs.rename(this.#lock, tombstone);

--- a/packages/coding-agent/test/sdk-broker-restart.test.ts
+++ b/packages/coding-agent/test/sdk-broker-restart.test.ts
@@ -14,6 +14,36 @@ describe("SDK broker restart", () => {
 		expect(second.token).not.toBe(first.token);
 		await b.stop();
 	});
+	it("reclaims repeated identical stale locks into distinct tombstones", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-restart-repeat-"));
+		const lock = path.join(dir, "sdk", "broker.lock");
+		const owner = JSON.stringify({ version: 1, ownerId: "stale-owner", pid: 999_999_999, acquiredAt: 0 });
+		await fs.mkdir(lock, { recursive: true });
+		await fs.writeFile(path.join(lock, "owner.json"), owner);
+
+		const first = new Broker({ agentDir: dir });
+		try {
+			await first.start();
+		} finally {
+			await first.stop();
+		}
+
+		await fs.mkdir(lock, { recursive: true });
+		await fs.writeFile(path.join(lock, "owner.json"), owner);
+		const second = new Broker({ agentDir: dir });
+		try {
+			const discovery = await second.start();
+			expect(discovery.ownerId).toBeDefined();
+			expect(second.ownsDiscovery).toBe(true);
+			const tombstones = (await fs.readdir(path.dirname(lock))).filter(name =>
+				name.startsWith(".broker.lock.stale-"),
+			);
+			expect(tombstones).toHaveLength(2);
+			expect(new Set(tombstones).size).toBe(2);
+		} finally {
+			await second.stop();
+		}
+	});
 
 	it("allows one owner during simultaneous primary lock takeover", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-restart-race-"));


### PR DESCRIPTION
## Summary

- derive stale broker tombstones from the concrete lock instance rather than reusable owner contents
- retain exact owner and lock snapshot validation before takeover
- add regression coverage for byte-identical stale lock recurrence after a prior tombstone

## Root cause

`Broker.#reclaimStaleLock` previously derived the tombstone destination only from `snapshot.identity`. Recreating the same dead owner lock byte-for-byte therefore selected the already-retained tombstone path. `rename()` returned `EEXIST`, the source lock remained in place, and the startup acquisition loop retried the same unreclaimable lock indefinitely. Broker discovery was never published, blocking broker-backed discovery, resume, close, and delete operations until manual filesystem cleanup.

## Fix

The lock snapshot now records the concrete filesystem identity of the outer lock path using exact bigint `dev` and `ino` values. The reclaim path reads the lock instance identity, reads the owner record, verifies the outer path still identifies the same directory or file, re-reads immediately before reclaim and compares both owner identity and concrete lock identity, then derives the retained tombstone from that concrete lock identity.

All contenders observing one stale lock instance derive the same destination, preserving the existing delayed-contender fence. A byte-identical lock recreated after takeover has a different inode while the original inode remains retained in its tombstone, so it receives a distinct destination and can be reclaimed normally. Legacy regular-file locks remain supported.

## Regression coverage

The new restart regression reproduces the failure sequence:

1. create a dead-owner `sdk/broker.lock/owner.json`,
2. start and stop a broker to retain the first tombstone,
3. recreate the same lock with byte-identical owner JSON,
4. start a second broker, and
5. assert it owns discovery and two distinct tombstones exist.

The existing simultaneous primary-lock takeover test remains green, ensuring two contenders still converge on one owner rather than renaming a successor lock.

## Verification

- `bun test test/sdk-broker-restart.test.ts` — 4 pass, 0 fail
- focused restart suite repeated 10 times — all pass
- `bunx biome check src/sdk/broker/broker.ts test/sdk-broker-restart.test.ts` — pass
- `bun run check` in `packages/coding-agent` — pass
- `git diff --check origin/dev...HEAD` — pass
- rebased onto current upstream `dev` before push

## Scope

This is a focused three-file change. No broker protocol, discovery schema, lock owner record, or lifecycle API changes.