### PR TITLE
fix(ai): recover OAuth refresh rotation races before failure classification

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - OpenAI Responses / Codex native history replay no longer submits missing resident-image placeholders as `input_image.image_url`. Invalid values (including `[Session resident imageUrl blob missing: …]`) are dropped, or retained as `file_id`-only parts when a non-empty `file_id` is present, so a single unavailable historical image cannot brick `/retry` (#2924).
 - Raised the first-event stream timeout floor to five minutes for `alibaba-token-plan` models using the OpenAI Completions and Responses APIs, while preserving caller and environment overrides and the existing inter-event idle timeout.
+- OAuth refresh peer-rotation recovery now runs before failure classification instead of only on the definitive-failure path, and the definitive matcher recognizes the "grant is invalid" phrasing. Providers whose invalid-grant response does not contain the literal `invalid_grant` (e.g. Kimi's 400 "The provided authorization grant is invalid") previously had rotation races misclassified as transient, temp-blocking a healthy credential for five minutes on every race; with Kimi's ~12-minute access tokens and multiple processes sharing the credential store this surfaced as repeated logouts. Genuine revocations are now disabled with a cause instead of looping temp-blocks.
 
 ## [0.11.7] - 2026-07-22
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3202,10 +3202,38 @@ export class AuthStorage {
 			return { apiKey: result.apiKey, credential: updated };
 		} catch (error) {
 			const errorMsg = String(error);
+			// Peer-rotation recovery runs before ANY failure classification: a
+			// concurrent process may have rotated the refresh token, which
+			// invalidates the snapshot token we just attempted. Re-read the row —
+			// if the persisted refresh token changed, the peer's rotation succeeded
+			// and we pick up the fresh credential instead of disabling (definitive
+			// path) or temp-blocking (transient path) a row that is actually
+			// healthy. This matters for providers whose invalid-grant response does
+			// not match the definitive regex below (e.g. Kimi's 400 "The provided
+			// authorization grant is invalid"): with short-lived access tokens and
+			// multiple gjc processes sharing the store, the stale-snapshot failure
+			// would otherwise be misclassified as transient and the credential
+			// temp-blocked on every rotation race.
+			const attemptedCredentialId = this.#getStoredCredentials(provider)[selection.index]?.id;
+			if (attemptedCredentialId !== undefined) {
+				const latestRow = this.#store.listAuthCredentials(provider).find(row => row.id === attemptedCredentialId);
+				const latestCredential = latestRow?.credential;
+				if (latestCredential?.type === "oauth" && latestCredential.refresh !== selection.credential.refresh) {
+					logger.debug("OAuth refresh race detected; another process rotated token first", {
+						provider,
+						index: selection.index,
+						credentialId: attemptedCredentialId,
+					});
+					await this.reload();
+					return this.#resolveOAuthSelection(provider, sessionId, options);
+				}
+			}
 			// Only remove credentials for definitive auth failures
 			// Keep credentials for transient errors (network, 5xx) and block temporarily
 			const isDefinitiveFailure =
-				/invalid_grant|invalid_token|revoked|unauthorized|expired.*refresh|refresh.*expired/i.test(errorMsg) ||
+				/invalid_grant|grant is invalid|invalid_token|revoked|unauthorized|expired.*refresh|refresh.*expired/i.test(
+					errorMsg,
+				) ||
 				(/\b(401|403)\b/.test(errorMsg) && !/timeout|network|fetch failed|ECONNREFUSED/i.test(errorMsg));
 
 			logger.warn("OAuth token refresh failed", {
@@ -3216,27 +3244,6 @@ export class AuthStorage {
 			});
 
 			if (isDefinitiveFailure) {
-				// The credential at this index may have been rotated by another process between
-				// our in-memory snapshot and the refresh attempt: Anthropic rotates refresh
-				// tokens on every use, so the peer's success leaves our stored token invalid.
-				// Re-read the row from disk before marking it disabled — if the persisted
-				// refresh token has changed, the peer rotation succeeded and we should pick
-				// up the new credential instead of soft-deleting the row that the peer just
-				// updated.
-				const credentialId = this.#getStoredCredentials(provider)[selection.index]?.id;
-				if (credentialId !== undefined) {
-					const latestRow = this.#store.listAuthCredentials(provider).find(row => row.id === credentialId);
-					const latestCredential = latestRow?.credential;
-					if (latestCredential?.type === "oauth" && latestCredential.refresh !== selection.credential.refresh) {
-						logger.debug("OAuth refresh race detected; another process rotated token first", {
-							provider,
-							index: selection.index,
-							credentialId,
-						});
-						await this.reload();
-						return this.#resolveOAuthSelection(provider, sessionId, options);
-					}
-				}
 				// Permanently disable invalid credentials with an explicit cause for inspection/debugging.
 				// Use a CAS-style disable conditioned on the row still containing the stale credential
 				// we tried to refresh, so a peer rotation that lands between the pre-check above and

--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -327,4 +327,91 @@ describe("AuthStorage OAuth refresh race", () => {
 		const retryKey = await authStorage.getApiKey("unit-oauth-rotation", sessionId);
 		expect(retryKey).toBe("access-b");
 	});
+
+	test("recovers from a non-definitive invalid-grant failure when a peer rotated the token", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		// Kimi-style failure: refresh-token rotation by a peer leaves our snapshot
+		// token rejected with a message that does NOT match the definitive-failure
+		// regex (HTTP 400 "The provided authorization grant is invalid", not the
+		// literal "invalid_grant"). Before the fix this was misclassified as
+		// transient and the healthy credential was temp-blocked for 5 minutes on
+		// every rotation race — with Kimi's ~12-minute access tokens and several
+		// gjc processes sharing the store, users saw repeated "logged out" states.
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "stale-access",
+				refresh: "stale-refresh",
+				expires: Date.now() - 60_000,
+			},
+		]);
+		const storedBefore = store.listAuthCredentials("anthropic");
+		expect(storedBefore).toHaveLength(1);
+		const credentialId = storedBefore[0]!.id;
+
+		// Peer process rotated the row first.
+		store.updateAuthCredential(credentialId, {
+			type: "oauth",
+			access: "fresh-access-from-peer",
+			refresh: "fresh-refresh-from-peer",
+			expires: Date.now() + 60 * 60_000,
+		});
+
+		vi.spyOn(oauthUtils, "refreshOAuthToken").mockImplementation(async (_provider, credentials) => {
+			if (credentials.refresh === "stale-refresh") {
+				throw new Error("Kimi token refresh failed: 400: The provided authorization grant is invalid");
+			}
+			return credentials;
+		});
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (provider, creds) => {
+			const credential = creds[provider];
+			if (!credential) return null;
+			return { newCredentials: credential, apiKey: credential.access };
+		});
+
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			const apiKey = await authStorage!.getApiKey("anthropic", "session-kimi-race");
+
+			// The peer-rotated credential must be picked up — not temp-blocked.
+			expect(apiKey).toBe("fresh-access-from-peer");
+			expect(events).toHaveLength(0);
+
+			const stored = store!.listAuthCredentials("anthropic");
+			expect(stored).toHaveLength(1);
+			expect(stored[0]?.id).toBe(credentialId);
+			if (stored[0]?.credential.type === "oauth") {
+				expect(stored[0].credential.refresh).toBe("fresh-refresh-from-peer");
+			}
+		});
+	});
+
+	test("disables on a genuine Kimi-style invalid-grant failure with no peer rotation", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		// Same Kimi message shape, but no peer updated the row: the refresh token
+		// is genuinely revoked, so the credential must be disabled (and the
+		// onCredentialDisabled listener fired) instead of looping 5-minute
+		// temp-blocks forever.
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "expired-access",
+				refresh: "revoked-refresh",
+				expires: Date.now() - 60_000,
+			},
+		]);
+
+		vi.spyOn(oauthUtils, "refreshOAuthToken").mockImplementation(async () => {
+			throw new Error("Kimi token refresh failed: 400: The provided authorization grant is invalid");
+		});
+
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			const apiKey = await authStorage!.getApiKey("anthropic", "session-kimi-revoked");
+
+			expect(apiKey).toBeUndefined();
+			expect(events).toHaveLength(1);
+			expect(events[0]?.disabledCause).toContain("authorization grant is invalid");
+		});
+	});
 });


### PR DESCRIPTION
## Problem

Since enabling Kimi Code, logins appeared to drop repeatedly (re-login required once or more per day). Production logs from 2026-07-22/23 show the mechanism:

- Kimi access tokens live ~12 minutes, so OAuth refreshes are frequent, and several gjc processes (TUI, usage pollers, agent runs) share the same credential store.
- Kimi rotates the refresh token on every refresh. Any process refreshing from a stale in-memory snapshot is rejected with `400: The provided authorization grant is invalid`.
- That message does not match the definitive-failure regex (`invalid_grant` etc.) and is not 401/403, so it was classified **transient** (`isDefinitiveFailure: false` in logs) — and the peer-rotation recovery (re-read row → reload → re-resolve) only existed on the **definitive** path.
- Result: a perfectly healthy credential got temp-blocked for 5 minutes on every rotation race, surfacing as repeated "logged out" states. Genuine revocations also looped temp-blocks forever instead of disabling with a cause.

## Fix (`packages/ai/src/auth-storage.ts`)

- Hoist the peer-rotation row check ahead of definitive/transient classification: on **any** refresh failure, if the persisted row's refresh token differs from the attempted one, reload and re-resolve with the peer's rotated credential instead of disabling or temp-blocking.
- Extend the definitive matcher with `grant is invalid` so genuine revocations disable the credential and fire `onCredentialDisabled` (prompting re-login) rather than looping temp-blocks.

## Verification

- New regression tests in `auth-storage-oauth-refresh-race.test.ts`: (1) stale-rotation race with a Kimi-style non-definitive message recovers the peer-rotated credential with no disable event; (2) the same message with no peer rotation disables the credential. **Both fail on the pre-fix code** (mutation-verified).
- `bun test` on all 16 auth-storage/auth-broker test files: 119 pass / 0 fail.
- `biome check` + `tsc --noEmit` on `packages/ai`: clean.