### PR TITLE
fix(tui): hold fragmented capability-probe replies instead of typing them into the composer

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Fixed
 
+- Fragmented terminal capability-probe replies (OSC 11 background color, DA1, Kitty flags, Mode 2031 DSR) are no longer flushed into the input stream as individual characters when the reply is split across stdin reads, which typed sequences such as `^[]11;rgb:0000/0000/0000^G^[[?62;22;52c` into the composer. Incomplete OSC/CSI prefixes are now held at the stdin decoding boundary until they complete (bounded), and an ESC arriving mid-sequence cuts the unterminated sequence instead of swallowing the key that follows it (#3264).
+
 - `waitForRenderCommit` / generation-scoped render tokens resolve only after a successful buffer write (or fail open on stopped/unavailable terminals), enabling awaitable progress frames for interactive resume without hanging (#2914).
 
 ### Fixed

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -26,6 +26,28 @@ const BRACKETED_PASTE_END = "\x1b[201~";
 const SGR_QUARANTINE_MAX_BYTES = 256;
 const SGR_QUARANTINE_TIMEOUT_MS = 100;
 
+// An incomplete capability-probe reply must not be flushed into the input
+// stream: its fragments would be delivered as individual characters and typed
+// into the application. Hold such a prefix until it completes, bounded so a
+// terminal that never finishes the reply cannot wedge input.
+const PROBE_FRAGMENT_HOLD_MAX_MS = 500;
+const PROBE_FRAGMENT_MAX_BYTES = 256;
+const PROBE_ESCAPE_HOLD_MAX_MS = 150;
+const PROBE_REPLY_WINDOW_MS = 2500;
+
+/**
+ * True when the buffer is an escape sequence that only a terminal reply can
+ * complete: an OSC missing its BEL/ST terminator (OSC 11 background color) or a
+ * CSI missing its final byte (DA1, Kitty keyboard flags, Mode 2031 DSR, and
+ * ordinary CSI keys such as arrows). SGR mouse prefixes are excluded because
+ * they have their own quarantine.
+ */
+function isIncompleteProbeReplyPrefix(buffer: string): boolean {
+	if (buffer.length > PROBE_FRAGMENT_MAX_BYTES) return false;
+	if (/^\x1b\][^\x07\x1b]*$/.test(buffer)) return true;
+	return /^\x1b\[\??[\d;]*$/.test(buffer);
+}
+
 /** True for complete SGR mouse CSI reports. These remain control input, never text. */
 export function isSgrMouseSequence(sequence: string): boolean {
 	return /^\x1b\[<\d+;\d+;\d+[Mm]$/.test(sequence);
@@ -238,6 +260,19 @@ function parseUnmodifiedKittyPrintableCodepoint(sequence: string): number | unde
 	return codepoint >= 32 ? codepoint : undefined;
 }
 
+/**
+ * True when the ESC at `index` can still continue the escape sequence that
+ * started at offset 0, i.e. it is (or may become) the ST terminator `ESC \` of
+ * an OSC/DCS/APC string. Anywhere else an ESC cancels the sequence in progress.
+ */
+function continuesAsStringTerminator(remaining: string, index: number): boolean {
+	const introducer = remaining[1];
+	if (introducer !== "]" && introducer !== "P" && introducer !== "_") return false;
+	const afterEsc = remaining[index + 1];
+	// Terminator not fully delivered yet: keep buffering rather than guessing.
+	return afterEsc === undefined || afterEsc === "\\";
+}
+
 function extractCompleteSequences(buffer: string): { sequences: string[]; remainder: string } {
 	const sequences: string[] = [];
 	let pos = 0;
@@ -270,6 +305,16 @@ function extractCompleteSequences(buffer: string): { sequences: string[]; remain
 					pos += seqEnd;
 					break;
 				} else if (status === "incomplete") {
+					// An ESC cancels an escape sequence already in progress; it can only
+					// continue one as the ST terminator of an OSC/DCS/APC string. Cutting
+					// here keeps an unterminated sequence (e.g. a probe reply whose
+					// terminator was dropped) from swallowing the key that follows it.
+					// seqEnd === 1 is excluded so Meta sequences (ESC ESC [ A) still parse.
+					if (remaining[seqEnd] === ESC && seqEnd >= 2 && !continuesAsStringTerminator(remaining, seqEnd)) {
+						sequences.push(candidate);
+						pos += seqEnd;
+						break;
+					}
 					seqEnd++;
 				} else {
 					// Should not happen when starting with ESC
@@ -346,6 +391,8 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 	#sgrQuarantineBytes = 0;
 	#sgrQuarantineSemicolons = 0;
 	#sgrQuarantineHasDigit = false;
+	#probeHoldStartedAt: number | undefined;
+	#probeReplyWindowUntil = 0;
 
 	constructor(options: StdinBufferOptions = {}) {
 		super();
@@ -497,17 +544,10 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			this.#emitDataSequence(sequence);
 		}
 
-		if (this.#buffer.length > 0) {
-			this.#timeout = setTimeout(() => {
-				if (isSgrMousePrefix(this.#buffer)) {
-					this.#beginSgrQuarantine();
-					return;
-				}
-				const flushed = this.flush();
-				for (const sequence of flushed) {
-					this.#emitDataSequence(sequence);
-				}
-			}, this.#timeoutMs);
+		if (this.#buffer.length === 0) {
+			this.#probeHoldStartedAt = undefined;
+		} else {
+			this.#timeout = setTimeout(() => this.#onFlushTimeout(), this.#timeoutMs);
 		}
 	}
 
@@ -599,12 +639,56 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		this.emit("data", sequence);
 	}
 
+	/**
+	 * Called by the terminal right after it writes a capability probe (OSC 11,
+	 * DA1, Kitty flags, Mode 2031). A lone ESC arriving inside this window may be
+	 * the first byte of the reply rather than an Esc key press, so it is held
+	 * briefly instead of being flushed as input.
+	 */
+	noteProbeIssued(windowMs: number = PROBE_REPLY_WINDOW_MS): void {
+		this.#probeReplyWindowUntil = Date.now() + windowMs;
+	}
+
+	#onFlushTimeout(): void {
+		if (isSgrMousePrefix(this.#buffer)) {
+			this.#beginSgrQuarantine();
+			return;
+		}
+		if (this.#shouldHoldProbeFragment()) {
+			this.#timeout = setTimeout(() => this.#onFlushTimeout(), this.#timeoutMs);
+			return;
+		}
+		this.#probeHoldStartedAt = undefined;
+		const flushed = this.flush();
+		for (const sequence of flushed) {
+			this.#emitDataSequence(sequence);
+		}
+	}
+
+	#shouldHoldProbeFragment(): boolean {
+		const buffer = this.#buffer;
+		if (buffer.length === 0) return false;
+		const now = Date.now();
+		const bareEscape = buffer === ESC;
+		if (bareEscape) {
+			// A lone ESC is a real key press: hold it only while a probe reply is
+			// still expected, and only briefly.
+			if (now >= this.#probeReplyWindowUntil) return false;
+		} else if (!isIncompleteProbeReplyPrefix(buffer)) {
+			return false;
+		}
+		if (this.#probeHoldStartedAt === undefined) this.#probeHoldStartedAt = now;
+		const limit = bareEscape ? PROBE_ESCAPE_HOLD_MAX_MS : PROBE_FRAGMENT_HOLD_MAX_MS;
+		return now - this.#probeHoldStartedAt < limit;
+	}
+
 	flush(): string[] {
 		if (this.#timeout) {
 			clearTimeout(this.#timeout);
 			this.#timeout = undefined;
 		}
 		if (this.#sgrQuarantine) this.#endSgrQuarantine();
+		this.#probeHoldStartedAt = undefined;
 
 		const pendingMeta = this.#consumePendingSingleUtf8LeadAsMeta();
 
@@ -637,6 +721,7 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		this.#sgrQuarantineBytes = 0;
 		this.#sgrQuarantineSemicolons = 0;
 		this.#sgrQuarantineHasDigit = false;
+		this.#probeHoldStartedAt = undefined;
 		// Drop any incomplete multi-byte sequence the decoder is holding so a
 		// stale partial prefix cannot combine with future input. destroy()
 		// resets the decoder by calling clear().

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -318,6 +318,7 @@ export class ProcessTerminal implements Terminal {
 		// When the terminal reports a change, we re-query OSC 11 to get the
 		// actual background color (following Neovim convention) with 100ms debounce.
 		this.#safeWrite("\x1b[?2031h");
+		this.#stdinBuffer?.noteProbeIssued();
 
 		// Start periodic OSC 11 re-query for terminals without Mode 2031
 		// (Warp, Alacritty, WezTerm, iTerm2). Self-disables once Mode 2031 fires.
@@ -562,6 +563,7 @@ export class ProcessTerminal implements Terminal {
 		this.#pendingDa1Sentinels++;
 		this.#safeWrite("\x1b]11;?\x07"); // OSC 11 query (BEL terminated)
 		this.#safeWrite("\x1b[c"); // DA1 sentinel
+		this.#stdinBuffer?.noteProbeIssued();
 	}
 	/**
 	 * Parse an OSC 11 background color response and compute BT.601 luminance.
@@ -631,6 +633,7 @@ export class ProcessTerminal implements Terminal {
 			return;
 		}
 		this.#safeWrite("\x1b[?u");
+		this.#stdinBuffer?.noteProbeIssued();
 		// Windows Terminal and conhost do not implement the Kitty keyboard
 		// protocol, so the query above never activates it there. They do honor the
 		// modifyOtherKeys fallback below — but that mode breaks Windows CJK/Hangul

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -5,7 +5,7 @@
  * MIT License - Copyright (c) 2025 opentui
  */
 
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { StdinBuffer } from "@gajae-code/tui/stdin-buffer";
 
 describe("StdinBuffer", () => {
@@ -583,6 +583,114 @@ describe("StdinBuffer", () => {
 			processInput(Buffer.from([0xc1]));
 			expect(emittedSequences).toEqual(["\x1bA"]);
 			expect(emittedSequences.join("")).not.toContain("\uFFFD");
+		});
+	});
+	describe("Capability-probe reply fragments", () => {
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("holds an incomplete OSC prefix instead of flushing its fragments", () => {
+			vi.useFakeTimers();
+			processInput("\x1b]11;rgb:00");
+			vi.advanceTimersByTime(100);
+			expect(emittedSequences).toEqual([]);
+
+			processInput("00/0000/0000\x07");
+			expect(emittedSequences).toEqual(["\x1b]11;rgb:0000/0000/0000\x07"]);
+		});
+
+		it("holds an incomplete CSI prefix instead of flushing its fragments", () => {
+			vi.useFakeTimers();
+			processInput("\x1b[?62");
+			vi.advanceTimersByTime(100);
+			expect(emittedSequences).toEqual([]);
+
+			processInput(";22;52c");
+			expect(emittedSequences).toEqual(["\x1b[?62;22;52c"]);
+		});
+
+		it("reassembles a reply delivered one byte at a time", () => {
+			vi.useFakeTimers();
+			buffer.noteProbeIssued();
+			for (const char of "\x1b]11;rgb:1c1c/1c1c/1c1c\x07") {
+				processInput(char);
+				vi.advanceTimersByTime(15);
+			}
+
+			expect(emittedSequences).toEqual(["\x1b]11;rgb:1c1c/1c1c/1c1c\x07"]);
+		});
+
+		it("flushes a held prefix once the bounded hold elapses", () => {
+			vi.useFakeTimers();
+			processInput("\x1b]11;rgb:00");
+			vi.advanceTimersByTime(400);
+			expect(emittedSequences).toEqual([]);
+
+			vi.advanceTimersByTime(200);
+			expect(emittedSequences).toEqual(["\x1b]11;rgb:00"]);
+		});
+
+		it("flushes a lone ESC promptly when no probe reply is expected", () => {
+			vi.useFakeTimers();
+			processInput("\x1b");
+			vi.advanceTimersByTime(20);
+
+			expect(emittedSequences).toEqual(["\x1b"]);
+		});
+
+		it("holds a lone ESC briefly while a probe reply is expected", () => {
+			vi.useFakeTimers();
+			buffer.noteProbeIssued();
+			processInput("\x1b");
+			vi.advanceTimersByTime(20);
+			expect(emittedSequences).toEqual([]);
+
+			vi.advanceTimersByTime(200);
+			expect(emittedSequences).toEqual(["\x1b"]);
+		});
+
+		it("resolves a held ESC immediately when the next key arrives", () => {
+			vi.useFakeTimers();
+			buffer.noteProbeIssued();
+			processInput("\x1b");
+			vi.advanceTimersByTime(20);
+			processInput("a");
+
+			expect(emittedSequences).toEqual(["\x1ba"]);
+		});
+
+		it("still quarantines an SGR mouse prefix", () => {
+			vi.useFakeTimers();
+			processInput("\x1b[<35;20");
+			vi.advanceTimersByTime(20);
+			processInput(";5M");
+			vi.advanceTimersByTime(20);
+
+			expect(emittedSequences).toEqual([]);
+		});
+		it("cuts an unterminated sequence when a new escape arrives", () => {
+			vi.useFakeTimers();
+			processInput("\x1b]11;rgb:ff");
+			vi.advanceTimersByTime(50);
+			processInput("\x1b[A");
+
+			expect(emittedSequences).toEqual(["\x1b]11;rgb:ff", "\x1b[A"]);
+		});
+
+		it("keeps ESC \\ as the string terminator of an OSC reply", () => {
+			vi.useFakeTimers();
+			processInput("\x1b]11;rgb:1c1c/1c1c/1c1c");
+			vi.advanceTimersByTime(50);
+			processInput("\x1b\\");
+
+			expect(emittedSequences).toEqual(["\x1b]11;rgb:1c1c/1c1c/1c1c\x1b\\"]);
+		});
+
+		it("still emits a Meta escape pair (ESC ESC) as one sequence", () => {
+			processInput("\x1b\x1b");
+
+			expect(emittedSequences).toEqual(["\x1b\x1b"]);
 		});
 	});
 });

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -401,4 +401,22 @@ describe("ProcessTerminal raw-Buffer stdin (issue #454)", () => {
 
 		terminal.stop();
 	});
+	it("does not leak a fragmented OSC 11 + DA1 reply into the input handler", () => {
+		const { terminal, received } = setupTerminal();
+
+		// The reply is split across stdin reads with a gap larger than the
+		// StdinBuffer completion timeout, which previously flushed the partial
+		// sequence and typed its remaining bytes into the editor.
+		vi.useFakeTimers();
+		process.stdin.emit("data", Buffer.from("\x1b]11;rgb:00", "utf8"));
+		vi.advanceTimersByTime(50);
+		process.stdin.emit("data", Buffer.from("00/0000/0000\x07\x1b[?62", "utf8"));
+		vi.advanceTimersByTime(50);
+		process.stdin.emit("data", Buffer.from(";22;52c", "utf8"));
+
+		expect(received).toEqual([]);
+		expect(terminal.appearance).toBe("dark");
+
+		terminal.stop();
+	});
 });


### PR DESCRIPTION
Fixes #3264.

## Problem

A capability-probe reply that GJC itself solicits (OSC 11 background color + the DA1 sentinel) is typed into the composer as literal text when the reply is **split across stdin reads**:

```
we have ^[]11;rgb:0000/0000/0000^G^[[?62;22;52clocal ^[]11;rgb:0000/0000/0000^G^[[?62;22;52cthin ...
```

Observed in Ghostty 1.3.2 / macOS. Because `#startOsc11Poll()` re-queries every 2s, once the condition holds the prompt keeps filling with garbage.

## Root cause

`ProcessTerminal` drops probe replies with **whole-sequence** regexes (`da1ResponsePattern`, `osc11ResponsePattern`). `StdinBuffer` flushes its accumulator after `timeoutMs` (10ms) even when the buffer holds an incomplete escape sequence, so a reply split with a larger gap leaves as individual characters. Those fragments match nothing, reach `#inputHandler`, and are inserted as text. A busy event loop, a stalled render, or tmux/ssh chunking is enough to produce the gap.

`terminal.ts` has partial reassembly (`#privateCsiResponseBuffer`, `#osc11ResponseBuffer`), but it only kicks in once a *whole* fragment sequence arrives with the right prefix - a lone `ESC` flushed on its own defeats it.

Reproduced against `packages/tui` by driving a real `ProcessTerminal` with a fake stdin and splitting `\x1b]11;rgb:0000/0000/0000\x07` + `\x1b[?62;22;52c` at every offset with a 20ms gap: cuts 1-4 leak the whole OSC 11 reply and cuts 25-26 leak the DA1 reply; byte-at-a-time delivery leaks all 36 bytes.

## Fix

Handle it where stdin is tokenized instead of adding another reply-shape filter:

1. **Hold incomplete probe-reply prefixes.** An OSC without its BEL/ST terminator (`/^\x1b\][^\x07\x1b]*$/`) and a CSI without its final byte (`/^\x1b\[\??[\d;]*$/`) can only be completed by more bytes, so they are held rather than flushed, bounded by `PROBE_FRAGMENT_HOLD_MAX_MS` (500ms) / `PROBE_FRAGMENT_MAX_BYTES` (256). No keypress pays for this branch; split arrow keys are reassembled as a side effect.
2. **Bare `ESC` only inside a probe window.** A lone `ESC` is a genuine key press, so it is held only while a reply is expected - `ProcessTerminal` calls `stdinBuffer.noteProbeIssued()` right after writing the OSC 11 / DA1 / Kitty / Mode 2031 probes - and only for 150ms. Any following byte resolves the hold immediately, so only a bare Esc pressed inside the window is delayed (tmux's default `escape-time` is 500ms for comparison).
3. **An ESC cancels a sequence in progress.** `extractCompleteSequences` kept scanning across an embedded `ESC`, so an unterminated probe reply could merge with the next key (`\x1b[?62` + `\x1b[A` became one token). Now an `ESC` cuts the unterminated sequence unless it is the ST terminator of an OSC/DCS/APC string. Meta (`ESC ESC`) parsing is unchanged.

Completed replies then reach the existing whole-sequence handlers and are consumed as before.

## Tests

- `packages/tui/test/stdin-buffer.test.ts`: new `Capability-probe reply fragments` block - incomplete OSC/CSI prefixes are held and reassembled, byte-at-a-time delivery reassembles, a held prefix is still flushed once the bound elapses, a lone ESC is prompt without a probe window and briefly held inside one, a following key resolves a held ESC immediately, SGR mouse quarantine is untouched, an ESC cuts an unterminated sequence, `ESC \` still terminates an OSC.
- `packages/tui/test/terminal-appearance.test.ts`: a fragmented OSC 11 + DA1 reply must not reach the input handler while still updating `terminal.appearance`.
- Full `packages/tui` suite: 864 pass / 6 skip / 0 fail. `bun run check` (biome + tsc) clean.
