### PR TITLE
feat(workflow): authoritative repository binding for plans and tasks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Plans and delegated tasks can carry an authoritative repository binding (`gjc.repository_binding.v1`). Ultragoal plans and ralplan seeds stamp worktree/common-dir identity at creation, task items accept an optional binding, and spawn/goal-start fail closed when the active cwd is a sibling repository (#2901).
+
 ### Fixed
 
 - On macOS, resuming a managed session no longer fails with `identity_mismatch` when the first write-append open changes only file `ctime` (e.g. APFS write-provenance / `com.apple.provenance`). `appendSync` allows a single bounded re-capture + retry when `dev`/`ino`/`size`/`mtime`/SHA-256 remain unchanged, and still rejects real content races and repeated ctime transitions (#2944).

--- a/packages/coding-agent/scripts/dogfood-repository-binding.ts
+++ b/packages/coding-agent/scripts/dogfood-repository-binding.ts
@@ -1,0 +1,162 @@
+/**
+ * Product-surface dogfood for #2901 repository binding.
+ *
+ * Creates two sibling git repos, runs real `gjc ultragoal` / `gjc ralplan`
+ * CLI entrypoints from source, and prints fail-closed mismatch evidence.
+ *
+ * Usage (from monorepo root):
+ *   bun packages/coding-agent/scripts/dogfood-repository-binding.ts
+ */
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	assertCwdMatchesRepositoryBinding,
+	assertPathUnderRepositoryBinding,
+	parseRepositoryBinding,
+} from "../src/gjc-runtime/repository-binding";
+import { readUltragoalPlan, startNextUltragoalGoal } from "../src/gjc-runtime/ultragoal-runtime";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const cli = path.join(repoRoot, "packages/coding-agent/src/cli.ts");
+
+async function runGit(cwd: string, args: string[]): Promise<void> {
+	const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	const code = await proc.exited;
+	if (code !== 0) throw new Error(`git ${args.join(" ")} failed: ${await new Response(proc.stderr).text()}`);
+}
+
+async function initRepo(root: string): Promise<void> {
+	await fsp.mkdir(root, { recursive: true });
+	await runGit(root, ["init"]);
+	await runGit(root, ["config", "user.email", "dogfood@example.com"]);
+	await runGit(root, ["config", "user.name", "Dogfood"]);
+	await fsp.writeFile(path.join(root, "README.md"), `repo ${path.basename(root)}\n`);
+	await runGit(root, ["add", "README.md"]);
+	await runGit(root, ["commit", "-m", `init ${path.basename(root)}`]);
+}
+
+async function runCli(cwd: string, args: string[], env: NodeJS.ProcessEnv): Promise<{ code: number; stdout: string; stderr: string }> {
+	const proc = Bun.spawn(["bun", cli, ...args], { cwd, env, stdout: "pipe", stderr: "pipe" });
+	const [code, stdout, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+	return { code, stdout, stderr };
+}
+
+async function main(): Promise<void> {
+	const dogfoodRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-dogfood-2901-"));
+	const left = path.join(dogfoodRoot, "gajae-code");
+	const right = path.join(dogfoodRoot, "oh-my-openagent-senpi");
+	await initRepo(left);
+	await initRepo(right);
+
+	const sessionId = `dogfood-2901-${process.pid}`;
+	const env = { ...process.env, GJC_SESSION_ID: sessionId };
+
+	console.log("# Dogfood: repository binding (#2901)");
+	console.log(`root=${dogfoodRoot}`);
+	console.log(`left=${left}`);
+	console.log(`right=${right}`);
+	console.log(`session=${sessionId}`);
+	console.log(`cli=${cli}`);
+	console.log(`bun=${Bun.version}`);
+	console.log(`commit=${Bun.spawnSync(["git", "-C", repoRoot, "rev-parse", "--short", "HEAD"]).stdout.toString().trim()}`);
+	console.log();
+
+	// 1) Product CLI: create goals stamps binding
+	const create = await runCli(
+		left,
+		[
+			"ultragoal",
+			"create-goals",
+			"--brief",
+			"@goal dogfood binding\nProve repository binding stamps and fail-closed sibling mismatch.",
+			"--json",
+		],
+		env,
+	);
+	console.log("## 1) gjc ultragoal create-goals (LEFT)");
+	console.log(`exit=${create.code}`);
+	console.log(create.stdout.trim() || create.stderr.trim());
+	if (create.code !== 0) process.exit(1);
+
+	const plan = await readUltragoalPlan(left, sessionId);
+	if (!plan?.repositoryBinding) {
+		console.error("FAIL: plan missing repositoryBinding");
+		process.exit(1);
+	}
+	console.log();
+	console.log("## 2) goals.json repositoryBinding");
+	console.log(JSON.stringify(plan.repositoryBinding, null, 2));
+
+	// 2) Matching cwd starts goal
+	console.log();
+	console.log("## 3) startNextUltragoalGoal on LEFT (match)");
+	const started = await startNextUltragoalGoal({ cwd: left, sessionId });
+	console.log(`ok goal=${started.goal?.id} status=${started.goal?.status}`);
+
+	// 3) Sibling mismatch fails closed
+	console.log();
+	console.log("## 4) assertCwdMatchesRepositoryBinding on RIGHT (sibling)");
+	try {
+		await assertCwdMatchesRepositoryBinding(right, plan.repositoryBinding);
+		console.error("FAIL: expected identity_mismatch");
+		process.exit(1);
+	} catch (error) {
+		console.log(`fail_closed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	// 4) Path escape fails closed
+	console.log();
+	console.log("## 5) assertPathUnderRepositoryBinding sibling absolute path");
+	try {
+		assertPathUnderRepositoryBinding(plan.repositoryBinding, path.join(right, "README.md"));
+		console.error("FAIL: expected path_outside_root");
+		process.exit(1);
+	} catch (error) {
+		console.log(`fail_closed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	// 5) Task binding validation shape
+	console.log();
+	console.log("## 6) task repositoryBinding parse + match");
+	const taskBinding = parseRepositoryBinding(plan.repositoryBinding);
+	await assertCwdMatchesRepositoryBinding(left, taskBinding);
+	console.log("task_binding_ok on LEFT");
+	try {
+		await assertCwdMatchesRepositoryBinding(right, taskBinding);
+		console.error("FAIL: task binding should reject RIGHT");
+		process.exit(1);
+	} catch (error) {
+		console.log(`task_binding_fail_closed on RIGHT: ${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	// 6) Ralplan seed stamps binding via product CLI
+	console.log();
+	console.log("## 7) gjc ralplan seed (LEFT)");
+	const ralplan = await runCli(left, ["ralplan", "--json", "dogfood multi-repo binding"], env);
+	console.log(`exit=${ralplan.code}`);
+	console.log(ralplan.stdout.trim() || ralplan.stderr.trim());
+	if (ralplan.code !== 0) process.exit(1);
+	const statePath = path.join(left, ".gjc", `_session-${sessionId}`, "state", "ralplan-state.json");
+	const state = JSON.parse(await fsp.readFile(statePath, "utf8")) as {
+		repository_binding?: unknown;
+		run_id?: string;
+	};
+	console.log();
+	console.log("## 8) ralplan-state.json repository_binding");
+	console.log(JSON.stringify({ run_id: state.run_id, repository_binding: state.repository_binding }, null, 2));
+	if (!state.repository_binding) {
+		console.error("FAIL: ralplan state missing repository_binding");
+		process.exit(1);
+	}
+
+	console.log();
+	console.log("DOGFOOD_OK");
+}
+
+await main();

--- a/packages/coding-agent/scripts/dogfood-repository-binding.ts
+++ b/packages/coding-agent/scripts/dogfood-repository-binding.ts
@@ -37,7 +37,11 @@ async function initRepo(root: string): Promise<void> {
 	await runGit(root, ["commit", "-m", `init ${path.basename(root)}`]);
 }
 
-async function runCli(cwd: string, args: string[], env: NodeJS.ProcessEnv): Promise<{ code: number; stdout: string; stderr: string }> {
+async function runCli(
+	cwd: string,
+	args: string[],
+	env: NodeJS.ProcessEnv,
+): Promise<{ code: number; stdout: string; stderr: string }> {
 	const proc = Bun.spawn(["bun", cli, ...args], { cwd, env, stdout: "pipe", stderr: "pipe" });
 	const [code, stdout, stderr] = await Promise.all([
 		proc.exited,
@@ -64,7 +68,9 @@ async function main(): Promise<void> {
 	console.log(`session=${sessionId}`);
 	console.log(`cli=${cli}`);
 	console.log(`bun=${Bun.version}`);
-	console.log(`commit=${Bun.spawnSync(["git", "-C", repoRoot, "rev-parse", "--short", "HEAD"]).stdout.toString().trim()}`);
+	console.log(
+		`commit=${Bun.spawnSync(["git", "-C", repoRoot, "rev-parse", "--short", "HEAD"]).stdout.toString().trim()}`,
+	);
 	console.log();
 
 	// 1) Product CLI: create goals stamps binding

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -23,6 +23,7 @@ import {
 	writeArtifact,
 	writeWorkflowEnvelopeAtomic,
 } from "./state-writer";
+import { captureRepositoryBinding } from "./repository-binding";
 import { assertSafePathComponent, CommandError, flagValue, hasFlag } from "./workflow-cli-common";
 import { getSkillManifest } from "./workflow-manifest";
 
@@ -817,6 +818,7 @@ async function seedRalplanState(
 	const runId = existingRunId ?? resolved.sessionId ?? defaultRunId();
 	assertSafePathComponent(runId, "run-id");
 	const now = new Date().toISOString();
+	const repositoryBinding = await captureRepositoryBinding(cwd, { displayPath: cwd });
 	const payload: Record<string, unknown> = {
 		active: true,
 		current_phase: "planner",
@@ -827,6 +829,7 @@ async function seedRalplanState(
 		task: resolved.task,
 		run_id: runId,
 		updated_at: now,
+		repository_binding: repositoryBinding,
 	};
 	if (resolved.architectKind) payload.architect_kind = resolved.architectKind;
 	if (resolved.criticKind) payload.critic_kind = resolved.criticKind;

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -11,6 +11,7 @@ import {
 	type RalplanIndexRow,
 	summarizeRalplanIndex,
 } from "./ledger-event-renderer";
+import { captureRepositoryBinding } from "./repository-binding";
 import { GJC_RALPLAN_ARTIFACT_ENV, isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
 import { modeStatePath, sessionPlansDir } from "./session-layout";
 import { resolveGjcSessionForWrite, writeSessionActivityMarker } from "./session-resolution";
@@ -23,7 +24,6 @@ import {
 	writeArtifact,
 	writeWorkflowEnvelopeAtomic,
 } from "./state-writer";
-import { captureRepositoryBinding } from "./repository-binding";
 import { assertSafePathComponent, CommandError, flagValue, hasFlag } from "./workflow-cli-common";
 import { getSkillManifest } from "./workflow-manifest";
 

--- a/packages/coding-agent/src/gjc-runtime/repository-binding.ts
+++ b/packages/coding-agent/src/gjc-runtime/repository-binding.ts
@@ -1,0 +1,209 @@
+/**
+ * Authoritative repository/worktree binding for plans and delegated tasks (#2901).
+ *
+ * Multi-repo parent directories must not let QA/review lanes infer a sibling repo
+ * from prose. Bindings carry a validated worktree root + git common-dir identity
+ * so spawn/handoff can fail closed on mismatch.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { head, repo, type GitRepository } from "../utils/git";
+
+export const REPOSITORY_BINDING_SCHEMA = "gjc.repository_binding.v1" as const;
+
+export interface RepositoryBinding {
+	schema: typeof REPOSITORY_BINDING_SCHEMA;
+	/** Canonical realpath of the git worktree root (or resolved cwd root). */
+	worktreeRoot: string;
+	/** Git common dir realpath when available; null outside a git checkout. */
+	commonDir: string | null;
+	/** Optional repo-relative subdirectory the lane should operate under. */
+	relativeSubdir?: string;
+	/** Optional display path (may be non-canonical); never used for authority. */
+	displayPath?: string;
+	/** Optional baseline HEAD at capture time. */
+	head?: string;
+	/** Optional branch name at capture time (when not detached). */
+	branch?: string;
+}
+
+export type RepositoryBindingErrorCode =
+	| "not_a_repository"
+	| "identity_mismatch"
+	| "path_outside_root"
+	| "invalid_binding";
+
+export class RepositoryBindingError extends Error {
+	readonly code: RepositoryBindingErrorCode;
+
+	constructor(code: RepositoryBindingErrorCode, message: string) {
+		super(message);
+		this.name = "RepositoryBindingError";
+		this.code = code;
+	}
+}
+
+async function realpathOrResolve(target: string): Promise<string> {
+	try {
+		return await fs.realpath(target);
+	} catch {
+		return path.resolve(target);
+	}
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+/** Capture a durable binding from the active cwd/worktree. */
+export async function captureRepositoryBinding(
+	cwd: string,
+	options: { relativeSubdir?: string; displayPath?: string } = {},
+): Promise<RepositoryBinding> {
+	const resolvedCwd = await realpathOrResolve(cwd);
+	const repository = await repo.resolve(resolvedCwd);
+	const worktreeRoot = repository
+		? await realpathOrResolve(repository.repoRoot)
+		: resolvedCwd;
+	const commonDir = repository ? await realpathOrResolve(repository.commonDir) : null;
+
+	let headSha: string | undefined;
+	let branch: string | undefined;
+	if (repository) {
+		const headState = await head.resolve(resolvedCwd);
+		if (headState) {
+			headSha = headState.commit || undefined;
+			branch = headState.kind === "ref" ? headState.branchName || undefined : undefined;
+		}
+	}
+
+	const binding: RepositoryBinding = {
+		schema: REPOSITORY_BINDING_SCHEMA,
+		worktreeRoot,
+		commonDir,
+		...(options.relativeSubdir
+			? { relativeSubdir: normalizeRelativeSubdir(options.relativeSubdir) }
+			: {}),
+		...(options.displayPath ? { displayPath: options.displayPath } : {}),
+		...(headSha ? { head: headSha } : {}),
+		...(branch ? { branch } : {}),
+	};
+	return binding;
+}
+
+function normalizeRelativeSubdir(relative: string): string {
+	const normalized = relative.replaceAll("\\", "/").replace(/^\.\/+/u, "").replace(/\/+$/u, "");
+	if (normalized === "" || normalized === ".") {
+		throw new RepositoryBindingError("invalid_binding", "relativeSubdir must be a non-empty relative path");
+	}
+	if (path.isAbsolute(normalized) || normalized.split("/").includes("..")) {
+		throw new RepositoryBindingError(
+			"invalid_binding",
+			"relativeSubdir must be repo-relative without '..' segments",
+		);
+	}
+	return normalized;
+}
+
+/** Parse a binding from JSON/plan payload; fail closed on malformed shapes. */
+export function parseRepositoryBinding(value: unknown): RepositoryBinding {
+	if (!isObject(value)) {
+		throw new RepositoryBindingError("invalid_binding", "repository binding must be an object");
+	}
+	const schema = nonEmptyString(value.schema);
+	if (schema !== REPOSITORY_BINDING_SCHEMA) {
+		throw new RepositoryBindingError(
+			"invalid_binding",
+			`repository binding schema must be ${REPOSITORY_BINDING_SCHEMA}`,
+		);
+	}
+	const worktreeRoot = nonEmptyString(value.worktreeRoot ?? value.worktree_root);
+	if (!worktreeRoot) {
+		throw new RepositoryBindingError("invalid_binding", "repository binding requires worktreeRoot");
+	}
+	const commonDirRaw = value.commonDir ?? value.common_dir;
+	const commonDir =
+		commonDirRaw === null || commonDirRaw === undefined
+			? null
+			: nonEmptyString(commonDirRaw) ??
+				(() => {
+					throw new RepositoryBindingError("invalid_binding", "commonDir must be a string or null");
+				})();
+	const relativeSubdirRaw = value.relativeSubdir ?? value.relative_subdir;
+	const relativeSubdir =
+		relativeSubdirRaw === undefined ? undefined : normalizeRelativeSubdir(String(relativeSubdirRaw));
+	const displayPath = nonEmptyString(value.displayPath ?? value.display_path);
+	const head = nonEmptyString(value.head);
+	const branch = nonEmptyString(value.branch);
+	return {
+		schema: REPOSITORY_BINDING_SCHEMA,
+		worktreeRoot: path.resolve(worktreeRoot),
+		commonDir: commonDir === null ? null : path.resolve(commonDir),
+		...(relativeSubdir ? { relativeSubdir } : {}),
+		...(displayPath ? { displayPath } : {}),
+		...(head ? { head } : {}),
+		...(branch ? { branch } : {}),
+	};
+}
+
+/** True when two bindings refer to the same repository identity (linked worktrees ok). */
+export function repositoryBindingsMatch(left: RepositoryBinding, right: RepositoryBinding): boolean {
+	if (left.commonDir && right.commonDir) {
+		return path.resolve(left.commonDir) === path.resolve(right.commonDir);
+	}
+	// Non-git workspaces: require exact worktree root match.
+	return path.resolve(left.worktreeRoot) === path.resolve(right.worktreeRoot);
+}
+
+/**
+ * Ensure `cwd` is inside the bound repository (or the same linked worktree family).
+ * Fails closed on sibling-repo drift.
+ */
+export async function assertCwdMatchesRepositoryBinding(
+	cwd: string,
+	binding: RepositoryBinding,
+): Promise<RepositoryBinding> {
+	const active = await captureRepositoryBinding(cwd);
+	if (!repositoryBindingsMatch(active, binding)) {
+		throw new RepositoryBindingError(
+			"identity_mismatch",
+			`Active worktree does not match plan/task repository binding. active=${active.worktreeRoot} (commonDir=${active.commonDir ?? "none"}) bound=${binding.worktreeRoot} (commonDir=${binding.commonDir ?? "none"}).`,
+		);
+	}
+	return active;
+}
+
+/** Ensure a declared target path resolves under the bound worktree root. */
+export function assertPathUnderRepositoryBinding(binding: RepositoryBinding, targetPath: string): string {
+	const root = path.resolve(binding.worktreeRoot);
+	const base = binding.relativeSubdir ? path.resolve(root, binding.relativeSubdir) : root;
+	const resolved = path.isAbsolute(targetPath) ? path.resolve(targetPath) : path.resolve(base, targetPath);
+	const relative = path.relative(root, resolved);
+	if (relative.startsWith("..") || path.isAbsolute(relative)) {
+		throw new RepositoryBindingError(
+			"path_outside_root",
+			`Path escapes bound repository root: ${targetPath} (root=${root})`,
+		);
+	}
+	return resolved;
+}
+
+/** Optional helper for tests and diagnostics. */
+export function bindingFromGitRepository(
+	repository: GitRepository,
+	options: { relativeSubdir?: string; displayPath?: string; head?: string; branch?: string } = {},
+): RepositoryBinding {
+	return {
+		schema: REPOSITORY_BINDING_SCHEMA,
+		worktreeRoot: path.resolve(repository.repoRoot),
+		commonDir: path.resolve(repository.commonDir),
+		...(options.relativeSubdir ? { relativeSubdir: normalizeRelativeSubdir(options.relativeSubdir) } : {}),
+		...(options.displayPath ? { displayPath: options.displayPath } : {}),
+		...(options.head ? { head: options.head } : {}),
+		...(options.branch ? { branch: options.branch } : {}),
+	};
+}

--- a/packages/coding-agent/src/gjc-runtime/repository-binding.ts
+++ b/packages/coding-agent/src/gjc-runtime/repository-binding.ts
@@ -7,7 +7,7 @@
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { head, repo, type GitRepository } from "../utils/git";
+import { type GitRepository, head, repo } from "../utils/git";
 
 export const REPOSITORY_BINDING_SCHEMA = "gjc.repository_binding.v1" as const;
 
@@ -66,9 +66,7 @@ export async function captureRepositoryBinding(
 ): Promise<RepositoryBinding> {
 	const resolvedCwd = await realpathOrResolve(cwd);
 	const repository = await repo.resolve(resolvedCwd);
-	const worktreeRoot = repository
-		? await realpathOrResolve(repository.repoRoot)
-		: resolvedCwd;
+	const worktreeRoot = repository ? await realpathOrResolve(repository.repoRoot) : resolvedCwd;
 	const commonDir = repository ? await realpathOrResolve(repository.commonDir) : null;
 
 	let headSha: string | undefined;
@@ -85,9 +83,7 @@ export async function captureRepositoryBinding(
 		schema: REPOSITORY_BINDING_SCHEMA,
 		worktreeRoot,
 		commonDir,
-		...(options.relativeSubdir
-			? { relativeSubdir: normalizeRelativeSubdir(options.relativeSubdir) }
-			: {}),
+		...(options.relativeSubdir ? { relativeSubdir: normalizeRelativeSubdir(options.relativeSubdir) } : {}),
 		...(options.displayPath ? { displayPath: options.displayPath } : {}),
 		...(headSha ? { head: headSha } : {}),
 		...(branch ? { branch } : {}),
@@ -96,15 +92,15 @@ export async function captureRepositoryBinding(
 }
 
 function normalizeRelativeSubdir(relative: string): string {
-	const normalized = relative.replaceAll("\\", "/").replace(/^\.\/+/u, "").replace(/\/+$/u, "");
+	const normalized = relative
+		.replaceAll("\\", "/")
+		.replace(/^\.\/+/u, "")
+		.replace(/\/+$/u, "");
 	if (normalized === "" || normalized === ".") {
 		throw new RepositoryBindingError("invalid_binding", "relativeSubdir must be a non-empty relative path");
 	}
 	if (path.isAbsolute(normalized) || normalized.split("/").includes("..")) {
-		throw new RepositoryBindingError(
-			"invalid_binding",
-			"relativeSubdir must be repo-relative without '..' segments",
-		);
+		throw new RepositoryBindingError("invalid_binding", "relativeSubdir must be repo-relative without '..' segments");
 	}
 	return normalized;
 }
@@ -129,10 +125,10 @@ export function parseRepositoryBinding(value: unknown): RepositoryBinding {
 	const commonDir =
 		commonDirRaw === null || commonDirRaw === undefined
 			? null
-			: nonEmptyString(commonDirRaw) ??
+			: (nonEmptyString(commonDirRaw) ??
 				(() => {
 					throw new RepositoryBindingError("invalid_binding", "commonDir must be a string or null");
-				})();
+				})());
 	const relativeSubdirRaw = value.relativeSubdir ?? value.relative_subdir;
 	const relativeSubdir =
 		relativeSubdirRaw === undefined ? undefined : normalizeRelativeSubdir(String(relativeSubdirRaw));

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -6,6 +6,12 @@ import { buildUltragoalHudSummary as buildWorkflowUltragoalHudSummary } from "..
 import { renderCliWriteReceipt } from "./cli-write-receipt";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
 import {
+	assertCwdMatchesRepositoryBinding,
+	captureRepositoryBinding,
+	parseRepositoryBinding,
+	type RepositoryBinding,
+} from "./repository-binding";
+import {
 	CRITIC_GATE_HARD_STOP_EVENT,
 	CRITIC_GATE_OVERRIDE_EVENT,
 	CRITIC_VERDICT_EVENT,
@@ -192,6 +198,8 @@ export interface UltragoalPlan {
 	gjcObjective: string;
 	gjcObjectiveAliases?: string[];
 	goals: UltragoalGoal[];
+	/** Authoritative repository identity for multi-repo fail-closed spawn (#2901). */
+	repositoryBinding?: RepositoryBinding;
 	createdAt: string;
 	updatedAt: string;
 	[key: string]: unknown;
@@ -1349,6 +1357,10 @@ function normalizePlan(raw: unknown): UltragoalPlan {
 				(value): value is string => typeof value === "string" && value.trim().length > 0,
 			)
 		: undefined;
+	let repositoryBinding: RepositoryBinding | undefined;
+	if (record.repositoryBinding !== undefined) {
+		repositoryBinding = parseRepositoryBinding(record.repositoryBinding);
+	}
 	return {
 		version: 1,
 		brief,
@@ -1358,6 +1370,7 @@ function normalizePlan(raw: unknown): UltragoalPlan {
 		goals,
 		createdAt,
 		updatedAt,
+		...(repositoryBinding ? { repositoryBinding } : {}),
 		...(typeof record.state_revision === "number" && Number.isFinite(record.state_revision)
 			? { state_revision: record.state_revision }
 			: {}),
@@ -1558,12 +1571,16 @@ export async function createUltragoalPlan(input: {
 		goal.validationBatch = validationBatchByGoalId.get(goal.id);
 		validateValidationBatchPipelineExclusion(goal);
 	}
+	const repositoryBinding = await captureRepositoryBinding(input.cwd, {
+		displayPath: input.cwd,
+	});
 	const plan: UltragoalPlan = {
 		version: 1,
 		brief,
 		gjcGoalMode: input.gjcGoalMode ?? "aggregate",
 		gjcObjective: DEFAULT_ULTRAGOAL_OBJECTIVE,
 		goals,
+		repositoryBinding,
 		createdAt: now,
 		updatedAt: now,
 	};
@@ -1650,6 +1667,9 @@ export async function startNextUltragoalGoal(input: {
 }> {
 	const plan = await readUltragoalPlan(input.cwd, input.sessionId);
 	if (!plan) throw new Error("No ultragoal plan found. Run `gjc ultragoal create-goals --brief ...` first.");
+	if (plan.repositoryBinding) {
+		await assertCwdMatchesRepositoryBinding(input.cwd, plan.repositoryBinding);
+	}
 	const goal = chooseNextGoal(plan, input.retryFailed === true);
 	if (!goal) return { plan, allComplete: getUltragoalRunCompletionState(plan).allComplete };
 	if (goal.status !== "active") {

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -43,6 +43,11 @@ import {
 
 // Import review tools for side effects (registers subagent tool handlers)
 import "../tools/review";
+import {
+	assertCwdMatchesRepositoryBinding,
+	parseRepositoryBinding,
+	RepositoryBindingError,
+} from "../gjc-runtime/repository-binding";
 import { initializeLocalRoot, type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import { generateCommitMessage } from "../utils/commit-message-generator";
 import * as git from "../utils/git";
@@ -126,6 +131,25 @@ function addUsageTotals(target: Usage, usage: Partial<Usage>): void {
 	target.cost.cacheRead += cost.cacheRead;
 	target.cost.cacheWrite += cost.cacheWrite;
 	target.cost.total += cost.total;
+}
+
+async function validateTaskRepositoryBindings(
+	cwd: string,
+	tasks: readonly TaskItem[],
+): Promise<string | undefined> {
+	for (const task of tasks) {
+		if (!task.repositoryBinding) continue;
+		try {
+			const binding = parseRepositoryBinding(task.repositoryBinding);
+			await assertCwdMatchesRepositoryBinding(cwd, binding);
+		} catch (error) {
+			if (error instanceof RepositoryBindingError) {
+				return `Task "${task.id}" repository binding rejected: ${error.message}`;
+			}
+			return `Task "${task.id}" repository binding rejected: ${error instanceof Error ? error.message : String(error)}`;
+		}
+	}
+	return undefined;
 }
 
 function validateTaskIdsForScheduling(tasks: readonly TaskItem[]): string | undefined {
@@ -436,6 +460,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const taskIdValidationError = validateTaskIdsForScheduling(taskItems);
 		if (taskIdValidationError) {
 			return createTaskModeError(taskIdValidationError);
+		}
+		const repositoryBindingError = await validateTaskRepositoryBindings(this.session.cwd, taskItems);
+		if (repositoryBindingError) {
+			return createTaskModeError(repositoryBindingError);
 		}
 		if (taskItems.length === 0) {
 			return this.#executeSync(_toolCallId, params, signal, onUpdate);

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -133,10 +133,7 @@ function addUsageTotals(target: Usage, usage: Partial<Usage>): void {
 	target.cost.total += cost.total;
 }
 
-async function validateTaskRepositoryBindings(
-	cwd: string,
-	tasks: readonly TaskItem[],
-): Promise<string | undefined> {
+async function validateTaskRepositoryBindings(cwd: string, tasks: readonly TaskItem[]): Promise<string | undefined> {
 	for (const task of tasks) {
 		if (!task.repositoryBinding) continue;
 		try {

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -74,6 +74,23 @@ const spawnPlanSchema = z
 	})
 	.describe("justification required before spawning more than four tasks");
 
+const repositoryBindingSchema = z
+	.object({
+		schema: z.literal("gjc.repository_binding.v1"),
+		worktreeRoot: z.string().min(1).describe("canonical git worktree root"),
+		commonDir: z.string().min(1).nullable().describe("git common dir, or null outside a git checkout"),
+		relativeSubdir: z
+			.string()
+			.min(1)
+			.optional()
+			.describe("optional repo-relative subdirectory; not an absolute cwd"),
+		displayPath: z.string().min(1).optional().describe("human-facing path; never used for authority"),
+		head: z.string().min(1).optional(),
+		branch: z.string().min(1).optional(),
+	})
+	.strict()
+	.describe("authoritative repository identity for multi-repo fail-closed spawn");
+
 const createTaskItemSchema = (_contextEnabled: boolean) =>
 	z.object({
 		id: z.string().max(48).refine(isValidTaskId, TASK_ID_DESCRIPTION).describe("filesystem-safe task identifier"),
@@ -85,6 +102,9 @@ const createTaskItemSchema = (_contextEnabled: boolean) =>
 			.describe(
 				"fork-context mode: none/omitted copies no parent context; receipt copies a minimal receipt-sized snapshot; last-turn copies only the latest exchange; bounded copies the bounded default snapshot; full copies a larger sanitized snapshot up to the configured/model token cap",
 			),
+		repositoryBinding: repositoryBindingSchema
+			.optional()
+			.describe("fail-closed repository identity; when set, must match the active worktree before spawn"),
 	});
 
 /** Single task item for parallel execution (default shape with context enabled). */

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -79,11 +79,7 @@ const repositoryBindingSchema = z
 		schema: z.literal("gjc.repository_binding.v1"),
 		worktreeRoot: z.string().min(1).describe("canonical git worktree root"),
 		commonDir: z.string().min(1).nullable().describe("git common dir, or null outside a git checkout"),
-		relativeSubdir: z
-			.string()
-			.min(1)
-			.optional()
-			.describe("optional repo-relative subdirectory; not an absolute cwd"),
+		relativeSubdir: z.string().min(1).optional().describe("optional repo-relative subdirectory; not an absolute cwd"),
 		displayPath: z.string().min(1).optional().describe("human-facing path; never used for authority"),
 		head: z.string().min(1).optional(),
 		branch: z.string().min(1).optional(),

--- a/packages/coding-agent/test/gjc-runtime/repository-binding.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/repository-binding.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	assertCwdMatchesRepositoryBinding,
+	assertPathUnderRepositoryBinding,
+	captureRepositoryBinding,
+	parseRepositoryBinding,
+	REPOSITORY_BINDING_SCHEMA,
+	RepositoryBindingError,
+	repositoryBindingsMatch,
+} from "../../src/gjc-runtime/repository-binding";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fsp.rm(dir, { recursive: true, force: true })));
+});
+
+async function initGitRepo(root: string): Promise<void> {
+	const run = async (args: string[]) => {
+		const proc = Bun.spawn(["git", ...args], { cwd: root, stdout: "pipe", stderr: "pipe" });
+		const code = await proc.exited;
+		if (code !== 0) {
+			const err = await new Response(proc.stderr).text();
+			throw new Error(`git ${args.join(" ")} failed: ${err}`);
+		}
+	};
+	await run(["init"]);
+	await run(["config", "user.email", "test@example.com"]);
+	await run(["config", "user.name", "Test"]);
+	await fsp.writeFile(path.join(root, "README.md"), "hello\n");
+	await run(["add", "README.md"]);
+	await run(["commit", "-m", "init"]);
+}
+
+describe("repository binding (#2901)", () => {
+	it("captures and matches the same repository identity", async () => {
+		const root = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-repo-bind-"));
+		tempRoots.push(root);
+		await initGitRepo(root);
+
+		const binding = await captureRepositoryBinding(root);
+		expect(binding.schema).toBe(REPOSITORY_BINDING_SCHEMA);
+		expect(binding.commonDir).toBeTruthy();
+		expect(path.resolve(binding.worktreeRoot)).toBe(path.resolve(root));
+
+		const active = await assertCwdMatchesRepositoryBinding(root, binding);
+		expect(repositoryBindingsMatch(active, binding)).toBe(true);
+		expect(assertPathUnderRepositoryBinding(binding, "README.md")).toContain("README.md");
+	});
+
+	it("fails closed when active cwd is a sibling repository", async () => {
+		const parent = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-repo-siblings-"));
+		tempRoots.push(parent);
+		const left = path.join(parent, "left");
+		const right = path.join(parent, "right");
+		await fsp.mkdir(left);
+		await fsp.mkdir(right);
+		await initGitRepo(left);
+		await initGitRepo(right);
+
+		const leftBinding = await captureRepositoryBinding(left);
+		await expect(assertCwdMatchesRepositoryBinding(right, leftBinding)).rejects.toBeInstanceOf(
+			RepositoryBindingError,
+		);
+		await expect(assertCwdMatchesRepositoryBinding(right, leftBinding)).rejects.toMatchObject({
+			code: "identity_mismatch",
+		});
+
+		expect(() => assertPathUnderRepositoryBinding(leftBinding, path.join(right, "README.md"))).toThrow(
+			/escapes bound repository root/,
+		);
+	});
+
+	it("rejects relativeSubdir that escapes with ..", () => {
+		expect(() =>
+			parseRepositoryBinding({
+				schema: REPOSITORY_BINDING_SCHEMA,
+				worktreeRoot: "/tmp/repo",
+				commonDir: "/tmp/repo/.git",
+				relativeSubdir: "../sibling",
+			}),
+		).toThrow(/relativeSubdir/);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #2901.

Plans and delegated tasks can now carry an authoritative repository identity so multi-repo parent workspaces fail closed instead of letting QA/review lanes drift into a sibling repository.

## What / Why

Ralplan/Ultragoal artifacts and `TaskItem` had no repository binding. Authority was implicit session cwd, while plans only carried repo-relative paths. In a multi-repo parent directory a delegated lane could inspect/mutate a sibling based on prose inference.

## How (first slice)

- New `repository-binding.ts`: capture/parse/match/path checks (`gjc.repository_binding.v1`)
- Ultragoal `create-goals` stamps `repositoryBinding`; `startNextUltragoalGoal` fails closed on mismatch
- Ralplan consensus seed records `repository_binding` in run state
- Task items accept optional `repositoryBinding`; task spawn validates before scheduling
- `relativeSubdir` is repo-relative only (no absolute cwd / `..`)

## Product dogfood (not unit tests alone)

Reproducible product-surface script:

```sh
bun packages/coding-agent/scripts/dogfood-repository-binding.ts
```

Creates two sibling git repos, runs real `gjc ultragoal create-goals` + `gjc ralplan` CLI entrypoints, and proves:

- binding stamped on `goals.json` / `ralplan-state.json`
- LEFT start succeeds
- RIGHT sibling cwd fails closed with identity_mismatch
- sibling absolute path fails closed as path_outside_root

See the latest PR comment for a full transcript from a local product run.

## Tests

- `bun test packages/coding-agent/test/gjc-runtime/repository-binding.test.ts`
- `bun packages/coding-agent/scripts/dogfood-repository-binding.ts` (product dogfood)

## Out of scope / follow-up

- Auto-binding every historical plan without field
- Isolating worktree spawn to rewrite child cwd from binding
- Auto-extraction of binding from free-form plan prose