### PR TITLE
fix(cli): suppress interactive bootstrap for print/help/version equals forms

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
 - SDK daemon CLI end-to-end tests now drain spawned child stdout and stderr concurrently with process exit, preventing CI pipe teardown races from replacing the product exit contract with SIGPIPE status 141 (#3024).
+- Interactive launch bootstrap is now suppressed for parser-accepted `--print=`, `--help=`, and `--version=` equals forms, keeping non-interactive output free of the warming-workspace preamble on TTYs.
 
 ## [0.11.8] - 2026-07-23
 ### Added

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -128,6 +128,7 @@ export function interactiveBootstrapText(
 		const arg = argv[index];
 		if (
 			arg === "--print" ||
+			arg?.startsWith("--print=") ||
 			arg === "-p" ||
 			arg === "--export" ||
 			arg?.startsWith("--export=") ||
@@ -136,8 +137,10 @@ export function interactiveBootstrapText(
 			arg === "--mode" ||
 			arg?.startsWith("--mode=") ||
 			arg === "--help" ||
+			arg?.startsWith("--help=") ||
 			arg === "-h" ||
 			arg === "--version" ||
+			arg?.startsWith("--version=") ||
 			arg === "-v"
 		)
 			return undefined;

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -60,6 +60,11 @@ describe("GJC public CLI command surface", () => {
 			expect(interactiveBootstrapText(["launch", flag], true, true)).toBeUndefined();
 		}
 	});
+	it("suppresses the interactive bootstrap for parser-accepted equals forms of print, help, and version", () => {
+		for (const flag of ["--print=true", "--help=true", "--version=true", "--print=false"]) {
+			expect(interactiveBootstrapText(["launch", flag], true, true)).toBeUndefined();
+		}
+	});
 
 	it("does not prefix spawned noninteractive launch help output with the bootstrap", () => {
 		const result = Bun.spawnSync(["bun", cliEntry, "launch", "--help"], {


### PR DESCRIPTION
## Summary
Post-merge repair for #2915: `interactiveBootstrapText` suppressed `--print`/`--help`/`--version` only as bare tokens, but the generic parser accepts `--flag=value` forms. On a TTY, `gjc launch --print=true` (and `--help=true`, `--version=true`) received the ANSI "GJC warming workspace" bootstrap before non-interactive output, corrupting it.

## Changes
- Recognize `--print=`, `--help=`, `--version=` prefixes in the bootstrap classifier (`cli.ts`).
- Add TTY-classifier regression tests for equals forms.
- CHANGELOG entry under Unreleased.

## Evidence
Found by post-merge architect review of the #2915 change set (product-lane MEDIUM). Focused run: `bun test test/cli-command-surface.test.ts --test-name-pattern bootstrap` → 5 pass / 0 fail.