### PR TITLE
fix(agent): recover repeated malformed tool calls

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Repeated malformed tool calls now get one tool-free recovery response, preventing argument-validation loops from ending without an answer while leaving ordinary execution-error retries unchanged.
+
 ## [0.11.10] - 2026-07-25
 
 ## [0.11.8] - 2026-07-23

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -32,6 +32,7 @@ import {
 	shouldMitigateHarmonyLeak,
 	signalListLabel,
 } from "./harmony-leak";
+import repeatedToolFailureRecoveryPrompt from "./prompts/repeated-tool-failure-recovery.md" with { type: "text" };
 import { type AgentRunCoverage, type AgentRunSummary, ToolCallBlockedError } from "./run-collector";
 import {
 	type AgentTelemetry,
@@ -1247,6 +1248,9 @@ async function runLoopBody(
 	// Fires at most one repaired resend per run for the poisoned-history
 	// `invalid_prompt` circuit breaker below.
 	let invalidPromptRepairAttempted = false;
+	let previousMalformedToolSignatures = new Set<string>();
+	let recoverWithoutTools = false;
+	let malformedToolRecoveryAttempted = false;
 
 	// Outer loop: continues when queued follow-up messages arrive after agent would stop
 	while (true) {
@@ -1331,8 +1335,24 @@ async function runLoopBody(
 								attemptTransaction.stageAssistantMessageEvent(partial, event),
 						}
 					: config;
+				const responseContext = recoverWithoutTools
+					? {
+							...currentContext,
+							messages: [
+								...currentContext.messages,
+								{
+									role: "user" as const,
+									content: repeatedToolFailureRecoveryPrompt,
+									synthetic: true,
+									timestamp: Date.now(),
+								},
+							],
+							tools: [],
+						}
+					: currentContext;
+				recoverWithoutTools = false;
 				message = await streamAssistantResponse(
-					currentContext,
+					responseContext,
 					attemptConfig,
 					loopSignal,
 					attemptTransaction ? (attemptTransaction as unknown as EventStream<AgentEvent, AgentMessage[]>) : stream,
@@ -1527,6 +1547,7 @@ async function runLoopBody(
 			hasMoreToolCalls = toolCalls.length > 0;
 
 			const toolResults: ToolResultMessage[] = [];
+			let repeatedMalformedToolCall = false;
 			if (hasMoreToolCalls) {
 				const executionResult = await executeToolCalls(
 					currentContext,
@@ -1540,6 +1561,18 @@ async function runLoopBody(
 
 				toolResults.push(...executionResult.toolResults);
 				steeringMessagesFromExecution = executionResult.steeringMessages;
+
+				const malformedSignatures = executionResult.malformedToolCallSignatures;
+				const allToolCallsMalformed = toolResults.length > 0 && malformedSignatures.length === toolResults.length;
+				if (allToolCallsMalformed) {
+					const uniqueMalformedSignatures = new Set(malformedSignatures);
+					repeatedMalformedToolCall =
+						uniqueMalformedSignatures.size < malformedSignatures.length ||
+						[...uniqueMalformedSignatures].some(signature => previousMalformedToolSignatures.has(signature));
+					previousMalformedToolSignatures = uniqueMalformedSignatures;
+				} else {
+					previousMalformedToolSignatures = new Set();
+				}
 
 				for (const result of toolResults) {
 					currentContext.messages.push(result);
@@ -1559,6 +1592,10 @@ async function runLoopBody(
 				stream.push(buildAgentEndEvent(newMessages, telemetry, stepCounter.count, "paused"));
 				stream.end(newMessages);
 				return;
+			}
+			if (repeatedMalformedToolCall && !malformedToolRecoveryAttempted) {
+				recoverWithoutTools = true;
+				malformedToolRecoveryAttempted = true;
 			}
 		}
 
@@ -1910,7 +1947,11 @@ async function executeToolCalls(
 	config: AgentLoopConfig,
 	telemetry: AgentTelemetry | undefined,
 	invokeAgentSpan: Span | undefined,
-): Promise<{ toolResults: ToolResultMessage[]; steeringMessages?: AgentMessage[] }> {
+): Promise<{
+	toolResults: ToolResultMessage[];
+	steeringMessages?: AgentMessage[];
+	malformedToolCallSignatures: string[];
+}> {
 	const tools = currentContext.tools;
 	const {
 		getSteeringMessages,
@@ -1951,6 +1992,7 @@ async function executeToolCalls(
 		skipped: false,
 		toolResultMessage: undefined as ToolResultMessage | undefined,
 		resultEmitted: false,
+		argumentValidationFailed: false,
 	}));
 
 	const checkSteering = async (): Promise<void> => {
@@ -2070,6 +2112,7 @@ async function executeToolCalls(
 		await runInActiveSpan(toolSpan, async () => {
 			try {
 				if (toolCall.incompleteArguments) {
+					record.argumentValidationFailed = true;
 					// The provider flagged this call's argument JSON as truncated
 					// (the model hit its output-token limit mid-call). Executing the
 					// best-effort partial parse would run the tool on wrong input, so
@@ -2104,6 +2147,7 @@ async function executeToolCalls(
 					if (tool.lenientArgValidation) {
 						effectiveArgs = argsForExecution;
 					} else {
+						record.argumentValidationFailed = true;
 						throw validationError;
 					}
 				}
@@ -2255,7 +2299,12 @@ async function executeToolCalls(
 		}
 	}
 
-	return { toolResults: emittedToolResults, steeringMessages };
+	const malformedToolCallSignatures = records.flatMap(record =>
+		record.argumentValidationFailed && record.toolResultMessage?.isError
+			? [`${record.toolCall.name}:${JSON.stringify(record.toolCall.arguments)}`]
+			: [],
+	);
+	return { toolResults: emittedToolResults, steeringMessages, malformedToolCallSignatures };
 }
 
 /**

--- a/packages/agent/src/prompts/repeated-tool-failure-recovery.md
+++ b/packages/agent/src/prompts/repeated-tool-failure-recovery.md
@@ -1,0 +1,1 @@
+The immediately preceding tool calls failed because their arguments were malformed. Do not call any tools. Answer the original user request now using the conversation and any successful tool results already available. If the evidence is incomplete, state that limitation instead of returning an empty response.

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -378,6 +378,105 @@ describe("agentLoop with AgentMessage", () => {
 		}
 	});
 
+	it("recovers without tools after repeated malformed tool calls", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				throw new Error("invalid calls must not execute");
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				{ content: ["answered without tools"] },
+			],
+		});
+		const streamedToolCounts: number[] = [];
+		const streamedMessages: Message[][] = [];
+		const inspectingStream = (...args: Parameters<typeof mock.stream>) => {
+			streamedToolCounts.push(args[1].tools?.length ?? 0);
+			streamedMessages.push(args[1].messages);
+			return mock.stream(...args);
+		};
+		const events: AgentEvent[] = [];
+		const stream = agentLoop(
+			[createUserMessage("echo something")],
+			context,
+			{ model: mock.model, convertToLlm: identityConverter },
+			undefined,
+			inspectingStream,
+		);
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		expect(events.filter(event => event.type === "tool_execution_end")).toHaveLength(2);
+		expect(streamedToolCounts).toEqual([1, 1, 0]);
+		expect(streamedMessages[2].at(-1)).toMatchObject({
+			role: "user",
+			content: expect.stringContaining("Do not call any tools"),
+			synthetic: true,
+		});
+		expect(events.at(-1)).toMatchObject({ type: "agent_end", stopReason: "completed" });
+		expect(
+			events.findLast(
+				event =>
+					event.type === "message_end" &&
+					event.message.role === "assistant" &&
+					event.message.content.some(block => block.type === "text" && block.text === "answered without tools"),
+			),
+		).toBeDefined();
+	});
+
+	it("keeps tools available when repeated calls fail during execution", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		let executions = 0;
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				executions += 1;
+				throw new Error("transient execution failure");
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "same" } }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "same" } }] },
+				{ content: ["recovered normally"] },
+			],
+		});
+		const streamedToolCounts: number[] = [];
+		const inspectingStream = (...args: Parameters<typeof mock.stream>) => {
+			streamedToolCounts.push(args[1].tools?.length ?? 0);
+			return mock.stream(...args);
+		};
+		const stream = agentLoop(
+			[createUserMessage("echo something")],
+			context,
+			{ model: mock.model, convertToLlm: identityConverter },
+			undefined,
+			inspectingStream,
+		);
+
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(executions).toBe(2);
+		expect(streamedToolCounts).toEqual([1, 1, 1]);
+	});
+
 	it("injects and strips intent when intent tracing is enabled", async () => {
 		const toolSchema = z.object({ value: z.string() });
 		const executedParams: Record<string, unknown>[] = [];


### PR DESCRIPTION
## Summary

- detect repeated tool calls whose arguments fail schema validation or are incomplete
- make one bounded tool-free recovery request so the agent returns a useful final answer
- preserve normal retry behavior for valid tool calls that fail during execution

## Root cause

A provider could repeat the same unusable tool call and exhaust the loop without producing a final response. Treating all tool errors as malformed would be too broad, so recovery is limited to argument-validation failures.

## Verification

- bun test packages/agent/test (568 pass, 0 fail)
- bun run check in packages/agent
- git diff --check