### PR TITLE
fix(coding-agent): post-#3191 SDK matrix count pins

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Changelog
-
 ## [Unreleased]
+
+### Fixed
+
+- Post-merge Dev CI: update SDK operation matrix length pins for `model.profile.set` (C53) added by #3191 so registry bijection and control-count gates match the generated inventory.
 
 ### Added
 

--- a/packages/coding-agent/test/sdk-operation-matrix.test.ts
+++ b/packages/coding-agent/test/sdk-operation-matrix.test.ts
@@ -83,7 +83,7 @@ describe("SDK operation matrix", () => {
 		const registryById = new Map(OPERATIONS.map(operation => [operation.id, operation]));
 		const inventoryIds = registryInventory.map(row => row.sourceId.replace("registry:", ""));
 		expect(new Set(inventoryIds)).toEqual(new Set(registryById.keys()));
-		expect(registryInventory).toHaveLength(92);
+		expect(registryInventory).toHaveLength(93);
 
 		for (const row of registryInventory) {
 			const id = row.sourceId.startsWith("registry:") ? row.sourceId.slice("registry:".length) : row.sourceId;
@@ -100,7 +100,7 @@ describe("SDK operation matrix", () => {
 	});
 
 	it("keeps control errors, query continuity, counts, and the stage-05 adapter partition explicit", () => {
-		expect(OPERATIONS.filter(operation => operation.kind === "control")).toHaveLength(52);
+		expect(OPERATIONS.filter(operation => operation.kind === "control")).toHaveLength(53);
 		expect(OPERATIONS.filter(operation => operation.kind === "global")).toHaveLength(7);
 		expect(OPERATIONS.filter(operation => operation.kind === "query")).toHaveLength(27);
 		expect(OPERATIONS.filter(operation => operation.kind === "reverse")).toHaveLength(6);


### PR DESCRIPTION
## Summary
- Post-merge Dev CI on `553368678` failed `SDK operation matrix` length pins after #3191 added control `model.profile.set` (C53).
- Update registry inventory length 92→93 and control count 52→53.

Closes post-merge red on Dev CI run 30194811559 (shard-6).

## Verification
- `bun --cwd=packages/coding-agent test test/sdk-operation-matrix.test.ts` (4 pass)