### PR TITLE
fix(state): keep corrupt-state warnings off TUI stderr

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Workflow state readers no longer write corrupt-state or out-of-band warnings straight to `process.stderr` during interactive sessions. Warnings go through the TUI-safe file logger; CLI `gjc state` still surfaces structured warnings on the command result stderr path so the live prompt is not painted over mid-frame (#3002).
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
 
 ## [0.11.8] - 2026-07-23

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { logger } from "@gajae-code/utils";
+// Subpath import keeps this module native-free for gjc-state-gates (the package
+// barrel pulls procmgr/ptree → @gajae-code/natives).
+import * as logger from "@gajae-code/utils/logger";
 import type { WorkflowHudSummary } from "../skill-state/active-state";
 import {
 	applyHandoffToActiveState,

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
 import type { WorkflowHudSummary } from "../skill-state/active-state";
 import {
 	applyHandoffToActiveState,
@@ -265,6 +266,16 @@ async function describeStaleClearState(
 	return undefined;
 }
 
+/**
+ * Route workflow-state warnings through the file logger (console transport off
+ * by default) so interactive TUI sessions never paint raw bytes into the
+ * alternate-screen stream. CLI commands still surface structured warnings via
+ * {@link StateCommandResult.stderr} where applicable.
+ */
+function emitStateWarning(message: string, context?: Record<string, unknown>): void {
+	logger.warn(message, context);
+}
+
 async function readJsonFile(filePath: string): Promise<Record<string, unknown> | null> {
 	try {
 		const raw = await fs.readFile(filePath, "utf-8");
@@ -276,7 +287,10 @@ async function readJsonFile(filePath: string): Promise<Record<string, unknown> |
 	} catch (error) {
 		const err = error as NodeJS.ErrnoException;
 		if (err.code === "ENOENT") return null;
-		process.stderr.write(`WARNING: failed to read ${filePath}; ignoring corrupt state: ${err.message}\n`);
+		emitStateWarning(`WARNING: failed to read ${filePath}; ignoring corrupt state: ${err.message}`, {
+			filePath,
+			error: err.message,
+		});
 		return null;
 	}
 }
@@ -287,7 +301,10 @@ async function readJsonValue(filePath: string): Promise<unknown | null> {
 	} catch (error) {
 		const err = error as NodeJS.ErrnoException;
 		if (err.code === "ENOENT") return null;
-		process.stderr.write(`WARNING: failed to read ${filePath}; ignoring corrupt state: ${err.message}\n`);
+		emitStateWarning(`WARNING: failed to read ${filePath}; ignoring corrupt state: ${err.message}`, {
+			filePath,
+			error: err.message,
+		});
 		return null;
 	}
 }
@@ -1603,7 +1620,7 @@ async function handleHandoffUnlocked(args: readonly string[], cwd: string): Prom
 			toPhase: "handoff",
 		});
 		await updateWorkflowTransactionJournal(cwd, sessionId, mutationId, { steps: ["caller-mode-state"] });
-		if (callerWrite.warning) process.stderr.write(`${callerWrite.warning}\n`);
+		if (callerWrite.warning) emitStateWarning(callerWrite.warning, { skill: caller, verb: "handoff" });
 		const stampedCallerReceipt = isPlainObject(callerWrite.stamped.receipt) ? callerWrite.stamped.receipt : {};
 		await syncSkillActiveState({
 			cwd,
@@ -1646,6 +1663,7 @@ async function handleHandoffUnlocked(args: readonly string[], cwd: string): Prom
 					active_state: activeStateFile(cwd, sessionId),
 				},
 			}),
+			...(callerWrite.warning ? { stderr: `${callerWrite.warning}\n` } : {}),
 		};
 	}
 
@@ -1746,7 +1764,9 @@ async function handleHandoffUnlocked(args: readonly string[], cwd: string): Prom
 	);
 	const stampedCallerReceipt = isPlainObject(callerWrite.stamped.receipt) ? callerWrite.stamped.receipt : {};
 	const stampedCalleeReceipt = isPlainObject(calleeWrite.stamped.receipt) ? calleeWrite.stamped.receipt : {};
-	for (const warning of warnings) process.stderr.write(`${warning}\n`);
+	for (const warning of warnings) {
+		emitStateWarning(warning, { skill: caller, verb: "handoff", to: callee });
+	}
 	if (process.env.GJC_STATE_HANDOFF_FAIL_AFTER_CALLER === mutationId) {
 		throw new StateCommandError(1, `injected handoff failure after caller write for ${mutationId}`);
 	}
@@ -1818,6 +1838,7 @@ async function handleHandoffUnlocked(args: readonly string[], cwd: string): Prom
 				active_state: activeStateFile(cwd, sessionId),
 			},
 		}),
+		...(warnings.length > 0 ? { stderr: `${warnings.join("\n")}\n` } : {}),
 	};
 }
 

--- a/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
@@ -8,7 +8,7 @@ import {
 	sessionStateDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { readWorkflowStateJson, runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
-import { logger } from "@gajae-code/utils";
+import * as logger from "@gajae-code/utils/logger";
 
 const TEST_SESSION_ID = "test-session";
 

--- a/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { deepInterviewCharacterCount } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-state";
@@ -7,7 +7,8 @@ import {
 	modeStatePath,
 	sessionStateDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
-import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+import { readWorkflowStateJson, runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+import { logger } from "@gajae-code/utils";
 
 const TEST_SESSION_ID = "test-session";
 
@@ -94,6 +95,34 @@ describe("native gjc state runtime", () => {
 
 		const status = await runNativeStateCommand(["status", "--mode", "ralplan", "--json"], root);
 		expect(status.status).toBe(0);
+	});
+
+	it("does not paint corrupt ultragoal-state warnings onto process.stderr (#3002)", async () => {
+		const root = await tempDir();
+		const stateDir = sessionStateDir(root, TEST_SESSION_ID);
+		await fs.mkdir(stateDir, { recursive: true });
+		const corruptPath = path.join(stateDir, "ultragoal-state.json");
+		await fs.writeFile(corruptPath, "{not json");
+
+		const stderrWrites: string[] = [];
+		const stderrSpy = spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+			stderrWrites.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		});
+		const warn = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const state = await readWorkflowStateJson(root, "ultragoal", TEST_SESSION_ID);
+			expect(state).toEqual({});
+			const painted = stderrWrites.join("");
+			expect(painted).not.toContain("WARNING:");
+			expect(painted).not.toContain("ignoring corrupt state");
+			expect(
+				warn.mock.calls.some(call => typeof call[0] === "string" && call[0].includes("ignoring corrupt state")),
+			).toBe(true);
+		} finally {
+			warn.mockRestore();
+			stderrSpy.mockRestore();
+		}
 	});
 
 	it('supports the legacy --input \'{"mode":"..."}\' payload shape for read', async () => {

--- a/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { modeStatePath, sessionStateDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
-import { logger } from "@gajae-code/utils";
+import * as logger from "@gajae-code/utils/logger";
 
 const TEST_SESSION_ID = "test-session";
 

--- a/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { modeStatePath, sessionStateDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+import { logger } from "@gajae-code/utils";
 
 const TEST_SESSION_ID = "test-session";
 
@@ -175,13 +176,19 @@ describe("gjc state write hardening", () => {
 		const root = await tempDir();
 		await writeRawState(root, "ralplan", "{broken json");
 		const stderr = captureStderrWrites();
+		const warn = spyOn(logger, "warn").mockImplementation(() => {});
 		try {
 			const read = await runNativeStateCommand(["read", "--mode", "ralplan", "--json"], root);
 			expect(read.status).toBe(0);
 			const status = await runNativeStateCommand(["status", "--mode", "ralplan", "--json"], root);
 			expect(status.status).toBe(0);
-			expect(stderr.writes.join("")).toContain("ignoring corrupt state");
+			// TUI-safe: never paint raw warning bytes into the alternate-screen stream (#3002).
+			expect(stderr.writes.join("")).not.toContain("ignoring corrupt state");
+			expect(
+				warn.mock.calls.some(call => typeof call[0] === "string" && call[0].includes("ignoring corrupt state")),
+			).toBe(true);
 		} finally {
+			warn.mockRestore();
 			stderr.restore();
 		}
 


### PR DESCRIPTION
## Summary

Fixes #3002.

While ultragoal (or any workflow state) is active, corrupt mode-state was fail-open as empty, but `readJsonFile` / `readJsonValue` painted raw `WARNING: ... ignoring corrupt state` bytes onto `process.stderr`. On an interactive TUI that lands in the alternate-screen stream and temporarily overlays the composer until the next redraw.

## Fix

- Route corrupt-state and handoff out-of-band warnings through the TUI-safe file logger (`logger.warn`, console transport off by default), matching `hooks/skill-state.ts`.
- Keep structured CLI warnings on `StateCommandResult.stderr` so `gjc state` still surfaces them when the CLI command path prints the result.
- Regression: corrupt ultragoal-state read must not write `WARNING` / `ignoring corrupt state` to `process.stderr`.

## Product dogfood (compiled binary)

```sh
bun run build
# then spawn packages/coding-agent/dist/gjc (not bun src/cli.ts)
```

## Tests

```sh
bun test packages/coding-agent/test/gjc-runtime/state-runtime.test.ts -t "does not paint corrupt ultragoal"
bun test packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts -t "corrupt existing state"
```

## Evidence

Exact-head full-build + compiled-binary dogfood transcript in the PR comment.