### PR TITLE
fix(tui): prevent duplicate transcript scrollback rows

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Streaming layout contraction followed by regrowth no longer re-admits an already committed logical row into native terminal scrollback, preventing occasional duplicated assistant lines after Markdown reflow.
+
 ## [0.11.10] - 2026-07-25
 
 ## [0.11.7] - 2026-07-22

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -662,6 +662,9 @@ export class TUI extends Container {
 	#cursorRow = 0; // Logical cursor row (end of rendered content)
 	#hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
 	#viewportTopRow = 0; // Content row currently mapped to screen row 0
+	#scrollbackResumeViewportTop: number | undefined; // Reflowed history below this frontier is already committed
+	#nativeScrollbackViewportTop = 0;
+	#transcriptIdentityResetPending = false;
 	#manualViewportTop: number | undefined;
 	#viewportAnchorComponent: Component | null = null;
 	#viewportAnchorFrame: ViewportAnchorFrame | null = null;
@@ -835,6 +838,9 @@ export class TUI extends Container {
 		this.#manualViewportFallbackAnchors = [];
 		this.#reconcileMissingViewportAnchor = false;
 		this.#viewportAnchorFrame = null;
+		this.#scrollbackResumeViewportTop = undefined;
+		this.#nativeScrollbackViewportTop = 0;
+		this.#transcriptIdentityResetPending = true;
 	}
 
 	/** Allow one semantic-neighbor reconciliation after a definitive same-transcript rebuild. */
@@ -1395,7 +1401,8 @@ export class TUI extends Container {
 		}
 		if (renderMetrics.enabled) renderMetrics.recordRequest(source);
 		if (force) {
-			const preserveViewportCursor = useViewportRepaintPath(this.terminal);
+			const preserveViewportCursor =
+				useViewportRepaintPath(this.terminal) || shouldPreserveScrollbackOnFullClear(this.terminal);
 			// A forced full redraw supersedes any queued input-priority render.
 			this.#inputRenderPending = false;
 			this.#previousLines = [];
@@ -2393,6 +2400,19 @@ export class TUI extends Container {
 			if (usedWindowNormalize) renderMetrics.recordLineCount("offscreenScan", diffStart);
 		}
 		this.#latestRenderedLines = newLines;
+		const naturalViewportTop = Math.max(0, newLines.length - height);
+		const priorLogicalLineCount = Math.max(this.#previousLines.length, this.#maxLinesRendered);
+		if (this.#transcriptIdentityResetPending) {
+			this.#transcriptIdentityResetPending = false;
+		} else if (
+			newLines.length < priorLogicalLineCount &&
+			(naturalViewportTop < prevViewportTop || this.#manualViewportTop !== undefined)
+		) {
+			this.#scrollbackResumeViewportTop = Math.max(
+				this.#scrollbackResumeViewportTop ?? 0,
+				this.#nativeScrollbackViewportTop,
+			);
+		}
 
 		if (this.#manualViewportTop !== undefined) {
 			let resolvedAnchorTop = anchorFrame === null ? null : this.#resolveManualAnchor(anchorFrame);
@@ -2473,7 +2493,16 @@ export class TUI extends Container {
 			return;
 		}
 		// Helper to clear scrollback and viewport and render all new lines
+		let viewportRepaint: (reason: string, targetViewportTop?: number) => void;
 		const fullRender = (clear: boolean, reason = "full render"): void => {
+			if (
+				clear &&
+				shouldPreserveScrollbackOnFullClear(this.terminal) &&
+				this.#scrollbackResumeViewportTop !== undefined
+			) {
+				viewportRepaint(`preserving full replay blocked after scrollback-unsafe contraction: ${reason}`);
+				return;
+			}
 			this.#fullRedrawCount += 1;
 			if (renderMetrics.enabled) renderMetrics.recordFullRedraw(reason);
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
@@ -2500,15 +2529,21 @@ export class TUI extends Container {
 				this.#maxLinesRendered = Math.max(this.#maxLinesRendered, newLines.length);
 			}
 			this.#viewportTopRow = Math.max(0, this.#maxLinesRendered - height);
+			this.#nativeScrollbackViewportTop = clear
+				? this.#viewportTopRow
+				: Math.max(this.#nativeScrollbackViewportTop, this.#viewportTopRow);
+			if (clear && !shouldPreserveScrollbackOnFullClear(this.terminal)) {
+				this.#scrollbackResumeViewportTop = undefined;
+			}
 			this.#previousLines = newLines;
 			this.#previousWidth = width;
 			this.#previousHeight = height;
 		};
 
-		const viewportRepaint = (reason: string): void => {
+		viewportRepaint = (reason: string, targetViewportTop = Math.max(0, newLines.length - height)): void => {
 			this.#fullRedrawCount += 1;
 			if (renderMetrics.enabled) renderMetrics.recordFullRedraw(reason);
-			const nextViewportTop = Math.max(0, newLines.length - height);
+			const nextViewportTop = targetViewportTop;
 			const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - prevViewportTop));
 			let buffer = "\x1b[?2026h";
 			if (currentScreenRow > 0) {
@@ -2644,7 +2679,7 @@ export class TUI extends Container {
 			}
 			lastChanged = newLines.length - 1;
 		}
-		const appendStart = appendedLines && firstChanged === this.#previousLines.length && firstChanged > 0;
+		let appendStart = appendedLines && firstChanged === this.#previousLines.length && firstChanged > 0;
 
 		// No changes - but still need to update hardware cursor position if it moved
 		if (firstChanged === -1) {
@@ -2657,6 +2692,32 @@ export class TUI extends Container {
 		if (newLines.length < this.#previousLines.length && nextLiveViewportTop !== prevViewportTop) {
 			viewportRepaint(`content contraction changed viewport top (${prevViewportTop} -> ${nextLiveViewportTop})`);
 			return;
+		}
+		if (appendedLines && this.#scrollbackResumeViewportTop !== undefined && nextLiveViewportTop > prevViewportTop) {
+			const resumeViewportTop = this.#scrollbackResumeViewportTop;
+			if (nextLiveViewportTop <= resumeViewportTop) {
+				viewportRepaint(
+					`content expansion below committed scrollback frontier (${prevViewportTop} -> ${nextLiveViewportTop}, frontier=${resumeViewportTop})`,
+				);
+				return;
+			}
+
+			const previousLines = this.#previousLines;
+			const previousWidth = this.#previousWidth;
+			const previousHeight = this.#previousHeight;
+			viewportRepaint(
+				`staging committed scrollback frontier before resumed admission (${prevViewportTop} -> ${resumeViewportTop} -> ${nextLiveViewportTop})`,
+				resumeViewportTop,
+			);
+			this.#previousLines = previousLines;
+			this.#previousWidth = previousWidth;
+			this.#previousHeight = previousHeight;
+			prevViewportTop = resumeViewportTop;
+			viewportTop = resumeViewportTop;
+			hardwareCursorRow = this.#hardwareCursorRow;
+			firstChanged = resumeViewportTop;
+			appendStart = false;
+			this.#scrollbackResumeViewportTop = undefined;
 		}
 		// All changes are in deleted lines (nothing to render, just clear)
 		if (firstChanged >= newLines.length) {
@@ -2855,6 +2916,7 @@ export class TUI extends Container {
 		// Track content height for viewport calculation
 		this.#maxLinesRendered = newLines.length;
 		this.#viewportTopRow = Math.max(0, newLines.length - height);
+		this.#nativeScrollbackViewportTop = Math.max(this.#nativeScrollbackViewportTop, this.#viewportTopRow);
 
 		this.#previousLines = newLines;
 		this.#previousWidth = width;

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -158,6 +158,147 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
+		it("does not retain a duplicated row when streaming reflow pulls history back into the viewport", async () => {
+			const term = new VirtualTerminal(64, 10, { isProcessTerminal: true });
+			const tui = new TUI(term);
+			const repeated = "이 요구사항은 작은 인증 변경이 아니라 제품 아키텍처 변경입니다.";
+			const prefix = ["context-0", "context-1", "context-2", "context-3", "현재 PRD에 미치는 영향", repeated];
+			const component = new MutableLinesComponent([...prefix, ...rows("initial-", 6)]);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				expect(countMatches(visible(term), /제품 아키텍처 변경입니다/)).toBe(1);
+
+				component.setLines([...prefix, ...rows("draft-", 14)]);
+				tui.requestRender();
+				await settle(term);
+				expect(countMatches(term.getScrollBuffer(), /제품 아키텍처 변경입니다/)).toBe(1);
+
+				component.setLines([...prefix, ...rows("reflowed-", 6)]);
+				tui.requestRender();
+				await settle(term);
+				expect(countMatches(visible(term), /제품 아키텍처 변경입니다/)).toBe(1);
+
+				component.setLines([...prefix, ...rows("final-", 18)]);
+				tui.requestRender();
+				await settle(term);
+
+				expect(countMatches(term.getScrollBuffer(), /제품 아키텍처 변경입니다/)).toBe(1);
+				expect(countMatches(term.getScrollBuffer(), /final-4/)).toBe(1);
+
+				component.setLines([...prefix, ...rows("final-", 22)]);
+				tui.requestRender();
+				await settle(term);
+
+				expect(countMatches(term.getScrollBuffer(), /제품 아키텍처 변경입니다/)).toBe(1);
+				expect(countMatches(term.getScrollBuffer(), /final-8/)).toBe(1);
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("re-enables native scrollback admission after transcript identity replacement", async () => {
+			const term = new VirtualTerminal(40, 6, { isProcessTerminal: true });
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("old-", 8));
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				component.setLines(rows("old-expanded-", 14));
+				tui.requestRender();
+				await settle(term);
+				component.setLines(rows("old-contracted-", 8));
+				tui.requestRender();
+				await settle(term);
+
+				tui.resetViewportAnchorIntent();
+				const replacement = ["new-0", "new-1", "new-2", "new-sentinel", ...rows("new-tail-", 4)];
+				component.setLines(replacement);
+				tui.requestRender();
+				await settle(term);
+				component.setLines([...replacement, ...rows("new-growth-", 6)]);
+				tui.requestRender();
+				await settle(term);
+
+				expect(countMatches(term.getScrollBuffer(), /new-sentinel/)).toBe(1);
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("keeps scrollback admission suspended across a preserving forced contraction", async () => {
+			Bun.env.TMUX = "1";
+			Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER = "1";
+			const term = new VirtualTerminal(48, 8, { isProcessTerminal: true });
+			const tui = new TUI(term);
+			const marker = "forced-reflow-marker";
+			const prefix = ["a", "b", "c", marker];
+			const component = new MutableLinesComponent([...prefix, ...rows("initial-", 6)]);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				component.setLines([...prefix, ...rows("expanded-", 14)]);
+				tui.requestRender();
+				await settle(term);
+				expect(countMatches(term.getScrollBuffer(), /forced-reflow-marker/)).toBe(1);
+
+				component.setLines([...prefix, ...rows("contracted-", 6)]);
+				tui.requestRender(true);
+				await settle(term);
+				component.setLines([...prefix, ...rows("regrown-", 18)]);
+				tui.requestRender();
+				await settle(term);
+
+				expect(countMatches(term.getScrollBuffer(), /forced-reflow-marker/)).toBe(1);
+				expect(countMatches(term.getScrollBuffer(), /regrown-6/)).toBe(1);
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("uses the native committed frontier after manual viewport contraction", async () => {
+			const term = new VirtualTerminal(40, 10, { isProcessTerminal: true });
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("history-", 20));
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				component.setLines(rows("history-", 30));
+				tui.requestRender();
+				await settle(term);
+				expect(countMatches(term.getScrollBuffer(), /history-12/)).toBe(1);
+				expect(tui.scrollViewportPages(-1)).toBe(true);
+				await term.flush();
+
+				component.setLines(rows("history-", 20));
+				tui.requestRender();
+				await settle(term);
+				component.setLines([...rows("history-", 20), ...rows("growth-", 14)]);
+				tui.requestRender();
+				await settle(term);
+				expect(tui.followLiveViewport()).toBe(true);
+				await term.flush();
+
+				component.setLines([...rows("history-", 20), ...rows("growth-", 15)]);
+				tui.requestRender();
+				await settle(term);
+				expect(visible(term)).toEqual(rows("growth-", 15).slice(-10));
+
+				expect(countMatches(term.getScrollBuffer(), /history-12/)).toBe(1);
+				expect(countMatches(term.getScrollBuffer(), /growth-0/)).toBe(1);
+			} finally {
+				tui.stop();
+			}
+		});
+
 		it("repaints live viewport when overflowed content shrinks only at the tail", async () => {
 			const term = new VirtualTerminal(20, 5);
 			const tui = new TUI(term);


### PR DESCRIPTION
## What

- track the native scrollback commit frontier independently from the live/manual viewport
- repaint regrowth below the committed frontier so old logical rows are not admitted twice
- stage the frontier and resume in-place differential output when growth crosses it, preserving exactly-once admission for genuinely new rows
- preserve the frontier across resize, forced render, legacy multiplexer, and manual viewport paths
- reset frontier accounting on transcript identity replacement or an actual non-preserving scrollback clear
- add deterministic regressions for reflow/regrowth, resumed new-row admission, transcript replacement, forced legacy rendering, and PageUp → contraction → growth → follow-live

## Why

Fixes #3212.

Streaming Markdown can expand, contract after reflow, and expand again. The live grid contains one logical copy, but differential scrolling could admit that row into native terminal scrollback twice. A permanent admission suspension avoided duplication but lost future history; the final implementation uses a bounded native-history frontier and resumes normal admission after crossing it.

## Testing

- `bun test packages/tui/test/render-regressions.test.ts` — 36 pass, 0 fail
- `bun test packages/tui/test` — 850 pass, 6 skip, 0 fail
- `bun run --cwd packages/tui check` — pass
- `git diff --check origin/dev...HEAD` — pass
- rebuilt `packages/natives` after rebasing onto current `dev`, then reran the complete TUI suite
- repository-wide `bun check` previously reached SDK closure tests but the local environment lacks `tmux`; the unrelated lifecycle-control test stopped with `ENOENT`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:3d7776788370f6b54cb24593cc22dcd9cf3cfd36 reviewer:architect evidence:local-exact-head-review
```

The independent exact-head review covered the rebased commit against `dev` `6353481d5c592910ac57b65809f7a1b97cf8fdf2` and returned CLEAR / APPROVE with no findings.

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (local environment lacks `tmux`; package checks and full TUI suite pass)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit