### PR TITLE
fix(provider): propagate resolved bearer to OpenAI models-list discovery (#2945)

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2049,7 +2049,10 @@ export class ModelRegistry {
 		const modelsUrl = `${baseUrl}/models`;
 
 		const headers: Record<string, string> = { ...(providerConfig.headers ?? {}) };
-		const apiKey = await this.authStorage.getApiKey(providerConfig.provider);
+		// Resolve with the same baseUrl context completion requests use so an
+		// endpoint-scoped (or config-pinned) credential wins here exactly as it
+		// does for chat completions.
+		const apiKey = await this.authStorage.getApiKey(providerConfig.provider, undefined, { baseUrl });
 		if (apiKey && apiKey !== DEFAULT_LOCAL_TOKEN && apiKey !== kNoAuth) {
 			headers.Authorization = `Bearer ${apiKey}`;
 		}
@@ -2059,6 +2062,13 @@ export class ModelRegistry {
 			signal: AbortSignal.timeout(250),
 		});
 		if (!response.ok) {
+			if (response.status === 401 || response.status === 403) {
+				// Redacted by construction: name the provider, endpoint, and the
+				// config surface to fix — never the resolved key.
+				throw new Error(
+					`HTTP ${response.status} from ${modelsUrl}: provider "${providerConfig.provider}" credential was rejected for OpenAI models-list discovery; check providers.${providerConfig.provider}.apiKey/apiKeyEnv.`,
+				);
+			}
 			throw new Error(`HTTP ${response.status} from ${modelsUrl}`);
 		}
 		const payload = (await response.json()) as { data?: Array<{ id: string }> };

--- a/packages/coding-agent/test/issue-2945-provider-discovery-bearer.test.ts
+++ b/packages/coding-agent/test/issue-2945-provider-discovery-bearer.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { resetSettingsForTest } from "@gajae-code/coding-agent/config/settings";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { Snowflake } from "@gajae-code/utils";
+
+const EXPECTED_KEY = "issue-2945-local-key";
+const KEY_ENV = "ISSUE_2945_LLM_API_KEY";
+
+type SeenRequest = { url: string | undefined; authorization: string | undefined };
+
+async function startModelsListServer(options: {
+	expectedKey?: string;
+	seen: SeenRequest[];
+}): Promise<{ server: http.Server; baseUrl: string }> {
+	const server = http.createServer((req, res) => {
+		options.seen.push({ url: req.url, authorization: req.headers.authorization });
+		if (options.expectedKey !== undefined && req.headers.authorization !== `Bearer ${options.expectedKey}`) {
+			res.writeHead(401, { "content-type": "application/json" });
+			res.end(JSON.stringify({ error: "missing or invalid bearer" }));
+			return;
+		}
+		res.writeHead(200, { "content-type": "application/json" });
+		res.end(JSON.stringify({ data: [{ id: "local-model-1" }] }));
+	});
+	await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (address === null || typeof address === "string") throw new Error("server address unavailable");
+	return { server, baseUrl: `http://127.0.0.1:${address.port}/v1` };
+}
+
+describe("issue #2945 provider discovery Bearer auth", () => {
+	let tempDir: string;
+	let modelsJsonPath: string;
+	let authStorage: AuthStorage;
+	let server: http.Server | undefined;
+	const seen: SeenRequest[] = [];
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = path.join(os.tmpdir(), `gjc-test-issue-2945-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsJsonPath = path.join(tempDir, "models.yml");
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		seen.length = 0;
+	});
+
+	afterEach(() => {
+		resetSettingsForTest();
+		authStorage.close();
+		server?.close();
+		server = undefined;
+		delete process.env[KEY_ENV];
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true });
+		}
+	});
+
+	let baseUrl: string;
+	async function waitForRequest(): Promise<void> {
+		const deadline = Date.now() + 5_000;
+		while (seen.length === 0 && Date.now() < deadline) {
+			await Bun.sleep(25);
+		}
+	}
+
+	test("authenticated models-list endpoint receives the resolved apiKeyEnv bearer", async () => {
+		process.env[KEY_ENV] = EXPECTED_KEY;
+		({ server, baseUrl } = await startModelsListServer({ expectedKey: EXPECTED_KEY, seen }));
+		await Bun.write(
+			modelsJsonPath,
+			`providers:\n  local:\n    baseUrl: ${baseUrl}\n    apiKeyEnv: ${KEY_ENV}\n    api: openai-completions\n    discovery:\n      type: openai-models-list\n    models: []\n`,
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		await registry.refresh("online");
+		await waitForRequest();
+
+		expect(seen.length).toBeGreaterThan(0);
+		expect(seen[0].url).toBe("/v1/models");
+		expect(seen[0].authorization).toBe(`Bearer ${EXPECTED_KEY}`);
+		expect(registry.find("local", "local-model-1")).toBeDefined();
+	});
+
+	test("unauthenticated local-provider discovery sends no Authorization header", async () => {
+		({ server, baseUrl } = await startModelsListServer({ seen }));
+		await Bun.write(
+			modelsJsonPath,
+			`providers:\n  local:\n    baseUrl: ${baseUrl}\n    api: openai-completions\n    auth: none\n    discovery:\n      type: openai-models-list\n    models: []\n`,
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		await registry.refresh("online");
+		await waitForRequest();
+
+		expect(seen.length).toBeGreaterThan(0);
+		expect(seen[0].authorization).toBeUndefined();
+		expect(registry.find("local", "local-model-1")).toBeDefined();
+	});
+
+	test("rejected credentials surface a useful redacted error", async () => {
+		process.env[KEY_ENV] = "wrong-key";
+		({ server, baseUrl } = await startModelsListServer({ expectedKey: EXPECTED_KEY, seen }));
+		await Bun.write(
+			modelsJsonPath,
+			`providers:\n  local:\n    baseUrl: ${baseUrl}\n    apiKeyEnv: ${KEY_ENV}\n    api: openai-completions\n    discovery:\n      type: openai-models-list\n    models: []\n`,
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		await registry.refresh("online");
+		await waitForRequest();
+
+		expect(seen.length).toBeGreaterThan(0);
+		expect(seen[0].authorization).toBe("Bearer wrong-key");
+		expect(registry.find("local", "local-model-1")).toBeUndefined();
+
+		const status = registry.getProviderDiscoveryState("local");
+		expect(status?.status).toBe("unavailable");
+		expect(status?.error).toBeDefined();
+		expect(status?.error).toContain("HTTP 401");
+		expect(status?.error).toContain("local");
+		// Redaction: the error must never carry key material.
+		expect(status?.error).not.toContain("wrong-key");
+		expect(status?.error).not.toContain(EXPECTED_KEY);
+	});
+});

--- a/packages/coding-agent/test/issue-2945-provider-discovery-bearer.test.ts
+++ b/packages/coding-agent/test/issue-2945-provider-discovery-bearer.test.ts
@@ -61,9 +61,9 @@ describe("issue #2945 provider discovery Bearer auth", () => {
 	});
 
 	let baseUrl: string;
-	async function waitForRequest(): Promise<void> {
+	async function waitFor(condition: () => boolean): Promise<void> {
 		const deadline = Date.now() + 5_000;
-		while (seen.length === 0 && Date.now() < deadline) {
+		while (!condition() && Date.now() < deadline) {
 			await Bun.sleep(25);
 		}
 	}
@@ -78,9 +78,10 @@ describe("issue #2945 provider discovery Bearer auth", () => {
 
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 		await registry.refresh("online");
-		await waitForRequest();
+		// Wait for the merged end state, not just the HTTP request: discovery
+		// merges into the catalog asynchronously after the response arrives.
+		await waitFor(() => seen.length > 0 && registry.find("local", "local-model-1") !== undefined);
 
-		expect(seen.length).toBeGreaterThan(0);
 		expect(seen[0].url).toBe("/v1/models");
 		expect(seen[0].authorization).toBe(`Bearer ${EXPECTED_KEY}`);
 		expect(registry.find("local", "local-model-1")).toBeDefined();
@@ -95,9 +96,8 @@ describe("issue #2945 provider discovery Bearer auth", () => {
 
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 		await registry.refresh("online");
-		await waitForRequest();
+		await waitFor(() => seen.length > 0 && registry.find("local", "local-model-1") !== undefined);
 
-		expect(seen.length).toBeGreaterThan(0);
 		expect(seen[0].authorization).toBeUndefined();
 		expect(registry.find("local", "local-model-1")).toBeDefined();
 	});
@@ -112,9 +112,8 @@ describe("issue #2945 provider discovery Bearer auth", () => {
 
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 		await registry.refresh("online");
-		await waitForRequest();
+		await waitFor(() => seen.length > 0 && registry.getProviderDiscoveryState("local")?.status === "unavailable");
 
-		expect(seen.length).toBeGreaterThan(0);
 		expect(seen[0].authorization).toBe("Bearer wrong-key");
 		expect(registry.find("local", "local-model-1")).toBeUndefined();
 


### PR DESCRIPTION
## Summary

Fixes #2945.

An OpenAI-compatible local provider whose `GET /v1/models` requires `Authorization: Bearer <key>` could fail GJC discovery even when the same request succeeds via curl. Traced contract: `ModelRegistry.#discoverOpenAIModelsList` (packages/coding-agent/src/config/model-registry.ts) builds the models-list request; its key resolution now matches completion requests.

## Changes

- `#discoverOpenAIModelsList` resolves the provider key via `authStorage.getApiKey(provider, undefined, { baseUrl })` — the same endpoint context completion requests use (`getApiKey(model, sessionId, { baseUrl, modelId })`) — so endpoint-scoped and config-pinned (models.yml `apiKey`/`apiKeyEnv`) credentials authenticate `/v1/models` consistently with chat completions.
- 401/403 responses now throw an actionable, redacted error naming the provider and the `providers.<name>.apiKey/apiKeyEnv` config surface. No key material is ever included in errors or logs.
- No provider schema or UX changes; unauthenticated local-provider discovery is unchanged (no key resolved → no Authorization header).

## Regression coverage

New `packages/coding-agent/test/issue-2945-provider-discovery-bearer.test.ts` spins up a local models-list endpoint that rejects requests without the expected Bearer header:

1. Authenticated endpoint: discovery sends `Authorization: Bearer <resolved apiKeyEnv key>` and the discovered model becomes available.
2. Unauthenticated local provider (`auth: none`): discovery succeeds with no Authorization header.
3. Rejected credentials: HTTP 401 surfaces a useful error containing the provider context and **never** the key.

## Verification

- `bun test packages/coding-agent/test/issue-2945-provider-discovery-bearer.test.ts` — 3 pass
- `bun test packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/model-registry-runtime-provider.test.ts packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts` — 157 pass
- `biome check` (root + touched files) — clean
- `tsc -p packages/coding-agent/tsconfig.json --noEmit` — clean

Not merged; exact-head GJC review required per issue instructions.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*