### PR TITLE
fix(internal-urls): accept cleanup_pending marker in the sync '/var/folders/2n/jzsj1lqn7fx7n_12yhzpwkn00000gn/T/gjc-local/019f97b8-24d8-7000-a4c6-4407998c0855' resolver

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- The synchronous `local://` resolver now accepts a `cleanup_pending` legacy-migration marker instead of rejecting it as unsafe. The async gate already treats that state as settled — entries are installed and content-verified, and only retirement of the legacy source is outstanding — so a managed session whose migration ended in `cleanup_pending` previously failed closed with "Unsafe local:// migration marker" on every `local://` read even though `initializeLocalRoot()` had succeeded. Both marker checks now share one settled-state definition; unrecognized marker values are still rejected. Follow-up to #3080; the asymmetry has been reachable since #2797.
 - Restricted role-agent `bash` now accepts literal mid-word tildes, so git revision syntax such as `git diff HEAD~1` no longer has to be quoted. Bash performs tilde expansion only at the start of a word, so word-initial forms (`~`, `~/path`, `~user`) remain blocked.
 - Restricted role-agent `bash` now rejects unquoted tildes at every bash expansion position inside assignment words, including the compound `name+=value` form, so `A=~`, `A+=~`, `foo=~root/bar`, `A=x:~`, `A+=x:~`, and repeated colon segments such as `a=x:~:y:~` fail closed. Tildes bash does not expand — mid-word git revisions (`HEAD~1`), non-assignment words (`--opt=~`, `1abc=~`, `a++=~`, `a+b=~`), and quoted forms — remain allowed (#3117).
 - ACP sessions now apply execution permission decisions to eval calls and to tools invoked from JavaScript or Python eval contexts, while non-ACP session behavior remains unchanged.

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -147,6 +147,17 @@ const MAX_LEGACY_LOCAL_BYTES = 64 * 1024 * 1024;
 
 type LegacyMigrationState = "complete" | "cleanup_pending";
 
+/**
+ * Marker values that mean legacy migration has settled for this root and the
+ * synchronous resolver may proceed. `cleanup_pending` counts: the entries are
+ * installed and content-verified, and only retirement of the legacy source is
+ * outstanding. Must stay in sync with {@link readMigrationMarker}, which the
+ * async gate uses to decide the same question.
+ */
+function isSettledMigrationMarkerValue(value: string): boolean {
+	return value === "verified\n" || value === "absent\n" || value === "cleanup_pending\n";
+}
+
 interface LegacyEntrySnapshot {
 	readonly relativePath: string;
 	readonly dev: bigint;
@@ -540,8 +551,13 @@ function initializeLocalRootSyncWhenLegacyAbsent(options: LocalProtocolOptions, 
 	if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw new Error("Unsafe local:// root");
 	const marker = path.join(localRoot, LEGACY_MIGRATION_MARKER);
 	try {
-		const value = fsSync.readFileSync(marker, "utf8");
-		if (value !== "verified\n" && value !== "absent\n") throw new Error("Unsafe local:// migration marker");
+		// Accept exactly the marker states the async gate treats as settled. A
+		// `cleanup_pending` marker means the entries are fully installed and verified
+		// and only retirement of the legacy source is outstanding, so resolution is
+		// safe; rejecting it here made the sync resolver fail closed on a root the
+		// async gate had already completed.
+		if (!isSettledMigrationMarkerValue(fsSync.readFileSync(marker, "utf8")))
+			throw new Error("Unsafe local:// migration marker");
 		initializedLocalRoots.add(localRoot);
 		return;
 	} catch (error) {
@@ -558,7 +574,10 @@ function initializeLocalRootSyncWhenLegacyAbsent(options: LocalProtocolOptions, 
 		fsSync.writeFileSync(marker, "absent\n", { mode: 0o600, flag: "wx" });
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-		if (fsSync.readFileSync(marker, "utf8") !== "absent\n") throw new Error("Unsafe local:// migration marker");
+		// A concurrent initializer won the exclusive create. Any settled marker state
+		// it wrote is authoritative; only an unrecognized value is unsafe.
+		if (!isSettledMigrationMarkerValue(fsSync.readFileSync(marker, "utf8")))
+			throw new Error("Unsafe local:// migration marker");
 	}
 	initializedLocalRoots.add(localRoot);
 }

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -407,6 +407,44 @@ describe("LocalProtocolHandler", () => {
 		expect(resolveLocalUrlToPath("local://memo.txt", options)).toBe(path.join(root, "memo.txt"));
 	});
 
+	it("resolves against a cleanup_pending root the async gate already settled", async () => {
+		// The async gate treats `cleanup_pending` as settled: entries are installed and
+		// content-verified, only legacy-source retirement is outstanding. The sync
+		// resolver used to reject that same marker as unsafe, so a session whose
+		// migration ended in `cleanup_pending` failed closed on every local:// read.
+		await withTempDir(async artifactsDir => {
+			const sessionId = `cleanup-pending-sync-${path.basename(artifactsDir)}`;
+			await withLocalRoot(sessionId, async localRoot => {
+				await Bun.write(path.join(localRoot, "carried.json"), '{"carried":true}');
+				await fs.writeFile(path.join(localRoot, ".gjc-local-legacy-migrated-v1"), "cleanup_pending\n", {
+					mode: 0o600,
+				});
+
+				const options = localOptions(sessionId, artifactsDir);
+				expect(resolveLocalUrlToPath("local://carried.json", options)).toBe(path.join(localRoot, "carried.json"));
+				// Idempotent: a second resolution must not rewrite or reject the marker.
+				expect(resolveLocalUrlToPath("local://", options)).toBe(localRoot);
+				expect(await fs.readFile(path.join(localRoot, ".gjc-local-legacy-migrated-v1"), "utf8")).toBe(
+					"cleanup_pending\n",
+				);
+			});
+		});
+	});
+
+	it("still rejects an unrecognized migration marker value", async () => {
+		await withTempDir(async artifactsDir => {
+			const sessionId = `unsafe-marker-sync-${path.basename(artifactsDir)}`;
+			await withLocalRoot(sessionId, async localRoot => {
+				await fs.writeFile(path.join(localRoot, ".gjc-local-legacy-migrated-v1"), "definitely-not-a-state\n", {
+					mode: 0o600,
+				});
+				expect(() => resolveLocalUrlToPath("local://memo.txt", localOptions(sessionId, artifactsDir))).toThrow(
+					"Unsafe local:// migration marker",
+				);
+			});
+		});
+	});
+
 	it("blocks symlink escapes outside local root", async () => {
 		if (process.platform === "win32") return;
 


### PR DESCRIPTION
## What

Closes non-blocking follow-up **1** from the #3080 post-merge review: the `cleanup_pending` marker asymmetry between the async gate and the sync resolver.

## Why

The two paths disagreed on what counts as a settled legacy-migration marker.

**Async gate** — `cleanup_pending` is a terminal state, and `initializeLocalRoot()` returns successfully on it:

```ts
if (value === "cleanup_pending\n") return "cleanup_pending";
if (value === "verified\n" || value === "absent\n") return "complete";
```

**Sync resolver** — accepted only two values and threw on everything else:

```ts
if (value !== "verified\n" && value !== "absent\n") throw new Error("Unsafe local:// migration marker");
```

`migrateManagedLegacyLocal()` writes `cleanup_pending` on a specific, designed-for outcome: every entry is installed and sha256-verified in the destination, but `source.retire()` could not complete. So a managed session could reach a state where `initializeLocalRoot()` reported success and **every subsequent `local://` read failed closed** with `Unsafe local:// migration marker`, unrecoverable until the marker was deleted by hand.

This is the same class of defect as #3080 — an async gate and a sync resolver disagreeing about readiness — on the exact state the migration is designed to reach when retirement is deferred.

## Changes

- New `isSettledMigrationMarkerValue()` helper, used by **both** sync marker checks, so the two paths cannot drift apart again. Documented as needing to stay in sync with `readMigrationMarker()`.
- The concurrent-`EEXIST` recheck now accepts any settled state the winning initializer wrote, instead of only `absent`. Previously a racing initializer that legitimately wrote `verified` or `cleanup_pending` would make the loser throw.
- Unrecognized marker values are **still rejected** — the fail-closed posture on genuinely corrupt markers is unchanged, and there is a test for it.

## Testing

Red before, green after — verified by reverting only the source file:

```
(fail) LocalProtocolHandler > resolves against a cleanup_pending root the async gate already settled
error: Unsafe local:// migration marker    → 18 pass / 1 fail
```

With the fix:

- `bun test packages/coding-agent/test/internal-urls/ packages/coding-agent/test/sdk-session-isolation.test.ts` → **93 pass / 0 fail**
- `bun run --cwd packages/coding-agent check` (biome + `tsc --noEmit`) → clean

Two tests added: one asserting resolution and marker idempotence on a `cleanup_pending` root, one asserting an unrecognized value still throws.

## Scope

`local-protocol.ts` + its test + CHANGELOG. Does not touch `agent-session.ts`, so it is independent of #3140 (the #3080 claims-scope correction) and of #3138 (atomic rotation).

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:pending reviewer:human evidence:bun test internal-urls + sdk-session-isolation (93 pass @ 90aa337); red before fix (18/1); biome + tsc clean
```

---

- [x] Target branch is `dev`
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Regression test fails before the fix

@Yeachan-Heo this is your post-merge follow-up 1, implemented. Follow-up 2 (ordering coverage for the other five gated sites) I have deliberately not bundled here — it belongs with #3138's lifecycle work, since four of those five sites cannot be given a meaningful ordering test without the atomic rotation contract that issue defines.
