### PR TITLE
fix(notifications): group Telegram /usage windows by provider

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
+- The Telegram `/usage` report now groups quota windows by provider, so every provider that reports usage (not only the Anthropic 5h/7d windows) is shown. Previously all providers were merged into a single 5-hour/weekly pair keyed only by window kind, which hid every non-Anthropic provider; the report also now surfaces non-5h/7d windows, credential tiers, and derives the used fraction from `used`/`limit` when a fraction is not provided.
 
 ## [0.11.8] - 2026-07-23
 ### Added

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -1280,7 +1280,9 @@ function formatLocalUsage(ctx: ExtensionContext): string {
 }
 
 interface SafeUsageWindow {
-	kind: "5h" | "7d";
+	key: string;
+	label: string;
+	tier?: string;
 	usedFraction?: number;
 	resetsAt?: number;
 }
@@ -1338,37 +1340,90 @@ function shouldReplaceUsageWindow(current: SafeUsageWindow, candidate: SafeUsage
 	return current.resetsAt === undefined || candidate.resetsAt < current.resetsAt;
 }
 
-function formatRemoteUsageWindows(reports: unknown): string[] {
+function formatUsageProviderName(provider: string): string {
+	return provider
+		.split(/[-_]/g)
+		.map(part => (part ? part[0].toUpperCase() + part.slice(1) : ""))
+		.join(" ");
+}
+
+function usageWindowLabel(limit: Record<string, unknown>): string {
+	const kind = classifyUsageWindow(limit);
+	if (kind === "5h") return "5-hour limit";
+	if (kind === "7d") return "Weekly limit";
+	const window = isRecord(limit.window) ? limit.window : undefined;
+	const scope = isRecord(limit.scope) ? limit.scope : undefined;
+	for (const candidate of [window?.label, limit.label, window?.id, scope?.windowId]) {
+		if (typeof candidate === "string" && candidate.trim()) return candidate;
+	}
+	return "limit";
+}
+
+function usageWindowKey(limit: Record<string, unknown>): string {
+	const kind = classifyUsageWindow(limit);
+	if (kind) return kind;
+	const window = isRecord(limit.window) ? limit.window : undefined;
+	const scope = isRecord(limit.scope) ? limit.scope : undefined;
+	for (const candidate of [window?.id, scope?.windowId, limit.id]) {
+		if (typeof candidate === "string" && candidate.trim()) return candidate.toLowerCase();
+	}
+	return usageWindowLabel(limit).toLowerCase();
+}
+
+function usageWindowSortWeight(key: string): number {
+	if (key === "5h") return 0;
+	if (key === "7d") return 1;
+	return 2;
+}
+
+// Group provider-reported limits by provider so every registered provider (not
+// just the Anthropic 5h/7d windows) shows up in the Telegram `/usage` report.
+export function formatRemoteUsageWindows(reports: unknown): string[] {
 	if (!Array.isArray(reports)) return [];
-	const windows = new Map<SafeUsageWindow["kind"], SafeUsageWindow>();
+	const byProvider = new Map<string, Map<string, SafeUsageWindow>>();
 	for (const report of reports) {
 		if (!isRecord(report) || !Array.isArray(report.limits)) continue;
+		const provider = typeof report.provider === "string" && report.provider ? report.provider : "unknown";
+		const windows = byProvider.get(provider) ?? new Map<string, SafeUsageWindow>();
+		byProvider.set(provider, windows);
 		for (const value of report.limits) {
 			if (!isRecord(value)) continue;
-			const kind = classifyUsageWindow(value);
-			if (!kind) continue;
 			const window = isRecord(value.window) ? value.window : undefined;
 			const amount = isRecord(value.amount) ? value.amount : undefined;
+			const scope = isRecord(value.scope) ? value.scope : undefined;
 			const usedFraction = getUsageUsedFraction(amount);
 			const resetsAt = window?.resetsAt;
+			const tier = scope?.tier;
 			const candidate: SafeUsageWindow = {
-				kind,
+				key: usageWindowKey(value),
+				label: usageWindowLabel(value),
+				...(typeof tier === "string" && tier ? { tier } : {}),
 				...(typeof usedFraction === "number" && Number.isFinite(usedFraction) ? { usedFraction } : {}),
 				...(typeof resetsAt === "number" && Number.isFinite(resetsAt) ? { resetsAt } : {}),
 			};
-			const current = windows.get(kind);
-			if (!current || shouldReplaceUsageWindow(current, candidate)) windows.set(kind, candidate);
+			const current = windows.get(candidate.key);
+			if (!current || shouldReplaceUsageWindow(current, candidate)) windows.set(candidate.key, candidate);
 		}
 	}
-	return (["5h", "7d"] as const).flatMap(kind => {
-		const window = windows.get(kind);
-		if (!window) return [];
-		const details = [kind === "5h" ? "5-hour limit" : "Weekly limit"];
-		if (window.usedFraction !== undefined) details.push(`${Number((window.usedFraction * 100).toFixed(1))}% used`);
-		const resetTime = window.resetsAt === undefined ? undefined : formatStableResetTime(window.resetsAt);
-		if (resetTime) details.push(`resets ${resetTime}`);
-		return [details.join(" — ")];
-	});
+
+	const lines: string[] = [];
+	for (const [provider, windows] of [...byProvider.entries()].sort(([left], [right]) => left.localeCompare(right))) {
+		const entries = [...windows.values()].sort(
+			(left, right) =>
+				usageWindowSortWeight(left.key) - usageWindowSortWeight(right.key) || left.label.localeCompare(right.label),
+		);
+		if (entries.length === 0) continue;
+		if (lines.length > 0) lines.push("");
+		lines.push(formatUsageProviderName(provider));
+		for (const window of entries) {
+			const details = [window.tier ? `${window.label} (${window.tier})` : window.label];
+			if (window.usedFraction !== undefined) details.push(`${Number((window.usedFraction * 100).toFixed(1))}% used`);
+			const resetTime = window.resetsAt === undefined ? undefined : formatStableResetTime(window.resetsAt);
+			if (resetTime) details.push(`resets ${resetTime}`);
+			lines.push(`- ${details.join(" — ")}`);
+		}
+	}
+	return lines;
 }
 
 async function formatUsage(ctx: ExtensionContext, api: ExtensionAPI): Promise<string> {

--- a/packages/coding-agent/test/notifications-control-executor.test.ts
+++ b/packages/coding-agent/test/notifications-control-executor.test.ts
@@ -246,7 +246,10 @@ describe("executeNotificationControlCommand", () => {
 		const apiState = fakeApi();
 		apiState.setUsageReports([
 			{
-				provider: secret,
+				// Provider is an enum-like identifier that is intentionally displayed as a
+				// group header; every other field below stays a secret sentinel to prove
+				// credentials/PII are never projected into the report.
+				provider: "claude",
 				metadata: { accountId: secret, email: secret, baseUrl: secret },
 				raw: { accessToken: secret },
 				limits: [
@@ -289,8 +292,9 @@ describe("executeNotificationControlCommand", () => {
 				"Cost: $0.012345",
 				"",
 				"Usage windows",
-				"5-hour limit — 90% used — resets 2027-01-02 03:04:05 UTC",
-				"Weekly limit — 25% used — resets 2026-01-09 03:04:05 UTC",
+				"Claude",
+				"- 5-hour limit — 90% used — resets 2027-01-02 03:04:05 UTC",
+				"- Weekly limit — 25% used — resets 2026-01-09 03:04:05 UTC",
 			].join("\n"),
 		});
 		expect(apiState.usageFetchCalls).toBe(1);

--- a/packages/coding-agent/test/notifications-usage-windows.test.ts
+++ b/packages/coding-agent/test/notifications-usage-windows.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { formatRemoteUsageWindows } from "../src/sdk/bus/index";
+
+const RESET_5H = Date.parse("2026-07-24T03:30:00Z");
+const RESET_7D = Date.parse("2026-07-26T03:00:00Z");
+const RESET_CODEX = Date.parse("2026-07-28T17:02:47Z");
+
+describe("formatRemoteUsageWindows", () => {
+	test("groups windows by provider instead of collapsing across providers", () => {
+		const lines = formatRemoteUsageWindows([
+			{
+				provider: "claude",
+				limits: [
+					{
+						id: "5h",
+						label: "5 Hour",
+						window: { id: "5h", label: "5 Hour", durationMs: 5 * 3_600_000, resetsAt: RESET_5H },
+						amount: { usedFraction: 0.07, unit: "percent" },
+					},
+					{
+						id: "7d",
+						label: "7 Day",
+						window: { id: "7d", label: "7 Day", durationMs: 7 * 24 * 3_600_000, resetsAt: RESET_7D },
+						amount: { usedFraction: 0.79, unit: "percent" },
+					},
+				],
+			},
+			{
+				provider: "openai-codex",
+				limits: [
+					{
+						id: "7d",
+						label: "7 Day",
+						window: { id: "7d", label: "7 Day", durationMs: 7 * 24 * 3_600_000, resetsAt: RESET_CODEX },
+						scope: { provider: "openai-codex", tier: "pro" },
+						amount: { usedFraction: 0.53, unit: "percent" },
+					},
+				],
+			},
+		]);
+
+		expect(lines).toEqual([
+			"Claude",
+			"- 5-hour limit — 7% used — resets 2026-07-24 03:30:00 UTC",
+			"- Weekly limit — 79% used — resets 2026-07-26 03:00:00 UTC",
+			"",
+			"Openai Codex",
+			"- Weekly limit (pro) — 53% used — resets 2026-07-28 17:02:47 UTC",
+		]);
+	});
+
+	test("keeps non-5h/7d windows and derives used fraction from used/limit", () => {
+		const lines = formatRemoteUsageWindows([
+			{
+				provider: "gemini",
+				limits: [
+					{
+						id: "daily",
+						label: "Daily requests",
+						window: { id: "daily", label: "Daily" },
+						amount: { used: 120, limit: 1000, unit: "requests" },
+					},
+				],
+			},
+		]);
+
+		expect(lines).toEqual(["Gemini", "- Daily — 12% used"]);
+	});
+
+	test("dedupes the same window across accounts keeping the highest usage", () => {
+		const lines = formatRemoteUsageWindows([
+			{
+				provider: "claude",
+				limits: [
+					{
+						id: "5h",
+						label: "5 Hour",
+						window: { id: "5h", label: "5 Hour", resetsAt: RESET_5H },
+						amount: { usedFraction: 0.1, unit: "percent" },
+					},
+				],
+			},
+			{
+				provider: "claude",
+				limits: [
+					{
+						id: "5h",
+						label: "5 Hour",
+						window: { id: "5h", label: "5 Hour", resetsAt: RESET_5H },
+						amount: { usedFraction: 0.42, unit: "percent" },
+					},
+				],
+			},
+		]);
+
+		expect(lines).toEqual(["Claude", "- 5-hour limit — 42% used — resets 2026-07-24 03:30:00 UTC"]);
+	});
+
+	test("skips providers that report no limits and tolerates malformed input", () => {
+		expect(formatRemoteUsageWindows(undefined)).toEqual([]);
+		expect(formatRemoteUsageWindows("nope")).toEqual([]);
+		expect(formatRemoteUsageWindows([{ provider: "grok-cli", limits: [] }, { provider: "kimi" }, null])).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What

Telegram `/usage` now groups quota windows by provider. Previously every
provider's limits were merged into a single 5h/7d pair keyed only by window
kind, so only Anthropic-shaped windows were ever shown and all other registered
providers (OpenAI Codex, Gemini, ...) were hidden.

## Why

Running `/usage` in Telegram only showed Anthropic; other providers' usage was
invisible even though the ACP/TUI `/usage` already renders a per-provider
breakdown — only the Telegram path was missing it.

Change: group limits by `report.provider` and render a provider header followed
by each of that provider's windows. Non-5h/7d windows are kept (labeled from the
window/limit label), the credential `tier` is shown (e.g. `Weekly limit (pro)`),
the used fraction is derived from `used`/`limit` when a fraction is absent, and
repeated windows are deduplicated per provider (keeping the highest usage).

Before:

    Usage windows
    5-hour limit — 7% used — resets 2026-07-24 03:30:00 UTC
    Weekly limit — 79% used — resets 2026-07-26 03:00:00 UTC

After:

    Usage windows
    Anthropic
    - 5-hour limit — 7% used — resets 2026-07-24 03:30:00 UTC
    - Weekly limit — 79% used — resets 2026-07-26 03:00:00 UTC

    Openai Codex
    - Weekly limit (pro) — 53% used — resets 2026-07-28 17:02:47 UTC

## Testing

    bun test packages/coding-agent/test/notifications-usage-windows.test.ts
    bun test packages/coding-agent/test/notifications-control-executor.test.ts
    bunx biome check packages/coding-agent/src/sdk/bus/index.ts \
      packages/coding-agent/test/notifications-usage-windows.test.ts \
      packages/coding-agent/test/notifications-control-executor.test.ts

- New `notifications-usage-windows.test.ts` (4 tests): provider grouping,
  non-5h/7d windows, tier display, used/limit derivation, per-provider
  cross-account dedupe, malformed-input tolerance.
- Updated the redaction test in `notifications-control-executor.test.ts` to
  reflect the provider header while keeping every credential/PII field
  (email, accountId, baseUrl, access token, secret window label) as a secret
  sentinel that must never appear in the output.
- biome clean on all changed files.

Security note: the provider identifier is a fixed enum-like value (the same one
the ACP `/usage` renders), not a credential, so it is displayed as a group
header. Credential/PII fields are still never projected.

## GJC verdict

    gajae.pr-review-verdict.v1 needs-human sha256:f7b466439d1335bc92e0de278c87ac8f52111964 reviewer:human evidence:local bun test + biome (no independent review)

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (verify on CI; only focused tests + biome were run locally)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [ ] Verdict above matches the exact PR head, not an earlier commit
