### PR TITLE
fix(cli): fail closed on bare or flag-adjacent --thinking

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -205,7 +205,15 @@ export function parseArgs(args: string[]): Args {
 				}
 			}
 			result.tools = validTools;
-		} else if (arg === "--thinking" && i + 1 < args.length) {
+		} else if (arg === "--thinking") {
+			// Match --credential / --mcp-config: a missing value or a following flag is
+			// a usage error, not a silent no-op / accidental consumption of `-p`.
+			const next = args[i + 1];
+			if (!next || next.startsWith("-")) {
+				throw new CliParseError(
+					`--thinking requires <level> (${THINKING_EFFORTS.join(", ")})`,
+				);
+			}
 			const rawThinking = args[++i];
 			const thinking = parseEffort(rawThinking);
 			if (thinking === undefined) {

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -210,9 +210,7 @@ export function parseArgs(args: string[]): Args {
 			// a usage error, not a silent no-op / accidental consumption of `-p`.
 			const next = args[i + 1];
 			if (!next || next.startsWith("-")) {
-				throw new CliParseError(
-					`--thinking requires <level> (${THINKING_EFFORTS.join(", ")})`,
-				);
+				throw new CliParseError(`--thinking requires <level> (${THINKING_EFFORTS.join(", ")})`);
 			}
 			const rawThinking = args[++i];
 			const thinking = parseEffort(rawThinking);

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -646,4 +646,19 @@ describe("CLI --thinking contract", () => {
 		expect(() => parseArgs(["--thinking", "ludicrous"])).toThrow(CliParseError);
 		expect(() => parseArgs(["--thinking", "off"])).toThrow(CliParseError);
 	});
+
+	test("rejects a bare --thinking with no value", () => {
+		expect(() => parseArgs(["--thinking"])).toThrow(CliParseError);
+		expect(() => parseArgs(["--thinking"])).toThrow(/--thinking requires <level>/);
+	});
+
+	test("rejects --thinking when the next token is another flag", () => {
+		// Pre-#3200 residual: `i + 1 < args.length` alone treated `-p` as the level.
+		expect(() => parseArgs(["--thinking", "-p", "hi"])).toThrow(CliParseError);
+		expect(() => parseArgs(["--thinking", "-p", "hi"])).toThrow(/--thinking requires <level>/);
+	});
+
+	test("rejects an empty --thinking= value", () => {
+		expect(() => parseArgs(["--thinking="])).toThrow(CliParseError);
+	});
 });


### PR DESCRIPTION
## Summary

Follow-up to #3200 (owner review residual N1).

`--thinking` already fail-closes invalid levels, but two silent paths remained:

| Input | Before | After |
|---|---|---|
| `gjc --thinking` | silent no-op | `CliParseError: --thinking requires <level> (...)` |
| `gjc --thinking -p hi` | treated `-p` as the level → invalid-level error with confusing token | missing-value error (does not consume the next flag) |
| `gjc --thinking=` | empty string → invalid level | same fail-closed path |

Matches the existing `--credential` / `--mcp-config` missing-value pattern.

## Test plan

- [x] `bun test packages/coding-agent/test/cli-args-mpreset.test.ts` — 44 pass
- [x] new cases: bare flag, flag-adjacent next token, empty `=` value