### PR TITLE
feat(coding-agent): default preset selection to persistence

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `/model` preset selection now offers `Set as default` as the first action while retaining `Apply for this session`, custom preset rename, and delete actions.
+
 ### Fixed
 
 - `gjc resume` and delete no longer pay a durable (fsync-backed) lock acquisition for managed session tombstones that have nothing left to reconcile; a scope with many accumulated already-completed tombstones opens noticeably faster (#3067).

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -229,8 +229,8 @@ const PROFILE_ROLE_PREVIEW_ORDER: GjcModelAssignmentTargetId[] = [
 	"critic",
 	"architect",
 ];
-const PRESET_SCOPE_LABELS = ["Apply for this session", "Set as default"];
-const CUSTOM_PRESET_SCOPE_LABELS = ["Apply for this session", "Set as default", "Rename", "Delete"];
+const PRESET_SCOPE_LABELS = ["Set as default", "Apply for this session"];
+const CUSTOM_PRESET_SCOPE_LABELS = ["Set as default", "Apply for this session", "Rename", "Delete"];
 
 function isPrintableCharacter(keyData: string): boolean {
 	return keyData.length === 1 && keyData >= " " && keyData !== "\x7f";
@@ -1246,7 +1246,7 @@ export class ModelSelectorComponent extends Container {
 				);
 			}
 		} else {
-			this.#listContainer.addChild(new Text(theme.fg("muted", "  Press Enter to apply this preset"), 0, 0));
+			this.#listContainer.addChild(new Text(theme.fg("muted", "  Press Enter to choose an action"), 0, 0));
 		}
 	}
 
@@ -1655,7 +1655,7 @@ export class ModelSelectorComponent extends Container {
 			this.#onSelectCallback({
 				kind: "profile",
 				profileName: this.#previewProfileName,
-				setDefault: this.#presetScopeIndex === 1,
+				setDefault: this.#presetScopeIndex === 0,
 			});
 			return;
 		}

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -178,33 +178,64 @@ describe("model selector profile red-team", () => {
 		expect(rendered.match(/Profile Alpha/g) ?? []).toHaveLength(1);
 	});
 
-	test("profile actions wire Apply for this session to persistDefault false and Set as default to true", async () => {
+	test("profile actions default to persistence and retain session-only application", async () => {
 		const selections: ModelSelectorSelection[] = [];
-		const applySelector = createSelector(selection => {
+		const select = (selection: ModelSelectorSelection) => {
 			selections.push(selection);
-		});
-		await renderSelector(applySelector);
-		applySelector.handleInput("\x1b[C");
-		applySelector.handleInput("\x1b[B");
-		applySelector.handleInput("\n");
-		applySelector.handleInput("\n");
-		applySelector.handleInput("\n");
+		};
+		const persistentSelector = createSelector(select);
+		await renderSelector(persistentSelector);
+		persistentSelector.handleInput("\x1b[C");
+		persistentSelector.handleInput("\x1b[B");
+		persistentSelector.handleInput("\n");
+		persistentSelector.handleInput("\n");
 
-		const defaultSelector = createSelector(selection => {
-			selections.push(selection);
-		});
-		await renderSelector(defaultSelector);
-		defaultSelector.handleInput("\x1b[C");
-		defaultSelector.handleInput("\x1b[B");
-		defaultSelector.handleInput("\n");
-		defaultSelector.handleInput("\n");
-		defaultSelector.handleInput("\x1b[B");
-		defaultSelector.handleInput("\n");
+		const menu = normalizeRenderedText(persistentSelector.render(240).join("\n"));
+		expect(menu).toContain("Set as default");
+		expect(menu).toContain("Apply for this session");
+		persistentSelector.handleInput("\n");
+
+		const sessionSelector = createSelector(select);
+		await renderSelector(sessionSelector);
+		sessionSelector.handleInput("\x1b[C");
+		sessionSelector.handleInput("\x1b[B");
+		sessionSelector.handleInput("\n");
+		sessionSelector.handleInput("\n");
+		sessionSelector.handleInput("\x1b[B");
+		sessionSelector.handleInput("\n");
 
 		expect(selections).toEqual([
-			{ kind: "profile", profileName: "profile-a", setDefault: false },
 			{ kind: "profile", profileName: "profile-a", setDefault: true },
+			{ kind: "profile", profileName: "profile-a", setDefault: false },
 		]);
+	});
+
+	test("custom profile action indices retain rename and delete", async () => {
+		const renamed: ModelSelectorSelection[] = [];
+		const renameSelector = createSelector(selection => {
+			renamed.push(selection);
+		});
+		await renderSelector(renameSelector);
+		renameSelector.refreshPresetProfiles("profile-a");
+		renameSelector.handleInput("\n");
+		renameSelector.handleInput("\x1b[B");
+		renameSelector.handleInput("\x1b[B");
+		renameSelector.handleInput("\n");
+
+		const deleted: ModelSelectorSelection[] = [];
+		const deleteSelector = createSelector(selection => {
+			deleted.push(selection);
+		});
+		await renderSelector(deleteSelector);
+		deleteSelector.refreshPresetProfiles("profile-a");
+		deleteSelector.handleInput("\n");
+		deleteSelector.handleInput("\x1b[B");
+		deleteSelector.handleInput("\x1b[B");
+		deleteSelector.handleInput("\x1b[B");
+		deleteSelector.handleInput("\n");
+
+		expect(renamed).toEqual([{ kind: "renameProfile", profileName: "profile-a" }]);
+		expect(deleted).toEqual([{ kind: "deleteProfile", profileName: "profile-a" }]);
 	});
 
 	test("controller persists only Set as default and leaves Apply for this session non-default", async () => {


### PR DESCRIPTION
## Summary

This is a clean current-`dev` successor to closed PR #2302 and the empty resubmission #3142.

- place **Set as default** first in the preset action menu
- retain **Apply for this session** as the second, non-persistent action
- preserve custom preset **Rename** and **Delete** positions
- change the prompt copy from “apply this preset” to “choose an action”
- add only a new `Unreleased > Changed` entry; no released changelog history is moved

## Closed-review feedback addressed

The final blocker on #2302 was unrelated changelog scope drift. This successor is rebuilt from current upstream `dev` and changes exactly three files. It does not move or rewrite any released entry.

Session-only activation remains available and continues to emit `setDefault: false`; the first action emits `setDefault: true`. Custom-profile rename and delete remain reachable at their existing semantic positions.

## Verification

Verified at exact head `b1684ff5832201d47cfbe1a481045f37cdd1dadf`, one commit ahead of current `dev` `baa4dc76b585e2ff952e71202dd59b1229d33af3`:

- focused preset/controller/CLI suites: **78 passed, 0 failed**
- `bun --cwd=packages/coding-agent run check`
- Biome and TypeScript package checks passed
- native addon built before the selector suites

No contributor merge is requested or authorized; owner product confirmation remains authoritative.