### PR TITLE
fix(tools): allow literal mid-word tildes in restricted role-agent bash

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Restricted role-agent `bash` now accepts literal mid-word tildes, so git revision syntax such as `git diff HEAD~1` no longer has to be quoted. Bash performs tilde expansion only at the start of a word, so word-initial forms (`~`, `~/path`, `~user`) remain blocked.
 - Interactive prompt cancellation now reaches API-key preflight through `ModelRegistry`, allowing aborted submissions to clear immediately even while a shared credential-usage request continues in the background.
 - Alibaba Token Plan canonical first-event timeouts now surface without session retry/fallback replay and are not internally retried by auto-compaction, preventing repeated provider usage (#3026).
 - Delegated-task and subagent status surfaces now distinguish provider recovery from normal running, identify first-event versus idle-stream stalls, show retry budget and provider-progress age, and aggregate concurrent degradation by provider (#3071).

--- a/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
+++ b/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
@@ -18,7 +18,9 @@ export interface BashRestrictionOptions {
 }
 
 const SHELL_CONTROL_CHARS = new Set([";", "|", "&", "<", ">", "(", ")"]);
-const UNSAFE_UNQUOTED_EXPANSION_CHARS = new Set(["$", "*", "?", "[", "]", "{", "}", "~"]);
+// `~` is handled separately: bash only performs tilde expansion at the start of a
+// word, so a mid-word `~` (e.g. the git revision `HEAD~1`) is a literal character.
+const UNSAFE_UNQUOTED_EXPANSION_CHARS = new Set(["$", "*", "?", "[", "]", "{", "}"]);
 const ALLOWED_STATE_ACTIONS = new Set(["read", "write", "contract"]);
 const CANONICAL_STATE_TARGETS = new Set<string>(CANONICAL_GJC_WORKFLOW_SKILLS);
 const READ_ONLY_COMMANDS = new Set(["grep", "rg", "tree", "ls", "pwd", "wc", "du", "file", "stat"]);
@@ -81,6 +83,13 @@ function parseShellWords(command: string): { words: string[]; reason?: string } 
 		}
 		if (UNSAFE_UNQUOTED_EXPANSION_CHARS.has(char)) {
 			return { words, reason: `shell expansion character '${char}' is not allowed in restricted bash commands` };
+		}
+		// Tilde expansion is positional: bash expands `~`, `~/path`, and `~user` only when
+		// the tilde opens a word. A tilde inside a word is literal, which is what git
+		// revision syntax such as `HEAD~1` relies on, so only the word-initial form is
+		// rejected here.
+		if (char === "~" && !wordStarted) {
+			return { words, reason: "shell expansion character '~' is not allowed in restricted bash commands" };
 		}
 		if (/\s/u.test(char)) {
 			if (wordStarted) {

--- a/packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts
+++ b/packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts
@@ -290,6 +290,34 @@ describe("checkBashAllowedPrefixes", () => {
 		expect(result.reason).toContain("shell expansion character");
 	});
 
+	it("allows literal mid-word tildes so git revision syntax works unquoted", () => {
+		const gitPrefixes = [...ROLE_AGENT_PREFIXES, "git diff", "git show", "git log", "git rev-parse"];
+
+		// bash performs tilde expansion only at the start of a word, so `HEAD~1` is a
+		// literal argument and must not be rejected as an expansion attempt.
+		for (const command of [
+			"git diff HEAD~1",
+			"git show HEAD~2",
+			"git diff HEAD~1..HEAD",
+			"git log HEAD~5",
+			"git rev-parse HEAD~3",
+			"git diff HEAD~1 -- src/a.ts",
+		]) {
+			expect({ command, ...checkBashAllowedPrefixes(command, gitPrefixes) }).toMatchObject({ allowed: true });
+		}
+	});
+
+	it("still blocks word-initial tildes that bash would expand to a home directory", () => {
+		const gitPrefixes = [...ROLE_AGENT_PREFIXES, "git diff", "git show", "git log"];
+
+		for (const command of ["git diff ~/secrets", "git show ~", "git log ~root", "git diff -- ~/x"]) {
+			const result = checkBashAllowedPrefixes(command, gitPrefixes);
+
+			expect({ command, allowed: result.allowed }).toMatchObject({ allowed: false });
+			expect(result.reason).toContain("shell expansion character");
+		}
+	});
+
 	it("blocks backslash escape smuggling", () => {
 		const result = checkBashAllowedPrefixes("gjc state ralplan\\ clear --json", ROLE_AGENT_PREFIXES);
 


### PR DESCRIPTION
Follow-up to #3109.

## The caveat this removes

#3109 gave `architect`/`planner`/`critic` read-only git, but shipped with a documented workaround: `git diff HEAD~1` was **blocked**, and agents had to write `git diff 'HEAD~1'`, `HEAD^`, or an explicit SHA. That's the single most common way to reference a prior revision, so it was a sharp edge on an otherwise useful capability.

## Root cause

`parseShellWords` treated `~` as an unsafe expansion character **anywhere** in a command:

```ts
const UNSAFE_UNQUOTED_EXPANSION_CHARS = new Set(["$", "*", "?", "[", "]", "{", "}", "~"]);
```

But bash performs tilde expansion **only at the start of a word**. `HEAD~1` is a literal argument, so this was a false positive — the guard was stricter than the threat it models.

## Fix

`~` is now checked positionally rather than unconditionally, reusing the `wordStarted` state the parser already tracks. Everything else is untouched: `$`, `*`, `?`, `[`, `]`, `{`, `}`, command substitution, control operators, and backslash escapes all behave exactly as before.

| | commands |
|---|---|
| ✅ now allowed | `git diff HEAD~1`, `git show HEAD~2`, `git diff HEAD~1..HEAD`, `git log HEAD~5`, `git rev-parse HEAD~3`, `git diff HEAD~1 -- src/a.ts` |
| ⛔ still blocked | `git diff ~/secrets`, `git show ~`, `git log ~root`, `git diff ~user/x`, `git diff -- ~/x`, `git diff $(cat x)`, ``git show `id` ``, `git log *.ts`, `git diff {a,b}`, `git show ?` |

## Verified against real bash

Rather than reasoning about the grammar, I checked what bash actually does. Every newly-allowed argument is literal; every still-blocked form genuinely expands:

```
LITERAL   HEAD~1        LITERAL   HEAD~1..HEAD      LITERAL   main...HEAD
EXPANDED  ~        -> /Users/bellman
EXPANDED  ~/secrets -> /Users/bellman/secrets
EXPANDED  ~root     -> /var/root
```

So the change strictly narrows a false positive without widening the real attack surface.

## Tests

Two focused cases added to `bash-allowed-prefixes.test.ts` — one locking the revision syntax, one locking the still-blocked home-directory forms.

```
bun test test/tools/bash-allowed-prefixes.test.ts test/default-gjc-definitions.test.ts \
         test/rlm.test.ts test/tools/bash-interceptor.test.ts test/tool-discovery
# 148 pass, 0 fail

bun run check:tools   # biome + tsc clean
```

Mutation-verified: restoring `"~"` to `UNSAFE_UNQUOTED_EXPANSION_CHARS` fails the new test, so it locks real behavior rather than restating the constant.

`rlm.test.ts` is included because the RLM read-only profile shares this parser.
