### PR TITLE
fix(tui): expose provider retry recovery state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Alibaba Token Plan canonical first-event timeouts now surface without session retry/fallback replay and are not internally retried by auto-compaction, preventing repeated provider usage (#3026).
+- Delegated-task and subagent status surfaces now distinguish provider recovery from normal running, identify first-event versus idle-stream stalls, show retry budget and provider-progress age, and aggregate concurrent degradation by provider (#3071).
 
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
 - Windows managed-session resume no longer reports `durability_failed` when Bun rejects `fsync` on the read-only descriptor used to revalidate an existing canonical binding; Windows now uses an owner-writable descriptor for that durability fence while retaining no-follow and pre/post identity/content checks.

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1012,10 +1012,22 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			: undefined;
 	};
 
-	const hasMatchingActiveProviderModel = (message: AgentMessage): message is AssistantMessage =>
+	const isProviderAssistantMessage = (message: AgentMessage): message is AssistantMessage =>
 		message.role === "assistant" &&
 		"stopReason" in message &&
 		Array.isArray(message.content) &&
+		getMessageModelString(message) !== undefined;
+
+	const isSuccessfulProviderAssistantMessage = (message: AgentMessage): message is AssistantMessage =>
+		isProviderAssistantMessage(message) &&
+		message.stopReason !== "error" &&
+		message.stopReason !== "aborted" &&
+		message.errorMessage === undefined &&
+		message.errorKind === undefined &&
+		message.transportFailure === undefined;
+
+	const hasMatchingActiveProviderModel = (message: AgentMessage): message is AssistantMessage =>
+		isProviderAssistantMessage(message) &&
 		activeProviderModelString !== undefined &&
 		getMessageModelString(message) === activeProviderModelString;
 
@@ -1034,6 +1046,13 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		}
 	};
 
+	const getProviderTextDelta = (event: Extract<AgentEvent, { type: "message_update" }>): string | undefined => {
+		const update = (event as { assistantMessageEvent?: unknown }).assistantMessageEvent;
+		if (!update || typeof update !== "object") return undefined;
+		const record = update as { type?: unknown; delta?: unknown };
+		return record.type === "text_delta" && typeof record.delta === "string" ? record.delta : undefined;
+	};
+
 	const isProviderBackedRecoveryEvent = (
 		event: Extract<AgentEvent, { type: "message_start" | "message_update" }>,
 		eventOrdinal: number,
@@ -1041,16 +1060,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		if (!progress.retryState || eventOrdinal <= retryStartOrdinal || seenAssistantMessages.has(event.message))
 			return false;
 		if (!hasMatchingActiveProviderModel(event.message)) return false;
-		if (event.type === "message_start") {
-			const message = event.message;
-			return (
-				message.stopReason !== "error" &&
-				message.stopReason !== "aborted" &&
-				message.errorMessage === undefined &&
-				message.errorKind === undefined &&
-				message.transportFailure === undefined
-			);
-		}
+		if (event.type === "message_start") return isSuccessfulProviderAssistantMessage(event.message);
 		return isProviderStreamingUpdate(event);
 	};
 
@@ -1233,9 +1243,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					progress.retryState = undefined;
 					flushProgress = true;
 				}
-				if (event.assistantMessageEvent.type === "text_delta") {
-					appendRecentOutputTail(event.assistantMessageEvent.delta);
-				}
+				const textDelta = getProviderTextDelta(event);
+				if (textDelta !== undefined) appendRecentOutputTail(textDelta);
 				break;
 			}
 
@@ -1243,7 +1252,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				// Extract text from assistant and toolResult messages (not user prompts)
 				const role = event.message?.role;
 				if (role === "assistant") {
-					lastProviderProgressAtMs = now;
+					if (isSuccessfulProviderAssistantMessage(event.message)) lastProviderProgressAtMs = now;
 					const messageContent =
 						getMessageContent(event.message) || (event as AgentEvent & { content?: unknown }).content;
 					if (messageContent && Array.isArray(messageContent)) {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -50,6 +50,7 @@ import type { EventBus } from "../utils/event-bus";
 import { buildNamedToolChoiceResult } from "../utils/tool-choice";
 import type { WorkspaceTree } from "../workspace-tree";
 import { validateAllocatedTaskId } from "./id";
+import { classifyProviderRetry, providerNameFromModel } from "./provider-retry-status";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
 import { persistTaskTokenLog, taskTokenLogFromUsage } from "./token-log";
 import {
@@ -846,6 +847,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	let resolvedModelString: string | undefined;
 	let lastAssistantModelString: string | undefined;
 	let effectiveThinkingLevelForWarning: ThinkingLevel | undefined;
+	let lastProviderProgressAtMs: number | undefined;
 
 	// Accumulate usage incrementally from message_end events (no memory for streaming events)
 	const accumulatedUsage = {
@@ -1049,6 +1051,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		switch (event.type) {
 			case "message_start":
 				if (event.message?.role === "assistant") {
+					lastProviderProgressAtMs = now;
 					resetRecentOutput();
 				}
 				break;
@@ -1164,6 +1167,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			case "message_update": {
 				if (event.message?.role !== "assistant") break;
+				lastProviderProgressAtMs = now;
 				const assistantEvent = (
 					event as AgentEvent & {
 						assistantMessageEvent?: { type?: string; delta?: string };
@@ -1188,6 +1192,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				// Extract text from assistant and toolResult messages (not user prompts)
 				const role = event.message?.role;
 				if (role === "assistant") {
+					lastProviderProgressAtMs = now;
 					const messageContent =
 						getMessageContent(event.message) || (event as AgentEvent & { content?: unknown }).content;
 					if (messageContent && Array.isArray(messageContent)) {
@@ -1742,6 +1747,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						attempt: event.attempt,
 						maxAttempts: event.maxAttempts,
 						unbounded: event.unbounded,
+						kind: classifyProviderRetry(event.errorMessage),
+						provider: providerNameFromModel(lastAssistantModelString ?? resolvedModelString),
+						lastProviderProgressAtMs,
 						delayMs: event.delayMs,
 						errorMessage: event.errorMessage,
 						startedAtMs: Date.now(),

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -867,6 +867,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	let sessionEventOrdinal = 0;
 	let retryStartOrdinal = 0;
 	const seenAssistantMessages = new WeakSet<AgentMessage>();
+	const seenAssistantMessageIdentities = new Set<string>();
 
 	// Accumulate usage incrementally from message_end events (no memory for streaming events)
 	const accumulatedUsage = {
@@ -1012,6 +1013,21 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			: undefined;
 	};
 
+	const getAssistantMessageIdentity = (message: AgentMessage): string | undefined => {
+		if (message.role !== "assistant") return undefined;
+		const model = getMessageModelString(message);
+		const timestamp = "timestamp" in message ? message.timestamp : undefined;
+		if (!model || typeof timestamp !== "number") return undefined;
+		const responseId = "responseId" in message && typeof message.responseId === "string" ? message.responseId : "";
+		return JSON.stringify([model, timestamp, responseId]);
+	};
+
+	const rememberAssistantMessage = (message: AgentMessage): void => {
+		seenAssistantMessages.add(message);
+		const identity = getAssistantMessageIdentity(message);
+		if (identity) seenAssistantMessageIdentities.add(identity);
+	};
+
 	const isProviderAssistantMessage = (message: AgentMessage): message is AssistantMessage =>
 		message.role === "assistant" &&
 		"stopReason" in message &&
@@ -1057,7 +1073,13 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		event: Extract<AgentEvent, { type: "message_start" | "message_update" }>,
 		eventOrdinal: number,
 	): boolean => {
-		if (!progress.retryState || eventOrdinal <= retryStartOrdinal || seenAssistantMessages.has(event.message))
+		const messageIdentity = getAssistantMessageIdentity(event.message);
+		if (
+			!progress.retryState ||
+			eventOrdinal <= retryStartOrdinal ||
+			seenAssistantMessages.has(event.message) ||
+			(messageIdentity !== undefined && seenAssistantMessageIdentities.has(messageIdentity))
+		)
 			return false;
 		if (!hasMatchingActiveProviderModel(event.message)) return false;
 		if (event.type === "message_start") return isSuccessfulProviderAssistantMessage(event.message);
@@ -1112,7 +1134,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				if (event.message.role !== "assistant") break;
 				const retryWasActive = Boolean(progress.retryState);
 				const recoversRetry = isProviderBackedRecoveryEvent(event, eventOrdinal);
-				seenAssistantMessages.add(event.message);
+				rememberAssistantMessage(event.message);
 				if (recoversRetry || !retryWasActive) {
 					lastProviderProgressAtMs = now;
 					resetRecentOutput();
@@ -1237,7 +1259,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				if (event.message.role !== "assistant") break;
 				const retryWasActive = Boolean(progress.retryState);
 				const recoversRetry = isProviderBackedRecoveryEvent(event, eventOrdinal);
-				if (!retryWasActive) seenAssistantMessages.add(event.message);
+				if (!retryWasActive) rememberAssistantMessage(event.message);
 				if (recoversRetry || !retryWasActive) lastProviderProgressAtMs = now;
 				if (recoversRetry) {
 					progress.retryState = undefined;
@@ -1809,7 +1831,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				if (event.type === "auto_retry_start") {
 					retryStartOrdinal = eventOrdinal;
 					for (const message of session.messages) {
-						if (message.role === "assistant") seenAssistantMessages.add(message);
+						if (message.role === "assistant") rememberAssistantMessage(message);
 					}
 					progress.retryState = {
 						attempt: event.attempt,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -15,7 +15,7 @@ import type {
 } from "@gajae-code/agent-core";
 import { recordHandoff, resolveTelemetry } from "@gajae-code/agent-core";
 import { estimateMessageTokensHeuristic } from "@gajae-code/agent-core/compaction";
-import type { Message, Model, ServiceTier } from "@gajae-code/ai";
+import type { AssistantMessage, Message, Model, ServiceTier } from "@gajae-code/ai";
 import { type JsonSchemaValidationIssue, validateJsonSchemaValue } from "@gajae-code/ai/utils/schema";
 import { logger, prompt, untilAborted } from "@gajae-code/utils";
 import { AsyncJobManager } from "../async";
@@ -80,6 +80,21 @@ const agentEventTypes = new Set<AgentEvent["type"]>([
 	"tool_execution_start",
 	"tool_execution_update",
 	"tool_execution_end",
+]);
+
+const providerStreamingUpdateTypes = new Set<string>([
+	"text_start",
+	"text_delta",
+	"text_end",
+	"thinking_start",
+	"thinking_delta",
+	"thinking_end",
+	"reasoning_summary_start",
+	"reasoning_summary_delta",
+	"reasoning_summary_end",
+	"toolcall_start",
+	"toolcall_delta",
+	"toolcall_end",
 ]);
 
 const isAgentEvent = (event: AgentSessionEvent): event is AgentEvent =>
@@ -846,8 +861,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	let modelSubstitutionWarning: ModelSubstitutionWarning | undefined;
 	let resolvedModelString: string | undefined;
 	let lastAssistantModelString: string | undefined;
+	let activeProviderModelString: string | undefined;
 	let effectiveThinkingLevelForWarning: ThinkingLevel | undefined;
 	let lastProviderProgressAtMs: number | undefined;
+	let sessionEventOrdinal = 0;
+	let retryStartOrdinal = 0;
+	const seenAssistantMessages = new WeakSet<AgentMessage>();
 
 	// Accumulate usage incrementally from message_end events (no memory for streaming events)
 	const accumulatedUsage = {
@@ -929,7 +948,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 	const emitProgressNow = () => {
 		progress.durationMs = Date.now() - startTime;
-		onProgress?.({ ...progress });
+		const progressSnapshot = structuredClone(progress);
+		onProgress?.(progressSnapshot);
 		if (options.eventBus) {
 			options.eventBus.emit(TASK_SUBAGENT_PROGRESS_CHANNEL, {
 				index,
@@ -937,7 +957,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				agentSource: agent.source,
 				task,
 				assignment,
-				progress: { ...progress },
+				progress: progressSnapshot,
 				sessionFile: null,
 			});
 		}
@@ -992,6 +1012,48 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			: undefined;
 	};
 
+	const hasMatchingActiveProviderModel = (message: AgentMessage): message is AssistantMessage =>
+		message.role === "assistant" &&
+		"stopReason" in message &&
+		Array.isArray(message.content) &&
+		activeProviderModelString !== undefined &&
+		getMessageModelString(message) === activeProviderModelString;
+
+	const isProviderStreamingUpdate = (event: Extract<AgentEvent, { type: "message_update" }>): boolean => {
+		const update = event.assistantMessageEvent;
+		if (!update || typeof update !== "object" || !providerStreamingUpdateTypes.has(update.type)) return false;
+		if (!("partial" in update) || getMessageModelString(update.partial) !== activeProviderModelString) return false;
+		switch (update.type) {
+			case "text_delta":
+			case "thinking_delta":
+			case "reasoning_summary_delta":
+			case "toolcall_delta":
+				return typeof update.delta === "string";
+			default:
+				return typeof update.contentIndex === "number";
+		}
+	};
+
+	const isProviderBackedRecoveryEvent = (
+		event: Extract<AgentEvent, { type: "message_start" | "message_update" }>,
+		eventOrdinal: number,
+	): boolean => {
+		if (!progress.retryState || eventOrdinal <= retryStartOrdinal || seenAssistantMessages.has(event.message))
+			return false;
+		if (!hasMatchingActiveProviderModel(event.message)) return false;
+		if (event.type === "message_start") {
+			const message = event.message;
+			return (
+				message.stopReason !== "error" &&
+				message.stopReason !== "aborted" &&
+				message.errorMessage === undefined &&
+				message.errorKind === undefined &&
+				message.transportFailure === undefined
+			);
+		}
+		return isProviderStreamingUpdate(event);
+	};
+
 	const updateRecentOutputLines = () => {
 		const lines = recentOutputTail.split("\n").filter(line => line.trim());
 		progress.recentOutput = lines.slice(-8).reverse();
@@ -1002,21 +1064,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		recentOutputTail += text;
 		if (recentOutputTail.length > RECENT_OUTPUT_TAIL_BYTES) {
 			recentOutputTail = recentOutputTail.slice(-RECENT_OUTPUT_TAIL_BYTES);
-		}
-		updateRecentOutputLines();
-	};
-
-	const replaceRecentOutputFromContent = (content: unknown[]) => {
-		recentOutputTail = "";
-		for (const block of content) {
-			if (!block || typeof block !== "object") continue;
-			const record = block as { type?: unknown; text?: unknown };
-			if (record.type !== "text" || typeof record.text !== "string") continue;
-			if (!record.text) continue;
-			recentOutputTail += record.text;
-			if (recentOutputTail.length > RECENT_OUTPUT_TAIL_BYTES) {
-				recentOutputTail = recentOutputTail.slice(-RECENT_OUTPUT_TAIL_BYTES);
-			}
 		}
 		updateRecentOutputLines();
 	};
@@ -1040,21 +1087,32 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		});
 	};
 
-	const processEvent = (event: AgentEvent) => {
+	const processEvent = (event: AgentEvent, eventOrdinal: number) => {
 		if (resolved) return;
 
 		forwardSubagentEvent(event);
 
 		const now = Date.now();
 		let flushProgress = false;
+		// A retry is recovered at the first assistant provider event, before the
+		// session emits auto_retry_end after message completion.
 
 		switch (event.type) {
-			case "message_start":
-				if (event.message?.role === "assistant") {
+			case "message_start": {
+				if (event.message.role !== "assistant") break;
+				const retryWasActive = Boolean(progress.retryState);
+				const recoversRetry = isProviderBackedRecoveryEvent(event, eventOrdinal);
+				seenAssistantMessages.add(event.message);
+				if (recoversRetry || !retryWasActive) {
 					lastProviderProgressAtMs = now;
 					resetRecentOutput();
 				}
+				if (recoversRetry) {
+					progress.retryState = undefined;
+					flushProgress = true;
+				}
 				break;
+			}
 
 			case "tool_execution_start": {
 				progress.toolCount++;
@@ -1166,24 +1224,17 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 
 			case "message_update": {
-				if (event.message?.role !== "assistant") break;
-				lastProviderProgressAtMs = now;
-				const assistantEvent = (
-					event as AgentEvent & {
-						assistantMessageEvent?: { type?: string; delta?: string };
-					}
-				).assistantMessageEvent;
-				if (assistantEvent?.type === "text_delta" && typeof assistantEvent.delta === "string") {
-					appendRecentOutputTail(assistantEvent.delta);
-					break;
+				if (event.message.role !== "assistant") break;
+				const retryWasActive = Boolean(progress.retryState);
+				const recoversRetry = isProviderBackedRecoveryEvent(event, eventOrdinal);
+				if (!retryWasActive) seenAssistantMessages.add(event.message);
+				if (recoversRetry || !retryWasActive) lastProviderProgressAtMs = now;
+				if (recoversRetry) {
+					progress.retryState = undefined;
+					flushProgress = true;
 				}
-				if (assistantEvent && assistantEvent.type !== "text_delta") {
-					break;
-				}
-				const updateContent =
-					getMessageContent(event.message) || (event as AgentEvent & { content?: unknown }).content;
-				if (updateContent && Array.isArray(updateContent)) {
-					replaceRecentOutputFromContent(updateContent);
+				if (event.assistantMessageEvent.type === "text_delta") {
+					appendRecentOutputTail(event.assistantMessageEvent.delta);
 				}
 				break;
 			}
@@ -1205,6 +1256,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					const assistantModel = getMessageModelString(event.message);
 					if (assistantModel) {
 						lastAssistantModelString = assistantModel;
+						activeProviderModelString = assistantModel;
 						if (resolvedModelString && assistantModel !== resolvedModelString && !modelSubstitutionWarning) {
 							modelSubstitutionWarning = {
 								requested: resolvedModelString,
@@ -1372,6 +1424,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			);
 			if (model) {
 				resolvedModelString = formatModelString(model);
+				activeProviderModelString = resolvedModelString;
 			}
 			if (authFallbackUsed && model && requestedModel) {
 				modelSubstitutionWarning = {
@@ -1742,13 +1795,21 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			const MAX_YIELD_RETRIES = 3;
 			unsubscribe = session.subscribe(event => {
+				sessionEventOrdinal += 1;
+				const eventOrdinal = sessionEventOrdinal;
 				if (event.type === "auto_retry_start") {
+					retryStartOrdinal = eventOrdinal;
+					for (const message of session.messages) {
+						if (message.role === "assistant") seenAssistantMessages.add(message);
+					}
 					progress.retryState = {
 						attempt: event.attempt,
 						maxAttempts: event.maxAttempts,
 						unbounded: event.unbounded,
 						kind: classifyProviderRetry(event.errorMessage),
-						provider: providerNameFromModel(lastAssistantModelString ?? resolvedModelString),
+						provider: providerNameFromModel(
+							activeProviderModelString ?? lastAssistantModelString ?? resolvedModelString,
+						),
 						lastProviderProgressAtMs,
 						delayMs: event.delayMs,
 						errorMessage: event.errorMessage,
@@ -1771,12 +1832,13 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					return;
 				}
 				if (event.type === "model_fallback_switched") {
+					activeProviderModelString = event.to;
 					forwardSubagentEvent(event);
 					return;
 				}
 				if (isAgentEvent(event)) {
 					try {
-						processEvent(event);
+						processEvent(event, eventOrdinal);
 					} catch (err) {
 						logger.error("Subagent event processing failed", {
 							error: err instanceof Error ? err.message : String(err),

--- a/packages/coding-agent/src/task/provider-retry-status.ts
+++ b/packages/coding-agent/src/task/provider-retry-status.ts
@@ -78,7 +78,7 @@ export interface ProviderDegradationGroup {
 export function collectProviderDegradationGroups(progress: readonly AgentProgress[]): ProviderDegradationGroup[] {
 	const counts = new Map<string, number>();
 	for (const item of progress) {
-		if (item.status !== "running" || !item.retryState) continue;
+		if (!isAgentProgress(item) || item.status !== "running" || !item.retryState) continue;
 		const provider = item.retryState.provider ?? "provider";
 		counts.set(provider, (counts.get(provider) ?? 0) + 1);
 	}

--- a/packages/coding-agent/src/task/provider-retry-status.ts
+++ b/packages/coding-agent/src/task/provider-retry-status.ts
@@ -1,4 +1,4 @@
-import type { AgentProgress } from "./types";
+import type { AgentProgress, TaskToolDetails } from "./types";
 
 export type ProviderRetryKind = NonNullable<AgentProgress["retryState"]>["kind"];
 
@@ -31,6 +31,43 @@ export function providerProgressAgeLabel(retryState: NonNullable<AgentProgress["
 	if (retryState.lastProviderProgressAtMs === undefined) return "no provider events yet";
 	const ageSeconds = Math.max(0, Math.floor((nowMs - retryState.lastProviderProgressAtMs) / 1000));
 	return `last provider progress ${ageSeconds}s ago`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object";
+}
+
+function isTaskToolDetails(value: unknown): value is TaskToolDetails {
+	return (
+		isRecord(value) && Array.isArray(value.results) && (value.progress === undefined || Array.isArray(value.progress))
+	);
+}
+
+function isAgentProgress(value: unknown): value is AgentProgress {
+	return isRecord(value) && typeof value.status === "string";
+}
+
+export function hasActiveProviderRetryInTaskDetails(details: TaskToolDetails, seen = new WeakSet<object>()): boolean {
+	if (!isTaskToolDetails(details) || seen.has(details)) return false;
+	seen.add(details);
+	for (const progress of details.progress ?? []) {
+		if (isAgentProgress(progress) && hasActiveProviderRetryInProgress(progress, seen)) return true;
+	}
+	return false;
+}
+
+export function hasActiveProviderRetryInProgress(progress: AgentProgress, seen = new WeakSet<object>()): boolean {
+	if (!isAgentProgress(progress) || seen.has(progress)) return false;
+	seen.add(progress);
+	if (progress.status === "running" && progress.retryState) return true;
+
+	const nestedTaskData = isRecord(progress.extractedToolData) ? progress.extractedToolData.task : undefined;
+	if (Array.isArray(nestedTaskData)) {
+		for (const nestedDetails of nestedTaskData) {
+			if (hasActiveProviderRetryInTaskDetails(nestedDetails as TaskToolDetails, seen)) return true;
+		}
+	}
+	return hasActiveProviderRetryInTaskDetails(progress.inflightTaskDetails as TaskToolDetails, seen);
 }
 
 export interface ProviderDegradationGroup {

--- a/packages/coding-agent/src/task/provider-retry-status.ts
+++ b/packages/coding-agent/src/task/provider-retry-status.ts
@@ -1,0 +1,51 @@
+import type { AgentProgress } from "./types";
+
+export type ProviderRetryKind = NonNullable<AgentProgress["retryState"]>["kind"];
+
+const FIRST_EVENT_TIMEOUT_PATTERN = /stream timed out while waiting for the first event/i;
+const IDLE_STREAM_STALL_PATTERN = /stream stalled while waiting for the next event/i;
+
+export function classifyProviderRetry(errorMessage: string): ProviderRetryKind {
+	if (FIRST_EVENT_TIMEOUT_PATTERN.test(errorMessage)) return "first_event_timeout";
+	if (IDLE_STREAM_STALL_PATTERN.test(errorMessage)) return "idle_stream_stall";
+	return "provider_error";
+}
+
+export function providerNameFromModel(model: string | undefined): string | undefined {
+	const provider = model?.split("/", 1)[0]?.trim();
+	return provider || undefined;
+}
+
+export function providerRetryPhaseLabel(kind: ProviderRetryKind): string {
+	switch (kind) {
+		case "first_event_timeout":
+			return "first event timeout";
+		case "idle_stream_stall":
+			return "stream stalled";
+		case "provider_error":
+			return "provider error";
+	}
+}
+
+export function providerProgressAgeLabel(retryState: NonNullable<AgentProgress["retryState"]>, nowMs: number): string {
+	if (retryState.lastProviderProgressAtMs === undefined) return "no provider events yet";
+	const ageSeconds = Math.max(0, Math.floor((nowMs - retryState.lastProviderProgressAtMs) / 1000));
+	return `last provider progress ${ageSeconds}s ago`;
+}
+
+export interface ProviderDegradationGroup {
+	provider: string;
+	count: number;
+}
+
+export function collectProviderDegradationGroups(progress: readonly AgentProgress[]): ProviderDegradationGroup[] {
+	const counts = new Map<string, number>();
+	for (const item of progress) {
+		if (item.status !== "running" || !item.retryState) continue;
+		const provider = item.retryState.provider ?? "provider";
+		counts.set(provider, (counts.get(provider) ?? 0) + 1);
+	}
+	return Array.from(counts, ([provider, count]) => ({ provider, count }))
+		.filter(group => group.count > 1)
+		.sort((a, b) => b.count - a.count || a.provider.localeCompare(b.provider));
+}

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -28,6 +28,11 @@ import {
 	type SubmitReviewDetails,
 } from "../tools/review";
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine } from "../tui";
+import {
+	collectProviderDegradationGroups,
+	providerProgressAgeLabel,
+	providerRetryPhaseLabel,
+} from "./provider-retry-status";
 import type { TaskResultReceipt } from "./receipt";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
 import type { AgentProgress, TaskParams, TaskToolDetails } from "./types";
@@ -121,6 +126,15 @@ function normalizeReportFindings(value: unknown): ReportFindingDetails[] {
 
 function formatModelSubstitutionWarning(warning: { requested: string; effective: string }): string {
 	return `Requested model substituted: ${warning.requested} -> ${warning.effective}`;
+}
+
+function renderProviderDegradationNotices(progress: readonly AgentProgress[], theme: Theme): string[] {
+	return collectProviderDegradationGroups(progress).map(group =>
+		theme.fg(
+			"warning",
+			truncateToWidth(replaceTabs(`provider degraded: ${group.count} subagents retrying on ${group.provider}`), 100),
+		),
+	);
 }
 
 function formatJsonScalar(value: unknown, _theme: Theme): string {
@@ -548,14 +562,11 @@ function renderAgentProgress(
 	const titlePart = description ? `${theme.bold(displayId)}: ${description}` : displayId;
 	let statusLine = `${prefix} ${theme.fg(iconColor, icon)} ${theme.fg("accent", titlePart)}`;
 
-	// Show retry-blocked badge so the parent immediately sees that a child
-	// is sleeping on a provider 429, not silently progressing. Wins over the
-	// generic running spinner because "we're waiting on a quota window" is
-	// the operationally meaningful state.
+	// A provider recovery loop is operationally distinct from normal agent work.
 	if (progress.retryState && progress.status === "running") {
-		statusLine += ` ${formatBadge("retrying", "warning", theme)}`;
+		statusLine += ` ${formatBadge("provider degraded", "warning", theme)}`;
 	} else if (progress.retryFailure && (progress.status === "failed" || progress.status === "aborted")) {
-		statusLine += ` ${formatBadge("rate-limited", "error", theme)}`;
+		statusLine += ` ${formatBadge("provider failed", "error", theme)}`;
 	} else if (progress.status === "failed" || progress.status === "aborted") {
 		const statusLabel = progress.status === "failed" ? "failed" : "aborted";
 		statusLine += ` ${formatBadge(statusLabel, iconColor, theme)}`;
@@ -615,8 +626,10 @@ function renderAgentProgress(
 	// keep spinning while a child sleeps on a 3-hour provider rate-limit.
 	if (progress.retryState && progress.status === "running") {
 		const attemptLabel = progress.retryState.unbounded
-			? `attempt ${progress.retryState.attempt}`
-			: `${progress.retryState.attempt}/${progress.retryState.maxAttempts}`;
+			? `attempt ${progress.retryState.attempt}, unbounded`
+			: `attempt ${progress.retryState.attempt} of ${progress.retryState.maxAttempts}, bounded`;
+		const phaseLabel = providerRetryPhaseLabel(progress.retryState.kind);
+		const progressAge = staticTime ? "" : ` · ${providerProgressAgeLabel(progress.retryState, Date.now())}`;
 		// `staticTime` omits the wall-clock countdown so a cached await body stays a
 		// pure function of its key (the producer already drops time-only churn).
 		let waitLabel = "";
@@ -624,7 +637,7 @@ function renderAgentProgress(
 			const remainingMs = Math.max(0, progress.retryState.startedAtMs + progress.retryState.delayMs - Date.now());
 			waitLabel = remainingMs > 0 ? ` in ${formatDuration(remainingMs)}` : " now";
 		}
-		const summary = `retrying ${attemptLabel}${waitLabel}: ${truncateToWidth(replaceTabs(progress.retryState.errorMessage), 60)}`;
+		const summary = `${phaseLabel} · retrying ${attemptLabel}${waitLabel}${progressAge}: ${truncateToWidth(replaceTabs(progress.retryState.errorMessage), 60)}`;
 		lines.push(`${continuePrefix}${theme.tree.hook} ${theme.fg("warning", summary)}`);
 	} else if (progress.retryFailure && progress.status !== "running") {
 		const summary = `auto-retry gave up after ${progress.retryFailure.attempt} attempt${
@@ -960,6 +973,7 @@ export function renderResult(
 			const shouldRenderProgress =
 				Boolean(details.progress && details.progress.length > 0) && (isPartial || details.results.length === 0);
 			if (shouldRenderProgress && details.progress) {
+				lines.push(...renderProviderDegradationNotices(details.progress, theme));
 				details.progress.forEach((progress, i) => {
 					const isLast = i === details.progress!.length - 1;
 					lines.push(...renderAgentProgress(progress, isLast, expanded, theme, spinnerFrame));

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -30,6 +30,7 @@ import {
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine } from "../tui";
 import {
 	collectProviderDegradationGroups,
+	hasActiveProviderRetryInTaskDetails,
 	providerProgressAgeLabel,
 	providerRetryPhaseLabel,
 } from "./provider-retry-status";
@@ -966,7 +967,8 @@ export function renderResult(
 				.u32(spinnerFrame ?? 0)
 				.u32(width)
 				.digest();
-			if (cached?.key === key) return cached.lines;
+			const hasDynamicRetry = hasActiveProviderRetryInTaskDetails(details);
+			if (!hasDynamicRetry && cached?.key === key) return cached.lines;
 
 			const lines: string[] = [];
 
@@ -1011,7 +1013,7 @@ export function renderResult(
 			if (lines.length === 0) {
 				const text = fallbackText.trim() ? fallbackText : "No results";
 				const result = [theme.fg("dim", truncateToWidth(text, width))];
-				cached = { key, lines: result };
+				if (!hasDynamicRetry) cached = { key, lines: result };
 				return result;
 			}
 
@@ -1033,9 +1035,9 @@ export function renderResult(
 			}
 
 			const indented = lines.map(line =>
-				line.length > 0 ? truncateToWidth(`   ${line}`, width, Ellipsis.Omit) : "",
+				line.length > 0 ? truncateToWidth(`   ${replaceTabs(line)}`, width, Ellipsis.Omit) : "",
 			);
-			cached = { key, lines: indented };
+			if (!hasDynamicRetry) cached = { key, lines: indented };
 			return indented;
 		},
 		invalidate() {
@@ -1089,6 +1091,7 @@ function renderNestedTaskTree(
 		}
 		const inflight = details.progress;
 		if (inflight && inflight.length > 0) {
+			lines.push(...renderProviderDegradationNotices(inflight, theme));
 			inflight.forEach((prog, index) => {
 				const isLast = index === inflight.length - 1;
 				lines.push(...renderAgentProgress(prog, isLast, expanded, theme, spinnerFrame, staticTime));

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -972,20 +972,23 @@ export function renderResult(
 
 			const lines: string[] = [];
 
-			const shouldRenderProgress =
-				Boolean(details.progress && details.progress.length > 0) && (isPartial || details.results.length === 0);
+			const hasProgress = Boolean(details.progress && details.progress.length > 0);
+			const shouldRenderProgress = hasProgress && (isPartial || details.results.length === 0);
+			const hasResults = details.results.length > 0;
+			if (hasResults) {
+				details.results.forEach((res, i) => {
+					const isLast = !shouldRenderProgress && i === details.results.length - 1;
+					lines.push(...renderAgentResult(res, isLast, expanded, theme));
+				});
+			}
 			if (shouldRenderProgress && details.progress) {
 				lines.push(...renderProviderDegradationNotices(details.progress, theme));
 				details.progress.forEach((progress, i) => {
 					const isLast = i === details.progress!.length - 1;
 					lines.push(...renderAgentProgress(progress, isLast, expanded, theme, spinnerFrame));
 				});
-			} else if (details.results && details.results.length > 0) {
-				details.results.forEach((res, i) => {
-					const isLast = i === details.results.length - 1;
-					lines.push(...renderAgentResult(res, isLast, expanded, theme));
-				});
-
+			}
+			if (hasResults && !shouldRenderProgress) {
 				const abortedCount = details.results.filter(r => r.status === "aborted").length;
 				const mergeFailedCount = details.results.filter(r => r.status === "merge_failed").length;
 				const successCount = details.results.filter(r => r.status === "completed").length;
@@ -1081,15 +1084,14 @@ function renderNestedTaskTree(
 ): string[] {
 	const lines: string[] = [];
 	for (const details of detailsList) {
-		const hasResults = Boolean(details.results && details.results.length > 0);
-		if (hasResults) {
+		const inflight = details.progress;
+		const hasInflight = Boolean(inflight && inflight.length > 0);
+		if (details.results && details.results.length > 0) {
 			details.results.forEach((result, index) => {
-				const isLast = index === details.results.length - 1;
+				const isLast = !hasInflight && index === details.results.length - 1;
 				lines.push(...renderAgentResult(result, isLast, expanded, theme));
 			});
-			continue;
 		}
-		const inflight = details.progress;
 		if (inflight && inflight.length > 0) {
 			lines.push(...renderProviderDegradationNotices(inflight, theme));
 			inflight.forEach((prog, index) => {

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -285,6 +285,9 @@ export interface AgentProgress {
 		attempt: number;
 		maxAttempts: number;
 		unbounded?: boolean;
+		kind: "first_event_timeout" | "idle_stream_stall" | "provider_error";
+		provider?: string;
+		lastProviderProgressAtMs?: number;
 		delayMs: number;
 		errorMessage: string;
 		startedAtMs: number;

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -13,6 +13,7 @@ import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import {
 	collectProviderDegradationGroups,
+	hasActiveProviderRetryInProgress,
 	providerProgressAgeLabel,
 	providerRetryPhaseLabel,
 } from "../task/provider-retry-status";
@@ -47,7 +48,8 @@ const PREVIEW_LINE_WIDTH = 80;
  * wall-clock displays are deliberately kept OUT of the cached body — the animated
  * spinner and the fresh duration live in the cheap per-subagent status line, and
  * `renderSubagentLiveProgress` is invoked with `staticTime` so current-tool elapsed
- * and retry countdowns are never baked into cached lines.
+ * and retry countdowns are never baked into cached lines. Snapshots with an active
+ * retry anywhere in their nested task tree bypass this cache and render dynamically.
  */
 const SUBAGENT_BODY_CACHE_MAX = 128;
 const subagentBodyCache = new Map<bigint, string[]>();
@@ -82,6 +84,15 @@ export const subagentBodyCacheTestHooks = {
 	},
 };
 
+function snapshotHasActiveRetry(snapshot: SubagentSnapshot): boolean {
+	if (snapshot.liveProgressAvailable === false || !snapshot.progress) return false;
+	return hasActiveProviderRetryInProgress(snapshot.progress);
+}
+
+function boundSubagentBodyLines(lines: string[], width: number): string[] {
+	return lines.map(line => (line.length > 0 ? truncateToWidth(replaceTabs(line), width, Ellipsis.Omit) : ""));
+}
+
 function renderCachedSubagentBody(
 	snapshot: SubagentSnapshot,
 	signature: string,
@@ -97,9 +108,7 @@ function renderCachedSubagentBody(
 		subagentBodyCache.set(key, hit);
 		return hit;
 	}
-	const lines = renderSubagentSnapshotBody(snapshot, expanded, theme).map(line =>
-		line.length > 0 ? truncateToWidth(line, width, Ellipsis.Omit) : "",
-	);
+	const lines = boundSubagentBodyLines(renderSubagentSnapshotBody(snapshot, expanded, theme), width);
 	subagentBodyRenderCount += 1;
 	subagentBodyCache.set(key, lines);
 	if (subagentBodyCache.size > SUBAGENT_BODY_CACHE_MAX) {
@@ -107,6 +116,16 @@ function renderCachedSubagentBody(
 		if (oldest !== undefined) subagentBodyCache.delete(oldest);
 	}
 	return lines;
+}
+
+function renderDynamicSubagentBody(
+	snapshot: SubagentSnapshot,
+	expanded: boolean,
+	width: number,
+	theme: Theme,
+): string[] {
+	subagentBodyRenderCount += 1;
+	return boundSubagentBodyLines(renderSubagentSnapshotBody(snapshot, expanded, theme, false), width);
 }
 
 function statusIconKind(status: SubagentSnapshot["status"]): ToolUIStatus {
@@ -147,10 +166,14 @@ function renderSubagentStatusLine(snapshot: SubagentSnapshot, theme: Theme, spin
 	return `${icon} ${id} ${status} ${duration}`;
 }
 
-// Heavy, cacheable per-subagent body: a pure function of (snapshot content, expanded,
-// theme). No spinner frame and no wall-clock displays leak in (live progress uses
-// `staticTime`), so the module body cache can never serve stale or frozen-ticking lines.
-function renderSubagentSnapshotBody(snapshot: SubagentSnapshot, expanded: boolean, theme: Theme): string[] {
+// Heavy per-subagent body. The cache path uses staticTime=true; the bounded dynamic
+// path opts into wall-clock displays when an active retry exists in the nested tree.
+function renderSubagentSnapshotBody(
+	snapshot: SubagentSnapshot,
+	expanded: boolean,
+	theme: Theme,
+	staticTime = true,
+): string[] {
 	const lines: string[] = [];
 
 	// Static receipt fields (parity with the markdown content for non-await actions).
@@ -185,9 +208,9 @@ function renderSubagentSnapshotBody(snapshot: SubagentSnapshot, expanded: boolea
 	// exists (subagent.ts #liveProgressFields), but the renderer also honors an
 	// explicit `liveProgressAvailable: false` so stale retained progress can never
 	// resurrect a live panel (AC5). `staticTime` keeps wall-clock displays out of
-	// these cached lines.
+	// cached lines when the body is served by the cache.
 	if (snapshot.progress && snapshot.liveProgressAvailable !== false) {
-		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, undefined, true)) {
+		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, undefined, staticTime)) {
 			lines.push(`  ${pl}`);
 		}
 	} else if (snapshot.liveProgressAvailable && (snapshot.status === "running" || snapshot.status === "queued")) {
@@ -262,11 +285,17 @@ export const subagentToolRenderer = {
 					},
 					theme,
 				);
-				const out: string[] = [truncateToWidth(header, width, Ellipsis.Omit)];
+				const out: string[] = [truncateToWidth(replaceTabs(header), width, Ellipsis.Omit)];
 				// Discoverability: the inline panel is a bounded preview; the session
 				// observer (ctrl+s) streams the full per-subagent message history.
 				if (runningCount > 0) {
-					out.push(truncateToWidth(`  ${theme.fg("dim", "(ctrl+s to observe sessions)")}`, width, Ellipsis.Omit));
+					out.push(
+						truncateToWidth(
+							replaceTabs(`  ${theme.fg("dim", "(ctrl+s to observe sessions)")}`),
+							width,
+							Ellipsis.Omit,
+						),
+					);
 				}
 				const liveProgress = subagents.flatMap(snapshot =>
 					snapshot.progress && snapshot.liveProgressAvailable !== false ? [snapshot.progress] : [],
@@ -274,7 +303,9 @@ export const subagentToolRenderer = {
 				for (const group of collectProviderDegradationGroups(liveProgress)) {
 					out.push(
 						truncateToWidth(
-							`  ${theme.fg("warning", `provider degraded: ${group.count} subagents retrying on ${group.provider}`)}`,
+							replaceTabs(
+								`  ${theme.fg("warning", `provider degraded: ${group.count} subagents retrying on ${group.provider}`)}`,
+							),
 							width,
 							Ellipsis.Omit,
 						),
@@ -285,15 +316,19 @@ export const subagentToolRenderer = {
 					subagentAwaitRenderedStateSignature([snapshot], result.details),
 				);
 				subagents.forEach((snapshot, index) => {
-					// Fresh per-subagent status line (cheap), then the cached heavy body.
+					// Fresh per-subagent status line (cheap), then a cached or dynamic body.
 					out.push(
 						truncateToWidth(
-							renderSubagentStatusLine(snapshot, theme, options.spinnerFrame),
+							replaceTabs(renderSubagentStatusLine(snapshot, theme, options.spinnerFrame)),
 							width,
 							Ellipsis.Omit,
 						),
 					);
-					out.push(...renderCachedSubagentBody(snapshot, snapshotSignatures![index]!, expanded, width, theme));
+					out.push(
+						...(snapshotHasActiveRetry(snapshot)
+							? renderDynamicSubagentBody(snapshot, expanded, width, theme)
+							: renderCachedSubagentBody(snapshot, snapshotSignatures![index]!, expanded, width, theme)),
+					);
 				});
 				return out;
 			},

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -11,6 +11,11 @@ import type { Component } from "@gajae-code/tui";
 import { Text } from "@gajae-code/tui";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
+import {
+	collectProviderDegradationGroups,
+	providerProgressAgeLabel,
+	providerRetryPhaseLabel,
+} from "../task/provider-retry-status";
 import { renderSubagentLiveProgress } from "../task/render";
 import { Ellipsis, Hasher, renderStatusLine } from "../tui";
 import {
@@ -131,7 +136,13 @@ function renderSubagentStatusLine(snapshot: SubagentSnapshot, theme: Theme, spin
 		snapshot.status === "running" ? spinnerFrame : undefined,
 	);
 	const id = theme.fg("muted", truncateToWidth(replaceTabs(snapshot.id), PREVIEW_LINE_WIDTH, Ellipsis.Unicode));
-	const status = theme.fg("dim", snapshot.status);
+	const retryState = snapshot.liveProgressAvailable !== false ? snapshot.progress?.retryState : undefined;
+	const status = retryState
+		? theme.fg(
+				"warning",
+				`provider degraded · ${providerRetryPhaseLabel(retryState.kind)} · ${providerProgressAgeLabel(retryState, Date.now())}`,
+			)
+		: theme.fg("dim", snapshot.status);
 	const duration = theme.fg("dim", formatDuration(snapshot.durationMs));
 	return `${icon} ${id} ${status} ${duration}`;
 }
@@ -256,6 +267,18 @@ export const subagentToolRenderer = {
 				// observer (ctrl+s) streams the full per-subagent message history.
 				if (runningCount > 0) {
 					out.push(truncateToWidth(`  ${theme.fg("dim", "(ctrl+s to observe sessions)")}`, width, Ellipsis.Omit));
+				}
+				const liveProgress = subagents.flatMap(snapshot =>
+					snapshot.progress && snapshot.liveProgressAvailable !== false ? [snapshot.progress] : [],
+				);
+				for (const group of collectProviderDegradationGroups(liveProgress)) {
+					out.push(
+						truncateToWidth(
+							`  ${theme.fg("warning", `provider degraded: ${group.count} subagents retrying on ${group.provider}`)}`,
+							width,
+							Ellipsis.Omit,
+						),
+					);
 				}
 
 				snapshotSignatures ??= subagents.map(snapshot =>

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -936,6 +936,8 @@ function canonicalizeProgressForSignature(progress: AgentProgress): unknown {
 					attempt: progress.retryState.attempt,
 					maxAttempts: progress.retryState.maxAttempts,
 					unbounded: progress.retryState.unbounded ?? false,
+					kind: progress.retryState.kind,
+					provider: progress.retryState.provider ?? null,
 					delayMs: progress.retryState.delayMs,
 					errorMessage: progress.retryState.errorMessage,
 					// startedAtMs intentionally excluded (drives countdown only).

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { AgentBusyError, type AgentTelemetryConfig, type Tracer } from "@gajae-code/agent-core";
-import { type AssistantMessage, Effort, type Model } from "@gajae-code/ai";
+import { type AssistantMessage, type AssistantMessageEvent, Effort, type Model } from "@gajae-code/ai";
 import { kNoAuth } from "../../src/config/model-registry";
 
 import { Settings } from "../../src/config/settings";
@@ -12,7 +12,8 @@ import type { AgentSession, AgentSessionEvent, ForkContextSeed, PromptOptions } 
 import type { AuthStorage } from "../../src/session/auth-storage";
 import { runSubprocess, SUBAGENT_WARNING_MISSING_YIELD } from "../../src/task/executor";
 
-import type { AgentDefinition } from "../../src/task/types";
+import { type AgentDefinition, type AgentProgress, TASK_SUBAGENT_PROGRESS_CHANNEL } from "../../src/task/types";
+
 import { EventBus } from "../../src/utils/event-bus";
 
 function createAssistantStopMessage(text: string): AssistantMessage {
@@ -57,6 +58,9 @@ function createMockSession(
 		state,
 		agent: { state: { systemPrompt: ["test"] } },
 		model: options?.model,
+		get messages() {
+			return state.messages;
+		},
 		extensionRunner: undefined,
 		sessionManager: {
 			appendSessionInit: () => {},
@@ -206,6 +210,269 @@ describe("runSubprocess yield reminders", () => {
 				scope: "subagent",
 			}),
 		]);
+	});
+
+	it("clears provider retry state on the first recovered assistant event", async () => {
+		let currentEvent = "setup";
+		const progressUpdates: Array<{ event: string; progress: AgentProgress }> = [];
+		const eventBus = new EventBus();
+		const disposeProgressListener = eventBus.on(TASK_SUBAGENT_PROGRESS_CHANNEL, payload => {
+			const progress = (payload as { progress: AgentProgress }).progress;
+			progressUpdates.push({ event: currentEvent, progress: structuredClone(progress) });
+		});
+
+		const session = createMockSession(({ emit, state }) => {
+			const recovered = { ...createAssistantStopMessage("recovered"), provider: "test", model: "mock" };
+
+			currentEvent = "auto_retry_start";
+			emit({
+				type: "auto_retry_start",
+				attempt: 1,
+				maxAttempts: 3,
+				delayMs: 10_000,
+				errorMessage: "provider stream stalled",
+			});
+			state.messages.push(recovered);
+			currentEvent = "message_start";
+			emit({ type: "message_start", message: recovered });
+			currentEvent = "auto_retry_end";
+			emit({ type: "auto_retry_end", success: true, attempt: 1 });
+			currentEvent = "tool_execution_end";
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-recovered-retry",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { recovered: true } },
+				},
+				isError: false,
+			});
+		});
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-retry-recovered-event",
+			eventBus,
+			modelOverride: "test/mock",
+			modelRegistry,
+		});
+
+		const retryStartIndex = progressUpdates.findIndex(update => update.event === "auto_retry_start");
+		const recoveredIndex = progressUpdates.findIndex(update => update.event === "message_start");
+		const retryEndIndex = progressUpdates.findIndex(update => update.event === "auto_retry_end");
+		expect(retryStartIndex).toBeGreaterThanOrEqual(0);
+		expect(progressUpdates[retryStartIndex]?.progress.retryState).toMatchObject({
+			attempt: 1,
+			kind: "provider_error",
+		});
+		expect(recoveredIndex).toBeGreaterThan(retryStartIndex);
+		expect(retryEndIndex).toBeGreaterThan(recoveredIndex);
+		expect(progressUpdates[recoveredIndex]?.progress.retryState).toBeUndefined();
+		expect(result.exitCode).toBe(0);
+		disposeProgressListener();
+	});
+
+	it("only clears retries on qualifying provider activity and starts each retry with the latest fallback provider", async () => {
+		let currentEvent = "setup";
+		const progressUpdates: Array<{ event: string; progress: AgentProgress }> = [];
+		const eventBus = new EventBus();
+		const disposeProgressListener = eventBus.on(TASK_SUBAGENT_PROGRESS_CHANNEL, payload => {
+			progressUpdates.push({
+				event: currentEvent,
+				progress: structuredClone((payload as { progress: AgentProgress }).progress),
+			});
+		});
+
+		const session = createMockSession(({ emit }) => {
+			const assistant = { ...createAssistantStopMessage("streaming"), provider: "test", model: "mock" };
+			const errored = { ...assistant, stopReason: "error" as const, errorMessage: "upstream failed" };
+			const update = (assistantMessageEvent: AssistantMessageEvent) =>
+				emit({ type: "message_update", message: { ...assistant }, assistantMessageEvent });
+			const retry = (attempt: number) =>
+				emit({
+					type: "auto_retry_start",
+					attempt,
+					maxAttempts: 3,
+					delayMs: 10_000,
+					errorMessage: "provider stream stalled",
+				});
+			const flush = () => emit({ type: "agent_end", messages: [], stopReason: "completed" });
+
+			currentEvent = "retry-1";
+			retry(1);
+			currentEvent = "errored-assistant-start";
+			emit({ type: "message_start", message: errored });
+			flush();
+			currentEvent = "aborted-assistant-start";
+			emit({ type: "message_start", message: { ...assistant, stopReason: "aborted" } });
+			flush();
+			currentEvent = "user-start";
+			emit({ type: "message_start", message: { role: "user", content: "control", timestamp: Date.now() } });
+			flush();
+			currentEvent = "control-update";
+			update({
+				type: "toolChoiceIncapability",
+				api: "openai-responses",
+				provider: "test",
+				model: "mock",
+				requestedLevel: "required",
+				resolvedLevel: "none",
+				reason: "unsupported",
+				registryKey: "test/mock",
+			});
+			flush();
+			currentEvent = "error-update";
+			update({ type: "error", reason: "error", error: errored });
+			flush();
+			currentEvent = "malformed-update";
+			emit({
+				type: "message_update",
+				message: assistant,
+				assistantMessageEvent: { type: "text_delta" } as unknown as AssistantMessageEvent,
+			});
+			flush();
+			currentEvent = "qualifying-update";
+			update({ type: "text_delta", contentIndex: 0, delta: "ok", partial: assistant });
+			currentEvent = "delayed-end";
+			emit({ type: "auto_retry_end", success: true, attempt: 1 });
+			currentEvent = "fallback-one";
+			emit({
+				type: "model_fallback_switched",
+				eventId: "fallback-one",
+				from: "test/mock",
+				to: "first/model",
+				reason: "rate_limit",
+				role: "executor",
+				scope: "subagent",
+				activeIndex: 1,
+				chainLength: 3,
+				attemptsUsed: 1,
+			});
+			currentEvent = "fallback-two";
+			emit({
+				type: "model_fallback_switched",
+				eventId: "fallback-two",
+				from: "first/model",
+				to: "final/model",
+				reason: "rate_limit",
+				role: "executor",
+				scope: "subagent",
+				activeIndex: 2,
+				chainLength: 3,
+				attemptsUsed: 2,
+			});
+			currentEvent = "retry-2";
+			retry(2);
+			currentEvent = "qualifying-start";
+			emit({ type: "message_start", message: { ...assistant, provider: "final", model: "model" } });
+			currentEvent = "tool_execution_end";
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "retry-qualification",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: {} },
+				},
+				isError: false,
+			});
+		});
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-retry-qualification",
+			eventBus,
+			modelOverride: "test/mock",
+			modelRegistry,
+		});
+		const states = (event: string) =>
+			progressUpdates.filter(update => update.event === event).map(update => update.progress);
+		for (const event of [
+			"errored-assistant-start",
+			"aborted-assistant-start",
+			"user-start",
+			"control-update",
+			"error-update",
+			"malformed-update",
+		]) {
+			expect(states(event).at(-1)?.retryState).toMatchObject({ attempt: 1, provider: "test" });
+		}
+		expect(states("qualifying-update").at(-1)?.retryState).toBeUndefined();
+		expect(states("delayed-end").at(-1)?.retryState).toBeUndefined();
+		expect(states("retry-2").at(-1)?.retryState).toMatchObject({ attempt: 2, provider: "final" });
+		expect(states("qualifying-start").at(-1)?.retryState).toBeUndefined();
+		expect(result.exitCode).toBe(0);
+		disposeProgressListener();
+	});
+
+	it("attributes fallback retries to the switched model provider", async () => {
+		let currentEvent = "setup";
+		const progressUpdates: Array<{ event: string; progress: AgentProgress }> = [];
+		const eventBus = new EventBus();
+		eventBus.on(TASK_SUBAGENT_PROGRESS_CHANNEL, payload => {
+			const progress = (payload as { progress: AgentProgress }).progress;
+			progressUpdates.push({ event: currentEvent, progress });
+		});
+
+		const session = createMockSession(({ emit, state }) => {
+			const failedProviderMessage = {
+				...createAssistantStopMessage("primary response"),
+				provider: "primary",
+				model: "model",
+			};
+			state.messages.push(failedProviderMessage);
+
+			currentEvent = "message_end";
+			emit({ type: "message_end", message: failedProviderMessage });
+			currentEvent = "model_fallback_switched";
+			emit({
+				type: "model_fallback_switched",
+				eventId: "fallback-provider-attribution",
+				from: "primary/model",
+				to: "fallback/model",
+				reason: "rate_limit",
+				role: "executor",
+				scope: "subagent",
+				activeIndex: 1,
+				chainLength: 2,
+				attemptsUsed: 1,
+			});
+			currentEvent = "auto_retry_start";
+			emit({
+				type: "auto_retry_start",
+				attempt: 1,
+				maxAttempts: 3,
+				delayMs: 10_000,
+				errorMessage: "provider rate limit",
+			});
+			currentEvent = "auto_retry_end";
+			emit({ type: "auto_retry_end", success: true, attempt: 1 });
+			currentEvent = "tool_execution_end";
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-fallback-retry",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { provider: "fallback" } },
+				},
+				isError: false,
+			});
+		});
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-fallback-provider-attribution",
+			eventBus,
+		});
+
+		const retryStart = progressUpdates.find(update => update.event === "auto_retry_start");
+		expect(retryStart?.progress.retryState?.provider).toBe("fallback");
+		expect(result.exitCode).toBe(0);
 	});
 
 	it("waits for session_start extension user messages before prompting the subagent", async () => {

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -333,6 +333,13 @@ describe("runSubprocess yield reminders", () => {
 				assistantMessageEvent: { type: "text_delta" } as unknown as AssistantMessageEvent,
 			});
 			flush();
+			currentEvent = "missing-update";
+			emit({
+				type: "message_update",
+				message: { ...assistant },
+				assistantMessageEvent: undefined,
+			} as unknown as AgentSessionEvent);
+			flush();
 			currentEvent = "qualifying-update";
 			update({ type: "text_delta", contentIndex: 0, delta: "ok", partial: assistant });
 			currentEvent = "delayed-end";
@@ -397,6 +404,7 @@ describe("runSubprocess yield reminders", () => {
 			"control-update",
 			"error-update",
 			"malformed-update",
+			"missing-update",
 		]) {
 			expect(states(event).at(-1)?.retryState).toMatchObject({ attempt: 1, provider: "test" });
 		}
@@ -472,6 +480,73 @@ describe("runSubprocess yield reminders", () => {
 
 		const retryStart = progressUpdates.find(update => update.event === "auto_retry_start");
 		expect(retryStart?.progress.retryState?.provider).toBe("fallback");
+		expect(result.exitCode).toBe(0);
+	});
+
+	it("does not count synthesized terminal message ends as provider progress", async () => {
+		let currentEvent = "setup";
+		const progressUpdates: Array<{ event: string; progress: AgentProgress }> = [];
+		const eventBus = new EventBus();
+		eventBus.on(TASK_SUBAGENT_PROGRESS_CHANNEL, payload => {
+			progressUpdates.push({
+				event: currentEvent,
+				progress: structuredClone((payload as { progress: AgentProgress }).progress),
+			});
+		});
+		const session = createMockSession(({ emit }) => {
+			const terminal = {
+				...createAssistantStopMessage("terminal failure"),
+				provider: "test",
+				model: "mock",
+				stopReason: "error" as const,
+				errorMessage: "provider failed",
+			};
+			currentEvent = "retry-1";
+			emit({
+				type: "auto_retry_start",
+				attempt: 1,
+				maxAttempts: 3,
+				delayMs: 1_000,
+				errorMessage: "provider failed",
+			});
+			currentEvent = "terminal-start";
+			emit({ type: "message_start", message: terminal });
+			currentEvent = "terminal-end";
+			emit({ type: "message_end", message: terminal });
+			currentEvent = "failed-end";
+			emit({ type: "auto_retry_end", success: false, attempt: 1, finalError: "provider failed" });
+			currentEvent = "retry-2";
+			emit({
+				type: "auto_retry_start",
+				attempt: 2,
+				maxAttempts: 3,
+				delayMs: 1_000,
+				errorMessage: "provider failed again",
+			});
+			currentEvent = "tool_execution_end";
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "terminal-progress-guard",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: {} },
+				},
+				isError: false,
+			});
+		});
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-terminal-progress-guard",
+			eventBus,
+			modelOverride: "test/mock",
+			modelRegistry,
+		});
+		const secondRetry = progressUpdates.find(update => update.event === "retry-2")?.progress.retryState;
+		expect(secondRetry).toMatchObject({ attempt: 2, provider: "test" });
+		expect(secondRetry?.lastProviderProgressAtMs).toBeUndefined();
 		expect(result.exitCode).toBe(0);
 	});
 

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -285,8 +285,13 @@ describe("runSubprocess yield reminders", () => {
 			});
 		});
 
-		const session = createMockSession(({ emit }) => {
+		const session = createMockSession(({ emit, state }) => {
 			const assistant = { ...createAssistantStopMessage("streaming"), provider: "test", model: "mock" };
+			const baseline = {
+				...assistant,
+				content: [{ type: "text" as const, text: "baseline" }],
+				timestamp: assistant.timestamp - 1_000,
+			};
 			const errored = { ...assistant, stopReason: "error" as const, errorMessage: "upstream failed" };
 			const update = (assistantMessageEvent: AssistantMessageEvent) =>
 				emit({ type: "message_update", message: { ...assistant }, assistantMessageEvent });
@@ -299,9 +304,17 @@ describe("runSubprocess yield reminders", () => {
 					errorMessage: "provider stream stalled",
 				});
 			const flush = () => emit({ type: "agent_end", messages: [], stopReason: "completed" });
+			state.messages.push(baseline);
 
 			currentEvent = "retry-1";
 			retry(1);
+			currentEvent = "baseline-replay-update";
+			emit({
+				type: "message_update",
+				message: { ...baseline },
+				assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "replay", partial: { ...baseline } },
+			});
+			flush();
 			currentEvent = "errored-assistant-start";
 			emit({ type: "message_start", message: errored });
 			flush();
@@ -401,6 +414,7 @@ describe("runSubprocess yield reminders", () => {
 			"errored-assistant-start",
 			"aborted-assistant-start",
 			"user-start",
+			"baseline-replay-update",
 			"control-update",
 			"error-update",
 			"malformed-update",
@@ -513,6 +527,8 @@ describe("runSubprocess yield reminders", () => {
 			emit({ type: "message_start", message: terminal });
 			currentEvent = "terminal-end";
 			emit({ type: "message_end", message: terminal });
+			currentEvent = "cancelled-agent-end";
+			emit({ type: "agent_end", messages: [terminal], stopReason: "cancelled" });
 			currentEvent = "failed-end";
 			emit({ type: "auto_retry_end", success: false, attempt: 1, finalError: "provider failed" });
 			currentEvent = "retry-2";
@@ -545,6 +561,9 @@ describe("runSubprocess yield reminders", () => {
 			modelRegistry,
 		});
 		const secondRetry = progressUpdates.find(update => update.event === "retry-2")?.progress.retryState;
+		const cancelledRetry = progressUpdates.find(update => update.event === "cancelled-agent-end")?.progress
+			.retryState;
+		expect(cancelledRetry).toMatchObject({ attempt: 1, provider: "test" });
 		expect(secondRetry).toMatchObject({ attempt: 2, provider: "test" });
 		expect(secondRetry?.lastProviderProgressAtMs).toBeUndefined();
 		expect(result.exitCode).toBe(0);

--- a/packages/coding-agent/test/task/render-nested-live.test.ts
+++ b/packages/coding-agent/test/task/render-nested-live.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, it } from "bun:test";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { AgentProgress, TaskResultReceipt, TaskToolDetails } from "@gajae-code/coding-agent/task";
 import { taskToolRenderer } from "@gajae-code/coding-agent/task/render";
+import { collectProviderDegradationGroups } from "../../src/task/provider-retry-status";
 
 // Defends the live-rendering contract for the `task` tool: while a Level-1
 // subagent is still mid-flight, any nested `task` activity it has produced
@@ -159,6 +160,70 @@ describe("task renderer: nested live rendering", () => {
 		expect(text).toContain("Delta child running");
 		expect(text).toContain("2.0 Parent>GammaSub");
 		expect(text).toContain("2.1 Parent>DeltaSub");
+	});
+
+	it("keeps completed and running siblings visible in mixed root and nested snapshots", async () => {
+		const completed = makeCompletedSubResult("2-Mixed.0-Done", "Completed sibling remains visible");
+		const running = makeRunningSubProgress("2-Mixed.1-Live", "Running sibling remains visible");
+		const theme = (await getThemeByName("red-claw"))!;
+		const rootComponent = taskToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "Running mixed task" }],
+				details: {
+					projectAgentsDir: null,
+					results: [completed],
+					totalDurationMs: completed.durationMs,
+					progress: [running],
+				},
+			},
+			{ expanded: false, isPartial: true, spinnerFrame: 0 },
+			theme,
+		);
+		const rootText = Bun.stripANSI(rootComponent.render(160).join("\n"));
+		expect(rootText).toContain("Completed sibling remains visible");
+		expect(rootText).toContain("Running sibling remains visible");
+		expect(rootText.indexOf("Completed sibling remains visible")).toBeLessThan(
+			rootText.indexOf("Running sibling remains visible"),
+		);
+
+		const nestedText = await render(
+			makeRunningProgress({
+				id: "2-Mixed",
+				currentTool: "task",
+				inflightTaskDetails: {
+					projectAgentsDir: null,
+					results: [completed],
+					totalDurationMs: completed.durationMs,
+					progress: [running],
+				},
+			}),
+		);
+		expect(nestedText).toContain("Completed sibling remains visible");
+		expect(nestedText).toContain("Running sibling remains visible");
+		expect(nestedText.indexOf("Completed sibling remains visible")).toBeLessThan(
+			nestedText.indexOf("Running sibling remains visible"),
+		);
+	});
+
+	it("ignores malformed progress entries while grouping valid retry siblings", () => {
+		const retrying = (id: string): AgentProgress => ({
+			...makeRunningSubProgress(id, id),
+			retryState: {
+				attempt: 1,
+				maxAttempts: 3,
+				kind: "provider_error",
+				provider: "anthropic",
+				delayMs: 1_000,
+				errorMessage: "provider unavailable",
+				startedAtMs: 0,
+			},
+		});
+		const groups = collectProviderDegradationGroups([
+			null,
+			retrying("2-Guard.0-First"),
+			retrying("2-Guard.1-Second"),
+		] as unknown as AgentProgress[]);
+		expect(groups).toEqual([{ provider: "anthropic", count: 2 }]);
 	});
 
 	it("aggregates nested same-provider retries and refreshes their age without content mutation", async () => {

--- a/packages/coding-agent/test/task/render-nested-live.test.ts
+++ b/packages/coding-agent/test/task/render-nested-live.test.ts
@@ -161,6 +161,62 @@ describe("task renderer: nested live rendering", () => {
 		expect(text).toContain("2.1 Parent>DeltaSub");
 	});
 
+	it("aggregates nested same-provider retries and refreshes their age without content mutation", async () => {
+		const retryingChild = (id: string): AgentProgress => ({
+			...makeRunningSubProgress(id, `${id} retrying`),
+			retryState: {
+				attempt: 2,
+				maxAttempts: 4,
+				kind: "idle_stream_stall",
+				provider: "anthropic",
+				lastProviderProgressAtMs: 0,
+				delayMs: 60_000,
+				errorMessage: "Anthropic stream stalled while waiting for the next event",
+				startedAtMs: 0,
+			},
+		});
+		const parent = makeRunningProgress({
+			id: "2-NestedRetryParent",
+			currentTool: "task",
+			inflightTaskDetails: {
+				projectAgentsDir: null,
+				results: [],
+				totalDurationMs: 0,
+				progress: [retryingChild("2-NestedRetryParent.0-Alpha"), retryingChild("2-NestedRetryParent.1-Beta")],
+			},
+		});
+		const theme = (await getThemeByName("red-claw"))!;
+		const component = taskToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "Running 1 agents..." }],
+				details: {
+					projectAgentsDir: null,
+					results: [],
+					totalDurationMs: 0,
+					progress: [parent],
+				} satisfies TaskToolDetails,
+			},
+			{ expanded: false, isPartial: true, spinnerFrame: 0 },
+			theme,
+		);
+		const originalNow = Date.now;
+		try {
+			Date.now = () => 20_000;
+			const first = Bun.stripANSI(component.render(160).join("\n"));
+			Date.now = () => 35_000;
+			const second = Bun.stripANSI(component.render(160).join("\n"));
+
+			const notice = "provider degraded: 2 subagents retrying on anthropic";
+			expect(first).toContain(notice);
+			expect(first.split(notice).length - 1).toBe(1);
+			expect(first).toContain("last provider progress 20s ago");
+			expect(second).toContain("last provider progress 35s ago");
+			expect(second).not.toEqual(first);
+		} finally {
+			Date.now = originalNow;
+		}
+	});
+
 	it("renders requested model substitution in live progress", async () => {
 		const text = await render(
 			makeRunningProgress({
@@ -220,5 +276,62 @@ describe("task renderer: nested live rendering", () => {
 		const zetaIdx = text.indexOf("Zeta running");
 		// Completed entries are emitted before the in-flight snapshot.
 		expect(epsilonIdx).toBeLessThan(zetaIdx);
+	});
+	it("aggregates direct retry siblings once per owning list without hiding healthy or separate nested work", async () => {
+		const retry = (id: string): AgentProgress => ({
+			...makeRunningSubProgress(id, `${id}\tretrying`),
+			retryState: {
+				attempt: 1,
+				maxAttempts: 3,
+				kind: "idle_stream_stall",
+				provider: "anthropic",
+				lastProviderProgressAtMs: 0,
+				delayMs: 60_000,
+				errorMessage: `stream\tstalled ${"x".repeat(120)}`,
+				startedAtMs: 0,
+			},
+		});
+		const healthy = makeRunningSubProgress("5-Parent.2-Healthy", "Healthy child remains visible");
+		const parent = makeRunningProgress({
+			id: "5-Parent",
+			currentTool: "task",
+			inflightTaskDetails: {
+				projectAgentsDir: null,
+				results: [],
+				totalDurationMs: 0,
+				progress: [retry("5-Parent.0-First"), retry("5-Parent.1-Second"), healthy],
+			},
+			extractedToolData: {
+				task: [
+					{ projectAgentsDir: null, results: [], totalDurationMs: 0, progress: [retry("5-Elsewhere.0-Only")] },
+				],
+			},
+		});
+		const theme = (await getThemeByName("red-claw"))!;
+		const component = taskToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "Running" }],
+				details: { projectAgentsDir: null, results: [], totalDurationMs: 0, progress: [parent] },
+			},
+			{ expanded: true, isPartial: true, spinnerFrame: 0 },
+			theme,
+		);
+		const originalNow = Date.now;
+		try {
+			Date.now = () => 20_000;
+			const first = Bun.stripANSI(component.render(160).join("\n"));
+			Date.now = () => 35_000;
+			const second = Bun.stripANSI(component.render(160).join("\n"));
+			const notice = "provider degraded: 2 subagents retrying on anthropic";
+			expect(first.split(notice).length - 1).toBe(1);
+			expect(first).toContain("Healthy child remains visible");
+			expect(first.indexOf("5.0 Parent>First")).toBeLessThan(first.indexOf("Healthy child remains visible"));
+			expect(first).toContain("last provider progress 20s ago");
+			expect(second).toContain("last provider progress 35s ago");
+			expect(first).not.toContain("\t");
+			expect(component.render(40).every(line => Bun.stringWidth(Bun.stripANSI(line)) <= 40)).toBe(true);
+		} finally {
+			Date.now = originalNow;
+		}
 	});
 });

--- a/packages/coding-agent/test/tools/subagent-live-progress.test.ts
+++ b/packages/coding-agent/test/tools/subagent-live-progress.test.ts
@@ -355,7 +355,14 @@ describe("subagentAwaitRenderedStateSignature", () => {
 				durationMs: 1_000,
 				currentTool: "read",
 				currentToolStartMs: 1_000,
-				retryState: { attempt: 1, maxAttempts: 3, delayMs: 5_000, errorMessage: "429", startedAtMs: 1_000 },
+				retryState: {
+					attempt: 1,
+					maxAttempts: 3,
+					kind: "provider_error",
+					delayMs: 5_000,
+					errorMessage: "429",
+					startedAtMs: 1_000,
+				},
 			}),
 		});
 		const later = makeSnapshot({
@@ -366,7 +373,14 @@ describe("subagentAwaitRenderedStateSignature", () => {
 				durationMs: 999_999,
 				currentTool: "read",
 				currentToolStartMs: 2_000,
-				retryState: { attempt: 1, maxAttempts: 3, delayMs: 5_000, errorMessage: "429", startedAtMs: 2_000 },
+				retryState: {
+					attempt: 1,
+					maxAttempts: 3,
+					kind: "provider_error",
+					delayMs: 5_000,
+					errorMessage: "429",
+					startedAtMs: 2_000,
+				},
 			}),
 		});
 		expect(subagentAwaitRenderedStateSignature([later])).toBe(subagentAwaitRenderedStateSignature([early]));
@@ -420,7 +434,14 @@ describe("subagentAwaitRenderedStateSignature", () => {
 				...s,
 				progress: {
 					...baseProgress,
-					retryState: { attempt: 1, maxAttempts: 3, delayMs: 1_000, errorMessage: "429", startedAtMs: 0 },
+					retryState: {
+						attempt: 1,
+						maxAttempts: 3,
+						kind: "provider_error",
+						delayMs: 1_000,
+						errorMessage: "429",
+						startedAtMs: 0,
+					},
 				},
 			}),
 			s => ({ ...s, progress: { ...baseProgress, retryFailure: { attempt: 3, errorMessage: "gave up" } } }),

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -204,6 +204,66 @@ describe("subagentToolRenderer", () => {
 		expect(out).toContain("bash");
 	});
 
+	it("distinguishes first-event timeout recovery from normal running", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-FirstEvent",
+					liveProgressAvailable: true,
+					progress: progress({
+						id: "0-FirstEvent",
+						retryState: {
+							attempt: 2,
+							maxAttempts: 4,
+							kind: "first_event_timeout",
+							provider: "openai-responses",
+							delayMs: 5_000,
+							errorMessage: "OpenAI responses stream timed out while waiting for the first event",
+							startedAtMs: Date.now(),
+						},
+					}),
+				}),
+			],
+		});
+
+		expect(out).toContain("provider degraded");
+		expect(out).toContain("first event timeout");
+		expect(out).toContain("no provider events yet");
+		expect(out).toContain("retrying attempt 2 of 4, bounded");
+	});
+
+	it("shows idle-stream progress age and aggregates same-provider degradation", () => {
+		const lastProviderProgressAtMs = Date.now() - 12_000;
+		const retryState = {
+			attempt: 1,
+			maxAttempts: 3,
+			kind: "idle_stream_stall" as const,
+			provider: "anthropic",
+			lastProviderProgressAtMs,
+			delayMs: 10_000,
+			errorMessage: "Anthropic stream stalled while waiting for the next event",
+			startedAtMs: Date.now(),
+		};
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-StalledA",
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-StalledA", retryState }),
+				}),
+				snapshot({
+					id: "0-StalledB",
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-StalledB", retryState }),
+				}),
+			],
+		});
+
+		expect(out).toContain("provider degraded: 2 subagents retrying on anthropic");
+		expect(out).toContain("stream stalled");
+		expect(out).toMatch(/last provider progress 1[12]s ago/);
+	});
+
 	it("preserves static receipt fields for non-await actions (guidance, output ref, description, agent, assignment, truncation)", () => {
 		const out = render({
 			subagents: [

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -402,6 +402,137 @@ describe("subagent await renderer body cache (PR2)", () => {
 		],
 	});
 
+	const nestedRetry = (
+		provider = "anthropic",
+		errorMessage = "Anthropic stream stalled while waiting for the next event",
+	): SubagentToolDetails => ({
+		subagents: [
+			snapshot({
+				id: "0-Nested",
+				liveProgressAvailable: true,
+				progress: progress({
+					id: "0-Nested",
+					currentTool: "task",
+					inflightTaskDetails: {
+						projectAgentsDir: null,
+						results: [],
+						totalDurationMs: 0,
+						progress: [
+							progress({
+								id: "0-Nested.0-Child",
+								retryState: {
+									attempt: 2,
+									maxAttempts: 4,
+									kind: "idle_stream_stall",
+									provider,
+									lastProviderProgressAtMs: 0,
+									delayMs: 60_000,
+									errorMessage,
+									startedAtMs: 0,
+								},
+							}),
+							progress({
+								id: "0-Nested.1-Child",
+								retryState: {
+									attempt: 2,
+									maxAttempts: 4,
+									kind: "idle_stream_stall",
+									provider,
+									lastProviderProgressAtMs: 0,
+									delayMs: 60_000,
+									errorMessage,
+									startedAtMs: 0,
+								},
+							}),
+						],
+					},
+				}),
+			}),
+		],
+	});
+
+	it("refreshes nested retry age and countdown on await-body updates", () => {
+		const details = nestedRetry();
+		const originalNow = Date.now;
+		try {
+			Date.now = () => 20_000;
+			const first = renderWith(details).join("\n");
+			Date.now = () => 35_000;
+			const second = renderWith(details).join("\n");
+
+			expect(first).toContain("provider degraded: 2 subagents retrying on anthropic");
+			expect(first).toContain("last provider progress 20s ago");
+			expect(first).toContain("in 40.0s");
+			expect(second).toContain("last provider progress 35s ago");
+			expect(second).toContain("in 25.0s");
+			expect(second).not.toEqual(first);
+		} finally {
+			Date.now = originalNow;
+		}
+	});
+
+	it("bounds dynamic nested retry lines and sanitizes tabs at narrow widths", () => {
+		const lines = renderWith(nestedRetry("anthropic\tproduction", `provider\terror ${"x".repeat(160)}`), {
+			width: 40,
+		});
+		expect(lines.every(line => Bun.stringWidth(Bun.stripANSI(line)) <= 40)).toBe(true);
+		expect(lines.join("\n")).not.toContain("\t");
+	});
+
+	it("keeps nested retry groups isolated by snapshot and bypasses only their dynamic cache entries", () => {
+		const firstNested = nestedRetry();
+		const secondNested = nestedRetry();
+		secondNested.subagents[0] = snapshot({
+			id: "0-OtherNested",
+			liveProgressAvailable: true,
+			progress: progress({
+				id: "0-OtherNested",
+				currentTool: "task",
+				inflightTaskDetails: firstNested.subagents[0]?.progress?.inflightTaskDetails,
+			}),
+		});
+		const combined: SubagentToolDetails = { subagents: [...firstNested.subagents, ...secondNested.subagents] };
+		const healthy = live("0-Healthy");
+		const originalNow = Date.now;
+		try {
+			Date.now = () => 20_000;
+			renderWith(healthy);
+			expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+			expect(subagentBodyCacheTestHooks.size).toBe(1);
+			const first = renderWith(combined).join("\n");
+			Date.now = () => 35_000;
+			const second = renderWith(combined).join("\n");
+			const notice = "provider degraded: 2 subagents retrying on anthropic";
+			expect(first.split(notice).length - 1).toBe(2);
+			expect(second).toContain("last provider progress 35s ago");
+			expect(subagentBodyCacheTestHooks.bodyRenders).toBe(5);
+			expect(subagentBodyCacheTestHooks.size).toBe(1);
+			renderWith(healthy);
+			expect(subagentBodyCacheTestHooks.bodyRenders).toBe(5);
+			expect(subagentBodyCacheTestHooks.size).toBe(1);
+		} finally {
+			Date.now = originalNow;
+		}
+	});
+
+	it("does not aggregate matching retrying siblings from separate await requests", () => {
+		const retryState = {
+			attempt: 1,
+			maxAttempts: 3,
+			kind: "provider_error" as const,
+			provider: "anthropic",
+			delayMs: 10_000,
+			errorMessage: "provider unavailable",
+			startedAtMs: 0,
+		};
+		const request = (id: string): SubagentToolDetails => ({
+			subagents: [snapshot({ id, liveProgressAvailable: true, progress: progress({ id, retryState }) })],
+		});
+		const notice = "provider degraded: 2 subagents retrying on anthropic";
+		expect(renderWith(request("0-RequestA")).join("\n")).not.toContain(notice);
+		expect(renderWith(request("0-RequestB")).join("\n")).not.toContain(notice);
+	});
+
 	it("reuses the cached heavy body across component recreation for identical content", () => {
 		renderWith(live("0-A"));
 		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);


### PR DESCRIPTION
## Summary
- distinguish provider recovery from normal subagent running state
- label first-event timeouts separately from idle-stream stalls
- show bounded/unbounded retry semantics and last provider progress age
- aggregate concurrent stalled subagents by provider

## Verification
- `bun test packages/coding-agent/test/tools/subagent-render.test.ts packages/coding-agent/test/tools/subagent-live-progress.test.ts` (39 pass)
- `bun --cwd=packages/coding-agent run check`
- root `bun run check:ts` progressed through formatting, declaration, baseline, schema, and SDK checks before the 600s observation timeout

Closes #3071

— GJC coding agent