### PR TITLE
test(telegram): widen the /btw e2e waitFor budget for loaded CI shards

### DIFF
--- a/packages/coding-agent/test/notifications-telegram-btw-e2e.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-btw-e2e.test.ts
@@ -16,8 +16,24 @@ import {
 const THREAD_ID = 901;
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
 
+/**
+ * Polls until `predicate` holds.
+ *
+ * These cases drive a real daemon, a real WebSocket, and a stubbed bot whose
+ * calls one test deliberately holds open to exercise a duplicate-delivery race,
+ * so time spent here tracks how contended the runner is rather than whether the
+ * behaviour under test is correct. The previous 8s budget passed locally but
+ * expired on loaded CI shards: an 8,185ms failure was observed waiting for
+ * "ephemeral turn", well inside that test's own 30s budget.
+ *
+ * The budget is not raised to near the test timeout because a single test
+ * chains up to six of these waits, and an over-long per-wait deadline would let
+ * the enclosing 30s test expire first with a less useful error. Every caller
+ * still asserts its exact post-condition after waiting, so a real regression
+ * fails on the assertion rather than on the clock.
+ */
 async function waitFor(predicate: () => boolean, label: string): Promise<void> {
-	const deadline = Date.now() + 8_000;
+	const deadline = Date.now() + 12_000;
 	while (Date.now() < deadline) {
 		if (predicate()) return;
 		await sleep(20);


### PR DESCRIPTION
## The failure

`/btw travels through NotificationServer and a real WebSocket with one strict terminal dispatch` failed on dev-ci ([run 30235560989](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30235560989)):

```
error: timed out waiting for ephemeral turn
  at waitFor (notifications-telegram-btw-e2e.test.ts:25:12)
  at async <anonymous> (notifications-telegram-btw-e2e.test.ts:270:10)
(fail) /btw travels through NotificationServer ... [8185.47ms]
```

8,185ms against `waitFor`'s hardcoded **8,000ms** deadline — not against the test's own 30s budget, which had ample time left. My first hypothesis was a plain test timeout; the 30s budget rules that out.

## The trigger is mine

PR #3111 rewrote this test to prove the duplicate-delivery race deterministically, adding a `beforeCall` hook that holds `sendRichMessage` open on `terminalReplyGate.release.promise`.

Holding the bot call blocks daemon progress — that is the point of the gate — but it also means the *earlier* `waitFor(..., "ephemeral turn")` must now make progress while the daemon is contended. Comfortable on an unloaded machine; over 8s on a loaded CI shard.

## Why 12s and not more

A single test chains **up to six** of these waits inside a 30s budget. Raising the per-wait deadline to near the test timeout would let the enclosing test expire first and report a less useful error. 12s is a comfortable multiple of observed CI latency while leaving room for the chain.

The bound stays finite, so a real hang still fails rather than hanging the suite, and every caller still asserts its exact post-condition after waiting — a genuine regression fails on the assertion, not on the clock.

## Verification

Not reproducible on darwin-arm64: 6× parallel whole-file runs pass **both before and after** this change, so I can't offer a local red-then-green. It is verified by mechanism instead — the observed failure duration matches the old deadline precisely, and the code path that consumes the budget is the gate I added.

- Whole file: 4/4 pass
- 6× parallel contention: 6/6 clean, zero `waitFor` timeouts
- biome clean; single-file diff

## Scope

This fixes 2 of 136 failing observations in the post-merge dev window. A census of all 13 failed runs is in `phase6r-postmerge-failure-census.json`; the dominant failures are unrelated suites (SelectorController session deletion, test manifest runner, SDK operation matrix) that this PR does not address.
