### PR TITLE
test(build): add workspace build-dependency-order regression (investigation: race not reproduced)

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "build": "bun run --workspaces --if-present build",
     "build:native": "bun --cwd=packages/natives run build",
     "test": "bun run --parallel test:ts test:rs",
-    "test:ts": "bun run test:release && bun run --workspaces --if-present test",
+    "test:ts": "bun run test:release && bun test scripts/build-dependency-order.test.ts && bun run --workspaces --if-present test",
     "test:release": "bun test scripts/release-publish-order.test.ts scripts/restart-sdk-broker.test.ts",
     "generate-schemas": "bun scripts/generate-json-schemas.ts",
     "check:schemas": "bun scripts/generate-json-schemas.ts --check",

--- a/scripts/build-dependency-order.test.ts
+++ b/scripts/build-dependency-order.test.ts
@@ -11,7 +11,8 @@ import * as path from "node:path";
 // `bun run build` invocation into an unordered race.
 //
 // This regression protects that invariant directly: the `@gajae-code/*`
-// workspace dependency graph, restricted to packages with a `build` script,
+// workspace dependency graph, restricted to packages scheduled for a `build`
+// run (any of `prebuild`/`build`/`postbuild` present),
 // must stay acyclic. It intentionally does not invoke Bun or assert anything
 // about CLI flag spelling (`--workspaces` vs `--filter`), since both route
 // through the same scheduler and neither guards this invariant on its own.
@@ -26,7 +27,7 @@ interface WorkspacePackageManifest {
 }
 
 interface WorkspaceBuildGraph {
-	/** Packages with a `build` script -- the only nodes Bun's scheduler creates for a `build` run. */
+	/** Packages scheduled for a `build` run (any of `prebuild`/`build`/`postbuild` present) -- the only nodes Bun's scheduler creates for that run. */
 	scheduledPackageNames: Set<string>;
 	/** consumer package name -> producer package names (regular `dependencies` only, restricted to scheduled packages). */
 	edges: Map<string, string[]>;
@@ -107,7 +108,7 @@ function findCycle(edges: Map<string, string[]>): string[] | null {
 }
 
 describe("workspace build dependency graph stays acyclic", () => {
-	test("no dependency cycle among build-script-bearing @gajae-code/* packages", async () => {
+	test("no dependency cycle among build-lifecycle-scheduled @gajae-code/* packages", async () => {
 		const { scheduledPackageNames, edges } = await readWorkspaceBuildGraph();
 
 		// Sanity: the graph must actually contain the packages this regression
@@ -119,7 +120,7 @@ describe("workspace build dependency graph stays acyclic", () => {
 		const cycle = findCycle(edges);
 		if (cycle) {
 			throw new Error(
-				`Dependency cycle detected among build-script-bearing @gajae-code/* packages: ${cycle.join(" -> ")}. ` +
+				`Dependency cycle detected among build-lifecycle-scheduled @gajae-code/* packages: ${cycle.join(" -> ")}. ` +
 					"Bun's workspace-script scheduler disables build ordering for every scheduled package " +
 					"in a run when any cycle exists among them, which silently turns `bun run build` into an " +
 					"unordered race (see packages/coding-agent's build shelling into `bun --cwd=../natives run " +

--- a/scripts/build-dependency-order.test.ts
+++ b/scripts/build-dependency-order.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+// Bun's workspace-script scheduler (src/cli/filter_run.zig, `runScriptsWithFilter`)
+// orders `bun run --workspaces`/`bun run --filter '*'` scripts by each package's
+// regular `dependencies` graph, restricted to packages that declare the invoked
+// script (here: `build`). If a dependency cycle exists among those scripted
+// packages, Bun's own scheduler detects it and disables ordering for *every*
+// scripted package in the run, not just the cyclic ones -- silently turning every
+// `bun run build` invocation into an unordered race.
+//
+// This regression protects that invariant directly: the `@gajae-code/*`
+// workspace dependency graph, restricted to packages with a `build` script,
+// must stay acyclic. It intentionally does not invoke Bun or assert anything
+// about CLI flag spelling (`--workspaces` vs `--filter`), since both route
+// through the same scheduler and neither guards this invariant on its own.
+
+const repoRoot = path.join(import.meta.dir, "..");
+const packagesDir = path.join(repoRoot, "packages");
+
+interface WorkspacePackageManifest {
+	name?: string;
+	scripts?: Record<string, string>;
+	dependencies?: Record<string, string>;
+}
+
+interface WorkspaceBuildGraph {
+	/** Packages with a `build` script -- the only nodes Bun's scheduler creates for a `build` run. */
+	scheduledPackageNames: Set<string>;
+	/** consumer package name -> producer package names (regular `dependencies` only, restricted to scheduled packages). */
+	edges: Map<string, string[]>;
+}
+
+async function readWorkspaceBuildGraph(): Promise<WorkspaceBuildGraph> {
+	const entries = await fs.readdir(packagesDir, { withFileTypes: true });
+	const manifests: WorkspacePackageManifest[] = [];
+
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const manifestPath = path.join(packagesDir, entry.name, "package.json");
+		try {
+			manifests.push((await Bun.file(manifestPath).json()) as WorkspacePackageManifest);
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+			throw err;
+		}
+	}
+
+	const scheduledPackageNames = new Set(
+		manifests.filter(manifest => manifest.name && manifest.scripts?.build).map(manifest => manifest.name as string),
+	);
+
+	const edges = new Map<string, string[]>();
+	for (const name of scheduledPackageNames) edges.set(name, []);
+
+	for (const manifest of manifests) {
+		if (!manifest.name || !scheduledPackageNames.has(manifest.name)) continue;
+		const dependencyNames = Object.keys(manifest.dependencies ?? {});
+		const producers = dependencyNames.filter(dependencyName => scheduledPackageNames.has(dependencyName));
+		edges.set(manifest.name, producers);
+	}
+
+	return { scheduledPackageNames, edges };
+}
+
+/** Mirrors Bun's own `hasCycle` in `src/cli/filter_run.zig`: DFS with visiting/visited marks. */
+function findCycle(edges: Map<string, string[]>): string[] | null {
+	const visiting = new Set<string>();
+	const visited = new Set<string>();
+
+	function visit(node: string, path: string[]): string[] | null {
+		visiting.add(node);
+		path.push(node);
+		for (const producer of edges.get(node) ?? []) {
+			if (visiting.has(producer)) return [...path, producer];
+			if (!visited.has(producer)) {
+				const cycle = visit(producer, path);
+				if (cycle) return cycle;
+			}
+		}
+		path.pop();
+		visiting.delete(node);
+		visited.add(node);
+		return null;
+	}
+
+	for (const node of edges.keys()) {
+		if (visited.has(node)) continue;
+		const cycle = visit(node, []);
+		if (cycle) return cycle;
+	}
+	return null;
+}
+
+describe("workspace build dependency graph stays acyclic", () => {
+	test("no dependency cycle among build-script-bearing @gajae-code/* packages", async () => {
+		const { scheduledPackageNames, edges } = await readWorkspaceBuildGraph();
+
+		// Sanity: the graph must actually contain the packages this regression
+		// exists to protect (otherwise the test would pass vacuously).
+		expect(scheduledPackageNames.has("@gajae-code/natives")).toBe(true);
+		expect(scheduledPackageNames.has("@gajae-code/coding-agent")).toBe(true);
+		expect(edges.get("@gajae-code/coding-agent")).toContain("@gajae-code/natives");
+
+		const cycle = findCycle(edges);
+		if (cycle) {
+			throw new Error(
+				`Dependency cycle detected among build-script-bearing @gajae-code/* packages: ${cycle.join(" -> ")}. ` +
+					"Bun's workspace-script scheduler disables build ordering for every scheduled package " +
+					"in a run when any cycle exists among them, which silently turns `bun run build` into an " +
+					"unordered race (see packages/coding-agent's build shelling into `bun --cwd=../natives run " +
+					"embed:native`). Break this cycle instead of relying on `--workspaces`/`--filter` CLI spelling.",
+			);
+		}
+	});
+});

--- a/scripts/build-dependency-order.test.ts
+++ b/scripts/build-dependency-order.test.ts
@@ -47,8 +47,21 @@ async function readWorkspaceBuildGraph(): Promise<WorkspaceBuildGraph> {
 		}
 	}
 
+	// Bun schedules a package as a node whenever it has a `prebuild`, `build`, or
+	// `postbuild` script for the invoked `build` run (matching filter_run.zig's
+	// [pre_script_name, script_name, post_script_name] scan) -- not only when
+	// `build` itself is present. A future package with only lifecycle hooks
+	// (or an intentionally empty `build` script) must still be scheduled here.
 	const scheduledPackageNames = new Set(
-		manifests.filter(manifest => manifest.name && manifest.scripts?.build).map(manifest => manifest.name as string),
+		manifests
+			.filter(
+				manifest =>
+					manifest.name &&
+					(manifest.scripts?.build !== undefined ||
+						manifest.scripts?.prebuild !== undefined ||
+						manifest.scripts?.postbuild !== undefined),
+			)
+			.map(manifest => manifest.name as string),
 	);
 
 	const edges = new Map<string, string[]>();

--- a/scripts/build-dependency-order.test.ts
+++ b/scripts/build-dependency-order.test.ts
@@ -4,15 +4,17 @@ import * as path from "node:path";
 
 // Bun's workspace-script scheduler (src/cli/filter_run.zig, `runScriptsWithFilter`)
 // orders `bun run --workspaces`/`bun run --filter '*'` scripts by each package's
-// regular `dependencies` graph, restricted to packages that declare the invoked
-// script (here: `build`). If a dependency cycle exists among those scripted
-// packages, Bun's own scheduler detects it and disables ordering for *every*
-// scripted package in the run, not just the cyclic ones -- silently turning every
+// regular `dependencies` graph, restricted to packages scheduled for the
+// invoked script (here: `build`, scheduled by any of `prebuild`/`build`/
+// `postbuild` being present -- Bun scans all three per package). If a
+// dependency cycle exists among those scheduled packages, Bun's own
+// scheduler detects it and disables ordering for *every* scheduled package
+// in the run, not just the cyclic ones -- silently turning every
 // `bun run build` invocation into an unordered race.
 //
 // This regression protects that invariant directly: the `@gajae-code/*`
 // workspace dependency graph, restricted to packages scheduled for a `build`
-// run (any of `prebuild`/`build`/`postbuild` present),
+// run (any of `prebuild`/`build`/`postbuild` present)
 // must stay acyclic. It intentionally does not invoke Bun or assert anything
 // about CLI flag spelling (`--workspaces` vs `--filter`), since both route
 // through the same scheduler and neither guards this invariant on its own.


### PR DESCRIPTION
## Summary

Investigates the post-merge dogfood blocker reported after merging #3275 and fast-forwarding `dev`: `bun run build` failed twice locally, with `@gajae-code/coding-agent`'s build shelling into `bun --cwd=../natives run embed:native` and losing the race against `@gajae-code/natives`'s in-flight Rust compile (`embed-native.ts` throws `No native addons found for <platform>-<arch>` when no compiled addon exists yet).

**This PR does not apply a speculative code fix.** Following the approved investigation-first plan, I gathered direct evidence against all three candidate root-cause mechanisms and none reproduced or could be confirmed. Per the plan's explicit stop rule, forcing an unconfirmed change would be worse than reporting the evidence honestly. What *is* added is a deterministic regression test that guards the one invariant that actually matters here, regardless of which mechanism (if any) turns out to be the real cause in other environments.

## Evidence trail

### Initial (retracted) hypothesis

My first hypothesis was that `bun run --workspaces --if-present build` (the root script) has no dependency-order guarantee, and that switching to `bun run --filter='*' --if-present build` would fix it. **This is false and was retracted after direct Bun 1.3.14 source inspection** (`src/cli/filter_run.zig`, `runScriptsWithFilter`): when `--workspaces` is set, Bun internally rewrites `filters_to_use = &.{"*"}` and both code paths go through the identical dependency-graph scheduler, which starts a script only once all of its workspace-package dependencies' same-named scripts have exited (`remaining_dependencies`/`dependents` tracking, matched by dependency **name** — never by specifier value such as `catalog:` vs `workspace:*`). A one-line CLI-flag swap would have been a behavioral no-op.

### Mechanism 1 — dependency cycle (Bun disables *all* ordering on any cycle)

Bun's scheduler has a documented global short-circuit: if a dependency cycle exists anywhere among the scripted workspace packages, ordering is disabled for **every** scheduled package in that run, not just the cyclic ones.

Checked the `@gajae-code/*` workspace graph (regular `dependencies` only, restricted to packages that declare a `build` script, mirroring Bun's own `hasCycle`):

```
Scheduled (build-script-bearing) packages: @gajae-code/natives, @gajae-code/coding-agent, @gajae-code/stats
Edges (consumer -> producer):
  @gajae-code/coding-agent -> @gajae-code/stats, @gajae-code/natives
NO CYCLE — graph is acyclic
```

**Not confirmed.** (This check is now a permanent automated regression — see below.)

### Mechanism 2 — scheduler/edge visibility loss

Built a real, transparent process-observation harness: an unmodified `bun run --workspaces --if-present build` invocation run under `strace -f -tt -e trace=execve,exit_group`, in a **disposable git worktree checked out `--detach` at the exact base commit** (`18f6935b7c5f9995b5478b2f0e083a2d4302736d`, since the branch was already checked out in the primary worktree), so nothing in the canonical checkout was touched.

Ran **3 bounded attempts** (clean `packages/natives/native/pi_natives.*` state before each), all completed successfully. Example causal timeline from attempt 1 (monotonic strace timestamps, real PIDs):

```
natives build process (pid 3882332):
  exit_group(0)         09:46:29.802598
  fully exited          09:46:29.816755
coding-agent build process (pid 3907753):
  started                09:46:29.819833   <- after natives fully exited
  embed:native sub-invocation (pid 3908023)
  started                09:46:31.389973   <- well after natives exited
```

`coding-agent`'s `embed:native` never started before `natives`'s process actually exited, in any of the 3 attempts. Ran 3 additional verification builds in the **primary checkout** afterward (clean-state each time) — all 3 also completed successfully with correct ordering.

**Not confirmed.** No specifier change (e.g. `catalog:` → `workspace:*`) is applied, since Bun's scheduler doesn't branch on specifier value in the first place — such a change would have no source-level justification without direct evidence of a different, concrete gap, which this harness did not find.

### Mechanism 3 — invocation composition bypassing Bun's scheduler

Surveyed every site that invokes `coding-agent`'s `build`/`embed:native` and `natives`'s `build`:

- Root `package.json` `build` — the actual local dogfood gate is the **bare `bun run build`**, i.e. a single Bun-scheduled invocation. No `Justfile`, `Makefile`, husky/lint-staged hook, or other wrapping tool exists in this repo that composes these two builds differently.
- `.github/workflows/dev-ci.yml` — builds natives via `ci:build:native`, then (separately) `bun --cwd=packages/coding-agent run build`, as **sequential steps within the same job** — safe by construction (GitHub Actions steps run in order).
- `scripts/install-tests/run-ci.sh`, `scripts/install-tests/binary.dockerfile` — both run `bun --cwd=packages/natives run build` then `bun --cwd=packages/coding-agent run build` as sequential shell/Dockerfile `RUN` lines — safe by construction.

CI never actually exercises the racy path at all (it always builds natives via caching/artifacts, ahead of a direct, separately-invoked coding-agent build). The only place that could race is the local `bun run build` — which is a single Bun-scheduled invocation, not an independent/parallel composition.

**Not confirmed** — there is no bypassing composition to fix.

## What this PR changes

Per the plan's stop rule (no mechanism confirmed with direct evidence → no speculative source change), the diff is intentionally small:

- `scripts/build-dependency-order.test.ts` (new): a deterministic, no-Bun-invocation test that walks `packages/*/package.json`, builds the `@gajae-code/*` workspace dependency graph (regular `dependencies`, build-script-bearing packages only), and asserts it stays acyclic — mirroring Bun's own cycle-detection logic. This guards the one invariant that would silently disable *all* build ordering if ever violated, independent of which CLI flag is used.
- `package.json`: wires the new test into `test:ts` (alongside the existing `test:release` pattern) so it runs as part of `bun run test`.

No `build-binary.ts` / `build-native.ts` internals were touched. No sleeps/retries. No generated artifacts committed (verified via `git status --ignored` before/after every build attempt).

## Verification

- `bun run build` from a clean/fresh native-artifact state, run **3 times** in a disposable detached worktree + **3 times** in the primary checkout (6 total) — all succeeded, all with directly observed or logically confirmed correct build ordering.
- `bun test scripts/build-dependency-order.test.ts` — passes.
- `packages/natives` full test suite (113 pass, 37 skip, 0 fail) and `packages/coding-agent` build — both green with the rebuilt addon in place.
- `git diff` reviewed; `git status --ignored` confirms no generated `.node`/`dist`/`.build` artifacts staged.

## Honest caveat

I could not reproduce the originally reported failure in this environment across 6 total clean-state build attempts. This does not disprove the original bug report — it may be timing/environment-dependent (different filesystem, CPU count, Rust compile cache warmth, or Bun build behavior specific to the original failing runner) — but it does mean I have no direct evidence to point at a specific code change, and per the approved plan I am not guessing. If the race reproduces again, the harness technique used here (strace-based process-exec timeline against the unmodified command) is directly reusable to pin down the exact failing timestamp/process pair.

Does not merge this PR. Post-merge Dev CI (run 30251464028) still needs to reach terminal green, and this PR requires separate human review.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
