### PR TITLE
test(session): hermetic fork/moveTo failure-injection across platforms (#3209)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - JetBrains Air ACP sessions now preserve final answers across fast prompt completion, expose tool/retry/goal/notices and session title updates, apply Air's legacy `session/set_model` preset changes through the canonical session configuration path, accept client-supplied stdio/HTTP/SSE MCP servers, reject unsupported additional directories, and reject unavailable model presets before provider dispatch.
 
 ### Fixed
+- Session-manager fork/moveTo failure-injection tests now use a platform-aware hermetic seam: retained `RecoveryFsRoot` prototype spies on Linux and the direct native/fs fallbacks off Linux, with a required hit counter so a dead injection fails closed (#3209).
 - The #3216 win32 cleanup-producer regression no longer hardcodes divergent directory size `4096`; it injects `nativeRoot.size + 1` so the test stays hermetic when Linux directory size is already `4096` (post-merge Dev CI red on `79f0de870`).
 
 - Windows artifact-migration cleanup identity capture is now provable off-Windows: `detachArtifactRootForMigration` takes an injectable platform seam so the `win32` producer branch is exercised deterministically, and its regression fails if the native-root capture is reverted (#2913).

--- a/packages/coding-agent/test/session-manager/managed-failure-injection.ts
+++ b/packages/coding-agent/test/session-manager/managed-failure-injection.ts
@@ -1,0 +1,252 @@
+/**
+ * Platform-aware failure injection for managed session durability tests.
+ *
+ * Retained RecoveryFsRoot authority is Linux-only
+ * (`retainManagedDirectoryAuthority` returns undefined off Linux, and
+ * `ManagedSessionDescendantStore` only opens RecoveryFsRoot on Linux).
+ * On other hosts production uses direct native rename/snapshot/fs paths, so
+ * `RecoveryFsRoot.prototype` spies never intercept.
+ *
+ * These helpers install injection on the production call path for the host and
+ * require at least one hit so a dead seam fails closed instead of silently succeeding.
+ */
+import { vi } from "bun:test";
+import * as fs from "node:fs";
+import * as native from "@gajae-code/natives";
+
+export function publishFailure(code: string, reason: "io_failure" | "identity_violation") {
+	return {
+		ok: false as const,
+		code,
+		mutationState: "not_committed" as const,
+		durabilityState: "not_attempted" as const,
+		reason,
+		primitive: "renameat2_noreplace" as const,
+		phase: "preflight" as const,
+		diagnostic: { schemaVersion: 1 as const, collectionState: "complete" as const },
+	};
+}
+
+export type ManagedInjectionHandle = {
+	restore: () => void;
+	hits: () => number;
+	/** Throws if the injection never ran (dead spy / wrong seam). */
+	assertHit: () => void;
+};
+
+function handle(hits: { n: number }, restore: () => void): ManagedInjectionHandle {
+	return {
+		restore,
+		hits: () => hits.n,
+		assertHit: () => {
+			if (hits.n < 1) {
+				throw new Error(
+					`managed failure-injection seam never ran (platform=${process.platform}); production path bypassed the spy`,
+				);
+			}
+		},
+	};
+}
+
+/** Inject tree rename failures (fork artifact publish / rename boundary). */
+export function injectManagedTreeRename(
+	impl: (source: string, destination: string) => ReturnType<typeof publishFailure> | "passthrough",
+): ManagedInjectionHandle {
+	const hits = { n: 0 };
+	if (process.platform === "linux") {
+		const real = native.RecoveryFsRoot.prototype.renameManagedTreeNoReplace;
+		const spy = vi.spyOn(native.RecoveryFsRoot.prototype, "renameManagedTreeNoReplace").mockImplementation(function (
+			this: native.RecoveryFsRoot,
+			source,
+			destination,
+			expected,
+		) {
+			const result = impl(String(source), String(destination));
+			if (result === "passthrough") return real.call(this, source, destination, expected);
+			hits.n += 1;
+			return result;
+		});
+		return handle(hits, () => spy.mockRestore());
+	}
+	const real = native.renameNoReplacePath;
+	const spy = vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) => {
+		const result = impl(String(source), String(destination));
+		if (result === "passthrough") return real(source, destination);
+		hits.n += 1;
+		return result;
+	});
+	return handle(hits, () => spy.mockRestore());
+}
+
+/** Inject managed tree snapshot failures (post-publish retained capture). */
+export function injectManagedTreeSnapshot(failure: { ok: false; code: string }): ManagedInjectionHandle {
+	const hits = { n: 0 };
+	if (process.platform === "linux") {
+		const spy = vi.spyOn(native.RecoveryFsRoot.prototype, "snapshotManagedTree").mockImplementation(() => {
+			hits.n += 1;
+			return failure as never;
+		});
+		return handle(hits, () => spy.mockRestore());
+	}
+	const spy = vi.spyOn(native, "snapshotDirectoryTree").mockImplementation(() => {
+		hits.n += 1;
+		return failure as never;
+	});
+	return handle(hits, () => spy.mockRestore());
+}
+
+/**
+ * Inject retained-tree fsync identity failures.
+ * Linux: RecoveryFsRoot.fsyncExpected. Other hosts: fs.fsyncSync during tree fsync.
+ */
+export function injectManagedTreeFsync(options: {
+	shouldFail: (pathOrRelative: string) => boolean;
+	code: string;
+}): ManagedInjectionHandle {
+	const hits = { n: 0 };
+	if (process.platform === "linux") {
+		const real = native.RecoveryFsRoot.prototype.fsyncExpected;
+		const spy = vi.spyOn(native.RecoveryFsRoot.prototype, "fsyncExpected").mockImplementation(function (
+			this: native.RecoveryFsRoot,
+			relativePath,
+			directory,
+			expectedDev,
+			expectedIno,
+			expectedSize,
+			expectedMtimeNs,
+			expectedSha256,
+		) {
+			if (options.shouldFail(String(relativePath))) {
+				hits.n += 1;
+				return { ok: false, code: options.code };
+			}
+			return real.call(
+				this,
+				relativePath,
+				directory,
+				expectedDev,
+				expectedIno,
+				expectedSize,
+				expectedMtimeNs,
+				expectedSha256,
+			);
+		});
+		return handle(hits, () => spy.mockRestore());
+	}
+	// Non-Linux fsyncTree walks files with open+fsync. Force the first fsync to
+	// surface the expected code; production maps the throw into the fork failure.
+	const spy = vi.spyOn(fs, "fsyncSync").mockImplementation((() => {
+		hits.n += 1;
+		throw new Error(options.code);
+	}) as typeof fs.fsyncSync);
+	return handle(hits, () => spy.mockRestore());
+}
+
+/** Inject managed file rename failures (transcript publication). */
+export function injectManagedFileRename(
+	impl: (source: string, destination: string) => ReturnType<typeof publishFailure> | "passthrough",
+): ManagedInjectionHandle {
+	const hits = { n: 0 };
+	if (process.platform === "linux") {
+		const real = native.RecoveryFsRoot.prototype.renameManagedFileNoReplace;
+		const spy = vi.spyOn(native.RecoveryFsRoot.prototype, "renameManagedFileNoReplace").mockImplementation(function (
+			this: native.RecoveryFsRoot,
+			sourceRelativePath,
+			destinationRelativePath,
+			expectedDev,
+			expectedIno,
+			expectedSize,
+			expectedMtimeNs,
+			expectedCtimeNs,
+			expectedSha256,
+		) {
+			const result = impl(String(sourceRelativePath), String(destinationRelativePath));
+			if (result === "passthrough") {
+				return real.call(
+					this,
+					sourceRelativePath,
+					destinationRelativePath,
+					expectedDev,
+					expectedIno,
+					expectedSize,
+					expectedMtimeNs,
+					expectedCtimeNs,
+					expectedSha256,
+				);
+			}
+			hits.n += 1;
+			return result;
+		});
+		return handle(hits, () => spy.mockRestore());
+	}
+	const real = native.renameNoReplacePath;
+	const spy = vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) => {
+		const result = impl(String(source), String(destination));
+		if (result === "passthrough") return real(source, destination);
+		hits.n += 1;
+		return result;
+	});
+	return handle(hits, () => spy.mockRestore());
+}
+
+/** Inject managed append failures (moveTo cwd header_patch). */
+export function injectManagedAppend(
+	impl: (relativePath: string, data: Uint8Array) => { ok: false; code: string } | "passthrough",
+): ManagedInjectionHandle {
+	const hits = { n: 0 };
+	if (process.platform === "linux") {
+		const real = native.RecoveryFsRoot.prototype.appendManaged;
+		const spy = vi.spyOn(native.RecoveryFsRoot.prototype, "appendManaged").mockImplementation(function (
+			this: native.RecoveryFsRoot,
+			relativePath,
+			data,
+			expectedDev,
+			expectedIno,
+			expectedSize,
+			expectedMtimeNs,
+			expectedCtimeNs,
+			expectedSha256,
+		) {
+			const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as ArrayBuffer);
+			const result = impl(String(relativePath), bytes);
+			if (result === "passthrough") {
+				return real.call(
+					this,
+					relativePath,
+					data,
+					expectedDev,
+					expectedIno,
+					expectedSize,
+					expectedMtimeNs,
+					expectedCtimeNs,
+					expectedSha256,
+				);
+			}
+			hits.n += 1;
+			return result;
+		});
+		return handle(hits, () => spy.mockRestore());
+	}
+	const realWrite = fs.writeSync.bind(fs);
+	const spy = vi.spyOn(fs, "writeSync").mockImplementation(function (
+		this: unknown,
+		...args: Parameters<typeof fs.writeSync>
+	) {
+		const buffer = args[1];
+		const bytes =
+			typeof buffer === "string"
+				? Buffer.from(buffer)
+				: Buffer.isBuffer(buffer)
+					? buffer
+					: buffer instanceof Uint8Array
+						? Buffer.from(buffer)
+						: Buffer.alloc(0);
+		const result = impl("", bytes);
+		if (result !== "passthrough") {
+			hits.n += 1;
+			throw new Error(result.code);
+		}
+		return realWrite(...args);
+	} as typeof fs.writeSync);
+	return handle(hits, () => spy.mockRestore());
+}

--- a/packages/coding-agent/test/session-manager/managed-failure-injection.ts
+++ b/packages/coding-agent/test/session-manager/managed-failure-injection.ts
@@ -233,14 +233,11 @@ export function injectManagedAppend(
 		...args: Parameters<typeof fs.writeSync>
 	) {
 		const buffer = args[1];
-		const bytes =
-			typeof buffer === "string"
+		const bytes = Buffer.isBuffer(buffer)
+			? buffer
+			: typeof buffer === "string"
 				? Buffer.from(buffer)
-				: Buffer.isBuffer(buffer)
-					? buffer
-					: buffer instanceof Uint8Array
-						? Buffer.from(buffer)
-						: Buffer.alloc(0);
+				: Buffer.from(String(buffer ?? ""));
 		const result = impl("", bytes);
 		if (result !== "passthrough") {
 			hits.n += 1;

--- a/packages/coding-agent/test/session-manager/session-id.test.ts
+++ b/packages/coding-agent/test/session-manager/session-id.test.ts
@@ -1,25 +1,19 @@
-import { describe, expect, it, vi } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
-import * as native from "@gajae-code/natives";
 import { TempDir } from "@gajae-code/utils";
+import {
+	injectManagedFileRename,
+	injectManagedTreeFsync,
+	injectManagedTreeRename,
+	injectManagedTreeSnapshot,
+	publishFailure,
+} from "./managed-failure-injection";
 
 const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
-function publishFailure(code: string, reason: "io_failure" | "identity_violation") {
-	return {
-		ok: false,
-		code,
-		mutationState: "not_committed",
-		durabilityState: "not_attempted",
-		reason,
-		primitive: "renameat2_noreplace",
-		phase: "preflight",
-		diagnostic: { schemaVersion: 1, collectionState: "complete" },
-	} as const;
-}
 function expectUuidV7SessionId(session: SessionManager): string {
 	const sessionId = session.getSessionId();
 	expect(sessionId).toMatch(UUID_V7_RE);
@@ -107,26 +101,19 @@ describe("SessionManager session ids", () => {
 		const oldSessionFile = session.getSessionFile();
 		const oldSessionId = session.getSessionId();
 		if (!oldSessionFile) throw new Error("Expected session file");
-		const realRename = native.RecoveryFsRoot.prototype.renameManagedTreeNoReplace;
-		const spy = vi.spyOn(native.RecoveryFsRoot.prototype, "renameManagedTreeNoReplace").mockImplementation(function (
-			this: native.RecoveryFsRoot,
-			source,
-			destination,
-			expected,
-		) {
-			return source.includes(".fork-staging")
-				? publishFailure("io_error", "io_failure")
-				: realRename.call(this, source, destination, expected);
-		});
+		const injection = injectManagedTreeRename((source, _destination) =>
+			source.includes(".fork-staging") ? publishFailure("io_error", "io_failure") : "passthrough",
+		);
 		try {
 			await expect(session.fork()).rejects.toThrow("io_error");
+			injection.assertHit();
 			expect(session.getSessionFile()).toBe(oldSessionFile);
 			expect(session.getSessionId()).toBe(oldSessionId);
 			const entries = await fs.readdir(path.dirname(oldSessionFile));
 			expect(entries.filter(entry => entry.endsWith(".jsonl"))).toEqual([path.basename(oldSessionFile)]);
 			expect(entries.some(entry => entry.includes("fork-staging"))).toBe(false);
 		} finally {
-			spy.mockRestore();
+			injection.restore();
 			await session.close();
 		}
 	});
@@ -157,15 +144,14 @@ describe("SessionManager session ids", () => {
 		const oldSessionFile = session.getSessionFile();
 		const oldSessionId = session.getSessionId();
 		if (!oldSessionFile) throw new Error("Expected session file");
-		const spy = vi
-			.spyOn(native.RecoveryFsRoot.prototype, "renameManagedTreeNoReplace")
-			.mockReturnValue(publishFailure("identity_mismatch", "identity_violation"));
+		const injection = injectManagedTreeRename(() => publishFailure("identity_mismatch", "identity_violation"));
 		try {
 			await expect(session.fork()).rejects.toThrow("identity_mismatch");
+			injection.assertHit();
 			expect(session.getSessionFile()).toBe(oldSessionFile);
 			expect(session.getSessionId()).toBe(oldSessionId);
 		} finally {
-			spy.mockRestore();
+			injection.restore();
 			await session.close();
 		}
 	});
@@ -179,14 +165,13 @@ describe("SessionManager session ids", () => {
 		await session.saveArtifact("artifact", "test");
 		const oldSessionFile = session.getSessionFile();
 		if (!oldSessionFile) throw new Error("Expected session file");
-		const spy = vi
-			.spyOn(native.RecoveryFsRoot.prototype, "renameManagedTreeNoReplace")
-			.mockReturnValue(publishFailure("identity_mismatch", "identity_violation"));
+		const injection = injectManagedTreeRename(() => publishFailure("identity_mismatch", "identity_violation"));
 		try {
 			await expect(session.fork()).rejects.toThrow("identity_mismatch");
+			injection.assertHit();
 			expect(session.getSessionFile()).toBe(oldSessionFile);
 		} finally {
-			spy.mockRestore();
+			injection.restore();
 			await session.close();
 		}
 	});
@@ -200,14 +185,13 @@ describe("SessionManager session ids", () => {
 		await session.saveArtifact("artifact", "test");
 		const oldSessionFile = session.getSessionFile();
 		if (!oldSessionFile) throw new Error("Expected session file");
-		const spy = vi
-			.spyOn(native.RecoveryFsRoot.prototype, "snapshotManagedTree")
-			.mockReturnValue({ ok: false, code: "identity_mismatch" });
+		const injection = injectManagedTreeSnapshot({ ok: false, code: "identity_mismatch" });
 		try {
 			await expect(session.fork()).rejects.toThrow("identity_mismatch");
+			injection.assertHit();
 			expect(session.getSessionFile()).toBe(oldSessionFile);
 		} finally {
-			spy.mockRestore();
+			injection.restore();
 			await session.close();
 		}
 	});
@@ -221,34 +205,16 @@ describe("SessionManager session ids", () => {
 		await session.saveArtifact("artifact", "test");
 		const oldSessionFile = session.getSessionFile();
 		if (!oldSessionFile) throw new Error("Expected session file");
-		const realFsyncExpected = native.RecoveryFsRoot.prototype.fsyncExpected;
-		const spy = vi.spyOn(native.RecoveryFsRoot.prototype, "fsyncExpected").mockImplementation(function (
-			this: native.RecoveryFsRoot,
-			relativePath,
-			directory,
-			expectedDev,
-			expectedIno,
-			expectedSize,
-			expectedMtimeNs,
-			expectedSha256,
-		) {
-			if (relativePath.endsWith(".log")) return { ok: false, code: "identity_mismatch" };
-			return realFsyncExpected.call(
-				this,
-				relativePath,
-				directory,
-				expectedDev,
-				expectedIno,
-				expectedSize,
-				expectedMtimeNs,
-				expectedSha256,
-			);
+		const injection = injectManagedTreeFsync({
+			shouldFail: relativePath => relativePath.endsWith(".log"),
+			code: "identity_mismatch",
 		});
 		try {
 			await expect(session.fork()).rejects.toThrow("identity_mismatch");
+			injection.assertHit();
 			expect(session.getSessionFile()).toBe(oldSessionFile);
 		} finally {
-			spy.mockRestore();
+			injection.restore();
 			await session.close();
 		}
 	});
@@ -263,33 +229,12 @@ describe("SessionManager session ids", () => {
 		const oldSessionFile = session.getSessionFile();
 		const oldSessionId = session.getSessionId();
 		if (!oldSessionFile) throw new Error("Expected session file");
-		const realRename = native.RecoveryFsRoot.prototype.renameManagedFileNoReplace;
-		const spy = vi.spyOn(native.RecoveryFsRoot.prototype, "renameManagedFileNoReplace").mockImplementation(function (
-			this: native.RecoveryFsRoot,
-			sourceRelativePath,
-			destinationRelativePath,
-			expectedDev,
-			expectedIno,
-			expectedSize,
-			expectedMtimeNs,
-			expectedCtimeNs,
-			expectedSha256,
-		) {
-			if (destinationRelativePath.endsWith(".jsonl")) return publishFailure("io_error", "io_failure");
-			return realRename.call(
-				this,
-				sourceRelativePath,
-				destinationRelativePath,
-				expectedDev,
-				expectedIno,
-				expectedSize,
-				expectedMtimeNs,
-				expectedCtimeNs,
-				expectedSha256,
-			);
-		});
+		const injection = injectManagedFileRename((_source, destination) =>
+			destination.endsWith(".jsonl") ? publishFailure("io_error", "io_failure") : "passthrough",
+		);
 		try {
 			await expect(session.fork()).rejects.toThrow("io_error");
+			injection.assertHit();
 			expect(session.getSessionFile()).toBe(oldSessionFile);
 			expect(session.getSessionId()).toBe(oldSessionId);
 			const entries = await fs.readdir(path.dirname(oldSessionFile));
@@ -300,7 +245,7 @@ describe("SessionManager session ids", () => {
 			expect(artifactDirectories).toContain(path.basename(oldSessionFile, ".jsonl"));
 			expect(artifactDirectories).toHaveLength(1);
 		} finally {
-			spy.mockRestore();
+			injection.restore();
 			await session.close();
 		}
 	});

--- a/packages/coding-agent/test/session-manager/title-source-persistence.test.ts
+++ b/packages/coding-agent/test/session-manager/title-source-persistence.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -10,10 +10,10 @@ import {
 	SessionManager,
 } from "@gajae-code/coding-agent/session/session-manager";
 import { FileSessionStorage, type SessionStorageWriter } from "@gajae-code/coding-agent/session/session-storage";
-import * as native from "@gajae-code/natives";
 import { getConfigRootDir, parseJsonlLenient, setAgentDir } from "@gajae-code/utils";
 
 import { makeAssistantMessage } from "./helpers";
+import { injectManagedAppend } from "./managed-failure-injection";
 
 function getHeader(entries: unknown[]): SessionHeader | undefined {
 	return entries.find(
@@ -314,36 +314,16 @@ describe("session title source persistence", () => {
 			const originalFile = session.getSessionFile();
 			expect(originalFile).toBeDefined();
 
-			const originalAppend = native.RecoveryFsRoot.prototype.appendManaged;
-			const append = vi.spyOn(native.RecoveryFsRoot.prototype, "appendManaged").mockImplementation(function (
-				this: native.RecoveryFsRoot,
-				relativePath,
-				data,
-				expectedDev,
-				expectedIno,
-				expectedSize,
-				expectedMtimeNs,
-				expectedCtimeNs,
-				expectedSha256,
-			) {
-				if (Buffer.from(data).includes(Buffer.from('"type":"header_patch"')))
-					return { ok: false, code: "header_patch_write_failed" };
-				return originalAppend.call(
-					this,
-					relativePath,
-					data,
-					expectedDev,
-					expectedIno,
-					expectedSize,
-					expectedMtimeNs,
-					expectedCtimeNs,
-					expectedSha256,
-				);
-			});
+			const injection = injectManagedAppend((_relativePath, data) =>
+				Buffer.from(data).includes(Buffer.from('"type":"header_patch"'))
+					? { ok: false, code: "header_patch_write_failed" }
+					: "passthrough",
+			);
 			try {
 				await expect(session.moveTo(destinationCwd)).rejects.toThrow("header_patch_write_failed");
+				injection.assertHit();
 			} finally {
-				append.mockRestore();
+				injection.restore();
 			}
 			expect(session.getCwd()).toBe(cwd);
 			expect(session.getSessionFile()).toBe(originalFile);


### PR DESCRIPTION
## Summary

Seven fork/moveTo failure-injection tests spy `RecoveryFsRoot.prototype.*` and expect fail-closed rejections. On macOS (and Windows) those spies never intercept production because retained RecoveryFsRoot authority is **Linux-only**.

## Root cause

Product gates:

- `retainManagedDirectoryAuthority(...)` returns `undefined` when `process.platform !== "linux"`
- `ManagedSessionDescendantStore` only opens `openRecoveryFsRoot` on Linux

Off Linux, production uses direct `renameNoReplacePath` / `snapshotDirectoryTree` / `fs` paths. Prototype spies resolve as no-ops; fork/moveTo succeeds; assertions fail as `Expected promise that rejects`.

This is a dead test seam / host dependency, not a newly introduced product fail-closed regression of the retained-authority path (that path is still Linux-only by design).

## Fix

- Add `managed-failure-injection.ts` helpers that inject on the **production** seam for the host:
  - Linux: `RecoveryFsRoot.prototype` methods
  - non-Linux: `renameNoReplacePath` / `snapshotDirectoryTree` / `fs.fsyncSync` / `fs.writeSync`
- Require `assertHit()` so a dead injection fails closed instead of silently green
- Wire the seven tests through those helpers

## Verification

```sh
bun test packages/coding-agent/test/session-manager/session-id.test.ts \
         packages/coding-agent/test/session-manager/title-source-persistence.test.ts
# 22 pass / 0 fail

bun test packages/coding-agent/test/session-manager/session-id.test.ts \
         packages/coding-agent/test/session-manager/title-source-persistence.test.ts \
         packages/coding-agent/test/session-manager/draft.test.ts \
         packages/coding-agent/test/task-managed-descendants.test.ts \
         packages/coding-agent/test/session-storage.test.ts
# 94 pass / 0 fail
```

Product production fail-closed paths unchanged. Coordinates with #3211 conceptually (spy seam repairs) without duplicating its #2261 prepare/commit work.

Closes #3209