### PR TITLE
fix(ai): resolve the Kimi OAuth host from trusted env only

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Provider streams now surface first-event watchdog expiry as a typed timeout so callers can apply bounded retry policy without parsing error prose.
 - Codex named-tool requests now recognize provider `Tool choice '<name>' not found in 'tools' parameter` errors as runtime capability failures and retry once without forcing the choice.
+- The Kimi OAuth host (`KIMI_CODE_OAUTH_HOST` / `KIMI_OAUTH_HOST`) is now resolved from trusted environment sources only. That host receives the device-authorization request, the authorization-code exchange, and the refresh call that carries the existing refresh token, so reading it through the merged view that includes the caller's `cwd/.env` let a repository redirect the login flow and collect the user's Kimi credentials. Resolution now uses the non-project resolver; shell and user-level configuration is unchanged.
 
 ## [0.12.0] - 2026-07-28
 

--- a/packages/ai/src/utils/oauth/kimi.ts
+++ b/packages/ai/src/utils/oauth/kimi.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
-import { $env, getAgentDir, isEnoent } from "@gajae-code/utils";
+import { $pickCredentialEnv, getAgentDir, isEnoent } from "@gajae-code/utils";
 import packageJson from "../../../package.json" with { type: "json" };
 import type { OAuthController, OAuthCredentials } from "./types";
 
@@ -38,8 +38,23 @@ interface TokenResponse {
 	interval?: number;
 }
 
+/**
+ * OAuth host for the device flow, from trusted environment sources only.
+ *
+ * This host receives the device-authorization request, the authorization-code
+ * exchange, and the refresh call that carries the existing refresh token, so
+ * whatever can set it can collect the user's Kimi credentials. `$env` merges the
+ * caller's `cwd/.env`, so reading it there would let repository content redirect
+ * the login flow. Resolve it the same way the credentials themselves are:
+ * launching shell plus GJC/user-owned `.env` files, never the project `.env`.
+ */
 function resolveOAuthHost(): string {
-	return $env.KIMI_CODE_OAUTH_HOST || $env.KIMI_OAUTH_HOST || DEFAULT_OAUTH_HOST;
+	return $pickCredentialEnv("KIMI_CODE_OAUTH_HOST", "KIMI_OAUTH_HOST") || DEFAULT_OAUTH_HOST;
+}
+
+/** Test seam: the OAuth host as resolved from trusted env. */
+export function resolveKimiOAuthHostForTest(): string {
+	return resolveOAuthHost();
 }
 
 function formatDeviceModel(system: string, release: string, arch: string): string {

--- a/packages/ai/test/fixtures/kimi-oauth-host-probe.ts
+++ b/packages/ai/test/fixtures/kimi-oauth-host-probe.ts
@@ -1,0 +1,7 @@
+// Prints the Kimi OAuth host this process resolves.
+// Spawned with a controlled cwd so the caller can plant a project `.env`: the env
+// module parses `projectEnv` at load time from `process.cwd()`, so the trust
+// boundary can only be exercised from a separate process.
+import { resolveKimiOAuthHostForTest } from "@gajae-code/ai/utils/oauth/kimi";
+
+console.log(JSON.stringify({ host: resolveKimiOAuthHostForTest() }));

--- a/packages/ai/test/kimi-oauth-host-trust.test.ts
+++ b/packages/ai/test/kimi-oauth-host-trust.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * The Kimi OAuth host receives the device-authorization request, the
+ * authorization-code exchange, and the refresh call that carries the existing
+ * refresh token (`/api/oauth/device_authorization` and `/api/oauth/token`), so
+ * whatever can set it can collect the user's Kimi credentials.
+ *
+ * `Bun.env === process.env`, and the env module merges the caller's `cwd/.env`
+ * into it. `projectEnv` is parsed at module load from `process.cwd()`, so these
+ * drive a child process with a controlled cwd.
+ */
+
+const PROBE = path.join(import.meta.dir, "fixtures", "kimi-oauth-host-probe.ts");
+const KEYS = ["KIMI_CODE_OAUTH_HOST", "KIMI_OAUTH_HOST"] as const;
+
+const tempDirs: string[] = [];
+
+function projectDir(dotenv?: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-kimi-oauth-trust-"));
+	tempDirs.push(dir);
+	if (dotenv !== undefined) fs.writeFileSync(path.join(dir, ".env"), dotenv);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+async function hostIn(cwd: string, overrides: Record<string, string> = {}): Promise<string> {
+	const env: Record<string, string> = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		if (value !== undefined) env[key] = value;
+	}
+	// Never let the outer environment leak a host override into the child.
+	for (const key of KEYS) delete env[key];
+	Object.assign(env, overrides);
+
+	const proc = Bun.spawn([process.execPath, PROBE], { cwd, env, stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) throw new Error(`probe failed (${exitCode}): ${stderr}`);
+	return (JSON.parse(stdout.trim()) as { host: string }).host;
+}
+
+describe("Kimi OAuth host trust boundary", () => {
+	it("uses the built-in host when nothing overrides it", async () => {
+		expect(await hostIn(projectDir())).not.toContain("attacker.example");
+	});
+
+	it("ignores a KIMI_CODE_OAUTH_HOST planted by the project .env", async () => {
+		const cwd = projectDir("KIMI_CODE_OAUTH_HOST=https://attacker.example\n");
+		expect(await hostIn(cwd)).not.toContain("attacker.example");
+	});
+
+	it("ignores the legacy KIMI_OAUTH_HOST planted by the project .env", async () => {
+		const cwd = projectDir("KIMI_OAUTH_HOST=https://attacker.example\n");
+		expect(await hostIn(cwd)).not.toContain("attacker.example");
+	});
+
+	it("still honors an inherited KIMI_CODE_OAUTH_HOST", async () => {
+		expect(await hostIn(projectDir(), { KIMI_CODE_OAUTH_HOST: "https://kimi.internal" })).toBe(
+			"https://kimi.internal",
+		);
+	});
+
+	it("still honors the inherited legacy alias", async () => {
+		expect(await hostIn(projectDir(), { KIMI_OAUTH_HOST: "https://kimi-legacy.internal" })).toBe(
+			"https://kimi-legacy.internal",
+		);
+	});
+
+	it("keeps the primary name ahead of the legacy alias", async () => {
+		const host = await hostIn(projectDir(), {
+			KIMI_CODE_OAUTH_HOST: "https://kimi.internal",
+			KIMI_OAUTH_HOST: "https://kimi-legacy.internal",
+		});
+		expect(host).toBe("https://kimi.internal");
+	});
+
+	it("does not let the project .env override an inherited host", async () => {
+		const cwd = projectDir("KIMI_CODE_OAUTH_HOST=https://attacker.example\n");
+		expect(await hostIn(cwd, { KIMI_CODE_OAUTH_HOST: "https://kimi.internal" })).toBe("https://kimi.internal");
+	});
+});


### PR DESCRIPTION
Successor to #3278, reopened per your triage note:

> Legacy/open batch triage: closing without merge in this lane. **Reopen with an updated review request if this should still land.**

#3278 could not be reopened directly — GitHub returns 422 once the head has been force-pushed — so this is a fresh PR on the same branch, rebased onto current `dev`.

## Why it should still land

`resolveOAuthHost()` read `KIMI_CODE_OAUTH_HOST` / `KIMI_OAUTH_HOST` through `$env`. That host serves the device-authorization request the user is sent to (`:100`), the code exchange (`:169`), and the refresh call that carries the existing refresh token (`:233`).

Your review on #3278 reached **MERGE_READY** after independently reproducing the boundary with your own probe rather than reusing mine, and recorded that the surface closure was total. No technical blocker was raised; the later `CHANGES_REQUESTED` was the batch-triage note quoted above.

## State on this head

Rebased onto current `dev` (zero commits behind), suite re-run green after the rebase. Everything else is byte-identical to the head you reviewed.

If the no-merge lane was a deliberate policy call for external contributions rather than housekeeping, say so and I will stop resubmitting this class rather than keep adding noise.