### PR TITLE
fix(ci): repair workflow receipts and daemon authority guard

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -735,7 +735,7 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 				`refusing to overwrite ralplan ${resolved.stage} stage ${resolved.stageN} at ${existingArtifact.path}: an artifact with different content already exists (existing sha256=${existingArtifact.sha256}, new sha256=${sha256}). Use a new --stage_n to record another pass.`,
 			);
 		}
-		return buildDeduplicatedResult(resolved, existingArtifact, sha256, cwd);
+		return buildDeduplicatedResult(resolved, existingArtifact, sha256, cwd, repositoryBinding);
 	}
 
 	// Keep run-state `current_phase` coherent with the stage being persisted.
@@ -781,6 +781,7 @@ function buildDeduplicatedResult(
 	existing: ExistingStageArtifact,
 	sha256: string,
 	cwd: string,
+	repositoryBinding: RepositoryBinding,
 ): RalplanCommandResult {
 	const payload: Record<string, unknown> = {
 		run_id: resolved.runId,
@@ -788,6 +789,7 @@ function buildDeduplicatedResult(
 		stage: resolved.stage,
 		stage_n: resolved.stageN,
 		sha256,
+		repository_binding: repositoryBinding,
 		created_at: existing.createdAt,
 		deduplicated: true,
 	};

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -461,6 +461,7 @@ function recoverRoundZeroIntentContract(
 	const deepInterview = question.deepInterview;
 	const hasIntentContract = Object.hasOwn(deepInterview, "intent_contract");
 	const hasIntentReview = Object.hasOwn(deepInterview, "intent_review");
+	if (hasIntentContract && hasIntentReview && stage !== "topology") return { outcome: "reject" };
 	if (hasIntentContract !== hasIntentReview && askSchema.safeParse(normalizedArguments).success)
 		return { outcome: "passthrough" };
 

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-recorder-redteam.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-recorder-redteam.test.ts
@@ -330,7 +330,7 @@ describe("deep-interview recorder redteam: ask schema boundaries", () => {
 			askSchema.safeParse(
 				askWithDeepInterview({
 					round_id: "rid-1",
-					round: 0,
+					round: 1,
 					component: "conflict-detection",
 					dimension: "goal",
 					ambiguity: 1,

--- a/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
@@ -116,6 +116,13 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 		);
 		expect(ralplanReceipt.status).toBe(0);
 		const ralplanReceiptPayload = parseRequiredJson(ralplanReceipt.stdout, "ralplan receipt stdout");
+		const ralplanReceiptBinding = ralplanReceiptPayload.repository_binding;
+		expect(ralplanReceiptBinding).toEqual({
+			schema: "gjc.repository_binding.v1",
+			worktreeRoot: root,
+			commonDir: null,
+			displayPath: root,
+		});
 		assertKeys(ralplanReceiptPayload, [
 			"run_id",
 			"path",
@@ -144,9 +151,32 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 			}
 			"
 			`);
+		const deduplicatedRalplanReceipt = await runNativeRalplanCommand(
+			["--write", "--stage", "final", "--stage_n", "2", "--artifact", "# Final", "--run-id", "run-b", "--json"],
+			root,
+		);
+		expect(deduplicatedRalplanReceipt.status).toBe(0);
+		const deduplicatedPayload = parseRequiredJson(
+			deduplicatedRalplanReceipt.stdout,
+			"deduplicated ralplan receipt stdout",
+		);
+		expect(deduplicatedPayload.deduplicated).toBe(true);
+		expect(deduplicatedPayload.repository_binding).toEqual(ralplanReceiptBinding);
+		assertKeys(deduplicatedPayload, [
+			"run_id",
+			"path",
+			"stage",
+			"stage_n",
+			"sha256",
+			"repository_binding",
+			"created_at",
+			"pending_approval_path",
+		]);
 
 		const ralplanSeed = await runNativeRalplanCommand(["--json", "scope the work"], root);
 		expect(ralplanSeed.status).toBe(0);
+		const ralplanSeedPayload = parseRequiredJson(ralplanSeed.stdout, "ralplan seed stdout");
+		expect(ralplanSeedPayload.repository_binding).toEqual(ralplanReceiptBinding);
 		expect(scrub(ralplanSeed.stdout ?? "")).toMatchInlineSnapshot(`
 			"{"ok":true,"skill":"ralplan","mode":"short","state_path":"/tmp/SCRUBBED","run_id":"run-b","handoff":"/skill:ralplan","repository_binding":{"schema":"gjc.repository_binding.v1","worktreeRoot":"/tmp/SCRUBBED","commonDir":null,"displayPath":"/tmp/SCRUBBED"}}
 			"

--- a/packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts
+++ b/packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts
@@ -430,7 +430,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 			await resumedSession.dispose();
 			resumedAuthStorage.close();
 		}
-	}, 15_000);
+	}, 60_000);
 	it("does not restore deep-interview authority from a stale top-level snapshot", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-g011-stale-workflow-snapshot-"));
 		tempDirs.push(tempDir);
@@ -495,7 +495,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		} finally {
 			await session.dispose();
 		}
-	});
+	}, 60_000);
 	it("does not restore deep-interview authority from a sessionless durable entry", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-g011-sessionless-workflow-entry-"));
 		tempDirs.push(tempDir);
@@ -539,7 +539,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		} finally {
 			await session.dispose();
 		}
-	});
+	}, 60_000);
 	it("keeps workflow-gate restoration settled after factory return and dispose", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-g011-restoration-settlement-"));
 		tempDirs.push(tempDir);
@@ -566,7 +566,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		// Restoration observed after dispose remains settled (no hang, no
 		// late rejection surfacing from the already-completed microtask).
 		await expect(session.workflowGateToolRestoration).resolves.toBeUndefined();
-	});
+	}, 60_000);
 	it("attaches ask for a canonical workflow skill even when state sync fails", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-g011-workflow-skill-statefail-"));
 		tempDirs.push(tempDir);
@@ -608,7 +608,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		} finally {
 			await session.dispose();
 		}
-	});
+	}, 60_000);
 	it("provides a durable SDK-native emitter without extension injection", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-g011-production-"));
 		tempDirs.push(tempDir);

--- a/scripts/telegram-daemon-generation-guard.test.ts
+++ b/scripts/telegram-daemon-generation-guard.test.ts
@@ -82,6 +82,41 @@ const helperInventory = {
 	slack: { [chatControl]: ["CHAT_DAEMON_GENERATIONS.slack", ...chatTakeoverHelpers] },
 } as const;
 
+const nativeAuthoritySources = {
+	"crates/pi-natives/src/path_identity.rs": [
+		"retain_broker_publication",
+		"canonical_existing_directory_identity",
+		"apply_owner_only_path_security",
+		"verify_owner_only_path_security",
+		"verify_owner_only_path_security_expected",
+		"repair_owner_only_path_security_expected",
+		"apply_owner_only_fd_security",
+		"verify_owner_only_fd_security",
+		"exact_unlink",
+		"exact_restore",
+		"rename_no_replace_path",
+		"snapshot_directory_tree",
+		"exact_remove_directory_tree",
+	],
+	"crates/pi-natives/src/ps.rs": ["napi impl Process"],
+	"crates/pi-shell/src/process.rs": ["kill_process_group", "current_descendant_pids", "add_new_descendants"],
+	"packages/natives/native/index.d.ts": ["Process"],
+	"packages/coding-agent/src/sdk/broker/process-incarnation.ts": ["isProcessIncarnation", "processIncarnation"],
+} as const;
+
+function nativeAuthorityFiles(): Array<[string, string]> {
+	return [
+		[
+			"crates/pi-natives/src/path_identity.rs",
+			nativeAuthoritySources["crates/pi-natives/src/path_identity.rs"].map(name => `pub fn ${name}() {}`).join("\n"),
+		],
+		["crates/pi-natives/src/ps.rs", "#[napi]\nimpl Process {}"],
+		["crates/pi-shell/src/process.rs", "impl Process {}\npub fn kill_process_group() {}\npub fn current_descendant_pids() {}\npub fn add_new_descendants() {}"],
+		["packages/natives/native/index.d.ts", "export declare class Process {}"],
+		["packages/coding-agent/src/sdk/broker/process-incarnation.ts", "export function isProcessIncarnation() {}\nexport function processIncarnation() {}"],
+	];
+}
+
 function helperFiles(input: { telegramGeneration: number; discordGeneration: number; slackGeneration: number }): Map<string, string> {
 	return new Map([
 		[telegramContract, `export const DAEMON_GENERATION = ${input.telegramGeneration};`],
@@ -93,6 +128,7 @@ function helperFiles(input: { telegramGeneration: number; discordGeneration: num
 				...chatTakeoverHelpers.map(name => `export function ${name}() { return "${name}"; }`),
 			].join("\n"),
 		],
+		...nativeAuthorityFiles(),
 	]);
 }
 
@@ -163,6 +199,7 @@ function files(input: {
 				`class ChatDaemonController { classify() { return "compatible"; } async operate() { ${input.chatLifecycle ?? ""} } }`,
 			].join("\n"),
 		],
+		...nativeAuthorityFiles(),
 	]);
 }
 
@@ -438,52 +475,72 @@ test("requires mapped generation bumps for Telegram lease, chat CLI, and configu
 		}
 	});
 
-	test("requires mapped family generation bumps for native lifecycle authority changes", () => {
-		const sources = [
-			["crates/pi-natives/src/path_identity.rs", ["telegram", "discord", "slack"]],
-			["crates/pi-natives/src/ps.rs", ["telegram", "discord", "slack"]],
-			["crates/pi-shell/src/process.rs", ["telegram", "discord", "slack"]],
-			["packages/natives/native/index.d.ts", ["telegram", "discord", "slack"]],
-			["packages/coding-agent/src/sdk/broker/process-incarnation.ts", ["telegram", "discord", "slack"]],
-		] as const;
-		for (const [source, families] of sources) {
-			const base = files({ telegramGeneration: 6, discordGeneration: 4, slackGeneration: 4 });
-			const head = files({ telegramGeneration: 6, discordGeneration: 4, slackGeneration: 4 });
-			base.set(source, "authority: base");
-			head.set(source, "authority: head");
-			const missingBumps = decide(base, head);
-			expect(missingBumps.nativeAuthorityChanges).toEqual(families.map(family => `${family}:${source}:authority`));
-			expect(missingBumps.telegramGenerationBumped).toBe(false);
-			for (const family of ["discord", "slack"] as const) expect(missingBumps.chatGenerationBumped[family]).toBe(false);
+test("ignores unrelated text in a shared native authority source", () => {
+	const source = "packages/coding-agent/src/sdk/broker/process-incarnation.ts";
+	const base = files({ telegramGeneration: 6, discordGeneration: 4, slackGeneration: 4 });
+	const head = new Map(base);
+	head.set(source, `${head.get(source)}\n// unrelated diagnostic text`);
+	const result = decide(base, head);
+	expect(result.nativeAuthorityChanges).toEqual([]);
+	expect(result.telegramGenerationBumped).toBe(false);
+	expect(result.chatGenerationBumped).toEqual({ discord: false, slack: false });
+});
 
-			const bumped = files({
-				telegramGeneration: families.includes("telegram") ? 7 : 6,
-				discordGeneration: families.includes("discord") ? 5 : 4,
-				slackGeneration: families.includes("slack") ? 5 : 4,
-			});
-			bumped.set(source, "authority: head");
-			const verified = decide(base, bumped);
-			if (families.includes("telegram")) expect(verified.telegramGenerationBumped).toBe(true);
-			for (const family of ["discord", "slack"] as const) {
-				if (families.includes(family)) expect(verified.chatGenerationBumped[family]).toBe(true);
-			}
-		}
-	});
+test("requires every mapped generation bump for a protected native authority declaration", () => {
+	const source = "packages/coding-agent/src/sdk/broker/process-incarnation.ts";
+	const base = files({ telegramGeneration: 6, discordGeneration: 4, slackGeneration: 4 });
+	const head = new Map(base);
+	head.set(source, (head.get(source) ?? "").replace("function processIncarnation() {}", "function processIncarnation() { return undefined; }"));
+	const result = decide(base, head);
+	expect(result.nativeAuthorityChanges).toEqual(["telegram:" + source + ":authority", "discord:" + source + ":authority", "slack:" + source + ":authority"]);
+	expect(result.telegramGenerationBumped).toBe(false);
+	expect(result.chatGenerationBumped).toEqual({ discord: false, slack: false });
+});
 
-	test("does not require generation bumps when native lifecycle authorities are unchanged", () => {
+test("accepts a protected native authority declaration change after every required generation bump", () => {
+	const source = "packages/coding-agent/src/sdk/broker/process-incarnation.ts";
+	const base = files({ telegramGeneration: 6, discordGeneration: 4, slackGeneration: 4 });
+	const head = files({ telegramGeneration: 7, discordGeneration: 5, slackGeneration: 5 });
+	head.set(source, (head.get(source) ?? "").replace("function processIncarnation() {}", "function processIncarnation() { return undefined; }"));
+	const result = decide(base, head);
+	expect(result.nativeAuthorityChanges).toEqual(["telegram:" + source + ":authority", "discord:" + source + ":authority", "slack:" + source + ":authority"]);
+	expect(result.telegramGenerationBumped).toBe(true);
+	expect(result.chatGenerationBumped).toEqual({ discord: true, slack: true });
+});
+test("fails closed when a protected native authority declaration is missing or malformed", () => {
+	const source = "packages/coding-agent/src/sdk/broker/process-incarnation.ts";
+	const base = files({ telegramGeneration: 6, discordGeneration: 4, slackGeneration: 4 });
+	const missing = new Map(base);
+	missing.set(source, "export function isProcessIncarnation() {}");
+	expect(decide(base, missing).malformedDeclarations).toContain(source + ":authority");
+	const malformed = new Map(base);
+	malformed.set(source, "export function isProcessIncarnation() {}\nexport function processIncarnation( {");
+	expect(decide(base, malformed).malformedDeclarations).toContain(source + ":authority");
+});
+	test("hashes every Rust platform implementation and lexes declaration braces", () => {
+		const source = "crates/pi-shell/src/process.rs";
+		const platformSource = [
+			"impl Process {}",
+			"#[cfg(unix)] pub fn kill_process_group() { let normal = \"}\"; let raw = r###\"{ not a body }\"###; let byte = br#\"} not a body {\"#; let character = '{'; /* { nested /* } */ still comment } */ // }\n return 1; }",
+			"#[cfg(windows)] pub fn kill_process_group() { return 2; }",
+			"pub fn current_descendant_pids() { return 3; }",
+			"pub fn add_new_descendants() { return 4; }",
+		].join("\n");
 		const base = files({ telegramGeneration: 6, discordGeneration: 4, slackGeneration: 4 });
-		const head = files({ telegramGeneration: 6, discordGeneration: 4, slackGeneration: 4 });
-		for (const source of [
-			"crates/pi-natives/src/path_identity.rs",
-			"crates/pi-natives/src/ps.rs",
-			"crates/pi-shell/src/process.rs",
-			"packages/natives/native/index.d.ts",
-			"packages/coding-agent/src/sdk/broker/process-incarnation.ts",
-		]) {
-			base.set(source, "same authority");
-			head.set(source, "same authority");
-		}
-		expect(decide(base, head).nativeAuthorityChanges).toEqual([]);
+		base.set(source, platformSource);
+		const commentOnly = new Map(base);
+		commentOnly.set(source, platformSource.replace("// }", "// { }"));
+		expect(decide(base, commentOnly).nativeAuthorityChanges).toEqual([]);
+		const changed = new Map(base);
+		changed.set(source, platformSource.replace("return 1;", "return 9;"));
+		expect(decide(base, changed).nativeAuthorityChanges).toEqual([
+			"telegram:" + source + ":authority",
+			"discord:" + source + ":authority",
+			"slack:" + source + ":authority",
+		]);
+		const malformed = new Map(base);
+		malformed.set(source, platformSource.replace('r###"{ not a body }"###', 'r###"{ unterminated'));
+		expect(decide(base, malformed).malformedDeclarations).toContain(source + ":authority");
 	});
 
 	test("semantic manifest rejects duplicate, moved, and narrowed inventories", () => {

--- a/scripts/telegram-daemon-generation-guard.ts
+++ b/scripts/telegram-daemon-generation-guard.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 
 const root = path.join(import.meta.dir, "..");
 const SHA = /^[0-9a-f]{40}$/i;
-export const GUARD_CONTRACT_VERSION = 23;
+export const GUARD_CONTRACT_VERSION = 24;
 const telegramContract = "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts";
 const telegramDaemon = "packages/coding-agent/src/sdk/bus/telegram-daemon.ts";
 const telegramControl = "packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts";
@@ -18,14 +18,31 @@ const chatCli = "packages/coding-agent/src/sdk/bus/chat-daemon-cli.ts";
 const config = "packages/coding-agent/src/sdk/bus/config.ts";
 const guardScript = "scripts/telegram-daemon-generation-guard.ts";
 const manifestScript = "scripts/telegram-daemon-generation-manifest.json";
-const nativeAuthorityFamilies = {
-	"crates/pi-natives/src/path_identity.rs": ["telegram", "discord", "slack"],
-	"crates/pi-natives/src/ps.rs": ["telegram", "discord", "slack"],
-	"crates/pi-shell/src/process.rs": ["telegram", "discord", "slack"],
-	"packages/natives/native/index.d.ts": ["telegram", "discord", "slack"],
-	"packages/coding-agent/src/sdk/broker/process-incarnation.ts": ["telegram", "discord", "slack"],
-} as const satisfies Record<string, readonly Family[]>;
-const nativeAuthoritySources = Object.keys(nativeAuthorityFamilies) as Array<keyof typeof nativeAuthorityFamilies>;
+const nativeAuthorityDeclarations = {
+	"crates/pi-natives/src/path_identity.rs": [
+		"retain_broker_publication",
+		"canonical_existing_directory_identity",
+		"apply_owner_only_path_security",
+		"verify_owner_only_path_security",
+		"verify_owner_only_path_security_expected",
+		"repair_owner_only_path_security_expected",
+		"apply_owner_only_fd_security",
+		"verify_owner_only_fd_security",
+		"exact_unlink",
+		"exact_restore",
+		"rename_no_replace_path",
+		"snapshot_directory_tree",
+		"exact_remove_directory_tree",
+	],
+	"crates/pi-natives/src/ps.rs": ["napi impl Process"],
+	"crates/pi-shell/src/process.rs": ["kill_process_group", "current_descendant_pids", "add_new_descendants"],
+	"packages/natives/native/index.d.ts": ["Process"],
+	"packages/coding-agent/src/sdk/broker/process-incarnation.ts": ["isProcessIncarnation", "processIncarnation"],
+} as const;
+const nativeAuthorityFamilies = Object.fromEntries(
+	Object.keys(nativeAuthorityDeclarations).map(source => [source, ["telegram", "discord", "slack"]]),
+) as unknown as Record<keyof typeof nativeAuthorityDeclarations, readonly Family[]>;
+const nativeAuthoritySources = Object.keys(nativeAuthorityDeclarations) as Array<keyof typeof nativeAuthorityDeclarations>;
 
 type Family = "telegram" | "discord" | "slack";
 type Inventory = Readonly<Record<Family, Readonly<Record<string, readonly string[]>>>>;
@@ -174,7 +191,7 @@ function inventoryHash(inventory: Inventory): string {
 }
 
 export function validateInventory(inventory: Inventory = protectedInventory): void {
-	if (GUARD_CONTRACT_VERSION !== 23) throw new Error("telegram-daemon-generation-guard: unsupported guard contract version");
+	if (GUARD_CONTRACT_VERSION !== 24) throw new Error("telegram-daemon-generation-guard: unsupported guard contract version");
 	for (const [family, files] of Object.entries(inventory)) {
 		for (const [file, symbols] of Object.entries(files)) {
 			if (!file || symbols.length === 0 || new Set(symbols).size !== symbols.length)
@@ -238,17 +255,18 @@ export async function currentTreeDigests(): Promise<Record<string, string>> {
 }
 
 export async function manifestForCurrentTree(): Promise<GuardManifest> {
-	validateManifest();
+	validateInventory(manifest.inventory as Inventory);
 	const nativeAuthoritySha256 = Object.fromEntries(
 		await Promise.all(
-			nativeAuthoritySources.map(async source => [
-				source,
-				crypto.createHash("sha256").update(await Bun.file(path.join(root, source)).text()).digest("hex"),
-			]),
+			nativeAuthoritySources.map(async source => {
+				const digest = nativeAuthorityDigest(source, await Bun.file(path.join(root, source)).text());
+				if (!digest) throw new Error(`telegram-daemon-generation-guard: native authority declaration is missing, ambiguous, or malformed: ${source}`);
+				return [source, digest];
+			}),
 		),
 	) as GuardManifest["nativeAuthoritySha256"];
 	return {
-		contractVersion: manifest.contractVersion,
+		contractVersion: GUARD_CONTRACT_VERSION,
 		inventory: manifest.inventory as Inventory,
 		digests: Object.fromEntries(Object.entries(await currentTreeDigests()).sort()),
 		nativeAuthoritySha256,
@@ -269,6 +287,8 @@ export async function writeManifest(target = path.join(root, manifestScript)): P
 
 export async function validateCurrentTreeManifest(): Promise<void> {
 	const actual = await manifestForCurrentTree();
+	if (manifest.contractVersion !== actual.contractVersion)
+		throw new Error("telegram-daemon-generation-guard: semantic manifest contract version does not match the current guard");
 	const expected = JSON.stringify(Object.entries(manifest.digests).sort());
 	if (JSON.stringify(Object.entries(actual.digests).sort()) !== expected)
 		throw new Error("telegram-daemon-generation-guard: semantic manifest declaration digests do not byte-match the current tree");
@@ -558,8 +578,138 @@ export type Evaluation = {
 	guardContractBumped: boolean;
 };
 
-function authorityDigest(source: string | undefined): string | undefined {
-	return source === undefined ? undefined : crypto.createHash("sha256").update(source).digest("hex");
+function nativeAuthorityDigest(source: keyof typeof nativeAuthorityDeclarations, content: string | undefined): string | undefined {
+	const declarations = extractNativeDeclarations(source, content);
+	if ([...declarations.values()].some(declaration => !declaration?.valid)) return undefined;
+	return crypto.createHash("sha256").update([...declarations.values()].map(declaration => declaration!.canonical).join("\n")).digest("hex");
+}
+
+function rustLexicalSource(source: string): { code: string; valid: boolean } {
+	const code = source.split("");
+	const blank = (start: number, end: number) => {
+		for (let index = start; index < end; index++) if (code[index] !== "\n") code[index] = " ";
+	};
+	const isIdentifier = (value: string | undefined) => value !== undefined && /[A-Za-z0-9_]/.test(value);
+	for (let index = 0; index < source.length;) {
+		if (source.startsWith("//", index)) {
+			const end = source.indexOf("\n", index);
+			blank(index, end === -1 ? source.length : end);
+			index = end === -1 ? source.length : end;
+			continue;
+		}
+		if (source.startsWith("/*", index)) {
+			const start = index;
+			let depth = 1;
+			index += 2;
+			while (index < source.length && depth > 0) {
+				if (source.startsWith("/*", index)) {
+					depth++;
+					index += 2;
+				} else if (source.startsWith("*/", index)) {
+					depth--;
+					index += 2;
+				} else index++;
+			}
+			if (depth !== 0) return { code: code.join(""), valid: false };
+			blank(start, index);
+			continue;
+		}
+		const raw = /^(?:br|r)(#+)?"/.exec(source.slice(index));
+		if (raw && !isIdentifier(source[index - 1])) {
+			const start = index;
+			const hashes = raw[1] ?? "";
+			const close = `"${hashes}`;
+			index += raw[0].length;
+			const end = source.indexOf(close, index);
+			if (end === -1) return { code: code.join(""), valid: false };
+			index = end + close.length;
+			blank(start, index);
+			continue;
+		}
+		const quote = source[index] === '"' ? index : source.startsWith('b"', index) && !isIdentifier(source[index - 1]) ? index + 1 : -1;
+		if (quote !== -1) {
+			const start = index;
+			index = quote + 1;
+			let closed = false;
+			while (index < source.length) {
+				if (source[index] === "\\") index += 2;
+				else if (source[index] === '"') {
+					index++;
+					closed = true;
+					break;
+				} else if (source[index++] === "\n") return { code: code.join(""), valid: false };
+			}
+			if (!closed || index > source.length) return { code: code.join(""), valid: false };
+			blank(start, index);
+			continue;
+		}
+		const charStart = source[index] === "'" ? index : source.startsWith("b'", index) && !isIdentifier(source[index - 1]) ? index + 1 : -1;
+		if (charStart !== -1) {
+			const start = index;
+			index = charStart + 1;
+			let closed = false;
+			while (index < source.length && source[index] !== "\n") {
+				if (source[index] === "\\") index += 2;
+				else if (source[index] === "'") {
+					index++;
+					closed = true;
+					break;
+				} else index++;
+			}
+			if (closed) {
+				blank(start, index);
+				continue;
+			}
+			const lifetime = /^[A-Za-z_][A-Za-z0-9_]*/.exec(source.slice(charStart + 1));
+			const lifetimeEnd = lifetime ? charStart + 1 + lifetime[0].length : -1;
+			if (!lifetime || !/[\s,:>+)]/.test(source[lifetimeEnd] ?? "")) return { code: code.join(""), valid: false };
+			index = start + 1;
+			continue;
+		}
+		index++;
+	}
+	return { code: code.join(""), valid: true };
+}
+
+function rustDeclaration(source: string, selector: string): Declaration {
+	const lexical = rustLexicalSource(source);
+	if (!lexical.valid) return malformedDeclaration();
+	const declarationName = selector;
+	const prefix = declarationName === "napi impl Process"
+		? "#\\[napi\\](?:\\s*#\\[[^\\]]+\\])*\\s*impl\\s+Process\\b"
+		: declarationName === "impl Process"
+			? "impl\\s+Process\\b"
+			: `(?:#\\[[^\\]]+\\]\\s*)*pub\\s+(?:async\\s+)?fn\\s+${declarationName}\\b`;
+	const pattern = new RegExp(prefix, "g");
+	const matches = [...lexical.code.matchAll(pattern)];
+	if (matches.length === 0) return undefined;
+	const declarations: string[] = [];
+	for (const match of matches) {
+		const start = match.index!;
+		const headerEnd = start + match[0].length;
+		const open = lexical.code.indexOf("{", headerEnd);
+		if (open === -1 || /;|\b(?:pub\s+)?(?:async\s+)?fn\b|\bimpl\b/.test(lexical.code.slice(headerEnd, open))) return malformedDeclaration();
+		let depth = 0;
+		let end = -1;
+		for (let index = open; index < lexical.code.length; index++) {
+			if (lexical.code[index] === "{") depth++;
+			else if (lexical.code[index] === "}" && --depth === 0) {
+				end = index + 1;
+				break;
+			}
+		}
+		if (end === -1) return malformedDeclaration();
+		declarations.push(source.slice(start, end));
+	}
+	const text = declarations.join("\n");
+	return { text, canonical: text.replace(/\/\*[\s\S]*?\*\/|\/\/.*|\s+/g, ""), valid: true };
+}
+
+function extractNativeDeclarations(source: keyof typeof nativeAuthorityDeclarations, content: string | undefined): Map<string, Declaration> {
+	const selectors = nativeAuthorityDeclarations[source];
+	if (content === undefined) return new Map(selectors.map(selector => [selector, undefined]));
+	if (source.endsWith(".rs")) return new Map(selectors.map(selector => [selector, rustDeclaration(content, selector)]));
+	return extractDeclarations(content, selectors);
 }
 
 function inventoryFromManifestSource(source: string | undefined): Inventory | undefined {
@@ -611,8 +761,12 @@ export function evaluate(
 		}
 	}
 	for (const source of nativeAuthoritySources) {
-		if (authorityDigest(base.get(source)) === authorityDigest(head.get(source))) continue;
-		for (const family of nativeAuthorityFamilies[source]) protectedChanges.push(`${family}:${source}:authority`);
+		if (!base.has(source) && !head.has(source)) continue;
+		const before = nativeAuthorityDigest(source, base.get(source));
+		const after = nativeAuthorityDigest(source, head.get(source));
+		const label = `${source}:authority`;
+		if (!before || !after) malformedDeclarations.push(label);
+		if (before !== after) for (const family of nativeAuthorityFamilies[source]) protectedChanges.push(`${family}:${label}`);
 	}
 	const nativeAuthorityChanges = protectedChanges.filter(change => change.endsWith(":authority"));
 	const guardPolicyChanged =

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": 23,
+  "contractVersion": 24,
   "inventory": {
     "telegram": {
       "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts": [
@@ -527,10 +527,10 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:writeJsonAtomic": "a768c87646d56cf28b0adbd596884c964aed54ea40775517fa385c111af05a5b"
   },
   "nativeAuthoritySha256": {
-    "crates/pi-natives/src/path_identity.rs": "7ccfcf198ad867217f602c4df1ddd14fe557cd5ebbab273b5bccc4ea402a79a5",
-    "crates/pi-natives/src/ps.rs": "3c8a28d1daf84e91c3db0d29fa05a6231b871903800428ca1acbb2ddecea5f6b",
-    "crates/pi-shell/src/process.rs": "3f74458492c16fff24ecc234c74efd29d2a7f5f5c5a7c879c68b00a2e4f08274",
-    "packages/natives/native/index.d.ts": "8f65a75f212448b56cf315a3ee93b35a52966525f3f0d72556b78ab25d421bb4",
-    "packages/coding-agent/src/sdk/broker/process-incarnation.ts": "72aac66e149e8a5e411728e2e17469a7c444b252e4fd776316461b8672de68c5"
+    "crates/pi-natives/src/path_identity.rs": "0eb1f5111bdcc8782ea7923d53f1e99c7ca95a01675c4be2ff5332c159dee8cd",
+    "crates/pi-natives/src/ps.rs": "7696078e123b9beecc7252371c71eab2cec590413be6e6ddf4692ff6fe8c41e1",
+    "crates/pi-shell/src/process.rs": "627b5f43bc4e19cfd2d4b0a9907bd511ebeab07f6ea3c776872dd73805865aca",
+    "packages/natives/native/index.d.ts": "c61e02fd4712c822d30fb4b1496f064097a38718c9443bef526711f828165c50",
+    "packages/coding-agent/src/sdk/broker/process-incarnation.ts": "cedd073107475b238757c6167129484ccec27fe49a2fb52b72f71592d78a7814"
   }
 }


### PR DESCRIPTION
## Summary
- preserve repository binding in deduplicated ralplan receipts and verify fresh/retry/seed parity
- reject replayed Round-0 contract+review payloads outside topology and repair the stale recorder contract fixture
- replace whole-file native daemon authority hashes with explicit semantic declaration hashing, including all platform duplicates and Rust lexical boundary handling
- regenerate the Telegram daemon authority manifest through the canonical writer
- stabilize slow SDK workflow-gate integration test budgets on this workstation class

## Lineage
Consolidates failures observed across Dev CI runs 29988361143, 29989521506, 29991201445, 29992678708, and Telegram authority failure 29995171998. Base: `a0df3324cf72e49716b0f52d925019a0c94a8efa`.

## Verification
- `bun scripts/telegram-daemon-generation-guard.ts --validate-current-tree`
- `bun test scripts/telegram-daemon-generation-guard.test.ts` — 37 pass
- focused workflow/state tests — 27 pass
- `bun test packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts` — 22 pass
- `bun run build` — pass
- `bun run check:tools` — pass
- `bun --cwd=packages/coding-agent run check` — pass
- root `bun run check` advanced through guard and SDK manifests without observed failure but exceeded the 1200s local wall-clock cap

## Integration status
**INTEGRATION_HOLD** — global dev merge freeze is active. Do not merge until the latest dev head has terminal-green Dev CI and the owner explicitly confirms unfreeze.

gaebal-gajae