### PR TITLE
fix(utils): validate integer CLI flags exactly

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -9,6 +9,11 @@
 ### Fixed
 
 - Fatal crashes (`uncaughtException` / `unhandledRejection`) are now also persisted to a dedicated, append-only crash log (`~/.gjc/agent/gjc-crash.log`) before any stderr output, and the fatal handler prints the crash-log path. The daily logger file is gzip-archived independently by every gjc process at date rollover; that shared-archive race can truncate a day's log to an empty `.gz` and destroy the `logger.error` crash record, leaving crashes undiagnosable. The rotation-immune crash log is capped at 512 KB, bounds every individual record (UTF-8-safe truncation with a marker), scrubs credential material (bearer/auth headers, key=value credential fields, and well-known vendor token shapes) before persisting, and enforces owner-only file permissions.
+### Fixed
+
+- Integer CLI flags now reject trailing characters, decimals, exponent notation, surrounding whitespace, and values outside JavaScript's safe-integer range instead of silently truncating or rounding them.
+
+## [0.11.8] - 2026-07-23
 
 ## [0.11.7] - 2026-07-22
 ### Added

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -211,8 +211,11 @@ export abstract class Command {
 				if (raw === undefined || typeof raw === "boolean") {
 					flags[name] = desc.default ?? undefined;
 				} else {
-					const n = Number.parseInt(raw as string, 10);
-					if (Number.isNaN(n)) {
+					if (typeof raw !== "string" || !/^-?\d+$/.test(raw)) {
+						throw new CliParseError(`Expected integer for --${name}, got "${String(raw)}"`);
+					}
+					const n = Number(raw);
+					if (!Number.isSafeInteger(n)) {
 						throw new CliParseError(`Expected integer for --${name}, got "${raw}"`);
 					}
 					flags[name] = n;

--- a/packages/utils/test/cli.test.ts
+++ b/packages/utils/test/cli.test.ts
@@ -12,6 +12,7 @@ class Demo extends Command {
 	};
 	static flags = {
 		scope: Flags.string({ description: "scope", options: ["user", "project"] }),
+		count: Flags.integer({ description: "count" }),
 	};
 	async run(): Promise<void> {
 		const { args } = await this.parse(Demo);
@@ -101,6 +102,28 @@ describe("cli parse — CliParseError for invalid input", () => {
 		const cmd = new Demo(["build", "--scope", "porject"], CFG);
 		await expect(cmd.parse(Demo)).rejects.toBeInstanceOf(CliParseError);
 		await expect(cmd.parse(Demo)).rejects.toThrow(/Expected --scope to be one of: user, project/);
+	});
+
+	it.each([
+		"12oops",
+		"1.5",
+		"1e3",
+		" 12 ",
+		"9007199254740992",
+	])("throws CliParseError for a non-exact integer flag value %j", async value => {
+		const cmd = new Demo(["build", "--count", value], CFG);
+		await expect(cmd.parse(Demo)).rejects.toBeInstanceOf(CliParseError);
+		await expect(cmd.parse(Demo)).rejects.toThrow(`Expected integer for --count, got "${value}"`);
+	});
+
+	it.each([
+		["--count=0", 0],
+		["--count=-12", -12],
+		["--count=0012", 12],
+	])("accepts exact integer flag token %j", async (flag, expected) => {
+		const cmd = new Demo(["build", flag], CFG);
+		const { flags } = await cmd.parse(Demo);
+		expect(flags.count).toBe(expected);
 	});
 
 	it("wraps node:util unknown-flag errors as CliParseError (strict command)", async () => {


### PR DESCRIPTION
## Summary
- reject partially parsed integer flags such as `12oops`, decimals, and exponent notation
- reject values outside JavaScript safe-integer range instead of rounding them
- preserve exact signed integer support and add parser regression coverage

## Verification
- `bun test packages/utils/test/cli.test.ts` (19 passed)
- `bun --cwd=packages/utils run check`
- `git diff --check`