### PR TITLE
fix(ai): resolve the Kimi OAuth host from trusted env only

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- The Kimi OAuth host (`KIMI_CODE_OAUTH_HOST` / `KIMI_OAUTH_HOST`) is now resolved from trusted environment sources only. That host receives the device-authorization request, the authorization-code exchange, and the refresh call that carries the existing refresh token, so reading it through the merged view that includes the caller's `cwd/.env` let a repository redirect the login flow and collect the user's Kimi credentials. Resolution now uses the non-project resolver; shell and user-level configuration is unchanged.
 - Anthropic `ping` keepalives no longer reset stream progress, so responses that stop producing content now reach the idle timeout instead of hanging indefinitely.
 - The documented `GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS` environment variable now takes effect: the stream-watchdog idle-timeout helpers resolve it GJC-first before the legacy `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` / `PI_STREAM_IDLE_TIMEOUT_MS` aliases (previously only the `PI_`-prefixed names were read, so setting the documented GJC name was a silent no-op).
 - The documented OpenAI-code provider knobs now take effect: `GJC_OPENAI_CODE_DEBUG`, `GJC_OPENAI_CODE_WEBSOCKET`, `GJC_OPENAI_CODE_WEBSOCKET_IDLE_TIMEOUT_MS`, `GJC_OPENAI_CODE_WEBSOCKET_RETRY_BUDGET`, and `GJC_OPENAI_CODE_WEBSOCKET_RETRY_DELAY_MS` are resolved GJC-first ahead of the legacy `PI_CODEX_*` names. The Codex → OpenAI-code rename had updated the documentation but not the reads, so every documented name was a silent no-op.

--- a/packages/ai/src/utils/oauth/kimi.ts
+++ b/packages/ai/src/utils/oauth/kimi.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
-import { $env, getAgentDir, isEnoent } from "@gajae-code/utils";
+import { $pickCredentialEnv, getAgentDir, isEnoent } from "@gajae-code/utils";
 import packageJson from "../../../package.json" with { type: "json" };
 import type { OAuthController, OAuthCredentials } from "./types";
 
@@ -38,8 +38,23 @@ interface TokenResponse {
 	interval?: number;
 }
 
+/**
+ * OAuth host for the device flow, from trusted environment sources only.
+ *
+ * This host receives the device-authorization request, the authorization-code
+ * exchange, and the refresh call that carries the existing refresh token, so
+ * whatever can set it can collect the user's Kimi credentials. `$env` merges the
+ * caller's `cwd/.env`, so reading it there would let repository content redirect
+ * the login flow. Resolve it the same way the credentials themselves are:
+ * launching shell plus GJC/user-owned `.env` files, never the project `.env`.
+ */
 function resolveOAuthHost(): string {
-	return $env.KIMI_CODE_OAUTH_HOST || $env.KIMI_OAUTH_HOST || DEFAULT_OAUTH_HOST;
+	return $pickCredentialEnv("KIMI_CODE_OAUTH_HOST", "KIMI_OAUTH_HOST") || DEFAULT_OAUTH_HOST;
+}
+
+/** Test seam: the OAuth host as resolved from trusted env. */
+export function resolveKimiOAuthHostForTest(): string {
+	return resolveOAuthHost();
 }
 
 function formatDeviceModel(system: string, release: string, arch: string): string {

--- a/packages/ai/test/fixtures/kimi-oauth-host-probe.ts
+++ b/packages/ai/test/fixtures/kimi-oauth-host-probe.ts
@@ -1,0 +1,7 @@
+// Prints the Kimi OAuth host this process resolves.
+// Spawned with a controlled cwd so the caller can plant a project `.env`: the env
+// module parses `projectEnv` at load time from `process.cwd()`, so the trust
+// boundary can only be exercised from a separate process.
+import { resolveKimiOAuthHostForTest } from "@gajae-code/ai/utils/oauth/kimi";
+
+console.log(JSON.stringify({ host: resolveKimiOAuthHostForTest() }));

--- a/packages/ai/test/kimi-oauth-host-trust.test.ts
+++ b/packages/ai/test/kimi-oauth-host-trust.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * The Kimi OAuth host receives the device-authorization request, the
+ * authorization-code exchange, and the refresh call that carries the existing
+ * refresh token (`/api/oauth/device_authorization` and `/api/oauth/token`), so
+ * whatever can set it can collect the user's Kimi credentials.
+ *
+ * `Bun.env === process.env`, and the env module merges the caller's `cwd/.env`
+ * into it. `projectEnv` is parsed at module load from `process.cwd()`, so these
+ * drive a child process with a controlled cwd.
+ */
+
+const PROBE = path.join(import.meta.dir, "fixtures", "kimi-oauth-host-probe.ts");
+const KEYS = ["KIMI_CODE_OAUTH_HOST", "KIMI_OAUTH_HOST"] as const;
+
+const tempDirs: string[] = [];
+
+function projectDir(dotenv?: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-kimi-oauth-trust-"));
+	tempDirs.push(dir);
+	if (dotenv !== undefined) fs.writeFileSync(path.join(dir, ".env"), dotenv);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+async function hostIn(cwd: string, overrides: Record<string, string> = {}): Promise<string> {
+	const env: Record<string, string> = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		if (value !== undefined) env[key] = value;
+	}
+	// Never let the outer environment leak a host override into the child.
+	for (const key of KEYS) delete env[key];
+	Object.assign(env, overrides);
+
+	const proc = Bun.spawn([process.execPath, PROBE], { cwd, env, stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) throw new Error(`probe failed (${exitCode}): ${stderr}`);
+	return (JSON.parse(stdout.trim()) as { host: string }).host;
+}
+
+describe("Kimi OAuth host trust boundary", () => {
+	it("uses the built-in host when nothing overrides it", async () => {
+		expect(await hostIn(projectDir())).not.toContain("attacker.example");
+	});
+
+	it("ignores a KIMI_CODE_OAUTH_HOST planted by the project .env", async () => {
+		const cwd = projectDir("KIMI_CODE_OAUTH_HOST=https://attacker.example\n");
+		expect(await hostIn(cwd)).not.toContain("attacker.example");
+	});
+
+	it("ignores the legacy KIMI_OAUTH_HOST planted by the project .env", async () => {
+		const cwd = projectDir("KIMI_OAUTH_HOST=https://attacker.example\n");
+		expect(await hostIn(cwd)).not.toContain("attacker.example");
+	});
+
+	it("still honors an inherited KIMI_CODE_OAUTH_HOST", async () => {
+		expect(await hostIn(projectDir(), { KIMI_CODE_OAUTH_HOST: "https://kimi.internal" })).toBe(
+			"https://kimi.internal",
+		);
+	});
+
+	it("still honors the inherited legacy alias", async () => {
+		expect(await hostIn(projectDir(), { KIMI_OAUTH_HOST: "https://kimi-legacy.internal" })).toBe(
+			"https://kimi-legacy.internal",
+		);
+	});
+
+	it("keeps the primary name ahead of the legacy alias", async () => {
+		const host = await hostIn(projectDir(), {
+			KIMI_CODE_OAUTH_HOST: "https://kimi.internal",
+			KIMI_OAUTH_HOST: "https://kimi-legacy.internal",
+		});
+		expect(host).toBe("https://kimi.internal");
+	});
+
+	it("does not let the project .env override an inherited host", async () => {
+		const cwd = projectDir("KIMI_CODE_OAUTH_HOST=https://attacker.example\n");
+		expect(await hostIn(cwd, { KIMI_CODE_OAUTH_HOST: "https://kimi.internal" })).toBe("https://kimi.internal");
+	});
+});


### PR DESCRIPTION
Same trust-boundary class as #3252 / #3262 / #3276, applied to an OAuth login flow.

## Problem

```ts
// utils/oauth/kimi.ts:42
return $env.KIMI_CODE_OAUTH_HOST || $env.KIMI_OAUTH_HOST || DEFAULT_OAUTH_HOST;
```

`Bun.env === process.env`, and the env module folds the caller's `cwd/.env` into it. That host is used for all three legs of the device flow:

| line | request | what it carries |
|---|---|---|
| `:100` | `POST /api/oauth/device_authorization` | starts the flow; the user is shown this host's verification URL |
| `:169` | `POST /api/oauth/token` | authorization-code exchange |
| `:233` | `POST /api/oauth/token` | **refresh — sends the existing refresh token** |

So a repository could plant one line in `.env` and redirect the login: phish the user with an attacker-hosted verification page, receive the code exchange, and receive the stored refresh token on the next refresh.

## Fix

Resolve through `$pickCredentialEnv`, the resolver this codebase already designates for material that must not come from the caller's project `.env`. Precedence between the two names is preserved (`KIMI_CODE_OAUTH_HOST` first), and the launching shell, `~/.env`, the GJC config `.env` and the agent `.env` keep working.

## Tests

`kimi-oauth-host-trust.test.ts` spawns a probe with a controlled cwd (the env module parses `projectEnv` at load time, so the boundary is only observable across processes): built-in host by default, neither name can be planted via `.env`, both inherited names still apply, the primary name stays ahead of the legacy alias, and a planted `.env` cannot override an inherited host.

**Proof-first: reverting the resolver fails exactly the two planted cases (5 pass / 2 fail).**

## Verification

`bun run check` in `packages/ai` (whole-package biome + tsc): exit 0. New suite: 7 pass / 0 fail. Kimi-related suites across the package: 232 pass / 0 fail.

## Related, not bundled

`usage/kimi.ts` reads `$env.KIMI_CODE_BASE_URL` for the usage endpoint, and several sites read `process.env.GROK_CLI_OAUTH_TOKEN` directly. Those are separate files and will come as their own PRs so each stays independently reviewable.