### PR TITLE
fix(tui): recover appearance probing after a dropped OSC 11/DA1 reply

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Appearance probing (OSC 11 background-color query + DA1 sentinel) no longer latches when a terminal or intervening multiplexer/SSH link drops a reply. Previously a dropped DA1 sentinel left the probe state pending forever, so every later poll only re-queued and appearance detection — plus the stdin drain that depends on it — never re-armed, eventually filling the composer with raw escape sequences and freezing keystroke input until restart. A per-query watchdog now recovers the stalled cycle and resumes probing, and the timer is cleared on teardown (#3047).
+
 ## [0.11.8] - 2026-07-23
 
 ## [0.11.7] - 2026-07-22

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -8,6 +8,10 @@ import { isUnderTerminalMultiplexer } from "./terminal-capabilities";
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1000;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
 const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
+// OSC 11 / DA1 appearance-probe watchdog. A live terminal answers in well under
+// a second; 3s only elapses when a reply was dropped (multiplexer/SSH glitch),
+// at which point the probe cycle is recovered instead of latching forever.
+const OSC11_QUERY_TIMEOUT_MS = 3_000;
 
 /**
  * Whether GJC may reprogram the keyboard with enhanced input protocols
@@ -222,6 +226,7 @@ export class ProcessTerminal implements Terminal {
 	#privateCsiResponseBuffer = "";
 	#pendingDa1Sentinels = 0;
 	#osc11PollTimer?: Timer;
+	#osc11QueryWatchdog?: Timer;
 	#mode2031DebounceTimer?: Timer;
 	#progressTimer?: ReturnType<typeof setInterval>;
 	#mouseEnabled = false;
@@ -475,10 +480,13 @@ export class ProcessTerminal implements Terminal {
 					this.#osc11Pending = false;
 					this.#osc11ResponseBuffer = "";
 				}
-				// Now that this DA1 cycle is complete, start any queued query.
+				// Now that this DA1 cycle is complete, start any queued query (which
+				// re-arms the watchdog); otherwise disarm it — both replies resolved.
 				if (this.#osc11QueryQueued && !this.#dead) {
 					this.#osc11QueryQueued = false;
 					this.#startOsc11Query();
+				} else {
+					this.#settleOsc11QueryWatchdog();
 				}
 				return;
 			}
@@ -499,6 +507,9 @@ export class ProcessTerminal implements Terminal {
 					const [, rHex, gHex, bHex] = osc11Match;
 					this.#osc11Pending = false;
 					this.#osc11ResponseBuffer = "";
+					// If the DA1 sentinel already arrived the cycle is done; otherwise
+					// stay armed until it does (or the watchdog recovers a dropped DA1).
+					this.#settleOsc11QueryWatchdog();
 					this.#handleOsc11Response(rHex!, gHex!, bHex!);
 					return;
 				}
@@ -556,8 +567,60 @@ export class ProcessTerminal implements Terminal {
 		this.#osc11Pending = true;
 		this.#osc11ResponseBuffer = "";
 		this.#pendingDa1Sentinels++;
+		this.#armOsc11QueryWatchdog();
 		this.#safeWrite("\x1b]11;?\x07"); // OSC 11 query (BEL terminated)
 		this.#safeWrite("\x1b[c"); // DA1 sentinel
+	}
+
+	/**
+	 * A terminal (or an intervening multiplexer / SSH link) can silently drop the
+	 * OSC 11 and/or DA1 reply for the in-flight probe. Without a timeout,
+	 * `#osc11Pending` / `#pendingDa1Sentinels` stay set forever, so every later
+	 * poll only re-queues (`#osc11QueryQueued`) and appearance probing never
+	 * re-arms — which also wedges the stdin drain that depends on it, latching the
+	 * composer (raw escape leakage, then dead input). A live terminal answers in
+	 * well under a second; when the far longer watchdog elapses the reply was
+	 * genuinely dropped, so abandon the stalled cycle and let probing resume.
+	 */
+	#armOsc11QueryWatchdog(): void {
+		this.#clearOsc11QueryWatchdog();
+		this.#osc11QueryWatchdog = setTimeout(() => {
+			this.#osc11QueryWatchdog = undefined;
+			this.#recoverStalledOsc11Query();
+		}, OSC11_QUERY_TIMEOUT_MS);
+		this.#osc11QueryWatchdog.unref();
+	}
+
+	#clearOsc11QueryWatchdog(): void {
+		if (this.#osc11QueryWatchdog) {
+			clearTimeout(this.#osc11QueryWatchdog);
+			this.#osc11QueryWatchdog = undefined;
+		}
+	}
+
+	/**
+	 * Disarm the watchdog only once BOTH the OSC 11 reply and its DA1 sentinel
+	 * have resolved. A half-complete cycle (e.g. OSC received but DA1 still
+	 * outstanding — the exact dropped-DA1 case) must stay armed so the watchdog
+	 * still recovers it.
+	 */
+	#settleOsc11QueryWatchdog(): void {
+		if (!this.#osc11Pending && this.#pendingDa1Sentinels === 0) {
+			this.#clearOsc11QueryWatchdog();
+		}
+	}
+
+	#recoverStalledOsc11Query(): void {
+		if (this.#dead) return;
+		this.#osc11Pending = false;
+		this.#pendingDa1Sentinels = 0;
+		this.#osc11ResponseBuffer = "";
+		// Re-arm immediately if a poll queued behind the stalled cycle; otherwise
+		// the next periodic poll starts a fresh query.
+		if (this.#osc11QueryQueued) {
+			this.#osc11QueryQueued = false;
+			this.#startOsc11Query();
+		}
 	}
 	/**
 	 * Parse an OSC 11 background color response and compute BT.601 luminance.
@@ -723,6 +786,7 @@ export class ProcessTerminal implements Terminal {
 		this.#osc11ResponseBuffer = "";
 		this.#privateCsiResponseBuffer = "";
 		this.#pendingDa1Sentinels = 0;
+		this.#clearOsc11QueryWatchdog();
 
 		// Disable Kitty keyboard protocol if not already done by drainInput()
 		if (this.#kittyProtocolActive) {
@@ -824,6 +888,7 @@ export class ProcessTerminal implements Terminal {
 		this.#dead = true;
 		this.#clearProgressTimer();
 		this.#stopOsc11Poll();
+		this.#clearOsc11QueryWatchdog();
 		if (this.#mode2031DebounceTimer) {
 			clearTimeout(this.#mode2031DebounceTimer);
 			this.#mode2031DebounceTimer = undefined;

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -329,6 +329,57 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 
 		terminal.stop();
 	});
+
+	it("recovers appearance probing after the OSC 11 reply arrives but the DA1 sentinel is dropped (#3047)", () => {
+		vi.useFakeTimers();
+		const { terminal, queryCount, sentinelCount, received } = setupTerminal();
+		expect(queryCount()).toBe(1);
+		expect(sentinelCount()).toBe(1);
+
+		// OSC 11 reply arrives; the DA1 sentinel is dropped by the multiplexer.
+		process.stdin.emit("data", "\x1b]11;rgb:ffff/ffff/ffff\x07");
+
+		// The 2s poll cannot start a new query while the sentinel is still
+		// outstanding — pre-fix this latched forever (only re-queuing).
+		vi.advanceTimersByTime(2_000);
+		expect(queryCount()).toBe(1);
+
+		// The 3s watchdog abandons the stalled cycle and the queued poll re-arms.
+		vi.advanceTimersByTime(1_100);
+		expect(queryCount()).toBe(2);
+		expect(sentinelCount()).toBe(2);
+		expect(received).toEqual([]);
+
+		terminal.stop();
+	});
+
+	it("recovers appearance probing when both the OSC 11 and DA1 replies are dropped (#3047)", () => {
+		vi.useFakeTimers();
+		const { terminal, queryCount } = setupTerminal();
+		expect(queryCount()).toBe(1);
+
+		// No replies at all; a poll only queues behind the in-flight cycle.
+		vi.advanceTimersByTime(2_000);
+		expect(queryCount()).toBe(1);
+
+		// Watchdog fires and re-arms the queued query.
+		vi.advanceTimersByTime(1_100);
+		expect(queryCount()).toBe(2);
+
+		terminal.stop();
+	});
+
+	it("clears the OSC 11 watchdog on stop() so no probe fires after teardown (#3047)", () => {
+		vi.useFakeTimers();
+		const { terminal, queryCount } = setupTerminal();
+		expect(queryCount()).toBe(1);
+
+		// Stop with a cycle still in flight (replies dropped); teardown must clear
+		// both the poll and the watchdog so nothing fires afterward.
+		terminal.stop();
+		vi.advanceTimersByTime(10_000);
+		expect(queryCount()).toBe(1);
+	});
 });
 
 describe("ProcessTerminal raw-Buffer stdin (issue #454)", () => {


### PR DESCRIPTION
## What

`ProcessTerminal` probes appearance by writing an OSC 11 background-color query + a DA1 sentinel, then relies on the in-order DA1 reply to close the cycle. If a terminal (or an intervening multiplexer/SSH link) drops the OSC 11 and/or DA1 reply, `#osc11Pending`/`#pendingDa1Sentinels` stay set forever — every later poll only re-queues (`#osc11QueryQueued`) and appearance probing never re-arms. Because the stdin drain depends on that cycle, the composer eventually fills with raw escape sequences and then stops registering keystrokes until restart (#3047).

## Fix

Add a per-query watchdog:
- Armed in `#startOsc11Query()`.
- Disarmed only once BOTH the OSC 11 reply and its DA1 sentinel resolve — a good OSC reply followed by a dropped DA1 keeps it armed (the exact gap that closed the prior attempt), so it is still recovered.
- On timeout, the stalled cycle is abandoned (state reset, remaining sentinel cleared per the reviewer guidance) and any queued query re-arms.
- Cleared on teardown in both `stop()` and `#markUnavailable()`.

A live terminal answers in well under a second, so the 3s window only elapses on a genuine drop (no false resets on slow-but-alive terminals).

## Tests (fake timers)

In `terminal-appearance.test.ts`: OSC-received + DA1-dropped recovers; both-dropped recovers; `stop()` clears the watchdog so nothing fires after teardown. Full `packages/tui` suite: 843 pass / 0 fail; `tsc` + `biome` clean.

## Credit / context

Builds on #3047 by @sskys18 (reviewed correct-direction, closed only because the watchdog was disarmed before the DA1 cycle closed, so an `OSC received + DA1 lost` drop still latched). This keeps that direction and closes exactly that gap.

Fixes #3047.