### PR TITLE
fix(agent): bound and settle repeated malformed tool-call recovery

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Repeated malformed tool calls now get one tool-free recovery response, preventing argument-validation loops from ending without an answer while leaving ordinary execution-error retries unchanged. The recovery turn commits its assistant to the durable context, forces `toolChoice: "none"` alongside an empty tool list without consuming a queued tool choice, and never executes a tool call it did not advertise. Its recovery prompt is request-only, so append-only tool prefixes stay stable and the durable message log is unchanged.
+- Argument-validation loops now reach a deterministic terminal state. If a model keeps emitting only malformed tool calls after the one-shot recovery turn, the run stops with an explanatory error instead of calling the provider indefinitely. The bound counts consecutive all-malformed turns rather than repeated argument signatures, so a model rotating invalid argument shapes is bounded too; any healthy tool turn resets it.
+
 ## [0.11.10] - 2026-07-25
 
 ## [0.11.8] - 2026-07-23

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -16,6 +16,7 @@ import {
 	type ToolResultMessage,
 	type TSchema,
 	transportFailureFacts,
+	type UserMessage,
 	validateToolArguments,
 	zodToWireSchema,
 } from "@gajae-code/ai";
@@ -32,6 +33,7 @@ import {
 	shouldMitigateHarmonyLeak,
 	signalListLabel,
 } from "./harmony-leak";
+import repeatedToolFailureRecoveryPrompt from "./prompts/repeated-tool-failure-recovery.md" with { type: "text" };
 import { type AgentRunCoverage, type AgentRunSummary, ToolCallBlockedError } from "./run-collector";
 import {
 	type AgentTelemetry,
@@ -100,6 +102,17 @@ class ManagedAttemptSnapshotError extends Error {
 const managedAttemptTextEncoder = new TextEncoder();
 
 const ABORTED: unique symbol = Symbol("agent-loop-aborted");
+
+/**
+ * Terminal bound for argument-validation loops: how many CONSECUTIVE turns may
+ * consist entirely of malformed tool calls before the run stops.
+ *
+ * The one-shot tools-free recovery turn fires first; this is the deterministic
+ * backstop for a model that keeps emitting unusable calls after it. Counted per
+ * turn rather than per argument signature so a model rotating invalid shapes is
+ * bounded too.
+ */
+const MAX_CONSECUTIVE_MALFORMED_TURNS = 5;
 function managedContextOverflow(message: AssistantMessage, config: AgentLoopConfig): boolean {
 	const transportFailure = managedTransportFailure(message);
 	// Managed empty-stop responses may be repaired by the managed shell below; only
@@ -1247,6 +1260,21 @@ async function runLoopBody(
 	// Fires at most one repaired resend per run for the poisoned-history
 	// `invalid_prompt` circuit breaker below.
 	let invalidPromptRepairAttempted = false;
+	let previousMalformedToolSignatures = new Set<string>();
+	const recoveryState: {
+		pending: boolean;
+		inserted: boolean;
+		syntheticMessage?: UserMessage;
+	} = { pending: false, inserted: false };
+	let malformedToolRecoveryAttempted = false;
+	// Deterministic terminal circuit breaker for argument-validation loops.
+	//
+	// Counts CONSECUTIVE turns whose tool calls were all malformed, regardless of
+	// whether the arguments repeat. Signature-based "repeated" detection alone is
+	// not a bound: a model that rotates invalid argument shapes never trips it, so
+	// the loop could run forever. Any turn that produces a non-malformed batch
+	// resets the counter, so healthy runs are unaffected.
+	let consecutiveMalformedTurns = 0;
 
 	// Outer loop: continues when queued follow-up messages arrive after agent would stop
 	while (true) {
@@ -1331,6 +1359,15 @@ async function runLoopBody(
 								attemptTransaction.stageAssistantMessageEvent(partial, event),
 						}
 					: config;
+				if (recoveryState.pending && !recoveryState.inserted) {
+					recoveryState.syntheticMessage = {
+						role: "user",
+						content: repeatedToolFailureRecoveryPrompt,
+						synthetic: true,
+						timestamp: Date.now(),
+					};
+					recoveryState.inserted = true;
+				}
 				message = await streamAssistantResponse(
 					currentContext,
 					attemptConfig,
@@ -1341,6 +1378,9 @@ async function runLoopBody(
 					stepCounter,
 					streamFn,
 					harmonyRetryAttempt,
+					recoveryState.pending && recoveryState.syntheticMessage
+						? { syntheticMessage: recoveryState.syntheticMessage }
+						: undefined,
 				);
 				const detection = detectHarmonyLeakInAssistantMessage(message);
 				if (detection && shouldMitigateHarmonyLeak(config.model, detection)) {
@@ -1493,6 +1533,7 @@ async function runLoopBody(
 			if (config.fallbackManaged && message.stopReason !== "error" && message.stopReason !== "aborted") {
 				await config.onManagedAttemptAccepted?.();
 			}
+			const wasRecoveryAttempt = recoveryState.pending;
 
 			if (message.stopReason === "error" || message.stopReason === "aborted") {
 				// Create placeholder tool results for any tool calls in the aborted message
@@ -1527,24 +1568,65 @@ async function runLoopBody(
 			hasMoreToolCalls = toolCalls.length > 0;
 
 			const toolResults: ToolResultMessage[] = [];
+			let repeatedMalformedToolCall = false;
 			if (hasMoreToolCalls) {
-				const executionResult = await executeToolCalls(
-					currentContext,
-					message,
-					loopSignal,
-					stream,
-					config,
-					telemetry,
-					invokeAgentSpan,
-				);
+				if (wasRecoveryAttempt) {
+					for (const toolCall of toolCalls) {
+						const result = createAbortedToolResult(
+							toolCall,
+							stream,
+							"error",
+							"Tool calls are disabled during repeated malformed tool-call recovery.",
+						);
+						currentContext.messages.push(result);
+						newMessages.push(result);
+						toolResults.push(result);
+						recordSkippedTool(telemetry, {
+							toolCallId: toolCall.id,
+							toolName: toolCall.name,
+							status: "skipped",
+						});
+					}
+				} else {
+					const executionResult = await executeToolCalls(
+						currentContext,
+						message,
+						loopSignal,
+						stream,
+						config,
+						telemetry,
+						invokeAgentSpan,
+					);
 
-				toolResults.push(...executionResult.toolResults);
-				steeringMessagesFromExecution = executionResult.steeringMessages;
+					toolResults.push(...executionResult.toolResults);
+					steeringMessagesFromExecution = executionResult.steeringMessages;
 
-				for (const result of toolResults) {
-					currentContext.messages.push(result);
-					newMessages.push(result);
+					const malformedSignatures = executionResult.malformedToolCallSignatures;
+					const allToolCallsMalformed =
+						toolResults.length > 0 && malformedSignatures.length === toolResults.length;
+					if (allToolCallsMalformed) {
+						consecutiveMalformedTurns += 1;
+						const uniqueMalformedSignatures = new Set(malformedSignatures);
+						repeatedMalformedToolCall =
+							uniqueMalformedSignatures.size < malformedSignatures.length ||
+							[...uniqueMalformedSignatures].some(signature => previousMalformedToolSignatures.has(signature));
+						previousMalformedToolSignatures = uniqueMalformedSignatures;
+					} else {
+						consecutiveMalformedTurns = 0;
+						previousMalformedToolSignatures = new Set();
+					}
+
+					for (const result of toolResults) {
+						currentContext.messages.push(result);
+						newMessages.push(result);
+					}
 				}
+			}
+
+			if (wasRecoveryAttempt) {
+				recoveryState.pending = false;
+				recoveryState.inserted = false;
+				recoveryState.syntheticMessage = undefined;
 			}
 
 			stream.push({ type: "turn_end", message, toolResults });
@@ -1557,6 +1639,27 @@ async function runLoopBody(
 			if (pendingMessages.length > 0) continue;
 			if (config.shouldPause?.()) {
 				stream.push(buildAgentEndEvent(newMessages, telemetry, stepCounter.count, "paused"));
+				stream.end(newMessages);
+				return;
+			}
+			if (repeatedMalformedToolCall && !malformedToolRecoveryAttempted) {
+				recoveryState.pending = true;
+				recoveryState.inserted = false;
+				recoveryState.syntheticMessage = undefined;
+				malformedToolRecoveryAttempted = true;
+			} else if (consecutiveMalformedTurns >= MAX_CONSECUTIVE_MALFORMED_TURNS) {
+				// Deterministic terminal circuit breaker. The one-shot recovery turn
+				// above already had its chance; if the model is still emitting only
+				// malformed tool calls after it, the run cannot make progress and must
+				// stop rather than burn the provider budget. Terminates on consecutive
+				// count, not argument signatures, so rotating invalid shapes are bounded
+				// too.
+				message.stopReason = "error";
+				const breakerMessage = `Stopping after ${consecutiveMalformedTurns} consecutive turns of malformed tool calls; the model did not produce a usable tool call or answer.`;
+				message.errorMessage = message.errorMessage
+					? `${message.errorMessage} | ${breakerMessage}`
+					: breakerMessage;
+				stream.push(buildAgentEndEvent(newMessages, telemetry, stepCounter.count));
 				stream.end(newMessages);
 				return;
 			}
@@ -1615,6 +1718,7 @@ async function streamAssistantResponse(
 	stepCounter: StepCounter,
 	streamFn?: StreamFn,
 	harmonyRetryAttempt = 0,
+	recoveryMode?: { syntheticMessage: UserMessage },
 ): Promise<AssistantMessage> {
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
@@ -1639,7 +1743,24 @@ async function streamAssistantResponse(
 			tools: normalizeTools(context.tools, !!config.intentTracing),
 		};
 	}
-
+	if (recoveryMode) {
+		if (config.appendOnlyContext) {
+			const syntheticMessages = normalizeMessagesForProvider(
+				await config.convertToLlm([recoveryMode.syntheticMessage]),
+				config.model,
+			);
+			llmContext = { ...llmContext, messages: [...llmContext.messages, ...syntheticMessages], tools: [] };
+		} else {
+			llmContext = {
+				...llmContext,
+				messages: normalizeMessagesForProvider(
+					await config.convertToLlm([...messages, recoveryMode.syntheticMessage]),
+					config.model,
+				),
+				tools: [],
+			};
+		}
+	}
 	const streamFunction = streamFn || streamSimple;
 
 	// Resolve API key (important for expiring tokens) — do this before resolving
@@ -1654,7 +1775,7 @@ async function streamAssistantResponse(
 
 	const resolvedMetadata = config.metadataResolver ? config.metadataResolver(config.model.provider) : config.metadata;
 
-	const dynamicToolChoice = config.getToolChoice?.();
+	const dynamicToolChoice = recoveryMode ? undefined : config.getToolChoice?.();
 	const dynamicReasoning = config.getReasoning?.();
 	const harmonyMitigationEnabled = isHarmonyLeakMitigationTarget(config.model);
 	const harmonyAbortController = harmonyMitigationEnabled ? new AbortController() : undefined;
@@ -1665,7 +1786,7 @@ async function streamAssistantResponse(
 		: signal;
 	const effectiveTemperature =
 		harmonyRetryAttempt > 0 && config.temperature !== undefined ? config.temperature + 0.05 : config.temperature;
-	const effectiveToolChoice = dynamicToolChoice ?? config.toolChoice;
+	const effectiveToolChoice = recoveryMode ? "none" : (dynamicToolChoice ?? config.toolChoice);
 	const effectiveReasoning = dynamicReasoning ?? config.reasoning;
 
 	const chatStepNumber = stepCounter.count;
@@ -1910,7 +2031,11 @@ async function executeToolCalls(
 	config: AgentLoopConfig,
 	telemetry: AgentTelemetry | undefined,
 	invokeAgentSpan: Span | undefined,
-): Promise<{ toolResults: ToolResultMessage[]; steeringMessages?: AgentMessage[] }> {
+): Promise<{
+	toolResults: ToolResultMessage[];
+	steeringMessages?: AgentMessage[];
+	malformedToolCallSignatures: string[];
+}> {
 	const tools = currentContext.tools;
 	const {
 		getSteeringMessages,
@@ -1951,6 +2076,7 @@ async function executeToolCalls(
 		skipped: false,
 		toolResultMessage: undefined as ToolResultMessage | undefined,
 		resultEmitted: false,
+		argumentValidationFailed: false,
 	}));
 
 	const checkSteering = async (): Promise<void> => {
@@ -2070,6 +2196,7 @@ async function executeToolCalls(
 		await runInActiveSpan(toolSpan, async () => {
 			try {
 				if (toolCall.incompleteArguments) {
+					record.argumentValidationFailed = true;
 					// The provider flagged this call's argument JSON as truncated
 					// (the model hit its output-token limit mid-call). Executing the
 					// best-effort partial parse would run the tool on wrong input, so
@@ -2104,6 +2231,7 @@ async function executeToolCalls(
 					if (tool.lenientArgValidation) {
 						effectiveArgs = argsForExecution;
 					} else {
+						record.argumentValidationFailed = true;
 						throw validationError;
 					}
 				}
@@ -2255,7 +2383,12 @@ async function executeToolCalls(
 		}
 	}
 
-	return { toolResults: emittedToolResults, steeringMessages };
+	const malformedToolCallSignatures = records.flatMap(record =>
+		record.argumentValidationFailed && record.toolResultMessage?.isError
+			? [`${record.toolCall.name}:${JSON.stringify(record.toolCall.arguments)}`]
+			: [],
+	);
+	return { toolResults: emittedToolResults, steeringMessages, malformedToolCallSignatures };
 }
 
 /**

--- a/packages/agent/src/prompts/repeated-tool-failure-recovery.md
+++ b/packages/agent/src/prompts/repeated-tool-failure-recovery.md
@@ -1,0 +1,1 @@
+The immediately preceding tool calls failed because their arguments were malformed. Do not call any tools. Answer the original user request now using the conversation and any successful tool results already available. If the evidence is incomplete, state that limitation instead of returning an empty response.

--- a/packages/agent/test/agent-loop-malformed-circuit-breaker.test.ts
+++ b/packages/agent/test/agent-loop-malformed-circuit-breaker.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoopContinue } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
+import type { Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import * as z from "zod/v4";
+import { createUserMessage } from "./helpers";
+
+// Bounded termination for argument-validation loops.
+//
+// The one-shot tools-free recovery turn fires first. If the model keeps
+// emitting only malformed tool calls after it, the run must reach a
+// deterministic terminal state instead of looping against the provider
+// forever. The bound counts CONSECUTIVE all-malformed turns rather than
+// repeated argument signatures, so a model rotating invalid shapes -- which
+// never trips signature-based "repeated" detection -- is bounded too.
+
+const toolSchema = z.object({ value: z.string() });
+const RECOVERY_MARKER = "Do not call any tools";
+/** Well above the production bound; only guards the test runner. */
+const RUNAWAY_CAP = 60;
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+function throwingTool(onExecute?: () => void): AgentTool<typeof toolSchema, Record<string, never>> {
+	return {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute() {
+			onExecute?.();
+			throw new Error("invalid calls must not execute");
+		},
+	};
+}
+
+function countRecoveryPrompts(messages: readonly (AgentMessage | Message)[]): number {
+	return messages.filter(m => "content" in m && typeof m.content === "string" && m.content.includes(RECOVERY_MARKER))
+		.length;
+}
+
+/** Every toolCall id must have a matching toolResult (provider API requirement). */
+function assertToolPairing(messages: readonly AgentMessage[]): void {
+	const calledIds: string[] = [];
+	for (const message of messages) {
+		if (message.role !== "assistant") continue;
+		for (const block of message.content) {
+			if (block.type === "toolCall") calledIds.push(block.id);
+		}
+	}
+	const resultIds = new Set(
+		messages.filter(m => m.role === "toolResult").map(m => (m as { toolCallId: string }).toolCallId),
+	);
+	for (const id of calledIds) {
+		expect(resultIds.has(id)).toBe(true);
+	}
+}
+
+describe("malformed tool-call circuit breaker", () => {
+	it("terminates a never-ending identical malformed loop", async () => {
+		let executions = 0;
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool(() => (executions += 1))],
+		};
+		let calls = 0;
+		// Always the SAME invalid arguments -> trips signature "repeated" every turn.
+		const mock = createMockModel({
+			handler: () => {
+				calls += 1;
+				if (calls > RUNAWAY_CAP) return { content: ["runaway guard"] };
+				return { content: [{ type: "toolCall" as const, id: `tool-${calls}`, name: "echo", arguments: {} }] };
+			},
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoopContinue(context, config, undefined, mock.stream);
+		const events: AgentEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+		await stream.result();
+
+		// The loop stopped on its own, well before the runaway guard.
+		expect(calls).toBeLessThan(RUNAWAY_CAP);
+		// It ended terminally rather than silently going quiet.
+		const agentEnd = events.findLast(event => event.type === "agent_end");
+		expect(agentEnd).toBeDefined();
+		// The recovery turn still got its one chance before the breaker fired.
+		expect(executions).toBe(0);
+		assertToolPairing(context.messages);
+		// The request-only synthetic never leaked into durable history.
+		expect(countRecoveryPrompts(context.messages)).toBe(0);
+	}, 30_000);
+
+	it("terminates a rotating-signature malformed loop that never trips repeat detection", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool()],
+		};
+		let calls = 0;
+		// Every turn uses DIFFERENT invalid arguments, so the signature-overlap
+		// heuristic never reports "repeated". Only a consecutive-turn bound stops this.
+		const mock = createMockModel({
+			handler: () => {
+				calls += 1;
+				if (calls > RUNAWAY_CAP) return { content: ["runaway guard"] };
+				return {
+					content: [
+						{ type: "toolCall" as const, id: `tool-${calls}`, name: "echo", arguments: { rotating: calls } },
+					],
+				};
+			},
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoopContinue(context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+		await stream.result();
+
+		expect(calls).toBeLessThan(RUNAWAY_CAP);
+		assertToolPairing(context.messages);
+	}, 30_000);
+
+	it("reports a terminal error explaining why the run stopped", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool()],
+		};
+		let calls = 0;
+		const mock = createMockModel({
+			handler: () => {
+				calls += 1;
+				if (calls > RUNAWAY_CAP) return { content: ["runaway guard"] };
+				return { content: [{ type: "toolCall" as const, id: `tool-${calls}`, name: "echo", arguments: {} }] };
+			},
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoopContinue(context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+		const produced = (await stream.result()) as AgentMessage[];
+
+		// The terminating assistant message carries a diagnosable reason.
+		const last = produced.findLast(m => m.role === "assistant");
+		expect(last).toBeDefined();
+		if (last?.role !== "assistant") throw new Error("expected an assistant message");
+		expect(last.stopReason).toBe("error");
+		expect(last.errorMessage).toContain("consecutive turns of malformed tool calls");
+	}, 30_000);
+
+	it("does not fire when the model recovers into a real answer", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool()],
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				// The recovery turn answers, as intended.
+				{ content: ["recovered with a real answer"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoopContinue(context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+		const produced = (await stream.result()) as AgentMessage[];
+
+		// Normal completion: the breaker did not hijack a healthy recovery.
+		const last = produced.findLast(m => m.role === "assistant");
+		if (last?.role !== "assistant") throw new Error("expected an assistant message");
+		expect(last.stopReason).not.toBe("error");
+		expect(last.content.some(block => block.type === "text" && block.text === "recovered with a real answer")).toBe(
+			true,
+		);
+		expect(mock.calls.length).toBe(3);
+	});
+
+	it("does not count healthy tool turns toward the bound", async () => {
+		let executions = 0;
+		const okTool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				executions += 1;
+				return { content: [{ type: "text", text: "ok" }], details: { value: "ok" } };
+			},
+		};
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [okTool],
+		};
+		// Far more successful tool turns than the bound, then a normal answer.
+		const responses = Array.from({ length: 12 }, (_v, i) => ({
+			content: [{ type: "toolCall" as const, id: `tool-${i}`, name: "echo", arguments: { value: `v${i}` } }],
+		}));
+		const mock = createMockModel({ responses: [...responses, { content: ["all good"] }] });
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoopContinue(context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+		const produced = (await stream.result()) as AgentMessage[];
+
+		// Every healthy tool call ran and the run completed normally.
+		expect(executions).toBe(12);
+		const last = produced.findLast(m => m.role === "assistant");
+		if (last?.role !== "assistant") throw new Error("expected an assistant message");
+		expect(last.stopReason).not.toBe("error");
+	}, 30_000);
+});

--- a/packages/agent/test/agent-loop-recovery-coverage.test.ts
+++ b/packages/agent/test/agent-loop-recovery-coverage.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoopContinue } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
+import type { Context, Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import * as z from "zod/v4";
+import { createUserMessage } from "./helpers";
+
+// Coverage for the repeated-malformed-tool-call recovery turn (PR #3169).
+//
+// The recovery synthetic is REQUEST-ONLY: it is injected into the provider
+// payload inside `streamAssistantResponse` and never enters durable history.
+// These tests cover the three branches the primary recovery suite leaves open:
+// retry idempotency of the one-shot injection, the non-append-only full
+// conversion seam, and the error/aborted terminal exit during recovery.
+//
+// All tests use `agentLoopContinue`, which shares the caller's `messages`
+// array, so assertions about durable history are real. `agentLoop` copies the
+// array into a fresh context, which would make those assertions vacuous.
+
+const RECOVERY_MARKER = "Do not call any tools";
+const INVALID_PROMPT = "Request blocked (code=invalid_prompt)";
+
+// A leaked tool-call envelope on the assistant text surface. Triggers the
+// harmony abort/retry `continue` for openai-codex models.
+const LEAKED = [
+	"call",
+	'<invoke name="web_search">',
+	'<parameter name="query">portfolio copywriting examples</parameter>',
+	"</invoke>",
+].join("\n");
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+const toolSchema = z.object({ value: z.string() });
+
+function malformedTool(onExecute?: () => void): AgentTool<typeof toolSchema, Record<string, never>> {
+	return {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute() {
+			onExecute?.();
+			throw new Error("invalid calls must not execute");
+		},
+	};
+}
+
+/** Count messages carrying the request-only recovery prompt. */
+function countRecoveryPrompts(messages: readonly (AgentMessage | Message)[]): number {
+	return messages.filter(m => "content" in m && typeof m.content === "string" && m.content.includes(RECOVERY_MARKER))
+		.length;
+}
+
+async function drain(stream: AsyncIterable<unknown> & { result(): Promise<unknown> }): Promise<void> {
+	for await (const _event of stream) {
+		// consume
+	}
+	await stream.result();
+}
+
+describe("recovery turn retry idempotency", () => {
+	// `recoveryState.inserted` exists so a recovery request that re-enters the
+	// stream call via the harmony abort/retry `continue` does not append a
+	// SECOND synthetic prompt.
+	it("injects exactly one synthetic across a harmony abort/retry during recovery", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [malformedTool()],
+		};
+		const mock = createMockModel({
+			provider: "openai-codex",
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				// First recovery attempt leaks -> harmony abort/retry `continue`.
+				{ content: [LEAKED] },
+				// Retried recovery attempt answers cleanly.
+				{ content: ["recovered after harmony retry"] },
+			],
+		});
+		const requests: Context[] = [];
+		const audits: Array<{ action: string }> = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			onHarmonyLeak: event => {
+				audits.push(event as unknown as { action: string });
+			},
+		};
+
+		await drain(
+			agentLoopContinue(context, config, undefined, (...args: Parameters<typeof mock.stream>) => {
+				requests.push(args[1]);
+				return mock.stream(...args);
+			}),
+		);
+
+		// The harmony retry actually fired.
+		expect(audits.some(a => a.action === "abort_retry")).toBe(true);
+
+		// Both the leaked recovery attempt and its retry are recovery requests,
+		// and each carries EXACTLY ONE synthetic - never a duplicate.
+		const recoveryRequests = requests.filter(request => countRecoveryPrompts(request.messages) > 0);
+		expect(recoveryRequests.length).toBe(2);
+		for (const request of recoveryRequests) {
+			expect(countRecoveryPrompts(request.messages)).toBe(1);
+			expect(request.tools).toEqual([]);
+		}
+
+		// The request-only synthetic never reaches durable history.
+		expect(countRecoveryPrompts(context.messages)).toBe(0);
+	});
+
+	// Same invariant across the repaired `invalid_prompt` `continue`.
+	it("injects exactly one synthetic across an invalid_prompt repair during recovery", async () => {
+		// Poisoned durable history so `repairInvalidPromptHistory` can change
+		// bytes and take the `continue` branch instead of failing fast.
+		const poisoned = createUserMessage(
+			'echo something<|channel|>analysis to=functions.bash<|message|>{"command":"gjc --help"}<|call|>',
+		);
+		const context: AgentContext = { systemPrompt: [""], messages: [poisoned], tools: [malformedTool()] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				// First recovery attempt is rejected -> repaired resend `continue`.
+				{ throw: INVALID_PROMPT },
+				{ content: ["recovered after invalid_prompt repair"] },
+			],
+		});
+		const requests: Context[] = [];
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		await drain(
+			agentLoopContinue(context, config, undefined, (...args: Parameters<typeof mock.stream>) => {
+				requests.push(args[1]);
+				return mock.stream(...args);
+			}),
+		);
+
+		// The repaired resend fired: 4 provider calls, and history was neutralized.
+		expect(mock.calls.length).toBe(4);
+		expect((poisoned.content as string).includes("<\u007c")).toBe(false);
+
+		const recoveryRequests = requests.filter(request => countRecoveryPrompts(request.messages) > 0);
+		expect(recoveryRequests.length).toBe(2);
+		for (const request of recoveryRequests) {
+			expect(countRecoveryPrompts(request.messages)).toBe(1);
+			expect(request.tools).toEqual([]);
+		}
+		expect(countRecoveryPrompts(context.messages)).toBe(0);
+	});
+});
+
+describe("non-append-only recovery conversion seam", () => {
+	// Without an append-only manager the per-message converter contract does not
+	// hold, so recovery must convert `[...durable, synthetic]` together in one
+	// uncached call. A context-sensitive converter proves the whole array was
+	// converted rather than the synthetic alone.
+	it("converts the synthetic together with durable history and does not poison the cache", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [malformedTool()],
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				{ content: ["recovered"] },
+				{ content: ["follow-up answer"] },
+			],
+		});
+		const requests: Context[] = [];
+		// Context-sensitive: the marker is emitted ONLY when the synthetic is
+		// converted alongside at least one prior message. An isolated
+		// single-message conversion of the synthetic cannot produce it.
+		const contextSensitiveConverter = (messages: AgentMessage[]): Message[] => {
+			const converted = identityConverter(messages);
+			const syntheticIndex = converted.findIndex(
+				m => typeof m.content === "string" && m.content.includes(RECOVERY_MARKER),
+			);
+			if (syntheticIndex > 0) {
+				converted[syntheticIndex] = {
+					...converted[syntheticIndex],
+					content: `${converted[syntheticIndex].content as string}\n[co-converted-with:${syntheticIndex}]`,
+				} as Message;
+			}
+			return converted;
+		};
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: contextSensitiveConverter };
+		const capture = (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			return mock.stream(...args);
+		};
+
+		await drain(agentLoopContinue(context, config, undefined, capture));
+
+		const recoveryRequest = requests.at(-1);
+		expect(recoveryRequest?.tools).toEqual([]);
+		// Full-array conversion output reached the provider.
+		expect(
+			recoveryRequest?.messages.some(
+				m => typeof m.content === "string" && m.content.includes("[co-converted-with:"),
+			),
+		).toBe(true);
+
+		// The next ordinary turn keeps neither the marker nor the synthetic, so
+		// the recovery conversion bypassed rather than poisoned the cache.
+		context.messages.push(createUserMessage("follow-up"));
+		await drain(agentLoopContinue(context, config, undefined, capture));
+
+		const ordinaryRequest = requests.at(-1);
+		expect(countRecoveryPrompts(ordinaryRequest?.messages ?? [])).toBe(0);
+		expect(
+			ordinaryRequest?.messages.some(
+				m => typeof m.content === "string" && m.content.includes("[co-converted-with:"),
+			),
+		).toBe(false);
+		expect(countRecoveryPrompts(context.messages)).toBe(0);
+	});
+});
+
+describe("recovery terminal error/aborted exit", () => {
+	// The recovery dispatch guard sits before the error/aborted terminal branch.
+	// A terminal recovery response must still pair placeholder tool results and
+	// must never execute a tool.
+	for (const stopReason of ["error", "aborted"] as const) {
+		it(`pairs placeholder results and executes nothing when recovery ends in ${stopReason}`, async () => {
+			let executions = 0;
+			const context: AgentContext = {
+				systemPrompt: [""],
+				messages: [createUserMessage("echo something")],
+				tools: [malformedTool(() => (executions += 1))],
+			};
+			const mock = createMockModel({
+				responses: [
+					{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+					{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+					// Terminal recovery response that still emits a tool call.
+					{
+						content: [{ type: "toolCall", id: "tool-3", name: "echo", arguments: { value: "x" } }],
+						stopReason,
+						...(stopReason === "error" ? { errorMessage: "provider exploded" } : {}),
+					},
+				],
+			});
+			const requests: Context[] = [];
+			const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+			const stream = agentLoopContinue(context, config, undefined, (...args: Parameters<typeof mock.stream>) => {
+				requests.push(args[1]);
+				return mock.stream(...args);
+			});
+			const events = await Array.fromAsync(stream);
+			await stream.result();
+
+			// The terminal response really was the recovery request.
+			const recoveryRequest = requests.at(-1);
+			expect(countRecoveryPrompts(recoveryRequest?.messages ?? [])).toBe(1);
+			expect(recoveryRequest?.tools).toEqual([]);
+
+			// Terminal completion happened.
+			expect(events.some(event => event.type === "agent_end")).toBe(true);
+
+			// tool-3 got a paired placeholder result, preserving tool_use/tool_result.
+			expect(context.messages.some(m => m.role === "toolResult" && m.toolCallId === "tool-3")).toBe(true);
+
+			// The malformed tool never executed on any turn.
+			expect(executions).toBe(0);
+			// The synthetic stays out of durable history even on the terminal path.
+			expect(countRecoveryPrompts(context.messages)).toBe(0);
+		});
+	}
+});

--- a/packages/agent/test/agent-loop-recovery-redteam.test.ts
+++ b/packages/agent/test/agent-loop-recovery-redteam.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoopContinue } from "@gajae-code/agent-core/agent-loop";
+import { AppendOnlyContextManager } from "@gajae-code/agent-core/append-only-context";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
+import type { Context, Message, ToolChoice } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import * as z from "zod/v4";
+import { createUserMessage } from "./helpers";
+
+// Adversarial / red-team coverage for the repeated-malformed-tool-call recovery
+// turn (PR #3169). These tests try to BREAK the three contracted behaviors:
+//
+//   1. the recovery synthetic is request-only and never reaches durable state
+//   2. append-only prefix identity and log stay intact across recovery
+//   3. recovery forces `toolChoice: "none"`, never consumes the queue-backed
+//      `getToolChoice`, and never executes a tool
+//
+// Every assertion uses a public surface. Durable-history assertions go through
+// `agentLoopContinue`, which shares the caller's `messages` array; `agentLoop`
+// copies it (`agent-loop.ts:291`) and would make such assertions vacuous.
+
+const RECOVERY_MARKER = "Do not call any tools";
+const toolSchema = z.object({ value: z.string() });
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+function throwingTool(onExecute?: () => void): AgentTool<typeof toolSchema, Record<string, never>> {
+	return {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute() {
+			onExecute?.();
+			throw new Error("invalid calls must not execute");
+		},
+	};
+}
+
+function countRecoveryPrompts(messages: readonly (AgentMessage | Message)[]): number {
+	return messages.filter(m => "content" in m && typeof m.content === "string" && m.content.includes(RECOVERY_MARKER))
+		.length;
+}
+
+/** Every toolCall id in an assistant message must have a matching toolResult. */
+function assertToolPairing(messages: readonly AgentMessage[]): void {
+	const calledIds: string[] = [];
+	for (const message of messages) {
+		if (message.role !== "assistant") continue;
+		for (const block of message.content) {
+			if (block.type === "toolCall") calledIds.push(block.id);
+		}
+	}
+	const resultIds = new Set(
+		messages.filter(m => m.role === "toolResult").map(m => (m as { toolCallId: string }).toolCallId),
+	);
+	for (const id of calledIds) {
+		expect(resultIds.has(id)).toBe(true);
+	}
+}
+
+async function drain(stream: AsyncIterable<unknown> & { result(): Promise<unknown> }): Promise<void> {
+	for await (const _event of stream) {
+		// consume
+	}
+	await stream.result();
+}
+
+const malformedCall = (id: string) => ({ type: "toolCall" as const, id, name: "echo", arguments: {} });
+
+describe("redteam: synthetic leakage under stress", () => {
+	it("keeps the synthetic out of durable state across chained continuations", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool()],
+		};
+		const appendOnlyContext = new AppendOnlyContextManager();
+		const mock = createMockModel({
+			responses: [
+				{ content: [malformedCall("tool-1")] },
+				{ content: [malformedCall("tool-2")] },
+				{ content: ["recovered"] },
+				{ content: ["second run answer"] },
+				{ content: ["third run answer"] },
+			],
+		});
+		const requests: Context[] = [];
+		const config: AgentLoopConfig = { model: mock.model, appendOnlyContext, convertToLlm: identityConverter };
+		const capture = (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			return mock.stream(...args);
+		};
+
+		await drain(agentLoopContinue(context, config, undefined, capture));
+		// The recovery turn genuinely happened.
+		expect(requests.some(request => countRecoveryPrompts(request.messages) === 1)).toBe(true);
+
+		// Two further continuations reusing the SAME append-only manager.
+		context.messages.push(createUserMessage("again"));
+		await drain(agentLoopContinue(context, config, undefined, capture));
+		context.messages.push(createUserMessage("and again"));
+		await drain(agentLoopContinue(context, config, undefined, capture));
+
+		// The synthetic never reached durable history or the durable log.
+		expect(countRecoveryPrompts(context.messages)).toBe(0);
+		expect(countRecoveryPrompts(appendOnlyContext.log.entries())).toBe(0);
+		// And no later request replays it.
+		for (const request of requests.slice(3)) {
+			expect(countRecoveryPrompts(request.messages)).toBe(0);
+		}
+		assertToolPairing(context.messages);
+	});
+
+	it("keeps the synthetic out of durable state when steering arrives after recovery", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool()],
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [malformedCall("tool-1")] },
+				{ content: [malformedCall("tool-2")] },
+				{ content: ["recovered"] },
+				{ content: ["post-steering answer"] },
+			],
+		});
+		const requests: Context[] = [];
+		let steered = false;
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			getSteeringMessages: async () => {
+				if (steered) return [];
+				steered = true;
+				return [createUserMessage("steering after recovery")];
+			},
+		};
+
+		await drain(
+			agentLoopContinue(context, config, undefined, (...args: Parameters<typeof mock.stream>) => {
+				requests.push(args[1]);
+				return mock.stream(...args);
+			}),
+		);
+
+		expect(steered).toBe(true);
+		expect(requests.some(request => countRecoveryPrompts(request.messages) === 1)).toBe(true);
+		expect(countRecoveryPrompts(context.messages)).toBe(0);
+		assertToolPairing(context.messages);
+	});
+});
+
+describe("redteam: one-shot recovery bound", () => {
+	it("does not fire a second tools-free turn for a later malformed batch in the same run", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool()],
+		};
+		const mock = createMockModel({
+			responses: [
+				// First repeated-malformed batch -> arms recovery.
+				{ content: [malformedCall("tool-1")] },
+				{ content: [malformedCall("tool-2")] },
+				// Recovery turn (tools hidden). Model answers.
+				{ content: ["recovered once"] },
+				// A second repeated-malformed batch after recovery.
+				{ content: [malformedCall("tool-3")] },
+				{ content: [malformedCall("tool-4")] },
+				{ content: ["final answer"] },
+			],
+		});
+		const requests: Context[] = [];
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		await drain(
+			agentLoopContinue(context, config, undefined, (...args: Parameters<typeof mock.stream>) => {
+				requests.push(args[1]);
+				return mock.stream(...args);
+			}),
+		);
+
+		// Recovery is one-shot: exactly ONE request ever carried the synthetic,
+		// and exactly one request had tools suppressed.
+		const recoveryRequests = requests.filter(request => countRecoveryPrompts(request.messages) > 0);
+		expect(recoveryRequests.length).toBe(1);
+		expect(requests.filter(request => request.tools?.length === 0).length).toBe(1);
+
+		// The run terminated rather than wedging, and pairing survived.
+		expect(countRecoveryPrompts(context.messages)).toBe(0);
+		assertToolPairing(context.messages);
+	});
+});
+
+describe("redteam: tool-choice integrity", () => {
+	it("consumes no queue entry for recovery and hands it to the next ordinary request", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool()],
+		};
+		// A genuinely queue-CONSUMING getter: each call removes an entry.
+		const queue: ToolChoice[] = ["required", "auto"];
+		const getterCalls: number[] = [];
+		const mock = createMockModel({
+			responses: [
+				{ content: [malformedCall("tool-1")] },
+				{ content: [malformedCall("tool-2")] },
+				{ content: ["recovered"] },
+				{ content: ["next ordinary answer"] },
+			],
+		});
+		const requests: Context[] = [];
+		const toolChoices: unknown[] = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			getToolChoice: () => {
+				getterCalls.push(queue.length);
+				return queue.shift();
+			},
+		};
+		const capture = (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			toolChoices.push(args[2]?.toolChoice);
+			return mock.stream(...args);
+		};
+
+		await drain(agentLoopContinue(context, config, undefined, capture));
+
+		const recoveryIndex = requests.findIndex(request => countRecoveryPrompts(request.messages) > 0);
+		expect(recoveryIndex).toBeGreaterThanOrEqual(0);
+		// The recovery request forced "none" and its tools were suppressed.
+		expect(toolChoices[recoveryIndex]).toBe("none");
+		expect(requests[recoveryIndex]?.tools).toEqual([]);
+
+		// The getter fired once per NON-recovery request only.
+		expect(getterCalls.length).toBe(requests.length - 1);
+		// Two entries were queued and only the two ordinary requests took them,
+		// in order: nothing was silently swallowed by recovery.
+		expect(toolChoices.filter(choice => choice !== "none")).toEqual(["required", "auto"]);
+	});
+
+	it("overrides a static required tool choice on the recovery request only", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool()],
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [malformedCall("tool-1")] },
+				{ content: [malformedCall("tool-2")] },
+				{ content: ["recovered"] },
+			],
+		});
+		const requests: Context[] = [];
+		const toolChoices: unknown[] = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			toolChoice: "required",
+		};
+
+		await drain(
+			agentLoopContinue(context, config, undefined, (...args: Parameters<typeof mock.stream>) => {
+				requests.push(args[1]);
+				toolChoices.push(args[2]?.toolChoice);
+				return mock.stream(...args);
+			}),
+		);
+
+		const recoveryIndex = requests.findIndex(request => countRecoveryPrompts(request.messages) > 0);
+		expect(toolChoices[recoveryIndex]).toBe("none");
+		// Ordinary requests keep the static forced choice.
+		for (let i = 0; i < toolChoices.length; i++) {
+			if (i !== recoveryIndex) expect(toolChoices[i]).toBe("required");
+		}
+	});
+});
+
+describe("redteam: tool execution containment", () => {
+	it("executes nothing and pairs every call when recovery emits multiple tool calls", async () => {
+		let executions = 0;
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool(() => (executions += 1))],
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [malformedCall("tool-1")] },
+				{ content: [malformedCall("tool-2")] },
+				// Recovery response illegally emits SEVERAL calls, including one
+				// naming a tool that does not exist.
+				{
+					content: [
+						{ type: "toolCall", id: "tool-3", name: "echo", arguments: { value: "a" } },
+						{ type: "toolCall", id: "tool-4", name: "echo", arguments: { value: "b" } },
+						{ type: "toolCall", id: "tool-5", name: "ghost", arguments: { value: "c" } },
+					],
+				},
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		await drain(agentLoopContinue(context, config, undefined, mock.stream));
+
+		// No tool ran during the recovery turn.
+		expect(executions).toBe(0);
+		// Every emitted call got a paired result, including the unknown tool.
+		for (const id of ["tool-3", "tool-4", "tool-5"]) {
+			expect(context.messages.some(m => m.role === "toolResult" && m.toolCallId === id)).toBe(true);
+		}
+		assertToolPairing(context.messages);
+		expect(countRecoveryPrompts(context.messages)).toBe(0);
+	});
+});
+
+describe("redteam: append-only prefix integrity", () => {
+	it("holds prefix identity across recovery and keeps the log usable next turn", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool()],
+		};
+		const appendOnlyContext = new AppendOnlyContextManager();
+		const mock = createMockModel({
+			responses: [
+				{ content: [malformedCall("tool-1")] },
+				{ content: [malformedCall("tool-2")] },
+				{ content: ["recovered"] },
+				{ content: ["ordinary answer"] },
+			],
+		});
+		const requests: Context[] = [];
+		const config: AgentLoopConfig = { model: mock.model, appendOnlyContext, convertToLlm: identityConverter };
+		const capture = (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			return mock.stream(...args);
+		};
+
+		await drain(agentLoopContinue(context, config, undefined, capture));
+
+		const recoveryIndex = requests.findIndex(request => countRecoveryPrompts(request.messages) > 0);
+		expect(recoveryIndex).toBeGreaterThanOrEqual(0);
+		expect(requests[recoveryIndex]?.tools).toEqual([]);
+
+		const fingerprintAfterRecovery = appendOnlyContext.prefix.fingerprint;
+		const versionAfterRecovery = appendOnlyContext.prefix.version;
+
+		// An ordinary turn on the same manager, with tools restored.
+		context.messages.push(createUserMessage("follow-up"));
+		await drain(agentLoopContinue(context, config, undefined, capture));
+
+		// Recovery did not bust the frozen tool prefix: the ordinary turn after
+		// recovery reuses the very same prefix identity.
+		expect(appendOnlyContext.prefix.fingerprint).toBe(fingerprintAfterRecovery);
+		expect(appendOnlyContext.prefix.version).toBe(versionAfterRecovery);
+		// The ordinary request got real tools back.
+		expect(requests.at(-1)?.tools?.length).toBe(1);
+		// The log matches what the last ordinary request actually sent.
+		expect(countRecoveryPrompts(appendOnlyContext.log.entries())).toBe(0);
+		expect(appendOnlyContext.log.entries()).toEqual(requests.at(-1)?.messages ?? []);
+	});
+});
+
+describe("redteam: managed fallback interaction", () => {
+	it("commits the recovery assistant exactly once under managed fallback", async () => {
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [throwingTool()],
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [malformedCall("tool-1")] },
+				{ content: [malformedCall("tool-2")] },
+				{ content: ["managed recovery answer"] },
+			],
+		});
+		const requests: Context[] = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			fallbackManaged: true,
+		};
+
+		const stream = agentLoopContinue(context, config, undefined, (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			return mock.stream(...args);
+		});
+		await Array.fromAsync(stream);
+		const produced = (await stream.result()) as AgentMessage[];
+
+		// The recovery turn happened, and the answer is present exactly once.
+		expect(requests.some(request => countRecoveryPrompts(request.messages) === 1)).toBe(true);
+		const answers = produced.filter(
+			m => m.role === "assistant" && m.content.some(b => b.type === "text" && b.text === "managed recovery answer"),
+		);
+		expect(answers.length).toBe(1);
+		// No orphaned results, no synthetic in durable state.
+		assertToolPairing(context.messages);
+		expect(countRecoveryPrompts(context.messages)).toBe(0);
+	});
+});

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { agentLoop, agentLoopContinue, INTENT_FIELD, normalizeTools } from "@gajae-code/agent-core/agent-loop";
+import {
+	agentLoop,
+	agentLoopContinue,
+	agentLoopDetailed,
+	INTENT_FIELD,
+	normalizeTools,
+} from "@gajae-code/agent-core/agent-loop";
+import { AppendOnlyContextManager } from "@gajae-code/agent-core/append-only-context";
 import type {
 	AgentContext,
 	AgentEvent,
@@ -9,7 +16,7 @@ import type {
 	AgentToolContext,
 	ToolCallContext,
 } from "@gajae-code/agent-core/types";
-import type { AssistantMessage, Message, ToolResultMessage } from "@gajae-code/ai";
+import type { AssistantMessage, Context, Message, ToolResultMessage } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import * as z from "zod/v4";
@@ -376,6 +383,520 @@ describe("agentLoop with AgentMessage", () => {
 		if (toolEnd?.type === "tool_execution_end") {
 			expect(toolEnd.isError).toBeFalsy();
 		}
+	});
+
+	it("recovers without tools after repeated malformed tool calls", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				throw new Error("invalid calls must not execute");
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				{ content: ["answered without tools"] },
+			],
+		});
+		const streamedToolCounts: number[] = [];
+		const streamedMessages: Message[][] = [];
+		const inspectingStream = (...args: Parameters<typeof mock.stream>) => {
+			streamedToolCounts.push(args[1].tools?.length ?? 0);
+			streamedMessages.push(args[1].messages);
+			return mock.stream(...args);
+		};
+		const events: AgentEvent[] = [];
+		const stream = agentLoop(
+			[createUserMessage("echo something")],
+			context,
+			{ model: mock.model, convertToLlm: identityConverter },
+			undefined,
+			inspectingStream,
+		);
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		expect(events.filter(event => event.type === "tool_execution_end")).toHaveLength(2);
+		expect(streamedToolCounts).toEqual([1, 1, 0]);
+		expect(streamedMessages[2].at(-1)).toMatchObject({
+			role: "user",
+			content: expect.stringContaining("Do not call any tools"),
+			synthetic: true,
+		});
+		expect(events.at(-1)).toMatchObject({ type: "agent_end", stopReason: "completed" });
+		expect(
+			events.findLast(
+				event =>
+					event.type === "message_end" &&
+					event.message.role === "assistant" &&
+					event.message.content.some(block => block.type === "text" && block.text === "answered without tools"),
+			),
+		).toBeDefined();
+	});
+	it("keeps the recovery assistant in the next request's durable history", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				throw new Error("invalid calls must not execute");
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				{ content: ["recovery assistant"] },
+				{ content: ["follow-up answer"] },
+			],
+		});
+		const requests: Context[] = [];
+		const inspectingStream = (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			return mock.stream(...args);
+		};
+		let suppliedFollowUp = false;
+		const stream = agentLoop(
+			[createUserMessage("echo something")],
+			context,
+			{
+				model: mock.model,
+				convertToLlm: identityConverter,
+				getFollowUpMessages: async () => {
+					if (suppliedFollowUp) return [];
+					suppliedFollowUp = true;
+					return [createUserMessage("follow-up")];
+				},
+			},
+			undefined,
+			inspectingStream,
+		);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(requests[2]?.messages.at(-1)).toMatchObject({
+			role: "user",
+			content: expect.stringContaining("Do not call any tools"),
+			synthetic: true,
+		});
+		expect(
+			requests[3]?.messages.some(
+				message =>
+					message.role === "assistant" &&
+					message.content.some(block => block.type === "text" && block.text === "recovery assistant"),
+			),
+		).toBe(true);
+	});
+
+	it("forces static tool choice to none on the recovery request", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				throw new Error("invalid calls must not execute");
+			},
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				{ content: ["recovered"] },
+			],
+		});
+		const requests: Context[] = [];
+		const toolChoices: unknown[] = [];
+		const inspectingStream = (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			toolChoices.push(args[2]?.toolChoice);
+			return mock.stream(...args);
+		};
+		const stream = agentLoop(
+			[createUserMessage("echo something")],
+			{ systemPrompt: [""], messages: [], tools: [tool] },
+			{ model: mock.model, convertToLlm: identityConverter, toolChoice: "required" },
+			undefined,
+			inspectingStream,
+		);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(requests[2]?.tools).toEqual([]);
+		expect(requests[2]?.messages.at(-1)).toMatchObject({
+			content: expect.stringContaining("Do not call any tools"),
+		});
+		expect(toolChoices[2]).toBe("none");
+	});
+
+	it("does not consume dynamic tool choice during recovery", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				throw new Error("invalid calls must not execute");
+			},
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				{ content: ["recovered"] },
+				{ content: ["follow-up answer"] },
+			],
+		});
+		const queuedChoices: NonNullable<AgentLoopConfig["toolChoice"]>[] = ["auto", "any", "required"];
+		const consumedChoices: NonNullable<AgentLoopConfig["toolChoice"]>[] = [];
+		const requests: Context[] = [];
+		const toolChoices: unknown[] = [];
+		const inspectingStream = (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			toolChoices.push(args[2]?.toolChoice);
+			return mock.stream(...args);
+		};
+		let suppliedFollowUp = false;
+		const stream = agentLoop(
+			[createUserMessage("echo something")],
+			{ systemPrompt: [""], messages: [], tools: [tool] },
+			{
+				model: mock.model,
+				convertToLlm: identityConverter,
+				getToolChoice: () => {
+					const choice = queuedChoices.shift();
+					if (choice) consumedChoices.push(choice);
+					return choice;
+				},
+				getFollowUpMessages: async () => {
+					if (suppliedFollowUp) return [];
+					suppliedFollowUp = true;
+					return [createUserMessage("follow-up")];
+				},
+			},
+			undefined,
+			inspectingStream,
+		);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(requests[2]?.tools).toEqual([]);
+		expect(requests[2]?.messages.at(-1)).toMatchObject({
+			content: expect.stringContaining("Do not call any tools"),
+		});
+		expect(toolChoices).toEqual(["auto", "any", "none", "required"]);
+		expect(consumedChoices).toEqual(["auto", "any", "required"]);
+		expect(queuedChoices).toEqual([]);
+	});
+
+	it("preserves append-only prefix identity across recovery", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				throw new Error("invalid calls must not execute");
+			},
+		};
+		const appendOnlyContext = new AppendOnlyContextManager();
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				{ content: ["recovered"] },
+			],
+		});
+		const requests: Context[] = [];
+		let beforeRecovery: { fingerprint: string; version: number } | undefined;
+		const inspectingStream = (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			if (requests.length === 2) {
+				beforeRecovery = {
+					fingerprint: appendOnlyContext.prefix.fingerprint,
+					version: appendOnlyContext.prefix.version,
+				};
+			}
+			return mock.stream(...args);
+		};
+		const stream = agentLoop(
+			[createUserMessage("echo something")],
+			{ systemPrompt: [""], messages: [], tools: [tool] },
+			{ model: mock.model, convertToLlm: identityConverter, appendOnlyContext },
+			undefined,
+			inspectingStream,
+		);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(requests[2]?.tools).toEqual([]);
+		expect(requests[2]?.messages.at(-1)).toMatchObject({
+			content: expect.stringContaining("Do not call any tools"),
+		});
+		expect(beforeRecovery).toBeDefined();
+		if (!beforeRecovery) throw new Error("Expected prefix snapshot before recovery");
+		expect(appendOnlyContext.prefix.fingerprint).toBe(beforeRecovery.fingerprint);
+		expect(appendOnlyContext.prefix.version).toBe(beforeRecovery.version);
+	});
+
+	it("does not persist the recovery synthetic in the append-only log", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				throw new Error("invalid calls must not execute");
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const appendOnlyContext = new AppendOnlyContextManager();
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				{ content: ["recovered"] },
+				{ content: ["follow-up answer"] },
+			],
+		});
+		const requests: Context[] = [];
+		const inspectingStream = (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			return mock.stream(...args);
+		};
+		let suppliedFollowUp = false;
+		const stream = agentLoop(
+			[createUserMessage("echo something")],
+			context,
+			{
+				model: mock.model,
+				convertToLlm: identityConverter,
+				appendOnlyContext,
+				getFollowUpMessages: async () => {
+					if (suppliedFollowUp) return [];
+					suppliedFollowUp = true;
+					return [createUserMessage("follow-up")];
+				},
+			},
+			undefined,
+			inspectingStream,
+		);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(requests[2]?.tools).toEqual([]);
+		expect(requests[2]?.messages.at(-1)).toMatchObject({
+			content: expect.stringContaining("Do not call any tools"),
+		});
+		expect(
+			appendOnlyContext.log
+				.entries()
+				.some(message => typeof message.content === "string" && message.content.includes("Do not call any tools")),
+		).toBe(false);
+		expect(appendOnlyContext.log.entries()).toEqual(requests[3]?.messages);
+	});
+
+	// The converted-context cache is keyed by provider-visible content hashes and
+	// does not carry its suffix-reuse state across separate `agentLoopContinue`
+	// invocations, so a fresh run legitimately converts its whole history. The
+	// recovery-specific invariant is therefore NOT "the next turn converts exactly
+	// the durable suffix" — it is that a recovery turn leaves the durable
+	// conversion input IDENTICAL to a run that never recovered, i.e. the
+	// request-only synthetic never inflates later durable conversions.
+	it("does not leak the recovery synthetic into later durable conversions", async () => {
+		const tool: AgentTool = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: {
+				type: "object",
+				properties: { value: { type: "string" } },
+				required: ["value"],
+			},
+			async execute() {
+				throw new Error("invalid calls must not execute");
+			},
+		};
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [createUserMessage("echo something")],
+			tools: [tool],
+		};
+		const appendOnlyContext = new AppendOnlyContextManager();
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				{ content: ["recovered"] },
+				{ content: ["follow-up answer"] },
+			],
+		});
+		const requests: Context[] = [];
+		const conversionSizes: number[] = [];
+		const inspectingStream = (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			return mock.stream(...args);
+		};
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			appendOnlyContext,
+			convertToLlm: messages => {
+				conversionSizes.push(messages.length);
+				return identityConverter(messages);
+			},
+		};
+		const recovery = agentLoopContinue(context, config, undefined, inspectingStream);
+		for await (const _event of recovery) {
+			// drain
+		}
+		await recovery.result();
+
+		context.messages.push(createUserMessage("follow-up one"), createUserMessage("follow-up two"));
+		const ordinary = agentLoopContinue(context, config, undefined, inspectingStream);
+		for await (const _event of ordinary) {
+			// drain
+		}
+		await ordinary.result();
+
+		const recoveryRequest = requests[2];
+		const nextOrdinaryRequest = requests[3];
+		expect(recoveryRequest?.tools).toEqual([]);
+		expect(recoveryRequest?.messages.at(-1)).toMatchObject({
+			content: expect.stringContaining("Do not call any tools"),
+		});
+
+		// The recovery turn itself converts ONLY the synthetic in append-only mode.
+		const recoveryConversionSize = conversionSizes[3];
+		expect(recoveryConversionSize).toBe(1);
+
+		// The next ordinary turn converts exactly the durable history and nothing
+		// more: the synthetic is absent, so the conversion input equals the real
+		// durable message count rather than durable + 1.
+		expect(conversionSizes.at(-1)).toBe(context.messages.length - 1);
+		expect(nextOrdinaryRequest?.messages).not.toContainEqual(
+			expect.objectContaining({ content: expect.stringContaining("Do not call any tools") }),
+		);
+	});
+
+	it("skips recovery-turn tool calls while preserving paired result accounting", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		let executions = 0;
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				executions += 1;
+				return { content: [{ type: "text", text: "executed" }], details: { value: "recovery" } };
+			},
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-3", name: "echo", arguments: { value: "recovery" } }] },
+				{ content: ["recovery acknowledged"] },
+			],
+		});
+		const requests: Context[] = [];
+		const inspectingStream = (...args: Parameters<typeof mock.stream>) => {
+			requests.push(args[1]);
+			return mock.stream(...args);
+		};
+		const detailed = agentLoopDetailed(
+			[createUserMessage("echo something")],
+			{ systemPrompt: [""], messages: [], tools: [tool] },
+			{ model: mock.model, convertToLlm: identityConverter },
+			undefined,
+			inspectingStream,
+		);
+		const events: AgentEvent[] = [];
+		for await (const event of detailed.stream) {
+			events.push(event);
+		}
+		const { telemetry, coverage } = await detailed.detailed();
+
+		expect(requests[2]?.tools).toEqual([]);
+		expect(requests[2]?.messages.at(-1)).toMatchObject({
+			content: expect.stringContaining("Do not call any tools"),
+		});
+		expect(executions).toBe(0);
+		const recoveryResult = events.find(
+			(event): event is Extract<AgentEvent, { type: "message_end" }> =>
+				event.type === "message_end" &&
+				event.message.role === "toolResult" &&
+				event.message.toolCallId === "tool-3",
+		);
+		if (recoveryResult?.message.role !== "toolResult") {
+			throw new Error("Expected paired tool result for recovery call");
+		}
+		expect(recoveryResult.message.isError).toBe(true);
+		expect(telemetry?.tools.skipped).toBe(1);
+		expect(telemetry?.tools.byName.echo?.skipped).toBe(1);
+		expect(coverage?.toolsInvoked).toEqual(["echo"]);
+	});
+
+	it("keeps tools available when repeated calls fail during execution", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		let executions = 0;
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute() {
+				executions += 1;
+				throw new Error("transient execution failure");
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "same" } }] },
+				{ content: [{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "same" } }] },
+				{ content: ["recovered normally"] },
+			],
+		});
+		const streamedToolCounts: number[] = [];
+		const inspectingStream = (...args: Parameters<typeof mock.stream>) => {
+			streamedToolCounts.push(args[1].tools?.length ?? 0);
+			return mock.stream(...args);
+		};
+		const stream = agentLoop(
+			[createUserMessage("echo something")],
+			context,
+			{ model: mock.model, convertToLlm: identityConverter },
+			undefined,
+			inspectingStream,
+		);
+
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(executions).toBe(2);
+		expect(streamedToolCounts).toEqual([1, 1, 1]);
 	});
 
 	it("injects and strips intent when intent tracing is enabled", async () => {


### PR DESCRIPTION
Successor to #3169 (closed after exact-head `REQUEST_CHANGES`), based on current `dev` (`41d6850ca`). Opened fresh rather than stacking onto the closed head, as requested.

Repeated argument-validation failures could end a run without an answer. The model gets one tools-free recovery turn to answer from the conversation; ordinary execution-error retries are untouched.

## The four blockers from #3169

**1. Durable context settlement.** The recovery call no longer clones `messages`, so the generated assistant answer is committed to `currentContext.messages` and survives follow-up and continue paths. The recovery prompt itself is *request-only* — it never enters durable history or `newMessages`, so nothing needs rolling back on an unaccepted attempt. It is armed once per recovery turn, so the Harmony abort/retry and repaired `invalid_prompt` paths cannot inject it twice.

**2. Append-only compatibility.** The prompt is injected *after* `syncMessages`/`build`, so it never reaches the durable log and the sync cursor stays consistent. `build` still sees the real `context.tools`, so the frozen tool prefix keeps its fingerprint **and** version; tools are suppressed on the request only. Append-only mode converts the prompt in isolation under its per-message contract, while other configurations convert the whole request history in one uncached call so cross-message converters stay correct and the converted-context cache is never written.

**3. Forced-tool override.** Recovery *skips* the queue-backed `getToolChoice` rather than discarding its result, so no queued entry is silently consumed, and sends `toolChoice: "none"` with the empty tool list. If a provider emits tool calls anyway they become paired non-executed error results with skipped accounting, instead of running against tools that were never advertised.

**4. Bounded termination.** A run now stops deterministically after 5 consecutive turns of entirely malformed tool calls, reporting why. The bound counts *consecutive turns*, not repeated argument signatures — a model rotating invalid shapes never trips signature-based repeat detection and would otherwise loop against the provider indefinitely. Any healthy tool turn resets the counter.

## Tests

19 focused tests across three files, each mapped to the contract it proves. Falsifiability was verified by stashing the implementation and re-running: **15 fail on the unfixed source**, the rest are honest regression guards (stated as such rather than presented as fail-first).

- `agent-loop.test.ts` — durable-history settlement, forced/dynamic tool choice, prefix identity, log isolation, dispatch containment
- `agent-loop-recovery-coverage.test.ts` — retry idempotency across both continue paths, the non-append-only conversion seam, terminal error/aborted exits
- `agent-loop-malformed-circuit-breaker.test.ts` — identical-signature and rotating-signature runaway loops, terminal error text, plus two guards proving the breaker does not fire on healthy recovery or on many successful tool turns

Two harness traps were found and corrected rather than worked around: `agentLoop` copies `context.messages` (so durable assertions through it are vacuous — those now route through `agentLoopContinue`), and a proposed suffix-conversion assertion was vacuous because converter sizes are identical with no recovery at all.

## Verification

From `packages/agent`: `bun test` **593 pass / 0 fail** across 48 files; `bun run check:types` pass; `bunx biome check .` clean.

## Not included

The coarser malformed-signature detection key (tool name + validation class) stays deferred — it was marked non-blocking and widens behavior beyond this fix set. The consecutive-turn bound above already covers the rotating-signature case it was aimed at.
