### PR TITLE
fix(ask): ignore aborted remote answer failures

### DIFF
--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -1252,6 +1252,14 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 			receipt: AskRemoteReceipt;
 			settlement?: AskSettlement;
 		};
+		const ignoreRemoteAnswerFailure = (error: unknown): Promise<never> => {
+			if (!(error instanceof Error && error.name === "AbortError")) {
+				logger.warn("Ask remote answer source failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+			return new Promise<never>(() => {});
+		};
 		const settleActiveRemote = async (settlement: AskSettlement): Promise<void> => {
 			const receipt = activeRemoteReceipt;
 			activeRemoteReceipt = undefined;
@@ -1304,60 +1312,62 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 								remoteController.signal,
 							)
 						: source.awaitAnswer(prompt, options, remoteController.signal)
-				).then((answer): RemoteRaceResult | Promise<RemoteRaceResult> => {
-					if (answer === undefined) return new Promise<never>(() => {});
-					const receipt = typeof answer === "string" ? legacyAskReceipt(answer) : answer;
-					if (generation !== remoteGeneration) {
-						return receipt
-							.settle({ kind: "resolve_without_commit", reason: "aborted" })
-							.then(() => new Promise<never>(() => {}));
-					}
-					const remoteValue = receipt.interaction.kind === "value" ? receipt.interaction.value : undefined;
-					const value = remoteValue ?? REMOTE_NAVIGATION_FORWARD;
-					const selectedValue =
-						remoteValue === undefined
-							? value
-							: (options.find(
-									option =>
-										option === remoteValue ||
-										option === `${theme.checkbox.checked} ${remoteValue}` ||
-										option === `${theme.checkbox.unchecked} ${remoteValue}`,
-								) ?? value);
-					const normalizedRemoteValue = remoteValue?.startsWith(`${theme.checkbox.checked} `)
-						? remoteValue.slice(`${theme.checkbox.checked} `.length)
-						: remoteValue?.startsWith(`${theme.checkbox.unchecked} `)
-							? remoteValue.slice(`${theme.checkbox.unchecked} `.length)
-							: remoteValue;
-					const semanticRemoteValue = normalizedRemoteValue?.replace(/^\s*\d+[.)]\s+/, "");
-					const transitionReason =
-						semanticRemoteValue === OTHER_OPTION
-							? "other_transition"
-							: semanticRemoteValue === ASK_CLARIFICATION_OPTION
-								? "clarification_transition"
-								: undefined;
-					if (transitionReason) {
-						return {
-							winner: "remote" as const,
-							value: selectedValue,
-							receipt,
-							settlement: { kind: "resolve_without_commit", reason: transitionReason },
-						};
-					}
-					if (
-						remoteValue !== undefined &&
-						activeRemoteRequest?.interaction === "selector" &&
-						activeRemoteRequest.controls.length > 0 &&
-						activeRemoteRequest.options.includes(remoteValue)
-					) {
-						return {
-							winner: "remote" as const,
-							value: selectedValue,
-							receipt,
-							settlement: { kind: "resolve_without_commit", reason: "toggle" },
-						};
-					}
-					return { winner: "remote" as const, value: selectedValue, receipt };
-				});
+				)
+					.then((answer): RemoteRaceResult | Promise<RemoteRaceResult> => {
+						if (answer === undefined) return new Promise<never>(() => {});
+						const receipt = typeof answer === "string" ? legacyAskReceipt(answer) : answer;
+						if (generation !== remoteGeneration) {
+							return receipt
+								.settle({ kind: "resolve_without_commit", reason: "aborted" })
+								.then(() => new Promise<never>(() => {}));
+						}
+						const remoteValue = receipt.interaction.kind === "value" ? receipt.interaction.value : undefined;
+						const value = remoteValue ?? REMOTE_NAVIGATION_FORWARD;
+						const selectedValue =
+							remoteValue === undefined
+								? value
+								: (options.find(
+										option =>
+											option === remoteValue ||
+											option === `${theme.checkbox.checked} ${remoteValue}` ||
+											option === `${theme.checkbox.unchecked} ${remoteValue}`,
+									) ?? value);
+						const normalizedRemoteValue = remoteValue?.startsWith(`${theme.checkbox.checked} `)
+							? remoteValue.slice(`${theme.checkbox.checked} `.length)
+							: remoteValue?.startsWith(`${theme.checkbox.unchecked} `)
+								? remoteValue.slice(`${theme.checkbox.unchecked} `.length)
+								: remoteValue;
+						const semanticRemoteValue = normalizedRemoteValue?.replace(/^\s*\d+[.)]\s+/, "");
+						const transitionReason =
+							semanticRemoteValue === OTHER_OPTION
+								? "other_transition"
+								: semanticRemoteValue === ASK_CLARIFICATION_OPTION
+									? "clarification_transition"
+									: undefined;
+						if (transitionReason) {
+							return {
+								winner: "remote" as const,
+								value: selectedValue,
+								receipt,
+								settlement: { kind: "resolve_without_commit", reason: transitionReason },
+							};
+						}
+						if (
+							remoteValue !== undefined &&
+							activeRemoteRequest?.interaction === "selector" &&
+							activeRemoteRequest.controls.length > 0 &&
+							activeRemoteRequest.options.includes(remoteValue)
+						) {
+							return {
+								winner: "remote" as const,
+								value: selectedValue,
+								receipt,
+								settlement: { kind: "resolve_without_commit", reason: "toggle" },
+							};
+						}
+						return { winner: "remote" as const, value: selectedValue, receipt };
+					})
+					.catch(ignoreRemoteAnswerFailure);
 
 				const local = extensionUi
 					.select(prompt, options, { ...dialogOptions, signal: localController.signal })
@@ -1419,18 +1429,20 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 								remoteController.signal,
 							)
 						: source.awaitAnswer(title, [], remoteController.signal)
-				).then((answer): RemoteRaceResult | Promise<RemoteRaceResult> => {
-					if (answer === undefined) return new Promise<never>(() => {});
-					const receipt = typeof answer === "string" ? legacyAskReceipt(answer) : answer;
-					if (generation !== remoteGeneration) {
-						return receipt
-							.settle({ kind: "resolve_without_commit", reason: "aborted" })
-							.then(() => new Promise<never>(() => {}));
-					}
-					const value =
-						receipt.interaction.kind === "control" ? REMOTE_NAVIGATION_FORWARD : receipt.interaction.value;
-					return { winner: "remote" as const, value, receipt };
-				});
+				)
+					.then((answer): RemoteRaceResult | Promise<RemoteRaceResult> => {
+						if (answer === undefined) return new Promise<never>(() => {});
+						const receipt = typeof answer === "string" ? legacyAskReceipt(answer) : answer;
+						if (generation !== remoteGeneration) {
+							return receipt
+								.settle({ kind: "resolve_without_commit", reason: "aborted" })
+								.then(() => new Promise<never>(() => {}));
+						}
+						const value =
+							receipt.interaction.kind === "control" ? REMOTE_NAVIGATION_FORWARD : receipt.interaction.value;
+						return { winner: "remote" as const, value, receipt };
+					})
+					.catch(ignoreRemoteAnswerFailure);
 				const local = extensionUi
 					.editor(title, prefill, { ...(dialogOptions ?? {}), signal: localController.signal }, editorOptions)
 					.then(answer => {

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -795,6 +795,34 @@ describe("AskTool remote semantic settlements", () => {
 		expect(result.details?.selectedOptions).toEqual(["remote"]);
 		expect(settlements).toEqual([{ kind: "commit" }]);
 	});
+	it("does not leak an aborted remote selector rejection into the next ask", async () => {
+		let remoteCalls = 0;
+		const source: AskAnswerSource = {
+			awaitAnswer: async () => undefined,
+			awaitAnswerRequest: (_request, signal) => {
+				remoteCalls++;
+				return new Promise<AskRemoteReceipt | undefined>((_resolve, reject) => {
+					signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
+						once: true,
+					});
+				});
+			},
+		};
+		const tool = new AskTool(createSession({ getAskAnswerSource: () => source }));
+
+		for (const id of ["first", "second"]) {
+			const result = await tool.execute(
+				`local-wins-${id}`,
+				{ questions: [{ id, question: `Choose ${id}`, options: [{ label: "local" }, { label: "remote" }] }] },
+				undefined,
+				undefined,
+				createContext({ select: () => Promise.resolve("local") }),
+			);
+			expect(result.details?.selectedOptions).toEqual(["local"]);
+		}
+		await Promise.resolve();
+		expect(remoteCalls).toBe(2);
+	});
 
 	it("atomically selects a same-microtask remote editor receipt over local text", async () => {
 		const settlements: unknown[] = [];


### PR DESCRIPTION
## Summary

- isolate remote ask answer-source rejections from the local UI race
- ignore abort rejections from the remote leg after the local selector/editor wins
- add a regression for two local-winning asks where the aborted remote source rejects with `AbortError`

## Why PR, not issue

This was reproduced locally with a failing regression and the fix is small, targeted, and verified. Opening a PR is more useful than filing a standalone issue because the patch includes the guard and the regression test.

## Reproduction

Pre-fix, the added regression failed with:

```text
ToolAbortError: Ask input was cancelled
(fail) AskTool remote semantic settlements > does not leak an aborted remote selector rejection into the next ask
```

The failure shape is a local UI answer winning while the remote answer source rejects on abort; that remote rejection was allowed to reject the ask race.

## Verification

```text
bun test packages/coding-agent/test/tools/ask.test.ts --test-name-pattern "aborted remote selector rejection"
bun test packages/coding-agent/test/tools/ask.test.ts
bunx biome check packages/coding-agent/src/tools/ask.ts packages/coding-agent/test/tools/ask.test.ts
bun run check:types  # from packages/coding-agent
```
