### PR TITLE
fix(coding-agent): repair #3225 continue breadcrumb and SDK inventory

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -119,6 +119,8 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"agent_session:continuePersistedHistory": "internal startup lifecycle plumbing, not a user-facing control seam",
 	"agent_session:promoteRecoveryHydrationAfterOwnershipReadyFence":
 		"internal owner-recovery authority transition after a durable writer fence, never a user-facing SDK operation",
+	"agent_session:restoreFromMemoryGuardCheckpoint":
+		"internal owner-recovery staged restore builder after durable claims/fencing, never a user-facing SDK operation",
 	"agent_session:setActiveModelProfile": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:getActiveModelProfile": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:getSessionDefaultModelSelector": "internal accessor/plumbing, not a user-facing control seam",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2904,6 +2904,17 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:restoreFromMemoryGuardCheckpoint",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal owner-recovery staged restore builder after durable claims/fencing, never a user-facing SDK operation",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:promoteRecoveryHydrationAfterOwnershipReadyFence",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -8395,20 +8395,7 @@ export class SessionManager {
 			relativeToManagedRoot === "" ||
 			(!relativeToManagedRoot.startsWith("..") && !path.isAbsolute(relativeToManagedRoot));
 
-		if (!isManagedPath) {
-			assertManagedDestinationBound();
-			const adoptedName = `${header.id}-${inspected.identity.sha256.slice(0, 12)}.jsonl`;
-			try {
-				await managedDestinationStore.publishNoReplace(adoptedName, inspected.content);
-			} catch (error) {
-				if (!(error instanceof Error && error.message.includes("destination_conflict"))) throw error;
-			}
-			const adoptedPath = path.join(destination.directory, adoptedName);
-			const adopted = inspectResumeSessionFile(adoptedPath, storage);
-			if ("kind" in adopted || adopted.identity.sha256 !== inspected.identity.sha256)
-				throw new Error("Managed adoption did not preserve the selected session.");
-			return adoptedPath;
-		}
+		if (!isManagedPath) return filePath;
 		assertManagedDestinationBound();
 		const resolved = resolveManagedScope({
 			cwd: header.cwd,

--- a/packages/coding-agent/test/session-manager/worktree-continue.test.ts
+++ b/packages/coding-agent/test/session-manager/worktree-continue.test.ts
@@ -110,11 +110,16 @@ describe("continueRecent with --worktree sessions", () => {
 			`${JSON.stringify({ type: "session", id: "unmanaged", timestamp: "2025-01-01T00:00:00Z", cwd: worktree, version: 3 })}\n${JSON.stringify({ type: "message", id: "1", parentId: null, timestamp: "2025-01-01T00:00:01Z", message: { role: "user", content: "unmanaged", timestamp: 1 } })}\n`,
 		);
 		writeBreadcrumb(worktree, unmanagedFile);
+		const before = fs.readFileSync(unmanagedFile, "utf8");
 
 		writeSession(worktree, "managed-worktree-session");
 		const resumed = await SessionManager.continueRecent(repo);
 		try {
+			// Terminal-specific explicit breadcrumb paths must stay at the verified path.
+			// Managed resume must not adopt/copy them into agent/sessions/v2-* storage.
 			expect(resumed.getSessionFile()).toBe(unmanagedFile);
+			expect(fs.readFileSync(unmanagedFile, "utf8")).toBe(before);
+			expect(resumed.getSessionFile()?.includes(`${path.sep}agent${path.sep}sessions${path.sep}`)).toBe(false);
 		} finally {
 			await resumed.close();
 		}


### PR DESCRIPTION
## Summary
Post-#3225 dev CI shard 2 failed two primary checks. This PR repairs them without reopening the recovery ownership feature surface.

1. **SDK operation inventory** — `AgentSession.restoreFromMemoryGuardCheckpoint` was an unclassified scanned seam. Reviewed as internal owner-recovery staged restore (parallel to `promoteRecoveryHydrationAfterOwnershipReadyFence`) and added to `LOCKED_EXCLUSIONS`; regenerated inventory (pending=0).
2. **Terminal-specific explicit breadcrumb** — `prepareManagedCandidateForWrite` began adopting non-managed paths into managed v2 storage, rewriting verified explicit breadcrumb paths under `agent/sessions/v2-*`. Restored pre-#3225 behavior: non-managed paths return `filePath` in place. Strengthened the worktree continue regression.

## Verification
- `bun test packages/coding-agent/test/session-manager/worktree-continue.test.ts` (4 pass)
- `bun test packages/coding-agent/test/sdk-operation-inventory.test.ts` (17 pass)
- `bun test` memory-guard-checkpoint + owner-claims + revisions (10 pass)
- `bun --cwd=packages/coding-agent run check` (biome + types)
- `bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts` (pending=0)

## Notes
- Does not hide a public SDK surface: restore is staged recovery only, not user-facing SDK control.
- Preserves explicit-directory terminal specificity per product contract.