### PR TITLE
fix(ai): time out stalled Anthropic ping streams

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Anthropic `ping` keepalives no longer reset stream progress, so responses that stop producing content now reach the idle timeout instead of hanging indefinitely.
+
 ## [0.11.10] - 2026-07-25
 
 ## [0.11.9] - 2026-07-24

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1182,6 +1182,40 @@ function shouldIgnoreAnthropicPreambleEvent(eventType: unknown): boolean {
 	return !ANTHROPIC_PRE_MESSAGE_START_EVENT_TYPES.has(eventType);
 }
 
+function createAnthropicStreamProgressPredicate(): (event: unknown) => boolean {
+	let outputTokens = -1;
+
+	return event => {
+		if (!isRecord(event) || typeof event.type !== "string") return false;
+		if (
+			event.type === "message_start" ||
+			event.type === "content_block_start" ||
+			event.type === "content_block_stop" ||
+			event.type === "message_stop"
+		) {
+			return true;
+		}
+		if (event.type === "content_block_delta") {
+			if (!isRecord(event.delta)) return false;
+			const delta = event.delta;
+			return (
+				(typeof delta.text === "string" && delta.text.length > 0) ||
+				(typeof delta.thinking === "string" && delta.thinking.length > 0) ||
+				(typeof delta.partial_json === "string" && delta.partial_json.length > 0) ||
+				(typeof delta.signature === "string" && delta.signature.length > 0)
+			);
+		}
+		if (event.type === "message_delta") {
+			if (isRecord(event.delta) && event.delta.stop_reason != null) return true;
+			if (!isRecord(event.usage) || typeof event.usage.output_tokens !== "number") return false;
+			if (event.usage.output_tokens <= outputTokens) return false;
+			outputTokens = event.usage.output_tokens;
+			return true;
+		}
+		return false;
+	};
+}
+
 function isTransientStreamEnvelopeError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
 	return (
@@ -1457,6 +1491,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 					let sawEvent = false;
 					let sawMessageStart = false;
 					let sawTerminalEnvelope = false;
+					const isProgressEvent = createAnthropicStreamProgressPredicate();
 
 					for await (const event of iterateWithIdleTimeout(anthropicStream, {
 						idleTimeoutMs,
@@ -1466,6 +1501,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 						onIdle: () => activeAbortTracker.abortLocally(idleTimeoutAbortError),
 						onFirstItemTimeout: () => activeAbortTracker.abortLocally(firstEventTimeoutAbortError),
 						abortSignal: options?.signal,
+						isProgressItem: isProgressEvent,
 					})) {
 						sawEvent = true;
 						if (sawProviderSafetyStop) {

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -173,8 +173,6 @@ export async function* iterateWithIdleTimeout<T>(
 			}
 		}
 
-		const nextResultPromise = withRacy(iterator.next());
-
 		const racers: Array<
 			Promise<
 				| { kind: "next"; result: IteratorResult<T> }
@@ -182,7 +180,7 @@ export async function* iterateWithIdleTimeout<T>(
 				| { kind: "timeout" }
 				| { kind: "abort" }
 			>
-		> = [nextResultPromise];
+		> = [];
 
 		let timer: NodeJS.Timeout | undefined;
 		let resolveTimeout: ((value: { kind: "timeout" }) => void) | undefined;
@@ -206,6 +204,13 @@ export async function* iterateWithIdleTimeout<T>(
 			abortSignal.addEventListener("abort", abortListener, { once: true });
 			racers.push(promise);
 		}
+
+		// Arm timeout/abort races before asking the source for its next item. A
+		// periodic keepalive iterator commonly registers its own timer inside
+		// `next()`; registering that first lets equal-deadline keepalives win every
+		// race and extend the idle window forever. Already-buffered items still
+		// settle as microtasks before a 0ms watchdog.
+		racers.unshift(withRacy(iterator.next()));
 
 		try {
 			const outcome = await Promise.race(racers);

--- a/packages/ai/test/anthropic-stream-timeout.test.ts
+++ b/packages/ai/test/anthropic-stream-timeout.test.ts
@@ -300,4 +300,55 @@ describe("anthropic first-event timeout retries", () => {
 			},
 		]);
 	});
+
+	it("does not let Anthropic ping events keep a stalled response alive", async () => {
+		const create = ((_body: unknown, requestOptions?: { signal?: AbortSignal }) => {
+			const response = new Response(null, { status: 200, headers: { "request-id": "req_ping_stall" } });
+			const data: MockAnthropicStream = {
+				async *[Symbol.asyncIterator]() {
+					yield {
+						type: "message_start",
+						message: {
+							id: "msg_ping_stall",
+							usage: {
+								input_tokens: 12,
+								output_tokens: 0,
+								cache_read_input_tokens: 0,
+								cache_creation_input_tokens: 0,
+							},
+						},
+					};
+					yield {
+						type: "content_block_start",
+						index: 0,
+						content_block: { type: "text", text: "" },
+					};
+					yield {
+						type: "content_block_delta",
+						index: 0,
+						delta: { type: "text_delta", text: "checking" },
+					};
+					while (!requestOptions?.signal?.aborted) {
+						await Bun.sleep(1);
+						yield { type: "ping" };
+					}
+				},
+			};
+			return {
+				async withResponse() {
+					return { data, response, request_id: "req_ping_stall" };
+				},
+			} as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const result = await streamAnthropic(model, context, {
+			client,
+			streamFirstEventTimeoutMs: 5000,
+			streamIdleTimeoutMs: 5,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Anthropic stream stalled while waiting for the next event");
+	});
 });


### PR DESCRIPTION
## Summary
- classify only semantic Anthropic stream events as progress so ping keepalives cannot reset the idle deadline
- arm timeout and abort races before requesting the source's next event, preventing equal-deadline keepalives from winning forever
- add a regression that reproduces the indefinite ping-only stall

## Verification
- regression failed by timeout on origin/dev before the fix
- bun test ./test/anthropic-stream-timeout.test.ts ./test/anthropic-stream-envelope.test.ts ./test/openai-completions-progress-chunk.test.ts
- bun run check (packages/ai)
- git diff --check