### PR TITLE
fix(auth): cancel stalled prompt preflight

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Credential selection and aggregate usage callers now stop awaiting immediately when their own signal aborts without cancelling shared usage fetches, and ranking deadlines no longer re-await the same stalled usage request during credential resolution.
 - Kimi Code now allows one continuous 300-second first-event wait before aborting, while preserving explicit caller and environment timeout overrides and the existing inter-event idle timeout.
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2514,9 +2514,12 @@ export class AuthStorage {
 		if (storeHook) {
 			return storeHook(provider, credential, options?.signal);
 		}
-		return this.#fetchUsageCached(
-			this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
-			options?.timeoutMs ?? this.#usageRequestTimeoutMs,
+		return raceUsageWithSignal(
+			this.#fetchUsageCached(
+				this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
+				options?.timeoutMs ?? this.#usageRequestTimeoutMs,
+			),
+			options?.signal,
 		);
 	}
 
@@ -2568,7 +2571,7 @@ export class AuthStorage {
 		const cacheKey = this.#buildUsageReportsCacheKey(requests);
 
 		const inFlight = this.#usageReportsInFlight.get(cacheKey);
-		if (inFlight) return inFlight;
+		if (inFlight) return raceUsageWithSignal(inFlight, options?.signal);
 
 		const promise = (async () => {
 			if (options?.logDetails !== false) {
@@ -2616,7 +2619,7 @@ export class AuthStorage {
 		});
 
 		this.#usageReportsInFlight.set(cacheKey, promise);
-		return promise;
+		return raceUsageWithSignal(promise, options?.signal);
 	}
 
 	/**
@@ -2867,7 +2870,7 @@ export class AuthStorage {
 				const blockedUntil = this.#getCredentialBlockedUntil(args.providerKey, selection.index);
 				if (blockedUntil !== undefined) return { selection, usage: null, usageChecked: false, blockedUntil };
 				const usage = await this.#getUsageReport(args.provider, selection.credential, {
-					...args.options,
+					baseUrl: args.options?.baseUrl,
 					timeoutMs: this.#usageRequestTimeoutMs,
 				});
 				return { selection, usage, usageChecked: true, blockedUntil: undefined as number | undefined };
@@ -2880,16 +2883,21 @@ export class AuthStorage {
 		// path so memory drops immediately.
 		const timer = setTimeout(() => timeoutSignal.resolve(null), usageTimeout);
 		timer.unref?.();
-		const usageResults = await Promise.race([usagePromise, timeoutSignal.promise]).then(result => {
-			clearTimeout(timer);
-			return (
-				result ??
-				args.order.map(idx => {
-					const selection = args.credentials[idx];
-					return selection ? { selection, usage: null, usageChecked: false, blockedUntil: undefined } : null;
-				})
+		let resolvedUsageResults: Awaited<typeof usagePromise> | null;
+		try {
+			resolvedUsageResults = await raceUsageWithSignal(
+				Promise.race([usagePromise, timeoutSignal.promise]),
+				args.options?.signal,
 			);
-		});
+		} finally {
+			clearTimeout(timer);
+		}
+		const usageResults =
+			resolvedUsageResults ??
+			args.order.map(idx => {
+				const selection = args.credentials[idx];
+				return selection ? { selection, usage: null, usageChecked: true, blockedUntil: undefined } : null;
+			});
 
 		for (let orderPos = 0; orderPos < usageResults.length; orderPos += 1) {
 			const result = usageResults[orderPos];

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -103,6 +103,16 @@ function createCredential(accountId: string, email: string): OAuthCredentials {
 	};
 }
 
+async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(10);
+	}
+
+	throw new Error("Timed out waiting for condition");
+}
+
 describe("AuthStorage codex oauth ranking", () => {
 	let tempDir = "";
 	let store: AuthCredentialStore | null = null;
@@ -390,6 +400,114 @@ describe("AuthStorage codex oauth ranking", () => {
 
 		expect(apiKey).toBe("api-acct-first");
 		expect(elapsedMs).toBeLessThan(100);
+	});
+
+	test("does not re-await a shared usage request after the ranking deadline", async () => {
+		if (!store) throw new Error("test setup failed");
+		vi.useFakeTimers();
+		const usageGate = Promise.withResolvers<UsageReport | null>();
+		let usageCalls = 0;
+		let apiKeyPromise: Promise<string | undefined> | undefined;
+		const stalledAuthStorage = new AuthStorage(store, {
+			usageProviderResolver: provider =>
+				provider === "openai-codex"
+					? ({
+							id: "openai-codex",
+							async fetchUsage() {
+								usageCalls += 1;
+								return usageGate.promise;
+							},
+						} satisfies UsageProvider)
+					: undefined,
+			usageRequestTimeoutMs: 1000,
+		});
+
+		await stalledAuthStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-first", "first@example.com") },
+			{ type: "oauth", ...createCredential("acct-second", "second@example.com") },
+		]);
+
+		try {
+			apiKeyPromise = stalledAuthStorage.getApiKey("openai-codex", "session-ranking-deadline");
+			for (let attempt = 0; attempt < 20 && usageCalls < 2; attempt += 1) {
+				await Promise.resolve();
+			}
+			expect(usageCalls).toBe(2);
+			vi.advanceTimersByTime(5000);
+			await Promise.resolve();
+			vi.useRealTimers();
+			const outcome = await Promise.race([apiKeyPromise, Bun.sleep(100).then(() => "still-pending" as const)]);
+
+			expect(outcome).toBe("api-acct-first");
+			expect(usageCalls).toBe(2);
+		} finally {
+			usageGate.resolve(null);
+			vi.useRealTimers();
+			if (apiKeyPromise) await Promise.allSettled([apiKeyPromise]);
+			await stalledAuthStorage.fetchUsageReports();
+		}
+	});
+
+	test("aborts an oauth selection caller without cancelling shared usage work", async () => {
+		if (!store) throw new Error("test setup failed");
+		const usageGates = new Map<string, PromiseWithResolvers<UsageReport | null>>();
+		let usageCalls = 0;
+		const sharedAuthStorage = new AuthStorage(store, {
+			usageProviderResolver: provider =>
+				provider === "openai-codex"
+					? ({
+							id: "openai-codex",
+							async fetchUsage(params) {
+								usageCalls += 1;
+								const accountId = params.credential.accountId;
+								if (!accountId) return null;
+								const gate = Promise.withResolvers<UsageReport | null>();
+								usageGates.set(accountId, gate);
+								return gate.promise;
+							},
+						} satisfies UsageProvider)
+					: undefined,
+			usageRequestTimeoutMs: 30_000,
+		});
+		await sharedAuthStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-first", "first@example.com") },
+			{ type: "oauth", ...createCredential("acct-second", "second@example.com") },
+		]);
+
+		const controller = new AbortController();
+		const selection = sharedAuthStorage.getApiKey("openai-codex", "session-cancelled", {
+			signal: controller.signal,
+		});
+		const selectionOutcome = selection.then(
+			() => "resolved" as const,
+			() => "rejected" as const,
+		);
+		let peer: Promise<UsageReport[] | null> | undefined;
+		try {
+			await waitFor(() => usageCalls === 2);
+			peer = sharedAuthStorage.fetchUsageReports();
+
+			controller.abort();
+			const outcome = await Promise.race([selectionOutcome, Bun.sleep(100).then(() => "pending" as const)]);
+			for (const [accountId, gate] of usageGates) {
+				gate.resolve(
+					createCodexUsageReport({
+						accountId,
+						primary: { usedFraction: 0.1, resetInMs: HOUR_MS },
+						secondary: { usedFraction: 0.2, resetInMs: WEEK_MS },
+					}),
+				);
+			}
+			const peerReports = await peer;
+
+			expect(outcome).toBe("rejected");
+			expect(peerReports).toHaveLength(2);
+			expect(usageCalls).toBe(2);
+		} finally {
+			controller.abort();
+			for (const gate of usageGates.values()) gate.resolve(null);
+			await Promise.allSettled(peer ? [selection, peer] : [selection]);
+		}
 	});
 
 	test("sorts 3 accounts by weekly drain rate", async () => {

--- a/packages/ai/test/auth-storage-usage-cache.test.ts
+++ b/packages/ai/test/auth-storage-usage-cache.test.ts
@@ -24,6 +24,16 @@ function anthropicReports(reports: UsageReport[] | null): UsageReport[] {
 	return (reports ?? []).filter(r => r.provider === "anthropic");
 }
 
+async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(10);
+	}
+
+	throw new Error("Timed out waiting for condition");
+}
+
 /**
  * Force every cache entry to look stale to AuthStorage WITHOUT dropping the
  * value. The cache layer is two-tier: the store-level `expiresAtSec` controls
@@ -161,6 +171,41 @@ describe("AuthStorage usage cache: last-good failure fallback", () => {
 		expect(second).toHaveLength(1);
 		// Cache hit — provider was NOT called a second time.
 		expect(calls).toBe(1);
+	});
+
+	it("cancels one aggregate caller without stopping its shared local usage fetch", async () => {
+		const gate = Promise.withResolvers<UsageReport | null>();
+		let calls = 0;
+		const goldReport = makeReport("a@example.com");
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async () => {
+			calls += 1;
+			return gate.promise;
+		});
+
+		const controller = new AbortController();
+		const cancelled = storage.fetchUsageReports({ signal: controller.signal });
+		const cancelledOutcome = cancelled.then(
+			() => "resolved" as const,
+			() => "rejected" as const,
+		);
+		let peer: Promise<UsageReport[] | null> | undefined;
+		try {
+			await waitFor(() => calls === 1);
+			peer = storage.fetchUsageReports();
+
+			controller.abort();
+			const outcome = await Promise.race([cancelledOutcome, Bun.sleep(100).then(() => "pending" as const)]);
+			gate.resolve(goldReport);
+			const peerReports = anthropicReports(await peer);
+
+			expect(outcome).toBe("rejected");
+			expect(peerReports).toHaveLength(1);
+			expect(calls).toBe(1);
+		} finally {
+			controller.abort();
+			gate.resolve(goldReport);
+			await Promise.allSettled(peer ? [cancelled, peer] : [cancelled]);
+		}
 	});
 
 	it("suppresses provider and account details for secret-safe callers", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Interactive prompt cancellation now reaches API-key preflight through `ModelRegistry`, allowing aborted submissions to clear immediately even while a shared credential-usage request continues in the background.
 - Alibaba Token Plan canonical first-event timeouts now surface without session retry/fallback replay and are not internally retried by auto-compaction, preventing repeated provider usage (#3026).
 
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2564,13 +2564,14 @@ export class ModelRegistry {
 	async getApiKey(
 		model: Model<Api>,
 		sessionId?: string,
-		options: { credentialSelector?: AuthCredentialSelector } = {},
+		options: { credentialSelector?: AuthCredentialSelector; signal?: AbortSignal } = {},
 	): Promise<string | undefined> {
 		return this.#getApiKeyOrNoAuth(model.provider, () =>
 			this.authStorage.getApiKey(model.provider, sessionId, {
 				baseUrl: model.baseUrl,
 				modelId: model.id,
 				credentialSelector: options.credentialSelector,
+				signal: options.signal,
 			}),
 		);
 	}
@@ -2582,12 +2583,13 @@ export class ModelRegistry {
 		provider: string,
 		sessionId?: string,
 		baseUrl?: string,
-		options: { credentialSelector?: AuthCredentialSelector } = {},
+		options: { credentialSelector?: AuthCredentialSelector; signal?: AbortSignal } = {},
 	): Promise<string | undefined> {
 		return this.#getApiKeyOrNoAuth(provider, () =>
 			this.authStorage.getApiKey(provider, sessionId, {
 				baseUrl,
 				credentialSelector: options.credentialSelector,
+				signal: options.signal,
 			}),
 		);
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7530,7 +7530,11 @@ export class AgentSession {
 			}
 
 			// Validate API key
-			const apiKey = await this.#modelRegistry.getApiKey(this.model, this.sessionId);
+			const apiKey = await this.#awaitPromptPreflight(
+				generation,
+				preflightSignal,
+				this.#modelRegistry.getApiKey(this.model, this.sessionId, { signal: preflightSignal }),
+			);
 			if (!apiKey) {
 				throw new Error(formatNoCredentialOnboardingError(this.model.provider));
 			}

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -16,6 +16,8 @@ import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { TtsrManager } from "@gajae-code/coding-agent/export/ttsr";
 import type { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
+import { submitInteractiveInput } from "@gajae-code/coding-agent/main";
+import type { SubmittedUserInput } from "@gajae-code/coding-agent/modes/types";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { convertToLlm } from "@gajae-code/coding-agent/session/messages";
@@ -122,6 +124,81 @@ describe("AgentSession concurrent prompt guard", () => {
 		// Cleanup
 		await session.abort();
 		await firstPrompt.catch(() => {}); // Ignore abort error
+	});
+
+	it("aborts stalled API-key preflight, clears the submission, and accepts the next prompt", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		let streamCalls = 0;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: () => {
+				streamCalls += 1;
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const message = createAssistantMessage("ok");
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			},
+		});
+		const sessionManager = SessionManager.inMemory();
+		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth-preflight-cancel.db"));
+		authStorages.push(authStorage);
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		const apiKeyGate = Promise.withResolvers<string | undefined>();
+		let stallApiKey = true;
+		let preflightSignal: AbortSignal | undefined;
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (_model, _sessionId, options) => {
+			preflightSignal = options?.signal;
+			return stallApiKey ? apiKeyGate.promise : "test-key";
+		});
+		session = new AgentSession({ agent, sessionManager, settings: Settings.isolated(), modelRegistry });
+
+		const mode = {
+			markPendingSubmissionStarted: vi.fn(() => true),
+			finishPendingSubmission: vi.fn(),
+			showError: vi.fn(),
+			checkShutdownRequested: vi.fn(async () => {}),
+		};
+		const input: SubmittedUserInput = {
+			text: "cancel during auth",
+			images: undefined,
+			cancelled: false,
+			started: false,
+		};
+		const submission = submitInteractiveInput(mode, session, input);
+		const submissionOutcome = submission.then(() => "settled" as const);
+		let abort: Promise<void> | undefined;
+		try {
+			await waitFor(() => preflightSignal !== undefined);
+
+			abort = session.abort();
+			const outcome = await Promise.race([submissionOutcome, Bun.sleep(100).then(() => "pending" as const)]);
+			apiKeyGate.resolve("test-key");
+			await submission;
+			await abort;
+
+			expect(outcome).toBe("settled");
+			expect(preflightSignal?.aborted).toBe(true);
+			expect(mode.finishPendingSubmission).toHaveBeenCalledWith(input);
+			expect(mode.showError).not.toHaveBeenCalled();
+			expect(session.isStreaming).toBe(false);
+			expect(
+				agent.state.messages.filter(message => message.role === "user" || message.role === "assistant"),
+			).toEqual([]);
+
+			stallApiKey = false;
+			await session.prompt("after abort");
+
+			expect(streamCalls).toBe(1);
+			expect(agent.state.messages.filter(message => message.role === "user")).toHaveLength(1);
+			expect(agent.state.messages.filter(message => message.role === "assistant")).toHaveLength(1);
+		} finally {
+			apiKeyGate.resolve("test-key");
+			await Promise.allSettled(abort ? [submission, abort] : [submission]);
+		}
 	});
 
 	it("should allow steer() while streaming", async () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -156,6 +156,40 @@ describe("ModelRegistry", () => {
 			}
 		};
 	}
+
+	test("forwards caller cancellation through model and provider key lookups", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const model = registry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Anthropic model");
+		const controller = new AbortController();
+		const credentialSelector = { kind: "email" as const, value: "worker@example.com" };
+		const getApiKey = vi.spyOn(authStorage, "getApiKey").mockResolvedValue("test-key");
+
+		try {
+			await registry.getApiKey(model, "model-session", {
+				credentialSelector,
+				signal: controller.signal,
+			});
+			await registry.getApiKeyForProvider("anthropic", "provider-session", "https://proxy.example.com", {
+				credentialSelector,
+				signal: controller.signal,
+			});
+
+			expect(getApiKey).toHaveBeenNthCalledWith(1, "anthropic", "model-session", {
+				baseUrl: model.baseUrl,
+				modelId: model.id,
+				credentialSelector,
+				signal: controller.signal,
+			});
+			expect(getApiKey).toHaveBeenNthCalledWith(2, "anthropic", "provider-session", {
+				baseUrl: "https://proxy.example.com",
+				credentialSelector,
+				signal: controller.signal,
+			});
+		} finally {
+			getApiKey.mockRestore();
+		}
+	});
 
 	function mockOpenAiCompatibleModels(url: string, modelIds: string[]) {
 		return hookFetch(input => {


### PR DESCRIPTION
## Summary

- make credential selection and aggregate usage waits respect each caller's cancellation without cancelling shared usage fetches
- stop credential resolution from re-awaiting the same stalled usage request after the ranking deadline
- thread prompt preflight cancellation through ModelRegistry and AuthStorage so aborted interactive submissions clear immediately
- add regression coverage and changelog entries for both affected packages

## Validation

- 5 focused regression tests passed
- 4 affected test files passed: 187 tests total
- bun --cwd=packages/ai run check
- bun --cwd=packages/coding-agent run check
- git diff --check

Local Windows note: Bun 1.3.14 retains SQLite WAL handles until process exit even after Database.close(). The affected suites were run with a temporary EBUSY-only teardown guard to isolate that existing platform issue; the guard was removed before commit.