### PR TITLE
ci: drop default contents:write to read in release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,11 @@ on:
             type: choice
             options: [tag-build-verify, main-nontag]
 
+# Least privilege by default: only `publish` needs write, and it declares its
+# own job-level `contents: write` override. This keeps rehearsal dispatches
+# (and every build/verify job) on a read-scoped GITHUB_TOKEN.
 permissions:
-   contents: write
+   contents: read
 
 concurrency:
    # Release tags never cancel; ordinary CI is cancellable per ref.


### PR DESCRIPTION
## Why

`ci.yml` declares `permissions: contents: write` at the workflow level, but **`publish` is the only job that needs write — and it already declares its own job-level `contents: write` override**. The workflow-level grant is redundant and hands a write-scoped `GITHUB_TOKEN` to every build/verify job, now including the rehearsal dispatches added in #3122, which only check out and build.

Surfaced by an independent audit of the flaky-CI stabilization program.

## Change

```diff
-permissions:
-   contents: write
+# Least privilege by default: only `publish` needs write, and it declares its
+# own job-level `contents: write` override. This keeps rehearsal dispatches
+# (and every build/verify job) on a read-scoped GITHUB_TOKEN.
+permissions:
+   contents: read
```

## Why this is behavior-neutral

Grepped `ci.yml` for `GITHUB_TOKEN`, `github.token`, `gh api`, `gh release`, and `git push` — **zero matches outside the comment I just added**. `publish` keeps its unchanged job-level `contents: write`, so real tag releases are unaffected. Every other job only checks out and builds.

## Verification

- `bun scripts/check-workflow-yaml.ts` — all three workflows parse
- `bun test scripts/release-policy.test.ts scripts/release-publish-order.test.ts scripts/ci-dev-affected.test.ts` — 113 pass / 0 fail