### PR TITLE
fix(session): open managed scope binding writable for durability fsync on Windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
+- Managed session scope binding durability verification no longer fails on Windows. `fsyncCanonicalBinding` opened the binding read-only before `fsync`, but Windows `FlushFileBuffers` rejects read-only handles with `EPERM`; every resume/continue/fork of a project with an existing scope binding then aborted with `Could not open managed session: durability_failed`. The durability fsync now opens the binding with write access on Windows (matching the existing win32 fsync-open pattern in managed storage), while POSIX behavior is unchanged.
 
 ## [0.11.8] - 2026-07-23
 ### Added

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -579,7 +579,13 @@ function fsyncCanonicalBinding(bindingPath: string, expected: string): void {
 	if (captured.bytes.toString("utf8") !== expected) throw new Error("binding_invalid");
 	let descriptor: number | undefined;
 	try {
-		descriptor = fs.openSync(bindingPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+		descriptor = fs.openSync(
+			bindingPath,
+			// Windows FlushFileBuffers requires a writable handle; a read-only fd makes
+			// fsync fail with EPERM. Mirror the win32 fsync-open pattern used elsewhere in
+			// managed storage so binding durability verification does not spuriously fail.
+			(process.platform === "win32" ? fs.constants.O_WRONLY : fs.constants.O_RDONLY) | fs.constants.O_NOFOLLOW,
+		);
 		const before = fs.fstatSync(descriptor, { bigint: true });
 		if (
 			before.dev !== captured.identity.dev ||

--- a/packages/coding-agent/test/managed-scope-owner-only-self-heal.test.ts
+++ b/packages/coding-agent/test/managed-scope-owner-only-self-heal.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import type { NativeOwnerOnlySecurityResult } from "@gajae-code/natives";
 import * as native from "@gajae-code/natives";
 import {
+	ensureManagedScope,
 	prepareManagedSessionScopeForWriteSync,
 	resolveManagedScope,
 	resolveManagedScopeForWrite,
@@ -116,5 +117,40 @@ describe("managed scope write resolver", () => {
 		expect(verify).toHaveBeenCalled();
 		expect(apply).not.toHaveBeenCalled();
 		expect(repair).not.toHaveBeenCalled();
+	});
+});
+
+// Preparing an already-bound managed scope re-validates the existing binding for
+// durability. That verification opens the binding and fsyncs it. On Windows,
+// FlushFileBuffers fails with EPERM on a read-only handle, so opening the binding
+// read-only made the second (and every later) preparation throw `durability_failed`,
+// which aborted resume/continue/fork while brand-new sessions (a separate sync path)
+// still worked. Preparing a scope that already has its binding must stay resolved.
+describe("managed scope binding preparation is durably repeatable", () => {
+	function fixture(): { cwd: string; agentDir: string; sessionsRoot: string } {
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-scope-rebind-home-"));
+		temporaryDirectories.push(home);
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-scope-rebind-cwd-"));
+		temporaryDirectories.push(cwd);
+		const agentDir = path.join(home, "agent");
+		const sessionsRoot = path.join(agentDir, "sessions");
+		fs.mkdirSync(sessionsRoot, { recursive: true, mode: 0o700 });
+		return { cwd, agentDir, sessionsRoot };
+	}
+
+	it("re-resolves a scope whose binding already exists without a spurious durability failure", async () => {
+		const { cwd, agentDir, sessionsRoot } = fixture();
+		const policy = process.platform === "win32" ? "windows-existing-verify-first" : "default";
+
+		// First preparation creates the v2 binding (no collision, no durability fsync).
+		const first = await ensureManagedScope(resolveScope(cwd, agentDir, sessionsRoot), policy);
+		expect(first.kind).toBe("resolved");
+
+		// A fresh preparation (as a later launch would perform) collides with the
+		// existing binding and must revalidate it durably rather than failing closed.
+		const second = await ensureManagedScope(resolveScope(cwd, agentDir, sessionsRoot), policy);
+		expect(second.kind).toBe("resolved");
+		const third = await ensureManagedScope(resolveScope(cwd, agentDir, sessionsRoot), policy);
+		expect(third.kind).toBe("resolved");
 	});
 });


### PR DESCRIPTION
## What

Fix a Windows-only crash where resuming, continuing, or forking a session aborts with:

```
[Unhandled Rejection] Error: Could not open managed session: durability_failed
    at prepareManagedCandidateForWrite (.../session/session-manager.ts)
```

`fsyncCanonicalBinding` (managed scope binding durability verification) opened the binding with `O_RDONLY` before calling `fs.fsyncSync`. On Windows, `FlushFileBuffers` rejects read-only handles, so `fsync` throws `EPERM`, which is caught and rethrown as `durability_failed`. This path runs on every managed **resume/continue/fork** once a project's v2 scope binding already exists (the collision branch), so it fails deterministically on Windows. Brand-new sessions kept working because `SessionManager.create` uses the separate `prepareManagedSessionScopeForWriteSync` path, which never fsyncs the pre-existing binding — which is why the symptom looked intermittent.

The fix opens the binding writable on win32 for the durability fsync only, mirroring the pattern already used elsewhere in managed storage (`packages/coding-agent/src/session/internal/managed-session-storage.ts`):

```ts
(process.platform === "win32" ? fs.constants.O_WRONLY : fs.constants.O_RDONLY) | fs.constants.O_NOFOLLOW
```

POSIX behavior is unchanged. The handle still uses `O_NOFOLLOW`, never writes to the binding, and the before/after identity checks are preserved (opening for write does not change mtime/size/ino).

## Why

Root cause: Windows `FlushFileBuffers` requires write access on the handle; a read-only fd makes `fsync` fail with `EPERM`. The sibling functions in this codebase already special-case win32 for exactly this reason; `fsyncCanonicalBinding` was the one spot that hardcoded `O_RDONLY`.

Reproduced deterministically on Windows 11 (win32-x64): `ensureManagedScope` on an existing binding failed 400/400 before the change and succeeded 400/400 after.

No tracked issue; this documents and fixes the root cause.

## Testing

- **New regression test** (`test/managed-scope-owner-only-self-heal.test.ts` → "managed scope binding preparation is durably repeatable"): prepares an already-bound scope repeatedly and asserts each preparation stays `resolved`.
  - Without the fix (on Windows): **fails** — the second `ensureManagedScope` returns `error` (`durability_failed`).
  - With the fix: **passes** (`3 pass / 1 skip`).
- `bun test packages/coding-agent/test/managed-scope-owner-only-self-heal.test.ts` → 3 pass, 1 skip (linux-only self-heal), 0 fail.
- `biome check` on both changed files → clean.
- `bun --cwd=packages/coding-agent run check:types` (`tsc -p tsconfig.json --noEmit`) → passes.

Platform: verified on Windows 11 / win32-x64. POSIX path is unchanged by construction.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:97d273a9daaef9c5a74daf7bf013402f11cb8c53 reviewer:human evidence:local:bun-test+biome+tsc(win32-x64)
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes (biome + `tsc --noEmit` on the package; focused test green)
- [x] Tested locally (Windows 11, win32-x64; fails-without / passes-with the fix)
- [x] CHANGELOG updated (user-facing bugfix)
- [x] Verdict above matches the exact PR head
