### PR TITLE
fix(ai): resolve the Kimi usage base URL from trusted env only

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- The Kimi usage endpoint base (`KIMI_CODE_BASE_URL`) is now resolved from trusted environment sources only. That base becomes the URL the usage request sends `Authorization: Bearer <accessToken>` to, so reading it through the merged view that includes the caller's `cwd/.env` let a repository collect the user's Kimi access token. An explicit caller-supplied base URL still takes precedence, and shell / user-level configuration is unchanged.
 - Anthropic `ping` keepalives no longer reset stream progress, so responses that stop producing content now reach the idle timeout instead of hanging indefinitely.
 - The documented `GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS` environment variable now takes effect: the stream-watchdog idle-timeout helpers resolve it GJC-first before the legacy `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` / `PI_STREAM_IDLE_TIMEOUT_MS` aliases (previously only the `PI_`-prefixed names were read, so setting the documented GJC name was a silent no-op).
 - The documented OpenAI-code provider knobs now take effect: `GJC_OPENAI_CODE_DEBUG`, `GJC_OPENAI_CODE_WEBSOCKET`, `GJC_OPENAI_CODE_WEBSOCKET_IDLE_TIMEOUT_MS`, `GJC_OPENAI_CODE_WEBSOCKET_RETRY_BUDGET`, and `GJC_OPENAI_CODE_WEBSOCKET_RETRY_DELAY_MS` are resolved GJC-first ahead of the legacy `PI_CODEX_*` names. The Codex → OpenAI-code rename had updated the documentation but not the reads, so every documented name was a silent no-op.

--- a/packages/ai/src/usage/kimi.ts
+++ b/packages/ai/src/usage/kimi.ts
@@ -1,4 +1,4 @@
-import { $env } from "@gajae-code/utils";
+import { $credentialEnv } from "@gajae-code/utils";
 import type {
 	UsageAmount,
 	UsageFetchContext,
@@ -31,10 +31,24 @@ type KimiUsageRow = {
 	window?: UsageWindow;
 };
 
+/**
+ * Usage endpoint base, with the environment override resolved from trusted
+ * sources only.
+ *
+ * The result becomes the usage URL that the request sends
+ * `Authorization: Bearer <accessToken>` to, so whatever can set it receives the
+ * user's Kimi access token. `$env` merges the caller's `cwd/.env`, so reading it
+ * there would let repository content collect that token.
+ */
 function normalizeBaseUrl(baseUrl?: string): string {
-	const envBase = $env.KIMI_CODE_BASE_URL?.trim();
+	const envBase = $credentialEnv("KIMI_CODE_BASE_URL");
 	const candidate = baseUrl?.trim() || envBase || DEFAULT_BASE_URL;
 	return candidate.replace(/\/+$/, "");
+}
+
+/** Test seam: the usage base URL as resolved from a caller value plus trusted env. */
+export function normalizeKimiUsageBaseUrlForTest(baseUrl?: string): string {
+	return normalizeBaseUrl(baseUrl);
 }
 
 function buildUsageUrl(baseUrl: string): string {

--- a/packages/ai/test/fixtures/kimi-usage-baseurl-probe.ts
+++ b/packages/ai/test/fixtures/kimi-usage-baseurl-probe.ts
@@ -1,0 +1,12 @@
+// Prints the Kimi usage base URL this process resolves.
+// Spawned with a controlled cwd so the caller can plant a project `.env`: the env
+// module parses `projectEnv` at load time from `process.cwd()`, so the trust
+// boundary can only be exercised from a separate process.
+import { normalizeKimiUsageBaseUrlForTest } from "@gajae-code/ai/usage/kimi";
+
+console.log(
+	JSON.stringify({
+		fromEnv: normalizeKimiUsageBaseUrlForTest(),
+		callerWins: normalizeKimiUsageBaseUrlForTest("https://caller.internal"),
+	}),
+);

--- a/packages/ai/test/kimi-usage-baseurl-trust.test.ts
+++ b/packages/ai/test/kimi-usage-baseurl-trust.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * The Kimi usage base URL becomes the endpoint the usage request sends
+ * `Authorization: Bearer <accessToken>` to, so whatever can set it receives the
+ * user's Kimi access token.
+ *
+ * `Bun.env === process.env`, and the env module merges the caller's `cwd/.env`
+ * into it. `projectEnv` is parsed at module load from `process.cwd()`, so these
+ * drive a child process with a controlled cwd.
+ */
+
+const PROBE = path.join(import.meta.dir, "fixtures", "kimi-usage-baseurl-probe.ts");
+const KEY = "KIMI_CODE_BASE_URL";
+
+interface Resolved {
+	fromEnv: string;
+	callerWins: string;
+}
+
+const tempDirs: string[] = [];
+
+function projectDir(dotenv?: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-kimi-usage-trust-"));
+	tempDirs.push(dir);
+	if (dotenv !== undefined) fs.writeFileSync(path.join(dir, ".env"), dotenv);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+async function resolveIn(cwd: string, overrides: Record<string, string> = {}): Promise<Resolved> {
+	const env: Record<string, string> = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		if (value !== undefined) env[key] = value;
+	}
+	// Never let the outer environment leak a base URL into the child.
+	delete env[KEY];
+	Object.assign(env, overrides);
+
+	const proc = Bun.spawn([process.execPath, PROBE], { cwd, env, stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) throw new Error(`probe failed (${exitCode}): ${stderr}`);
+	return JSON.parse(stdout.trim()) as Resolved;
+}
+
+describe("Kimi usage base URL trust boundary", () => {
+	it("uses the built-in base when nothing overrides it", async () => {
+		expect((await resolveIn(projectDir())).fromEnv).not.toContain("attacker.example");
+	});
+
+	it("ignores a KIMI_CODE_BASE_URL planted by the project .env", async () => {
+		const cwd = projectDir("KIMI_CODE_BASE_URL=https://attacker.example\n");
+		expect((await resolveIn(cwd)).fromEnv).not.toContain("attacker.example");
+	});
+
+	it("still honors an inherited KIMI_CODE_BASE_URL", async () => {
+		expect((await resolveIn(projectDir(), { KIMI_CODE_BASE_URL: "https://kimi.internal" })).fromEnv).toBe(
+			"https://kimi.internal",
+		);
+	});
+
+	it("does not let the project .env override an inherited base URL", async () => {
+		const cwd = projectDir("KIMI_CODE_BASE_URL=https://attacker.example\n");
+		expect((await resolveIn(cwd, { KIMI_CODE_BASE_URL: "https://kimi.internal" })).fromEnv).toBe(
+			"https://kimi.internal",
+		);
+	});
+
+	it("keeps an explicit caller base URL ahead of the environment", async () => {
+		const cwd = projectDir("KIMI_CODE_BASE_URL=https://attacker.example\n");
+		expect((await resolveIn(cwd)).callerWins).toBe("https://caller.internal");
+	});
+});


### PR DESCRIPTION
Companion to #3278 (Kimi OAuth host) — same provider, different file, kept separate so each stays independently reviewable.

## Problem

```ts
// usage/kimi.ts:35
const envBase = $env.KIMI_CODE_BASE_URL?.trim();
```

`Bun.env === process.env`, and the env module folds the caller's `cwd/.env` into it. That base becomes the usage URL (`buildUsageUrl` at `:40`, used at `:231`), and the request sends the credential to it:

```ts
// :237
Authorization: `Bearer ${accessToken}`
```

So a repository could plant one line in `.env` and receive the user's Kimi access token.

## Fix

Resolve through `$credentialEnv`, the resolver this codebase already designates for material that must not come from the caller's project `.env`. An explicit caller-supplied base URL still takes precedence, and the launching shell, `~/.env`, the GJC config `.env` and the agent `.env` keep working.

## Tests

`kimi-usage-baseurl-trust.test.ts` spawns a probe with a controlled cwd (the env module parses `projectEnv` at load time, so the boundary is only observable across processes): built-in base by default, a planted `.env` is ignored, an inherited value still applies, a planted `.env` cannot override an inherited one, and an explicit caller value stays ahead of the environment.

**Proof-first: reverting the resolver fails exactly `ignores a KIMI_CODE_BASE_URL planted by the project .env` (4 pass / 1 fail).**

## Verification

`bun run check` in `packages/ai` (whole-package biome + tsc): exit 0. New suite: 5 pass / 0 fail. Kimi-related suites across the package: 232 pass / 0 fail.