### PR TITLE
fix(utils): honor documented GJC_BASH_NO_CI / GJC_BASH_NO_LOGIN / GJC_SHELL_PREFIX

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Strict CLI commands now reject unexpected positional arguments with usage guidance instead of silently ignoring typos or unsupported trailing input; non-strict passthrough commands and variadic arguments retain their existing behavior (#3173).
 - Integer CLI flags now reject trailing characters, decimals, exponent notation, surrounding whitespace, and values outside JavaScript's safe-integer range instead of silently truncating or rounding them (#3172).
+- The documented `GJC_BASH_NO_CI`, `GJC_BASH_NO_LOGIN`, and `GJC_SHELL_PREFIX` environment variables now take effect for the spawn shell configuration; they are resolved GJC-first ahead of the legacy `PI_`/`CLAUDE_` aliases (previously only the legacy names were read, so setting the documented GJC name was a silent no-op). Adds `resetShellConfigCache()` for deterministic shell-config testing.
 
 ## [0.11.10] - 2026-07-25
 

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -43,7 +43,7 @@ function isExecutable(path: string): boolean {
  * Build the spawn environment (cached).
  */
 function buildSpawnEnv(shell: string): Record<string, string> {
-	const noCI = $env.PI_BASH_NO_CI || $env.CLAUDE_BASH_NO_CI;
+	const noCI = $env.GJC_BASH_NO_CI || $env.PI_BASH_NO_CI || $env.CLAUDE_BASH_NO_CI;
 	const inherited = filterProcessEnv(Bun.env);
 	delete inherited.GJC_SESSION_FILE;
 	delete inherited.GJC_MANAGED_OWNER_TRANSCRIPT_PATH;
@@ -60,10 +60,10 @@ function buildSpawnEnv(shell: string): Record<string, string> {
 
 /**
  * Get shell args, optionally including login shell flag.
- * Supports PI_BASH_NO_LOGIN and ANTHROPIC_MODEL_BASH_NO_LOGIN to skip -l.
+ * Supports GJC_BASH_NO_LOGIN (PI_BASH_NO_LOGIN / ANTHROPIC_MODEL_BASH_NO_LOGIN legacy aliases) to skip -l.
  */
 function getShellArgs(): string[] {
-	const noLogin = $env.PI_BASH_NO_LOGIN || $env.CLAUDE_BASH_NO_LOGIN;
+	const noLogin = $env.GJC_BASH_NO_LOGIN || $env.PI_BASH_NO_LOGIN || $env.CLAUDE_BASH_NO_LOGIN;
 	return noLogin ? ["-c"] : ["-l", "-c"];
 }
 
@@ -71,7 +71,7 @@ function getShellArgs(): string[] {
  * Get shell prefix for wrapping commands (profilers, strace, etc.).
  */
 function getShellPrefix(): string | undefined {
-	return $env.PI_SHELL_PREFIX || $env.CLAUDE_CODE_SHELL_PREFIX;
+	return $env.GJC_SHELL_PREFIX || $env.PI_SHELL_PREFIX || $env.CLAUDE_CODE_SHELL_PREFIX;
 }
 
 /**
@@ -185,6 +185,15 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 	}
 	cachedShellConfig = buildConfig("sh");
 	return cachedShellConfig;
+}
+
+/**
+ * Clear the memoized shell configuration so the next {@link getShellConfig}
+ * call re-resolves the shell and re-reads the environment (shell-selection and
+ * bash CI/login/prefix knobs). Primarily for tests that vary those inputs.
+ */
+export function resetShellConfigCache(): void {
+	cachedShellConfig = null;
 }
 
 /**

--- a/packages/utils/test/shell-config-env.test.ts
+++ b/packages/utils/test/shell-config-env.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { getShellConfig, resetShellConfigCache } from "../src/procmgr";
+
+// Env knobs read by the shell config, plus CI which the spawn env would
+// otherwise inherit and confound the GJC_BASH_NO_CI assertion.
+const KEYS = [
+	"GJC_BASH_NO_CI",
+	"PI_BASH_NO_CI",
+	"CLAUDE_BASH_NO_CI",
+	"GJC_BASH_NO_LOGIN",
+	"PI_BASH_NO_LOGIN",
+	"CLAUDE_BASH_NO_LOGIN",
+	"GJC_SHELL_PREFIX",
+	"PI_SHELL_PREFIX",
+	"CLAUDE_CODE_SHELL_PREFIX",
+	"CI",
+] as const;
+
+const saved = new Map<string, string | undefined>();
+
+beforeEach(() => {
+	for (const key of KEYS) {
+		saved.set(key, Bun.env[key]);
+		delete Bun.env[key];
+	}
+	resetShellConfigCache();
+});
+
+afterEach(() => {
+	for (const [key, value] of saved) {
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+	}
+	resetShellConfigCache();
+});
+
+describe("getShellConfig honors documented GJC_ bash/shell knobs", () => {
+	it("adds CI=true by default", () => {
+		expect(getShellConfig().env.CI).toBe("true");
+	});
+
+	it("GJC_BASH_NO_CI suppresses CI=true (documented name honored)", () => {
+		Bun.env.GJC_BASH_NO_CI = "1";
+		resetShellConfigCache();
+		expect(getShellConfig().env.CI).toBeUndefined();
+	});
+
+	it("legacy PI_BASH_NO_CI still suppresses CI=true", () => {
+		Bun.env.PI_BASH_NO_CI = "1";
+		resetShellConfigCache();
+		expect(getShellConfig().env.CI).toBeUndefined();
+	});
+
+	it("uses a login shell by default", () => {
+		expect(getShellConfig().args).toEqual(["-l", "-c"]);
+	});
+
+	it("GJC_BASH_NO_LOGIN drops the login flag", () => {
+		Bun.env.GJC_BASH_NO_LOGIN = "1";
+		resetShellConfigCache();
+		expect(getShellConfig().args).toEqual(["-c"]);
+	});
+
+	it("has no shell prefix by default", () => {
+		expect(getShellConfig().prefix).toBeUndefined();
+	});
+
+	it("honors GJC_SHELL_PREFIX", () => {
+		Bun.env.GJC_SHELL_PREFIX = "strace -f";
+		resetShellConfigCache();
+		expect(getShellConfig().prefix).toBe("strace -f");
+	});
+
+	it("resolves GJC-first: GJC_SHELL_PREFIX wins over legacy PI_SHELL_PREFIX", () => {
+		Bun.env.GJC_SHELL_PREFIX = "gjc-prefix";
+		Bun.env.PI_SHELL_PREFIX = "pi-prefix";
+		resetShellConfigCache();
+		expect(getShellConfig().prefix).toBe("gjc-prefix");
+	});
+});


### PR DESCRIPTION
## What

`docs/environment-variables.md` documents `GJC_BASH_NO_CI`, `GJC_BASH_NO_LOGIN`, and `GJC_SHELL_PREFIX`, but the spawn shell config in `packages/utils/src/procmgr.ts` only read the legacy `PI_`/`CLAUDE_` names:

- `buildSpawnEnv`: `PI_BASH_NO_CI || CLAUDE_BASH_NO_CI`
- `getShellArgs`: `PI_BASH_NO_LOGIN || CLAUDE_BASH_NO_LOGIN`
- `getShellPrefix`: `PI_SHELL_PREFIX || CLAUDE_CODE_SHELL_PREFIX`

So setting the documented GJC names was a silent no-op.

## Fix

Resolve each GJC name **first**, keeping the `PI_`/`CLAUDE_` names as backward-compatible fallbacks. Same class as the merged GJC_* migrations (#2827 / #2943 / #3041); this completes the deferred bash/shell part noted as a follow-up in #3041. Inline `||` prepends preserve exact semantics (no `$pickenv` trim/empty-string drift) and add no new imports.

## Tests

Adds `resetShellConfigCache()` (mirrors the `clearResolvedChainCache` precedent) so the memoized shell config can be re-derived across env variations, and a focused `shell-config-env.test.ts` covering: default `CI=true` / login-shell / no-prefix, each GJC knob taking effect (`GJC_BASH_NO_CI` suppresses `CI`, `GJC_BASH_NO_LOGIN` drops `-l`, `GJC_SHELL_PREFIX` sets the prefix), the legacy `PI_` fallback, and GJC-first precedence over `PI_`. 8 pass / 0 fail; utils `tsc` + `biome` clean.