### PR TITLE
fix(notifications): fence malformed topic creation retries

### DIFF
--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -258,6 +258,7 @@ const BTW_QUESTION_LIMIT_TEXT = "Question must be at most 4096 Unicode scalar va
 type ParsedBtwCommand = { kind: "question"; question: string } | { kind: "ignored" };
 type TelegramFileDownload = { bytes: Buffer } | { failure: "download_failed" | "too_large" };
 class ThreadedModeCapabilityRefusal extends Error {}
+class MalformedForumTopicResponse extends Error {}
 
 /** Only an explicit Bot API capability refusal may enable flat private-chat delivery. */
 function isThreadedModeCapabilityRefusal(response: unknown): boolean {
@@ -2963,6 +2964,13 @@ export class TelegramNotificationDaemon {
 	private readonly botApi: BotApi;
 	private readonly effects = new TelegramEffectSupervisor();
 	private readonly topics = new TopicRegistry();
+	/**
+	 * A malformed successful create response is ambiguous: Telegram may have
+	 * created the topic even though the daemon cannot address it. Fence retries
+	 * for the same endpoint so discovery/replay loops cannot create unbounded
+	 * orphan topics. A replacement endpoint gets one fresh attempt.
+	 */
+	private readonly malformedTopicCreates = new Map<string, string>();
 	/** Serializes registry snapshots so an older atomic write cannot overwrite newer rename state. */
 	/** Legacy sockets have no durable token, so explicit teardown is their revocation fence. */
 	private readonly droppedSessions = new WeakSet<SessionSocket>();
@@ -5117,6 +5125,8 @@ export class TelegramNotificationDaemon {
 		if (session && sessionId === session.sessionId && this.#logicalSessionId(session) !== sessionId) return undefined;
 		const capturedCreationLease = creationLease ?? (session ? this.#socketLease(session, sessionId) : undefined);
 		if (session?.logicalSessionIdTrusted && !capturedCreationLease) return undefined;
+		const creationEndpointKey = session?.endpointDigest ?? session?.endpointKey ?? "unbound";
+		if (this.malformedTopicCreates.get(sessionId) === creationEndpointKey) return undefined;
 		const existing = this.topics.get(sessionId);
 		if (existing?.authorityState === "delete_pending" || existing?.bindingMalformed) return undefined;
 		if (existing) return existing.topicId;
@@ -5141,9 +5151,12 @@ export class TelegramNotificationDaemon {
 					const res = await this.botApi.call("createForumTopic", { chat_id: this.opts.chatId, name });
 					if (isThreadedModeCapabilityRefusal(res)) throw new ThreadedModeCapabilityRefusal();
 					const tid = (res as { result?: { message_thread_id?: unknown } }).result?.message_thread_id;
-					if (typeof tid !== "number" || !Number.isSafeInteger(tid) || tid <= 0)
-						throw new Error("createForumTopic: invalid message_thread_id");
+					if (typeof tid !== "number" || !Number.isSafeInteger(tid) || tid <= 0) {
+						this.malformedTopicCreates.set(sessionId, creationEndpointKey);
+						throw new MalformedForumTopicResponse("createForumTopic: invalid message_thread_id");
+					}
 					acceptedTopicId = String(tid);
+					this.malformedTopicCreates.delete(sessionId);
 					if (capturedCreationLease && !(await this.#awaitCreationLeaseAuthority(capturedCreationLease))) {
 						if (
 							!this.topics.fenceAcceptedCreateForLease(

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -15872,3 +15872,54 @@ describe("telegram daemon /btw reservation and capability boundaries", () => {
 		).toEqual([909]);
 	});
 });
+test("malformed createForumTopic response is attempted once per endpoint", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const originalCall = bot.call.bind(bot);
+	bot.call = async (method, body, options) => {
+		if (method === "createForumTopic") {
+			bot.calls.push({ method, body, options });
+			return { ok: true, result: true };
+		}
+		return originalCall(method, body, options);
+	};
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+	});
+
+	daemon.connectSession("S", "ws://first", "token");
+	await Bun.sleep(20);
+	const first = daemon.sessions.get("S")!;
+	await expect(
+		daemon.handleSessionMessage(first, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "gajae-code",
+			branch: "dev",
+		}),
+	).rejects.toThrow("invalid message_thread_id");
+	await daemon.handleSessionMessage(first, {
+		type: "turn_stream",
+		sessionId: "S",
+		text: "must not retry",
+	});
+	expect(bot.calls.filter(call => call.method === "createForumTopic")).toHaveLength(1);
+	(first.ws as unknown as FakeWs).close();
+
+	daemon.connectSession("S", "ws://replacement", "token");
+	const replacement = daemon.sessions.get("S")!;
+	await expect(
+		daemon.handleSessionMessage(replacement, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "gajae-code",
+			branch: "dev",
+		}),
+	).rejects.toThrow("invalid message_thread_id");
+	expect(bot.calls.filter(call => call.method === "createForumTopic")).toHaveLength(2);
+});


### PR DESCRIPTION
## Summary
- fence malformed `createForumTopic` success responses by session endpoint
- prevent discovery, replay, and frame handling from repeatedly creating potentially orphaned Telegram topics
- permit one fresh attempt only after the endpoint identity changes

## Why
A real 0.11.7 daemon repeatedly received `{ ok: true }` responses without a valid `result.message_thread_id`. Telegram could already have accepted the side effect, while the daemon treated every later session event as another creation opportunity. This produced a rapid create/delete loop and thousands of authority-epoch increments for one session.

Malformed successful responses are ambiguous and must not be retried against the same endpoint. The first failure remains visible to existing callers; later attempts fail closed without another external side effect.

## Verification
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/sdk/bus/telegram-daemon.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts` (407 pass)
- `git diff --check`