### PR TITLE
fix(ai): decide Anthropic adaptive thinking display by parsed version, not id shape

### DIFF
--- a/artifacts/architecture-2383-eval.json
+++ b/artifacts/architecture-2383-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "67cd55244f886f568da678bda4314298f01abf0e",
-		"providerSourceSha256": "978c083395de102cb8c78d1e25b164daea3c3558dbd7d90e7a190d3f22550e9b",
+		"providerSourceBlobOid": "c56ed124951c9d922f727b6ddde123349effe0a5",
+		"providerSourceSha256": "22ebcf813814afefd9c07292dbb8b54904678715df70285f5ee9e19e46a578c0",
 		"inputFixtureSha256": "b1ca8d3183ca168140774f848ed414252178f7c5788d61243069862ae59c129b"
 	},
 	"derivationCommands": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Credential selection and aggregate usage callers now stop awaiting immediately when their own signal aborts without cancelling shared usage fetches, and ranking deadlines no longer re-await the same stalled usage request during credential resolution.
 - Kimi Code now allows one continuous 300-second first-event wait before aborting, while preserving explicit caller and environment timeout overrides and the existing inter-event idle timeout.
+- Anthropic adaptive-thinking `display` support is now decided by the parsed model version instead of a dash-separated id-shape regex, and the predicate is shared by the Anthropic and Bedrock providers instead of being duplicated in both. Replaying the previous regex across the 510 bundled `anthropic-messages` / `bedrock-converse-stream` ids changes 11 verdicts, all corrections: the eight dot-separated gateway ids (`github-copilot/claude-opus-4.{7,8}`, `vercel-ai-gateway/anthropic/claude-opus-4.{7,8}` and their `-fast` variants, `zenmux/anthropic/claude-opus-4.{7,8}`) were omitting `display: "summarized"` and therefore billing thinking tokens without streaming the summary (#2791 class), and the three date-suffixed Opus 4.0 ids (`anthropic/claude-opus-4-20250514`, `{us,eu}.anthropic.claude-opus-4-20250514-v1:0`) were parsed as minor version `20250514`, classified as Opus 4.7+, and had the `interleaved-thinking-2025-05-14` beta they still need suppressed. Dateless major-version ids such as `claude-opus-5` are now recognized as well.
 
 ### Added
 

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -350,6 +350,26 @@ export function hasOpus47ApiRestrictions(modelId: string): boolean {
 	return semverGte(parsed.version, "4.7") && parsed.kind === "opus";
 }
 
+/**
+ * Returns true for Anthropic models that accept the adaptive thinking `display`
+ * field. Opus 4.7+ and Fable (5+) default `display` to "omitted" — thinking
+ * tokens are billed but no summary streams back — so they must opt in
+ * explicitly (issue #2791). Older adaptive-thinking models (Opus 4.6,
+ * Sonnet 4.6+) reject the field outright.
+ *
+ * The model version is the authority here, not the id shape: dateless ids carry
+ * a single version segment (`claude-opus-5`), gateway ids use dot separators
+ * (`claude-opus-4.8`), date-suffixed ids pin an older version than their suffix
+ * suggests (`claude-opus-4-20250514` is Opus 4.0), and Bedrock ids add
+ * region/inference-profile prefixes (`eu.anthropic.claude-opus-4-8`).
+ */
+export function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
+	const parsed = parseAnthropicModel(getCanonicalModelId(modelId));
+	if (!parsed) return false;
+	if (parsed.kind === "fable") return true;
+	return parsed.kind === "opus" && semverGte(parsed.version, "4.7");
+}
+
 function anthropicModelHasRealXHighEffort<TApi extends Api>(model: ApiModel<TApi>): boolean {
 	if (model.api !== "anthropic-messages") return false;
 	const parsedModel = parseKnownModel(model.id);

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -9,7 +9,11 @@
 
 import { $credentialEnv, $env, $flag, extractHttpStatusFromError, fetchWithRetry } from "@gajae-code/utils";
 import type { Effort } from "../model-thinking";
-import { mapEffortToAnthropicAdaptiveEffort, requireSupportedEffort } from "../model-thinking";
+import {
+	mapEffortToAnthropicAdaptiveEffort,
+	requireSupportedEffort,
+	supportsAdaptiveThinkingDisplay,
+} from "../model-thinking";
 import { calculateCost } from "../models";
 import type {
 	Api,
@@ -905,25 +909,6 @@ function buildAdditionalModelRequestFields(
 	}
 
 	return result;
-}
-
-/**
- * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
- * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
- * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
- * "omitted" — thinking tokens are billed but no content streams back — so it
- * must opt in like Opus 4.7+ (issue #2791).
- * Bedrock model ids are prefixed with region/inference-profile slugs (e.g.
- * `eu.anthropic.Anthropic model-opus-4-7-...`); the regex matches the `Anthropic model-opus-X-Y`
- * fragment regardless of prefix.
- */
-function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
-	if (/claude-fable-\d/.test(modelId)) return true;
-	const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
-	if (!match) return false;
-	const major = Number(match[1]);
-	const minor = Number(match[2]);
-	return major > 4 || (major === 4 && minor >= 7);
 }
 
 /**

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -19,7 +19,11 @@ import {
 	logger,
 	readSseEvents,
 } from "@gajae-code/utils";
-import { hasOpus47ApiRestrictions, mapEffortToAnthropicAdaptiveEffort } from "../model-thinking";
+import {
+	hasOpus47ApiRestrictions,
+	mapEffortToAnthropicAdaptiveEffort,
+	supportsAdaptiveThinkingDisplay,
+} from "../model-thinking";
 import { calculateCost } from "../models";
 import { isUsageLimitError } from "../rate-limit-utils";
 import { getEnvApiKey, OUTPUT_FALLBACK_BUFFER } from "../stream";
@@ -307,22 +311,6 @@ type AnthropicSamplingParams = MessageCreateParamsStreaming & {
 
 const ANTHROPIC_STOP_SEQUENCES_MAX = 4;
 let warnedStopSequencesTrim = false;
-
-/**
- * Adaptive thinking `display` is supported starting with Anthropic model Opus 4.7.
- * Older adaptive-thinking models (Opus 4.6, Sonnet 4.6+) reject the field.
- * Fable (5+) postdates Opus 4.7, accepts `display`, and defaults it to
- * "omitted" — thinking tokens are billed but no content streams back — so it
- * must opt in like Opus 4.7+ (issue #2791).
- */
-function supportsAdaptiveThinkingDisplay(modelId: string): boolean {
-	if (/claude-fable-\d/.test(modelId)) return true;
-	const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
-	if (!match) return false;
-	const major = Number(match[1]);
-	const minor = Number(match[2]);
-	return major > 4 || (major === 4 && minor >= 7);
-}
 
 const ANTHROPIC_PROVIDER_SESSION_STATE_KEY = "anthropic-messages";
 

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1166,6 +1166,97 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.output_config).toEqual({ effort: "high" });
 	});
 
+	it("requests summarized adaptive thinking for dot-separated gateway Opus ids", async () => {
+		// github-copilot, vercel-ai-gateway and zenmux ship Opus 4.7/4.8 with a dot
+		// between the version segments; the display opt-in must not depend on the
+		// separator.
+		const payload = (await captureAnthropicPayload(
+			{
+				...ANTHROPIC_MODEL,
+				id: "claude-opus-4.8",
+				name: "Anthropic Opus 4.8",
+				thinking: {
+					mode: "anthropic-adaptive",
+					minLevel: Effort.Minimal,
+					maxLevel: Effort.Max,
+				},
+			},
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				thinkingEnabled: true,
+				reasoning: Effort.High,
+			},
+		)) as {
+			thinking?: { type?: string; display?: string };
+			output_config?: { effort?: string };
+		};
+
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toEqual({ effort: "high" });
+	});
+
+	it("requests summarized adaptive thinking for dateless Opus major-version ids", async () => {
+		const payload = (await captureAnthropicPayload(
+			{
+				...ANTHROPIC_MODEL,
+				id: "claude-opus-5",
+				name: "Anthropic Opus 5",
+				thinking: {
+					mode: "anthropic-adaptive",
+					minLevel: Effort.Minimal,
+					maxLevel: Effort.Max,
+				},
+			},
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				thinkingEnabled: true,
+				reasoning: Effort.High,
+			},
+		)) as {
+			thinking?: { type?: string; display?: string };
+			output_config?: { effort?: string };
+		};
+
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toEqual({ effort: "high" });
+	});
+
+	it("keeps the interleaved-thinking beta for date-suffixed Opus 4.0 and drops it for Opus 4.7+", () => {
+		// `claude-opus-4-20250514` is Opus 4.0 with a release-date suffix, so it
+		// still needs the beta; Opus 4.7+ carries adaptive display instead.
+		const opus40 = buildAnthropicClientOptions({
+			model: { ...ANTHROPIC_MODEL, id: "claude-opus-4-20250514", name: "Anthropic Opus 4.0" },
+			apiKey: "sk-ant-api-test",
+			extraBetas: [],
+			stream: true,
+			interleavedThinking: true,
+		});
+		const opus48 = buildAnthropicClientOptions({
+			model: { ...ANTHROPIC_MODEL, id: "claude-opus-4-8", name: "Anthropic Opus 4.8" },
+			apiKey: "sk-ant-api-test",
+			extraBetas: [],
+			stream: true,
+			interleavedThinking: true,
+		});
+		const gatewayOpus48 = buildAnthropicClientOptions({
+			model: { ...ANTHROPIC_MODEL, id: "claude-opus-4.8", name: "Anthropic Opus 4.8" },
+			apiKey: "sk-ant-api-test",
+			extraBetas: [],
+			stream: true,
+			interleavedThinking: true,
+		});
+
+		expect(opus40.defaultHeaders["Anthropic-Beta"]).toContain("interleaved-thinking-2025-05-14");
+		expect(opus48.defaultHeaders["Anthropic-Beta"]).not.toContain("interleaved-thinking-2025-05-14");
+		expect(gatewayOpus48.defaultHeaders["Anthropic-Beta"]).not.toContain("interleaved-thinking-2025-05-14");
+	});
+
 	it("maps Opus max reasoning to Anthropic adaptive max", async () => {
 		const payload = (await captureAnthropicPayload(
 			{

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -9,6 +9,7 @@ import {
 	mapEffortToAnthropicAdaptiveEffort,
 	mapEffortToGoogleThinkingLevel,
 	requireSupportedEffort,
+	supportsAdaptiveThinkingDisplay,
 } from "@gajae-code/ai/model-thinking";
 import type { Api, Model, Provider, ThinkingControlMode } from "@gajae-code/ai/types";
 
@@ -37,6 +38,52 @@ describe("thinking control modes", () => {
 		const modes: readonly ThinkingControlMode[] = THINKING_CONTROL_MODES;
 		expect(modes).toEqual(["effort", "budget", "google-level", "anthropic-adaptive", "anthropic-budget-effort"]);
 		expect(new Set(modes).size).toBe(modes.length);
+	});
+});
+
+describe("supportsAdaptiveThinkingDisplay", () => {
+	it("opts Opus 4.7+ into summarized display across every bundled id shape", () => {
+		// Dash-separated first-party ids.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-7")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-8")).toBe(true);
+		// Dot-separated gateway ids (github-copilot, vercel-ai-gateway, zenmux).
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.7")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.8")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("anthropic/claude-opus-4.8")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("anthropic/claude-opus-4.8-fast")).toBe(true);
+		// Dateless major-version ids.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-5")).toBe(true);
+		// Bedrock region / inference-profile prefixes.
+		expect(supportsAdaptiveThinkingDisplay("us.anthropic.claude-opus-4-8")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("global.anthropic.claude-opus-4-7")).toBe(true);
+		// Fable defaults display to "omitted" too (issue #2791).
+		expect(supportsAdaptiveThinkingDisplay("claude-fable-5")).toBe(true);
+	});
+
+	it("keeps pre-4.7 Anthropic models off the display field they reject", () => {
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-6")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.6")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-5-20251101")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-1-20250805")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-sonnet-4-5")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-sonnet-5")).toBe(false);
+	});
+
+	it("reads the version segment, not a date suffix, for Opus 4.0 snapshots", () => {
+		// `20250514` is the release date of Opus 4.0, not minor version 20250514:
+		// these ids still need the interleaved-thinking beta.
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-20250514")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("us.anthropic.claude-opus-4-20250514-v1:0")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("eu.anthropic.claude-opus-4-20250514-v1:0")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-0")).toBe(false);
+	});
+
+	it("returns false for ids outside the Anthropic opus/fable families", () => {
+		expect(supportsAdaptiveThinkingDisplay("claude-3-opus-20240229")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("anthropic.claude-3-opus-20240229-v1:0")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("gpt-5.6-sol")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("glm-5.2")).toBe(false);
+		expect(supportsAdaptiveThinkingDisplay("")).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## What

`supportsAdaptiveThinkingDisplay` decides whether an Anthropic request carries `thinking.display = "summarized"` and whether the `interleaved-thinking-2025-05-14` beta is attached. It was duplicated verbatim in `packages/ai/src/providers/anthropic.ts` and `packages/ai/src/providers/amazon-bedrock.ts`, and both copies gated on the id **shape**:

```ts
const match = /claude-opus-(\d+)-(\d+)/.exec(modelId);
```

Id shape is not the authority for a model version. This PR replaces both copies with one exported predicate in `model-thinking.ts` that parses the version through `parseAnthropicModel` / `getCanonicalModelId` — the same authority `hasOpus47ApiRestrictions` already uses two functions above it.

No catalog entry, no model addition, no default/profile change.

## Why it is a live defect on `dev`

Replaying the previous regex against the current `dev` catalog (`ef25c2c`) over all **510** bundled `anthropic-messages` / `bedrock-converse-stream` ids gives **11 differing verdicts, all corrections**:

| Class | Ids | Before → After | Effect |
| --- | --- | --- | --- |
| Dot-separated gateway ids (8, all `anthropic-adaptive`) | `github-copilot/claude-opus-4.{7,8}`, `vercel-ai-gateway/anthropic/claude-opus-4.{7,8}` + `-fast`, `zenmux/anthropic/claude-opus-4.{7,8}` | `false` → `true` | The old regex demanded dash-separated versions, so `display` was omitted. Anthropic then applies its `omitted` default: **thinking tokens billed, no summary streamed** (#2791 class). |
| Date-suffixed Opus 4.0 (3, `budget` mode) | `anthropic/claude-opus-4-20250514`, `{us,eu}.anthropic.claude-opus-4-20250514-v1:0` | `true` → `false` | The old regex read the release date as the minor version (`20250514 >= 7`) and classified Opus 4.0 as Opus 4.7+, **suppressing the `interleaved-thinking-2025-05-14` beta** these models need. |

Reproduction (`bun`, no network, no credentials — old predicate inlined, new one imported from source):

```
anthropic-messages / bedrock-converse-stream ids scanned: 510
differing verdicts: 11
  true -> false  amazon-bedrock/eu.anthropic.claude-opus-4-20250514-v1:0  [budget]
  true -> false  amazon-bedrock/us.anthropic.claude-opus-4-20250514-v1:0  [budget]
  true -> false  anthropic/claude-opus-4-20250514  [budget]
  false -> true  github-copilot/claude-opus-4.7  [anthropic-adaptive]
  false -> true  github-copilot/claude-opus-4.8  [anthropic-adaptive]
  false -> true  vercel-ai-gateway/anthropic/claude-opus-4.7  [anthropic-adaptive]
  false -> true  vercel-ai-gateway/anthropic/claude-opus-4.7-fast  [anthropic-adaptive]
  false -> true  vercel-ai-gateway/anthropic/claude-opus-4.8  [anthropic-adaptive]
  false -> true  vercel-ai-gateway/anthropic/claude-opus-4.8-fast  [anthropic-adaptive]
  false -> true  zenmux/anthropic/claude-opus-4.7  [anthropic-adaptive]
  false -> true  zenmux/anthropic/claude-opus-4.8  [anthropic-adaptive]
```

Unaffected: Opus 4.6 in both separator forms, every Sonnet/Haiku, `claude-opus-4-1-20250805` and `claude-opus-4-5-20251101` (their date suffixes never won the version match), `claude-3-opus-*`, Fable, `-latest` aliases, and every non-Anthropic id.

Dateless major-version ids (`claude-opus-5`, `us.anthropic.claude-opus-5`) are recognized as a side effect of parsing the version, so a future catalog row in that shape cannot silently inherit the `omitted` default.

## Relationship to #3118 / #3097

Both are now **closed**. #3097 was closed on the catalog-generation blocker. #3118 was closed at `2026-07-25T02:52Z` with four blockers: the `ApiModel` compile error, the typed seed not being canonical after the first generation (`prevModelsJson` wins), too-narrow generated-output proof, and the `claude-opus-latest` product-contract move. Point 4 of that verdict is why this PR exists:

> **Adaptive parser work is materially better:** the shared parser-based predicate covers dateless Opus 5, dot/dash forms, Bedrock region/profile prefixes, gateway wrappers, Fable, and date-suffixed Opus 4 false positives, and both Anthropic and Bedrock consume it. The `claude-opus-latest` canonical/default move to Opus 5 is nevertheless a model/catalog/alias product-contract change and would still require owner confirmation after all blockers are cleared.

This PR carries **only** that repair — no catalog row, no generator seed, no `models.json` change, no alias/default/profile move — so none of the four blockers apply to it, and the 11 wrong verdicts stop being hostage to the Opus 5 product decision. Implementation and tests were written independently against the same authority (`parseAnthropicModel` / `getCanonicalModelId`), which is why the predicate body converges with the closed PR's.

## Tests

New, and all of them fail against the previous implementation (verified by restoring the old body and re-running — 5 failing assertions):

- `packages/ai/test/model-thinking.test.ts` — `supportsAdaptiveThinkingDisplay` across every bundled id shape: dash, dot, dateless, Bedrock region/inference-profile prefixes, gateway `provider/model` prefixes, `-fast` suffixes, Fable, pre-4.7 negatives, date-suffixed Opus 4.0 negatives, non-Anthropic negatives, empty string.
- `packages/ai/test/anthropic-alignment.test.ts` — request-level: `thinking: { type: "adaptive", display: "summarized" }` for `claude-opus-4.8` and `claude-opus-5`, plus the interleaved-beta boundary (present for `claude-opus-4-20250514`, absent for `claude-opus-4-8` and `claude-opus-4.8`).

```
bun test packages/ai/test/model-thinking.test.ts packages/ai/test/anthropic-alignment.test.ts   # 77 pass / 0 fail
bun test packages/ai/test                                                                       # 1902 pass / 337 skip / 1 fail (pre-existing)
bun --cwd=packages/ai run check                                                                 # biome + tsc clean
bun run check:tools                                                                             # clean
bun run check:public-sync                                                                       # in sync
bun run check:schemas                                                                           # clean
```

The single failure is `fugu-provider.test.ts` "resolves FUGU_API_KEY from environment", reproduced on an unmodified `dev` checkout in the same shell — a real `fish_…` Fugu credential in the local environment/credential store wins over the test's `Bun.env` assignment. Unrelated to this diff.

`artifacts/architecture-2383-eval.json` is refreshed in a separate commit because it pins `git rev-parse HEAD:packages/ai/src/providers/anthropic.ts` and that file's SHA-256; only those two identity fields change, regenerated with the artifact's own recorded derivation command (same pattern as #2794 / #2940 / #3046).

## Base

Merged current `dev` (`866368d`) into the head with a normal merge commit — no rebase, no force-push. The focused suites, the eval-evidence test and `bun --cwd=packages/ai run check` were re-run green on the merged head (79 pass / 0 fail).

