### PR TITLE
fix(session): repair Windows artifact migration recovery

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -227,7 +227,7 @@ jobs:
       - name: Windows session-path canonicalization regression
         shell: pwsh
         run: |
-          bun test packages/coding-agent/test/session-manager/windows-canonical-path.test.ts
+          bun test packages/coding-agent/test/session-manager/windows-canonical-path.test.ts packages/coding-agent/test/session-manager/session-directory.test.ts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   windows-telegram-daemon-safety:

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -1264,6 +1264,202 @@ function receiptMatches(
 	}
 }
 
+function plannedDetachedArtifactPath(sourcePath: string, operation: string): string {
+	return path.join(path.dirname(sourcePath), `.gjc-migrate-${operation}-artifacts`);
+}
+
+type ParsedReceiptArtifactIdentity = {
+	dev: bigint;
+	ino: bigint;
+	size: bigint;
+	mtimeNs: bigint;
+};
+
+function artifactDirectoryIdentityFromTree(
+	tree: NativeDirectoryTreeSnapshot,
+): ParsedReceiptArtifactIdentity | undefined {
+	const root = tree.entries.find(entry => entry.relativePath === "" && entry.kind === "directory");
+	if (!root) return undefined;
+	const rootDev = parseDecimalString(tree.rootDev);
+	const rootIno = parseDecimalString(tree.rootIno);
+	const dev = parseDecimalString(root.dev);
+	const ino = parseDecimalString(root.ino);
+	const size = parseDecimalString(root.size);
+	const mtimeNs = parseDecimalString(root.mtimeNs);
+	if (
+		rootDev === undefined ||
+		rootIno === undefined ||
+		dev === undefined ||
+		ino === undefined ||
+		size === undefined ||
+		mtimeNs === undefined ||
+		rootDev !== dev ||
+		rootIno !== ino
+	)
+		return undefined;
+	return { dev, ino, size, mtimeNs };
+}
+
+function sameArtifactIdentity(
+	left: ParsedReceiptArtifactIdentity | undefined,
+	right: ParsedReceiptArtifactIdentity | undefined,
+): boolean {
+	return (
+		!!left &&
+		!!right &&
+		left.dev === right.dev &&
+		left.ino === right.ino &&
+		left.size === right.size &&
+		left.mtimeNs === right.mtimeNs
+	);
+}
+
+function sameNativeDirectoryTree(
+	left: NativeDirectoryTreeSnapshot,
+	right: NativeDirectoryTreeSnapshot,
+	ignoreRootCtime = false,
+): boolean {
+	return (
+		left.rootDev === right.rootDev &&
+		left.rootIno === right.rootIno &&
+		left.entries.length === right.entries.length &&
+		left.entries.every((entry, index) => {
+			const other = right.entries[index];
+			return (
+				other !== undefined &&
+				entry.relativePath === other.relativePath &&
+				entry.kind === other.kind &&
+				entry.dev === other.dev &&
+				entry.ino === other.ino &&
+				entry.size === other.size &&
+				entry.mtimeNs === other.mtimeNs &&
+				(ignoreRootCtime && entry.relativePath === "" ? true : entry.ctimeNs === other.ctimeNs) &&
+				entry.sha256 === other.sha256
+			);
+		})
+	);
+}
+
+type ParsedPreparedArtifactReceipt = {
+	attemptId: string;
+	sourceArtifactQuarantine?: {
+		path: string;
+		detachedPath: string;
+		identity: ParsedReceiptArtifactIdentity;
+		tree: NativeDirectoryTreeSnapshot;
+	};
+};
+function parsePreparedArtifactQuarantine(
+	record: unknown,
+	source: ManagedCandidate,
+	operation: string,
+): ParsedPreparedArtifactReceipt["sourceArtifactQuarantine"] {
+	if (record === undefined) return undefined;
+	if (!record || typeof record !== "object") throw new Error("durability_failed");
+	const value = record as {
+		path?: unknown;
+		detachedPath?: unknown;
+		identity?: unknown;
+		tree?: unknown;
+	};
+	const expectedPath = source.path.slice(0, -6);
+	const expectedDetachedPath = plannedDetachedArtifactPath(source.path, operation);
+	const identityRecord = value.identity as Record<string, unknown> | undefined;
+	const dev = typeof identityRecord?.dev === "string" ? parseDecimalString(identityRecord.dev) : undefined;
+	const ino = typeof identityRecord?.ino === "string" ? parseDecimalString(identityRecord.ino) : undefined;
+	const size = typeof identityRecord?.size === "string" ? parseDecimalString(identityRecord.size) : undefined;
+	const mtimeNs = typeof identityRecord?.mtimeNs === "string" ? parseDecimalString(identityRecord.mtimeNs) : undefined;
+	const tree = artifactTreeSnapshot(value.tree);
+	if (
+		typeof value.path !== "string" ||
+		value.path !== expectedPath ||
+		typeof value.detachedPath !== "string" ||
+		value.detachedPath !== expectedDetachedPath ||
+		dev === undefined ||
+		ino === undefined ||
+		size === undefined ||
+		mtimeNs === undefined ||
+		!tree
+	)
+		throw new Error("durability_failed");
+	const identity: ParsedReceiptArtifactIdentity = { dev, ino, size, mtimeNs };
+	const parsedTreeIdentity = artifactDirectoryIdentityFromTree(tree);
+	if (!sameArtifactIdentity(identity, parsedTreeIdentity)) throw new Error("durability_failed");
+	return { path: value.path, detachedPath: value.detachedPath, identity, tree };
+}
+function parsePreparedArtifactReceipt(
+	receiptPath: string,
+	scope: ManagedScope,
+	source: ManagedCandidate,
+	destination: { path: string; sessionId: string; cwd: string },
+): ParsedPreparedArtifactReceipt {
+	const record = JSON.parse(captureManagedFileNoFollow(receiptPath).bytes.toString("utf8"));
+	if (!record || typeof record !== "object") throw new Error("durability_failed");
+	const value = record as {
+		schemaVersion?: unknown;
+		state?: unknown;
+		policy?: unknown;
+		scope?: unknown;
+		attemptId?: unknown;
+		source?: unknown;
+		destination?: unknown;
+		artifactManifest?: unknown;
+		sourceArtifactQuarantine?: unknown;
+	};
+	if (
+		value.schemaVersion !== 2 ||
+		value.state !== "prepared" ||
+		value.policy !== "copy-retain" ||
+		value.scope !== scopeDigest(scope.platform, scope.canonicalCwd) ||
+		typeof value.attemptId !== "string" ||
+		value.attemptId.length === 0 ||
+		!Array.isArray(value.artifactManifest) ||
+		value.artifactManifest.length !== 0
+	) {
+		throw new Error("durability_failed");
+	}
+	const sourceRecord = value.source as Record<string, unknown> | undefined;
+	const destinationRecord = value.destination as Record<string, unknown> | undefined;
+	const sourceHeader = sourceRecord?.header as Record<string, unknown> | undefined;
+	const destinationHeader = destinationRecord?.header as Record<string, unknown> | undefined;
+	const sourceIdentity = sourceRecord?.identity as Record<string, unknown> | undefined;
+	const operation = stableOperationName(source);
+	if (
+		!sourceRecord ||
+		typeof sourceRecord.path !== "string" ||
+		sourceRecord.path !== source.path ||
+		sourceRecord.sessionId !== source.sessionId ||
+		sourceRecord.sha256 !== source.identity.sha256 ||
+		!sourceHeader ||
+		typeof sourceHeader.id !== "string" ||
+		sourceHeader.id !== source.sessionId ||
+		typeof sourceHeader.cwd !== "string" ||
+		sourceHeader.cwd !== source.cwd ||
+		!sourceIdentity ||
+		sourceIdentity.dev !== String(source.identity.dev) ||
+		sourceIdentity.ino !== String(source.identity.ino) ||
+		sourceIdentity.size !== source.identity.size ||
+		sourceIdentity.mtimeNs !== String(source.identity.mtimeNs)
+	) {
+		throw new Error("durability_failed");
+	}
+	if (
+		!destinationRecord ||
+		typeof destinationRecord.path !== "string" ||
+		destinationRecord.path !== destination.path ||
+		destinationRecord.sessionId !== destination.sessionId ||
+		!destinationHeader ||
+		typeof destinationHeader.id !== "string" ||
+		destinationHeader.id !== destination.sessionId ||
+		destinationHeader.cwd !== destination.cwd
+	) {
+		throw new Error("durability_failed");
+	}
+	return {
+		attemptId: value.attemptId,
+		sourceArtifactQuarantine: parsePreparedArtifactQuarantine(value.sourceArtifactQuarantine, source, operation),
+	};
+}
 function preparedReceiptMatches(
 	receiptPath: string,
 	scope: ManagedScope,
@@ -1272,44 +1468,17 @@ function preparedReceiptMatches(
 	artifactPlan: DetachedArtifactRoot | undefined,
 ): boolean {
 	try {
-		const record = JSON.parse(captureManagedFileNoFollow(receiptPath).bytes.toString("utf8")) as Record<
-			string,
-			unknown
-		>;
-		const recordedSource = record.source as Record<string, unknown> | undefined;
-		const recordedDestination = record.destination as Record<string, unknown> | undefined;
-		const quarantine = record.sourceArtifactQuarantine as Record<string, unknown> | undefined;
-		const identity = quarantine?.identity as Record<string, unknown> | undefined;
-		return (
-			record.schemaVersion === 2 &&
-			record.state === "prepared" &&
-			record.policy === "copy-retain" &&
-			record.scope === scopeDigest(scope.platform, scope.canonicalCwd) &&
-			Array.isArray(record.artifactManifest) &&
-			record.artifactManifest.length === 0 &&
-			recordedSource?.path === source.path &&
-			recordedSource.sessionId === source.sessionId &&
-			recordedSource.sha256 === source.identity.sha256 &&
-			(recordedSource.identity as Record<string, unknown> | undefined)?.dev === String(source.identity.dev) &&
-			(recordedSource.identity as Record<string, unknown> | undefined)?.ino === String(source.identity.ino) &&
-			(recordedSource.identity as Record<string, unknown> | undefined)?.size === source.identity.size &&
-			(recordedSource.identity as Record<string, unknown> | undefined)?.mtimeNs ===
-				String(source.identity.mtimeNs) &&
-			recordedDestination?.path === destination.path &&
-			recordedDestination.sessionId === destination.sessionId &&
-			recordedDestination.header instanceof Object &&
-			(recordedDestination.header as Record<string, unknown>).id === destination.sessionId &&
-			(recordedDestination.header as Record<string, unknown>).cwd === destination.cwd &&
-			(artifactPlan
-				? quarantine?.path === artifactPlan.originalPath &&
+		const parsed = parsePreparedArtifactReceipt(receiptPath, scope, source, destination);
+		const quarantine = parsed.sourceArtifactQuarantine;
+		return artifactPlan
+			? !!(
+					quarantine &&
+					quarantine.path === artifactPlan.originalPath &&
 					quarantine.detachedPath === artifactPlan.detachedPath &&
-					identity?.dev === String(artifactPlan.identity.dev) &&
-					identity.ino === String(artifactPlan.identity.ino) &&
-					identity.size === String(artifactPlan.identity.size) &&
-					identity.mtimeNs === String(artifactPlan.identity.mtimeNs) &&
-					JSON.stringify(artifactTreeSnapshot(quarantine.tree)) === JSON.stringify(artifactPlan.tree)
-				: quarantine === undefined)
-		);
+					sameArtifactIdentity(quarantine.identity, artifactPlan.identity) &&
+					(process.platform !== "win32" || sameNativeDirectoryTree(quarantine.tree, artifactPlan.tree))
+				)
+			: !quarantine;
 	} catch {
 		return false;
 	}
@@ -1773,41 +1942,53 @@ function artifactIdentityAt(pathname: string): SessionStorageFileIdentity | unde
 	}
 }
 
+const DECIMAL_PATTERN = /^\d+$/;
+const parseDecimalString = (value: unknown): bigint | undefined => {
+	if (typeof value !== "string" || !DECIMAL_PATTERN.test(value)) return;
+	return BigInt(value);
+};
+
+const isSafeRelativePath = (relativePath: string): boolean =>
+	!path.isAbsolute(relativePath) && !relativePath.split(/[\\/]/).includes("..");
+
 function artifactTreeSnapshot(value: unknown): NativeDirectoryTreeSnapshot | undefined {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
 	const snapshot = value as Record<string, unknown>;
-	if (typeof snapshot.rootDev !== "string" || typeof snapshot.rootIno !== "string" || !Array.isArray(snapshot.entries))
-		return undefined;
 	if (
-		snapshot.entries.length === 0 ||
-		!snapshot.entries.every(entry => {
-			if (!entry || typeof entry !== "object" || Array.isArray(entry)) return false;
-			const item = entry as Record<string, unknown>;
-			return (
-				typeof item.relativePath === "string" &&
-				!path.isAbsolute(item.relativePath) &&
-				!item.relativePath.split(/[\\/]/).includes("..") &&
-				(item.kind === "file" || item.kind === "directory") &&
-				typeof item.dev === "string" &&
-				typeof item.ino === "string" &&
-				typeof item.size === "string" &&
-				typeof item.mtimeNs === "string" &&
-				typeof item.ctimeNs === "string" &&
-				(item.sha256 === undefined || typeof item.sha256 === "string")
-			);
-		})
+		parseDecimalString(snapshot.rootDev) === undefined ||
+		parseDecimalString(snapshot.rootIno) === undefined ||
+		!Array.isArray(snapshot.entries)
 	)
 		return undefined;
-	const roots = snapshot.entries.filter(entry => {
-		const item = entry as Record<string, unknown>;
-		return (
-			item.relativePath === "" &&
-			item.kind === "directory" &&
-			item.dev === snapshot.rootDev &&
-			item.ino === snapshot.rootIno
-		);
-	});
-	if (roots.length !== 1) return undefined;
+	const entries = snapshot.entries as Array<Record<string, unknown>>;
+	if (entries.length === 0) return undefined;
+	const seen = new Set<string>();
+	let rootCount = 0;
+	for (const entry of entries) {
+		if (!entry || typeof entry !== "object" || Array.isArray(entry)) return undefined;
+		if (typeof entry.relativePath !== "string" || !isSafeRelativePath(entry.relativePath)) return undefined;
+		const relativePath = entry.relativePath;
+		if (seen.has(relativePath)) return undefined;
+		seen.add(relativePath);
+		if (entry.kind !== "file" && entry.kind !== "directory") return undefined;
+		if (relativePath === "") {
+			if (entry.kind !== "directory" || entry.dev !== snapshot.rootDev || entry.ino !== snapshot.rootIno)
+				return undefined;
+			rootCount++;
+		}
+		if (
+			parseDecimalString(entry.dev) === undefined ||
+			parseDecimalString(entry.ino) === undefined ||
+			parseDecimalString(entry.size) === undefined ||
+			parseDecimalString(entry.mtimeNs) === undefined ||
+			parseDecimalString(entry.ctimeNs) === undefined
+		) {
+			return undefined;
+		}
+		if (entry.kind === "file" && typeof entry.sha256 !== "undefined" && typeof entry.sha256 !== "string")
+			return undefined;
+	}
+	if (rootCount !== 1) return undefined;
 	return snapshot as unknown as NativeDirectoryTreeSnapshot;
 }
 
@@ -2269,15 +2450,16 @@ function planArtifactRootForMigration(sourceTranscript: string, operation: strin
 	}
 	if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("unsafe_artifacts");
 	const tree = snapshotArtifactTree(originalPath);
-	const root = tree.entries.find(entry => entry.relativePath === "" && entry.kind === "directory");
-	if (!root) throw new Error("unsafe_artifacts");
+	const identity = artifactDirectoryIdentityFromTree(tree);
+	if (!identity || identity.dev !== stat.dev || identity.ino !== stat.ino || identity.mtimeNs !== stat.mtimeNs)
+		throw new Error("unsafe_artifacts");
 	return {
 		originalPath,
 		detachedPath: path.join(path.dirname(originalPath), `.gjc-migrate-${operation}-artifacts`),
 		identity: {
 			dev: stat.dev,
 			ino: stat.ino,
-			size: process.platform === "win32" ? BigInt(root.size) : stat.size,
+			size: process.platform === "win32" ? identity.size : stat.size,
 			mtimeNs: stat.mtimeNs,
 		},
 		tree,
@@ -2300,26 +2482,64 @@ function sameDirectoryObject(leftPath: string, rightPath: string): boolean {
 		return false;
 	}
 }
+function artifactRootExistsNoFollow(pathname: string): boolean {
+	try {
+		const stat = fs.lstatSync(pathname);
+		if (stat.isSymbolicLink() || !stat.isDirectory()) throw new Error("unsafe_artifacts");
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+function assertDetachedArtifactRoot(pathname: string, plan: DetachedArtifactRoot, requireTree: boolean): void {
+	let observed: fs.BigIntStats;
+	try {
+		observed = fs.lstatSync(pathname, { bigint: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") throw new Error("durability_failed");
+		throw error;
+	}
+	if (!observed.isDirectory() || observed.isSymbolicLink()) throw new Error("unsafe_artifacts");
+	if (
+		observed.dev !== plan.identity.dev ||
+		observed.ino !== plan.identity.ino ||
+		observed.mtimeNs !== plan.identity.mtimeNs ||
+		(process.platform !== "win32" && observed.size !== plan.identity.size)
+	) {
+		throw new Error("durability_failed");
+	}
+	const expectedParent = path.dirname(plan.detachedPath);
+	if (!sameDirectoryObject(path.dirname(pathname), expectedParent)) throw new Error("durability_failed");
+	const treePath =
+		process.platform === "win32" && artifactRootExistsNoFollow(plan.detachedPath) ? plan.detachedPath : pathname;
+	if (
+		process.platform === "win32" &&
+		(!sameDirectoryObject(pathname, treePath) || !sameDirectoryObject(path.dirname(treePath), expectedParent))
+	) {
+		throw new Error("durability_failed");
+	}
+	if (!requireTree) return;
+	const observedTree = snapshotArtifactTree(treePath);
+	const observedIdentity = artifactDirectoryIdentityFromTree(observedTree);
+	if (!sameArtifactIdentity(observedIdentity, plan.identity) || !sameNativeDirectoryTree(observedTree, plan.tree))
+		throw new Error("durability_failed");
+}
+function assertRestoredArtifactRoot(pathname: string, plan: DetachedArtifactRoot): void {
+	assertDetachedArtifactRoot(pathname, plan, false);
+	const observedTree = snapshotArtifactTree(pathname);
+	const observedIdentity = artifactDirectoryIdentityFromTree(observedTree);
+	if (
+		!sameArtifactIdentity(observedIdentity, plan.identity) ||
+		!sameNativeDirectoryTree(observedTree, plan.tree, process.platform !== "win32")
+	)
+		throw new Error("durability_failed");
+}
 
 function matchesDetachedArtifactRoot(pathname: string, plan: DetachedArtifactRoot): boolean {
-	try {
-		const stat = fs.lstatSync(pathname, { bigint: true });
-		const snapshot = native.snapshotDirectoryTree(pathname);
-		const root = snapshot.snapshot?.entries.find(entry => entry.relativePath === "" && entry.kind === "directory");
-		return (
-			stat.isDirectory() &&
-			!stat.isSymbolicLink() &&
-			stat.dev === plan.identity.dev &&
-			stat.ino === plan.identity.ino &&
-			stat.mtimeNs === plan.identity.mtimeNs &&
-			(process.platform === "win32"
-				? snapshot.ok && !!root && BigInt(root.size) === plan.identity.size
-				: stat.size === plan.identity.size) &&
-			sameDirectoryObject(path.dirname(pathname), path.dirname(plan.detachedPath))
-		);
-	} catch {
-		return false;
-	}
+	assertDetachedArtifactRoot(pathname, plan, process.platform === "win32");
+	return true;
 }
 
 function sameArtifactTree(left: NativeDirectoryTreeSnapshot, right: NativeDirectoryTreeSnapshot): boolean {
@@ -2380,10 +2600,11 @@ function cleanupAuthorityMatches(cleanup: SourceArtifactCleanup, parent: string)
 	}
 }
 
-function detachArtifactRootForMigration(plan: DetachedArtifactRoot): {
-	detached: DetachedArtifactRoot;
-	cleanup?: SourceArtifactCleanup;
-} {
+function detachArtifactRootForMigration(
+	plan: DetachedArtifactRoot,
+	assertPublicationConsent?: () => void,
+): { detached: DetachedArtifactRoot; cleanup?: SourceArtifactCleanup } {
+	assertPublicationConsent?.();
 	const result = native.exactUnlink(plan.originalPath, {
 		...plan.identity,
 		directory: true,
@@ -2410,6 +2631,7 @@ function detachArtifactRootForMigration(plan: DetachedArtifactRoot): {
 		process.platform === "win32" ? fs.realpathSync.native(result.detachedPath) : result.detachedPath;
 	if (!matchesDetachedArtifactRoot(detachedPath, plan)) throw new Error("durability_failed");
 	const detached = { ...plan, detachedPath };
+	assertPublicationConsent?.();
 	if (!cleanupPending) return { detached };
 	const placeholder = result.retainedPlaceholderPath!;
 	const stat = fs.lstatSync(placeholder, { bigint: true });
@@ -2428,11 +2650,12 @@ function detachArtifactRootForMigration(plan: DetachedArtifactRoot): {
 	return { detached, cleanup };
 }
 
-function restorePreparedArtifactRoot(scope: ManagedScope, source: ManagedCandidate): void {
-	const preparedReceipt = receiptPathFor(scope, source, "prepared");
-	const detachedReceipt = receiptPathFor(scope, source, "detached");
-	const receipt = fs.existsSync(detachedReceipt) ? detachedReceipt : preparedReceipt;
-	let record: {
+function restoreDetachedReceiptArtifactRoot(
+	receipt: string,
+	source: ManagedCandidate,
+	assertPublicationConsent?: () => void,
+): void {
+	const record = JSON.parse(captureManagedFileNoFollow(receipt).bytes.toString("utf8")) as {
 		sourceArtifactQuarantine?: {
 			path?: unknown;
 			detachedPath?: unknown;
@@ -2448,98 +2671,150 @@ function restorePreparedArtifactRoot(scope: ManagedScope, source: ManagedCandida
 			tree?: unknown;
 		};
 	};
-	try {
-		record = JSON.parse(captureManagedFileNoFollow(receipt).bytes.toString("utf8")) as typeof record;
-	} catch {
-		if (!fs.existsSync(receipt)) return;
-		throw new Error("durability_failed");
-	}
 	const quarantine = record.sourceArtifactQuarantine;
-	if (!quarantine) return;
-	const identity = quarantine.identity;
+	const identity = quarantine?.identity;
+	const tree = artifactTreeSnapshot(quarantine?.tree);
 	if (
-		quarantine.path !== source.path.slice(0, -6) ||
+		quarantine?.path !== source.path.slice(0, -6) ||
 		typeof quarantine.detachedPath !== "string" ||
 		path.dirname(quarantine.detachedPath) !== path.dirname(source.path) ||
 		!path.basename(quarantine.detachedPath).startsWith(".gjc-migrate-") ||
-		!artifactTreeSnapshot(quarantine.tree) ||
+		quarantine.role !== "detached_artifact_root" ||
 		!identity ||
 		typeof identity.dev !== "string" ||
 		typeof identity.ino !== "string" ||
 		typeof identity.size !== "string" ||
-		typeof identity.mtimeNs !== "string"
+		typeof identity.mtimeNs !== "string" ||
+		!tree
 	)
 		throw new Error("durability_failed");
-	if (receipt === detachedReceipt && quarantine.role !== "detached_artifact_root")
-		throw new Error("durability_failed");
-	if (receipt === detachedReceipt) {
-		const cleanup = record.sourceArtifactCleanup;
-		const cleanupIdentity = cleanup?.identity;
-		const cleanupTree = artifactTreeSnapshot(cleanup?.tree);
-		if (
-			cleanup?.state !== "cleanup_pending" ||
-			cleanup.role !== "exchange_placeholder" ||
-			typeof cleanup.retainedPath !== "string" ||
-			!cleanupIdentity ||
-			typeof cleanupIdentity.dev !== "string" ||
-			typeof cleanupIdentity.ino !== "string" ||
-			typeof cleanupIdentity.size !== "string" ||
-			typeof cleanupIdentity.mtimeNs !== "string" ||
-			!cleanupTree ||
-			!cleanupAuthorityMatches(
-				{
-					state: "cleanup_pending",
-					role: "exchange_placeholder",
-					retainedPath: cleanup.retainedPath,
-					identity: {
-						dev: BigInt(cleanupIdentity.dev),
-						ino: BigInt(cleanupIdentity.ino),
-						size: BigInt(cleanupIdentity.size),
-						mtimeNs: BigInt(cleanupIdentity.mtimeNs),
-					},
-					tree: cleanupTree,
-				},
-				path.dirname(source.path),
-			)
-		)
-			throw new Error("durability_failed");
-	}
 
-	const expectedTree = artifactTreeSnapshot(quarantine.tree)!;
-	const assertPreparedTree = (pathname: string): void => {
-		validateManagedArtifactTree(pathname);
-		const observed = native.snapshotDirectoryTree(pathname);
-		if (!observed.ok || !observed.snapshot || !sameArtifactTree(observed.snapshot, expectedTree))
-			throw new Error("durability_failed");
+	const cleanup = record.sourceArtifactCleanup;
+	const cleanupIdentity = cleanup?.identity;
+	const cleanupTree = artifactTreeSnapshot(cleanup?.tree);
+	if (
+		cleanup?.state !== "cleanup_pending" ||
+		cleanup.role !== "exchange_placeholder" ||
+		typeof cleanup.retainedPath !== "string" ||
+		!cleanupIdentity ||
+		typeof cleanupIdentity.dev !== "string" ||
+		typeof cleanupIdentity.ino !== "string" ||
+		typeof cleanupIdentity.size !== "string" ||
+		typeof cleanupIdentity.mtimeNs !== "string" ||
+		!cleanupTree
+	)
+		throw new Error("durability_failed");
+	const cleanupAuthority: SourceArtifactCleanup = {
+		state: "cleanup_pending",
+		role: "exchange_placeholder",
+		retainedPath: cleanup.retainedPath,
+		identity: {
+			dev: BigInt(cleanupIdentity.dev),
+			ino: BigInt(cleanupIdentity.ino),
+			size: BigInt(cleanupIdentity.size),
+			mtimeNs: BigInt(cleanupIdentity.mtimeNs),
+		},
+		tree: cleanupTree,
 	};
-	if (fs.existsSync(quarantine.path)) {
-		const existing = fs.lstatSync(quarantine.path, { bigint: true });
+	if (!cleanupAuthorityMatches(cleanupAuthority, path.dirname(source.path))) throw new Error("durability_failed");
+
+	const detached: DetachedArtifactRoot = {
+		originalPath: quarantine.path,
+		detachedPath: quarantine.detachedPath,
+		identity: {
+			dev: BigInt(identity.dev),
+			ino: BigInt(identity.ino),
+			size: BigInt(identity.size),
+			mtimeNs: BigInt(identity.mtimeNs),
+		},
+		tree,
+	};
+	if (artifactRootExistsNoFollow(detached.originalPath)) {
+		const existing = fs.lstatSync(detached.originalPath, { bigint: true });
 		if (
 			!existing.isSymbolicLink() &&
 			existing.isDirectory() &&
-			existing.dev === BigInt(identity.dev) &&
-			existing.ino === BigInt(identity.ino) &&
-			existing.size === BigInt(identity.size) &&
-			existing.mtimeNs === BigInt(identity.mtimeNs)
-		) {
-			assertPreparedTree(quarantine.path);
-		}
-		// A changed source pathname is independent retained authority. Do not replace
-		// it with the detached original; retain both roots for recovery.
+			existing.dev === detached.identity.dev &&
+			existing.ino === detached.identity.ino &&
+			existing.size === detached.identity.size &&
+			existing.mtimeNs === detached.identity.mtimeNs
+		)
+			assertRestoredArtifactRoot(detached.originalPath, detached);
 		return;
 	}
-	assertPreparedTree(quarantine.detachedPath);
-	const result = native.exactRestore(quarantine.detachedPath, quarantine.path, {
-		dev: BigInt(identity.dev),
-		ino: BigInt(identity.ino),
-		size: BigInt(identity.size),
-		mtimeNs: BigInt(identity.mtimeNs),
+	assertPublicationConsent?.();
+	assertDetachedArtifactRoot(detached.detachedPath, detached, true);
+	restoreDetachedArtifactRoot(detached, cleanupAuthority, assertPublicationConsent);
+}
+
+function restorePreparedArtifactRoot(
+	scope: ManagedScope,
+	source: ManagedCandidate,
+	destination: { path: string; sessionId: string; cwd: string },
+	assertPublicationConsent?: () => void,
+): void {
+	assertPublicationConsent?.();
+	const detachedReceipt = receiptPathFor(scope, source, "detached");
+	if (fs.existsSync(detachedReceipt)) {
+		restoreDetachedReceiptArtifactRoot(detachedReceipt, source, assertPublicationConsent);
+		return;
+	}
+	const receipt = receiptPathFor(scope, source, "prepared");
+	let parsedReceipt: ParsedPreparedArtifactReceipt;
+	try {
+		parsedReceipt = parsePreparedArtifactReceipt(receipt, scope, source, destination);
+	} catch {
+		try {
+			fs.lstatSync(receipt);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		}
+		throw new Error("durability_failed");
+	}
+	const quarantine = parsedReceipt.sourceArtifactQuarantine;
+	if (!quarantine) {
+		const detachedPath = plannedDetachedArtifactPath(source.path, stableOperationName(source));
+		if (artifactRootExistsNoFollow(detachedPath)) throw new Error("durability_failed");
+		return;
+	}
+	const prepared = {
+		originalPath: quarantine.path,
+		detachedPath: quarantine.detachedPath,
+		identity: quarantine.identity,
+		tree: quarantine.tree,
+	};
+	const detachedExists = artifactRootExistsNoFollow(prepared.detachedPath);
+	const originalExists = artifactRootExistsNoFollow(prepared.originalPath);
+	if (originalExists && detachedExists) throw new Error("destination_conflict");
+	if (originalExists) {
+		assertPublicationConsent?.();
+		assertRestoredArtifactRoot(prepared.originalPath, prepared);
+		assertPublicationConsent?.();
+		return;
+	}
+	if (!detachedExists) throw new Error("durability_failed");
+	assertPublicationConsent?.();
+	assertDetachedArtifactRoot(prepared.detachedPath, prepared, true);
+	assertPublicationConsent?.();
+	const result = native.exactRestore(prepared.detachedPath, prepared.originalPath, {
+		dev: prepared.identity.dev,
+		ino: prepared.identity.ino,
+		size: prepared.identity.size,
+		mtimeNs: prepared.identity.mtimeNs,
 		directory: true,
 	});
 	if (!result.ok) throw new Error("durability_failed");
+	assertPublicationConsent?.();
+	assertRestoredArtifactRoot(prepared.originalPath, prepared);
+	assertPublicationConsent?.();
 }
 
-function restoreDetachedArtifactRoot(detached: DetachedArtifactRoot, cleanup?: SourceArtifactCleanup): void {
+function restoreDetachedArtifactRoot(
+	detached: DetachedArtifactRoot,
+	cleanup?: SourceArtifactCleanup,
+	assertPublicationConsent?: () => void,
+): void {
+	assertPublicationConsent?.();
 	if (cleanup && !cleanupAuthorityMatches(cleanup, path.dirname(detached.originalPath)))
 		throw new Error("durability_failed");
 	const result = native.exactRestore(detached.detachedPath, detached.originalPath, {
@@ -2547,6 +2822,8 @@ function restoreDetachedArtifactRoot(detached: DetachedArtifactRoot, cleanup?: S
 		directory: true,
 	});
 	if (!result.ok) throw new Error("durability_failed");
+	assertRestoredArtifactRoot(detached.originalPath, detached);
+	assertPublicationConsent?.();
 }
 
 async function copyArtifacts(
@@ -2557,6 +2834,7 @@ async function copyArtifacts(
 	lock: ManagedStorageLock,
 	expectedCandidate: ManagedCandidate,
 	expectedIdentity: ResumeSessionIdentity,
+	assertPublicationConsent?: () => void,
 	sourceRootOverride?: string,
 ): Promise<void> {
 	const root = scopeRoot(scope);
@@ -2587,7 +2865,7 @@ async function copyArtifacts(
 			throw new Error("source_changed");
 		try {
 			revalidatePickerConsent(scope, expectedCandidate, expectedIdentity);
-			await copyManagedFileNoReplace(source, destination, snapshot, root);
+			await copyManagedFileNoReplace(source, destination, snapshot, assertPublicationConsent, root);
 		} catch (error) {
 			if ((error as Error).message !== "destination_conflict") throw error;
 		}
@@ -2602,7 +2880,6 @@ async function copyArtifacts(
 	if (!manifestMatches(sourceTranscript, manifest, sourceRoot) || !manifestMatches(destinationTranscript, manifest))
 		throw new Error("durability_failed");
 }
-
 function migrationReceipt(
 	scope: ManagedScope,
 	lock: ManagedStorageLock,
@@ -2957,7 +3234,7 @@ export async function openManagedCandidateForWrite(
 	let lock: ManagedStorageLock | undefined;
 	let detachedArtifacts: DetachedArtifactRoot | undefined;
 	let sourceArtifactCleanup: SourceArtifactCleanup | undefined;
-
+	let assertPublicationConsent: (() => void) | undefined;
 	try {
 		revalidatePickerConsent(scope, current, expectedIdentity);
 		lock = await acquireManagedLock(path.join(internal, MANAGED_LOCKS_DIRECTORY), operation, scopeRoot(scope));
@@ -2979,26 +3256,15 @@ export async function openManagedCandidateForWrite(
 
 		scopeRoot(scope);
 		revalidatePickerConsent(scope, afterLock, expectedIdentity);
-		restorePreparedArtifactRoot(scope, afterLock);
-		scopeRoot(scope);
-
-		let sourceSnapshot = captureManagedFileNoFollow(afterLock.path);
-		if (
-			sourceSnapshot.identity.dev !== afterLock.identity.dev ||
-			sourceSnapshot.identity.ino !== afterLock.identity.ino ||
-			sourceSnapshot.identity.size !== afterLock.identity.size ||
-			sourceSnapshot.identity.mtimeNs !== afterLock.identity.mtimeNs ||
-			sourceSnapshot.identity.sha256 !== afterLock.identity.sha256 ||
-			sourceSnapshot.bytes.byteLength !== afterLock.identity.size
-		)
-			throw new Error("source_changed");
-		let manifest: readonly ArtifactManifestEntry[] = [];
-		const artifactPlan = planArtifactRootForMigration(afterLock.path, operation);
-		const intendedDestination = { path: destination, sessionId: afterLock.sessionId, cwd: afterLock.cwd };
-		const assertPublicationConsent = (): void => {
+		assertPublicationConsent = () => {
 			heldLock.assertOwned();
 			revalidatePickerConsent(scope, afterLock, expectedIdentity);
 		};
+		const intendedDestination = { path: destination, sessionId: afterLock.sessionId, cwd: afterLock.cwd };
+		restorePreparedArtifactRoot(scope, afterLock, intendedDestination, assertPublicationConsent);
+		scopeRoot(scope);
+		let manifest: readonly ArtifactManifestEntry[] = [];
+		const artifactPlan = planArtifactRootForMigration(afterLock.path, operation);
 		if (existing && existing.identity.sha256 !== afterLock.identity.sha256) {
 			return {
 				kind: "error",
@@ -3047,14 +3313,14 @@ export async function openManagedCandidateForWrite(
 		lock.assertOwned();
 		if (!preparedReceiptMatches(preparedReceipt, scope, afterLock, intendedDestination, artifactPlan))
 			throw new Error("durability_failed");
-		if (artifactPlan && fs.existsSync(artifactPlan.detachedPath)) throw new Error("destination_conflict");
-
+		if (artifactPlan && artifactRootExistsNoFollow(artifactPlan.detachedPath))
+			throw new Error("destination_conflict");
 		revalidatePickerConsent(scope, afterLock, expectedIdentity);
 
 		scopeRoot(scope);
 
 		if (artifactPlan) {
-			const detached = detachArtifactRootForMigration(artifactPlan);
+			const detached = detachArtifactRootForMigration(artifactPlan, assertPublicationConsent);
 			detachedArtifacts = detached.detached;
 			sourceArtifactCleanup = detached.cleanup;
 			const detachedReceipt = receiptPathFor(scope, afterLock, "detached");
@@ -3096,29 +3362,24 @@ export async function openManagedCandidateForWrite(
 			lock,
 			afterLock,
 			expectedIdentity,
+			assertPublicationConsent,
 			detachedArtifacts?.detachedPath,
 		);
-
-		if (!existing) {
-			revalidatePickerConsent(scope, afterLock, expectedIdentity);
-			lock.assertOwned();
-			sourceSnapshot = captureManagedFileNoFollow(afterLock.path);
-			if (
-				sourceSnapshot.identity.dev !== afterLock.identity.dev ||
-				sourceSnapshot.identity.ino !== afterLock.identity.ino ||
-				sourceSnapshot.identity.size !== afterLock.identity.size ||
-				sourceSnapshot.identity.mtimeNs !== afterLock.identity.mtimeNs ||
-				sourceSnapshot.identity.sha256 !== afterLock.identity.sha256 ||
-				sourceSnapshot.bytes.byteLength !== afterLock.identity.size
-			)
-				throw new Error("source_changed");
-		}
 
 		if (!existing) {
 			try {
 				revalidatePickerConsent(scope, afterLock, expectedIdentity);
 				lock.assertOwned();
-				await copyManagedFileNoReplace(afterLock.path, destination, sourceSnapshot, scopeRoot(scope));
+				assertPublicationConsent?.();
+				const sourceSnapshot = captureManagedFileNoFollow(afterLock.path);
+				assertPublicationConsent?.();
+				await copyManagedFileNoReplace(
+					afterLock.path,
+					destination,
+					sourceSnapshot,
+					assertPublicationConsent,
+					scopeRoot(scope),
+				);
 			} catch (error) {
 				if ((error as Error).message !== "destination_conflict") throw error;
 			}
@@ -3141,7 +3402,7 @@ export async function openManagedCandidateForWrite(
 		if (detachedArtifacts) {
 			revalidatePickerConsent(scope, afterLock, expectedIdentity);
 			scopeRoot(scope);
-			restoreDetachedArtifactRoot(detachedArtifacts, sourceArtifactCleanup);
+			restoreDetachedArtifactRoot(detachedArtifacts, sourceArtifactCleanup, assertPublicationConsent);
 			detachedArtifacts = undefined;
 		}
 
@@ -3206,8 +3467,18 @@ export async function openManagedCandidateForWrite(
 		};
 	} catch (error) {
 		try {
-			if (detachedArtifacts) restoreDetachedArtifactRoot(detachedArtifacts, sourceArtifactCleanup);
-		} catch {
+			if (detachedArtifacts)
+				restoreDetachedArtifactRoot(detachedArtifacts, sourceArtifactCleanup, assertPublicationConsent);
+		} catch (restoreError) {
+			const restoreCode = expectedFailure(restoreError);
+			if (restoreCode === "migration_busy" || restoreCode === "source_changed") {
+				return {
+					kind: "error",
+					code: restoreCode,
+					message:
+						restoreError instanceof Error ? restoreError.message : "Managed migration recovery lost authority.",
+				};
+			}
 			return {
 				kind: "error",
 				code: "durability_failed",

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -1505,13 +1505,16 @@ export async function copyManagedFileNoReplace(
 	source: string,
 	destination: string,
 	snapshot = captureManagedFileNoFollow(source),
+	assertPublicationConsent?: () => void,
 	root?: ManagedDirectoryRoot,
 	policy: ManagedSessionSecurityPolicy = "default",
 ): Promise<void> {
+	assertPublicationConsent?.();
 	const named = captureManagedFileNoFollow(source);
+	assertPublicationConsent?.();
 	if (!sameIdentity(snapshot.identity, named.identity) || !snapshot.bytes.equals(named.bytes))
 		throw new Error("source_changed");
-	await publishManagedFileNoReplace(destination, snapshot.bytes, undefined, root, policy);
+	await publishManagedFileNoReplace(destination, snapshot.bytes, assertPublicationConsent, root, policy);
 	const destinationSnapshot = captureManagedFileNoFollow(destination);
 	if (!destinationSnapshot.bytes.equals(snapshot.bytes)) throw new Error("durability_failed");
 }

--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -11,7 +11,9 @@ import {
 	prepareManagedSessionScopeForWrite,
 	resolveManagedScope,
 } from "../../src/session/internal/managed-session-scope";
+import * as managedStorage from "../../src/session/internal/managed-session-storage";
 import {
+	copyManagedFileNoReplace,
 	publishManagedFileNoReplace,
 	validateNativeSecurityResult,
 } from "../../src/session/internal/managed-session-storage";
@@ -299,6 +301,27 @@ describe("managed session write protocol", () => {
 		expect(await fs.readFile(destination, "utf8")).toBe("managed\n");
 		expect((await fs.readdir(scope.directoryPath)).filter(name => name.endsWith(".staging"))).toEqual([]);
 	});
+	it("forwards copy consent through the final no-replace publication boundary", async () => {
+		const { scope } = await fixture();
+		await prepareManagedSessionScopeForWrite(scope);
+		const source = path.join(scope.directoryPath, "copy-source.jsonl");
+		const destination = path.join(scope.directoryPath, "copy-destination.jsonl");
+		await fs.writeFile(source, "managed\n");
+		let consentChecks = 0;
+		const assertPublicationConsent = (): void => {
+			consentChecks++;
+			if (consentChecks === 4) throw new Error("migration_busy");
+		};
+
+		await expect(copyManagedFileNoReplace(source, destination, undefined, assertPublicationConsent)).rejects.toThrow(
+			"migration_busy",
+		);
+
+		expect(consentChecks).toBe(4);
+		await expect(fs.access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(await fs.readFile(source, "utf8")).toBe("managed\n");
+		expect((await fs.readdir(scope.directoryPath)).filter(name => name.endsWith(".staging"))).toEqual([]);
+	});
 	it("quarantines and restores the complete legacy artifact topology before committing migration authority", async () => {
 		const { cwd, sessionsRoot, scope } = await fixture();
 		const legacy = legacyDirectory(sessionsRoot, cwd);
@@ -430,6 +453,103 @@ describe("managed session write protocol", () => {
 		if (!detached) throw new Error("Missing retained detached artifact root");
 		expect(await fs.readFile(path.join(legacy, detached, "payload.txt"), "utf8")).toBe("authoritative");
 	});
+	it("captures the transcript after artifact detach and immediately supplies that snapshot to copy", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const legacy = legacyDirectory(sessionsRoot, cwd);
+		const source = path.join(legacy, "transcript-capture-order.jsonl");
+		const sourceArtifacts = source.slice(0, -6);
+		await fs.mkdir(sourceArtifacts, { recursive: true });
+		await fs.writeFile(source, transcript("transcript-capture-order", cwd));
+		await fs.writeFile(path.join(sourceArtifacts, "payload.txt"), "authoritative");
+		const listed = listManagedCandidates(scope);
+		if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
+
+		const exactUnlink = native.exactUnlink;
+		const capture = managedStorage.captureManagedFileNoFollow;
+		const copy = managedStorage.copyManagedFileNoReplace;
+		const beforeArtifactTransaction = capture(source);
+		let artifactDetached = false;
+		let copyObserved = false;
+		const unlink = vi.spyOn(native, "exactUnlink").mockImplementation((pathname, identity) => {
+			const result = exactUnlink(pathname, identity);
+			if (identity.directory && identity.detachOnly && result.ok) {
+				artifactDetached = true;
+				syncFs.chmodSync(source, 0o444);
+				syncFs.chmodSync(source, 0o600);
+				const afterArtifactDetach = capture(source);
+				expect(afterArtifactDetach.identity.dev).toBe(beforeArtifactTransaction.identity.dev);
+				expect(afterArtifactDetach.identity.ino).toBe(beforeArtifactTransaction.identity.ino);
+				expect(afterArtifactDetach.identity.size).toBe(beforeArtifactTransaction.identity.size);
+				expect(afterArtifactDetach.identity.mtimeNs).toBe(beforeArtifactTransaction.identity.mtimeNs);
+				expect(afterArtifactDetach.identity.sha256).toBe(beforeArtifactTransaction.identity.sha256);
+				expect(afterArtifactDetach.identity.ctimeNs).not.toBe(beforeArtifactTransaction.identity.ctimeNs);
+			}
+			return result;
+		});
+		const copySpy = vi
+			.spyOn(managedStorage, "copyManagedFileNoReplace")
+			.mockImplementation(async (sourcePath, destinationPath, snapshot, consent, root, policy) => {
+				if (sourcePath === source) {
+					expect(artifactDetached).toBe(true);
+					expect(snapshot).toEqual(capture(source));
+					expect(snapshot?.identity.ctimeNs).not.toBe(beforeArtifactTransaction.identity.ctimeNs);
+					copyObserved = true;
+				}
+				return copy(sourcePath, destinationPath, snapshot, consent, root, policy);
+			});
+		try {
+			const opened = await openManagedCandidateForWrite(scope, listed.owned[0]);
+			expect(opened).toMatchObject({ kind: "opened", migrated: true });
+		} finally {
+			copySpy.mockRestore();
+			unlink.mockRestore();
+		}
+		expect(copyObserved).toBe(true);
+	});
+	it.skipIf(process.platform !== "win32")(
+		"uses native artifact-root size authority when Bun reports a different directory size",
+		async () => {
+			const { cwd, sessionsRoot, scope } = await fixture();
+			const legacy = legacyDirectory(sessionsRoot, cwd);
+			const source = path.join(legacy, "mixed-directory-size.jsonl");
+			const sourceArtifacts = source.slice(0, -6);
+			await fs.mkdir(sourceArtifacts, { recursive: true });
+			await fs.writeFile(source, transcript("mixed-directory-size", cwd));
+			await fs.writeFile(path.join(sourceArtifacts, "payload.txt"), "payload");
+			const nativeTree = native.snapshotDirectoryTree(sourceArtifacts);
+			if (!nativeTree.ok || !nativeTree.snapshot) throw new Error("Missing native artifact snapshot");
+			const nativeRoot = nativeTree.snapshot.entries.find(entry => entry.relativePath === "");
+			if (!nativeRoot) throw new Error("Missing native artifact root");
+			const nativeSize = BigInt(nativeRoot.size);
+			const syntheticBunSize = nativeSize === 0n ? 4096n : 0n;
+			const lstatSync = syncFs.lstatSync;
+			const syntheticLstatSync = ((...args: Parameters<typeof syncFs.lstatSync>) => {
+				const stat = lstatSync(...args);
+				if (!stat) return stat;
+				const pathname = args[0];
+				if (
+					typeof pathname === "string" &&
+					typeof stat.size === "bigint" &&
+					stat.isDirectory() &&
+					(path.resolve(pathname) === path.resolve(sourceArtifacts) ||
+						path.basename(pathname).startsWith(".gjc-migrate-"))
+				) {
+					Object.defineProperty(stat, "size", { value: syntheticBunSize });
+				}
+				return stat;
+			}) as typeof syncFs.lstatSync;
+			const lstat = vi.spyOn(syncFs, "lstatSync").mockImplementation(syntheticLstatSync);
+			try {
+				const listed = listManagedCandidates(scope);
+				if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
+				const opened = await openManagedCandidateForWrite(scope, listed.owned[0]);
+				expect(opened).toMatchObject({ kind: "opened", migrated: true });
+				expect(syntheticBunSize).not.toBe(nativeSize);
+			} finally {
+				lstat.mockRestore();
+			}
+		},
+	);
 	it("retains a detached legacy artifact root when exact restoration collides", async () => {
 		const { cwd, sessionsRoot, scope } = await fixture();
 		const legacy = legacyDirectory(sessionsRoot, cwd);
@@ -461,6 +581,306 @@ describe("managed session write protocol", () => {
 		if (!detached) throw new Error("Missing retained detached artifact root");
 		expect(await fs.readFile(path.join(legacy, detached, "payload.txt"), "utf8")).toBe("authoritative");
 		expect(await fs.readFile(source, "utf8")).toBe(transcript("restore-collision", cwd));
+	});
+	it("retries a prepared migration after the authorized artifact root was already restored", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const legacy = legacyDirectory(sessionsRoot, cwd);
+		const source = path.join(legacy, "prepared-restored.jsonl");
+		const sourceArtifacts = source.slice(0, -6);
+		await fs.mkdir(path.join(sourceArtifacts, "nested"), { recursive: true });
+		await fs.writeFile(source, transcript("prepared-restored", cwd));
+		await fs.writeFile(path.join(sourceArtifacts, "nested", "payload.txt"), "authoritative");
+		const listed = listManagedCandidates(scope);
+		if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
+
+		const exactRestore = native.exactRestore;
+		let forcedFailure = false;
+		const restore = vi.spyOn(native, "exactRestore").mockImplementation((detachedPath, originalPath, identity) => {
+			const result = exactRestore(detachedPath, originalPath, identity);
+			if (!forcedFailure && result.ok && path.basename(detachedPath).startsWith(".gjc-migrate-")) {
+				forcedFailure = true;
+				return { ...result, ok: false, code: "forced_post_restore_failure" };
+			}
+			return result;
+		});
+		try {
+			await expect(openManagedCandidateForWrite(scope, listed.owned[0])).resolves.toMatchObject({
+				kind: "error",
+				code: "durability_failed",
+			});
+		} finally {
+			restore.mockRestore();
+		}
+		expect(forcedFailure).toBe(true);
+		expect(await fs.readFile(path.join(sourceArtifacts, "nested", "payload.txt"), "utf8")).toBe("authoritative");
+
+		const receipts = path.join(scope.directoryPath, ".gjc-managed-session-internal", "receipts");
+		expect((await fs.readdir(receipts)).filter(name => name.endsWith(".prepared.json"))).toHaveLength(1);
+		const retryListing = listManagedCandidates(scope);
+		if (retryListing.kind !== "complete") throw new Error(retryListing.message);
+		const retryCandidate = retryListing.owned.find(candidate => candidate.path === source);
+		if (!retryCandidate) throw new Error("Missing retained legacy candidate");
+
+		const retried = await openManagedCandidateForWrite(scope, retryCandidate);
+		expect(retried).toMatchObject({ kind: "opened", migrated: true });
+		if (retried.kind !== "opened") throw new Error(retried.message);
+		expect(await fs.readFile(path.join(retried.path.slice(0, -6), "nested", "payload.txt"), "utf8")).toBe(
+			"authoritative",
+		);
+		expect((await fs.readdir(receipts)).filter(name => name.endsWith(".prepared.json"))).toHaveLength(0);
+		expect((await fs.readdir(receipts)).filter(name => name.endsWith(".published.json"))).toHaveLength(0);
+	});
+	it.skipIf(process.platform !== "win32")(
+		"rejects a prepared receipt with a non-deterministic detached artifact path before mutation",
+		async () => {
+			const { cwd, sessionsRoot, scope } = await fixture();
+			const legacy = legacyDirectory(sessionsRoot, cwd);
+			const source = path.join(legacy, "prepared-path-tamper.jsonl");
+			const sourceArtifacts = source.slice(0, -6);
+			await fs.mkdir(sourceArtifacts, { recursive: true });
+			await fs.writeFile(source, transcript("prepared-path-tamper", cwd));
+			await fs.writeFile(path.join(sourceArtifacts, "payload.txt"), "authoritative");
+			const listed = listManagedCandidates(scope);
+			if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
+
+			const exactRestore = native.exactRestore;
+			let forcedFailure = false;
+			const restoreFailure = vi
+				.spyOn(native, "exactRestore")
+				.mockImplementation((detachedPath, originalPath, identity) => {
+					const result = exactRestore(detachedPath, originalPath, identity);
+					if (!forcedFailure && result.ok && path.basename(detachedPath).startsWith(".gjc-migrate-")) {
+						forcedFailure = true;
+						return { ...result, ok: false, code: "forced_post_restore_failure" };
+					}
+					return result;
+				});
+			try {
+				await expect(openManagedCandidateForWrite(scope, listed.owned[0])).resolves.toMatchObject({
+					kind: "error",
+					code: "durability_failed",
+				});
+			} finally {
+				restoreFailure.mockRestore();
+			}
+			expect(forcedFailure).toBe(true);
+
+			const receipts = path.join(scope.directoryPath, ".gjc-managed-session-internal", "receipts");
+			const preparedName = (await fs.readdir(receipts)).find(name => name.endsWith(".prepared.json"));
+			if (!preparedName) throw new Error("Missing prepared receipt");
+			const preparedPath = path.join(receipts, preparedName);
+			const prepared = JSON.parse(await fs.readFile(preparedPath, "utf8")) as {
+				sourceArtifactQuarantine?: { detachedPath?: string };
+			};
+			if (!prepared.sourceArtifactQuarantine) throw new Error("Missing prepared artifact authority");
+			prepared.sourceArtifactQuarantine.detachedPath = path.join(legacy, ".gjc-migrate-forged-artifacts");
+			await fs.writeFile(preparedPath, `${JSON.stringify(prepared)}\n`);
+
+			const restore = vi.spyOn(native, "exactRestore");
+			const unlink = vi.spyOn(native, "exactUnlink");
+			try {
+				const retryListing = listManagedCandidates(scope);
+				if (retryListing.kind !== "complete") throw new Error(retryListing.message);
+				const retryCandidate = retryListing.owned.find(candidate => candidate.path === source);
+				if (!retryCandidate) throw new Error("Missing retained legacy candidate");
+				await expect(openManagedCandidateForWrite(scope, retryCandidate)).resolves.toMatchObject({
+					kind: "error",
+					code: "durability_failed",
+				});
+			} finally {
+				restore.mockRestore();
+				unlink.mockRestore();
+			}
+			expect(restore).not.toHaveBeenCalled();
+			expect(unlink).not.toHaveBeenCalled();
+			expect(await fs.readFile(path.join(sourceArtifacts, "payload.txt"), "utf8")).toBe("authoritative");
+			expect(await fs.readFile(preparedPath, "utf8")).toContain(".gjc-migrate-forged-artifacts");
+			expect(
+				(await fs.readdir(receipts)).filter(
+					name => name.endsWith(".json") && !name.endsWith(".prepared.json") && !name.endsWith(".published.json"),
+				),
+			).toHaveLength(0);
+		},
+	);
+	it("rejects an omitted prepared quarantine when deterministic detached evidence exists", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const legacy = legacyDirectory(sessionsRoot, cwd);
+		const source = path.join(legacy, "prepared-quarantine-omitted.jsonl");
+		const sourceArtifacts = source.slice(0, -6);
+		await fs.mkdir(sourceArtifacts, { recursive: true });
+		await fs.writeFile(source, transcript("prepared-quarantine-omitted", cwd));
+		await fs.writeFile(path.join(sourceArtifacts, "payload.txt"), "authoritative");
+		const listed = listManagedCandidates(scope);
+		if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
+
+		const exactUnlink = native.exactUnlink;
+		let interrupted = false;
+		const unlinkFailure = vi.spyOn(native, "exactUnlink").mockImplementation((pathname, identity) => {
+			const result = exactUnlink(pathname, identity);
+			if (!interrupted && identity.directory && identity.detachOnly && result.ok) {
+				interrupted = true;
+				throw new Error("simulated_crash_after_detach");
+			}
+			return result;
+		});
+		try {
+			await expect(openManagedCandidateForWrite(scope, listed.owned[0])).resolves.toMatchObject({ kind: "error" });
+		} finally {
+			unlinkFailure.mockRestore();
+		}
+		expect(interrupted).toBe(true);
+
+		const receipts = path.join(scope.directoryPath, ".gjc-managed-session-internal", "receipts");
+		const preparedName = (await fs.readdir(receipts)).find(name => name.endsWith(".prepared.json"));
+		if (!preparedName) throw new Error("Missing prepared receipt");
+		const preparedPath = path.join(receipts, preparedName);
+		const prepared = JSON.parse(await fs.readFile(preparedPath, "utf8")) as Record<string, unknown>;
+		delete prepared.sourceArtifactQuarantine;
+		await fs.writeFile(preparedPath, `${JSON.stringify(prepared)}\n`);
+
+		const restore = vi.spyOn(native, "exactRestore");
+		const unlink = vi.spyOn(native, "exactUnlink");
+		try {
+			const retryListing = listManagedCandidates(scope);
+			if (retryListing.kind !== "complete") throw new Error(retryListing.message);
+			const retryCandidate = retryListing.owned.find(candidate => candidate.path === source);
+			if (!retryCandidate) throw new Error("Missing retained legacy candidate");
+			await expect(openManagedCandidateForWrite(scope, retryCandidate)).resolves.toMatchObject({
+				kind: "error",
+				code: "durability_failed",
+			});
+		} finally {
+			restore.mockRestore();
+			unlink.mockRestore();
+		}
+		expect(restore).not.toHaveBeenCalled();
+		expect(unlink).not.toHaveBeenCalled();
+		const detached = (await fs.readdir(legacy)).find(
+			name => name.startsWith(".gjc-migrate-") && name.endsWith("-artifacts"),
+		);
+		if (!detached) throw new Error("Missing retained detached evidence");
+		expect(await fs.readFile(path.join(legacy, detached, "payload.txt"), "utf8")).toBe("authoritative");
+	});
+	it("recovers a prepared migration whose artifact root was detached before an interrupted return", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const legacy = legacyDirectory(sessionsRoot, cwd);
+		const source = path.join(legacy, "prepared-detached.jsonl");
+		const sourceArtifacts = source.slice(0, -6);
+		await fs.mkdir(sourceArtifacts, { recursive: true });
+		await fs.writeFile(source, transcript("prepared-detached", cwd));
+		await fs.writeFile(path.join(sourceArtifacts, "payload.txt"), "authoritative");
+		const listed = listManagedCandidates(scope);
+		if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
+
+		const exactUnlink = native.exactUnlink;
+		let interrupted = false;
+		const unlink = vi.spyOn(native, "exactUnlink").mockImplementation((pathname, identity) => {
+			const result = exactUnlink(pathname, identity);
+			if (!interrupted && identity.directory && identity.detachOnly && result.ok) {
+				interrupted = true;
+				throw new Error("simulated_crash_after_detach");
+			}
+			return result;
+		});
+		try {
+			await expect(openManagedCandidateForWrite(scope, listed.owned[0])).resolves.toMatchObject({ kind: "error" });
+		} finally {
+			unlink.mockRestore();
+		}
+		expect(interrupted).toBe(true);
+		await expect(fs.access(sourceArtifacts)).rejects.toMatchObject({ code: "ENOENT" });
+		const detached = (await fs.readdir(legacy)).find(
+			name => name.startsWith(".gjc-migrate-") && name.endsWith("-artifacts"),
+		);
+		if (!detached) throw new Error("Missing retained detached root");
+		expect(await fs.readFile(path.join(legacy, detached, "payload.txt"), "utf8")).toBe("authoritative");
+
+		const retryListing = listManagedCandidates(scope);
+		if (retryListing.kind !== "complete") throw new Error(retryListing.message);
+		const retryCandidate = retryListing.owned.find(candidate => candidate.path === source);
+		if (!retryCandidate) throw new Error("Missing retained legacy candidate");
+		const retried = await openManagedCandidateForWrite(scope, retryCandidate);
+		expect(retried).toMatchObject({ kind: "opened", migrated: true });
+		if (retried.kind !== "opened") throw new Error(retried.message);
+		expect(await fs.readFile(path.join(sourceArtifacts, "payload.txt"), "utf8")).toBe("authoritative");
+		expect(await fs.readFile(path.join(retried.path.slice(0, -6), "payload.txt"), "utf8")).toBe("authoritative");
+	});
+	it("rejects false native restore success and re-establishes the exact source root", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const legacy = legacyDirectory(sessionsRoot, cwd);
+		const source = path.join(legacy, "false-restore-success.jsonl");
+		const sourceArtifacts = source.slice(0, -6);
+		await fs.mkdir(sourceArtifacts, { recursive: true });
+		await fs.writeFile(source, transcript("false-restore-success", cwd));
+		await fs.writeFile(path.join(sourceArtifacts, "payload.txt"), "authoritative");
+		const listed = listManagedCandidates(scope);
+		if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
+
+		const exactRestore = native.exactRestore;
+		let lied = false;
+		const restore = vi.spyOn(native, "exactRestore").mockImplementation((detachedPath, originalPath, identity) => {
+			if (!lied && path.basename(detachedPath).startsWith(".gjc-migrate-")) {
+				lied = true;
+				return { ok: true };
+			}
+			return exactRestore(detachedPath, originalPath, identity);
+		});
+		try {
+			await expect(openManagedCandidateForWrite(scope, listed.owned[0])).resolves.toMatchObject({
+				kind: "error",
+				code: "durability_failed",
+			});
+		} finally {
+			restore.mockRestore();
+		}
+		expect(lied).toBe(true);
+		expect(await fs.readFile(path.join(sourceArtifacts, "payload.txt"), "utf8")).toBe("authoritative");
+		const receipts = path.join(scope.directoryPath, ".gjc-managed-session-internal", "receipts");
+		expect(
+			(await fs.readdir(receipts)).filter(
+				name => name.endsWith(".json") && !name.endsWith(".prepared.json") && !name.endsWith(".published.json"),
+			),
+		).toHaveLength(0);
+	});
+	it("stops after artifact detach when picker identity changes before publication", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const legacy = legacyDirectory(sessionsRoot, cwd);
+		const source = path.join(legacy, "picker-loss-after-detach.jsonl");
+		const sourceArtifacts = source.slice(0, -6);
+		await fs.mkdir(sourceArtifacts, { recursive: true });
+		await fs.writeFile(source, transcript("picker-loss-after-detach", cwd, "original"));
+		await fs.writeFile(path.join(sourceArtifacts, "payload.txt"), "authoritative");
+		const listed = listManagedCandidates(scope);
+		if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
+
+		const replacement = transcript("picker-loss-after-detach", cwd, "replacement");
+		const exactUnlink = native.exactUnlink;
+		let replaced = false;
+		const unlink = vi.spyOn(native, "exactUnlink").mockImplementation((pathname, identity) => {
+			const result = exactUnlink(pathname, identity);
+			if (!replaced && identity.directory && identity.detachOnly && result.ok) {
+				replaced = true;
+				syncFs.unlinkSync(source);
+				syncFs.writeFileSync(source, replacement);
+			}
+			return result;
+		});
+		try {
+			await expect(openManagedCandidateForWrite(scope, listed.owned[0])).resolves.toMatchObject({
+				kind: "error",
+				code: "source_changed",
+			});
+		} finally {
+			unlink.mockRestore();
+		}
+		expect(replaced).toBe(true);
+		expect(await fs.readFile(source, "utf8")).toBe(replacement);
+		await expect(fs.access(sourceArtifacts)).rejects.toMatchObject({ code: "ENOENT" });
+		const detached = (await fs.readdir(legacy)).find(
+			name => name.startsWith(".gjc-migrate-") && name.endsWith("-artifacts"),
+		);
+		if (!detached) throw new Error("Missing retained detached root");
+		expect(await fs.readFile(path.join(legacy, detached, "payload.txt"), "utf8")).toBe("authoritative");
 	});
 	it("lists disabled legacy candidates read-only, rejects mutation, then migrates safely when re-enabled", async () => {
 		const { cwd, sessionsRoot, scope } = await fixture();

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -126,16 +126,40 @@ describe("dev-ci canonical-plan workflow contract", () => {
 	test("routes the Windows session-path regression suite onto windows-latest and requires it", async () => {
 		const workflow = await Bun.file(path.join(import.meta.dir, "..", ".github", "workflows", "dev-ci.yml")).text();
 		expect(workflow).toContain("has_windows_session_path: ${{ steps.plan.outputs.has_windows_session_path }}");
-		const windowsJob = workflow.slice(workflow.indexOf("  windows-dev-doctor:"), workflow.indexOf("\n  affected-native:"));
+		const jobStart = workflow.indexOf("  windows-dev-doctor:");
+		const jobEnd = workflow.indexOf("\n  windows-telegram-daemon-safety:", jobStart);
+		expect(jobStart).toBeGreaterThan(-1);
+		expect(jobEnd).toBeGreaterThan(jobStart);
+		const windowsJob = workflow.slice(jobStart, jobEnd);
+		const requiredPredicate =
+			"contains(needs.affected-plan.outputs.changed_paths, 'scripts/dev-link') || needs.affected-plan.outputs.has_windows_session_path == 'true'";
 		expect(windowsJob).toContain("runs-on: windows-latest");
-		expect(windowsJob).toContain("needs.affected-plan.outputs.has_windows_session_path == 'true'");
-		expect(windowsJob).toContain("Windows session-path canonicalization regression");
-		expect(windowsJob).toContain("bun test packages/coding-agent/test/session-manager/windows-canonical-path.test.ts");
-		// The required predicate must textually match the job gate so the aggregate
-		// invariant (windowsDoctor === required ? success : skipped) never fails closed.
-		const requiredLines = workflow.split("\n").filter(line => line.includes("CI_DEV_WINDOWS_DOCTOR_REQUIRED:"));
-		expect(requiredLines.length).toBe(2);
-		for (const line of requiredLines) expect(line).toContain("|| needs.affected-plan.outputs.has_windows_session_path == 'true'");
+		expect(windowsJob).toContain(
+			`if: \${{ needs.affected-plan.outputs.relevant == 'true' && (${requiredPredicate}) }}`,
+		);
+		const buildStart = windowsJob.indexOf("      - name: Build native addon (win32-x64 baseline)");
+		const regressionStart = windowsJob.indexOf("      - name: Windows session-path canonicalization regression");
+		expect(buildStart).toBeGreaterThan(-1);
+		expect(regressionStart).toBeGreaterThan(buildStart);
+		const buildStep = windowsJob.slice(buildStart, windowsJob.indexOf("\n      - name:", buildStart + 1));
+		expect(buildStep).toContain("TARGET_PLATFORM: win32");
+		expect(buildStep).toContain("TARGET_ARCH: x64");
+		expect(buildStep).toContain("TARGET_VARIANTS: baseline");
+		expect(buildStep.split("\n").filter(line => line.trim().startsWith("run:"))).toEqual([
+			"        run: bun run ci:build:native",
+		]);
+		const regressionStep = windowsJob.slice(regressionStart);
+		expect(regressionStep.split("\n").filter(line => line.trim().startsWith("bun test "))).toEqual([
+			"          bun test packages/coding-agent/test/session-manager/windows-canonical-path.test.ts packages/coding-agent/test/session-manager/session-directory.test.ts",
+		]);
+		const requiredLines = workflow
+			.split("\n")
+			.filter(line => line.includes("CI_DEV_WINDOWS_DOCTOR_REQUIRED:"))
+			.map(line => line.trim());
+		expect(requiredLines).toEqual([
+			`CI_DEV_WINDOWS_DOCTOR_REQUIRED: \${{ ${requiredPredicate} }}`,
+			`CI_DEV_WINDOWS_DOCTOR_REQUIRED: \${{ ${requiredPredicate} }}`,
+		]);
 	});
 
 	describe("detached evidence subprocess contract", () => {
@@ -1040,8 +1064,10 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 		for (const changedPath of [
 			"packages/coding-agent/src/session/internal/managed-session-scope.ts",
 			"packages/coding-agent/src/session/blob-store.ts",
+			"packages/coding-agent/src/session/internal/managed-session-storage.ts",
 			"packages/coding-agent/src/session/session-manager.ts",
 			"packages/coding-agent/test/session-manager/windows-canonical-path.test.ts",
+			"packages/coding-agent/test/session-manager/session-directory.test.ts",
 		]) {
 			expect(isWindowsSessionPathRegressionPath(changedPath)).toBe(true);
 			expect(needsWindowsSessionPathRegression([changedPath])).toBe(true);

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -417,9 +417,11 @@ export function needsDarwinArm64TabWorkerSmoke(paths: readonly string[]): boolea
 // run and require the windows-latest job whenever any of these change.
 export function isWindowsSessionPathRegressionPath(changedPath: string): boolean {
 	return changedPath === "packages/coding-agent/src/session/internal/managed-session-scope.ts" ||
+		changedPath === "packages/coding-agent/src/session/internal/managed-session-storage.ts" ||
 		changedPath === "packages/coding-agent/src/session/blob-store.ts" ||
 		changedPath === "packages/coding-agent/src/session/session-manager.ts" ||
-		changedPath === "packages/coding-agent/test/session-manager/windows-canonical-path.test.ts";
+		changedPath === "packages/coding-agent/test/session-manager/windows-canonical-path.test.ts" ||
+		changedPath === "packages/coding-agent/test/session-manager/session-directory.test.ts";
 }
 
 export function needsWindowsSessionPathRegression(paths: readonly string[]): boolean {


### PR DESCRIPTION
## Summary
- recover and rebase the Windows artifact migration repair onto current `dev`
- validate deterministic detached artifact evidence and restore exact artifact roots safely
- preserve publication consent checks and cleanup-pending authority across migration recovery
- update affected CI coverage for the session migration paths

## Verification
- `bun test packages/coding-agent/test/session-manager/session-directory.test.ts -t "(quarantines and restores the complete legacy artifact topology|captures the transcript after artifact detach|retains a detached legacy artifact root|rejects an omitted prepared quarantine|stops after artifact detach)"` (5 passed)
- `bun check` passed formatting, TypeScript declarations, Node 20, schema, and initial SDK gates; the aggregate run later hit the Windows test timeout
