### PR TITLE
fix(natives): recover Cargo from rustup homes for addon builds

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -236,6 +236,44 @@ jobs:
           bun test packages/coding-agent/test/session-manager/windows-canonical-path.test.ts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+
+  windows-native-build-toolchain:
+    name: Windows native build toolchain path
+    needs: [affected-plan]
+    if: ${{ needs.affected-plan.outputs.relevant == 'true' && (contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/scripts/build-native.ts') || contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/scripts/rust-toolchain-path.ts') || contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/test/build-native-profile.test.ts') || contains(needs.affected-plan.outputs.changed_paths, 'scripts/ci-build-native.ts')) }}
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify checked-out source head
+        shell: pwsh
+        run: |
+          $head = (git rev-parse HEAD).Trim()
+          if ($head -ne $env:CI_DEV_SOURCE_SHA) { throw "Checked-out SHA $head does not match $env:CI_DEV_SOURCE_SHA" }
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3.14"
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+        with:
+          toolchain: nightly-2026-04-29
+      - name: Cache bun dependencies
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-1.3.14-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+      - run: bun install --frozen-lockfile
+      - name: Run native build toolchain tests
+        run: bun test packages/natives/test/build-native-profile.test.ts
+      - name: Build native addon (win32-x64 baseline)
+        env:
+          TARGET_PLATFORM: win32
+          TARGET_ARCH: x64
+          TARGET_VARIANTS: baseline
+        run: bun run ci:build:native
   windows-telegram-daemon-safety:
     name: Windows Telegram daemon safety
     needs: [affected-plan]

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Native addon builds now prepend the active `rustup` toolchain's Cargo directory before invoking `napi`, so non-interactive shells without `~/.cargo/bin` on `PATH` no longer fail with opaque `cargo metadata failed to run` errors.
 
 ## [0.11.11] - 2026-07-26
 ### Added

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -4,6 +4,7 @@ import { $ } from "bun";
 import { detectHostAvx2Support } from "../../../scripts/host-detect";
 import { assertRequiredSymbols } from "./embed-guard";
 import { generateEnumExports } from "./gen-enums";
+import { resolveCargoToolchainPath } from "./rust-toolchain-path";
 
 const repoRoot = path.join(import.meta.dir, "../../..");
 const rustDir = path.join(repoRoot, "crates/pi-natives");
@@ -264,11 +265,24 @@ if (!napiBin) {
 	throw new Error("Could not locate @napi-rs/cli `napi` binary in node_modules/.bin");
 }
 
+const cargoPathResolution = await resolveCargoToolchainPath({
+	cwd: repoRoot,
+	currentPath: Bun.env.PATH ?? "",
+});
+if (!cargoPathResolution) {
+	throw new Error(
+		"Could not locate Cargo for native addon build. Install Rust with rustup, or ensure `cargo` is available on PATH.",
+	);
+}
+Bun.env.PATH = cargoPathResolution.pathValue;
+
 try {
 	const buildResult = await $`${napiBin} ${napiArgs}`.nothrow();
 	if (buildResult.exitCode !== 0) {
-		const stderr = buildResult.stderr?.toString("utf-8") ?? "";
-		throw new Error(`napi build failed${stderr ? `:\n${stderr}` : ""}`);
+		const stderr = buildResult.stderr?.toString("utf-8").trim() ?? "";
+		const stdout = buildResult.stdout?.toString("utf-8").trim() ?? "";
+		const details = [stderr, stdout].filter(detail => detail !== "").join("\n");
+		throw new Error(`napi build failed${details ? `:\n${details}` : ""}`);
 	}
 
 	const builtAddonPath = await resolveBuiltAddonPath(buildOutputDir, canonicalAddonFilename);

--- a/packages/natives/scripts/rust-toolchain-path.ts
+++ b/packages/natives/scripts/rust-toolchain-path.ts
@@ -1,0 +1,102 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import { $ } from "bun";
+
+export type CargoToolchainPathSource = "rustup" | "path";
+
+export type CargoToolchainPathResolution = {
+	cargoBinary: string;
+	toolchainBin: string;
+	pathValue: string;
+	source: CargoToolchainPathSource;
+};
+
+export function prependPathEntry(currentPath: string, entry: string, separator: string): string {
+	const existingEntries = currentPath.split(separator).filter(Boolean);
+	const dedupedEntries = existingEntries.filter(existingEntry => existingEntry !== entry);
+	return [entry, ...dedupedEntries].join(separator);
+}
+
+export function resolveCargoToolchainPathFromCandidates(options: {
+	currentPath: string;
+	pathSeparator: string;
+	pathCargoBinary: string | null;
+	rustupCargoBinary: string | null;
+}): CargoToolchainPathResolution | null {
+	const rustupCargoBinary = options.rustupCargoBinary?.trim() || null;
+	const pathCargoBinary = options.pathCargoBinary?.trim() || null;
+	const cargoBinary = rustupCargoBinary ?? pathCargoBinary;
+	if (!cargoBinary) return null;
+
+	const source: CargoToolchainPathSource = rustupCargoBinary ? "rustup" : "path";
+	const toolchainBin = path.dirname(cargoBinary);
+	return {
+		cargoBinary,
+		toolchainBin,
+		pathValue: prependPathEntry(options.currentPath, toolchainBin, options.pathSeparator),
+		source,
+	};
+}
+
+export function dedupeOrderedPaths(paths: readonly string[]): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+
+	for (const candidate of paths) {
+		const normalized = candidate.trim();
+		if (normalized === "" || seen.has(normalized)) continue;
+		seen.add(normalized);
+		result.push(normalized);
+	}
+
+	return result;
+}
+
+export function resolveRustupCandidatePaths(options: {
+	currentPath: string;
+	cargoHome?: string;
+	homeDir: string;
+}): string[] {
+	const explicitPathRustup = Bun.which("rustup", { PATH: options.currentPath });
+	const cargoHome = options.cargoHome?.trim() || null;
+	const defaultCargoHome = path.join(options.homeDir, ".cargo");
+
+	return dedupeOrderedPaths([
+		explicitPathRustup ?? "",
+		cargoHome ? path.join(cargoHome, "bin", process.platform === "win32" ? "rustup.exe" : "rustup") : "",
+		path.join(defaultCargoHome, "bin", process.platform === "win32" ? "rustup.exe" : "rustup"),
+	]);
+}
+
+async function resolveRustupCargoBinary(cwd: string, rustupCandidates: readonly string[]): Promise<string | null> {
+	for (const rustupBinary of rustupCandidates) {
+		const result = await $`${rustupBinary} which cargo`.cwd(cwd).quiet().nothrow();
+		if (result.exitCode !== 0) continue;
+
+		const cargoBinary = result.stdout.toString("utf-8").trim();
+		if (cargoBinary !== "") return cargoBinary;
+	}
+	return null;
+}
+
+export async function resolveCargoToolchainPath(options: {
+	cwd: string;
+	currentPath: string;
+}): Promise<CargoToolchainPathResolution | null> {
+	const pathSeparator = process.platform === "win32" ? ";" : ":";
+	const rustupCargoBinary = await resolveRustupCargoBinary(
+		options.cwd,
+		resolveRustupCandidatePaths({
+			currentPath: options.currentPath,
+			cargoHome: Bun.env.CARGO_HOME,
+			homeDir: os.homedir(),
+		}),
+	);
+	const pathCargoBinary = Bun.which("cargo", { PATH: options.currentPath }) ?? null;
+	return resolveCargoToolchainPathFromCandidates({
+		currentPath: options.currentPath,
+		pathSeparator,
+		pathCargoBinary,
+		rustupCargoBinary,
+	});
+}

--- a/packages/natives/test/build-native-profile.test.ts
+++ b/packages/natives/test/build-native-profile.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
+import {
+	prependPathEntry,
+	resolveCargoToolchainPath,
+	resolveCargoToolchainPathFromCandidates,
+	resolveRustupCandidatePaths,
+} from "../scripts/rust-toolchain-path";
 
 const repoRoot = path.join(import.meta.dir, "../../..");
 
@@ -61,5 +69,161 @@ describe("native build Cargo profiles", () => {
 		const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
 		expect(exitCode).not.toBe(0);
 		expect(stderr).toContain("Unsupported PI_NATIVE_PROFILE: bogus");
+	});
+});
+
+describe("native build Rust toolchain integration", () => {
+	it.skipIf(process.platform === "win32")(
+		"resolves cargo through CARGO_HOME rustup when neither rustup nor cargo is on PATH",
+		async () => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-rustup-path-"));
+			const cargoHome = path.join(tempDir, "cargo-home");
+			const cargoBinary = path.join(cargoHome, "toolchains", "nightly", "bin", "cargo");
+			const rustupBinary = path.join(cargoHome, "bin", "rustup");
+
+			await fs.mkdir(path.dirname(rustupBinary), { recursive: true });
+			await fs.mkdir(path.dirname(cargoBinary), { recursive: true });
+			await Bun.write(
+				rustupBinary,
+				`#!/bin/sh
+if [ "$1" = "which" ] && [ "$2" = "cargo" ]; then
+	printf '%s\n' "${cargoBinary}"
+	exit 0
+fi
+exit 1
+`,
+			);
+			await fs.chmod(rustupBinary, 0o755);
+
+			const previousCargoHome = Bun.env.CARGO_HOME;
+			try {
+				Bun.env.CARGO_HOME = cargoHome;
+				const resolution = await resolveCargoToolchainPath({
+					cwd: repoRoot,
+					currentPath: "/usr/bin:/bin",
+				});
+
+				expect(resolution).toEqual({
+					cargoBinary,
+					toolchainBin: path.dirname(cargoBinary),
+					pathValue: `${path.dirname(cargoBinary)}:/usr/bin:/bin`,
+					source: "rustup",
+				});
+			} finally {
+				if (previousCargoHome === undefined) {
+					delete Bun.env.CARGO_HOME;
+				} else {
+					Bun.env.CARGO_HOME = previousCargoHome;
+				}
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
+		},
+	);
+});
+
+describe("native build Rust toolchain PATH", () => {
+	it("prepends the rustup active toolchain cargo bin before invoking napi", () => {
+		const resolution = resolveCargoToolchainPathFromCandidates({
+			currentPath: "/usr/bin:/bin",
+			pathSeparator: ":",
+			pathCargoBinary: null,
+			rustupCargoBinary: "/Users/example/.rustup/toolchains/nightly/bin/cargo",
+		});
+
+		expect(resolution).toEqual({
+			cargoBinary: "/Users/example/.rustup/toolchains/nightly/bin/cargo",
+			toolchainBin: "/Users/example/.rustup/toolchains/nightly/bin",
+			pathValue: "/Users/example/.rustup/toolchains/nightly/bin:/usr/bin:/bin",
+			source: "rustup",
+		});
+	});
+
+	it("prefers rustup's active cargo over a different cargo already on PATH", () => {
+		const resolution = resolveCargoToolchainPathFromCandidates({
+			currentPath: "/opt/cargo/bin:/usr/bin",
+			pathSeparator: ":",
+			pathCargoBinary: "/opt/cargo/bin/cargo",
+			rustupCargoBinary: "/Users/example/.rustup/toolchains/nightly/bin/cargo",
+		});
+
+		expect(resolution).toEqual({
+			cargoBinary: "/Users/example/.rustup/toolchains/nightly/bin/cargo",
+			toolchainBin: "/Users/example/.rustup/toolchains/nightly/bin",
+			pathValue: "/Users/example/.rustup/toolchains/nightly/bin:/opt/cargo/bin:/usr/bin",
+			source: "rustup",
+		});
+	});
+
+	it("deduplicates an existing toolchain bin while preserving the remaining PATH order", () => {
+		expect(prependPathEntry("/usr/bin:/toolchain/bin:/bin", "/toolchain/bin", ":")).toBe(
+			"/toolchain/bin:/usr/bin:/bin",
+		);
+	});
+
+	it("keeps a single toolchain entry when the current PATH only contains that entry", () => {
+		expect(prependPathEntry("/toolchain/bin", "/toolchain/bin", ":")).toBe("/toolchain/bin");
+	});
+
+	it("supports Windows PATH separators when deduplicating a toolchain bin", () => {
+		expect(prependPathEntry("C:\\Windows\\System32;C:\\Rust\\bin;C:\\Tools", "C:\\Rust\\bin", ";")).toBe(
+			"C:\\Rust\\bin;C:\\Windows\\System32;C:\\Tools",
+		);
+	});
+
+	it("falls back to a cargo binary already on PATH when rustup cannot resolve one", () => {
+		const resolution = resolveCargoToolchainPathFromCandidates({
+			currentPath: "/opt/cargo/bin:/usr/bin",
+			pathSeparator: ":",
+			pathCargoBinary: "/opt/cargo/bin/cargo",
+			rustupCargoBinary: null,
+		});
+
+		expect(resolution).toEqual({
+			cargoBinary: "/opt/cargo/bin/cargo",
+			toolchainBin: "/opt/cargo/bin",
+			pathValue: "/opt/cargo/bin:/usr/bin",
+			source: "path",
+		});
+	});
+
+	it("probes CARGO_HOME and the default cargo home when rustup is missing from PATH", () => {
+		expect(
+			resolveRustupCandidatePaths({
+				currentPath: "/usr/bin:/bin",
+				cargoHome: "/custom/cargo",
+				homeDir: "/Users/example",
+			}),
+		).toEqual(["/custom/cargo/bin/rustup", "/Users/example/.cargo/bin/rustup"]);
+	});
+
+	it("deduplicates CARGO_HOME when it matches the default cargo home", () => {
+		expect(
+			resolveRustupCandidatePaths({
+				currentPath: "/usr/bin:/bin",
+				cargoHome: "/Users/example/.cargo",
+				homeDir: "/Users/example",
+			}),
+		).toEqual(["/Users/example/.cargo/bin/rustup"]);
+	});
+	it("returns null when neither rustup nor PATH can provide cargo", () => {
+		expect(
+			resolveCargoToolchainPathFromCandidates({
+				currentPath: "/usr/bin:/bin",
+				pathSeparator: ":",
+				pathCargoBinary: null,
+				rustupCargoBinary: null,
+			}),
+		).toBeNull();
+	});
+
+	it("treats whitespace-only cargo candidates as unavailable", () => {
+		expect(
+			resolveCargoToolchainPathFromCandidates({
+				currentPath: "/usr/bin:/bin",
+				pathSeparator: ":",
+				pathCargoBinary: "  ",
+				rustupCargoBinary: "\t",
+			}),
+		).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary
- reworks closed PR #3331 with the review feedback addressed
- resolves Cargo through `rustup` discovered from PATH, `$CARGO_HOME/bin`, or the default `~/.cargo/bin` before invoking `napi build`
- keeps PATH `cargo` as the fallback after rustup resolution, matching the repo's `rust-toolchain.toml` authority
- adds real integration coverage for the common rustup-init layout where neither `rustup` nor `cargo` is on PATH but `CARGO_HOME/bin/rustup` exists
- adds Windows CI coverage for the native build toolchain path by running the native build-profile test and win32-x64 baseline native build on `windows-latest`

## Review feedback addressed
- #3331 was closed because it only recovered Homebrew/system rustup layouts, used only fabricated pure-helper tests, and had no Windows CI coverage.
- This version probes `$CARGO_HOME/bin/rustup` and `~/.cargo/bin/rustup`, exercises the actual `Bun.which` + `rustup which cargo` integration through a temporary fake CARGO_HOME rustup, and adds a Windows native-build workflow job for this path.

## Verification
- `bun test packages/natives/test/build-native-profile.test.ts` — 13 pass
- `bunx biome check .github/workflows/dev-ci.yml packages/natives/CHANGELOG.md packages/natives/scripts/build-native.ts packages/natives/scripts/rust-toolchain-path.ts packages/natives/test/build-native-profile.test.ts` — OK
- `TOOLCHAIN_BIN="$(dirname "$(rustup which cargo)")"; PATH="$TOOLCHAIN_BIN:$PATH" bun test scripts/ci-dev-affected.test.ts` — 80 pass
- `PATH=/opt/homebrew/bin:/usr/bin:/bin bun run build` in `packages/natives` — pass
- missing rustup/cargo negative scenario with isolated `CARGO_HOME` — clear Cargo-not-found error

## Notes
- A direct `bun test scripts/ci-dev-affected.test.ts` fails in this local non-interactive shell because `cargo` is not on PATH; rerunning with the active rustup toolchain bin prepended passes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
