### PR TITLE
fix(sdk): join completed-start controller teardown before shutdown returns

### DIFF
--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -5173,9 +5173,21 @@ export function createNotificationsExtension(
 		const id = sessionId(ctx);
 		const rt = runtimes.get(id);
 		if (rt) terminalizeInFlightTools(rt, id, "unknown");
+		// Startup is only genuinely in flight when a `sessionStartPromises` entry
+		// exists. Once startup has settled, the host is broker-visible and its
+		// post-start `reconcileCurrentSession` may already have minted a
+		// replacement notification-root token whose unregister is still awaiting
+		// its file lock and atomic registry write. Returning before that settles
+		// leaves a stale `sessions[id]` row that the retained older token is
+		// correctly fenced from removing, so shutdown must join it.
+		const startupWasPending = sessionStartPromises.has(id);
 		const controllerStop =
 			typeof ctx.sessionManager.getCwd === "function" ? controller.stopCurrentSession(ctx) : Promise.resolve(false);
-		void controllerStop.catch(error => logger.warn(`notifications: controller shutdown failed: ${String(error)}`));
+		const settledControllerStop = controllerStop.catch(error => {
+			logger.warn(`notifications: controller shutdown failed: ${String(error)}`);
+			return false;
+		});
+		if (startupWasPending) void settledControllerStop;
 		try {
 			await stopSession(id);
 		} catch (error) {
@@ -5186,5 +5198,10 @@ export function createNotificationsExtension(
 			// error severity (matching the postmortem cleanup precedent).
 			logger.error(`notifications: SDK notification runtime cleanup failed: ${String(error)}`);
 		}
+		// Keep shutdown nonblocking only while native startup is genuinely
+		// pending (the `/notify on` path); otherwise await the controller queue so
+		// completed-start reconciliation and its replacement-token cleanup are
+		// joined before lifecycle shutdown returns.
+		if (!startupWasPending) await settledControllerStop;
 	});
 }


### PR DESCRIPTION
## The bug

`session_shutdown` starts `controller.stopCurrentSession(ctx)` but **discards the promise**, awaiting only `stopSession(id)`:

```ts
const controllerStop = ... controller.stopCurrentSession(ctx) ...;
void controllerStop.catch(...);   // fire-and-forget
await stopSession(id);            // returns without joining the above
```

Once startup has settled, the host is broker-visible and can accept `session.close` while the startup handler's post-start `reconcileCurrentSession` is still running. That reconciliation can mint a **replacement** notification-root token, and `ensureTelegramDaemon` then unregisters it asynchronously.

So shutdown could return — and disposal exit — **before that unregister's file lock and atomic registry write settled**, leaving a stale `sessions[id]` row. The retained older token cannot clean it up afterwards, because `unregisterNotificationRoot` correctly fences token mismatches by design.

## The fix

Snapshot `sessionStartPromises.has(id)` first, then await the settled controller stop after `stopSession` **whenever startup was not pending** — joining completed-start reconciliation and its replacement-token cleanup.

The intentional nonblocking behavior is preserved exactly where it matters: a genuinely pending startup entry (the `/notify on` path) still leaves the controller stop fire-and-forget.

## How it surfaced

The flaky-CI stabilization soak. The regression test `Telegram root release failure is retained and retried through lifecycle shutdown` failed **deterministically on darwin-arm64** at dev head while Linux CI stayed green ([run 30147146988](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30147146988), 34/34 shards).

This is a **completion-ordering divergence, not a path problem**. Both the registry path and the notification-root path are lexical `path.join` with no `realpath` or case folding, so `/var` vs `/private/var` and case-insensitive APFS do not explain it. On Darwin the native host/server teardown simply completes before the background replacement-token unregister finishes its lock acquisition and atomic write; Linux happened to win that race the other way.

I initially misdiagnosed this twice — first as a dev regression from #3048, then as a Darwin path quirk. It is neither: it is a real product race that Darwin's scheduling exposes reliably and Linux's hides.

## Verification (darwin-arm64)

- Previously-failing test: **10/10 pass** (was failing every run)
- Whole `sdk-host-wiring.test.ts`: **72/72** — first fully green run of this file on Darwin this session
- `notifications-telegram-daemon` + `notifications-telegram-btw-e2e`: **463/463**
- `bun run check:types` clean, biome clean

The assertion was **kept intact** rather than replaced with polling, which would have hidden the lifecycle-return bug rather than fixing it.

## Unrelated known failure

`sdk-broker.test.ts > preserves typed verified-delete partial-cleanup evidence` fails on Darwin both with and without this change (verified by stashing the fix), so it is pre-existing and out of scope here.
