### PR TITLE
fix(session): use native cleanup authority size on Windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Alibaba Token Plan first-event timeouts also match the exported lazy-stream watchdog text, preserve sticky fallback selection across later turns, avoid same-candidate auto-compaction replay, and reset attempt/overflow budgets only when an accepted queued steering/follow-up successor starts (#3026).
+- Interrupted managed-session artifact cleanup on Windows now validates the retained directory's size and mtime from the native snapshot root instead of Bun's directory metadata, avoiding false `durability_failed` results while preserving fail-closed authority checks (#2913).
 - Queued steering and follow-up successors now reset predecessor fallback attempt budgets and overflow-maintenance counters only after `continue()` accepts the queued turn, without clearing the sticky fallback cursor.
 - Questions about `ultragoal` behavior now stay on the direct-answer path instead of being misclassified as requests to start the durable workflow.
 - Workflow intent routing now requires a leading `/skill:ultragoal` for slash-command escalation and recognizes Korean object-particle requests such as `ultragoal을 사용해줘` without routing questions that merely mention the command.

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -2400,7 +2400,11 @@ type SourceArtifactCleanup = {
 	tree: NativeDirectoryTreeSnapshot;
 };
 
-function cleanupAuthorityMatches(cleanup: SourceArtifactCleanup, parent: string): boolean {
+export function cleanupAuthorityMatches(
+	cleanup: SourceArtifactCleanup,
+	parent: string,
+	platform: NodeJS.Platform = process.platform,
+): boolean {
 	try {
 		const stat = fs.lstatSync(cleanup.retainedPath, { bigint: true });
 		if (
@@ -2408,15 +2412,26 @@ function cleanupAuthorityMatches(cleanup: SourceArtifactCleanup, parent: string)
 			!stat.isDirectory() ||
 			stat.isSymbolicLink() ||
 			stat.dev !== cleanup.identity.dev ||
-			stat.ino !== cleanup.identity.ino ||
-			stat.size !== cleanup.identity.size ||
-			stat.mtimeNs !== cleanup.identity.mtimeNs
+			stat.ino !== cleanup.identity.ino
 		)
 			return false;
 		const snapshot = native.snapshotDirectoryTree(cleanup.retainedPath);
+		const observedRoot = snapshot.snapshot?.entries.find(
+			entry => entry.relativePath === "" && entry.kind === "directory",
+		);
+		if (
+			!snapshot.ok ||
+			!snapshot.snapshot ||
+			!observedRoot ||
+			(platform === "win32"
+				? observedRoot.dev !== cleanup.identity.dev.toString() ||
+					observedRoot.ino !== cleanup.identity.ino.toString() ||
+					BigInt(observedRoot.size) !== cleanup.identity.size ||
+					BigInt(observedRoot.mtimeNs) !== cleanup.identity.mtimeNs
+				: stat.size !== cleanup.identity.size || stat.mtimeNs !== cleanup.identity.mtimeNs)
+		)
+			return false;
 		return (
-			!!snapshot.ok &&
-			!!snapshot.snapshot &&
 			sameArtifactTree(snapshot.snapshot, cleanup.tree) &&
 			cleanup.tree.entries.length === 1 &&
 			cleanup.tree.entries[0]?.relativePath === "" &&

--- a/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
+++ b/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
@@ -7,6 +7,7 @@ import type { NativeDirectoryTreeSnapshot } from "@gajae-code/natives";
 import * as native from "@gajae-code/natives";
 import {
 	canonicalBindingOpenFlags,
+	cleanupAuthorityMatches,
 	fsyncCanonicalBinding,
 	listManagedCandidates,
 	matchesMigrationArtifactRoot,
@@ -204,6 +205,71 @@ describe("managed session Windows durability", () => {
 		expect(matchesMigrationArtifactRoot(artifacts, identity, expectedTree, "win32")).toBe(true);
 		await fs.writeFile(payload, "modified");
 		expect(matchesMigrationArtifactRoot(artifacts, identity, expectedTree, "win32")).toBe(false);
+	});
+
+	it("uses native root metadata for cleanup authority on Windows without changing non-Windows checks", async () => {
+		const root = temporaryDirectory("gjc-cleanup-authority-root-");
+		temporaryDirectories.push(root);
+		const retainedPath = path.join(root, "retained");
+		await fs.mkdir(retainedPath);
+		const originalSnapshotDirectoryTree = native.snapshotDirectoryTree;
+		const observed = originalSnapshotDirectoryTree(retainedPath);
+		if (!observed.ok || !observed.snapshot) throw new Error("Native snapshot unavailable");
+		const nativeRoot = observed.snapshot.entries.find(
+			entry => entry.relativePath === "" && entry.kind === "directory",
+		);
+		if (!nativeRoot) throw new Error("Native root missing");
+		const expectedTree: NativeDirectoryTreeSnapshot = {
+			...observed.snapshot,
+			entries: observed.snapshot.entries.map(entry =>
+				entry.relativePath === "" && entry.kind === "directory" ? { ...entry, size: "4096" } : entry,
+			),
+		};
+		vi.spyOn(native, "snapshotDirectoryTree").mockImplementation(pathname =>
+			pathname === retainedPath ? { ok: true, snapshot: expectedTree } : originalSnapshotDirectoryTree(pathname),
+		);
+		const stat = syncFs.lstatSync(retainedPath, { bigint: true });
+		stat.dev = BigInt(nativeRoot.dev);
+		stat.ino = BigInt(nativeRoot.ino);
+		stat.size = 0n;
+		stat.mtimeNs = BigInt(nativeRoot.mtimeNs);
+		vi.spyOn(syncFs, "lstatSync").mockReturnValue(stat);
+		const cleanup = {
+			state: "cleanup_pending" as const,
+			role: "exchange_placeholder" as const,
+			retainedPath,
+			identity: {
+				dev: BigInt(nativeRoot.dev),
+				ino: BigInt(nativeRoot.ino),
+				size: 4096n,
+				mtimeNs: BigInt(nativeRoot.mtimeNs),
+			},
+			tree: expectedTree,
+		};
+		const parent = path.dirname(retainedPath);
+
+		expect(cleanupAuthorityMatches(cleanup, parent, "win32")).toBe(true);
+		expect(
+			cleanupAuthorityMatches({ ...cleanup, identity: { ...cleanup.identity, size: 4097n } }, parent, "win32"),
+		).toBe(false);
+		expect(
+			cleanupAuthorityMatches(
+				{ ...cleanup, identity: { ...cleanup.identity, mtimeNs: cleanup.identity.mtimeNs + 1n } },
+				parent,
+				"win32",
+			),
+		).toBe(false);
+		expect(
+			cleanupAuthorityMatches(
+				{ ...cleanup, identity: { ...cleanup.identity, dev: cleanup.identity.dev + 1n } },
+				parent,
+				"win32",
+			),
+		).toBe(false);
+		expect(cleanupAuthorityMatches(cleanup, path.join(root, "other"), "win32")).toBe(false);
+		expect(
+			cleanupAuthorityMatches({ ...cleanup, identity: { ...cleanup.identity, size: 0n } }, parent, "darwin"),
+		).toBe(true);
 	});
 
 	it("tolerates a POSIX root ctime change caused by detaching artifacts", async () => {


### PR DESCRIPTION
## Summary

- Fix `cleanupAuthorityMatches()` so Windows directory size and `mtimeNs` come from the root entry returned by `native.snapshotDirectoryTree()`, matching the existing `matchesMigrationArtifactRoot()` authority pattern.
- Add the trailing injectable `platform: NodeJS.Platform = process.platform` seam and deterministic cleanup-authority regression coverage.
- Add an Unreleased changelog entry.

`matchesMigrationArtifactRoot()` was already correct and deliberately left unchanged.

## Regression and guard coverage

The new fixture uses a temporary directory, `vi.spyOn` cleanup, and an injected platform value:

- `platform = "win32"`, Bun lstat directory `size = 0n`, and stored/native root `size = 4096` now matches.
- A native root size mismatch (`4096` observed vs `4097` stored) still fails, so the authority guard is not weakened into always-true.
- Windows `mtimeNs`, `dev`, and parent-path mismatches still fail.
- `platform = "darwin"` still uses Bun's lstat size authority, preserving the non-Windows behavior.

The regression test was run against the pre-fix unconditional Bun size check and failed at the expected Windows `0` versus native `4096` assertion (10 pass, 1 fail), then passed after the fix (11 pass, 0 fail).

## Verification boundary

The filesystem/native fixture behavior is host-verified on this macOS machine. The Windows branch, Bun-zero directory size scenario, native-root agreement/mismatch, and platform-specific metadata checks are proven through the injected `platform` seam only; no Windows host was assumed.

## Adjacent size comparison audit

- Line 597: writable binding `fstat` size; regular file, not a directory/native-tree comparison.
- Line 606: post-`fsync` binding `fstat` size; regular file, not a directory/native-tree comparison.
- Line 627: recaptured canonical binding identity; regular file, not a directory/native-tree comparison.
- Line 1766: planned cleanup transcript identity; regular file snapshot.
- Line 1864: cleanup receipt transcript identity; regular file metadata.
- Line 3091: source transcript snapshot before migration copy; regular file identity.
- Line 3212: source transcript snapshot before final publish; regular file identity.

None of these compare Bun directory size against a native-derived directory identity, so they were intentionally unchanged.

## Tests

- `bun test packages/coding-agent/test/session-manager/session-durability-windows.test.ts` — 11 pass, 0 fail, 38 expect calls.
- `bun test packages/coding-agent/test/session-manager/session-directory.test.ts` — 44 pass, 11 skipped, 0 fail, 272 expect calls.
- `bun test packages/coding-agent/test/session-manager/file-operations.test.ts` — 32 pass, 0 fail, 79 expect calls.
- `bun test packages/coding-agent/test/internal-urls/local-protocol.test.ts` — 19 pass, 0 fail, 61 expect calls.
- `bun test packages/coding-agent/test/session-manager/migration.test.ts` — 2 pass, 0 fail, 10 expect calls.
- Targeted `bunx biome check` over the three changed files — passed.
