### PR TITLE
fix(coding-agent): create async put() blobs owner-only (0700/0600)

### DIFF
--- a/packages/coding-agent/src/session/blob-store.ts
+++ b/packages/coding-agent/src/session/blob-store.ts
@@ -124,8 +124,13 @@ export class BlobStore {
 			},
 		};
 
-		await Bun.write(blobPath, data);
-		await fsp.chmod(blobPath, BLOB_FILE_MODE);
+		// Create the blob directory 0700 and the file 0600 at creation, mirroring
+		// putSync/putImmutableSync. The previous Bun.write let the parent dir be
+		// created with the process umask (e.g. 0755) and the file at 0644 before a
+		// follow-up chmod, violating the owner-only contract above and leaving a
+		// group/other-readable window a managed-tree snapshot fails closed on.
+		await fsp.mkdir(this.dir, { recursive: true, mode: BLOB_DIR_MODE });
+		await fsp.writeFile(blobPath, data, { mode: BLOB_FILE_MODE });
 		return result;
 	}
 

--- a/packages/coding-agent/test/blob-store-owner-only.test.ts
+++ b/packages/coding-agent/test/blob-store-owner-only.test.ts
@@ -50,6 +50,21 @@ describe.skipIf(process.platform === "win32")("blob store owner-only permissions
 		}
 	});
 
+	it("creates base BlobStore async put() blobs owner-only under a permissive umask", async () => {
+		const previousUmask = process.umask(0o002);
+		try {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-blob-mode-async-"));
+			temporaryDirectories.push(root);
+			const store = new BlobStore(path.join(root, "blobs"));
+			const { path: blobPath } = await store.put(Buffer.from("async blob"));
+
+			expect(fs.statSync(path.join(root, "blobs")).mode & 0o777).toBe(0o700);
+			expect(fs.statSync(blobPath).mode & 0o777).toBe(0o600);
+		} finally {
+			process.umask(previousUmask);
+		}
+	});
+
 	it("installs immutable blobs owner-only under a permissive umask", () => {
 		const previousUmask = process.umask(0o002);
 		try {


### PR DESCRIPTION
## What

`BlobStore.put()` (async) violated the module's own owner-only creation contract (`blob-store.ts:8-18`: "blobs and their directories MUST be created 0700/0600 rather than inheriting a group/other-readable mode from the process umask"). Unlike `putSync`/`putImmutableSync`, which `mkdir` the dir `0700` and create the file `0600` at creation, the async path:

```ts
await Bun.write(blobPath, data);          // implicitly creates the parent dir with the umask (e.g. 0755)
await fsp.chmod(blobPath, BLOB_FILE_MODE); // and the file at 0644, narrowed to 0600 only afterwards
```

That leaves the blob directory persistently non-owner-only and the file group/other-readable during a creation window. A managed session scope's owner-only tree snapshot fails closed on any group/other-readable descendant, and `put()` is reachable from image externalization and async session persistence.

## Fix

Create the directory `0700` and the file `0600` at creation via `fsp.mkdir` + `fsp.writeFile`, mirroring `putSync`/`putImmutableSync` (which also create-with-mode and do not chmod afterwards):

```ts
await fsp.mkdir(this.dir, { recursive: true, mode: BLOB_DIR_MODE });
await fsp.writeFile(blobPath, data, { mode: BLOB_FILE_MODE });
```

## Tests

`packages/coding-agent/test/blob-store-owner-only.test.ts` — added the async `put()` case to the existing owner-only permission suite (under a permissive `umask(0o002)`). It **fails on the old code** (dir `0o755` ≠ `0o700`) and **passes with the fix** (4 pass). coding-agent `tsc` clean; biome clean.
