### PR TITLE
fix(coding-agent): bind MCP OAuth credentials to trusted endpoints

### DIFF
--- a/packages/ai/src/auth-broker/client.ts
+++ b/packages/ai/src/auth-broker/client.ts
@@ -12,6 +12,7 @@ import type {
 	CredentialDisableRequest,
 	CredentialDisableResponse,
 	CredentialIfAbsentUploadResponse,
+	CredentialRefreshRequest,
 	CredentialRefreshResponse,
 	CredentialUploadRequest,
 	CredentialUploadResponse,
@@ -237,6 +238,18 @@ export class AuthBrokerClient {
 
 	async refreshCredential(id: number, signal?: AbortSignal): Promise<CredentialRefreshResponse> {
 		return this.#request("POST", `/v1/credential/${id}/refresh`, {
+			schema: credentialRefreshResponseSchema,
+			signal,
+		}) as Promise<CredentialRefreshResponse>;
+	}
+
+	async refreshMCPCredential(
+		id: number,
+		body: CredentialRefreshRequest,
+		signal?: AbortSignal,
+	): Promise<CredentialRefreshResponse> {
+		return this.#request("POST", `/v1/credential/${id}/refresh`, {
+			body,
 			schema: credentialRefreshResponseSchema,
 			signal,
 		}) as Promise<CredentialRefreshResponse>;

--- a/packages/ai/src/auth-broker/refresher.ts
+++ b/packages/ai/src/auth-broker/refresher.ts
@@ -96,6 +96,7 @@ export class AuthBrokerRefresher {
 			const targets: number[] = [];
 			for (const entry of snapshot.credentials) {
 				if (entry.credential.type !== "oauth") continue;
+				if (entry.credential.mcpBinding) continue;
 				const expires = entry.credential.expires;
 				if (typeof expires !== "number" || !Number.isFinite(expires)) continue;
 				if (expires > deadline) continue;

--- a/packages/ai/src/auth-broker/remote-store.ts
+++ b/packages/ai/src/auth-broker/remote-store.ts
@@ -14,6 +14,8 @@ import {
 	type AuthCredentialIfAbsentResult,
 	type AuthCredentialSnapshotEntry,
 	type AuthCredentialStore,
+	assertCanonicalMCPOAuthBinding,
+	type MCPOAuthRefreshClient,
 	type OAuthCredential,
 	REMOTE_REFRESH_SENTINEL,
 	type StoredAuthCredential,
@@ -510,6 +512,29 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 			projectId: refreshed.projectId,
 			enterpriseUrl: refreshed.enterpriseUrl,
 		};
+	}
+
+	async refreshMCPOAuthCredential(
+		credentialId: number,
+		credential: OAuthCredential,
+		client: MCPOAuthRefreshClient,
+		signal?: AbortSignal,
+	): Promise<OAuthCredential> {
+		const { entry } = await this.#client.refreshMCPCredential(credentialId, client, signal);
+		if (entry.credential.type !== "oauth") {
+			throw new Error(`Broker returned non-OAuth credential for id=${credentialId}`);
+		}
+		assertCanonicalMCPOAuthBinding(credential.mcpBinding);
+		assertCanonicalMCPOAuthBinding(entry.credential.mcpBinding);
+		if (
+			entry.credential.mcpBinding.resourceOrigin !== credential.mcpBinding.resourceOrigin ||
+			entry.credential.mcpBinding.tokenEndpoint !== credential.mcpBinding.tokenEndpoint
+		) {
+			throw new Error("Broker returned mismatched MCP OAuth credential binding");
+		}
+		this.#applyCredentialEntry(entry);
+		this.#maybeRefreshSnapshot("MCP credential refresh");
+		return entry.credential;
 	}
 
 	/**

--- a/packages/ai/src/auth-broker/server.ts
+++ b/packages/ai/src/auth-broker/server.ts
@@ -16,6 +16,7 @@ import { AuthBrokerRefresher, type AuthBrokerRefresherSchedule } from "./refresh
 import type {
 	CredentialDisableResponse,
 	CredentialIfAbsentUploadResponse,
+	CredentialRefreshRequest,
 	CredentialRefreshResponse,
 	CredentialUploadResponse,
 	HealthzResponse,
@@ -33,7 +34,11 @@ import {
 	DEFAULT_SERVER_IDLE_TIMEOUT_S,
 	DEFAULT_STREAM_KEEPALIVE_MS,
 } from "./types";
-import { credentialDisableRequestSchema, credentialUploadRequestSchema } from "./wire-schemas";
+import {
+	credentialDisableRequestSchema,
+	credentialRefreshRequestSchema,
+	credentialUploadRequestSchema,
+} from "./wire-schemas";
 
 export interface AuthBrokerServerOptions {
 	/** Underlying credential storage (wraps the local SQLite store on the broker). */
@@ -561,7 +566,10 @@ export function startAuthBroker(opts: AuthBrokerServerOptions): AuthBrokerServer
 				if (refreshMatch) {
 					const id = Number.parseInt(refreshMatch[1], 10);
 					try {
-						const entry = await opts.storage.refreshCredentialById(id, req.signal);
+						const parsed = await parseBody(req, credentialRefreshRequestSchema, { allowEmpty: true });
+						if (!parsed.ok) return parsed.response;
+						const refreshRequest: CredentialRefreshRequest = parsed.data;
+						const entry = await opts.storage.refreshCredentialById(id, req.signal, refreshRequest);
 						const body: CredentialRefreshResponse = { entry };
 						logger.info("auth-broker credential refreshed", {
 							id,

--- a/packages/ai/src/auth-broker/types.ts
+++ b/packages/ai/src/auth-broker/types.ts
@@ -11,6 +11,7 @@ import type {
 	AuthCredentialIfAbsentReason,
 	AuthCredentialSnapshot,
 	AuthCredentialSnapshotEntry,
+	MCPOAuthRefreshClient,
 } from "../auth-storage";
 import type { UsageReport } from "../usage";
 
@@ -48,6 +49,9 @@ export interface UsageResponse {
 export interface CredentialRefreshResponse {
 	entry: AuthCredentialSnapshotEntry;
 }
+
+/** Optional MCP client metadata; the broker still selects the stored token endpoint. */
+export type CredentialRefreshRequest = MCPOAuthRefreshClient;
 
 /** POST /v1/credential/:id/disable request body. */
 export interface CredentialDisableRequest {

--- a/packages/ai/src/auth-broker/wire-schemas.ts
+++ b/packages/ai/src/auth-broker/wire-schemas.ts
@@ -11,10 +11,18 @@
  * `hasOnlyFields` allowlist for the same effect.
  */
 import * as z from "zod/v4";
-import { REMOTE_REFRESH_SENTINEL } from "../auth-storage";
+import { isCanonicalMCPOAuthBinding, REMOTE_REFRESH_SENTINEL } from "../auth-storage";
 import { usageReportSchema } from "../usage";
 
 // ─── Credential payloads ───────────────────────────────────────────────────
+
+export const mcpOAuthBindingSchema = z
+	.object({
+		resourceOrigin: z.string().min(1),
+		tokenEndpoint: z.string().min(1),
+	})
+	.strict()
+	.refine(isCanonicalMCPOAuthBinding, { message: "MCP OAuth binding must use canonical HTTP(S) URLs" });
 
 /** Real OAuth credential (broker-side) — refresh token is the actual upstream value. */
 export const oauthCredentialSchema = z
@@ -37,6 +45,7 @@ export const oauthCredentialSchema = z
 		projectId: z.string().optional(),
 		email: z.string().optional(),
 		accountId: z.string().optional(),
+		mcpBinding: mcpOAuthBindingSchema.optional(),
 	})
 	.strict();
 
@@ -163,6 +172,13 @@ export const usageResponseSchema = z
 	.strict();
 
 // ─── Refresh ───────────────────────────────────────────────────────────────
+
+export const credentialRefreshRequestSchema = z
+	.object({
+		clientId: z.string().optional(),
+		clientSecret: z.string().optional(),
+	})
+	.strict();
 
 export const credentialRefreshResponseSchema = z
 	.object({

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -46,11 +46,112 @@ export type ApiKeyCredential = {
 	key: string;
 };
 
+export interface MCPOAuthBinding {
+	/** Exact HTTP(S) origin of the MCP resource endpoint. */
+	resourceOrigin: string;
+	/** Exact canonical HTTP(S) token endpoint used to create and refresh the credential. */
+	tokenEndpoint: string;
+}
+
+function resolveCanonicalHttpUrl(value: string): URL | undefined {
+	try {
+		const parsed = new URL(value);
+		if (
+			(parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+			parsed.username !== "" ||
+			parsed.password !== "" ||
+			parsed.hash !== ""
+		) {
+			return undefined;
+		}
+		return parsed;
+	} catch {
+		return undefined;
+	}
+}
+
+export function resolveMCPOAuthResourceOrigin(value: string): string | undefined {
+	return resolveCanonicalHttpUrl(value)?.origin;
+}
+
+export function resolveMCPOAuthTokenEndpoint(value: string): string | undefined {
+	return resolveCanonicalHttpUrl(value)?.href;
+}
+
+export function isCanonicalMCPOAuthBinding(binding: MCPOAuthBinding): boolean {
+	return (
+		resolveMCPOAuthResourceOrigin(binding.resourceOrigin) === binding.resourceOrigin &&
+		resolveMCPOAuthTokenEndpoint(binding.tokenEndpoint) === binding.tokenEndpoint
+	);
+}
+
+export function assertCanonicalMCPOAuthBinding(
+	binding: MCPOAuthBinding | undefined,
+): asserts binding is MCPOAuthBinding {
+	if (!binding || !isCanonicalMCPOAuthBinding(binding)) {
+		throw new Error("Invalid MCP OAuth credential binding");
+	}
+}
+
 export type OAuthCredential = {
 	type: "oauth";
+	/** Present only for credentials created by runtime MCP OAuth. */
+	mcpBinding?: MCPOAuthBinding;
 } & OAuthCredentials;
 
 export type AuthCredential = ApiKeyCredential | OAuthCredential;
+
+export interface MCPOAuthRefreshClient {
+	clientId?: string;
+	clientSecret?: string;
+}
+
+async function refreshBoundMCPOAuthCredential(
+	credential: OAuthCredential,
+	client: MCPOAuthRefreshClient = {},
+	signal?: AbortSignal,
+): Promise<OAuthCredentials> {
+	const binding = credential.mcpBinding;
+	assertCanonicalMCPOAuthBinding(binding);
+	const params = new URLSearchParams({
+		grant_type: "refresh_token",
+		refresh_token: credential.refresh,
+	});
+	if (client.clientId) params.set("client_id", client.clientId);
+	if (client.clientSecret) params.set("client_secret", client.clientSecret);
+
+	const response = await fetch(binding.tokenEndpoint, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: params.toString(),
+		redirect: "manual",
+		signal,
+	});
+	if (response.status >= 300 && response.status < 400) {
+		throw new Error(`MCP OAuth refresh rejected redirect response (${response.status})`);
+	}
+	if (!response.ok) throw new Error(`MCP OAuth refresh failed (${response.status})`);
+	const payload: unknown = await response.json();
+	if (!payload || typeof payload !== "object") throw new Error("MCP OAuth refresh returned an invalid payload");
+	const data = payload as { access_token?: unknown; refresh_token?: unknown; expires_in?: unknown };
+	if (typeof data.access_token !== "string" || data.access_token.length === 0) {
+		throw new Error("MCP OAuth refresh returned an invalid access token");
+	}
+	if (data.refresh_token !== undefined && typeof data.refresh_token !== "string") {
+		throw new Error("MCP OAuth refresh returned an invalid refresh token");
+	}
+	if (
+		data.expires_in !== undefined &&
+		(typeof data.expires_in !== "number" || !Number.isFinite(data.expires_in) || data.expires_in < 0)
+	) {
+		throw new Error("MCP OAuth refresh returned an invalid expiry");
+	}
+	return {
+		access: data.access_token,
+		refresh: data.refresh_token || credential.refresh,
+		expires: Date.now() + (data.expires_in ?? 3600) * 1000,
+	};
+}
 
 export type AuthCredentialEntry = AuthCredential | AuthCredential[];
 
@@ -230,6 +331,13 @@ export interface AuthCredentialStore {
 		credential: OAuthCredential,
 		signal?: AbortSignal,
 	): Promise<OAuthCredentials>;
+	/** Broker-backed MCP refresh using the broker's stored token endpoint and refresh secret. */
+	refreshMCPOAuthCredential?(
+		credentialId: number,
+		credential: OAuthCredential,
+		client: MCPOAuthRefreshClient,
+		signal?: AbortSignal,
+	): Promise<OAuthCredential>;
 	/**
 	 * Optional async pre-read hook invoked after AuthStorage selects a stored
 	 * credential but before it returns that credential for an outbound request.
@@ -632,7 +740,9 @@ function authCredentialEquals(left: AuthCredential, right: AuthCredential): bool
 		left.accountId === right.accountId &&
 		left.email === right.email &&
 		left.projectId === right.projectId &&
-		left.enterpriseUrl === right.enterpriseUrl
+		left.enterpriseUrl === right.enterpriseUrl &&
+		left.mcpBinding?.resourceOrigin === right.mcpBinding?.resourceOrigin &&
+		left.mcpBinding?.tokenEndpoint === right.mcpBinding?.tokenEndpoint
 	);
 }
 
@@ -3009,6 +3119,8 @@ export class AuthStorage {
 		const overrideRefresh = this.#refreshOAuthCredentialOverride ?? storeRefresh;
 		if (overrideRefresh && credentialId !== undefined) {
 			refreshPromise = overrideRefresh(provider, credentialId, credential, signal);
+		} else if (credential.mcpBinding) {
+			refreshPromise = refreshBoundMCPOAuthCredential(credential, {}, signal);
 		} else {
 			const customProvider = getOAuthProvider(provider);
 			if (customProvider) {
@@ -3518,14 +3630,18 @@ export class AuthStorage {
 	 * refresh attempt, which is required for providers that rotate refresh tokens
 	 * on every successful refresh.
 	 */
-	async refreshCredentialById(id: number, signal?: AbortSignal): Promise<AuthCredentialSnapshotEntry> {
+	async refreshCredentialById(
+		id: number,
+		signal?: AbortSignal,
+		mcpClient: MCPOAuthRefreshClient = {},
+	): Promise<AuthCredentialSnapshotEntry> {
 		const existing = this.#oauthRefreshInFlight.get(id);
 		if (existing) return raceCredentialRefreshWithSignal(existing, signal);
 
 		const promise = (async () => {
 			this.#bumpGeneration("credential-refresh-start");
 			try {
-				return await this.#forceRefreshCredentialByIdUnshared(id, signal);
+				return await this.#forceRefreshCredentialByIdUnshared(id, signal, mcpClient);
 			} catch (error) {
 				this.#bumpGeneration("credential-refresh-failure");
 				throw error;
@@ -3549,7 +3665,32 @@ export class AuthStorage {
 		return this.refreshCredentialById(id, signal);
 	}
 
-	async #forceRefreshCredentialByIdUnshared(id: number, signal?: AbortSignal): Promise<AuthCredentialSnapshotEntry> {
+	/** Force-refresh the first OAuth credential stored for a provider. */
+	async forceRefreshOAuthCredential(
+		provider: string,
+		expected: OAuthCredential,
+		client: MCPOAuthRefreshClient = {},
+		signal?: AbortSignal,
+	): Promise<OAuthCredential> {
+		const storageProvider = resolveOAuthStorageProvider(provider);
+		const target = this.#getStoredCredentials(storageProvider).find(
+			entry => entry.credential === expected || authCredentialEquals(entry.credential, expected),
+		);
+		if (target?.credential.type !== "oauth") {
+			throw new Error(`No OAuth credential found for provider=${storageProvider}`);
+		}
+		const entry = await this.refreshCredentialById(target.id, signal, client);
+		if (entry.credential.type !== "oauth") {
+			throw new Error(`Credential ${target.id} is not OAuth`);
+		}
+		return entry.credential;
+	}
+
+	async #forceRefreshCredentialByIdUnshared(
+		id: number,
+		signal?: AbortSignal,
+		mcpClient: MCPOAuthRefreshClient = {},
+	): Promise<AuthCredentialSnapshotEntry> {
 		for (const [provider, entries] of this.#data) {
 			const index = entries.findIndex(entry => entry.id === id);
 			if (index === -1) continue;
@@ -3560,7 +3701,27 @@ export class AuthStorage {
 			// Pass a clone with expires=0 so the cached not-yet-expired short-circuit
 			// in #refreshOAuthCredential doesn't suppress the requested refresh.
 			const stale: OAuthCredential = { ...target.credential, expires: 0 };
-			const refreshed = await this.#refreshOAuthCredential(provider as Provider, stale, id, signal);
+			let refreshed: OAuthCredentials;
+			if (target.credential.mcpBinding) {
+				assertCanonicalMCPOAuthBinding(target.credential.mcpBinding);
+				const remoteRefresh = this.#store.refreshMCPOAuthCredential?.bind(this.#store);
+				const refreshedCredential = remoteRefresh
+					? await remoteRefresh(id, stale, mcpClient, signal)
+					: {
+							type: "oauth" as const,
+							...(await refreshBoundMCPOAuthCredential(stale, mcpClient, signal)),
+							mcpBinding: target.credential.mcpBinding,
+						};
+				if (
+					refreshedCredential.mcpBinding?.resourceOrigin !== target.credential.mcpBinding.resourceOrigin ||
+					refreshedCredential.mcpBinding.tokenEndpoint !== target.credential.mcpBinding.tokenEndpoint
+				) {
+					throw new Error("Refreshed MCP OAuth credential binding mismatch");
+				}
+				refreshed = refreshedCredential;
+			} else {
+				refreshed = await this.#refreshOAuthCredential(provider as Provider, stale, id, signal);
+			}
 			const updated: OAuthCredential = {
 				type: "oauth",
 				access: refreshed.access,
@@ -3570,6 +3731,7 @@ export class AuthStorage {
 				email: refreshed.email ?? target.credential.email,
 				projectId: refreshed.projectId ?? target.credential.projectId,
 				enterpriseUrl: refreshed.enterpriseUrl ?? target.credential.enterpriseUrl,
+				mcpBinding: target.credential.mcpBinding,
 			};
 			this.#replaceCredentialAt(provider, index, updated);
 			return {

--- a/packages/ai/test/auth-broker-refresher.test.ts
+++ b/packages/ai/test/auth-broker-refresher.test.ts
@@ -92,6 +92,31 @@ describe("AuthBrokerRefresher", () => {
 		expect(refreshSpy).not.toHaveBeenCalled();
 	});
 
+	test("does not sweep MCP-bound credentials without transient client metadata", async () => {
+		const now = 1_700_000_000_000;
+		store!.replaceAuthCredentialsForProvider("mcp_oauth_bound", [
+			{
+				type: "oauth",
+				access: "old",
+				refresh: "client-authenticated-refresh",
+				expires: now + 60_000,
+				mcpBinding: {
+					resourceOrigin: "https://mcp.example",
+					tokenEndpoint: "https://auth.example/token",
+				},
+			},
+		]);
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		storage = new AuthStorage(store!);
+		await storage.reload();
+		const refresher = new AuthBrokerRefresher({ storage, refreshSkewMs: 5 * 60_000, now: () => now });
+
+		await refresher.tick();
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(storage.exportSnapshot().credentials).toHaveLength(1);
+	});
+
 	test("disables credentials on definitive failure (invalid_grant)", async () => {
 		const now = 1_700_000_000_000;
 		store!.saveOAuth("anthropic", {

--- a/packages/ai/test/auth-broker-wire.test.ts
+++ b/packages/ai/test/auth-broker-wire.test.ts
@@ -8,6 +8,7 @@ import {
 	AuthBrokerStreamUnsupportedError,
 	AuthStorage,
 	REMOTE_REFRESH_SENTINEL,
+	RemoteAuthCredentialStore,
 	type SnapshotStreamEvent,
 	SqliteAuthCredentialStore,
 	startAuthBroker,
@@ -89,6 +90,85 @@ describe("auth-broker wire surface", () => {
 			expect(entry.credential.access).toBe("access-a");
 			// Refresh token is replaced with the wire sentinel — clients never see it.
 			expect(entry.credential.refresh).toBe(REMOTE_REFRESH_SENTINEL);
+		}
+	});
+
+	test("broker refresh posts the real secret only to the stored MCP token endpoint and preserves binding", async () => {
+		let requestBody = "";
+		const tokenServer = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				requestBody = await request.text();
+				return Response.json({
+					access_token: "rotated-access",
+					refresh_token: "rotated-refresh",
+					expires_in: 3600,
+				});
+			},
+		});
+		const client = new AuthBrokerClient({ url: handle!.url, token });
+		const provider = "mcp_oauth_remote";
+		const mcpBinding = {
+			resourceOrigin: "https://mcp.example",
+			tokenEndpoint: tokenServer.url.href,
+		};
+
+		let clientStorage: AuthStorage | undefined;
+		let streamIterator: AsyncIterator<SnapshotStreamEvent> | undefined;
+		try {
+			const uploaded = await client.uploadCredential(provider, {
+				type: "oauth",
+				access: "old-access",
+				refresh: "broker-refresh-secret",
+				expires: Date.now() - 1,
+				mcpBinding,
+			});
+			const id = uploaded.entries[0]?.id;
+			if (id === undefined) throw new Error("expected uploaded credential");
+			const initial = await client.fetchSnapshot();
+			if (initial.status !== 200) throw new Error("expected snapshot");
+			const remoteStore = new RemoteAuthCredentialStore({ client, initialSnapshot: initial.snapshot });
+			clientStorage = new AuthStorage(remoteStore);
+			await clientStorage.reload();
+			const expected = clientStorage.get(provider);
+			if (expected?.type !== "oauth") throw new Error("expected remote OAuth credential");
+			streamIterator = client.openSnapshotStream()[Symbol.asyncIterator]();
+			await streamIterator.next();
+
+			const refreshed = await clientStorage.forceRefreshOAuthCredential(provider, expected, {
+				clientId: "remote-client",
+				clientSecret: "REMOTE_CLIENT_SECRET",
+			});
+			expect(requestBody).toContain("refresh_token=broker-refresh-secret");
+			expect(requestBody).not.toContain(REMOTE_REFRESH_SENTINEL);
+			expect(requestBody).toContain("client_id=remote-client");
+			expect(requestBody).toContain("client_secret=REMOTE_CLIENT_SECRET");
+			expect(refreshed).toMatchObject({
+				type: "oauth",
+				access: "rotated-access",
+				refresh: REMOTE_REFRESH_SENTINEL,
+				mcpBinding,
+			});
+			const delta = await streamIterator.next();
+			expect(delta.done).toBe(false);
+			expect(JSON.stringify(delta.value)).not.toContain("REMOTE_CLIENT_SECRET");
+
+			const snapshot = await client.fetchSnapshot();
+			if (snapshot.status !== 200) throw new Error("expected snapshot");
+			expect(snapshot.snapshot.credentials.find(entry => entry.id === id)?.credential).toMatchObject({
+				access: "rotated-access",
+				mcpBinding,
+			});
+			expect(JSON.stringify(snapshot.snapshot)).not.toContain("REMOTE_CLIENT_SECRET");
+			expect(store!.listAuthCredentials(provider)[0]?.credential).toMatchObject({
+				access: "rotated-access",
+				refresh: "rotated-refresh",
+				mcpBinding,
+			});
+		} finally {
+			await streamIterator?.return?.();
+			clientStorage?.close();
+			await tokenServer.stop(true);
 		}
 	});
 

--- a/packages/ai/test/auth-storage-mcp-origin.test.ts
+++ b/packages/ai/test/auth-storage-mcp-origin.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { oauthCredentialSchema, remoteOauthCredentialSchema } from "../src/auth-broker/wire-schemas";
+import { AuthStorage, REMOTE_REFRESH_SENTINEL, SqliteAuthCredentialStore } from "../src/auth-storage";
+
+describe("MCP OAuth credential binding persistence", () => {
+	let tempDir = "";
+
+	afterEach(async () => {
+		if (tempDir) await fs.rm(tempDir, { recursive: true, force: true });
+		tempDir = "";
+	});
+
+	test("preserves the bound MCP and token endpoints across storage reopen", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-mcp-oauth-origin-"));
+		const dbPath = path.join(tempDir, "agent.db");
+		const provider = "mcp_oauth_test";
+		const firstStore = await SqliteAuthCredentialStore.open(dbPath);
+		firstStore.replaceAuthCredentialsForProvider(provider, [
+			{
+				type: "oauth",
+				access: "access",
+				refresh: "refresh",
+				expires: Date.now() + 60_000,
+				mcpBinding: {
+					resourceOrigin: "https://mcp.example",
+					tokenEndpoint: "https://auth.example/token",
+				},
+			},
+		]);
+		firstStore.close();
+
+		const reopenedStore = await SqliteAuthCredentialStore.open(dbPath);
+		try {
+			expect(reopenedStore.listAuthCredentials(provider)[0]?.credential).toMatchObject({
+				type: "oauth",
+				mcpBinding: {
+					resourceOrigin: "https://mcp.example",
+					tokenEndpoint: "https://auth.example/token",
+				},
+			});
+		} finally {
+			reopenedStore.close();
+		}
+	});
+
+	test("rejects malformed or noncanonical bindings on upload, snapshot, and refresh", async () => {
+		const invalidBindings = [
+			{ resourceOrigin: "not-a-url", tokenEndpoint: "https://auth.example/token" },
+			{ resourceOrigin: "https://user@mcp.example", tokenEndpoint: "https://auth.example/token" },
+			{ resourceOrigin: "https://mcp.example/", tokenEndpoint: "https://auth.example/token" },
+			{ resourceOrigin: "https://mcp.example", tokenEndpoint: "https://auth.example:443/token" },
+			{ resourceOrigin: "https://mcp.example", tokenEndpoint: "https://user:pass@auth.example/token" },
+		];
+		for (const mcpBinding of invalidBindings) {
+			const credential = { type: "oauth" as const, access: "access", expires: 0, mcpBinding };
+			expect(oauthCredentialSchema.safeParse({ ...credential, refresh: "refresh" }).success).toBe(false);
+			expect(
+				remoteOauthCredentialSchema.safeParse({ ...credential, refresh: REMOTE_REFRESH_SENTINEL }).success,
+			).toBe(false);
+		}
+
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-mcp-oauth-invalid-binding-"));
+		const storage = new AuthStorage(await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db")));
+		await storage.reload();
+		await storage.set("mcp_oauth_invalid", {
+			type: "oauth",
+			access: "old-access",
+			refresh: "refresh",
+			expires: 0,
+			mcpBinding: invalidBindings[4],
+		});
+		const credential = storage.get("mcp_oauth_invalid");
+		if (credential?.type !== "oauth") throw new Error("expected OAuth credential");
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		try {
+			await expect(storage.forceRefreshOAuthCredential("mcp_oauth_invalid", credential)).rejects.toThrow(
+				"Invalid MCP OAuth credential binding",
+			);
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			storage.close();
+			fetchSpy.mockRestore();
+		}
+	});
+
+	test("refreshes a local MCP credential through its stored token endpoint and preserves its binding", async () => {
+		let requestBody = "";
+		const tokenServer = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				requestBody = await request.text();
+				return Response.json({ access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600 });
+			},
+		});
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-mcp-oauth-refresh-"));
+		const dbPath = path.join(tempDir, "agent.db");
+		const provider = "mcp_oauth_local";
+		const binding = {
+			resourceOrigin: "https://mcp.example",
+			tokenEndpoint: tokenServer.url.href,
+		};
+		const storage = new AuthStorage(await SqliteAuthCredentialStore.open(dbPath));
+		await storage.reload();
+		await storage.set(provider, {
+			type: "oauth",
+			access: "old-access",
+			refresh: "local-refresh-secret",
+			expires: Date.now() - 1,
+			mcpBinding: binding,
+		});
+
+		try {
+			const credential = storage.get(provider);
+			if (credential?.type !== "oauth") throw new Error("expected OAuth credential");
+			const refreshed = await storage.forceRefreshOAuthCredential(provider, credential, {
+				clientId: "bound-client",
+				clientSecret: "bound-secret",
+			});
+			expect(refreshed).toMatchObject({ access: "new-access", mcpBinding: binding });
+			expect(requestBody).toContain("refresh_token=local-refresh-secret");
+			expect(requestBody).toContain("client_id=bound-client");
+			expect(requestBody).toContain("client_secret=bound-secret");
+			expect(storage.get(provider)).toMatchObject({
+				access: "new-access",
+				refresh: "new-refresh",
+				mcpBinding: binding,
+			});
+		} finally {
+			storage.close();
+			await tokenServer.stop(true);
+		}
+	});
+
+	test("rejects 307 and 308 redirects without forwarding MCP refresh credentials", async () => {
+		const forwardedBodies: string[] = [];
+		const redirectTarget = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				forwardedBodies.push(await request.text());
+				return Response.json({ access_token: "attacker-access" });
+			},
+		});
+		let redirectStatus = 307;
+		let tokenEndpointCalls = 0;
+		const tokenServer = Bun.serve({
+			port: 0,
+			fetch() {
+				tokenEndpointCalls++;
+				return new Response(null, {
+					status: redirectStatus,
+					headers: { Location: redirectTarget.url.href },
+				});
+			},
+		});
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-mcp-oauth-redirect-"));
+		const provider = "mcp_oauth_redirect";
+		const storage = new AuthStorage(await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db")));
+		await storage.reload();
+		await storage.set(provider, {
+			type: "oauth",
+			access: "old-access",
+			refresh: "redirect-refresh-secret",
+			expires: 0,
+			mcpBinding: {
+				resourceOrigin: "https://mcp.example",
+				tokenEndpoint: tokenServer.url.href,
+			},
+		});
+
+		try {
+			for (redirectStatus of [307, 308]) {
+				const credential = storage.get(provider);
+				if (credential?.type !== "oauth") throw new Error("expected OAuth credential");
+				await expect(
+					storage.forceRefreshOAuthCredential(
+						provider,
+						credential,
+						{ clientId: "redirect-client", clientSecret: "redirect-client-secret" },
+						undefined,
+					),
+				).rejects.toThrow(`MCP OAuth refresh rejected redirect response (${redirectStatus})`);
+			}
+			expect(tokenEndpointCalls).toBe(2);
+			expect(forwardedBodies).toEqual([]);
+			expect(storage.get(provider)).toMatchObject({
+				access: "old-access",
+				refresh: "redirect-refresh-secret",
+			});
+		} finally {
+			storage.close();
+			await tokenServer.stop(true);
+			await redirectTarget.stop(true);
+		}
+	});
+
+	test("passes caller cancellation to the bound token fetch", async () => {
+		const fetchStarted = Promise.withResolvers<AbortSignal>();
+		const fetchMock = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			const requestSignal = init?.signal;
+			if (!requestSignal) throw new Error("expected refresh fetch signal");
+			fetchStarted.resolve(requestSignal);
+			const pending = Promise.withResolvers<void>();
+			const rejectOnAbort = (): void => pending.reject(new Error("token request aborted"));
+			if (requestSignal.aborted) {
+				rejectOnAbort();
+			} else {
+				requestSignal.addEventListener("abort", rejectOnAbort, { once: true });
+			}
+			await pending.promise;
+			return Response.json({ access_token: "unexpected-access" });
+		};
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-mcp-oauth-abort-"));
+		const provider = "mcp_oauth_abort";
+		const storage = new AuthStorage(await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db")));
+		await storage.reload();
+		await storage.set(provider, {
+			type: "oauth",
+			access: "old-access",
+			refresh: "abort-refresh-secret",
+			expires: 0,
+			mcpBinding: {
+				resourceOrigin: "https://mcp.example",
+				tokenEndpoint: "https://auth.example/token",
+			},
+		});
+		const credential = storage.get(provider);
+		if (credential?.type !== "oauth") throw new Error("expected OAuth credential");
+		const controller = new AbortController();
+
+		try {
+			const refresh = storage.forceRefreshOAuthCredential(provider, credential, {}, controller.signal);
+			expect(await fetchStarted.promise).toBe(controller.signal);
+			controller.abort();
+			await expect(refresh).rejects.toThrow("credential refresh aborted");
+			expect(storage.get(provider)).toMatchObject({
+				access: "old-access",
+				refresh: "abort-refresh-secret",
+			});
+		} finally {
+			storage.close();
+			fetchSpy.mockRestore();
+		}
+	});
+
+	test("rejects invalid refresh payloads through AuthStorage without persisting them", async () => {
+		let payload: unknown;
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation((async () => Response.json(payload)) as unknown as typeof fetch);
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-mcp-oauth-invalid-refresh-"));
+		const storage = new AuthStorage(await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db")));
+		await storage.reload();
+		await storage.set("mcp_oauth_invalid_refresh", {
+			type: "oauth",
+			access: "old-access",
+			refresh: "refresh",
+			expires: 0,
+			mcpBinding: { resourceOrigin: "https://mcp.example", tokenEndpoint: "https://auth.example/token" },
+		});
+		const credential = storage.get("mcp_oauth_invalid_refresh");
+		if (credential?.type !== "oauth") throw new Error("expected OAuth credential");
+		try {
+			for (payload of [
+				null,
+				{},
+				{ access_token: 1 },
+				{ access_token: "" },
+				{ access_token: "access", refresh_token: 1 },
+				{ access_token: "access", expires_in: "3600" },
+				{ access_token: "access", expires_in: -1 },
+			]) {
+				await expect(
+					storage.forceRefreshOAuthCredential("mcp_oauth_invalid_refresh", credential),
+				).rejects.toThrow();
+				const stored = storage.get("mcp_oauth_invalid_refresh");
+				expect(stored?.type === "oauth" ? stored.access : undefined).toBe("old-access");
+			}
+		} finally {
+			storage.close();
+			fetchSpy.mockRestore();
+		}
+	});
+
+	test("refreshes the exact requested credential when a provider has multiple rows", async () => {
+		let firstCalls = 0;
+		let secondCalls = 0;
+		const firstServer = Bun.serve({
+			port: 0,
+			fetch() {
+				firstCalls++;
+				return Response.json({ access_token: "wrong-access" });
+			},
+		});
+		const secondServer = Bun.serve({
+			port: 0,
+			fetch() {
+				secondCalls++;
+				return Response.json({ access_token: "second-access" });
+			},
+		});
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-mcp-oauth-exact-"));
+		const storage = new AuthStorage(await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db")));
+		await storage.reload();
+		const first = {
+			type: "oauth" as const,
+			access: "first-old",
+			refresh: "first-refresh",
+			expires: 0,
+			accountId: "first",
+			mcpBinding: { resourceOrigin: "https://first.example", tokenEndpoint: firstServer.url.href },
+		};
+		const second = {
+			type: "oauth" as const,
+			access: "second-old",
+			refresh: "second-refresh",
+			expires: 0,
+			accountId: "second",
+			mcpBinding: { resourceOrigin: "https://second.example", tokenEndpoint: secondServer.url.href },
+		};
+		await storage.set("mcp_oauth_multiple", [first, second]);
+
+		try {
+			const refreshed = await storage.forceRefreshOAuthCredential("mcp_oauth_multiple", second);
+			expect(refreshed.access).toBe("second-access");
+			expect(firstCalls).toBe(0);
+			expect(secondCalls).toBe(1);
+		} finally {
+			storage.close();
+			await firstServer.stop(true);
+			await secondServer.stop(true);
+		}
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Runtime MCP OAuth credentials are now bound to their authorized server origin and token endpoint, reject redirecting refresh responses, and fail closed when legacy or changed configuration lacks an exact match.
 - Telegram notification daemon self-heals degraded on-disk state: permanently missing scan roots are pruned (so one deleted worktree no longer disables orphan-topic cleanup), and retained exact-unlink transition/placeholder artifacts are reaped on ownership acquire and each scan. `gjc daemon reload` can recover without manual filesystem surgery (#2956).
 - On macOS, resuming a managed session no longer fails with `identity_mismatch` when the first write-append open changes only file `ctime` (e.g. APFS write-provenance / `com.apple.provenance`). `appendSync` allows a single bounded re-capture + retry when `dev`/`ino`/`size`/`mtime`/SHA-256 remain unchanged, and still rejects real content races and repeated ctime transitions (#2944).
 - Interactive `/resume` / `AgentSession.switchSession()` now awaits verified managed `local://` legacy-root migration for the newly selected session before post-commit lifecycle proceeds, matching cold-start `createAgentSession()` readiness from #2797 so synchronous `local://` resolution no longer fails with "legacy migration must complete before path resolution" after a mid-session switch (#2925).

--- a/packages/coding-agent/src/modes/components/runtime-mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/runtime-mcp-add-wizard.ts
@@ -60,6 +60,7 @@ type WizardStep =
  */
 export interface MCPAddWizardOAuthResult {
 	credentialId: string;
+	tokenEndpoint: string;
 	clientId?: string;
 	clientSecret?: string;
 }
@@ -122,6 +123,7 @@ export class MCPAddWizard extends Container {
 	#onCancelCallback: () => void;
 	#onOAuthCallback:
 		| ((
+				endpointUrl: string,
 				authUrl: string,
 				tokenUrl: string,
 				clientId: string,
@@ -141,6 +143,7 @@ export class MCPAddWizard extends Container {
 		onComplete: (name: string, config: MCPServerConfig, scope: Scope) => void,
 		onCancel: () => void,
 		onOAuth?: (
+			endpointUrl: string,
 			authUrl: string,
 			tokenUrl: string,
 			clientId: string,
@@ -1189,6 +1192,7 @@ export class MCPAddWizard extends Container {
 		try {
 			// Call OAuth handler
 			const oauthResult = await this.#onOAuthCallback(
+				this.#state.url,
 				this.#state.oauthAuthUrl,
 				this.#state.oauthTokenUrl,
 				this.#state.oauthClientId,
@@ -1200,6 +1204,7 @@ export class MCPAddWizard extends Container {
 			// Store credential ID + any dynamically-registered client credentials,
 			// so the final mcp.json entry persists everything needed for refresh.
 			this.#state.oauthCredentialId = oauthResult.credentialId;
+			this.#state.oauthTokenUrl = oauthResult.tokenEndpoint;
 			if (oauthResult.clientId) this.#state.oauthClientId = oauthResult.clientId;
 			if (oauthResult.clientSecret) this.#state.oauthClientSecret = oauthResult.clientSecret;
 

--- a/packages/coding-agent/src/modes/controllers/runtime-mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/runtime-mcp-command-controller.ts
@@ -4,6 +4,7 @@
  * Handles /mcp subcommands for managing MCP servers.
  */
 import * as path from "node:path";
+import { resolveMCPOAuthResourceOrigin, resolveMCPOAuthTokenEndpoint } from "@gajae-code/ai";
 import { Spacer, Text } from "@gajae-code/tui";
 import { getMCPConfigPath, getProjectDir } from "@gajae-code/utils";
 import type { SourceMeta } from "../../capability/types";
@@ -61,6 +62,7 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string)
  */
 interface OAuthFlowResult {
 	credentialId: string;
+	tokenEndpoint: string;
 	clientId?: string;
 	clientSecret?: string;
 }
@@ -423,6 +425,7 @@ export class MCPCommandController {
 						try {
 							const oauthClientSecret = finalConfig.oauth?.clientSecret ?? "";
 							const oauthResult = await this.#handleOAuthFlow(
+								finalConfig.url,
 								oauth.authorizationUrl,
 								oauth.tokenUrl,
 								oauth.clientId ?? finalConfig.oauth?.clientId ?? "",
@@ -439,7 +442,7 @@ export class MCPCommandController {
 								auth: {
 									type: "oauth",
 									credentialId: oauthResult.credentialId,
-									tokenUrl: oauth.tokenUrl,
+									tokenUrl: oauthResult.tokenEndpoint,
 									clientId: persistedClientId,
 									clientSecret: persistedClientSecret,
 								},
@@ -480,8 +483,15 @@ export class MCPCommandController {
 				done();
 				this.#handleWizardCancel();
 			},
-			async (authUrl: string, tokenUrl: string, clientId: string, clientSecret: string, scopes: string) => {
-				return await this.#handleOAuthFlow(authUrl, tokenUrl, clientId, clientSecret, scopes);
+			async (
+				endpointUrl: string,
+				authUrl: string,
+				tokenUrl: string,
+				clientId: string,
+				clientSecret: string,
+				scopes: string,
+			) => {
+				return await this.#handleOAuthFlow(endpointUrl, authUrl, tokenUrl, clientId, clientSecret, scopes);
 			},
 			async (config: MCPServerConfig) => {
 				return await this.#handleTestConnection(config);
@@ -503,6 +513,7 @@ export class MCPCommandController {
 	 * Handle OAuth authentication flow for MCP server
 	 */
 	async #handleOAuthFlow(
+		endpointUrl: string,
 		authUrl: string,
 		tokenUrl: string,
 		clientId: string,
@@ -514,11 +525,13 @@ export class MCPCommandController {
 	): Promise<OAuthFlowResult> {
 		const authStorage = this.ctx.session.modelRegistry.authStorage;
 		let parsedAuthUrl: URL;
+		const resourceOrigin = resolveMCPOAuthResourceOrigin(endpointUrl);
+		const tokenEndpoint = resolveMCPOAuthTokenEndpoint(tokenUrl);
+		if (!resourceOrigin || !tokenEndpoint) throw new Error("Invalid MCP OAuth configuration.");
 
 		// Validate OAuth URLs
 		try {
 			parsedAuthUrl = new URL(authUrl);
-			new URL(tokenUrl);
 		} catch (_error) {
 			throw new Error(
 				`Invalid OAuth URLs. Please check:\n  Authorization URL: ${authUrl}\n  Token URL: ${tokenUrl}`,
@@ -533,7 +546,7 @@ export class MCPCommandController {
 			const flow = new MCPOAuthFlow(
 				{
 					authorizationUrl: authUrl,
-					tokenUrl: tokenUrl,
+					tokenUrl: tokenEndpoint,
 					clientId: resolvedClientId,
 					clientSecret: resolvedClientSecret,
 					scopes: scopes || undefined,
@@ -618,6 +631,10 @@ export class MCPCommandController {
 			const oauthCredential: OAuthCredential = {
 				type: "oauth",
 				...credentials,
+				mcpBinding: {
+					resourceOrigin,
+					tokenEndpoint,
+				},
 			};
 
 			// Store under a synthetic provider name
@@ -625,6 +642,7 @@ export class MCPCommandController {
 
 			return {
 				credentialId,
+				tokenEndpoint,
 				clientId: flow.resolvedClientId,
 				clientSecret: flow.registeredClientSecret,
 			};
@@ -1328,6 +1346,10 @@ export class MCPCommandController {
 				this.ctx.showError(`Server "${name}" is disabled. Run /mcp enable ${name} first.`);
 				return;
 			}
+			if (found.config.type !== "http" && found.config.type !== "sse") {
+				this.ctx.showError(`Server "${name}" does not use a remote MCP transport.`);
+				return;
+			}
 
 			const currentAuth = (found.config as MCPServerConfig & { auth?: MCPAuthConfig }).auth;
 			if (currentAuth?.type === "oauth") {
@@ -1341,6 +1363,7 @@ export class MCPCommandController {
 			this.#showMessage(["", theme.fg("muted", `Reauthorizing "${name}"...`), ""].join("\n"));
 
 			const oauthResult = await this.#handleOAuthFlow(
+				found.config.url,
 				oauth.authorizationUrl,
 				oauth.tokenUrl,
 				oauth.clientId ?? found.config.oauth?.clientId ?? "",
@@ -1359,7 +1382,7 @@ export class MCPCommandController {
 				auth: {
 					type: "oauth",
 					credentialId: oauthResult.credentialId,
-					tokenUrl: oauth.tokenUrl,
+					tokenUrl: oauthResult.tokenEndpoint,
 					clientId: persistedClientId,
 					clientSecret: persistedClientSecret,
 				},

--- a/packages/coding-agent/src/runtime-mcp/manager.ts
+++ b/packages/coding-agent/src/runtime-mcp/manager.ts
@@ -6,12 +6,12 @@
  */
 import * as path from "node:path";
 import * as url from "node:url";
-import type { TSchema } from "@gajae-code/ai";
+import { isCanonicalMCPOAuthBinding, resolveMCPOAuthResourceOrigin, type TSchema } from "@gajae-code/ai";
 import { logger } from "@gajae-code/utils";
 import type { SourceMeta } from "../capability/types";
 import * as configValue from "../config/resolve-config-value";
 import type { CustomTool } from "../extensibility/custom-tools/types";
-import type { AuthStorage } from "../session/auth-storage";
+import type { AuthStorage, OAuthCredential } from "../session/auth-storage";
 import {
 	connectToServer,
 	disconnectServer,
@@ -27,7 +27,6 @@ import {
 	unsubscribeFromResources,
 } from "./client";
 import { loadAllMCPConfigs, validateServerConfig } from "./config";
-import { refreshMCPOAuthToken } from "./oauth-flow";
 import type { MCPToolDetails } from "./tool-bridge";
 import { DeferredMCPTool, MCPTool } from "./tool-bridge";
 import type { MCPToolCache } from "./tool-cache";
@@ -1469,64 +1468,63 @@ export class MCPManager {
 		let resolved: MCPServerConfig = { ...config };
 
 		const auth = config.auth;
-		if (auth?.type === "oauth" && auth.credentialId && this.#authStorage) {
+		if (auth?.type === "oauth") {
+			if (!auth.credentialId || !this.#authStorage || (config.type !== "http" && config.type !== "sse")) {
+				throw new MCPExpectedFailure();
+			}
 			const credentialId = auth.credentialId;
 			let credential = this.#authStorage.get(credentialId);
-			if (credential?.type === "oauth") {
-				// Proactive refresh: 5-minute buffer before expiry
-				// Force refresh: on 401/403 auth errors (revoked tokens, clock skew, missing expires)
-				const REFRESH_BUFFER_MS = 5 * 60_000;
-				const shouldRefresh =
-					forceRefresh || (credential.expires && Date.now() >= credential.expires - REFRESH_BUFFER_MS);
-				let refreshedCredential:
-					| {
-							type: "oauth";
-							access: string;
-							refresh: string;
-							expires: number;
-					  }
-					| undefined;
-				if (shouldRefresh && credential.refresh && auth.tokenUrl) {
-					try {
-						const refreshed = await refreshMCPOAuthToken(
-							auth.tokenUrl,
-							credential.refresh,
-							auth.clientId,
-							auth.clientSecret,
-						);
-						refreshedCredential = { type: "oauth", ...refreshed };
-					} catch (error) {
-						if (!(error instanceof MCPExpectedFailure)) throw error;
-						if (this.#toolsOnly) {
-							logger.debug("MCP OAuth refresh failed");
-						} else {
-							logger.warn("MCP OAuth refresh failed, using existing token");
-						}
+			const binding = credential?.type === "oauth" ? credential.mcpBinding : undefined;
+			const endpointOrigin = resolveMCPOAuthResourceOrigin(config.url);
+			if (
+				credential?.type !== "oauth" ||
+				!binding ||
+				!isCanonicalMCPOAuthBinding(binding) ||
+				binding.resourceOrigin !== endpointOrigin ||
+				(auth.tokenUrl !== undefined && auth.tokenUrl !== binding.tokenEndpoint)
+			) {
+				throw new MCPExpectedFailure();
+			}
+
+			// Proactive refresh: 5-minute buffer before expiry
+			// Force refresh: on 401/403 auth errors (revoked tokens, clock skew, missing expires)
+			const REFRESH_BUFFER_MS = 5 * 60_000;
+			const shouldRefresh =
+				forceRefresh || (credential.expires && Date.now() >= credential.expires - REFRESH_BUFFER_MS);
+			if (shouldRefresh && credential.refresh) {
+				let refreshedCredential: OAuthCredential | undefined;
+				try {
+					refreshedCredential = await this.#authStorage.forceRefreshOAuthCredential(credentialId, credential, {
+						clientId: auth.clientId,
+						clientSecret: auth.clientSecret,
+					});
+				} catch {
+					if (forceRefresh) throw new MCPExpectedFailure();
+					if (this.#toolsOnly) {
+						logger.debug("MCP OAuth refresh failed");
+					} else {
+						logger.warn("MCP OAuth refresh failed, using existing token");
 					}
 				}
 				if (refreshedCredential) {
-					await this.#authStorage.set(credentialId, refreshedCredential);
+					const refreshedBinding = refreshedCredential.mcpBinding;
+					if (
+						!refreshedBinding ||
+						refreshedBinding.resourceOrigin !== binding.resourceOrigin ||
+						refreshedBinding.tokenEndpoint !== binding.tokenEndpoint
+					) {
+						throw new MCPExpectedFailure();
+					}
 					credential = refreshedCredential;
 				}
-
-				if (resolved.type === "http" || resolved.type === "sse") {
-					resolved = {
-						...resolved,
-						headers: {
-							...resolved.headers,
-							Authorization: `Bearer ${credential.access}`,
-						},
-					};
-				} else {
-					resolved = {
-						...resolved,
-						env: {
-							...resolved.env,
-							OAUTH_ACCESS_TOKEN: credential.access,
-						},
-					};
-				}
 			}
+			resolved = {
+				...config,
+				headers: {
+					...config.headers,
+					Authorization: `Bearer ${credential.access}`,
+				},
+			};
 		}
 		if (this.#toolsOnly && resolved.type === "stdio") {
 			resolved = { ...resolved, noInheritEnv: true };

--- a/packages/coding-agent/src/runtime-mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/runtime-mcp/oauth-flow.ts
@@ -8,29 +8,10 @@
 import type { OAuthCallbackFlowOptions } from "@gajae-code/ai/utils/oauth/callback-server";
 import { OAuthCallbackFlow } from "@gajae-code/ai/utils/oauth/callback-server";
 import type { OAuthController, OAuthCredentials } from "@gajae-code/ai/utils/oauth/types";
-import { MCPExpectedFailure } from "./types";
 
 const DEFAULT_PORT = 3000;
 const CALLBACK_PATH = "/callback";
 const CALLBACK_BIND_HOSTNAME = "127.0.0.1";
-type RefreshTokenResponse = {
-	access_token: string;
-	refresh_token?: string;
-	expires_in?: number;
-};
-
-function isRefreshTokenResponse(value: unknown): value is RefreshTokenResponse {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-	const payload = value as Record<string, unknown>;
-	return (
-		typeof payload.access_token === "string" &&
-		payload.access_token.length > 0 &&
-		(payload.refresh_token === undefined || typeof payload.refresh_token === "string") &&
-		(payload.expires_in === undefined ||
-			(typeof payload.expires_in === "number" && Number.isFinite(payload.expires_in) && payload.expires_in >= 0))
-	);
-}
-
 function isLoopbackHostname(hostname: string): boolean {
 	return hostname === "localhost" || hostname === "127.0.0.1";
 }
@@ -383,57 +364,4 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 			// Ignore network/probe failures to avoid blocking flows that still work.
 		}
 	}
-}
-
-/**
- * Refresh an MCP OAuth token using the standard refresh_token grant.
- * Returns updated credentials; preserves the old refresh token if the server doesn't rotate it.
- */
-export async function refreshMCPOAuthToken(
-	tokenUrl: string,
-	refreshToken: string,
-	clientId?: string,
-	clientSecret?: string,
-): Promise<OAuthCredentials> {
-	const params = new URLSearchParams({
-		grant_type: "refresh_token",
-		refresh_token: refreshToken,
-	});
-	if (clientId) params.set("client_id", clientId);
-	if (clientSecret) params.set("client_secret", clientSecret);
-
-	let response: Response;
-	try {
-		response = await fetch(tokenUrl, {
-			method: "POST",
-			headers: { "Content-Type": "application/x-www-form-urlencoded" },
-			body: params.toString(),
-		});
-	} catch (error) {
-		throw new MCPExpectedFailure(error);
-	}
-
-	if (!response.ok) {
-		let text: string;
-		try {
-			text = await response.text();
-		} catch (error) {
-			throw new MCPExpectedFailure(error);
-		}
-		throw new MCPExpectedFailure(new Error(`MCP OAuth refresh failed: ${response.status} ${text}`));
-	}
-
-	let data: unknown;
-	try {
-		data = await response.json();
-	} catch {
-		throw new MCPExpectedFailure();
-	}
-	if (!isRefreshTokenResponse(data)) throw new MCPExpectedFailure();
-	const expiresIn = data.expires_in ?? 3600;
-	return {
-		access: data.access_token,
-		refresh: data.refresh_token ?? refreshToken,
-		expires: Date.now() + expiresIn * 1000,
-	};
 }

--- a/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
@@ -7,7 +7,6 @@ import * as configValue from "../../src/config/resolve-config-value";
 import { loadMCPJsonFile } from "../../src/discovery/mcp-json";
 import * as mcpClient from "../../src/runtime-mcp/client";
 import { createMCPManager, MCPManager } from "../../src/runtime-mcp/manager";
-import { refreshMCPOAuthToken } from "../../src/runtime-mcp/oauth-flow";
 import { MCPTool } from "../../src/runtime-mcp/tool-bridge";
 import type { JsonRpcMessage, MCPServerConfig, MCPServerConnection, MCPTransport } from "../../src/runtime-mcp/types";
 import { MCPExpectedFailure } from "../../src/runtime-mcp/types";
@@ -175,8 +174,11 @@ describe("MCP manager lifecycle cleanup", () => {
 					access: accessToken,
 					refresh: refreshToken,
 					expires: Date.now() - 1,
+					mcpBinding: { resourceOrigin: server.url.origin, tokenEndpoint: tokenUrl },
 				}),
-				set: async () => {},
+				forceRefreshOAuthCredential: async () => {
+					throw new Error(`${rawFailure}:${refreshToken}`);
+				},
 			} as never);
 			await Bun.write(
 				configPath,
@@ -210,64 +212,160 @@ describe("MCP manager lifecycle cleanup", () => {
 		}
 	});
 	test.each([
-		["null root", null],
-		["missing access token", {}],
-		["wrong-typed access token", { access_token: 1 }],
-		["empty access token", { access_token: "" }],
-		["wrong-typed refresh token", { access_token: "access", refresh_token: 1 }],
-		["wrong-typed expiry", { access_token: "access", expires_in: "3600" }],
-		["negative expiry", { access_token: "access", expires_in: -1 }],
-	])("rejects invalid OAuth refresh payloads without persisting credentials: %s", async (_name, payload) => {
-		const cwd = await mkdtempExact("gjc-mcp-oauth-invalid-refresh-");
-		const configPath = join(cwd, "exact.json");
-		const manager = new MCPManager(cwd, null, { toolsOnly: true });
-		const persist = vi.fn(async () => {});
-		const fetchSpy = vi
-			.spyOn(globalThis, "fetch")
-			.mockImplementation((async () => Response.json(payload)) as unknown as typeof fetch);
-		const connectSpy = vi.spyOn(mcpClient, "connectToServer").mockRejectedValue(new MCPExpectedFailure());
+		{
+			name: "missing HTTP binding",
+			type: "http" as const,
+			binding: undefined,
+			tokenUrl: "https://tokens.example/refresh",
+		},
+		{
+			name: "mismatched HTTP origin",
+			type: "http" as const,
+			binding: { resourceOrigin: "https://other.example", tokenEndpoint: "https://tokens.example/refresh" },
+			tokenUrl: "https://tokens.example/refresh",
+		},
+		{
+			name: "missing SSE binding",
+			type: "sse" as const,
+			binding: undefined,
+			tokenUrl: "https://tokens.example/refresh",
+		},
+		{
+			name: "tampered token endpoint",
+			type: "http" as const,
+			binding: { resourceOrigin: "https://mcp.example", tokenEndpoint: "https://tokens.example/refresh" },
+			tokenUrl: "https://attacker.example/refresh",
+		},
+	])("fails closed without refreshing an OAuth credential with $name", async ({ type, binding, tokenUrl }) => {
+		const manager = new MCPManager(process.cwd());
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		const forceRefresh = vi.fn(async () => {
+			throw new Error("must not refresh");
+		});
+		const access = "BOUNDARY_ACCESS_VALUE";
+		const refresh = "BOUNDARY_REFRESH_VALUE";
+		manager.setAuthStorage({
+			get: () => ({
+				type: "oauth",
+				access,
+				refresh,
+				expires: Date.now() - 1,
+				...(binding ? { mcpBinding: binding } : {}),
+			}),
+			forceRefreshOAuthCredential: forceRefresh,
+		} as never);
 
 		try {
-			const refreshError = await refreshMCPOAuthToken("https://example.test/token", "refresh").then(
-				() => new Error("Expected OAuth refresh to reject"),
-				error => error,
-			);
-			expect(refreshError).toBeInstanceOf(MCPExpectedFailure);
-			const expectedFailure = refreshError as MCPExpectedFailure;
-			expect(expectedFailure.message).toBe("MCP server operation failed");
-			expect(expectedFailure.cause).toBeUndefined();
-
-			manager.setAuthStorage({
-				get: () => ({
-					type: "oauth",
-					access: "access",
-					refresh: "refresh",
-					expires: Date.now() - 1,
-				}),
-				set: persist,
-			} as never);
-			await Bun.write(
-				configPath,
-				JSON.stringify({
-					mcpServers: {
-						oauth: {
-							type: "http",
-							url: "http://127.0.0.1:1",
-							auth: { type: "oauth", credentialId: "credential", tokenUrl: "https://example.test/token" },
-						},
+			const failure = await manager
+				.prepareConfig({
+					type,
+					url: "https://mcp.example/path",
+					headers: { "X-Public": "value" },
+					auth: {
+						type: "oauth",
+						credentialId: "BOUNDARY_CREDENTIAL_ID",
+						tokenUrl,
 					},
-				}),
-			);
+				})
+				.then(
+					() => new Error("Expected OAuth binding validation to reject"),
+					error => error,
+				);
 
-			const result = await manager.discoverAndConnect({ configPath });
-			expect(result.errors.get("oauth")).toBe("MCP server unavailable");
-			expect(persist).not.toHaveBeenCalled();
-			expect(connectSpy).toHaveBeenCalledTimes(1);
-			expect(fetchSpy).toHaveBeenCalledTimes(2);
+			expect(failure).toBeInstanceOf(MCPExpectedFailure);
+			expect((failure as MCPExpectedFailure).message).toBe("MCP server operation failed");
+			expect((failure as MCPExpectedFailure).cause).toBeUndefined();
+			expect(fetchSpy).not.toHaveBeenCalled();
+			expect(forceRefresh).not.toHaveBeenCalled();
+			const diagnostics = JSON.stringify(failure);
+			for (const value of [access, refresh, "BOUNDARY_CREDENTIAL_ID", tokenUrl]) {
+				expect(diagnostics).not.toContain(value);
+			}
 		} finally {
-			await manager.disconnectAll();
 			vi.restoreAllMocks();
-			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+	test("refreshes and injects OAuth only for the exact bound endpoint origin", async () => {
+		const manager = new MCPManager(process.cwd());
+		const forceRefresh = vi.fn(async () => ({
+			type: "oauth" as const,
+			access: "new-access",
+			refresh: "new-refresh",
+			expires: Date.now() + 3_600_000,
+			mcpBinding: {
+				resourceOrigin: "https://mcp.example",
+				tokenEndpoint: "https://tokens.example/refresh",
+			},
+		}));
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		manager.setAuthStorage({
+			get: () => ({
+				type: "oauth",
+				access: "old-access",
+				refresh: "old-refresh",
+				expires: Date.now() - 1,
+				mcpBinding: {
+					resourceOrigin: "https://mcp.example",
+					tokenEndpoint: "https://tokens.example/refresh",
+				},
+			}),
+			forceRefreshOAuthCredential: forceRefresh,
+		} as never);
+
+		try {
+			const resolved = await manager.prepareConfig({
+				type: "http",
+				url: "https://mcp.example/another/path?query=1",
+				auth: {
+					type: "oauth",
+					credentialId: "credential",
+				},
+			});
+
+			if (resolved.type !== "http") throw new Error("Expected HTTP MCP config");
+			expect(resolved.headers?.Authorization).toBe("Bearer new-access");
+			expect(fetchSpy).not.toHaveBeenCalled();
+			expect(forceRefresh).toHaveBeenCalledWith("credential", expect.objectContaining({ access: "old-access" }), {
+				clientId: undefined,
+				clientSecret: undefined,
+			});
+		} finally {
+			vi.restoreAllMocks();
+		}
+	});
+	test("fails closed when authoritative refresh returns a missing MCP binding", async () => {
+		const manager = new MCPManager(process.cwd());
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		manager.setAuthStorage({
+			get: () => ({
+				type: "oauth",
+				access: "old-access",
+				refresh: "__remote__",
+				expires: Date.now() - 1,
+				mcpBinding: {
+					resourceOrigin: "https://mcp.example",
+					tokenEndpoint: "https://tokens.example/refresh",
+				},
+			}),
+			forceRefreshOAuthCredential: async () => ({
+				type: "oauth",
+				access: "untrusted-new-access",
+				refresh: "__remote__",
+				expires: Date.now() + 3_600_000,
+			}),
+		} as never);
+
+		try {
+			await expect(
+				manager.prepareConfig({
+					type: "http",
+					url: "https://mcp.example/path",
+					auth: { type: "oauth", credentialId: "credential" },
+				}),
+			).rejects.toThrow("MCP server operation failed");
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			vi.restoreAllMocks();
 		}
 	});
 	test("propagates unexpected tools-only OAuth resolution failures", async () => {
@@ -365,7 +463,7 @@ describe("MCP manager lifecycle cleanup", () => {
 			await rm(cwd, { recursive: true, force: true });
 		}
 	});
-	test("preserves 401 auth callback failures after connection cleanup", async () => {
+	test("fails closed when a forced 401 refresh fails", async () => {
 		let deleteCount = 0;
 		const server = Bun.serve({
 			port: 0,
@@ -400,20 +498,23 @@ describe("MCP manager lifecycle cleanup", () => {
 		const cwd = await mkdtempExact("gjc-mcp-auth-callback-");
 		const configPath = join(cwd, "exact.json");
 		const manager = new MCPManager(cwd, null, { toolsOnly: true });
-		const failure = new Error("trusted credential storage failure");
-		let credentialLookups = 0;
+		const failure = new Error("SECRET_REFRESH_FAILURE");
+		const forceRefresh = vi.fn(async () => {
+			throw failure;
+		});
 		try {
 			manager.setAuthStorage({
-				get: () => {
-					credentialLookups++;
-					if (credentialLookups === 2) throw failure;
-					return {
-						type: "oauth",
-						access: "access",
-						refresh: "refresh",
-						expires: Date.now() + 60 * 60_000,
-					};
-				},
+				get: () => ({
+					type: "oauth",
+					access: "access",
+					refresh: "refresh",
+					expires: Date.now() + 60 * 60_000,
+					mcpBinding: {
+						resourceOrigin: server.url.origin,
+						tokenEndpoint: "https://auth.example/token",
+					},
+				}),
+				forceRefreshOAuthCredential: forceRefresh,
 			} as never);
 			await Bun.write(
 				configPath,
@@ -428,14 +529,91 @@ describe("MCP manager lifecycle cleanup", () => {
 				}),
 			);
 
-			await expect(manager.discoverAndConnect({ configPath })).rejects.toBe(failure);
-			expect(credentialLookups).toBe(2);
+			const result = await manager.discoverAndConnect({ configPath });
+			expect(result.errors.get("auth")).toBe("MCP server unavailable");
+			expect(JSON.stringify(result.errors)).not.toContain(failure.message);
+			expect(forceRefresh).toHaveBeenCalledTimes(1);
 			expect(deleteCount).toBe(1);
 			expect(manager.getConnectedServers()).toEqual([]);
 		} finally {
 			await manager.disconnectAll();
 			await server.stop(true);
 			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+	test("routes a remote OAuth 401 refresh through authoritative storage", async () => {
+		const authorizationHeaders: string[] = [];
+		const server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				if (request.method === "DELETE") return new Response(null, { status: 204 });
+				if (request.method === "GET") return new Response(null, { status: 405 });
+				const body = await request.text();
+				authorizationHeaders.push(request.headers.get("authorization") ?? "");
+				const rpc = JSON.parse(body) as { id?: string | number; method?: string };
+				if (rpc.method === "initialize") {
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id: rpc.id ?? 0,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "remote-auth-retry", version: "1" },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": "remote-auth-retry-session" } },
+					);
+				}
+				if (rpc.method === "tools/list") return new Response("denied", { status: 401 });
+				return new Response(null, { status: 202 });
+			},
+		});
+		const cwd = await mkdtempExact("gjc-mcp-remote-auth-retry-");
+		const configPath = join(cwd, "exact.json");
+		const manager = new MCPManager(cwd, null, { toolsOnly: true });
+		const binding = { resourceOrigin: server.url.origin, tokenEndpoint: "https://auth.example/token" };
+		const forceRefresh = vi.fn(async () => ({
+			type: "oauth" as const,
+			access: "remote-new-access",
+			refresh: "__remote__",
+			expires: Date.now() + 60 * 60_000,
+			mcpBinding: binding,
+		}));
+		manager.setAuthStorage({
+			get: () => ({
+				type: "oauth",
+				access: "remote-old-access",
+				refresh: "__remote__",
+				expires: Date.now() + 60 * 60_000,
+				mcpBinding: binding,
+			}),
+			forceRefreshOAuthCredential: forceRefresh,
+		} as never);
+
+		try {
+			await Bun.write(
+				configPath,
+				JSON.stringify({
+					mcpServers: {
+						remote: {
+							type: "http",
+							url: server.url.href,
+							auth: { type: "oauth", credentialId: "credential" },
+						},
+					},
+				}),
+			);
+			const result = await manager.discoverAndConnect({ configPath });
+			expect(result.errors.get("remote")).toBe("MCP server unavailable");
+			expect(forceRefresh).toHaveBeenCalledTimes(1);
+			expect(authorizationHeaders).toContain("Bearer remote-old-access");
+			expect(authorizationHeaders).toContain("Bearer remote-new-access");
+		} finally {
+			await manager.disconnectAll();
+			await server.stop(true);
+			await rm(cwd, { recursive: true, force: true });
+			vi.restoreAllMocks();
 		}
 	});
 	test("fails soft per server for malformed HTTP initialize and stdio tools/list results", async () => {


### PR DESCRIPTION
## Summary

Replacement for closed PR #2734, rebuilt as one commit on exact current `dev` (`c12fba3e`).

- bind each runtime MCP OAuth credential to the canonical resource origin and exact token endpoint established at issuance
- reject legacy, foreign, or mismatched bindings across local and broker-backed refresh paths
- send secret-bearing refresh POSTs with `redirect: "manual"` and reject every 3xx response, preventing 307/308 forwarding of refresh/client secrets
- pass caller cancellation through to the bound token fetch
- remove the stdio `OAUTH_ACCESS_TOKEN` injection path

## Review finding addressed

The prior exact head followed 307/308 redirects from the bound token endpoint. This replacement adds live two-server regression coverage proving the redirect target receives zero requests for both status codes, while the stored credential remains unchanged. A separate test proves the exact caller `AbortSignal` reaches `fetch` and aborts the token request.

## Scope

This is the same end-to-end binding contract already reviewed on #2734 plus the narrow redirect/cancellation correction. The 16-file surface is cohesive across issuance, persistence, broker transport, runtime enforcement, and contract tests; it is not an unrelated redesign. No overlapping open PR was found.

## Verification

- 60 focused AI and coding-agent tests passed
- `packages/ai` check passed
- `packages/coding-agent` check passed
- root workspace build passed
- exact 307/308 cross-origin redirect regression: target received 0 requests
- exact caller-signal propagation regression passed
- diff/staged checks passed

Not tested locally: hosted CI matrix and Windows runtime behavior.