### PR TITLE
fix(utils): reject extra CLI positionals (#3173)

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Strict CLI commands now reject unexpected positional arguments with usage guidance instead of silently ignoring typos or unsupported trailing input; non-strict passthrough commands and variadic arguments retain their existing behavior (#3173).
+
 ## [0.11.10] - 2026-07-25
 
 ## [0.11.9] - 2026-07-24

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -270,6 +270,12 @@ export abstract class Command {
 			}
 		}
 
+		if (strict && posIdx < positionals.length) {
+			const unexpected = positionals.slice(posIdx);
+			const rendered = unexpected.map(value => JSON.stringify(value)).join(", ");
+			throw new CliParseError(`Unexpected argument${unexpected.length === 1 ? "" : "s"}: ${rendered}`);
+		}
+
 		return { flags, args, argv: positionals } as never;
 	}
 }

--- a/packages/utils/test/cli.test.ts
+++ b/packages/utils/test/cli.test.ts
@@ -126,6 +126,38 @@ describe("cli parse — CliParseError for invalid input", () => {
 		expect(flags.count).toBe(expected);
 	});
 
+	it("throws CliParseError for extra positional arguments in strict commands", async () => {
+		const cmd = new Demo(["build", "unexpected", "also-unexpected"], CFG);
+		await expect(cmd.parse(Demo)).rejects.toBeInstanceOf(CliParseError);
+		await expect(cmd.parse(Demo)).rejects.toThrow('Unexpected arguments: "unexpected", "also-unexpected"');
+	});
+
+	it("preserves extra positional arguments for commands that opt out of strict parsing", async () => {
+		class NonStrict extends Command {
+			static strict = false;
+			static args = { action: Args.string({}) };
+			async run(): Promise<void> {
+				await this.parse(NonStrict);
+			}
+		}
+		const cmd = new NonStrict(["build", "passthrough"], CFG);
+		const parsed = await cmd.parse(NonStrict);
+		expect(parsed.args.action).toBe("build");
+		expect(parsed.argv).toEqual(["build", "passthrough"]);
+	});
+
+	it("allows a multiple positional descriptor to consume every remaining argument", async () => {
+		class Multiple extends Command {
+			static args = { values: Args.string({ multiple: true }) };
+			async run(): Promise<void> {
+				await this.parse(Multiple);
+			}
+		}
+		const cmd = new Multiple(["one", "two"], CFG);
+		const parsed = await cmd.parse(Multiple);
+		expect(parsed.args.values).toEqual(["one", "two"]);
+	});
+
 	it("wraps node:util unknown-flag errors as CliParseError (strict command)", async () => {
 		class Strict extends Command {
 			static flags = { verbose: Flags.boolean({}) };
@@ -164,6 +196,15 @@ describe("cli run — usage instead of uncaught crash", () => {
 		expect(out.toLowerCase()).toContain("usage"); // renderCommandHelp printed the command usage
 		expect(exitCode).toBe(2);
 		expect(sideEffect.ran).toBe(false); // command body never ran
+	});
+
+	it("renders usage and skips execution for extra positional arguments", async () => {
+		sideEffect.ran = false;
+		const { err, out, exitCode } = await runCapturing(["demo", "build", "extra"]);
+		expect(err).toContain('Unexpected argument: "extra"');
+		expect(out.toLowerCase()).toContain("usage");
+		expect(exitCode).toBe(2);
+		expect(sideEffect.ran).toBe(false);
 	});
 
 	it("runs the command normally for valid input and leaves exitCode unset", async () => {


### PR DESCRIPTION
## Summary
- reject positional tokens left unconsumed by strict commands
- preserve passthrough behavior for `static strict = false` commands
- preserve variadic argument consumption
- render normal CLI usage and skip command execution on the new parse error

Closes #3173.

## Verification
- `bun test packages/utils/test/cli.test.ts` (15 passed)
- `bun --cwd=packages/utils run check`
- `bun test packages/coding-agent/test/cli-command-surface.test.ts packages/coding-agent/test/cli-command-registry.test.ts packages/coding-agent/test/cli-help-load-order.test.ts` (39 passed)
- `git diff --check`