### PR TITLE
fix(coding-agent): resolve skill-hook config paths from trusted dirs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Memory consolidation redacts GitHub tokens. The scrubber covered AWS ids, JWTs and keyword-prefixed keys, but GitHub tokens carry none of those keywords, so they reached `MEMORY.md` and `memory_summary.md` verbatim — and the summary is injected into every later session. Now covers the same three prefixes the contribution-prep scrubber already handled.
+- The native skill hook resolves its config paths through the trusted directory helpers. It read `GJC_CODING_AGENT_DIR` / `GJC_CONFIG_DIR` straight from `process.env`, which Bun populates from `cwd/.env` before any module runs, so a repository could point the hook at a directory it ships and inject its own `skills.customDirectories` — bypassing the escalation guards that already exist for exactly this.
 - Align managed fallback abort-after-exhaustion expectations with #3257 ownership release: a subscriber abort at terminal `message_end` no longer expects a second `requestRunTerminal(cancelled)` because the logical-run owner is already cleared.
 - Python eval timeout annotations now prefer the caller-configured `timeoutMs` over remaining wall-clock budget so async setup cannot flake second formatting in CI.
 - Overflow maintenance now stops cleanly when no-op compaction would replay the same oversized request; the runtime status explains that `/clear` preserves the current session ID before retrying.

--- a/packages/coding-agent/src/hooks/native-skill-hook.ts
+++ b/packages/coding-agent/src/hooks/native-skill-hook.ts
@@ -1,6 +1,6 @@
 import { appendFile, mkdir, stat } from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
+import { getAgentDir, getConfigDirName } from "@gajae-code/utils";
 import { YAML } from "bun";
 import type { SkillDiscoverySettings } from "../config/skill-settings-defaults";
 import { DEFAULT_DISABLED_EXTENSIONS, DEFAULT_SKILL_DISCOVERY_SETTINGS } from "../config/skill-settings-defaults";
@@ -153,11 +153,24 @@ async function readRawConfig(filePath: string): Promise<Record<string, unknown> 
 	}
 }
 
+/**
+ * Config files that decide skill discovery, resolved through the trusted helpers.
+ *
+ * These paths pick the `config.yml` whose `skills.customDirectories` the agent
+ * then loads skills from, so the directory they are built from is a trust
+ * boundary. Bun loads `cwd/.env` into `process.env` before any module runs, so
+ * reading `GJC_CODING_AGENT_DIR` / `GJC_CONFIG_DIR` directly let a repository
+ * point this at a directory it ships and inject its own skill directories.
+ *
+ * `getAgentDir()` and `getConfigDirName()` apply the escalation guards that
+ * already exist for exactly this (`trustedAgentDirOverride`,
+ * `trustedConfigDirName`), and resolve to the same locations this used to build
+ * by hand: `dirs.agentDir` is `path.join(os.homedir(), getConfigDirName(), "agent")`
+ * when no trusted override is present.
+ */
 function resolveConfigPaths(cwd: string, override?: string[]): string[] {
 	if (override) return override;
-	const configDirName = process.env.GJC_CONFIG_DIR ?? process.env.PI_CONFIG_DIR ?? ".gjc";
-	const userAgentDir = process.env.GJC_CODING_AGENT_DIR ?? path.join(os.homedir(), configDirName, "agent");
-	return [path.join(userAgentDir, "config.yml"), path.join(cwd, configDirName, "config.yml")];
+	return [path.join(getAgentDir(), "config.yml"), path.join(cwd, getConfigDirName(), "config.yml")];
 }
 
 async function resolveEffectiveSkillConfig(

--- a/packages/coding-agent/test/fixtures/skill-hook-config-probe.ts
+++ b/packages/coding-agent/test/fixtures/skill-hook-config-probe.ts
@@ -1,0 +1,11 @@
+/**
+ * Prints the skill `customDirectories` the native skill hook resolves for the
+ * current working directory. Bun loads `cwd/.env` into `process.env` before any
+ * module runs, so this must be a child process started with the scenario's cwd.
+ */
+import { resolveGjcNativeSkillConfigForTesting } from "../../src/hooks/native-skill-hook";
+
+const config = (await resolveGjcNativeSkillConfigForTesting({ cwd: process.cwd() })) as {
+	skillsSettings?: { customDirectories?: string[] };
+};
+console.log(JSON.stringify(config.skillsSettings?.customDirectories ?? []));

--- a/packages/coding-agent/test/skill-hook-agent-dir-trust.test.ts
+++ b/packages/coding-agent/test/skill-hook-agent-dir-trust.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * `resolveConfigPaths` picks the `config.yml` whose `skills.customDirectories`
+ * the agent then loads skills from, so the directory it is built from is a trust
+ * boundary. It used to read `GJC_CODING_AGENT_DIR` / `GJC_CONFIG_DIR` straight
+ * from `process.env`, which Bun populates from `cwd/.env` before any module
+ * runs — so a repository could point the hook at a directory it ships and inject
+ * its own skill directories, bypassing `trustedAgentDirOverride`.
+ *
+ * The value is only visible to a process started with that cwd, so these drive a
+ * child process.
+ */
+
+const PROBE = path.join(import.meta.dir, "fixtures", "skill-hook-config-probe.ts");
+const scenarios: string[] = [];
+
+afterEach(() => {
+	for (const dir of scenarios.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function scenario(dotenv: string | undefined, configs: Record<string, string>): { dir: string; home: string } {
+	const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "gjc-skill-hook-trust-")));
+	scenarios.push(dir);
+	const repo = path.join(dir, "repo");
+	const home = path.join(dir, "home");
+	fs.mkdirSync(repo, { recursive: true });
+	fs.mkdirSync(path.join(home, ".gjc", "agent"), { recursive: true });
+	if (dotenv !== undefined) fs.writeFileSync(path.join(repo, ".env"), dotenv);
+	for (const [relative, body] of Object.entries(configs)) {
+		const target = path.join(dir, relative);
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		fs.writeFileSync(target, body);
+	}
+	return { dir, home };
+}
+
+async function customDirectoriesIn(dir: string, home: string): Promise<string[]> {
+	const proc = Bun.spawn([process.execPath, PROBE], {
+		cwd: path.join(dir, "repo"),
+		env: { ...process.env, HOME: home, GJC_CODING_AGENT_DIR: undefined, GJC_CONFIG_DIR: undefined },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [out, err] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	if ((await proc.exited) !== 0) throw new Error(`probe failed: ${err}`);
+	return JSON.parse(out.trim()) as string[];
+}
+
+function skillConfig(directory: string): string {
+	return `skills:\n  customDirectories:\n    - ${directory}\n`;
+}
+
+describe("skill hook agent-dir trust boundary", () => {
+	it("ignores an agent dir the project .env points at", async () => {
+		const { dir, home } = scenario(`GJC_CODING_AGENT_DIR=${path.join("/tmp", "planted")}\n`, {});
+		const planted = path.join(dir, "planted");
+		fs.mkdirSync(planted, { recursive: true });
+		fs.writeFileSync(path.join(planted, "config.yml"), skillConfig("/tmp/attacker-skills"));
+
+		// Point the .env at the planted dir inside this scenario.
+		fs.writeFileSync(path.join(dir, "repo", ".env"), `GJC_CODING_AGENT_DIR=${planted}\n`);
+
+		expect(await customDirectoriesIn(dir, home)).not.toContain("/tmp/attacker-skills");
+	});
+
+	it("still honors config in the trusted agent dir", async () => {
+		const { dir, home } = scenario(undefined, {});
+		fs.writeFileSync(path.join(home, ".gjc", "agent", "config.yml"), skillConfig("/tmp/legit-skills"));
+
+		expect(await customDirectoriesIn(dir, home)).toContain("/tmp/legit-skills");
+	});
+
+	it("ignores a config dir name the project .env points at", async () => {
+		const { dir, home } = scenario("GJC_CONFIG_DIR=.evil\n", {});
+		fs.mkdirSync(path.join(home, ".evil", "agent"), { recursive: true });
+		fs.writeFileSync(path.join(home, ".evil", "agent", "config.yml"), skillConfig("/tmp/evil-skills"));
+
+		expect(await customDirectoriesIn(dir, home)).not.toContain("/tmp/evil-skills");
+	});
+});


### PR DESCRIPTION
A call site that never went through the escalation guards added by #3285 / #3295.

## Problem

`resolveConfigPaths` (`native-skill-hook.ts:156`) built its config locations from raw `process.env`:

```ts
const configDirName = process.env.GJC_CONFIG_DIR ?? process.env.PI_CONFIG_DIR ?? ".gjc";
const userAgentDir = process.env.GJC_CODING_AGENT_DIR ?? path.join(os.homedir(), configDirName, "agent");
return [path.join(userAgentDir, "config.yml"), path.join(cwd, configDirName, "config.yml")];
```

Bun loads `cwd/.env` into `process.env` before any module runs, so **both values are repository-controlled**.

What makes it matter: the `config.yml` these paths select carries `skills.customDirectories` — **the directories the agent then loads skills from**. So a repository could point the hook at a directory it ships and inject its own skill directories.

## Measured

Scenario repo whose `.env` sets `GJC_CODING_AGENT_DIR` to a planted directory containing a `config.yml`:

```json
{
 "raw_env":           "<tmp>/evil",
 "trusted_agent_dir": "<tmp>/home/.gjc/agent",
 "hook_customDirectories": ["<tmp>/attacker-skills"]
}
```

The trusted resolver **correctly rejected** the planted directory. The hook loaded it anyway and returned the injected entry.

After the change, same scenario:

```
customDirectories: []                            ← injection gone
customDirectories: ["<tmp>/legit-skills"]        ← config in the trusted agent dir still honored
```

## Fix

Use `getAgentDir()` and `getConfigDirName()`, which apply `trustedAgentDirOverride` and `trustedConfigDirName`.

These resolve to the **same locations** the hook built by hand — `dirs.agentDir` is `path.join(os.homedir(), getConfigDirName(), "agent")` absent a trusted override — so only the untrusted case changes.

## Tests

`skill-hook-agent-dir-trust.test.ts` (3 cases) drives a child process, since the planted value is only visible to a process started with that cwd: an agent dir the project `.env` points at is ignored, a config dir *name* the project `.env` points at is ignored, and config in the trusted agent dir is still honored.

**Proof-first: restoring the raw reads fails the two bypass cases while the trusted-config case keeps passing.**

## Verification

`bun run check` in `packages/coding-agent`: exit 0. New suite 3 pass / 0 fail. Skill-named suites 684 pass / 0 fail; hook-named suites 470 pass / 0 fail.