### PR TITLE
test: make the env trust suites hermetic

### DIFF
--- a/packages/coding-agent/test/tools/browser/launch-env-trust.test.ts
+++ b/packages/coding-agent/test/tools/browser/launch-env-trust.test.ts
@@ -36,6 +36,12 @@ interface BrowserEnvOverrides {
 
 const tempDirs: string[] = [];
 
+function tempDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-trust-iso-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
 function projectDir(dotenv?: string): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-browser-env-trust-"));
 	tempDirs.push(dir);
@@ -54,6 +60,12 @@ async function resolveIn(cwd: string, overrides: Record<string, string> = {}): P
 	}
 	// Never let the outer environment leak an override into the child.
 	for (const key of BROWSER_KEYS) delete env[key];
+	// `$credentialEnv` also consults file sources the child env cannot mask:
+	// the agent `.env`, the GJC config `.env`, `~/.env` and the login shell rc
+	// files. Point HOME and the agent dir at empty temp dirs so a contributor who
+	// exports one of these names from a shell rc still sees a hermetic result.
+	env.HOME = tempDir();
+	env.GJC_CODING_AGENT_DIR = tempDir();
 	Object.assign(env, overrides);
 
 	const proc = Bun.spawn([process.execPath, PROBE], { cwd, env, stdout: "pipe", stderr: "pipe" });

--- a/packages/utils/test/shell-prefix-trust.test.ts
+++ b/packages/utils/test/shell-prefix-trust.test.ts
@@ -18,6 +18,12 @@ const PREFIX_KEYS = ["PI_SHELL_PREFIX", "CLAUDE_CODE_SHELL_PREFIX"] as const;
 
 const tempDirs: string[] = [];
 
+function tempDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-trust-iso-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
 function projectDir(dotenv?: string): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-shell-prefix-trust-"));
 	tempDirs.push(dir);
@@ -36,6 +42,12 @@ async function resolvePrefixIn(cwd: string, overrides: Record<string, string> = 
 	}
 	// Never let the outer environment leak a prefix into the child.
 	for (const key of PREFIX_KEYS) delete env[key];
+	// `$credentialEnv` also consults file sources the child env cannot mask:
+	// the agent `.env`, the GJC config `.env`, `~/.env` and the login shell rc
+	// files. Point HOME and the agent dir at empty temp dirs so a contributor who
+	// exports one of these names from a shell rc still sees a hermetic result.
+	env.HOME = tempDir();
+	env.GJC_CODING_AGENT_DIR = tempDir();
 	Object.assign(env, overrides);
 
 	const proc = Bun.spawn([process.execPath, PROBE], { cwd, env, stdout: "pipe", stderr: "pipe" });


### PR DESCRIPTION
Acting on the non-blocking defect you documented in the #3273 review, applied to the **already-merged** suites so the fix lands independently of the open PRs.

## Problem

`resolveIn()` / `resolvePrefixIn()` strip the variables under test from the child environment. That masks the *inherited* source only. `$credentialEnv` also consults file sources the child env cannot mask (`env.ts:220-229`):

- the agent `.env`
- the GJC config `.env`
- `~/.env`
- the login shell rc files (`~/.zshenv`, `~/.zprofile`, `~/.zshrc`, `~/.bash_profile`, `~/.bashrc`)

So a contributor who exports `PI_SHELL_PREFIX` or `PUPPETEER_*` from a shell rc — normal for exactly the audience these features serve — sees these suites fail, while CI stays green because its runners are clean. Your review reproduced this with `OPENAI_BASE_URL` from `~/.zshrc`.

## Fix

Point `HOME` and `GJC_CODING_AGENT_DIR` at empty temp dirs in the child, so every trusted source is neutral and only the scenario under test supplies a value.

## Reproduced, then fixed

With a `HOME` whose `.bashrc` exports `PI_SHELL_PREFIX`:

```
without isolation: 4 failures
  resolves no prefix when nothing sets one
  ignores a shell prefix planted by the project .env
  ignores the legacy CLAUDE_CODE_SHELL_PREFIX planted by the project .env
  still honors the legacy alias from the launching shell

with isolation:    12 pass / 0 fail across both suites
```

## Scope

Only the two suites already on `dev` (`launch-env-trust.test.ts`, `shell-prefix-trust.test.ts`). My open PRs carrying the same pattern are deliberately untouched — force-pushing them would reset the exact-head verdicts you have already issued. I will fold the same isolation into each as it is reviewed, or into a single follow-up once they land, whichever you prefer.

No production code changes.