### PR TITLE
fix(session): reclaim dead migration owners

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
 - Windows managed-session resume no longer reports `durability_failed` when Bun rejects `fsync` on the read-only descriptor used to revalidate an existing canonical binding; Windows now uses an owner-writable descriptor for that durability fence while retaining no-follow and pre/post identity/content checks.
+- macOS managed-session resume now immediately reclaims an unexpired migration lease when its owning process has exited, preventing a crashed prior session from surfacing `migration_busy`.
 - SDK daemon CLI end-to-end tests now drain spawned child stdout and stderr concurrently with process exit, preventing CI pipe teardown races from replacing the product exit contract with SIGPIPE status 141 (#3024).
 - Interactive launch bootstrap is now suppressed for parser-accepted `--print=`, `--help=`, and `--version=` equals forms, keeping non-interactive output free of the warming-workspace preamble on TTYs.
 

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -1615,8 +1615,10 @@ export async function acquireManagedLock(
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
 			const owner = parseLock(lockPath);
-			if (owner && owner.leaseExpiresAt < Date.now()) {
-				const ownerGone = ownerDefinitelyGone(owner);
+			const ownerGone = owner ? ownerDefinitelyGone(owner) : false;
+			// A crashed process cannot renew or publish through its descriptor. Reclaim it
+			// immediately instead of waiting for the still-future lease to expire.
+			if (owner && (ownerGone || owner.leaseExpiresAt < Date.now())) {
 				if (staleObservedAt === undefined) staleObservedAt = Date.now();
 				if (ownerGone || Date.now() - staleObservedAt >= LOCK_STALE_RECHECK_MS) {
 					const quarantine = `${lockPath}.${randomUUID()}.stale`;

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -6,6 +6,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as native from "@gajae-code/natives";
 import {
+	acquireManagedLock,
 	ManagedSessionDescendantStore,
 	managedDirectoryRoot,
 	publishManagedFileNoReplace,
@@ -31,6 +32,69 @@ import {
 	type VerifiedSessionDeleteTarget,
 } from "../src/session/session-storage";
 
+describe("managed storage lock recovery", () => {
+	it("reclaims a dead owner's unexpired lease instead of returning migration_busy", async () => {
+		const root = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-dead-managed-lock-"));
+		try {
+			const exited = Bun.spawn([process.execPath, "-e", "process.exit(0)"], {
+				stdout: "ignore",
+				stderr: "ignore",
+			});
+			await exited.exited;
+			const locksDirectory = path.join(root, "locks");
+			await fsp.mkdir(locksDirectory, { mode: 0o700 });
+			const lockPath = path.join(locksDirectory, "resume.lock");
+			const now = Date.now();
+			await fsp.writeFile(
+				lockPath,
+				`${JSON.stringify({
+					attemptId: "abandoned-attempt",
+					pid: exited.pid,
+					processStartId: "abandoned-process",
+					createdAt: now,
+					heartbeatAt: now,
+					leaseExpiresAt: now + 60_000,
+				})}\n`,
+				{ mode: 0o600 },
+			);
+
+			const lock = await acquireManagedLock(locksDirectory, "resume");
+			try {
+				expect(lock.path).toBe(lockPath);
+				expect(lock.attemptId).not.toBe("abandoned-attempt");
+				lock.assertOwned();
+			} finally {
+				await lock.release();
+			}
+		} finally {
+			await fsp.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not reclaim a live owner's unexpired lease", async () => {
+		const root = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-live-managed-lock-"));
+		try {
+			const locksDirectory = path.join(root, "locks");
+			await fsp.mkdir(locksDirectory, { mode: 0o700 });
+			const lockPath = path.join(locksDirectory, "resume.lock");
+			const now = Date.now();
+			const record = {
+				attemptId: "live-attempt",
+				pid: process.pid,
+				processStartId: "live-process",
+				createdAt: now,
+				heartbeatAt: now,
+				leaseExpiresAt: now + 60_000,
+			};
+			await fsp.writeFile(lockPath, `${JSON.stringify(record)}\n`, { mode: 0o600 });
+
+			await expect(acquireManagedLock(locksDirectory, "resume")).rejects.toThrow("migration_busy");
+			expect(JSON.parse(await fsp.readFile(lockPath, "utf8"))).toEqual(record);
+		} finally {
+			await fsp.rm(root, { recursive: true, force: true });
+		}
+	}, 10_000);
+});
 describe("native publish outcome classification", () => {
 	const preMutation = {
 		ok: false,


### PR DESCRIPTION
## Summary

- reclaim a managed migration lock immediately when its recorded owner process is definitively gone, even if the lease expiry is still in the future
- preserve the existing bounded wait and fail-closed behavior for live or ambiguously observable owners
- add regressions for both the dead-owner recovery path and the live-owner fencing invariant

## Root cause

A prior GJC process can exit or crash while its managed migration lease still has up to 60 seconds remaining. `acquireManagedLock()` previously checked process liveness only after `leaseExpiresAt`, so a quick macOS `gjc --continue` or `/resume` retried for five seconds and surfaced `migration_busy` even though the recorded owner no longer existed.

The lock now enters the existing identity-bound quarantine/reclaim path when `ownerDefinitelyGone()` proves the PID is absent (`ESRCH`, or an existing boot-ID mismatch). `EPERM` and every ambiguous result remain non-authoritative, so live/unknown owners are not stolen. The existing inode, attempt ID, heartbeat, release, and publication fencing is unchanged.

## Verification

- `bun test packages/coding-agent/test/session-storage.test.ts -t "managed storage lock recovery"` — 2 passed
- `bun test packages/coding-agent/test/session-manager/session-directory.test.ts -t "copy-retains a legacy candidate|revalidates an existing canonical binding"` — 2 passed
- `bunx biome check packages/coding-agent/src/session/internal/managed-session-storage.ts packages/coding-agent/test/session-storage.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

The full `session-storage.test.ts` suite has unrelated Windows-native mocking and symlink-permission baseline failures on this Windows host; the new lock tests and managed resume migration tests pass. Hosted CI/macOS maintainer verification is requested for the reported platform.