### PR TITLE
test: close the teardown-ordering witness gap and fix a soak-caught dispose flake

### DIFF
--- a/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
@@ -118,6 +118,14 @@ describe("process-lifecycle adversarial owned-process invariants", () => {
 			const exit = await owner.awaitExit({ timeoutMs: 2_000 });
 			expect(exit.exited).toBe(true);
 			await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after concurrent dispose");
+			// The child's TERM trap appends the marker asynchronously, so awaitExit can
+			// return before that write lands under shard load. Poll for the single
+			// terminating signal instead of sampling the file once.
+			await waitForAsync(
+				async () => (await Bun.file(tmp).text()).split("\n").filter(line => line === "term").length === 1,
+				2_000,
+				"single term marker after concurrent dispose",
+			);
 			const marker = await Bun.file(tmp).text();
 			expect(marker.split("\n").filter(line => line === "term")).toHaveLength(1);
 		} finally {

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -3535,18 +3535,22 @@ test("session teardown drains admitted direct gate resolution before detaching i
 	dirs.push(cwd);
 	const sessionId = `direct-resolution-drain-${Date.now()}`;
 	const emitter = new BrokerWorkflowGateEmitter(sessionId, new FileGateStore(path.join(cwd, "gates.json")));
-	const resolution = Promise.withResolvers<{ status: "accepted" }>();
-	const sessionClosedBarrier = Promise.withResolvers<void>();
-	const sessionClosedReached = Promise.withResolvers<void>();
+	const resolution = Promise.withResolvers<void>();
+	const preDrainBarrier = Promise.withResolvers<void>();
+	const sessionClosedDrained = Promise.withResolvers<void>();
+	const terminalized = Promise.withResolvers<void>();
 	const events: string[] = [];
+	let controllerAttached = false;
 	let resolutionStarted = false;
 	const originalRegisterController = emitter.registerGateTerminalController!.bind(emitter);
 	const originalResolveGate = emitter.resolveGate!.bind(emitter);
 	const originalPushFrameAndWait = NotificationServer.prototype.pushFrameAndWait;
 	const registerController = spyOn(emitter, "registerGateTerminalController").mockImplementation(controller => {
 		const detach = originalRegisterController(controller);
+		controllerAttached = true;
 		return () => {
 			events.push("controller-detached");
+			controllerAttached = false;
 			detach();
 		};
 	});
@@ -3555,6 +3559,7 @@ test("session teardown drains admitted direct gate resolution before detaching i
 		await resolution.promise;
 		const resolved = await originalResolveGate(response);
 		events.push("gate-terminalized");
+		terminalized.resolve();
 		return resolved;
 	});
 	const pushFrameAndWait = spyOn(NotificationServer.prototype, "pushFrameAndWait").mockImplementation(async function (
@@ -3562,16 +3567,18 @@ test("session teardown drains admitted direct gate resolution before detaching i
 		frame,
 		timeout,
 	) {
+		const delivered = await originalPushFrameAndWait.call(this, frame, timeout);
 		if ((JSON.parse(frame) as { type?: unknown }).type === "session_closed") {
-			sessionClosedReached.resolve();
-			await sessionClosedBarrier.promise;
+			sessionClosedDrained.resolve();
+			await preDrainBarrier.promise;
 		}
-		return await originalPushFrameAndWait.call(this, frame, timeout);
+		return delivered;
 	});
 	process.env.GJC_NOTIFICATIONS = "1";
 	const sessionContext = context(cwd, sessionId, "main", {}, emitter);
 	const handlers = start(sessionContext);
 	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	let shutdown: Promise<unknown> | undefined;
 	try {
 		await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
 		const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
@@ -3585,7 +3592,11 @@ test("session teardown drains admitted direct gate resolution before detaching i
 		emitter.onGateEmitted!(gate => {
 			gateId = gate.gate_id;
 		});
-		void emitter.emitGate({ stage: "ralplan", kind: "approval", schema: { type: "string" } }).catch(() => {});
+		const gateContinuation = emitter.emitGate({
+			stage: "ralplan",
+			kind: "approval",
+			schema: { type: "string" },
+		});
 		await waitFor(() => gateId !== "", "workflow gate");
 		socket.send(
 			JSON.stringify({
@@ -3602,14 +3613,22 @@ test("session teardown drains admitted direct gate resolution before detaching i
 			}),
 		);
 		await waitFor(() => resolutionStarted, "direct gate resolution");
-		const shutdown = handlers.get("session_shutdown")!({ type: "session_shutdown" }, sessionContext);
-		await sessionClosedReached.promise;
-		expect(events).toEqual([]);
-		sessionClosedBarrier.resolve();
-		resolution.resolve({ status: "accepted" });
+		shutdown = Promise.resolve(handlers.get("session_shutdown")!({ type: "session_shutdown" }, sessionContext));
+		await sessionClosedDrained.promise;
+		expect(controllerAttached).toBe(true);
+		preDrainBarrier.resolve();
+		await new Promise<void>(resolve => setImmediate(resolve));
+		expect(controllerAttached).toBe(true);
+		resolution.resolve();
+		expect(await gateContinuation).toBe("approve");
+		await terminalized.promise;
+		expect(controllerAttached).toBe(true);
 		await shutdown;
 		expect(events).toEqual(["gate-terminalized", "controller-detached"]);
 	} finally {
+		preDrainBarrier.resolve();
+		resolution.resolve();
+		await shutdown?.catch(() => {});
 		pushFrameAndWait.mockRestore();
 		resolveGate.mockRestore();
 		registerController.mockRestore();


### PR DESCRIPTION
Two test-only changes from the flaky-CI stabilization program. No product code.

## 1. Production-observable teardown ordering witness

The Phase 2 rewrite of `session teardown drains admitted direct gate resolution` was accepted with a **narrowed claim** because a mutation probe survived: replacing `await rt.waitForGateResolutionQuiescence()` with `void ...` still passed.

Why it survived: the test fully mocked `resolveGate`, so the delayed operation never touched the real terminal controller, and it released the resolver after a single `setImmediate` while `stopSession()` was independently awaiting the native `pushFrameAndWait(session_closed)` barrier. Resolution therefore completed before teardown reached detachment **even without the quiescence await** — the test couldn't observe the invariant it claimed to guard.

Now it calls through the **original** `registerGateTerminalController` and the **original** `resolveGate` (wrapping the latter only with a deferred pre-terminalization gate), makes `pushFrameAndWait(session_closed)` an explicit test-controlled pre-drain barrier, asserts the controller is still attached at the quiescence point, then observes real accepted terminalization and gate continuation before detachment.

**Mutation-proved:** the `void`-await mutation now **fails** at the pre-detachment assertion (`controllerAttached` false). 10/10 unmutated.

## 2. Soak-caught flake: concurrent-dispose TERM marker

Caught live by the stabilization soak — main-nontag rehearsal run [30149261910](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30149261910) failed on shard 11:

```
(fail) process-lifecycle adversarial owned-process invariants >
       double and concurrent dispose share one settled result and
       issue one terminating signal
expect(received).toHaveLength(expected)   Expected: 1   Received: 0
```

The child's TERM trap appends its marker asynchronously (`trap 'echo term >> $tmp; exit 0' TERM`), so under shard load `awaitExit` can return before that write lands and the single-sample read sees an empty file. The file already has a `waitForAsync` helper for exactly this shape; the marker assertion just wasn't using it.

Polls for the marker before asserting, **preserving the original invariant** — still exactly one `term` line, not weakened to "at least one".

> This test was **not** in the 62-suspect audit shortlist: it neither failed nor retried during the mined two-week window, so the Phase 0 audit could not have shortlisted it. The soak is what surfaced it.

## Verification

- Ordering witness: mutation fails as required; 10/10 unmutated
- Dispose flake: 15/15 reruns, 4x parallel contention clean, whole file 9/9
- `bun run check:types` clean; biome clean; `git diff --check` clean