### PR TITLE
fix(coding-agent): treat an empty --agent-dir as absent in the daemons

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- An empty `--agent-dir` no longer makes the notification daemons write into the current working directory. Every daemon path is built as `path.join(agentDir, "notifications")`, which silently yields a relative path when the first segment is empty, so the daemon's lock, ownership, state, heartbeat and topic files landed in whatever repository the user was in. The daemon entry points now treat an empty value as absent, matching the truthy check `parseSdkInternalArgv` already applies to the broker.
 - Align managed fallback abort-after-exhaustion expectations with #3257 ownership release: a subscriber abort at terminal `message_end` no longer expects a second `requestRunTerminal(cancelled)` because the logical-run owner is already cleared.
 - Python eval timeout annotations now prefer the caller-configured `timeoutMs` over remaining wall-clock budget so async setup cannot flake second formatting in CI.
 - Overflow maintenance now stops cleanly when no-op compaction would replay the same oversized request; the runtime status explains that `/clear` preserves the current session ID before retrying.

--- a/packages/coding-agent/src/sdk/bus/chat-daemon-cli.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-daemon-cli.ts
@@ -39,9 +39,26 @@ export interface RunChatDaemonInternalDeps {
 
 export type ChatDaemonConfig = ChatDaemonRuntimeConfig;
 
+/**
+ * Value for `name`, treating an empty value as absent.
+ *
+ * The spawn sites pass `--agent-dir` unconditionally
+ * (`telegram-daemon.ts:2910`, `chat-daemon-control.ts:393`,
+ * `broker/ensure.ts:248`), so an empty agent dir arrives as `--agent-dir ""`.
+ * `??` would accept that, and every daemon path is built with
+ * `path.join(agentDir, "notifications")`, which silently yields a *relative*
+ * path when the first segment is empty — the daemon's lock, ownership, state,
+ * heartbeat and topic files then land in the current working directory, i.e.
+ * inside whatever repository the user happened to be in.
+ *
+ * `parseSdkInternalArgv` (`commands/sdk.ts:516`) already rejects an empty
+ * `--agent-dir` with a truthy check; this is the same guard for the daemon
+ * entry points.
+ */
 function argValue(argv: string[], name: string): string | undefined {
 	const index = argv.indexOf(name);
-	return index >= 0 ? argv[index + 1] : undefined;
+	const value = index >= 0 ? argv[index + 1] : undefined;
+	return value ? value : undefined;
 }
 
 function defaultPidAlive(pid: number): boolean {

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts
@@ -50,9 +50,26 @@ export interface RunDaemonInternalDeps {
 const OWNER_WATCHDOG_INTERVAL_MS = 5_000;
 const OWNER_STALL_MS = 3 * HEARTBEAT_TTL_MS;
 
+/**
+ * Value for `name`, treating an empty value as absent.
+ *
+ * The spawn sites pass `--agent-dir` unconditionally
+ * (`telegram-daemon.ts:2910`, `chat-daemon-control.ts:393`,
+ * `broker/ensure.ts:248`), so an empty agent dir arrives as `--agent-dir ""`.
+ * `??` would accept that, and every daemon path is built with
+ * `path.join(agentDir, "notifications")`, which silently yields a *relative*
+ * path when the first segment is empty — the daemon's lock, ownership, state,
+ * heartbeat and topic files then land in the current working directory, i.e.
+ * inside whatever repository the user happened to be in.
+ *
+ * `parseSdkInternalArgv` (`commands/sdk.ts:516`) already rejects an empty
+ * `--agent-dir` with a truthy check; this is the same guard for the daemon
+ * entry points.
+ */
 function argValue(argv: string[], name: string): string | undefined {
 	const i = argv.indexOf(name);
-	return i >= 0 ? argv[i + 1] : undefined;
+	const value = i >= 0 ? argv[i + 1] : undefined;
+	return value ? value : undefined;
 }
 const DAEMON_COMPATIBILITY_DIAGNOSTIC_LIMIT = 1;
 let daemonCompatibilityDiagnosticCount = 0;
@@ -199,7 +216,9 @@ export function createDaemonControlHooks(settings: Settings) {
 }
 
 export async function runDaemonSmoke(opts: { agentDir?: string } = {}): Promise<void> {
-	const agentDir = opts.agentDir ?? fs.mkdtempSync(path.join(process.cwd(), ".telegram-daemon-smoke-"));
+	// `??` would accept an empty dir and skip the temp dir entirely, writing the
+	// smoke artifacts into the current working directory.
+	const agentDir = opts.agentDir || fs.mkdtempSync(path.join(process.cwd(), ".telegram-daemon-smoke-"));
 	const settings = createLightweightDaemonSettings({ agentDir, rawConfig: {} });
 	const paths = daemonPaths(agentDir);
 	await fs.promises.mkdir(paths.dir, { recursive: true, mode: 0o700 });

--- a/packages/coding-agent/test/daemon-empty-agent-dir.test.ts
+++ b/packages/coding-agent/test/daemon-empty-agent-dir.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { daemonPaths } from "@gajae-code/coding-agent/sdk/bus/daemon-paths";
+import { runDaemonSmoke } from "@gajae-code/coding-agent/sdk/bus/telegram-daemon-cli";
+
+/**
+ * Every daemon path is built as `path.join(agentDir, "notifications")`, which
+ * silently yields a *relative* path when the first segment is empty. The spawn
+ * sites pass `--agent-dir` unconditionally, so `--agent-dir ""` used to make the
+ * daemon write its lock, ownership, state, heartbeat and topic files into the
+ * current working directory — inside whatever repository the user was in.
+ *
+ * `parseSdkInternalArgv` already rejects an empty `--agent-dir`; these lock the
+ * same guard onto the daemon entry points.
+ */
+
+async function withTempCwd(fn: (dir: string) => Promise<void>): Promise<void> {
+	// macOS resolves os.tmpdir() through a symlink, so compare against the real path.
+	const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "gjc-empty-agent-dir-")));
+	const previous = process.cwd();
+	process.chdir(dir);
+	try {
+		await fn(dir);
+	} finally {
+		process.chdir(previous);
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+describe("empty --agent-dir", () => {
+	it("keeps daemon paths relative when the agent dir is empty (the hazard)", () => {
+		// Documents *why* the guard is needed: path.join swallows the empty segment.
+		expect(path.isAbsolute(daemonPaths("").dir)).toBe(false);
+		expect(daemonPaths("").dir).toBe("notifications");
+		// A real agent dir is unaffected.
+		expect(daemonPaths("/home/u/.gjc/agent").dir).toBe("/home/u/.gjc/agent/notifications");
+	});
+
+	it("does not write daemon state into the working directory on an empty agent dir", async () => {
+		await withTempCwd(async dir => {
+			await runDaemonSmoke({ agentDir: "" });
+			expect(fs.existsSync(path.join(dir, "notifications"))).toBe(false);
+			// It falls back to its own temp dir instead of the cwd root.
+			const fallback = fs.readdirSync(dir).filter(n => n.startsWith(".telegram-daemon-smoke-"));
+			expect(fallback).toHaveLength(1);
+		});
+	});
+
+	it("still honors an explicit agent dir", async () => {
+		await withTempCwd(async dir => {
+			const agentDir = path.join(dir, "agent");
+			await runDaemonSmoke({ agentDir });
+			expect(fs.existsSync(path.join(agentDir, "notifications"))).toBe(true);
+			expect(fs.existsSync(path.join(dir, "notifications"))).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
Found from physical evidence on this machine: a stray `/tmp/notifications/` holding `telegram-callback-aliases.json` and `telegram-topics.json`, written while the cwd was `/tmp`.

## Problem

Every daemon path is built with:

```ts
const dir = path.join(agentDir, "notifications");   // daemon-paths.ts:24
```

`path.join` **swallows an empty leading segment**, so an empty agent dir turns every one of those paths into a *relative* one:

```
daemonPaths("").dir                  === "notifications"      // relative to cwd
daemonPaths("/home/u/.gjc/agent").dir === "/home/u/.gjc/agent/notifications"
```

The daemon's lock, ownership, state, heartbeat, seen-updates, alias and topic files then land in the current working directory — inside whatever repository the user happens to be in.

## The empty value is reachable

All three spawn sites pass the flag **unconditionally**:

```
telegram-daemon.ts:2910     "--agent-dir", input.agentDir
chat-daemon-control.ts:393  "--agent-dir", input.agentDir
broker/ensure.ts:248        "--agent-dir", settings.agentDir
```

And both daemon receivers resolved it with `??`, which accepts `""`:

```
telegram-daemon-cli.ts:216  argValue(argv, "--agent-dir") ?? env ?? cwd/.gjc/agent
chat-daemon-cli.ts:164      same
```

`runDaemonSmoke` had the same `??`, where an empty dir additionally skipped the `mkdtemp` entirely.

## The repo already had the right guard

One module away, the broker receiver rejects exactly this:

```ts
// commands/sdk.ts:516
if (argv[0] === "broker-internal" && argv.length === 3 && argv[1] === "--agent-dir" && argv[2])
```

That truthy check is the precedent. This PR applies the same rule to the two daemon entry points, so **only the empty case changes** — every non-empty value resolves exactly as before.

## Tests

`daemon-empty-agent-dir.test.ts` (3 cases): the hazard itself (`daemonPaths("")` is relative while a real dir is absolute), the cwd staying clean on an empty agent dir with the fallback temp dir used instead, and an explicit agent dir still being honored.

**Proof-first: reverting the smoke guard fails the cwd case.**

## Verification

`bun run check` in `packages/coding-agent` (whole-package biome + tsc): exit 0. New suite 3 pass / 0 fail. Daemon-named suites across the package: 910 pass / 0 fail.