### PR TITLE
fix(session): tolerate Darwin ctime-only identity bump on managed append

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- On macOS, resuming a managed session no longer fails with `identity_mismatch` when the first write-append open changes only file `ctime` (e.g. APFS write-provenance / `com.apple.provenance`). `appendSync` allows a single bounded re-capture + retry when `dev`/`ino`/`size`/`mtime`/SHA-256 remain unchanged, and still rejects real content races and repeated ctime transitions (#2944).
+
 ## [0.11.7] - 2026-07-22
 ### Added
 

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -675,7 +675,7 @@ export class ManagedSessionDescendantStore {
 	appendSync(relativePath: string, bytes: Uint8Array): void {
 		this.#assertBound();
 		const resolved = this.#resolve(relativePath);
-		const existing = this.readExpected(relativePath);
+		let existing = this.readExpected(relativePath);
 		if (!existing) throw new Error("managed_append_missing");
 		if (this.#authority) {
 			const appended = this.#authority.appendManaged(
@@ -692,20 +692,49 @@ export class ManagedSessionDescendantStore {
 			this.#assertBound();
 			return;
 		}
+		// On Darwin, the first write-append open can change only ctime (e.g. com.apple.provenance)
+		// while leaving dev/ino/size/mtime/content intact. Allow one bounded refresh+retry for that
+		// transition only; any other identity change or a second ctime transition stays fail-closed.
+		// See https://github.com/Yeachan-Heo/gajae-code/issues/2944
 		let fd: number | undefined;
+		let darwinCtimeRefreshConsumed = false;
 		try {
-			fd = fs.openSync(resolved, fs.constants.O_WRONLY | fs.constants.O_APPEND | fs.constants.O_NOFOLLOW);
-			const before = identity(fs.fstatSync(fd, { bigint: true }));
-			if (!sameIdentity(before, existing.identity)) throw new Error("identity_mismatch");
-			secureFileDescriptor(resolved, fd, "verify");
-			let offset = 0;
-			while (offset < bytes.byteLength) offset += fs.writeSync(fd, bytes, offset, bytes.byteLength - offset);
-			fs.fsyncSync(fd);
-			secureFileDescriptor(resolved, fd, "verify");
-			const after = identity(fs.fstatSync(fd, { bigint: true }));
-			const named = identity(fs.lstatSync(resolved, { bigint: true }));
-			if (!sameIdentity(after, named) || after.dev !== before.dev || after.ino !== before.ino)
-				throw new Error("identity_mismatch");
+			for (;;) {
+				fd = fs.openSync(resolved, fs.constants.O_WRONLY | fs.constants.O_APPEND | fs.constants.O_NOFOLLOW);
+				const before = identity(fs.fstatSync(fd, { bigint: true }));
+				if (!sameIdentity(before, existing.identity)) {
+					const allowDarwinCtimeRefresh =
+						process.platform === "darwin" &&
+						!darwinCtimeRefreshConsumed &&
+						isCtimeOnlyIdentityMismatch(before, existing.identity);
+					if (!allowDarwinCtimeRefresh) throw new Error("identity_mismatch");
+					fs.closeSync(fd);
+					fd = undefined;
+					darwinCtimeRefreshConsumed = true;
+					const original = existing;
+					const refreshed = this.readExpected(relativePath);
+					if (
+						!refreshed ||
+						!sameStableIdentityIgnoringCtime(refreshed.identity, original.identity) ||
+						refreshed.identity.sha256 !== original.identity.sha256 ||
+						!refreshed.bytes.equals(original.bytes)
+					) {
+						throw new Error("identity_mismatch");
+					}
+					existing = refreshed;
+					continue;
+				}
+				secureFileDescriptor(resolved, fd, "verify");
+				let offset = 0;
+				while (offset < bytes.byteLength) offset += fs.writeSync(fd, bytes, offset, bytes.byteLength - offset);
+				fs.fsyncSync(fd);
+				secureFileDescriptor(resolved, fd, "verify");
+				const after = identity(fs.fstatSync(fd, { bigint: true }));
+				const named = identity(fs.lstatSync(resolved, { bigint: true }));
+				if (!sameIdentity(after, named) || after.dev !== before.dev || after.ino !== before.ino)
+					throw new Error("identity_mismatch");
+				break;
+			}
 		} finally {
 			if (fd !== undefined) fs.closeSync(fd);
 		}
@@ -1146,6 +1175,24 @@ function sameIdentity(left: ManagedFileSnapshot["identity"], right: ManagedFileS
 		left.mtimeNs === right.mtimeNs &&
 		left.ctimeNs === right.ctimeNs
 	);
+}
+
+/** Content/path identity that remains meaningful across a Darwin write-open ctime-only transition. */
+function sameStableIdentityIgnoringCtime(
+	left: ManagedFileSnapshot["identity"],
+	right: ManagedFileSnapshot["identity"],
+): boolean {
+	return (
+		left.dev === right.dev && left.ino === right.ino && left.size === right.size && left.mtimeNs === right.mtimeNs
+	);
+}
+
+/** True when observed identity matches expected on every field except ctimeNs. */
+function isCtimeOnlyIdentityMismatch(
+	observed: ManagedFileSnapshot["identity"],
+	expected: ManagedFileSnapshot["identity"],
+): boolean {
+	return sameStableIdentityIgnoringCtime(observed, expected) && observed.ctimeNs !== expected.ctimeNs;
 }
 
 function parseLock(pathname: string): LockRecord | undefined {

--- a/packages/coding-agent/test/session/managed-append-darwin-ctime.test.ts
+++ b/packages/coding-agent/test/session/managed-append-darwin-ctime.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression for https://github.com/Yeachan-Heo/gajae-code/issues/2944
+ *
+ * On Darwin, the first O_WRONLY|O_APPEND open of a managed transcript can change
+ * only ctime (write-provenance / com.apple.provenance) while leaving dev, ino,
+ * size, mtime, and content unchanged. appendSync must accept a single bounded
+ * refresh+retry for that case and stay fail-closed for real races.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	ManagedSessionDescendantStore,
+	managedDirectoryRoot,
+} from "../../src/session/internal/managed-session-storage";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(
+		temporaryDirectories.splice(0).map(directory => fsp.rm(directory, { recursive: true, force: true })),
+	);
+});
+
+async function createStore(): Promise<{
+	root: string;
+	store: ManagedSessionDescendantStore;
+	filePath: string;
+	relativePath: string;
+}> {
+	const root = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-append-darwin-ctime-"));
+	temporaryDirectories.push(root);
+	// Owner-only directory expected by managed security.
+	await fsp.chmod(root, 0o700);
+	const store = new ManagedSessionDescendantStore(managedDirectoryRoot(root), root);
+	const relativePath = "transcript.jsonl";
+	const initial = Buffer.from(`${JSON.stringify({ type: "session", id: "seed" })}\n`, "utf8");
+	store.publishNoReplaceSync(relativePath, initial);
+	return { root, store, filePath: path.join(root, relativePath), relativePath };
+}
+
+function isWriteAppendOpen(_file: fs.PathLike, flags: fs.OpenMode | undefined): boolean {
+	if (typeof flags !== "number") return false;
+	const write = (flags & fs.constants.O_WRONLY) !== 0 || (flags & fs.constants.O_RDWR) !== 0;
+	const append = (flags & fs.constants.O_APPEND) !== 0;
+	return write && append;
+}
+
+function installWriteOpenHook(
+	targetPath: string,
+	hook: (pathname: string) => void,
+	options?: { maxCalls?: number },
+): { calls: number } {
+	const state = { calls: 0 };
+	const maxCalls = options?.maxCalls ?? Number.POSITIVE_INFINITY;
+	const realOpenSync = fs.openSync.bind(fs);
+	vi.spyOn(fs, "openSync").mockImplementation(((
+		file: fs.PathLike,
+		flags?: fs.OpenMode | undefined,
+		mode?: fs.Mode | undefined,
+	) => {
+		const pathname = typeof file === "string" ? file : file.toString();
+		if (pathname === targetPath && isWriteAppendOpen(file, flags) && state.calls < maxCalls) {
+			state.calls += 1;
+			hook(pathname);
+		}
+		return realOpenSync(file, flags as never, mode as never);
+	}) as typeof fs.openSync);
+	return state;
+}
+
+/** Same-mode chmod: on Darwin/APFS this typically advances ctime only. */
+function bumpCtimeOnly(pathname: string): void {
+	const mode = fs.lstatSync(pathname).mode;
+	fs.chmodSync(pathname, mode & 0o7777);
+}
+
+describe("ManagedSessionDescendantStore.appendSync fail-closed races", () => {
+	it("rejects size mutation between capture and write-open without appending the request", async () => {
+		const { store, filePath, relativePath } = await createStore();
+		const beforeBytes = fs.readFileSync(filePath);
+		const record = Buffer.from(`${JSON.stringify({ type: "message", id: "m-race" })}\n`, "utf8");
+
+		installWriteOpenHook(filePath, pathname => {
+			fs.appendFileSync(pathname, "stale-race\n");
+		});
+
+		expect(() => store.appendSync(relativePath, record)).toThrow("identity_mismatch");
+		const after = fs.readFileSync(filePath, "utf8");
+		expect(after.includes('"id":"m-race"')).toBe(false);
+		expect(after.startsWith(beforeBytes.toString("utf8"))).toBe(true);
+	});
+});
+
+describe.skipIf(process.platform !== "darwin")(
+	"ManagedSessionDescendantStore.appendSync Darwin ctime-only refresh (#2944)",
+	() => {
+		it("accepts a one-time ctime-only transition before write-open and appends exactly once", async () => {
+			const { store, filePath, relativePath } = await createStore();
+			const beforeBytes = fs.readFileSync(filePath);
+			const record = Buffer.from(`${JSON.stringify({ type: "message", id: "m1" })}\n`, "utf8");
+
+			// One-shot ctime bump on the first write-append open only.
+			const openState = installWriteOpenHook(
+				filePath,
+				pathname => {
+					bumpCtimeOnly(pathname);
+				},
+				{ maxCalls: 1 },
+			);
+
+			store.appendSync(relativePath, record);
+
+			expect(openState.calls).toBe(1);
+			const afterBytes = fs.readFileSync(filePath);
+			expect(afterBytes.equals(Buffer.concat([beforeBytes, record]))).toBe(true);
+			expect(afterBytes.toString("utf8").trimEnd().split("\n")).toHaveLength(2);
+		});
+
+		it("rejects a second ctime-only transition after the single bounded refresh", async () => {
+			const { store, filePath, relativePath } = await createStore();
+			const beforeBytes = fs.readFileSync(filePath);
+			const record = Buffer.from(`${JSON.stringify({ type: "message", id: "m3" })}\n`, "utf8");
+
+			// Every write-append open bumps ctime → refresh once, then fail closed.
+			installWriteOpenHook(filePath, pathname => {
+				bumpCtimeOnly(pathname);
+			});
+
+			expect(() => store.appendSync(relativePath, record)).toThrow("identity_mismatch");
+			expect(fs.readFileSync(filePath).equals(beforeBytes)).toBe(true);
+		});
+
+		it("documents that same-mode chmod can change only ctime on this host", async () => {
+			const { store, filePath, relativePath } = await createStore();
+			const captured = store.readExpected(relativePath);
+			if (!captured) throw new Error("expected seed transcript");
+			bumpCtimeOnly(filePath);
+			const after = fs.lstatSync(filePath, { bigint: true });
+			expect(after.dev).toBe(captured.identity.dev);
+			expect(after.ino).toBe(captured.identity.ino);
+			expect(Number(after.size)).toBe(captured.identity.size);
+			expect(after.mtimeNs).toBe(captured.identity.mtimeNs);
+			// Some hosts/FS configurations may not advance ctime for a no-op mode rewrite;
+			// the openSync-hook tests above still cover the repair path deterministically when
+			// ctime does move. Soft-assert here so CI hosts without the delta do not fail.
+			if (after.ctimeNs === captured.identity.ctimeNs) return;
+			expect(after.ctimeNs).not.toBe(captured.identity.ctimeNs);
+		});
+	},
+);


### PR DESCRIPTION
## Summary

Fixes #2944.

On macOS, resuming a managed session can fail immediately with `identity_mismatch` in `ManagedSessionDescendantStore.appendSync()` when the first write-append open changes **only** file `ctime` (APFS write-provenance / `com.apple.provenance`) while `dev`, `ino`, `size`, `mtime`, and content stay the same.

## What

In the non-authority (non-Linux) `appendSync` path:

1. Detect a **ctime-only** pre-write identity mismatch on Darwin.
2. Close the write fd, re-capture once, and require unchanged `dev`/`ino`/`size`/`mtimeNs`/SHA-256/bytes vs the original capture.
3. Retry write-open once and require a normal exact identity match.
4. Reject any non-ctime identity change, and reject a second ctime transition after the single refresh.

Linux retained-authority `appendManaged` path is unchanged.

## Why

macOS write-open provenance can advance ctime without a content race. Treating that as a hard identity mismatch bricks resume of valid managed transcripts.

## Tests

```sh
bun test packages/coding-agent/test/session/managed-append-darwin-ctime.test.ts
# 4 pass (Darwin suite + cross-platform size-mutation fail-closed)
```

- One-time ctime-only transition (simulated via same-mode `chmod` before write-open): append succeeds, exactly one JSONL record added.
- Size mutation between capture and open: still `identity_mismatch`; requested record not written.
- Repeated ctime mutation on every write-open: rejected after the single bounded refresh.

## Changelog

`packages/coding-agent/CHANGELOG.md` — `[Unreleased]` Fixed entry for #2944.