### PR TITLE
fix(sdk): finish post-#3227 Q28 parity + failure correlation

### DIFF
--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -3526,7 +3526,8 @@ export function createNotificationsExtension(
 				if (trackReconciliation) releasePromptAdmission(clientRef);
 				return;
 			}
-			if (trackReconciliation) await notePromptReconciliationAccepted(correlation, clientRef);
+			// Register delivery ownership synchronously before any await so post-accept
+			// failures that race the durable write still emit correlated terminals.
 			cleanupPromptRecords();
 			while (promptSubmissions.size >= PROMPT_SUBMISSION_CAPACITY) {
 				const oldest = promptSubmissions.entries().next().value as [string, PromptSubmission] | undefined;
@@ -3545,6 +3546,7 @@ export function createNotificationsExtension(
 				createdAt: Date.now(),
 				bufferedFrames: [],
 			});
+			if (trackReconciliation) await notePromptReconciliationAccepted(correlation, clientRef);
 		};
 		const recordPromptTerminal = (correlation: { commandId: string; turnId: string } | undefined) => {
 			if (!correlation) return false;

--- a/packages/coding-agent/test/manifests/sdk-adapter-parity-v1.json
+++ b/packages/coding-agent/test/manifests/sdk-adapter-parity-v1.json
@@ -8556,6 +8556,102 @@
 			"expected": "forwarded"
 		},
 		{
+			"adapterTestId": "AD-T-Q28",
+			"sdkId": "skill.invoke_status",
+			"adapter": "telegram",
+			"disposition": "prohibited",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-T-Q28",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-T-Q28:"
+			],
+			"expected": "rejected_before_send"
+		},
+		{
+			"adapterTestId": "AD-D-Q28",
+			"sdkId": "skill.invoke_status",
+			"adapter": "discord",
+			"disposition": "prohibited",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-D-Q28",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-D-Q28:"
+			],
+			"expected": "rejected_before_send"
+		},
+		{
+			"adapterTestId": "AD-S-Q28",
+			"sdkId": "skill.invoke_status",
+			"adapter": "slack",
+			"disposition": "prohibited",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-S-Q28",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-S-Q28:"
+			],
+			"expected": "rejected_before_send"
+		},
+		{
+			"adapterTestId": "AD-M-Q28",
+			"sdkId": "skill.invoke_status",
+			"adapter": "mcp",
+			"disposition": "generic_safe",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-M-Q28",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-M-Q28:"
+			],
+			"expected": "forwarded"
+		},
+		{
+			"adapterTestId": "AD-A-Q28",
+			"sdkId": "skill.invoke_status",
+			"adapter": "acp",
+			"disposition": "generic_safe",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-A-Q28",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-A-Q28:"
+			],
+			"expected": "forwarded"
+		},
+		{
+			"adapterTestId": "AD-L-Q28",
+			"sdkId": "skill.invoke_status",
+			"adapter": "daemonCli",
+			"disposition": "generic_safe",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-L-Q28",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-L-Q28:"
+			],
+			"expected": "forwarded"
+		},
+		{
 			"adapterTestId": "AD-T-R01",
 			"sdkId": "terminal.create/output/release/wait",
 			"adapter": "telegram",

--- a/packages/coding-agent/test/notifications-session-switch.test.ts
+++ b/packages/coding-agent/test/notifications-session-switch.test.ts
@@ -305,9 +305,13 @@ test("accepted turn.prompt submission failures emit a correlated terminal event"
 	createNotificationsExtension({
 		on: (event: string, handler: Handler) => handlers.set(event, handler),
 		registerCommand: () => {},
-		sendUserMessage: (_content: unknown, options: { onPreflightAccepted?: () => void } | undefined) => {
-			options?.onPreflightAccepted?.();
-			return Promise.reject(Object.assign(new Error("submission failed after acceptance"), { code: "unavailable" }));
+		sendUserMessage: async (
+			_content: unknown,
+			options?: { onPreflightAccepted?: () => void; onPreflightAcceptCommit?: () => void | Promise<void> },
+		) => {
+			if (options?.onPreflightAcceptCommit) await options.onPreflightAcceptCommit();
+			else options?.onPreflightAccepted?.();
+			throw Object.assign(new Error("submission failed after acceptance"), { code: "unavailable" });
 		},
 	} as never);
 	const sessionId = `terminal-failure-${process.pid}-${Date.now()}`;

--- a/packages/coding-agent/test/sdk-adapter-dispositions.test.ts
+++ b/packages/coding-agent/test/sdk-adapter-dispositions.test.ts
@@ -28,7 +28,7 @@ const parityRows = (
 		rows: ParityRow[];
 	}
 ).rows;
-expect(parityRows).toHaveLength(564);
+expect(parityRows).toHaveLength(570);
 const parityPrefix: Record<Adapter, string> = {
 	telegram: "T",
 	discord: "D",
@@ -92,6 +92,7 @@ const expectedDomainErrors: Readonly<Record<string, string>> = {
 	"auth.login": "operation_not_session_owned",
 	"skill.invoke": "invalid_input",
 	"turn.prompt_status": "invalid_request",
+	"skill.invoke_status": "invalid_request",
 	"mode.plan.set": "unavailable",
 	"model.profile.set": "invalid_input",
 };

--- a/packages/coding-agent/test/telegram-baseline-manifest.test.ts
+++ b/packages/coding-agent/test/telegram-baseline-manifest.test.ts
@@ -333,7 +333,7 @@ describe("test manifest runner", () => {
 		expect(result.exitCode, output(result)).toBe(0);
 		expect(output(result)).toContain(`manifest command receipts complete: ${manifest.commands.length}`);
 		expect(output(result)).toContain(
-			"manifest row receipts complete: 564 (telegram=94, discord=94, slack=94, mcp=94, acp=94, daemonCli=94)",
+			"manifest row receipts complete: 570 (telegram=95, discord=95, slack=95, mcp=95, acp=95, daemonCli=95)",
 		);
 		const invocations = (await Bun.file(fake.log).text()).trim().split("\n");
 		expect(invocations).toHaveLength(manifest.commands.length + manifest.rows.length);


### PR DESCRIPTION
## Summary
Successor to #3229. Unblocks remaining post-#3227 `dev` red on `b469cf9`.

### Fixes
1. **Prompt failure correlation**: `recordPromptAccepted` registers delivery ownership **before** awaiting durable `noteAccepted`, so post-accept submission failures still emit correlated `agent_failed` terminals (race with async durable fence).
2. **Q28 adapter parity**: regenerate `sdk-adapter-parity-v1.json` to **570** rows (95×6); add `skill.invoke_status` expected empty-selector `invalid_request` like Q26; update telegram baseline fixture string.
3. Notification session-switch mock fires awaitable preflight fence.

### Verification (local)
- notifications-session-switch, matrix/inventory, Q28 adapter rows, host wiring subset, telegram baseline manifest runner, coding-agent `bun run check`

Preserves #3031/#3032/#3035 durability. Holds unrelated merges (e.g. #3226) until post-merge dev green.

## Test plan
- [x] Focused residual reds green locally
- [ ] Exact-head CI green
- [ ] Post-merge dev green