### PR TITLE
fix(coding-agent): keep ultragoal questions on direct path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Questions about `ultragoal` behavior now stay on the direct-answer path instead of being misclassified as requests to start the durable workflow.
 - Aligned the startup GJC Forge splash border with the composer trailing gutter, including the one-row constrained fallback.
 - `gjc resume` and delete no longer pay a durable (fsync-backed) lock acquisition for managed session tombstones that have nothing left to reconcile; a scope with many accumulated already-completed tombstones opens noticeably faster (#3067).
 

--- a/packages/coding-agent/src/workflow/workflow-intent-diff.ts
+++ b/packages/coding-agent/src/workflow/workflow-intent-diff.ts
@@ -40,7 +40,9 @@ interface RouteMatch {
 const PROMPT_PREVIEW_LIMIT = 240;
 
 const DURABLE_TRACKING_PATTERNS = [
-	/\bultragoal\b/i,
+	/\/skill:ultragoal\b/i,
+	/\b(?:use|run|start|create|activate|invoke|execute)\s+(?:the\s+)?ultragoal\b/i,
+	/\bultragoal(?:로|으로)[^.!?\n]{0,40}(?:해|진행|실행|관리|처리)/i,
 	/\bdurable (?:goal|tracking|ledger|plan)\b/i,
 	/\b(?:goal|tracking|plan) ledger\b/i,
 	/\bcheckpoint(?:ed|ing)? (?:goal|plan|workflow|release|work)\b/i,

--- a/packages/coding-agent/test/agent-session-workflow-intent-diff.test.ts
+++ b/packages/coding-agent/test/agent-session-workflow-intent-diff.test.ts
@@ -156,8 +156,10 @@ describe("AgentSession workflow intent-diff tracking", () => {
 		await session.prompt("I'm not sure what this product should be, don't assume the requirements");
 		await session.prompt("create a durable goal ledger for this multi-step release");
 		await session.prompt("create a durable goal ledger for this production release");
+		await session.prompt("use ultragoal to track this release");
+		await session.prompt("ultragoal로 이 작업 처리해줘");
 
-		const [deepInterview, ultragoal, productionUltragoal] = workflowIntentEntries();
+		const [deepInterview, ultragoal, productionUltragoal, namedUltragoal, koreanUltragoal] = workflowIntentEntries();
 		expect(deepInterview?.data).toMatchObject({
 			route: "deep-interview",
 			recommendedSkill: "deep-interview",
@@ -177,6 +179,28 @@ describe("AgentSession workflow intent-diff tracking", () => {
 			directTracking: "not-direct",
 			rootCausePhase: { status: "active", triggers: ["high-risk transition"] },
 		});
+		expect(namedUltragoal?.data).toMatchObject({
+			route: "ultragoal",
+			recommendedSkill: "ultragoal",
+		});
+		expect(koreanUltragoal?.data).toMatchObject({
+			route: "ultragoal",
+			recommendedSkill: "ultragoal",
+		});
+	});
+
+	it("keeps questions about ultragoal behavior on the direct path", async () => {
+		await session.prompt("How many consensus rounds does ultragoal run, and can I limit them?");
+		await session.prompt(
+			"ultragoal 같은거 쓰면 합의 몇번이나 하게 되어 있음? 끝도 없이 하는 경우도 있는거 같은데 제약 할수 있는 옵션 있음?",
+		);
+
+		for (const entry of workflowIntentEntries()) {
+			expect(entry.data).toMatchObject({
+				route: "direct",
+				directTracking: "custom-entry-only",
+			});
+		}
 	});
 
 	it("lets ambiguous requirements take precedence over durable tracking words", async () => {


### PR DESCRIPTION
## Summary
- require an explicit invocation phrase before routing a bare ultragoal mention to the durable workflow
- keep English and Korean questions about ultragoal behavior on the direct-answer path
- preserve explicit English, Korean, and /skill:ultragoal invocation routing

## Verification
- bun test ./test/agent-session-workflow-intent-diff.test.ts
- bun run check (packages/coding-agent)
- git diff --check