### PR TITLE
fix(telegram): isolate lifecycle worktree launches

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Telegram ask notifications now preserve the authoritative recommended choice from native asks and workflow gates, marking that option as `(Recommended)` in the message body without changing button indices or submitted answers.
 - Telegram `/session_close` now fails closed when tmux disappearance cannot be confirmed, and publishes the managed owner verdict before locked terminal-state preservation so normal close finalization is not delayed behind that state path.
 - Managed publication now fails closed on malformed, committed, or mutation-unknown native outcomes: it never retries or cleans a destination, and preserves bounded atomic-unavailable/durability diagnostics through managed startup (#2804).
+- Telegram `/session_create worktree` now pins the active GJC runtime, enters the requested linked worktree, and keeps tmux project/branch metadata aligned without mutating the primary checkout.
 
 ## [0.11.6] - 2026-07-21
 ## [0.11.5] - 2026-07-20

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -15,6 +15,7 @@ import {
 	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
 	GJC_TMUX_OWNER_GENERATION_ENV,
 } from "../gjc-runtime/session-state-sidecar";
+import { GJC_TMUX_BRANCH_OPTION, GJC_TMUX_PROJECT_OPTION, resolveGjcTmuxCommand } from "../gjc-runtime/tmux-common";
 import { runRootCommand } from "../main";
 import { prepareAcpTerminalAuthArgs } from "../modes/acp/terminal-auth";
 
@@ -56,6 +57,28 @@ export async function persistCoordinatorLaunchFailure(
 	};
 	await fs.mkdir(path.dirname(stateFile), { recursive: true });
 	await Bun.write(stateFile, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function updateWorktreeTmuxMetadata(launch: PreparedLaunchWorktree): void {
+	const target = process.env.TMUX_PANE;
+	if (!launch.worktree.enabled) return;
+	if (!target) {
+		if (process.env[GJC_COORDINATOR_SESSION_ID_ENV]) throw new Error("worktree_tmux_pane_missing");
+		return;
+	}
+	const tmux = resolveGjcTmuxCommand(process.env);
+	const metadata: Array<[string, string]> = [[GJC_TMUX_PROJECT_OPTION, launch.cwd]];
+	if (!launch.worktree.detached) {
+		if (!launch.worktree.branchName) throw new Error("worktree_branch_missing");
+		metadata.push([GJC_TMUX_BRANCH_OPTION, launch.worktree.branchName]);
+	}
+	for (const [option, value] of metadata) {
+		const result = Bun.spawnSync([tmux, "set-option", "-t", target, option, value]);
+		if (result.exitCode !== 0) {
+			const detail = result.stderr.toString().trim();
+			throw new Error(`worktree_tmux_metadata_failed:${option}${detail ? `: ${detail}` : ""}`);
+		}
+	}
 }
 
 export default class Index extends Command {
@@ -222,8 +245,14 @@ export default class Index extends Command {
 			throw error;
 		}
 		if (launch.worktree.enabled) {
-			process.chdir(launch.cwd);
-			setProjectDir(launch.cwd);
+			try {
+				process.chdir(launch.cwd);
+				setProjectDir(launch.cwd);
+				updateWorktreeTmuxMetadata(launch);
+			} catch (error) {
+				await persistCoordinatorLaunchFailure(error, launch.cwd);
+				throw error;
+			}
 		}
 		const launchParsed = parseArgs(launch.args);
 		if (

--- a/packages/coding-agent/src/daemon/runtime.ts
+++ b/packages/coding-agent/src/daemon/runtime.ts
@@ -30,6 +30,7 @@ const COMPILED_RELOAD_WARNING =
  * own subcommand directly and cannot pick up workspace source edits.
  */
 export function resolveGjcRuntimeSpawnInfo(execPath: string = process.execPath): GjcRuntimeSpawnInfo {
+	if (!path.isAbsolute(execPath)) throw new Error("gjc_runtime_exec_path_not_absolute");
 	const base = path.basename(execPath).toLowerCase();
 	const fromSource = base === "bun" || base === "node" || base.startsWith("bun") || base.startsWith("node");
 	const sourceEntry = fromSource ? path.resolve(import.meta.dir, "../../bin/gjc.js") : undefined;

--- a/packages/coding-agent/src/sdk/bus/lifecycle-control-runtime.ts
+++ b/packages/coding-agent/src/sdk/bus/lifecycle-control-runtime.ts
@@ -12,6 +12,7 @@ import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
 import type { NotificationControlServer as NativeNotificationControlServer } from "@gajae-code/natives";
 import { logger } from "@gajae-code/utils";
+import { resolveGjcRuntimeSpawnInfo } from "../../daemon/runtime";
 import { readLinuxProcStartTime } from "../../gjc-runtime/linux-proc";
 import {
 	MANAGED_OWNER_PREDECESSOR_GENERATION_ENV,
@@ -782,6 +783,7 @@ async function completeLifecycleSpawnTransaction(input: {
 	ownerIsolationProbe?: OwnerIsolationProbe;
 	prepareSpawn?: () => void;
 	previousBaseline?: OwnerGenerationBaseline;
+	recordProjectMetadata?: boolean;
 }): Promise<void> {
 	const previousBaseline =
 		input.previousBaseline ?? (await captureOwnerGenerationBaseline(input.stateDir, input.sessionId));
@@ -807,7 +809,7 @@ async function completeLifecycleSpawnTransaction(input: {
 			{
 				sessionId: input.sessionId,
 				sessionStateFile: input.sessionStateFile,
-				project: input.cwd,
+				project: input.recordProjectMetadata === false ? undefined : input.cwd,
 				ownerGeneration: input.generation,
 				ownerServerKey: ownerExecution.serverKey,
 			},
@@ -860,7 +862,7 @@ async function completeLifecycleSpawnTransaction(input: {
 /** Real daemon-safe tmux launcher: canonical owner-isolation plan + GJC tags. */
 export function daemonSpawnCreate(
 	env: NodeJS.ProcessEnv = process.env,
-	opts: { ownerIsolationProbe?: OwnerIsolationProbe } = {},
+	opts: { ownerIsolationProbe?: OwnerIsolationProbe; execPath?: string } = {},
 ) {
 	return async (
 		frame: SessionCreateFrame,
@@ -871,6 +873,8 @@ export function daemonSpawnCreate(
 		const tmux = tmuxBinary.command;
 		const name = tmuxSessionNameFor(ids.intendedSessionId);
 		const { cwd, args } = buildCreateArgv(frame, ids);
+		const runtime = resolveGjcRuntimeSpawnInfo(opts.execPath);
+		const gjcCommand = [runtime.execPath, ...runtime.argsPrefix];
 		const sessionStateFile = lifecycleRuntimeStateFile(cwd, ids.intendedSessionId, name);
 		const stateDir = path.dirname(sessionStateFile);
 		const previousBaseline = await captureOwnerGenerationBaseline(stateDir, ids.intendedSessionId);
@@ -891,7 +895,7 @@ export function daemonSpawnCreate(
 			[GJC_TMUX_OWNER_GENERATION_ENV]: generation,
 			[GJC_TMUX_OWNER_STATE_DIR_ENV]: stateDir,
 			[GJC_TMUX_OWNER_SERVER_KEY_ENV]: "default",
-			GJC_MANAGED_OWNER_COMMAND_JSON: JSON.stringify(["gjc", ...args]),
+			GJC_MANAGED_OWNER_COMMAND_JSON: JSON.stringify([...gjcCommand, ...args]),
 			[MANAGED_OWNER_RUN_ID_ENV]: runId,
 			[MANAGED_OWNER_INCARNATION_ENV]: incarnation,
 			...(predecessor
@@ -908,7 +912,7 @@ export function daemonSpawnCreate(
 		const envPairs = Object.entries(childEnv)
 			.map(([key, value]) => `${key}=${shellQuote(value)}`)
 			.join(" ");
-		const command = `cd ${shellQuote(cwd)} && exec env ${envPairs} gjc ${shellQuote(MANAGED_OWNER_SUPERVISOR_ARG)}`;
+		const command = `cd ${shellQuote(cwd)} && exec env ${envPairs} ${gjcCommand.map(shellQuote).join(" ")} ${shellQuote(MANAGED_OWNER_SUPERVISOR_ARG)}`;
 		await completeLifecycleSpawnTransaction({
 			tmux,
 			env,
@@ -923,6 +927,7 @@ export function daemonSpawnCreate(
 			prepareSpawn: () => {
 				if (frame.target.kind === "plain_dir") fs.mkdirSync(cwd, { recursive: true });
 			},
+			recordProjectMetadata: frame.target.kind !== "worktree",
 			previousBaseline,
 		});
 
@@ -951,7 +956,7 @@ async function applyRequiredLifecycleTmuxMetadata(
 	metadata: {
 		sessionId: string;
 		sessionStateFile: string;
-		project: string;
+		project?: string;
 		ownerGeneration: string;
 		ownerServerKey: string;
 	},
@@ -960,7 +965,7 @@ async function applyRequiredLifecycleTmuxMetadata(
 	if (
 		!metadata.sessionId.trim() ||
 		!metadata.sessionStateFile.trim() ||
-		!metadata.project.trim() ||
+		(metadata.project !== undefined && !metadata.project.trim()) ||
 		!metadata.ownerGeneration.trim() ||
 		!metadata.ownerServerKey.trim()
 	)
@@ -1018,6 +1023,7 @@ export function daemonResumeSession(
 		sessionsRoot?: string;
 		listSessions?: (env: NodeJS.ProcessEnv) => GjcTmuxSessionStatus[];
 		ownerIsolationProbe?: OwnerIsolationProbe;
+		execPath?: string;
 	} = {},
 ) {
 	return async (target: {
@@ -1091,6 +1097,8 @@ export function daemonResumeSession(
 		const generation = crypto.randomUUID();
 		const runId = crypto.randomUUID();
 		const incarnation = crypto.randomUUID();
+		const runtime = resolveGjcRuntimeSpawnInfo(opts.execPath);
+		const gjcCommand = [runtime.execPath, ...runtime.argsPrefix];
 		const childEnv: Record<string, string> = {
 			GJC_TMUX_LAUNCHED: "1",
 			GJC_NOTIFICATIONS: "1",
@@ -1099,7 +1107,7 @@ export function daemonResumeSession(
 			[GJC_TMUX_OWNER_GENERATION_ENV]: generation,
 			[GJC_TMUX_OWNER_STATE_DIR_ENV]: stateDir,
 			[GJC_TMUX_OWNER_SERVER_KEY_ENV]: "default",
-			GJC_MANAGED_OWNER_COMMAND_JSON: JSON.stringify(["gjc", "--resume", resumeId]),
+			GJC_MANAGED_OWNER_COMMAND_JSON: JSON.stringify([...gjcCommand, "--resume", resumeId]),
 			[MANAGED_OWNER_RUN_ID_ENV]: runId,
 			[MANAGED_OWNER_INCARNATION_ENV]: incarnation,
 			...(predecessor
@@ -1115,7 +1123,7 @@ export function daemonResumeSession(
 		const envPairs = Object.entries(childEnv)
 			.map(([key, value]) => `${key}=${shellQuote(value)}`)
 			.join(" ");
-		const command = `cd ${shellQuote(resolvedResumeCwd)} && exec env ${envPairs} gjc ${shellQuote(MANAGED_OWNER_SUPERVISOR_ARG)}`;
+		const command = `cd ${shellQuote(resolvedResumeCwd)} && exec env ${envPairs} ${gjcCommand.map(shellQuote).join(" ")} ${shellQuote(MANAGED_OWNER_SUPERVISOR_ARG)}`;
 		await completeLifecycleSpawnTransaction({
 			tmux,
 			env,

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -191,6 +191,10 @@ describe("daemon runtime detection", () => {
 		expect(compiled.argsPrefix).toEqual([]);
 	});
 
+	test("rejects a relative runtime executable before spawning", () => {
+		expect(() => resolveGjcRuntimeSpawnInfo("gjc")).toThrow("gjc_runtime_exec_path_not_absolute");
+	});
+
 	test("chat daemon spawn uses source and compiled command forms", () => {
 		const source = buildChatDaemonSpawnArgs({
 			kind: "discord",

--- a/packages/coding-agent/test/manifests/telegram-baseline-v1.json
+++ b/packages/coding-agent/test/manifests/telegram-baseline-v1.json
@@ -285,6 +285,13 @@
 			"argv": [
 				"bun",
 				"test",
+				"packages/coding-agent/test/notifications-telegram-lifecycle-worktree-e2e.test.ts"
+			]
+		},
+		{
+			"argv": [
+				"bun",
+				"test",
 				"packages/coding-agent/test/notifications-telegram-reference.test.ts"
 			]
 		},

--- a/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
@@ -1609,6 +1609,7 @@ describe("lifecycle control runtime", () => {
 			const result = await daemonSpawnCreate(
 				{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: callsFile },
 				{
+					execPath: "/opt/gjc current/gjc",
 					ownerIsolationProbe: {
 						readCallerCgroup: async () => "/gjc-lifecycle-test.scope\n",
 						probeServer: async () =>
@@ -1623,7 +1624,7 @@ describe("lifecycle control runtime", () => {
 									},
 					},
 				},
-			)(createFrame({ target: { kind: "existing_path", path: proj } }), {
+			)(createFrame({ target: { kind: "worktree", repo: proj, branch: "fix-telegram-close" } }), {
 				lifecycleRequestId: "lc-owner",
 				intendedSessionId: "owner-123",
 			});
@@ -1649,6 +1650,11 @@ describe("lifecycle control runtime", () => {
 			expect(calls).toContain("@gjc-owner-server-key");
 			expect(calls).not.toContain("GJC_OWNER_");
 			expect(calls).toContain(`GJC_COORDINATOR_SESSION_STATE_FILE='${result.sessionStateFile}'`);
+			expect(calls).toContain(
+				`GJC_MANAGED_OWNER_COMMAND_JSON='["/opt/gjc current/gjc","--worktree=fix-telegram-close"]'`,
+			);
+			expect(calls).toContain("'/opt/gjc current/gjc' '--internal-managed-owner-supervisor'");
+			expect(calls).not.toContain("@gjc-project");
 			expect(calls).not.toContain("gjc-lifecycle-owner-isolation");
 			fs.rmSync(root, { recursive: true, force: true });
 		},

--- a/packages/coding-agent/test/notifications-telegram-lifecycle-worktree-e2e.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-lifecycle-worktree-e2e.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "../src/config/settings";
+import { TelegramNotificationDaemon } from "../src/sdk/bus/telegram-daemon";
+
+const roots: string[] = [];
+const agentDirs: string[] = [];
+const tmuxFixtures: TmuxFixture[] = [];
+
+interface TmuxFixture {
+	dir: string;
+	socket: string;
+	command: string;
+}
+
+function commandWorks(command: string, args: string[]): boolean {
+	const result = Bun.spawnSync([command, ...args], { stdout: "pipe", stderr: "pipe" });
+	return result.exitCode === 0;
+}
+
+function git(args: string[], cwd: string): string {
+	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	if (result.exitCode !== 0) throw new Error(result.stderr.toString());
+	return result.stdout.toString().trim();
+}
+
+const unsupportedPrerequisite =
+	process.platform === "win32"
+		? "requires a POSIX tmux server"
+		: Bun.which("git") === null || !commandWorks("git", ["--version"])
+			? "requires a working git executable"
+			: Bun.which("tmux") === null || !commandWorks("tmux", ["-V"])
+				? "requires a working tmux executable"
+				: null;
+
+function createTmuxFixture(): TmuxFixture {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-telegram-worktree-tmux-"));
+	const socket = path.join(dir, "server.sock");
+	const command = path.join(dir, "tmux-fixture");
+	fs.writeFileSync(command, `#!/bin/sh\nexec tmux -S '${socket}' "$@"\n`, { mode: 0o700 });
+	const fixture = { dir, socket, command };
+	tmuxFixtures.push(fixture);
+	return fixture;
+}
+
+function tmux(fixture: TmuxFixture, args: string[]): string {
+	const result = Bun.spawnSync(["tmux", "-S", fixture.socket, ...args], { stdout: "pipe", stderr: "pipe" });
+	if (result.exitCode !== 0) throw new Error(result.stderr.toString());
+	return result.stdout.toString().trim();
+}
+
+function tmuxSessionNames(fixture: TmuxFixture): string[] {
+	const result = Bun.spawnSync(["tmux", "-S", fixture.socket, "list-sessions", "-F", "#{session_name}"], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (result.exitCode !== 0) return [];
+	return result.stdout
+		.toString()
+		.split("\n")
+		.map(name => name.trim())
+		.filter(Boolean);
+}
+
+function tmuxOption(fixture: TmuxFixture, session: string, option: string): string {
+	return tmux(fixture, ["show-options", "-v", "-t", session, option]);
+}
+
+function optionalTmuxOption(fixture: TmuxFixture, session: string, option: string): string | undefined {
+	const result = Bun.spawnSync(["tmux", "-S", fixture.socket, "show-options", "-v", "-t", session, option], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	return result.exitCode === 0 ? result.stdout.toString().trim() : undefined;
+}
+
+function fixtureSettings(agentDir: string): Settings {
+	const base = Settings.isolated({
+		"notifications.enabled": true,
+		"notifications.telegram.botToken": "123456:test-token",
+		"notifications.telegram.chatId": "42",
+	}) as Settings;
+	return new Proxy(base, {
+		get(target, prop) {
+			if (prop === "getAgentDir") return () => agentDir;
+			const value = Reflect.get(target, prop, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	}) as Settings;
+}
+
+function createRepo(): string {
+	const repo = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-telegram-worktree-e2e-"));
+	roots.push(repo);
+	git(["init"], repo);
+	git(["config", "user.email", "test@example.com"], repo);
+	git(["config", "user.name", "Test User"], repo);
+	fs.writeFileSync(path.join(repo, "tracked-sentinel.txt"), "primary\n");
+	fs.writeFileSync(path.join(repo, ".gitignore"), ".gjc/\n");
+	git(["add", "tracked-sentinel.txt", ".gitignore"], repo);
+	git(["commit", "-m", "initial"], repo);
+	return repo;
+}
+
+afterEach(() => {
+	for (const fixture of tmuxFixtures.splice(0)) {
+		Bun.spawnSync(["tmux", "-S", fixture.socket, "kill-server"]);
+		fs.rmSync(fixture.dir, { recursive: true, force: true });
+	}
+	for (const repo of roots.splice(0)) {
+		const worktreeRoot = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`);
+		for (const line of git(["worktree", "list", "--porcelain"], repo).split("\n")) {
+			if (!line.startsWith("worktree ")) continue;
+			const candidate = line.slice("worktree ".length);
+			if (candidate !== repo) Bun.spawnSync(["git", "worktree", "remove", "--force", candidate], { cwd: repo });
+		}
+		fs.rmSync(repo, { recursive: true, force: true });
+		fs.rmSync(worktreeRoot, { recursive: true, force: true });
+	}
+	for (const agentDir of agentDirs.splice(0)) fs.rmSync(agentDir, { recursive: true, force: true });
+});
+
+describe("Telegram /session_create worktree isolation", () => {
+	(unsupportedPrerequisite ? test.skip : test)(
+		"dispatches the exact command into a disposable named worktree without changing the primary checkout",
+		async () => {
+			const repo = createRepo();
+			const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-telegram-worktree-agent-"));
+			const tmuxFixture = createTmuxFixture();
+			agentDirs.push(agentDir);
+			const pathShadow = path.join(agentDir, "gjc");
+			const pathShadowSentinel = path.join(agentDir, "path-shadow-invoked");
+			fs.writeFileSync(pathShadow, '#!/bin/sh\n: > "$GJC_PATH_SHADOW_SENTINEL"\nexit 97\n', { mode: 0o700 });
+			const primary = {
+				topLevel: git(["rev-parse", "--show-toplevel"], repo),
+				head: git(["rev-parse", "HEAD"], repo),
+				branch: git(["branch", "--show-current"], repo),
+				index: fs.readFileSync(path.join(repo, ".git", "index")),
+				status: git(["status", "--porcelain=v1"], repo),
+				sentinel: fs.readFileSync(path.join(repo, "tracked-sentinel.txt"), "utf8"),
+			};
+			const calls: { method: string; body: Record<string, unknown> | null }[] = [];
+			const daemon = new TelegramNotificationDaemon({
+				settings: fixtureSettings(agentDir),
+				ownerId: "telegram-worktree-e2e",
+				botToken: "123456:test-token",
+				chatId: "42",
+				botApi: {
+					call: async (method: string, body: Record<string, unknown> | null) => {
+						calls.push({ method, body });
+						if (method === "getChat") return { ok: true, result: { id: body?.chat_id, type: "private" } };
+						return { ok: true, result: [] };
+					},
+				} as never,
+			});
+			const lifecycleControl = daemon as unknown as {
+				startLifecycleControl: () => Promise<boolean>;
+				stopLifecycleControl: () => void;
+			};
+			const previousTmuxCommand = process.env.GJC_TMUX_COMMAND;
+			const previousPath = process.env.PATH;
+			const previousPathShadowSentinel = process.env.GJC_PATH_SHADOW_SENTINEL;
+			process.env.PATH = `${agentDir}${path.delimiter}${previousPath ?? ""}`;
+			process.env.GJC_PATH_SHADOW_SENTINEL = pathShadowSentinel;
+			process.env.GJC_TMUX_COMMAND = tmuxFixture.command;
+			try {
+				expect(await lifecycleControl.startLifecycleControl()).toBe(true);
+				await daemon.handleTelegramUpdate({
+					update_id: 71,
+					message: {
+						chat: { id: "42", type: "private" },
+						message_id: 71,
+						text: `/session_create worktree ${repo} fix-telegram-close`,
+					},
+				});
+
+				const createdTmuxSessions = tmuxSessionNames(tmuxFixture);
+				expect(createdTmuxSessions).toHaveLength(1);
+				const tmuxSession = createdTmuxSessions[0]!;
+				const sessionId = tmuxOption(tmuxFixture, tmuxSession, "@gjc-session-id");
+				const sessionStateFile = tmuxOption(tmuxFixture, tmuxSession, "@gjc-session-state-file");
+				expect(sessionId).toMatch(/^s[0-9a-f]{12}$/);
+				const lifecycleDir = path.join(path.dirname(sessionStateFile), sessionId, "owner-lifecycle");
+
+				const worktreeRoot = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`);
+				let worktree: string | undefined;
+				for (let attempt = 0; attempt < 100 && worktree === undefined; attempt++) {
+					worktree = git(["worktree", "list", "--porcelain"], repo)
+						.split("\n")
+						.find(line => line.startsWith("worktree ") && line.includes(worktreeRoot))
+						?.slice("worktree ".length);
+					if (worktree === undefined) await Bun.sleep(50);
+				}
+				if (worktree === undefined) {
+					const pane = tmux(tmuxFixture, ["capture-pane", "-p", "-t", tmuxSession]);
+					const paneCommand = tmux(tmuxFixture, [
+						"list-panes",
+						"-t",
+						tmuxSession,
+						"-F",
+						"#{pane_pid} #{pane_start_command}",
+					]);
+					const bindings = fs
+						.readdirSync(lifecycleDir, { recursive: true })
+						.filter(entry => String(entry).endsWith(".binding.json"))
+						.map(entry => fs.readFileSync(path.join(lifecycleDir, String(entry)), "utf8"));
+					throw new Error(
+						`linked worktree was not created\ncommand=${paneCommand}\nbindings=${bindings.join("\n")}\n${pane}`,
+					);
+				}
+				expect(git(["rev-parse", "--show-toplevel"], worktree)).toBe(worktree);
+				expect(git(["branch", "--show-current"], worktree)).toBe("fix-telegram-close");
+				expect(worktree).not.toBe(repo);
+				expect(fs.statSync(worktree).isDirectory()).toBe(true);
+				expect(fs.existsSync(path.join(repo, "fix-telegram-close"))).toBe(false);
+				let projectMetadata: string | undefined;
+				let branchMetadata: string | undefined;
+				for (let attempt = 0; attempt < 100; attempt++) {
+					projectMetadata = optionalTmuxOption(tmuxFixture, tmuxSession, "@gjc-project");
+					branchMetadata = optionalTmuxOption(tmuxFixture, tmuxSession, "@gjc-branch");
+					if (projectMetadata === worktree && branchMetadata === "fix-telegram-close") break;
+					await Bun.sleep(50);
+				}
+				expect(projectMetadata).toBe(worktree);
+				expect(branchMetadata).toBe("fix-telegram-close");
+				const bindingFiles = fs
+					.readdirSync(lifecycleDir, { recursive: true })
+					.filter(entry => String(entry).endsWith(".binding.json"));
+				expect(bindingFiles).toHaveLength(1);
+				const binding = JSON.parse(fs.readFileSync(path.join(lifecycleDir, String(bindingFiles[0])), "utf8")) as {
+					command?: string[];
+				};
+				expect(binding.command).toEqual([
+					process.execPath,
+					path.resolve(import.meta.dir, "../bin/gjc.js"),
+					"--worktree=fix-telegram-close",
+				]);
+				expect(fs.existsSync(pathShadowSentinel)).toBe(false);
+
+				const gjcRoot = path.join(repo, ".gjc");
+				expect(sessionStateFile.startsWith(`${gjcRoot}${path.sep}`)).toBe(true);
+				expect(git(["rev-parse", "--show-toplevel"], repo)).toBe(primary.topLevel);
+				expect(git(["rev-parse", "HEAD"], repo)).toBe(primary.head);
+				expect(git(["branch", "--show-current"], repo)).toBe(primary.branch);
+				expect(fs.readFileSync(path.join(repo, ".git", "index"))).toEqual(primary.index);
+				expect(git(["status", "--porcelain=v1"], repo)).toBe(primary.status);
+				expect(fs.readFileSync(path.join(repo, "tracked-sentinel.txt"), "utf8")).toBe(primary.sentinel);
+				expect(calls.filter(call => call.method === "sendMessage")).toHaveLength(1);
+				expect(String(calls.find(call => call.method === "sendMessage")?.body?.text)).toContain(sessionId);
+			} finally {
+				lifecycleControl.stopLifecycleControl();
+				if (previousTmuxCommand === undefined) delete process.env.GJC_TMUX_COMMAND;
+				else process.env.GJC_TMUX_COMMAND = previousTmuxCommand;
+				if (previousPath === undefined) delete process.env.PATH;
+				else process.env.PATH = previousPath;
+				if (previousPathShadowSentinel === undefined) delete process.env.GJC_PATH_SHADOW_SENTINEL;
+				else process.env.GJC_PATH_SHADOW_SENTINEL = previousPathShadowSentinel;
+			}
+		},
+		60_000,
+	);
+});


### PR DESCRIPTION
## What

- Pin Telegram lifecycle supervisor and child launches to the active GJC runtime's absolute argv instead of resolving bare `gjc` through `PATH`.
- Keep linked-worktree creation and `chdir` in the existing child launch path.
- Make the child the sole final writer of worktree `@gjc-project` and `@gjc-branch` metadata.
- Fail managed worktree launches closed when the pane, cwd transition, or final tmux metadata cannot be established.
- Add an exact Telegram-to-tmux E2E regression covering runtime provenance, linked cwd/branch, and primary checkout invariance.

## Why

`/session_create worktree <repo> <branch>` correctly produced `--worktree=<branch>`, but the lifecycle daemon relaunched bare `gjc`. A stale or PATH-shadowed installation could therefore bypass the active checkout's worktree launch behavior and start the session in the primary checkout.

This preserves the existing architecture: the daemon transports the named-worktree request, while the managed child remains the sole authority for worktree creation, entry, and final project/branch metadata.

## Previous review

Supersedes #2918.

This revision addresses every owner-review blocker from that PR:

- rebased onto current `dev`
- incorporated the intervening daemon/session changes, including #2921, #2922, #2868, and #2818
- removed the contributor-local scratch reproduction document
- removed the generated docs-index change
- resolved the `CHANGELOG.md` and `daemon-control.test.ts` overlap
- reduced the final diff to product source, focused tests, test manifest, and changelog only

The technical approach itself is unchanged from the owner-approved direction in #2918.

## Testing

- `bun test packages/coding-agent/test/daemon-control.test.ts --test-name-pattern "daemon runtime detection"` — 3 passed
- Related lifecycle/worktree suite — 69 passed
- `bun --cwd=packages/coding-agent run check`
- `bun scripts/telegram-daemon-generation-guard.ts --validate-current-tree`
- `bun packages/coding-agent/scripts/generate-telegram-baseline-manifest.ts --check`
- `bun scripts/check-public-version-sync.ts`
- `git diff --check upstream/dev...HEAD`

The E2E verifies:

- the exact Telegram command
- a PATH-shadowed `gjc` is never invoked
- exact source runtime and managed-child argv
- linked-worktree cwd and requested branch
- final tmux project and branch metadata
- unchanged primary HEAD, branch, index, status, and tracked content

The full `daemon-control.test.ts` currently has unrelated latest-`dev` owner-fixture failures after the native ABI update. The changed runtime-detection tests and all directly affected lifecycle/worktree tests pass.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:9c2b8c590b5d8406903b025b1d51c6fa291f9b6d reviewer:architect evidence:exact-8-file-readonly-review
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — directly affected package/type and lifecycle guards pass; unrelated latest-`dev` daemon owner fixtures remain failing locally
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict above matches the exact PR head