### PR TITLE
fix(coding-agent): stop no-op overflow replay

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Overflow maintenance now stops cleanly when no-op compaction would replay the same oversized request; the runtime status explains that `/clear` preserves the current session ID before retrying.
 - Runtime MCP OAuth credentials are now bound to their authorized server origin and token endpoint, reject redirecting refresh responses, and fail closed when legacy or changed configuration lacks an exact match.
 - `/share` now keeps full-session HTML in owner-private unpredictable staging until the share handler or `gh gist create` process has fully stopped; cancelling a blocked gist upload terminates and awaits that process before reporting cancellation and removing the export.
 - Telegram notification daemon self-heals degraded on-disk state: permanently missing scan roots are pruned (so one deleted worktree no longer disables orphan-topic cleanup), and retained exact-unlink transition/placeholder artifacts are reaped on ownership acquire and each scan. `gjc daemon reload` can recover without manual filesystem surgery (#2956).

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -893,6 +893,8 @@ export class EventController {
 			} else if (event.willRetry && !isHandoffAction) {
 				this.ctx.showStatus("Context overflow maintenance completed");
 			}
+		} else if (event.skipped && event.errorMessage && !isHandoffAction) {
+			this.ctx.showStatus(event.errorMessage);
 		} else if (event.errorMessage) {
 			this.ctx.showWarning(event.errorMessage);
 		} else if (isHandoffAction) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -12293,16 +12293,29 @@ export class AgentSession {
 			if (autoCompactionSignal.aborted) return await emitAborted();
 
 			if (!preparation) {
-				const continuationSkipReason = willRetry ? this.#detectOverflowRetryContinuationSkip() : undefined;
+				// #checkCompaction removes the failed overflow assistant before entering
+				// this path. A resumable tail would therefore resend the same oversized
+				// request even though maintenance made no change. Non-resumable tails
+				// retain the existing synthetic auto-continue recovery, which changes
+				// the request and is covered by the continuation contract.
+				const overflowNoopWouldReplay = reason === "overflow" && willRetry && this.#isResumableAgentTail();
+				const continuationSkipReason =
+					!overflowNoopWouldReplay && willRetry ? this.#detectOverflowRetryContinuationSkip() : undefined;
 				await this.#emitSessionEvent({
 					type: "auto_compaction_end",
 					action,
 					result: undefined,
 					aborted: false,
-					willRetry: willRetry && !continuationSkipReason,
+					willRetry: overflowNoopWouldReplay ? false : willRetry && !continuationSkipReason,
+					errorMessage: overflowNoopWouldReplay
+						? "Context overflow recovery skipped: nothing eligible to compact. Run /clear to preserve this session ID, or switch to a larger-context model before retrying."
+						: undefined,
 					skipped: true,
 					continuationSkipReason,
 				});
+				if (overflowNoopWouldReplay) {
+					return { kind: "skipped" };
+				}
 				if (willRetry) {
 					return { kind: "skipped", continuationScheduled: this.#scheduleOverflowRetryContinuation(generation) };
 				}

--- a/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent, type AgentOptions } from "@gajae-code/agent-core";
+import * as compactionModule from "@gajae-code/agent-core/compaction";
 import { type AssistantMessage, getBundledModel, type Model } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
@@ -148,6 +149,7 @@ describe("AgentSession managed fallback upstream request counts", () => {
 	function createSession(
 		maxAttempts: number,
 		streamFn: AgentOptions["streamFn"],
+		settingsOverrides: Record<string, unknown> = {},
 	): { primary: Model; fallback: Model } {
 		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallback = getBundledModel("openai", "gpt-4o-mini");
@@ -161,11 +163,43 @@ describe("AgentSession managed fallback upstream request counts", () => {
 			"compaction.enabled": false,
 			"fallback.maxAttempts": maxAttempts,
 			"retry.baseDelayMs": 10,
+			...settingsOverrides,
 		});
 		settings.setModelRole("default", selector(primary));
 		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
 		session!.setConfiguredModelChain("default", [selector(primary), selector(fallback)], "test");
 		return { primary, fallback };
+	}
+
+	function seedCompactableHistory(primary: Model): void {
+		for (let index = 0; index < 4; index++) {
+			const user = {
+				role: "user" as const,
+				content: `seed request ${index} `.repeat(40),
+				timestamp: Date.now() + index * 2,
+			};
+			const assistant: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: `seed response ${index} `.repeat(40) }],
+				api: primary.api,
+				provider: primary.provider,
+				model: primary.id,
+				usage: {
+					input: 20_000,
+					output: 200,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 20_200,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now() + index * 2 + 1,
+			};
+			session!.agent.appendMessage(user);
+			session!.sessionManager.appendMessage(user);
+			session!.agent.appendMessage(assistant);
+			session!.sessionManager.appendMessage(assistant);
+		}
 	}
 
 	it("N=1 sends one managed request to each chain entry without a hidden replay", async () => {
@@ -273,24 +307,100 @@ describe("AgentSession managed fallback upstream request counts", () => {
 		);
 	});
 
-	it("bounds repeated overflow maintenance within one logical run", async () => {
+	it("terminalizes overflow maintenance when compaction would be a no-op", async () => {
 		const calls: string[] = [];
 		const events: AgentSessionEvent[] = [];
-		const { primary, fallback } = createSession(1, model => {
-			calls.push(selector(model));
-			return typedOpaqueOverflowStream(model);
-		});
+		const { primary, fallback } = createSession(
+			1,
+			model => {
+				calls.push(selector(model));
+				return typedOpaqueOverflowStream(model);
+			},
+			{
+				"compaction.enabled": true,
+				"compaction.keepRecentTokens": 1,
+			},
+		);
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(undefined);
 		session!.subscribe(event => events.push(event));
 
 		await session!.prompt("Stop after bounded overflow maintenance");
 		await session!.waitForIdle();
 
-		expect(calls).toEqual([selector(primary), selector(primary)]);
+		expect(prepareSpy).toHaveBeenCalled();
+		expect(calls).toEqual([selector(primary)]);
 		expect(calls).not.toContain(selector(fallback));
+		expect(events.filter(event => event.type === "auto_compaction_start")).toHaveLength(1);
+		expect(events.filter(event => event.type === "auto_retry_start")).toHaveLength(0);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "auto_compaction_end",
+				action: "context-full",
+				aborted: false,
+				skipped: true,
+				willRetry: false,
+				errorMessage: expect.stringContaining("nothing eligible to compact"),
+			}),
+		);
 		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
 		expect(session!.messages.at(-1)).toMatchObject({
 			role: "assistant",
 			stopReason: "error",
+			errorStatus: 400,
+		});
+	});
+
+	it("preserves successful overflow compaction and retry on the same model", async () => {
+		const calls: string[] = [];
+		const events: AgentSessionEvent[] = [];
+		let primaryCalls = 0;
+		const { primary, fallback } = createSession(
+			1,
+			model => {
+				calls.push(selector(model));
+				if (selector(model) !== selector(primary)) return successfulStream(model);
+				primaryCalls += 1;
+				return primaryCalls === 1
+					? typedOpaqueOverflowStream(model)
+					: successfulStream(model, "Recovered after compaction");
+			},
+			{
+				"compaction.enabled": true,
+				"compaction.keepRecentTokens": 1,
+			},
+		);
+		seedCompactableHistory(primary);
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: "Compacted summary",
+			shortSummary: undefined,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+			preserveData: undefined,
+		}));
+		session!.subscribe(event => events.push(event));
+
+		await session!.prompt("Recover after real overflow compaction");
+		await session!.waitForIdle();
+
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+		expect(calls).toEqual([selector(primary), selector(primary)]);
+		expect(calls).not.toContain(selector(fallback));
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "auto_compaction_end",
+				action: "context-full",
+				aborted: false,
+				willRetry: true,
+				result: expect.objectContaining({ summary: "Compacted summary" }),
+			}),
+		);
+		expect(events.filter(event => event.type === "agent_end")).toEqual([
+			expect.objectContaining({ stopReason: "completed" }),
+		]);
+		expect(session!.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			content: [{ type: "text", text: "Recovered after compaction" }],
 		});
 	});
 	it("preserves a prior fallback charge across overflow maintenance", async () => {

--- a/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
@@ -186,6 +186,27 @@ describe("EventController auto-compaction overflow status", () => {
 		expect(fixture.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: true });
 	});
 
+	it("shows a skipped overflow reason as status instead of warning", async () => {
+		const fixture = await runEndEvent({
+			type: "auto_compaction_end",
+			action: "context-full",
+			result: undefined,
+			aborted: false,
+			willRetry: false,
+			skipped: true,
+			errorMessage:
+				"Context overflow recovery skipped: nothing eligible to compact. Run /clear to preserve this session ID, or switch to a larger-context model before retrying.",
+		});
+
+		expect(fixture.loaderStop).toHaveBeenCalledTimes(1);
+		expect(fixture.ctx.autoCompactionLoader).toBeUndefined();
+		expect(fixture.showStatus).toHaveBeenCalledWith(
+			"Context overflow recovery skipped: nothing eligible to compact. Run /clear to preserve this session ID, or switch to a larger-context model before retrying.",
+		);
+		expect(fixture.showWarning).not.toHaveBeenCalled();
+		expect(fixture.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false });
+	});
+
 	it("clears the loader before showing disabled non-resumable overflow recovery status", async () => {
 		const fixture = await runEndEvent({
 			type: "auto_compaction_end",


### PR DESCRIPTION
## Problem

When overflow compaction has no eligible history, `prepareCompaction(...)`
returns without changing the context. The runtime can still schedule a
continuation from the resumable tail, replaying the same oversized provider
request and failing identically.

## Fix

- stop overflow recovery when no-op compaction would replay the unchanged
  resumable request
- emit a terminal skipped event with `willRetry: false`
- show actionable `/clear` or model-switch guidance as status rather than warning
- preserve successful-compaction retry and non-resumable synthetic continuation
  behavior
- add a changelog entry plus regression and control coverage

| Case | Behavior |
| --- | --- |
| no-op compaction + resumable tail | terminal skip with recovery guidance |
| non-resumable tail | existing synthetic auto-continue unchanged |
| successful compaction | existing same-model retry unchanged |

## Tests

- 48 focused and adjacent auto-compaction tests pass, 0 fail
- `bun run check` passes in `packages/coding-agent` (Biome + typecheck)
- changed TypeScript files pass Biome
- `git diff --check` passes
- source-linked `bun run dev:doctor` and `gjc --smoke-test` pass

A monolithic local `bun test` was not used as a green signal: it surfaced
order/environment-sensitive SDK and daemon failures, while a sampled failure
passed in isolation on clean `origin/dev`. Verification relies on the focused
suites and package-wide checks above.

## Related PRs

#1664/#1665 guard repeated oversized maintenance-model attempts after a
preparation exists, and #2479 routes managed overflow into compaction. This PR
covers the remaining `!preparation` branch, where no-op maintenance would replay
the unchanged primary request.
