### PR TITLE
fix(coding-agent): bind Python bridge bearer to its session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Concurrent edits to the same file path are serialized through a path-scoped mutation lock (in-process always; durable cross-process lock on the real filesystem). Disjoint concurrent `applyPatch` / replace mutations no longer silently overwrite each other, and a commit-time content check rejects writers that observe a mid-flight change. The production `executePatchSingle` / `LspFileSystem` path explicitly enables the durable lock rather than inferring it from FileSystem object identity (#2900).
 - Lean notification verbosity no longer floods remote clients with intermediate tool-turn `turn_stream` frames. Under `/lean`, the latest assistant answer is deferred until `agent_end` (idle); ask lead-ins still flush immediately before inline buttons, and `/verbose` keeps per-turn streaming (including opt-in live frames) (#2863).
 - Ultragoal `complete-goals` no longer reports contradictory next actions when every incomplete story is `blocked` or `review_blocked`. Text and JSON now agree on `next-action=resolve-blockers` with blocked goal IDs/status; failed-only schedules surface `retry-failed`; `execute-goal` always includes a `goal_id` (#2903).
+- Bound each Python tool bridge bearer capability to one active session registration, reject non-canonical or empty bearer credentials before lookup, and rotate authority whenever a retained session replaces its kernel.
 
 ## [0.11.7] - 2026-07-22
 ### Added

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -61,7 +61,7 @@ export interface PythonExecutorOptions {
 	/** @internal Bridge session id, set by `executePython` before delegating. */
 	bridgeSessionId?: string;
 	/** @internal Bridge endpoint info, set by `executePython` before delegating. */
-	bridge?: { url: string; token: string };
+	bridge?: { url: string; capability: string };
 }
 
 export interface PythonKernelExecutor {
@@ -106,6 +106,7 @@ export interface PythonResult {
 interface PythonSession {
 	sessionId: string;
 	kernel: PythonKernel;
+	bridgeCapability?: string;
 	ownerIds: Set<string>;
 	hasFallbackOwner: boolean;
 	queue: Promise<void>;
@@ -261,14 +262,14 @@ function buildKernelEnv(options: {
 	sessionFile?: string;
 	artifactsDir?: string;
 	bridgeSessionId?: string;
-	bridge?: { url: string; token: string };
+	bridge?: { url: string; capability: string };
 }): Record<string, string> | undefined {
 	const env: Record<string, string> = {};
 	if (options.sessionFile) env.PI_SESSION_FILE = options.sessionFile;
 	if (options.artifactsDir) env.PI_ARTIFACTS_DIR = options.artifactsDir;
 	if (options.bridge && options.bridgeSessionId) {
 		env.PI_TOOL_BRIDGE_URL = options.bridge.url;
-		env.PI_TOOL_BRIDGE_TOKEN = options.bridge.token;
+		env.PI_TOOL_BRIDGE_CAPABILITY = options.bridge.capability;
 		env.PI_TOOL_BRIDGE_SESSION = options.bridgeSessionId;
 	}
 	return Object.keys(env).length > 0 ? env : undefined;
@@ -328,6 +329,7 @@ async function acquireSession(sessionId: string, cwd: string, options: PythonExe
 			const session: PythonSession = {
 				sessionId,
 				kernel,
+				bridgeCapability: options.bridge?.capability,
 				ownerIds: new Set(),
 				hasFallbackOwner: false,
 				queue: Promise.resolve(),
@@ -361,12 +363,25 @@ async function replaceSessionKernel(
 		throw new PythonExecutionCancelledError(false);
 	}
 	requireRemainingTimeoutMs(options.deadlineMs);
-	const next = await startKernel(cwd, options);
-	if (sessions.get(session.sessionId) !== session) {
-		await next.shutdown().catch(() => undefined);
-		throw new PythonExecutionCancelledError(false);
+	const bridge = options.bridge;
+	const previousCapability = bridge?.capability;
+	const nextCapability = bridge ? crypto.randomUUID() : undefined;
+	if (bridge && nextCapability) bridge.capability = nextCapability;
+	let next: PythonKernel | undefined;
+	try {
+		next = await startKernel(cwd, options);
+		if (sessions.get(session.sessionId) !== session) {
+			throw new PythonExecutionCancelledError(false);
+		}
+		session.kernel = next;
+		session.bridgeCapability = nextCapability;
+	} catch (err) {
+		await next?.shutdown().catch(() => undefined);
+		if (bridge && previousCapability && bridge.capability === nextCapability) {
+			bridge.capability = previousCapability;
+		}
+		throw err;
 	}
-	session.kernel = next;
 }
 
 async function resetSession(sessionId: string): Promise<void> {
@@ -481,8 +496,8 @@ async function executeWithKernel(
 			displayOutputs.push({ type: "status", event });
 		});
 	const unregisterBridge =
-		options?.toolSession && options?.bridgeSessionId
-			? registerPyToolBridge(options.bridgeSessionId, {
+		options?.toolSession && options?.bridgeSessionId && options.bridge
+			? registerPyToolBridge(options.bridgeSessionId, options.bridge.capability, {
 					toolSession: options.toolSession,
 					signal: options.signal,
 					emitStatus,
@@ -578,7 +593,8 @@ async function ensureKernelAvailable(cwd: string, options: PythonExecutorOptions
 async function ensureToolBridge(options: PythonExecutorOptions): Promise<void> {
 	if (!options.toolSession || options.bridge) return;
 	try {
-		options.bridge = await ensurePyToolBridge();
+		const bridge = await ensurePyToolBridge();
+		options.bridge = { ...bridge, capability: crypto.randomUUID() };
 	} catch (err) {
 		logger.warn("Failed to start Python tool bridge", {
 			error: err instanceof Error ? err.message : String(err),
@@ -607,6 +623,9 @@ async function executeOnSession(code: string, cwd: string, options: PythonExecut
 		await resetSession(sessionId);
 	}
 	const session = await acquireSession(sessionId, cwd, options);
+	if (options.bridge && session.bridgeCapability) {
+		options.bridge.capability = session.bridgeCapability;
+	}
 	return await runQueued(session, options, async () => {
 		if (options.signal?.aborted) {
 			throw new PythonExecutionCancelledError(isTimedOutCancellation(options.signal.reason, options.signal));

--- a/packages/coding-agent/src/eval/py/prelude.py
+++ b/packages/coding-agent/src/eval/py/prelude.py
@@ -453,10 +453,10 @@ if "__gjc_prelude_loaded__" not in globals():
 
     if all(
         _k in os.environ
-        for _k in ("PI_TOOL_BRIDGE_URL", "PI_TOOL_BRIDGE_TOKEN", "PI_TOOL_BRIDGE_SESSION")
+        for _k in ("PI_TOOL_BRIDGE_URL", "PI_TOOL_BRIDGE_CAPABILITY", "PI_TOOL_BRIDGE_SESSION")
     ):
         tool = _ToolProxy(
             os.environ["PI_TOOL_BRIDGE_URL"],
-            os.environ["PI_TOOL_BRIDGE_TOKEN"],
+            os.environ["PI_TOOL_BRIDGE_CAPABILITY"],
             os.environ["PI_TOOL_BRIDGE_SESSION"],
         )

--- a/packages/coding-agent/src/eval/py/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/py/tool-bridge.ts
@@ -19,7 +19,10 @@ export interface PyToolBridgeEntry {
 
 export interface PyToolBridgeInfo {
 	url: string;
-	token: string;
+}
+
+interface PyToolBridgeRegistration extends PyToolBridgeEntry {
+	sessionId: string;
 }
 
 interface BridgeServer {
@@ -27,11 +30,20 @@ interface BridgeServer {
 	stop: () => Promise<void>;
 }
 
-const registrations = new Map<string, PyToolBridgeEntry>();
+const registrations = new Map<string, PyToolBridgeRegistration>();
 let serverPromise: Promise<BridgeServer> | null = null;
 
+function isCanonicalCapability(capability: string): boolean {
+	return capability.length > 0 && !/\s/.test(capability);
+}
+
+function parseBearerCapability(authorization: string | null): string | null {
+	if (!authorization?.startsWith("Bearer ")) return null;
+	const capability = authorization.slice("Bearer ".length);
+	return isCanonicalCapability(capability) ? capability : null;
+}
+
 async function startServer(): Promise<BridgeServer> {
-	const token = crypto.randomUUID();
 	const server = Bun.serve({
 		hostname: "127.0.0.1",
 		port: 0,
@@ -40,7 +52,12 @@ async function startServer(): Promise<BridgeServer> {
 			if (req.method !== "POST" || url.pathname !== "/v1/tool") {
 				return new Response("Not Found", { status: 404 });
 			}
-			if (req.headers.get("authorization") !== `Bearer ${token}`) {
+			const capability = parseBearerCapability(req.headers.get("authorization"));
+			if (!capability) {
+				return new Response("Forbidden", { status: 403 });
+			}
+			const registration = registrations.get(capability);
+			if (!registration) {
 				return new Response("Forbidden", { status: 403 });
 			}
 
@@ -55,19 +72,15 @@ async function startServer(): Promise<BridgeServer> {
 			if (!sessionId || !name) {
 				return Response.json({ ok: false, error: "Missing session/name" }, { status: 400 });
 			}
-			const entry = registrations.get(sessionId);
-			if (!entry) {
-				return Response.json(
-					{ ok: false, error: `No active Python tool bridge session: ${sessionId}` },
-					{ status: 200 },
-				);
+			if (sessionId !== registration.sessionId) {
+				return new Response("Forbidden", { status: 403 });
 			}
 
 			try {
 				const value = await callSessionTool(name, body.args, {
-					session: entry.toolSession,
-					signal: entry.signal,
-					emitStatus: entry.emitStatus,
+					session: registration.toolSession,
+					signal: registration.signal,
+					emitStatus: registration.emitStatus,
 				});
 				return Response.json({ ok: true, value });
 			} catch (err) {
@@ -81,7 +94,6 @@ async function startServer(): Promise<BridgeServer> {
 
 	const info: PyToolBridgeInfo = {
 		url: `http://${server.hostname}:${server.port}`,
-		token,
 	};
 	logger.debug("Python tool bridge listening", { url: info.url });
 
@@ -111,11 +123,15 @@ export async function ensurePyToolBridge(): Promise<PyToolBridgeInfo> {
  * Register a tool session for the duration of one execution. The returned
  * function MUST be called to remove the entry once execution finishes.
  */
-export function registerPyToolBridge(sessionId: string, entry: PyToolBridgeEntry): () => void {
-	registrations.set(sessionId, entry);
+export function registerPyToolBridge(sessionId: string, capability: string, entry: PyToolBridgeEntry): () => void {
+	if (!isCanonicalCapability(capability)) {
+		throw new Error("Python tool bridge capability must be a non-empty canonical bearer token");
+	}
+	const registration = { ...entry, sessionId };
+	registrations.set(capability, registration);
 	return () => {
-		if (registrations.get(sessionId) === entry) {
-			registrations.delete(sessionId);
+		if (registrations.get(capability) === registration) {
+			registrations.delete(capability);
 		}
 	};
 }

--- a/packages/coding-agent/test/core/python-executor-session.test.ts
+++ b/packages/coding-agent/test/core/python-executor-session.test.ts
@@ -1,12 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { disposeAllKernelSessions, executePython } from "@gajae-code/coding-agent/eval/py/executor";
 import * as pythonKernel from "@gajae-code/coding-agent/eval/py/kernel";
+import { disposePyToolBridge } from "@gajae-code/coding-agent/eval/py/tool-bridge";
+import type { ToolSession } from "@gajae-code/coding-agent/tools";
 
 class FakeKernel {
+	#onExecute?: () => Promise<void>;
 	executeCalls = 0;
 	shutdownCalls = 0;
 	alive = true;
-	constructor(private readonly shouldThrow: boolean = false) {}
+	constructor(
+		private readonly shouldThrow: boolean = false,
+		onExecute?: () => Promise<void>,
+	) {
+		this.#onExecute = onExecute;
+	}
 
 	isAlive(): boolean {
 		return this.alive;
@@ -14,6 +22,7 @@ class FakeKernel {
 
 	async execute(): Promise<{ status: "ok"; cancelled: false; timedOut: false; stdinRequested: false }> {
 		this.executeCalls += 1;
+		await this.#onExecute?.();
 		if (this.shouldThrow) {
 			this.alive = false;
 			throw new Error("kernel crashed");
@@ -36,6 +45,7 @@ describe("executePython session lifecycle", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		await disposeAllKernelSessions();
+		await disposePyToolBridge();
 	});
 
 	it("restarts session when kernel is not alive", async () => {
@@ -98,6 +108,58 @@ describe("executePython session lifecycle", () => {
 		});
 
 		expect(startSpy).toHaveBeenCalledTimes(2);
+		expect(kernel1.shutdownCalls).toBe(1);
+		expect(kernel2.executeCalls).toBe(1);
+	});
+
+	it("rotates the session capability when replacing a dead kernel automatically", async () => {
+		const kernel1 = new FakeKernel();
+		const bridgeEnvironments: Array<Record<string, string | undefined>> = [];
+		const kernel2 = new FakeKernel(false, async () => {
+			const bridgeUrl = bridgeEnvironments[1]!.PI_TOOL_BRIDGE_URL;
+			const firstCapability = bridgeEnvironments[0]!.PI_TOOL_BRIDGE_CAPABILITY;
+			const rotatedCapability = bridgeEnvironments[1]!.PI_TOOL_BRIDGE_CAPABILITY;
+			const callBridge = async (capability: string): Promise<Response> =>
+				await fetch(`${bridgeUrl}/v1/tool`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json", Authorization: `Bearer ${capability}` },
+					body: JSON.stringify({}),
+				});
+			expect((await callBridge(firstCapability!)).status).toBe(403);
+			expect((await callBridge(rotatedCapability!)).status).toBe(400);
+		});
+		const starts = [kernel1, kernel2];
+		vi.spyOn(pythonKernel, "checkPythonKernelAvailability").mockResolvedValue({ ok: true });
+		vi.spyOn(pythonKernel.PythonKernel, "start").mockImplementation(async options => {
+			bridgeEnvironments.push(options.env ?? {});
+			const next = starts.shift();
+			if (!next) throw new Error("No kernel available");
+			return next as unknown as pythonKernel.PythonKernel;
+		});
+		const toolSession = { getToolByName: () => undefined } as unknown as ToolSession;
+
+		await executePython("print('one')", {
+			cwd: "/tmp",
+			sessionId: "bridge-session",
+			kernelMode: "session",
+			toolSession,
+		});
+		kernel1.alive = false;
+		await executePython("print('two')", {
+			cwd: "/tmp",
+			sessionId: "bridge-session",
+			kernelMode: "session",
+			toolSession,
+		});
+
+		expect(bridgeEnvironments).toHaveLength(2);
+		const firstCapability = bridgeEnvironments[0]!.PI_TOOL_BRIDGE_CAPABILITY;
+		const rotatedCapability = bridgeEnvironments[1]!.PI_TOOL_BRIDGE_CAPABILITY;
+		expect(firstCapability).toBeString();
+		expect(rotatedCapability).toBeString();
+		expect(rotatedCapability).not.toBe(firstCapability);
+		expect(bridgeEnvironments[0]!.PI_TOOL_BRIDGE_TOKEN).toBeUndefined();
+		expect(bridgeEnvironments[0]!.PI_TOOL_BRIDGE_SESSION).toBe("bridge-session");
 		expect(kernel1.shutdownCalls).toBe(1);
 		expect(kernel2.executeCalls).toBe(1);
 	});

--- a/packages/coding-agent/test/core/python-tool-bridge.integration.test.ts
+++ b/packages/coding-agent/test/core/python-tool-bridge.integration.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import type { AgentTool, AgentToolResult } from "@gajae-code/agent-core";
+import { executePythonWithKernel } from "@gajae-code/coding-agent/eval/py/executor";
+import { PythonKernel } from "@gajae-code/coding-agent/eval/py/kernel";
+import {
+	disposePyToolBridge,
+	ensurePyToolBridge,
+	registerPyToolBridge,
+} from "@gajae-code/coding-agent/eval/py/tool-bridge";
+import { resolvePythonIntegrationGate, type ToolSession } from "@gajae-code/coding-agent/tools";
+import { TempDir } from "@gajae-code/utils";
+
+const SHOULD_RUN = resolvePythonIntegrationGate(Bun.env);
+
+describe.skipIf(!SHOULD_RUN)("Python tool bridge integration", () => {
+	afterAll(async () => {
+		await disposePyToolBridge();
+	});
+
+	it("uses the session capability from the Python prelude to invoke its registered tool", async () => {
+		using tempDir = TempDir.createSync("@python-tool-bridge-");
+		const calls: unknown[] = [];
+		const readTool = {
+			name: "read",
+			label: "read",
+			description: "read",
+			parameters: { type: "object" },
+			async execute(_id: string, args: unknown): Promise<AgentToolResult> {
+				calls.push(args);
+				return { content: [{ type: "text", text: "file body" }] };
+			},
+		} as unknown as AgentTool;
+		const toolSession = {
+			getToolByName: (name: string) => (name === "read" ? readTool : undefined),
+		} as unknown as ToolSession;
+		const bridge = await ensurePyToolBridge();
+		const capability = crypto.randomUUID();
+		const sessionId = "python-prelude-session";
+		const unregister = registerPyToolBridge(sessionId, capability, { toolSession });
+		const kernel = await PythonKernel.start({
+			cwd: tempDir.path(),
+			env: {
+				PI_TOOL_BRIDGE_URL: bridge.url,
+				PI_TOOL_BRIDGE_CAPABILITY: capability,
+				PI_TOOL_BRIDGE_SESSION: sessionId,
+			},
+		});
+		try {
+			const result = await executePythonWithKernel(kernel, 'tool.read({"path": "example.ts"})');
+			expect(result.exitCode).toBe(0);
+			expect(result.output).toContain("file body");
+			expect(calls).toEqual([{ path: "example.ts", _i: "py prelude" }]);
+		} finally {
+			unregister();
+			await kernel.shutdown();
+		}
+	});
+});

--- a/packages/coding-agent/test/core/python-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/python-tool-bridge.test.ts
@@ -31,16 +31,12 @@ function makeSession(tools: Map<string, AgentTool>): ToolSession {
 	return { getToolByName: (name: string) => tools.get(name) } as unknown as ToolSession;
 }
 
-async function call(
-	info: { url: string; token: string },
-	body: Record<string, unknown>,
-	overrides?: { token?: string },
-): Promise<Response> {
+async function call(info: { url: string }, capability: string, body: Record<string, unknown>): Promise<Response> {
 	return await fetch(`${info.url}/v1/tool`, {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
-			Authorization: `Bearer ${overrides?.token ?? info.token}`,
+			Authorization: `Bearer ${capability}`,
 		},
 		body: JSON.stringify(body),
 	});
@@ -58,9 +54,10 @@ describe("Python tool bridge HTTP server", () => {
 		});
 		const session = makeSession(new Map([["read", readTool]]));
 		const info = await ensurePyToolBridge();
-		const unregister = registerPyToolBridge("test-session-1", { toolSession: session });
+		const capability = crypto.randomUUID();
+		const unregister = registerPyToolBridge("test-session-1", capability, { toolSession: session });
 		try {
-			const res = await call(info, {
+			const res = await call(info, capability, {
 				session: "test-session-1",
 				name: "read",
 				args: { path: "foo.ts", _i: "py prelude" },
@@ -76,13 +73,10 @@ describe("Python tool bridge HTTP server", () => {
 		}
 	});
 
-	it("returns ok=false when no session is registered for the given id", async () => {
+	it("rejects an unregistered capability", async () => {
 		const info = await ensurePyToolBridge();
-		const res = await call(info, { session: "missing", name: "read", args: {} });
-		expect(res.status).toBe(200);
-		const body = (await res.json()) as { ok: boolean; error?: string };
-		expect(body.ok).toBe(false);
-		expect(typeof body.error).toBe("string");
+		const res = await call(info, crypto.randomUUID(), { session: "missing", name: "read", args: {} });
+		expect(res.status).toBe(403);
 	});
 
 	it("surfaces tool errors as ok=false with the error message", async () => {
@@ -99,9 +93,10 @@ describe("Python tool bridge HTTP server", () => {
 				}) as unknown as AgentTool,
 		} as unknown as ToolSession;
 		const info = await ensurePyToolBridge();
-		const unregister = registerPyToolBridge("err-session", { toolSession: session });
+		const capability = crypto.randomUUID();
+		const unregister = registerPyToolBridge("err-session", capability, { toolSession: session });
 		try {
-			const res = await call(info, { session: "err-session", name: "boom", args: {} });
+			const res = await call(info, capability, { session: "err-session", name: "boom", args: {} });
 			expect(res.status).toBe(200);
 			const body = await res.json();
 			expect(body).toEqual({ ok: false, error: "kapow" });
@@ -112,14 +107,121 @@ describe("Python tool bridge HTTP server", () => {
 
 	it("rejects requests with a bad bearer token", async () => {
 		const info = await ensurePyToolBridge();
-		const res = await call(info, { session: "anything", name: "read", args: {} }, { token: "wrong" });
+		const res = await call(info, "wrong", { session: "anything", name: "read", args: {} });
 		expect(res.status).toBe(403);
+	});
+
+	it("rejects missing, empty, and whitespace bearer credentials before lookup", async () => {
+		const info = await ensurePyToolBridge();
+		for (const authorization of [null, "Bearer ", "Bearer    ", "Bearer invalid capability"]) {
+			const headers = new Headers({ "Content-Type": "application/json" });
+			if (authorization !== null) headers.set("Authorization", authorization);
+			const res = await fetch(`${info.url}/v1/tool`, {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ session: "anything", name: "read", args: {} }),
+			});
+			expect(res.status).toBe(403);
+		}
+	});
+
+	it("rejects empty and whitespace registration capabilities", () => {
+		const session = makeSession(new Map());
+		for (const capability of ["", " ", "\t", "invalid capability"]) {
+			expect(() => registerPyToolBridge("invalid-registration", capability, { toolSession: session })).toThrow(
+				"canonical bearer token",
+			);
+		}
 	});
 
 	it("returns 400 when body is missing required fields", async () => {
 		const info = await ensurePyToolBridge();
-		const res = await call(info, { name: "read" });
-		expect(res.status).toBe(400);
+		const capability = crypto.randomUUID();
+		const unregister = registerPyToolBridge("validation-session", capability, {
+			toolSession: makeSession(new Map()),
+		});
+		try {
+			const res = await call(info, capability, { name: "read" });
+			expect(res.status).toBe(400);
+		} finally {
+			unregister();
+		}
+	});
+
+	it("authenticates before parsing the request body", async () => {
+		const info = await ensurePyToolBridge();
+		const res = await fetch(`${info.url}/v1/tool`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Authorization: "Bearer wrong" },
+			body: "not-json",
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it("does not let one session capability select another registered session", async () => {
+		const callsA: FakeCall[] = [];
+		const callsB: FakeCall[] = [];
+		const capabilityA = crypto.randomUUID();
+		const capabilityB = crypto.randomUUID();
+		const info = await ensurePyToolBridge();
+		const unregisterA = registerPyToolBridge("session-a", capabilityA, {
+			toolSession: makeSession(
+				new Map([["read", makeFakeTool("read", callsA, { content: [{ type: "text", text: "A" }] })]]),
+			),
+		});
+		const unregisterB = registerPyToolBridge("session-b", capabilityB, {
+			toolSession: makeSession(
+				new Map([["read", makeFakeTool("read", callsB, { content: [{ type: "text", text: "B" }] })]]),
+			),
+		});
+		try {
+			const crossSession = await call(info, capabilityA, { session: "session-b", name: "read", args: {} });
+			expect(crossSession.status).toBe(403);
+			expect(callsA).toHaveLength(0);
+			expect(callsB).toHaveLength(0);
+
+			const ownSession = await call(info, capabilityB, { session: "session-b", name: "read", args: {} });
+			expect(ownSession.status).toBe(200);
+			expect(await ownSession.json()).toEqual({ ok: true, value: "B" });
+			expect(callsB).toHaveLength(1);
+		} finally {
+			unregisterA();
+			unregisterB();
+		}
+	});
+
+	it("invalidates unregistered capabilities and accepts a rotated capability", async () => {
+		const calls: FakeCall[] = [];
+		const session = makeSession(
+			new Map([["read", makeFakeTool("read", calls, { content: [{ type: "text", text: "ok" }] })]]),
+		);
+		const info = await ensurePyToolBridge();
+		const staleCapability = crypto.randomUUID();
+		const unregisterStale = registerPyToolBridge("rotation-session", staleCapability, { toolSession: session });
+		unregisterStale();
+
+		const rotatedCapability = crypto.randomUUID();
+		const unregisterRotated = registerPyToolBridge("rotation-session", rotatedCapability, {
+			toolSession: session,
+		});
+		try {
+			const stale = await call(info, staleCapability, {
+				session: "rotation-session",
+				name: "read",
+				args: {},
+			});
+			expect(stale.status).toBe(403);
+
+			const rotated = await call(info, rotatedCapability, {
+				session: "rotation-session",
+				name: "read",
+				args: {},
+			});
+			expect(rotated.status).toBe(200);
+			expect(calls).toHaveLength(1);
+		} finally {
+			unregisterRotated();
+		}
 	});
 
 	it("invokes emitStatus alongside the tool result", async () => {
@@ -130,12 +232,13 @@ describe("Python tool bridge HTTP server", () => {
 		const session = makeSession(new Map([["read", readTool]]));
 		const info = await ensurePyToolBridge();
 		const statusEvents: Array<{ op: string }> = [];
-		const unregister = registerPyToolBridge("status-session", {
+		const capability = crypto.randomUUID();
+		const unregister = registerPyToolBridge("status-session", capability, {
 			toolSession: session,
 			emitStatus: event => statusEvents.push(event),
 		});
 		try {
-			const res = await call(info, {
+			const res = await call(info, capability, {
 				session: "status-session",
 				name: "read",
 				args: { path: "foo.ts" },


### PR DESCRIPTION
Supersedes #2738 with the blocking bearer-validation finding addressed on current dev.

## Scope
- replace the process-wide Python bridge bearer with a per-kernel capability bound to one session registration
- rotate that capability when a retained session replaces its kernel and invalidate it when the execution unregisters
- reject empty or whitespace-bearing capabilities at registration
- parse Authorization to a capability-or-null result and return 403 before map lookup for missing, empty, whitespace, malformed, or unknown bearer credentials
- preserve the loopback transport, persistent-session behavior, tool result contract, and caller cancellation flow

## Reproduction coverage
- absent Authorization header
- empty Bearer credential
- whitespace-only and whitespace-containing credentials
- empty/whitespace registration attempts
- cross-session selection with another session capability
- stale capability invalidation and automatic kernel-rotation authority
- real Python prelude to host-tool bridge invocation

## Verification at exact head 75a441b1d
- 15 focused Python bridge/session tests passed
- GJC_PYTHON_INTEGRATION=1 bridge integration passed
- bun --cwd=packages/coding-agent run check
- bun --cwd=packages/coding-agent run build
- git diff --check

The production change is confined to the Python executor, prelude environment key, and loopback bridge registration/authentication boundary. No overlapping open Python tool-bridge PR was found.