### PR TITLE
fix(ai): align Anthropic subscription OAuth attribution

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Anthropic subscription OAuth requests now use the current Claude Code compatibility attribution (`2.1.219`, `sdk-cli`) instead of the stale `2.1.63` CLI fingerprint that Anthropic can misclassify as extra usage.
+
 ## [0.11.11] - 2026-07-26
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -490,7 +490,8 @@ function getCacheControl(
 }
 
 // Stealth mode: Mimic Anthropic Code headers and tool prefixing.
-export const claudeCodeVersion = "2.1.63";
+export const claudeCodeVersion = "2.1.219";
+export const claudeCodeEntrypoint = "sdk-cli";
 export const claudeToolPrefix: string = "proxy_";
 export const claudeCodeSystemInstruction = "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
 
@@ -566,7 +567,7 @@ function createClaudeBillingHeader(payload: unknown): string {
 	const buildHash = Array.from(randomBytes, byte => byte.toString(16).padStart(2, "0"))
 		.join("")
 		.slice(0, 3);
-	return `${CLAUDE_BILLING_HEADER_PREFIX} cc_version=${claudeCodeVersion}.${buildHash}; cc_entrypoint=cli; cch=${cch};`;
+	return `${CLAUDE_BILLING_HEADER_PREFIX} cc_version=${claudeCodeVersion}.${buildHash}; cc_entrypoint=${claudeCodeEntrypoint}; cch=${cch};`;
 }
 
 const CLAUDE_CLOAKING_USER_ID_REGEX =

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -1,4 +1,5 @@
 import { scheduler } from "node:timers/promises";
+import { claudeCodeVersion } from "../providers/anthropic";
 import type {
 	CredentialRankingStrategy,
 	UsageAmount,
@@ -31,7 +32,7 @@ const CLAUDE_HEADERS = {
 	"anthropic-beta":
 		"claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05",
 	"content-type": "application/json",
-	"user-agent": "claude-cli/2.1.63 (external, cli)",
+	"user-agent": `claude-cli/${claudeCodeVersion} (external, cli)`,
 	connection: "keep-alive",
 } as const;
 

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -9,6 +9,7 @@ import {
 	buildAnthropicClientOptions,
 	buildAnthropicHeaders,
 	buildAnthropicSystemBlocks,
+	claudeCodeEntrypoint,
 	claudeCodeVersion,
 	generateClaudeCloakingUserId,
 	isClaudeCloakingUserId,
@@ -115,6 +116,13 @@ describe("Anthropic request fingerprint alignment", () => {
 			extraInstructions: ["Use citations when possible"],
 			cacheControl: { type: "ephemeral" },
 		});
+
+		const billingHeader = blocks?.[0]?.text;
+		expect(billingHeader).toMatch(
+			new RegExp(
+				`^x-anthropic-billing-header: cc_version=${claudeCodeVersion}\\.[0-9a-f]{3}; cc_entrypoint=${claudeCodeEntrypoint}; cch=[0-9a-f]{5};$`,
+			),
+		);
 
 		expect(blocks).toBeDefined();
 		// Earlier blocks must NOT carry cache_control; a single trailing breakpoint covers them all.

--- a/packages/ai/test/claude-usage-headers.test.ts
+++ b/packages/ai/test/claude-usage-headers.test.ts
@@ -75,7 +75,7 @@ describe("claude usage request headers", () => {
 
 		const headers = calls[0]?.init?.headers;
 		expect(getHeaderCaseInsensitive(headers, "authorization")).toBe(`Bearer ${token}`);
-		expect(getHeaderCaseInsensitive(headers, "user-agent")).toBe("claude-cli/2.1.63 (external, cli)");
+		expect(getHeaderCaseInsensitive(headers, "user-agent")).toBe("claude-cli/2.1.219 (external, cli)");
 
 		const beta = getHeaderCaseInsensitive(headers, "anthropic-beta");
 		expect(beta).toBeDefined();


### PR DESCRIPTION
## Summary

- update the Claude Code compatibility version from `2.1.63` to `2.1.219`
- align the Anthropic billing attribution entrypoint with the official Agent SDK CLI (`sdk-cli`)
- reuse the shared compatibility version for Claude usage requests to prevent drift
- add billing-header regression coverage and update usage-header expectations

## Root cause

Anthropic subscription OAuth requests emitted by GJC used a stale Claude Code fingerprint. Anthropic now misclassifies that request shape as extra usage, returning HTTP 400 even when the same Max-subscription OAuth token works in the official Claude CLI.

The diagnosis was isolated by injecting the official CLI's current access token directly into both clients: official Claude CLI succeeded; unpatched GJC failed. The patched source CLI succeeds with that same token.

Closes #3246.

## Verification

- `bun test packages/ai/test/anthropic-alignment.test.ts packages/ai/test/claude-usage-headers.test.ts` — 48 pass
- `biome check . --no-errors-on-unmatched && tsc -p tsconfig.tools.json --noEmit` — pass
- patched source CLI + current Claude Max OAuth token + `anthropic/claude-sonnet-4-6` — `PATCHED_GJC_OK`, exit 0
- full `bun run check:ts` advanced through the initial static/type/release checks and extensive SDK manifests without failures, but exceeded the 300-second local command window