### PR TITLE
fix(test): complete isUnattended → supportsRemoteGateAnswers rename in test mocks

### DIFF
--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -3091,7 +3091,7 @@ test("workflow gate recommendation projection marks only one exact hint without 
 		| undefined;
 	let terminalController: { completeGateInteractions: (gateId: string) => unknown } | undefined;
 	const workflowGate = {
-		isUnattended: () => true,
+		supportsRemoteGateAnswers: () => true,
 		onGateEmitted: (listener: typeof emitGate) => {
 			emitGate = listener;
 			return () => {};

--- a/packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts
+++ b/packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts
@@ -186,7 +186,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 				required: true,
 			};
 			const emitter: WorkflowGateEmitter = {
-				isUnattended: () => true,
+				supportsRemoteGateAnswers: () => true,
 				emitGate: () => Promise.resolve(undefined),
 				listPendingGates: () => [pendingGate],
 			};
@@ -216,7 +216,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		});
 		try {
 			const emitter: WorkflowGateEmitter = {
-				isUnattended: () => true,
+				supportsRemoteGateAnswers: () => true,
 				emitGate: () => Promise.resolve(undefined),
 				listPendingGates: () => {
 					throw new Error("pending gate lookup failed");

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -2808,7 +2808,7 @@ describe("AskTool deep-interview recorder persistence", () => {
 		});
 		spyOn(deepInterviewRecorder, "syncDeepInterviewRecorderHud").mockResolvedValue(undefined);
 		const gateEmitter = {
-			isUnattended: () => true,
+			supportsRemoteGateAnswers: () => true,
 			emitGate: vi.fn(async () => ({ selected: ["Budget"] })),
 		};
 		const tool = new AskTool(
@@ -2835,7 +2835,7 @@ describe("AskTool deep-interview recorder persistence", () => {
 	});
 
 	it("bounds the complete legacy and multi-question ask payload before any gate emission", async () => {
-		const gateEmitter = { isUnattended: () => true, emitGate: vi.fn(async () => ({ selected: ["A"] })) };
+		const gateEmitter = { supportsRemoteGateAnswers: () => true, emitGate: vi.fn(async () => ({ selected: ["A"] })) };
 		const tool = new AskTool(
 			createSession({ hasUI: false, getWorkflowGateEmitter: () => gateEmitter } as Partial<ToolSession>),
 		);
@@ -2862,7 +2862,7 @@ describe("AskTool deep-interview recorder persistence", () => {
 
 	it("forwards bounded inert adapter context through the canonical gate", async () => {
 		const gateEmitter = {
-			isUnattended: () => true,
+			supportsRemoteGateAnswers: () => true,
 			emitGate: vi.fn(async () => ({ selected: ["Continue"] })),
 		};
 		const adapterContext = {
@@ -3103,7 +3103,7 @@ describe("AskTool Round-0 intent recovery", () => {
 
 	it("terminally rejects every recovery-shaped near-miss before coercion", () => {
 		const recorder = spyOn(deepInterviewRecorder, "appendOrMergeDeepInterviewRound");
-		const gateEmitter = { isUnattended: () => true, emitGate: vi.fn() };
+		const gateEmitter = { supportsRemoteGateAnswers: () => true, emitGate: vi.fn() };
 		const tool = new AskTool(
 			createSession({ hasUI: false, getWorkflowGateEmitter: () => gateEmitter } as Partial<ToolSession>),
 		);
@@ -3228,7 +3228,7 @@ describe("AskTool Round-0 intent recovery", () => {
 		});
 		spyOn(deepInterviewRecorder, "syncDeepInterviewRecorderHud").mockResolvedValue(undefined);
 		const gateEmitter = {
-			isUnattended: () => true,
+			supportsRemoteGateAnswers: () => true,
 			emitGate: vi.fn(async () => ({ selected: ["Looks right"] })),
 		};
 		const tool = new AskTool(


### PR DESCRIPTION
## Summary
- #2521 renamed `WorkflowGateEmitter.isUnattended` → `supportsRemoteGateAnswers`, but its older merge-base missed eight emitter mocks that landed on dev via #2908 (ask.test.ts ×5, sdk-workflow-gate-emitter.test.ts ×2, sdk-host-wiring.test.ts ×1).
- Post-merge dev (4b9d8c8e) broke: `check:types` TS2353/TS2352 errors, shard-8 four AskTool runtime failures (`supportsRemoteGateAnswers is not a function`), shard-6 legacy-emitter waitFor timeout.

## Verification
- `bun run check:types` clean; zero `isUnattended` leftovers repo-wide.
- All five originally failing tests pass individually: 4× AskTool shard-8 tests + shard-6 `workflow gate recommendation projection` (2.0s).
- sdk-workflow-gate-emitter restoration timeouts reproduce identically on pre-#2521 dev (38571d19) — classified pre-existing infrastructure flakiness, out of scope.

Restore-dev-green exception lane.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*