### PR TITLE
test(coding-agent): stabilize artifact cap migration

### DIFF
--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -329,7 +329,13 @@ describe("managed session write protocol", () => {
 			const artifacts = source.slice(0, -6);
 			await fs.mkdir(artifacts, { recursive: true });
 			await fs.writeFile(source, transcript(`artifact-cap-${count}`, cwd));
-			for (let index = 0; index < count; index++) syncFs.writeFileSync(path.join(artifacts, `${index}.bin`), "");
+			for (let start = 0; start < count; start += 256) {
+				await Promise.all(
+					Array.from({ length: Math.min(256, count - start) }, (_, offset) =>
+						fs.writeFile(path.join(artifacts, `${start + offset}.bin`), ""),
+					),
+				);
+			}
 
 			const listed = listManagedCandidates(scope);
 			if (listed.kind !== "complete" || !listed.owned[0]) throw new Error("Missing legacy candidate");
@@ -348,7 +354,7 @@ describe("managed session write protocol", () => {
 			};
 			expect(receipt.artifactManifest).toHaveLength(count + 1);
 		}
-	}, 120_000);
+	}, 180_000);
 	it("returns a typed strict-open capacity failure and surfaces it from continueRecent", async () => {
 		const { cwd, sessionsRoot, scope } = await fixture();
 		const legacy = legacyDirectory(sessionsRoot, cwd);


### PR DESCRIPTION
## Summary
- create the 9,999/10,000/10,001 legacy artifact fixtures in bounded async batches instead of serial synchronous writes
- raise the test timeout from 120s to 180s to retain margin for loaded CI runners

## Evidence
Current dev run 30268414631 failed because this exact test timed out at 120.68s.

On clean current-dev worktree `b853f15d` (Bun 1.3.14, macOS arm64):
- before: 114.57s cold, then 89.06s / 88.53s
- after: 85.30s / 88.82s / 87.96s
- `bun --cwd=packages/coding-agent run check` passed
- `git diff --check` passed

The test still exercises all three former-cap boundaries and verifies both source/destination artifact counts and committed receipt manifest cardinality.