### PR TITLE
fix(coding-agent): repair dev CI 30244279756 after #3257

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Fixed
 
+- Align managed fallback abort-after-exhaustion expectations with #3257 ownership release: a subscriber abort at terminal `message_end` no longer expects a second `requestRunTerminal(cancelled)` because the logical-run owner is already cleared.
+- Python eval timeout annotations now prefer the caller-configured `timeoutMs` over remaining wall-clock budget so async setup cannot flake second formatting in CI.
 - Overflow maintenance now stops cleanly when no-op compaction would replay the same oversized request; the runtime status explains that `/clear` preserves the current session ID before retrying.
 - The `ask` tool no longer rejects a JSON-string-encoded single-sided Round 0 payload before coercion; only the retired contract+review pair stays terminal, so a provider that serializes `questions` as a string no longer drives the model into an unbounded retry loop.
 - Browser launch overrides (`PUPPETEER_EXECUTABLE_PATH`, `PUPPETEER_PROXY`, `PUPPETEER_PROXY_BYPASS_LOOPBACK`, `PUPPETEER_PROXY_IGNORE_CERT_ERRORS`) are now resolved from trusted environment sources only. `Bun.env` is `process.env` and the env module merges the caller's `cwd/.env` into it, so a repository could previously plant a `.env` that chose the browser binary, routed every request through its own proxy, and disabled certificate validation. Resolution now goes through the non-project resolver (launching shell plus GJC/user-owned `.env` files); shell-level configuration is unchanged.

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -518,10 +518,7 @@ async function executeWithKernel(
 			// Remaining wall-clock budget can shrink after async setup (Settings.init,
 			// kernel start) and would otherwise flake Math.round() second formatting.
 			const annotation = result.timedOut
-				? formatKernelTimeoutAnnotation(
-						options?.timeoutMs ?? executionTimeoutMs,
-						result.kernelKilled ?? false,
-					)
+				? formatKernelTimeoutAnnotation(options?.timeoutMs ?? executionTimeoutMs, result.kernelKilled ?? false)
 				: undefined;
 			let crashNotice: string | null = null;
 			if (result.kernelKilled) {

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -514,8 +514,14 @@ async function executeWithKernel(
 		});
 
 		if (result.cancelled) {
+			// Prefer the caller-configured timeout for the user-facing annotation.
+			// Remaining wall-clock budget can shrink after async setup (Settings.init,
+			// kernel start) and would otherwise flake Math.round() second formatting.
 			const annotation = result.timedOut
-				? formatKernelTimeoutAnnotation(executionTimeoutMs, result.kernelKilled ?? false)
+				? formatKernelTimeoutAnnotation(
+						options?.timeoutMs ?? executionTimeoutMs,
+						result.kernelKilled ?? false,
+					)
 				: undefined;
 			let crashNotice: string | null = null;
 			if (result.kernelKilled) {
@@ -569,7 +575,9 @@ async function executeWithKernel(
 				cancelled: true,
 				displayOutputs,
 				stdinRequested: false,
-				...(await sink.dump(timedOut ? formatTimeoutAnnotation(executionTimeoutMs) : undefined)),
+				...(await sink.dump(
+					timedOut ? formatTimeoutAnnotation(options?.timeoutMs ?? executionTimeoutMs) : undefined,
+				)),
 			};
 		}
 		const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/coding-agent/test/agent-session-fallback-attempt-transaction.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-attempt-transaction.test.ts
@@ -380,10 +380,14 @@ describe("AgentSession managed fallback attempt transaction", () => {
 
 		const agentEnds = events.filter(event => event.type === "agent_end");
 		expect(agentEnds).toHaveLength(1);
-		expect(terminalSpy).toHaveBeenCalledTimes(2);
-		expect(terminalSpy.mock.calls).toEqual([
-			[terminalSpy.mock.calls[0]![0], expect.objectContaining({ stopReason: "exhausted" })],
-			[terminalSpy.mock.calls[0]![0], expect.objectContaining({ stopReason: "cancelled" })],
+		// PR #3257 clears managed ownership before terminal observers run, so a
+		// subscriber abort at message_end no longer sees a live logical-run owner
+		// and must not issue a second requestRunTerminal(cancelled). Exhausted
+		// completion remains the sole terminalization.
+		expect(terminalSpy).toHaveBeenCalledTimes(1);
+		expect(terminalSpy.mock.calls[0]).toEqual([
+			terminalSpy.mock.calls[0]![0],
+			expect.objectContaining({ stopReason: "exhausted" }),
 		]);
 		expect(agentEnds[0]).toMatchObject({
 			messages: [

--- a/packages/coding-agent/test/provider-auth-health.redteam.test.ts
+++ b/packages/coding-agent/test/provider-auth-health.redteam.test.ts
@@ -176,7 +176,7 @@ describe("provider auth health state attacks", () => {
 		}
 
 		expect(Reflect.ownKeys(Object.prototype)).toEqual(objectPrototypeKeysBefore);
-		expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
 		expect(Object.prototype.constructor).toBe(Object);
 		expect(typeof Object.prototype.toString).toBe("function");
 


### PR DESCRIPTION
## What

- Align `preserves exhausted completion when a subscriber aborts after unavailable-tail diagnostics` with #3257: managed logical-run ownership is cleared before terminal observers, so a subscriber `abort()` at `message_end` must not expect a second `requestRunTerminal(cancelled)`.
- Prefer caller-configured `timeoutMs` when formatting Python eval timeout annotations, so remaining wall-clock budget after async setup cannot flake `Math.round()` second text in CI.

## Why

Dev CI run [30244279756](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30244279756) failed at head `2d8770169` (#3257):

1. **Shard 1 (attributable regression):** `agent-session-fallback-attempt-transaction.test.ts:383` expected `requestRunTerminal` ×2, got ×1. #3257 intentionally clears `#managedLogicalRunOwner` inside `requestRunTerminal` before terminal observers; abort-after-diagnostics therefore correctly skips a cancelled terminalization.
2. **Shard 2 (independent timing flake):** `python-executor-per-call.test.ts:147` expected `after 2s`, got `after 1s`. Annotation used remaining budget after `Settings.init`/setup, so CI latency could round to 1s. Not caused by #3257 product delta.

## Classification

| Failure | Class | Repair |
|---|---|---|
| fallback terminal call count | branch regression vs stale test after #3257 | update test contract |
| python timeout text 2s→1s | independent remaining-budget formatting flake | annotate from configured `timeoutMs` |

## Constraints

- Minimal attributable repair only on this branch.
- Do **not** merge to `dev` until this PR review/CI is green (leave dev merge frozen).
- Do **not** rerun/cancel release workflows.

## Test plan

- [x] `bun test packages/coding-agent/test/agent-session-fallback-attempt-transaction.test.ts` (8/8)
- [x] `bun test` python-executor per-call/timeout/streaming/mapping/result suites (12/12)
- [x] Simulated remaining-budget shrink still reports configured `2s`
- [ ] Hosted PR CI (coding-agent affected shards)