### PR TITLE
fix(deep-interview): unblock apply-round-result so interviews can score rounds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `gjc resume` and delete no longer pay a durable (fsync-backed) lock acquisition for managed session tombstones that have nothing left to reconcile; a scope with many accumulated already-completed tombstones opens noticeably faster (#3067).
+- `gjc deep-interview apply-round-result` no longer fails with `DI_INTERNAL_ERROR` on every call, which made the deep-interview workflow unable to score a single round. Three defects stacked: the Round-0 topology gate is recorded as a permanently unscorable `answered` shell (`--round` must be >= 1) yet counted toward the "earlier rounds must be scored" precondition, deadlocking every later round; the round-result decoder materializes omitted optional keys as `undefined`, which canonical JSON rejected outright, so any request omitting `targeting`/`ontology`/`bookkeeping` could not be digested; and `scoreToUnits` tested the raw float product, so ordinary scores whose scaling misses the integer grid (`0.69 * 10_000` is `6900.000000000001`) were rejected as non-integral 1e-4 units. Round-0 gate shells are now excluded from the ordering precondition, canonical JSON drops `undefined` object properties like `JSON.stringify` (array elements and the top-level value stay strict), and 1e-4 unit conversion is decided from the shortest round-trip decimal so genuinely off-grid precision such as `0.00005` and `0.05000000000000001` is still rejected.
 
 ## [0.11.10] - 2026-07-25
 ### Changed

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-ambiguity.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-ambiguity.ts
@@ -207,7 +207,21 @@ export function deriveAmbiguityMilestone(
 
 export function scoreToUnits(score: number): number {
 	if (!Number.isFinite(score) || score < 0 || score > 1) throw new RangeError("score must be finite in [0, 1]");
-	const units = score * 10_000;
+	/**
+	 * Scores carry at most four decimal places, but `score * 10_000` misses the
+	 * integer grid for ordinary values: `0.69 * 10_000` is `6900.000000000001` and
+	 * `0.07 * 10_000` is `700.0000000000001`. Ambiguity is fed straight back in as
+	 * `units / 10_000`, so testing the float product rejected most real scores.
+	 *
+	 * Decide from the shortest round-trip decimal instead. That is exact: every
+	 * genuine 1e-4 value has at most four fraction digits, while off-grid
+	 * precision keeps its digits (`0.00005`, `0.05000000000000001`) and is
+	 * rejected. An epsilon on the product cannot separate those two cases -- both
+	 * residuals are ~1e-13.
+	 */
+	const decimal = /^(\d+)(?:\.(\d{1,4}))?$/.exec(String(score));
+	if (!decimal) throw new RangeError("score must be expressed in integral 1e-4 units");
+	const units = Number(decimal[1]) * 10_000 + Number((decimal[2] ?? "").padEnd(4, "0"));
 	if (!Number.isSafeInteger(units)) throw new RangeError("score must be expressed in integral 1e-4 units");
 	return units;
 }

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-ambiguity.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-ambiguity.ts
@@ -217,12 +217,12 @@ export function scoreToUnits(score: number): number {
 	 * genuine 1e-4 value has at most four fraction digits, while off-grid
 	 * precision keeps its digits (`0.00005`, `0.05000000000000001`) and is
 	 * rejected. An epsilon on the product cannot separate those two cases -- both
-	 * residuals are ~1e-13.
+	 * residuals are ~1e-13. The `[0, 1]` guard plus the four-digit cap already
+	 * bound the result to an integer in `[0, 10_000]`.
 	 */
 	const decimal = /^(\d+)(?:\.(\d{1,4}))?$/.exec(String(score));
 	if (!decimal) throw new RangeError("score must be expressed in integral 1e-4 units");
 	const units = Number(decimal[1]) * 10_000 + Number((decimal[2] ?? "").padEnd(4, "0"));
-	if (!Number.isSafeInteger(units)) throw new RangeError("score must be expressed in integral 1e-4 units");
 	return units;
 }
 

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
@@ -1016,7 +1016,7 @@ export function deepInterviewAnswerIdentityEqual(
 			component: a.component ?? null,
 			dimension: a.dimension ?? null,
 			question_text: a.question_text ?? null,
-			question_hash: a.question_hash,
+			question_hash: a.question_hash ?? null,
 			selected_options: a.selected_options ?? [],
 			custom_input: a.custom_input ?? null,
 		}) ===
@@ -1028,7 +1028,7 @@ export function deepInterviewAnswerIdentityEqual(
 			component: b.component ?? null,
 			dimension: b.dimension ?? null,
 			question_text: b.question_text ?? null,
-			question_hash: b.question_hash,
+			question_hash: b.question_hash ?? null,
 			selected_options: b.selected_options ?? [],
 			custom_input: b.custom_input ?? null,
 		})
@@ -1076,15 +1076,17 @@ export function applyDeepInterviewRoundResultV1(
 	/**
 	 * Rounds must be scored in order, but the Round 0 topology gate is not a
 	 * scorable round: the recorder persists it as an `answered` shell to bind the
-	 * locked intent contract, and `apply-round-result` rejects `--round 0`
-	 * outright. Counting it here would deadlock every later round forever, so the
-	 * ordering precondition only covers real interview rounds (>= 1).
+	 * locked intent contract, `apply-round-result` rejects `--round 0`, and
+	 * `validateDeepInterviewV1Envelope` refuses to persist a round-0 record that
+	 * is anything other than an answered, score-less shell. Counting it here would
+	 * deadlock every later round forever, so the gate is excluded by identity
+	 * rather than by an ordering range.
 	 */
 	if (
 		rounds.some(
 			round =>
 				round.lifecycle !== "scored" &&
-				round.round >= 1 &&
+				round.round !== 0 &&
 				(round.round < shell.round || (round.round === shell.round && round.round_key < shell.round_key)),
 		)
 	)

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
@@ -937,8 +937,20 @@ function canonicalJsonValue(value: unknown): unknown {
 		if (value === undefined) throw new TypeError("canonical JSON rejects undefined");
 		return value;
 	}
+	/**
+	 * Object properties set to `undefined` are dropped, matching `JSON.stringify`:
+	 * an omitted optional key and a present-but-undefined one must digest
+	 * identically. Decoded requests routinely materialize every optional key (an
+	 * omitted `targeting` becomes `targeting: undefined`), so rejecting them here
+	 * would make every request carrying an absent optional field unserializable.
+	 * Array elements and the top-level value stay strict: `undefined` there is a
+	 * real encoding bug, not an absent field.
+	 */
 	const output: Record<string, unknown> = {};
-	for (const key of Object.keys(value).sort()) output[key] = canonicalJsonValue(value[key]);
+	for (const key of Object.keys(value).sort()) {
+		if (value[key] === undefined) continue;
+		output[key] = canonicalJsonValue(value[key]);
+	}
 	return output;
 }
 
@@ -1061,10 +1073,18 @@ export function applyDeepInterviewRoundResultV1(
 		typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
 	if (!dimensions.every(dimension => finiteScore(result.global_scores[dimension])))
 		throw new Error("DI_STATE_SCHEMA_INVALID");
+	/**
+	 * Rounds must be scored in order, but the Round 0 topology gate is not a
+	 * scorable round: the recorder persists it as an `answered` shell to bind the
+	 * locked intent contract, and `apply-round-result` rejects `--round 0`
+	 * outright. Counting it here would deadlock every later round forever, so the
+	 * ordering precondition only covers real interview rounds (>= 1).
+	 */
 	if (
 		rounds.some(
 			round =>
 				round.lifecycle !== "scored" &&
+				round.round >= 1 &&
 				(round.round < shell.round || (round.round === shell.round && round.round_key < shell.round_key)),
 		)
 	)

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-ambiguity.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-ambiguity.test.ts
@@ -353,19 +353,25 @@ describe("deep-interview v1 core contracts", () => {
 		// encoding bug, not an absent field.
 		expect(() => canonicalDeepInterviewJson([1, undefined])).toThrow("canonical JSON rejects undefined");
 		expect(() => canonicalDeepInterviewJson(undefined)).toThrow("canonical JSON rejects undefined");
+		// `null` must survive the collapse. If the skip predicate ever loosened to
+		// `!value[key]` or `== undefined`, null/0/""/false would fold into "absent"
+		// and silently change the meaning of every persisted round_result_digest.
+		expect(canonicalDeepInterviewJson({ a: null })).toBe('{"a":null}');
+		expect(canonicalDeepInterviewJson({ a: 0, b: "", c: false })).toBe('{"a":0,"b":"","c":false}');
 
 		// `0.69 * 10_000` is `6900.000000000001` in IEEE-754; ambiguity round-trips
-		// through `units / 10_000`, so these ordinary scores must convert cleanly
-		// while genuinely off-grid precision stays rejected.
-		expect(scoreToUnits(0.69)).toBe(6_900);
-		expect(scoreToUnits(0.07)).toBe(700);
-		expect(scoreToUnits(0.29)).toBe(2_900);
-		expect(scoreToUnits(0.0001)).toBe(1);
-		expect(scoreToUnits(0)).toBe(0);
-		expect(scoreToUnits(1)).toBe(10_000);
-		expect(() => scoreToUnits(0.00005)).toThrow("integral 1e-4 units");
-		expect(() => scoreToUnits(0.05000000000000001)).toThrow("integral 1e-4 units");
-		expect(() => scoreToUnits(1.5)).toThrow("finite in [0, 1]");
+		// through `units / 10_000`, so every value on the 1e-4 grid must convert
+		// exactly while genuinely off-grid precision stays rejected. The sweep is the
+		// real contract: spot checks alone cannot show which floats miss the grid.
+		const offGrid: number[] = [];
+		for (let units = 0; units <= 10_000; units += 1) if (scoreToUnits(units / 10_000) !== units) offGrid.push(units);
+		expect(offGrid).toEqual([]);
+		expect(scoreToUnits(-0)).toBe(0);
+		expect(scoreToUnits(0.9999)).toBe(9_999);
+		for (const rejected of [0.00005, 0.05000000000000001, 0.30000000000000004, 1e-7])
+			expect(() => scoreToUnits(rejected)).toThrow("integral 1e-4 units");
+		for (const rejected of [1.5, -0.1, Number.NaN, Number.POSITIVE_INFINITY])
+			expect(() => scoreToUnits(rejected)).toThrow("finite in [0, 1]");
 
 		const filePath = "/tmp/state.json";
 		const envelope = {
@@ -480,5 +486,64 @@ describe("deep-interview v1 core contracts", () => {
 				"2026-01-01T00:02:00.000Z",
 			),
 		).toThrow("DI_ROUND_RESULT_CONFLICT");
+
+		// The Round-0 gate is excluded from the "earlier rounds must be scored"
+		// precondition only because a round-0 record can never carry scoring. Pin
+		// that premise with a positive control and a negative case differing by
+		// exactly one field, so the assertion cannot pass for an unrelated reason: if
+		// the validator's round-0 rule is deleted, the scored fixture below becomes
+		// valid and this test goes red.
+		const gateShell = {
+			round: 0,
+			round_key: "r0",
+			question_id: "round0-topology",
+			question_text: "Confirm locked intent",
+			question_hash: "question",
+			answer_hash: "answer",
+			lifecycle: "answered",
+			answered_at: "2026-01-01T00:00:00.000Z",
+		};
+		const withRoundZero = (record: Record<string, unknown>): Record<string, unknown> => {
+			const candidate = structuredClone(applied.envelope) as Record<string, unknown>;
+			(candidate.state as { rounds: Record<string, unknown>[] }).rounds.unshift(record);
+			return candidate;
+		};
+		validateDeepInterviewV1Envelope(withRoundZero({ ...gateShell }));
+		expect(() =>
+			validateDeepInterviewV1Envelope(
+				withRoundZero({ ...gateShell, scores: { goal: 0.2, constraints: 0.3, criteria: 0.4 } }),
+			),
+		).toThrow("DI_STATE_SCHEMA_INVALID");
+		// The gate's `review-topology`/`topology` metadata is accepted only while the
+		// record stays a score-less shell, which is what keeps it unscorable.
+		validateDeepInterviewV1Envelope(
+			withRoundZero({ ...gateShell, component: "review-topology", dimension: "topology" }),
+		);
+	});
+
+	it("refuses to score the Round-0 topology gate through the repair CLI", async () => {
+		const cwd = await tempDir();
+		await seedRecorderState(cwd);
+		const rejected = await runDeepInterviewRepairCommand(
+			[
+				"apply-round-result",
+				"--session-id",
+				TEST_SESSION_ID,
+				"--schema-version",
+				"1",
+				"--expected-revision",
+				"1",
+				"--round",
+				"0",
+				"--question-id",
+				"round0-topology",
+				"--result-json",
+				JSON.stringify({ global_scores: { goal: 0.4, constraints: 0.3, criteria: 0.2 } }),
+				"--json",
+			],
+			cwd,
+		);
+		expect(rejected.status).toBe(2);
+		expect(rejected.stderr).toContain("DI_INVALID_ROUND");
 	});
 });

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-ambiguity.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-ambiguity.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { deriveAmbiguityMilestone } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-ambiguity";
+import { deriveAmbiguityMilestone, scoreToUnits } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-ambiguity";
 import {
 	answerHash,
 	appendOrMergeDeepInterviewRound,
@@ -338,6 +338,34 @@ describe("deep-interview v1 core contracts", () => {
 			deepInterviewRoundResultDigest({ result: { a: { alpha: 1, beta: 2 }, z: ["x"] }, round: 1, question_id: "q" }),
 		);
 		expect(canonicalDeepInterviewJson({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+		// Decoded requests materialize every optional key, so an absent optional field
+		// arrives as `undefined`. It must serialize like an omitted key instead of
+		// throwing, and both spellings must digest identically.
+		expect(canonicalDeepInterviewJson({ a: 1, targeting: undefined })).toBe('{"a":1}');
+		expect(
+			deepInterviewRoundResultDigest({
+				round: 1,
+				question_id: "q",
+				result: { global_scores: { goal: 0.5 }, targeting: undefined, ontology: undefined },
+			}),
+		).toBe(deepInterviewRoundResultDigest({ round: 1, question_id: "q", result: { global_scores: { goal: 0.5 } } }));
+		// Array elements and the top-level value stay strict: `undefined` there is an
+		// encoding bug, not an absent field.
+		expect(() => canonicalDeepInterviewJson([1, undefined])).toThrow("canonical JSON rejects undefined");
+		expect(() => canonicalDeepInterviewJson(undefined)).toThrow("canonical JSON rejects undefined");
+
+		// `0.69 * 10_000` is `6900.000000000001` in IEEE-754; ambiguity round-trips
+		// through `units / 10_000`, so these ordinary scores must convert cleanly
+		// while genuinely off-grid precision stays rejected.
+		expect(scoreToUnits(0.69)).toBe(6_900);
+		expect(scoreToUnits(0.07)).toBe(700);
+		expect(scoreToUnits(0.29)).toBe(2_900);
+		expect(scoreToUnits(0.0001)).toBe(1);
+		expect(scoreToUnits(0)).toBe(0);
+		expect(scoreToUnits(1)).toBe(10_000);
+		expect(() => scoreToUnits(0.00005)).toThrow("integral 1e-4 units");
+		expect(() => scoreToUnits(0.05000000000000001)).toThrow("integral 1e-4 units");
+		expect(() => scoreToUnits(1.5)).toThrow("finite in [0, 1]");
 
 		const filePath = "/tmp/state.json";
 		const envelope = {

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts
@@ -809,6 +809,33 @@ describe("deep-interview recorder: persistence (state-writer backed)", () => {
 		};
 		expect(persisted.state.rounds.find(round => round.round === 0)?.lifecycle).toBe("answered");
 		expect(persisted.state.rounds.find(round => round.round === 1)?.lifecycle).toBe("scored");
+		// The result JSON above omits `targeting`/`ontology`/`bookkeeping`, so the
+		// decoder materializes them as `undefined`. Replaying it must digest to the
+		// same value and settle as an idempotent noop rather than a conflict.
+		const replay = await runDeepInterviewRepairCommand(
+			[
+				"apply-round-result",
+				"--session-id",
+				TEST_SESSION_ID,
+				"--schema-version",
+				"1",
+				"--expected-revision",
+				String(before.state_revision + 1),
+				"--round",
+				"1",
+				"--question-id",
+				"q1",
+				"--result-json",
+				JSON.stringify({
+					global_scores: { goal: 0.4, constraints: 0.3, criteria: 0.2 },
+					component_updates: [{ component_id: "alpha", scores: { goal: 0.4, constraints: 0.3, criteria: 0.2 } }],
+				}),
+				"--json",
+			],
+			cwd,
+		);
+		expect(replay.status, replay.stderr).toBe(0);
+		expect(JSON.parse(replay.stdout ?? "{}")).toMatchObject({ ok: true, written: false });
 	});
 
 	it("canonicalizes an agent-supplied dimension label before persisting the shell", () => {

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts
@@ -718,6 +718,99 @@ describe("deep-interview recorder: persistence (state-writer backed)", () => {
 		expect(compact.pending_shells).toEqual([]);
 	});
 
+	it("scores Round 1 even though the unscorable Round-0 topology gate shell stays answered", async () => {
+		// Regression: the Round-0 topology gate is recorded as an `answered` shell so the
+		// locked intent contract can bind to its answer hash, but `apply-round-result`
+		// rejects `--round 0`, so that shell can never reach `scored`. Counting it in the
+		// "earlier rounds must be scored" precondition deadlocked every later round, making
+		// the whole interview unable to score a single answer.
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		await seedRecorderState(cwd);
+		expect(
+			(
+				await runDeepInterviewRepairCommand(
+					[
+						"confirm-topology",
+						"--session-id",
+						TEST_SESSION_ID,
+						"--schema-version",
+						"1",
+						"--expected-revision",
+						"1",
+						"--input-json",
+						'{"components":[{"id":"alpha","name":"Alpha"}],"deferred_components":[]}',
+						"--json",
+					],
+					cwd,
+				)
+			).status,
+		).toBe(0);
+		await appendOrMergeDeepInterviewRound(
+			cwd,
+			statePath,
+			{
+				round: 0,
+				questionId: "round0-topology",
+				questionText: "Confirm locked intent",
+				component: "review-topology",
+				dimension: "topology",
+				selectedOptions: ["Confirm"],
+				intent_contract: {
+					items: [{ id: "surface:review", category: "surface" as const, statement: "Provide a reviewer surface" }],
+					confirmation_options: ["Confirm"],
+				},
+			},
+			{ sessionId: TEST_SESSION_ID },
+		);
+		await appendOrMergeDeepInterviewRound(
+			cwd,
+			statePath,
+			{
+				round: 1,
+				questionId: "q1",
+				questionText: "Q?",
+				component: "alpha",
+				dimension: "goal",
+				selectedOptions: ["a"],
+			},
+			{ sessionId: TEST_SESSION_ID },
+		);
+		const before = JSON.parse(await fs.readFile(statePath, "utf-8")) as {
+			state_revision: number;
+			state: { rounds: DeepInterviewRoundRecord[] };
+		};
+		expect(before.state.rounds.find(round => round.round === 0)?.lifecycle).toBe("answered");
+		const scored = await runDeepInterviewRepairCommand(
+			[
+				"apply-round-result",
+				"--session-id",
+				TEST_SESSION_ID,
+				"--schema-version",
+				"1",
+				"--expected-revision",
+				String(before.state_revision),
+				"--round",
+				"1",
+				"--question-id",
+				"q1",
+				"--result-json",
+				JSON.stringify({
+					global_scores: { goal: 0.4, constraints: 0.3, criteria: 0.2 },
+					component_updates: [{ component_id: "alpha", scores: { goal: 0.4, constraints: 0.3, criteria: 0.2 } }],
+				}),
+				"--json",
+			],
+			cwd,
+		);
+		expect(scored.status, scored.stderr).toBe(0);
+		const persisted = JSON.parse(await fs.readFile(statePath, "utf-8")) as {
+			state: { rounds: DeepInterviewRoundRecord[] };
+		};
+		expect(persisted.state.rounds.find(round => round.round === 0)?.lifecycle).toBe("answered");
+		expect(persisted.state.rounds.find(round => round.round === 1)?.lifecycle).toBe("scored");
+	});
+
 	it("canonicalizes an agent-supplied dimension label before persisting the shell", () => {
 		// `deepInterview.dimension` is free text on post-topology asks; the persisted envelope
 		// only accepts canonical ids, so a display label must not reach state verbatim.


### PR DESCRIPTION
## What

`gjc deep-interview apply-round-result` failed with `DI_INTERNAL_ERROR` on **every** call, so a deep interview could never score a single round. Three independent defects stacked on the same path:

1. **The Round-0 topology gate deadlocks all scoring.** The recorder persists the Round-0 gate as an `answered` round shell — it has to, because the locked intent contract binds to its answer hash and spec persistence fails without it. But that shell can never reach `scored`: `apply-round-result` validates `--round` as positive (`safeInt(..., positive=true)`), and `validateDeepInterviewV1Envelope` only accepts a round-0 record that is an answered, score-less shell. `applyDeepInterviewRoundResultV1` still counted it in the "every strictly-earlier round must be scored" precondition, so every later round was permanently blocked.

2. **Omitted optional keys could not be digested.** `decodeDeepInterviewRoundResultJson` materializes all seven top-level keys, so a request omitting `targeting`/`ontology`/`bookkeeping` arrives with explicit `undefined` values. `canonicalJsonValue` rejected `undefined` outright, so computing the replay digest threw a raw `TypeError` that surfaced as the opaque `DI_INTERNAL_ERROR`.

3. **Ordinary scores were rejected as off-grid.** `scoreToUnits` tested the raw float product with `Number.isSafeInteger`. `0.69 * 10_000` is `6900.000000000001`, and effective ambiguity round-trips through `units / 10_000`, so the runtime's own derived values failed their own validation.

Fixes, in order:

- Exclude the non-scorable Round-0 gate from the ordering precondition, by identity (`round.round !== 0`) rather than by a range.
- Drop `undefined` object properties in canonical JSON exactly like `JSON.stringify`. Array elements and the top-level value stay strict — `undefined` there is a real encoding bug, not an absent field. Absent and present-but-undefined now digest identically, which is what the replay contract needs.
- Decide 1e-4 units from the shortest round-trip decimal instead of the float product. An epsilon cannot work here: `0.69 * 10_000` and `0.05000000000000001 * 10_000` both sit ~1e-13 off the grid, but only the first is a legitimate score.

## Why

Reproduced while running `/skill:deep-interview` on v0.11.10: every `apply-round-result` returned `DI_INTERNAL_ERROR`, including a minimal `{global_scores}` payload in a clean scratch session. The workflow is unusable end-to-end — Round 0 is mandatory, and once it exists nothing can be scored.

`DI_INTERNAL_ERROR` is the catch-all for any non-`DI_` exception, so both root causes surfaced as the same opaque code with no actionable signal.

## Testing

Focused tests (all green, `bun test`):

```
packages/coding-agent/test/gjc-runtime/deep-interview-{ambiguity,recorder,recorder-redteam,state,state-redteam,runtime,hud-sync,intent-shell-validation}.test.ts
packages/coding-agent/test/deep-interview-{repair-cli,draft-cli,draft-consume,skill-contract,workflow-gates,gate-redteam}.test.ts
packages/coding-agent/test/workflow-mutation-guard.test.ts
-> 265 pass, 0 fail
```

Checks: `bun run check:tools` and `bun --cwd=packages/coding-agent run check` both clean.

New coverage:

- **End-to-end regression** (`deep-interview-recorder.test.ts`): records a Round-0 topology gate through the recorder, then scores Round 1 through the repair CLI, asserting the gate stays `answered` while Round 1 becomes `scored`. This is the exact real-world sequence that was broken.
- **CLI idempotency** with a result JSON that omits optional keys — the exact shape that used to throw — asserting the replay settles as a noop (`status 0`, `written: false`) rather than a second write or a conflict.
- **Isolating pin for the Round-0 premise**: a positive control plus a negative case differing by exactly one field (`scores`), so deleting the validator's round-0 clause turns the test red. Plus `apply-round-result --round 0` -> `DI_INVALID_ROUND`.
- **Digest collision boundary**: `null` (and `0`/`""`/`false`) must survive the undefined-drop, so loosening the skip predicate to `!value[key]` cannot silently change the meaning of every persisted `round_result_digest`.
- **Exhaustive `scoreToUnits` sweep** over all 10,001 grid values, plus `-0`, `0.9999`, and `0.30000000000000004`.

**Mutation-tested.** Each fix was reverted in turn and the suite confirmed to fail:

| Reverted change | Failing test |
| --- | --- |
| Round-0 ordering exclusion | `scores Round 1 even though the unscorable Round-0 topology gate shell stays answered` |
| canonical-JSON skip predicate -> `!value[key]` | `uses ready-first milestones, canonical round digests, ...` |
| `scoreToUnits` -> float-product check | `uses ready-first milestones, canonical round digests, ...` |
| validator round-0 clause | `persists component scores before flooring and validates v1 lifecycle safety` |

Pre-existing failures on this machine in `managed-owner-supervisor`, `managed-owner-admission`, `launch-tmux`, `ultragoal-owner-loss-recovery`, and `team-runtime` were verified identical on clean `dev` (tmux/sandbox/git-identity environment issues) and are unrelated.

## Notes for the reviewer

- **Backward compatibility.** `scoreToUnits`'s new rule accepts a strict superset of the old one, so no already-persisted envelope can flip to `DI_STATE_SCHEMA_INVALID` — which matters because `validateDeepInterviewV1Envelope` runs on the read value too. The canonical-JSON change cannot alter any previously-computable digest: every input containing `undefined` previously threw rather than producing one.
- **One externally visible acceptance change**: `gjc deep-interview --threshold 0.69` previously exited 2 and now succeeds with `threshold_units: 6900`. Off-grid precision such as `0.05000000000000001` is still rejected; the existing contract test covering that holds by construction, not by coincidence.
- **Not addressed here** (disclosed, pre-existing, out of scope): `inspect --selector triggers` on a *legacy* envelope previously crashed while computing `view_sha256` when `kind`/`status`/`dimension` were absent, and now returns a normal response matching the bytes `JSON.stringify` already emitted. That is a consequence of the canonical-JSON parity fix and an improvement, but it is untested and outside this PR's stated scope.

## GJC verdict

Reviewed by an independent `architect` role agent across four passes (`0143ce4e`, `a4d8baf5`, `3d5b9bed`, `45ad0099`). The second pass found that one new assertion passed for reasons unrelated to the rule it claimed to pin; that was fixed and re-verified by counterfactual and by mutation testing. No blocker or major finding at any pass; no outstanding findings at the exact head.

```text
gajae.pr-review-verdict.v1 merge-approved sha256:422b95cfcb55f38f210a82eb657d41ac1d67032638b2bf7ff87c55e9dcb0d8d5 reviewer:architect evidence:local bun test (265 pass/0 fail across 15 deep-interview suites) + bun run check:tools + bun --cwd=packages/coding-agent run check, head 45ad0099136342798edbf08cae052149c21e5603
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
