### PR TITLE
chore(sdk): classify buildPreparedDisplaySessionContext as an internal seam

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -86,6 +86,7 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"agent_session:refreshMCPTools": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:refreshGjcSubskillTools": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:buildDisplaySessionContext": "internal accessor/plumbing, not a user-facing control seam",
+	"agent_session:buildPreparedDisplaySessionContext": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:convertMessagesToLlm": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:prepareSimpleStreamOptions": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:getPlanModeState": "internal accessor/plumbing, not a user-facing control seam",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2937,6 +2937,17 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:buildPreparedDisplaySessionContext",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal accessor/plumbing, not a user-facing control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:convertMessagesToLlm",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",


### PR DESCRIPTION
## What

Classifies the new `agent_session:buildPreparedDisplaySessionContext` seam as an internal exclusion and regenerates the SDK operation inventory.

## Why

PR #3138 (`fix(session): atomic prepare/ready/commit session identity rotation`, commit `0c25d133d`) added `AgentSession.buildPreparedDisplaySessionContext()` but did not classify it, so `check:sdk-closure` — which `bun run check:ts` runs — fails on `dev`:

```
Pending review source seam: agent_session:buildPreparedDisplaySessionContext.
Add it to SEAM_TO_SDK or LOCKED_EXCLUSIONS.
```

Verified this originates from #3138 and predates the current head: the check already fails when run at `0c25d133d` itself.

## Why `exclude` is the right classification

The method mirrors the already-excluded `buildDisplaySessionContext` six lines above it in `agent-session.ts` — it deobfuscates a session context and strips ephemeral custom messages for display:

```ts
buildPreparedDisplaySessionContext(prepared: PreparedNewSession): SessionContext {
    const context = deobfuscateSessionContext(
        this.sessionManager.buildPreparedNewSessionContext(prepared),
        this.#obfuscator,
    );
    return { ...context, messages: this.#withoutEphemeralCustomMessages(context.messages) };
}
```

It is display plumbing with no public SDK registry operation and no adapter mapping, so it takes the same rationale string as its sibling rather than being promoted into `SEAM_TO_SDK`.

## How

Added the entry to `LOCKED_EXCLUSIONS`, then regenerated with the documented command:

```sh
bun --cwd=packages/coding-agent run scripts/generate-sdk-operation-inventory.ts
```

Inventory result: 328 records — include=175, exclude=153, **pending=0**.

## Tests

```sh
bun --cwd=packages/coding-agent run scripts/generate-sdk-operation-inventory.ts --check   # exit 0
```