### PR TITLE
fix(session): migrate legacy local:// root on interactive resume switch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - On macOS, resuming a managed session no longer fails with `identity_mismatch` when the first write-append open changes only file `ctime` (e.g. APFS write-provenance / `com.apple.provenance`). `appendSync` allows a single bounded re-capture + retry when `dev`/`ino`/`size`/`mtime`/SHA-256 remain unchanged, and still rejects real content races and repeated ctime transitions (#2944).
+- Interactive `/resume` / `AgentSession.switchSession()` now awaits verified managed `local://` legacy-root migration for the newly selected session before post-commit lifecycle proceeds, matching cold-start `createAgentSession()` readiness from #2797 so synchronous `local://` resolution no longer fails with "legacy migration must complete before path resolution" after a mid-session switch (#2925).
 
 ## [0.11.7] - 2026-07-22
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -261,7 +261,7 @@ import { GoalRuntime } from "../goals/runtime";
 import type { Goal, GoalModeState } from "../goals/state";
 import type { HindsightSessionState } from "../hindsight/state";
 import { buildSkillStopOutput, ensureWorkflowSkillActivationState } from "../hooks/skill-state";
-import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
+import { initializeLocalRoot, type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import { shutdownAll as shutdownAllLspClients } from "../lsp/client";
 import { resolveMemoryBackend } from "../memory-backend";
 import {
@@ -4554,6 +4554,8 @@ export class AgentSession {
 		return {
 			getArtifactsDir: () => this.sessionManager.getArtifactsDir(),
 			isManagedDestination: () => this.sessionManager.isManagedDestination(),
+			// Required for verified legacy local:// migration on managed sessions (#2797 / #2925).
+			getManagedLegacyLocalMigrationSource: () => this.sessionManager.getManagedLegacyLocalMigrationSource(),
 			getSessionId: () => this.sessionManager.getSessionId(),
 		};
 	}
@@ -14508,6 +14510,13 @@ export class AgentSession {
 				await this.sessionManager.ensureOnDisk();
 
 				if (switchingToDifferentSession) {
+					// Interactive /resume (and any other switchSession identity change) must
+					// await verified legacy local:// migration for the *new* session before
+					// post-commit session_switch / local path resolution. createAgentSession
+					// already does this at cold start (#2797); switchSession previously omitted
+					// it, so resolving local:// after /resume could fail-closed with
+					// "legacy migration must complete before path resolution" (#2925).
+					await initializeLocalRoot(this.#localProtocolOptions());
 					this.#resetHindsightConversationTrackingIfHindsight();
 					this.#resetIrcRosterDeliveryState();
 				}

--- a/packages/coding-agent/test/sdk-session-isolation.test.ts
+++ b/packages/coding-agent/test/sdk-session-isolation.test.ts
@@ -157,6 +157,76 @@ describe("createAgentSession session storage isolation", () => {
 			await session.dispose();
 		}
 	}, 20_000);
+
+	it("migrates a switched managed session's legacy local:// root before resolution (#2925)", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `gjc-sdk-local-switch-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const cwd = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const destination = SessionManager.managedDestination(cwd, agentDir);
+
+		// Session A — start here so createAgentSession initializes A's local root only.
+		const sessionA = SessionManager.create(cwd, destination);
+		sessionA.appendMessage({ role: "user", content: "session A", timestamp: Date.now() });
+		await sessionA.flush();
+		const sessionAFile = sessionA.getSessionFile();
+		if (!sessionAFile) throw new Error("Expected session A path");
+		await sessionA.close();
+
+		// Session B — carry a legacy artifacts/local tree that needs verified migration.
+		const sessionB = SessionManager.create(cwd, destination);
+		sessionB.appendMessage({ role: "user", content: "session B", timestamp: Date.now() });
+		await sessionB.flush();
+		const sessionBFile = sessionB.getSessionFile();
+		if (!sessionBFile) throw new Error("Expected session B path");
+		const sessionBArtifacts = sessionB.getArtifactsDir();
+		if (!sessionBArtifacts) throw new Error("Expected session B artifacts path");
+		const legacyLocalRoot = path.join(sessionBArtifacts, "local");
+		fs.mkdirSync(legacyLocalRoot, { recursive: true, mode: 0o700 });
+		fs.writeFileSync(path.join(legacyLocalRoot, "switched.md"), "switched-bytes", { mode: 0o600 });
+		await sessionB.close();
+
+		const managerA = await SessionManager.open(sessionAFile, destination);
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			sessionManager: managerA,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			expect(await session.switchSession(sessionBFile)).toBe(true);
+
+			const localOptions = {
+				getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+				isManagedDestination: () => session.sessionManager.isManagedDestination(),
+				getManagedLegacyLocalMigrationSource: () => session.sessionManager.getManagedLegacyLocalMigrationSource(),
+				getSessionId: () => session.sessionManager.getSessionId(),
+			};
+			const resolved = resolveLocalUrlToPath("local://switched.md", localOptions);
+			expect(resolved).toBe(path.join(resolveLocalRoot(localOptions), "switched.md"));
+			expect(fs.readFileSync(resolved, "utf8")).toBe("switched-bytes");
+			// Legacy source retired after verified migration (marker may be verified or cleanup_pending).
+			expect(fs.existsSync(path.join(legacyLocalRoot, "switched.md"))).toBe(false);
+			const marker = fs.readFileSync(
+				path.join(resolveLocalRoot(localOptions), ".gjc-local-legacy-migrated-v1"),
+				"utf8",
+			);
+			expect(marker === "verified\n" || marker === "cleanup_pending\n").toBe(true);
+		} finally {
+			await session.dispose();
+		}
+	}, 30_000);
+
 	it("initializes a default local root without shadowing an explicit owner", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `gjc-sdk-local-owner-${Snowflake.next()}-`));
 		tempDirs.push(tempDir);


### PR DESCRIPTION
## Summary

Fixes #2925 (follow-up to #2797).

Cold start via `createAgentSession()` already awaited verified managed `local://` legacy-root migration. Interactive `/resume` through `AgentSession.switchSession()` only swapped `SessionManager` identity, so a later synchronous `local://` resolve for the *new* session failed closed with:

```text
local:// legacy migration must complete before path resolution
```

## What

1. **`AgentSession.#localProtocolOptions()`** now includes `getManagedLegacyLocalMigrationSource` (same authority `createAgentSession` / `SessionManager` already expose).
2. **`switchSession()`** — after the successor is durable (`ensureOnDisk`) and when switching to a different session — `await initializeLocalRoot(this.#localProtocolOptions())` **before** post-commit `session_switch` hooks / path resolution.

Reload of the same session file is unchanged (no re-migration). Fail-closed migration verification is preserved.

## Tests

```sh
bun test packages/coding-agent/test/sdk-session-isolation.test.ts \
  -t "migrates a|cleanup_pending when managed legacy"
# 2 pass
```

New case: managed sessions A→B with B carrying `artifacts/local/switched.md`; after `switchSession(B)`, `local://switched.md` resolves and the legacy source is retired.

## Changelog

`packages/coding-agent/CHANGELOG.md` — `[Unreleased]` Fixed for #2925.