### PR TITLE
test(notifications): align Telegram daemon generation pin with production generation 25

### DIFF
--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -2217,9 +2217,11 @@ describe("telegram daemon", () => {
 			}),
 		);
 	}
-	test("keeps wire protocol 3 while typed retained exact-unlink cleanup authority uses generation 24", () => {
+	test("keeps wire protocol 3 while startup dead-root prune + leak-artifact self-heal uses generation 25", () => {
 		expect(NOTIFICATION_PROTOCOL_VERSION).toBe(3);
-		expect(DAEMON_GENERATION).toBe(24);
+		// Production generation advanced to 25 via #2958/#2956 (startup dead-root
+		// prune + leak-artifact self-heal); see DAEMON_GENERATION contract history.
+		expect(DAEMON_GENERATION).toBe(25);
 	});
 
 	test("#2028 reloads a fully-provenanced owner without a generation", async () => {


### PR DESCRIPTION
## Problem
Dev CI run `29980815311` (dev head `c12fba3e712073c94057687fda70a3c9962c0daf`) failed only in job `89122650944` (`test:@gajae-code/coding-agent:shard-6-of-8`): the contract test in `packages/coding-agent/test/notifications-telegram-daemon.test.ts` still named and pinned generation 24 while production `DAEMON_GENERATION` is correctly **25** after merged #2958/#2956 (startup dead-root prune + leak-artifact self-heal on `TelegramNotificationDaemon.run`).

## Fix
Minimal contract-correct test/comment update — production generation is **not** rolled backward:
- Test name: `... typed retained exact-unlink cleanup authority uses generation 24` → `... startup dead-root prune + leak-artifact self-heal uses generation 25`
- Expectation: `expect(DAEMON_GENERATION).toBe(24)` → `toBe(25)` with a comment referencing the #2958/#2956 contract history
- Wire protocol expectation (`NOTIFICATION_PROTOCOL_VERSION === 3`) unchanged

## Evidence (signed)
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts` → **419 pass, 0 fail** (1577 expect() calls)
- `bun run --cwd packages/coding-agent check` (biome + `tsc -p tsconfig.json --noEmit`) → clean, no fixes applied
- Root `bun run build` (all workspaces incl. natives rebuild + `dist/gjc` compile) → all exited 0
- `bun test scripts/telegram-daemon-generation-guard.test.ts` → **34 pass, 0 fail** (337 expect() calls)

Note: job 89122650944 logs were no longer retrievable via the API (404), but the failing assertion is the only generation-24 pin in the tree and matches the reported shard failure exactly.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*