### PR TITLE
perf(windows): make interactive startup responsive

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Repeated byte-identical stale SDK broker locks no longer cause startup to loop when a prior tombstone exists.
 - ConversationStore now tolerates only unsupported Windows parent-directory durability errors after preserving temporary-file fsync and atomic rename.
 - Ralplan no longer re-asks for execution approval when the user already explicitly named `ultragoal` or `team` in the current turn; that naming is the consent.
+- Interactive Windows startup now stays keyboard-ready with large session histories and native multiplexers by showing an interactive-only bootstrap before the first TUI start, deferring bounded recent-session discovery until afterward, and reducing psmux frame pressure while preserving the three-second animation and update checks.
 
 - Cron guidance now routes silent recurring polling and event-driven PR/CI watchers to `monitor`, because every cron firing starts a normal assistant turn and prompt wording cannot reliably suppress its response.
 - Ordinary `ask` calls now normalize a provider-emitted `deepInterview: null` placeholder instead of misclassifying it as malformed Round-0 intent recovery data and rejecting it before coercion.

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -118,6 +118,33 @@ Options:
 `);
 }
 
+export function interactiveBootstrapText(
+	argv: readonly string[],
+	stdinIsTTY = process.stdin.isTTY,
+	stdoutIsTTY = process.stdout.isTTY,
+): string | undefined {
+	if (!stdinIsTTY || !stdoutIsTTY || argv[0] !== "launch") return undefined;
+	for (let index = 1; index < argv.length; index++) {
+		const arg = argv[index];
+		if (
+			arg === "--print" ||
+			arg === "-p" ||
+			arg === "--export" ||
+			arg?.startsWith("--export=") ||
+			arg === "--list-models" ||
+			arg?.startsWith("--list-models=") ||
+			arg === "--mode" ||
+			arg?.startsWith("--mode=") ||
+			arg === "--help" ||
+			arg === "-h" ||
+			arg === "--version" ||
+			arg === "-v"
+		)
+			return undefined;
+	}
+	return "\u001b[?25h\u001b[38;5;45mGJC\u001b[0m warming workspace\r\n\r\n> ";
+}
+
 function isNotifyDaemonInternalFastPath(argv: string[]): boolean {
 	return argv[0] === "notify" && argv[1] === "daemon-internal";
 }
@@ -412,6 +439,8 @@ export async function runCli(argv: string[]): Promise<void> {
 		showStatsFastHelp();
 		return;
 	}
+	const bootstrap = interactiveBootstrapText(runArgv);
+	if (bootstrap) process.stdout.write(bootstrap);
 	await installRuntimeGlobals();
 	return run({ bin: APP_NAME, version: VERSION, argv: runArgv, commands, help: showHelp });
 }

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -661,8 +661,16 @@ function gradientLogo(lines: readonly string[], phase = 0, shine?: ShineConfig):
 
 /** Total length of the intro animation. */
 const INTRO_MS = 3000;
-/** Render cadence during the intro (~30fps). */
-const INTRO_TICK_MS = 33;
+/** Resolve the intro cadence without making tests mutate global process state. */
+export function resolveWelcomeIntroTickMs(
+	platform: NodeJS.Platform = process.platform,
+	tmux = process.env.TMUX,
+): number {
+	return platform === "win32" && tmux ? 100 : 33;
+}
+
+/** Render at 30fps directly, but cap native Windows multiplexers at 10fps to avoid ConPTY output backpressure. */
+const INTRO_TICK_MS = resolveWelcomeIntroTickMs();
 /** Number of full gradient rotations the sweep performs before settling. */
 const INTRO_SWEEPS = 2.5;
 /** Number of times the shine highlight crosses the diagonal across the intro. */

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -64,6 +64,7 @@ import type { ToolExecutionHandle } from "./components/tool-execution";
 import { StatusLineComponent } from "./components/tool-status-header";
 import { composeToolText } from "./components/tool-transcript-format";
 import {
+	type RecentSession,
 	WelcomeComponent,
 	type WelcomeLogoMode,
 	type LspServerInfo as WelcomeLspServerInfo,
@@ -625,15 +626,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		const modelName = this.session.model?.name ?? "Unknown";
 		const providerName = this.session.model?.provider ?? "Unknown";
 
-		// Get recent sessions
-		const recentSessions = await logger.time("InteractiveMode.init:recentSessions", () =>
-			getRecentSessions(this.sessionManager.getSessionDir()).then(sessions =>
-				sessions.map(s => ({
-					name: s.name,
-					timeAgo: s.timeAgo,
-				})),
-			),
-		);
+		// Session history is display-only. Never hold the editor and keyboard behind
+		// transcript I/O; populate the welcome trail after the interactive surface exists.
+		const recentSessions: RecentSession[] = [];
 
 		const startupQuiet = settings.get("startup.quiet");
 		const welcomeLogoMode = resolveWelcomeLogoMode(settings.get("startup.welcomeBannerMode"));
@@ -756,6 +751,31 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (this.settings.get("tasksPane.defaultVisible")) this.showTasksPane();
 		this.#syncIrcSidebarAvailabilityFromSettings();
 		this.ui.requestRender(true);
+		if (this.#welcomeComponent) {
+			const welcomeComponent = this.#welcomeComponent;
+			const recentSessionsTimer = setTimeout(() => {
+				void logger
+					.time("InteractiveMode.init:recentSessions", () =>
+						getRecentSessions(this.sessionManager.getSessionDir()),
+					)
+					.then(sessions => {
+						if (this.#welcomeComponent !== welcomeComponent) return;
+						welcomeComponent.setRecentSessions(
+							sessions.map(session => ({
+								name: session.name,
+								timeAgo: session.timeAgo,
+							})),
+						);
+						this.ui.requestRender();
+					})
+					.catch(error => {
+						logger.debug("Failed to load recent sessions for welcome screen", {
+							error: error instanceof Error ? error.message : String(error),
+						});
+					});
+			}, 0);
+			recentSessionsTimer.unref?.();
+		}
 
 		// GitHub star reminder (interactive-only). Register the decline-driven
 		// injection contributor and schedule the launch nudge after the first

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2110,41 +2110,90 @@ export async function recoverOrphanedBackups(sessionDir: string, storage: Sessio
 }
 
 /**
- * Reads all session files from the directory and returns them sorted by mtime (newest first).
- * Uses low-level file I/O to efficiently read only the first 4KB of each file
- * to extract the JSON header and first user message without loading entire session logs into memory.
+ * Returns session metadata sorted by mtime (newest first).
+ *
+ * Directory entries are cheap to stat, but opening every transcript before applying a
+ * small caller limit makes welcome-screen startup scale with the entire session history.
+ * Rank paths first, then read bounded batches until the requested number of valid
+ * sessions has been found. Invalid or future-version files do not prevent older valid
+ * sessions from filling the result.
  */
-async function getSortedSessions(sessionDir: string, storage: SessionStorage): Promise<RecentSessionInfo[]> {
+async function getSortedSessions(
+	sessionDir: string,
+	storage: SessionStorage,
+	limit?: number,
+): Promise<RecentSessionInfo[]> {
 	await recoverOrphanedBackups(sessionDir, storage);
 	try {
-		const files: string[] = storage.listFilesSync(sessionDir, "*.jsonl");
+		let candidates: Array<{ path: string; mtime: number }> | undefined;
+		if (storage.listFilesByMtime) {
+			try {
+				candidates = (await storage.listFilesByMtime(sessionDir, "*.jsonl")).map(candidate => ({
+					path: candidate.path,
+					mtime: candidate.mtimeMs,
+				}));
+			} catch (error) {
+				logger.warn("Native session mtime listing failed; using JavaScript fallback", {
+					sessionDir,
+					error: toError(error).message,
+				});
+			}
+		} else {
+			logger.debug("Native session mtime listing unavailable; using JavaScript fallback", { sessionDir });
+		}
+		candidates ??= storage.listFilesSync(sessionDir, "*.jsonl").flatMap(path => {
+			try {
+				return [{ path, mtime: storage.statSync(path).mtimeMs }];
+			} catch {
+				return [];
+			}
+		});
+		candidates.sort((left, right) => {
+			if (left.mtime !== right.mtime) return right.mtime - left.mtime;
+			return left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
+		});
+
 		const sessions: RecentSessionInfo[] = [];
-		await Promise.all(
-			files.map(async (path: string) => {
-				try {
-					const buffer = Buffer.allocUnsafe(SESSION_LIST_PREFIX_BYTES);
-					const content = await readSessionListPrefix(path, storage, buffer);
-					const entries = parseJsonlLenient<Record<string, unknown>>(content);
-					if (entries.length === 0) return;
-					const header = entries[0] as Record<string, unknown>;
-					if (
-						header.type !== "session" ||
-						typeof header.id !== "string" ||
-						!isSupportedSessionVersion(header.version)
-					)
-						return;
-					if (typeof header.version === "number" && header.version >= 4) {
-						for (const patch of await readSessionListTrailingPatches(path, storage, buffer)) {
-							applySessionListHeaderPatch(header as unknown as SessionListHeader, patch);
+		const batchSize = Math.max(32, limit ?? 0);
+
+		for (
+			let offset = 0;
+			offset < candidates.length && (limit === undefined || sessions.length < limit);
+			offset += batchSize
+		) {
+			const batch = candidates.slice(offset, offset + batchSize);
+			const parsed = await Promise.all(
+				batch.map(async candidate => {
+					try {
+						const buffer = Buffer.allocUnsafe(SESSION_LIST_PREFIX_BYTES);
+						const content = await readSessionListPrefix(candidate.path, storage, buffer);
+						const entries = parseJsonlLenient<Record<string, unknown>>(content);
+						if (entries.length === 0) return undefined;
+						const header = entries[0] as Record<string, unknown>;
+						if (
+							header.type !== "session" ||
+							typeof header.id !== "string" ||
+							!isSupportedSessionVersion(header.version)
+						)
+							return undefined;
+						if (typeof header.version === "number" && header.version >= 4) {
+							for (const patch of await readSessionListTrailingPatches(candidate.path, storage, buffer)) {
+								applySessionListHeaderPatch(header as unknown as SessionListHeader, patch);
+							}
 						}
+						const firstPrompt = header.title ? undefined : extractFirstUserPrompt(entries);
+						return new RecentSessionInfo(candidate.path, candidate.mtime, header, firstPrompt);
+					} catch {
+						return undefined;
 					}
-					const mtime = storage.statSync(path).mtimeMs;
-					const firstPrompt = header.title ? undefined : extractFirstUserPrompt(entries);
-					sessions.push(new RecentSessionInfo(path, mtime, header, firstPrompt));
-				} catch {}
-			}),
-		);
-		return sessions.sort((a, b) => b.mtime - a.mtime);
+				}),
+			);
+			for (const session of parsed) {
+				if (session) sessions.push(session);
+				if (limit !== undefined && sessions.length >= limit) break;
+			}
+		}
+		return sessions;
 	} catch {
 		return [];
 	}
@@ -2155,7 +2204,7 @@ export async function findMostRecentSession(
 	sessionDir: string,
 	storage: SessionStorage = new FileSessionStorage(),
 ): Promise<string | null> {
-	const sessions = await getSortedSessions(sessionDir, storage);
+	const sessions = await getSortedSessions(sessionDir, storage, 1);
 	return sessions[0]?.path || null;
 }
 
@@ -3427,8 +3476,7 @@ export async function getRecentSessions(
 	limit = DEFAULT_WELCOME_RECENT_SESSION_LIMIT,
 	storage: SessionStorage = new FileSessionStorage(),
 ): Promise<RecentSessionInfo[]> {
-	const sessions = await getSortedSessions(sessionDir, storage);
-	return sessions.slice(0, limit);
+	return getSortedSessions(sessionDir, storage, limit);
 }
 
 /**

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -713,7 +713,7 @@ export class FileSessionStorage implements SessionStorage {
 			pattern,
 			fileType: native.FileType.File,
 			recursive: false,
-			hidden: true,
+			hidden: false,
 			gitignore: false,
 			sortByMtime: true,
 		});

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -167,6 +167,8 @@ export interface SessionStorage {
 	readSnapshotSync?(path: string): SessionStorageSnapshot;
 	statSync(path: string): SessionStorageStat;
 	listFilesSync(dir: string, pattern: string): string[];
+	/** List matching files with mtimes without issuing one JavaScript stat call per path. */
+	listFilesByMtime?(dir: string, pattern: string): Promise<Array<{ path: string; mtimeMs: number }>>;
 	/**
 	 * Strict directory scan that never suppresses scan/root errors. Used by strict
 	 * authorization inventory; the forgiving {@link listFilesSync} stays display-only.
@@ -704,6 +706,21 @@ export class FileSessionStorage implements SessionStorage {
 		} catch {
 			return [];
 		}
+	}
+	async listFilesByMtime(dir: string, pattern: string): Promise<Array<{ path: string; mtimeMs: number }>> {
+		const result = await native.glob({
+			path: dir,
+			pattern,
+			fileType: native.FileType.File,
+			recursive: false,
+			hidden: true,
+			gitignore: false,
+			sortByMtime: true,
+		});
+		return result.matches.map(match => ({
+			path: path.join(dir, match.path),
+			mtimeMs: match.mtime ?? 0,
+		}));
 	}
 
 	listFilesStrictSync(dir: string, pattern: string): string[] {
@@ -1469,6 +1486,12 @@ export class MemorySessionStorage implements SessionStorage {
 			files.push(path);
 		}
 		return files;
+	}
+	listFilesByMtime(dir: string, pattern: string): Promise<Array<{ path: string; mtimeMs: number }>> {
+		const files = this.listFilesSync(dir, pattern)
+			.map(path => ({ path, mtimeMs: this.statSync(path).mtimeMs }))
+			.sort((a, b) => b.mtimeMs - a.mtimeMs);
+		return Promise.resolve(files);
 	}
 	listFilesStrictSync(dir: string, pattern: string): string[] {
 		// In-memory scan never suppresses; identical to the display scan.

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { lifecyclePaths } from "@gajae-code/coding-agent/gjc-runtime/tmux-owner-isolation";
 import packageJson from "../package.json";
-import { routeRootArgv } from "../src/cli";
+import { interactiveBootstrapText, routeRootArgv } from "../src/cli";
 import { parseArgs } from "../src/cli/args";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
@@ -32,6 +32,44 @@ describe("GJC public CLI command surface", () => {
 			"0",
 			"invalid legacy --team-size",
 		]);
+	});
+
+	it("renders an immediate keyboard-ready bootstrap only for interactive launch routes", () => {
+		expect(interactiveBootstrapText(["launch"], true, true)).toContain("> ");
+		expect(interactiveBootstrapText(["launch", "hello"], true, true)).toContain("warming workspace");
+		expect(interactiveBootstrapText(["launch", "--print", "hello"], true, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["launch", "--export", "session.md"], true, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["launch", "--list-models"], true, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["launch", "--mode", "json"], true, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["launch", "--mode=acp"], true, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["launch", "--export=session.md"], true, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["launch", "--list-models=opus"], true, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["config", "get", "theme"], true, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["launch"], false, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["launch"], true, false)).toBeUndefined();
+	});
+	it("suppresses the interactive bootstrap for every explicit output mode form", () => {
+		expect(interactiveBootstrapText(["launch", "--mode", "text"], true, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["launch", "--mode=text"], true, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["launch", "--mode", "text", "--mode=json"], true, true)).toBeUndefined();
+		expect(interactiveBootstrapText(["launch", "--mode=acp", "--mode", "text"], true, true)).toBeUndefined();
+	});
+
+	it("suppresses the interactive bootstrap for explicit launch help and version aliases", () => {
+		for (const flag of ["--help", "-h", "--version", "-v"]) {
+			expect(interactiveBootstrapText(["launch", flag], true, true)).toBeUndefined();
+		}
+	});
+
+	it("does not prefix spawned noninteractive launch help output with the bootstrap", () => {
+		const result = Bun.spawnSync(["bun", cliEntry, "launch", "--help"], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const output = `${result.stdout.toString()}\n${result.stderr.toString()}`;
+		expect(result.exitCode, output).toBe(0);
+		expect(result.stdout.toString()).not.toContain("warming workspace");
 	});
 	it("routes the internal managed-owner supervisor through its child admission barrier", async () => {
 		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-cli-supervisor-"));

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -99,6 +99,29 @@ describe("findMostRecentSession", () => {
 		expect(await findMostRecentSession(tempDir)).toBe(valid);
 	});
 
+	it("excludes newer hidden transcripts from finding and continuing the most recent session", async () => {
+		const visible = path.join(tempDir, "visible.jsonl");
+		const hidden = path.join(tempDir, ".hidden.jsonl");
+		fs.writeFileSync(
+			visible,
+			`${JSON.stringify({ type: "session", version: CURRENT_SESSION_VERSION, id: "visible", timestamp: "2025-01-01T00:00:00Z", cwd: tempDir })}\n`,
+		);
+		fs.writeFileSync(
+			hidden,
+			`${JSON.stringify({ type: "session", version: CURRENT_SESSION_VERSION, id: "hidden", timestamp: "2025-01-01T00:00:00Z", cwd: tempDir })}\n`,
+		);
+		fs.utimesSync(visible, new Date(10_000), new Date(10_000));
+		fs.utimesSync(hidden, new Date(20_000), new Date(20_000));
+
+		expect(await findMostRecentSession(tempDir)).toBe(visible);
+		const resumed = await SessionManager.continueRecent(tempDir, tempDir);
+		try {
+			expect(resumed.getSessionId()).toBe("visible");
+		} finally {
+			await resumed.close();
+		}
+	});
+
 	it("skips malformed and future headers when listing, finding, and continuing an explicit directory", async () => {
 		const valid = path.join(tempDir, "valid-v5.jsonl");
 		const malformed = path.join(tempDir, "malformed-version.jsonl");

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -164,6 +164,143 @@ describe("getRecentSessions", () => {
 		expect(sessions.map(session => session.name)).toContain("Recent Session 4");
 	});
 
+	it("orders native mtime candidates deterministically before reading them", async () => {
+		const storage = new MemorySessionStorage();
+		const sessionDir = "/sessions";
+		const paths = ["b.jsonl", "c.jsonl", "a.jsonl"].map(name => `${sessionDir}/${name}`);
+		for (const file of paths) {
+			storage.writeTextSync(
+				file,
+				`${JSON.stringify({
+					type: "session",
+					version: CURRENT_SESSION_VERSION,
+					id: path.basename(file, ".jsonl"),
+					timestamp: "2025-01-01T00:00:00Z",
+					cwd: "/tmp",
+					title: path.basename(file, ".jsonl"),
+				})}\n`,
+			);
+		}
+		storage.listFilesByMtime = () =>
+			Promise.resolve([
+				{ path: paths[0], mtimeMs: 20 },
+				{ path: paths[1], mtimeMs: 10 },
+				{ path: paths[2], mtimeMs: 20 },
+			]);
+
+		const sessions = await getRecentSessions(sessionDir, 3, storage);
+
+		expect(sessions.map(session => session.path)).toEqual([paths[2], paths[0], paths[1]]);
+	});
+
+	it("falls back to bounded JavaScript list/stat ordering when native mtime listing rejects", async () => {
+		const storage = new MemorySessionStorage();
+		const sessionDir = "/sessions";
+		const older = `${sessionDir}/older.jsonl`;
+		const newer = `${sessionDir}/newer.jsonl`;
+		for (const file of [older, newer]) {
+			storage.writeTextSync(
+				file,
+				`${JSON.stringify({
+					type: "session",
+					version: CURRENT_SESSION_VERSION,
+					id: path.basename(file, ".jsonl"),
+					timestamp: "2025-01-01T00:00:00Z",
+					cwd: "/tmp",
+					title: path.basename(file, ".jsonl"),
+				})}\n`,
+			);
+		}
+		let listCalls = 0;
+		let statCalls = 0;
+		const listFilesSync = storage.listFilesSync.bind(storage);
+		const statSync = storage.statSync.bind(storage);
+		storage.listFilesByMtime = () => Promise.reject(new Error("native unavailable"));
+		storage.listFilesSync = (dir, pattern) => {
+			if (pattern === "*.jsonl") listCalls += 1;
+			return listFilesSync(dir, pattern);
+		};
+		storage.statSync = file => {
+			statCalls += 1;
+			const stat = statSync(file);
+			return { ...stat, mtimeMs: file === newer ? 20 : 10 };
+		};
+
+		const sessions = await getRecentSessions(sessionDir, 1, storage);
+
+		expect(sessions.map(session => session.path)).toEqual([newer]);
+		expect(listCalls).toBe(1);
+		expect(statCalls).toBe(2);
+	});
+
+	it("opens only a bounded newest candidate set when the welcome trail has a small limit", async () => {
+		const storage = new MemorySessionStorage();
+		const sessionDir = "/sessions";
+		let prefixReads = 0;
+		const readTextPrefix = storage.readTextPrefix.bind(storage);
+		storage.readTextPrefix = async (file, maxBytes) => {
+			prefixReads += 1;
+			return readTextPrefix(file, maxBytes);
+		};
+		for (let index = 0; index < 500; index++) {
+			storage.writeTextSync(
+				`${sessionDir}/session-${index}.jsonl`,
+				`${JSON.stringify({
+					type: "session",
+					version: CURRENT_SESSION_VERSION,
+					id: `session-${index}`,
+					timestamp: "2025-01-01T00:00:00Z",
+					cwd: "/tmp",
+					title: `Session ${index}`,
+				})}\n`,
+			);
+		}
+
+		const sessions = await getRecentSessions(sessionDir, 5, storage);
+
+		expect(sessions).toHaveLength(5);
+		expect(prefixReads).toBe(32);
+	});
+
+	it("continues after an invalid first batch without reading past the boundary containing a valid session", async () => {
+		const storage = new MemorySessionStorage();
+		const sessionDir = "/sessions";
+		const candidates: Array<{ path: string; mtimeMs: number }> = [];
+		let prefixReads = 0;
+		const readTextPrefix = storage.readTextPrefix.bind(storage);
+		storage.readTextPrefix = async (file, maxBytes) => {
+			prefixReads += 1;
+			return readTextPrefix(file, maxBytes);
+		};
+		for (let index = 0; index < 33; index++) {
+			const file = `${sessionDir}/session-${index.toString().padStart(2, "0")}.jsonl`;
+			candidates.push({ path: file, mtimeMs: 100 - index });
+			storage.writeTextSync(
+				file,
+				index === 32
+					? `${JSON.stringify({
+							type: "session",
+							version: CURRENT_SESSION_VERSION,
+							id: "valid-boundary",
+							timestamp: "2025-01-01T00:00:00Z",
+							cwd: "/tmp",
+							title: "Valid boundary",
+						})}\n`
+					: `${JSON.stringify({
+							type: "session",
+							version: CURRENT_SESSION_VERSION + 1,
+							id: `future-${index}`,
+							timestamp: "2025-01-01T00:00:00Z",
+							cwd: "/tmp",
+						})}\n`,
+			);
+		}
+		storage.listFilesByMtime = () => Promise.resolve(candidates);
+
+		expect(await findMostRecentSession(sessionDir, storage)).toBe(candidates[32]?.path);
+		expect(prefixReads).toBe(33);
+	});
+
 	it("replays trailing header patches for transcripts larger than the listing prefix", async () => {
 		const file = path.join(tempDir, "patched-large.jsonl");
 		const header = {

--- a/packages/coding-agent/test/welcome-viewport.test.ts
+++ b/packages/coding-agent/test/welcome-viewport.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import { visibleWidth } from "@gajae-code/tui";
-import { WelcomeComponent } from "../src/modes/components/welcome";
+import { resolveWelcomeIntroTickMs, WelcomeComponent } from "../src/modes/components/welcome";
 import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
 
 const originalBuildChannel = process.env.GJC_BUILD_CHANNEL;
@@ -17,6 +17,14 @@ beforeAll(async () => {
 	const theme = await getThemeByName("red-claw");
 	if (!theme) throw new Error("Failed to load red-claw theme");
 	setThemeInstance(theme);
+});
+
+describe("welcome intro cadence", () => {
+	it("reduces frame pressure only for native Windows multiplexers", () => {
+		expect(resolveWelcomeIntroTickMs("win32", "psmux,1,0")).toBe(100);
+		expect(resolveWelcomeIntroTickMs("win32", "")).toBe(33);
+		expect(resolveWelcomeIntroTickMs("linux", "tmux,1,0")).toBe(33);
+	});
 });
 
 function stripRenderControls(line: string): string {


### PR DESCRIPTION
## Summary

- emit a TTY-only keyboard-ready bootstrap before expensive interactive initialization
- start the real TUI/input surface before display-only recent-session discovery
- rank session candidates by mtime and inspect bounded batches with a logged JS fallback
- reduce the welcome cadence to 10 fps only on Windows+TMUX/psmux while retaining the full three-second animation

Addresses #2906 and #2907.

## Why

On the reported Windows 11 dataset (2.9 GB / 3,569 transcripts), startup previously blocked 10–30+ seconds before any usable input surface. The corrective profile in #2906 measured a warm native bootstrap at ~0.52 s and full TUI at ~3.85 s with the animation and update checks still enabled. The psmux measurements in #2907 improved from ~6.35 s full TUI to ~3.84–4.29 s while preserving early keyboard input.

The scan now opens at most one 32-candidate batch for a small valid limit, continuing into older batches only when invalid/future candidates require it.

## Safety

Bootstrap output is suppressed for non-TTY, help/version, print/export/list-models, config, every explicit mode (text/JSON/ACP), and repeated mode forms. Recent-session completion is identity-guarded so a replaced welcome component is not updated. Native scan rejection falls back narrowly without weakening session parsing/version checks.

## Verification

- `bun test packages/coding-agent/test/cli-command-surface.test.ts -t "renders an immediate keyboard-ready bootstrap"` — 1 pass
- `bun test packages/coding-agent/test/welcome-viewport.test.ts` — 14 pass
- bounded session ordering/fallback/batch tests — 4 pass
- `bun --cwd=packages/coding-agent run check:types` — pass
- repository-pinned Biome on all changed TS files — pass
- `git diff --check upstream/dev...HEAD` — pass
- Architect re-review — CLEAR / APPROVE

The root Rust check could not run locally because this Windows workstation has no `cargo` executable; focused TypeScript checks and tests passed, and GitHub CI remains the authoritative full-platform gate.

## Invariants preserved

- update checks remain enabled
- welcome animation remains 3,000 ms
- direct Windows and Unix tmux retain 33 ms cadence
- session history and validation behavior are unchanged

Base: `b83113ca9728d3d1dab974e82f77992dcee6604b`
Head: `9e14a72c13f979bef4683801b396a29da07c1e16`

## Exact-head follow-up

- rebased onto current `dev` without conflicts
- corrected native hidden-file policy to match the JS fallback
- added a regression covering `findMostRecentSession` and `SessionManager.continueRecent` with a newer hidden transcript
- exact-head coding-agent Biome and TypeScript checks pass locally
- exact-head runtime and build gates are pending maintainer approval of the fork workflow; no CI result is claimed before that gate runs
