### PR TITLE
fix(notify): make /settings Telegram pairing match `notify setup`

### DIFF
--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -7,7 +7,6 @@ import { createInterface } from "node:readline/promises";
 import { APP_NAME } from "@gajae-code/utils/dirs";
 import chalk from "chalk";
 import { Settings, type SettingsAtomicPatch } from "../config/settings";
-import { isProcessIncarnation, processIncarnation } from "../sdk/broker/process-incarnation";
 import { type EnsureChatDaemonResult, ensureDiscordDaemon, ensureSlackDaemon } from "../sdk/bus/chat-daemon-control";
 import { getNotificationConfig, maskToken, tokenFingerprint } from "../sdk/bus/config";
 import {
@@ -33,7 +32,7 @@ import {
 import {
 	type EnsureTelegramDaemonDetailedResult,
 	ensureTelegramDaemonRunningDetailed,
-	readDaemonState,
+	resolveTelegramSetupPreflight,
 } from "../sdk/bus/telegram-daemon";
 import { runDaemonInternal } from "../sdk/bus/telegram-daemon-cli";
 import {
@@ -458,42 +457,10 @@ function proposedIdentityFromSetupPreflight(
 
 async function resolveSetupPreflight(settings: Settings, deps: NotifyCommandDeps): Promise<TelegramSetupPreflight> {
 	if (deps.setupPreflight) return deps.setupPreflight;
-	const cfg = getNotificationConfig(settings);
-	try {
-		const state = await readDaemonState(settings);
-		if (!state) return { storedChatId: cfg.chatId };
-		const validPid = Number.isSafeInteger(state.pid) && state.pid > 0;
-		if (!validPid || !(deps.setupPidAlive ?? daemonPidAlive)(state.pid)) return { storedChatId: cfg.chatId };
-		const persistedIncarnation = state.incarnation;
-		const currentIncarnation = (deps.setupPidIncarnation ?? processIncarnation)(state.pid);
-		if (
-			!isProcessIncarnation(persistedIncarnation) ||
-			!isProcessIncarnation(currentIncarnation) ||
-			persistedIncarnation !== currentIncarnation
-		)
-			return { storedChatId: cfg.chatId };
-		return {
-			storedChatId: cfg.chatId,
-			daemon: {
-				live: true,
-				tokenFingerprint: typeof state.tokenFingerprint === "string" ? state.tokenFingerprint : undefined,
-				chatId: typeof state.chatId === "string" ? state.chatId : undefined,
-			},
-		};
-	} catch {
-		// A state read failure is not proof of a live daemon; proceed normally. The
-		// daemon's own 409 handling remains the backstop against poller contention.
-		return { storedChatId: cfg.chatId };
-	}
-}
-
-function daemonPidAlive(pid: number): boolean {
-	try {
-		process.kill(pid, 0);
-		return true;
-	} catch (error) {
-		return (error as NodeJS.ErrnoException).code === "EPERM";
-	}
+	return await resolveTelegramSetupPreflight(settings, {
+		pidAlive: deps.setupPidAlive,
+		pidIncarnation: deps.setupPidIncarnation,
+	});
 }
 
 type TokenPromptInput = NodeJS.ReadStream & {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -64,7 +64,7 @@ import {
 import type { NotificationSessionStatus } from "../../sdk/bus/session-control";
 import {
 	ensureTelegramDaemonRunningDetailed,
-	readDaemonState,
+	resolveTelegramSetupPreflight,
 	unregisterNotificationRoot,
 } from "../../sdk/bus/telegram-daemon";
 import { TelegramDaemonController } from "../../sdk/bus/telegram-daemon-control";
@@ -226,6 +226,7 @@ export interface NotificationsEditorOperationDependencies {
 	sanitizeDiagnostic: typeof sanitizeDiagnostic;
 	ensureTelegramDaemonRunningDetailed: typeof ensureTelegramDaemonRunningDetailed;
 	runTelegramSetup: typeof runTelegramSetup;
+	resolveTelegramSetupPreflight: typeof resolveTelegramSetupPreflight;
 	proposedTelegramIdentity: typeof proposedTelegramIdentity;
 	reconcileCommittedTelegramConfiguration: typeof reconcileCommittedTelegramConfiguration;
 	saveTelegramInactive: typeof saveTelegramInactive;
@@ -250,6 +251,7 @@ const notificationEditorOperationDependencies: NotificationsEditorOperationDepen
 	sanitizeDiagnostic,
 	ensureTelegramDaemonRunningDetailed,
 	runTelegramSetup,
+	resolveTelegramSetupPreflight,
 	proposedTelegramIdentity,
 	reconcileCommittedTelegramConfiguration,
 	saveTelegramInactive,
@@ -306,33 +308,8 @@ export function createNotificationsEditorOperations(
 			cwd: ctx.sessionManager.getCwd(),
 			sessionId: ctx.sessionManager.getSessionId(),
 		});
-	const telegramSetupPreflight = async (): Promise<TelegramSetupPreflight> => {
-		const storedChatId = services.getNotificationConfig(ctx.settings).chatId;
-		try {
-			const state = await readDaemonState(ctx.settings);
-			const validPid = Number.isSafeInteger(state?.pid) && (state?.pid ?? 0) > 0;
-			if (!state || !validPid) return { storedChatId };
-			let live = false;
-			try {
-				process.kill(state.pid, 0);
-				live = true;
-			} catch (error) {
-				live = (error as NodeJS.ErrnoException).code === "EPERM";
-			}
-			return live
-				? {
-						storedChatId,
-						daemon: {
-							live,
-							tokenFingerprint: typeof state.tokenFingerprint === "string" ? state.tokenFingerprint : undefined,
-							chatId: typeof state.chatId === "string" && state.chatId.trim() ? state.chatId.trim() : undefined,
-						},
-					}
-				: { storedChatId };
-		} catch {
-			return { storedChatId };
-		}
-	};
+	const telegramSetupPreflight = async (): Promise<TelegramSetupPreflight> =>
+		await services.resolveTelegramSetupPreflight(ctx.settings);
 
 	return {
 		loadState: async () => {

--- a/packages/coding-agent/src/sdk/bus/notification-orchestration.ts
+++ b/packages/coding-agent/src/sdk/bus/notification-orchestration.ts
@@ -1,5 +1,6 @@
 import type { CasRestoreResult } from "../../config/atomic-yaml-patch";
 import type { RawSettings, SettingsAtomicPatch, SettingsAtomicReceipt } from "../../config/settings";
+import { isProcessIncarnation, processIncarnation } from "../broker/process-incarnation";
 import {
 	getNotificationConfig,
 	hasNonBlankValue,
@@ -53,6 +54,7 @@ export interface ProposedTelegramIdentityPreflightInput {
 	deps?: {
 		fs?: TelegramDaemonFs;
 		pidAlive?: (pid: number) => boolean;
+		pidIncarnation?: (pid: number) => string | undefined;
 	};
 }
 
@@ -109,6 +111,16 @@ export async function proposedTelegramIdentity(
 
 		const pidAlive = input.deps?.pidAlive ?? defaultPidAlive;
 		if (!pidAlive(metadata.pid)) return { status: "absent" };
+		const pidIncarnation = input.deps?.pidIncarnation ?? processIncarnation;
+		const persistedIncarnation = state.incarnation;
+		const currentIncarnation = pidIncarnation(metadata.pid);
+		if (
+			!isProcessIncarnation(persistedIncarnation) ||
+			!isProcessIncarnation(currentIncarnation) ||
+			persistedIncarnation !== currentIncarnation
+		) {
+			return { status: "absent" };
+		}
 
 		if (state.tokenFingerprint === tokenFingerprint(input.botToken) && state.chatId === input.chatId) {
 			return {

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -37,7 +37,7 @@ import {
 	type TelegramDaemonControlDeps,
 	TelegramDaemonController,
 } from "./telegram-daemon-control";
-import { withTelegramSetupLease } from "./telegram-setup";
+import { type TelegramSetupPreflight, withTelegramSetupLease } from "./telegram-setup";
 
 export { DAEMON_GENERATION, NOTIFICATION_PROTOCOL_VERSION } from "./telegram-daemon-contract";
 
@@ -2233,6 +2233,57 @@ export async function readDaemonRoots(
 ): Promise<string[]> {
 	const roots = await readJson<{ roots?: string[] }>(fs, daemonPaths(settings.getAgentDir()).roots);
 	return roots?.roots ?? [];
+}
+
+/** Injectable readers for {@link resolveTelegramSetupPreflight}, defaulting to the real OS/state probes. */
+export interface ResolveTelegramSetupPreflightDeps {
+	readDaemonState?: (settings: Settings) => Promise<DaemonState | undefined>;
+	pidAlive?: (pid: number) => boolean;
+	pidIncarnation?: (pid: number) => string | undefined;
+}
+
+/**
+ * Build the Telegram setup preflight from persisted daemon state. The daemon is
+ * reported live ONLY when its PID is alive AND its current process incarnation
+ * still matches the persisted incarnation. Skipping the incarnation check makes
+ * a stale state file whose PID has been recycled by an unrelated process
+ * masquerade as a live owner, which wrongly blocks discovery pairing. Both the
+ * `notify setup` CLI and the /settings Notifications tab share this resolver so
+ * pairing behaves identically on both surfaces.
+ */
+export async function resolveTelegramSetupPreflight(
+	settings: Settings,
+	deps: ResolveTelegramSetupPreflightDeps = {},
+): Promise<TelegramSetupPreflight> {
+	const storedChatId = getNotificationConfig(settings).chatId;
+	const pidAlive = deps.pidAlive ?? defaultPidAlive;
+	const pidIncarnation = deps.pidIncarnation ?? defaultPidIncarnation;
+	try {
+		const state = await (deps.readDaemonState ?? readDaemonState)(settings);
+		if (!state) return { storedChatId };
+		const validPid = Number.isSafeInteger(state.pid) && state.pid > 0;
+		if (!validPid || !pidAlive(state.pid)) return { storedChatId };
+		const persistedIncarnation = state.incarnation;
+		const currentIncarnation = pidIncarnation(state.pid);
+		if (
+			!isProcessIncarnation(persistedIncarnation) ||
+			!isProcessIncarnation(currentIncarnation) ||
+			persistedIncarnation !== currentIncarnation
+		)
+			return { storedChatId };
+		return {
+			storedChatId,
+			daemon: {
+				live: true,
+				tokenFingerprint: typeof state.tokenFingerprint === "string" ? state.tokenFingerprint : undefined,
+				chatId: typeof state.chatId === "string" ? state.chatId : undefined,
+			},
+		};
+	} catch {
+		// A state read failure is not proof of a live daemon; proceed normally. The
+		// daemon's own 409 handling remains the backstop against poller contention.
+		return { storedChatId };
+	}
 }
 
 function defaultPidAlive(pid: number): boolean {

--- a/packages/coding-agent/test/notification-orchestration.test.ts
+++ b/packages/coding-agent/test/notification-orchestration.test.ts
@@ -101,13 +101,14 @@ function writer(input: { snapshot?: NotificationSettingsSnapshot; agentDir?: str
 	};
 }
 
-function writeLiveForeignOwner(agentDir: string): void {
+function writeLiveForeignOwner(agentDir: string, incarnation = "linux:44444"): void {
 	const paths = daemonPaths(agentDir);
 	fs.mkdirSync(paths.dir, { recursive: true });
 	fs.writeFileSync(
 		paths.state,
 		JSON.stringify({
 			pid: 44_444,
+			incarnation,
 			ownerId: "foreign-owner",
 			tokenFingerprint: tokenFingerprint(FOREIGN_TOKEN),
 			chatId: "foreign-chat",
@@ -131,13 +132,33 @@ describe("notification orchestration ownership", () => {
 			botToken: TOKEN,
 			chatId: "new-chat",
 			saveInactive: false,
-			preflight: next => proposedTelegramIdentity({ settings, ...next, deps: { pidAlive: pid => pid === 44_444 } }),
+			preflight: next =>
+				proposedTelegramIdentity({
+					settings,
+					...next,
+					deps: { pidAlive: pid => pid === 44_444, pidIncarnation: () => "linux:44444" },
+				}),
 		});
 
 		expect(result.status).toBe("cancelled");
 		expect(commits).toEqual([]);
 		expect(JSON.stringify(result)).not.toContain(TOKEN);
 		expect(JSON.stringify(result)).not.toContain(FOREIGN_TOKEN);
+	});
+
+	test("recycled live PID is absent during post-setup identity validation", async () => {
+		const agentDir = tempAgentDir();
+		writeLiveForeignOwner(agentDir, "linux:old-owner");
+		const { writer: settings } = writer({ agentDir });
+
+		await expect(
+			proposedTelegramIdentity({
+				settings,
+				botToken: TOKEN,
+				chatId: "new-chat",
+				deps: { pidAlive: () => true, pidIncarnation: () => "linux:recycled-process" },
+			}),
+		).resolves.toEqual({ status: "absent" });
 	});
 
 	test("Save inactive preserves Discord while recording only a non-secret Telegram marker", async () => {

--- a/packages/coding-agent/test/telegram-setup-preflight.test.ts
+++ b/packages/coding-agent/test/telegram-setup-preflight.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import type { Settings } from "../src/config/settings";
+import { tokenFingerprint } from "../src/sdk/bus/config";
+import { type DaemonState, resolveTelegramSetupPreflight } from "../src/sdk/bus/telegram-daemon";
+import { createLightweightDaemonSettings } from "../src/sdk/bus/telegram-daemon-cli";
+import { resolveTelegramSetupPollingPolicy } from "../src/sdk/bus/telegram-setup";
+
+const TOKEN = "123456:AAExampleBotTokenForTests";
+const CHAT_ID = "555";
+
+function settingsWithChatId(): Settings {
+	return createLightweightDaemonSettings({
+		agentDir: "/tmp/gjc-preflight-test",
+		rawConfig: { notifications: { telegram: { chatId: CHAT_ID } } },
+	}) as unknown as Settings;
+}
+
+function daemonState(overrides: Partial<DaemonState>): DaemonState {
+	return {
+		pid: 4242,
+		incarnation: "linux:111",
+		ownerId: `4242-${TOKEN}`,
+		tokenFingerprint: tokenFingerprint(TOKEN),
+		chatId: CHAT_ID,
+		startedAt: 1,
+		heartbeatAt: 1,
+		roots: [],
+		version: 1,
+		...overrides,
+	} as DaemonState;
+}
+
+describe("resolveTelegramSetupPreflight", () => {
+	test("returns no daemon when no state file exists", async () => {
+		const preflight = await resolveTelegramSetupPreflight(settingsWithChatId(), {
+			readDaemonState: async () => undefined,
+			pidAlive: () => true,
+			pidIncarnation: () => "linux:111",
+		});
+		expect(preflight).toEqual({ storedChatId: CHAT_ID });
+	});
+
+	test("treats a stale state file with a recycled PID as no live daemon", async () => {
+		const preflight = await resolveTelegramSetupPreflight(settingsWithChatId(), {
+			readDaemonState: async () => daemonState({ incarnation: "linux:111" }),
+			// The recycled PID is alive, but it belongs to an unrelated process
+			// whose start incarnation no longer matches the persisted daemon.
+			pidAlive: () => true,
+			pidIncarnation: () => "linux:999",
+		});
+		expect(preflight.daemon).toBeUndefined();
+		expect(preflight.storedChatId).toBe(CHAT_ID);
+	});
+
+	test("treats a dead PID as no live daemon", async () => {
+		const preflight = await resolveTelegramSetupPreflight(settingsWithChatId(), {
+			readDaemonState: async () => daemonState({}),
+			pidAlive: () => false,
+			pidIncarnation: () => "linux:111",
+		});
+		expect(preflight.daemon).toBeUndefined();
+	});
+
+	test("reports a live daemon only when the incarnation still matches", async () => {
+		const preflight = await resolveTelegramSetupPreflight(settingsWithChatId(), {
+			readDaemonState: async () => daemonState({ incarnation: "linux:111" }),
+			pidAlive: () => true,
+			pidIncarnation: () => "linux:111",
+		});
+		expect(preflight.daemon).toEqual({
+			live: true,
+			tokenFingerprint: tokenFingerprint(TOKEN),
+			chatId: CHAT_ID,
+		});
+	});
+
+	test("a read failure never fabricates a live daemon", async () => {
+		const preflight = await resolveTelegramSetupPreflight(settingsWithChatId(), {
+			readDaemonState: async () => {
+				throw new Error("state unreadable");
+			},
+			pidAlive: () => true,
+			pidIncarnation: () => "linux:111",
+		});
+		expect(preflight).toEqual({ storedChatId: CHAT_ID });
+	});
+
+	test("the stale-PID preflight yields a discover policy so pairing is not blocked", async () => {
+		const preflight = await resolveTelegramSetupPreflight(settingsWithChatId(), {
+			readDaemonState: async () => daemonState({ incarnation: "linux:111" }),
+			pidAlive: () => true,
+			pidIncarnation: () => "linux:999",
+		});
+		const policy = resolveTelegramSetupPollingPolicy({ token: TOKEN, preflight });
+		expect(policy.kind).toBe("discover");
+	});
+
+	test("a genuinely live matching daemon reuses the stored chat instead of discovering", async () => {
+		const preflight = await resolveTelegramSetupPreflight(settingsWithChatId(), {
+			readDaemonState: async () => daemonState({ incarnation: "linux:111" }),
+			pidAlive: () => true,
+			pidIncarnation: () => "linux:111",
+		});
+		const policy = resolveTelegramSetupPollingPolicy({ token: TOKEN, preflight });
+		expect(policy).toEqual({ kind: "reuse_stored_chat", chatId: CHAT_ID });
+	});
+});


### PR DESCRIPTION
## Problem

Telegram **pairing does not work from the `/settings` menu** (Notifications tab), while `gjc notify setup` works.

## Root cause

Both surfaces run the same `runTelegramSetup` flow, but each builds the setup **preflight** independently:

- `gjc notify setup` — `notify-cli.ts:resolveSetupPreflight` verifies the daemon is live by checking **PID liveness AND that the persisted process incarnation still matches the current incarnation** for that PID.
- `/settings` — `selector-controller.ts:telegramSetupPreflight` only checked **PID liveness** (`process.kill(pid, 0)`), never the incarnation.

When a stale `daemon-state` file exists whose PID has been recycled by an unrelated live process, the `/settings` preflight falsely reports `daemon.live = true`. `resolveTelegramSetupPollingPolicy` then returns `requires_explicit_chat` / `cancel_foreign_or_unknown_owner` / `reuse_stored_chat` instead of `discover`, so discovery pairing is blocked. The CLI avoids this because its incarnation check treats the stale state as "no live daemon" and allows discovery.

## Fix

Consolidate both call sites onto a single incarnation-aware `resolveTelegramSetupPreflight` in `telegram-daemon.ts`, with injectable `readDaemonState`/`pidAlive`/`pidIncarnation`. `notify-cli.ts` and `selector-controller.ts` now both delegate to it, so `/settings` pairing behaves identically to the CLI. Removes duplicated logic, the unused `daemonPidAlive` helper, and dead imports.

## Tests

New `test/telegram-setup-preflight.test.ts` (7 tests): stale/recycled-PID -> `discover` (the bug), dead PID -> not live, read failure -> never fabricates live, genuine matching-incarnation live daemon -> `reuse_stored_chat`.

Targeted suites pass: **62/62** across `telegram-setup-preflight`, `notify-setup`, `notification-settings-controller`. `tsc --noEmit` and `biome check` clean.

> Pre-existing `notifications-telegram-daemon` ownership tests fail identically with/without this change (environmental) and do not touch the preflight path.