### PR TITLE
fix(ci): refresh Telegram native authority attestation

### DIFF
--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -527,7 +527,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:writeJsonAtomic": "a768c87646d56cf28b0adbd596884c964aed54ea40775517fa385c111af05a5b"
   },
   "nativeAuthoritySha256": {
-    "crates/pi-natives/src/path_identity.rs": "7ccfcf198ad867217f602c4df1ddd14fe557cd5ebbab273b5bccc4ea402a79a5",
+    "crates/pi-natives/src/path_identity.rs": "b6c3bc76bfce864386f91b8c174e0292782c2f5a44788e40226987d9885260f3",
     "crates/pi-natives/src/ps.rs": "3c8a28d1daf84e91c3db0d29fa05a6231b871903800428ca1acbb2ddecea5f6b",
     "crates/pi-shell/src/process.rs": "3f74458492c16fff24ecc234c74efd29d2a7f5f5c5a7c879c68b00a2e4f08274",
     "packages/natives/native/index.d.ts": "8f65a75f212448b56cf315a3ee93b35a52966525f3f0d72556b78ab25d421bb4",


### PR DESCRIPTION
## Summary

- Refresh the generated SHA-256 attestation for `crates/pi-natives/src/path_identity.rs`.
- Leave product code, daemon generations, protected inventory, and guard policy unchanged.
- Repair the `Telegram daemon generation guard` failure on the latest `dev` head.

## Root cause

`dev` commit `9541ed0c65d05528c6b853e6521e184e2e2e6edb` changed a Windows test-only import in the protected native source. The committed manifest still contained the digest for the prior file bytes, so latest-head Dev CI run `29995171998` failed with:

```text
telegram-daemon-generation-guard: native authority digests do not byte-match the current tree
```

Regenerating the manifest changes exactly one digest and does not require a lifecycle or guard-contract generation bump.

## Exact-head evidence

- Base: `a0df3324cf72e49716b0f52d925019a0c94a8efa`
- Head: `86ae953a4637218b834ed3b4074c4d2162bdeb53`
- `bun scripts/telegram-daemon-generation-guard.ts --write-manifest` is idempotent at this head.
- `bun scripts/telegram-daemon-generation-guard.ts --validate-current-tree` passed.
- Exact base/head guard evaluation passed with `no protected changes`.
- `bun test scripts/telegram-daemon-generation-guard.test.ts`: 34 passed, 0 failed, 337 expectations.
- `git diff --check upstream/dev...HEAD` passed.
- Diff surface: one generated manifest file, one hash replacement.

The global integration hold remains owner-controlled; this PR only supplies the narrowly scoped CI repair needed for a terminal-green latest `dev` run.
