### PR TITLE
fix coordinator workflow question reconciliation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,9 @@
 - Task output-limit environment overrides now honor values loaded from agent, config-root, and home dotenv files through the shared utils env loader while retaining strict positive safe-integer validation and canonical GJC-first alias precedence.
 - `--thinking` now advertises the supported Effort levels and fails closed with a usage error for invalid, missing, empty, or flag-adjacent values, rather than silently ignoring a token or consuming another flag.
 - MCP servers configured with a large `timeout` no longer widen the startup hang window for every consumer. The long startup ceiling now applies only to ACP lifecycle launches that supply their own MCP servers, derived from the session readiness deadline with reserved headroom; ordinary CLI/SDK `mcpConfigPath`, project, user, and plugin-bundle consumers keep the short default. An ACP launch that reaches the readiness cutoff before MCP startup now fails fast as a pending startup instead of silently falling back to the ordinary ceiling.
+### Fixed
+
+- Coordinator MCP now reconciles canonical structured questions from every workflow stage without misclassifying row-level gate diagnostics as malformed pagination, and unwraps accepted SDK gate-answer envelopes before reporting the terminal resolution.
 
 - SDK MCP stdio (`gjc mcp-serve sdk`) now awaits in-flight JSON-RPC handlers after stdin EOF so tools/call responses finish and WebSocket clients close before process exit; the entrypoint e2e fixture bounds child/server/temp cleanup on success and failure so the suite cannot hang for the full 60s on a stuck server.
 - Shared kind-aware durable invocation reconciliation substrate for `turn.prompt` and `skill.invoke` (#3031/#3032/#3035): private `.sdk-reconciliation` store, awaitable preflight accept fence, non-hanging skill early-accept with optional `clientRef`.

--- a/packages/coding-agent/src/coordinator-mcp/question-gate-codec.ts
+++ b/packages/coding-agent/src/coordinator-mcp/question-gate-codec.ts
@@ -147,7 +147,7 @@ function askSchema(labels: string[], multi: boolean, allowEmpty: boolean): JsonS
 }
 export function decodeAskGateV1(gate: WorkflowGate): PrivateAskGateCodecV1 | null {
 	if (
-		gate.stage !== "deep-interview" ||
+		(gate.stage !== "deep-interview" && gate.stage !== "ralplan" && gate.stage !== "ultragoal") ||
 		gate.kind !== "question" ||
 		!isRecord(gate.context) ||
 		!boundedText(gate.context.prompt, MAX_TEXT) ||

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -859,7 +859,7 @@ interface RuntimePromptAcknowledgement {
 	turn_id: string;
 }
 
-function acknowledgementPayload(result: unknown): Record<string, unknown> | null {
+function sdkResultPayload(result: unknown): Record<string, unknown> | null {
 	const response = asRecord(result);
 	if (!response) return null;
 	const envelope = ["ok", "result", "error"].some(key => Object.hasOwn(response, key));
@@ -887,7 +887,7 @@ function runtimeAcknowledgementIdentity(
 }
 
 function normalizeRuntimePromptAcknowledgement(result: unknown): RuntimePromptAcknowledgement {
-	const acknowledgement = acknowledgementPayload(result);
+	const acknowledgement = sdkResultPayload(result);
 	if (acknowledgement?.accepted !== true)
 		throw new SdkClientError("unavailable", "SDK did not acknowledge prompt delivery.");
 	return {
@@ -2458,15 +2458,8 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 				items.push(...pageItems);
 				if (complete) {
 					const valid = items.every(item => {
-						if (!item || typeof item !== "object" || Buffer.byteLength(JSON.stringify(item)) > 16 * 1024)
-							return false;
-						const gate = item as WorkflowGateQueryRecord & WorkflowGate;
-						return (
-							gate.tag === "pending" &&
-							typeof gate.gate_id === "string" &&
-							gate.gate_id.length > 0 &&
-							!!decodeAskGateV1(gate)
-						);
+						const encoded = JSON.stringify(item);
+						return typeof encoded === "string" && Buffer.byteLength(encoded) <= 16 * 1024;
 					});
 					return valid
 						? { items, revision, complete: true, reason: null }
@@ -4492,7 +4485,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 								{ id: gateId, response: translated, expectedSessionId: sessionId },
 								(claimed as { requestId: string }).requestId,
 							);
-							const resolution = asRecord(result);
+							const resolution = sdkResultPayload(result);
 							const status = resolution?.status;
 							if (status === "rejected") {
 								await withAdmittedSessionTransaction(questionPaths, sessionId, async transaction => {

--- a/packages/coding-agent/test/coordinator-mcp-question-codec.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-question-codec.test.ts
@@ -46,6 +46,12 @@ function gate(): WorkflowGate {
 }
 
 describe("coordinator MCP ask-gate codec", () => {
+	it("decodes canonical ask gates for every workflow stage", () => {
+		for (const stage of ["deep-interview", "ralplan", "ultragoal"] as const) {
+			expect(decodeAskGateV1({ ...gate(), stage })).not.toBeNull();
+		}
+	});
+
 	it("projects a pending Q12 ask without exposing the private codec or binding after it is answered", () => {
 		const codec = decodeAskGateV1(gate());
 		if (!codec) throw new Error("expected a valid deep-interview ask gate");

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -76,7 +76,11 @@ function lifecycleControls(controls: SdkControl[]): SdkControl[] {
 	);
 }
 
-function sharedAskGate(gateId: string, runtimeTurnId: string): WorkflowGate & { id: string; tag: "pending" } {
+function sharedAskGate(
+	gateId: string,
+	runtimeTurnId: string,
+	stage: WorkflowGate["stage"] = "deep-interview",
+): WorkflowGate & { id: string; tag: "pending" } {
 	const labels = ["Continue", "Stop"];
 	const schema = buildAskGateAnswerSchema({ multi: false, allowEmpty: false }, labels);
 	return {
@@ -85,7 +89,7 @@ function sharedAskGate(gateId: string, runtimeTurnId: string): WorkflowGate & { 
 		type: "workflow_gate",
 		gate_id: gateId,
 		runtime_turn_id: runtimeTurnId,
-		stage: "deep-interview",
+		stage,
 		kind: "question",
 		schema,
 		schema_hash: schemaHash(schema),
@@ -1360,7 +1364,11 @@ describe("Coordinator MCP canonical SDK controls", () => {
 				return cursor
 					? {
 							ok: true,
-							page: { items: [sharedAskGate("gate-q12", runtimeTurnId)], complete: true, revision: "q12-r1" },
+							page: {
+								items: [sharedAskGate("gate-q12", runtimeTurnId, "ralplan")],
+								complete: true,
+								revision: "q12-r1",
+							},
 						}
 					: {
 							ok: true,
@@ -1378,7 +1386,12 @@ describe("Coordinator MCP canonical SDK controls", () => {
 			undefined,
 			{
 				controlResult: control =>
-					control.operation === "workflow.gate_answer" ? { status: "accepted" } : undefined,
+					control.operation === "workflow.gate_answer"
+						? {
+								ok: true,
+								result: { status: "accepted", resolved_at: "2026-07-17T00:01:00.000Z" },
+							}
+						: undefined,
 			},
 		);
 		await registerSdkSession(server, root);
@@ -1398,6 +1411,7 @@ describe("Coordinator MCP canonical SDK controls", () => {
 		expect(question).toMatchObject({
 			question_id: "gate-q12",
 			status: "pending",
+			stage: "ralplan",
 		});
 		expect(JSON.stringify(question)).not.toContain("codec");
 		if (typeof question.answer_binding !== "string") throw new Error("missing answer binding");
@@ -1446,7 +1460,7 @@ describe("Coordinator MCP canonical SDK controls", () => {
 		).toMatchObject({ ok: false, error: { code: "idempotency_conflict" } });
 	});
 
-	it("rejects malformed complete Q12 snapshots without mutating question authority", async () => {
+	it("diagnoses malformed gate rows without misclassifying legal Q12 pagination", async () => {
 		const root = await tempRoot();
 		const controls: SdkControl[] = [];
 		let runtimeTurnId = "unbound";
@@ -1473,10 +1487,13 @@ describe("Coordinator MCP canonical SDK controls", () => {
 		const second = await server.callTool("gjc_coordinator_list_questions", { session_id: "visible-session" });
 		expect(first).toMatchObject({
 			questions: [],
-			diagnostics: expect.arrayContaining([expect.objectContaining({ reason: "pagination_malformed" })]),
-			reconciliation: { complete: false, reason: "pagination_malformed" },
+			diagnostics: expect.arrayContaining([
+				expect.objectContaining({ reason: "missing_runtime_turn", gate_id: "bad-runtime" }),
+				expect.objectContaining({ reason: "unsupported_gate", gate_id: "unsupported" }),
+			]),
+			reconciliation: { complete: true, reason: null },
 		});
-		expect(second).toMatchObject({ questions: [], reconciliation: { complete: false } });
+		expect(second).toMatchObject({ questions: [], reconciliation: { complete: true, reason: null } });
 	});
 
 	it("does not fabricate stale questions from incomplete or paginated Q12 observations", async () => {


### PR DESCRIPTION
## Summary

- decode canonical Coordinator MCP ask gates from `deep-interview`, `ralplan`, and `ultragoal`
- keep Q12 page validation focused on bounded JSON transport shape so malformed rows receive row-level diagnostics
- unwrap the SDK result envelope before evaluating `workflow.gate_answer` resolution
- add regression coverage and an Unreleased changelog entry

This is the fresh `dev`-base replacement requested after #3233 was closed for targeting `main`. The bugs remain reproducible against current `dev`.

## Root cause

`decodeAskGateV1` accepted only `deep-interview`, so valid Ralplan and Ultragoal question gates were excluded. The Q12 snapshot boundary then classified that semantic row failure as `pagination_malformed`.

Separately, the answer path read `status` from the outer SDK response rather than the inner `result` payload. The SDK could accept and advance the gate while Coordinator returned `terminal_uncertain`.

## Changes

- accept every canonical workflow stage in the ask-gate codec
- validate Q12 completed pages for bounded serialization at the page boundary
- retain `missing_runtime_turn` and `unsupported_gate` diagnostics in the per-row reconciliation path
- reuse `sdkResultPayload` for prompt acknowledgements and gate-answer receipts
- exercise a Ralplan gate and the real `{ ok, result: { status } }` response envelope

## Verification on current `dev`

```text
bun test packages/coding-agent/test/coordinator-mcp-question-codec.test.ts \
  packages/coding-agent/test/coordinator-mcp-server.test.ts

56 pass
0 fail
276 expect()
```

```text
bun --cwd=packages/coding-agent run check
Checked 2371 files. No fixes applied.
tsc -p tsconfig.json --noEmit
```

`git diff --check` passes.

A live Coordinator MCP smoke test also returned an accepted `workflow.gate_answer` receipt and allowed the Ralplan session to continue.

Fixes #3232

## Out of scope

The separate lifecycle/root observations recorded in #3232—restart orphan reconciliation, runtime completion versus durable active state, and sibling-worktree artifact roots—are not changed here.
