### PR TITLE
perf(coding-agent): skip lock acquisition for already-completed tombstones (rebase of #3069)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `gjc resume` and delete no longer pay a durable (fsync-backed) lock acquisition for managed session tombstones that have nothing left to reconcile; a scope with many accumulated already-completed tombstones opens noticeably faster (#3067).
+
 ## [0.11.10] - 2026-07-25
 ### Changed
 

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -2798,6 +2798,7 @@ export async function reconcileManagedTombstones(
 		const tombstone = path.join(directory, name);
 		const targets = retiredTargets(scope, tombstone);
 		if (!targets) continue;
+		if (targets.every(target => cleanupCompleted(scope, tombstone, target))) continue;
 		let lock: ManagedStorageLock | undefined;
 		try {
 			lock = await acquireManagedLock(

--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -11,6 +11,7 @@ import {
 	prepareManagedSessionScopeForWrite,
 	resolveManagedScope,
 } from "../../src/session/internal/managed-session-scope";
+import * as managedSessionStorage from "../../src/session/internal/managed-session-storage";
 import {
 	MANAGED_ARTIFACT_MAX_FILES,
 	publishManagedFileNoReplace,
@@ -1287,6 +1288,66 @@ describe("managed session write protocol", () => {
 			expect(forStuck.kind).toBe("error");
 		} finally {
 			unlink.mockRestore();
+		}
+	});
+	it("skips durable lock acquisition when a tombstone's targets are already cleanup_completed", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const legacy = legacyDirectory(sessionsRoot, cwd);
+		const source = path.join(legacy, "already-done.jsonl");
+		await fs.mkdir(legacy, { recursive: true });
+		await fs.writeFile(source, transcript("already-done", cwd));
+		const listed = listManagedCandidates(scope);
+		if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing candidate");
+
+		await expect(deleteManagedSessionCandidate(scope, listed.owned[0])).resolves.toMatchObject({
+			kind: "deleted",
+		});
+
+		const restarted = resolveManagedScope({ cwd, agentDir: path.dirname(sessionsRoot), sessionsRoot });
+		if (restarted.kind !== "resolved") throw new Error(restarted.message);
+
+		const lock = vi.spyOn(managedSessionStorage, "acquireManagedLock");
+		try {
+			expect((await prepareManagedSessionScopeForWrite(restarted.scope)).kind).toBe("resolved");
+			expect(lock).not.toHaveBeenCalled();
+		} finally {
+			lock.mockRestore();
+		}
+	});
+	it("still acquires the lock when a completed cleanup receipt no longer binds its target identity", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const legacy = legacyDirectory(sessionsRoot, cwd);
+		const source = path.join(legacy, "tampered-receipt.jsonl");
+		await fs.mkdir(legacy, { recursive: true });
+		await fs.writeFile(source, transcript("tampered-receipt", cwd));
+		const listed = listManagedCandidates(scope);
+		if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing candidate");
+
+		await expect(deleteManagedSessionCandidate(scope, listed.owned[0])).resolves.toMatchObject({
+			kind: "deleted",
+		});
+
+		const tombstones = path.join(scope.directoryPath, ".gjc-managed-session-internal", "tombstones");
+		const completed = (await fs.readdir(tombstones)).filter(name => name.includes(".cleanup-completed-"));
+		expect(completed.length).toBeGreaterThan(0);
+		for (const name of completed) {
+			const receiptPath = path.join(tombstones, name);
+			const record = JSON.parse(await fs.readFile(receiptPath, "utf8")) as {
+				target: { identity: { sha256: string } };
+			};
+			record.target.identity.sha256 = "0".repeat(64);
+			await fs.writeFile(receiptPath, `${JSON.stringify(record)}\n`);
+		}
+
+		const restarted = resolveManagedScope({ cwd, agentDir: path.dirname(sessionsRoot), sessionsRoot });
+		if (restarted.kind !== "resolved") throw new Error(restarted.message);
+
+		const lock = vi.spyOn(managedSessionStorage, "acquireManagedLock");
+		try {
+			expect((await prepareManagedSessionScopeForWrite(restarted.scope)).kind).toBe("resolved");
+			expect(lock).toHaveBeenCalled();
+		} finally {
+			lock.mockRestore();
 		}
 	});
 	it("reconciles a crash-after-tombstone on a fresh scope without resurrecting the candidate", async () => {


### PR DESCRIPTION
Rebase of #3069 (exact head `2b58273861fc7466284bffdbe737651362cb5f43`) onto current `dev`.

`reconcileManagedTombstones` acquired a durable fsync-backed operation lock for every tombstone in the scope, including tombstones whose targets had already published a `cleanup_completed` receipt and therefore had nothing left to reconcile. Scopes that accumulate many completed tombstones paid that cost on every `gjc resume` and delete.

Skip the lock only when every target of the tombstone still satisfies the identity-bound `cleanupCompleted` predicate, which verifies schema version, state, scope digest, tombstone path, attempt, target path/sessionId/cwd, and the full identity tuple (dev, ino, size, mtimeNs, sha256). Any target that fails the predicate falls through to the existing locked reconciliation path unchanged, so this is never a blanket skip.

## Tests
- untouched completed receipts → zero lock acquisitions
- a completed receipt whose recorded target sha256 no longer matches → lock is still acquired (negative control; fails if the skip is made unconditional)

## Scope
Three files, additive only: the one-line guard, the two tests plus one import, and the CHANGELOG entry. No main/release branch mutation.

Closes #3067.
Supersedes #3069 (same author intent, same semantics, rebased after owner-direct approval of the product contract).

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*