### PR TITLE
fix(coding-agent): harden recovered settings controls

### DIFF
--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -259,10 +259,18 @@ export function initializeWithSettings(activeSettings: Settings): void {
 	for (const id of disabled) disabledProviders.add(id);
 }
 
+function assertDisabledProvidersWritable(activeSettings: Settings): void {
+	if (!activeSettings.canWriteDurableConfig()) {
+		throw new Error(
+			"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+		);
+	}
+}
 /**
  * Persist current disabled providers to settings.
  */
 function persistDisabledProviders(activeSettings: Settings, providers: ReadonlySet<string>): void {
+	assertDisabledProvidersWritable(activeSettings);
 	activeSettings.set("disabledProviders", Array.from(providers));
 }
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1085,49 +1085,9 @@ export class Settings implements NotificationSettingsReader {
 		this.#hasMalformedConfigRoot = false;
 		this.#hasInvalidNotificationConfiguration = false;
 		this.#captureRawNotificationConfig({});
+		let content: string;
 		try {
-			const content = await Bun.file(filePath).text();
-			const parsed = YAML.parse(content);
-			if (parsed === undefined) return {};
-			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-				this.#hasMalformedConfigRoot = true;
-				this.#captureRawNotificationConfig(undefined);
-				return {};
-			}
-			const parsedRaw = parsed as RawSettings;
-			if (filePath === this.#configPath) this.#captureRawNotificationConfig(parsedRaw);
-			if (filePath === this.#configPath) {
-				try {
-					parseNotificationSettingsSnapshot(parsedRaw);
-				} catch (error) {
-					if (!(error instanceof Error) || error.message !== "gjc_notify_daemon_invalid_configuration")
-						throw error;
-					this.#hasInvalidNotificationConfiguration = true;
-				}
-			}
-			this.#futureSchemaVersion =
-				filePath === this.#configPath &&
-				typeof parsedRaw.configSchemaVersion === "number" &&
-				parsedRaw.configSchemaVersion > CONFIG_SCHEMA_VERSION;
-
-			const configSchemaVersion = parsedRaw.configSchemaVersion;
-			if (
-				filePath === this.#configPath &&
-				(typeof configSchemaVersion !== "number" || configSchemaVersion < CONFIG_SCHEMA_VERSION)
-			) {
-				this.#schemaMigrationPending = true;
-			}
-			const migrated = this.#migrateRawSettings(parsedRaw);
-			const reconciled = reconcileSettingsSchema(migrated);
-			if (typeof configSchemaVersion === "number" && configSchemaVersion > CONFIG_SCHEMA_VERSION) {
-				reconciled.report.issues.push({
-					path: "configSchemaVersion",
-					kind: "pending-migration",
-					detail: `Configuration requires schema version ${configSchemaVersion}.`,
-				});
-			}
-			this.#schemaReport = reconciled.report;
-			return reconciled.settings;
+			content = await Bun.file(filePath).text();
 		} catch (error) {
 			if (isEnoent(error)) {
 				this.#captureRawNotificationConfig({});
@@ -1135,6 +1095,53 @@ export class Settings implements NotificationSettingsReader {
 			}
 			throw error;
 		}
+		let parsed: unknown;
+		try {
+			parsed = YAML.parse(content);
+		} catch {
+			this.#hasMalformedConfigRoot = true;
+			this.#captureRawNotificationConfig(undefined);
+			return {};
+		}
+		if (parsed === undefined) return {};
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			this.#hasMalformedConfigRoot = true;
+			this.#captureRawNotificationConfig(undefined);
+			return {};
+		}
+		const parsedRaw = parsed as RawSettings;
+		if (filePath === this.#configPath) this.#captureRawNotificationConfig(parsedRaw);
+		if (filePath === this.#configPath) {
+			try {
+				parseNotificationSettingsSnapshot(parsedRaw);
+			} catch (error) {
+				if (!(error instanceof Error) || error.message !== "gjc_notify_daemon_invalid_configuration") throw error;
+				this.#hasInvalidNotificationConfiguration = true;
+			}
+		}
+		this.#futureSchemaVersion =
+			filePath === this.#configPath &&
+			typeof parsedRaw.configSchemaVersion === "number" &&
+			parsedRaw.configSchemaVersion > CONFIG_SCHEMA_VERSION;
+
+		const configSchemaVersion = parsedRaw.configSchemaVersion;
+		if (
+			filePath === this.#configPath &&
+			(typeof configSchemaVersion !== "number" || configSchemaVersion < CONFIG_SCHEMA_VERSION)
+		) {
+			this.#schemaMigrationPending = true;
+		}
+		const migrated = this.#migrateRawSettings(parsedRaw);
+		const reconciled = reconcileSettingsSchema(migrated);
+		if (typeof configSchemaVersion === "number" && configSchemaVersion > CONFIG_SCHEMA_VERSION) {
+			reconciled.report.issues.push({
+				path: "configSchemaVersion",
+				kind: "pending-migration",
+				detail: `Configuration requires schema version ${configSchemaVersion}.`,
+			});
+		}
+		this.#schemaReport = reconciled.report;
+		return reconciled.settings;
 	}
 
 	async #loadProjectSettings(): Promise<RawSettings> {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -388,7 +388,7 @@ export class Settings implements NotificationSettingsReader {
 	private constructor(options: SettingsOptions = {}) {
 		this.#cwd = path.normalize(options.cwd ?? getProjectDir());
 		this.#agentDir = path.normalize(options.agentDir ?? getAgentDir());
-		this.#configPath = options.inMemory ? null : path.join(this.#agentDir, "config.yml");
+		this.#configPath = options.inMemory ? null : path.resolve(this.#agentDir, "config.yml");
 		this.#persist = !options.inMemory;
 
 		if (options.overrides) {
@@ -706,13 +706,16 @@ export class Settings implements NotificationSettingsReader {
 		}));
 		for (const entry of revisions) this.#pathRevisions.set(entry.patch.path, entry.revision);
 
+		const commit = applyAtomicYamlPatches(this.#configPath, durablePatches, {
+			validateRoot: (root, currentPatches) =>
+				this.#rejectAtomicNotificationRepairForMalformedRoot(currentPatches, root),
+			onRestored: restoredPatches =>
+				this.#applyRestoredDurableBatch(revisions, restoredPatches, notificationValidationGuard),
+		});
+		const failureRefresh = this.#reserveAtomicFailureRefresh(commit);
 		try {
-			const receipt = await applyAtomicYamlPatches(this.#configPath, durablePatches, {
-				validateRoot: (root, currentPatches) =>
-					this.#rejectAtomicNotificationRepairForMalformedRoot(currentPatches, root),
-				onRestored: restoredPatches =>
-					this.#applyRestoredDurableBatch(revisions, restoredPatches, notificationValidationGuard),
-			});
+			const receipt = await commit;
+			await failureRefresh;
 			const appliedNotificationMutation = this.#applyDurableBatch(revisions);
 			this.#recordNotificationValidationBatchApply(notificationValidationGuard, appliedNotificationMutation);
 			return receipt;
@@ -723,6 +726,7 @@ export class Settings implements NotificationSettingsReader {
 					else this.#pathRevisions.set(entry.patch.path, entry.previousRevision);
 				}
 			}
+			await failureRefresh;
 			if (this.#modified.size > 0 && !this.#pendingSaveSlot) this.#queueSave();
 			throw error;
 		}
@@ -743,38 +747,41 @@ export class Settings implements NotificationSettingsReader {
 		this.#releasePendingSaveSlot();
 		let revisions: DurableBatchRevision[] = [];
 		const notificationValidationGuard = this.#notificationValidationRestoreGuard();
+		const commit = applyAtomicYamlPatchesWithCurrent(
+			this.#configPath,
+			async current => {
+				const patches = await buildPatches(structuredClone(current));
+				const durablePatches: AtomicYamlPatch[] = patches.map(patch => {
+					if (!isAtomicSettingsPath(patch.path)) {
+						throw new Error(`Unknown setting path for atomic batch: ${patch.path}`);
+					}
+					if (patch.op === "unset") return { path: patch.path, op: "unset" };
+					if (patch.value === undefined) {
+						throw new TypeError(
+							`Settings set patch for ${patch.path} cannot carry undefined; use unset instead.`,
+						);
+					}
+					return { path: patch.path, op: "set", value: structuredClone(patch.value) };
+				});
+				revisions = durablePatches.map(patch => ({
+					patch,
+					revision: ++this.#nextRevision,
+					previousRevision: this.#pathRevisions.get(patch.path),
+				}));
+				for (const entry of revisions) this.#pathRevisions.set(entry.patch.path, entry.revision);
+				return durablePatches;
+			},
+			{
+				validateRoot: (root, currentPatches) =>
+					this.#rejectAtomicNotificationRepairForMalformedRoot(currentPatches, root),
+				onRestored: restoredPatches =>
+					this.#applyRestoredDurableBatch(revisions, restoredPatches, notificationValidationGuard),
+			},
+		);
+		const failureRefresh = this.#reserveAtomicFailureRefresh(commit);
 		try {
-			const receipt = await applyAtomicYamlPatchesWithCurrent(
-				this.#configPath,
-				async current => {
-					const patches = await buildPatches(structuredClone(current));
-					const durablePatches: AtomicYamlPatch[] = patches.map(patch => {
-						if (!isAtomicSettingsPath(patch.path)) {
-							throw new Error(`Unknown setting path for atomic batch: ${patch.path}`);
-						}
-						if (patch.op === "unset") return { path: patch.path, op: "unset" };
-						if (patch.value === undefined) {
-							throw new TypeError(
-								`Settings set patch for ${patch.path} cannot carry undefined; use unset instead.`,
-							);
-						}
-						return { path: patch.path, op: "set", value: structuredClone(patch.value) };
-					});
-					revisions = durablePatches.map(patch => ({
-						patch,
-						revision: ++this.#nextRevision,
-						previousRevision: this.#pathRevisions.get(patch.path),
-					}));
-					for (const entry of revisions) this.#pathRevisions.set(entry.patch.path, entry.revision);
-					return durablePatches;
-				},
-				{
-					validateRoot: (root, currentPatches) =>
-						this.#rejectAtomicNotificationRepairForMalformedRoot(currentPatches, root),
-					onRestored: restoredPatches =>
-						this.#applyRestoredDurableBatch(revisions, restoredPatches, notificationValidationGuard),
-				},
-			);
+			const receipt = await commit;
+			await failureRefresh;
 			const appliedNotificationMutation = this.#applyDurableBatch(revisions);
 			this.#recordNotificationValidationBatchApply(notificationValidationGuard, appliedNotificationMutation);
 			return receipt;
@@ -785,6 +792,7 @@ export class Settings implements NotificationSettingsReader {
 					else this.#pathRevisions.set(entry.patch.path, entry.previousRevision);
 				}
 			}
+			await failureRefresh;
 			if (this.#modified.size > 0 && !this.#pendingSaveSlot) this.#queueSave();
 			throw error;
 		}
@@ -1806,14 +1814,34 @@ export class Settings implements NotificationSettingsReader {
 		return applicable.some(patch => isNotificationSettingsPath(patch.path));
 	}
 
+	#reserveAtomicFailureRefresh(commit: Promise<unknown>): Promise<void> {
+		if (!this.#persist || !this.#configPath) return Promise.resolve();
+		return enqueueAtomicYamlOperation(this.#configPath, async canonicalPath => {
+			try {
+				await commit;
+				return;
+			} catch {
+				// The original commit error remains authoritative. Recovery failures
+				// are diagnostic only and must not replace it.
+			}
+			try {
+				await this.#refreshDurableSettingsUnderQueue(canonicalPath);
+			} catch (refreshError) {
+				logger.warn("Settings: refresh after atomic batch failure failed", { error: String(refreshError) });
+			}
+		});
+	}
+	async #refreshDurableSettingsUnderQueue(canonicalPath: string): Promise<void> {
+		const previousFingerprint = this.#durableNotificationFingerprint;
+		const current = await this.#loadYaml(canonicalPath);
+		if (previousFingerprint !== this.#durableNotificationFingerprint) this.#notificationValidationGeneration++;
+		this.#replaceGlobalWithDurable(current);
+	}
 	async #refreshDurableSettings(): Promise<void> {
 		if (!this.#persist || !this.#configPath) return;
-		await enqueueAtomicYamlOperation(this.#configPath, async canonicalPath => {
-			const previousFingerprint = this.#durableNotificationFingerprint;
-			const current = await this.#loadYaml(canonicalPath);
-			if (previousFingerprint !== this.#durableNotificationFingerprint) this.#notificationValidationGeneration++;
-			this.#replaceGlobalWithDurable(current);
-		});
+		await enqueueAtomicYamlOperation(this.#configPath, canonicalPath =>
+			this.#refreshDurableSettingsUnderQueue(canonicalPath),
+		);
 	}
 	#assertDurableConfigWritable(): void {
 		if (this.canWriteDurableConfig()) return;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -374,6 +374,8 @@ export class Settings implements NotificationSettingsReader {
 	/** A newer config schema must never be rewritten by legacy migrations. */
 	#futureSchemaVersion = false;
 	#hasMalformedConfigRoot = false;
+	/** YAML syntax was unrecoverable, so the loaded defaults are read-only until config.yml is repaired. */
+	#hasRecoveredConfigSyntax = false;
 	#hasInvalidNotificationConfiguration = false;
 	#notificationValidationGeneration = 0;
 	/** Notification subtree fingerprint from the last raw durable config read. */
@@ -538,6 +540,7 @@ export class Settings implements NotificationSettingsReader {
 			this.unset(path);
 			return;
 		}
+		this.#assertDurableConfigWritable();
 		this.#set(path, value, true);
 	}
 
@@ -569,6 +572,7 @@ export class Settings implements NotificationSettingsReader {
 	 * `undefined` value. Defaults/project settings become visible immediately.
 	 */
 	unset<P extends SettingPath>(path: P): void {
+		this.#assertDurableConfigWritable();
 		const prev = this.get(path);
 		const patch: SettingsPatch = {
 			path,
@@ -594,6 +598,7 @@ export class Settings implements NotificationSettingsReader {
 	 * {@link set}, canonical state and hooks change only after the rename succeeds.
 	 */
 	async commitAtomicBatch(patches: readonly SettingsAtomicPatch[]): Promise<CasReceipt> {
+		this.#assertDurableConfigWritable();
 		if (!this.#persist || !this.#configPath) {
 			const notificationValidationGuard = this.#notificationValidationRestoreGuard();
 			const changes = new Map<string, { before: unknown; beforeHash: string; afterHash: string }>();
@@ -722,6 +727,7 @@ export class Settings implements NotificationSettingsReader {
 			current: Readonly<RawSettings>,
 		) => Promise<readonly SettingsAtomicPatch[]> | readonly SettingsAtomicPatch[],
 	): Promise<CasReceipt> {
+		this.#assertDurableConfigWritable();
 		if (!this.#persist || !this.#configPath) {
 			const patches = await buildPatches(structuredClone(this.#global));
 			return this.commitAtomicBatch(patches);
@@ -948,6 +954,7 @@ export class Settings implements NotificationSettingsReader {
 	}
 
 	setGlobalModelRole(role: ModelRole | string, modelId: ModelSelectorValue | undefined): void {
+		this.#assertDurableConfigWritable();
 		const revision = ++this.#nextRevision;
 		const patch: SettingsPatch = {
 			path: "modelRoles",
@@ -1083,6 +1090,7 @@ export class Settings implements NotificationSettingsReader {
 
 	async #loadYaml(filePath: string): Promise<RawSettings> {
 		this.#hasMalformedConfigRoot = false;
+		this.#hasRecoveredConfigSyntax = false;
 		this.#hasInvalidNotificationConfiguration = false;
 		this.#captureRawNotificationConfig({});
 		let content: string;
@@ -1099,13 +1107,34 @@ export class Settings implements NotificationSettingsReader {
 		try {
 			parsed = YAML.parse(content);
 		} catch {
+			this.#hasRecoveredConfigSyntax = true;
 			this.#hasMalformedConfigRoot = true;
+			this.#schemaReport = {
+				valid: false,
+				issues: [
+					{
+						path: "config.yml",
+						kind: "invalid",
+						detail: "Configuration YAML syntax is invalid; repair config.yml before changing settings.",
+					},
+				],
+			};
 			this.#captureRawNotificationConfig(undefined);
 			return {};
 		}
 		if (parsed === undefined) return {};
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
 			this.#hasMalformedConfigRoot = true;
+			this.#schemaReport = {
+				valid: false,
+				issues: [
+					{
+						path: "config.yml",
+						kind: "invalid",
+						detail: "Configuration root must be a YAML mapping.",
+					},
+				],
+			};
 			this.#captureRawNotificationConfig(undefined);
 			return {};
 		}
@@ -1534,7 +1563,7 @@ export class Settings implements NotificationSettingsReader {
 	// ─────────────────────────────────────────────────────────────────────────
 
 	#queueSave(): void {
-		if (!this.#persist || !this.#configPath) return;
+		if (!this.#persist || !this.#configPath || this.#hasRecoveredConfigSyntax) return;
 
 		const currentSlot = this.#pendingSaveSlot;
 		if (currentSlot && !currentSlot.captured && !currentSlot.released) {
@@ -1729,6 +1758,12 @@ export class Settings implements NotificationSettingsReader {
 		const current = await this.#loadYaml(this.#configPath);
 		if (previousFingerprint !== this.#durableNotificationFingerprint) this.#notificationValidationGeneration++;
 		this.#replaceGlobalWithDurable(current);
+	}
+	#assertDurableConfigWritable(): void {
+		if (!this.#persist || !this.#hasRecoveredConfigSyntax) return;
+		throw new Error(
+			"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+		);
 	}
 
 	// ─────────────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1023,7 +1023,9 @@ export class Settings implements NotificationSettingsReader {
 		this.#global = current;
 		for (const patch of this.#pendingPatchesInGenerationOrder()) {
 			applySettingsPatch(this.#global, { ...patch, value: structuredClone(patch.value) });
-			this.#applyNotificationMutationToRaw(patch.path, patch.value);
+			if (this.#rawNotificationConfig !== undefined) {
+				this.#applyNotificationMutationToRaw(patch.path, patch.value);
+			}
 		}
 		this.#rebuildMerged();
 		this.#recomputeNotificationValidationFromRaw();

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -535,7 +535,6 @@ export class Settings implements NotificationSettingsReader {
 	canWriteDurableConfig(): boolean {
 		return !this.#persist || !this.#hasRecoveredConfigSyntax;
 	}
-	}
 
 	/**
 	 * Set a setting value (sync).

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -838,6 +838,15 @@ export class Settings implements NotificationSettingsReader {
 			}
 		}
 		await this.#refreshDurableSettings();
+		if (this.#modified.size > 0 && !this.#pendingSaveSlot) {
+			this.#queueSave();
+			this.#releasePendingSaveSlot();
+			try {
+				await this.#savePromise;
+			} catch {
+				// Keep dirty state for a later explicit flush or mutation.
+			}
+		}
 	}
 
 	/** Like {@link flush}, but reports a durable save failure to the caller. */
@@ -845,8 +854,20 @@ export class Settings implements NotificationSettingsReader {
 		this.#releasePendingSaveSlot();
 		if (this.#modified.size > 0 && !this.#pendingSaveSlot) this.#queueSave();
 		this.#releasePendingSaveSlot();
-		await this.#savePromise;
+		let saveError: unknown;
+		try {
+			await this.#savePromise;
+		} catch (error) {
+			saveError = error;
+		}
 		await this.#refreshDurableSettings();
+		if (this.#modified.size > 0 && !this.#pendingSaveSlot) {
+			this.#queueSave();
+			this.#releasePendingSaveSlot();
+			await this.#savePromise;
+			return;
+		}
+		if (saveError !== undefined) throw saveError;
 	}
 
 	async cloneForCwd(cwd: string): Promise<Settings> {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -13,7 +13,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { isDeepStrictEqual } from "node:util";
+import * as util from "node:util";
 import {
 	getAgentDbPath,
 	getAgentDir,
@@ -1048,7 +1048,7 @@ export class Settings implements NotificationSettingsReader {
 		for (const settingPath of Object.keys(SETTINGS_SCHEMA) as SettingPath[]) {
 			const previousValue = previous.get(settingPath);
 			const nextValue = this.get(settingPath);
-			if (isDeepStrictEqual(previousValue, nextValue)) continue;
+			if (util.isDeepStrictEqual(previousValue, nextValue)) continue;
 			const hook = SETTING_HOOKS[settingPath];
 			if (hook) hook(nextValue, previousValue);
 			for (const listener of this.#changeListeners) listener(settingPath);

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -892,6 +892,10 @@ export class Settings implements NotificationSettingsReader {
 		cloned.#rawNotificationConfig = structuredClone(this.#rawNotificationConfig);
 		cloned.#durableRawNotificationConfig = structuredClone(this.#durableRawNotificationConfig);
 		cloned.#durableNotificationFingerprint = this.#durableNotificationFingerprint;
+		cloned.#modified = new Map([...this.#modified].map(([key, patch]) => [key, structuredClone(patch)]));
+		cloned.#nextGeneration = this.#nextGeneration;
+		cloned.#pathRevisions = structuredClone(this.#pathRevisions);
+		cloned.#nextRevision = this.#nextRevision;
 		cloned.#project = this.#persist ? await cloned.#loadProjectSettings() : structuredClone(this.#project);
 		cloned.#overrides = structuredClone(this.#overrides);
 		await cloned.#normalizeAfterLoad();
@@ -1672,25 +1676,33 @@ export class Settings implements NotificationSettingsReader {
 					this.#recomputeNotificationValidationFromRaw();
 				},
 			};
-		}).then(() => undefined);
-		this.#savePromise = save;
-		void save.catch(error => {
-			logger.warn("Settings: background save failed", { error: String(error) });
-			for (const patch of captured) {
-				const key = settingsPatchKey(patch);
-				if (this.#modified.get(key)?.generation === patch.generation) this.#modified.set(key, patch);
-			}
-			if (durableBeforeWrite) {
-				this.#global = durableBeforeWrite;
-				this.#captureRawNotificationConfig(durableBeforeWrite);
-				for (const patch of this.#pendingPatchesInGenerationOrder()) {
-					applySettingsPatch(this.#global, { ...patch, value: structuredClone(patch.value) });
-					this.#applyNotificationMutationToRaw(patch.path, patch.value);
+		})
+			.then(() => undefined)
+			.catch(async error => {
+				logger.warn("Settings: background save failed", { error: String(error) });
+				for (const patch of captured) {
+					const key = settingsPatchKey(patch);
+					if (this.#modified.get(key)?.generation === patch.generation) this.#modified.set(key, patch);
 				}
-				this.#rebuildMerged();
-				this.#recomputeNotificationValidationFromRaw();
-			}
-		});
+				if (durableBeforeWrite) {
+					this.#global = durableBeforeWrite;
+					this.#captureRawNotificationConfig(durableBeforeWrite);
+					for (const patch of this.#pendingPatchesInGenerationOrder()) {
+						applySettingsPatch(this.#global, { ...patch, value: structuredClone(patch.value) });
+						this.#applyNotificationMutationToRaw(patch.path, patch.value);
+					}
+					this.#rebuildMerged();
+					this.#recomputeNotificationValidationFromRaw();
+				}
+				try {
+					await this.#refreshDurableSettings();
+				} catch (refreshError) {
+					logger.warn("Settings: refresh after background save failure failed", { error: String(refreshError) });
+				}
+				throw error;
+			});
+		this.#savePromise = save;
+		void save.catch(() => {});
 		this.#armSaveTimer(slot);
 	}
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -13,6 +13,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import {
 	getAgentDbPath,
 	getAgentDir,
@@ -1031,6 +1032,10 @@ export class Settings implements NotificationSettingsReader {
 	}
 
 	#replaceGlobalWithDurable(current: RawSettings): void {
+		const previous = new Map<SettingPath, unknown>();
+		for (const settingPath of Object.keys(SETTINGS_SCHEMA) as SettingPath[]) {
+			previous.set(settingPath, structuredClone(this.get(settingPath)));
+		}
 		this.#global = current;
 		for (const patch of this.#pendingPatchesInGenerationOrder()) {
 			applySettingsPatch(this.#global, { ...patch, value: structuredClone(patch.value) });
@@ -1040,6 +1045,14 @@ export class Settings implements NotificationSettingsReader {
 		}
 		this.#rebuildMerged();
 		this.#recomputeNotificationValidationFromRaw();
+		for (const settingPath of Object.keys(SETTINGS_SCHEMA) as SettingPath[]) {
+			const previousValue = previous.get(settingPath);
+			const nextValue = this.get(settingPath);
+			if (isDeepStrictEqual(previousValue, nextValue)) continue;
+			const hook = SETTING_HOOKS[settingPath];
+			if (hook) hook(nextValue, previousValue);
+			for (const listener of this.#changeListeners) listener(settingPath);
+		}
 	}
 	/**
 	 * Set an agent model override while keeping any live runtime override aligned.

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -42,6 +42,7 @@ import {
 	atomicYamlPathHash,
 	type CasReceipt,
 	deleteByPath,
+	enqueueAtomicYamlOperation,
 	reserveAtomicYamlUpdateSlot,
 	setByPath,
 } from "./atomic-yaml-patch";
@@ -892,13 +893,12 @@ export class Settings implements NotificationSettingsReader {
 		cloned.#rawNotificationConfig = structuredClone(this.#rawNotificationConfig);
 		cloned.#durableRawNotificationConfig = structuredClone(this.#durableRawNotificationConfig);
 		cloned.#durableNotificationFingerprint = this.#durableNotificationFingerprint;
-		cloned.#modified = new Map([...this.#modified].map(([key, patch]) => [key, structuredClone(patch)]));
-		cloned.#nextGeneration = this.#nextGeneration;
-		cloned.#pathRevisions = structuredClone(this.#pathRevisions);
-		cloned.#nextRevision = this.#nextRevision;
 		cloned.#project = this.#persist ? await cloned.#loadProjectSettings() : structuredClone(this.#project);
 		cloned.#overrides = structuredClone(this.#overrides);
-		await cloned.#normalizeAfterLoad();
+		if (cloned.#hasRecoveredConfigSyntax) {
+			cloned.#sanitizeModelSelectorRecords();
+			cloned.#rebuildMerged();
+		} else await cloned.#normalizeAfterLoad();
 		cloned.#fireAllHooks();
 		return cloned;
 	}
@@ -1808,10 +1808,12 @@ export class Settings implements NotificationSettingsReader {
 
 	async #refreshDurableSettings(): Promise<void> {
 		if (!this.#persist || !this.#configPath) return;
-		const previousFingerprint = this.#durableNotificationFingerprint;
-		const current = await this.#loadYaml(this.#configPath);
-		if (previousFingerprint !== this.#durableNotificationFingerprint) this.#notificationValidationGeneration++;
-		this.#replaceGlobalWithDurable(current);
+		await enqueueAtomicYamlOperation(this.#configPath, async canonicalPath => {
+			const previousFingerprint = this.#durableNotificationFingerprint;
+			const current = await this.#loadYaml(canonicalPath);
+			if (previousFingerprint !== this.#durableNotificationFingerprint) this.#notificationValidationGeneration++;
+			this.#replaceGlobalWithDurable(current);
+		});
 	}
 	#assertDurableConfigWritable(): void {
 		if (this.canWriteDurableConfig()) return;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -530,6 +530,12 @@ export class Settings implements NotificationSettingsReader {
 		return () => this.#changeListeners.delete(listener);
 	}
 
+	/** Whether durable settings mutations are permitted for the loaded configuration. */
+	canWriteDurableConfig(): boolean {
+		return !this.#persist || !this.#hasRecoveredConfigSyntax;
+	}
+	}
+
 	/**
 	 * Set a setting value (sync).
 	 * Updates global settings and reserves its background persistence slot before
@@ -854,8 +860,13 @@ export class Settings implements NotificationSettingsReader {
 			inMemory: !this.#persist,
 		});
 		cloned.#storage = this.#storage;
+		cloned.#schemaReport = structuredClone(this.#schemaReport);
+		cloned.#schemaMigrationPending = this.#schemaMigrationPending;
 		cloned.#futureSchemaVersion = this.#futureSchemaVersion;
-
+		cloned.#hasMalformedConfigRoot = this.#hasMalformedConfigRoot;
+		cloned.#hasRecoveredConfigSyntax = this.#hasRecoveredConfigSyntax;
+		cloned.#hasInvalidNotificationConfiguration = this.#hasInvalidNotificationConfiguration;
+		cloned.#notificationValidationGeneration = this.#notificationValidationGeneration;
 		cloned.#global = structuredClone(this.#global);
 		cloned.#rawNotificationConfig = structuredClone(this.#rawNotificationConfig);
 		cloned.#durableRawNotificationConfig = structuredClone(this.#durableRawNotificationConfig);
@@ -1088,21 +1099,29 @@ export class Settings implements NotificationSettingsReader {
 		}
 	}
 
-	async #loadYaml(filePath: string): Promise<RawSettings> {
+	#resetYamlLoadState(): void {
 		this.#hasMalformedConfigRoot = false;
 		this.#hasRecoveredConfigSyntax = false;
 		this.#hasInvalidNotificationConfiguration = false;
+		this.#schemaReport = { issues: [], valid: true };
+		this.#schemaMigrationPending = false;
+		this.#futureSchemaVersion = false;
 		this.#captureRawNotificationConfig({});
+	}
+
+	async #loadYaml(filePath: string): Promise<RawSettings> {
 		let content: string;
 		try {
 			content = await Bun.file(filePath).text();
 		} catch (error) {
 			if (isEnoent(error)) {
-				this.#captureRawNotificationConfig({});
+				this.#resetYamlLoadState();
 				return {};
 			}
 			throw error;
 		}
+		this.#resetYamlLoadState();
+		if (content.trim() === "") return {};
 		let parsed: unknown;
 		try {
 			parsed = YAML.parse(content);
@@ -1760,7 +1779,7 @@ export class Settings implements NotificationSettingsReader {
 		this.#replaceGlobalWithDurable(current);
 	}
 	#assertDurableConfigWritable(): void {
-		if (!this.#persist || !this.#hasRecoveredConfigSyntax) return;
+		if (this.canWriteDurableConfig()) return;
 		throw new Error(
 			"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
 		);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -698,7 +698,7 @@ async function promptForkSession(session: SessionInfo): Promise<boolean> {
 	}
 }
 
-async function getChangelogForDisplay(parsed: Args): Promise<string | undefined> {
+export async function getChangelogForDisplay(parsed: Args): Promise<string | undefined> {
 	if (parsed.continue || parsed.resume) {
 		return undefined;
 	}
@@ -710,15 +710,19 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 
 	const lastVersion = settings.get("lastChangelogVersion");
 	if (!lastVersion) {
-		settings.set("lastChangelogVersion", VERSION);
-		await flushChangelogVersion();
+		if (settings.canWriteDurableConfig()) {
+			settings.set("lastChangelogVersion", VERSION);
+			await flushChangelogVersion();
+		}
 		return getInstalledVersionChangelogEntry(entries, VERSION)?.content;
 	}
 
 	if (lastVersion !== VERSION) {
 		const newEntries = getNewEntries(entries, lastVersion);
-		settings.set("lastChangelogVersion", VERSION);
-		await flushChangelogVersion();
+		if (settings.canWriteDurableConfig()) {
+			settings.set("lastChangelogVersion", VERSION);
+			await flushChangelogVersion();
+		}
 		if (newEntries.length > 0) {
 			return newEntries.map(e => e.content).join("\n\n");
 		}

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -235,18 +235,16 @@ function getSavedUsageMode(): UsageMode {
 	return segmentOptions.usage?.mode === "remaining" ? "remaining" : "used";
 }
 
-function setSavedUsageMode(mode: string): StatusLineSegmentOptions {
+function getUsageModeSettings(mode: string): StatusLineSegmentOptions {
 	const normalizedMode: UsageMode = mode === "remaining" ? "remaining" : "used";
 	const segmentOptions = settings.get("statusLine.segmentOptions") as StatusLineSegmentOptions;
-	const nextOptions: StatusLineSegmentOptions = {
+	return {
 		...segmentOptions,
 		usage: {
 			...(segmentOptions.usage ?? {}),
 			mode: normalizedMode,
 		},
 	};
-	settings.set("statusLine.segmentOptions", nextOptions as Record<string, unknown>);
-	return nextOptions;
 }
 
 function statusSegmentLabel(id: StatusLineSegmentId): string {
@@ -613,14 +611,17 @@ class StatusLineCustomEditor extends Container {
 	}
 
 	#save(): void {
-		settings.set("statusLine.preset", "custom");
-		settings.set("statusLine.leftSegments", [...this.#draft.leftSegments]);
-		settings.set("statusLine.rightSegments", [...this.#draft.rightSegments]);
-		settings.set("statusLine.separator", this.#draft.separator);
-		settings.set(
-			"statusLine.segmentOptions",
-			cloneSegmentOptions(this.#draft.segmentOptions) as Record<string, unknown>,
-		);
+		const saved = commitInteractiveSettings(this.callbacks, () => {
+			settings.set("statusLine.preset", "custom");
+			settings.set("statusLine.leftSegments", [...this.#draft.leftSegments]);
+			settings.set("statusLine.rightSegments", [...this.#draft.rightSegments]);
+			settings.set("statusLine.separator", this.#draft.separator);
+			settings.set(
+				"statusLine.segmentOptions",
+				cloneSegmentOptions(this.#draft.segmentOptions) as Record<string, unknown>,
+			);
+		});
+		if (!saved) return;
 		this.callbacks.onChange("statusLine.preset", "custom");
 		this.callbacks.onChange("statusLine.leftSegments", [...this.#draft.leftSegments]);
 		this.callbacks.onChange("statusLine.rightSegments", [...this.#draft.rightSegments]);
@@ -707,8 +708,28 @@ export interface SettingsCallbacks {
 	getStatusLinePreview?: (width?: number) => string;
 	/** Called when plugins change */
 	onPluginsChanged?: () => void;
+	/** Called when an interactive setting cannot be committed. */
+	onError?: (message: string) => void;
 	/** Called when settings panel is closed */
 	onCancel: () => void;
+}
+function commitInteractiveSettings(callbacks: SettingsCallbacks, commit: () => void): boolean {
+	if (!settings.canWriteDurableConfig()) {
+		callbacks.onError?.(
+			"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+		);
+		return false;
+	}
+	try {
+		commit();
+		return true;
+	} catch (error) {
+		if (!settings.canWriteDurableConfig()) {
+			callbacks.onError?.(error instanceof Error ? error.message : String(error));
+			return false;
+		}
+		throw error;
+	}
 }
 
 /**
@@ -998,7 +1019,7 @@ export class SettingsSelectorComponent extends Container {
 					done(accepted ? value : undefined);
 					return;
 				}
-				this.#setSettingValue(def.path, value);
+				if (!commitInteractiveSettings(this.callbacks, () => this.#setSettingValue(def.path, value))) return;
 				this.callbacks.onChange(def.path, value);
 				done(value);
 			},
@@ -1031,7 +1052,7 @@ export class SettingsSelectorComponent extends Container {
 			value => {
 				// Empty string clears the setting; undefined-typed string settings
 				// store "" which the browser.ts expandPath ignores (no-op fallback).
-				this.#setSettingValue(def.path, value);
+				if (!commitInteractiveSettings(this.callbacks, () => this.#setSettingValue(def.path, value))) return;
 				this.callbacks.onChange(def.path, value);
 				wrappedDone(value);
 			},
@@ -1089,7 +1110,15 @@ export class SettingsSelectorComponent extends Container {
 			getSettingsListTheme(),
 			(id, newValue) => {
 				if (id === STATUS_LINE_USAGE_MODE_ID) {
-					const segmentOptions = setSavedUsageMode(newValue);
+					const segmentOptions = getUsageModeSettings(newValue);
+					if (
+						!commitInteractiveSettings(this.callbacks, () => {
+							settings.set("statusLine.segmentOptions", segmentOptions as Record<string, unknown>);
+						})
+					) {
+						this.#refreshCurrentTabItems(defs);
+						return;
+					}
 					this.callbacks.onChange("statusLine.segmentOptions", segmentOptions);
 					if (tabId === "appearance") {
 						this.#triggerStatusLinePreview();
@@ -1105,14 +1134,20 @@ export class SettingsSelectorComponent extends Container {
 
 				if (def.type === "boolean") {
 					const boolValue = newValue === "true";
-					settings.set(path, boolValue as never);
+					if (!commitInteractiveSettings(this.callbacks, () => settings.set(path, boolValue as never))) {
+						this.#refreshCurrentTabItems(defs);
+						return;
+					}
 					this.callbacks.onChange(path, boolValue);
 
 					if (tabId === "appearance") {
 						this.#triggerStatusLinePreview();
 					}
 				} else if (def.type === "enum") {
-					settings.set(path, newValue as never);
+					if (!commitInteractiveSettings(this.callbacks, () => settings.set(path, newValue as never))) {
+						this.#refreshCurrentTabItems(defs);
+						return;
+					}
 					this.callbacks.onChange(path, newValue);
 				}
 				// Submenu/text types already persisted the value inside their own

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -1015,7 +1015,14 @@ export class SettingsSelectorComponent extends Container {
 					// The shared pet commit policy rechecks capability immediately
 					// before mutation and persists only on acceptance; the settings
 					// surface must not persist ahead of that result.
-					const accepted = this.callbacks.onPetCommit?.(value) ?? false;
+					let accepted = false;
+					if (
+						!commitInteractiveSettings(this.callbacks, () => {
+							accepted = this.callbacks.onPetCommit?.(value) ?? false;
+						})
+					) {
+						return;
+					}
 					done(accepted ? value : undefined);
 					return;
 				}

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -281,7 +281,24 @@ export class ExtensionUiController {
 				const disabled = [...(session.settings.get("disabledExtensions") ?? [])];
 				const on = input.on === true;
 				const next = on ? disabled.filter(value => value !== id) : [...new Set([...disabled, id])];
-				session.settings.set("disabledExtensions", next);
+				if (!session.settings.canWriteDurableConfig()) {
+					throw Object.assign(
+						new Error(
+							"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+						),
+						{ code: "invalid_request" },
+					);
+				}
+				try {
+					session.settings.set("disabledExtensions", next);
+				} catch (error) {
+					if (!session.settings.canWriteDurableConfig()) {
+						throw Object.assign(new Error(error instanceof Error ? error.message : String(error)), {
+							code: "invalid_request",
+						});
+					}
+					throw error;
+				}
 				return { changed: true, enabled: on };
 			}
 			case "session.delete":

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -2061,7 +2061,7 @@ export class InputController {
 			throw error;
 		}
 		this.ctx.hideThinkingBlock = hideThinkingBlock;
-		this.ctx.session.agent.hideThinkingSummary = hideThinkingBlock;
+		this.ctx.session.setThinkingVisibility(hideThinkingBlock ? "hidden" : "visible");
 
 		// Rebuild chat from session messages
 		// Detach the live streaming component before the disposing clear() so the

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -2044,9 +2044,24 @@ export class InputController {
 	}
 
 	toggleThinkingBlockVisibility(): void {
-		this.ctx.hideThinkingBlock = !this.ctx.hideThinkingBlock;
-		settings.set("hideThinkingBlock", this.ctx.hideThinkingBlock);
-		this.ctx.session.agent.hideThinkingSummary = this.ctx.hideThinkingBlock;
+		if (!settings.canWriteDurableConfig()) {
+			this.ctx.showError(
+				"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+			);
+			return;
+		}
+		const hideThinkingBlock = !this.ctx.hideThinkingBlock;
+		try {
+			settings.set("hideThinkingBlock", hideThinkingBlock);
+		} catch (error) {
+			if (!settings.canWriteDurableConfig()) {
+				this.ctx.showError(error instanceof Error ? error.message : String(error));
+				return;
+			}
+			throw error;
+		}
+		this.ctx.hideThinkingBlock = hideThinkingBlock;
+		this.ctx.session.agent.hideThinkingSummary = hideThinkingBlock;
 
 		// Rebuild chat from session messages
 		// Detach the live streaming component before the disposing clear() so the

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1153,6 +1153,12 @@ export class SelectorController {
 		);
 		if (scope === undefined) return;
 		const persistDefault = scope.trim().toLowerCase() === "default";
+		if (persistDefault && !this.ctx.settings.canWriteDurableConfig()) {
+			this.ctx.showError(
+				"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+			);
+			return;
+		}
 
 		const imageProvider = normalized as
 			| "auto"

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1227,6 +1227,12 @@ export class SelectorController {
 				this.ctx.session.thinkingLevel,
 				availableLevels,
 				selection => {
+					if (selection.persistDefault && !this.ctx.settings.canWriteDurableConfig()) {
+						this.ctx.showError(
+							"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+						);
+						return;
+					}
 					done();
 
 					const { level, persistDefault } = selection;
@@ -1336,24 +1342,40 @@ export class SelectorController {
 		getAvailableThemes().then(availableThemes => {
 			const initialTheme = getCurrentThemeName() ?? "red-claw";
 			this.showSelector(done => {
+				const restoreAndClose = () => {
+					void restoreThemePreview(initialTheme).then(result => {
+						if (!result.success && result.error) {
+							this.ctx.showError(`Failed to restore theme preview: ${result.error}`);
+						}
+						this.#refreshThemeUi();
+					});
+					done();
+				};
 				const selector = new ThemeSelectorComponent(
 					initialTheme,
 					availableThemes,
 					themeName => {
-						const settingPath = getDetectedThemeSettingsPath();
-						settings.set(settingPath, themeName);
+						if (!settings.canWriteDurableConfig()) {
+							this.ctx.showError(
+								"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+							);
+							restoreAndClose();
+							return;
+						}
+						try {
+							settings.set(getDetectedThemeSettingsPath(), themeName);
+						} catch (error) {
+							if (!settings.canWriteDurableConfig()) {
+								this.ctx.showError(error instanceof Error ? error.message : String(error));
+								restoreAndClose();
+								return;
+							}
+							throw error;
+						}
 						this.#refreshThemeUi();
 						done();
 					},
-					() => {
-						void restoreThemePreview(initialTheme).then(result => {
-							if (!result.success && result.error) {
-								this.ctx.showError(`Failed to restore theme preview: ${result.error}`);
-							}
-							this.#refreshThemeUi();
-						});
-						done();
-					},
+					restoreAndClose,
 					themeName => {
 						void previewTheme(themeName).then(result => {
 							if (!result.success && result.error) {
@@ -1377,8 +1399,9 @@ export class SelectorController {
 			const selector = new PetSelectorComponent(
 				initial,
 				mode => {
-					this.ctx.setPetMode(mode);
-					done();
+					if (this.ctx.setPetMode(mode)) {
+						done();
+					}
 				},
 				() => {
 					this.ctx.previewPetMode(initial);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1292,6 +1292,7 @@ export class SelectorController {
 						onPetPreview: mode => {
 							this.ctx.previewPetMode(mode as PetMode);
 						},
+						onPetCommit: mode => this.ctx.commitPetPreviewMode(mode as PetMode),
 						onStatusLinePreview: previewSettings => {
 							// Update status line with preview settings
 							this.ctx.statusLine.updateSettings({

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1272,6 +1272,7 @@ export class SelectorController {
 					},
 					{
 						onChange: (id, value) => this.handleSettingChange(id, value),
+						onError: message => this.ctx.showError(message),
 						onThemePreview: themeName => {
 							return previewTheme(themeName).then(result => {
 								if (!result.success && result.error && !isThemePreviewSuperseded(result)) {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1226,19 +1226,18 @@ export class SelectorController {
 			const selector = new ThinkingSelectorComponent(
 				this.ctx.session.thinkingLevel,
 				availableLevels,
-				selection => {
-					if (selection.persistDefault && !this.ctx.settings.canWriteDurableConfig()) {
-						this.ctx.showError(
-							"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
-						);
+				async selection => {
+					const { level, persistDefault } = selection;
+					const configuredDefault = this.ctx.settings.get("defaultThinkingLevel");
+					const levelToApply = level === ThinkingLevel.Inherit ? configuredDefault : level;
+					try {
+						await this.ctx.session.setThinkingLevelForControl(level, persistDefault);
+					} catch (error) {
+						this.ctx.showError(error instanceof Error ? error.message : String(error));
 						return;
 					}
 					done();
 
-					const { level, persistDefault } = selection;
-					const configuredDefault = this.ctx.settings.get("defaultThinkingLevel");
-					const levelToApply = level === ThinkingLevel.Inherit ? configuredDefault : level;
-					this.ctx.session.setThinkingLevel(levelToApply, persistDefault);
 					const effectiveLevel = this.ctx.session.thinkingLevel ?? ThinkingLevel.Off;
 					const requestedLabel =
 						level === ThinkingLevel.Inherit ? `${level} (configured default: ${configuredDefault})` : level;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1199,8 +1199,22 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.ui.requestRender();
 			return false;
 		}
+		if (!settings.canWriteDurableConfig()) {
+			this.showError(
+				"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+			);
+			return false;
+		}
+		try {
+			settings.set("pet.mode", mode);
+		} catch (error) {
+			if (!settings.canWriteDurableConfig()) {
+				this.showError(error instanceof Error ? error.message : String(error));
+				return false;
+			}
+			throw error;
+		}
 		apply(mode);
-		settings.set("pet.mode", mode);
 		this.ui.requestRender();
 		return true;
 	}

--- a/packages/coding-agent/src/modes/runtime-init.ts
+++ b/packages/coding-agent/src/modes/runtime-init.ts
@@ -380,7 +380,24 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 						const disabled = [...(session.settings.get("disabledExtensions") ?? [])];
 						const on = input.on === true;
 						const next = on ? disabled.filter(value => value !== id) : [...new Set([...disabled, id])];
-						session.settings.set("disabledExtensions", next);
+						if (!session.settings.canWriteDurableConfig()) {
+							throw Object.assign(
+								new Error(
+									"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+								),
+								{ code: "invalid_request" },
+							);
+						}
+						try {
+							session.settings.set("disabledExtensions", next);
+						} catch (error) {
+							if (!session.settings.canWriteDurableConfig()) {
+								throw Object.assign(new Error(error instanceof Error ? error.message : String(error)), {
+									code: "invalid_request",
+								});
+							}
+							throw error;
+						}
 						return { changed: true, enabled: on };
 					}
 					case "session.delete":

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -10388,6 +10388,13 @@ export class AgentSession {
 			}
 			throw new Error("Unable to persist reasoning settings.");
 		}
+		if (
+			mutationRevision === this.#thinkingVisibilityMutationRevision &&
+			this.#thinkingVisibilityLiveMutationRevision === expectedLiveMutationRevision
+		) {
+			this.setThinkingVisibility(visibility);
+			return;
+		}
 
 		if (
 			mutationRevision !== this.#thinkingVisibilityMutationRevision ||

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -10273,6 +10273,14 @@ export class AgentSession {
 		}
 
 		if (
+			mutationRevision === this.#thinkingLevelMutationRevision &&
+			this.#thinkingLevelLiveMutationRevision === expectedLiveMutationRevision
+		) {
+			this.setThinkingLevel(level === ThinkingLevel.Inherit ? this.#getInheritedThinkingLevel() : level);
+			this.sessionManager.appendThinkingLevelChange(ThinkingLevel.Inherit);
+			return;
+		}
+		if (
 			mutationRevision !== this.#thinkingLevelMutationRevision ||
 			this.#reasoningControlContextGeneration !== expectedContextGeneration ||
 			this.sessionManager.getSessionId() !== expectedSessionId ||

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2755,7 +2755,6 @@ export class AgentSession {
 		this.#thinkingLevelLiveMutationRevision++;
 		this.#pendingThinkingLevelControlSuccess = undefined;
 		this.#pendingThinkingLevelControlFailure = undefined;
-		this.#thinkingVisibilityLiveMutationRevision++;
 		this.#pendingThinkingVisibilityControlSuccess = undefined;
 		this.#pendingThinkingVisibilityControlFailure = undefined;
 		this.#thinkingLevel = scope.thinkingLevel;
@@ -9434,7 +9433,6 @@ export class AgentSession {
 		this.#thinkingLevelLiveMutationRevision++;
 		this.#pendingThinkingLevelControlSuccess = undefined;
 		this.#pendingThinkingLevelControlFailure = undefined;
-		this.#thinkingVisibilityLiveMutationRevision++;
 		this.#pendingThinkingVisibilityControlSuccess = undefined;
 		this.#pendingThinkingVisibilityControlFailure = undefined;
 		this.#thinkingLevel = inheritedThinkingLevel;
@@ -9875,7 +9873,6 @@ export class AgentSession {
 		this.#thinkingLevelLiveMutationRevision++;
 		this.#pendingThinkingLevelControlSuccess = undefined;
 		this.#pendingThinkingLevelControlFailure = undefined;
-		this.#thinkingVisibilityLiveMutationRevision++;
 		this.#pendingThinkingVisibilityControlSuccess = undefined;
 		this.#pendingThinkingVisibilityControlFailure = undefined;
 		this.#thinkingLevel = thinkingLevel;
@@ -15135,7 +15132,6 @@ export class AgentSession {
 				this.#thinkingLevelLiveMutationRevision++;
 				this.#pendingThinkingLevelControlSuccess = undefined;
 				this.#pendingThinkingLevelControlFailure = undefined;
-				this.#thinkingVisibilityLiveMutationRevision++;
 				this.#pendingThinkingVisibilityControlSuccess = undefined;
 				this.#pendingThinkingVisibilityControlFailure = undefined;
 				this.#thinkingLevel = nextThinkingLevel;
@@ -15213,7 +15209,6 @@ export class AgentSession {
 				this.#thinkingLevelLiveMutationRevision++;
 				this.#pendingThinkingLevelControlSuccess = undefined;
 				this.#pendingThinkingLevelControlFailure = undefined;
-				this.#thinkingVisibilityLiveMutationRevision++;
 				this.#pendingThinkingVisibilityControlSuccess = undefined;
 				this.#pendingThinkingVisibilityControlFailure = undefined;
 				this.#thinkingLevel = previousThinkingLevel;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1572,6 +1572,8 @@ export class AgentSession {
 	#sessionAdmissionClosed = false;
 	#sessionAdmissionContext = new AsyncLocalStorage<SessionAdmissionEntry>();
 	#defaultModelSelectionMutationRevision = 0;
+	#thinkingLevelMutationRevision = 0;
+	#thinkingVisibilityMutationRevision = 0;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
 
@@ -2710,6 +2712,7 @@ export class AgentSession {
 			this.agent.setModel(scope.model);
 			this.#syncAppendOnlyContext(scope.model);
 		}
+		this.#thinkingLevelMutationRevision++;
 		this.#thinkingLevel = scope.thinkingLevel;
 		this.agent.setThinkingLevel(toReasoningEffort(scope.thinkingLevel));
 		void this.#syncEditToolModeAfterModelChange(previousEditMode);
@@ -9381,6 +9384,7 @@ export class AgentSession {
 	): Promise<void> {
 		this.#clearConstructorToolSelectionAuthority();
 		const inheritedThinkingLevel = resolveThinkingLevelForModel(this.model, this.#getInheritedThinkingLevel());
+		this.#thinkingLevelMutationRevision++;
 		this.#thinkingLevel = inheritedThinkingLevel;
 		this.agent.setThinkingLevel(toReasoningEffort(inheritedThinkingLevel));
 		this.sessionManager.appendThinkingLevelChange(ThinkingLevel.Inherit);
@@ -9815,6 +9819,7 @@ export class AgentSession {
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
 		const thinkingLevelChanged = this.#thinkingLevel !== thinkingLevel;
+		this.#thinkingLevelMutationRevision++;
 		this.#thinkingLevel = thinkingLevel;
 		this.agent.setThinkingLevel(toReasoningEffort(thinkingLevel));
 		if (thinkingLevelChanged) {
@@ -10123,7 +10128,16 @@ export class AgentSession {
 	 * Set thinking level.
 	 * Saves the effective metadata-clamped level to the session, and to settings when requested.
 	 */
+	#assertDurableSettingsWritable(): void {
+		if (this.settings.canWriteDurableConfig()) return;
+		throw new Error(
+			"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+		);
+	}
+
 	setThinkingLevel(level: ThinkingLevel | undefined, persist: boolean = false): void {
+		if (persist) this.#assertDurableSettingsWritable();
+		this.#thinkingLevelMutationRevision++;
 		const effectiveLevel = resolveThinkingLevelForModel(this.model, level);
 		const isChanging = effectiveLevel !== this.#thinkingLevel;
 
@@ -10143,11 +10157,10 @@ export class AgentSession {
 	}
 
 	/**
-	 * Set thinking level from a control surface. Global changes are durable or rolled back.
+	 * Set thinking level from a control surface. Global changes commit before affecting live state.
 	 */
 	async setThinkingLevelForControl(level: ThinkingLevel, persist: boolean): Promise<void> {
 		const previousThinkingLevel = this.thinkingLevel;
-		const previousScope = this.getThinkingScopeForControl();
 		if (!persist) {
 			this.setThinkingLevel(level === ThinkingLevel.Inherit ? this.#getInheritedThinkingLevel() : level);
 			if (level === ThinkingLevel.Inherit || this.thinkingLevel === previousThinkingLevel) {
@@ -10156,26 +10169,30 @@ export class AgentSession {
 			return;
 		}
 
-		const previousDefaultThinkingLevel = this.settings.getGlobal("defaultThinkingLevel");
-		if (level === ThinkingLevel.Inherit) {
-			const defaultLevel = getDefault("defaultThinkingLevel");
-			this.settings.set("defaultThinkingLevel", defaultLevel);
-			this.setThinkingLevel(this.#getInheritedThinkingLevel());
-		} else {
-			this.setThinkingLevel(level, true);
-		}
+		this.#assertDurableSettingsWritable();
+		const effectiveLevel = resolveThinkingLevelForModel(
+			this.model,
+			level === ThinkingLevel.Inherit ? this.#getInheritedThinkingLevel() : level,
+		);
+		const persistedLevel = level === ThinkingLevel.Inherit ? getDefault("defaultThinkingLevel") : effectiveLevel;
+		const mutationRevision = ++this.#thinkingLevelMutationRevision;
+		const expectedSessionId = this.sessionManager.getSessionId();
+		const expectedModel = this.model;
 		try {
-			await this.settings.flushOrThrow();
-			this.sessionManager.appendThinkingLevelChange(ThinkingLevel.Inherit);
+			await this.settings.commitAtomicBatch([{ path: "defaultThinkingLevel", op: "set", value: persistedLevel }]);
 		} catch {
-			this.settings.set("defaultThinkingLevel", previousDefaultThinkingLevel ?? getDefault("defaultThinkingLevel"));
-			this.setThinkingLevel(previousThinkingLevel);
-			this.sessionManager.appendThinkingLevelChange(
-				previousScope === "global config" ? ThinkingLevel.Inherit : previousThinkingLevel,
-			);
-			await this.settings.flushOrThrow().catch(() => {});
 			throw new Error("Unable to persist reasoning settings.");
 		}
+
+		if (
+			mutationRevision !== this.#thinkingLevelMutationRevision ||
+			this.sessionManager.getSessionId() !== expectedSessionId ||
+			this.model !== expectedModel
+		) {
+			return;
+		}
+		this.setThinkingLevel(level === ThinkingLevel.Inherit ? this.#getInheritedThinkingLevel() : effectiveLevel);
+		this.sessionManager.appendThinkingLevelChange(ThinkingLevel.Inherit);
 	}
 
 	getThinkingScopeForControl(): "session" | "global config" {
@@ -10191,6 +10208,8 @@ export class AgentSession {
 	}
 
 	setThinkingVisibility(visibility: "visible" | "hidden", persist: boolean = false): void {
+		if (persist) this.#assertDurableSettingsWritable();
+		this.#thinkingVisibilityMutationRevision++;
 		this.agent.hideThinkingSummary = visibility === "hidden";
 		if (persist) {
 			this.settings.set("hideThinkingBlock", visibility === "hidden");
@@ -10198,7 +10217,7 @@ export class AgentSession {
 	}
 
 	/**
-	 * Set thinking visibility from a control surface. Global changes are durable or rolled back.
+	 * Set thinking visibility from a control surface. Global changes commit before affecting live state.
 	 */
 	async setThinkingVisibilityForControl(visibility: "visible" | "hidden", persist: boolean): Promise<void> {
 		if (!persist) {
@@ -10206,17 +10225,24 @@ export class AgentSession {
 			return;
 		}
 
-		const previousVisibility = this.getThinkingVisibility();
-		const previousHideThinkingBlock = this.settings.getGlobal("hideThinkingBlock");
-		this.setThinkingVisibility(visibility, true);
+		this.#assertDurableSettingsWritable();
+		const mutationRevision = ++this.#thinkingVisibilityMutationRevision;
+		const expectedSessionId = this.sessionManager.getSessionId();
 		try {
-			await this.settings.flushOrThrow();
+			await this.settings.commitAtomicBatch([
+				{ path: "hideThinkingBlock", op: "set", value: visibility === "hidden" },
+			]);
 		} catch {
-			this.settings.set("hideThinkingBlock", previousHideThinkingBlock ?? getDefault("hideThinkingBlock"));
-			this.setThinkingVisibility(previousVisibility);
-			await this.settings.flushOrThrow().catch(() => {});
 			throw new Error("Unable to persist reasoning settings.");
 		}
+
+		if (
+			mutationRevision !== this.#thinkingVisibilityMutationRevision ||
+			this.sessionManager.getSessionId() !== expectedSessionId
+		) {
+			return;
+		}
+		this.setThinkingVisibility(visibility);
 	}
 
 	/**
@@ -10393,6 +10419,7 @@ export class AgentSession {
 	 * Saves to settings.
 	 */
 	setSteeringMode(mode: "all" | "one-at-a-time"): void {
+		this.#assertDurableSettingsWritable();
 		this.agent.setSteeringMode(mode);
 		this.settings.set("steeringMode", mode);
 	}
@@ -10402,6 +10429,7 @@ export class AgentSession {
 	 * Saves to settings.
 	 */
 	setFollowUpMode(mode: "all" | "one-at-a-time"): void {
+		this.#assertDurableSettingsWritable();
 		this.agent.setFollowUpMode(mode);
 		this.settings.set("followUpMode", mode);
 	}
@@ -10411,6 +10439,7 @@ export class AgentSession {
 	 * Saves to settings.
 	 */
 	setInterruptMode(mode: "immediate" | "wait"): void {
+		this.#assertDurableSettingsWritable();
 		this.agent.setInterruptMode(mode);
 		this.settings.set("interruptMode", mode);
 	}
@@ -14979,6 +15008,7 @@ export class AgentSession {
 				if (previousModel) {
 					this.agent.setModel(previousModel);
 				}
+				this.#thinkingLevelMutationRevision++;
 				this.#thinkingLevel = previousThinkingLevel;
 				this.agent.setThinkingLevel(toReasoningEffort(previousThinkingLevel));
 				this.agent.serviceTier = previousServiceTier;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1574,6 +1574,45 @@ export class AgentSession {
 	#defaultModelSelectionMutationRevision = 0;
 	#thinkingLevelMutationRevision = 0;
 	#thinkingVisibilityMutationRevision = 0;
+	#thinkingLevelLiveMutationRevision = 0;
+	#thinkingVisibilityLiveMutationRevision = 0;
+	#reasoningControlContextGeneration = 0;
+	#pendingThinkingLevelControlSuccess:
+		| {
+				level: ThinkingLevel;
+				mutationRevision: number;
+				sessionId: string;
+				model: Model | undefined;
+				contextGeneration: number;
+		  }
+		| undefined;
+	#pendingThinkingVisibilityControlSuccess:
+		| {
+				visibility: "visible" | "hidden";
+				mutationRevision: number;
+				sessionId: string;
+				model: Model | undefined;
+				contextGeneration: number;
+		  }
+		| undefined;
+	#pendingThinkingLevelControlFailure:
+		| {
+				mutationRevision: number;
+				liveMutationRevision: number;
+				sessionId: string;
+				model: Model | undefined;
+				contextGeneration: number;
+		  }
+		| undefined;
+	#pendingThinkingVisibilityControlFailure:
+		| {
+				mutationRevision: number;
+				liveMutationRevision: number;
+				sessionId: string;
+				model: Model | undefined;
+				contextGeneration: number;
+		  }
+		| undefined;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
 
@@ -2709,10 +2748,16 @@ export class AgentSession {
 		this.#defaultFallbackController = scope.fallbackController;
 		const previousEditMode = this.#resolveActiveEditMode();
 		if (scope.model) {
-			this.agent.setModel(scope.model);
+			this.#setAgentModelWithReasoningContext(scope.model);
 			this.#syncAppendOnlyContext(scope.model);
 		}
 		this.#thinkingLevelMutationRevision++;
+		this.#thinkingLevelLiveMutationRevision++;
+		this.#pendingThinkingLevelControlSuccess = undefined;
+		this.#pendingThinkingLevelControlFailure = undefined;
+		this.#thinkingVisibilityLiveMutationRevision++;
+		this.#pendingThinkingVisibilityControlSuccess = undefined;
+		this.#pendingThinkingVisibilityControlFailure = undefined;
 		this.#thinkingLevel = scope.thinkingLevel;
 		this.agent.setThinkingLevel(toReasoningEffort(scope.thinkingLevel));
 		void this.#syncEditToolModeAfterModelChange(previousEditMode);
@@ -5156,6 +5201,7 @@ export class AgentSession {
 	 * such event.
 	 */
 	#syncAgentSessionId(sessionId?: string): void {
+		this.#reasoningControlContextGeneration++;
 		const sid = this.#providerSessionId ?? sessionId ?? this.sessionManager.getSessionId();
 		this.agent.sessionId = sid;
 		this.agent.providerSessionId = this.#providerCacheSessionId ?? sid;
@@ -9385,6 +9431,12 @@ export class AgentSession {
 		this.#clearConstructorToolSelectionAuthority();
 		const inheritedThinkingLevel = resolveThinkingLevelForModel(this.model, this.#getInheritedThinkingLevel());
 		this.#thinkingLevelMutationRevision++;
+		this.#thinkingLevelLiveMutationRevision++;
+		this.#pendingThinkingLevelControlSuccess = undefined;
+		this.#pendingThinkingLevelControlFailure = undefined;
+		this.#thinkingVisibilityLiveMutationRevision++;
+		this.#pendingThinkingVisibilityControlSuccess = undefined;
+		this.#pendingThinkingVisibilityControlFailure = undefined;
 		this.#thinkingLevel = inheritedThinkingLevel;
 		this.agent.setThinkingLevel(toReasoningEffort(inheritedThinkingLevel));
 		this.sessionManager.appendThinkingLevelChange(ThinkingLevel.Inherit);
@@ -9734,7 +9786,7 @@ export class AgentSession {
 		const ownsScope = scope !== undefined && !suppliedScope;
 		try {
 			if (isTemporaryOperation) {
-				this.agent.setModel(model);
+				this.#setAgentModelWithReasoningContext(model);
 				this.#syncAppendOnlyContext(model);
 			} else {
 				this.#setModelAuthoritatively(model, options?.cause ?? "temporary-operation");
@@ -9820,6 +9872,12 @@ export class AgentSession {
 		this.#setModelWithProviderSessionReset(model);
 		const thinkingLevelChanged = this.#thinkingLevel !== thinkingLevel;
 		this.#thinkingLevelMutationRevision++;
+		this.#thinkingLevelLiveMutationRevision++;
+		this.#pendingThinkingLevelControlSuccess = undefined;
+		this.#pendingThinkingLevelControlFailure = undefined;
+		this.#thinkingVisibilityLiveMutationRevision++;
+		this.#pendingThinkingVisibilityControlSuccess = undefined;
+		this.#pendingThinkingVisibilityControlFailure = undefined;
 		this.#thinkingLevel = thinkingLevel;
 		this.agent.setThinkingLevel(toReasoningEffort(thinkingLevel));
 		if (thinkingLevelChanged) {
@@ -10138,6 +10196,9 @@ export class AgentSession {
 	setThinkingLevel(level: ThinkingLevel | undefined, persist: boolean = false): void {
 		if (persist) this.#assertDurableSettingsWritable();
 		this.#thinkingLevelMutationRevision++;
+		this.#thinkingLevelLiveMutationRevision++;
+		this.#pendingThinkingLevelControlSuccess = undefined;
+		this.#pendingThinkingLevelControlFailure = undefined;
 		const effectiveLevel = resolveThinkingLevelForModel(this.model, level);
 		const isChanging = effectiveLevel !== this.#thinkingLevel;
 
@@ -10176,19 +10237,80 @@ export class AgentSession {
 		);
 		const persistedLevel = level === ThinkingLevel.Inherit ? getDefault("defaultThinkingLevel") : effectiveLevel;
 		const mutationRevision = ++this.#thinkingLevelMutationRevision;
+		const expectedLiveMutationRevision = this.#thinkingLevelLiveMutationRevision;
 		const expectedSessionId = this.sessionManager.getSessionId();
 		const expectedModel = this.model;
+		const expectedContextGeneration = this.#reasoningControlContextGeneration;
 		try {
 			await this.settings.commitAtomicBatch([{ path: "defaultThinkingLevel", op: "set", value: persistedLevel }]);
 		} catch {
+			if (
+				mutationRevision === this.#thinkingLevelMutationRevision &&
+				this.#reasoningControlContextGeneration === expectedContextGeneration &&
+				this.sessionManager.getSessionId() === expectedSessionId &&
+				this.model === expectedModel
+			) {
+				const pending = this.#pendingThinkingLevelControlSuccess;
+				this.#pendingThinkingLevelControlSuccess = undefined;
+				if (
+					pending &&
+					pending.contextGeneration === expectedContextGeneration &&
+					this.sessionManager.getSessionId() === pending.sessionId &&
+					this.model === pending.model
+				) {
+					this.setThinkingLevel(
+						pending.level === ThinkingLevel.Inherit ? this.#getInheritedThinkingLevel() : pending.level,
+					);
+					this.sessionManager.appendThinkingLevelChange(ThinkingLevel.Inherit);
+				} else {
+					this.#pendingThinkingLevelControlFailure = {
+						mutationRevision,
+						liveMutationRevision: expectedLiveMutationRevision,
+						sessionId: expectedSessionId,
+						model: expectedModel,
+						contextGeneration: expectedContextGeneration,
+					};
+				}
+			}
 			throw new Error("Unable to persist reasoning settings.");
 		}
 
 		if (
 			mutationRevision !== this.#thinkingLevelMutationRevision ||
+			this.#reasoningControlContextGeneration !== expectedContextGeneration ||
 			this.sessionManager.getSessionId() !== expectedSessionId ||
 			this.model !== expectedModel
 		) {
+			if (
+				this.#thinkingLevelLiveMutationRevision === expectedLiveMutationRevision &&
+				this.#reasoningControlContextGeneration === expectedContextGeneration &&
+				this.sessionManager.getSessionId() === expectedSessionId &&
+				this.model === expectedModel &&
+				(this.#pendingThinkingLevelControlSuccess?.mutationRevision ?? -1) < mutationRevision
+			) {
+				this.#pendingThinkingLevelControlSuccess = {
+					level,
+					mutationRevision,
+					sessionId: expectedSessionId,
+					model: expectedModel,
+					contextGeneration: expectedContextGeneration,
+				};
+				const failure = this.#pendingThinkingLevelControlFailure;
+				if (
+					failure &&
+					failure.mutationRevision === this.#thinkingLevelMutationRevision &&
+					failure.liveMutationRevision === expectedLiveMutationRevision &&
+					failure.sessionId === expectedSessionId &&
+					failure.model === expectedModel &&
+					failure.contextGeneration === expectedContextGeneration
+				) {
+					this.#pendingThinkingLevelControlFailure = undefined;
+					this.setThinkingLevel(
+						level === ThinkingLevel.Inherit ? this.#getInheritedThinkingLevel() : effectiveLevel,
+					);
+					this.sessionManager.appendThinkingLevelChange(ThinkingLevel.Inherit);
+				}
+			}
 			return;
 		}
 		this.setThinkingLevel(level === ThinkingLevel.Inherit ? this.#getInheritedThinkingLevel() : effectiveLevel);
@@ -10210,6 +10332,9 @@ export class AgentSession {
 	setThinkingVisibility(visibility: "visible" | "hidden", persist: boolean = false): void {
 		if (persist) this.#assertDurableSettingsWritable();
 		this.#thinkingVisibilityMutationRevision++;
+		this.#thinkingVisibilityLiveMutationRevision++;
+		this.#pendingThinkingVisibilityControlSuccess = undefined;
+		this.#pendingThinkingVisibilityControlFailure = undefined;
 		this.agent.hideThinkingSummary = visibility === "hidden";
 		if (persist) {
 			this.settings.set("hideThinkingBlock", visibility === "hidden");
@@ -10227,19 +10352,76 @@ export class AgentSession {
 
 		this.#assertDurableSettingsWritable();
 		const mutationRevision = ++this.#thinkingVisibilityMutationRevision;
+		const expectedLiveMutationRevision = this.#thinkingVisibilityLiveMutationRevision;
 		const expectedSessionId = this.sessionManager.getSessionId();
+		const expectedModel = this.model;
+		const expectedContextGeneration = this.#reasoningControlContextGeneration;
 		try {
 			await this.settings.commitAtomicBatch([
 				{ path: "hideThinkingBlock", op: "set", value: visibility === "hidden" },
 			]);
 		} catch {
+			if (
+				mutationRevision === this.#thinkingVisibilityMutationRevision &&
+				this.#reasoningControlContextGeneration === expectedContextGeneration &&
+				this.sessionManager.getSessionId() === expectedSessionId &&
+				this.model === expectedModel
+			) {
+				const pending = this.#pendingThinkingVisibilityControlSuccess;
+				this.#pendingThinkingVisibilityControlSuccess = undefined;
+				if (
+					pending &&
+					pending.contextGeneration === expectedContextGeneration &&
+					this.sessionManager.getSessionId() === pending.sessionId &&
+					this.model === pending.model
+				) {
+					this.setThinkingVisibility(pending.visibility);
+				} else {
+					this.#pendingThinkingVisibilityControlFailure = {
+						mutationRevision,
+						liveMutationRevision: expectedLiveMutationRevision,
+						sessionId: expectedSessionId,
+						model: expectedModel,
+						contextGeneration: expectedContextGeneration,
+					};
+				}
+			}
 			throw new Error("Unable to persist reasoning settings.");
 		}
 
 		if (
 			mutationRevision !== this.#thinkingVisibilityMutationRevision ||
-			this.sessionManager.getSessionId() !== expectedSessionId
+			this.#reasoningControlContextGeneration !== expectedContextGeneration ||
+			this.sessionManager.getSessionId() !== expectedSessionId ||
+			this.model !== expectedModel
 		) {
+			if (
+				this.#thinkingVisibilityLiveMutationRevision === expectedLiveMutationRevision &&
+				this.#reasoningControlContextGeneration === expectedContextGeneration &&
+				this.sessionManager.getSessionId() === expectedSessionId &&
+				this.model === expectedModel &&
+				(this.#pendingThinkingVisibilityControlSuccess?.mutationRevision ?? -1) < mutationRevision
+			) {
+				this.#pendingThinkingVisibilityControlSuccess = {
+					visibility,
+					mutationRevision,
+					sessionId: expectedSessionId,
+					model: expectedModel,
+					contextGeneration: expectedContextGeneration,
+				};
+				const failure = this.#pendingThinkingVisibilityControlFailure;
+				if (
+					failure &&
+					failure.mutationRevision === this.#thinkingVisibilityMutationRevision &&
+					failure.liveMutationRevision === expectedLiveMutationRevision &&
+					failure.sessionId === expectedSessionId &&
+					failure.model === expectedModel &&
+					failure.contextGeneration === expectedContextGeneration
+				) {
+					this.#pendingThinkingVisibilityControlFailure = undefined;
+					this.setThinkingVisibility(visibility);
+				}
+			}
 			return;
 		}
 		this.setThinkingVisibility(visibility);
@@ -11927,13 +12109,18 @@ export class AgentSession {
 		this.#defaultFallbackExhaustedLastTurn = false;
 	}
 
+	#setAgentModelWithReasoningContext(model: Model | undefined): void {
+		this.#reasoningControlContextGeneration++;
+		this.agent.setModel(model);
+	}
+
 	#setModelWithProviderSessionReset(model: Model | undefined): void {
 		this.#defaultModelSelectionMutationRevision++;
 		const currentModel = this.model;
 		if (currentModel) {
 			this.#closeProviderSessionsForModelSwitch(currentModel, model);
 		}
-		this.agent.setModel(model);
+		this.#setAgentModelWithReasoningContext(model);
 	}
 
 	#setModelAuthoritatively(model: Model, cause: ModelChangeCause): void {
@@ -11942,7 +12129,7 @@ export class AgentSession {
 		if (cause !== "temporary-operation") this.#commitAllTemporaryProviderSessionScopes();
 		const currentModel = this.model;
 		if (currentModel) this.#closeProviderSessionsForModelSwitch(currentModel, model);
-		this.agent.setModel(model);
+		this.#setAgentModelWithReasoningContext(model);
 		this.#syncAppendOnlyContext(model);
 	}
 
@@ -14937,6 +15124,13 @@ export class AgentSession {
 						? this.#getInheritedThinkingLevel()
 						: persistedThinkingLevel,
 				);
+				this.#thinkingLevelMutationRevision++;
+				this.#thinkingLevelLiveMutationRevision++;
+				this.#pendingThinkingLevelControlSuccess = undefined;
+				this.#pendingThinkingLevelControlFailure = undefined;
+				this.#thinkingVisibilityLiveMutationRevision++;
+				this.#pendingThinkingVisibilityControlSuccess = undefined;
+				this.#pendingThinkingVisibilityControlFailure = undefined;
 				this.#thinkingLevel = nextThinkingLevel;
 				this.agent.setThinkingLevel(toReasoningEffort(nextThinkingLevel));
 				this.agent.serviceTier = hasServiceTierEntry
@@ -15006,9 +15200,15 @@ export class AgentSession {
 				this.agent.restoreSteering(previousAgentSteeringQueue);
 				this.agent.restoreFollowUp(previousAgentFollowUpQueue);
 				if (previousModel) {
-					this.agent.setModel(previousModel);
+					this.#setAgentModelWithReasoningContext(previousModel);
 				}
 				this.#thinkingLevelMutationRevision++;
+				this.#thinkingLevelLiveMutationRevision++;
+				this.#pendingThinkingLevelControlSuccess = undefined;
+				this.#pendingThinkingLevelControlFailure = undefined;
+				this.#thinkingVisibilityLiveMutationRevision++;
+				this.#pendingThinkingVisibilityControlSuccess = undefined;
+				this.#pendingThinkingVisibilityControlFailure = undefined;
 				this.#thinkingLevel = previousThinkingLevel;
 				this.agent.setThinkingLevel(toReasoningEffort(previousThinkingLevel));
 				this.agent.serviceTier = previousServiceTier;

--- a/packages/coding-agent/test/agent-session-queued-prompts.test.ts
+++ b/packages/coding-agent/test/agent-session-queued-prompts.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as path from "node:path";
 import type { AgentMessage } from "@gajae-code/agent-core";
 import { Agent } from "@gajae-code/agent-core";
@@ -62,7 +62,10 @@ describe("AgentSession queued prompts (issue #434)", () => {
 		await removeTempDirWithRetry(tempDir);
 	});
 
-	function buildSession(responses: MockHandler[]): AgentSession {
+	function buildSession(
+		responses: MockHandler[],
+		settings = Settings.isolated({ "compaction.enabled": false }),
+	): AgentSession {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected bundled Anthropic test model to exist");
 		const mock = createMockModel({ responses });
@@ -71,7 +74,6 @@ describe("AgentSession queued prompts (issue #434)", () => {
 			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
 			streamFn: mock.stream,
 		});
-		const settings = Settings.isolated({ "compaction.enabled": false });
 		settings.setModelRole("default", `${model.provider}/${model.id}`);
 		return new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
 	}
@@ -102,6 +104,34 @@ describe("AgentSession queued prompts (issue #434)", () => {
 		}
 	}
 
+	it("rejects persisted queue modes before changing the live agent", () => {
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			steeringMode: "one-at-a-time",
+			followUpMode: "one-at-a-time",
+			interruptMode: "immediate",
+		});
+		session = buildSession([], settings);
+		const canWrite = spyOn(settings, "canWriteDurableConfig").mockReturnValue(false);
+		const set = spyOn(settings, "set");
+
+		try {
+			expect(() => session!.setSteeringMode("all")).toThrow("Repair config.yml");
+			expect(() => session!.setFollowUpMode("all")).toThrow("Repair config.yml");
+			expect(() => session!.setInterruptMode("wait")).toThrow("Repair config.yml");
+
+			expect(session.agent.getSteeringMode()).toBe("one-at-a-time");
+			expect(session.agent.getFollowUpMode()).toBe("one-at-a-time");
+			expect(session.agent.getInterruptMode()).toBe("immediate");
+			expect(settings.getGlobal("steeringMode")).toBe("one-at-a-time");
+			expect(settings.getGlobal("followUpMode")).toBe("one-at-a-time");
+			expect(settings.getGlobal("interruptMode")).toBe("immediate");
+			expect(set).not.toHaveBeenCalled();
+		} finally {
+			canWrite.mockRestore();
+			set.mockRestore();
+		}
+	});
 	it("runs prompts queued while busy after the active turn, in submission order", async () => {
 		const gate = Promise.withResolvers<void>();
 		session = buildSession([

--- a/packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts
+++ b/packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts
@@ -2,11 +2,11 @@
  * Regression test for #1075:
  * discoverAgents() must skip GJC plugin roots when the plugin provider is disabled.
  */
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { disableProvider, enableProvider } from "../../src/capability";
+import { disableProvider, enableProvider, initializeWithSettings, isProviderEnabled } from "../../src/capability";
 import { clearCache as clearFsCache } from "../../src/capability/fs";
 import { resetSettingsForTest, Settings } from "../../src/config/settings";
 import { clearClaudePluginRootsCache } from "../../src/discovery/helpers";
@@ -78,5 +78,22 @@ describe("discoverAgents — claude-plugins disabled provider", () => {
 		clearClaudePluginRootsCache();
 		const { agents } = await discoverAgents(tempHome, tempHome, settings);
 		expect(agents.map(a => a.name)).not.toContain("simplifier");
+	});
+	test("rejects provider toggles before mutating state when initialized settings are read-only", () => {
+		const writableSettings = Settings.isolated();
+		const readOnlySettings = Settings.isolated({ disabledProviders: ["already-disabled"] });
+		const canWrite = vi.spyOn(readOnlySettings, "canWriteDurableConfig").mockReturnValue(false);
+		initializeWithSettings(readOnlySettings);
+
+		try {
+			expect(() => disableProvider("new-provider")).toThrow("Repair config.yml");
+			expect(isProviderEnabled("new-provider")).toBe(true);
+
+			expect(() => enableProvider("already-disabled")).toThrow("Repair config.yml");
+			expect(isProviderEnabled("already-disabled")).toBe(false);
+		} finally {
+			canWrite.mockRestore();
+			initializeWithSettings(writableSettings);
+		}
 	});
 });

--- a/packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts
+++ b/packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts
@@ -6,7 +6,14 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { disableProvider, enableProvider, initializeWithSettings, isProviderEnabled } from "../../src/capability";
+import {
+	disableProvider,
+	enableProvider,
+	getDisabledProviders,
+	initializeWithSettings,
+	isProviderEnabled,
+	setDisabledProviders,
+} from "../../src/capability";
 import { clearCache as clearFsCache } from "../../src/capability/fs";
 import { resetSettingsForTest, Settings } from "../../src/config/settings";
 import { clearClaudePluginRootsCache } from "../../src/discovery/helpers";
@@ -91,6 +98,9 @@ describe("discoverAgents — claude-plugins disabled provider", () => {
 
 			expect(() => enableProvider("already-disabled")).toThrow("Repair config.yml");
 			expect(isProviderEnabled("already-disabled")).toBe(false);
+
+			expect(() => setDisabledProviders(["replacement"])).toThrow("Repair config.yml");
+			expect(getDisabledProviders()).toEqual(["already-disabled"]);
 		} finally {
 			canWrite.mockRestore();
 			initializeWithSettings(writableSettings);

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -5,6 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { defaultEditorTheme } from "../../tui/test/test-themes";
 import { formatKeyHint as formatKeyHintForPlatform } from "../src/config/keybindings";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
 import { CustomEditor, type PasteTextContext } from "../src/modes/components/custom-editor";
 import { QueuedMessageSelectorComponent } from "../src/modes/components/queued-message-selector";
 import { InputController } from "../src/modes/controllers/input-controller";
@@ -389,6 +390,31 @@ describe("InputController keybinding setup", () => {
 
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(1, { temporaryOnly: true });
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(2);
+	});
+	it("routes accepted thinking visibility changes through the session", async () => {
+		const activeSettings = await Settings.init({ inMemory: true });
+		const set = vi.spyOn(activeSettings, "set");
+		const { InputController, ctx } = await createContext();
+		const setThinkingVisibility = vi.fn();
+		const session = ctx.session as unknown as { setThinkingVisibility: (visibility: "visible" | "hidden") => void };
+		session.setThinkingVisibility = setThinkingVisibility;
+		ctx.hideThinkingBlock = false;
+		ctx.chatContainer = {
+			detachChild: vi.fn(),
+			addChild: vi.fn(),
+		} as unknown as InteractiveModeContext["chatContainer"];
+		ctx.rebuildChatFromMessages = vi.fn();
+
+		try {
+			new InputController(ctx).toggleThinkingBlockVisibility();
+
+			expect(set).toHaveBeenCalledWith("hideThinkingBlock", true);
+			expect(setThinkingVisibility).toHaveBeenCalledWith("hidden");
+			expect(set.mock.invocationCallOrder[0]).toBeLessThan(setThinkingVisibility.mock.invocationCallOrder[0]);
+		} finally {
+			set.mockRestore();
+			resetSettingsForTest();
+		}
 	});
 
 	it("registers the default IRC sidebar shortcut and consumes its dispatch", async () => {

--- a/packages/coding-agent/test/issue-775-repro.test.ts
+++ b/packages/coding-agent/test/issue-775-repro.test.ts
@@ -364,7 +364,7 @@ describe("issue #775: per-model defaultLevel", () => {
 	});
 	it("leaves reasoning level state untouched when config corruption breaks the durable commit", async () => {
 		const agentDir = path.join(tempDir.path(), "agent");
-		const settings = await Settings.init({ cwd: tempDir.path(), agentDir });
+		const settings = await Settings.loadForScope({ cwd: tempDir.path(), agentDir });
 		await createSession(getSonnet(), settings);
 		const history = structuredClone(session.sessionManager.getBranch());
 		const settingsBefore = settings.getGlobal("defaultThinkingLevel");
@@ -384,12 +384,13 @@ describe("issue #775: per-model defaultLevel", () => {
 			expect(settings.getGlobal("defaultThinkingLevel")).toBe(settingsBefore);
 		} finally {
 			unsubscribe();
+			settings.getStorage()?.close();
 		}
 	});
 
 	it("leaves reasoning visibility state untouched when config corruption breaks the durable commit", async () => {
 		const agentDir = path.join(tempDir.path(), "agent");
-		const settings = await Settings.init({ cwd: tempDir.path(), agentDir });
+		const settings = await Settings.loadForScope({ cwd: tempDir.path(), agentDir });
 		await createSession(getSonnet(), settings);
 		const history = structuredClone(session.sessionManager.getBranch());
 		const settingsBefore = settings.getGlobal("hideThinkingBlock");
@@ -409,6 +410,7 @@ describe("issue #775: per-model defaultLevel", () => {
 			expect(settings.getGlobal("hideThinkingBlock")).toBe(settingsBefore);
 		} finally {
 			unsubscribe();
+			settings.getStorage()?.close();
 		}
 	});
 });

--- a/packages/coding-agent/test/issue-775-repro.test.ts
+++ b/packages/coding-agent/test/issue-775-repro.test.ts
@@ -330,6 +330,108 @@ describe("issue #775: per-model defaultLevel", () => {
 			commit.mockRestore();
 		}
 	});
+	it("reconciles an older successful thinking level after the newer durable commit fails", async () => {
+		const settings = Settings.isolated({ defaultThinkingLevel: Effort.Low });
+		await createSession(getSonnet(), settings);
+		const firstStarted = Promise.withResolvers<void>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const secondStarted = Promise.withResolvers<void>();
+		const commitAtomicBatch = settings.commitAtomicBatch.bind(settings);
+		let callCount = 0;
+		const commit = spyOn(settings, "commitAtomicBatch").mockImplementation(async changes => {
+			if (++callCount === 1) {
+				firstStarted.resolve();
+				await releaseFirst.promise;
+				return commitAtomicBatch(changes);
+			}
+			secondStarted.resolve();
+			throw new Error("newer commit failed");
+		});
+
+		try {
+			const older = session.setThinkingLevelForControl(Effort.Medium, true);
+			await firstStarted.promise;
+			const newer = session.setThinkingLevelForControl(Effort.High, true);
+			await secondStarted.promise;
+			releaseFirst.resolve();
+			await older;
+			await expect(newer).rejects.toThrow("Unable to persist reasoning settings.");
+
+			expect(settings.getGlobal("defaultThinkingLevel")).toBe(Effort.Medium);
+			expect(session.thinkingLevel).toBe(Effort.Medium);
+			expect(session.getThinkingScopeForControl()).toBe("global config");
+		} finally {
+			commit.mockRestore();
+		}
+	});
+	it("reconciles an older successful thinking visibility after the newer durable commit fails", async () => {
+		const settings = Settings.isolated({ hideThinkingBlock: false });
+		await createSession(getSonnet(), settings);
+		const firstStarted = Promise.withResolvers<void>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const secondStarted = Promise.withResolvers<void>();
+		const commitAtomicBatch = settings.commitAtomicBatch.bind(settings);
+		let callCount = 0;
+		const commit = spyOn(settings, "commitAtomicBatch").mockImplementation(async changes => {
+			if (++callCount === 1) {
+				firstStarted.resolve();
+				await releaseFirst.promise;
+				return commitAtomicBatch(changes);
+			}
+			secondStarted.resolve();
+			throw new Error("newer commit failed");
+		});
+
+		try {
+			const older = session.setThinkingVisibilityForControl("hidden", true);
+			await firstStarted.promise;
+			const newer = session.setThinkingVisibilityForControl("visible", true);
+			await secondStarted.promise;
+			releaseFirst.resolve();
+			await older;
+			await expect(newer).rejects.toThrow("Unable to persist reasoning settings.");
+
+			expect(settings.getGlobal("hideThinkingBlock")).toBe(true);
+			expect(session.getThinkingVisibility()).toBe("hidden");
+		} finally {
+			commit.mockRestore();
+		}
+	});
+	it("does not reconcile over an intervening live thinking level mutation", async () => {
+		const settings = Settings.isolated({ defaultThinkingLevel: Effort.Low });
+		await createSession(getSonnet(), settings);
+		const firstStarted = Promise.withResolvers<void>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const secondStarted = Promise.withResolvers<void>();
+		const commitAtomicBatch = settings.commitAtomicBatch.bind(settings);
+		let callCount = 0;
+		const commit = spyOn(settings, "commitAtomicBatch").mockImplementation(async changes => {
+			if (++callCount === 1) {
+				firstStarted.resolve();
+				await releaseFirst.promise;
+				return commitAtomicBatch(changes);
+			}
+			secondStarted.resolve();
+			throw new Error("newer commit failed");
+		});
+
+		try {
+			const older = session.setThinkingLevelForControl(Effort.Medium, true);
+			await firstStarted.promise;
+			const newer = session.setThinkingLevelForControl(Effort.High, true);
+			await secondStarted.promise;
+			releaseFirst.resolve();
+			await older;
+			await session.setThinkingLevelForControl(Effort.Low, false);
+			await expect(newer).rejects.toThrow("Unable to persist reasoning settings.");
+
+			expect(settings.getGlobal("defaultThinkingLevel")).toBe(Effort.Medium);
+			expect(session.thinkingLevel).toBe(Effort.Low);
+			expect(session.getThinkingScopeForControl()).toBe("session");
+		} finally {
+			commit.mockRestore();
+		}
+	});
 	it("rejects durable thinking controls before mutating session state", async () => {
 		const sonnet = getSonnet();
 		const settings = Settings.isolated({

--- a/packages/coding-agent/test/issue-775-repro.test.ts
+++ b/packages/coding-agent/test/issue-775-repro.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as path from "node:path";
 import { Agent, ThinkingLevel } from "@gajae-code/agent-core";
 import { Effort, getBundledModel, type Model } from "@gajae-code/ai";
@@ -180,5 +180,235 @@ describe("issue #775: per-model defaultLevel", () => {
 		expect(session.thinkingLevel).toBe(settings.get("defaultThinkingLevel"));
 		expect(session.getThinkingScopeForControl()).toBe("global config");
 		expect(session.sessionManager.buildSessionContext().thinkingLevel).toBe(ThinkingLevel.Inherit);
+	});
+	it("keeps a newer session thinking level when a global control commit finishes", async () => {
+		const settings = Settings.isolated({ defaultThinkingLevel: Effort.Low });
+		await createSession(getSonnet(), settings);
+		const commitStarted = Promise.withResolvers<void>();
+		const releaseCommit = Promise.withResolvers<void>();
+		const commitAtomicBatch = settings.commitAtomicBatch.bind(settings);
+		const commit = spyOn(settings, "commitAtomicBatch").mockImplementation(async changes => {
+			commitStarted.resolve();
+			await releaseCommit.promise;
+			return commitAtomicBatch(changes);
+		});
+		const events: string[] = [];
+		const unsubscribe = session.subscribe(event => events.push(event.type));
+
+		try {
+			const persistentControl = session.setThinkingLevelForControl(Effort.Medium, true);
+			await commitStarted.promise;
+			await session.setThinkingLevelForControl(Effort.Low, false);
+			const historyAfterNewerControl = structuredClone(session.sessionManager.getBranch());
+
+			releaseCommit.resolve();
+			await persistentControl;
+
+			expect(settings.getGlobal("defaultThinkingLevel")).toBe(Effort.Medium);
+			expect(session.thinkingLevel).toBe(Effort.Low);
+			expect(session.sessionManager.getBranch()).toEqual(historyAfterNewerControl);
+			expect(events).toEqual([]);
+		} finally {
+			unsubscribe();
+			commit.mockRestore();
+		}
+	});
+
+	it("keeps a newer session thinking visibility when a global control commit finishes", async () => {
+		const settings = Settings.isolated({ hideThinkingBlock: false });
+		await createSession(getSonnet(), settings);
+		session.setThinkingVisibility("hidden");
+		const history = structuredClone(session.sessionManager.getBranch());
+		const commitStarted = Promise.withResolvers<void>();
+		const releaseCommit = Promise.withResolvers<void>();
+		const commitAtomicBatch = settings.commitAtomicBatch.bind(settings);
+		const commit = spyOn(settings, "commitAtomicBatch").mockImplementation(async changes => {
+			commitStarted.resolve();
+			await releaseCommit.promise;
+			return commitAtomicBatch(changes);
+		});
+
+		try {
+			const persistentControl = session.setThinkingVisibilityForControl("visible", true);
+			await commitStarted.promise;
+			session.setThinkingVisibility("hidden");
+
+			releaseCommit.resolve();
+			await persistentControl;
+
+			expect(settings.getGlobal("hideThinkingBlock")).toBe(false);
+			expect(session.getThinkingVisibility()).toBe("hidden");
+			expect(session.sessionManager.getBranch()).toEqual(history);
+		} finally {
+			commit.mockRestore();
+		}
+	});
+
+	it("lets the newest overlapping persistent thinking level own live promotion", async () => {
+		const settings = Settings.isolated({ defaultThinkingLevel: Effort.Low });
+		await createSession(getSonnet(), settings);
+		const firstStarted = Promise.withResolvers<void>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const secondStarted = Promise.withResolvers<void>();
+		const releaseSecond = Promise.withResolvers<void>();
+		const commitAtomicBatch = settings.commitAtomicBatch.bind(settings);
+		let callCount = 0;
+		const commit = spyOn(settings, "commitAtomicBatch").mockImplementation(async changes => {
+			callCount++;
+			if (callCount === 1) {
+				firstStarted.resolve();
+				await releaseFirst.promise;
+			} else {
+				secondStarted.resolve();
+				await releaseSecond.promise;
+			}
+			return commitAtomicBatch(changes);
+		});
+		const events: string[] = [];
+		const unsubscribe = session.subscribe(event => events.push(event.type));
+
+		try {
+			const older = session.setThinkingLevelForControl(Effort.Medium, true);
+			await firstStarted.promise;
+			const newer = session.setThinkingLevelForControl(Effort.High, true);
+			await secondStarted.promise;
+
+			releaseFirst.resolve();
+			await older;
+			expect(session.thinkingLevel).toBe(Effort.Low);
+
+			releaseSecond.resolve();
+			await newer;
+
+			expect(settings.getGlobal("defaultThinkingLevel")).toBe(Effort.High);
+			expect(session.thinkingLevel).toBe(Effort.High);
+			expect(events).toEqual(["thinking_level_changed"]);
+			expect(session.getThinkingScopeForControl()).toBe("global config");
+		} finally {
+			unsubscribe();
+			commit.mockRestore();
+		}
+	});
+
+	it("lets the newest overlapping persistent visibility own live promotion", async () => {
+		const settings = Settings.isolated({ hideThinkingBlock: false });
+		await createSession(getSonnet(), settings);
+		const firstStarted = Promise.withResolvers<void>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const secondStarted = Promise.withResolvers<void>();
+		const releaseSecond = Promise.withResolvers<void>();
+		const commitAtomicBatch = settings.commitAtomicBatch.bind(settings);
+		let callCount = 0;
+		const commit = spyOn(settings, "commitAtomicBatch").mockImplementation(async changes => {
+			callCount++;
+			if (callCount === 1) {
+				firstStarted.resolve();
+				await releaseFirst.promise;
+			} else {
+				secondStarted.resolve();
+				await releaseSecond.promise;
+			}
+			return commitAtomicBatch(changes);
+		});
+
+		try {
+			const older = session.setThinkingVisibilityForControl("hidden", true);
+			await firstStarted.promise;
+			const newer = session.setThinkingVisibilityForControl("visible", true);
+			await secondStarted.promise;
+
+			releaseFirst.resolve();
+			await older;
+			expect(session.getThinkingVisibility()).toBe("visible");
+
+			releaseSecond.resolve();
+			await newer;
+
+			expect(settings.getGlobal("hideThinkingBlock")).toBe(false);
+			expect(session.getThinkingVisibility()).toBe("visible");
+		} finally {
+			commit.mockRestore();
+		}
+	});
+	it("rejects durable thinking controls before mutating session state", async () => {
+		const sonnet = getSonnet();
+		const settings = Settings.isolated({
+			defaultThinkingLevel: Effort.Low,
+			hideThinkingBlock: false,
+		});
+		await createSession(sonnet, settings);
+		const canWrite = spyOn(settings, "canWriteDurableConfig").mockReturnValue(false);
+		const set = spyOn(settings, "set");
+		const history = structuredClone(session.sessionManager.getBranch());
+		const events: string[] = [];
+		const unsubscribe = session.subscribe(event => events.push(event.type));
+
+		try {
+			expect(() => session.setThinkingLevel(Effort.High, true)).toThrow("Repair config.yml");
+			await expect(session.setThinkingLevelForControl(Effort.High, true)).rejects.toThrow("Repair config.yml");
+			expect(() => session.setThinkingVisibility("hidden", true)).toThrow("Repair config.yml");
+			await expect(session.setThinkingVisibilityForControl("hidden", true)).rejects.toThrow("Repair config.yml");
+
+			expect(session.thinkingLevel).toBe(Effort.Low);
+			expect(session.getThinkingVisibility()).toBe("visible");
+			expect(session.sessionManager.getBranch()).toEqual(history);
+			expect(events).toEqual([]);
+			expect(settings.getGlobal("defaultThinkingLevel")).toBe(Effort.Low);
+			expect(settings.getGlobal("hideThinkingBlock")).toBe(false);
+			expect(set).not.toHaveBeenCalled();
+		} finally {
+			unsubscribe();
+			canWrite.mockRestore();
+			set.mockRestore();
+		}
+	});
+	it("leaves reasoning level state untouched when config corruption breaks the durable commit", async () => {
+		const agentDir = path.join(tempDir.path(), "agent");
+		const settings = await Settings.init({ cwd: tempDir.path(), agentDir });
+		await createSession(getSonnet(), settings);
+		const history = structuredClone(session.sessionManager.getBranch());
+		const settingsBefore = settings.getGlobal("defaultThinkingLevel");
+		const events: string[] = [];
+		const unsubscribe = session.subscribe(event => events.push(event.type));
+
+		try {
+			await Bun.write(path.join(agentDir, "config.yml"), "defaultThinkingLevel: [\n");
+
+			await expect(session.setThinkingLevelForControl(Effort.High, true)).rejects.toThrow(
+				"Unable to persist reasoning settings.",
+			);
+
+			expect(session.thinkingLevel).toBe(Effort.Low);
+			expect(session.sessionManager.getBranch()).toEqual(history);
+			expect(events).toEqual([]);
+			expect(settings.getGlobal("defaultThinkingLevel")).toBe(settingsBefore);
+		} finally {
+			unsubscribe();
+		}
+	});
+
+	it("leaves reasoning visibility state untouched when config corruption breaks the durable commit", async () => {
+		const agentDir = path.join(tempDir.path(), "agent");
+		const settings = await Settings.init({ cwd: tempDir.path(), agentDir });
+		await createSession(getSonnet(), settings);
+		const history = structuredClone(session.sessionManager.getBranch());
+		const settingsBefore = settings.getGlobal("hideThinkingBlock");
+		const events: string[] = [];
+		const unsubscribe = session.subscribe(event => events.push(event.type));
+
+		try {
+			await Bun.write(path.join(agentDir, "config.yml"), "hideThinkingBlock: [\n");
+
+			await expect(session.setThinkingVisibilityForControl("hidden", true)).rejects.toThrow(
+				"Unable to persist reasoning settings.",
+			);
+
+			expect(session.getThinkingVisibility()).toBe("visible");
+			expect(session.sessionManager.getBranch()).toEqual(history);
+			expect(events).toEqual([]);
+			expect(settings.getGlobal("hideThinkingBlock")).toBe(settingsBefore);
+		} finally {
+			unsubscribe();
+		}
 	});
 });

--- a/packages/coding-agent/test/issue-775-repro.test.ts
+++ b/packages/coding-agent/test/issue-775-repro.test.ts
@@ -243,23 +243,27 @@ describe("issue #775: per-model defaultLevel", () => {
 			commit.mockRestore();
 		}
 	});
-	it("applies committed thinking visibility after an intervening model change", async () => {
+	it("applies committed thinking visibility across a persistent default-model selection", async () => {
 		const settings = Settings.isolated({ hideThinkingBlock: false });
 		await createSession(getSonnet(), settings);
 		session.setThinkingVisibility("hidden");
 		const commitStarted = Promise.withResolvers<void>();
 		const releaseCommit = Promise.withResolvers<void>();
 		const commitAtomicBatch = settings.commitAtomicBatch.bind(settings);
+		let commitCount = 0;
 		const commit = spyOn(settings, "commitAtomicBatch").mockImplementation(async changes => {
-			commitStarted.resolve();
-			await releaseCommit.promise;
+			commitCount++;
+			if (commitCount === 1) {
+				commitStarted.resolve();
+				await releaseCommit.promise;
+			}
 			return commitAtomicBatch(changes);
 		});
 
 		try {
 			const persistentControl = session.setThinkingVisibilityForControl("visible", true);
 			await commitStarted.promise;
-			await session.setModel(getOpus());
+			await session.setDefaultModelSelection(getOpus(), Effort.High);
 			expect(session.getThinkingVisibility()).toBe("hidden");
 
 			releaseCommit.resolve();

--- a/packages/coding-agent/test/issue-775-repro.test.ts
+++ b/packages/coding-agent/test/issue-775-repro.test.ts
@@ -213,6 +213,34 @@ describe("issue #775: per-model defaultLevel", () => {
 			commit.mockRestore();
 		}
 	});
+	it("applies committed thinking effort after a context-only clear", async () => {
+		const settings = Settings.isolated({ defaultThinkingLevel: Effort.Low });
+		await createSession(getSonnet(), settings);
+		const commitStarted = Promise.withResolvers<void>();
+		const releaseCommit = Promise.withResolvers<void>();
+		const commitAtomicBatch = settings.commitAtomicBatch.bind(settings);
+		const commit = spyOn(settings, "commitAtomicBatch").mockImplementation(async changes => {
+			commitStarted.resolve();
+			await releaseCommit.promise;
+			return commitAtomicBatch(changes);
+		});
+
+		try {
+			const persistentControl = session.setThinkingLevelForControl(Effort.Medium, true);
+			await commitStarted.promise;
+			await session.clearContext();
+			expect(session.thinkingLevel).toBe(Effort.Low);
+
+			releaseCommit.resolve();
+			await persistentControl;
+
+			expect(settings.getGlobal("defaultThinkingLevel")).toBe(Effort.Medium);
+			expect(session.thinkingLevel).toBe(Effort.Medium);
+			expect(session.getThinkingScopeForControl()).toBe("global config");
+		} finally {
+			commit.mockRestore();
+		}
+	});
 
 	it("keeps a newer session thinking visibility when a global control commit finishes", async () => {
 		const settings = Settings.isolated({ hideThinkingBlock: false });

--- a/packages/coding-agent/test/issue-775-repro.test.ts
+++ b/packages/coding-agent/test/issue-775-repro.test.ts
@@ -243,6 +243,34 @@ describe("issue #775: per-model defaultLevel", () => {
 			commit.mockRestore();
 		}
 	});
+	it("applies committed thinking visibility after an intervening model change", async () => {
+		const settings = Settings.isolated({ hideThinkingBlock: false });
+		await createSession(getSonnet(), settings);
+		session.setThinkingVisibility("hidden");
+		const commitStarted = Promise.withResolvers<void>();
+		const releaseCommit = Promise.withResolvers<void>();
+		const commitAtomicBatch = settings.commitAtomicBatch.bind(settings);
+		const commit = spyOn(settings, "commitAtomicBatch").mockImplementation(async changes => {
+			commitStarted.resolve();
+			await releaseCommit.promise;
+			return commitAtomicBatch(changes);
+		});
+
+		try {
+			const persistentControl = session.setThinkingVisibilityForControl("visible", true);
+			await commitStarted.promise;
+			await session.setModel(getOpus());
+			expect(session.getThinkingVisibility()).toBe("hidden");
+
+			releaseCommit.resolve();
+			await persistentControl;
+
+			expect(settings.getGlobal("hideThinkingBlock")).toBe(false);
+			expect(session.getThinkingVisibility()).toBe("visible");
+		} finally {
+			commit.mockRestore();
+		}
+	});
 
 	it("lets the newest overlapping persistent thinking level own live promotion", async () => {
 		const settings = Settings.isolated({ defaultThinkingLevel: Effort.Low });

--- a/packages/coding-agent/test/modes/components/settings-selector-memory-refresh.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-memory-refresh.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
 import { SettingsSelectorComponent } from "@gajae-code/coding-agent/modes/components/settings-selector";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -61,6 +64,55 @@ describe("SettingsSelectorComponent memory tab", () => {
 		expect(after).toContain("Memory Backend");
 		expect(after).toContain("Hindsight API URL");
 		expect(after).toContain("Hindsight Auto Recall");
+	});
+	it("reports malformed-YAML repair errors without changing an interactive control", async () => {
+		const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "settings-selector-recovery-"));
+		const agentDir = path.join(testDir, "agent");
+		fs.mkdirSync(agentDir, { recursive: true });
+		resetSettingsForTest();
+		await Bun.write(path.join(agentDir, "config.yml"), "theme: [");
+
+		const errors: string[] = [];
+		const changes: Array<{ path: string; value: unknown }> = [];
+		let cleanupError: unknown;
+		try {
+			await Settings.init({ cwd: testDir, agentDir });
+			const component = new SettingsSelectorComponent(
+				{
+					availableThinkingLevels: [],
+					thinkingLevel: undefined,
+					availableThemes: ["blue-crab"],
+					availableModelProfiles: [],
+					cwd: testDir,
+				},
+				{
+					onChange: (path, value) => changes.push({ path, value }),
+					onError: message => errors.push(message),
+					onCancel: () => {},
+				},
+			);
+
+			component.handleInput("\n");
+			component.handleInput("\n");
+
+			expect(errors).toEqual([
+				"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+			]);
+			expect(changes).toEqual([]);
+			expect(settings.get("theme.dark")).toBe("red-claw");
+			component.handleInput("\x1b");
+			expect(component.render(120).join("\n")).toContain("red-claw");
+		} finally {
+			Settings.instance.getStorage()?.close();
+			try {
+				fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+			} catch (error) {
+				if (process.platform !== "win32" || (error as NodeJS.ErrnoException).code !== "EBUSY") {
+					cleanupError = error;
+				}
+			}
+		}
+		if (cleanupError) throw cleanupError;
 	});
 
 	it("hides Hindsight rows again when the backend is switched back to off without leaving the tab", () => {

--- a/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
@@ -121,4 +121,26 @@ describe("SettingsSelectorComponent pet capability", () => {
 		expect(onChange).not.toHaveBeenCalled();
 		expect(settings.get("pet.mode")).toBe("off");
 	});
+	it("rejects read-only pet commits before the shared policy can mutate widget state", () => {
+		const canWrite = vi.spyOn(Settings.instance, "canWriteDurableConfig").mockReturnValue(false);
+		const onChange = vi.fn();
+		const onError = vi.fn();
+		const onPetCommit = vi.fn(() => true);
+		try {
+			const component = makeComponent(true, { onChange, onError, onPetCommit });
+
+			openPetSetting(component);
+			component.handleInput("\x1b[B");
+			component.handleInput("\n");
+
+			expect(onError).toHaveBeenCalledWith(
+				"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+			);
+			expect(onPetCommit).not.toHaveBeenCalled();
+			expect(onChange).not.toHaveBeenCalled();
+			expect(settings.get("pet.mode")).toBe("off");
+		} finally {
+			canWrite.mockRestore();
+		}
+	});
 });

--- a/packages/coding-agent/test/modes/components/thinking-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/thinking-selector.test.ts
@@ -236,4 +236,57 @@ describe("SelectorController effort selector", () => {
 		expect(ctx.ui.requestRender).toHaveBeenCalled();
 		expect(ctx.ui.setFocus).toHaveBeenLastCalledWith(ctx.editor);
 	});
+
+	it("rejects persisted effort changes before mutating live session state during recovery", () => {
+		const editorContainer = {
+			children: [] as unknown[],
+			clear() {
+				this.children = [];
+			},
+			addChild(child: unknown) {
+				this.children.push(child);
+			},
+		};
+		const settings = Settings.isolated({ defaultThinkingLevel: ThinkingLevel.High });
+		const canWrite = vi.spyOn(settings, "canWriteDurableConfig").mockReturnValue(false);
+		const session = {
+			thinkingLevel: ThinkingLevel.Off as ThinkingLevel | undefined,
+			getAvailableThinkingLevels: () => [ThinkingLevel.Low],
+			setThinkingLevel: vi.fn(),
+		};
+		const showError = vi.fn();
+		const ctx = {
+			editorContainer,
+			editor: {},
+			session,
+			settings,
+			ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+			statusLine: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			updateEditorTopBorder: vi.fn(),
+			showStatus: vi.fn(),
+			showError,
+		} as unknown as InteractiveModeContext;
+		try {
+			const controller = new SelectorController(ctx);
+			controller.showEffortSelector();
+			const selector = editorContainer.children[0];
+			if (!(selector instanceof ThinkingSelectorComponent)) {
+				throw new Error("Expected /effort to mount ThinkingSelectorComponent");
+			}
+
+			selector.handleInput("\x1b[B");
+			selector.handleInput("\n");
+			selector.handleInput("\x1b[B");
+			selector.handleInput("\n");
+
+			expect(session.setThinkingLevel).not.toHaveBeenCalled();
+			expect(showError).toHaveBeenCalledWith(
+				"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
+			);
+			expect(editorContainer.children[0]).toBe(selector);
+		} finally {
+			canWrite.mockRestore();
+		}
+	});
 });

--- a/packages/coding-agent/test/modes/components/thinking-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/thinking-selector.test.ts
@@ -81,7 +81,7 @@ describe("ThinkingSelectorComponent", () => {
 });
 
 describe("SelectorController effort selector", () => {
-	it("applies inherit through the configured default and refreshes chrome", () => {
+	it("applies inherit through the configured default and refreshes chrome", async () => {
 		const editorContainer = {
 			children: [] as unknown[],
 			clear() {
@@ -97,9 +97,9 @@ describe("SelectorController effort selector", () => {
 		const session = {
 			thinkingLevel: ThinkingLevel.Inherit as ThinkingLevel | undefined,
 			getAvailableThinkingLevels: () => [ThinkingLevel.Low, ThinkingLevel.High],
-			setThinkingLevel(level: ThinkingLevel | undefined, persist?: boolean) {
+			async setThinkingLevelForControl(level: ThinkingLevel, persist: boolean) {
 				thinkingLevelCalls.push({ level, persist });
-				this.thinkingLevel = level;
+				this.thinkingLevel = level === ThinkingLevel.Inherit ? settings.get("defaultThinkingLevel") : level;
 			},
 		};
 		const ctx = {
@@ -130,8 +130,9 @@ describe("SelectorController effort selector", () => {
 		expect(thinkingLevelCalls).toEqual([]);
 
 		selector.handleInput("\n");
+		await Bun.sleep(0);
 
-		expect(thinkingLevelCalls).toEqual([{ level: ThinkingLevel.High, persist: false }]);
+		expect(thinkingLevelCalls).toEqual([{ level: ThinkingLevel.Inherit, persist: false }]);
 		expect(statuses[0]).toContain("configured default: high");
 		expect(statuses[0]).toContain("Effective effort: high");
 		expect(ctx.statusLine.invalidate).toHaveBeenCalled();
@@ -141,7 +142,7 @@ describe("SelectorController effort selector", () => {
 		expect(ctx.ui.setFocus).toHaveBeenLastCalledWith(ctx.editor);
 	});
 
-	it("can persist the selected effort as the default", () => {
+	it("can persist the selected effort as the default", async () => {
 		const editorContainer = {
 			children: [] as unknown[],
 			clear() {
@@ -157,7 +158,7 @@ describe("SelectorController effort selector", () => {
 		const session = {
 			thinkingLevel: ThinkingLevel.Off as ThinkingLevel | undefined,
 			getAvailableThinkingLevels: () => [ThinkingLevel.Low, ThinkingLevel.High],
-			setThinkingLevel(level: ThinkingLevel | undefined, persist?: boolean) {
+			async setThinkingLevelForControl(level: ThinkingLevel, persist: boolean) {
 				thinkingLevelCalls.push({ level, persist });
 				this.thinkingLevel = level;
 			},
@@ -190,6 +191,7 @@ describe("SelectorController effort selector", () => {
 		selector.handleInput("\n");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
+		await Bun.sleep(0);
 
 		expect(thinkingLevelCalls).toEqual([{ level: ThinkingLevel.Low, persist: true }]);
 		expect(notifyConfigChanged).toHaveBeenCalled();
@@ -210,7 +212,7 @@ describe("SelectorController effort selector", () => {
 		const session = {
 			thinkingLevel: ThinkingLevel.Off as ThinkingLevel | undefined,
 			getAvailableThinkingLevels: () => [ThinkingLevel.Low],
-			setThinkingLevel: vi.fn(),
+			setThinkingLevelForControl: vi.fn(),
 		};
 		const ctx = {
 			editorContainer,
@@ -232,12 +234,12 @@ describe("SelectorController effort selector", () => {
 		}
 		selector.handleInput("\x1b");
 
-		expect(session.setThinkingLevel).not.toHaveBeenCalled();
+		expect(session.setThinkingLevelForControl).not.toHaveBeenCalled();
 		expect(ctx.ui.requestRender).toHaveBeenCalled();
 		expect(ctx.ui.setFocus).toHaveBeenLastCalledWith(ctx.editor);
 	});
 
-	it("rejects persisted effort changes before mutating live session state during recovery", () => {
+	it("surfaces atomic persisted effort failures without reporting success", async () => {
 		const editorContainer = {
 			children: [] as unknown[],
 			clear() {
@@ -248,11 +250,13 @@ describe("SelectorController effort selector", () => {
 			},
 		};
 		const settings = Settings.isolated({ defaultThinkingLevel: ThinkingLevel.High });
-		const canWrite = vi.spyOn(settings, "canWriteDurableConfig").mockReturnValue(false);
+		const atomicFailure = new Error("Repair config.yml before changing reasoning settings.");
 		const session = {
 			thinkingLevel: ThinkingLevel.Off as ThinkingLevel | undefined,
 			getAvailableThinkingLevels: () => [ThinkingLevel.Low],
-			setThinkingLevel: vi.fn(),
+			setThinkingLevelForControl: vi.fn(async () => {
+				throw atomicFailure;
+			}),
 		};
 		const showError = vi.fn();
 		const ctx = {
@@ -279,14 +283,14 @@ describe("SelectorController effort selector", () => {
 			selector.handleInput("\n");
 			selector.handleInput("\x1b[B");
 			selector.handleInput("\n");
+			await Bun.sleep(0);
 
-			expect(session.setThinkingLevel).not.toHaveBeenCalled();
-			expect(showError).toHaveBeenCalledWith(
-				"Cannot change settings while config.yml has invalid YAML syntax. Repair config.yml and reload settings.",
-			);
+			expect(session.setThinkingLevelForControl).toHaveBeenCalledWith(ThinkingLevel.Low, true);
+			expect(showError).toHaveBeenCalledWith(atomicFailure.message);
+			expect(ctx.showStatus).not.toHaveBeenCalled();
 			expect(editorContainer.children[0]).toBe(selector);
 		} finally {
-			canWrite.mockRestore();
+			settings.getStorage()?.close();
 		}
 	});
 });

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -515,6 +515,28 @@ describe("notifications config", () => {
 			}
 		}
 	}, 30_000);
+	test("Settings keeps malformed notification leaves fail-closed with a relative agent directory", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notification-relative-agent-dir-"));
+		tempDirs.push(root);
+		const agentDir = path.join(root, "agent");
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(agentDir, "config.yml"),
+			`${JSON.stringify({ notifications: { enabled: "invalid" } })}\n`,
+		);
+
+		const settings = await Settings.loadForScope({
+			cwd: root,
+			agentDir: path.relative(process.cwd(), agentDir),
+		});
+		try {
+			expect(() => settings.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			await settings.flush();
+			expect(() => settings.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+		} finally {
+			settings.getStorage()?.close();
+		}
+	});
 	test("Settings revalidates malformed notification config after direct repairs only", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notification-direct-repair-"));
 		tempDirs.push(root);

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -988,6 +988,53 @@ describe("notifications config", () => {
 			missingSettings.getStorage()?.close();
 		}
 	});
+	test("recovered YAML syntax is read-only until config.yml is repaired", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-settings-syntax-recovery-"));
+		tempDirs.push(root);
+		const agentDir = path.join(root, "agent");
+		const configPath = path.join(agentDir, "config.yml");
+		const malformed = "notifications: [\n";
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.writeFileSync(configPath, malformed);
+
+		const settings = await Settings.loadForScope({ cwd: root, agentDir });
+		try {
+			expect(settings.getSchemaReport()).toEqual({
+				valid: false,
+				issues: [
+					{
+						path: "config.yml",
+						kind: "invalid",
+						detail: "Configuration YAML syntax is invalid; repair config.yml before changing settings.",
+					},
+				],
+			});
+			expect(() => settings.set("theme.dark", "blue-crab")).toThrow("Repair config.yml");
+			expect(() => settings.unset("theme.dark")).toThrow("Repair config.yml");
+			await expect(
+				settings.commitAtomicBatch([{ path: "theme.dark", op: "set", value: "blue-crab" }]),
+			).rejects.toThrow("Repair config.yml");
+			await expect(
+				settings.commitAtomicBatchWithCurrent(() => [{ path: "theme.dark", op: "set", value: "blue-crab" }]),
+			).rejects.toThrow("Repair config.yml");
+			expect(settings.get("theme.dark")).toBe("red-claw");
+			await settings.flush();
+			expect(fs.readFileSync(configPath, "utf8")).toBe(malformed);
+
+			fs.writeFileSync(configPath, "theme:\n  dark: blue-crab\n");
+			await settings.flush();
+			expect(settings.getSchemaReport()).toEqual({ issues: [], valid: true });
+			settings.set("theme.dark", "red-claw");
+			await settings.flushOrThrow();
+			expect(YAML.parse(fs.readFileSync(configPath, "utf8"))).toMatchObject({ theme: { dark: "red-claw" } });
+		} finally {
+			settings.getStorage()?.close();
+		}
+
+		const isolated = Settings.isolated();
+		isolated.set("theme.dark", "blue-crab");
+		expect(isolated.get("theme.dark")).toBe("blue-crab");
+	});
 
 	test("project notification settings are ignored without leaking credentials", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-project-boundary-"));

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -932,38 +932,60 @@ describe("notifications config", () => {
 			settings.getStorage()?.close();
 		}
 	});
-	test("full Settings rejects invalid or inaccessible config.yml like lightweight loading", async () => {
+	test("full Settings recovers defaults from invalid YAML while notifications remain fail-closed", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-btw-settings-load-"));
 		tempDirs.push(root);
-
-		const fixtures =
-			process.platform === "win32"
-				? (["notifications: [\n"] as const)
-				: (["notifications: [\n", "directory"] as const);
-		for (const [index, fixture] of fixtures.entries()) {
-			const agentDir = path.join(root, `agent-${index}`);
-			const configPath = path.join(agentDir, "config.yml");
-			fs.mkdirSync(agentDir, { recursive: true });
-			if (fixture === "directory") {
-				fs.mkdirSync(configPath);
-			} else {
-				fs.writeFileSync(configPath, fixture);
-			}
-
-			await expect(Settings.loadForScope({ cwd: root, agentDir })).rejects.toThrow();
-			await expect(loadLightweightDaemonSettings(agentDir)).rejects.toThrow();
+		const agentDir = path.join(root, "invalid-yaml");
+		const configPath = path.join(agentDir, "config.yml");
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.writeFileSync(configPath, "notifications: [\n");
+		resetSettingsForTest();
+		const initialized = await Settings.init({ cwd: root, agentDir });
+		try {
+			expect(initialized.get("theme.dark")).toBe("red-claw");
+			expect(() => initialized.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+		} finally {
+			resetSettingsForTest();
 		}
 
-		const agentDir = path.join(root, "missing-config");
-		fs.mkdirSync(agentDir, { recursive: true });
 		const settings = await Settings.loadForScope({ cwd: root, agentDir });
 		try {
-			expect(settings.getNotificationSettingsSnapshot().telegram.btw.enabled).toBe(true);
-			expect(
-				(await loadLightweightDaemonSettings(agentDir)).getNotificationSettingsSnapshot().telegram.btw.enabled,
-			).toBe(true);
+			expect(settings.get("theme.dark")).toBe("red-claw");
+			expect(() => settings.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			await expect(loadLightweightDaemonSettings(agentDir)).rejects.toThrow();
 		} finally {
 			settings.getStorage()?.close();
+		}
+
+		fs.writeFileSync(configPath, `${JSON.stringify({ notifications: { enabled: true } })}\n`);
+		const repaired = await Settings.loadForScope({ cwd: root, agentDir });
+		try {
+			expect(repaired.getNotificationSettingsSnapshot()).toMatchObject({ enabled: true });
+			expect(repaired.getNotificationSettingsSnapshot()).toEqual(
+				(await loadLightweightDaemonSettings(agentDir)).getNotificationSettingsSnapshot(),
+			);
+		} finally {
+			repaired.getStorage()?.close();
+		}
+
+		if (process.platform !== "win32") {
+			const inaccessibleAgentDir = path.join(root, "directory");
+			fs.mkdirSync(path.join(inaccessibleAgentDir, "config.yml"), { recursive: true });
+			await expect(Settings.loadForScope({ cwd: root, agentDir: inaccessibleAgentDir })).rejects.toThrow();
+			await expect(loadLightweightDaemonSettings(inaccessibleAgentDir)).rejects.toThrow();
+		}
+
+		const missingAgentDir = path.join(root, "missing-config");
+		fs.mkdirSync(missingAgentDir, { recursive: true });
+		const missingSettings = await Settings.loadForScope({ cwd: root, agentDir: missingAgentDir });
+		try {
+			expect(missingSettings.getNotificationSettingsSnapshot().telegram.btw.enabled).toBe(true);
+			expect(
+				(await loadLightweightDaemonSettings(missingAgentDir)).getNotificationSettingsSnapshot().telegram.btw
+					.enabled,
+			).toBe(true);
+		} finally {
+			missingSettings.getStorage()?.close();
 		}
 	});
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -668,6 +668,28 @@ describe("Settings", () => {
 			settings.getStorage()?.close();
 		}
 	});
+	it("serializes failed-save recovery behind a later reserved save", async () => {
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		let queuedNewestSave = false;
+		const warning = vi.spyOn(logger, "warn").mockImplementation(message => {
+			if (message !== "Settings: background save failed" || queuedNewestSave) return;
+			queuedNewestSave = true;
+			fs.writeFileSync(getConfigPath(), YAML.stringify({ theme: { dark: "red-claw" } }, null, 2));
+			settings.set("theme.dark", "red-claw");
+		});
+		try {
+			settings.set("theme.dark", "blue-crab");
+			await Bun.write(getConfigPath(), "theme: [");
+			await expect(settings.flushOrThrow()).rejects.toThrow();
+
+			expect(queuedNewestSave).toBe(true);
+			expect(settings.get("theme.dark")).toBe("red-claw");
+			expect((await readSettings()).theme).toEqual({ dark: "red-claw" });
+		} finally {
+			warning.mockRestore();
+			settings.getStorage()?.close();
+		}
+	});
 
 	it("keeps malformed global recovery and notification state in cwd clones", async () => {
 		const malformed = "notifications: [";
@@ -687,7 +709,7 @@ describe("Settings", () => {
 			source.getStorage()?.close();
 		}
 	});
-	it("preserves retained dirty patches in recovered cwd clones", async () => {
+	it("keeps the source as the sole owner of retained patches in recovered cwd clones", async () => {
 		const clonedCwd = path.join(testDir, "cloned-project");
 		fs.mkdirSync(clonedCwd, { recursive: true });
 		const source = await Settings.init({ cwd: projectDir, agentDir });
@@ -701,9 +723,12 @@ describe("Settings", () => {
 			expect(cloned.get("theme.dark")).toBe("blue-crab");
 
 			await Bun.write(getConfigPath(), "");
-			await cloned.flushOrThrow();
-
+			await source.flushOrThrow();
 			expect((await readSettings()).theme).toEqual({ dark: "blue-crab" });
+
+			await Bun.write(getConfigPath(), YAML.stringify({ theme: { dark: "red-claw" } }, null, 2));
+			await cloned.flushOrThrow();
+			expect((await readSettings()).theme).toEqual({ dark: "red-claw" });
 		} finally {
 			source.getStorage()?.close();
 		}

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -593,6 +593,25 @@ describe("Settings", () => {
 		}
 	});
 
+	it("persists a retained dirty patch on the first flush after YAML repair", async () => {
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		try {
+			settings.set("theme.dark", "blue-crab");
+			await Bun.write(getConfigPath(), "theme: [");
+			await settings.flush();
+
+			expect(settings.canWriteDurableConfig()).toBe(false);
+			expect(settings.get("theme.dark")).toBe("blue-crab");
+
+			await Bun.write(getConfigPath(), "");
+			await settings.flushOrThrow();
+
+			expect(settings.canWriteDurableConfig()).toBe(true);
+			expect((await readSettings()).theme).toEqual({ dark: "blue-crab" });
+		} finally {
+			settings.getStorage()?.close();
+		}
+	});
 	it("retains fail-closed recovery state when a durable refresh read fails", async () => {
 		const malformed = "notifications: [";
 		await Bun.write(getConfigPath(), malformed);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -476,6 +476,71 @@ describe("Settings", () => {
 			await settings.flushOrThrow();
 			expect((await readSettings()).notifications).toEqual({ redact: true });
 		});
+		it("fails closed after an atomic read failure", async () => {
+			for (const commit of [
+				(settings: Settings) =>
+					settings.commitAtomicBatch([{ path: "theme.dark", op: "set" as const, value: "red-claw" }]),
+				(settings: Settings) =>
+					settings.commitAtomicBatchWithCurrent(() => [
+						{ path: "theme.dark", op: "set" as const, value: "red-claw" },
+					]),
+			]) {
+				await writeSettings({ theme: { dark: "blue-crab" } });
+				const settings = await Settings.loadForScope({ cwd: projectDir, agentDir });
+				await Bun.write(getConfigPath(), "notifications: [");
+
+				const failure = await commit(settings).catch(error => error);
+				expect(failure).toBeInstanceOf(Error);
+				expect(settings.canWriteDurableConfig()).toBe(false);
+				expect(settings.getSchemaReport()).toMatchObject({
+					valid: false,
+					issues: [{ path: "config.yml", kind: "invalid" }],
+				});
+				expect(() => settings.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+				await expect(
+					settings.commitAtomicBatch([{ path: "theme.dark", op: "set", value: "red-claw" }]),
+				).rejects.toThrow("Repair config.yml");
+				settings.getStorage()?.close();
+			}
+		});
+		it("keeps atomic failure recovery ahead of causally dependent queued work", async () => {
+			for (const commit of [
+				(settings: Settings) =>
+					settings.commitAtomicBatch([{ path: "notifications.enabled", op: "set" as const, value: true }]),
+				(settings: Settings) =>
+					settings.commitAtomicBatchWithCurrent(() => [
+						{ path: "notifications.enabled", op: "set" as const, value: true },
+					]),
+			]) {
+				await writeSettings({ theme: { dark: "blue-crab" } });
+				const settings = await Settings.loadForScope({ cwd: projectDir, agentDir });
+				await Bun.write(getConfigPath(), "malformed-root\n");
+
+				const firstSettled = Promise.withResolvers<void>();
+				const first = commit(settings);
+				void first.finally(() => firstSettled.resolve()).catch(() => undefined);
+				const later = settings.commitAtomicBatchWithCurrent(async () => {
+					await firstSettled.promise;
+					return [];
+				});
+				const bounded = await Promise.race([
+					Promise.allSettled([first, later]),
+					Bun.sleep(2_000).then(() => "timeout" as const),
+				]);
+
+				expect(bounded).not.toBe("timeout");
+				expect(bounded).toMatchObject([
+					{
+						status: "rejected",
+						reason: {
+							message: "Cannot atomically repair notification settings while config.yml has a malformed root.",
+						},
+					},
+					{ status: "fulfilled" },
+				]);
+				settings.getStorage()?.close();
+			}
+		});
 
 		it("exposes an ordinary set and hook before disk completion without reentrant flush deadlock", async () => {
 			const settings = await Settings.init({ cwd: projectDir, agentDir });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -612,6 +612,22 @@ describe("Settings", () => {
 			settings.getStorage()?.close();
 		}
 	});
+	it("enters syntax recovery after a debounced save encounters malformed YAML", async () => {
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		try {
+			settings.set("theme.dark", "blue-crab");
+			await Bun.write(getConfigPath(), "theme: [");
+			await Bun.sleep(300);
+
+			expect(settings.canWriteDurableConfig()).toBe(false);
+			expect(settings.get("theme.dark")).toBe("blue-crab");
+			expect(settings.getSchemaReport()).toMatchObject({ valid: false });
+			expect(() => settings.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			expect(() => settings.set("theme.light", "blue-crab")).toThrow("Repair config.yml");
+		} finally {
+			settings.getStorage()?.close();
+		}
+	});
 	it("preserves fail-closed notifications while replaying dirty patches after external syntax corruption", async () => {
 		const settings = await Settings.init({ cwd: projectDir, agentDir });
 		try {
@@ -667,6 +683,27 @@ describe("Settings", () => {
 			expect(() => cloned.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
 			expect(() => cloned.set("notifications.redact", true)).toThrow("Repair config.yml");
 			expect(await Bun.file(getConfigPath()).text()).toBe(malformed);
+		} finally {
+			source.getStorage()?.close();
+		}
+	});
+	it("preserves retained dirty patches in recovered cwd clones", async () => {
+		const clonedCwd = path.join(testDir, "cloned-project");
+		fs.mkdirSync(clonedCwd, { recursive: true });
+		const source = await Settings.init({ cwd: projectDir, agentDir });
+		try {
+			source.set("theme.dark", "blue-crab");
+			await Bun.write(getConfigPath(), "theme: [");
+			await Bun.sleep(300);
+
+			const cloned = await source.cloneForCwd(clonedCwd);
+			expect(cloned.canWriteDurableConfig()).toBe(false);
+			expect(cloned.get("theme.dark")).toBe("blue-crab");
+
+			await Bun.write(getConfigPath(), "");
+			await cloned.flushOrThrow();
+
+			expect((await readSettings()).theme).toEqual({ dark: "blue-crab" });
 		} finally {
 			source.getStorage()?.close();
 		}

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -568,4 +568,66 @@ describe("Settings", () => {
 		expect(migration?.default).toBe("copy-retain");
 		expect(migration?.enum).toEqual(["copy-retain", "disabled"]);
 	});
+	it("clears recovered diagnostics and notification validation after an empty-file repair", async () => {
+		const malformed = "notifications: [";
+		await Bun.write(getConfigPath(), malformed);
+		const settings = await Settings.loadForScope({ cwd: projectDir, agentDir });
+		try {
+			expect(settings.canWriteDurableConfig()).toBe(false);
+			expect(settings.getSchemaReport()).toMatchObject({ valid: false });
+			expect(() => settings.set("theme.dark", "red-claw")).toThrow("Repair config.yml");
+			expect(await Bun.file(getConfigPath()).text()).toBe(malformed);
+
+			await Bun.write(getConfigPath(), "");
+			await settings.flush();
+
+			expect(settings.canWriteDurableConfig()).toBe(true);
+			expect(settings.getSchemaReport()).toEqual({ issues: [], valid: true });
+			expect(settings.getNotificationSettingsSnapshot()).toMatchObject({ enabled: false });
+			settings.set("notifications.redact", true);
+			expect(settings.get("notifications.redact")).toBe(true);
+			await settings.flushOrThrow();
+			expect(await readSettings()).toMatchObject({ notifications: { redact: true } });
+		} finally {
+			settings.getStorage()?.close();
+		}
+	});
+
+	it("retains fail-closed recovery state when a durable refresh read fails", async () => {
+		const malformed = "notifications: [";
+		await Bun.write(getConfigPath(), malformed);
+		const settings = await Settings.loadForScope({ cwd: projectDir, agentDir });
+		try {
+			expect(settings.canWriteDurableConfig()).toBe(false);
+			fs.rmSync(getConfigPath());
+			fs.mkdirSync(getConfigPath());
+
+			await expect(settings.flush()).rejects.toThrow();
+			expect(settings.canWriteDurableConfig()).toBe(false);
+			expect(settings.getSchemaReport()).toMatchObject({ valid: false });
+			expect(() => settings.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			expect(() => settings.set("notifications.redact", true)).toThrow("Repair config.yml");
+		} finally {
+			settings.getStorage()?.close();
+		}
+	});
+
+	it("keeps malformed global recovery and notification state in cwd clones", async () => {
+		const malformed = "notifications: [";
+		const clonedCwd = path.join(testDir, "cloned-project");
+		fs.mkdirSync(clonedCwd, { recursive: true });
+		await Bun.write(getConfigPath(), malformed);
+		const source = await Settings.loadForScope({ cwd: projectDir, agentDir });
+		try {
+			const cloned = await source.cloneForCwd(clonedCwd);
+			expect(cloned.canWriteDurableConfig()).toBe(false);
+			expect(cloned.getSchemaReport()).toEqual(source.getSchemaReport());
+			expect(() => source.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			expect(() => cloned.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			expect(() => cloned.set("notifications.redact", true)).toThrow("Repair config.yml");
+			expect(await Bun.file(getConfigPath()).text()).toBe(malformed);
+		} finally {
+			source.getStorage()?.close();
+		}
+	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -612,6 +612,28 @@ describe("Settings", () => {
 			settings.getStorage()?.close();
 		}
 	});
+	it("preserves fail-closed notifications while replaying dirty patches after external syntax corruption", async () => {
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		try {
+			settings.set("notifications.redact", true);
+			settings.set("theme.dark", "blue-crab");
+			await Bun.write(getConfigPath(), "notifications: [");
+			await settings.flush();
+
+			expect(() => settings.getNotificationSettingsSnapshot()).toThrow("gjc_notify_daemon_invalid_configuration");
+			expect(settings.get("theme.dark")).toBe("blue-crab");
+
+			await Bun.write(getConfigPath(), "");
+			await settings.flushOrThrow();
+
+			expect(await readSettings()).toMatchObject({
+				notifications: { redact: true },
+				theme: { dark: "blue-crab" },
+			});
+		} finally {
+			settings.getStorage()?.close();
+		}
+	});
 	it("retains fail-closed recovery state when a durable refresh read fails", async () => {
 		const malformed = "notifications: [";
 		await Bun.write(getConfigPath(), malformed);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -4,7 +4,14 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Effort } from "@gajae-code/ai";
 import { onAppendOnlyModeChanged, resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
-import { getCustomThemesDir, getProjectAgentDir, logger, Snowflake } from "@gajae-code/utils";
+import {
+	getCustomThemesDir,
+	getDefaultTabWidth,
+	getProjectAgentDir,
+	logger,
+	Snowflake,
+	setDefaultTabWidth,
+} from "@gajae-code/utils";
 import { YAML } from "bun";
 import { withFileLock } from "../src/config/file-lock";
 import { createLightweightDaemonSettings } from "../src/sdk/bus/telegram-daemon-cli";
@@ -654,6 +661,25 @@ describe("Settings", () => {
 			await settings.flushOrThrow();
 			expect(await readSettings()).toMatchObject({ notifications: { redact: true } });
 		} finally {
+			settings.getStorage()?.close();
+		}
+	});
+	it("publishes repaired durable setting changes through hooks and listeners", async () => {
+		await Bun.write(getConfigPath(), "display: [");
+		const settings = await Settings.loadForScope({ cwd: projectDir, agentDir });
+		const changedPaths: string[] = [];
+		const unsubscribe = settings.onChanged(settingPath => changedPaths.push(settingPath));
+		try {
+			setDefaultTabWidth(3);
+			await Bun.write(getConfigPath(), "display:\n  tabWidth: 7\n");
+			await settings.flush();
+
+			expect(settings.get("display.tabWidth")).toBe(7);
+			expect(getDefaultTabWidth()).toBe(7);
+			expect(changedPaths).toEqual(["display.tabWidth"]);
+		} finally {
+			unsubscribe();
+			setDefaultTabWidth(4);
 			settings.getStorage()?.close();
 		}
 	});

--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -3,10 +3,11 @@ import * as path from "node:path";
 import { getBundledModel } from "@gajae-code/ai";
 import { postmortem, TempDir } from "@gajae-code/utils";
 import { type Args, parseArgs } from "../src/cli/args";
-import { Settings } from "../src/config/settings";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
 import { SETTINGS_SCHEMA } from "../src/config/settings-schema";
 import {
 	classifyStartupUpdateRoute,
+	getChangelogForDisplay,
 	initializeInteractiveModeWithStartupUpdate,
 	runRootCommand,
 	StartupUpdateOrchestrator,
@@ -78,6 +79,22 @@ describe("startup update contract", () => {
 		expect(setting.ui.description).toContain("never install");
 		expect(setting.ui.description).toContain("Use `gjc update` only");
 		expect(setting.ui.description).toContain("source, linked, and unrecognized installs use their original method");
+	});
+	it("displays the changelog without rewriting malformed global YAML", async () => {
+		using tempDir = TempDir.createSync("@gjc-malformed-changelog-");
+		const agentDir = path.join(tempDir.path(), "agent");
+		const malformed = "notifications: [";
+		await Bun.write(path.join(agentDir, "config.yml"), malformed);
+		resetSettingsForTest();
+		const activeSettings = await Settings.init({ cwd: tempDir.path(), agentDir });
+		try {
+			expect(activeSettings.canWriteDurableConfig()).toBe(false);
+			expect(await getChangelogForDisplay(rootArgs())).toBeDefined();
+			expect(() => activeSettings.set("lastChangelogVersion", "0.0.0")).toThrow("Repair config.yml");
+			expect(await Bun.file(path.join(agentDir, "config.yml")).text()).toBe(malformed);
+		} finally {
+			resetSettingsForTest();
+		}
 	});
 
 	it("classifies every noninteractive launch route and starts no checker for them", () => {


### PR DESCRIPTION
## Summary
- recover malformed global `config.yml` without silently authorizing durable writes
- serialize settings, provider, model, thinking-level, and thinking-visibility control mutations
- preserve current session-scoped capability APIs while failing closed on recovered syntax
- reconcile failed reasoning controls against concurrent live/session/model transitions
- add focused malformed-config, recovery-control, provider, selector, and session regression coverage

## Provenance
Semantic reconstruction of the still-needed recovery/settings portion from the stale `maint/telegram-btw-side-session` evidence branch onto current `dev`. The already-merged Telegram BTW feature itself is unchanged. Current-dev session transition and capability boundaries were retained during conflict resolution.

## Verification
- `bun test` over 10 affected recovery/settings/session suites: **211 pass / 0 fail / 954 expects**
- Biome over all 20 changed files: **pass**
- `git diff --check`: **pass**
- package typecheck currently reaches the same unrelated baseline native declaration mismatch on clean `dev`: `WindowsJobMemoryProbeResult` missing from the linked `@gajae-code/natives`; no additional branch-specific type errors remain

Please review the exact head and recovery authority/concurrency contracts.