### PR TITLE
feat(telegram): add session-scoped /status command

### DIFF
--- a/crates/gjc-sdk/src/protocol.rs
+++ b/crates/gjc-sdk/src/protocol.rs
@@ -1083,6 +1083,22 @@ pub enum ControlCommandStatus {
 	Unavailable,
 }
 
+/// Structured one-shot session status rendered by the notification daemon.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionStatus {
+	pub repo:           String,
+	pub branch:         String,
+	pub machine:        String,
+	pub session_id:     String,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub model:          Option<String>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub context:        Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub workflow_lines: Vec<String>,
+}
+
 /// A Telegram-safe model choice surfaced by a successful `model` list control
 /// result.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1099,19 +1115,22 @@ pub struct ModelChoice {
 #[serde(rename_all = "camelCase")]
 pub struct ControlCommandResult {
 	/// The session this result belongs to.
-	pub session_id:    String,
+	pub session_id:     String,
 	/// Client request id being answered.
-	pub request_id:    String,
+	pub request_id:     String,
 	/// Telegram update id this result corresponds to, when known.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub update_id:     Option<i64>,
+	pub update_id:      Option<i64>,
 	/// Terminal command status.
-	pub status:        ControlCommandStatus,
+	pub status:         ControlCommandStatus,
 	/// Short deterministic Telegram-visible text.
-	pub message:       String,
+	pub message:        String,
+	/// Optional structured session status rendered by the notification daemon.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub session_status: Option<SessionStatus>,
 	/// Optional model choices for a successful bare `model` list request.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub model_choices: Option<Vec<ModelChoice>>,
+	pub model_choices:  Option<Vec<ModelChoice>>,
 }
 
 /// Agent loop activity state, driving the client's live typing indicator.
@@ -1920,12 +1939,21 @@ mod tests {
 	#[test]
 	fn control_command_result_model_choices_roundtrip() {
 		let msg = ServerMessage::ControlCommandResult(ControlCommandResult {
-			session_id:    "s1".into(),
-			request_id:    "r1".into(),
-			update_id:     Some(42),
-			status:        ControlCommandStatus::Ok,
-			message:       "Select a model".into(),
-			model_choices: Some(vec![ModelChoice {
+			session_id:     "s1".into(),
+			request_id:     "r1".into(),
+			update_id:      Some(42),
+			status:         ControlCommandStatus::Ok,
+			message:        "Select a model".into(),
+			session_status: Some(SessionStatus {
+				repo:           "repo".into(),
+				branch:         "dev".into(),
+				machine:        "host".into(),
+				session_id:     "s1".into(),
+				model:          Some("model".into()),
+				context:        Some("25k/100k 25%".into()),
+				workflow_lines: vec!["Ralplan".into(), "• status: active".into()],
+			}),
+			model_choices:  Some(vec![ModelChoice {
 				selector: "provider/model".into(),
 				label:    "Model".into(),
 			}]),
@@ -1936,6 +1964,7 @@ mod tests {
 		assert_eq!(v["requestId"], "r1");
 		assert_eq!(v["updateId"], 42);
 		assert_eq!(v["status"], "ok");
+		assert_eq!(v["sessionStatus"]["sessionId"], "s1");
 		assert_eq!(v["modelChoices"][0]["selector"], "provider/model");
 		assert_eq!(serde_json::from_value::<ServerMessage>(v).unwrap(), msg);
 	}
@@ -1945,7 +1974,10 @@ mod tests {
 		let raw = r#"{"type":"control_command_result","sessionId":"s1","requestId":"r1","status":"ok","message":"done"}"#;
 		let msg: ServerMessage = serde_json::from_str(raw).unwrap();
 		match msg {
-			ServerMessage::ControlCommandResult(result) => assert_eq!(result.model_choices, None),
+			ServerMessage::ControlCommandResult(result) => {
+				assert_eq!(result.model_choices, None);
+				assert_eq!(result.session_status, None);
+			},
 			other => panic!("expected control_command_result, got {other:?}"),
 		}
 	}

--- a/packages/coding-agent/src/sdk/bus/config-commands.ts
+++ b/packages/coding-agent/src/sdk/bus/config-commands.ts
@@ -20,14 +20,15 @@ export interface ConfigCommandChange {
 	redact?: boolean;
 }
 
-export type TelegramControlCommandName = "reasoning" | "usage" | "context" | "compact" | "model";
+export type TelegramControlCommandName = "reasoning" | "usage" | "context" | "compact" | "model" | "status";
 
 export type TelegramControlCommand =
 	| { name: "reasoning"; action: "cycle" | "status" | "set" | "show" | "hide"; level?: string; global?: boolean }
 	| { name: "usage" }
 	| { name: "context" }
 	| { name: "compact"; instructions?: string }
-	| { name: "model"; action: "list" | "set"; selector?: string };
+	| { name: "model"; action: "list" | "set"; selector?: string }
+	| { name: "status" };
 
 export type TelegramControlCommandParseResult =
 	| { kind: "none" }
@@ -41,6 +42,7 @@ const TELEGRAM_CONTROL_COMMANDS = new Set<TelegramControlCommandName>([
 	"context",
 	"compact",
 	"model",
+	"status",
 ]);
 const TELEGRAM_REASONING_LEVELS = new Set(["inherit", "off", "minimal", "low", "medium", "high", "xhigh", "max"]);
 
@@ -61,6 +63,8 @@ export function telegramControlCommandUsage(commandName: TelegramControlCommandN
 			return "Usage: /compact [instructions]";
 		case "model":
 			return "Usage: /model [provider/model]";
+		case "status":
+			return "Usage: /status";
 	}
 }
 
@@ -81,6 +85,10 @@ export function parseTelegramControlCommand(text: string, botUsername?: string):
 		case "context":
 			return rest.length === 0
 				? { kind: "command", command: { name: commandName } }
+				: { kind: "invalid", commandName, usage };
+		case "status":
+			return rest.length === 0
+				? { kind: "command", command: { name: "status" } }
 				: { kind: "invalid", commandName, usage };
 		case "compact": {
 			const instructions = trimmed.slice(rawRoot.length + 1).trim();

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -41,6 +41,12 @@ import {
 	type WorkflowGateTerminalProof,
 } from "../../modes/shared/agent-wire/workflow-gate-broker";
 import type { AgentSessionEvent } from "../../session/agent-session";
+import {
+	collapsePlanningPipeline,
+	readVisibleSkillActiveState,
+	type SkillActiveEntry,
+	type WorkflowHudChip,
+} from "../../skill-state/active-state";
 import { parseThinkingLevel } from "../../thinking";
 import type {
 	AskAnswerRequest,
@@ -65,7 +71,6 @@ import {
 	normalizeSdkStartupFailure,
 	type SdkStartupFailure,
 } from "../startup-capability";
-
 import { registerTelegramFileSink } from "./attachment-registry";
 import { ensureDiscordDaemon, ensureSlackDaemon } from "./chat-daemon-control";
 import {
@@ -1225,9 +1230,20 @@ interface NotificationControlCommandPayload {
 	instructions?: unknown;
 }
 
+export interface NotificationSessionStatus {
+	repo: string;
+	branch: string;
+	machine: string;
+	sessionId: string;
+	model?: string;
+	context?: string;
+	workflowLines: string[];
+}
+
 export interface NotificationControlCommandResult {
 	status: "ok" | "error" | "unavailable";
 	message: string;
+	sessionStatus?: NotificationSessionStatus;
 	modelChoices?: Array<{ selector: string; label: string }>;
 }
 
@@ -1255,6 +1271,76 @@ function formatContextUsageLine(ctx: ExtensionContext): string {
 	const window = formatCompactTokenCount(usage.contextWindow);
 	const pct = usage.percent == null ? "unknown" : `${usage.percent.toFixed(1)}%`;
 	return `Context: ${tokens}/${window} ${pct}`;
+}
+
+const STATUS_ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+
+function sanitizeStatusPart(value: string | undefined): string {
+	const sanitized = (value ?? "")
+		.replace(STATUS_ANSI_PATTERN, "")
+		.replace(/[\r\n\t]+/g, " ")
+		.trim();
+	return sanitized.length <= 240 ? sanitized : `${sanitized.slice(0, 239)}…`;
+}
+
+function compareStatusEntries(a: SkillActiveEntry, b: SkillActiveEntry): number {
+	return a.skill.localeCompare(b.skill) || (a.phase ?? "").localeCompare(b.phase ?? "");
+}
+
+function compareStatusChips(a: WorkflowHudChip, b: WorkflowHudChip): number {
+	return (a.priority ?? 50) - (b.priority ?? 50) || a.label.localeCompare(b.label);
+}
+
+/** Render canonical HUD state as a compact vertical summary for one-shot remote status. */
+export function renderSessionWorkflowStatusLines(entries: readonly SkillActiveEntry[]): string[] {
+	const visible = collapsePlanningPipeline(entries.filter(entry => entry.active !== false));
+	const entry = visible.filter(candidate => sanitizeStatusPart(candidate.skill)).sort(compareStatusEntries)[0];
+	if (!entry) return [];
+	const chips = new Map(
+		[...(entry.hud?.chips ?? [])]
+			.sort(compareStatusChips)
+			.map(chip => [sanitizeStatusPart(chip.label), sanitizeStatusPart(chip.value)]),
+	);
+	if (entry.skill === "ralplan") {
+		const stage = chips.get("stage") || sanitizeStatusPart(entry.phase);
+		const pending = chips.get("pending") === "approval";
+		const verdict = chips.get("verdict");
+		return [
+			"Ralplan",
+			stage ? `• stage: ${stage}` : "",
+			pending ? "• status: awaiting approval" : "• status: active",
+			verdict ? `• verdict: ${verdict.toLowerCase()}` : "",
+		].filter(Boolean);
+	}
+	if (entry.skill === "ultragoal") {
+		const current = chips.get("current")?.replace(/^([^:]+):/, "$1 — ");
+		return [
+			"Ultragoal",
+			`• status: ${chips.get("status") || sanitizeStatusPart(entry.phase) || "active"}`,
+			chips.get("goals") ? `• goals: ${chips.get("goals")} complete` : "",
+			current ? `• current: ${current}` : "",
+			chips.get("blocked") ? `• blocked: ${chips.get("blocked")}` : "",
+		].filter(Boolean);
+	}
+	return [sanitizeStatusPart(entry.skill), `• status: ${sanitizeStatusPart(entry.phase) || "active"}`];
+}
+
+async function readNotificationSessionStatus(ctx: ExtensionContext): Promise<NotificationSessionStatus> {
+	const sessionId = ctx.sessionManager.getSessionId();
+	const identityFields = buildIdentity(ctx.cwd);
+	const modelName = ctx.model ? truncate(`${ctx.model.name ?? ctx.model.id} (${ctx.model.provider})`, 200) : undefined;
+	const contextText = formatContextUsageLine(ctx).replace(/^Context:\s*/, "");
+	const state = await readVisibleSkillActiveState(ctx.cwd, sessionId, { tier: "hud" }).catch(() => undefined);
+	const workflowLines = renderSessionWorkflowStatusLines(state?.active_skills ?? []);
+	return {
+		repo: identityFields.repo,
+		branch: identityFields.branch,
+		machine: truncate(identityFields.machine, 100),
+		sessionId,
+		...(modelName ? { model: modelName } : {}),
+		...(contextText ? { context: contextText } : {}),
+		workflowLines,
+	};
 }
 
 function formatLocalUsage(ctx: ExtensionContext): string {
@@ -1408,9 +1494,10 @@ export async function executeNotificationControlCommand(
 	ctx: ExtensionContext,
 	api: ExtensionAPI,
 	expectedSessionId?: string,
+	liveSessionId?: string,
 ): Promise<NotificationControlCommandResult> {
 	try {
-		return await executeNotificationControlCommandUnchecked(command, ctx, api, expectedSessionId);
+		return await executeNotificationControlCommandUnchecked(command, ctx, api, expectedSessionId, liveSessionId);
 	} catch {
 		logger.warn("notifications: control command failed");
 		return { status: "error", message: CONTROL_COMMAND_FAILURE_MESSAGE };
@@ -1422,9 +1509,35 @@ async function executeNotificationControlCommandUnchecked(
 	ctx: ExtensionContext,
 	api: ExtensionAPI,
 	expectedSessionId?: string,
+	liveSessionId?: string,
 ): Promise<NotificationControlCommandResult> {
 	if (!command || typeof command.name !== "string") return { status: "error", message: "Invalid control command." };
 	switch (command.name) {
+		case "status": {
+			const managerSessionId = ctx.sessionManager.getSessionId();
+			if (
+				typeof expectedSessionId !== "string" ||
+				expectedSessionId.trim() === "" ||
+				managerSessionId !== expectedSessionId ||
+				liveSessionId !== expectedSessionId
+			)
+				return { status: "unavailable", message: "Status unavailable for this session." };
+			const sessionStatus = await readNotificationSessionStatus(ctx);
+			return {
+				status: "ok",
+				message: [
+					"GJC session",
+					`repo: ${sessionStatus.repo}`,
+					`branch: ${sessionStatus.branch}`,
+					`machine: ${sessionStatus.machine}`,
+					`session: ${sessionStatus.sessionId}`,
+					...(sessionStatus.model ? [`model: ${sessionStatus.model}`] : []),
+					...(sessionStatus.context ? [`context: ${sessionStatus.context}`] : []),
+					...sessionStatus.workflowLines,
+				].join("\n"),
+				sessionStatus,
+			};
+		}
 		case "reasoning": {
 			const global = command.global === true;
 			if (command.action === "status") return { status: "ok", message: formatReasoningSettings(api) };
@@ -4025,13 +4138,17 @@ export function createNotificationsExtension(
 					if (!runtime || !inbound.requestId) return;
 					const activeRuntime = runtime;
 					if (inbound.sessionId !== activeRuntime.id) {
+						const command = parseControlCommandPayload(inbound.commandJson);
 						pushSessionFrame(activeRuntime, {
 							type: "control_command_result",
 							sessionId: activeRuntime.id,
 							requestId: inbound.requestId,
 							updateId: inbound.updateId,
 							status: "error",
-							message: STALE_MODEL_BUTTON_MESSAGE,
+							message:
+								command?.name === "status"
+									? "Status unavailable for this session."
+									: STALE_MODEL_BUTTON_MESSAGE,
 						});
 						return;
 					}
@@ -4040,6 +4157,7 @@ export function createNotificationsExtension(
 						ctx,
 						api,
 						inbound.sessionId,
+						activeRuntime.id,
 					).then(result => {
 						if (runtime !== activeRuntime) return;
 						pushSessionFrame(activeRuntime, {
@@ -4049,6 +4167,7 @@ export function createNotificationsExtension(
 							updateId: inbound.updateId,
 							status: result.status,
 							message: result.message,
+							sessionStatus: result.sessionStatus,
 							modelChoices: result.modelChoices,
 						});
 					});

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
@@ -32,8 +32,9 @@ export const NOTIFICATION_PROTOCOL_VERSION = 3;
  * fencing, attested generation-bearing pre-incarnation owner handoff in
  * generation 20, guarded modern generation-absent predecessor signaling in
  * generation 21, dead Windows v0.10 owner replacement in generation 22, and
- * retained native cleanup authority revalidation in generation 23, and typed
+ * retained native cleanup authority revalidation in generation 23, typed
  * retained exact-unlink cleanup authority acceptance (concrete detached
- * quarantine plus proven canonical absence) in generation 24.
+ * quarantine plus proven canonical absence) in generation 24, and
+ * session-scoped status command routing in generation 25.
  */
-export const DAEMON_GENERATION = 24;
+export const DAEMON_GENERATION = 25;

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
@@ -35,6 +35,6 @@ export const NOTIFICATION_PROTOCOL_VERSION = 3;
  * retained native cleanup authority revalidation in generation 23, typed
  * retained exact-unlink cleanup authority acceptance (concrete detached
  * quarantine plus proven canonical absence) in generation 24, and
- * session-scoped status command routing in generation 25.
+ * session-scoped status command routing in generation 26.
  */
-export const DAEMON_GENERATION = 25;
+export const DAEMON_GENERATION = 26;

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -95,7 +95,7 @@ import {
 	readEndpoint,
 	routeInboundUpdate,
 } from "./telegram-reference";
-import { decideThreadedInbound, type InboundAttachment } from "./threaded-inbound";
+import { decideThreadedInbound, extractInboundAttachment, type InboundAttachment } from "./threaded-inbound";
 import { renderThreadedFrame, type ThreadedSend } from "./threaded-render";
 import { type TopicEndpointBinding, TopicRegistry, type TopicRegistryState } from "./topic-registry";
 
@@ -7814,20 +7814,63 @@ export class TelegramNotificationDaemon {
 		// update_id dedupe are all enforced by decideThreadedInbound.
 		const raw = update as {
 			callback_query?: unknown;
-			message?: { text?: unknown; reply_to_message?: { message_id?: unknown } };
+			message?: {
+				message_id?: unknown;
+				text?: unknown;
+				caption?: unknown;
+				photo?: unknown;
+				document?: unknown;
+				video?: unknown;
+				audio?: unknown;
+				voice?: unknown;
+				animation?: unknown;
+				chat?: { id?: unknown };
+				reply_to_message?: { message_id?: unknown };
+				message_thread_id?: unknown;
+			};
 		};
 		// A reply to a known ask message routes to that ask (below). Any OTHER
 		// message in a topic (plain text, or a reply to a non-ask message) is a
 		// free-text injection. Previously replies bypassed injection entirely.
 		const replyTo = raw.message?.reply_to_message?.message_id;
+		const commandText =
+			typeof raw.message?.text === "string"
+				? raw.message.text
+				: typeof raw.message?.caption === "string"
+					? raw.message.caption
+					: undefined;
 		const reservedBtw =
 			typeof raw.message?.text === "string" ? parseBtwCommand(raw.message.text, this.botUsername) : undefined;
+		const directControl = commandText
+			? parseTelegramControlCommand(commandText, this.botUsername)
+			: ({ kind: "none" } as const);
+		const mediaStatus =
+			((directControl.kind === "invalid" && directControl.commandName === "status") ||
+				(directControl.kind === "command" && directControl.command.name === "status")) &&
+			Boolean(raw.message && extractInboundAttachment(raw.message));
+		if (mediaStatus && !raw.callback_query) {
+			const inbound = decideThreadedInbound(update as never, {
+				pairedChatId: this.opts.chatId,
+				topicToSession: t => this.topics.sessionForTopic(t),
+				isDuplicate: id => this.dispatchState.seenUpdateIds.has(id),
+			});
+			if (inbound.kind !== "inject" || !inbound.attachment || !(await this.pairedChatIsPrivate())) return;
+			if (await this.reserveSeenUpdateId(inbound.updateId)) {
+				try {
+					await this.botApi.call("sendMessage", {
+						chat_id: this.opts.chatId,
+						message_thread_id: Number(inbound.threadId),
+						text: "Usage: /status",
+						parse_mode: TELEGRAM_PARSE_MODE,
+					});
+				} catch {
+					logger.warn("notifications: status media usage delivery failed");
+				}
+			}
+			return;
+		}
 		const isAskReply =
 			replyTo !== undefined && (this.messageRoutes.has(String(replyTo)) || this.messageRoutes.has(Number(replyTo)));
-		const directControl =
-			typeof raw.message?.text === "string"
-				? parseTelegramControlCommand(raw.message.text, this.botUsername)
-				: ({ kind: "none" } as const);
 		const interceptAskControl = isAskReply && directControl.kind !== "none";
 		if (!raw.callback_query && (!isAskReply || interceptAskControl || reservedBtw !== undefined)) {
 			const inbound = decideThreadedInbound(update as never, {
@@ -8225,6 +8268,7 @@ export class TelegramNotificationDaemon {
 					{ command: "usage", description: "Show provider/local usage for this session" },
 					{ command: "model", description: "Select a model for this session" },
 					{ command: "context", description: "Show current context usage for this session" },
+					{ command: "status", description: "Show current session and workflow status" },
 					{ command: "compact", description: "Compact this session: /compact [instructions]" },
 					{ command: "btw", description: "Ask an ephemeral side question in this session" },
 					{ command: "session_create", description: "Create a GJC session: path, worktree, or dir [--mpreset]" },

--- a/packages/coding-agent/src/sdk/bus/threaded-inbound.ts
+++ b/packages/coding-agent/src/sdk/bus/threaded-inbound.ts
@@ -75,7 +75,9 @@ function asString(value: unknown): string | undefined {
 	return undefined;
 }
 
-function extractAttachment(message: NonNullable<InboundUpdate["message"]>): InboundAttachment | undefined {
+export function extractInboundAttachment(
+	message: NonNullable<InboundUpdate["message"]>,
+): InboundAttachment | undefined {
 	if (Array.isArray(message.photo) && message.photo.length > 0) {
 		const photo = message.photo[message.photo.length - 1];
 		if (photo && typeof photo === "object" && "file_id" in photo && typeof photo.file_id === "string") {
@@ -130,7 +132,7 @@ export function decideThreadedInbound(update: InboundUpdate, ctx: ThreadedInboun
 			: typeof message.caption === "string"
 				? message.caption.trim()
 				: "";
-	const attachment = extractAttachment(message);
+	const attachment = extractInboundAttachment(message);
 	if (!text && attachment === undefined) return { kind: "ignore", reason: "empty_text" };
 
 	if (typeof message.message_id !== "number" || !Number.isSafeInteger(message.message_id) || message.message_id <= 0) {

--- a/packages/coding-agent/src/sdk/bus/threaded-render.ts
+++ b/packages/coding-agent/src/sdk/bus/threaded-render.ts
@@ -94,6 +94,7 @@ interface ThreadedFrame {
 	// control_command_result
 	status?: unknown;
 	message?: unknown;
+	sessionStatus?: unknown;
 }
 
 function str(v: unknown): string | undefined {
@@ -104,22 +105,48 @@ function isDotOnlyText(value: string): boolean {
 	return /^[.\s]+$/.test(value);
 }
 
-/** Format the one-time identity header as pinned bullets. */
-export function formatIdentityHeader(frame: {
+interface SessionIdentityFields {
 	repo?: unknown;
 	branch?: unknown;
 	machine?: unknown;
 	sessionId?: unknown;
-	title?: unknown;
-}): string {
-	const title = str(frame.title) ?? "GJC session";
-	const bullets = [
+}
+
+function formatSessionIdentityBullets(frame: SessionIdentityFields): string[] {
+	return [
 		`• repo: ${code(str(frame.repo) ?? "?")}`,
 		`• branch: ${code(str(frame.branch) ?? "?")}`,
 		`• machine: ${code(str(frame.machine) ?? "?")}`,
 		`• session: ${code(str(frame.sessionId) ?? "?")}`,
-	];
+	].filter((line): line is string => Boolean(line));
+}
+
+/** Format the one-time identity header as pinned bullets. */
+export function formatIdentityHeader(
+	frame: SessionIdentityFields & {
+		title?: unknown;
+	},
+): string {
+	const title = str(frame.title) ?? "GJC session";
+	const bullets = formatSessionIdentityBullets(frame);
 	return `${bold(title)}\n${bullets.join("\n")}`;
+}
+
+/** Format a one-shot session status using the identity card's visual grammar. */
+export function formatSessionStatusHeader(
+	frame: SessionIdentityFields & {
+		model?: unknown;
+		context?: unknown;
+	},
+): string {
+	const model = str(frame.model);
+	const context = str(frame.context);
+	const bullets = [
+		...formatSessionIdentityBullets(frame),
+		model ? `• model: ${escapeHtml(model)}` : undefined,
+		context ? `• context: ${escapeHtml(context)}` : undefined,
+	].filter((line): line is string => Boolean(line));
+	return `${bold("GJC session")}\n${bullets.join("\n")}`;
 }
 
 /** Format a streamed context update into a compact block (omitting empty fields). */
@@ -282,6 +309,22 @@ export function renderThreadedFrame(frame: ThreadedFrame): ThreadedSend | undefi
 			if (!message) return undefined;
 			const status = str(frame.status);
 			const prefix = status === "ok" ? "✅" : status === "unavailable" ? "⚠️" : "❌";
+			const sessionStatus =
+				frame.sessionStatus && typeof frame.sessionStatus === "object"
+					? (frame.sessionStatus as Record<string, unknown>)
+					: undefined;
+			if (sessionStatus) {
+				const workflowLines = Array.isArray(sessionStatus.workflowLines)
+					? sessionStatus.workflowLines.map(str).filter((line): line is string => Boolean(line))
+					: [];
+				const identity = formatSessionStatusHeader(sessionStatus);
+				const workflow = workflowLines.length > 0 ? `\n\n${workflowLines.map(escapeHtml).join("\n")}` : "";
+				return {
+					method: "sendMessage",
+					lane: "idle",
+					text: finalizeTelegramHtml(`${identity}${workflow}`),
+				};
+			}
 			return {
 				method: "sendMessage",
 				lane: "idle",

--- a/packages/coding-agent/test/manifests/telegram-baseline-v1.json
+++ b/packages/coding-agent/test/manifests/telegram-baseline-v1.json
@@ -264,6 +264,13 @@
 			"argv": [
 				"bun",
 				"test",
+				"packages/coding-agent/test/notifications-session-status.test.ts"
+			]
+		},
+		{
+			"argv": [
+				"bun",
+				"test",
 				"packages/coding-agent/test/notifications-session-switch.test.ts"
 			]
 		},

--- a/packages/coding-agent/test/notifications-config-commands.test.ts
+++ b/packages/coding-agent/test/notifications-config-commands.test.ts
@@ -160,6 +160,25 @@ describe("parseTelegramControlCommand", () => {
 			command: { name: "model", action: "set", selector: "OpenAI/GPT-5" },
 		});
 	});
+	test("/status accepts only its zero-argument local form", () => {
+		expect(parseTelegramControlCommand("  /STATUS  ", "GajaeCodeBot")).toEqual({
+			kind: "command",
+			command: { name: "status" },
+		});
+		expect(parseTelegramControlCommand("/status@GajaeCodeBot", "GajaeCodeBot")).toEqual({
+			kind: "command",
+			command: { name: "status" },
+		});
+		expect(parseTelegramControlCommand("/status now", "GajaeCodeBot")).toEqual({
+			kind: "invalid",
+			commandName: "status",
+			usage: "Usage: /status",
+		});
+		expect(parseTelegramControlCommand("/status@OtherBot", "GajaeCodeBot")).toEqual({
+			kind: "ignored",
+			commandName: "status",
+		});
+	});
 
 	test("recognized invalid forms fail closed", () => {
 		expect(parseTelegramControlCommand("/usage now")).toMatchObject({ kind: "invalid", commandName: "usage" });

--- a/packages/coding-agent/test/notifications-control-executor.test.ts
+++ b/packages/coding-agent/test/notifications-control-executor.test.ts
@@ -25,7 +25,11 @@ function fakeCtx(overrides: Record<string, unknown> = {}) {
 					premiumRequests: 2,
 					cost: 0.012345,
 				}),
+				getSessionId: () => "session",
+				getHeader: () => null,
 			},
+			getTranscript: () => [],
+			cwd: "/tmp/status-test",
 			modelRegistry: {
 				getAvailable: () => [],
 			},
@@ -146,6 +150,60 @@ describe("executeNotificationControlCommand", () => {
 		expect(usage.status).toBe("ok");
 		expect(usage.message).toContain("Input tokens: 10");
 		expect("sendUserMessage" in api).toBe(false);
+	});
+	test("status validates expected, manager, and live identities before touching cwd or control APIs", async () => {
+		const { ctx } = fakeCtx({
+			cwd: (() => {
+				throw new Error("status must not read cwd for stale identity");
+			}) as unknown as string,
+			sessionManager: { getSessionId: () => "manager" },
+		});
+		const { api, cycleCalls, thinkingLevelCalls, visibilityCalls, temporaryModelCalls } = fakeApi();
+
+		expect(
+			await executeNotificationControlCommand({ name: "status" }, ctx as any, api as any, "expected", "live"),
+		).toEqual({
+			status: "unavailable",
+			message: "Status unavailable for this session.",
+		});
+		expect(cycleCalls).toBe(0);
+		expect(thinkingLevelCalls).toEqual([]);
+		expect(visibilityCalls).toEqual([]);
+		expect(temporaryModelCalls).toEqual([]);
+	});
+
+	test("status performs an explicit same-session read without steering a busy turn", async () => {
+		const { ctx } = fakeCtx({
+			cwd: "/home/alice/secret-client/repo",
+			sessionManager: { getSessionId: () => "same-session", getHeader: () => null },
+			getTranscript: () => [],
+		});
+		const { api, cycleCalls, thinkingLevelCalls, visibilityCalls, temporaryModelCalls } = fakeApi();
+
+		const result = await executeNotificationControlCommand(
+			{ name: "status" },
+			ctx as any,
+			api as any,
+			"same-session",
+			"same-session",
+		);
+		expect(result.status).toBe("ok");
+		expect(result.message).toContain("GJC session");
+		expect(result.message).toContain("repo: repo");
+		expect(result.message).not.toContain("<code>");
+		expect(result.message).not.toContain("/home/alice");
+		expect(JSON.stringify(result.sessionStatus)).not.toContain("/home/alice");
+		expect(result.sessionStatus).toMatchObject({
+			repo: "repo",
+			branch: "(detached)",
+			sessionId: "same-session",
+			context: "25k/272k 9.2%",
+			workflowLines: [],
+		});
+		expect(cycleCalls).toBe(0);
+		expect(thinkingLevelCalls).toEqual([]);
+		expect(visibilityCalls).toEqual([]);
+		expect(temporaryModelCalls).toEqual([]);
 	});
 
 	test("reports reasoning display and persists only global mutations", async () => {

--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../src/sdk/bus/html-format";
 import { TelegramNotificationDaemon } from "../src/sdk/bus/telegram-daemon";
 import { buildActionMessage } from "../src/sdk/bus/telegram-reference";
-import { formatIdentityHeader, renderThreadedFrame } from "../src/sdk/bus/threaded-render";
+import { formatIdentityHeader, formatSessionStatusHeader, renderThreadedFrame } from "../src/sdk/bus/threaded-render";
 
 describe("escapeHtml (AC2)", () => {
 	test("escapes & < > and escapes & first", () => {
@@ -258,6 +258,21 @@ describe("threaded-render HTML treatment (AC3/AC5)", () => {
 	test("identity header bolds title and wraps fields in code", () => {
 		expect(formatIdentityHeader({ title: "Sess", repo: "r", branch: "b", machine: "m", sessionId: "s" })).toBe(
 			`${bold("Sess")}\n• repo: ${code("r")}\n• branch: ${code("b")}\n• machine: ${code("m")}\n• session: ${code("s")}`,
+		);
+	});
+
+	test("status header extends the visual grammar without changing the pinned identity contract", () => {
+		expect(
+			formatSessionStatusHeader({
+				repo: "r",
+				branch: "b",
+				machine: "m",
+				sessionId: "s",
+				model: "model <x>",
+				context: "25k/100k 25%",
+			}),
+		).toBe(
+			`${bold("GJC session")}\n• repo: ${code("r")}\n• branch: ${code("b")}\n• machine: ${code("m")}\n• session: ${code("s")}\n• model: model &lt;x&gt;\n• context: 25k/100k 25%`,
 		);
 	});
 

--- a/packages/coding-agent/test/notifications-session-status.test.ts
+++ b/packages/coding-agent/test/notifications-session-status.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { renderSessionWorkflowStatusLines } from "../src/sdk/bus";
+
+describe("Telegram session workflow status", () => {
+	test("renders low-noise Ralplan approval state", () => {
+		expect(
+			renderSessionWorkflowStatusLines([
+				{
+					skill: "ralplan",
+					phase: "final",
+					hud: {
+						version: 1,
+						chips: [
+							{ label: "pending", value: "approval", priority: 5 },
+							{ label: "stage", value: "final", priority: 10 },
+							{ label: "verdict", value: "APPROVE", priority: 40 },
+						],
+					},
+				},
+			]),
+		).toEqual(["Ralplan", "• stage: final", "• status: awaiting approval", "• verdict: approve"]);
+	});
+
+	test("renders and bounds Ultragoal status without terminal chip syntax", () => {
+		const lines = renderSessionWorkflowStatusLines([
+			{
+				skill: "ultragoal",
+				phase: "executing",
+				hud: {
+					version: 1,
+					chips: [
+						{ label: "blocked", value: "1", priority: 5 },
+						{ label: "goals", value: "2/5", priority: 10 },
+						{ label: "current", value: `g3:${"x".repeat(500)}`, priority: 20 },
+						{ label: "status", value: "active", priority: 30 },
+					],
+				},
+			},
+		]);
+		expect(lines).toHaveLength(5);
+		expect(lines[0]).toBe("Ultragoal");
+		expect(lines[1]).toBe("• status: active");
+		expect(lines[2]).toBe("• goals: 2/5 complete");
+		expect(lines[3]).toStartWith("• current: g3 — ");
+		expect(lines[3]?.length).toBeLessThanOrEqual(254);
+		expect(lines[4]).toBe("• blocked: 1");
+	});
+
+	test("collapses the planning pipeline and sanitizes control text", () => {
+		const lines = renderSessionWorkflowStatusLines([
+			{ skill: "ralplan", phase: "final", active: true, updated_at: "2026-01-01T00:00:00.000Z" },
+			{
+				skill: "ultragoal",
+				phase: "executing\n\u001b[31m",
+				active: true,
+				updated_at: "2026-01-01T00:05:00.000Z",
+			},
+		]);
+		expect(lines.join("\n")).toContain("Ultragoal");
+		expect(lines.join("\n")).not.toContain("Ralplan");
+		expect(lines.join("\n")).not.toMatch(/[\u001b\r\t]/);
+	});
+});

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -2217,9 +2217,9 @@ describe("telegram daemon", () => {
 			}),
 		);
 	}
-	test("keeps wire protocol 3 while session-scoped status routing uses generation 25", () => {
+	test("keeps wire protocol 3 while session-scoped status routing uses generation 26", () => {
 		expect(NOTIFICATION_PROTOCOL_VERSION).toBe(3);
-		expect(DAEMON_GENERATION).toBe(25);
+		expect(DAEMON_GENERATION).toBe(26);
 	});
 
 	test("#2028 reloads a fully-provenanced owner without a generation", async () => {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -2217,9 +2217,9 @@ describe("telegram daemon", () => {
 			}),
 		);
 	}
-	test("keeps wire protocol 3 while typed retained exact-unlink cleanup authority uses generation 24", () => {
+	test("keeps wire protocol 3 while session-scoped status routing uses generation 25", () => {
 		expect(NOTIFICATION_PROTOCOL_VERSION).toBe(3);
-		expect(DAEMON_GENERATION).toBe(24);
+		expect(DAEMON_GENERATION).toBe(25);
 	});
 
 	test("#2028 reloads a fully-provenanced owner without a generation", async () => {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -6737,7 +6737,7 @@ describe("telegram daemon", () => {
 		});
 	});
 
-	test("telegram control command forwards control_command instead of user_message", async () => {
+	test("telegram session controls stay on the addressed session thread instead of becoming user messages", async () => {
 		FakeWs.instances = [];
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
@@ -6764,6 +6764,10 @@ describe("telegram daemon", () => {
 			update_id: 8,
 			message: { chat: { id: 42 }, message_thread_id: threadId, text: "/context", message_id: 101 },
 		});
+		await daemon.handleTelegramUpdate({
+			update_id: 9,
+			message: { chat: { id: 42 }, message_thread_id: threadId, text: "/status", message_id: 102 },
+		});
 
 		const sent = FakeWs.instances[0]!.sent.map(frame => JSON.parse(frame));
 		expect(sent).toContainEqual({
@@ -6774,6 +6778,15 @@ describe("telegram daemon", () => {
 			updateId: 8,
 			threadId: String(threadId),
 			command: { name: "context" },
+		});
+		expect(sent).toContainEqual({
+			type: "control_command",
+			sessionId: "S",
+			token: "ts",
+			requestId: "tg:9",
+			updateId: 9,
+			threadId: String(threadId),
+			command: { name: "status" },
 		});
 		expect(sent.some(frame => frame.type === "user_message")).toBe(false);
 	});
@@ -6986,6 +6999,84 @@ describe("telegram daemon", () => {
 			message: { chat: { id: 42 }, message_thread_id: threadId, text: "/reasoning impossible", message_id: 102 },
 		});
 		expect(usageMessages()).toHaveLength(1);
+	});
+	test("reserves known-ask media /status captions before reply or attachment routing", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: setPrivateAgentDir(settings(agentDir), agentDir),
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			rich: { enabled: false },
+			WebSocketImpl: FakeWs as any,
+		});
+		daemon.connectSession("S", "ws://s", "ts");
+		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
+			type: "action_needed",
+			kind: "ask",
+			id: "ask1",
+			question: "Name it?",
+			options: ["a", "b"],
+		});
+		const ask = bot.calls.find(call => call.method === "sendMessage")!;
+		const threadId = ask.body.message_thread_id;
+		const askMessageId = bot.calls.indexOf(ask) + 1;
+		bot.calls = [];
+
+		for (const [offset, attachment] of [
+			{ photo: [{ file_id: "must-not-download" }] },
+			{ document: { file_id: "must-not-download" } },
+			{ video: { file_id: "must-not-download" } },
+			{ audio: { file_id: "must-not-download" } },
+			{ voice: { file_id: "must-not-download" } },
+			{ animation: { file_id: "must-not-download" } },
+		].entries()) {
+			await daemon.handleTelegramUpdate({
+				update_id: 906 + offset,
+				message: {
+					chat: { id: 42 },
+					message_thread_id: threadId,
+					caption: "/status extra",
+					...attachment,
+					message_id: 907 + offset,
+					reply_to_message: { message_id: askMessageId },
+				},
+			});
+		}
+
+		const frames = FakeWs.instances[0]!.sent.map(frame => JSON.parse(frame));
+		expect(
+			frames.some(
+				frame => frame.type === "reply" || frame.type === "user_message" || frame.type === "control_command",
+			),
+		).toBe(false);
+		expect(bot.calls.filter(call => call.method === "sendMessage")).toHaveLength(6);
+		expect(bot.calls[0]!.body.text).toBe("Usage: /status");
+		expect(daemon.sessions.get("S")!.pending.has("ask1")).toBe(true);
+		await daemon.handleTelegramUpdate({
+			update_id: 999,
+			message: {
+				chat: { id: 99 },
+				message_thread_id: threadId,
+				caption: "/status extra",
+				animation: { file_id: "foreign" },
+				message_id: 1000,
+			},
+		});
+		await daemon.handleTelegramUpdate({
+			update_id: 1001,
+			message: {
+				chat: { id: 42 },
+				message_thread_id: 999_999,
+				caption: "/status extra",
+				animation: { file_id: "unknown-topic" },
+				message_id: 1002,
+			},
+		});
+		expect(bot.calls.filter(call => call.method === "sendMessage")).toHaveLength(6);
 	});
 
 	test("wrong-suffix telegram control command is consumed, not injected or ask-answered", async () => {

--- a/packages/coding-agent/test/notifications-threaded-render.test.ts
+++ b/packages/coding-agent/test/notifications-threaded-render.test.ts
@@ -146,6 +146,31 @@ describe("renderThreadedFrame", () => {
 		expect(send?.text).toContain("✅ Context: &lt;25&gt;/100 (25.0%)");
 	});
 
+	test("control_command_result renders structured session status inside the daemon", () => {
+		const send = renderThreadedFrame({
+			type: "control_command_result",
+			sessionId: "s",
+			status: "ok",
+			message: "plain fallback",
+			sessionStatus: {
+				repo: "repo <unsafe>",
+				branch: "dev",
+				path: "C:\\work\\repo",
+				machine: "host",
+				sessionId: "s",
+				model: "model <unsafe>",
+				context: "25k/100k 25%",
+				workflowLines: ["Ralplan", "• status: awaiting <approval>"],
+			},
+		});
+		expect(send?.text).toStartWith("<b>GJC session</b>");
+		expect(send?.text).toContain("• repo: <code>repo &lt;unsafe&gt;</code>");
+		expect(send?.text).not.toContain("C:\\work\\repo");
+		expect(send?.text).toContain("• session: <code>s</code>");
+		expect(send?.text).toContain("• model: model &lt;unsafe&gt;");
+		expect(send?.text).toContain("• status: awaiting &lt;approval&gt;");
+	});
+
 	test("tool_activity edits a started bubble with its terminal result", () => {
 		const started = renderThreadedFrame({
 			type: "tool_activity",

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -1197,6 +1197,28 @@ test("SDK host replays event frames over direct v3 ingress and routes queries th
 		ok: false,
 		error: { code: "unknown_operation" },
 	});
+	socket.send(
+		JSON.stringify({
+			type: "control_command",
+			sessionId,
+			token: endpoint.token,
+			requestId: "status",
+			command: { name: "status" },
+		}),
+	);
+	await waitFor(
+		() => frames.some(frame => frame.type === "control_command_result" && frame.requestId === "status"),
+		"same-session status response",
+	);
+	const statusFrame = frames.find(frame => frame.type === "control_command_result" && frame.requestId === "status");
+	expect(statusFrame).toMatchObject({
+		type: "control_command_result",
+		sessionId,
+		requestId: "status",
+		status: "ok",
+	});
+	expect(statusFrame?.sessionStatus).toMatchObject({ sessionId });
+	expect(JSON.stringify(statusFrame?.sessionStatus)).not.toContain(cwd);
 });
 
 test("SDK host preserves ordered prompt image blocks in the host payload", async () => {

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -458,7 +458,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:ownerPidFromOwnerId": "46691373b2bee01f28f3817a6aa6a7efffe880c2cea337c89155582c98d952bf",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonInternal": "4d61235b0c32bf9afc63e1af29eaeca05368607c4997257c15febe071b30b582",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonSmoke": "6f085a667aa5c83de46d2d8945fb845c355fcbb43c46872342a44489203a5830",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "3ca28917ff0cb1fa2a1aaffc6e711a52332c094e300686d4a7282117da3a6501",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "3a118fed456aa6f1605b3d8c0c21ca4d6133b2e27fc9f4e5cfb12e90b76fc528",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:NOTIFICATION_PROTOCOL_VERSION": "b99289f651fedcf020d28dbaf6f07dd37e7e4a5f6dc1f5118b872112325f1e81",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:DaemonProcessReference": "c3d13e3670a6245a1250c4ebfcd80a36dd8fc96c67ab64d9f979182bd117bc4e",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:TelegramDaemonController": "8ae322035cfe83f10caf26320bd4638b5433be0e812d7cbf6cdb329bcdff92fe",

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -458,7 +458,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:ownerPidFromOwnerId": "46691373b2bee01f28f3817a6aa6a7efffe880c2cea337c89155582c98d952bf",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonInternal": "4d61235b0c32bf9afc63e1af29eaeca05368607c4997257c15febe071b30b582",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonSmoke": "6f085a667aa5c83de46d2d8945fb845c355fcbb43c46872342a44489203a5830",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "b66c4b4bb6d9eabbf5c6e07d1feba7c105a3742a928a090c9f5f32348ec6435a",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "3ca28917ff0cb1fa2a1aaffc6e711a52332c094e300686d4a7282117da3a6501",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:NOTIFICATION_PROTOCOL_VERSION": "b99289f651fedcf020d28dbaf6f07dd37e7e4a5f6dc1f5118b872112325f1e81",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:DaemonProcessReference": "c3d13e3670a6245a1250c4ebfcd80a36dd8fc96c67ab64d9f979182bd117bc4e",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:TelegramDaemonController": "8ae322035cfe83f10caf26320bd4638b5433be0e812d7cbf6cdb329bcdff92fe",


### PR DESCRIPTION
## Summary

- add a zero-argument `/status` command for connected Telegram session topics
- report repository, branch, machine, session, model, context, and active workflow status
- keep local workspace paths out of both the typed wire payload and Telegram output
- register `/status` in the Telegram slash-command menu

## Behavior

`/status` resolves only the session associated with the current Telegram topic.

- validates requested, managed, and live session identities before reading status
- does not inject a user turn or answer a pending ask
- rejects arguments and media with the exact usage response
- does not route stale or mismatched requests across session topics
- preserves a plain-text fallback for non-Telegram control consumers

## Real-product dogfood

Built and exercised the exact PR head against the configured Telegram bot from a connected real session topic.

- Base: `a3370ff9e56cfb39d46c4761011ee6f888b06119`
- Head: `0b719a06c9fb58214784a39be0077b7624f0a9b6`
- Built binary SHA-256: `1fb1c332bf1995f3172144672e6c91ccfaa3352bde3152ef87f6306f0a4e4735`
- Live daemon `/proc/<pid>/exe` SHA-256: `1fb1c332bf1995f3172144672e6c91ccfaa3352bde3152ef87f6306f0a4e4735`
- `gjc notify health --probe`: daemon heartbeat healthy, one live endpoint, Telegram reachable
- `/status` returned the expected repository, branch, machine, session, model, and context values in the connected Telegram topic
- Telegram's slash-command menu exposed `/status` with its session-status description

The daemon executable checksum matching the built artifact ties the Telegram dogfood run to this exact head rather than an installed or stale binary.

## Verification

- `bun test packages/coding-agent/test/notifications-session-status.test.ts packages/coding-agent/test/notifications-config-commands.test.ts packages/coding-agent/test/notifications-control-executor.test.ts packages/coding-agent/test/notifications-html-format.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/test/notifications-threaded-render.test.ts` — 515 passed
- focused SDK host status wire test — 1 passed
- `cargo test -p gjc-sdk control_command_result --lib` — 2 passed
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- `git diff --check upstream/dev..HEAD`


## Prior review

Supersedes #2848, which was closed because the exact head lacked reproducible build provenance and concrete real-product dogfood evidence. This PR addresses that closure reason with the exact base/head SHAs, matching built-binary and live-daemon checksums, Telegram health evidence, and an actual `/status` run from a connected Telegram session topic.
