### PR TITLE
fix(edit): serialize concurrent same-path mutations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - On macOS, resuming a managed session no longer fails with `identity_mismatch` when the first write-append open changes only file `ctime` (e.g. APFS write-provenance / `com.apple.provenance`). `appendSync` allows a single bounded re-capture + retry when `dev`/`ino`/`size`/`mtime`/SHA-256 remain unchanged, and still rejects real content races and repeated ctime transitions (#2944).
+- Concurrent edits to the same file path are serialized through a path-scoped mutation lock (in-process always; durable cross-process lock on the real filesystem). Disjoint concurrent `applyPatch` / replace mutations no longer silently overwrite each other, and a commit-time content check rejects writers that observe a mid-flight change (#2900).
 
 ## [0.11.7] - 2026-07-22
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - On macOS, resuming a managed session no longer fails with `identity_mismatch` when the first write-append open changes only file `ctime` (e.g. APFS write-provenance / `com.apple.provenance`). `appendSync` allows a single bounded re-capture + retry when `dev`/`ino`/`size`/`mtime`/SHA-256 remain unchanged, and still rejects real content races and repeated ctime transitions (#2944).
-- Concurrent edits to the same file path are serialized through a path-scoped mutation lock (in-process always; durable cross-process lock on the real filesystem). Disjoint concurrent `applyPatch` / replace mutations no longer silently overwrite each other, and a commit-time content check rejects writers that observe a mid-flight change (#2900).
+- Concurrent edits to the same file path are serialized through a path-scoped mutation lock (in-process always; durable cross-process lock on the real filesystem). Disjoint concurrent `applyPatch` / replace mutations no longer silently overwrite each other, and a commit-time content check rejects writers that observe a mid-flight change. The production `executePatchSingle` / `LspFileSystem` path explicitly enables the durable lock rather than inferring it from FileSystem object identity (#2900).
 
 ## [0.11.7] - 2026-07-22
 ### Added

--- a/packages/coding-agent/src/edit/modes/patch.ts
+++ b/packages/coding-agent/src/edit/modes/patch.ts
@@ -44,6 +44,7 @@ import {
 	restoreLineEndings,
 	stripBom,
 } from "../normalize";
+import { withEditPathMutation } from "../path-mutation-lock";
 import { readEditFileText, serializeEditFileText } from "../read-file";
 import type { EditToolDetails, LspBatchRequest } from "../renderer";
 import {
@@ -93,6 +94,12 @@ export interface ApplyPatchOptions {
 	fuzzyThreshold?: number;
 	allowFuzzy?: boolean;
 	fs?: FileSystem;
+	/**
+	 * When false, skip durable cross-process file locks (in-process path mutex
+	 * still serializes). Defaults to true for the real filesystem and false for
+	 * injectible `fs` implementations.
+	 */
+	crossProcessLock?: boolean;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1409,13 +1416,27 @@ function applyHunksToContent(
 
 /**
  * Apply a patch operation to the filesystem.
+ *
+ * Concurrent mutations of the same absolute path are serialized (in-process always;
+ * cross-process file lock when using the real filesystem) so disjoint concurrent
+ * edits cannot silently overwrite each other (#2900).
  */
 export async function applyPatch(input: PatchInput, options: ApplyPatchOptions): Promise<ApplyPatchResult> {
-	return applyNormalizedPatch(input, options);
+	const resolvePath = (p: string): string => resolveToCwd(p, options.cwd);
+	const absolutePath = resolvePath(input.path);
+	const mutationPaths = [absolutePath];
+	if (input.rename) {
+		const destPath = resolvePath(input.rename);
+		if (destPath !== absolutePath) mutationPaths.push(destPath);
+	}
+	const usingDefaultFs = options.fs === undefined || options.fs === defaultFileSystem;
+	const crossProcess = options.crossProcessLock ?? usingDefaultFs;
+	return withEditPathMutation(mutationPaths, () => applyNormalizedPatch(input, options), { crossProcess });
 }
 
 /**
  * Apply a normalized patch operation to the filesystem.
+ * Caller must already hold path mutation rights when concurrent writers exist.
  * @internal
  */
 async function applyNormalizedPatch(input: PatchInput, options: ApplyPatchOptions): Promise<ApplyPatchResult> {
@@ -1514,6 +1535,12 @@ async function applyNormalizedPatch(input: PatchInput, options: ApplyPatchOption
 	const isMove = Boolean(input.rename) && destPath !== absolutePath;
 
 	if (!dryRun) {
+		// Commit-time CAS: reject if another writer mutated the file after our
+		// authoritative read (e.g. a process that did not take the path lock).
+		const commitContent = await readExistingPatchFile(fs, absolutePath, input.path);
+		if (commitContent !== originalContent) {
+			throw new ApplyPatchError(`concurrent edit conflict: file changed since read: ${input.path}`);
+		}
 		if (isMove) {
 			const parentDir = path.dirname(destPath);
 			if (parentDir && parentDir !== ".") {

--- a/packages/coding-agent/src/edit/modes/patch.ts
+++ b/packages/coding-agent/src/edit/modes/patch.ts
@@ -96,8 +96,11 @@ export interface ApplyPatchOptions {
 	fs?: FileSystem;
 	/**
 	 * When false, skip durable cross-process file locks (in-process path mutex
-	 * still serializes). Defaults to true for the real filesystem and false for
-	 * injectible `fs` implementations.
+	 * still serializes). Defaults to true only for the real `defaultFileSystem`
+	 * (or when `fs` is omitted). Disk-backed adapters that are not
+	 * `defaultFileSystem` (notably production `LspFileSystem` via
+	 * `executePatchSingle`) MUST pass `crossProcessLock: true` explicitly —
+	 * object identity is not a durable-lock capability probe.
 	 */
 	crossProcessLock?: boolean;
 }
@@ -1762,11 +1765,16 @@ export async function executePatchSingle(
 
 	const input: PatchInput = { path: resolvedPath, op, rename: resolvedRename, diff };
 	const patchFileSystem = new LspFileSystem(writethrough, signal, batchRequest, beginDeferredDiagnosticsForPath);
+	// Production edit path uses LspFileSystem (disk-backed writethrough), which is
+	// not `defaultFileSystem` by object identity. Force durable cross-process
+	// locking so multi-process agents cannot silently race past the path mutex
+	// (#2900 review: do not infer lock capability from FileSystem identity).
 	const result = await applyPatch(input, {
 		cwd: session.cwd,
 		fs: patchFileSystem,
 		fuzzyThreshold,
 		allowFuzzy,
+		crossProcessLock: true,
 	});
 
 	// Post-write verification: only meaningful for in-place updates where the

--- a/packages/coding-agent/src/edit/modes/replace.ts
+++ b/packages/coding-agent/src/edit/modes/replace.ts
@@ -55,6 +55,7 @@ void import("@gajae-code/natives")
 		// Native unavailable; fuzzy matching uses the TS fallback.
 	});
 
+import { withEditPathMutation } from "../path-mutation-lock";
 import { readEditFileText, serializeEditFileText } from "../read-file";
 import type { EditToolDetails, LspBatchRequest } from "../renderer";
 
@@ -1087,6 +1088,47 @@ export async function executeReplaceSingle(
 	}
 
 	const absolutePath = resolvePlanPath(session, path);
+	return withEditPathMutation([absolutePath], () =>
+		executeReplaceSingleUnderLock({
+			session,
+			path,
+			params,
+			signal,
+			batchRequest,
+			allowFuzzy,
+			fuzzyThreshold,
+			writethrough,
+			beginDeferredDiagnosticsForPath,
+			absolutePath,
+			old_text,
+			new_text,
+			all,
+		}),
+	);
+}
+
+async function executeReplaceSingleUnderLock(
+	options: ExecuteReplaceSingleOptions & {
+		absolutePath: string;
+		old_text: string;
+		new_text: string;
+		all: boolean | undefined;
+	},
+): Promise<AgentToolResult<EditToolDetails, typeof replaceEditEntrySchema>> {
+	const {
+		path,
+		signal,
+		batchRequest,
+		allowFuzzy,
+		fuzzyThreshold,
+		writethrough,
+		beginDeferredDiagnosticsForPath,
+		absolutePath,
+		old_text,
+		new_text,
+		all,
+	} = options;
+
 	const rawContent = await readEditFileText(absolutePath, path);
 	const { bom, text: content } = stripBom(rawContent);
 	const originalEnding = detectLineEnding(content);

--- a/packages/coding-agent/src/edit/path-mutation-lock.ts
+++ b/packages/coding-agent/src/edit/path-mutation-lock.ts
@@ -1,0 +1,112 @@
+/**
+ * Path-scoped mutation coordinator for edit tools.
+ *
+ * Serializes concurrent read→compute→write windows against the same absolute
+ * path so independent sessions cannot silently overwrite each other's successful
+ * disjoint edits (https://github.com/Yeachan-Heo/gajae-code/issues/2900).
+ *
+ * - Always: in-process async mutex keyed by resolved absolute path.
+ * - Optionally: durable cross-process `<path>.lock` via `withFileLock` for real
+ *   filesystem mutations (subagents / separate processes).
+ *
+ * Nested acquisition of the same path is not supported; callers that already
+ * hold the lock must not re-enter.
+ */
+import * as path from "node:path";
+import { type FileLockOptions, withFileLock } from "../config/file-lock";
+
+type AsyncMutex = {
+	acquire(): Promise<() => void>;
+};
+
+const pathMutexes = new Map<string, AsyncMutex>();
+
+function createAsyncMutex(): AsyncMutex {
+	let locked = false;
+	const waiters: Array<() => void> = [];
+	return {
+		async acquire(): Promise<() => void> {
+			if (!locked) {
+				locked = true;
+				return () => release();
+			}
+			await new Promise<void>(resolve => {
+				waiters.push(resolve);
+			});
+			return () => release();
+		},
+	};
+
+	function release(): void {
+		const next = waiters.shift();
+		if (next) {
+			next();
+			return;
+		}
+		locked = false;
+	}
+}
+
+function mutexFor(absolutePath: string): AsyncMutex {
+	const key = path.resolve(absolutePath);
+	let mutex = pathMutexes.get(key);
+	if (!mutex) {
+		mutex = createAsyncMutex();
+		pathMutexes.set(key, mutex);
+	}
+	return mutex;
+}
+
+async function withInProcessPathLock<T>(absolutePath: string, fn: () => Promise<T>): Promise<T> {
+	const release = await mutexFor(absolutePath).acquire();
+	try {
+		return await fn();
+	} finally {
+		release();
+	}
+}
+
+/** Default lock budget: long enough for large writes + formatter writeback. */
+const DEFAULT_CROSS_PROCESS_LOCK: FileLockOptions = {
+	staleMs: 60_000,
+	retries: 600,
+	retryDelayMs: 50,
+};
+
+export type EditPathMutationOptions = {
+	/**
+	 * When true (default), also acquire a durable cross-process file lock.
+	 * Disable for injectible/in-memory filesystem tests that do not touch disk.
+	 */
+	crossProcess?: boolean;
+	fileLock?: FileLockOptions;
+};
+
+/**
+ * Run `fn` while holding exclusive mutation rights for every absolute path.
+ * Paths are locked in lexicographic order to avoid deadlocks on multi-path ops
+ * (e.g. rename source + destination).
+ */
+export async function withEditPathMutation<T>(
+	absolutePaths: readonly string[],
+	fn: () => Promise<T>,
+	options: EditPathMutationOptions = {},
+): Promise<T> {
+	const unique = [...new Set(absolutePaths.map(entry => path.resolve(entry)))].sort();
+	if (unique.length === 0) return fn();
+
+	const crossProcess = options.crossProcess !== false;
+	const fileLock = { ...DEFAULT_CROSS_PROCESS_LOCK, ...options.fileLock };
+
+	const runAt = async (index: number): Promise<T> => {
+		if (index >= unique.length) return fn();
+		const target = unique[index];
+		const next = () => runAt(index + 1);
+		return withInProcessPathLock(target, async () => {
+			if (!crossProcess) return next();
+			return withFileLock(target, next, fileLock);
+		});
+	};
+
+	return runAt(0);
+}

--- a/packages/coding-agent/test/core/concurrent-edit-path-lock.test.ts
+++ b/packages/coding-agent/test/core/concurrent-edit-path-lock.test.ts
@@ -135,4 +135,75 @@ describe("concurrent path mutation (#2900)", () => {
 		const joined = events.join(",");
 		expect(joined === "a-start,a-end,b-start,b-end" || joined === "b-start,b-end,a-start,a-end").toBe(true);
 	});
+
+	/**
+	 * Production `executePatchSingle` uses `LspFileSystem`, which is disk-backed but
+	 * is NOT `defaultFileSystem` by object identity. Cross-process locking must be
+	 * opted in explicitly for that path (#2900 review).
+	 */
+	it("disk-backed non-default FileSystem still serializes across processes when crossProcessLock is true", async () => {
+		const root = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-concurrent-edit-lsp-"));
+		temporaryDirectories.push(root);
+		const filePath = path.join(root, "file.txt");
+		await fsp.writeFile(filePath, "a\nb\nc\n", "utf8");
+
+		const patchModule = path.resolve(import.meta.dir, "../../src/edit/modes/patch.ts");
+		// Standalone worker: custom disk FileSystem (LspFileSystem-shaped) + explicit lock.
+		const workerSource = `
+import * as fsp from "node:fs/promises";
+import { applyPatch } from ${JSON.stringify(patchModule)};
+
+const filePath = process.argv[2]!;
+const from = process.argv[3]!;
+const to = process.argv[4]!;
+const delayMs = Number(process.argv[5] ?? "30");
+
+const diskFs = {
+	exists: async (p: string) => {
+		try {
+			await fsp.access(p);
+			return true;
+		} catch {
+			return false;
+		}
+	},
+	read: async (p: string) => fsp.readFile(p, "utf8"),
+	write: async (p: string, content: string) => {
+		await Bun.sleep(delayMs);
+		await fsp.writeFile(p, content, "utf8");
+	},
+	delete: async (p: string) => fsp.unlink(p),
+	mkdir: async (p: string) => {
+		await fsp.mkdir(p, { recursive: true });
+	},
+};
+
+await applyPatch(
+	{ path: filePath, op: "update", diff: \`@@\\n-\${from}\\n+\${to}\` },
+	{ cwd: ${JSON.stringify(root)}, fs: diskFs, allowFuzzy: false, crossProcessLock: true },
+);
+`;
+		const workerTs = path.join(root, "worker.ts");
+		await fsp.writeFile(workerTs, workerSource, "utf8");
+
+		const spawnWorker = (from: string, to: string) =>
+			Bun.spawn(["bun", "run", workerTs, filePath, from, to, "40"], {
+				stdout: "pipe",
+				stderr: "pipe",
+				cwd: root,
+			});
+
+		const a = spawnWorker("a", "A");
+		const b = spawnWorker("c", "C");
+		const [codeA, codeB] = await Promise.all([a.exited, b.exited]);
+		const stderrA = await new Response(a.stderr).text();
+		const stderrB = await new Response(b.stderr).text();
+		if (codeA !== 0) throw new Error(`worker A failed (${codeA}): ${stderrA}`);
+		if (codeB !== 0) throw new Error(`worker B failed (${codeB}): ${stderrB}`);
+
+		const text = await fsp.readFile(filePath, "utf8");
+		expect(text.includes("A")).toBe(true);
+		expect(text.includes("C")).toBe(true);
+		expect(text).toBe("A\nb\nC\n");
+	});
 });

--- a/packages/coding-agent/test/core/concurrent-edit-path-lock.test.ts
+++ b/packages/coding-agent/test/core/concurrent-edit-path-lock.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression for https://github.com/Yeachan-Heo/gajae-code/issues/2900
+ *
+ * Concurrent disjoint applyPatch calls must not silently drop a successful edit.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { applyPatch, type FileSystem } from "../../src/edit/modes/patch";
+import { withEditPathMutation } from "../../src/edit/path-mutation-lock";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories.splice(0).map(directory => fsp.rm(directory, { recursive: true, force: true })),
+	);
+});
+
+function memoryFs(initial: string): { text: string; fs: FileSystem } {
+	const state = { text: initial };
+	return {
+		get text() {
+			return state.text;
+		},
+		set text(value: string) {
+			state.text = value;
+		},
+		fs: {
+			exists: async () => true,
+			read: async () => state.text,
+			write: async (_p, content) => {
+				await Bun.sleep(10);
+				state.text = content;
+			},
+			delete: async () => {
+				state.text = "";
+			},
+			mkdir: async () => {},
+		},
+	};
+}
+
+describe("concurrent path mutation (#2900)", () => {
+	it("keeps both disjoint concurrent applyPatch results under injectible fs", async () => {
+		const store = memoryFs("a\nb\nc\n");
+		const results = await Promise.all([
+			applyPatch(
+				{ path: "x", op: "update", diff: "@@\n-a\n+A" },
+				{ cwd: ".", fs: store.fs, allowFuzzy: false, crossProcessLock: false },
+			),
+			applyPatch(
+				{ path: "x", op: "update", diff: "@@\n-c\n+C" },
+				{ cwd: ".", fs: store.fs, allowFuzzy: false, crossProcessLock: false },
+			),
+		]);
+
+		expect(store.text.includes("A")).toBe(true);
+		expect(store.text.includes("C")).toBe(true);
+		expect(store.text).toBe("A\nb\nC\n");
+		// Both calls report success; order may vary but neither is a silent loss.
+		expect(results).toHaveLength(2);
+		expect(results.every(result => result.change.type === "update")).toBe(true);
+	});
+
+	it("rejects a write when content changed after the locked read (CAS)", async () => {
+		// Force a mid-flight mutation between the first read and the commit-time CAS read:
+		// first read returns original; commit re-read returns different content.
+		let phase: "patch" | "cas" = "patch";
+		const racingFs: FileSystem = {
+			exists: async () => true,
+			read: async () => {
+				if (phase === "patch") {
+					phase = "cas";
+					return "a\nb\nc\n";
+				}
+				return "other\nb\nc\n";
+			},
+			write: async () => {
+				throw new Error("write must not run on conflict");
+			},
+			delete: async () => {},
+			mkdir: async () => {},
+		};
+
+		await expect(
+			applyPatch(
+				{ path: "x", op: "update", diff: "@@\n-a\n+A" },
+				{ cwd: ".", fs: racingFs, allowFuzzy: false, crossProcessLock: false },
+			),
+		).rejects.toThrow(/concurrent edit conflict/);
+	});
+
+	it("serializes real-filesystem concurrent writes so both disjoint edits survive", async () => {
+		const root = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-concurrent-edit-"));
+		temporaryDirectories.push(root);
+		const filePath = path.join(root, "file.txt");
+		await fsp.writeFile(filePath, "a\nb\nc\n", "utf8");
+
+		await Promise.all([
+			applyPatch({ path: filePath, op: "update", diff: "@@\n-a\n+A" }, { cwd: root, allowFuzzy: false }),
+			applyPatch({ path: filePath, op: "update", diff: "@@\n-c\n+C" }, { cwd: root, allowFuzzy: false }),
+		]);
+
+		const text = await fsp.readFile(filePath, "utf8");
+		expect(text.includes("A")).toBe(true);
+		expect(text.includes("C")).toBe(true);
+		expect(text).toBe("A\nb\nC\n");
+	});
+
+	it("withEditPathMutation runs critical sections for one path strictly one-at-a-time", async () => {
+		const events: string[] = [];
+		await Promise.all([
+			withEditPathMutation(
+				["/tmp/gjc-edit-lock-a"],
+				async () => {
+					events.push("a-start");
+					await Bun.sleep(20);
+					events.push("a-end");
+				},
+				{ crossProcess: false },
+			),
+			withEditPathMutation(
+				["/tmp/gjc-edit-lock-a"],
+				async () => {
+					events.push("b-start");
+					await Bun.sleep(5);
+					events.push("b-end");
+				},
+				{ crossProcess: false },
+			),
+		]);
+		// Full mutual exclusion: no interleaving of start/end pairs (order of a/b is race-dependent).
+		const joined = events.join(",");
+		expect(joined === "a-start,a-end,b-start,b-end" || joined === "b-start,b-end,a-start,a-end").toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #2900.

Two concurrent `applyPatch` (or replace) operations could read the same file version, both report success, and the last writer would silently drop the other successful disjoint edit.

## What

1. **`withEditPathMutation`** (`packages/coding-agent/src/edit/path-mutation-lock.ts`)
   - In-process async mutex keyed by absolute path (always)
   - Durable cross-process `<path>.lock` via existing `withFileLock` when using the real filesystem
   - Multi-path ops (rename) lock in sorted order to avoid deadlocks

2. **`applyPatch`** acquires path mutation rights around the full read→compute→write window. Injectible/custom `fs` skips cross-process locks by default (still in-process serializes).

3. **Commit-time CAS** on update: re-read before write; if content ≠ original snapshot, throw `concurrent edit conflict` without writing.

4. **`executeReplaceSingle`** also runs under the same path coordinator.

## Why

Edit exclusivity was only per agent-loop (`concurrency = "exclusive"`). Independent sessions / concurrent `Promise.all` shared no path lock and no commit digest, so TOCTOU lost updates were reported as success.

## Tests

```sh
bun test packages/coding-agent/test/core/concurrent-edit-path-lock.test.ts
# 4 pass

# Issue one-liner (now exits 0):
bun -e 'import { applyPatch } from "./packages/coding-agent/src/edit/modes/patch.ts"; let text="a\nb\nc\n"; const fs={read:async()=>text,write:async(_p:string,c:string)=>{await Bun.sleep(10);text=c},delete:async()=>{},mkdir:async()=>{}}; const results=await Promise.all([applyPatch({path:"x",op:"update",diff:"@@\n-a\n+A"},{cwd:".",fs,allowFuzzy:false}),applyPatch({path:"x",op:"update",diff:"@@\n-c\n+C"},{cwd:".",fs,allowFuzzy:false})]); if(!(text.includes("A")&&text.includes("C"))) process.exit(1);'
```

- Disjoint concurrent injectible-fs patches both survive (`A` and `C`)
- CAS rejects mid-flight content change
- Real filesystem concurrent patches both survive
- Mutex non-interleaving for one path

## Scope notes / follow-ups

- Hashline multi-entry / write-tool / formatter writeback paths can adopt `withEditPathMutation` the same way; this PR covers the issue's deterministic `applyPatch` repro plus replace.
- Strict three-way merge of overlapping concurrent edits is intentionally not attempted — serialization + CAS is fail-closed and preserves disjoint success.

## Changelog

`packages/coding-agent/CHANGELOG.md` — `[Unreleased]` Fixed for #2900.