### PR TITLE
fix(ai): honor documented GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Anthropic `ping` keepalives no longer reset stream progress, so responses that stop producing content now reach the idle timeout instead of hanging indefinitely.
+- The documented `GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS` environment variable now takes effect: the stream-watchdog idle-timeout helpers resolve it GJC-first before the legacy `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` / `PI_STREAM_IDLE_TIMEOUT_MS` aliases (previously only the `PI_`-prefixed names were read, so setting the documented GJC name was a silent no-op).
 
 ## [0.11.10] - 2026-07-25
 

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -19,7 +19,7 @@ function normalizeIdleTimeoutMs(value: string | undefined, fallback: number): nu
 /**
  * Returns the idle timeout used for provider streaming transports.
  *
- * `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` is accepted as a backward-compatible alias.
+ * `GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS` is honored first; `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` is a backward-compatible alias.
  * Set `PI_STREAM_IDLE_TIMEOUT_MS=0` to disable the watchdog.
  *
  * Providers that legitimately stream much slower than the global default can pass
@@ -27,17 +27,20 @@ function normalizeIdleTimeoutMs(value: string | undefined, fallback: number): nu
  * Caller options still take precedence; env overrides still trump the fallback.
  */
 export function getStreamIdleTimeoutMs(fallbackMs: number = DEFAULT_STREAM_IDLE_TIMEOUT_MS): number | undefined {
-	return normalizeIdleTimeoutMs($env.PI_STREAM_IDLE_TIMEOUT_MS ?? $env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS, fallbackMs);
+	return normalizeIdleTimeoutMs(
+		$env.GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS ?? $env.PI_STREAM_IDLE_TIMEOUT_MS ?? $env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS,
+		fallbackMs,
+	);
 }
 
 /**
  * Returns the idle timeout used for OpenAI-family streaming transports.
  *
- * Set `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS=0` to disable the watchdog.
+ * Honors `GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS` first (`PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` is the legacy alias). Set `=0` to disable.
  */
 export function getOpenAIStreamIdleTimeoutMs(): number | undefined {
 	return normalizeIdleTimeoutMs(
-		$env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS ?? $env.PI_STREAM_IDLE_TIMEOUT_MS,
+		$env.GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS ?? $env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS ?? $env.PI_STREAM_IDLE_TIMEOUT_MS,
 		DEFAULT_STREAM_IDLE_TIMEOUT_MS,
 	);
 }

--- a/packages/ai/test/stream-timeout-defaults.test.ts
+++ b/packages/ai/test/stream-timeout-defaults.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
+	getOpenAIStreamIdleTimeoutMs,
 	getProviderFirstEventTimeoutFallbackMs,
 	getStreamFirstEventTimeoutMs,
 	getStreamIdleTimeoutMs,
@@ -17,6 +18,7 @@ import {
 const ENV_KEYS = [
 	"PI_STREAM_IDLE_TIMEOUT_MS",
 	"PI_OPENAI_STREAM_IDLE_TIMEOUT_MS",
+	"GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS",
 	"PI_STREAM_FIRST_EVENT_TIMEOUT_MS",
 ] as const;
 
@@ -62,6 +64,35 @@ describe("getStreamIdleTimeoutMs(fallbackMs)", () => {
 	it("treats PI_STREAM_IDLE_TIMEOUT_MS=0 as a watchdog disable", () => {
 		Bun.env.PI_STREAM_IDLE_TIMEOUT_MS = "0";
 		expect(getStreamIdleTimeoutMs(300_000)).toBeUndefined();
+	});
+
+	it("honors the documented GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS override", () => {
+		Bun.env.GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS = "77";
+		expect(getStreamIdleTimeoutMs(300_000)).toBe(77);
+	});
+
+	it("resolves GJC-first: GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS wins over legacy PI_STREAM_IDLE_TIMEOUT_MS", () => {
+		Bun.env.GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS = "77";
+		Bun.env.PI_STREAM_IDLE_TIMEOUT_MS = "42";
+		expect(getStreamIdleTimeoutMs(300_000)).toBe(77);
+	});
+
+	it("treats GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS=0 as a watchdog disable", () => {
+		Bun.env.GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS = "0";
+		expect(getStreamIdleTimeoutMs(300_000)).toBeUndefined();
+	});
+});
+
+describe("getOpenAIStreamIdleTimeoutMs()", () => {
+	it("honors the documented GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS first", () => {
+		Bun.env.GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS = "88";
+		Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = "42";
+		expect(getOpenAIStreamIdleTimeoutMs()).toBe(88);
+	});
+
+	it("falls back to the legacy PI_OPENAI_STREAM_IDLE_TIMEOUT_MS alias", () => {
+		Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = "42";
+		expect(getOpenAIStreamIdleTimeoutMs()).toBe(42);
 	});
 });
 


### PR DESCRIPTION
## What

`docs/environment-variables.md` documents `GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS`, but the stream-watchdog idle-timeout helpers in `packages/ai/src/utils/idle-iterator.ts` only read the legacy `PI_`-prefixed names:

- `getStreamIdleTimeoutMs`: `PI_STREAM_IDLE_TIMEOUT_MS ?? PI_OPENAI_STREAM_IDLE_TIMEOUT_MS`
- `getOpenAIStreamIdleTimeoutMs`: `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS ?? PI_STREAM_IDLE_TIMEOUT_MS`

So setting the documented GJC name was a silent no-op.

## Fix

Resolve `GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS` **first** in both getters, keeping the `PI_` names as backward-compatible fallbacks. Same class as the merged GJC_* env migrations (#2827 / #2943 / #3041); this is the deferred stream-idle piece noted as a follow-up in #3041.

Semantics preserved: the existing `??` nullish chain is kept (GJC unset ⇒ identical PI behavior), and `=0` still disables the watchdog. No new imports (uses the already-imported `$env`).

## Tests

`stream-timeout-defaults.test.ts` extended: GJC-first precedence over `PI_STREAM_IDLE_TIMEOUT_MS`, documented-override, `=0` disable, and legacy `PI_OPENAI` alias fallback — for both `getStreamIdleTimeoutMs` and `getOpenAIStreamIdleTimeoutMs`. Full file: 16 pass / 0 fail; `ai` `tsc` + `biome` clean.