### PR TITLE
test(ai): refresh anthropic cache eval provider identity pins

### DIFF
--- a/artifacts/architecture-2383-eval.json
+++ b/artifacts/architecture-2383-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "67cd55244f886f568da678bda4314298f01abf0e",
-		"providerSourceSha256": "978c083395de102cb8c78d1e25b164daea3c3558dbd7d90e7a190d3f22550e9b",
+		"providerSourceBlobOid": "cd917d79da5b050baaeff81d23c1621fb64d567e",
+		"providerSourceSha256": "01ef19c5c198f59003184d624c3e09660de4558e67179ff1084bc2c6de055d9d",
 		"inputFixtureSha256": "b1ca8d3183ca168140774f848ed414252178f7c5788d61243069862ae59c129b"
 	},
 	"derivationCommands": [


### PR DESCRIPTION
## What

Refreshes the two provider source-identity pins in `artifacts/architecture-2383-eval.json`.

## Why

#3167 (`fix(ai): time out stalled Anthropic ping streams`) modified `packages/ai/src/providers/anthropic.ts`, but did not refresh the eval artifact that pins that file's blob OID and sha256 as immutable evidence. The artifact still named the pre-#3167 blob, so `anthropic-cache-eval.integration.test.ts` fails on current `dev`:

```
- "providerSourceBlobOid": "cd917d79da5b050baaeff81d23c1621fb64d567e"   (actual, post-#3167)
+ "providerSourceBlobOid": "67cd55244f886f568da678bda4314298f01abf0e"   (artifact, pre-#3167)
```

Found by a red-team sweep of the post-#3167 `dev` head, not by CI — the affected-path gating did not schedule this suite for #3167.

## How

Regenerated with the artifact's own documented command:

```sh
WRITE_ARCHITECTURE_2383_EVAL=1 bun test packages/ai/test/anthropic-cache-eval.integration.test.ts
```

Only `providerSourceBlobOid` and `providerSourceSha256` changed. Every simulated retention measurement, per-turn number, method statement, and conclusion in the eval is byte identical, so this re-binds source identity without restating or weakening any finding.

## Tests

```sh
bun test packages/ai/test/anthropic-cache-eval.integration.test.ts packages/ai/test/anthropic-stream-timeout.test.ts
# 8 pass, 0 fail
```