### PR TITLE
fix(task): require explicit phrasing for executor ultragoal red-team mode

### DIFF
--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -53,7 +53,6 @@ import { validateAllocatedTaskId } from "./id";
 import { classifyProviderRetry, providerNameFromModel } from "./provider-retry-status";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
 import { persistTaskTokenLog, taskTokenLogFromUsage } from "./token-log";
-import { assignmentRequestsUltragoalRedTeam } from "./ultragoal-redteam-activation";
 import {
 	type AgentDefinition,
 	type AgentProgress,
@@ -68,6 +67,7 @@ import {
 	TASK_SUBAGENT_PROGRESS_CHANNEL,
 	type TaskToolDetails,
 } from "./types";
+import { assignmentRequestsUltragoalRedTeam } from "./ultragoal-redteam-activation";
 
 /** Agent event types to forward for progress tracking. */
 const agentEventTypes = new Set<AgentEvent["type"]>([

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -53,6 +53,7 @@ import { validateAllocatedTaskId } from "./id";
 import { classifyProviderRetry, providerNameFromModel } from "./provider-retry-status";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
 import { persistTaskTokenLog, taskTokenLogFromUsage } from "./token-log";
+import { assignmentRequestsUltragoalRedTeam } from "./ultragoal-redteam-activation";
 import {
 	type AgentDefinition,
 	type AgentProgress,
@@ -1603,9 +1604,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					systemPrompt: defaultPrompt => {
 						const subagentPrompt = prompt.render(subagentSystemPromptTemplate, {
 							agent: prompt.render(agent.systemPrompt, {
-								ultragoalRedTeam: /ultragoal\s+completion\s+(?:qa|red-team)|executorQa/i.test(
-									options.assignment ?? task,
-								),
+								// Explicit activation only — bare `executorQa` mentions must not flip mode (#2698).
+								ultragoalRedTeam: assignmentRequestsUltragoalRedTeam(options.assignment ?? task),
 							}),
 							context: options.context?.trim() ?? "",
 							worktree: worktree ?? "",

--- a/packages/coding-agent/src/task/ultragoal-redteam-activation.ts
+++ b/packages/coding-agent/src/task/ultragoal-redteam-activation.ts
@@ -1,0 +1,27 @@
+/**
+ * Decide whether an executor assignment should inject the ultragoal red-team
+ * prompt fragment. Activation must be explicit — bare mentions of `executorQa`
+ * (docs, quality-gate field names, negative instructions) must not flip the mode.
+ *
+ * Mirrors `executor.md`:
+ * "activates only when the assignment explicitly labels Executor as Ultragoal
+ * completion QA/red-team or asks for `executorQa` red-team evidence."
+ */
+
+const ULTRAGOAL_COMPLETION_QA =
+	/\bultragoal\s+completion\s+(?:qa|red[-\s]?team)\b/i;
+
+/** `executorQa` within a short window of red-team / matrix / evidence framing. */
+const EXECUTOR_QA_EVIDENCE =
+	/\bexecutorQa\b[\s\S]{0,120}\b(?:red[-\s]?team|matrix|evidence)\b|\b(?:red[-\s]?team|matrix|evidence)\b[\s\S]{0,120}\bexecutorQa\b/i;
+
+/** Common Ultragoal skill spawn phrasing: "executor QA/red-team lane". */
+const EXECUTOR_QA_LANE = /\bexecutor\b[\s\S]{0,48}\b(?:qa|red[-\s]?team)\s+lane\b/i;
+
+export function assignmentRequestsUltragoalRedTeam(assignment: string | undefined): boolean {
+	const text = assignment?.trim() ?? "";
+	if (text.length === 0) return false;
+	return (
+		ULTRAGOAL_COMPLETION_QA.test(text) || EXECUTOR_QA_EVIDENCE.test(text) || EXECUTOR_QA_LANE.test(text)
+	);
+}

--- a/packages/coding-agent/src/task/ultragoal-redteam-activation.ts
+++ b/packages/coding-agent/src/task/ultragoal-redteam-activation.ts
@@ -8,8 +8,7 @@
  * completion QA/red-team or asks for `executorQa` red-team evidence."
  */
 
-const ULTRAGOAL_COMPLETION_QA =
-	/\bultragoal\s+completion\s+(?:qa|red[-\s]?team)\b/i;
+const ULTRAGOAL_COMPLETION_QA = /\bultragoal\s+completion\s+(?:qa|red[-\s]?team)\b/i;
 
 /** `executorQa` within a short window of red-team / matrix / evidence framing. */
 const EXECUTOR_QA_EVIDENCE =
@@ -21,7 +20,5 @@ const EXECUTOR_QA_LANE = /\bexecutor\b[\s\S]{0,48}\b(?:qa|red[-\s]?team)\s+lane\
 export function assignmentRequestsUltragoalRedTeam(assignment: string | undefined): boolean {
 	const text = assignment?.trim() ?? "";
 	if (text.length === 0) return false;
-	return (
-		ULTRAGOAL_COMPLETION_QA.test(text) || EXECUTOR_QA_EVIDENCE.test(text) || EXECUTOR_QA_LANE.test(text)
-	);
+	return ULTRAGOAL_COMPLETION_QA.test(text) || EXECUTOR_QA_EVIDENCE.test(text) || EXECUTOR_QA_LANE.test(text);
 }

--- a/packages/coding-agent/test/task/ultragoal-redteam-activation.test.ts
+++ b/packages/coding-agent/test/task/ultragoal-redteam-activation.test.ts
@@ -6,78 +6,52 @@ describe("assignmentRequestsUltragoalRedTeam", () => {
 		expect(assignmentRequestsUltragoalRedTeam(undefined)).toBe(false);
 		expect(assignmentRequestsUltragoalRedTeam("")).toBe(false);
 		expect(assignmentRequestsUltragoalRedTeam("   ")).toBe(false);
+		expect(assignmentRequestsUltragoalRedTeam("Implement the retry helper and add unit tests.")).toBe(false);
 		expect(
-			assignmentRequestsUltragoalRedTeam("Implement the retry helper and add unit tests."),
-		).toBe(false);
-		expect(
-			assignmentRequestsUltragoalRedTeam(
-				"Fix blocking findings only, then leave verification to the parent.",
-			),
+			assignmentRequestsUltragoalRedTeam("Fix blocking findings only, then leave verification to the parent."),
 		).toBe(false);
 	});
 
 	test("does not activate on a bare executorQa token (incidental mention)", () => {
 		// #2698: free-form assignment text that merely contains the field name
 		// used to flip red-team mode via /executorQa/i.
-		expect(assignmentRequestsUltragoalRedTeam("Document the executorQa JSON field names.")).toBe(
-			false,
-		);
+		expect(assignmentRequestsUltragoalRedTeam("Document the executorQa JSON field names.")).toBe(false);
 		expect(
-			assignmentRequestsUltragoalRedTeam(
-				"Do not invent executorQa rows; the parent owns the quality gate.",
-			),
+			assignmentRequestsUltragoalRedTeam("Do not invent executorQa rows; the parent owns the quality gate."),
 		).toBe(false);
 		expect(
-			assignmentRequestsUltragoalRedTeam(
-				"The quality gate schema includes architectReview and executorQa keys.",
-			),
+			assignmentRequestsUltragoalRedTeam("The quality gate schema includes architectReview and executorQa keys."),
 		).toBe(false);
 	});
 
 	test("activates on explicit ultragoal completion QA / red-team labeling", () => {
-		expect(
-			assignmentRequestsUltragoalRedTeam(
-				"You are the Ultragoal completion QA lane. Break the change.",
-			),
-		).toBe(true);
-		expect(
-			assignmentRequestsUltragoalRedTeam(
-				"Ultragoal completion red-team: produce the adversarial matrix.",
-			),
-		).toBe(true);
-		expect(
-			assignmentRequestsUltragoalRedTeam("Run ultragoal completion red team against HEAD."),
-		).toBe(true);
+		expect(assignmentRequestsUltragoalRedTeam("You are the Ultragoal completion QA lane. Break the change.")).toBe(
+			true,
+		);
+		expect(assignmentRequestsUltragoalRedTeam("Ultragoal completion red-team: produce the adversarial matrix.")).toBe(
+			true,
+		);
+		expect(assignmentRequestsUltragoalRedTeam("Run ultragoal completion red team against HEAD.")).toBe(true);
 	});
 
 	test("activates when assignment asks for executorQa red-team evidence", () => {
 		expect(
-			assignmentRequestsUltragoalRedTeam(
-				"Produce executorQa red-team evidence for the frozen change set.",
-			),
+			assignmentRequestsUltragoalRedTeam("Produce executorQa red-team evidence for the frozen change set."),
 		).toBe(true);
 		expect(
-			assignmentRequestsUltragoalRedTeam(
-				"Fill the executorQa matrix with contractCoverage and adversarialCases.",
-			),
+			assignmentRequestsUltragoalRedTeam("Fill the executorQa matrix with contractCoverage and adversarialCases."),
 		).toBe(true);
 		expect(
-			assignmentRequestsUltragoalRedTeam(
-				"Return red-team evidence under the executorQa contract exactly.",
-			),
+			assignmentRequestsUltragoalRedTeam("Return red-team evidence under the executorQa contract exactly."),
 		).toBe(true);
 	});
 
 	test("activates on Ultragoal skill spawn phrasing for the QA/red-team lane", () => {
 		expect(
-			assignmentRequestsUltragoalRedTeam(
-				"Delegate an executor QA/red-team lane to build and run the e2e suite.",
-			),
+			assignmentRequestsUltragoalRedTeam("Delegate an executor QA/red-team lane to build and run the e2e suite."),
 		).toBe(true);
 		expect(
-			assignmentRequestsUltragoalRedTeam(
-				"You are the executor red-team lane for this story's live CLI surface.",
-			),
+			assignmentRequestsUltragoalRedTeam("You are the executor red-team lane for this story's live CLI surface."),
 		).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/task/ultragoal-redteam-activation.test.ts
+++ b/packages/coding-agent/test/task/ultragoal-redteam-activation.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { assignmentRequestsUltragoalRedTeam } from "../../src/task/ultragoal-redteam-activation";
+
+describe("assignmentRequestsUltragoalRedTeam", () => {
+	test("is off for empty or ordinary implementation assignments", () => {
+		expect(assignmentRequestsUltragoalRedTeam(undefined)).toBe(false);
+		expect(assignmentRequestsUltragoalRedTeam("")).toBe(false);
+		expect(assignmentRequestsUltragoalRedTeam("   ")).toBe(false);
+		expect(
+			assignmentRequestsUltragoalRedTeam("Implement the retry helper and add unit tests."),
+		).toBe(false);
+		expect(
+			assignmentRequestsUltragoalRedTeam(
+				"Fix blocking findings only, then leave verification to the parent.",
+			),
+		).toBe(false);
+	});
+
+	test("does not activate on a bare executorQa token (incidental mention)", () => {
+		// #2698: free-form assignment text that merely contains the field name
+		// used to flip red-team mode via /executorQa/i.
+		expect(assignmentRequestsUltragoalRedTeam("Document the executorQa JSON field names.")).toBe(
+			false,
+		);
+		expect(
+			assignmentRequestsUltragoalRedTeam(
+				"Do not invent executorQa rows; the parent owns the quality gate.",
+			),
+		).toBe(false);
+		expect(
+			assignmentRequestsUltragoalRedTeam(
+				"The quality gate schema includes architectReview and executorQa keys.",
+			),
+		).toBe(false);
+	});
+
+	test("activates on explicit ultragoal completion QA / red-team labeling", () => {
+		expect(
+			assignmentRequestsUltragoalRedTeam(
+				"You are the Ultragoal completion QA lane. Break the change.",
+			),
+		).toBe(true);
+		expect(
+			assignmentRequestsUltragoalRedTeam(
+				"Ultragoal completion red-team: produce the adversarial matrix.",
+			),
+		).toBe(true);
+		expect(
+			assignmentRequestsUltragoalRedTeam("Run ultragoal completion red team against HEAD."),
+		).toBe(true);
+	});
+
+	test("activates when assignment asks for executorQa red-team evidence", () => {
+		expect(
+			assignmentRequestsUltragoalRedTeam(
+				"Produce executorQa red-team evidence for the frozen change set.",
+			),
+		).toBe(true);
+		expect(
+			assignmentRequestsUltragoalRedTeam(
+				"Fill the executorQa matrix with contractCoverage and adversarialCases.",
+			),
+		).toBe(true);
+		expect(
+			assignmentRequestsUltragoalRedTeam(
+				"Return red-team evidence under the executorQa contract exactly.",
+			),
+		).toBe(true);
+	});
+
+	test("activates on Ultragoal skill spawn phrasing for the QA/red-team lane", () => {
+		expect(
+			assignmentRequestsUltragoalRedTeam(
+				"Delegate an executor QA/red-team lane to build and run the e2e suite.",
+			),
+		).toBe(true);
+		expect(
+			assignmentRequestsUltragoalRedTeam(
+				"You are the executor red-team lane for this story's live CLI surface.",
+			),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Addresses the #2698 correctness item: executor red-team mode activated via free-form regex on assignment text.

### Before

```ts
/ultragoal\s+completion\s+(?:qa|red-team)|executorQa/i.test(assignment)
```

Any incidental `executorQa` mention (docs, schema field names, \"do not invent executorQa rows\") flipped `{{#if ultragoalRedTeam}}` on the executor prompt.

### After

`assignmentRequestsUltragoalRedTeam()` — explicit only:

| Assignment | Mode |
|---|---|
| ordinary implementation / fix blockers | **off** |
| bare `executorQa` / schema field mention | **off** |
| \"Ultragoal completion QA/red-team\" | **on** |
| \"executorQa red-team evidence\" / \"executorQa matrix\" | **on** |
| \"executor QA/red-team lane\" (skill spawn phrasing) | **on** |

Matches `executor.md`: *activates only when the assignment explicitly labels Executor as Ultragoal completion QA/red-team or asks for executorQa red-team evidence*.

## Test plan

- [x] `bun test packages/coding-agent/test/task/ultragoal-redteam-activation.test.ts` — 5 pass
- [x] system-prompt-templates + default-gjc-definitions still green (54 pass total)

Closes nothing automatically — #2698 is a multi-item audit; this is one tracked correctness fix.