### PR TITLE
fix(notifications): tolerate concurrent recent-session appends

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `skill_discovery` empty results now carry a `notice` when discovery config caused the emptiness — naming the exact disabled setting (`skills.enabled`, `skills.enablePiProject`, or `skills.enablePiUser`) and the `gjc config set` command to enable it. Previously a disabled config was indistinguishable from "no skills exist", silently hiding freshly written user/project skills.
 
 ### Fixed
+- Telegram `/session_recent` now retries one concurrently appended managed transcript and omits only candidates that remain unstable, preserving independently verified recent-session rows.
 - Repeated byte-identical stale SDK broker locks no longer cause startup to loop when a prior tombstone exists.
 - Ralplan no longer re-asks for execution approval when the user already explicitly named `ultragoal` or `team` in the current turn; that naming is the consent.
 

--- a/packages/coding-agent/src/sdk/bus/recent-activity.ts
+++ b/packages/coding-agent/src/sdk/bus/recent-activity.ts
@@ -11,7 +11,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { verifyOwnerOnlyPathSecurity } from "@gajae-code/natives";
 import { getAgentDir, getSessionsDir } from "@gajae-code/utils";
-import { FileSessionStorage } from "../../session/session-storage";
+import { FileSessionStorage, type SessionStorageSnapshot } from "../../session/session-storage";
 import {
 	type LogicalSessionCandidate,
 	listManagedSessionCandidates,
@@ -58,25 +58,52 @@ export interface RecentActivityDeps {
 	readInitialLines?: (file: string, maxLines: number) => string[];
 }
 
+class ManagedCandidateChangedError extends Error {}
+class ManagedCandidateUnavailableError extends Error {}
+
+const CHANGED_CANDIDATE_WARNING = "Ignored managed session candidate that changed during inspection.";
+
+function isAppendExtension(bytes: Uint8Array, candidate: LogicalSessionCandidate): boolean {
+	return (
+		bytes.byteLength >= candidate.identity.size &&
+		createHash("sha256").update(bytes.subarray(0, candidate.identity.size)).digest("hex") ===
+			candidate.identity.sha256
+	);
+}
+
 function readCandidateInitialLines(
 	candidate: LogicalSessionCandidate,
 	readInitialLines: ((file: string, maxLines: number) => string[]) | undefined,
+	appendBase?: LogicalSessionCandidate,
 ): string[] {
 	if (readInitialLines) return readInitialLines(candidate.path, 8);
 	if (candidate.provenance !== "legacy") {
 		const security = verifyOwnerOnlyPathSecurity(candidate.path, "file");
-		if (!security.ok) throw new Error(`Managed session metadata path is unsafe: ${security.code}`);
+		if (!security.ok) throw new ManagedCandidateUnavailableError("Managed session metadata path is unsafe.");
 	}
-	const snapshot = new FileSessionStorage().readSnapshotSync(candidate.path);
+	let snapshot: SessionStorageSnapshot;
+	try {
+		snapshot = new FileSessionStorage().readSnapshotSync(candidate.path);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ELOOP" || code === "ENOTDIR")
+			throw new ManagedCandidateUnavailableError("Managed session metadata is unavailable.");
+		throw error;
+	}
+	const sameFile = snapshot.stat.dev === candidate.identity.dev && snapshot.stat.ino === candidate.identity.ino;
 	const digest = createHash("sha256").update(snapshot.bytes).digest("hex");
-	if (
-		snapshot.stat.dev !== candidate.identity.dev ||
-		snapshot.stat.ino !== candidate.identity.ino ||
-		snapshot.stat.size !== candidate.identity.size ||
-		snapshot.stat.mtimeNs !== candidate.identity.mtimeNs ||
-		digest !== candidate.identity.sha256
-	)
-		throw new Error("Managed session changed after ownership was verified.");
+	const exactIdentity =
+		sameFile &&
+		snapshot.stat.size === candidate.identity.size &&
+		snapshot.stat.mtimeNs === candidate.identity.mtimeNs &&
+		digest === candidate.identity.sha256;
+	if (appendBase && (!sameFile || !isAppendExtension(snapshot.bytes, appendBase)))
+		throw new ManagedCandidateUnavailableError("Managed session no longer extends the verified transcript.");
+	if (!exactIdentity) {
+		if (sameFile && isAppendExtension(snapshot.bytes, candidate))
+			throw new ManagedCandidateChangedError("Managed session was appended after ownership was verified.");
+		throw new ManagedCandidateUnavailableError("Managed session changed without an append-only extension.");
+	}
 	return Buffer.from(snapshot.bytes).toString("utf8").split("\n").slice(0, 8);
 }
 
@@ -227,13 +254,13 @@ export async function listRecentSessions(deps: RecentActivityDeps): Promise<List
 	const resolved = await resolveRecentScopes(deps);
 	if (resolved.kind === "error") return resolved;
 	const warnings = [...resolved.warnings];
-	const candidates: LogicalSessionCandidate[] = [];
+	const candidates: Array<{ scope: ManagedSessionScope; candidate: LogicalSessionCandidate }> = [];
 	for (const scope of resolved.scopes) {
 		const listed = await listManagedSessionCandidates({ scope });
 		if (listed.kind !== "complete") {
 			return { kind: "error", code: "managed_scan_failed", message: listed.message };
 		}
-		candidates.push(...listed.owned);
+		candidates.push(...listed.owned.map(candidate => ({ scope, candidate })));
 		warnings.push(
 			...listed.invalid
 				.filter(
@@ -245,28 +272,65 @@ export async function listRecentSessions(deps: RecentActivityDeps): Promise<List
 	}
 
 	const entries: RecentSessionEntry[] = [];
-	for (const candidate of candidates) {
-		let initialLines: string[];
+	for (const { scope, candidate } of candidates) {
+		let selected = candidate;
+		let initialLines: string[] | undefined;
 		try {
-			initialLines = readCandidateInitialLines(candidate, readInitialLines);
+			initialLines = readCandidateInitialLines(selected, readInitialLines);
 		} catch (error) {
-			return {
-				kind: "error",
-				code: "managed_scan_failed",
-				message: `Could not read managed session metadata: ${error instanceof Error ? error.message : String(error)}`,
-			};
+			if (error instanceof ManagedCandidateChangedError) {
+				const refreshed = await listManagedSessionCandidates({ scope });
+				if (refreshed.kind !== "complete")
+					return { kind: "error", code: "managed_scan_failed", message: refreshed.message };
+				const sameFile = refreshed.owned.find(
+					current =>
+						path.resolve(current.path) === path.resolve(candidate.path) &&
+						current.identity.dev === candidate.identity.dev &&
+						current.identity.ino === candidate.identity.ino,
+				);
+				if (sameFile) {
+					try {
+						initialLines = readCandidateInitialLines(sameFile, readInitialLines, candidate);
+						selected = sameFile;
+					} catch (retryError) {
+						if (
+							!(retryError instanceof ManagedCandidateChangedError) &&
+							!(retryError instanceof ManagedCandidateUnavailableError)
+						)
+							return {
+								kind: "error",
+								code: "managed_scan_failed",
+								message: `Could not read managed session metadata: ${
+									retryError instanceof Error ? retryError.message : String(retryError)
+								}`,
+							};
+					}
+				}
+			} else if (!(error instanceof ManagedCandidateUnavailableError)) {
+				return {
+					kind: "error",
+					code: "managed_scan_failed",
+					message: `Could not read managed session metadata: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				};
+			}
+			if (!initialLines) {
+				warnings.push(CHANGED_CANDIDATE_WARNING);
+				continue;
+			}
 		}
 		const meta = headerMeta(initialLines[0]);
 		const internal = isInternalSession(initialLines);
 		if (internal && !includeInternal) continue;
 		entries.push({
-			sessionId: candidate.sessionId,
-			path: candidate.cwd,
+			sessionId: selected.sessionId,
+			path: selected.cwd,
 			branch: meta.branch,
 			title: meta.title,
-			sessionStateFile: candidate.path,
-			mtimeMs: candidate.identity.mtimeMs,
-			currentTerminal: breadcrumbs.has(path.resolve(candidate.path)) || undefined,
+			sessionStateFile: selected.path,
+			mtimeMs: selected.identity.mtimeMs,
+			currentTerminal: breadcrumbs.has(path.resolve(selected.path)) || undefined,
 			internal: internal || undefined,
 		});
 	}

--- a/packages/coding-agent/test/notifications-recent-activity.test.ts
+++ b/packages/coding-agent/test/notifications-recent-activity.test.ts
@@ -290,27 +290,134 @@ describe("recent-activity picker", () => {
 		expect(result.entries.map(entry => entry.sessionId)).toEqual(["authoritative-id"]);
 	});
 
-	it("rejects a transcript replaced after the readonly managed inventory is captured", async () => {
+	it("revalidates one concurrent append without discarding stable candidates", async () => {
 		const root = tempRoot();
 		const cwd = path.join(root, "workspace");
 		const directory = await managedDirectory(root, cwd);
-		const session = writeSession(directory, "stable", cwd, { title: "original" }, 9_000);
-		const originalReadSnapshot = FileSessionStorage.prototype.readSnapshotSync;
-		FileSessionStorage.prototype.readSnapshotSync = function (file: string) {
-			fs.writeFileSync(
-				session,
-				`${JSON.stringify({ type: "session", id: "stable", cwd, title: "replacement" })}\n`,
-				{ mode: 0o600 },
-			);
-			return originalReadSnapshot.call(this, file);
-		};
+		const changing = writeSession(directory, "changing", cwd, {}, 9_000);
+		writeSession(directory, "stable", cwd, {}, 10_000);
+		const original = FileSessionStorage.prototype.readSnapshotSync;
+		let appended = false;
+		let changingReads = 0;
+		const reader = vi.spyOn(FileSessionStorage.prototype, "readSnapshotSync").mockImplementation(function (
+			this: FileSessionStorage,
+			file: string,
+		) {
+			if (file === changing) changingReads++;
+			if (file === changing && !appended) {
+				appended = true;
+				fs.appendFileSync(changing, `${JSON.stringify({ type: "message", append: true })}\n`);
+			}
+			return original.call(this, file);
+		});
 		try {
-			await expect(listRecentSessions({ cwd, sessionsRoot: root })).resolves.toMatchObject({
-				kind: "error",
-				code: "managed_scan_failed",
-			});
+			const result = await listRecentSessions({ cwd, sessionsRoot: root });
+			expect(result).toMatchObject({ kind: "complete", warnings: [] });
+			if (result.kind !== "complete") return;
+			expect(result.entries.map(entry => entry.sessionId)).toEqual(["changing", "stable"]);
+			expect(changingReads).toBe(2);
 		} finally {
-			FileSessionStorage.prototype.readSnapshotSync = originalReadSnapshot;
+			reader.mockRestore();
+		}
+	});
+
+	it("omits a continuously changing candidate while retaining stable results", async () => {
+		const root = tempRoot();
+		const cwd = path.join(root, "workspace");
+		const directory = await managedDirectory(root, cwd);
+		const changing = writeSession(directory, "changing", cwd, {}, 9_000);
+		writeSession(directory, "stable", cwd, {}, 10_000);
+		const original = FileSessionStorage.prototype.readSnapshotSync;
+		const reader = vi.spyOn(FileSessionStorage.prototype, "readSnapshotSync").mockImplementation(function (
+			this: FileSessionStorage,
+			file: string,
+		) {
+			if (file === changing) fs.appendFileSync(changing, `${JSON.stringify({ type: "message", append: true })}\n`);
+			return original.call(this, file);
+		});
+		try {
+			const result = await listRecentSessions({ cwd, sessionsRoot: root });
+			expect(result).toMatchObject({
+				kind: "complete",
+				warnings: ["Ignored managed session candidate that changed during inspection."],
+			});
+			if (result.kind !== "complete") return;
+			expect(result.entries.map(entry => entry.sessionId)).toEqual(["stable"]);
+		} finally {
+			reader.mockRestore();
+		}
+	});
+
+	it("omits a same-inode rewrite instead of adopting rewritten metadata", async () => {
+		const root = tempRoot();
+		const cwd = path.join(root, "workspace");
+		const directory = await managedDirectory(root, cwd);
+		const changing = writeSession(directory, "changing", cwd, {}, 9_000);
+		writeSession(directory, "stable", cwd, {}, 10_000);
+		const original = FileSessionStorage.prototype.readSnapshotSync;
+		let rewritten = false;
+		const reader = vi.spyOn(FileSessionStorage.prototype, "readSnapshotSync").mockImplementation(function (
+			this: FileSessionStorage,
+			file: string,
+		) {
+			if (file === changing && !rewritten) {
+				rewritten = true;
+				fs.writeFileSync(
+					changing,
+					`${JSON.stringify({ type: "session", id: "rewritten", cwd, title: "rewritten" })}\n`,
+					{ mode: 0o600 },
+				);
+			}
+			return original.call(this, file);
+		});
+		try {
+			const result = await listRecentSessions({ cwd, sessionsRoot: root });
+			expect(result).toMatchObject({
+				kind: "complete",
+				warnings: ["Ignored managed session candidate that changed during inspection."],
+			});
+			if (result.kind !== "complete") return;
+			expect(result.entries.map(entry => entry.sessionId)).toEqual(["stable"]);
+		} finally {
+			reader.mockRestore();
+		}
+	});
+
+	it("omits a transcript replaced after the readonly managed inventory is captured", async () => {
+		const root = tempRoot();
+		const cwd = path.join(root, "workspace");
+		const directory = await managedDirectory(root, cwd);
+		const changing = writeSession(directory, "changing", cwd, {}, 9_000);
+		writeSession(directory, "stable", cwd, {}, 10_000);
+		const replacement = path.join(root, "replacement.jsonl");
+		fs.writeFileSync(
+			replacement,
+			`${JSON.stringify({ type: "session", id: "replacement", cwd, title: "replacement" })}\n`,
+			{ mode: 0o600 },
+		);
+		secureOwnerOnlyFile(replacement);
+		const original = FileSessionStorage.prototype.readSnapshotSync;
+		let replaced = false;
+		const reader = vi.spyOn(FileSessionStorage.prototype, "readSnapshotSync").mockImplementation(function (
+			this: FileSessionStorage,
+			file: string,
+		) {
+			if (file === changing && !replaced) {
+				replaced = true;
+				fs.renameSync(replacement, changing);
+			}
+			return original.call(this, file);
+		});
+		try {
+			const result = await listRecentSessions({ cwd, sessionsRoot: root });
+			expect(result).toMatchObject({
+				kind: "complete",
+				warnings: ["Ignored managed session candidate that changed during inspection."],
+			});
+			if (result.kind !== "complete") return;
+			expect(result.entries.map(entry => entry.sessionId)).toEqual(["stable"]);
+		} finally {
+			reader.mockRestore();
 		}
 	});
 
@@ -324,6 +431,26 @@ describe("recent-activity picker", () => {
 		fs.symlinkSync(target, path.join(directory, "linked.jsonl"));
 		const result = await listRecentSessions({ cwd, sessionsRoot: root });
 		expect(result).toMatchObject({ kind: "complete", entries: [] });
+	});
+
+	it("preserves unexpected metadata reader failures as request errors", async () => {
+		const root = tempRoot();
+		const cwd = path.join(root, "workspace");
+		const directory = await managedDirectory(root, cwd);
+		writeSession(directory, "stable", cwd, {}, 10_000);
+
+		const result = await listRecentSessions({
+			cwd,
+			sessionsRoot: root,
+			readInitialLines: () => {
+				throw new Error("reader failed");
+			},
+		});
+		expect(result).toMatchObject({
+			kind: "error",
+			code: "managed_scan_failed",
+			message: "Could not read managed session metadata: reader failed",
+		});
 	});
 
 	it("returns a diagnostic instead of treating an invalid workspace as no sessions", async () => {


### PR DESCRIPTION
## Summary

- Revalidate one append-only managed transcript change against the canonical scope inventory.
- Omit only candidates that remain unstable, are rewritten, or are replaced while preserving stable `/session_recent` rows.
- Keep scope-level and unexpected metadata failures as request errors.

## Problem

`/session_recent` inventories managed candidates and then reads their metadata. An active session can append to its JSONL transcript between those steps, causing the candidate identity check to fail. The current code promotes that candidate-local race to `managed_scan_failed`, so one unrelated active session can abort the entire recent-session list.

## Changes

- Detect append-only growth by verifying the original transcript SHA-256 over the refreshed byte prefix.
- Refresh the candidate through `listManagedSessionCandidates` once and accept only the same path, device, and inode.
- Bound changed candidates to the initial metadata read plus one retry.
- Omit continuously changing, same-inode rewritten, unavailable, or inode-replaced candidates with a sanitized warning.
- Preserve existing v2 owner-only checks, no-follow snapshot identity checks, stale-cwd behavior, sorting, filtering, and public result types.
- Add focused regression coverage for successful append retry, retry exhaustion, same-inode rewrite, inode replacement, and unexpected reader failures.

## Verification

- `bun test packages/coding-agent/test/notifications-recent-activity.test.ts packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts` — 27 passed, 0 failed
- `bun test scripts/telegram-daemon-generation-guard.test.ts` — 32 passed, 0 failed
- `bun scripts/telegram-daemon-generation-guard.ts --validate-current-tree`
- `bun scripts/verify-gjc-plugins.ts` — 16/16 gates passed
- `bun scripts/check-public-version-sync.ts`
- `bunx biome check packages/coding-agent/src/sdk/bus/recent-activity.ts packages/coding-agent/test/notifications-recent-activity.test.ts`
- `git diff --check upstream/dev...HEAD`
- Independent P0–P3 review — 0 findings, `CLEAR / APPROVE`

## Known upstream failure

The full coding-agent type check currently fails unchanged on `upstream/dev` because test fixtures from #2521 still use `isUnattended` instead of `supportsRemoteGateAnswers`. This PR does not touch those files.
