### PR TITLE
fix(natives): recover Cargo from rustup homes for addon builds

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -236,6 +236,44 @@ jobs:
           bun test packages/coding-agent/test/session-manager/windows-canonical-path.test.ts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+
+  windows-native-build-toolchain:
+    name: Windows native build toolchain path
+    needs: [affected-plan]
+    if: ${{ needs.affected-plan.outputs.relevant == 'true' && (contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/scripts/build-native.ts') || contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/scripts/rust-toolchain-path.ts') || contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/test/build-native-profile.test.ts') || contains(needs.affected-plan.outputs.changed_paths, 'scripts/ci-build-native.ts')) }}
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      CI_DEV_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify checked-out source head
+        shell: pwsh
+        run: |
+          $head = (git rev-parse HEAD).Trim()
+          if ($head -ne $env:CI_DEV_SOURCE_SHA) { throw "Checked-out SHA $head does not match $env:CI_DEV_SOURCE_SHA" }
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3.14"
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+        with:
+          toolchain: nightly-2026-04-29
+      - name: Cache bun dependencies
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-1.3.14-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+      - run: bun install --frozen-lockfile
+      - name: Run native build toolchain tests
+        run: bun test packages/natives/test/build-native-profile.test.ts
+      - name: Build native addon (win32-x64 baseline)
+        env:
+          TARGET_PLATFORM: win32
+          TARGET_ARCH: x64
+          TARGET_VARIANTS: baseline
+        run: bun run ci:build:native
   windows-telegram-daemon-safety:
     name: Windows Telegram daemon safety
     needs: [affected-plan]

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -615,7 +615,7 @@ jobs:
   affected-evidence-producer:
     name: Affected path validation / evidence producer
     if: ${{ always() }}
-    needs: [affected-plan, affected-native, affected-python-matrix, affected-shards, telegram-daemon-generation, windows-dev-doctor, windows-telegram-daemon-safety, affected-darwin-arm64-tab-worker-smoke]
+    needs: [affected-plan, affected-native, affected-python-matrix, affected-shards, telegram-daemon-generation, windows-dev-doctor, windows-native-build-toolchain, windows-telegram-daemon-safety, affected-darwin-arm64-tab-worker-smoke]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
@@ -676,6 +676,8 @@ jobs:
           CI_DEV_PYTHON_RESULT: ${{ needs.affected-python-matrix.result == 'skipped' && 'skipped' || needs.affected-python-matrix.result }}
           CI_DEV_WINDOWS_DOCTOR_RESULT: ${{ needs.windows-dev-doctor.result }}
           CI_DEV_WINDOWS_DOCTOR_REQUIRED: ${{ contains(needs.affected-plan.outputs.changed_paths, 'scripts/dev-link') || needs.affected-plan.outputs.has_windows_session_path == 'true' }}
+          CI_DEV_WINDOWS_NATIVE_TOOLCHAIN_RESULT: ${{ needs.windows-native-build-toolchain.result }}
+          CI_DEV_WINDOWS_NATIVE_TOOLCHAIN_REQUIRED: ${{ contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/scripts/build-native.ts') || contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/scripts/rust-toolchain-path.ts') || contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/test/build-native-profile.test.ts') || contains(needs.affected-plan.outputs.changed_paths, 'scripts/ci-build-native.ts') }}
           CI_DEV_TELEGRAM_GUARD_RESULT: ${{ needs.telegram-daemon-generation.result }}
           CI_DEV_TELEGRAM_GUARD_REQUIRED: ${{ needs.affected-plan.outputs.relevant }}
           CI_DEV_TELEGRAM_WINDOWS_RESULT: ${{ needs.windows-telegram-daemon-safety.result }}
@@ -702,7 +704,7 @@ jobs:
   affected:
     name: Affected path validation
     if: ${{ always() }}
-    needs: [affected-evidence-producer, affected-plan, affected-native, affected-python-matrix, affected-shards, telegram-daemon-generation, windows-dev-doctor, windows-telegram-daemon-safety, affected-darwin-arm64-tab-worker-smoke]
+    needs: [affected-evidence-producer, affected-plan, affected-native, affected-python-matrix, affected-shards, telegram-daemon-generation, windows-dev-doctor, windows-native-build-toolchain, windows-telegram-daemon-safety, affected-darwin-arm64-tab-worker-smoke]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     env:
@@ -719,6 +721,8 @@ jobs:
       CI_DEV_PYTHON_RESULT: ${{ needs.affected-python-matrix.result == 'skipped' && 'skipped' || needs.affected-python-matrix.result }}
       CI_DEV_WINDOWS_DOCTOR_RESULT: ${{ needs.windows-dev-doctor.result }}
       CI_DEV_WINDOWS_DOCTOR_REQUIRED: ${{ contains(needs.affected-plan.outputs.changed_paths, 'scripts/dev-link') || needs.affected-plan.outputs.has_windows_session_path == 'true' }}
+      CI_DEV_WINDOWS_NATIVE_TOOLCHAIN_RESULT: ${{ needs.windows-native-build-toolchain.result }}
+      CI_DEV_WINDOWS_NATIVE_TOOLCHAIN_REQUIRED: ${{ contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/scripts/build-native.ts') || contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/scripts/rust-toolchain-path.ts') || contains(needs.affected-plan.outputs.changed_paths, 'packages/natives/test/build-native-profile.test.ts') || contains(needs.affected-plan.outputs.changed_paths, 'scripts/ci-build-native.ts') }}
       CI_DEV_DARWIN_ARM64_TAB_WORKER_SMOKE_RESULT: ${{ needs.affected-plan.outputs.has_darwin_arm64_tab_worker_smoke == 'true' && 'success' || 'skipped' }}
       CI_DEV_DARWIN_ARM64_TAB_WORKER_SMOKE_REQUIRED: ${{ needs.affected-plan.outputs.has_darwin_arm64_tab_worker_smoke }}
       CI_DEV_TELEGRAM_GUARD_RESULT: ${{ needs.telegram-daemon-generation.result }}

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Native addon builds now prepend the active `rustup` toolchain's Cargo directory before invoking `napi`, so non-interactive shells without `~/.cargo/bin` on `PATH` no longer fail with opaque `cargo metadata failed to run` errors.
 
 ## [0.11.11] - 2026-07-26
 ### Added

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -4,6 +4,7 @@ import { $ } from "bun";
 import { detectHostAvx2Support } from "../../../scripts/host-detect";
 import { assertRequiredSymbols } from "./embed-guard";
 import { generateEnumExports } from "./gen-enums";
+import { resolveCargoToolchainPath } from "./rust-toolchain-path";
 
 const repoRoot = path.join(import.meta.dir, "../../..");
 const rustDir = path.join(repoRoot, "crates/pi-natives");
@@ -264,11 +265,24 @@ if (!napiBin) {
 	throw new Error("Could not locate @napi-rs/cli `napi` binary in node_modules/.bin");
 }
 
+const cargoPathResolution = await resolveCargoToolchainPath({
+	cwd: repoRoot,
+	currentPath: Bun.env.PATH ?? "",
+});
+if (!cargoPathResolution) {
+	throw new Error(
+		"Could not locate Cargo for native addon build. Install Rust with rustup, or ensure `cargo` is available on PATH.",
+	);
+}
+Bun.env.PATH = cargoPathResolution.pathValue;
+
 try {
 	const buildResult = await $`${napiBin} ${napiArgs}`.nothrow();
 	if (buildResult.exitCode !== 0) {
-		const stderr = buildResult.stderr?.toString("utf-8") ?? "";
-		throw new Error(`napi build failed${stderr ? `:\n${stderr}` : ""}`);
+		const stderr = buildResult.stderr?.toString("utf-8").trim() ?? "";
+		const stdout = buildResult.stdout?.toString("utf-8").trim() ?? "";
+		const details = [stderr, stdout].filter(detail => detail !== "").join("\n");
+		throw new Error(`napi build failed${details ? `:\n${details}` : ""}`);
 	}
 
 	const builtAddonPath = await resolveBuiltAddonPath(buildOutputDir, canonicalAddonFilename);

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -250,12 +250,6 @@ const canonicalAddonPath = path.join(nativeDir, canonicalAddonFilename);
 
 console.log(`Building pi-natives for ${targetPlatform}-${targetArch}${variantSuffix}${profileSuffix}…`);
 
-await fs.mkdir(nativeDir, { recursive: true });
-await cleanupStaleTemps(nativeDir);
-await fs.mkdir(path.join(nativeDir, ".build"), { recursive: true });
-const buildOutputDir = await fs.mkdtemp(buildOutputDirPrefix);
-napiArgs[10] = buildOutputDir;
-
 // Resolve napi bin directly: `bunx @napi-rs/cli` can pick up the wrong bin on
 // systems where `cli` exists on PATH (e.g. Mono's /usr/bin/cli on Ubuntu).
 const napiBin = Bun.which("napi", {
@@ -275,6 +269,12 @@ if (!cargoPathResolution) {
 	);
 }
 Bun.env.PATH = cargoPathResolution.pathValue;
+
+await fs.mkdir(nativeDir, { recursive: true });
+await cleanupStaleTemps(nativeDir);
+await fs.mkdir(path.join(nativeDir, ".build"), { recursive: true });
+const buildOutputDir = await fs.mkdtemp(buildOutputDirPrefix);
+napiArgs[10] = buildOutputDir;
 
 try {
 	const buildResult = await $`${napiBin} ${napiArgs}`.nothrow();

--- a/packages/natives/scripts/rust-toolchain-path.ts
+++ b/packages/natives/scripts/rust-toolchain-path.ts
@@ -1,0 +1,102 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import { $ } from "bun";
+
+export type CargoToolchainPathSource = "rustup" | "path";
+
+export type CargoToolchainPathResolution = {
+	cargoBinary: string;
+	toolchainBin: string;
+	pathValue: string;
+	source: CargoToolchainPathSource;
+};
+
+export function prependPathEntry(currentPath: string, entry: string, separator: string): string {
+	const existingEntries = currentPath.split(separator).filter(Boolean);
+	const dedupedEntries = existingEntries.filter(existingEntry => existingEntry !== entry);
+	return [entry, ...dedupedEntries].join(separator);
+}
+
+export function resolveCargoToolchainPathFromCandidates(options: {
+	currentPath: string;
+	pathSeparator: string;
+	pathCargoBinary: string | null;
+	rustupCargoBinary: string | null;
+}): CargoToolchainPathResolution | null {
+	const rustupCargoBinary = options.rustupCargoBinary?.trim() || null;
+	const pathCargoBinary = options.pathCargoBinary?.trim() || null;
+	const cargoBinary = rustupCargoBinary ?? pathCargoBinary;
+	if (!cargoBinary) return null;
+
+	const source: CargoToolchainPathSource = rustupCargoBinary ? "rustup" : "path";
+	const toolchainBin = path.dirname(cargoBinary);
+	return {
+		cargoBinary,
+		toolchainBin,
+		pathValue: prependPathEntry(options.currentPath, toolchainBin, options.pathSeparator),
+		source,
+	};
+}
+
+export function dedupeOrderedPaths(paths: readonly string[]): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+
+	for (const candidate of paths) {
+		const normalized = candidate.trim();
+		if (normalized === "" || seen.has(normalized)) continue;
+		seen.add(normalized);
+		result.push(normalized);
+	}
+
+	return result;
+}
+
+export function resolveRustupCandidatePaths(options: {
+	currentPath: string;
+	cargoHome?: string;
+	homeDir: string;
+}): string[] {
+	const explicitPathRustup = Bun.which("rustup", { PATH: options.currentPath });
+	const cargoHome = options.cargoHome?.trim() || null;
+	const defaultCargoHome = path.join(options.homeDir, ".cargo");
+
+	return dedupeOrderedPaths([
+		explicitPathRustup ?? "",
+		cargoHome ? path.join(cargoHome, "bin", process.platform === "win32" ? "rustup.exe" : "rustup") : "",
+		path.join(defaultCargoHome, "bin", process.platform === "win32" ? "rustup.exe" : "rustup"),
+	]);
+}
+
+async function resolveRustupCargoBinary(cwd: string, rustupCandidates: readonly string[]): Promise<string | null> {
+	for (const rustupBinary of rustupCandidates) {
+		const result = await $`${rustupBinary} which cargo`.cwd(cwd).quiet().nothrow();
+		if (result.exitCode !== 0) continue;
+
+		const cargoBinary = result.stdout.toString("utf-8").trim();
+		if (cargoBinary !== "") return cargoBinary;
+	}
+	return null;
+}
+
+export async function resolveCargoToolchainPath(options: {
+	cwd: string;
+	currentPath: string;
+}): Promise<CargoToolchainPathResolution | null> {
+	const pathSeparator = process.platform === "win32" ? ";" : ":";
+	const rustupCargoBinary = await resolveRustupCargoBinary(
+		options.cwd,
+		resolveRustupCandidatePaths({
+			currentPath: options.currentPath,
+			cargoHome: Bun.env.CARGO_HOME,
+			homeDir: os.homedir(),
+		}),
+	);
+	const pathCargoBinary = Bun.which("cargo", { PATH: options.currentPath }) ?? null;
+	return resolveCargoToolchainPathFromCandidates({
+		currentPath: options.currentPath,
+		pathSeparator,
+		pathCargoBinary,
+		rustupCargoBinary,
+	});
+}

--- a/packages/natives/test/build-native-profile.test.ts
+++ b/packages/natives/test/build-native-profile.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
+import {
+	prependPathEntry,
+	resolveCargoToolchainPath,
+	resolveCargoToolchainPathFromCandidates,
+	resolveRustupCandidatePaths,
+} from "../scripts/rust-toolchain-path";
 
 const repoRoot = path.join(import.meta.dir, "../../..");
+const rustupExecutableName = process.platform === "win32" ? "rustup.exe" : "rustup";
 
 type TomlSection = Record<string, string>;
 
@@ -61,5 +70,164 @@ describe("native build Cargo profiles", () => {
 		const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
 		expect(exitCode).not.toBe(0);
 		expect(stderr).toContain("Unsupported PI_NATIVE_PROFILE: bogus");
+	});
+});
+
+describe("native build Rust toolchain integration", () => {
+	it.skipIf(process.platform === "win32")(
+		"resolves cargo through CARGO_HOME rustup when neither rustup nor cargo is on PATH",
+		async () => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-rustup-path-"));
+			const cargoHome = path.join(tempDir, "cargo-home");
+			const cargoBinary = path.join(cargoHome, "toolchains", "nightly", "bin", "cargo");
+			const rustupBinary = path.join(cargoHome, "bin", "rustup");
+
+			await fs.mkdir(path.dirname(rustupBinary), { recursive: true });
+			await fs.mkdir(path.dirname(cargoBinary), { recursive: true });
+			await Bun.write(
+				rustupBinary,
+				`#!/bin/sh
+if [ "$1" = "which" ] && [ "$2" = "cargo" ]; then
+	printf '%s\n' "${cargoBinary}"
+	exit 0
+fi
+exit 1
+`,
+			);
+			await fs.chmod(rustupBinary, 0o755);
+
+			const previousCargoHome = Bun.env.CARGO_HOME;
+			try {
+				Bun.env.CARGO_HOME = cargoHome;
+				const resolution = await resolveCargoToolchainPath({
+					cwd: repoRoot,
+					currentPath: "/usr/bin:/bin",
+				});
+
+				expect(resolution).toEqual({
+					cargoBinary,
+					toolchainBin: path.dirname(cargoBinary),
+					pathValue: `${path.dirname(cargoBinary)}:/usr/bin:/bin`,
+					source: "rustup",
+				});
+			} finally {
+				if (previousCargoHome === undefined) {
+					delete Bun.env.CARGO_HOME;
+				} else {
+					Bun.env.CARGO_HOME = previousCargoHome;
+				}
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
+		},
+	);
+});
+
+describe("native build Rust toolchain PATH", () => {
+	it("prepends the rustup active toolchain cargo bin before invoking napi", () => {
+		const resolution = resolveCargoToolchainPathFromCandidates({
+			currentPath: "/usr/bin:/bin",
+			pathSeparator: ":",
+			pathCargoBinary: null,
+			rustupCargoBinary: "/Users/example/.rustup/toolchains/nightly/bin/cargo",
+		});
+
+		expect(resolution).toEqual({
+			cargoBinary: "/Users/example/.rustup/toolchains/nightly/bin/cargo",
+			toolchainBin: "/Users/example/.rustup/toolchains/nightly/bin",
+			pathValue: "/Users/example/.rustup/toolchains/nightly/bin:/usr/bin:/bin",
+			source: "rustup",
+		});
+	});
+
+	it("prefers rustup's active cargo over a different cargo already on PATH", () => {
+		const resolution = resolveCargoToolchainPathFromCandidates({
+			currentPath: "/opt/cargo/bin:/usr/bin",
+			pathSeparator: ":",
+			pathCargoBinary: "/opt/cargo/bin/cargo",
+			rustupCargoBinary: "/Users/example/.rustup/toolchains/nightly/bin/cargo",
+		});
+
+		expect(resolution).toEqual({
+			cargoBinary: "/Users/example/.rustup/toolchains/nightly/bin/cargo",
+			toolchainBin: "/Users/example/.rustup/toolchains/nightly/bin",
+			pathValue: "/Users/example/.rustup/toolchains/nightly/bin:/opt/cargo/bin:/usr/bin",
+			source: "rustup",
+		});
+	});
+
+	it("deduplicates an existing toolchain bin while preserving the remaining PATH order", () => {
+		expect(prependPathEntry("/usr/bin:/toolchain/bin:/bin", "/toolchain/bin", ":")).toBe(
+			"/toolchain/bin:/usr/bin:/bin",
+		);
+	});
+
+	it("keeps a single toolchain entry when the current PATH only contains that entry", () => {
+		expect(prependPathEntry("/toolchain/bin", "/toolchain/bin", ":")).toBe("/toolchain/bin");
+	});
+
+	it("supports Windows PATH separators when deduplicating a toolchain bin", () => {
+		expect(prependPathEntry("C:\\Windows\\System32;C:\\Rust\\bin;C:\\Tools", "C:\\Rust\\bin", ";")).toBe(
+			"C:\\Rust\\bin;C:\\Windows\\System32;C:\\Tools",
+		);
+	});
+
+	it("falls back to a cargo binary already on PATH when rustup cannot resolve one", () => {
+		const resolution = resolveCargoToolchainPathFromCandidates({
+			currentPath: "/opt/cargo/bin:/usr/bin",
+			pathSeparator: ":",
+			pathCargoBinary: "/opt/cargo/bin/cargo",
+			rustupCargoBinary: null,
+		});
+
+		expect(resolution).toEqual({
+			cargoBinary: "/opt/cargo/bin/cargo",
+			toolchainBin: "/opt/cargo/bin",
+			pathValue: "/opt/cargo/bin:/usr/bin",
+			source: "path",
+		});
+	});
+
+	it("probes CARGO_HOME and the default cargo home when rustup is missing from PATH", () => {
+		expect(
+			resolveRustupCandidatePaths({
+				currentPath: "/usr/bin:/bin",
+				cargoHome: "/custom/cargo",
+				homeDir: "/Users/example",
+			}),
+		).toEqual([
+			path.join("/custom/cargo", "bin", rustupExecutableName),
+			path.join("/Users/example", ".cargo", "bin", rustupExecutableName),
+		]);
+	});
+
+	it("deduplicates CARGO_HOME when it matches the default cargo home", () => {
+		expect(
+			resolveRustupCandidatePaths({
+				currentPath: "/usr/bin:/bin",
+				cargoHome: "/Users/example/.cargo",
+				homeDir: "/Users/example",
+			}),
+		).toEqual([path.join("/Users/example", ".cargo", "bin", rustupExecutableName)]);
+	});
+	it("returns null when neither rustup nor PATH can provide cargo", () => {
+		expect(
+			resolveCargoToolchainPathFromCandidates({
+				currentPath: "/usr/bin:/bin",
+				pathSeparator: ":",
+				pathCargoBinary: null,
+				rustupCargoBinary: null,
+			}),
+		).toBeNull();
+	});
+
+	it("treats whitespace-only cargo candidates as unavailable", () => {
+		expect(
+			resolveCargoToolchainPathFromCandidates({
+				currentPath: "/usr/bin:/bin",
+				pathSeparator: ":",
+				pathCargoBinary: "  ",
+				rustupCargoBinary: "\t",
+			}),
+		).toBeNull();
 	});
 });

--- a/packages/natives/test/build-native-profile.test.ts
+++ b/packages/natives/test/build-native-profile.test.ts
@@ -39,6 +39,16 @@ function parseTomlSections(source: string): Record<string, TomlSection> {
 	return sections;
 }
 
+async function listNativeBuildDirs(): Promise<string[]> {
+	const buildRoot = path.join(repoRoot, "packages/natives/native/.build");
+	try {
+		return (await fs.readdir(buildRoot)).sort();
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw err;
+	}
+}
+
 describe("native build Cargo profiles", () => {
 	it("defines an unwind-safe dist profile that only inherits size settings from release", async () => {
 		const cargoToml = await Bun.file(path.join(repoRoot, "Cargo.toml")).text();
@@ -116,6 +126,38 @@ exit 1
 				} else {
 					Bun.env.CARGO_HOME = previousCargoHome;
 				}
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
+		},
+	);
+});
+
+describe("native build failure cleanup", () => {
+	it.skipIf(process.platform === "win32")(
+		"does not create a native .build directory when Cargo is unavailable",
+		async () => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-missing-cargo-"));
+			const before = await listNativeBuildDirs();
+
+			try {
+				const proc = Bun.spawn({
+					cmd: [process.execPath, path.join(repoRoot, "packages/natives/scripts/build-native.ts")],
+					cwd: repoRoot,
+					env: {
+						...process.env,
+						CARGO_HOME: path.join(tempDir, "cargo-home"),
+						HOME: path.join(tempDir, "home"),
+						PATH: "/usr/bin:/bin",
+					},
+					stdout: "pipe",
+					stderr: "pipe",
+				});
+
+				const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+				expect(exitCode).not.toBe(0);
+				expect(stderr).toContain("Could not locate Cargo for native addon build");
+				expect(await listNativeBuildDirs()).toEqual(before);
+			} finally {
 				await fs.rm(tempDir, { recursive: true, force: true });
 			}
 		},

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -47,22 +47,22 @@ describe("planTasks command shape (issue #622)", () => {
 
 describe("dev-ci canonical-plan workflow contract", () => {
 	test("pins independent no-shard and multi-shard detached-document byte oracles", () => {
-		const noShardManifest = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"planMode\":\"pr\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"},\"aggregateResults\":{\"plan\":\"success\",\"native\":\"skipped\",\"shards\":\"skipped\",\"windowsDoctor\":\"skipped\",\"windowsDoctorRequired\":\"false\",\"telegramGuard\":\"skipped\",\"telegramGuardRequired\":\"false\",\"telegramWindows\":\"skipped\",\"telegramWindowsRequired\":\"false\",\"hasNative\":\"false\",\"hasTasks\":\"false\",\"darwinArm64TabWorkerSmoke\":\"skipped\",\"darwinArm64TabWorkerSmokeRequired\":\"false\"},\"taskIdentities\":[],\"childEvidence\":[{\"name\":\".ci-dev-affected-plan.json\",\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}]}\n";
-		const multiShardManifest = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"planMode\":\"push\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"},\"aggregateResults\":{\"plan\":\"success\",\"native\":\"success\",\"shards\":\"success\",\"windowsDoctor\":\"success\",\"windowsDoctorRequired\":\"true\",\"telegramGuard\":\"success\",\"telegramGuardRequired\":\"true\",\"telegramWindows\":\"success\",\"telegramWindowsRequired\":\"true\",\"hasNative\":\"true\",\"hasTasks\":\"true\",\"darwinArm64TabWorkerSmoke\":\"skipped\",\"darwinArm64TabWorkerSmokeRequired\":\"false\"},\"taskIdentities\":[{\"key\":\"one\",\"identity\":\"id-one\"},{\"key\":\"two\",\"identity\":\"id-two\"}],\"childEvidence\":[{\"name\":\".ci-dev-affected-plan.json\",\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},{\"name\":\".ci-dev-shard-receipts/0.json\",\"sha256\":\"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"},{\"name\":\".ci-dev-shard-receipts/1.json\",\"sha256\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}]}\n";
-		const noShardReceipt = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"manifestSha256\":\"54a4c5abf1fc7a81f2fee152dce6aba6d3838148b8cb0c193a868cf333fc52b2\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"}}\n";
-		const multiShardReceipt = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"manifestSha256\":\"0b8ee9d2d0d223ee62eb43ad67364116e9d882d08eb84aa3ba9d428a78bdae08\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"}}\n";
+		const noShardManifest = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"planMode\":\"pr\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"},\"aggregateResults\":{\"plan\":\"success\",\"native\":\"skipped\",\"shards\":\"skipped\",\"windowsDoctor\":\"skipped\",\"windowsDoctorRequired\":\"false\",\"windowsNativeToolchain\":\"skipped\",\"windowsNativeToolchainRequired\":\"false\",\"telegramGuard\":\"skipped\",\"telegramGuardRequired\":\"false\",\"telegramWindows\":\"skipped\",\"telegramWindowsRequired\":\"false\",\"hasNative\":\"false\",\"hasTasks\":\"false\",\"darwinArm64TabWorkerSmoke\":\"skipped\",\"darwinArm64TabWorkerSmokeRequired\":\"false\"},\"taskIdentities\":[],\"childEvidence\":[{\"name\":\".ci-dev-affected-plan.json\",\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}]}\n";
+		const multiShardManifest = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"planMode\":\"push\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"},\"aggregateResults\":{\"plan\":\"success\",\"native\":\"success\",\"shards\":\"success\",\"windowsDoctor\":\"success\",\"windowsDoctorRequired\":\"true\",\"windowsNativeToolchain\":\"success\",\"windowsNativeToolchainRequired\":\"true\",\"telegramGuard\":\"success\",\"telegramGuardRequired\":\"true\",\"telegramWindows\":\"success\",\"telegramWindowsRequired\":\"true\",\"hasNative\":\"true\",\"hasTasks\":\"true\",\"darwinArm64TabWorkerSmoke\":\"skipped\",\"darwinArm64TabWorkerSmokeRequired\":\"false\"},\"taskIdentities\":[{\"key\":\"one\",\"identity\":\"id-one\"},{\"key\":\"two\",\"identity\":\"id-two\"}],\"childEvidence\":[{\"name\":\".ci-dev-affected-plan.json\",\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},{\"name\":\".ci-dev-shard-receipts/0.json\",\"sha256\":\"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"},{\"name\":\".ci-dev-shard-receipts/1.json\",\"sha256\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}]}\n";
+		const noShardReceipt = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"manifestSha256\":\"a4069f49c385d008aebe32436bb4cbde309cae51d28c4236bb0e33f0be186094\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"}}\n";
+		const multiShardReceipt = "{\"schemaVersion\":1,\"subject\":\"ci-dev-affected-evidence\",\"manifestSha256\":\"760601ea59164b84d93bc4bf192085447ea86c90e969b080aeea48828f1b5320\",\"sourceSha\":\"0123456789abcdef0123456789abcdef01234567\",\"planDigest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"replayScope\":{\"repository\":\"owner/repo\",\"workflow\":\"Dev CI\",\"runId\":\"42\"}}\n";
 		const hash = (value: string) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
-		expect(hash(noShardManifest)).toBe("54a4c5abf1fc7a81f2fee152dce6aba6d3838148b8cb0c193a868cf333fc52b2");
-		expect(hash(multiShardManifest)).toBe("0b8ee9d2d0d223ee62eb43ad67364116e9d882d08eb84aa3ba9d428a78bdae08");
-		expect(hash(noShardReceipt)).toBe("94811782eb24e82ea14b59b600a13f2b0969f50767b300910b8665855f534c19");
-		expect(hash(multiShardReceipt)).toBe("09341439a0211c277328dcb07117568d57a3ecddad4d35ae6f03dae57c37e260");
+		expect(hash(noShardManifest)).toBe("a4069f49c385d008aebe32436bb4cbde309cae51d28c4236bb0e33f0be186094");
+		expect(hash(multiShardManifest)).toBe("760601ea59164b84d93bc4bf192085447ea86c90e969b080aeea48828f1b5320");
+		expect(hash(noShardReceipt)).toBe("7f3cb1ebf7ca106b8030dd79353dabbc57ed22137ac41e169cc5700d29493091");
+		expect(hash(multiShardReceipt)).toBe("2c298faf1d92681cef1499a7526d1df0e8aee947694804d50aa47e015b222e26");
 	});
 	test("uses a detached finalized evidence producer and artifact-ID consumer", async () => {
 		const workflow = await Bun.file(path.join(import.meta.dir, "..", ".github", "workflows", "dev-ci.yml")).text();
 		expect(workflow).toContain("affected-evidence-producer:");
 		expect(workflow).toContain("name: Affected path validation / evidence producer");
 		expect(workflow).toContain("  affected:\n    name: Affected path validation\n    if: ${{ always() }}");
-		expect(workflow).toContain("needs: [affected-evidence-producer, affected-plan, affected-native, affected-python-matrix, affected-shards, telegram-daemon-generation, windows-dev-doctor, windows-telegram-daemon-safety, affected-darwin-arm64-tab-worker-smoke]");
+		expect(workflow).toContain("needs: [affected-evidence-producer, affected-plan, affected-native, affected-python-matrix, affected-shards, telegram-daemon-generation, windows-dev-doctor, windows-native-build-toolchain, windows-telegram-daemon-safety, affected-darwin-arm64-tab-worker-smoke]");
 		expect(workflow).toContain("artifact_id: ${{ steps.upload-evidence.outputs.artifact-id }}");
 		expect(workflow).toContain("artifact_digest: ${{ steps.upload-evidence.outputs.artifact-digest }}");
 		expect(workflow).toContain("artifact-ids: ${{ needs.affected-evidence-producer.outputs.artifact_id }}");
@@ -149,6 +149,8 @@ describe("dev-ci canonical-plan workflow contract", () => {
 			python: "skipped",
 			windowsDoctor: "skipped",
 			windowsDoctorRequired: "false",
+			windowsNativeToolchain: "skipped",
+			windowsNativeToolchainRequired: "false",
 			telegramGuard: "skipped",
 			telegramGuardRequired: "false",
 			telegramWindows: "skipped",
@@ -170,7 +172,8 @@ describe("dev-ci canonical-plan workflow contract", () => {
 				CI_DEV_EVIDENCE_ROOT: root, CI_DEV_AFFECTED_PLAN: path.join(root, ".ci-dev-affected-plan.json"), CI_DEV_PLAN_SOURCE_SHA: sourceSha,
 				CI_DEV_SOURCE_SHA: sourceSha, CI_DEV_PLAN_DIGEST: digest, CI_DEV_PLAN_MODE: "pr", GITHUB_REPOSITORY: "owner/repo", GITHUB_WORKFLOW: "Dev CI", GITHUB_RUN_ID: "42",
 				CI_DEV_PLAN_RESULT: baseAggregate.plan, CI_DEV_NATIVE_RESULT: baseAggregate.native, CI_DEV_SHARDS_RESULT: baseAggregate.shards, CI_DEV_WINDOWS_DOCTOR_RESULT: baseAggregate.windowsDoctor,
-				CI_DEV_WINDOWS_DOCTOR_REQUIRED: baseAggregate.windowsDoctorRequired, CI_DEV_HAS_NATIVE: baseAggregate.hasNative, CI_DEV_HAS_TASKS: baseAggregate.hasTasks,
+				CI_DEV_WINDOWS_DOCTOR_REQUIRED: baseAggregate.windowsDoctorRequired, CI_DEV_WINDOWS_NATIVE_TOOLCHAIN_RESULT: baseAggregate.windowsNativeToolchain,
+				CI_DEV_WINDOWS_NATIVE_TOOLCHAIN_REQUIRED: baseAggregate.windowsNativeToolchainRequired, CI_DEV_HAS_NATIVE: baseAggregate.hasNative, CI_DEV_HAS_TASKS: baseAggregate.hasTasks,
 				CI_DEV_PYTHON_RESULT: baseAggregate.python, CI_DEV_HAS_PYTHON: baseAggregate.hasPython,
 				CI_DEV_DARWIN_ARM64_TAB_WORKER_SMOKE_RESULT: baseAggregate.darwinArm64TabWorkerSmoke,
 				CI_DEV_DARWIN_ARM64_TAB_WORKER_SMOKE_REQUIRED: baseAggregate.darwinArm64TabWorkerSmokeRequired,
@@ -357,10 +360,10 @@ describe("dev-ci canonical-plan workflow contract", () => {
 
 	test("aggregate result truth table rejects every missing, failed, cancelled, and unplanned dependency", () => {
 		const valid: AffectedAggregateResults[] = [
-			{ plan: "success", native: "success", shards: "success", python: "success", windowsDoctor: "success", windowsDoctorRequired: "true", telegramGuard: "success", telegramGuardRequired: "true", telegramWindows: "success", telegramWindowsRequired: "true", hasNative: "true", hasTasks: "true", hasPython: "true", darwinArm64TabWorkerSmoke: "success", darwinArm64TabWorkerSmokeRequired: "true" },
-			{ plan: "success", native: "skipped", shards: "skipped", python: "skipped", windowsDoctor: "skipped", windowsDoctorRequired: "false", telegramGuard: "skipped", telegramGuardRequired: "false", telegramWindows: "skipped", telegramWindowsRequired: "false", hasNative: "false", hasTasks: "false", hasPython: "false", darwinArm64TabWorkerSmoke: "skipped", darwinArm64TabWorkerSmokeRequired: "false" },
-			{ plan: "success", native: "success", shards: "skipped", python: "skipped", windowsDoctor: "skipped", windowsDoctorRequired: "false", telegramGuard: "success", telegramGuardRequired: "true", telegramWindows: "success", telegramWindowsRequired: "true", hasNative: "true", hasTasks: "false", hasPython: "false", darwinArm64TabWorkerSmoke: "skipped", darwinArm64TabWorkerSmokeRequired: "false" },
-			{ plan: "success", native: "skipped", shards: "success", python: "skipped", windowsDoctor: "success", windowsDoctorRequired: "true", telegramGuard: "success", telegramGuardRequired: "true", telegramWindows: "success", telegramWindowsRequired: "true", hasNative: "false", hasTasks: "true", hasPython: "false", darwinArm64TabWorkerSmoke: "skipped", darwinArm64TabWorkerSmokeRequired: "false" },
+			{ plan: "success", native: "success", shards: "success", python: "success", windowsDoctor: "success", windowsDoctorRequired: "true", windowsNativeToolchain: "success", windowsNativeToolchainRequired: "true", telegramGuard: "success", telegramGuardRequired: "true", telegramWindows: "success", telegramWindowsRequired: "true", hasNative: "true", hasTasks: "true", hasPython: "true", darwinArm64TabWorkerSmoke: "success", darwinArm64TabWorkerSmokeRequired: "true" },
+			{ plan: "success", native: "skipped", shards: "skipped", python: "skipped", windowsDoctor: "skipped", windowsDoctorRequired: "false", windowsNativeToolchain: "skipped", windowsNativeToolchainRequired: "false", telegramGuard: "skipped", telegramGuardRequired: "false", telegramWindows: "skipped", telegramWindowsRequired: "false", hasNative: "false", hasTasks: "false", hasPython: "false", darwinArm64TabWorkerSmoke: "skipped", darwinArm64TabWorkerSmokeRequired: "false" },
+			{ plan: "success", native: "success", shards: "skipped", python: "skipped", windowsDoctor: "skipped", windowsDoctorRequired: "false", windowsNativeToolchain: "skipped", windowsNativeToolchainRequired: "false", telegramGuard: "success", telegramGuardRequired: "true", telegramWindows: "success", telegramWindowsRequired: "true", hasNative: "true", hasTasks: "false", hasPython: "false", darwinArm64TabWorkerSmoke: "skipped", darwinArm64TabWorkerSmokeRequired: "false" },
+			{ plan: "success", native: "skipped", shards: "success", python: "skipped", windowsDoctor: "success", windowsDoctorRequired: "true", windowsNativeToolchain: "success", windowsNativeToolchainRequired: "true", telegramGuard: "success", telegramGuardRequired: "true", telegramWindows: "success", telegramWindowsRequired: "true", hasNative: "false", hasTasks: "true", hasPython: "false", darwinArm64TabWorkerSmoke: "skipped", darwinArm64TabWorkerSmokeRequired: "false" },
 		];
 		for (const results of valid) expect(() => validateAffectedAggregate(results)).not.toThrow();
 
@@ -375,6 +378,9 @@ describe("dev-ci canonical-plan workflow contract", () => {
 			{ ...valid[0]!, windowsDoctor: "failure" },
 			{ ...valid[0]!, windowsDoctor: "cancelled" },
 			{ ...valid[0]!, windowsDoctor: "skipped" },
+			{ ...valid[0]!, windowsNativeToolchain: "failure" },
+			{ ...valid[0]!, windowsNativeToolchain: "cancelled" },
+			{ ...valid[0]!, windowsNativeToolchain: "skipped" },
 			{ ...valid[0]!, darwinArm64TabWorkerSmoke: "failure" },
 			{ ...valid[0]!, darwinArm64TabWorkerSmoke: "cancelled" },
 			{ ...valid[0]!, darwinArm64TabWorkerSmoke: "skipped" },
@@ -392,10 +398,13 @@ describe("dev-ci canonical-plan workflow contract", () => {
 			{ ...valid[1]!, telegramWindowsRequired: "" },
 			{ ...valid[1]!, telegramWindowsRequired: "maybe" },
 			{ ...valid[1]!, windowsDoctor: "success" },
+			{ ...valid[1]!, windowsNativeToolchain: "success" },
 			{ ...valid[1]!, telegramGuard: "success" },
 			{ ...valid[1]!, telegramWindows: "success" },
 			{ ...valid[1]!, windowsDoctorRequired: "" },
 			{ ...valid[1]!, windowsDoctorRequired: "maybe" },
+			{ ...valid[1]!, windowsNativeToolchainRequired: "" },
+			{ ...valid[1]!, windowsNativeToolchainRequired: "maybe" },
 			{ ...valid[1]!, hasNative: "" },
 			{ ...valid[1]!, hasTasks: "maybe" },
 			{ ...valid[1]!, hasPython: "maybe" },

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -1493,6 +1493,8 @@ export interface AffectedAggregateResults {
 	python: string;
 	windowsDoctor: string;
 	windowsDoctorRequired: string;
+	windowsNativeToolchain: string;
+	windowsNativeToolchainRequired: string;
 	telegramGuard: string;
 	telegramGuardRequired: string;
 	telegramWindows: string;
@@ -1514,6 +1516,8 @@ export function validateAffectedAggregate(results: AffectedAggregateResults): vo
 	if (results.python !== (results.hasPython === "true" ? "success" : "skipped")) throw new Error(results.hasPython === "true" ? "required Python matrix did not succeed" : "unplanned Python matrix was not skipped");
 	if (results.windowsDoctorRequired !== "true" && results.windowsDoctorRequired !== "false") throw new Error(`planner emitted invalid windows_doctor_required=${results.windowsDoctorRequired}`);
 	if (results.windowsDoctor !== (results.windowsDoctorRequired === "true" ? "success" : "skipped")) throw new Error(results.windowsDoctorRequired === "true" ? "required Windows dev:doctor did not succeed" : "unplanned Windows dev:doctor was not skipped");
+	if (results.windowsNativeToolchainRequired !== "true" && results.windowsNativeToolchainRequired !== "false") throw new Error(`planner emitted invalid windows_native_toolchain_required=${results.windowsNativeToolchainRequired}`);
+	if (results.windowsNativeToolchain !== (results.windowsNativeToolchainRequired === "true" ? "success" : "skipped")) throw new Error(results.windowsNativeToolchainRequired === "true" ? "required Windows native build toolchain check did not succeed" : "unplanned Windows native build toolchain check was not skipped");
 	if (results.darwinArm64TabWorkerSmokeRequired !== "true" && results.darwinArm64TabWorkerSmokeRequired !== "false") throw new Error(`planner emitted invalid darwin_arm64_tab_worker_smoke_required=${results.darwinArm64TabWorkerSmokeRequired}`);
 	if (results.darwinArm64TabWorkerSmoke !== (results.darwinArm64TabWorkerSmokeRequired === "true" ? "success" : "skipped")) throw new Error(results.darwinArm64TabWorkerSmokeRequired === "true" ? "required Darwin arm64 tab-worker smoke did not succeed" : "unplanned Darwin arm64 tab-worker smoke was not skipped");
 	if (results.telegramGuardRequired !== "true" && results.telegramGuardRequired !== "false") throw new Error(`planner emitted invalid telegram_guard_required=${results.telegramGuardRequired}`);
@@ -1530,6 +1534,8 @@ async function validateAggregate(): Promise<void> {
 		python: Bun.env.CI_DEV_PYTHON_RESULT?.trim() || "",
 		windowsDoctor: Bun.env.CI_DEV_WINDOWS_DOCTOR_RESULT?.trim() || "",
 		windowsDoctorRequired: Bun.env.CI_DEV_WINDOWS_DOCTOR_REQUIRED?.trim() || "",
+		windowsNativeToolchain: Bun.env.CI_DEV_WINDOWS_NATIVE_TOOLCHAIN_RESULT?.trim() || "",
+		windowsNativeToolchainRequired: Bun.env.CI_DEV_WINDOWS_NATIVE_TOOLCHAIN_REQUIRED?.trim() || "",
 		telegramGuard: Bun.env.CI_DEV_TELEGRAM_GUARD_RESULT?.trim() || "",
 		telegramGuardRequired: Bun.env.CI_DEV_TELEGRAM_GUARD_REQUIRED?.trim() || "",
 		telegramWindows: Bun.env.CI_DEV_TELEGRAM_WINDOWS_RESULT?.trim() || "",
@@ -1551,6 +1557,8 @@ async function validateAggregate(): Promise<void> {
 	console.log(`planned Python work: ${results.hasPython}`);
 	console.log(`windows-dev-doctor: ${results.windowsDoctor}`);
 	console.log(`planned Windows dev:doctor: ${results.windowsDoctorRequired}`);
+	console.log(`windows-native-build-toolchain: ${results.windowsNativeToolchain}`);
+	console.log(`planned Windows native build toolchain: ${results.windowsNativeToolchainRequired}`);
 	console.log(`darwin-arm64 tab-worker smoke: ${results.darwinArm64TabWorkerSmoke}`);
 	console.log(`planned Darwin arm64 tab-worker smoke: ${results.darwinArm64TabWorkerSmokeRequired}`);
 	console.log(`telegram-daemon-generation: ${results.telegramGuard}`);
@@ -1643,6 +1651,8 @@ function aggregateFromEnv(): AffectedAggregateResults {
 		python: requiredEnv("CI_DEV_PYTHON_RESULT"),
 		windowsDoctor: requiredEnv("CI_DEV_WINDOWS_DOCTOR_RESULT"),
 		windowsDoctorRequired: requiredEnv("CI_DEV_WINDOWS_DOCTOR_REQUIRED"),
+		windowsNativeToolchain: requiredEnv("CI_DEV_WINDOWS_NATIVE_TOOLCHAIN_RESULT"),
+		windowsNativeToolchainRequired: requiredEnv("CI_DEV_WINDOWS_NATIVE_TOOLCHAIN_REQUIRED"),
 		telegramGuard: requiredEnv("CI_DEV_TELEGRAM_GUARD_RESULT"),
 		telegramGuardRequired: requiredEnv("CI_DEV_TELEGRAM_GUARD_REQUIRED"),
 		telegramWindows: requiredEnv("CI_DEV_TELEGRAM_WINDOWS_RESULT"),
@@ -1665,6 +1675,8 @@ function parseAggregate(value: unknown): AffectedAggregateResults {
 			"windowsDoctor",
 			"python",
 			"windowsDoctorRequired",
+			"windowsNativeToolchain",
+			"windowsNativeToolchainRequired",
 			"telegramGuard",
 			"telegramGuardRequired",
 			"telegramWindows",
@@ -1685,6 +1697,8 @@ function parseAggregate(value: unknown): AffectedAggregateResults {
 		python: value.python as string,
 		windowsDoctor: value.windowsDoctor as string,
 		windowsDoctorRequired: value.windowsDoctorRequired as string,
+		windowsNativeToolchain: value.windowsNativeToolchain as string,
+		windowsNativeToolchainRequired: value.windowsNativeToolchainRequired as string,
 		telegramGuard: value.telegramGuard as string,
 		telegramGuardRequired: value.telegramGuardRequired as string,
 		telegramWindows: value.telegramWindows as string,


### PR DESCRIPTION
## Summary
- reworks closed PRs #3331/#3334 with review feedback addressed
- resolves Cargo through `rustup` discovered from PATH, `$CARGO_HOME/bin`, or the default `~/.cargo/bin` before invoking `napi build`
- keeps PATH `cargo` as the fallback after rustup resolution, matching the repo's `rust-toolchain.toml` authority
- adds real integration coverage for the common rustup-init layout where neither `rustup` nor `cargo` is on PATH but `CARGO_HOME/bin/rustup` exists
- adds Windows CI coverage for the native build toolchain path by running the native build-profile test and win32-x64 baseline native build on `windows-latest`

## Review feedback addressed
- #3331 was closed because it only recovered Homebrew/system rustup layouts, used only fabricated pure-helper tests, and had no Windows CI coverage.
- This version probes `$CARGO_HOME/bin/rustup` and `~/.cargo/bin/rustup`, exercises the actual `Bun.which` + `rustup which cargo` integration through a temporary fake CARGO_HOME rustup, and adds a Windows native-build workflow job for this path.
- #3334 exposed a Windows path expectation bug in the new tests; this branch uses platform-native expected paths before opening the PR.

## Verification
- `bun test packages/natives/test/build-native-profile.test.ts` — 13 pass
- `bunx biome check .github/workflows/dev-ci.yml packages/natives/CHANGELOG.md packages/natives/scripts/build-native.ts packages/natives/scripts/rust-toolchain-path.ts packages/natives/test/build-native-profile.test.ts` — OK
- `TOOLCHAIN_BIN="$(dirname "$(rustup which cargo)")"; PATH="$TOOLCHAIN_BIN:$PATH" bun test scripts/ci-dev-affected.test.ts` — 80 pass
- `PATH=/opt/homebrew/bin:/usr/bin:/bin bun run build` in `packages/natives` — pass
- missing rustup/cargo negative scenario with isolated `CARGO_HOME` — clear Cargo-not-found error

## Notes
- A direct `bun test scripts/ci-dev-affected.test.ts` fails in this local non-interactive shell because `cargo` is not on PATH; rerunning with the active rustup toolchain bin prepended passes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
