### PR TITLE
fix(session): open scope binding with a writable handle for fsync on Windows

### DIFF
--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -579,7 +579,12 @@ function fsyncCanonicalBinding(bindingPath: string, expected: string): void {
 	if (captured.bytes.toString("utf8") !== expected) throw new Error("binding_invalid");
 	let descriptor: number | undefined;
 	try {
-		descriptor = fs.openSync(bindingPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+		// win32: FlushFileBuffers requires a writable handle, so an O_RDONLY fsync fails
+		// with EPERM (same convention as fsyncManagedArtifactTree in managed-session-storage).
+		descriptor = fs.openSync(
+			bindingPath,
+			(process.platform === "win32" ? fs.constants.O_WRONLY : fs.constants.O_RDONLY) | fs.constants.O_NOFOLLOW,
+		);
 		const before = fs.fstatSync(descriptor, { bigint: true });
 		if (
 			before.dev !== captured.identity.dev ||

--- a/packages/coding-agent/test/sdk-session-directory.windows.test.ts
+++ b/packages/coding-agent/test/sdk-session-directory.windows.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as native from "@gajae-code/natives";
 import { resolveManagedSessionScope } from "../src/sdk/session-directory";
+import { prepareManagedSessionScopeForWrite, resolveManagedScope } from "../src/session/internal/managed-session-scope";
 import {
 	ManagedSessionDescendantStore,
 	shouldFsyncManagedDirectory,
@@ -32,6 +33,25 @@ it("skips unsupported managed directory fsync on Windows", () => {
 	expect(shouldFsyncManagedDirectory("linux")).toBe(true);
 });
 describe.skipIf(process.platform !== "win32")("Windows managed session directory", () => {
+	it("re-prepares an existing scope binding without a read-only fsync EPERM", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-directory-windows-binding-fsync-"));
+		temporaryDirectories.push(root);
+		const cwd = path.join(root, "workspace");
+		const agentDir = path.join(root, "agent");
+		await fs.mkdir(cwd);
+		const resolved = resolveManagedScope({ cwd, agentDir, sessionsRoot: path.join(agentDir, "sessions") });
+		if (resolved.kind === "error") throw new Error(resolved.message);
+
+		const first = await prepareManagedSessionScopeForWrite(resolved.scope, "windows-existing-verify-first");
+		expect(first.kind).toBe("resolved");
+
+		// The second preparation collides with the published binding and must flush it
+		// through fsyncCanonicalBinding. FlushFileBuffers requires a writable handle on
+		// Windows, so an O_RDONLY descriptor fails with EPERM -> durability_failed.
+		const second = await prepareManagedSessionScopeForWrite(resolved.scope, "windows-existing-verify-first");
+		expect(second).toEqual({ kind: "resolved", scope: resolved.scope });
+	});
+
 	it("uses one scope for a workspace and its junction alias", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-directory-windows-"));
 		temporaryDirectories.push(root);


### PR DESCRIPTION
## Problem

Since the `fsyncCanonicalBinding` helper was introduced (0.11.8), **every managed session resume on Windows fails** with:

```
[Unhandled Rejection] Error: Could not open managed session: durability_failed
    at prepareManagedCandidateForWrite (…/src/session/session-manager.ts:7302:14)
```

`fsyncCanonicalBinding` opens the scope binding file with `O_RDONLY | O_NOFOLLOW` and calls `fs.fsyncSync`. On Windows, `fsync` maps to `FlushFileBuffers`, which requires a handle with **write access** — a read-only handle always fails with `EPERM`:

```js
const fd = fs.openSync(bindingPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
fs.fsyncSync(fd); // EPERM: operation not permitted, fsync  (win32)
```

The failure path: existing scope → `publishManagedFileNoReplace` returns `destination_conflict` → `bindingCollision` → `fsyncCanonicalBinding` → `EPERM` → wrapped as `durability_failed` → resume aborts before any candidate is opened. New-session creation uses the sync store path and is unaffected, which is why only resume dies.

The codebase already handles this Windows quirk elsewhere: `fsyncManagedArtifactTree` opens `O_WRONLY` on win32, and `shouldFsyncManagedDirectory` / `fsyncManagedParent` skip directory fsync on win32. This helper is the one site that missed the convention.

## Fix

Open the binding descriptor with `O_WRONLY` on win32 (identical to `fsyncManagedArtifactTree`). All content/identity verification around the flush is unchanged; POSIX behavior is unchanged.

## Regression test

Added to `sdk-session-directory.windows.test.ts`: preparing the same scope twice with `windows-existing-verify-first` must resolve. On unpatched source the second call returns `{ kind: "error", code: "durability_failed" }`; with the fix it resolves.

Verified on Windows 11 (Bun 1.3.14):
- before: new test fails with `durability_failed`
- after: passes; remaining failures in that file (`junction alias`, `verify-first second startup`) are pre-existing on clean `main` on my machine and unrelated.

Also verified end-to-end on a real `~/.gjc/agent/sessions` scope: all five managed candidates that previously failed to open now open with `migrated: false`.