### PR TITLE
fix(coding-agent): isolate tombstone reconciliation failures per-target

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Rejected subagent schema payloads now retain their complete structured data in canonical output artifacts; inline results remain bounded while `agent://` output stays lossless (#2894).
 - Managed legacy-session artifact migration now validates Windows directory roots from the native tree snapshot, tolerates only lazy metadata on plain Windows directories, and replays both clean and cleanup-pending detaches while retaining fail-closed receipt validation. Canonical binding durability sync uses a writable no-follow handle on Windows NTFS stacks that reject `FlushFileBuffers` on read-only handles (#3015, #2913).
-- A single managed session tombstone that fails to reconcile (e.g. an artifact directory identity mismatch) no longer blocks resume or delete of every other session in the same managed scope; the failure is isolated to that tombstone and logged, unless it belongs to the session currently being opened, which still fails closed (#<issue-1-number>).
+- A single managed session tombstone that fails to reconcile (e.g. an artifact directory identity mismatch) no longer blocks resume or delete of every other session in the same managed scope; the failure is isolated to that tombstone and logged, unless it belongs to the session currently being opened, which still fails closed.
 
 ## [0.11.8] - 2026-07-23
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Rejected subagent schema payloads now retain their complete structured data in canonical output artifacts; inline results remain bounded while `agent://` output stays lossless (#2894).
 - Managed legacy-session artifact migration now validates Windows directory roots from the native tree snapshot, tolerates only lazy metadata on plain Windows directories, and replays both clean and cleanup-pending detaches while retaining fail-closed receipt validation. Canonical binding durability sync uses a writable no-follow handle on Windows NTFS stacks that reject `FlushFileBuffers` on read-only handles (#3015, #2913).
+- A single managed session tombstone that fails to reconcile (e.g. an artifact directory identity mismatch) no longer blocks resume or delete of every other session in the same managed scope; the failure is isolated to that tombstone and logged, unless it belongs to the session currently being opened, which still fails closed (#<issue-1-number>).
+
 ## [0.11.8] - 2026-07-23
 ### Added
 

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -8,7 +8,7 @@ import {
 	verifyOwnerOnlyPathSecurity,
 	verifyOwnerOnlyPathSecurityExpected,
 } from "@gajae-code/natives";
-import { pathIsWithin } from "@gajae-code/utils";
+import { logger, pathIsWithin } from "@gajae-code/utils";
 import type { ResumeSessionIdentity } from "../session-manager";
 import {
 	FileSessionStorage,
@@ -2783,7 +2783,10 @@ function validateCandidateForScope(scope: ManagedScope, candidate: ManagedCandid
 }
 
 /** Resume tombstoned cleanup under its original operation lease without restoring retired candidates. */
-export async function reconcileManagedTombstones(scope: ManagedScope): Promise<void> {
+export async function reconcileManagedTombstones(
+	scope: ManagedScope,
+	expectedCandidate?: ManagedCandidate,
+): Promise<void> {
 	const directory = path.join(managedInternalDirectory(scope), MANAGED_TOMBSTONES_DIRECTORY);
 	for (const name of fs.readdirSync(directory)) {
 		const tombstone = path.join(directory, name);
@@ -2801,135 +2804,148 @@ export async function reconcileManagedTombstones(scope: ManagedScope): Promise<v
 			for (const target of lockedTargets) {
 				lock.assertOwned();
 				if (cleanupCompleted(scope, tombstone, target)) continue;
-				const pending = pendingCleanupReceipt(scope, tombstone, target);
-				const observedPending = pending ? probePlannedCleanupDetach(target, pending) : undefined;
 				try {
-					fs.lstatSync(target.path);
-				} catch (error) {
-					if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-						if (!observedPending) continue;
-						if (
-							cleanupArtifactsRemoved(scope, tombstone, target, observedPending.attempt) &&
-							cleanupRootsAbsent(tombstone, target, observedPending)
-						) {
-							fsyncManagedParent(target.path);
-							await publishCleanupCompleted(scope, tombstone, target, lock);
-							continue;
-						}
-					} else throw error;
-				}
-				const verified = observedPending ? target : validateCandidateForScope(scope, target);
-				if (!verified || !sameCandidate(verified, target)) throw new Error("source_changed");
-				const discoveredDetach =
-					!!observedPending &&
-					(observedPending.detachedArtifactsPath !== pending?.detachedArtifactsPath ||
-						observedPending.detachedTranscriptPath !== pending?.detachedTranscriptPath);
-				const active =
-					discoveredDetach || (observedPending && requiresFreshCleanupPlan(observedPending))
-						? nextCleanupReceipt(target, observedPending)
-						: (observedPending ?? nextCleanupReceipt(target, undefined));
-				if (!observedPending || discoveredDetach || requiresFreshCleanupPlan(observedPending))
-					await publishCleanupPending(scope, tombstone, active, lock);
-				let deletion = await new FileSessionStorage().deleteSessionVerified({
-					sessionsRoot: scope.sessionsRoot,
-					transcriptPath: target.path,
-					sessionId: target.sessionId,
-					cwd: target.cwd,
-					transcriptIdentity: target.identity,
-					expectedArtifactsIdentity: active.expectedArtifactsIdentity,
-					expectedArtifactsTree: active.expectedArtifactsTree,
-					detachedArtifactsPath:
-						active.detachedArtifactsPath ??
-						observedPending?.detachedArtifactsPath ??
-						(fs.existsSync(active.plannedArtifactsPath) ? active.plannedArtifactsPath : undefined),
-					detachedTranscriptPath:
-						active.detachedTranscriptPath ??
-						observedPending?.detachedTranscriptPath ??
-						(pending && fs.existsSync(pending.plannedTranscriptPath)
-							? pending.plannedTranscriptPath
-							: undefined) ??
-						(fs.existsSync(active.plannedTranscriptPath) ? active.plannedTranscriptPath : undefined),
-					retainedArtifactsSuccessorPath: active.retainedArtifactsSuccessorPath,
-					retainedArtifactsPlaceholderPath: active.retainedArtifactsPlaceholderPath,
-					retainedArtifactsUnknownPath: active.retainedArtifactsUnknownPath,
-					retainedTranscriptSuccessorPath: active.retainedTranscriptSuccessorPath,
-					retainedTranscriptPlaceholderPath: active.retainedTranscriptPlaceholderPath,
-					retainedTranscriptUnknownPath: active.retainedTranscriptUnknownPath,
-					plannedArtifactsPath: active.plannedArtifactsPath,
-					plannedTranscriptPath: active.plannedTranscriptPath,
-					...(cleanupArtifactsRemoved(scope, tombstone, target, pending?.attempt ?? active.attempt)
-						? { artifactsRemoved: true as const }
-						: {}),
-				});
-				if (deletion.kind === "artifacts_removed") {
-					await publishCleanupArtifactsRemoved(scope, tombstone, active, lock);
-					deletion = await new FileSessionStorage().deleteSessionVerified({
+					const pending = pendingCleanupReceipt(scope, tombstone, target);
+					const observedPending = pending ? probePlannedCleanupDetach(target, pending) : undefined;
+					try {
+						fs.lstatSync(target.path);
+					} catch (error) {
+						if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+							if (!observedPending) continue;
+							if (
+								cleanupArtifactsRemoved(scope, tombstone, target, observedPending.attempt) &&
+								cleanupRootsAbsent(tombstone, target, observedPending)
+							) {
+								fsyncManagedParent(target.path);
+								await publishCleanupCompleted(scope, tombstone, target, lock);
+								continue;
+							}
+						} else throw error;
+					}
+					const verified = observedPending ? target : validateCandidateForScope(scope, target);
+					if (!verified || !sameCandidate(verified, target)) throw new Error("source_changed");
+					const discoveredDetach =
+						!!observedPending &&
+						(observedPending.detachedArtifactsPath !== pending?.detachedArtifactsPath ||
+							observedPending.detachedTranscriptPath !== pending?.detachedTranscriptPath);
+					const active =
+						discoveredDetach || (observedPending && requiresFreshCleanupPlan(observedPending))
+							? nextCleanupReceipt(target, observedPending)
+							: (observedPending ?? nextCleanupReceipt(target, undefined));
+					if (!observedPending || discoveredDetach || requiresFreshCleanupPlan(observedPending))
+						await publishCleanupPending(scope, tombstone, active, lock);
+					let deletion = await new FileSessionStorage().deleteSessionVerified({
 						sessionsRoot: scope.sessionsRoot,
 						transcriptPath: target.path,
 						sessionId: target.sessionId,
 						cwd: target.cwd,
 						transcriptIdentity: target.identity,
-						plannedArtifactsPath: active.plannedArtifactsPath,
-						plannedTranscriptPath: active.plannedTranscriptPath,
-						detachedTranscriptPath: active.detachedTranscriptPath ?? observedPending?.detachedTranscriptPath,
-
+						expectedArtifactsIdentity: active.expectedArtifactsIdentity,
+						expectedArtifactsTree: active.expectedArtifactsTree,
+						detachedArtifactsPath:
+							active.detachedArtifactsPath ??
+							observedPending?.detachedArtifactsPath ??
+							(fs.existsSync(active.plannedArtifactsPath) ? active.plannedArtifactsPath : undefined),
+						detachedTranscriptPath:
+							active.detachedTranscriptPath ??
+							observedPending?.detachedTranscriptPath ??
+							(pending && fs.existsSync(pending.plannedTranscriptPath)
+								? pending.plannedTranscriptPath
+								: undefined) ??
+							(fs.existsSync(active.plannedTranscriptPath) ? active.plannedTranscriptPath : undefined),
 						retainedArtifactsSuccessorPath: active.retainedArtifactsSuccessorPath,
 						retainedArtifactsPlaceholderPath: active.retainedArtifactsPlaceholderPath,
 						retainedArtifactsUnknownPath: active.retainedArtifactsUnknownPath,
 						retainedTranscriptSuccessorPath: active.retainedTranscriptSuccessorPath,
 						retainedTranscriptPlaceholderPath: active.retainedTranscriptPlaceholderPath,
 						retainedTranscriptUnknownPath: active.retainedTranscriptUnknownPath,
-						artifactsRemoved: true,
+						plannedArtifactsPath: active.plannedArtifactsPath,
+						plannedTranscriptPath: active.plannedTranscriptPath,
+						...(cleanupArtifactsRemoved(scope, tombstone, target, pending?.attempt ?? active.attempt)
+							? { artifactsRemoved: true as const }
+							: {}),
+					});
+					if (deletion.kind === "artifacts_removed") {
+						await publishCleanupArtifactsRemoved(scope, tombstone, active, lock);
+						deletion = await new FileSessionStorage().deleteSessionVerified({
+							sessionsRoot: scope.sessionsRoot,
+							transcriptPath: target.path,
+							sessionId: target.sessionId,
+							cwd: target.cwd,
+							transcriptIdentity: target.identity,
+							plannedArtifactsPath: active.plannedArtifactsPath,
+							plannedTranscriptPath: active.plannedTranscriptPath,
+							detachedTranscriptPath: active.detachedTranscriptPath ?? observedPending?.detachedTranscriptPath,
+
+							retainedArtifactsSuccessorPath: active.retainedArtifactsSuccessorPath,
+							retainedArtifactsPlaceholderPath: active.retainedArtifactsPlaceholderPath,
+							retainedArtifactsUnknownPath: active.retainedArtifactsUnknownPath,
+							retainedTranscriptSuccessorPath: active.retainedTranscriptSuccessorPath,
+							retainedTranscriptPlaceholderPath: active.retainedTranscriptPlaceholderPath,
+							retainedTranscriptUnknownPath: active.retainedTranscriptUnknownPath,
+							artifactsRemoved: true,
+						});
+					}
+					if (deletion.kind === "cleanup_pending") {
+						const retry = nextCleanupReceipt(target, active);
+						await publishCleanupPending(
+							scope,
+							tombstone,
+							{
+								...retry,
+								expectedArtifactsIdentity:
+									deletion.phase === "artifacts"
+										? deletion.artifactsIdentity
+										: active.expectedArtifactsIdentity,
+								expectedArtifactsTree:
+									deletion.phase === "artifacts" ? deletion.artifactsTree : active.expectedArtifactsTree,
+								detachedArtifactsPath:
+									deletion.phase === "artifacts"
+										? deletion.detachedArtifactsPath
+										: active.detachedArtifactsPath,
+								detachedTranscriptPath:
+									deletion.phase === "transcript"
+										? deletion.detachedTranscriptPath
+										: active.detachedTranscriptPath,
+								retainedArtifactsSuccessorPath:
+									deletion.phase === "artifacts"
+										? deletion.retainedSuccessorPath
+										: active.retainedArtifactsSuccessorPath,
+								retainedArtifactsPlaceholderPath:
+									deletion.phase === "artifacts"
+										? deletion.retainedPlaceholderPath
+										: active.retainedArtifactsPlaceholderPath,
+								retainedArtifactsUnknownPath:
+									deletion.phase === "artifacts"
+										? deletion.retainedUnknownPath
+										: active.retainedArtifactsUnknownPath,
+								retainedTranscriptSuccessorPath:
+									deletion.phase === "transcript"
+										? deletion.retainedSuccessorPath
+										: active.retainedTranscriptSuccessorPath,
+								retainedTranscriptPlaceholderPath:
+									deletion.phase === "transcript"
+										? deletion.retainedPlaceholderPath
+										: active.retainedTranscriptPlaceholderPath,
+								retainedTranscriptUnknownPath:
+									deletion.phase === "transcript"
+										? deletion.retainedUnknownPath
+										: active.retainedTranscriptUnknownPath,
+							},
+							lock,
+						);
+						continue;
+					}
+					fsyncManagedParent(target.path);
+					await publishCleanupCompleted(scope, tombstone, target, lock);
+				} catch (error) {
+					if (!expectedCandidate || target.sessionId === expectedCandidate.sessionId) throw error;
+					logger.warn("Tombstone reconciliation failed for one target; will retry on a future scope open", {
+						tombstone,
+						sessionId: target.sessionId,
+						error: String(error),
 					});
 				}
-				if (deletion.kind === "cleanup_pending") {
-					const retry = nextCleanupReceipt(target, active);
-					await publishCleanupPending(
-						scope,
-						tombstone,
-						{
-							...retry,
-							expectedArtifactsIdentity:
-								deletion.phase === "artifacts" ? deletion.artifactsIdentity : active.expectedArtifactsIdentity,
-							expectedArtifactsTree:
-								deletion.phase === "artifacts" ? deletion.artifactsTree : active.expectedArtifactsTree,
-							detachedArtifactsPath:
-								deletion.phase === "artifacts" ? deletion.detachedArtifactsPath : active.detachedArtifactsPath,
-							detachedTranscriptPath:
-								deletion.phase === "transcript"
-									? deletion.detachedTranscriptPath
-									: active.detachedTranscriptPath,
-							retainedArtifactsSuccessorPath:
-								deletion.phase === "artifacts"
-									? deletion.retainedSuccessorPath
-									: active.retainedArtifactsSuccessorPath,
-							retainedArtifactsPlaceholderPath:
-								deletion.phase === "artifacts"
-									? deletion.retainedPlaceholderPath
-									: active.retainedArtifactsPlaceholderPath,
-							retainedArtifactsUnknownPath:
-								deletion.phase === "artifacts"
-									? deletion.retainedUnknownPath
-									: active.retainedArtifactsUnknownPath,
-							retainedTranscriptSuccessorPath:
-								deletion.phase === "transcript"
-									? deletion.retainedSuccessorPath
-									: active.retainedTranscriptSuccessorPath,
-							retainedTranscriptPlaceholderPath:
-								deletion.phase === "transcript"
-									? deletion.retainedPlaceholderPath
-									: active.retainedTranscriptPlaceholderPath,
-							retainedTranscriptUnknownPath:
-								deletion.phase === "transcript"
-									? deletion.retainedUnknownPath
-									: active.retainedTranscriptUnknownPath,
-						},
-						lock,
-					);
-					continue;
-				}
-				fsyncManagedParent(target.path);
-				await publishCleanupCompleted(scope, tombstone, target, lock);
 			}
 		} finally {
 			if (lock) await lock.release().catch(() => undefined);
@@ -2956,7 +2972,7 @@ export async function prepareManagedSessionScopeForWrite(
 		ensureManagedDirectory(path.join(internal, MANAGED_LOCKS_DIRECTORY), root, policy);
 		ensureManagedDirectory(path.join(internal, MANAGED_RECEIPTS_DIRECTORY), root, policy);
 		ensureManagedDirectory(path.join(internal, MANAGED_TOMBSTONES_DIRECTORY), root, policy);
-		await reconcileManagedTombstones(scope);
+		await reconcileManagedTombstones(scope, expectedCandidate);
 		return { kind: "resolved", scope };
 	} catch (error) {
 		const publication = error instanceof ManagedPublishError ? error : undefined;

--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -1126,6 +1126,56 @@ describe("managed session write protocol", () => {
 		if (secondListed.kind === "complete")
 			expect(secondListed.owned.map(candidate => candidate.sessionId)).toEqual(["second"]);
 	});
+	it("isolates a permanently unresolvable tombstone without blocking an unrelated candidate, but still fails closed for the affected candidate itself", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const legacy = legacyDirectory(sessionsRoot, cwd);
+		const stuckSource = path.join(legacy, "stuck-target.jsonl");
+		const okSource = path.join(legacy, "ok-target.jsonl");
+		await fs.mkdir(legacy, { recursive: true });
+		await fs.writeFile(stuckSource, transcript("stuck-target", cwd));
+		await fs.writeFile(okSource, transcript("ok-target", cwd));
+
+		const listed = listManagedCandidates(scope);
+		if (listed.kind !== "complete") throw new Error("Missing candidates");
+		const stuckCandidate = listed.owned.find(candidate => candidate.sessionId === "stuck-target");
+		const okCandidate = listed.owned.find(candidate => candidate.sessionId === "ok-target");
+		if (!stuckCandidate || !okCandidate) throw new Error("Missing candidates");
+
+		const exactUnlink = native.exactUnlink;
+		const unlink = vi.spyOn(native, "exactUnlink").mockImplementation((pathname, identity) => {
+			if (pathname === stuckSource) return { ok: false, code: "identity_mismatch" };
+			return exactUnlink(pathname, identity);
+		});
+		try {
+			await expect(deleteManagedSessionCandidate(scope, stuckCandidate)).resolves.toMatchObject({
+				kind: "error",
+			});
+
+			// A caller opening the unrelated candidate must not be blocked by the stuck tombstone.
+			const forOk = await prepareManagedSessionScopeForWrite(
+				scope,
+				"default",
+				undefined,
+				okCandidate,
+				okCandidate.identity,
+			);
+			expect(forOk.kind).toBe("resolved");
+
+			// A caller acting on the stuck candidate itself must still fail closed, not be silently
+			// isolated — isolation only applies to targets that are provably a different session than
+			// the one the caller is actually operating on.
+			const forStuck = await prepareManagedSessionScopeForWrite(
+				scope,
+				"default",
+				undefined,
+				stuckCandidate,
+				stuckCandidate.identity,
+			);
+			expect(forStuck.kind).toBe("error");
+		} finally {
+			unlink.mockRestore();
+		}
+	});
 	it("reconciles a crash-after-tombstone on a fresh scope without resurrecting the candidate", async () => {
 		const { cwd, sessionsRoot, scope } = await fixture();
 		const legacy = legacyDirectory(sessionsRoot, cwd);


### PR DESCRIPTION
## Summary

Wrap each target's reconciliation inside `reconcileManagedTombstones()` so one unresolvable tombstone no longer fails scope resolution for the entire managed scope — but only when that tombstone is provably for a *different* session than the one the caller is actually opening right now (a new `expectedCandidate` parameter, threaded from `prepareManagedSessionScopeForWrite`'s existing parameter of the same name).

Fixes #3066

## Root cause

`reconcileManagedTombstones()` had no per-target error boundary. Any exception from reconciling one tombstone's target (e.g. a native-vs-Node identity_mismatch on a stale artifact directory) propagated out of the whole function, failing `prepareManagedSessionScopeForWrite` for the entire scope — blocking resume/delete of every other, unrelated session.

## Known trade-off

Full rationale is in the linked issue. In short: an earlier blanket-catch version broke `session-directory.test.ts`'s "rejects a replacement retained deterministic .removing root during replay" (a tamper-detection test). This version fixes that by only isolating a target when it belongs to a different session than `expectedCandidate`. Residual trade-off: a real tamper of an *unrelated* session's tombstone is now logged and skipped instead of raising `binding_invalid` for the whole scope — nothing unsafe happens to the content itself, only the alarm is downgraded for that case. A stronger `dev`/`ino`/`size` re-verification was considered and rejected as unreliable on NTFS (see issue).

## Verification

- Rebased onto current `dev` (includes #3052/#3061, a different code path — see the linked issue); re-verified everything below on that base.
- Type-check and `biome check` both clean.
- `bun test` across session-storage/session-manager (293 tests, incl. the new upstream `session-durability-windows.test.ts`): byte-identical failing-test list to unmodified `dev` — zero regressions.
- The tamper-detection test above passes.
- New regression test: seeds two candidates, makes one's native unlink permanently fail, asserts the unrelated candidate still resolves *and* the affected candidate itself still fails closed. Confirmed it fails on unmodified `dev` and passes with this fix.
- Manually reproduced the scope-wide block and confirmed resolution.
- Failures are now logged via `logger.warn` (tombstone, sessionId, error) instead of silently swallowed — matches this codebase's existing `logger.warn(message, context)` convention.
