### PR TITLE
fix(coding-agent): only abbreviate paths inside home in shortenPath

### DIFF
--- a/packages/coding-agent/src/tools/browser/screenshot-format.ts
+++ b/packages/coding-agent/src/tools/browser/screenshot-format.ts
@@ -1,10 +1,15 @@
 import * as os from "node:os";
+import * as path from "node:path";
 
 import { formatDimensionNote, type ResizedImage } from "../../utils/image-resize";
 
 function shortenPath(filePath: string): string {
 	const home = os.homedir();
-	return home && filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+	if (!home) return filePath;
+	// Require a separator boundary so a sibling that shares the home prefix
+	// (e.g. "/home/woodyx/x" for home "/home/woody") is not corrupted into "~x/x".
+	const boundary = home.endsWith(path.sep) ? home : home + path.sep;
+	return filePath === home || filePath.startsWith(boundary) ? `~${filePath.slice(home.length)}` : filePath;
 }
 
 export function formatScreenshot(opts: {

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -571,7 +571,13 @@ export function truncateDiffByHunk(
 export function shortenPath(filePath: string, homeDir?: string): string {
 	if (typeof filePath !== "string") return "";
 	const home = homeDir ?? os.homedir();
-	if (home && filePath.startsWith(home)) {
+	if (!home) return filePath;
+	// Only abbreviate paths that are exactly home or genuinely inside it. A bare
+	// startsWith(home) also matches siblings that merely share the prefix
+	// (e.g. "/home/woodyx/notes.txt" for home "/home/woody"), which would corrupt
+	// them into "~x/notes.txt"; require a path-separator boundary after home.
+	const boundary = home.endsWith(path.sep) ? home : home + path.sep;
+	if (filePath === home || filePath.startsWith(boundary)) {
 		return `~${filePath.slice(home.length)}`;
 	}
 	return filePath;

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -209,4 +209,14 @@ describe("render helper null-safety", () => {
 		// Sanity: real input still works.
 		expect(shortenPath("/home/u/x", "/home/u")).toBe("~/x");
 	});
+
+	it("shortenPath only abbreviates paths inside home, not siblings sharing the prefix", () => {
+		expect(shortenPath("/home/woody/a.txt", "/home/woody")).toBe("~/a.txt");
+		expect(shortenPath("/home/woody", "/home/woody")).toBe("~");
+		// Siblings that merely share the string prefix must be returned verbatim.
+		expect(shortenPath("/home/woodyx/notes.txt", "/home/woody")).toBe("/home/woodyx/notes.txt");
+		expect(shortenPath("/home/woody-backup/x", "/home/woody")).toBe("/home/woody-backup/x");
+		expect(shortenPath("/home/woodyshire", "/home/woody")).toBe("/home/woodyshire");
+		expect(shortenPath("/etc/passwd", "/home/woody")).toBe("/etc/passwd");
+	});
 });


### PR DESCRIPTION
## What

`shortenPath` (`packages/coding-agent/src/tools/render-utils.ts`) abbreviated a path to `~` notation with a bare `filePath.startsWith(home)` and **no path-separator boundary**. A sibling directory that merely shares a string prefix with `$HOME` was rewritten into a corrupt `~`-path:

```js
shortenPath("/home/woodyx/notes.txt", "/home/woody"); // "~x/notes.txt"   (should be unchanged)
shortenPath("/home/woody-backup/x",  "/home/woody");  // "~-backup/x"     (should be unchanged)
shortenPath("/home/woodyshire",      "/home/woody");  // "~shire"         (should be unchanged)
```

This value is not only TUI cosmetics — it feeds the model-facing system-prompt cwd and contribution redaction, so a cwd that is a sibling of `$HOME` is shown to the model as a corrupted path.

## Fix

Require an exact match or a real separator boundary after `home` before abbreviating. Fixed in **both** copies of the helper (`tools/render-utils.ts` and `tools/browser/screenshot-format.ts`), which had the same bug.

## Tests

`packages/coding-agent/test/tools/render-utils.test.ts` — added a case covering prefix-sharing siblings, exact-home (`/home/woody` → `~`), a real child (`~/a.txt`), and a path outside home. Existing cases still pass (`bun test .../render-utils.test.ts` → 12 pass). biome clean.
