### PR TITLE
fix(ci): cover native daemon authority implementations

### DIFF
--- a/scripts/telegram-daemon-generation-guard.test.ts
+++ b/scripts/telegram-daemon-generation-guard.test.ts
@@ -99,7 +99,7 @@ const nativeAuthoritySources = {
 		"exact_remove_directory_tree",
 	],
 	"crates/pi-natives/src/ps.rs": ["napi impl Process"],
-	"crates/pi-shell/src/process.rs": ["kill_process_group", "current_descendant_pids", "add_new_descendants"],
+	"crates/pi-shell/src/process.rs": ["impl Process", "kill_process_group", "current_descendant_pids", "add_new_descendants"],
 	"packages/natives/native/index.d.ts": ["Process"],
 	"packages/coding-agent/src/sdk/broker/process-incarnation.ts": ["isProcessIncarnation", "processIncarnation"],
 } as const;
@@ -108,10 +108,16 @@ function nativeAuthorityFiles(): Array<[string, string]> {
 	return [
 		[
 			"crates/pi-natives/src/path_identity.rs",
-			nativeAuthoritySources["crates/pi-natives/src/path_identity.rs"].map(name => `pub fn ${name}() {}`).join("\n"),
+			[
+				...nativeAuthoritySources["crates/pi-natives/src/path_identity.rs"].map(name => `pub fn ${name}() {}`),
+				`mod platform {\n${nativeAuthoritySources["crates/pi-natives/src/path_identity.rs"].map(name => `\tpub(super) fn ${name}() {}`).join("\n")}\n}`,
+			].join("\n"),
 		],
 		["crates/pi-natives/src/ps.rs", "#[napi]\nimpl Process {}"],
-		["crates/pi-shell/src/process.rs", "impl Process {}\npub fn kill_process_group() {}\npub fn current_descendant_pids() {}\npub fn add_new_descendants() {}"],
+		[
+			"crates/pi-shell/src/process.rs",
+			"impl Process { pub fn incarnation(&self) {} }\npub fn kill_process_group() {}\npub fn current_descendant_pids() {}\npub fn add_new_descendants() {}",
+		],
 		["packages/natives/native/index.d.ts", "export declare class Process {}"],
 		["packages/coding-agent/src/sdk/broker/process-incarnation.ts", "export function isProcessIncarnation() {}\nexport function processIncarnation() {}"],
 	];
@@ -517,6 +523,36 @@ test("fails closed when a protected native authority declaration is missing or m
 	malformed.set(source, "export function isProcessIncarnation() {}\nexport function processIncarnation( {");
 	expect(decide(base, malformed).malformedDeclarations).toContain(source + ":authority");
 });
+	test("hashes restricted native path implementations behind public wrappers", () => {
+		const source = "crates/pi-natives/src/path_identity.rs";
+		const base = files({ telegramGeneration: 6, discordGeneration: 4, slackGeneration: 4 });
+		const head = new Map(base);
+		head.set(
+			source,
+			(head.get(source) ?? "").replace(
+				"pub(super) fn apply_owner_only_path_security() {}",
+				"pub(super) fn apply_owner_only_path_security() { let changed = true; }",
+			),
+		);
+		expect(decide(base, head).nativeAuthorityChanges).toEqual([
+			"telegram:" + source + ":authority",
+			"discord:" + source + ":authority",
+			"slack:" + source + ":authority",
+		]);
+	});
+
+	test("hashes core Process methods used by daemon control", () => {
+		const source = "crates/pi-shell/src/process.rs";
+		const base = files({ telegramGeneration: 6, discordGeneration: 4, slackGeneration: 4 });
+		const head = new Map(base);
+		head.set(source, (head.get(source) ?? "").replace("pub fn incarnation(&self) {}", "pub fn incarnation(&self) { let changed = true; }"));
+		expect(decide(base, head).nativeAuthorityChanges).toEqual([
+			"telegram:" + source + ":authority",
+			"discord:" + source + ":authority",
+			"slack:" + source + ":authority",
+		]);
+	});
+
 	test("hashes every Rust platform implementation and lexes declaration braces", () => {
 		const source = "crates/pi-shell/src/process.rs";
 		const platformSource = [

--- a/scripts/telegram-daemon-generation-guard.ts
+++ b/scripts/telegram-daemon-generation-guard.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 
 const root = path.join(import.meta.dir, "..");
 const SHA = /^[0-9a-f]{40}$/i;
-export const GUARD_CONTRACT_VERSION = 24;
+export const GUARD_CONTRACT_VERSION = 25;
 const telegramContract = "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts";
 const telegramDaemon = "packages/coding-agent/src/sdk/bus/telegram-daemon.ts";
 const telegramControl = "packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts";
@@ -35,7 +35,7 @@ const nativeAuthorityDeclarations = {
 		"exact_remove_directory_tree",
 	],
 	"crates/pi-natives/src/ps.rs": ["napi impl Process"],
-	"crates/pi-shell/src/process.rs": ["kill_process_group", "current_descendant_pids", "add_new_descendants"],
+	"crates/pi-shell/src/process.rs": ["impl Process", "kill_process_group", "current_descendant_pids", "add_new_descendants"],
 	"packages/natives/native/index.d.ts": ["Process"],
 	"packages/coding-agent/src/sdk/broker/process-incarnation.ts": ["isProcessIncarnation", "processIncarnation"],
 } as const;
@@ -191,7 +191,7 @@ function inventoryHash(inventory: Inventory): string {
 }
 
 export function validateInventory(inventory: Inventory = protectedInventory): void {
-	if (GUARD_CONTRACT_VERSION !== 24) throw new Error("telegram-daemon-generation-guard: unsupported guard contract version");
+	if (GUARD_CONTRACT_VERSION !== 25) throw new Error("telegram-daemon-generation-guard: unsupported guard contract version");
 	for (const [family, files] of Object.entries(inventory)) {
 		for (const [file, symbols] of Object.entries(files)) {
 			if (!file || symbols.length === 0 || new Set(symbols).size !== symbols.length)
@@ -679,7 +679,7 @@ function rustDeclaration(source: string, selector: string): Declaration {
 		? "#\\[napi\\](?:\\s*#\\[[^\\]]+\\])*\\s*impl\\s+Process\\b"
 		: declarationName === "impl Process"
 			? "impl\\s+Process\\b"
-			: `(?:#\\[[^\\]]+\\]\\s*)*pub\\s+(?:async\\s+)?fn\\s+${declarationName}\\b`;
+			: `(?:#\\[[^\\]]+\\]\\s*)*pub(?:\\(super\\))?\\s+(?:async\\s+)?fn\\s+${declarationName}\\b`;
 	const pattern = new RegExp(prefix, "g");
 	const matches = [...lexical.code.matchAll(pattern)];
 	if (matches.length === 0) return undefined;

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": 24,
+  "contractVersion": 25,
   "inventory": {
     "telegram": {
       "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts": [
@@ -527,9 +527,9 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:writeJsonAtomic": "a768c87646d56cf28b0adbd596884c964aed54ea40775517fa385c111af05a5b"
   },
   "nativeAuthoritySha256": {
-    "crates/pi-natives/src/path_identity.rs": "0eb1f5111bdcc8782ea7923d53f1e99c7ca95a01675c4be2ff5332c159dee8cd",
+    "crates/pi-natives/src/path_identity.rs": "c2c4d0be8e3e50c3938d73959da141055e914348cab30b1061b62491e8dcb80d",
     "crates/pi-natives/src/ps.rs": "7696078e123b9beecc7252371c71eab2cec590413be6e6ddf4692ff6fe8c41e1",
-    "crates/pi-shell/src/process.rs": "627b5f43bc4e19cfd2d4b0a9907bd511ebeab07f6ea3c776872dd73805865aca",
+    "crates/pi-shell/src/process.rs": "785e41bf94d69a085eaa621dfbad0f7dd629d99559fc81a75331466755e04227",
     "packages/natives/native/index.d.ts": "c61e02fd4712c822d30fb4b1496f064097a38718c9443bef526711f828165c50",
     "packages/coding-agent/src/sdk/broker/process-incarnation.ts": "cedd073107475b238757c6167129484ccec27fe49a2fb52b72f71592d78a7814"
   }


### PR DESCRIPTION
## Problem

The semantic native-authority guard introduced in #3007 narrowed two existing ownership boundaries too far:

- Rust function selectors matched `pub fn` but not the `pub(super) fn` platform implementations in `path_identity.rs`.
- `pi-shell` authority covered three free functions but omitted the core `impl Process` methods used for incarnation, signaling, child traversal, status, and termination behavior.

This meant those authority implementations could change without changing the native authority digest or requiring the mapped Telegram/Discord/Slack generation bumps.

Review evidence:
- https://github.com/Yeachan-Heo/gajae-code/pull/3007#discussion_r3637351187
- https://github.com/Yeachan-Heo/gajae-code/pull/3007#discussion_r3637351196

## Narrow fix

- Include `pub(super)` implementations for the already-listed Rust path-authority symbols.
- Include every `impl Process` block in the `crates/pi-shell/src/process.rs` authority digest.
- Bump the guard contract to v25 and regenerate only the semantic manifest hashes.
- Add focused regressions proving each previously missed implementation changes all three mapped authority receipts.

No daemon runtime, public API, generation number, or unrelated native source behavior changes.

## Exact-head evidence

Base: `fb71a7e172298af6810b495afab16adccab2768a`
Head: `a8545f10833579a1a62a481ab77bd82ce2ae9ebd`

- `bun test scripts/telegram-daemon-generation-guard.test.ts` — 39 pass, 0 fail
- `bun run check:tools` — Biome and tools TypeScript check pass
- `bun scripts/telegram-daemon-generation-guard.ts --validate-current-tree` — pass
- exact base/head guard execution — `telegram-daemon-generation-guard: v25 no protected changes`
- `git diff --check upstream/dev...HEAD` — pass
- `git merge-tree --write-tree upstream/dev HEAD` — clean (`641e3f0b7f47669ad4ddc935842ecafb4c7f77c3`)

Global integration freeze is respected; this follow-up does not request a merge exception and can wait for terminal-green `dev` CI plus explicit owner unfreeze.