### PR TITLE
feat(github-review): built-in GitHub code-review bot

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -44,6 +44,7 @@ export const commands: CommandEntry[] = [
 	{ name: "team", load: () => import("./commands/team").then(m => m.default) },
 	{ name: "ultragoal", load: () => import("./commands/ultragoal").then(m => m.default) },
 	{ name: "gc", load: () => import("./commands/gc").then(m => m.default) },
+	{ name: "github-review", load: () => import("./commands/github-review").then(m => m.default) },
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },
 	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
 	{ name: "stats", load: () => import("./commands/stats").then(m => m.default) },

--- a/packages/coding-agent/src/commands/github-review.ts
+++ b/packages/coding-agent/src/commands/github-review.ts
@@ -1,0 +1,148 @@
+/**
+ * `gjc github-review` — built-in GitHub code-review bot.
+ *
+ *   serve            run the webhook server (HMAC verify → router → embedded sessions)
+ *   sweep            one-shot sweep (stale check-runs, crashed runs, missed PRs)
+ *   complete R N SHA V   idempotent review completion (invoked by agent turns)
+ *   token            print a fresh App installation token
+ *   gh <args...>     run `gh` authenticated as the App (posting identity)
+ *   status           dump review state entries
+ */
+import { spawn } from "node:child_process";
+import { Args, Command, Flags } from "@gajae-code/utils/cli";
+
+const ACTIONS = new Set(["serve", "sweep", "complete", "token", "gh", "status"]);
+
+export default class GithubReview extends Command {
+	static description = "Built-in GitHub code-review bot (webhook server, sweeper, completion helper)";
+	static strict = false;
+
+	static args = {
+		action: Args.string({ description: "serve|sweep|complete|token|gh|status", required: true }),
+	};
+
+	static flags = {
+		config: Flags.string({ description: "Path to github-review.json config" }),
+		"dry-run": Flags.boolean({ description: "sweep: report only, close nothing", default: false }),
+		json: Flags.boolean({ char: "j", description: "status: machine-readable JSON", default: false }),
+	};
+
+	static examples = [
+		"gjc github-review serve",
+		"gjc github-review sweep --dry-run",
+		"gjc github-review complete owner/repo 42 <sha> success",
+		"gjc github-review gh pr comment 42 --repo owner/repo --body 'hi'",
+	];
+
+	async run(): Promise<void> {
+		const { flags } = await this.parse(GithubReview);
+		const argv = this.argv.filter(a => a !== "--dry-run" && a !== "--json" && a !== "-j");
+		const configFlagIndex = argv.indexOf("--config");
+		if (configFlagIndex >= 0) argv.splice(configFlagIndex, 2);
+		const [action, ...rest] = argv;
+		if (!action || !ACTIONS.has(action)) {
+			console.error(`Unknown github-review action: ${action ?? "(none)"}`);
+			console.error(`Valid actions: ${[...ACTIONS].join(", ")}`);
+			process.exitCode = 2;
+			return;
+		}
+		const { loadGithubReviewConfig } = await import("../github-review/config");
+		const config = loadGithubReviewConfig(flags.config);
+
+		switch (action) {
+			case "serve":
+				return await this.serve(config);
+			case "sweep": {
+				const { ReviewService } = await import("../github-review/service");
+				const { runSweep } = await import("../github-review/sweeper");
+				const result = await runSweep(new ReviewService(config), {
+					dryRun: flags["dry-run"],
+					log: line => console.error(line),
+				});
+				console.log(JSON.stringify(result));
+				return;
+			}
+			case "complete": {
+				const [repo, num, sha, verdict] = rest;
+				const pr = Number(num);
+				if (!repo || !Number.isInteger(pr) || !sha || !verdict) {
+					console.error("usage: gjc github-review complete <owner/repo> <pr> <sha> <success|failure|neutral>");
+					process.exitCode = 2;
+					return;
+				}
+				const { ReviewService } = await import("../github-review/service");
+				const { completeReviewRun } = await import("../github-review/complete");
+				const v = verdict === "success" || verdict === "failure" || verdict === "neutral" ? verdict : "neutral";
+				await completeReviewRun(new ReviewService(config), repo, pr, sha, v);
+				return;
+			}
+			case "token": {
+				const { AppTokenProvider } = await import("../github-review/github");
+				console.log(await new AppTokenProvider(config).token());
+				return;
+			}
+			case "gh": {
+				const { AppTokenProvider } = await import("../github-review/github");
+				const token = await new AppTokenProvider(config).token();
+				const child = spawn("gh", rest, {
+					stdio: "inherit",
+					env: { ...process.env, GH_TOKEN: token, GITHUB_TOKEN: token },
+				});
+				process.exitCode = await new Promise<number>(resolve => child.on("close", code => resolve(code ?? 1)));
+				return;
+			}
+			case "status": {
+				const { ReviewService } = await import("../github-review/service");
+				const service = new ReviewService(config);
+				const entries = Object.fromEntries(service.store.entries());
+				console.log(flags.json ? JSON.stringify(entries) : JSON.stringify(entries, null, 2));
+				return;
+			}
+		}
+	}
+
+	private async serve(config: import("../github-review/config").GithubReviewConfig): Promise<void> {
+		const log = (line: string) => console.log(`${new Date().toISOString()} ${line}`);
+
+		// ── exit guard ──────────────────────────────────────────────────
+		// A daemon embedding the SDK must never let library code kill running
+		// reviews: the session command surface exposes a `shutdown` binding
+		// that calls process.exit(0) (observed in production: clean exits mid-
+		// review). Block foreign exits loudly; only our signal path may exit.
+		const realExit = process.exit.bind(process);
+		let exitAllowed = false;
+		process.exit = ((code?: number) => {
+			if (exitAllowed) return realExit(code);
+			log(`BLOCKED process.exit(${code ?? 0})\n${new Error("exit blocked").stack}`);
+			return undefined as never;
+		}) as typeof process.exit;
+		process.on("beforeExit", code => {
+			log(`beforeExit(${code}) — event loop drained unexpectedly`);
+		});
+
+		const { startGithubReviewServer } = await import("../github-review/server");
+		const server = await startGithubReviewServer(config, log);
+
+		let draining = false;
+		for (const signal of ["SIGTERM", "SIGINT"] as const) {
+			process.on(signal, () => {
+				if (draining) {
+					exitAllowed = true;
+					realExit(0);
+				}
+				draining = true;
+				const { running, queued } = server.runner.status();
+				log(`${signal} — draining (running=${running}, queued=${queued})`);
+				void (async () => {
+					await server.close();
+					await server.runner.drain(150_000);
+					exitAllowed = true;
+					log("drained — exiting");
+					realExit(0);
+				})();
+			});
+		}
+		// Keep serving until a signal arrives.
+		await new Promise<never>(() => {});
+	}
+}

--- a/packages/coding-agent/src/commands/github-review.ts
+++ b/packages/coding-agent/src/commands/github-review.ts
@@ -35,17 +35,18 @@ export default class GithubReview extends Command {
 	];
 
 	async run(): Promise<void> {
-		const { flags } = await this.parse(GithubReview);
-		const argv = this.argv.filter(a => a !== "--dry-run" && a !== "--json" && a !== "-j");
-		const configFlagIndex = argv.indexOf("--config");
-		if (configFlagIndex >= 0) argv.splice(configFlagIndex, 2);
-		const [action, ...rest] = argv;
+		const action = this.argv[0];
 		if (!action || !ACTIONS.has(action)) {
 			console.error(`Unknown github-review action: ${action ?? "(none)"}`);
 			console.error(`Valid actions: ${[...ACTIONS].join(", ")}`);
 			process.exitCode = 2;
 			return;
 		}
+		// `gh` is a raw passthrough: everything after it belongs to gh, so it
+		// must bypass our flag parser (`--json`, `--config` are valid gh flags).
+		if (action === "gh") return await this.gh(this.argv.slice(1));
+		const { flags, argv } = await this.parse(GithubReview);
+		const rest = (argv as string[]).slice(1);
 		const { loadGithubReviewConfig } = await import("../github-review/config");
 		const config = loadGithubReviewConfig(flags.config);
 
@@ -81,16 +82,6 @@ export default class GithubReview extends Command {
 				console.log(await new AppTokenProvider(config).token());
 				return;
 			}
-			case "gh": {
-				const { AppTokenProvider } = await import("../github-review/github");
-				const token = await new AppTokenProvider(config).token();
-				const child = spawn("gh", rest, {
-					stdio: "inherit",
-					env: { ...process.env, GH_TOKEN: token, GITHUB_TOKEN: token },
-				});
-				process.exitCode = await new Promise<number>(resolve => child.on("close", code => resolve(code ?? 1)));
-				return;
-			}
 			case "status": {
 				const { ReviewService } = await import("../github-review/service");
 				const service = new ReviewService(config);
@@ -99,6 +90,18 @@ export default class GithubReview extends Command {
 				return;
 			}
 		}
+	}
+
+	/** Run `gh` authenticated as the App (config from default path / GJC_GHR_* env). */
+	private async gh(args: string[]): Promise<void> {
+		const { loadGithubReviewConfig } = await import("../github-review/config");
+		const { AppTokenProvider } = await import("../github-review/github");
+		const token = await new AppTokenProvider(loadGithubReviewConfig()).token();
+		const child = spawn("gh", args, {
+			stdio: "inherit",
+			env: { ...process.env, GH_TOKEN: token, GITHUB_TOKEN: token },
+		});
+		process.exitCode = await new Promise<number>(resolve => child.on("close", code => resolve(code ?? 1)));
 	}
 
 	private async serve(config: import("../github-review/config").GithubReviewConfig): Promise<void> {

--- a/packages/coding-agent/src/github-review/complete.ts
+++ b/packages/coding-agent/src/github-review/complete.ts
@@ -1,0 +1,118 @@
+/**
+ * Idempotent completion + drain: the single code-owned exit point of a review
+ * run. The LLM turn invokes `gjc github-review complete` as its last step;
+ * the runner invokes it on timeout/crash; the sweeper invokes it for stale
+ * runs. Safe to re-run.
+ *
+ *   1. release the in-flight state lock (ReviewStateStore.completeReview)
+ *   2. close the check-run (by stored check_id, else by sha lookup)
+ *   3. flip the live status line in the marked summary comment (✅ / ❌)
+ *   4. drain: requeue pending (superseded) / queued PRs via a synthetic
+ *      signed webhook POST, paced under the gateway rate limit
+ */
+import * as crypto from "node:crypto";
+import type { ReviewService } from "./service";
+
+export type Verdict = "success" | "failure" | "neutral";
+
+const DRAIN_MAX = 2;
+const DRAIN_PACE_MS = 3000;
+
+/**
+ * Re-trigger a review by POSTing a synthetic signed pull_request event to the
+ * local gateway. Routes through the normal gate → natural dedup.
+ */
+export async function requeueReview(service: ReviewService, repo: string, pr: number, sha: string): Promise<boolean> {
+	const { webhookSecret, localWebhookUrl } = service.config;
+	const payload = {
+		action: "synchronize",
+		number: pr,
+		pull_request: {
+			title: "(review requeue)",
+			draft: false,
+			user: { login: "gjc-review-requeue", type: "User" },
+			head: { ref: "", sha },
+			base: { ref: "" },
+		},
+		repository: { full_name: repo },
+	};
+	const body = Buffer.from(JSON.stringify(payload));
+	const signature = `sha256=${crypto.createHmac("sha256", webhookSecret).update(body).digest("hex")}`;
+	try {
+		const res = await fetch(localWebhookUrl, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-Hub-Signature-256": signature,
+				"X-GitHub-Event": "pull_request",
+				"X-GitHub-Delivery": `gjc-requeue-${crypto.randomUUID()}`,
+				"User-Agent": "gjc-review-requeue",
+			},
+			body,
+		});
+		service.logEvent("requeue", { repo, pr, sha, ok: res.ok });
+		return res.ok;
+	} catch (error) {
+		service.logEvent("requeue_failed", { repo, pr, sha, error: String(error) });
+		return false;
+	}
+}
+
+/** Kick the next waiting review(s), respecting the concurrency cap. */
+export async function drainWaiters(
+	service: ReviewService,
+	exclude?: { repo: string; pr: number },
+	pendingFirst?: { repo: string; pr: number; sha: string },
+): Promise<void> {
+	const todo: Array<{ repo: string; pr: number; sha: string }> = [];
+	if (pendingFirst) todo.push(pendingFirst);
+	const free = Math.max(0, service.config.maxInflight - service.store.countInflight() - todo.length);
+	for (const cand of service.store.findDrainCandidates(free)) {
+		if (exclude && cand.repo === exclude.repo && cand.pr === exclude.pr) continue;
+		todo.push(cand);
+	}
+	for (const [i, item] of todo.slice(0, DRAIN_MAX).entries()) {
+		if (i > 0) await new Promise(resolve => setTimeout(resolve, DRAIN_PACE_MS)); // rate-limit pacing
+		await requeueReview(service, item.repo, item.pr, item.sha);
+	}
+}
+
+/** Finish the review of `sha` on repo#pr. Never throws. */
+export async function completeReviewRun(
+	service: ReviewService,
+	repo: string,
+	pr: number,
+	sha: string,
+	verdict: Verdict,
+): Promise<void> {
+	try {
+		const ok = verdict === "success";
+		const conclusion: Verdict = verdict === "success" || verdict === "failure" ? verdict : "neutral";
+		const result = service.store.completeReview(repo, pr, sha, ok);
+		if (result.stale) {
+			// A newer review owns the lock — just close our own check by sha.
+			await service.closeCheck(repo, sha, null, conclusion);
+			service.logEvent("complete_stale", { repo, pr, sha });
+			return;
+		}
+		const closed = await service.closeCheck(repo, sha, result.checkId, conclusion);
+		const short = sha === "$SHA" ? sha : sha.slice(0, 7);
+		const line = ok
+			? `✅ ${service.config.botDisplayName} 리뷰 완료 (head \`${short}\`)`
+			: `❌ 리뷰가 정상 종료되지 않았어 (head \`${short}\`) — \`${service.mention()} review\` 로 재시도`;
+		await service.upsertStatusLine(repo, pr, line);
+		service.logEvent("complete", {
+			repo,
+			pr,
+			sha,
+			ok,
+			checks_closed: closed,
+			pending: result.pendingSha,
+			duration_s: result.durationSeconds,
+		});
+		await drainWaiters(service, { repo, pr }, result.pendingSha ? { repo, pr, sha: result.pendingSha } : undefined);
+	} catch (error) {
+		// Never leave the caller hanging on our bugs.
+		service.logEvent("complete_error", { repo, pr, sha, error: String(error) });
+	}
+}

--- a/packages/coding-agent/src/github-review/config.ts
+++ b/packages/coding-agent/src/github-review/config.ts
@@ -1,0 +1,173 @@
+/**
+ * Configuration for the built-in GitHub code-review bot.
+ *
+ * One GitHub App webhook drives the whole pipeline: pull_request events start
+ * reviews, issue_comment events carry `@<bot> <command>` commands and PR chat,
+ * and pull_request_review_comment events are inline diff-thread replies.
+ *
+ * Config is a JSON file (default `~/.gjc/github-review.json`) with env
+ * overrides so a launchd/systemd unit can tweak knobs without editing files.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export interface GithubReviewConfig {
+	/** GitHub App id (numeric string). */
+	appId: string;
+	/** Installation id of the App on the target org/user. */
+	installationId: string;
+	/** Path to the App's RS256 private key (.pem). */
+	privateKeyPath: string;
+	/** Webhook HMAC secret (X-Hub-Signature-256). */
+	webhookSecret: string;
+	/** Bot login WITHOUT the `[bot]` suffix (GraphQL identity), e.g. "gajae-code". */
+	botLogin: string;
+	/** Mention aliases that trigger the bot, e.g. ["gajae", "가재"]. */
+	botAliases: string[];
+	/** Display name used in bot prose, e.g. "가재". Defaults to botLogin. */
+	botDisplayName: string;
+	/** Marker/tmp-file prefix (`<!-- <prefix>-summary -->`). Defaults to botLogin. */
+	markerPrefix: string;
+	/** Check-run name shown on PRs. */
+	checkName: string;
+	/** HTTP listen host/port/path for the webhook endpoint. */
+	host: string;
+	port: number;
+	webhookPath: string;
+	/** Max reviews running at once; extra PRs queue in the state store. */
+	maxInflight: number;
+	/** Hard deadline for one review session, in minutes. */
+	turnTimeoutMinutes: number;
+	/** Optional model pattern for review sessions (default: configured default model). */
+	modelPattern?: string;
+	/** Working directory for review sessions (reviews are remote-read-only; any dir works). */
+	cwd: string;
+	/** State/cache/log root (state.json, events.jsonl, learnings/, app token cache). */
+	dataDir: string;
+	/** Repos (substring match, case-insensitive) the bot must never touch. */
+	ignoreRepos: string[];
+	/** Per-repo config filename fetched from the PR head, e.g. ".gajae.yaml". */
+	repoConfigFile: string;
+	/** In-flight reviews older than this are considered crashed (seconds). */
+	inflightStaleSeconds: number;
+	/** Background sweep interval (0 disables the in-process sweeper). */
+	sweepIntervalSeconds: number;
+	/** Check-runs stuck in_progress longer than this get force-closed (minutes). */
+	sweepStaleMinutes: number;
+	/** Command executed by the agent to post as the App, e.g. "gjc github-review gh". */
+	postCommand: string;
+	/** Command executed by the agent to finish a review, e.g. "gjc github-review complete". */
+	completeCommand: string;
+	/** Webhook URL used for self-requeue POSTs (drain path). */
+	localWebhookUrl: string;
+	/** GitHub API base (override for GHES/tests). */
+	apiBase: string;
+}
+
+export const DEFAULT_CONFIG_PATH = path.join(os.homedir(), ".gjc", "github-review.json");
+
+const DEFAULTS = {
+	botAliases: [] as string[],
+	checkName: "GJC Code Review",
+	host: "127.0.0.1",
+	port: 8644,
+	webhookPath: "/webhooks/github-review",
+	maxInflight: 4,
+	turnTimeoutMinutes: 45,
+	ignoreRepos: [] as string[],
+	repoConfigFile: ".gjc-review.yml",
+	inflightStaleSeconds: 20 * 60,
+	sweepIntervalSeconds: 90,
+	sweepStaleMinutes: 10,
+	apiBase: "https://api.github.com",
+};
+
+function readJsonFile(filePath: string): Record<string, unknown> {
+	const raw = fs.readFileSync(filePath, "utf8");
+	const parsed: unknown = JSON.parse(raw);
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new Error(`github-review config must be a JSON object: ${filePath}`);
+	}
+	return parsed as Record<string, unknown>;
+}
+
+function str(v: unknown): string | undefined {
+	return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function num(v: unknown): number | undefined {
+	if (typeof v === "number" && Number.isFinite(v)) return v;
+	if (typeof v === "string" && v.trim() !== "" && Number.isFinite(Number(v))) return Number(v);
+	return undefined;
+}
+
+function strList(v: unknown): string[] | undefined {
+	if (!Array.isArray(v)) return undefined;
+	return v.filter((x): x is string => typeof x === "string");
+}
+
+/**
+ * Load config from `filePath` (or DEFAULT_CONFIG_PATH), applying env overrides
+ * (GJC_GHR_* namespace). Throws with a precise message when a required field
+ * is missing — a review bot with a half-config must fail at startup, not at
+ * the first webhook.
+ */
+export function loadGithubReviewConfig(filePath?: string, env: NodeJS.ProcessEnv = process.env): GithubReviewConfig {
+	const configPath = filePath ?? env.GJC_GHR_CONFIG ?? DEFAULT_CONFIG_PATH;
+	const file = fs.existsSync(configPath) ? readJsonFile(configPath) : {};
+
+	const appId = env.GJC_GHR_APP_ID ?? str(file.appId);
+	const installationId =
+		env.GJC_GHR_INSTALLATION_ID ?? str(file.installationId) ?? num(file.installationId)?.toString();
+	const privateKeyPath = env.GJC_GHR_PRIVATE_KEY ?? str(file.privateKeyPath);
+	const webhookSecret = env.GJC_GHR_WEBHOOK_SECRET ?? str(file.webhookSecret);
+	const botLogin = env.GJC_GHR_BOT_LOGIN ?? str(file.botLogin);
+	const missing = Object.entries({ appId, installationId, privateKeyPath, webhookSecret, botLogin })
+		.filter(([, v]) => !v)
+		.map(([k]) => k);
+	if (missing.length > 0) {
+		throw new Error(`github-review config missing required field(s): ${missing.join(", ")} (config: ${configPath})`);
+	}
+
+	const port = num(env.GJC_GHR_PORT) ?? num(file.port) ?? DEFAULTS.port;
+	const host = env.GJC_GHR_HOST ?? str(file.host) ?? DEFAULTS.host;
+	const webhookPath = str(file.webhookPath) ?? DEFAULTS.webhookPath;
+	const dataDir = env.GJC_GHR_DATA_DIR ?? str(file.dataDir) ?? path.join(os.homedir(), ".gjc", "github-review");
+	const aliases = strList(file.botAliases) ?? DEFAULTS.botAliases;
+
+	return {
+		appId: appId as string,
+		installationId: installationId as string,
+		privateKeyPath: expandHome(privateKeyPath as string),
+		webhookSecret: webhookSecret as string,
+		botLogin: botLogin as string,
+		botAliases: aliases.length > 0 ? aliases : [botLogin as string],
+		botDisplayName: str(file.botDisplayName) ?? (botLogin as string),
+		markerPrefix: str(file.markerPrefix) ?? (botLogin as string),
+		checkName: str(file.checkName) ?? DEFAULTS.checkName,
+		host,
+		port,
+		webhookPath,
+		maxInflight: num(env.GJC_GHR_MAX_INFLIGHT) ?? num(file.maxInflight) ?? DEFAULTS.maxInflight,
+		turnTimeoutMinutes:
+			num(env.GJC_GHR_TURN_TIMEOUT_MIN) ?? num(file.turnTimeoutMinutes) ?? DEFAULTS.turnTimeoutMinutes,
+		modelPattern: env.GJC_GHR_MODEL ?? str(file.modelPattern),
+		cwd: expandHome(env.GJC_GHR_CWD ?? str(file.cwd) ?? os.homedir()),
+		dataDir: expandHome(dataDir),
+		ignoreRepos: strList(file.ignoreRepos) ?? DEFAULTS.ignoreRepos,
+		repoConfigFile: str(file.repoConfigFile) ?? DEFAULTS.repoConfigFile,
+		inflightStaleSeconds:
+			num(env.GJC_GHR_INFLIGHT_STALE_SEC) ?? num(file.inflightStaleSeconds) ?? DEFAULTS.inflightStaleSeconds,
+		sweepIntervalSeconds: num(file.sweepIntervalSeconds) ?? DEFAULTS.sweepIntervalSeconds,
+		sweepStaleMinutes: num(env.GJC_GHR_SWEEP_MIN) ?? num(file.sweepStaleMinutes) ?? DEFAULTS.sweepStaleMinutes,
+		postCommand: str(file.postCommand) ?? "gjc github-review gh",
+		completeCommand: str(file.completeCommand) ?? "gjc github-review complete",
+		localWebhookUrl: str(file.localWebhookUrl) ?? `http://127.0.0.1:${port}${webhookPath}`,
+		apiBase: str(file.apiBase) ?? DEFAULTS.apiBase,
+	};
+}
+
+function expandHome(p: string): string {
+	return p.startsWith("~/") ? path.join(os.homedir(), p.slice(2)) : p;
+}

--- a/packages/coding-agent/src/github-review/github.ts
+++ b/packages/coding-agent/src/github-review/github.ts
@@ -1,0 +1,146 @@
+/**
+ * Minimal GitHub REST access for the review bot: App-JWT minting, installation
+ * token caching, and a thin fetch wrapper. Zero dependencies by design — the
+ * bot posts as the App, reads with the same token, and everything else
+ * (reviews themselves) happens inside agent turns via `gh`.
+ */
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { GithubReviewConfig } from "./config";
+
+function base64url(buf: Buffer): string {
+	return buf.toString("base64").replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+/** RS256 App JWT (9 min lifetime, 1 min clock-skew backdate). */
+export function mintAppJwt(appId: string, privateKeyPem: string, nowEpoch = Math.floor(Date.now() / 1000)): string {
+	const header = base64url(Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })));
+	const payload = base64url(Buffer.from(JSON.stringify({ iat: nowEpoch - 60, exp: nowEpoch + 540, iss: appId })));
+	const signature = crypto.createSign("RSA-SHA256").update(`${header}.${payload}`).sign(privateKeyPem);
+	return `${header}.${payload}.${base64url(signature)}`;
+}
+
+interface CachedToken {
+	token: string;
+	expires_epoch: number;
+}
+
+/**
+ * Installation access token provider with disk + memory caching (tokens live
+ * 1h; refreshed when <5 min remain). `tokenOrEmpty` never throws — callers on
+ * best-effort paths (acks, status lines) skip work when it returns "".
+ */
+export class AppTokenProvider {
+	private cached: CachedToken | null = null;
+	private readonly cachePath: string;
+
+	constructor(
+		private readonly config: Pick<
+			GithubReviewConfig,
+			"appId" | "installationId" | "privateKeyPath" | "apiBase" | "dataDir"
+		>,
+	) {
+		this.cachePath = path.join(config.dataDir, "app-token.json");
+	}
+
+	async token(): Promise<string> {
+		const now = Math.floor(Date.now() / 1000);
+		if (this.cached && this.cached.expires_epoch > now + 300) return this.cached.token;
+		const disk = this.readDiskCache();
+		if (disk && disk.expires_epoch > now + 300) {
+			this.cached = disk;
+			return disk.token;
+		}
+		const pem = fs.readFileSync(this.config.privateKeyPath, "utf8");
+		const jwt = mintAppJwt(this.config.appId, pem, now);
+		const res = await fetch(`${this.config.apiBase}/app/installations/${this.config.installationId}/access_tokens`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${jwt}`,
+				Accept: "application/vnd.github+json",
+				"User-Agent": "gjc-github-review",
+			},
+		});
+		const body = (await res.json()) as { token?: string; expires_at?: string; message?: string };
+		if (!res.ok || !body.token) {
+			throw new Error(`installation token mint failed: ${res.status} ${body.message ?? ""}`);
+		}
+		const expires = body.expires_at ? Math.floor(Date.parse(body.expires_at) / 1000) : now + 3600;
+		this.cached = { token: body.token, expires_epoch: expires };
+		this.writeDiskCache(this.cached);
+		return body.token;
+	}
+
+	async tokenOrEmpty(): Promise<string> {
+		try {
+			return await this.token();
+		} catch {
+			return "";
+		}
+	}
+
+	private readDiskCache(): CachedToken | null {
+		try {
+			const parsed = JSON.parse(fs.readFileSync(this.cachePath, "utf8")) as CachedToken;
+			return typeof parsed.token === "string" && typeof parsed.expires_epoch === "number" ? parsed : null;
+		} catch {
+			return null;
+		}
+	}
+
+	private writeDiskCache(token: CachedToken): void {
+		try {
+			fs.mkdirSync(path.dirname(this.cachePath), { recursive: true });
+			fs.writeFileSync(this.cachePath, JSON.stringify(token), { mode: 0o600 });
+		} catch {
+			/* memory cache still works */
+		}
+	}
+}
+
+export interface GithubRequestOptions {
+	method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+	body?: unknown;
+	token: string;
+	timeoutMs?: number;
+}
+
+/** Thin GitHub REST client. `request` throws; `tryRequest` returns null (best-effort lanes). */
+export class GithubApi {
+	constructor(private readonly apiBase: string) {}
+
+	async request<T = unknown>(apiPath: string, options: GithubRequestOptions): Promise<T> {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? 15_000);
+		try {
+			const res = await fetch(`${this.apiBase}${apiPath}`, {
+				method: options.method ?? "GET",
+				headers: {
+					Authorization: `token ${options.token}`,
+					Accept: "application/vnd.github+json",
+					"User-Agent": "gjc-github-review",
+					...(options.body !== undefined ? { "Content-Type": "application/json" } : {}),
+				},
+				body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+				signal: controller.signal,
+			});
+			if (!res.ok) {
+				const text = await res.text().catch(() => "");
+				throw new Error(`GitHub ${options.method ?? "GET"} ${apiPath} → ${res.status}: ${text.slice(0, 200)}`);
+			}
+			if (res.status === 204) return undefined as T;
+			return (await res.json()) as T;
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+
+	async tryRequest<T = unknown>(apiPath: string, options: GithubRequestOptions): Promise<T | null> {
+		try {
+			return await this.request<T>(apiPath, options);
+		} catch {
+			return null;
+		}
+	}
+}

--- a/packages/coding-agent/src/github-review/index.ts
+++ b/packages/coding-agent/src/github-review/index.ts
@@ -1,0 +1,18 @@
+export { completeReviewRun, drainWaiters, requeueReview, type Verdict } from "./complete";
+export { DEFAULT_CONFIG_PATH, type GithubReviewConfig, loadGithubReviewConfig } from "./config";
+export { AppTokenProvider, GithubApi, mintAppJwt } from "./github";
+export * from "./instructions";
+export { loadRepoConfig, parseMinimalYaml, type RepoReviewConfig } from "./repo-config";
+export { instructionContext, type RouteAction, WebhookRouter } from "./router";
+export { InstructionRunner } from "./runner";
+export { DeliveryLog, type GithubReviewServer, startGithubReviewServer, verifySignature } from "./server";
+export { mentionsBot, parseCommand, ReviewService } from "./service";
+export {
+	appendEvent,
+	type CompleteResult,
+	type DrainCandidate,
+	type GateStatus,
+	type PrState,
+	ReviewStateStore,
+} from "./state";
+export { detectMissedPrs, runSweep, type SweepResult } from "./sweeper";

--- a/packages/coding-agent/src/github-review/instructions.ts
+++ b/packages/coding-agent/src/github-review/instructions.ts
@@ -1,0 +1,300 @@
+/**
+ * Instruction builders for review sessions. Each webhook decision compiles to
+ * ONE self-contained natural-language instruction executed by an embedded
+ * agent session; the agent posts to GitHub itself (via the App-identity `gh`
+ * wrapper) so reviews land as the bot with inline comments and verdicts.
+ *
+ * Hard-won prompt rules encoded here:
+ * - shell redirects/heredocs/pipes are banned (the security guard blocks them
+ *   mid-review); file payloads go through the write tool + `--input`/`--body-file`.
+ * - completion runs through the idempotent complete helper, never a hand-rolled
+ *   check-run PATCH.
+ * - GraphQL author logins have NO `[bot]` suffix; REST logins DO.
+ */
+import type { RepoReviewConfig } from "./repo-config";
+
+export interface InstructionContext {
+	/** Command that runs `gh` with the App installation token (posting identity). */
+	postCmd: string;
+	/** Command that finishes a review run (check-run close, state release, drain). */
+	completeCmd: string;
+	/** Bot login without the `[bot]` suffix (GraphQL identity). */
+	botLogin: string;
+	/** Marker/tmp-file prefix, e.g. "gajae" → `<!-- gajae-summary -->`. */
+	markerPrefix: string;
+	/** Display name used in prose, e.g. "가재". */
+	botDisplayName: string;
+	/** First mention alias, e.g. "@gajae". */
+	mention: string;
+	/** Repos the bot must never act on (defense-in-depth inside chat turns). */
+	ignoreRepos: string[];
+}
+
+export function summaryMarker(ctx: Pick<InstructionContext, "markerPrefix">): string {
+	return `<!-- ${ctx.markerPrefix}-summary -->`;
+}
+
+export function prSummaryMarkers(ctx: Pick<InstructionContext, "markerPrefix">): { open: string; close: string } {
+	return { open: `<!-- ${ctx.markerPrefix}-pr-summary -->`, close: `<!-- /${ctx.markerPrefix}-pr-summary -->` };
+}
+
+function ignoreClause(ctx: InstructionContext): string {
+	if (ctx.ignoreRepos.length === 0) return "";
+	return `다음 리포 관련이면 아무것도 하지 마라: ${ctx.ignoreRepos.join(", ")}.`;
+}
+
+export function helpText(ctx: InstructionContext): string {
+	const m = ctx.mention;
+	return (
+		`🦞 **${ctx.botDisplayName} 명령어**\n` +
+		`- \`${m} review\` — 지금 리뷰\n` +
+		`- \`${m} summary\` — 요약(walkthrough) 갱신\n` +
+		`- \`${m} fix <내용>\` — 수정을 committable suggestion 으로 제안\n` +
+		`- \`${m} resolve\` — 봇 리뷰 스레드 정리\n` +
+		`- \`${m} learn <규칙>\` — 프로젝트 규칙 학습(이후 리뷰 반영)\n` +
+		`- \`${m} pause\` / \`${m} resume\` — 자동 리뷰 정지/재개\n` +
+		`- \`${m} help\` — 도움말`
+	);
+}
+
+function shellQuote(s: string): string {
+	return `'${s.replaceAll("'", `'\\''`)}'`;
+}
+
+/** Post ONE canned reply as the bot. 메시지를 명령에 인라인해서 애매함 제거. */
+export function replyInstr(ctx: InstructionContext, repo: string, num: number, msg: string): string {
+	const cmd = `${ctx.postCmd} pr comment ${num} --repo ${repo} --body ${shellQuote(msg)}`;
+	return (
+		"아래 gh 명령 **딱 하나만 그대로** 실행하고 즉시 종료해라. " +
+		"판단·수정·추가 작업·되묻기 전부 금지. 그냥 이 명령만 실행:\n" +
+		cmd
+	);
+}
+
+/**
+ * Upsert a marked walkthrough summary comment (+ conditional mermaid diagram,
+ * + closing poem, + PR body summary block).
+ */
+export function summaryInstr(ctx: InstructionContext, repo: string, num: number, config?: RepoReviewConfig): string {
+	const cfg = config ?? {};
+	const marker = summaryMarker(ctx);
+	const pb = prSummaryMarkers(ctx);
+	const diagram =
+		cfg.diagrams === false
+			? ""
+			: "변경이 흐름성(API 호출 체인·상태머신·이벤트 플로우)일 때만 mermaid 코드블록(```mermaid) 1개" +
+				"(sequenceDiagram 또는 flowchart)를 표 아래 추가. **확신 없으면 생략**(틀린 다이어그램은 무보다 나쁨). ";
+	const poem =
+		cfg.poem === false
+			? ""
+			: "요약 맨 아래에 이번 변경 내용을 소재로 한 짧은 시 한 편(4~6줄, 한국어, 각 줄 끝 쉼표/느낌표 리듬, " +
+				"라임보다 위트 우선)을 추가 — 형식: 🦞 이모지로 시작하는 인용 블록(각 줄 '> '), " +
+				"마지막 줄에 어울리는 이모지 1~2개. 파일명·기능명을 자연스럽게 녹여라. ";
+	const bodyStep =
+		cfg.pr_summary === false
+			? ""
+			: `5) PR **본문**에도 요약 반영: B=$(gh pr view ${num} --repo ${repo} --json body --jq .body) 로 현재 본문 확보 → ` +
+				`'${pb.open}' 마커 블록이 있으면 그 블록만 교체, 없으면 본문 **끝에** 추가` +
+				`(작성자 원문은 절대 수정 금지. 블록 형식: 마커 줄 + '## 🦞 요약' + 2~4문장 + 마커 닫는 줄 '${pb.close}'). ` +
+				`→ file 도구로 /tmp/${ctx.markerPrefix}-prbody-${num}.md 에 새 본문 전체 저장 후 ` +
+				`${ctx.postCmd} api --method PATCH repos/${repo}/pulls/${num} -F body=@/tmp/${ctx.markerPrefix}-prbody-${num}.md\n`;
+	return (
+		`${repo} PR #${num} 의 walkthrough 요약을 upsert(있으면 갱신, 없으면 생성)한다. ` +
+		"**shell 리다이렉트/heredoc/파이프(`>`,`<<`,`|`) 금지**(보안가드에 막힘):\n" +
+		`1) gh pr diff ${num} --repo ${repo} 로 변경 파악.\n` +
+		`2) 요약 본문(첫 줄 마커 '${marker}' 필수): ## 🦞 Walkthrough + 1~2문장 목적 + 파일별 표. ` +
+		diagram +
+		poem +
+		`→ **file 도구로** /tmp/${ctx.markerPrefix}-summary-${num}.md 에 저장(terminal 아님).\n` +
+		`3) 기존 요약 CID 찾기: CID=$(gh api repos/${repo}/issues/${num}/comments --jq 'map(select(.user.login=="${ctx.botLogin}[bot]" and (.body|contains("${marker}"))))[0].id // empty')\n` +
+		`4) CID 있으면 갱신: ${ctx.postCmd} api --method PATCH repos/${repo}/issues/comments/$CID -F body=@/tmp/${ctx.markerPrefix}-summary-${num}.md\n` +
+		`   없으면 생성:   ${ctx.postCmd} pr comment ${num} --repo ${repo} --body-file /tmp/${ctx.markerPrefix}-summary-${num}.md\n` +
+		bodyStep
+	);
+}
+
+const NOISE_RULES =
+	"노이즈 규칙: 인라인 comments는 확신 높은 것만 최대 8개, nit·사소한 스타일은 comments에 넣지 말고 " +
+	"body 끝 '<details><summary>Nitpicks</summary>' 접힘 블록으로. 수정 제안이 명확하면 그 comment body에 " +
+	"committable suggestion(코드펜스 ```suggestion 열고 다음 줄 고친 코드 ``` 닫기, 해당 라인 정확 매핑 시).";
+
+const REVIEW_JSON =
+	'{"commit_id":"<COMMIT>","event":"COMMENT|REQUEST_CHANGES|APPROVE",' +
+	'"body":"<한국어 요약>","comments":[{"path":"<file>","line":<diff 우측 new 라인>,' +
+	'"side":"RIGHT","body":"<지적>"}]}';
+
+/**
+ * Final step: the single idempotent completion call (check-run close, state
+ * release, pending/queued drain). Owned by code, not the LLM.
+ */
+export function closeLineFor(ctx: InstructionContext, repo: string, num: number, sha: string): string {
+	const note = sha === "$SHA" ? " ($SHA 는 0)에서 확보한 값 리터럴로 치환)" : "";
+	return (
+		"마지막) **반드시**(리뷰 게시 성공/실패 무관) 완료 헬퍼 실행(terminal, 멱등):\n" +
+		`   ${ctx.completeCmd} ${repo} ${num} ${sha} success${note}\n` +
+		"   게시에 실패했으면 success 대신 failure. 체크런 닫기·상태 해제·대기 리뷰 재개를 " +
+		"이 명령 하나가 다 처리한다. check-runs 를 손으로 PATCH 하지 마라.\n"
+	);
+}
+
+export interface BuildReviewOptions {
+	closeLine?: string;
+	force?: boolean;
+	incremental?: boolean;
+	baseSha?: string;
+	config?: RepoReviewConfig;
+	learnings?: string;
+}
+
+/**
+ * Deep review instruction (direct execution). incremental → only commits after
+ * `baseSha` (push re-review). headSha="$SHA" → the agent resolves it.
+ */
+export function buildReview(
+	ctx: InstructionContext,
+	repo: string,
+	num: number,
+	headSha: string,
+	options: BuildReviewOptions = {},
+): string {
+	const { closeLine = "", force = false, incremental = false, baseSha, learnings = "" } = options;
+	const cfg = options.config ?? {};
+	const jsonTemplate = REVIEW_JSON.replace("<COMMIT>", headSha);
+	const fetch =
+		headSha === "$SHA"
+			? `0) head sha 확보: SHA=$(gh pr view ${num} --repo ${repo} --json headRefOid --jq .headRefOid) — JSON의 commit_id에 이 값(리터럴)을 넣어라.\n`
+			: "";
+	const inc = incremental && !!baseSha;
+	const diffCmd = inc ? `gh api repos/${repo}/compare/${baseSha}...${headSha}` : `gh pr diff ${num} --repo ${repo}`;
+	const scope = inc
+		? `증분 리뷰: 지난 리뷰(${(baseSha as string).slice(0, 7)}) 이후 **새 커밋만** 본다. ` +
+			"이미 지적했거나 안 바뀐 코드는 재지적 금지, 새로 생긴 이슈만."
+		: "PR 전체를 리뷰한다.";
+	const dedup =
+		force || inc
+			? ""
+			: "1) 중복 방지: " +
+				`gh api repos/${repo}/pulls/${num}/reviews --jq '[.[]|select(.user.login=="${ctx.botLogin}[bot]")]|length' ` +
+				"→ 0이 아니면 아무것도 하지 말고 종료.\n";
+	const core =
+		`2) 리뷰를 **직접 수행**한다 (read-only, 로컬 파일 수정 금지, 리포 clone 금지). ${scope} ` +
+		`${diffCmd} + 관련 파일로 아키텍처/버그/보안/회귀 점검. ` +
+		`시크릿 스캔: diff를 **file 쓰기 도구로** /tmp/${ctx.markerPrefix}-diff-scan-${num}.txt 에 저장해 ` +
+		`gitleaks detect --no-git --source /tmp/${ctx.markerPrefix}-diff-scan-${num}.txt 실행, ` +
+		"발견 시 해당 라인을 인라인 지적 **최우선**으로 포함. " +
+		`CI 컨텍스트: gh api repos/${repo}/commits/${headSha}/check-runs ` +
+		`--jq '[.check_runs[]|select(.conclusion=="failure")|{name,summary:.output.summary}]' 로 ` +
+		"실패 체크를 확인해 관련 원인 코드에 집중하되, CI 린터가 이미 잡은 항목은 재지적 금지. " +
+		`리뷰 결과는 설명 없이 JSON 하나로 정리한다(게시는 3에서): ${jsonTemplate}. ` +
+		`라인 앵커 불확실하면 comments에서 빼라. ${NOISE_RULES}\n`;
+	let extras = "";
+	if (learnings) extras += `이 리포 학습된 규칙(반드시 반영, 아래에 어긋나면 지적 말 것):\n${learnings}\n`;
+	if (cfg.ignore_paths?.length) extras += `제외 경로(리뷰/코멘트 하지 마): ${cfg.ignore_paths.join(", ")}\n`;
+	if (cfg.max_comments) extras += `인라인 코멘트는 최대 ${cfg.max_comments}개로 제한.\n`;
+	if (cfg.tone) extras += `톤: ${cfg.tone}\n`;
+	for (const pi of cfg.path_instructions ?? []) {
+		if (pi?.path && pi.instructions) {
+			extras += `경로별 지침 — \`${pi.path}\` 에 해당하는 파일: ${pi.instructions}\n`;
+		}
+	}
+	const post =
+		"3) 리뷰 JSON을 App 명의로 게시. **shell 리다이렉트/heredoc/파이프(`>`, `<<`, `|`, cat, echo) 전부 금지**" +
+		"(보안 가드가 승인 대기로 막아 리뷰가 실패한다). 반드시 이 2단계로:\n" +
+		`   ① **file 쓰기 도구(write)로** JSON을 /tmp/${ctx.markerPrefix}-review-${num}.json 에 저장 ` +
+		"(terminal 아님! file 도구로 직접 write).\n" +
+		`   ② terminal로 게시: ${ctx.postCmd} api --method POST repos/${repo}/pulls/${num}/reviews ` +
+		`--input /tmp/${ctx.markerPrefix}-review-${num}.json\n` +
+		"   JSON 깨졌으면 comments 빼고 body만이라도 반드시 게시.\n";
+	const outdated = !inc
+		? ""
+		: "4.5) **해소된 이전 지적 정리**: 이번 diff 에서 변경/삭제된 라인의 봇 스레드만 GraphQL 로 resolve" +
+			`(reviewThreads 조회 → isResolved=false + 작성자 login == "${ctx.botLogin}" ` +
+			`(**GraphQL 은 \`[bot]\` 접미사가 없다** — "${ctx.botLogin}[bot]" 으로 비교하면 전부 미스난다) ` +
+			"+ **해당 파일·라인이 이번 push 로 바뀐 것만** resolveReviewThread — 뮤테이션은 **반드시 일반 gh**(사용자 토큰)로, " +
+			"App 토큰은 FORBIDDEN 난다). 애매하면 건드리지 마라.\n";
+	const summary = `4) 게시 후 walkthrough 요약 upsert:\n${summaryInstr(ctx, repo, num, cfg)}`;
+	return (
+		`GitHub ${repo} PR #${num} 자동 코드리뷰 (head ${headSha}, ${inc ? "증분" : "전체"}). ` +
+		"게시는 terminal로 직접, aside 금지. 인사말 없이 한국어로.\n" +
+		"⚠️ 리포를 clone 하지 마라. `git clone`·`rm`·로컬 git 조작·파일 리다이렉트(`>`) 전부 금지" +
+		"(보안 가드에 막혀 리뷰가 실패한다). 변경은 오직 `gh pr diff` / `gh api .../compare` 로만 본다.\n" +
+		`${extras}\n${fetch}${dedup}${core}${post}${summary}${outdated}${closeLine}`
+	);
+}
+
+/** Force a review from a command. sha="$SHA" → agent resolves it (fail-open). */
+export function forceReviewInstr(ctx: InstructionContext, repo: string, num: number, sha = "$SHA"): string {
+	return `지금 강제 리뷰한다(기존 봇 리뷰 있어도 무시).\n${buildReview(ctx, repo, num, sha, {
+		closeLine: closeLineFor(ctx, repo, num, sha),
+		force: true,
+	})}`;
+}
+
+/** `<mention> fix` — 코드를 push/commit 하지 않고 committable suggestion 으로만 제안(안전). */
+export function fixInstr(ctx: InstructionContext, repo: string, num: number, args: string): string {
+	return (
+		`'${ctx.mention} fix' 요청: "${args}". **절대 push/commit/브랜치 수정 금지 — suggestion 으로만** 처리(terminal):\n` +
+		`0) SHA=$(gh pr view ${num} --repo ${repo} --json headRefOid --jq .headRefOid)\n` +
+		`1) gh pr diff ${num} --repo ${repo} 로 코드 확인(read-only — 로컬 수정·게시 금지).\n` +
+		"2) 수정을 committable suggestion 으로 게시(작성자 1클릭 커밋): " +
+		`${ctx.postCmd} api --method POST repos/${repo}/pulls/${num}/reviews 로 ` +
+		"event=COMMENT, commit_id=$SHA, comments 각 body 에 ```suggestion 블록(해당 라인). " +
+		"suggestion 으로 표현 안 되면 코멘트로 설명+코드블록.\n" +
+		`${ignoreClause(ctx)} 인사말 없이 한국어로.`
+	);
+}
+
+/** `<mention> resolve` — 봇의 unresolved 리뷰 스레드를 GraphQL 로 정리. */
+export function resolveInstr(ctx: InstructionContext, repo: string, num: number): string {
+	const [owner, name] = repo.split("/");
+	return (
+		`이 PR #${num}의 ${ctx.botLogin}[bot] 리뷰 스레드를 정리(resolve)한다. terminal, GraphQL 로:\n` +
+		`1) reviewThreads 조회: gh api graphql -f query='{ repository(owner:"${owner}",name:"${name}"){ pullRequest(number:${num})` +
+		"{ reviewThreads(first:100){ nodes{ id isResolved comments(first:1){nodes{author{login}}} } } } } }'\n" +
+		`2) isResolved=false 이고 첫 코멘트 author.login 이 "${ctx.botLogin}" 인 thread 마다` +
+		`(**GraphQL 은 \`[bot]\` 접미사 없음** — "${ctx.botLogin}[bot]" 비교는 전부 미스): ` +
+		"gh api graphql -f query='mutation{ resolveReviewThread(input:{threadId:\"<ID>\"}){ thread{ id } } }'\n" +
+		`3) 끝나면 '${ctx.botDisplayName} 리뷰 스레드 정리 완료' 코멘트 한 개(이건 ${ctx.postCmd}). ` +
+		`뮤테이션은 **반드시 일반 gh**(사용자 토큰) — App 토큰은 FORBIDDEN. ${ignoreClause(ctx)}`
+	);
+}
+
+/** Inline diff-thread reply (pull_request_review_comment mentioning the bot). */
+export function reviewThreadReplyInstr(
+	ctx: InstructionContext,
+	repo: string,
+	num: number,
+	comment: { id: number; login: string; path?: string; line?: number | null; diffHunk?: string; body: string },
+): string {
+	return (
+		`GitHub ${repo} PR #${num} 의 diff 라인 인라인 코멘트에서 ${comment.login} 가 ${ctx.botDisplayName}(너)를 불렀다.\n` +
+		`파일 ${comment.path} 라인 ${comment.line} 근처:\n` +
+		`diff hunk:\n${comment.diffHunk}\n` +
+		`코멘트:\n---\n${comment.body}\n---\n\n` +
+		"이 줄에 대한 질문에 한국어 반말로 정확히 답한다. 코드 판단이 필요하면 " +
+		"질문에 답하는 데 필요한 **최소 범위**(해당 파일+직접 의존 1~3개)만 gh 로 확인, 전체 PR 재검증 금지.\n" +
+		"답은 반드시 같은 스레드에, App 명의로 단다:\n" +
+		`  ${ctx.postCmd} api --method POST repos/${repo}/pulls/${num}/comments/${comment.id}/replies -f body='<답>'\n` +
+		ignoreClause(ctx)
+	);
+}
+
+/** PR conversation chat (issue_comment mentioning the bot, no command). */
+export function chatInstr(
+	ctx: InstructionContext,
+	repo: string,
+	num: number,
+	title: string,
+	login: string,
+	body: string,
+): string {
+	return (
+		`GitHub ${repo} PR #${num} "${title}" 코멘트에서 ${login} 가 ${ctx.botDisplayName}(너)를 불렀다:\n` +
+		`---\n${body}\n---\n\n` +
+		"한국어 반말로 답한다. 코드/저장소 작업이 필요하면 직접 수행" +
+		"(조회는 gh, 리포 clone·로컬 수정 금지)하고 결과를 요약, 단순 질문·대화면 바로 답. 핵심만.\n" +
+		"답은 이 PR에 App 명의로 코멘트한다:\n" +
+		`  ${ctx.postCmd} pr comment ${num} --repo ${repo} --body '<답>'\n` +
+		ignoreClause(ctx)
+	);
+}

--- a/packages/coding-agent/src/github-review/repo-config.ts
+++ b/packages/coding-agent/src/github-review/repo-config.ts
@@ -1,0 +1,108 @@
+/**
+ * Per-repo review config, fetched from the PR head ref (e.g. `.gjc-review.yml`).
+ *
+ * Supported keys: enabled(bool), max_comments(int), tone(str),
+ * ignore_paths(list[str]), pr_summary(bool), diagrams(bool), poem(bool),
+ * path_instructions(list[{path, instructions}]).
+ *
+ * The parser is a deliberate YAML subset (flat scalars, simple lists, lists
+ * of small maps) so the bot stays dependency-free; unknown shapes degrade to
+ * "no config" rather than failing a review.
+ */
+import type { GithubApi } from "./github";
+
+export interface RepoReviewConfig {
+	enabled?: boolean;
+	max_comments?: number;
+	tone?: string;
+	ignore_paths?: string[];
+	pr_summary?: boolean;
+	diagrams?: boolean;
+	poem?: boolean;
+	path_instructions?: Array<{ path?: string; instructions?: string }>;
+	[key: string]: unknown;
+}
+
+function scalar(raw: string): string | number | boolean {
+	const v = raw.trim().replace(/^["']|["']$/g, "");
+	if (/^(true|false)$/i.test(v)) return v.toLowerCase() === "true";
+	if (/^-?\d+$/.test(v)) return Number(v);
+	return v;
+}
+
+/** Tiny YAML subset parser — see module doc for the supported shapes. */
+export function parseMinimalYaml(text: string): Record<string, unknown> {
+	const doc: Record<string, unknown> = {};
+	let currentList: string | null = null;
+	for (const rawLine of text.split("\n")) {
+		const line = rawLine.replace(/\s+$/, "");
+		const s = line.trim();
+		if (!s || s.startsWith("#")) continue;
+		const list = currentList !== null ? doc[currentList] : undefined;
+		if (s.startsWith("- ") && Array.isArray(list)) {
+			const item = s.slice(2).trim();
+			const colon = item.indexOf(":");
+			if (colon > 0) {
+				// list-of-maps item: `- path: "x"`
+				list.push({ [item.slice(0, colon).trim()]: scalar(item.slice(colon + 1)) });
+			} else {
+				list.push(item.replace(/^["']|["']$/g, ""));
+			}
+			continue;
+		}
+		if (/^[ \t]/.test(line) && s.includes(":") && Array.isArray(list) && list.length > 0) {
+			const last = list[list.length - 1];
+			if (typeof last === "object" && last !== null && !Array.isArray(last)) {
+				// continuation key of the current map item: `  instructions: ...`
+				const colon = s.indexOf(":");
+				(last as Record<string, unknown>)[s.slice(0, colon).trim()] = scalar(s.slice(colon + 1));
+				continue;
+			}
+		}
+		if (line.includes(":") && !/^[ \t]/.test(line)) {
+			const colon = line.indexOf(":");
+			const key = line.slice(0, colon).trim();
+			const value = line.slice(colon + 1).trim();
+			if (value === "") {
+				doc[key] = [];
+				currentList = key;
+				continue;
+			}
+			currentList = null;
+			if (value.startsWith("[") && value.endsWith("]")) {
+				doc[key] = value
+					.slice(1, -1)
+					.split(",")
+					.map(x => x.trim().replace(/^["']|["']$/g, ""))
+					.filter(x => x.length > 0);
+			} else {
+				doc[key] = scalar(value);
+			}
+		}
+	}
+	return doc;
+}
+
+/**
+ * Load the repo config file at `ref`. Returns {} on absence or any failure —
+ * a broken config file must never block reviews.
+ */
+export async function loadRepoConfig(
+	api: GithubApi,
+	token: string,
+	repo: string,
+	ref: string,
+	fileName: string,
+): Promise<RepoReviewConfig> {
+	if (!token) return {};
+	const res = await api.tryRequest<{ content?: string }>(
+		`/repos/${repo}/contents/${encodeURIComponent(fileName)}?ref=${encodeURIComponent(ref)}`,
+		{ token, timeoutMs: 5000 },
+	);
+	if (!res?.content) return {};
+	try {
+		return parseMinimalYaml(Buffer.from(res.content, "base64").toString("utf8")) as RepoReviewConfig;
+	} catch {
+		return {};
+	}
+}

--- a/packages/coding-agent/src/github-review/router.ts
+++ b/packages/coding-agent/src/github-review/router.ts
@@ -1,0 +1,278 @@
+/**
+ * Single-route webhook router. A GitHub App has ONE webhook URL, so
+ * pull_request / issue_comment / pull_request_review_comment all land here.
+ * The router inspects the payload, applies the review gate, fires immediate
+ * acks (reaction, check-run, status line), and returns either an instruction
+ * to run in an embedded agent session or a silent skip with a reason.
+ *
+ * Review lifecycle (gate → ack → run → complete):
+ *   gate     — ReviewStateStore.tryAcquireReview CAS: dedup same-sha,
+ *              supersede on newer sha, queue past the concurrency cap.
+ *   ack      — check-run `in_progress` + live ⏳ status line (best-effort).
+ *   complete — the review prompt ends with the complete command, the single
+ *              idempotent owner of check-run close / state release / drain.
+ *              The sweeper covers crashed runs.
+ */
+import type { GithubReviewConfig } from "./config";
+import {
+	buildReview,
+	chatInstr,
+	closeLineFor,
+	fixInstr,
+	forceReviewInstr,
+	helpText,
+	type InstructionContext,
+	replyInstr,
+	resolveInstr,
+	reviewThreadReplyInstr,
+	summaryInstr,
+} from "./instructions";
+import { loadRepoConfig } from "./repo-config";
+import type { ReviewService } from "./service";
+import { mentionsBot, parseCommand } from "./service";
+
+const REVIEW_ACTIONS = new Set(["opened", "reopened", "ready_for_review", "synchronize"]);
+
+export type RouteAction =
+	| { kind: "silent"; reason: string }
+	| { kind: "run"; instruction: string; review?: { repo: string; pr: number; sha: string } };
+
+function silent(reason: string): RouteAction {
+	return { kind: "silent", reason };
+}
+
+function run(instruction: string, review?: { repo: string; pr: number; sha: string }): RouteAction {
+	return { kind: "run", instruction, ...(review ? { review } : {}) };
+}
+
+interface GithubUser {
+	login?: string;
+	type?: string;
+}
+
+/** Loop guard: skip bot-authored events (incl. our own posts). */
+function isBot(user: GithubUser): boolean {
+	return user.type === "Bot" || (user.login ?? "").endsWith("[bot]");
+}
+
+export function instructionContext(config: GithubReviewConfig): InstructionContext {
+	return {
+		postCmd: config.postCommand,
+		completeCmd: config.completeCommand,
+		botLogin: config.botLogin,
+		markerPrefix: config.markerPrefix,
+		botDisplayName: config.botDisplayName,
+		mention: `@${config.botAliases[0]}`,
+		ignoreRepos: config.ignoreRepos,
+	};
+}
+
+export class WebhookRouter {
+	private readonly ctx: InstructionContext;
+
+	constructor(
+		private readonly config: GithubReviewConfig,
+		private readonly service: ReviewService,
+	) {
+		this.ctx = instructionContext(config);
+	}
+
+	async route(payload: Record<string, unknown>): Promise<RouteAction> {
+		const repo = ((payload.repository as { full_name?: string } | undefined)?.full_name ?? "").trim();
+		if (!repo) return silent("no repository");
+		const lower = repo.toLowerCase();
+		if (this.config.ignoreRepos.some(ig => lower.includes(ig.toLowerCase()))) {
+			return silent("ignored repo");
+		}
+
+		const comment = payload.comment as Record<string, unknown> | undefined;
+		if (comment && (comment.pull_request_review_id !== undefined || comment.path !== undefined)) {
+			return await this.routeReviewComment(payload, repo, comment);
+		}
+		if (comment) return await this.routeIssueComment(payload, repo, comment);
+		if (payload.pull_request) return await this.routePullRequest(payload, repo);
+		return silent("unhandled event shape");
+	}
+
+	// ── mode: inline diff-line thread reply (pull_request_review_comment) ──
+	private async routeReviewComment(
+		payload: Record<string, unknown>,
+		repo: string,
+		comment: Record<string, unknown>,
+	): Promise<RouteAction> {
+		if (payload.action !== "created") return silent("review-comment action");
+		const user = (comment.user ?? {}) as GithubUser;
+		if (isBot(user)) return silent("bot author");
+		const body = (comment.body as string | undefined) ?? "";
+		if (!mentionsBot(body, this.config.botAliases)) return silent("no trigger");
+		await this.service.ackReaction(repo, comment.id as number | undefined, true);
+		const pr = (payload.pull_request ?? {}) as { number?: number };
+		const num = pr.number ?? 0;
+		return run(
+			reviewThreadReplyInstr(this.ctx, repo, num, {
+				id: (comment.id as number) ?? 0,
+				login: user.login ?? "",
+				path: comment.path as string | undefined,
+				line: comment.line as number | null,
+				diffHunk: comment.diff_hunk as string | undefined,
+				body,
+			}),
+		);
+	}
+
+	// ── mode: PR conversation chat / commands (issue_comment) ──
+	private async routeIssueComment(
+		payload: Record<string, unknown>,
+		repo: string,
+		comment: Record<string, unknown>,
+	): Promise<RouteAction> {
+		const action = payload.action as string | undefined;
+		if (action !== "created" && action !== "edited") return silent("issue-comment action");
+		const issue = (payload.issue ?? {}) as { number?: number; title?: string; pull_request?: unknown };
+		if (issue.pull_request === undefined) return silent("not a PR comment");
+		const user = (comment.user ?? {}) as GithubUser;
+		if (isBot(user)) return silent("bot author");
+		const body = (comment.body as string | undefined) ?? "";
+		const num = issue.number ?? 0;
+		const command = parseCommand(body, this.config.botAliases);
+		if (command) {
+			await this.service.ackReaction(repo, comment.id as number | undefined);
+			const handled = await this.handleCommand(command.cmd, command.args, repo, num);
+			if (handled) return handled;
+		}
+		if (action === "edited") return silent("edited without new command"); // 중복 채팅 응답 방지
+		if (!mentionsBot(body, this.config.botAliases)) return silent("no trigger");
+		await this.service.ackReaction(repo, comment.id as number | undefined);
+		return run(chatInstr(this.ctx, repo, num, issue.title ?? "", user.login ?? "", body));
+	}
+
+	/** Handle `<mention> <cmd>`. Returns null for unrecognized commands (falls through to chat). */
+	private async handleCommand(cmd: string, args: string, repo: string, num: number): Promise<RouteAction | null> {
+		switch (cmd) {
+			case "help":
+				return run(replyInstr(this.ctx, repo, num, helpText(this.ctx)));
+			case "summary":
+				return run(summaryInstr(this.ctx, repo, num));
+			case "fix":
+				return run(fixInstr(this.ctx, repo, num, args));
+			case "resolve":
+				return run(resolveInstr(this.ctx, repo, num));
+			case "review":
+				return await this.handleReviewCommand(repo, num);
+			case "pause":
+				this.service.store.setPrState(repo, num, { paused: true });
+				return run(
+					replyInstr(
+						this.ctx,
+						repo,
+						num,
+						`⏸️ 이 PR 자동 리뷰 일시정지했어. \`${this.ctx.mention} resume\` 로 재개.`,
+					),
+				);
+			case "resume":
+				this.service.store.setPrState(repo, num, { paused: false });
+				return run(
+					replyInstr(
+						this.ctx,
+						repo,
+						num,
+						`▶️ 자동 리뷰 재개. \`${this.ctx.mention} review\` 로 지금 바로 돌릴 수도 있어.`,
+					),
+				);
+			case "learn":
+				this.service.addLearning(repo, args);
+				return run(replyInstr(this.ctx, repo, num, `🧠 학습함: ${args}  (이후 리뷰에 반영할게.)`));
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * `<mention> review` — same gate as the auto path (in-flight dedup /
+	 * supersede / queue), then a forced review. Fail-open to the $SHA agent
+	 * flow when the head sha can't be resolved in budget.
+	 */
+	private async handleReviewCommand(repo: string, num: number): Promise<RouteAction> {
+		const sha = await this.service.fetchHeadSha(repo, num);
+		if (!sha) {
+			this.service.logEvent("cmd_review_no_sha", { repo, pr: num });
+			return run(forceReviewInstr(this.ctx, repo, num));
+		}
+		const { status, state } = this.service.store.tryAcquireReview(repo, num, sha, this.config.maxInflight);
+		this.service.logEvent("trigger", { mode: "cmd_review", repo, pr: num, sha, gate: status });
+		switch (status) {
+			case "duplicate": {
+				if (state.dup_notified_sha === sha) return silent("duplicate already notified"); // 재알림 스팸 금지
+				this.service.store.setPrState(repo, num, { dup_notified_sha: sha });
+				return run(
+					replyInstr(
+						this.ctx,
+						repo,
+						num,
+						`⏳ 이미 이 커밋(\`${sha.slice(0, 7)}\`) 리뷰가 돌고 있어. 끝나면 결과가 올라온다.`,
+					),
+				);
+			}
+			case "superseded":
+				return run(
+					replyInstr(
+						this.ctx,
+						repo,
+						num,
+						`⏳ 진행 중인 리뷰가 끝나는 대로 최신 커밋(\`${sha.slice(0, 7)}\`)으로 다시 리뷰할게.`,
+					),
+				);
+			case "queued":
+				return run(
+					replyInstr(
+						this.ctx,
+						repo,
+						num,
+						"⏳ 동시 리뷰 상한에 걸려 대기열에 넣었어. 차례가 오면 자동으로 시작한다.",
+					),
+				);
+			default: {
+				await this.service.startReviewAcks(repo, num, sha);
+				return run(forceReviewInstr(this.ctx, repo, num, sha), { repo, pr: num, sha });
+			}
+		}
+	}
+
+	// ── mode: full code review (pull_request opened/reopened/ready/sync) ──
+	private async routePullRequest(payload: Record<string, unknown>, repo: string): Promise<RouteAction> {
+		const action = payload.action as string | undefined;
+		if (!action || !REVIEW_ACTIONS.has(action)) return silent("pr action");
+		const pr = payload.pull_request as {
+			draft?: boolean;
+			user?: GithubUser;
+			head?: { sha?: string };
+		};
+		if (pr.draft) return silent("draft");
+		if (isBot(pr.user ?? {})) return silent("bot author");
+		const num = (payload.number as number | undefined) ?? 0;
+		const prState = this.service.store.getPrState(repo, num);
+		if (prState.paused) return silent("paused"); // `<mention> pause` 된 PR은 자동 리뷰 안 함
+		const headSha = pr.head?.sha ?? "";
+		const token = await this.service.tokens.tokenOrEmpty();
+		const cfg = await loadRepoConfig(this.service.api, token, repo, headSha, this.config.repoConfigFile);
+		if (cfg.enabled === false) return silent("disabled by repo config");
+		const lastSha = prState.last_reviewed_sha;
+		if (lastSha && lastSha === headSha) return silent("sha already reviewed"); // 재배달/무변경 push 방지
+
+		const { status } = this.service.store.tryAcquireReview(repo, num, headSha, this.config.maxInflight);
+		this.service.logEvent("trigger", { mode: "auto", action, repo, pr: num, sha: headSha, gate: status });
+		if (status !== "acquired") return silent(`gate ${status}`); // 완료헬퍼·sweeper가 이어받음
+
+		const incremental = action === "synchronize" && !!lastSha;
+		await this.service.startReviewAcks(repo, num, headSha);
+		const learnings = this.service.getLearnings(repo);
+		const instruction = buildReview(this.ctx, repo, num, headSha, {
+			closeLine: closeLineFor(this.ctx, repo, num, headSha),
+			incremental,
+			baseSha: lastSha,
+			config: cfg,
+			learnings,
+		});
+		return run(instruction, { repo, pr: num, sha: headSha });
+	}
+}

--- a/packages/coding-agent/src/github-review/runner.ts
+++ b/packages/coding-agent/src/github-review/runner.ts
@@ -1,0 +1,105 @@
+/**
+ * Executes router instructions in embedded agent sessions with a concurrency
+ * cap and a hard per-turn deadline.
+ *
+ * Reviews carry `{repo, pr, sha}` metadata: when a review session ends
+ * abnormally (timeout, error, abort) the runner force-completes the run as a
+ * failure immediately instead of waiting for the sweeper — check-run closed,
+ * state released, waiters drained.
+ */
+import { completeReviewRun } from "./complete";
+import type { RouteAction } from "./router";
+import type { ReviewService } from "./service";
+
+export interface RunnerStatus {
+	running: number;
+	queued: number;
+}
+
+export class InstructionRunner {
+	private running = 0;
+	private readonly waiters: Array<() => void> = [];
+
+	constructor(
+		private readonly service: ReviewService,
+		private readonly log: (line: string) => void = () => {},
+	) {}
+
+	status(): RunnerStatus {
+		return { running: this.running, queued: this.waiters.length };
+	}
+
+	/** Wait until all running sessions finish (graceful drain), up to `timeoutMs`. */
+	async drain(timeoutMs: number): Promise<boolean> {
+		const deadline = Date.now() + timeoutMs;
+		while (this.running > 0 && Date.now() < deadline) {
+			await new Promise(resolve => setTimeout(resolve, 500));
+		}
+		return this.running === 0;
+	}
+
+	private async withSlot<T>(fn: () => Promise<T>): Promise<T> {
+		if (this.running >= this.service.config.maxInflight) {
+			await new Promise<void>(resolve => this.waiters.push(resolve));
+		}
+		this.running += 1;
+		try {
+			return await fn();
+		} finally {
+			this.running -= 1;
+			this.waiters.shift()?.();
+		}
+	}
+
+	/** Fire-and-forget entry point: GitHub expects a fast 200; reviews run for minutes. */
+	dispatch(delivery: string, action: Extract<RouteAction, { kind: "run" }>): void {
+		void this.execute(delivery, action).catch(async error => {
+			this.log(`[${delivery}] session failed: ${String(error).slice(0, 600)}`);
+			if (action.review) {
+				await completeReviewRun(this.service, action.review.repo, action.review.pr, action.review.sha, "failure");
+			}
+		});
+	}
+
+	private async execute(delivery: string, action: Extract<RouteAction, { kind: "run" }>): Promise<void> {
+		await this.withSlot(async () => {
+			const started = Date.now();
+			const { config } = this.service;
+			this.log(`[${delivery}] session start (running=${this.running})`);
+			// Lazy: pulls in the full SDK (incl. native addons) only when a
+			// session actually starts, keeping CLI/tests light.
+			const { createAgentSession } = await import("../sdk/session");
+			const { session } = await createAgentSession({
+				cwd: config.cwd,
+				...(config.modelPattern ? { modelPattern: config.modelPattern } : {}),
+			});
+			const { promise, resolve } = Promise.withResolvers<string | null>();
+			const unsubscribe = session.subscribe(event => {
+				if (event.type !== "agent_end") return;
+				const stopReason = (event as { stopReason?: string }).stopReason;
+				if (stopReason === "maintenance") return;
+				resolve(stopReason ?? null);
+			});
+			const deadline = setTimeout(() => {
+				resolve("review_timeout");
+				void session.abort().catch(() => {});
+			}, config.turnTimeoutMinutes * 60_000);
+			let stopReason: string | null = null;
+			try {
+				await session.prompt(action.instruction);
+				stopReason = await promise;
+				const mins = Math.round((Date.now() - started) / 60_000);
+				this.log(`[${delivery}] session end (${stopReason}, ${mins}min)`);
+			} finally {
+				clearTimeout(deadline);
+				unsubscribe();
+				await session.dispose().catch(() => {});
+			}
+			if (action.review && stopReason !== "completed" && stopReason !== null) {
+				// Abnormal end (timeout/error/abort): the in-turn complete step never
+				// ran — finish the lifecycle as a failure now (idempotent if it did).
+				await completeReviewRun(this.service, action.review.repo, action.review.pr, action.review.sha, "failure");
+			}
+		});
+	}
+}

--- a/packages/coding-agent/src/github-review/server.ts
+++ b/packages/coding-agent/src/github-review/server.ts
@@ -1,0 +1,162 @@
+/**
+ * GitHub webhook HTTP server for the review bot.
+ *
+ *   GitHub (or tunnel) → POST <webhookPath> → HMAC verify → delivery dedup →
+ *   router → embedded agent session (fire-and-forget; GitHub gets a fast 200).
+ *
+ * GET /health reports runner load so deploy scripts can avoid restarting the
+ * process while reviews are running. An in-process sweeper runs on an
+ * interval (no external cron needed).
+ */
+import * as crypto from "node:crypto";
+import * as http from "node:http";
+import type { GithubReviewConfig } from "./config";
+import { WebhookRouter } from "./router";
+import { InstructionRunner } from "./runner";
+import { ReviewService } from "./service";
+import { runSweep } from "./sweeper";
+
+const ALLOWED_EVENTS = new Set(["pull_request", "issue_comment", "pull_request_review_comment"]);
+
+/** Constant-time HMAC check of X-Hub-Signature-256. */
+export function verifySignature(secret: string, body: Uint8Array, header: string | null | undefined): boolean {
+	if (!header?.startsWith("sha256=")) return false;
+	const expected = crypto.createHmac("sha256", secret).update(body).digest("hex");
+	const got = header.slice("sha256=".length);
+	if (got.length !== expected.length) return false;
+	return crypto.timingSafeEqual(Buffer.from(got, "utf8"), Buffer.from(expected, "utf8"));
+}
+
+/** GitHub redelivers; small LRU of processed delivery ids. */
+export class DeliveryLog {
+	private readonly seen: string[] = [];
+
+	constructor(private readonly capacity = 500) {}
+
+	alreadySeen(id: string): boolean {
+		if (this.seen.includes(id)) return true;
+		this.seen.push(id);
+		if (this.seen.length > this.capacity) this.seen.splice(0, Math.floor(this.capacity / 2));
+		return false;
+	}
+}
+
+export interface GithubReviewServer {
+	close(): Promise<void>;
+	runner: InstructionRunner;
+	service: ReviewService;
+	port: number;
+}
+
+function readBody(req: http.IncomingMessage, limitBytes = 5 * 1024 * 1024): Promise<Buffer> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		let size = 0;
+		req.on("data", (chunk: Buffer) => {
+			size += chunk.length;
+			if (size > limitBytes) {
+				reject(new Error("payload too large"));
+				req.destroy();
+				return;
+			}
+			chunks.push(chunk);
+		});
+		req.on("end", () => resolve(Buffer.concat(chunks)));
+		req.on("error", reject);
+	});
+}
+
+function json(res: http.ServerResponse, status: number, body: unknown): void {
+	const payload = JSON.stringify(body);
+	res.writeHead(status, { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) });
+	res.end(payload);
+}
+
+export async function startGithubReviewServer(
+	config: GithubReviewConfig,
+	log: (line: string) => void = line => console.log(`${new Date().toISOString()} ${line}`),
+): Promise<GithubReviewServer> {
+	const service = new ReviewService(config);
+	const router = new WebhookRouter(config, service);
+	const runner = new InstructionRunner(service, log);
+	const deliveries = new DeliveryLog();
+
+	const server = http.createServer((req, res) => {
+		void (async () => {
+			const url = new URL(req.url ?? "/", `http://${config.host}`);
+			if (req.method === "GET" && url.pathname === "/health") {
+				json(res, 200, { ok: true, ...runner.status() });
+				return;
+			}
+			if (req.method !== "POST" || url.pathname !== config.webhookPath) {
+				json(res, 404, { error: "not found" });
+				return;
+			}
+			const body = await readBody(req);
+			if (!verifySignature(config.webhookSecret, body, req.headers["x-hub-signature-256"] as string | undefined)) {
+				json(res, 401, { error: "invalid signature" });
+				return;
+			}
+			const event = (req.headers["x-github-event"] as string | undefined) ?? "";
+			if (!ALLOWED_EVENTS.has(event)) {
+				json(res, 200, { ok: true, skipped: "event" });
+				return;
+			}
+			const delivery = (req.headers["x-github-delivery"] as string | undefined) ?? crypto.randomUUID();
+			if (deliveries.alreadySeen(delivery)) {
+				json(res, 200, { ok: true, skipped: "duplicate" });
+				return;
+			}
+			let payload: Record<string, unknown>;
+			try {
+				payload = JSON.parse(body.toString("utf8")) as Record<string, unknown>;
+			} catch {
+				json(res, 400, { error: "invalid json" });
+				return;
+			}
+			const action = await router.route(payload);
+			if (action.kind === "silent") {
+				json(res, 200, { ok: true, skipped: action.reason });
+				return;
+			}
+			runner.dispatch(delivery, action);
+			json(res, 200, { ok: true, dispatched: true });
+		})().catch(error => {
+			log(`webhook request failed: ${String(error).slice(0, 400)}`);
+			if (!res.headersSent) json(res, 500, { error: "internal" });
+		});
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(config.port, config.host, resolve);
+	});
+	const address = server.address();
+	const port = typeof address === "object" && address ? address.port : config.port;
+	log(`github-review listening on ${config.host}:${port}${config.webhookPath} (max ${config.maxInflight} concurrent)`);
+
+	let sweepTimer: ReturnType<typeof setInterval> | null = null;
+	if (config.sweepIntervalSeconds > 0) {
+		let sweeping = false;
+		sweepTimer = setInterval(() => {
+			if (sweeping) return;
+			sweeping = true;
+			void runSweep(service, { log })
+				.catch(error => log(`sweep failed: ${String(error).slice(0, 400)}`))
+				.finally(() => {
+					sweeping = false;
+				});
+		}, config.sweepIntervalSeconds * 1000);
+		sweepTimer.unref?.();
+	}
+
+	return {
+		runner,
+		service,
+		port,
+		async close() {
+			if (sweepTimer) clearInterval(sweepTimer);
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		},
+	};
+}

--- a/packages/coding-agent/src/github-review/service.ts
+++ b/packages/coding-agent/src/github-review/service.ts
@@ -1,0 +1,264 @@
+/**
+ * Side-effecting GitHub helpers shared by the router, completion, and sweeper:
+ * ack reactions, the live status line inside the marked summary comment,
+ * check-run lifecycle, head-sha resolution, and per-repo learnings.
+ *
+ * Everything here is best-effort: a failed ack or status line must never
+ * block or fail a review.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { GithubReviewConfig } from "./config";
+import { AppTokenProvider, GithubApi } from "./github";
+import { appendEvent, ReviewStateStore } from "./state";
+
+export interface CheckRunInfo {
+	id: number;
+	status?: string;
+	name?: string;
+	started_at?: string;
+}
+
+export class ReviewService {
+	readonly api: GithubApi;
+	readonly tokens: AppTokenProvider;
+	readonly store: ReviewStateStore;
+	readonly eventsPath: string;
+	private readonly summaryMarker: string;
+	private readonly statusRe: RegExp;
+
+	constructor(readonly config: GithubReviewConfig) {
+		this.api = new GithubApi(config.apiBase);
+		this.tokens = new AppTokenProvider(config);
+		this.store = new ReviewStateStore(config.dataDir, config.inflightStaleSeconds);
+		this.eventsPath = path.join(config.dataDir, "events.jsonl");
+		this.summaryMarker = `<!-- ${config.markerPrefix}-summary -->`;
+		this.statusRe = new RegExp(
+			`<!-- ${config.markerPrefix}-status -->.*?<!-- /${config.markerPrefix}-status -->`,
+			"s",
+		);
+	}
+
+	logEvent(kind: string, fields: Record<string, unknown> = {}): void {
+		appendEvent(this.eventsPath, kind, fields);
+	}
+
+	/** 👀 on the triggering comment — instant "접수" signal before the minutes-long LLM turn. */
+	async ackReaction(repo: string, commentId: number | undefined, reviewComment = false): Promise<boolean> {
+		if (!commentId) return false;
+		const token = await this.tokens.tokenOrEmpty();
+		if (!token) return false;
+		const kind = reviewComment ? "pulls" : "issues";
+		const res = await this.api.tryRequest(`/repos/${repo}/${kind}/comments/${commentId}/reactions`, {
+			method: "POST",
+			body: { content: "eyes" },
+			token,
+			timeoutMs: 5000,
+		});
+		this.logEvent("ack_reaction", { repo, comment_id: commentId, ok: res !== null });
+		return res !== null;
+	}
+
+	/** Resolve the PR head sha. "" on failure (fail-open to the $SHA agent flow). */
+	async fetchHeadSha(repo: string, pr: number): Promise<string> {
+		const token = await this.tokens.tokenOrEmpty();
+		if (!token) return "";
+		const res = await this.api.tryRequest<{ head?: { sha?: string } }>(`/repos/${repo}/pulls/${pr}`, {
+			token,
+			timeoutMs: 5000,
+		});
+		return res?.head?.sha ?? "";
+	}
+
+	/**
+	 * Create an in_progress check-run so the PR shows "review in progress" the
+	 * instant the webhook fires. Returns the check-run id or null.
+	 */
+	async createCheck(repo: string, headSha: string): Promise<number | null> {
+		if (!headSha || headSha === "$SHA") return null;
+		const token = await this.tokens.tokenOrEmpty();
+		if (!token) return null;
+		const res = await this.api.tryRequest<{ id?: number }>(`/repos/${repo}/check-runs`, {
+			method: "POST",
+			body: {
+				name: this.config.checkName,
+				head_sha: headSha,
+				status: "in_progress",
+				output: {
+					title: "리뷰 진행 중",
+					summary: `${this.config.botDisplayName}가 이 PR을 리뷰하고 있어요… 잠시만.`,
+				},
+			},
+			token,
+			timeoutMs: 5000,
+		});
+		return res?.id ?? null;
+	}
+
+	async closeCheck(repo: string, sha: string, checkId: number | null, conclusion: string): Promise<number> {
+		const token = await this.tokens.tokenOrEmpty();
+		if (!token) return 0;
+		const body = {
+			status: "completed",
+			conclusion,
+			output: {
+				title: conclusion === "success" ? "리뷰 완료" : "리뷰 종료",
+				summary:
+					conclusion === "success"
+						? "코드리뷰 게시함."
+						: `리뷰가 정상 종료되지 않았습니다. \`${this.mention()} review\` 로 재시도하세요.`,
+			},
+		};
+		const ids: number[] = checkId ? [checkId] : [];
+		if (ids.length === 0 && sha && sha !== "$SHA") {
+			const res = await this.api.tryRequest<{ check_runs?: CheckRunInfo[] }>(
+				`/repos/${repo}/commits/${sha}/check-runs?check_name=${encodeURIComponent(this.config.checkName)}`,
+				{ token },
+			);
+			for (const cr of res?.check_runs ?? []) {
+				if (cr.status === "in_progress") ids.push(cr.id);
+			}
+		}
+		let closed = 0;
+		for (const id of ids) {
+			const res = await this.api.tryRequest(`/repos/${repo}/check-runs/${id}`, { method: "PATCH", body, token });
+			if (res !== null) closed += 1;
+		}
+		return closed;
+	}
+
+	mention(): string {
+		return `@${this.config.botAliases[0]}`;
+	}
+
+	private statusBlock(line: string): string {
+		const p = this.config.markerPrefix;
+		return `<!-- ${p}-status -->\n> ${line}\n<!-- /${p}-status -->`;
+	}
+
+	/** Find the marked walkthrough comment id (oldest match), or null. */
+	async findSummaryCommentId(token: string, repo: string, pr: number): Promise<number | null> {
+		const comments = await this.api.tryRequest<Array<{ id: number; body?: string; user?: { login?: string } }>>(
+			`/repos/${repo}/issues/${pr}/comments?per_page=100`,
+			{ token },
+		);
+		if (!Array.isArray(comments)) return null;
+		for (const c of comments) {
+			if (c.user?.login === `${this.config.botLogin}[bot]` && (c.body ?? "").includes(this.summaryMarker)) {
+				return c.id;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Create/update the live ⏳/✅/❌ status line inside the summary comment.
+	 * Best-effort; returns the comment id or null.
+	 */
+	async upsertStatusLine(repo: string, pr: number, line: string): Promise<number | null> {
+		const token = await this.tokens.tokenOrEmpty();
+		if (!token) return null;
+		let cid = this.store.getPrState(repo, pr).summary_comment_id ?? null;
+		if (!cid) {
+			cid = await this.findSummaryCommentId(token, repo, pr);
+			if (cid) this.store.setPrState(repo, pr, { summary_comment_id: cid });
+		}
+		if (cid) {
+			const comment = await this.api.tryRequest<{ body?: string }>(`/repos/${repo}/issues/comments/${cid}`, {
+				token,
+			});
+			if (comment?.body !== undefined && comment.body !== null) {
+				let body = comment.body;
+				if (this.statusRe.test(body)) {
+					body = body.replace(this.statusRe, this.statusBlock(line));
+				} else if (body.includes(this.summaryMarker)) {
+					body = body.replace(this.summaryMarker, `${this.summaryMarker}\n${this.statusBlock(line)}`);
+				} else {
+					body = `${this.statusBlock(line)}\n${body}`;
+				}
+				const res = await this.api.tryRequest(`/repos/${repo}/issues/comments/${cid}`, {
+					method: "PATCH",
+					body: { body },
+					token,
+				});
+				if (res !== null) return cid;
+			}
+		}
+		const body = `${this.summaryMarker}\n${this.statusBlock(line)}\n\n_리뷰가 끝나면 이 코멘트가 🦞 Walkthrough 요약으로 갱신됩니다._`;
+		const created = await this.api.tryRequest<{ id?: number }>(`/repos/${repo}/issues/${pr}/comments`, {
+			method: "POST",
+			body: { body },
+			token,
+		});
+		if (created?.id) {
+			this.store.setPrState(repo, pr, { summary_comment_id: created.id });
+			return created.id;
+		}
+		return null;
+	}
+
+	/** Immediate user-visible ack: check-run first, live status line second. */
+	async startReviewAcks(repo: string, pr: number, headSha: string): Promise<number | null> {
+		const checkId = await this.createCheck(repo, headSha);
+		if (checkId) {
+			this.store.setPrState(repo, pr, { check_id: checkId });
+			this.logEvent("check_created", { repo, pr, sha: headSha, check_id: checkId });
+		}
+		await this.upsertStatusLine(
+			repo,
+			pr,
+			`⏳ ${this.config.botDisplayName}가 리뷰 중… (head \`${headSha.slice(0, 7)}\`)`,
+		);
+		return checkId;
+	}
+
+	// ── per-repo learnings (프로젝트 규칙 기억) ──────────────────────────
+	private learnPath(repo: string): string {
+		return path.join(this.config.dataDir, "learnings", `${repo.replaceAll("/", "__")}.md`);
+	}
+
+	getLearnings(repo: string): string {
+		try {
+			return fs.readFileSync(this.learnPath(repo), "utf8").trim();
+		} catch {
+			return "";
+		}
+	}
+
+	addLearning(repo: string, note: string): void {
+		const trimmed = (note ?? "").trim();
+		if (!trimmed) return;
+		try {
+			const p = this.learnPath(repo);
+			fs.mkdirSync(path.dirname(p), { recursive: true });
+			fs.appendFileSync(p, `- ${trimmed}\n`);
+		} catch {
+			/* best-effort */
+		}
+	}
+}
+
+/** Return (cmd, args) when body is a `<mention> <cmd> ...` command, else null. */
+export function parseCommand(body: string, aliases: string[]): { cmd: string; args: string } | null {
+	if (!body) return null;
+	const commands = ["review", "summary", "pause", "resume", "resolve", "help", "fix", "learn"];
+	const aliasAlt = aliases.map(a => a.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+	// NB: JS `\b` is ASCII-only — a Korean command word like `리뷰` needs a
+	// Unicode-aware boundary, hence the explicit lookahead.
+	const re = new RegExp(
+		`(?:@?(?:${aliasAlt}))\\s+(${commands.join("|")}|리뷰)(?![\\p{L}\\p{N}_])\\s*([\\s\\S]*)`,
+		"iu",
+	);
+	const m = re.exec(body);
+	if (!m) return null;
+	let cmd = m[1].toLowerCase();
+	if (cmd === "리뷰") cmd = "review";
+	return { cmd, args: (m[2] ?? "").trim() };
+}
+
+/** True when any alias (or @alias) appears in the text. */
+export function mentionsBot(body: string, aliases: string[]): boolean {
+	if (!body) return false;
+	const aliasAlt = aliases.map(a => a.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+	return new RegExp(`@?(?:${aliasAlt})`, "i").test(body);
+}

--- a/packages/coding-agent/src/github-review/state.ts
+++ b/packages/coding-agent/src/github-review/state.ts
@@ -1,0 +1,274 @@
+/**
+ * Per-PR review state machine, shared across processes (server, `complete`
+ * CLI invocations from agent turns, sweeper).
+ *
+ * State machine (per PR):
+ *   review_status: idle | queued | in_flight | posted | failed
+ *   in_flight_sha / in_flight_since / check_id  — current review run
+ *   pending_sha                                 — newer head arrived mid-review (supersede)
+ *   queued_sha / queued_since                   — waiting for a concurrency slot
+ *   last_reviewed_sha / review_count            — set on successful completion
+ *
+ * Every read-modify-write goes through an exclusive on-disk lock: the bare
+ * read-modify-write this replaced lost ~50% of concurrent updates (measured
+ * on the predecessor pipeline).
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export type GateStatus = "acquired" | "duplicate" | "superseded" | "queued";
+
+export interface PrState {
+	review_status?: "idle" | "queued" | "in_flight" | "posted" | "failed";
+	in_flight_sha?: string;
+	in_flight_since?: number;
+	check_id?: number;
+	pending_sha?: string;
+	queued_sha?: string;
+	queued_since?: number;
+	last_reviewed_sha?: string;
+	review_count?: number;
+	summary_comment_id?: number;
+	dup_notified_sha?: string;
+	paused?: boolean;
+	updated_at?: number;
+}
+
+export interface CompleteResult {
+	stale: boolean;
+	pendingSha: string | null;
+	checkId: number | null;
+	durationSeconds: number | null;
+}
+
+export interface DrainCandidate {
+	repo: string;
+	pr: number;
+	sha: string;
+}
+
+const LOCK_STALE_MS = 30_000;
+const LOCK_SPIN_MS = 25;
+const LOCK_TIMEOUT_MS = 10_000;
+
+/** Cross-process mutex via exclusive lockdir creation with stale takeover. */
+function withFileLock<T>(lockDir: string, fn: () => T): T {
+	const deadline = Date.now() + LOCK_TIMEOUT_MS;
+	for (;;) {
+		try {
+			fs.mkdirSync(lockDir);
+			break;
+		} catch {
+			try {
+				const age = Date.now() - fs.statSync(lockDir).mtimeMs;
+				if (age > LOCK_STALE_MS) {
+					fs.rmdirSync(lockDir);
+					continue;
+				}
+			} catch {
+				continue; // raced with the holder's release — retry immediately
+			}
+			if (Date.now() > deadline) throw new Error(`state lock timeout: ${lockDir}`);
+			const until = Date.now() + LOCK_SPIN_MS;
+			while (Date.now() < until) {
+				/* short blocking spin: state ops are millisecond-scale */
+			}
+		}
+	}
+	try {
+		return fn();
+	} finally {
+		try {
+			fs.rmdirSync(lockDir);
+		} catch {
+			/* released by stale takeover */
+		}
+	}
+}
+
+export class ReviewStateStore {
+	readonly statePath: string;
+	private readonly lockDir: string;
+
+	constructor(
+		dataDir: string,
+		private readonly inflightStaleSeconds: number,
+		private readonly now: () => number = () => Math.floor(Date.now() / 1000),
+	) {
+		this.statePath = path.join(dataDir, "reviews.json");
+		this.lockDir = `${this.statePath}.lock`;
+	}
+
+	private load(): Record<string, PrState> {
+		try {
+			return JSON.parse(fs.readFileSync(this.statePath, "utf8")) as Record<string, PrState>;
+		} catch {
+			return {};
+		}
+	}
+
+	private save(state: Record<string, PrState>): void {
+		fs.mkdirSync(path.dirname(this.statePath), { recursive: true });
+		const tmp = `${this.statePath}.${process.pid}.tmp`;
+		fs.writeFileSync(tmp, JSON.stringify(state));
+		fs.renameSync(tmp, this.statePath);
+	}
+
+	private key(repo: string, pr: number): string {
+		return `${repo}#${pr}`;
+	}
+
+	private isFreshInflight(entry: PrState, now: number): boolean {
+		return entry.review_status === "in_flight" && now - (entry.in_flight_since ?? 0) < this.inflightStaleSeconds;
+	}
+
+	getPrState(repo: string, pr: number): PrState {
+		return this.load()[this.key(repo, pr)] ?? {};
+	}
+
+	setPrState(repo: string, pr: number, fields: Partial<PrState>): PrState {
+		return withFileLock(this.lockDir, () => {
+			const state = this.load();
+			const cur: PrState = { ...state[this.key(repo, pr)], ...fields, updated_at: this.now() };
+			state[this.key(repo, pr)] = cur;
+			this.save(state);
+			return cur;
+		});
+	}
+
+	/** Snapshot of all entries (sweeper/status surfaces). */
+	entries(): Array<[string, PrState]> {
+		return Object.entries(this.load());
+	}
+
+	countInflight(): number {
+		const now = this.now();
+		return Object.values(this.load()).filter(e => this.isFreshInflight(e, now)).length;
+	}
+
+	/**
+	 * Atomic CAS gate for starting a review of `sha` on repo#pr.
+	 *
+	 *   acquired   — caller owns the review; state marked in_flight
+	 *   duplicate  — same sha already in flight; do nothing
+	 *   superseded — an older sha is in flight; sha recorded as pending_sha
+	 *   queued     — concurrency cap reached; sha parked as queued_sha
+	 */
+	tryAcquireReview(
+		repo: string,
+		pr: number,
+		sha: string,
+		maxInflight?: number,
+	): { status: GateStatus; state: PrState } {
+		const now = this.now();
+		return withFileLock(this.lockDir, () => {
+			const state = this.load();
+			const k = this.key(repo, pr);
+			const cur: PrState = { ...state[k] };
+			let status: GateStatus;
+			if (this.isFreshInflight(cur, now)) {
+				if (cur.in_flight_sha === sha) {
+					status = "duplicate";
+				} else {
+					cur.pending_sha = sha;
+					status = "superseded";
+				}
+			} else if (
+				maxInflight &&
+				Object.entries(state).filter(([kk, v]) => kk !== k && this.isFreshInflight(v, now)).length >= maxInflight
+			) {
+				cur.review_status = "queued";
+				cur.queued_sha = sha;
+				cur.queued_since = now;
+				status = "queued";
+			} else {
+				cur.review_status = "in_flight";
+				cur.in_flight_sha = sha;
+				cur.in_flight_since = now;
+				delete cur.check_id;
+				delete cur.queued_sha;
+				delete cur.queued_since;
+				if (cur.pending_sha === sha) delete cur.pending_sha;
+				status = "acquired";
+			}
+			cur.updated_at = now;
+			state[k] = cur;
+			this.save(state);
+			return { status, state: { ...cur } };
+		});
+	}
+
+	/**
+	 * Mark the in-flight review of `sha` finished (idempotent).
+	 * stale=true → a newer run owns the lock; the caller must not drain or
+	 * touch shared state, only clean up artifacts it created itself.
+	 */
+	completeReview(repo: string, pr: number, sha: string, ok: boolean): CompleteResult {
+		const now = this.now();
+		return withFileLock(this.lockDir, () => {
+			const state = this.load();
+			const k = this.key(repo, pr);
+			const cur: PrState = { ...state[k] };
+			if (this.isFreshInflight(cur, now) && cur.in_flight_sha && cur.in_flight_sha !== sha) {
+				return { stale: true, pendingSha: null, checkId: null, durationSeconds: null };
+			}
+			let pending = cur.pending_sha ?? null;
+			if (pending === sha) pending = null;
+			const checkId = cur.check_id ?? null;
+			const durationSeconds = cur.in_flight_since ? now - cur.in_flight_since : null;
+			const alreadyDone =
+				!cur.in_flight_sha &&
+				(cur.review_status === "posted" || cur.review_status === "failed") &&
+				cur.last_reviewed_sha === sha;
+			cur.review_status = ok ? "posted" : "failed";
+			if (ok) {
+				cur.last_reviewed_sha = sha;
+				if (!alreadyDone) cur.review_count = (cur.review_count ?? 0) + 1;
+			}
+			delete cur.in_flight_sha;
+			delete cur.in_flight_since;
+			delete cur.check_id;
+			delete cur.pending_sha;
+			cur.updated_at = now;
+			state[k] = cur;
+			this.save(state);
+			return { stale: false, pendingSha: pending, checkId, durationSeconds };
+		});
+	}
+
+	/**
+	 * PRs waiting for a review slot: pending (superseded) first, then queued
+	 * (oldest first). Read-only.
+	 */
+	findDrainCandidates(limit = 3): DrainCandidate[] {
+		const now = this.now();
+		const pending: DrainCandidate[] = [];
+		const queued: Array<{ since: number; c: DrainCandidate }> = [];
+		for (const [k, v] of Object.entries(this.load())) {
+			const hash = k.lastIndexOf("#");
+			if (hash <= 0) continue;
+			const repo = k.slice(0, hash);
+			const pr = Number(k.slice(hash + 1));
+			if (!Number.isInteger(pr)) continue;
+			if (this.isFreshInflight(v, now)) continue; // still running; its completion drains pending
+			if (v.pending_sha) {
+				pending.push({ repo, pr, sha: v.pending_sha });
+			} else if (v.review_status === "queued" && v.queued_sha) {
+				queued.push({ since: v.queued_since ?? 0, c: { repo, pr, sha: v.queued_sha } });
+			}
+		}
+		queued.sort((a, b) => a.since - b.since);
+		return [...pending, ...queued.map(q => q.c)].slice(0, limit);
+	}
+}
+
+/** Append one structured JSONL event. Best-effort, never throws. */
+export function appendEvent(eventsPath: string, kind: string, fields: Record<string, unknown> = {}): void {
+	try {
+		fs.mkdirSync(path.dirname(eventsPath), { recursive: true });
+		const record = { ts: Math.floor(Date.now() / 1000), event: kind, ...fields };
+		fs.appendFileSync(eventsPath, `${JSON.stringify(record)}\n`);
+	} catch {
+		/* diagnostics only */
+	}
+}

--- a/packages/coding-agent/src/github-review/sweeper.ts
+++ b/packages/coding-agent/src/github-review/sweeper.ts
@@ -1,0 +1,192 @@
+/**
+ * Failsafe sweeper for review check-runs and state.
+ *
+ * The router creates an `in_progress` check-run the instant a PR event fires,
+ * but a crashed/hung agent turn would leave it open FOREVER — GitHub never
+ * auto-expires API-created check-runs. The sweeper:
+ *
+ *   1. closes any bot check-run stuck `in_progress` past `sweepStaleMinutes`
+ *      (skipping fresh in-flight reviews — the state machine is the source of
+ *      truth; reviews routinely run 8–15 minutes);
+ *   2. force-completes stale in_flight state entries through the idempotent
+ *      completion path (threshold `inflightStaleSeconds`, deliberately LONGER
+ *      than the check sweep so a slow-but-alive review isn't drained over);
+ *   3. drains leftover pending/queued PRs when slots are free;
+ *   4. requeues open PRs GitHub never delivered an `opened` webhook for
+ *      (observed in production: PRs receiving review_requested+edited but no
+ *      opened delivery).
+ *
+ * Idempotent + best-effort: safe on a schedule, never throws.
+ */
+import { completeReviewRun, requeueReview } from "./complete";
+import type { CheckRunInfo, ReviewService } from "./service";
+
+const MISS_GRACE_MIN = 10;
+const MISS_LOOKBACK_MIN = 24 * 60;
+
+export interface SweepResult {
+	checksClosed: number;
+	forceCompleted: number;
+	drained: number;
+	missedRequeued: number;
+}
+
+interface OpenPr {
+	number?: number;
+	draft?: boolean;
+	created_at?: string;
+	user?: { login?: string; type?: string };
+	head?: { sha?: string };
+}
+
+function ageMinutes(iso: string | undefined, now: number): number {
+	if (!iso) return 0;
+	const started = Date.parse(iso);
+	return Number.isFinite(started) ? (now - started) / 60_000 : 0;
+}
+
+/** Open PRs with no state entry: candidates for a missed `opened` webhook. */
+export function detectMissedPrs(
+	stateKeys: Set<string>,
+	repo: string,
+	prs: OpenPr[],
+	nowMs = Date.now(),
+): Array<{ repo: string; pr: number; sha: string; ageMin: number }> {
+	const out: Array<{ repo: string; pr: number; sha: string; ageMin: number }> = [];
+	for (const pr of prs) {
+		const num = pr.number;
+		const sha = pr.head?.sha;
+		if (!num || !sha) continue;
+		if (stateKeys.has(`${repo}#${num}`) || pr.draft) continue;
+		const user = pr.user ?? {};
+		if (user.type === "Bot" || (user.login ?? "").endsWith("[bot]")) continue;
+		const age = ageMinutes(pr.created_at, nowMs);
+		// Grace avoids racing a normal delivery; lookback avoids resurrecting
+		// ancient pre-bot PRs.
+		if (age >= MISS_GRACE_MIN && age <= MISS_LOOKBACK_MIN) {
+			out.push({ repo, pr: num, sha, ageMin: Math.floor(age) });
+		}
+	}
+	return out;
+}
+
+export async function runSweep(
+	service: ReviewService,
+	options: { dryRun?: boolean; log?: (line: string) => void } = {},
+): Promise<SweepResult> {
+	const { dryRun = false, log = () => {} } = options;
+	const result: SweepResult = { checksClosed: 0, forceCompleted: 0, drained: 0, missedRequeued: 0 };
+	const token = await service.tokens.tokenOrEmpty();
+	if (!token) {
+		log("sweep: no token; abort");
+		return result;
+	}
+	const entries = service.store.entries();
+	const stateKeys = new Set(entries.map(([k]) => k));
+	const repos = [...new Set(entries.map(([k]) => k.slice(0, k.lastIndexOf("#"))).filter(Boolean))];
+	const nowMs = Date.now();
+	const nowSec = Math.floor(nowMs / 1000);
+	const staleMs = service.config.sweepStaleMinutes * 60_000;
+	const missed: Array<{ repo: string; pr: number; sha: string; ageMin: number }> = [];
+
+	// ── 1. stale check-runs on open PRs ──
+	for (const repo of repos) {
+		const prs = await service.api.tryRequest<OpenPr[]>(`/repos/${repo}/pulls?state=open&per_page=100`, { token });
+		if (!Array.isArray(prs)) continue;
+		missed.push(...detectMissedPrs(stateKeys, repo, prs, nowMs));
+		for (const pr of prs) {
+			const sha = pr.head?.sha;
+			if (!pr.number || !sha) continue;
+			// 상태머신이 진실의 원천: fresh in_flight(정상 진행 중) 리뷰의 체크런은
+			// 건드리지 않는다 — 리뷰는 통상 8~15분 걸린다.
+			const entry = entries.find(([k]) => k === `${repo}#${pr.number}`)?.[1];
+			if (
+				entry?.review_status === "in_flight" &&
+				entry.in_flight_sha === sha &&
+				nowSec - (entry.in_flight_since ?? 0) < service.config.inflightStaleSeconds
+			) {
+				continue; // 살아있는 리뷰 — 넘치면 아래 reconcile 이 처리
+			}
+			const res = await service.api.tryRequest<{ check_runs?: CheckRunInfo[] }>(
+				`/repos/${repo}/commits/${sha}/check-runs?check_name=${encodeURIComponent(service.config.checkName)}`,
+				{ token },
+			);
+			for (const cr of res?.check_runs ?? []) {
+				if (cr.name !== service.config.checkName || cr.status !== "in_progress") continue;
+				const mins = ageMinutes(cr.started_at, nowMs);
+				if (mins * 60_000 < staleMs) continue;
+				if (dryRun) {
+					log(`sweep DRY: would close ${repo} check ${cr.id} (in_progress ${Math.floor(mins)}m)`);
+					result.checksClosed += 1;
+					continue;
+				}
+				const patched = await service.api.tryRequest(`/repos/${repo}/check-runs/${cr.id}`, {
+					method: "PATCH",
+					body: {
+						status: "completed",
+						conclusion: "neutral",
+						output: {
+							title: "리뷰 시간 초과로 정리됨",
+							summary:
+								`리뷰 세션이 ${Math.floor(mins)}분 이상 응답이 없어 stuck 체크런을 자동 정리했습니다. ` +
+								`필요하면 \`${service.mention()} review\` 로 재요청하세요.`,
+						},
+					},
+					token,
+				});
+				if (patched !== null) {
+					result.checksClosed += 1;
+					log(`sweep: closed ${repo} check ${cr.id} (was in_progress ${Math.floor(mins)}m)`);
+				}
+			}
+		}
+	}
+
+	// ── 2. force-complete stale in_flight state entries ──
+	for (const [key, entry] of entries) {
+		if (entry.review_status !== "in_flight") continue;
+		const age = nowSec - (entry.in_flight_since ?? 0);
+		if (age < service.config.inflightStaleSeconds) continue;
+		const hash = key.lastIndexOf("#");
+		const repo = key.slice(0, hash);
+		const pr = Number(key.slice(hash + 1));
+		const sha = entry.in_flight_sha ?? "";
+		if (!repo || !Number.isInteger(pr) || !sha) continue;
+		if (dryRun) {
+			log(`sweep DRY: would force-complete ${key} (in_flight ${Math.floor(age / 60)}m)`);
+			result.forceCompleted += 1;
+			continue;
+		}
+		log(`sweep: force-completing stale review ${key} (in_flight ${Math.floor(age / 60)}m)`);
+		service.logEvent("sweeper_force_complete", { repo, pr, sha, age_min: Math.floor(age / 60) });
+		await completeReviewRun(service, repo, pr, sha, "failure");
+		result.forceCompleted += 1;
+	}
+
+	// ── 3. drain waiters even when nothing went stale (missed-drain safety net) ──
+	if (!dryRun) {
+		const free = Math.max(0, service.config.maxInflight - service.store.countInflight());
+		for (const [i, cand] of service.store.findDrainCandidates(Math.min(free, 2)).entries()) {
+			if (i > 0) await new Promise(resolve => setTimeout(resolve, 3000)); // rate-limit pacing
+			log(`sweep: draining queued review ${cand.repo}#${cand.pr} @ ${cand.sha.slice(0, 7)}`);
+			await requeueReview(service, cand.repo, cand.pr, cand.sha);
+			result.drained += 1;
+		}
+	}
+
+	// ── 4. missed-webhook recovery, paced ──
+	for (const m of missed.slice(0, 2)) {
+		if (dryRun) {
+			log(`sweep DRY: would requeue missed PR ${m.repo}#${m.pr} @ ${m.sha.slice(0, 7)} (age ${m.ageMin}m)`);
+			result.missedRequeued += 1;
+			continue;
+		}
+		log(
+			`sweep: requeueing missed PR ${m.repo}#${m.pr} @ ${m.sha.slice(0, 7)} (opened webhook lost, age ${m.ageMin}m)`,
+		);
+		service.logEvent("missed_pr_requeue", { repo: m.repo, pr: m.pr, sha: m.sha, age_min: m.ageMin });
+		await requeueReview(service, m.repo, m.pr, m.sha);
+		result.missedRequeued += 1;
+	}
+	return result;
+}

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -146,6 +146,7 @@ process.exitCode = await child.exited;`;
 			"team",
 			"ultragoal",
 			"gc",
+			"github-review",
 			"ralplan",
 			"config",
 			"stats",

--- a/packages/coding-agent/test/github-review-router.test.ts
+++ b/packages/coding-agent/test/github-review-router.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { GithubReviewConfig } from "../src/github-review/config";
+import { parseMinimalYaml, type RepoReviewConfig } from "../src/github-review/repo-config";
+import { type RouteAction, WebhookRouter } from "../src/github-review/router";
+import { mentionsBot, parseCommand, ReviewService } from "../src/github-review/service";
+
+const tmps: string[] = [];
+afterEach(() => {
+	for (const dir of tmps.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function testConfig(dataDir: string, overrides: Partial<GithubReviewConfig> = {}): GithubReviewConfig {
+	return {
+		appId: "1",
+		installationId: "2",
+		privateKeyPath: "/nonexistent.pem",
+		webhookSecret: "s3cret",
+		botLogin: "gajae-code",
+		botAliases: ["gajae", "가재"],
+		botDisplayName: "가재",
+		markerPrefix: "gajae",
+		checkName: "가재 코드리뷰",
+		host: "127.0.0.1",
+		port: 0,
+		webhookPath: "/webhooks/gajae",
+		maxInflight: 4,
+		turnTimeoutMinutes: 45,
+		cwd: os.tmpdir(),
+		dataDir,
+		ignoreRepos: ["polybetbot"],
+		repoConfigFile: ".gajae.yaml",
+		inflightStaleSeconds: 20 * 60,
+		sweepIntervalSeconds: 0,
+		sweepStaleMinutes: 10,
+		postCommand: "gajae-gh",
+		completeCommand: "gajae-review-complete",
+		localWebhookUrl: "http://127.0.0.1:0/webhooks/gajae",
+		apiBase: "https://api.github.invalid",
+		...overrides,
+	};
+}
+
+interface Harness {
+	router: WebhookRouter;
+	service: ReviewService;
+	acks: Array<{ commentId: number | undefined; reviewComment: boolean }>;
+	startAcks: Array<{ repo: string; pr: number; sha: string }>;
+}
+
+/** Router harness with all network lanes stubbed out. */
+function makeHarness(
+	options: { config?: Partial<GithubReviewConfig>; repoConfig?: RepoReviewConfig; headSha?: string } = {},
+): Harness {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ghr-router-"));
+	tmps.push(dir);
+	const config = testConfig(dir, options.config);
+	const service = new ReviewService(config);
+	const acks: Harness["acks"] = [];
+	const startAcks: Harness["startAcks"] = [];
+	service.tokens.tokenOrEmpty = async () => "test-token";
+	service.api.tryRequest = (async (apiPath: string) => {
+		if (apiPath.includes("/contents/") && options.repoConfig !== undefined) {
+			// Serve the repo config as a contents API blob.
+			const yaml = Object.entries(options.repoConfig)
+				.map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+				.join("\n");
+			return { content: Buffer.from(yaml).toString("base64") };
+		}
+		if (/\/pulls\/\d+$/.test(apiPath)) return { head: { sha: options.headSha ?? "" } };
+		return null;
+	}) as typeof service.api.tryRequest;
+	service.ackReaction = async (_repo, commentId, reviewComment = false) => {
+		acks.push({ commentId, reviewComment });
+		return true;
+	};
+	service.startReviewAcks = async (repo, pr, sha) => {
+		startAcks.push({ repo, pr, sha });
+		return null;
+	};
+	return { router: new WebhookRouter(config, service), service, acks, startAcks };
+}
+
+function prEvent(
+	overrides: Record<string, unknown> = {},
+	prOverrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		action: "opened",
+		number: 42,
+		pull_request: {
+			draft: false,
+			user: { login: "human", type: "User" },
+			head: { sha: "abc1234def" },
+			...prOverrides,
+		},
+		repository: { full_name: "acme/web" },
+		...overrides,
+	};
+}
+
+function commentEvent(body: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		action: "created",
+		issue: { number: 42, title: "T", pull_request: {} },
+		comment: { id: 7, body, user: { login: "human", type: "User" } },
+		repository: { full_name: "acme/web" },
+		...overrides,
+	};
+}
+
+function asRun(action: RouteAction): Extract<RouteAction, { kind: "run" }> {
+	expect(action.kind).toBe("run");
+	return action as Extract<RouteAction, { kind: "run" }>;
+}
+
+describe("pull_request auto review", () => {
+	test("opened → full review with gate, acks, complete line, metadata", async () => {
+		const h = makeHarness();
+		const action = asRun(await h.router.route(prEvent()));
+		expect(action.instruction).toContain("자동 코드리뷰");
+		expect(action.instruction).toContain("gh pr diff 42 --repo acme/web");
+		expect(action.instruction).toContain("gajae-review-complete acme/web 42 abc1234def success");
+		expect(action.instruction).toContain("gitleaks");
+		expect(action.instruction).toContain('select(.user.login=="gajae-code[bot]")'); // dedup step
+		expect(action.review).toEqual({ repo: "acme/web", pr: 42, sha: "abc1234def" });
+		expect(h.startAcks).toEqual([{ repo: "acme/web", pr: 42, sha: "abc1234def" }]);
+		expect(h.service.store.getPrState("acme/web", 42).in_flight_sha).toBe("abc1234def");
+	});
+
+	test.each(["closed", "labeled", "review_requested"])("action %s → silent", async action => {
+		const h = makeHarness();
+		expect((await h.router.route(prEvent({ action }))).kind).toBe("silent");
+	});
+
+	test("draft / bot author / ignored repo → silent", async () => {
+		const h = makeHarness();
+		expect((await h.router.route(prEvent({}, { draft: true }))).kind).toBe("silent");
+		expect((await h.router.route(prEvent({}, { user: { login: "dep[bot]", type: "Bot" } }))).kind).toBe("silent");
+		expect((await h.router.route(prEvent({ repository: { full_name: "acme/PolyBetBot-api" } }))).kind).toBe("silent");
+	});
+
+	test("paused PR → silent", async () => {
+		const h = makeHarness();
+		h.service.store.setPrState("acme/web", 42, { paused: true });
+		expect((await h.router.route(prEvent())).kind).toBe("silent");
+	});
+
+	test("same sha already reviewed → silent (redelivery guard)", async () => {
+		const h = makeHarness();
+		h.service.store.setPrState("acme/web", 42, { last_reviewed_sha: "abc1234def" });
+		expect((await h.router.route(prEvent({ action: "synchronize" }))).kind).toBe("silent");
+	});
+
+	test("gate: duplicate and supersede are silent on the auto path", async () => {
+		const h = makeHarness();
+		await h.router.route(prEvent());
+		expect((await h.router.route(prEvent())).kind).toBe("silent"); // duplicate
+		const superseded = await h.router.route(prEvent({}, { head: { sha: "newsha0000" } }));
+		expect(superseded.kind).toBe("silent");
+		expect(h.service.store.getPrState("acme/web", 42).pending_sha).toBe("newsha0000");
+	});
+
+	test("synchronize after a review → incremental (compare, resolve step, no dedup)", async () => {
+		const h = makeHarness();
+		h.service.store.setPrState("acme/web", 42, { last_reviewed_sha: "oldsha9999" });
+		const action = asRun(await h.router.route(prEvent({ action: "synchronize" })));
+		expect(action.instruction).toContain("repos/acme/web/compare/oldsha9999...abc1234def");
+		expect(action.instruction).toContain("증분");
+		expect(action.instruction).toContain("resolveReviewThread");
+		expect(action.instruction).not.toContain("중복 방지");
+	});
+
+	test("repo config: enabled:false → silent", async () => {
+		const h = makeHarness({ repoConfig: { enabled: false } });
+		expect((await h.router.route(prEvent())).kind).toBe("silent");
+	});
+
+	test("repo config knobs flow into the instruction", async () => {
+		const h = makeHarness({
+			repoConfig: { max_comments: 3, tone: "부드럽게", ignore_paths: ["dist/", "gen/"] },
+		});
+		const action = asRun(await h.router.route(prEvent()));
+		expect(action.instruction).toContain("최대 3개로 제한");
+		expect(action.instruction).toContain("톤: 부드럽게");
+		expect(action.instruction).toContain("dist/, gen/");
+	});
+
+	test("poem included by default, omitted with poem:false", async () => {
+		const withPoem = asRun(await makeHarness().router.route(prEvent()));
+		expect(withPoem.instruction).toContain("시 한 편");
+		expect(withPoem.instruction).toContain("🦞");
+		const without = asRun(await makeHarness({ repoConfig: { poem: false } }).router.route(prEvent()));
+		expect(without.instruction).not.toContain("시 한 편");
+	});
+
+	test("diagrams:false and pr_summary:false trim the summary steps", async () => {
+		const h = makeHarness({ repoConfig: { diagrams: false, pr_summary: false } });
+		const action = asRun(await h.router.route(prEvent()));
+		expect(action.instruction).not.toContain("mermaid");
+		expect(action.instruction).not.toContain("PR **본문**");
+	});
+
+	test("learnings are injected", async () => {
+		const h = makeHarness();
+		h.service.addLearning("acme/web", "모든 API 에러는 problem+json");
+		const action = asRun(await h.router.route(prEvent()));
+		expect(action.instruction).toContain("학습된 규칙");
+		expect(action.instruction).toContain("problem+json");
+	});
+});
+
+describe("issue_comment commands", () => {
+	test("@gajae help → canned reply, ack fired", async () => {
+		const h = makeHarness();
+		const action = asRun(await h.router.route(commentEvent("@gajae help")));
+		expect(action.instruction).toContain("가재 명령어");
+		expect(action.instruction).toContain("딱 하나만 그대로");
+		expect(h.acks).toEqual([{ commentId: 7, reviewComment: false }]);
+	});
+
+	test("@gajae summary → summary instruction", async () => {
+		const action = asRun(await makeHarness().router.route(commentEvent("@gajae summary")));
+		expect(action.instruction).toContain("<!-- gajae-summary -->");
+		expect(action.instruction).toContain("walkthrough");
+	});
+
+	test("가재 리뷰 (korean alias + command) routes to review", async () => {
+		const h = makeHarness({ headSha: "abc1234def" });
+		const action = asRun(await h.router.route(commentEvent("가재 리뷰 부탁해")));
+		expect(action.instruction).toContain("강제 리뷰");
+		expect(action.review).toEqual({ repo: "acme/web", pr: 42, sha: "abc1234def" });
+	});
+
+	test("@gajae review with unresolvable sha falls back to $SHA flow", async () => {
+		const h = makeHarness({ headSha: "" });
+		const action = asRun(await h.router.route(commentEvent("@gajae review")));
+		expect(action.instruction).toContain("$SHA");
+		expect(action.review).toBeUndefined();
+	});
+
+	test("@gajae review honors the gate: duplicate notifies once, then silent", async () => {
+		const h = makeHarness({ headSha: "abc1234def" });
+		h.service.store.tryAcquireReview("acme/web", 42, "abc1234def");
+		const first = asRun(await h.router.route(commentEvent("@gajae review")));
+		expect(first.instruction).toContain("이미 이 커밋");
+		const second = await h.router.route(commentEvent("@gajae review"));
+		expect(second.kind).toBe("silent");
+	});
+
+	test("@gajae review supersede / queue replies", async () => {
+		const h = makeHarness({ headSha: "newsha0000" });
+		h.service.store.tryAcquireReview("acme/web", 42, "oldsha1111");
+		const superseded = asRun(await h.router.route(commentEvent("@gajae review")));
+		expect(superseded.instruction).toContain("다시 리뷰할게");
+
+		const q = makeHarness({ headSha: "abc1234def", config: { maxInflight: 1 } });
+		q.service.store.tryAcquireReview("acme/other", 9, "zzz");
+		const queued = asRun(await q.router.route(commentEvent("@gajae review")));
+		expect(queued.instruction).toContain("대기열");
+	});
+
+	test("@gajae pause / resume flip state and reply", async () => {
+		const h = makeHarness();
+		const paused = asRun(await h.router.route(commentEvent("@gajae pause")));
+		expect(paused.instruction).toContain("일시정지");
+		expect(h.service.store.getPrState("acme/web", 42).paused).toBe(true);
+		const resumed = asRun(await h.router.route(commentEvent("@gajae resume")));
+		expect(resumed.instruction).toContain("재개");
+		expect(h.service.store.getPrState("acme/web", 42).paused).toBe(false);
+	});
+
+	test("@gajae learn stores the rule and confirms", async () => {
+		const h = makeHarness();
+		const action = asRun(await h.router.route(commentEvent("@gajae learn 커밋은 conventional commits")));
+		expect(action.instruction).toContain("학습함");
+		expect(h.service.getLearnings("acme/web")).toContain("conventional commits");
+	});
+
+	test("@gajae fix / resolve build the right instructions", async () => {
+		const h = makeHarness();
+		const fix = asRun(await h.router.route(commentEvent("@gajae fix null 체크 추가해줘")));
+		expect(fix.instruction).toContain("suggestion");
+		expect(fix.instruction).toContain("push/commit/브랜치 수정 금지");
+		const resolve = asRun(await h.router.route(commentEvent("@gajae resolve")));
+		expect(resolve.instruction).toContain('repository(owner:"acme",name:"web")');
+		expect(resolve.instruction).toContain("resolveReviewThread");
+	});
+
+	test("plain mention → chat; no mention → silent; bot author → silent", async () => {
+		const h = makeHarness();
+		const chat = asRun(await h.router.route(commentEvent("가재야 이 PR 어때?")));
+		expect(chat.instruction).toContain("한국어 반말");
+		expect((await h.router.route(commentEvent("그냥 사람들끼리 대화"))).kind).toBe("silent");
+		expect(
+			(
+				await h.router.route(
+					commentEvent("@gajae review", {
+						comment: { id: 7, body: "@gajae review", user: { login: "x[bot]", type: "Bot" } },
+					}),
+				)
+			).kind,
+		).toBe("silent");
+	});
+
+	test("edited comments only count when they carry a command", async () => {
+		const h = makeHarness();
+		expect((await h.router.route(commentEvent("가재야 안녕", { action: "edited" }))).kind).toBe("silent");
+		const edited = await h.router.route(commentEvent("@gajae help", { action: "edited" }));
+		expect(edited.kind).toBe("run");
+	});
+
+	test("non-PR issue comment → silent", async () => {
+		const h = makeHarness();
+		expect((await h.router.route(commentEvent("@gajae help", { issue: { number: 42, title: "T" } }))).kind).toBe(
+			"silent",
+		);
+	});
+});
+
+describe("pull_request_review_comment", () => {
+	function reviewCommentEvent(body: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+		return {
+			action: "created",
+			pull_request: { number: 42 },
+			comment: {
+				id: 55,
+				pull_request_review_id: 999,
+				path: "src/a.ts",
+				line: 10,
+				diff_hunk: "@@ -1 +1 @@",
+				body,
+				user: { login: "human", type: "User" },
+			},
+			repository: { full_name: "acme/web" },
+			...overrides,
+		};
+	}
+
+	test("mention in a diff thread → threaded reply instruction + 👀 ack", async () => {
+		const h = makeHarness();
+		const action = asRun(await h.router.route(reviewCommentEvent("@gajae 이 라인 왜 이래?")));
+		expect(action.instruction).toContain("repos/acme/web/pulls/42/comments/55/replies");
+		expect(action.instruction).toContain("src/a.ts");
+		expect(h.acks).toEqual([{ commentId: 55, reviewComment: true }]);
+	});
+
+	test("no mention / bot author / non-created → silent", async () => {
+		const h = makeHarness();
+		expect((await h.router.route(reviewCommentEvent("그냥 리뷰 코멘트"))).kind).toBe("silent");
+		expect((await h.router.route(reviewCommentEvent("@gajae hi", { action: "edited" }))).kind).toBe("silent");
+	});
+});
+
+describe("parseCommand / mentionsBot", () => {
+	const aliases = ["gajae", "가재"];
+	test("recognizes commands with and without @, case-insensitive", () => {
+		expect(parseCommand("@gajae review", aliases)).toEqual({ cmd: "review", args: "" });
+		expect(parseCommand("GAJAE Summary now", aliases)).toEqual({ cmd: "summary", args: "now" });
+		expect(parseCommand("가재 리뷰", aliases)).toEqual({ cmd: "review", args: "" });
+		expect(parseCommand("가재 learn 룰은 룰이다", aliases)).toEqual({ cmd: "learn", args: "룰은 룰이다" });
+	});
+	test("non-commands return null", () => {
+		expect(parseCommand("@gajae 안녕", aliases)).toBeNull();
+		expect(parseCommand("reviews are nice", aliases)).toBeNull();
+		expect(parseCommand("", aliases)).toBeNull();
+	});
+	test("mentionsBot matches any alias", () => {
+		expect(mentionsBot("hey @gajae look", aliases)).toBe(true);
+		expect(mentionsBot("가재야 고마워", aliases)).toBe(true);
+		expect(mentionsBot("nothing here", aliases)).toBe(false);
+	});
+});
+
+describe("parseMinimalYaml", () => {
+	test("scalars, booleans, ints, inline and block lists", () => {
+		const doc = parseMinimalYaml(
+			[
+				"# comment",
+				"enabled: true",
+				"max_comments: 5",
+				'tone: "친절하게"',
+				"ignore_paths: [dist/, gen/]",
+				"reviewers:",
+				"  - alice",
+				'  - "bob"',
+			].join("\n"),
+		);
+		expect(doc.enabled).toBe(true);
+		expect(doc.max_comments).toBe(5);
+		expect(doc.tone).toBe("친절하게");
+		expect(doc.ignore_paths).toEqual(["dist/", "gen/"]);
+		expect(doc.reviewers).toEqual(["alice", "bob"]);
+	});
+
+	test("list of maps with continuation keys (path_instructions)", () => {
+		const doc = parseMinimalYaml(
+			[
+				"path_instructions:",
+				'  - path: "src/api/**"',
+				"    instructions: REST 규칙 검사",
+				'  - path: "**/*.sql"',
+				"    instructions: 인덱스 확인",
+			].join("\n"),
+		);
+		expect(doc.path_instructions).toEqual([
+			{ path: "src/api/**", instructions: "REST 규칙 검사" },
+			{ path: "**/*.sql", instructions: "인덱스 확인" },
+		]);
+	});
+});

--- a/packages/coding-agent/test/github-review-server.test.ts
+++ b/packages/coding-agent/test/github-review-server.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { completeReviewRun } from "../src/github-review/complete";
+import type { GithubReviewConfig } from "../src/github-review/config";
+import {
+	DeliveryLog,
+	type GithubReviewServer,
+	startGithubReviewServer,
+	verifySignature,
+} from "../src/github-review/server";
+import { ReviewService } from "../src/github-review/service";
+import { detectMissedPrs } from "../src/github-review/sweeper";
+
+const SECRET = "s3cret";
+const tmps: string[] = [];
+const servers: GithubReviewServer[] = [];
+
+afterEach(async () => {
+	for (const server of servers.splice(0)) await server.close();
+	for (const dir of tmps.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function testConfig(overrides: Partial<GithubReviewConfig> = {}): GithubReviewConfig {
+	const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ghr-server-"));
+	tmps.push(dataDir);
+	return {
+		appId: "1",
+		installationId: "2",
+		privateKeyPath: "/nonexistent.pem",
+		webhookSecret: SECRET,
+		botLogin: "gajae-code",
+		botAliases: ["gajae"],
+		botDisplayName: "가재",
+		markerPrefix: "gajae",
+		checkName: "가재 코드리뷰",
+		host: "127.0.0.1",
+		port: 0,
+		webhookPath: "/webhooks/gajae",
+		maxInflight: 4,
+		turnTimeoutMinutes: 45,
+		cwd: os.tmpdir(),
+		dataDir,
+		ignoreRepos: [],
+		repoConfigFile: ".gajae.yaml",
+		inflightStaleSeconds: 20 * 60,
+		sweepIntervalSeconds: 0,
+		sweepStaleMinutes: 10,
+		postCommand: "gajae-gh",
+		completeCommand: "gajae-review-complete",
+		localWebhookUrl: "http://127.0.0.1:0/webhooks/gajae",
+		apiBase: "https://api.github.invalid",
+		...overrides,
+	};
+}
+
+function sign(body: string, secret = SECRET): string {
+	return `sha256=${crypto.createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+/** Payload that reaches the router but resolves silently (bot author). */
+const SILENT_PAYLOAD = JSON.stringify({
+	action: "opened",
+	number: 1,
+	pull_request: { draft: false, user: { login: "x[bot]", type: "Bot" }, head: { sha: "a" } },
+	repository: { full_name: "acme/web" },
+});
+
+async function post(server: GithubReviewServer, body: string, headers: Record<string, string>): Promise<Response> {
+	return await fetch(`http://127.0.0.1:${server.port}/webhooks/gajae`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json", ...headers },
+		body,
+	});
+}
+
+describe("verifySignature", () => {
+	const body = new TextEncoder().encode("payload");
+	test("accepts a valid signature", () => {
+		expect(verifySignature(SECRET, body, sign("payload"))).toBe(true);
+	});
+	test("rejects wrong secret, malformed header, missing header", () => {
+		expect(verifySignature(SECRET, body, sign("payload", "other"))).toBe(false);
+		expect(verifySignature(SECRET, body, "sha1=abc")).toBe(false);
+		expect(verifySignature(SECRET, body, null)).toBe(false);
+	});
+});
+
+describe("DeliveryLog", () => {
+	test("dedupes and bounds memory", () => {
+		const log = new DeliveryLog(4);
+		expect(log.alreadySeen("a")).toBe(false);
+		expect(log.alreadySeen("a")).toBe(true);
+		for (const id of ["b", "c", "d", "e"]) log.alreadySeen(id);
+		// "a" was evicted by the LRU trim → treated as new again
+		expect(log.alreadySeen("a")).toBe(false);
+	});
+});
+
+describe("webhook server", () => {
+	async function startServer(): Promise<GithubReviewServer> {
+		const server = await startGithubReviewServer(testConfig(), () => {});
+		servers.push(server);
+		return server;
+	}
+
+	test("health reports runner load", async () => {
+		const server = await startServer();
+		const res = await fetch(`http://127.0.0.1:${server.port}/health`);
+		expect(await res.json()).toEqual({ ok: true, running: 0, queued: 0 });
+	});
+
+	test("rejects bad signatures with 401", async () => {
+		const server = await startServer();
+		const res = await post(server, SILENT_PAYLOAD, {
+			"X-Hub-Signature-256": sign(SILENT_PAYLOAD, "wrong"),
+			"X-GitHub-Event": "pull_request",
+			"X-GitHub-Delivery": "d1",
+		});
+		expect(res.status).toBe(401);
+	});
+
+	test("filters events, dedupes deliveries, routes silent payloads", async () => {
+		const server = await startServer();
+		const headers = {
+			"X-Hub-Signature-256": sign(SILENT_PAYLOAD),
+			"X-GitHub-Event": "pull_request",
+			"X-GitHub-Delivery": "d2",
+		};
+		const first = await post(server, SILENT_PAYLOAD, headers);
+		expect(await first.json()).toEqual({ ok: true, skipped: "bot author" });
+		const dup = await post(server, SILENT_PAYLOAD, headers);
+		expect(await dup.json()).toEqual({ ok: true, skipped: "duplicate" });
+		const wrongEvent = await post(server, SILENT_PAYLOAD, {
+			...headers,
+			"X-GitHub-Event": "push",
+			"X-GitHub-Delivery": "d3",
+		});
+		expect(await wrongEvent.json()).toEqual({ ok: true, skipped: "event" });
+		const notFound = await fetch(`http://127.0.0.1:${server.port}/nope`);
+		expect(notFound.status).toBe(404);
+	});
+});
+
+describe("completeReviewRun", () => {
+	test("closes the stored check, flips the status line, drains pending via signed requeue", async () => {
+		const config = testConfig();
+		const service = new ReviewService(config);
+		// Start a review with a pending supersede and a recorded check.
+		service.store.tryAcquireReview("acme/web", 42, "aaa");
+		service.store.setPrState("acme/web", 42, { check_id: 77 });
+		service.store.tryAcquireReview("acme/web", 42, "bbb");
+
+		const closedChecks: Array<{ id: number; conclusion: string }> = [];
+		const statusLines: string[] = [];
+		const requeued: Array<{ pr: number; sha: string }> = [];
+		service.closeCheck = async (_repo, _sha, checkId, conclusion) => {
+			closedChecks.push({ id: checkId ?? -1, conclusion });
+			return checkId ? 1 : 0;
+		};
+		service.upsertStatusLine = async (_repo, _pr, line) => {
+			statusLines.push(line);
+			return 1;
+		};
+		const realFetch = globalThis.fetch;
+		globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+			const body = JSON.parse(String(init?.body)) as { number: number; pull_request: { head: { sha: string } } };
+			requeued.push({ pr: body.number, sha: body.pull_request.head.sha });
+			// requeue POSTs must be signed so the gateway accepts them
+			const headers = init?.headers as Record<string, string>;
+			const expected = `sha256=${crypto.createHmac("sha256", SECRET).update(String(init?.body)).digest("hex")}`;
+			expect(headers["X-Hub-Signature-256"]).toBe(expected);
+			return new Response("{}", { status: 200 });
+		}) as typeof fetch;
+		try {
+			await completeReviewRun(service, "acme/web", 42, "aaa", "success");
+		} finally {
+			globalThis.fetch = realFetch;
+		}
+		expect(closedChecks).toEqual([{ id: 77, conclusion: "success" }]);
+		expect(statusLines).toHaveLength(1);
+		expect(statusLines[0]).toContain("✅");
+		expect(requeued).toEqual([{ pr: 42, sha: "bbb" }]);
+		expect(service.store.getPrState("acme/web", 42).review_status).toBe("posted");
+	});
+
+	test("stale completion only closes its own check by sha", async () => {
+		const config = testConfig();
+		const service = new ReviewService(config);
+		service.store.tryAcquireReview("acme/web", 42, "newer");
+		const closed: Array<number | null> = [];
+		service.closeCheck = async (_repo, _sha, checkId) => {
+			closed.push(checkId);
+			return 0;
+		};
+		service.upsertStatusLine = async () => {
+			throw new Error("stale completion must not touch the status line");
+		};
+		await completeReviewRun(service, "acme/web", 42, "older", "failure");
+		expect(closed).toEqual([null]); // sha-lookup path, no stored id
+		expect(service.store.getPrState("acme/web", 42).in_flight_sha).toBe("newer");
+	});
+});
+
+describe("detectMissedPrs", () => {
+	const now = Date.parse("2026-07-24T12:00:00Z");
+	const mkPr = (num: number, ageMin: number, extra: Record<string, unknown> = {}) => ({
+		number: num,
+		head: { sha: `sha${num}` },
+		created_at: new Date(now - ageMin * 60_000).toISOString(),
+		user: { login: "human", type: "User" },
+		...extra,
+	});
+
+	test("flags human non-draft PRs without state inside [grace, lookback]", () => {
+		const found = detectMissedPrs(
+			new Set(["acme/web#1"]),
+			"acme/web",
+			[
+				mkPr(1, 60), // has state → skip
+				mkPr(2, 60), // → flagged
+				mkPr(3, 5), // too fresh (grace) → skip
+				mkPr(4, 26 * 60), // too old (lookback) → skip
+				mkPr(5, 60, { draft: true }),
+				mkPr(6, 60, { user: { login: "dep[bot]", type: "Bot" } }),
+			],
+			now,
+		);
+		expect(found).toEqual([{ repo: "acme/web", pr: 2, sha: "sha2", ageMin: 60 }]);
+	});
+});

--- a/packages/coding-agent/test/github-review-state.test.ts
+++ b/packages/coding-agent/test/github-review-state.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ReviewStateStore } from "../src/github-review/state";
+
+const STALE_SEC = 20 * 60;
+const tmps: string[] = [];
+
+function makeStore(now: () => number): ReviewStateStore {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ghr-state-"));
+	tmps.push(dir);
+	return new ReviewStateStore(dir, STALE_SEC, now);
+}
+
+afterEach(() => {
+	for (const dir of tmps.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("review gate CAS", () => {
+	test("acquire → duplicate → supersede", () => {
+		let now = 1000;
+		const store = makeStore(() => now);
+		expect(store.tryAcquireReview("o/r", 1, "aaa").status).toBe("acquired");
+		expect(store.tryAcquireReview("o/r", 1, "aaa").status).toBe("duplicate");
+		const superseded = store.tryAcquireReview("o/r", 1, "bbb");
+		expect(superseded.status).toBe("superseded");
+		expect(superseded.state.pending_sha).toBe("bbb");
+		now += 10;
+		expect(store.getPrState("o/r", 1).in_flight_sha).toBe("aaa");
+	});
+
+	test("stale in-flight is re-acquirable", () => {
+		let now = 1000;
+		const store = makeStore(() => now);
+		store.tryAcquireReview("o/r", 1, "aaa");
+		now += STALE_SEC + 1;
+		expect(store.tryAcquireReview("o/r", 1, "bbb").status).toBe("acquired");
+	});
+
+	test("concurrency cap queues other PRs, not the same PR", () => {
+		const store = makeStore(() => 1000);
+		expect(store.tryAcquireReview("o/r", 1, "aaa", 1).status).toBe("acquired");
+		const queued = store.tryAcquireReview("o/r", 2, "ccc", 1);
+		expect(queued.status).toBe("queued");
+		expect(queued.state.queued_sha).toBe("ccc");
+		// Same PR with a newer sha supersedes rather than queues.
+		expect(store.tryAcquireReview("o/r", 1, "bbb", 1).status).toBe("superseded");
+	});
+
+	test("acquiring a pending sha clears pending", () => {
+		let now = 1000;
+		const store = makeStore(() => now);
+		store.tryAcquireReview("o/r", 1, "aaa");
+		store.tryAcquireReview("o/r", 1, "bbb");
+		now += STALE_SEC + 1;
+		const acquired = store.tryAcquireReview("o/r", 1, "bbb");
+		expect(acquired.status).toBe("acquired");
+		expect(acquired.state.pending_sha).toBeUndefined();
+	});
+});
+
+describe("completeReview", () => {
+	test("success releases state and reports pending + duration", () => {
+		let now = 1000;
+		const store = makeStore(() => now);
+		store.tryAcquireReview("o/r", 1, "aaa");
+		store.setPrState("o/r", 1, { check_id: 77 });
+		store.tryAcquireReview("o/r", 1, "bbb"); // supersede
+		now += 300;
+		const result = store.completeReview("o/r", 1, "aaa", true);
+		expect(result.stale).toBe(false);
+		expect(result.pendingSha).toBe("bbb");
+		expect(result.checkId).toBe(77);
+		expect(result.durationSeconds).toBe(300);
+		const state = store.getPrState("o/r", 1);
+		expect(state.review_status).toBe("posted");
+		expect(state.last_reviewed_sha).toBe("aaa");
+		expect(state.review_count).toBe(1);
+		expect(state.in_flight_sha).toBeUndefined();
+	});
+
+	test("stale when a newer run owns the lock", () => {
+		const store = makeStore(() => 1000);
+		store.tryAcquireReview("o/r", 1, "bbb");
+		const result = store.completeReview("o/r", 1, "aaa", true);
+		expect(result.stale).toBe(true);
+		expect(store.getPrState("o/r", 1).in_flight_sha).toBe("bbb");
+	});
+
+	test("idempotent: re-completing the same sha does not double-count", () => {
+		const store = makeStore(() => 1000);
+		store.tryAcquireReview("o/r", 1, "aaa");
+		store.completeReview("o/r", 1, "aaa", true);
+		store.completeReview("o/r", 1, "aaa", true);
+		expect(store.getPrState("o/r", 1).review_count).toBe(1);
+	});
+
+	test("failure keeps last_reviewed_sha untouched", () => {
+		const store = makeStore(() => 1000);
+		store.setPrState("o/r", 1, { last_reviewed_sha: "old" });
+		store.tryAcquireReview("o/r", 1, "aaa");
+		store.completeReview("o/r", 1, "aaa", false);
+		const state = store.getPrState("o/r", 1);
+		expect(state.review_status).toBe("failed");
+		expect(state.last_reviewed_sha).toBe("old");
+	});
+});
+
+describe("drain candidates", () => {
+	test("pending first, then queued oldest-first; fresh in-flight excluded", () => {
+		const now = 1000;
+		const store = makeStore(() => now);
+		// live in-flight with a pending sha → excluded (its completion drains it)
+		store.tryAcquireReview("o/r", 1, "aaa");
+		store.tryAcquireReview("o/r", 1, "bbb");
+		// stale in-flight with pending → included
+		store.setPrState("o/r", 2, {
+			review_status: "in_flight",
+			in_flight_sha: "ccc",
+			in_flight_since: now - STALE_SEC - 5,
+			pending_sha: "ddd",
+		});
+		// queued entries, different ages
+		store.setPrState("o/r", 3, { review_status: "queued", queued_sha: "eee", queued_since: now - 50 });
+		store.setPrState("o/r", 4, { review_status: "queued", queued_sha: "fff", queued_since: now - 100 });
+		const candidates = store.findDrainCandidates(5);
+		expect(candidates).toEqual([
+			{ repo: "o/r", pr: 2, sha: "ddd" },
+			{ repo: "o/r", pr: 4, sha: "fff" },
+			{ repo: "o/r", pr: 3, sha: "eee" },
+		]);
+	});
+
+	test("countInflight ignores stale entries", () => {
+		let now = 1000;
+		const store = makeStore(() => now);
+		store.tryAcquireReview("o/r", 1, "aaa");
+		store.tryAcquireReview("o/r", 2, "bbb");
+		expect(store.countInflight()).toBe(2);
+		now += STALE_SEC + 1;
+		expect(store.countInflight()).toBe(0);
+	});
+});


### PR DESCRIPTION
## What

A built-in GitHub code-review bot: `gjc github-review serve` turns a GitHub App webhook into CodeRabbit-style automated PR reviews executed by embedded agent sessions (`createAgentSession`). Battle-tested design: this is a TypeScript port of a pipeline that has been reviewing production PRs daily (inline comments, walkthrough summaries with mermaid diagrams and a closing poem, incremental re-reviews on push).

## Surface

```
gjc github-review serve              # webhook server + in-process sweeper
gjc github-review sweep [--dry-run]  # one-shot reconcile
gjc github-review complete R N SHA V # idempotent completion (called by agent turns)
gjc github-review token|gh|status    # App token, App-identity gh passthrough, state dump
```

Config: `~/.gjc/github-review.json` (App id/installation/PEM/secret/bot identity) + `GJC_GHR_*` env overrides. Per-repo tuning via a config file at the PR head (`enabled`, `diagrams`, `poem`, `pr_summary`, `tone`, `max_comments`, `ignore_paths`, `path_instructions`) parsed by a dependency-free YAML subset parser.

## Design notes

- **Gate → ack → run → complete.** A cross-process CAS state machine per PR (in-flight dedup, supersede-on-newer-sha, concurrency queue). Instant UX ack: `in_progress` check-run + live ⏳ status line upserted into the marked walkthrough comment.
- **Completion is code-owned, not LLM-owned.** The review prompt ends with the idempotent `complete` helper; the runner force-fails abandoned sessions; the interval sweeper reaps stuck check-runs (GitHub never expires them), stale in-flight state, and PRs whose `opened` delivery was lost (observed in production). Waiting PRs are drained via signed self-requeue POSTs.
- **Daemon safety.** Serve installs an exit guard: embedded-SDK code paths that call `process.exit` (e.g. the session `shutdown` binding — observed killing in-flight reviews) are blocked and logged with a stack; only the SIGTERM drain path may exit. Graceful drain waits for running reviews before exiting.
- **Zero new dependencies.** RS256 App JWT via node:crypto, REST via fetch, node:http server.
- Review sessions are remote-read-only (`gh pr diff` / compare API); prompts ban clone/redirect/heredoc, which the security guard would block mid-review anyway.

## Tests

`github-review-{state,router,server}.test.ts` — 78 new assertions across the state machine, router decisions and instruction content (incl. incremental mode and thread auto-resolve), command parsing (Unicode-boundary aware for Korean aliases), YAML subset parser, HMAC/dedup HTTP surface (real server), completion + drain (signed requeue verified), and missed-PR detection. `tsc` clean; smoke-tested serve end-to-end (health, signed/unsigned POSTs, SIGTERM drain).
