### PR TITLE
fix(coding-agent): align welcome and composer gutters

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Aligned the startup GJC Forge splash border with the composer trailing gutter, including the one-row constrained fallback.
 - `gjc resume` and delete no longer pay a durable (fsync-backed) lock acquisition for managed session tombstones that have nothing left to reconcile; a scope with many accumulated already-completed tombstones opens noticeably faster (#3067).
 
 ## [0.11.10] - 2026-07-25

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -20,6 +20,7 @@ export interface WelcomeComponentOptions {
 	getViewportRows?: () => number | undefined;
 	getReservedBottomRows?: (termWidth: number) => number;
 	changelogMarkdown?: string;
+	rightGutterWidth?: number;
 	collapseChangelog?: boolean;
 	buildLabel?: string;
 	keyDisplayContext?: KeyDisplayContext;
@@ -110,7 +111,8 @@ export class WelcomeComponent implements Component {
 	}
 
 	render(termWidth: number): string[] {
-		const boxWidth = Math.max(0, termWidth);
+		const rightGutterWidth = this.#rightGutterWidth(termWidth);
+		const boxWidth = Math.max(0, termWidth - rightGutterWidth);
 		if (boxWidth < 4) {
 			return [];
 		}
@@ -245,7 +247,7 @@ export class WelcomeComponent implements Component {
 			lines.push(tl + titleStyled + theme.fg("dim", hChar.repeat(afterTitle)) + tr);
 		}
 		if (outputRows === 1) {
-			return lines;
+			return this.#withRightGutter(lines, rightGutterWidth);
 		}
 
 		if (showRightColumn) {
@@ -273,7 +275,7 @@ export class WelcomeComponent implements Component {
 			lines.push(bl + h.repeat(leftCol) + br);
 		}
 
-		return lines;
+		return this.#withRightGutter(lines, rightGutterWidth);
 	}
 
 	/** Center text within a given width */
@@ -295,6 +297,19 @@ export class WelcomeComponent implements Component {
 		}
 		return str + padding(width - visLen);
 	}
+	#rightGutterWidth(termWidth: number): number {
+		const configured = this.options.rightGutterWidth ?? 0;
+		if (!Number.isFinite(configured) || configured <= 0) return 0;
+		const gutterWidth = Math.floor(configured);
+		return Math.min(gutterWidth, Math.max(0, termWidth - 4));
+	}
+
+	#withRightGutter(lines: string[], rightGutterWidth: number): string[] {
+		if (rightGutterWidth <= 0) return lines;
+		const gutter = padding(rightGutterWidth);
+		return lines.map(line => line + gutter);
+	}
+
 	#targetRows(termWidth: number): number | undefined {
 		const viewportRows = this.options.getViewportRows?.();
 		if (typeof viewportRows !== "number" || !Number.isFinite(viewportRows) || viewportRows <= 0) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -168,6 +168,7 @@ export function getComposerPlaceholder(
 	return buildComposerPlaceholder(keybindings, context, options);
 }
 const WELCOME_RESERVED_CONTAINER_CHILD_LIMIT = 8;
+const COMPOSER_RIGHT_GUTTER_WIDTH = 1;
 
 const IRC_SIDEBAR_TOGGLE_SHADOWING_ACTIONS: readonly AppKeybinding[] = [
 	"app.plan.toggle",
@@ -214,7 +215,7 @@ function configureDefaultComposerChrome(editor: CustomEditor): void {
 	editor.setInputPrefix(getDefaultInputPrefix());
 	editor.setPlaceholder(getDefaultComposerPlaceholder());
 	editor.setPaddingX(1);
-	editor.setRightGutterWidth(1);
+	editor.setRightGutterWidth(COMPOSER_RIGHT_GUTTER_WIDTH);
 	editor.setTopBorder(undefined);
 }
 
@@ -713,6 +714,7 @@ export class InteractiveMode implements InteractiveModeContext {
 					getViewportRows: () => this.ui.terminal.rows,
 					getReservedBottomRows: getWelcomeReservedBottomRows,
 					changelogMarkdown: this.#changelogMarkdown,
+					rightGutterWidth: COMPOSER_RIGHT_GUTTER_WIDTH,
 					collapseChangelog: settings.get("collapseChangelog"),
 					keyDisplayContext: this.#keyDisplayContext,
 				},

--- a/packages/coding-agent/test/welcome-viewport.test.ts
+++ b/packages/coding-agent/test/welcome-viewport.test.ts
@@ -76,6 +76,28 @@ describe("WelcomeComponent viewport sizing", () => {
 		}
 	});
 
+	it("reserves the composer gutter for normal and one-row welcome layouts", () => {
+		const normal = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii", {
+			rightGutterWidth: 1,
+		});
+		for (const line of normal.render(100).map(stripRenderControls)) {
+			expect(visibleWidth(line)).toBe(100);
+			expect(line.endsWith(" ")).toBe(true);
+			expect(visibleWidth(line.trimEnd())).toBe(99);
+		}
+
+		const constrained = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii", {
+			rightGutterWidth: 1,
+			getViewportRows: () => 1,
+			getReservedBottomRows: () => 0,
+		});
+		const lines = constrained.render(100).map(stripRenderControls);
+		expect(lines).toHaveLength(1);
+		expect(visibleWidth(lines[0]!)).toBe(100);
+		expect(lines[0]!.endsWith(" ")).toBe(true);
+		expect(visibleWidth(lines[0]!.trimEnd())).toBe(99);
+	});
+
 	it("renders the build label from metadata instead of defaulting to dev", () => {
 		const welcome = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii", {
 			buildLabel: "release build",


### PR DESCRIPTION
## Summary

This is a clean current-`dev` successor to closed PR #1862.

- reserve the same one-column trailing gutter for the startup welcome splash that the composer already uses
- share the composer gutter constant with `WelcomeComponent`
- apply the gutter to both the normal welcome layout and the constrained one-row fallback
- add a direct one-row regression so the original review blocker cannot recur

## Closed-review feedback addressed

The final review on #1862 found that `outputRows === 1` returned the top border before `#withRightGutter()` was applied. This successor explicitly routes that early return through the same gutter helper as the normal path.

## Verification

Verified at exact head `de7d3b958874754a41396005f7e368eb84c42189`, exactly one commit and four files ahead of current `dev` `baa4dc76b585e2ff952e71202dd59b1229d33af3`:

- `welcome-viewport.test.ts`: **17 passed, 0 failed**
- focused `interactive-mode-editor-component.test.ts`: **5 passed, 0 failed**
- `bun --cwd=packages/coding-agent run check`
- Biome and TypeScript checks passed
- native addon built before integration tests

No contributor merge is requested or authorized; owner review remains authoritative.