### PR TITLE
fix(ai): cap server-supplied Retry-After in the Claude usage fetch

### DIFF
--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -17,6 +17,13 @@ const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 const MAX_ATTEMPTS = 3;
 const BASE_RETRY_DELAY_MS = 500;
+/**
+ * Ceiling for a server-supplied `Retry-After`. Matches `OPENAI_RETRY_DELAY_CAP_MS`
+ * and `fetchWithRetry`'s `DEFAULT_MAX_DELAY_MS`. Without it a hostile or
+ * misconfigured endpoint stalls the usage fetch for as long as it likes
+ * (`Retry-After: 86400` previously produced a 24h sleep).
+ */
+const MAX_RETRY_DELAY_MS = 60_000;
 
 const CLAUDE_HEADERS = {
 	accept: "application/json, text/plain, */*",
@@ -140,13 +147,23 @@ function isAbortError(error: unknown, signal?: AbortSignal): boolean {
 	return error.name === "AbortError" || error.name === "TimeoutError";
 }
 
+/**
+ * Honour the server hint but never exceed `MAX_RETRY_DELAY_MS`, and never
+ * return a negative/non-finite delay. Keeps the sleep bounded so an abort has
+ * an upper bound to fire within.
+ */
+function clampRetryDelay(baseline: number, hintMs: number): number {
+	const hint = Number.isFinite(hintMs) ? Math.max(0, hintMs) : 0;
+	return Math.min(Math.max(baseline, hint), MAX_RETRY_DELAY_MS);
+}
+
 function retryDelayMs(attempt: number, retryAfter: string | null): number {
 	const baseline = BASE_RETRY_DELAY_MS * 2 ** attempt;
 	if (!retryAfter?.trim()) return baseline;
 	const seconds = Number.parseFloat(retryAfter);
-	if (Number.isFinite(seconds)) return Math.max(baseline, Math.max(0, seconds * 1000));
+	if (Number.isFinite(seconds)) return clampRetryDelay(baseline, seconds * 1000);
 	const dateDelay = Date.parse(retryAfter) - Date.now();
-	return Number.isFinite(dateDelay) ? Math.max(baseline, Math.max(0, dateDelay)) : baseline;
+	return Number.isFinite(dateDelay) ? clampRetryDelay(baseline, dateDelay) : baseline;
 }
 
 async function waitBeforeRetry(

--- a/packages/ai/test/claude-usage-retry.test.ts
+++ b/packages/ai/test/claude-usage-retry.test.ts
@@ -119,6 +119,56 @@ describe("claudeUsageProvider retry contract", () => {
 		expect(retryWait.mock.calls[0]?.[0]).toBe(1000);
 	});
 
+	it("caps an absurd Retry-After instead of stalling for hours", async () => {
+		let attempt = 0;
+		const retryWait = vi.fn(async (_delayMs: number, _signal?: AbortSignal) => {});
+		const fetchMock = (async () => {
+			attempt += 1;
+			if (attempt === 1) {
+				// A hostile/misconfigured endpoint asks for a 24h backoff. Honouring
+				// it verbatim would stall the usage fetch for a day.
+				return jsonResponse(429, { error: "rate_limited" }, { "retry-after": "86400" });
+			}
+			return jsonResponse(200, VALID_PAYLOAD);
+		}) as unknown as typeof fetch;
+
+		const report = await claudeUsageProvider.fetchUsage(baseParams(), makeContext(fetchMock, retryWait));
+		expect(report).not.toBeNull();
+		expect(retryWait).toHaveBeenCalledTimes(1);
+		expect(retryWait.mock.calls[0]?.[0]).toBe(60_000);
+	});
+
+	it("caps an absurd HTTP-date Retry-After too", async () => {
+		let attempt = 0;
+		const retryWait = vi.fn(async (_delayMs: number, _signal?: AbortSignal) => {});
+		const farFuture = new Date(Date.now() + 24 * 60 * 60 * 1000).toUTCString();
+		const fetchMock = (async () => {
+			attempt += 1;
+			if (attempt === 1) return jsonResponse(429, { error: "rate_limited" }, { "retry-after": farFuture });
+			return jsonResponse(200, VALID_PAYLOAD);
+		}) as unknown as typeof fetch;
+
+		const report = await claudeUsageProvider.fetchUsage(baseParams(), makeContext(fetchMock, retryWait));
+		expect(report).not.toBeNull();
+		expect(retryWait.mock.calls[0]?.[0]).toBe(60_000);
+	});
+
+	it("ignores a negative Retry-After and never sleeps negatively", async () => {
+		let attempt = 0;
+		const retryWait = vi.fn(async (_delayMs: number, _signal?: AbortSignal) => {});
+		const fetchMock = (async () => {
+			attempt += 1;
+			if (attempt === 1) return jsonResponse(429, { error: "rate_limited" }, { "retry-after": "-5" });
+			return jsonResponse(200, VALID_PAYLOAD);
+		}) as unknown as typeof fetch;
+
+		const report = await claudeUsageProvider.fetchUsage(baseParams(), makeContext(fetchMock, retryWait));
+		expect(report).not.toBeNull();
+		const delay = retryWait.mock.calls[0]?.[0] ?? -1;
+		expect(delay).toBeGreaterThanOrEqual(0);
+		expect(delay).toBeLessThanOrEqual(60_000);
+	});
+
 	it("aborts the retry sleep when the signal fires mid-backoff", async () => {
 		let attempt = 0;
 		const fetchMock = (async (_url: string | URL, init?: RequestInit) => {


### PR DESCRIPTION
## The bug

`retryDelayMs()` in `packages/ai/src/usage/claude.ts` honoured the server's `Retry-After` verbatim:

```ts
const seconds = Number.parseFloat(retryAfter);
if (Number.isFinite(seconds)) return Math.max(baseline, Math.max(0, seconds * 1000));
```

No upper bound. A hostile or misconfigured endpoint could stall the usage fetch for as long as it liked:

| `Retry-After` | delay handed to `scheduler.wait()` (before) |
|---|---|
| `86400` | `86_400_000` ms — **24 hours** |
| HTTP-date `+24h` | `86_399_386` ms |

The sleep is abort-aware, but with no signal — or a long-lived one — the usage refresh just hangs, and `auth-storage` ranks credentials off this call.

## Why this is the odd one out

Every sibling retry path in the repo already bounds the server hint:

| Path | Cap |
|---|---|
| `utils/fetch-retry.ts` | `DEFAULT_MAX_DELAY_MS = 60_000` (+ fail-fast when the hint exceeds it) |
| `providers/openai-bounded-rate-limits.ts` | `OPENAI_RETRY_DELAY_CAP_MS = 60_000` |
| `session/agent-session.ts` (auto-compaction) | `maxAcceptableDelayMs = 30_000` |
| `providers/google-gemini-cli.ts` | `RATE_LIMIT_BUDGET_MS` |

Only the Claude usage path had no ceiling — an omission, not a design choice.

## Fix

Add `MAX_RETRY_DELAY_MS = 60_000` and clamp through a small `clampRetryDelay()` that also drops non-finite/negative hints. 60s matches the established convention and **preserves both pre-existing assertions exactly** (`Retry-After: 1` → `1000`, `Retry-After: 60` → `60_000`), so this is a pure tightening of the worst case.

## Regression coverage

Added to `test/claude-usage-retry.test.ts`: absurd numeric `Retry-After`, absurd HTTP-date `Retry-After`, and a negative `Retry-After`.

Against the **unfixed** code the first two fail with `Expected: 60000 / Received: 86400000` and `Received: 86399386`. With the fix all pass.

## Gates

- `test/claude-usage-retry.test.ts` — 11 pass (8 pre-existing + 3 new), 0 fail
- usage suite (`claude-usage-headers`, `auth-storage-usage-cache`, `openai-codex-usage`, `usage-attribution`, `grok-cli-usage`) — 28 pass, 0 fail
- `tsc -p packages/ai/tsconfig.json --noEmit` — clean

## Scope

Found while sweeping the harness for the same bug class as #3131 (unbounded server/env-controlled sleeps). Also checked and found **healthy**, so deliberately untouched: timer hygiene (28 `setInterval` / 30 `clearInterval`, every file balanced with `clearInterval`/`unref`), child-process cancel propagation in `tools/bash.ts`, `fetchWithRetry`, and the Anthropic/OpenAI bounded rate-limit paths.
