### PR TITLE
chore(test): regenerate telegram baseline manifest for merged daemon suites

### DIFF
--- a/packages/coding-agent/test/manifests/telegram-baseline-v1.json
+++ b/packages/coding-agent/test/manifests/telegram-baseline-v1.json
@@ -278,6 +278,41 @@
 			"argv": [
 				"bun",
 				"test",
+				"packages/coding-agent/test/notifications-telegram-daemon-2956-redteam.test.ts"
+			]
+		},
+		{
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/notifications-telegram-daemon-2956.test.ts"
+			]
+		},
+		{
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/notifications-telegram-daemon-2960-redteam.test.ts"
+			]
+		},
+		{
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/notifications-telegram-daemon-2960.test.ts"
+			]
+		},
+		{
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/notifications-telegram-daemon-self-heal.test.ts"
+			]
+		},
+		{
+			"argv": [
+				"bun",
+				"test",
 				"packages/coding-agent/test/notifications-telegram-daemon.test.ts"
 			]
 		},
@@ -342,6 +377,13 @@
 				"bun",
 				"test",
 				"packages/coding-agent/test/telegram-send-tool.test.ts"
+			]
+		},
+		{
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/telegram-setup-preflight.test.ts"
 			]
 		}
 	],


### PR DESCRIPTION
## What

Regenerate `packages/coding-agent/test/manifests/telegram-baseline-v1.json` (49 → 55 commands) via `bun scripts/generate-telegram-baseline-manifest.ts`. One-file diff, +42 lines, no product code.

## Why

Root `bun check` currently fails on **pristine `origin/dev`** at the `check:sdk-closure` exact-match gate:

```
Telegram baseline manifest does not exactly match the generated baseline:
- missing command: bun test packages/coding-agent/test/notifications-telegram-daemon-2956-redteam.test.ts
- missing command: bun test packages/coding-agent/test/notifications-telegram-daemon-2956.test.ts
- missing command: bun test packages/coding-agent/test/notifications-telegram-daemon-2960-redteam.test.ts
- missing command: bun test packages/coding-agent/test/notifications-telegram-daemon-2960.test.ts
- missing command: bun test packages/coding-agent/test/notifications-telegram-daemon-self-heal.test.ts
- missing command: bun test packages/coding-agent/test/telegram-setup-preflight.test.ts
```

The generator glob-discovers `notifications-*.test.ts` / `telegram-*.test.ts` and requires the committed manifest to match exactly. These six suites were merged without regenerating the manifest:

- `a7e35936` — fix(notifications): stop Telegram daemon infinite respawn + lazy topic creation (#2960) (#2984) — 4 files
- `11e6fa69` — fix(notifications): self-heal Telegram daemon state (#2958) — 1 file
- `24fd6b67` — fix(notify): make Telegram setup incarnation-aware across surfaces (#2959) — 1 file

The manifest itself was last touched before those merges (`4c415b13`), so every dev checkout has been failing this gate since 2026-07-23.

## Testing

- `bun scripts/generate-telegram-baseline-manifest.ts --check` → passes after regen (55 commands).
- All six newly enrolled suites pass locally: `bun test` → 28 pass / 0 fail across the 6 files.
- Diff is manifest-only; no excluded-entry or reviewed-exclusion changes.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:f3911f072719e2fec20eef0459d8993c9d025a7ec3c88d87c9fe93e7f4956782 reviewer:human evidence:bun scripts/generate-telegram-baseline-manifest.ts --check (pass @ bb3eaf74)
```

(diff hash = `sha256(git diff origin/dev...HEAD)` at head `bb3eaf74`; no independent architect/critic review was run, so per template this is `needs-human`.)

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — the telegram-baseline gate now passes; full root `bun check` not re-run end-to-end for this manifest-only diff (gate-level check + 6 enrolled suites verified)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — not user-facing; test-manifest only
- [x] Verdict above matches the exact PR head, not an earlier commit
