### PR TITLE
fix(coding-agent): cap legacy auto-compaction Retry-After at retry.maxDelayMs

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -341,6 +341,7 @@ import {
 import {
 	type ConfiguredFallbackChain,
 	cappedExponentialWithFullJitter,
+	compactionRetryDelay,
 	effectiveFallbackDelay,
 	FallbackChainController,
 } from "./fallback-chain-controller";
@@ -12463,8 +12464,14 @@ export class AgentSession {
 								break;
 							}
 
-							const baseDelayMs = retrySettings.baseDelayMs * 2 ** attempt;
-							const delayMs = retryAfterMs !== undefined ? Math.max(baseDelayMs, retryAfterMs) : baseDelayMs;
+							// Legacy parsed Retry-After is capped at retry.maxDelayMs (see
+							// compactionRetryDelay); only managed fallback is uncapped.
+							const delayMs = compactionRetryDelay(
+								retrySettings.baseDelayMs,
+								retrySettings.maxDelayMs,
+								attempt,
+								retryAfterMs,
+							);
 
 							// If retry delay is too long (>30s), try next candidate instead of waiting
 							const maxAcceptableDelayMs = 30_000;

--- a/packages/coding-agent/src/session/fallback-chain-controller.ts
+++ b/packages/coding-agent/src/session/fallback-chain-controller.ts
@@ -174,6 +174,33 @@ export function cappedExponentialWithFullJitter(
 	return Math.floor(Math.max(0, cap) * Math.max(0, Math.min(1, random())));
 }
 
+/**
+ * Legacy auto-compaction retry delay.
+ *
+ * Deliberately the mirror image of `effectiveFallbackDelay`: this path recovers
+ * Retry-After by regex over provider error prose (`#parseRetryAfterMsFromError`),
+ * so it follows the documented legacy rule — `retry.maxDelayMs` caps every
+ * legacy session retry delay, including provider retry-after hints. Managed
+ * fallback stays uncapped because it retries within its own per-entry budget;
+ * compaction has no such budget, so the final candidate would otherwise sleep
+ * for the full server-suggested duration.
+ *
+ * `maxDelayMs <= 0` means "no cap", matching `cappedExponentialWithFullJitter`.
+ * A missing, NaN, or infinite hint collapses to "no usable hint".
+ */
+export function compactionRetryDelay(
+	baseDelayMs: number,
+	maxDelayMs: number,
+	attempt: number,
+	retryAfterMs: number | undefined,
+): number {
+	const exponential = baseDelayMs * 2 ** Math.max(0, attempt);
+	const hint = Number.isFinite(retryAfterMs) ? Math.max(0, retryAfterMs as number) : 0;
+	const hinted = Math.max(exponential, hint);
+	const bounded = maxDelayMs > 0 ? Math.min(hinted, maxDelayMs) : hinted;
+	return Math.max(0, bounded);
+}
+
 /** Retry-After is intentionally uncapped. */
 export function effectiveFallbackDelay(
 	baseDelayMs: number,

--- a/packages/coding-agent/test/routing-adversarial.test.ts
+++ b/packages/coding-agent/test/routing-adversarial.test.ts
@@ -93,6 +93,42 @@ describe("routing adversarial contract probes", () => {
 		expect(compactionRetryDelay(2_000, 0, 0, 45_000)).toBe(45_000);
 	});
 
+	// Both legacy surfaces recover Retry-After from prose, so the documented rule
+	// ("retry.maxDelayMs caps every legacy session retry delay, including provider
+	// retry-after hints") must bind them identically. This pins the two together so
+	// a future change to one cannot silently drift from the other.
+	test("legacy compaction agrees with the legacy non-compaction retry-after cap", () => {
+		const maxDelayMs = 300_000;
+		const baseDelayMs = 2_000;
+		for (const hint of [1_000, 45_000, 299_999, 300_000, 300_001, THREE_HOURS_MS]) {
+			// agent-session.ts, legacy non-compaction path: Math.min(retryAfterMs, maxDelayMs)
+			const legacyNonCompaction = Math.min(hint, maxDelayMs);
+			const compaction = compactionRetryDelay(baseDelayMs, maxDelayMs, 0, hint);
+			expect(compaction).toBeLessThanOrEqual(maxDelayMs);
+			// Compaction may floor at its exponential, but never exceeds the legacy bound.
+			expect(compaction).toBeLessThanOrEqual(Math.max(legacyNonCompaction, baseDelayMs));
+		}
+	});
+
+	test("compaction retry delay invariant holds across the whole parameter grid", () => {
+		const hints = [undefined, 0, 1_000, THREE_HOURS_MS, Number.NaN, Number.POSITIVE_INFINITY, -1];
+		let checked = 0;
+		for (const baseDelayMs of [0, 1, 500, 2_000, 60_000]) {
+			for (const maxDelayMs of [0, 1_000, 30_000, 300_000]) {
+				for (const attempt of [0, 1, 3, 10, 30]) {
+					for (const hint of hints) {
+						const delay = compactionRetryDelay(baseDelayMs, maxDelayMs, attempt, hint);
+						expect(Number.isFinite(delay)).toBe(true);
+						expect(delay).toBeGreaterThanOrEqual(0);
+						if (maxDelayMs > 0) expect(delay).toBeLessThanOrEqual(maxDelayMs);
+						checked++;
+					}
+				}
+			}
+		}
+		expect(checked).toBe(700);
+	});
+
 	test("charges rotated-entry retries against the chain-wide attempt budget", () => {
 		const controller = new FallbackChainController(
 			{ role: "default", entries: ["xai/grok", "anthropic/claude"], origin: "test", explicitHead: true },

--- a/packages/coding-agent/test/routing-adversarial.test.ts
+++ b/packages/coding-agent/test/routing-adversarial.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@gajae-code/coding-agent/session/cache-economics";
 import {
 	cappedExponentialWithFullJitter,
+	compactionRetryDelay,
 	effectiveFallbackDelay,
 	FallbackChainController,
 } from "@gajae-code/coding-agent/session/fallback-chain-controller";
@@ -58,6 +59,38 @@ describe("routing adversarial contract probes", () => {
 		expect(cappedExponentialWithFullJitter(100, 1_000, 10, () => 1)).toBe(1_000);
 		expect(Math.min(THREE_HOURS_MS, 1_000)).toBe(1_000);
 		expect(effectiveFallbackDelay(100, 1_000, 1, THREE_HOURS_MS, () => 1)).toBe(THREE_HOURS_MS);
+	});
+
+	// Mirror image of the contract above: auto-compaction recovers Retry-After by
+	// regex over provider error prose, so it is legacy and MUST stay capped.
+	// Managed fallback is uncapped only because it retries within its own
+	// per-entry budget; compaction has no such budget.
+	test("caps legacy compaction retry-after at retry.maxDelayMs", () => {
+		// A hostile/misconfigured provider asking for 3h cannot outrun the cap.
+		expect(compactionRetryDelay(100, 1_000, 0, THREE_HOURS_MS)).toBe(1_000);
+		// Same hint, managed fallback path: still honoured verbatim.
+		expect(effectiveFallbackDelay(100, 1_000, 1, THREE_HOURS_MS, () => 1)).toBe(THREE_HOURS_MS);
+	});
+
+	test("compaction retry delay honours hints below the cap and keeps exponential growth", () => {
+		// No hint → plain exponential (base * 2**attempt), unchanged behaviour.
+		expect(compactionRetryDelay(2_000, 300_000, 0, undefined)).toBe(2_000);
+		expect(compactionRetryDelay(2_000, 300_000, 3, undefined)).toBe(16_000);
+		// Hint below the cap wins over the exponential, exactly as before.
+		expect(compactionRetryDelay(2_000, 300_000, 0, 45_000)).toBe(45_000);
+		// Hint smaller than the exponential never shortens the backoff.
+		expect(compactionRetryDelay(2_000, 300_000, 3, 1_000)).toBe(16_000);
+	});
+
+	test("compaction retry delay never yields a negative, NaN, or infinite sleep", () => {
+		for (const hint of [undefined, Number.NaN, Number.POSITIVE_INFINITY, -5_000]) {
+			const delay = compactionRetryDelay(2_000, 300_000, 0, hint);
+			expect(Number.isFinite(delay)).toBe(true);
+			expect(delay).toBeGreaterThanOrEqual(0);
+			expect(delay).toBeLessThanOrEqual(300_000);
+		}
+		// maxDelayMs <= 0 means "no cap", matching cappedExponentialWithFullJitter.
+		expect(compactionRetryDelay(2_000, 0, 0, 45_000)).toBe(45_000);
 	});
 
 	test("charges rotated-entry retries against the chain-wide attempt budget", () => {


### PR DESCRIPTION
Follow-up to #3131 / #3132, and the deliberate counterpart to the "intentionally uncapped" managed-fallback contract.

## The gap

The auto-compaction retry loop recovers `Retry-After` by **regex over provider error prose** (`#parseRetryAfterMsFromError`) and then slept on it uncapped:

```ts
const baseDelayMs = retrySettings.baseDelayMs * 2 ** attempt;
const delayMs = retryAfterMs !== undefined ? Math.max(baseDelayMs, retryAfterMs) : baseDelayMs;
```

A 30s heuristic switches to the next compaction candidate when the delay is too long — but it **explicitly falls through on the last candidate**:

```ts
// No more candidates - we have to wait
```

There the session slept for the full server-suggested duration. A 3h hint produced a 3h sleep.

## Why this is a gap and not the documented design

`non-compaction-retry-policy.md` states the rule precisely:

> `retry.maxDelayMs` caps every legacy session retry delay, including provider retry-after hints. **Managed fallback intentionally does not cap typed Retry-After values because it retries within its separate per-entry budget.**

The uncapped exemption is scoped to **managed fallback**, and justified by its **per-entry budget**. Auto-compaction is:

- **legacy** — prose-parsed, not typed transport facts
- **without a per-entry budget** — nothing to advance to once candidates run out

So the documented rule says it should be capped. The non-compaction legacy path already does exactly this:

```ts
// agent-session.ts, non-compaction legacy retry
? Math.min(retryAfterMs, retrySettings.maxDelayMs)
```

Compaction was the only legacy consumer missing the bound.

## What this does *not* change

`effectiveFallbackDelay` stays uncapped. Its contract test —

```ts
test("keeps legacy backoff capped while managed retry-after remains intentionally uncapped", ...)
```

— still passes, unmodified. The two tests now sit **adjacent** so the two-tier policy reads as a documented pair rather than an accident:

| Path | Retry-After source | Policy |
|---|---|---|
| managed fallback | typed transport facts | honoured verbatim (own per-entry budget) |
| legacy retry | prose regex | capped at `retry.maxDelayMs` |
| legacy compaction | prose regex | **capped at `retry.maxDelayMs`** ← this PR |

Candidate-switching is unaffected in the default configuration: a hint above the cap still exceeds the 30s threshold either way, so only the terminal last-candidate sleep changes (3h → `retry.maxDelayMs`, default 5min).

## Implementation

Adds `compactionRetryDelay()` beside `cappedExponentialWithFullJitter` and `effectiveFallbackDelay`, following that file's existing convention of pure, directly unit-tested delay math (it already hosts the generic legacy retry math, not just fallback-chain math).

It also collapses a missing/NaN/infinite hint to "no usable hint" — `#parseRetryAfterMsFromError` can return `Infinity` via `Number("1e999") * 1000`, which would otherwise reach `scheduler.wait`.

## Regression coverage

Added to `routing-adversarial.test.ts`: cap enforcement, hint-below-cap passthrough, preserved exponential growth, and the non-finite/negative guard. Against the uncapped code the cap test fails with `Expected: 1000 / Received: 10800000` (3h).

## Gates

- `routing-adversarial.test.ts` — 9 pass, 0 fail (incl. the untouched "intentionally uncapped" contract)
- fallback + retry + compaction suites (37 files) — 279 pass, 18 skip
- `tsc -p packages/coding-agent/tsconfig.json --noEmit` — clean

The 2 failures in `agent-session-retry-fallback.test.ts` are **pre-existing on `origin/dev`** — verified identical (14 pass / 2 fail) with these changes stashed.
