### PR TITLE
feat(ai): add Claude Opus 5 via typed generator seed and repair adaptive-display id parsing

### DIFF
--- a/artifacts/architecture-2383-eval.json
+++ b/artifacts/architecture-2383-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "67cd55244f886f568da678bda4314298f01abf0e",
-		"providerSourceSha256": "978c083395de102cb8c78d1e25b164daea3c3558dbd7d90e7a190d3f22550e9b",
+		"providerSourceBlobOid": "c56ed124951c9d922f727b6ddde123349effe0a5",
+		"providerSourceSha256": "22ebcf813814afefd9c07292dbb8b54904678715df70285f5ee9e19e46a578c0",
 		"inputFixtureSha256": "b1ca8d3183ca168140774f848ed414252178f7c5788d61243069862ae59c129b"
 	},
 	"derivationCommands": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added the Anthropic **Claude Opus 5** (`anthropic/claude-opus-5`) bundled catalog entry: 1M-token context window, 128k max output, text + image input, adaptive thinking through `max`, and $5 / $25 per MTok with $0.50 cache reads and $6.25 5-minute cache writes. The row's source of truth is the typed `FIRST_PARTY_CATALOG_SEEDS` generator input, which carries the Anthropic documentation URLs and retrieval date it was transcribed from and binds them into the generated row as `catalogProvenance`. Seed precedence is live upstream sources → typed seeds → previously generated catalog, so a live models.dev/discovery row always wins while a seed correction still overrides the stale generated row it bootstrapped, and credential-less regeneration keeps emitting the model. Catalog-only — the Anthropic provider default (`claude-sonnet-5`) and every built-in model profile are unchanged.
+
 ### Fixed
 
+- Fixed adaptive thinking being billed but never displayed whenever an Anthropic model id did not have the exact `claude-opus-<major>-<minor>` shape. `supportsAdaptiveThinkingDisplay` was a per-provider regex duplicated in the Anthropic Messages and Bedrock Converse transports, and it is now one shared predicate in `model-thinking.ts` that parses the Anthropic model version, the same authority `hasOpus47ApiRestrictions` already uses. Three id classes change behavior (same failure class as #2791): dateless ids (`claude-opus-5`, including region-prefixed Bedrock forms) and gateway dot-form ids (`claude-opus-4.7` / `claude-opus-4.8` / `-fast` on `github-copilot`, `vercel-ai-gateway`, `zenmux`) now send `display: "summarized"` instead of inheriting Anthropic's `omitted` default and no longer attach the redundant `interleaved-thinking-2025-05-14` beta; date-suffixed Opus 4.0 ids (`claude-opus-4-20250514` and its Bedrock variants) are no longer misread as version 4.20250514, so these budget-thinking models regain the interleaved-thinking beta they need. Opus 4.6, every Sonnet/Haiku, `-latest` aliases, and non-Anthropic ids are unaffected.
 - Credential selection and aggregate usage callers now stop awaiting immediately when their own signal aborts without cancelling shared usage fetches, and ranking deadlines no longer re-await the same stalled usage request during credential resolution.
 - Kimi Code now allows one continuous 300-second first-event wait before aborting, while preserving explicit caller and environment timeout overrides and the existing inter-event idle timeout.
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -111,6 +111,92 @@ export function injectImageGenerationModels(models: Model[]): void {
 	}
 }
 
+/**
+ * A first-party model transcribed from published provider documentation, kept as
+ * a typed generator input instead of a hand-edit in the generated catalog.
+ */
+interface FirstPartyCatalogSeed {
+	/** Upstream-shaped entry; normalization (name scrub, thinking, limits) runs later. */
+	readonly model: Model;
+	/** Published documentation the fields were transcribed from. */
+	readonly provenance: {
+		readonly sources: readonly string[];
+		readonly retrievedAt: string;
+	};
+}
+
+/**
+ * Typed catalog seeds for first-party models that live upstream sources do not
+ * return yet.
+ *
+ * models.dev and provider discovery stay the primary sources: a seed is skipped
+ * whenever a live source returned the same provider/model key. A seed does
+ * outrank the previously generated `src/models.json` row, so correcting a seed
+ * field corrects the regenerated catalog instead of losing to the stale row it
+ * bootstrapped. The seed is upstream-shaped and flows through the same pipeline
+ * as every other entry (`applyGlobalModelsDevFallback`,
+ * `applyGeneratedModelPolicies`, name scrubbing, thinking inference), and the
+ * emitted row carries `catalogProvenance` so the artifact records which
+ * documentation produced its fields.
+ */
+export const FIRST_PARTY_CATALOG_SEEDS: readonly FirstPartyCatalogSeed[] = [
+	{
+		// Claude Opus 5: GA on the Claude API, announced 2026-07-24.
+		model: {
+			id: "claude-opus-5",
+			name: "Claude Opus 5",
+			api: "anthropic-messages",
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+			contextWindow: 1_000_000,
+			maxTokens: 128_000,
+		} satisfies Model<"anthropic-messages">,
+		provenance: {
+			sources: [
+				"https://platform.claude.com/docs/en/about-claude/models/overview",
+				"https://platform.claude.com/docs/en/about-claude/pricing",
+			],
+			retrievedAt: "2026-07-25",
+		},
+	},
+];
+
+function modelKey(model: Pick<Model, "provider" | "id">): string {
+	return `${model.provider}/${model.id}`;
+}
+
+/**
+ * Merge typed catalog seeds for provider/model keys the live sources did not
+ * return, binding each seed's provenance into the emitted row. Idempotent: a key
+ * already present in `models` is left untouched, so live upstream metadata wins.
+ */
+export function injectFirstPartyCatalogSeeds(models: Model[]): void {
+	const present = new Set(models.map(modelKey));
+	for (const seed of FIRST_PARTY_CATALOG_SEEDS) {
+		if (present.has(modelKey(seed.model))) {
+			continue;
+		}
+		present.add(modelKey(seed.model));
+		models.push({
+			...seed.model,
+			input: [...seed.model.input],
+			cost: { ...seed.model.cost },
+			catalogProvenance: {
+				sources: [...seed.provenance.sources],
+				retrievedAt: seed.provenance.retrievedAt,
+			},
+		});
+	}
+}
+
+/** Provider/model keys the typed seed table owns. */
+export function firstPartyCatalogSeedKeys(): ReadonlySet<string> {
+	return new Set(FIRST_PARTY_CATALOG_SEEDS.map(seed => modelKey(seed.model)));
+}
+
 async function resolveProviderApiKey(providerId: string, catalog: CatalogDiscoveryConfig): Promise<string | undefined> {
 	for (const envVar of catalog.envVars) {
 		const value = $env[envVar as keyof typeof $env];
@@ -395,56 +481,52 @@ async function fetchCodexDiscoveryModels(): Promise<Model<"openai-codex-response
 	}
 }
 
-async function generateModels() {
-	// Fetch models from dynamic sources
-	const modelsDevModels = await loadModelsDevData();
-	const catalogProviderModels = (
-		await Promise.all(
-			PROVIDER_DESCRIPTORS.filter(isCatalogDescriptor).map(descriptor => fetchProviderModelsFromCatalog(descriptor)),
-		)
-	).flat();
-	const gitLabDuoModels = getGitLabDuoModels();
-	// Combine models (models.dev has priority)
-	let allModels = applyGlobalModelsDevFallback(
-		[...modelsDevModels, ...catalogProviderModels, ...gitLabDuoModels, ...createAzureOpenAICatalogModels()],
-		modelsDevModels,
-	);
+/** Inputs the deterministic catalog composition consumes. */
+export interface ComposeCatalogInput {
+	/** Everything live sources returned this run (models.dev, catalog descriptors, discovery). */
+	readonly liveModels: readonly Model[];
+	/** models.dev rows only; used for the same-id metadata fallback. */
+	readonly modelsDevModels: readonly Model[];
+	/** Previously generated catalog, used as the last-resort fallback. */
+	readonly previousCatalog: Record<string, Record<string, Model>>;
+}
+
+// Discovery-only providers (local inference servers) — never bundle static models.
+const DISCOVERY_ONLY_PROVIDERS = new Set(["ollama", "vllm"]);
+
+/**
+ * Compose the bundled catalog from live sources, typed seeds, and the previously
+ * generated catalog. Pure: no network, no credentials, no filesystem — same
+ * inputs always yield the same output, which is what the generation tests assert.
+ *
+ * Precedence, highest first:
+ *   1. live sources (models.dev, catalog descriptors, provider discovery)
+ *   2. `FIRST_PARTY_CATALOG_SEEDS` (documented transcriptions)
+ *   3. the previously generated catalog (static-only and auth-gated providers)
+ */
+export function composeCatalog(input: ComposeCatalogInput): Record<string, Record<string, Model>> {
+	let allModels = applyGlobalModelsDevFallback([...input.liveModels], input.modelsDevModels);
 
 	if (!allModels.some(model => model.provider === "cloudflare-ai-gateway")) {
 		allModels.push(CLOUDFLARE_FALLBACK_MODEL);
 	}
 
-	const specialDiscoverySources = [
-		{ label: "Antigravity", fetch: fetchAntigravityModels },
-		{ label: "OpenAI code", fetch: fetchCodexDiscoveryModels },
-	] as const;
-	const specialDiscoveries = await Promise.all(
-		specialDiscoverySources.map(async source => ({
-			label: source.label,
-			models: await source.fetch(),
-		})),
-	);
-	for (const discovery of specialDiscoveries) {
-		if (discovery.models.length > 0) {
-			console.log(`Added ${discovery.models.length} models from ${discovery.label} discovery`);
-			allModels.push(...discovery.models);
-		}
-	}
+	// Typed seeds outrank the previously generated rows they bootstrapped, so a
+	// seed correction reaches the regenerated catalog; live sources still win.
+	injectFirstPartyCatalogSeeds(allModels);
 
 	// Merge previous models.json entries as fallback for any provider/model
 	// not fetched dynamically. This replaces all hardcoded fallback lists —
 	// static-only providers (vertex, gemini-cli), auth-gated providers when
 	// credentials are unavailable, and ad-hoc model additions all persist
 	// through the existing models.json seed.
-	// Discovery-only providers (local inference servers) — never bundle static models.
-	const discoveryOnlyProviders = new Set(["ollama", "vllm"]);
-	const fetchedKeys = new Set(allModels.map(model => `${model.provider}/${model.id}`));
+	const resolvedKeys = new Set(allModels.map(modelKey));
 
-	for (const models of Object.values(prevModelsJson as Record<string, Record<string, Model>>)) {
+	for (const models of Object.values(input.previousCatalog)) {
 		for (const model of Object.values(models)) {
 			if (
-				!fetchedKeys.has(`${model.provider}/${model.id}`) &&
-				!discoveryOnlyProviders.has(model.provider) &&
+				!resolvedKeys.has(modelKey(model)) &&
+				!DISCOVERY_ONLY_PROVIDERS.has(model.provider) &&
 				!isRetiredBundledModel(model)
 			) {
 				allModels.push(model.provider === "openai" ? { ...model, baseUrl: "" } : model);
@@ -453,7 +535,7 @@ async function generateModels() {
 	}
 	allModels = allModels.filter(model => !isRetiredBundledModel(model));
 
-	allModels = applyGlobalModelsDevFallback(allModels, modelsDevModels);
+	allModels = applyGlobalModelsDevFallback(allModels, input.modelsDevModels);
 	allModels = applyPremiumMultiplierOverrides(allModels);
 	allModels = applyCodexPricingFallback(allModels);
 	allModels = applyClaudeOpusVisionCorrections(allModels);
@@ -464,7 +546,7 @@ async function generateModels() {
 	// Group by provider and sort each provider's models
 	const providers: Record<string, Record<string, Model>> = {};
 	for (const model of allModels) {
-		if (discoveryOnlyProviders.has(model.provider)) continue;
+		if (DISCOVERY_ONLY_PROVIDERS.has(model.provider)) continue;
 		if (!providers[model.provider]) {
 			providers[model.provider] = {};
 		}
@@ -488,12 +570,54 @@ async function generateModels() {
 	for (const key in MODELS) {
 		MODELS[key] = sortObj(MODELS[key]);
 	}
+	return MODELS;
+}
+
+async function generateModels() {
+	// Fetch models from dynamic sources
+	const modelsDevModels = await loadModelsDevData();
+	const catalogProviderModels = (
+		await Promise.all(
+			PROVIDER_DESCRIPTORS.filter(isCatalogDescriptor).map(descriptor => fetchProviderModelsFromCatalog(descriptor)),
+		)
+	).flat();
+	const gitLabDuoModels = getGitLabDuoModels();
+	const liveModels: Model[] = [
+		...modelsDevModels,
+		...catalogProviderModels,
+		...gitLabDuoModels,
+		...createAzureOpenAICatalogModels(),
+	];
+
+	const specialDiscoverySources = [
+		{ label: "Antigravity", fetch: fetchAntigravityModels },
+		{ label: "OpenAI code", fetch: fetchCodexDiscoveryModels },
+	] as const;
+	const specialDiscoveries = await Promise.all(
+		specialDiscoverySources.map(async source => ({
+			label: source.label,
+			models: await source.fetch(),
+		})),
+	);
+	for (const discovery of specialDiscoveries) {
+		if (discovery.models.length > 0) {
+			console.log(`Added ${discovery.models.length} models from ${discovery.label} discovery`);
+			liveModels.push(...discovery.models);
+		}
+	}
+
+	const MODELS = composeCatalog({
+		liveModels,
+		modelsDevModels,
+		previousCatalog: prevModelsJson as Record<string, Record<string, Model>>,
+	});
 
 	// Generate JSON file
 	await Bun.write(path.join(packageRoot, "src/models.json"), JSON.stringify(MODELS, null, "	"));
 	console.log("Generated src/models.json");
 
 	// Print statistics
+	const allModels = Object.values(MODELS).flatMap(models => Object.values(models));
 	const totalModels = allModels.length;
 	const reasoningModels = allModels.filter(m => m.reasoning).length;
 

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -350,6 +350,24 @@ export function hasOpus47ApiRestrictions(modelId: string): boolean {
 	return semverGte(parsed.version, "4.7") && parsed.kind === "opus";
 }
 
+/**
+ * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
+ * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
+ * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
+ * "omitted" — thinking tokens are billed but no content streams back — so it
+ * must opt in like Opus 4.7+ (issue #2791).
+ *
+ * Version parsing (not id-shape matching) is the authority here: dateless ids
+ * carry a single version segment (`claude-opus-5`), and Bedrock ids add
+ * region/inference-profile prefixes (`eu.anthropic.claude-opus-5`).
+ */
+export function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
+	const parsed = parseAnthropicModel(getCanonicalModelId(modelId));
+	if (!parsed) return false;
+	if (parsed.kind === "fable") return true;
+	return parsed.kind === "opus" && semverGte(parsed.version, "4.7");
+}
+
 function anthropicModelHasRealXHighEffort<TApi extends Api>(model: ApiModel<TApi>): boolean {
 	if (model.api !== "anthropic-messages") return false;
 	const parsedModel = parseKnownModel(model.id);

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -3512,6 +3512,38 @@
 				"maxLevel": "max"
 			}
 		},
+		"claude-opus-5": {
+			"id": "claude-opus-5",
+			"name": "Anthropic Opus 5",
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"baseUrl": "https://api.anthropic.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"catalogProvenance": {
+				"sources": [
+					"https://platform.claude.com/docs/en/about-claude/models/overview",
+					"https://platform.claude.com/docs/en/about-claude/pricing"
+				],
+				"retrievedAt": "2026-07-25"
+			},
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "max"
+			}
+		},
 		"claude-sonnet-4-0": {
 			"id": "claude-sonnet-4-0",
 			"name": "Anthropic Sonnet 4 (latest)",

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -9,7 +9,11 @@
 
 import { $credentialEnv, $env, $flag, extractHttpStatusFromError, fetchWithRetry } from "@gajae-code/utils";
 import type { Effort } from "../model-thinking";
-import { mapEffortToAnthropicAdaptiveEffort, requireSupportedEffort } from "../model-thinking";
+import {
+	mapEffortToAnthropicAdaptiveEffort,
+	requireSupportedEffort,
+	supportsAdaptiveThinkingDisplay,
+} from "../model-thinking";
 import { calculateCost } from "../models";
 import type {
 	Api,
@@ -905,25 +909,6 @@ function buildAdditionalModelRequestFields(
 	}
 
 	return result;
-}
-
-/**
- * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
- * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
- * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
- * "omitted" — thinking tokens are billed but no content streams back — so it
- * must opt in like Opus 4.7+ (issue #2791).
- * Bedrock model ids are prefixed with region/inference-profile slugs (e.g.
- * `eu.anthropic.Anthropic model-opus-4-7-...`); the regex matches the `Anthropic model-opus-X-Y`
- * fragment regardless of prefix.
- */
-function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
-	if (/claude-fable-\d/.test(modelId)) return true;
-	const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
-	if (!match) return false;
-	const major = Number(match[1]);
-	const minor = Number(match[2]);
-	return major > 4 || (major === 4 && minor >= 7);
 }
 
 /**

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -19,7 +19,11 @@ import {
 	logger,
 	readSseEvents,
 } from "@gajae-code/utils";
-import { hasOpus47ApiRestrictions, mapEffortToAnthropicAdaptiveEffort } from "../model-thinking";
+import {
+	hasOpus47ApiRestrictions,
+	mapEffortToAnthropicAdaptiveEffort,
+	supportsAdaptiveThinkingDisplay,
+} from "../model-thinking";
 import { calculateCost } from "../models";
 import { isUsageLimitError } from "../rate-limit-utils";
 import { getEnvApiKey, OUTPUT_FALLBACK_BUFFER } from "../stream";
@@ -307,22 +311,6 @@ type AnthropicSamplingParams = MessageCreateParamsStreaming & {
 
 const ANTHROPIC_STOP_SEQUENCES_MAX = 4;
 let warnedStopSequencesTrim = false;
-
-/**
- * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
- * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
- * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
- * "omitted" — thinking tokens are billed but no content streams back — so it
- * must opt in like Opus 4.7+ (issue #2791).
- */
-function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
-	if (/claude-fable-\d/.test(modelId)) return true;
-	const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
-	if (!match) return false;
-	const major = Number(match[1]);
-	const minor = Number(match[2]);
-	return major > 4 || (major === 4 && minor >= 7);
-}
 
 const ANTHROPIC_PROVIDER_SESSION_STATE_KEY = "anthropic-messages";
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -960,6 +960,22 @@ export interface ModelRequestTransform {
 	extraBody?: Record<string, unknown>;
 }
 
+/**
+ * Published provider documentation a bundled catalog row was transcribed from.
+ *
+ * Set by the catalog generator for first-party models it seeds from typed inputs
+ * (a model published after the last upstream snapshot, or any regeneration
+ * without network access or provider credentials). Rows resolved from a live
+ * upstream source carry no provenance, so the presence of this field identifies
+ * exactly which fields came from a documented transcription.
+ */
+export interface CatalogProvenance {
+	/** Documentation URLs the fields were transcribed from. */
+	sources: readonly string[];
+	/** ISO `YYYY-MM-DD` date the documentation was read. */
+	retrievedAt: string;
+}
+
 export interface Model<TApi extends Api = any> {
 	id: string;
 	name: string;
@@ -1045,4 +1061,9 @@ export interface Model<TApi extends Api = any> {
 	 * `options.isOAuth = true` for the underlying provider call.
 	 */
 	isOAuth?: boolean;
+	/**
+	 * Documentation the generator transcribed this bundled row from. Only set for
+	 * typed generator seeds; live upstream rows leave it unset.
+	 */
+	catalogProvenance?: CatalogProvenance;
 }

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1166,6 +1166,44 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.output_config).toEqual({ effort: "high" });
 	});
 
+	it("requests summarized adaptive thinking for Opus 5 dateless ids", async () => {
+		const payload = (await captureAnthropicPayload(
+			{
+				...ANTHROPIC_MODEL,
+				id: "claude-opus-5",
+				name: "Anthropic Opus 5",
+				thinking: {
+					mode: "anthropic-adaptive",
+					minLevel: Effort.Minimal,
+					maxLevel: Effort.Max,
+				},
+			},
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				thinkingEnabled: true,
+				reasoning: Effort.Max,
+				temperature: 0.2,
+				topP: 0.3,
+				topK: 4,
+			},
+		)) as {
+			temperature?: number;
+			top_p?: number;
+			top_k?: number;
+			thinking?: { type?: string; display?: string };
+			output_config?: { effort?: string };
+		};
+
+		expect(payload.temperature).toBeUndefined();
+		expect(payload.top_p).toBeUndefined();
+		expect(payload.top_k).toBeUndefined();
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toEqual({ effort: "max" });
+	});
+
 	it("maps Opus max reasoning to Anthropic adaptive max", async () => {
 		const payload = (await captureAnthropicPayload(
 			{

--- a/packages/ai/test/generate-models-composition.test.ts
+++ b/packages/ai/test/generate-models-composition.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import { composeCatalog, FIRST_PARTY_CATALOG_SEEDS, firstPartyCatalogSeedKeys } from "../scripts/generate-models";
+import bundledModelsJson from "../src/models.json" with { type: "json" };
+import type { Model } from "../src/types";
+
+/**
+ * Deterministic generation coverage for the catalog surface this package seeds.
+ *
+ * `composeCatalog` is the whole merge/normalization pipeline `generateModels()`
+ * runs after fetching. These tests drive it with in-memory fixtures only — no
+ * network, no provider credentials, no discovery — so precedence and output
+ * exactness are asserted on the real code path rather than on the seed table.
+ */
+
+const bundledCatalog = bundledModelsJson as unknown as Record<string, Record<string, Model>>;
+
+function clone<T>(value: T): T {
+	return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function bundledRow(key: string): Model {
+	const separator = key.indexOf("/");
+	const provider = key.slice(0, separator);
+	const id = key.slice(separator + 1);
+	const row = bundledCatalog[provider]?.[id];
+	if (!row) throw new Error(`Expected bundled catalog row for ${key}`);
+	return row;
+}
+
+function composedRow(catalog: Record<string, Record<string, Model>>, key: string): Model | undefined {
+	const separator = key.indexOf("/");
+	return catalog[key.slice(0, separator)]?.[key.slice(separator + 1)];
+}
+
+describe("composeCatalog seeded surface", () => {
+	it("reproduces every committed seeded row from the typed seed alone", () => {
+		// Empty live sources and an empty previous catalog: the committed row must
+		// be exactly what the pipeline emits from the seed, so no field in
+		// `src/models.json` can be a hand-fix that regeneration would drop.
+		const catalog = composeCatalog({ liveModels: [], modelsDevModels: [], previousCatalog: {} });
+
+		for (const key of firstPartyCatalogSeedKeys()) {
+			expect(clone(composedRow(catalog, key))).toEqual(clone(bundledRow(key)));
+		}
+	});
+
+	it("overrides a stale previously generated row instead of inheriting it", () => {
+		// Regression for the bootstrap trap: once the generated catalog carries the
+		// key, a corrected seed must still win, or the seed stops being canonical.
+		const previousCatalog: Record<string, Record<string, Model>> = {};
+		for (const key of firstPartyCatalogSeedKeys()) {
+			const stale = clone(bundledRow(key));
+			stale.name = "Stale Generated Row";
+			stale.cost = { input: 999, output: 999, cacheRead: 999, cacheWrite: 999 };
+			stale.contextWindow = 4_096;
+			stale.maxTokens = 512;
+			delete stale.catalogProvenance;
+			previousCatalog[stale.provider] = { ...(previousCatalog[stale.provider] ?? {}), [stale.id]: stale };
+		}
+
+		const catalog = composeCatalog({ liveModels: [], modelsDevModels: [], previousCatalog });
+
+		for (const key of firstPartyCatalogSeedKeys()) {
+			expect(clone(composedRow(catalog, key))).toEqual(clone(bundledRow(key)));
+		}
+	});
+
+	it("yields to a genuinely fresher live upstream row for the same key", () => {
+		const seed = FIRST_PARTY_CATALOG_SEEDS[0];
+		if (!seed) throw new Error("Expected at least one catalog seed");
+		const live = clone(seed.model) as Model;
+		live.name = "Claude Opus 5 (upstream)";
+		live.contextWindow = 2_000_000;
+		live.maxTokens = 300_000;
+
+		const catalog = composeCatalog({
+			liveModels: [live],
+			modelsDevModels: [live],
+			previousCatalog: {},
+		});
+
+		const row = composedRow(catalog, `${seed.model.provider}/${seed.model.id}`);
+		expect(row?.contextWindow).toBe(2_000_000);
+		expect(row?.maxTokens).toBe(300_000);
+		// Upstream rows are not documented transcriptions, so they carry no provenance.
+		expect(row?.catalogProvenance).toBeUndefined();
+		// The name still goes through generated-name scrubbing.
+		expect(row?.name).toBe("Anthropic Opus 5 (upstream)");
+	});
+
+	it("binds seed provenance into the emitted row", () => {
+		const catalog = composeCatalog({ liveModels: [], modelsDevModels: [], previousCatalog: {} });
+
+		for (const seed of FIRST_PARTY_CATALOG_SEEDS) {
+			const row = composedRow(catalog, `${seed.model.provider}/${seed.model.id}`);
+			expect(row?.catalogProvenance).toEqual({
+				sources: [...seed.provenance.sources],
+				retrievedAt: seed.provenance.retrievedAt,
+			});
+		}
+	});
+
+	it("is idempotent when its own output is fed back as the previous catalog", () => {
+		const first = composeCatalog({ liveModels: [], modelsDevModels: [], previousCatalog: {} });
+		const second = composeCatalog({ liveModels: [], modelsDevModels: [], previousCatalog: clone(first) });
+
+		for (const key of firstPartyCatalogSeedKeys()) {
+			expect(clone(composedRow(second, key))).toEqual(clone(composedRow(first, key)));
+		}
+	});
+
+	it("does not mutate the exported seed table", () => {
+		const before = clone(FIRST_PARTY_CATALOG_SEEDS);
+		composeCatalog({ liveModels: [], modelsDevModels: [], previousCatalog: clone(bundledCatalog) });
+		expect(clone(FIRST_PARTY_CATALOG_SEEDS)).toEqual(before);
+	});
+
+	it("keeps the committed catalog's seeded rows stable through a full recompose", () => {
+		// Feeding the committed catalog back in (still no network/credentials) must
+		// leave the seeded rows byte-identical: the seed and the artifact agree.
+		const catalog = composeCatalog({
+			liveModels: [],
+			modelsDevModels: [],
+			previousCatalog: clone(bundledCatalog),
+		});
+
+		for (const key of firstPartyCatalogSeedKeys()) {
+			expect(clone(composedRow(catalog, key))).toEqual(clone(bundledRow(key)));
+		}
+	});
+});

--- a/packages/ai/test/generate-models.test.ts
+++ b/packages/ai/test/generate-models.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { injectImageGenerationModels } from "../scripts/generate-models";
+import {
+	FIRST_PARTY_CATALOG_SEEDS,
+	injectFirstPartyCatalogSeeds,
+	injectImageGenerationModels,
+} from "../scripts/generate-models";
 import type { Model } from "../src/types";
 
 describe("injectImageGenerationModels", () => {
@@ -25,5 +29,56 @@ describe("injectImageGenerationModels", () => {
 				output: ["text", "image"],
 			}),
 		]);
+	});
+});
+
+describe("injectFirstPartyCatalogSeeds", () => {
+	it("carries published provenance for every seed", () => {
+		expect(FIRST_PARTY_CATALOG_SEEDS.length).toBeGreaterThan(0);
+		for (const seed of FIRST_PARTY_CATALOG_SEEDS) {
+			expect(seed.provenance.sources.length).toBeGreaterThan(0);
+			for (const source of seed.provenance.sources) {
+				expect(source).toMatch(/^https:\/\//);
+			}
+			expect(seed.provenance.retrievedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		}
+	});
+
+	it("binds provenance into every injected row", () => {
+		const models: Model[] = [];
+		injectFirstPartyCatalogSeeds(models);
+
+		for (const seed of FIRST_PARTY_CATALOG_SEEDS) {
+			const injected = models.find(model => model.provider === seed.model.provider && model.id === seed.model.id);
+			expect(injected?.catalogProvenance).toEqual({
+				sources: [...seed.provenance.sources],
+				retrievedAt: seed.provenance.retrievedAt,
+			});
+		}
+	});
+
+	it("is idempotent and never overrides an upstream entry for the same key", () => {
+		const seed = FIRST_PARTY_CATALOG_SEEDS[0];
+		if (!seed) throw new Error("Expected at least one catalog seed");
+
+		const models: Model[] = [];
+		injectFirstPartyCatalogSeeds(models);
+		injectFirstPartyCatalogSeeds(models);
+		expect(models.filter(model => model.provider === seed.model.provider && model.id === seed.model.id)).toHaveLength(
+			1,
+		);
+
+		const upstream = { ...seed.model, name: "Upstream Name", contextWindow: 123_456 } as Model;
+		const withUpstream: Model[] = [upstream];
+		injectFirstPartyCatalogSeeds(withUpstream);
+		expect(withUpstream).toEqual([upstream]);
+	});
+
+	it("does not mutate the exported seed table", () => {
+		const before = JSON.parse(JSON.stringify(FIRST_PARTY_CATALOG_SEEDS));
+		const models: Model[] = [];
+		injectFirstPartyCatalogSeeds(models);
+		injectFirstPartyCatalogSeeds(models);
+		expect(JSON.parse(JSON.stringify(FIRST_PARTY_CATALOG_SEEDS))).toEqual(before);
 	});
 });

--- a/packages/ai/test/issue-1373-repro.test.ts
+++ b/packages/ai/test/issue-1373-repro.test.ts
@@ -100,6 +100,16 @@ describe("issue #1373: Bedrock Claude thinkingDisplay", () => {
 		});
 	});
 
+	it("defaults adaptive thinking to display=summarized on Opus 5 dateless ids", async () => {
+		const payload = await captureBedrockPayload(adaptiveModel("us.anthropic.claude-opus-5"), {
+			reasoning: Effort.High,
+		});
+		expect(payload.additionalModelRequestFields?.thinking).toMatchObject({
+			type: "adaptive",
+			display: "summarized",
+		});
+	});
+
 	it("respects explicit thinkingDisplay='omitted' on Opus 4.7+", async () => {
 		const payload = await captureBedrockPayload(adaptiveModel("eu.anthropic.claude-opus-4-7"), {
 			reasoning: Effort.High,

--- a/packages/ai/test/issue-830-repro.test.ts
+++ b/packages/ai/test/issue-830-repro.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { Effort } from "../src/model-thinking";
 import { getBundledModel } from "../src/models";
 import { DEFAULT_MODEL_PER_PROVIDER, PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
 import { MODELS_DEV_PROVIDER_DESCRIPTORS } from "../src/provider-models/openai-compat";
@@ -76,5 +77,30 @@ describe("Anthropic Sonnet 5 model catalog support", () => {
 		expect(sonnet5?.api).toBe("anthropic-messages");
 		expect(sonnet5?.reasoning).toBe(true);
 		expect(sonnet46?.api).toBe("anthropic-messages");
+	});
+});
+
+describe("Anthropic Opus 5 model catalog support", () => {
+	test("registers Opus 5 with published Anthropic limits and pricing", () => {
+		const opus5 = getBundledModel("anthropic", "claude-opus-5");
+		expect(opus5?.api).toBe("anthropic-messages");
+		expect(opus5?.baseUrl).toBe("https://api.anthropic.com");
+		expect(opus5?.reasoning).toBe(true);
+		expect(opus5?.input).toEqual(["text", "image"]);
+		expect(opus5?.contextWindow).toBe(1_000_000);
+		expect(opus5?.maxTokens).toBe(128_000);
+		expect(opus5?.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
+		expect(opus5?.thinking).toEqual({
+			mode: "anthropic-adaptive",
+			minLevel: Effort.Minimal,
+			maxLevel: Effort.Max,
+		});
+	});
+
+	test("keeps the Anthropic provider default and older Opus entries untouched", () => {
+		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "anthropic");
+		expect(descriptor?.defaultModel).toBe("claude-sonnet-5");
+		expect(DEFAULT_MODEL_PER_PROVIDER.anthropic).toBe("claude-sonnet-5");
+		expect(getBundledModel("anthropic", "claude-opus-4-8")?.api).toBe("anthropic-messages");
 	});
 });

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -5,10 +5,12 @@ import {
 	clampThinkingLevelForModel,
 	Effort,
 	enrichModelThinking,
+	hasOpus47ApiRestrictions,
 	linkOpenAIPromotionTargets,
 	mapEffortToAnthropicAdaptiveEffort,
 	mapEffortToGoogleThinkingLevel,
 	requireSupportedEffort,
+	supportsAdaptiveThinkingDisplay,
 } from "@gajae-code/ai/model-thinking";
 import type { Api, Model, Provider, ThinkingControlMode } from "@gajae-code/ai/types";
 
@@ -183,6 +185,64 @@ describe("model thinking metadata", () => {
 		expect(fableBedrock.thinking?.maxLevel).toBe(Effort.High);
 		expect(mapEffortToAnthropicAdaptiveEffort(fableBedrock, Effort.High)).toBe("high");
 		expect(() => mapEffortToAnthropicAdaptiveEffort(fableBedrock, Effort.XHigh)).toThrow(/not supported/);
+	});
+
+	it("classifies dateless Opus 5 ids as adaptive thinking with xhigh + max support", () => {
+		const opus5 = createModel({
+			id: "claude-opus-5",
+			api: "anthropic-messages",
+			provider: "anthropic",
+		});
+		const opus5Bedrock = createModel({
+			id: "us.anthropic.claude-opus-5",
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+		});
+
+		expect(opus5.thinking).toEqual({
+			mode: "anthropic-adaptive",
+			minLevel: Effort.Minimal,
+			maxLevel: Effort.Max,
+		});
+		expect(mapEffortToAnthropicAdaptiveEffort(opus5, Effort.XHigh)).toBe("xhigh");
+		expect(mapEffortToAnthropicAdaptiveEffort(opus5, Effort.Max)).toBe("max");
+
+		// Bedrock Converse lacks the Messages-only xhigh preset (same split as Opus 4.7+).
+		expect(opus5Bedrock.thinking?.mode).toBe("anthropic-adaptive");
+		expect(opus5Bedrock.thinking?.maxLevel).toBe(Effort.Max);
+		expect(() => mapEffortToAnthropicAdaptiveEffort(opus5Bedrock, Effort.XHigh)).toThrow(/not supported/);
+		expect(mapEffortToAnthropicAdaptiveEffort(opus5Bedrock, Effort.Max)).toBe("max");
+	});
+
+	it("reports Opus 4.7+ restrictions and adaptive display for single-segment Opus versions", () => {
+		// Both Anthropic transports gate `display: "summarized"` on this predicate.
+		// A regex expecting `claude-opus-<major>-<minor>` never matched the dateless
+		// `claude-opus-5` id, so Opus 5 thinking was billed and never displayed.
+		expect(hasOpus47ApiRestrictions("claude-opus-5")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-5")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("us.anthropic.claude-opus-5")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-7")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-fable-5")).toBe(true);
+		// Opus 4.6 and every Sonnet reject the field.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-6")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-sonnet-5")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("gpt-5.6-sol")).toBe(false);
+	});
+
+	it("resolves adaptive display for dot-form ids and rejects date-suffixed Opus 4", () => {
+		// Gateways publish dot-form ids (`claude-opus-4.8`), which the dash-only
+		// regex never matched: Copilot / Vercel AI Gateway / ZenMux Opus 4.7+ were
+		// billed for adaptive thinking that streamed no content.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.8")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("anthropic/claude-opus-4.7-fast")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.6")).toBe(false);
+		// `claude-opus-4-20250514` is dated Opus 4.0, not version 4.20250514. The
+		// dash-only regex read the date as the minor version and misclassified it
+		// as Opus 4.7+, which also suppressed the interleaved-thinking beta these
+		// budget-thinking models need.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-20250514")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("us.anthropic.claude-opus-4-20250514-v1:0")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-1-20250805")).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -526,10 +526,16 @@ describe("ModelRegistry", () => {
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
-			const opusVariants = registry.getCanonicalVariants("claude-opus-4-8");
+			// `-latest` collapses onto the highest bundled version of the family,
+			// so the Opus target tracks the newest catalog entry (currently Opus 5).
+			const opusVariants = registry.getCanonicalVariants("claude-opus-5");
+			const supersededOpusVariants = registry.getCanonicalVariants("claude-opus-4-8");
 			const haikuVariants = registry.getCanonicalVariants("claude-haiku-4-5");
 
 			expect(opusVariants.some(variant => variant.selector === "demo/anthropic/claude-opus-latest")).toBe(true);
+			expect(supersededOpusVariants.some(variant => variant.selector === "demo/anthropic/claude-opus-latest")).toBe(
+				false,
+			);
 			expect(haikuVariants.some(variant => variant.selector === "demo/anthropic/claude-haiku-latest")).toBe(true);
 			expect(
 				registry


### PR DESCRIPTION
Supersedes #3118 (and #3097). Both were closed and cannot be reopened because the branch was force-pushed after closure — same author, same branch, and this revision implements every blocker from the #3118 review.

## Blocker-by-blocker

### 1. `ApiModel` compile error — fixed

The import was in `packages/ai/test/generate-models.test.ts` (the generator script never referenced `ApiModel`); `ApiModel` is only a local alias for `Model` inside `model-thinking.ts`. The test now uses `Model` directly. `bun --cwd=packages/ai run check` and `bun run ci:check:full` both pass locally — I had only run the root `check:tools` before, which does not include the package tsconfigs. My miss.

### 2. The typed seed is now authoritative against the stale generated row, and provenance is bound into the artifact

You were right that the previous ordering made the seed a one-shot bootstrap: seeds ran *after* the `prevModelsJson` merge, so the row it had already produced won forever and later seed corrections were silently dropped.

Precedence is now explicit, and it is the seed that outranks the previously generated catalog:

1. live sources (models.dev, catalog descriptors, provider discovery)
2. `FIRST_PARTY_CATALOG_SEEDS`
3. previously generated `src/models.json`

Concretely, `injectFirstPartyCatalogSeeds` runs against the live-source set *before* the previous-catalog pass computes its `resolvedKeys`, so a seeded key suppresses the stale generated row while a genuinely fresher live row still shuts the seed out.

Provenance is no longer only beside the seed: the emitted row carries it. `Model` gains an optional `catalogProvenance { sources, retrievedAt }`, set only for rows the generator seeds from a documented transcription, so the artifact itself records the source and retrieval date — and the absence of that field is equally informative (the row came from a live upstream source):

```json
"claude-opus-5": {
  …
  "maxTokens": 128000,
  "catalogProvenance": {
    "sources": [
      "https://platform.claude.com/docs/en/about-claude/models/overview",
      "https://platform.claude.com/docs/en/about-claude/pricing"
    ],
    "retrievedAt": "2026-07-25"
  },
  "thinking": { "mode": "anthropic-adaptive", "minLevel": "minimal", "maxLevel": "max" }
}
```

The seed stays upstream-shaped (`"Claude Opus 5"`, no `thinking` block) precisely so the artifact cannot contain a hand-fixed field: `scrubGeneratedModelName` produces `"Anthropic Opus 5"` and `refreshModelThinking` derives the `anthropic-adaptive` `minimal…max` range.

### 3. Deterministic generation on the real merge path

`generateModels()` is split: all fetching stays in it, and the entire merge/normalization/grouping/sorting body moves to a pure `composeCatalog({ liveModels, modelsDevModels, previousCatalog })`. Behavior is unchanged — the same functions run in the same order — but generation is now testable without network, credentials, or discovery.

`packages/ai/test/generate-models-composition.test.ts` drives that real path with in-memory fixtures:

| Assertion | What it proves |
| --- | --- |
| seed-only compose (`liveModels: []`, `previousCatalog: {}`) equals the committed row | the artifact is reproducible from the typed source; no hand-fixed field |
| stale previous row (wrong name/cost/limits, no provenance) → output equals the committed row | your blocker 2: the seed beats its own stale output |
| fresher live row (2M context / 300k output) wins, keeps no provenance, still gets name scrubbing | upstream priority preserved, provenance is not forged onto upstream rows |
| provenance bound into every seeded emitted row | your blocker 2, second half |
| recomposing the **committed catalog** leaves every seeded row byte-identical | seed and artifact agree in the real merge order, not just in isolation |
| feeding the composer's own output back in is idempotent | no drift on repeat generation |

Plus injector-level coverage in `generate-models.test.ts` (provenance shape per seed, idempotence, never overriding an existing key, seed table not mutated).

### On "full generated-output exactness"

I owe you a measurement rather than a claim: a whole-file fixed point is **not** assertable against `dev` today, for three reasons I verified, none of them Opus 5:

1. **Formatting.** `generateModels()` writes `JSON.stringify(…, "\t")`; the committed file has biome-collapsed rows (e.g. `"input": ["text"]` in `alibaba-token-plan`), so raw generator output never matches the committed bytes without a formatter pass.
2. **Empty-live-source artifacts.** With no network, `CLOUDFLARE_FALLBACK_MODEL` (200k, `"Anthropic Sonnet 4.5"`) replaces the committed `cloudflare-ai-gateway/claude-sonnet-4-5` row (1M, `"… (latest)"`), which only exists because a models.dev-backed run filled it.
3. **Committed rows that already diverge from the current pipeline.** `opengateway` is not key-sorted in the committed file (`openai/gpt-4o` precedes `anthropic/…`), and its `anthropic/claude-sonnet-4-5` row would re-derive `maxLevel: "xhigh"` instead of the committed `"high"`.

So the deterministic tests scope exactness to the surface this PR affects — the seeded keys — and additionally prove the committed catalog is a fixed point *for those rows*. If you want the whole-file guarantee, it needs a separate change (formatter step in the generator + reconciling those pre-existing rows); happy to take that as its own PR.

I also ran the real networked generator: the regenerated `anthropic/claude-opus-5` object is byte-identical to the committed one. I did not commit the rest of that output, because it also carries unrelated live drift — **1261 insertions / 142 deletions across 17 providers** (`openrouter` 15 changed, `venice` 16, `amazon-bedrock` +6/7, `alibaba-token-plan` +12, `google` +6, …) — which is a catalog refresh, not Opus 5 support. Separate PR on request; the Bedrock region variants and the Copilot row for Opus 5 are part of that drift.

## 4. Adaptive parser work (unchanged from your positive assessment)

Both transports consume one shared, version-parsing predicate in `model-thinking.ts` instead of two duplicated regexes. Replaying the old regex over all 511 bundled `anthropic-messages` / `bedrock-converse-stream` ids gives 12 diffs, all corrections: dateless Opus 5 (2), gateway dot-form Opus 4.7/4.8 incl. `-fast` on `github-copilot` / `vercel-ai-gateway` / `zenmux` (8, pre-existing silent-thinking bug on `dev`), and date-suffixed Opus 4.0 misread as version 4.20250514 (3, which had lost the `interleaved-thinking-2025-05-14` beta). Opus 4.6, every Sonnet/Haiku, `-latest` aliases, and non-Anthropic ids are untouched.

## Tests

```
bun run ci:check:full                                        # all workspaces clean (incl. publish-types, schemas, node20, public-sync)
bun test packages/ai/test                                    # 1913 pass / 337 skip / 1 fail (pre-existing, see below)
bun test packages/ai/test/generate-models-composition.test.ts # 7 pass
bun test packages/ai/test/generate-models.test.ts             # 5 pass
bun test packages/ai/test/model-thinking.test.ts packages/ai/test/issue-830-repro.test.ts \
         packages/ai/test/issue-1373-repro.test.ts packages/ai/test/anthropic-alignment.test.ts \
         packages/ai/test/anthropic-cache-eval.integration.test.ts   # 94 pass
bun test packages/coding-agent/test/model-registry.test.ts -t "collapses anthropic latest aliases"   # pass
```

Pre-existing failures on this machine, reproduced on an unmodified `dev` checkout: `auth-storage-if-absent.test.ts` (worker `stderr` assertion picks up Bun's `FORCE_COLOR` warning from the local env), two `model-registry.test.ts` canonical-variant stickiness tests (local AWS credentials present), `agent-session-profile-resume-default.test.ts` (activation rollback).

`artifacts/architecture-2383-eval.json` is refreshed with its recorded derivation command because it binds the blob OID / SHA-256 of `packages/ai/src/providers/anthropic.ts` (same pattern as #2794 / #2940 / #3046).

## Still your call

- Accepting a first-party Opus 5 catalog entry.
- `claude-opus-latest` retargeting to the highest bundled Opus (existing resolver behavior; the registry test asserts the new target and removal from Opus 4.8). Metadata impact is nil — the Opus 5 row is identical to Opus 4.8 apart from `id`/`name`/provenance. I have not pinned the alias, since that would hardcode a per-model quality preference into a generic version-ordering resolver.
- Whether the separate catalog refresh lands, and whether a formatter step + whole-file exactness guarantee is wanted.
- `claude-mythos-5` is not parsed by `parseAnthropicModel` (`opus|sonnet|fable`), so it would hit the same silent-thinking bug. Absent from models.dev and this catalog, so left out rather than written speculatively.
