### PR TITLE
fix(coding-agent): redact GitHub tokens in memory consolidation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Memory consolidation redacts GitHub tokens. The scrubber covered AWS ids, JWTs and keyword-prefixed keys, but GitHub tokens carry none of those keywords, so they reached `MEMORY.md` and `memory_summary.md` verbatim — and the summary is injected into every later session. Now covers the same three prefixes the contribution-prep scrubber already handled.
 - Align managed fallback abort-after-exhaustion expectations with #3257 ownership release: a subscriber abort at terminal `message_end` no longer expects a second `requestRunTerminal(cancelled)` because the logical-run owner is already cleared.
 - Python eval timeout annotations now prefer the caller-configured `timeoutMs` over remaining wall-clock budget so async setup cannot flake second formatting in CI.
 - Overflow maintenance now stops cleanly when no-op compaction would replay the same oversized request; the runtime status explains that `/clear` preserves the current session ID before retrying.

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -976,11 +976,21 @@ function redactSecrets(input: string): string {
 		/(?:sk|pk|rk|tok|key|secret|token|password)[-_A-Za-z0-9]{12,}/g,
 		/[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}/g,
 		/(?:AKIA|ASIA)[A-Z0-9]{16}/g,
+		// GitHub tokens carry no keyword the first pattern recognizes, so without
+		// this they reached MEMORY.md and memory_summary.md verbatim — and the
+		// summary is injected into every later session. Same shapes the
+		// contribution-prep scrubber already covers.
+		/\b(?:gh[opsur]_[A-Za-z0-9_]{12,}|github_pat_[A-Za-z0-9_]{12,})\b/g,
 	];
 	for (const pattern of patterns) {
 		out = out.replace(pattern, "[REDACTED]");
 	}
 	return out;
+}
+
+/** Secret scrubbing applied to every phase-2 consolidation output. Test seam. */
+export function redactMemorySecretsForTesting(input: string): string {
+	return redactSecrets(input);
 }
 
 function sanitizeSkillName(name: string): string {

--- a/packages/coding-agent/test/memories-redact-secrets.test.ts
+++ b/packages/coding-agent/test/memories-redact-secrets.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { redactMemorySecretsForTesting as redact } from "@gajae-code/coding-agent/memories";
+
+/**
+ * `docs/memory.md`: "All output is scanned for secrets before being written to
+ * disk." Phase-2 consolidation writes `MEMORY.md` and `memory_summary.md`, and
+ * the summary is injected into every later session — so anything that survives
+ * this scrub is both persisted and re-fed to the model indefinitely.
+ *
+ * The scrubber covered AWS, JWTs and keyword-prefixed keys, but no GitHub token
+ * shape: they carry none of the keywords the first pattern looks for. The
+ * sibling scrubber in `session/contribution-prep.ts` already covers all three
+ * GitHub prefixes, so this closes a gap the repo had already recognized
+ * elsewhere.
+ */
+
+describe("memory consolidation secret redaction", () => {
+	it("redacts GitHub token formats", () => {
+		const cases = [
+			"ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4",
+			"gho_A1b2C3d4E5f6G7h8I9j0K1l2M3n4",
+			"ghs_A1b2C3d4E5f6G7h8I9j0K1l2M3n4",
+			"github_pat_11ABCDEFG0hijklmnopq_RSTUVWXYZ0123456789",
+		];
+		for (const token of cases) {
+			const out = redact(`the deploy step used ${token} for auth`);
+			expect(out).not.toContain(token);
+			expect(out).toContain("[REDACTED]");
+			// Surrounding context survives so the memory stays useful.
+			expect(out).toContain("the deploy step used");
+		}
+	});
+
+	it("keeps redacting the shapes it already covered", () => {
+		const preserved = {
+			aws: "AKIA1234567890ABCDEF",
+			awsTemporary: "ASIA1234567890ABCDEF",
+			openai: "sk-A1b2C3d4E5f6G7h8I9j0",
+			jwt: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5NXgL0n3I9Pl",
+		};
+		for (const value of Object.values(preserved)) {
+			expect(redact(`value ${value}`)).not.toContain(value);
+		}
+	});
+
+	it("leaves ordinary prose alone", () => {
+		const prose = "Ran the github workflow twice; the second attempt passed.";
+		expect(redact(prose)).toBe(prose);
+	});
+});


### PR DESCRIPTION
`docs/memory.md` states that all phase-2 output is *"scanned for secrets before being written to disk"*. For GitHub tokens it was not.

## Problem

`redactSecrets` (`memories/index.ts:973`) covered three shapes:

```ts
/(?:sk|pk|rk|tok|key|secret|token|password)[-_A-Za-z0-9]{12,}/   // keyword-prefixed
/<base64>\.<base64>\.<base64>/                                   // JWT
/(?:AKIA|ASIA)[A-Z0-9]{16}/                                      // AWS
```

GitHub tokens match **none** of them — `ghp_` / `gho_` / `ghs_` / `github_pat_` carry no keyword the first pattern looks for.

Measured against the shipped rule set:

```
AKIA…         redacted
ASIA…         redacted
sk-…          redacted
JWT           redacted
ghp_…         survived   ←
gho_…         survived   ←
github_pat_…  survived   ←
```

## Why it matters here specifically

That output is `MEMORY.md` and `memory_summary.md`, and per the same doc the summary is **injected into every later session**. A token that slips through is not just persisted — it is re-fed to the model indefinitely.

## The repo already recognized this

```ts
// session/contribution-prep.ts:90
/\b(?:ghp_[A-Za-z0-9_]{12,}|gho_[A-Za-z0-9_]{12,}|github_pat_[A-Za-z0-9_]{12,})\b/
```

The sibling scrubber covers all three prefixes. This applies the same shapes to the memory path.

## Tests

`memories-redact-secrets.test.ts` exercises the scrubber through an exported test seam: the four GitHub prefixes are redacted **with their surrounding context intact** (the memory has to stay useful), the previously covered shapes still are, and ordinary prose mentioning "github" is untouched.

**Proof-first: removing only the new pattern fails the GitHub case while the other two keep passing.**

## Verification

`bun run check` in `packages/coding-agent`: exit 0. New suite 3 pass / 0 fail. Memory-named suites 460 pass / 0 fail.