### PR TITLE
test(sdk): scope startup-failure spies to the test's own first call

### DIFF
--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -671,10 +671,36 @@ test("session_start swallows startup plus owner-release failure without surfacin
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-startup-cleanup-double-failure-"));
 	dirs.push(cwd);
 	const sessionId = `startup-cleanup-double-failure-${Date.now()}`;
-	const serverStart = spyOn(NotificationServer.prototype, "start").mockRejectedValueOnce(
-		new Error("server start failed"),
-	);
-	const hostStop = spyOn(SessionSdkHost.prototype, "stop").mockRejectedValueOnce(new Error("host stop failed"));
+	// `mockRejectedValueOnce` on a shared prototype is a one-shot global: a peer
+	// test scheduled concurrently in the same shard can consume the single
+	// rejection, after which this test's own `start`/`stop` resolve, startup
+	// never sets `suppressExtensionError`, and the error surfaces. Scope the
+	// rejection to this test's first call instead so shard composition cannot
+	// steal it.
+	let serverStartRejected = false;
+	const serverStartImpl = NotificationServer.prototype.start;
+	const serverStart = spyOn(NotificationServer.prototype, "start").mockImplementation(async function (
+		this: NotificationServer,
+		...args: Parameters<NotificationServer["start"]>
+	) {
+		if (!serverStartRejected) {
+			serverStartRejected = true;
+			throw new Error("server start failed");
+		}
+		return await serverStartImpl.apply(this, args);
+	});
+	let hostStopRejected = false;
+	const hostStopImpl = SessionSdkHost.prototype.stop;
+	const hostStop = spyOn(SessionSdkHost.prototype, "stop").mockImplementation(async function (
+		this: SessionSdkHost,
+		...args: Parameters<SessionSdkHost["stop"]>
+	) {
+		if (!hostStopRejected) {
+			hostStopRejected = true;
+			throw new Error("host stop failed");
+		}
+		return await hostStopImpl.apply(this, args);
+	});
 	const errorSpy = spyOn(logger, "error").mockImplementation(() => {});
 	let restored = false;
 	try {


### PR DESCRIPTION
## Caught by the soak

main-nontag rehearsal [run 30151115867](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30151115867) failed on shard 8:

```
(fail) session_start swallows startup plus owner-release failure
       without surfacing an extension error
expect(surfaced).toEqual([])   received 1 surfaced error:
  "notifications: SDK startup failed: server start failed"
```

## Root cause

The test armed `mockRejectedValueOnce` on **shared prototypes** — `NotificationServer.prototype.start` and `SessionSdkHost.prototype.stop`. That is a **one-shot global**: a peer test scheduled concurrently in the same shard can consume the single rejection first.

When that happens, this test's own `start()` resolves, so `startSession` never reaches the `stopSession` catch that sets `suppressExtensionError` ([`src/sdk/bus/index.ts:4407-4420`](https://github.com/Yeachan-Heo/gajae-code/blob/dev/packages/coding-agent/src/sdk/bus/index.ts#L4407-L4420)) — and the startup error surfaces through `session_start` instead of being swallowed.

**Three** separate tests in this file arm one-shot rejections on those same two prototypes. Every one of them restores correctly, so this is cross-test interference within a shard, *not* a missing restore. It only reproduces under specific shard compositions, which is why it appeared in the 16-shard main-nontag grouping and not in the 8-shard dev-ci runs.

## Fix

Replace both one-shots with per-test guarded implementations that reject only on **this test's first call**, then delegate to the real method. Shard composition can no longer steal the rejection.

Assertions are unchanged — including `expect(hostStop).toHaveBeenCalledTimes(2)`, which is exactly what makes the "first call rejects, second succeeds" semantics load-bearing.

## Verification (darwin-arm64)

- Targeted test: **10/10** reruns
- **6× concurrent whole-file runs: zero failures** (the interference scenario)
- Whole file: **72/72**
- `bun run check:types` clean, biome clean

## Context

This is the second flake the stabilization soak surfaced that the Phase 0 audit could not have found — it neither failed nor retried during the mined two-week window. Previously recorded as `OPEN` in the soak ledger because I could not reproduce it on Darwin; the shared-prototype analysis identified the mechanism without needing a Linux repro.
