### PR TITLE
fix(coding-agent): stop replay after no-op overflow compaction

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1196,6 +1196,9 @@ export class Agent {
 	 */
 	requestRunTerminal(logicalRunId: ManagedLogicalRunId, request: RunTerminalRequest): boolean {
 		if (this.#terminalizedLogicalRunIds.has(logicalRunId)) return false;
+		if (this.#managedLogicalRunOwner === logicalRunId) {
+			this.#managedLogicalRunOwner = undefined;
+		}
 		this.#finalizeRun(
 			logicalRunId,
 			{

--- a/packages/agent/test/managed-attempt-transaction.test.ts
+++ b/packages/agent/test/managed-attempt-transaction.test.ts
@@ -280,6 +280,53 @@ describe("managed attempt transaction", () => {
 		expect(agent.state.messages.filter(message => message.role === "assistant")).toHaveLength(0);
 	});
 
+	it("clears managed ownership before terminal observers run", async () => {
+		const mock = createMockModel();
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["test"], tools: [], messages: [] },
+			streamFn: async () => {
+				throw Object.assign(new Error(""), {
+					transportFailure: { kind: "transport", status: 400, openaiErrorCode: "context_length_exceeded" },
+				});
+			},
+		});
+		let ownerBeforeTerminal: number | undefined;
+		let ownerAtMessageEnd: number | undefined;
+		let ownerAtAgentEnd: number | undefined;
+		agent.subscribe(event => {
+			if (event.type === "message_end" && event.message.role === "assistant") {
+				ownerAtMessageEnd = agent.currentManagedLogicalRunId;
+			}
+			if (event.type === "agent_end") {
+				ownerAtAgentEnd = agent.currentManagedLogicalRunId;
+			}
+		});
+
+		await agent.prompt("run", {
+			fallbackManaged: true,
+			onManagedAttemptOutcome: outcome => {
+				if (outcome.type !== "context_overflow_discarded") {
+					throw new Error(`Expected discarded overflow, received ${outcome.type}`);
+				}
+				return {
+					type: "maintenance",
+					continuation: ownership => {
+						ownerBeforeTerminal = agent.currentManagedLogicalRunId;
+						agent.requestRunTerminal(ownership.logicalRunId, {
+							stopReason: "error",
+							messages: [outcome.message],
+						});
+					},
+				};
+			},
+		});
+
+		expect(ownerBeforeTerminal).toBeDefined();
+		expect(ownerAtMessageEnd).toBeUndefined();
+		expect(ownerAtAgentEnd).toBeUndefined();
+		expect(agent.currentManagedLogicalRunId).toBeUndefined();
+	});
+
 	it("discards retryable managed failures before any assistant lifecycle escapes", async () => {
 		const mock = createMockModel();
 		const streamFn = async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Overflow maintenance now stops cleanly when no-op compaction would replay the same oversized request; the runtime status explains that `/clear` preserves the current session ID before retrying.
 - Runtime MCP OAuth credentials are now bound to their authorized server origin and token endpoint, reject redirecting refresh responses, and fail closed when legacy or changed configuration lacks an exact match.
 - `/share` now keeps full-session HTML in owner-private unpredictable staging until the share handler or `gh gist create` process has fully stopped; cancelling a blocked gist upload terminates and awaits that process before reporting cancellation and removing the export.
 - MCP diagnostics now redact opaque endpoint paths, user information, query values, and fragments without changing outbound requests, and parse-failure logs omit response bodies that could echo request secrets.

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -893,6 +893,8 @@ export class EventController {
 			} else if (event.willRetry && !isHandoffAction) {
 				this.ctx.showStatus("Context overflow maintenance completed");
 			}
+		} else if (event.skipped && event.errorMessage && !isHandoffAction) {
+			this.ctx.showStatus(event.errorMessage);
 		} else if (event.errorMessage) {
 			this.ctx.showWarning(event.errorMessage);
 		} else if (isHandoffAction) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -10795,7 +10795,11 @@ export class AgentSession {
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
 	 */
-	async #checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<boolean> {
+	async #checkCompaction(
+		assistantMessage: AssistantMessage,
+		skipAbortedCheck = true,
+		onTerminalOverflowNoop?: () => void,
+	): Promise<boolean> {
 		// Safety stops are terminal and must not trigger context maintenance.
 		if (
 			assistantMessage.errorKind === "provider_safety_stop" ||
@@ -10831,8 +10835,10 @@ export class AgentSession {
 			// Remove the error message from agent state (it IS saved to session for history,
 			// but we don't want it in context for the retry)
 			const messages = this.agent.state.messages;
+			let removedOverflowAssistant = false;
 			if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
 				this.agent.replaceMessages(messages.slice(0, -1));
+				removedOverflowAssistant = true;
 			}
 
 			// Try context promotion first - switch to a larger model and retry without compacting
@@ -10847,7 +10853,15 @@ export class AgentSession {
 			// No promotion target available fall through to compaction
 			const compactionSettings = this.settings.getGroup("compaction");
 			if (compactionSettings.enabled && compactionSettings.strategy !== "off") {
-				const status = await this.#runAutoCompaction("overflow", true);
+				const status = await this.#runAutoCompaction("overflow", true, false, {
+					beforeTerminalOverflowNoop: () => {
+						if (onTerminalOverflowNoop) {
+							onTerminalOverflowNoop();
+						} else if (removedOverflowAssistant) {
+							this.agent.appendMessage(assistantMessage);
+						}
+					},
+				});
 				return "continuationScheduled" in status && status.continuationScheduled === true;
 			}
 			return this.#scheduleOverflowRetryContinuation(generation);
@@ -12156,6 +12170,7 @@ export class AgentSession {
 			deferHandoffMaintenance?: boolean;
 			force?: boolean;
 			signal?: AbortSignal;
+			beforeTerminalOverflowNoop?: () => void;
 		},
 	): Promise<AutoCompactionTerminalStatus> {
 		const compactionSettings = this.settings.getGroup("compaction");
@@ -12293,16 +12308,42 @@ export class AgentSession {
 			if (autoCompactionSignal.aborted) return await emitAborted();
 
 			if (!preparation) {
-				const continuationSkipReason = willRetry ? this.#detectOverflowRetryContinuationSkip() : undefined;
+				// #checkCompaction removes the failed overflow assistant before entering
+				// this path. A resumable tail would therefore resend the same oversized
+				// request even though maintenance made no change. Non-resumable tails
+				// retain the existing synthetic auto-continue recovery, which changes
+				// the request and is covered by the continuation contract.
+				const overflowNoopWouldReplay = reason === "overflow" && willRetry && this.#isResumableAgentTail();
+				const continuationSkipReason =
+					!overflowNoopWouldReplay && willRetry ? this.#detectOverflowRetryContinuationSkip() : undefined;
+				if (overflowNoopWouldReplay) {
+					options?.beforeTerminalOverflowNoop?.();
+				}
 				await this.#emitSessionEvent({
 					type: "auto_compaction_end",
 					action,
 					result: undefined,
 					aborted: false,
-					willRetry: willRetry && !continuationSkipReason,
+					willRetry: overflowNoopWouldReplay ? false : willRetry && !continuationSkipReason,
+					errorMessage: overflowNoopWouldReplay
+						? "Context overflow recovery skipped: nothing eligible to compact. Run /clear to preserve this session ID, or switch to a larger-context model before retrying."
+						: undefined,
 					skipped: true,
 					continuationSkipReason,
 				});
+				if (overflowNoopWouldReplay) {
+					if (continueAfterMaintenance && this.agent.hasQueuedMessages()) {
+						this.#scheduleAgentContinue({
+							delayMs: 100,
+							generation,
+							shouldContinue: () => this.agent.hasQueuedMessages(),
+							onSkip: skipReason => this.#logCompactionContinuationSkipped("queued_continue", skipReason),
+							onError: error => this.#logCompactionContinuationError("queued_continue", error),
+						});
+						return { kind: "skipped", continuationScheduled: true };
+					}
+					return { kind: "skipped" };
+				}
 				if (willRetry) {
 					return { kind: "skipped", continuationScheduled: this.#scheduleOverflowRetryContinuation(generation) };
 				}
@@ -12940,8 +12981,15 @@ export class AgentSession {
 				type: "maintenance",
 				continuation: async ownership => {
 					if (!ownership.isCurrent()) return;
-					const successorScheduled = await this.#checkCompaction(outcome.message);
-					if (successorScheduled || !ownership.isCurrent()) return;
+					let terminalized = false;
+					const successorScheduled = await this.#checkCompaction(outcome.message, true, () => {
+						terminalized = true;
+						this.agent.requestRunTerminal(ownership.logicalRunId, {
+							stopReason: "error",
+							messages: [outcome.message],
+						});
+					});
+					if (terminalized || successorScheduled || !ownership.isCurrent()) return;
 					this.agent.requestRunTerminal(ownership.logicalRunId, {
 						stopReason: "error",
 						messages: [outcome.message],

--- a/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent, type AgentOptions } from "@gajae-code/agent-core";
+import * as compactionModule from "@gajae-code/agent-core/compaction";
 import { type AssistantMessage, getBundledModel, type Model } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
@@ -123,7 +124,7 @@ function successfulStream(model: Model, content = "Recovered"): AssistantMessage
 	});
 }
 
-describe("AgentSession managed fallback upstream request counts", () => {
+describe("AgentSession fallback upstream request counts", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
 	let modelRegistry: ModelRegistry;
@@ -148,6 +149,7 @@ describe("AgentSession managed fallback upstream request counts", () => {
 	function createSession(
 		maxAttempts: number,
 		streamFn: AgentOptions["streamFn"],
+		settingsOverrides: Record<string, unknown> = {},
 	): { primary: Model; fallback: Model } {
 		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallback = getBundledModel("openai", "gpt-4o-mini");
@@ -161,11 +163,65 @@ describe("AgentSession managed fallback upstream request counts", () => {
 			"compaction.enabled": false,
 			"fallback.maxAttempts": maxAttempts,
 			"retry.baseDelayMs": 10,
+			...settingsOverrides,
 		});
 		settings.setModelRole("default", selector(primary));
 		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
 		session!.setConfiguredModelChain("default", [selector(primary), selector(fallback)], "test");
 		return { primary, fallback };
+	}
+
+	function createPlainSession(
+		streamFn: AgentOptions["streamFn"],
+		settingsOverrides: Record<string, unknown> = {},
+	): Model {
+		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!primary) throw new Error("Expected bundled test model");
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn,
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 10,
+			...settingsOverrides,
+		});
+		settings.setModelRole("default", selector(primary));
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		session.setConfiguredModelChain("default", [selector(primary)], "test");
+		return primary;
+	}
+
+	function seedCompactableHistory(primary: Model): void {
+		for (let index = 0; index < 4; index++) {
+			const user = {
+				role: "user" as const,
+				content: `seed request ${index} `.repeat(40),
+				timestamp: Date.now() + index * 2,
+			};
+			const assistant: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: `seed response ${index} `.repeat(40) }],
+				api: primary.api,
+				provider: primary.provider,
+				model: primary.id,
+				usage: {
+					input: 20_000,
+					output: 200,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 20_200,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now() + index * 2 + 1,
+			};
+			session!.agent.appendMessage(user);
+			session!.sessionManager.appendMessage(user);
+			session!.agent.appendMessage(assistant);
+			session!.sessionManager.appendMessage(assistant);
+		}
 	}
 
 	it("N=1 sends one managed request to each chain entry without a hidden replay", async () => {
@@ -273,25 +329,294 @@ describe("AgentSession managed fallback upstream request counts", () => {
 		);
 	});
 
-	it("bounds repeated overflow maintenance within one logical run", async () => {
+	it("terminalizes overflow maintenance when compaction would be a no-op", async () => {
 		const calls: string[] = [];
 		const events: AgentSessionEvent[] = [];
-		const { primary, fallback } = createSession(1, model => {
-			calls.push(selector(model));
-			return typedOpaqueOverflowStream(model);
+		let managedOwnerAtTerminalEvent: number | undefined;
+		const { primary, fallback } = createSession(
+			1,
+			model => {
+				calls.push(selector(model));
+				return typedOpaqueOverflowStream(model);
+			},
+			{
+				"compaction.enabled": true,
+				"compaction.keepRecentTokens": 1,
+			},
+		);
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(undefined);
+		session!.subscribe(event => {
+			events.push(event);
+			if (
+				event.type === "auto_compaction_end" &&
+				event.skipped &&
+				!event.willRetry &&
+				event.errorMessage?.includes("nothing eligible to compact")
+			) {
+				managedOwnerAtTerminalEvent = session!.agent.currentManagedLogicalRunId;
+			}
 		});
-		session!.subscribe(event => events.push(event));
 
 		await session!.prompt("Stop after bounded overflow maintenance");
 		await session!.waitForIdle();
 
-		expect(calls).toEqual([selector(primary), selector(primary)]);
+		expect(prepareSpy).toHaveBeenCalled();
+		expect(calls).toEqual([selector(primary)]);
 		expect(calls).not.toContain(selector(fallback));
+		expect(events.filter(event => event.type === "auto_compaction_start")).toHaveLength(1);
+		expect(events.filter(event => event.type === "auto_retry_start")).toHaveLength(0);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "auto_compaction_end",
+				action: "context-full",
+				aborted: false,
+				skipped: true,
+				willRetry: false,
+				errorMessage: expect.stringContaining("nothing eligible to compact"),
+			}),
+		);
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
+		expect(managedOwnerAtTerminalEvent).toBeUndefined();
+		expect(session!.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			stopReason: "error",
+			errorStatus: 400,
+		});
+		expect(
+			session!.messages.filter(message => message.role === "assistant" && message.stopReason === "error"),
+		).toHaveLength(1);
+	});
+
+	it("resumes a successor queued while managed no-op maintenance is starting", async () => {
+		const calls: string[] = [];
+		const events: AgentSessionEvent[] = [];
+		let requestCount = 0;
+		let queuedPrompt: Promise<void> | undefined;
+		const successorTerminal = Promise.withResolvers<void>();
+		const { primary } = createSession(
+			1,
+			model => {
+				calls.push(selector(model));
+				requestCount += 1;
+				return requestCount === 1
+					? typedOpaqueOverflowStream(model)
+					: successfulStream(model, "Queued successor completed");
+			},
+			{
+				"compaction.enabled": true,
+				"compaction.keepRecentTokens": 1,
+			},
+		);
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(undefined);
+		session!.subscribe(event => {
+			events.push(event);
+			if (
+				event.type === "agent_end" &&
+				event.messages.some(
+					message =>
+						message.role === "assistant" &&
+						message.content.some(
+							content => content.type === "text" && content.text === "Queued successor completed",
+						),
+				)
+			) {
+				successorTerminal.resolve();
+			}
+			if (
+				!queuedPrompt &&
+				event.type === "auto_compaction_start" &&
+				event.reason === "overflow" &&
+				event.action === "context-full"
+			) {
+				queuedPrompt = session!.prompt("Run after terminal overflow", {
+					skipCompactionCheck: true,
+					streamingBehavior: "steer",
+				});
+			}
+		});
+
+		await session!.prompt("Terminal overflow before queued successor");
+		expect(queuedPrompt).toBeDefined();
+		await queuedPrompt;
+		await Promise.race([
+			successorTerminal.promise,
+			Bun.sleep(1_000).then(() => {
+				throw new Error(
+					`Queued successor did not reach terminal lifecycle: calls=${JSON.stringify(calls)}, events=${JSON.stringify(
+						events.map(event => event.type),
+					)}, owner=${String(session!.agent.currentManagedLogicalRunId)}`,
+				);
+			}),
+		]);
+		await session!.waitForIdle();
+
+		expect(prepareSpy).toHaveBeenCalled();
+		expect(calls).toEqual([selector(primary), selector(primary)]);
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
+		expect(session!.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			content: [{ type: "text", text: "Queued successor completed" }],
+			stopReason: "stop",
+		});
+	});
+
+	it("preserves the terminal overflow assistant after plain no-op maintenance", async () => {
+		const calls: StreamCall[] = [];
+		const events: AgentSessionEvent[] = [];
+		const primary = createPlainSession(
+			(model, _context, options) => {
+				calls.push({
+					selector: selector(model),
+					fallbackManaged: options?.fallbackManaged,
+					fallbackAttempt: options?.fallbackAttempt,
+				});
+				return typedOpaqueOverflowStream(model);
+			},
+			{
+				"compaction.enabled": true,
+				"compaction.keepRecentTokens": 1,
+			},
+		);
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(undefined);
+		session!.subscribe(event => events.push(event));
+
+		await session!.prompt("Preserve the terminal plain overflow");
+		await session!.waitForIdle();
+
+		expect(prepareSpy).toHaveBeenCalled();
+		expect(calls).toEqual([{ selector: selector(primary), fallbackManaged: undefined, fallbackAttempt: undefined }]);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "auto_compaction_end",
+				action: "context-full",
+				aborted: false,
+				skipped: true,
+				willRetry: false,
+				errorMessage: expect.stringContaining("nothing eligible to compact"),
+			}),
+		);
 		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
 		expect(session!.messages.at(-1)).toMatchObject({
 			role: "assistant",
 			stopReason: "error",
+			errorStatus: 400,
 		});
+		expect(
+			session!.sessionManager
+				.getBranch()
+				.filter(
+					entry =>
+						entry.type === "message" &&
+						entry.message.role === "assistant" &&
+						entry.message.stopReason === "error",
+				),
+		).toHaveLength(1);
+	});
+
+	it("settles plain overflow before terminal observers mutate live state", async () => {
+		const calls: StreamCall[] = [];
+		const primary = createPlainSession(
+			(model, _context, options) => {
+				calls.push({
+					selector: selector(model),
+					fallbackManaged: options?.fallbackManaged,
+					fallbackAttempt: options?.fallbackAttempt,
+				});
+				return typedOpaqueOverflowStream(model);
+			},
+			{
+				"compaction.enabled": true,
+				"compaction.keepRecentTokens": 1,
+			},
+		);
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(undefined);
+		let resetAtTerminalEvent = false;
+		session!.subscribe(event => {
+			if (
+				event.type === "auto_compaction_end" &&
+				event.skipped &&
+				!event.willRetry &&
+				event.errorMessage?.includes("nothing eligible to compact")
+			) {
+				resetAtTerminalEvent = true;
+				session!.agent.reset();
+			}
+		});
+
+		await session!.prompt("Clear while observing terminal plain overflow");
+		await session!.waitForIdle();
+
+		expect(prepareSpy).toHaveBeenCalled();
+		expect(calls).toEqual([{ selector: selector(primary), fallbackManaged: undefined, fallbackAttempt: undefined }]);
+		expect(resetAtTerminalEvent).toBeTrue();
+		expect(session!.messages).toEqual([]);
+		expect(
+			session!.sessionManager
+				.getBranch()
+				.filter(
+					entry =>
+						entry.type === "message" &&
+						entry.message.role === "assistant" &&
+						entry.message.stopReason === "error",
+				),
+		).toHaveLength(1);
+	});
+
+	it("preserves successful overflow compaction and retry on the same model", async () => {
+		const calls: string[] = [];
+		const events: AgentSessionEvent[] = [];
+		let primaryCalls = 0;
+		const { primary, fallback } = createSession(
+			1,
+			model => {
+				calls.push(selector(model));
+				if (selector(model) !== selector(primary)) return successfulStream(model);
+				primaryCalls += 1;
+				return primaryCalls === 1
+					? typedOpaqueOverflowStream(model)
+					: successfulStream(model, "Recovered after compaction");
+			},
+			{
+				"compaction.enabled": true,
+				"compaction.keepRecentTokens": 1,
+			},
+		);
+		seedCompactableHistory(primary);
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: "Compacted summary",
+			shortSummary: undefined,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+			preserveData: undefined,
+		}));
+		session!.subscribe(event => events.push(event));
+
+		await session!.prompt("Recover after real overflow compaction");
+		await session!.waitForIdle();
+
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+		expect(calls).toEqual([selector(primary), selector(primary)]);
+		expect(calls).not.toContain(selector(fallback));
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "auto_compaction_end",
+				action: "context-full",
+				aborted: false,
+				willRetry: true,
+				result: expect.objectContaining({ summary: "Compacted summary" }),
+			}),
+		);
+		expect(events.filter(event => event.type === "agent_end")).toEqual([
+			expect.objectContaining({ stopReason: "completed" }),
+		]);
+		expect(session!.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			content: [{ type: "text", text: "Recovered after compaction" }],
+		});
+		expect(
+			session!.messages.filter(message => message.role === "assistant" && message.stopReason === "error"),
+		).toHaveLength(0);
 	});
 	it("preserves a prior fallback charge across overflow maintenance", async () => {
 		const calls: string[] = [];

--- a/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
@@ -186,6 +186,27 @@ describe("EventController auto-compaction overflow status", () => {
 		expect(fixture.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: true });
 	});
 
+	it("shows a skipped overflow reason as status instead of warning", async () => {
+		const fixture = await runEndEvent({
+			type: "auto_compaction_end",
+			action: "context-full",
+			result: undefined,
+			aborted: false,
+			willRetry: false,
+			skipped: true,
+			errorMessage:
+				"Context overflow recovery skipped: nothing eligible to compact. Run /clear to preserve this session ID, or switch to a larger-context model before retrying.",
+		});
+
+		expect(fixture.loaderStop).toHaveBeenCalledTimes(1);
+		expect(fixture.ctx.autoCompactionLoader).toBeUndefined();
+		expect(fixture.showStatus).toHaveBeenCalledWith(
+			"Context overflow recovery skipped: nothing eligible to compact. Run /clear to preserve this session ID, or switch to a larger-context model before retrying.",
+		);
+		expect(fixture.showWarning).not.toHaveBeenCalled();
+		expect(fixture.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false });
+	});
+
 	it("clears the loader before showing disabled non-resumable overflow recovery status", async () => {
 		const fixture = await runEndEvent({
 			type: "auto_compaction_end",


### PR DESCRIPTION
## Summary

Supersedes #3008, rebased onto current `dev` per the resubmission request.

When context overflow recovery compacts to an unchanged resumable message tail, retrying would send the same oversized provider request again. This change treats that no-op result as terminal instead.

## Scope

- stop scheduling a retry when compaction leaves the resumable message tail unchanged
- settle the removed assistant and managed logical-run ownership before terminal observers run
- publish actionable recovery guidance as status
- cover observer reset, queued-successor, session, agent lifecycle, and controller behavior with regression tests

This preserves the overflow and compaction contracts established by #1664, #1665, and #2479.

## Verification

- 567 agent-core tests
- 51 focused and adjacent tests across six coding-agent suites
- `bun --cwd=packages/agent run check`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check origin/dev...HEAD`

The full local root check reached the Telegram baseline generation guard, where current upstream `dev` also reports the same six missing baseline commands in a clean worktree. This PR does not modify that generator or its inputs. Hosted required checks will provide the exact-head result for this PR.
