### PR TITLE
fix(sdk): unbreak post-#3227 host preflight + operation matrix

### DIFF
--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -2122,11 +2122,16 @@ function sdkControlSurface(
 				error: Object.assign(new Error("Prompt preflight was cancelled before execution."), { code: "busy" }),
 			});
 		pendingPreflightCancellations.add(cancelPreflight);
-		const onPreflightAcceptCommit = async () => {
+		const settleAccepted = async () => {
 			if (preflightSettled) return;
 			accepted = true;
 			await onPromptAccepted(correlation, requesterConnectionId, trimmedClientRef, trackReconciliation);
 			settlePreflight({ status: "accepted" });
+		};
+		// Durable fence preferred; keep legacy onPreflightAccepted for hosts/tests that only fire the sync hook.
+		const onPreflightAcceptCommit = settleAccepted;
+		const onPreflightAccepted = () => {
+			void settleAccepted();
 		};
 		// Do not acknowledge the prompt until AgentSession's async preflight
 		// succeeds. The terminal result records correlation before agent_start can fire.
@@ -2136,6 +2141,7 @@ function sdkControlSurface(
 				api.sendUserMessage(content, {
 					...(deliverAs ? { deliverAs } : !forceFresh && isBusy() ? { deliverAs: "steer" as const } : {}),
 					onPreflightAcceptCommit,
+					onPreflightAccepted,
 				}),
 			);
 		} catch (error) {

--- a/packages/coding-agent/test/helpers/sdk-production-host.ts
+++ b/packages/coding-agent/test/helpers/sdk-production-host.ts
@@ -91,7 +91,8 @@ export async function startProductionSdkHost(
 			});
 			if (options.acceptPromptPreflightWithoutExecution) {
 				session.sendUserMessage = async (_content, promptOptions) => {
-					promptOptions?.onPreflightAccepted?.();
+					if (promptOptions?.onPreflightAcceptCommit) await promptOptions.onPreflightAcceptCommit();
+					else promptOptions?.onPreflightAccepted?.();
 				};
 			}
 			const priorNotifications = process.env.GJC_NOTIFICATIONS;

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -15,6 +15,15 @@ import type {
 	ExtensionContextActions,
 	ExtensionUIContext,
 } from "../src/extensibility/extensions/types";
+
+async function firePreflightAccept(options?: {
+	onPreflightAccepted?: () => void;
+	onPreflightAcceptCommit?: () => void | Promise<void>;
+}): Promise<void> {
+	if (options?.onPreflightAcceptCommit) await options.onPreflightAcceptCommit();
+	else options?.onPreflightAccepted?.();
+}
+
 import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
 import { buildAskGateAnswerSchema as buildDeepInterviewAskGateAnswerSchema } from "../src/modes/shared/agent-wire/deep-interview-gate";
 import {
@@ -134,8 +143,15 @@ function start(
 			options?: Parameters<ExtensionActions["sendUserMessage"]>[1],
 		) => {
 			if (forwardPreflightCallbacks) return Promise.resolve(sendUserMessage(content, options));
-			const { onPreflightAccepted, ...delivery } = options ?? {};
+			const { onPreflightAccepted, onPreflightAcceptCommit, ...delivery } = options ?? {};
 			const submission = sendUserMessage(content, Object.keys(delivery).length > 0 ? delivery : undefined);
+			// Prefer awaitable durable fence; fall back to legacy sync accept for older mocks.
+			if (onPreflightAcceptCommit) {
+				return Promise.resolve(onPreflightAcceptCommit()).then(() => {
+					onPreflightAccepted?.();
+					return submission;
+				});
+			}
 			onPreflightAccepted?.();
 			return Promise.resolve(submission);
 		},
@@ -1662,8 +1678,8 @@ test("SDK host buffers synchronous pre-ack start and end until after acknowledge
 	handlers = start(
 		sessionContext,
 		undefined,
-		(_content, options) => {
-			options?.onPreflightAccepted?.();
+		async (_content, options) => {
+			await firePreflightAccept(options);
 			void handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
 			void handlers.get("agent_end")?.({ type: "agent_end" }, sessionContext);
 		},
@@ -1720,8 +1736,8 @@ test("SDK host buffers synchronous pre-ack accepted failure until after acknowle
 	handlers = start(
 		sessionContext,
 		undefined,
-		(_content, options) => {
-			options?.onPreflightAccepted?.();
+		async (_content, options) => {
+			await firePreflightAccept(options);
 			void handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
 			throw Object.assign(new Error("synchronous accepted failure"), { code: "unavailable" });
 		},
@@ -1867,7 +1883,7 @@ test("SDK host serializes concurrent prompt admission and replays correlated lif
 			submissions.push(String(content));
 			preflightStarted.resolve();
 			await releasePreflight.promise;
-			options?.onPreflightAccepted?.();
+			await firePreflightAccept(options);
 		},
 		true,
 	);
@@ -2044,7 +2060,7 @@ test("SDK host terminalizes a cancelled preflight and releases prompt authority"
 					throw Object.assign(new Error("Prompt preflight was cancelled before execution."), { code: "busy" });
 				}
 			}
-			options?.onPreflightAccepted?.();
+			await firePreflightAccept(options);
 		},
 		true,
 	);
@@ -2111,7 +2127,9 @@ test("SDK host terminalizes a never-resolving preflight on abort and fences late
 		undefined,
 		async (content, options) => {
 			if (content !== "never resolve") return;
-			latePreflightAccepted = options?.onPreflightAccepted;
+			latePreflightAccepted = options?.onPreflightAcceptCommit
+				? () => void options.onPreflightAcceptCommit?.()
+				: options?.onPreflightAccepted;
 			preflightStarted.resolve();
 			await neverPreflight.promise;
 		},
@@ -2191,7 +2209,7 @@ test("SDK host abort-and-prompt cancels a never-resolving preflight before repla
 				preflightStarted.resolve();
 				await neverPreflight.promise;
 			}
-			options?.onPreflightAccepted?.();
+			await firePreflightAccept(options);
 		},
 		true,
 	);
@@ -2270,9 +2288,9 @@ test("SDK host waits for asynchronous abort unwind before delivering an abort-an
 	const handlers = start(
 		sessionContext,
 		undefined,
-		(content, options) => {
+		async (content, options) => {
 			deliveries.push([content, options]);
-			options?.onPreflightAccepted?.();
+			await firePreflightAccept(options);
 		},
 		true,
 	);
@@ -4604,12 +4622,17 @@ test("clientRef admission reservation is released when a submission is rejected 
 	const handlers = start(
 		sessionContext,
 		undefined,
-		(content: unknown, options: { onPreflightAccepted?: () => void } | undefined) => {
+		async (
+			content: unknown,
+			options:
+				| { onPreflightAccepted?: () => void; onPreflightAcceptCommit?: () => void | Promise<void> }
+				| undefined,
+		) => {
 			const text = String(content);
 			deliveries.push(text);
 			if (text === "doomed preflight")
 				return Promise.reject(Object.assign(new Error("submission lost"), { code: "unavailable" }));
-			options?.onPreflightAccepted?.();
+			await firePreflightAccept(options);
 			return Promise.resolve();
 		},
 		true,
@@ -4709,8 +4732,13 @@ test("accepted-then-failed submission retains its reconciliation record and bloc
 	const handlers = start(
 		sessionContext,
 		undefined,
-		(_content: unknown, options: { onPreflightAccepted?: () => void } | undefined) => {
-			options?.onPreflightAccepted?.();
+		async (
+			_content: unknown,
+			options:
+				| { onPreflightAccepted?: () => void; onPreflightAcceptCommit?: () => void | Promise<void> }
+				| undefined,
+		) => {
+			await firePreflightAccept(options);
 			throw Object.assign(new Error("synchronous accepted failure"), { code: "unavailable" });
 		},
 		true,

--- a/packages/coding-agent/test/sdk-operation-matrix.test.ts
+++ b/packages/coding-agent/test/sdk-operation-matrix.test.ts
@@ -83,7 +83,7 @@ describe("SDK operation matrix", () => {
 		const registryById = new Map(OPERATIONS.map(operation => [operation.id, operation]));
 		const inventoryIds = registryInventory.map(row => row.sourceId.replace("registry:", ""));
 		expect(new Set(inventoryIds)).toEqual(new Set(registryById.keys()));
-		expect(registryInventory).toHaveLength(93);
+		expect(registryInventory).toHaveLength(94);
 
 		for (const row of registryInventory) {
 			const id = row.sourceId.startsWith("registry:") ? row.sourceId.slice("registry:".length) : row.sourceId;
@@ -102,7 +102,7 @@ describe("SDK operation matrix", () => {
 	it("keeps control errors, query continuity, counts, and the stage-05 adapter partition explicit", () => {
 		expect(OPERATIONS.filter(operation => operation.kind === "control")).toHaveLength(53);
 		expect(OPERATIONS.filter(operation => operation.kind === "global")).toHaveLength(7);
-		expect(OPERATIONS.filter(operation => operation.kind === "query")).toHaveLength(27);
+		expect(OPERATIONS.filter(operation => operation.kind === "query")).toHaveLength(28);
 		expect(OPERATIONS.filter(operation => operation.kind === "reverse")).toHaveLength(6);
 		for (const operation of OPERATIONS.filter(operation => operation.kind === "control"))
 			expect(operation.errorCodes.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
Unblocks frozen `dev` after #3227 merge (`21c226372`).

### Root causes
1. **Matrix drift**: Q28 `skill.invoke_status` added a registry/query row; fixtures still expected 93/27.
2. **Host lifecycle red**: durable fence switched control path to `onPreflightAcceptCommit` only. Host wiring fixtures and production-host accept stubs still only fired `onPreflightAccepted`, so prompts completed without preflight acceptance (`busy`) or hung on 5s pre-ack waits.

### Fix
- Dual-wire bus `sendUserMessage` with both `onPreflightAcceptCommit` (durable) and `onPreflightAccepted` (legacy/sync).
- Fixture/helper paths fire awaitable commit when present; else legacy accept.
- Matrix counts: registry **94**, queries **28**.

### Verification (local)
- `sdk-operation-matrix` + `sdk-operation-inventory`
- Full `sdk-host-wiring` (117 suite w/ q26/recon/control)
- `packages/coding-agent` `bun run check`

Preserves #3031/#3032/#3035 durability contracts; restores pre-#3227 host wire semantics for ordinary tests.

## Test plan
- [x] Focused failing suites green locally
- [ ] Exact-head CI green
- [ ] Post-merge dev green

Does not close product issues; repair only.