### PR TITLE
fix(task): preserve complete rejected structured payloads (#2894)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
 - SDK daemon CLI end-to-end tests now drain spawned child stdout and stderr concurrently with process exit, preventing CI pipe teardown races from replacing the product exit contract with SIGPIPE status 141 (#3024).
 
+- Rejected subagent schema payloads now retain their complete structured data in canonical output artifacts; inline results remain bounded while `agent://` output stays lossless (#2894).
 ## [0.11.8] - 2026-07-23
 ### Added
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -486,11 +486,12 @@ function buildSchemaViolationOutcome(
 		missing.length > 0
 			? `schema_violation: missing required fields: ${missing.join(", ")}`
 			: `schema_violation: ${failure.message}`;
+	const dataPreview = previewOffendingData(data);
 	const payload = {
 		error: "schema_violation",
 		message: failure.message,
 		missingRequired: missing,
-		data: previewOffendingData(data),
+		data,
 	};
 	let rawOutput: string;
 	try {
@@ -498,7 +499,7 @@ function buildSchemaViolationOutcome(
 	} catch {
 		rawOutput = `{"error":"schema_violation","message":${JSON.stringify(headline)}}`;
 	}
-	return { rawOutput, stderr: headline, exitCode: 1 };
+	return { rawOutput, stderr: `${headline}. Offending data preview: ${dataPreview}`, exitCode: 1 };
 }
 
 function buildPlaceholderYieldOutcome(
@@ -541,9 +542,16 @@ export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): Fi
 				const completeData = normalizeCompleteData(submitData, reportFindings);
 				const { validator, error: schemaError } = buildOutputValidator(outputSchema);
 				if (schemaError) {
-					rawOutput = `{"error":"schema_violation","message":"invalid output schema: ${schemaError.replace(/"/g, '\\"')}"}`;
-					stderr = `schema_violation: invalid output schema: ${schemaError}`;
-					exitCode = 1;
+					const outcome = buildSchemaViolationOutcome(
+						{
+							message: `invalid output schema: ${schemaError}`,
+							missingRequired: [],
+						},
+						completeData,
+					);
+					rawOutput = outcome.rawOutput;
+					stderr = outcome.stderr;
+					exitCode = outcome.exitCode;
 				} else {
 					const placeholderPath = findPlaceholderYieldPath(completeData);
 					if (placeholderPath) {

--- a/packages/coding-agent/test/task/executor-rejected-payload-artifact.test.ts
+++ b/packages/coding-agent/test/task/executor-rejected-payload-artifact.test.ts
@@ -22,7 +22,14 @@ function createMessage(): AssistantMessage {
 		api: "openai-responses",
 		provider: "openai",
 		model: "mock",
-		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
 		stopReason: "stop",
 		timestamp: Date.now(),
 	};
@@ -49,7 +56,12 @@ function createSession(data: unknown): AgentSession {
 		},
 		prompt: async () => {
 			emit({ type: "message_end", message });
-			emit({ type: "tool_execution_end", toolCallId: "yield-large-rejection", toolName: "yield", result: { content: [], details: { status: "success", data } } });
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "yield-large-rejection",
+				toolName: "yield",
+				result: { content: [], details: { status: "success", data } },
+			});
 			emit({ type: "agent_end", messages: [message], stopReason: "completed" });
 		},
 		waitForIdle: async () => {},
@@ -90,7 +102,11 @@ describe("rejected payload output artifact", () => {
 			subagentId: id,
 			artifactsDir,
 			settings: Settings.isolated(),
-			modelRegistry: { refresh: async () => {}, getAvailable: () => [], getApiKey: async () => kNoAuth } as unknown as import("../../src/config/model-registry").ModelRegistry,
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [],
+				getApiKey: async () => kNoAuth,
+			} as unknown as import("../../src/config/model-registry").ModelRegistry,
 			enableLsp: false,
 			outputSchema: { type: "object", properties: { accepted: { type: "boolean" } }, required: ["accepted"] },
 		});

--- a/packages/coding-agent/test/task/executor-rejected-payload-artifact.test.ts
+++ b/packages/coding-agent/test/task/executor-rejected-payload-artifact.test.ts
@@ -52,7 +52,7 @@ function createSession(data: unknown): AgentSession {
 		setConfiguredModelChain: () => {},
 		getConfiguredModelChain: () => undefined,
 		seedDefaultFallbackResolution: () => {},
-		subscribe: listener => {
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => listeners.splice(listeners.indexOf(listener), 1);
 		},

--- a/packages/coding-agent/test/task/executor-rejected-payload-artifact.test.ts
+++ b/packages/coding-agent/test/task/executor-rejected-payload-artifact.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentEvent } from "@gajae-code/agent-core";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { AsyncJobManager } from "../../src/async/job-manager";
+import { kNoAuth } from "../../src/config/model-registry";
+import { Settings } from "../../src/config/settings";
+import type { LoadExtensionsResult } from "../../src/extensibility/extensions/types";
+import type { CreateAgentSessionResult } from "../../src/sdk";
+import * as sdkModule from "../../src/sdk";
+import type { AgentSession, AgentSessionEvent } from "../../src/session/agent-session";
+import { runSubprocess } from "../../src/task/executor";
+import type { AgentDefinition } from "../../src/task/types";
+import { EventBus } from "../../src/utils/event-bus";
+
+function createMessage(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "submitted rejected payload" }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function createSession(data: unknown): AgentSession {
+	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	const message = createMessage();
+	const emit = (event: AgentEvent) => listeners.forEach(listener => listener(event));
+	return {
+		state: { messages: [] },
+		agent: { state: { systemPrompt: ["test"] } },
+		model: undefined,
+		extensionRunner: undefined,
+		sessionManager: { appendSessionInit: () => {} },
+		getActiveToolNames: () => ["yield"],
+		setActiveToolsByName: async () => {},
+		setConfiguredModelChain: () => {},
+		getConfiguredModelChain: () => undefined,
+		seedDefaultFallbackResolution: () => {},
+		subscribe: listener => {
+			listeners.push(listener);
+			return () => listeners.splice(listeners.indexOf(listener), 1);
+		},
+		prompt: async () => {
+			emit({ type: "message_end", message });
+			emit({ type: "tool_execution_end", toolCallId: "yield-large-rejection", toolName: "yield", result: { content: [], details: { status: "success", data } } });
+			emit({ type: "agent_end", messages: [message], stopReason: "completed" });
+		},
+		waitForIdle: async () => {},
+		getLastAssistantMessage: () => message,
+		abort: async () => {},
+		dispose: async () => {},
+	} as unknown as AgentSession;
+}
+
+describe("rejected payload output artifact", () => {
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		const manager = AsyncJobManager.instance();
+		if (manager) await manager.dispose({ timeoutMs: 100 });
+		AsyncJobManager.setInstance(undefined);
+	});
+
+	it("truncates only the inline output and preserves the complete rejected envelope artifact", async () => {
+		AsyncJobManager.setInstance(new AsyncJobManager({ onJobComplete: async () => {} }));
+		const data = { findings: "x".repeat(500_100), tail: "ARTIFACT-LOSSLESS-TAIL-SENTINEL" };
+		const session = createSession(data);
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue({
+			session,
+			extensionsResult: {} as LoadExtensionsResult,
+			setToolUIContext: () => {},
+			eventBus: new EventBus(),
+		} as CreateAgentSessionResult);
+		const artifactsDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-rejected-payload-"));
+		const id = "0-RejectedPayload";
+		const agent: AgentDefinition = { name: "executor", description: "test", systemPrompt: "test", source: "bundled" };
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "submit rejected payload",
+			index: 0,
+			id,
+			subagentId: id,
+			artifactsDir,
+			settings: Settings.isolated(),
+			modelRegistry: { refresh: async () => {}, getAvailable: () => [], getApiKey: async () => kNoAuth } as unknown as import("../../src/config/model-registry").ModelRegistry,
+			enableLsp: false,
+			outputSchema: { type: "object", properties: { accepted: { type: "boolean" } }, required: ["accepted"] },
+		});
+
+		const artifact = fs.readFileSync(path.join(artifactsDir, `${id}.md`), "utf8");
+		expect(result.truncated).toBe(true);
+		expect(result.output.length).toBeLessThan(artifact.length);
+		expect(JSON.parse(artifact).data).toEqual(data);
+		fs.rmSync(artifactsDir, { recursive: true, force: true });
+	});
+});

--- a/packages/coding-agent/test/task/executor-rejected-payload-artifact.test.ts
+++ b/packages/coding-agent/test/task/executor-rejected-payload-artifact.test.ts
@@ -38,7 +38,9 @@ function createMessage(): AssistantMessage {
 function createSession(data: unknown): AgentSession {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
 	const message = createMessage();
-	const emit = (event: AgentEvent) => listeners.forEach(listener => listener(event));
+	const emit = (event: AgentEvent) => {
+		for (const listener of listeners) listener(event);
+	};
 	return {
 		state: { messages: [] },
 		agent: { state: { systemPrompt: ["test"] } },

--- a/packages/coding-agent/test/task/executor-warnings.test.ts
+++ b/packages/coding-agent/test/task/executor-warnings.test.ts
@@ -204,4 +204,113 @@ describe("subagent warning injection", () => {
 		expect(result.rawOutput.includes("SYSTEM WARNING")).toBe(false);
 		expect(result.exitCode).toBe(0);
 	});
+
+	describe("rejected payload persistence", () => {
+		function rejectedEnvelope(result: ReturnType<typeof finalizeSubprocessOutput>) {
+			return JSON.parse(result.rawOutput) as { error: string; data: unknown };
+		}
+
+		it.each([499, 500, 501])("round-trips a rejected payload serialized to %i UTF-16 code units", length => {
+			const data = "x".repeat(length - 2);
+			expect(JSON.stringify(data)).toHaveLength(length);
+
+			const result = finalizeSubprocessOutput({
+				rawOutput: "ignored",
+				exitCode: 0,
+				stderr: "",
+				doneAborted: false,
+				signalAborted: false,
+				yieldItems: [{ status: "success", data }],
+				outputSchema: { type: "object" },
+			});
+
+			expect(rejectedEnvelope(result).data).toEqual(data);
+		});
+
+		it("preserves unicode and escaped content beyond the former preview boundary", () => {
+			const data = {
+				findings: [
+					{
+						message: `${"a".repeat(497)}😀\"\\\n한국어`,
+						tail: "REJECTED-PAYLOAD-TAIL-SENTINEL",
+					},
+				],
+			};
+			const result = finalizeSubprocessOutput({
+				rawOutput: "ignored",
+				exitCode: 0,
+				stderr: "",
+				doneAborted: false,
+				signalAborted: false,
+				yieldItems: [{ status: "success", data }],
+				outputSchema: { type: "object", properties: { accepted: { type: "boolean" } }, required: ["accepted"] },
+			});
+
+			expect(rejectedEnvelope(result).data).toEqual(data);
+			expect(result.rawOutput).toContain("REJECTED-PAYLOAD-TAIL-SENTINEL");
+		});
+
+		it("preserves long findings in explicit yields, fallback completions, and placeholder rejections", () => {
+			const data = {
+				findings: Array.from({ length: 20 }, (_, index) => ({
+					message: `finding ${index}: ${"detail ".repeat(40)}${index === 19 ? "LONG-FINDINGS-TAIL-SENTINEL" : ""}`,
+				})),
+				tail: "LONG-FINDINGS-TAIL-SENTINEL",
+			};
+			const invalidSchema = { type: "object", properties: { accepted: { type: "boolean" } }, required: ["accepted"] };
+			const explicit = finalizeSubprocessOutput({
+				rawOutput: "ignored",
+				exitCode: 0,
+				stderr: "",
+				doneAborted: false,
+				signalAborted: false,
+				yieldItems: [{ status: "success", data }],
+				outputSchema: invalidSchema,
+			});
+			const fallback = finalizeSubprocessOutput({
+				rawOutput: JSON.stringify({ data: { accepted: true } }),
+				exitCode: 0,
+				stderr: "",
+				doneAborted: false,
+				signalAborted: false,
+				yieldItems: undefined,
+				reportFindings: data.findings,
+				outputSchema: { ...invalidSchema, additionalProperties: false },
+			});
+			const placeholder = finalizeSubprocessOutput({
+				rawOutput: "ignored",
+				exitCode: 0,
+				stderr: "",
+				doneAborted: false,
+				signalAborted: false,
+				yieldItems: [{ status: "success", data: { ...data, plan_markdown: placeholderPlanText } }],
+				outputSchema: undefined,
+			});
+
+			for (const result of [explicit, fallback, placeholder]) {
+				expect(result.exitCode).toBe(1);
+				expect(result.rawOutput).toContain("LONG-FINDINGS-TAIL-SENTINEL");
+			}
+			expect(rejectedEnvelope(explicit).data).toEqual(data);
+			expect(rejectedEnvelope(fallback).data).toEqual({ accepted: true, findings: data.findings });
+			expect(rejectedEnvelope(placeholder).data).toEqual({ ...data, plan_markdown: placeholderPlanText });
+		});
+
+		it("preserves rejected data when the output schema itself is invalid", () => {
+			const data = { tail: "INVALID-SCHEMA-TAIL-SENTINEL", details: "x".repeat(600) };
+			const result = finalizeSubprocessOutput({
+				rawOutput: "ignored",
+				exitCode: 0,
+				stderr: "",
+				doneAborted: false,
+				signalAborted: false,
+				yieldItems: [{ status: "success", data }],
+				outputSchema: "{",
+			});
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toContain("invalid output schema");
+			expect(rejectedEnvelope(result).data).toEqual(data);
+		});
+	});
 });

--- a/packages/coding-agent/test/task/executor-warnings.test.ts
+++ b/packages/coding-agent/test/task/executor-warnings.test.ts
@@ -231,7 +231,7 @@ describe("subagent warning injection", () => {
 			const data = {
 				findings: [
 					{
-						message: `${"a".repeat(497)}😀\"\\\n한국어`,
+						message: `${"a".repeat(497)}😀"\\\n한국어`,
 						tail: "REJECTED-PAYLOAD-TAIL-SENTINEL",
 					},
 				],
@@ -257,7 +257,11 @@ describe("subagent warning injection", () => {
 				})),
 				tail: "LONG-FINDINGS-TAIL-SENTINEL",
 			};
-			const invalidSchema = { type: "object", properties: { accepted: { type: "boolean" } }, required: ["accepted"] };
+			const invalidSchema = {
+				type: "object",
+				properties: { accepted: { type: "boolean" } },
+				required: ["accepted"],
+			};
 			const explicit = finalizeSubprocessOutput({
 				rawOutput: "ignored",
 				exitCode: 0,

--- a/packages/coding-agent/test/task/executor-warnings.test.ts
+++ b/packages/coding-agent/test/task/executor-warnings.test.ts
@@ -253,7 +253,13 @@ describe("subagent warning injection", () => {
 		it("preserves long findings in explicit yields, fallback completions, and placeholder rejections", () => {
 			const data = {
 				findings: Array.from({ length: 20 }, (_, index) => ({
-					message: `finding ${index}: ${"detail ".repeat(40)}${index === 19 ? "LONG-FINDINGS-TAIL-SENTINEL" : ""}`,
+					title: `finding ${index}`,
+					body: `${"detail ".repeat(40)}${index === 19 ? "LONG-FINDINGS-TAIL-SENTINEL" : ""}`,
+					priority: 1,
+					confidence: 1,
+					file_path: "src/example.ts",
+					line_start: 1,
+					line_end: 1,
 				})),
 				tail: "LONG-FINDINGS-TAIL-SENTINEL",
 			};


### PR DESCRIPTION
## Summary
Rejected structured review payloads were physically truncated at 500 UTF-16 code units by `previewOffendingData` before publication — the truncated envelope became the canonical `agent://` artifact (observed 630-byte artifact in #2894), making full review findings permanently unrecoverable.

## Changes
- `buildSchemaViolationOutcome` now persists the actual structured value; `previewOffendingData` is used only for bounded parent-facing stderr diagnostics.
- Invalid-output-schema branch routed through the same lossless builder.
- `truncateTail` applies only to the inline `SingleResult.output` view; the artifact receives the complete raw output.

## Tests
Boundary (499/500/501 code units), unicode surrogate-straddle + escaping + tail sentinel, observed ~630-byte shape regression, inline-truncated-vs-artifact-complete split, and coverage of all four rejection branches. New integration test `executor-rejected-payload-artifact.test.ts`. Focused run: 215 pass / 0 fail across test/task/.

Fixes #2894.