### PR TITLE
fix(providers): rank BizRouter directly below OpenGateway in /login

### DIFF
--- a/packages/coding-agent/src/config/provider-ranking.ts
+++ b/packages/coding-agent/src/config/provider-ranking.ts
@@ -52,6 +52,7 @@ export const FAMOUS_PROVIDER_ORDER: readonly string[] = [
 	"xiaomi-token-plan-ams",
 	"xiaomi-token-plan-cn",
 	"opengateway",
+	"bizrouter",
 	"github-copilot",
 	"cursor",
 ];

--- a/packages/coding-agent/test/provider-ranking.test.ts
+++ b/packages/coding-agent/test/provider-ranking.test.ts
@@ -112,6 +112,7 @@ describe("famous provider list", () => {
 			"xiaomi-token-plan-ams",
 			"xiaomi-token-plan-cn",
 			"opengateway",
+			"bizrouter",
 			"github-copilot",
 			"cursor",
 		];


### PR DESCRIPTION
## Problem

`/login` did not show **BizRouter** anywhere near the other gateways. It rendered at position **22 of 51** — outside the selector's 10-row visible window, and detached from OpenGateway.

The provider itself was wired correctly (#3220): `getOAuthProviders()` returns `{"id":"bizrouter","name":"BizRouter","available":true}`, and the CLI, env resolution, and login flow all work. Only its **ranking** was missing.

## Root cause

`/login` no longer renders the raw registration array. Since #3238's ranking work landed, `oauth-selector.ts` sorts through `compareRankedProviders`, which ranks against the curated `FAMOUS_PROVIDER_ORDER` allowlist in `packages/coding-agent/src/config/provider-ranking.ts`.

`bizrouter` was not on that list, so `providerRankTier` classified it as `PROVIDER_RANK_TIER.other` and it sorted alphabetically among the unranked tail.

The BizRouter PR could not have covered this — the ranking file did not exist on that branch; the two changes landed independently.

## Change

Two lines, one entry each:

- `provider-ranking.ts` — `"bizrouter"` inserted immediately after `"opengateway"`, keeping the two gateways grouped per the list's existing convention.
- `provider-ranking.test.ts` — the same entry mirrored into `agreedOrder`. This is required, not incidental: that list is written out independently so "an accidental reorder or removal of the constant cannot validate itself," and the test fails without it.

## Result

```
18 OpenGateway by Sionic AI
19 BizRouter
20 GitHub Copilot
```

`opengateway: 18 | bizrouter: 19 | adjacent: true`

## Verification

| Command | Result |
| --- | --- |
| `bun test provider-ranking{,.redteam,-surfaces}.test.ts` | 30 pass / 0 fail |
| `bunx tsc -p packages/coding-agent/tsconfig.json --noEmit` | clean |
| `git diff --check` | clean |

Live ranked order re-derived from `getOAuthProviders()` + `sortRankedProviders()` confirms adjacency.

### Known limitation (not addressed here)

BizRouter is now at #19, still below the 10-row `OAUTH_SELECTOR_MAX_VISIBLE` window, so it needs one PageDown. That is inherent to a 51-provider list with no type-to-filter in `oauth-selector.ts`'s `handleInput` (up/down/pageUp/pageDown only). Adding a filter is a separate, larger change and is deliberately out of scope for this fix.
