### PR TITLE
fix(resume): cut ordinary /resume readiness wait and progress lag

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Interactive `/resume` no longer awaits ordinary notification-endpoint rotation after predecessor fencing when the transition is stamped `interactive_selector_resume`; lifecycle/SDK identity-control paths still await readiness and use a fail-closed control-drain orchestration that sends terminal control outcomes only after successor readiness, while uncertain predecessor stop no longer starts the successor (#2914).
+- Interactive TUI `/resume` commits a status-container progress lease before inspect/migration/switch work and clears it on every exit path, with generation-scoped render-commit wait that fails open when the terminal is stopped or unavailable (#2914).
+
+### Added
+
+- Deterministic tests for session_switch await policy (selector defer vs default/branch await), control-drain ordering, host pre-response readiness gating, and resume progress lease-before-switch behavior (#2914).
 
 ### Added
 

--- a/packages/coding-agent/src/extensibility/shared-events.ts
+++ b/packages/coding-agent/src/extensibility/shared-events.ts
@@ -38,6 +38,9 @@ export interface SessionBeforeSwitchEvent {
 	targetSessionFile?: string;
 }
 
+/** Origin used when an interactive session selector resumes a session. */
+export const INTERACTIVE_SELECTOR_RESUME_ORIGIN = "interactive_selector_resume";
+
 /** Fired after switching to another session */
 export interface SessionSwitchEvent {
 	type: "session_switch";
@@ -45,6 +48,8 @@ export interface SessionSwitchEvent {
 	reason: "new" | "resume" | "fork";
 	/** Session file we came from */
 	previousSessionFile: string | undefined;
+	/** Optional provenance for this session transition. */
+	transition?: { origin: string };
 }
 
 /** Fired before branching a session (can be cancelled) */

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -30,6 +30,7 @@ import {
 	getPluginsCacheDir,
 	MarketplaceManager,
 } from "../../extensibility/plugins/marketplace";
+import { INTERACTIVE_SELECTOR_RESUME_ORIGIN } from "../../extensibility/shared-events";
 import {
 	getAvailableThemes,
 	getCurrentThemeName,
@@ -165,6 +166,7 @@ import type { JobsObserver } from "../jobs-observer";
 import type { SessionObserverRegistry } from "../session-observer-registry";
 import type { TasksAggregator } from "../tasks-aggregator";
 import type { TranscriptItemRegistry } from "../transcript-item-registry";
+import { acquireResumeProgressLease } from "../utils/ui-helpers";
 
 const CALLBACK_SERVER_PROVIDERS = new Set<string>([
 	"anthropic",
@@ -2262,28 +2264,42 @@ export class SelectorController {
 	async handleResumeSession(sessionPath: string): Promise<void> {
 		const previousSessionId = this.ctx.sessionManager.getSessionId();
 		this.#clearTransientSessionUi();
-		const migrationPolicy =
-			this.ctx.settings?.get("session.directoryMigration") === "disabled" ? "disabled" : "copy-retain";
-		let writableSessionPath = sessionPath;
-		if (this.ctx.sessionManager.isManagedDestination()) {
-			const inspection = await SessionManager.inspectSessionTailReadOnly(sessionPath);
-			if (inspection.kind === "error") throw new Error(`Could not inspect selected session: ${inspection.reason}`);
-			writableSessionPath = await this.ctx.sessionManager.prepareManagedCandidateForStrictAdoption(
-				sessionPath,
-				migrationPolicy,
-				inspection.identity,
-			);
-		}
-		// Switch session via AgentSession (emits hook and tool session events)
-		if (!(await this.ctx.session.switchSession(writableSessionPath))) return;
-		const switchingToDifferentSession = previousSessionId !== this.ctx.sessionManager.getSessionId();
-		if (switchingToDifferentSession) this.ctx.resetIrcSidebarSession();
-		this.#refreshSessionTerminalTitle();
-		this.ctx.updateEditorBorderColor();
+		const progressLease = acquireResumeProgressLease(this.ctx);
+		try {
+			await progressLease.committed;
+			const migrationPolicy =
+				this.ctx.settings?.get("session.directoryMigration") === "disabled" ? "disabled" : "copy-retain";
+			let writableSessionPath = sessionPath;
+			if (this.ctx.sessionManager.isManagedDestination()) {
+				const inspection = await SessionManager.inspectSessionTailReadOnly(sessionPath);
+				if (inspection.kind === "error")
+					throw new Error(`Could not inspect selected session: ${inspection.reason}`);
+				writableSessionPath = await this.ctx.sessionManager.prepareManagedCandidateForStrictAdoption(
+					sessionPath,
+					migrationPolicy,
+					inspection.identity,
+				);
+			}
+			// Switch session via AgentSession (emits hook and tool session events)
+			if (
+				!(await this.ctx.session.switchSession(writableSessionPath, {
+					transition: { origin: INTERACTIVE_SELECTOR_RESUME_ORIGIN },
+				}))
+			)
+				return;
+			const switchingToDifferentSession = previousSessionId !== this.ctx.sessionManager.getSessionId();
+			if (switchingToDifferentSession) this.ctx.resetIrcSidebarSession();
+			this.#refreshSessionTerminalTitle();
+			this.ctx.updateEditorBorderColor();
 
-		this.ctx.rebuildInitialMessages(switchingToDifferentSession ? "replace-identity" : "reconcile-same-transcript");
-		await this.ctx.reloadTodos();
-		this.ctx.showStatus("Resumed session");
+			this.ctx.rebuildInitialMessages(
+				switchingToDifferentSession ? "replace-identity" : "reconcile-same-transcript",
+			);
+			await this.ctx.reloadTodos();
+			this.ctx.showStatus("Resumed session");
+		} finally {
+			progressLease.clear();
+		}
 	}
 
 	async handleSessionDeleteCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@gajae-code/agent-core";
 import type { AssistantMessage, ImageContent, Message } from "@gajae-code/ai";
-import { type Component, Spacer, Text, TruncatedText, type TUI, truncateToWidth } from "@gajae-code/tui";
+import { type Component, Loader, Spacer, Text, TruncatedText, type TUI, truncateToWidth } from "@gajae-code/tui";
 import { settings } from "../../config/settings";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
 import { buildSkillPromptMessage, parseSkillInvocations } from "../../extensibility/skills";
@@ -84,6 +84,43 @@ class BoundedIrcTextComponent implements Component {
 export function prepareTranscriptRebuild(ui: TUI, policy: TranscriptRebuildPolicy): void {
 	if (policy === "replace-identity") ui.resetViewportAnchorIntent();
 	else ui.prepareViewportAnchorForTranscriptRebuild();
+}
+
+export const RESUME_PROGRESS_COMMIT_TIMEOUT_MS = 250;
+
+export interface ResumeProgressLease {
+	readonly committed: Promise<boolean>;
+	clear(): void;
+}
+
+/**
+ * Mount a resume loader on the live status rail and wait for its render generation
+ * to commit before session I/O begins. The commit is advisory: a stopped or
+ * unavailable terminal resolves false and callers continue without blocking.
+ */
+export function acquireResumeProgressLease(
+	ctx: Pick<InteractiveModeContext, "ui" | "statusContainer">,
+): ResumeProgressLease {
+	const loader = new Loader(
+		ctx.ui,
+		spinner => theme?.fg?.("accent", spinner) ?? spinner,
+		message => theme?.fg?.("muted", message) ?? message,
+		"Resuming session…",
+	);
+	ctx.statusContainer.addChild(loader);
+	const generation = ctx.ui.requestRenderWithGeneration(false, "resume-progress");
+	let active = true;
+	const committed = ctx.ui.waitForRenderCommit(generation, RESUME_PROGRESS_COMMIT_TIMEOUT_MS).catch(() => false);
+	return {
+		committed,
+		clear(): void {
+			if (!active) return;
+			active = false;
+			if (ctx.statusContainer.children.includes(loader)) ctx.statusContainer.removeChild(loader);
+			else loader.stop();
+			ctx.ui.requestRender(false, "resume-progress-clear");
+		},
+	};
 }
 type TextBlock = { type: "text"; text: string };
 interface RenderInitialMessagesOptions {

--- a/packages/coding-agent/src/sdk/bus/control-drain-lease.ts
+++ b/packages/coding-agent/src/sdk/bus/control-drain-lease.ts
@@ -9,11 +9,15 @@
 
 export type TerminalSendOutcome = "written" | "disconnected" | "write_failed";
 
+/** Fence/capability hooks may return false to reject; undefined means ok. */
+export type IdentityControlGateResult = boolean | undefined;
+export type IdentityControlGate = () => IdentityControlGateResult | Promise<IdentityControlGateResult>;
+
 export interface IdentityControlSuccessPathInput {
 	/** Fence predecessor inbound work. The fence must not close its response writer. */
-	fence: () => void | boolean | Promise<void | boolean>;
+	fence: IdentityControlGate;
 	/** Optional explicit proof that the predecessor writer is still usable. */
-	ensurePredecessorSendCapable?: () => void | boolean | Promise<void | boolean>;
+	ensurePredecessorSendCapable?: IdentityControlGate;
 	/** Start successor B and resolve only after its public endpoint is ready. */
 	startSuccessor: () => Promise<void>;
 	/** Write and flush either the success or non-success terminal response. */
@@ -25,8 +29,8 @@ export interface IdentityControlSuccessPathInput {
 }
 
 export interface IdentityControlTerminalPathInput {
-	fenceInbound: () => void | boolean | Promise<void | boolean>;
-	ensurePredecessorSendCapable?: () => void | boolean | Promise<void | boolean>;
+	fenceInbound: IdentityControlGate;
+	ensurePredecessorSendCapable?: IdentityControlGate;
 	startSuccessorReady: () => Promise<void>;
 	sendTerminal: () => Promise<TerminalSendOutcome>;
 	stopPredecessor: () => Promise<void>;

--- a/packages/coding-agent/src/sdk/bus/control-drain-lease.ts
+++ b/packages/coding-agent/src/sdk/bus/control-drain-lease.ts
@@ -1,0 +1,100 @@
+/**
+ * Ordering seam for an in-band SDK identity transition.
+ *
+ * A request arrives through predecessor A, so a successful terminal response cannot
+ * be published until successor B is ready. Native builds may provide a true
+ * send-only connection lease; source/dev builds use the conservative fallback in
+ * which the predecessor server remains alive until the terminal write completes.
+ */
+
+export type TerminalSendOutcome = "written" | "disconnected" | "write_failed";
+
+export interface IdentityControlSuccessPathInput {
+	/** Fence predecessor inbound work. The fence must not close its response writer. */
+	fence: () => void | boolean | Promise<void | boolean>;
+	/** Optional explicit proof that the predecessor writer is still usable. */
+	ensurePredecessorSendCapable?: () => void | boolean | Promise<void | boolean>;
+	/** Start successor B and resolve only after its public endpoint is ready. */
+	startSuccessor: () => Promise<void>;
+	/** Write and flush either the success or non-success terminal response. */
+	sendTerminal: () => Promise<TerminalSendOutcome>;
+	/** Release predecessor A after the terminal response has settled. */
+	stopPredecessor: () => Promise<void>;
+	/** Set only when a caller cannot use the retained-writer fallback. */
+	requireNativeControlDrain?: boolean;
+}
+
+export interface IdentityControlTerminalPathInput {
+	fenceInbound: () => void | boolean | Promise<void | boolean>;
+	ensurePredecessorSendCapable?: () => void | boolean | Promise<void | boolean>;
+	startSuccessorReady: () => Promise<void>;
+	sendTerminal: () => Promise<TerminalSendOutcome>;
+	stopPredecessor: () => Promise<void>;
+	requireNativeControlDrain?: boolean;
+}
+
+/**
+ * Probe the loaded native addon, never an environment flag or a TypeScript shim.
+ * Older/source installs intentionally report false so callers can select the
+ * retained-writer fallback or fail closed when detach is mandatory.
+ */
+export function isNativeControlDrainAvailable(): boolean {
+	try {
+		// Keep the addon lazy: importing the bus must continue to work without a
+		// compiled native artifact (tests and source distributions do that often).
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const natives = require("@gajae-code/natives") as {
+			NotificationServer?: {
+				prototype?: Record<string, unknown>;
+			};
+		};
+		const prototype = natives.NotificationServer?.prototype;
+		return (
+			typeof prototype?.acquireControlDrain === "function" &&
+			typeof prototype?.sendTerminalAndWait === "function" &&
+			typeof prototype?.closeControlDrain === "function"
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Run the only safe ordering for a successful identity-control response.
+ *
+ * The `finally` is deliberately around both successor startup and terminal
+ * delivery: a failed startup must not leave the fenced predecessor alive, and a
+ * failed/disconnected terminal write must still release it. When native detach
+ * is unavailable the caller is expected to keep A's server up (not call
+ * `stopAndWait`) until `sendTerminal` settles.
+ */
+export async function runIdentityControlSuccessPath(
+	input: IdentityControlSuccessPathInput,
+): Promise<TerminalSendOutcome> {
+	if (input.requireNativeControlDrain && !isNativeControlDrainAvailable())
+		throw new Error("SDK identity control requires the native control-drain lease.");
+
+	if ((await input.fence()) === false) throw new Error("SDK identity control predecessor fence was not acquired.");
+	if ((await input.ensurePredecessorSendCapable?.()) === false)
+		throw new Error("SDK identity control predecessor writer is not send-capable.");
+	try {
+		await input.startSuccessor();
+		return await input.sendTerminal();
+	} finally {
+		await input.stopPredecessor();
+	}
+}
+
+/** Compatibility spelling used by the host wiring design notes. */
+export async function runIdentityControlTerminalPath(
+	input: IdentityControlTerminalPathInput,
+): Promise<TerminalSendOutcome> {
+	return runIdentityControlSuccessPath({
+		fence: input.fenceInbound,
+		ensurePredecessorSendCapable: input.ensurePredecessorSendCapable,
+		startSuccessor: input.startSuccessorReady,
+		sendTerminal: input.sendTerminal,
+		stopPredecessor: input.stopPredecessor,
+		requireNativeControlDrain: input.requireNativeControlDrain,
+	});
+}

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -3846,6 +3846,21 @@ export function createNotificationsExtension(
 						ok: false,
 						error: { code: "conflict", message: "session identity mutation is already active" },
 					};
+				const requireNativeControlDrain =
+					(request as { requireNativeControlDrain?: unknown }).requireNativeControlDrain === true ||
+					(!!request.input &&
+						typeof request.input === "object" &&
+						!Array.isArray(request.input) &&
+						(request.input as { requireNativeControlDrain?: unknown }).requireNativeControlDrain === true);
+				if (requireNativeControlDrain && !isNativeControlDrainAvailable())
+					return {
+						id: requestId,
+						ok: false,
+						error: {
+							code: "unavailable",
+							message: "SDK identity control requires the native control-drain lease.",
+						},
+					};
 				if (rotatesIdentity) identityControlInFlight = true;
 				const response = await controlRequesterContext.run(connectionId, () =>
 					dispatchControl(
@@ -4975,7 +4990,11 @@ export function createNotificationsExtension(
 			const pendingStartup = sessionStartPromises.get(newId);
 			if (pendingStartup) {
 				if (awaitStartup) {
-					await pendingStartup;
+					const result = await pendingStartup;
+					if (!lifecycleStartupCapability && result.status === "failed")
+						throw new Error(
+							`notifications: SDK startup failed: ${result.failure?.message ?? "Unknown startup failure."}`,
+						);
 					if (!extensionShuttingDown && runtimes.has(newId) && activeRuntimeId === newId)
 						await controller.reconcileCurrentSession(ctx);
 				} else {

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -43,6 +43,7 @@ import {
 	type WorkflowGateTerminalProof,
 } from "../../modes/shared/agent-wire/workflow-gate-broker";
 import type { AgentSessionEvent } from "../../session/agent-session";
+import { INTERACTIVE_SELECTOR_RESUME_ORIGIN } from "../../extensibility/shared-events";
 import { parseThinkingLevel } from "../../thinking";
 import type {
 	AskAnswerRequest,
@@ -81,6 +82,7 @@ import {
 	type NotificationSettingsReader,
 	sessionTag,
 } from "./config";
+import { runIdentityControlSuccessPath, type TerminalSendOutcome } from "./control-drain-lease";
 import { telegramControlCommandUsage } from "./config-commands";
 import { imageAttachmentsFromMessage, notificationActionPayload, summaryFromMessage, truncate } from "./helpers";
 import { createKindAwareReconciliation } from "./kind-aware-reconciliation";
@@ -96,6 +98,8 @@ import {
 	type RegisterNotificationRootResult,
 	unregisterNotificationRoot,
 } from "./telegram-daemon";
+export { isNativeControlDrainAvailable, runIdentityControlSuccessPath, runIdentityControlTerminalPath } from "./control-drain-lease";
+export type { IdentityControlSuccessPathInput, IdentityControlTerminalPathInput, TerminalSendOutcome } from "./control-drain-lease";
 
 // ===========================================================================
 // Session lifecycle control protocol (TypeScript mirror of the Rust wire
@@ -888,6 +892,8 @@ interface SessionRuntime {
 	disposeGateListener: () => void;
 	/** Whether notification-only delivery and answer resources are active. */
 	notificationsActive: boolean;
+	/** Rejects new SDK frames while a leased terminal response drains. */
+	inboundFenced: boolean;
 	/** Set as soon as terminal teardown is requested, before startup settles. */
 	stopping: boolean;
 	/** Recreates notification-only resources after `/notify on`. */
@@ -2964,6 +2970,18 @@ export async function ensureConfiguredProviderDaemons(
 	if (isSlackConfigured(cfg)) await ensureProviderDaemon("slack", settings);
 }
 
+/**
+ * Classify whether a session identity event must await notification endpoint startup.
+ * Only an interactive selector resume may defer this ancillary startup; all other
+ * events, including branches and unknown origins, fail closed to awaiting it.
+ */
+export function shouldAwaitNotificationStartup(event: {
+	type: "session_switch" | "session_branch";
+	transition?: { origin: string };
+}): boolean {
+	return event.type !== "session_switch" || event.transition?.origin !== INTERACTIVE_SELECTOR_RESUME_ORIGIN;
+}
+
 export function createNotificationsExtension(
 	api: ExtensionAPI,
 	options: {
@@ -3007,7 +3025,11 @@ export function createNotificationsExtension(
 	let activeRuntimeId: string | undefined;
 	let identityControlInFlight = false;
 	let deferredIdentityRotation:
-		| { event: { previousSessionFile?: string }; ctx: ExtensionContext; awaitStartup: boolean }
+		| {
+			event: { previousSessionFile?: string; transition?: { origin: string } };
+			ctx: ExtensionContext;
+			awaitStartup: boolean;
+		}
 		| undefined;
 	let extensionShuttingDown = false;
 
@@ -3068,6 +3090,7 @@ export function createNotificationsExtension(
 		const requestedRuntime = retryRuntime ?? activeRuntime;
 		if (expectedRuntime && requestedRuntime !== expectedRuntime) return false;
 		if (reason === "session" && requestedRuntime) {
+			requestedRuntime.inboundFenced = true;
 			requestedRuntime.stopping = true;
 			requestedRuntime.abortEphemeralTurns();
 		}
@@ -3706,6 +3729,73 @@ export function createNotificationsExtension(
 				};
 			},
 			onRequest: options.onSdkRequest,
+			beforeControlResponse: async (connectionId, request, response, sendTerminal) => {
+				if (typeof request.operation !== "string" || !identityControlOperations.has(request.operation)) return;
+				const pending = deferredIdentityRotation;
+				deferredIdentityRotation = undefined;
+				identityControlInFlight = false;
+				if (response.ok !== true || !pending) return;
+
+				const predecessorId = activeRuntimeId ?? sessionIdFromFile(pending.event.previousSessionFile);
+				if (!predecessorId) throw new Error("notifications: identity control predecessor is unknown.");
+				let terminalAttempted = false;
+				let terminalOutcome: TerminalSendOutcome | undefined;
+				try {
+					terminalOutcome = await runIdentityControlSuccessPath({
+						fence: () => {
+							const predecessor = runtimes.get(predecessorId);
+							if (!predecessor || predecessor.stopping || predecessor.serverStopped)
+								throw new Error(`notifications: predecessor runtime ${predecessorId} cannot be fenced.`);
+							predecessor.inboundFenced = true;
+						},
+						ensurePredecessorSendCapable: () => {
+							const predecessor = runtimes.get(predecessorId);
+							if (!predecessor || predecessor.stopping || predecessor.serverStopped)
+								throw new Error(`notifications: predecessor runtime ${predecessorId} is not send-capable.`);
+						},
+						startSuccessor: async () => {
+							const successorId = sessionId(pending.ctx);
+							try {
+								await rotateSessionAuthority(pending.event, pending.ctx, true, {
+									deferPredecessorStop: true,
+								});
+								const successor = runtimes.get(successorId);
+								if (!successor || !successor.host.started || activeRuntimeId !== successorId)
+									throw new Error(`notifications: successor runtime ${successorId} was not ready.`);
+							} catch (error) {
+								(response as Record<string, unknown>).ok = false;
+								delete (response as Record<string, unknown>).result;
+								(response as Record<string, unknown>).error = {
+									code: "unavailable",
+									message: error instanceof Error ? error.message : "Successor session was not ready.",
+								};
+							}
+						},
+						sendTerminal: async () => {
+							terminalAttempted = true;
+							try {
+								await sendTerminal();
+								return "written";
+							} catch {
+								return "write_failed";
+							}
+						},
+						stopPredecessor: async () => {
+							try {
+								await stopSession(predecessorId);
+							} catch (error) {
+								if (!terminalAttempted) throw error;
+								logger.error(`notifications: deferred predecessor cleanup failed: ${String(error)}`);
+							}
+						},
+						requireNativeControlDrain:
+							(request as { requireNativeControlDrain?: unknown }).requireNativeControlDrain === true,
+					});
+				} catch (error) {
+					if (!terminalAttempted) throw error;
+					logger.error(`notifications: identity terminal delivery failed (${terminalOutcome ?? "unknown"}): ${String(error)}`);
+				}
+			},
 			afterControlResponse: async (connectionId, request, response) => {
 				if (
 					(request.operation === "turn.prompt" ||
@@ -3726,13 +3816,6 @@ export function createNotificationsExtension(
 				}
 
 				if (request.operation === "session.close" && response.ok === true) ctx.shutdown();
-				if (typeof request.operation === "string" && identityControlOperations.has(request.operation)) {
-					const pending = deferredIdentityRotation;
-					deferredIdentityRotation = undefined;
-					identityControlInFlight = false;
-					if (response.ok === true && pending)
-						await rotateSessionAuthority(pending.event, pending.ctx, pending.awaitStartup);
-				}
 			},
 			control: async (connectionId, frame) => {
 				const request = frame as {
@@ -3823,6 +3906,7 @@ export function createNotificationsExtension(
 			workflowGate: undefined,
 			gatePresentations,
 			stopping: false,
+			inboundFenced: false,
 			abortEphemeralTurns: () => {},
 			disableEphemeralTurns: () => {},
 			cancelPostmortemCleanup: () => {},
@@ -3906,6 +3990,22 @@ export function createNotificationsExtension(
 					const frame = JSON.parse(inbound.json) as unknown;
 					if (!frame || typeof frame !== "object") return;
 					const typedFrame = frame as Record<string, unknown>;
+					if (initializedRuntime.inboundFenced) {
+						if (typedFrame.type === "control_request" && typeof typedFrame.id === "string") {
+							try {
+								server.sendTo(
+									inbound.connectionId,
+									JSON.stringify({
+										type: "control_response",
+										id: typedFrame.id,
+										ok: false,
+										error: { code: "endpoint_stale", message: "session endpoint is draining." },
+									}),
+								);
+							} catch {}
+						}
+						return;
+					}
 					if (typedFrame.type === "ephemeral_turn" || typedFrame.type === "ephemeral_turn_cancel") return;
 					if (typedFrame.type === "event_replay") {
 						const capabilities = Array.isArray(typedFrame.capabilities) ? typedFrame.capabilities : [];
@@ -3940,7 +4040,7 @@ export function createNotificationsExtension(
 
 			server.onReply((err, reply) => {
 				if (err || !reply) return;
-				if (runtime?.stopping || runtime?.policySuspended || runtimes.get(id) !== runtime) {
+				if (runtime?.inboundFenced || runtime?.stopping || runtime?.policySuspended || runtimes.get(id) !== runtime) {
 					try {
 						server.closeClaimInvalid(reply.replyReceiptId, "session_stopping");
 					} catch {}
@@ -4182,6 +4282,7 @@ export function createNotificationsExtension(
 			// thread (forwarded by the daemon over the WS, fail-closed at the daemon).
 			server.onInbound((err, inbound) => {
 				if (err || !inbound) return;
+				if (initializedRuntime.inboundFenced) return;
 				const authenticatedInbound = inbound as typeof inbound & {
 					connectionId: string;
 					messageId?: number;
@@ -4829,10 +4930,28 @@ export function createNotificationsExtension(
 		});
 	};
 
+	const preparePredecessorForTerminal = async (id: string): Promise<void> => {
+		const predecessor = runtimes.get(id);
+		if (!predecessor || cleanupRetries.has(id))
+			throw new Error(`notifications: predecessor runtime ${id} is not safely send-capable.`);
+		predecessor.inboundFenced = true;
+		// Release broker/host authority while leaving the native server alive for
+		// the one accepted terminal response. stopAndWait is deferred to stopSession.
+		const stopped = await predecessor.host.stop();
+		if (stopped !== "stopped" && predecessor.host.started)
+			throw new Error(`notifications: predecessor runtime ${id} host release was not proven.`);
+		predecessor.hostStopped = true;
+		predecessor.brokerRegistrationReleased = !predecessor.brokerRegistrationActive || predecessor.hostStopped;
+		if (predecessor.brokerRegistrationActive && predecessor.hostStopped)
+			predecessor.brokerRegistrationActive = false;
+		predecessor.host.reverse.dispose();
+	};
+
 	const rotateSessionAuthority = async (
 		event: { previousSessionFile?: string },
 		ctx: ExtensionContext,
 		awaitStartup: boolean,
+		options: { deferPredecessorStop?: boolean } = {},
 	): Promise<void> => {
 		if (extensionShuttingDown) return;
 		const newId = sessionId(ctx);
@@ -4856,14 +4975,14 @@ export function createNotificationsExtension(
 		}
 		if (prevId && prevId !== newId) {
 			controller.rekeySession(prevId, newId);
-			try {
-				await stopSession(prevId);
-			} catch (error) {
-				// A retained owner-release failure keeps the exact runtime in
-				// cleanupRetries for an explicit later retry; log it rather than
-				// surfacing a red extension error
-				// while rotating session authority (/new, fork, resume, branch).
-				logger.error(`notifications: SDK notification runtime cleanup failed: ${String(error)}`);
+			if (options.deferPredecessorStop) {
+				await preparePredecessorForTerminal(prevId);
+			} else {
+				const stopped = await stopSession(prevId);
+				if (cleanupRetries.has(prevId) || runtimes.has(prevId) || sessionStartPromises.has(prevId))
+					throw new Error(`notifications: predecessor runtime ${prevId} release is uncertain.`);
+				if (!stopped && activeRuntimeId === prevId)
+					throw new Error(`notifications: predecessor runtime ${prevId} release was not proven.`);
 			}
 		}
 		if (extensionShuttingDown) return;
@@ -4884,18 +5003,19 @@ export function createNotificationsExtension(
 		trackBranchStartup(newId, ctx, startup);
 	};
 	api.on("session_switch", async (event, ctx) => {
+		const awaitStartup = shouldAwaitNotificationStartup(event);
+		if (identityControlInFlight) {
+			deferredIdentityRotation = { event, ctx, awaitStartup };
+			return;
+		}
+		await rotateSessionAuthority(event, ctx, awaitStartup);
+	});
+	api.on("session_branch", async (event, ctx) => {
 		if (identityControlInFlight) {
 			deferredIdentityRotation = { event, ctx, awaitStartup: true };
 			return;
 		}
 		await rotateSessionAuthority(event, ctx, true);
-	});
-	api.on("session_branch", async (event, ctx) => {
-		if (identityControlInFlight) {
-			deferredIdentityRotation = { event, ctx, awaitStartup: false };
-			return;
-		}
-		await rotateSessionAuthority(event, ctx, false);
 	});
 
 	const terminalizeInFlightTools = (

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -83,7 +83,11 @@ import {
 	sessionTag,
 } from "./config";
 import { telegramControlCommandUsage } from "./config-commands";
-import { runIdentityControlSuccessPath, type TerminalSendOutcome } from "./control-drain-lease";
+import {
+	isNativeControlDrainAvailable,
+	runIdentityControlSuccessPath,
+	type TerminalSendOutcome,
+} from "./control-drain-lease";
 import { imageAttachmentsFromMessage, notificationActionPayload, summaryFromMessage, truncate } from "./helpers";
 import { createKindAwareReconciliation } from "./kind-aware-reconciliation";
 import { assertNativeRuntimeCompatibility } from "./native-runtime-compatibility";

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -35,6 +35,7 @@ import { isModelProfileProviderAvailable, projectModelProfileCatalog } from "../
 import { isAuthenticated, kNoAuth } from "../../config/model-registry";
 import { Settings } from "../../config/settings";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../../extensibility/extensions";
+import { INTERACTIVE_SELECTOR_RESUME_ORIGIN } from "../../extensibility/shared-events";
 import { toAgentWireEventPayload } from "../../modes/shared/agent-wire/event-envelope";
 import {
 	NotificationGatePolicyChangedError,
@@ -43,7 +44,6 @@ import {
 	type WorkflowGateTerminalProof,
 } from "../../modes/shared/agent-wire/workflow-gate-broker";
 import type { AgentSessionEvent } from "../../session/agent-session";
-import { INTERACTIVE_SELECTOR_RESUME_ORIGIN } from "../../extensibility/shared-events";
 import { parseThinkingLevel } from "../../thinking";
 import type {
 	AskAnswerRequest,
@@ -82,8 +82,8 @@ import {
 	type NotificationSettingsReader,
 	sessionTag,
 } from "./config";
-import { runIdentityControlSuccessPath, type TerminalSendOutcome } from "./control-drain-lease";
 import { telegramControlCommandUsage } from "./config-commands";
+import { runIdentityControlSuccessPath, type TerminalSendOutcome } from "./control-drain-lease";
 import { imageAttachmentsFromMessage, notificationActionPayload, summaryFromMessage, truncate } from "./helpers";
 import { createKindAwareReconciliation } from "./kind-aware-reconciliation";
 import { assertNativeRuntimeCompatibility } from "./native-runtime-compatibility";
@@ -98,8 +98,17 @@ import {
 	type RegisterNotificationRootResult,
 	unregisterNotificationRoot,
 } from "./telegram-daemon";
-export { isNativeControlDrainAvailable, runIdentityControlSuccessPath, runIdentityControlTerminalPath } from "./control-drain-lease";
-export type { IdentityControlSuccessPathInput, IdentityControlTerminalPathInput, TerminalSendOutcome } from "./control-drain-lease";
+
+export type {
+	IdentityControlSuccessPathInput,
+	IdentityControlTerminalPathInput,
+	TerminalSendOutcome,
+} from "./control-drain-lease";
+export {
+	isNativeControlDrainAvailable,
+	runIdentityControlSuccessPath,
+	runIdentityControlTerminalPath,
+} from "./control-drain-lease";
 
 // ===========================================================================
 // Session lifecycle control protocol (TypeScript mirror of the Rust wire
@@ -3026,10 +3035,10 @@ export function createNotificationsExtension(
 	let identityControlInFlight = false;
 	let deferredIdentityRotation:
 		| {
-			event: { previousSessionFile?: string; transition?: { origin: string } };
-			ctx: ExtensionContext;
-			awaitStartup: boolean;
-		}
+				event: { previousSessionFile?: string; transition?: { origin: string } };
+				ctx: ExtensionContext;
+				awaitStartup: boolean;
+		  }
 		| undefined;
 	let extensionShuttingDown = false;
 
@@ -3729,7 +3738,7 @@ export function createNotificationsExtension(
 				};
 			},
 			onRequest: options.onSdkRequest,
-			beforeControlResponse: async (connectionId, request, response, sendTerminal) => {
+			beforeControlResponse: async (_connectionId, request, response, sendTerminal) => {
 				if (typeof request.operation !== "string" || !identityControlOperations.has(request.operation)) return;
 				const pending = deferredIdentityRotation;
 				deferredIdentityRotation = undefined;
@@ -3760,7 +3769,7 @@ export function createNotificationsExtension(
 									deferPredecessorStop: true,
 								});
 								const successor = runtimes.get(successorId);
-								if (!successor || !successor.host.started || activeRuntimeId !== successorId)
+								if (!successor?.host.started || activeRuntimeId !== successorId)
 									throw new Error(`notifications: successor runtime ${successorId} was not ready.`);
 							} catch (error) {
 								(response as Record<string, unknown>).ok = false;
@@ -3793,7 +3802,9 @@ export function createNotificationsExtension(
 					});
 				} catch (error) {
 					if (!terminalAttempted) throw error;
-					logger.error(`notifications: identity terminal delivery failed (${terminalOutcome ?? "unknown"}): ${String(error)}`);
+					logger.error(
+						`notifications: identity terminal delivery failed (${terminalOutcome ?? "unknown"}): ${String(error)}`,
+					);
 				}
 			},
 			afterControlResponse: async (connectionId, request, response) => {
@@ -4040,7 +4051,12 @@ export function createNotificationsExtension(
 
 			server.onReply((err, reply) => {
 				if (err || !reply) return;
-				if (runtime?.inboundFenced || runtime?.stopping || runtime?.policySuspended || runtimes.get(id) !== runtime) {
+				if (
+					runtime?.inboundFenced ||
+					runtime?.stopping ||
+					runtime?.policySuspended ||
+					runtimes.get(id) !== runtime
+				) {
 					try {
 						server.closeClaimInvalid(reply.replyReceiptId, "session_stopping");
 					} catch {}
@@ -4942,8 +4958,7 @@ export function createNotificationsExtension(
 			throw new Error(`notifications: predecessor runtime ${id} host release was not proven.`);
 		predecessor.hostStopped = true;
 		predecessor.brokerRegistrationReleased = !predecessor.brokerRegistrationActive || predecessor.hostStopped;
-		if (predecessor.brokerRegistrationActive && predecessor.hostStopped)
-			predecessor.brokerRegistrationActive = false;
+		if (predecessor.brokerRegistrationActive && predecessor.hostStopped) predecessor.brokerRegistrationActive = false;
 		predecessor.host.reverse.dispose();
 	};
 

--- a/packages/coding-agent/src/sdk/host/host.ts
+++ b/packages/coding-agent/src/sdk/host/host.ts
@@ -9,6 +9,13 @@ export interface SessionSdkHostOptions extends HostEndpointAdapters {
 	query?: (connectionId: string, frame: SdkFrame) => unknown | Promise<unknown>;
 	/** Best-effort diagnostic observation of accepted control/query frames. */
 	onRequest?: SdkRequestObserver;
+	/** Runs before a control response is sent; identity transitions use sendTerminal. */
+	beforeControlResponse?: (
+		connectionId: string,
+		request: SdkFrame,
+		response: SdkFrame,
+		sendTerminal: () => Promise<void>,
+	) => void | Promise<void>;
 	/** Runs only after a successful control response has been sent to the client. */
 	afterControlResponse?: (connectionId: string, request: SdkFrame, response: SdkFrame) => void | Promise<void>;
 	installProviderDefinitions?: (capability: string, definitions: unknown) => void;
@@ -36,6 +43,14 @@ function errorFrame(connectionId: string, frame: SdkFrame, error: unknown): SdkF
 				? candidate.code
 				: "internal";
 	const message = typeof candidate?.message === "string" ? candidate.message : "SDK host operation failed.";
+	if (frame.type === "control_request") {
+		return {
+			type: "control_response",
+			id: typeof frame.id === "string" ? frame.id : "",
+			ok: false,
+			error: { code, message },
+		};
+	}
 	return {
 		type: "reverse_response",
 		id: typeof frame.id === "string" ? frame.id : "",
@@ -214,7 +229,14 @@ export class SessionSdkHost {
 					const result = await this.#options.control?.(connectionId, frame);
 					if (result !== undefined) {
 						const response = { type: "control_response", ...(result as SdkFrame) };
-						await this.#send(connectionId, response);
+						let terminalSent = false;
+						const sendTerminal = async (): Promise<void> => {
+							if (terminalSent) return;
+							terminalSent = true;
+							await this.#send(connectionId, response);
+						};
+						await this.#options.beforeControlResponse?.(connectionId, frame, response, sendTerminal);
+						await sendTerminal();
 						await this.#options.afterControlResponse?.(connectionId, frame, response);
 					}
 					break;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -235,6 +235,7 @@ import type {
 	TurnEndEvent,
 	TurnStartEvent,
 } from "../extensibility/extensions";
+import type { SessionSwitchEvent } from "../extensibility/shared-events";
 import type { CompactOptions, ContextUsage, ExtensionTranscriptEntry } from "../extensibility/extensions/types";
 import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
 import {
@@ -14777,7 +14778,10 @@ export class AgentSession {
 	 * Listeners are preserved and will continue receiving events.
 	 * @returns true if switch completed, false if cancelled by hook
 	 */
-	async switchSession(sessionPath: string): Promise<boolean> {
+	async switchSession(
+		sessionPath: string,
+		options?: { transition?: SessionSwitchEvent["transition"] },
+	): Promise<boolean> {
 		this.#beginSessionTransition("switch-session");
 		try {
 			const previousSessionFile = this.sessionManager.getSessionFile();
@@ -14936,6 +14940,7 @@ export class AgentSession {
 						type: "session_switch",
 						reason: "resume",
 						previousSessionFile,
+						...(options?.transition ? { transition: options.transition } : {}),
 					});
 				}
 				return true;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -235,7 +235,6 @@ import type {
 	TurnEndEvent,
 	TurnStartEvent,
 } from "../extensibility/extensions";
-import type { SessionSwitchEvent } from "../extensibility/shared-events";
 import type { CompactOptions, ContextUsage, ExtensionTranscriptEntry } from "../extensibility/extensions/types";
 import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
 import {
@@ -246,6 +245,7 @@ import { resolveCurrentPhaseForParent } from "../extensibility/gjc-plugins/injec
 import { readActiveSubskillsForParent, toActiveSubskillEntry } from "../extensibility/gjc-plugins/state";
 import { loadActiveSubskillTools } from "../extensibility/gjc-plugins/tools";
 import type { HookCommandContext } from "../extensibility/hooks/types";
+import type { SessionSwitchEvent } from "../extensibility/shared-events";
 import {
 	buildSkillPromptMessage,
 	getSkillSlashCommandName,

--- a/packages/coding-agent/test/notifications-session-switch.test.ts
+++ b/packages/coding-agent/test/notifications-session-switch.test.ts
@@ -6,8 +6,9 @@ import { Agent, ThinkingLevel } from "@gajae-code/agent-core";
 import { closeModelCache, getBundledModel } from "@gajae-code/ai";
 import { ModelRegistry } from "../src/config/model-registry";
 import type { ExtensionRunner } from "../src/extensibility/extensions/runner";
+import { INTERACTIVE_SELECTOR_RESUME_ORIGIN } from "../src/extensibility/shared-events";
 import { getTelegramFileSink } from "../src/sdk/bus/attachment-registry";
-import { createNotificationsExtension } from "../src/sdk/bus/index";
+import { createNotificationsExtension, shouldAwaitNotificationStartup } from "../src/sdk/bus/index";
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
 import { SessionSdkHost } from "../src/sdk/host";
 import { AgentSession } from "../src/session/agent-session";
@@ -69,6 +70,18 @@ async function withNotifications<T>(fn: () => Promise<T>): Promise<T> {
 		else process.env.GJC_NOTIFICATIONS = prevEnv;
 	}
 }
+
+test("session transition startup classifier defers only interactive selector resumes", () => {
+	expect([
+		shouldAwaitNotificationStartup({
+			type: "session_switch",
+			transition: { origin: INTERACTIVE_SELECTOR_RESUME_ORIGIN },
+		}),
+		shouldAwaitNotificationStartup({ type: "session_switch" }),
+		shouldAwaitNotificationStartup({ type: "session_switch", transition: { origin: "other" } }),
+		shouldAwaitNotificationStartup({ type: "session_branch" }),
+	]).toEqual([false, true, true, true]);
+});
 
 function createHarness(
 	prefix: string,
@@ -491,7 +504,7 @@ test("session_branch rotates endpoint authority", async () => {
 	});
 });
 
-test("session_branch with the same id does not await optional startup and reconciles after it settles", async () => {
+test("session_branch with the same id awaits startup before settling", async () => {
 	await withNotifications(async () => {
 		const entered = deferred();
 		const release = deferred();
@@ -523,7 +536,7 @@ test("session_branch with the same id does not await optional startup and reconc
 			});
 			await Promise.resolve();
 			await Promise.resolve();
-			expect(branchSettled).toBe(true);
+			expect(branchSettled).toBe(false);
 
 			release.resolve();
 			await startup;
@@ -538,11 +551,10 @@ test("session_branch with the same id does not await optional startup and reconc
 	});
 });
 
-test("session_branch settles before optional startup, publishes later, and shutdown drains its startup", async () => {
+test("session_branch awaits startup before publishing and settling", async () => {
 	await withNotifications(async () => {
 		const entered = deferred();
 		const release = deferred();
-		const startupSettled = deferred<{ sessionId: string; status: string }>();
 		const hostStart = SessionSdkHost.prototype.start;
 		const startSpy = vi.spyOn(SessionSdkHost.prototype, "start").mockImplementation(async function (
 			this: SessionSdkHost,
@@ -551,9 +563,7 @@ test("session_branch settles before optional startup, publishes later, and shutd
 			await release.promise;
 			return await hostStart.call(this);
 		});
-		const harness = createHarness("gjc-notif-branch-new-pending-", "Original", receipt =>
-			startupSettled.resolve(receipt),
-		);
+		const harness = createHarness("gjc-notif-branch-new-pending-");
 		try {
 			const previousId = `previous-${harness.sid}`;
 			let branchSettled = false;
@@ -568,12 +578,12 @@ test("session_branch settles before optional startup, publishes later, and shutd
 			await entered.promise;
 			await Promise.resolve();
 			await Promise.resolve();
-			expect(branchSettled).toBe(true);
+			expect(branchSettled).toBe(false);
 			expect(fs.existsSync(harness.endpoint())).toBe(false);
 
 			release.resolve();
 			await branch;
-			expect((await startupSettled.promise).status).toBe("started");
+			expect(branchSettled).toBe(true);
 			expect(fs.existsSync(harness.endpoint())).toBe(true);
 			expect(getTelegramFileSink(harness.sid)).toBeDefined();
 
@@ -586,7 +596,7 @@ test("session_branch settles before optional startup, publishes later, and shutd
 	});
 });
 
-test("session_branch cleans up a failed deferred startup", async () => {
+test("session_branch propagates failed startup", async () => {
 	await withNotifications(async () => {
 		const entered = deferred();
 		const release = deferred();
@@ -595,33 +605,47 @@ test("session_branch cleans up a failed deferred startup", async () => {
 		) {
 			entered.resolve();
 			await release.promise;
-			throw new Error("deferred branch startup failed");
+			throw new Error("branch startup failed");
 		});
-		const startupSettled = deferred<{ sessionId: string; status: string }>();
-		const harness = createHarness("gjc-notif-branch-failed-pending-", "Original", receipt =>
-			startupSettled.resolve(receipt),
-		);
+		const harness = createHarness("gjc-notif-branch-failed-pending-");
 		try {
-			const branch = harness.handlers.get("session_branch")!(
-				{ type: "session_branch", previousSessionFile: harness.previousSessionFile(`previous-${harness.sid}`) },
-				harness.ctx,
+			let branchSettled = false;
+			let branchError: unknown;
+			const branch = Promise.resolve(
+				harness.handlers.get("session_branch")!(
+					{ type: "session_branch", previousSessionFile: harness.previousSessionFile(`previous-${harness.sid}`) },
+					harness.ctx,
+				),
+			).then(
+				() => {
+					branchSettled = true;
+				},
+				error => {
+					branchSettled = true;
+					branchError = error;
+				},
 			);
 			await entered.promise;
-			await branch;
-			expect(getTelegramFileSink(harness.sid)).toBeUndefined();
+			await Promise.resolve();
+			expect(branchSettled).toBe(false);
+
 			release.resolve();
-			expect((await startupSettled.promise).status).toBe("failed");
+			await branch;
+			expect(branchSettled).toBe(true);
+			expect(branchError).toBeInstanceOf(Error);
+			expect(getTelegramFileSink(harness.sid)).toBeUndefined();
 			expect(fs.existsSync(harness.endpoint())).toBe(false);
 			await harness.handlers.get("session_shutdown")!({ type: "session_shutdown" }, harness.ctx);
 			expect(fs.existsSync(harness.endpoint())).toBe(false);
 			expect(getTelegramFileSink(harness.sid)).toBeUndefined();
 		} finally {
+			release.resolve();
 			startSpy.mockRestore();
 		}
 	});
 });
 
-test("session_shutdown fences and drains deferred branch startup", async () => {
+test("session_branch remains pending while startup is blocked", async () => {
 	await withNotifications(async () => {
 		const entered = deferred();
 		const release = deferred();
@@ -635,22 +659,24 @@ test("session_shutdown fences and drains deferred branch startup", async () => {
 		});
 		const harness = createHarness("gjc-notif-branch-shutdown-pending-");
 		try {
-			const branch = harness.handlers.get("session_branch")!(
-				{ type: "session_branch", previousSessionFile: harness.previousSessionFile(`previous-${harness.sid}`) },
-				harness.ctx,
-			);
-			await entered.promise;
-			await branch;
-			let shutdownSettled = false;
-			const shutdown = Promise.resolve(
-				harness.handlers.get("session_shutdown")!({ type: "session_shutdown" }, harness.ctx),
+			let branchSettled = false;
+			const branch = Promise.resolve(
+				harness.handlers.get("session_branch")!(
+					{ type: "session_branch", previousSessionFile: harness.previousSessionFile(`previous-${harness.sid}`) },
+					harness.ctx,
+				),
 			).then(() => {
-				shutdownSettled = true;
+				branchSettled = true;
 			});
+			await entered.promise;
 			await Promise.resolve();
-			expect(shutdownSettled).toBe(false);
+			expect(branchSettled).toBe(false);
+
 			release.resolve();
-			await shutdown;
+			await branch;
+			expect(branchSettled).toBe(true);
+			expect(fs.existsSync(harness.endpoint())).toBe(true);
+			await harness.handlers.get("session_shutdown")!({ type: "session_shutdown" }, harness.ctx);
 			expect(fs.existsSync(harness.endpoint())).toBe(false);
 			expect(getTelegramFileSink(harness.sid)).toBeUndefined();
 		} finally {

--- a/packages/coding-agent/test/resume-progress-lease.test.ts
+++ b/packages/coding-agent/test/resume-progress-lease.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { Container, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+import { SelectorController } from "../src/modes/controllers/selector-controller";
+import { initTheme } from "../src/modes/theme/theme";
+import type { InteractiveModeContext } from "../src/modes/types";
+
+beforeAll(() => initTheme());
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void; reject(error: unknown): void } {
+	let resolve!: (value: T) => void;
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<T>((promiseResolve, promiseReject) => {
+		resolve = promiseResolve;
+		reject = promiseReject;
+	});
+	return { promise, resolve, reject };
+}
+
+describe("resume progress lease", () => {
+	it("commits the status loader before a blocked session switch", async () => {
+		const terminal = new VirtualTerminal(80, 12);
+		const ui = new TUI(terminal);
+		const statusContainer = new Container();
+		ui.addChild(statusContainer);
+		ui.start();
+
+		let currentSessionId = "before";
+		let progressCommittedBeforeSwitch = false;
+		const switchStarted = deferred<void>();
+		const switchResult = deferred<boolean>();
+		const session = {
+			switchSession: vi.fn(async () => {
+				progressCommittedBeforeSwitch = terminal.getWriteLog().join("").includes("Resuming session");
+				switchStarted.resolve();
+				return await switchResult.promise;
+			}),
+		};
+		const context = {
+			ui,
+			statusContainer,
+			loadingAnimation: undefined,
+			pendingMessagesContainer: new Container(),
+			compactionQueuedMessages: [],
+			streamingComponent: undefined,
+			streamingMessage: undefined,
+			pendingTools: new Map(),
+			session,
+			settings: { get: () => undefined },
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				isManagedDestination: () => false,
+				getSessionName: () => undefined,
+				getCwd: () => "/tmp",
+			},
+			resetIrcSidebarSession: vi.fn(),
+			updateEditorBorderColor: vi.fn(),
+			rebuildInitialMessages: vi.fn(),
+			reloadTodos: vi.fn(async () => undefined),
+			showStatus: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(context);
+
+		const resume = controller.handleResumeSession("/tmp/target.jsonl");
+		await switchStarted.promise;
+		expect(progressCommittedBeforeSwitch).toBe(true);
+		expect(statusContainer.children).toHaveLength(1);
+
+		currentSessionId = "after";
+		switchResult.resolve(true);
+		await resume;
+		expect(statusContainer.children).toHaveLength(0);
+		expect(context.showStatus).toHaveBeenCalledWith("Resumed session");
+		expect(session.switchSession).toHaveBeenCalledWith("/tmp/target.jsonl", expect.any(Object));
+
+		ui.stop();
+	});
+});

--- a/packages/coding-agent/test/sdk-control-drain-lease.test.ts
+++ b/packages/coding-agent/test/sdk-control-drain-lease.test.ts
@@ -8,8 +8,12 @@ import {
 test("identity control terminal path waits for successor before sending and stopping predecessor", async () => {
 	const order: string[] = [];
 	const outcome = await runIdentityControlSuccessPath({
-		fence: () => order.push("fence"),
-		ensurePredecessorSendCapable: () => order.push("send-capable"),
+		fence: () => {
+			order.push("fence");
+		},
+		ensurePredecessorSendCapable: () => {
+			order.push("send-capable");
+		},
 		startSuccessor: async () => {
 			order.push("start");
 		},
@@ -29,13 +33,19 @@ test("identity control terminal path waits for successor before sending and stop
 test("identity control terminal path releases predecessor after a failed terminal write", async () => {
 	const order: string[] = [];
 	const outcome = await runIdentityControlSuccessPath({
-		fence: () => order.push("fence"),
-		startSuccessor: async () => order.push("start"),
+		fence: () => {
+			order.push("fence");
+		},
+		startSuccessor: async () => {
+			order.push("start");
+		},
 		sendTerminal: async (): Promise<TerminalSendOutcome> => {
 			order.push("terminal");
 			return "write_failed";
 		},
-		stopPredecessor: async () => order.push("stop"),
+		stopPredecessor: async () => {
+			order.push("stop");
+		},
 	});
 
 	expect(outcome).toBe("write_failed");
@@ -47,10 +57,16 @@ test("identity control terminal path fails closed when detach is required withou
 	if (isNativeControlDrainAvailable()) return;
 	await expect(
 		runIdentityControlSuccessPath({
-			fence: () => order.push("fence"),
-			startSuccessor: async () => order.push("start"),
+			fence: () => {
+				order.push("fence");
+			},
+			startSuccessor: async () => {
+				order.push("start");
+			},
 			sendTerminal: async () => "written",
-			stopPredecessor: async () => order.push("stop"),
+			stopPredecessor: async () => {
+				order.push("stop");
+			},
 			requireNativeControlDrain: true,
 		}),
 	).rejects.toThrow("native control-drain lease");

--- a/packages/coding-agent/test/sdk-control-drain-lease.test.ts
+++ b/packages/coding-agent/test/sdk-control-drain-lease.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import {
+	isNativeControlDrainAvailable,
+	runIdentityControlSuccessPath,
+	type TerminalSendOutcome,
+} from "../src/sdk/bus/control-drain-lease";
+
+test("identity control terminal path waits for successor before sending and stopping predecessor", async () => {
+	const order: string[] = [];
+	const outcome = await runIdentityControlSuccessPath({
+		fence: () => order.push("fence"),
+		ensurePredecessorSendCapable: () => order.push("send-capable"),
+		startSuccessor: async () => {
+			order.push("start");
+		},
+		sendTerminal: async () => {
+			order.push("terminal");
+			return "written";
+		},
+		stopPredecessor: async () => {
+			order.push("stop");
+		},
+	});
+
+	expect(outcome).toBe("written");
+	expect(order).toEqual(["fence", "send-capable", "start", "terminal", "stop"]);
+});
+
+test("identity control terminal path releases predecessor after a failed terminal write", async () => {
+	const order: string[] = [];
+	const outcome = await runIdentityControlSuccessPath({
+		fence: () => order.push("fence"),
+		startSuccessor: async () => order.push("start"),
+		sendTerminal: async (): Promise<TerminalSendOutcome> => {
+			order.push("terminal");
+			return "write_failed";
+		},
+		stopPredecessor: async () => order.push("stop"),
+	});
+
+	expect(outcome).toBe("write_failed");
+	expect(order).toEqual(["fence", "start", "terminal", "stop"]);
+});
+
+test("identity control terminal path fails closed when detach is required without a native lease", async () => {
+	const order: string[] = [];
+	if (isNativeControlDrainAvailable()) return;
+	await expect(
+		runIdentityControlSuccessPath({
+			fence: () => order.push("fence"),
+			startSuccessor: async () => order.push("start"),
+			sendTerminal: async () => "written",
+			stopPredecessor: async () => order.push("stop"),
+			requireNativeControlDrain: true,
+		}),
+	).rejects.toThrow("native control-drain lease");
+	expect(order).toEqual([]);
+});

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2390,7 +2390,7 @@ test("SDK session switches rotate endpoint authority before publishing the repla
 });
 
 for (const eventType of ["session_switch", "session_branch"] as const) {
-	test(`SDK ${eventType} rotation swallows a retained owner-release failure without surfacing an extension error`, async () => {
+	test(`SDK ${eventType} rotation fails closed when predecessor release is uncertain`, async () => {
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), `gjc-sdk-rotate-fail-${eventType}-`));
 		dirs.push(cwd);
 		const sessionA = `rotate-fail-a-${Date.now()}`;
@@ -2414,7 +2414,6 @@ for (const eventType of ["session_switch", "session_branch"] as const) {
 		// Fail A's owner release exactly once so the rotate-time stopSession(prevId)
 		// throws the retained-retry AggregateError.
 		const stop = spyOn(SessionSdkHost.prototype, "stop").mockRejectedValueOnce(new Error("host stop failed"));
-		const errorSpy = spyOn(logger, "error").mockImplementation(() => {});
 		try {
 			const startupCapability = new SdkStartupCapability();
 			const handlers = start(ctx, undefined, () => {}, false, new Map(), {
@@ -2426,55 +2425,20 @@ for (const eventType of ["session_switch", "session_branch"] as const) {
 			await waitFor(() => fs.existsSync(endpointAPath), "session A endpoint");
 
 			activeSessionId = sessionB;
-			// Drive the rotation handler through a real ExtensionRunner so the onError
-			// seam proves the swallowed failure is not surfaced as a red extension error.
-			const rotationExt = {
-				path: "test-rotation-ext",
-				handlers: new Map([
-					[
-						eventType,
-						[
-							async () => {
-								await handlers.get(eventType)!(
-									{
-										type: eventType,
-										reason: "new",
-										previousSessionFile: path.join(cwd, "sessions", `ts_${sessionA}.jsonl`),
-									},
-									ctx,
-								);
-							},
-						],
-					],
-				]),
+			// A retained predecessor cleanup must fail closed and rethrow before any
+			// successor endpoint can publish.
+			const rotationEvent = {
+				type: eventType,
+				reason: "new",
+				previousSessionFile: path.join(cwd, "sessions", `ts_${sessionA}.jsonl`),
 			};
-			const runner = new ExtensionRunner([rotationExt as never], {} as never, cwd, {} as never, {} as never);
-			runner.initialize({} as never, {} as never);
-			const surfaced: Array<{ event: string }> = [];
-			runner.onError(error => surfaced.push(error));
-			await expect(
-				runner.emit({
-					type: eventType,
-					reason: "new",
-					previousSessionFile: path.join(cwd, "sessions", `ts_${sessionA}.jsonl`),
-				} as never),
-			).resolves.toBeUndefined();
-			expect(surfaced).toEqual([]);
+			await expect(handlers.get(eventType)!(rotationEvent, ctx)).rejects.toThrow(
+				`SDK notification runtime ${sessionA} owner release failed`,
+			);
 
-			// Rotation still publishes B and retires A despite the swallowed failure.
+			// The failed predecessor release quarantines B: no successor endpoint is published.
 			const endpointBPath = path.join(cwd, ".gjc", "state", "sdk", `${sessionB}.json`);
-			await waitFor(() => !fs.existsSync(endpointAPath) && fs.existsSync(endpointBPath), "rotated session endpoint");
-
-			// The failure is logged at error severity with the shared prefix and A's
-			// identity, never surfaced as a red extension error.
-			const breadcrumbs = errorSpy.mock.calls.map(args => String(args[0]));
-			expect(
-				breadcrumbs.some(
-					message =>
-						message.startsWith("notifications: SDK notification runtime cleanup failed: ") &&
-						message.includes(`SDK notification runtime ${sessionA} owner release failed`),
-				),
-			).toBe(true);
+			expect(fs.existsSync(endpointBPath)).toBe(false);
 
 			// With the mock restored, A's retained cleanup can still complete.
 			stop.mockRestore();
@@ -2488,7 +2452,6 @@ for (const eventType of ["session_switch", "session_branch"] as const) {
 			await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, ctx);
 		} finally {
 			stop.mockRestore();
-			errorSpy.mockRestore();
 		}
 	});
 }

--- a/packages/coding-agent/test/sdk-host.test.ts
+++ b/packages/coding-agent/test/sdk-host.test.ts
@@ -299,4 +299,41 @@ describe("SessionSdkHost", () => {
 			await host.stop();
 		}
 	});
+	test("beforeControlResponse gates terminal delivery until the successor hook resolves", async () => {
+		let receive!: (connectionId: string, frame: Record<string, unknown>) => void;
+		const sent: Array<Record<string, unknown>> = [];
+		const successorReady = Promise.withResolvers<void>();
+		const order: string[] = [];
+		const host = new SessionSdkHost({
+			sessionId: "control-drain-order",
+			stateRoot: "/tmp/control-drain-order",
+			token: "token",
+			sendFrame: (_connectionId, frame) => {
+				order.push("send");
+				sent.push(frame);
+			},
+			onFrame: handler => {
+				receive = handler;
+				return () => {};
+			},
+			control: (_connectionId, frame) => ({ id: frame.id, ok: true, result: {} }),
+			beforeControlResponse: async (_connectionId, _request, _response, sendTerminal) => {
+				order.push("before");
+				await successorReady.promise;
+				order.push("ready");
+				await sendTerminal();
+			},
+		});
+		await host.start();
+		receive("client", { type: "control_request", id: "c1", operation: "session.switch", input: {} });
+		await new Promise(resolve => setTimeout(resolve, 0));
+		expect(sent).toEqual([]);
+		expect(order).toEqual(["before"]);
+		successorReady.resolve();
+		await new Promise(resolve => setTimeout(resolve, 0));
+		await new Promise(resolve => setTimeout(resolve, 0));
+		expect(sent).toEqual([expect.objectContaining({ type: "control_response", id: "c1", ok: true })]);
+		expect(order).toEqual(["before", "ready", "send"]);
+		await host.stop();
+	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- `waitForRenderCommit` / generation-scoped render tokens resolve only after a successful buffer write (or fail open on stopped/unavailable terminals), enabling awaitable progress frames for interactive resume without hanging (#2914).
 
 ### Fixed
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -623,6 +623,10 @@ type TuiRenderCounterSnapshot = {
 	debugRedrawAppendWrites: number;
 	differentialGuardVisibleWidthCalls: number;
 };
+type RenderCommitWaiter = {
+	resolve: (committed: boolean) => void;
+	timer: NodeJS.Timeout;
+};
 
 /**
  * TUI - Main class for managing terminal UI with differential rendering
@@ -651,6 +655,11 @@ export class TUI extends Container {
 	/** Global callback for debug key (Shift+Ctrl+D). Called before input is forwarded to focused component. */
 	onDebug?: () => void;
 	#renderRequested = false;
+	#nextRenderGeneration = 0;
+	#renderRequestedGeneration = 0;
+	#committedRenderGeneration = 0;
+	#renderCommitWaiters = new Map<number, Set<RenderCommitWaiter>>();
+	#lastRenderWriteSucceeded = false;
 	#renderTimer: NodeJS.Timeout | undefined;
 	#lastRenderAt = 0;
 	static readonly #MIN_RENDER_INTERVAL_MS = 16;
@@ -1118,6 +1127,57 @@ export class TUI extends Container {
 		this.requestRender(true);
 	}
 
+	/**
+	 * Wait for a specific render request generation to be written successfully.
+	 *
+	 * Render requests are coalesced, so committing a newer generation also commits
+	 * every older generation represented by that frame. A stopped or unavailable
+	 * terminal resolves waiters false so UI callers can fail open instead of
+	 * holding a session operation behind a dead renderer.
+	 */
+	waitForRenderCommit(generation: number, timeoutMs = 250): Promise<boolean> {
+		if (generation <= 0 || generation <= this.#committedRenderGeneration) return Promise.resolve(true);
+		if (this.#stopped || !this.terminalAvailable) return Promise.resolve(false);
+		return new Promise<boolean>(resolve => {
+			const waiter: RenderCommitWaiter = {
+				resolve,
+				timer: setTimeout(
+					() => {
+						const waiters = this.#renderCommitWaiters.get(generation);
+						if (waiters) {
+							waiters.delete(waiter);
+							if (waiters.size === 0) this.#renderCommitWaiters.delete(generation);
+						}
+						resolve(false);
+					},
+					Math.max(0, timeoutMs),
+				),
+			};
+			waiter.timer.unref?.();
+			const waiters = this.#renderCommitWaiters.get(generation) ?? new Set();
+			waiters.add(waiter);
+			this.#renderCommitWaiters.set(generation, waiters);
+		});
+	}
+
+	#settleRenderCommitWaiters(committed: boolean, generation = Number.POSITIVE_INFINITY): void {
+		if (committed) this.#committedRenderGeneration = Math.max(this.#committedRenderGeneration, generation);
+		for (const [waiterGeneration, waiters] of this.#renderCommitWaiters) {
+			if (committed && waiterGeneration > generation) continue;
+			this.#renderCommitWaiters.delete(waiterGeneration);
+			for (const waiter of waiters) {
+				clearTimeout(waiter.timer);
+				waiter.resolve(committed);
+			}
+		}
+	}
+
+	#commitRenderGeneration(generation: number): void {
+		if (generation <= 0) return;
+		if (this.#lastRenderWriteSucceeded) this.#settleRenderCommitWaiters(true, generation);
+		else if (this.#stopped || !this.terminalAvailable) this.#settleRenderCommitWaiters(false, generation);
+	}
+
 	get terminalAvailable(): boolean {
 		return !this.#terminalUnavailable && this.terminal.available;
 	}
@@ -1126,6 +1186,7 @@ export class TUI extends Container {
 		this.#terminalUnavailable = true;
 		this.#stopped = true;
 		this.#renderRequested = false;
+		this.#settleRenderCommitWaiters(false);
 		if (this.#renderTimer) {
 			clearTimeout(this.#renderTimer);
 			this.#renderTimer = undefined;
@@ -1324,6 +1385,7 @@ export class TUI extends Container {
 		this.flushTerminalCleanup();
 		this.#clearSixelProbeState();
 		this.#stopped = true;
+		this.#settleRenderCommitWaiters(false);
 		if (this.#renderTimer) {
 			clearTimeout(this.#renderTimer);
 			this.#renderTimer = undefined;
@@ -1395,6 +1457,17 @@ export class TUI extends Container {
 	}
 
 	requestRender(force = false, source = "unknown"): void {
+		this.requestRenderWithGeneration(force, source);
+	}
+
+	requestRenderWithGeneration(force = false, source = "unknown"): number {
+		const generation = ++this.#nextRenderGeneration;
+		this.#renderRequestedGeneration = Math.max(this.#renderRequestedGeneration, generation);
+		this.#requestRenderCore(force, source, generation);
+		return generation;
+	}
+
+	#requestRenderCore(force: boolean, source: string, generation: number): void {
 		if (!this.terminalAvailable) {
 			this.#markTerminalUnavailable();
 			return;
@@ -1429,12 +1502,17 @@ export class TUI extends Container {
 			this.#renderRequested = true;
 			process.nextTick(() => {
 				if (this.#stopped || !this.#renderRequested) {
+					this.#settleRenderCommitWaiters(false, generation);
 					return;
 				}
+				const requestedGeneration = this.#renderRequestedGeneration;
+				this.#renderRequestedGeneration = 0;
 				this.#renderRequested = false;
 				this.#lastRenderAt = performance.now();
+				this.#lastRenderWriteSucceeded = false;
 				const t0 = renderMetrics.now();
 				this.#doRender();
+				this.#commitRenderGeneration(requestedGeneration);
 				if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
 			});
 			return;
@@ -1455,6 +1533,7 @@ export class TUI extends Container {
 		if (this.#renderRequested) return;
 		this.#renderRequested = true;
 		process.nextTick(() => this.#scheduleRender());
+		return;
 	}
 
 	#scheduleRender(): void {
@@ -1469,10 +1548,14 @@ export class TUI extends Container {
 			if (this.#stopped || !this.#renderRequested) {
 				return;
 			}
+			const requestedGeneration = this.#renderRequestedGeneration;
+			this.#renderRequestedGeneration = 0;
 			this.#renderRequested = false;
 			this.#lastRenderAt = performance.now();
+			this.#lastRenderWriteSucceeded = false;
 			const t0 = renderMetrics.now();
 			this.#doRender();
+			this.#commitRenderGeneration(requestedGeneration);
 			if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
 			if (this.#renderRequested) {
 				this.#scheduleRender();
@@ -1495,10 +1578,14 @@ export class TUI extends Container {
 			this.#renderTimer = undefined;
 			if (renderMetrics.enabled) renderMetrics.setTimerGauge("tui.renderTimer", 0);
 		}
+		const requestedGeneration = this.#renderRequestedGeneration;
+		this.#renderRequestedGeneration = 0;
 		this.#renderRequested = false;
 		this.#lastRenderAt = performance.now();
+		this.#lastRenderWriteSucceeded = false;
 		const t0 = renderMetrics.now();
 		this.#doRender();
+		this.#commitRenderGeneration(requestedGeneration);
 		if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
 	}
 
@@ -3004,8 +3091,13 @@ export class TUI extends Container {
 			buffer += `\x1b[?2026h\x1b7${overlay}\x1b8\x1b[?2026l`;
 		}
 		if (!this.#writeTerminal(buffer)) return false;
-		if (!this.#imeCursorActive) return true;
-		return this.#writeCursorPosition(cursorPos, totalLines);
+		if (!this.#imeCursorActive) {
+			this.#lastRenderWriteSucceeded = true;
+			return true;
+		}
+		const cursorWritten = this.#writeCursorPosition(cursorPos, totalLines);
+		if (cursorWritten) this.#lastRenderWriteSucceeded = true;
+		return cursorWritten;
 	}
 
 	/**

--- a/packages/tui/test/render-commit.test.ts
+++ b/packages/tui/test/render-commit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { Text } from "../src/components/text";
+import { TUI } from "../src/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+describe("generation-scoped render commits", () => {
+	it("resolves after the requested generation writes successfully", async () => {
+		const terminal = new VirtualTerminal(40, 8);
+		const tui = new TUI(terminal);
+		tui.start();
+		tui.addChild(new Text("resume-progress", 1, 0));
+
+		const generation = tui.requestRenderWithGeneration(false, "test.resume-progress");
+		expect(await tui.waitForRenderCommit(generation)).toBe(true);
+		expect(terminal.getWriteLog().join(" ")).toContain("resume-progress");
+
+		tui.stop();
+	});
+
+	it("fails open immediately after the renderer is stopped", async () => {
+		const terminal = new VirtualTerminal(40, 8);
+		const tui = new TUI(terminal);
+		tui.start();
+		tui.stop();
+
+		const generation = tui.requestRenderWithGeneration(false, "test.stopped");
+		expect(await tui.waitForRenderCommit(generation)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- Stamp interactive selector `/resume` with `interactive_selector_resume` so `session_switch` defers only ancillary notification-endpoint startup after predecessor fencing; `session_branch` and default/absent origins keep awaited readiness.
- Fail closed when predecessor `stopSession` is uncertain/`cleanupRetries`; identity-control terminal outcomes are sent only after successor readiness via control-drain orchestration (A remains send-capable until terminal flush, then stops).
- Interactive TUI progress lease on `statusContainer` with generation-scoped render commit (fail-open if terminal stopped); clears on every exit path.
- Deterministic tests for await policy matrix, control-drain ordering, host pre-response gating, and progress-before-switch.

Closes #2914

## Plan / specs
- Deep-interview: `.gjc/_session-*/specs/deep-interview-resume-readiness-latency.md` (early-exit; intent-review gate bypassed with coverage note)
- Ralplan pending approval: stage-05 consensus (Architect CLEAR, Critic OKAY)

## Test plan
- [x] `bun test packages/coding-agent/test/sdk-control-drain-lease.test.ts packages/coding-agent/test/sdk-host.test.ts packages/coding-agent/test/resume-progress-lease.test.ts packages/tui/test/render-commit.test.ts packages/coding-agent/test/notifications-session-switch.test.ts` (32 pass)
- [x] `bun test packages/coding-agent/test/sdk-host-wiring.test.ts packages/coding-agent/test/sdk-resume-tool-pairing.test.ts packages/tui/test/resize-replay-storm.test.ts` (91 pass)
- [ ] CI full resume/SDK/TUI suite on PR
- [ ] Hostile review of origin stamp fail-closed defaults and control-drain ordering

## Notes
- Native writer-detach API remains a fail-closed future path (`requireNativeControlDrain`); default path keeps A server alive until after terminal send.
- Deep-interview product gap: intent-review `DI_STATE_SCHEMA_INVALID` / same-round continue-shell scoring deadlock (related #3180/#2643); seed retained for later filing.