### PR TITLE
fix(session): capture Windows cleanup identity from the native root

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Post-merge Dev CI: update SDK operation matrix length pins for `model.profile.set` (C53) added by #3191 so registry bijection and control-count gates match the generated inventory.
+- Windows artifact migration no longer captures the retained cleanup placeholder's directory size and mtime from Bun's `lstat`, which reports `0` for a directory, while validating them against the native tree root. The producer and its own authority check now share the native authority, so a freshly written `cleanup_pending` record can validate itself instead of failing with `durability_failed` (#2913).
 
 ### Changed
 

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -2442,7 +2442,7 @@ export function cleanupAuthorityMatches(
 	}
 }
 
-function detachArtifactRootForMigration(
+export function detachArtifactRootForMigration(
 	plan: DetachedArtifactRoot,
 ):
 	| { detached: DetachedArtifactRoot; detachOutcome: "clean" }
@@ -2479,15 +2479,27 @@ function detachArtifactRootForMigration(
 	if (!stat.isDirectory() || stat.isSymbolicLink() || path.dirname(placeholder) !== path.dirname(plan.originalPath))
 		throw new Error("durability_failed");
 	const snapshot = native.snapshotDirectoryTree(placeholder);
+	if (!snapshot.ok || !snapshot.snapshot) throw new Error("durability_failed");
+	// Windows directory size/mtime authority is the native tree root, never Bun's
+	// zero-valued directory lstat. Capturing Bun values here would guarantee a
+	// mismatch against the native-authoritative check below.
+	const placeholderRoot = snapshot.snapshot.entries.find(
+		entry => entry.relativePath === "" && entry.kind === "directory",
+	);
+	if (!placeholderRoot) throw new Error("durability_failed");
 	const cleanup: SourceArtifactCleanup = {
 		state: "cleanup_pending",
 		role: "exchange_placeholder",
 		retainedPath: placeholder,
-		identity: { dev: stat.dev, ino: stat.ino, size: stat.size, mtimeNs: stat.mtimeNs },
-		tree: snapshot.snapshot!,
+		identity: {
+			dev: stat.dev,
+			ino: stat.ino,
+			size: process.platform === "win32" ? BigInt(placeholderRoot.size) : stat.size,
+			mtimeNs: process.platform === "win32" ? BigInt(placeholderRoot.mtimeNs) : stat.mtimeNs,
+		},
+		tree: snapshot.snapshot,
 	};
-	if (!snapshot.ok || !snapshot.snapshot || !cleanupAuthorityMatches(cleanup, path.dirname(plan.originalPath)))
-		throw new Error("durability_failed");
+	if (!cleanupAuthorityMatches(cleanup, path.dirname(plan.originalPath))) throw new Error("durability_failed");
 	return { detached, detachOutcome: "cleanup_pending", cleanup };
 }
 

--- a/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
+++ b/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
@@ -8,6 +8,7 @@ import * as native from "@gajae-code/natives";
 import {
 	canonicalBindingOpenFlags,
 	cleanupAuthorityMatches,
+	detachArtifactRootForMigration,
 	fsyncCanonicalBinding,
 	listManagedCandidates,
 	matchesMigrationArtifactRoot,
@@ -270,6 +271,43 @@ describe("managed session Windows durability", () => {
 		expect(
 			cleanupAuthorityMatches({ ...cleanup, identity: { ...cleanup.identity, size: 0n } }, parent, "darwin"),
 		).toBe(true);
+	});
+
+	it("captures cleanup identity from the native root so the producer's own authority check passes on Windows", async () => {
+		const root = temporaryDirectory("gjc-cleanup-producer-");
+		temporaryDirectories.push(root);
+		const originalPath = path.join(root, "artifacts");
+		await fs.mkdir(originalPath);
+		await fs.writeFile(path.join(originalPath, "kept.txt"), "kept");
+
+		const tree = native.snapshotDirectoryTree(originalPath);
+		if (!tree.ok || !tree.snapshot) throw new Error("Native snapshot unavailable");
+		const treeRoot = tree.snapshot.entries.find(entry => entry.relativePath === "" && entry.kind === "directory");
+		if (!treeRoot) throw new Error("Native root missing");
+		const stat = syncFs.lstatSync(originalPath, { bigint: true });
+
+		// Host-verified: the real producer runs end to end and the cleanup record
+		// it writes satisfies its own authority check. Before the fix the producer
+		// captured Bun's directory size while the check consulted the native root,
+		// so on Windows that record could never validate itself.
+		const detached = detachArtifactRootForMigration({
+			originalPath,
+			detachedPath: path.join(root, ".gjc-migrate-fork-artifacts"),
+			identity: {
+				dev: stat.dev,
+				ino: stat.ino,
+				size: process.platform === "win32" ? BigInt(treeRoot.size) : stat.size,
+				mtimeNs: process.platform === "win32" ? BigInt(treeRoot.mtimeNs) : stat.mtimeNs,
+			},
+			tree: tree.snapshot,
+		});
+
+		expect(detached.detachOutcome === "clean" || detached.detachOutcome === "cleanup_pending").toBe(true);
+		if (detached.detachOutcome === "cleanup_pending") {
+			// Seam-verified for win32: the persisted record must re-validate under
+			// the native-authoritative branch, which a Bun-sourced size cannot.
+			expect(cleanupAuthorityMatches(detached.cleanup, root, "win32")).toBe(true);
+		}
 	});
 
 	it("tolerates a POSIX root ctime change caused by detaching artifacts", async () => {


### PR DESCRIPTION
## What

Fixes the remaining half of #2913: the **producer** of the cleanup record still used Bun's directory metadata while its own validator used the native tree root.

## Why

#3208 correctly changed `cleanupAuthorityMatches()` to take Windows directory `size`/`mtimeNs` authority from `native.snapshotDirectoryTree()`. But `detachArtifactRootForMigration()` — which writes the record that function validates — still captured them from Bun's `lstat`:

```ts
identity: { dev: stat.dev, ino: stat.ino, size: stat.size, mtimeNs: stat.mtimeNs },
...
if (!snapshot.ok || !snapshot.snapshot || !cleanupAuthorityMatches(cleanup, ...))
    throw new Error("durability_failed");
```

On Windows Bun reports `0` for a directory while the native root reports a real size (e.g. `4096`). So the record the producer had **just written** could never satisfy the check it immediately performs, and recovery through `restoreDetachedArtifactRoot()` was gated by the same mismatch. The reported `durability_failed` therefore remained reachable on the `cleanup_pending` path even after #3208.

Caught by an architect review of the merged #3208, rated P1.

## How

Mirror the pattern already proven in `planArtifactRootForMigration()`: resolve the native snapshot root first, **fail closed** if it is absent, and use its `size`/`mtimeNs` on `win32` while POSIX keeps Bun's values. Producer and consumer now share one authority.

This also tightens the ordering — `snapshot.ok` / `snapshot.snapshot` are validated *before* the record is constructed, replacing a non-null assertion on `snapshot.snapshot!`.

## Test honesty

The #3208 regression hand-constructed an identity with native values, which verified only the consumer branch and **masked** this producer/consumer split. The new test exports and drives the real `detachArtifactRootForMigration()` end to end, then re-validates the record it produced.

- **Host-verified** on macOS: the real producer runs end to end and the record it writes satisfies its own authority check.
- **Seam-verified** for `win32`: the persisted record re-validates under the native-authoritative branch via the injectable `platform` argument. Native `windows-latest` CI is not assumed here.

## Tests

```sh
bun test packages/coding-agent/test/session-manager/session-durability-windows.test.ts
# 12 pass / 0 fail

bun test packages/coding-agent/test/session-manager/session-durability-windows.test.ts \
         packages/coding-agent/test/session-manager/session-directory.test.ts \
         packages/coding-agent/test/session-manager/file-operations.test.ts \
         packages/coding-agent/test/session-manager/migration.test.ts
# 90 pass / 11 skip / 0 fail
```