### PR TITLE
fix(ai): widen first-event stream timeout to 5min for alibaba-token-plan

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - OpenAI Responses / Codex native history replay no longer submits missing resident-image placeholders as `input_image.image_url`. Invalid values (including `[Session resident imageUrl blob missing: …]`) are dropped, or retained as `file_id`-only parts when a non-empty `file_id` is present, so a single unavailable historical image cannot brick `/retry` (#2924).
+- Raised the first-event stream timeout floor to five minutes for `alibaba-token-plan` models using the OpenAI Completions and Responses APIs, while preserving caller and environment overrides and the existing inter-event idle timeout.
 
 ## [0.11.7] - 2026-07-22
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -426,6 +426,7 @@ function getTrailingPartialDeepseekToken(text: string): string {
 	return tail;
 }
 
+const ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS = 300_000;
 const OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI completions stream timed out while waiting for the first event";
 
@@ -562,8 +563,10 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					openaiStream = await createCompletionsStream("none");
 				}
 			}
+			const firstEventFallbackMs =
+				model.provider === "alibaba-token-plan" ? ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS : undefined;
 			const firstEventWatchdog = createWatchdog(
-				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs),
+				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs),
 				() => abortTracker.abortLocally(firstEventTimeoutAbortError),
 			);
 			if (premiumRequestsTotal !== undefined) {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -130,6 +130,7 @@ export interface OpenAIResponsesOptions extends StreamOptions {
 }
 
 const OPENAI_RESPONSES_PROVIDER_SESSION_STATE_PREFIX = "openai-responses:";
+const ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS = 300_000;
 const OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI responses stream timed out while waiting for the first event";
 const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
@@ -330,8 +331,10 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 				await notifyProviderResponse(options, response, model, request_id);
 				return data;
 			});
+			const firstEventFallbackMs =
+				model.provider === "alibaba-token-plan" ? ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS : undefined;
 			const firstEventWatchdog = createWatchdog(
-				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs),
+				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs),
 				() => abortTracker.abortLocally(firstEventTimeoutAbortError),
 			);
 			if (premiumRequestsTotal !== undefined) output.usage.premiumRequests = premiumRequestsTotal;


### PR DESCRIPTION
## Problem

Alibaba Token Plan models (`token-plan.ap-southeast-1.maas.aliyuncs.com`) routinely exceed the 120s first-event watchdog, causing spurious `"Provider stream timed out while waiting for the first event"` aborts. Reasoning models (qwen3.8-max-preview, deepseek-v4-pro) can take well over 2 minutes for the first SSE frame on cold starts / heavy thinking.

## Fix

Pass a 300s (5-minute) fallback to `getStreamFirstEventTimeoutMs` when `model.provider === "alibaba-token-plan"`, in both transports:

- `openai-completions.ts` — most alibaba-token-plan models
- `openai-responses.ts` — qwen3.8-max-preview

Uses the existing `fallbackMs` second-arg mechanism (same one the google-gemini-cli 5-min floor introduced). No changes to `register-builtins.ts` / `LazyStreamLimits` since alibaba-token-plan shares the generic OpenAI-compat lazy streams with every other provider.

## Precedence preserved

1. `StreamOptions.streamFirstEventTimeoutMs` (caller) — unchanged
2. `PI_STREAM_FIRST_EVENT_TIMEOUT_MS` (env) — unchanged
3. **Provider fallback: 300s for alibaba-token-plan, 100s default otherwise** ← this PR
4. `max(fallback, idleTimeoutMs)` floor — unchanged

Inter-event idle timeout (120s default) is untouched.

## Verification

- `bun test packages/ai/test/openai-first-event-timeout.test.ts` — 10 pass
- `bunx biome check` — clean