### PR TITLE
fix(coding-agent): enforce ACP eval permissions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Runtime MCP OAuth credentials are now bound to their authorized server origin and token endpoint, reject redirecting refresh responses, and fail closed when legacy or changed configuration lacks an exact match.
+- ACP sessions now apply execution permission decisions to eval calls and to tools invoked from JavaScript or Python eval contexts, while non-ACP session behavior remains unchanged.
 - Telegram notification daemon self-heals degraded on-disk state: permanently missing scan roots are pruned (so one deleted worktree no longer disables orphan-topic cleanup), and retained exact-unlink transition/placeholder artifacts are reaped on ownership acquire and each scan. `gjc daemon reload` can recover without manual filesystem surgery (#2956).
 - On macOS, resuming a managed session no longer fails with `identity_mismatch` when the first write-append open changes only file `ctime` (e.g. APFS write-provenance / `com.apple.provenance`). `appendSync` allows a single bounded re-capture + retry when `dev`/`ino`/`size`/`mtime`/SHA-256 remain unchanged, and still rejects real content races and repeated ctime transitions (#2944).
 - Interactive `/resume` / `AgentSession.switchSession()` now awaits verified managed `local://` legacy-root migration for the newly selected session before post-commit lifecycle proceeds, matching cold-start `createAgentSession()` readiness from #2797 so synchronous `local://` resolution no longer fails with "legacy migration must complete before path resolution" after a mid-session switch (#2925).

--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -68,6 +68,7 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"agent_session:getAsyncDeliveryStateForAcp":
 		"internal ACP lifecycle quiescence plumbing, not a user-facing control seam",
 	"agent_session:getToolByName": "internal accessor/plumbing, not a user-facing control seam",
+	"agent_session:getToolForExecution": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:registerForegroundBashBackgroundRequestHandler":
 		"internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:hasForegroundBashBackgroundRequestHandler":

--- a/packages/coding-agent/src/eval/js/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/js/tool-bridge.ts
@@ -30,7 +30,7 @@ function toolResultHasError(result: AgentToolResult): boolean {
 }
 
 function getTool(session: ToolSession, name: string): AgentTool {
-	const tool = session.getToolByName?.(name);
+	const tool = session.getToolForExecution ? session.getToolForExecution(name) : session.getToolByName?.(name);
 	if (!tool) {
 		throw new ToolError(`Unknown tool from js runtime: ${name}`);
 	}

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2613,6 +2613,17 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:getToolForExecution",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal accessor/plumbing, not a user-facing control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:registerForegroundBashBackgroundRequestHandler",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1540,6 +1540,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			goalToolAllowedOps: options.goalToolAllowedOps,
 			discoverableToolAllowedNames: options.discoverableToolAllowedNames,
 			getToolByName: name => session?.getToolByName(name),
+			getToolForExecution: name => session?.getToolForExecution(name),
 			agentRegistry,
 			getSessionSpawns: () => options.spawns ?? "*",
 			getModelString: () => (hasExplicitModel && model ? formatModelString(model) : undefined),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1031,10 +1031,14 @@ function createHandoffContext(document: string): string {
 // ============================================================================
 
 /** Tools that require user permission before execution when an ACP client is connected. */
-const PERMISSION_REQUIRED_TOOLS = new Set(["bash", "monitor", "edit", "delete", "move"]);
+const PERMISSION_REQUIRED_TOOLS = new Set(["bash", "monitor", "eval", "edit", "delete", "move"]);
 
 function isShellExecutionPermissionTool(toolName: string): boolean {
 	return toolName === "bash" || toolName === "monitor";
+}
+
+function isExecutionPermissionTool(toolName: string): boolean {
+	return isShellExecutionPermissionTool(toolName) || toolName === "eval";
 }
 
 /** Permission options presented to the client on each gated tool call. */
@@ -1103,6 +1107,18 @@ function getPermissionIntent(
 	if (isShellExecutionPermissionTool(toolName)) {
 		const cmd = getStringProperty(a, "command")?.slice(0, 80);
 		return { toolName, title: cmd || toolName, cacheKey: toolName };
+	}
+	if (toolName === "eval") {
+		const cells = Array.isArray(a.cells) ? a.cells : [];
+		const firstCell = cells.find(cell => cell && typeof cell === "object" && !Array.isArray(cell));
+		const cell = firstCell as Record<string, unknown> | undefined;
+		const title = cell ? getStringProperty(cell, "title") : undefined;
+		const language = cell ? getStringProperty(cell, "language") : undefined;
+		return {
+			toolName,
+			title: title ?? (language ? `Eval ${language}` : "eval"),
+			cacheKey: toolName,
+		};
 	}
 	if (toolName === "delete") {
 		const p = getStringProperty(a, "path");
@@ -5456,6 +5472,12 @@ export class AgentSession {
 		return undefined;
 	}
 
+	/** Get a registered tool with the same guards used for model-facing execution. */
+	getToolForExecution(name: string): AgentTool | undefined {
+		const tool = this.getToolByName(name);
+		return tool ? this.#prepareToolForExecution(tool) : undefined;
+	}
+
 	/**
 	 * Register a UI/control-plane request handler for a currently foregrounded
 	 * managed bash execution. This is intentionally narrower than generic
@@ -5720,6 +5742,7 @@ export class AgentSession {
 						return await target.execute(toolCallId, args as never, signal, onUpdate, ctx);
 					}
 					const isShellExecutionTool = isShellExecutionPermissionTool(target.name);
+					const isExecutionTool = isExecutionPermissionTool(target.name);
 					const command =
 						isShellExecutionTool && args && typeof args === "object" && !Array.isArray(args)
 							? getStringProperty(args as Record<string, unknown>, "command")
@@ -5762,7 +5785,7 @@ export class AgentSession {
 								toolCallId,
 								toolName: target.name,
 								title: permissionIntent.title,
-								...(isShellExecutionTool ? { kind: "execute" } : {}),
+								...(isExecutionTool ? { kind: "execute" } : {}),
 								status: "pending",
 								rawInput: args,
 								...(commandContent ? { content: commandContent } : {}),

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -273,9 +273,11 @@ export interface ToolSession {
 	/** Agent identity used for IRC routing. Returns the registry id (e.g. "0-Main", "0-AuthLoader"). */
 	getAgentId?: () => string | null;
 	/** Look up a registered tool by name (used by the eval js backend's tool bridge). */
+	getToolByName?: (name: string) => AgentTool | undefined;
+	/** Look up a registered tool with the session's execution guards applied. */
+	getToolForExecution?: (name: string) => AgentTool | undefined;
 	/** Purge undelivered queued custom messages matching the predicate. Returns counts. */
 	purgeQueuedCustomMessages?: (predicate: (message: CustomMessage) => boolean) => PurgeQueuedCustomMessagesResult;
-	getToolByName?: (name: string) => AgentTool | undefined;
 	/** Agent registry for IRC routing across live sessions. */
 	agentRegistry?: AgentRegistry;
 	/** Optional restricted bash command prefixes for read-only role agents and constrained modes. */

--- a/packages/coding-agent/test/agent-session-acp-permission.test.ts
+++ b/packages/coding-agent/test/agent-session-acp-permission.test.ts
@@ -23,6 +23,7 @@ import { SessionManager } from "@gajae-code/coding-agent/session/session-manager
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { TempDir } from "@gajae-code/utils";
 import * as z from "zod/v4";
+import { callSessionTool } from "../src/eval/js/tool-bridge";
 
 // ---------------------------------------------------------------------------
 // Shared setup
@@ -62,6 +63,13 @@ function makeToolSession(bridge: ClientBridge): ToolSession {
 	} as unknown as ToolSession;
 }
 
+function makeExecutionToolSession(agentSession: AgentSession): ToolSession {
+	return {
+		getToolByName: (name: string) => agentSession.getToolByName(name),
+		getToolForExecution: (name: string) => agentSession.getToolForExecution(name),
+	} as unknown as ToolSession;
+}
+
 /** Build a minimal ClientBridge whose requestPermission resolves to the given outcome. */
 function makeBridge(outcome: ClientBridgePermissionOutcome): ClientBridge {
 	return {
@@ -72,7 +80,11 @@ function makeBridge(outcome: ClientBridgePermissionOutcome): ClientBridge {
 	};
 }
 
-async function createSession(tools: AgentTool[], bridge?: ClientBridge): Promise<AgentSession> {
+async function createSession(
+	tools: AgentTool[],
+	bridge?: ClientBridge,
+	permissionMode: "allow" | "prompt" = "prompt",
+): Promise<AgentSession> {
 	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 	if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
 
@@ -100,7 +112,7 @@ async function createSession(tools: AgentTool[], bridge?: ClientBridge): Promise
 	});
 
 	// Session default is `allow`; ACP registers a prompt bridge alongside prompt mode (see acp-agent).
-	sess.setSdkPermissionMode("prompt");
+	sess.setSdkPermissionMode(permissionMode);
 	if (bridge) sess.setClientBridge(bridge);
 	return sess;
 }
@@ -730,6 +742,184 @@ it("setClientBridge wraps tools that were already active", async () => {
 	await wrappedBash!.execute("call-1", { command: "echo hi" }, undefined, undefined as never, undefined as never);
 
 	expect(permissionSpy).toHaveBeenCalledTimes(1);
+	expect(bashTool.executeCalls).toBe(1);
+});
+
+it("eval allow_once requests execution permission before running", async () => {
+	const evalTool = makeFakeTool("eval");
+	const requests: ClientBridgePermissionToolCall[] = [];
+	const bridge: ClientBridge = {
+		capabilities: { requestPermission: true },
+		async requestPermission(toolCall, options, _signal) {
+			requests.push(toolCall);
+			expect(options.map(option => option.optionId)).toEqual([
+				"allow_once",
+				"allow_always",
+				"reject_once",
+				"reject_always",
+			]);
+			return { outcome: "selected", optionId: "allow_once", kind: "allow_once" };
+		},
+	};
+	session = await createSession([evalTool], bridge);
+	await session.setActiveToolsByName(["eval"]);
+	const wrappedEval = session.agent.state.tools.find(tool => tool.name === "eval");
+
+	await wrappedEval!.execute(
+		"call-eval-allow",
+		{ cells: [{ language: "js", code: "1 + 1", title: "Calculate" }] },
+		undefined,
+		undefined as never,
+		undefined as never,
+	);
+
+	expect(requests).toEqual([
+		expect.objectContaining({
+			toolCallId: "call-eval-allow",
+			toolName: "eval",
+			title: "Calculate",
+			kind: "execute",
+			status: "pending",
+		}),
+	]);
+	expect(evalTool.executeCalls).toBe(1);
+});
+
+it("eval reject_once does not execute", async () => {
+	const evalTool = makeFakeTool("eval");
+	const bridge = makeBridge({ outcome: "selected", optionId: "reject_once", kind: "reject_once" });
+	session = await createSession([evalTool], bridge);
+	await session.setActiveToolsByName(["eval"]);
+	const wrappedEval = session.agent.state.tools.find(tool => tool.name === "eval");
+
+	await expect(
+		wrappedEval!.execute(
+			"call-eval-reject",
+			{ cells: [{ language: "py", code: "print(1)" }] },
+			undefined,
+			undefined as never,
+			undefined as never,
+		),
+	).rejects.toThrow(/rejected by user/);
+	expect(evalTool.executeCalls).toBe(0);
+});
+
+it("eval allow_always is reused for later eval calls", async () => {
+	const evalTool = makeFakeTool("eval");
+	const bridge = makeBridge({ outcome: "selected", optionId: "allow_always", kind: "allow_always" });
+	const permissionSpy = spyOn(bridge, "requestPermission");
+	session = await createSession([evalTool], bridge);
+	await session.setActiveToolsByName(["eval"]);
+	const wrappedEval = session.agent.state.tools.find(tool => tool.name === "eval");
+
+	await wrappedEval!.execute(
+		"call-eval-always-1",
+		{ cells: [{ language: "js", code: "1" }] },
+		undefined,
+		undefined as never,
+		undefined as never,
+	);
+	await wrappedEval!.execute(
+		"call-eval-always-2",
+		{ cells: [{ language: "py", code: "2" }] },
+		undefined,
+		undefined as never,
+		undefined as never,
+	);
+
+	expect(permissionSpy).toHaveBeenCalledTimes(1);
+	expect(evalTool.executeCalls).toBe(2);
+});
+
+it("eval cancelled and unknown permission outcomes fail closed", async () => {
+	for (const outcome of [
+		{ outcome: "cancelled" as const },
+		{ outcome: "selected" as const, optionId: "allow_typo" },
+	]) {
+		const evalTool = makeFakeTool("eval");
+		const bridge = makeBridge(outcome);
+		session = await createSession([evalTool], bridge);
+		await session.setActiveToolsByName(["eval"]);
+		const wrappedEval = session.agent.state.tools.find(tool => tool.name === "eval");
+
+		await expect(
+			wrappedEval!.execute(
+				"call-eval-fail-closed",
+				{ cells: [{ language: "js", code: "1" }] },
+				undefined,
+				undefined as never,
+				undefined as never,
+			),
+		).rejects.toThrow(outcome.outcome === "cancelled" ? /cancelled/ : /unknown option ID/);
+		expect(evalTool.executeCalls).toBe(0);
+		await session.dispose();
+		session = undefined;
+	}
+});
+
+it("nested eval tool calls use the prepared permission-wrapped dispatch", async () => {
+	const bashTool = makeFakeTool("bash");
+	let nestedSession: AgentSession | undefined;
+	let evalExecuteCalls = 0;
+	const evalTool = {
+		...makeFakeTool("eval"),
+		async execute() {
+			evalExecuteCalls++;
+			await callSessionTool(
+				"bash",
+				{ command: "echo nested" },
+				{ session: makeExecutionToolSession(nestedSession!) },
+			);
+			return { content: [{ type: "text" as const, text: "ok" }] };
+		},
+	};
+	const requestedTools: string[] = [];
+	const bridge: ClientBridge = {
+		capabilities: { requestPermission: true },
+		async requestPermission(toolCall, _options, _signal) {
+			requestedTools.push(toolCall.toolName);
+			if (toolCall.toolName === "eval") {
+				return { outcome: "selected", optionId: "allow_once", kind: "allow_once" };
+			}
+			return { outcome: "selected", optionId: "reject_once", kind: "reject_once" };
+		},
+	};
+	nestedSession = await createSession([evalTool, bashTool], bridge);
+	session = nestedSession;
+	await session.setActiveToolsByName(["eval"]);
+	const wrappedEval = session.agent.state.tools.find(tool => tool.name === "eval");
+
+	await expect(
+		wrappedEval!.execute(
+			"call-eval-nested",
+			{ cells: [{ language: "js", code: "await tools.bash(...)" }] },
+			undefined,
+			undefined as never,
+			undefined as never,
+		),
+	).rejects.toThrow(/rejected by user/);
+	expect(requestedTools).toEqual(["eval", "bash"]);
+	expect(evalExecuteCalls).toBe(1);
+	expect(bashTool.executeCalls).toBe(0);
+});
+
+it("non-ACP eval and nested dispatch preserve execution without permission prompts", async () => {
+	const evalTool = makeFakeTool("eval");
+	const bashTool = makeFakeTool("bash");
+	session = await createSession([evalTool, bashTool], undefined, "allow");
+	await session.setActiveToolsByName(["eval"]);
+	const wrappedEval = session.agent.state.tools.find(tool => tool.name === "eval");
+
+	await wrappedEval!.execute(
+		"call-eval-local",
+		{ cells: [{ language: "js", code: "1" }] },
+		undefined,
+		undefined as never,
+		undefined as never,
+	);
+	await callSessionTool("bash", { command: "echo local" }, { session: makeExecutionToolSession(session) });
+
+	expect(evalTool.executeCalls).toBe(1);
 	expect(bashTool.executeCalls).toBe(1);
 });
 

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -32,6 +32,39 @@ function createSession(tools: AgentTool[]): ToolSession {
 }
 
 describe("callSessionTool", () => {
+	it("prefers the session's prepared tool dispatch over the raw registry lookup", async () => {
+		const rawExecute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "raw" }] });
+		const preparedExecute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "prepared" }] });
+		const rawTool = createTool("bash", rawExecute);
+		const preparedTool = createTool("bash", preparedExecute);
+		const session = {
+			...createSession([]),
+			getToolByName: () => rawTool,
+			getToolForExecution: () => preparedTool,
+		};
+
+		await expect(callSessionTool("bash", { command: "echo guarded" }, { session })).resolves.toBe("prepared");
+		expect(preparedExecute).toHaveBeenCalledTimes(1);
+		expect(rawExecute).not.toHaveBeenCalled();
+	});
+
+	it("does not fall back to the raw registry when prepared dispatch rejects a tool", async () => {
+		const rawExecute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "raw" }] });
+		const rawTool = createTool("bash", rawExecute);
+		const rawLookup = vi.fn(() => rawTool);
+		const session = {
+			...createSession([]),
+			getToolByName: rawLookup,
+			getToolForExecution: () => undefined,
+		};
+
+		await expect(callSessionTool("bash", { command: "echo unguarded" }, { session })).rejects.toThrow(
+			"Unknown tool from js runtime: bash",
+		);
+		expect(rawLookup).not.toHaveBeenCalled();
+		expect(rawExecute).not.toHaveBeenCalled();
+	});
+
 	it("injects js intent and summarizes text results", async () => {
 		const execute = vi.fn().mockResolvedValue({
 			content: [{ type: "text", text: "hello" }],


### PR DESCRIPTION
Replaces closed #2737 with the reviewed permission-boundary fix rebased onto current dev.

Scope
- Route JavaScript and Python eval-triggered tool calls through the session prepared-tool dispatcher.
- Apply the existing ACP permission decision and cache to eval execution.
- Include eval in the permission-required execution set with bounded intent metadata.
- Preserve non-ACP behavior and the generated SDK operation inventory contract.

Exact-head refresh after adjacent merges
- Base: 9657928fef1211af53ae3b2b81957aeb53965429
- Head: bba5a1244756fcfa587cb0add815cbfd3e686ee3
- ACP and JavaScript bridge suites: 36 passed, 112 expectations
- SDK operation inventory and matrix suites: 21 passed, 1527 expectations
- coding-agent Biome and TypeScript check passed
- full workspace build passed
- exact diff check passed

The original maintainer review found no implementation-level security defect and requested a current-dev rebase, Unreleased changelog placement, and fresh exact-head/merge-result CI. This rewritten head satisfies those local gates; hosted CI is rerunning now.