### PR TITLE
test(coding-agent): fix dev CI shard-5 managed-session migration timing flake

### DIFF
--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -320,35 +320,49 @@ describe("managed session write protocol", () => {
 		expect(await fs.readFile(destination, "utf8")).toBe("managed\n");
 		expect((await fs.readdir(scope.directoryPath)).filter(name => name.endsWith(".staging"))).toEqual([]);
 	});
-	it("migrates legacy artifact directories at and around the former file-count cap", async () => {
+	// This boundary check used to run all three counts (9,999 / 10,000 / 10,001) inside a single
+	// it(..., 120_000) with a shared timeout. Each iteration does a full legacy-artifact migration
+	// (identity capture, per-file read + SHA-256 verify, publish, and a second re-verification pass)
+	// over ~10,000 files, which is legitimate CPU/IO-bound work. Measured on dev HEAD b853f15d7:
+	// combined 3-iteration run took 96.40s unloaded against the shared 120s budget (~24s headroom).
+	// Under induced CPU contention (taskset -c 0,1 + 4x `yes`) the combined run crossed 120s at
+	// 123.83s with {kind:"error", code:"migration_busy"} instead of {kind:"opened", migrated:true}.
+	// Splitting into one it() per boundary removes the 3x-shared-budget problem, but a *single*
+	// boundary iteration was independently observed to spike past 120s under ordinary ambient
+	// machine contention (31.92s typical, one observed run at 120.85s timing out with
+	// {kind:"error", code:"source_changed"}) — the exact failure shape reported by dev CI shard-5
+	// job 89986200896. Both observations are the same root cause: this workload's fail-closed
+	// identity/timing checks are correct, but the fixed clock budget has too little margin for its
+	// own CPU/IO-bound cost under real contention. 300s gives ~10x headroom over the typical ~30s
+	// per-boundary cost while still catching a genuinely hung migration. Do not recombine these into
+	// a single it() with a shared timeout, and do not shrink this margin without re-measuring.
+	it.each([9_999, 10_000, 10_001])("migrates legacy artifact directories at count %i", async count => {
 		expect(MANAGED_ARTIFACT_MAX_FILES).toBeGreaterThan(10_001);
-		for (const count of [9_999, 10_000, 10_001]) {
-			const { cwd, sessionsRoot, scope } = await fixture();
-			const legacy = legacyDirectory(sessionsRoot, cwd);
-			const source = path.join(legacy, `artifact-cap-${count}.jsonl`);
-			const artifacts = source.slice(0, -6);
-			await fs.mkdir(artifacts, { recursive: true });
-			await fs.writeFile(source, transcript(`artifact-cap-${count}`, cwd));
-			for (let index = 0; index < count; index++) syncFs.writeFileSync(path.join(artifacts, `${index}.bin`), "");
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const legacy = legacyDirectory(sessionsRoot, cwd);
+		const source = path.join(legacy, `artifact-cap-${count}.jsonl`);
+		const artifacts = source.slice(0, -6);
+		await fs.mkdir(artifacts, { recursive: true });
+		await fs.writeFile(source, transcript(`artifact-cap-${count}`, cwd));
+		for (let index = 0; index < count; index++) syncFs.writeFileSync(path.join(artifacts, `${index}.bin`), "");
 
-			const listed = listManagedCandidates(scope);
-			if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
-			const opened = await openManagedCandidateForWrite(scope, listed.owned[0]);
-			expect(opened).toMatchObject({ kind: "opened", migrated: true });
-			if (opened.kind !== "opened") continue;
-			expect((await fs.readdir(opened.path.slice(0, -6))).filter(name => name.endsWith(".bin"))).toHaveLength(count);
-			expect((await fs.readdir(artifacts)).filter(name => name.endsWith(".bin"))).toHaveLength(count);
-			const receipts = path.join(scope.directoryPath, ".gjc-managed-session-internal", "receipts");
-			const committed = (await fs.readdir(receipts)).find(
-				name => JSON.parse(syncFs.readFileSync(path.join(receipts, name), "utf8")).state === "committed",
-			);
-			if (!committed) throw new Error("Missing committed migration receipt");
-			const receipt = JSON.parse(await fs.readFile(path.join(receipts, committed), "utf8")) as {
-				artifactManifest?: unknown[];
-			};
-			expect(receipt.artifactManifest).toHaveLength(count + 1);
-		}
-	}, 120_000);
+		const listed = listManagedCandidates(scope);
+		if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
+		const opened = await openManagedCandidateForWrite(scope, listed.owned[0]);
+		expect(opened).toMatchObject({ kind: "opened", migrated: true });
+		if (opened.kind !== "opened") return;
+		expect((await fs.readdir(opened.path.slice(0, -6))).filter(name => name.endsWith(".bin"))).toHaveLength(count);
+		expect((await fs.readdir(artifacts)).filter(name => name.endsWith(".bin"))).toHaveLength(count);
+		const receipts = path.join(scope.directoryPath, ".gjc-managed-session-internal", "receipts");
+		const committed = (await fs.readdir(receipts)).find(
+			name => JSON.parse(syncFs.readFileSync(path.join(receipts, name), "utf8")).state === "committed",
+		);
+		if (!committed) throw new Error("Missing committed migration receipt");
+		const receipt = JSON.parse(await fs.readFile(path.join(receipts, committed), "utf8")) as {
+			artifactManifest?: unknown[];
+		};
+		expect(receipt.artifactManifest).toHaveLength(count + 1);
+	}, 300_000);
 	it("returns a typed strict-open capacity failure and surfaces it from continueRecent", async () => {
 		const { cwd, sessionsRoot, scope } = await fixture();
 		const legacy = legacyDirectory(sessionsRoot, cwd);


### PR DESCRIPTION
## Failing job

Dev CI shard-5: https://github.com/Yeachan-Heo/gajae-code/actions/runs/30268414631, job [89986200896](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30268414631/job/89986200896)

Test: `managed session write protocol > migrates legacy artifact directories at and around the former file-count cap` in `packages/coding-agent/test/session-manager/session-directory.test.ts`. Reported symptom: the test timed out at 120s, and one iteration returned `{kind:"error", code:"source_changed"}` instead of `{kind:"opened", migrated:true}`.

## Root cause

The failing test wrapped **three** sequential full legacy-artifact migrations (9,999 / 10,000 / 10,001 files, ~90,000 files total) inside a single `it(..., 120_000)`. Each migration is legitimate CPU/IO-bound work: identity capture (dev/ino/size/mtimeNs), per-file read + SHA-256 verification, publish, and a second re-verification pass before commit.

Measured on this repo's `dev` HEAD (`b853f15d7167a49173bc03ef7efe99c5bae8f234`), with the native addon rebuilt from source:

- **Unloaded baseline**: the combined 3-iteration test took **96.40s** against the shared **120s** budget — only ~24s of headroom.
- **Under induced CPU contention** (`taskset -c 0,1` + 4x `yes` pinned to the same 2 cores): the combined test crossed 120s at **123.83s** and returned `{kind:"error", code:"migration_busy"}` instead of `opened` — the same failure *shape* as CI (a fail-closed error instead of success), just a different one of several codes this path can legitimately return once the clock/lock budget runs out mid-flight.
- **A single boundary iteration alone**, on an intermediate 120s-per-test version of the fix, was independently observed to spike past 120s under *ordinary ambient host contention* (31.92s typical, one run at **120.85s**, timing out with `{kind:"error", code:"source_changed"}`) — reproducing CI's exact failure code.

The identity/`source_changed` checks (`managed-session-scope.ts:3116-3125`, `3237-3246`, `3280-3286`) behaved correctly in every run: they never fired on an unchanged file, only once the operation ran long enough to lose its race against the fixed timeout/lock budget. This is a **test-timing-budget defect**, not a production correctness defect.

## Why #3313 is not causal

`#3313` ("garbage-collect stale session local roots") only touches `gc-render.ts`, `gc-runtime.ts`, `internal-urls/local-root-gc.ts`, and their own tests — it operates on `/tmp/gjc-local/<session-id>` marker directories, unrelated to the legacy-artifact migration path under test.

```
$ git log --oneline 1122e2ced..b853f15d7 -- crates/ packages/natives/
(empty)
```

No native crate or `packages/natives` changes exist between the pre-#3313 commit and current HEAD, so there is no code-graph link between #3313 and the session-manager/migration path, and no ABI drift risk in re-verifying against this HEAD.

## Fix

Split the single `it()` into three independent `it.each()` instances — one per boundary value — each keeping its own timeout (raised from 120s to **300s**, ~10x the typical ~30s per-boundary cost, justified by the mechanism evidence above) and identical assertions. Added a comment documenting the measured baselines so this isn't silently recombined or shrunk later.

- **No production code changed** (`managed-session-scope.ts`, `session-manager.ts` untouched).
- **No boundary-value or `MANAGED_ARTIFACT_MAX_FILES` changes** — 9,999 / 10,000 / 10,001 coverage is preserved exactly.
- **No `source_changed` / identity-verification check weakened.**
- **#3313 untouched**, not reverted.

```
 packages/coding-agent/test/session-manager/session-directory.test.ts | 68 +++++++++++++++++--------
 1 file changed, 41 insertions(+), 27 deletions(-)
```

## Verification

- 3x unloaded runs of the split tests: all pass (94.46s / 89.51s / 203.95s combined across the 3 boundaries, depending on ambient host load).
- 1x run under induced CPU contention (`taskset -c 0,1` + 4x `yes`): all pass, 132.28s combined, comfortably inside the 300s-per-test budget.
- Full `session-directory.test.ts`: 54 pass / 3 skip / 0 fail (305 `expect()` calls).
- Full `test/session-manager/` suite: 245 pass / 5 skip / 0 fail (966 `expect()` calls across 19 files).
- `bunx biome check` on the modified file: clean.

**This PR is intentionally left unmerged** pending review.

---
Signed-off-by: Yeachan-Heo <yeachan-heo@gajae.dev>
