### PR TITLE
feat(providers): rank existing and well-known providers first in /model, /login, /provider

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Added
 
 - Deterministic tests for session_switch await policy (selector defer vs default/branch await), control-drain ordering, host pre-response readiness gating, and resume progress lease-before-switch behavior (#2914).
+- Telegram per-tool activity is now opt-in and remains durably controllable with `/toolactivity on|off` or the Notifications preferences UI; disabling it suppresses tool start/completion success and error bubbles without hiding assistant, ask, or session notifications.
+- `/model`, `/login`, and `/provider` now order providers through one shared ranking: providers you already have (valid auth, in-flight validation, or a configured non-OAuth provider) come first, then providers whose stored credentials failed validation, then a curated list of well-known providers with regional and device variants grouped behind their primary, then everything else by display name. In `/model` rows, role/default rank and recent usage still take precedence over provider order (#3243).
 
 ### Added
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2507,6 +2507,13 @@ export class ModelRegistry {
 		return this.#keylessProviders.has(model.provider) || this.authStorage.hasAuth(model.provider);
 	}
 
+	/**
+	 * Check whether auth is configured for a provider.
+	 */
+	hasConfiguredProviderAuth(provider: string): boolean {
+		return this.#keylessProviders.has(provider) || this.authStorage.hasAuth(provider);
+	}
+
 	getDiscoverableProviders(): string[] {
 		const disabledProviders = getDisabledProviderIdsFromSettings();
 		return this.#discoveryManager.providers

--- a/packages/coding-agent/src/config/provider-auth-health.ts
+++ b/packages/coding-agent/src/config/provider-auth-health.ts
@@ -1,0 +1,42 @@
+import type { AuthStorage } from "@gajae-code/ai/auth-storage";
+
+/**
+ * Most recent OAuth validation outcome per provider, used only as an ordering
+ * hint so `/model` can rank a provider whose stored credentials failed
+ * validation below one that is healthy, without re-running validation itself.
+ *
+ * Entries are scoped to the `AuthStorage` that produced them and to its
+ * credential generation, so any login, logout, import, or deletion discards the
+ * stale result instead of overriding current auth state.
+ */
+export type ProviderAuthHealth = "valid" | "invalid";
+
+interface HealthEntry {
+	generation: number;
+	health: ProviderAuthHealth;
+}
+
+const healthByStorage = new WeakMap<AuthStorage, Map<string, HealthEntry>>();
+
+export function recordProviderAuthHealth(
+	authStorage: AuthStorage,
+	providerId: string,
+	health: ProviderAuthHealth,
+): void {
+	let entries = healthByStorage.get(authStorage);
+	if (!entries) {
+		entries = new Map();
+		healthByStorage.set(authStorage, entries);
+	}
+	entries.set(providerId, { generation: authStorage.getGeneration(), health });
+}
+
+export function getProviderAuthHealth(authStorage: AuthStorage, providerId: string): ProviderAuthHealth | undefined {
+	const entry = healthByStorage.get(authStorage)?.get(providerId);
+	if (!entry || entry.generation !== authStorage.getGeneration()) return undefined;
+	return entry.health;
+}
+
+export function clearProviderAuthHealth(authStorage: AuthStorage): void {
+	healthByStorage.delete(authStorage);
+}

--- a/packages/coding-agent/src/config/provider-ranking.ts
+++ b/packages/coding-agent/src/config/provider-ranking.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared provider ordering used by every provider-facing selector (`/login`,
+ * `/model`, `/provider`).
+ *
+ * Providers the user already has come first, then a curated list of well-known
+ * providers, then everything else alphabetically. This is the single source of
+ * truth for that order — surfaces must not keep their own famous-provider list.
+ */
+
+/**
+ * Auth/config state of a provider as seen by the calling surface.
+ *
+ * - `valid` — stored credentials that validated successfully.
+ * - `checking` — stored credentials whose async validation is still in flight.
+ *   Ranked with `valid` so rows do not reflow when validation resolves.
+ * - `configured` — no OAuth record, but the provider is present in the model
+ *   registry with a working API key (custom/API-compatible providers).
+ * - `invalid` — stored credentials that failed validation (problematic login).
+ * - `none` — nothing stored and nothing configured.
+ */
+export type ProviderAuthState = "valid" | "checking" | "configured" | "invalid" | "none";
+
+export const PROVIDER_RANK_TIER = {
+	existing: 0,
+	problematic: 1,
+	famous: 2,
+	other: 3,
+} as const;
+
+export type ProviderRankTier = (typeof PROVIDER_RANK_TIER)[keyof typeof PROVIDER_RANK_TIER];
+
+/**
+ * Curated provider order for the famous tier. Regional and device variants sit
+ * immediately behind their primary so related entries stay grouped.
+ */
+export const FAMOUS_PROVIDER_ORDER: readonly string[] = [
+	"openai-codex",
+	"openai-codex-device",
+	"anthropic",
+	"xai",
+	"opencode-go",
+	"zai",
+	"glm-zcode",
+	"alibaba-token-plan",
+	"qwen-portal",
+	"kimi-code",
+	"moonshot",
+	"minimax-code",
+	"minimax-code-cn",
+	"xiaomi",
+	"xiaomi-token-plan-sgp",
+	"xiaomi-token-plan-ams",
+	"xiaomi-token-plan-cn",
+	"opengateway",
+	"github-copilot",
+	"cursor",
+];
+
+const FAMOUS_PROVIDER_INDEX = new Map(FAMOUS_PROVIDER_ORDER.map((id, index) => [id, index]));
+
+/** A provider as ranked by a surface. `label` is what the user sees. */
+export interface RankableProvider {
+	id: string;
+	label: string;
+	authState: ProviderAuthState;
+}
+
+/** A provider's position in the ordering: its tier plus its rank inside that tier. */
+export interface ProviderRank {
+	tier: ProviderRankTier;
+	intraTierRank: number;
+}
+
+/**
+ * The single ranking result for a provider. `intraTierRank` is the curated
+ * famous-list position, or `Number.MAX_SAFE_INTEGER` for providers that are not
+ * on the list and therefore order by display label.
+ */
+export function rankProvider(provider: RankableProvider): ProviderRank {
+	return {
+		tier: providerRankTier(provider.authState, provider.id),
+		intraTierRank: FAMOUS_PROVIDER_INDEX.get(provider.id) ?? Number.MAX_SAFE_INTEGER,
+	};
+}
+
+export function providerRankTier(authState: ProviderAuthState, id: string): ProviderRankTier {
+	if (authState === "valid" || authState === "checking" || authState === "configured") {
+		return PROVIDER_RANK_TIER.existing;
+	}
+	if (authState === "invalid") return PROVIDER_RANK_TIER.problematic;
+	return FAMOUS_PROVIDER_INDEX.has(id) ? PROVIDER_RANK_TIER.famous : PROVIDER_RANK_TIER.other;
+}
+
+/** Position within the famous list, or `undefined` for providers not on it. */
+export function famousProviderIndex(id: string): number | undefined {
+	return FAMOUS_PROVIDER_INDEX.get(id);
+}
+
+/**
+ * Total order over providers: tier, then famous-list position, then display
+ * label, then id. The trailing id comparison guarantees no ties.
+ */
+export function compareRankedProviders(left: RankableProvider, right: RankableProvider): number {
+	const leftRank = rankProvider(left);
+	const rightRank = rankProvider(right);
+	if (leftRank.tier !== rightRank.tier) return leftRank.tier - rightRank.tier;
+	if (leftRank.intraTierRank !== rightRank.intraTierRank) return leftRank.intraTierRank - rightRank.intraTierRank;
+
+	const label = left.label.localeCompare(right.label);
+	if (label !== 0) return label;
+
+	return left.id.localeCompare(right.id);
+}
+
+/** Convenience wrapper returning a new array in ranked order. */
+export function sortRankedProviders<T extends RankableProvider>(providers: readonly T[]): T[] {
+	return [...providers].sort(compareRankedProviders);
+}

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -31,6 +31,8 @@ import {
 } from "../../config/model-resolver";
 import { type ModelSelectorValue, normalizeModelSelectorValue, selectorHead } from "../../config/model-selector-value";
 import type { ModelProfileConfig } from "../../config/models-config-schema";
+import { getProviderAuthHealth } from "../../config/provider-auth-health";
+import { compareRankedProviders, type ProviderAuthState } from "../../config/provider-ranking";
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 import { formatModelOnboardingInlineHint } from "../../setup/model-onboarding-guidance";
@@ -542,10 +544,22 @@ export class ModelSelectorComponent extends Container {
 		this.#applyTabFilter();
 	}
 
+	#resolveProviderAuthState(providerId: string): ProviderAuthState {
+		const health = getProviderAuthHealth(this.#modelRegistry.authStorage, providerId);
+		if (health) return health;
+		return this.#modelRegistry.hasConfiguredProviderAuth(providerId) ? "configured" : "none";
+	}
+
 	#sortModels(models: ModelItem[]): void {
-		// Sort: default-tagged model first, then MRU, then alphabetical
+		// Sort: default-tagged model first, then MRU, then provider ranking
 		const mruOrder = this.#settings.getStorage()?.getModelUsageOrder() ?? [];
 		const mruIndex = new Map(mruOrder.map((key, i) => [key, i]));
+		const providerAuthStateById = new Map<string, ProviderAuthState>();
+		for (const item of models) {
+			if (!providerAuthStateById.has(item.provider)) {
+				providerAuthStateById.set(item.provider, this.#resolveProviderAuthState(item.provider));
+			}
+		}
 
 		const modelRank = (item: ModelItem) => computeModelRank(item.model, this.#roles);
 
@@ -566,7 +580,18 @@ export class ModelSelectorComponent extends Container {
 			if (aMru !== bMru) return aMru - bMru;
 
 			// By provider, then recency within provider
-			const providerCmp = a.provider.localeCompare(b.provider);
+			const providerCmp = compareRankedProviders(
+				{
+					id: a.provider,
+					label: a.provider,
+					authState: providerAuthStateById.get(a.provider) ?? "none",
+				},
+				{
+					id: b.provider,
+					label: b.provider,
+					authState: providerAuthStateById.get(b.provider) ?? "none",
+				},
+			);
 			if (providerCmp !== 0) return providerCmp;
 
 			// Priority field (lower = better, e.g. OpenAI code backend priority values)
@@ -608,6 +633,12 @@ export class ModelSelectorComponent extends Container {
 	#sortCanonicalModels(models: CanonicalModelItem[]): void {
 		const mruOrder = this.#settings.getStorage()?.getModelUsageOrder() ?? [];
 		const mruIndex = new Map(mruOrder.map((key, i) => [key, i]));
+		const providerAuthStateById = new Map<string, ProviderAuthState>();
+		for (const item of models) {
+			if (!providerAuthStateById.has(item.model.provider)) {
+				providerAuthStateById.set(item.model.provider, this.#resolveProviderAuthState(item.model.provider));
+			}
+		}
 
 		const modelRank = (item: CanonicalModelItem) => computeModelRank(item.model, this.#roles);
 
@@ -620,7 +651,18 @@ export class ModelSelectorComponent extends Container {
 			const bMru = mruIndex.get(`${b.model.provider}/${b.model.id}`) ?? Number.MAX_SAFE_INTEGER;
 			if (aMru !== bMru) return aMru - bMru;
 
-			const providerCmp = a.model.provider.localeCompare(b.model.provider);
+			const providerCmp = compareRankedProviders(
+				{
+					id: a.model.provider,
+					label: a.model.provider,
+					authState: providerAuthStateById.get(a.model.provider) ?? "none",
+				},
+				{
+					id: b.model.provider,
+					label: b.model.provider,
+					authState: providerAuthStateById.get(b.model.provider) ?? "none",
+				},
+			);
 			if (providerCmp !== 0) return providerCmp;
 
 			return a.id.localeCompare(b.id);
@@ -735,8 +777,23 @@ export class ModelSelectorComponent extends Container {
 		for (const provider of this.#modelRegistry.getDiscoverableProviders()) {
 			providerSet.add(provider);
 		}
+		const providerAuthStateById = new Map<string, ProviderAuthState>();
+		for (const provider of providerSet) {
+			providerAuthStateById.set(provider, this.#resolveProviderAuthState(provider));
+		}
 		const sortedProviderIds = Array.from(providerSet).sort((left, right) =>
-			formatProviderTabLabel(left).localeCompare(formatProviderTabLabel(right)),
+			compareRankedProviders(
+				{
+					id: left,
+					label: formatProviderTabLabel(left),
+					authState: providerAuthStateById.get(left) ?? "none",
+				},
+				{
+					id: right,
+					label: formatProviderTabLabel(right),
+					authState: providerAuthStateById.get(right) ?? "none",
+				},
+			),
 		);
 		this.#providers = [...STATIC_PROVIDER_TABS, ...sortedProviderIds.map(createProviderTab)];
 		const activeIndex = this.#providers.findIndex(tab => tab.id === activeTabId);

--- a/packages/coding-agent/src/modes/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/components/oauth-selector.ts
@@ -1,6 +1,8 @@
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import type { OAuthProviderInfo } from "@gajae-code/ai/utils/oauth/types";
 import { Container, matchesKey, Spacer, TruncatedText } from "@gajae-code/tui";
+import { recordProviderAuthHealth } from "../../config/provider-auth-health";
+import { compareRankedProviders, type ProviderAuthState } from "../../config/provider-ranking";
 import { theme } from "../../modes/theme/theme";
 import { matchesSelectCancel } from "../../modes/utils/keybinding-matchers";
 import type { AuthStorage } from "../../session/auth-storage";
@@ -14,6 +16,7 @@ const OAUTH_SELECTOR_MAX_VISIBLE = 10;
 export class OAuthSelectorComponent extends Container {
 	#listContainer: Container;
 	#allProviders: OAuthProviderInfo[] = [];
+	#sortedProviders: OAuthProviderInfo[] = [];
 	#selectedIndex: number = 0;
 	#mode: "login" | "logout";
 	#authStorage: AuthStorage;
@@ -91,7 +94,7 @@ export class OAuthSelectorComponent extends Container {
 			}
 			this.#authState.set(provider.id, "checking");
 			pending += 1;
-			void this.#validateProvider(provider.id, generation);
+			void this.#validateProvider(provider.id, generation, this.#authStorage.getGeneration());
 		}
 
 		if (pending > 0) {
@@ -101,7 +104,7 @@ export class OAuthSelectorComponent extends Container {
 		}
 	}
 
-	async #validateProvider(providerId: string, generation: number): Promise<void> {
+	async #validateProvider(providerId: string, generation: number, authGeneration: number): Promise<void> {
 		if (!this.#validateAuthCallback) return;
 		let isValid = false;
 		try {
@@ -112,6 +115,11 @@ export class OAuthSelectorComponent extends Container {
 
 		if (generation !== this.#validationGeneration) return;
 		this.#authState.set(providerId, isValid ? "valid" : "invalid");
+		// Only record the ordering hint when the credentials validated are still the
+		// current ones; a result from a superseded generation must not describe them.
+		if (authGeneration === this.#authStorage.getGeneration()) {
+			recordProviderAuthHealth(this.#authStorage, providerId, isValid ? "valid" : "invalid");
+		}
 		if (![...this.#authState.values()].includes("checking")) {
 			this.#stopSpinner();
 		}
@@ -138,6 +146,10 @@ export class OAuthSelectorComponent extends Container {
 		}
 	}
 
+	#getProviderAuthState(providerId: string): ProviderAuthState {
+		return this.#authState.get(providerId) ?? "none";
+	}
+
 	#getStatusIndicator(providerId: string): string {
 		const state = this.#authState.get(providerId);
 		if (state === "checking") {
@@ -154,9 +166,25 @@ export class OAuthSelectorComponent extends Container {
 		return this.#authStorage.hasAuth(providerId) ? theme.fg("success", ` ${theme.status.success} logged in`) : "";
 	}
 	#updateList(): void {
+		const selectedProviderId = this.#sortedProviders[this.#selectedIndex]?.id;
+		const rankedProviders = this.#allProviders.map(provider => ({
+			provider,
+			id: provider.id,
+			label: provider.name,
+			authState: this.#getProviderAuthState(provider.id),
+		}));
+		rankedProviders.sort(compareRankedProviders);
+		this.#sortedProviders = rankedProviders.map(({ provider }) => provider);
+		if (selectedProviderId !== undefined) {
+			const selectedIndex = this.#sortedProviders.findIndex(provider => provider.id === selectedProviderId);
+			if (selectedIndex >= 0) this.#selectedIndex = selectedIndex;
+		}
+		if (this.#selectedIndex >= this.#sortedProviders.length) {
+			this.#selectedIndex = Math.max(0, this.#sortedProviders.length - 1);
+		}
 		this.#listContainer.clear();
 
-		const total = this.#allProviders.length;
+		const total = this.#sortedProviders.length;
 		const maxVisible = OAUTH_SELECTOR_MAX_VISIBLE;
 		const startIndex =
 			total <= maxVisible
@@ -165,7 +193,7 @@ export class OAuthSelectorComponent extends Container {
 		const endIndex = Math.min(startIndex + maxVisible, total);
 
 		for (let i = startIndex; i < endIndex; i++) {
-			const provider = this.#allProviders[i];
+			const provider = this.#sortedProviders[i];
 			if (!provider) continue;
 			const isSelected = i === this.#selectedIndex;
 			const isAvailable = provider.available;
@@ -218,23 +246,25 @@ export class OAuthSelectorComponent extends Container {
 	handleInput(keyData: string): void {
 		// Up arrow
 		if (matchesKey(keyData, "up")) {
-			if (this.#allProviders.length > 0) {
-				this.#selectedIndex = this.#selectedIndex === 0 ? this.#allProviders.length - 1 : this.#selectedIndex - 1;
+			if (this.#sortedProviders.length > 0) {
+				this.#selectedIndex =
+					this.#selectedIndex === 0 ? this.#sortedProviders.length - 1 : this.#selectedIndex - 1;
 			}
 			this.#statusMessage = undefined;
 			this.#updateList();
 		}
 		// Down arrow
 		else if (matchesKey(keyData, "down")) {
-			if (this.#allProviders.length > 0) {
-				this.#selectedIndex = this.#selectedIndex === this.#allProviders.length - 1 ? 0 : this.#selectedIndex + 1;
+			if (this.#sortedProviders.length > 0) {
+				this.#selectedIndex =
+					this.#selectedIndex === this.#sortedProviders.length - 1 ? 0 : this.#selectedIndex + 1;
 			}
 			this.#statusMessage = undefined;
 			this.#updateList();
 		}
 		// Page up - jump up by one visible page
 		else if (matchesKey(keyData, "pageUp")) {
-			if (this.#allProviders.length > 0) {
+			if (this.#sortedProviders.length > 0) {
 				this.#selectedIndex = Math.max(0, this.#selectedIndex - OAUTH_SELECTOR_MAX_VISIBLE);
 			}
 			this.#statusMessage = undefined;
@@ -242,9 +272,9 @@ export class OAuthSelectorComponent extends Container {
 		}
 		// Page down - jump down by one visible page
 		else if (matchesKey(keyData, "pageDown")) {
-			if (this.#allProviders.length > 0) {
+			if (this.#sortedProviders.length > 0) {
 				this.#selectedIndex = Math.min(
-					this.#allProviders.length - 1,
+					this.#sortedProviders.length - 1,
 					this.#selectedIndex + OAUTH_SELECTOR_MAX_VISIBLE,
 				);
 			}
@@ -253,7 +283,7 @@ export class OAuthSelectorComponent extends Container {
 		}
 		// Enter
 		else if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
-			const selectedProvider = this.#allProviders[this.#selectedIndex];
+			const selectedProvider = this.#sortedProviders[this.#selectedIndex];
 			if (selectedProvider?.available) {
 				this.#statusMessage = undefined;
 				this.stopValidation();

--- a/packages/coding-agent/src/setup/provider-onboarding.ts
+++ b/packages/coding-agent/src/setup/provider-onboarding.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { getAgentDbPath, getAgentDir } from "@gajae-code/utils";
 import { YAML } from "bun";
 import { type ModelsConfig, ModelsConfigSchema } from "../config/models-config-schema";
+import { compareRankedProviders, famousProviderIndex } from "../config/provider-ranking";
 import { AuthStorage } from "../session/auth-storage";
 import providerPresets from "./provider-presets.json";
 
@@ -81,11 +82,25 @@ export function findProviderPreset(value: string | undefined): ProviderPreset | 
 	return PROVIDER_PRESETS.find(preset => preset.id === normalized || preset.aliases.includes(normalized));
 }
 
+function providerPresetRankingId(preset: ProviderPreset): string {
+	return (
+		[preset.providerId, preset.id, ...preset.aliases].find(id => famousProviderIndex(id) !== undefined) ?? preset.id
+	);
+}
+
 export function formatProviderPresetList(): string {
-	return PROVIDER_PRESETS.map(preset => {
-		const aliases = preset.aliases.length > 0 ? ` (aliases: ${preset.aliases.join(", ")})` : "";
-		return `${preset.id}${aliases}: ${preset.description}`;
-	}).join("\n");
+	return [...PROVIDER_PRESETS]
+		.sort((left, right) =>
+			compareRankedProviders(
+				{ id: providerPresetRankingId(left), label: left.name, authState: "none" },
+				{ id: providerPresetRankingId(right), label: right.name, authState: "none" },
+			),
+		)
+		.map(preset => {
+			const aliases = preset.aliases.length > 0 ? ` (aliases: ${preset.aliases.join(", ")})` : "";
+			return `${preset.id}${aliases}: ${preset.description}`;
+		})
+		.join("\n");
 }
 
 export function parseModelList(values: readonly string[]): string[] {

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -76,6 +76,7 @@ function createRegistry(profiles: Iterable<[string, ModelProfileDefinition]> = [
 		getError: () => undefined,
 		getAvailable: () => [...models],
 		getAll: () => [...models],
+		hasConfiguredProviderAuth: () => false,
 		getProviders: () => [],
 		getCanonicalModels: () => [],
 		getDiscoverableProviders: () => [],

--- a/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
+++ b/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
@@ -34,6 +34,7 @@ async function createSelector(state: ProviderDiscoveryState): Promise<ModelSelec
 		getError: () => undefined,
 		getAvailable: () => [],
 		getAll: () => [],
+		hasConfiguredProviderAuth: () => false,
 		getDiscoverableProviders: () => [state.provider],
 		getCanonicalModels: () => [],
 		resolveCanonicalModel: () => undefined,

--- a/packages/coding-agent/test/keybindings-escape-components.test.ts
+++ b/packages/coding-agent/test/keybindings-escape-components.test.ts
@@ -77,6 +77,7 @@ describe("component escape bindings", () => {
 		});
 		const modelRegistry = {
 			getAll: () => [model],
+			hasConfiguredProviderAuth: () => false,
 			getDiscoverableProviders: () => [],
 			getCanonicalModels: () => [],
 			resolveCanonicalModel: () => undefined,

--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -128,6 +128,7 @@ function createRegistry(
 			...builtinCodexModels,
 			...builtinComboModels,
 		],
+		hasConfiguredProviderAuth: (provider: string) => authenticatedProviders.includes(provider),
 		getDiscoverableProviders: () => [],
 		getCanonicalModels: () => [],
 		resolveCanonicalModel: () => undefined,

--- a/packages/coding-agent/test/model-selector-batch-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-batch-thinking.test.ts
@@ -40,6 +40,7 @@ function createSelector(
 ): ModelSelectorComponent {
 	const modelRegistry = {
 		getAll: () => [model],
+		hasConfiguredProviderAuth: () => false,
 		getDiscoverableProviders: () => [],
 		getCanonicalModels: () => [],
 		resolveCanonicalModel: () => undefined,

--- a/packages/coding-agent/test/model-selector-controller-batch.test.ts
+++ b/packages/coding-agent/test/model-selector-controller-batch.test.ts
@@ -41,6 +41,7 @@ function createControllerContext() {
 			getAvailable: () => [selectedModel],
 			refresh: vi.fn(async () => {}),
 			getAll: () => [selectedModel],
+			hasConfiguredProviderAuth: () => false,
 			getError: () => undefined,
 			getCanonicalModels: () => [],
 			getDiscoverableProviders: () => [],

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -48,6 +48,7 @@ function createRegistry(options: { profiles?: ModelProfileDefinition[]; missingC
 		getError: () => undefined,
 		getAvailable: () => [defaultModel, alternateModel, flatModel],
 		getAll: () => [defaultModel, alternateModel, flatModel],
+		hasConfiguredProviderAuth: () => false,
 		getDiscoverableProviders: () => [],
 		getCanonicalModels: () => [],
 		resolveCanonicalModel: () => undefined,

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -54,6 +54,7 @@ function createRegistry(options: { missingCredentials?: boolean } = {}) {
 		getError: () => undefined,
 		getAvailable: () => [defaultModel, alternateModel],
 		getAll: () => [defaultModel, alternateModel],
+		hasConfiguredProviderAuth: () => false,
 		getDiscoverableProviders: () => [],
 		getCanonicalModels: () => [],
 		resolveCanonicalModel: () => undefined,

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -58,6 +58,7 @@ function createSelector(
 		options.modelRegistry ??
 		({
 			getAll: () => [model],
+			hasConfiguredProviderAuth: () => false,
 			getDiscoverableProviders: () => [],
 			getCanonicalModels: () => [],
 			resolveCanonicalModel: () => undefined,
@@ -382,6 +383,7 @@ describe("ModelSelector canonical model selection", () => {
 		const selectorValue = `${model.provider}/${model.id}`;
 		const modelRegistry = {
 			getAll: () => [model],
+			hasConfiguredProviderAuth: () => false,
 			getDiscoverableProviders: () => [],
 			getCanonicalModels: () => [
 				{
@@ -430,6 +432,7 @@ describe("ModelSelector canonical model selection", () => {
 		});
 		const modelRegistry = {
 			getAll: () => availableModels,
+			hasConfiguredProviderAuth: () => false,
 			refresh: vi.fn(async () => {}),
 			refreshProvider,
 			getError: () => undefined,
@@ -741,6 +744,7 @@ function createFastSelector(args: {
 	const isFastForSubagentProvider = args.isFastForSubagentProvider ?? isFastForProvider;
 	const modelRegistry = {
 		getAll: () => models,
+		hasConfiguredProviderAuth: () => false,
 		getDiscoverableProviders: () => [],
 		getCanonicalModels: () => [],
 		resolveCanonicalModel: () => undefined,

--- a/packages/coding-agent/test/oauth-selector-validation-race.redteam.test.ts
+++ b/packages/coding-agent/test/oauth-selector-validation-race.redteam.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, test, vi } from "bun:test";
+import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
+import { clearProviderAuthHealth, getProviderAuthHealth } from "@gajae-code/coding-agent/config/provider-auth-health";
+import { OAuthSelectorComponent } from "@gajae-code/coding-agent/modes/components/oauth-selector";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+
+let testTheme = await getThemeByName("red-claw");
+
+function installTestTheme(): void {
+	if (!testTheme) throw new Error("Failed to load red-claw test theme");
+	setThemeInstance(testTheme);
+}
+
+function stripAnsi(value: string): string {
+	return value.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function renderedText(selector: OAuthSelectorComponent): string {
+	installTestTheme();
+	return selector.render(240).map(stripAnsi).join("\n");
+}
+
+function requireProvider(providerId: string) {
+	const provider = getOAuthProviders().find(candidate => candidate.id === providerId);
+	if (!provider) throw new Error(`Expected OAuth provider ${providerId}`);
+	return provider;
+}
+
+async function flushValidation(): Promise<void> {
+	await Bun.sleep(0);
+	await Bun.sleep(0);
+}
+
+beforeEach(async () => {
+	testTheme = await getThemeByName("red-claw");
+	installTestTheme();
+});
+
+describe("OAuth selector validation generation race", () => {
+	test("drops a stale invalid result after the AuthStorage generation changes", async () => {
+		const provider = requireProvider("anthropic");
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey(provider.id, "initial-key");
+		const validation = Promise.withResolvers<boolean>();
+		let selector: OAuthSelectorComponent | undefined;
+
+		try {
+			const generationBeforeValidation = authStorage.getGeneration();
+			selector = new OAuthSelectorComponent(
+				"login",
+				authStorage,
+				() => {},
+				() => {},
+				{ validateAuth: async () => validation.promise, requestRender: vi.fn() },
+			);
+			await Bun.sleep(0);
+			expect(renderedText(selector)).toContain("checking");
+
+			authStorage.setRuntimeApiKey(provider.id, "new-generation-key");
+			expect(authStorage.getGeneration()).toBeGreaterThan(generationBeforeValidation);
+			validation.resolve(false);
+			await validation.promise;
+			await flushValidation();
+
+			expect(getProviderAuthHealth(authStorage, provider.id)).toBeUndefined();
+			expect(renderedText(selector)).not.toContain("checking");
+		} finally {
+			selector?.dispose();
+			clearProviderAuthHealth(authStorage);
+			authStorage.close();
+		}
+	});
+
+	test("records a fresh invalid result when the AuthStorage generation is unchanged", async () => {
+		const provider = requireProvider("anthropic");
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey(provider.id, "initial-key");
+		const validation = Promise.withResolvers<boolean>();
+		let selector: OAuthSelectorComponent | undefined;
+
+		try {
+			const generationBeforeValidation = authStorage.getGeneration();
+			selector = new OAuthSelectorComponent(
+				"login",
+				authStorage,
+				() => {},
+				() => {},
+				{ validateAuth: async () => validation.promise, requestRender: vi.fn() },
+			);
+			await Bun.sleep(0);
+			validation.resolve(false);
+			await validation.promise;
+			await flushValidation();
+
+			expect(authStorage.getGeneration()).toBe(generationBeforeValidation);
+			expect(getProviderAuthHealth(authStorage, provider.id)).toBe("invalid");
+			expect(renderedText(selector)).toContain("invalid");
+		} finally {
+			selector?.dispose();
+			clearProviderAuthHealth(authStorage);
+			authStorage.close();
+		}
+	});
+
+	test("records a fresh valid result when the AuthStorage generation is unchanged", async () => {
+		const provider = requireProvider("anthropic");
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey(provider.id, "initial-key");
+		const validation = Promise.withResolvers<boolean>();
+		let selector: OAuthSelectorComponent | undefined;
+
+		try {
+			const generationBeforeValidation = authStorage.getGeneration();
+			selector = new OAuthSelectorComponent(
+				"login",
+				authStorage,
+				() => {},
+				() => {},
+				{ validateAuth: async () => validation.promise, requestRender: vi.fn() },
+			);
+			await Bun.sleep(0);
+			validation.resolve(true);
+			await validation.promise;
+			await flushValidation();
+
+			expect(authStorage.getGeneration()).toBe(generationBeforeValidation);
+			expect(getProviderAuthHealth(authStorage, provider.id)).toBe("valid");
+			expect(renderedText(selector)).not.toContain("checking");
+		} finally {
+			selector?.dispose();
+			clearProviderAuthHealth(authStorage);
+			authStorage.close();
+		}
+	});
+
+	test("terminates the spinner when one provider is stale and another is fresh", async () => {
+		const providers = getOAuthProviders().slice(0, 2);
+		if (providers.length < 2) throw new Error("Expected at least two OAuth providers");
+		const [droppedProvider, freshProvider] = providers;
+		if (!droppedProvider || !freshProvider) throw new Error("Expected two OAuth providers");
+
+		const authStorage = await AuthStorage.create(":memory:");
+		for (const provider of providers) authStorage.setRuntimeApiKey(provider.id, `${provider.id}-initial-key`);
+		const validations = new Map(providers.map(provider => [provider.id, Promise.withResolvers<boolean>()]));
+		let selector: OAuthSelectorComponent | undefined;
+
+		try {
+			const generationBeforeValidation = authStorage.getGeneration();
+			selector = new OAuthSelectorComponent(
+				"login",
+				authStorage,
+				() => {},
+				() => {},
+				{
+					validateAuth: async providerId => {
+						const validation = validations.get(providerId);
+						if (!validation) throw new Error(`Unexpected provider validation: ${providerId}`);
+						// The first callback runs before the selector starts the second validation,
+						// so this mutation gives the two in-flight calls different auth generations.
+						if (providerId === droppedProvider.id) {
+							authStorage.setRuntimeApiKey(providerId, `${providerId}-new-generation-key`);
+						}
+						return validation.promise;
+					},
+					requestRender: vi.fn(),
+				},
+			);
+			await Bun.sleep(0);
+			expect(authStorage.getGeneration()).toBeGreaterThan(generationBeforeValidation);
+			expect(renderedText(selector)).toContain("checking");
+
+			validations.get(droppedProvider.id)?.resolve(false);
+			validations.get(freshProvider.id)?.resolve(true);
+			await Promise.all([...validations.values()].map(validation => validation.promise));
+			await flushValidation();
+
+			expect(getProviderAuthHealth(authStorage, droppedProvider.id)).toBeUndefined();
+			expect(getProviderAuthHealth(authStorage, freshProvider.id)).toBe("valid");
+			const rendered = renderedText(selector);
+			expect(rendered).not.toContain("checking");
+		} finally {
+			selector?.dispose();
+			clearProviderAuthHealth(authStorage);
+			authStorage.close();
+		}
+	});
+
+	test("keeps the selector-generation guard independent of AuthStorage generation", async () => {
+		const provider = requireProvider("anthropic");
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey(provider.id, "initial-key");
+		const validation = Promise.withResolvers<boolean>();
+		let selector: OAuthSelectorComponent | undefined;
+
+		try {
+			const generationBeforeValidation = authStorage.getGeneration();
+			selector = new OAuthSelectorComponent(
+				"login",
+				authStorage,
+				() => {},
+				() => {},
+				{ validateAuth: async () => validation.promise, requestRender: vi.fn() },
+			);
+			await Bun.sleep(0);
+			selector.stopValidation();
+			expect(authStorage.getGeneration()).toBe(generationBeforeValidation);
+			validation.resolve(false);
+			await validation.promise;
+			await flushValidation();
+
+			expect(getProviderAuthHealth(authStorage, provider.id)).toBeUndefined();
+		} finally {
+			selector?.dispose();
+			clearProviderAuthHealth(authStorage);
+			authStorage.close();
+		}
+	});
+});

--- a/packages/coding-agent/test/provider-auth-health-generation.redteam.test.ts
+++ b/packages/coding-agent/test/provider-auth-health-generation.redteam.test.ts
@@ -224,7 +224,6 @@ describe("generation-scoped provider auth health", () => {
 
 	test("returns undefined for a storage with no recorded entries", async () => {
 		const authStorage = await createAuthStorage();
-		expect(() => getProviderAuthHealth(authStorage, "never-recorded")).not.toThrow();
 		expect(getProviderAuthHealth(authStorage, "never-recorded")).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/provider-auth-health-generation.redteam.test.ts
+++ b/packages/coding-agent/test/provider-auth-health-generation.redteam.test.ts
@@ -1,0 +1,456 @@
+import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from "bun:test";
+import type { Model } from "@gajae-code/ai";
+import type { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import {
+	clearProviderAuthHealth,
+	getProviderAuthHealth,
+	recordProviderAuthHealth,
+} from "@gajae-code/coding-agent/config/provider-auth-health";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { AuthStorage, type AuthStorage as AuthStorageType } from "@gajae-code/coding-agent/session/auth-storage";
+import type { TUI } from "@gajae-code/tui";
+
+const model = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
+
+const apiKey = (key: string) => ({ type: "api_key" as const, key });
+const oauthCredential = (suffix: string) => ({
+	type: "oauth" as const,
+	access: `access-${suffix}`,
+	refresh: `refresh-${suffix}`,
+	expires: 0,
+	accountId: `account-${suffix}`,
+});
+
+let testTheme = await getThemeByName("red-claw");
+const trackedAuthStorages = new Set<AuthStorageType>();
+
+function installTestTheme(): void {
+	if (!testTheme) throw new Error("Failed to load red-claw test theme");
+	setThemeInstance(testTheme);
+}
+
+function stripAnsi(value: string): string {
+	return value.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function renderedLines(component: { render(width: number): string[] }): string[] {
+	installTestTheme();
+	return component.render(240).map(stripAnsi);
+}
+
+function modelRows(selector: ModelSelectorComponent, models: readonly Model[]): string[] {
+	const keys = models.map(candidate => `${candidate.provider}/${candidate.id}`).sort((a, b) => b.length - a.length);
+	return renderedLines(selector).flatMap(line => {
+		const normalized = line.trimStart().replace(/^❯\s+/, "");
+		const key = keys.find(candidate => normalized.startsWith(candidate));
+		return key ? [key] : [];
+	});
+}
+
+async function createAuthStorage(options: ConstructorParameters<typeof AuthStorage>[1] = {}): Promise<AuthStorageType> {
+	const authStorage = await AuthStorage.create(":memory:", options);
+	trackedAuthStorages.add(authStorage);
+	return authStorage;
+}
+
+type ProviderAuthSpy = Mock<(provider: string) => boolean>;
+
+function createModelRegistry(
+	models: readonly Model[],
+	authStorage: AuthStorageType,
+	configuredProviders: readonly string[] = [],
+): { registry: ModelRegistry; hasConfiguredProviderAuth: ProviderAuthSpy } {
+	const configured = new Set(configuredProviders);
+	const hasConfiguredProviderAuth = vi.fn(
+		(provider: string) => configured.has(provider) || authStorage.hasAuth(provider),
+	);
+	const registry = {
+		authStorage,
+		refresh: vi.fn(async () => {}),
+		refreshProvider: vi.fn(async () => {}),
+		getError: () => undefined,
+		getAvailable: () => [...models],
+		getAll: () => [...models],
+		hasConfiguredProviderAuth,
+		getDiscoverableProviders: () => [],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+		getModelProfiles: () => new Map(),
+		getApiKeyForProvider: async () => undefined,
+		getApiKey: async () => undefined,
+	} as unknown as ModelRegistry;
+	return { registry, hasConfiguredProviderAuth };
+}
+
+async function createModelSelector(
+	models: readonly Model[],
+	authStorage: AuthStorageType,
+	configuredProviders: readonly string[] = [],
+): Promise<{ selector: ModelSelectorComponent; registry: ModelRegistry; hasConfiguredProviderAuth: ProviderAuthSpy }> {
+	const { registry, hasConfiguredProviderAuth } = createModelRegistry(models, authStorage, configuredProviders);
+	const selector = new ModelSelectorComponent(
+		{ requestRender: vi.fn() } as unknown as TUI,
+		undefined,
+		Settings.isolated(),
+		registry,
+		[],
+		() => {},
+		() => {},
+		{ temporaryOnly: true },
+	);
+	await Bun.sleep(10);
+	return { selector, registry, hasConfiguredProviderAuth };
+}
+
+type GenerationObservation = {
+	method: string;
+	before: number;
+	after: number;
+	bumped: boolean;
+};
+
+async function observeGeneration(
+	method: string,
+	setup: ((authStorage: AuthStorageType) => void | Promise<void>) | undefined,
+	mutation: (authStorage: AuthStorageType) => void | Promise<void>,
+	options: ConstructorParameters<typeof AuthStorage>[1] = {},
+): Promise<GenerationObservation> {
+	const authStorage = await createAuthStorage(options);
+	if (setup) await setup(authStorage);
+	const before = authStorage.getGeneration();
+	await mutation(authStorage);
+	const after = authStorage.getGeneration();
+	return { method, before, after, bumped: after > before };
+}
+
+beforeEach(async () => {
+	testTheme = await getThemeByName("red-claw");
+	installTestTheme();
+});
+
+afterEach(() => {
+	for (const authStorage of trackedAuthStorages) {
+		clearProviderAuthHealth(authStorage);
+		authStorage.close();
+	}
+	trackedAuthStorages.clear();
+});
+
+describe("generation-scoped provider auth health", () => {
+	test("uses the new generation for a newer write and replaces the old provider entry", async () => {
+		const authStorage = await createAuthStorage();
+		const provider = "generation-race-provider";
+		const initialGeneration = authStorage.getGeneration();
+
+		recordProviderAuthHealth(authStorage, provider, "invalid");
+		expect(getProviderAuthHealth(authStorage, provider)).toBe("invalid");
+
+		// The first validation result is now stale. A real credential mutation creates
+		// the next generation before the newer validation result is recorded.
+		authStorage.setRuntimeApiKey(provider, "fresh-runtime-key");
+		expect(authStorage.getGeneration()).toBeGreaterThan(initialGeneration);
+		recordProviderAuthHealth(authStorage, provider, "valid");
+
+		expect(getProviderAuthHealth(authStorage, provider)).toBe("valid");
+		// A subsequent generation bump must invalidate the latest entry, not reveal the
+		// original invalid result that was replaced in the per-storage map.
+		authStorage.removeRuntimeApiKey(provider);
+		expect(getProviderAuthHealth(authStorage, provider)).toBeUndefined();
+	});
+
+	test("keeps generations strictly monotonic so an old entry cannot revive", async () => {
+		const authStorage = await createAuthStorage();
+		const provider = "monotonic-provider";
+		recordProviderAuthHealth(authStorage, provider, "valid");
+
+		const generations = [authStorage.getGeneration()];
+		await authStorage.set("stored-provider", apiKey("stored-key"));
+		generations.push(authStorage.getGeneration());
+		authStorage.setRuntimeApiKey("runtime-provider", "runtime-key");
+		generations.push(authStorage.getGeneration());
+		authStorage.removeRuntimeApiKey("runtime-provider");
+		generations.push(authStorage.getGeneration());
+		authStorage.setConfigApiKey("config-provider", "config-key");
+		generations.push(authStorage.getGeneration());
+		authStorage.removeConfigApiKey("config-provider");
+		generations.push(authStorage.getGeneration());
+		await authStorage.remove("stored-provider");
+		generations.push(authStorage.getGeneration());
+
+		for (let index = 1; index < generations.length; index += 1) {
+			expect(generations[index]).toBeGreaterThan(generations[index - 1]!);
+		}
+		expect(getProviderAuthHealth(authStorage, provider)).toBeUndefined();
+
+		// The entry is only visible again after an explicit write at the current
+		// generation; no earlier generation can become valid by arithmetic reversal.
+		recordProviderAuthHealth(authStorage, provider, "invalid");
+		expect(getProviderAuthHealth(authStorage, provider)).toBe("invalid");
+	});
+
+	test("invalidates only providers that were not revalidated after a bump", async () => {
+		const authStorage = await createAuthStorage();
+		const revalidatedProvider = "revalidated-provider";
+		const staleProvider = "stale-after-bump-provider";
+		recordProviderAuthHealth(authStorage, revalidatedProvider, "invalid");
+		recordProviderAuthHealth(authStorage, staleProvider, "valid");
+
+		authStorage.setRuntimeApiKey(revalidatedProvider, "revalidated-key");
+		recordProviderAuthHealth(authStorage, revalidatedProvider, "valid");
+
+		expect(getProviderAuthHealth(authStorage, revalidatedProvider)).toBe("valid");
+		expect(getProviderAuthHealth(authStorage, staleProvider)).toBeUndefined();
+	});
+
+	test("scopes health by AuthStorage identity even when generations match", async () => {
+		const [storageA, storageB] = await Promise.all([createAuthStorage(), createAuthStorage()]);
+		expect(storageA.getGeneration()).toBe(storageB.getGeneration());
+
+		recordProviderAuthHealth(storageA, "same-generation-provider", "valid");
+		expect(getProviderAuthHealth(storageA, "same-generation-provider")).toBe("valid");
+		expect(getProviderAuthHealth(storageB, "same-generation-provider")).toBeUndefined();
+
+		recordProviderAuthHealth(storageB, "same-generation-provider", "invalid");
+		clearProviderAuthHealth(storageA);
+		expect(getProviderAuthHealth(storageA, "same-generation-provider")).toBeUndefined();
+		expect(getProviderAuthHealth(storageB, "same-generation-provider")).toBe("invalid");
+
+		clearProviderAuthHealth(storageB);
+		expect(getProviderAuthHealth(storageB, "same-generation-provider")).toBeUndefined();
+	});
+
+	test("returns undefined for a storage with no recorded entries", async () => {
+		const authStorage = await createAuthStorage();
+		expect(() => getProviderAuthHealth(authStorage, "never-recorded")).not.toThrow();
+		expect(getProviderAuthHealth(authStorage, "never-recorded")).toBeUndefined();
+	});
+});
+
+describe("AuthStorage generation mutation inventory", () => {
+	test("empirically confirms the login/logout and credential mutation generation contract", async () => {
+		const observations = await Promise.all([
+			observeGeneration("setRuntimeApiKey", undefined, authStorage => {
+				authStorage.setRuntimeApiKey("runtime-provider", "runtime-key");
+			}),
+			observeGeneration(
+				"removeRuntimeApiKey",
+				authStorage => authStorage.setRuntimeApiKey("runtime-provider", "runtime-key"),
+				authStorage => authStorage.removeRuntimeApiKey("runtime-provider"),
+			),
+			observeGeneration("setConfigApiKey", undefined, authStorage => {
+				authStorage.setConfigApiKey("config-provider", "config-key");
+			}),
+			observeGeneration(
+				"removeConfigApiKey",
+				authStorage => authStorage.setConfigApiKey("config-provider", "config-key"),
+				authStorage => authStorage.removeConfigApiKey("config-provider"),
+			),
+			observeGeneration(
+				"clearConfigApiKeys",
+				authStorage => authStorage.setConfigApiKey("config-provider", "config-key"),
+				authStorage => authStorage.clearConfigApiKeys(),
+			),
+			observeGeneration("set", undefined, authStorage => authStorage.set("set-provider", apiKey("set-key"))),
+			observeGeneration("login", undefined, authStorage =>
+				authStorage.login("opencode-go", {
+					onAuth: () => {},
+					onPrompt: async () => "login-key",
+				}),
+			),
+			observeGeneration("importCredentialIfAbsent", undefined, async authStorage => {
+				await authStorage.importCredentialIfAbsent("import-provider", apiKey("import-key"));
+			}),
+			observeGeneration(
+				"remove",
+				authStorage => authStorage.set("remove-provider", apiKey("remove-key")),
+				authStorage => authStorage.remove("remove-provider"),
+			),
+			observeGeneration(
+				"logout",
+				authStorage => authStorage.set("logout-provider", apiKey("logout-key")),
+				authStorage => authStorage.logout("logout-provider"),
+			),
+			observeGeneration("upsertCredential", undefined, authStorage => {
+				authStorage.upsertCredential("upsert-provider", apiKey("upsert-key"));
+			}),
+			observeGeneration(
+				"disableCredentialById",
+				async authStorage => {
+					await authStorage.set("disable-provider", apiKey("disable-key"));
+				},
+				authStorage => {
+					const entry = authStorage
+						.exportSnapshot()
+						.credentials.find(item => item.provider === "disable-provider");
+					if (!entry) throw new Error("Expected credential to disable");
+					expect(authStorage.disableCredentialById(entry.id, "red-team disable")).toBe(true);
+				},
+			),
+			observeGeneration(
+				"refreshCredentialById",
+				async authStorage => {
+					await authStorage.set("refresh-provider", oauthCredential("refresh"));
+				},
+				async authStorage => {
+					const entry = authStorage
+						.exportSnapshot()
+						.credentials.find(item => item.provider === "refresh-provider");
+					if (!entry) throw new Error("Expected OAuth credential to refresh");
+					await authStorage.refreshCredentialById(entry.id);
+				},
+				{
+					refreshOAuthCredential: async (_provider, _id, credential) => ({
+						access: `${credential.access}-refreshed`,
+						refresh: `${credential.refresh}-refreshed`,
+						expires: Date.now() + 3_600_000,
+					}),
+				},
+			),
+			observeGeneration(
+				"forceRefreshCredentialById",
+				async authStorage => {
+					await authStorage.set("force-refresh-provider", oauthCredential("force-refresh"));
+				},
+				async authStorage => {
+					const entry = authStorage
+						.exportSnapshot()
+						.credentials.find(item => item.provider === "force-refresh-provider");
+					if (!entry) throw new Error("Expected OAuth credential to force-refresh");
+					await authStorage.forceRefreshCredentialById(entry.id);
+				},
+				{
+					refreshOAuthCredential: async (_provider, _id, credential) => ({
+						access: `${credential.access}-forced`,
+						refresh: `${credential.refresh}-forced`,
+						expires: Date.now() + 3_600_000,
+					}),
+				},
+			),
+			observeGeneration(
+				"forceRefreshOAuthCredential",
+				async authStorage => {
+					await authStorage.set("force-refresh-oauth-provider", oauthCredential("force-refresh-oauth"));
+				},
+				async authStorage => {
+					const credential = authStorage.getOAuthCredential("force-refresh-oauth-provider");
+					if (!credential) throw new Error("Expected OAuth credential to force-refresh by provider");
+					await authStorage.forceRefreshOAuthCredential("force-refresh-oauth-provider", credential);
+				},
+				{
+					refreshOAuthCredential: async (_provider, _id, credential) => ({
+						access: `${credential.access}-forced-by-provider`,
+						refresh: `${credential.refresh}-forced-by-provider`,
+						expires: Date.now() + 3_600_000,
+					}),
+				},
+			),
+		]);
+
+		const bumpingMethods = observations
+			.filter(observation => observation.bumped)
+			.map(observation => observation.method);
+		expect(bumpingMethods).toEqual([
+			"setRuntimeApiKey",
+			"removeRuntimeApiKey",
+			"setConfigApiKey",
+			"removeConfigApiKey",
+			"clearConfigApiKeys",
+			"set",
+			"login",
+			"importCredentialIfAbsent",
+			"remove",
+			"logout",
+			"upsertCredential",
+			"disableCredentialById",
+			"refreshCredentialById",
+			"forceRefreshCredentialById",
+			"forceRefreshOAuthCredential",
+		]);
+
+		// These are deliberately no-op/non-persistent paths, not credential deletion
+		// paths: a local SQLite invalidation only marks a request as blocked and reloads
+		// the unchanged row; reload alone also has no new credential snapshot.
+		const noBump = await observeGeneration(
+			"invalidateCredentialMatching (local active row)",
+			authStorage => authStorage.set("invalidate-provider", apiKey("invalidate-key")),
+			async authStorage => {
+				await authStorage.invalidateCredentialMatching("invalidate-provider", "invalidate-key");
+			},
+		);
+		expect(noBump.bumped).toBe(false);
+
+		const reload = await observeGeneration("reload (unchanged store)", undefined, authStorage =>
+			authStorage.reload(),
+		);
+		expect(reload.bumped).toBe(false);
+
+		const missingRemove = await observeGeneration("remove (missing provider)", undefined, authStorage =>
+			authStorage.remove("missing-remove-provider"),
+		);
+		expect(missingRemove.bumped).toBe(false);
+	});
+
+	test("does not bump for duplicate writes, but does bump for the first real mutation", async () => {
+		const authStorage = await createAuthStorage();
+		await authStorage.set("duplicate-provider", apiKey("same-key"));
+		const afterFirstSet = authStorage.getGeneration();
+		await authStorage.set("duplicate-provider", apiKey("same-key"));
+		expect(authStorage.getGeneration()).toBe(afterFirstSet);
+
+		const firstImport = await authStorage.importCredentialIfAbsent("import-duplicate-provider", apiKey("import-key"));
+		expect(firstImport.inserted).toBe(true);
+		const afterFirstImport = authStorage.getGeneration();
+		const secondImport = await authStorage.importCredentialIfAbsent(
+			"import-duplicate-provider",
+			apiKey("import-key-2"),
+		);
+		expect(secondImport.inserted).toBe(false);
+		expect(authStorage.getGeneration()).toBe(afterFirstImport);
+
+		const afterFirstUpsert = authStorage.getGeneration();
+		authStorage.upsertCredential("duplicate-provider", apiKey("same-key"));
+		expect(authStorage.getGeneration()).toBe(afterFirstUpsert);
+	});
+});
+
+describe("generation invalidation in visible model ranking", () => {
+	test("moves an invalid provider out of tier one after a real generation bump", async () => {
+		const authStorage = await createAuthStorage();
+		const invalidProvider = "generation-visible-invalid-provider";
+		const invalidModel = model(invalidProvider, "invalid-model");
+		const famousModel = model("anthropic", "famous-model");
+
+		recordProviderAuthHealth(authStorage, invalidProvider, "invalid");
+		const before = await createModelSelector([famousModel, invalidModel], authStorage);
+		try {
+			expect(modelRows(before.selector, [invalidModel, famousModel])).toEqual([
+				`${invalidProvider}/invalid-model`,
+				"anthropic/famous-model",
+			]);
+		} finally {
+			before.selector.dispose();
+		}
+
+		const generationBeforeMutation = authStorage.getGeneration();
+		authStorage.setRuntimeApiKey(invalidProvider, "temporary-key");
+		authStorage.removeRuntimeApiKey(invalidProvider);
+		expect(authStorage.getGeneration()).toBeGreaterThan(generationBeforeMutation);
+		expect(getProviderAuthHealth(authStorage, invalidProvider)).toBeUndefined();
+
+		const after = await createModelSelector([famousModel, invalidModel], authStorage);
+		try {
+			// The health hint is gone, so the provider falls back to `none` and the
+			// famous provider wins tier 2 ordering over this tier 3 provider.
+			expect(modelRows(after.selector, [invalidModel, famousModel])).toEqual([
+				"anthropic/famous-model",
+				`${invalidProvider}/invalid-model`,
+			]);
+			expect(after.hasConfiguredProviderAuth).toHaveBeenCalledWith(invalidProvider);
+		} finally {
+			after.selector.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/provider-auth-health.redteam.test.ts
+++ b/packages/coding-agent/test/provider-auth-health.redteam.test.ts
@@ -1,0 +1,418 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Model } from "@gajae-code/ai";
+import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import {
+	clearProviderAuthHealth,
+	getProviderAuthHealth,
+	recordProviderAuthHealth,
+} from "@gajae-code/coding-agent/config/provider-auth-health";
+import {
+	compareRankedProviders,
+	PROVIDER_RANK_TIER,
+	providerRankTier,
+	type RankableProvider,
+} from "@gajae-code/coding-agent/config/provider-ranking";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
+import { OAuthSelectorComponent } from "@gajae-code/coding-agent/modes/components/oauth-selector";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { AuthStorage, type AuthStorage as AuthStorageType } from "@gajae-code/coding-agent/session/auth-storage";
+import type { TUI } from "@gajae-code/tui";
+
+const model = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
+
+const PROBE_API_KEY_ENV = "GJC_REDTEAM_PROVIDER_AUTH_HEALTH_PROBE_KEY";
+
+let testTheme = await getThemeByName("red-claw");
+
+function installTestTheme(): void {
+	if (!testTheme) throw new Error("Failed to load test theme");
+	setThemeInstance(testTheme);
+}
+
+function stripAnsi(value: string): string {
+	return value.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function renderedLines(component: { render(width: number): string[] }): string[] {
+	installTestTheme();
+	return component.render(240).map(stripAnsi);
+}
+
+function modelRows(selector: ModelSelectorComponent, models: readonly Model[]): string[] {
+	const keys = models.map(candidate => `${candidate.provider}/${candidate.id}`).sort((a, b) => b.length - a.length);
+	return renderedLines(selector).flatMap(line => {
+		const normalized = line.trimStart().replace(/^❯\s+/, "");
+		const key = keys.find(candidate => normalized.startsWith(candidate));
+		return key ? [key] : [];
+	});
+}
+
+type AuthStorageDouble = Pick<AuthStorageType, "hasAuth" | "getGeneration">;
+type MutableAuthStorageDouble = AuthStorageType & { bumpGeneration(): void };
+
+const trackedAuthStorages = new Set<AuthStorageType>();
+
+function trackAuthStorage<T extends AuthStorageType>(authStorage: T): T {
+	trackedAuthStorages.add(authStorage);
+	return authStorage;
+}
+
+function clearTrackedProviderAuthHealth(): void {
+	for (const authStorage of trackedAuthStorages) clearProviderAuthHealth(authStorage);
+	trackedAuthStorages.clear();
+}
+
+function createAuthStorageDouble(authenticatedProviders: readonly string[] = []): MutableAuthStorageDouble {
+	let generation = 1;
+	const providers = new Set(authenticatedProviders);
+	const authStorage = {
+		hasAuth: (provider: string) => providers.has(provider),
+		getGeneration: () => generation,
+		bumpGeneration: () => {
+			generation += 1;
+		},
+	};
+	return trackAuthStorage(authStorage as unknown as AuthStorageType) as unknown as MutableAuthStorageDouble;
+}
+
+type ModelRegistryOptions = {
+	models: readonly Model[];
+	configuredProviders?: readonly string[];
+	authStorage?: AuthStorageDouble;
+};
+
+function createModelRegistry(options: ModelRegistryOptions): ModelRegistry {
+	const configuredProviders = new Set(options.configuredProviders ?? []);
+	const authStorage = options.authStorage ?? createAuthStorageDouble([...configuredProviders]);
+	trackAuthStorage(authStorage as unknown as AuthStorageType);
+	const hasConfiguredProviderAuth = vi.fn(
+		(provider: string) => configuredProviders.has(provider) || authStorage.hasAuth(provider),
+	);
+	return {
+		authStorage,
+		refresh: vi.fn(async () => {}),
+		refreshProvider: vi.fn(async () => {}),
+		getError: () => undefined,
+		getAvailable: () => [...options.models],
+		getAll: () => [...options.models],
+		hasConfiguredProviderAuth,
+		getDiscoverableProviders: () => [],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+		getModelProfiles: () => new Map(),
+		getApiKeyForProvider: async () => undefined,
+		getApiKey: async () => undefined,
+	} as unknown as ModelRegistry;
+}
+
+async function createModelSelector(
+	models: readonly Model[],
+	options: { registry?: ModelRegistry; configuredProviders?: readonly string[]; authStorage?: AuthStorageDouble } = {},
+): Promise<ModelSelectorComponent> {
+	const selector = new ModelSelectorComponent(
+		{ requestRender: vi.fn() } as unknown as TUI,
+		undefined,
+		Settings.isolated(),
+		options.registry ??
+			createModelRegistry({
+				models,
+				configuredProviders: options.configuredProviders,
+				authStorage: options.authStorage,
+			}),
+		[],
+		() => {},
+		() => {},
+		{ temporaryOnly: true },
+	);
+	await Bun.sleep(10);
+	return selector;
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+	const deadline = Date.now() + 2_000;
+	while (!condition() && Date.now() < deadline) await Bun.sleep(10);
+	expect(condition()).toBe(true);
+}
+
+beforeEach(async () => {
+	clearTrackedProviderAuthHealth();
+	testTheme = await getThemeByName("red-claw");
+	installTestTheme();
+});
+
+afterEach(() => {
+	clearTrackedProviderAuthHealth();
+});
+
+describe("provider auth health state attacks", () => {
+	test("records last-write-wins health and clear fully removes every entry", () => {
+		const authStorage = createAuthStorageDouble();
+		recordProviderAuthHealth(authStorage, "last-write", "invalid");
+		recordProviderAuthHealth(authStorage, "last-write", "valid");
+		recordProviderAuthHealth(authStorage, "other-entry", "invalid");
+
+		expect(getProviderAuthHealth(authStorage, "last-write")).toBe("valid");
+		expect(getProviderAuthHealth(authStorage, "other-entry")).toBe("invalid");
+
+		clearProviderAuthHealth(authStorage);
+		expect(getProviderAuthHealth(authStorage, "last-write")).toBeUndefined();
+		expect(getProviderAuthHealth(authStorage, "other-entry")).toBeUndefined();
+	});
+
+	test("uses Map-safe keys without prototype pollution", () => {
+		const authStorage = createAuthStorageDouble();
+		const ids = ["", "x".repeat(100_000), "零😀e\u0301", "__proto__", "constructor", "toString"];
+		const objectPrototypeKeysBefore = Reflect.ownKeys(Object.prototype);
+
+		for (const id of ids) {
+			recordProviderAuthHealth(authStorage, id, "valid");
+			expect(getProviderAuthHealth(authStorage, id)).toBe("valid");
+		}
+
+		expect(Reflect.ownKeys(Object.prototype)).toEqual(objectPrototypeKeysBefore);
+		expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
+		expect(Object.prototype.constructor).toBe(Object);
+		expect(Object.prototype.toString).toBe(Object.prototype.toString);
+
+		clearProviderAuthHealth(authStorage);
+		for (const id of ids) expect(getProviderAuthHealth(authStorage, id)).toBeUndefined();
+	});
+
+	test("isolates OAuth validation health between unrelated AuthStorage instances", async () => {
+		const target = getOAuthProviders().find(provider => provider.id === "cursor");
+		if (!target) throw new Error("Expected cursor OAuth provider");
+
+		const oauthStorage = trackAuthStorage(await AuthStorage.create(":memory:"));
+		const modelStorage = trackAuthStorage(await AuthStorage.create(":memory:"));
+		oauthStorage.setRuntimeApiKey(target.id, "oauth-test-key");
+		const oauthSelector = new OAuthSelectorComponent(
+			"login",
+			oauthStorage,
+			() => {},
+			() => {},
+			{ validateAuth: async () => false, requestRender: vi.fn() },
+		);
+
+		try {
+			await waitFor(() => getProviderAuthHealth(oauthStorage, target.id) === "invalid");
+			expect(getProviderAuthHealth(oauthStorage, target.id)).toBe("invalid");
+			expect(getProviderAuthHealth(modelStorage, target.id)).toBeUndefined();
+
+			const cursorModel = model("cursor", "cursor-model");
+			const anthropicModel = model("anthropic", "anthropic-model");
+			const selector = await createModelSelector([anthropicModel, cursorModel], { authStorage: modelStorage });
+			try {
+				// The model selector's storage has no validation hint, so famous-list order remains anthropic before cursor.
+				expect(modelRows(selector, [cursorModel, anthropicModel])).toEqual([
+					"anthropic/anthropic-model",
+					"cursor/cursor-model",
+				]);
+			} finally {
+				selector.dispose();
+			}
+		} finally {
+			oauthSelector.dispose();
+			modelStorage.close();
+			oauthStorage.close();
+		}
+	});
+
+	test("discards a valid hint after the AuthStorage generation changes", async () => {
+		const staleProvider = "stale-custom-provider";
+		const staleModel = model(staleProvider, "stale-model");
+		const famousModel = model("anthropic", "anthropic-model");
+		const authStorage = createAuthStorageDouble();
+		const registry = createModelRegistry({ models: [famousModel, staleModel], authStorage });
+
+		recordProviderAuthHealth(authStorage, staleProvider, "valid");
+		expect(getProviderAuthHealth(authStorage, staleProvider)).toBe("valid");
+		authStorage.bumpGeneration();
+		expect(getProviderAuthHealth(authStorage, staleProvider)).toBeUndefined();
+		expect(authStorage.hasAuth(staleProvider)).toBe(false);
+
+		const selector = await createModelSelector([famousModel, staleModel], { registry });
+		try {
+			// Once the generation changes, /model falls back to hasConfiguredProviderAuth instead of the old hint.
+			expect(modelRows(selector, [staleModel, famousModel])).toEqual([
+				"anthropic/anthropic-model",
+				"stale-custom-provider/stale-model",
+			]);
+			expect(registry.hasConfiguredProviderAuth).toHaveBeenCalledWith(staleProvider);
+		} finally {
+			selector.dispose();
+		}
+	});
+
+	test("ranks recorded invalid famous providers above tier-three unknown providers", async () => {
+		const staleInvalid = model("cursor", "cursor-model");
+		const unknown = model("tier-three-unknown", "unknown-model");
+		const authStorage = createAuthStorageDouble();
+		recordProviderAuthHealth(authStorage, staleInvalid.provider, "invalid");
+
+		const selector = await createModelSelector([unknown, staleInvalid], { authStorage });
+		try {
+			expect(modelRows(selector, [staleInvalid, unknown])).toEqual([
+				"cursor/cursor-model",
+				"tier-three-unknown/unknown-model",
+			]);
+		} finally {
+			selector.dispose();
+		}
+
+		const staleInvalidEntry: RankableProvider = { id: "cursor", label: "Cursor", authState: "invalid" };
+		const unknownEntry: RankableProvider = {
+			id: "tier-three-unknown",
+			label: "AAA Unknown",
+			authState: "none",
+		};
+		expect(providerRankTier(staleInvalidEntry.authState, staleInvalidEntry.id)).toBe(PROVIDER_RANK_TIER.problematic);
+		expect(compareRankedProviders(staleInvalidEntry, unknownEntry)).toBeLessThan(0);
+		expect(compareRankedProviders(unknownEntry, staleInvalidEntry)).toBeGreaterThan(0);
+	});
+
+	test("discards invalid health after a public credential mutation bumps generation", async () => {
+		const provider = "relogin-provider";
+		const authStorage = trackAuthStorage(await AuthStorage.create(":memory:"));
+		try {
+			const initialGeneration = authStorage.getGeneration();
+			recordProviderAuthHealth(authStorage, provider, "invalid");
+			expect(getProviderAuthHealth(authStorage, provider)).toBe("invalid");
+
+			authStorage.setRuntimeApiKey(provider, "relogin-key");
+			expect(authStorage.getGeneration()).toBeGreaterThan(initialGeneration);
+			expect(authStorage.hasAuth(provider)).toBe(true);
+			expect(getProviderAuthHealth(authStorage, provider)).toBeUndefined();
+		} finally {
+			clearProviderAuthHealth(authStorage);
+			authStorage.close();
+		}
+	});
+
+	test("discards valid health after runtime-key logout and falls back to configured auth", async () => {
+		const provider = "configured-after-logout";
+		const configuredModel = model(provider, "configured-model");
+		const famousModel = model("anthropic", "anthropic-model");
+		const authStorage = trackAuthStorage(await AuthStorage.create(":memory:"));
+		try {
+			authStorage.setRuntimeApiKey(provider, "configured-key");
+			const registry = createModelRegistry({
+				models: [famousModel, configuredModel],
+				configuredProviders: [provider],
+				authStorage,
+			});
+			recordProviderAuthHealth(authStorage, provider, "valid");
+			expect(getProviderAuthHealth(authStorage, provider)).toBe("valid");
+
+			authStorage.removeRuntimeApiKey(provider);
+			expect(authStorage.hasAuth(provider)).toBe(false);
+			expect(getProviderAuthHealth(authStorage, provider)).toBeUndefined();
+
+			const selector = await createModelSelector([famousModel, configuredModel], { registry });
+			try {
+				expect(modelRows(selector, [configuredModel, famousModel])).toEqual([
+					"configured-after-logout/configured-model",
+					"anthropic/anthropic-model",
+				]);
+				expect(registry.hasConfiguredProviderAuth).toHaveBeenCalledWith(provider);
+			} finally {
+				selector.dispose();
+			}
+		} finally {
+			clearProviderAuthHealth(authStorage);
+			authStorage.close();
+		}
+	});
+});
+
+describe("hasConfiguredProviderAuth contract attacks", () => {
+	test("agrees with hasConfiguredAuth for a configured provider that owns a model", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-provider-auth-health-"));
+		const modelsPath = path.join(root, "models.yml");
+		const authStorage = trackAuthStorage(await AuthStorage.create(":memory:"));
+		const previousProbeKey = process.env[PROBE_API_KEY_ENV];
+		delete process.env[PROBE_API_KEY_ENV];
+
+		try {
+			await Bun.write(
+				modelsPath,
+				JSON.stringify({
+					providers: {
+						"configured-probe": {
+							baseUrl: "https://configured-probe.example/v1",
+							api: "openai-responses",
+							apiKeyEnv: PROBE_API_KEY_ENV,
+							models: [{ id: "probe-model", name: "Probe Model", reasoning: false, input: ["text"] }],
+						},
+						"keyless-probe": {
+							baseUrl: "https://keyless-probe.example/v1",
+							api: "openai-responses",
+							auth: "none",
+							models: [{ id: "probe-model", name: "Keyless Probe", reasoning: false, input: ["text"] }],
+						},
+					},
+				}),
+			);
+
+			const registry = new ModelRegistry(authStorage, modelsPath);
+			await registry.refresh("offline");
+			const configuredModel = registry.find("configured-probe", "probe-model");
+			const keylessModel = registry.find("keyless-probe", "probe-model");
+			if (!configuredModel || !keylessModel) throw new Error("Expected probe models in registry");
+
+			expect(authStorage.hasAuth(configuredModel.provider)).toBe(false);
+			expect(registry.hasConfiguredAuth(configuredModel)).toBe(false);
+			expect(registry.hasConfiguredProviderAuth(configuredModel.provider)).toBe(false);
+
+			authStorage.setRuntimeApiKey(configuredModel.provider, "probe-key");
+			expect(registry.hasConfiguredAuth(configuredModel)).toBe(true);
+			expect(registry.hasConfiguredProviderAuth(configuredModel.provider)).toBe(true);
+			expect(registry.hasConfiguredAuth(configuredModel)).toBe(
+				registry.hasConfiguredProviderAuth(configuredModel.provider),
+			);
+		} finally {
+			if (previousProbeKey === undefined) delete process.env[PROBE_API_KEY_ENV];
+			else process.env[PROBE_API_KEY_ENV] = previousProbeKey;
+			authStorage.close();
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	test("returns true for a keyless provider with no stored credentials", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-provider-auth-health-keyless-"));
+		const modelsPath = path.join(root, "models.yml");
+		const authStorage = trackAuthStorage(await AuthStorage.create(":memory:"));
+		await Bun.write(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"keyless-probe": {
+						baseUrl: "https://keyless-probe.example/v1",
+						api: "openai-responses",
+						auth: "none",
+						models: [{ id: "probe-model", name: "Keyless Probe", reasoning: false, input: ["text"] }],
+					},
+				},
+			}),
+		);
+
+		try {
+			const registry = new ModelRegistry(authStorage, modelsPath);
+			await registry.refresh("offline");
+			const keylessModel = registry.find("keyless-probe", "probe-model");
+			if (!keylessModel) throw new Error("Expected keyless probe model in registry");
+
+			expect(authStorage.hasAuth(keylessModel.provider)).toBe(false);
+			expect(registry.hasConfiguredAuth(keylessModel)).toBe(true);
+			expect(registry.hasConfiguredProviderAuth(keylessModel.provider)).toBe(true);
+		} finally {
+			authStorage.close();
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/provider-auth-health.redteam.test.ts
+++ b/packages/coding-agent/test/provider-auth-health.redteam.test.ts
@@ -178,7 +178,7 @@ describe("provider auth health state attacks", () => {
 		expect(Reflect.ownKeys(Object.prototype)).toEqual(objectPrototypeKeysBefore);
 		expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
 		expect(Object.prototype.constructor).toBe(Object);
-		expect(Object.prototype.toString).toBe(Object.prototype.toString);
+		expect(typeof Object.prototype.toString).toBe("function");
 
 		clearProviderAuthHealth(authStorage);
 		for (const id of ids) expect(getProviderAuthHealth(authStorage, id)).toBeUndefined();

--- a/packages/coding-agent/test/provider-ranking-surfaces.test.ts
+++ b/packages/coding-agent/test/provider-ranking-surfaces.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import type { Model } from "@gajae-code/ai";
+import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
+import type { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import {
+	clearProviderAuthHealth,
+	getProviderAuthHealth,
+	recordProviderAuthHealth,
+} from "@gajae-code/coding-agent/config/provider-auth-health";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
+import { OAuthSelectorComponent } from "@gajae-code/coding-agent/modes/components/oauth-selector";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { AuthStorage, type AuthStorage as AuthStorageType } from "@gajae-code/coding-agent/session/auth-storage";
+import type { TUI } from "@gajae-code/tui";
+
+const model = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
+
+let testTheme = await getThemeByName("red-claw");
+
+function installTestTheme(): void {
+	if (!testTheme) throw new Error("Failed to load test theme");
+	setThemeInstance(testTheme);
+}
+
+function stripAnsi(value: string): string {
+	return value.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function renderedLines(component: { render(width: number): string[] }): string[] {
+	installTestTheme();
+	return component.render(240).map(stripAnsi);
+}
+
+function modelRows(selector: ModelSelectorComponent, models: readonly Model[]): string[] {
+	const keys = models.map(candidate => `${candidate.provider}/${candidate.id}`).sort((a, b) => b.length - a.length);
+	return renderedLines(selector).flatMap(line => {
+		const normalized = line.trimStart().replace(/^❯\s+/, "");
+		const key = keys.find(candidate => normalized.startsWith(candidate));
+		return key ? [key] : [];
+	});
+}
+
+function oauthRows(selector: OAuthSelectorComponent): string[] {
+	const providers = getOAuthProviders().sort((left, right) => right.name.length - left.name.length);
+	return renderedLines(selector).flatMap(line => {
+		const normalized = line.trimStart().replace(/^❯\s+/, "");
+		const provider = providers.find(candidate => normalized.startsWith(candidate.name));
+		return provider ? [provider.id] : [];
+	});
+}
+
+type AuthStorageDouble = Pick<AuthStorageType, "hasAuth" | "getGeneration">;
+
+const trackedAuthStorages = new Set<AuthStorageType>();
+
+function trackAuthStorage<T extends AuthStorageType>(authStorage: T): T {
+	trackedAuthStorages.add(authStorage);
+	return authStorage;
+}
+
+function clearTrackedProviderAuthHealth(): void {
+	for (const authStorage of trackedAuthStorages) clearProviderAuthHealth(authStorage);
+	trackedAuthStorages.clear();
+}
+
+function createAuthStorage(authenticatedProviders: string | readonly string[] = []): AuthStorageType {
+	let generation = 1;
+	const providers = new Set(
+		typeof authenticatedProviders === "string" ? [authenticatedProviders] : authenticatedProviders,
+	);
+	const authStorage = {
+		hasAuth: (provider: string) => providers.has(provider),
+		getGeneration: () => generation,
+		bumpGeneration: () => {
+			generation += 1;
+		},
+	};
+	return trackAuthStorage(authStorage as unknown as AuthStorageType);
+}
+
+function createModelRegistry(options: {
+	models: readonly Model[];
+	discoverableProviders?: readonly string[];
+	configuredProviders?: readonly string[];
+	authStorage?: AuthStorageDouble;
+}): ModelRegistry {
+	const configuredProviders = new Set(options.configuredProviders ?? []);
+	const authStorage = options.authStorage ?? createAuthStorage([...configuredProviders]);
+	trackAuthStorage(authStorage as unknown as AuthStorageType);
+	const hasConfiguredProviderAuth = vi.fn(
+		(provider: string) => configuredProviders.has(provider) || authStorage.hasAuth(provider),
+	);
+	return {
+		authStorage,
+		refresh: vi.fn(async () => {}),
+		refreshProvider: vi.fn(async () => {}),
+		getError: () => undefined,
+		getAvailable: () => [...options.models],
+		getAll: () => [...options.models],
+		hasConfiguredProviderAuth,
+		getDiscoverableProviders: () => [...(options.discoverableProviders ?? [])],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+		getModelProfiles: () => new Map(),
+		getApiKeyForProvider: async () => undefined,
+		getApiKey: async () => undefined,
+	} as unknown as ModelRegistry;
+}
+
+async function createModelSelector(
+	models: readonly Model[],
+	options: {
+		configuredProviders?: readonly string[];
+		discoverableProviders?: readonly string[];
+		settings?: Settings;
+		authStorage?: AuthStorageDouble;
+		registry?: ModelRegistry;
+	} = {},
+): Promise<ModelSelectorComponent> {
+	const selector = new ModelSelectorComponent(
+		{ requestRender: vi.fn() } as unknown as TUI,
+		undefined,
+		options.settings ?? Settings.isolated(),
+		options.registry ??
+			createModelRegistry({
+				models,
+				configuredProviders: options.configuredProviders,
+				discoverableProviders: options.discoverableProviders,
+				authStorage: options.authStorage,
+			}),
+		[],
+		() => {},
+		() => {},
+		{ temporaryOnly: true },
+	);
+	await Bun.sleep(10);
+	return selector;
+}
+
+beforeEach(async () => {
+	clearTrackedProviderAuthHealth();
+	testTheme = await getThemeByName("red-claw");
+	installTestTheme();
+});
+
+afterEach(() => {
+	clearTrackedProviderAuthHealth();
+});
+
+describe("/login provider ranking surface", () => {
+	test("preserves the selected provider id when validation re-sorts rows", async () => {
+		const target = getOAuthProviders().find(provider => provider.id === "anthropic");
+		if (!target) throw new Error("Expected anthropic OAuth provider");
+		const validation = Promise.withResolvers<boolean>();
+		const selected: string[] = [];
+		const selector = new OAuthSelectorComponent(
+			"login",
+			createAuthStorage(target.id),
+			providerId => selected.push(providerId),
+			() => {},
+			{ validateAuth: async () => validation.promise, requestRender: vi.fn() },
+		);
+
+		await Bun.sleep(0);
+		selector.handleInput("\x1b[A");
+		validation.resolve(false);
+		await Bun.sleep(0);
+		selector.handleInput("\n");
+
+		expect(selected).toEqual([target.id]);
+		selector.dispose();
+	});
+
+	test("keeps row order stable when checking credentials become valid", async () => {
+		const target = getOAuthProviders().find(provider => provider.id === "anthropic");
+		if (!target) throw new Error("Expected anthropic OAuth provider");
+		const validation = Promise.withResolvers<boolean>();
+		const selector = new OAuthSelectorComponent(
+			"login",
+			createAuthStorage(target.id),
+			() => {},
+			() => {},
+			{ validateAuth: async () => validation.promise, requestRender: vi.fn() },
+		);
+
+		await Bun.sleep(0);
+		const before = oauthRows(selector);
+		validation.resolve(true);
+		await Bun.sleep(0);
+		const after = oauthRows(selector);
+
+		expect(after).toEqual(before);
+		selector.dispose();
+	});
+});
+
+describe("/model provider ranking surface", () => {
+	test("keeps static tabs first and preserves role and MRU precedence over provider tier", async () => {
+		const defaultModel = model("anthropic", "default");
+		const mruModel = model("cursor", "mru");
+		const configuredModel = model("configured-provider", "configured");
+		const settings = Settings.isolated({ modelRoles: { default: "anthropic/default" } });
+		vi.spyOn(settings, "getStorage").mockReturnValue({
+			getModelUsageOrder: () => [`${mruModel.provider}/${mruModel.id}`],
+		} as never);
+		const selector = await createModelSelector([configuredModel, mruModel, defaultModel], {
+			configuredProviders: [configuredModel.provider],
+			settings,
+		});
+
+		const rows = modelRows(selector, [defaultModel, mruModel, configuredModel]);
+		const rendered = renderedLines(selector).join("\n");
+		expect(rows).toEqual([
+			`${defaultModel.provider}/${defaultModel.id}`,
+			`${mruModel.provider}/${mruModel.id}`,
+			`${configuredModel.provider}/${configuredModel.id}`,
+		]);
+		expect(rendered.indexOf("ALL")).toBeLessThan(rendered.indexOf("CANONICAL"));
+		selector.dispose();
+	});
+
+	test("ranks invalid health below tier zero and above famous providers, including zero-model discovery auth", async () => {
+		const configuredModel = model("configured-provider", "configured");
+		const invalidModel = model("invalid-provider", "invalid");
+		const famousModel = model("anthropic", "famous");
+		const registry = createModelRegistry({
+			models: [famousModel, invalidModel, configuredModel],
+			configuredProviders: [configuredModel.provider, "configured-discovery"],
+			discoverableProviders: ["configured-discovery"],
+		});
+		recordProviderAuthHealth(registry.authStorage, invalidModel.provider, "invalid");
+		const selector = await createModelSelector([famousModel, invalidModel, configuredModel], { registry });
+
+		const rows = modelRows(selector, [configuredModel, invalidModel, famousModel]);
+		const rendered = renderedLines(selector).join("\n");
+		expect(rows).toEqual([
+			`${configuredModel.provider}/${configuredModel.id}`,
+			`${invalidModel.provider}/${invalidModel.id}`,
+			`${famousModel.provider}/${famousModel.id}`,
+		]);
+		expect(rendered.indexOf("CONFIGURED-DISCOVERY")).toBeLessThan(rendered.indexOf("ANTHROPIC"));
+		selector.dispose();
+	});
+
+	test("drops an invalid provider out of tier one after an AuthStorage generation bump", async () => {
+		const invalidProvider = "generation-invalid-provider";
+		const invalidModel = model(invalidProvider, "invalid");
+		const famousModel = model("anthropic", "famous");
+		const authStorage = trackAuthStorage(await AuthStorage.create(":memory:"));
+		try {
+			const registry = createModelRegistry({ models: [famousModel, invalidModel], authStorage });
+			recordProviderAuthHealth(registry.authStorage, invalidProvider, "invalid");
+
+			const beforeSelector = await createModelSelector([famousModel, invalidModel], { registry });
+			try {
+				expect(modelRows(beforeSelector, [invalidModel, famousModel])).toEqual([
+					"generation-invalid-provider/invalid",
+					"anthropic/famous",
+				]);
+			} finally {
+				beforeSelector.dispose();
+			}
+
+			const initialGeneration = authStorage.getGeneration();
+			authStorage.setRuntimeApiKey(invalidProvider, "fresh-key");
+			authStorage.removeRuntimeApiKey(invalidProvider);
+			expect(authStorage.getGeneration()).toBeGreaterThan(initialGeneration);
+			expect(getProviderAuthHealth(authStorage, invalidProvider)).toBeUndefined();
+
+			const afterSelector = await createModelSelector([famousModel, invalidModel], { registry });
+			try {
+				expect(modelRows(afterSelector, [invalidModel, famousModel])).toEqual([
+					"anthropic/famous",
+					"generation-invalid-provider/invalid",
+				]);
+			} finally {
+				afterSelector.dispose();
+			}
+		} finally {
+			clearProviderAuthHealth(authStorage);
+			authStorage.close();
+		}
+	});
+});

--- a/packages/coding-agent/test/provider-ranking.redteam.test.ts
+++ b/packages/coding-agent/test/provider-ranking.redteam.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, test } from "bun:test";
+import {
+	compareRankedProviders,
+	FAMOUS_PROVIDER_ORDER,
+	famousProviderIndex,
+	type ProviderAuthState,
+	type RankableProvider,
+	sortRankedProviders,
+} from "../src/config/provider-ranking";
+import { formatProviderPresetList, PROVIDER_PRESETS } from "../src/setup/provider-onboarding";
+
+const AUTH_STATES: readonly ProviderAuthState[] = ["valid", "checking", "configured", "invalid", "none"];
+const EXISTING_AUTH_STATES: readonly ProviderAuthState[] = ["valid", "checking", "configured"];
+const UNICODE_LABELS = ["가나다", "Ångström", "Éclair", "😀 Provider", "東京", "مرحبا", "e\u0301", "é"];
+
+type ProviderSignature = `${string}\u0000${ProviderAuthState}\u0000${string}`;
+
+function provider(id: string, authState: ProviderAuthState, label = id): RankableProvider {
+	return { id, label, authState };
+}
+
+function sign(value: number): -1 | 0 | 1 {
+	return value === 0 ? 0 : value < 0 ? -1 : 1;
+}
+
+function oppositeSign(value: number): -1 | 0 | 1 {
+	const valueSign = sign(value);
+	return valueSign === 0 ? 0 : valueSign === 1 ? -1 : 1;
+}
+
+function mulberry32(seed: number): () => number {
+	let state = seed >>> 0;
+	return () => {
+		state = (state + 0x6d2b79f5) >>> 0;
+		let value = state;
+		value = Math.imul(value ^ (value >>> 15), value | 1);
+		value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+		return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+	};
+}
+
+function shuffle<T>(values: readonly T[], seed: number): T[] {
+	const random = mulberry32(seed);
+	const shuffled = [...values];
+	for (let index = shuffled.length - 1; index > 0; index -= 1) {
+		const swapIndex = Math.floor(random() * (index + 1));
+		[shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+	}
+	return shuffled;
+}
+
+function signature(entry: RankableProvider): ProviderSignature {
+	return `${entry.id}\u0000${entry.authState}\u0000${entry.label}`;
+}
+
+function presetRankingId(preset: (typeof PROVIDER_PRESETS)[number]): string {
+	return (
+		[preset.providerId, preset.id, ...preset.aliases].find(id => famousProviderIndex(id) !== undefined) ?? preset.id
+	);
+}
+
+describe("provider ranking adversarial properties", () => {
+	test("keeps reflexivity, antisymmetry, and transitivity over generated providers", () => {
+		const unknownIds = Array.from(
+			{ length: 24 },
+			(_, index) => `unknown-generated-${index.toString(36).padStart(2, "0")}`,
+		);
+		const ids = [...FAMOUS_PROVIDER_ORDER, ...unknownIds];
+		const entries = ids.flatMap((id, idIndex) =>
+			AUTH_STATES.map(authState =>
+				provider(id, authState, `${UNICODE_LABELS[idIndex % UNICODE_LABELS.length]} ${id}`),
+			),
+		);
+
+		for (const entry of entries) {
+			expect(compareRankedProviders(entry, entry)).toBe(0);
+		}
+
+		for (let leftIndex = 0; leftIndex < entries.length; leftIndex += 1) {
+			for (let rightIndex = leftIndex + 1; rightIndex < entries.length; rightIndex += 1) {
+				const left = entries[leftIndex];
+				const right = entries[rightIndex];
+				const forward = compareRankedProviders(left, right);
+				const backward = compareRankedProviders(right, left);
+				expect(sign(forward)).toBe(oppositeSign(backward));
+			}
+		}
+
+		for (let first = 0; first < entries.length; first += 1) {
+			for (let second = first + 1; second < entries.length; second += 1) {
+				for (let third = second + 1; third < entries.length; third += 1) {
+					const firstSecond = compareRankedProviders(entries[first], entries[second]);
+					const secondThird = compareRankedProviders(entries[second], entries[third]);
+					if (firstSecond <= 0 && secondThird <= 0) {
+						expect(compareRankedProviders(entries[first], entries[third])).toBeLessThanOrEqual(0);
+					}
+				}
+			}
+		}
+	});
+
+	test("produces one deterministic sequence across 64 seeded input permutations", () => {
+		const entries: RankableProvider[] = [
+			...FAMOUS_PROVIDER_ORDER.map((id, index) =>
+				provider(id, AUTH_STATES[index % AUTH_STATES.length], UNICODE_LABELS[index % UNICODE_LABELS.length]),
+			),
+			...Array.from({ length: 80 }, (_, index) =>
+				provider(
+					`custom-generated-${index.toString(36).padStart(2, "0")}`,
+					AUTH_STATES[(index + 1) % AUTH_STATES.length],
+					UNICODE_LABELS[(index + 3) % UNICODE_LABELS.length],
+				),
+			),
+		];
+		const before = entries.map(signature);
+		const expected = sortRankedProviders(entries);
+		const expectedIds = expected.map(entry => entry.id);
+		const expectedSignatures = expected.map(signature);
+
+		for (let shuffleNumber = 0; shuffleNumber < 64; shuffleNumber += 1) {
+			const shuffled = shuffle(entries, 0x51_7e_0000 + shuffleNumber);
+			const sorted = sortRankedProviders(shuffled);
+			expect(sorted.map(entry => entry.id)).toEqual(expectedIds);
+			expect(sorted.map(signature)).toEqual(expectedSignatures);
+		}
+		expect(entries.map(signature)).toEqual(before);
+	});
+
+	test("handles empty, singleton, identical-label, and homogeneous-auth-state inputs", () => {
+		expect(sortRankedProviders([])).toEqual([]);
+
+		const singleton = [provider("single", "none", "Only one")];
+		const singletonResult = sortRankedProviders(singleton);
+		expect(singletonResult).toEqual(singleton);
+		expect(singletonResult).not.toBe(singleton);
+
+		const sameLabel = [
+			provider("zeta", "none", "Same label"),
+			provider("alpha", "none", "Same label"),
+			provider("middle", "none", "Same label"),
+		];
+		expect(sortRankedProviders(sameLabel).map(entry => entry.id)).toEqual(["alpha", "middle", "zeta"]);
+
+		for (const authState of AUTH_STATES) {
+			const homogeneous = [
+				provider("custom-z", authState, "Same label"),
+				provider("anthropic", authState, "Same label"),
+				provider("custom-a", authState, "Same label"),
+			];
+			const sorted = sortRankedProviders(homogeneous);
+			expect(sorted.every(entry => entry.authState === authState)).toBe(true);
+			expect(sorted.map(entry => entry.id)).toEqual(["anthropic", "custom-a", "custom-z"]);
+		}
+	});
+
+	test("keeps Unicode and locale-sensitive labels in a total, non-throwing order", () => {
+		const entries = [
+			provider("korean", "none", "가나다"),
+			provider("accented", "none", "Ångström"),
+			provider("accented-e", "none", "Éclair"),
+			provider("emoji", "none", "😀 Provider"),
+			provider("cjk", "none", "東京"),
+			provider("arabic", "none", "مرحبا"),
+			provider("decomposed-e", "none", "e\u0301"),
+			provider("composed-e", "none", "é"),
+		];
+		const before = entries.map(signature);
+		const sorted = sortRankedProviders(entries);
+
+		expect(sorted).toHaveLength(entries.length);
+		expect(new Set(sorted.map(entry => entry.id)).size).toBe(entries.length);
+		expect(entries.map(signature)).toEqual(before);
+		for (let leftIndex = 0; leftIndex < sorted.length; leftIndex += 1) {
+			for (let rightIndex = leftIndex + 1; rightIndex < sorted.length; rightIndex += 1) {
+				expect(compareRankedProviders(sorted[leftIndex], sorted[rightIndex])).not.toBe(0);
+				expect(sign(compareRankedProviders(sorted[leftIndex], sorted[rightIndex]))).toBe(
+					oppositeSign(compareRankedProviders(sorted[rightIndex], sorted[leftIndex])),
+				);
+			}
+		}
+	});
+
+	test("retains duplicate ids without mutating the input", () => {
+		const input = [
+			provider("duplicate", "none", "Duplicate"),
+			provider("duplicate", "none", "Duplicate"),
+			provider("duplicate", "invalid", "Duplicate"),
+			provider("duplicate", "valid", "Duplicate"),
+			provider("custom", "none", "Custom"),
+		];
+		const before = input.map(signature);
+		const sorted = sortRankedProviders(input);
+
+		expect(sorted).not.toBe(input);
+		expect(sorted.filter(entry => entry.id === "duplicate")).toHaveLength(4);
+		expect(sorted.filter(entry => entry.id === "custom")).toHaveLength(1);
+		expect(sorted.map(signature)).toContain("duplicate\u0000valid\u0000Duplicate");
+		expect(sorted.map(signature)).toContain("duplicate\u0000invalid\u0000Duplicate");
+		expect(input.map(signature)).toEqual(before);
+	});
+});
+
+describe("provider ranking spec-contract attacks", () => {
+	test("keeps every famous variant immediately behind its primary in a full mixed sort", () => {
+		const mixed = [
+			provider("configured-custom", "configured", "Configured custom"),
+			provider("invalid-custom", "invalid", "Invalid custom"),
+			...FAMOUS_PROVIDER_ORDER.map((id, index) => provider(id, "none", `Famous ${index}`)),
+			provider("unknown-last", "none", "AAA unknown"),
+		];
+		const sortedIds = sortRankedProviders(mixed).map(entry => entry.id);
+		const expected = ["configured-custom", "invalid-custom", ...FAMOUS_PROVIDER_ORDER, "unknown-last"];
+		expect(sortedIds).toEqual(expected);
+
+		const groups = [
+			["openai-codex", "openai-codex-device"],
+			["zai", "glm-zcode"],
+			["alibaba-token-plan", "qwen-portal"],
+			["kimi-code", "moonshot"],
+			["minimax-code", "minimax-code-cn"],
+			["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"],
+		];
+		for (const group of groups) {
+			const start = sortedIds.indexOf(group[0]);
+			expect(sortedIds.slice(start, start + group.length)).toEqual(group);
+		}
+	});
+
+	test("never lets an unauthed famous provider outrank an invalid provider", () => {
+		const invalidProviders = [
+			provider("invalid-a", "invalid", "AAA invalid"),
+			provider("invalid-b", "invalid", "ZZZ invalid"),
+			provider("invalid-famous-shaped", "invalid", "Invalid famous-shaped"),
+		];
+		const famousProviders = FAMOUS_PROVIDER_ORDER.map(id => provider(id, "none", `Famous ${id}`));
+		const sortedIds = sortRankedProviders([...famousProviders, ...invalidProviders]).map(entry => entry.id);
+		const firstFamous = sortedIds.findIndex(id => FAMOUS_PROVIDER_ORDER.includes(id));
+		expect(sortedIds.slice(0, firstFamous).sort()).toEqual(invalidProviders.map(entry => entry.id).sort());
+		for (const invalid of invalidProviders) {
+			for (const famous of famousProviders) {
+				expect(compareRankedProviders(invalid, famous)).toBeLessThan(0);
+			}
+		}
+	});
+
+	test("never lets a tier-3 unknown provider outrank a tier-2 famous provider", () => {
+		const famousProviders = FAMOUS_PROVIDER_ORDER.map(id => provider(id, "none", `Famous ${id}`));
+		const unknownProviders = Array.from({ length: 16 }, (_, index) =>
+			provider(`unknown-tier-three-${index}`, "none", `AAA ${index}`),
+		);
+		const sortedIds = sortRankedProviders([...unknownProviders, ...famousProviders]).map(entry => entry.id);
+		const firstUnknown = sortedIds.findIndex(id => id.startsWith("unknown-tier-three-"));
+		expect(sortedIds.slice(firstUnknown)).toEqual(unknownProviders.map(entry => entry.id).sort());
+		for (const famous of famousProviders) {
+			for (const unknown of unknownProviders) {
+				expect(compareRankedProviders(famous, unknown)).toBeLessThan(0);
+			}
+		}
+	});
+
+	test("treats checking, valid, and configured as mutually indistinguishable", () => {
+		const base = [
+			provider("openai-codex", "none", "Codex"),
+			provider("anthropic", "none", "Claude"),
+			provider("custom-z", "none", "Zeta"),
+			provider("custom-a", "none", "Alpha"),
+		];
+		const sequences = EXISTING_AUTH_STATES.map(authState =>
+			sortRankedProviders(base.map(entry => ({ ...entry, authState }))).map(entry => entry.id),
+		);
+		expect(sequences[1]).toEqual(sequences[0]);
+		expect(sequences[2]).toEqual(sequences[0]);
+
+		for (let leftIndex = 0; leftIndex < base.length; leftIndex += 1) {
+			for (let rightIndex = leftIndex + 1; rightIndex < base.length; rightIndex += 1) {
+				const baseline = sign(
+					compareRankedProviders(
+						{ ...base[leftIndex], authState: "valid" },
+						{ ...base[rightIndex], authState: "valid" },
+					),
+				);
+				for (const leftState of EXISTING_AUTH_STATES) {
+					for (const rightState of EXISTING_AUTH_STATES) {
+						expect(
+							sign(
+								compareRankedProviders(
+									{ ...base[leftIndex], authState: leftState },
+									{ ...base[rightIndex], authState: rightState },
+								),
+							),
+						).toBe(baseline);
+					}
+				}
+			}
+		}
+	});
+});
+
+describe("/provider preset CLI surface", () => {
+	test("preserves line format, includes all presets, and follows shared ranking", () => {
+		const output = formatProviderPresetList();
+
+		const lines = output.split("\n");
+		expect(lines).toHaveLength(PROVIDER_PRESETS.length);
+		for (const line of lines) {
+			expect(line).toMatch(/^[a-z0-9][a-z0-9._-]*(?: \(aliases: [^)]*\))?: .+$/);
+		}
+		for (const preset of PROVIDER_PRESETS) {
+			const aliases = preset.aliases.length > 0 ? ` (aliases: ${preset.aliases.join(", ")})` : "";
+			expect(lines).toContain(`${preset.id}${aliases}: ${preset.description}`);
+		}
+
+		const expectedPresets = [...PROVIDER_PRESETS].sort((left, right) =>
+			compareRankedProviders(
+				{ id: presetRankingId(left), label: left.name, authState: "none" },
+				{ id: presetRankingId(right), label: right.name, authState: "none" },
+			),
+		);
+		const expectedLines = expectedPresets.map(preset => {
+			const aliases = preset.aliases.length > 0 ? ` (aliases: ${preset.aliases.join(", ")})` : "";
+			return `${preset.id}${aliases}: ${preset.description}`;
+		});
+		expect(lines).toEqual(expectedLines);
+		expect(lines.map(line => line.match(/^([a-z0-9][a-z0-9._-]*)/)?.[1])).toEqual([
+			"glm",
+			"alibaba-token-plan",
+			"minimax",
+			"minimax-cn",
+		]);
+	});
+});

--- a/packages/coding-agent/test/provider-ranking.test.ts
+++ b/packages/coding-agent/test/provider-ranking.test.ts
@@ -89,6 +89,40 @@ describe("famous provider list", () => {
 	test("the list has no duplicates", () => {
 		expect(new Set(FAMOUS_PROVIDER_ORDER).size).toBe(FAMOUS_PROVIDER_ORDER.length);
 	});
+
+	test("matches the agreed curated order exactly", () => {
+		// Written out independently of FAMOUS_PROVIDER_ORDER so an accidental
+		// reorder or removal of the constant cannot validate itself.
+		const agreedOrder = [
+			"openai-codex",
+			"openai-codex-device",
+			"anthropic",
+			"xai",
+			"opencode-go",
+			"zai",
+			"glm-zcode",
+			"alibaba-token-plan",
+			"qwen-portal",
+			"kimi-code",
+			"moonshot",
+			"minimax-code",
+			"minimax-code-cn",
+			"xiaomi",
+			"xiaomi-token-plan-sgp",
+			"xiaomi-token-plan-ams",
+			"xiaomi-token-plan-cn",
+			"opengateway",
+			"github-copilot",
+			"cursor",
+		];
+		expect([...FAMOUS_PROVIDER_ORDER]).toEqual(agreedOrder);
+
+		// The same order must survive an actual sort of shuffled input.
+		const shuffled = [...agreedOrder]
+			.reverse()
+			.map((id, index) => provider(id, "none", `Label ${String(index).padStart(2, "0")}`));
+		expect(sortRankedProviders(shuffled).map(entry => entry.id)).toEqual(agreedOrder);
+	});
 });
 
 describe("compareRankedProviders", () => {

--- a/packages/coding-agent/test/provider-ranking.test.ts
+++ b/packages/coding-agent/test/provider-ranking.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import {
+	compareRankedProviders,
+	FAMOUS_PROVIDER_ORDER,
+	famousProviderIndex,
+	PROVIDER_RANK_TIER,
+	providerRankTier,
+	type RankableProvider,
+	rankProvider,
+	sortRankedProviders,
+} from "../src/config/provider-ranking";
+
+function provider(id: string, authState: RankableProvider["authState"], label = id): RankableProvider {
+	return { id, label, authState };
+}
+
+describe("providerRankTier", () => {
+	test("valid, checking, and configured share the existing tier", () => {
+		expect(providerRankTier("valid", "anthropic")).toBe(PROVIDER_RANK_TIER.existing);
+		expect(providerRankTier("checking", "anthropic")).toBe(PROVIDER_RANK_TIER.existing);
+		expect(providerRankTier("configured", "glm-proxy")).toBe(PROVIDER_RANK_TIER.existing);
+	});
+
+	test("invalid credentials rank in the problematic tier", () => {
+		expect(providerRankTier("invalid", "anthropic")).toBe(PROVIDER_RANK_TIER.problematic);
+		expect(providerRankTier("invalid", "some-unknown-provider")).toBe(PROVIDER_RANK_TIER.problematic);
+	});
+
+	test("unauthenticated providers split into famous and other", () => {
+		expect(providerRankTier("none", "openai-codex")).toBe(PROVIDER_RANK_TIER.famous);
+		expect(providerRankTier("none", "tavily")).toBe(PROVIDER_RANK_TIER.other);
+	});
+});
+
+describe("rankProvider", () => {
+	test("returns the tier and the intra-tier rank in one result", () => {
+		expect(rankProvider(provider("anthropic", "valid"))).toEqual({
+			tier: PROVIDER_RANK_TIER.existing,
+			intraTierRank: famousProviderIndex("anthropic") as number,
+		});
+		expect(rankProvider(provider("openai-codex", "none"))).toEqual({
+			tier: PROVIDER_RANK_TIER.famous,
+			intraTierRank: famousProviderIndex("openai-codex") as number,
+		});
+		expect(rankProvider(provider("kagi", "invalid"))).toEqual({
+			tier: PROVIDER_RANK_TIER.problematic,
+			intraTierRank: Number.MAX_SAFE_INTEGER,
+		});
+		expect(rankProvider(provider("my-custom-gateway", "none"))).toEqual({
+			tier: PROVIDER_RANK_TIER.other,
+			intraTierRank: Number.MAX_SAFE_INTEGER,
+		});
+	});
+
+	test("agrees with the comparator it backs", () => {
+		const left = provider("openai-codex", "none");
+		const right = provider("cursor", "none");
+		const leftRank = rankProvider(left);
+		const rightRank = rankProvider(right);
+		expect(leftRank.tier).toBe(rightRank.tier);
+		expect(leftRank.intraTierRank).toBeLessThan(rightRank.intraTierRank);
+		expect(compareRankedProviders(left, right)).toBeLessThan(0);
+	});
+});
+
+describe("famous provider list", () => {
+	test("variants sit immediately behind their primary", () => {
+		const pairs: [string, string][] = [
+			["openai-codex", "openai-codex-device"],
+			["zai", "glm-zcode"],
+			["alibaba-token-plan", "qwen-portal"],
+			["kimi-code", "moonshot"],
+			["minimax-code", "minimax-code-cn"],
+			["xiaomi", "xiaomi-token-plan-sgp"],
+		];
+		for (const [primary, variant] of pairs) {
+			const primaryIndex = famousProviderIndex(primary);
+			const variantIndex = famousProviderIndex(variant);
+			expect(primaryIndex).toBeDefined();
+			expect(variantIndex).toBe((primaryIndex as number) + 1);
+		}
+	});
+
+	test("github copilot and cursor are on the famous list", () => {
+		expect(famousProviderIndex("github-copilot")).toBeDefined();
+		expect(famousProviderIndex("cursor")).toBeDefined();
+	});
+
+	test("the list has no duplicates", () => {
+		expect(new Set(FAMOUS_PROVIDER_ORDER).size).toBe(FAMOUS_PROVIDER_ORDER.length);
+	});
+});
+
+describe("compareRankedProviders", () => {
+	test("orders a fixture registry exactly", () => {
+		const fixture: RankableProvider[] = [
+			provider("tavily", "none", "Tavily"),
+			provider("cursor", "none", "Cursor (Claude, GPT, etc.)"),
+			provider("kagi", "invalid", "Kagi"),
+			provider("openai-codex", "none", "ChatGPT Plus/Pro (Codex Subscription)"),
+			provider("glm-proxy", "configured", "GLM / zAI"),
+			provider("anthropic", "valid", "Anthropic (Claude Pro/Max)"),
+			provider("cerebras", "none", "Cerebras"),
+			provider("minimax-code-cn", "none", "MiniMax Coding Plan (China)"),
+			provider("xai", "checking", "xAI"),
+			provider("minimax-code", "none", "MiniMax Coding Plan (International)"),
+		];
+
+		expect(sortRankedProviders(fixture).map(entry => entry.id)).toEqual([
+			// tier 0: valid / checking / configured, famous order then label
+			"anthropic",
+			"xai",
+			"glm-proxy",
+			// tier 1: problematic credentials
+			"kagi",
+			// tier 2: famous, curated order with variants behind their primary
+			"openai-codex",
+			"minimax-code",
+			"minimax-code-cn",
+			"cursor",
+			// tier 3: everything else, alphabetical by label
+			"cerebras",
+			"tavily",
+		]);
+	});
+
+	test("an authed-but-invalid provider outranks an unauthenticated famous provider", () => {
+		const invalid = provider("kagi", "invalid", "Kagi");
+		const famous = provider("anthropic", "none", "Anthropic (Claude Pro/Max)");
+		expect(compareRankedProviders(invalid, famous)).toBeLessThan(0);
+		expect(sortRankedProviders([famous, invalid]).map(entry => entry.id)).toEqual(["kagi", "anthropic"]);
+	});
+
+	test("checking ranks with valid so rows do not reflow during validation", () => {
+		const before = sortRankedProviders([
+			provider("anthropic", "checking", "Anthropic (Claude Pro/Max)"),
+			provider("cursor", "none", "Cursor"),
+			provider("kagi", "invalid", "Kagi"),
+		]).map(entry => entry.id);
+		const after = sortRankedProviders([
+			provider("anthropic", "valid", "Anthropic (Claude Pro/Max)"),
+			provider("cursor", "none", "Cursor"),
+			provider("kagi", "invalid", "Kagi"),
+		]).map(entry => entry.id);
+		expect(after).toEqual(before);
+	});
+
+	test("unknown and custom providers land last", () => {
+		const ranked = sortRankedProviders([
+			provider("my-custom-gateway", "none", "My Custom Gateway"),
+			provider("opengateway", "none", "OpenGateway by Sionic AI"),
+			provider("github-copilot", "none", "GitHub Copilot"),
+			provider("aaa-custom", "none", "AAA Custom"),
+		]).map(entry => entry.id);
+		expect(ranked.slice(0, 2)).toEqual(["opengateway", "github-copilot"]);
+		expect(ranked.slice(2)).toEqual(["aaa-custom", "my-custom-gateway"]);
+	});
+
+	test("the comparator is a stable total order with no ties", () => {
+		const states: RankableProvider["authState"][] = ["valid", "checking", "configured", "invalid", "none"];
+		const entries: RankableProvider[] = [];
+		for (const id of [...FAMOUS_PROVIDER_ORDER, "tavily", "kagi", "custom-one", "custom-two"]) {
+			entries.push(provider(id, states[entries.length % states.length], `Label ${id}`));
+		}
+
+		for (const left of entries) {
+			for (const right of entries) {
+				if (left.id === right.id) {
+					expect(compareRankedProviders(left, right)).toBe(0);
+					continue;
+				}
+				const forward = compareRankedProviders(left, right);
+				const backward = compareRankedProviders(right, left);
+				expect(forward).not.toBe(0);
+				expect(Math.sign(forward)).toBe(-Math.sign(backward));
+			}
+		}
+
+		const sorted = sortRankedProviders(entries).map(entry => entry.id);
+		const reversed = sortRankedProviders([...entries].reverse()).map(entry => entry.id);
+		expect(reversed).toEqual(sorted);
+		expect(new Set(sorted).size).toBe(entries.length);
+	});
+
+	test("identical labels still break ties by id", () => {
+		const left = provider("bbb", "none", "Same Label");
+		const right = provider("aaa", "none", "Same Label");
+		expect(compareRankedProviders(left, right)).toBeGreaterThan(0);
+		expect(sortRankedProviders([left, right]).map(entry => entry.id)).toEqual(["aaa", "bbb"]);
+	});
+});


### PR DESCRIPTION
## Summary

Providers you already have now sort to the top of every provider-facing selector, then a curated list of well-known providers, then everything else alphabetically.

One shared ranking module owns the order:

| Tier | Meaning |
|---|---|
| 0 | valid auth, in-flight `checking`, or a configured non-OAuth provider |
| 1 | stored credentials that failed validation (problematic logins) |
| 2 | famous providers, hand-ordered, variants behind their primary |
| 3 | everything else, by display name |

Famous order: `openai-codex`, `anthropic`, `xai`, `opencode-go`, `zai` (GLM Coding Plan), `alibaba-token-plan`, `kimi-code`, `minimax-code`, `xiaomi` (MiMo), `opengateway` (Sionic AI), `github-copilot`, `cursor`. Regional/device variants (`openai-codex-device`, `minimax-code-cn`, `xiaomi-token-plan-*`, `glm-zcode`, `qwen-portal`, `moonshot`) group directly behind their primary.

## Surfaces

- **`/login`** — `oauth-selector` renders `getOAuthProviders()` through the ranking instead of raw array order, preserving the selected provider **by id** across re-sorts. `checking` shares tier 0 with `valid`, so rows don't reflow when async validation resolves.
- **`/model`** — provider tabs replace the alphabetical sort; `#sortModels` / `#sortCanonicalModels` replace **only** the provider `localeCompare` tiebreak. Role/default rank and MRU still outrank provider tier.
- **`/provider`** — `formatProviderPresetList` ranks presets with the rendered line format unchanged. The four-action onboarding menu is untouched, and the custom-provider wizard enumerates no providers (verified: 0 matches for `getOAuthProviders|PROVIDER_PRESETS|getDiscoverableProviders|modelRegistry` across its 380 lines), so it needs no change.

## Ranking a failed login without re-validating

To rank a broken login below a healthy one in `/model` without duplicating OAuth validation there, validation results are recorded as an ordering hint in an `AuthStorage`-scoped, **generation-checked** `WeakMap`. Any credential mutation bumps the generation and discards the hint, and a validation that began against an older generation is never recorded.

The hint affects **ordering only** — it never gates auth, requests, or credential access, and OAuth validation behavior is byte-identical to before this change.

Also adds `ModelRegistry.hasConfiguredProviderAuth(provider)` so a configured discovery-only provider with **zero models** still ranks tier 0.

## Scope

Ordering-only. No auth flow, credential storage, or provider registration behavior changes. No providers or presets added or removed.

## Verification

- `bun test` over 32 focused provider/model/login/oauth/selector files — **304 pass, 0 fail**
- `bunx tsc --noEmit -p packages/coding-agent/tsconfig.json` — exit 0
- `bunx biome check` over all 21 changed files — clean (1 deliberate `useLiteralKeys` info on a prototype-pollution test that must use bracket access)

**Mutation checks** (proving the new tests aren't vacuous):

| Mutation | Result |
|---|---|
| remove the generation equality check in `getProviderAuthHealth` | 8 tests fail |
| remove selected-id preservation in `oauth-selector` | 1 test fails |
| remove the auth-generation guard on health recording | 2 tests fail |

All restore to green.

**Red-team coverage** — comparator antisymmetry/transitivity/reflexivity over 220 generated providers, 64 seeded shuffles for sort determinism, unicode and duplicate labels, `__proto__`/prototype-pollution key safety, tier-inversion attempts, `AuthStorage` generation monotonicity and WeakMap identity scoping, and an empirical inventory of the 15 `AuthStorage` methods that bump `getGeneration()` (no realistic logout/delete path misses one).

**Pre-existing failures** — 7 unrelated failures (3 model-registry canonical-equivalence, 4 session-storage fd-security) reproduce identically on a clean `git stash -u` tree: 181 pass / 7 fail both with and without this change set.

## Review trail

Four `architect` review rounds: `BLOCK/BLOCK/WATCH REQUEST CHANGES` → `WATCH×3 REQUEST CHANGES` → `WATCH×3 COMMENT` → **`CLEAR/CLEAR/CLEAR APPROVE`**. Three terminal `critic` rounds ending **OKAY**. Every finding is either fixed or dispositioned with evidence.

## Note on module location

`provider-ranking.ts` lives in `packages/coding-agent/src/config` rather than `packages/ai`. All consumers are inside `packages/coding-agent`, and this worktree's `node_modules` symlinks to the main checkout, so newly added files under `packages/ai` don't resolve via `@gajae-code/ai/*`. Architect review explicitly recommended against adding a `packages/ai` → `coding-agent` dependency just to relocate UI-ordering policy.
