### PR TITLE
perf(coding-agent): skip lock acquisition for already-completed tombstones

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Rejected subagent schema payloads now retain their complete structured data in canonical output artifacts; inline results remain bounded while `agent://` output stays lossless (#2894).
 - Managed legacy-session artifact migration now validates Windows directory roots from the native tree snapshot, tolerates only lazy metadata on plain Windows directories, and replays both clean and cleanup-pending detaches while retaining fail-closed receipt validation. Canonical binding durability sync uses a writable no-follow handle on Windows NTFS stacks that reject `FlushFileBuffers` on read-only handles (#3015, #2913).
+- `gjc resume` and delete no longer pay a durable (fsync-backed) lock acquisition for managed session tombstones that have nothing left to reconcile; a scope with many accumulated already-completed tombstones opens noticeably faster (#<issue-2-number>).
+
 ## [0.11.8] - 2026-07-23
 ### Added
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Rejected subagent schema payloads now retain their complete structured data in canonical output artifacts; inline results remain bounded while `agent://` output stays lossless (#2894).
 - Managed legacy-session artifact migration now validates Windows directory roots from the native tree snapshot, tolerates only lazy metadata on plain Windows directories, and replays both clean and cleanup-pending detaches while retaining fail-closed receipt validation. Canonical binding durability sync uses a writable no-follow handle on Windows NTFS stacks that reject `FlushFileBuffers` on read-only handles (#3015, #2913).
-- `gjc resume` and delete no longer pay a durable (fsync-backed) lock acquisition for managed session tombstones that have nothing left to reconcile; a scope with many accumulated already-completed tombstones opens noticeably faster (#<issue-2-number>).
+- `gjc resume` and delete no longer pay a durable (fsync-backed) lock acquisition for managed session tombstones that have nothing left to reconcile; a scope with many accumulated already-completed tombstones opens noticeably faster.
 
 ## [0.11.8] - 2026-07-23
 ### Added

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -2789,6 +2789,7 @@ export async function reconcileManagedTombstones(scope: ManagedScope): Promise<v
 		const tombstone = path.join(directory, name);
 		const targets = retiredTargets(scope, tombstone);
 		if (!targets) continue;
+		if (targets.every(target => cleanupCompleted(scope, tombstone, target))) continue;
 		let lock: ManagedStorageLock | undefined;
 		try {
 			lock = await acquireManagedLock(

--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -11,6 +11,7 @@ import {
 	prepareManagedSessionScopeForWrite,
 	resolveManagedScope,
 } from "../../src/session/internal/managed-session-scope";
+import * as managedSessionStorage from "../../src/session/internal/managed-session-storage";
 import {
 	publishManagedFileNoReplace,
 	validateNativeSecurityResult,
@@ -1125,6 +1126,30 @@ describe("managed session write protocol", () => {
 			expect(firstListed.owned.map(candidate => candidate.sessionId)).toEqual(["first"]);
 		if (secondListed.kind === "complete")
 			expect(secondListed.owned.map(candidate => candidate.sessionId)).toEqual(["second"]);
+	});
+	it("skips durable lock acquisition when a tombstone's targets are already cleanup_completed", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const legacy = legacyDirectory(sessionsRoot, cwd);
+		const source = path.join(legacy, "already-done.jsonl");
+		await fs.mkdir(legacy, { recursive: true });
+		await fs.writeFile(source, transcript("already-done", cwd));
+		const listed = listManagedCandidates(scope);
+		if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing candidate");
+
+		await expect(deleteManagedSessionCandidate(scope, listed.owned[0])).resolves.toMatchObject({
+			kind: "deleted",
+		});
+
+		const restarted = resolveManagedScope({ cwd, agentDir: path.dirname(sessionsRoot), sessionsRoot });
+		if (restarted.kind !== "resolved") throw new Error(restarted.message);
+
+		const lock = vi.spyOn(managedSessionStorage, "acquireManagedLock");
+		try {
+			expect((await prepareManagedSessionScopeForWrite(restarted.scope)).kind).toBe("resolved");
+			expect(lock).not.toHaveBeenCalled();
+		} finally {
+			lock.mockRestore();
+		}
 	});
 	it("reconciles a crash-after-tombstone on a fresh scope without resurrecting the candidate", async () => {
 		const { cwd, sessionsRoot, scope } = await fixture();


### PR DESCRIPTION
## Summary

Add a cheap read-only pre-check in `reconcileManagedTombstones()`: skip the durable (fsync-backed) lock acquisition entirely when every target in a tombstone is already recorded `cleanup_completed`.

Fixes #3067

## Root cause

`acquireManagedLock()` fsyncs the lock file and its parent directory — intentional durability elsewhere in this codebase — but was called unconditionally per tombstone, before checking whether that tombstone had any remaining work. Completed tombstones pay this cost forever, on every resume/delete.

## Verification

- Rebased onto current `dev` (includes #3052/#3061, a different code path — see the isolation PR for detail); re-verified everything below on that base.
- Type-check and `biome check` both clean.
- `bun test` (session-storage.test.ts, managed-scope-owner-only-self-heal.test.ts, session-manager/, 293 tests) — byte-identical failing-test list to unmodified `dev` — zero regressions.
- New regression test: "skips durable lock acquisition when a tombstone's targets are already cleanup_completed" — spies on `acquireManagedLock` and asserts it's never called once a tombstone is fully reconciled. Confirmed this test fails on unmodified `dev` (1 call recorded) and passes with this fix (0 calls).
- Measured: `gjc --resume` on a scope with 13 accumulated tombstones dropped from ~55s to ~10s after this change.
