### PR TITLE
ci: add offline workflow permission invariant regression (#3139)

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -20,6 +20,12 @@ on:
         required: true
         type: string
 
+# Least privilege by default: no dev-ci job needs a write-scoped GITHUB_TOKEN.
+# Every job only checks out, installs, tests, and exchanges artifacts through the
+# Actions artifact API, so a read-scoped token is sufficient.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/scripts/check-workflow-permissions.test.ts
+++ b/scripts/check-workflow-permissions.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import { parse } from "yaml";
+import {
+	JOB_WRITE_ALLOWLIST,
+	REQUIRED_READ_DEFAULT,
+	evaluateWorkflowPermissions,
+	readWorkflowDocuments,
+} from "./check-workflow-permissions";
+
+const CI_WORKFLOW = ".github/workflows/ci.yml";
+const DEV_CI_WORKFLOW = ".github/workflows/dev-ci.yml";
+const repoRoot = `${import.meta.dir}/..`;
+
+async function parsedWorkflow(file: string): Promise<Record<string, unknown>> {
+	return parse(await Bun.file(`${repoRoot}/${file}`).text()) as Record<string, unknown>;
+}
+
+function documentRecord(value: unknown): Record<string, unknown> {
+	return value as Record<string, unknown>;
+}
+
+function jobWriteScopes(document: Record<string, unknown>): string[] {
+	const jobs = documentRecord(document.jobs);
+	return Object.entries(jobs).flatMap(([job, value]) => {
+		const permissions = documentRecord(value).permissions;
+		if (typeof permissions !== "object" || permissions === null || Array.isArray(permissions)) return [];
+		return Object.entries(permissions as Record<string, unknown>)
+			.filter(([, scope]) => scope === "write")
+			.map(([scope]) => `${job}.${scope}`);
+	});
+}
+
+describe("workflow permission policy", () => {
+	test("committed workflows satisfy the default-deny evaluator", async () => {
+		const workflows = await readWorkflowDocuments();
+		expect(evaluateWorkflowPermissions(workflows)).toEqual([]);
+		expect(workflows.map(workflow => workflow.file)).toEqual([
+			".github/workflows/ci.yml",
+			".github/workflows/dev-ci.yml",
+			".github/workflows/public-site-sync.yml",
+		]);
+	});
+
+	test("ci.yml has an exact read-scoped workflow default and one write job", async () => {
+		const workflows = await readWorkflowDocuments();
+		const ci = workflows.find(workflow => workflow.file === CI_WORKFLOW);
+		expect(ci).toBeDefined();
+		const document = documentRecord(ci!.document);
+
+		expect(REQUIRED_READ_DEFAULT).toContain(CI_WORKFLOW);
+		expect(document.permissions).toEqual({ contents: "read" });
+		expect(JOB_WRITE_ALLOWLIST).toEqual([{ workflow: CI_WORKFLOW, job: "publish", scope: "contents" }]);
+		expect(jobWriteScopes(document)).toEqual(["publish.contents"]);
+	});
+
+	test("dev-ci.yml has an exact read-scoped workflow default and no write job scope", async () => {
+		const workflows = await readWorkflowDocuments();
+		const devCi = workflows.find(workflow => workflow.file === DEV_CI_WORKFLOW);
+		expect(devCi).toBeDefined();
+		const document = documentRecord(devCi!.document);
+
+		expect(REQUIRED_READ_DEFAULT).toContain(DEV_CI_WORKFLOW);
+		expect(document.permissions).toEqual({ contents: "read" });
+		expect(jobWriteScopes(document)).toEqual([]);
+	});
+
+	test("detects a ci.yml workflow contents write mutation", async () => {
+		const source = await parsedWorkflow(CI_WORKFLOW);
+		const document = structuredClone(source);
+		const permissions = documentRecord(document.permissions);
+		permissions.contents = "write";
+
+		const violations = evaluateWorkflowPermissions([{ file: CI_WORKFLOW, document }]);
+		expect(violations).toHaveLength(1);
+		const violation = violations[0]!;
+		// The remediation must name the exact required value; "none" is rejected too.
+		expect(violation).toMatchObject({ path: "permissions.contents", actual: '"write"', expected: '"read"', workflow: CI_WORKFLOW });
+		expect(violation.message).toContain(CI_WORKFLOW);
+		expect(violation.message).toContain("permissions.contents");
+		expect(violation.message).not.toContain("none");
+	});
+
+	test("detects a ci.yml check job contents write mutation", async () => {
+		const source = await parsedWorkflow(CI_WORKFLOW);
+		const document = structuredClone(source);
+		const jobs = documentRecord(document.jobs);
+		const check = documentRecord(jobs.check);
+		check.permissions = { contents: "write" };
+
+		const violations = evaluateWorkflowPermissions([{ file: CI_WORKFLOW, document }]);
+		expect(violations).toHaveLength(1);
+		const violation = violations[0]!;
+		// Job scopes keep the generic non-write remediation plus the allowlist note.
+		expect(violation).toMatchObject({
+			path: "jobs.check.permissions.contents",
+			actual: '"write"',
+			expected: '"read" or "none"',
+			workflow: CI_WORKFLOW,
+			job: "check",
+		});
+		expect(violation.message).toContain(CI_WORKFLOW);
+		expect(violation.message).toContain("check");
+		expect(violation.message).toContain("jobs.check.permissions.contents");
+		expect(violation.message).toContain('only job "publish"');
+	});
+
+	test("detects a ci.yml check job write-all mutation", async () => {
+		const source = await parsedWorkflow(CI_WORKFLOW);
+		const document = structuredClone(source);
+		documentRecord(documentRecord(document.jobs).check).permissions = "write-all";
+
+		const violations = evaluateWorkflowPermissions([{ file: CI_WORKFLOW, document }]);
+		const violation = violations.find(candidate => candidate.path === "jobs.check.permissions");
+		expect(violation).toBeDefined();
+		expect(violation).toMatchObject({ actual: '"write-all"', workflow: CI_WORKFLOW, job: "check" });
+		expect(violation!.message).toContain(CI_WORKFLOW);
+		expect(violation!.message).toContain("check");
+		expect(violation!.message).toContain("jobs.check.permissions");
+	});
+
+	test("detects a non-mapping jobs mutation", async () => {
+		const source = await parsedWorkflow(CI_WORKFLOW);
+		const document = structuredClone(source);
+		document.jobs = null;
+
+		const violations = evaluateWorkflowPermissions([{ file: CI_WORKFLOW, document }]);
+		const violation = violations.find(candidate => candidate.path === "jobs");
+		expect(violation).toBeDefined();
+		expect(violation).toMatchObject({ actual: "null", workflow: CI_WORKFLOW, expected: "a jobs mapping" });
+	});
+
+	test("detects a non-mapping job mutation", async () => {
+		const source = await parsedWorkflow(CI_WORKFLOW);
+		const document = structuredClone(source);
+		documentRecord(document.jobs).check = null;
+
+		const violations = evaluateWorkflowPermissions([{ file: CI_WORKFLOW, document }]);
+		const violation = violations.find(candidate => candidate.path === "jobs.check");
+		expect(violation).toBeDefined();
+		expect(violation).toMatchObject({ actual: "null", workflow: CI_WORKFLOW, job: "check", expected: "a job mapping" });
+	});
+
+	test("detects a ci.yml workflow write-all mutation", async () => {
+		const source = await parsedWorkflow(CI_WORKFLOW);
+		const document = structuredClone(source);
+		document.permissions = "write-all";
+
+		const violations = evaluateWorkflowPermissions([{ file: CI_WORKFLOW, document }]);
+		expect(violations.length).toBeGreaterThan(0);
+		expect(violations.some(violation => violation.message.includes(CI_WORKFLOW))).toBe(true);
+		expect(violations.some(violation => violation.message.includes("permissions"))).toBe(true);
+		expect(violations.some(violation => violation.message.includes("write-all"))).toBe(true);
+	});
+
+	test("requires exact contents read for a required workflow permissions mapping", async () => {
+		const source = await parsedWorkflow(DEV_CI_WORKFLOW);
+		const document = structuredClone(source);
+		document.permissions = { contents: "none" };
+
+		const violations = evaluateWorkflowPermissions([{ file: DEV_CI_WORKFLOW, document }]);
+		const violation = violations.find(candidate => candidate.path === "permissions.contents");
+		expect(violation).toBeDefined();
+		expect(violation).toMatchObject({ actual: '"none"', workflow: DEV_CI_WORKFLOW, expected: '"read"' });
+	});
+
+	test("requires exact contents read for a required workflow read-all default", async () => {
+		const source = await parsedWorkflow(DEV_CI_WORKFLOW);
+		const document = structuredClone(source);
+		document.permissions = "read-all";
+
+		const violations = evaluateWorkflowPermissions([{ file: DEV_CI_WORKFLOW, document }]);
+		const violation = violations.find(candidate => candidate.path === "permissions.contents");
+		expect(violation).toBeDefined();
+		expect(violation).toMatchObject({ actual: "<absent>", workflow: DEV_CI_WORKFLOW, expected: '"read"' });
+	});
+
+	test("rejects an extra read scope on a required workflow default", async () => {
+		const source = await parsedWorkflow(DEV_CI_WORKFLOW);
+		const document = structuredClone(source);
+		document.permissions = { contents: "read", actions: "read" };
+
+		const violations = evaluateWorkflowPermissions([{ file: DEV_CI_WORKFLOW, document }]);
+		expect(violations).toHaveLength(1);
+		expect(violations[0]).toMatchObject({ path: "permissions.actions", actual: '"read"', workflow: DEV_CI_WORKFLOW });
+		expect(violations[0]?.message).toContain(DEV_CI_WORKFLOW);
+		expect(violations[0]?.message).toContain("permissions.actions");
+	});
+
+	test("reports one authoritative remediation per path for a write extra scope", async () => {
+		const source = await parsedWorkflow(DEV_CI_WORKFLOW);
+		const document = structuredClone(source);
+		document.permissions = { contents: "write", actions: "write" };
+
+		const violations = evaluateWorkflowPermissions([{ file: DEV_CI_WORKFLOW, document }]);
+		// Each offending path gets exactly one non-contradictory expectation.
+		expect(violations).toHaveLength(2);
+		expect(violations.map(violation => violation.path)).toEqual(["permissions.contents", "permissions.actions"]);
+		expect(violations[0]).toMatchObject({ path: "permissions.contents", actual: '"write"', expected: '"read"' });
+		expect(violations[1]?.path).toBe("permissions.actions");
+		expect(violations[1]?.expected).toContain("<absent>");
+		expect(violations[1]?.expected).not.toContain('"read" or "none"');
+	});
+
+	test("detects a deleted dev-ci.yml workflow permissions block", async () => {
+		const source = await parsedWorkflow(DEV_CI_WORKFLOW);
+		const document = structuredClone(source);
+		delete document.permissions;
+
+		const violations = evaluateWorkflowPermissions([{ file: DEV_CI_WORKFLOW, document }]);
+		expect(violations.length).toBeGreaterThan(0);
+		expect(violations.some(violation => violation.message.includes(DEV_CI_WORKFLOW))).toBe(true);
+	});
+
+	test("allows the ci.yml publish permissions block to be removed", async () => {
+		const source = await parsedWorkflow(CI_WORKFLOW);
+		const document = structuredClone(source);
+		delete documentRecord(documentRecord(document.jobs).publish).permissions;
+
+		expect(evaluateWorkflowPermissions([{ file: CI_WORKFLOW, document }])).toEqual([]);
+	});
+});

--- a/scripts/check-workflow-permissions.ts
+++ b/scripts/check-workflow-permissions.ts
@@ -1,0 +1,248 @@
+#!/usr/bin/env bun
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { parse } from "yaml";
+
+const repoRoot = path.join(import.meta.dir, "..");
+const workflowDir = path.join(repoRoot, ".github", "workflows");
+
+export interface PermissionViolation {
+	workflow: string;
+	job?: string;
+	path: string;
+	actual: string;
+	expected: string;
+	message: string;
+}
+
+export interface WorkflowInput {
+	file: string;
+	document: unknown;
+}
+
+export const JOB_WRITE_ALLOWLIST: readonly { workflow: string; job: string; scope: string }[] = [
+	{ workflow: ".github/workflows/ci.yml", job: "publish", scope: "contents" },
+];
+
+export const REQUIRED_READ_DEFAULT: readonly string[] = [
+	".github/workflows/ci.yml",
+	".github/workflows/dev-ci.yml",
+	".github/workflows/public-site-sync.yml",
+];
+
+const EXPECTED_WORKFLOW_DEFAULT = "an explicit least-privilege permissions block";
+const EXPECTED_SCOPE_VALUE = '"read", "write", or "none"';
+const EXPECTED_NON_WRITE_SCOPE = '"read" or "none"';
+const EXPECTED_PERMISSION_VALUE = '"read-all" or a permissions mapping';
+const JOB_WRITE_ALLOWLIST_NOTE = 'only job "publish" in .github/workflows/ci.yml may hold contents: write';
+
+type RecordValue = Record<string, unknown>;
+
+function isRecord(value: unknown): value is RecordValue {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(value: RecordValue, key: string): boolean {
+	return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function displayValue(value: unknown): string {
+	if (typeof value === "string") return JSON.stringify(value);
+	if (value === null) return "null";
+	if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") return String(value);
+	try {
+		return String(value);
+	} catch {
+		return "<unprintable>";
+	}
+}
+
+function isAllowlisted(workflow: string, job: string, scope: string): boolean {
+	return JOB_WRITE_ALLOWLIST.some(entry => entry.workflow === workflow && entry.job === job && entry.scope === scope);
+}
+
+function workflowViolation(
+	violations: PermissionViolation[],
+	workflow: string,
+	permissionPath: string,
+	actual: string,
+	expected: string,
+): void {
+	violations.push({
+		workflow,
+		path: permissionPath,
+		actual,
+		expected,
+		message: `${workflow}: ${permissionPath} = ${actual} (expected ${expected})`,
+	});
+}
+
+function jobViolation(
+	violations: PermissionViolation[],
+	workflow: string,
+	job: string,
+	permissionPath: string,
+	actual: string,
+	expected: string,
+): void {
+	violations.push({
+		workflow,
+		job,
+		path: permissionPath,
+		actual,
+		expected,
+		message: `${workflow}: job "${job}": ${permissionPath} = ${actual} (expected ${expected}; ${JOB_WRITE_ALLOWLIST_NOTE})`,
+	});
+}
+
+function hasViolationAt(violations: PermissionViolation[], workflow: string, permissionPath: string): boolean {
+	return violations.some(violation => violation.workflow === workflow && violation.path === permissionPath);
+}
+
+function evaluateScopeMapping(
+	violations: PermissionViolation[],
+	workflow: string,
+	permissions: RecordValue,
+	pathPrefix: string,
+	job: string | undefined,
+	requiredReadDefault: boolean,
+): void {
+	for (const [scope, value] of Object.entries(permissions)) {
+		const permissionPath = `${pathPrefix}.${scope}`;
+		// On a required workflow default, every non-`contents` scope is forbidden
+		// outright; the exact-mapping pass below owns that path's single diagnostic.
+		if (requiredReadDefault && job === undefined && scope !== "contents") continue;
+		if (value === "write") {
+			if (job === undefined || !isAllowlisted(workflow, job, scope)) {
+				// Required workflows must be exactly `contents: read`, so "none" is not a
+				// valid remediation for them even though it is a non-write value.
+				const writeExpected = requiredReadDefault && job === undefined && scope === "contents" ? displayValue("read") : EXPECTED_NON_WRITE_SCOPE;
+				if (job === undefined) {
+					workflowViolation(violations, workflow, permissionPath, displayValue(value), writeExpected);
+				} else {
+					jobViolation(violations, workflow, job, permissionPath, displayValue(value), writeExpected);
+				}
+			}
+			continue;
+		}
+		if (value === "read" || value === "none") continue;
+
+		const expected = requiredReadDefault && job === undefined && scope === "contents" ? displayValue("read") : EXPECTED_SCOPE_VALUE;
+		const actual = displayValue(value);
+		if (job === undefined) {
+			workflowViolation(violations, workflow, permissionPath, actual, expected);
+		} else {
+			jobViolation(violations, workflow, job, permissionPath, actual, expected);
+		}
+	}
+}
+
+function evaluateWorkflowDefault(
+	violations: PermissionViolation[],
+	workflow: string,
+	document: RecordValue | undefined,
+): void {
+	const permissions = document && hasOwn(document, "permissions") ? document.permissions : undefined;
+	if (permissions === undefined || permissions === null) {
+		workflowViolation(violations, workflow, "permissions", "<absent>", EXPECTED_WORKFLOW_DEFAULT);
+		return;
+	}
+
+	const requiredReadDefault = REQUIRED_READ_DEFAULT.includes(workflow);
+	if (permissions === "write-all") {
+		workflowViolation(violations, workflow, "permissions", displayValue(permissions), EXPECTED_PERMISSION_VALUE);
+	} else if (permissions === "read-all") {
+		// read-all is non-writing, but required workflows still need an exact contents default.
+	} else if (isRecord(permissions)) {
+		evaluateScopeMapping(violations, workflow, permissions, "permissions", undefined, requiredReadDefault);
+	} else {
+		workflowViolation(violations, workflow, "permissions", displayValue(permissions), EXPECTED_PERMISSION_VALUE);
+	}
+
+	if (requiredReadDefault && !hasViolationAt(violations, workflow, "permissions.contents")) {
+		const hasContents = isRecord(permissions) && hasOwn(permissions, "contents");
+		const contents = hasContents ? permissions.contents : undefined;
+		if (contents !== "read") {
+			workflowViolation(violations, workflow, "permissions.contents", hasContents ? displayValue(contents) : "<absent>", displayValue("read"));
+		}
+	}
+
+	// Required workflows must carry exactly `contents: read` -- extra read/none
+	// scopes are still a privilege expansion over the least-privilege default.
+	if (requiredReadDefault && isRecord(permissions)) {
+		for (const scope of Object.keys(permissions)) {
+			if (scope === "contents") continue;
+			workflowViolation(violations, workflow, `permissions.${scope}`, displayValue(permissions[scope]), "<absent>; required workflows declare exactly contents: read");
+		}
+	}
+}
+
+function evaluateJobPermissions(violations: PermissionViolation[], workflow: string, document: RecordValue | undefined): void {
+	if (!document || !hasOwn(document, "jobs")) return;
+
+	const jobs = document.jobs;
+	if (!isRecord(jobs)) {
+		workflowViolation(violations, workflow, "jobs", displayValue(jobs), "a jobs mapping");
+		return;
+	}
+
+	for (const [job, jobValue] of Object.entries(jobs)) {
+		if (!isRecord(jobValue)) {
+			jobViolation(violations, workflow, job, `jobs.${job}`, displayValue(jobValue), "a job mapping");
+			continue;
+		}
+		if (!hasOwn(jobValue, "permissions")) continue;
+
+		const permissions = jobValue.permissions;
+		const permissionPath = `jobs.${job}.permissions`;
+		if (permissions === undefined || permissions === null) {
+			jobViolation(violations, workflow, job, permissionPath, displayValue(permissions), EXPECTED_PERMISSION_VALUE);
+		} else if (permissions === "write-all") {
+			jobViolation(violations, workflow, job, permissionPath, displayValue(permissions), EXPECTED_PERMISSION_VALUE);
+		} else if (permissions === "read-all") {
+			// read-all is accepted as a non-writing job override.
+		} else if (isRecord(permissions)) {
+			evaluateScopeMapping(violations, workflow, permissions, permissionPath, job, false);
+		} else {
+			jobViolation(violations, workflow, job, permissionPath, displayValue(permissions), EXPECTED_PERMISSION_VALUE);
+		}
+	}
+}
+
+export function evaluateWorkflowPermissions(workflows: readonly WorkflowInput[]): PermissionViolation[] {
+	const violations: PermissionViolation[] = [];
+	for (const workflow of workflows) {
+		const document = isRecord(workflow.document) ? workflow.document : undefined;
+		evaluateWorkflowDefault(violations, workflow.file, document);
+		evaluateJobPermissions(violations, workflow.file, document);
+	}
+	return violations;
+}
+
+export async function readWorkflowDocuments(): Promise<WorkflowInput[]> {
+	const entries = await fs.readdir(workflowDir, { withFileTypes: true });
+	const workflowFiles = entries
+		.filter(entry => entry.isFile() && /\.ya?ml$/i.test(entry.name))
+		.map(entry => entry.name)
+		.sort((left, right) => left.localeCompare(right));
+
+	return Promise.all(
+		workflowFiles.map(async fileName => {
+			const absolutePath = path.join(workflowDir, fileName);
+			const file = path.relative(repoRoot, absolutePath).split(path.sep).join("/");
+			const document = parse(await fs.readFile(absolutePath, "utf8"));
+			return { file, document };
+		}),
+	);
+}
+
+if (import.meta.main) {
+	const workflows = await readWorkflowDocuments();
+	const violations = evaluateWorkflowPermissions(workflows);
+	if (violations.length > 0) {
+		for (const violation of violations) console.error(violation.message);
+		process.exitCode = 1;
+	} else {
+		for (const workflow of workflows) console.log(`ok ${workflow.file}`);
+	}
+}

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -1133,19 +1133,32 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 		expect(tasks[2]?.command).toEqual(["bash", "-lc", 'TARGET_VARIANTS="baseline modern" bun scripts/ci-build-native.ts']);
 	});
 
-	test("a CI workflow change plans yaml-parse + ci-selftest + ci-dry-run only", () => {
+	test("a CI workflow change plans yaml-parse + ci-selftest + ci-dry-run + workflow-permissions", () => {
 		const tasks = targeted([".github/workflows/dev-ci.yml"]);
-		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest", "yaml-parse"]);
+		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest", "workflow-permissions", "yaml-parse"]);
 	});
 
-	test("a CI harness script change plans ci-selftest + ci-dry-run (no yaml-parse)", () => {
+	test("broad planner schedules workflow permission regression for workflow and checker changes", () => {
+		for (const changedPath of [".github/workflows/dev-ci.yml", "scripts/check-workflow-permissions.ts"]) {
+			const task = planTasks([changedPath], targetingPackages).find(candidate => candidate.key === "workflow-permissions");
+			expect(task).toBeDefined();
+			expect(task?.command).toEqual(["bun", "test", "scripts/check-workflow-permissions.test.ts", "scripts/release-policy.test.ts"]);
+		}
+	});
+
+	test("a CI harness script change plans ci-selftest + ci-dry-run + workflow-permissions (no yaml-parse)", () => {
 		const tasks = targeted(["scripts/ci-dev-affected.ts"]);
-		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest"]);
+		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest", "workflow-permissions"]);
+	});
+
+	test("a workflow permission checker change plans its own regression", () => {
+		const tasks = targeted(["scripts/check-workflow-permissions.ts"]);
+		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest", "workflow-permissions"]);
 	});
 
 	test("the dev CI guard topology test is scheduled and executed as a CI harness change", () => {
 		const tasks = targeted(["scripts/dev-ci-guard-topology.test.ts"]);
-		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest"]);
+		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest", "workflow-permissions"]);
 		expect(tasks.find(task => task.key === "ci-selftest")?.command).toEqual([
 			"bun",
 			"test",

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -772,6 +772,7 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	if (paths.some(isWorkflowOrScriptPath)) {
 		add(tasks, "affected-dry-run", "Affected CI selector self-check", ["bun", "scripts/ci-dev-affected.ts", "--dry-run"]);
 		add(tasks, "affected-selftest", "Affected CI selector unit tests", ["bun", "test", "scripts/ci-dev-affected.test.ts", "scripts/dev-ci-guard-topology.test.ts"]);
+		add(tasks, "workflow-permissions", "Workflow permission policy regression", ["bun", "test", "scripts/check-workflow-permissions.test.ts", "scripts/release-policy.test.ts"]);
 		if (paths.some(isWorkflowPath)) {
 			add(tasks, "workflow-yaml-parse", "Workflow YAML parse check", ["bun", "scripts/check-workflow-yaml.ts"]);
 		}
@@ -783,7 +784,7 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 // PR-mode targeted planner. For each changed path it emits the smallest safe set
 // of tasks instead of the broad affected suite:
 //   - docs/changelog-only -> nothing expensive
-//   - workflow / CI harness scripts -> yaml-parse + ci-selftest + ci-dry-run
+//   - workflow / CI harness scripts -> yaml-parse + ci-selftest + ci-dry-run + permission check
 //   - a changed test file -> run exactly that test file (test:<path>)
 //   - a source file with a directly-named test -> run that test file only
 //   - a source file with no mapped test -> owning package check + relevant smoke
@@ -802,6 +803,7 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 	const fullWorkspace = relevant.some(isFullWorkspacePath) && !isRootPackageReleaseHarnessOnly(relevant);
 	let needCiSelftest = false;
 	let needYamlParse = false;
+	let needPermissionCheck = false;
 
 	if (fullWorkspace) {
 		add(tasks, "root-check", "Root TypeScript/tooling check", ["bun", "run", "ci:check:full"]);
@@ -814,10 +816,12 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 		if (isWorkflowPath(changedPath)) {
 			needYamlParse = true;
 			needCiSelftest = true;
+			needPermissionCheck = true;
 			continue;
 		}
 		if (isCiHarnessScriptPath(changedPath)) {
 			needCiSelftest = true;
+			needPermissionCheck = true;
 			continue;
 		}
 		if (isRustPath(changedPath)) {
@@ -902,6 +906,9 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 	}
 	if (needYamlParse) {
 		add(tasks, "yaml-parse", "Workflow YAML parse check", ["bun", "scripts/check-workflow-yaml.ts"]);
+	}
+	if (needPermissionCheck) {
+		add(tasks, "workflow-permissions", "Workflow permission policy regression", ["bun", "test", "scripts/check-workflow-permissions.test.ts", "scripts/release-policy.test.ts"]);
 	}
 
 	ensureNativeBuild(tasks);
@@ -1004,7 +1011,7 @@ function isTestFilePath(changedPath: string): boolean {
 }
 
 function isCiHarnessScriptPath(changedPath: string): boolean {
-	return changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/ci-dev-affected.test.ts" || changedPath === "scripts/dev-ci-guard-topology.test.ts" || changedPath === "scripts/check-workflow-yaml.ts";
+	return changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/ci-dev-affected.test.ts" || changedPath === "scripts/dev-ci-guard-topology.test.ts" || changedPath === "scripts/check-workflow-yaml.ts" || changedPath === "scripts/check-workflow-permissions.ts" || changedPath === "scripts/check-workflow-permissions.test.ts";
 }
 
 
@@ -1405,7 +1412,9 @@ function isWorkflowHarnessPath(changedPath: string): boolean {
 		changedPath === "scripts/ci-dev-affected.ts" ||
 		changedPath === "scripts/ci-dev-affected.test.ts" ||
 		changedPath === "scripts/dev-ci-guard-topology.test.ts" ||
-		changedPath === "scripts/check-workflow-yaml.ts"
+		changedPath === "scripts/check-workflow-yaml.ts" ||
+		changedPath === "scripts/check-workflow-permissions.ts" ||
+		changedPath === "scripts/check-workflow-permissions.test.ts"
 	);
 }
 

--- a/scripts/release-policy.test.ts
+++ b/scripts/release-policy.test.ts
@@ -116,6 +116,29 @@ describe("stable release policy", () => {
 		expect(publicSync).toContain("bun scripts/check-public-version-sync.ts --live");
 	});
 
+	// #3139 least-privilege invariant: CI keeps its workflow default read-scoped.
+	test("pins the ci.yml workflow default to contents read", async () => {
+		const ci = await workflow();
+		const header = ci.slice(0, ci.indexOf("\njobs:"));
+		const permissionsStart = header.indexOf("\npermissions:");
+		const permissionsEnd = header.indexOf("\n\n", permissionsStart);
+		const permissions = header.slice(permissionsStart, permissionsEnd);
+
+		expect(header).toMatch(/permissions:\n   contents: read/u);
+		expect(permissions).not.toMatch(/:\s+write(?:\s|$)/u);
+	});
+
+	// #3139 least-privilege invariant: only publish may hold contents write.
+	test("pins publish as the only job-level contents write permission", async () => {
+		const ci = await workflow();
+		const jobs = [...ci.slice(ci.indexOf("\njobs:")).matchAll(/^ {3}[a-z_][a-z0-9_]*:$/gmu)].map(job => job[0].trim().slice(0, -1));
+		for (const job of jobs) {
+			const section = jobSection(ci, job);
+			if (job === "publish") expect(section).toContain("contents: write");
+			else expect(section).not.toContain("contents: write");
+		}
+	});
+
 	test("rejects reused or moved tags and directs corrections to a newer stable version", async () => {
 		const releaseScript = await Bun.file(releaseScriptPath).text();
 


### PR DESCRIPTION
## Summary

Closes the #3139 gap: the release CI permission model had no automated policy test. #3136 narrowed the `ci.yml` default to `contents: read` while `publish` kept the sole job-level `contents: write` override, but nothing prevented a future edit from silently restoring workflow-wide write scope or adding another write-scoped job. `dev-ci.yml` had no explicit permission block at all.

This adds a deterministic **offline** policy regression — no hosted GitHub state, no network.

## What changed

**`scripts/check-workflow-permissions.ts`** (new) — pure default-deny evaluator + CLI:

| Rule | Behavior |
|---|---|
| 1 | Every `.github/workflows/*.y(a)ml` MUST declare a workflow-level `permissions` block |
| 2 | Scalar `write-all` at workflow or job level is denied (`read-all` / `{}` are non-write) |
| 3 | Any workflow-level `write` scope is denied |
| 4 | Any job-level `write` scope is denied unless allowlisted — the allowlist holds exactly one triple: `ci.yml` / `publish` / `contents` |
| 5 | `ci.yml`, `dev-ci.yml`, `public-site-sync.yml` must declare **exactly** `contents: read` (extra scopes are a privilege expansion) |

Malformed `jobs` containers and job entries fail closed; the evaluator is total and never throws. `bun scripts/check-workflow-permissions.ts` prints every violation and exits 1.

**`.github/workflows/dev-ci.yml`** — codified `contents: read`, after verifying (not assuming) its jobs need no write token: they only check out, install, test, and exchange artifacts through the Actions artifact API. No `git push`, no `gh` CLI, no `secrets.*`, no release/PR/issue mutation.

**`scripts/check-workflow-permissions.test.ts`** (new) — mutation proofs that read the **real committed YAML** from disk, parse it, mutate the parsed document, and re-evaluate. Inline fixtures are deliberately avoided: a hand-built fixture would keep passing even if the real workflow drifted, which is the exact failure mode this issue exists to prevent.

**Routing** — `scripts/ci-dev-affected.ts` schedules a `workflow-permissions` task running both the new regression and `release-policy.test.ts`, registered identically in the broad and targeted planners. The checker and its test are classified as CI-harness paths, so the guard self-protects. Two assertions were added to `release-policy.test.ts`.

## Acceptance criteria

| Criterion | Status |
|---|---|
| `ci.yml` defaults to `contents: read` | Enforced by rule 5 + release-policy assertion |
| `publish` is the sole `contents: write` job | Enforced by rule 4 allowlist + release-policy assertion |
| Non-publish write fails with a clear workflow/job/path diagnostic | Enforced; diagnostics carry workflow, job, path, actual, expected |
| `dev-ci.yml` least-privilege default, verified not assumed | Audited, then codified |
| Mutation: default → write fails | Proven |
| Mutation: non-publish job write fails | Proven |
| Release-policy tests + affected routing select the regression | Both planners schedule both suites |
| Scope limited to #3139 | Exactly 6 files |

## Verification

Live mutation proofs against the real files (tree reverted clean after each):

```
ci.yml default -> write      .github/workflows/ci.yml: permissions.contents = "write" (expected "read")
dev-ci default -> write      .github/workflows/dev-ci.yml: permissions.contents = "write" (expected "read")
non-publish job -> write     .github/workflows/ci.yml: job "check": jobs.check.permissions.contents = "write"
                             (expected "read" or "none"; only job "publish" in .github/workflows/ci.yml may hold contents: write)
extra read scope             .github/workflows/dev-ci.yml: permissions.actions = "read"
                             (expected <absent>; required workflows declare exactly contents: read)
clean tree                   exit 0
```

- `bun test` across the 4 relevant suites: **110 pass / 0 fail / 758 expect()**
- `bun run check:tools` (biome + tsc): clean
- `bun scripts/check-workflow-yaml.ts`, `bun scripts/ci-dev-affected.ts --dry-run`: exit 0

Planned via ralplan consensus (Planner → Architect → Critic), then executed under ultragoal with parallel executor slices. Three read-only architect review passes raised 7 blocking findings total, all fixed and re-verified; the final pass returned Architecture/Product/Code **CLEAR**, **APPROVE**, zero blockers. An independent red-team lane probed 33 adversarial cases — `write-all` at both levels, non-`contents` write scopes, allowlist scope/workflow specificity, a `dev-ci` job renamed to `publish`, YAML anchors and merge keys, case/type variants, unpoliced new workflow files, malformed shapes, and crash/totality probes — with **zero bypasses and zero crashes**.

**Do not merge.** Awaiting exact-head CI and terminal adversarial review.

Refs #3139

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
