### PR TITLE
fix(coding-agent): enforce ralplan consensus iteration cap (#3165)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Ralplan consensus planning now enforces a finite planner/revision iteration budget at the native write path (default 5, configurable via `gjc.ralplan.maxIterations`). Opening another planner/revision pass past the cap fails closed with exit code 3 and an operator-visible `PLANNING-STUCK` marker instead of silent unbounded re-review; `final`/post-interview escalation remains allowed without auto-implementation (#3165).
+- Ralplan consensus planning now enforces a finite planner/revision iteration budget at the native write path (default 5, configurable via `gjc.ralplan.maxIterations`). Opening another planner/revision pass past the cap fails closed with exit code 3 and an operator-visible `PLANNING-STUCK` marker instead of silent unbounded re-review; `final`/post-interview escalation remains allowed without auto-implementation. The cap also floors against on-disk `stage-*-{planner,revision}.md` artifacts so a wiped, truncated, or malformed `index.jsonl` cannot fail open after prior openers (#3165).
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Ralplan consensus planning now enforces a finite planner/revision iteration budget at the native write path (default 5, configurable via `gjc.ralplan.maxIterations`). Opening another planner/revision pass past the cap fails closed with exit code 3 and an operator-visible `PLANNING-STUCK` marker instead of silent unbounded re-review; `final`/post-interview escalation remains allowed without auto-implementation (#3165).
+
 ### Fixed
 
 - Aligned the startup GJC Forge splash border with the composer trailing gutter, including the one-row constrained fallback.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -501,6 +501,11 @@ export const SETTINGS_SCHEMA = {
 		default: 0.05,
 		validate: (value: number) => Number.isFinite(value) && value > 0 && value <= 1,
 	},
+	"gjc.ralplan.maxIterations": {
+		type: "number",
+		default: 5,
+		validate: (value: number) => Number.isInteger(value) && value >= 1 && value <= 20,
+	},
 
 	// ────────────────────────────────────────────────────────────────────────
 	// Appearance

--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -67,14 +67,15 @@ The consensus workflow:
    - **Plan-only Critic lane**: independently check quality, principle-option consistency, alternatives, risks, acceptance criteria, and verification; when the plan is thin, request concrete expansion rather than only defects. Persist with `gjc ralplan --write --stage critic --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --json`, then return receipt/path plus `OKAY`/`ITERATE`/`REJECT`.
    - **Sequential fallback**: if Critic must evaluate Architect findings, verdict, antithesis, tradeoffs, synthesis, status, or any Architect-produced artifact, await the Architect result before issuing that Architect-dependent Critic pass.
 4. **Review join gate**: before consensus, revision, reconciliation, finalization, or approval, verify both Architect and Critic receipts/verdicts exist for the same Planner artifact/pass (`path`, `sha256`, `stage_n`). A non-`CLEAR` Architect verdict, non-`APPROVE` Architect decision, or any non-`OKAY` Critic verdict routes back to Planner revision; do not finalize from only one review lane.
-5. **Re-review loop** (max 5 iterations): Any non-`OKAY` Critic verdict (`ITERATE` or `REJECT`) or Architect result that is not `CLEAR`/`APPROVE` MUST run the same full closed loop:
+5. **Re-review loop** (max 5 iterations; **runtime-enforced**): Any non-`OKAY` Critic verdict (`ITERATE` or `REJECT`) or Architect result that is not `CLEAR`/`APPROVE` MUST run the same full closed loop:
    a. Collect Architect + Critic feedback
    b. Revise the plan by resuming the SAME persisted Planner subagent with consolidated Architect + Critic feedback (see **Persisted Planner** below); fall back to a fresh Planner spawn only per the fallback routing table
    c. Return to the review fan-out or sequential fallback path above
       - Persist each Planner revision with `gjc ralplan --write --stage revision --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --json` before re-review, then pass the receipt/path forward instead of duplicating the full revision markdown in the parent conversation.
    d. Re-join Architect and Critic verdicts for the same revised Planner artifact/pass
    e. Repeat this loop until Critic returns `OKAY` **and** Architect is `CLEAR`/`APPROVE` for the same Planner artifact/pass, or 5 iterations are reached
-   f. If 5 iterations are reached without Critic `OKAY` plus Architect `CLEAR`/`APPROVE`, present the best version to the user
+   f. If 5 iterations are reached without Critic `OKAY` plus Architect `CLEAR`/`APPROVE`, **stop opening further planner/revision passes**. Present the best version to the user (interactive) or surface `PLANNING-STUCK` (headless). Do **not** auto-start implementation.
+   g. **Runtime budget (#3165):** native `gjc ralplan --write` refuses a new `planner`/`revision` that would open consensus iteration **> max** (default **5**, overridable via `gjc.ralplan.maxIterations` in project/user `.gjc/settings.json`, integer 1..20). Cap uses the same iteration definition as the HUD (`planner`/`revision` openers in `index.jsonl`). Overflow exits **3**, prints operator-visible **`PLANNING-STUCK`** on stdout (and stderr detail; JSON includes `planning_stuck: true`), and still allows `architect`/`critic` within an already-opened pass plus `post-interview`/`adr`/`final` so the best plan can be escalated to `pending approval` without auto-execution. A new `--run-id` starts a fresh budget.
 6. **Post-ralplan interview** (intent reconciliation gate): After the review join gate has both Critic `OKAY` and Architect `CLEAR`/`APPROVE` for the same Planner artifact/pass, and before the plan is finalized, reconcile the consensus plan against the user's actual intent. The goal is to make sure ralplan did not silently bake in assumptions that conflict with what the user wants.
    a. **Collect open items** from the run: every assumption the Planner/Architect/Critic resolved by assumption rather than by stated fact, every ambiguity flagged during review, and every decision the loop made without explicit user input. Source these from the persisted `planner`/`architect`/`critic`/`revision` stage artifacts, not from memory.
    b. **Cross-check prior context for conflicts**: glob `.gjc/_session-{sessionid}/specs/deep-interview-*.md` and other prior specs/plans/context relevant by topic. For each, list points where the consensus plan contradicts, weakens, or expands beyond a previously crystallized decision, constraint, or non-goal. Cite the conflicting artifact and line/section.
@@ -102,6 +103,24 @@ The consensus workflow:
    The skill tool then dispatches the execution skill same-turn and runs `gjc state ralplan handoff --to <team|ultragoal> --json` in-process to atomically demote ralplan, promote the callee, and sync `.gjc/_session-{sessionid}/state/skill-active-state.json`. You do not need to run the handoff verb yourself.
 
 > **Important:** Architect and Critic MAY run in the same parallel batch only for the plan-only Critic lane after Planner persistence. Any Architect-dependent Critic pass MUST remain sequential: await Architect before issuing Critic, then apply the same review join gate before consensus.
+
+## Consensus iteration cap (operator contract)
+
+- Default max consensus iterations: **5** (`gjc.ralplan.maxIterations`).
+- On cap: exit code **3**, marker **`PLANNING-STUCK`** (stdout), no silent re-loop, no automatic ultragoal/team handoff.
+- Headless/CI: treat `PLANNING-STUCK` / exit 3 as terminal planning failure for orchestration/watchdogs.
+- Interactive: present best existing plan via the final approval gate; residual critic findings stay as caveats.
+- Override example (project `.gjc/settings.json`):
+
+```json
+{
+  "gjc": {
+    "ralplan": {
+      "maxIterations": 3
+    }
+  }
+}
+```
 
 
 Follow this ralplan-internal consensus workflow for consensus mode details.

--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -107,7 +107,7 @@ The consensus workflow:
 ## Consensus iteration cap (operator contract)
 
 - Default max consensus iterations: **5** (`gjc.ralplan.maxIterations`).
-- On cap: exit code **3**, marker **`PLANNING-STUCK`** (stdout), no silent re-loop, no automatic ultragoal/team handoff.
+- On cap: exit code **3**, marker **`PLANNING-STUCK`** (stdout), no silent re-loop, no automatic ultragoal/team handoff. Opener budget is `max(index.jsonl openers, on-disk stage-*-{planner,revision}.md count)` so a missing/empty/malformed ledger cannot fail open after prior openers.
 - Headless/CI: treat `PLANNING-STUCK` / exit 3 as terminal planning failure for orchestration/watchdogs.
 - Interactive: present best existing plan via the final approval gate; residual critic findings stay as caveats.
 - Override example (project `.gjc/settings.json`):

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import { syncSkillActiveState } from "../skill-state/active-state";
 import { buildRalplanHudSummary } from "../skill-state/workflow-hud";
@@ -21,7 +22,7 @@ import {
 	RepositoryBindingError,
 } from "./repository-binding";
 import { GJC_RALPLAN_ARTIFACT_ENV, isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
-import { modeStatePath, sessionPlansDir } from "./session-layout";
+import { gjcRoot, modeStatePath, sessionPlansDir } from "./session-layout";
 import { resolveGjcSessionForWrite, writeSessionActivityMarker } from "./session-resolution";
 import { migrateWorkflowState } from "./state-migrations";
 import { runNativeStateCommand } from "./state-runtime";
@@ -63,6 +64,163 @@ export interface RalplanCommandResult {
 
 const KNOWN_STAGES = ["planner", "architect", "critic", "revision", "post-interview", "adr", "final"] as const;
 type RalplanStage = (typeof KNOWN_STAGES)[number];
+/** Default consensus iterations (planner + revision openers) per run. Matches SKILL.md re-review cap. */
+export const RALPLAN_DEFAULT_MAX_ITERATIONS = 5;
+/** Inclusive upper bound for `gjc.ralplan.maxIterations` settings overrides. */
+export const RALPLAN_MAX_ITERATIONS_LIMIT = 20;
+/** Operator-visible stuck signal for headless/CI orchestration (#3165). */
+export const PLANNING_STUCK_MARKER = "PLANNING-STUCK";
+
+const RALPLAN_ITERATION_OPENER_STAGES = new Set<RalplanStage>(["planner", "revision"]);
+
+export type RalplanIterationCapDecision =
+	| {
+			allowed: true;
+			currentIterations: number;
+			projectedIterations: number;
+			maxIterations: number;
+	  }
+	| {
+			allowed: false;
+			currentIterations: number;
+			projectedIterations: number;
+			maxIterations: number;
+			reason: string;
+	  };
+
+/**
+ * Pure consensus-iteration budget gate (#3165).
+ *
+ * A `planner` or `revision` write opens a new iteration (same definition as
+ * `summarizeRalplanIndex`). Other stages never open iterations and are always
+ * allowed by this gate — including `final` after the cap is already reached.
+ */
+export function evaluateRalplanIterationCap(input: {
+	rows: readonly RalplanIndexRow[];
+	stage: string;
+	maxIterations?: number;
+}): RalplanIterationCapDecision {
+	const maxIterations =
+		typeof input.maxIterations === "number" &&
+		Number.isInteger(input.maxIterations) &&
+		input.maxIterations >= 1 &&
+		input.maxIterations <= RALPLAN_MAX_ITERATIONS_LIMIT
+			? input.maxIterations
+			: RALPLAN_DEFAULT_MAX_ITERATIONS;
+	const currentIterations = summarizeRalplanIndex(input.rows).iteration;
+	if (!RALPLAN_ITERATION_OPENER_STAGES.has(input.stage as RalplanStage)) {
+		return {
+			allowed: true,
+			currentIterations,
+			projectedIterations: currentIterations,
+			maxIterations,
+		};
+	}
+	const projectedIterations = currentIterations + 1;
+	if (projectedIterations > maxIterations) {
+		return {
+			allowed: false,
+			currentIterations,
+			projectedIterations,
+			maxIterations,
+			reason:
+				`ralplan consensus iteration cap exceeded: opening ${input.stage} would start ` +
+				`iteration ${projectedIterations} (max ${maxIterations})`,
+		};
+	}
+	return {
+		allowed: true,
+		currentIterations,
+		projectedIterations,
+		maxIterations,
+	};
+}
+
+function parseMaxIterationsValue(value: unknown): number | null {
+	return typeof value === "number" &&
+		Number.isFinite(value) &&
+		Number.isInteger(value) &&
+		value >= 1 &&
+		value <= RALPLAN_MAX_ITERATIONS_LIMIT
+		? value
+		: null;
+}
+
+async function readSettingsMaxIterations(settingsPath: string): Promise<number | null> {
+	try {
+		const raw = await Bun.file(settingsPath).text();
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+		const flat = parseMaxIterationsValue(parsed["gjc.ralplan.maxIterations"]);
+		if (flat !== null) return flat;
+		const gjc = parsed.gjc;
+		if (gjc && typeof gjc === "object") {
+			const ralplan = (gjc as Record<string, unknown>).ralplan;
+			if (ralplan && typeof ralplan === "object") {
+				return parseMaxIterationsValue((ralplan as Record<string, unknown>).maxIterations);
+			}
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Resolve ralplan consensus iteration cap. Project `./.gjc/settings.json` overrides
+ * user settings, else default 5.
+ */
+export async function resolveRalplanMaxIterations(cwd: string): Promise<{ maxIterations: number; source: string }> {
+	const projectPath = path.join(gjcRoot(cwd), "settings.json");
+	const project = await readSettingsMaxIterations(projectPath);
+	if (project !== null) return { maxIterations: project, source: projectPath };
+	const userDir = process.env.GJC_CONFIG_DIR?.trim() || path.join(os.homedir(), ".gjc");
+	const userPath = path.join(userDir, "settings.json");
+	const user = await readSettingsMaxIterations(userPath);
+	if (user !== null) return { maxIterations: user, source: userPath };
+	return { maxIterations: RALPLAN_DEFAULT_MAX_ITERATIONS, source: "default" };
+}
+
+function buildPlanningStuckResult(input: {
+	json: boolean;
+	stage: RalplanStage;
+	stageN: number;
+	runId: string;
+	decision: Extract<RalplanIterationCapDecision, { allowed: false }>;
+	source: string;
+}): RalplanCommandResult {
+	const detail =
+		`${PLANNING_STUCK_MARKER}: ${input.decision.reason} ` +
+		`(run_id=${input.runId}, stage=${input.stage}, stage_n=${input.stageN}, source=${input.source}). ` +
+		`Stop opening planner/revision passes; escalate the best existing plan via final/pending-approval without auto-implementation.`;
+	if (input.json) {
+		return {
+			status: 3,
+			stdout: `${JSON.stringify(
+				{
+					ok: false,
+					planning_stuck: true,
+					marker: PLANNING_STUCK_MARKER,
+					run_id: input.runId,
+					stage: input.stage,
+					stage_n: input.stageN,
+					iteration: input.decision.currentIterations,
+					projected_iteration: input.decision.projectedIterations,
+					max_iterations: input.decision.maxIterations,
+					max_iterations_source: input.source,
+					reason: input.decision.reason,
+				},
+				null,
+				2,
+			)}\n`,
+			stderr: `${detail}\n`,
+		};
+	}
+	return {
+		status: 3,
+		stdout: `${PLANNING_STUCK_MARKER}\n`,
+		stderr: `${detail}\n`,
+	};
+}
 
 const KNOWN_ARCHITECT_KINDS = new Set(["openai-code"]);
 const KNOWN_CRITIC_KINDS = new Set(["openai-code"]);
@@ -736,6 +894,27 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 			);
 		}
 		return buildDeduplicatedResult(resolved, existingArtifact, sha256, cwd, repositoryBinding);
+	}
+
+	// Consensus iteration budget (#3165): refuse new planner/revision openers past the cap.
+	// Dedupe returns above so identical re-writes never stuck-signal. Non-openers (architect,
+	// critic, final, …) remain allowed so operators can escalate without auto-implementation.
+	const indexRows = await readRalplanIndexRows(cwd, resolved.sessionId, resolved.runId);
+	const { maxIterations, source: maxIterationsSource } = await resolveRalplanMaxIterations(cwd);
+	const capDecision = evaluateRalplanIterationCap({
+		rows: indexRows,
+		stage: resolved.stage,
+		maxIterations,
+	});
+	if (!capDecision.allowed) {
+		return buildPlanningStuckResult({
+			json: resolved.json,
+			stage: resolved.stage,
+			stageN: resolved.stageN,
+			runId: resolved.runId,
+			decision: capDecision,
+			source: maxIterationsSource,
+		});
 	}
 
 	// Keep run-state `current_phase` coherent with the stage being persisted.

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -94,11 +94,16 @@ export type RalplanIterationCapDecision =
  * A `planner` or `revision` write opens a new iteration (same definition as
  * `summarizeRalplanIndex`). Other stages never open iterations and are always
  * allowed by this gate — including `final` after the cap is already reached.
+ *
+ * `iterationFloor` raises the observed opener count when on-disk evidence or a
+ * recovered ledger is higher than the parsed index (fail-closed vs wipe/truncate).
  */
 export function evaluateRalplanIterationCap(input: {
 	rows: readonly RalplanIndexRow[];
 	stage: string;
 	maxIterations?: number;
+	/** Minimum opener count (e.g. on-disk stage-*-{planner,revision}.md). */
+	iterationFloor?: number;
 }): RalplanIterationCapDecision {
 	const maxIterations =
 		typeof input.maxIterations === "number" &&
@@ -107,7 +112,12 @@ export function evaluateRalplanIterationCap(input: {
 		input.maxIterations <= RALPLAN_MAX_ITERATIONS_LIMIT
 			? input.maxIterations
 			: RALPLAN_DEFAULT_MAX_ITERATIONS;
-	const currentIterations = summarizeRalplanIndex(input.rows).iteration;
+	const fromIndex = summarizeRalplanIndex(input.rows).iteration;
+	const floor =
+		typeof input.iterationFloor === "number" && Number.isInteger(input.iterationFloor) && input.iterationFloor > 0
+			? input.iterationFloor
+			: 0;
+	const currentIterations = Math.max(fromIndex, floor);
 	if (!RALPLAN_ITERATION_OPENER_STAGES.has(input.stage as RalplanStage)) {
 		return {
 			allowed: true,
@@ -118,6 +128,7 @@ export function evaluateRalplanIterationCap(input: {
 	}
 	const projectedIterations = currentIterations + 1;
 	if (projectedIterations > maxIterations) {
+		const ledgerNote = floor > fromIndex ? ` (ledger under-count: index=${fromIndex}, on-disk openers=${floor})` : "";
 		return {
 			allowed: false,
 			currentIterations,
@@ -125,7 +136,7 @@ export function evaluateRalplanIterationCap(input: {
 			maxIterations,
 			reason:
 				`ralplan consensus iteration cap exceeded: opening ${input.stage} would start ` +
-				`iteration ${projectedIterations} (max ${maxIterations})`,
+				`iteration ${projectedIterations} (max ${maxIterations})${ledgerNote}`,
 		};
 	}
 	return {
@@ -134,6 +145,63 @@ export function evaluateRalplanIterationCap(input: {
 		projectedIterations,
 		maxIterations,
 	};
+}
+
+/** Filename pattern for persisted planner/revision stage artifacts. */
+const OPENER_ARTIFACT_RE = /^stage-\d{2,}-(planner|revision)\.md$/;
+
+/**
+ * Count on-disk planner/revision stage artifacts for a run. Used as a floor when
+ * `index.jsonl` is missing, empty, truncated, or otherwise under-counts openers.
+ */
+export async function countRalplanOnDiskOpeners(cwd: string, sessionId: string, runId: string): Promise<number> {
+	const runDir = path.join(sessionPlansDir(cwd, sessionId), "ralplan", runId);
+	try {
+		const entries = await fs.readdir(runDir);
+		let count = 0;
+		for (const name of entries) {
+			if (OPENER_ARTIFACT_RE.test(name)) count += 1;
+		}
+		return count;
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Load index rows for cap enforcement. Unlike HUD reads, returns structural
+ * signals so callers can fail closed when the ledger is empty/malformed while
+ * opener artifacts already exist on disk.
+ */
+export async function loadRalplanIndexForCap(
+	cwd: string,
+	sessionId: string,
+	runId: string,
+): Promise<{ rows: RalplanIndexRow[]; indexPresent: boolean; parseableLines: number; rawLineCount: number }> {
+	const indexPath = path.join(sessionPlansDir(cwd, sessionId), "ralplan", runId, "index.jsonl");
+	try {
+		const text = await fs.readFile(indexPath, "utf8");
+		const lines = text.split(/\r?\n/).filter(line => line.trim().length > 0);
+		const rows: RalplanIndexRow[] = [];
+		for (const line of lines) {
+			const row = parseRalplanIndexLine(line);
+			if (row) rows.push(row);
+		}
+		return {
+			rows,
+			indexPresent: true,
+			parseableLines: rows.length,
+			rawLineCount: lines.length,
+		};
+	} catch (error) {
+		const code =
+			error && typeof error === "object" && "code" in error ? (error as { code?: string }).code : undefined;
+		if (code === "ENOENT") {
+			return { rows: [], indexPresent: false, parseableLines: 0, rawLineCount: 0 };
+		}
+		// Unreadable index: treat as present-but-untrusted empty parse.
+		return { rows: [], indexPresent: true, parseableLines: 0, rawLineCount: 0 };
+	}
 }
 
 function parseMaxIterationsValue(value: unknown): number | null {
@@ -899,12 +967,16 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 	// Consensus iteration budget (#3165): refuse new planner/revision openers past the cap.
 	// Dedupe returns above so identical re-writes never stuck-signal. Non-openers (architect,
 	// critic, final, …) remain allowed so operators can escalate without auto-implementation.
-	const indexRows = await readRalplanIndexRows(cwd, resolved.sessionId, resolved.runId);
+	// On-disk opener artifacts floor the count so a wiped/truncated/malformed index.jsonl cannot
+	// under-count and fail open after prior planner/revision writes.
+	const indexLoad = await loadRalplanIndexForCap(cwd, resolved.sessionId, resolved.runId);
+	const onDiskOpeners = await countRalplanOnDiskOpeners(cwd, resolved.sessionId, resolved.runId);
 	const { maxIterations, source: maxIterationsSource } = await resolveRalplanMaxIterations(cwd);
 	const capDecision = evaluateRalplanIterationCap({
-		rows: indexRows,
+		rows: indexLoad.rows,
 		stage: resolved.stage,
 		maxIterations,
+		iterationFloor: onDiskOpeners,
 	});
 	if (!capDecision.allowed) {
 		return buildPlanningStuckResult({

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -1195,6 +1195,27 @@ describe("ralplan consensus iteration cap (#3165)", () => {
 				maxIterations: 2,
 			}).allowed,
 		).toBe(false);
+		// Floor from on-disk openers wins over an empty/under-counted index.
+		expect(
+			evaluateRalplanIterationCap({
+				rows: [],
+				stage: "revision",
+				maxIterations: 5,
+				iterationFloor: 5,
+			}),
+		).toMatchObject({
+			allowed: false,
+			currentIterations: 5,
+			projectedIterations: 6,
+		});
+		expect(
+			evaluateRalplanIterationCap({
+				rows: [{ stage: "planner", stageN: 1 }],
+				stage: "revision",
+				maxIterations: 5,
+				iterationFloor: 3,
+			}).allowed,
+		).toBe(true);
 	});
 
 	it("rejects a 6th revision opener with PLANNING-STUCK and still allows final", async () => {
@@ -1277,5 +1298,120 @@ describe("ralplan consensus iteration cap (#3165)", () => {
 		const payload = JSON.parse(first.stdout ?? "{}");
 		expect(payload.deduplicated).toBe(true);
 		expect(payload.planning_stuck).toBeUndefined();
+	});
+	it("fails closed when index.jsonl is emptied after max openers (ledger wipe)", async () => {
+		const root = await tempDir();
+		const runId = "wipe-cap";
+		const write = async (stage: string, stageN: number, body: string) =>
+			runNativeRalplanCommand(
+				["--write", "--stage", stage, "--stage_n", String(stageN), "--artifact", body, "--run-id", runId, "--json"],
+				root,
+			);
+
+		expect((await write("planner", 1, "# p")).status).toBe(0);
+		for (let n = 2; n <= 5; n++) {
+			expect((await write("revision", n, `# r${n}`)).status).toBe(0);
+		}
+
+		const indexPath = path.join(ralplanRunDir(root, runId), "index.jsonl");
+		await fs.writeFile(indexPath, "", "utf-8");
+
+		const stuck = await write("revision", 6, "# after wipe");
+		expect(stuck.status).toBe(3);
+		const payload = JSON.parse(stuck.stdout ?? "{}");
+		expect(payload.planning_stuck).toBe(true);
+		expect(payload.reason).toContain("on-disk openers");
+		// Non-openers still escalate after untrusted ledger.
+		expect((await write("final", 6, "# final after wipe")).status).toBe(0);
+	});
+
+	it("fails closed when index.jsonl is truncated under on-disk openers", async () => {
+		const root = await tempDir();
+		const runId = "trunc-cap";
+		const write = async (stage: string, stageN: number, body: string) =>
+			runNativeRalplanCommand(
+				["--write", "--stage", stage, "--stage_n", String(stageN), "--artifact", body, "--run-id", runId, "--json"],
+				root,
+			);
+
+		expect((await write("planner", 1, "# p")).status).toBe(0);
+		for (let n = 2; n <= 5; n++) {
+			expect((await write("revision", n, `# r${n}`)).status).toBe(0);
+		}
+
+		const indexPath = path.join(ralplanRunDir(root, runId), "index.jsonl");
+		const full = await fs.readFile(indexPath, "utf-8");
+		const firstLine = full.split(/\r?\n/).find(line => line.trim().length > 0) ?? "";
+		await fs.writeFile(indexPath, `${firstLine}\n`, "utf-8");
+
+		const stuck = await write("revision", 6, "# after truncate");
+		expect(stuck.status).toBe(3);
+		expect(JSON.parse(stuck.stdout ?? "{}").planning_stuck).toBe(true);
+	});
+
+	it("fails closed when index.jsonl is only malformed lines while openers exist on disk", async () => {
+		const root = await tempDir();
+		const runId = "malformed-cap";
+		const write = async (stage: string, stageN: number, body: string) =>
+			runNativeRalplanCommand(
+				["--write", "--stage", stage, "--stage_n", String(stageN), "--artifact", body, "--run-id", runId, "--json"],
+				root,
+			);
+
+		expect((await write("planner", 1, "# p")).status).toBe(0);
+		for (let n = 2; n <= 5; n++) {
+			expect((await write("revision", n, `# r${n}`)).status).toBe(0);
+		}
+
+		const indexPath = path.join(ralplanRunDir(root, runId), "index.jsonl");
+		await fs.writeFile(indexPath, '{not-json\nnot a row\n{"stage":1}\n', "utf-8");
+
+		const stuck = await write("revision", 6, "# after malformed");
+		expect(stuck.status).toBe(3);
+		expect(JSON.parse(stuck.stdout ?? "{}").planning_stuck).toBe(true);
+		// architect/critic remain allowed (not openers)
+		expect((await write("architect", 6, "# a")).status).toBe(0);
+		expect((await write("critic", 6, "Verdict: ITERATE")).status).toBe(0);
+	});
+
+	it("fails closed when index is deleted but opener stage files remain", async () => {
+		const root = await tempDir();
+		const runId = "delete-index-cap";
+		const write = async (stage: string, stageN: number, body: string) =>
+			runNativeRalplanCommand(
+				["--write", "--stage", stage, "--stage_n", String(stageN), "--artifact", body, "--run-id", runId, "--json"],
+				root,
+			);
+
+		expect((await write("planner", 1, "# p")).status).toBe(0);
+		for (let n = 2; n <= 5; n++) {
+			expect((await write("revision", n, `# r${n}`)).status).toBe(0);
+		}
+
+		await fs.rm(path.join(ralplanRunDir(root, runId), "index.jsonl"), { force: true });
+
+		const stuck = await write("revision", 6, "# after delete index");
+		expect(stuck.status).toBe(3);
+		expect(JSON.parse(stuck.stdout ?? "{}").planning_stuck).toBe(true);
+	});
+
+	it("clean new run_id still allows openers after another run is ledger-stuck", async () => {
+		const root = await tempDir();
+		const write = async (runId: string, stage: string, stageN: number, body: string) =>
+			runNativeRalplanCommand(
+				["--write", "--stage", stage, "--stage_n", String(stageN), "--artifact", body, "--run-id", runId, "--json"],
+				root,
+			);
+
+		expect((await write("run-old", "planner", 1, "# p")).status).toBe(0);
+		for (let n = 2; n <= 5; n++) {
+			expect((await write("run-old", "revision", n, `# r${n}`)).status).toBe(0);
+		}
+		await fs.writeFile(path.join(ralplanRunDir(root, "run-old"), "index.jsonl"), "", "utf-8");
+		expect((await write("run-old", "revision", 6, "# stuck")).status).toBe(3);
+
+		// Fresh run is independent even while the old run remains at cap under wipe.
+		expect((await write("run-new", "planner", 1, "# p-new")).status).toBe(0);
+		expect((await write("run-new", "revision", 2, "# r2-new")).status).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -1,7 +1,12 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
+import {
+	evaluateRalplanIterationCap,
+	PLANNING_STUCK_MARKER,
+	RALPLAN_DEFAULT_MAX_ITERATIONS,
+	runNativeRalplanCommand,
+} from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
 import {
 	GJC_RALPLAN_ARTIFACT_ENV,
 	GJC_RESTRICTED_ROLE_AGENT_BASH_ENV,
@@ -1152,5 +1157,125 @@ describe("native gjc ralplan runtime — post-clear re-activation (#644)", () =>
 		const after = await readState(root);
 		expect(after.active).toBe(false);
 		expect(after.current_phase).toBe("complete");
+	});
+});
+describe("ralplan consensus iteration cap (#3165)", () => {
+	it("evaluateRalplanIterationCap allows openers up to max and rejects the next", () => {
+		const rows = [
+			{ stage: "planner", stageN: 1 },
+			{ stage: "architect", stageN: 1 },
+			{ stage: "critic", stageN: 1 },
+			{ stage: "revision", stageN: 2 },
+			{ stage: "revision", stageN: 3 },
+			{ stage: "revision", stageN: 4 },
+			{ stage: "revision", stageN: 5 },
+		];
+		expect(evaluateRalplanIterationCap({ rows, stage: "revision" })).toMatchObject({
+			allowed: false,
+			currentIterations: 5,
+			projectedIterations: 6,
+			maxIterations: RALPLAN_DEFAULT_MAX_ITERATIONS,
+		});
+		expect(evaluateRalplanIterationCap({ rows, stage: "final" }).allowed).toBe(true);
+		expect(evaluateRalplanIterationCap({ rows, stage: "architect" }).allowed).toBe(true);
+		expect(
+			evaluateRalplanIterationCap({
+				rows: [{ stage: "planner", stageN: 1 }],
+				stage: "revision",
+				maxIterations: 2,
+			}).allowed,
+		).toBe(true);
+		expect(
+			evaluateRalplanIterationCap({
+				rows: [
+					{ stage: "planner", stageN: 1 },
+					{ stage: "revision", stageN: 2 },
+				],
+				stage: "revision",
+				maxIterations: 2,
+			}).allowed,
+		).toBe(false);
+	});
+
+	it("rejects a 6th revision opener with PLANNING-STUCK and still allows final", async () => {
+		const root = await tempDir();
+		const runId = "cap-run";
+		const write = async (stage: string, stageN: number, body: string) =>
+			runNativeRalplanCommand(
+				["--write", "--stage", stage, "--stage_n", String(stageN), "--artifact", body, "--run-id", runId, "--json"],
+				root,
+			);
+
+		expect((await write("planner", 1, "# p1")).status).toBe(0);
+		expect((await write("architect", 1, "# a1")).status).toBe(0);
+		expect((await write("critic", 1, "Verdict: ITERATE")).status).toBe(0);
+		for (let n = 2; n <= 5; n++) {
+			expect((await write("revision", n, `# r${n}`)).status).toBe(0);
+			expect((await write("architect", n, `# a${n}`)).status).toBe(0);
+			expect((await write("critic", n, "Verdict: ITERATE")).status).toBe(0);
+		}
+
+		const stuck = await write("revision", 6, "# r6 perpetual iterate");
+		expect(stuck.status).toBe(3);
+		expect(stuck.stdout).toContain(PLANNING_STUCK_MARKER);
+		expect(stuck.stderr).toContain(PLANNING_STUCK_MARKER);
+		const payload = JSON.parse(stuck.stdout ?? "{}");
+		expect(payload).toMatchObject({
+			ok: false,
+			planning_stuck: true,
+			marker: PLANNING_STUCK_MARKER,
+			max_iterations: 5,
+			projected_iteration: 6,
+		});
+
+		const final = await write("final", 6, "# best effort pending approval");
+		expect(final.status).toBe(0);
+		expect(final.stdout).toContain("pending_approval_path");
+	});
+
+	it("honors project settings maxIterations=2 and resets budget on new run_id", async () => {
+		const root = await tempDir();
+		await fs.mkdir(path.join(root, ".gjc"), { recursive: true });
+		await fs.writeFile(
+			path.join(root, ".gjc", "settings.json"),
+			JSON.stringify({ gjc: { ralplan: { maxIterations: 2 } } }),
+			"utf-8",
+		);
+
+		const write = async (runId: string, stage: string, stageN: number, body: string) =>
+			runNativeRalplanCommand(
+				["--write", "--stage", stage, "--stage_n", String(stageN), "--artifact", body, "--run-id", runId, "--json"],
+				root,
+			);
+
+		expect((await write("run-a", "planner", 1, "# p")).status).toBe(0);
+		expect((await write("run-a", "revision", 2, "# r2")).status).toBe(0);
+		const stuck = await write("run-a", "revision", 3, "# r3");
+		expect(stuck.status).toBe(3);
+		expect(JSON.parse(stuck.stdout ?? "{}").max_iterations).toBe(2);
+
+		// Fresh run_id must not inherit the stuck budget.
+		expect((await write("run-b", "planner", 1, "# p-b")).status).toBe(0);
+		expect((await write("run-b", "revision", 2, "# r2-b")).status).toBe(0);
+	});
+
+	it("dedupes an identical revision write at the cap without PLANNING-STUCK", async () => {
+		const root = await tempDir();
+		const runId = "dedupe-cap";
+		const write = async (stage: string, stageN: number, body: string) =>
+			runNativeRalplanCommand(
+				["--write", "--stage", stage, "--stage_n", String(stageN), "--artifact", body, "--run-id", runId, "--json"],
+				root,
+			);
+
+		expect((await write("planner", 1, "# p")).status).toBe(0);
+		for (let n = 2; n <= 5; n++) {
+			expect((await write("revision", n, `# r${n}`)).status).toBe(0);
+		}
+		const first = await write("revision", 5, "# r5");
+		expect(first.status).toBe(0);
+		const payload = JSON.parse(first.stdout ?? "{}");
+		expect(payload.deduplicated).toBe(true);
+		expect(payload.planning_stuck).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary
- Enforce a deterministic finite consensus-iteration budget in native `gjc ralplan --write` so perpetual Critic `ITERATE` cannot open unbounded planner/revision rounds.
- Default max is **5** (matches skill prose); optional override `gjc.ralplan.maxIterations` (1..20) in project/user `.gjc/settings.json`.
- Cap overflow exits **3** with operator-visible **`PLANNING-STUCK`** (stdout + stderr; JSON `planning_stuck: true`). Architect/critic within an opened pass and `final`/`post-interview`/`adr` remain allowed so the best plan can escalate to pending-approval **without auto-implementation**.

Fixes #3165

## Changes
- `evaluateRalplanIterationCap` / `resolveRalplanMaxIterations` in `ralplan-runtime.ts` reuse the existing `summarizeRalplanIndex` opener definition (`planner`/`revision`).
- Settings schema key `gjc.ralplan.maxIterations`.
- Skill + CHANGELOG operator contract for headless vs interactive stuck handling.
- Tests: pure evaluator, adversarial 6th revision stuck, final after stuck, settings override + run_id reset, dedupe at cap.

## Verification
```
bun test packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
# 54 pass
bun test packages/coding-agent/test/default-gjc-definitions.test.ts
# 31 pass
```

## Non-goals
- No critic severity/convergence heuristic (issue option 3 deferred).
- No automatic ultragoal/team handoff on stuck.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*