### PR TITLE
test(session): exercise portable append race path

### DIFF
--- a/packages/coding-agent/test/session/managed-append-darwin-ctime.test.ts
+++ b/packages/coding-agent/test/session/managed-append-darwin-ctime.test.ts
@@ -93,7 +93,7 @@ describe("ManagedSessionDescendantStore.appendSync fail-closed races", () => {
 		const beforeBytes = fs.readFileSync(filePath);
 		const record = Buffer.from(`${JSON.stringify({ type: "message", id: "m-race" })}\n`, "utf8");
 
-		installWriteOpenHook(
+		const openState = installWriteOpenHook(
 			filePath,
 			pathname => {
 				fs.appendFileSync(pathname, "stale-race\n");
@@ -102,9 +102,10 @@ describe("ManagedSessionDescendantStore.appendSync fail-closed races", () => {
 		);
 
 		expect(() => store.appendSync(relativePath, record)).toThrow("identity_mismatch");
+		expect(openState.calls).toBe(1);
 		const after = fs.readFileSync(filePath, "utf8");
+		expect(after).toBe(`${beforeBytes.toString("utf8")}stale-race\n`);
 		expect(after.includes('"id":"m-race"')).toBe(false);
-		expect(after.startsWith(beforeBytes.toString("utf8"))).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/test/session/managed-append-darwin-ctime.test.ts
+++ b/packages/coding-agent/test/session/managed-append-darwin-ctime.test.ts
@@ -25,7 +25,7 @@ afterEach(async () => {
 	);
 });
 
-async function createStore(): Promise<{
+async function createStore(options?: { withoutNativeAuthority?: boolean }): Promise<{
 	root: string;
 	store: ManagedSessionDescendantStore;
 	filePath: string;
@@ -35,7 +35,16 @@ async function createStore(): Promise<{
 	temporaryDirectories.push(root);
 	// Owner-only directory expected by managed security.
 	await fsp.chmod(root, 0o700);
-	const store = new ManagedSessionDescendantStore(managedDirectoryRoot(root), root);
+	const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+	let store: ManagedSessionDescendantStore;
+	try {
+		if (options?.withoutNativeAuthority && process.platform === "linux") {
+			Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+		}
+		store = new ManagedSessionDescendantStore(managedDirectoryRoot(root), root);
+	} finally {
+		if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
+	}
 	const relativePath = "transcript.jsonl";
 	const initial = Buffer.from(`${JSON.stringify({ type: "session", id: "seed" })}\n`, "utf8");
 	store.publishNoReplaceSync(relativePath, initial);
@@ -80,13 +89,17 @@ function bumpCtimeOnly(pathname: string): void {
 
 describe("ManagedSessionDescendantStore.appendSync fail-closed races", () => {
 	it("rejects size mutation between capture and write-open without appending the request", async () => {
-		const { store, filePath, relativePath } = await createStore();
+		const { store, filePath, relativePath } = await createStore({ withoutNativeAuthority: true });
 		const beforeBytes = fs.readFileSync(filePath);
 		const record = Buffer.from(`${JSON.stringify({ type: "message", id: "m-race" })}\n`, "utf8");
 
-		installWriteOpenHook(filePath, pathname => {
-			fs.appendFileSync(pathname, "stale-race\n");
-		});
+		installWriteOpenHook(
+			filePath,
+			pathname => {
+				fs.appendFileSync(pathname, "stale-race\n");
+			},
+			{ maxCalls: 1 },
+		);
 
 		expect(() => store.appendSync(relativePath, record)).toThrow("identity_mismatch");
 		const after = fs.readFileSync(filePath, "utf8");


### PR DESCRIPTION
## What

Repair the deterministic shard-7 regression introduced with #2946 by making the fail-closed size-race test exercise the portable JavaScript append path on Linux, limiting the injected write-open race to one mutation, and asserting the hook ran exactly once with exact stale-race bytes.

## Why

Dev CI repeatedly failed only `ManagedSessionDescendantStore.appendSync fail-closed races > rejects size mutation between capture and write-open without appending the request` at merged dev heads. The production ctime-refresh repair remains intact. The regression was in the cross-platform test harness: Linux retained native authority bypassed the mocked portable `fs.openSync` path, while an unbounded injected `appendFileSync` could recursively reinject once the portable path was reached.

Issue #2944 remains closed because the Darwin ctime repair itself is complete; this PR restores valid portable fail-closed coverage.

## Testing

Exact head: `71218a7b71f8961ef6bae4bf30d231074c4c66a4`
Diff SHA-256: `55faa1646b3ce4b343e927dd35b0e5fe5567ba68ac1fde95f895e931fcd8fa12`

Fresh detached exact-head checkout:
- `bun test packages/coding-agent/test/session/managed-append-darwin-ctime.test.ts` — 1 pass, 3 Darwin skips, 0 fail, 4 assertions.
- `CI_FORCE_FULL=1 CI_CODING_AGENT_TEST_SHARDS=8 GITHUB_ACTIONS='' bun scripts/ci-dev-affected.ts --task=test:@gajae-code/coding-agent:shard-7-of-8` — 2030 pass, 58 skip, 0 fail, 7405 assertions.
- `bun run build` — passed.
- Native production size-race adversarial replay — `identity_mismatch`; stale mutation observed; requested append absent.
- Hosted run [29977640398](https://github.com/Yeachan-Heo/gajae-code/actions/runs/29977640398) — terminal green, no failed or pending checks.
- Independent architect exact-head review — CLEAR/CLEAR/CLEAR, APPROVE.
- Independent executor red-team exact-head review — passed/passed/passed, no blockers.
- Duplicate automated P1 comments were resolved with the zero-component `ensureManagedDirectory` fast path and fresh native-binding evidence.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:55faa1646b3ce4b343e927dd35b0e5fe5567ba68ac1fde95f895e931fcd8fa12 reviewer:architect evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/29977640398
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (not run; scoped exact-head CI, forced shard, and build are green)
- [x] Tested locally
- [x] CHANGELOG updated (not user-facing; no entry required)
- [x] Verdict above matches the exact PR head, not an earlier commit