### PR TITLE
fix(utils): persist fatal crashes to a rotation-immune crash log

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ## [0.11.8] - 2026-07-23
+### Fixed
+
+- Fatal crashes (`uncaughtException` / `unhandledRejection`) are now also written to a dedicated, append-only crash log (`~/.gjc/agent/gjc-crash.log`, capped at 512 KB) in addition to the rotating daily logger file, and the fatal handler prints the crash-log path to stderr. The daily log is gzip-archived independently by every gjc process at date rollover; that shared-archive race can truncate a day's log to an empty `.gz` and destroy the `logger.error` crash record, leaving crashes undiagnosable. The rotation-immune crash log preserves the record regardless.
 
 ## [0.11.7] - 2026-07-22
 ### Added

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -5,9 +5,12 @@
  * in response to process exit, signals, or fatal exceptions. It is intended to
  * allow reliably releasing resources or shutting down subprocesses, files, sockets, etc.
  */
+import * as fs from "node:fs";
 import inspector from "node:inspector";
+import * as path from "node:path";
 import { isMainThread } from "node:worker_threads";
 import { BROKEN_PIPE_EXIT_CODE, createProcessStdoutEpipeClassifier } from "./broken-pipe";
+import { getCrashLogPath } from "./dirs";
 import * as logger from "./logger";
 import { safeStderrWrite } from "./safe-stderr";
 
@@ -204,6 +207,52 @@ function formatFatalError(label: string, err: Error): string {
 	const formattedStack = stackLines.length > 0 ? `\n${stackLines.join("\n")}` : "";
 	return `\n[${label}] ${name}: ${message}${formattedStack}\n`;
 }
+/** Cap for the durable crash log; it is reset past this so a crash loop cannot fill the disk. */
+const CRASH_LOG_MAX_BYTES = 512 * 1024;
+
+/**
+ * Append a fatal-crash record to the dedicated, rotation-immune crash log
+ * (`~/.gjc/agent/gjc-crash.log`).
+ *
+ * The daily logger file is gzip-archived at date rollover by every gjc process
+ * independently; that shared-archive race can truncate a day's log to an empty
+ * `.gz`, destroying the `logger.error` crash record written here. This
+ * append-only file is never rotated, so a crash stays diagnosable regardless.
+ *
+ * Fully defensive: it never throws (a failing crash writer must not mask the
+ * original fatal) and uses synchronous IO so the record lands before
+ * `process.exit`. Returns the path written, or `undefined` on failure.
+ */
+export function recordFatalCrash(
+	label: string,
+	reason: unknown,
+	options: { path?: string; now?: Date } = {},
+): string | undefined {
+	try {
+		const err = errorForDiagnostic(reason);
+		const target = options.path ?? getCrashLogPath();
+		const now = options.now ?? new Date();
+		const report =
+			`${now.toISOString()} pid=${process.pid} [${label}] ` +
+			`${err.name || "Error"}: ${err.message || "(no message)"}\n` +
+			`${err.stack ?? ""}\n\n`;
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		let existingSize = 0;
+		try {
+			existingSize = fs.statSync(target).size;
+		} catch {}
+		// Reset (rather than append) when the file would exceed the cap so the
+		// newest crash is always retained without unbounded growth.
+		if (existingSize + Buffer.byteLength(report) > CRASH_LOG_MAX_BYTES) {
+			fs.writeFileSync(target, report, { mode: 0o600 });
+		} else {
+			fs.appendFileSync(target, report, { mode: 0o600 });
+		}
+		return target;
+	} catch {
+		return undefined;
+	}
+}
 
 async function exitQuietlyForAttributableStdoutEpipe(reason: Reason): Promise<void> {
 	if (ordinaryFatalStarted || quietShutdownStarted) return;
@@ -227,6 +276,10 @@ async function handleFatalError(label: string, reason: unknown, cleanupReason: R
 	process.exitCode = 1;
 	const err = errorForDiagnostic(reason);
 	safeStderrWrite(formatFatalError(label, err));
+	// Persist to the rotation-immune crash log first, before cleanup (which may
+	// itself hang or fail), so the record survives even if the daily log is lost.
+	const crashLogPath = recordFatalCrash(label, err);
+	if (crashLogPath) safeStderrWrite(`[${label}] crash recorded at ${crashLogPath}\n`);
 	if (!quietShutdownStarted) {
 		logger.error(label === "Uncaught Exception" ? "Uncaught exception" : "Unhandled rejection", {
 			err,

--- a/packages/utils/test/postmortem-crash-log.test.ts
+++ b/packages/utils/test/postmortem-crash-log.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { recordFatalCrash } from "../src/postmortem";
+
+function tempCrashLog(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-crash-log-"));
+	// Nested path proves the writer creates missing parent directories.
+	return path.join(dir, "agent", "gjc-crash.log");
+}
+
+describe("recordFatalCrash", () => {
+	it("writes a structured, diagnosable record for an Error", () => {
+		const target = tempCrashLog();
+		const err = new Error("boom while streaming");
+		const now = new Date("2026-07-23T21:22:31.647Z");
+
+		const written = recordFatalCrash("Uncaught Exception", err, { path: target, now });
+
+		expect(written).toBe(target);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("2026-07-23T21:22:31.647Z");
+		expect(contents).toContain(`pid=${process.pid}`);
+		expect(contents).toContain("[Uncaught Exception]");
+		expect(contents).toContain("Error: boom while streaming");
+		// The full stack must be present so the crash is actually diagnosable.
+		expect(contents).toContain(err.stack ?? "MISSING_STACK");
+	});
+
+	it("stringifies non-Error rejection reasons", () => {
+		const target = tempCrashLog();
+		const written = recordFatalCrash("Unhandled Rejection", "Request was aborted", { path: target });
+		expect(written).toBe(target);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("[Unhandled Rejection]");
+		expect(contents).toContain("Request was aborted");
+	});
+
+	it("appends successive crashes rather than overwriting", () => {
+		const target = tempCrashLog();
+		recordFatalCrash("Uncaught Exception", new Error("first"), { path: target });
+		recordFatalCrash("Uncaught Exception", new Error("second"), { path: target });
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("Error: first");
+		expect(contents).toContain("Error: second");
+		expect(contents.indexOf("first")).toBeLessThan(contents.indexOf("second"));
+	});
+
+	it("resets past the size cap so a crash loop cannot grow unbounded", () => {
+		const target = tempCrashLog();
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		// Pre-fill beyond the 512KB cap.
+		fs.writeFileSync(target, "x".repeat(600 * 1024));
+		recordFatalCrash("Uncaught Exception", new Error("post-cap crash"), { path: target });
+		const size = fs.statSync(target).size;
+		expect(size).toBeLessThan(512 * 1024);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("Error: post-cap crash");
+		// Old oversized content is gone; newest crash retained.
+		expect(contents).not.toContain("x".repeat(1024));
+	});
+
+	it("never throws when the target path is unwritable", () => {
+		// A path whose parent is an existing file cannot be created as a directory.
+		const fileAsParent = tempCrashLog();
+		fs.mkdirSync(path.dirname(fileAsParent), { recursive: true });
+		fs.writeFileSync(fileAsParent, "i am a file");
+		const bogus = path.join(fileAsParent, "nested", "gjc-crash.log");
+		const result = recordFatalCrash("Uncaught Exception", new Error("x"), { path: bogus });
+		expect(result).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem

Fatal errors (`uncaughtException` / `unhandledRejection`) are caught by the postmortem handler but were only recorded via `logger.error` into the rotating daily log file (`gjc.%DATE%.log`).

Every gjc process runs its own `winston-daily-rotate-file` instance against the *same shared* `gjc.%DATE%.log` and independently gzip-archives it at date rollover. When multiple processes race on the same archive at midnight, the day's log can be truncated to an empty `.gz`, destroying the crash record and leaving the crash undiagnosable.

Observed: `~/.gjc/logs/gjc.2026-07-23.log.gz` is 0 bytes even though the daily-rotate audit recorded a non-empty source hash — that day's uncaught-exception record was lost, so the reported "session errored and shut down" could not be traced.

A dedicated crash-log helper `getCrashLogPath()` (`~/.gjc/agent/gjc-crash.log`) already existed but had zero callers.

## Fix

- Wire the previously-unused `getCrashLogPath()` into the fatal handler in `packages/utils/src/postmortem.ts`.
- On a fatal, append a structured, stack-bearing record (`timestamp pid label name: message` + full stack) to the dedicated append-only crash log **before** cleanup runs, using synchronous IO so the record lands before `process.exit`.
- Cap the crash log at 512 KB and reset past the cap so a crash loop cannot fill the disk; the newest crash is always retained.
- Print the crash-log path to stderr so the user knows where to look.
- The writer is fully defensive (never throws) so it cannot mask the original fatal error.

The dedicated crash log is append-only and never rotated/archived, so it survives the daily-log gzip race. This is a diagnosability fix; the shared daily-log rotation race itself is out of scope and left as a follow-up.

## Verification

- `bun test packages/utils/test/postmortem-crash-log.test.ts packages/utils/test/postmortem.test.ts` — 26 pass, 0 fail
- `bun --cwd=packages/utils run check` (Biome + `tsc --noEmit`) — pass

New `recordFatalCrash` contract tests cover: record shape (timestamp/pid/label/stack), non-Error rejection reasons stringified, append semantics across successive crashes, size-cap reset, and the never-throw guarantee on an unwritable path.

## Out of scope

The session crash's direct trigger was expired provider credentials (grok-build refresh token revoked; kimi/qwen token invalid), which is a re-login matter, not a code change. This PR ensures the *next* crash is diagnosable regardless.

## Exact-head evidence

Base: `586b3893a5cdf76c77a50df90ec3fdbf986fd0ee`
Head: `ca6f786467e126b0c475940c6d55f9f30b02aec5`

- `git diff --check upstream/dev...HEAD` — clean
- `git merge-tree --write-tree upstream/dev HEAD` — conflict-free (`27fa9d781796391b79576b8596dab2784f9c472a`)
- Diff scope: `packages/utils/{src/postmortem.ts, CHANGELOG.md, test/postmortem-crash-log.test.ts}` — 3 files, +129