### PR TITLE
perf(resume): commit feedback before SDK and transcript work

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Fixed
 - Telegram `/session_recent` now retries one concurrently appended managed transcript and omits only candidates that remain unstable, preserving independently verified recent-session rows.
 - On Windows/psmux, `/resume` now commits immediate progress feedback and repaints only the live viewport instead of replaying the entire selected transcript, while preserving complete history and scroll navigation.
+- Ordinary interactive session switches no longer wait for successor SDK endpoint readiness; lifecycle and SDK-controlled transitions retain readiness acknowledgement, and background startup failures remain observable.
 - Repeated byte-identical stale SDK broker locks no longer cause startup to loop when a prior tombstone exists.
 - ConversationStore now tolerates only unsupported Windows parent-directory durability errors after preserving temporary-file fsync and atomic rename.
 - Ralplan no longer re-asks for execution approval when the user already explicitly named `ultragoal` or `team` in the current turn; that naming is the consent.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 - Telegram `/session_recent` now retries one concurrently appended managed transcript and omits only candidates that remain unstable, preserving independently verified recent-session rows.
+- On Windows/psmux, `/resume` now commits immediate progress feedback and repaints only the live viewport instead of replaying the entire selected transcript, while preserving complete history and scroll navigation.
 - Repeated byte-identical stale SDK broker locks no longer cause startup to loop when a prior tombstone exists.
 - ConversationStore now tolerates only unsupported Windows parent-directory durability errors after preserving temporary-file fsync and atomic rename.
 - Ralplan no longer re-asks for execution approval when the user already explicitly named `ultragoal` or `team` in the current turn; that naming is the consent.

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -2134,9 +2134,11 @@ export class SelectorController {
 		this.showSelector(done => {
 			const selector = new SessionSelectorComponent(
 				sessions,
-				async sessionPath => {
+				sessionPath => {
 					done();
-					await this.handleResumeSession(sessionPath);
+					void this.handleResumeSession(sessionPath).catch(() => {
+						// The resume boundary commits its error frame before rethrowing for direct callers.
+					});
 				},
 				() => {
 					done();
@@ -2224,20 +2226,35 @@ export class SelectorController {
 	async handleResumeSession(sessionPath: string): Promise<void> {
 		const previousSessionId = this.ctx.sessionManager.getSessionId();
 		this.#clearTransientSessionUi();
-		const migrationPolicy =
-			this.ctx.settings?.get("session.directoryMigration") === "disabled" ? "disabled" : "copy-retain";
-		let writableSessionPath = sessionPath;
-		if (this.ctx.sessionManager.isManagedDestination()) {
-			const inspection = await SessionManager.inspectSessionTailReadOnly(sessionPath);
-			if (inspection.kind === "error") throw new Error(`Could not inspect selected session: ${inspection.reason}`);
-			writableSessionPath = await this.ctx.sessionManager.prepareManagedCandidateForStrictAdoption(
-				sessionPath,
-				migrationPolicy,
-				inspection.identity,
-			);
+		this.ctx.showStatus("Resuming session…");
+		await this.ctx.ui.requestRenderAndWait(false, "session.resume");
+		let resumed: boolean;
+		try {
+			const migrationPolicy =
+				this.ctx.settings?.get("session.directoryMigration") === "disabled" ? "disabled" : "copy-retain";
+			let writableSessionPath = sessionPath;
+			if (this.ctx.sessionManager.isManagedDestination()) {
+				const inspection = await SessionManager.inspectSessionTailReadOnly(sessionPath);
+				if (inspection.kind === "error")
+					throw new Error(`Could not inspect selected session: ${inspection.reason}`);
+				writableSessionPath = await this.ctx.sessionManager.prepareManagedCandidateForStrictAdoption(
+					sessionPath,
+					migrationPolicy,
+					inspection.identity,
+				);
+			}
+			// Switch session via AgentSession (emits hook and tool session events)
+			resumed = await this.ctx.session.switchSession(writableSessionPath);
+		} catch (error) {
+			this.ctx.showError(`Resume failed: ${error instanceof Error ? error.message : String(error)}`);
+			await this.ctx.ui.requestRenderAndWait(false, "session.resume");
+			throw error;
 		}
-		// Switch session via AgentSession (emits hook and tool session events)
-		if (!(await this.ctx.session.switchSession(writableSessionPath))) return;
+		if (!resumed) {
+			this.ctx.showStatus("Resume cancelled");
+			await this.ctx.ui.requestRenderAndWait(false, "session.resume");
+			return;
+		}
 		const switchingToDifferentSession = previousSessionId !== this.ctx.sessionManager.getSessionId();
 		if (switchingToDifferentSession) this.ctx.resetIrcSidebarSession();
 		this.#refreshSessionTerminalTitle();

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -4481,6 +4481,12 @@ export function createNotificationsExtension(
 	): Promise<void> =>
 		startup
 			.then(async result => {
+				if (result.status === "failed" && !extensionShuttingDown && !result.suppressExtensionError) {
+					logger.error(
+						`notifications: deferred SDK startup failed for session ${id}: ${result.failure?.message ?? "Unknown startup failure."}`,
+					);
+					return;
+				}
 				if (
 					result.status !== "started" ||
 					extensionShuttingDown ||
@@ -4572,7 +4578,7 @@ export function createNotificationsExtension(
 			deferredIdentityRotation = { event, ctx, awaitStartup: true };
 			return;
 		}
-		await rotateSessionAuthority(event, ctx, true);
+		await rotateSessionAuthority(event, ctx, lifecycleStartupCapability !== undefined);
 	});
 	api.on("session_branch", async (event, ctx) => {
 		if (identityControlInFlight) {

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -85,6 +85,8 @@ describe("InteractiveMode.setEditorComponent", () => {
 		mode.rebuildChatFromMessages("replace-identity");
 		expect(reset).toHaveBeenCalledTimes(1);
 		expect(reconcile).not.toHaveBeenCalled();
+		reset.mockClear();
+		reconcile.mockClear();
 
 		mode.rebuildInitialMessages("reconcile-same-transcript", {
 			messages: [],
@@ -98,6 +100,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 			mode: "none",
 		});
 		expect(reconcile).toHaveBeenCalledTimes(1);
+		expect(reset).not.toHaveBeenCalled();
 	});
 
 	it("renders an idle extension custom message through the real rebuild boundary", async () => {

--- a/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
@@ -41,6 +41,7 @@ function createContext(currentSessionFile: string): {
 	prepareManagedCandidateForStrictAdoption: Mock<(targetPath: string) => Promise<string>>;
 	listForResumePickerReadOnly: Mock<() => Promise<SessionInfo[]>>;
 	switchSession: Mock<(targetPath: string) => Promise<boolean>>;
+	requestRenderAndWait: Mock<() => Promise<void>>;
 } {
 	const calls: string[] = [];
 	let managedDestination = false;
@@ -71,6 +72,9 @@ function createContext(currentSessionFile: string): {
 	});
 	const prepareManagedCandidateForStrictAdoption = vi.fn(async (targetPath: string) => targetPath);
 	const listForResumePickerReadOnly = vi.fn(async () => [] as SessionInfo[]);
+	const requestRenderAndWait = vi.fn(async () => {
+		calls.push("ui.requestRenderAndWait");
+	});
 	const ctx = {
 		editorContainer,
 		editor: {},
@@ -79,6 +83,7 @@ function createContext(currentSessionFile: string): {
 			requestRender: vi.fn(() => {
 				calls.push("ui.requestRender");
 			}),
+			requestRenderAndWait,
 			resetViewportAnchorIntent: vi.fn(() => {
 				calls.push("ui.resetViewportAnchorIntent");
 			}),
@@ -151,7 +156,9 @@ function createContext(currentSessionFile: string): {
 		showStatus: vi.fn((message: string) => {
 			calls.push(`showStatus:${message}`);
 		}),
-		showError: vi.fn(),
+		showError: vi.fn((message: string) => {
+			calls.push(`showError:${message}`);
+		}),
 		resetIrcSidebarSession: vi.fn(() => {
 			calls.push("resetIrcSidebarSession");
 		}),
@@ -177,6 +184,7 @@ function createContext(currentSessionFile: string): {
 		prepareManagedCandidateForStrictAdoption,
 		listForResumePickerReadOnly,
 		switchSession,
+		requestRenderAndWait,
 	};
 }
 
@@ -191,6 +199,66 @@ beforeAll(() => {
 describe("SelectorController session deletion", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
+	});
+
+	it("commits resume feedback before awaiting session inspection or switching", async () => {
+		const barrier = Promise.withResolvers<void>();
+		const { ctx, calls, requestRenderAndWait, switchSession } = createContext("/tmp/project/sessions/a.jsonl");
+		requestRenderAndWait.mockImplementation(async () => {
+			calls.push("ui.requestRenderAndWait");
+			await barrier.promise;
+		});
+		const controller = new SelectorController(ctx);
+
+		const resume = controller.handleResumeSession("/tmp/project/sessions/b.jsonl");
+		await Promise.resolve();
+
+		expect(calls.slice(-2)).toEqual(["showStatus:Resuming session…", "ui.requestRenderAndWait"]);
+		expect(switchSession).not.toHaveBeenCalled();
+
+		barrier.resolve();
+		await resume;
+		expect(switchSession).toHaveBeenCalledTimes(1);
+	});
+
+	it("replaces committed resume progress when session switching is cancelled", async () => {
+		const { ctx, calls, requestRenderAndWait, switchSession } = createContext("/tmp/project/sessions/a.jsonl");
+		switchSession.mockResolvedValue(false);
+		const controller = new SelectorController(ctx);
+
+		await controller.handleResumeSession("/tmp/project/sessions/b.jsonl");
+
+		expect(calls.slice(-4)).toEqual([
+			"showStatus:Resuming session…",
+			"ui.requestRenderAndWait",
+			"showStatus:Resume cancelled",
+			"ui.requestRenderAndWait",
+		]);
+		expect(switchSession).toHaveBeenCalledTimes(1);
+		expect(requestRenderAndWait).toHaveBeenCalledTimes(2);
+		expect(ctx.rebuildInitialMessages).not.toHaveBeenCalled();
+		expect(ctx.reloadTodos).not.toHaveBeenCalled();
+		expect(ctx.showStatus).not.toHaveBeenCalledWith("Resumed session");
+	});
+
+	it("replaces committed resume progress and rethrows when session switching rejects", async () => {
+		const failure = new Error("switch failed");
+		const { ctx, calls, requestRenderAndWait, switchSession } = createContext("/tmp/project/sessions/a.jsonl");
+		switchSession.mockRejectedValue(failure);
+		const controller = new SelectorController(ctx);
+
+		await expect(controller.handleResumeSession("/tmp/project/sessions/b.jsonl")).rejects.toBe(failure);
+
+		expect(calls.slice(-4)).toEqual([
+			"showStatus:Resuming session…",
+			"ui.requestRenderAndWait",
+			"showError:Resume failed: switch failed",
+			"ui.requestRenderAndWait",
+		]);
+		expect(requestRenderAndWait).toHaveBeenCalledTimes(2);
+		expect(ctx.rebuildInitialMessages).not.toHaveBeenCalled();
+		expect(ctx.reloadTodos).not.toHaveBeenCalled();
+		expect(ctx.showStatus).not.toHaveBeenCalledWith("Resumed session");
 	});
 
 	it("resets manual viewport intent before rendering a different session", async () => {

--- a/packages/coding-agent/test/notifications-session-switch.test.ts
+++ b/packages/coding-agent/test/notifications-session-switch.test.ts
@@ -4,12 +4,14 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Agent, ThinkingLevel } from "@gajae-code/agent-core";
 import { closeModelCache, getBundledModel } from "@gajae-code/ai";
+import { logger } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import type { ExtensionRunner } from "../src/extensibility/extensions/runner";
 import { getTelegramFileSink } from "../src/sdk/bus/attachment-registry";
 import { createNotificationsExtension } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
 import { SessionSdkHost } from "../src/sdk/host";
+import { attachLifecycleStartupCapability, SdkStartupCapability } from "../src/sdk/startup-capability";
 import { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
 import { SessionManager } from "../src/session/session-manager";
@@ -74,7 +76,10 @@ function createHarness(
 	prefix: string,
 	initialName: string | undefined = "Original",
 	onBranchStartupSettled?: (receipt: { sessionId: string; status: string }) => void,
+	lifecycleStartupCapability?: SdkStartupCapability,
 ) {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
 	const handlers = new Map<string, Handler>();
 	const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
 	const api = {
@@ -85,10 +90,11 @@ function createHarness(
 			commands.set(name, command),
 		sendUserMessage: () => {},
 	} as never;
-	createNotificationsExtension(api, { onBranchStartupSettled });
-
-	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-	tempDirs.push(cwd);
+	if (lifecycleStartupCapability) attachLifecycleStartupCapability(api, lifecycleStartupCapability);
+	createNotificationsExtension(api, {
+		onBranchStartupSettled,
+		settings: lifecycleStartupCapability ? ({ get: () => undefined, getAgentDir: () => cwd } as never) : undefined,
+	});
 
 	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	let sid = `${prefix}${suffix}`;
@@ -426,9 +432,9 @@ test("session_switch rotates SDK authority while preserving topic identity", asy
 		await handlers.get("session_switch")!({ type: "session_switch", reason: "new", previousSessionFile }, ctx);
 
 		const newEndpoint = path.join(notifDir, `${sid}.json`);
-		expect(fs.existsSync(newEndpoint)).toBe(true);
-		expect(getTelegramFileSink(sid)).toBeDefined();
-		expect(fs.existsSync(originalEndpoint)).toBe(false);
+		await waitFor(() => fs.existsSync(newEndpoint), 4000, "rotated endpoint");
+		await waitFor(() => getTelegramFileSink(sid) !== undefined, 4000, "rotated file sink");
+		await waitFor(() => !fs.existsSync(originalEndpoint), 4000, "previous endpoint removal");
 		const newFrames = await connectFrames(newEndpoint);
 
 		await handlers.get("agent_start")!({ type: "agent_start" }, ctx);
@@ -442,6 +448,159 @@ test("session_switch rotates SDK authority while preserving topic identity", asy
 		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
 		else process.env.GJC_NOTIFICATIONS = prevEnv;
 	}
+});
+
+test("ordinary session_switch releases predecessor authority without awaiting successor readiness", async () => {
+	await withNotifications(async () => {
+		const harness = createHarness("gjc-notif-switch-async-");
+		await startAndConnect(harness);
+		const previousId = harness.sid;
+		const previousEndpoint = harness.endpoint(previousId);
+		const entered = deferred();
+		const release = deferred();
+		const hostStart = SessionSdkHost.prototype.start;
+		const startSpy = vi.spyOn(SessionSdkHost.prototype, "start").mockImplementation(async function (
+			this: SessionSdkHost,
+		) {
+			entered.resolve();
+			await release.promise;
+			return await hostStart.call(this);
+		});
+		try {
+			harness.sid = `successor-${previousId}`;
+			let switchSettled = false;
+			const transition = Promise.resolve(
+				harness.handlers.get("session_switch")!(
+					{ type: "session_switch", previousSessionFile: harness.previousSessionFile(previousId) },
+					harness.ctx,
+				),
+			).then(() => {
+				switchSettled = true;
+			});
+
+			await entered.promise;
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(switchSettled).toBe(true);
+			expect(fs.existsSync(previousEndpoint)).toBe(false);
+			expect(fs.existsSync(harness.endpoint())).toBe(false);
+
+			release.resolve();
+			await transition;
+			await waitFor(() => fs.existsSync(harness.endpoint()), 4000, "asynchronous successor endpoint");
+			await harness.handlers.get("session_shutdown")!({ type: "session_shutdown" }, harness.ctx);
+		} finally {
+			release.resolve();
+			startSpy.mockRestore();
+		}
+	});
+});
+
+test("ordinary session_switch reports failed deferred successor startup without restoring predecessor authority", async () => {
+	await withNotifications(async () => {
+		const startupSettled = deferred<{ sessionId: string; status: string }>();
+		const harness = createHarness("gjc-notif-switch-failed-async-", "Original", receipt =>
+			startupSettled.resolve(receipt),
+		);
+		await startAndConnect(harness);
+		const previousId = harness.sid;
+		const previousEndpoint = harness.endpoint(previousId);
+		const entered = deferred();
+		const release = deferred();
+		let predecessorReleasedBeforeStart = false;
+		const startSpy = vi.spyOn(SessionSdkHost.prototype, "start").mockImplementation(async () => {
+			predecessorReleasedBeforeStart = !fs.existsSync(previousEndpoint);
+			entered.resolve();
+			await release.promise;
+			throw new Error("ordinary successor startup failed");
+		});
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		try {
+			harness.sid = `successor-${previousId}`;
+			let switchSettled = false;
+			const transition = Promise.resolve(
+				harness.handlers.get("session_switch")!(
+					{ type: "session_switch", previousSessionFile: harness.previousSessionFile(previousId) },
+					harness.ctx,
+				),
+			).then(() => {
+				switchSettled = true;
+			});
+
+			await entered.promise;
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(switchSettled).toBe(true);
+			expect(predecessorReleasedBeforeStart).toBe(true);
+			expect(fs.existsSync(previousEndpoint)).toBe(false);
+			expect(fs.existsSync(harness.endpoint())).toBe(false);
+
+			release.resolve();
+			await transition;
+			expect(await startupSettled.promise).toEqual({ sessionId: harness.sid, status: "failed" });
+			expect(errorSpy).toHaveBeenCalledWith(
+				`notifications: deferred SDK startup failed for session ${harness.sid}: ordinary successor startup failed`,
+			);
+			expect(fs.existsSync(previousEndpoint)).toBe(false);
+			expect(fs.existsSync(harness.endpoint())).toBe(false);
+
+			await harness.handlers.get("session_shutdown")!({ type: "session_shutdown" }, harness.ctx);
+			expect(fs.existsSync(previousEndpoint)).toBe(false);
+			expect(fs.existsSync(harness.endpoint())).toBe(false);
+			expect(getTelegramFileSink(harness.sid)).toBeUndefined();
+		} finally {
+			release.resolve();
+			errorSpy.mockRestore();
+			startSpy.mockRestore();
+		}
+	});
+});
+
+test("lifecycle session_switch retains successor readiness acknowledgement", async () => {
+	await withNotifications(async () => {
+		const capability = new SdkStartupCapability();
+		const harness = createHarness("gjc-notif-switch-lifecycle-", "Original", undefined, capability);
+		await startAndConnect(harness);
+		const previousId = harness.sid;
+		const previousEndpoint = harness.endpoint(previousId);
+		const entered = deferred();
+		const release = deferred();
+		const hostStart = SessionSdkHost.prototype.start;
+		const startSpy = vi.spyOn(SessionSdkHost.prototype, "start").mockImplementation(async function (
+			this: SessionSdkHost,
+		) {
+			entered.resolve();
+			await release.promise;
+			return await hostStart.call(this);
+		});
+		try {
+			harness.sid = `successor-${previousId}`;
+			let switchSettled = false;
+			const transition = Promise.resolve(
+				harness.handlers.get("session_switch")!(
+					{ type: "session_switch", previousSessionFile: harness.previousSessionFile(previousId) },
+					harness.ctx,
+				),
+			).then(() => {
+				switchSettled = true;
+			});
+
+			await entered.promise;
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(switchSettled).toBe(false);
+			expect(fs.existsSync(previousEndpoint)).toBe(false);
+			expect(fs.existsSync(harness.endpoint())).toBe(false);
+
+			release.resolve();
+			await transition;
+			expect(fs.existsSync(harness.endpoint())).toBe(true);
+			await harness.handlers.get("session_shutdown")!({ type: "session_shutdown" }, harness.ctx);
+		} finally {
+			release.resolve();
+			startSpy.mockRestore();
+		}
+	});
 });
 
 test("session_switch rotates authority without a previous session file", async () => {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -632,6 +632,7 @@ export class TUI extends Container {
 	onDebug?: () => void;
 	#renderRequested = false;
 	#renderTimer: NodeJS.Timeout | undefined;
+	#renderCommitWaiters: Array<() => void> = [];
 	#lastRenderAt = 0;
 	static readonly #MIN_RENDER_INTERVAL_MS = 16;
 	// Input-priority scheduling: an input keystroke must never be starved behind a
@@ -648,6 +649,7 @@ export class TUI extends Container {
 	#manualViewportAnchor: ManualViewportAnchor | null = null;
 	#manualViewportFallbackAnchors: ManualViewportAnchor[] = [];
 	#reconcileMissingViewportAnchor = false;
+	#transcriptIdentityReplaced = false;
 	#lastCursorPosition: { row: number; col: number } | null = null;
 	#sixelProbePendingDa = false;
 	#sixelProbePendingGraphics = false;
@@ -808,6 +810,7 @@ export class TUI extends Container {
 		this.#manualViewportAnchor = null;
 		this.#manualViewportFallbackAnchors = [];
 		this.#reconcileMissingViewportAnchor = false;
+		this.#transcriptIdentityReplaced = true;
 		this.#viewportAnchorFrame = null;
 	}
 
@@ -1100,6 +1103,13 @@ export class TUI extends Container {
 			if (renderMetrics.enabled) renderMetrics.setTimerGauge("tui.renderTimer", 0);
 		}
 		this.#clearSixelProbeState();
+		this.#resolveRenderCommitWaiters();
+	}
+
+	#resolveRenderCommitWaiters(): void {
+		const waiters = this.#renderCommitWaiters;
+		this.#renderCommitWaiters = [];
+		for (const resolve of waiters) resolve();
 	}
 
 	#writeTerminal(data: string): boolean {
@@ -1297,6 +1307,7 @@ export class TUI extends Container {
 			this.#renderTimer = undefined;
 			if (renderMetrics.enabled) renderMetrics.setTimerGauge("tui.renderTimer", 0);
 		}
+		this.#resolveRenderCommitWaiters();
 		// Move cursor to the end of the content to prevent overwriting/artifacts on exit
 		if (this.#previousLines.length > 0) {
 			const targetRow = this.#previousLines.length; // Line after the last content
@@ -1362,6 +1373,21 @@ export class TUI extends Container {
 		this.requestRender(dimensionsChanged && !useViewportRepaintPath(this.terminal), "resize");
 	}
 
+	/**
+	 * Request a render and resolve after that frame has emitted through the terminal
+	 * adapter. Stopped or unavailable terminals resolve immediately.
+	 */
+	requestRenderAndWait(force = false, source = "unknown"): Promise<void> {
+		if (this.#stopped || !this.terminalAvailable) {
+			if (!this.terminalAvailable) this.#markTerminalUnavailable();
+			return Promise.resolve();
+		}
+		const { promise, resolve } = Promise.withResolvers<void>();
+		this.#renderCommitWaiters.push(resolve);
+		this.requestRender(force, source);
+		return promise;
+	}
+
 	requestRender(force = false, source = "unknown"): void {
 		if (!this.terminalAvailable) {
 			this.#markTerminalUnavailable();
@@ -1401,7 +1427,7 @@ export class TUI extends Container {
 				this.#renderRequested = false;
 				this.#lastRenderAt = performance.now();
 				const t0 = renderMetrics.now();
-				this.#doRender();
+				this.#commitRender();
 				if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
 			});
 			return;
@@ -1424,6 +1450,16 @@ export class TUI extends Container {
 		process.nextTick(() => this.#scheduleRender());
 	}
 
+	#commitRender(): void {
+		const waiters = this.#renderCommitWaiters;
+		this.#renderCommitWaiters = [];
+		try {
+			this.#doRender();
+		} finally {
+			for (const resolve of waiters) resolve();
+		}
+	}
+
 	#scheduleRender(): void {
 		if (this.#stopped || this.#renderTimer || !this.#renderRequested) {
 			return;
@@ -1439,7 +1475,7 @@ export class TUI extends Container {
 			this.#renderRequested = false;
 			this.#lastRenderAt = performance.now();
 			const t0 = renderMetrics.now();
-			this.#doRender();
+			this.#commitRender();
 			if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
 			if (this.#renderRequested) {
 				this.#scheduleRender();
@@ -1465,7 +1501,7 @@ export class TUI extends Container {
 		this.#renderRequested = false;
 		this.#lastRenderAt = performance.now();
 		const t0 = renderMetrics.now();
-		this.#doRender();
+		this.#commitRender();
 		if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
 	}
 
@@ -2413,6 +2449,13 @@ export class TUI extends Container {
 			const msg = `[${new Date().toISOString()}] fullRender: ${reason} (prev=${this.#previousLines.length}, new=${newLines.length}, height=${height})\n`;
 			this.#appendDebugRedrawLog(msg);
 		};
+		if (this.#transcriptIdentityReplaced) {
+			this.#transcriptIdentityReplaced = false;
+			if (useViewportRepaintPath(this.terminal) && this.#previousLines.length > 0) {
+				viewportRepaint("transcript identity replaced");
+				return;
+			}
+		}
 
 		// First render - just output everything without clearing (assumes clean screen)
 		if (this.#previousLines.length === 0 && !widthChanged && !heightChanged) {

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -105,6 +105,41 @@ function visible(term: VirtualTerminal): string[] {
 	return term.getViewport().map(line => line.trimEnd());
 }
 
+describe("TUI render commit barrier", () => {
+	it("resolves only after the requested frame reaches the terminal adapter", async () => {
+		const term = new VirtualTerminal(30, 5);
+		const tui = new TUI(term);
+		tui.addChild(new Lines(["committed-frame"]));
+		try {
+			tui.start();
+			term.clearWriteLog();
+			const commit = tui.requestRenderAndWait(false, "test.commit");
+			let emittedAtResolution = false;
+			void commit.then(() => {
+				emittedAtResolution = term.getWriteLog().join("").includes("committed-frame");
+			});
+
+			expect(emittedAtResolution).toBe(false);
+			await commit;
+			expect(emittedAtResolution).toBe(true);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("resolves without scheduling output after the TUI stops or the terminal is unavailable", async () => {
+		const stoppedTerm = new VirtualTerminal(30, 5);
+		const stoppedTui = new TUI(stoppedTerm);
+		stoppedTui.stop();
+		await stoppedTui.requestRenderAndWait(false, "test.stopped");
+
+		const unavailableTerm = new VirtualTerminal(30, 5);
+		Object.defineProperty(unavailableTerm, "available", { configurable: true, get: () => false });
+		const unavailableTui = new TUI(unavailableTerm);
+		await unavailableTui.requestRenderAndWait(false, "test.unavailable");
+	});
+});
+
 describe("TUI manual viewport paging", () => {
 	it("pages through the rendered transcript without editing content", async () => {
 		const term = new VirtualTerminal(30, 5);
@@ -841,7 +876,7 @@ describe("registered viewport anchor", () => {
 		}
 	});
 	it("resets stale manual intent when the transcript identity changes", async () => {
-		const term = new VirtualTerminal(30, 6);
+		const term = new VirtualTerminal(30, 6, { isProcessTerminal: true });
 		const tui = new TUI(term);
 		const transcriptA = new AnchoredTranscript();
 		for (let index = 0; index < 20; index++) transcriptA.addRow(`session-a-${index}`, `session-a-${index}`);
@@ -853,6 +888,7 @@ describe("registered viewport anchor", () => {
 			expect(tui.scrollViewportPages(-1)).toBe(true);
 			await term.flush();
 			expect(visible(term).some(line => line.includes("session-a-"))).toBe(true);
+			term.clearWriteLog();
 
 			const transcriptB = new AnchoredTranscript();
 			for (let index = 0; index < 8; index++) transcriptB.addRow(`session-b-${index}`, `session-b-${index}`);
@@ -862,6 +898,9 @@ describe("registered viewport anchor", () => {
 			tui.setViewportAnchorComponent(transcriptB);
 			tui.requestRender();
 			await settle(term);
+			const identityRender = term.getWriteLog().join("");
+			expect(identityRender).not.toContain("session-b-0");
+			expect(identityRender).toContain("session-b-7");
 			expect(visible(term).some(line => line.includes("session-b-"))).toBe(true);
 			expect(visible(term).some(line => line.includes("session-a-"))).toBe(false);
 		} finally {


### PR DESCRIPTION
## Summary

Two independently revertible commits:

1. add an awaitable terminal render barrier, commit `Resuming session…` before resume work, and repaint only the live viewport on transcript identity replacement
2. keep ordinary interactive SDK successor startup off the resume critical path while preserving lifecycle readiness and observable background failures

Addresses #2914.

## Measured behavior

On Windows 11 with a ~3 MB / 900-entry transcript:

| Surface | Before | After local corrective patch |
|---|---:|---:|
| `/resume` selector | — | ~92 ms |
| committed progress feedback | none | ~15 ms |
| full restoration | ~3.5 s | ~1.66 s |

The full transcript remains in memory/on disk and internal scroll navigation is preserved; the terminal no longer needs a full-history replay for an identity replacement.

## Correctness

- `requestRenderAndWait()` resolves only after the terminal adapter write commits, and drains safely on stop/unavailable terminal
- cancelled and rejected resumes replace the committed progress frame accurately
- session-ID changes select replace-identity; same-ID restoration reconciles the transcript
- ordinary UI switches retire predecessor authority before tracking successor startup in the background
- lifecycle-capable switches still await successor readiness
- asynchronous ordinary startup failure is explicitly logged instead of swallowed

## Verification

- selector controller suite — 13 pass / 45 assertions
- TUI viewport suite — 27 pass / 277 assertions
- notification session-switch suite — 19 pass / 72 assertions
- coding-agent and TUI type checks — pass
- repository-pinned Biome on changed TS files — pass
- `git diff --check upstream/dev...HEAD` — pass
- two Architect review passes; final blocking findings resolved

The broad interactive editor suite has a pre-existing Windows `EBUSY` temp-directory cleanup failure on this workstation; the changed policy assertion is covered in the focused source review and GitHub CI is the authoritative full-suite gate. The root Rust check could not run locally because `cargo` is not installed.

## Commit boundary

- `4be2d109` — UI/render/viewport and UI changelog
- `7b54c9f2` — SDK readiness/diagnostics and SDK changelog

Base: `b83113ca9728d3d1dab974e82f77992dcee6604b`
Head: `7b54c9f2118c950cc5b0de7266a3ab91ac811fbf`

## Exact-head follow-up

- both commits rebased onto current `dev` without conflicts
- range review confirms the render barrier, viewport repaint policy, lifecycle-ready path, deferred ordinary SDK startup, and failure diagnostics remain present
- exact-head coding-agent and TUI Biome and TypeScript checks pass locally
- exact-head runtime and build gates are pending maintainer approval of the fork workflow; no CI result is claimed before that gate runs


## Exact-head follow-up

- both commits rebased onto current `dev` without conflicts
- range review confirms the render barrier, viewport repaint policy, lifecycle-ready path, deferred ordinary SDK startup, and failure diagnostics remain present
- exact-head coding-agent and TUI Biome and TypeScript checks pass locally
- exact-head runtime and build gates are pending maintainer approval of the fork workflow; no CI result is claimed before that gate runs
