### PR TITLE
fix(notifications): fence malformed topic success per endpoint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
+
 ## [0.11.8] - 2026-07-23
 ### Added
 

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -3673,7 +3673,7 @@ export class TelegramNotificationDaemon {
 	 * payload. Remember that ambiguity per endpoint so later frames cannot repeat
 	 * the external side effect. Explicit API failures remain retryable.
 	 */
-	#malformedTopicCreateEndpoints = new Map<string, string>();
+	readonly #malformedTopicCreateEndpoints = new Map<string, string>();
 	/** Serializes registry snapshots so an older atomic write cannot overwrite newer rename state. */
 	/** Legacy sockets have no durable token, so explicit teardown is their revocation fence. */
 	private readonly droppedSessions = new WeakSet<SessionSocket>();

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -3668,6 +3668,12 @@ export class TelegramNotificationDaemon {
 	private readonly botApi: BotApi;
 	private readonly effects = new TelegramEffectSupervisor();
 	private readonly topics = new TopicRegistry();
+	/**
+	 * Telegram may accept createForumTopic while returning an unusable success
+	 * payload. Remember that ambiguity per endpoint so later frames cannot repeat
+	 * the external side effect. Explicit API failures remain retryable.
+	 */
+	#malformedTopicCreateEndpoints = new Map<string, string>();
 	/** Serializes registry snapshots so an older atomic write cannot overwrite newer rename state. */
 	/** Legacy sockets have no durable token, so explicit teardown is their revocation fence. */
 	private readonly droppedSessions = new WeakSet<SessionSocket>();
@@ -5844,6 +5850,9 @@ export class TelegramNotificationDaemon {
 		if (session && sessionId === session.sessionId && this.#logicalSessionId(session) !== sessionId) return undefined;
 		const capturedCreationLease = creationLease ?? (session ? this.#socketLease(session, sessionId) : undefined);
 		if (session?.logicalSessionIdTrusted && !capturedCreationLease) return undefined;
+		const creationEndpointKey = session?.endpointDigest ?? session?.endpointKey ?? "unbound";
+		if (this.#malformedTopicCreateEndpoints.get(sessionId) === creationEndpointKey)
+			throw new Error("createForumTopic: invalid message_thread_id");
 		const existing = this.topics.get(sessionId);
 		if (existing?.authorityState === "delete_pending" || existing?.bindingMalformed) return undefined;
 		if (existing) return existing.topicId;
@@ -5867,10 +5876,17 @@ export class TelegramNotificationDaemon {
 						throw new Error("topic authority was revoked during creation");
 					const res = await this.botApi.call("createForumTopic", { chat_id: this.opts.chatId, name });
 					if (isThreadedModeCapabilityRefusal(res)) throw new ThreadedModeCapabilityRefusal();
-					const tid = (res as { result?: { message_thread_id?: unknown } }).result?.message_thread_id;
-					if (typeof tid !== "number" || !Number.isSafeInteger(tid) || tid <= 0)
+					const response = res as {
+						ok?: unknown;
+						result?: { message_thread_id?: unknown };
+					};
+					const tid = response.result?.message_thread_id;
+					if (typeof tid !== "number" || !Number.isSafeInteger(tid) || tid <= 0) {
+						if (response.ok === true) this.#malformedTopicCreateEndpoints.set(sessionId, creationEndpointKey);
 						throw new Error("createForumTopic: invalid message_thread_id");
+					}
 					acceptedTopicId = String(tid);
+					this.#malformedTopicCreateEndpoints.delete(sessionId);
 					if (capturedCreationLease && !(await this.#awaitCreationLeaseAuthority(capturedCreationLease))) {
 						if (
 							!this.topics.fenceAcceptedCreateForLease(

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -9019,7 +9019,7 @@ test("topic creation transport failures fail closed without flat delivery", asyn
 	expect(bot.calls.filter(call => call.method === "sendMessage")).toHaveLength(0);
 });
 
-test("malformed topic creation success fails closed without flat delivery", async () => {
+test("malformed topic creation success is attempted once per endpoint and fails closed", async () => {
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();
 	bot.call = async (method, body) => {
@@ -9035,7 +9035,66 @@ test("malformed topic creation success fails closed without flat delivery", asyn
 		chatId: "42",
 		botApi: bot,
 	});
-	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	const session = {
+		sessionId: "S",
+		endpointDigest: "endpoint-1",
+		token: "tok",
+		ws: { readyState: 1, send() {} },
+		pending: new Map(),
+	};
+
+	for (let attempt = 0; attempt < 2; attempt++) {
+		await expect(
+			daemon.handleSessionMessage(session as never, {
+				type: "identity_header",
+				sessionId: "S",
+				repo: "r",
+				branch: "b",
+			}),
+		).rejects.toThrow("invalid message_thread_id");
+	}
+	expect(bot.calls.filter(call => call.method === "createForumTopic")).toHaveLength(1);
+	expect(bot.calls.filter(call => call.method === "sendMessage")).toHaveLength(0);
+
+	await expect(
+		daemon.handleSessionMessage({ ...session, endpointDigest: "endpoint-2" } as never, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		}),
+	).rejects.toThrow("invalid message_thread_id");
+	expect(bot.calls.filter(call => call.method === "createForumTopic")).toHaveLength(2);
+});
+
+test("explicit topic creation failure remains retryable", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	let createAttempts = 0;
+	bot.call = async (method, body) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { type: "private" } };
+		if (method === "createForumTopic") {
+			createAttempts++;
+			if (createAttempts === 1) return { ok: false, error_code: 429, description: "Too Many Requests" };
+			return { ok: true, result: { message_thread_id: 42 } };
+		}
+		return { ok: true, result: { message_id: 1 } };
+	};
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = {
+		sessionId: "S",
+		endpointDigest: "endpoint-1",
+		token: "tok",
+		ws: { readyState: 1, send() {} },
+		pending: new Map(),
+	};
 
 	await expect(
 		daemon.handleSessionMessage(session as never, {
@@ -9045,7 +9104,15 @@ test("malformed topic creation success fails closed without flat delivery", asyn
 			branch: "b",
 		}),
 	).rejects.toThrow("invalid message_thread_id");
-	expect(bot.calls.filter(call => call.method === "sendMessage")).toHaveLength(0);
+	await daemon.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+
+	expect(bot.calls.filter(call => call.method === "createForumTopic")).toHaveLength(2);
+	expect(bot.calls.filter(call => call.method === "sendMessage")).toHaveLength(1);
 });
 
 test("topic persistence failures fail closed without flat delivery", async () => {


### PR DESCRIPTION
## Summary
- fence only explicit `ok: true` `createForumTopic` responses that lack a valid positive safe-integer `message_thread_id`
- keep repeated frames on the same endpoint fail-closed without repeating the ambiguous external side effect
- allow one fresh attempt after endpoint replacement
- preserve retries for explicit Bot API failures such as `ok: false` / 429

## Context
#2910 was correctly closed: its first implementation fenced every response without a thread id, including retryable `ok: false` responses, and it predated the generation-26/lazy-topic lifecycle merged in #2984.

#2984 fixes the broader observed ownership/reload/eager-topic storm. This PR is the narrower remaining response-boundary safeguard requested in the owner review on #2910: a successful-but-malformed create response is ambiguous because Telegram may already have accepted the side effect, so the same endpoint must not blindly create again.

Unlike #2910, a fenced follow-up still throws the original error instead of returning `undefined`, so it cannot enter flat-delivery fallback.

## Regression coverage
- malformed explicit success is called once for the same endpoint
- no flat fallback occurs while fenced
- endpoint replacement permits exactly one fresh create attempt
- explicit `ok: false` response remains retryable and a following valid success delivers normally

## Verification
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts` — 420 pass
- `bun --cwd=packages/coding-agent run check` — Biome and TypeScript pass
- `git diff --check`