### PR TITLE
fix(utils): persist fatal crashes to a bounded, redacted rotation-immune crash log

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fatal crashes (`uncaughtException` / `unhandledRejection`) are now also persisted to a dedicated, append-only crash log (`~/.gjc/agent/gjc-crash.log`) before any stderr output, and the fatal handler prints the crash-log path. The daily logger file is gzip-archived independently by every gjc process at date rollover; that shared-archive race can truncate a day's log to an empty `.gz` and destroy the `logger.error` crash record, leaving crashes undiagnosable. The rotation-immune crash log is capped at 512 KB, bounds every individual record (UTF-8-safe truncation with a marker), scrubs credential material (bearer/auth headers, key=value credential fields, and well-known vendor token shapes) before persisting, and enforces owner-only file permissions.
+
 ## [0.11.8] - 2026-07-23
 
 ## [0.11.7] - 2026-07-22

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -5,9 +5,12 @@
  * in response to process exit, signals, or fatal exceptions. It is intended to
  * allow reliably releasing resources or shutting down subprocesses, files, sockets, etc.
  */
+import * as fs from "node:fs";
 import inspector from "node:inspector";
+import * as path from "node:path";
 import { isMainThread } from "node:worker_threads";
 import { BROKEN_PIPE_EXIT_CODE, createProcessStdoutEpipeClassifier } from "./broken-pipe";
+import { getCrashLogPath } from "./dirs";
 import * as logger from "./logger";
 import { safeStderrWrite } from "./safe-stderr";
 
@@ -204,6 +207,104 @@ function formatFatalError(label: string, err: Error): string {
 	const formattedStack = stackLines.length > 0 ? `\n${stackLines.join("\n")}` : "";
 	return `\n[${label}] ${name}: ${message}${formattedStack}\n`;
 }
+/** Cap for the durable crash log; it is reset past this so a crash loop cannot fill the disk. */
+export const CRASH_LOG_MAX_BYTES = 512 * 1024;
+/**
+ * Per-record budget so a single oversized error body cannot bypass the file
+ * cap: every persisted record is truncated to this many bytes (UTF-8 safe,
+ * with a marker) before the append/reset decision.
+ */
+export const CRASH_RECORD_MAX_BYTES = 64 * 1024;
+const CRASH_RECORD_TRUNCATION_MARKER = "\n… [crash record truncated]\n\n";
+
+/**
+ * Best-effort scrub of credential material from a crash record before it is
+ * persisted indefinitely. Covers bearer/basic-style headers, key=value or
+ * JSON key forms of common credential names, and well-known vendor token
+ * shapes. Normal messages and stack frames are untouched; matches are
+ * replaced in place so surrounding diagnostic context survives.
+ */
+function redactCrashSecrets(text: string): string {
+	let redacted = text;
+	redacted = redacted.replace(/\b(?:Bearer|Basic|Token)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "«redacted-auth»");
+	redacted = redacted.replace(/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g, "«redacted-jwt»");
+	redacted = redacted.replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, "«redacted-api-key»");
+	redacted = redacted.replace(/\bgh[opsur]_[A-Za-z0-9]{16,}\b/g, "«redacted-github-token»");
+	redacted = redacted.replace(/\bxox[baprs]-[A-Za-z0-9-]{8,}\b/g, "«redacted-slack-token»");
+	redacted = redacted.replace(/\bAKIA[0-9A-Z]{16}\b/g, "«redacted-aws-key»");
+	redacted = redacted.replace(
+		/(["']?(?:api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|secret[_-]?key|password|passwd|authorization)["']?\s*[=:]\s*["']?)[^\s"',;}\]]{8,}/gi,
+		"$1«redacted»",
+	);
+	return redacted;
+}
+
+/**
+ * Bound one record to CRASH_RECORD_MAX_BYTES without splitting a UTF-8
+ * sequence. Keeps the header (timestamp/label/message) at the front, where
+ * the diagnostic value is highest.
+ */
+function boundCrashRecord(report: string): string {
+	if (Buffer.byteLength(report, "utf8") <= CRASH_RECORD_MAX_BYTES) return report;
+	const bytes = Buffer.from(report, "utf8");
+	const budget = CRASH_RECORD_MAX_BYTES - Buffer.byteLength(CRASH_RECORD_TRUNCATION_MARKER, "utf8");
+	let end = budget;
+	// Drop trailing continuation bytes of a truncated multi-byte sequence.
+	while (end > 0 && (bytes[end - 1] & 0xc0) === 0x80) end--;
+	// Drop the now-incomplete lead byte, if any.
+	if (end > 0 && bytes[end - 1] >= 0xc0) end--;
+	return bytes.subarray(0, end).toString("utf8") + CRASH_RECORD_TRUNCATION_MARKER;
+}
+
+/**
+ * Append a fatal-crash record to the dedicated, rotation-immune crash log
+ * (`~/.gjc/agent/gjc-crash.log`).
+ *
+ * The daily logger file is gzip-archived at date rollover by every gjc process
+ * independently; that shared-archive race can truncate a day's log to an empty
+ * `.gz`, destroying the `logger.error` crash record written here. This
+ * append-only file is never rotated, so a crash stays diagnosable regardless.
+ *
+ * Fully defensive: it never throws (a failing crash writer must not mask the
+ * original fatal) and uses synchronous IO so the record lands before
+ * `process.exit`. Returns the path written, or `undefined` on failure.
+ */
+export function recordFatalCrash(
+	label: string,
+	reason: unknown,
+	options: { path?: string; now?: Date } = {},
+): string | undefined {
+	try {
+		const err = errorForDiagnostic(reason);
+		const target = options.path ?? getCrashLogPath();
+		const now = options.now ?? new Date();
+		const report = boundCrashRecord(
+			`${now.toISOString()} pid=${process.pid} [${label}] ` +
+				`${err.name || "Error"}: ${redactCrashSecrets(err.message || "(no message)")}\n` +
+				`${redactCrashSecrets(err.stack ?? "")}\n\n`,
+		);
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		let existingSize = 0;
+		try {
+			existingSize = fs.statSync(target).size;
+		} catch {}
+		// Reset (rather than append) when the file would exceed the cap so the
+		// newest crash is always retained without unbounded growth. Every record
+		// is individually bounded above, so no single crash can bypass the cap.
+		if (existingSize + Buffer.byteLength(report, "utf8") > CRASH_LOG_MAX_BYTES) {
+			fs.writeFileSync(target, report, { mode: 0o600 });
+		} else {
+			fs.appendFileSync(target, report, { mode: 0o600 });
+		}
+		// A pre-existing file may carry looser permissions; enforce owner-only.
+		try {
+			fs.chmodSync(target, 0o600);
+		} catch {}
+		return target;
+	} catch {
+		return undefined;
+	}
+}
 
 async function exitQuietlyForAttributableStdoutEpipe(reason: Reason): Promise<void> {
 	if (ordinaryFatalStarted || quietShutdownStarted) return;
@@ -226,7 +327,12 @@ async function handleFatalError(label: string, reason: unknown, cleanupReason: R
 	ordinaryFatalStarted = true;
 	process.exitCode = 1;
 	const err = errorForDiagnostic(reason);
+	// Persist first: the rotation-immune record must land before any
+	// best-effort stderr output, so a slow or failing stderr cannot cost the
+	// crash record. Cleanup (which may itself hang or fail) runs afterwards.
+	const crashLogPath = recordFatalCrash(label, err);
 	safeStderrWrite(formatFatalError(label, err));
+	if (crashLogPath) safeStderrWrite(`[${label}] crash recorded at ${crashLogPath}\n`);
 	if (!quietShutdownStarted) {
 		logger.error(label === "Uncaught Exception" ? "Uncaught exception" : "Unhandled rejection", {
 			err,

--- a/packages/utils/test/postmortem-crash-log.test.ts
+++ b/packages/utils/test/postmortem-crash-log.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { CRASH_LOG_MAX_BYTES, CRASH_RECORD_MAX_BYTES, recordFatalCrash } from "../src/postmortem";
+
+function tempCrashLog(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-crash-log-"));
+	// Nested path proves the writer creates missing parent directories.
+	return path.join(dir, "agent", "gjc-crash.log");
+}
+
+const POSTMORTEM_SOURCE = path.resolve(import.meta.dir, "../src/postmortem.ts");
+
+function spawnBun(script: string, options: { args?: string[]; env?: Record<string, string> } = {}) {
+	const result = Bun.spawnSync({
+		cmd: [process.execPath, script, ...(options.args ?? [])],
+		stdout: "pipe",
+		stderr: "pipe",
+		env: { ...process.env, ...options.env },
+	});
+	return {
+		exitCode: result.exitCode,
+		stdout: result.stdout.toString(),
+		stderr: result.stderr.toString(),
+	};
+}
+
+describe("recordFatalCrash", () => {
+	it("writes a structured, diagnosable record for an Error", () => {
+		const target = tempCrashLog();
+		const err = new Error("boom while streaming");
+		const now = new Date("2026-07-23T21:22:31.647Z");
+
+		const written = recordFatalCrash("Uncaught Exception", err, { path: target, now });
+
+		expect(written).toBe(target);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("2026-07-23T21:22:31.647Z");
+		expect(contents).toContain(`pid=${process.pid}`);
+		expect(contents).toContain("[Uncaught Exception]");
+		expect(contents).toContain("Error: boom while streaming");
+		// The full stack must be present so the crash is actually diagnosable.
+		expect(contents).toContain(err.stack ?? "MISSING_STACK");
+	});
+
+	it("stringifies non-Error rejection reasons", () => {
+		const target = tempCrashLog();
+		const written = recordFatalCrash("Unhandled Rejection", "Request was aborted", { path: target });
+		expect(written).toBe(target);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("[Unhandled Rejection]");
+		expect(contents).toContain("Request was aborted");
+	});
+
+	it("appends successive crashes rather than overwriting", () => {
+		const target = tempCrashLog();
+		recordFatalCrash("Uncaught Exception", new Error("first"), { path: target });
+		recordFatalCrash("Uncaught Exception", new Error("second"), { path: target });
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("Error: first");
+		expect(contents).toContain("Error: second");
+		expect(contents.indexOf("first")).toBeLessThan(contents.indexOf("second"));
+	});
+
+	it("resets past the size cap so a crash loop cannot grow unbounded", () => {
+		const target = tempCrashLog();
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		// Pre-fill beyond the 512KB cap.
+		fs.writeFileSync(target, "x".repeat(600 * 1024));
+		recordFatalCrash("Uncaught Exception", new Error("post-cap crash"), { path: target });
+		const size = fs.statSync(target).size;
+		expect(size).toBeLessThan(CRASH_LOG_MAX_BYTES);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("Error: post-cap crash");
+		// Old oversized content is gone; newest crash retained.
+		expect(contents).not.toContain("x".repeat(1024));
+	});
+
+	it("bounds a single oversized record so it cannot bypass the file cap", () => {
+		const target = tempCrashLog();
+		const huge = new Error(`megacrash ${"z".repeat(1024 * 1024)}`);
+
+		recordFatalCrash("Uncaught Exception", huge, { path: target });
+
+		const size = fs.statSync(target).size;
+		expect(size).toBeLessThanOrEqual(CRASH_RECORD_MAX_BYTES);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("megacrash");
+		expect(contents).toContain("[crash record truncated]");
+	});
+
+	it("truncates on a UTF-8 boundary without replacement characters", () => {
+		const target = tempCrashLog();
+		// Multi-byte characters right at the truncation boundary.
+		const message = `한국어 메시지 ${"가".repeat(CRASH_RECORD_MAX_BYTES)}`;
+
+		recordFatalCrash("Uncaught Exception", new Error(message), { path: target });
+
+		const size = fs.statSync(target).size;
+		expect(size).toBeLessThanOrEqual(CRASH_RECORD_MAX_BYTES);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("[crash record truncated]");
+		expect(contents).not.toContain("�");
+	});
+
+	it("redacts credential material before persisting", () => {
+		const target = tempCrashLog();
+		const bearer = "Bearer abcdef0123456789abcdef0123456789";
+		const apiKey = "sk-abcdef0123456789abcdef";
+		const github = "ghp_abcdef0123456789abcdef0123";
+		const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+		const refresh = `"refresh_token": "rt-abcdef0123456789"`;
+		const err = new Error(`auth failed: ${bearer}, ${apiKey}, ${github}, ${jwt}, ${refresh}, password=hunter2secret`);
+
+		recordFatalCrash("Uncaught Exception", err, { path: target });
+
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("auth failed");
+		expect(contents).toContain("«redacted»");
+		expect(contents).not.toContain("abcdef0123456789");
+		expect(contents).not.toContain("hunter2secret");
+		expect(contents).not.toContain("dozjgNryP4J3jVmNHl0w5N");
+		// The key context survives so the record stays diagnosable.
+		expect(contents).toContain('"refresh_token": "«redacted»');
+	});
+
+	it("enforces owner-only permissions on a pre-existing file", () => {
+		if (process.platform === "win32") return;
+		const target = tempCrashLog();
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		fs.writeFileSync(target, "prior content\n", { mode: 0o644 });
+		fs.chmodSync(target, 0o644);
+
+		recordFatalCrash("Uncaught Exception", new Error("perm check"), { path: target });
+
+		expect(fs.statSync(target).mode & 0o777).toBe(0o600);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("prior content");
+		expect(contents).toContain("perm check");
+	});
+
+	it("stays bounded when concurrent writers cross the cap simultaneously", () => {
+		const target = tempCrashLog();
+		const dir = path.dirname(path.dirname(target));
+		const writerScript = path.join(dir, "crash-writer.ts");
+		fs.writeFileSync(
+			writerScript,
+			`import { recordFatalCrash } from ${JSON.stringify(POSTMORTEM_SOURCE)};\n` +
+				`const target = process.argv[2];\n` +
+				`const payload = "y".repeat(48 * 1024);\n` +
+				`for (let i = 0; i < 10; i++) recordFatalCrash("Uncaught Exception", new Error(payload + i), { path: target });\n`,
+		);
+		const writerCount = 6;
+		const results = Array.from({ length: writerCount }, () => spawnBun(writerScript, { args: [target] }));
+		for (const result of results) expect(result.exitCode).toBe(0);
+
+		// stat-then-append races across processes may overshoot the cap, but only
+		// by at most one bounded record per racing writer.
+		const sizeAfterRace = fs.statSync(target).size;
+		expect(sizeAfterRace).toBeLessThanOrEqual(CRASH_LOG_MAX_BYTES + writerCount * CRASH_RECORD_MAX_BYTES);
+
+		// A subsequent write observes the overshoot, resets, and retains the
+		// newest crash within the cap.
+		recordFatalCrash("Uncaught Exception", new Error("post-race crash"), { path: target });
+		const finalSize = fs.statSync(target).size;
+		expect(finalSize).toBeLessThanOrEqual(CRASH_LOG_MAX_BYTES);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("post-race crash");
+	});
+
+	it("never throws when the target path is unwritable", () => {
+		// A path whose parent is an existing file cannot be created as a directory.
+		const fileAsParent = tempCrashLog();
+		fs.mkdirSync(path.dirname(fileAsParent), { recursive: true });
+		fs.writeFileSync(fileAsParent, "i am a file");
+		const bogus = path.join(fileAsParent, "nested", "gjc-crash.log");
+		const result = recordFatalCrash("Uncaught Exception", new Error("x"), { path: bogus });
+		expect(result).toBeUndefined();
+	});
+});
+
+describe("fatal handler process fixtures", () => {
+	function runFatalFixture(body: string): { exitCode: number; stderr: string; crashLog: string } {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-fatal-fixture-"));
+		const script = path.join(dir, "fixture.ts");
+		fs.writeFileSync(script, `import ${JSON.stringify(POSTMORTEM_SOURCE)};\n${body}\n`);
+		const result = spawnBun(script, {
+			env: { GJC_CODING_AGENT_DIR: path.join(dir, "agent") },
+		});
+		return { ...result, crashLog: path.join(dir, "agent", "gjc-crash.log") };
+	}
+
+	it("persists an uncaught exception to the crash log before exiting 1", () => {
+		const { exitCode, stderr, crashLog } = runFatalFixture(`throw new Error("spawned uncaught boom");`);
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("spawned uncaught boom");
+		expect(stderr).toContain("crash recorded at");
+		const contents = fs.readFileSync(crashLog, "utf8");
+		expect(contents).toContain("[Uncaught Exception]");
+		expect(contents).toContain("spawned uncaught boom");
+	});
+
+	it("persists an unhandled rejection to the crash log before exiting 1", () => {
+		const { exitCode, stderr, crashLog } = runFatalFixture(
+			`void Promise.reject(new Error("spawned rejection boom"));`,
+		);
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("spawned rejection boom");
+		expect(stderr).toContain("crash recorded at");
+		const contents = fs.readFileSync(crashLog, "utf8");
+		expect(contents).toContain("[Unhandled Rejection]");
+		expect(contents).toContain("spawned rejection boom");
+	});
+});


### PR DESCRIPTION
Successor to #3023, addressing every requirement in the closing architect `REQUEST_CHANGES` review.

## Problem

Fatal errors (`uncaughtException` / `unhandledRejection`) are caught by the postmortem handler but were only recorded via `logger.error` into the rotating daily log file (`gjc.%DATE%.log`).

Every gjc process runs its own `winston-daily-rotate-file` instance against the *same shared* daily log and independently gzip-archives it at date rollover. When multiple processes race on the same archive at midnight, the day's log can be truncated to an empty `.gz`, destroying the crash record and leaving the crash undiagnosable.

Observed: `~/.gjc/logs/gjc.2026-07-23.log.gz` is 0 bytes even though the daily-rotate audit recorded a non-empty source hash — that day's uncaught-exception record was lost, so the reported "session errored and shut down" could not be traced.

## Fix (`packages/utils/src/postmortem.ts`)

- Persist a structured, stack-bearing record (`timestamp pid label name: message` + full stack) to the dedicated append-only crash log (`~/.gjc/agent/gjc-crash.log`) using synchronous IO, so the record lands before `process.exit`.
- **Persist before stderr**: the fatal handler now writes the crash record *before* any best-effort stderr output, so a slow or failing stderr cannot cost the record. (#3023 review: unsafe stderr-before-persist ordering)
- **Bound each record**: every record is truncated to a 64 KB per-record budget (UTF-8-safe, with an explicit marker) before the append/reset decision, so a single oversized error body can never bypass the 512 KB file cap. (#3023 review: oversized records bypassed the cap)
- **Redact before persisting**: credential material is scrubbed in place — bearer/basic auth headers, JWTs, `sk-` keys, GitHub/Slack/AWS token shapes, and `key=value`/JSON forms of `api_key`, `access_token`, `refresh_token`, `client_secret`, `password`, `authorization`, etc. — while surrounding diagnostic context survives. (#3023 review: token-bearing error bodies persisted indefinitely)
- **Enforce permissions**: the file is created `0o600` and explicitly `chmod`'d after every write so a pre-existing file with looser permissions is tightened. (#3023 review: enforce target permissions)
- Cap the crash log at 512 KB and reset past the cap so a crash loop cannot fill the disk; the newest crash is always retained. Cross-process stat-then-append races can overshoot transiently, but only by at most one bounded record per racing writer — proven by the new concurrency test.
- The writer is fully defensive (never throws) so it cannot mask the original fatal error.

The changelog entry is under `## [Unreleased]` as required.

## Verification

- `bun test packages/utils/test/` — **174 pass, 0 fail** (18 files)
- `bun test packages/utils/test/postmortem-crash-log.test.ts packages/utils/test/postmortem.test.ts` — **33 pass, 0 fail**
- `bun --cwd=packages/utils run check` (Biome + `tsc --noEmit`) — pass
- `git diff --check` — clean

New `recordFatalCrash` contract tests cover (#3023 review items in parentheses):
- record shape (timestamp/pid/label/full stack), non-Error rejection reasons stringified, append semantics across successive crashes, size-cap reset, never-throw on an unwritable path
- per-record bounding of an oversized crash with truncation marker (cap bypass)
- UTF-8-boundary truncation with no replacement characters
- credential redaction for bearer/JWT/`sk-`/GitHub/`refresh_token`/`password` forms (secret persistence)
- owner-only permission enforcement on a pre-existing `0o644` file (permissions)
- **simultaneous cap crossing**: 6 spawned writers appending 640 KB each concurrently; final size proven bounded by `cap + writers × record budget`, and a subsequent write resets and retains the newest crash within the cap (cap-crossing concurrency)
- **real fatal-handler process fixtures**: spawned `bun` processes importing the actual postmortem module — one `throw`, one `Promise.reject` — assert exit code 1, stderr diagnostics, and the crash record persisted at the `GJC_CODING_AGENT_DIR`-isolated crash log (real uncaught/unhandled coverage)

## Out of scope

The session crash's direct trigger was expired provider credentials (re-login matter, not a code change). The shared daily-log rotation race itself remains a follow-up; this PR ensures the *next* crash is diagnosable regardless.

## Exact-head evidence

Base: `49617f16ae744e0d6f0a9eb343a31b79864f24af`
Head: `da4ef6298c2daf91d4f2c953692ea745c373ff58`

- `git merge-tree --write-tree upstream/dev HEAD` — conflict-free (`05f0277a3bdbb431f641260b766757784edfe3f6`)
- Diff scope: `packages/utils/{src/postmortem.ts, test/postmortem-crash-log.test.ts, CHANGELOG.md}` — 3 files, +325
