### PR TITLE
fix: honor the remaining documented GJC_* environment variables

### DIFF
--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -1,5 +1,5 @@
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
-import { prompt } from "@gajae-code/utils";
+import { $pickenv, prompt } from "@gajae-code/utils";
 import type * as z from "zod/v4";
 import {
 	executeHashlineSingle,
@@ -352,11 +352,8 @@ export class EditTool implements AgentTool<TInput> {
 	readonly #pendingDeferredFetches = new Map<string, AbortController>();
 
 	constructor(private readonly session: ToolSession) {
-		const {
-			PI_EDIT_FUZZY: editFuzzy = "auto",
-			PI_EDIT_FUZZY_THRESHOLD: editFuzzyThreshold = "auto",
-			PI_EDIT_VARIANT: envEditVariant = "auto",
-		} = Bun.env;
+		const { PI_EDIT_FUZZY: editFuzzy = "auto", PI_EDIT_FUZZY_THRESHOLD: editFuzzyThreshold = "auto" } = Bun.env;
+		const envEditVariant = $pickenv("GJC_EDIT_VARIANT", "PI_EDIT_VARIANT") ?? "auto";
 
 		this.#editMode = resolveConfiguredEditMode(envEditVariant);
 		this.#allowFuzzy = resolveAllowFuzzy(session, editFuzzy);

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -705,7 +705,7 @@ function applyGjcTmuxRootTerminalTitleProfile(context: {
 }
 
 function shouldSetGjcTmuxRootTerminalTitle(parsed: Args, env: NodeJS.ProcessEnv): boolean {
-	return !parsed.noTitle && !env.PI_NO_TITLE;
+	return !parsed.noTitle && !(env.GJC_NO_TITLE || env.PI_NO_TITLE);
 }
 
 function buildTmuxRenameWindowArgs(title: string, target?: string): string[] {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -11,7 +11,6 @@ import * as path from "node:path";
 import { createInterface } from "node:readline/promises";
 import type { ImageContent } from "@gajae-code/ai";
 import {
-	$env,
 	$pickenv,
 	getAgentDir,
 	getProjectDir,
@@ -1613,9 +1612,9 @@ export async function runRootCommand(
 					process.stdout.write(`${chalk.dim(`Model scope: ${modelList} ${chalk.gray("(Alt+N to cycle)")}`)}\n`);
 				}
 
-				if ($env.PI_TIMING) {
+				if ($pickenv("GJC_TIMING", "PI_TIMING")) {
 					logger.printTimings();
-					exitForTiming = $env.PI_TIMING === "x";
+					exitForTiming = $pickenv("GJC_TIMING", "PI_TIMING") === "x";
 				}
 
 				if (!exitForTiming) {
@@ -1660,7 +1659,7 @@ export async function runRootCommand(
 					initialImages,
 					suppressProcessExit: deps.suppressProcessExit,
 				});
-				if ($env.PI_TIMING) {
+				if ($pickenv("GJC_TIMING", "PI_TIMING")) {
 					logger.printTimings();
 				}
 			} finally {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@gajae-code/tui";
-import { $env, logger, sanitizeText } from "@gajae-code/utils";
+import { $pickenv, logger, sanitizeText } from "@gajae-code/utils";
 import { type AppKeybinding, KEYBINDINGS } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
@@ -934,7 +934,7 @@ export class InputController {
 
 		// Generate session title on first message
 		const hasUserMessages = this.ctx.session.messages.some((m: AgentMessage) => m.role === "user");
-		if (!hasUserMessages && !this.ctx.sessionManager.getSessionName() && !$env.PI_NO_TITLE) {
+		if (!hasUserMessages && !this.ctx.sessionManager.getSessionName() && !$pickenv("GJC_NO_TITLE", "PI_NO_TITLE")) {
 			const registry = this.ctx.session.modelRegistry;
 			generateSessionTitle(
 				text,

--- a/packages/coding-agent/src/task/gjc-command.ts
+++ b/packages/coding-agent/src/task/gjc-command.ts
@@ -1,6 +1,6 @@
 import process from "node:process";
 
-import { $env } from "@gajae-code/utils";
+import { $pickenv } from "@gajae-code/utils";
 
 interface GjcCommand {
 	cmd: string;
@@ -12,7 +12,7 @@ const DEFAULT_CMD = process.platform === "win32" ? "gjc.cmd" : "gjc";
 const DEFAULT_SHELL = process.platform === "win32";
 
 export function resolveGjcCommand(): GjcCommand {
-	const envCmd = $env.PI_SUBPROCESS_CMD;
+	const envCmd = $pickenv("GJC_SUBPROCESS_CMD", "PI_SUBPROCESS_CMD");
 	if (envCmd?.trim()) {
 		return { cmd: envCmd, args: [], shell: DEFAULT_SHELL };
 	}

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -17,7 +17,7 @@ import * as os from "node:os";
 import path from "node:path";
 import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
 import type { Model, Usage } from "@gajae-code/ai";
-import { $env, prompt, Snowflake } from "@gajae-code/utils";
+import { $pickenv, prompt, Snowflake } from "@gajae-code/utils";
 import type { ToolSession } from "..";
 import { AsyncJobManager, OwnerSubagentShutdownError, type ResumeRunner } from "../async";
 import { resolveAgentModelPatterns } from "../config/model-resolver";
@@ -403,7 +403,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		private readonly session: ToolSession,
 		discoveredAgents: AgentDefinition[],
 	) {
-		this.#blockedAgent = $env.PI_BLOCKED_AGENT;
+		this.#blockedAgent = $pickenv("GJC_BLOCKED_AGENT", "PI_BLOCKED_AGENT");
 		this.#discoveredAgents = discoveredAgents;
 	}
 

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -1,6 +1,6 @@
 import type { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Usage } from "@gajae-code/ai";
-import { $env } from "@gajae-code/utils";
+import { $pickenv } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { isValidTaskId, TASK_ID_DESCRIPTION } from "./id";
 import type { TaskResultReceipt } from "./receipt";
@@ -27,10 +27,10 @@ const parseNumber = (value: string | undefined, defaultValue: number): number =>
 };
 
 /** Maximum output bytes per agent */
-export const MAX_OUTPUT_BYTES = parseNumber($env.PI_TASK_MAX_OUTPUT_BYTES, 500_000);
+export const MAX_OUTPUT_BYTES = parseNumber($pickenv("GJC_TASK_MAX_OUTPUT_BYTES", "PI_TASK_MAX_OUTPUT_BYTES"), 500_000);
 
 /** Maximum output lines per agent */
-export const MAX_OUTPUT_LINES = parseNumber($env.PI_TASK_MAX_OUTPUT_LINES, 5000);
+export const MAX_OUTPUT_LINES = parseNumber($pickenv("GJC_TASK_MAX_OUTPUT_LINES", "PI_TASK_MAX_OUTPUT_LINES"), 5000);
 
 /** EventBus channel for raw subagent events */
 export const TASK_SUBAGENT_EVENT_CHANNEL = "task:subagent:event";

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -3,7 +3,7 @@ import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallb
 import { type AstReplaceChange, type AstReplaceFileChange, astEdit } from "@gajae-code/natives";
 import type { Component } from "@gajae-code/tui";
 import { Text } from "@gajae-code/tui";
-import { $envpos, prompt, untilAborted } from "@gajae-code/utils";
+import { $pickenvpos, prompt, untilAborted } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { computeLineHash, HL_BODY_SEP } from "../hashline/hash";
@@ -199,7 +199,7 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 				seenPatterns.add(pat);
 			}
 			const normalizedRewrites = Object.fromEntries(ops);
-			const maxFiles = $envpos("PI_MAX_AST_FILES", 1000);
+			const maxFiles = $pickenvpos(["GJC_MAX_AST_FILES", "PI_MAX_AST_FILES"], 1000);
 
 			const scope = await resolveToolSearchScope({
 				rawPaths: params.paths,

--- a/packages/coding-agent/src/tools/bash-pty-selection.ts
+++ b/packages/coding-agent/src/tools/bash-pty-selection.ts
@@ -1,4 +1,4 @@
-import { $env } from "@gajae-code/utils/env";
+import { $pickenv } from "@gajae-code/utils/env";
 
 /** Minimal UI-capability fields needed to decide whether bash can use the local PTY overlay. */
 export interface BashPtyContext {
@@ -9,6 +9,6 @@ export interface BashPtyContext {
 /** Return whether a bash tool call should use the local interactive PTY overlay. */
 export function canUseInteractiveBashPty(pty: boolean, ctx: BashPtyContext | undefined): boolean {
 	if (!pty) return false;
-	if ($env.PI_NO_PTY === "1") return false;
+	if ($pickenv("GJC_NO_PTY", "PI_NO_PTY") === "1") return false;
 	return ctx?.hasUI === true && ctx.ui !== undefined;
 }

--- a/packages/coding-agent/src/utils/edit-mode.ts
+++ b/packages/coding-agent/src/utils/edit-mode.ts
@@ -1,4 +1,4 @@
-import { $env } from "@gajae-code/utils/env";
+import { $pickenv } from "@gajae-code/utils/env";
 
 export type EditMode = "replace" | "patch" | "hashline" | "vim" | "apply_patch";
 
@@ -34,7 +34,7 @@ export function resolveEditMode(session: EditModeSessionLike): EditMode {
 	const modelVariant = session.settings.getEditVariantForModel?.(activeModel);
 	if (modelVariant) return modelVariant;
 
-	const envMode = normalizeEditMode($env.PI_EDIT_VARIANT);
+	const envMode = normalizeEditMode($pickenv("GJC_EDIT_VARIANT", "PI_EDIT_VARIANT"));
 	if (envMode) return envMode;
 
 	const settingsMode = normalizeEditMode(String(session.settings.get("edit.mode") ?? ""));

--- a/packages/coding-agent/src/utils/sixel.ts
+++ b/packages/coding-agent/src/utils/sixel.ts
@@ -1,4 +1,4 @@
-import { $env, $flag } from "@gajae-code/utils";
+import { $pickenv, $pickflag } from "@gajae-code/utils";
 
 const SIXEL_START_REGEX = /\x1bP(?:[0-9;]*)q/u;
 const SIXEL_END_SEQUENCE = "\x1b\\";
@@ -14,8 +14,8 @@ const SIXEL_PLACEHOLDER_PREFIX = "__GJC_SIXEL_SEQUENCE_";
  * - PI_ALLOW_SIXEL_PASSTHROUGH=1
  */
 export function isSixelPassthroughEnabled(): boolean {
-	const forcedProtocol = $env.PI_FORCE_IMAGE_PROTOCOL?.trim().toLowerCase();
-	return forcedProtocol === "sixel" && $flag("PI_ALLOW_SIXEL_PASSTHROUGH");
+	const forcedProtocol = $pickenv("GJC_FORCE_IMAGE_PROTOCOL", "PI_FORCE_IMAGE_PROTOCOL")?.trim().toLowerCase();
+	return forcedProtocol === "sixel" && $pickflag("GJC_ALLOW_SIXEL_PASSTHROUGH", "PI_ALLOW_SIXEL_PASSTHROUGH");
 }
 /** Returns true when the text contains a SIXEL start sequence. */
 export function containsSixelSequence(text: string): boolean {

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -1,5 +1,5 @@
 import { encodeSixel } from "@gajae-code/natives";
-import { $env } from "@gajae-code/utils";
+import { $env, $pickenv } from "@gajae-code/utils";
 
 export enum ImageProtocol {
 	Kitty = "\x1b_G",
@@ -125,7 +125,7 @@ export function isCursorNeutralImagePermittedInFallback(): boolean {
 }
 
 function getForcedImageProtocol(): ImageProtocol | null | undefined {
-	const raw = $env.PI_FORCE_IMAGE_PROTOCOL?.trim().toLowerCase();
+	const raw = $pickenv("GJC_FORCE_IMAGE_PROTOCOL", "PI_FORCE_IMAGE_PROTOCOL")?.trim().toLowerCase();
 	if (!raw) return undefined;
 	if (raw === "kitty") return ImageProtocol.Kitty;
 	if (raw === "iterm2" || raw === "iterm") return ImageProtocol.Iterm2;

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1,6 +1,6 @@
 import { dlopen, FFIType, ptr } from "bun:ffi";
 import * as fs from "node:fs";
-import { $env, $flag } from "@gajae-code/utils";
+import { $env, $flag, $pickenv } from "@gajae-code/utils";
 import { setKittyProtocolActive } from "./keys";
 import { StdinBuffer } from "./stdin-buffer";
 import { isUnderTerminalMultiplexer } from "./terminal-capabilities";
@@ -209,7 +209,7 @@ export class ProcessTerminal implements Terminal {
 	#stdinBuffer?: StdinBuffer;
 	#stdinDataHandler?: (data: string | Buffer) => void;
 	#dead = false;
-	#writeLogPath = $env.PI_TUI_WRITE_LOG || "";
+	#writeLogPath = $pickenv("GJC_TUI_WRITE_LOG", "PI_TUI_WRITE_LOG") || "";
 	#detachLogPath = $env.PI_TUI_TERMINAL_DETACH_LOG || "";
 	#windowsVTInputRestore?: () => void;
 	#stdoutErrorHandler?: (err: Error) => void;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -4,7 +4,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { performance } from "node:perf_hooks";
-import { $flag, getDebugLogPath, logger, onDefaultTabWidthChange } from "@gajae-code/utils";
+import { $flag, $pickflag, getDebugLogPath, logger, onDefaultTabWidthChange } from "@gajae-code/utils";
 import { getKeybindings } from "./keybindings";
 import { isKeyRelease } from "./keys";
 import { renderMetrics } from "./metrics";
@@ -654,7 +654,7 @@ export class TUI extends Container {
 	#sixelProbeBuffer = "";
 	#sixelProbeTimeout?: NodeJS.Timeout;
 	#sixelProbeUnsubscribe?: () => void;
-	#showHardwareCursor = $flag("PI_HARDWARE_CURSOR");
+	#showHardwareCursor = $pickflag("GJC_HARDWARE_CURSOR", "PI_HARDWARE_CURSOR");
 	#debugRedraw = TUI.#readDebugRedrawFlag();
 	// macOS: steady-block cursor anchors CJK IME overlays; disable with GJC_TUI_IME_CURSOR=0.
 	readonly #useImeBlockCursor = $flag("GJC_TUI_IME_CURSOR", process.platform === "darwin");

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -279,3 +279,23 @@ export function $flag(name: string, def: boolean = false): boolean {
 	// would silently read as false while only `FOO=TRUE`/`FOO=1` worked.
 	return TRUTHY[value.toUpperCase()] === true;
 }
+
+/** Resolve the first flag among keys that has a set value (GJC-first, PI fallback). Matches $flag semantics per key. */
+export function $pickflag(...keys: string[]): boolean {
+	for (const key of keys) {
+		const value = $env[key]?.trim();
+		if (value) return TRUTHY[value.toUpperCase()] === true;
+	}
+	return false;
+}
+
+/** Resolve the first positive integer among keys, else defaultValue (GJC-first). Set-but-invalid keys are skipped. */
+export function $pickenvpos(keys: string[], defaultValue: number): number {
+	for (const key of keys) {
+		const raw = $env[key]?.trim();
+		if (!raw) continue;
+		const parsed = Number.parseInt(raw, 10);
+		if (!Number.isNaN(parsed) && parsed > 0) return parsed;
+	}
+	return defaultValue;
+}

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -13,6 +13,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import * as fs from "node:fs";
 import type * as winston from "winston";
 import { getLogsDir } from "./dirs";
+import { $pickenv } from "./env";
 
 /** Ensure a logs directory exists; return the resolved path. */
 function ensureDir(dir: string): string {
@@ -410,7 +411,7 @@ function printModuleLoadSummary(loads: Span[], depth: number, lines: string[]): 
 	}
 	const wall = unionEnd > unionStart ? unionEnd - unionStart : 0;
 	lines.push(`${childIndent}(modules): ${loads.length} loaded, wall ${fmtMs(wall)}, sum ${fmtMs(totalSelf)}`);
-	const showAll = process.env.PI_TIMING === "full";
+	const showAll = $pickenv("GJC_TIMING", "PI_TIMING") === "full";
 	const sorted = [...loads].sort((a, b) => durationOf(b) - durationOf(a));
 	const visible = showAll ? sorted : sorted.slice(0, MODULE_LOAD_VERBOSE_TOP);
 	for (const span of visible) {

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import { $flag, filterProcessEnv, parseEnvFile, parseShellEnvFile } from "../src/env";
+import { $flag, $pickenvpos, $pickflag, filterProcessEnv, parseEnvFile, parseShellEnvFile } from "../src/env";
 
 const tempDirs: string[] = [];
 
@@ -341,5 +341,77 @@ describe("$flag", () => {
 	it("returns the default when the variable is unset", () => {
 		expect($flag(NAME)).toBe(false);
 		expect($flag(NAME, true)).toBe(true);
+	});
+});
+
+describe("$pickflag", () => {
+	const GJC_NAME = "__GJC_UTILS_PICKFLAG_PROBE";
+	const PI_NAME = "__PI_UTILS_PICKFLAG_PROBE";
+	afterEach(() => {
+		delete process.env[GJC_NAME];
+		delete process.env[PI_NAME];
+	});
+
+	it("prefers the GJC-first key when both are set", () => {
+		process.env[GJC_NAME] = "1";
+		process.env[PI_NAME] = "0";
+		expect($pickflag(GJC_NAME, PI_NAME)).toBe(true);
+	});
+
+	it("lets a falsy GJC value win over a truthy PI value (first set key decides)", () => {
+		process.env[GJC_NAME] = "0";
+		process.env[PI_NAME] = "1";
+		expect($pickflag(GJC_NAME, PI_NAME)).toBe(false);
+	});
+
+	it("falls back to the PI key when the GJC key is unset", () => {
+		process.env[PI_NAME] = "true";
+		expect($pickflag(GJC_NAME, PI_NAME)).toBe(true);
+	});
+
+	it("returns false when neither key is set", () => {
+		expect($pickflag(GJC_NAME, PI_NAME)).toBe(false);
+	});
+
+	it("applies TRUTHY case-insensitive matching per matched key", () => {
+		process.env[GJC_NAME] = "YES";
+		expect($pickflag(GJC_NAME, PI_NAME)).toBe(true);
+		process.env[GJC_NAME] = "enabled";
+		expect($pickflag(GJC_NAME, PI_NAME)).toBe(false);
+	});
+});
+
+describe("$pickenvpos", () => {
+	const GJC_NAME = "__GJC_UTILS_PICKENVPOS_PROBE";
+	const PI_NAME = "__PI_UTILS_PICKENVPOS_PROBE";
+	afterEach(() => {
+		delete process.env[GJC_NAME];
+		delete process.env[PI_NAME];
+	});
+
+	it("prefers a positive GJC-first value when both are set", () => {
+		process.env[GJC_NAME] = "7";
+		process.env[PI_NAME] = "9";
+		expect($pickenvpos([GJC_NAME, PI_NAME], 100)).toBe(7);
+	});
+
+	it("falls back to the PI key when the GJC key is unset", () => {
+		process.env[PI_NAME] = "42";
+		expect($pickenvpos([GJC_NAME, PI_NAME], 100)).toBe(42);
+	});
+
+	it("returns the default when neither key is set", () => {
+		expect($pickenvpos([GJC_NAME, PI_NAME], 100)).toBe(100);
+	});
+
+	it("returns the default when the only set value is invalid", () => {
+		process.env[GJC_NAME] = "not-a-number";
+		expect($pickenvpos([GJC_NAME, PI_NAME], 100)).toBe(100);
+	});
+
+	it("skips a set-but-invalid GJC key and falls through to a valid PI key", () => {
+		process.env[GJC_NAME] = "-5";
+		process.env[PI_NAME] = "3";
+		expect($pickenvpos([GJC_NAME, PI_NAME], 100)).toBe(3);
 	});
 });


### PR DESCRIPTION
## What

Following #2827 (which fixed `GJC_{SMOL,SLOW,PLAN}_MODEL`), **13 more** environment variables are documented in `docs/environment-variables.md` / `docs/tools/*` and advertised in `gjc --help`, but the code read only the legacy `PI_*` name — so setting the documented `GJC_*` variable was a silent no-op:

```
GJC_NO_PTY, GJC_NO_TITLE, GJC_TIMING, GJC_EDIT_VARIANT, GJC_FORCE_IMAGE_PROTOCOL,
GJC_ALLOW_SIXEL_PASSTHROUGH, GJC_TUI_WRITE_LOG, GJC_HARDWARE_CURSOR,
GJC_BLOCKED_AGENT, GJC_SUBPROCESS_CMD, GJC_TASK_MAX_OUTPUT_BYTES,
GJC_TASK_MAX_OUTPUT_LINES, GJC_MAX_AST_FILES
```

## Fix

Resolve `GJC_*` first with `PI_*` as a fallback, matching the repo-wide GJC-first / PI-fallback convention (`config.ts`, `dirs.ts`, `gc-runtime.ts`, `lsp/lspmux.ts`, …):

- String reads use the existing `$pickenv("GJC_X", "PI_X")`.
- Added `$pickflag` and `$pickenvpos` — the GJC-first analogs of `$flag`/`$envpos`, mirroring the existing `$pickenv`/`$pickCredentialEnv` naming — for the flag and positive-int read sites. `$pickflag` decides on the first key that has any set value (so `GJC_X` set wins even if `PI_X` is also set), and `$pickenvpos` skips a set-but-invalid key to reach a valid one.
- `launch-tmux` keeps its injected-env dependency-injection contract (used by `launch-tmux.test.ts`) by resolving GJC-first against its local `env` parameter rather than global env.

`PI_*` names are retained as fallbacks; behavior is unchanged when only `PI_*` is set.

## Tests

`packages/utils/test/env.test.ts` — added `$pickflag`/`$pickenvpos` unit tests (GJC-first, PI fallback, none-set, invalid-skip, case-insensitive).

Verification: `tsc -p tsconfig.json --noEmit` clean for coding-agent, tui, and utils; `bun test .../env.test.ts` → 23 pass; `launch-tmux` + `bash-pty-selection` → 133 pass; biome clean.
