### PR TITLE
fix(deep-interview): exempt round-0 intent shell from topology component check

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
@@ -1661,7 +1661,9 @@ export function validateDeepInterviewV1Envelope(value: Record<string, unknown>):
 			roundRecord.component !== undefined &&
 			(typeof roundRecord.component !== "string" ||
 				roundRecord.component === "" ||
-				(hasTopologyComponents && !componentIds.has(roundRecord.component)))
+				(hasTopologyComponents &&
+					!componentIds.has(roundRecord.component) &&
+					!(isRoundZeroIntentShell && roundRecord.component === "review-topology")))
 		)
 			return invalid();
 		if (

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-intent-shell-validation.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-intent-shell-validation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { validateDeepInterviewV1Envelope } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-state";
+
+/**
+ * Regression for the deep-interview flake: the Round 0 intent-contract shell
+ * deliberately carries the sentinel component `"review-topology"` (see ask.ts /
+ * deep-interview-recorder.ts buildAnswerShell). Once topology is confirmed,
+ * `hasTopologyComponents` is true and `"review-topology"` is not one of the real
+ * component ids, so the component check must exempt the round-zero intent shell
+ * exactly as the sibling dimension check already exempts `"topology"`. Without the
+ * exemption the whole envelope failed `DI_STATE_SCHEMA_INVALID` depending on the
+ * ordering of Round 0 recording vs `confirm-topology`.
+ */
+function envelopeWithConfirmedTopology(roundComponent: string): Record<string, unknown> {
+	return {
+		skill: "deep-interview",
+		schema_version: 1,
+		state: {
+			type: "greenfield",
+			threshold: 0.05,
+			threshold_units: 500,
+			established_facts: [],
+			topology: {
+				status: "confirmed",
+				components: [
+					{ id: "transport" },
+					{ id: "protocol-schema" },
+					{ id: "core-api" },
+					{ id: "aux-api" },
+					{ id: "cli-entrypoint" },
+				],
+			},
+			rounds: [
+				{
+					round_key: "iv1::r:0::q:intent-confirmation",
+					round: 0,
+					question_id: "intent-confirmation",
+					question_text: "Confirm locked intent",
+					question_hash: "a".repeat(64),
+					answer_hash: "b".repeat(64),
+					answered_at: "2026-01-01T00:00:00.000Z",
+					lifecycle: "answered",
+					component: roundComponent,
+					dimension: "topology",
+				},
+			],
+		},
+	};
+}
+
+describe("validateDeepInterviewV1Envelope: round-0 intent shell component", () => {
+	it("accepts the review-topology sentinel after topology is confirmed", () => {
+		expect(() => validateDeepInterviewV1Envelope(envelopeWithConfirmedTopology("review-topology"))).not.toThrow();
+	});
+
+	it("still rejects an unknown component on the round-0 shell", () => {
+		expect(() => validateDeepInterviewV1Envelope(envelopeWithConfirmedTopology("not-a-component"))).toThrow(
+			"DI_STATE_SCHEMA_INVALID",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a deep-interview flake where locking the Round 0 intent contract fails with `DI_STATE_SCHEMA_INVALID` depending on the ordering of Round 0 recording vs `confirm-topology`.

The Round 0 intent-contract shell deliberately carries the **sentinel** component `"review-topology"` (`ask.ts:165`, `deep-interview-recorder.ts` `buildAnswerShell` via `input.component`). This is not a real topology component. In `validateDeepInterviewV1Envelope` (`deep-interview-state.ts`), the per-round **component** membership check had no exemption for the round-zero intent shell, while the sibling **dimension** check already exempts it:

```ts
// dimension check already had the round-zero exemption:
!(isRoundZeroIntentShell && roundRecord.dimension === "topology")
```

So once topology is confirmed (`hasTopologyComponents === true`) and `componentIds` does not contain `"review-topology"`, re-validating the envelope rejected the shell. Whether it fired depended on ordering (Round 0 recorded before vs after `confirm-topology`), which made it present as an intermittent flake.

## Fix

Add the symmetric round-zero exemption to the component check so a round-0 intent shell with component `"review-topology"` always validates:

```ts
(hasTopologyComponents &&
    !componentIds.has(roundRecord.component) &&
    !(isRoundZeroIntentShell && roundRecord.component === "review-topology"))
```

The exemption is narrow: it applies only to the round-zero intent shell and only for the exact `"review-topology"` sentinel. Any other unknown component still fails validation.

## Tests

- New regression test `test/gjc-runtime/deep-interview-intent-shell-validation.test.ts`:
  - accepts `review-topology` on the round-0 shell after topology is confirmed
  - still rejects an unknown component on the round-0 shell
- `bun run check:types` clean; biome clean.
- Existing deep-interview recorder / ambiguity / runtime / gate-redteam suites pass.

## Notes

A pre-existing, unrelated failure in `state-handoff-thrift.test.ts` (macOS `/var` vs `/private/var` tmpdir symlink normalization) is not touched by this change.
