### PR TITLE
fix(security): reject bash tilde expansion in assignment words (#3117)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Restricted role-agent `bash` now accepts literal mid-word tildes, so git revision syntax such as `git diff HEAD~1` no longer has to be quoted. Bash performs tilde expansion only at the start of a word, so word-initial forms (`~`, `~/path`, `~user`) remain blocked.
-- Restricted role-agent `bash` now rejects unquoted tildes at every bash expansion position inside assignment words, so `A=~`, `foo=~root/bar`, `A=x:~`, and repeated colon segments such as `a=x:~:y:~` fail closed. Tildes bash does not expand — mid-word git revisions (`HEAD~1`), non-assignment words (`--opt=~`, `1abc=~`), and quoted forms — remain allowed (#3117).
+- Restricted role-agent `bash` now rejects unquoted tildes at every bash expansion position inside assignment words, including the compound `name+=value` form, so `A=~`, `A+=~`, `foo=~root/bar`, `A=x:~`, `A+=x:~`, and repeated colon segments such as `a=x:~:y:~` fail closed. Tildes bash does not expand — mid-word git revisions (`HEAD~1`), non-assignment words (`--opt=~`, `1abc=~`, `a++=~`, `a+b=~`), and quoted forms — remain allowed (#3117).
 - Interactive prompt cancellation now reaches API-key preflight through `ModelRegistry`, allowing aborted submissions to clear immediately even while a shared credential-usage request continues in the background.
 - Alibaba Token Plan canonical first-event timeouts now surface without session retry/fallback replay and are not internally retried by auto-compaction, preventing repeated provider usage (#3026).
 - Delegated-task and subagent status surfaces now distinguish provider recovery from normal running, identify first-event versus idle-stream stalls, show retry budget and provider-progress age, and aggregate concurrent degradation by provider (#3071).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Restricted role-agent `bash` now accepts literal mid-word tildes, so git revision syntax such as `git diff HEAD~1` no longer has to be quoted. Bash performs tilde expansion only at the start of a word, so word-initial forms (`~`, `~/path`, `~user`) remain blocked.
+- Restricted role-agent `bash` now rejects unquoted tildes at every bash expansion position inside assignment words, so `A=~`, `foo=~root/bar`, `A=x:~`, and repeated colon segments such as `a=x:~:y:~` fail closed. Tildes bash does not expand — mid-word git revisions (`HEAD~1`), non-assignment words (`--opt=~`, `1abc=~`), and quoted forms — remain allowed (#3117).
 - Interactive prompt cancellation now reaches API-key preflight through `ModelRegistry`, allowing aborted submissions to clear immediately even while a shared credential-usage request continues in the background.
 - Alibaba Token Plan canonical first-event timeouts now surface without session retry/fallback replay and are not internally retried by auto-compaction, preventing repeated provider usage (#3026).
 - Delegated-task and subagent status surfaces now distinguish provider recovery from normal running, identify first-event versus idle-stream stalls, show retry budget and provider-progress age, and aggregate concurrent degradation by provider (#3071).

--- a/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
+++ b/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
@@ -18,9 +18,13 @@ export interface BashRestrictionOptions {
 }
 
 const SHELL_CONTROL_CHARS = new Set([";", "|", "&", "<", ">", "(", ")"]);
-// `~` is handled separately: bash only performs tilde expansion at the start of a
-// word, so a mid-word `~` (e.g. the git revision `HEAD~1`) is a literal character.
+// `~` is handled separately: bash performs tilde expansion only at positions where a
+// tilde can open an expansion - the start of a word, and inside an assignment word
+// directly after the first `=` or after a `:` in the assigned value. A tilde anywhere
+// else (e.g. the git revision `HEAD~1`) is a literal character.
 const UNSAFE_UNQUOTED_EXPANSION_CHARS = new Set(["$", "*", "?", "[", "]", "{", "}"]);
+// A bash assignment word has a plain assignment name before its first unquoted `=`.
+const ASSIGNMENT_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
 const ALLOWED_STATE_ACTIONS = new Set(["read", "write", "contract"]);
 const CANONICAL_STATE_TARGETS = new Set<string>(CANONICAL_GJC_WORKFLOW_SKILLS);
 const READ_ONLY_COMMANDS = new Set(["grep", "rg", "tree", "ls", "pwd", "wc", "du", "file", "stat"]);
@@ -31,6 +35,14 @@ function parseShellWords(command: string): { words: string[]; reason?: string } 
 	let quote: "single" | "double" | null = null;
 
 	let wordStarted = false;
+	// Per-token tilde-expansion state. `assignmentNameCandidate` stays true while the
+	// characters before the first unquoted `=` could still form an assignment name (any
+	// quoting in that region disqualifies the token), `sawAssignmentEquals` records that
+	// the token is an assignment word, and `tildeExpandable` means an unquoted `~` at the
+	// current index would actually be expanded by bash.
+	let assignmentNameCandidate = true;
+	let sawAssignmentEquals = false;
+	let tildeExpandable = false;
 	for (let index = 0; index < command.length; index += 1) {
 		const char = command[index]!;
 		const next = command[index + 1];
@@ -65,11 +77,15 @@ function parseShellWords(command: string): { words: string[]; reason?: string } 
 		if (char === "'") {
 			quote = "single";
 			wordStarted = true;
+			if (!sawAssignmentEquals) assignmentNameCandidate = false;
+			tildeExpandable = false;
 			continue;
 		}
 		if (char === '"') {
 			quote = "double";
 			wordStarted = true;
+			if (!sawAssignmentEquals) assignmentNameCandidate = false;
+			tildeExpandable = false;
 			continue;
 		}
 		if (char === "`" || (char === "$" && next === "(")) {
@@ -84,11 +100,11 @@ function parseShellWords(command: string): { words: string[]; reason?: string } 
 		if (UNSAFE_UNQUOTED_EXPANSION_CHARS.has(char)) {
 			return { words, reason: `shell expansion character '${char}' is not allowed in restricted bash commands` };
 		}
-		// Tilde expansion is positional: bash expands `~`, `~/path`, and `~user` only when
-		// the tilde opens a word. A tilde inside a word is literal, which is what git
-		// revision syntax such as `HEAD~1` relies on, so only the word-initial form is
-		// rejected here.
-		if (char === "~" && !wordStarted) {
+		// Tilde expansion is positional: bash expands a tilde only where one can open an
+		// expansion, i.e. at the start of a word or, inside an assignment word, directly
+		// after the first `=` or after a `:` in the assigned value. A tilde anywhere else
+		// is literal, which is what git revision syntax such as `HEAD~1` relies on.
+		if (char === "~" && (!wordStarted || tildeExpandable)) {
 			return { words, reason: "shell expansion character '~' is not allowed in restricted bash commands" };
 		}
 		if (/\s/u.test(char)) {
@@ -97,10 +113,28 @@ function parseShellWords(command: string): { words: string[]; reason?: string } 
 				current = "";
 				wordStarted = false;
 			}
+			assignmentNameCandidate = true;
+			sawAssignmentEquals = false;
+			tildeExpandable = false;
 			continue;
 		}
 		if (char === "\\") {
 			return { words, reason: "backslash escapes are not allowed in restricted bash commands" };
+		}
+		if (char === "=" && !sawAssignmentEquals) {
+			// Only a plain assignment name before the first unquoted `=` makes this an
+			// assignment word whose value bash scans for tilde expansions.
+			if (assignmentNameCandidate && ASSIGNMENT_NAME_PATTERN.test(current)) {
+				sawAssignmentEquals = true;
+				tildeExpandable = true;
+			} else {
+				assignmentNameCandidate = false;
+				tildeExpandable = false;
+			}
+		} else if (char === ":" && sawAssignmentEquals) {
+			tildeExpandable = true;
+		} else {
+			tildeExpandable = false;
 		}
 		current += char;
 		wordStarted = true;

--- a/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
+++ b/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
@@ -23,8 +23,9 @@ const SHELL_CONTROL_CHARS = new Set([";", "|", "&", "<", ">", "(", ")"]);
 // directly after the first `=` or after a `:` in the assigned value. A tilde anywhere
 // else (e.g. the git revision `HEAD~1`) is a literal character.
 const UNSAFE_UNQUOTED_EXPANSION_CHARS = new Set(["$", "*", "?", "[", "]", "{", "}"]);
-// A bash assignment word has a plain assignment name before its first unquoted `=`.
-const ASSIGNMENT_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+// A bash assignment word has a plain assignment name before its first unquoted `=`,
+// in either the `name=value` or the compound `name+=value` form.
+const ASSIGNMENT_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*\+?$/u;
 const ALLOWED_STATE_ACTIONS = new Set(["read", "write", "contract"]);
 const CANONICAL_STATE_TARGETS = new Set<string>(CANONICAL_GJC_WORKFLOW_SKILLS);
 const READ_ONLY_COMMANDS = new Set(["grep", "rg", "tree", "ls", "pwd", "wc", "du", "file", "stat"]);

--- a/packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts
+++ b/packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts
@@ -318,6 +318,61 @@ describe("checkBashAllowedPrefixes", () => {
 		}
 	});
 
+	it("blocks tildes at bash expansion positions inside assignment words", () => {
+		const gitPrefixes = [...ROLE_AGENT_PREFIXES, "git diff", "git show", "git log"];
+
+		// bash expands a tilde directly after the first `=` of an assignment word and
+		// after each `:` in that word's value, so every one of these expands for real.
+		for (const command of [
+			"git diff A=~",
+			"git diff A=~/p",
+			"git diff A=~user",
+			"git diff foo=~root/bar",
+			"git diff A=x:~",
+			"git diff b=pre:~",
+			"git diff a=x:~:y:~",
+			"git diff a=:~",
+			"git diff a=~~",
+		]) {
+			const result = checkBashAllowedPrefixes(command, gitPrefixes);
+
+			expect({ command, allowed: result.allowed }).toMatchObject({ allowed: false });
+			expect(result.reason).toContain("shell expansion character '~'");
+		}
+	});
+
+	it("allows tildes at positions bash does not expand in assignment-like words", () => {
+		const gitPrefixes = [...ROLE_AGENT_PREFIXES, "git diff", "git show", "git log"];
+
+		for (const command of [
+			// not assignment words: the region before `=` is not a plain assignment name
+			"git diff --opt=~",
+			"git diff a-b=~",
+			"git diff 1abc=~",
+			"git diff =~",
+			"git diff a~b=c:~",
+			// assignment words, but the tilde is not at an expansion position
+			"git diff a=x~y",
+			"git diff a=x:y~z",
+			"git diff a=b=~",
+		]) {
+			expect({ command, ...checkBashAllowedPrefixes(command, gitPrefixes) }).toMatchObject({ allowed: true });
+		}
+	});
+
+	it("keeps quoted assignment tildes literal and resets tilde state at token boundaries", () => {
+		const gitPrefixes = [...ROLE_AGENT_PREFIXES, "git diff", "git show", "git log"];
+
+		for (const command of ["git diff a='~'", 'git diff a="~"', "git diff a=b HEAD~1", "git diff HEAD~1 a=b"]) {
+			expect({ command, ...checkBashAllowedPrefixes(command, gitPrefixes) }).toMatchObject({ allowed: true });
+		}
+
+		// a new token after whitespace restarts assignment tracking
+		const result = checkBashAllowedPrefixes("git diff HEAD~1 A=~", gitPrefixes);
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("shell expansion character '~'");
+	});
+
 	it("blocks backslash escape smuggling", () => {
 		const result = checkBashAllowedPrefixes("gjc state ralplan\\ clear --json", ROLE_AGENT_PREFIXES);
 

--- a/packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts
+++ b/packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts
@@ -341,6 +341,41 @@ describe("checkBashAllowedPrefixes", () => {
 		}
 	});
 
+	it("blocks tildes at bash expansion positions inside compound `+=` assignment words", () => {
+		const gitPrefixes = [...ROLE_AGENT_PREFIXES, "git diff", "git show", "git log"];
+
+		// bash treats `name+=value` as an assignment word too, so its value expands
+		// tildes at the same positions as `name=value`.
+		for (const command of [
+			"git diff A+=~",
+			"git diff A+=~/p",
+			"git diff A+=~user",
+			"git diff A+=x:~",
+			"git diff A+=x:~:y:~",
+		]) {
+			const result = checkBashAllowedPrefixes(command, gitPrefixes);
+
+			expect({ command, allowed: result.allowed }).toMatchObject({ allowed: false });
+			expect(result.reason).toContain("shell expansion character '~'");
+		}
+	});
+
+	it("allows tildes that compound `+=` recognition must not newly block", () => {
+		const gitPrefixes = [...ROLE_AGENT_PREFIXES, "git diff", "git show", "git log"];
+
+		for (const command of [
+			// compound assignment words, but the tilde is not at an expansion position
+			"git diff a+=x~y",
+			"git diff a+=b=~",
+			// not assignment words: `a++`, an empty name, and `a+b` are not valid names
+			"git diff a++=~",
+			"git diff +=~",
+			"git diff a+b=~",
+		]) {
+			expect({ command, ...checkBashAllowedPrefixes(command, gitPrefixes) }).toMatchObject({ allowed: true });
+		}
+	});
+
 	it("allows tildes at positions bash does not expand in assignment-like words", () => {
 		const gitPrefixes = [...ROLE_AGENT_PREFIXES, "git diff", "git show", "git log"];
 


### PR DESCRIPTION
Closes #3117.

## Problem

PR #3115 made the restricted role-agent bash parser treat `~` positionally, but it only rejected a tilde that opens a whitespace-delimited word. Bash also performs tilde expansion inside an **assignment word**: directly after the first `=`, and after each `:` in the assigned value. The post-merge audit on #3115 confirmed `A=~`, `foo=~root/bar`, and `A=x:~` all expand for real while the committed parser accepted them.

## Fix

`parseShellWords` now tracks per-token assignment state and rejects an unquoted `~` at exactly the positions bash expands one:

1. word start (existing behavior),
2. immediately after the first unquoted `=` of an assignment word,
3. immediately after an unquoted `:` inside that assignment word's value.

An assignment word requires the raw characters before the first unquoted `=` to match `[A-Za-z_][A-Za-z0-9_]*` with no quote syntax. Assignment-value context persists to the end of the token; later ordinary `=` characters create no new expansion position. Token state resets at whitespace boundaries.

## Behavior

Now rejected: `A=~`, `A=~/p`, `A=~user`, `foo=~root/bar`, `A=x:~`, `b=pre:~`, `a=x:~:y:~`, `a=:~`, `a=~~`

Still allowed (bash does not expand these): `--opt=~`, `a-b=~`, `1abc=~`, `=~`, `a~b=c:~`, `a=x~y`, `a=x:y~z`, `a=b=~`, quoted `a='~'` / `a="~"`, and every #3115 git revision (`HEAD~1`, `HEAD~1..HEAD`, `HEAD~5`, …).

Unchanged: parameter expansion, command substitution, control operators, newlines, backslash escapes, unterminated quotes, all prefix/state-action contracts, and the tilde denial reason string.

## Verification

Ground truth from real bash:

```
a=b=~   -> b=~                 (literal, second '=' is not an expansion position)
a=x~y   -> x~y                 (literal)
d=x:y~z -> x:y~z               (literal)
e=x:~   -> x:/home/<user>      (expands)
f=~     -> /home/<user>        (expands)
```

Gates run in this worktree (base `ef25c2c12b16b24ce7796c5272602e3a8f94dedd`):

- `bun test test/tools/bash-allowed-prefixes.test.ts` — 34 pass / 0 fail / 147 assertions
- `bun run check:types` — clean
- `bun run lint` — clean

Three regression tests were added covering reject positions, allowed non-expansion positions, quoted forms, and token-boundary state reset. They are pure parser assertions with no `$HOME` or platform dependence, so Linux/macOS/Windows CI evaluate identical behavior.

`test/rlm.test.ts` and `test/default-gjc-definitions.test.ts` fail in this environment because the `pi_natives` linux-x64 addon is not built; verified identical failures on the untouched base commit via `git stash`.

## Known limitation

Pathological quoted-name assignment forms such as `"A"=~` remain allowed. The parser cannot faithfully reconstruct a quoted name region after tokenization, and no allowed prefix uses that shape. Documented deliberately rather than over-blocking beyond real bash semantics.

**Do not merge** — this PR is pending a separate frozen exact-head adversarial GJC review.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*