### PR TITLE
fix(ci): capture SDK daemon CLI child output through files

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Telegram notification topics now fence malformed successful `createForumTopic` responses per session endpoint, preventing repeated ambiguous topic creation while keeping explicit Bot API failures retryable.
 - Windows managed-session resume no longer reports `durability_failed` when Bun rejects `fsync` on the read-only descriptor used to revalidate an existing canonical binding; Windows now uses an owner-writable descriptor for that durability fence while retaining no-follow and pre/post identity/content checks.
-- SDK daemon CLI end-to-end tests now drain spawned child stdout and stderr concurrently with process exit, preventing CI pipe teardown races from replacing the product exit contract with SIGPIPE status 141 (#3024).
+- SDK daemon CLI end-to-end tests now capture spawned child stdout and stderr through temporary files instead of pipes, removing the CI pipe teardown race that replaced the product exit contract with SIGPIPE status 141 (#3024).
 - Interactive launch bootstrap is now suppressed for parser-accepted `--print=`, `--help=`, and `--version=` equals forms, keeping non-interactive output free of the warming-workspace preamble on TTYs.
 - Managed legacy-session artifact migration now accepts up to 50,000 files, processes copy work in bounded batches, and reports capacity exhaustion separately from unsafe artifact topology (#2935).
 - Kimi Code first-event timeouts now surface after the provider's continuous first-event wait instead of replaying the full request from zero.

--- a/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { closeSync, openSync } from "node:fs";
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import path from "node:path";
 import { Broker } from "../src/sdk/broker/broker";
 
@@ -7,17 +9,33 @@ const cliEntrypoint = path.resolve(import.meta.dir, "../src/cli.ts");
 
 type CliResult = { exitCode: number; stdout: string; stderr: string };
 
+// Capture through files rather than pipes: a piped child that outlives the
+// parent's read teardown can be killed by SIGPIPE (exit 141) under CI load,
+// which masks the CLI's real exit contract.
 async function runCli(repo: string, agentDir: string, args: string[]): Promise<CliResult> {
-	const child = Bun.spawn([process.execPath, "run", cliEntrypoint, "daemon", "session", ...args], {
-		cwd: repo,
-		env: { ...process.env, GJC_CODING_AGENT_DIR: agentDir },
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-	const stdout = new Response(child.stdout).text();
-	const stderr = new Response(child.stderr).text();
-	const [exitCode, stdoutText, stderrText] = await Promise.all([child.exited, stdout, stderr]);
-	return { exitCode, stdout: stdoutText, stderr: stderrText };
+	const captureDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-sdk-cli-capture-"));
+	const stdoutPath = path.join(captureDir, "stdout");
+	const stderrPath = path.join(captureDir, "stderr");
+	const stdoutFd = openSync(stdoutPath, "w");
+	const stderrFd = openSync(stderrPath, "w");
+	try {
+		const child = Bun.spawn([process.execPath, "run", cliEntrypoint, "daemon", "session", ...args], {
+			cwd: repo,
+			env: { ...process.env, GJC_CODING_AGENT_DIR: agentDir },
+			stdout: stdoutFd,
+			stderr: stderrFd,
+		});
+		const exitCode = await child.exited;
+		return {
+			exitCode,
+			stdout: await fs.readFile(stdoutPath, "utf8"),
+			stderr: await fs.readFile(stderrPath, "utf8"),
+		};
+	} finally {
+		closeSync(stdoutFd);
+		closeSync(stderrFd);
+		await fs.rm(captureDir, { recursive: true, force: true });
+	}
 }
 
 describe("SDK daemon session CLI", () => {


### PR DESCRIPTION
## Problem

Dev CI on the `dev` tip (run 30137375791) failed with a single test:

```
(fail) SDK daemon session CLI > AD-L-G02: uses the broker and per-session WebSocket endpoints without leaking ordinary credentials
  expect(query.exitCode).toBe(0)
  Expected: 0
  Received: 141
```

141 = SIGPIPE. The two other failing jobs (`evidence producer`, `Affected path validation`) are cascading fail-closed aggregates of this shard.

This is the known flake #3024. PR #3027 changed `runCli` to drain the child's stdout/stderr concurrently with `child.exited`, which narrowed the window but did not close it — the child can still write after the parent's pipe readers tear down, and gets SIGPIPE'd.

## Fix

Capture the child's stdout/stderr into a temporary directory via file descriptors instead of pipes. The child never writes to a pipe that can be closed underneath it, so the observed exit code is always the CLI's real exit contract.

## Verification

- `bun test test/sdk-daemon-cli-e2e.test.ts` — 5 pass, 0 fail
- 10x parallel repeat of the full file — 0 fail
- `biome check` on the changed test — OK