### PR TITLE
fix(ai): name the failed host when a request never reaches the provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Anthropic subscription OAuth requests now use the current Claude Code compatibility attribution (`2.1.219`, `sdk-cli`) instead of the stale `2.1.63` CLI fingerprint that Anthropic can misclassify as extra usage.
+- Connection failures now name the transport code and the target URL. Bun reports DNS and socket failures as a bare `Error` whose message is a standalone hint ("Was there a typo in the url or port?", "Unable to connect. Is the computer able to access the url?") and keeps the actionable facts on `code` and `path`, but only `message` reached the assistant message. A provider outage, a local DNS failure, and a mistyped custom base URL therefore all rendered as the same context-free sentence with no host in it. Such failures now read `... (transport=FailedToOpenSocket url=https://chatgpt.com/backend-api/codex/responses)`; the URL is reduced to origin and path so a key carried in the query string is not surfaced.
 
 ### Documentation
 

--- a/packages/ai/src/utils/http-inspector.ts
+++ b/packages/ai/src/utils/http-inspector.ts
@@ -27,6 +27,34 @@ type ErrorWithStatus = {
 const SENSITIVE_HEADERS = ["authorization", "x-api-key", "api-key", "cookie", "set-cookie", "proxy-authorization"];
 
 /**
+ * Connection-level failure codes, meaning the request never reached the
+ * provider and no HTTP status exists. Bun reports the first group for `fetch`;
+ * the `E*`/`UND_ERR_*` group comes from Node-style DNS and socket errors.
+ *
+ * Deliberately excludes aborts and TLS/certificate codes: an abort is a
+ * user/watchdog outcome with its own display path, and its message must keep
+ * matching the abort normalizers in `modes/utils/abort-message`.
+ */
+const TRANSPORT_FAILURE_CODES: ReadonlySet<string> = new Set([
+	"ConnectionClosed",
+	"ConnectionRefused",
+	"ConnectionReset",
+	"ConnectionTimeout",
+	"FailedToOpenSocket",
+	"HTTP2Unsupported",
+	"EAI_AGAIN",
+	"ECONNREFUSED",
+	"ECONNRESET",
+	"EHOSTUNREACH",
+	"ENETUNREACH",
+	"ENOTFOUND",
+	"EPIPE",
+	"ETIMEDOUT",
+	"UND_ERR_CONNECT_TIMEOUT",
+	"UND_ERR_SOCKET",
+]);
+
+/**
  * Privacy note appended next to a saved raw HTTP request dump. The dump is
  * sanitized (secrets/thinking redacted) but can still contain prompt content
  * and request metadata, so we explicitly discourage pasting it into public
@@ -88,6 +116,54 @@ export async function appendRawHttpRequestDumpFor400(
 	}
 }
 
+/** Origin and path of `value`, dropping query, fragment, and credentials so a
+ *  key carried in the request URL (Google `?key=`, signed URLs) never lands in
+ *  a user-visible error string. */
+function redactRequestUrl(value: unknown): string | undefined {
+	if (typeof value !== "string" || value.trim().length === 0) return undefined;
+	try {
+		const url = new URL(value);
+		return `${url.origin}${url.pathname}`;
+	} catch {
+		return undefined;
+	}
+}
+
+function findTransportFailure(error: unknown, depth: number): { code: string; url?: string } | undefined {
+	if (!error || typeof error !== "object" || depth > 2) return undefined;
+	const info = error as { code?: unknown; path?: unknown; url?: unknown; cause?: unknown };
+	if (typeof info.code === "string" && TRANSPORT_FAILURE_CODES.has(info.code)) {
+		return { code: info.code, url: redactRequestUrl(info.path) ?? redactRequestUrl(info.url) };
+	}
+	return findTransportFailure(info.cause, depth + 1);
+}
+
+/**
+ * Name the failed connection when the request never produced an HTTP status.
+ *
+ * Bun raises DNS and socket failures as a bare `Error` whose message is a
+ * standalone hint ("Was there a typo in the url or port?", "Unable to connect.
+ * Is the computer able to access the url?") while the actionable facts live on
+ * `code` and `path`. Those properties are dropped when only `message` reaches
+ * the assistant message, so a provider outage, a local DNS failure, and a
+ * mistyped custom base URL all render as the same context-free sentence.
+ * Appending the code and the target URL tells the user which host failed and
+ * whether the fault is theirs.
+ */
+export function appendTransportFailureContext(
+	message: string,
+	error: unknown,
+	rawRequestDump: RawHttpRequestDump | undefined,
+): string {
+	if (extractHttpStatusFromError(error) !== undefined) return message;
+	const failure = findTransportFailure(error, 0);
+	if (!failure) return message;
+
+	const url = failure.url ?? redactRequestUrl(rawRequestDump?.url);
+	const context = url ? `transport=${failure.code} url=${url}` : `transport=${failure.code}`;
+	return message.includes(context) ? message : `${message} (${context})`;
+}
+
 export async function finalizeErrorMessage(
 	error: unknown,
 	rawRequestDump: RawHttpRequestDump | undefined,
@@ -105,6 +181,7 @@ export async function finalizeErrorMessage(
 	if (isModelUnavailableError(message, error)) {
 		message = `${message}\n\n${formatModelUnavailableGuidance(rawRequestDump)}`;
 	}
+	message = appendTransportFailureContext(message, error, rawRequestDump);
 	return appendRawHttpRequestDumpFor400(message, error, rawRequestDump);
 }
 

--- a/packages/ai/test/http-inspector.test.ts
+++ b/packages/ai/test/http-inspector.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getConfigRootDir, setAgentDir } from "@gajae-code/utils";
 import {
+	appendTransportFailureContext,
 	finalizeErrorMessage,
 	formatModelUnavailableGuidance,
 	isModelUnavailableError,
@@ -163,5 +164,100 @@ describe("HTTP 400 error message safety (issue #438)", () => {
 		expect(guidance).toContain("not available");
 		expect(guidance).toContain("gjc --list-models");
 		expect(guidance).not.toContain("''");
+	});
+});
+
+describe("transport failure context", () => {
+	function bunTransportError(message: string, code: string, path?: string): Error {
+		return Object.assign(new Error(message), path === undefined ? { code } : { code, path });
+	}
+
+	function codexDump(): RawHttpRequestDump {
+		return {
+			provider: "openai-codex",
+			api: "openai-responses",
+			model: "gpt-5.6-sol",
+			method: "POST",
+			url: "https://chatgpt.com/backend-api/codex/responses",
+		};
+	}
+
+	it("names the host and the failure code for a Bun DNS failure", async () => {
+		const error = bunTransportError(
+			"Was there a typo in the url or port?",
+			"FailedToOpenSocket",
+			"https://chatgpt.com/backend-api/codex/responses",
+		);
+
+		const message = await finalizeErrorMessage(error, codexDump());
+
+		expect(message).toContain("Was there a typo in the url or port?");
+		expect(message).toContain("transport=FailedToOpenSocket");
+		expect(message).toContain("url=https://chatgpt.com/backend-api/codex/responses");
+	});
+
+	it("falls back to the request dump URL when the error carries no path", () => {
+		const error = bunTransportError(
+			"Unable to connect. Is the computer able to access the url?",
+			"ConnectionRefused",
+		);
+
+		const message = appendTransportFailureContext(error.message, error, codexDump());
+
+		expect(message).toContain("transport=ConnectionRefused");
+		expect(message).toContain("url=https://chatgpt.com/backend-api/codex/responses");
+	});
+
+	it("keeps query strings out of the surfaced URL", () => {
+		const error = bunTransportError(
+			"Unable to connect. Is the computer able to access the url?",
+			"ENOTFOUND",
+			"https://generativelanguage.googleapis.com/v1beta/models/gemini:streamGenerateContent?key=synthetic-secret",
+		);
+
+		const message = appendTransportFailureContext(error.message, error, undefined);
+
+		expect(message).toContain(
+			"url=https://generativelanguage.googleapis.com/v1beta/models/gemini:streamGenerateContent",
+		);
+		expect(message).not.toContain("synthetic-secret");
+	});
+
+	it("reads the transport failure through a wrapped cause", () => {
+		const error = Object.assign(new Error("fetch failed"), {
+			cause: bunTransportError(
+				"connect ECONNREFUSED 127.0.0.1:11434",
+				"ECONNREFUSED",
+				"http://127.0.0.1:11434/api/chat",
+			),
+		});
+
+		const message = appendTransportFailureContext(error.message, error, undefined);
+
+		expect(message).toContain("transport=ECONNREFUSED");
+		expect(message).toContain("url=http://127.0.0.1:11434/api/chat");
+	});
+
+	it("leaves errors that reached an HTTP status untouched", () => {
+		const error = Object.assign(new Error("500 upstream failure"), { status: 500, code: "ConnectionReset" });
+
+		expect(appendTransportFailureContext(error.message, error, codexDump())).toBe("500 upstream failure");
+	});
+
+	it("leaves aborts untouched so the abort display path keeps matching", () => {
+		const error = Object.assign(new Error("Request was aborted."), { name: "AbortError", code: "ABORT_ERR" });
+
+		expect(appendTransportFailureContext(error.message, error, codexDump())).toBe("Request was aborted.");
+	});
+
+	it("does not append the same context twice", () => {
+		const error = bunTransportError(
+			"Was there a typo in the url or port?",
+			"FailedToOpenSocket",
+			"https://chatgpt.com/x",
+		);
+		const once = appendTransportFailureContext(error.message, error, undefined);
+
+		expect(appendTransportFailureContext(once, error, undefined)).toBe(once);
 	});
 });


### PR DESCRIPTION
## What

`finalizeErrorMessage` now names the failed connection when a request never produced an HTTP status: it appends `transport=<code>` and, when known, `url=<origin+path>`.

Before:

```
Error: Was there a typo in the url or port?
```

After:

```
Was there a typo in the url or port? (transport=FailedToOpenSocket url=https://chatgpt.com/backend-api/codex/responses)
```

## Why

Bun raises DNS and socket failures as a bare `Error` whose message is a standalone hint, and keeps the actionable facts on separate properties:

```
name:    Error
message: "Was there a typo in the url or port?"
code:    "FailedToOpenSocket"
path:    "https://chatgpt.com/backend-api/codex/responses"
```

Only `message` was carried forward into the assistant message, so a provider outage, a local DNS failure, and a mistyped custom base URL all rendered as the same context-free sentence with no host in it.

This was found the hard way. A stale macOS resolver entry left the apex name `chatgpt.com` unresolvable through `getaddrinfo()` while `dig`, `dns-sd -Q`, and every subdomain still worked. Every `openai-codex` request died — that provider is the only one whose base URL is an apex domain (`CODEX_BASE_URL = "https://chatgpt.com/backend-api"`) — while `api.anthropic.com` and `api.kimi.com` kept streaming normally. The user-visible signal for a single broken hostname was a sentence implying they had mistyped a URL they never typed. Printing the code and the host would have turned a multi-step diagnosis into a glance.

## Scope

`finalizeErrorMessage` is the shared chokepoint for Anthropic, OpenAI Responses/Completions, OpenAI Codex, Azure, Google, and Ollama, so this lands once for every provider.

Deliberately narrow:

- **Only when there is no HTTP status.** Errors that reached a response already carry status, body text, and the existing 400 guidance, and are returned unchanged.
- **Only connection-level codes.** An explicit allowlist of Bun (`ConnectionRefused`, `FailedToOpenSocket`, …) and Node-style (`ENOTFOUND`, `EAI_AGAIN`, `ECONNRESET`, …) codes. Aborts are excluded on purpose: `ABORT_ERR` is not in the set, so `modes/utils/abort-message` keeps matching `/^Request was aborted\.?$/` exactly and the abort display path is unaffected. There is a regression test for this.
- **URL reduced to origin and path.** A key carried in the query string (Google `?key=`, signed URLs) is never surfaced. There is a test for this too.
- **Idempotent**, and it walks `cause` up to two levels so `undici`-style wrapped errors (`fetch failed` → `ECONNREFUSED`) still resolve.

## Tests

Added 7 cases to `packages/ai/test/http-inspector.test.ts`: Bun DNS failure end-to-end through `finalizeErrorMessage`, request-dump URL fallback, query-string redaction, wrapped `cause`, HTTP-status errors untouched, aborts untouched, idempotence.

```
bun test packages/ai/test/http-inspector.test.ts     12 pass 0 fail
bun test packages/ai/test                          1943 pass 0 fail (337 skip, 222 files)
bun --cwd=packages/ai run check                    biome + tsc clean
```
