### PR TITLE
fix(coordinator): settle broker turns and reap lifecycle sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Ordinary `ask` calls now normalize a provider-emitted `deepInterview: null` placeholder instead of misclassifying it as malformed Round-0 intent recovery data and rejecting it before coercion.
 - Coordinator turn reads now adopt only schema-valid, canonical in-session agent runtime terminal state attributable by matching turn ID or a terminal timestamp at/after turn start, settling durable turns and unblocking existing idle reaping.
+- Coordinator-created lifecycle sessions now persist ephemeral ownership in canonical creation state, allowing terminal settlement, explicit stop, and idle reaping to close only their incarnation-bound broker host while registered sessions remain protected.
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.
 - Restored `/models` preset landing navigation after the Image Generation row and made compaction/pruning regression fixtures use an explicit 200K context boundary instead of a mutable provider descriptor default.
 - Fixed Windows legacy session artifact migration by using native directory identity size, a traversable detached-path alias, and writable file handles for final durability sync.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Ralplan no longer re-asks for execution approval when the user already explicitly named `ultragoal` or `team` in the current turn; that naming is the consent.
 
 - Ordinary `ask` calls now normalize a provider-emitted `deepInterview: null` placeholder instead of misclassifying it as malformed Round-0 intent recovery data and rejecting it before coercion.
+- Coordinator turn reads now adopt only schema-valid, canonical in-session agent runtime terminal state attributable by matching turn ID or a terminal timestamp at/after turn start, settling durable turns and unblocking existing idle reaping.
 - Documented that custom OpenAI-compatible models omit vision by default: when `input` is unset, GJC treats the model as text-only and strips images with `[image omitted: model does not support vision]`. Vision backends must set `input: [text, image]` in `models.yml`.
 - Restored `/models` preset landing navigation after the Image Generation row and made compaction/pruning regression fixtures use an explicit 200K context boundary instead of a mutable provider descriptor default.
 - Fixed Windows legacy session artifact migration by using native directory identity size, a traversable detached-path alias, and writable file handles for final durability sync.

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -4158,6 +4158,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 							session = normalizeSession({
 								session_id: sessionId,
 								cwd: sessionCwd,
+								ephemeral: true,
 								...(mpresetResolution.mpreset ? { mpreset: mpresetResolution.mpreset } : {}),
 								broker_workspace: binding.workspace,
 								endpoint_generation: binding.endpointGeneration,

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -12,6 +12,7 @@ import {
 	type CoordinatorToolName,
 } from "../coordinator/contract";
 import { readLinuxProcStartTimeSync } from "../gjc-runtime/linux-proc";
+import { sessionRuntimeDir } from "../gjc-runtime/session-layout";
 import type { WorkflowGate, WorkflowGateQueryRecord } from "../modes/shared/agent-wire/workflow-gate-types";
 import type { BrokerDiscovery } from "../sdk/broker/discovery";
 import { type EnsureBrokerSettings, ensureBroker } from "../sdk/broker/ensure";
@@ -145,6 +146,7 @@ function reportableFinalResponse(response: CoordinatorFinalResponse): boolean {
 }
 
 interface RuntimeSessionStatePayload extends CoordinatorSessionState {
+	ended_at: string;
 	final_response?: CoordinatorFinalResponse;
 	error?: { code: string; message: string; recoverable: boolean } | null;
 }
@@ -1331,6 +1333,73 @@ async function clearActiveTurn(namespaceDir: string, turn: TurnRecord): Promise<
 
 async function readSessionState(namespaceDir: string, sessionId: string): Promise<CoordinatorSessionState | null> {
 	return (await readJsonFile(sessionStateFile(namespaceDir, sessionId))) as CoordinatorSessionState | null;
+}
+
+function validCoordinatorFinalResponse(value: unknown): value is CoordinatorFinalResponse {
+	const response = asRecord(value);
+	return (
+		response !== null &&
+		(response.text === null || typeof response.text === "string") &&
+		response.format === "markdown" &&
+		(response.source === null || typeof response.source === "string") &&
+		(response.artifact_path === null || typeof response.artifact_path === "string") &&
+		typeof response.truncated === "boolean"
+	);
+}
+
+function validRuntimeError(value: unknown): value is { code: string; message: string; recoverable: boolean } {
+	const error = asRecord(value);
+	return (
+		error !== null &&
+		typeof error.code === "string" &&
+		typeof error.message === "string" &&
+		typeof error.recoverable === "boolean"
+	);
+}
+
+function validatedTerminalRuntimeState(value: unknown): RuntimeSessionStatePayload | null {
+	const state = asRecord(value);
+	if (
+		state?.schema_version !== 1 ||
+		typeof state.session_id !== "string" ||
+		(state.state !== "completed" && state.state !== "errored") ||
+		typeof state.ready_for_input !== "boolean" ||
+		(state.current_turn_id !== null && typeof state.current_turn_id !== "string") ||
+		(state.last_turn_id !== null && typeof state.last_turn_id !== "string") ||
+		typeof state.updated_at !== "string" ||
+		typeof state.ended_at !== "string" ||
+		state.source !== "agent_session_event" ||
+		(state.live !== null && typeof state.live !== "boolean") ||
+		(state.reason !== null && typeof state.reason !== "string") ||
+		(state.final_response !== undefined && !validCoordinatorFinalResponse(state.final_response)) ||
+		(state.error !== undefined && state.error !== null && !validRuntimeError(state.error))
+	)
+		return null;
+	return state as unknown as RuntimeSessionStatePayload;
+}
+
+async function readAttributableTerminalRuntimeState(
+	cwd: string,
+	turn: TurnRecord,
+): Promise<RuntimeSessionStatePayload | null> {
+	const runtimeDir = sessionRuntimeDir(cwd, turn.session_id);
+	const stateFile = path.join(runtimeDir, "runtime-state.json");
+	let canonicalRuntimeDir: string;
+	let canonicalStateFile: string;
+	try {
+		[canonicalRuntimeDir, canonicalStateFile] = await Promise.all([fs.realpath(runtimeDir), fs.realpath(stateFile)]);
+	} catch {
+		return null;
+	}
+	const relative = path.relative(canonicalRuntimeDir, canonicalStateFile);
+	if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) return null;
+	const runtimeState = validatedTerminalRuntimeState(await readJsonFile(canonicalStateFile));
+	if (!runtimeState || runtimeState.session_id !== turn.session_id) return null;
+	if (runtimeState.current_turn_id !== null)
+		return runtimeState.current_turn_id === turn.turn_id ? runtimeState : null;
+	const endedAt = Date.parse(runtimeState.ended_at);
+	const startedAt = turn.started_at === null ? Number.NaN : Date.parse(turn.started_at);
+	return Number.isFinite(endedAt) && Number.isFinite(startedAt) && endedAt >= startedAt ? runtimeState : null;
 }
 
 async function writeSessionStateUnlocked(
@@ -3051,6 +3120,16 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		);
 		if (resolvedTurn !== turn) sessionState = await readSessionState(namespaceDir, resolvedTurn.session_id);
 		if (
+			session &&
+			ACTIVE_TURN_STATUSES.has(resolvedTurn.status) &&
+			sessionState?.state !== "completed" &&
+			sessionState?.state !== "errored"
+		) {
+			const cwd = optionalString(session.cwd);
+			const runtimeState = cwd ? await readAttributableTerminalRuntimeState(cwd, resolvedTurn) : null;
+			if (runtimeState) sessionState = runtimeState;
+		}
+		if (
 			sessionState?.state === "needs_user_input" &&
 			sessionState.current_turn_id === resolvedTurn.turn_id &&
 			ACTIVE_TURN_STATUSES.has(resolvedTurn.status) &&
@@ -3061,13 +3140,19 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			await writeTurnRecord(namespaceDir, resolvedTurn);
 			await writeActiveTurn(namespaceDir, resolvedTurn);
 		}
+		const terminalStateTimestamp = sessionState
+			? Date.parse((sessionState as RuntimeSessionStatePayload).ended_at ?? sessionState.updated_at)
+			: Number.NaN;
+		const turnStartedAt = resolvedTurn.started_at === null ? Number.NaN : Date.parse(resolvedTurn.started_at);
 		if (
 			sessionState &&
 			ACTIVE_TURN_STATUSES.has(resolvedTurn.status) &&
+			sessionState.source === "agent_session_event" &&
 			(sessionState.current_turn_id === resolvedTurn.turn_id ||
-				(sessionState.state === "errored" &&
-					sessionState.source === "agent_session_event" &&
-					sessionState.current_turn_id == null)) &&
+				(sessionState.current_turn_id == null &&
+					Number.isFinite(terminalStateTimestamp) &&
+					Number.isFinite(turnStartedAt) &&
+					terminalStateTimestamp >= turnStartedAt)) &&
 			(sessionState.state === "completed" || sessionState.state === "errored")
 		) {
 			resolvedTurn = await markTurnTerminalFromSessionState(resolvedTurn, sessionState);

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createCoordinatorMcpServer } from "../src/coordinator-mcp/server";
+import { sessionRuntimeDir } from "../src/gjc-runtime/session-layout";
 import { schemaHash } from "../src/modes/shared/agent-wire/workflow-gate-schema";
 import {
 	buildAskGateAnswerSchema,
@@ -737,6 +738,171 @@ describe("Coordinator MCP canonical SDK controls", () => {
 			advisory_status: { authority: "sdk", live: true, is_streaming: true },
 		});
 		expect(queries).toEqual(["Q12", "context.get"]);
+	});
+	it("adopts only attributable canonical agent terminal runtime state and clears the active-turn reaper blocker", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const server = await createSdkControlServer(root, controls);
+		await registerSdkSession(server, root);
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "finish durably",
+			idempotency_key: "terminal-runtime-state",
+			allow_mutation: true,
+		});
+		const turnId = sent.turn_id as string;
+		const turnFile = path.join(root, ".gjc", "coordinator-state", "local", "repo", "turns", `${turnId}.json`);
+		const turn = JSON.parse(await fs.readFile(turnFile, "utf8")) as { started_at: string };
+		const runtimeDir = sessionRuntimeDir(root, "visible-session");
+		await fs.mkdir(runtimeDir, { recursive: true });
+		await Bun.write(
+			path.join(runtimeDir, "runtime-state.json"),
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "visible-session",
+				state: "completed",
+				ready_for_input: true,
+				current_turn_id: null,
+				last_turn_id: null,
+				updated_at: new Date().toISOString(),
+				ended_at: new Date().toISOString(),
+				source: "agent_session_event",
+				live: false,
+				reason: null,
+				final_response: {
+					text: "authoritative final",
+					format: "markdown",
+					source: "agent_end",
+					artifact_path: null,
+					truncated: false,
+				},
+			}),
+		);
+
+		await expect(
+			server.callTool("gjc_coordinator_await_turn", { turn_id: turnId, timeout_ms: 50 }),
+		).resolves.toMatchObject({
+			ok: true,
+			turn: { status: "completed", final_response: { text: "authoritative final" } },
+		});
+		const sessionFile = path.join(
+			root,
+			".gjc",
+			"coordinator-state",
+			"local",
+			"repo",
+			"sessions",
+			"visible-session.json",
+		);
+		const session = JSON.parse(await fs.readFile(sessionFile, "utf8"));
+		await Bun.write(sessionFile, JSON.stringify({ ...session, ephemeral: true }));
+		await expect(
+			server.callTool("gjc_coordinator_stop_session", { session_id: "visible-session", allow_mutation: true }),
+		).resolves.toMatchObject({ ok: true, closed: true });
+		expect(controls.some(control => control.operation === "session.close")).toBe(true);
+		expect(Date.parse(turn.started_at)).toBeFinite();
+	});
+
+	it("adopts attributable runtime failure with a safe error projection", async () => {
+		const root = await tempRoot();
+		const server = await createSdkControlServer(root, []);
+		await registerSdkSession(server, root);
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "fail durably",
+			idempotency_key: "terminal-runtime-failure",
+			allow_mutation: true,
+		});
+		const runtimeDir = sessionRuntimeDir(root, "visible-session");
+		await fs.mkdir(runtimeDir, { recursive: true });
+		await Bun.write(
+			path.join(runtimeDir, "runtime-state.json"),
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "visible-session",
+				state: "errored",
+				ready_for_input: false,
+				current_turn_id: sent.turn_id,
+				last_turn_id: null,
+				updated_at: new Date().toISOString(),
+				ended_at: new Date().toISOString(),
+				source: "agent_session_event",
+				live: false,
+				reason: "agent_error",
+				error: { code: "agent_error", message: "safe runtime failure", recoverable: true },
+			}),
+		);
+		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id })).resolves.toMatchObject({
+			ok: true,
+			turn: { status: "failed", error: { code: "agent_error", message: "safe runtime failure" } },
+		});
+	});
+
+	it("ignores stale, mismatched, malformed, wrong-session/source, and out-of-root runtime states", async () => {
+		for (const invalid of [
+			"stale",
+			"mismatched",
+			"malformed",
+			"wrong-session",
+			"wrong-source",
+			"out-of-root",
+		] as const) {
+			const root = await tempRoot();
+			const server = await createSdkControlServer(root, []);
+			await registerSdkSession(server, root);
+			const sent = await server.callTool("gjc_coordinator_send_prompt", {
+				session_id: "visible-session",
+				prompt: invalid,
+				idempotency_key: `invalid-runtime-${invalid}`,
+				allow_mutation: true,
+			});
+			const turnFile = path.join(
+				root,
+				".gjc",
+				"coordinator-state",
+				"local",
+				"repo",
+				"turns",
+				`${sent.turn_id}.json`,
+			);
+			const turn = JSON.parse(await fs.readFile(turnFile, "utf8")) as { started_at: string };
+			const runtimeDir = sessionRuntimeDir(root, "visible-session");
+			await fs.mkdir(runtimeDir, { recursive: true });
+			const runtimeFile = path.join(runtimeDir, "runtime-state.json");
+			const payload: Record<string, unknown> = {
+				schema_version: 1,
+				session_id: invalid === "wrong-session" ? "another-session" : "visible-session",
+				state: "completed",
+				ready_for_input: true,
+				current_turn_id: invalid === "stale" ? null : invalid === "mismatched" ? "turn-other" : sent.turn_id,
+				last_turn_id: null,
+				updated_at: new Date().toISOString(),
+				ended_at:
+					invalid === "stale" ? new Date(Date.parse(turn.started_at) - 1).toISOString() : new Date().toISOString(),
+				source: invalid === "wrong-source" ? "coordinator" : "agent_session_event",
+				live: false,
+				reason: null,
+				final_response: {
+					text: "must not settle",
+					format: "markdown",
+					source: "agent_end",
+					artifact_path: null,
+					truncated: false,
+				},
+			};
+			if (invalid === "malformed") payload.schema_version = "one";
+			if (invalid === "out-of-root") {
+				const outside = path.join(root, "outside-runtime-state.json");
+				await Bun.write(outside, JSON.stringify(payload));
+				await fs.symlink(outside, runtimeFile);
+			} else {
+				await Bun.write(runtimeFile, JSON.stringify(payload));
+			}
+			await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id })).resolves.toMatchObject({
+				ok: true,
+				turn: { status: "active" },
+			});
+		}
 	});
 	it("uses the generation-bound broker endpoint when a stale local endpoint file is absent", async () => {
 		const root = await tempRoot();

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -802,6 +802,65 @@ describe("Coordinator MCP canonical SDK controls", () => {
 		expect(controls.some(control => control.operation === "session.close")).toBe(true);
 		expect(Date.parse(turn.started_at)).toBeFinite();
 	});
+	it("preserves ephemeral ownership while settling and closing a lifecycle-created terminal session", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const brokerSessions: Array<Record<string, unknown>> = [];
+		const server = await createSdkControlServer(root, controls, undefined, undefined, brokerSessions);
+		const started = await server.callTool("gjc_coordinator_start_session", {
+			cwd: root,
+			prompt: "finish and close",
+			idempotency_key: "terminal-lifecycle-session",
+			allow_mutation: true,
+		});
+		const sessionId = started.session_id as string;
+		const turnId = started.turn_id as string;
+		const runtimeDir = sessionRuntimeDir(root, sessionId);
+		await fs.mkdir(runtimeDir, { recursive: true });
+		await Bun.write(
+			path.join(runtimeDir, "runtime-state.json"),
+			JSON.stringify({
+				schema_version: 1,
+				session_id: sessionId,
+				state: "completed",
+				ready_for_input: true,
+				current_turn_id: null,
+				last_turn_id: null,
+				updated_at: new Date().toISOString(),
+				ended_at: new Date().toISOString(),
+				source: "agent_session_event",
+				live: false,
+				reason: null,
+				final_response: {
+					text: "done",
+					format: "markdown",
+					source: "agent_end",
+					artifact_path: null,
+					truncated: false,
+				},
+			}),
+		);
+
+		await expect(
+			server.callTool("gjc_coordinator_await_turn", { turn_id: turnId, timeout_ms: 50 }),
+		).resolves.toMatchObject({
+			ok: true,
+			turn: { status: "completed" },
+		});
+		await expect(
+			server.callTool("gjc_coordinator_stop_session", { session_id: sessionId, allow_mutation: true }),
+		).resolves.toMatchObject({ ok: true, closed: true });
+		expect(brokerSessions).toEqual([]);
+		expect(controls.filter(control => control.operation === "session.close")).toEqual([
+			expect.objectContaining({
+				input: expect.objectContaining({
+					sessionId,
+					endpointGeneration: 1,
+					endpointIncarnation: expect.stringMatching(/^[a-f0-9]{64}$/),
+				}),
+			}),
+		]);
+	});
 
 	it("adopts attributable runtime failure with a safe error projection", async () => {
 		const root = await tempRoot();
@@ -1933,6 +1992,35 @@ describe("Coordinator MCP canonical SDK controls", () => {
 		]);
 		expect(await Bun.file(idleFile).exists()).toBe(false);
 		expect(await Bun.file(path.join(sessionsDir, "registered-session.json")).exists()).toBe(true);
+	});
+	it("idle reaps a lifecycle-created session without broad process cleanup", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const brokerSessions: Array<Record<string, unknown>> = [];
+		const server = await createSdkControlServer(root, controls, undefined, undefined, brokerSessions);
+		const started = await server.callTool("gjc_coordinator_start_session", {
+			cwd: root,
+			idempotency_key: "idle-lifecycle-session",
+			allow_mutation: true,
+		});
+		const sessionId = (started.lifecycle as { session_id: string }).session_id;
+		const namespaceDir = path.join(root, ".gjc", "coordinator-state", "local", "repo");
+		const sessionFile = path.join(namespaceDir, "sessions", `${sessionId}.json`);
+		const session = JSON.parse(await fs.readFile(sessionFile, "utf8"));
+		await Bun.write(
+			sessionFile,
+			JSON.stringify({ ...session, created_at: new Date(Date.now() - 31 * 60_000).toISOString() }),
+		);
+		await fs.rm(path.join(namespaceDir, "session-states", `${sessionId}.json`));
+
+		expect(await server.sessionReaper.sweepOnce()).toBe(1);
+		expect(brokerSessions).toEqual([]);
+		expect(controls.filter(control => control.operation === "session.close")).toEqual([
+			expect.objectContaining({
+				input: expect.objectContaining({ sessionId, endpointIncarnation: session.endpoint_incarnation }),
+				idempotencyKey: `coordinator-reap:${sessionId}:${session.endpoint_incarnation}`,
+			}),
+		]);
 	});
 	describe("Coordinator MCP real broker lifecycle", () => {
 		for (const discoveryState of [


### PR DESCRIPTION
## Problem

Closes #2549.

Broker-spawned sessions can finish and write final runtime state while Coordinator keeps the durable turn active. This makes `await_turn` time out, leaves the active-turn reaper blocker in place, and can retain session hosts.

A second lifecycle defect compounds the problem: Coordinator-created sessions do not preserve ephemeral ownership in canonical creation state, so canonical stop and idle reaping reject them as `not_ephemeral`.

## Cause

Coordinator only trusted its stale durable projection even when the canonical per-session runtime state had an attributable terminal `agent_session_event`. Lifecycle creation also omitted the ephemeral ownership bit before persisting canonical session state.

## Fix

- Adopt canonical runtime terminal state at the existing terminal projection boundary only when path, schema, session, source, state, turn/timestamp, and root-containment checks pass.
- Feed validated completion or failure through the existing terminal writer and clear active-turn authority.
- Preserve `ephemeral: true` for Coordinator-created lifecycle sessions.
- Keep stop and idle reaping on exact incarnation-bound broker `session.close` authority.
- Preserve non-ephemeral, active-turn, workspace, endpoint-generation, and mismatched-incarnation protections.

This is intentionally a small alternative to the broader, currently blocked #2874 approach. It does not add a second replay/receipt/settlement architecture.

## Verification

- Current `dev` (`38571d19`) accepted both commits through a clean three-way cherry-pick.
- Focused Coordinator lifecycle suites on current `dev`: 64 passed, 0 failed.
- Exact-lockfile TypeScript check on current `dev`: passed.
- Scoped Biome and `git diff --check`: passed.
- Original repair suites: 55 server, 7 stop-session, and 50 session-state-sidecar tests passed.
- `gjc --smoke-test`: passed.
- Live disposable acceptance proved:
  - `await_turn` returns completed with exact final response;
  - `current_turn_id` clears;
  - ownership remains `ephemeral: true`;
  - canonical stop returns `closed: true`;
  - follow-up status is `not_found`;
  - exact host exits.

## Caveat

The full repository `bun run check` did not finish within the local 30-minute command ceiling. A broader unrelated SDK-host fixture showed order-sensitive/native-artifact behavior, while all affected focused suites pass.
