### PR TITLE
fix(ai): honor documented GJC_OPENAI_CODE_* env names

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Anthropic `ping` keepalives no longer reset stream progress, so responses that stop producing content now reach the idle timeout instead of hanging indefinitely.
 - The documented `GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS` environment variable now takes effect: the stream-watchdog idle-timeout helpers resolve it GJC-first before the legacy `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` / `PI_STREAM_IDLE_TIMEOUT_MS` aliases (previously only the `PI_`-prefixed names were read, so setting the documented GJC name was a silent no-op).
+- The documented OpenAI-code provider knobs now take effect: `GJC_OPENAI_CODE_DEBUG`, `GJC_OPENAI_CODE_WEBSOCKET`, `GJC_OPENAI_CODE_WEBSOCKET_IDLE_TIMEOUT_MS`, `GJC_OPENAI_CODE_WEBSOCKET_RETRY_BUDGET`, and `GJC_OPENAI_CODE_WEBSOCKET_RETRY_DELAY_MS` are resolved GJC-first ahead of the legacy `PI_CODEX_*` names. The Codex → OpenAI-code rename had updated the documentation but not the reads, so every documented name was a silent no-op.
 
 ## [0.11.10] - 2026-07-25
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -2,7 +2,7 @@ import * as os from "node:os";
 import { scheduler } from "node:timers/promises";
 import {
 	$env,
-	$flag,
+	$pickflag,
 	asRecord,
 	extractHttpStatusFromError,
 	fetchWithRetry,
@@ -98,7 +98,7 @@ export interface OpenAICodexResponsesOptions extends StreamOptions {
 	serviceTier?: ServiceTier;
 }
 
-const CODEX_DEBUG = $flag("PI_CODEX_DEBUG");
+const CODEX_DEBUG = $pickflag("GJC_OPENAI_CODE_DEBUG", "PI_CODEX_DEBUG");
 const CODEX_MAX_RETRIES = 5;
 const CODEX_RETRY_DELAY_MS = 500;
 const CODEX_WEBSOCKET_CONNECT_TIMEOUT_MS = 10000;
@@ -299,24 +299,34 @@ function parseCodexPositiveInteger(value: string | undefined, fallback: number):
 }
 
 function isCodexWebSocketEnvEnabled(): boolean {
-	return $flag("PI_CODEX_WEBSOCKET");
+	return $pickflag("GJC_OPENAI_CODE_WEBSOCKET", "PI_CODEX_WEBSOCKET");
 }
 
 function getCodexWebSocketRetryBudget(options?: Pick<OpenAICodexResponsesOptions, "streamMaxRetries">): number {
 	if (options?.streamMaxRetries !== undefined) {
 		return resolveRetryBudget(options.streamMaxRetries, CODEX_WEBSOCKET_RETRY_BUDGET);
 	}
-	return parseCodexNonNegativeInteger($env.PI_CODEX_WEBSOCKET_RETRY_BUDGET, CODEX_WEBSOCKET_RETRY_BUDGET);
+	return parseCodexNonNegativeInteger(
+		$env.GJC_OPENAI_CODE_WEBSOCKET_RETRY_BUDGET ?? $env.PI_CODEX_WEBSOCKET_RETRY_BUDGET,
+		CODEX_WEBSOCKET_RETRY_BUDGET,
+	);
 }
 
 function getCodexWebSocketRetryDelayMs(retry: number): number {
-	const baseDelay = parseCodexPositiveInteger($env.PI_CODEX_WEBSOCKET_RETRY_DELAY_MS, CODEX_RETRY_DELAY_MS);
+	const baseDelay = parseCodexPositiveInteger(
+		$env.GJC_OPENAI_CODE_WEBSOCKET_RETRY_DELAY_MS ?? $env.PI_CODEX_WEBSOCKET_RETRY_DELAY_MS,
+		CODEX_RETRY_DELAY_MS,
+	);
 	return baseDelay * Math.max(1, retry);
 }
 
 function getCodexWebSocketIdleTimeoutMs(overrideMs?: number): number {
 	return (
-		overrideMs ?? parseCodexPositiveInteger($env.PI_CODEX_WEBSOCKET_IDLE_TIMEOUT_MS, CODEX_WEBSOCKET_IDLE_TIMEOUT_MS)
+		overrideMs ??
+		parseCodexPositiveInteger(
+			$env.GJC_OPENAI_CODE_WEBSOCKET_IDLE_TIMEOUT_MS ?? $env.PI_CODEX_WEBSOCKET_IDLE_TIMEOUT_MS,
+			CODEX_WEBSOCKET_IDLE_TIMEOUT_MS,
+		)
 	);
 }
 

--- a/packages/ai/test/openai-code-env-names.test.ts
+++ b/packages/ai/test/openai-code-env-names.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { getOpenAICodexTransportDetails } from "@gajae-code/ai/providers/openai-codex-responses";
+import type { Model } from "@gajae-code/ai/types";
+
+/**
+ * The provider was renamed Codex -> "OpenAI code" and the documented env names
+ * followed (GJC_OPENAI_CODE_*), but the reads still used the legacy PI_CODEX_*
+ * names. These pin the documented name working, the legacy alias still working,
+ * and GJC-first precedence.
+ */
+
+const KEYS = ["GJC_OPENAI_CODE_WEBSOCKET", "PI_CODEX_WEBSOCKET"] as const;
+const saved = new Map<string, string | undefined>();
+
+beforeEach(() => {
+	for (const key of KEYS) {
+		saved.set(key, Bun.env[key]);
+		delete Bun.env[key];
+	}
+});
+
+afterEach(() => {
+	for (const [key, value] of saved) {
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+	}
+});
+
+// `preferWebsockets: false` on the model (and no caller option) leaves the env
+// flag as the only thing that can turn websocket preference on, isolating it.
+function envOnlyCodexModel(): Model<"openai-codex-responses"> {
+	return {
+		id: "gpt-5.3-codex-spark",
+		name: "GPT-5.3 Codex Spark",
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		baseUrl: "",
+		reasoning: true,
+		preferWebsockets: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 128000,
+	};
+}
+
+describe("OpenAI code websocket env flag", () => {
+	it("is off when neither name is set", () => {
+		expect(getOpenAICodexTransportDetails(envOnlyCodexModel()).websocketPreferred).toBe(false);
+	});
+
+	it("honors the documented GJC_OPENAI_CODE_WEBSOCKET", () => {
+		Bun.env.GJC_OPENAI_CODE_WEBSOCKET = "1";
+		expect(getOpenAICodexTransportDetails(envOnlyCodexModel()).websocketPreferred).toBe(true);
+	});
+
+	it("still honors the legacy PI_CODEX_WEBSOCKET alias", () => {
+		Bun.env.PI_CODEX_WEBSOCKET = "1";
+		expect(getOpenAICodexTransportDetails(envOnlyCodexModel()).websocketPreferred).toBe(true);
+	});
+
+	it("resolves GJC-first: an explicit GJC=0 wins over legacy PI=1", () => {
+		Bun.env.GJC_OPENAI_CODE_WEBSOCKET = "0";
+		Bun.env.PI_CODEX_WEBSOCKET = "1";
+		expect(getOpenAICodexTransportDetails(envOnlyCodexModel()).websocketPreferred).toBe(false);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Interactive `/resume` no longer awaits ordinary notification-endpoint rotation after predecessor fencing when the transition is stamped `interactive_selector_resume`; lifecycle/SDK identity-control paths still await readiness and use a fail-closed control-drain orchestration that sends terminal control outcomes only after successor readiness, while uncertain predecessor stop no longer starts the successor (#2914).
 - Interactive TUI `/resume` commits a status-container progress lease before inspect/migration/switch work and clears it on every exit path, with generation-scoped render-commit wait that fails open when the terminal is stopped or unavailable (#2914).
 - Interactive `/resume` progress lease fails open when `statusContainer` or UI lacks child-mutation/render-commit surface, preserving headless/minimal controller contexts without weakening full TUI progress-before-switch (#3234 post-merge).
+- The documented `GJC_OPENAI_CODE_WEB_SEARCH_MODEL` environment variable now overrides the OpenAI-code web-search model; it is resolved GJC-first ahead of the legacy `PI_CODEX_WEB_SEARCH_MODEL` name (previously only the legacy name was read, so the documented name was a silent no-op).
 
 ### Added
 

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -36,7 +36,7 @@ const DEFAULT_INSTRUCTIONS =
 	"You are a helpful assistant with web search capabilities. Search the web to answer the user's question accurately and cite your sources.";
 
 function getConfiguredModel(): string | undefined {
-	const configuredModel = $env.PI_CODEX_WEB_SEARCH_MODEL?.trim();
+	const configuredModel = ($env.GJC_OPENAI_CODE_WEB_SEARCH_MODEL ?? $env.PI_CODEX_WEB_SEARCH_MODEL)?.trim();
 	return configuredModel ? configuredModel : undefined;
 }
 

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -11,6 +11,7 @@ type CapturedRequest = {
 };
 
 const originalCodexSearchModel = process.env.PI_CODEX_WEB_SEARCH_MODEL;
+const originalDocumentedCodexSearchModel = process.env.GJC_OPENAI_CODE_WEB_SEARCH_MODEL;
 
 function makeSseResponse(model: string): string {
 	return [
@@ -219,6 +220,11 @@ describe("searchCodex model selection", () => {
 		} else {
 			process.env.PI_CODEX_WEB_SEARCH_MODEL = originalCodexSearchModel;
 		}
+		if (originalDocumentedCodexSearchModel === undefined) {
+			delete process.env.GJC_OPENAI_CODE_WEB_SEARCH_MODEL;
+		} else {
+			process.env.GJC_OPENAI_CODE_WEB_SEARCH_MODEL = originalDocumentedCodexSearchModel;
+		}
 	});
 
 	it("uses the built-in default model when PI_CODEX_WEB_SEARCH_MODEL is unset", async () => {
@@ -288,6 +294,28 @@ describe("searchCodex model selection", () => {
 		const result = await searchCodex(makeSearchParams("overridden codex model"));
 
 		expect(capturedRequest).not.toBeNull();
+		expect(capturedRequest?.body?.model).toBe("gpt-5.4-mini");
+		expect(result.model).toBe("gpt-5.4-mini");
+	});
+
+	it("uses the documented GJC_OPENAI_CODE_WEB_SEARCH_MODEL when provided", async () => {
+		process.env.GJC_OPENAI_CODE_WEB_SEARCH_MODEL = "gpt-5.4-mini";
+		using _hook = mockCodexFetch("gpt-5.4-mini");
+
+		const result = await searchCodex(makeSearchParams("documented codex model override"));
+
+		expect(capturedRequest).not.toBeNull();
+		expect(capturedRequest?.body?.model).toBe("gpt-5.4-mini");
+		expect(result.model).toBe("gpt-5.4-mini");
+	});
+
+	it("resolves GJC-first: GJC_OPENAI_CODE_WEB_SEARCH_MODEL wins over legacy PI_CODEX_WEB_SEARCH_MODEL", async () => {
+		process.env.GJC_OPENAI_CODE_WEB_SEARCH_MODEL = "gpt-5.4-mini";
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
+		using _hook = mockCodexFetch("gpt-5.4-mini");
+
+		const result = await searchCodex(makeSearchParams("gjc-first codex model"));
+
 		expect(capturedRequest?.body?.model).toBe("gpt-5.4-mini");
 		expect(result.model).toBe("gpt-5.4-mini");
 	});


### PR DESCRIPTION
## What

The provider was renamed Codex → “OpenAI code” and `docs/environment-variables.md` followed with `GJC_OPENAI_CODE_*` names, but the reads still use the legacy `PI_CODEX_*` names. Every documented knob is a silent no-op:

| documented (docs L345-350, L381) | actually read | site |
|---|---|---|
| `GJC_OPENAI_CODE_DEBUG` | `PI_CODEX_DEBUG` | `openai-codex-responses.ts:101` |
| `GJC_OPENAI_CODE_WEBSOCKET` | `PI_CODEX_WEBSOCKET` | `:302` |
| `GJC_OPENAI_CODE_WEBSOCKET_IDLE_TIMEOUT_MS` | `PI_CODEX_WEBSOCKET_IDLE_TIMEOUT_MS` | `:319` |
| `GJC_OPENAI_CODE_WEBSOCKET_RETRY_BUDGET` | `PI_CODEX_WEBSOCKET_RETRY_BUDGET` | `:309` |
| `GJC_OPENAI_CODE_WEBSOCKET_RETRY_DELAY_MS` | `PI_CODEX_WEBSOCKET_RETRY_DELAY_MS` | `:313` |
| `GJC_OPENAI_CODE_WEB_SEARCH_MODEL` | `PI_CODEX_WEB_SEARCH_MODEL` | `web/search/providers/codex.ts:39` |

Note the drift is two-fold — both the `GJC_`/`PI_` prefix **and** the `OPENAI_CODE`/`CODEX` segment.

## Fix

Resolve each documented name first, keeping the `PI_CODEX_*` name as a backward-compatible fallback. Same class as the merged GJC_* migrations (#2827 / #2943 / #3041 / #3171). Semantics preserved: `$pickflag` matches `$flag` per key, and the `??` chains keep the existing parse/default behavior.

`GJC_OPENAI_CODE_WEBSOCKET_V2` is documented but has **no implementation at all** (no reader under any prefix), so it is deliberately untouched here rather than guessed at.

## Tests

Coverage at both ends of the rename:

- `packages/ai/test/openai-code-env-names.test.ts` (new) — drives the exported `getOpenAICodexTransportDetails()` with a `preferWebsockets: false` model so the env flag is the only thing that can enable websocket preference: off when unset, on for the documented name, on for the legacy alias, and GJC-first precedence (explicit `GJC=0` beats `PI=1`).
- `web-search-codex.test.ts` — extends the existing fetch-mock harness beside the current `PI_CODEX_WEB_SEARCH_MODEL` test: documented name honored (asserted on the outgoing request body + result model) and GJC-first precedence; env save/restore extended so nothing leaks.

The three websocket numerics and the debug flag are the identical one-line `??`/`$pickflag` prepend on module-private helpers (and a module-scope const) with no exported seam — I did not add test-only exports for them; happy to if you would prefer explicit coverage.

Existing `openai-codex-stream` / `openai-codex` / `openai-codex-default` suites: 53 pass / 0 fail (they set the `PI_` names, which still win when the GJC names are unset). `ai` + `coding-agent` `tsc` and `biome` clean.