### PR TITLE
fix: honor documented GJC_ TUI-debug and commit env vars

### DIFF
--- a/packages/coding-agent/src/commit/agentic/index.ts
+++ b/packages/coding-agent/src/commit/agentic/index.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import { createInterface } from "node:readline/promises";
-import { $env, getProjectDir, isEnoent, prompt } from "@gajae-code/utils";
+import { $env, $pickenv, getProjectDir, isEnoent, prompt } from "@gajae-code/utils";
 import { applyChangelogProposals } from "../../commit/changelog";
 import { detectChangelogBoundaries } from "../../commit/changelog/detect";
 import { parseUnreleasedSection } from "../../commit/changelog/parse";
@@ -88,7 +88,7 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 	} else {
 		process.stdout.write("  └─ (none found)\n");
 	}
-	const forceFallback = $env.PI_COMMIT_TEST_FALLBACK?.toLowerCase() === "true";
+	const forceFallback = $pickenv("GJC_COMMIT_TEST_FALLBACK", "PI_COMMIT_TEST_FALLBACK")?.toLowerCase() === "true";
 	if (forceFallback) {
 		process.stdout.write("● Forcing fallback commit generation...\n");
 		const fallbackProposal = generateFallbackProposal(numstat);
@@ -152,7 +152,7 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 	}
 
 	if (!usedFallback && !commitState.proposal && !commitState.splitProposal) {
-		if ($env.PI_COMMIT_NO_FALLBACK?.toLowerCase() !== "true") {
+		if ($pickenv("GJC_COMMIT_NO_FALLBACK", "PI_COMMIT_NO_FALLBACK")?.toLowerCase() !== "true") {
 			process.stdout.write("● Agent did not provide proposal, using fallback...\n");
 			commitState.proposal = generateFallbackProposal(numstat);
 			usedFallback = true;

--- a/packages/coding-agent/src/commit/map-reduce/index.ts
+++ b/packages/coding-agent/src/commit/map-reduce/index.ts
@@ -1,6 +1,6 @@
 import type { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Api, Model } from "@gajae-code/ai";
-import { $env } from "@gajae-code/utils";
+import { $pickenv } from "@gajae-code/utils";
 import { parseFileDiffs } from "../../commit/git/diff";
 import type { ConventionalAnalysis } from "../../commit/types";
 import { isExcludedFile } from "../../commit/utils/exclusions";
@@ -34,7 +34,7 @@ export interface MapReduceInput {
 }
 
 export function shouldUseMapReduce(diff: string, settings?: MapReduceSettings): boolean {
-	if ($env.PI_COMMIT_MAP_REDUCE?.toLowerCase() === "false") return false;
+	if ($pickenv("GJC_COMMIT_MAP_REDUCE", "PI_COMMIT_MAP_REDUCE")?.toLowerCase() === "false") return false;
 	if (settings?.enabled === false) return false;
 	const minFiles = settings?.minFiles ?? MIN_FILES_FOR_MAP_REDUCE;
 	const maxFileTokens = settings?.maxFileTokens ?? MAX_FILE_TOKENS;

--- a/packages/coding-agent/test/commit-map-reduce-env.test.ts
+++ b/packages/coding-agent/test/commit-map-reduce-env.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { shouldUseMapReduce } from "../src/commit/map-reduce";
+
+const KEYS = ["GJC_COMMIT_MAP_REDUCE", "PI_COMMIT_MAP_REDUCE"] as const;
+const original = new Map(KEYS.map(key => [key, Bun.env[key]] as const));
+const clear = (): void => {
+	for (const key of KEYS) delete Bun.env[key];
+};
+afterEach(() => {
+	for (const [key, value] of original) {
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+	}
+});
+
+// `minFiles: 0` makes an empty diff (0 files) satisfy `fileCount >= minFiles`, so
+// shouldUseMapReduce would return true absent any env override — isolating the
+// GJC_COMMIT_MAP_REDUCE / PI_COMMIT_MAP_REDUCE gate.
+const forceEligible = { minFiles: 0 };
+
+describe("shouldUseMapReduce env gating", () => {
+	it("is enabled when no override is set", () => {
+		clear();
+		expect(shouldUseMapReduce("", forceEligible)).toBe(true);
+	});
+
+	it("honors the documented GJC_COMMIT_MAP_REDUCE=false", () => {
+		clear();
+		Bun.env.GJC_COMMIT_MAP_REDUCE = "false";
+		expect(shouldUseMapReduce("", forceEligible)).toBe(false);
+	});
+
+	it("falls back to legacy PI_COMMIT_MAP_REDUCE=false", () => {
+		clear();
+		Bun.env.PI_COMMIT_MAP_REDUCE = "false";
+		expect(shouldUseMapReduce("", forceEligible)).toBe(false);
+	});
+
+	it("resolves GJC-first: GJC=true is not overridden by PI=false", () => {
+		clear();
+		Bun.env.GJC_COMMIT_MAP_REDUCE = "true";
+		Bun.env.PI_COMMIT_MAP_REDUCE = "false";
+		expect(shouldUseMapReduce("", forceEligible)).toBe(true);
+	});
+});

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -660,7 +660,7 @@ export class TUI extends Container {
 	readonly #useImeBlockCursor = $flag("GJC_TUI_IME_CURSOR", process.platform === "darwin");
 	// showHardwareCursor=false but cursor is shown for IME anchoring (macOS).
 	#imeCursorActive = false;
-	#clearOnShrink = $flag("PI_CLEAR_ON_SHRINK"); // Clear empty rows when content shrinks (default: off)
+	#clearOnShrink = $pickflag("GJC_CLEAR_ON_SHRINK", "PI_CLEAR_ON_SHRINK"); // Clear empty rows when content shrinks (default: off)
 	// Default-on: reuse the previous normalized off-screen prefix and only normalize/diff the
 	// visible window, bounding per-frame work on huge transcripts. Output stays byte-identical;
 	// set PI_TUI_VIRTUAL_VIEWPORT=0 to restore legacy full-transcript normalization.
@@ -693,7 +693,7 @@ export class TUI extends Container {
 
 	static #readDebugRedrawFlag(): boolean {
 		TUI.#renderCounters.debugRedrawEnvReads += 1;
-		return $flag("PI_DEBUG_REDRAW");
+		return $pickflag("GJC_DEBUG_REDRAW", "PI_DEBUG_REDRAW");
 	}
 
 	#appendDebugRedrawLog(message: string): void {
@@ -2451,7 +2451,7 @@ export class TUI extends Container {
 
 		// Content shrunk below the previous render and no overlays - re-render to clear empty rows
 		// (overlays need the padding, so only do this when no overlays are active)
-		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
+		// Configurable via setClearOnShrink() or GJC_CLEAR_ON_SHRINK=0 env var
 		if (this.#clearOnShrink && newLines.length < this.#previousLines.length && this.overlayStack.length === 0) {
 			logRedraw(`clearOnShrink (prev=${this.#previousLines.length}, new=${newLines.length})`);
 			if (
@@ -2662,7 +2662,7 @@ export class TUI extends Container {
 		buffer += seq;
 		buffer += "\x1b[?2026l"; // End synchronized output
 
-		if ($flag("PI_TUI_DEBUG")) {
+		if ($pickflag("GJC_TUI_DEBUG", "PI_TUI_DEBUG")) {
 			const debugDir = "/tmp/tui";
 			fs.mkdirSync(debugDir, { recursive: true });
 			const debugPath = path.join(debugDir, `render-${Date.now()}-${Math.random().toString(36).slice(2)}.log`);


### PR DESCRIPTION
## What

The GJC_* env migration (#2943) left **six documented variables** reading only the legacy PI_ name, so setting the documented GJC_ name was a silent no-op:

- `docs/environment-variables.md` §9: `GJC_CLEAR_ON_SHRINK`, `GJC_DEBUG_REDRAW`, `GJC_TUI_DEBUG` — `tui.ts` read `$flag("PI_...")`
- `docs/environment-variables.md` §10: `GJC_COMMIT_TEST_FALLBACK`, `GJC_COMMIT_NO_FALLBACK`, `GJC_COMMIT_MAP_REDUCE` — `commit/*` read `$env.PI_...`

## Fix

Resolve GJC_ first with PI_ fallback via the existing `$pickflag`/`$pickenv` helpers, matching #2827/#2943. PI_ names stay as fallbacks; behavior is unchanged when only PI_ is set.

## Tests

`packages/coding-agent/test/commit-map-reduce-env.test.ts` covers the exported `shouldUseMapReduce` gate (default-enabled, GJC honored, PI fallback, GJC-beats-PI). tui/coding-agent `tsc` clean; tui debug-flag tests green; `issue-2598-repro` (native-free tab-worker contract) green; biome clean.

## Follow-up (transparent)

A broader doc-vs-code sweep found other documented GJC_ vars still on PI_ (`procmgr` bash/shell knobs, `perplexity` auth-borrow, the OpenAI stream idle timeout) that carry additional legacy aliases (`CLAUDE_*`, multiple PI_ names) plus some doc-only rows with no reader (RPC/websocket/runtime — likely stale docs). Those need per-var care and are left for a focused follow-up rather than bundled here.