### PR TITLE
feat(ai): add Claude Opus 5 and repair Anthropic adaptive-display id parsing

### DIFF
--- a/artifacts/architecture-2383-eval.json
+++ b/artifacts/architecture-2383-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "67cd55244f886f568da678bda4314298f01abf0e",
-		"providerSourceSha256": "978c083395de102cb8c78d1e25b164daea3c3558dbd7d90e7a190d3f22550e9b",
+		"providerSourceBlobOid": "c56ed124951c9d922f727b6ddde123349effe0a5",
+		"providerSourceSha256": "22ebcf813814afefd9c07292dbb8b54904678715df70285f5ee9e19e46a578c0",
 		"inputFixtureSha256": "b1ca8d3183ca168140774f848ed414252178f7c5788d61243069862ae59c129b"
 	},
 	"derivationCommands": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added the Anthropic **Claude Opus 5** (`anthropic/claude-opus-5`) bundled catalog entry: 1M-token context window, 128k max output, text + image input, adaptive thinking through `max`, and $5 / $25 per MTok with $0.50 cache reads and $6.25 5-minute cache writes. Catalog-only — the Anthropic provider default (`claude-sonnet-5`) and every built-in model profile are unchanged.
+
 ### Fixed
 
+- Fixed adaptive thinking being billed but never displayed whenever an Anthropic model id did not have the exact `claude-opus-<major>-<minor>` shape. `supportsAdaptiveThinkingDisplay` was a per-provider regex duplicated in the Anthropic Messages and Bedrock Converse transports, and it is now one shared predicate in `model-thinking.ts` that parses the Anthropic model version, the same authority `hasOpus47ApiRestrictions` already uses. Three id classes change behavior (same failure class as #2791): dateless ids (`claude-opus-5`, including region-prefixed Bedrock forms) and gateway dot-form ids (`claude-opus-4.7` / `claude-opus-4.8` / `-fast` on `github-copilot`, `vercel-ai-gateway`, `zenmux`) now send `display: "summarized"` instead of inheriting Anthropic's `omitted` default and no longer attach the redundant `interleaved-thinking-2025-05-14` beta; date-suffixed Opus 4.0 ids (`claude-opus-4-20250514` and its Bedrock variants) are no longer misread as version 4.20250514, so these budget-thinking models regain the interleaved-thinking beta they need. Opus 4.6, every Sonnet/Haiku, `-latest` aliases, and non-Anthropic ids are unaffected.
 - Credential selection and aggregate usage callers now stop awaiting immediately when their own signal aborts without cancelling shared usage fetches, and ranking deadlines no longer re-await the same stalled usage request during credential resolution.
 - Kimi Code now allows one continuous 300-second first-event wait before aborting, while preserving explicit caller and environment timeout overrides and the existing inter-event idle timeout.
 

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -350,6 +350,24 @@ export function hasOpus47ApiRestrictions(modelId: string): boolean {
 	return semverGte(parsed.version, "4.7") && parsed.kind === "opus";
 }
 
+/**
+ * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
+ * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
+ * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
+ * "omitted" — thinking tokens are billed but no content streams back — so it
+ * must opt in like Opus 4.7+ (issue #2791).
+ *
+ * Version parsing (not id-shape matching) is the authority here: dateless ids
+ * carry a single version segment (`claude-opus-5`), and Bedrock ids add
+ * region/inference-profile prefixes (`eu.anthropic.claude-opus-5`).
+ */
+export function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
+	const parsed = parseAnthropicModel(getCanonicalModelId(modelId));
+	if (!parsed) return false;
+	if (parsed.kind === "fable") return true;
+	return parsed.kind === "opus" && semverGte(parsed.version, "4.7");
+}
+
 function anthropicModelHasRealXHighEffort<TApi extends Api>(model: ApiModel<TApi>): boolean {
 	if (model.api !== "anthropic-messages") return false;
 	const parsedModel = parseKnownModel(model.id);

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -3512,6 +3512,31 @@
 				"maxLevel": "max"
 			}
 		},
+		"claude-opus-5": {
+			"id": "claude-opus-5",
+			"name": "Anthropic Opus 5",
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"baseUrl": "https://api.anthropic.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "max"
+			}
+		},
 		"claude-sonnet-4-0": {
 			"id": "claude-sonnet-4-0",
 			"name": "Anthropic Sonnet 4 (latest)",

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -9,7 +9,11 @@
 
 import { $credentialEnv, $env, $flag, extractHttpStatusFromError, fetchWithRetry } from "@gajae-code/utils";
 import type { Effort } from "../model-thinking";
-import { mapEffortToAnthropicAdaptiveEffort, requireSupportedEffort } from "../model-thinking";
+import {
+	mapEffortToAnthropicAdaptiveEffort,
+	requireSupportedEffort,
+	supportsAdaptiveThinkingDisplay,
+} from "../model-thinking";
 import { calculateCost } from "../models";
 import type {
 	Api,
@@ -905,25 +909,6 @@ function buildAdditionalModelRequestFields(
 	}
 
 	return result;
-}
-
-/**
- * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
- * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
- * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
- * "omitted" — thinking tokens are billed but no content streams back — so it
- * must opt in like Opus 4.7+ (issue #2791).
- * Bedrock model ids are prefixed with region/inference-profile slugs (e.g.
- * `eu.anthropic.Anthropic model-opus-4-7-...`); the regex matches the `Anthropic model-opus-X-Y`
- * fragment regardless of prefix.
- */
-function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
-	if (/claude-fable-\d/.test(modelId)) return true;
-	const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
-	if (!match) return false;
-	const major = Number(match[1]);
-	const minor = Number(match[2]);
-	return major > 4 || (major === 4 && minor >= 7);
 }
 
 /**

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -19,7 +19,11 @@ import {
 	logger,
 	readSseEvents,
 } from "@gajae-code/utils";
-import { hasOpus47ApiRestrictions, mapEffortToAnthropicAdaptiveEffort } from "../model-thinking";
+import {
+	hasOpus47ApiRestrictions,
+	mapEffortToAnthropicAdaptiveEffort,
+	supportsAdaptiveThinkingDisplay,
+} from "../model-thinking";
 import { calculateCost } from "../models";
 import { isUsageLimitError } from "../rate-limit-utils";
 import { getEnvApiKey, OUTPUT_FALLBACK_BUFFER } from "../stream";
@@ -307,22 +311,6 @@ type AnthropicSamplingParams = MessageCreateParamsStreaming & {
 
 const ANTHROPIC_STOP_SEQUENCES_MAX = 4;
 let warnedStopSequencesTrim = false;
-
-/**
- * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
- * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
- * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
- * "omitted" — thinking tokens are billed but no content streams back — so it
- * must opt in like Opus 4.7+ (issue #2791).
- */
-function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
-	if (/claude-fable-\d/.test(modelId)) return true;
-	const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
-	if (!match) return false;
-	const major = Number(match[1]);
-	const minor = Number(match[2]);
-	return major > 4 || (major === 4 && minor >= 7);
-}
 
 const ANTHROPIC_PROVIDER_SESSION_STATE_KEY = "anthropic-messages";
 

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1166,6 +1166,44 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.output_config).toEqual({ effort: "high" });
 	});
 
+	it("requests summarized adaptive thinking for Opus 5 dateless ids", async () => {
+		const payload = (await captureAnthropicPayload(
+			{
+				...ANTHROPIC_MODEL,
+				id: "claude-opus-5",
+				name: "Anthropic Opus 5",
+				thinking: {
+					mode: "anthropic-adaptive",
+					minLevel: Effort.Minimal,
+					maxLevel: Effort.Max,
+				},
+			},
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				thinkingEnabled: true,
+				reasoning: Effort.Max,
+				temperature: 0.2,
+				topP: 0.3,
+				topK: 4,
+			},
+		)) as {
+			temperature?: number;
+			top_p?: number;
+			top_k?: number;
+			thinking?: { type?: string; display?: string };
+			output_config?: { effort?: string };
+		};
+
+		expect(payload.temperature).toBeUndefined();
+		expect(payload.top_p).toBeUndefined();
+		expect(payload.top_k).toBeUndefined();
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toEqual({ effort: "max" });
+	});
+
 	it("maps Opus max reasoning to Anthropic adaptive max", async () => {
 		const payload = (await captureAnthropicPayload(
 			{

--- a/packages/ai/test/issue-1373-repro.test.ts
+++ b/packages/ai/test/issue-1373-repro.test.ts
@@ -100,6 +100,16 @@ describe("issue #1373: Bedrock Claude thinkingDisplay", () => {
 		});
 	});
 
+	it("defaults adaptive thinking to display=summarized on Opus 5 dateless ids", async () => {
+		const payload = await captureBedrockPayload(adaptiveModel("us.anthropic.claude-opus-5"), {
+			reasoning: Effort.High,
+		});
+		expect(payload.additionalModelRequestFields?.thinking).toMatchObject({
+			type: "adaptive",
+			display: "summarized",
+		});
+	});
+
 	it("respects explicit thinkingDisplay='omitted' on Opus 4.7+", async () => {
 		const payload = await captureBedrockPayload(adaptiveModel("eu.anthropic.claude-opus-4-7"), {
 			reasoning: Effort.High,

--- a/packages/ai/test/issue-830-repro.test.ts
+++ b/packages/ai/test/issue-830-repro.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { Effort } from "../src/model-thinking";
 import { getBundledModel } from "../src/models";
 import { DEFAULT_MODEL_PER_PROVIDER, PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
 import { MODELS_DEV_PROVIDER_DESCRIPTORS } from "../src/provider-models/openai-compat";
@@ -76,5 +77,30 @@ describe("Anthropic Sonnet 5 model catalog support", () => {
 		expect(sonnet5?.api).toBe("anthropic-messages");
 		expect(sonnet5?.reasoning).toBe(true);
 		expect(sonnet46?.api).toBe("anthropic-messages");
+	});
+});
+
+describe("Anthropic Opus 5 model catalog support", () => {
+	test("registers Opus 5 with published Anthropic limits and pricing", () => {
+		const opus5 = getBundledModel("anthropic", "claude-opus-5");
+		expect(opus5?.api).toBe("anthropic-messages");
+		expect(opus5?.baseUrl).toBe("https://api.anthropic.com");
+		expect(opus5?.reasoning).toBe(true);
+		expect(opus5?.input).toEqual(["text", "image"]);
+		expect(opus5?.contextWindow).toBe(1_000_000);
+		expect(opus5?.maxTokens).toBe(128_000);
+		expect(opus5?.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
+		expect(opus5?.thinking).toEqual({
+			mode: "anthropic-adaptive",
+			minLevel: Effort.Minimal,
+			maxLevel: Effort.Max,
+		});
+	});
+
+	test("keeps the Anthropic provider default and older Opus entries untouched", () => {
+		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "anthropic");
+		expect(descriptor?.defaultModel).toBe("claude-sonnet-5");
+		expect(DEFAULT_MODEL_PER_PROVIDER.anthropic).toBe("claude-sonnet-5");
+		expect(getBundledModel("anthropic", "claude-opus-4-8")?.api).toBe("anthropic-messages");
 	});
 });

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -5,10 +5,12 @@ import {
 	clampThinkingLevelForModel,
 	Effort,
 	enrichModelThinking,
+	hasOpus47ApiRestrictions,
 	linkOpenAIPromotionTargets,
 	mapEffortToAnthropicAdaptiveEffort,
 	mapEffortToGoogleThinkingLevel,
 	requireSupportedEffort,
+	supportsAdaptiveThinkingDisplay,
 } from "@gajae-code/ai/model-thinking";
 import type { Api, Model, Provider, ThinkingControlMode } from "@gajae-code/ai/types";
 
@@ -183,6 +185,64 @@ describe("model thinking metadata", () => {
 		expect(fableBedrock.thinking?.maxLevel).toBe(Effort.High);
 		expect(mapEffortToAnthropicAdaptiveEffort(fableBedrock, Effort.High)).toBe("high");
 		expect(() => mapEffortToAnthropicAdaptiveEffort(fableBedrock, Effort.XHigh)).toThrow(/not supported/);
+	});
+
+	it("classifies dateless Opus 5 ids as adaptive thinking with xhigh + max support", () => {
+		const opus5 = createModel({
+			id: "claude-opus-5",
+			api: "anthropic-messages",
+			provider: "anthropic",
+		});
+		const opus5Bedrock = createModel({
+			id: "us.anthropic.claude-opus-5",
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+		});
+
+		expect(opus5.thinking).toEqual({
+			mode: "anthropic-adaptive",
+			minLevel: Effort.Minimal,
+			maxLevel: Effort.Max,
+		});
+		expect(mapEffortToAnthropicAdaptiveEffort(opus5, Effort.XHigh)).toBe("xhigh");
+		expect(mapEffortToAnthropicAdaptiveEffort(opus5, Effort.Max)).toBe("max");
+
+		// Bedrock Converse lacks the Messages-only xhigh preset (same split as Opus 4.7+).
+		expect(opus5Bedrock.thinking?.mode).toBe("anthropic-adaptive");
+		expect(opus5Bedrock.thinking?.maxLevel).toBe(Effort.Max);
+		expect(() => mapEffortToAnthropicAdaptiveEffort(opus5Bedrock, Effort.XHigh)).toThrow(/not supported/);
+		expect(mapEffortToAnthropicAdaptiveEffort(opus5Bedrock, Effort.Max)).toBe("max");
+	});
+
+	it("reports Opus 4.7+ restrictions and adaptive display for single-segment Opus versions", () => {
+		// Both Anthropic transports gate `display: "summarized"` on this predicate.
+		// A regex expecting `claude-opus-<major>-<minor>` never matched the dateless
+		// `claude-opus-5` id, so Opus 5 thinking was billed and never displayed.
+		expect(hasOpus47ApiRestrictions("claude-opus-5")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-5")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("us.anthropic.claude-opus-5")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-7")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-fable-5")).toBe(true);
+		// Opus 4.6 and every Sonnet reject the field.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-6")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-sonnet-5")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("gpt-5.6-sol")).toBe(false);
+	});
+
+	it("resolves adaptive display for dot-form ids and rejects date-suffixed Opus 4", () => {
+		// Gateways publish dot-form ids (`claude-opus-4.8`), which the dash-only
+		// regex never matched: Copilot / Vercel AI Gateway / ZenMux Opus 4.7+ were
+		// billed for adaptive thinking that streamed no content.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.8")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("anthropic/claude-opus-4.7-fast")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.6")).toBe(false);
+		// `claude-opus-4-20250514` is dated Opus 4.0, not version 4.20250514. The
+		// dash-only regex read the date as the minor version and misclassified it
+		// as Opus 4.7+, which also suppressed the interleaved-thinking beta these
+		// budget-thinking models need.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-20250514")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("us.anthropic.claude-opus-4-20250514-v1:0")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-1-20250805")).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -526,10 +526,16 @@ describe("ModelRegistry", () => {
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
-			const opusVariants = registry.getCanonicalVariants("claude-opus-4-8");
+			// `-latest` collapses onto the highest bundled version of the family,
+			// so the Opus target tracks the newest catalog entry (currently Opus 5).
+			const opusVariants = registry.getCanonicalVariants("claude-opus-5");
+			const supersededOpusVariants = registry.getCanonicalVariants("claude-opus-4-8");
 			const haikuVariants = registry.getCanonicalVariants("claude-haiku-4-5");
 
 			expect(opusVariants.some(variant => variant.selector === "demo/anthropic/claude-opus-latest")).toBe(true);
+			expect(supersededOpusVariants.some(variant => variant.selector === "demo/anthropic/claude-opus-latest")).toBe(
+				false,
+			);
 			expect(haikuVariants.some(variant => variant.selector === "demo/anthropic/claude-haiku-latest")).toBe(true);
 			expect(
 				registry


### PR DESCRIPTION
## What

Adds Anthropic **Claude Opus 5** support:

1. Registers `anthropic/claude-opus-5` in the bundled catalog (`packages/ai/src/models.json`).
2. Repairs the id-shape parsing that gated adaptive thinking `display`, which made Opus 5 — and, as found during self-review, three id classes already in the catalog — **billed but never displayed**.

Defaults are untouched: the Anthropic provider default stays `claude-sonnet-5`, and no built-in model profile (`claude-opus`, `opus-codex`, `fable-opus-codex`, …) changes.

> **Correction to the first revision of this description.** It claimed "behavior for existing ids is unchanged". That was wrong, and I replayed the pre-change regex against the catalog to quantify it: 12 of 511 bundled `anthropic-messages` / `bedrock-converse-stream` ids change result. All 12 are corrections, enumerated below.

## Authoritative field sources

Every catalog field comes from Anthropic's published documentation — no estimates:

| Field | Value | Source |
| --- | --- | --- |
| Claude API ID / alias | `claude-opus-5` | https://platform.claude.com/docs/en/about-claude/models/overview |
| Context window | 1,000,000 | https://platform.claude.com/docs/en/about-claude/models/overview |
| Max output | 128,000 | https://platform.claude.com/docs/en/about-claude/models/overview |
| Input modalities | text + image | https://platform.claude.com/docs/en/about-claude/models/overview |
| Adaptive thinking | Yes (extended `thinking.type: "enabled"`: No) | https://platform.claude.com/docs/en/about-claude/models/overview |
| Input / Output | $5 / $25 per MTok | https://platform.claude.com/docs/en/about-claude/pricing |
| Cache read / 5m cache write | $0.50 / $6.25 per MTok | https://platform.claude.com/docs/en/about-claude/pricing |

Availability is GA on the Claude API, and the upstream catalog agrees: `models.dev` publishes `anthropic/claude-opus-5` with the same limits and pricing (`release_date` / `last_updated` `2026-07-24`), effort values `low…max`. The entry mirrors the deterministic shape the generator produces for `claude-opus-4-8` / `claude-opus-4-7`; it is identical to the Opus 4.8 entry apart from `id`/`name`.

## The parsing repair

`supportsAdaptiveThinkingDisplay` was duplicated verbatim in `providers/anthropic.ts` and `providers/amazon-bedrock.ts`, both gating on an id shape:

```ts
const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
```

Both copies are replaced by one exported predicate in `model-thinking.ts` that parses the Anthropic model version — the same authority `hasOpus47ApiRestrictions` already uses — so region-prefixed Bedrock ids and any future dateless id are handled once, in one place.

Behavior delta, measured by replaying the old regex against every bundled adaptive-capable entry (511 ids → 12 diffs):

| Class | Ids | Before → After | Effect |
| --- | --- | --- | --- |
| Dateless | `anthropic/claude-opus-5`, `us.anthropic.claude-opus-5` | `false` → `true` | Was inheriting Anthropic's `omitted` default: thinking tokens billed, no reasoning streamed (#2791 class). Now sends `display: "summarized"`. |
| Gateway dot-form | `github-copilot/claude-opus-4.7`, `…/claude-opus-4.8`, `vercel-ai-gateway/anthropic/claude-opus-4.{7,8}` + `-fast`, `zenmux/anthropic/claude-opus-4.{7,8}` (8 ids, all `anthropic-adaptive`) | `false` → `true` | Same silent-thinking bug on three gateways, because the regex demanded dash-separated versions. Now matches first-party Opus 4.7/4.8 behavior, and drops the redundant `interleaved-thinking-2025-05-14` beta. |
| Date-suffixed Opus 4.0 | `anthropic/claude-opus-4-20250514`, `{us,eu}.anthropic.claude-opus-4-20250514-v1:0` (all `budget` mode) | `true` → `false` | The old regex read the date as the minor version (`minor = 20250514 ≥ 7`) and classified Opus 4.0 as Opus 4.7+, suppressing the `interleaved-thinking-2025-05-14` beta these budget-thinking models need. Now restored. |

Unaffected (verified): Opus 4.6 in both dash and dot form, every Sonnet/Haiku, `claude-opus-4-1-20250805`, `-latest` aliases (`getCanonicalModelId` only strips a `/` prefix — it does not resolve aliases), and non-Anthropic ids.

Reproduced before the fix (both transports emitted `{ type: "adaptive" }` with no `display`), green after:

```
✗ requests summarized adaptive thinking for Opus 5 dateless ids
✗ defaults adaptive thinking to display=summarized on Opus 5 dateless ids
```

## Tests

```
bun test packages/ai/test/model-thinking.test.ts \
         packages/ai/test/issue-830-repro.test.ts \
         packages/ai/test/issue-1373-repro.test.ts \
         packages/ai/test/anthropic-alignment.test.ts     # 87 pass / 0 fail
bun test packages/ai/test                                  # 1902 pass / 337 skip / 1 fail (pre-existing, see below)
bun test packages/coding-agent/test/model-registry.test.ts \
         packages/coding-agent/test/model-profiles-catalog.test.ts \
         packages/coding-agent/test/model-profile-activation.test.ts \
         packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts \
         packages/coding-agent/test/agent-session-profile-resume-default.test.ts \
         packages/coding-agent/test/model-registry-runtime-provider.test.ts \
         packages/coding-agent/test/model-selector-batch-thinking.test.ts   # 223 pass / 3 fail (pre-existing)
bun run check:tools        # biome + tsc (tools) clean
bun run check:public-sync  # in sync
bun run check:schemas      # clean
WRITE_ARCHITECTURE_2383_EVAL=1 bun test packages/ai/test/anthropic-cache-eval.integration.test.ts
```

New coverage locks each class: dateless Opus 5 on Messages and Bedrock (request payloads), dot-form `claude-opus-4.8` / `anthropic/claude-opus-4.7-fast`, date-suffixed `claude-opus-4-20250514` (plus the Bedrock form and `claude-opus-4-1-20250805`), Opus 4.6 / Sonnet 5 / non-Anthropic negatives, effort mapping (`xhigh` + `max` on Messages, `max`-only on Bedrock), and the catalog fields with defaults asserted unchanged.

`artifacts/architecture-2383-eval.json` is refreshed because the evidence binds the blob OID / SHA-256 of `packages/ai/src/providers/anthropic.ts`, using the derivation command recorded in the artifact (same pattern as #2794 / #2940 / #3046).

One expected test update: `model-registry.test.ts` "collapses anthropic latest aliases into the best upstream claude family id" now targets `claude-opus-5`. The alias resolver is unchanged — `claude-opus-latest` collapses onto the highest bundled Opus version, which is now Opus 5 — and the test additionally asserts the superseded `claude-opus-4-8` no longer collects that alias. Metadata impact is nil, since the Opus 5 entry is identical to Opus 4.8 apart from `id`/`name`.

Pre-existing failures on this machine, reproduced on an unmodified `dev` checkout and unrelated to this change:

- `packages/ai/test/auth-storage-if-absent.test.ts` — worker `stderr` assertion picks up Bun's `FORCE_COLOR`/`NO_COLOR` warning from the local environment.
- `packages/coding-agent/test/model-registry.test.ts` — two canonical-variant stickiness tests that resolve to `amazon-bedrock` because local AWS credentials are present.
- `packages/coding-agent/test/agent-session-profile-resume-default.test.ts` — activation-rollback test.

## Not included (deliberately)

- No default/profile changes: promoting Opus 5 into `claude-opus`, `opus-codex`, or the Anthropic provider default is a product judgment, so it is left to maintainers.
- No Bedrock / Vertex / Copilot / OpenRouter Opus 5 rows: those providers' entries come from catalog discovery, and this PR keeps the same footprint as the Sonnet 5 catalog addition (first-party `anthropic` entry only).
- No `-latest` pin: keeping `claude-opus-latest` on Opus 4.8 would mean hardcoding a per-model quality preference into a generic version-ordering resolver. Happy to follow up with an explicit pin list or catalog-level "preferred tier" metadata if you want that.
- `claude-mythos-5` (Anthropic's invitation-only Fable-5-spec sibling) is not parsed by `parseAnthropicModel`, which knows `opus|sonnet|fable`, so it would hit the same silent-thinking bug. It is absent from both `models.dev` and this catalog, so it is out of scope here — flagging it as a known follow-up.
- Fast mode (`speed: "fast"`, supported on Opus 5 per the pricing page) needs no client change — the transport forwards the flag without client-side model gating.
