### PR TITLE
feat(orca): Orca agent-status bridge — successor to #3113 (lifecycle + proxy blockers resolved)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Orca terminal panes now get live GJC agent status: a bundled Orca status bridge detects the pane's agent-hook endpoint (`ORCA_PANE_KEY` / `ORCA_AGENT_HOOK_ENDPOINT`) and reports pi-protocol lifecycle events (working/done state, active tool and input, prompt, last assistant reply, session resume metadata, startup prefill) to Orca's `/hook/pi` receiver. Root pane-owning sessions only; delivery is latest-only and strictly best-effort, with a WSL→Windows curl fallback for split-loopback setups.
+
 ### Fixed
 
 - Interactive prompt cancellation now reaches API-key preflight through `ModelRegistry`, allowing aborted submissions to clear immediately even while a shared credential-usage request continues in the background.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Orca terminal panes now get live GJC agent status: a bundled Orca status bridge detects the pane's agent-hook endpoint (`ORCA_PANE_KEY` / `ORCA_AGENT_HOOK_ENDPOINT`) and reports pi-protocol lifecycle events (working/done state, active tool and input, prompt, last assistant reply, session resume metadata, startup prefill) to Orca's `/hook/pi` receiver. Root pane-owning sessions only; delivery is latest-only and strictly best-effort, with a WSL→Windows curl fallback for split-loopback setups.
+- Orca terminal panes now get live GJC agent status: a bundled Orca status bridge detects the pane's agent-hook endpoint (`ORCA_PANE_KEY` / `ORCA_AGENT_HOOK_ENDPOINT`) and reports pi-protocol lifecycle events (working/done state, active tool and input, prompt, last assistant reply, session resume metadata, startup prefill) to Orca's `/hook/pi` receiver. Delivery is fail-closed and loopback-only: the hook port must be a strict decimal TCP port and the constructed URL is re-asserted component-by-component, hook tokens are charset-validated before header/argv use, and the endpoint file is trusted only after `O_NOFOLLOW` descriptor-pinned owner/mode and directory-ancestry validation. Exported previews are bounded, and the bridge is gated by the new `orca.statusBridge` setting (plus a `GJC_ORCA_STATUS_BRIDGE=0` kill-switch), registers for root pane-owning sessions only, and posts latest-only and strictly best-effort, with a hardened single-flight WSL→Windows curl fallback for split-loopback setups.
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -276,6 +276,13 @@ export const SETTINGS_SCHEMA = {
 		default: "copy-retain",
 	},
 
+	// Orca terminal integration: pi-protocol agent-status bridge. When enabled
+	// and the session runs inside an Orca pane, bounded status previews
+	// (state, prompt, tool name/input, last assistant reply) are posted to
+	// Orca's loopback agent-hook endpoint. Disable to keep session content
+	// out of the terminal host. Env kill-switch: GJC_ORCA_STATUS_BRIDGE=0.
+	"orca.statusBridge": { type: "boolean", default: true },
+
 	// Notifications (shared daemon with Telegram/Discord/Slack presentation adapters)
 	"notifications.enabled": { type: "boolean", default: false },
 	"notifications.telegram.botToken": {

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1823,10 +1823,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 		// Orca terminal panes export a loopback agent-hook endpoint; the bridge
 		// reports pi-protocol status events so Orca shows live agent state for
-		// GJC sessions. Root pane-owning sessions only; strictly best-effort.
+		// GJC sessions. Gated by the orca.statusBridge consent setting; root
+		// pane-owning sessions only; strictly best-effort and loopback-only.
 		if (
 			shouldRegisterOrcaStatusBridge({
 				env: process.env,
+				enabled: settings.get("orca.statusBridge") !== false,
 				taskDepth,
 				parentTaskPrefix: options.parentTaskPrefix,
 				currentAgentType: options.currentAgentType,

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -164,6 +164,7 @@ import { getImageGenTools } from "../tools/image-gen";
 import { wrapToolWithMetaNotice } from "../tools/output-meta";
 import { guardToolForUltragoalAsk } from "../tools/ultragoal-ask-guard";
 import { EventBus } from "../utils/event-bus";
+import { createOrcaStatusBridge, shouldRegisterOrcaStatusBridge } from "../utils/orca-status-bridge";
 import { buildNamedToolChoice, buildNamedToolChoiceResult } from "../utils/tool-choice";
 import { buildWorkspaceTree, type WorkspaceTree } from "../workspace-tree";
 import {
@@ -1818,6 +1819,22 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 		} catch (error) {
 			logger.warn("Failed to load constrained GJC plugin hooks", { error });
+		}
+
+		// Orca terminal panes export a loopback agent-hook endpoint; the bridge
+		// reports pi-protocol status events so Orca shows live agent state for
+		// GJC sessions. Root pane-owning sessions only; strictly best-effort.
+		if (
+			shouldRegisterOrcaStatusBridge({
+				env: process.env,
+				taskDepth,
+				parentTaskPrefix: options.parentTaskPrefix,
+				currentAgentType: options.currentAgentType,
+			})
+		) {
+			inlineExtensions.push(async api => {
+				createOrcaStatusBridge(api);
+			});
 		}
 		let notificationCfg: NotificationConfig | undefined;
 		try {

--- a/packages/coding-agent/src/utils/orca-status-bridge.ts
+++ b/packages/coding-agent/src/utils/orca-status-bridge.ts
@@ -13,11 +13,28 @@
  * filesystem extension discovery (which is quarantined) and without any
  * Orca-side changes.
  *
+ * Security contract (fail-closed):
+ * - Delivery only ever targets `http://127.0.0.1:<port>/hook/pi` where the
+ *   port is a strictly numeric TCP port; the constructed URL is re-asserted
+ *   component-by-component before any request. Coordinates that fail parsing
+ *   drop the post instead of degrading.
+ * - The hook token must match a conservative charset before it is placed in
+ *   a header or argv, so hostile env/file values cannot inject headers.
+ * - The endpoint file is opened `O_NOFOLLOW`, must be a regular file owned by
+ *   the current user without group/world write, its directory ancestry must
+ *   not be writable by other users, and contents are read through the pinned
+ *   file descriptor (no path re-dereference between validation and read).
+ * - Outbound previews are bounded (prompt/assistant text and serialized tool
+ *   input) and the bridge is gated by the `orca.statusBridge` setting plus a
+ *   `GJC_ORCA_STATUS_BRIDGE=0` environment kill-switch.
+ *
  * Delivery is strictly best-effort: a missing, restarting, or slow Orca must
  * never surface errors inside the session or delay the agent loop.
  */
 
+import { constants as fsConstants } from "node:fs";
 import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { logger } from "@gajae-code/utils";
 import type {
 	AgentEndEvent,
@@ -38,9 +55,19 @@ const HOOK_POST_TIMEOUT_MS = 1000;
 const OWNERSHIP_ENV = "ORCA_PI_STATUS_OWNED";
 /** Startup editor prefill delivered by Orca when launching a pi-protocol agent. */
 const PREFILL_ENV = "ORCA_PI_PREFILL";
+/** Environment kill-switch honored in addition to the `orca.statusBridge` setting. */
+const KILL_SWITCH_ENV = "GJC_ORCA_STATUS_BRIDGE";
 const AGENT_END_IDLE_RECHECK_MS = 25;
 const AGENT_END_IDLE_RECHECK_MAX_MS = 250;
 const WINDOWS_CURL_PATH = "/mnt/c/Windows/System32/curl.exe";
+/** Bounds for exported previews; Orca renders previews, not transcripts. */
+const MAX_PREVIEW_TEXT_CHARS = 2000;
+const MAX_TOOL_INPUT_JSON_CHARS = 4096;
+const TRUNCATION_MARKER = "…[truncated by GJC]";
+/** Hook tokens are Orca-generated UUID-shaped values; anything outside this
+ * charset is treated as hostile (prevents header/argv injection). */
+const TOKEN_PATTERN = /^[A-Za-z0-9._-]{8,256}$/;
+const PORT_PATTERN = /^[0-9]{1,5}$/;
 
 export interface OrcaHookCoords {
 	port: string | undefined;
@@ -54,10 +81,56 @@ export interface OrcaStatusBridgeOptions {
 	env?: NodeJS.ProcessEnv;
 	/** Fetch implementation. Default: global `fetch`. */
 	fetchImpl?: typeof fetch;
-	/** WSL runtime probe override (default: cached `/proc` sniff). */
+	/** WSL runtime probe override (default: `WSL_DISTRO_NAME` presence). */
 	isWslRuntime?: () => boolean;
-	/** Spawn seam for the WSL → Windows curl fallback. */
-	spawnCurl?: (command: string[], body: string) => void;
+	/** Spawn seam for the WSL → Windows curl fallback. Resolves when the
+	 * spawned delivery finishes (used to bound concurrent children). */
+	spawnCurl?: (command: string[], body: string) => Promise<void> | void;
+	/** POSIX uid override for endpoint-file ownership checks (test seam). */
+	ownerUid?: number;
+}
+
+/** Validate a hook port value: strictly decimal, 1–65535. */
+export function validateOrcaHookPort(value: string | undefined): string | null {
+	if (!value || !PORT_PATTERN.test(value)) return null;
+	const port = Number(value);
+	if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+	return String(port);
+}
+
+/** Validate a hook token for safe use in a header value and argv. */
+export function validateOrcaHookToken(value: string | undefined): string | null {
+	if (!value || !TOKEN_PATTERN.test(value)) return null;
+	return value;
+}
+
+/**
+ * Build the loopback hook URL and re-assert every component after
+ * construction, so no input can smuggle authority, credentials, or an
+ * alternate path into the request target.
+ */
+export function buildOrcaHookUrl(portValue: string | undefined): string | null {
+	const port = validateOrcaHookPort(portValue);
+	if (!port) return null;
+	let url: URL;
+	try {
+		url = new URL(`http://127.0.0.1:${port}${ORCA_HOOK_PATH}`);
+	} catch {
+		return null;
+	}
+	if (
+		url.protocol !== "http:" ||
+		url.hostname !== "127.0.0.1" ||
+		url.port !== port ||
+		url.pathname !== ORCA_HOOK_PATH ||
+		url.username !== "" ||
+		url.password !== "" ||
+		url.search !== "" ||
+		url.hash !== ""
+	) {
+		return null;
+	}
+	return url.href;
 }
 
 /**
@@ -73,10 +146,34 @@ export function parseOrcaEndpointFile(contents: string): Record<string, string> 
 	return out;
 }
 
+/** Bound a preview string; previews feed Orca's dashboard, not transcripts. */
+export function boundPreviewText(text: string, maxChars: number = MAX_PREVIEW_TEXT_CHARS): string {
+	if (text.length <= maxChars) return text;
+	return text.slice(0, maxChars) + TRUNCATION_MARKER;
+}
+
+/**
+ * Bound a raw tool input for export. Small inputs are forwarded verbatim so
+ * Orca can derive tool-aware previews server-side; oversized or
+ * unserializable inputs collapse to a bounded preview wrapper.
+ */
+export function boundToolInput(input: unknown): unknown {
+	let serialized: string;
+	try {
+		serialized = JSON.stringify(input) ?? "";
+	} catch {
+		return { gjc_truncated: true, preview: "" };
+	}
+	if (serialized.length <= MAX_TOOL_INPUT_JSON_CHARS) return input;
+	return { gjc_truncated: true, preview: serialized.slice(0, MAX_PREVIEW_TEXT_CHARS) + TRUNCATION_MARKER };
+}
+
 /**
  * Gate for registering the bridge on a session.
  *
  * Only the root interactive/print session of the pane-owning process reports:
+ * - requires the `orca.statusBridge` setting (explicit consent surface) and
+ *   the `GJC_ORCA_STATUS_BRIDGE` kill-switch to allow it;
  * - requires an Orca pane identity in the environment;
  * - helper/subagent sessions (task depth, parent prefix, role agent) stay
  *   silent so in-process fan-out does not thrash the pane status;
@@ -85,10 +182,14 @@ export function parseOrcaEndpointFile(contents: string): Record<string, string> 
  */
 export function shouldRegisterOrcaStatusBridge(input: {
 	env: NodeJS.ProcessEnv;
+	/** Value of the `orca.statusBridge` setting. */
+	enabled: boolean;
 	taskDepth?: number;
 	parentTaskPrefix?: string;
 	currentAgentType?: string;
 }): boolean {
+	if (!input.enabled) return false;
+	if (input.env[KILL_SWITCH_ENV] === "0") return false;
 	if (!input.env.ORCA_PANE_KEY) return false;
 	if ((input.taskDepth ?? 0) > 0 || input.parentTaskPrefix !== undefined || input.currentAgentType !== undefined) {
 		return false;
@@ -126,11 +227,11 @@ interface PendingPost {
  *
  * Event mapping (GJC extension events → Orca `/hook/pi` payloads):
  * - `session_start` → `session_start` (also applies `ORCA_PI_PREFILL`)
- * - `before_agent_start` → `before_agent_start` + `prompt`
+ * - `before_agent_start` → `before_agent_start` + bounded `prompt`
  * - `agent_start` → `agent_start`
  * - `tool_call` / `tool_execution_start` / `tool_execution_end` → same names
- *   with `tool_name` / raw `tool_input` (Orca derives the preview server-side)
- * - assistant `message_end` → `message_end` + visible `text`
+ *   with `tool_name` / bounded `tool_input` (Orca derives previews server-side)
+ * - assistant `message_end` → `message_end` + bounded visible `text`
  * - `agent_end` → `agent_end`, deferred until `ctx.isIdle()` so queued
  *   follow-up work keeps the pane in `working` instead of flapping to done.
  */
@@ -145,12 +246,16 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 	// snapshots, and status posting must stay off the agent-loop critical path.
 	let activePost = false;
 	let pendingPost: PendingPost | null = null;
-	// Endpoint-file cache keyed by stat identity: re-reading on every event is
-	// cheap but re-parsing during streaming tool execution is wasteful.
+	// Endpoint-file parse cache keyed by fstat identity of the pinned
+	// descriptor; ancestry approval is cached per resolved path.
 	let cachedEndpointKey = "";
 	let cachedEndpointValues: Record<string, string> | null = null;
+	let approvedAncestryPath: string | null = null;
 	let cachedIsWsl: boolean | null = null;
 	let cachedCurlAvailable: boolean | null = null;
+	// Bounded curl lifecycle: at most one Windows-side delivery in flight;
+	// bursts drop instead of accumulating child processes.
+	let curlInFlight = false;
 
 	function updateSessionMetadata(ctx: ExtensionContext): void {
 		const sessionId = ctx.sessionManager.getSessionId();
@@ -172,14 +277,74 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 		}
 	}
 
+	function ownerUid(): number | null {
+		if (options.ownerUid !== undefined) return options.ownerUid;
+		return typeof process.getuid === "function" ? process.getuid() : null;
+	}
+
+	/** ssh-style strict ancestry: every parent directory must be owned by the
+	 * current user or root and must not be writable by group/other, so another
+	 * local user cannot swap the endpoint file or a parent directory. */
+	async function validateEndpointAncestry(endpointPath: string): Promise<boolean> {
+		const resolved = path.resolve(endpointPath);
+		if (approvedAncestryPath === resolved) return true;
+		const uid = ownerUid();
+		if (uid === null) {
+			// Windows: no POSIX ownership; rely on O_NOFOLLOW-equivalent open and
+			// the loopback-only URL contract.
+			approvedAncestryPath = resolved;
+			return true;
+		}
+		let current = path.dirname(resolved);
+		for (;;) {
+			const stat = await fs.lstat(current);
+			if (!stat.isDirectory()) return false;
+			if (stat.uid !== uid && stat.uid !== 0) return false;
+			// Writable-by-others directories are only tolerated with the sticky
+			// bit (e.g. /tmp), where other users cannot rename or unlink entries.
+			if ((stat.mode & 0o022) !== 0 && (stat.mode & 0o1000) === 0) return false;
+			const parent = path.dirname(current);
+			if (parent === current) break;
+			current = parent;
+		}
+		approvedAncestryPath = resolved;
+		return true;
+	}
+
+	/**
+	 * Read the endpoint file fail-closed: `O_NOFOLLOW` open pins the inode,
+	 * ownership/mode are validated on the pinned descriptor, and contents are
+	 * read through that descriptor so no path re-dereference can race the
+	 * validation. Any failure returns null (env coordinates are NOT replaced
+	 * by unvalidated file contents).
+	 */
+	function rejectEndpoint(endpointPath: string, reason: string): null {
+		if (!warnedBadEndpoint) {
+			warnedBadEndpoint = true;
+			logger.warn("Orca status bridge rejected hook endpoint file", { path: endpointPath, reason });
+		}
+		return null;
+	}
+
 	async function readEndpointFile(): Promise<Record<string, string> | null> {
 		const endpointPath = env.ORCA_AGENT_HOOK_ENDPOINT;
 		if (!endpointPath) return null;
+		let handle: fs.FileHandle | undefined;
 		try {
-			const stat = await fs.stat(endpointPath);
-			const cacheKey = `${stat.mtimeMs}:${stat.size}:${stat.ino}`;
+			if (!(await validateEndpointAncestry(endpointPath))) {
+				return rejectEndpoint(endpointPath, "untrusted directory ancestry");
+			}
+			handle = await fs.open(endpointPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+			const stat = await handle.stat();
+			if (!stat.isFile()) return rejectEndpoint(endpointPath, "not a regular file");
+			const uid = ownerUid();
+			if (uid !== null) {
+				if (stat.uid !== uid) return rejectEndpoint(endpointPath, "not owned by the current user");
+				if ((stat.mode & 0o022) !== 0) return rejectEndpoint(endpointPath, "writable by group/other");
+			}
+			const cacheKey = `${stat.dev}:${stat.ino}:${stat.mtimeMs}:${stat.size}`;
 			if (cacheKey === cachedEndpointKey && cachedEndpointValues) return cachedEndpointValues;
-			const contents = await Bun.file(endpointPath).text();
+			const contents = await handle.readFile("utf8");
 			cachedEndpointValues = parseOrcaEndpointFile(contents);
 			cachedEndpointKey = cacheKey;
 			return cachedEndpointValues;
@@ -189,12 +354,14 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 			const code = (error as { code?: string } | null)?.code;
 			if (code !== "ENOENT" && !warnedBadEndpoint) {
 				warnedBadEndpoint = true;
-				logger.warn("Orca status bridge failed to read hook endpoint file", {
+				logger.warn("Orca status bridge rejected hook endpoint file", {
 					path: endpointPath,
 					error: String(error),
 				});
 			}
 			return null;
+		} finally {
+			await handle?.close().catch(() => {});
 		}
 	}
 
@@ -217,10 +384,14 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 
 	// WSL loopback is not the Windows loopback, so a WSL-side POST cannot reach
 	// Orca. curl.exe runs on the Windows side, where 127.0.0.1 IS the listener
-	// Orca binds. Fire-and-forget: blocking on the spawn would stall the TUI.
+	// Orca binds. The URL and token are the already-validated values, `-q`
+	// disables curlrc config processing, and at most one child is in flight.
 	async function postViaWindowsCurl(url: string, token: string, body: string): Promise<void> {
+		if (curlInFlight) return;
 		const command = [
 			WINDOWS_CURL_PATH,
+			// Must be first: disables .curlrc processing before other options.
+			"-q",
 			"-sS",
 			// The spawn is detached from the event loop, so these bounds size a
 			// background process, not TUI latency; WSL→Win32 connects can be slow.
@@ -243,7 +414,16 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 			url,
 		];
 		if (options.spawnCurl) {
-			options.spawnCurl(command, body);
+			const spawnCurl = options.spawnCurl;
+			curlInFlight = true;
+			// Fire-and-forget like the real path: delivery completion only clears
+			// the single-flight slot, it never blocks the post queue.
+			void Promise.resolve()
+				.then(() => spawnCurl(command, body))
+				.catch(() => {})
+				.finally(() => {
+					curlInFlight = false;
+				});
 			return;
 		}
 		if (cachedCurlAvailable === null) {
@@ -253,11 +433,20 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 		}
 		if (!cachedCurlAvailable) return;
 		try {
+			curlInFlight = true;
 			const child = Bun.spawn(command, { stdin: "pipe", stdout: "ignore", stderr: "ignore" });
 			child.stdin.write(body);
 			await child.stdin.end();
 			child.unref();
+			// Clear the slot when the bounded (--max-time) child exits; delivery
+			// itself stays fire-and-forget.
+			void child.exited
+				.catch(() => {})
+				.finally(() => {
+					curlInFlight = false;
+				});
 		} catch {
+			curlInFlight = false;
 			// Best-effort bridge; a failed spawn must not surface in the session.
 		}
 	}
@@ -265,8 +454,9 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 	async function postOnce(hookEventName: string, extra: Record<string, unknown>): Promise<void> {
 		const coords = await resolveHookCoords();
 		const paneKey = env.ORCA_PANE_KEY;
-		if (!coords.port || !coords.token || !paneKey) return;
-		const url = `http://127.0.0.1:${coords.port}${ORCA_HOOK_PATH}`;
+		const url = buildOrcaHookUrl(coords.port);
+		const token = validateOrcaHookToken(coords.token);
+		if (!url || !token || !paneKey) return;
 		const body = JSON.stringify({
 			paneKey,
 			launchToken: env.ORCA_AGENT_LAUNCH_TOKEN || "",
@@ -281,7 +471,7 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					"X-Orca-Agent-Hook-Token": coords.token,
+					"X-Orca-Agent-Hook-Token": token,
 				},
 				body,
 				signal: AbortSignal.timeout(HOOK_POST_TIMEOUT_MS),
@@ -290,7 +480,7 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 			// Status reporting must never fail the run because Orca is unavailable
 			// or restarting; on WSL fall through to the Windows-side listener.
 			if (!isWslRuntime()) return;
-			await postViaWindowsCurl(url, coords.token, body);
+			await postViaWindowsCurl(url, token, body);
 		}
 	}
 
@@ -372,7 +562,7 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 	});
 
 	pi.on("before_agent_start", (event: BeforeAgentStartEvent) => {
-		post("before_agent_start", { prompt: event.prompt ?? "" });
+		post("before_agent_start", { prompt: boundPreviewText(event.prompt ?? "") });
 	});
 
 	pi.on("agent_start", () => {
@@ -382,11 +572,11 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 	});
 
 	pi.on("tool_call", (event: ToolCallEvent) => {
-		post("tool_call", { tool_name: event.toolName, tool_input: event.input });
+		post("tool_call", { tool_name: event.toolName, tool_input: boundToolInput(event.input) });
 	});
 
 	pi.on("tool_execution_start", (event: ToolExecutionStartEvent) => {
-		post("tool_execution_start", { tool_name: event.toolName, tool_input: event.args });
+		post("tool_execution_start", { tool_name: event.toolName, tool_input: boundToolInput(event.args) });
 	});
 
 	pi.on("tool_execution_end", (event: ToolExecutionEndEvent) => {
@@ -400,7 +590,7 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 		if (message?.role !== "assistant") return;
 		const text = extractAssistantText(event.message);
 		if (!text) return;
-		post("message_end", { role: "assistant", text });
+		post("message_end", { role: "assistant", text: boundPreviewText(text) });
 	});
 
 	pi.on("agent_end", (_event: AgentEndEvent, ctx: ExtensionContext) => {

--- a/packages/coding-agent/src/utils/orca-status-bridge.ts
+++ b/packages/coding-agent/src/utils/orca-status-bridge.ts
@@ -29,6 +29,14 @@
  * - Outbound previews are bounded (prompt/assistant text and serialized tool
  *   input) and the bridge is gated by the `orca.statusBridge` setting plus a
  *   `GJC_ORCA_STATUS_BRIDGE=0` environment kill-switch.
+ * - The default transport is a raw loopback TCP socket, so inherited
+ *   HTTP(S)_PROXY environment routing can never carry the token or payload
+ *   off-host (Bun's fetch — and its node:http shim — honor proxy env even
+ *   for 127.0.0.1 targets), matching the curl path's `--noproxy 127.0.0.1`.
+ * - `session_shutdown` disposes the bridge: the agent_end idle recheck timer,
+ *   queued post state, and the pane ownership marker (when owned by this
+ *   process) are released, so never-idle sessions cannot leak timers or
+ *   suppress the next pane process's reporting.
  *
  * Delivery is strictly best-effort: a missing, restarting, or slow Orca must
  * never surface errors inside the session or delay the agent loop.
@@ -36,6 +44,7 @@
 
 import { constants as fsConstants } from "node:fs";
 import * as fs from "node:fs/promises";
+import * as net from "node:net";
 import * as path from "node:path";
 import { logger } from "@gajae-code/utils";
 import type {
@@ -145,6 +154,68 @@ export function buildOrcaHookUrl(
 }
 
 /**
+ * Proxy-immune loopback POST used as the default transport.
+ *
+ * Bun's `fetch` (and its `node:http` shim) honor inherited `HTTP(S)_PROXY`
+ * environment variables even for 127.0.0.1 targets, which would route the
+ * hook token and status payload through an arbitrary proxy. A raw TCP dial
+ * to the loopback address cannot be redirected by environment configuration.
+ * Exposed for tests; conforms to the `fetch` call shape the bridge uses.
+ */
+export async function loopbackHookFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+	const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+	if (url.protocol !== "http:" || url.hostname !== "127.0.0.1" || !url.port) {
+		throw new Error("loopbackHookFetch only accepts explicit http://127.0.0.1:<port> targets.");
+	}
+	const method = init?.method ?? "GET";
+	const headers = (init?.headers ?? {}) as Record<string, string>;
+	const body = typeof init?.body === "string" ? Buffer.from(init.body) : Buffer.alloc(0);
+	const signal = init?.signal ?? undefined;
+
+	return await new Promise<Response>((resolve, reject) => {
+		const socket = net.connect({ host: "127.0.0.1", port: Number(url.port) });
+		let settled = false;
+		let raw = "";
+		const fail = (error: Error): void => {
+			if (settled) return;
+			settled = true;
+			socket.destroy();
+			reject(error);
+		};
+		const onAbort = (): void => fail(new Error("Orca hook delivery aborted."));
+		signal?.addEventListener("abort", onAbort, { once: true });
+		socket.on("connect", () => {
+			const headerLines = Object.entries(headers)
+				.map(([name, value]) => `${name}: ${value}\r\n`)
+				.join("");
+			socket.write(
+				`${method} ${url.pathname} HTTP/1.1\r\n` +
+					`Host: 127.0.0.1:${url.port}\r\n` +
+					"Connection: close\r\n" +
+					`Content-Length: ${body.byteLength}\r\n` +
+					`${headerLines}\r\n`,
+			);
+			if (body.byteLength > 0) socket.write(body);
+		});
+		socket.on("data", chunk => {
+			raw += chunk.toString("utf8");
+		});
+		socket.on("error", error => fail(error instanceof Error ? error : new Error(String(error))));
+		socket.on("close", () => {
+			signal?.removeEventListener("abort", onAbort);
+			if (settled) return;
+			settled = true;
+			const match = raw.match(/^HTTP\/1\.[01] (\d{3})/);
+			if (!match) {
+				reject(new Error("Orca hook endpoint returned no HTTP status line."));
+				return;
+			}
+			resolve(new Response(null, { status: Number(match[1]) }));
+		});
+	});
+}
+
+/**
  * Parse an Orca endpoint file (`KEY=VALUE` POSIX env or `set KEY=VALUE`
  * Windows cmd form; tolerates CRLF line endings).
  */
@@ -248,13 +319,14 @@ interface PendingPost {
  */
 export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBridgeOptions = {}): void {
 	const env = options.env ?? process.env;
-	const fetchImpl = options.fetchImpl ?? fetch;
+	const fetchImpl = options.fetchImpl ?? loopbackHookFetch;
 	env[OWNERSHIP_ENV] = String(process.pid);
 
 	let sessionMetadata: Record<string, unknown> = {};
 	let warnedBadEndpoint = false;
 	// Latest-only delivery: a stalled Orca receiver must not queue up obsolete
 	// snapshots, and status posting must stay off the agent-loop critical path.
+	let disposed = false;
 	let activePost = false;
 	let pendingPost: PendingPost | null = null;
 	// Endpoint-file parse cache keyed by fstat identity of the pinned
@@ -523,6 +595,7 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 	}
 
 	function post(hookEventName: string, extra: Record<string, unknown> = {}): void {
+		if (disposed) return;
 		pendingPost = { hookEventName, extra };
 		drainPosts();
 	}
@@ -624,5 +697,25 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 		pendingAgentEndContext = ctx;
 		pendingAgentEndCheck = setTimeout(checkPendingAgentEnd, 0);
 		pendingAgentEndCheck.unref?.();
+	});
+
+	// Bounded lifecycle: session shutdown disposes the bridge so a never-idle
+	// session cannot keep the agent_end recheck timer rescheduling forever,
+	// retain queued post state, or leave the pane ownership marker claimed —
+	// which would suppress reporting from the next process to own this pane.
+	// Shutdown is a definitive turn boundary: an agent_end still deferred on
+	// the idle recheck reports now (once), or the pane would stay 'working'
+	// forever after a shutdown that raced the deferred post. `post()` refuses
+	// new work after disposal, so the queue empties once and stays empty.
+	pi.on("session_shutdown", () => {
+		if (disposed) return;
+		const agentEndStillDeferred = pendingAgentEndContext !== null;
+		clearPendingAgentEndCheck();
+		if (agentEndStillDeferred) postAgentEndOnce();
+		disposed = true;
+		drainPosts();
+		if (env[OWNERSHIP_ENV] === String(process.pid)) {
+			delete env[OWNERSHIP_ENV];
+		}
 	});
 }

--- a/packages/coding-agent/src/utils/orca-status-bridge.ts
+++ b/packages/coding-agent/src/utils/orca-status-bridge.ts
@@ -6,7 +6,8 @@
  * events to it get live status (working / done), tool activity, prompt, and
  * last-reply previews in Orca's dashboard and pane badges.
  *
- * Orca has first-class support for the pi hook protocol (`/hook/pi`), which
+ * Orca supports the pi hook protocol (`/hook/gjc` on versions with
+ * first-class GJC support, `/hook/pi` everywhere else), which
  * GJC speaks natively as a pi-lineage agent. This module ports the semantics
  * of Orca's managed `orca-agent-status.ts` pi extension onto GJC's bundled
  * extension surface, so GJC panes inside Orca report status without any
@@ -14,7 +15,8 @@
  * Orca-side changes.
  *
  * Security contract (fail-closed):
- * - Delivery only ever targets `http://127.0.0.1:<port>/hook/pi` where the
+ * - Delivery only ever targets `http://127.0.0.1:<port>/hook/gjc` (or the
+ *   `/hook/pi` fallback after a 404 negotiation) where the
  *   port is a strictly numeric TCP port; the constructed URL is re-asserted
  *   component-by-component before any request. Coordinates that fail parsing
  *   drop the post instead of degrading.
@@ -48,7 +50,12 @@ import type {
 	ToolExecutionStartEvent,
 } from "../extensibility/extensions";
 
-const ORCA_HOOK_PATH = "/hook/pi";
+/** Preferred route on Orca versions with first-class GJC support. */
+const ORCA_GJC_HOOK_PATH = "/hook/gjc";
+/** Fallback route accepted by every Orca version with pi support. */
+const ORCA_PI_HOOK_PATH = "/hook/pi";
+const ORCA_HOOK_PATHS = [ORCA_GJC_HOOK_PATH, ORCA_PI_HOOK_PATH] as const;
+export type OrcaHookPath = (typeof ORCA_HOOK_PATHS)[number];
 const HOOK_POST_TIMEOUT_MS = 1000;
 /** Pane-scoped ownership marker shared with Orca's managed pi extension: child
  * processes inherit the pane env, and only one process per pane may report. */
@@ -109,12 +116,16 @@ export function validateOrcaHookToken(value: string | undefined): string | null 
  * construction, so no input can smuggle authority, credentials, or an
  * alternate path into the request target.
  */
-export function buildOrcaHookUrl(portValue: string | undefined): string | null {
+export function buildOrcaHookUrl(
+	portValue: string | undefined,
+	hookPath: OrcaHookPath = ORCA_GJC_HOOK_PATH,
+): string | null {
 	const port = validateOrcaHookPort(portValue);
 	if (!port) return null;
+	if (!ORCA_HOOK_PATHS.includes(hookPath)) return null;
 	let url: URL;
 	try {
-		url = new URL(`http://127.0.0.1:${port}${ORCA_HOOK_PATH}`);
+		url = new URL(`http://127.0.0.1:${port}${hookPath}`);
 	} catch {
 		return null;
 	}
@@ -122,7 +133,7 @@ export function buildOrcaHookUrl(portValue: string | undefined): string | null {
 		url.protocol !== "http:" ||
 		url.hostname !== "127.0.0.1" ||
 		url.port !== port ||
-		url.pathname !== ORCA_HOOK_PATH ||
+		url.pathname !== hookPath ||
 		url.username !== "" ||
 		url.password !== "" ||
 		url.search !== "" ||
@@ -225,7 +236,7 @@ interface PendingPost {
 /**
  * Register the Orca status bridge on an extension API surface.
  *
- * Event mapping (GJC extension events → Orca `/hook/pi` payloads):
+ * Event mapping (GJC extension events → Orca pi-protocol payloads):
  * - `session_start` → `session_start` (also applies `ORCA_PI_PREFILL`)
  * - `before_agent_start` → `before_agent_start` + bounded `prompt`
  * - `agent_start` → `agent_start`
@@ -451,12 +462,16 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 		}
 	}
 
+	// Route negotiation: prefer the first-class GJC route; an Orca without it
+	// answers 404 once and the bridge permanently falls back to the pi route
+	// (which such versions render with pi identity but full status support).
+	let activeHookPath: OrcaHookPath = ORCA_GJC_HOOK_PATH;
+
 	async function postOnce(hookEventName: string, extra: Record<string, unknown>): Promise<void> {
 		const coords = await resolveHookCoords();
 		const paneKey = env.ORCA_PANE_KEY;
-		const url = buildOrcaHookUrl(coords.port);
 		const token = validateOrcaHookToken(coords.token);
-		if (!url || !token || !paneKey) return;
+		if (!token || !paneKey) return;
 		const body = JSON.stringify({
 			paneKey,
 			launchToken: env.ORCA_AGENT_LAUNCH_TOKEN || "",
@@ -466,21 +481,31 @@ export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBrid
 			version: coords.version,
 			payload: { hook_event_name: hookEventName, ...(await getPersistedSessionMetadata()), ...extra },
 		});
-		try {
-			await fetchImpl(url, {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					"X-Orca-Agent-Hook-Token": token,
-				},
-				body,
-				signal: AbortSignal.timeout(HOOK_POST_TIMEOUT_MS),
-			});
-		} catch {
-			// Status reporting must never fail the run because Orca is unavailable
-			// or restarting; on WSL fall through to the Windows-side listener.
-			if (!isWslRuntime()) return;
-			await postViaWindowsCurl(url, token, body);
+		for (;;) {
+			const url = buildOrcaHookUrl(coords.port, activeHookPath);
+			if (!url) return;
+			try {
+				const response = await fetchImpl(url, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"X-Orca-Agent-Hook-Token": token,
+					},
+					body,
+					signal: AbortSignal.timeout(HOOK_POST_TIMEOUT_MS),
+				});
+				if (response.status === 404 && activeHookPath === ORCA_GJC_HOOK_PATH) {
+					activeHookPath = ORCA_PI_HOOK_PATH;
+					continue;
+				}
+				return;
+			} catch {
+				// Status reporting must never fail the run because Orca is unavailable
+				// or restarting; on WSL fall through to the Windows-side listener.
+				if (!isWslRuntime()) return;
+				await postViaWindowsCurl(url, token, body);
+				return;
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/utils/orca-status-bridge.ts
+++ b/packages/coding-agent/src/utils/orca-status-bridge.ts
@@ -1,0 +1,413 @@
+/**
+ * Orca agent-status bridge.
+ *
+ * The Orca terminal exports a loopback agent-hook endpoint into every pane
+ * (`ORCA_AGENT_HOOK_ENDPOINT` / `ORCA_PANE_KEY`). Agents that POST lifecycle
+ * events to it get live status (working / done), tool activity, prompt, and
+ * last-reply previews in Orca's dashboard and pane badges.
+ *
+ * Orca has first-class support for the pi hook protocol (`/hook/pi`), which
+ * GJC speaks natively as a pi-lineage agent. This module ports the semantics
+ * of Orca's managed `orca-agent-status.ts` pi extension onto GJC's bundled
+ * extension surface, so GJC panes inside Orca report status without any
+ * filesystem extension discovery (which is quarantined) and without any
+ * Orca-side changes.
+ *
+ * Delivery is strictly best-effort: a missing, restarting, or slow Orca must
+ * never surface errors inside the session or delay the agent loop.
+ */
+
+import * as fs from "node:fs/promises";
+import { logger } from "@gajae-code/utils";
+import type {
+	AgentEndEvent,
+	BeforeAgentStartEvent,
+	ExtensionAPI,
+	ExtensionContext,
+	MessageEndEvent,
+	SessionStartEvent,
+	ToolCallEvent,
+	ToolExecutionEndEvent,
+	ToolExecutionStartEvent,
+} from "../extensibility/extensions";
+
+const ORCA_HOOK_PATH = "/hook/pi";
+const HOOK_POST_TIMEOUT_MS = 1000;
+/** Pane-scoped ownership marker shared with Orca's managed pi extension: child
+ * processes inherit the pane env, and only one process per pane may report. */
+const OWNERSHIP_ENV = "ORCA_PI_STATUS_OWNED";
+/** Startup editor prefill delivered by Orca when launching a pi-protocol agent. */
+const PREFILL_ENV = "ORCA_PI_PREFILL";
+const AGENT_END_IDLE_RECHECK_MS = 25;
+const AGENT_END_IDLE_RECHECK_MAX_MS = 250;
+const WINDOWS_CURL_PATH = "/mnt/c/Windows/System32/curl.exe";
+
+export interface OrcaHookCoords {
+	port: string | undefined;
+	token: string | undefined;
+	env: string;
+	version: string;
+}
+
+export interface OrcaStatusBridgeOptions {
+	/** Environment to read Orca coordinates from. Default: `process.env`. */
+	env?: NodeJS.ProcessEnv;
+	/** Fetch implementation. Default: global `fetch`. */
+	fetchImpl?: typeof fetch;
+	/** WSL runtime probe override (default: cached `/proc` sniff). */
+	isWslRuntime?: () => boolean;
+	/** Spawn seam for the WSL → Windows curl fallback. */
+	spawnCurl?: (command: string[], body: string) => void;
+}
+
+/**
+ * Parse an Orca endpoint file (`KEY=VALUE` POSIX env or `set KEY=VALUE`
+ * Windows cmd form; tolerates CRLF line endings).
+ */
+export function parseOrcaEndpointFile(contents: string): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const line of contents.split(/\r?\n/)) {
+		const match = line.match(/^(?:set\s+)?([A-Z0-9_]+)=(.*)$/);
+		if (match) out[match[1]] = match[2].replace(/\r$/, "");
+	}
+	return out;
+}
+
+/**
+ * Gate for registering the bridge on a session.
+ *
+ * Only the root interactive/print session of the pane-owning process reports:
+ * - requires an Orca pane identity in the environment;
+ * - helper/subagent sessions (task depth, parent prefix, role agent) stay
+ *   silent so in-process fan-out does not thrash the pane status;
+ * - a pane already owned by another process (inherited `ORCA_PI_STATUS_OWNED`)
+ *   stays with that owner.
+ */
+export function shouldRegisterOrcaStatusBridge(input: {
+	env: NodeJS.ProcessEnv;
+	taskDepth?: number;
+	parentTaskPrefix?: string;
+	currentAgentType?: string;
+}): boolean {
+	if (!input.env.ORCA_PANE_KEY) return false;
+	if ((input.taskDepth ?? 0) > 0 || input.parentTaskPrefix !== undefined || input.currentAgentType !== undefined) {
+		return false;
+	}
+	const owner = input.env[OWNERSHIP_ENV];
+	if (owner && owner !== String(process.pid)) return false;
+	return true;
+}
+
+/** Extract concatenated text parts from an assistant message for the dashboard
+ * preview; tool_use / reasoning parts are omitted (Orca renders tool activity
+ * from the dedicated tool events). */
+export function extractAssistantText(message: unknown): string {
+	if (!message || typeof message !== "object") return "";
+	const content = (message as { content?: unknown }).content;
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	let out = "";
+	for (const part of content) {
+		if (part && typeof part === "object" && (part as { type?: unknown }).type === "text") {
+			const text = (part as { text?: unknown }).text;
+			if (typeof text === "string") out += text;
+		}
+	}
+	return out;
+}
+
+interface PendingPost {
+	hookEventName: string;
+	extra: Record<string, unknown>;
+}
+
+/**
+ * Register the Orca status bridge on an extension API surface.
+ *
+ * Event mapping (GJC extension events → Orca `/hook/pi` payloads):
+ * - `session_start` → `session_start` (also applies `ORCA_PI_PREFILL`)
+ * - `before_agent_start` → `before_agent_start` + `prompt`
+ * - `agent_start` → `agent_start`
+ * - `tool_call` / `tool_execution_start` / `tool_execution_end` → same names
+ *   with `tool_name` / raw `tool_input` (Orca derives the preview server-side)
+ * - assistant `message_end` → `message_end` + visible `text`
+ * - `agent_end` → `agent_end`, deferred until `ctx.isIdle()` so queued
+ *   follow-up work keeps the pane in `working` instead of flapping to done.
+ */
+export function createOrcaStatusBridge(pi: ExtensionAPI, options: OrcaStatusBridgeOptions = {}): void {
+	const env = options.env ?? process.env;
+	const fetchImpl = options.fetchImpl ?? fetch;
+	env[OWNERSHIP_ENV] = String(process.pid);
+
+	let sessionMetadata: Record<string, unknown> = {};
+	let warnedBadEndpoint = false;
+	// Latest-only delivery: a stalled Orca receiver must not queue up obsolete
+	// snapshots, and status posting must stay off the agent-loop critical path.
+	let activePost = false;
+	let pendingPost: PendingPost | null = null;
+	// Endpoint-file cache keyed by stat identity: re-reading on every event is
+	// cheap but re-parsing during streaming tool execution is wasteful.
+	let cachedEndpointKey = "";
+	let cachedEndpointValues: Record<string, string> | null = null;
+	let cachedIsWsl: boolean | null = null;
+	let cachedCurlAvailable: boolean | null = null;
+
+	function updateSessionMetadata(ctx: ExtensionContext): void {
+		const sessionId = ctx.sessionManager.getSessionId();
+		const sessionFile = ctx.sessionManager.getSessionFile();
+		sessionMetadata = sessionId
+			? { session_id: sessionId, ...(sessionFile ? { session_file: sessionFile } : {}) }
+			: {};
+	}
+
+	async function getPersistedSessionMetadata(): Promise<Record<string, unknown>> {
+		const sessionFile = sessionMetadata.session_file;
+		if (typeof sessionFile !== "string" || !sessionFile) return {};
+		try {
+			// GJC publishes the planned session path before creating the transcript;
+			// recheck on every post so the first completed turn becomes resumable.
+			return (await Bun.file(sessionFile).exists()) ? sessionMetadata : {};
+		} catch {
+			return {};
+		}
+	}
+
+	async function readEndpointFile(): Promise<Record<string, string> | null> {
+		const endpointPath = env.ORCA_AGENT_HOOK_ENDPOINT;
+		if (!endpointPath) return null;
+		try {
+			const stat = await fs.stat(endpointPath);
+			const cacheKey = `${stat.mtimeMs}:${stat.size}:${stat.ino}`;
+			if (cacheKey === cachedEndpointKey && cachedEndpointValues) return cachedEndpointValues;
+			const contents = await Bun.file(endpointPath).text();
+			cachedEndpointValues = parseOrcaEndpointFile(contents);
+			cachedEndpointKey = cacheKey;
+			return cachedEndpointValues;
+		} catch (error) {
+			cachedEndpointKey = "";
+			cachedEndpointValues = null;
+			const code = (error as { code?: string } | null)?.code;
+			if (code !== "ENOENT" && !warnedBadEndpoint) {
+				warnedBadEndpoint = true;
+				logger.warn("Orca status bridge failed to read hook endpoint file", {
+					path: endpointPath,
+					error: String(error),
+				});
+			}
+			return null;
+		}
+	}
+
+	async function resolveHookCoords(): Promise<OrcaHookCoords> {
+		const fileEnv = (await readEndpointFile()) ?? {};
+		return {
+			port: fileEnv.ORCA_AGENT_HOOK_PORT || env.ORCA_AGENT_HOOK_PORT,
+			token: fileEnv.ORCA_AGENT_HOOK_TOKEN || env.ORCA_AGENT_HOOK_TOKEN,
+			env: fileEnv.ORCA_AGENT_HOOK_ENV || env.ORCA_AGENT_HOOK_ENV || "",
+			version: fileEnv.ORCA_AGENT_HOOK_VERSION || env.ORCA_AGENT_HOOK_VERSION || "",
+		};
+	}
+
+	function isWslRuntime(): boolean {
+		if (options.isWslRuntime) return options.isWslRuntime();
+		if (cachedIsWsl !== null) return cachedIsWsl;
+		cachedIsWsl = Boolean(env.WSL_DISTRO_NAME);
+		return cachedIsWsl;
+	}
+
+	// WSL loopback is not the Windows loopback, so a WSL-side POST cannot reach
+	// Orca. curl.exe runs on the Windows side, where 127.0.0.1 IS the listener
+	// Orca binds. Fire-and-forget: blocking on the spawn would stall the TUI.
+	async function postViaWindowsCurl(url: string, token: string, body: string): Promise<void> {
+		const command = [
+			WINDOWS_CURL_PATH,
+			"-sS",
+			// The spawn is detached from the event loop, so these bounds size a
+			// background process, not TUI latency; WSL→Win32 connects can be slow.
+			"--connect-timeout",
+			"3",
+			"--max-time",
+			"10",
+			"--noproxy",
+			"127.0.0.1",
+			"-o",
+			"NUL",
+			"-X",
+			"POST",
+			"-H",
+			"Content-Type: application/json",
+			"-H",
+			`X-Orca-Agent-Hook-Token: ${token}`,
+			"--data-binary",
+			"@-",
+			url,
+		];
+		if (options.spawnCurl) {
+			options.spawnCurl(command, body);
+			return;
+		}
+		if (cachedCurlAvailable === null) {
+			cachedCurlAvailable = await Bun.file(WINDOWS_CURL_PATH)
+				.exists()
+				.catch(() => false);
+		}
+		if (!cachedCurlAvailable) return;
+		try {
+			const child = Bun.spawn(command, { stdin: "pipe", stdout: "ignore", stderr: "ignore" });
+			child.stdin.write(body);
+			await child.stdin.end();
+			child.unref();
+		} catch {
+			// Best-effort bridge; a failed spawn must not surface in the session.
+		}
+	}
+
+	async function postOnce(hookEventName: string, extra: Record<string, unknown>): Promise<void> {
+		const coords = await resolveHookCoords();
+		const paneKey = env.ORCA_PANE_KEY;
+		if (!coords.port || !coords.token || !paneKey) return;
+		const url = `http://127.0.0.1:${coords.port}${ORCA_HOOK_PATH}`;
+		const body = JSON.stringify({
+			paneKey,
+			launchToken: env.ORCA_AGENT_LAUNCH_TOKEN || "",
+			tabId: env.ORCA_TAB_ID || "",
+			worktreeId: env.ORCA_WORKTREE_ID || "",
+			env: coords.env,
+			version: coords.version,
+			payload: { hook_event_name: hookEventName, ...(await getPersistedSessionMetadata()), ...extra },
+		});
+		try {
+			await fetchImpl(url, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"X-Orca-Agent-Hook-Token": coords.token,
+				},
+				body,
+				signal: AbortSignal.timeout(HOOK_POST_TIMEOUT_MS),
+			});
+		} catch {
+			// Status reporting must never fail the run because Orca is unavailable
+			// or restarting; on WSL fall through to the Windows-side listener.
+			if (!isWslRuntime()) return;
+			await postViaWindowsCurl(url, coords.token, body);
+		}
+	}
+
+	function drainPosts(): void {
+		if (activePost || !pendingPost) return;
+		const next = pendingPost;
+		pendingPost = null;
+		activePost = true;
+		void postOnce(next.hookEventName, next.extra)
+			.catch(() => {})
+			.finally(() => {
+				activePost = false;
+				drainPosts();
+			});
+	}
+
+	function post(hookEventName: string, extra: Record<string, unknown> = {}): void {
+		pendingPost = { hookEventName, extra };
+		drainPosts();
+	}
+
+	function applyStartupPrefill(ctx: ExtensionContext): void {
+		const prefill = env[PREFILL_ENV];
+		if (!prefill || !ctx.hasUI) return;
+		delete env[PREFILL_ENV];
+		try {
+			ctx.ui.setEditorText(prefill);
+		} catch {
+			// Prefill is a convenience; ignore hosts without an editor surface.
+		}
+	}
+
+	// GJC stays non-idle across retry/compaction/queued follow-up work, so a
+	// bare agent_end may not be a turn boundary yet. Defer the done post until
+	// the session is actually idle, with a capped exponential recheck.
+	let agentEndReported = false;
+	let agentEndIdleRecheckMs = AGENT_END_IDLE_RECHECK_MS;
+	let pendingAgentEndCheck: ReturnType<typeof setTimeout> | null = null;
+	let pendingAgentEndContext: Pick<ExtensionContext, "isIdle"> | null = null;
+
+	function clearPendingAgentEndCheck(): void {
+		if (pendingAgentEndCheck !== null) clearTimeout(pendingAgentEndCheck);
+		pendingAgentEndCheck = null;
+		pendingAgentEndContext = null;
+	}
+
+	function postAgentEndOnce(): void {
+		if (agentEndReported) return;
+		agentEndReported = true;
+		post("agent_end");
+	}
+
+	function checkPendingAgentEnd(): void {
+		pendingAgentEndCheck = null;
+		const ctx = pendingAgentEndContext;
+		if (!ctx || agentEndReported) {
+			pendingAgentEndContext = null;
+			return;
+		}
+		try {
+			if (ctx.isIdle()) {
+				pendingAgentEndContext = null;
+				postAgentEndOnce();
+				return;
+			}
+		} catch {
+			pendingAgentEndContext = null;
+			return;
+		}
+		pendingAgentEndCheck = setTimeout(checkPendingAgentEnd, agentEndIdleRecheckMs);
+		pendingAgentEndCheck.unref?.();
+		agentEndIdleRecheckMs = Math.min(agentEndIdleRecheckMs * 2, AGENT_END_IDLE_RECHECK_MAX_MS);
+	}
+
+	pi.on("session_start", (_event: SessionStartEvent, ctx: ExtensionContext) => {
+		updateSessionMetadata(ctx);
+		applyStartupPrefill(ctx);
+		post("session_start");
+	});
+
+	pi.on("before_agent_start", (event: BeforeAgentStartEvent) => {
+		post("before_agent_start", { prompt: event.prompt ?? "" });
+	});
+
+	pi.on("agent_start", () => {
+		clearPendingAgentEndCheck();
+		agentEndReported = false;
+		post("agent_start");
+	});
+
+	pi.on("tool_call", (event: ToolCallEvent) => {
+		post("tool_call", { tool_name: event.toolName, tool_input: event.input });
+	});
+
+	pi.on("tool_execution_start", (event: ToolExecutionStartEvent) => {
+		post("tool_execution_start", { tool_name: event.toolName, tool_input: event.args });
+	});
+
+	pi.on("tool_execution_end", (event: ToolExecutionEndEvent) => {
+		post("tool_execution_end", { tool_name: event.toolName });
+	});
+
+	// Capture the assistant's final text on each completed message so the
+	// dashboard preview reflects the latest reply before agent_end fires.
+	pi.on("message_end", (event: MessageEndEvent) => {
+		const message = event.message as { role?: unknown };
+		if (message?.role !== "assistant") return;
+		const text = extractAssistantText(event.message);
+		if (!text) return;
+		post("message_end", { role: "assistant", text });
+	});
+
+	pi.on("agent_end", (_event: AgentEndEvent, ctx: ExtensionContext) => {
+		clearPendingAgentEndCheck();
+		agentEndIdleRecheckMs = AGENT_END_IDLE_RECHECK_MS;
+		pendingAgentEndContext = ctx;
+		pendingAgentEndCheck = setTimeout(checkPendingAgentEnd, 0);
+		pendingAgentEndCheck.unref?.();
+	});
+}

--- a/packages/coding-agent/test/orca-status-bridge.test.ts
+++ b/packages/coding-agent/test/orca-status-bridge.test.ts
@@ -560,6 +560,105 @@ describe("createOrcaStatusBridge delivery", () => {
 		expect((await second).url).toBe("/hook/pi");
 	});
 
+	it("uses a proxy-immune transport by default: inherited HTTP_PROXY never sees the payload", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const proxyHits: string[] = [];
+		const proxyServer = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch: request => {
+				proxyHits.push(request.url);
+				return new Response("via-proxy");
+			},
+		});
+		cleanups.push(() => proxyServer.stop(true));
+		const savedProxy = { HTTP_PROXY: process.env.HTTP_PROXY, http_proxy: process.env.http_proxy };
+		process.env.HTTP_PROXY = `http://127.0.0.1:${proxyServer.port}`;
+		process.env.http_proxy = process.env.HTTP_PROXY;
+		cleanups.push(() => {
+			if (savedProxy.HTTP_PROXY === undefined) delete process.env.HTTP_PROXY;
+			else process.env.HTTP_PROXY = savedProxy.HTTP_PROXY;
+			if (savedProxy.http_proxy === undefined) delete process.env.http_proxy;
+			else process.env.http_proxy = savedProxy.http_proxy;
+		});
+
+		const { api, handlers } = captureHandlers();
+		// No fetchImpl seam: exercises the real default transport.
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		const delivery = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		const post = await delivery;
+		expect(post.url).toBe("/hook/gjc");
+		expect(post.token).toBe("test-token-1234");
+		expect(post.body.payload.hook_event_name).toBe("agent_start");
+		expect(proxyHits).toEqual([]);
+	});
+
+	it("disposes on session_shutdown: never-idle recheck stops and ownership is released", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		const env = bridgeEnv(receiver);
+		createOrcaStatusBridge(api, { env });
+		expect(env.ORCA_PI_STATUS_OWNED).toBe(String(process.pid));
+		const ctx = fakeContext({ isIdle: () => false });
+
+		const started = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, ctx);
+		await started;
+		// Deterministic never-idle: the recheck loop is live when shutdown fires.
+		handlers.get("agent_end")?.({ type: "agent_end", messages: [] }, ctx);
+		await Bun.sleep(80);
+		const finalPost = receiver.nextDelivery();
+		handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
+		expect(env.ORCA_PI_STATUS_OWNED).toBeUndefined();
+		// Shutdown is the turn boundary: the deferred agent_end reports exactly once.
+		expect((await finalPost).body.payload.hook_event_name).toBe("agent_end");
+		const before = receiver.received.length;
+		// Longer than the max recheck interval: a surviving timer would fire here.
+		await Bun.sleep(400);
+		expect(receiver.received.filter(post => post.body.payload.hook_event_name === "agent_end")).toHaveLength(1);
+		// Disposed bridge ignores later events entirely.
+		handlers.get("agent_start")?.({ type: "agent_start" }, ctx);
+		await Bun.sleep(40);
+		expect(receiver.received.length).toBe(before);
+	});
+
+	it("flushes a snapshot queued at shutdown instead of dropping the final done state", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		const ctx = fakeContext();
+
+		// Hold the first post open so the next snapshot is queued, then shut
+		// down while it is still pending — the race print mode exhibits.
+		receiver.hold = true;
+		const first = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, ctx);
+		await first;
+		handlers.get("agent_end")?.({ type: "agent_end", messages: [] }, ctx);
+		await Bun.sleep(40);
+		handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
+		const flushed = receiver.nextDelivery();
+		receiver.hold = false;
+		receiver.releaseHeld();
+		expect((await flushed).body.payload.hook_event_name).toBe("agent_end");
+	});
+
+	it("does not release a pane ownership marker another process has since claimed", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		const env = bridgeEnv(receiver);
+		createOrcaStatusBridge(api, { env });
+		const otherPid = String(process.pid + 1);
+		env.ORCA_PI_STATUS_OWNED = otherPid;
+		handlers.get("session_shutdown")?.({ type: "session_shutdown" }, fakeContext());
+		expect(env.ORCA_PI_STATUS_OWNED).toBe(otherPid);
+	});
+
 	it("stays inert without Orca coordinates", async () => {
 		const { api, handlers } = captureHandlers();
 		createOrcaStatusBridge(api, { env: { ORCA_PANE_KEY: "tab-1:leaf-1" } as NodeJS.ProcessEnv });

--- a/packages/coding-agent/test/orca-status-bridge.test.ts
+++ b/packages/coding-agent/test/orca-status-bridge.test.ts
@@ -4,10 +4,14 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "../src/extensibility/extensions";
 import {
+	boundPreviewText,
+	boundToolInput,
+	buildOrcaHookUrl,
 	createOrcaStatusBridge,
 	extractAssistantText,
 	parseOrcaEndpointFile,
 	shouldRegisterOrcaStatusBridge,
+	validateOrcaHookToken,
 } from "../src/utils/orca-status-bridge";
 
 type ExtensionEventHandler = (event: unknown, ctx: ExtensionContext) => unknown;
@@ -109,10 +113,12 @@ function bridgeEnv(receiver: HookReceiver, extra: Record<string, string> = {}): 
 		ORCA_TAB_ID: "tab-1",
 		ORCA_WORKTREE_ID: "repo::wt",
 		ORCA_AGENT_HOOK_PORT: String(receiver.port),
-		ORCA_AGENT_HOOK_TOKEN: "test-token",
+		ORCA_AGENT_HOOK_TOKEN: "test-token-1234",
 		...extra,
 	} as NodeJS.ProcessEnv;
 }
+
+const REGISTER_BASE = { enabled: true } as const;
 
 const cleanups: Array<() => void> = [];
 afterEach(() => {
@@ -141,28 +147,93 @@ describe("parseOrcaEndpointFile", () => {
 	});
 });
 
+describe("buildOrcaHookUrl", () => {
+	it("builds a loopback URL for a strictly numeric port", () => {
+		expect(buildOrcaHookUrl("57343")).toBe("http://127.0.0.1:57343/hook/pi");
+		expect(buildOrcaHookUrl("007")).toBe("http://127.0.0.1:7/hook/pi");
+	});
+
+	it("rejects authority-injection and malformed port values", () => {
+		expect(buildOrcaHookUrl("80@evil.example")).toBeNull();
+		expect(buildOrcaHookUrl("80/evil")).toBeNull();
+		expect(buildOrcaHookUrl("80?x=1")).toBeNull();
+		expect(buildOrcaHookUrl("80#frag")).toBeNull();
+		expect(buildOrcaHookUrl("80 81")).toBeNull();
+		expect(buildOrcaHookUrl("-1")).toBeNull();
+		expect(buildOrcaHookUrl("0")).toBeNull();
+		expect(buildOrcaHookUrl("65536")).toBeNull();
+		expect(buildOrcaHookUrl("")).toBeNull();
+		expect(buildOrcaHookUrl(undefined)).toBeNull();
+	});
+});
+
+describe("validateOrcaHookToken", () => {
+	it("accepts UUID-shaped tokens and rejects injection attempts", () => {
+		expect(validateOrcaHookToken("a6d786d1-c208-4347-81c2-cf56872b16fd")).toBe(
+			"a6d786d1-c208-4347-81c2-cf56872b16fd",
+		);
+		expect(validateOrcaHookToken("bad\r\nX-Injected: 1")).toBeNull();
+		expect(validateOrcaHookToken("has space")).toBeNull();
+		expect(validateOrcaHookToken("short")).toBeNull();
+		expect(validateOrcaHookToken(undefined)).toBeNull();
+	});
+});
+
+describe("preview bounding", () => {
+	it("bounds preview text with a truncation marker", () => {
+		expect(boundPreviewText("short")).toBe("short");
+		const bounded = boundPreviewText("x".repeat(5000));
+		expect(bounded.length).toBeLessThan(2100);
+		expect(bounded.endsWith("…[truncated by GJC]")).toBe(true);
+	});
+
+	it("forwards small tool inputs verbatim and collapses oversized ones", () => {
+		const small = { command: "ls" };
+		expect(boundToolInput(small)).toBe(small);
+		const huge = { blob: "y".repeat(10000) };
+		const bounded = boundToolInput(huge) as { gjc_truncated: boolean; preview: string };
+		expect(bounded.gjc_truncated).toBe(true);
+		expect(bounded.preview.length).toBeLessThan(2100);
+	});
+});
+
 describe("shouldRegisterOrcaStatusBridge", () => {
 	it("requires an Orca pane identity", () => {
-		expect(shouldRegisterOrcaStatusBridge({ env: {} as NodeJS.ProcessEnv })).toBe(false);
-		expect(shouldRegisterOrcaStatusBridge({ env: { ORCA_PANE_KEY: "t:l" } as NodeJS.ProcessEnv })).toBe(true);
+		expect(shouldRegisterOrcaStatusBridge({ ...REGISTER_BASE, env: {} as NodeJS.ProcessEnv })).toBe(false);
+		expect(
+			shouldRegisterOrcaStatusBridge({ ...REGISTER_BASE, env: { ORCA_PANE_KEY: "t:l" } as NodeJS.ProcessEnv }),
+		).toBe(true);
+	});
+
+	it("respects the consent setting and the environment kill-switch", () => {
+		const env = { ORCA_PANE_KEY: "t:l" } as NodeJS.ProcessEnv;
+		expect(shouldRegisterOrcaStatusBridge({ env, enabled: false })).toBe(false);
+		expect(
+			shouldRegisterOrcaStatusBridge({
+				enabled: true,
+				env: { ORCA_PANE_KEY: "t:l", GJC_ORCA_STATUS_BRIDGE: "0" } as NodeJS.ProcessEnv,
+			}),
+		).toBe(false);
 	});
 
 	it("stays silent for helper and subagent sessions", () => {
 		const env = { ORCA_PANE_KEY: "t:l" } as NodeJS.ProcessEnv;
-		expect(shouldRegisterOrcaStatusBridge({ env, taskDepth: 1 })).toBe(false);
-		expect(shouldRegisterOrcaStatusBridge({ env, parentTaskPrefix: "6-Extensions" })).toBe(false);
-		expect(shouldRegisterOrcaStatusBridge({ env, currentAgentType: "executor" })).toBe(false);
+		expect(shouldRegisterOrcaStatusBridge({ ...REGISTER_BASE, env, taskDepth: 1 })).toBe(false);
+		expect(shouldRegisterOrcaStatusBridge({ ...REGISTER_BASE, env, parentTaskPrefix: "6-Extensions" })).toBe(false);
+		expect(shouldRegisterOrcaStatusBridge({ ...REGISTER_BASE, env, currentAgentType: "executor" })).toBe(false);
 	});
 
 	it("defers to a pane already owned by another process", () => {
 		const otherPid = String(process.pid + 1);
 		expect(
 			shouldRegisterOrcaStatusBridge({
+				...REGISTER_BASE,
 				env: { ORCA_PANE_KEY: "t:l", ORCA_PI_STATUS_OWNED: otherPid } as NodeJS.ProcessEnv,
 			}),
 		).toBe(false);
 		expect(
 			shouldRegisterOrcaStatusBridge({
+				...REGISTER_BASE,
 				env: { ORCA_PANE_KEY: "t:l", ORCA_PI_STATUS_OWNED: String(process.pid) } as NodeJS.ProcessEnv,
 			}),
 		).toBe(true);
@@ -202,7 +273,7 @@ describe("createOrcaStatusBridge delivery", () => {
 		handlers.get("session_start")?.({ type: "session_start" }, ctx);
 		let post = await delivery;
 		expect(post.url).toBe("/hook/pi");
-		expect(post.token).toBe("test-token");
+		expect(post.token).toBe("test-token-1234");
 		expect(post.body.paneKey).toBe("tab-1:leaf-1");
 		expect(post.body.tabId).toBe("tab-1");
 		expect(post.body.worktreeId).toBe("repo::wt");
@@ -234,7 +305,60 @@ describe("createOrcaStatusBridge delivery", () => {
 		expect(post.body.payload).toMatchObject({ hook_event_name: "message_end", role: "assistant", text: "done!" });
 	});
 
-	it("prefers coordinates from the endpoint file over the environment", async () => {
+	it("bounds oversized prompt and assistant text previews", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		const ctx = fakeContext();
+
+		const delivery = receiver.nextDelivery();
+		handlers.get("before_agent_start")?.({ type: "before_agent_start", prompt: "p".repeat(6000) }, ctx);
+		const post = await delivery;
+		const prompt = post.body.payload.prompt as string;
+		expect(prompt.length).toBeLessThan(2100);
+		expect(prompt.endsWith("…[truncated by GJC]")).toBe(true);
+	});
+
+	it("drops delivery entirely for authority-injection port values", async () => {
+		const fetchCalls: string[] = [];
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, {
+			env: {
+				ORCA_PANE_KEY: "tab-1:leaf-1",
+				ORCA_AGENT_HOOK_PORT: "80@evil.example",
+				ORCA_AGENT_HOOK_TOKEN: "test-token-1234",
+			} as NodeJS.ProcessEnv,
+			fetchImpl: ((input: string | URL | Request) => {
+				fetchCalls.push(String(input));
+				return Promise.resolve(new Response("ok"));
+			}) as typeof fetch,
+		});
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		await Bun.sleep(20);
+		expect(fetchCalls).toEqual([]);
+	});
+
+	it("drops delivery when the token would allow header injection", async () => {
+		const fetchCalls: string[] = [];
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, {
+			env: {
+				ORCA_PANE_KEY: "tab-1:leaf-1",
+				ORCA_AGENT_HOOK_PORT: "57343",
+				ORCA_AGENT_HOOK_TOKEN: "bad\r\nX-Injected: 1",
+			} as NodeJS.ProcessEnv,
+			fetchImpl: ((input: string | URL | Request) => {
+				fetchCalls.push(String(input));
+				return Promise.resolve(new Response("ok"));
+			}) as typeof fetch,
+		});
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		await Bun.sleep(20);
+		expect(fetchCalls).toEqual([]);
+	});
+
+	it("prefers coordinates from a trusted endpoint file over the environment", async () => {
 		const receiver = startHookReceiver();
 		cleanups.push(receiver.stop);
 		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-orca-endpoint-"));
@@ -242,8 +366,9 @@ describe("createOrcaStatusBridge delivery", () => {
 		const endpointPath = path.join(dir, "endpoint.env");
 		await Bun.write(
 			endpointPath,
-			`ORCA_AGENT_HOOK_PORT=${receiver.port}\nORCA_AGENT_HOOK_TOKEN=file-token\nORCA_AGENT_HOOK_ENV=production\n`,
+			`ORCA_AGENT_HOOK_PORT=${receiver.port}\nORCA_AGENT_HOOK_TOKEN=file-token-1234\nORCA_AGENT_HOOK_ENV=production\n`,
 		);
+		await fs.chmod(endpointPath, 0o600);
 		const { api, handlers } = captureHandlers();
 		createOrcaStatusBridge(api, {
 			env: {
@@ -251,14 +376,75 @@ describe("createOrcaStatusBridge delivery", () => {
 				ORCA_AGENT_HOOK_ENDPOINT: endpointPath,
 				// Stale env coordinates that the endpoint file must win over.
 				ORCA_AGENT_HOOK_PORT: "1",
-				ORCA_AGENT_HOOK_TOKEN: "stale-token",
+				ORCA_AGENT_HOOK_TOKEN: "stale-token-1234",
 			} as NodeJS.ProcessEnv,
 		});
 		const delivery = receiver.nextDelivery();
 		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
 		const post = await delivery;
-		expect(post.token).toBe("file-token");
+		expect(post.token).toBe("file-token-1234");
 		expect(post.body.payload.hook_event_name).toBe("agent_start");
+	});
+
+	it("ignores a symlinked endpoint file and falls back to env coordinates", async () => {
+		if (process.platform === "win32") return;
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-orca-endpoint-"));
+		cleanups.push(() => void fs.rm(dir, { recursive: true, force: true }));
+		const realPath = path.join(dir, "real.env");
+		await Bun.write(realPath, `ORCA_AGENT_HOOK_PORT=${receiver.port}\nORCA_AGENT_HOOK_TOKEN=sneaky-token-1234\n`);
+		const linkPath = path.join(dir, "endpoint.env");
+		await fs.symlink(realPath, linkPath);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, {
+			env: bridgeEnv(receiver, { ORCA_AGENT_HOOK_ENDPOINT: linkPath }),
+		});
+		const delivery = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		const post = await delivery;
+		// Symlink rejected (O_NOFOLLOW): trusted env token used, not the file's.
+		expect(post.token).toBe("test-token-1234");
+	});
+
+	it("ignores a group/world-writable endpoint file", async () => {
+		if (process.platform === "win32") return;
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-orca-endpoint-"));
+		cleanups.push(() => void fs.rm(dir, { recursive: true, force: true }));
+		const endpointPath = path.join(dir, "endpoint.env");
+		await Bun.write(endpointPath, `ORCA_AGENT_HOOK_PORT=${receiver.port}\nORCA_AGENT_HOOK_TOKEN=loose-token-1234\n`);
+		await fs.chmod(endpointPath, 0o666);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, {
+			env: bridgeEnv(receiver, { ORCA_AGENT_HOOK_ENDPOINT: endpointPath }),
+		});
+		const delivery = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		const post = await delivery;
+		expect(post.token).toBe("test-token-1234");
+	});
+
+	it("ignores an endpoint file owned by another user", async () => {
+		if (process.platform === "win32") return;
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-orca-endpoint-"));
+		cleanups.push(() => void fs.rm(dir, { recursive: true, force: true }));
+		const endpointPath = path.join(dir, "endpoint.env");
+		await Bun.write(endpointPath, `ORCA_AGENT_HOOK_PORT=${receiver.port}\nORCA_AGENT_HOOK_TOKEN=alien-token-1234\n`);
+		await fs.chmod(endpointPath, 0o600);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, {
+			env: bridgeEnv(receiver, { ORCA_AGENT_HOOK_ENDPOINT: endpointPath }),
+			// Simulate the file belonging to a different uid than the owner check expects.
+			ownerUid: (process.getuid?.() ?? 0) + 1,
+		});
+		const delivery = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		const post = await delivery;
+		expect(post.token).toBe("test-token-1234");
 	});
 
 	it("collapses bursts to the latest snapshot while a post is in flight", async () => {
@@ -354,24 +540,43 @@ describe("createOrcaStatusBridge delivery", () => {
 		await Bun.sleep(20);
 	});
 
-	it("falls back to Windows curl delivery on WSL when loopback posting fails", async () => {
+	it("falls back to hardened Windows curl delivery on WSL with a single-flight cap", async () => {
 		const { api, handlers } = captureHandlers();
 		const spawned: Array<{ command: string[]; body: string }> = [];
+		let releaseFirst: (() => void) | undefined;
 		createOrcaStatusBridge(api, {
 			env: {
 				ORCA_PANE_KEY: "tab-1:leaf-1",
 				ORCA_AGENT_HOOK_PORT: "1",
-				ORCA_AGENT_HOOK_TOKEN: "test-token",
+				ORCA_AGENT_HOOK_TOKEN: "test-token-1234",
 			} as NodeJS.ProcessEnv,
 			fetchImpl: (() => Promise.reject(new Error("loopback unreachable"))) as unknown as typeof fetch,
 			isWslRuntime: () => true,
-			spawnCurl: (command, body) => spawned.push({ command, body }),
+			spawnCurl: (command, body) => {
+				spawned.push({ command, body });
+				const { promise, resolve } = Promise.withResolvers<void>();
+				releaseFirst ??= resolve;
+				return promise;
+			},
 		});
-		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		const ctx = fakeContext();
+		handlers.get("agent_start")?.({ type: "agent_start" }, ctx);
 		await Bun.sleep(20);
 		expect(spawned).toHaveLength(1);
+		// curlrc processing disabled before any other option.
+		expect(spawned[0].command[1]).toBe("-q");
 		expect(spawned[0].command).toContain("http://127.0.0.1:1/hook/pi");
-		expect(spawned[0].command).toContain("X-Orca-Agent-Hook-Token: test-token");
+		expect(spawned[0].command).toContain("X-Orca-Agent-Hook-Token: test-token-1234");
 		expect(JSON.parse(spawned[0].body).payload.hook_event_name).toBe("agent_start");
+		// Second delivery attempt while the first child is alive is dropped.
+		handlers.get("before_agent_start")?.({ type: "before_agent_start", prompt: "x" }, ctx);
+		await Bun.sleep(20);
+		expect(spawned).toHaveLength(1);
+		releaseFirst?.();
+		await Bun.sleep(20);
+		// Slot cleared: the next event spawns again.
+		handlers.get("agent_start")?.({ type: "agent_start" }, ctx);
+		await Bun.sleep(20);
+		expect(spawned).toHaveLength(2);
 	});
 });

--- a/packages/coding-agent/test/orca-status-bridge.test.ts
+++ b/packages/coding-agent/test/orca-status-bridge.test.ts
@@ -1,0 +1,377 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "../src/extensibility/extensions";
+import {
+	createOrcaStatusBridge,
+	extractAssistantText,
+	parseOrcaEndpointFile,
+	shouldRegisterOrcaStatusBridge,
+} from "../src/utils/orca-status-bridge";
+
+type ExtensionEventHandler = (event: unknown, ctx: ExtensionContext) => unknown;
+
+function captureHandlers(): { api: ExtensionAPI; handlers: Map<string, ExtensionEventHandler> } {
+	const handlers = new Map<string, ExtensionEventHandler>();
+	const api = {
+		on(event: string, handler: ExtensionEventHandler) {
+			handlers.set(event, handler);
+		},
+	} as unknown as ExtensionAPI;
+	return { api, handlers };
+}
+
+function fakeContext(
+	overrides: Partial<{ isIdle: () => boolean; hasUI: boolean; setEditorText: (text: string) => void }> = {},
+): ExtensionContext {
+	return {
+		hasUI: overrides.hasUI ?? false,
+		ui: { setEditorText: overrides.setEditorText ?? (() => {}) },
+		sessionManager: {
+			getSessionId: () => "orca-test-session",
+			getSessionFile: () => undefined,
+		},
+		isIdle: overrides.isIdle ?? (() => true),
+	} as unknown as ExtensionContext;
+}
+
+interface ReceivedPost {
+	url: string;
+	token: string | null;
+	body: {
+		paneKey: string;
+		tabId: string;
+		worktreeId: string;
+		payload: Record<string, unknown>;
+	};
+}
+
+interface HookReceiver {
+	port: number;
+	received: ReceivedPost[];
+	nextDelivery: () => Promise<ReceivedPost>;
+	/** When set, holds responses open until released (for queue-collapse tests). */
+	hold: boolean;
+	releaseHeld: () => void;
+	stop: () => void;
+}
+
+function startHookReceiver(): HookReceiver {
+	const received: ReceivedPost[] = [];
+	let waiters: Array<(post: ReceivedPost) => void> = [];
+	let heldReleases: Array<() => void> = [];
+	const receiver: HookReceiver = {
+		port: 0,
+		received,
+		hold: false,
+		nextDelivery: () => {
+			const { promise, resolve } = Promise.withResolvers<ReceivedPost>();
+			waiters.push(resolve);
+			return promise;
+		},
+		releaseHeld: () => {
+			const releases = heldReleases;
+			heldReleases = [];
+			for (const release of releases) release();
+		},
+		stop: () => server.stop(true),
+	};
+	const server = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0,
+		fetch: async request => {
+			const post: ReceivedPost = {
+				url: new URL(request.url).pathname,
+				token: request.headers.get("X-Orca-Agent-Hook-Token"),
+				body: (await request.json()) as ReceivedPost["body"],
+			};
+			received.push(post);
+			const pendingWaiters = waiters;
+			waiters = [];
+			for (const waiter of pendingWaiters) waiter(post);
+			if (receiver.hold) {
+				const { promise, resolve } = Promise.withResolvers<void>();
+				heldReleases.push(resolve);
+				await promise;
+			}
+			return new Response("ok");
+		},
+	});
+	if (server.port === undefined) throw new Error("Hook receiver failed to bind a port.");
+	receiver.port = server.port;
+	return receiver;
+}
+
+function bridgeEnv(receiver: HookReceiver, extra: Record<string, string> = {}): NodeJS.ProcessEnv {
+	return {
+		ORCA_PANE_KEY: "tab-1:leaf-1",
+		ORCA_TAB_ID: "tab-1",
+		ORCA_WORKTREE_ID: "repo::wt",
+		ORCA_AGENT_HOOK_PORT: String(receiver.port),
+		ORCA_AGENT_HOOK_TOKEN: "test-token",
+		...extra,
+	} as NodeJS.ProcessEnv;
+}
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	while (cleanups.length > 0) cleanups.pop()?.();
+});
+
+describe("parseOrcaEndpointFile", () => {
+	it("parses POSIX KEY=VALUE lines", () => {
+		expect(parseOrcaEndpointFile("ORCA_AGENT_HOOK_PORT=57343\nORCA_AGENT_HOOK_TOKEN=abc\n")).toEqual({
+			ORCA_AGENT_HOOK_PORT: "57343",
+			ORCA_AGENT_HOOK_TOKEN: "abc",
+		});
+	});
+
+	it("parses Windows `set KEY=VALUE` lines and strips CR", () => {
+		expect(parseOrcaEndpointFile("set ORCA_AGENT_HOOK_PORT=57343\r\nset ORCA_AGENT_HOOK_TOKEN=abc\r\n")).toEqual({
+			ORCA_AGENT_HOOK_PORT: "57343",
+			ORCA_AGENT_HOOK_TOKEN: "abc",
+		});
+	});
+
+	it("ignores non-matching lines", () => {
+		expect(parseOrcaEndpointFile("# comment\nlowercase=skip\nORCA_AGENT_HOOK_ENV=production")).toEqual({
+			ORCA_AGENT_HOOK_ENV: "production",
+		});
+	});
+});
+
+describe("shouldRegisterOrcaStatusBridge", () => {
+	it("requires an Orca pane identity", () => {
+		expect(shouldRegisterOrcaStatusBridge({ env: {} as NodeJS.ProcessEnv })).toBe(false);
+		expect(shouldRegisterOrcaStatusBridge({ env: { ORCA_PANE_KEY: "t:l" } as NodeJS.ProcessEnv })).toBe(true);
+	});
+
+	it("stays silent for helper and subagent sessions", () => {
+		const env = { ORCA_PANE_KEY: "t:l" } as NodeJS.ProcessEnv;
+		expect(shouldRegisterOrcaStatusBridge({ env, taskDepth: 1 })).toBe(false);
+		expect(shouldRegisterOrcaStatusBridge({ env, parentTaskPrefix: "6-Extensions" })).toBe(false);
+		expect(shouldRegisterOrcaStatusBridge({ env, currentAgentType: "executor" })).toBe(false);
+	});
+
+	it("defers to a pane already owned by another process", () => {
+		const otherPid = String(process.pid + 1);
+		expect(
+			shouldRegisterOrcaStatusBridge({
+				env: { ORCA_PANE_KEY: "t:l", ORCA_PI_STATUS_OWNED: otherPid } as NodeJS.ProcessEnv,
+			}),
+		).toBe(false);
+		expect(
+			shouldRegisterOrcaStatusBridge({
+				env: { ORCA_PANE_KEY: "t:l", ORCA_PI_STATUS_OWNED: String(process.pid) } as NodeJS.ProcessEnv,
+			}),
+		).toBe(true);
+	});
+});
+
+describe("extractAssistantText", () => {
+	it("returns string content directly and concatenates text parts", () => {
+		expect(extractAssistantText({ role: "assistant", content: "plain" })).toBe("plain");
+		expect(
+			extractAssistantText({
+				role: "assistant",
+				content: [
+					{ type: "text", text: "first " },
+					{ type: "toolCall", id: "x" },
+					{ type: "text", text: "second" },
+				],
+			}),
+		).toBe("first second");
+	});
+
+	it("returns empty for tool-only or malformed messages", () => {
+		expect(extractAssistantText(undefined)).toBe("");
+		expect(extractAssistantText({ content: [{ type: "toolCall" }] })).toBe("");
+	});
+});
+
+describe("createOrcaStatusBridge delivery", () => {
+	it("posts pi-protocol lifecycle payloads with pane identity and token", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		const ctx = fakeContext();
+
+		let delivery = receiver.nextDelivery();
+		handlers.get("session_start")?.({ type: "session_start" }, ctx);
+		let post = await delivery;
+		expect(post.url).toBe("/hook/pi");
+		expect(post.token).toBe("test-token");
+		expect(post.body.paneKey).toBe("tab-1:leaf-1");
+		expect(post.body.tabId).toBe("tab-1");
+		expect(post.body.worktreeId).toBe("repo::wt");
+		expect(post.body.payload.hook_event_name).toBe("session_start");
+
+		delivery = receiver.nextDelivery();
+		handlers.get("before_agent_start")?.({ type: "before_agent_start", prompt: "fix the bug" }, ctx);
+		post = await delivery;
+		expect(post.body.payload).toMatchObject({ hook_event_name: "before_agent_start", prompt: "fix the bug" });
+
+		delivery = receiver.nextDelivery();
+		handlers.get("tool_execution_start")?.(
+			{ type: "tool_execution_start", toolCallId: "c1", toolName: "bash", args: { command: "ls" } },
+			ctx,
+		);
+		post = await delivery;
+		expect(post.body.payload).toMatchObject({
+			hook_event_name: "tool_execution_start",
+			tool_name: "bash",
+			tool_input: { command: "ls" },
+		});
+
+		delivery = receiver.nextDelivery();
+		handlers.get("message_end")?.(
+			{ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "done!" }] } },
+			ctx,
+		);
+		post = await delivery;
+		expect(post.body.payload).toMatchObject({ hook_event_name: "message_end", role: "assistant", text: "done!" });
+	});
+
+	it("prefers coordinates from the endpoint file over the environment", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-orca-endpoint-"));
+		cleanups.push(() => void fs.rm(dir, { recursive: true, force: true }));
+		const endpointPath = path.join(dir, "endpoint.env");
+		await Bun.write(
+			endpointPath,
+			`ORCA_AGENT_HOOK_PORT=${receiver.port}\nORCA_AGENT_HOOK_TOKEN=file-token\nORCA_AGENT_HOOK_ENV=production\n`,
+		);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, {
+			env: {
+				ORCA_PANE_KEY: "tab-1:leaf-1",
+				ORCA_AGENT_HOOK_ENDPOINT: endpointPath,
+				// Stale env coordinates that the endpoint file must win over.
+				ORCA_AGENT_HOOK_PORT: "1",
+				ORCA_AGENT_HOOK_TOKEN: "stale-token",
+			} as NodeJS.ProcessEnv,
+		});
+		const delivery = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		const post = await delivery;
+		expect(post.token).toBe("file-token");
+		expect(post.body.payload.hook_event_name).toBe("agent_start");
+	});
+
+	it("collapses bursts to the latest snapshot while a post is in flight", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		const ctx = fakeContext();
+
+		receiver.hold = true;
+		const first = receiver.nextDelivery();
+		handlers.get("tool_execution_start")?.(
+			{ type: "tool_execution_start", toolCallId: "c1", toolName: "bash", args: { command: "one" } },
+			ctx,
+		);
+		await first;
+		// Queued while the first post is held open; only the latest may survive.
+		handlers.get("tool_execution_start")?.(
+			{ type: "tool_execution_start", toolCallId: "c2", toolName: "bash", args: { command: "two" } },
+			ctx,
+		);
+		handlers.get("tool_execution_end")?.({ type: "tool_execution_end", toolCallId: "c2", toolName: "bash" }, ctx);
+		const second = receiver.nextDelivery();
+		receiver.hold = false;
+		receiver.releaseHeld();
+		const post = await second;
+		expect(post.body.payload.hook_event_name).toBe("tool_execution_end");
+		expect(receiver.received).toHaveLength(2);
+	});
+
+	it("defers agent_end until the session is idle and reports it once", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		let idle = false;
+		const ctx = fakeContext({ isIdle: () => idle });
+
+		const started = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, ctx);
+		await started;
+
+		const ended = receiver.nextDelivery();
+		handlers.get("agent_end")?.({ type: "agent_end", messages: [] }, ctx);
+		await Bun.sleep(60);
+		expect(receiver.received.filter(post => post.body.payload.hook_event_name === "agent_end")).toHaveLength(0);
+		idle = true;
+		const post = await ended;
+		expect(post.body.payload.hook_event_name).toBe("agent_end");
+		// A second agent_end for the same run must not double-report.
+		handlers.get("agent_end")?.({ type: "agent_end", messages: [] }, ctx);
+		await Bun.sleep(60);
+		expect(receiver.received.filter(p => p.body.payload.hook_event_name === "agent_end")).toHaveLength(1);
+	});
+
+	it("cancels a pending agent_end check when a new agent loop starts", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		const ctx = fakeContext({ isIdle: () => false });
+
+		handlers.get("agent_end")?.({ type: "agent_end", messages: [] }, ctx);
+		const restarted = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, ctx);
+		await restarted;
+		await Bun.sleep(120);
+		expect(receiver.received.filter(post => post.body.payload.hook_event_name === "agent_end")).toHaveLength(0);
+	});
+
+	it("applies the Orca startup prefill once on session_start when a UI exists", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		const { api, handlers } = captureHandlers();
+		const env = bridgeEnv(receiver, { ORCA_PI_PREFILL: "continue the review" });
+		createOrcaStatusBridge(api, { env });
+		const prefills: string[] = [];
+		const ctx = fakeContext({ hasUI: true, setEditorText: text => prefills.push(text) });
+
+		const delivery = receiver.nextDelivery();
+		handlers.get("session_start")?.({ type: "session_start" }, ctx);
+		await delivery;
+		handlers.get("session_start")?.({ type: "session_start" }, ctx);
+		expect(prefills).toEqual(["continue the review"]);
+		expect(env.ORCA_PI_PREFILL).toBeUndefined();
+	});
+
+	it("stays inert without Orca coordinates", async () => {
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: { ORCA_PANE_KEY: "tab-1:leaf-1" } as NodeJS.ProcessEnv });
+		// No port/token anywhere: handler must be a silent no-op.
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		await Bun.sleep(20);
+	});
+
+	it("falls back to Windows curl delivery on WSL when loopback posting fails", async () => {
+		const { api, handlers } = captureHandlers();
+		const spawned: Array<{ command: string[]; body: string }> = [];
+		createOrcaStatusBridge(api, {
+			env: {
+				ORCA_PANE_KEY: "tab-1:leaf-1",
+				ORCA_AGENT_HOOK_PORT: "1",
+				ORCA_AGENT_HOOK_TOKEN: "test-token",
+			} as NodeJS.ProcessEnv,
+			fetchImpl: (() => Promise.reject(new Error("loopback unreachable"))) as unknown as typeof fetch,
+			isWslRuntime: () => true,
+			spawnCurl: (command, body) => spawned.push({ command, body }),
+		});
+		handlers.get("agent_start")?.({ type: "agent_start" }, fakeContext());
+		await Bun.sleep(20);
+		expect(spawned).toHaveLength(1);
+		expect(spawned[0].command).toContain("http://127.0.0.1:1/hook/pi");
+		expect(spawned[0].command).toContain("X-Orca-Agent-Hook-Token: test-token");
+		expect(JSON.parse(spawned[0].body).payload.hook_event_name).toBe("agent_start");
+	});
+});

--- a/packages/coding-agent/test/orca-status-bridge.test.ts
+++ b/packages/coding-agent/test/orca-status-bridge.test.ts
@@ -57,6 +57,8 @@ interface HookReceiver {
 	nextDelivery: () => Promise<ReceivedPost>;
 	/** When set, holds responses open until released (for queue-collapse tests). */
 	hold: boolean;
+	/** When set, answers /hook/gjc with 404 (route-negotiation tests). */
+	gjcRouteMissing: boolean;
 	releaseHeld: () => void;
 	stop: () => void;
 }
@@ -69,6 +71,7 @@ function startHookReceiver(): HookReceiver {
 		port: 0,
 		received,
 		hold: false,
+		gjcRouteMissing: false,
 		nextDelivery: () => {
 			const { promise, resolve } = Promise.withResolvers<ReceivedPost>();
 			waiters.push(resolve);
@@ -90,6 +93,9 @@ function startHookReceiver(): HookReceiver {
 				token: request.headers.get("X-Orca-Agent-Hook-Token"),
 				body: (await request.json()) as ReceivedPost["body"],
 			};
+			if (receiver.gjcRouteMissing && post.url === "/hook/gjc") {
+				return new Response("not found", { status: 404 });
+			}
 			received.push(post);
 			const pendingWaiters = waiters;
 			waiters = [];
@@ -149,8 +155,9 @@ describe("parseOrcaEndpointFile", () => {
 
 describe("buildOrcaHookUrl", () => {
 	it("builds a loopback URL for a strictly numeric port", () => {
-		expect(buildOrcaHookUrl("57343")).toBe("http://127.0.0.1:57343/hook/pi");
-		expect(buildOrcaHookUrl("007")).toBe("http://127.0.0.1:7/hook/pi");
+		expect(buildOrcaHookUrl("57343")).toBe("http://127.0.0.1:57343/hook/gjc");
+		expect(buildOrcaHookUrl("007")).toBe("http://127.0.0.1:7/hook/gjc");
+		expect(buildOrcaHookUrl("57343", "/hook/pi")).toBe("http://127.0.0.1:57343/hook/pi");
 	});
 
 	it("rejects authority-injection and malformed port values", () => {
@@ -272,7 +279,7 @@ describe("createOrcaStatusBridge delivery", () => {
 		let delivery = receiver.nextDelivery();
 		handlers.get("session_start")?.({ type: "session_start" }, ctx);
 		let post = await delivery;
-		expect(post.url).toBe("/hook/pi");
+		expect(post.url).toBe("/hook/gjc");
 		expect(post.token).toBe("test-token-1234");
 		expect(post.body.paneKey).toBe("tab-1:leaf-1");
 		expect(post.body.tabId).toBe("tab-1");
@@ -532,6 +539,27 @@ describe("createOrcaStatusBridge delivery", () => {
 		expect(env.ORCA_PI_PREFILL).toBeUndefined();
 	});
 
+	it("falls back to the pi route once when Orca answers 404 for /hook/gjc", async () => {
+		const receiver = startHookReceiver();
+		cleanups.push(receiver.stop);
+		receiver.gjcRouteMissing = true;
+		const { api, handlers } = captureHandlers();
+		createOrcaStatusBridge(api, { env: bridgeEnv(receiver) });
+		const ctx = fakeContext();
+
+		const first = receiver.nextDelivery();
+		handlers.get("agent_start")?.({ type: "agent_start" }, ctx);
+		const post = await first;
+		// The 404'd /hook/gjc attempt is not recorded; the same event lands on /hook/pi.
+		expect(post.url).toBe("/hook/pi");
+		expect(post.body.payload.hook_event_name).toBe("agent_start");
+
+		// Negotiation is sticky: later events go straight to the pi route.
+		const second = receiver.nextDelivery();
+		handlers.get("tool_execution_end")?.({ type: "tool_execution_end", toolCallId: "c1", toolName: "bash" }, ctx);
+		expect((await second).url).toBe("/hook/pi");
+	});
+
 	it("stays inert without Orca coordinates", async () => {
 		const { api, handlers } = captureHandlers();
 		createOrcaStatusBridge(api, { env: { ORCA_PANE_KEY: "tab-1:leaf-1" } as NodeJS.ProcessEnv });
@@ -565,7 +593,7 @@ describe("createOrcaStatusBridge delivery", () => {
 		expect(spawned).toHaveLength(1);
 		// curlrc processing disabled before any other option.
 		expect(spawned[0].command[1]).toBe("-q");
-		expect(spawned[0].command).toContain("http://127.0.0.1:1/hook/pi");
+		expect(spawned[0].command).toContain("http://127.0.0.1:1/hook/gjc");
 		expect(spawned[0].command).toContain("X-Orca-Agent-Hook-Token: test-token-1234");
 		expect(JSON.parse(spawned[0].body).payload.hook_event_name).toBe("agent_start");
 		// Second delivery attempt while the first child is alive is dropped.

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -40,6 +40,16 @@
 			},
 			"additionalProperties": false
 		},
+		"orca": {
+			"type": "object",
+			"properties": {
+				"statusBridge": {
+					"type": "boolean",
+					"default": true
+				}
+			},
+			"additionalProperties": false
+		},
 		"notifications": {
 			"type": "object",
 			"properties": {


### PR DESCRIPTION
Successor to #3113 (closed with REQUEST_CHANGES; #3106 was the original). Both prior review rounds are fully addressed; this branch = hardened bridge + `/hook/gjc` route negotiation + the two remaining lifecycle/transport blockers from the #3113 review.

## Response to the #3113 review (commit `7cc21a03`)

**1. Unbounded `agent_end` idle recheck + no shutdown disposal** — `session_shutdown` now disposes the bridge:
- the idle recheck timer/context are cleared, so a never-idle session cannot reschedule every 250ms forever;
- `post()` refuses new work after disposal (queue empties once and stays empty);
- `ORCA_PI_STATUS_OWNED` is released **only when this process still owns it**, so inherited ownership can no longer suppress the next pane process's reporting.
- Shutdown is treated as a definitive turn boundary: an `agent_end` still deferred on the recheck reports exactly once before disposal. This matters: a naive dispose (clear-everything) introduced a real regression that **live testing caught** — print-mode shutdown races the deferred `agent_end`, and killing the timer without the final report left the pane stuck in `working`. The deterministic never-idle→shutdown regression test asserts: single final `agent_end`, no surviving timer after 400ms (> max recheck), ownership released, disposed bridge inert to later events.

**2. Native fetch honoring inherited proxy routing** — confirmed empirically on Bun: both `fetch` and the `node:http` shim route **even 127.0.0.1 targets** through `HTTP(S)_PROXY` (and `proxy: ""` does not disable it). The default transport is now `loopbackHookFetch`: a raw TCP dial to 127.0.0.1 that environment configuration cannot redirect, matching the curl path's `--noproxy 127.0.0.1`. Host/path/token are the already-validated values; the response is parsed only for the status code the route negotiation needs. Regression test runs the real default transport against a live proxy listener with `HTTP_PROXY` set: target receives the post, proxy records zero hits.

## Carried over from the previous rounds (already reviewed as repaired in #3113)

- Fail-closed coordinates: strict decimal port + component-asserted loopback URL, charset-validated token (header/argv injection unrepresentable)
- Endpoint file: `O_NOFOLLOW` descriptor-pinned owner/mode validation, strict-modes directory ancestry, fd-read (no validate→read race)
- Consent + bounds: `orca.statusBridge` setting, `GJC_ORCA_STATUS_BRIDGE=0` kill-switch, bounded prompt/text/tool-input previews
- Hardened single-flight WSL curl fallback (`-q` first)
- `/hook/gjc` preferred with sticky 404 fallback to `/hook/pi` (pairs with stablyai/orca#10476, which adds first-class GJC identity to Orca)

## Verification

- `bun test packages/coding-agent/test/orca-status-bridge.test.ts` — **33 tests** (protocol, security regressions, route negotiation, lifecycle disposal, proxy immunity)
- `bun run --cwd packages/coding-agent check` (biome + tsc) — clean; `check:schemas` clean
- **Live e2e** against Orca 1.4.154, with `HTTP_PROXY` pointed at a blackhole (`127.0.0.1:9`): status lands direct (proxy-immune) and the ledger records the full `working → done` lifecycle with the final reply preview; kill-switch run leaves the ledger untouched; 404 negotiation verified (no `/hook/gjc` on 1.4.154 → same event lands on `/hook/pi`).

Aware the dev merge freeze may still be in effect — parked as review-ready.