### PR TITLE
fix(ai): apply Alibaba timeout to outer lazy-stream watchdog

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - OpenAI Responses / Codex native history replay no longer submits missing resident-image placeholders as `input_image.image_url`. Invalid values (including `[Session resident imageUrl blob missing: …]`) are dropped, or retained as `file_id`-only parts when a non-empty `file_id` is present, so a single unavailable historical image cannot brick `/retry` (#2924).
-- Raised the first-event stream timeout floor to five minutes for `alibaba-token-plan` models using the OpenAI Completions and Responses APIs, while preserving caller and environment overrides and the existing inter-event idle timeout.
+- Raised the first-event stream timeout floor to five minutes for `alibaba-token-plan` models at both the OpenAI provider and outer lazy-stream watchdogs, while preserving caller and environment overrides and the existing inter-event idle timeout.
 
 ## [0.11.7] - 2026-07-22
 

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -190,6 +190,15 @@ interface LazyStreamLimits {
 const GOOGLE_GEMINI_CLI_LAZY_STREAM_LIMITS: LazyStreamLimits = {
 	defaultFirstEventTimeoutMs: 300_000,
 };
+const ALIBABA_TOKEN_PLAN_LAZY_STREAM_FIRST_EVENT_TIMEOUT_MS = 300_000;
+
+export function resolveLazyStreamFirstEventFallbackMs(
+	provider: string,
+	configuredFallbackMs?: number,
+): number | undefined {
+	if (configuredFallbackMs !== undefined) return configuredFallbackMs;
+	return provider === "alibaba-token-plan" ? ALIBABA_TOKEN_PLAN_LAZY_STREAM_FIRST_EVENT_TIMEOUT_MS : undefined;
+}
 
 function forwardStream<TApi extends Api>(
 	target: EventStreamImpl,
@@ -202,11 +211,14 @@ function forwardStream<TApi extends Api>(
 	(async () => {
 		try {
 			const idleTimeoutMs = options.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs(limits?.defaultIdleTimeoutMs);
+			const firstEventFallbackMs = resolveLazyStreamFirstEventFallbackMs(
+				model.provider,
+				limits?.defaultFirstEventTimeoutMs,
+			);
 			const watchedSource = iterateWithIdleTimeout(source, {
 				idleTimeoutMs,
 				firstItemTimeoutMs:
-					options.streamFirstEventTimeoutMs ??
-					getStreamFirstEventTimeoutMs(idleTimeoutMs, limits?.defaultFirstEventTimeoutMs),
+					options.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs),
 				errorMessage: LAZY_STREAM_IDLE_TIMEOUT_ERROR,
 				firstItemErrorMessage: LAZY_STREAM_FIRST_EVENT_TIMEOUT_ERROR,
 				onIdle: () => abortTracker.abortLocally(new Error(LAZY_STREAM_IDLE_TIMEOUT_ERROR)),

--- a/packages/ai/test/register-builtins.test.ts
+++ b/packages/ai/test/register-builtins.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { setBedrockProviderModule, streamBedrock } from "../src/providers/register-builtins";
+import {
+	resolveLazyStreamFirstEventFallbackMs,
+	setBedrockProviderModule,
+	streamBedrock,
+} from "../src/providers/register-builtins";
 import type { AssistantMessage, Context, Model } from "../src/types";
 import type { AssistantMessageEventStream } from "../src/utils/event-stream";
 
@@ -172,5 +176,10 @@ describe("register-builtins lazy streams", () => {
 		}
 		expect(result.stopReason).toBe("aborted");
 		expect(result.errorMessage).toBe("Request was aborted");
+	});
+	it("uses a five-minute outer first-event fallback for Alibaba Token Plan", () => {
+		expect(resolveLazyStreamFirstEventFallbackMs("alibaba-token-plan")).toBe(300_000);
+		expect(resolveLazyStreamFirstEventFallbackMs("openai")).toBeUndefined();
+		expect(resolveLazyStreamFirstEventFallbackMs("alibaba-token-plan", 42_000)).toBe(42_000);
 	});
 });


### PR DESCRIPTION
## Problem

`alibaba-token-plan` already gives OpenAI Completions and Responses streams a five-minute first-event timeout because Qwen reasoning models can take longer than the global default to emit their first SSE frame.

That provider-level override did not protect the same request at the lazy-loading boundary. `register-builtins.ts` wraps the provider stream with a second first-event watchdog, and that outer watchdog still used the shared effective default of 120 seconds. It therefore aborted valid Alibaba requests before the provider-level 300-second watchdog could take effect.

The resulting error was the generic outer-wrapper message:

```text
Provider stream timed out while waiting for the first event
```

This was reproducible as an empty response with zero usage exactly 120 seconds after the request started.

## Root cause

The request had two watchdogs:

1. OpenAI provider watchdog: 300 seconds for `alibaba-token-plan`
2. Outer lazy-stream watchdog: 120 seconds for providers without a wrapper-specific override

The shorter outer watchdog always won. Google Gemini CLI already passes a 300-second limit into the lazy wrapper; Alibaba had only the inner override.

## Fix

Apply a 300-second first-event fallback to the outer lazy stream only when `model.provider === "alibaba-token-plan"`.

The effective precedence remains:

1. request-level `streamFirstEventTimeoutMs`
2. `PI_STREAM_FIRST_EVENT_TIMEOUT_MS`
3. wrapper-specific configured fallback
4. Alibaba's 300-second fallback
5. shared default

The steady-state inter-event idle timeout is unchanged.

## Scope

- Does not change timeout behavior for OpenAI, Anthropic, Azure, Bedrock, Ollama, or other OpenAI-compatible providers.
- Does not change Google Gemini CLI / Antigravity behavior; their existing five-minute lazy-wrapper limit remains intact.
- Does not extend the timeout after streaming has begun.

## Tests

Added regression coverage for:

- Alibaba resolving to a 300-second outer first-event fallback
- unrelated providers retaining the shared default
- an explicitly configured wrapper fallback taking precedence

Verification performed:

```text
bun check
bun test test/register-builtins.test.ts test/stream-timeout-defaults.test.ts test/openai-first-event-timeout.test.ts
```

Result: 24 tests passed, 0 failed.