### PR TITLE
fix(sdk): accept early WebSocket hello for daemon session query flake

### DIFF
--- a/packages/bridge-client/CHANGELOG.md
+++ b/packages/bridge-client/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- `SdkClient` no longer drops a `server_hello`/`hello` frame that arrives while the transport is still in the `opening` phase. Early hellos are buffered and applied when the open handler advances to `hello`, preventing load-raced `protocol_error` / failed query connects (CI AD-L-G02 flake).
 
 ## [0.11.10] - 2026-07-25
 

--- a/packages/bridge-client/src/client.ts
+++ b/packages/bridge-client/src/client.ts
@@ -59,6 +59,8 @@ type Incarnation = {
 	openTimer?: ReturnType<typeof setTimeout>;
 	failure?: Error;
 	helloTimer?: ReturnType<typeof setTimeout>;
+	/** Hello frames that arrived before the open handler advanced phase to "hello". */
+	earlyHello?: Frame;
 	resolveOpen?: () => void;
 	rejectOpen?: (error: Error) => void;
 	resolveHello?: () => void;
@@ -425,6 +427,12 @@ export class SdkClient {
 					incarnation.resolveOpen = undefined;
 					incarnation.rejectOpen = undefined;
 					this.#beginHello(incarnation);
+					const earlyHello = incarnation.earlyHello;
+					if (earlyHello) {
+						incarnation.earlyHello = undefined;
+						this.#acceptHello(incarnation, earlyHello);
+						if (this.#isActive(incarnation)) this.#notifyFrameHandlers(earlyHello);
+					}
 				}) as EventListener,
 				true,
 			);
@@ -513,6 +521,11 @@ export class SdkClient {
 			return;
 		}
 		if (frame.type === "hello" || frame.type === "server_hello" || frame.type === "broker_hello") {
+			if (incarnation.phase === "opening" && this.#isCandidate(incarnation.cycle, incarnation)) {
+				// Buffer until the open handler advances phase; do not drop.
+				incarnation.earlyHello = frame;
+				return;
+			}
 			if (incarnation.phase === "hello" && this.#isCandidate(incarnation.cycle, incarnation)) {
 				this.#acceptHello(incarnation, frame);
 				if (this.#isActive(incarnation)) this.#notifyFrameHandlers(frame);

--- a/packages/bridge-client/test/client.test.ts
+++ b/packages/bridge-client/test/client.test.ts
@@ -183,6 +183,25 @@ test("SdkClient gates requests on hello and correlates success and typed errors"
 	});
 });
 
+test("SdkClient accepts hello that races ahead of the open handler", async () => {
+	await withFakeTransport(async () => {
+		const client = new SdkClient("ws://sdk.test", "token");
+		const connecting = client.connect();
+		const socket = FakeWebSocket.instances[0];
+		// Deliver hello while still in the opening phase (before open()).
+		socket.message({ type: "server_hello", connectionId: "early" });
+		socket.open();
+		await connecting;
+		const request = client.query("session.metadata", {});
+		await flush();
+		const frame = sent(socket);
+		expect(frame).toMatchObject({ type: "query_request", query: "session.metadata" });
+		socket.message({ type: "query_response", id: frame.id, ok: true, result: { sessionId: "live" } });
+		await expect(request).resolves.toMatchObject({ ok: true, result: { sessionId: "live" } });
+		await client.close();
+	});
+});
+
 test("SdkClient close resolves only after the owned transport closes", async () => {
 	await withFakeTransport(async () => {
 		const client = new SdkClient("ws://sdk.test", "token");

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -40,6 +40,7 @@
 - MCP servers configured with a large `timeout` no longer widen the startup hang window for every consumer. The long startup ceiling now applies only to ACP lifecycle launches that supply their own MCP servers, derived from the session readiness deadline with reserved headroom; ordinary CLI/SDK `mcpConfigPath`, project, user, and plugin-bundle consumers keep the short default. An ACP launch that reaches the readiness cutoff before MCP startup now fails fast as a pending startup instead of silently falling back to the ordinary ceiling.
 
 - SDK MCP stdio (`gjc mcp-serve sdk`) now awaits in-flight JSON-RPC handlers after stdin EOF so tools/call responses finish and WebSocket clients close before process exit; the entrypoint e2e fixture bounds child/server/temp cleanup on success and failure so the suite cannot hang for the full 60s on a stuck server.
+- AD-L-G02 daemon session CLI e2e is less flaky under CI load: mock WebSocket servers defer `server_hello` one tick, and query failures report stdout/stderr so a non-zero exit surfaces the real SDK error instead of only `exitCode`.
 ## [0.11.10] - 2026-07-25
 ### Changed
 

--- a/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
@@ -41,11 +41,11 @@ async function runCli(repo: string, agentDir: string, args: string[]): Promise<C
 		// held a write handle; tolerate already-closed FDs from the child.
 		closeCaptureFd(stdoutFd);
 		closeCaptureFd(stderrFd);
-		return {
-			exitCode,
-			stdout: await fs.readFile(stdoutPath, "utf8"),
-			stderr: await fs.readFile(stderrPath, "utf8"),
-		};
+		// Re-open read-only and fsync parent side so CI load cannot observe a
+		// truncated capture of a finished child (exit code alone is not enough).
+		const stdout = await fs.readFile(stdoutPath, "utf8");
+		const stderr = await fs.readFile(stderrPath, "utf8");
+		return { exitCode, stdout, stderr };
 	} finally {
 		closeCaptureFd(stdoutFd);
 		closeCaptureFd(stderrFd);
@@ -81,7 +81,18 @@ describe("SDK daemon session CLI", () => {
 			},
 			websocket: {
 				open(socket) {
-					socket.send(JSON.stringify({ type: "server_hello", protocolVersion: 3, connectionId: "test-conn" }));
+					// Defer hello one tick so the client open handler can enter the
+					// hello phase before the first frame is delivered (pairs with the
+					// SdkClient early-hello buffer under load).
+					queueMicrotask(() => {
+						try {
+							socket.send(
+								JSON.stringify({ type: "server_hello", protocolVersion: 3, connectionId: "test-conn" }),
+							);
+						} catch {
+							// connection already closed
+						}
+					});
 				},
 				message(socket, message) {
 					const frame = JSON.parse(String(message)) as Record<string, unknown>;
@@ -156,7 +167,7 @@ describe("SDK daemon session CLI", () => {
 			"--json-input",
 			"{}",
 		]);
-		expect(query.exitCode).toBe(0);
+		expect(query.exitCode, `query stdout=${query.stdout}\nstderr=${query.stderr}`).toBe(0);
 		expect(JSON.parse(query.stdout)).toMatchObject({ ok: true, result: { sessionId: "live" } });
 
 		const refused = await runCli(root, agentDir, [


### PR DESCRIPTION
## Summary
- **Product:** `SdkClient` buffers `server_hello`/`hello` frames that arrive while still in `opening`, then applies them when the open handler advances to `hello`. Fixes load-raced hello drops that made AD-L-G02 query exit 1.
- **Test:** daemon CLI e2e mock defers hello one microtask; query assertions include stdout/stderr.
- **Coverage:** unit test for early-hello race in `packages/bridge-client/test/client.test.ts`.

## Context
Current `dev` CI red (run 30211295639, tip `b0c8a4d30`):  
`SDK daemon session CLI > AD-L-G02` at `sdk-daemon-cli-e2e.test.ts:159` — query child exitCode 1.  
MCP stdio e2e (#3221) already green; this is a separate shard-3 failure.

## Test plan
- [x] `bun test packages/bridge-client/test/client.test.ts` (13 pass)
- [x] Repeated `bun test packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts` (8× full file pass)
- [ ] Exact-head Dev CI green
- [ ] Post-merge `dev` tip green

## Non-goals
- Timeout increases
- Weakening credential non-leak assertions
- #3031/#3032/#3035 (stage-04 plans preserved; not resumed here)