### PR TITLE
fix(ai): fail fast on over-cap Retry-After in Claude usage fetch

### DIFF
--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -19,9 +19,9 @@ const MAX_ATTEMPTS = 3;
 const BASE_RETRY_DELAY_MS = 500;
 /**
  * Ceiling for a server-supplied `Retry-After`. Matches `OPENAI_RETRY_DELAY_CAP_MS`
- * and `fetchWithRetry`'s `DEFAULT_MAX_DELAY_MS`. Without it a hostile or
- * misconfigured endpoint stalls the usage fetch for as long as it likes
- * (`Retry-After: 86400` previously produced a 24h sleep).
+ * and `fetchWithRetry`'s `DEFAULT_MAX_DELAY_MS`. Hints above this fail fast
+ * (no sleep, no further attempts) — same contract as `fetchWithRetry` — so a
+ * quota window longer than the cap cannot burn stacked 60s backoffs.
  */
 const MAX_RETRY_DELAY_MS = 60_000;
 
@@ -148,22 +148,37 @@ function isAbortError(error: unknown, signal?: AbortSignal): boolean {
 }
 
 /**
- * Honour the server hint but never exceed `MAX_RETRY_DELAY_MS`, and never
- * return a negative/non-finite delay. Keeps the sleep bounded so an abort has
- * an upper bound to fire within.
+ * Parse a `Retry-After` header into milliseconds.
+ * Returns `undefined` for missing/invalid/negative numeric hints so callers
+ * fall back to the exponential baseline. Past HTTP-dates collapse to 0.
  */
-function clampRetryDelay(baseline: number, hintMs: number): number {
-	const hint = Number.isFinite(hintMs) ? Math.max(0, hintMs) : 0;
-	return Math.min(Math.max(baseline, hint), MAX_RETRY_DELAY_MS);
+function parseRetryAfterMs(retryAfter: string | null): number | undefined {
+	if (!retryAfter?.trim()) return undefined;
+	const seconds = Number.parseFloat(retryAfter);
+	if (Number.isFinite(seconds)) {
+		if (seconds < 0) return undefined;
+		return seconds * 1000;
+	}
+	const dateDelay = Date.parse(retryAfter) - Date.now();
+	if (!Number.isFinite(dateDelay)) return undefined;
+	return Math.max(0, dateDelay);
 }
 
-function retryDelayMs(attempt: number, retryAfter: string | null): number {
+/**
+ * Resolve the next backoff. Mirrors `fetchWithRetry`:
+ * - no/invalid hint → exponential baseline
+ * - hint within cap → max(baseline, hint)
+ * - hint above cap → fail fast (do not sleep or retry)
+ */
+function resolveRetryDelayMs(
+	attempt: number,
+	retryAfter: string | null,
+): { kind: "delay"; ms: number } | { kind: "fail_fast" } {
 	const baseline = BASE_RETRY_DELAY_MS * 2 ** attempt;
-	if (!retryAfter?.trim()) return baseline;
-	const seconds = Number.parseFloat(retryAfter);
-	if (Number.isFinite(seconds)) return clampRetryDelay(baseline, seconds * 1000);
-	const dateDelay = Date.parse(retryAfter) - Date.now();
-	return Number.isFinite(dateDelay) ? clampRetryDelay(baseline, dateDelay) : baseline;
+	const hint = parseRetryAfterMs(retryAfter);
+	if (hint === undefined) return { kind: "delay", ms: baseline };
+	if (hint > MAX_RETRY_DELAY_MS) return { kind: "fail_fast" };
+	return { kind: "delay", ms: Math.max(baseline, hint) };
 }
 
 async function waitBeforeRetry(
@@ -174,12 +189,13 @@ async function waitBeforeRetry(
 ): Promise<boolean> {
 	if (signal?.aborted) return false;
 	if (attempt >= MAX_ATTEMPTS - 1) return false;
+	const resolved = resolveRetryDelayMs(attempt, retryAfter);
+	if (resolved.kind === "fail_fast") return false;
 	try {
-		const delayMs = retryDelayMs(attempt, retryAfter);
 		if (retryWait) {
-			await retryWait(delayMs, signal);
+			await retryWait(resolved.ms, signal);
 		} else {
-			await scheduler.wait(delayMs, { signal });
+			await scheduler.wait(resolved.ms, { signal });
 		}
 		return !signal?.aborted;
 	} catch (error) {

--- a/packages/ai/test/claude-usage-retry.test.ts
+++ b/packages/ai/test/claude-usage-retry.test.ts
@@ -119,37 +119,51 @@ describe("claudeUsageProvider retry contract", () => {
 		expect(retryWait.mock.calls[0]?.[0]).toBe(1000);
 	});
 
-	it("caps an absurd Retry-After instead of stalling for hours", async () => {
+	it("fails fast when Retry-After exceeds the delay cap (matches fetchWithRetry)", async () => {
 		let attempt = 0;
 		const retryWait = vi.fn(async (_delayMs: number, _signal?: AbortSignal) => {});
 		const fetchMock = (async () => {
 			attempt += 1;
-			if (attempt === 1) {
-				// A hostile/misconfigured endpoint asks for a 24h backoff. Honouring
-				// it verbatim would stall the usage fetch for a day.
-				return jsonResponse(429, { error: "rate_limited" }, { "retry-after": "86400" });
-			}
-			return jsonResponse(200, VALID_PAYLOAD);
+			// Over-cap hint means the quota window is longer than we will wait.
+			// Sibling fetchWithRetry returns immediately; clamp-and-retry would
+			// burn up to MAX_ATTEMPTS * 60s for a credential that cannot recover.
+			return jsonResponse(429, { error: "rate_limited" }, { "retry-after": "86400" });
 		}) as unknown as typeof fetch;
 
 		const report = await claudeUsageProvider.fetchUsage(baseParams(), makeContext(fetchMock, retryWait));
-		expect(report).not.toBeNull();
-		expect(retryWait).toHaveBeenCalledTimes(1);
-		expect(retryWait.mock.calls[0]?.[0]).toBe(60_000);
+		expect(report).toBeNull();
+		expect(attempt).toBe(1);
+		expect(retryWait).not.toHaveBeenCalled();
 	});
 
-	it("caps an absurd HTTP-date Retry-After too", async () => {
+	it("fails fast when an HTTP-date Retry-After exceeds the delay cap", async () => {
 		let attempt = 0;
 		const retryWait = vi.fn(async (_delayMs: number, _signal?: AbortSignal) => {});
 		const farFuture = new Date(Date.now() + 24 * 60 * 60 * 1000).toUTCString();
 		const fetchMock = (async () => {
 			attempt += 1;
-			if (attempt === 1) return jsonResponse(429, { error: "rate_limited" }, { "retry-after": farFuture });
+			return jsonResponse(429, { error: "rate_limited" }, { "retry-after": farFuture });
+		}) as unknown as typeof fetch;
+
+		const report = await claudeUsageProvider.fetchUsage(baseParams(), makeContext(fetchMock, retryWait));
+		expect(report).toBeNull();
+		expect(attempt).toBe(1);
+		expect(retryWait).not.toHaveBeenCalled();
+	});
+
+	it("still retries when Retry-After is exactly at the delay cap", async () => {
+		let attempt = 0;
+		const retryWait = vi.fn(async (_delayMs: number, _signal?: AbortSignal) => {});
+		const fetchMock = (async () => {
+			attempt += 1;
+			if (attempt === 1) return jsonResponse(429, { error: "rate_limited" }, { "retry-after": "60" });
 			return jsonResponse(200, VALID_PAYLOAD);
 		}) as unknown as typeof fetch;
 
 		const report = await claudeUsageProvider.fetchUsage(baseParams(), makeContext(fetchMock, retryWait));
 		expect(report).not.toBeNull();
+		expect(attempt).toBe(2);
+		expect(retryWait).toHaveBeenCalledTimes(1);
 		expect(retryWait.mock.calls[0]?.[0]).toBe(60_000);
 	});
 


### PR DESCRIPTION
## Summary

Follow-up to #3132. That PR correctly capped absurd `Retry-After` values at 60s, but still **slept the clamped delay and retried**. For a credential whose quota window is hours long (`Retry-After: 86400`), that burns up to `MAX_ATTEMPTS × 60s` before returning null.

Sibling path `packages/utils/src/fetch-retry.ts` already fail-fasts:

```ts
if (hint !== undefined && hint > maxDelayMs) return response;
```

Align Claude usage fetch with the same contract.

### Behavior

| `Retry-After` | Before (post-#3132) | After |
|---|---|---|
| missing / invalid / negative | exponential baseline | unchanged |
| `1` … `60` (incl. exact cap) | `max(baseline, hint)` then retry | unchanged |
| `> 60` (numeric or HTTP-date) | clamp to 60s, sleep, retry | **no sleep, stop immediately** |

### Changes

- `packages/ai/src/usage/claude.ts` — `parseRetryAfterMs` + `resolveRetryDelayMs` with `{delay|fail_fast}`; `waitBeforeRetry` returns false on over-cap
- `packages/ai/test/claude-usage-retry.test.ts` — over-cap numeric/HTTP-date fail-fast; exact-cap still retries at 60s

## Test plan

- [x] `bun test packages/ai/test/claude-usage-retry.test.ts` — 12 pass
- [x] usage suite (`claude-usage-headers`, `auth-storage-usage-cache`) — 21 pass total
- [x] `tsc -p packages/ai/tsconfig.json --noEmit` — clean