### PR TITLE
fix(tools): accept JSON-string asks and recover NNBSP screenshot paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Fixed
 
+- The `ask` tool no longer rejects a JSON-string-encoded single-sided Round 0 payload before coercion; only the retired contract+review pair stays terminal, so a provider that serializes `questions` as a string no longer drives the model into an unbounded retry loop.
+- macOS screenshot paths now recover the narrow no-break space before `AM`/`PM` for any following separator, so IDE-attached files such as `Screenshot … 11.23.30 PM-1785075812409.png` resolve instead of failing with `ENOENT`; word continuations like ` PMX` are left untouched.
 - Interactive `/resume` no longer awaits ordinary notification-endpoint rotation after predecessor fencing when the transition is stamped `interactive_selector_resume`; lifecycle/SDK identity-control paths still await readiness and use a fail-closed control-drain orchestration that sends terminal control outcomes only after successor readiness, while uncertain predecessor stop no longer starts the successor (#2914).
 - Interactive TUI `/resume` commits a status-container progress lease before inspect/migration/switch work and clears it on every exit path, with generation-scoped render-commit wait that fails open when the terminal is stopped or unavailable (#2914).
 - Interactive `/resume` progress lease fails open when `statusContainer` or UI lacks child-mutation/render-commit surface, preserving headless/minimal controller contexts without weakening full TUI progress-before-switch (#3234 post-merge).

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -351,15 +351,23 @@ function parseEncodedContainer(value: unknown): unknown {
 function isRoundZeroRecoveryCandidate(value: unknown): boolean {
 	const root = parseEncodedContainer(value);
 	if (typeof root !== "object" || root === null || !Object.hasOwn(root, "questions")) return false;
-	const questionsValue = parseEncodedContainer((root as Record<string, unknown>).questions);
+	const rawQuestions = (root as Record<string, unknown>).questions;
+	const questionsValue = parseEncodedContainer(rawQuestions);
 	if (!Array.isArray(questionsValue)) return questionsValue === null;
+	const rootEncoded = typeof value === "string" || typeof rawQuestions === "string";
 	return questionsValue.some(rawQuestion => {
 		const question = parseEncodedContainer(rawQuestion);
 		if (typeof question !== "object" || question === null || !Object.hasOwn(question, "deepInterview")) return false;
-		const deepInterview = parseEncodedContainer((question as Record<string, unknown>).deepInterview);
+		const rawDeepInterview = (question as Record<string, unknown>).deepInterview;
+		const deepInterview = parseEncodedContainer(rawDeepInterview);
 		if (typeof deepInterview !== "object" || deepInterview === null) return false;
 		const metadata = deepInterview as Record<string, unknown>;
-		return Object.hasOwn(metadata, "intent_contract") || Object.hasOwn(metadata, "intent_review");
+		const hasContract = Object.hasOwn(metadata, "intent_contract");
+		const hasReview = Object.hasOwn(metadata, "intent_review");
+		// A JSON-string container is terminal only for the retired contract+review
+		// pair; canonical single-sided asks stay eligible for generic JSON coercion.
+		const encoded = rootEncoded || typeof rawQuestion === "string" || typeof rawDeepInterview === "string";
+		return encoded ? hasContract && hasReview : hasContract || hasReview;
 	});
 }
 

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -33,7 +33,11 @@ function normalizeUnicodeSpaces(str: string): string {
 }
 
 function tryMacOSScreenshotPath(filePath: string): string {
-	return filePath.replace(/ (AM|PM)\./g, `${NARROW_NO_BREAK_SPACE}$1.`);
+	// macOS writes a narrow no-break space before AM/PM, but the model normalizes it
+	// to a plain space. The original name is not always `…PM.png`: attachment paths
+	// append a timestamp (`…PM-1785075812409.png`), so match any non-alphanumeric
+	// separator or end of segment rather than a literal dot.
+	return filePath.replace(/ (AM|PM)(?=[^A-Za-z0-9/]|$)/g, `${NARROW_NO_BREAK_SPACE}$1`);
 }
 
 function tryNFDVariant(filePath: string): string {

--- a/packages/coding-agent/test/file-mentions.test.ts
+++ b/packages/coding-agent/test/file-mentions.test.ts
@@ -84,6 +84,31 @@ describe("generateFileMentionMessages path resolution", () => {
 	});
 });
 
+describe("resolveReadPath macOS screenshot recovery", () => {
+	const NNBSP = "\u202f";
+
+	test("recovers the narrow no-break space before AM/PM for any following separator", async () => {
+		const cwd = await createTempDir();
+		const cases = [
+			`Screenshot 2026-07-26 at 11.23.30${NNBSP}PM.png`,
+			`Screenshot 2026-07-26 at 11.23.31${NNBSP}PM-1785075812409.png`,
+			`Screenshot 2026-07-26 at 11.23.32${NNBSP}AM_2.png`,
+		];
+		for (const name of cases) {
+			await Bun.write(path.join(cwd, name), "x");
+			// The model normalizes NNBSP to a plain space before the tool sees the path.
+			const typed = path.join(cwd, name.replace(NNBSP, " "));
+			expect(resolveReadPath(typed, cwd)).toBe(path.join(cwd, name));
+		}
+	});
+
+	test("leaves a plain-space path alone when AM/PM is part of a longer word", async () => {
+		const cwd = await createTempDir();
+		const typed = path.join(cwd, "a PMX.png");
+		expect(resolveReadPath(typed, cwd)).toBe(typed);
+	});
+});
+
 describe("generateFileMentionMessages duplicate suppression + inline cap (Finding 5)", () => {
 	function files(messages: Awaited<ReturnType<typeof generateFileMentionMessages>>) {
 		const m = messages[0];

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -3481,4 +3481,29 @@ describe("AskTool Round-0 intent recovery", () => {
 			deepInterview: { intent_review: expect.any(Object) },
 		});
 	});
+
+	it("coerces JSON-string containers for single-sided deep-interview asks", () => {
+		const contractOnly = roundZeroPair();
+		Reflect.deleteProperty(contractOnly.questions[0].deepInterview, "intent_review");
+		const encodedQuestions = { questions: JSON.stringify(contractOnly.questions) } as unknown as Record<
+			string,
+			unknown
+		>;
+		expect(validateAsk(encodedQuestions).questions[0]).toMatchObject({
+			deepInterview: { intent_contract: expect.any(Object) },
+		});
+
+		const postRoundReview = roundZeroPair();
+		Reflect.deleteProperty(postRoundReview.questions[0].deepInterview, "intent_contract");
+		postRoundReview.questions[0].deepInterview.round = 1;
+		postRoundReview.questions[0].deepInterview.component = "locked-intent";
+		postRoundReview.questions[0].deepInterview.dimension = "constraints";
+		const encodedReview = { questions: JSON.stringify(postRoundReview.questions) } as unknown as Record<
+			string,
+			unknown
+		>;
+		expect(validateAsk(encodedReview, "post-topology").questions[0]).toMatchObject({
+			deepInterview: { intent_review: expect.any(Object) },
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- `ask` no longer rejects a JSON-string-encoded single-sided Round 0 payload before coercion. `isRoundZeroRecoveryCandidate` treated any encoded container carrying `intent_contract` **or** `intent_review` as terminal, but only the retired contract+review *pair* should be. A provider that serialized `questions` as a string therefore had every canonical ask refused ahead of the generic JSON-container coercion, and the model retried indefinitely. Encoded containers are now terminal only when both intent shapes are present; the unencoded path is unchanged.
- macOS screenshot paths now recover the narrow no-break space before `AM`/`PM` for any following separator. `tryMacOSScreenshotPath` matched ` (AM|PM)\.` — a literal dot only. macOS writes U+202F before AM/PM and the model normalizes it to a plain space, so recovery worked for `…11.23.30 PM.png` but not for the IDE attachment form `…11.23.30 PM-1785075812409.png`, which failed to stat. The pattern now accepts any non-alphanumeric separator or segment end while leaving word continuations such as ` PMX` untouched.

## Verification

- `bun test packages/coding-agent/test/tools/ask.test.ts packages/coding-agent/test/file-mentions.test.ts` (100 pass)
- `bun x tsc --noEmit -p packages/coding-agent/tsconfig.json` (0 errors)
- `git diff --check origin/dev..HEAD`
