### PR TITLE
chore(schemas): regenerate config schema for ralplan.maxIterations

### DIFF
--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -347,6 +347,16 @@
 						}
 					},
 					"additionalProperties": false
+				},
+				"ralplan": {
+					"type": "object",
+					"properties": {
+						"maxIterations": {
+							"type": "number",
+							"default": 5
+						}
+					},
+					"additionalProperties": false
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## What

Regenerates `schemas/config.schema.json` to include the `ralplan.maxIterations` property.

## Why

PR #3170 added `ralplan.maxIterations` to `packages/coding-agent/src/config/settings-schema.ts` but did not regenerate the published JSON schema. `bun run check:schemas` — which `bun run check:ts` runs — therefore fails on `dev`:

```
Generated JSON Schemas are out of date: schemas/config.schema.json
Run `bun run generate-schemas` and commit the updated files.
```

Bisected to confirm ownership: the check passes at `f14e244d2` (the commit before #3170) and fails from `41d6850ca` (#3170's merge) onward.

## How

```sh
bun run generate-schemas
```

The diff is exactly the new `ralplan.maxIterations` property. No other schema content changed.

## Tests

```sh
bun scripts/generate-json-schemas.ts --check   # passes
```