### PR TITLE
fix(coding-agent): bound every docs.rs rustdoc input

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Lean notification verbosity no longer floods remote clients with intermediate tool-turn `turn_stream` frames. Under `/lean`, the latest assistant answer is deferred until `agent_end` (idle); ask lead-ins still flush immediately before inline buttons, and `/verbose` keeps per-turn streaming (including opt-in live frames) (#2863).
 - Ultragoal `complete-goals` no longer reports contradictory next actions when every incomplete story is `blocked` or `review_blocked`. Text and JSON now agree on `next-action=resolve-blockers` with blocked goal IDs/status; failed-only schedules surface `retry-failed`; `execute-goal` always includes a `goal_id` (#2903).
 - Bound each Python tool bridge bearer capability to one active session registration, reject non-canonical or empty bearer credentials before lookup, and rotate authority whenever a retained session replaces its kernel.
+- Bounded docs.rs rustdoc downloads, legacy cache reads, and gzip expansion before parsing or caching; transport-level content encoding is disabled and rejected so Bun cannot decompress outside the explicit output guard.
 
 ## [0.11.7] - 2026-07-22
 ### Added

--- a/packages/coding-agent/src/web/scrapers/docs-rs.ts
+++ b/packages/coding-agent/src/web/scrapers/docs-rs.ts
@@ -299,7 +299,21 @@ async function readCachedRustdocCrate(
 ): Promise<{ crate: RustdocCrate; fetchedAt: string } | null> {
 	const cachePath = getDocsRsCachePath(target);
 	try {
-		const [jsonStr, stat] = await Promise.all([Bun.file(cachePath).text(), fs.stat(cachePath)]);
+		const stat = await fs.stat(cachePath);
+		if (stat.size > MAX_BYTES) {
+			await fs.rm(cachePath, { force: true });
+			return null;
+		}
+
+		const cacheBytes = await Bun.file(cachePath)
+			.slice(0, MAX_BYTES + 1)
+			.arrayBuffer();
+		if (cacheBytes.byteLength > MAX_BYTES) {
+			await fs.rm(cachePath, { force: true });
+			return null;
+		}
+
+		const jsonStr = Buffer.from(cacheBytes).toString("utf-8");
 		const crate = tryParseJson<RustdocCrate>(jsonStr);
 		if (!crate?.index) return null;
 		return { crate, fetchedAt: stat.mtime.toISOString() };
@@ -378,10 +392,21 @@ export const handleDocsRs: SpecialHandler = async (
 		const requestSignal = ptree.combineSignals(signal, timeout * 1000);
 		const response = await fetch(jsonUrl, {
 			signal: requestSignal,
-			headers: { "User-Agent": "gjc-web-fetch/1.0", Accept: "application/gzip" },
+			headers: {
+				"User-Agent": "gjc-web-fetch/1.0",
+				Accept: "application/gzip",
+				"Accept-Encoding": "identity",
+			},
 			redirect: "follow",
+			decompress: false,
 		});
 		if (!response.ok) return null;
+
+		const contentEncoding = response.headers.get("Content-Encoding");
+		if (contentEncoding && contentEncoding.trim().toLowerCase() !== "identity") {
+			await response.body?.cancel();
+			return null;
+		}
 
 		const reader = response.body?.getReader();
 		if (!reader) return null;
@@ -394,13 +419,13 @@ export const handleDocsRs: SpecialHandler = async (
 			chunks.push(value);
 			totalSize += value.length;
 			if (totalSize > MAX_BYTES) {
-				reader.cancel();
-				break;
+				await reader.cancel();
+				return null;
 			}
 		}
 
 		const compressed = Buffer.concat(chunks);
-		const jsonStr = gunzipSync(compressed).toString("utf-8");
+		const jsonStr = gunzipSync(compressed, { maxOutputLength: MAX_BYTES }).toString("utf-8");
 		crate_ = tryParseJson<RustdocCrate>(jsonStr);
 		if (crate_?.index) {
 			await writeCachedRustdocCrate(target, jsonStr);

--- a/packages/coding-agent/test/tools/web-scrapers/docs-rs.test.ts
+++ b/packages/coding-agent/test/tools/web-scrapers/docs-rs.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { gunzipSync, gzipSync } from "node:zlib";
+import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+import { ToolAbortError } from "../../../src/tools/tool-errors";
+import { handleDocsRs } from "../../../src/web/scrapers/docs-rs";
+import { MAX_BYTES } from "../../../src/web/scrapers/types";
+
+const originalAgentDir = getAgentDir();
+let agentDir: string;
+
+function rustdocJson(crateName: string, padding = 0): string {
+	return JSON.stringify({
+		root: 0,
+		crate_version: "1.0.0",
+		index: {
+			0: {
+				name: crateName,
+				docs: `${crateName} docs`,
+				attrs: [],
+				inner: { module: { items: [], is_crate: true } },
+				visibility: "public",
+				deprecation: null,
+			},
+		},
+		paths: {},
+		format_version: 37,
+		padding: "x".repeat(padding),
+	});
+}
+
+function mockGzip(body: Uint8Array): void {
+	vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(body, { status: 200 }));
+}
+
+beforeEach(async () => {
+	agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-docs-rs-"));
+	setAgentDir(agentDir);
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	setAgentDir(originalAgentDir);
+	await fs.rm(agentDir, { recursive: true, force: true });
+});
+
+describe("docs.rs rustdoc gzip bounds", () => {
+	it("rejects concatenated gzip output over MAX_BYTES without caching", async () => {
+		const input = Buffer.alloc(1024 * 1024);
+		const member = gzipSync(input);
+		expect(gunzipSync(Buffer.concat([member, member])).length).toBe(input.length * 2);
+		mockGzip(Buffer.concat(Array.from({ length: MAX_BYTES / input.length + 1 }, () => member)));
+
+		expect(await handleDocsRs("https://docs.rs/output_limit/1.0.0/output_limit/", 20)).toBeNull();
+		expect(await fs.readdir(agentDir)).toEqual([]);
+	});
+
+	it("passes MAX_BYTES from the production handler without allocating it", async () => {
+		const cancel = vi.fn(async () => {});
+		const response = {
+			ok: true,
+			headers: new Headers(),
+			body: { getReader: () => ({ read: async () => ({ done: false, value: { length: MAX_BYTES + 1 } }), cancel }) },
+		} as unknown as Response;
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+
+		expect(await handleDocsRs("https://docs.rs/production_limit/1.0.0/production_limit/", 20)).toBeNull();
+		expect(cancel).toHaveBeenCalledTimes(1);
+		expect(await fs.readdir(agentDir)).toEqual([]);
+	});
+
+	it("renders and caches under-budget rustdoc gzip", async () => {
+		mockGzip(gzipSync(rustdocJson("bounded")));
+
+		const result = await handleDocsRs("https://docs.rs/bounded/1.0.0/bounded/", 20);
+		expect(result?.content).toContain("bounded docs");
+		expect((await fs.readdir(path.join(agentDir, "webcache"))).length).toBe(1);
+	});
+
+	it("removes an oversized legacy cache entry before refetching", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(gzipSync(rustdocJson("initial")), { status: 200 }));
+		const url = "https://docs.rs/legacy_cache/1.0.0/legacy_cache/";
+		const cachePath = path.join(agentDir, "webcache", "docsrs_legacy_cache_1.0.0", "rustdoc.json");
+
+		expect((await handleDocsRs(url, 20))?.content).toContain("initial docs");
+		await fs.truncate(cachePath, MAX_BYTES + 1);
+		fetchSpy.mockResolvedValue(new Response(gzipSync(rustdocJson("refetched")), { status: 200 }));
+
+		expect((await handleDocsRs(url, 20))?.content).toContain("refetched docs");
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+		expect((await fs.stat(cachePath)).size).toBeLessThanOrEqual(MAX_BYTES);
+	});
+
+	it("disables transport decompression and rejects encoded responses", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(gzipSync(rustdocJson("encoded")), {
+				status: 200,
+				headers: { "Content-Encoding": "gzip" },
+			}),
+		);
+
+		expect(await handleDocsRs("https://docs.rs/encoded/1.0.0/encoded/", 20)).toBeNull();
+		const request = fetchSpy.mock.calls[0]?.[1] as BunFetchRequestInit | undefined;
+		expect(request?.decompress).toBe(false);
+		expect(new Headers(request?.headers).get("Accept-Encoding")).toBe("identity");
+		expect(await fs.readdir(agentDir)).toEqual([]);
+	});
+
+	it("preserves caller abort errors", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(new DOMException("Aborted", "AbortError"));
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(
+			handleDocsRs("https://docs.rs/aborted/1.0.0/aborted/", 20, controller.signal),
+		).rejects.toBeInstanceOf(ToolAbortError);
+	});
+});


### PR DESCRIPTION
Replaces conflict-closed #2977 (which superseded #2886) without changing the owner-reviewed security boundary.

Why this replacement exists
The owner review on #2977 found no security or implementation findings and reached `MERGE_READY`, but the SHA-pinned merge was rejected after adjacent work moved `dev` and made the immutable head conflict. This branch preserves that reviewed boundary on current `dev`.

Scope
- Reject and remove legacy rustdoc cache entries larger than `MAX_BYTES` before parsing, with a bounded read that also catches file growth after stat.
- Request identity transfer encoding, disable Bun automatic response decompression, and reject any encoded transport response before reading it.
- Preserve the existing compressed-download and gzip-expansion limits, rendering, cache layout, and caller abort behavior.
- Keep the changelog entry under the current Unreleased section.

Reproduction coverage
- Oversized concatenated gzip expansion is rejected without caching.
- An over-limit streamed response is cancelled.
- An oversized legacy cache is removed and the crate is refetched.
- `Content-Encoding: gzip` is rejected while the request proves `decompress: false` and `Accept-Encoding: identity`.
- Under-budget rendering/caching and caller abort behavior remain covered.

Exact-head refresh
- Base: `e87d86e81dfcce7f03694eb8ee38f75d7b309722`
- Head: `1761d1b918cfafbf9c4c1029c90a5023b055a5ac`
- focused docs.rs suite: 6 passed, 17 expectations
- coding-agent Biome and TypeScript check passed
- coding-agent production build passed
- `git diff --check upstream/dev...HEAD` passed
- range-diff against the preceding head preserves the code and test patch; only the changelog application context moved with current Unreleased entries

This exact-head refresh was required after GitHub left the prior head's mergeability calculation at `UNKNOWN` while its merge ref remained pinned to an older base. Fresh hosted CI and review are required on this rewritten head.

No overlapping open docs.rs PR was present when this replacement was opened.
