### PR TITLE
fix(sdk): drain MCP stdio handlers so e2e cannot hang after stdin EOF

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,7 @@
 - `--thinking` now advertises the supported Effort levels and fails closed with a usage error for invalid, missing, empty, or flag-adjacent values, rather than silently ignoring a token or consuming another flag.
 - MCP servers configured with a large `timeout` no longer widen the startup hang window for every consumer. The long startup ceiling now applies only to ACP lifecycle launches that supply their own MCP servers, derived from the session readiness deadline with reserved headroom; ordinary CLI/SDK `mcpConfigPath`, project, user, and plugin-bundle consumers keep the short default. An ACP launch that reaches the readiness cutoff before MCP startup now fails fast as a pending startup instead of silently falling back to the ordinary ceiling.
 
+- SDK MCP stdio (`gjc mcp-serve sdk`) now awaits in-flight JSON-RPC handlers after stdin EOF so tools/call responses finish and WebSocket clients close before process exit; the entrypoint e2e fixture bounds child/server/temp cleanup on success and failure so the suite cannot hang for the full 60s on a stuck server.
 ## [0.11.10] - 2026-07-25
 ### Changed
 

--- a/packages/coding-agent/src/sdk/mcp/server.ts
+++ b/packages/coding-agent/src/sdk/mcp/server.ts
@@ -301,9 +301,16 @@ export function createSdkMcpServer(options: SdkMcpServerOptions = {}) {
 export async function runSdkMcpStdio(options: SdkMcpServerOptions = {}): Promise<void> {
 	const server = createSdkMcpServer(options);
 	let buffer = "";
+	const inflight = new Set<Promise<void>>();
 	process.stdin.setEncoding("utf8");
-	await new Promise<void>(resolve => {
-		process.stdin.on("data", (chunk: string) => {
+
+	const track = (work: Promise<void>): void => {
+		inflight.add(work);
+		void work.finally(() => inflight.delete(work));
+	};
+
+	await new Promise<void>((resolve, reject) => {
+		const onData = (chunk: string) => {
 			buffer += chunk;
 			let index = buffer.indexOf("\n");
 			while (index >= 0) {
@@ -311,22 +318,43 @@ export async function runSdkMcpStdio(options: SdkMcpServerOptions = {}): Promise
 				buffer = buffer.slice(index + 1);
 				index = buffer.indexOf("\n");
 				if (!line) continue;
-				void (async () => {
-					let request: JsonRpcRequest;
-					try {
-						request = JSON.parse(line) as JsonRpcRequest;
-					} catch {
-						process.stdout.write(
-							`${JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "parse_error" } })}\n`,
-						);
-						return;
-					}
-					const response = await server.handleJsonRpc(request);
-					// JSON-RPC notifications (no id) receive no response.
-					if (request.id !== undefined) process.stdout.write(`${JSON.stringify(response)}\n`);
-				})();
+				track(
+					(async () => {
+						let request: JsonRpcRequest;
+						try {
+							request = JSON.parse(line) as JsonRpcRequest;
+						} catch {
+							process.stdout.write(
+								`${JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "parse_error" } })}\n`,
+							);
+							return;
+						}
+						const response = await server.handleJsonRpc(request);
+						// JSON-RPC notifications (no id) receive no response.
+						if (request.id !== undefined) process.stdout.write(`${JSON.stringify(response)}\n`);
+					})(),
+				);
 			}
-		});
-		process.stdin.on("end", () => resolve());
+		};
+		const onEnd = () => {
+			process.stdin.off("data", onData);
+			process.stdin.off("end", onEnd);
+			process.stdin.off("error", onError);
+			resolve();
+		};
+		const onError = (error: Error) => {
+			process.stdin.off("data", onData);
+			process.stdin.off("end", onEnd);
+			process.stdin.off("error", onError);
+			reject(error);
+		};
+		process.stdin.on("data", onData);
+		process.stdin.on("end", onEnd);
+		process.stdin.on("error", onError);
 	});
+
+	// Stdin EOF must not drop in-flight tools/call handlers (WS connect/query).
+	// Awaiting them also prevents the process from exiting before responses flush,
+	// and lets clients close so the event loop can drain deterministically.
+	await Promise.allSettled([...inflight]);
 }

--- a/packages/coding-agent/test/fixtures/sdk-mcp-entrypoint-e2e-script.ts
+++ b/packages/coding-agent/test/fixtures/sdk-mcp-entrypoint-e2e-script.ts
@@ -77,30 +77,30 @@ try {
 		explicitBin && explicitBin.length > 0
 			? [explicitBin, "mcp-serve", "sdk"]
 			: ["bun", "run", cliEntry, "mcp-serve", "sdk"];
-	child = Bun.spawn(spawnCmd, {
+	const proc = Bun.spawn(spawnCmd, {
 		cwd: repo,
 		stdin: "pipe",
 		stdout: "pipe",
 		stderr: "pipe",
 		env: process.env,
 	});
-	const writer = child.stdin;
-	writer.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" })}\n`);
-	writer.write(`${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" })}\n`);
-	writer.write(
+	child = proc;
+	proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" })}\n`);
+	proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" })}\n`);
+	proc.stdin.write(
 		`${JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "gjc_session_query", arguments: { sessionId: "s1", query: "session.metadata" } } })}\n`,
 	);
-	writer.write(
+	proc.stdin.write(
 		`${JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "gjc_session_global", arguments: { operation: "session.get_endpoint" } } })}\n`,
 	);
-	await writer.end();
+	await proc.stdin.end();
 
 	// Bound wait: kill the child if it does not exit after stdin EOF so the outer
 	// suite never sits on an open stdout pipe for the full 60s.
-	const outPromise = new Response(child.stdout).text();
-	const errPromise = new Response(child.stderr).text();
+	const outPromise = new Response(proc.stdout).text();
+	const errPromise = new Response(proc.stderr).text();
 	const exitState = await Promise.race([
-		child.exited.then(code => ({ kind: "exit" as const, code })),
+		proc.exited.then(code => ({ kind: "exit" as const, code })),
 		Bun.sleep(15_000).then(() => ({ kind: "timeout" as const })),
 	]);
 	if (exitState.kind === "timeout") {

--- a/packages/coding-agent/test/fixtures/sdk-mcp-entrypoint-e2e-script.ts
+++ b/packages/coding-agent/test/fixtures/sdk-mcp-entrypoint-e2e-script.ts
@@ -1,74 +1,143 @@
-// Entrypoint-level proof: gjc mcp-serve sdk speaks JSON-RPC over stdio and its
+// Entrypoint-level proof: `gjc mcp-serve sdk` speaks JSON-RPC over stdio and its
 // session control reaches a recorded SDK WebSocket (no coordinator paths).
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+// fixtures/ -> test/ -> package root (packages/coding-agent)
+const packageRoot = path.resolve(import.meta.dir, "..", "..");
+const cliEntry = path.join(packageRoot, "src", "cli.ts");
+
 const repo = await mkdtemp(path.join(tmpdir(), "mcp-sdk-e2e-"));
 const received: string[] = [];
-const server = Bun.serve<{ t: string }>({
-	port: 0,
-	fetch(req, srv) {
-		if (srv.upgrade(req, { data: { t: "x" } })) return undefined;
-		return new Response("nf", { status: 404 });
-	},
-	websocket: {
-		open(ws) {
-			ws.send(JSON.stringify({ type: "server_hello", protocolVersion: 3, connectionId: "e2e" }));
+let server: ReturnType<typeof Bun.serve> | undefined;
+let child: ReturnType<typeof Bun.spawn> | undefined;
+
+const cleanup = async () => {
+	if (child) {
+		try {
+			child.kill();
+		} catch {
+			// already exited
+		}
+		try {
+			await Promise.race([child.exited, Bun.sleep(2_000)]);
+		} catch {
+			// ignore
+		}
+		child = undefined;
+	}
+	if (server) {
+		try {
+			server.stop(true);
+		} catch {
+			// ignore
+		}
+		server = undefined;
+	}
+	await rm(repo, { recursive: true, force: true });
+};
+
+try {
+	server = Bun.serve<{ t: string }>({
+		port: 0,
+		fetch(req, srv) {
+			if (srv.upgrade(req, { data: { t: "x" } })) return undefined;
+			return new Response("nf", { status: 404 });
 		},
-		message(ws, raw) {
-			const frame = JSON.parse(String(raw)) as Record<string, unknown>;
-			received.push(String(frame.type));
-			if (frame.type === "query_request")
-				ws.send(
-					JSON.stringify({
-						type: "query_response",
-						id: frame.id,
-						ok: true,
-						page: { items: [{ sessionId: "s1" }], complete: true, revision: "1" },
-					}),
-				);
+		websocket: {
+			open(ws) {
+				ws.send(JSON.stringify({ type: "server_hello", protocolVersion: 3, connectionId: "e2e" }));
+			},
+			message(ws, raw) {
+				const frame = JSON.parse(String(raw)) as Record<string, unknown>;
+				received.push(String(frame.type));
+				if (frame.type === "query_request")
+					ws.send(
+						JSON.stringify({
+							type: "query_response",
+							id: frame.id,
+							ok: true,
+							page: { items: [{ sessionId: "s1" }], complete: true, revision: "1" },
+						}),
+					);
+			},
 		},
-	},
-});
-await mkdir(path.join(repo, ".gjc", "state", "sdk"), { recursive: true });
-await writeFile(
-	path.join(repo, ".gjc", "state", "sdk", "s1.json"),
-	JSON.stringify({ url: `ws://127.0.0.1:${server.port}`, token: "tok" }),
-);
-const child = Bun.spawn(["bun", "run", path.resolve("src/cli.ts"), "mcp-serve", "sdk"], {
-	cwd: repo,
-	stdin: "pipe",
-	stdout: "pipe",
-	stderr: "pipe",
-});
-const writer = child.stdin;
-writer.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" })}\n`);
-writer.write(`${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" })}\n`);
-writer.write(
-	`${JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "gjc_session_query", arguments: { sessionId: "s1", query: "session.metadata" } } })}\n`,
-);
-writer.write(
-	`${JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "gjc_session_global", arguments: { operation: "session.get_endpoint" } } })}\n`,
-);
-await writer.end();
-const out = await new Response(child.stdout).text();
-await child.exited;
-server.stop(true);
-await rm(repo, { recursive: true, force: true });
-const lines = out
-	.trim()
-	.split("\n")
-	.map(l => JSON.parse(l));
-const byId = Object.fromEntries(lines.map(l => [l.id, l]));
-if (byId[1]?.result?.serverInfo?.name !== "gjc-sdk-mcp") throw new Error(`initialize failed: ${out}`);
-if (!byId[2]?.result?.tools?.some((t: { name: string }) => t.name === "gjc_session_query"))
-	throw new Error("tools/list failed");
-const queryText = JSON.parse(byId[3].result.content[0].text);
-if (queryText.page?.items?.[0]?.sessionId !== "s1")
-	throw new Error(`query did not reach the SDK socket: ${JSON.stringify(queryText)}`);
-if (!received.includes("query_request")) throw new Error("no frame reached the recorded WS");
-const g02 = JSON.parse(byId[4].result.content[0].text);
-if (g02.ok !== false || !String(g02.error?.code ?? "").includes("endpoint_credential"))
-	throw new Error(`G02 not rejected: ${JSON.stringify(g02)}`);
-console.log("MCP-SDK-E2E-OK frames:", received.join(","));
+	});
+	await mkdir(path.join(repo, ".gjc", "state", "sdk"), { recursive: true });
+	await writeFile(
+		path.join(repo, ".gjc", "state", "sdk", "s1.json"),
+		JSON.stringify({ url: `ws://127.0.0.1:${server.port}`, token: "tok" }),
+	);
+
+	// Default: package source under test (CI monorepo with natives).
+	// Override with GJC_MCP_E2E_BIN for local machines lacking matching natives.
+	const explicitBin = process.env.GJC_MCP_E2E_BIN?.trim();
+	const spawnCmd =
+		explicitBin && explicitBin.length > 0
+			? [explicitBin, "mcp-serve", "sdk"]
+			: ["bun", "run", cliEntry, "mcp-serve", "sdk"];
+	child = Bun.spawn(spawnCmd, {
+		cwd: repo,
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+		env: process.env,
+	});
+	const writer = child.stdin;
+	writer.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" })}\n`);
+	writer.write(`${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" })}\n`);
+	writer.write(
+		`${JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "gjc_session_query", arguments: { sessionId: "s1", query: "session.metadata" } } })}\n`,
+	);
+	writer.write(
+		`${JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "gjc_session_global", arguments: { operation: "session.get_endpoint" } } })}\n`,
+	);
+	await writer.end();
+
+	// Bound wait: kill the child if it does not exit after stdin EOF so the outer
+	// suite never sits on an open stdout pipe for the full 60s.
+	const outPromise = new Response(child.stdout).text();
+	const errPromise = new Response(child.stderr).text();
+	const exitState = await Promise.race([
+		child.exited.then(code => ({ kind: "exit" as const, code })),
+		Bun.sleep(15_000).then(() => ({ kind: "timeout" as const })),
+	]);
+	if (exitState.kind === "timeout") {
+		try {
+			child.kill();
+		} catch {
+			// ignore
+		}
+	}
+	const [out, err] = await Promise.all([outPromise, errPromise]);
+	const exitCode = exitState.kind === "exit" ? exitState.code : await child.exited;
+	if (exitState.kind === "timeout") {
+		throw new Error(`mcp-serve sdk did not exit within 15s after stdin EOF\nstdout:\n${out}\nstderr:\n${err}`);
+	}
+	if (exitCode !== 0) {
+		throw new Error(`mcp-serve sdk exited ${exitCode}\nstdout:\n${out}\nstderr:\n${err}`);
+	}
+
+	const lines = out
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map(l => JSON.parse(l));
+	const byId = Object.fromEntries(lines.map(l => [l.id, l]));
+	if (byId[1]?.result?.serverInfo?.name !== "gjc-sdk-mcp") throw new Error(`initialize failed: ${out}`);
+	if (!byId[2]?.result?.tools?.some((t: { name: string }) => t.name === "gjc_session_query"))
+		throw new Error("tools/list failed");
+	const queryText = JSON.parse(byId[3].result.content[0].text);
+	if (queryText.page?.items?.[0]?.sessionId !== "s1")
+		throw new Error(`query did not reach the SDK socket: ${JSON.stringify(queryText)}`);
+	if (!received.includes("query_request")) throw new Error("no frame reached the recorded WS");
+	const g02 = JSON.parse(byId[4].result.content[0].text);
+	if (g02.ok !== false || !String(g02.error?.code ?? "").includes("endpoint_credential"))
+		throw new Error(`G02 not rejected: ${JSON.stringify(g02)}`);
+	console.log("MCP-SDK-E2E-OK frames:", received.join(","));
+} catch (error) {
+	await cleanup();
+	throw error;
+}
+await cleanup();

--- a/packages/coding-agent/test/sdk-mcp-entrypoint-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-entrypoint-e2e.test.ts
@@ -10,12 +10,20 @@ const script = path.join(packageRoot, "test", "fixtures", "sdk-mcp-entrypoint-e2
 // rejected before any send. It exits nonzero with a thrown error otherwise.
 test("gjc mcp-serve sdk serves the SDK MCP adapter end-to-end", async () => {
 	const child = Bun.spawn(["bun", script], { cwd: packageRoot, stdout: "pipe", stderr: "pipe" });
-	const [exitCode, stdout, stderr] = await Promise.all([
-		child.exited,
-		new Response(child.stdout).text(),
-		new Response(child.stderr).text(),
-	]);
-	expect(exitCode, `${stdout}\n${stderr}`).toBe(0);
-	expect(stdout).toContain("MCP-SDK-E2E-OK");
-	expect(stdout).toContain("query_request");
+	try {
+		const [exitCode, stdout, stderr] = await Promise.all([
+			child.exited,
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+		]);
+		expect(exitCode, `${stdout}\n${stderr}`).toBe(0);
+		expect(stdout).toContain("MCP-SDK-E2E-OK");
+		expect(stdout).toContain("query_request");
+	} finally {
+		try {
+			child.kill();
+		} catch {
+			// already exited
+		}
+	}
 }, 60000);


### PR DESCRIPTION
## Summary
- `runSdkMcpStdio` no longer fire-and-forgets JSON-RPC handlers: after stdin EOF it awaits all in-flight `tools/call` work so responses flush and WebSocket clients close before process exit.
- Entrypoint e2e fixture uses absolute package CLI path, bounds child exit (15s) with kill-before-drain, and always cleans server/tempdir on success and failure so the suite cannot sit on the outer 60s timeout.

## Context
Current `dev` CI red (run 30208649718): `gjc mcp-serve sdk serves the SDK MCP adapter end-to-end` at exact 60s in `packages/coding-agent/test/sdk-mcp-entrypoint-e2e.test.ts`. Same flake pattern on prior run 30207861668.

## Test plan
- [x] Repeated `GJC_MCP_E2E_BIN=gjc bun test packages/coding-agent/test/sdk-mcp-entrypoint-e2e.test.ts` (local; source needs matching natives)
- [ ] CI exact-head green for this PR
- [ ] Post-merge `dev` green

## Non-goals
- Timeout raise only
- Unrelated SDK reconciliation (#3031/#3032/#3035) — suspended, plans preserved under session ralplan artifacts