### PR TITLE
test(coding-agent): fix sdk-daemon-cli e2e EBADF teardown after #3076

### DIFF
--- a/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
@@ -12,6 +12,17 @@ type CliResult = { exitCode: number; stdout: string; stderr: string };
 // Capture through files rather than pipes: a piped child that outlives the
 // parent's read teardown can be killed by SIGPIPE (exit 141) under CI load,
 // which masks the CLI's real exit contract.
+function closeCaptureFd(fd: number): void {
+	// Bun.spawn may close inherited capture FDs when a short-lived child exits,
+	// especially on fail-closed CLI paths. Ignore EBADF so teardown does not
+	// mask the CLI exit contract under CI load (see shard-6 post-#3076 red).
+	try {
+		closeSync(fd);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException | undefined)?.code !== "EBADF") throw error;
+	}
+}
+
 async function runCli(repo: string, agentDir: string, args: string[]): Promise<CliResult> {
 	const captureDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-sdk-cli-capture-"));
 	const stdoutPath = path.join(captureDir, "stdout");
@@ -26,14 +37,18 @@ async function runCli(repo: string, agentDir: string, args: string[]): Promise<C
 			stderr: stderrFd,
 		});
 		const exitCode = await child.exited;
+		// Close before reading so file contents are durable even if Bun still
+		// held a write handle; tolerate already-closed FDs from the child.
+		closeCaptureFd(stdoutFd);
+		closeCaptureFd(stderrFd);
 		return {
 			exitCode,
 			stdout: await fs.readFile(stdoutPath, "utf8"),
 			stderr: await fs.readFile(stderrPath, "utf8"),
 		};
 	} finally {
-		closeSync(stdoutFd);
-		closeSync(stderrFd);
+		closeCaptureFd(stdoutFd);
+		closeCaptureFd(stderrFd);
 		await fs.rm(captureDir, { recursive: true, force: true });
 	}
 }


### PR DESCRIPTION
## Summary
- Terminal red on `dev` after #3076: `Affected path validation / test:@gajae-code/coding-agent:shard-6-of-8`
- Failed case: `SDK daemon session CLI > requires a caller lifecycle idempotency key before broker connection`
- CI root cause was **not** the lifecycle idempotency product contract. Log shows:
  - `EBADF: bad file descriptor, close` at `runCli` finally `closeSync(stdoutFd)`
  - run: https://github.com/Yeachan-Heo/gajae-code/actions/runs/30163803981
- Bun.spawn can close inherited capture FDs when a short-lived fail-closed CLI exits; unconditional parent `closeSync` then throws and masks the intended exit-2 / `invalid_input` assertion.

## Fix
- Close capture FDs via a helper that ignores `EBADF`
- Close once after child exit before reading capture files, and again in `finally` for safety
- Product contract unchanged: lifecycle global ops still require `--idempotency-key` and fail closed before broker connection

## Verification
- Root-caused from failed job log `89693881988` (shard-6-of-8): exact stack at test line 35 / 199
- Local full e2e blocked on host native sentinel mismatch (`@gajae-code/natives@0.11.10`); fix is harness-only and matches CI failure surface
- Please re-run coding-agent shard-6 / full affected path validation on this PR

## Non-goals
- No product path change in session CLI / broker lifecycle validation
- No main/release touch

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*