### PR TITLE
fix(coding-agent): advertise search in fast help

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- Fast CLI help now advertises the active `search` built-in tool instead of the retired `grep` name.
 
 - Align managed fallback abort-after-exhaustion expectations with #3257 ownership release: a subscriber abort at terminal `message_end` no longer expects a second `requestRunTerminal(cancelled)` because the logical-run owner is already cleared.
 - Python eval timeout annotations now prefer the caller-configured `timeoutMs` over remaining wall-clock budget so async setup cannot flake second formatting in CI.

--- a/packages/coding-agent/src/cli/fast-help.ts
+++ b/packages/coding-agent/src/cli/fast-help.ts
@@ -93,7 +93,7 @@ Available Tools (default-enabled unless noted):
   bash          - Execute bash commands
   edit          - Edit files with find/replace
   write         - Write files (creates/overwrites)
-  grep          - Search file contents
+  search        - Search file contents
   find          - Find files by glob pattern
   lsp           - Language server protocol (code intelligence)
   python        - Execute Python code (requires: ${APP_NAME} setup python)

--- a/packages/coding-agent/test/cli-help-load-order.test.ts
+++ b/packages/coding-agent/test/cli-help-load-order.test.ts
@@ -372,6 +372,8 @@ describe("CLI help single source of truth", () => {
 		expect(fastHelpSource).toContain("Environment Variables:");
 		expect(fastHelpSource).toContain("Available Tools (default-enabled unless noted):");
 		expect(fastHelpSource).toContain("Useful Commands:");
+		expect(fastHelpSource).toContain("search        - Search file contents");
+		expect(fastHelpSource).not.toContain("grep          - Search file contents");
 	});
 
 	it("fast-help.ts never emits the stale pre-rebrand tagline", async () => {


### PR DESCRIPTION
## What
- replace the retired `grep` tool label in fast CLI help with the active `search` name
- lock the active label and stale-label absence in focused help-surface coverage
- document the user-visible correction under Unreleased

## Why
`gjc --help` advertised a built-in tool the agent cannot call while omitting the actual `search` tool name. This is the separate stale-help concern identified by the repository owner in #3277.

Closes #3292.

## Testing
- `bun test packages/coding-agent/test/cli-help-load-order.test.ts` (11 passed)
- `bunx biome check packages/coding-agent/src/cli/fast-help.ts packages/coding-agent/test/cli-help-load-order.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

## GJC verdict
`gajae.pr-review-verdict.v1 merge-approved sha256:2cb2ee63328e07366f8e8ee581f97c48282b4f76 reviewer:architect evidence:agent-review-5-Review3292`