### PR TITLE
feat(ai): add Claude Opus 5 via typed generator seed and repair adaptive-display id parsing

### DIFF
--- a/artifacts/architecture-2383-eval.json
+++ b/artifacts/architecture-2383-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "67cd55244f886f568da678bda4314298f01abf0e",
-		"providerSourceSha256": "978c083395de102cb8c78d1e25b164daea3c3558dbd7d90e7a190d3f22550e9b",
+		"providerSourceBlobOid": "c56ed124951c9d922f727b6ddde123349effe0a5",
+		"providerSourceSha256": "22ebcf813814afefd9c07292dbb8b54904678715df70285f5ee9e19e46a578c0",
 		"inputFixtureSha256": "b1ca8d3183ca168140774f848ed414252178f7c5788d61243069862ae59c129b"
 	},
 	"derivationCommands": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added the Anthropic **Claude Opus 5** (`anthropic/claude-opus-5`) bundled catalog entry: 1M-token context window, 128k max output, text + image input, adaptive thinking through `max`, and $5 / $25 per MTok with $0.50 cache reads and $6.25 5-minute cache writes. The entry's source of truth is a typed `FIRST_PARTY_CATALOG_SEEDS` generator input carrying the Anthropic documentation URLs and retrieval date it was transcribed from; the seed is merged only when models.dev and provider discovery do not return the key, so upstream metadata always wins and credential-less regeneration keeps emitting the model. Catalog-only — the Anthropic provider default (`claude-sonnet-5`) and every built-in model profile are unchanged.
+
 ### Fixed
 
+- Fixed adaptive thinking being billed but never displayed whenever an Anthropic model id did not have the exact `claude-opus-<major>-<minor>` shape. `supportsAdaptiveThinkingDisplay` was a per-provider regex duplicated in the Anthropic Messages and Bedrock Converse transports, and it is now one shared predicate in `model-thinking.ts` that parses the Anthropic model version, the same authority `hasOpus47ApiRestrictions` already uses. Three id classes change behavior (same failure class as #2791): dateless ids (`claude-opus-5`, including region-prefixed Bedrock forms) and gateway dot-form ids (`claude-opus-4.7` / `claude-opus-4.8` / `-fast` on `github-copilot`, `vercel-ai-gateway`, `zenmux`) now send `display: "summarized"` instead of inheriting Anthropic's `omitted` default and no longer attach the redundant `interleaved-thinking-2025-05-14` beta; date-suffixed Opus 4.0 ids (`claude-opus-4-20250514` and its Bedrock variants) are no longer misread as version 4.20250514, so these budget-thinking models regain the interleaved-thinking beta they need. Opus 4.6, every Sonnet/Haiku, `-latest` aliases, and non-Anthropic ids are unaffected.
 - Credential selection and aggregate usage callers now stop awaiting immediately when their own signal aborts without cancelling shared usage fetches, and ranking deadlines no longer re-await the same stalled usage request during credential resolution.
 - Kimi Code now allows one continuous 300-second first-event wait before aborting, while preserving explicit caller and environment timeout overrides and the existing inter-event idle timeout.
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -111,6 +111,70 @@ export function injectImageGenerationModels(models: Model[]): void {
 	}
 }
 
+/**
+ * A first-party model transcribed from published provider documentation, kept as
+ * a typed generator input instead of a hand-edit in the generated catalog.
+ */
+interface FirstPartyCatalogSeed {
+	/** Upstream-shaped entry; normalization (name scrub, thinking, limits) runs later. */
+	readonly model: Model;
+	/** Published documentation the fields were transcribed from. */
+	readonly provenance: {
+		readonly sources: readonly string[];
+		readonly retrievedAt: string;
+	};
+}
+
+/**
+ * Typed catalog seeds for freshly published first-party models.
+ *
+ * models.dev and provider discovery stay the primary sources. A model published
+ * after the last upstream snapshot — or any regeneration without network access
+ * or provider credentials — would otherwise drop the entry, so each seed is
+ * merged only when the dynamic sources did not return the same provider/model
+ * key, then flows through the same pipeline as every other entry
+ * (`applyGlobalModelsDevFallback`, `applyGeneratedModelPolicies`, name
+ * scrubbing, thinking inference). No field is fixed up in `src/models.json`.
+ */
+export const FIRST_PARTY_CATALOG_SEEDS: readonly FirstPartyCatalogSeed[] = [
+	{
+		// Claude Opus 5: GA on the Claude API, announced 2026-07-24.
+		model: {
+			id: "claude-opus-5",
+			name: "Claude Opus 5",
+			api: "anthropic-messages",
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+			contextWindow: 1_000_000,
+			maxTokens: 128_000,
+		} satisfies Model<"anthropic-messages">,
+		provenance: {
+			sources: [
+				"https://platform.claude.com/docs/en/about-claude/models/overview",
+				"https://platform.claude.com/docs/en/about-claude/pricing",
+			],
+			retrievedAt: "2026-07-25",
+		},
+	},
+];
+
+/**
+ * Merge typed catalog seeds for provider/model keys the dynamic sources and the
+ * previous bundled catalog did not supply. Idempotent: seeding an array that
+ * already carries the key is a no-op, so upstream metadata always wins.
+ */
+export function injectFirstPartyCatalogSeeds(models: Model[]): void {
+	for (const seed of FIRST_PARTY_CATALOG_SEEDS) {
+		if (models.some(model => model.provider === seed.model.provider && model.id === seed.model.id)) {
+			continue;
+		}
+		models.push({ ...seed.model, input: [...seed.model.input], cost: { ...seed.model.cost } });
+	}
+}
+
 async function resolveProviderApiKey(providerId: string, catalog: CatalogDiscoveryConfig): Promise<string | undefined> {
 	for (const envVar of catalog.envVars) {
 		const value = $env[envVar as keyof typeof $env];
@@ -451,6 +515,9 @@ async function generateModels() {
 			}
 		}
 	}
+	// Typed first-party seeds fill models that neither the dynamic sources nor the
+	// previous catalog carried, then normalize with everything else below.
+	injectFirstPartyCatalogSeeds(allModels);
 	allModels = allModels.filter(model => !isRetiredBundledModel(model));
 
 	allModels = applyGlobalModelsDevFallback(allModels, modelsDevModels);

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -350,6 +350,24 @@ export function hasOpus47ApiRestrictions(modelId: string): boolean {
 	return semverGte(parsed.version, "4.7") && parsed.kind === "opus";
 }
 
+/**
+ * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
+ * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
+ * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
+ * "omitted" — thinking tokens are billed but no content streams back — so it
+ * must opt in like Opus 4.7+ (issue #2791).
+ *
+ * Version parsing (not id-shape matching) is the authority here: dateless ids
+ * carry a single version segment (`claude-opus-5`), and Bedrock ids add
+ * region/inference-profile prefixes (`eu.anthropic.claude-opus-5`).
+ */
+export function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
+	const parsed = parseAnthropicModel(getCanonicalModelId(modelId));
+	if (!parsed) return false;
+	if (parsed.kind === "fable") return true;
+	return parsed.kind === "opus" && semverGte(parsed.version, "4.7");
+}
+
 function anthropicModelHasRealXHighEffort<TApi extends Api>(model: ApiModel<TApi>): boolean {
 	if (model.api !== "anthropic-messages") return false;
 	const parsedModel = parseKnownModel(model.id);

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -3512,6 +3512,31 @@
 				"maxLevel": "max"
 			}
 		},
+		"claude-opus-5": {
+			"id": "claude-opus-5",
+			"name": "Anthropic Opus 5",
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"baseUrl": "https://api.anthropic.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "max"
+			}
+		},
 		"claude-sonnet-4-0": {
 			"id": "claude-sonnet-4-0",
 			"name": "Anthropic Sonnet 4 (latest)",

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -9,7 +9,11 @@
 
 import { $credentialEnv, $env, $flag, extractHttpStatusFromError, fetchWithRetry } from "@gajae-code/utils";
 import type { Effort } from "../model-thinking";
-import { mapEffortToAnthropicAdaptiveEffort, requireSupportedEffort } from "../model-thinking";
+import {
+	mapEffortToAnthropicAdaptiveEffort,
+	requireSupportedEffort,
+	supportsAdaptiveThinkingDisplay,
+} from "../model-thinking";
 import { calculateCost } from "../models";
 import type {
 	Api,
@@ -905,25 +909,6 @@ function buildAdditionalModelRequestFields(
 	}
 
 	return result;
-}
-
-/**
- * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
- * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
- * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
- * "omitted" — thinking tokens are billed but no content streams back — so it
- * must opt in like Opus 4.7+ (issue #2791).
- * Bedrock model ids are prefixed with region/inference-profile slugs (e.g.
- * `eu.anthropic.Anthropic model-opus-4-7-...`); the regex matches the `Anthropic model-opus-X-Y`
- * fragment regardless of prefix.
- */
-function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
-	if (/claude-fable-\d/.test(modelId)) return true;
-	const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
-	if (!match) return false;
-	const major = Number(match[1]);
-	const minor = Number(match[2]);
-	return major > 4 || (major === 4 && minor >= 7);
 }
 
 /**

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -19,7 +19,11 @@ import {
 	logger,
 	readSseEvents,
 } from "@gajae-code/utils";
-import { hasOpus47ApiRestrictions, mapEffortToAnthropicAdaptiveEffort } from "../model-thinking";
+import {
+	hasOpus47ApiRestrictions,
+	mapEffortToAnthropicAdaptiveEffort,
+	supportsAdaptiveThinkingDisplay,
+} from "../model-thinking";
 import { calculateCost } from "../models";
 import { isUsageLimitError } from "../rate-limit-utils";
 import { getEnvApiKey, OUTPUT_FALLBACK_BUFFER } from "../stream";
@@ -307,22 +311,6 @@ type AnthropicSamplingParams = MessageCreateParamsStreaming & {
 
 const ANTHROPIC_STOP_SEQUENCES_MAX = 4;
 let warnedStopSequencesTrim = false;
-
-/**
- * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
- * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
- * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
- * "omitted" — thinking tokens are billed but no content streams back — so it
- * must opt in like Opus 4.7+ (issue #2791).
- */
-function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
-	if (/claude-fable-\d/.test(modelId)) return true;
-	const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
-	if (!match) return false;
-	const major = Number(match[1]);
-	const minor = Number(match[2]);
-	return major > 4 || (major === 4 && minor >= 7);
-}
 
 const ANTHROPIC_PROVIDER_SESSION_STATE_KEY = "anthropic-messages";
 

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1166,6 +1166,44 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.output_config).toEqual({ effort: "high" });
 	});
 
+	it("requests summarized adaptive thinking for Opus 5 dateless ids", async () => {
+		const payload = (await captureAnthropicPayload(
+			{
+				...ANTHROPIC_MODEL,
+				id: "claude-opus-5",
+				name: "Anthropic Opus 5",
+				thinking: {
+					mode: "anthropic-adaptive",
+					minLevel: Effort.Minimal,
+					maxLevel: Effort.Max,
+				},
+			},
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				thinkingEnabled: true,
+				reasoning: Effort.Max,
+				temperature: 0.2,
+				topP: 0.3,
+				topK: 4,
+			},
+		)) as {
+			temperature?: number;
+			top_p?: number;
+			top_k?: number;
+			thinking?: { type?: string; display?: string };
+			output_config?: { effort?: string };
+		};
+
+		expect(payload.temperature).toBeUndefined();
+		expect(payload.top_p).toBeUndefined();
+		expect(payload.top_k).toBeUndefined();
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toEqual({ effort: "max" });
+	});
+
 	it("maps Opus max reasoning to Anthropic adaptive max", async () => {
 		const payload = (await captureAnthropicPayload(
 			{

--- a/packages/ai/test/generate-models.test.ts
+++ b/packages/ai/test/generate-models.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { injectImageGenerationModels } from "../scripts/generate-models";
-import type { Model } from "../src/types";
+import {
+	FIRST_PARTY_CATALOG_SEEDS,
+	injectFirstPartyCatalogSeeds,
+	injectImageGenerationModels,
+} from "../scripts/generate-models";
+import { applyGeneratedModelPolicies } from "../src/model-thinking";
+import { getBundledModel } from "../src/models";
+import type { Api, ApiModel, Model } from "../src/types";
 
 describe("injectImageGenerationModels", () => {
 	it("adds typed image-output models once for OpenAI and Codex", () => {
@@ -25,5 +31,60 @@ describe("injectImageGenerationModels", () => {
 				output: ["text", "image"],
 			}),
 		]);
+	});
+});
+
+describe("injectFirstPartyCatalogSeeds", () => {
+	it("carries published provenance for every seed", () => {
+		expect(FIRST_PARTY_CATALOG_SEEDS.length).toBeGreaterThan(0);
+		for (const seed of FIRST_PARTY_CATALOG_SEEDS) {
+			expect(seed.provenance.sources.length).toBeGreaterThan(0);
+			for (const source of seed.provenance.sources) {
+				expect(source).toMatch(/^https:\/\//);
+			}
+			expect(seed.provenance.retrievedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		}
+	});
+
+	it("reproduces the bundled catalog entry from the typed seed alone", () => {
+		// Deterministic: no network fetch, no provider credentials, no discovery.
+		// Seeding an empty catalog and running the generator's normalization must
+		// yield exactly the committed `models.json` entry, so the generated
+		// artifact stays reproducible from this source.
+		const models: Model[] = [];
+		injectFirstPartyCatalogSeeds(models);
+		applyGeneratedModelPolicies(models as ApiModel<Api>[]);
+
+		for (const seed of FIRST_PARTY_CATALOG_SEEDS) {
+			const generated = models.find(model => model.provider === seed.model.provider && model.id === seed.model.id);
+			const bundled = getBundledModel(seed.model.provider as Parameters<typeof getBundledModel>[0], seed.model.id);
+			expect(bundled).toBeDefined();
+			expect(JSON.parse(JSON.stringify(generated))).toEqual(JSON.parse(JSON.stringify(bundled)));
+		}
+	});
+
+	it("is idempotent and never overrides an upstream entry for the same key", () => {
+		const seed = FIRST_PARTY_CATALOG_SEEDS[0];
+		if (!seed) throw new Error("Expected at least one catalog seed");
+
+		const models: Model[] = [];
+		injectFirstPartyCatalogSeeds(models);
+		injectFirstPartyCatalogSeeds(models);
+		expect(models.filter(model => model.provider === seed.model.provider && model.id === seed.model.id)).toHaveLength(
+			1,
+		);
+
+		const upstream = { ...seed.model, name: "Upstream Name", contextWindow: 123_456 } as Model;
+		const withUpstream: Model[] = [upstream];
+		injectFirstPartyCatalogSeeds(withUpstream);
+		expect(withUpstream).toEqual([upstream]);
+	});
+
+	it("does not mutate the exported seed table", () => {
+		const before = JSON.parse(JSON.stringify(FIRST_PARTY_CATALOG_SEEDS));
+		const models: Model[] = [];
+		injectFirstPartyCatalogSeeds(models);
+		applyGeneratedModelPolicies(models as ApiModel<Api>[]);
+		expect(JSON.parse(JSON.stringify(FIRST_PARTY_CATALOG_SEEDS))).toEqual(before);
 	});
 });

--- a/packages/ai/test/issue-1373-repro.test.ts
+++ b/packages/ai/test/issue-1373-repro.test.ts
@@ -100,6 +100,16 @@ describe("issue #1373: Bedrock Claude thinkingDisplay", () => {
 		});
 	});
 
+	it("defaults adaptive thinking to display=summarized on Opus 5 dateless ids", async () => {
+		const payload = await captureBedrockPayload(adaptiveModel("us.anthropic.claude-opus-5"), {
+			reasoning: Effort.High,
+		});
+		expect(payload.additionalModelRequestFields?.thinking).toMatchObject({
+			type: "adaptive",
+			display: "summarized",
+		});
+	});
+
 	it("respects explicit thinkingDisplay='omitted' on Opus 4.7+", async () => {
 		const payload = await captureBedrockPayload(adaptiveModel("eu.anthropic.claude-opus-4-7"), {
 			reasoning: Effort.High,

--- a/packages/ai/test/issue-830-repro.test.ts
+++ b/packages/ai/test/issue-830-repro.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { Effort } from "../src/model-thinking";
 import { getBundledModel } from "../src/models";
 import { DEFAULT_MODEL_PER_PROVIDER, PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
 import { MODELS_DEV_PROVIDER_DESCRIPTORS } from "../src/provider-models/openai-compat";
@@ -76,5 +77,30 @@ describe("Anthropic Sonnet 5 model catalog support", () => {
 		expect(sonnet5?.api).toBe("anthropic-messages");
 		expect(sonnet5?.reasoning).toBe(true);
 		expect(sonnet46?.api).toBe("anthropic-messages");
+	});
+});
+
+describe("Anthropic Opus 5 model catalog support", () => {
+	test("registers Opus 5 with published Anthropic limits and pricing", () => {
+		const opus5 = getBundledModel("anthropic", "claude-opus-5");
+		expect(opus5?.api).toBe("anthropic-messages");
+		expect(opus5?.baseUrl).toBe("https://api.anthropic.com");
+		expect(opus5?.reasoning).toBe(true);
+		expect(opus5?.input).toEqual(["text", "image"]);
+		expect(opus5?.contextWindow).toBe(1_000_000);
+		expect(opus5?.maxTokens).toBe(128_000);
+		expect(opus5?.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
+		expect(opus5?.thinking).toEqual({
+			mode: "anthropic-adaptive",
+			minLevel: Effort.Minimal,
+			maxLevel: Effort.Max,
+		});
+	});
+
+	test("keeps the Anthropic provider default and older Opus entries untouched", () => {
+		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "anthropic");
+		expect(descriptor?.defaultModel).toBe("claude-sonnet-5");
+		expect(DEFAULT_MODEL_PER_PROVIDER.anthropic).toBe("claude-sonnet-5");
+		expect(getBundledModel("anthropic", "claude-opus-4-8")?.api).toBe("anthropic-messages");
 	});
 });

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -5,10 +5,12 @@ import {
 	clampThinkingLevelForModel,
 	Effort,
 	enrichModelThinking,
+	hasOpus47ApiRestrictions,
 	linkOpenAIPromotionTargets,
 	mapEffortToAnthropicAdaptiveEffort,
 	mapEffortToGoogleThinkingLevel,
 	requireSupportedEffort,
+	supportsAdaptiveThinkingDisplay,
 } from "@gajae-code/ai/model-thinking";
 import type { Api, Model, Provider, ThinkingControlMode } from "@gajae-code/ai/types";
 
@@ -183,6 +185,64 @@ describe("model thinking metadata", () => {
 		expect(fableBedrock.thinking?.maxLevel).toBe(Effort.High);
 		expect(mapEffortToAnthropicAdaptiveEffort(fableBedrock, Effort.High)).toBe("high");
 		expect(() => mapEffortToAnthropicAdaptiveEffort(fableBedrock, Effort.XHigh)).toThrow(/not supported/);
+	});
+
+	it("classifies dateless Opus 5 ids as adaptive thinking with xhigh + max support", () => {
+		const opus5 = createModel({
+			id: "claude-opus-5",
+			api: "anthropic-messages",
+			provider: "anthropic",
+		});
+		const opus5Bedrock = createModel({
+			id: "us.anthropic.claude-opus-5",
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+		});
+
+		expect(opus5.thinking).toEqual({
+			mode: "anthropic-adaptive",
+			minLevel: Effort.Minimal,
+			maxLevel: Effort.Max,
+		});
+		expect(mapEffortToAnthropicAdaptiveEffort(opus5, Effort.XHigh)).toBe("xhigh");
+		expect(mapEffortToAnthropicAdaptiveEffort(opus5, Effort.Max)).toBe("max");
+
+		// Bedrock Converse lacks the Messages-only xhigh preset (same split as Opus 4.7+).
+		expect(opus5Bedrock.thinking?.mode).toBe("anthropic-adaptive");
+		expect(opus5Bedrock.thinking?.maxLevel).toBe(Effort.Max);
+		expect(() => mapEffortToAnthropicAdaptiveEffort(opus5Bedrock, Effort.XHigh)).toThrow(/not supported/);
+		expect(mapEffortToAnthropicAdaptiveEffort(opus5Bedrock, Effort.Max)).toBe("max");
+	});
+
+	it("reports Opus 4.7+ restrictions and adaptive display for single-segment Opus versions", () => {
+		// Both Anthropic transports gate `display: "summarized"` on this predicate.
+		// A regex expecting `claude-opus-<major>-<minor>` never matched the dateless
+		// `claude-opus-5` id, so Opus 5 thinking was billed and never displayed.
+		expect(hasOpus47ApiRestrictions("claude-opus-5")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-5")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("us.anthropic.claude-opus-5")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-7")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-fable-5")).toBe(true);
+		// Opus 4.6 and every Sonnet reject the field.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-6")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-sonnet-5")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("gpt-5.6-sol")).toBe(false);
+	});
+
+	it("resolves adaptive display for dot-form ids and rejects date-suffixed Opus 4", () => {
+		// Gateways publish dot-form ids (`claude-opus-4.8`), which the dash-only
+		// regex never matched: Copilot / Vercel AI Gateway / ZenMux Opus 4.7+ were
+		// billed for adaptive thinking that streamed no content.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.8")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("anthropic/claude-opus-4.7-fast")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.6")).toBe(false);
+		// `claude-opus-4-20250514` is dated Opus 4.0, not version 4.20250514. The
+		// dash-only regex read the date as the minor version and misclassified it
+		// as Opus 4.7+, which also suppressed the interleaved-thinking beta these
+		// budget-thinking models need.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-20250514")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("us.anthropic.claude-opus-4-20250514-v1:0")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-1-20250805")).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -526,10 +526,16 @@ describe("ModelRegistry", () => {
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
-			const opusVariants = registry.getCanonicalVariants("claude-opus-4-8");
+			// `-latest` collapses onto the highest bundled version of the family,
+			// so the Opus target tracks the newest catalog entry (currently Opus 5).
+			const opusVariants = registry.getCanonicalVariants("claude-opus-5");
+			const supersededOpusVariants = registry.getCanonicalVariants("claude-opus-4-8");
 			const haikuVariants = registry.getCanonicalVariants("claude-haiku-4-5");
 
 			expect(opusVariants.some(variant => variant.selector === "demo/anthropic/claude-opus-latest")).toBe(true);
+			expect(supersededOpusVariants.some(variant => variant.selector === "demo/anthropic/claude-opus-latest")).toBe(
+				false,
+			);
 			expect(haikuVariants.some(variant => variant.selector === "demo/anthropic/claude-haiku-latest")).toBe(true);
 			expect(
 				registry


### PR DESCRIPTION
Supersedes #3097 (closed with `REQUEST_CHANGES`; that branch could not be reopened because it was force-pushed after closure). Same author, same branch, and this revision implements the blocking change you asked for.

## What you asked for in #3097

> Blocking catalog-generation defect: the first-party Opus 5 entry is added only by directly editing `packages/ai/src/models.json`. […] Move the entry into a typed generator input/fallback with provenance, regenerate `models.json`, and add a deterministic generation test independent of credentials and network discovery.

### 1. Typed generator input with provenance

`packages/ai/scripts/generate-models.ts` gains `FIRST_PARTY_CATALOG_SEEDS`, a typed table where each seed carries the upstream-shaped `Model` plus the published documentation it was transcribed from:

```ts
{
  model: { id: "claude-opus-5", name: "Claude Opus 5", api: "anthropic-messages", provider: "anthropic", … },
  provenance: {
    sources: [
      "https://platform.claude.com/docs/en/about-claude/models/overview",
      "https://platform.claude.com/docs/en/about-claude/pricing",
    ],
    retrievedAt: "2026-07-25",
  },
}
```

`injectFirstPartyCatalogSeeds` runs after the models.dev merge, the catalog-descriptor discovery, and the previous-`models.json` seed pass, and adds a seed **only when that provider/model key is still missing** — upstream metadata always wins, so this is a fallback for "published after the last upstream snapshot" and for credential-less/offline regeneration. models.dev has since picked Opus 5 up (`release_date 2026-07-24`), and the seed correctly becomes a no-op on a networked run.

The seed is deliberately upstream-shaped, not catalog-shaped: no `thinking` block, and the raw provider name. Normalization derives the rest, which is what proves nothing is hand-fixed in the artifact — `"Claude Opus 5"` → `"Anthropic Opus 5"` via `scrubGeneratedModelName`, and `thinking: { mode: "anthropic-adaptive", minLevel: "minimal", maxLevel: "max" }` via `refreshModelThinking`.

### 2. Regeneration

`bun packages/ai/scripts/generate-models.ts` was run, and the regenerated `anthropic/claude-opus-5` object is **byte-identical to the committed entry** (verified by parsing both files and comparing the objects).

I did **not** commit the rest of that regeneration output. The same run pulls in unrelated live upstream drift accumulated since the last catalog refresh: **1261 insertions / 142 deletions**, touching 17 providers — `openrouter` (+3 / 15 changed), `venice` (+3 / 16), `amazon-bedrock` (+6 / 7), `alibaba-token-plan` (+12), `google` (+6), `kilo` (+3 / 3), `vercel-ai-gateway` (+4 / 1), `github-copilot` (+1 / 1), `opencode-zen` (+2), `opencode-go` (+1), plus metadata-only changes in `cursor`, `gitlab-duo`, `litellm`, `openai`, `openai-codex`, `opengateway`, `qianfan`. That is a catalog refresh, not Opus 5 support, and folding it into this PR would make the diff unreviewable and conflict-prone. Happy to send it as a separate refresh PR, or to include any subset you want (the Bedrock region variants and the Copilot row for Opus 5 are part of that drift).

### 3. Deterministic generation test — no network, no credentials

`packages/ai/test/generate-models.test.ts` (existing file, same style as the `injectImageGenerationModels` test):

- **Reproducibility**: seed an empty catalog → `applyGeneratedModelPolicies` → deep-equals the committed `models.json` entry.
- **Idempotence**: repeated injection yields exactly one entry.
- **Upstream priority**: a pre-existing entry for the same key is never overwritten.
- **Purity**: the exported seed table is not mutated by injection or normalization.

## Everything else carried over from #3097

Your exact-head red-team on `c41454e6` cleared these; they are unchanged apart from the rebase onto current `dev`.

**Shared adaptive-display predicate.** `supportsAdaptiveThinkingDisplay` was duplicated verbatim in `providers/anthropic.ts` and `providers/amazon-bedrock.ts`, gating on `/claude-opus-(\d+)-(\d+)/`. Both copies are replaced by one exported predicate in `model-thinking.ts` that parses the Anthropic model version — the same authority `hasOpus47ApiRestrictions` uses. Replaying the old regex against all 511 bundled `anthropic-messages` / `bedrock-converse-stream` ids gives 12 diffs, all corrections:

| Class | Ids | Before → After | Effect |
| --- | --- | --- | --- |
| Dateless | `anthropic/claude-opus-5`, `us.anthropic.claude-opus-5` | `false` → `true` | Was inheriting Anthropic's `omitted` default: thinking billed, nothing streamed (#2791 class). |
| Gateway dot-form | `github-copilot/claude-opus-4.{7,8}`, `vercel-ai-gateway/anthropic/claude-opus-4.{7,8}` + `-fast`, `zenmux/anthropic/claude-opus-4.{7,8}` (8 ids, all `anthropic-adaptive`) | `false` → `true` | Same silent-thinking bug, pre-existing on `dev`, because the regex demanded dash-separated versions. Also drops the redundant `interleaved-thinking-2025-05-14` beta. |
| Date-suffixed Opus 4.0 | `anthropic/claude-opus-4-20250514`, `{us,eu}.anthropic.claude-opus-4-20250514-v1:0` (`budget` mode) | `true` → `false` | The old regex read the date as the minor version (`20250514 ≥ 7`) and classified Opus 4.0 as Opus 4.7+, suppressing the interleaved-thinking beta these models need. |

Unaffected: Opus 4.6 in dash and dot form, every Sonnet/Haiku, `claude-opus-4-1-20250805`, `-latest` aliases (`getCanonicalModelId` only strips up to the last `/`), non-Anthropic ids.

**Defaults untouched.** Anthropic provider default stays `claude-sonnet-5`; `claude-opus`, `opus-codex`, `fable-opus-codex` are unchanged; asserted by test. The only policy migration remains the existing canonical resolver: `claude-opus-latest` collapses onto the highest bundled Opus, now Opus 5, and `model-registry.test.ts` verifies both the new target and removal from Opus 4.8. Metadata impact is nil — the Opus 5 entry is identical to Opus 4.8 apart from `id`/`name`. I have not pinned `-latest` back to 4.8, since that would hardcode a per-model quality preference into a generic version-ordering resolver.

**Evidence artifact.** `artifacts/architecture-2383-eval.json` is refreshed with the recorded derivation command because it binds the blob OID / SHA-256 of `packages/ai/src/providers/anthropic.ts` (same pattern as #2794 / #2940 / #3046).

## Tests

```
bun test packages/ai/test/generate-models.test.ts \
         packages/ai/test/model-thinking.test.ts \
         packages/ai/test/issue-830-repro.test.ts \
         packages/ai/test/issue-1373-repro.test.ts \
         packages/ai/test/anthropic-alignment.test.ts \
         packages/ai/test/anthropic-cache-eval.integration.test.ts    # 94 pass / 0 fail
bun test packages/ai/test                                              # 1906 pass / 337 skip / 1 fail (pre-existing)
bun test packages/coding-agent/test/model-registry.test.ts -t "collapses anthropic latest aliases"   # pass
bun run check:tools        # biome + tsc (tools) clean
bun run check:public-sync  # in sync
bun run check:schemas      # clean
bun packages/ai/scripts/generate-models.ts   # regenerated entry == committed entry
```

Pre-existing failures on this machine, reproduced on an unmodified `dev` checkout: `auth-storage-if-absent.test.ts` (worker `stderr` assertion picks up Bun's `FORCE_COLOR` warning from the local env), two `model-registry.test.ts` canonical-variant stickiness tests (local AWS credentials present), and `agent-session-profile-resume-default.test.ts` (activation rollback).

## Still your call

- Whether to accept a first-party Opus 5 catalog entry at all.
- Whether `claude-opus-latest` retargeting to the highest bundled Opus is acceptable, or should be pinned.
- Whether the separate catalog refresh (the 1261/142 drift above) should land, and whether Opus 5's Bedrock/Copilot rows come with it.
- `claude-mythos-5` is not parsed by `parseAnthropicModel` (`opus|sonnet|fable`), so it would hit the same silent-thinking bug. It is in neither models.dev nor this catalog, so I left it out rather than write speculative support.
