### PR TITLE
feat(coding-agent): add Alibaba Bailian (Token Plan) wan2.7-image provider to generate_image

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `/btw` now opens an ephemeral multi-turn side chat: plain text continues the side thread until Esc returns to the main chat, while visible text-only context stays outside the main transcript and session observability/debug hooks and is scrubbed synchronously on close or abort.
 - Added `statusLine.showActionHints` (default: `true`) to hide contextual action hints while retaining configured status-line segments.
 - `skill_discovery` empty results now carry a `notice` when discovery config caused the emptiness — naming the exact disabled setting (`skills.enabled`, `skills.enablePiProject`, or `skills.enablePiUser`) and the `gjc config set` command to enable it. Previously a disabled config was indistinguishable from "no skills exist", silently hiding freshly written user/project skills.
+- `generate_image` now supports Alibaba Bailian (Token Plan) `wan2.7-image` as an image provider: set `providers.image` to `alibaba` (or let auto-detect find `ALIBABA_TOKEN_PLAN_API_KEY` / a registered `alibaba-token-plan` key), override the model with `providers.imageModel` (e.g. `wan2.7-image-pro`). Short-lived OSS result URLs are downloaded immediately, and image editing works via input images.
 
 ### Fixed
 - Repeated byte-identical stale SDK broker locks no longer cause startup to loop when a prior tombstone exists.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3309,7 +3309,7 @@ export const SETTINGS_SCHEMA = {
 	},
 	"providers.image": {
 		type: "enum",
-		values: ["auto", "openai", "gemini", "openrouter", "antigravity", "custom"] as const,
+		values: ["auto", "openai", "gemini", "openrouter", "antigravity", "alibaba", "custom"] as const,
 		default: "auto",
 		ui: {
 			tab: "providers",
@@ -3319,12 +3319,17 @@ export const SETTINGS_SCHEMA = {
 				{
 					value: "auto",
 					label: "Auto",
-					description: "Priority: GPT model image tool > Antigravity > OpenRouter > Gemini",
+					description: "Priority: GPT model image tool > Antigravity > OpenRouter > Gemini > Alibaba",
 				},
 				{ value: "openai", label: "OpenAI", description: "Uses gpt-image-2 via OpenAI Responses/Codex" },
 				{ value: "gemini", label: "Gemini", description: "Requires GEMINI_API_KEY" },
 				{ value: "openrouter", label: "OpenRouter", description: "Requires OPENROUTER_API_KEY" },
 				{ value: "antigravity", label: "Antigravity", description: "Requires login with google-antigravity" },
+				{
+					value: "alibaba",
+					label: "Alibaba Bailian",
+					description: "Requires ALIBABA_TOKEN_PLAN_API_KEY (wan2.7-image via Token Plan)",
+				},
 				{
 					value: "custom",
 					label: "Custom",

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1108,12 +1108,12 @@ export class SelectorController {
 
 	async #handleImageGenerationConfig(): Promise<void> {
 		const provider = await this.ctx.showHookInput(
-			"Image Generation provider (auto, openai, gemini, openrouter, antigravity, custom)",
+			"Image Generation provider (auto, openai, gemini, openrouter, antigravity, alibaba, custom)",
 			"auto",
 		);
 		if (provider === undefined) return;
 		const normalized = provider.trim().toLowerCase();
-		const validProviders = ["auto", "openai", "gemini", "openrouter", "antigravity", "custom"];
+		const validProviders = ["auto", "openai", "gemini", "openrouter", "antigravity", "alibaba", "custom"];
 		if (!validProviders.includes(normalized)) {
 			this.ctx.showStatus(`Invalid image provider: ${normalized}. Valid: ${validProviders.join(", ")}`);
 			return;
@@ -1145,7 +1145,14 @@ export class SelectorController {
 		if (scope === undefined) return;
 		const persistDefault = scope.trim().toLowerCase() === "default";
 
-		const imageProvider = normalized as "auto" | "openai" | "gemini" | "openrouter" | "antigravity" | "custom";
+		const imageProvider = normalized as
+			| "auto"
+			| "openai"
+			| "gemini"
+			| "openrouter"
+			| "antigravity"
+			| "alibaba"
+			| "custom";
 		setPreferredImageProvider(imageProvider === "custom" ? "auto" : imageProvider);
 		setConfiguredImageModel({
 			provider: imageProvider,
@@ -1644,6 +1651,7 @@ export class SelectorController {
 					imgProvider === "gemini" ||
 					imgProvider === "openrouter" ||
 					imgProvider === "antigravity" ||
+					imgProvider === "alibaba" ||
 					imgProvider === "custom"
 				) {
 					setPreferredImageProvider(imgProvider === "custom" ? "auto" : imgProvider);

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1170,6 +1170,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			imageProvider === "gemini" ||
 			imageProvider === "openrouter" ||
 			imageProvider === "antigravity" ||
+			imageProvider === "alibaba" ||
 			imageProvider === "custom"
 		) {
 			setPreferredImageProvider(imageProvider === "custom" ? "auto" : imageProvider);

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -41,10 +41,12 @@ const OPENAI_IMAGE_OUTPUT_FORMAT = "webp";
 const OPENAI_IMAGE_MIME_TYPE = "image/webp";
 
 const ANTIGRAVITY_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
+const ALIBABA_TOKEN_PLAN_HOST = "https://token-plan.ap-southeast-1.maas.aliyuncs.com";
+const ALIBABA_IMAGE_GENERATION_URL = `${ALIBABA_TOKEN_PLAN_HOST}/api/v1/services/aigc/multimodal-generation/generation`;
 const IMAGE_SYSTEM_INSTRUCTION =
 	"You are an AI image generator. Generate images based on user descriptions. Focus on creating high-quality, visually appealing images that match the user's request.";
 
-type ImageProvider = "antigravity" | "gemini" | "openai" | "openai-codex" | "openrouter";
+type ImageProvider = "alibaba" | "antigravity" | "gemini" | "openai" | "openai-codex" | "openrouter";
 interface ImageApiKey {
 	provider: ImageProvider;
 	apiKey: string;
@@ -294,6 +296,81 @@ interface AntigravityResponseChunk {
 		}>;
 		usageMetadata?: GeminiUsageMetadata;
 	};
+}
+
+interface AlibabaImageContentPart {
+	type?: string;
+	text?: string;
+	image?: string;
+}
+
+interface AlibabaImageResponse {
+	code?: string;
+	message?: string;
+	output?: {
+		choices?: Array<{ message?: { content?: AlibabaImageContentPart[] } }>;
+	};
+}
+
+/** Map the tool's image_size values onto wan2.7's 1K/2K size classes. */
+export function resolveAlibabaImageSize(imageSize: string | undefined): string | undefined {
+	switch (imageSize) {
+		case "1024x1024":
+			return "1K";
+		case "1536x1024":
+		case "1024x1536":
+			return "2K";
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Build the Bailian multimodal-generation request body for wan2.7 image
+ * generation/editing. Input images ride along as data URLs; generation-only
+ * calls send just the prompt text. The sync endpoint returns OSS URLs inline.
+ */
+export function buildAlibabaImageRequest(
+	model: string,
+	promptText: string,
+	inputImages: InlineImageData[],
+	imageSize: string | undefined,
+): {
+	model: string;
+	input: { messages: Array<{ role: "user"; content: Array<{ text: string } | { image: string }> }> };
+	parameters: { n: number; watermark: boolean; size?: string };
+} {
+	const content: Array<{ text: string } | { image: string }> = [];
+	for (const image of inputImages) {
+		content.push({ image: toDataUrl(image) });
+	}
+	content.push({ text: promptText });
+	const size = resolveAlibabaImageSize(imageSize);
+	return {
+		model,
+		input: { messages: [{ role: "user", content }] },
+		parameters: { n: 1, watermark: false, ...(size ? { size } : {}) },
+	};
+}
+
+/** Collect OSS image URLs and any text parts from a Bailian image response. */
+export function collectAlibabaImageResult(response: AlibabaImageResponse): {
+	imageUrls: string[];
+	responseText?: string;
+} {
+	const imageUrls: string[] = [];
+	const textParts: string[] = [];
+	for (const choice of response.output?.choices ?? []) {
+		for (const part of choice.message?.content ?? []) {
+			if (part.image) {
+				imageUrls.push(part.image);
+			} else if (part.text) {
+				textParts.push(part.text);
+			}
+		}
+	}
+	const responseText = textParts.join("\n").trim();
+	return { imageUrls, responseText: responseText.length > 0 ? responseText : undefined };
 }
 
 interface ImageGenToolDetails {
@@ -585,6 +662,7 @@ export function setPreferredImageProvider(provider: ImageProvider | "auto"): voi
 /** Provider → default image model mapping for auto-binding */
 export const IMAGE_PROVIDER_DEFAULTS: Record<string, string> = {
 	openai: "gpt-image-2",
+	alibaba: "wan2.7-image",
 	"openai-codex": "gpt-image-2",
 	antigravity: "gemini-3-pro-image",
 	gemini: "gemini-3-pro-image-preview",
@@ -704,6 +782,18 @@ async function findOpenAIHostedImageCredentials(
 	};
 }
 
+async function findAlibabaImageCredentials(
+	modelRegistry: ModelRegistry | undefined,
+	sessionId?: string,
+): Promise<ImageApiKey | null> {
+	const envKey = getEnvApiKey("alibaba-token-plan");
+	if (envKey) return { provider: "alibaba", apiKey: envKey };
+	if (!modelRegistry) return null;
+	const apiKey = await modelRegistry.getApiKeyForProvider("alibaba-token-plan", sessionId);
+	if (!isAuthenticated(apiKey)) return null;
+	return { provider: "alibaba", apiKey };
+}
+
 async function findImageApiKey(
 	modelRegistry?: ModelRegistry,
 	activeModel?: Model,
@@ -744,6 +834,9 @@ async function findImageApiKey(
 			const openRouterKey = getEnvApiKey("openrouter");
 			return openRouterKey ? { provider: "openrouter", apiKey: openRouterKey } : null;
 		}
+		if (config.provider === "alibaba") {
+			return await findAlibabaImageCredentials(modelRegistry, sessionId);
+		}
 	}
 
 	// If a specific provider is preferred (legacy path), try it first.
@@ -762,9 +855,11 @@ async function findImageApiKey(
 	} else if (preferredImageProvider === "openrouter") {
 		const openRouterKey = getEnvApiKey("openrouter");
 		return openRouterKey ? { provider: "openrouter", apiKey: openRouterKey } : null;
+	} else if (preferredImageProvider === "alibaba") {
+		return await findAlibabaImageCredentials(modelRegistry, sessionId);
 	}
 
-	// Auto-detect: GPT hosted image generation, then Antigravity, OpenRouter, Gemini.
+	// Auto-detect: GPT hosted image generation, then Antigravity, OpenRouter, Gemini, Alibaba.
 	const openAI = await findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
 	if (openAI) return openAI;
 
@@ -781,6 +876,9 @@ async function findImageApiKey(
 
 	const googleKey = $env.GOOGLE_API_KEY;
 	if (googleKey) return { provider: "gemini", apiKey: googleKey };
+
+	const alibaba = await findAlibabaImageCredentials(modelRegistry, sessionId);
+	if (alibaba) return alibaba;
 
 	return null;
 }
@@ -1218,7 +1316,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 			const apiKey = await findImageApiKey(ctx.modelRegistry, ctx.model, sessionId);
 			if (!apiKey) {
 				throw new Error(
-					"No image API credentials found. Use a GPT Responses/Codex model with OpenAI credentials, login with google-antigravity, or set OPENROUTER_API_KEY, GEMINI_API_KEY, or GOOGLE_API_KEY.",
+					"No image API credentials found. Use a GPT Responses/Codex model with OpenAI credentials, login with google-antigravity, or set OPENROUTER_API_KEY, GEMINI_API_KEY, GOOGLE_API_KEY, or ALIBABA_TOKEN_PLAN_API_KEY.",
 				);
 			}
 
@@ -1230,9 +1328,11 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						? (apiKey.model?.id ?? resolveImageModel(provider, null))
 						: provider === "antigravity"
 							? resolveImageModel("antigravity", null)
-							: provider === "openrouter"
-								? resolveImageModel("openrouter", null)
-								: resolveImageModel("gemini", null);
+							: provider === "alibaba"
+								? resolveImageModel("alibaba", null)
+								: provider === "openrouter"
+									? resolveImageModel("openrouter", null)
+									: resolveImageModel("gemini", null);
 			const resolvedModel = provider === "openrouter" ? resolveOpenRouterModel(model) : model;
 			const cwd = ctx.sessionManager.getCwd();
 
@@ -1442,6 +1542,78 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 					details: {
 						provider,
 						model: resolvedModel,
+						imageCount: inlineImages.length,
+						imagePaths,
+						images: inlineImages,
+						responseText,
+					},
+				};
+			}
+
+			if (provider === "alibaba") {
+				const requestBody = buildAlibabaImageRequest(
+					model,
+					assemblePrompt(params),
+					resolvedImages,
+					params.image_size,
+				);
+
+				const response = await fetch(ALIBABA_IMAGE_GENERATION_URL, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: `Bearer ${apiKey.apiKey}`,
+					},
+					body: JSON.stringify(requestBody),
+					signal: requestSignal,
+				});
+
+				const rawText = await response.text();
+				if (!response.ok) {
+					let message = rawText;
+					try {
+						const parsed = JSON.parse(rawText) as { message?: string; error?: { message?: string } };
+						message = parsed.error?.message ?? parsed.message ?? message;
+					} catch {
+						// Keep raw text.
+					}
+					throw new Error(`Alibaba image request failed (${response.status}): ${message}`);
+				}
+
+				const data = JSON.parse(rawText) as AlibabaImageResponse;
+				if (data.code) {
+					throw new Error(`Alibaba image request failed: ${data.code}: ${data.message ?? ""}`.trim());
+				}
+
+				const { imageUrls, responseText } = collectAlibabaImageResult(data);
+				// Result URLs are short-lived OSS-signed URLs (24h); download immediately.
+				const inlineImages: InlineImageData[] = [];
+				for (const imageUrl of imageUrls) {
+					inlineImages.push(await loadImageFromUrl(imageUrl, requestSignal));
+				}
+
+				if (inlineImages.length === 0) {
+					const messageText = responseText ? `\n\n${responseText}` : "";
+					return {
+						content: [{ type: "text", text: `No image data returned.${messageText}` }],
+						details: {
+							provider,
+							model,
+							imageCount: 0,
+							imagePaths: [],
+							images: [],
+							responseText,
+						},
+					};
+				}
+
+				const imagePaths = await saveImagesToTemp(inlineImages);
+
+				return {
+					content: [{ type: "text", text: buildResponseSummary(provider, model, imagePaths, responseText) }],
+					details: {
+						provider,
+						model,
 						imageCount: inlineImages.length,
 						imagePaths,
 						images: inlineImages,

--- a/packages/coding-agent/test/image-gen-alibaba.test.ts
+++ b/packages/coding-agent/test/image-gen-alibaba.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildAlibabaImageRequest,
+	collectAlibabaImageResult,
+	IMAGE_PROVIDER_DEFAULTS,
+	resolveAlibabaImageSize,
+} from "../src/tools/image-gen";
+
+describe("resolveAlibabaImageSize", () => {
+	test("maps square size to 1K", () => {
+		expect(resolveAlibabaImageSize("1024x1024")).toBe("1K");
+	});
+
+	test("maps landscape and portrait sizes to 2K", () => {
+		expect(resolveAlibabaImageSize("1536x1024")).toBe("2K");
+		expect(resolveAlibabaImageSize("1024x1536")).toBe("2K");
+	});
+
+	test("returns undefined when no size requested", () => {
+		expect(resolveAlibabaImageSize(undefined)).toBeUndefined();
+	});
+});
+
+describe("buildAlibabaImageRequest", () => {
+	test("builds a generation request with prompt-only content", () => {
+		const body = buildAlibabaImageRequest("wan2.7-image", "a red apple", [], undefined);
+		expect(body.model).toBe("wan2.7-image");
+		expect(body.input.messages).toHaveLength(1);
+		expect(body.input.messages[0]!.role).toBe("user");
+		expect(body.input.messages[0]!.content).toEqual([{ text: "a red apple" }]);
+		expect(body.parameters.n).toBe(1);
+		expect(body.parameters.size).toBeUndefined();
+	});
+
+	test("prepends input images as data URLs for editing", () => {
+		const body = buildAlibabaImageRequest(
+			"wan2.7-image-pro",
+			"put the graffiti on the car",
+			[{ data: "aGVsbG8=", mimeType: "image/png" }],
+			"1024x1024",
+		);
+		expect(body.input.messages[0]!.content).toEqual([
+			{ image: "data:image/png;base64,aGVsbG8=" },
+			{ text: "put the graffiti on the car" },
+		]);
+		expect(body.parameters.size).toBe("1K");
+	});
+});
+
+describe("collectAlibabaImageResult", () => {
+	test("collects image URLs and text parts from choices", () => {
+		const result = collectAlibabaImageResult({
+			output: {
+				choices: [
+					{
+						message: {
+							content: [
+								{ type: "image", image: "https://oss.example/img1.png" },
+								{ text: "generated one image" },
+							],
+						},
+					},
+					{ message: { content: [{ image: "https://oss.example/img2.png" }] } },
+				],
+			},
+		});
+		expect(result.imageUrls).toEqual(["https://oss.example/img1.png", "https://oss.example/img2.png"]);
+		expect(result.responseText).toBe("generated one image");
+	});
+
+	test("returns empty result for missing output", () => {
+		const result = collectAlibabaImageResult({});
+		expect(result.imageUrls).toEqual([]);
+		expect(result.responseText).toBeUndefined();
+	});
+});
+
+describe("alibaba image provider defaults", () => {
+	test("auto-binds wan2.7-image", () => {
+		expect(IMAGE_PROVIDER_DEFAULTS.alibaba).toBe("wan2.7-image");
+	});
+});

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -2396,6 +2396,7 @@
 						"gemini",
 						"openrouter",
 						"antigravity",
+						"alibaba",
 						"custom"
 					],
 					"description": "Provider and model for image generation tool",


### PR DESCRIPTION
## What

Adds `alibaba` as an image generation provider backed by the Alibaba Cloud Bailian (Model Studio) **Token Plan** sync endpoint (`token-plan.ap-southeast-1.maas.aliyuncs.com`), default model `wan2.7-image`.

## Why

The `alibaba-token-plan` chat provider already ships built-in (catalog models + `alibaba-token-plan-balanced` / `qwenmaxxing` presets), but Token Plan subscribers had no way to use their wan2.7 image quota through `generate_image` — the plan also covers image generation. This closes that gap natively instead of requiring an external CLI wrapper (e.g. omp-alibaba-maas).

## How

- `generate_image` dispatches to `POST /api/v1/services/aigc/multimodal-generation/generation` (sync mode — the Token Plan image API rejects async calls). Result OSS URLs expire in 24h, so images are downloaded immediately via the existing `loadImageFromUrl` (public-URL validation included) and saved to temp like every other provider.
- Image editing works by passing `input` images as data URLs in the message content.
- `image_size` maps onto wan2.7 size classes (`1024x1024` → `1K`, `1536x1024`/`1024x1536` → `2K`); unset omits the parameter so the API default applies.
- Credentials: `ALIBABA_TOKEN_PLAN_API_KEY` env, falling back to the registered `alibaba-token-plan` provider key. **Auto-detect tries Alibaba last**, so existing users' provider priority is unchanged.
- `providers.image` settings enum, SDK session wiring, and the interactive selector accept `alibaba`; model overridable via `providers.imageModel` (`wan2.7-image-pro` for 4K).

Video (HappyHorse t2v/i2v) is intentionally out of scope — it needs the async task-poll flow, which has no counterpart in the image-gen tool; can follow up separately if wanted.

## Tests

- `bun test packages/coding-agent/test/image-gen-alibaba.test.ts` — 8 pass (request builder, response collector, size mapping, provider defaults)
- `bun test packages/coding-agent/test/{image-input,image-input-normalization,block-images,model-profiles-catalog,provider-onboarding}.test.ts` — 42 pass
- `biome check` clean on touched files; `tsc -p packages/coding-agent` introduces no new errors (pre-existing `isUnattended`-rename test errors on dev are untouched)