### PR TITLE
fix(ci): align postmerge test contracts

### DIFF
--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -197,6 +197,7 @@ function createContext(): {
 		} as unknown as InteractiveModeContext["sessionManager"],
 		keybindings: {
 			getKeys: (action: string) => (action === "app.interrupt" ? ["escape"] : []),
+			getDisplayString: () => "",
 		} as unknown as InteractiveModeContext["keybindings"],
 		pendingImages: [],
 		lastEscapeTime: 0,

--- a/packages/coding-agent/test/notifications-session-switch.test.ts
+++ b/packages/coding-agent/test/notifications-session-switch.test.ts
@@ -363,7 +363,7 @@ test("accepted turn.prompt submission failures emit a correlated terminal event"
 				payload: expect.objectContaining({
 					commandId: response.result?.commandId,
 					turnId: response.result?.turnId,
-					error: { code: "unavailable", message: "submission failed after acceptance" },
+					error: { code: "unavailable", message: "Prompt submission failed." },
 				}),
 			}),
 		]),

--- a/packages/coding-agent/test/tools/issue-2643-openai-completions-wire.test.ts
+++ b/packages/coding-agent/test/tools/issue-2643-openai-completions-wire.test.ts
@@ -145,7 +145,7 @@ describe("issue #2643 — OpenAI completions AskTool wire contract", () => {
 	});
 
 	it("locally corrects the bounded Round-0 pair and returns exact rejection codes for stripped constraints", async () => {
-		const tool = await askTool();
+		const tool = await askTool("topology");
 		const validateRaw = tool.rawArgumentValidation;
 		if (!validateRaw) throw new Error("AskTool omitted raw argument validation");
 		const contract = {


### PR DESCRIPTION
## Summary
- add the newly required `getDisplayString` method to the shared command-palette keybinding test double
- align the accepted prompt terminal-event assertion with the standardized public failure message
- run the Round-0 wire recovery assertion under its required topology-stage authority

## Failure lineage
Post-merge Dev CI run 29999761289 failed shard 2 and shard 8 at exact dev head `e6861ed28a55e76688b6957a1086c1827fe34052`. This branch was rebased onto current dev `fb71a7e172298af6810b495afab16adccab2768a` before the commit.

`fb71a7e172298af6810b495afab16adccab2768a` is a direct child of the recovery merge and contains the narrow Windows/NTFS fix `fix(ci): tolerate lazy NTFS directory metadata in plain-tree walk identity check`. GitHub's commit API exposes no associated author/committer login for that push. It was not reverted because its code and commit message directly address the long-running Windows native safety path; this PR preserves it and layers only stale test-contract repairs.

## Verification
- focused three-file suite: 74 pass
- exact affected wrapper shard 2/8: 1505 pass, 32 skip, 0 fail
- exact affected wrapper shard 8/8: 1659 pass, 82 skip, 0 fail
- `bun --cwd=packages/coding-agent run check`: pass

Serialized recovery exception only. No release or tag action.

gaebal-gajae