### PR TITLE
fix(gjc): allow /dev/null redirects and repair hook-seeded deep-interview state

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/deep-interview-draft.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-draft.ts
@@ -17,6 +17,7 @@ import { type DeepInterviewRepairResult, runDeepInterviewRepairCommand } from ".
 import { canonicalDeepInterviewJson, validateDeepInterviewV1Envelope } from "./deep-interview-state";
 import { modeStatePath } from "./session-layout";
 import {
+	isNativeDeepInterviewV1,
 	readExistingStateForMutation,
 	transformGuardedWorkflowEnvelopeAtomic,
 	verifyWorkflowEnvelopeReceiptValue,
@@ -295,7 +296,7 @@ async function revision(cwd: string, session: string): Promise<{ revision: numbe
 	if (receipt === "receipt-missing") throw new Error("DI_RECEIPT_MISSING");
 	if (receipt === "checksum-mismatch") throw new Error("DI_RECEIPT_CHECKSUM_MISMATCH");
 	try {
-		if (receipt === "native-valid") validateDeepInterviewV1Envelope(observed.value);
+		if (isNativeDeepInterviewV1(observed.value)) validateDeepInterviewV1Envelope(observed.value);
 	} catch {
 		throw new Error("DI_STATE_SCHEMA_INVALID");
 	}

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
@@ -101,6 +101,21 @@ export interface TransitionValidationResult {
 // Pure helpers: records
 // =============================================================================
 
+/**
+ * `deepInterview.dimension` is agent-supplied free text on post-topology asks, but the persisted
+ * envelope only accepts canonical dimension ids. Fold obvious case/label variants down, and drop
+ * anything unrecognized rather than persisting a value the validator rejects.
+ */
+function canonicalDimension(value: string | undefined): string | undefined {
+	if (value === undefined) return undefined;
+	const normalized = value.trim().toLowerCase();
+	if (normalized === "topology") return "topology";
+	for (const dimension of ["goal", "constraints", "criteria", "context"]) {
+		if (normalized === dimension || normalized.startsWith(`${dimension} `)) return dimension;
+	}
+	return undefined;
+}
+
 export function buildAnswerShell(
 	input: DeepInterviewAnswerInput,
 	now: string = new Date().toISOString(),
@@ -116,7 +131,7 @@ export function buildAnswerShell(
 		selected_options: input.selectedOptions,
 		custom_input: input.customInput,
 		component: input.component,
-		dimension: input.dimension,
+		dimension: canonicalDimension(input.dimension),
 		ambiguity_at_ask: input.ambiguity,
 		lifecycle: "answered",
 		answered_at: now,

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -298,7 +298,7 @@ export function workflowEnvelopeContentSha256(value: unknown): string {
 		.update(JSON.stringify(canonicalizeJson(withoutReceiptChecksum(value))))
 		.digest("hex");
 }
-function isNativeDeepInterviewV1(value: Record<string, unknown>): boolean {
+export function isNativeDeepInterviewV1(value: Record<string, unknown>): boolean {
 	if (value.skill !== "deep-interview") return false;
 	return value.schema_version === 1 || (isPlainObject(value.state) && value.state.schema_version === 1);
 }

--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { logger } from "@gajae-code/utils";
 import type { SkillDiscoverySettings } from "../config/skill-settings-defaults";
 import { detectDeepInterviewPlaintextAskLeak } from "../deep-interview/plaintext-gate-guard";
+import { scoreToUnits } from "../gjc-runtime/deep-interview-ambiguity";
 import { activeSnapshotPath, modeStatePath as sessionModeStatePath } from "../gjc-runtime/session-layout";
 import { resolveGjcSessionForRead } from "../gjc-runtime/session-resolution";
 import { ModeStateSchema, SkillActiveStateSchema } from "../gjc-runtime/state-schema";
@@ -410,8 +411,29 @@ async function seedSkillActivationState(
 		...(input.turnId ? { turn_id: input.turnId } : {}),
 	};
 	if (skill === "deep-interview") {
-		modeState.threshold = DEFAULT_DEEP_INTERVIEW_AMBIGUITY_THRESHOLD;
+		const threshold = DEFAULT_DEEP_INTERVIEW_AMBIGUITY_THRESHOLD;
+		const thresholdUnits = scoreToUnits(threshold);
+		modeState.schema_version = 1;
+		modeState.resolution = "standard";
+		modeState.threshold = threshold;
+		modeState.threshold_units = thresholdUnits;
 		modeState.threshold_source = "default";
+		modeState.state = {
+			setup: { status: "unresolved" },
+			type: "greenfield",
+			intent_contract_required: true,
+			rounds: [],
+			established_facts: [],
+			topology: { status: "pending", components: [], deferred_components: [] },
+			ontology_snapshots: [],
+			auto_researched_rounds: [],
+			auto_answered_rounds: [],
+			architect_failures: 0,
+			current_ambiguity: 1.0,
+			threshold,
+			threshold_units: thresholdUnits,
+			threshold_source: "default",
+		};
 	}
 
 	await readExistingStateForMutation(initializedStatePath);

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -35,17 +35,28 @@ function planningPhaseBlockMessage(skill: CanonicalGjcWorkflowSkill): string {
 }
 
 const BLOCKED_TOOL_NAMES = new Set(["edit", "write", "ast_edit", "bash"]);
+/**
+ * Only `/dev/null` is exempt. `/dev/stdout`, `/dev/stderr`, and `/dev/fd/<n>` are descriptor
+ * aliases: `exec 1<>src/product.ts; printf x >/dev/stdout` reaches a real repository file
+ * through a rebound descriptor, so they must stay blocked.
+ */
+const DEVICE_SINK_PATHS = new Set(["/dev/null"]);
+/** Bash write forms the plain `>`/`>>` scanner misses: clobber, dup-to-path, and read-write open. */
+const BASH_EXTENDED_WRITE_RE = /(?:>\||<>|>&(?![\s;&|]*(?:\d+|-)(?:[\s;&|]|$)))\s*([^\s;&|]+)/g;
+/** Descriptor rebinding is not statically resolvable; any `exec` redirection forces a fail-closed verdict. */
+const BASH_EXEC_REDIRECT_RE = /(?:^|[;&|\n])\s*(?:sudo\s+)?exec\b[^;&|\n]*[<>]/i;
+
 const ARCHIVE_OR_SQLITE_BASE_RE = /^(.+?\.(?:tar\.gz|sqlite3|sqlite|db3|zip|tgz|tar|db))(?:$|:)/i;
 const INTERNAL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 const VIM_FILE_SWITCH_RE = /^\s*:(?:e|e!|edit|edit!)(?:\s+([^<\r\n]+))?(?:<CR>|\r|\n|$)/i;
 const BASH_MUTATION_COMMAND_RE =
-	/(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:tee|touch|rm|mkdir|cp|mv|install|truncate)\b([^;&|\n]*)|(?:^|[^<>])(?:>>?|\d>>?)\s*([^\s;&|]+)/gi;
+	/(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:[^\s;&|]*\/)?(?:tee|touch|rm|mkdir|cp|mv|install|truncate)\b([^;&|\n]*)|(?:^|[^<>])(?:>>?|\d>>?)\s*([^\s;&|]+)/gi;
 const BASH_IN_PLACE_MUTATION_COMMAND_RE = /(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:sed|perl)\b([^;&|\n]*)/gi;
 const BASH_OPAQUE_INTERPRETER_WRITE_RE =
 	/(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:python3?|node|ruby)\b[^;&|\n]*(?:-c|-e)\b[^;&|\n]*(?:open\s*\(|writeFile(?:Sync)?\s*\(|\.write\s*\()/i;
 const BASH_HEREDOC_OPAQUE_INTERPRETER_WRITE_RE =
 	/(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:python3?|node|ruby)\b[^;&|\n]*(?:<<[-]?\s*['"]?\w+['"]?)[\s\S]*(?:open\s*\(|writeFile(?:Sync)?\s*\(|\.write\s*\()/i;
-const BASH_DD_OUTPUT_RE = /(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?dd\b([^;&|\n]*)/gi;
+const BASH_DD_OUTPUT_RE = /(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:[^\s;&|]*\/)?dd\b([^;&|\n]*)/gi;
 
 type ToolWithEditMode = AgentTool & {
 	mode?: unknown;
@@ -371,6 +382,10 @@ function cleanShellWord(value: string): string {
 	return value.replace(/^['"]|['"]$/g, "");
 }
 
+function isDeviceSinkPath(value: string): boolean {
+	return DEVICE_SINK_PATHS.has(cleanShellWord(value));
+}
+
 function extractBashTargets(args: unknown): ExtractedTargets {
 	const record = getRecord(args);
 	const command = safeString(record?.command);
@@ -382,11 +397,25 @@ function extractBashTargets(args: unknown): ExtractedTargets {
 	if (BASH_OPAQUE_INTERPRETER_WRITE_RE.test(command) || BASH_HEREDOC_OPAQUE_INTERPRETER_WRITE_RE.test(command)) {
 		targets.unknown = true;
 	}
+	// `exec 1<>file` rebinds a descriptor, so a later `>/dev/null` may not reach the device at all.
+	if (BASH_EXEC_REDIRECT_RE.test(command)) {
+		targets.unknown = true;
+	}
+	for (const match of command.matchAll(BASH_EXTENDED_WRITE_RE)) {
+		const cleaned = cleanShellWord(match[1] ?? "");
+		if (!cleaned) targets.unknown = true;
+		else if (!isDeviceSinkPath(cleaned)) addPath(targets, cleaned);
+	}
 	for (const match of command.matchAll(BASH_DD_OUTPUT_RE)) {
 		const parts = shellWords(match[1] ?? "").map(cleanShellWord);
-		const output = parts.find(part => part.startsWith("of="));
-		if (output) addPath(targets, output.slice(3));
-		else targets.unknown = true;
+		// Every `of=` counts: GNU dd honors the last one, so `of=/dev/null of=real.ts` writes real.ts.
+		const outputs = parts.filter(part => part.startsWith("of="));
+		if (outputs.length === 0) targets.unknown = true;
+		for (const output of outputs) {
+			const outputPath = cleanShellWord(output.slice(3));
+			if (!outputPath) targets.unknown = true;
+			else if (!isDeviceSinkPath(outputPath)) addPath(targets, outputPath);
+		}
 	}
 	for (const match of command.matchAll(BASH_IN_PLACE_MUTATION_COMMAND_RE)) {
 		const parts = shellWords(match[1] ?? "").map(cleanShellWord);
@@ -399,12 +428,17 @@ function extractBashTargets(args: unknown): ExtractedTargets {
 	for (const match of command.matchAll(BASH_MUTATION_COMMAND_RE)) {
 		const redirected = match[2]?.trim();
 		if (redirected) {
-			addPath(targets, cleanShellWord(redirected));
+			const cleaned = cleanShellWord(redirected);
+			// A capture that dequotes to nothing (e.g. `>" src.ts"`) is a truncated parse, not a safe no-op.
+			if (!cleaned) targets.unknown = true;
+			else if (!isDeviceSinkPath(cleaned)) addPath(targets, cleaned);
 			continue;
 		}
 		const parts = shellWords(match[1] ?? "");
 		const commandName = match[0]
-			?.match(/(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(tee|touch|rm|mkdir|cp|mv|install|truncate)\b/i)?.[1]
+			?.match(
+				/(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:[^\s;&|]*\/)?(tee|touch|rm|mkdir|cp|mv|install|truncate)\b/i,
+			)?.[1]
 			?.toLowerCase();
 		const targetParts =
 			commandName === "cp" || commandName === "mv" || commandName === "install" || commandName === "truncate"

--- a/packages/coding-agent/test/deep-interview-repair-cli.test.ts
+++ b/packages/coding-agent/test/deep-interview-repair-cli.test.ts
@@ -7,7 +7,11 @@ import {
 	runDeepInterviewRepairCommand,
 } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-repair";
 import { runNativeDeepInterviewCommand } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
+import { validateDeepInterviewV1Envelope } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-state";
+import { modeStatePath } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import { stampWorkflowEnvelopeChecksum } from "@gajae-code/coding-agent/gjc-runtime/state-writer";
 import { WORKFLOW_MANIFEST } from "@gajae-code/coding-agent/gjc-runtime/workflow-manifest";
+import { ensureWorkflowSkillActivationState } from "@gajae-code/coding-agent/hooks/skill-state";
 
 describe("deep-interview typed repair CLI", () => {
 	it("keeps typed repair verbs aligned with the public workflow manifest", () => {
@@ -1216,6 +1220,179 @@ describe("deep-interview typed repair CLI", () => {
 				"--json",
 			]);
 			expect(invalidGreenfieldContextResult.stderr).toContain("DI_INVALID_RESULT_JSON");
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+	it("creates an initialize-context draft from a hook-seeded session", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-deep-interview-repair-"));
+		const session = "hook-seeded-draft";
+		try {
+			await ensureWorkflowSkillActivationState({
+				cwd,
+				skill: "deep-interview",
+				sessionId: session,
+				nowIso: "2026-01-01T00:00:00.000Z",
+			});
+			const result = await runNativeDeepInterviewCommand(
+				["draft", "create", "--for", "initialize-context", "--session-id", session, "--json"],
+				cwd,
+			);
+			expect(result.status).toBe(0);
+			const output = JSON.parse(result.stdout!);
+			expect(output).toMatchObject({ ok: true });
+			expect(output.draft.id).toMatch(/^[a-f0-9]{32}$/);
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("consumes a real initial_idea on a hook-seeded session without DI_SETUP_CONFLICT", async () => {
+		for (const type of ["greenfield", "brownfield"] as const) {
+			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-deep-interview-repair-"));
+			const session = "hook-seeded-idea";
+			try {
+				await ensureWorkflowSkillActivationState({ cwd, skill: "deep-interview", sessionId: session });
+				const created = await runNativeDeepInterviewCommand(
+					["draft", "create", "--for", "initialize-context", "--session-id", session, "--json"],
+					cwd,
+				);
+				expect(created.status).toBe(0);
+				const draft = JSON.parse(created.stdout!).draft;
+				let revision = draft.draft_revision;
+				for (const [pointer, value] of [
+					["/type", type],
+					["/threshold", "0.05"],
+					["/initial_idea", "a real user idea"],
+				]) {
+					const edited = await runNativeDeepInterviewCommand(
+						[
+							"draft",
+							"edit",
+							"--draft-id",
+							draft.id,
+							"--expected-draft-revision",
+							String(revision),
+							"--op",
+							"set",
+							"--path",
+							pointer,
+							"--value",
+							value,
+							"--json",
+						],
+						cwd,
+					);
+					expect(edited.status).toBe(0);
+					revision = JSON.parse(edited.stdout!).draft.draft_revision;
+				}
+				const consumed = await runNativeDeepInterviewCommand(
+					["initialize-context", "--draft-id", draft.id, "--expected-draft-revision", String(revision), "--json"],
+					cwd,
+				);
+				expect(consumed.status).toBe(0);
+				expect(JSON.parse(consumed.stdout!)).toMatchObject({ ok: true, consumed: true });
+			} finally {
+				await fs.rm(cwd, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("keeps hook and runtime deep-interview seed shapes in parity", async () => {
+		const hookCwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-deep-interview-repair-"));
+		const runtimeCwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-deep-interview-repair-"));
+		const hookSession = "hook-shape";
+		const runtimeSession = "runtime-shape";
+		try {
+			await ensureWorkflowSkillActivationState({
+				cwd: hookCwd,
+				skill: "deep-interview",
+				sessionId: hookSession,
+				nowIso: "2026-01-01T00:00:00.000Z",
+			});
+			const runtimeResult = await runNativeDeepInterviewCommand(
+				["--session-id", runtimeSession, "--json", "shape parity"],
+				runtimeCwd,
+			);
+			expect(runtimeResult.status).toBe(0);
+
+			const hookEnvelope = JSON.parse(
+				await fs.readFile(modeStatePath(hookCwd, hookSession, "deep-interview"), "utf8"),
+			) as Record<string, unknown>;
+			const runtimeEnvelope = JSON.parse(
+				await fs.readFile(modeStatePath(runtimeCwd, runtimeSession, "deep-interview"), "utf8"),
+			) as Record<string, unknown>;
+			expect(() => validateDeepInterviewV1Envelope(hookEnvelope)).not.toThrow();
+			expect(() => validateDeepInterviewV1Envelope(runtimeEnvelope)).not.toThrow();
+			expect(
+				Object.keys(hookEnvelope)
+					.filter(key => key !== "cwd" && key !== "state_revision")
+					.sort(),
+			).toEqual(
+				Object.keys(runtimeEnvelope)
+					.filter(key => key !== "state_revision")
+					.sort(),
+			);
+			// The hook seeds no `initial_idea`: activation carries no user idea yet, and pre-seeding
+			// an empty string would make a later typed initialize-context fail with DI_SETUP_CONFLICT.
+			expect(Object.keys(hookEnvelope.state as Record<string, unknown>).sort()).toEqual(
+				Object.keys(runtimeEnvelope.state as Record<string, unknown>)
+					.filter(key => key !== "initial_idea")
+					.sort(),
+			);
+			expect((hookEnvelope.state as Record<string, unknown>).initial_idea).toBeUndefined();
+		} finally {
+			await fs.rm(hookCwd, { recursive: true, force: true });
+			await fs.rm(runtimeCwd, { recursive: true, force: true });
+		}
+	});
+
+	it("still rejects a malformed native v1 envelope during draft creation", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-deep-interview-repair-"));
+		const session = "malformed-native-draft";
+		try {
+			await ensureWorkflowSkillActivationState({ cwd, skill: "deep-interview", sessionId: session });
+			const statePath = modeStatePath(cwd, session, "deep-interview");
+			const malformed = JSON.parse(await fs.readFile(statePath, "utf8")) as Record<string, unknown>;
+			(malformed.state as Record<string, unknown>).threshold_units = 499;
+			await fs.writeFile(statePath, JSON.stringify(stampWorkflowEnvelopeChecksum(malformed, statePath)));
+
+			const result = await runNativeDeepInterviewCommand(
+				["draft", "create", "--for", "initialize-context", "--session-id", session, "--json"],
+				cwd,
+			);
+			expect(result.status).toBe(2);
+			expect(JSON.parse(result.stderr!)).toEqual({
+				ok: false,
+				issue: { code: "DI_STATE_SCHEMA_INVALID", message: "DI_STATE_SCHEMA_INVALID" },
+			});
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps non-deep-interview hook seeds minimal", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-deep-interview-repair-"));
+		const session = "ralplan-minimal-seed";
+		try {
+			await ensureWorkflowSkillActivationState({ cwd, skill: "ralplan", sessionId: session });
+			const state = JSON.parse(await fs.readFile(modeStatePath(cwd, session, "ralplan"), "utf8")) as Record<
+				string,
+				unknown
+			>;
+			expect(Object.keys(state).sort()).toEqual([
+				"active",
+				"current_phase",
+				"cwd",
+				"receipt",
+				"session_id",
+				"skill",
+				"state_revision",
+				"updated_at",
+				"version",
+			]);
+			expect(state.schema_version).toBeUndefined();
+			expect(state.state).toBeUndefined();
 		} finally {
 			await fs.rm(cwd, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts
@@ -717,4 +717,26 @@ describe("deep-interview recorder: persistence (state-writer backed)", () => {
 		expect(compact.recent_scored_rounds).toEqual([]);
 		expect(compact.pending_shells).toEqual([]);
 	});
+
+	it("canonicalizes an agent-supplied dimension label before persisting the shell", () => {
+		// `deepInterview.dimension` is free text on post-topology asks; the persisted envelope
+		// only accepts canonical ids, so a display label must not reach state verbatim.
+		for (const [supplied, expected] of [
+			["Constraints", "constraints"],
+			["Goal Clarity", "goal"],
+			["Success Criteria", undefined],
+			["criteria", "criteria"],
+			["topology", "topology"],
+			["not-a-dimension", undefined],
+		] as const) {
+			const shell = buildAnswerShell({
+				round: 1,
+				questionId: "q",
+				questionText: "question",
+				selectedOptions: ["a"],
+				dimension: supplied,
+			} as never);
+			expect(shell.dimension).toBe(expected as never);
+		}
+	});
 });

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -332,6 +332,102 @@ describe("workflow mutation guard", () => {
 		}
 	});
 
+	it("allows the /dev/null sink during active deep-interview", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		for (const command of [
+			"echo hi > /dev/null",
+			"echo hi 2>/dev/null",
+			"grep -rn pattern src 2>/dev/null | head -5",
+			"cmd >/dev/null 2>&1",
+			'echo hi > "/dev/null"',
+			"dd if=/dev/zero of=/dev/null",
+		]) {
+			const decision = await getWorkflowMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("bash"),
+				args: { command },
+			});
+			expect(decision.blocked).toBe(false);
+			expect(decision.targets).toEqual([]);
+		}
+	});
+
+	it("blocks every descriptor alias during active deep-interview", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		// `/dev/stdout`, `/dev/stderr`, and `/dev/fd/<n>` all name a descriptor that `exec` can
+		// rebind onto a real repository file, so none of them may be treated as a sink.
+		for (const [command, expected] of [
+			["echo x >/dev/fd/3", "/dev/fd/3"],
+			["echo hi > /dev/stdout", "/dev/stdout"],
+			["echo hi 2> /dev/stderr", "/dev/stderr"],
+		] as const) {
+			const decision = await getWorkflowMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("bash"),
+				args: { command },
+			});
+			expect(decision.blocked).toBe(true);
+			expect(decision.targets).toContain(expected);
+		}
+	});
+
+	it("blocks sink-suppression bypasses during active deep-interview", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		// Every case pairs a real write with a `/dev/null` sink: suppressing the sink must not
+		// leave an empty target list that reads as "safe".
+		for (const command of [
+			"exec 1<>src/product.ts; printf x >/dev/stdout",
+			"exec 1<>.gjc/_session-session-a/state/deep-interview-state.json; printf x >/dev/stdout",
+			"/bin/dd if=/dev/zero of=src/product.ts count=1 2>/dev/null",
+			"printf x | /usr/bin/tee src/product.ts >/dev/null",
+			"dd if=/dev/zero of=/dev/null of=src/product.ts count=1",
+			"printf x >|src/product.ts 2>/dev/null",
+			"printf x >&src/product.ts 2>/dev/null",
+			"printf x >|.gjc/_session-session-a/state/deep-interview-state.json 2>/dev/null",
+			'dd if=/dev/zero of=" /dev/null"',
+			'printf x >" src.ts"',
+		]) {
+			const decision = await getWorkflowMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("bash"),
+				args: { command },
+			});
+			expect(decision.blocked).toBe(true);
+		}
+	});
+
+	it("keeps project, .gjc, mixed, dd, and exact-match-negative targets blocked", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		for (const command of [
+			"echo x > src/product.ts",
+			"echo x > .gjc/_session-test/state/deep-interview-state.json",
+			"echo hi > /dev/null; touch src/product.ts",
+			"dd if=/dev/zero of=src/product.ts",
+			"echo x > /dev/nullx",
+			"echo x > dev/null",
+		]) {
+			const decision = await getWorkflowMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("bash"),
+				args: { command },
+			});
+			expect(decision.blocked).toBe(true);
+			expect(decision.targets.length).toBeGreaterThan(0);
+		}
+	});
+
 	it("blocks vim file-switches into .gjc", async () => {
 		const cwd = await makeTempRoot();
 		await writeActiveDeepInterview(cwd);


### PR DESCRIPTION
Two defects made the deep-interview workflow unusable in practice. Both are fixed here; they share one review/QA boundary.

## Bug 1 — guard blocked `/dev/null` redirects

`extractBashTargets` captured every `>`/`>>` target, so `cmd 2>/dev/null` was treated as a repository write and blocked during any planning phase — including the brownfield exploration deep-interview itself mandates before Round 1.

Only `/dev/null` is exempted. `/dev/stdout`, `/dev/stderr`, and `/dev/fd/<n>` stay blocked: they are descriptor aliases, and `exec 1<>src/product.ts; printf x >/dev/stdout` reaches a real file through a rebound descriptor.

Suppressing a sink target must not turn a mutating command into an empty-target "safe" verdict. Review caught that the naive exemption regressed 9 commands from blocked to allowed, so this PR also closes those paths:

- `exec` redirections fail closed (descriptor rebinding is not statically resolvable)
- `>|`, `>&path`, and `<>` write forms are recognized
- path-qualified writers (`/bin/dd`, `/usr/bin/tee`) are matched
- every `dd of=` operand is inspected, not just the first (GNU dd honors the last)
- a redirect capture that dequotes to nothing is `unknown`, not safe — this one was already broken before this PR

## Bug 2 — hook-seeded state failed native validation

The draft CLI ran `validateDeepInterviewV1Envelope` whenever `verifyWorkflowEnvelopeReceiptValue` returned `native-valid`, but that verdict covers receipt shape and checksum only — it does not imply a native v1 body. The hook's minimal `ModeState` has no `schema_version` and no `state`, so every typed operation (`initialize-context`, `confirm-topology`, `record-answer`, `apply-round-result`) failed with `DI_STATE_SCHEMA_INVALID`. Interviews ran fully manually and persisted `rounds: []` despite completed rounds. `gjc state clear --force` did not help, because the reseed went through the same hook writer.

Fix: gate on `isNativeDeepInterviewV1`, matching the already-correct `transformGuardedWorkflowEnvelopeAtomic` at `state-writer.ts:735`, and seed a native v1 envelope from the hook.

The seed deliberately omits `initial_idea`. Pre-seeding `""` made a later `initialize-context` carrying a real idea fail with `DI_SETUP_CONFLICT` — caught during verification, now covered by a regression test for both greenfield and brownfield.

Round shells now canonicalize the agent-supplied `deepInterview.dimension` label, which is free text on post-topology asks but must be a canonical id in persisted state. Before this PR the invalid value was persisted only because hook-seeded envelopes were never validated at all.

## Verification

- Adversarial matrix: 10 bypass commands, all blocked. Each was executed, and each was confirmed blocked at clean HEAD too (except the pre-existing quoted-whitespace case, also fixed).
- Benign matrix: `2>/dev/null`, `>/dev/null 2>&1`, piped grep, quoted `/dev/null`, `dd of=/dev/null` all allowed.
- `.gjc/**` writes remain blocked in every case, including through every bypass form above.
- End-to-end: hook seed → `draft create` → `edit` → `check` → `initialize-context` now completes.
- `bun run lint:ts` clean; `tsc --noEmit` clean.
- Full `packages/coding-agent/test` run in shards: 3934 pass / 15 fail, and all 15 failures reproduce identically at clean HEAD (tmux, managed-owner, model-registry, native-addon, and compiled-daemon suites — environmental and unrelated).

## Review notes

An architect review and an adversarial red-team lane both returned BLOCK on the first iteration. Their findings are what produced the descriptor-alias narrowing, the `exec`/`>|`/`>&` handling, the multi-`of=` fix, and the `initial_idea` correction. Two of their remaining recommendations are deliberately **not** in this PR, since they are pre-existing conditions rather than regressions:

- `verifyWorkflowEnvelopeReceiptValue` returning `native-valid` for a non-native body is a misleading API name; `deep-interview-repair.ts:1400` still derives `legacy` from that verdict. Worth a follow-up rename/split.
- `extractBashTargets` is a regex scanner used as a shell security boundary. It is more conservative after this PR, but a real shell AST is the durable fix.

Also unaddressed: sessions already carrying a pre-fix minimal hook seed are not migrated.
