### PR TITLE
feat(workflow): enforce repository binding before discovery and handoff

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Plans and delegated tasks can carry an authoritative repository binding (`gjc.repository_binding.v1`). Ultragoal plans and ralplan seeds stamp worktree/common-dir identity at creation, task items accept an optional binding, and spawn/goal-start fail closed when the active cwd is a sibling repository (#2901).
+- Plans and delegated tasks carry an authoritative repository binding (`gjc.repository_binding.v1`). Ultragoal/ralplan stamp identity at creation; task lanes stamp omitted bindings from session cwd **before** agent discovery; ralplan stage writes and handoff re-entry enforce the seed binding; declared paths must stay under the bound root; task receipts include the resolved identity; linked isolation worktrees must match the source repository (#2901).
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Plans and delegated tasks can carry an authoritative repository binding (`gjc.repository_binding.v1`). Ultragoal plans and ralplan seeds stamp worktree/common-dir identity at creation, task items accept an optional binding, and spawn/goal-start fail closed when the active cwd is a sibling repository (#2901).
+
 ### Fixed
 
 - Telegram notification daemon self-heals degraded on-disk state: permanently missing scan roots are pruned (so one deleted worktree no longer disables orphan-topic cleanup), and retained exact-unlink transition/placeholder artifacts are reaped on ownership acquire and each scan. `gjc daemon reload` can recover without manual filesystem surgery (#2956).

--- a/packages/coding-agent/scripts/dogfood-repository-binding.ts
+++ b/packages/coding-agent/scripts/dogfood-repository-binding.ts
@@ -15,6 +15,7 @@ import {
 	assertCwdMatchesRepositoryBinding,
 	assertPathUnderRepositoryBinding,
 	parseRepositoryBinding,
+	resolveTaskRepositoryBinding,
 } from "../src/gjc-runtime/repository-binding";
 import { readUltragoalPlan, startNextUltragoalGoal } from "../src/gjc-runtime/ultragoal-runtime";
 
@@ -127,14 +128,16 @@ async function main(): Promise<void> {
 		console.log(`fail_closed: ${error instanceof Error ? error.message : String(error)}`);
 	}
 
-	// 5) Task binding validation shape
+	// 5) Task binding stamp + sibling fail-closed (pre-discovery authority)
 	console.log();
-	console.log("## 6) task repositoryBinding parse + match");
+	console.log("## 6) task binding stamp (omit declaration) + sibling reject");
+	const stamped = await resolveTaskRepositoryBinding(left, undefined);
+	console.log(`stamped_worktreeRoot=${stamped.worktreeRoot}`);
+	await assertCwdMatchesRepositoryBinding(left, stamped);
+	console.log("task_stamp_ok on LEFT");
 	const taskBinding = parseRepositoryBinding(plan.repositoryBinding);
-	await assertCwdMatchesRepositoryBinding(left, taskBinding);
-	console.log("task_binding_ok on LEFT");
 	try {
-		await assertCwdMatchesRepositoryBinding(right, taskBinding);
+		await resolveTaskRepositoryBinding(right, taskBinding);
 		console.error("FAIL: task binding should reject RIGHT");
 		process.exit(1);
 	} catch (error) {
@@ -160,6 +163,44 @@ async function main(): Promise<void> {
 		console.error("FAIL: ralplan state missing repository_binding");
 		process.exit(1);
 	}
+
+	// 7) Ralplan stage write on LEFT succeeds and echoes repository_binding
+	console.log();
+	console.log("## 9) gjc ralplan --write planner on LEFT (match)");
+	const notePath = path.join(left, "dogfood-planner.md");
+	await fsp.writeFile(notePath, "# dogfood planner\n");
+	const writeLeft = await runCli(
+		left,
+		["ralplan", "--write", "--stage", "planner", "--stage_n", "1", "--artifact", notePath, "--json"],
+		env,
+	);
+	console.log(`exit=${writeLeft.code}`);
+	console.log(writeLeft.stdout.trim() || writeLeft.stderr.trim());
+	if (writeLeft.code !== 0) process.exit(1);
+	const writePayload = JSON.parse(writeLeft.stdout) as { repository_binding?: { worktreeRoot?: string } };
+	if (!writePayload.repository_binding?.worktreeRoot) {
+		console.error("FAIL: write receipt missing repository_binding");
+		process.exit(1);
+	}
+
+	// 8) Copy seed authority into RIGHT session layout → stage write fails closed
+	console.log();
+	console.log("## 10) ralplan --write on RIGHT with LEFT binding (fail-closed)");
+	const rightStateDir = path.join(right, ".gjc", `_session-${sessionId}`, "state");
+	await fsp.mkdir(rightStateDir, { recursive: true });
+	await fsp.copyFile(statePath, path.join(rightStateDir, "ralplan-state.json"));
+	const writeRight = await runCli(
+		right,
+		["ralplan", "--write", "--stage", "architect", "--stage_n", "1", "--artifact", "# arch\n", "--json"],
+		env,
+	);
+	console.log(`exit=${writeRight.code}`);
+	console.log((writeRight.stderr || writeRight.stdout).trim());
+	if (writeRight.code === 0) {
+		console.error("FAIL: expected sibling write to fail closed");
+		process.exit(1);
+	}
+	console.log("fail_closed: ralplan write on sibling rejected");
 
 	console.log();
 	console.log("DOGFOOD_OK");

--- a/packages/coding-agent/scripts/dogfood-repository-binding.ts
+++ b/packages/coding-agent/scripts/dogfood-repository-binding.ts
@@ -1,0 +1,162 @@
+/**
+ * Product-surface dogfood for #2901 repository binding.
+ *
+ * Creates two sibling git repos, runs real `gjc ultragoal` / `gjc ralplan`
+ * CLI entrypoints from source, and prints fail-closed mismatch evidence.
+ *
+ * Usage (from monorepo root):
+ *   bun packages/coding-agent/scripts/dogfood-repository-binding.ts
+ */
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	assertCwdMatchesRepositoryBinding,
+	assertPathUnderRepositoryBinding,
+	parseRepositoryBinding,
+} from "../src/gjc-runtime/repository-binding";
+import { readUltragoalPlan, startNextUltragoalGoal } from "../src/gjc-runtime/ultragoal-runtime";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const cli = path.join(repoRoot, "packages/coding-agent/src/cli.ts");
+
+async function runGit(cwd: string, args: string[]): Promise<void> {
+	const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	const code = await proc.exited;
+	if (code !== 0) throw new Error(`git ${args.join(" ")} failed: ${await new Response(proc.stderr).text()}`);
+}
+
+async function initRepo(root: string): Promise<void> {
+	await fsp.mkdir(root, { recursive: true });
+	await runGit(root, ["init"]);
+	await runGit(root, ["config", "user.email", "dogfood@example.com"]);
+	await runGit(root, ["config", "user.name", "Dogfood"]);
+	await fsp.writeFile(path.join(root, "README.md"), `repo ${path.basename(root)}\n`);
+	await runGit(root, ["add", "README.md"]);
+	await runGit(root, ["commit", "-m", `init ${path.basename(root)}`]);
+}
+
+async function runCli(cwd: string, args: string[], env: NodeJS.ProcessEnv): Promise<{ code: number; stdout: string; stderr: string }> {
+	const proc = Bun.spawn(["bun", cli, ...args], { cwd, env, stdout: "pipe", stderr: "pipe" });
+	const [code, stdout, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+	return { code, stdout, stderr };
+}
+
+async function main(): Promise<void> {
+	const dogfoodRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-dogfood-2901-"));
+	const left = path.join(dogfoodRoot, "gajae-code");
+	const right = path.join(dogfoodRoot, "oh-my-openagent-senpi");
+	await initRepo(left);
+	await initRepo(right);
+
+	const sessionId = `dogfood-2901-${process.pid}`;
+	const env = { ...process.env, GJC_SESSION_ID: sessionId };
+
+	console.log("# Dogfood: repository binding (#2901)");
+	console.log(`root=${dogfoodRoot}`);
+	console.log(`left=${left}`);
+	console.log(`right=${right}`);
+	console.log(`session=${sessionId}`);
+	console.log(`cli=${cli}`);
+	console.log(`bun=${Bun.version}`);
+	console.log(`commit=${Bun.spawnSync(["git", "-C", repoRoot, "rev-parse", "--short", "HEAD"]).stdout.toString().trim()}`);
+	console.log();
+
+	// 1) Product CLI: create goals stamps binding
+	const create = await runCli(
+		left,
+		[
+			"ultragoal",
+			"create-goals",
+			"--brief",
+			"@goal dogfood binding\nProve repository binding stamps and fail-closed sibling mismatch.",
+			"--json",
+		],
+		env,
+	);
+	console.log("## 1) gjc ultragoal create-goals (LEFT)");
+	console.log(`exit=${create.code}`);
+	console.log(create.stdout.trim() || create.stderr.trim());
+	if (create.code !== 0) process.exit(1);
+
+	const plan = await readUltragoalPlan(left, sessionId);
+	if (!plan?.repositoryBinding) {
+		console.error("FAIL: plan missing repositoryBinding");
+		process.exit(1);
+	}
+	console.log();
+	console.log("## 2) goals.json repositoryBinding");
+	console.log(JSON.stringify(plan.repositoryBinding, null, 2));
+
+	// 2) Matching cwd starts goal
+	console.log();
+	console.log("## 3) startNextUltragoalGoal on LEFT (match)");
+	const started = await startNextUltragoalGoal({ cwd: left, sessionId });
+	console.log(`ok goal=${started.goal?.id} status=${started.goal?.status}`);
+
+	// 3) Sibling mismatch fails closed
+	console.log();
+	console.log("## 4) assertCwdMatchesRepositoryBinding on RIGHT (sibling)");
+	try {
+		await assertCwdMatchesRepositoryBinding(right, plan.repositoryBinding);
+		console.error("FAIL: expected identity_mismatch");
+		process.exit(1);
+	} catch (error) {
+		console.log(`fail_closed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	// 4) Path escape fails closed
+	console.log();
+	console.log("## 5) assertPathUnderRepositoryBinding sibling absolute path");
+	try {
+		assertPathUnderRepositoryBinding(plan.repositoryBinding, path.join(right, "README.md"));
+		console.error("FAIL: expected path_outside_root");
+		process.exit(1);
+	} catch (error) {
+		console.log(`fail_closed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	// 5) Task binding validation shape
+	console.log();
+	console.log("## 6) task repositoryBinding parse + match");
+	const taskBinding = parseRepositoryBinding(plan.repositoryBinding);
+	await assertCwdMatchesRepositoryBinding(left, taskBinding);
+	console.log("task_binding_ok on LEFT");
+	try {
+		await assertCwdMatchesRepositoryBinding(right, taskBinding);
+		console.error("FAIL: task binding should reject RIGHT");
+		process.exit(1);
+	} catch (error) {
+		console.log(`task_binding_fail_closed on RIGHT: ${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	// 6) Ralplan seed stamps binding via product CLI
+	console.log();
+	console.log("## 7) gjc ralplan seed (LEFT)");
+	const ralplan = await runCli(left, ["ralplan", "--json", "dogfood multi-repo binding"], env);
+	console.log(`exit=${ralplan.code}`);
+	console.log(ralplan.stdout.trim() || ralplan.stderr.trim());
+	if (ralplan.code !== 0) process.exit(1);
+	const statePath = path.join(left, ".gjc", `_session-${sessionId}`, "state", "ralplan-state.json");
+	const state = JSON.parse(await fsp.readFile(statePath, "utf8")) as {
+		repository_binding?: unknown;
+		run_id?: string;
+	};
+	console.log();
+	console.log("## 8) ralplan-state.json repository_binding");
+	console.log(JSON.stringify({ run_id: state.run_id, repository_binding: state.repository_binding }, null, 2));
+	if (!state.repository_binding) {
+		console.error("FAIL: ralplan state missing repository_binding");
+		process.exit(1);
+	}
+
+	console.log();
+	console.log("DOGFOOD_OK");
+}
+
+await main();

--- a/packages/coding-agent/scripts/dogfood-repository-binding.ts
+++ b/packages/coding-agent/scripts/dogfood-repository-binding.ts
@@ -37,7 +37,11 @@ async function initRepo(root: string): Promise<void> {
 	await runGit(root, ["commit", "-m", `init ${path.basename(root)}`]);
 }
 
-async function runCli(cwd: string, args: string[], env: NodeJS.ProcessEnv): Promise<{ code: number; stdout: string; stderr: string }> {
+async function runCli(
+	cwd: string,
+	args: string[],
+	env: NodeJS.ProcessEnv,
+): Promise<{ code: number; stdout: string; stderr: string }> {
 	const proc = Bun.spawn(["bun", cli, ...args], { cwd, env, stdout: "pipe", stderr: "pipe" });
 	const [code, stdout, stderr] = await Promise.all([
 		proc.exited,
@@ -64,7 +68,9 @@ async function main(): Promise<void> {
 	console.log(`session=${sessionId}`);
 	console.log(`cli=${cli}`);
 	console.log(`bun=${Bun.version}`);
-	console.log(`commit=${Bun.spawnSync(["git", "-C", repoRoot, "rev-parse", "--short", "HEAD"]).stdout.toString().trim()}`);
+	console.log(
+		`commit=${Bun.spawnSync(["git", "-C", repoRoot, "rev-parse", "--short", "HEAD"]).stdout.toString().trim()}`,
+	);
 	console.log();
 
 	// 1) Product CLI: create goals stamps binding

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -23,6 +23,7 @@ import {
 	writeArtifact,
 	writeWorkflowEnvelopeAtomic,
 } from "./state-writer";
+import { captureRepositoryBinding } from "./repository-binding";
 import { assertSafePathComponent, CommandError, flagValue, hasFlag } from "./workflow-cli-common";
 import { getSkillManifest } from "./workflow-manifest";
 
@@ -817,6 +818,7 @@ async function seedRalplanState(
 	const runId = existingRunId ?? resolved.sessionId ?? defaultRunId();
 	assertSafePathComponent(runId, "run-id");
 	const now = new Date().toISOString();
+	const repositoryBinding = await captureRepositoryBinding(cwd, { displayPath: cwd });
 	const payload: Record<string, unknown> = {
 		active: true,
 		current_phase: "planner",
@@ -827,6 +829,7 @@ async function seedRalplanState(
 		task: resolved.task,
 		run_id: runId,
 		updated_at: now,
+		repository_binding: repositoryBinding,
 	};
 	if (resolved.architectKind) payload.architect_kind = resolved.architectKind;
 	if (resolved.criticKind) payload.critic_kind = resolved.criticKind;

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -11,7 +11,15 @@ import {
 	type RalplanIndexRow,
 	summarizeRalplanIndex,
 } from "./ledger-event-renderer";
-import { captureRepositoryBinding } from "./repository-binding";
+import {
+	assertCwdMatchesRepositoryBinding,
+	assertPathUnderRepositoryBinding,
+	captureRepositoryBinding,
+	parseRepositoryBinding,
+	publicRepositoryBinding,
+	type RepositoryBinding,
+	RepositoryBindingError,
+} from "./repository-binding";
 import { GJC_RALPLAN_ARTIFACT_ENV, isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
 import { modeStatePath, sessionPlansDir } from "./session-layout";
 import { resolveGjcSessionForWrite, writeSessionActivityMarker } from "./session-resolution";
@@ -178,6 +186,43 @@ async function readActiveRunId(cwd: string, sessionId: string): Promise<string |
 	if (!candidate) return undefined;
 	assertSafePathComponent(candidate, "run-id");
 	return candidate;
+}
+
+/**
+ * Read the authoritative repository binding from ralplan run state and fail closed
+ * when the active cwd no longer matches (handoff / QA / stage write) (#2901).
+ */
+async function enforceRalplanRepositoryBinding(cwd: string, sessionId: string): Promise<RepositoryBinding> {
+	const statePath = ralplanStatePath(cwd, sessionId);
+	const existingRead = await readExistingStateForMutation(statePath);
+	if (existingRead.kind === "corrupt") {
+		throw new RalplanCommandError(
+			2,
+			`existing ralplan state is corrupt or tampered (${existingRead.error}); refusing to proceed at ${statePath}`,
+		);
+	}
+	if (existingRead.kind === "absent") {
+		// No prior seed — capture live authority so subsequent handoffs still have a stamp.
+		return publicRepositoryBinding(await captureRepositoryBinding(cwd, { displayPath: cwd }));
+	}
+	const raw = existingRead.value.repository_binding ?? existingRead.value.repositoryBinding;
+	try {
+		if (raw === undefined) {
+			// Legacy seeds without a field: stamp current cwd and require future writes match it.
+			return publicRepositoryBinding(await captureRepositoryBinding(cwd, { displayPath: cwd }));
+		}
+		const binding = parseRepositoryBinding(raw);
+		await assertCwdMatchesRepositoryBinding(cwd, binding);
+		return publicRepositoryBinding(binding);
+	} catch (error) {
+		if (error instanceof RepositoryBindingError) {
+			throw new RalplanCommandError(2, `ralplan repository binding rejected: ${error.message}`);
+		}
+		throw new RalplanCommandError(
+			2,
+			`ralplan repository binding rejected: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
 }
 
 /**
@@ -652,6 +697,24 @@ async function buildRalplanHud(options: {
 async function handleArtifactWrite(args: readonly string[], cwd: string): Promise<RalplanCommandResult> {
 	const plannerState = parsePlannerStateArgs(args);
 	const resolved = await resolveArtifactArgs(args, cwd);
+	// Fail closed before stage persistence / path writes when cwd drifted to a sibling repo.
+	const repositoryBinding = await enforceRalplanRepositoryBinding(cwd, resolved.sessionId);
+	// Artifact file paths (when --artifact points at a file) must stay under the bound root.
+	const rawArtifact = flagValue(args, "--artifact");
+	if (rawArtifact && !isRestrictedRoleAgentBash()) {
+		const candidate = path.isAbsolute(rawArtifact) ? rawArtifact : path.resolve(cwd, rawArtifact);
+		try {
+			const stat = await fs.stat(candidate);
+			if (stat.isFile()) {
+				assertPathUnderRepositoryBinding(repositoryBinding, candidate);
+			}
+		} catch (error) {
+			if (error instanceof RepositoryBindingError) {
+				throw new RalplanCommandError(2, `ralplan repository binding rejected: ${error.message}`);
+			}
+			// Non-file / missing path is inline content; resolveArtifactContent already handled it.
+		}
+	}
 	const content = resolved.artifact.endsWith("\n") ? resolved.artifact : `${resolved.artifact}\n`;
 	const sha256 = createHash("sha256").update(content).digest("hex");
 
@@ -697,6 +760,7 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 		stage: persisted.stage,
 		stage_n: persisted.stageN,
 		sha256: persisted.sha256,
+		repository_binding: repositoryBinding,
 		created_at: persisted.createdAt,
 	};
 	if (persisted.pendingApprovalPath) payload.pending_approval_path = persisted.pendingApprovalPath;
@@ -810,7 +874,7 @@ function resolveConsensusArgs(args: readonly string[], cwd: string): ConsensusHa
 async function seedRalplanState(
 	cwd: string,
 	resolved: ConsensusHandoffArgs,
-): Promise<{ statePath: string; runId: string }> {
+): Promise<{ statePath: string; runId: string; repositoryBinding: RepositoryBinding }> {
 	const statePath = ralplanStatePath(cwd, resolved.sessionId);
 	// Reuse an existing run id when present so a re-invocation of `gjc ralplan "task"` doesn't
 	// orphan in-progress artifacts under a fresh run id.
@@ -818,7 +882,11 @@ async function seedRalplanState(
 	const runId = existingRunId ?? resolved.sessionId ?? defaultRunId();
 	assertSafePathComponent(runId, "run-id");
 	const now = new Date().toISOString();
-	const repositoryBinding = await captureRepositoryBinding(cwd, { displayPath: cwd });
+	// When an active seed already carries authority, re-entry must match it (fail closed).
+	// Otherwise stamp the current cwd as the durable binding for this run.
+	const repositoryBinding = existingRunId
+		? await enforceRalplanRepositoryBinding(cwd, resolved.sessionId)
+		: publicRepositoryBinding(await captureRepositoryBinding(cwd, { displayPath: cwd }));
 	const payload: Record<string, unknown> = {
 		active: true,
 		current_phase: "planner",
@@ -852,7 +920,7 @@ async function seedRalplanState(
 		},
 	});
 	await writeSessionActivityMarker(cwd, resolved.sessionId, { writer: "ralplan-runtime", path: statePath });
-	return { statePath, runId };
+	return { statePath, runId, repositoryBinding };
 }
 
 async function handleConsensusHandoff(args: readonly string[], cwd: string): Promise<RalplanCommandResult> {
@@ -860,7 +928,7 @@ async function handleConsensusHandoff(args: readonly string[], cwd: string): Pro
 	if (!resolved.task) {
 		throw new RalplanCommandError(2, 'gjc ralplan requires a task description, e.g. `gjc ralplan "<task>"`.');
 	}
-	const { statePath, runId } = await seedRalplanState(cwd, resolved);
+	const { statePath, runId, repositoryBinding } = await seedRalplanState(cwd, resolved);
 	const mode = resolved.deliberate ? "deliberate" : "short";
 	await syncRalplanHud({
 		cwd,
@@ -878,6 +946,7 @@ async function handleConsensusHandoff(args: readonly string[], cwd: string): Pro
 		state_path: statePath,
 		run_id: runId,
 		handoff: "/skill:ralplan",
+		repository_binding: repositoryBinding,
 	};
 	const stdout = resolved.json
 		? renderCliWriteReceipt({ ok: true, ...summary })

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -11,6 +11,7 @@ import {
 	type RalplanIndexRow,
 	summarizeRalplanIndex,
 } from "./ledger-event-renderer";
+import { captureRepositoryBinding } from "./repository-binding";
 import { GJC_RALPLAN_ARTIFACT_ENV, isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
 import { modeStatePath, sessionPlansDir } from "./session-layout";
 import { resolveGjcSessionForWrite, writeSessionActivityMarker } from "./session-resolution";
@@ -23,7 +24,6 @@ import {
 	writeArtifact,
 	writeWorkflowEnvelopeAtomic,
 } from "./state-writer";
-import { captureRepositoryBinding } from "./repository-binding";
 import { assertSafePathComponent, CommandError, flagValue, hasFlag } from "./workflow-cli-common";
 import { getSkillManifest } from "./workflow-manifest";
 

--- a/packages/coding-agent/src/gjc-runtime/repository-binding.ts
+++ b/packages/coding-agent/src/gjc-runtime/repository-binding.ts
@@ -1,0 +1,209 @@
+/**
+ * Authoritative repository/worktree binding for plans and delegated tasks (#2901).
+ *
+ * Multi-repo parent directories must not let QA/review lanes infer a sibling repo
+ * from prose. Bindings carry a validated worktree root + git common-dir identity
+ * so spawn/handoff can fail closed on mismatch.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { head, repo, type GitRepository } from "../utils/git";
+
+export const REPOSITORY_BINDING_SCHEMA = "gjc.repository_binding.v1" as const;
+
+export interface RepositoryBinding {
+	schema: typeof REPOSITORY_BINDING_SCHEMA;
+	/** Canonical realpath of the git worktree root (or resolved cwd root). */
+	worktreeRoot: string;
+	/** Git common dir realpath when available; null outside a git checkout. */
+	commonDir: string | null;
+	/** Optional repo-relative subdirectory the lane should operate under. */
+	relativeSubdir?: string;
+	/** Optional display path (may be non-canonical); never used for authority. */
+	displayPath?: string;
+	/** Optional baseline HEAD at capture time. */
+	head?: string;
+	/** Optional branch name at capture time (when not detached). */
+	branch?: string;
+}
+
+export type RepositoryBindingErrorCode =
+	| "not_a_repository"
+	| "identity_mismatch"
+	| "path_outside_root"
+	| "invalid_binding";
+
+export class RepositoryBindingError extends Error {
+	readonly code: RepositoryBindingErrorCode;
+
+	constructor(code: RepositoryBindingErrorCode, message: string) {
+		super(message);
+		this.name = "RepositoryBindingError";
+		this.code = code;
+	}
+}
+
+async function realpathOrResolve(target: string): Promise<string> {
+	try {
+		return await fs.realpath(target);
+	} catch {
+		return path.resolve(target);
+	}
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+/** Capture a durable binding from the active cwd/worktree. */
+export async function captureRepositoryBinding(
+	cwd: string,
+	options: { relativeSubdir?: string; displayPath?: string } = {},
+): Promise<RepositoryBinding> {
+	const resolvedCwd = await realpathOrResolve(cwd);
+	const repository = await repo.resolve(resolvedCwd);
+	const worktreeRoot = repository
+		? await realpathOrResolve(repository.repoRoot)
+		: resolvedCwd;
+	const commonDir = repository ? await realpathOrResolve(repository.commonDir) : null;
+
+	let headSha: string | undefined;
+	let branch: string | undefined;
+	if (repository) {
+		const headState = await head.resolve(resolvedCwd);
+		if (headState) {
+			headSha = headState.commit || undefined;
+			branch = headState.kind === "ref" ? headState.branchName || undefined : undefined;
+		}
+	}
+
+	const binding: RepositoryBinding = {
+		schema: REPOSITORY_BINDING_SCHEMA,
+		worktreeRoot,
+		commonDir,
+		...(options.relativeSubdir
+			? { relativeSubdir: normalizeRelativeSubdir(options.relativeSubdir) }
+			: {}),
+		...(options.displayPath ? { displayPath: options.displayPath } : {}),
+		...(headSha ? { head: headSha } : {}),
+		...(branch ? { branch } : {}),
+	};
+	return binding;
+}
+
+function normalizeRelativeSubdir(relative: string): string {
+	const normalized = relative.replaceAll("\\", "/").replace(/^\.\/+/u, "").replace(/\/+$/u, "");
+	if (normalized === "" || normalized === ".") {
+		throw new RepositoryBindingError("invalid_binding", "relativeSubdir must be a non-empty relative path");
+	}
+	if (path.isAbsolute(normalized) || normalized.split("/").includes("..")) {
+		throw new RepositoryBindingError(
+			"invalid_binding",
+			"relativeSubdir must be repo-relative without '..' segments",
+		);
+	}
+	return normalized;
+}
+
+/** Parse a binding from JSON/plan payload; fail closed on malformed shapes. */
+export function parseRepositoryBinding(value: unknown): RepositoryBinding {
+	if (!isObject(value)) {
+		throw new RepositoryBindingError("invalid_binding", "repository binding must be an object");
+	}
+	const schema = nonEmptyString(value.schema);
+	if (schema !== REPOSITORY_BINDING_SCHEMA) {
+		throw new RepositoryBindingError(
+			"invalid_binding",
+			`repository binding schema must be ${REPOSITORY_BINDING_SCHEMA}`,
+		);
+	}
+	const worktreeRoot = nonEmptyString(value.worktreeRoot ?? value.worktree_root);
+	if (!worktreeRoot) {
+		throw new RepositoryBindingError("invalid_binding", "repository binding requires worktreeRoot");
+	}
+	const commonDirRaw = value.commonDir ?? value.common_dir;
+	const commonDir =
+		commonDirRaw === null || commonDirRaw === undefined
+			? null
+			: nonEmptyString(commonDirRaw) ??
+				(() => {
+					throw new RepositoryBindingError("invalid_binding", "commonDir must be a string or null");
+				})();
+	const relativeSubdirRaw = value.relativeSubdir ?? value.relative_subdir;
+	const relativeSubdir =
+		relativeSubdirRaw === undefined ? undefined : normalizeRelativeSubdir(String(relativeSubdirRaw));
+	const displayPath = nonEmptyString(value.displayPath ?? value.display_path);
+	const head = nonEmptyString(value.head);
+	const branch = nonEmptyString(value.branch);
+	return {
+		schema: REPOSITORY_BINDING_SCHEMA,
+		worktreeRoot: path.resolve(worktreeRoot),
+		commonDir: commonDir === null ? null : path.resolve(commonDir),
+		...(relativeSubdir ? { relativeSubdir } : {}),
+		...(displayPath ? { displayPath } : {}),
+		...(head ? { head } : {}),
+		...(branch ? { branch } : {}),
+	};
+}
+
+/** True when two bindings refer to the same repository identity (linked worktrees ok). */
+export function repositoryBindingsMatch(left: RepositoryBinding, right: RepositoryBinding): boolean {
+	if (left.commonDir && right.commonDir) {
+		return path.resolve(left.commonDir) === path.resolve(right.commonDir);
+	}
+	// Non-git workspaces: require exact worktree root match.
+	return path.resolve(left.worktreeRoot) === path.resolve(right.worktreeRoot);
+}
+
+/**
+ * Ensure `cwd` is inside the bound repository (or the same linked worktree family).
+ * Fails closed on sibling-repo drift.
+ */
+export async function assertCwdMatchesRepositoryBinding(
+	cwd: string,
+	binding: RepositoryBinding,
+): Promise<RepositoryBinding> {
+	const active = await captureRepositoryBinding(cwd);
+	if (!repositoryBindingsMatch(active, binding)) {
+		throw new RepositoryBindingError(
+			"identity_mismatch",
+			`Active worktree does not match plan/task repository binding. active=${active.worktreeRoot} (commonDir=${active.commonDir ?? "none"}) bound=${binding.worktreeRoot} (commonDir=${binding.commonDir ?? "none"}).`,
+		);
+	}
+	return active;
+}
+
+/** Ensure a declared target path resolves under the bound worktree root. */
+export function assertPathUnderRepositoryBinding(binding: RepositoryBinding, targetPath: string): string {
+	const root = path.resolve(binding.worktreeRoot);
+	const base = binding.relativeSubdir ? path.resolve(root, binding.relativeSubdir) : root;
+	const resolved = path.isAbsolute(targetPath) ? path.resolve(targetPath) : path.resolve(base, targetPath);
+	const relative = path.relative(root, resolved);
+	if (relative.startsWith("..") || path.isAbsolute(relative)) {
+		throw new RepositoryBindingError(
+			"path_outside_root",
+			`Path escapes bound repository root: ${targetPath} (root=${root})`,
+		);
+	}
+	return resolved;
+}
+
+/** Optional helper for tests and diagnostics. */
+export function bindingFromGitRepository(
+	repository: GitRepository,
+	options: { relativeSubdir?: string; displayPath?: string; head?: string; branch?: string } = {},
+): RepositoryBinding {
+	return {
+		schema: REPOSITORY_BINDING_SCHEMA,
+		worktreeRoot: path.resolve(repository.repoRoot),
+		commonDir: path.resolve(repository.commonDir),
+		...(options.relativeSubdir ? { relativeSubdir: normalizeRelativeSubdir(options.relativeSubdir) } : {}),
+		...(options.displayPath ? { displayPath: options.displayPath } : {}),
+		...(options.head ? { head: options.head } : {}),
+		...(options.branch ? { branch: options.branch } : {}),
+	};
+}

--- a/packages/coding-agent/src/gjc-runtime/repository-binding.ts
+++ b/packages/coding-agent/src/gjc-runtime/repository-binding.ts
@@ -7,7 +7,7 @@
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { head, repo, type GitRepository } from "../utils/git";
+import { type GitRepository, head, repo } from "../utils/git";
 
 export const REPOSITORY_BINDING_SCHEMA = "gjc.repository_binding.v1" as const;
 
@@ -66,9 +66,7 @@ export async function captureRepositoryBinding(
 ): Promise<RepositoryBinding> {
 	const resolvedCwd = await realpathOrResolve(cwd);
 	const repository = await repo.resolve(resolvedCwd);
-	const worktreeRoot = repository
-		? await realpathOrResolve(repository.repoRoot)
-		: resolvedCwd;
+	const worktreeRoot = repository ? await realpathOrResolve(repository.repoRoot) : resolvedCwd;
 	const commonDir = repository ? await realpathOrResolve(repository.commonDir) : null;
 
 	let headSha: string | undefined;
@@ -85,9 +83,7 @@ export async function captureRepositoryBinding(
 		schema: REPOSITORY_BINDING_SCHEMA,
 		worktreeRoot,
 		commonDir,
-		...(options.relativeSubdir
-			? { relativeSubdir: normalizeRelativeSubdir(options.relativeSubdir) }
-			: {}),
+		...(options.relativeSubdir ? { relativeSubdir: normalizeRelativeSubdir(options.relativeSubdir) } : {}),
 		...(options.displayPath ? { displayPath: options.displayPath } : {}),
 		...(headSha ? { head: headSha } : {}),
 		...(branch ? { branch } : {}),
@@ -96,15 +92,15 @@ export async function captureRepositoryBinding(
 }
 
 function normalizeRelativeSubdir(relative: string): string {
-	const normalized = relative.replaceAll("\\", "/").replace(/^\.\/+/u, "").replace(/\/+$/u, "");
+	const normalized = relative
+		.replaceAll("\\", "/")
+		.replace(/^\.\/+/u, "")
+		.replace(/\/+$/u, "");
 	if (normalized === "" || normalized === ".") {
 		throw new RepositoryBindingError("invalid_binding", "relativeSubdir must be a non-empty relative path");
 	}
 	if (path.isAbsolute(normalized) || normalized.split("/").includes("..")) {
-		throw new RepositoryBindingError(
-			"invalid_binding",
-			"relativeSubdir must be repo-relative without '..' segments",
-		);
+		throw new RepositoryBindingError("invalid_binding", "relativeSubdir must be repo-relative without '..' segments");
 	}
 	return normalized;
 }
@@ -129,10 +125,10 @@ export function parseRepositoryBinding(value: unknown): RepositoryBinding {
 	const commonDir =
 		commonDirRaw === null || commonDirRaw === undefined
 			? null
-			: nonEmptyString(commonDirRaw) ??
+			: (nonEmptyString(commonDirRaw) ??
 				(() => {
 					throw new RepositoryBindingError("invalid_binding", "commonDir must be a string or null");
-				})();
+				})());
 	const relativeSubdirRaw = value.relativeSubdir ?? value.relative_subdir;
 	const relativeSubdir =
 		relativeSubdirRaw === undefined ? undefined : normalizeRelativeSubdir(String(relativeSubdirRaw));

--- a/packages/coding-agent/src/gjc-runtime/repository-binding.ts
+++ b/packages/coding-agent/src/gjc-runtime/repository-binding.ts
@@ -5,6 +5,7 @@
  * from prose. Bindings carry a validated worktree root + git common-dir identity
  * so spawn/handoff can fail closed on mismatch.
  */
+import * as fssync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { type GitRepository, head, repo } from "../utils/git";
@@ -46,6 +47,15 @@ export class RepositoryBindingError extends Error {
 async function realpathOrResolve(target: string): Promise<string> {
 	try {
 		return await fs.realpath(target);
+	} catch {
+		return path.resolve(target);
+	}
+}
+
+/** Sync realpath for path-under-root checks (handles macOS /var → /private/var). */
+function realpathSyncOrResolve(target: string): string {
+	try {
+		return fssync.realpathSync(target);
 	} catch {
 		return path.resolve(target);
 	}
@@ -175,9 +185,11 @@ export async function assertCwdMatchesRepositoryBinding(
 
 /** Ensure a declared target path resolves under the bound worktree root. */
 export function assertPathUnderRepositoryBinding(binding: RepositoryBinding, targetPath: string): string {
-	const root = path.resolve(binding.worktreeRoot);
-	const base = binding.relativeSubdir ? path.resolve(root, binding.relativeSubdir) : root;
-	const resolved = path.isAbsolute(targetPath) ? path.resolve(targetPath) : path.resolve(base, targetPath);
+	const root = realpathSyncOrResolve(binding.worktreeRoot);
+	const base = binding.relativeSubdir ? realpathSyncOrResolve(path.resolve(root, binding.relativeSubdir)) : root;
+	const candidate = path.isAbsolute(targetPath) ? path.resolve(targetPath) : path.resolve(base, targetPath);
+	// Prefer realpath when the path exists so macOS /var ↔ /private/var aliases match.
+	const resolved = realpathSyncOrResolve(candidate);
 	const relative = path.relative(root, resolved);
 	if (relative.startsWith("..") || path.isAbsolute(relative)) {
 		throw new RepositoryBindingError(
@@ -186,6 +198,56 @@ export function assertPathUnderRepositoryBinding(binding: RepositoryBinding, tar
 		);
 	}
 	return resolved;
+}
+
+/**
+ * Public identity snapshot for receipts/handoffs (no display-only fields required).
+ * Always includes the schema + durable roots so downstream lanes can re-verify.
+ */
+export function publicRepositoryBinding(binding: RepositoryBinding): RepositoryBinding {
+	return {
+		schema: REPOSITORY_BINDING_SCHEMA,
+		worktreeRoot: path.resolve(binding.worktreeRoot),
+		commonDir: binding.commonDir === null ? null : path.resolve(binding.commonDir),
+		...(binding.relativeSubdir ? { relativeSubdir: binding.relativeSubdir } : {}),
+		...(binding.displayPath ? { displayPath: binding.displayPath } : {}),
+		...(binding.head ? { head: binding.head } : {}),
+		...(binding.branch ? { branch: binding.branch } : {}),
+	};
+}
+
+/**
+ * Resolve the authoritative binding for a delegated task before discovery/spawn.
+ *
+ * - Missing declaration → stamp from session cwd (never leave authority implicit).
+ * - Declared binding → parse + fail closed unless it matches the active session worktree.
+ * - relativeSubdir (when present) must resolve under the bound root.
+ */
+export async function resolveTaskRepositoryBinding(
+	sessionCwd: string,
+	declared: unknown | undefined,
+): Promise<RepositoryBinding> {
+	const sessionBinding = await captureRepositoryBinding(sessionCwd, { displayPath: sessionCwd });
+	if (declared === undefined || declared === null) {
+		return publicRepositoryBinding(sessionBinding);
+	}
+	const taskBinding = parseRepositoryBinding(declared);
+	await assertCwdMatchesRepositoryBinding(sessionCwd, taskBinding);
+	if (taskBinding.relativeSubdir) {
+		assertPathUnderRepositoryBinding(taskBinding, ".");
+	}
+	return publicRepositoryBinding(taskBinding);
+}
+
+/**
+ * Ensure an execution/isolation root (cwd or worktree) still matches the bound identity.
+ * Used after isolation workspace creation so linked worktrees keep the source repository.
+ */
+export async function assertExecutionRootMatchesRepositoryBinding(
+	executionRoot: string,
+	binding: RepositoryBinding,
+): Promise<RepositoryBinding> {
+	return await assertCwdMatchesRepositoryBinding(executionRoot, binding);
 }
 
 /** Optional helper for tests and diagnostics. */

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -6,6 +6,12 @@ import { buildUltragoalHudSummary as buildWorkflowUltragoalHudSummary } from "..
 import { renderCliWriteReceipt } from "./cli-write-receipt";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
 import {
+	assertCwdMatchesRepositoryBinding,
+	captureRepositoryBinding,
+	parseRepositoryBinding,
+	type RepositoryBinding,
+} from "./repository-binding";
+import {
 	CRITIC_GATE_HARD_STOP_EVENT,
 	CRITIC_GATE_OVERRIDE_EVENT,
 	CRITIC_VERDICT_EVENT,
@@ -192,6 +198,8 @@ export interface UltragoalPlan {
 	gjcObjective: string;
 	gjcObjectiveAliases?: string[];
 	goals: UltragoalGoal[];
+	/** Authoritative repository identity for multi-repo fail-closed spawn (#2901). */
+	repositoryBinding?: RepositoryBinding;
 	createdAt: string;
 	updatedAt: string;
 	[key: string]: unknown;
@@ -1349,6 +1357,10 @@ function normalizePlan(raw: unknown): UltragoalPlan {
 				(value): value is string => typeof value === "string" && value.trim().length > 0,
 			)
 		: undefined;
+	let repositoryBinding: RepositoryBinding | undefined;
+	if (record.repositoryBinding !== undefined) {
+		repositoryBinding = parseRepositoryBinding(record.repositoryBinding);
+	}
 	return {
 		version: 1,
 		brief,
@@ -1358,6 +1370,7 @@ function normalizePlan(raw: unknown): UltragoalPlan {
 		goals,
 		createdAt,
 		updatedAt,
+		...(repositoryBinding ? { repositoryBinding } : {}),
 		...(typeof record.state_revision === "number" && Number.isFinite(record.state_revision)
 			? { state_revision: record.state_revision }
 			: {}),
@@ -1558,12 +1571,16 @@ export async function createUltragoalPlan(input: {
 		goal.validationBatch = validationBatchByGoalId.get(goal.id);
 		validateValidationBatchPipelineExclusion(goal);
 	}
+	const repositoryBinding = await captureRepositoryBinding(input.cwd, {
+		displayPath: input.cwd,
+	});
 	const plan: UltragoalPlan = {
 		version: 1,
 		brief,
 		gjcGoalMode: input.gjcGoalMode ?? "aggregate",
 		gjcObjective: DEFAULT_ULTRAGOAL_OBJECTIVE,
 		goals,
+		repositoryBinding,
 		createdAt: now,
 		updatedAt: now,
 	};
@@ -1695,6 +1712,13 @@ export async function startNextUltragoalGoal(input: {
 }> {
 	const plan = await readUltragoalPlan(input.cwd, input.sessionId);
 	if (!plan) throw new Error("No ultragoal plan found. Run `gjc ultragoal create-goals --brief ...` first.");
+	// Fail closed: delegated execution requires stamped repository authority (#2901).
+	if (!plan.repositoryBinding) {
+		throw new Error(
+			"Ultragoal plan is missing repositoryBinding; recreate goals so the plan is bound to an authoritative repository identity.",
+		);
+	}
+	await assertCwdMatchesRepositoryBinding(input.cwd, plan.repositoryBinding);
 	const retryFailed = input.retryFailed === true;
 	const goal = chooseNextGoal(plan, retryFailed);
 	if (!goal) {

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -43,6 +43,11 @@ import {
 
 // Import review tools for side effects (registers subagent tool handlers)
 import "../tools/review";
+import {
+	assertCwdMatchesRepositoryBinding,
+	parseRepositoryBinding,
+	RepositoryBindingError,
+} from "../gjc-runtime/repository-binding";
 import { initializeLocalRoot, type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import { generateCommitMessage } from "../utils/commit-message-generator";
 import * as git from "../utils/git";
@@ -126,6 +131,25 @@ function addUsageTotals(target: Usage, usage: Partial<Usage>): void {
 	target.cost.cacheRead += cost.cacheRead;
 	target.cost.cacheWrite += cost.cacheWrite;
 	target.cost.total += cost.total;
+}
+
+async function validateTaskRepositoryBindings(
+	cwd: string,
+	tasks: readonly TaskItem[],
+): Promise<string | undefined> {
+	for (const task of tasks) {
+		if (!task.repositoryBinding) continue;
+		try {
+			const binding = parseRepositoryBinding(task.repositoryBinding);
+			await assertCwdMatchesRepositoryBinding(cwd, binding);
+		} catch (error) {
+			if (error instanceof RepositoryBindingError) {
+				return `Task "${task.id}" repository binding rejected: ${error.message}`;
+			}
+			return `Task "${task.id}" repository binding rejected: ${error instanceof Error ? error.message : String(error)}`;
+		}
+	}
+	return undefined;
 }
 
 function validateTaskIdsForScheduling(tasks: readonly TaskItem[]): string | undefined {
@@ -436,6 +460,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const taskIdValidationError = validateTaskIdsForScheduling(taskItems);
 		if (taskIdValidationError) {
 			return createTaskModeError(taskIdValidationError);
+		}
+		const repositoryBindingError = await validateTaskRepositoryBindings(this.session.cwd, taskItems);
+		if (repositoryBindingError) {
+			return createTaskModeError(repositoryBindingError);
 		}
 		if (taskItems.length === 0) {
 			return this.#executeSync(_toolCallId, params, signal, onUpdate);

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -44,9 +44,13 @@ import {
 // Import review tools for side effects (registers subagent tool handlers)
 import "../tools/review";
 import {
-	assertCwdMatchesRepositoryBinding,
-	parseRepositoryBinding,
+	assertExecutionRootMatchesRepositoryBinding,
+	assertPathUnderRepositoryBinding,
+	captureRepositoryBinding,
+	publicRepositoryBinding,
+	type RepositoryBinding,
 	RepositoryBindingError,
+	resolveTaskRepositoryBinding,
 } from "../gjc-runtime/repository-binding";
 import { initializeLocalRoot, type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import { generateCommitMessage } from "../utils/commit-message-generator";
@@ -133,20 +137,41 @@ function addUsageTotals(target: Usage, usage: Partial<Usage>): void {
 	target.cost.total += cost.total;
 }
 
-async function validateTaskRepositoryBindings(cwd: string, tasks: readonly TaskItem[]): Promise<string | undefined> {
+/**
+ * Stamp/resolve repository authority for every task before agent discovery or spawn.
+ * Omitted bindings inherit the session worktree; declared ones must match it.
+ */
+async function resolveTaskItemsWithRepositoryBindings(
+	cwd: string,
+	tasks: readonly TaskItem[],
+): Promise<{ tasks: TaskItem[]; error?: string }> {
+	const resolved: TaskItem[] = [];
 	for (const task of tasks) {
-		if (!task.repositoryBinding) continue;
 		try {
-			const binding = parseRepositoryBinding(task.repositoryBinding);
-			await assertCwdMatchesRepositoryBinding(cwd, binding);
-		} catch (error) {
-			if (error instanceof RepositoryBindingError) {
-				return `Task "${task.id}" repository binding rejected: ${error.message}`;
+			const binding = await resolveTaskRepositoryBinding(cwd, task.repositoryBinding);
+			if (binding.relativeSubdir) {
+				assertPathUnderRepositoryBinding(binding, ".");
 			}
-			return `Task "${task.id}" repository binding rejected: ${error instanceof Error ? error.message : String(error)}`;
+			resolved.push({
+				...task,
+				repositoryBinding: binding,
+			});
+		} catch (error) {
+			const id = task.id?.trim() ? task.id : "(missing-id)";
+			if (error instanceof RepositoryBindingError) {
+				return { tasks: [], error: `Task "${id}" repository binding rejected: ${error.message}` };
+			}
+			return {
+				tasks: [],
+				error: `Task "${id}" repository binding rejected: ${error instanceof Error ? error.message : String(error)}`,
+			};
 		}
 	}
-	return undefined;
+	return { tasks: resolved };
+}
+
+function repositoryBindingFromTask(task: TaskItem): RepositoryBinding | undefined {
+	return task.repositoryBinding ? publicRepositoryBinding(task.repositoryBinding as RepositoryBinding) : undefined;
 }
 
 function validateTaskIdsForScheduling(tasks: readonly TaskItem[]): string | undefined {
@@ -420,12 +445,16 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			this.session.getSessionSpawns() ?? "*",
 		);
 	}
+	readonly #sessionRepositoryBinding: RepositoryBinding;
+
 	private constructor(
 		private readonly session: ToolSession,
 		discoveredAgents: AgentDefinition[],
+		sessionRepositoryBinding: RepositoryBinding,
 	) {
 		this.#blockedAgent = $pickenv("GJC_BLOCKED_AGENT", "PI_BLOCKED_AGENT");
 		this.#discoveredAgents = discoveredAgents;
+		this.#sessionRepositoryBinding = sessionRepositoryBinding;
 	}
 
 	#getTaskSimpleMode(): TaskSimpleMode {
@@ -433,11 +462,16 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	}
 
 	/**
-	 * Create a TaskTool instance with async agent discovery.
+	 * Create a TaskTool instance.
+	 * Repository authority is captured from session cwd *before* agent discovery so
+	 * multi-repo workspaces fail closed prior to context/discovery (#2901).
 	 */
 	static async create(session: ToolSession): Promise<TaskTool> {
+		const sessionRepositoryBinding = await captureRepositoryBinding(session.cwd, { displayPath: session.cwd });
+		// Authority check before discovery: session cwd must resolve to a stable binding.
+		await assertExecutionRootMatchesRepositoryBinding(session.cwd, sessionRepositoryBinding);
 		const { agents } = await discoverAgents(session.cwd);
-		return new TaskTool(session, agents);
+		return new TaskTool(session, agents, publicRepositoryBinding(sessionRepositoryBinding));
 	}
 
 	async execute(
@@ -453,17 +487,32 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			return createTaskModeError(validationError);
 		}
 
-		const taskItems = params.tasks ?? [];
-		const taskIdValidationError = validateTaskIdsForScheduling(taskItems);
+		// Re-verify session authority before using any discovered agents or scheduling work.
+		try {
+			await assertExecutionRootMatchesRepositoryBinding(this.session.cwd, this.#sessionRepositoryBinding);
+		} catch (error) {
+			const message =
+				error instanceof RepositoryBindingError
+					? error.message
+					: error instanceof Error
+						? error.message
+						: String(error);
+			return createTaskModeError(`Session repository binding rejected before task discovery: ${message}`);
+		}
+
+		const rawTaskItems = params.tasks ?? [];
+		const taskIdValidationError = validateTaskIdsForScheduling(rawTaskItems);
 		if (taskIdValidationError) {
 			return createTaskModeError(taskIdValidationError);
 		}
-		const repositoryBindingError = await validateTaskRepositoryBindings(this.session.cwd, taskItems);
-		if (repositoryBindingError) {
-			return createTaskModeError(repositoryBindingError);
+		const bindingResolution = await resolveTaskItemsWithRepositoryBindings(this.session.cwd, rawTaskItems);
+		if (bindingResolution.error) {
+			return createTaskModeError(bindingResolution.error);
 		}
+		const taskItems = bindingResolution.tasks;
+		const paramsWithBindings: TaskParams = { ...params, tasks: taskItems };
 		if (taskItems.length === 0) {
-			return this.#executeSync(_toolCallId, params, signal, onUpdate);
+			return this.#executeSync(_toolCallId, paramsWithBindings, signal, onUpdate);
 		}
 		const agent = getAgent(this.#discoveredAgents, params.agent);
 		if (!agent) {
@@ -951,13 +1000,31 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		},
 	): Promise<AgentToolResult<TaskToolDetails>> {
 		const startTime = Date.now();
+		// Pre-discovery authority: session cwd must still match the capture from create().
+		try {
+			await assertExecutionRootMatchesRepositoryBinding(this.session.cwd, this.#sessionRepositoryBinding);
+		} catch (error) {
+			const message =
+				error instanceof RepositoryBindingError
+					? error.message
+					: error instanceof Error
+						? error.message
+						: String(error);
+			return createTaskModeError(`Session repository binding rejected before task discovery: ${message}`);
+		}
+		const bindingResolution = await resolveTaskItemsWithRepositoryBindings(this.session.cwd, params.tasks ?? []);
+		if (bindingResolution.error) {
+			return createTaskModeError(bindingResolution.error);
+		}
+		const boundParams: TaskParams = { ...params, tasks: bindingResolution.tasks };
+
 		const { agents, projectAgentsDir } = await discoverAgents(this.session.cwd);
-		const { agent: agentName, context, schema: outputSchema } = params;
+		const { agent: agentName, context, schema: outputSchema } = boundParams;
 		const simpleMode = this.#getTaskSimpleMode();
 		const { contextEnabled, customSchemaEnabled } = getTaskSimpleModeCapabilities(simpleMode);
 		const sharedContext = contextEnabled ? context?.trim() : undefined;
 		const isolationMode = this.session.settings.get("task.isolation.mode");
-		const isolationRequested = "isolated" in params ? params.isolated === true : false;
+		const isolationRequested = "isolated" in boundParams ? boundParams.isolated === true : false;
 		const isIsolated = isolationMode !== "none" && isolationRequested;
 		const mergeMode = this.session.settings.get("task.isolation.merge");
 		const commitStyle = this.session.settings.get("task.isolation.commits");
@@ -965,7 +1032,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const taskDepth = this.session.taskDepth ?? 0;
 		const subagentLspEnabled = (this.session.enableLsp ?? true) && this.session.settings.get("task.enableLsp");
 
-		if (isolationMode === "none" && "isolated" in params) {
+		if (isolationMode === "none" && "isolated" in boundParams) {
 			return {
 				content: [
 					{
@@ -1025,7 +1092,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		}
 
 		const forkContextValidationError = validateForkContextRequests(
-			params.tasks ?? [],
+			boundParams.tasks ?? [],
 			agent,
 			this.session.settings.get("task.forkContext.enabled"),
 		);
@@ -1064,7 +1131,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			: (effectiveAgent.output ?? this.session.outputSchema);
 
 		// Handle empty or missing tasks
-		if (!params.tasks || params.tasks.length === 0) {
+		if (!boundParams.tasks || boundParams.tasks.length === 0) {
 			return {
 				content: [
 					{
@@ -1082,7 +1149,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			};
 		}
 
-		const tasks = params.tasks;
+		const tasks = boundParams.tasks;
 		const missingTaskIndexes: number[] = [];
 		const idIndexes = new Map<string, number[]>();
 
@@ -1198,7 +1265,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const emitProgress = () => {
 			const progress = Array.from(progressMap.values()).sort((a, b) => a.index - b.index);
 			onUpdate?.({
-				content: [{ type: "text", text: `Running ${params.tasks.length} agents...` }],
+				content: [{ type: "text", text: `Running ${tasks.length} agents...` }],
 				details: {
 					projectAgentsDir,
 					results: [],
@@ -1367,7 +1434,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				const taskSessionFile = managedPersistence
 					? null
 					: (overrides?.sessionFile ?? executionOverrides?.sessionFiles?.get(task.id) ?? null);
+				const taskRepositoryBinding = repositoryBindingFromTask(task) ?? this.#sessionRepositoryBinding;
+				// Declared paths (relativeSubdir) must stay under the bound root before spawn.
+				if (taskRepositoryBinding.relativeSubdir) {
+					assertPathUnderRepositoryBinding(taskRepositoryBinding, ".");
+				}
 				if (!isIsolated) {
+					await assertExecutionRootMatchesRepositoryBinding(this.session.cwd, taskRepositoryBinding);
 					const result = await runSubprocess({
 						cwd: this.session.cwd,
 						agent: effectiveAgent,
@@ -1418,7 +1491,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						parentTelemetry: this.session.getTelemetry?.(),
 						forkContextSeed,
 					});
-					return { ...result, ...(forkContext ? { forkContext } : {}), forkContextAdvisory };
+					return {
+						...result,
+						...(forkContext ? { forkContext } : {}),
+						forkContextAdvisory,
+						repositoryBinding: publicRepositoryBinding(taskRepositoryBinding),
+					};
 				}
 
 				const taskStart = Date.now();
@@ -1431,6 +1509,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 
 					isolationHandle = await ensureIsolation(repoRoot, task.id, preferredIsolationBackend);
 					const isolationDir = isolationHandle.mergedDir;
+					// Isolated worktrees must preserve the source repository identity (#2901).
+					await assertExecutionRootMatchesRepositoryBinding(isolationDir, taskRepositoryBinding);
 
 					const result = await runSubprocess({
 						cwd: this.session.cwd,
@@ -1487,6 +1567,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						...result,
 						...(forkContext ? { forkContext } : {}),
 						forkContextAdvisory,
+						repositoryBinding: publicRepositoryBinding(taskRepositoryBinding),
 					};
 					if (mergeMode === "branch" && resultWithForkContext.exitCode === 0) {
 						try {

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -133,10 +133,7 @@ function addUsageTotals(target: Usage, usage: Partial<Usage>): void {
 	target.cost.total += cost.total;
 }
 
-async function validateTaskRepositoryBindings(
-	cwd: string,
-	tasks: readonly TaskItem[],
-): Promise<string | undefined> {
+async function validateTaskRepositoryBindings(cwd: string, tasks: readonly TaskItem[]): Promise<string | undefined> {
 	for (const task of tasks) {
 		if (!task.repositoryBinding) continue;
 		try {

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -48,6 +48,8 @@ export interface TaskResultReceipt {
 	extractedToolCounts?: Record<string, number>;
 	forkContext?: SingleResult["forkContext"];
 	forkContextAdvisory?: SingleResult["forkContextAdvisory"];
+	/** Resolved repository identity for this delegated lane (#2901). */
+	repositoryBinding?: SingleResult["repositoryBinding"];
 	roi?: TaskRoi;
 }
 
@@ -262,6 +264,7 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 		extractedToolCounts,
 		forkContext: raw.forkContext,
 		forkContextAdvisory: raw.forkContextAdvisory,
+		repositoryBinding: raw.repositoryBinding,
 		roi: buildTaskRoi(raw),
 	};
 }

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -74,6 +74,23 @@ const spawnPlanSchema = z
 	})
 	.describe("justification required before spawning more than four tasks");
 
+const repositoryBindingSchema = z
+	.object({
+		schema: z.literal("gjc.repository_binding.v1"),
+		worktreeRoot: z.string().min(1).describe("canonical git worktree root"),
+		commonDir: z.string().min(1).nullable().describe("git common dir, or null outside a git checkout"),
+		relativeSubdir: z
+			.string()
+			.min(1)
+			.optional()
+			.describe("optional repo-relative subdirectory; not an absolute cwd"),
+		displayPath: z.string().min(1).optional().describe("human-facing path; never used for authority"),
+		head: z.string().min(1).optional(),
+		branch: z.string().min(1).optional(),
+	})
+	.strict()
+	.describe("authoritative repository identity for multi-repo fail-closed spawn");
+
 const createTaskItemSchema = (_contextEnabled: boolean) =>
 	z.object({
 		id: z.string().max(48).refine(isValidTaskId, TASK_ID_DESCRIPTION).describe("filesystem-safe task identifier"),
@@ -85,6 +102,9 @@ const createTaskItemSchema = (_contextEnabled: boolean) =>
 			.describe(
 				"fork-context mode: none/omitted copies no parent context; receipt copies a minimal receipt-sized snapshot; last-turn copies only the latest exchange; bounded copies the bounded default snapshot; full copies a larger sanitized snapshot up to the configured/model token cap",
 			),
+		repositoryBinding: repositoryBindingSchema
+			.optional()
+			.describe("fail-closed repository identity; when set, must match the active worktree before spawn"),
 	});
 
 /** Single task item for parallel execution (default shape with context enabled). */

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -79,11 +79,7 @@ const repositoryBindingSchema = z
 		schema: z.literal("gjc.repository_binding.v1"),
 		worktreeRoot: z.string().min(1).describe("canonical git worktree root"),
 		commonDir: z.string().min(1).nullable().describe("git common dir, or null outside a git checkout"),
-		relativeSubdir: z
-			.string()
-			.min(1)
-			.optional()
-			.describe("optional repo-relative subdirectory; not an absolute cwd"),
+		relativeSubdir: z.string().min(1).optional().describe("optional repo-relative subdirectory; not an absolute cwd"),
 		displayPath: z.string().min(1).optional().describe("human-facing path; never used for authority"),
 		head: z.string().min(1).optional(),
 		branch: z.string().min(1).optional(),

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -100,7 +100,9 @@ const createTaskItemSchema = (_contextEnabled: boolean) =>
 			),
 		repositoryBinding: repositoryBindingSchema
 			.optional()
-			.describe("fail-closed repository identity; when set, must match the active worktree before spawn"),
+			.describe(
+				"authoritative repository identity; omitted items are stamped from session cwd before discovery/spawn and still fail closed on sibling drift",
+			),
 	});
 
 /** Single task item for parallel execution (default shape with context enabled). */
@@ -369,6 +371,19 @@ export interface SingleResult {
 	 * never changes the actual mode selection).
 	 */
 	forkContextAdvisory?: { recommendedMode: ForkContextMode; reasons: string[] };
+	/**
+	 * Resolved repository identity used for this task after pre-discovery stamping
+	 * and fail-closed validation (#2901).
+	 */
+	repositoryBinding?: {
+		schema: "gjc.repository_binding.v1";
+		worktreeRoot: string;
+		commonDir: string | null;
+		relativeSubdir?: string;
+		displayPath?: string;
+		head?: string;
+		branch?: string;
+	};
 }
 
 /** True only for complete, factual five-bucket cost accounting. */

--- a/packages/coding-agent/test/gjc-runtime/repository-binding.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/repository-binding.test.ts
@@ -2,15 +2,21 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { runNativeRalplanCommand } from "../../src/gjc-runtime/ralplan-runtime";
 import {
 	assertCwdMatchesRepositoryBinding,
+	assertExecutionRootMatchesRepositoryBinding,
 	assertPathUnderRepositoryBinding,
 	captureRepositoryBinding,
 	parseRepositoryBinding,
+	publicRepositoryBinding,
 	REPOSITORY_BINDING_SCHEMA,
 	RepositoryBindingError,
 	repositoryBindingsMatch,
+	resolveTaskRepositoryBinding,
 } from "../../src/gjc-runtime/repository-binding";
+import { buildTaskReceipt } from "../../src/task/receipt";
+import type { SingleResult } from "../../src/task/types";
 
 const tempRoots: string[] = [];
 
@@ -83,5 +89,132 @@ describe("repository binding (#2901)", () => {
 				relativeSubdir: "../sibling",
 			}),
 		).toThrow(/relativeSubdir/);
+	});
+
+	it("stamps omitted task bindings from session cwd (no implicit unbound lane)", async () => {
+		const root = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-repo-stamp-"));
+		tempRoots.push(root);
+		await initGitRepo(root);
+
+		const stamped = await resolveTaskRepositoryBinding(root, undefined);
+		expect(stamped.schema).toBe(REPOSITORY_BINDING_SCHEMA);
+		expect(path.resolve(stamped.worktreeRoot)).toBe(path.resolve(root));
+		await assertExecutionRootMatchesRepositoryBinding(root, stamped);
+	});
+
+	it("rejects declared task binding that points at a sibling repo", async () => {
+		const parent = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-repo-task-sib-"));
+		tempRoots.push(parent);
+		const left = path.join(parent, "left");
+		const right = path.join(parent, "right");
+		await fsp.mkdir(left);
+		await fsp.mkdir(right);
+		await initGitRepo(left);
+		await initGitRepo(right);
+
+		const rightBinding = await captureRepositoryBinding(right);
+		await expect(resolveTaskRepositoryBinding(left, rightBinding)).rejects.toMatchObject({
+			code: "identity_mismatch",
+		});
+	});
+
+	it("preserves source repository identity in a linked git worktree", async () => {
+		const root = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-repo-wt-"));
+		tempRoots.push(root);
+		const main = path.join(root, "main");
+		const linked = path.join(root, "linked");
+		await fsp.mkdir(main);
+		await initGitRepo(main);
+		const binding = await captureRepositoryBinding(main);
+
+		const proc = Bun.spawn(["git", "worktree", "add", "--detach", linked, "HEAD"], {
+			cwd: main,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const code = await proc.exited;
+		if (code !== 0) {
+			throw new Error(`git worktree add failed: ${await new Response(proc.stderr).text()}`);
+		}
+
+		const active = await assertExecutionRootMatchesRepositoryBinding(linked, binding);
+		expect(repositoryBindingsMatch(active, binding)).toBe(true);
+		expect(path.resolve(active.commonDir ?? "")).toBe(path.resolve(binding.commonDir ?? ""));
+	});
+
+	it("includes resolved repository identity on task receipts", () => {
+		const binding = publicRepositoryBinding({
+			schema: REPOSITORY_BINDING_SCHEMA,
+			worktreeRoot: "/tmp/repo",
+			commonDir: "/tmp/repo/.git",
+			branch: "main",
+			head: "abc123",
+		});
+		const raw = {
+			index: 0,
+			id: "0-Task",
+			agent: "executor",
+			agentSource: "bundled",
+			task: "review",
+			exitCode: 0,
+			output: "ok",
+			stderr: "",
+			truncated: false,
+			durationMs: 1,
+			tokens: 0,
+			repositoryBinding: binding,
+		} satisfies SingleResult;
+		const receipt = buildTaskReceipt(raw);
+		expect(receipt.repositoryBinding).toEqual(binding);
+	});
+
+	it("enforces ralplan repository binding on stage write after seed", async () => {
+		const parent = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-ralplan-bind-"));
+		tempRoots.push(parent);
+		const left = path.join(parent, "left");
+		const right = path.join(parent, "right");
+		await fsp.mkdir(left);
+		await fsp.mkdir(right);
+		await initGitRepo(left);
+		await initGitRepo(right);
+
+		const sessionId = "test-session-2901";
+		const envSession = process.env.GJC_SESSION_ID;
+		process.env.GJC_SESSION_ID = sessionId;
+		try {
+			const seed = await runNativeRalplanCommand(["--json", "binding enforce dogfood"], left);
+			expect(seed.status).toBe(0);
+			const seedPayload = JSON.parse(seed.stdout ?? "{}") as { repository_binding?: { worktreeRoot?: string } };
+			expect(seedPayload.repository_binding?.worktreeRoot).toBeTruthy();
+
+			const artifactPath = path.join(left, "planner-note.md");
+			await fsp.writeFile(artifactPath, "# planner\n");
+			const okWrite = await runNativeRalplanCommand(
+				["--write", "--stage", "planner", "--stage_n", "1", "--artifact", artifactPath, "--json"],
+				left,
+			);
+			expect(okWrite.status).toBe(0);
+			const writePayload = JSON.parse(okWrite.stdout ?? "{}") as { repository_binding?: { worktreeRoot?: string } };
+			expect(writePayload.repository_binding?.worktreeRoot).toBeTruthy();
+
+			// Copy state into RIGHT under same relative session path is not how product works;
+			// instead re-seed is not needed: enforce uses LEFT seed when cwd is RIGHT only if
+			// state lives under RIGHT. Product path: seed on LEFT, then invoke write with cwd=RIGHT
+			// cannot see LEFT state — so test sibling by reusing LEFT binding via explicit fail path:
+			const leftState = path.join(left, ".gjc", `_session-${sessionId}`, "state", "ralplan-state.json");
+			const rightStateDir = path.join(right, ".gjc", `_session-${sessionId}`, "state");
+			await fsp.mkdir(rightStateDir, { recursive: true });
+			await fsp.copyFile(leftState, path.join(rightStateDir, "ralplan-state.json"));
+
+			const siblingWrite = await runNativeRalplanCommand(
+				["--write", "--stage", "architect", "--stage_n", "1", "--artifact", "# arch\n", "--json"],
+				right,
+			);
+			expect(siblingWrite.status).toBe(2);
+			expect(siblingWrite.stderr).toMatch(/repository binding rejected|identity_mismatch|does not match/i);
+		} finally {
+			if (envSession === undefined) delete process.env.GJC_SESSION_ID;
+			else process.env.GJC_SESSION_ID = envSession;
+		}
 	});
 });

--- a/packages/coding-agent/test/gjc-runtime/repository-binding.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/repository-binding.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	assertCwdMatchesRepositoryBinding,
+	assertPathUnderRepositoryBinding,
+	captureRepositoryBinding,
+	parseRepositoryBinding,
+	REPOSITORY_BINDING_SCHEMA,
+	RepositoryBindingError,
+	repositoryBindingsMatch,
+} from "../../src/gjc-runtime/repository-binding";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fsp.rm(dir, { recursive: true, force: true })));
+});
+
+async function initGitRepo(root: string): Promise<void> {
+	const run = async (args: string[]) => {
+		const proc = Bun.spawn(["git", ...args], { cwd: root, stdout: "pipe", stderr: "pipe" });
+		const code = await proc.exited;
+		if (code !== 0) {
+			const err = await new Response(proc.stderr).text();
+			throw new Error(`git ${args.join(" ")} failed: ${err}`);
+		}
+	};
+	await run(["init"]);
+	await run(["config", "user.email", "test@example.com"]);
+	await run(["config", "user.name", "Test"]);
+	await fsp.writeFile(path.join(root, "README.md"), "hello\n");
+	await run(["add", "README.md"]);
+	await run(["commit", "-m", "init"]);
+}
+
+describe("repository binding (#2901)", () => {
+	it("captures and matches the same repository identity", async () => {
+		const root = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-repo-bind-"));
+		tempRoots.push(root);
+		await initGitRepo(root);
+
+		const binding = await captureRepositoryBinding(root);
+		expect(binding.schema).toBe(REPOSITORY_BINDING_SCHEMA);
+		expect(binding.commonDir).toBeTruthy();
+		expect(path.resolve(binding.worktreeRoot)).toBe(path.resolve(root));
+
+		const active = await assertCwdMatchesRepositoryBinding(root, binding);
+		expect(repositoryBindingsMatch(active, binding)).toBe(true);
+		expect(assertPathUnderRepositoryBinding(binding, "README.md")).toContain("README.md");
+	});
+
+	it("fails closed when active cwd is a sibling repository", async () => {
+		const parent = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-repo-siblings-"));
+		tempRoots.push(parent);
+		const left = path.join(parent, "left");
+		const right = path.join(parent, "right");
+		await fsp.mkdir(left);
+		await fsp.mkdir(right);
+		await initGitRepo(left);
+		await initGitRepo(right);
+
+		const leftBinding = await captureRepositoryBinding(left);
+		await expect(assertCwdMatchesRepositoryBinding(right, leftBinding)).rejects.toBeInstanceOf(
+			RepositoryBindingError,
+		);
+		await expect(assertCwdMatchesRepositoryBinding(right, leftBinding)).rejects.toMatchObject({
+			code: "identity_mismatch",
+		});
+
+		expect(() => assertPathUnderRepositoryBinding(leftBinding, path.join(right, "README.md"))).toThrow(
+			/escapes bound repository root/,
+		);
+	});
+
+	it("rejects relativeSubdir that escapes with ..", () => {
+		expect(() =>
+			parseRepositoryBinding({
+				schema: REPOSITORY_BINDING_SCHEMA,
+				worktreeRoot: "/tmp/repo",
+				commonDir: "/tmp/repo/.git",
+				relativeSubdir: "../sibling",
+			}),
+		).toThrow(/relativeSubdir/);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #2901 (second slice).

Supersedes closed https://github.com/Yeachan-Heo/gajae-code/pull/2965 (and earlier #2955).

Owner red-team on #2965 found the first slice incomplete: optional task bindings, discovery-before-authority, path checks only in tests, ralplan write-only seed, and missing isolation/receipt coverage.

## What changed

1. **Pre-discovery authority** — `TaskTool.create()` captures/verifies session repository binding **before** `discoverAgents()`.
2. **Stamp omitted bindings** — every task item gets a resolved `repositoryBinding` from session cwd when omitted; declared bindings must match the active worktree.
3. **Spawn + isolation** — non-isolated and isolated execution re-assert identity; linked worktrees must preserve source `commonDir`.
4. **Path under root** — production ralplan `--artifact` file paths and task `relativeSubdir` are checked with realpath-safe root membership.
5. **Ralplan handoff enforcement** — seed re-entry and `--write` fail closed when cwd no longer matches `repository_binding`; write receipts echo identity.
6. **Receipts** — `SingleResult` / `TaskResultReceipt` carry resolved repository identity.
7. **Ultragoal** — `startNextUltragoalGoal` requires a stamped plan binding (no silent unbound plans).

## Product dogfood

```sh
bun packages/coding-agent/scripts/dogfood-repository-binding.ts
```

Proves sibling fail-closed for goal start, path escape, task stamp, ralplan seed, planner write (match), and architect write with copied LEFT binding on RIGHT (reject).

## Tests

```sh
bun test packages/coding-agent/test/gjc-runtime/repository-binding.test.ts
# 8 pass including linked worktree + ralplan sibling write + receipt identity
```

## Evidence

Exact-head `bun run build` + dogfood transcripts are in the PR comment.

## Still out of scope

- Auto-bind historical plans without a field (fail closed instead)
- Prose extraction of repository identity
- Rewriting isolation child cwd from binding beyond identity match