### PR TITLE
fix(session): tolerate detached artifact root ctime after #3052

### DIFF
--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -2353,10 +2353,11 @@ function sameArtifactTree(
 ): boolean {
 	const { platform = process.platform, phase = "strict" } = policy;
 	const entryKey = (entry: NativeDirectoryTreeSnapshot["entries"][number]): string => {
-		// pi-iso accepts Windows plain directories by stable file id and kind only: NTFS can lazily
-		// update directory size, mtime, and ctime while enumeration trails an open handle. All other
-		// platforms and phases compare every captured field, including nested-directory ctime.
-		if (phase === "migration" && platform === "win32" && entry.kind === "directory")
+		// Detaching the root directory changes its ctime without changing the preserved artifact tree;
+		// root identity and mtime are checked above. pi-iso also accepts Windows plain directories by
+		// stable file id and kind only because NTFS can lazily update their metadata while enumeration
+		// trails an open handle. All other platforms and nested directories compare every captured field.
+		if (phase === "migration" && entry.kind === "directory" && (entry.relativePath === "" || platform === "win32"))
 			return JSON.stringify([entry.relativePath, entry.kind, entry.dev, entry.ino]);
 		return JSON.stringify([
 			entry.relativePath,

--- a/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
+++ b/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
@@ -206,6 +206,39 @@ describe("managed session Windows durability", () => {
 		expect(matchesMigrationArtifactRoot(artifacts, identity, expectedTree, "win32")).toBe(false);
 	});
 
+	it("tolerates a POSIX root ctime change caused by detaching artifacts", async () => {
+		const root = temporaryDirectory("gjc-posix-root-ctime-");
+		temporaryDirectories.push(root);
+		const artifacts = path.join(root, "artifacts");
+		await fs.mkdir(artifacts);
+		const stat = syncFs.lstatSync(artifacts, { bigint: true });
+		const snapshot = native.snapshotDirectoryTree(artifacts);
+		if (!snapshot.ok || !snapshot.snapshot) throw new Error("Native snapshot unavailable");
+		const snapshotDirectoryTree = native.snapshotDirectoryTree;
+		vi.spyOn(native, "snapshotDirectoryTree").mockImplementation(pathname => {
+			const observed = snapshotDirectoryTree(pathname);
+			if (!observed.ok || !observed.snapshot) return observed;
+			return {
+				...observed,
+				snapshot: {
+					...observed.snapshot,
+					entries: observed.snapshot.entries.map(entry =>
+						entry.relativePath === "" && entry.kind === "directory"
+							? { ...entry, ctimeNs: (BigInt(entry.ctimeNs) + 1n).toString() }
+							: entry,
+					),
+				},
+			};
+		});
+		expect(
+			matchesMigrationArtifactRoot(
+				artifacts,
+				{ dev: stat.dev, ino: stat.ino, size: stat.size, mtimeNs: stat.mtimeNs },
+				snapshot.snapshot,
+				"darwin",
+			),
+		).toBe(true);
+	});
 	it("rejects POSIX nested-directory ctime drift", async () => {
 		const root = temporaryDirectory("gjc-posix-directory-ctime-");
 		temporaryDirectories.push(root);


### PR DESCRIPTION
## Summary
Post-merge repair for #3052: routing detached-root validation through the strict `sameArtifactTree` comparator broke legacy artifact migration on POSIX — `exactUnlink`'s root rename necessarily advances the root directory's ctime, so validation rejected the just-detached root as `durability_failed`. Dev CI on tip 5ead6a1c5 fails 5 session-directory tests with exactly this signature.

## Fix
Migration-phase comparison ignores ctime **only for the root directory entry** (relativePath === "") — root identity (dev/ino) and mtime are still verified by `matchesMigrationArtifactRoot` before tree comparison; nested directories remain fully strict on POSIX; Windows keeps its pi-iso-matched relaxation. Adds a Darwin root-ctime-drift regression test (suite now 10/10).

Fixes the Dev CI failures on dev tip 5ead6a1c5 (run 30077382347).