### PR TITLE
feat: add Anthropic Opus 5 and adopt it in the built-in Opus profiles

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 
 - Added first-class support for **OpenGateway by Sionic AI**, an OpenAI-compatible gateway. Registers the `opengateway` provider descriptor, `/login` OAuth entry (API-key paste validated against `https://apis.opengateway.ai/v1/models`), `OPENGATEWAY_API_KEY` environment resolution, and bundled `models.json` seed models. Models are discovered dynamically from the OpenAI-compatible `/v1/models` endpoint (base URL `https://apis.opengateway.ai/v1`).
+- Added **Claude Opus 5** (`claude-opus-5`) to the bundled `anthropic` model catalog: 1M context window, 128k max output, thinking on with the full effort ladder through `max`, and standard Opus pricing ($5/$25 per MTok, cache 0.5/6.25) — unchanged from Opus 4.8. As the newest Opus, it becomes the canonical target for the `claude-opus-latest` family alias.
 
 ## [0.11.8] - 2026-07-23
 

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -3512,6 +3512,31 @@
 				"maxLevel": "max"
 			}
 		},
+		"claude-opus-5": {
+			"id": "claude-opus-5",
+			"name": "Anthropic Opus 5",
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"baseUrl": "https://api.anthropic.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "max"
+			}
+		},
 		"claude-sonnet-4-0": {
 			"id": "claude-sonnet-4-0",
 			"name": "Anthropic Sonnet 4 (latest)",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- The built-in `Claude Opus`, `Opus + Codex`, and `Fable + Opus + Codex` model profiles now target **Claude Opus 5** (`claude-opus-5`) instead of Opus 4.8 for their Anthropic roles — the newest, same-priced Opus.
+
 ### Fixed
 
 - Alibaba Token Plan canonical first-event timeouts now surface without session retry/fallback replay and are not internally retried by auto-compaction, preventing repeated provider usage (#3026).

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -100,11 +100,11 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		architect: "opencode-go/deepseek-v4-pro",
 	}),
 	profile("claude-opus", ["anthropic"], {
-		default: "anthropic/claude-opus-4-8:xhigh",
+		default: "anthropic/claude-opus-5:xhigh",
 		executor: "anthropic/claude-sonnet-5",
-		planner: "anthropic/claude-opus-4-8:low",
-		critic: "anthropic/claude-opus-4-8:high",
-		architect: "anthropic/claude-opus-4-8:xhigh",
+		planner: "anthropic/claude-opus-5:low",
+		critic: "anthropic/claude-opus-5:high",
+		architect: "anthropic/claude-opus-5:xhigh",
 	}),
 	profile("claude-fable", ["anthropic"], {
 		default: "anthropic/claude-fable-5:xhigh",
@@ -271,7 +271,7 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		critic: "alibaba-token-plan/qwen3.8-max-preview:xhigh",
 	}),
 	profile("opus-codex", ["anthropic", "openai-codex"], {
-		default: "anthropic/claude-opus-4-8:xhigh",
+		default: "anthropic/claude-opus-5:xhigh",
 		executor: "openai-codex/gpt-5.6-terra:low",
 		planner: "anthropic/claude-sonnet-5",
 		critic: "openai-codex/gpt-5.6-sol:xhigh",
@@ -287,8 +287,8 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 	profile("fable-opus-codex", ["anthropic", "openai-codex"], {
 		default: "anthropic/claude-fable-5:high",
 		executor: "openai-codex/gpt-5.6-terra:medium",
-		planner: "anthropic/claude-opus-4-8:medium",
-		critic: "anthropic/claude-opus-4-8:high",
+		planner: "anthropic/claude-opus-5:medium",
+		critic: "anthropic/claude-opus-5:high",
 		architect: "openai-codex/gpt-5.6-sol:xhigh",
 	}),
 ];

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -91,6 +91,11 @@ function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelP
 				minLevel: ThinkingLevel.Low,
 				maxLevel: ThinkingLevel.XHigh,
 			}),
+			model("anthropic", "claude-opus-5", {
+				mode: "effort",
+				minLevel: ThinkingLevel.Low,
+				maxLevel: ThinkingLevel.Max,
+			}),
 			model("anthropic", "claude-fable-5", {
 				mode: "effort",
 				minLevel: ThinkingLevel.Low,
@@ -564,7 +569,7 @@ describe("model profile activation", () => {
 		[
 			"opus-codex",
 			{
-				default: "anthropic/claude-opus-4-8:xhigh",
+				default: "anthropic/claude-opus-5:xhigh",
 				executor: "openai-codex/gpt-5.6-terra:low",
 				planner: "anthropic/claude-sonnet-5",
 				critic: "openai-codex/gpt-5.6-sol:xhigh",
@@ -586,8 +591,8 @@ describe("model profile activation", () => {
 			{
 				default: "anthropic/claude-fable-5:high",
 				executor: "openai-codex/gpt-5.6-terra:medium",
-				planner: "anthropic/claude-opus-4-8:medium",
-				critic: "anthropic/claude-opus-4-8:high",
+				planner: "anthropic/claude-opus-5:medium",
+				critic: "anthropic/claude-opus-5:high",
 				architect: "openai-codex/gpt-5.6-sol:xhigh",
 			},
 		],

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -67,11 +67,11 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		name: "claude-opus",
 		requiredProviders: ["anthropic"],
 		mapping: {
-			default: "anthropic/claude-opus-4-8:xhigh",
+			default: "anthropic/claude-opus-5:xhigh",
 			executor: "anthropic/claude-sonnet-5",
-			planner: "anthropic/claude-opus-4-8:low",
-			critic: "anthropic/claude-opus-4-8:high",
-			architect: "anthropic/claude-opus-4-8:xhigh",
+			planner: "anthropic/claude-opus-5:low",
+			critic: "anthropic/claude-opus-5:high",
+			architect: "anthropic/claude-opus-5:xhigh",
 		},
 	},
 	{
@@ -320,7 +320,7 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		name: "opus-codex",
 		requiredProviders: ["anthropic", "openai-codex"],
 		mapping: {
-			default: "anthropic/claude-opus-4-8:xhigh",
+			default: "anthropic/claude-opus-5:xhigh",
 			executor: "openai-codex/gpt-5.6-terra:low",
 			planner: "anthropic/claude-sonnet-5",
 			critic: "openai-codex/gpt-5.6-sol:xhigh",
@@ -344,8 +344,8 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		mapping: {
 			default: "anthropic/claude-fable-5:high",
 			executor: "openai-codex/gpt-5.6-terra:medium",
-			planner: "anthropic/claude-opus-4-8:medium",
-			critic: "anthropic/claude-opus-4-8:high",
+			planner: "anthropic/claude-opus-5:medium",
+			critic: "anthropic/claude-opus-5:high",
 			architect: "openai-codex/gpt-5.6-sol:xhigh",
 		},
 	},
@@ -390,7 +390,7 @@ function substituteCodexFamily(selector: string, source: "sol" | "terra", target
 
 const fixedNonCodexComboMappings: Record<string, Partial<Record<Role, string>>> = {
 	"opus-codex": {
-		default: "anthropic/claude-opus-4-8:xhigh",
+		default: "anthropic/claude-opus-5:xhigh",
 		planner: "anthropic/claude-sonnet-5",
 	},
 	"codex-opencodego": {
@@ -400,8 +400,8 @@ const fixedNonCodexComboMappings: Record<string, Partial<Record<Role, string>>> 
 	},
 	"fable-opus-codex": {
 		default: "anthropic/claude-fable-5:high",
-		planner: "anthropic/claude-opus-4-8:medium",
-		critic: "anthropic/claude-opus-4-8:high",
+		planner: "anthropic/claude-opus-5:medium",
+		critic: "anthropic/claude-opus-5:high",
 	},
 };
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -492,7 +492,8 @@ describe("ModelRegistry", () => {
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
-			const opusVariants = registry.getCanonicalVariants("claude-opus-4-8");
+			// opus-5 is the newest opus, so the `claude-opus-latest` alias collapses into it.
+			const opusVariants = registry.getCanonicalVariants("claude-opus-5");
 			const haikuVariants = registry.getCanonicalVariants("claude-haiku-4-5");
 
 			expect(opusVariants.some(variant => variant.selector === "demo/anthropic/claude-opus-latest")).toBe(true);


### PR DESCRIPTION
## What

Registers **Claude Opus 5** (`claude-opus-5`) in the bundled `anthropic` model catalog.

## Specs (verified against Anthropic's model/pricing docs)

| Field | Value | Source |
|---|---|---|
| Model ID | `claude-opus-5` (dateless major-version format) | Model IDs & versioning |
| Context window | 1,000,000 (default **and** maximum) | What's new in Opus 5 |
| Max output | 128,000 | What's new in Opus 5 |
| Pricing | `$5` in / `$25` out per MTok, cache `0.5` / `6.25` | Pricing (unchanged from Opus 4.8) |
| Effort ladder | full ladder through flagship `max` | What's new in Opus 5 |
| Thinking | on by default, `anthropic-adaptive` | What's new in Opus 5 |
| Input | text + image | — |

Mirrors the existing `claude-opus-4-8` and `claude-sonnet-5` entries exactly.

## Canonical-alias update

Opus 5 is the newest opus (version segments `[5] > [4,8]`), so the `model-equivalence` engine correctly collapses the `claude-opus-latest` family alias into `claude-opus-5`. The `ModelRegistry` canonical test that anchored on the now-superseded `claude-opus-4-8` is updated to `claude-opus-5` (verified: the latest-alias variants move to opus-5).

## Verification

- `getBundledModel("anthropic", "claude-opus-5")` resolves with the correct specs.
- `issue-830-repro`, `models-lazy`, `model-thinking`, `model-profile-activation`, and the updated `model-registry` canonical test: green. The `anthropic` default model remains `claude-sonnet-5` (unchanged).
- biome clean.
- Note: 3 unrelated `ModelRegistry > canonical equivalence` cases (session-sticky / 64-entry-bound / reversed-candidate) fail on `dev` **without** this change too (pre-existing, order/state-dependent) — untouched here.

## Scope

This PR covers the **first-class `anthropic` provider** (the direct Claude API path). Opus 5 is also available on Bedrock (`anthropic.claude-opus-5`) and Google Cloud per the docs; that gateway coverage (with its regional-endpoint variants) is left for a focused follow-up.

Fast mode needs no catalog field — the provider already negotiates `speed:"fast"` via `serviceTier:"priority"` with a runtime fallback.

---

## Update: adopt Opus 5 in the built-in Opus profiles

A second commit points the built-in **Claude Opus**, **Opus + Codex**, and **Fable + Opus + Codex** profiles at `claude-opus-5` (instead of `claude-opus-4-8`) for their Anthropic roles — the newest Opus at the same price, per Anthropic's migration guide (`claude-opus-4-8` → `claude-opus-5`). Effort suffixes unchanged; opus-5 is thinking-on by default so `:xhigh` selectors carry no disable-thinking conflict. Profile catalog + activation tests updated (opus-5 fixture registered). Model-profile catalog/activation/preset/settings tests: green.