### PR TITLE
fix(cli): align --thinking help/options with Effort and fail closed

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -5,6 +5,7 @@
  * lightweight CLI runner from pi-utils.
  */
 import "@gajae-code/utils/postmortem";
+import { THINKING_EFFORTS } from "@gajae-code/ai";
 import { Args, type CliConfig, Command, type CommandEntry, Flags, run } from "@gajae-code/utils/cli";
 import { APP_NAME, formatBunRuntimeError, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
 import { loadNative as loadNativeBindings } from "../../natives/native/loader-state.js";
@@ -285,8 +286,8 @@ export class RootHelpCommand extends Command {
 		tmux: Flags.boolean({ description: "Launch interactive startup inside tmux" }),
 		tools: Flags.string({ description: "Comma-separated list of tools to enable (default: all)" }),
 		thinking: Flags.string({
-			description: "Set thinking level: ultra, high, medium, low",
-			options: ["ultra", "high", "medium", "low"],
+			description: `Set thinking level: ${THINKING_EFFORTS.join(", ")}`,
+			options: [...THINKING_EFFORTS],
 		}),
 		hook: Flags.string({ description: "Load a hook/extension file (can be used multiple times)", multiple: true }),
 		extension: Flags.string({

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -208,14 +208,14 @@ export function parseArgs(args: string[]): Args {
 		} else if (arg === "--thinking" && i + 1 < args.length) {
 			const rawThinking = args[++i];
 			const thinking = parseEffort(rawThinking);
-			if (thinking !== undefined) {
-				result.thinking = thinking;
-			} else {
-				logger.warn("Invalid thinking level passed to --thinking", {
-					level: rawThinking,
-					validThinkingLevels: THINKING_EFFORTS,
-				});
+			if (thinking === undefined) {
+				// Fail closed: a silent ignore left users believing `ultra` (or any typo)
+				// was applied. Help / Flags.options advertise the real Effort enum.
+				throw new CliParseError(
+					`Invalid --thinking level "${rawThinking}". Expected one of: ${THINKING_EFFORTS.join(", ")}`,
+				);
 			}
+			result.thinking = thinking;
 		} else if (arg === "--print" || arg === "-p") {
 			result.print = true;
 		} else if (arg === "--export" && i + 1 < args.length) {

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, spyOn, test, vi } from "bun:test";
 import { ThinkingLevel } from "@gajae-code/agent-core";
-import type { Model } from "@gajae-code/ai";
+import { type Model, THINKING_EFFORTS } from "@gajae-code/ai";
 import { CliParseError } from "@gajae-code/utils/cli";
 import { parseArgs } from "../src/cli/args";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
@@ -626,4 +626,24 @@ test("thinking-only startup uses authoritative override semantics", async () => 
 			options: { cause: "startup-override" },
 		}),
 	]);
+});
+
+describe("CLI --thinking contract", () => {
+	test("accepts every Effort level advertised by help", () => {
+		for (const level of THINKING_EFFORTS) {
+			expect(parseArgs(["--thinking", level]).thinking).toBe(level);
+		}
+	});
+
+	test("rejects the retired ultra token instead of silently ignoring it", () => {
+		expect(() => parseArgs(["--thinking", "ultra"])).toThrow(CliParseError);
+		expect(() => parseArgs(["--thinking", "ultra"])).toThrow(
+			/Invalid --thinking level "ultra".*minimal, low, medium, high, xhigh, max/,
+		);
+	});
+
+	test("rejects unknown tokens fail-closed", () => {
+		expect(() => parseArgs(["--thinking", "ludicrous"])).toThrow(CliParseError);
+		expect(() => parseArgs(["--thinking", "off"])).toThrow(CliParseError);
+	});
 });

--- a/packages/coding-agent/test/completion-cli.test.ts
+++ b/packages/coding-agent/test/completion-cli.test.ts
@@ -118,6 +118,15 @@ describe("GJC inshellisense completion spec", () => {
 			expect(findSubcommand(spec, command), command).toBeDefined();
 		}
 		expect(names(findSubcommand(spec, "web-search")!.name)).toContain("q");
+		// Root help must advertise the real Effort enum — not the retired `ultra` token.
+		expect(findOption(spec.options, "--thinking")?.args?.suggestions).toEqual([
+			"minimal",
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+			"max",
+		]);
 		expect(findOption(spec.options, "--tmux")).toBeDefined();
 		expect(findOption(spec.options, "--model")?.args).toEqual({ name: "value" });
 		expect(findOption(spec.options, "--resume")?.args).toEqual({ name: "value" });


### PR DESCRIPTION
## Summary

Root CLI help still advertised a retired thinking contract:

```text
--thinking: ultra, high, medium, low
```

while the real `Effort` enum (and `launch` command flags, `parseEffort`, model selectors) is:

```text
minimal | low | medium | high | xhigh | max
```

`parseArgs` also **silently ignored** invalid levels (including `ultra`), so users could believe a level was applied when it was not.

### Changes

1. **`RootHelpCommand`** (`cli.ts`): options/description now use `THINKING_EFFORTS`, matching `commands/launch.ts`.
2. **`parseArgs`** (`cli/args.ts`): invalid `--thinking` values throw `CliParseError` (fail closed) instead of `logger.warn` + ignore.
3. **Tests**:
   - accept every `THINKING_EFFORTS` value
   - reject `ultra` and unknown tokens with a clear message
   - completion/Fig root spec suggestions = real Effort list (not `ultra`)

### Why not alias `ultra → max`?

Public `ultra` was intentionally not productized (#1933 closed; ceiling is `max`). Aliasing would re-introduce a phantom tier in help/scripts. Fail-closed + correct help is the honest contract.

## Test plan

- [x] `bun test packages/coding-agent/test/cli-args-mpreset.test.ts packages/coding-agent/test/completion-cli.test.ts` → **48 pass / 0 fail**
- [ ] `gjc --help` shows `--thinking` as `minimal, low, medium, high, xhigh, max`
- [ ] `gjc --thinking ultra -p "hi"` fails with `Invalid --thinking level "ultra"...`
- [ ] `gjc --thinking max -p "hi"` accepts (subject to model/auth)