### PR TITLE
fix(tui): recover stdin after dropped OSC 11 reply

### DIFF
--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -222,6 +222,10 @@ export class ProcessTerminal implements Terminal {
 	#privateCsiResponseBuffer = "";
 	#pendingDa1Sentinels = 0;
 	#osc11PollTimer?: Timer;
+	// Bounds the OSC 11 / DA1 pending-query window so a dropped or mangled reply
+	// (a terminal multiplexer, or a TERM=dumb host that does not round-trip
+	// private-mode replies) cannot latch #osc11Pending forever and freeze stdin.
+	#osc11QueryWatchdog?: Timer;
 	#mode2031DebounceTimer?: Timer;
 	#progressTimer?: ReturnType<typeof setInterval>;
 	#mouseEnabled = false;
@@ -495,12 +499,26 @@ export class ProcessTerminal implements Terminal {
 				} else {
 					this.#osc11ResponseBuffer += sequence;
 					const osc11Match = this.#osc11ResponseBuffer.match(osc11ResponsePattern);
-					if (!osc11Match) return;
-					const [, rHex, gHex, bHex] = osc11Match;
-					this.#osc11Pending = false;
-					this.#osc11ResponseBuffer = "";
-					this.#handleOsc11Response(rHex!, gHex!, bHex!);
-					return;
+					if (osc11Match) {
+						const [, rHex, gHex, bHex] = osc11Match;
+						this.#osc11Pending = false;
+						this.#osc11ResponseBuffer = "";
+						this.#clearOsc11QueryWatchdog();
+						this.#handleOsc11Response(rHex!, gHex!, bHex!);
+						return;
+					}
+					// Bound the OSC 11 reassembly buffer. A real reply is <=~25 bytes; if
+					// the terminator is dropped or mangled (a multiplexer, or a TERM=dumb
+					// host) an unbounded buffer swallows every following keystroke and
+					// freezes input. Past the cap, abandon reassembly and let the current
+					// sequence fall through as normal input.
+					if (this.#osc11ResponseBuffer.length > 64) {
+						this.#osc11Pending = false;
+						this.#osc11ResponseBuffer = "";
+						this.#clearOsc11QueryWatchdog();
+					} else {
+						return;
+					}
 				}
 			}
 
@@ -558,6 +576,37 @@ export class ProcessTerminal implements Terminal {
 		this.#pendingDa1Sentinels++;
 		this.#safeWrite("\x1b]11;?\x07"); // OSC 11 query (BEL terminated)
 		this.#safeWrite("\x1b[c"); // DA1 sentinel
+		this.#armOsc11QueryWatchdog();
+	}
+
+	// OSC 11 pending-query watchdog. If neither the OSC 11 reply nor its DA1
+	// sentinel comes back (dropped by a multiplexer or a TERM=dumb host that does
+	// not round-trip private-mode replies), #osc11Pending / #pendingDa1Sentinels
+	// would latch forever: #queryBackgroundColor stops re-querying and the OSC 11
+	// reassembly branch swallows keystrokes. Force-resolve the cycle after a
+	// bounded wait so the state machine self-heals.
+	#armOsc11QueryWatchdog(): void {
+		this.#clearOsc11QueryWatchdog();
+		this.#osc11QueryWatchdog = setTimeout(() => {
+			this.#osc11QueryWatchdog = undefined;
+			if (this.#dead) return;
+			if (!this.#osc11Pending && this.#pendingDa1Sentinels === 0) return;
+			this.#osc11Pending = false;
+			this.#osc11ResponseBuffer = "";
+			this.#pendingDa1Sentinels = 0;
+			if (this.#osc11QueryQueued && !this.#dead) {
+				this.#osc11QueryQueued = false;
+				this.#startOsc11Query();
+			}
+		}, 1000);
+		this.#osc11QueryWatchdog.unref?.();
+	}
+
+	#clearOsc11QueryWatchdog(): void {
+		if (this.#osc11QueryWatchdog) {
+			clearTimeout(this.#osc11QueryWatchdog);
+			this.#osc11QueryWatchdog = undefined;
+		}
 	}
 	/**
 	 * Parse an OSC 11 background color response and compute BT.601 luminance.

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -236,6 +236,41 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		terminal.stop();
 	});
 
+	it("recovers keyboard input after a dropped OSC 11 reply latches the pending query (watchdog)", () => {
+		vi.useFakeTimers();
+		const { terminal, received } = setupTerminal();
+
+		// Prime the OSC 11 reassembly buffer with a partial reply whose terminator
+		// never arrives (dropped/mangled by a multiplexer or TERM=dumb host).
+		process.stdin.emit("data", "\x1b]11;rgb:00");
+		vi.advanceTimersByTime(50); // flush StdinBuffer so the partial is delivered
+
+		// The pending-query watchdog must clear the latch after its bounded wait so
+		// stdin stops being treated as OSC 11 continuation.
+		vi.advanceTimersByTime(1000);
+
+		process.stdin.emit("data", "a");
+		expect(received).toContain("a");
+
+		terminal.stop();
+	});
+
+	it("bounds the OSC 11 reassembly buffer so a keystroke flood is not swallowed (cap)", () => {
+		vi.useFakeTimers();
+		const { terminal, received } = setupTerminal();
+
+		// Prime the reassembly buffer with a never-terminated partial reply.
+		process.stdin.emit("data", "\x1b]11;rgb:00");
+		vi.advanceTimersByTime(50);
+
+		// Without a bound this swallows every following keystroke forever. Past the
+		// cap the buffer resets and subsequent keys reach the input handler.
+		for (let i = 0; i < 80; i++) process.stdin.emit("data", "x");
+		expect(received).toContain("x");
+
+		terminal.stop();
+	});
+
 	it("DA1 from old query does not cancel new queued query", () => {
 		vi.useFakeTimers();
 		const { terminal, queryCount, sentinelCount } = setupTerminal();


### PR DESCRIPTION
## Problem

Typing into the composer works in a fresh session, then after the session has
been running a while the input box starts filling with raw terminal escape
sequences, and eventually **no keystroke registers at all** until the process is
restarted.

The leaked bytes are terminal capability-probe replies and, when the Kitty
keyboard protocol is active, key-release events. The terminal-death endgame is
the important part and is a real state-machine latch, not just cosmetic leakage.

## Root cause

`ProcessTerminal` polls the terminal every 2s with an OSC 11 background-color
query plus a DA1 sentinel (`#startOsc11Query`). The design assumes an in-order
terminal always answers at least the DA1 sentinel, so `#osc11Pending` /
`#pendingDa1Sentinels` always clear.

Under a terminal multiplexer or a `TERM=dumb` host that does not reliably
round-trip private-mode replies (observed with **cmux** embedding libghostty,
and **tmux**), both the OSC 11 reply and its DA1 sentinel can be dropped, split,
or mangled. When that happens:

1. `#osc11Pending` latches `true` forever, so `#queryBackgroundColor` refuses to
   re-query (appearance polling silently dies), and
2. the OSC 11 reassembly branch keeps `#osc11ResponseBuffer` primed and, because
   that buffer has **no length cap** (unlike the private-CSI reassembly path
   which is bounded at 256), it appends and swallows every subsequent
   keystroke instead of forwarding it to the input handler.

A fresh session is fine because the pending state starts clean. It rots only
once a poll cycle loses a reply, which becomes likely the longer the session
runs, matching the "works at first, dies later" report.

## Fix

Two bounded, self-healing guards in `packages/tui/src/terminal.ts` (no fallback
behavior, no config knob):

- **`#armOsc11QueryWatchdog()`** - a 1s watchdog armed by `#startOsc11Query`.
  If the cycle is still pending when it fires, it force-resolves the pending
  state (`#osc11Pending`, `#osc11ResponseBuffer`, `#pendingDa1Sentinels`) and
  starts any queued query, so the next poll re-probes from a clean baseline
  instead of latching. Cleared on a successful OSC 11 parse; guarded so a stale
  fire is a no-op; `unref`'d so it never holds the loop open.
- **A 64-byte cap on `#osc11ResponseBuffer`** - a real OSC 11 reply is at most
  ~25 bytes. Past the cap, reassembly is abandoned and the current sequence
  falls through as normal input rather than being swallowed.

Both target the *latch*, complementing (not overlapping) the existing "new
escape sequence aborts reassembly" recovery, which only triggers for escape
sequences and never for plain keystrokes.

## Tests

Two regression tests in `terminal-appearance.test.ts`:

- **watchdog**: prime the reassembly buffer with a partial OSC 11 reply whose
  terminator never arrives, advance past the watchdog, and assert a plain
  keystroke reaches the input handler again.
- **cap**: prime the buffer, flood plain keystrokes, and assert input is
  forwarded once the buffer exceeds the cap.

Full `packages/tui` suite on this branch (`bun test test/*.test.ts`):

```
842 pass
0 fail
Ran 842 tests across 71 files.
```

## Risk

Scoped to the OSC 11 / DA1 appearance-probe state machine. On a well-behaved
terminal the watchdog is disarmed by the normal reply before it can fire and the
cap is never approached, so behavior is unchanged; the guards only engage when a
reply is actually lost.
