### PR TITLE
fix(ai): drop invalid image_url placeholders from Responses replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenAI Responses / Codex native history replay no longer submits missing resident-image placeholders as `input_image.image_url`. Invalid values (including `[Session resident imageUrl blob missing: …]`) are dropped, or retained as `file_id`-only parts when a non-empty `file_id` is present, so a single unavailable historical image cannot brick `/retry` (#2924).
+
 ## [0.11.7] - 2026-07-22
 
 ### Changed

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -271,17 +271,53 @@ function normalizeResponsesImageUrlForReplay(value: unknown): NormalizedResponse
 	return { imageUrl: stringifyResponsesStringParamForReplay(value) };
 }
 
+/**
+ * OpenAI Responses `input_image.image_url` must be a fetchable HTTP(S) URL or an
+ * image data URI. Session resident-blob materialization may leave a human-readable
+ * placeholder like `[Session resident imageUrl blob missing: sha256:…; …]` in this
+ * field; replaying that string as `image_url` makes Codex reject the entire turn
+ * with `invalid_value` (#2924).
+ */
+function isProviderSafeResponsesImageUrl(value: string): boolean {
+	const url = value.trim();
+	if (url.length === 0) return false;
+	if (url.startsWith("https://") || url.startsWith("http://")) return true;
+	// Accept only image data URIs — other data: schemes are not valid image inputs.
+	if (url.startsWith("data:image/")) return true;
+	return false;
+}
+
+function hasNonEmptyResponsesFileId(part: Record<string, unknown>): boolean {
+	return typeof part.file_id === "string" && part.file_id.trim().length > 0;
+}
+
 function sanitizeResponsesMessageContentForReplay(content: unknown): unknown {
 	if (typeof content === "string") return neutralizeReservedControlTokens(content.toWellFormed());
 	if (!Array.isArray(content)) return content;
-	return content.map(part => {
-		if (!part || typeof part !== "object") return part;
+	const sanitizedContent: unknown[] = [];
+	for (const part of content) {
+		if (!part || typeof part !== "object") {
+			sanitizedContent.push(part);
+			continue;
+		}
 		const sanitizedPart = { ...(part as Record<string, unknown>) };
 		if ("text" in sanitizedPart) {
 			sanitizedPart.text = normalizeResponsesMessageTextForReplay(sanitizedPart.text);
 		}
 		if ("image_url" in sanitizedPart) {
 			const normalizedImageUrl = normalizeResponsesImageUrlForReplay(sanitizedPart.image_url);
+			if (!isProviderSafeResponsesImageUrl(normalizedImageUrl.imageUrl)) {
+				// Keep the part when a provider file_id can stand alone; otherwise drop
+				// only this image part so neighboring text/history still replays.
+				if (!hasNonEmptyResponsesFileId(sanitizedPart)) continue;
+				delete sanitizedPart.image_url;
+				if (sanitizedPart.type === "image_url") sanitizedPart.type = "input_image";
+				if ("detail" in sanitizedPart && !isResponsesImageDetail(sanitizedPart.detail)) {
+					delete sanitizedPart.detail;
+				}
+				sanitizedContent.push(sanitizedPart);
+				continue;
+			}
 			sanitizedPart.image_url = normalizedImageUrl.imageUrl;
 			if (sanitizedPart.type === "image_url") {
 				sanitizedPart.type = "input_image";
@@ -292,8 +328,9 @@ function sanitizeResponsesMessageContentForReplay(content: unknown): unknown {
 				delete sanitizedPart.detail;
 			}
 		}
-		return sanitizedPart;
-	});
+		sanitizedContent.push(sanitizedPart);
+	}
+	return sanitizedContent;
 }
 
 function sanitizeResponsesStringFieldsForReplay(item: Record<string, unknown>): void {

--- a/packages/ai/test/openai-responses-history-image-url.test.ts
+++ b/packages/ai/test/openai-responses-history-image-url.test.ts
@@ -63,6 +63,8 @@ function makeCodexAssistantMessage(items: Record<string, unknown>[]): AssistantM
 	};
 }
 
+const MISSING_IMAGE_URL_PLACEHOLDER = `[Session resident imageUrl blob missing: sha256:${"a".repeat(64)}; original content unavailable]`;
+
 describe("OpenAI responses history image replay", () => {
 	it("normalizes object-valued image_url fields before replaying openai-codex native history", async () => {
 		const model = getBundledModel<"openai-codex-responses">("openai-codex", "gpt-5.2-codex");
@@ -94,6 +96,123 @@ describe("OpenAI responses history image replay", () => {
 				content: [
 					{ type: "input_text", text: "Recovered user image" },
 					{ type: "input_image", image_url: imageUrl, detail: "high" },
+				],
+			},
+			{ role: "user", content: [{ type: "input_text", text: "follow-up user" }] },
+		]);
+	});
+
+	it("drops missing resident-blob image_url placeholders instead of replaying invalid URLs (#2924)", async () => {
+		const model = getBundledModel<"openai-codex-responses">("openai-codex", "gpt-5.2-codex");
+		const historyItems: Record<string, unknown>[] = [
+			{
+				type: "message",
+				role: "user",
+				id: "msg_user_missing_blob",
+				content: [
+					{ type: "input_text", text: "before image" },
+					{
+						type: "input_image",
+						detail: "auto",
+						file_id: null,
+						image_url: MISSING_IMAGE_URL_PLACEHOLDER,
+					},
+					{ type: "input_text", text: "after image" },
+				],
+			},
+		];
+
+		const payload = await captureCodexPayload(model, {
+			messages: [
+				{ role: "user", content: "generic history that should be replaced", timestamp: Date.now() },
+				makeCodexAssistantMessage(historyItems),
+				{ role: "user", content: "follow-up user", timestamp: Date.now() },
+			],
+		});
+
+		expect(payload.input).toEqual([
+			{
+				type: "message",
+				role: "user",
+				content: [
+					{ type: "input_text", text: "before image" },
+					{ type: "input_text", text: "after image" },
+				],
+			},
+			{ role: "user", content: [{ type: "input_text", text: "follow-up user" }] },
+		]);
+		const serialized = JSON.stringify(payload.input);
+		expect(serialized.includes("image_url")).toBe(false);
+		expect(serialized.includes("blob missing")).toBe(false);
+	});
+
+	it("keeps file_id-only input_image when image_url is an invalid placeholder (#2924)", async () => {
+		const model = getBundledModel<"openai-codex-responses">("openai-codex", "gpt-5.2-codex");
+		const historyItems: Record<string, unknown>[] = [
+			{
+				type: "message",
+				role: "user",
+				id: "msg_user_file_id",
+				content: [
+					{
+						type: "input_image",
+						detail: "high",
+						file_id: "file-abc123",
+						image_url: MISSING_IMAGE_URL_PLACEHOLDER,
+					},
+				],
+			},
+		];
+
+		const payload = await captureCodexPayload(model, {
+			messages: [
+				{ role: "user", content: "generic history that should be replaced", timestamp: Date.now() },
+				makeCodexAssistantMessage(historyItems),
+				{ role: "user", content: "follow-up user", timestamp: Date.now() },
+			],
+		});
+
+		expect(payload.input).toEqual([
+			{
+				type: "message",
+				role: "user",
+				content: [{ type: "input_image", detail: "high", file_id: "file-abc123" }],
+			},
+			{ role: "user", content: [{ type: "input_text", text: "follow-up user" }] },
+		]);
+	});
+
+	it("preserves valid https and data:image image_url values on replay", async () => {
+		const model = getBundledModel<"openai-codex-responses">("openai-codex", "gpt-5.2-codex");
+		const httpsUrl = "https://example.com/a.png";
+		const dataUrl = "data:image/png;base64,AAA";
+		const historyItems: Record<string, unknown>[] = [
+			{
+				type: "message",
+				role: "user",
+				id: "msg_user_valid_urls",
+				content: [
+					{ type: "input_image", image_url: httpsUrl, detail: "low" },
+					{ type: "input_image", image_url: dataUrl },
+				],
+			},
+		];
+
+		const payload = await captureCodexPayload(model, {
+			messages: [
+				{ role: "user", content: "generic history that should be replaced", timestamp: Date.now() },
+				makeCodexAssistantMessage(historyItems),
+				{ role: "user", content: "follow-up user", timestamp: Date.now() },
+			],
+		});
+
+		expect(payload.input).toEqual([
+			{
+				type: "message",
+				role: "user",
+				content: [
+					{ type: "input_image", image_url: httpsUrl, detail: "low" },
+					{ type: "input_image", image_url: dataUrl },
 				],
 			},
 			{ role: "user", content: [{ type: "input_text", text: "follow-up user" }] },


### PR DESCRIPTION
## Summary

Fixes #2924.

When a session's resident image blob is missing, materialization leaves a human-readable placeholder such as:

```text
[Session resident imageUrl blob missing: sha256:…; original content unavailable]
```

inside provider-native `input_image.image_url` (including remote-compaction `replacementHistory`). Replay previously forwarded that string as-is, and Codex rejected the entire request with `invalid_value` — permanently bricking `/retry` and follow-ups.

## What

In `sanitizeResponsesMessageContentForReplay` (`packages/ai/src/utils.ts`):

- Accept only provider-safe `image_url` values: `http://`, `https://`, or `data:image/…`
- If invalid **and** a non-empty `file_id` exists → strip `image_url`, keep the `input_image` part
- If invalid **and** no `file_id` → drop only that image part
- Preserve adjacent `input_text` content
- Existing object→string `image_url` normalization for valid URLs is unchanged

## Tests

```sh
bun test packages/ai/test/openai-responses-history-image-url.test.ts
# 4 pass
```

- object-valued valid `image_url` still normalizes
- missing-blob placeholder dropped; neighboring text kept
- invalid `image_url` + valid `file_id` → file_id-only part
- valid `https://` and `data:image/` preserved

## Changelog

`packages/ai/CHANGELOG.md` — `[Unreleased]` Fixed for #2924.