### PR TITLE
chore(sdk): bump @agentclientprotocol/sdk to 1.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -228,7 +228,7 @@
     },
   },
   "catalog": {
-    "@agentclientprotocol/sdk": "1.2.1",
+    "@agentclientprotocol/sdk": "1.3.0",
     "@anthropic-ai/sdk": "^0.94.0",
     "@babel/generator": "^7.29.1",
     "@babel/parser": "^7.29.3",
@@ -300,7 +300,7 @@
     "zod": "4.4.3",
   },
   "packages": {
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.2.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.3.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.94.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-OVlCttk5MyeTGtrWX5+F3MJOfEMDuEjK8+rm9aQMDfRPWndVMbhk37QG8WLnVbcc7huyUGngVMjT7iMN2llySA=="],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "packages/*"
     ],
     "catalog": {
-      "@agentclientprotocol/sdk": "1.2.1",
+      "@agentclientprotocol/sdk": "1.3.0",
       "@anthropic-ai/sdk": "^0.94.0",
       "@babel/generator": "^7.29.1",
       "@babel/parser": "^7.29.3",


### PR DESCRIPTION
## Summary

Bumps `@agentclientprotocol/sdk` from 1.2.1 to 1.3.0. The change is the catalog pin plus the lockfile entry; no source changes.

Live probes observed `protocolVersion: 1`. The SDK's shipped v1 `schema/schema.json` is **not** byte-identical between these releases, so this is worth stating precisely rather than calling the bump a no-op. Six of 262 `$defs` changed; none were added or removed, and no `required` array changed:

- `ToolCall` and `ToolCallUpdate` gained an optional `name` property, documented upstream as **UNSTABLE** ("not part of the spec yet, and may be removed or changed at any point"). `required` stays `[toolCallId, title]` and `[toolCallId]`.
- `CreateElicitationRequest`, `CreateElicitationResponse`, `ElicitationPropertySchema`, and `MultiSelectItems` lost OpenAPI `discriminator`/`propertyName` keywords. Those are codegen annotations rather than JSON Schema validation constraints, so the `anyOf`/`const`/`required`/`not` validation semantics are unchanged.

No intentional emission or handling behavior is added by this bump. The tool-call constructors in `acp-event-mapper.ts` build their objects field by field and never set `name`, so nothing begins emitting the new field. All 48 SDK symbols referenced across 13 files resolve in 1.3.0.

Residual risk, stated separately from the above:

- External consumers that generate code from the shipped v1 schema and rely on `discriminator` for tagged-union dispatch may be affected. The verification here does not exercise schema-driven code generation, so compatibility for such consumers remains unverified.
- The focused checks do not exercise a notification containing the optional `name` field. They show only that the exercised path omits it; this catalog-and-lockfile-only PR adds no source-level use of `name`.

## Verification

Run on `779582aebafb14847bc0667194d5d34b4ad2606a`:

- `bun --cwd packages/coding-agent run check` — passed (Biome plus package TypeScript; the single `useLiteralKeys` info is pre-existing in `test/provider-auth-health.redteam.test.ts`, a file this PR does not touch)
- `bun --cwd packages/coding-agent run lint` — passed, same pre-existing info
- `bun test packages/coding-agent/test/*acp*.ts packages/coding-agent/test/acp/` — 191 pass, 0 fail
- `bun test packages/coding-agent/test/acp-initialize-conformance.test.ts packages/coding-agent/test/acp-event-mapper.test.ts` — 39 pass, 0 fail
- `git diff --check origin/dev..HEAD` — clean; changed files are exactly `package.json` and `bun.lock`

`bun --cwd packages/coding-agent run test` (the whole package suite) does **not** pass on this machine, and it does not pass on `dev` either. I ran it both ways to be sure the bump was not the cause:

- unmodified `dev`, still on SDK 1.2.1 — 13335 pass, 117 fail
- this branch on SDK 1.3.0 — 13385 pass, 116 fail

The failures are macOS-specific: `/var/folders/...` versus its `/private/var/folders/...` realpath in session-directory and managed-storage assertions, plus some tmux/timeout flakes. None of the failing files import `@agentclientprotocol/sdk`. The three that looked SDK-related (`sdk-session-directory`, `sdk-session-isolation`, `sdk-broker-lifecycle-e2e`) pass when run in isolation on this branch, so they are full-suite interference rather than a regression from this change. I am reporting this rather than quoting a green suite I did not get.

**Not run:** repository-root `bun check`, root `bun test`, and root `bun lint`. The package-scoped commands are not repository-root gates and are not reported as such.

Which test covers which surface, since the schema delta touches two different areas:

- `acp-event-mapper.test.ts` roots its validator at `#/$defs/SessionNotification`, so it validates emitted `ToolCall`/`ToolCallUpdate` notifications against the installed schema.
- `acp-initialize-conformance.test.ts` roots at `#/$defs/InitializeResponse`, so it covers negotiation and capabilities only.
- No test covers the four changed elicitation definitions directly.

Changed-surface probe, captured on this head against a real `gjc acp` process on 1.3.0 during a **single Bash tool execution**:

```
captured 4 tool-call notifications
carrying the new optional `name` field: 0
  tool_call:        keys=["sessionUpdate","toolCallId","title","kind","status","rawInput","content"]
  tool_call_update: keys=["sessionUpdate","toolCallId","status","rawOutput","content"]
```

Across the four captured notifications, zero carried a `name` property. This shows only that the one exercised Bash-tool path emitted no `name`; it does not cover other tool types, failure, partial-update, replay, elicitation, or external-codegen paths. The catalog-and-lockfile-only diff and the mapper implementation establish that this PR adds no source-level adoption of `name`; the event-mapper tests establish schema validity, not the absence of an optional field.
