### PR TITLE
feat(tui): add type-to-filter to the /login provider selector

### DIFF
--- a/packages/coding-agent/src/modes/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/components/oauth-selector.ts
@@ -1,6 +1,6 @@
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import type { OAuthProviderInfo } from "@gajae-code/ai/utils/oauth/types";
-import { Container, matchesKey, Spacer, TruncatedText } from "@gajae-code/tui";
+import { Container, fuzzyFilter, Input, matchesKey, Spacer, TruncatedText } from "@gajae-code/tui";
 import { recordProviderAuthHealth } from "../../config/provider-auth-health";
 import { compareRankedProviders, type ProviderAuthState } from "../../config/provider-ranking";
 import { theme } from "../../modes/theme/theme";
@@ -17,6 +17,8 @@ export class OAuthSelectorComponent extends Container {
 	#listContainer: Container;
 	#allProviders: OAuthProviderInfo[] = [];
 	#sortedProviders: OAuthProviderInfo[] = [];
+	#filteredProviders: OAuthProviderInfo[] = [];
+	#searchInput: Input;
 	#selectedIndex: number = 0;
 	#mode: "login" | "logout";
 	#authStorage: AuthStorage;
@@ -56,6 +58,14 @@ export class OAuthSelectorComponent extends Container {
 		// Add title
 		const title = mode === "login" ? "Select provider to login:" : "Select provider to logout:";
 		this.addChild(new TruncatedText(theme.bold(title)));
+		this.addChild(new Spacer(1));
+		// Filter box: the provider list is long enough that arrow-key-only
+		// navigation buries entries below the visible window.
+		this.#searchInput = new Input();
+		this.#searchInput.onSubmit = () => {
+			this.#selectCurrentProvider();
+		};
+		this.addChild(this.#searchInput);
 		this.addChild(new Spacer(1));
 		// Create list container
 		this.#listContainer = new Container();
@@ -166,7 +176,7 @@ export class OAuthSelectorComponent extends Container {
 		return this.#authStorage.hasAuth(providerId) ? theme.fg("success", ` ${theme.status.success} logged in`) : "";
 	}
 	#updateList(): void {
-		const selectedProviderId = this.#sortedProviders[this.#selectedIndex]?.id;
+		const selectedProviderId = this.#filteredProviders[this.#selectedIndex]?.id;
 		const rankedProviders = this.#allProviders.map(provider => ({
 			provider,
 			id: provider.id,
@@ -175,16 +185,23 @@ export class OAuthSelectorComponent extends Container {
 		}));
 		rankedProviders.sort(compareRankedProviders);
 		this.#sortedProviders = rankedProviders.map(({ provider }) => provider);
+		// Filter after ranking so an empty query preserves the curated order and a
+		// query still surfaces matches in that same order of preference.
+		this.#filteredProviders = fuzzyFilter(
+			this.#sortedProviders,
+			this.#searchInput.getValue(),
+			provider => `${provider.name} ${provider.id}`,
+		);
 		if (selectedProviderId !== undefined) {
-			const selectedIndex = this.#sortedProviders.findIndex(provider => provider.id === selectedProviderId);
+			const selectedIndex = this.#filteredProviders.findIndex(provider => provider.id === selectedProviderId);
 			if (selectedIndex >= 0) this.#selectedIndex = selectedIndex;
 		}
-		if (this.#selectedIndex >= this.#sortedProviders.length) {
-			this.#selectedIndex = Math.max(0, this.#sortedProviders.length - 1);
+		if (this.#selectedIndex >= this.#filteredProviders.length) {
+			this.#selectedIndex = Math.max(0, this.#filteredProviders.length - 1);
 		}
 		this.#listContainer.clear();
 
-		const total = this.#sortedProviders.length;
+		const total = this.#filteredProviders.length;
 		const maxVisible = OAUTH_SELECTOR_MAX_VISIBLE;
 		const startIndex =
 			total <= maxVisible
@@ -193,7 +210,7 @@ export class OAuthSelectorComponent extends Container {
 		const endIndex = Math.min(startIndex + maxVisible, total);
 
 		for (let i = startIndex; i < endIndex; i++) {
-			const provider = this.#sortedProviders[i];
+			const provider = this.#filteredProviders[i];
 			if (!provider) continue;
 			const isSelected = i === this.#selectedIndex;
 			const isAvailable = provider.available;
@@ -219,8 +236,11 @@ export class OAuthSelectorComponent extends Container {
 
 		// Show "no providers" if empty
 		if (total === 0) {
-			const message =
-				this.#mode === "login" ? "No OAuth providers available" : "No OAuth providers logged in. Use /login first.";
+			const message = this.#searchInput.getValue().trim()
+				? "No providers match the filter"
+				: this.#mode === "login"
+					? "No OAuth providers available"
+					: "No OAuth providers logged in. Use /login first.";
 			this.#listContainer.addChild(new TruncatedText(theme.fg("muted", `  ${message}`), 0, 0));
 		}
 		if (this.#statusMessage) {
@@ -243,60 +263,78 @@ export class OAuthSelectorComponent extends Container {
 			}
 		}
 	}
+	#selectCurrentProvider(): void {
+		const selectedProvider = this.#filteredProviders[this.#selectedIndex];
+		if (selectedProvider?.available) {
+			this.#statusMessage = undefined;
+			this.stopValidation();
+			this.#onSelectCallback(selectedProvider.id);
+		} else if (selectedProvider) {
+			this.#statusMessage = "Provider unavailable in this environment.";
+			this.#updateList();
+		}
+	}
 	handleInput(keyData: string): void {
 		// Up arrow
 		if (matchesKey(keyData, "up")) {
-			if (this.#sortedProviders.length > 0) {
+			if (this.#filteredProviders.length > 0) {
 				this.#selectedIndex =
-					this.#selectedIndex === 0 ? this.#sortedProviders.length - 1 : this.#selectedIndex - 1;
+					this.#selectedIndex === 0 ? this.#filteredProviders.length - 1 : this.#selectedIndex - 1;
 			}
 			this.#statusMessage = undefined;
 			this.#updateList();
+			return;
 		}
 		// Down arrow
-		else if (matchesKey(keyData, "down")) {
-			if (this.#sortedProviders.length > 0) {
+		if (matchesKey(keyData, "down")) {
+			if (this.#filteredProviders.length > 0) {
 				this.#selectedIndex =
-					this.#selectedIndex === this.#sortedProviders.length - 1 ? 0 : this.#selectedIndex + 1;
+					this.#selectedIndex === this.#filteredProviders.length - 1 ? 0 : this.#selectedIndex + 1;
 			}
 			this.#statusMessage = undefined;
 			this.#updateList();
+			return;
 		}
 		// Page up - jump up by one visible page
-		else if (matchesKey(keyData, "pageUp")) {
-			if (this.#sortedProviders.length > 0) {
+		if (matchesKey(keyData, "pageUp")) {
+			if (this.#filteredProviders.length > 0) {
 				this.#selectedIndex = Math.max(0, this.#selectedIndex - OAUTH_SELECTOR_MAX_VISIBLE);
 			}
 			this.#statusMessage = undefined;
 			this.#updateList();
+			return;
 		}
 		// Page down - jump down by one visible page
-		else if (matchesKey(keyData, "pageDown")) {
-			if (this.#sortedProviders.length > 0) {
+		if (matchesKey(keyData, "pageDown")) {
+			if (this.#filteredProviders.length > 0) {
 				this.#selectedIndex = Math.min(
-					this.#sortedProviders.length - 1,
+					this.#filteredProviders.length - 1,
 					this.#selectedIndex + OAUTH_SELECTOR_MAX_VISIBLE,
 				);
 			}
 			this.#statusMessage = undefined;
 			this.#updateList();
+			return;
 		}
 		// Enter
-		else if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
-			const selectedProvider = this.#sortedProviders[this.#selectedIndex];
-			if (selectedProvider?.available) {
-				this.#statusMessage = undefined;
-				this.stopValidation();
-				this.#onSelectCallback(selectedProvider.id);
-			} else if (selectedProvider) {
-				this.#statusMessage = "Provider unavailable in this environment.";
-				this.#updateList();
-			}
+		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+			this.#selectCurrentProvider();
+			return;
 		}
 		// Escape or Ctrl+C
-		else if (matchesSelectCancel(keyData)) {
+		if (matchesSelectCancel(keyData)) {
 			this.stopValidation();
 			this.#onCancelCallback();
+			return;
+		}
+		// Everything else edits the filter. A changed query invalidates the current
+		// position, so selection restarts at the best match.
+		const previousQuery = this.#searchInput.getValue();
+		this.#searchInput.handleInput(keyData);
+		if (this.#searchInput.getValue() !== previousQuery) {
+			this.#selectedIndex = 0;
+			this.#statusMessage = undefined;
+			this.#updateList();
 		}
 	}
 }

--- a/packages/coding-agent/test/oauth-selector-filter.test.ts
+++ b/packages/coding-agent/test/oauth-selector-filter.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
+import { OAuthSelectorComponent } from "@gajae-code/coding-agent/modes/components/oauth-selector";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+
+let testTheme = await getThemeByName("red-claw");
+
+function installTestTheme(): void {
+	if (!testTheme) throw new Error("Failed to load red-claw test theme");
+	setThemeInstance(testTheme);
+}
+
+function stripAnsi(value: string): string {
+	return value.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function renderedText(selector: OAuthSelectorComponent): string {
+	installTestTheme();
+	return selector.render(240).map(stripAnsi).join("\n");
+}
+
+function type(selector: OAuthSelectorComponent, text: string): void {
+	for (const char of text) selector.handleInput(char);
+}
+
+async function createSelector(): Promise<{ selector: OAuthSelectorComponent; selected: string[] }> {
+	const authStorage = await AuthStorage.create(":memory:");
+	const selected: string[] = [];
+	const selector = new OAuthSelectorComponent(
+		"login",
+		authStorage,
+		id => selected.push(id),
+		() => {},
+	);
+	return { selector, selected };
+}
+
+beforeEach(async () => {
+	testTheme = await getThemeByName("red-claw");
+	installTestTheme();
+});
+
+describe("OAuth selector filtering", () => {
+	test("a provider ranked past the visible window is reachable by typing", async () => {
+		// BizRouter ranks below the 10-row window, so it is not rendered on open.
+		const { selector } = await createSelector();
+		expect(renderedText(selector)).not.toContain("BizRouter");
+
+		type(selector, "bizrouter");
+
+		expect(renderedText(selector)).toContain("BizRouter");
+	});
+
+	test("enter selects the filtered match rather than the ranked-list entry at that index", async () => {
+		const { selector, selected } = await createSelector();
+		type(selector, "bizrouter");
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["bizrouter"]);
+	});
+
+	test("filtering matches on provider id as well as display name", async () => {
+		const { selector, selected } = await createSelector();
+		// "opengateway" is the id; the label is "OpenGateway by Sionic AI".
+		type(selector, "opengateway");
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["opengateway"]);
+	});
+
+	test("clearing the query restores the full list and keeps the matched provider selected", async () => {
+		const { selector, selected } = await createSelector();
+		const fullCount = getOAuthProviders().length;
+
+		type(selector, "biz");
+		selector.handleInput("\x7f"); // backspace
+		selector.handleInput("\x7f");
+		selector.handleInput("\x7f");
+
+		// Every provider is listed again...
+		expect(renderedText(selector)).toContain(`/${fullCount})`);
+		// ...and the provider found via the filter stays selected, rather than the
+		// cursor snapping back to the top of the restored list.
+		selector.handleInput("\n");
+		expect(selected).toEqual(["bizrouter"]);
+	});
+
+	test("a non-matching query reports no matches instead of an empty list", async () => {
+		const { selector } = await createSelector();
+		type(selector, "zzzznotaprovider");
+
+		const rendered = renderedText(selector);
+		expect(rendered).toContain("No providers match the filter");
+		// The generic "none available" copy would be wrong here: providers exist.
+		expect(rendered).not.toContain("No OAuth providers available");
+	});
+
+	test("enter on a non-matching query selects nothing", async () => {
+		const { selector, selected } = await createSelector();
+		type(selector, "zzzznotaprovider");
+		selector.handleInput("\n");
+
+		expect(selected).toEqual([]);
+	});
+
+	test("arrow keys still navigate and do not leak into the filter", async () => {
+		const { selector, selected } = await createSelector();
+		const providers = getOAuthProviders();
+		expect(providers.length).toBeGreaterThan(1);
+
+		selector.handleInput("\x1b[B"); // down
+		selector.handleInput("\n");
+
+		// Selection moved off the first entry, and the query stayed empty.
+		expect(selected).toHaveLength(1);
+		expect(selected[0]).not.toBe(providers[0]?.id);
+		expect(renderedText(selector)).not.toContain("No providers match the filter");
+	});
+
+	test("changing the query resets selection to the best match", async () => {
+		const { selector, selected } = await createSelector();
+		// Move the cursor down, then type: the new query must re-anchor selection
+		// at index 0 rather than keeping a stale offset into the old list.
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		type(selector, "bizrouter");
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["bizrouter"]);
+	});
+});


### PR DESCRIPTION
## Problem

`/login` renders 10 of 51 providers, and `handleInput` only bound `up`/`down`/`pageUp`/`pageDown`. Any provider ranked past the visible window was reachable only by repeated arrow presses.

Ranking alone cannot fix this. #3281 moved BizRouter into the famous tier, but it still lands at **19** — below the fold. Every provider outside the top 10 has the same problem, and it gets worse as providers are added.

## Change

Add a search `Input` above the list, following the established pattern in `model-selector.ts` (same `fuzzyFilter` helper, same "unhandled keys go to the search input" structure).

- **Filter runs after ranking**, so an empty query preserves the curated order and a query surfaces matches in that same order of preference.
- **Matches name and id**, so `opengateway` finds "OpenGateway by Sionic AI".
- **Navigation keys keep their behavior** and no longer fall through to the filter; every other key edits the query.
- **A changed query re-anchors selection** at the best match; clearing it restores the full list and keeps the matched provider selected.
- **Enter resolves against the filtered list.** Previously `handleInput` indexed `#sortedProviders` — with a query active that would have selected the wrong provider.
- **Empty results say "No providers match the filter"** instead of the misleading "No OAuth providers available".

## Verification

| Command | Result |
| --- | --- |
| `bun test oauth-selector-filter.test.ts` | 8 pass / 0 fail |
| `bun test oauth-selector*, provider-ranking*` (5 files) | 43 pass / 0 fail |
| `bun test oauth-discovery, oauth-flow, oauth-manual-input, login-preset-recommendation` | 27 pass / 0 fail |
| `bun test model-selector-profiles{,-redteam}, hook-selector-{inline-input,overflow}` | 56 pass / 0 fail |
| `bunx tsc -p packages/coding-agent/tsconfig.json --noEmit` | clean |
| `bun run lint:tools` | clean (3135 files) |
| `git diff --check` | clean |

### Tests are non-tautological

Reverting only the source change and re-running the new suite fails **7 of 8** tests — including enter selecting `openai-codex` instead of the typed `bizrouter`. The 8th is the arrow-key regression guard, which correctly passes both before and after.

### Scope note

While validating I hit failures in `session-storage`, `resume-confirm-continue`, `coordinator-mcp`, and several sdk/tmux suites. I confirmed these are **pre-existing** by stashing this change entirely and reproducing them identically on a clean tree — they are environment-sensitive (macOS `/tmp` vs `/private/tmp`, fd-security, 5s timeouts), unrelated to this diff, and untouched here.
