### PR TITLE
feat(orca): bundled Orca agent-status bridge over the pi hook protocol

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Orca terminal panes now get live GJC agent status: a bundled Orca status bridge detects the pane's agent-hook endpoint (`ORCA_PANE_KEY` / `ORCA_AGENT_HOOK_ENDPOINT`) and reports pi-protocol lifecycle events (working/done state, active tool and input, prompt, last assistant reply, session resume metadata, startup prefill) to Orca's `/hook/pi` receiver. Root pane-owning sessions only; delivery is latest-only and strictly best-effort, with a WSL→Windows curl fallback for split-loopback setups.
+
 ### Fixed
 
 - Interactive prompt cancellation now reaches API-key preflight through `ModelRegistry`, allowing aborted submissions to clear immediately even while a shared credential-usage request continues in the background.

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -164,6 +164,7 @@ import { getImageGenTools } from "../tools/image-gen";
 import { wrapToolWithMetaNotice } from "../tools/output-meta";
 import { guardToolForUltragoalAsk } from "../tools/ultragoal-ask-guard";
 import { EventBus } from "../utils/event-bus";
+import { createOrcaStatusBridge, shouldRegisterOrcaStatusBridge } from "../utils/orca-status-bridge";
 import { buildNamedToolChoice, buildNamedToolChoiceResult } from "../utils/tool-choice";
 import { buildWorkspaceTree, type WorkspaceTree } from "../workspace-tree";
 import {
@@ -1818,6 +1819,22 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 		} catch (error) {
 			logger.warn("Failed to load constrained GJC plugin hooks", { error });
+		}
+
+		// Orca terminal panes export a loopback agent-hook endpoint; the bridge
+		// reports pi-protocol status events so Orca shows live agent state for
+		// GJC sessions. Root pane-owning sessions only; strictly best-effort.
+		if (
+			shouldRegisterOrcaStatusBridge({
+				env: process.env,
+				taskDepth,
+				parentTaskPrefix: options.parentTaskPrefix,
+				currentAgentType: options.currentAgentType,
+			})
+		) {
+			inlineExtensions.push(async api => {
+				createOrcaStatusBridge(api);
+			});
 		}
 		let notificationCfg: NotificationConfig | undefined;
 		try {

--- a/packages/coding-agent/src/utils/orca-status-bridge.ts
+++ b/packages/coding-agent/src/utils/orca-status-bridge.ts
@@ -1,0 +1,413 @@
+/**
+ * Orca agent-status bridge.
+ *
+ * The Orca terminal exports a loopback agent-hook endpoint into every pane
+ * (`ORCA_AGENT_HOOK_ENDPOINT` / `ORCA_PANE_KEY`). Agents that POST lifecycle
+ * events to it get live status (working / done), tool activity, prompt, and
+ * last-reply previews in Orca's dashboard and pane badges.
+ *
+ * Orca has first-class support for the pi hook protocol (`/hook/pi`), which
+ * GJC speaks natively as a pi-lineage agent. This module ports the semantics
+ * of Orca's managed `orca-agent-status.ts` pi extension onto GJC's bundled
+ * extension surface, so GJC panes inside Orca report status without any
+ * filesystem extension discovery (which is quarantined) and without any
+ * Orca-side changes.
+ *
+ * Delivery is strictly best-effort: a missing, restarting, or slow Orca must
+ * never surface errors inside the session or delay the agent loop.
+ */
+
+import * as fs from "node:fs/promises";
+import { logger } from "@gajae-code/utils";
+import type {
+	AgentEndEvent,
+	BeforeAgentStartEvent,
+	ExtensionAPI,
+	ExtensionContext,
+	MessageEndEvent,
+	SessionStartEvent,
+	ToolCallEvent,
+	ToolExecutionEndEvent,
+	ToolExecutionStartEvent,
+} from "../extensibility/extensions";
+
+const ORCA_HOOK_PATH = "/hook/pi";
+const HOOK_POST_TIMEOUT_MS = 1000;
+/** Pane-scoped ownership marker shared with Orca's managed pi extension: child
+ * processes inherit the pane env, and only one process per pane may report. */
+const OWNERSHIP_ENV = "ORCA_PI_STATUS_OWNED";
+/** Startup editor prefill delivered by Orca when launching a pi-protocol agent. */
+const PREFILL_ENV = "ORCA_PI_PREFILL";
+const AGENT_END_IDLE_RECHECK_MS = 25;
+const AGENT_END_IDLE_RECHECK_MAX_MS = 250;
+const WINDOWS_CURL_PATH = "/mnt/c/Windows/System32/curl.exe";
+
+export interface OrcaHookCoords {
+	port: string | undefined;
+	token: string | undefined;
+	env: string;
+	version: string;
+}
+
+export interface OrcaStatusBridgeOptions {
+	/** Environment to read Orca coordinates from. Default: `process.env`. */
+	env?: NodeJS.ProcessEnv;
+	/** Fetch implementation. Default: global `fetch`. */
+	fetchImpl?: typeof fetch;
+	/** WSL runtime probe override (default: cached `/proc` sniff). */
+	isWslRuntime?: () => boolean;
+	/** Spawn seam for the WSL → Windows curl fallback. */
+	spawnCurl?: (command: string[], body: string) => void;
+}
+
+/**
+ * Parse an Orca endpoint file (`KEY=VALUE` POSIX env or `set KEY=VALUE`
+ * Windows cmd form; tolerates CRLF line endings).
+ */
+export function parseOrcaEndpointFile(contents: string): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const line of contents.split(/\r?\n/)) {
+		const match = line.match(/^(?:set\s+)?([A-Z0-9_]+)=(.*)$/);
+		if (match) out[match[1]] = match[2].replace(/\r$/, "");
+	}
+	return out;
+}
+
+/**
+ * Gate for registering the bridge on a session.
+ *
+ * Only the root interactive/print session of the pane-owning process reports:
+ * - requires an Orca pane identity in the environment;
+ * - helper/subagent sessions (task depth, parent prefix, role agent) stay
+ *   silent so in-process fan-out does not thrash the pane status;
+ * - a pane already owned by another process (inherited `ORCA_PI_STATUS_OWNED`)
+ *   stays with that owner.
+ */
+export function shouldRegisterOrcaStatusBridge(input: {
+	env: NodeJS.ProcessEnv;
+	taskDepth?: number;
+	parentTaskPrefix?: string;
+	currentAgentType?: string;
+}): boolean {
+	if (!input.env.ORCA_PANE_KEY) return false;
+	if ((input.taskDepth ?? 0) > 0 || input.parentTaskPrefix !== undefined || input.currentAgentType !== undefined) {
+		return false;
+	}
+	const owner = input.env[OWNERSHIP_ENV];
+	if (owner && owner !== String(process.pid)) return false;
+	return true;
+}
+
+/** Extract concatenated text parts from an assistant message for the dashboard
+ * preview; tool_use / reasoning parts are omitted (Orca renders tool activity
+ * from the dedicated tool events). */
+export function extractAssistantText(message: unknown): string {
+	if (!message || typeof message !== "object") return "";
+	const content = (message as { content?: unknown }).content;
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	let out = "";
+	for (const part of content) {
+		if (part && typeof part === "object" && (part as { type?: unknown }).type === "text") {
+			const text = (part as { text?: unknown }).text;
+			if (typeof text === "string") out += text;
+		}
+	}
+	return out;
+}
+
+interface PendingPost {
+	hookEventName: string;
+	extra: Record<string, unknown>;
+}
+
+/**
+ * Register the Orca status bridge on an extension API surface.
+ *
+ * Event mapping (GJC extension events → Orca `/hook/pi` payloads):
+ * - `session_start` → `session_start` (also applies `ORCA_PI_PREFILL`)
+ * - `before_agent_start` → `before_agent_start` + `prompt`
+ * - `agent_start` → `agent_start`
+ * - `tool_call` / `tool_execution_start` / `tool_execution_end` → same names
+ *   with `tool_name` / raw `tool_input` (Orca derives the preview server-side)
+ * - assistant `message_end` → `message_end` + visible `text`
+ * - `agent_end` → `agent_end`, deferred until `ctx.isIdle()` so queued
+ *   follow-up work keeps the pane in `working` instead of flapping to done.
+ */
+export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBridgeOptions = {}): void {
+	const env = options.env ?? process.env;
+	const fetchImpl = options.fetchImpl ?? fetch;
+	env[OWNERSHIP_ENV] = String(process.pid);
+
+	let sessionMetadata: Record<string, unknown> = {};
+	let warnedBadEndpoint = false;
+	// Latest-only delivery: a stalled Orca receiver must not queue up obsolete
+	// snapshots, and status posting must stay off the agent-loop critical path.
+	let activePost = false;
+	let pendingPost: PendingPost | null = null;
+	// Endpoint-file cache keyed by stat identity: re-reading on every event is
+	// cheap but re-parsing during streaming tool execution is wasteful.
+	let cachedEndpointKey = "";
+	let cachedEndpointValues: Record<string, string> | null = null;
+	let cachedIsWsl: boolean | null = null;
+	let cachedCurlAvailable: boolean | null = null;
+
+	function updateSessionMetadata(ctx: ExtensionContext): void {
+		const sessionId = ctx.sessionManager.getSessionId();
+		const sessionFile = ctx.sessionManager.getSessionFile();
+		sessionMetadata = sessionId
+			? { session_id: sessionId, ...(sessionFile ? { session_file: sessionFile } : {}) }
+			: {};
+	}
+
+	async function getPersistedSessionMetadata(): Promise<Record<string, unknown>> {
+		const sessionFile = sessionMetadata.session_file;
+		if (typeof sessionFile !== "string" || !sessionFile) return {};
+		try {
+			// GJC publishes the planned session path before creating the transcript;
+			// recheck on every post so the first completed turn becomes resumable.
+			return (await Bun.file(sessionFile).exists()) ? sessionMetadata : {};
+		} catch {
+			return {};
+		}
+	}
+
+	async function readEndpointFile(): Promise<Record<string, string> | null> {
+		const endpointPath = env.ORCA_AGENT_HOOK_ENDPOINT;
+		if (!endpointPath) return null;
+		try {
+			const stat = await fs.stat(endpointPath);
+			const cacheKey = `${stat.mtimeMs}:${stat.size}:${stat.ino}`;
+			if (cacheKey === cachedEndpointKey && cachedEndpointValues) return cachedEndpointValues;
+			const contents = await Bun.file(endpointPath).text();
+			cachedEndpointValues = parseOrcaEndpointFile(contents);
+			cachedEndpointKey = cacheKey;
+			return cachedEndpointValues;
+		} catch (error) {
+			cachedEndpointKey = "";
+			cachedEndpointValues = null;
+			const code = (error as { code?: string } | null)?.code;
+			if (code !== "ENOENT" && !warnedBadEndpoint) {
+				warnedBadEndpoint = true;
+				logger.warn("Orca status bridge failed to read hook endpoint file", {
+					path: endpointPath,
+					error: String(error),
+				});
+			}
+			return null;
+		}
+	}
+
+	async function resolveHookCoords(): Promise<OrcaHookCoords> {
+		const fileEnv = (await readEndpointFile()) ?? {};
+		return {
+			port: fileEnv.ORCA_AGENT_HOOK_PORT || env.ORCA_AGENT_HOOK_PORT,
+			token: fileEnv.ORCA_AGENT_HOOK_TOKEN || env.ORCA_AGENT_HOOK_TOKEN,
+			env: fileEnv.ORCA_AGENT_HOOK_ENV || env.ORCA_AGENT_HOOK_ENV || "",
+			version: fileEnv.ORCA_AGENT_HOOK_VERSION || env.ORCA_AGENT_HOOK_VERSION || "",
+		};
+	}
+
+	function isWslRuntime(): boolean {
+		if (options.isWslRuntime) return options.isWslRuntime();
+		if (cachedIsWsl !== null) return cachedIsWsl;
+		cachedIsWsl = Boolean(env.WSL_DISTRO_NAME);
+		return cachedIsWsl;
+	}
+
+	// WSL loopback is not the Windows loopback, so a WSL-side POST cannot reach
+	// Orca. curl.exe runs on the Windows side, where 127.0.0.1 IS the listener
+	// Orca binds. Fire-and-forget: blocking on the spawn would stall the TUI.
+	async function postViaWindowsCurl(url: string, token: string, body: string): Promise<void> {
+		const command = [
+			WINDOWS_CURL_PATH,
+			"-sS",
+			// The spawn is detached from the event loop, so these bounds size a
+			// background process, not TUI latency; WSL→Win32 connects can be slow.
+			"--connect-timeout",
+			"3",
+			"--max-time",
+			"10",
+			"--noproxy",
+			"127.0.0.1",
+			"-o",
+			"NUL",
+			"-X",
+			"POST",
+			"-H",
+			"Content-Type: application/json",
+			"-H",
+			`X-Orca-Agent-Hook-Token: ${token}`,
+			"--data-binary",
+			"@-",
+			url,
+		];
+		if (options.spawnCurl) {
+			options.spawnCurl(command, body);
+			return;
+		}
+		if (cachedCurlAvailable === null) {
+			cachedCurlAvailable = await Bun.file(WINDOWS_CURL_PATH)
+				.exists()
+				.catch(() => false);
+		}
+		if (!cachedCurlAvailable) return;
+		try {
+			const child = Bun.spawn(command, { stdin: "pipe", stdout: "ignore", stderr: "ignore" });
+			child.stdin.write(body);
+			await child.stdin.end();
+			child.unref();
+		} catch {
+			// Best-effort bridge; a failed spawn must not surface in the session.
+		}
+	}
+
+	async function postOnce(hookEventName: string, extra: Record<string, unknown>): Promise<void> {
+		const coords = await resolveHookCoords();
+		const paneKey = env.ORCA_PANE_KEY;
+		if (!coords.port || !coords.token || !paneKey) return;
+		const url = `http://127.0.0.1:${coords.port}${ORCA_HOOK_PATH}`;
+		const body = JSON.stringify({
+			paneKey,
+			launchToken: env.ORCA_AGENT_LAUNCH_TOKEN || "",
+			tabId: env.ORCA_TAB_ID || "",
+			worktreeId: env.ORCA_WORKTREE_ID || "",
+			env: coords.env,
+			version: coords.version,
+			payload: { hook_event_name: hookEventName, ...(await getPersistedSessionMetadata()), ...extra },
+		});
+		try {
+			await fetchImpl(url, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"X-Orca-Agent-Hook-Token": coords.token,
+				},
+				body,
+				signal: AbortSignal.timeout(HOOK_POST_TIMEOUT_MS),
+			});
+		} catch {
+			// Status reporting must never fail the run because Orca is unavailable
+			// or restarting; on WSL fall through to the Windows-side listener.
+			if (!isWslRuntime()) return;
+			await postViaWindowsCurl(url, coords.token, body);
+		}
+	}
+
+	function drainPosts(): void {
+		if (activePost || !pendingPost) return;
+		const next = pendingPost;
+		pendingPost = null;
+		activePost = true;
+		void postOnce(next.hookEventName, next.extra)
+			.catch(() => {})
+			.finally(() => {
+				activePost = false;
+				drainPosts();
+			});
+	}
+
+	function post(hookEventName: string, extra: Record<string, unknown> = {}): void {
+		pendingPost = { hookEventName, extra };
+		drainPosts();
+	}
+
+	function applyStartupPrefill(ctx: ExtensionContext): void {
+		const prefill = env[PREFILL_ENV];
+		if (!prefill || !ctx.hasUI) return;
+		delete env[PREFILL_ENV];
+		try {
+			ctx.ui.setEditorText(prefill);
+		} catch {
+			// Prefill is a convenience; ignore hosts without an editor surface.
+		}
+	}
+
+	// GJC stays non-idle across retry/compaction/queued follow-up work, so a
+	// bare agent_end may not be a turn boundary yet. Defer the done post until
+	// the session is actually idle, with a capped exponential recheck.
+	let agentEndReported = false;
+	let agentEndIdleRecheckMs = AGENT_END_IDLE_RECHECK_MS;
+	let pendingAgentEndCheck: ReturnType<typeof setTimeout> | null = null;
+	let pendingAgentEndContext: Pick<ExtensionContext, "isIdle"> | null = null;
+
+	function clearPendingAgentEndCheck(): void {
+		if (pendingAgentEndCheck !== null) clearTimeout(pendingAgentEndCheck);
+		pendingAgentEndCheck = null;
+		pendingAgentEndContext = null;
+	}
+
+	function postAgentEndOnce(): void {
+		if (agentEndReported) return;
+		agentEndReported = true;
+		post("agent_end");
+	}
+
+	function checkPendingAgentEnd(): void {
+		pendingAgentEndCheck = null;
+		const ctx = pendingAgentEndContext;
+		if (!ctx || agentEndReported) {
+			pendingAgentEndContext = null;
+			return;
+		}
+		try {
+			if (ctx.isIdle()) {
+				pendingAgentEndContext = null;
+				postAgentEndOnce();
+				return;
+			}
+		} catch {
+			pendingAgentEndContext = null;
+			return;
+		}
+		pendingAgentEndCheck = setTimeout(checkPendingAgentEnd, agentEndIdleRecheckMs);
+		pendingAgentEndCheck.unref?.();
+		agentEndIdleRecheckMs = Math.min(agentEndIdleRecheckMs * 2, AGENT_END_IDLE_RECHECK_MAX_MS);
+	}
+
+	pi.on("session_start", (_event: SessionStartEvent, ctx: ExtensionContext) => {
+		updateSessionMetadata(ctx);
+		applyStartupPrefill(ctx);
+		post("session_start");
+	});
+
+	pi.on("before_agent_start", (event: BeforeAgentStartEvent) => {
+		post("before_agent_start", { prompt: event.prompt ?? "" });
+	});
+
+	pi.on("agent_start", () => {
+		clearPendingAgentEndCheck();
+		agentEndReported = false;
+		post("agent_start");
+	});
+
+	pi.on("tool_call", (event: ToolCallEvent) => {
+		post("tool_call", { tool_name: event.toolName, tool_input: event.input });
+	});
+
+	pi.on("tool_execution_start", (event: ToolExecutionStartEvent) => {
+		post("tool_execution_start", { tool_name: event.toolName, tool_input: event.args });
+	});
+
+	pi.on("tool_execution_end", (event: ToolExecutionEndEvent) => {
+		post("tool_execution_end", { tool_name: event.toolName });
+	});
+
+	// Capture the assistant's final text on each completed message so the
+	// dashboard preview reflects the latest reply before agent_end fires.
+	pi.on("message_end", (event: MessageEndEvent) => {
+		const message = event.message as { role?: unknown };
+		if (message?.role !== "assistant") return;
+		const text = extractAssistantText(event.message);
+		if (!text) return;
+		post("message_end", { role: "assistant", text });
+	});
+
+	pi.on("agent_end", (_event: AgentEndEvent, ctx: ExtensionContext) => {
+		clearPendingAgentEndCheck();
+		agentEndIdleRecheckMs = AGENT_END_IDLE_RECHECK_MS;
+		pendingAgentEndContext = ctx;
+		pendingAgentEndCheck = setTimeout(checkPendingAgentEnd, 0);
+		pendingAgentEndCheck.unref?.();
+	});
+}

--- a/packages/coding-agent/test/orca-status-bridge.test.ts
+++ b/packages/coding-agent/test/orca-status-bridge.test.ts
@@ -1,0 +1,377 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "../src/extensibility/extensions";
+import {
+	createOrcaStatusBridge,
+	extractAssistantText,
+	parseOrcaEndpointFile,
+	shouldRegisterOrcaStatusBridge,
+} from "../src/utils/orca-status-bridge";
+
+type ExtensionEventHandler = (event: unknown, ctx: ExtensionContext) => unknown;
+
+function captureHandlers(): { api: ExtensionAPI; handlers: Map<string, ExtensionEventHandler> } {
+	const handlers = new Map<string, ExtensionEventHandler>();
+	const api = {
+		on(event: string, handler: ExtensionEventHandler) {
+			handlers.set(event, handler);
+		},
+	} as unknown as ExtensionAPI;
+	return { api, handlers };
+}
+
+function fakeContext(
+	overrides: Partial<{ isIdle: () => boolean; hasUI: boolean; setEditorText: (text: string) => void }> = {},
+): ExtensionContext {
+	return {
+		hasUI: overrides.hasUI ?? false,
+		ui: { setEditorText: overrides.setEditorText ?? (() => {}) },
+		sessionManager: {
+			getSessionId: () => "orca-test-session",
+			getSessionFile: () => undefined,
+		},
+		isIdle: overrides.isIdle ?? (() => true),
+	} as unknown as ExtensionContext;
+}
+
+interface ReceivedPost {
+	url: string;
+	token: string | null;
+	body: {
+		paneKey: string;
+		tabId: string;
+		worktreeId: string;
+		payload: Record<string, unknown>;
+	};
+}
+
+interface HookReceiver {
+	port: number;
+	received: ReceivedPost[];
+	nextDelivery: () => Promise<ReceivedPost>;
+	/** When set, holds responses open until released (for queue-collapse tests). */
+	hold: boolean;
+	releaseHeld: () => void;
+	stop: () => void;
+}
+
+function startHookReceiver(): HookReceiver {
+	const received: ReceivedPost[] = [];
+	let waiters: Array<(post: ReceivedPost) => void> = [];
+	let heldReleases: Array<() => void> = [];
+	const receiver: HookReceiver = {
+		port: 0,
+		received,
+		hold: false,
+		nextDelivery: () => {
+			const { promise, resolve } = Promise.withResolvers<ReceivedPost>();
+			waiters.push(resolve);
+			return promise;
+		},
+		releaseHeld: () => {
+			const releases = heldReleases;
+			heldReleases = [];
+			for (const release of releases) release();
+		},
+		stop: () => server.stop(true),
+	};
+	const server = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0,
+		fetch: async request => {
+			const post: ReceivedPost = {
+				url: new URL(request.url).pathname,
+				token: request.headers.get("X-Orca-Agent-Hook-Token"),
+				body: (await request.json()) as ReceivedPost["body"],
+			};
+			received.push(post);
+			const pendingWaiters = waiters;
+			waiters = [];
+			for (const waiter of pendingWaiters) waiter(post);
+			if (receiver.hold) {
+				const { promise, resolve } = Promise.withResolvers<void>();
+				heldReleases.push(resolve);
+				await promise;
+			}
+			return new Response("ok");
+		},
+	});
+	if (server.port === undefined) throw new Error("Hook receiver failed to bind a port.");
+	receiver.port = server.port;
+	return receiver;
+}
+
+function bridgeEnv(receiver: HookReceiver, extra: Record<string, string> = {}): NodeJS.ProcessEnv {
+	return {
+		ORCA_PANE_KEY: "tab-1:leaf-1",
+		ORCA_TAB_ID: "tab-1",
+		ORCA_WORKTREE_ID: "repo::wt",
+		ORCA_AGENT_HOOK_PORT: String(receiver.port),
+		ORCA_AGENT_HOOK_TOKEN: "test-token",
+		...extra,
+	} as NodeJS.ProcessEnv;
+}
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	while (cleanups.length > 0) cleanups.pop()?.();
+});
+
+describe("parseOrcaEndpointFile", () => {
+	it("parses POSIX KEY=VALUE lines", () => {
+		expect(parseOrcaEndpointFile("ORCA_AGENT_HOOK_PORT=57343\nORCA_AGENT_HOOK_TOKEN=abc\n")).toEqual({
+			ORCA_AGENT_HOOK_PORT: "57343",
+			ORCA_AGENT_HOOK_TOKEN: "abc",
+		});
+	});
+
+	it("parses Windows `set KEY=VALUE` lines and strips CR", () => {
+		expect(parseOrcaEndpointFile("set ORCA_AGENT_HOOK_PORT=57343\r\nset ORCA_AGENT_HOOK_TOKEN=abc\r\n")).toEqual({
+			ORCA_AGENT_HOOK_PORT: "57343",
+			ORCA_AGENT_HOOK_TOKEN: "abc",
+		});
+	});
+
+	it("ignores non-matching lines", () => {
+		expect(parseOrcaEndpointFile("# comment\nlowercase=skip\nORCA_AGENT_HOOK_ENV=production")).toEqual({
+			ORCA_AGENT_HOOK_ENV: "production",
+		});
+	});
+});
+
+describe("shouldRegisterOrcaStatusBridge", () => {
+	it("requires an Orca pane identity", () => {
+		expect(shouldRegisterOrcaStatusBridge({ env: {} as NodeJS.ProcessEnv })).toBe(false);
+		expect(shouldRegisterOrcaStatusBridge({ env: { ORCA_PANE_KEY: "t:l" } as NodeJS.ProcessEnv })).toBe(true);
+	});
+
+	it("stays silent for helper and subagent sessions", () => {
+		const env = { ORCA_PANE_KEY: "t:l" } as NodeJS.ProcessEnv;
+		expect(shouldRegisterOrcaStatusBridge({ env, taskDepth: 1 })).toBe(false);
+		expect(shouldRegisterOrcaStatusBridge({ env, parentTaskPrefix: "6-Extensions" })).toBe(false);
+		expect(shouldRegisterOrcaStatusBridge({ env, currentAgentType: "executor" })).toBe(false);
+	});
+
+	it("defers to a pane already owned by another process", () => {
+		const otherPid = String(process.pid + 1);
+		expect(
+			shouldRegisterOrcaStatusBridge({
+				env: { ORCA_PANE_KEY: "t:l", ORCA_PI_STATUS_OWNED: otherPid } as NodeJS.ProcessEnv,
+			}),
+		).toBe(false);
+		expect(
+			shouldRegisterOrcaStatusBridge({
+				env: { ORCA_PANE_KEY: "t:l", ORCA_PI_STATUS_OWNED: String(process.pid) } as NodeJS.ProcessEnv,
+			}),
+		).toBe(true);
+	});
+});
+
+describe("extractAssistantText", () => {
+	it("returns string content directly and concatenates text parts", () => {
+		expect(extractAssistantText({ role: "assistant", content: "plain" })).toBe("plain");
+		expect(
+			extractAssistantText({
+				role: "assistant",
+				content: [
+					{ type: "text", text: "first " },
+					{ type: "toolCall", id: "x" },
+					{ type: "text", text: "second" },
+				],
+			}),
+		).toBe("first second");
+	});
+
+	it("returns empty for tool-only or malformed messages", () => {
+		expect(extractAssistantText(undefined)).toBe("");
+		expect(extractAssistantText({ content: [{ type: "toolCall" }] })).toBe("");
+	});
+});
+
+describe("createOrcaStatusBridge delivery", () => {
+	it("posts pi-protocol lifecycle payloads with pane identity and token", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		const ctx = fakeContext();
+
+		let delivery = receiver.nextDelivery();
+		handlers.get("session_start")?.({ type: "session_start" }, ctx);
+		let post = await delivery;
+		expect(post.url).toBe("/hook/pi");
+		expect(post.token).toBe("test-token");
+		expect(post.body.paneKey).toBe("tab-1:leaf-1");
+		expect(post.body.tabId).toBe("tab-1");
+		expect(post.body.worktreeId).toBe("repo::wt");
+		expect(post.body.payload.hook_event_name).toBe("session_start");
+
+		delivery = receiver.nextDelivery();
+		handlers.get("before_agent_start")?.({ type: "before_agent_start", prompt: "fix the bug" }, ctx);
+		post = await delivery;
+		expect(post.body.payload).toMatchObject({ hook_event_name: "before_agent_start", prompt: "fix the bug" });
+
+		delivery = receiver.nextDelivery();
+		handlers.get("tool_execution_start")?.(
+			{ type: "tool_execution_start", toolCallId: "c1", toolName: "bash", args: { command: "ls" } },
+			ctx,
+		);
+		post = await delivery;
+		expect(post.body.payload).toMatchObject({
+			hook_event_name: "tool_execution_start",
+			tool_name: "bash",
+			tool_input: { command: "ls" },
+		});
+
+		delivery = receiver.nextDelivery();
+		handlers.get("message_end")?.(
+			{ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "done!" }] } },
+			ctx,
+		);
+		post = await delivery;
+		expect(post.body.payload).toMatchObject({ hook_event_name: "message_end", role: "assistant", text: "done!" });
+	});
+
+	it("prefers coordinates from the endpoint file over the environment", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-orca-endpoint-"));
+		cleanups.push(() => void fs.rm(dir, { recursive: true, force: true }));
+		const endpointPath = path.join(dir, "endpoint.env");
+		await Bun.write(
+			endpointPath,
+			`ORCA_AGENT_HOOK_PORT=${receiver.port}\nORCA_AGENT_HOOK_TOKEN=file-token\nORCA_AGENT_HOOK_ENV=production\n`,
+		);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, {
+			env: {
+				ORCA_PANE_KEY: "tab-1:leaf-1",
+				ORCA_AGENT_HOOK_ENDPOINT: endpointPath,
+				// Stale env coordinates that the endpoint file must win over.
+				ORCA_AGENT_HOOK_PORT: "1",
+				ORCA_AGENT_HOOK_TOKEN: "stale-token",
+			} as NodeJS.ProcessEnv,
+		});
+		const delivery = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		const post = await delivery;
+		expect(post.token).toBe("file-token");
+		expect(post.body.payload.hook_event_name).toBe("agent_start");
+	});
+
+	it("collapses bursts to the latest snapshot while a post is in flight", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		const ctx = fakeContext();
+
+		receiver.hold = true;
+		const first = receiver.nextDelivery();
+		handlers.get("tool_execution_start")?.(
+			{ type: "tool_execution_start", toolCallId: "c1", toolName: "bash", args: { command: "one" } },
+			ctx,
+		);
+		await first;
+		// Queued while the first post is held open; only the latest may survive.
+		handlers.get("tool_execution_start")?.(
+			{ type: "tool_execution_start", toolCallId: "c2", toolName: "bash", args: { command: "two" } },
+			ctx,
+		);
+		handlers.get("tool_execution_end")?.({ type: "tool_execution_end", toolCallId: "c2", toolName: "bash" }, ctx);
+		const second = receiver.nextDelivery();
+		receiver.hold = false;
+		receiver.releaseHeld();
+		const post = await second;
+		expect(post.body.payload.hook_event_name).toBe("tool_execution_end");
+		expect(receiver.received).toHaveLength(2);
+	});
+
+	it("defers agent_end until the session is idle and reports it once", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		let idle = false;
+		const ctx = fakeContext({ isIdle: () => idle });
+
+		const started = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, ctx);
+		await started;
+
+		const ended = receiver.nextDelivery();
+		handlers.get("agent_end")?.({ type: "agent_end", messages: [] }, ctx);
+		await Bun.sleep(60);
+		expect(receiver.received.filter(post => post.body.payload.hook_event_name === "agent_end")).toHaveLength(0);
+		idle = true;
+		const post = await ended;
+		expect(post.body.payload.hook_event_name).toBe("agent_end");
+		// A second agent_end for the same run must not double-report.
+		handlers.get("agent_end")?.({ type: "agent_end", messages: [] }, ctx);
+		await Bun.sleep(60);
+		expect(receiver.received.filter(p => p.body.payload.hook_event_name === "agent_end")).toHaveLength(1);
+	});
+
+	it("cancels a pending agent_end check when a new agent loop starts", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		const ctx = fakeContext({ isIdle: () => false });
+
+		handlers.get("agent_end")?.({ type: "agent_end", messages: [] }, ctx);
+		const restarted = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, ctx);
+		await restarted;
+		await Bun.sleep(120);
+		expect(receiver.received.filter(post => post.body.payload.hook_event_name === "agent_end")).toHaveLength(0);
+	});
+
+	it("applies the Orca startup prefill once on session_start when a UI exists", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		const env = bridgeEnv(receiver, { ORCA_PI_PREFILL: "continue the review" });
+		createOrcaStatusBridge(api, { env });
+		const prefills: string[] = [];
+		const ctx = fakeContext({ hasUI: true, setEditorText: text => prefills.push(text) });
+
+		const delivery = receiver.nextDelivery();
+		handlers.get("session_start")?.({ type: "session_start" }, ctx);
+		await delivery;
+		handlers.get("session_start")?.({ type: "session_start" }, ctx);
+		expect(prefills).toEqual(["continue the review"]);
+		expect(env.ORCA_PI_PREFILL).toBeUndefined();
+	});
+
+	it("stays inert without Orca coordinates", async () => {
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: { ORCA_PANE_KEY: "tab-1:leaf-1" } as NodeJS.ProcessEnv });
+		// No port/token anywhere: handler must be a silent no-op.
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		await Bun.sleep(20);
+	});
+
+	it("falls back to Windows curl delivery on WSL when loopback posting fails", async () => {
+		const { api, handlers } = captureHandlers();
+		const spawned: Array<{ command: string[]; body: string }> = [];
+		createOrcaStatusBridge(api, {
+			env: {
+				ORCA_PANE_KEY: "tab-1:leaf-1",
+				ORCA_AGENT_HOOK_PORT: "1",
+				ORCA_AGENT_HOOK_TOKEN: "test-token",
+			} as NodeJS.ProcessEnv,
+			fetchImpl: (() => Promise.reject(new Error("loopback unreachable"))) as unknown as typeof fetch,
+			isWslRuntime: () => true,
+			spawnCurl: (command, body) => spawned.push({ command, body }),
+		});
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		await Bun.sleep(20);
+		expect(spawned).toHaveLength(1);
+		expect(spawned[0].command).toContain("http://127.0.0.1:1/hook/pi");
+		expect(spawned[0].command).toContain("X-Orca-Agent-Hook-Token: test-token");
+		expect(JSON.parse(spawned[0].body).payload.hook_event_name).toBe("agent_start");
+	});
+});


### PR DESCRIPTION
## Why

[Orca](https://orca.dev) panes export a loopback agent-hook endpoint (`ORCA_PANE_KEY`, `ORCA_AGENT_HOOK_ENDPOINT`) into every terminal, and Orca ships first-class support for the **pi hook protocol** (`/hook/pi`): live working/done pane badges, active tool + input previews, prompt and last-reply dashboard previews, and session resume metadata.

GJC sessions inside Orca currently show nothing. Orca's managed pi extension (`~/.pi/agent/extensions/orca-agent-status.ts`) cannot load into GJC because filesystem extension discovery is quarantined (`sdk/session.ts`), and GJC's terminal title (`gjc: <session>`) does not match any of Orca's title heuristics. Since GJC speaks the pi extension event model natively, the clean fix is a **bundled** bridge on the inline-extension surface — zero Orca-side changes, zero discovery un-quarantining.

## What

- **`packages/coding-agent/src/utils/orca-status-bridge.ts`** — ports the semantics of Orca's managed pi extension:
  - posts `session_start`, `before_agent_start` (+`prompt`), `agent_start`, `tool_call`/`tool_execution_start`/`tool_execution_end` (+`tool_name`/raw `tool_input`; Orca derives previews server-side), assistant `message_end` (+visible text), `agent_end`
  - `agent_end` defers until `ctx.isIdle()` with a capped exponential recheck (25→250ms) so queued follow-up/retry/compaction work keeps the pane in `working` instead of flapping to done
  - endpoint coordinates come from the `ORCA_AGENT_HOOK_ENDPOINT` file (stat-identity cached, POSIX `KEY=VALUE` and Windows `set KEY=VALUE` forms) with env fallback
  - **latest-only delivery queue** + 1s post timeout: a stalled Orca receiver never accumulates obsolete snapshots and never touches the agent-loop critical path; all failures are silent
  - **WSL fallback**: when WSL loopback cannot reach the Windows-side listener, delivery falls through to `/mnt/c/Windows/System32/curl.exe` (fire-and-forget, cached probes)
  - `ORCA_PI_PREFILL` is consumed once on `session_start` as startup editor prefill
- **`sdk/session.ts`** — registers the bridge as a bundled inline extension, gated by `shouldRegisterOrcaStatusBridge`: requires an Orca pane identity, root sessions only (no task depth / parent task prefix / role agent), and defers to a pane already owned by another process via the `ORCA_PI_STATUS_OWNED` marker shared with Orca's managed extension.
- Changelog entry under `[Unreleased]`.

## Verification

- `bun test packages/coding-agent/test/orca-status-bridge.test.ts` — 16 tests: endpoint-file parsing (POSIX/cmd/CRLF), registration gating, payload shapes + pane identity + token header against a live `Bun.serve` receiver, endpoint-file precedence over stale env, burst collapse to latest snapshot, idle-deferred single `agent_end`, cancellation on new `agent_start`, one-shot prefill, inert-without-coordinates, WSL curl fallback argv/body.
- `bun run --cwd packages/coding-agent check` (biome + `tsc --noEmit`) — clean.
- **Live e2e** against Orca 1.4.154: a print-mode run launched from a real Orca pane lands in Orca's status ledger:

  ```json
  {"hookEventName":"agent_end","payload":{"state":"done","agentType":"pi","lastAssistantMessage":"ok"}}
  ```

## Notes

- Orca renders the pane with its pi identity (π icon/label) — inherent to speaking the pi protocol; Orca's agent catalog is hard-coded app-side.
- To also get GJC into Orca's launch menu, users can override the Pi entry's command to `gjc` in Orca Settings → Agents (`agentCmdOverrides`); with this bridge the status pipeline then works end-to-end.
- Follow-ups worth separate issues: `--hook=`/`-e`/`--no-extensions` are dead flags still advertised in `--help`, and an equals-form `--hook=<path>` value is currently swallowed into the initial prompt by the interactive launch bootstrap.