### PR TITLE
fix(ai): extend Kimi first-event wait without replay

### DIFF
--- a/artifacts/architecture-2383-eval.json
+++ b/artifacts/architecture-2383-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "d08cb38c79d9cfb1831e4882a99311d76a1bd4cf",
-		"providerSourceSha256": "4f521d3195b750bb8a631f5217d23d64e4ebaa8864bb89f101b5734e3d5e80d0",
+		"providerSourceBlobOid": "67cd55244f886f568da678bda4314298f01abf0e",
+		"providerSourceSha256": "978c083395de102cb8c78d1e25b164daea3c3558dbd7d90e7a190d3f22550e9b",
 		"inputFixtureSha256": "b1ca8d3183ca168140774f848ed414252178f7c5788d61243069862ae59c129b"
 	},
 	"derivationCommands": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Kimi Code now allows one continuous 300-second first-event wait before aborting, while preserving explicit caller and environment timeout overrides and the existing inter-event idle timeout.
 
 ### Added
 
@@ -11,7 +14,7 @@
 ### Fixed
 
 - OpenAI Responses / Codex native history replay no longer submits missing resident-image placeholders as `input_image.image_url`. Invalid values (including `[Session resident imageUrl blob missing: …]`) are dropped, or retained as `file_id`-only parts when a non-empty `file_id` is present, so a single unavailable historical image cannot brick `/retry` (#2924).
-- Raised the first-event stream timeout floor to five minutes for `alibaba-token-plan` models using the OpenAI Completions and Responses APIs, while preserving caller and environment overrides and the existing inter-event idle timeout.
+- Raised the first-event stream timeout floor to five minutes for `alibaba-token-plan` models at both the OpenAI provider and outer lazy-stream watchdogs, while preserving caller and environment overrides and the existing inter-event idle timeout.
 - OAuth refresh peer-rotation recovery now runs before failure classification instead of only on the definitive-failure path, and the definitive matcher recognizes the "grant is invalid" phrasing. Providers whose invalid-grant response does not contain the literal `invalid_grant` (e.g. Kimi's 400 "The provided authorization grant is invalid") previously had rotation races misclassified as transient, temp-blocking a healthy credential for five minutes on every race; with Kimi's ~12-minute access tokens and multiple processes sharing the credential store this surfaced as repeated logouts. Genuine revocations are now disabled with a cause instead of looping temp-blocks.
 - Anthropic 400 `Invalid \`signature\` in \`thinking\` block` responses now trigger the one-shot thinking replay repair instead of failing the turn. The existing repair matcher only recognized the "latest assistant message ... cannot be modified" wording, so the signature-validation variant — which can cite a `thinking`/`redacted_thinking` block anywhere in the replayed history (e.g. after compaction/pruning rewrote an earlier turn) — was treated as a fatal request error. The retry now rebuilds the request with thinking blocks dropped from every replayed assistant message (`repairAllAssistantThinking`), while the latest-message mutation variant keeps the targeted latest-only repair.
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -60,7 +60,12 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { transportFailureFacts } from "../utils/fallback-transport";
 import { isFoundryEnabled } from "../utils/foundry";
 import { finalizeErrorMessage, type RawHttpRequestDump, rewriteCopilotError } from "../utils/http-inspector";
-import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
+import {
+	getProviderFirstEventTimeoutFallbackMs,
+	getStreamFirstEventTimeoutMs,
+	getStreamIdleTimeoutMs,
+	iterateWithIdleTimeout,
+} from "../utils/idle-iterator";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse";
 import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
 import { notifyProviderResponse } from "../utils/provider-response";
@@ -1416,7 +1421,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				firstTokenTime = undefined;
 			};
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
-			const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
+			const firstEventFallbackMs = getProviderFirstEventTimeoutFallbackMs(model.provider);
+			const firstEventTimeoutMs =
+				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs);
 			stream.push({ type: "start", partial: output });
 			// Retry loop for transient errors from the stream.
 			// Provider-level transport/rate-limit failures: only before any streamed content starts.

--- a/packages/ai/src/providers/openai-anthropic-shim.ts
+++ b/packages/ai/src/providers/openai-anthropic-shim.ts
@@ -89,6 +89,8 @@ export function streamOpenAIAnthropicShim(
 					onResponse: options?.onResponse,
 					onSseEvent: options?.onSseEvent,
 					fetch: options?.fetch,
+					streamIdleTimeoutMs: options?.streamIdleTimeoutMs,
+					streamFirstEventTimeoutMs: options?.streamFirstEventTimeoutMs,
 					thinkingEnabled,
 					thinkingBudgetTokens: thinkingBudget,
 				});
@@ -118,6 +120,8 @@ export function streamOpenAIAnthropicShim(
 					onResponse: options?.onResponse,
 					onSseEvent: options?.onSseEvent,
 					fetch: options?.fetch,
+					streamIdleTimeoutMs: options?.streamIdleTimeoutMs,
+					streamFirstEventTimeoutMs: options?.streamFirstEventTimeoutMs,
 					reasoning: reasoningEffort,
 				});
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -49,6 +49,7 @@ import {
 import {
 	createWatchdog,
 	getOpenAIStreamIdleTimeoutMs,
+	getProviderFirstEventTimeoutFallbackMs,
 	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
@@ -427,6 +428,7 @@ function getTrailingPartialDeepseekToken(text: string): string {
 }
 
 const ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS = 300_000;
+
 const OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI completions stream timed out while waiting for the first event";
 
@@ -564,7 +566,9 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				}
 			}
 			const firstEventFallbackMs =
-				model.provider === "alibaba-token-plan" ? ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS : undefined;
+				model.provider === "alibaba-token-plan"
+					? ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS
+					: getProviderFirstEventTimeoutFallbackMs(model.provider);
 			const firstEventWatchdog = createWatchdog(
 				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs),
 				() => abortTracker.abortLocally(firstEventTimeoutAbortError),

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -190,6 +190,22 @@ interface LazyStreamLimits {
 const GOOGLE_GEMINI_CLI_LAZY_STREAM_LIMITS: LazyStreamLimits = {
 	defaultFirstEventTimeoutMs: 300_000,
 };
+const SLOW_FIRST_EVENT_PROVIDERS = new Set(["alibaba-token-plan", "kimi-code"]);
+
+/**
+ * Resolves the first-event timeout fallback for the outer lazy-stream watchdog.
+ * A configured wrapper-specific fallback (from `LazyStreamLimits`) always wins;
+ * otherwise providers known to have slow first events get a five-minute floor
+ * matching their inner provider-level override. Returns `undefined` for
+ * providers that should use the shared default.
+ */
+export function resolveLazyStreamFirstEventFallbackMs(
+	provider: string,
+	configuredFallbackMs?: number,
+): number | undefined {
+	if (configuredFallbackMs !== undefined) return configuredFallbackMs;
+	return SLOW_FIRST_EVENT_PROVIDERS.has(provider) ? 300_000 : undefined;
+}
 
 function forwardStream<TApi extends Api>(
 	target: EventStreamImpl,
@@ -202,11 +218,14 @@ function forwardStream<TApi extends Api>(
 	(async () => {
 		try {
 			const idleTimeoutMs = options.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs(limits?.defaultIdleTimeoutMs);
+			const firstEventFallbackMs = resolveLazyStreamFirstEventFallbackMs(
+				model.provider,
+				limits?.defaultFirstEventTimeoutMs,
+			);
 			const watchedSource = iterateWithIdleTimeout(source, {
 				idleTimeoutMs,
 				firstItemTimeoutMs:
-					options.streamFirstEventTimeoutMs ??
-					getStreamFirstEventTimeoutMs(idleTimeoutMs, limits?.defaultFirstEventTimeoutMs),
+					options.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs),
 				errorMessage: LAZY_STREAM_IDLE_TIMEOUT_ERROR,
 				firstItemErrorMessage: LAZY_STREAM_FIRST_EVENT_TIMEOUT_ERROR,
 				onIdle: () => abortTracker.abortLocally(new Error(LAZY_STREAM_IDLE_TIMEOUT_ERROR)),

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -2,6 +2,11 @@ import { $env } from "@gajae-code/utils";
 
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000;
 const DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS = 100_000;
+const KIMI_CODE_FIRST_EVENT_TIMEOUT_MS = 300_000;
+
+export function getProviderFirstEventTimeoutFallbackMs(provider: string): number | undefined {
+	return provider === "kimi-code" ? KIMI_CODE_FIRST_EVENT_TIMEOUT_MS : undefined;
+}
 
 function normalizeIdleTimeoutMs(value: string | undefined, fallback: number): number | undefined {
 	if (value === undefined) return fallback;

--- a/packages/ai/test/register-builtins.test.ts
+++ b/packages/ai/test/register-builtins.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from "bun:test";
-import { setBedrockProviderModule, streamBedrock } from "../src/providers/register-builtins";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import "../src/providers/openai-completions";
+import "../src/providers/openai-responses";
+import { getBundledModel } from "../src/models";
+import {
+	resolveLazyStreamFirstEventFallbackMs,
+	setBedrockProviderModule,
+	streamBedrock,
+} from "../src/providers/register-builtins";
+import { stream as streamModel } from "../src/stream";
 import type { AssistantMessage, Context, Model } from "../src/types";
 import type { AssistantMessageEventStream } from "../src/utils/event-stream";
 
@@ -172,5 +180,285 @@ describe("register-builtins lazy streams", () => {
 		}
 		expect(result.stopReason).toBe("aborted");
 		expect(result.errorMessage).toBe("Request was aborted");
+	});
+});
+
+describe("resolveLazyStreamFirstEventFallbackMs", () => {
+	it("returns 300s for slow-first-event providers without a configured fallback", () => {
+		expect(resolveLazyStreamFirstEventFallbackMs("alibaba-token-plan")).toBe(300_000);
+		expect(resolveLazyStreamFirstEventFallbackMs("kimi-code")).toBe(300_000);
+	});
+	it("returns undefined for unrelated providers", () => {
+		expect(resolveLazyStreamFirstEventFallbackMs("openai")).toBeUndefined();
+		expect(resolveLazyStreamFirstEventFallbackMs("amazon-bedrock")).toBeUndefined();
+	});
+	it("prefers a configured wrapper fallback over the provider default", () => {
+		expect(resolveLazyStreamFirstEventFallbackMs("alibaba-token-plan", 42_000)).toBe(42_000);
+		expect(resolveLazyStreamFirstEventFallbackMs("kimi-code", 42_000)).toBe(42_000);
+		expect(resolveLazyStreamFirstEventFallbackMs("google-gemini-cli", 300_000)).toBe(300_000);
+	});
+});
+
+describe("outer lazy-stream first-event watchdog (fake timers)", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	function createAlibabaModel(): Model<"bedrock-converse-stream"> {
+		return { ...createModel(), provider: "alibaba-token-plan" };
+	}
+
+	/** Flush pending microtasks so async generators and Promise.race settle. */
+	async function flush(ticks = 20): Promise<void> {
+		for (let i = 0; i < ticks; i++) await Promise.resolve();
+	}
+
+	/**
+	 * Creates a source that yields `start` immediately, then delays `delayMs`
+	 * (fake-timer controlled) before yielding a text_delta and completing.
+	 */
+	function createDelayedSource(delayMs: number) {
+		const partialMessage = createAssistantMessage("stop");
+		const finalMessage = createAssistantMessage("stop");
+		return {
+			async *[Symbol.asyncIterator]() {
+				yield { type: "start", partial: partialMessage } as const;
+				await new Promise<void>(resolve => setTimeout(resolve, delayMs));
+				yield { type: "text_delta", contentIndex: 0, delta: "hello", partial: partialMessage } as const;
+			},
+			result: async () => finalMessage,
+		} as unknown as AssistantMessageEventStream;
+	}
+
+	/** Creates a source that yields `start` then hangs forever. */
+	function createHangingSource() {
+		const partialMessage = createAssistantMessage("stop");
+		return {
+			async *[Symbol.asyncIterator]() {
+				yield { type: "start", partial: partialMessage } as const;
+				await new Promise<never>(() => {});
+			},
+		} as unknown as AssistantMessageEventStream;
+	}
+
+	function createDelayedSseResponse(delayMs: number, events: unknown[]): Response {
+		const encoder = new TextEncoder();
+		const payload = `${events
+			.map(event => `data: ${typeof event === "string" ? event : JSON.stringify(event)}`)
+			.join("\n\n")}\n\n`;
+		return new Response(
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					setTimeout(() => {
+						controller.enqueue(encoder.encode(payload));
+						controller.close();
+					}, delayMs);
+				},
+			}),
+			{ status: 200, headers: { "content-type": "text/event-stream" } },
+		);
+	}
+
+	it("alibaba-token-plan survives past the 120s shared default outer watchdog", async () => {
+		vi.useFakeTimers();
+		// Source emits its first real token at 150s — past the 120s default but
+		// well within Alibaba's 300s outer fallback.
+		const source = createDelayedSource(150_000);
+		setBedrockProviderModule({ streamBedrock: () => source });
+
+		const stream = streamBedrock(createAlibabaModel(), baseContext, {});
+		await flush();
+
+		// Advance past the shared 120s default — must NOT timeout.
+		vi.advanceTimersByTime(120_000);
+		await flush();
+		let settled = false;
+		void stream.result().then(() => {
+			settled = true;
+		});
+		await flush();
+		expect(settled).toBe(false);
+
+		// Advance to 150s — the source emits text_delta and completes.
+		vi.advanceTimersByTime(30_000);
+		await flush();
+		const result = await stream.result();
+		expect(result.stopReason).toBe("stop");
+		expect(result.errorMessage).toBeUndefined();
+	});
+
+	it("alibaba-token-plan times out at 300s when the source never emits", async () => {
+		vi.useFakeTimers();
+		const source = createHangingSource();
+		setBedrockProviderModule({ streamBedrock: () => source });
+
+		const stream = streamBedrock(createAlibabaModel(), baseContext, {});
+		await flush();
+
+		// 299s — still alive.
+		vi.advanceTimersByTime(299_000);
+		await flush();
+		let settled = false;
+		void stream.result().then(() => {
+			settled = true;
+		});
+		await flush();
+		expect(settled).toBe(false);
+
+		// 300s — watchdog fires.
+		vi.advanceTimersByTime(1_000);
+		await flush();
+		const result = await stream.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Provider stream timed out while waiting for the first event");
+	});
+
+	it("unrelated providers still time out at the 120s shared default", async () => {
+		vi.useFakeTimers();
+		// Source would emit at 150s, but the generic 120s watchdog fires first.
+		const source = createDelayedSource(150_000);
+		setBedrockProviderModule({ streamBedrock: () => source });
+
+		const stream = streamBedrock(createModel(), baseContext, {});
+		await flush();
+
+		vi.advanceTimersByTime(120_000);
+		await flush();
+		const result = await stream.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Provider stream timed out while waiting for the first event");
+	});
+
+	it("explicit streamFirstEventTimeoutMs takes precedence over the Alibaba fallback", async () => {
+		vi.useFakeTimers();
+		const source = createHangingSource();
+		setBedrockProviderModule({ streamBedrock: () => source });
+
+		const stream = streamBedrock(createAlibabaModel(), baseContext, {
+			streamFirstEventTimeoutMs: 60_000,
+		});
+		await flush();
+
+		// 59s — still alive.
+		vi.advanceTimersByTime(59_000);
+		await flush();
+		let settled = false;
+		void stream.result().then(() => {
+			settled = true;
+		});
+		await flush();
+		expect(settled).toBe(false);
+
+		// 60s — explicit override fires well before the 300s Alibaba fallback.
+		vi.advanceTimersByTime(1_000);
+		await flush();
+		const result = await stream.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Provider stream timed out while waiting for the first event");
+	});
+	it("keeps the exported OpenAI Completions lazy path alive past 120s for Alibaba", async () => {
+		vi.useFakeTimers();
+		const model = getBundledModel("alibaba-token-plan", "glm-5.2") as Model<"openai-completions">;
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async () =>
+			createDelayedSseResponse(150_000, [
+				{
+					id: "chatcmpl-delayed",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: model.id,
+					choices: [{ index: 0, delta: { content: "Hello delayed" } }],
+				},
+				{
+					id: "chatcmpl-delayed",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: model.id,
+					choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+					usage: {
+						prompt_tokens: 5,
+						completion_tokens: 2,
+						total_tokens: 7,
+						prompt_tokens_details: { cached_tokens: 0 },
+					},
+				},
+				"[DONE]",
+			])) as unknown as typeof fetch);
+
+		const lazyStream = streamModel(model, baseContext, { apiKey: "test-key" });
+		await flush();
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(120_000);
+		await flush();
+		let settled = false;
+		void lazyStream.result().then(() => {
+			settled = true;
+		});
+		await flush();
+		expect(settled).toBe(false);
+
+		vi.advanceTimersByTime(30_000);
+		await flush();
+		const result = await lazyStream.result();
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toContainEqual({ type: "text", text: "Hello delayed" });
+	});
+
+	it("keeps the exported OpenAI Responses lazy path alive past 120s for Alibaba", async () => {
+		vi.useFakeTimers();
+		const model = getBundledModel("alibaba-token-plan", "qwen3.8-max-preview") as Model<"openai-responses">;
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async () =>
+			createDelayedSseResponse(150_000, [
+				{ type: "response.created", response: { id: "resp-delayed" } },
+				{
+					type: "response.output_item.added",
+					item: { type: "message", id: "msg-delayed", role: "assistant", status: "in_progress", content: [] },
+				},
+				{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+				{ type: "response.output_text.delta", delta: "Hello delayed" },
+				{
+					type: "response.output_item.done",
+					item: {
+						type: "message",
+						id: "msg-delayed",
+						role: "assistant",
+						status: "completed",
+						content: [{ type: "output_text", text: "Hello delayed" }],
+					},
+				},
+				{
+					type: "response.completed",
+					response: {
+						id: "resp-delayed",
+						status: "completed",
+						usage: {
+							input_tokens: 5,
+							output_tokens: 2,
+							total_tokens: 7,
+							input_tokens_details: { cached_tokens: 0 },
+						},
+					},
+				},
+			])) as unknown as typeof fetch);
+
+		const lazyStream = streamModel(model, baseContext, { apiKey: "test-key" });
+		await flush();
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(120_000);
+		await flush();
+		let settled = false;
+		void lazyStream.result().then(() => {
+			settled = true;
+		});
+		await flush();
+		expect(settled).toBe(false);
+
+		vi.advanceTimersByTime(30_000);
+		await flush();
+		const result = await lazyStream.result();
+		expect(result.stopReason).toBe("stop");
+		expect(result.content[0]).toMatchObject({ type: "text", text: "Hello delayed" });
 	});
 });

--- a/packages/ai/test/stream-timeout-defaults.test.ts
+++ b/packages/ai/test/stream-timeout-defaults.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs } from "../src/utils/idle-iterator";
+import {
+	getProviderFirstEventTimeoutFallbackMs,
+	getStreamFirstEventTimeoutMs,
+	getStreamIdleTimeoutMs,
+} from "../src/utils/idle-iterator";
 
 /**
  * Per-provider fallback overrides on the stream-watchdog helpers.
  *
- * These are the gear that lets `google-gemini-cli` widen its first-event floor
- * beyond the 100s global default without forcing every other provider to wait
+ * These helpers let selected slow-first-token providers widen their first-event
+ * floor beyond the 100s global default without forcing every provider to wait
  * just as long. Tests pin the precedence contract callers depend on:
  * caller option > env var > per-provider fallback > base default.
  */
@@ -36,6 +40,15 @@ afterEach(() => {
 	}
 });
 
+describe("getProviderFirstEventTimeoutFallbackMs(provider)", () => {
+	it("gives Kimi Code one continuous 300-second first-event window", () => {
+		expect(getProviderFirstEventTimeoutFallbackMs("kimi-code")).toBe(300_000);
+	});
+
+	it("does not widen unrelated providers", () => {
+		expect(getProviderFirstEventTimeoutFallbackMs("anthropic")).toBeUndefined();
+	});
+});
 describe("getStreamIdleTimeoutMs(fallbackMs)", () => {
 	it("returns the per-provider fallback when env vars are unset", () => {
 		expect(getStreamIdleTimeoutMs(300_000)).toBe(300_000);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,11 +4,14 @@
 
 ### Fixed
 
+- Alibaba Token Plan canonical first-event timeouts now surface without session retry/fallback replay and are not internally retried by auto-compaction, preventing repeated provider usage (#3026).
+
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
 - Windows managed-session resume no longer reports `durability_failed` when Bun rejects `fsync` on the read-only descriptor used to revalidate an existing canonical binding; Windows now uses an owner-writable descriptor for that durability fence while retaining no-follow and pre/post identity/content checks.
 - SDK daemon CLI end-to-end tests now drain spawned child stdout and stderr concurrently with process exit, preventing CI pipe teardown races from replacing the product exit contract with SIGPIPE status 141 (#3024).
 - Interactive launch bootstrap is now suppressed for parser-accepted `--print=`, `--help=`, and `--version=` equals forms, keeping non-interactive output free of the warming-workspace preamble on TTYs.
 - Managed legacy-session artifact migration now accepts up to 50,000 files, processes copy work in bounded batches, and reports capacity exhaustion separately from unsafe artifact topology (#2935).
+- Kimi Code first-event timeouts now surface after the provider's continuous first-event wait instead of replaying the full request from zero.
 
 - Rejected subagent schema payloads now retain their complete structured data in canonical output artifacts; inline results remain bounded while `agent://` output stays lossless (#2894).
 - Managed legacy-session artifact migration now validates Windows directory roots from the native tree snapshot, tolerates only lazy metadata on plain Windows directories, and replays both clean and cleanup-pending detaches while retaining fail-closed receipt validation. Canonical binding durability sync uses a writable no-follow handle on Windows NTFS stacks that reject `FlushFileBuffers` on read-only handles (#3015, #2913).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -785,6 +785,22 @@ type RetryErrorClassification =
 
 const BARE_DEFAULT_WATCHDOG_ERROR =
 	/^(?:[A-Za-z][A-Za-z0-9-]*(?: [A-Za-z][A-Za-z0-9-]*){0,3} )stream (?:timed out while waiting for the first event|stalled while waiting for the next event)$/;
+const KIMI_CODE_FIRST_EVENT_TIMEOUT_MESSAGES = {
+	"anthropic-messages": new Set([
+		"Provider stream timed out while waiting for the first event",
+		"Anthropic stream timed out while waiting for the first event",
+	]),
+	"openai-completions": new Set([
+		"Provider stream timed out while waiting for the first event",
+		"OpenAI completions stream timed out while waiting for the first event",
+	]),
+} as const;
+
+const ALIBABA_TOKEN_PLAN_PROVIDER = "alibaba-token-plan";
+const ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MESSAGES = {
+	"openai-responses": "OpenAI responses stream timed out while waiting for the first event",
+	"openai-completions": "OpenAI completions stream timed out while waiting for the first event",
+} as const;
 
 function hasBareDefaultRetryDisqualifyingFacts(message: AssistantMessage): boolean {
 	if (message.errorKind !== undefined || message.errorStatus !== undefined) return true;
@@ -12432,6 +12448,7 @@ export class AgentSession {
 							}
 							const retryAfterMs = this.#parseRetryAfterMsFromError(message);
 							const shouldRetry =
+								!this.#isTerminalProviderCompactionTimeout(candidate, message) &&
 								retrySettings.enabled &&
 								attempt < retrySettings.maxRetries &&
 								(retryAfterMs !== undefined ||
@@ -12617,7 +12634,61 @@ export class AgentSession {
 	 * unknown/no-code errors are retryable.
 	 */
 
+	#isKimiCodeFirstEventTimeout(message: AssistantMessage): boolean {
+		if (message.stopReason !== "error" || message.provider !== "kimi-code") return false;
+		const errorMessage = message.errorMessage ?? "";
+		if (message.api === "anthropic-messages") {
+			return KIMI_CODE_FIRST_EVENT_TIMEOUT_MESSAGES["anthropic-messages"].has(errorMessage);
+		}
+		if (message.api === "openai-completions") {
+			return KIMI_CODE_FIRST_EVENT_TIMEOUT_MESSAGES["openai-completions"].has(errorMessage);
+		}
+		return false;
+	}
+
+	#isKimiCodeCompactionTimeout(candidate: Model, errorMessage: string): boolean {
+		if (candidate.provider !== "kimi-code") return false;
+		return /^(?:Summarization failed|Turn prefix summarization failed): (?:Provider|Anthropic|OpenAI completions) stream timed out while waiting for the first event$/.test(
+			errorMessage,
+		);
+	}
+
+	#alibabaTokenPlanCanonicalTimeoutForApi(api: string): string | undefined {
+		if (api === "openai-responses" || api === "openai-completions") {
+			return ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MESSAGES[api];
+		}
+		return undefined;
+	}
+
+	#isAlibabaTokenPlanFirstEventTimeout(message: AssistantMessage): boolean {
+		if (message.stopReason !== "error" || message.provider !== ALIBABA_TOKEN_PLAN_PROVIDER) return false;
+		const canonicalMessage = this.#alibabaTokenPlanCanonicalTimeoutForApi(message.api);
+		return canonicalMessage !== undefined && message.errorMessage === canonicalMessage;
+	}
+
+	#isAlibabaTokenPlanCompactionTimeout(candidate: Model, errorMessage: string): boolean {
+		if (candidate.provider !== ALIBABA_TOKEN_PLAN_PROVIDER) return false;
+		const canonicalMessage = this.#alibabaTokenPlanCanonicalTimeoutForApi(candidate.api);
+		if (canonicalMessage === undefined) return false;
+		return (
+			errorMessage === `Summarization failed: ${canonicalMessage}` ||
+			errorMessage === `Turn prefix summarization failed: ${canonicalMessage}`
+		);
+	}
+
+	#isTerminalProviderFirstEventTimeout(message: AssistantMessage): boolean {
+		return this.#isKimiCodeFirstEventTimeout(message) || this.#isAlibabaTokenPlanFirstEventTimeout(message);
+	}
+
+	#isTerminalProviderCompactionTimeout(candidate: Model, errorMessage: string): boolean {
+		return (
+			this.#isKimiCodeCompactionTimeout(candidate, errorMessage) ||
+			this.#isAlibabaTokenPlanCompactionTimeout(candidate, errorMessage)
+		);
+	}
+
 	#isRetryableError(message: AssistantMessage): boolean {
+		if (this.#isTerminalProviderFirstEventTimeout(message)) return false;
 		if (message.errorMessage?.startsWith("Model fallback chain exhausted;")) return false;
 		const transportFailure = message.transportFailure;
 		const contextWindow = this.model?.contextWindow ?? 0;
@@ -12765,6 +12836,9 @@ export class AgentSession {
 		// is also authoritative except for rate-limit copy where providers may have
 		// parsed an incidental quota number such as "400 requests per minute".
 		if (isTerminalHttp4xx && (explicitStatus !== undefined || !/rate.?limit|too many requests/i.test(err))) {
+			return "terminal";
+		}
+		if (this.#isTerminalProviderFirstEventTimeout(message)) {
 			return "terminal";
 		}
 		// A first-event timeout on ollama-cloud (the ollama-chat API) must not
@@ -12946,6 +13020,18 @@ export class AgentSession {
 						stopReason: "error",
 						messages: [outcome.message],
 					});
+				},
+			};
+		}
+		if (this.#isTerminalProviderFirstEventTimeout(outcome.failure.message)) {
+			// The managed transport discarded this attempt before session policy saw it.
+			// Remove its provisional controller charge and surface the original message.
+			this.#defaultFallbackChain().discardStartedAttempt();
+			return {
+				type: "terminal",
+				terminal: {
+					stopReason: "error",
+					messages: [outcome.failure.message],
 				},
 			};
 		}

--- a/packages/coding-agent/test/agent-session-auto-compaction-oversized.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-oversized.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@gajae-code/agent-core";
 import * as compactionModule from "@gajae-code/agent-core/compaction";
-import { getBundledModel } from "@gajae-code/ai";
+import { getBundledModel, type Model } from "@gajae-code/ai";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { AgentSession, type AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
@@ -65,6 +65,31 @@ describe("AgentSession oversized auto-maintenance guard", () => {
 			sessionManager.appendMessage(assistant);
 		}
 	}
+	function replaceSession(model: Model, settingsOverrides: Record<string, unknown> = {}): void {
+		authStorage.setRuntimeApiKey(model.provider, "test-key");
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		sessionManager = SessionManager.inMemory();
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.keepRecentTokens": 1,
+				"contextPromotion.enabled": false,
+				"retry.enabled": false,
+				"todo.reminders": false,
+				...settingsOverrides,
+			}),
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+	}
 
 	it("skips an unchanged oversized auto-maintenance retry after a context-length failure", async () => {
 		appendConversation();
@@ -109,5 +134,32 @@ describe("AgentSession oversized auto-maintenance guard", () => {
 		await session.runIdleCompaction();
 
 		expect(compactSpy).toHaveBeenCalledTimes(4);
+	});
+	it("does not retry a Kimi Code compaction first-event timeout on the same candidate", async () => {
+		const model = getBundledModel("kimi-code", "kimi-k2.5");
+		if (!model) throw new Error("Expected bundled Kimi Code model");
+		await session.dispose();
+		replaceSession(model, {
+			"retry.enabled": true,
+			"retry.maxRetries": 2,
+			"retry.baseDelayMs": 1,
+		});
+		appendConversation("Kimi compaction timeout");
+		const compactSpy = vi
+			.spyOn(compactionModule, "compact")
+			.mockImplementation((_preparation, candidate) =>
+				Promise.reject(
+					new Error(
+						candidate.provider === "kimi-code"
+							? "Summarization failed: Provider stream timed out while waiting for the first event"
+							: "terminal compaction failure",
+					),
+				),
+			);
+
+		await session.runIdleCompaction();
+
+		const matchingCalls = compactSpy.mock.calls.filter(([, candidate]) => candidate.id === model.id);
+		expect(matchingCalls).toHaveLength(1);
 	});
 });

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -112,6 +112,7 @@ describe("AgentSession resilient retry", () => {
 	}
 
 	function buildStatusErrorSession(options: {
+		model?: Model;
 		errorMessage?: string;
 		errorStatus?: number;
 		errorKind?: AssistantMessage["errorKind"];
@@ -119,14 +120,22 @@ describe("AgentSession resilient retry", () => {
 		recoveredContent?: string;
 		partialContent?: string;
 		bareDefault?: boolean;
+		messageApi?: AssistantMessage["api"];
+		messageProvider?: string;
+		messageModel?: string;
+		requestedModels?: string[];
+		settingsOverrides?: Record<string, unknown>;
 	}): AgentSession {
-		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
-		if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+		const model = options.model ?? getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled test model to exist");
+		authStorage.setRuntimeApiKey(model.provider, `${model.provider}-test-key`);
+		const requestedModels = options.requestedModels ?? [];
 		let calls = 0;
 		const agent = new Agent({
 			getApiKey: provider => `${provider}-test-key`,
 			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
 			streamFn: (requestedModel, context, opts) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
 				calls++;
 				if (calls > 1 && options.recoveredContent) {
 					return createMockModel({ responses: [{ content: [options.recoveredContent] }] }).stream(
@@ -140,9 +149,9 @@ describe("AgentSession resilient retry", () => {
 					const message: AssistantMessage = {
 						role: "assistant",
 						content: options.partialContent ? [{ type: "text", text: options.partialContent }] : [],
-						api: requestedModel.api,
-						provider: requestedModel.provider,
-						model: requestedModel.id,
+						api: options.messageApi ?? requestedModel.api,
+						provider: options.messageProvider ?? requestedModel.provider,
+						model: options.messageModel ?? requestedModel.id,
 						usage: {
 							input: 0,
 							output: 0,
@@ -173,6 +182,7 @@ describe("AgentSession resilient retry", () => {
 						"retry.maxDelayMs": 10,
 						"retry.maxRetries": 1,
 					}),
+			...options.settingsOverrides,
 		});
 		settings.setModelRole("default", `${model.provider}/${model.id}`);
 		return new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
@@ -180,13 +190,14 @@ describe("AgentSession resilient retry", () => {
 
 	// Builds a session pinned to an explicit model (e.g. ollama-cloud) so
 	// provider-scoped retry behavior can be exercised. The mock streams as
-	// itself, so the active model's API — not the errored message's API — is
-	// what the classifier reads.
+	// itself, so the active model's API remains authoritative for provider-scoped
+	// policies that intentionally use active-model state (such as #713).
 	function buildModelSession(options: {
 		model: Model;
 		responses: Array<{ throw: string } | { content: string[] }>;
 		settingsOverrides?: Record<string, unknown>;
 		requestedModels?: string[];
+		bareDefault?: boolean;
 	}): AgentSession {
 		const { model } = options;
 		authStorage.setRuntimeApiKey(model.provider, `${model.provider}-test-key`);
@@ -202,9 +213,13 @@ describe("AgentSession resilient retry", () => {
 		});
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
-			"retry.baseDelayMs": 1,
-			"retry.maxDelayMs": 10,
-			"retry.maxRetries": 1,
+			...(options.bareDefault
+				? {}
+				: {
+						"retry.baseDelayMs": 1,
+						"retry.maxDelayMs": 10,
+						"retry.maxRetries": 1,
+					}),
 			...options.settingsOverrides,
 		});
 		settings.setModelRole("default", `${model.provider}/${model.id}`);
@@ -746,6 +761,163 @@ describe("AgentSession resilient retry", () => {
 		expect(lastAssistant(sess).stopReason).toBe("stop");
 	});
 
+	it("surfaces exact Alibaba Token Plan first-event timeouts without retrying", async () => {
+		const responsesModel = getBundledModel("alibaba-token-plan", "qwen3.8-max-preview");
+		const completionsModel = getBundledModel("alibaba-token-plan", "deepseek-v4-pro");
+		if (!responsesModel || !completionsModel) throw new Error("Expected bundled Alibaba Token Plan models");
+
+		const cases = [
+			{
+				model: responsesModel,
+				errorMessage: "OpenAI responses stream timed out while waiting for the first event",
+				settingsOverrides: { "retry.maxRetries": 10 },
+				bareDefault: false,
+			},
+			{
+				model: completionsModel,
+				errorMessage: "OpenAI completions stream timed out while waiting for the first event",
+				settingsOverrides: undefined,
+				bareDefault: true,
+			},
+		] as const;
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		for (const testCase of cases) {
+			const requestedModels: string[] = [];
+			session = buildStatusErrorSession({
+				model: testCase.model,
+				errorMessage: testCase.errorMessage,
+				recoveredContent: "unused retry",
+				requestedModels,
+				bareDefault: testCase.bareDefault,
+				settingsOverrides: testCase.settingsOverrides,
+			});
+			const { retryStartEvents, retryEndEvents } = track(session);
+
+			await session.prompt(`Alibaba ${testCase.model.api} first-event timeout`);
+			await session.waitForIdle();
+
+			expect(requestedModels).toEqual([`${testCase.model.provider}/${testCase.model.id}`]);
+			expect(retryStartEvents).toHaveLength(0);
+			expect(retryEndEvents).toHaveLength(0);
+			expect(waitSpy).not.toHaveBeenCalled();
+			const final = lastAssistant(session);
+			expect(final).toMatchObject({
+				stopReason: "error",
+				provider: testCase.model.provider,
+				api: testCase.model.api,
+				model: testCase.model.id,
+				errorMessage: testCase.errorMessage,
+			});
+			expect(session.isRetrying).toBe(false);
+			expect(session.isStreaming).toBe(false);
+
+			await session.dispose();
+			session = undefined;
+			waitSpy.mockClear();
+		}
+	});
+
+	it("uses failed AssistantMessage identity rather than the active model for Alibaba timeout policy", async () => {
+		const alibabaModel = getBundledModel("alibaba-token-plan", "qwen3.8-max-preview");
+		const anthropicModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!alibabaModel || !anthropicModel) throw new Error("Expected bundled test models");
+		const timeoutMessage = "OpenAI responses stream timed out while waiting for the first event";
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		const retryRequestedModels: string[] = [];
+		session = buildStatusErrorSession({
+			model: alibabaModel,
+			errorMessage: timeoutMessage,
+			messageProvider: "openai",
+			messageApi: "openai-responses",
+			recoveredContent: "recovered after provider mismatch",
+			requestedModels: retryRequestedModels,
+		});
+		const retryEvents = track(session);
+		await session.prompt("Alibaba active model with non-Alibaba failed message");
+		await session.waitForIdle();
+		expect(retryRequestedModels).toHaveLength(2);
+		expect(retryEvents.retryStartEvents).toHaveLength(1);
+		expect(lastAssistant(session).stopReason).toBe("stop");
+		await session.dispose();
+		session = undefined;
+		waitSpy.mockClear();
+
+		const terminalRequestedModels: string[] = [];
+		session = buildStatusErrorSession({
+			model: anthropicModel,
+			errorMessage: timeoutMessage,
+			messageProvider: "alibaba-token-plan",
+			messageApi: "openai-responses",
+			messageModel: alibabaModel.id,
+			recoveredContent: "should-not-reach",
+			requestedModels: terminalRequestedModels,
+		});
+		const terminalEvents = track(session);
+		await session.prompt("Non-Alibaba active model with Alibaba failed message");
+		await session.waitForIdle();
+		expect(terminalRequestedModels).toHaveLength(1);
+		expect(terminalEvents.retryStartEvents).toHaveLength(0);
+		expect(waitSpy).not.toHaveBeenCalled();
+		expect(lastAssistant(session)).toMatchObject({
+			stopReason: "error",
+			provider: "alibaba-token-plan",
+			api: "openai-responses",
+			model: alibabaModel.id,
+			errorMessage: timeoutMessage,
+		});
+	});
+
+	it("keeps Alibaba near misses, cross-API text, and unrelated transient failures retryable", async () => {
+		const responsesModel = getBundledModel("alibaba-token-plan", "qwen3.8-max-preview");
+		const completionsModel = getBundledModel("alibaba-token-plan", "deepseek-v4-pro");
+		if (!responsesModel || !completionsModel) throw new Error("Expected bundled Alibaba Token Plan models");
+		const cases = [
+			{
+				model: responsesModel,
+				errorMessage: "Error: OpenAI responses stream timed out while waiting for the first event",
+			},
+			{
+				model: responsesModel,
+				errorMessage: "OpenAI responses stream timed out while waiting for the first event.",
+			},
+			{
+				model: responsesModel,
+				errorMessage: "OpenAI completions stream timed out while waiting for the first event",
+			},
+			{
+				model: completionsModel,
+				errorMessage: "OpenAI responses stream timed out while waiting for the first event",
+			},
+			{ model: completionsModel, errorMessage: "Alibaba stream stalled while waiting for the next event" },
+			{ model: completionsModel, errorMessage: "503 service unavailable" },
+			{ model: completionsModel, errorMessage: "429 rate limit exceeded" },
+			{ model: completionsModel, errorMessage: "network error: connection reset" },
+		] as const;
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		for (const testCase of cases) {
+			const requestedModels: string[] = [];
+			session = buildModelSession({
+				model: testCase.model,
+				responses: [{ throw: testCase.errorMessage }, { content: ["recovered"] }],
+				requestedModels,
+			});
+			const { retryStartEvents, retryEndEvents } = track(session);
+			await session.prompt(`Alibaba non-terminal ${testCase.errorMessage}`);
+			await session.waitForIdle();
+			expect(requestedModels).toHaveLength(2);
+			expect(retryStartEvents).toHaveLength(1);
+			expect(retryEndEvents).toEqual([expect.objectContaining({ success: true })]);
+			expect(lastAssistant(session).stopReason).toBe("stop");
+			expect(waitSpy).toHaveBeenCalled();
+			await session.dispose();
+			session = undefined;
+			waitSpy.mockClear();
+		}
+	});
+
 	it("bounds ollama-cloud first-event timeout retries instead of looping unbounded (#713)", async () => {
 		// ollama-cloud (ollama-chat API) can stall before its first token even
 		// for tiny prompts. Unbounded continuation retries re-issue the full
@@ -778,6 +950,26 @@ describe("AgentSession resilient retry", () => {
 		expect(last.stopReason).toBe("error");
 		expect(last.errorMessage).toContain("first event");
 		expect(waitSpy).toHaveBeenCalled();
+	});
+	it("surfaces a Kimi Code first-event timeout after its continuous wait without replaying the request", async () => {
+		const model = getBundledModel("kimi-code", "kimi-k2.5");
+		if (!model) throw new Error("Expected bundled Kimi Code test model to exist");
+		const requestedModels: string[] = [];
+		session = buildStatusErrorSession({
+			model,
+			errorMessage: "Provider stream timed out while waiting for the first event",
+			requestedModels,
+		});
+		const { retryStartEvents, retryEndEvents } = track(session);
+
+		await session.prompt("slow Kimi request");
+		await session.waitForIdle();
+
+		expect(retryStartEvents).toHaveLength(0);
+		expect(retryEndEvents).toHaveLength(0);
+		expect(requestedModels).toHaveLength(1);
+		expect(lastAssistant(session).stopReason).toBe("error");
+		expect(lastAssistant(session).errorMessage).toContain("first event");
 	});
 
 	it("keeps first-party first-event timeout retries unbounded (#713 scope guard)", async () => {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -55,6 +55,7 @@ describe("AgentSession retry fallback", () => {
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
 		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
 		authStorage.setRuntimeApiKey("openai", "openai-test-key");
+		authStorage.setRuntimeApiKey("alibaba-token-plan", "alibaba-token-plan-test-key");
 		authStorage.setRuntimeApiKey("google", "google-test-key");
 		modelRegistry = new ModelRegistry(authStorage);
 	});
@@ -446,6 +447,64 @@ describe("AgentSession retry fallback", () => {
 		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 1 });
 	});
 
+	it("does not replay a Kimi Code first-event timeout through a managed fallback chain", async () => {
+		const primary = getBundledModel("kimi-code", "kimi-k2.5");
+		const fallback = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!primary || !fallback) throw new Error("Expected bundled Kimi and Anthropic test models");
+		authStorage.setRuntimeApiKey("kimi-code", "kimi-test-key");
+
+		const requestedModels: string[] = [];
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: requestedModel => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				const stream = new AssistantMessageEventStream();
+				const message: AssistantMessage = {
+					role: "assistant",
+					content: [],
+					api: requestedModel.api,
+					provider: requestedModel.provider,
+					model: requestedModel.id,
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "error",
+					errorMessage: "Provider stream timed out while waiting for the first event",
+					timestamp: Date.now(),
+				};
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "error", reason: "error", error: message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "fallback.maxAttempts": 2 });
+		settings.setModelRole("default", `${primary.provider}/${primary.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		session.setConfiguredModelChain(
+			"default",
+			[`${primary.provider}/${primary.id}`, `${fallback.provider}/${fallback.id}`],
+			"test",
+		);
+
+		await session.prompt("slow Kimi request");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([`${primary.provider}/${primary.id}`]);
+		expect(getLastAssistantMessage(session)).toMatchObject({
+			provider: "kimi-code",
+			stopReason: "error",
+			errorMessage: "Provider stream timed out while waiting for the first event",
+		});
+		expect(session.model).toMatchObject({ provider: primary.provider, id: primary.id });
+	});
 	it("keeps a managed fallback selection sticky across later user prompts", async () => {
 		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallback = getBundledModel("openai", "gpt-4o-mini");
@@ -542,6 +601,88 @@ describe("AgentSession retry fallback", () => {
 			`${fallback.provider}/${fallback.id}`,
 			`${fallback.provider}/${fallback.id}`,
 		]);
+	});
+
+	it("surfaces an exact Alibaba timeout before managed transport fallback precedence", async () => {
+		const primary = getBundledModel("alibaba-token-plan", "qwen3.8-max-preview");
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!primary || !fallback) throw new Error("Expected bundled test models");
+
+		const requestedModels: string[] = [];
+		let calls = 0;
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, _context, _options) => {
+				calls++;
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const failure: AssistantMessage = {
+						role: "assistant",
+						content: [],
+						api: requestedModel.api,
+						provider: requestedModel.provider,
+						model: requestedModel.id,
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "error",
+						errorMessage: "OpenAI responses stream timed out while waiting for the first event",
+						transportFailure: { kind: "transport", status: 503 },
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "start", partial: failure });
+					stream.push({ type: "error", reason: "error", error: failure });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 1,
+			"fallback.maxAttempts": 1,
+		});
+		settings.setModelRole("default", `${primary.provider}/${primary.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		session.setConfiguredModelChain(
+			"default",
+			[`${primary.provider}/${primary.id}`, `${fallback.provider}/${fallback.id}`],
+			"test",
+		);
+		const switches: Extract<AgentSessionEvent, { type: "model_fallback_switched" }>[] = [];
+		session.subscribe(event => {
+			if (event.type === "model_fallback_switched") switches.push(event);
+		});
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("Do not replay exact Alibaba timeout through managed fallback");
+		await session.waitForIdle();
+
+		expect(calls).toBe(1);
+		expect(requestedModels).toEqual([`${primary.provider}/${primary.id}`]);
+		expect(switches).toHaveLength(0);
+		expect(retryStartEvents).toHaveLength(0);
+		expect(retryEndEvents).toHaveLength(0);
+		expect(waitSpy).not.toHaveBeenCalled();
+		expect(session.isRetrying).toBe(false);
+		expect(session.isStreaming).toBe(false);
+		const final = getLastAssistantMessage(session);
+		expect(final).toMatchObject({
+			stopReason: "error",
+			provider: primary.provider,
+			api: primary.api,
+			model: primary.id,
+			errorMessage: "OpenAI responses stream timed out while waiting for the first event",
+			transportFailure: { kind: "transport", status: 503 },
+		});
+		expect(final.errorMessage).not.toContain("Model fallback chain exhausted");
 	});
 
 	it("treats legacy usage-limit text without transport facts as terminal for a managed chain", async () => {


### PR DESCRIPTION
## Problem

Kimi Code can legitimately spend longer than the global 100-second first-event watchdog window before emitting its first SSE event. The watchdog aborted that still-running request, and session retry/fallback policy then replayed the full prompt from zero. A slow Kimi request could therefore consume repeated 100-second windows without ever allowing one inference enough time to finish, while also multiplying upstream work.

The Kimi OpenAI/Anthropic shim also did not forward explicit stream timeout options to its concrete transport, so caller overrides could be cut short by the inner provider watchdog.

## Fix

- Give `kimi-code` one continuous 300-second first-event window (the requested initial 100 seconds plus two additional 100-second grace windows) without disconnecting or restarting inference.
- Apply the same provider fallback to the lazy forwarding watchdog and both Kimi-compatible concrete transports, while preserving caller and `PI_STREAM_FIRST_EVENT_TIMEOUT_MS` precedence.
- Forward `streamFirstEventTimeoutMs` and `streamIdleTimeoutMs` through the OpenAI/Anthropic compatibility shim.
- Surface a Kimi first-event timeout after the continuous window instead of replaying it through ordinary retry or a managed fallback chain.
- Prevent auto-compaction from retrying the same Kimi candidate after the same canonical timeout wrapper; unrelated candidate traversal and provider retry behavior remain unchanged.
- Keep the steady-state inter-event idle timeout unchanged.

## Verification

- `bun test packages/ai/test/` — 1875 pass, 337 env-gated skip, 0 fail
- `bun test packages/coding-agent/test/agent-session-resilient-retry.test.ts packages/coding-agent/test/agent-session-retry-fallback.test.ts packages/coding-agent/test/agent-session-auto-compaction-oversized.test.ts packages/coding-agent/test/agent-session-auto-compaction.test.ts packages/coding-agent/test/agent-session-retry-cap.test.ts` — 57 pass, 0 fail
- `bun --cwd=packages/ai run check` — pass
- `bun --cwd=packages/coding-agent run check:types` — pass
- Biome on all changed TypeScript/tests — pass
- `git diff --check upstream/dev...HEAD` — clean

New regression coverage pins the Kimi 300-second provider fallback, unrelated-provider isolation, no ordinary retry, no managed fallback replay, and no same-candidate auto-compaction replay.

The full coding-agent directory suite was also attempted. Its focused and neighboring tests passed, but the unrelated existing macOS managed-owner supervisor test reproducibly fails with `managed_owner_supervisor_start_time_unavailable`; the broad process was subsequently killed with exit 137.

## Out of scope

Kimi does not expose a client-observable signal that distinguishes a long pre-token computation from a stalled connection. Without a provider heartbeat, this change intentionally treats both as alive for up to 300 seconds. Once the first event arrives, the existing 120-second inter-event idle watchdog remains authoritative.

## Exact-head evidence

Base: `49617f16ae744e0d6f0a9eb343a31b79864f24af`
Head: `a5fed0acfc2de3dbed6a42e6bbd9fdbfdde9b465`

- `git merge-tree --write-tree upstream/dev HEAD` — conflict-free (`27840dfe899ab5e64a3f5fe5c80efc8084c1d10f`)
- Diff scope: `packages/ai`, `packages/coding-agent`, and the directly-bound Anthropic architecture eval artifact

## Related work

- #3044 fixes the same outer lazy-watchdog mismatch for `alibaba-token-plan` and adds exported-path fake-timer coverage. This PR applies the provider-aware outer fallback to `kimi-code`; the `register-builtins.ts` changes may need rebasing if #3044 lands first.
- #3038 terminalizes Alibaba timeout replay. This PR applies the corresponding no-replay contract to Kimi, including managed fallback and same-candidate compaction paths.
- No open or closed PR specifically addressing Kimi first-event timeout behavior was found.