### PR TITLE
fix(resume): fail open progress lease on minimal statusContainer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Interactive `/resume` no longer awaits ordinary notification-endpoint rotation after predecessor fencing when the transition is stamped `interactive_selector_resume`; lifecycle/SDK identity-control paths still await readiness and use a fail-closed control-drain orchestration that sends terminal control outcomes only after successor readiness, while uncertain predecessor stop no longer starts the successor (#2914).
 - Interactive TUI `/resume` commits a status-container progress lease before inspect/migration/switch work and clears it on every exit path, with generation-scoped render-commit wait that fails open when the terminal is stopped or unavailable (#2914).
+- Interactive `/resume` progress lease fails open when `statusContainer` or UI lacks child-mutation/render-commit surface, preserving headless/minimal controller contexts without weakening full TUI progress-before-switch (#3234 post-merge).
 
 ### Added
 

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -97,30 +97,86 @@ export interface ResumeProgressLease {
  * Mount a resume loader on the live status rail and wait for its render generation
  * to commit before session I/O begins. The commit is advisory: a stopped or
  * unavailable terminal resolves false and callers continue without blocking.
+ *
+ * Fail open (no-op lease, committed=false) when the status rail or UI lacks the
+ * child-mutation/render-commit surface required to mount progress. Headless and
+ * minimal controller contexts keep resume/migration semantics; full interactive
+ * TUI containers retain progress-before-switch.
  */
 export function acquireResumeProgressLease(
 	ctx: Pick<InteractiveModeContext, "ui" | "statusContainer">,
 ): ResumeProgressLease {
+	if (!canMountResumeProgressLease(ctx)) {
+		return {
+			committed: Promise.resolve(false),
+			clear(): void {},
+		};
+	}
+
+	const statusContainer = ctx.statusContainer as ResumeProgressStatusSurface;
+	const ui = ctx.ui as ResumeProgressUiSurface;
 	const loader = new Loader(
-		ctx.ui,
+		ui,
 		spinner => theme?.fg?.("accent", spinner) ?? spinner,
 		message => theme?.fg?.("muted", message) ?? message,
 		"Resuming session…",
 	);
-	ctx.statusContainer.addChild(loader);
-	const generation = ctx.ui.requestRenderWithGeneration(false, "resume-progress");
+	statusContainer.addChild(loader);
+	const generation = ui.requestRenderWithGeneration(false, "resume-progress");
 	let active = true;
-	const committed = ctx.ui.waitForRenderCommit(generation, RESUME_PROGRESS_COMMIT_TIMEOUT_MS).catch(() => false);
+	const committed = ui.waitForRenderCommit(generation, RESUME_PROGRESS_COMMIT_TIMEOUT_MS).catch(() => false);
 	return {
 		committed,
 		clear(): void {
 			if (!active) return;
 			active = false;
-			if (ctx.statusContainer.children.includes(loader)) ctx.statusContainer.removeChild(loader);
+			if (statusContainer.children.includes(loader)) statusContainer.removeChild(loader);
 			else loader.stop();
-			ctx.ui.requestRender(false, "resume-progress-clear");
+			ui.requestRender(false, "resume-progress-clear");
 		},
 	};
+}
+
+type ResumeProgressStatusSurface = {
+	addChild: (child: Component) => void;
+	removeChild: (child: Component) => void;
+	children: Component[];
+};
+
+type ResumeProgressUiSurface = InteractiveModeContext["ui"] & {
+	requestRenderWithGeneration: (force?: boolean, source?: string) => number;
+	waitForRenderCommit: (generation: number, timeoutMs?: number) => Promise<boolean>;
+	requestRender: (force?: boolean, source?: string) => void;
+};
+
+function canMountResumeProgressLease(ctx: Pick<InteractiveModeContext, "ui" | "statusContainer">): boolean {
+	const status = ctx.statusContainer as
+		| Partial<{
+				addChild: unknown;
+				removeChild: unknown;
+				children: unknown;
+		  }>
+		| null
+		| undefined;
+	const ui = ctx.ui as
+		| Partial<{
+				requestRenderWithGeneration: unknown;
+				waitForRenderCommit: unknown;
+				requestRender: unknown;
+		  }>
+		| null
+		| undefined;
+
+	return (
+		!!status &&
+		typeof status.addChild === "function" &&
+		typeof status.removeChild === "function" &&
+		Array.isArray(status.children) &&
+		!!ui &&
+		typeof ui.requestRenderWithGeneration === "function" &&
+		typeof ui.waitForRenderCommit === "function" &&
+		typeof ui.requestRender === "function"
+	);
 }
 type TextBlock = { type: "text"; text: string };
 interface RenderInitialMessagesOptions {

--- a/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
@@ -256,7 +256,7 @@ describe("SelectorController session deletion", () => {
 		await controller.handleResumeSession(legacyPath);
 
 		expect(prepareManagedCandidateForStrictAdoption).toHaveBeenCalledWith(legacyPath, "copy-retain", identity);
-		expect(switchSession).toHaveBeenCalledWith(migratedPath);
+		expect(switchSession).toHaveBeenCalledWith(migratedPath, expect.any(Object));
 	});
 
 	it("keeps explicit selections out of the managed migration fence", async () => {
@@ -271,7 +271,7 @@ describe("SelectorController session deletion", () => {
 
 		expect(inspection).not.toHaveBeenCalled();
 		expect(prepareManagedCandidateForStrictAdoption).not.toHaveBeenCalled();
-		expect(switchSession).toHaveBeenCalledWith(explicitPath);
+		expect(switchSession).toHaveBeenCalledWith(explicitPath, expect.any(Object));
 	});
 
 	it("does not switch after a managed replacement race rejects the inspected identity", async () => {

--- a/packages/coding-agent/test/resume-progress-lease.test.ts
+++ b/packages/coding-agent/test/resume-progress-lease.test.ts
@@ -4,6 +4,7 @@ import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 import { SelectorController } from "../src/modes/controllers/selector-controller";
 import { initTheme } from "../src/modes/theme/theme";
 import type { InteractiveModeContext } from "../src/modes/types";
+import { acquireResumeProgressLease } from "../src/modes/utils/ui-helpers";
 
 beforeAll(() => initTheme());
 function deferred<T>(): { promise: Promise<T>; resolve(value: T): void; reject(error: unknown): void } {
@@ -73,5 +74,113 @@ describe("resume progress lease", () => {
 		expect(session.switchSession).toHaveBeenCalledWith("/tmp/target.jsonl", expect.any(Object));
 
 		ui.stop();
+	});
+
+	it("fails open when statusContainer lacks child mutation surface", async () => {
+		const switchSession = vi.fn(async () => true);
+		const statusContainer = {
+			clear: vi.fn(),
+			// Intentionally omit addChild/removeChild/children — legacy/minimal fixtures.
+		};
+		const ui = {
+			requestRender: vi.fn(),
+			requestRenderWithGeneration: vi.fn(() => 1),
+			waitForRenderCommit: vi.fn(async () => true),
+		};
+		const lease = acquireResumeProgressLease({
+			ui,
+			statusContainer,
+		} as unknown as Pick<InteractiveModeContext, "ui" | "statusContainer">);
+
+		expect(await lease.committed).toBe(false);
+		expect(ui.requestRenderWithGeneration).not.toHaveBeenCalled();
+		lease.clear();
+		expect(statusContainer.clear).not.toHaveBeenCalled();
+
+		const context = {
+			ui,
+			statusContainer,
+			loadingAnimation: undefined,
+			pendingMessagesContainer: { clear: vi.fn() },
+			compactionQueuedMessages: [],
+			streamingComponent: undefined,
+			streamingMessage: undefined,
+			pendingTools: new Map(),
+			session: { switchSession },
+			settings: { get: () => undefined },
+			sessionManager: {
+				getSessionId: () => "before",
+				isManagedDestination: () => false,
+				getSessionName: () => undefined,
+				getCwd: () => "/tmp",
+			},
+			resetIrcSidebarSession: vi.fn(),
+			updateEditorBorderColor: vi.fn(),
+			rebuildInitialMessages: vi.fn(),
+			reloadTodos: vi.fn(async () => undefined),
+			showStatus: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(context);
+
+		await expect(controller.handleResumeSession("/tmp/target.jsonl")).resolves.toBeUndefined();
+		expect(switchSession).toHaveBeenCalledWith("/tmp/target.jsonl", expect.any(Object));
+		expect(context.showStatus).toHaveBeenCalledWith("Resumed session");
+		expect(ui.requestRenderWithGeneration).not.toHaveBeenCalled();
+	});
+
+	it("fails open when statusContainer is only partially implemented", async () => {
+		const children: unknown[] = [];
+		const statusContainer = {
+			children,
+			addChild: vi.fn((child: unknown) => {
+				children.push(child);
+			}),
+			// Missing removeChild — partial surface must not mount either.
+			clear: vi.fn(),
+		};
+		const ui = {
+			requestRender: vi.fn(),
+			requestRenderWithGeneration: vi.fn(() => 1),
+			waitForRenderCommit: vi.fn(async () => true),
+		};
+
+		const lease = acquireResumeProgressLease({
+			ui,
+			statusContainer,
+		} as unknown as Pick<InteractiveModeContext, "ui" | "statusContainer">);
+
+		expect(await lease.committed).toBe(false);
+		expect(statusContainer.addChild).not.toHaveBeenCalled();
+		expect(ui.requestRenderWithGeneration).not.toHaveBeenCalled();
+		lease.clear();
+		expect(children).toHaveLength(0);
+	});
+
+	it("fails open when UI lacks render-commit surface", async () => {
+		const children: unknown[] = [];
+		const statusContainer = {
+			children,
+			addChild: vi.fn((child: unknown) => {
+				children.push(child);
+			}),
+			removeChild: vi.fn((child: unknown) => {
+				const index = children.indexOf(child);
+				if (index >= 0) children.splice(index, 1);
+			}),
+		};
+		const ui = {
+			// Legacy fixtures often only expose requestRender.
+			requestRender: vi.fn(),
+		};
+
+		const lease = acquireResumeProgressLease({
+			ui,
+			statusContainer,
+		} as unknown as Pick<InteractiveModeContext, "ui" | "statusContainer">);
+
+		expect(await lease.committed).toBe(false);
+		expect(statusContainer.addChild).not.toHaveBeenCalled();
+		lease.clear();
+		expect(children).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## Summary

Post-merge dev red after #3226 (run 30223401626, shard-5): six `SelectorController session deletion` tests crashed in `handleResumeSession` because `acquireResumeProgressLease` from #3234 assumes a full TUI `statusContainer` (`addChild`/`removeChild`/`children`) plus generation-scoped render-commit APIs.

This is a **production compatibility** fix, not fixture papering:

- Probe for the required child-mutation + render-commit surface.
- Fail open with a no-op lease (`committed=false`) when missing so headless/minimal contexts keep resume/migration/switch semantics.
- Preserve the full interactive progress-before-switch guarantee when the complete TUI surface exists.

## Root cause

`#3234` progress lease mounts a status-rail loader before inspect/migration/switch. Legacy/minimal controller fixtures (and any incomplete container) only expose `statusContainer.clear` / plain `requestRender`, so `addChild` threw before the managed race/migration path ran.

## Changes

- `acquireResumeProgressLease`: capability probe + fail-open no-op lease
- Focused regressions: missing `statusContainer` methods, partial surface, missing render-commit UI APIs
- Session-deletion suite retained; two `switchSession` assertions include the interactive resume transition origin already stamped by product
- Changelog note under Unreleased

## Test plan

- [x] `bun test packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts`
- [x] `bun test packages/coding-agent/test/resume-progress-lease.test.ts`
- [x] `bun test packages/tui/test/render-commit.test.ts`
- [x] Affected selector/viewport suites (session-selector-delete, command-palette, resume-confirm, welcome-viewport, completion-viewport)
- [x] `bun run --cwd packages/coding-agent check`
- [x] `bun run --cwd packages/tui check`
- [x] `git diff --check`

## Merge notes

- Dev-base repair only; no unrelated merge
- Exact head: branch tip must stay green before merge
- Serialize merge while post-#3226 shard-5 is red