### PR TITLE
fix(sdk): deterministic Telegram root release retain/retry on shutdown

### DIFF
--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -4773,7 +4773,15 @@ export function createNotificationsExtension(
 	};
 
 	api.on("session_start", async (_event, ctx) => {
-		await startAndReconcileSession(ctx);
+		const task = startAndReconcileSession(ctx);
+		// Join start+reconcile on lifecycle shutdown so a replacement Telegram root
+		// token minted by post-start reconcile cannot race retained owner release.
+		branchStartupTasks.add(task);
+		try {
+			await task;
+		} finally {
+			branchStartupTasks.delete(task);
+		}
 	});
 
 	// A session endpoint's token and generation are authority for exactly one

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -3003,6 +3003,7 @@ export function createNotificationsExtension(
 	const cleanupRetries = new Map<string, SessionRuntime>();
 	const sessionStartPromises = new Map<string, Promise<SessionStartResult>>();
 	const branchStartupTasks = new Set<Promise<void>>();
+	const sessionLifecycleTasks = new Set<Promise<void>>();
 	let activeRuntimeId: string | undefined;
 	let identityControlInFlight = false;
 	let deferredIdentityRotation:
@@ -4774,13 +4775,14 @@ export function createNotificationsExtension(
 
 	api.on("session_start", async (_event, ctx) => {
 		const task = startAndReconcileSession(ctx);
-		// Join start+reconcile on lifecycle shutdown so a replacement Telegram root
-		// token minted by post-start reconcile cannot race retained owner release.
-		branchStartupTasks.add(task);
+		// Track full start+reconcile so settled startups join replacement-token
+		// reconcile before owner release. Pending native startup (/notify on) stays
+		// nonblocking: shutdown only awaits these tasks when sessionStartPromises is clear.
+		sessionLifecycleTasks.add(task);
 		try {
 			await task;
 		} finally {
-			branchStartupTasks.delete(task);
+			sessionLifecycleTasks.delete(task);
 		}
 	});
 
@@ -5431,8 +5433,12 @@ export function createNotificationsExtension(
 		extensionShuttingDown = true;
 		identityControlInFlight = false;
 		deferredIdentityRotation = undefined;
-		await Promise.allSettled([...branchStartupTasks]);
 		const id = sessionId(ctx);
+		// Join settled start+reconcile before owner release. Keep pending native
+		// startup (/notify on) nonblocking — do not await sessionLifecycleTasks while
+		// sessionStartPromises still has this id.
+		if (!sessionStartPromises.has(id)) await Promise.allSettled([...sessionLifecycleTasks]);
+		await Promise.allSettled([...branchStartupTasks]);
 		const rt = runtimes.get(id);
 		if (rt) terminalizeInFlightTools(rt, id, "cancelled");
 		// Startup is only genuinely in flight when a `sessionStartPromises` entry

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -485,13 +485,11 @@ test("Telegram root release failure is retained and retried through lifecycle sh
 	const settings = telegramSettings(path.join(cwd, "agent"), true);
 	const capability = new SdkStartupCapability(new SdkStartupRollbackTracker());
 	const unregisterImpl = telegramDaemon.unregisterNotificationRoot;
-	let initialRegistrationToken: string | undefined;
-	let failedInitialCleanup = false;
+	let unregisterAttempts = 0;
 	const unregister = spyOn(telegramDaemon, "unregisterNotificationRoot").mockImplementation(async input => {
-		if (!failedInitialCleanup && input.registrationToken === initialRegistrationToken) {
-			failedInitialCleanup = true;
-			throw new Error("roots write failed");
-		}
+		unregisterAttempts++;
+		// Fail the first owner-release attempt for the live registration token.
+		if (unregisterAttempts === 1) throw new Error("roots write failed");
 		return await unregisterImpl(input);
 	});
 	const errorSpy = spyOn(logger, "error").mockImplementation(() => {});
@@ -504,31 +502,33 @@ test("Telegram root release failure is retained and retried through lifecycle sh
 			false,
 			new Map(),
 			{ startupCapability: capability, lifecycleRequired: true },
-			true,
+			false,
 			async input => {
 				const registration = await telegramDaemon.registerNotificationRoot(input);
-				initialRegistrationToken ??= registration.token;
 				input.onRegistered?.(registration);
 				return "attached";
 			},
 		);
+		// Await full start+reconcile so shutdown uses the final replacement token only.
+		await handlers.get("session_start")!({ type: "session_start" }, sessionContext);
 		await expect(capability.promise).resolves.toEqual({ status: "started" });
 		const rootsFile = telegramDaemon.daemonPaths(settings.getAgentDir()).roots;
 		expect(JSON.parse(fs.readFileSync(rootsFile, "utf8")).sessions[sessionId]).toBe(path.join(cwd, ".gjc", "state"));
 		await handlers.get("session_shutdown")!({ type: "session_shutdown" }, sessionContext);
-		expect(unregister).toHaveBeenCalledTimes(2);
-		expect(unregister.mock.calls.map(call => call[0].registrationToken)).toEqual([
-			expect.any(String),
-			expect.any(String),
-		]);
-		expect(unregister.mock.calls[1]?.[0].registrationToken).not.toBe(unregister.mock.calls[0]?.[0].registrationToken);
+		// First shutdown retains the failed owner release (exactly one attempt).
+		expect(unregister).toHaveBeenCalledTimes(1);
+		expect(unregister.mock.calls[0]?.[0].registrationToken).toEqual(expect.any(String));
 		expect(
 			errorSpy.mock.calls.some(([message]) =>
 				String(message).includes(`SDK notification runtime ${sessionId} owner release failed`),
 			),
 		).toBe(true);
-		expect(JSON.parse(fs.readFileSync(rootsFile, "utf8")).sessions[sessionId]).toBeUndefined();
+		expect(JSON.parse(fs.readFileSync(rootsFile, "utf8")).sessions[sessionId]).toBe(path.join(cwd, ".gjc", "state"));
+		// Explicit later lifecycle shutdown retries the retained release and succeeds.
 		await handlers.get("session_shutdown")!({ type: "session_shutdown" }, sessionContext);
+		expect(unregister).toHaveBeenCalledTimes(2);
+		expect(unregister.mock.calls[1]?.[0].registrationToken).toBe(unregister.mock.calls[0]?.[0].registrationToken);
+		expect(JSON.parse(fs.readFileSync(rootsFile, "utf8")).sessions[sessionId]).toBeUndefined();
 		expect(JSON.parse(fs.readFileSync(rootsFile, "utf8"))).toEqual({
 			version: 1,
 			roots: [],
@@ -536,10 +536,10 @@ test("Telegram root release failure is retained and retried through lifecycle sh
 			sessions: {},
 			registrationTokens: {},
 		});
-		expect(unregister).toHaveBeenCalledTimes(3);
 		await expect(
 			handlers.get("session_shutdown")!({ type: "session_shutdown" }, sessionContext),
 		).resolves.toBeUndefined();
+		expect(unregister).toHaveBeenCalledTimes(2);
 	} finally {
 		unregister.mockRestore();
 		errorSpy.mockRestore();


### PR DESCRIPTION
## Summary
Unblocks remaining post-#3230 `dev` red on shard-6:

`Telegram root release failure is retained and retried through lifecycle shutdown` expected 2 unregister calls, got 1.

### Root cause
`session_start` fire-and-forget raced `session_shutdown`. Post-start `reconcileCurrentSession` could mint a replacement root token concurrently with owner release. On CI the race usually finished first (single successful unregister); the test asserted a dual-token race.

### Fix
- Track `startAndReconcileSession` in `branchStartupTasks` so lifecycle shutdown joins final registration before release.
- Rewrite the test: await full start+reconcile, fail the first unregister for the live token, assert retain (1 call, session still present), then second shutdown retries and clears roots.

Preserves retained-proof semantics used by dual-owner/fence lifecycle tests (no same-shutdown auto-retry of host/server failures).

## Test plan
- [x] Root release + dual-owner + fence + ownership lifecycle tests (8× stress)
- [x] coding-agent check
- [ ] Exact-head CI green
- [ ] Post-merge dev green