### PR TITLE
fix(stats): enforce same-origin API policy

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restricted the local dashboard API to its exact loopback authority and same-origin browser requests, with POST-only bounded session sync.
+
 ## [0.11.7] - 2026-07-22
 
 ### Fixed

--- a/packages/stats/README.md
+++ b/packages/stats/README.md
@@ -60,7 +60,13 @@ console.log(stats.byModel[0].avgTokensPerSecond);
 | `GET /api/stats/models` | Per-model statistics |
 | `GET /api/stats/folders` | Per-folder/project statistics |
 | `GET /api/stats/timeseries` | Hourly time series data |
-| `GET /api/sync` | Trigger sync and return counts |
+| `POST /api/sync` | Trigger sync and return counts |
+
+## Local server security
+
+The dashboard binds only to `127.0.0.1`; the CLI opens its default browser URL through `localhost`. API requests must use HTTP, the server's actual port, and exactly `localhost` or `127.0.0.1`. Browser requests must remain same-origin, and session sync requires a same-origin `POST` request. The server does not enable cross-origin access or trust forwarded host headers.
+
+Reverse-proxy and non-loopback deployments are unsupported. They require a separate authenticated deployment boundary rather than relaxing these local-only checks.
 
 ## Data Storage
 

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -30,6 +30,7 @@
 	"scripts": {
 		"build": "bun run build.ts",
 		"dev": "bun run src/index.ts",
+		"test": "bun test",
 		"check": "biome check . && bun run check:types",
 		"check:types": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.client.json --noEmit",
 		"lint": "biome lint .",

--- a/packages/stats/src/client/api.ts
+++ b/packages/stats/src/client/api.ts
@@ -10,6 +10,12 @@ import type {
 
 const API_BASE = "/api";
 
+interface SyncResponse {
+	processed: number;
+	files: number;
+	totalMessages: number;
+}
+
 export async function getStats(range = "24h"): Promise<DashboardStats> {
 	const res = await fetch(`${API_BASE}/stats?range=${encodeURIComponent(range)}`);
 	if (!res.ok) throw new Error("Failed to fetch stats");
@@ -52,10 +58,10 @@ export async function getRequestDetails(id: number): Promise<RequestDetails> {
 	return res.json() as Promise<RequestDetails>;
 }
 
-export async function sync(): Promise<any> {
-	const res = await fetch(`${API_BASE}/sync`);
+export async function sync(): Promise<SyncResponse> {
+	const res = await fetch(`${API_BASE}/sync`, { method: "POST" });
 	if (!res.ok) throw new Error("Failed to sync");
-	return res.json();
+	return res.json() as Promise<SyncResponse>;
 }
 
 export async function getBehaviorDashboardStats(range = "24h"): Promise<BehaviorDashboardStats> {

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -15,6 +15,7 @@ import {
 } from "./aggregator";
 import { createCompiledClientAssetHandler } from "./compiled-client-assets";
 import embeddedClientArchiveTxt from "./embedded-client.generated.txt";
+import type { DashboardStats } from "./types";
 
 const getEmbeddedClientArchive = (() => {
 	const txt = embeddedClientArchiveTxt.replaceAll(/[\s\r\n]/g, "").trim();
@@ -30,6 +31,24 @@ const IS_BUN_COMPILED =
 	import.meta.url.includes("~BUN") ||
 	import.meta.url.includes("%7EBUN");
 const compiledClientAssets = createCompiledClientAssetHandler(() => getEmbeddedClientArchive?.() ?? null);
+
+interface SyncResult {
+	processed: number;
+	files: number;
+}
+
+export interface StatsServerOptions {
+	getDashboardStats?: (range?: string | null) => Promise<DashboardStats>;
+	syncAllSessions?: () => Promise<SyncResult>;
+	getTotalMessageCount?: () => Promise<number>;
+}
+
+interface ApiContext {
+	getDashboardStats: (range?: string | null) => Promise<DashboardStats>;
+	syncAllSessions: () => Promise<SyncResult>;
+	getTotalMessageCount: () => Promise<number>;
+	syncInProgress: boolean;
+}
 
 async function getLatestMtime(dir: string): Promise<number> {
 	const entries = await fs.readdir(dir, { withFileTypes: true });
@@ -115,7 +134,7 @@ const ensureClientBuild = async () => {
 /**
  * Handle API requests.
  */
-async function handleApi(req: Request): Promise<Response> {
+async function handleApi(req: Request, context: ApiContext): Promise<Response> {
 	const url = new URL(req.url);
 	const path = url.pathname;
 
@@ -123,7 +142,7 @@ async function handleApi(req: Request): Promise<Response> {
 	const range = url.searchParams.get("range");
 
 	if (path === "/api/stats") {
-		const stats = await getDashboardStats(range);
+		const stats = await context.getDashboardStats(range);
 		return Response.json(stats);
 	}
 
@@ -160,17 +179,17 @@ async function handleApi(req: Request): Promise<Response> {
 	}
 
 	if (path === "/api/stats/models") {
-		const stats = await getDashboardStats(range);
+		const stats = await context.getDashboardStats(range);
 		return Response.json(stats.byModel);
 	}
 
 	if (path === "/api/stats/folders") {
-		const stats = await getDashboardStats(range);
+		const stats = await context.getDashboardStats(range);
 		return Response.json(stats.byFolder);
 	}
 
 	if (path === "/api/stats/timeseries") {
-		const stats = await getDashboardStats(range);
+		const stats = await context.getDashboardStats(range);
 		return Response.json(stats.timeSeries);
 	}
 
@@ -183,12 +202,60 @@ async function handleApi(req: Request): Promise<Response> {
 	}
 
 	if (path === "/api/sync") {
-		const result = await syncAllSessions();
-		const count = await getTotalMessageCount();
-		return Response.json({ ...result, totalMessages: count });
+		if (context.syncInProgress) {
+			return Response.json({ error: "Sync already in progress" }, { status: 409 });
+		}
+		context.syncInProgress = true;
+		try {
+			const result = await context.syncAllSessions();
+			const count = await context.getTotalMessageCount();
+			return Response.json({ ...result, totalMessages: count });
+		} finally {
+			context.syncInProgress = false;
+		}
 	}
 
 	return new Response("Not Found", { status: 404 });
+}
+
+function forbidden(): Response {
+	return new Response("Forbidden", { status: 403 });
+}
+
+function methodNotAllowed(allowedMethod: "GET" | "POST"): Response {
+	return new Response("Method Not Allowed", { status: 405, headers: { Allow: allowedMethod } });
+}
+
+function validateApiRequest(req: Request, url: URL, boundPort: number): Response | null {
+	const authority = req.headers.get("Host");
+	const allowedAuthorities =
+		boundPort === 80
+			? new Set(["localhost", "localhost:80", "127.0.0.1", "127.0.0.1:80"])
+			: new Set([`localhost:${boundPort}`, `127.0.0.1:${boundPort}`]);
+	if (!authority || !allowedAuthorities.has(authority)) return forbidden();
+
+	if (url.protocol !== "http:" || (url.hostname !== "localhost" && url.hostname !== "127.0.0.1")) {
+		return forbidden();
+	}
+
+	const requestPort = url.port ? Number.parseInt(url.port, 10) : 80;
+	if (requestPort !== boundPort) return forbidden();
+
+	const origin = req.headers.get("Origin");
+	if (origin !== null) {
+		try {
+			const parsedOrigin = new URL(origin);
+			if (parsedOrigin.origin !== origin || origin !== url.origin) return forbidden();
+		} catch {
+			return forbidden();
+		}
+	}
+
+	const allowedMethod = url.pathname === "/api/sync" ? "POST" : "GET";
+	if (req.method !== allowedMethod) return methodNotAllowed(allowedMethod);
+	if (url.pathname === "/api/sync" && origin === null) return forbidden();
+
+	return null;
 }
 
 /**
@@ -217,52 +284,43 @@ async function handleStatic(requestPath: string): Promise<Response> {
 /**
  * Start the HTTP server.
  */
-export async function startServer(port = 3847): Promise<{ port: number; stop: () => void }> {
+export async function startServer(
+	port = 3847,
+	options: StatsServerOptions = {},
+): Promise<{ port: number; stop: () => void }> {
 	await ensureClientBuild();
+	const apiContext: ApiContext = {
+		getDashboardStats: options.getDashboardStats ?? getDashboardStats,
+		syncAllSessions: options.syncAllSessions ?? syncAllSessions,
+		getTotalMessageCount: options.getTotalMessageCount ?? getTotalMessageCount,
+		syncInProgress: false,
+	};
 
 	const server = Bun.serve({
 		hostname: "127.0.0.1",
 		port,
 		async fetch(req) {
-			const url = new URL(req.url);
+			let url: URL;
+			try {
+				url = new URL(req.url);
+			} catch {
+				return forbidden();
+			}
 			const path = url.pathname;
 
-			// CORS headers for local development
-			const corsHeaders = {
-				"Access-Control-Allow-Origin": "*",
-				"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-				"Access-Control-Allow-Headers": "Content-Type",
-			};
-
-			if (req.method === "OPTIONS") {
-				return new Response(null, { headers: corsHeaders });
+			if (path.startsWith("/api/")) {
+				const policyResponse = validateApiRequest(req, url, server.port ?? port);
+				if (policyResponse) return policyResponse;
 			}
 
 			try {
-				let response: Response;
-
 				if (path.startsWith("/api/")) {
-					response = await handleApi(req);
-				} else {
-					response = await handleStatic(path);
+					return await handleApi(req, apiContext);
 				}
-
-				// Add CORS headers to all responses
-				const headers = new Headers(response.headers);
-				for (const [key, value] of Object.entries(corsHeaders)) {
-					headers.set(key, value);
-				}
-
-				return new Response(response.body, {
-					status: response.status,
-					headers,
-				});
+				return await handleStatic(path);
 			} catch (error) {
 				console.error("Server error:", error);
-				return Response.json(
-					{ error: error instanceof Error ? error.message : "Unknown error" },
-					{ status: 500, headers: corsHeaders },
-				);
+				return Response.json({ error: error instanceof Error ? error.message : "Unknown error" }, { status: 500 });
 			}
 		},
 	});

--- a/packages/stats/test/server-security.test.ts
+++ b/packages/stats/test/server-security.test.ts
@@ -1,0 +1,202 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { sync as clientSync } from "../src/client/api";
+import { startServer } from "../src/server";
+import type { DashboardStats } from "../src/types";
+
+const EMPTY_DASHBOARD: DashboardStats = {
+	overall: {
+		totalRequests: 0,
+		successfulRequests: 0,
+		failedRequests: 0,
+		errorRate: 0,
+		totalInputTokens: 0,
+		totalOutputTokens: 0,
+		totalCacheReadTokens: 0,
+		totalCacheWriteTokens: 0,
+		cacheRate: 0,
+		totalCost: 0,
+		totalPremiumRequests: 0,
+		avgDuration: null,
+		avgTtft: null,
+		avgTokensPerSecond: null,
+		firstTimestamp: 0,
+		lastTimestamp: 0,
+	},
+	byModel: [],
+	byFolder: [],
+	timeSeries: [],
+	modelSeries: [],
+	modelPerformanceSeries: [],
+	costSeries: [],
+};
+
+describe("stats server request policy", () => {
+	let server: { port: number; stop(): void };
+	let syncCalls = 0;
+	let countCalls = 0;
+	let runSync: () => Promise<{ processed: number; files: number }>;
+
+	function request(host: string, path: string, init: RequestInit = {}): Promise<Response> {
+		const headers = new Headers(init.headers);
+		headers.set("Host", host);
+		return fetch(`http://127.0.0.1:${server.port}${path}`, { ...init, headers });
+	}
+
+	function origin(hostname = "localhost"): string {
+		return `http://${hostname}:${server.port}`;
+	}
+
+	beforeAll(async () => {
+		runSync = async () => ({ processed: 1, files: 1 });
+		server = await startServer(0, {
+			getDashboardStats: async () => EMPTY_DASHBOARD,
+			syncAllSessions: async () => {
+				syncCalls += 1;
+				return await runSync();
+			},
+			getTotalMessageCount: async () => {
+				countCalls += 1;
+				return 7;
+			},
+		});
+	});
+
+	afterAll(() => server.stop());
+
+	beforeEach(() => {
+		syncCalls = 0;
+		countCalls = 0;
+		runSync = async () => ({ processed: 1, files: 1 });
+	});
+
+	it("accepts only the exact loopback authority and actual port", async () => {
+		for (const hostname of ["localhost", "127.0.0.1"]) {
+			const response = await request(`${hostname}:${server.port}`, "/api/stats");
+			expect(response.status).toBe(200);
+			expect(response.headers.has("Access-Control-Allow-Origin")).toBe(false);
+		}
+
+		for (const authority of [
+			`evil.test:${server.port}`,
+			`127.0.0.2:${server.port}`,
+			`127.1:${server.port}`,
+			`LOCALHOST:${server.port}`,
+			`%6cocalhost:${server.port}`,
+			`localhost:${server.port + 1}`,
+			"localhost:bad",
+		]) {
+			expect((await request(authority, "/api/stats")).status).toBe(403);
+		}
+
+		const forwarded = await request(`evil.test:${server.port}`, "/api/stats", {
+			headers: { "X-Forwarded-Host": `localhost:${server.port}` },
+		});
+		expect(forwarded.status).toBe(403);
+	});
+
+	it("allows absent-Origin reads but rejects non-exact browser origins", async () => {
+		expect((await request(`localhost:${server.port}`, "/api/stats")).status).toBe(200);
+		for (const hostname of ["localhost", "127.0.0.1"]) {
+			const response = await request(`${hostname}:${server.port}`, "/api/stats", {
+				headers: { Origin: origin(hostname) },
+			});
+			expect(response.status).toBe(200);
+		}
+
+		for (const browserOrigin of ["null", `http://evil.test:${server.port}`, "not an origin"]) {
+			const response = await request(`localhost:${server.port}`, "/api/stats", {
+				headers: { Origin: browserOrigin },
+			});
+			expect(response.status).toBe(403);
+			expect(response.headers.has("Access-Control-Allow-Origin")).toBe(false);
+		}
+	});
+
+	it("enforces the API method and sync-origin matrix before side effects", async () => {
+		const host = `localhost:${server.port}`;
+		const wrongMethod = await request(host, "/api/sync");
+		expect(wrongMethod.status).toBe(405);
+		expect(wrongMethod.headers.get("Allow")).toBe("POST");
+		const readWrite = await request(host, "/api/stats", { method: "POST", headers: { Origin: origin() } });
+		expect(readWrite.status).toBe(405);
+		expect(readWrite.headers.get("Allow")).toBe("GET");
+		expect((await request(host, "/api/sync", { method: "POST" })).status).toBe(403);
+
+		for (const browserOrigin of ["null", `http://evil.test:${server.port}`]) {
+			expect(
+				(
+					await request(host, "/api/sync", {
+						method: "POST",
+						headers: { Origin: browserOrigin },
+					})
+				).status,
+			).toBe(403);
+		}
+
+		const foreignPreflight = await request(host, "/api/sync", {
+			method: "OPTIONS",
+			headers: { Origin: `http://evil.test:${server.port}` },
+		});
+		expect(foreignPreflight.status).toBe(403);
+		const sameOriginPreflight = await request(host, "/api/sync", {
+			method: "OPTIONS",
+			headers: { Origin: origin() },
+		});
+		expect(sameOriginPreflight.status).toBe(405);
+		expect(sameOriginPreflight.headers.get("Allow")).toBe("POST");
+		expect(syncCalls).toBe(0);
+		expect(countCalls).toBe(0);
+	});
+
+	it("runs at most one sync and releases the guard afterward", async () => {
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		runSync = async () => {
+			started.resolve();
+			await release.promise;
+			return { processed: 2, files: 1 };
+		};
+		const init = { method: "POST", headers: { Origin: origin() } };
+		const first = request(`localhost:${server.port}`, "/api/sync", init);
+		await started.promise;
+		const concurrent = await request(`localhost:${server.port}`, "/api/sync", init);
+		expect(concurrent.status).toBe(409);
+		expect(syncCalls).toBe(1);
+		expect(countCalls).toBe(0);
+		release.resolve();
+		expect((await first).status).toBe(200);
+
+		runSync = async () => ({ processed: 3, files: 1 });
+		expect((await request(`localhost:${server.port}`, "/api/sync", init)).status).toBe(200);
+		expect(syncCalls).toBe(2);
+		expect(countCalls).toBe(2);
+
+		runSync = async () => {
+			throw new Error("expected sync failure");
+		};
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			expect((await request(`localhost:${server.port}`, "/api/sync", init)).status).toBe(500);
+		} finally {
+			errorSpy.mockRestore();
+		}
+		runSync = async () => ({ processed: 4, files: 1 });
+		expect((await request(`localhost:${server.port}`, "/api/sync", init)).status).toBe(200);
+		expect(syncCalls).toBe(4);
+		expect(countCalls).toBe(3);
+	});
+
+	it("keeps static SPA fallback outside API policy and sends client sync as POST", async () => {
+		const staticResponse = await request(`localhost:${server.port}`, "/dashboard/route");
+		expect(staticResponse.status).toBe(200);
+		expect(staticResponse.headers.has("Access-Control-Allow-Origin")).toBe(false);
+
+		const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}"));
+		try {
+			await clientSync();
+			expect(fetchSpy).toHaveBeenCalledWith("/api/sync", { method: "POST" });
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
Replaces closed #2891 after rebasing the reviewed implementation onto current `dev` (`c12fba3e712073c94057687fda70a3c9962c0daf`) and relocating the changelog entry to the current Unreleased section.

## Scope

- bind accepted Host authority to the loopback listener and actual port
- enforce same-origin Origin on browser-facing API requests
- keep read routes GET-only and require same-origin POST for `/api/sync`
- remove wildcard CORS and serialize sync requests
- update the browser client and stats documentation for the enforced contract

## Evidence

- `bun test packages/stats/test/server-security.test.ts` — 5/5 passed
- `bun --cwd=packages/stats run check` — passed
- coding-agent TypeScript build — passed
- exact-head diff check — clean
- merge base is current `dev` at `c12fba3e712073c94057687fda70a3c9962c0daf`

The implementation received an adversarial security review on #2891 with no bypass found; this replacement changes only the base/changelog placement and reruns exact-head CI.