### PR TITLE
test(ci): add a fail-closed CI failure-identity extractor

### DIFF
--- a/scripts/ci-failure-extract.test.ts
+++ b/scripts/ci-failure-extract.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { extractFailures, stripTimestamp } from "./ci-failure-extract";
+
+const TS = "2026-07-22T03:18:36.0557475Z ";
+
+describe("stripTimestamp", () => {
+	test("removes the runner's ISO prefix", () => {
+		expect(stripTimestamp(`${TS}(fail) something`)).toBe("(fail) something");
+	});
+
+	test("leaves an unprefixed line untouched", () => {
+		expect(stripTimestamp("(fail) something")).toBe("(fail) something");
+	});
+});
+
+describe("extractFailures", () => {
+	// The exact defect that caused ~5% recall: patterns were matched against the
+	// raw line, so the timestamp prefix prevented every anchored match.
+	test("extracts identities from timestamp-prefixed lines", () => {
+		const log = [
+			`${TS}(fail) AgentSession auto-compaction > starts a synthetic continuation [25.45ms]`,
+			`${TS}(fail) AgentSession auto-compaction > discards the triggering agent_end`,
+		].join("\n");
+
+		const { identities } = extractFailures(log);
+
+		expect(identities).toEqual([
+			"AgentSession auto-compaction > discards the triggering agent_end",
+			"AgentSession auto-compaction > starts a synthetic continuation",
+		]);
+	});
+
+	test("strips the trailing duration but keeps names containing brackets", () => {
+		const log = [
+			`${TS}(fail) handles input [with brackets] in the name [1.20ms]`,
+			`${TS}(fail) plain name [12s]`,
+		].join("\n");
+
+		expect(extractFailures(log).identities).toEqual([
+			"handles input [with brackets] in the name",
+			"plain name",
+		]);
+	});
+
+	test("deduplicates an identity that fails more than once", () => {
+		const log = [`${TS}(fail) flaky one [1ms]`, `${TS}(fail) flaky one [2ms]`].join("\n");
+
+		const result = extractFailures(log);
+
+		expect(result.failures).toHaveLength(2);
+		expect(result.identities).toEqual(["flaky one"]);
+	});
+
+	test("records the runner's own fail count", () => {
+		const log = [`${TS}(fail) a`, `${TS} 1 fail`, `${TS} 1761 pass`].join("\n");
+
+		expect(extractFailures(log).reportedFailCount).toBe(1);
+	});
+
+	// The guard that makes silent under-counting impossible.
+	test("flags under-counting when the summary exceeds what was extracted", () => {
+		const log = [`${TS}(fail) only one recognised`, `${TS} 6 fail`].join("\n");
+
+		const result = extractFailures(log);
+
+		expect(result.underCounted).toBe(true);
+		expect(result.reportedFailCount).toBe(6);
+		expect(result.identities).toHaveLength(1);
+	});
+
+	test("does not flag under-counting when extraction agrees with the summary", () => {
+		const log = [`${TS}(fail) a`, `${TS}(fail) b`, `${TS} 2 fail`].join("\n");
+
+		expect(extractFailures(log).underCounted).toBe(false);
+	});
+
+	// A suite-level error (uncaught exception, failed import) is counted by the
+	// runner as a failure but never prints a `(fail) <name>` line, because there
+	// is no test to name. Observed in 6 of 1,068 real production logs.
+	test("does not flag under-counting when the shortfall is suite-level errors", () => {
+		const log = [`${TS} 10 pass`, `${TS} 1 fail`, `${TS} 1 error`].join("\n");
+
+		const result = extractFailures(log);
+
+		expect(result.reportedFailCount).toBe(1);
+		expect(result.reportedErrorCount).toBe(1);
+		expect(result.identities).toEqual([]);
+		expect(result.underCounted).toBe(false);
+	});
+
+	test("still flags under-counting when errors do not explain the whole shortfall", () => {
+		const log = [`${TS}(fail) one named`, `${TS} 5 fail`, `${TS} 1 error`].join("\n");
+
+		// 5 reported - 1 extracted - 1 error = 3 unexplained.
+		expect(extractFailures(log).underCounted).toBe(true);
+	});
+
+	test("does not flag under-counting when the log has no summary", () => {
+		const result = extractFailures(`${TS}(fail) a`);
+
+		expect(result.reportedFailCount).toBeUndefined();
+		expect(result.underCounted).toBe(false);
+	});
+
+	// A test *named* after the marker must not be mistaken for a failure; this is
+	// the false-positive direction of the same problem.
+	test("ignores prose and passing lines that merely mention the marker", () => {
+		const log = [
+			`${TS}(pass) retries transient errors [40ms]`,
+			`${TS}note: the runner prints (fail) for failures`,
+			`${TS}(fail) genuinely failing test`,
+		].join("\n");
+
+		expect(extractFailures(log).identities).toEqual(["genuinely failing test"]);
+	});
+
+	test("returns an empty result for a log with no failures", () => {
+		const result = extractFailures(`${TS} 1761 pass\n${TS} 0 fail`);
+
+		expect(result.identities).toEqual([]);
+		expect(result.underCounted).toBe(false);
+	});
+
+	test("reports the source line number for each failure", () => {
+		const log = [`${TS}setup`, `${TS}(fail) second line`].join("\n");
+
+		expect(extractFailures(log).failures[0]).toEqual({ identity: "second line", line: 2 });
+	});
+});

--- a/scripts/ci-failure-extract.ts
+++ b/scripts/ci-failure-extract.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env bun
+
+/**
+ * Extract failing-test identities from CI job logs.
+ *
+ * Written after a flaky-test audit mined a two-week CI window and recovered a
+ * failing-test identity from only 54 of 1,068 failing test jobs (~5%). The other
+ * ~1,015 jobs were bucketed as "non-test" purely because the ad-hoc extractor in
+ * use at the time never matched their output — their logs did contain ordinary
+ * `(fail) <name>` lines. Read literally, that bucket label ("no identity
+ * extracted") was mistaken for a finding ("no test failed") and sent two rounds
+ * of analysis in the wrong direction.
+ *
+ * Two properties keep that from recurring:
+ *
+ *   1. Runner log lines are prefixed with an ISO timestamp, so patterns must be
+ *      matched against the stripped line, never the raw one.
+ *   2. Bun prints a `<n> fail` summary. When the summary disagrees with the
+ *      number of identities extracted, the extraction is under-counting and the
+ *      caller is told so rather than silently receiving a short list.
+ */
+
+/** A single failing test recovered from a log. */
+export interface ExtractedFailure {
+	/** Test name exactly as the runner printed it, timing suffix removed. */
+	identity: string;
+	/** 1-based line number in the source log. */
+	line: number;
+}
+
+export interface ExtractionResult {
+	failures: ExtractedFailure[];
+	/** Distinct identities, sorted. */
+	identities: string[];
+	/** `<n> fail` from the runner's own summary, or undefined when absent. */
+	reportedFailCount?: number;
+	/**
+	 * `<n> error` from the runner's own summary. Bun counts suite-level errors
+	 * (an uncaught exception between tests, a failed import) here rather than as
+	 * a named `(fail)` line, so they legitimately have no identity to extract.
+	 */
+	reportedErrorCount?: number;
+	/**
+	 * True when the runner reported more failures than were extracted AND those
+	 * failures are not accounted for by suite-level errors, i.e. the patterns are
+	 * genuinely missing named output. Callers should fail closed on this.
+	 */
+	underCounted: boolean;
+}
+
+/** Strips the GitHub Actions ISO-8601 timestamp prefix from a log line. */
+const TIMESTAMP = /^\S+Z\s+/;
+
+/**
+ * `(fail) <name>` optionally followed by a `[12.34ms]` duration.
+ * Anchored so prose merely quoting "(fail)" cannot match.
+ */
+const BUN_FAIL = /^\(fail\)\s+(.+?)(?:\s+\[[\d.]+\s*m?s\])?\s*$/;
+
+/** Bun's tail summary, e.g. ` 6 fail`. */
+const BUN_SUMMARY = /^\s*(\d+)\s+fail\b/;
+
+/** Bun's suite-level error tally, e.g. ` 1 error`. */
+const BUN_ERROR_SUMMARY = /^\s*(\d+)\s+error\b/;
+
+export function stripTimestamp(line: string): string {
+	return line.replace(TIMESTAMP, "");
+}
+
+/**
+ * Extracts failing-test identities from a raw CI job log.
+ *
+ * Accepts the log exactly as the GitHub API returns it — timestamp prefixes and
+ * all — so callers cannot forget to normalise first.
+ */
+export function extractFailures(rawLog: string): ExtractionResult {
+	const failures: ExtractedFailure[] = [];
+	let reportedFailCount: number | undefined;
+	let reportedErrorCount: number | undefined;
+
+	const lines = rawLog.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const line = stripTimestamp(lines[i] ?? "");
+
+		const fail = BUN_FAIL.exec(line);
+		if (fail?.[1]) {
+			failures.push({ identity: fail[1].trim(), line: i + 1 });
+			continue;
+		}
+
+		if (reportedFailCount === undefined) {
+			const summary = BUN_SUMMARY.exec(line);
+			if (summary?.[1]) {
+				reportedFailCount = Number(summary[1]);
+				continue;
+			}
+		}
+
+		if (reportedErrorCount === undefined) {
+			const errors = BUN_ERROR_SUMMARY.exec(line);
+			if (errors?.[1]) reportedErrorCount = Number(errors[1]);
+		}
+	}
+
+	const identities = [...new Set(failures.map(f => f.identity))].sort();
+
+	// Compare against distinct identities: a single test failing in several
+	// shards of one log is one identity but several `(fail)` lines.
+	//
+	// Suite-level errors are counted by the runner as failures but never print a
+	// `(fail) <name>` line — there is no test to name when an import throws or an
+	// exception escapes between tests. Allowing for them keeps the guard pointed
+	// at genuine pattern gaps instead of firing on a shape it cannot ever match.
+	const unexplained = (reportedFailCount ?? 0) - identities.length - (reportedErrorCount ?? 0);
+	const underCounted = reportedFailCount !== undefined && unexplained > 0;
+
+	return { failures, identities, reportedFailCount, reportedErrorCount, underCounted };
+}
+
+if (import.meta.main) {
+	const file = Bun.argv[2];
+	if (!file) {
+		console.error("usage: bun scripts/ci-failure-extract.ts <job-log-file>");
+		process.exit(2);
+	}
+	const result = extractFailures(await Bun.file(file).text());
+	console.log(JSON.stringify(result, null, 2));
+	// Fail closed so a regression in the patterns surfaces as a non-zero exit
+	// rather than a quietly truncated list.
+	if (result.underCounted) {
+		console.error(
+			`under-counted: runner reported ${result.reportedFailCount} failures, extracted ${result.identities.length}`,
+		);
+		process.exit(1);
+	}
+}


### PR DESCRIPTION
## Why

A flaky-test audit mined a two-week CI window and recovered a failing-test identity from **54 of 1,068** failing test jobs (~5%). The other ~1,015 were bucketed as `nonTest` purely because the ad-hoc extractor in use never matched their output — their logs contained ordinary `(fail) <name>` lines all along.

Read literally, that bucket label (*"no identity extracted"*) was mistaken for a finding (*"no test failed"*). Two rounds of analysis were built on it and had to be retracted once step-level data contradicted them.

This lands the corrected extractor as committed, tested tooling so the next audit can't repeat the mistake.

## What stops it recurring

**Timestamp stripping.** Runner lines carry an ISO prefix. The original defect was matching anchored patterns against the *raw* line, so every one silently failed. Patterns here run against the stripped line, and `extractFailures` takes the log exactly as the API returns it so a caller can't forget to normalise.

**A fail-closed count check.** Bun prints a `<n> fail` summary. When it exceeds the extracted identity count the result is flagged `underCounted` and the CLI exits non-zero — a pattern regression surfaces instead of quietly returning a short list.

**Suite-error awareness.** Bun counts an uncaught exception or failed import as a failure but prints no `(fail) <name>` line, because there is no test to name. Six of the 1,068 real logs have exactly that shape:

```
 10 pass
 1 fail
 1 error
```

The shortfall is only "unexplained" once reported errors are subtracted. Without this the guard would fire permanently on output it can never match — a false alarm that trains people to ignore it.

## Validation

- **All 1,068 production job logs: 0 under-counts** (before suite-error awareness: 6)
- **14 unit tests**, covering timestamp stripping, duration suffixes, names *containing* brackets, dedup, line numbers, prose false-positives (`(pass)` lines and text merely mentioning the marker), and both directions of the suite-error case
- `bun test scripts/ci-dev-affected.test.ts` — 80 pass, confirming the new script doesn't disturb affected-path planning
- Tools typecheck clean; `git diff --check` clean; biome ignores `scripts/`

## Scope

Additive: one script plus its test. No existing file is modified, no workflow changes, nothing enters the PR critical path.
