### PR TITLE
fix(session): harden Windows session migration durability (#3015, #2913)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Interactive launch bootstrap is now suppressed for parser-accepted `--print=`, `--help=`, and `--version=` equals forms, keeping non-interactive output free of the warming-workspace preamble on TTYs.
 
 - Rejected subagent schema payloads now retain their complete structured data in canonical output artifacts; inline results remain bounded while `agent://` output stays lossless (#2894).
+- Managed legacy-session artifact migration now validates Windows directory roots from the native tree snapshot, tolerates only lazy metadata on plain Windows directories, and replays both clean and cleanup-pending detaches while retaining fail-closed receipt validation. Canonical binding durability sync uses a writable no-follow handle on Windows NTFS stacks that reject `FlushFileBuffers` on read-only handles (#3015, #2913).
 ## [0.11.8] - 2026-07-23
 ### Added
 

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -2335,46 +2335,30 @@ export function matchesMigrationArtifactRoot(
 			(platform !== "win32" && (stat.size !== identity.size || stat.mtimeNs !== identity.mtimeNs))
 		)
 			return false;
-		const directoryEntryKey = (entry: NativeDirectoryTreeSnapshot["entries"][number]): string =>
-			JSON.stringify(
-				platform === "win32"
-					? [entry.relativePath, entry.kind, entry.dev, entry.ino]
-					: [entry.relativePath, entry.kind, entry.dev, entry.ino, entry.size, entry.mtimeNs],
-			);
-		const strictEntryKey = (entry: NativeDirectoryTreeSnapshot["entries"][number]): string =>
-			JSON.stringify([
-				entry.relativePath,
-				entry.kind,
-				entry.dev,
-				entry.ino,
-				entry.size,
-				entry.mtimeNs,
-				entry.ctimeNs,
-				entry.sha256,
-			]);
-		const entryKey = (entry: NativeDirectoryTreeSnapshot["entries"][number]): string =>
-			entry.kind === "directory" ? directoryEntryKey(entry) : strictEntryKey(entry);
-		const expectedEntries = expectedTree.entries.map(entryKey).sort();
-		const observedEntries = observed.snapshot.entries.map(entryKey).sort();
-		return (
-			expectedEntries.length === observedEntries.length &&
-			expectedEntries.every((entry, index) => entry === observedEntries[index])
-		);
+		return sameArtifactTree(expectedTree, observed.snapshot, { platform, phase: "migration" });
 	} catch {
 		return false;
 	}
 }
 
-function matchesDetachedArtifactRoot(pathname: string, plan: DetachedArtifactRoot): boolean {
-	return (
-		matchesMigrationArtifactRoot(pathname, plan.identity, plan.tree) &&
-		sameDirectoryObject(path.dirname(pathname), path.dirname(plan.detachedPath))
-	);
-}
+type ArtifactTreeComparisonPolicy = {
+	platform?: NodeJS.Platform;
+	phase?: "migration" | "strict";
+};
 
-function sameArtifactTree(left: NativeDirectoryTreeSnapshot, right: NativeDirectoryTreeSnapshot): boolean {
-	const entryKey = (entry: NativeDirectoryTreeSnapshot["entries"][number]): string =>
-		JSON.stringify([
+function sameArtifactTree(
+	left: NativeDirectoryTreeSnapshot,
+	right: NativeDirectoryTreeSnapshot,
+	policy: ArtifactTreeComparisonPolicy = {},
+): boolean {
+	const { platform = process.platform, phase = "strict" } = policy;
+	const entryKey = (entry: NativeDirectoryTreeSnapshot["entries"][number]): string => {
+		// pi-iso accepts Windows plain directories by stable file id and kind only: NTFS can lazily
+		// update directory size, mtime, and ctime while enumeration trails an open handle. All other
+		// platforms and phases compare every captured field, including nested-directory ctime.
+		if (phase === "migration" && platform === "win32" && entry.kind === "directory")
+			return JSON.stringify([entry.relativePath, entry.kind, entry.dev, entry.ino]);
+		return JSON.stringify([
 			entry.relativePath,
 			entry.kind,
 			entry.dev,
@@ -2384,14 +2368,21 @@ function sameArtifactTree(left: NativeDirectoryTreeSnapshot, right: NativeDirect
 			entry.ctimeNs,
 			entry.sha256,
 		]);
+	};
+	const leftEntries = left.entries.map(entryKey).sort();
+	const rightEntries = right.entries.map(entryKey).sort();
 	return (
 		left.rootDev === right.rootDev &&
 		left.rootIno === right.rootIno &&
-		left.entries.length === right.entries.length &&
-		left.entries
-			.map(entryKey)
-			.sort()
-			.every((entry, index) => entry === right.entries.map(entryKey).sort()[index])
+		leftEntries.length === rightEntries.length &&
+		leftEntries.every((entry, index) => entry === rightEntries[index])
+	);
+}
+
+function matchesDetachedArtifactRoot(pathname: string, plan: DetachedArtifactRoot): boolean {
+	return (
+		matchesMigrationArtifactRoot(pathname, plan.identity, plan.tree) &&
+		sameDirectoryObject(path.dirname(pathname), path.dirname(plan.detachedPath))
 	);
 }
 
@@ -2430,10 +2421,11 @@ function cleanupAuthorityMatches(cleanup: SourceArtifactCleanup, parent: string)
 	}
 }
 
-function detachArtifactRootForMigration(plan: DetachedArtifactRoot): {
-	detached: DetachedArtifactRoot;
-	cleanup?: SourceArtifactCleanup;
-} {
+function detachArtifactRootForMigration(
+	plan: DetachedArtifactRoot,
+):
+	| { detached: DetachedArtifactRoot; detachOutcome: "clean" }
+	| { detached: DetachedArtifactRoot; detachOutcome: "cleanup_pending"; cleanup: SourceArtifactCleanup } {
 	const result = native.exactUnlink(plan.originalPath, {
 		...plan.identity,
 		directory: true,
@@ -2460,7 +2452,7 @@ function detachArtifactRootForMigration(plan: DetachedArtifactRoot): {
 		process.platform === "win32" ? fs.realpathSync.native(result.detachedPath) : result.detachedPath;
 	if (!matchesDetachedArtifactRoot(detachedPath, plan)) throw new Error("durability_failed");
 	const detached = { ...plan, detachedPath };
-	if (!cleanupPending) return { detached };
+	if (!cleanupPending) return { detached, detachOutcome: "clean" };
 	const placeholder = result.retainedPlaceholderPath!;
 	const stat = fs.lstatSync(placeholder, { bigint: true });
 	if (!stat.isDirectory() || stat.isSymbolicLink() || path.dirname(placeholder) !== path.dirname(plan.originalPath))
@@ -2475,7 +2467,7 @@ function detachArtifactRootForMigration(plan: DetachedArtifactRoot): {
 	};
 	if (!snapshot.ok || !snapshot.snapshot || !cleanupAuthorityMatches(cleanup, path.dirname(plan.originalPath)))
 		throw new Error("durability_failed");
-	return { detached, cleanup };
+	return { detached, detachOutcome: "cleanup_pending", cleanup };
 }
 
 export function restorePreparedArtifactRoot(scope: ManagedScope, source: ManagedCandidate): void {
@@ -2497,6 +2489,7 @@ export function restorePreparedArtifactRoot(scope: ManagedScope, source: Managed
 			identity?: Record<string, unknown>;
 			tree?: unknown;
 		};
+		detachOutcome?: unknown;
 	};
 	try {
 		record = JSON.parse(captureManagedFileNoFollow(receipt).bytes.toString("utf8")) as typeof record;
@@ -2520,39 +2513,46 @@ export function restorePreparedArtifactRoot(scope: ManagedScope, source: Managed
 		typeof identity.mtimeNs !== "string"
 	)
 		throw new Error("durability_failed");
-	if (receipt === detachedReceipt && quarantine.role !== "detached_artifact_root")
-		throw new Error("durability_failed");
-	if (receipt === detachedReceipt && record.sourceArtifactCleanup !== undefined) {
-		const cleanup = record.sourceArtifactCleanup;
-		const cleanupIdentity = cleanup.identity;
-		const cleanupTree = artifactTreeSnapshot(cleanup.tree);
-		if (
-			cleanup.state !== "cleanup_pending" ||
-			cleanup.role !== "exchange_placeholder" ||
-			typeof cleanup.retainedPath !== "string" ||
-			!cleanupIdentity ||
-			typeof cleanupIdentity.dev !== "string" ||
-			typeof cleanupIdentity.ino !== "string" ||
-			typeof cleanupIdentity.size !== "string" ||
-			typeof cleanupIdentity.mtimeNs !== "string" ||
-			!cleanupTree ||
-			!cleanupAuthorityMatches(
-				{
-					state: "cleanup_pending",
-					role: "exchange_placeholder",
-					retainedPath: cleanup.retainedPath,
-					identity: {
-						dev: BigInt(cleanupIdentity.dev),
-						ino: BigInt(cleanupIdentity.ino),
-						size: BigInt(cleanupIdentity.size),
-						mtimeNs: BigInt(cleanupIdentity.mtimeNs),
+	if (receipt === detachedReceipt) {
+		if (quarantine.role !== "detached_artifact_root") throw new Error("durability_failed");
+		if (record.detachOutcome === "clean") {
+			if (record.sourceArtifactCleanup !== undefined || fs.existsSync(quarantine.path))
+				throw new Error("durability_failed");
+		} else if (record.detachOutcome === "cleanup_pending") {
+			const cleanup = record.sourceArtifactCleanup;
+			if (!cleanup) throw new Error("durability_failed");
+			const cleanupIdentity = cleanup.identity;
+			const cleanupTree = artifactTreeSnapshot(cleanup.tree);
+			if (
+				cleanup.state !== "cleanup_pending" ||
+				cleanup.role !== "exchange_placeholder" ||
+				typeof cleanup.retainedPath !== "string" ||
+				!cleanupIdentity ||
+				typeof cleanupIdentity.dev !== "string" ||
+				typeof cleanupIdentity.ino !== "string" ||
+				typeof cleanupIdentity.size !== "string" ||
+				typeof cleanupIdentity.mtimeNs !== "string" ||
+				!cleanupTree ||
+				!cleanupAuthorityMatches(
+					{
+						state: "cleanup_pending",
+						role: "exchange_placeholder",
+						retainedPath: cleanup.retainedPath,
+						identity: {
+							dev: BigInt(cleanupIdentity.dev),
+							ino: BigInt(cleanupIdentity.ino),
+							size: BigInt(cleanupIdentity.size),
+							mtimeNs: BigInt(cleanupIdentity.mtimeNs),
+						},
+						tree: cleanupTree,
 					},
-					tree: cleanupTree,
-				},
-				path.dirname(source.path),
+					path.dirname(source.path),
+				)
 			)
-		)
+				throw new Error("durability_failed");
+		} else {
 			throw new Error("durability_failed");
+		}
 	}
 
 	const expectedTree = artifactTreeSnapshot(quarantine.tree)!;
@@ -2680,6 +2680,7 @@ function migrationReceipt(
 		role?: "detached_artifact_root";
 	},
 	sourceArtifactCleanup?: SourceArtifactCleanup,
+	detachOutcome?: "clean" | "cleanup_pending",
 ): Uint8Array {
 	lock.assertOwned();
 	const destinationRecord =
@@ -2697,7 +2698,7 @@ function migrationReceipt(
 					header: { id: destination.sessionId, cwd: destination.cwd },
 				};
 	return new TextEncoder().encode(
-		`${JSON.stringify({ schemaVersion: 2, state, policy: "copy-retain", attemptId: lock.attemptId, scope: scopeDigest(scope.platform, scope.canonicalCwd), source: { path: source.path, sessionId: source.sessionId, header: { id: source.sessionId, cwd: source.cwd }, identity: source.identity, sha256: source.identity.sha256 }, destination: destinationRecord, artifactManifest: manifest, ...(sourceArtifactQuarantine ? { sourceArtifactQuarantine } : {}), ...(sourceArtifactCleanup ? { sourceArtifactCleanup } : {}) }, (_key, value: unknown) => (typeof value === "bigint" ? value.toString() : value))}\n`,
+		`${JSON.stringify({ schemaVersion: 2, state, policy: "copy-retain", attemptId: lock.attemptId, scope: scopeDigest(scope.platform, scope.canonicalCwd), source: { path: source.path, sessionId: source.sessionId, header: { id: source.sessionId, cwd: source.cwd }, identity: source.identity, sha256: source.identity.sha256 }, destination: destinationRecord, artifactManifest: manifest, ...(sourceArtifactQuarantine ? { sourceArtifactQuarantine } : {}), ...(sourceArtifactCleanup ? { sourceArtifactCleanup } : {}), ...(detachOutcome ? { detachOutcome } : {}) }, (_key, value: unknown) => (typeof value === "bigint" ? value.toString() : value))}\n`,
 	);
 }
 
@@ -3118,7 +3119,7 @@ export async function openManagedCandidateForWrite(
 		if (artifactPlan) {
 			const detached = detachArtifactRootForMigration(artifactPlan);
 			detachedArtifacts = detached.detached;
-			sourceArtifactCleanup = detached.cleanup;
+			sourceArtifactCleanup = detached.detachOutcome === "cleanup_pending" ? detached.cleanup : undefined;
 			const detachedReceipt = receiptPathFor(scope, afterLock, "detached");
 			const detachedRecord = migrationReceipt(
 				scope,
@@ -3135,6 +3136,7 @@ export async function openManagedCandidateForWrite(
 					role: "detached_artifact_root",
 				},
 				sourceArtifactCleanup,
+				detached.detachOutcome,
 			);
 			try {
 				await publishManagedFileNoReplace(

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -2283,7 +2283,7 @@ function planArtifactRootForMigration(sourceTranscript: string, operation: strin
 			dev: stat.dev,
 			ino: stat.ino,
 			size: process.platform === "win32" ? BigInt(root.size) : stat.size,
-			mtimeNs: stat.mtimeNs,
+			mtimeNs: process.platform === "win32" ? BigInt(root.mtimeNs) : stat.mtimeNs,
 		},
 		tree,
 	};
@@ -2306,25 +2306,73 @@ function sameDirectoryObject(leftPath: string, rightPath: string): boolean {
 	}
 }
 
-function matchesDetachedArtifactRoot(pathname: string, plan: DetachedArtifactRoot): boolean {
+function matchesMigrationArtifactRoot(
+	pathname: string,
+	identity: DetachedArtifactRoot["identity"],
+	expectedTree: NativeDirectoryTreeSnapshot,
+): boolean {
 	try {
 		const stat = fs.lstatSync(pathname, { bigint: true });
-		const snapshot = native.snapshotDirectoryTree(pathname);
-		const root = snapshot.snapshot?.entries.find(entry => entry.relativePath === "" && entry.kind === "directory");
-		return (
-			stat.isDirectory() &&
-			!stat.isSymbolicLink() &&
-			stat.dev === plan.identity.dev &&
-			stat.ino === plan.identity.ino &&
-			stat.mtimeNs === plan.identity.mtimeNs &&
-			(process.platform === "win32"
-				? snapshot.ok && !!root && BigInt(root.size) === plan.identity.size
-				: stat.size === plan.identity.size) &&
-			sameDirectoryObject(path.dirname(pathname), path.dirname(plan.detachedPath))
+		if (
+			!stat.isDirectory() ||
+			stat.isSymbolicLink() ||
+			stat.dev !== identity.dev ||
+			stat.ino !== identity.ino
+		)
+			return false;
+		const observed = native.snapshotDirectoryTree(pathname);
+		const expectedRoot = expectedTree.entries.find(
+			entry => entry.relativePath === "" && entry.kind === "directory",
 		);
+		const observedRoot = observed.snapshot?.entries.find(
+			entry => entry.relativePath === "" && entry.kind === "directory",
+		);
+		if (
+			!observed.ok ||
+			!observed.snapshot ||
+			!expectedRoot ||
+			!observedRoot ||
+			(process.platform === "win32" &&
+				(observedRoot.dev !== identity.dev.toString() ||
+					observedRoot.ino !== identity.ino.toString() ||
+					BigInt(observedRoot.size) !== identity.size ||
+					BigInt(observedRoot.mtimeNs) !== identity.mtimeNs)) ||
+			(process.platform !== "win32" &&
+				(stat.size !== identity.size || stat.mtimeNs !== identity.mtimeNs))
+		)
+			return false;
+		const directoryEntryKey = (entry: NativeDirectoryTreeSnapshot["entries"][number]): string =>
+			JSON.stringify(
+				process.platform === "win32"
+					? [entry.relativePath, entry.kind, entry.dev, entry.ino]
+					: [entry.relativePath, entry.kind, entry.dev, entry.ino, entry.size, entry.mtimeNs],
+			);
+		const strictEntryKey = (entry: NativeDirectoryTreeSnapshot["entries"][number]): string =>
+			JSON.stringify([
+				entry.relativePath,
+				entry.kind,
+				entry.dev,
+				entry.ino,
+				entry.size,
+				entry.mtimeNs,
+				entry.ctimeNs,
+				entry.sha256,
+			]);
+		const entryKey = (entry: NativeDirectoryTreeSnapshot["entries"][number]): string =>
+			entry.kind === "directory" ? directoryEntryKey(entry) : strictEntryKey(entry);
+		const expectedEntries = expectedTree.entries.map(entryKey).sort();
+		const observedEntries = observed.snapshot.entries.map(entryKey).sort();
+		return expectedEntries.length === observedEntries.length && expectedEntries.every((entry, index) => entry === observedEntries[index]);
 	} catch {
 		return false;
 	}
+}
+
+function matchesDetachedArtifactRoot(pathname: string, plan: DetachedArtifactRoot): boolean {
+	return (
+		matchesMigrationArtifactRoot(pathname, plan.identity, plan.tree) &&
+		sameDirectoryObject(path.dirname(pathname), path.dirname(plan.detachedPath))
+	);
 }
 
 function sameArtifactTree(left: NativeDirectoryTreeSnapshot, right: NativeDirectoryTreeSnapshot): boolean {
@@ -2477,12 +2525,12 @@ function restorePreparedArtifactRoot(scope: ManagedScope, source: ManagedCandida
 		throw new Error("durability_failed");
 	if (receipt === detachedReceipt && quarantine.role !== "detached_artifact_root")
 		throw new Error("durability_failed");
-	if (receipt === detachedReceipt) {
+	if (receipt === detachedReceipt && record.sourceArtifactCleanup !== undefined) {
 		const cleanup = record.sourceArtifactCleanup;
-		const cleanupIdentity = cleanup?.identity;
-		const cleanupTree = artifactTreeSnapshot(cleanup?.tree);
+		const cleanupIdentity = cleanup.identity;
+		const cleanupTree = artifactTreeSnapshot(cleanup.tree);
 		if (
-			cleanup?.state !== "cleanup_pending" ||
+			cleanup.state !== "cleanup_pending" ||
 			cleanup.role !== "exchange_placeholder" ||
 			typeof cleanup.retainedPath !== "string" ||
 			!cleanupIdentity ||
@@ -2512,21 +2560,23 @@ function restorePreparedArtifactRoot(scope: ManagedScope, source: ManagedCandida
 
 	const expectedTree = artifactTreeSnapshot(quarantine.tree)!;
 	const assertPreparedTree = (pathname: string): void => {
-		validateManagedArtifactTree(pathname);
-		const observed = native.snapshotDirectoryTree(pathname);
-		if (!observed.ok || !observed.snapshot || !sameArtifactTree(observed.snapshot, expectedTree))
+		if (
+			!matchesMigrationArtifactRoot(pathname, {
+				dev: BigInt(identity.dev),
+				ino: BigInt(identity.ino),
+				size: BigInt(identity.size),
+				mtimeNs: BigInt(identity.mtimeNs),
+			}, expectedTree)
+		)
 			throw new Error("durability_failed");
 	};
 	if (fs.existsSync(quarantine.path)) {
-		const existing = fs.lstatSync(quarantine.path, { bigint: true });
-		if (
-			!existing.isSymbolicLink() &&
-			existing.isDirectory() &&
-			existing.dev === BigInt(identity.dev) &&
-			existing.ino === BigInt(identity.ino) &&
-			existing.size === BigInt(identity.size) &&
-			existing.mtimeNs === BigInt(identity.mtimeNs)
-		) {
+		if (matchesMigrationArtifactRoot(quarantine.path, {
+			dev: BigInt(identity.dev),
+			ino: BigInt(identity.ino),
+			size: BigInt(identity.size),
+			mtimeNs: BigInt(identity.mtimeNs),
+		}, expectedTree)) {
 			assertPreparedTree(quarantine.path);
 		}
 		// A changed source pathname is independent retained authority. Do not replace

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -2315,17 +2315,10 @@ export function matchesMigrationArtifactRoot(
 ): boolean {
 	try {
 		const stat = fs.lstatSync(pathname, { bigint: true });
-		if (
-			!stat.isDirectory() ||
-			stat.isSymbolicLink() ||
-			stat.dev !== identity.dev ||
-			stat.ino !== identity.ino
-		)
+		if (!stat.isDirectory() || stat.isSymbolicLink() || stat.dev !== identity.dev || stat.ino !== identity.ino)
 			return false;
 		const observed = native.snapshotDirectoryTree(pathname);
-		const expectedRoot = expectedTree.entries.find(
-			entry => entry.relativePath === "" && entry.kind === "directory",
-		);
+		const expectedRoot = expectedTree.entries.find(entry => entry.relativePath === "" && entry.kind === "directory");
 		const observedRoot = observed.snapshot?.entries.find(
 			entry => entry.relativePath === "" && entry.kind === "directory",
 		);
@@ -2363,7 +2356,10 @@ export function matchesMigrationArtifactRoot(
 			entry.kind === "directory" ? directoryEntryKey(entry) : strictEntryKey(entry);
 		const expectedEntries = expectedTree.entries.map(entryKey).sort();
 		const observedEntries = observed.snapshot.entries.map(entryKey).sort();
-		return expectedEntries.length === observedEntries.length && expectedEntries.every((entry, index) => entry === observedEntries[index]);
+		return (
+			expectedEntries.length === observedEntries.length &&
+			expectedEntries.every((entry, index) => entry === observedEntries[index])
+		);
 	} catch {
 		return false;
 	}
@@ -2562,22 +2558,32 @@ export function restorePreparedArtifactRoot(scope: ManagedScope, source: Managed
 	const expectedTree = artifactTreeSnapshot(quarantine.tree)!;
 	const assertPreparedTree = (pathname: string): void => {
 		if (
-			!matchesMigrationArtifactRoot(pathname, {
-				dev: BigInt(identity.dev),
-				ino: BigInt(identity.ino),
-				size: BigInt(identity.size),
-				mtimeNs: BigInt(identity.mtimeNs),
-			}, expectedTree)
+			!matchesMigrationArtifactRoot(
+				pathname,
+				{
+					dev: BigInt(identity.dev),
+					ino: BigInt(identity.ino),
+					size: BigInt(identity.size),
+					mtimeNs: BigInt(identity.mtimeNs),
+				},
+				expectedTree,
+			)
 		)
 			throw new Error("durability_failed");
 	};
 	if (fs.existsSync(quarantine.path)) {
-		if (matchesMigrationArtifactRoot(quarantine.path, {
-			dev: BigInt(identity.dev),
-			ino: BigInt(identity.ino),
-			size: BigInt(identity.size),
-			mtimeNs: BigInt(identity.mtimeNs),
-		}, expectedTree)) {
+		if (
+			matchesMigrationArtifactRoot(
+				quarantine.path,
+				{
+					dev: BigInt(identity.dev),
+					ino: BigInt(identity.ino),
+					size: BigInt(identity.size),
+					mtimeNs: BigInt(identity.mtimeNs),
+				},
+				expectedTree,
+			)
+		) {
 			assertPreparedTree(quarantine.path);
 		}
 		// A changed source pathname is independent retained authority. Do not replace

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -569,7 +569,11 @@ function fsyncManagedParent(pathname: string): void {
 	}
 }
 
-function fsyncCanonicalBinding(bindingPath: string, expected: string): void {
+export function canonicalBindingOpenFlags(platform: NodeJS.Platform = process.platform): number {
+	return (platform === "win32" ? fs.constants.O_RDWR : fs.constants.O_RDONLY) | fs.constants.O_NOFOLLOW;
+}
+
+export function fsyncCanonicalBinding(bindingPath: string, expected: string): void {
 	let captured: ManagedFileSnapshot;
 	try {
 		captured = captureManagedFileNoFollow(bindingPath);
@@ -581,10 +585,7 @@ function fsyncCanonicalBinding(bindingPath: string, expected: string): void {
 	try {
 		// Bun on Windows rejects fsync on a read-only file descriptor with EPERM.
 		// The managed binding is owner-writable, so reopen it read/write only for the durability fence.
-		descriptor = fs.openSync(
-			bindingPath,
-			(process.platform === "win32" ? fs.constants.O_RDWR : fs.constants.O_RDONLY) | fs.constants.O_NOFOLLOW,
-		);
+		descriptor = fs.openSync(bindingPath, canonicalBindingOpenFlags());
 		const before = fs.fstatSync(descriptor, { bigint: true });
 		if (
 			before.dev !== captured.identity.dev ||
@@ -2306,10 +2307,11 @@ function sameDirectoryObject(leftPath: string, rightPath: string): boolean {
 	}
 }
 
-function matchesMigrationArtifactRoot(
+export function matchesMigrationArtifactRoot(
 	pathname: string,
-	identity: DetachedArtifactRoot["identity"],
+	identity: { dev: bigint; ino: bigint; size: bigint; mtimeNs: bigint },
 	expectedTree: NativeDirectoryTreeSnapshot,
+	platform: NodeJS.Platform = process.platform,
 ): boolean {
 	try {
 		const stat = fs.lstatSync(pathname, { bigint: true });
@@ -2332,18 +2334,17 @@ function matchesMigrationArtifactRoot(
 			!observed.snapshot ||
 			!expectedRoot ||
 			!observedRoot ||
-			(process.platform === "win32" &&
+			(platform === "win32" &&
 				(observedRoot.dev !== identity.dev.toString() ||
 					observedRoot.ino !== identity.ino.toString() ||
 					BigInt(observedRoot.size) !== identity.size ||
 					BigInt(observedRoot.mtimeNs) !== identity.mtimeNs)) ||
-			(process.platform !== "win32" &&
-				(stat.size !== identity.size || stat.mtimeNs !== identity.mtimeNs))
+			(platform !== "win32" && (stat.size !== identity.size || stat.mtimeNs !== identity.mtimeNs))
 		)
 			return false;
 		const directoryEntryKey = (entry: NativeDirectoryTreeSnapshot["entries"][number]): string =>
 			JSON.stringify(
-				process.platform === "win32"
+				platform === "win32"
 					? [entry.relativePath, entry.kind, entry.dev, entry.ino]
 					: [entry.relativePath, entry.kind, entry.dev, entry.ino, entry.size, entry.mtimeNs],
 			);
@@ -2481,7 +2482,7 @@ function detachArtifactRootForMigration(plan: DetachedArtifactRoot): {
 	return { detached, cleanup };
 }
 
-function restorePreparedArtifactRoot(scope: ManagedScope, source: ManagedCandidate): void {
+export function restorePreparedArtifactRoot(scope: ManagedScope, source: ManagedCandidate): void {
 	const preparedReceipt = receiptPathFor(scope, source, "prepared");
 	const detachedReceipt = receiptPathFor(scope, source, "detached");
 	const receipt = fs.existsSync(detachedReceipt) ? detachedReceipt : preparedReceipt;

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -2470,7 +2470,11 @@ function detachArtifactRootForMigration(
 	return { detached, detachOutcome: "cleanup_pending", cleanup };
 }
 
-export function restorePreparedArtifactRoot(scope: ManagedScope, source: ManagedCandidate): void {
+export function restorePreparedArtifactRoot(
+	scope: ManagedScope,
+	source: ManagedCandidate,
+	lock?: ManagedStorageLock,
+): void {
 	const preparedReceipt = receiptPathFor(scope, source, "prepared");
 	const detachedReceipt = receiptPathFor(scope, source, "detached");
 	const receipt = fs.existsSync(detachedReceipt) ? detachedReceipt : preparedReceipt;
@@ -2519,11 +2523,35 @@ export function restorePreparedArtifactRoot(scope: ManagedScope, source: Managed
 		size: BigInt(identity.size),
 		mtimeNs: BigInt(identity.mtimeNs),
 	};
+	const expectedTree = artifactTreeSnapshot(quarantine.tree)!;
+	const assertPreparedTree = (pathname: string): void => {
+		if (
+			!matchesMigrationArtifactRoot(
+				pathname,
+				{
+					...artifactIdentity,
+				},
+				expectedTree,
+			)
+		)
+			throw new Error("durability_failed");
+	};
 	if (receipt === detachedReceipt) {
 		if (quarantine.role !== "detached_artifact_root") throw new Error("durability_failed");
 		if (record.detachOutcome === "clean") {
-			if (record.sourceArtifactCleanup !== undefined || fs.existsSync(quarantine.path))
-				throw new Error("durability_failed");
+			if (record.sourceArtifactCleanup !== undefined) throw new Error("durability_failed");
+			const originalExists = fs.existsSync(quarantine.path);
+			const detachedExists = fs.existsSync(quarantine.detachedPath);
+			if (originalExists) {
+				if (detachedExists) throw new Error("durability_failed");
+				assertPreparedTree(quarantine.path);
+				if (lock) {
+					lock.assertOwned();
+					fs.unlinkSync(receipt);
+					fsyncManagedParent(receipt);
+				}
+				return;
+			}
 		} else if (record.detachOutcome === "cleanup_pending") {
 			const cleanup = record.sourceArtifactCleanup;
 			if (!cleanup) throw new Error("durability_failed");
@@ -2561,19 +2589,6 @@ export function restorePreparedArtifactRoot(scope: ManagedScope, source: Managed
 		}
 	}
 
-	const expectedTree = artifactTreeSnapshot(quarantine.tree)!;
-	const assertPreparedTree = (pathname: string): void => {
-		if (
-			!matchesMigrationArtifactRoot(
-				pathname,
-				{
-					...artifactIdentity,
-				},
-				expectedTree,
-			)
-		)
-			throw new Error("durability_failed");
-	};
 	if (fs.existsSync(quarantine.path)) {
 		if (
 			matchesMigrationArtifactRoot(
@@ -2712,7 +2727,10 @@ async function removeStagedReceipts(scope: ManagedScope, candidate: ManagedCandi
 		const pathname = receiptPathFor(scope, candidate, state);
 		try {
 			const stat = fs.lstatSync(pathname);
-			if (stat.isFile() || stat.isSymbolicLink()) await fs.promises.unlink(pathname);
+			if (stat.isFile() || stat.isSymbolicLink()) {
+				await fs.promises.unlink(pathname);
+				fsyncManagedParent(pathname);
+			}
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
 		}
@@ -3039,7 +3057,7 @@ export async function openManagedCandidateForWrite(
 
 		scopeRoot(scope);
 		revalidatePickerConsent(scope, afterLock, expectedIdentity);
-		restorePreparedArtifactRoot(scope, afterLock);
+		restorePreparedArtifactRoot(scope, afterLock, heldLock);
 		scopeRoot(scope);
 
 		let sourceSnapshot = captureManagedFileNoFollow(afterLock.path);

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -2513,6 +2513,12 @@ export function restorePreparedArtifactRoot(scope: ManagedScope, source: Managed
 		typeof identity.mtimeNs !== "string"
 	)
 		throw new Error("durability_failed");
+	const artifactIdentity = {
+		dev: BigInt(identity.dev),
+		ino: BigInt(identity.ino),
+		size: BigInt(identity.size),
+		mtimeNs: BigInt(identity.mtimeNs),
+	};
 	if (receipt === detachedReceipt) {
 		if (quarantine.role !== "detached_artifact_root") throw new Error("durability_failed");
 		if (record.detachOutcome === "clean") {
@@ -2561,10 +2567,7 @@ export function restorePreparedArtifactRoot(scope: ManagedScope, source: Managed
 			!matchesMigrationArtifactRoot(
 				pathname,
 				{
-					dev: BigInt(identity.dev),
-					ino: BigInt(identity.ino),
-					size: BigInt(identity.size),
-					mtimeNs: BigInt(identity.mtimeNs),
+					...artifactIdentity,
 				},
 				expectedTree,
 			)
@@ -2576,10 +2579,7 @@ export function restorePreparedArtifactRoot(scope: ManagedScope, source: Managed
 			matchesMigrationArtifactRoot(
 				quarantine.path,
 				{
-					dev: BigInt(identity.dev),
-					ino: BigInt(identity.ino),
-					size: BigInt(identity.size),
-					mtimeNs: BigInt(identity.mtimeNs),
+					...artifactIdentity,
 				},
 				expectedTree,
 			)
@@ -2592,10 +2592,7 @@ export function restorePreparedArtifactRoot(scope: ManagedScope, source: Managed
 	}
 	assertPreparedTree(quarantine.detachedPath);
 	const result = native.exactRestore(quarantine.detachedPath, quarantine.path, {
-		dev: BigInt(identity.dev),
-		ino: BigInt(identity.ino),
-		size: BigInt(identity.size),
-		mtimeNs: BigInt(identity.mtimeNs),
+		...artifactIdentity,
 		directory: true,
 	});
 	if (!result.ok) throw new Error("durability_failed");

--- a/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
+++ b/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
@@ -10,15 +10,17 @@ import {
 	listManagedCandidates,
 	matchesMigrationArtifactRoot,
 	openManagedCandidateForWrite,
-	restorePreparedArtifactRoot,
 	resolveManagedScope,
+	restorePreparedArtifactRoot,
 } from "../../src/session/internal/managed-session-scope";
 
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
 	vi.restoreAllMocks();
-	await Promise.all(temporaryDirectories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })));
+	await Promise.all(
+		temporaryDirectories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })),
+	);
 });
 
 function temporaryDirectory(prefix: string): string {
@@ -26,7 +28,13 @@ function temporaryDirectory(prefix: string): string {
 }
 
 function legacyDirectory(sessionsRoot: string, cwd: string): string {
-	return path.join(sessionsRoot, `--${path.resolve(cwd).replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`);
+	return path.join(
+		sessionsRoot,
+		`--${path
+			.resolve(cwd)
+			.replace(/^[/\\]/, "")
+			.replace(/[/\\:]/g, "-")}--`,
+	);
 }
 
 function transcript(id: string, cwd: string): string {
@@ -63,7 +71,15 @@ async function interruptedArtifactMigration(id: string) {
 	const receipts = path.join(scope.directoryPath, ".gjc-managed-session-internal", "receipts");
 	const name = (await fs.readdir(receipts)).find(entry => entry.endsWith(".detached.json"));
 	if (!name) throw new Error("Missing detached receipt");
-	return { cwd, agentDir, sessionsRoot, source, artifacts, candidate: listed.owned[0], receipt: path.join(receipts, name) };
+	return {
+		cwd,
+		agentDir,
+		sessionsRoot,
+		source,
+		artifacts,
+		candidate: listed.owned[0],
+		receipt: path.join(receipts, name),
+	};
 }
 
 describe("managed session Windows durability", () => {
@@ -114,7 +130,9 @@ describe("managed session Windows durability", () => {
 		const stat = syncFs.lstatSync(artifacts, { bigint: true });
 		const snapshot = native.snapshotDirectoryTree(artifacts);
 		if (!snapshot.ok || !snapshot.snapshot) throw new Error("Native snapshot unavailable");
-		const nativeRoot = snapshot.snapshot.entries.find(entry => entry.relativePath === "" && entry.kind === "directory");
+		const nativeRoot = snapshot.snapshot.entries.find(
+			entry => entry.relativePath === "" && entry.kind === "directory",
+		);
 		if (!nativeRoot) throw new Error("Native root missing");
 		const authoritativeSize = (BigInt(nativeRoot.size) + 1n).toString();
 		const expectedTree = {
@@ -132,12 +150,19 @@ describe("managed session Windows durability", () => {
 				snapshot: {
 					...observed.snapshot,
 					entries: observed.snapshot.entries.map(entry =>
-						entry.relativePath === "" ? { ...entry, size: authoritativeSize, mtimeNs: nativeRoot.mtimeNs } : entry,
+						entry.relativePath === ""
+							? { ...entry, size: authoritativeSize, mtimeNs: nativeRoot.mtimeNs }
+							: entry,
 					),
 				},
 			};
 		});
-		const identity = { dev: stat.dev, ino: stat.ino, size: BigInt(authoritativeSize), mtimeNs: BigInt(nativeRoot.mtimeNs) };
+		const identity = {
+			dev: stat.dev,
+			ino: stat.ino,
+			size: BigInt(authoritativeSize),
+			mtimeNs: BigInt(nativeRoot.mtimeNs),
+		};
 		expect(matchesMigrationArtifactRoot(artifacts, identity, expectedTree, "win32")).toBe(true);
 		await fs.writeFile(payload, "drifted");
 		expect(matchesMigrationArtifactRoot(artifacts, identity, expectedTree, "win32")).toBe(false);
@@ -159,7 +184,11 @@ describe("managed session Windows durability", () => {
 		vi.spyOn(native, "snapshotDirectoryTree").mockImplementation(pathname =>
 			pathname === detachedPath ? { ok: true, snapshot: tree } : snapshotDirectoryTree(pathname),
 		);
-		const resolved = resolveManagedScope({ cwd: interrupted.cwd, agentDir: interrupted.agentDir, sessionsRoot: interrupted.sessionsRoot });
+		const resolved = resolveManagedScope({
+			cwd: interrupted.cwd,
+			agentDir: interrupted.agentDir,
+			sessionsRoot: interrupted.sessionsRoot,
+		});
 		if (resolved.kind !== "resolved") throw new Error(resolved.message);
 		const restarted = listManagedCandidates(resolved.scope);
 		if (restarted.kind !== "complete") throw new Error("Could not list restarted candidates");
@@ -175,7 +204,11 @@ describe("managed session Windows durability", () => {
 		record.sourceArtifactCleanup = { state: "cleanup_pending", role: "exchange_placeholder" };
 		await fs.writeFile(interrupted.receipt, `${JSON.stringify(record)}\n`);
 		vi.restoreAllMocks();
-		const resolved = resolveManagedScope({ cwd: interrupted.cwd, agentDir: interrupted.agentDir, sessionsRoot: interrupted.sessionsRoot });
+		const resolved = resolveManagedScope({
+			cwd: interrupted.cwd,
+			agentDir: interrupted.agentDir,
+			sessionsRoot: interrupted.sessionsRoot,
+		});
 		if (resolved.kind !== "resolved") throw new Error(resolved.message);
 		const restarted = listManagedCandidates(resolved.scope);
 		if (restarted.kind !== "complete") throw new Error("Could not list restarted candidates");

--- a/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
+++ b/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
@@ -103,6 +103,20 @@ async function interruptedArtifactMigration(
 	};
 }
 
+async function restartedLegacy(interrupted: Awaited<ReturnType<typeof interruptedArtifactMigration>>) {
+	const resolved = resolveManagedScope({
+		cwd: interrupted.cwd,
+		agentDir: interrupted.agentDir,
+		sessionsRoot: interrupted.sessionsRoot,
+	});
+	if (resolved.kind !== "resolved") throw new Error(resolved.message);
+	const restarted = listManagedCandidates(resolved.scope);
+	if (restarted.kind !== "complete") throw new Error("Could not list restarted candidates");
+	const legacy = restarted.owned.find(candidate => candidate.provenance === "legacy");
+	if (!legacy) throw new Error("Missing restarted legacy candidate");
+	return { scope: resolved.scope, legacy };
+}
+
 describe("managed session Windows durability", () => {
 	it("selects writable no-follow binding flags only on win32", () => {
 		expect(canonicalBindingOpenFlags("win32")).toBe(syncFs.constants.O_RDWR | syncFs.constants.O_NOFOLLOW);
@@ -255,6 +269,76 @@ describe("managed session Windows durability", () => {
 		if (!legacy) throw new Error("Missing restarted legacy candidate");
 		expect(() => restorePreparedArtifactRoot(resolved.scope, legacy)).not.toThrow();
 		expect((await fs.stat(interrupted.artifacts)).isDirectory()).toBe(true);
+	});
+
+	it("reconciles a clean receipt left after restoration before a second restart", async () => {
+		const interrupted = await interruptedArtifactMigration("clean-restored-stale-receipt", "clean");
+		const record = JSON.parse(await fs.readFile(interrupted.receipt, "utf8")) as {
+			sourceArtifactQuarantine?: { detachedPath?: string; tree?: NativeDirectoryTreeSnapshot };
+		};
+		const detachedPath = record.sourceArtifactQuarantine?.detachedPath;
+		const tree = record.sourceArtifactQuarantine?.tree;
+		if (!detachedPath || !tree) throw new Error("Missing detached artifact authority");
+		vi.restoreAllMocks();
+		const snapshotDirectoryTree = native.snapshotDirectoryTree;
+		vi.spyOn(native, "snapshotDirectoryTree").mockImplementation(pathname =>
+			pathname === detachedPath || pathname === interrupted.artifacts
+				? { ok: true, snapshot: tree }
+				: snapshotDirectoryTree(pathname),
+		);
+		const first = await restartedLegacy(interrupted);
+		let restored = false;
+		const exactRestore = native.exactRestore;
+		vi.spyOn(native, "exactRestore").mockImplementation((...args) => {
+			restored = true;
+			return exactRestore(...args);
+		});
+		const unlinkOriginal = syncFs.promises.unlink.bind(syncFs.promises);
+		const unlink = vi.spyOn(syncFs.promises, "unlink").mockImplementation(pathname => {
+			if (restored) return Promise.reject(new Error("injected unlink failure"));
+			return unlinkOriginal(pathname);
+		});
+		expect(await openManagedCandidateForWrite(first.scope, first.legacy)).toMatchObject({
+			kind: "error",
+			code: "durability_failed",
+		});
+		unlink.mockRestore();
+		expect((await fs.stat(interrupted.artifacts)).isDirectory()).toBe(true);
+		const stale = JSON.parse(await fs.readFile(interrupted.receipt, "utf8")) as {
+			detachOutcome?: unknown;
+			sourceArtifactQuarantine?: { detachedPath?: string };
+		};
+		expect(stale.detachOutcome).toBe("clean");
+		expect(stale.sourceArtifactQuarantine?.detachedPath).toBeDefined();
+		if (stale.sourceArtifactQuarantine?.detachedPath)
+			await expect(fs.access(stale.sourceArtifactQuarantine.detachedPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+		const second = await restartedLegacy(interrupted);
+		expect(await openManagedCandidateForWrite(second.scope, second.legacy)).toMatchObject({ kind: "opened" });
+	});
+
+	it("fails closed when a clean receipt's original artifact root was replaced", async () => {
+		const interrupted = await interruptedArtifactMigration("clean-replaced-root", "clean");
+		vi.restoreAllMocks();
+		await fs.mkdir(interrupted.artifacts);
+		await fs.writeFile(path.join(interrupted.artifacts, "foreign.txt"), "foreign");
+		const restarted = await restartedLegacy(interrupted);
+		expect(() => restorePreparedArtifactRoot(restarted.scope, restarted.legacy)).toThrow("durability_failed");
+	});
+
+	it("fails closed when clean or cleanup-pending receipts omit detachOutcome", async () => {
+		for (const detachOutcome of ["clean", "cleanup_pending"] as const) {
+			const interrupted = await interruptedArtifactMigration(
+				`missing-detach-outcome-${detachOutcome}`,
+				detachOutcome,
+			);
+			const record = JSON.parse(await fs.readFile(interrupted.receipt, "utf8")) as Record<string, unknown>;
+			delete record.detachOutcome;
+			await fs.writeFile(interrupted.receipt, `${JSON.stringify(record)}\n`);
+			vi.restoreAllMocks();
+			const restarted = await restartedLegacy(interrupted);
+			expect(() => restorePreparedArtifactRoot(restarted.scope, restarted.legacy)).toThrow("durability_failed");
+		}
 	});
 
 	it("fails closed when cleanup authority is deleted from a cleanup-pending receipt", async () => {

--- a/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
+++ b/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
@@ -53,7 +53,10 @@ async function fixture() {
 	return { cwd, agentDir, sessionsRoot, scope: resolved.scope };
 }
 
-async function interruptedArtifactMigration(id: string) {
+async function interruptedArtifactMigration(
+	id: string,
+	detachOutcome: "clean" | "cleanup_pending" = "cleanup_pending",
+) {
 	const { cwd, agentDir, sessionsRoot, scope } = await fixture();
 	const legacy = legacyDirectory(sessionsRoot, cwd);
 	const source = path.join(legacy, `${id}.jsonl`);
@@ -63,6 +66,23 @@ async function interruptedArtifactMigration(id: string) {
 	await fs.writeFile(source, transcript(id, cwd));
 	const listed = listManagedCandidates(scope);
 	if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
+	const artifactSnapshot = native.snapshotDirectoryTree(artifacts);
+	if (!artifactSnapshot.ok || !artifactSnapshot.snapshot) throw new Error("Native snapshot unavailable");
+	let detachedPath: string | undefined;
+	const snapshotDirectoryTree = native.snapshotDirectoryTree;
+	vi.spyOn(native, "snapshotDirectoryTree").mockImplementation(pathname =>
+		pathname === detachedPath ? { ok: true, snapshot: artifactSnapshot.snapshot } : snapshotDirectoryTree(pathname),
+	);
+	const exactUnlink = native.exactUnlink;
+	vi.spyOn(native, "exactUnlink").mockImplementation((pathname, identity) => {
+		if (pathname !== artifacts || !identity.directory || !identity.detachOnly || !identity.quarantineName)
+			return exactUnlink(pathname, identity);
+		detachedPath = path.join(path.dirname(pathname), identity.quarantineName);
+		syncFs.renameSync(pathname, detachedPath);
+		if (detachOutcome === "clean") return { ok: true, detachedPath };
+		syncFs.mkdirSync(pathname);
+		return { ok: false, code: "cleanup_pending", detachedPath, retainedPlaceholderPath: pathname };
+	});
 	vi.spyOn(native, "exactRestore").mockReturnValue({ ok: false, code: "io_error" });
 	expect(await openManagedCandidateForWrite(scope, listed.owned[0])).toMatchObject({
 		kind: "error",
@@ -120,12 +140,13 @@ describe("managed session Windows durability", () => {
 		expect(await fs.readFile(binding, "utf8")).toBe(expected);
 	});
 
-	it("uses native Windows root metadata for prepared receipt validation while rejecting file-content drift", async () => {
+	it("uses native Windows root metadata, tolerates pi-iso directory metadata drift, and rejects same-size content drift", async () => {
 		const root = temporaryDirectory("gjc-native-root-authority-");
 		temporaryDirectories.push(root);
 		const artifacts = path.join(root, "artifacts");
-		await fs.mkdir(artifacts);
-		const payload = path.join(artifacts, "payload.txt");
+		const nested = path.join(artifacts, "nested");
+		await fs.mkdir(nested, { recursive: true });
+		const payload = path.join(nested, "payload.txt");
 		await fs.writeFile(payload, "original");
 		const stat = syncFs.lstatSync(artifacts, { bigint: true });
 		const snapshot = native.snapshotDirectoryTree(artifacts);
@@ -149,11 +170,13 @@ describe("managed session Windows durability", () => {
 				...observed,
 				snapshot: {
 					...observed.snapshot,
-					entries: observed.snapshot.entries.map(entry =>
-						entry.relativePath === ""
-							? { ...entry, size: authoritativeSize, mtimeNs: nativeRoot.mtimeNs }
-							: entry,
-					),
+					entries: observed.snapshot.entries.map(entry => {
+						if (entry.relativePath === "")
+							return { ...entry, size: authoritativeSize, mtimeNs: nativeRoot.mtimeNs };
+						if (entry.relativePath === "nested" && entry.kind === "directory")
+							return { ...entry, size: "0", mtimeNs: "0", ctimeNs: "0" };
+						return entry;
+					}),
 				},
 			};
 		});
@@ -164,18 +187,53 @@ describe("managed session Windows durability", () => {
 			mtimeNs: BigInt(nativeRoot.mtimeNs),
 		};
 		expect(matchesMigrationArtifactRoot(artifacts, identity, expectedTree, "win32")).toBe(true);
-		await fs.writeFile(payload, "drifted");
+		await fs.writeFile(payload, "modified");
 		expect(matchesMigrationArtifactRoot(artifacts, identity, expectedTree, "win32")).toBe(false);
 	});
 
-	it("replays a clean detached receipt that omits sourceArtifactCleanup", async () => {
-		const interrupted = await interruptedArtifactMigration("clean-detached");
+	it("rejects POSIX nested-directory ctime drift", async () => {
+		const root = temporaryDirectory("gjc-posix-directory-ctime-");
+		temporaryDirectories.push(root);
+		const artifacts = path.join(root, "artifacts");
+		await fs.mkdir(path.join(artifacts, "nested"), { recursive: true });
+		const stat = syncFs.lstatSync(artifacts, { bigint: true });
+		const snapshot = native.snapshotDirectoryTree(artifacts);
+		if (!snapshot.ok || !snapshot.snapshot) throw new Error("Native snapshot unavailable");
+		const snapshotDirectoryTree = native.snapshotDirectoryTree;
+		vi.spyOn(native, "snapshotDirectoryTree").mockImplementation(pathname => {
+			const observed = snapshotDirectoryTree(pathname);
+			if (!observed.ok || !observed.snapshot) return observed;
+			return {
+				...observed,
+				snapshot: {
+					...observed.snapshot,
+					entries: observed.snapshot.entries.map(entry =>
+						entry.relativePath === "nested" && entry.kind === "directory"
+							? { ...entry, ctimeNs: (BigInt(entry.ctimeNs) + 1n).toString() }
+							: entry,
+					),
+				},
+			};
+		});
+		expect(
+			matchesMigrationArtifactRoot(
+				artifacts,
+				{ dev: stat.dev, ino: stat.ino, size: stat.size, mtimeNs: stat.mtimeNs },
+				snapshot.snapshot,
+				"darwin",
+			),
+		).toBe(false);
+	});
+
+	it("replays a genuinely clean detached receipt", async () => {
+		const interrupted = await interruptedArtifactMigration("clean-detached", "clean");
 		const record = JSON.parse(await fs.readFile(interrupted.receipt, "utf8")) as {
+			detachOutcome?: unknown;
 			sourceArtifactQuarantine?: { detachedPath?: string; tree?: unknown };
 			sourceArtifactCleanup?: unknown;
 		};
-		delete record.sourceArtifactCleanup;
-		await fs.writeFile(interrupted.receipt, `${JSON.stringify(record)}\n`);
+		expect(record.detachOutcome).toBe("clean");
+		expect(record.sourceArtifactCleanup).toBeUndefined();
 		vi.restoreAllMocks();
 		const detachedPath = record.sourceArtifactQuarantine?.detachedPath;
 		const tree = record.sourceArtifactQuarantine?.tree;
@@ -198,10 +256,11 @@ describe("managed session Windows durability", () => {
 		expect((await fs.stat(interrupted.artifacts)).isDirectory()).toBe(true);
 	});
 
-	it("fails closed for a detached receipt with partial cleanup-pending authority", async () => {
-		const interrupted = await interruptedArtifactMigration("partial-cleanup");
+	it("fails closed when cleanup authority is deleted from a cleanup-pending receipt", async () => {
+		const interrupted = await interruptedArtifactMigration("deleted-cleanup-authority", "cleanup_pending");
 		const record = JSON.parse(await fs.readFile(interrupted.receipt, "utf8")) as Record<string, unknown>;
-		record.sourceArtifactCleanup = { state: "cleanup_pending", role: "exchange_placeholder" };
+		expect(record.detachOutcome).toBe("cleanup_pending");
+		delete record.sourceArtifactCleanup;
 		await fs.writeFile(interrupted.receipt, `${JSON.stringify(record)}\n`);
 		vi.restoreAllMocks();
 		const resolved = resolveManagedScope({

--- a/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
+++ b/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as syncFs from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as native from "@gajae-code/natives";
+import {
+	canonicalBindingOpenFlags,
+	fsyncCanonicalBinding,
+	listManagedCandidates,
+	matchesMigrationArtifactRoot,
+	openManagedCandidateForWrite,
+	restorePreparedArtifactRoot,
+	resolveManagedScope,
+} from "../../src/session/internal/managed-session-scope";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(temporaryDirectories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })));
+});
+
+function temporaryDirectory(prefix: string): string {
+	return syncFs.mkdtempSync(path.join(syncFs.realpathSync(os.tmpdir()), prefix));
+}
+
+function legacyDirectory(sessionsRoot: string, cwd: string): string {
+	return path.join(sessionsRoot, `--${path.resolve(cwd).replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`);
+}
+
+function transcript(id: string, cwd: string): string {
+	return `${JSON.stringify({ type: "session", id, timestamp: "2026-01-01T00:00:00.000Z", cwd })}\n`;
+}
+
+async function fixture() {
+	const root = temporaryDirectory("gjc-session-durability-");
+	temporaryDirectories.push(root);
+	const cwd = path.join(root, "workspace");
+	const agentDir = path.join(root, "agent");
+	const sessionsRoot = path.join(agentDir, "sessions");
+	await fs.mkdir(cwd, { recursive: true });
+	const resolved = resolveManagedScope({ cwd, agentDir, sessionsRoot });
+	if (resolved.kind !== "resolved") throw new Error(resolved.message);
+	return { cwd, agentDir, sessionsRoot, scope: resolved.scope };
+}
+
+async function interruptedArtifactMigration(id: string) {
+	const { cwd, agentDir, sessionsRoot, scope } = await fixture();
+	const legacy = legacyDirectory(sessionsRoot, cwd);
+	const source = path.join(legacy, `${id}.jsonl`);
+	const artifacts = source.slice(0, -6);
+	await fs.mkdir(artifacts, { recursive: true });
+	await fs.writeFile(path.join(artifacts, "payload.txt"), "authoritative");
+	await fs.writeFile(source, transcript(id, cwd));
+	const listed = listManagedCandidates(scope);
+	if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
+	vi.spyOn(native, "exactRestore").mockReturnValue({ ok: false, code: "io_error" });
+	expect(await openManagedCandidateForWrite(scope, listed.owned[0])).toMatchObject({
+		kind: "error",
+		code: "durability_failed",
+	});
+	const receipts = path.join(scope.directoryPath, ".gjc-managed-session-internal", "receipts");
+	const name = (await fs.readdir(receipts)).find(entry => entry.endsWith(".detached.json"));
+	if (!name) throw new Error("Missing detached receipt");
+	return { cwd, agentDir, sessionsRoot, source, artifacts, candidate: listed.owned[0], receipt: path.join(receipts, name) };
+}
+
+describe("managed session Windows durability", () => {
+	it("selects writable no-follow binding flags only on win32", () => {
+		expect(canonicalBindingOpenFlags("win32")).toBe(syncFs.constants.O_RDWR | syncFs.constants.O_NOFOLLOW);
+		for (const platform of ["darwin", "linux", "freebsd"] as const)
+			expect(canonicalBindingOpenFlags(platform)).toBe(syncFs.constants.O_RDONLY | syncFs.constants.O_NOFOLLOW);
+	});
+
+	it("fsyncs a Windows canonical binding through a writable handle without changing its bytes", async () => {
+		const root = temporaryDirectory("gjc-binding-fsync-");
+		temporaryDirectories.push(root);
+		const binding = path.join(root, "binding.json");
+		const expected = '{"version":2}\n';
+		await fs.writeFile(binding, expected);
+		const openSync = syncFs.openSync.bind(syncFs);
+		const fsyncSync = syncFs.fsyncSync.bind(syncFs);
+		const flags: number[] = [];
+		vi.spyOn(syncFs, "openSync").mockImplementation((pathname, flag, mode) => {
+			flags.push(flag as number);
+			return openSync(pathname, flag, mode);
+		});
+		vi.spyOn(syncFs, "fsyncSync").mockImplementation(descriptor => {
+			if (flags.at(-1) === (syncFs.constants.O_RDONLY | syncFs.constants.O_NOFOLLOW)) {
+				const error = Object.assign(new Error("EPERM"), { code: "EPERM" });
+				throw error;
+			}
+			return fsyncSync(descriptor);
+		});
+		const platform = Object.getOwnPropertyDescriptor(process, "platform");
+		Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+		try {
+			expect(() => fsyncCanonicalBinding(binding, expected)).not.toThrow();
+		} finally {
+			if (platform) Object.defineProperty(process, "platform", platform);
+		}
+		expect(flags).toContain(syncFs.constants.O_RDWR | syncFs.constants.O_NOFOLLOW);
+		expect(await fs.readFile(binding, "utf8")).toBe(expected);
+	});
+
+	it("uses native Windows root metadata for prepared receipt validation while rejecting file-content drift", async () => {
+		const root = temporaryDirectory("gjc-native-root-authority-");
+		temporaryDirectories.push(root);
+		const artifacts = path.join(root, "artifacts");
+		await fs.mkdir(artifacts);
+		const payload = path.join(artifacts, "payload.txt");
+		await fs.writeFile(payload, "original");
+		const stat = syncFs.lstatSync(artifacts, { bigint: true });
+		const snapshot = native.snapshotDirectoryTree(artifacts);
+		if (!snapshot.ok || !snapshot.snapshot) throw new Error("Native snapshot unavailable");
+		const nativeRoot = snapshot.snapshot.entries.find(entry => entry.relativePath === "" && entry.kind === "directory");
+		if (!nativeRoot) throw new Error("Native root missing");
+		const authoritativeSize = (BigInt(nativeRoot.size) + 1n).toString();
+		const expectedTree = {
+			...snapshot.snapshot,
+			entries: snapshot.snapshot.entries.map(entry =>
+				entry.relativePath === "" ? { ...entry, size: authoritativeSize } : entry,
+			),
+		};
+		const snapshotDirectoryTree = native.snapshotDirectoryTree;
+		vi.spyOn(native, "snapshotDirectoryTree").mockImplementation(pathname => {
+			const observed = snapshotDirectoryTree(pathname);
+			if (!observed.ok || !observed.snapshot) return observed;
+			return {
+				...observed,
+				snapshot: {
+					...observed.snapshot,
+					entries: observed.snapshot.entries.map(entry =>
+						entry.relativePath === "" ? { ...entry, size: authoritativeSize, mtimeNs: nativeRoot.mtimeNs } : entry,
+					),
+				},
+			};
+		});
+		const identity = { dev: stat.dev, ino: stat.ino, size: BigInt(authoritativeSize), mtimeNs: BigInt(nativeRoot.mtimeNs) };
+		expect(matchesMigrationArtifactRoot(artifacts, identity, expectedTree, "win32")).toBe(true);
+		await fs.writeFile(payload, "drifted");
+		expect(matchesMigrationArtifactRoot(artifacts, identity, expectedTree, "win32")).toBe(false);
+	});
+
+	it("replays a clean detached receipt that omits sourceArtifactCleanup", async () => {
+		const interrupted = await interruptedArtifactMigration("clean-detached");
+		const record = JSON.parse(await fs.readFile(interrupted.receipt, "utf8")) as {
+			sourceArtifactQuarantine?: { detachedPath?: string; tree?: unknown };
+			sourceArtifactCleanup?: unknown;
+		};
+		delete record.sourceArtifactCleanup;
+		await fs.writeFile(interrupted.receipt, `${JSON.stringify(record)}\n`);
+		vi.restoreAllMocks();
+		const detachedPath = record.sourceArtifactQuarantine?.detachedPath;
+		const tree = record.sourceArtifactQuarantine?.tree;
+		if (!detachedPath || !tree) throw new Error("Missing detached artifact authority");
+		const snapshotDirectoryTree = native.snapshotDirectoryTree;
+		vi.spyOn(native, "snapshotDirectoryTree").mockImplementation(pathname =>
+			pathname === detachedPath ? { ok: true, snapshot: tree } : snapshotDirectoryTree(pathname),
+		);
+		const resolved = resolveManagedScope({ cwd: interrupted.cwd, agentDir: interrupted.agentDir, sessionsRoot: interrupted.sessionsRoot });
+		if (resolved.kind !== "resolved") throw new Error(resolved.message);
+		const restarted = listManagedCandidates(resolved.scope);
+		if (restarted.kind !== "complete") throw new Error("Could not list restarted candidates");
+		const legacy = restarted.owned.find(candidate => candidate.provenance === "legacy");
+		if (!legacy) throw new Error("Missing restarted legacy candidate");
+		expect(() => restorePreparedArtifactRoot(resolved.scope, legacy)).not.toThrow();
+		expect((await fs.stat(interrupted.artifacts)).isDirectory()).toBe(true);
+	});
+
+	it("fails closed for a detached receipt with partial cleanup-pending authority", async () => {
+		const interrupted = await interruptedArtifactMigration("partial-cleanup");
+		const record = JSON.parse(await fs.readFile(interrupted.receipt, "utf8")) as Record<string, unknown>;
+		record.sourceArtifactCleanup = { state: "cleanup_pending", role: "exchange_placeholder" };
+		await fs.writeFile(interrupted.receipt, `${JSON.stringify(record)}\n`);
+		vi.restoreAllMocks();
+		const resolved = resolveManagedScope({ cwd: interrupted.cwd, agentDir: interrupted.agentDir, sessionsRoot: interrupted.sessionsRoot });
+		if (resolved.kind !== "resolved") throw new Error(resolved.message);
+		const restarted = listManagedCandidates(resolved.scope);
+		if (restarted.kind !== "complete") throw new Error("Could not list restarted candidates");
+		const legacy = restarted.owned.find(candidate => candidate.provenance === "legacy");
+		if (!legacy) throw new Error("Missing restarted legacy candidate");
+		expect(() => restorePreparedArtifactRoot(resolved.scope, legacy)).toThrow("durability_failed");
+	});
+});

--- a/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
+++ b/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
@@ -3,6 +3,7 @@ import * as syncFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { NativeDirectoryTreeSnapshot } from "@gajae-code/natives";
 import * as native from "@gajae-code/natives";
 import {
 	canonicalBindingOpenFlags,
@@ -229,7 +230,7 @@ describe("managed session Windows durability", () => {
 		const interrupted = await interruptedArtifactMigration("clean-detached", "clean");
 		const record = JSON.parse(await fs.readFile(interrupted.receipt, "utf8")) as {
 			detachOutcome?: unknown;
-			sourceArtifactQuarantine?: { detachedPath?: string; tree?: unknown };
+			sourceArtifactQuarantine?: { detachedPath?: string; tree?: NativeDirectoryTreeSnapshot };
 			sourceArtifactCleanup?: unknown;
 		};
 		expect(record.detachOutcome).toBe("clean");


### PR DESCRIPTION
## Summary
Fixes two Windows session-durability blockers (root-caused by architect investigation):

- **#3015** — `fsyncCanonicalBinding()` opened the existing canonical binding `O_RDONLY|O_NOFOLLOW` before `fsyncSync`; Windows `FlushFileBuffers` rejects read-only handles with EPERM on some NTFS stacks (external USB SSDs), surfacing as `durability_failed` on every `gjc resume`. Now opens `O_RDWR|O_NOFOLLOW` on win32 only (no writes performed); POSIX unchanged. All identity/recapture fences retained.
- **#2913 completion** — prepared-receipt replay still gated the native tree check on Bun `lstat.size` (always 0 for detached Windows dirs) vs the receipt's native Win32 size. Migration-root validation is now unified behind one validator: native snapshot authority for win32 root size/mtime, strict file identity/hash checks, lazy plain-directory metadata tolerance per the pi-iso NTFS precedent.
- **Clean-detach replay** — detached receipts now accept exactly two shapes: clean detach (no cleanup authority) or `cleanup_pending` with full placeholder identity; partial/mixed shapes still fail closed. Previously an interrupted-but-clean detach was unrecoverable.

## Tests
New focused suite `test/session-manager/session-durability-windows.test.ts` (5 tests): win32-vs-posix flag selection, writable-handle fsync with unchanged bytes, native root-size authority + content-drift fail-closed, clean detached-receipt replay, partial cleanup-pending fail-closed.

Closes #3015. Progresses #2913 (recovery-consistency portion; the 0.11.8 tree already contained the direct matcher fix).