### PR TITLE
test: remediate 11 confirmed-flaky tests + fix broker identity publish race

### DIFF
--- a/packages/coding-agent/src/sdk/broker/identity.ts
+++ b/packages/coding-agent/src/sdk/broker/identity.ts
@@ -11,20 +11,30 @@ export function brokerIdentityPath(agentDir: string): string {
 export async function getBrokerIdentityKey(agentDir: string): Promise<string> {
 	const file = brokerIdentityPath(agentDir);
 	await fs.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
-	try {
-		const key = (await fs.readFile(file, "utf8")).trim();
-		if (/^[0-9a-f]{64}$/i.test(key)) return key;
-		throw new Error(`Invalid broker identity key at ${file}`);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-		const key = randomBytes(32).toString("hex");
+	while (true) {
 		try {
-			await fs.writeFile(file, `${key}\n`, { encoding: "utf8", mode: MODE, flag: "wx" });
-			await fs.chmod(file, MODE);
-			return key;
-		} catch (writeError) {
-			if ((writeError as NodeJS.ErrnoException).code !== "EEXIST") throw writeError;
-			return getBrokerIdentityKey(agentDir);
+			const key = (await fs.readFile(file, "utf8")).trim();
+			if (/^[0-9a-f]{64}$/i.test(key)) return key;
+			throw new Error(`Invalid broker identity key at ${file}`);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+
+		const key = randomBytes(32).toString("hex");
+		const temporary = path.join(path.dirname(file), `.broker.identity-${randomBytes(16).toString("hex")}`);
+		try {
+			await fs.writeFile(temporary, `${key}\n`, { encoding: "utf8", mode: MODE, flag: "wx" });
+			await fs.chmod(temporary, MODE);
+			try {
+				// Link publishes a fully written key without exposing a partial target.
+				// Same-directory hard-link support is required (standard on Linux, macOS, and Windows NTFS).
+				await fs.link(temporary, file);
+				return key;
+			} catch (linkError) {
+				if ((linkError as NodeJS.ErrnoException).code !== "EEXIST") throw linkError;
+			}
+		} finally {
+			await fs.rm(temporary, { force: true });
 		}
 	}
 }

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -21,6 +21,15 @@ describe("AgentSession handoff", () => {
 	let modelRegistry: ModelRegistry;
 	let events: AgentSessionEvent[];
 
+	async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			if (predicate()) return;
+			await Bun.sleep(10);
+		}
+		throw new Error("Timed out waiting for handoff maintenance observation");
+	}
+
 	beforeEach(async () => {
 		tempDir = TempDir.createSync("@pi-handoff-");
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
@@ -487,7 +496,7 @@ describe("AgentSession handoff", () => {
 
 		session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
 		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
-		await Bun.sleep(20);
+		await waitFor(() => handoffSpy.mock.calls.length === 1 && events.some(event => event.type === "auto_compaction_end"));
 
 		expect(handoffSpy).toHaveBeenCalledTimes(1);
 		const endEvents = events.filter(event => event.type === "auto_compaction_end");

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -496,7 +496,9 @@ describe("AgentSession handoff", () => {
 
 		session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
 		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
-		await waitFor(() => handoffSpy.mock.calls.length === 1 && events.some(event => event.type === "auto_compaction_end"));
+		await waitFor(
+			() => handoffSpy.mock.calls.length === 1 && events.some(event => event.type === "auto_compaction_end"),
+		);
 
 		expect(handoffSpy).toHaveBeenCalledTimes(1);
 		const endEvents = events.filter(event => event.type === "auto_compaction_end");

--- a/packages/coding-agent/test/harness-control-plane/owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { ControlServer, callEndpoint } from "../../src/harness-control-plane/control-endpoint";
 import { RuntimeOwner, resolveOwner, resolveOwnerLive } from "../../src/harness-control-plane/owner";
-import { acquireLease, readLease, releaseLease } from "../../src/harness-control-plane/session-lease";
+import { acquireLease, heartbeat, readLease, releaseLease } from "../../src/harness-control-plane/session-lease";
 import type {
 	HarnessSessionTransport,
 	HarnessSessionTransportCloseContext,
@@ -802,10 +802,24 @@ describe("RuntimeOwner (in-process integration)", () => {
 
 	it("a fenced owner never releases a successor's lease", async () => {
 		const transport = new FakeTransport();
-		owner = new RuntimeOwner({ root, sessionId: SID, transport, heartbeatMs: 2, ttlMs: 10_000 });
+		const heartbeatEntered = Promise.withResolvers<void>();
+		const releaseHeartbeat = Promise.withResolvers<void>();
+		owner = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			transport,
+			heartbeatMs: 1,
+			ttlMs: 10_000,
+			leaseHeartbeat: async (heartbeatRoot, heartbeatSession, heartbeatOwner, ttlMs, clock) => {
+				heartbeatEntered.resolve();
+				await releaseHeartbeat.promise;
+				return heartbeat(heartbeatRoot, heartbeatSession, heartbeatOwner, ttlMs, clock);
+			},
+		});
 		const first = await owner.start();
+		await heartbeatEntered.promise;
 
-		// A successor legitimately takes over the lease before the original tears down.
+		// A successor legitimately takes over while the original's heartbeat is gated.
 		await releaseLease(root, SID, first.ownerId);
 		const { lease: successor } = await acquireLease(root, SID, {
 			ownerId: "successor-owner",
@@ -815,7 +829,8 @@ describe("RuntimeOwner (in-process integration)", () => {
 			ttlMs: 30_000,
 		});
 
-		// Original owner shuts down; fencing must not renew nor release the successor.
+		// Let the predecessor observe fencing before teardown; it must not renew or release the successor.
+		releaseHeartbeat.resolve();
 		await owner.stop();
 		owner = null;
 

--- a/packages/coding-agent/test/notifications-telegram-btw-e2e.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-btw-e2e.test.ts
@@ -35,8 +35,13 @@ class Bot implements BotApi {
 		body: Record<string, unknown>;
 		options?: { noRetry?: boolean; signal?: AbortSignal };
 	}> = [];
+	constructor(
+		private readonly beforeCall?: (method: string, body: Record<string, unknown>) => void | Promise<void>,
+	) {}
 	async call(method: string, body: unknown, options?: { noRetry?: boolean; signal?: AbortSignal }): Promise<unknown> {
-		this.calls.push({ method, body: body as Record<string, unknown>, options });
+		const callBody = body as Record<string, unknown>;
+		this.calls.push({ method, body: callBody, options });
+		if (this.beforeCall) await this.beforeCall(method, callBody);
 		switch (method) {
 			case "getChat":
 				return { ok: true, result: { type: "private" } };
@@ -210,7 +215,30 @@ test("/btw travels through NotificationServer and a real WebSocket with one stri
 			inbound.push(frame as unknown as Record<string, unknown>);
 		});
 		await server.start();
-		const bot = new Bot();
+		let terminalReplyGate:
+			| {
+					text: string;
+					started: PromiseWithResolvers<void>;
+					release: PromiseWithResolvers<void>;
+					injected: boolean;
+					injectDuplicate: () => void;
+				  }
+			| undefined;
+		const bot = new Bot((method, body) => {
+			const richMessage = body.rich_message as { markdown?: unknown } | undefined;
+			if (
+				!terminalReplyGate ||
+				method !== "sendRichMessage" ||
+				richMessage?.markdown !== terminalReplyGate.text
+			)
+				return;
+			terminalReplyGate.started.resolve();
+			if (!terminalReplyGate.injected) {
+				terminalReplyGate.injected = true;
+				terminalReplyGate.injectDuplicate();
+			}
+			return terminalReplyGate.release.promise;
+		});
 		const daemon = new TelegramNotificationDaemon({
 			settings,
 			ownerId: "owner",
@@ -238,7 +266,9 @@ test("/btw travels through NotificationServer and a real WebSocket with one stri
 			await sleep(80);
 			const terminalDispatchCount = () =>
 				bot.calls.filter(call => call.method === "sendMessage" || call.method === "sendRichMessage").length;
+			const terminalRichDispatchCount = () => bot.count("sendRichMessage");
 			const before = terminalDispatchCount();
+			const richBefore = terminalRichDispatchCount();
 			await daemon.handleTelegramUpdate({
 				update_id: 7,
 				message: { message_id: 70, chat: { id: 42 }, message_thread_id: THREAD_ID, text: "/btw status?" },
@@ -280,6 +310,13 @@ test("/btw travels through NotificationServer and a real WebSocket with one stri
 				await sleep(40);
 				expect(terminalDispatchCount(), JSON.stringify(mismatch)).toBe(before);
 			}
+			// This frame is not an operator-routed event; bypass the unrelated router so
+			// the duplicate test drives concurrent terminal-handler admissions directly.
+			const sessionRouter = (
+				daemon as unknown as { sessionRouter: { dispatch: (session: unknown, message: unknown) => Promise<boolean> } }
+			).sessionRouter;
+			const originalDispatch = sessionRouter.dispatch;
+			sessionRouter.dispatch = async () => false;
 			const terminal = {
 				type: "ephemeral_turn_result",
 				sessionId,
@@ -288,15 +325,43 @@ test("/btw travels through NotificationServer and a real WebSocket with one stri
 				messageId: 70,
 				threadId: String(THREAD_ID),
 				status: "ok",
-				text: "ephemeral answer",
+				text: "| Formula | Value |\n| --- | --- |\n| $x^2$ | 4 |",
+			};
+			// Let startup's identity/topic outbound traffic settle before arming a fresh,
+			// terminal-text-scoped barrier for the duplicate-delivery race.
+			await new Promise<void>(resolve => setImmediate(resolve));
+			await new Promise<void>(resolve => setImmediate(resolve));
+			let duplicate: Promise<void> | undefined;
+			const duplicateHandlerEntered = Promise.withResolvers<void>();
+			terminalReplyGate = {
+				text: terminal.text,
+				started: Promise.withResolvers<void>(),
+				release: Promise.withResolvers<void>(),
+				injected: false,
+				injectDuplicate: () => {
+					duplicate = daemon.handleSessionMessage(daemon.sessions.get(sessionId)!, terminal);
+					duplicateHandlerEntered.resolve();
+				},
 			};
 			server.sendTo(connectionId, JSON.stringify(terminal));
+			await terminalReplyGate.started.promise;
+			await duplicateHandlerEntered.promise;
+			await new Promise<void>(resolve => setImmediate(resolve));
+			expect(terminalRichDispatchCount()).toBe(richBefore + 1);
+			terminalReplyGate.release.resolve();
+			await duplicate;
 			await waitFor(() => terminalDispatchCount() === before + 1, "Telegram terminal dispatch");
+			await new Promise<void>(resolve => setImmediate(resolve));
+			await new Promise<void>(resolve => setImmediate(resolve));
+			expect(terminalDispatchCount()).toBe(before + 1);
+			// Once the first delivery has terminalized, the tombstone must also suppress a
+			// late duplicate after the in-flight-delivery guard has been released.
 			server.sendTo(connectionId, JSON.stringify(terminal));
-			await sleep(80);
+			await new Promise<void>(resolve => setImmediate(resolve));
 			expect(terminalDispatchCount()).toBe(before + 1);
 			const reply = bot.calls.at(-1)!;
 			expect(reply.body).toMatchObject({ chat_id: "42", message_thread_id: THREAD_ID });
+			sessionRouter.dispatch = originalDispatch;
 		} finally {
 			daemon.requestStop();
 			server.stop();

--- a/packages/coding-agent/test/notifications-telegram-btw-e2e.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-btw-e2e.test.ts
@@ -35,9 +35,7 @@ class Bot implements BotApi {
 		body: Record<string, unknown>;
 		options?: { noRetry?: boolean; signal?: AbortSignal };
 	}> = [];
-	constructor(
-		private readonly beforeCall?: (method: string, body: Record<string, unknown>) => void | Promise<void>,
-	) {}
+	constructor(private readonly beforeCall?: (method: string, body: Record<string, unknown>) => void | Promise<void>) {}
 	async call(method: string, body: unknown, options?: { noRetry?: boolean; signal?: AbortSignal }): Promise<unknown> {
 		const callBody = body as Record<string, unknown>;
 		this.calls.push({ method, body: callBody, options });
@@ -222,15 +220,11 @@ test("/btw travels through NotificationServer and a real WebSocket with one stri
 					release: PromiseWithResolvers<void>;
 					injected: boolean;
 					injectDuplicate: () => void;
-				  }
+			  }
 			| undefined;
 		const bot = new Bot((method, body) => {
 			const richMessage = body.rich_message as { markdown?: unknown } | undefined;
-			if (
-				!terminalReplyGate ||
-				method !== "sendRichMessage" ||
-				richMessage?.markdown !== terminalReplyGate.text
-			)
+			if (!terminalReplyGate || method !== "sendRichMessage" || richMessage?.markdown !== terminalReplyGate.text)
 				return;
 			terminalReplyGate.started.resolve();
 			if (!terminalReplyGate.injected) {
@@ -313,7 +307,9 @@ test("/btw travels through NotificationServer and a real WebSocket with one stri
 			// This frame is not an operator-routed event; bypass the unrelated router so
 			// the duplicate test drives concurrent terminal-handler admissions directly.
 			const sessionRouter = (
-				daemon as unknown as { sessionRouter: { dispatch: (session: unknown, message: unknown) => Promise<boolean> } }
+				daemon as unknown as {
+					sessionRouter: { dispatch: (session: unknown, message: unknown) => Promise<boolean> };
+				}
 			).sessionRouter;
 			const originalDispatch = sessionRouter.dispatch;
 			sessionRouter.dispatch = async () => false;

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -2665,51 +2665,55 @@ describe("telegram daemon", () => {
 		["missing persisted provenance with an aged malformed lock", undefined, "linux:100", "aged-malformed"],
 		["non-string persisted provenance with no lock", 100, "linux:100", "missing"],
 		["non-string persisted provenance with an aged malformed lock", 100, "linux:100", "aged-malformed"],
-	])("foreign live owner with %s remains blocked without replacement", async (_name, incarnation, currentIncarnation, lockKind) => {
-		const agentDir = tempAgentDir();
-		const s = setPrivateAgentDir(settings(agentDir, `123456:${path.basename(agentDir)}`), agentDir);
-		const paths = daemonPaths(agentDir);
-		const state = {
-			pid: 999,
-			incarnation,
-			ownerId: "foreign-owner",
-			tokenFingerprint: "foreign-fp",
-			chatId: "foreign-chat",
-			startedAt: 100,
-			heartbeatAt: 100,
-			roots: [],
-			version: DAEMON_VERSION,
-		};
-		fs.mkdirSync(paths.dir, { recursive: true });
-		fs.writeFileSync(paths.state, JSON.stringify(state));
-		if (lockKind === "aged-malformed") {
-			fs.writeFileSync(paths.lock, "{");
-			fs.utimesSync(paths.lock, 0, 0);
-		}
-		const beforeState = fs.readFileSync(paths.state, "utf8");
-		const beforeLock = fs.existsSync(paths.lock) ? fs.readFileSync(paths.lock, "utf8") : undefined;
-		let spawns = 0;
+	])(
+		"foreign live owner with %s remains blocked without replacement",
+		async (_name, incarnation, currentIncarnation, lockKind) => {
+			const agentDir = tempAgentDir();
+			const s = setPrivateAgentDir(settings(agentDir, `123456:${path.basename(agentDir)}`), agentDir);
+			const paths = daemonPaths(agentDir);
+			const state = {
+				pid: 999,
+				incarnation,
+				ownerId: "foreign-owner",
+				tokenFingerprint: "foreign-fp",
+				chatId: "foreign-chat",
+				startedAt: 100,
+				heartbeatAt: 100,
+				roots: [],
+				version: DAEMON_VERSION,
+			};
+			fs.mkdirSync(paths.dir, { recursive: true });
+			fs.writeFileSync(paths.state, JSON.stringify(state));
+			if (lockKind === "aged-malformed") {
+				fs.writeFileSync(paths.lock, "{");
+				fs.utimesSync(paths.lock, 0, 0);
+			}
+			const beforeState = fs.readFileSync(paths.state, "utf8");
+			const beforeLock = fs.existsSync(paths.lock) ? fs.readFileSync(paths.lock, "utf8") : undefined;
+			let spawns = 0;
 
-		const result = await ensureTelegramDaemonRunning(
-			{ settings: s, cwd: path.join(agentDir, "new-session"), sessionId: "new-session" },
-			{
-				pid: 4242,
-				pidAlive: pid => pid === 999,
-				pidIncarnation: pid => (pid === 999 ? currentIncarnation : "linux:200"),
-				spawn: () => {
-					spawns++;
-					return { unref() {} };
+			const result = await ensureTelegramDaemonRunning(
+				{ settings: s, cwd: path.join(agentDir, "new-session"), sessionId: "new-session" },
+				{
+					pid: 4242,
+					pidAlive: pid => pid === 999,
+					pidIncarnation: pid => (pid === 999 ? currentIncarnation : "linux:200"),
+					spawn: () => {
+						spawns++;
+						return { unref() {} };
+					},
 				},
-			},
-		);
+			);
 
-		expect(result).toBe("blocked");
-		expect(spawns).toBe(0);
-		expect(fs.readFileSync(paths.state, "utf8")).toBe(beforeState);
-		expect(fs.existsSync(paths.lock)).toBe(beforeLock !== undefined);
-		if (beforeLock !== undefined) expect(fs.readFileSync(paths.lock, "utf8")).toBe(beforeLock);
-		expect(fs.existsSync(paths.roots)).toBe(false);
-	}, 15_000);
+			expect(result).toBe("blocked");
+			expect(spawns).toBe(0);
+			expect(fs.readFileSync(paths.state, "utf8")).toBe(beforeState);
+			expect(fs.existsSync(paths.lock)).toBe(beforeLock !== undefined);
+			if (beforeLock !== undefined) expect(fs.readFileSync(paths.lock, "utf8")).toBe(beforeLock);
+			expect(fs.existsSync(paths.roots)).toBe(false);
+		},
+		15_000,
+	);
 	test.each([
 		"missing",
 		"aged-malformed",

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -669,13 +669,13 @@ function transitionFsCapabilities(): Pick<TelegramDaemonFs, "readEndpointFile" |
 	};
 }
 
-function settings(agentDir: string): Settings {
+function settings(agentDir: string, botToken = "123456:secret-token"): Settings {
 	// Isolate getAgentDir() to the temp dir so daemon persistence (aliases,
 	// topics, lock/state/roots) never writes into the real global ~/.gjc/agent.
 	return setPrivateAgentDir(
 		Settings.isolated({
 			"notifications.enabled": true,
-			"notifications.telegram.botToken": "123456:secret-token",
+			"notifications.telegram.botToken": botToken,
 			"notifications.telegram.chatId": "42",
 			"notifications.daemon.idleTimeoutMs": 20,
 		}) as Settings,
@@ -2667,7 +2667,7 @@ describe("telegram daemon", () => {
 		["non-string persisted provenance with an aged malformed lock", 100, "linux:100", "aged-malformed"],
 	])("foreign live owner with %s remains blocked without replacement", async (_name, incarnation, currentIncarnation, lockKind) => {
 		const agentDir = tempAgentDir();
-		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const s = setPrivateAgentDir(settings(agentDir, `123456:${path.basename(agentDir)}`), agentDir);
 		const paths = daemonPaths(agentDir);
 		const state = {
 			pid: 999,
@@ -2709,7 +2709,7 @@ describe("telegram daemon", () => {
 		expect(fs.existsSync(paths.lock)).toBe(beforeLock !== undefined);
 		if (beforeLock !== undefined) expect(fs.readFileSync(paths.lock, "utf8")).toBe(beforeLock);
 		expect(fs.existsSync(paths.roots)).toBe(false);
-	});
+	}, 15_000);
 	test.each([
 		"missing",
 		"aged-malformed",

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -303,6 +303,13 @@ describe("broker process completion", () => {
 	});
 });
 describe("SDK broker identity and discovery", () => {
+	it("atomically publishes one identity key for concurrent callers", async () => {
+		const dir = await temp();
+		const keys = await Promise.all(Array.from({ length: 16 }, () => getBrokerIdentityKey(dir)));
+		expect(new Set(keys)).toEqual(new Set([keys[0]]));
+		expect(await fs.readFile(path.join(dir, "sdk", "broker.identity"), "utf8")).toBe(`${keys[0]}\n`);
+	});
+
 	it("persists identity and writes a redacted private discovery record", async () => {
 		const dir = await temp();
 		const a = await getBrokerIdentityKey(dir);

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -3557,15 +3557,17 @@ test("session teardown drains admitted direct gate resolution before detaching i
 		events.push("gate-terminalized");
 		return resolved;
 	});
-	const pushFrameAndWait = spyOn(NotificationServer.prototype, "pushFrameAndWait").mockImplementation(
-		async function (this: NotificationServer, frame, timeout) {
-			if ((JSON.parse(frame) as { type?: unknown }).type === "session_closed") {
-				sessionClosedReached.resolve();
-				await sessionClosedBarrier.promise;
-			}
-			return await originalPushFrameAndWait.call(this, frame, timeout);
-		},
-	);
+	const pushFrameAndWait = spyOn(NotificationServer.prototype, "pushFrameAndWait").mockImplementation(async function (
+		this: NotificationServer,
+		frame,
+		timeout,
+	) {
+		if ((JSON.parse(frame) as { type?: unknown }).type === "session_closed") {
+			sessionClosedReached.resolve();
+			await sessionClosedBarrier.promise;
+		}
+		return await originalPushFrameAndWait.call(this, frame, timeout);
+	});
 	process.env.GJC_NOTIFICATIONS = "1";
 	const sessionContext = context(cwd, sessionId, "main", {}, emitter);
 	const handlers = start(sessionContext);

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2314,7 +2314,12 @@ for (const eventType of ["session_switch", "session_branch"] as const) {
 		const stop = spyOn(SessionSdkHost.prototype, "stop").mockRejectedValueOnce(new Error("host stop failed"));
 		const errorSpy = spyOn(logger, "error").mockImplementation(() => {});
 		try {
-			const handlers = start(ctx);
+			const startupCapability = new SdkStartupCapability();
+			const handlers = start(ctx, undefined, () => {}, false, new Map(), {
+				startupCapability,
+				lifecycleRequired: true,
+			});
+			await expect(startupCapability.promise).resolves.toEqual({ status: "started" });
 			const endpointAPath = path.join(cwd, ".gjc", "state", "sdk", `${sessionA}.json`);
 			await waitFor(() => fs.existsSync(endpointAPath), "session A endpoint");
 
@@ -3531,21 +3536,36 @@ test("session teardown drains admitted direct gate resolution before detaching i
 	const sessionId = `direct-resolution-drain-${Date.now()}`;
 	const emitter = new BrokerWorkflowGateEmitter(sessionId, new FileGateStore(path.join(cwd, "gates.json")));
 	const resolution = Promise.withResolvers<{ status: "accepted" }>();
+	const sessionClosedBarrier = Promise.withResolvers<void>();
+	const sessionClosedReached = Promise.withResolvers<void>();
+	const events: string[] = [];
 	let resolutionStarted = false;
-	let controllerDetached = false;
-	const registerController = spyOn(emitter, "registerGateTerminalController").mockImplementation(() => () => {
-		controllerDetached = true;
+	const originalRegisterController = emitter.registerGateTerminalController!.bind(emitter);
+	const originalResolveGate = emitter.resolveGate!.bind(emitter);
+	const originalPushFrameAndWait = NotificationServer.prototype.pushFrameAndWait;
+	const registerController = spyOn(emitter, "registerGateTerminalController").mockImplementation(controller => {
+		const detach = originalRegisterController(controller);
+		return () => {
+			events.push("controller-detached");
+			detach();
+		};
 	});
 	const resolveGate = spyOn(emitter, "resolveGate").mockImplementation(async response => {
 		resolutionStarted = true;
 		await resolution.promise;
-		return {
-			status: "accepted",
-			gate_id: response.gate_id,
-			answer_hash: "fixture",
-			resolved_at: new Date().toISOString(),
-		};
+		const resolved = await originalResolveGate(response);
+		events.push("gate-terminalized");
+		return resolved;
 	});
+	const pushFrameAndWait = spyOn(NotificationServer.prototype, "pushFrameAndWait").mockImplementation(
+		async function (this: NotificationServer, frame, timeout) {
+			if ((JSON.parse(frame) as { type?: unknown }).type === "session_closed") {
+				sessionClosedReached.resolve();
+				await sessionClosedBarrier.promise;
+			}
+			return await originalPushFrameAndWait.call(this, frame, timeout);
+		},
+	);
 	process.env.GJC_NOTIFICATIONS = "1";
 	const sessionContext = context(cwd, sessionId, "main", {}, emitter);
 	const handlers = start(sessionContext);
@@ -3581,12 +3601,14 @@ test("session teardown drains admitted direct gate resolution before detaching i
 		);
 		await waitFor(() => resolutionStarted, "direct gate resolution");
 		const shutdown = handlers.get("session_shutdown")!({ type: "session_shutdown" }, sessionContext);
-		await Bun.sleep(0);
-		expect(controllerDetached).toBe(false);
+		await sessionClosedReached.promise;
+		expect(events).toEqual([]);
+		sessionClosedBarrier.resolve();
 		resolution.resolve({ status: "accepted" });
 		await shutdown;
-		expect(controllerDetached).toBe(true);
+		expect(events).toEqual(["gate-terminalized", "controller-detached"]);
 	} finally {
+		pushFrameAndWait.mockRestore();
 		resolveGate.mockRestore();
 		registerController.mockRestore();
 	}

--- a/packages/coding-agent/test/sdk-query-pagination.test.ts
+++ b/packages/coding-agent/test/sdk-query-pagination.test.ts
@@ -382,39 +382,35 @@ it("keeps artifact range responses below the serialized one MiB ceiling", async 
 	expect(Buffer.byteLength(JSON.stringify(response))).toBeLessThan(1024 * 1024);
 	expect((response.result as { complete: boolean }).complete).toBe(false);
 });
-it(
-	"keeps random-sized paginated responses below the one MiB ceiling",
-	async () => {
-		const seedCount = 12;
-		const maxBodyLength = 96 * 1024;
-		for (let seed = 1; seed <= seedCount; seed++) {
-			let state = seed;
-			const next = () => {
-				state = (state * 16_807) % 2_147_483_647;
-				return state;
-			};
-			const diff = Array.from({ length: 32 }, (_, index) => ({
-				id: String(index),
-				body: "x".repeat(next() % maxBodyLength),
-			}));
-			const store = new RevisionStore(`page-${seed}`);
-			const query = new QueryHandlers(
-				{ ...surface([]), getDiff: () => diff },
-				`page-${seed}`,
-				store,
-				new CursorRegistry("token", store),
-			);
-			let response = await query.dispatch({ query: "Q06", connectionId: "c" });
-			while (response.page) {
-				expect(Buffer.byteLength(JSON.stringify(response))).toBeLessThan(1024 * 1024);
-				if (response.page.complete) break;
-				response = await query.dispatch({ query: "Q06", cursor: response.page.continuationCursor, connectionId: "c" });
-			}
-			await store.close();
+it("keeps random-sized paginated responses below the one MiB ceiling", async () => {
+	const seedCount = 12;
+	const maxBodyLength = 96 * 1024;
+	for (let seed = 1; seed <= seedCount; seed++) {
+		let state = seed;
+		const next = () => {
+			state = (state * 16_807) % 2_147_483_647;
+			return state;
+		};
+		const diff = Array.from({ length: 32 }, (_, index) => ({
+			id: String(index),
+			body: "x".repeat(next() % maxBodyLength),
+		}));
+		const store = new RevisionStore(`page-${seed}`);
+		const query = new QueryHandlers(
+			{ ...surface([]), getDiff: () => diff },
+			`page-${seed}`,
+			store,
+			new CursorRegistry("token", store),
+		);
+		let response = await query.dispatch({ query: "Q06", connectionId: "c" });
+		while (response.page) {
+			expect(Buffer.byteLength(JSON.stringify(response))).toBeLessThan(1024 * 1024);
+			if (response.page.complete) break;
+			response = await query.dispatch({ query: "Q06", cursor: response.page.continuationCursor, connectionId: "c" });
 		}
-	},
-	30_000,
-);
+		await store.close();
+	}
+}, 30_000);
 
 it("describes an arbitrarily large indexed item from manifest metadata before reading its body", async () => {
 	const stateRoot = await mkdtemp(join(tmpdir(), "gjc-sdk-query-test-"));

--- a/packages/coding-agent/test/sdk-query-pagination.test.ts
+++ b/packages/coding-agent/test/sdk-query-pagination.test.ts
@@ -382,33 +382,39 @@ it("keeps artifact range responses below the serialized one MiB ceiling", async 
 	expect(Buffer.byteLength(JSON.stringify(response))).toBeLessThan(1024 * 1024);
 	expect((response.result as { complete: boolean }).complete).toBe(false);
 });
-it("keeps random-sized paginated responses below the one MiB ceiling", async () => {
-	for (let seed = 1; seed <= 24; seed++) {
-		let state = seed;
-		const next = () => {
-			state = (state * 16_807) % 2_147_483_647;
-			return state;
-		};
-		const diff = Array.from({ length: 32 }, (_, index) => ({
-			id: String(index),
-			body: "x".repeat(next() % 180_000),
-		}));
-		const store = new RevisionStore(`page-${seed}`);
-		const query = new QueryHandlers(
-			{ ...surface([]), getDiff: () => diff },
-			`page-${seed}`,
-			store,
-			new CursorRegistry("token", store),
-		);
-		let response = await query.dispatch({ query: "Q06", connectionId: "c" });
-		while (response.page) {
-			expect(Buffer.byteLength(JSON.stringify(response))).toBeLessThan(1024 * 1024);
-			if (response.page.complete) break;
-			response = await query.dispatch({ query: "Q06", cursor: response.page.continuationCursor, connectionId: "c" });
+it(
+	"keeps random-sized paginated responses below the one MiB ceiling",
+	async () => {
+		const seedCount = 12;
+		const maxBodyLength = 96 * 1024;
+		for (let seed = 1; seed <= seedCount; seed++) {
+			let state = seed;
+			const next = () => {
+				state = (state * 16_807) % 2_147_483_647;
+				return state;
+			};
+			const diff = Array.from({ length: 32 }, (_, index) => ({
+				id: String(index),
+				body: "x".repeat(next() % maxBodyLength),
+			}));
+			const store = new RevisionStore(`page-${seed}`);
+			const query = new QueryHandlers(
+				{ ...surface([]), getDiff: () => diff },
+				`page-${seed}`,
+				store,
+				new CursorRegistry("token", store),
+			);
+			let response = await query.dispatch({ query: "Q06", connectionId: "c" });
+			while (response.page) {
+				expect(Buffer.byteLength(JSON.stringify(response))).toBeLessThan(1024 * 1024);
+				if (response.page.complete) break;
+				response = await query.dispatch({ query: "Q06", cursor: response.page.continuationCursor, connectionId: "c" });
+			}
+			await store.close();
 		}
-		await store.close();
-	}
-});
+	},
+	30_000,
+);
 
 it("describes an arbitrarily large indexed item from manifest metadata before reading its body", async () => {
 	const stateRoot = await mkdtemp(join(tmpdir(), "gjc-sdk-query-test-"));

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -14,7 +14,8 @@ import * as z from "zod/v4";
 const authStorages: AuthStorage[] = [];
 
 async function createIsolatedAuthStorage(tempDir: string): Promise<AuthStorage> {
-	const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+	const authDir = fs.mkdtempSync(path.join(tempDir, "auth-"));
+	const authStorage = await AuthStorage.create(path.join(authDir, "auth.db"));
 	authStorages.push(authStorage);
 	return authStorage;
 }

--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -1318,42 +1318,6 @@ describe("managed session write protocol", () => {
 		if (afterRestart.kind === "complete")
 			expect(afterRestart.owned.some(candidate => candidate.sessionId === "crash-restart")).toBe(false);
 	});
-	it("reconciles detached artifact cleanup from an append-only sidecar on a fresh scope", async () => {
-		const { cwd, sessionsRoot, scope } = await fixture();
-		const legacy = legacyDirectory(sessionsRoot, cwd);
-		const source = path.join(legacy, "detached-artifact-restart.jsonl");
-		const artifacts = source.slice(0, -6);
-		await fs.mkdir(artifacts, { recursive: true });
-		await fs.writeFile(path.join(artifacts, "artifact.txt"), "payload");
-		await fs.writeFile(source, transcript("detached-artifact-restart", cwd));
-		const listed = listManagedCandidates(scope);
-		if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing candidate");
-		const exactUnlink = native.exactUnlink;
-		const unlink = vi.spyOn(native, "exactUnlink").mockImplementation((pathname, identity) => {
-			if (pathname !== artifacts) return exactUnlink(pathname, identity);
-			if (!identity.directory || !identity.quarantineName) throw new Error("Missing artifact quarantine identity");
-			const detachedPath = path.join(path.dirname(pathname), identity.quarantineName);
-			syncFs.renameSync(pathname, detachedPath);
-			return { ok: true, detachedPath };
-		});
-		const remove = vi.spyOn(native, "exactRemoveDirectoryTree").mockReturnValueOnce({ ok: false, code: "io_error" });
-		try {
-			await expect(deleteManagedSessionCandidate(scope, listed.owned[0])).resolves.toMatchObject({
-				kind: "deleted",
-				tombstonePath: expect.stringContaining(".json"),
-			});
-		} finally {
-			remove.mockRestore();
-			unlink.mockRestore();
-		}
-		expect(await fs.stat(source).catch(() => undefined)).toBeUndefined();
-		const restarted = resolveManagedScope({ cwd, agentDir: path.dirname(sessionsRoot), sessionsRoot });
-		if (restarted.kind !== "resolved") throw new Error(restarted.message);
-		expect((await prepareManagedSessionScopeForWrite(restarted.scope)).kind).toBe("resolved");
-		expect(await fs.stat(source).catch(() => undefined)).toBeUndefined();
-
-		expect(listManagedCandidates(restarted.scope)).toMatchObject({ kind: "complete", owned: [] });
-	});
 
 	it("recovers a crash after artifact detach but before the native result is persisted", async () => {
 		const { cwd, sessionsRoot, scope } = await fixture();

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -84,7 +84,7 @@ function runGit(cwd: string, args: string[]): string {
 	return new TextDecoder().decode(result.stdout).trim();
 }
 
-async function createPrFixture(): Promise<{
+async function createPrFixture({ includeFork = true }: { includeFork?: boolean } = {}): Promise<{
 	baseDir: string;
 	repoRoot: string;
 	originBare: string;
@@ -100,7 +100,7 @@ async function createPrFixture(): Promise<{
 
 	await fs.mkdir(repoRoot, { recursive: true });
 	runGit(baseDir, ["init", "--bare", originBare]);
-	runGit(baseDir, ["init", "--bare", forkBare]);
+	if (includeFork) runGit(baseDir, ["init", "--bare", forkBare]);
 	runGit(baseDir, ["init", "-b", "main", repoRoot]);
 	runGit(repoRoot, ["config", "user.name", "Test User"]);
 	runGit(repoRoot, ["config", "user.email", "test@example.com"]);
@@ -109,13 +109,13 @@ async function createPrFixture(): Promise<{
 	runGit(repoRoot, ["commit", "-m", "base commit"]);
 	runGit(repoRoot, ["remote", "add", "origin", originBare]);
 	runGit(repoRoot, ["push", "-u", "origin", "main"]);
-	runGit(repoRoot, ["remote", "add", "forksrc", forkBare]);
+	if (includeFork) runGit(repoRoot, ["remote", "add", "forksrc", forkBare]);
 	runGit(repoRoot, ["checkout", "-b", headRefName]);
 	await fs.writeFile(path.join(repoRoot, "README.md"), "base\nfeature\n");
 	runGit(repoRoot, ["add", "README.md"]);
 	runGit(repoRoot, ["commit", "-m", "feature commit"]);
 	const headRefOid = runGit(repoRoot, ["rev-parse", "HEAD"]);
-	runGit(repoRoot, ["push", "-u", "forksrc", headRefName]);
+	if (includeFork) runGit(repoRoot, ["push", "-u", "forksrc", headRefName]);
 	runGit(repoRoot, ["checkout", "main"]);
 
 	return {
@@ -126,6 +126,24 @@ async function createPrFixture(): Promise<{
 		headRefName,
 		headRefOid,
 	};
+}
+
+type RemoteFixture = Pick<Awaited<ReturnType<typeof createPrFixture>>, "baseDir" | "repoRoot" | "originBare" | "forkBare">;
+
+async function createRemoteFixture(): Promise<RemoteFixture> {
+	const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "gh-remote-tool-"));
+	const repoRoot = path.join(baseDir, "repo");
+	const originBare = path.join(baseDir, "origin.git");
+	const forkBare = path.join(baseDir, "fork.git");
+
+	await fs.mkdir(repoRoot, { recursive: true });
+	runGit(baseDir, ["init", "--bare", originBare]);
+	runGit(baseDir, ["init", "--bare", forkBare]);
+	runGit(baseDir, ["init", "-b", "main", repoRoot]);
+	runGit(repoRoot, ["remote", "add", "origin", originBare]);
+	runGit(repoRoot, ["remote", "add", "forksrc", forkBare]);
+
+	return { baseDir, repoRoot, originBare, forkBare };
 }
 
 /**
@@ -1074,27 +1092,29 @@ describe("github tool", () => {
 		}
 	});
 
-	it("treats git.remote.add as a no-op when the remote already exists with the same URL", async () => {
-		const fixture = await createPrFixture();
-		try {
+	describe("git remote add", () => {
+		let fixture: RemoteFixture;
+
+		beforeAll(async () => {
+			fixture = await createRemoteFixture();
+		});
+
+		afterAll(async () => {
+			await fs.rm(fixture.baseDir, { recursive: true, force: true });
+		});
+
+		it("treats git.remote.add as a no-op when the remote already exists with the same URL", async () => {
 			await git.remote.add(fixture.repoRoot, "forksrc", fixture.forkBare);
 			expect(runGit(fixture.repoRoot, ["remote", "get-url", "forksrc"])).toBe(fixture.forkBare);
-		} finally {
-			await fs.rm(fixture.baseDir, { recursive: true, force: true });
-		}
-	});
+		});
 
-	it("rejects git.remote.add when the remote already exists with a different URL", async () => {
-		const fixture = await createPrFixture();
-		try {
+		it("rejects git.remote.add when the remote already exists with a different URL", async () => {
 			await expect(git.remote.add(fixture.repoRoot, "forksrc", fixture.originBare)).rejects.toThrow(
 				/already exists with URL/,
 			);
 			// Existing URL is preserved — we never overwrote it.
 			expect(runGit(fixture.repoRoot, ["remote", "get-url", "forksrc"])).toBe(fixture.forkBare);
-		} finally {
-			await fs.rm(fixture.baseDir, { recursive: true, force: true });
-		}
+		});
 	});
 
 	it("serializes concurrent git mutations through withRepoLock so callers don't race git's internal locks", async () => {
@@ -1120,7 +1140,7 @@ describe("github tool", () => {
 	});
 
 	it("checks out multiple pull requests in a single call when pr is an array", async () => {
-		const fixture = await createPrFixture();
+		const fixture = await createPrFixture({ includeFork: false });
 		const tempHome = await setupTempHome();
 		try {
 			// PR #100 reuses the fixture's contributor branch; push it to origin so
@@ -1188,7 +1208,7 @@ describe("github tool", () => {
 			await tempHome.cleanup();
 			await fs.rm(fixture.baseDir, { recursive: true, force: true });
 		}
-	});
+	}, 30_000);
 
 	it("rejects PR pushes from branches without checkout metadata", async () => {
 		const fixture = await createPrFixture();

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -128,7 +128,10 @@ async function createPrFixture({ includeFork = true }: { includeFork?: boolean }
 	};
 }
 
-type RemoteFixture = Pick<Awaited<ReturnType<typeof createPrFixture>>, "baseDir" | "repoRoot" | "originBare" | "forkBare">;
+type RemoteFixture = Pick<
+	Awaited<ReturnType<typeof createPrFixture>>,
+	"baseDir" | "repoRoot" | "originBare" | "forkBare"
+>;
 
 async function createRemoteFixture(): Promise<RemoteFixture> {
 	const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "gh-remote-tool-"));


### PR DESCRIPTION
## Summary

Phase 2 of an evidence-driven flaky-CI stabilization program. Fixes the confirmed-flaky tests that have been forcing retries on dev PR CI, dev CI, and main/release CI, plus **one real product race** the audit uncovered.

**Audit basis:** every test that failed or retried in the frozen 2-week window (2026-07-10 → 2026-07-24) across dev PR CI, dev CI, and main/release CI was mined, reconciled, and dispositioned — 2,709 runs / 68,851 normalized jobs / 39,941 successful test-bearing jobs scanned for internal retries. 62 suspects → **32 flaky / 17 healthy / 13 outdated**, zero indeterminate.

## What changed

**Product fix (1):**
- `sdk/broker/identity.ts` — broker identity key was published via exclusive-create *before* the write completed, so concurrent readers could observe a partial file (`Invalid broker identity key`). Now writes a private 0600 temp file in the same directory and publishes atomically via `link()`, with EEXIST losers re-reading the winner. Reproduced under 4× parallel contention; new regression test in `sdk-broker.test.ts`.

**Flaky test rewrites (11)** — root-cause fixes, not timeout bumps:
| Test | Root cause | Fix |
|---|---|---|
| `sdk-broker-lifecycle-e2e` broker resume | product identity race (above) | product fix + contention regression |
| `notifications-telegram-btw-e2e` /btw terminal dispatch | async dispatch race | in-flight delivery gate + deterministic drain |
| `notifications-telegram-daemon` foreign-owner provenance | process-global per-token setup lease | per-case lease isolation |
| `sdk-host-wiring` teardown drain | gate-resolution/detach ordering | explicit quiescence barrier + ordering assertion |
| `sdk-host-wiring` branch rotation | rotation began before startup barrier | await `{status:"started"}` before rotating |
| `agent-session-handoff` context-full fallback | fixed `Bun.sleep(20)` observation race | bounded polling |
| `harness-control-plane/owner` fenced-owner lease | heartbeat scheduling race | injected gated heartbeat seam |
| `sdk-tool-activation` built-ins discovery | `SQLITE_IOERR` in shared temp AuthStorage | unique `mkdtemp` per test |
| `sdk-query-pagination` 1MiB ceiling | load-sensitive randomized workload | bounded deterministic workload |
| `tools/gh` remote-add no-op | git-subprocess fixture cost | shared minimal remote fixture |
| `tools/gh` multi-PR checkout | git-subprocess fixture cost | skip unused fork setup + scoped 30s budget |

**Deletion (1):** one superseded `session-directory` member (append-only-sidecar contract replaced by retained-cleanup, `c49c2596`). The other 12 outdated identities were already removed by prior cutovers (`5edb79bc`, `6e147d58`) — verified absent, no action.

## Verification

- 220/220 targeted stress iterations; 80/80 under 4× parallel contention
- Mutation probes: removing the `/btw` in-flight guard **fails** the test as required; handoff-fallback and dispatch-authority probes fail as required
- Typecheck clean; `git diff --check` clean
- Every disposition carries CI-run citations, raw logs with sha256 sidecars, blinded second-architect validation, and a verification receipt (24 receipts)

## Not in scope

**No workflow, required-check, or branch-protection changes.** The audit found zero in-window Windows *test* escapes (the three Windows-adjacent failures were native-addon infra), so per the plan's history-driven bound no speculative Windows job was added — the targeted-job design is recorded design-only for when a class becomes evidenced.

## Pre-existing failures (not from this PR)

`session-directory` (15) + `sdk-broker` (1) + `sdk-host-wiring` Telegram-root-retry (1) fail identically on clean `origin/dev` at `7c3f5907b` with a locally-built native addon. The Telegram-root-retry one looks like a genuine regression from #3048 — flagging separately, not touching it here.

## Follow-ups

Ranked backlog and CI/merge policy recommendations (quarantine-lane retry bounds, Windows placement rules, the dev-PR-CI resharding experiment design with ≥30% floor) are in the directions doc produced alongside this work.