### PR TITLE
feat: add Anthropic Opus 5 and adopt it in the built-in Opus profiles

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - Added first-class support for **OpenGateway by Sionic AI**, an OpenAI-compatible gateway. Registers the `opengateway` provider descriptor, `/login` OAuth entry (API-key paste validated against `https://apis.opengateway.ai/v1/models`), `OPENGATEWAY_API_KEY` environment resolution, and bundled `models.json` seed models. Models are discovered dynamically from the OpenAI-compatible `/v1/models` endpoint (base URL `https://apis.opengateway.ai/v1`).
+- Added **Claude Opus 5** (`claude-opus-5`) to the bundled `anthropic` model catalog: 1M context window, 128k max output, thinking on with the full effort ladder through `max`, and standard Opus pricing ($5/$25 per MTok, cache 0.5/6.25) — unchanged from Opus 4.8. As the newest Opus, it becomes the canonical target for the `claude-opus-latest` family alias.
 
 ## [0.11.8] - 2026-07-23
 

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -3512,6 +3512,31 @@
 				"maxLevel": "max"
 			}
 		},
+		"claude-opus-5": {
+			"id": "claude-opus-5",
+			"name": "Anthropic Opus 5",
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"baseUrl": "https://api.anthropic.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "max"
+			}
+		},
 		"claude-sonnet-4-0": {
 			"id": "claude-sonnet-4-0",
 			"name": "Anthropic Sonnet 4 (latest)",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- The built-in `Claude Opus`, `Opus + Codex`, and `Fable + Opus + Codex` model profiles now target **Claude Opus 5** (`claude-opus-5`) instead of Opus 4.8 for their Anthropic roles — the newest, same-priced Opus.
+
 ### Fixed
 
 - Interactive prompt cancellation now reaches API-key preflight through `ModelRegistry`, allowing aborted submissions to clear immediately even while a shared credential-usage request continues in the background.

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -100,11 +100,11 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		architect: "opencode-go/deepseek-v4-pro",
 	}),
 	profile("claude-opus", ["anthropic"], {
-		default: "anthropic/claude-opus-4-8:xhigh",
+		default: "anthropic/claude-opus-5:xhigh",
 		executor: "anthropic/claude-sonnet-5",
-		planner: "anthropic/claude-opus-4-8:low",
-		critic: "anthropic/claude-opus-4-8:high",
-		architect: "anthropic/claude-opus-4-8:xhigh",
+		planner: "anthropic/claude-opus-5:low",
+		critic: "anthropic/claude-opus-5:high",
+		architect: "anthropic/claude-opus-5:xhigh",
 	}),
 	profile("claude-fable", ["anthropic"], {
 		default: "anthropic/claude-fable-5:xhigh",
@@ -271,7 +271,7 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		critic: "alibaba-token-plan/qwen3.8-max-preview:xhigh",
 	}),
 	profile("opus-codex", ["anthropic", "openai-codex"], {
-		default: "anthropic/claude-opus-4-8:xhigh",
+		default: "anthropic/claude-opus-5:xhigh",
 		executor: "openai-codex/gpt-5.6-terra:low",
 		planner: "anthropic/claude-sonnet-5",
 		critic: "openai-codex/gpt-5.6-sol:xhigh",
@@ -287,8 +287,8 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 	profile("fable-opus-codex", ["anthropic", "openai-codex"], {
 		default: "anthropic/claude-fable-5:high",
 		executor: "openai-codex/gpt-5.6-terra:medium",
-		planner: "anthropic/claude-opus-4-8:medium",
-		critic: "anthropic/claude-opus-4-8:high",
+		planner: "anthropic/claude-opus-5:medium",
+		critic: "anthropic/claude-opus-5:high",
 		architect: "openai-codex/gpt-5.6-sol:xhigh",
 	}),
 ];

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -91,6 +91,11 @@ function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelP
 				minLevel: ThinkingLevel.Low,
 				maxLevel: ThinkingLevel.XHigh,
 			}),
+			model("anthropic", "claude-opus-5", {
+				mode: "effort",
+				minLevel: ThinkingLevel.Low,
+				maxLevel: ThinkingLevel.Max,
+			}),
 			model("anthropic", "claude-fable-5", {
 				mode: "effort",
 				minLevel: ThinkingLevel.Low,
@@ -564,7 +569,7 @@ describe("model profile activation", () => {
 		[
 			"opus-codex",
 			{
-				default: "anthropic/claude-opus-4-8:xhigh",
+				default: "anthropic/claude-opus-5:xhigh",
 				executor: "openai-codex/gpt-5.6-terra:low",
 				planner: "anthropic/claude-sonnet-5",
 				critic: "openai-codex/gpt-5.6-sol:xhigh",
@@ -586,8 +591,8 @@ describe("model profile activation", () => {
 			{
 				default: "anthropic/claude-fable-5:high",
 				executor: "openai-codex/gpt-5.6-terra:medium",
-				planner: "anthropic/claude-opus-4-8:medium",
-				critic: "anthropic/claude-opus-4-8:high",
+				planner: "anthropic/claude-opus-5:medium",
+				critic: "anthropic/claude-opus-5:high",
 				architect: "openai-codex/gpt-5.6-sol:xhigh",
 			},
 		],

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -67,11 +67,11 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		name: "claude-opus",
 		requiredProviders: ["anthropic"],
 		mapping: {
-			default: "anthropic/claude-opus-4-8:xhigh",
+			default: "anthropic/claude-opus-5:xhigh",
 			executor: "anthropic/claude-sonnet-5",
-			planner: "anthropic/claude-opus-4-8:low",
-			critic: "anthropic/claude-opus-4-8:high",
-			architect: "anthropic/claude-opus-4-8:xhigh",
+			planner: "anthropic/claude-opus-5:low",
+			critic: "anthropic/claude-opus-5:high",
+			architect: "anthropic/claude-opus-5:xhigh",
 		},
 	},
 	{
@@ -320,7 +320,7 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		name: "opus-codex",
 		requiredProviders: ["anthropic", "openai-codex"],
 		mapping: {
-			default: "anthropic/claude-opus-4-8:xhigh",
+			default: "anthropic/claude-opus-5:xhigh",
 			executor: "openai-codex/gpt-5.6-terra:low",
 			planner: "anthropic/claude-sonnet-5",
 			critic: "openai-codex/gpt-5.6-sol:xhigh",
@@ -344,8 +344,8 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		mapping: {
 			default: "anthropic/claude-fable-5:high",
 			executor: "openai-codex/gpt-5.6-terra:medium",
-			planner: "anthropic/claude-opus-4-8:medium",
-			critic: "anthropic/claude-opus-4-8:high",
+			planner: "anthropic/claude-opus-5:medium",
+			critic: "anthropic/claude-opus-5:high",
 			architect: "openai-codex/gpt-5.6-sol:xhigh",
 		},
 	},
@@ -390,7 +390,7 @@ function substituteCodexFamily(selector: string, source: "sol" | "terra", target
 
 const fixedNonCodexComboMappings: Record<string, Partial<Record<Role, string>>> = {
 	"opus-codex": {
-		default: "anthropic/claude-opus-4-8:xhigh",
+		default: "anthropic/claude-opus-5:xhigh",
 		planner: "anthropic/claude-sonnet-5",
 	},
 	"codex-opencodego": {
@@ -400,8 +400,8 @@ const fixedNonCodexComboMappings: Record<string, Partial<Record<Role, string>>> 
 	},
 	"fable-opus-codex": {
 		default: "anthropic/claude-fable-5:high",
-		planner: "anthropic/claude-opus-4-8:medium",
-		critic: "anthropic/claude-opus-4-8:high",
+		planner: "anthropic/claude-opus-5:medium",
+		critic: "anthropic/claude-opus-5:high",
 	},
 };
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -526,7 +526,8 @@ describe("ModelRegistry", () => {
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
-			const opusVariants = registry.getCanonicalVariants("claude-opus-4-8");
+			// opus-5 is the newest opus, so the `claude-opus-latest` alias collapses into it.
+			const opusVariants = registry.getCanonicalVariants("claude-opus-5");
 			const haikuVariants = registry.getCanonicalVariants("claude-haiku-4-5");
 
 			expect(opusVariants.some(variant => variant.selector === "demo/anthropic/claude-opus-latest")).toBe(true);


### PR DESCRIPTION
Supersedes #3096 (closed on a stale base). Rebased onto current `dev` (`478d5ccc`) with all three signed blockers addressed.

## What

Registers **Claude Opus 5** (`claude-opus-5`) in the bundled `anthropic` catalog and points the built-in Opus profiles at it.

## Specs (per Anthropic's Opus 5 docs)

1M context (default = max), 128k output, thinking on by default (`anthropic-adaptive`), full effort ladder through `max`, text+image, pricing `$5`/`$25` per MTok + cache `0.5`/`6.25` (unchanged from Opus 4.8). Mirrors the sibling `claude-opus-4-8` / `claude-sonnet-5` entries exactly.

## Blockers from the #3096 review, resolved

**1. Stale base / Telegram daemon generation guard.** Rebased onto current `dev`, which now carries the daemon-generation authority fixes + regenerated Telegram baseline manifest (`b9a12ac0`, `bb070682`, `66db4459`, `60c50373`, `214e1bfe`). That failure was inherited drift from the old base, not introduced here, and clears on the current base.

**2. Generated `models.json`.** `claude-opus-5` is a first-party Anthropic model not published on public `models.dev` — like this repo’s other ahead-of-models.dev entries (`claude-opus-4-8`, `claude-sonnet-5`). `scripts/generate-models.ts` merges the existing `models.json` as the seed for anything not fetched dynamically (its comment: *“ad-hoc model additions all persist through the existing models.json seed”*), so the seed entry is the canonical path for a first-party model that precedes its models.dev listing; an in-house regeneration reproduces it and public-models.dev priority never clobbers it. The entry is generator-shaped (identical field order to `claude-opus-4-8`, correct alphabetical key placement, passes `applyGeneratedModelPolicies` / `applyClaudeOpusVisionCorrections` unchanged). I did not run the generator in a contributor environment because against public models.dev it would strip the repo’s ahead-of-release catalog — happy to move the entry to a static source-of-truth file if one exists.

**3. Profile adoption + tests/changelog.** Built-in `claude-opus` / `opus-codex` / `fable-opus-codex` now target `claude-opus-5`; the canonical `claude-opus-latest` family alias collapses into it. Profile catalog + activation tests (opus-5 fixture registered) + `model-registry` canonical test + both package changelogs updated.

## Verification

`getBundledModel(“anthropic”,“claude-opus-5”)` resolves; `issue-830-repro`, `models-lazy`, `model-thinking`, `model-profiles-catalog`, `model-profile-activation`, and the `model-registry` canonical test are green; anthropic default stays `claude-sonnet-5`; biome + tsc clean.