### PR TITLE
fix(coding-agent): cap legacy auto-compaction Retry-After at retry.maxDelayMs

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -341,6 +341,7 @@ import {
 import {
 	type ConfiguredFallbackChain,
 	cappedExponentialWithFullJitter,
+	compactionRetryDelay,
 	effectiveFallbackDelay,
 	FallbackChainController,
 } from "./fallback-chain-controller";
@@ -12504,8 +12505,14 @@ export class AgentSession {
 								break;
 							}
 
-							const baseDelayMs = retrySettings.baseDelayMs * 2 ** attempt;
-							const delayMs = retryAfterMs !== undefined ? Math.max(baseDelayMs, retryAfterMs) : baseDelayMs;
+							// Legacy parsed Retry-After is capped at retry.maxDelayMs (see
+							// compactionRetryDelay); only managed fallback is uncapped.
+							const delayMs = compactionRetryDelay(
+								retrySettings.baseDelayMs,
+								retrySettings.maxDelayMs,
+								attempt,
+								retryAfterMs,
+							);
 
 							// If retry delay is too long (>30s), try next candidate instead of waiting
 							const maxAcceptableDelayMs = 30_000;

--- a/packages/coding-agent/src/session/fallback-chain-controller.ts
+++ b/packages/coding-agent/src/session/fallback-chain-controller.ts
@@ -186,6 +186,33 @@ export function cappedExponentialWithFullJitter(
 	return Math.floor(Math.max(0, cap) * Math.max(0, Math.min(1, random())));
 }
 
+/**
+ * Legacy auto-compaction retry delay.
+ *
+ * Deliberately the mirror image of `effectiveFallbackDelay`: this path recovers
+ * Retry-After by regex over provider error prose (`#parseRetryAfterMsFromError`),
+ * so it follows the documented legacy rule — `retry.maxDelayMs` caps every
+ * legacy session retry delay, including provider retry-after hints. Managed
+ * fallback stays uncapped because it retries within its own per-entry budget;
+ * compaction has no such budget, so the final candidate would otherwise sleep
+ * for the full server-suggested duration.
+ *
+ * `maxDelayMs <= 0` means "no cap", matching `cappedExponentialWithFullJitter`.
+ * A missing, NaN, or infinite hint collapses to "no usable hint".
+ */
+export function compactionRetryDelay(
+	baseDelayMs: number,
+	maxDelayMs: number,
+	attempt: number,
+	retryAfterMs: number | undefined,
+): number {
+	const exponential = baseDelayMs * 2 ** Math.max(0, attempt);
+	const hint = Number.isFinite(retryAfterMs) ? Math.max(0, retryAfterMs as number) : 0;
+	const hinted = Math.max(exponential, hint);
+	const bounded = maxDelayMs > 0 ? Math.min(hinted, maxDelayMs) : hinted;
+	return Math.max(0, bounded);
+}
+
 /** Retry-After is intentionally uncapped. */
 export function effectiveFallbackDelay(
 	baseDelayMs: number,

--- a/packages/coding-agent/test/routing-adversarial.test.ts
+++ b/packages/coding-agent/test/routing-adversarial.test.ts
@@ -93,6 +93,42 @@ describe("routing adversarial contract probes", () => {
 		expect(compactionRetryDelay(2_000, 0, 0, 45_000)).toBe(45_000);
 	});
 
+	// Both legacy surfaces recover Retry-After from prose, so the documented rule
+	// ("retry.maxDelayMs caps every legacy session retry delay, including provider
+	// retry-after hints") must bind them identically. This pins the two together so
+	// a future change to one cannot silently drift from the other.
+	test("legacy compaction agrees with the legacy non-compaction retry-after cap", () => {
+		const maxDelayMs = 300_000;
+		const baseDelayMs = 2_000;
+		for (const hint of [1_000, 45_000, 299_999, 300_000, 300_001, THREE_HOURS_MS]) {
+			// agent-session.ts, legacy non-compaction path: Math.min(retryAfterMs, maxDelayMs)
+			const legacyNonCompaction = Math.min(hint, maxDelayMs);
+			const compaction = compactionRetryDelay(baseDelayMs, maxDelayMs, 0, hint);
+			expect(compaction).toBeLessThanOrEqual(maxDelayMs);
+			// Compaction may floor at its exponential, but never exceeds the legacy bound.
+			expect(compaction).toBeLessThanOrEqual(Math.max(legacyNonCompaction, baseDelayMs));
+		}
+	});
+
+	test("compaction retry delay invariant holds across the whole parameter grid", () => {
+		const hints = [undefined, 0, 1_000, THREE_HOURS_MS, Number.NaN, Number.POSITIVE_INFINITY, -1];
+		let checked = 0;
+		for (const baseDelayMs of [0, 1, 500, 2_000, 60_000]) {
+			for (const maxDelayMs of [0, 1_000, 30_000, 300_000]) {
+				for (const attempt of [0, 1, 3, 10, 30]) {
+					for (const hint of hints) {
+						const delay = compactionRetryDelay(baseDelayMs, maxDelayMs, attempt, hint);
+						expect(Number.isFinite(delay)).toBe(true);
+						expect(delay).toBeGreaterThanOrEqual(0);
+						if (maxDelayMs > 0) expect(delay).toBeLessThanOrEqual(maxDelayMs);
+						checked++;
+					}
+				}
+			}
+		}
+		expect(checked).toBe(700);
+	});
+
 	test("tries a rotated Fable credential once before falling back to Opus", () => {
 		const fable = "anthropic/claude-fable-5:high";
 		const opus = "anthropic/claude-opus-5:high";

--- a/packages/coding-agent/test/routing-adversarial.test.ts
+++ b/packages/coding-agent/test/routing-adversarial.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@gajae-code/coding-agent/session/cache-economics";
 import {
 	cappedExponentialWithFullJitter,
+	compactionRetryDelay,
 	effectiveFallbackDelay,
 	FallbackChainController,
 } from "@gajae-code/coding-agent/session/fallback-chain-controller";
@@ -58,6 +59,38 @@ describe("routing adversarial contract probes", () => {
 		expect(cappedExponentialWithFullJitter(100, 1_000, 10, () => 1)).toBe(1_000);
 		expect(Math.min(THREE_HOURS_MS, 1_000)).toBe(1_000);
 		expect(effectiveFallbackDelay(100, 1_000, 1, THREE_HOURS_MS, () => 1)).toBe(THREE_HOURS_MS);
+	});
+
+	// Mirror image of the contract above: auto-compaction recovers Retry-After by
+	// regex over provider error prose, so it is legacy and MUST stay capped.
+	// Managed fallback is uncapped only because it retries within its own
+	// per-entry budget; compaction has no such budget.
+	test("caps legacy compaction retry-after at retry.maxDelayMs", () => {
+		// A hostile/misconfigured provider asking for 3h cannot outrun the cap.
+		expect(compactionRetryDelay(100, 1_000, 0, THREE_HOURS_MS)).toBe(1_000);
+		// Same hint, managed fallback path: still honoured verbatim.
+		expect(effectiveFallbackDelay(100, 1_000, 1, THREE_HOURS_MS, () => 1)).toBe(THREE_HOURS_MS);
+	});
+
+	test("compaction retry delay honours hints below the cap and keeps exponential growth", () => {
+		// No hint → plain exponential (base * 2**attempt), unchanged behaviour.
+		expect(compactionRetryDelay(2_000, 300_000, 0, undefined)).toBe(2_000);
+		expect(compactionRetryDelay(2_000, 300_000, 3, undefined)).toBe(16_000);
+		// Hint below the cap wins over the exponential, exactly as before.
+		expect(compactionRetryDelay(2_000, 300_000, 0, 45_000)).toBe(45_000);
+		// Hint smaller than the exponential never shortens the backoff.
+		expect(compactionRetryDelay(2_000, 300_000, 3, 1_000)).toBe(16_000);
+	});
+
+	test("compaction retry delay never yields a negative, NaN, or infinite sleep", () => {
+		for (const hint of [undefined, Number.NaN, Number.POSITIVE_INFINITY, -5_000]) {
+			const delay = compactionRetryDelay(2_000, 300_000, 0, hint);
+			expect(Number.isFinite(delay)).toBe(true);
+			expect(delay).toBeGreaterThanOrEqual(0);
+			expect(delay).toBeLessThanOrEqual(300_000);
+		}
+		// maxDelayMs <= 0 means "no cap", matching cappedExponentialWithFullJitter.
+		expect(compactionRetryDelay(2_000, 0, 0, 45_000)).toBe(45_000);
 	});
 
 	test("tries a rotated Fable credential once before falling back to Opus", () => {


### PR DESCRIPTION
Successor to #3134 (external head `4e36ae50cc1a5f79c4238c6fc69e1b66d0d7fee6`), rebased onto current dev.

#3134 was durable MERGE_READY but became merge-dirty after sequential merges (#3132, #3135). This PR preserves its semantics verbatim on top of dev. The contributor branch was not mutated.

## What it does

Legacy auto-compaction recovered `Retry-After` by regex over provider error prose and then slept for the full server-suggested duration:

```ts
const baseDelayMs = retrySettings.baseDelayMs * 2 ** attempt;
const delayMs = retryAfterMs !== undefined ? Math.max(baseDelayMs, retryAfterMs) : baseDelayMs;
```

Every other legacy session retry path caps that hint at `retry.maxDelayMs` — `#handleRetryableError` uses `Math.min(retryAfterMs, retrySettings.maxDelayMs)`. Only *managed* fallback is intentionally uncapped, because it retries within its own per-entry budget. Compaction has no such budget, so a hostile or misconfigured provider asking for 3h could stall the final candidate.

This routes compaction through a new `compactionRetryDelay()` helper that applies the documented legacy rule, so the two legacy surfaces agree.

## Rebase notes

- Both production hunks (`agent-session.ts`, `fallback-chain-controller.ts`) auto-merged cleanly. Dev's #3070 changes to `FallbackChainController` are confined to the class body and do not touch the delay helpers.
- The only conflicts were in `routing-adversarial.test.ts`, both purely positional: dev renamed `"charges rotated-entry retries against the chain-wide attempt budget"` to `"tries a rotated Fable credential once before falling back to Opus"` (adding `fable`/`opus` locals), while #3134 inserted new tests immediately above it. Resolved by keeping the new tests and dev's renamed test intact.
- Net diff against dev is byte-identical in shape to the original PR: 3 files, +105/-2.

## Verification

- `routing-adversarial.test.ts` — 11 pass (dev's rotation tests + 5 new cap tests, 2001 assertions)
- retry suites (`agent-session-retry-cap`, `retry-budget-settings`, `agent-session-resilient-retry`, `agent-session-fallback-attempt-accounting`, `settings-retry-fallback-migration`) — 70 pass
- compaction suites (`compaction`, `agent-session-compaction`, `agent-session-midrun-compaction`, `issue-986-compaction-auth-fallback`, `issue-697-compaction-provider-route`, `agent-session-retry-fallback`, `agent-session-manual-retry`) — 77 pass, 7 skip
- `bun --cwd=packages/coding-agent run check` (biome + tsc) — clean

Credit to @dmae97 for the original fix; commit authorship is preserved.
