### PR TITLE
fix(ci): drain SDK daemon CLI child pipes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
+- SDK daemon CLI end-to-end tests now drain spawned child stdout and stderr concurrently with process exit, preventing CI pipe teardown races from replacing the product exit contract with SIGPIPE status 141 (#3024).
 
 ## [0.11.8] - 2026-07-23
 ### Added

--- a/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
@@ -14,11 +14,10 @@ async function runCli(repo: string, agentDir: string, args: string[]): Promise<C
 		stdout: "pipe",
 		stderr: "pipe",
 	});
-	return {
-		exitCode: await child.exited,
-		stdout: await new Response(child.stdout).text(),
-		stderr: await new Response(child.stderr).text(),
-	};
+	const stdout = new Response(child.stdout).text();
+	const stderr = new Response(child.stderr).text();
+	const [exitCode, stdoutText, stderrText] = await Promise.all([child.exited, stdout, stderr]);
+	return { exitCode, stdout: stdoutText, stderr: stderrText };
 }
 
 describe("SDK daemon session CLI", () => {


### PR DESCRIPTION
## Summary
- drain SDK daemon CLI child stdout/stderr concurrently with child exit
- preserve the expected corrupt-discovery product exit code `1` instead of exposing SIGPIPE status `141` from a CI pipe lifecycle race
- document the repair in the coding-agent changelog

## Causality
- failing Dev CI job `89258740680` observed exit `141` only in the corrupt discovery case
- the product discovery/error path and test were unchanged by #3022 (`586b3893a..4d6260bbc`)
- the harness awaited `child.exited` before beginning stdout/stderr consumption, leaving pipe lifecycle timing sensitive under CI load
- #3022 touched only Telegram topic fencing and its tests; no direct causal path was found

## Evidence
- exact failing case: 5/5 pass at `4d6260bbc` before the repair locally, with full process/resource diagnostics
- pre-merge detached comparison at `586b3893a`: 5/5 pass
- focused suite before repair: 10/10 suite repetitions pass (50 tests)
- exact case after repair: 5/5 pass
- focused suite after repair: 5/5 tests pass
- `bun --cwd=packages/coding-agent run check`: pass
- `bun --cwd=packages/coding-agent run build`: pass
- `bun run check:sdk-closure`: relevant SDK manifests and `sdk-daemon-cli-e2e` passed; the broader command exceeded the local 1200s observation window while continuing through the adapter matrix

Closes #3024

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*