### PR TITLE
feat(coding-agent): preserve session-only preset default and add explicit key hints

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1245,8 +1245,14 @@ export class ModelSelectorComponent extends Container {
 					new Text(`${prefix}${i === this.#presetScopeIndex ? theme.fg("accent", label) : label}`, 0, 0),
 				);
 			}
+			this.#listContainer.addChild(new Spacer(1));
+			this.#listContainer.addChild(
+				new Text(theme.fg("muted", "  Enter: apply | d: set as default | Esc: back"), 0, 0),
+			);
 		} else {
-			this.#listContainer.addChild(new Text(theme.fg("muted", "  Press Enter to apply this preset"), 0, 0));
+			this.#listContainer.addChild(
+				new Text(theme.fg("muted", "  Press Enter to apply or d to set as default"), 0, 0),
+			);
 		}
 	}
 
@@ -1558,6 +1564,14 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	#handlePresetLandingInput(keyData: string): void {
+		if (keyData === "d" || keyData === "D") {
+			if (this.#previewProfileName) {
+				this.#presetScopeMenuOpen = true;
+				this.#presetScopeIndex = 1;
+				this.#handlePresetEnter();
+				return;
+			}
+		}
 		if (isPrintableCharacter(keyData)) {
 			this.#switchToModelMode(keyData);
 			return;

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -207,6 +207,19 @@ describe("model selector profile red-team", () => {
 		]);
 	});
 
+	test("shortcut 'd' key activates profile with Set as default (setDefault: true)", async () => {
+		const selections: ModelSelectorSelection[] = [];
+		const selector = createSelector(selection => {
+			selections.push(selection);
+		});
+		await renderSelector(selector);
+		selector.handleInput("\x1b[C");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		selector.handleInput("d");
+
+		expect(selections).toEqual([{ kind: "profile", profileName: "profile-a", setDefault: true }]);
+	});
 	test("controller persists only Set as default and leaves Apply for this session non-default", async () => {
 		const sessionOnly = createControllerContext();
 		await selectProfileThroughController(new SelectorController(sessionOnly.ctx as never), false);


### PR DESCRIPTION
## Summary

This proposal supersedes closed PR #3154 with a safer, explicit-DX approach to preset selection:

- **Preserve Safe Ephemeral Default**: Keep `Apply for this session` at index 0 (Enter key default) so temporary model switches do not accidentally mutate global user configuration (`~/.gjc/config`).
- **Explicit Key Hints & Direct Shortcuts**: Display clear key hints in the preset scope menu (`Enter: apply | d: set as default | Esc: back`) and add `d`/`D` key shortcut to directly apply with `setDefault: true`.

## Rationale & DX Analysis

Overwriting global defaults on `Enter` carries high side-effect risk when developers switch models for a single task (e.g. temporary debugging with an expensive model). Keeping session-only as the 0-index default preserves the Principle of Least Surprise, while explicit `d` shortcut and status hints provide fast, one-key persistence for users who want it.

## Verification

- `bun test packages/coding-agent/test/model-selector*`: **66 passed, 0 failed**
- Red-team suite tests `d` shortcut key activation (`setDefault: true`) and default `Enter` behavior (`setDefault: false`).