### PR TITLE
test: update selector resume fixture

### DIFF
--- a/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
@@ -114,8 +114,10 @@ function createContext(currentSessionFile: string): {
 			}),
 			removeChild: vi.fn(function (this: { children: unknown[] }, child: unknown) {
 				this.children = this.children.filter(candidate => candidate !== child);
+				(child as { dispose?: () => void }).dispose?.();
 			}),
 			clear: vi.fn(function (this: { children: unknown[] }) {
+				for (const child of this.children) (child as { dispose?: () => void }).dispose?.();
 				this.children = [];
 				calls.push("statusContainer.clear");
 			}),

--- a/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
@@ -79,6 +79,8 @@ function createContext(currentSessionFile: string): {
 			requestRender: vi.fn(() => {
 				calls.push("ui.requestRender");
 			}),
+			requestRenderWithGeneration: vi.fn(() => 1),
+			waitForRenderCommit: vi.fn(async () => true),
 			resetViewportAnchorIntent: vi.fn(() => {
 				calls.push("ui.resetViewportAnchorIntent");
 			}),
@@ -106,7 +108,15 @@ function createContext(currentSessionFile: string): {
 			}),
 		},
 		statusContainer: {
-			clear: vi.fn(() => {
+			children: [] as unknown[],
+			addChild: vi.fn(function (this: { children: unknown[] }, child: unknown) {
+				this.children.push(child);
+			}),
+			removeChild: vi.fn(function (this: { children: unknown[] }, child: unknown) {
+				this.children = this.children.filter(candidate => candidate !== child);
+			}),
+			clear: vi.fn(function (this: { children: unknown[] }) {
+				this.children = [];
 				calls.push("statusContainer.clear");
 			}),
 		},
@@ -256,7 +266,9 @@ describe("SelectorController session deletion", () => {
 		await controller.handleResumeSession(legacyPath);
 
 		expect(prepareManagedCandidateForStrictAdoption).toHaveBeenCalledWith(legacyPath, "copy-retain", identity);
-		expect(switchSession).toHaveBeenCalledWith(migratedPath);
+		expect(switchSession).toHaveBeenCalledWith(migratedPath, {
+			transition: { origin: "interactive_selector_resume" },
+		});
 	});
 
 	it("keeps explicit selections out of the managed migration fence", async () => {
@@ -271,7 +283,9 @@ describe("SelectorController session deletion", () => {
 
 		expect(inspection).not.toHaveBeenCalled();
 		expect(prepareManagedCandidateForStrictAdoption).not.toHaveBeenCalled();
-		expect(switchSession).toHaveBeenCalledWith(explicitPath);
+		expect(switchSession).toHaveBeenCalledWith(explicitPath, {
+			transition: { origin: "interactive_selector_resume" },
+		});
 	});
 
 	it("does not switch after a managed replacement race rejects the inspected identity", async () => {


### PR DESCRIPTION
Fixes the post-merge Dev CI failure on abdec47d (run 30223401626, shard 5). The selector resume tests had a stale InteractiveModeContext fixture after resume progress rendering and transition attribution landed: statusContainer lacked child mounting, TUI render-generation methods were absent, and switchSession expectations omitted the interactive_selector_resume transition.\n\nVerification: bun test packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts (10 pass, 0 fail).