### PR TITLE
fix(tui): collapse and redact bash invocations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Interactive prompt cancellation now reaches API-key preflight through `ModelRegistry`, allowing aborted submissions to clear immediately even while a shared credential-usage request continues in the background.
 - Alibaba Token Plan canonical first-event timeouts now surface without session retry/fallback replay and are not internally retried by auto-compaction, preventing repeated provider usage (#3026).
 - Delegated-task and subagent status surfaces now distinguish provider recovery from normal running, identify first-event versus idle-stream stalls, show retry budget and provider-progress age, and aggregate concurrent degradation by provider (#3071).
+- Bash invocation rendering now collapses multiline and oversized payloads by default while preserving expandable safe detail, and redacts credential keys and token-shaped values across streaming, success, error, and expanded views (#3072).
 
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
 - Windows managed-session resume no longer reports `durability_failed` when Bun rejects `fsync` on the read-only descriptor used to revalidate an existing canonical binding; Windows now uses an owner-writable descriptor for that durability fence while retaining no-follow and pre/post identity/content checks.

--- a/packages/coding-agent/src/modes/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/components/bash-execution.ts
@@ -16,7 +16,9 @@ import {
 } from "@gajae-code/tui";
 import { sanitizeText } from "@gajae-code/utils";
 import { theme } from "../../modes/theme/theme";
+import { formatInvocationCommand } from "../../tools/invocation-display";
 import type { TruncationMeta } from "../../tools/output-meta";
+import { replaceTabs } from "../../tools/render-utils";
 import {
 	containsSixelSequence,
 	getSixelLineMask,
@@ -51,6 +53,8 @@ export class BashExecutionComponent extends Container {
 	#chunkGate = false;
 	#contentContainer: Container;
 	#headerText: Text;
+	#colorKey: "dim" | "bashMode";
+	#shellLabel: string;
 
 	constructor(
 		private readonly command: string,
@@ -60,21 +64,14 @@ export class BashExecutionComponent extends Container {
 		super();
 
 		// Use dim border for excluded-from-context commands (!! prefix)
-		const colorKey = excludeFromContext ? "dim" : "bashMode";
-		const { contentContainer, loader } = buildExecutionFrame(this, ui, colorKey);
+		this.#colorKey = excludeFromContext ? "dim" : "bashMode";
+		this.#shellLabel = excludeFromContext ? "shell · no context" : "shell";
+		const { contentContainer, loader } = buildExecutionFrame(this, ui, this.#colorKey);
 		this.#contentContainer = contentContainer;
 		this.#loader = loader;
 
 		// Command header: terse shell rail, no extra render work on streaming chunks.
-		const shellLabel = excludeFromContext ? "shell · no context" : "shell";
-		this.#headerText = new Text(
-			`${theme.fg(colorKey, theme.bold(shellLabel))} ${theme.fg("dim", "·")} ${theme.fg(
-				colorKey,
-				theme.bold(`$ ${command}`),
-			)}`,
-			1,
-			0,
-		);
+		this.#headerText = new Text(this.#formatHeader(), 1, 0);
 		this.#contentContainer.addChild(this.#headerText);
 		this.#contentContainer.addChild(this.#loader);
 	}
@@ -84,6 +81,7 @@ export class BashExecutionComponent extends Container {
 	 */
 	setExpanded(expanded: boolean): void {
 		this.#expanded = expanded;
+		this.#headerText.setText(this.#formatHeader());
 		this.#updateDisplay();
 	}
 
@@ -221,6 +219,14 @@ export class BashExecutionComponent extends Container {
 			if (footer) this.#contentContainer.addChild(footer);
 		}
 		this.#displayBuiltWithGraphicsFallback = fallbackActive;
+	}
+
+	#formatHeader(): string {
+		const command = replaceTabs(sanitizeText(formatInvocationCommand(this.command, this.#expanded)));
+		return `${theme.fg(this.#colorKey, theme.bold(this.#shellLabel))} ${theme.fg("dim", "·")} ${theme.fg(
+			this.#colorKey,
+			theme.bold(`$ ${command}`),
+		)}`;
 	}
 
 	#clampDisplayLine(line: string): string {

--- a/packages/coding-agent/src/tools/bash-interactive.ts
+++ b/packages/coding-agent/src/tools/bash-interactive.ts
@@ -17,6 +17,7 @@ import { NON_INTERACTIVE_ENV } from "../exec/non-interactive-env";
 import type { Theme } from "../modes/theme/theme";
 import { OutputSink, type OutputSummary } from "../session/streaming-output";
 import { sanitizeWithOptionalSixelPassthrough } from "../utils/sixel";
+import { formatInvocationCommand } from "./invocation-display";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "./output-meta";
 import { formatStatusIcon, replaceTabs } from "./render-utils";
 
@@ -91,7 +92,7 @@ function normalizeInputForPty(data: string, applicationCursorKeysMode: boolean):
 	}
 	return data;
 }
-class BashInteractiveOverlayComponent implements Component {
+export class BashInteractiveOverlayComponent implements Component {
 	#terminal: XtermTerminalType;
 	#state: "running" | "complete" | "timed_out" | "killed" = "running";
 	#exitCode: number | undefined;
@@ -251,7 +252,8 @@ class BashInteractiveOverlayComponent implements Component {
 		const prefix = `${statusIcon} ${title} `;
 		const suffix = ` ${statusBadge}`;
 		const available = Math.max(1, innerWidth - visibleWidth(prefix) - visibleWidth(suffix));
-		const cmd = truncateToWidth(this.uiTheme.fg("muted", replaceTabs(this.command)), available);
+		const displayedCommand = replaceTabs(sanitizeText(formatInvocationCommand(this.command, false)));
+		const cmd = truncateToWidth(this.uiTheme.fg("muted", displayedCommand), available);
 		const header = truncateToWidth(`${prefix}${cmd}${suffix}`, innerWidth);
 		const footer =
 			this.#state === "running"

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
 import type { Component } from "@gajae-code/tui";
 import { ImageProtocol, TERMINAL, Text } from "@gajae-code/tui";
-import { getProjectDir, isEnoent, logger, prompt } from "@gajae-code/utils";
+import { getProjectDir, isEnoent, logger, prompt, sanitizeText } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { AsyncJobManager } from "../async";
 import { type BashResult, executeBash } from "../exec/bash-executor";
@@ -1194,14 +1194,17 @@ export function getBashEnvForDisplay(args: BashRenderArgs): Record<string, strin
 }
 
 export function formatBashCommand(args: BashRenderArgs, expanded = false): string {
-	const command = replaceTabs(formatInvocationCommand(args.command || "…", expanded));
+	const command = formatInvocationCommand(args.command || "…", expanded);
 	const prompt = "$";
 	const cwd = getProjectDir();
 	const displayWorkdir = formatToolWorkingDirectory(args.cwd, cwd);
 	const renderedCommand = [formatBashEnvAssignments(getBashEnvForDisplay(args), expanded), command]
 		.filter(Boolean)
 		.join(" ");
-	return displayWorkdir ? `${prompt} cd ${displayWorkdir} && ${renderedCommand}` : `${prompt} ${renderedCommand}`;
+	const invocation = displayWorkdir
+		? `${prompt} cd ${displayWorkdir} && ${renderedCommand}`
+		: `${prompt} ${renderedCommand}`;
+	return replaceTabs(sanitizeText(invocation));
 }
 
 /**
@@ -1212,14 +1215,15 @@ export function formatBashCommand(args: BashRenderArgs, expanded = false): strin
  * `theme.fg("dim", ...)` form render only the first line as dim.
  */
 export function formatBashCommandLines(args: BashRenderArgs, uiTheme: Theme, expanded = false): string[] {
-	const command = replaceTabs(formatInvocationCommand(args.command || "…", expanded));
+	const command = replaceTabs(sanitizeText(formatInvocationCommand(args.command || "…", expanded)));
 	const cwd = getProjectDir();
 	const displayWorkdir = formatToolWorkingDirectory(args.cwd, cwd);
 	const envAssignments = formatBashEnvAssignments(getBashEnvForDisplay(args), expanded);
 	const prefixParts = ["$"];
 	if (displayWorkdir) prefixParts.push(`cd ${displayWorkdir} &&`);
 	if (envAssignments) prefixParts.push(envAssignments);
-	const prefix = uiTheme.fg("dim", `${prefixParts.join(" ")} `);
+	const prefixText = replaceTabs(sanitizeText(`${prefixParts.join(" ")} `));
+	const prefix = uiTheme.fg("dim", prefixText);
 	const highlightedLines = highlightCode(command, "bash");
 	if (highlightedLines.length === 0) return [prefix.trimEnd()];
 	return highlightedLines.map((line, i) => (i === 0 ? `${prefix}${line}` : line));

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -29,6 +29,7 @@ import { checkBashInterception } from "./bash-interceptor";
 import { canUseInteractiveBashPty } from "./bash-pty-selection";
 import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-skill-urls";
 import { checkComposerBashPolicy } from "./composer-bash-policy";
+import { formatInvocationCommand, formatInvocationEnvironment } from "./invocation-display";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
 import { formatToolWorkingDirectory, replaceTabs } from "./render-utils";
@@ -176,23 +177,8 @@ function normalizeBashEnv(env: Record<string, string> | undefined): Record<strin
 	return normalized;
 }
 
-function escapeBashEnvValueForDisplay(value: string): string {
-	return value
-		.replaceAll("\\", "\\\\")
-		.replaceAll("\n", "\\n")
-		.replaceAll("\r", "\\r")
-		.replaceAll("\t", "\\t")
-		.replaceAll('"', '\\"')
-		.replaceAll("$", "\\$")
-		.replaceAll("`", "\\`");
-}
-
-function formatBashEnvAssignments(env: Record<string, string> | undefined): string {
-	if (!env || Object.keys(env).length === 0) return "";
-	return Object.entries(env)
-		.sort(([a], [b]) => a.localeCompare(b))
-		.map(([key, value]) => `${key}="${escapeBashEnvValueForDisplay(value)}"`)
-		.join(" ");
+function formatBashEnvAssignments(env: Record<string, string> | undefined, expanded: boolean): string {
+	return formatInvocationEnvironment(env, expanded);
 }
 
 function unescapePartialJsonString(value: string): string {
@@ -1207,12 +1193,14 @@ export function getBashEnvForDisplay(args: BashRenderArgs): Record<string, strin
 	return args.env ?? partialEnv;
 }
 
-export function formatBashCommand(args: BashRenderArgs): string {
-	const command = replaceTabs(args.command || "…");
+export function formatBashCommand(args: BashRenderArgs, expanded = false): string {
+	const command = replaceTabs(formatInvocationCommand(args.command || "…", expanded));
 	const prompt = "$";
 	const cwd = getProjectDir();
 	const displayWorkdir = formatToolWorkingDirectory(args.cwd, cwd);
-	const renderedCommand = [formatBashEnvAssignments(getBashEnvForDisplay(args)), command].filter(Boolean).join(" ");
+	const renderedCommand = [formatBashEnvAssignments(getBashEnvForDisplay(args), expanded), command]
+		.filter(Boolean)
+		.join(" ");
 	return displayWorkdir ? `${prompt} cd ${displayWorkdir} && ${renderedCommand}` : `${prompt} ${renderedCommand}`;
 }
 
@@ -1223,11 +1211,11 @@ export function formatBashCommand(args: BashRenderArgs): string {
  * reset SGR state at line boundaries, which made the previous single-string
  * `theme.fg("dim", ...)` form render only the first line as dim.
  */
-export function formatBashCommandLines(args: BashRenderArgs, uiTheme: Theme): string[] {
-	const command = replaceTabs(args.command || "…");
+export function formatBashCommandLines(args: BashRenderArgs, uiTheme: Theme, expanded = false): string[] {
+	const command = replaceTabs(formatInvocationCommand(args.command || "…", expanded));
 	const cwd = getProjectDir();
 	const displayWorkdir = formatToolWorkingDirectory(args.cwd, cwd);
-	const envAssignments = formatBashEnvAssignments(getBashEnvForDisplay(args));
+	const envAssignments = formatBashEnvAssignments(getBashEnvForDisplay(args), expanded);
 	const prefixParts = ["$"];
 	if (displayWorkdir) prefixParts.push(`cd ${displayWorkdir} &&`);
 	if (envAssignments) prefixParts.push(envAssignments);
@@ -1250,7 +1238,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 	return {
 		renderCall(args: TArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 			const renderArgs = toBashRenderArgs(args, config);
-			const cmdText = formatBashCommand(renderArgs);
+			const cmdText = formatBashCommand(renderArgs, options.expanded);
 			const title = config.resolveTitle(args, options);
 			const text = renderStatusLine({ icon: "pending", title, description: cmdText }, uiTheme);
 			return new Text(text, 0, 0);
@@ -1267,7 +1255,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 			args?: TArgs,
 		): Component {
 			const renderArgs = toBashRenderArgs(args, config);
-			const cmdLines = args ? formatBashCommandLines(renderArgs, uiTheme) : undefined;
+
 			const isError = result.isError === true;
 			const icon = options.isPartial ? "pending" : isError ? "error" : "success";
 			const title = config.resolveTitle(args, options);
@@ -1281,6 +1269,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 					const { renderContext } = options;
 					const expanded = renderContext?.expanded ?? options.expanded;
 					const previewLines = renderContext?.previewLines ?? BASH_DEFAULT_PREVIEW_LINES;
+					const cmdLines = args ? formatBashCommandLines(renderArgs, uiTheme, expanded) : undefined;
 
 					// Get output from context (preferred) or fall back to result content.
 					// Strip the LLM-facing notice appended by wrappedExecute so we don't

--- a/packages/coding-agent/src/tools/invocation-display.ts
+++ b/packages/coding-agent/src/tools/invocation-display.ts
@@ -10,6 +10,20 @@ const TOKEN_VALUE_PATTERN =
 	/\b(?:github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9]+|sk-[A-Za-z0-9_-]{16,}|sk_(?:live|test)_[A-Za-z0-9]{16,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|AIza[A-Za-z0-9_-]{20,}|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,})\b/g;
 const URL_CREDENTIAL_PATTERN = /\b([A-Za-z][A-Za-z0-9+.-]*:\/\/)([^\s/?#@]+)(@)/g;
 const LONG_VALUE_CHARS = TRUNCATE_LENGTHS.LINE;
+const ANSI_C_SIMPLE_ESCAPES: Readonly<Record<string, string>> = {
+	a: "\x07",
+	b: "\b",
+	e: "\x1b",
+	E: "\x1b",
+	f: "\f",
+	n: "\n",
+	r: "\r",
+	t: "\t",
+	v: "\v",
+	"\\": "\\",
+	"'": "'",
+	'"': '"',
+};
 
 function formatByteSize(value: string): string {
 	const bytes = new TextEncoder().encode(value).byteLength;
@@ -82,6 +96,8 @@ interface ShellWordWrapper {
 	suffix: string;
 }
 
+type ShellQuote = "single" | "double" | "ansi-c" | "backtick";
+
 function findShellWordSpans(command: string): ShellWordSpan[] {
 	const spans: ShellWordSpan[] = [];
 	let index = 0;
@@ -89,7 +105,7 @@ function findShellWordSpans(command: string): ShellWordSpan[] {
 		while (index < command.length && /[\s;&|()<>]/.test(command[index] ?? "")) index += 1;
 		if (index >= command.length) break;
 		const start = index;
-		let quote: "single" | "double" | "ansi-c" | undefined;
+		let quote: ShellQuote | undefined;
 		let substitutionDepth = 0;
 		while (index < command.length) {
 			const character = command[index] ?? "";
@@ -109,6 +125,15 @@ function findShellWordSpans(command: string): ShellWordSpan[] {
 				}
 				continue;
 			}
+			if (quote === "backtick") {
+				if (character === "\\") {
+					index = Math.min(index + 2, command.length);
+					continue;
+				}
+				index += 1;
+				if (character === "`") quote = undefined;
+				continue;
+			}
 			if (character === "\\") {
 				index = Math.min(index + 2, command.length);
 				continue;
@@ -120,6 +145,11 @@ function findShellWordSpans(command: string): ShellWordSpan[] {
 			}
 			if (character === "'") {
 				quote = index > start && command[index - 1] === "$" ? "ansi-c" : "single";
+				index += 1;
+				continue;
+			}
+			if (character === "`") {
+				quote = "backtick";
 				index += 1;
 				continue;
 			}
@@ -142,10 +172,51 @@ function findShellWordSpans(command: string): ShellWordSpan[] {
 	return spans;
 }
 
+function readAnsiDigits(value: string, start: number, maxLength: number, pattern: RegExp): string {
+	let end = start;
+	while (end < value.length && end - start < maxLength && pattern.test(value[end] ?? "")) end += 1;
+	return value.slice(start, end);
+}
+
+function ansiCodePoint(digits: string, radix: number, fallback: string): string {
+	if (!digits) return fallback;
+	const codePoint = Number.parseInt(digits, radix);
+	return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : fallback;
+}
+
+function decodeAnsiCEscape(value: string, index: number): { decoded: string; nextIndex: number } {
+	const escaped = value[index];
+	if (escaped === undefined) return { decoded: "\\", nextIndex: index };
+	const simple = ANSI_C_SIMPLE_ESCAPES[escaped];
+	if (simple !== undefined) return { decoded: simple, nextIndex: index + 1 };
+	if (escaped === "c") {
+		const control = value[index + 1];
+		if (control === undefined) return { decoded: "c", nextIndex: index + 1 };
+		return {
+			decoded: control === "?" ? "\x7f" : String.fromCharCode(control.toUpperCase().charCodeAt(0) & 0x1f),
+			nextIndex: index + 2,
+		};
+	}
+	if (escaped === "x") {
+		const digits = readAnsiDigits(value, index + 1, 2, /[0-9a-f]/i);
+		return { decoded: ansiCodePoint(digits, 16, "x"), nextIndex: index + 1 + digits.length };
+	}
+	if (escaped === "u" || escaped === "U") {
+		const digits = readAnsiDigits(value, index + 1, escaped === "u" ? 4 : 8, /[0-9a-f]/i);
+		return { decoded: ansiCodePoint(digits, 16, escaped), nextIndex: index + 1 + digits.length };
+	}
+	if (/[0-7]/.test(escaped)) {
+		const maxLength = escaped === "0" ? 4 : 3;
+		const digits = readAnsiDigits(value, index, maxLength, /[0-7]/);
+		return { decoded: ansiCodePoint(digits, 8, escaped), nextIndex: index + digits.length };
+	}
+	return { decoded: escaped, nextIndex: index + 1 };
+}
+
 function cookShellWord(value: string): string {
 	let output = "";
 	let index = 0;
-	let quote: "single" | "double" | "ansi-c" | undefined;
+	let quote: ShellQuote | undefined;
 	while (index < value.length) {
 		const character = value[index] ?? "";
 		if (quote === "single") {
@@ -154,14 +225,26 @@ function cookShellWord(value: string): string {
 			else output += character;
 			continue;
 		}
-		if (quote === "double" || quote === "ansi-c") {
+		if (quote === "ansi-c") {
+			if (character === "\\") {
+				const decodedEscape = decodeAnsiCEscape(value, index + 1);
+				output += decodedEscape.decoded;
+				index = decodedEscape.nextIndex;
+				continue;
+			}
+			index += 1;
+			if (character === "'") quote = undefined;
+			else output += character;
+			continue;
+		}
+		if (quote === "double" || quote === "backtick") {
 			if (character === "\\" && index + 1 < value.length) {
 				output += value[index + 1] ?? "";
 				index += 2;
 				continue;
 			}
 			index += 1;
-			if ((quote === "double" && character === '"') || (quote === "ansi-c" && character === "'")) {
+			if ((quote === "double" && character === '"') || (quote === "backtick" && character === "`")) {
 				quote = undefined;
 			} else {
 				output += character;
@@ -188,6 +271,11 @@ function cookShellWord(value: string): string {
 			index += 1;
 			continue;
 		}
+		if (character === "`") {
+			quote = "backtick";
+			index += 1;
+			continue;
+		}
 		output += character;
 		index += 1;
 	}
@@ -196,7 +284,7 @@ function cookShellWord(value: string): string {
 
 function findShellWordEquals(value: string): number {
 	let index = 0;
-	let quote: "single" | "double" | "ansi-c" | undefined;
+	let quote: ShellQuote | undefined;
 	let substitutionDepth = 0;
 	while (index < value.length) {
 		const character = value[index] ?? "";
@@ -216,6 +304,15 @@ function findShellWordEquals(value: string): number {
 			}
 			continue;
 		}
+		if (quote === "backtick") {
+			if (character === "\\") {
+				index = Math.min(index + 2, value.length);
+				continue;
+			}
+			index += 1;
+			if (character === "`") quote = undefined;
+			continue;
+		}
 		if (character === "\\") {
 			index = Math.min(index + 2, value.length);
 			continue;
@@ -227,6 +324,11 @@ function findShellWordEquals(value: string): number {
 		}
 		if (character === "'") {
 			quote = index > 0 && value[index - 1] === "$" ? "ansi-c" : "single";
+			index += 1;
+			continue;
+		}
+		if (character === "`") {
+			quote = "backtick";
 			index += 1;
 			continue;
 		}
@@ -277,26 +379,27 @@ function redactShellWords(command: string, expanded: boolean): string {
 		const logicalEquals = cookedWord.indexOf("=");
 		const rawName = rawEquals < 0 ? span.value : span.value.slice(0, rawEquals);
 		const logicalName = logicalEquals < 0 ? cookedWord : cookedWord.slice(0, logicalEquals);
-		if (rawEquals >= 0 && /^[A-Za-z_][A-Za-z0-9_]*$/.test(logicalName)) {
+		const classifiedName = logicalName.replace(/[\u0000-\u001f\u007f-\u009f]/g, "");
+		if (rawEquals >= 0 && /^[A-Za-z_][A-Za-z0-9_]*$/.test(classifiedName)) {
 			const rawValue = span.value.slice(rawEquals + 1);
 			const wrapper = splitShellWordWrapper(rawValue);
-			const displayed = displayValue(wrapper.value, expanded, isSensitiveInvocationName(logicalName));
+			const displayed = displayValue(wrapper.value, expanded, isSensitiveInvocationName(classifiedName));
 			replacements.set(index, `${rawName}=${wrapper.prefix}${displayed}${wrapper.suffix}`);
 			continue;
 		}
-		if (rawEquals < 0 && logicalEquals >= 0 && isSensitiveInvocationName(logicalName)) {
-			replacements.set(index, replaceShellWordValue(span.value, `${logicalName}=${REDACTED_INVOCATION_VALUE}`));
+		if (rawEquals < 0 && logicalEquals >= 0 && isSensitiveInvocationName(classifiedName)) {
+			replacements.set(index, replaceShellWordValue(span.value, `${classifiedName}=${REDACTED_INVOCATION_VALUE}`));
 			continue;
 		}
 
-		if (!isSensitiveFlagName(logicalName)) continue;
+		if (!isSensitiveFlagName(classifiedName)) continue;
 		if (rawEquals >= 0) {
 			const rawValue = span.value.slice(rawEquals + 1);
 			replacements.set(index, `${rawName}=${replaceShellWordValue(rawValue, REDACTED_INVOCATION_VALUE)}`);
 			continue;
 		}
 		if (logicalEquals >= 0) {
-			replacements.set(index, replaceShellWordValue(span.value, `${logicalName}=${REDACTED_INVOCATION_VALUE}`));
+			replacements.set(index, replaceShellWordValue(span.value, `${classifiedName}=${REDACTED_INVOCATION_VALUE}`));
 			continue;
 		}
 

--- a/packages/coding-agent/src/tools/invocation-display.ts
+++ b/packages/coding-agent/src/tools/invocation-display.ts
@@ -1,0 +1,153 @@
+import { PREVIEW_LIMITS, TRUNCATE_LENGTHS } from "./render-utils";
+
+export const REDACTED_INVOCATION_VALUE = "<redacted>";
+
+const SENSITIVE_NAME_PATTERN =
+	/(?:^|_)(?:api_?key|access_?key|token|secret|password|passwd|pwd|credential|authorization|auth|bearer|cookie|session|client_?secret|private_?key)(?:$|_)/i;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const TOKEN_VALUE_PATTERN =
+	/\b(?:github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9]+|sk-[A-Za-z0-9_-]{16,}|sk_(?:live|test)_[A-Za-z0-9]{16,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|AIza[A-Za-z0-9_-]{20,}|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,})\b/g;
+const URL_CREDENTIAL_PATTERN = /(https?:\/\/[^\s:/@]+:)([^\s@]+)(@)/gi;
+const LONG_VALUE_CHARS = TRUNCATE_LENGTHS.LINE;
+
+function formatByteSize(value: string): string {
+	const bytes = new TextEncoder().encode(value).byteLength;
+	if (bytes < 1024) return `${bytes} B`;
+	return `${(bytes / 1024).toFixed(bytes < 10 * 1024 ? 1 : 0)} KB`;
+}
+
+function summarizeValue(value: string, type: "argument" | "multiline"): string {
+	if (type === "multiline") {
+		return `<multiline, ${value.split(/\r?\n/).length} lines, ${formatByteSize(value)}>`;
+	}
+	return `<argument, ${formatByteSize(value)}>`;
+}
+
+export function isSensitiveInvocationName(name: string): boolean {
+	return SENSITIVE_NAME_PATTERN.test(name);
+}
+
+export function redactInvocationValuePatterns(value: string): string {
+	return value
+		.replace(BEARER_PATTERN, "Bearer <redacted>")
+		.replace(TOKEN_VALUE_PATTERN, REDACTED_INVOCATION_VALUE)
+		.replace(URL_CREDENTIAL_PATTERN, `$1${REDACTED_INVOCATION_VALUE}$3`);
+}
+
+function displayValue(value: string, expanded: boolean, sensitive: boolean): string {
+	if (sensitive) return REDACTED_INVOCATION_VALUE;
+	const redacted = redactInvocationValuePatterns(value);
+	if (expanded) return redacted;
+	if (/\r?\n/.test(value)) return summarizeValue(value, "multiline");
+	if (value.length > LONG_VALUE_CHARS) return summarizeValue(value, "argument");
+	return redacted;
+}
+
+function escapeBashDisplayValue(value: string): string {
+	return value
+		.replaceAll("\\", "\\\\")
+		.replaceAll("\n", "\\n")
+		.replaceAll("\r", "\\r")
+		.replaceAll("\t", "\\t")
+		.replaceAll('"', '\\"')
+		.replaceAll("$", "\\$")
+		.replaceAll("`", "\\`");
+}
+
+export function formatInvocationEnvironment(env: Record<string, string> | undefined, expanded: boolean): string {
+	if (!env || Object.keys(env).length === 0) return "";
+	return Object.entries(env)
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([key, value]) => {
+			const displayed = displayValue(value, expanded, isSensitiveInvocationName(key));
+			return `${key}="${escapeBashDisplayValue(displayed)}"`;
+		})
+		.join(" ");
+}
+
+function findClosingQuote(value: string, start: number, quote: string): number {
+	for (let index = start; index < value.length; index += 1) {
+		if (value[index] === "\\") {
+			index += 1;
+			continue;
+		}
+		if (value[index] === quote) return index;
+	}
+	return -1;
+}
+
+function redactEmbeddedAssignments(command: string, expanded: boolean): string {
+	const assignmentPattern = /(^|[\s;])([A-Za-z_][A-Za-z0-9_]*)=(['"])/gm;
+	let cursor = 0;
+	let output = "";
+	for (let match = assignmentPattern.exec(command); match; match = assignmentPattern.exec(command)) {
+		const [token, prefix, key, quote] = match;
+		const valueStart = match.index + token.length;
+		const valueEnd = findClosingQuote(command, valueStart, quote);
+		if (valueEnd < 0) continue;
+		output += command.slice(cursor, match.index);
+		const value = command.slice(valueStart, valueEnd);
+		const displayed = displayValue(value, expanded, isSensitiveInvocationName(key));
+		output += `${prefix}${key}=${quote}${displayed}${quote}`;
+		cursor = valueEnd + 1;
+		assignmentPattern.lastIndex = cursor;
+	}
+	output += command.slice(cursor);
+	return output.replace(
+		/(^|[\s;])([A-Za-z_][A-Za-z0-9_]*)=([^\s;'"]+)/gm,
+		(_match, prefix: string, key: string, value: string) =>
+			`${prefix}${key}=${displayValue(value, expanded, isSensitiveInvocationName(key))}`,
+	);
+}
+
+function redactSensitiveFlags(command: string): string {
+	const flagName =
+		"(--?[A-Za-z0-9_-]*(?:token|secret|password|passwd|pwd|credential|authorization|api[-_]?key)[A-Za-z0-9_-]*)";
+	let redacted = command.replace(
+		new RegExp(`${flagName}=(['"])([\\s\\S]*?)\\2`, "gi"),
+		(_match, flag: string, quote: string) => `${flag}=${quote}${REDACTED_INVOCATION_VALUE}${quote}`,
+	);
+	redacted = redacted.replace(
+		new RegExp(`${flagName}(\\s+)(['"])([\\s\\S]*?)\\3`, "gi"),
+		(_match, flag: string, spacing: string, quote: string) =>
+			`${flag}${spacing}${quote}${REDACTED_INVOCATION_VALUE}${quote}`,
+	);
+	redacted = redacted.replace(
+		new RegExp(`${flagName}=([^\\s'"]+)`, "gi"),
+		(_match, flag: string) => `${flag}=${REDACTED_INVOCATION_VALUE}`,
+	);
+	return redacted.replace(
+		new RegExp(`${flagName}(\\s+)([^\\s'"]+)`, "gi"),
+		(_match, flag: string, spacing: string) => `${flag}${spacing}${REDACTED_INVOCATION_VALUE}`,
+	);
+}
+
+function collapseMultilineCommand(command: string): string {
+	const lines = command.split(/\r?\n/);
+	if (lines.length <= PREVIEW_LIMITS.COLLAPSED_LINES) return command;
+	const prefix = lines.slice(0, PREVIEW_LIMITS.COLLAPSED_LINES).join("\n");
+	return `${prefix}\n<multiline command, ${lines.length} lines, ${formatByteSize(command)}>`;
+}
+
+function collapseLongQuotedArguments(command: string): string {
+	return command.replace(/(['"])([^'"\n]{111,})\1/g, (_match, quote: string, value: string) => {
+		return `${quote}${summarizeValue(value, "argument")}${quote}`;
+	});
+}
+
+function collapseLongUnquotedArguments(command: string): string {
+	return command.replace(
+		/(^|\s)([^\s'"]{111,})(?=\s|$)/g,
+		(_match, prefix: string, value: string) => `${prefix}${summarizeValue(value, "argument")}`,
+	);
+}
+
+export function formatInvocationCommand(command: string, expanded: boolean): string {
+	let displayed = redactEmbeddedAssignments(command, expanded);
+	displayed = redactSensitiveFlags(displayed);
+	displayed = redactInvocationValuePatterns(displayed);
+	if (expanded) return displayed;
+	displayed = collapseLongQuotedArguments(displayed);
+	displayed = collapseLongUnquotedArguments(displayed);
+	return collapseMultilineCommand(displayed);
+}

--- a/packages/coding-agent/src/tools/invocation-display.ts
+++ b/packages/coding-agent/src/tools/invocation-display.ts
@@ -1,3 +1,4 @@
+import { Ellipsis, truncateToWidth, visibleWidth } from "@gajae-code/tui";
 import { PREVIEW_LIMITS, TRUNCATE_LENGTHS } from "./render-utils";
 
 export const REDACTED_INVOCATION_VALUE = "<redacted>";
@@ -7,7 +8,7 @@ const SENSITIVE_NAME_PATTERN =
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 const TOKEN_VALUE_PATTERN =
 	/\b(?:github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9]+|sk-[A-Za-z0-9_-]{16,}|sk_(?:live|test)_[A-Za-z0-9]{16,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|AIza[A-Za-z0-9_-]{20,}|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,})\b/g;
-const URL_CREDENTIAL_PATTERN = /(https?:\/\/[^\s:/@]+:)([^\s@]+)(@)/gi;
+const URL_CREDENTIAL_PATTERN = /\b([A-Za-z][A-Za-z0-9+.-]*:\/\/)([^\s:/?#@]*):([^\s/?#@]*)(@)/g;
 const LONG_VALUE_CHARS = TRUNCATE_LENGTHS.LINE;
 
 function formatByteSize(value: string): string {
@@ -31,7 +32,11 @@ export function redactInvocationValuePatterns(value: string): string {
 	return value
 		.replace(BEARER_PATTERN, "Bearer <redacted>")
 		.replace(TOKEN_VALUE_PATTERN, REDACTED_INVOCATION_VALUE)
-		.replace(URL_CREDENTIAL_PATTERN, `$1${REDACTED_INVOCATION_VALUE}$3`);
+		.replace(
+			URL_CREDENTIAL_PATTERN,
+			(_match, scheme: string, user: string, _password: string, at: string) =>
+				`${scheme}${user}:${REDACTED_INVOCATION_VALUE}${at}`,
+		);
 }
 
 function displayValue(value: string, expanded: boolean, sensitive: boolean): string {
@@ -65,61 +70,123 @@ export function formatInvocationEnvironment(env: Record<string, string> | undefi
 		.join(" ");
 }
 
-function findClosingQuote(value: string, start: number, quote: string): number {
-	for (let index = start; index < value.length; index += 1) {
-		if (value[index] === "\\") {
+interface ShellWordSpan {
+	start: number;
+	end: number;
+	value: string;
+}
+
+interface ShellWordWrapper {
+	prefix: string;
+	value: string;
+	suffix: string;
+}
+
+function findShellWordSpans(command: string): ShellWordSpan[] {
+	const spans: ShellWordSpan[] = [];
+	let index = 0;
+	while (index < command.length) {
+		while (index < command.length && /[\s;&|()<>]/.test(command[index] ?? "")) index += 1;
+		if (index >= command.length) break;
+		const start = index;
+		let quote: "single" | "double" | "ansi-c" | undefined;
+		while (index < command.length) {
+			const character = command[index] ?? "";
+			if (!quote && /[\s;&|()<>]/.test(character)) break;
+			if (quote === "single") {
+				index += 1;
+				if (character === "'") quote = undefined;
+				continue;
+			}
+			if (quote === "double" || quote === "ansi-c") {
+				if (character === "\\") {
+					index = Math.min(index + 2, command.length);
+					continue;
+				}
+				index += 1;
+				if ((quote === "double" && character === '"') || (quote === "ansi-c" && character === "'")) {
+					quote = undefined;
+				}
+				continue;
+			}
+			if (character === "\\") {
+				index = Math.min(index + 2, command.length);
+				continue;
+			}
+			if (character === '"') {
+				quote = "double";
+				index += 1;
+				continue;
+			}
+			if (character === "'") {
+				quote = index > start && command[index - 1] === "$" ? "ansi-c" : "single";
+				index += 1;
+				continue;
+			}
 			index += 1;
+		}
+		spans.push({ start, end: index, value: command.slice(start, index) });
+	}
+	return spans;
+}
+
+function splitShellWordWrapper(value: string): ShellWordWrapper {
+	if (value.startsWith("$'") && value.endsWith("'")) {
+		return { prefix: "$'", value: value.slice(2, -1), suffix: "'" };
+	}
+	const quote = value[0];
+	if ((quote === "'" || quote === '"') && value.endsWith(quote)) {
+		return { prefix: quote, value: value.slice(1, -1), suffix: quote };
+	}
+	return { prefix: "", value, suffix: "" };
+}
+
+function replaceShellWordValue(value: string, displayed: string): string {
+	const wrapper = splitShellWordWrapper(value);
+	return `${wrapper.prefix}${displayed}${wrapper.suffix}`;
+}
+
+function isSensitiveFlagName(name: string): boolean {
+	return /^--?/.test(name) && isSensitiveInvocationName(name.replace(/^--?/, "").replaceAll("-", "_"));
+}
+
+function redactShellWords(command: string, expanded: boolean): string {
+	const spans = findShellWordSpans(command);
+	const replacements = new Map<number, string>();
+	for (const [index, span] of spans.entries()) {
+		if (replacements.has(index)) continue;
+		const assignment = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/s.exec(span.value);
+		if (assignment) {
+			const [, key, rawValue] = assignment;
+			const wrapper = splitShellWordWrapper(rawValue);
+			const displayed = displayValue(wrapper.value, expanded, isSensitiveInvocationName(key));
+			replacements.set(index, `${key}=${wrapper.prefix}${displayed}${wrapper.suffix}`);
 			continue;
 		}
-		if (value[index] === quote) return index;
-	}
-	return -1;
-}
 
-function redactEmbeddedAssignments(command: string, expanded: boolean): string {
-	const assignmentPattern = /(^|[\s;])([A-Za-z_][A-Za-z0-9_]*)=(['"])/gm;
-	let cursor = 0;
+		const equals = span.value.indexOf("=");
+		const flag = equals < 0 ? span.value : span.value.slice(0, equals);
+		if (!isSensitiveFlagName(flag)) continue;
+		if (equals >= 0) {
+			const rawValue = span.value.slice(equals + 1);
+			replacements.set(index, `${flag}=${replaceShellWordValue(rawValue, REDACTED_INVOCATION_VALUE)}`);
+			continue;
+		}
+
+		const next = spans[index + 1];
+		if (next && /^\s+$/.test(command.slice(span.end, next.start))) {
+			replacements.set(index + 1, replaceShellWordValue(next.value, REDACTED_INVOCATION_VALUE));
+		}
+	}
+
 	let output = "";
-	for (let match = assignmentPattern.exec(command); match; match = assignmentPattern.exec(command)) {
-		const [token, prefix, key, quote] = match;
-		const valueStart = match.index + token.length;
-		const valueEnd = findClosingQuote(command, valueStart, quote);
-		if (valueEnd < 0) continue;
-		output += command.slice(cursor, match.index);
-		const value = command.slice(valueStart, valueEnd);
-		const displayed = displayValue(value, expanded, isSensitiveInvocationName(key));
-		output += `${prefix}${key}=${quote}${displayed}${quote}`;
-		cursor = valueEnd + 1;
-		assignmentPattern.lastIndex = cursor;
+	let cursor = 0;
+	for (const [index, span] of spans.entries()) {
+		output += command.slice(cursor, span.start);
+		output += replacements.get(index) ?? span.value;
+		cursor = span.end;
 	}
-	output += command.slice(cursor);
-	return output.replace(
-		/(^|[\s;])([A-Za-z_][A-Za-z0-9_]*)=([^\s;'"]+)/gm,
-		(_match, prefix: string, key: string, value: string) =>
-			`${prefix}${key}=${displayValue(value, expanded, isSensitiveInvocationName(key))}`,
-	);
-}
-
-function redactSensitiveFlags(command: string): string {
-	const flagName =
-		"(--?[A-Za-z0-9_-]*(?:token|secret|password|passwd|pwd|credential|authorization|api[-_]?key)[A-Za-z0-9_-]*)";
-	let redacted = command.replace(
-		new RegExp(`${flagName}=(['"])([\\s\\S]*?)\\2`, "gi"),
-		(_match, flag: string, quote: string) => `${flag}=${quote}${REDACTED_INVOCATION_VALUE}${quote}`,
-	);
-	redacted = redacted.replace(
-		new RegExp(`${flagName}(\\s+)(['"])([\\s\\S]*?)\\3`, "gi"),
-		(_match, flag: string, spacing: string, quote: string) =>
-			`${flag}${spacing}${quote}${REDACTED_INVOCATION_VALUE}${quote}`,
-	);
-	redacted = redacted.replace(
-		new RegExp(`${flagName}=([^\\s'"]+)`, "gi"),
-		(_match, flag: string) => `${flag}=${REDACTED_INVOCATION_VALUE}`,
-	);
-	return redacted.replace(
-		new RegExp(`${flagName}(\\s+)([^\\s'"]+)`, "gi"),
-		(_match, flag: string, spacing: string) => `${flag}${spacing}${REDACTED_INVOCATION_VALUE}`,
-	);
+	return output + command.slice(cursor);
 }
 
 function collapseMultilineCommand(command: string): string {
@@ -142,12 +209,20 @@ function collapseLongUnquotedArguments(command: string): string {
 	);
 }
 
+function boundCollapsedLines(command: string): string {
+	return command
+		.split("\n")
+		.map(line =>
+			visibleWidth(line) > LONG_VALUE_CHARS ? truncateToWidth(line, LONG_VALUE_CHARS, Ellipsis.Unicode) : line,
+		)
+		.join("\n");
+}
+
 export function formatInvocationCommand(command: string, expanded: boolean): string {
-	let displayed = redactEmbeddedAssignments(command, expanded);
-	displayed = redactSensitiveFlags(displayed);
+	let displayed = redactShellWords(command, expanded);
 	displayed = redactInvocationValuePatterns(displayed);
 	if (expanded) return displayed;
 	displayed = collapseLongQuotedArguments(displayed);
 	displayed = collapseLongUnquotedArguments(displayed);
-	return collapseMultilineCommand(displayed);
+	return boundCollapsedLines(collapseMultilineCommand(displayed));
 }

--- a/packages/coding-agent/src/tools/invocation-display.ts
+++ b/packages/coding-agent/src/tools/invocation-display.ts
@@ -8,7 +8,7 @@ const SENSITIVE_NAME_PATTERN =
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 const TOKEN_VALUE_PATTERN =
 	/\b(?:github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9]+|sk-[A-Za-z0-9_-]{16,}|sk_(?:live|test)_[A-Za-z0-9]{16,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|AIza[A-Za-z0-9_-]{20,}|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,})\b/g;
-const URL_CREDENTIAL_PATTERN = /\b([A-Za-z][A-Za-z0-9+.-]*:\/\/)([^\s:/?#@]*):([^\s/?#@]*)(@)/g;
+const URL_CREDENTIAL_PATTERN = /\b([A-Za-z][A-Za-z0-9+.-]*:\/\/)([^\s/?#@]+)(@)/g;
 const LONG_VALUE_CHARS = TRUNCATE_LENGTHS.LINE;
 
 function formatByteSize(value: string): string {
@@ -32,11 +32,11 @@ export function redactInvocationValuePatterns(value: string): string {
 	return value
 		.replace(BEARER_PATTERN, "Bearer <redacted>")
 		.replace(TOKEN_VALUE_PATTERN, REDACTED_INVOCATION_VALUE)
-		.replace(
-			URL_CREDENTIAL_PATTERN,
-			(_match, scheme: string, user: string, _password: string, at: string) =>
-				`${scheme}${user}:${REDACTED_INVOCATION_VALUE}${at}`,
-		);
+		.replace(URL_CREDENTIAL_PATTERN, (_match, scheme: string, userinfo: string, at: string) => {
+			const colon = userinfo.indexOf(":");
+			if (colon < 0) return `${scheme}${REDACTED_INVOCATION_VALUE}${at}`;
+			return `${scheme}${userinfo.slice(0, colon)}:${REDACTED_INVOCATION_VALUE}${at}`;
+		});
 }
 
 function displayValue(value: string, expanded: boolean, sensitive: boolean): string {
@@ -90,9 +90,9 @@ function findShellWordSpans(command: string): ShellWordSpan[] {
 		if (index >= command.length) break;
 		const start = index;
 		let quote: "single" | "double" | "ansi-c" | undefined;
+		let substitutionDepth = 0;
 		while (index < command.length) {
 			const character = command[index] ?? "";
-			if (!quote && /[\s;&|()<>]/.test(character)) break;
 			if (quote === "single") {
 				index += 1;
 				if (character === "'") quote = undefined;
@@ -123,11 +123,128 @@ function findShellWordSpans(command: string): ShellWordSpan[] {
 				index += 1;
 				continue;
 			}
+			if (substitutionDepth > 0) {
+				if (character === "(") substitutionDepth += 1;
+				if (character === ")") substitutionDepth -= 1;
+				index += 1;
+				continue;
+			}
+			if (character === "$" && command[index + 1] === "(") {
+				substitutionDepth = 1;
+				index += 2;
+				continue;
+			}
+			if (/[\s;&|()<>]/.test(character)) break;
 			index += 1;
 		}
 		spans.push({ start, end: index, value: command.slice(start, index) });
 	}
 	return spans;
+}
+
+function cookShellWord(value: string): string {
+	let output = "";
+	let index = 0;
+	let quote: "single" | "double" | "ansi-c" | undefined;
+	while (index < value.length) {
+		const character = value[index] ?? "";
+		if (quote === "single") {
+			index += 1;
+			if (character === "'") quote = undefined;
+			else output += character;
+			continue;
+		}
+		if (quote === "double" || quote === "ansi-c") {
+			if (character === "\\" && index + 1 < value.length) {
+				output += value[index + 1] ?? "";
+				index += 2;
+				continue;
+			}
+			index += 1;
+			if ((quote === "double" && character === '"') || (quote === "ansi-c" && character === "'")) {
+				quote = undefined;
+			} else {
+				output += character;
+			}
+			continue;
+		}
+		if (character === "\\" && index + 1 < value.length) {
+			output += value[index + 1] ?? "";
+			index += 2;
+			continue;
+		}
+		if (character === "$" && value[index + 1] === "'") {
+			quote = "ansi-c";
+			index += 2;
+			continue;
+		}
+		if (character === '"') {
+			quote = "double";
+			index += 1;
+			continue;
+		}
+		if (character === "'") {
+			quote = "single";
+			index += 1;
+			continue;
+		}
+		output += character;
+		index += 1;
+	}
+	return output;
+}
+
+function findShellWordEquals(value: string): number {
+	let index = 0;
+	let quote: "single" | "double" | "ansi-c" | undefined;
+	let substitutionDepth = 0;
+	while (index < value.length) {
+		const character = value[index] ?? "";
+		if (quote === "single") {
+			index += 1;
+			if (character === "'") quote = undefined;
+			continue;
+		}
+		if (quote === "double" || quote === "ansi-c") {
+			if (character === "\\") {
+				index = Math.min(index + 2, value.length);
+				continue;
+			}
+			index += 1;
+			if ((quote === "double" && character === '"') || (quote === "ansi-c" && character === "'")) {
+				quote = undefined;
+			}
+			continue;
+		}
+		if (character === "\\") {
+			index = Math.min(index + 2, value.length);
+			continue;
+		}
+		if (character === '"') {
+			quote = "double";
+			index += 1;
+			continue;
+		}
+		if (character === "'") {
+			quote = index > 0 && value[index - 1] === "$" ? "ansi-c" : "single";
+			index += 1;
+			continue;
+		}
+		if (substitutionDepth > 0) {
+			if (character === "(") substitutionDepth += 1;
+			if (character === ")") substitutionDepth -= 1;
+			index += 1;
+			continue;
+		}
+		if (character === "$" && value[index + 1] === "(") {
+			substitutionDepth = 1;
+			index += 2;
+			continue;
+		}
+		if (character === "=") return index;
+		index += 1;
+	}
+	return -1;
 }
 
 function splitShellWordWrapper(value: string): ShellWordWrapper {
@@ -155,21 +272,31 @@ function redactShellWords(command: string, expanded: boolean): string {
 	const replacements = new Map<number, string>();
 	for (const [index, span] of spans.entries()) {
 		if (replacements.has(index)) continue;
-		const assignment = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/s.exec(span.value);
-		if (assignment) {
-			const [, key, rawValue] = assignment;
+		const rawEquals = findShellWordEquals(span.value);
+		const cookedWord = cookShellWord(span.value);
+		const logicalEquals = cookedWord.indexOf("=");
+		const rawName = rawEquals < 0 ? span.value : span.value.slice(0, rawEquals);
+		const logicalName = logicalEquals < 0 ? cookedWord : cookedWord.slice(0, logicalEquals);
+		if (rawEquals >= 0 && /^[A-Za-z_][A-Za-z0-9_]*$/.test(logicalName)) {
+			const rawValue = span.value.slice(rawEquals + 1);
 			const wrapper = splitShellWordWrapper(rawValue);
-			const displayed = displayValue(wrapper.value, expanded, isSensitiveInvocationName(key));
-			replacements.set(index, `${key}=${wrapper.prefix}${displayed}${wrapper.suffix}`);
+			const displayed = displayValue(wrapper.value, expanded, isSensitiveInvocationName(logicalName));
+			replacements.set(index, `${rawName}=${wrapper.prefix}${displayed}${wrapper.suffix}`);
+			continue;
+		}
+		if (rawEquals < 0 && logicalEquals >= 0 && isSensitiveInvocationName(logicalName)) {
+			replacements.set(index, replaceShellWordValue(span.value, `${logicalName}=${REDACTED_INVOCATION_VALUE}`));
 			continue;
 		}
 
-		const equals = span.value.indexOf("=");
-		const flag = equals < 0 ? span.value : span.value.slice(0, equals);
-		if (!isSensitiveFlagName(flag)) continue;
-		if (equals >= 0) {
-			const rawValue = span.value.slice(equals + 1);
-			replacements.set(index, `${flag}=${replaceShellWordValue(rawValue, REDACTED_INVOCATION_VALUE)}`);
+		if (!isSensitiveFlagName(logicalName)) continue;
+		if (rawEquals >= 0) {
+			const rawValue = span.value.slice(rawEquals + 1);
+			replacements.set(index, `${rawName}=${replaceShellWordValue(rawValue, REDACTED_INVOCATION_VALUE)}`);
+			continue;
+		}
+		if (logicalEquals >= 0) {
+			replacements.set(index, replaceShellWordValue(span.value, `${logicalName}=${REDACTED_INVOCATION_VALUE}`));
 			continue;
 		}
 

--- a/packages/coding-agent/src/tools/invocation-display.ts
+++ b/packages/coding-agent/src/tools/invocation-display.ts
@@ -97,6 +97,13 @@ interface ShellWordWrapper {
 }
 
 type ShellQuote = "single" | "double" | "ansi-c" | "backtick";
+type ShellScanQuote = Exclude<ShellQuote, "backtick">;
+
+interface ShellScanFrame {
+	kind: "word" | "substitution" | "backtick";
+	quote?: ShellScanQuote;
+	parenthesisDepth: number;
+}
 
 function findShellWordSpans(command: string): ShellWordSpan[] {
 	const spans: ShellWordSpan[] = [];
@@ -105,33 +112,45 @@ function findShellWordSpans(command: string): ShellWordSpan[] {
 		while (index < command.length && /[\s;&|()<>]/.test(command[index] ?? "")) index += 1;
 		if (index >= command.length) break;
 		const start = index;
-		let quote: ShellQuote | undefined;
-		let substitutionDepth = 0;
+		const frames: ShellScanFrame[] = [{ kind: "word", parenthesisDepth: 0 }];
 		while (index < command.length) {
+			const frame = frames.at(-1)!;
 			const character = command[index] ?? "";
-			if (quote === "single") {
+			if (frame.quote === "single") {
 				index += 1;
-				if (character === "'") quote = undefined;
+				if (character === "'") frame.quote = undefined;
 				continue;
 			}
-			if (quote === "double" || quote === "ansi-c") {
+			if (frame.quote === "ansi-c") {
 				if (character === "\\") {
 					index = Math.min(index + 2, command.length);
 					continue;
 				}
 				index += 1;
-				if ((quote === "double" && character === '"') || (quote === "ansi-c" && character === "'")) {
-					quote = undefined;
-				}
+				if (character === "'") frame.quote = undefined;
 				continue;
 			}
-			if (quote === "backtick") {
+			if (frame.quote === "double") {
 				if (character === "\\") {
 					index = Math.min(index + 2, command.length);
 					continue;
 				}
+				if (character === '"') {
+					frame.quote = undefined;
+					index += 1;
+					continue;
+				}
+				if (character === "$" && command[index + 1] === "(") {
+					frames.push({ kind: "substitution", parenthesisDepth: 1 });
+					index += 2;
+					continue;
+				}
+				if (character === "`") {
+					frames.push({ kind: "backtick", parenthesisDepth: 0 });
+					index += 1;
+					continue;
+				}
 				index += 1;
-				if (character === "`") quote = undefined;
 				continue;
 			}
 			if (character === "\\") {
@@ -139,29 +158,37 @@ function findShellWordSpans(command: string): ShellWordSpan[] {
 				continue;
 			}
 			if (character === '"') {
-				quote = "double";
+				frame.quote = "double";
 				index += 1;
 				continue;
 			}
 			if (character === "'") {
-				quote = index > start && command[index - 1] === "$" ? "ansi-c" : "single";
-				index += 1;
-				continue;
-			}
-			if (character === "`") {
-				quote = "backtick";
-				index += 1;
-				continue;
-			}
-			if (substitutionDepth > 0) {
-				if (character === "(") substitutionDepth += 1;
-				if (character === ")") substitutionDepth -= 1;
+				frame.quote = index > start && command[index - 1] === "$" ? "ansi-c" : "single";
 				index += 1;
 				continue;
 			}
 			if (character === "$" && command[index + 1] === "(") {
-				substitutionDepth = 1;
+				frames.push({ kind: "substitution", parenthesisDepth: 1 });
 				index += 2;
+				continue;
+			}
+			if (character === "`") {
+				if (frame.kind === "backtick") frames.pop();
+				else frames.push({ kind: "backtick", parenthesisDepth: 0 });
+				index += 1;
+				continue;
+			}
+			if (frame.kind === "substitution") {
+				if (character === "(") frame.parenthesisDepth += 1;
+				if (character === ")") {
+					frame.parenthesisDepth -= 1;
+					if (frame.parenthesisDepth === 0) frames.pop();
+				}
+				index += 1;
+				continue;
+			}
+			if (frame.kind === "backtick") {
+				index += 1;
 				continue;
 			}
 			if (/[\s;&|()<>]/.test(character)) break;

--- a/packages/coding-agent/test/bash-invocation-redaction.test.ts
+++ b/packages/coding-agent/test/bash-invocation-redaction.test.ts
@@ -2,12 +2,14 @@ import { beforeAll, describe, expect, it } from "bun:test";
 import { BashExecutionComponent } from "@gajae-code/coding-agent/modes/components/bash-execution";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
 import { bashToolRenderer, formatBashCommand } from "@gajae-code/coding-agent/tools/bash";
+import { BashInteractiveOverlayComponent } from "@gajae-code/coding-agent/tools/bash-interactive";
 import {
 	formatInvocationCommand,
 	formatInvocationEnvironment,
 } from "@gajae-code/coding-agent/tools/invocation-display";
 import type { TUI } from "@gajae-code/tui";
 import { visibleWidth } from "@gajae-code/tui";
+import xterm from "@xterm/headless";
 
 const ui = { requestRender: () => {} } as unknown as TUI;
 
@@ -187,6 +189,22 @@ describe("bash invocation display safety", () => {
 			expect(output).not.toContain("\x07");
 			expect(Bun.stripANSI(output)).toContain("printf 'red'link");
 		}
+	});
+
+	it("redacts and sanitizes the interactive PTY overlay header", async () => {
+		const theme = (await getThemeByName("red-claw"))!;
+		const secret = "ghp_abcdefghijklmnopqrstuvwxyz123456";
+		const maliciousUrl = "https://evil.test";
+		const command = `API_TOKEN='${secret}' printf '\x1b[31mred\x1b[0m\x07'\x1b]8;;${maliciousUrl}\x07link\x1b]8;;\x07`;
+		const component = new BashInteractiveOverlayComponent(command, theme, () => 24, xterm.Terminal);
+
+		const rendered = component.render(100).join("\n");
+		component.dispose();
+
+		expect(rendered).not.toContain(secret);
+		expect(rendered).not.toContain(maliciousUrl);
+		expect(rendered).not.toContain("\x07");
+		expect(Bun.stripANSI(rendered)).toContain("API_TOKEN='<redacted>' printf 'red'link");
 	});
 
 	it("keeps the shell execution header bounded and never reveals secrets when expanded", () => {

--- a/packages/coding-agent/test/bash-invocation-redaction.test.ts
+++ b/packages/coding-agent/test/bash-invocation-redaction.test.ts
@@ -64,17 +64,42 @@ describe("bash invocation display safety", () => {
 		}
 	});
 
-	it("redacts password userinfo for generic credential URLs and empty users", () => {
+	it("redacts logically constructed sensitive flags and command-substitution values", () => {
 		const command =
-			"printf %s postgres://user:db-secret@host/db https://:empty-user-secret@example.test ftp://name:p:a:ss@host/path";
+			"curl --coo$'kie'=session-secret --coo$'kie'\"=\"joined-secret --password=$(printf supersecret) --authorization $(printf authsecret) \"--password=quoted-secret\"";
+		for (const expanded of [false, true]) {
+			const displayed = formatInvocationCommand(command, expanded);
+			expect(displayed).not.toContain("session-secret");
+			expect(displayed).not.toContain("supersecret");
+			expect(displayed).not.toContain("authsecret");
+			expect(displayed).not.toContain("quoted-secret");
+			expect(displayed).not.toContain("joined-secret");
+			expect(displayed).toContain("--coo$'kie'=<redacted>");
+			expect(displayed).toContain("--password=<redacted>");
+			expect(displayed).toContain("--authorization <redacted>");
+			if (expanded) expect(displayed).toContain('"--password=<redacted>"');
+			expect(displayed).toContain("--cookie=<redacted>");
+		}
+	});
+
+	it("preserves safe quoted equals and command substitutions", () => {
+		const command = "printf '%s' 'a=b' $(printf visible)";
+		expect(formatInvocationCommand(command, true)).toBe(command);
+	});
+
+	it("redacts password and username-only userinfo for generic credential URLs", () => {
+		const command =
+			"printf %s postgres://user:db-secret@host/db https://:empty-user-secret@example.test ftp://name:p:a:ss@host/path https://opaque-api-token@example.test/path";
 		const displayed = formatInvocationCommand(command, true);
 
 		expect(displayed).not.toContain("db-secret");
 		expect(displayed).not.toContain("empty-user-secret");
 		expect(displayed).not.toContain("p:a:ss");
+		expect(displayed).not.toContain("opaque-api-token");
 		expect(displayed).toContain("postgres://user:<redacted>@host/db");
 		expect(displayed).toContain("https://:<redacted>@example.test");
 		expect(displayed).toContain("ftp://name:<redacted>@host/path");
+		expect(displayed).toContain("https://<redacted>@example.test/path");
 	});
 
 	it("keeps short safe commands readable and collapses large arguments", () => {

--- a/packages/coding-agent/test/bash-invocation-redaction.test.ts
+++ b/packages/coding-agent/test/bash-invocation-redaction.test.ts
@@ -82,6 +82,37 @@ describe("bash invocation display safety", () => {
 		}
 	});
 
+	it("redacts complete quoted and nested substitution spans in collapsed and expanded views", () => {
+		const cases: Array<[command: string, expected: string, secrets: string[]]> = [
+			['curl --password="$(printf "secret value")"', 'curl --password="<redacted>"', ["secret", "value"]],
+			['curl --password="$(echo $(printf "deep secret"))"', 'curl --password="<redacted>"', ["deep", "secret"]],
+			[
+				'curl --password="$(printf "%s" "literal ) ( secret")"',
+				'curl --password="<redacted>"',
+				["literal", "secret"],
+			],
+			['curl --password="`printf "legacy secret"`"', 'curl --password="<redacted>"', ["legacy", "secret"]],
+			[
+				'curl --password="`echo $(printf "nested legacy secret")`"',
+				'curl --password="<redacted>"',
+				["nested", "legacy", "secret"],
+			],
+			[
+				'curl --authorization "$(printf "separated secret")"',
+				'curl --authorization "<redacted>"',
+				["separated", "secret"],
+			],
+		];
+
+		for (const expanded of [false, true]) {
+			for (const [command, expected, secrets] of cases) {
+				const displayed = formatInvocationCommand(command, expanded);
+				expect(displayed).toBe(expected);
+				for (const secret of secrets) expect(displayed).not.toContain(secret);
+			}
+		}
+	});
+
 	it("redacts ANSI-C escaped sensitive flags and complete backtick substitutions", () => {
 		const cases: Array<[command: string, secret: string]> = [
 			["curl --coo$'\\x6b'ie=hex-secret", "hex-secret"],
@@ -250,6 +281,23 @@ describe("bash invocation display safety", () => {
 		expect(rendered).not.toContain(maliciousUrl);
 		expect(rendered).not.toContain("\x07");
 		expect(Bun.stripANSI(rendered)).toContain("API_TOKEN='<redacted>' printf 'red'link");
+	});
+
+	it("keeps quoted nested substitutions out of collapsed and expanded standard Bash cards", async () => {
+		const theme = (await getThemeByName("red-claw"))!;
+		const command = 'curl --password="$(echo $(printf "deep secret value"))"';
+
+		for (const expanded of [false, true]) {
+			const rendered = bashToolRenderer
+				.renderCall({ command }, { expanded, isPartial: true }, theme)
+				.render(120)
+				.join("\n");
+			const plain = Bun.stripANSI(rendered);
+			expect(plain).toContain('curl --password="<redacted>"');
+			expect(plain).not.toContain("deep");
+			expect(plain).not.toContain("secret value");
+			for (const line of rendered.split("\n")) expect(visibleWidth(line)).toBeLessThanOrEqual(120);
+		}
 	});
 
 	it("keeps ANSI-C and backtick secrets out of every Bash invocation header", async () => {

--- a/packages/coding-agent/test/bash-invocation-redaction.test.ts
+++ b/packages/coding-agent/test/bash-invocation-redaction.test.ts
@@ -1,0 +1,135 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { BashExecutionComponent } from "@gajae-code/coding-agent/modes/components/bash-execution";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { bashToolRenderer, formatBashCommand } from "@gajae-code/coding-agent/tools/bash";
+import {
+	formatInvocationCommand,
+	formatInvocationEnvironment,
+} from "@gajae-code/coding-agent/tools/invocation-display";
+import type { TUI } from "@gajae-code/tui";
+import { visibleWidth } from "@gajae-code/tui";
+
+const ui = { requestRender: () => {} } as unknown as TUI;
+
+beforeAll(async () => {
+	const theme = await getThemeByName("red-claw");
+	expect(theme).toBeDefined();
+	setThemeInstance(theme!);
+});
+
+describe("bash invocation display safety", () => {
+	it("summarizes multiline environment values while preserving expanded non-sensitive detail", () => {
+		const value = Array.from({ length: 8 }, (_, index) => `line ${index + 1}`).join("\n");
+		const collapsed = formatInvocationEnvironment({ ISSUE_BODY: value }, false);
+		const expanded = formatInvocationEnvironment({ ISSUE_BODY: value }, true);
+
+		expect(collapsed).toContain('ISSUE_BODY="<multiline, 8 lines,');
+		expect(collapsed).not.toContain("line 8");
+		expect(expanded).toContain("line 1\\nline 2");
+		expect(expanded).toContain("line 8");
+	});
+
+	it("redacts sensitive keys and token-shaped values in collapsed and expanded views", () => {
+		const secret = "github_pat_abcdefghijklmnopqrstuvwxyz123456";
+		for (const expanded of [false, true]) {
+			const env = formatInvocationEnvironment({ GITHUB_TOKEN: secret, SAFE: `Bearer ${secret}` }, expanded);
+			const command = formatInvocationCommand(
+				`curl --authorization '${secret}' --password 'my secret phrase' https://user:password@example.test`,
+				expanded,
+			);
+
+			expect(env).not.toContain(secret);
+			expect(env).toContain('GITHUB_TOKEN="<redacted>"');
+			expect(env).toContain("Bearer <redacted>");
+			expect(command).not.toContain(secret);
+			expect(command).not.toContain("password@example.test");
+			expect(command).not.toContain("my secret phrase");
+			expect(command).toContain("--authorization '<redacted>'");
+		}
+	});
+
+	it("keeps short safe commands readable and collapses large arguments", () => {
+		expect(formatInvocationCommand("git status --short", false)).toBe("git status --short");
+		const longArgument = JSON.stringify({ body: "x".repeat(300) });
+		const collapsed = formatInvocationCommand(`curl --data '${longArgument}' https://example.test`, false);
+		const expanded = formatInvocationCommand(`curl --data '${longArgument}' https://example.test`, true);
+
+		expect(collapsed).toContain("<argument,");
+		expect(collapsed).not.toContain("x".repeat(100));
+		expect(expanded).toContain(longArgument);
+
+		const unquoted = formatInvocationCommand(`printf %s ${"y".repeat(300)}`, false);
+		expect(unquoted).toContain("<argument,");
+		expect(unquoted).not.toContain("y".repeat(100));
+	});
+
+	it("applies the same redaction and expansion policy to bash tool arguments", () => {
+		const value = "first\nsecond\nthird\nfourth";
+		const collapsed = formatBashCommand({
+			command: "gh issue create",
+			env: { ISSUE_BODY: value, API_TOKEN: "sk-abcdefghijklmnop" },
+		});
+		const expanded = formatBashCommand(
+			{ command: "gh issue create", env: { ISSUE_BODY: value, API_TOKEN: "sk-abcdefghijklmnop" } },
+			true,
+		);
+
+		expect(collapsed).toContain("gh issue create");
+		expect(collapsed).toContain('ISSUE_BODY="<multiline, 4 lines,');
+		expect(collapsed).toContain('API_TOKEN="<redacted>"');
+		expect(expanded).toContain("first\\nsecond\\nthird\\nfourth");
+		expect(expanded).not.toContain("sk-abcdefghijklmnop");
+	});
+
+	it("redacts the invocation during streaming, success, failure, and expansion", async () => {
+		const theme = (await getThemeByName("red-claw"))!;
+		const secret = "sk-abcdefghijklmnopqrstuvwxyz";
+		const args = { command: `curl --api-key '${secret}' https://example.test`, env: { SESSION_TOKEN: secret } };
+		const rendered = [
+			bashToolRenderer.renderCall(args, { expanded: false, isPartial: true }, theme).render(120).join("\n"),
+			bashToolRenderer
+				.renderResult(
+					{ content: [{ type: "text", text: "ok" }], details: {}, isError: false },
+					{ expanded: false, isPartial: false },
+					theme,
+					args,
+				)
+				.render(120)
+				.join("\n"),
+			bashToolRenderer
+				.renderResult(
+					{ content: [{ type: "text", text: "failed" }], details: {}, isError: true },
+					{ expanded: true, isPartial: false },
+					theme,
+					args,
+				)
+				.render(120)
+				.join("\n"),
+		];
+
+		for (const output of rendered) {
+			expect(output).not.toContain(secret);
+			expect(Bun.stripANSI(output)).toContain("<redacted>");
+		}
+	});
+
+	it("keeps the shell execution header bounded and never reveals secrets when expanded", () => {
+		const body = Array.from({ length: 10 }, (_, index) => `설명 ${index + 1}`).join("\n");
+		const secret = "ghp_abcdefghijklmnopqrstuvwxyz123456";
+		const command = `ISSUE_BODY='${body}' GITHUB_TOKEN='${secret}' gh issue create --title fix`;
+		const component = new BashExecutionComponent(command, ui, false);
+		component.setComplete(0, false);
+
+		const collapsed = Bun.stripANSI(component.render(36).join("\n"));
+		expect(collapsed).toMatch(/<multiline,\s+10 lines,/);
+		expect(collapsed).not.toContain("설명 10");
+		expect(collapsed).not.toContain(secret);
+		for (const line of collapsed.split("\n")) expect(visibleWidth(line)).toBeLessThanOrEqual(36);
+
+		component.setExpanded(true);
+		const expanded = Bun.stripANSI(component.render(80).join("\n"));
+		expect(expanded).toContain("설명 10");
+		expect(expanded).not.toContain(secret);
+		expect(expanded).toContain("GITHUB_TOKEN='<redacted>'");
+	});
+});

--- a/packages/coding-agent/test/bash-invocation-redaction.test.ts
+++ b/packages/coding-agent/test/bash-invocation-redaction.test.ts
@@ -48,6 +48,33 @@ describe("bash invocation display safety", () => {
 		}
 	});
 
+	it("redacts complete shell words across escaped, ANSI-C, assignment, and cookie forms", () => {
+		const command = String.raw`PASSWORD=$'top secret' curl --password "top \"secret\" suffix" --cookie=$'session secret' --authorization BearerValue`;
+		for (const expanded of [false, true]) {
+			const displayed = formatInvocationCommand(command, expanded);
+			expect(displayed).not.toContain("top secret");
+			expect(displayed).not.toContain("suffix");
+			expect(displayed).not.toContain("session secret");
+			expect(displayed).not.toContain("BearerValue");
+			expect(displayed).toContain("PASSWORD=$'<redacted>'");
+			expect(displayed).toContain('--password "<redacted>"');
+			expect(displayed).toContain("--cookie=$'<redacted>'");
+		}
+	});
+
+	it("redacts password userinfo for generic credential URLs and empty users", () => {
+		const command =
+			"printf %s postgres://user:db-secret@host/db https://:empty-user-secret@example.test ftp://name:p:a:ss@host/path";
+		const displayed = formatInvocationCommand(command, true);
+
+		expect(displayed).not.toContain("db-secret");
+		expect(displayed).not.toContain("empty-user-secret");
+		expect(displayed).not.toContain("p:a:ss");
+		expect(displayed).toContain("postgres://user:<redacted>@host/db");
+		expect(displayed).toContain("https://:<redacted>@example.test");
+		expect(displayed).toContain("ftp://name:<redacted>@host/path");
+	});
+
 	it("keeps short safe commands readable and collapses large arguments", () => {
 		expect(formatInvocationCommand("git status --short", false)).toBe("git status --short");
 		const longArgument = JSON.stringify({ body: "x".repeat(300) });
@@ -61,6 +88,16 @@ describe("bash invocation display safety", () => {
 		const unquoted = formatInvocationCommand(`printf %s ${"y".repeat(300)}`, false);
 		expect(unquoted).toContain("<argument,");
 		expect(unquoted).not.toContain("y".repeat(100));
+	});
+
+	it("hard-bounds retained lines from oversized multiline quoted payloads", () => {
+		const oversized = "界".repeat(10_000);
+		const command = `printf '%s' '${oversized}\nsecond\nthird\nfourth'`;
+		const collapsed = formatInvocationCommand(command, false);
+
+		expect(collapsed).toContain("<multiline command, 4 lines,");
+		expect(collapsed).not.toContain("界".repeat(100));
+		for (const line of collapsed.split("\n")) expect(visibleWidth(line)).toBeLessThanOrEqual(110);
 	});
 
 	it("applies the same redaction and expansion policy to bash tool arguments", () => {
@@ -110,6 +147,45 @@ describe("bash invocation display safety", () => {
 		for (const output of rendered) {
 			expect(output).not.toContain(secret);
 			expect(Bun.stripANSI(output)).toContain("<redacted>");
+		}
+	});
+
+	it("sanitizes terminal controls before every bash tool-card invocation render", async () => {
+		const theme = (await getThemeByName("red-claw"))!;
+		const maliciousUrl = "https://evil.test";
+		const args = {
+			command: `printf '\x1b[31mred\x1b[0m\x07'\x1b]8;;${maliciousUrl}\x07link\x1b]8;;\x07`,
+			env: { SAFE: `ok\x1b]2;owned\x07` },
+		};
+		expect(formatBashCommand(args, true)).toBe("$ SAFE=\"ok\" printf 'red'link");
+
+		const rendered = [
+			bashToolRenderer.renderCall(args, { expanded: false, isPartial: true }, theme).render(120).join("\n"),
+			bashToolRenderer
+				.renderResult(
+					{ content: [{ type: "text", text: "ok" }], details: {}, isError: false },
+					{ expanded: false, isPartial: false },
+					theme,
+					args,
+				)
+				.render(120)
+				.join("\n"),
+			bashToolRenderer
+				.renderResult(
+					{ content: [{ type: "text", text: "failed" }], details: {}, isError: true },
+					{ expanded: true, isPartial: false },
+					theme,
+					args,
+				)
+				.render(120)
+				.join("\n"),
+		];
+
+		for (const output of rendered) {
+			expect(output).not.toContain(maliciousUrl);
+			expect(output).not.toContain("owned");
+			expect(output).not.toContain("\x07");
+			expect(Bun.stripANSI(output)).toContain("printf 'red'link");
 		}
 	});
 

--- a/packages/coding-agent/test/bash-invocation-redaction.test.ts
+++ b/packages/coding-agent/test/bash-invocation-redaction.test.ts
@@ -82,9 +82,29 @@ describe("bash invocation display safety", () => {
 		}
 	});
 
+	it("redacts ANSI-C escaped sensitive flags and complete backtick substitutions", () => {
+		const cases: Array<[command: string, secret: string]> = [
+			["curl --coo$'\\x6b'ie=hex-secret", "hex-secret"],
+			["curl --coo$'\\153'ie=octal-secret", "octal-secret"],
+			["curl --coo$'\\u006b'ie=unicode-secret", "unicode-secret"],
+			["curl --coo$'\\U0000006b'ie=long-unicode-secret", "long-unicode-secret"],
+			["curl --coo$'\\n'kie=standard-control-secret", "standard-control-secret"],
+			["curl --coo$'\\c@'kie=control-secret", "control-secret"],
+			["curl --password=`printf backtick-equals-secret`", "backtick-equals-secret"],
+			["curl --authorization `printf backtick-separated-secret`", "backtick-separated-secret"],
+		];
+		for (const expanded of [false, true]) {
+			for (const [command, secret] of cases) {
+				const displayed = formatInvocationCommand(command, expanded);
+				expect(displayed).not.toContain(secret);
+				expect(displayed).toContain("<redacted>");
+			}
+		}
+	});
+
 	it("preserves safe quoted equals and command substitutions", () => {
-		const command = "printf '%s' 'a=b' $(printf visible)";
-		expect(formatInvocationCommand(command, true)).toBe(command);
+		const commands = ["printf '%s' 'a=b' $(printf visible)", "printf '%s' `printf visible legacy`"];
+		for (const command of commands) expect(formatInvocationCommand(command, true)).toBe(command);
 	});
 
 	it("redacts password and username-only userinfo for generic credential URLs", () => {
@@ -230,6 +250,29 @@ describe("bash invocation display safety", () => {
 		expect(rendered).not.toContain(maliciousUrl);
 		expect(rendered).not.toContain("\x07");
 		expect(Bun.stripANSI(rendered)).toContain("API_TOKEN='<redacted>' printf 'red'link");
+	});
+
+	it("keeps ANSI-C and backtick secrets out of every Bash invocation header", async () => {
+		const theme = (await getThemeByName("red-claw"))!;
+		const command =
+			"curl --coo$'\\x6b'ie=card-secret --password=`printf equals-secret` --authorization `printf separated-secret`";
+		const toolCard = bashToolRenderer
+			.renderCall({ command }, { expanded: true, isPartial: true }, theme)
+			.render(180)
+			.join("\n");
+		const execution = new BashExecutionComponent(command, ui, false);
+		execution.setExpanded(true);
+		const executionHeader = execution.render(180).join("\n");
+		const overlay = new BashInteractiveOverlayComponent(command, theme, () => 24, xterm.Terminal);
+		const overlayHeader = overlay.render(180).join("\n");
+		overlay.dispose();
+
+		for (const rendered of [toolCard, executionHeader, overlayHeader]) {
+			expect(rendered).not.toContain("card-secret");
+			expect(rendered).not.toContain("equals-secret");
+			expect(rendered).not.toContain("separated-secret");
+			expect(Bun.stripANSI(rendered)).toContain("<redacted>");
+		}
 	});
 
 	it("keeps the shell execution header bounded and never reveals secrets when expanded", () => {

--- a/packages/coding-agent/test/tools/bash-sixel-render.test.ts
+++ b/packages/coding-agent/test/tools/bash-sixel-render.test.ts
@@ -38,7 +38,7 @@ describe("bashToolRenderer", () => {
 			uiTheme,
 		);
 		const rendered = sanitizeText(component.render(120).join("\n"));
-		expect(rendered).toContain('MERMAID="line \\"one\\"\\ntwo"');
+		expect(rendered).toContain('MERMAID="<multiline, 2 lines, 14 B>"');
 		expect(rendered).toContain("printf '%s' \"$MERMAID\"");
 	});
 
@@ -55,7 +55,7 @@ describe("bashToolRenderer", () => {
 			uiTheme,
 		);
 		const rendered = sanitizeText(component.render(120).join("\n"));
-		expect(rendered).toContain('MERMAID="line 1\\nline 2"');
+		expect(rendered).toContain('MERMAID="<multiline, 2 lines, 13 B>"');
 		expect(rendered).toContain("printf '%s' \"$MERMAID\"");
 	});
 


### PR DESCRIPTION
## Summary
- collapse multiline environment values and oversized command arguments into typed size summaries by default
- preserve expanded non-sensitive invocation detail
- redact recognized credential keys, sensitive flags, bearer credentials, URL passwords, and common token shapes in every render state
- apply the policy to both Bash tool cards and shell execution headers without changing execution inputs

## Verification
- `bun test packages/coding-agent/test/bash-invocation-redaction.test.ts packages/coding-agent/test/bash-execution-clamp.test.ts packages/coding-agent/test/tools/bash-sixel-render.test.ts` (39 pass)
- `bun test packages/coding-agent/test/g001-toolrender-redteam.test.ts packages/coding-agent/test/tool-render-lines.test.ts packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts` (15 pass)
- `bun --cwd=packages/coding-agent run check`

Closes #3072

— GJC coding agent