### PR TITLE
test(session): hermeticize win32 producer size divergence after #3216

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - JetBrains Air ACP sessions now preserve final answers across fast prompt completion, expose tool/retry/goal/notices and session title updates, apply Air's legacy `session/set_model` preset changes through the canonical session configuration path, accept client-supplied stdio/HTTP/SSE MCP servers, reject unsupported additional directories, and reject unavailable model presets before provider dispatch.
 
 ### Fixed
+- The #3216 win32 cleanup-producer regression no longer hardcodes divergent directory size `4096`; it injects `nativeRoot.size + 1` so the test stays hermetic when Linux directory size is already `4096` (post-merge Dev CI red on `79f0de870`).
 
 - Windows artifact-migration cleanup identity capture is now provable off-Windows: `detachArtifactRootForMigration` takes an injectable platform seam so the `win32` producer branch is exercised deterministically, and its regression fails if the native-root capture is reverted (#2913).
 - Post-merge Dev CI: update SDK operation matrix length pins for `model.profile.set` (C53) added by #3191 so registry bijection and control-count gates match the generated inventory.

--- a/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
+++ b/packages/coding-agent/test/session-manager/session-durability-windows.test.ts
@@ -286,13 +286,14 @@ describe("managed session Windows durability", () => {
 		if (!treeRoot) throw new Error("Native root missing");
 		const stat = syncFs.lstatSync(originalPath, { bigint: true });
 
-		// On this host Bun's directory size and the native root size agree, so a
-		// plain run cannot tell the two authorities apart. Inject the Windows
-		// divergence -- native root reports 4096 while Bun keeps its own value --
-		// so the assertion below can only pass if the producer reads the native
-		// root. Reverting the win32 branch makes this test fail.
+		// On this host Bun's directory size and the native root size often agree,
+		// so a plain run cannot tell the two authorities apart. Inject a size that
+		// is guaranteed to differ from the real native root so the assertion below
+		// can only pass if the producer reads the mocked native root. Hardcoding
+		// 4096 is not hermetic: Linux directory sizes can already be 4096.
+		// Reverting the win32 branch makes this test fail.
 		const originalSnapshot = native.snapshotDirectoryTree;
-		const divergentSize = "4096";
+		const divergentSize = (BigInt(treeRoot.size) + 1n).toString();
 		expect(divergentSize).not.toBe(treeRoot.size);
 		// Scope the divergence to the retained placeholder only; the detached
 		// original is validated by a separate upstream check that must see real


### PR DESCRIPTION
## Summary

Post-merge Dev CI on `79f0de870` (#3216) failed shard-1 with:

`managed session Windows durability > forces the win32 producer branch so cleanup identity comes from the native root`

`expect(received).not.toBe(expected)` with both sides `"4096"`.

## Root cause

#3216 hardcodes `divergentSize = "4096"` and asserts it differs from the real native root size. On Linux CI (and this host), native directory size is already `4096`, so the pretest assertion fails before the producer-branch check runs.

This is a test hermeticity bug, not a product regression of #3215/#3208 Windows native-root cleanup identity.

## Fix

Inject `nativeRoot.size + 1` (same pattern as the adjacent Windows authority tests) so the mocked native size is always distinct from the real root while preserving the fail-first property that only a native-root producer read yields the injected size.

## Verification

- Local probe: native root size `4096`; divergent becomes `4097`
- `bun test packages/coding-agent/test/session-manager/session-durability-windows.test.ts` — 12 pass / 0 fail
- Related suites (durability-windows + session-directory + file-operations + migration) — 98 pass / 3 skip / 0 fail

## Notes

- Product code unchanged; #3215/#3208 producer seam preserved
- Does **not** address #3209 seven failure-injection tests

Fixes post-merge regression from #3216