### PR TITLE
fix(ai): rename Codex reserved tool namespaces on the wire

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -133,6 +133,31 @@ const CODEX_WEBSOCKET_FATAL_PATTERNS = ["websocket error:", "websocket closed be
 /** Max total time to spend retrying 429s with server-provided delays (5 minutes). */
 const CODEX_RATE_LIMIT_BUDGET_MS = 5 * 60 * 1000;
 
+/**
+ * Tool names the Codex backend reserves for its own namespaces. Sending a
+ * function tool under one of these names is rejected with
+ * `Function 'computer.computer' not allowed in namespace 'computer'`.
+ * These are renamed on the wire and mapped back on receive so the internal
+ * tool name stays canonical everywhere else in the harness.
+ */
+const CODEX_RESERVED_TOOL_WIRE_NAMES: ReadonlyMap<string, string> = new Map([
+	["browser", "browser_tool"],
+	["computer", "computer_tool"],
+]);
+const CODEX_CANONICAL_TOOL_NAMES: ReadonlyMap<string, string> = new Map(
+	Array.from(CODEX_RESERVED_TOOL_WIRE_NAMES, ([canonical, wire]) => [wire, canonical]),
+);
+
+/** Maps a canonical tool name to the name Codex accepts on the wire. */
+export function codexToolWireName(name: string): string {
+	return CODEX_RESERVED_TOOL_WIRE_NAMES.get(name) ?? name;
+}
+
+/** Maps a Codex wire tool name back to the canonical harness tool name. */
+export function codexToolCanonicalName(wireName: string): string {
+	return CODEX_CANONICAL_TOOL_NAMES.get(wireName) ?? wireName;
+}
+
 const CODEX_PROGRESS_EVENT_TYPES = new Set([
 	"response.created",
 	"response.output_item.added",
@@ -477,7 +502,7 @@ export function normalizeCodexToolChoice(
 			: undefined;
 		return customTool
 			? { type: "custom", name: customTool.customWireName ?? customTool.name }
-			: { type: "function", name };
+			: { type: "function", name: codexToolWireName(name) };
 	};
 	if (choice.type === "function") {
 		if ("function" in choice && choice.function?.name) {
@@ -1100,7 +1125,7 @@ function createOutputBlockForItem(item: CodexEventItem): CodexOutputBlock | null
 		return {
 			type: "toolCall",
 			id: encodeResponsesToolCallId(item.call_id, item.id),
-			name: item.name,
+			name: codexToolCanonicalName(item.name),
 			arguments: {},
 			partialJson: item.arguments || "",
 		};
@@ -1358,7 +1383,7 @@ function handleOutputItemDone(
 		const toolCall: ToolCall = {
 			type: "toolCall",
 			id,
-			name: item.name,
+			name: codexToolCanonicalName(item.name),
 			arguments: parseStreamingJson(item.arguments || "{}"),
 		};
 		runtime.canSafelyReplayWebsocketOverSse = false;
@@ -2700,6 +2725,13 @@ function convertMessages(model: Model<"openai-codex-responses">, context: Contex
 				true,
 				customCallIds,
 			);
+			for (const item of outputItems) {
+				// Reconstructed (non-raw) history carries canonical tool names; the
+				// wire form has to match the renamed `tools` entries.
+				if (item.type === "function_call" && typeof item.name === "string") {
+					item.name = codexToolWireName(item.name);
+				}
+			}
 			if (outputItems.length > 0) {
 				messages.push(...outputItems);
 			}
@@ -2786,7 +2818,7 @@ export function convertOpenAICodexResponsesTools(
 		const { schema: parameters, strict: effectiveStrict } = adaptSchemaForStrict(baseParameters, strict);
 		return {
 			type: "function",
-			name: tool.name,
+			name: codexToolWireName(tool.name),
 			description: tool.description || "",
 			parameters,
 			...(effectiveStrict && { strict: true }),

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -276,6 +276,50 @@ describe("openai-codex streaming", () => {
 		]);
 	});
 
+	it("maps reserved tool wire names back to canonical tool names", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+		const token = createCodexTestToken();
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: {
+					type: "function_call",
+					id: "fc_1",
+					call_id: "call_1",
+					name: "computer_tool",
+					arguments: "",
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.function_call_arguments.done",
+				item_id: "fc_1",
+				arguments: '{"action":"screenshot"}',
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "function_call",
+					id: "fc_1",
+					call_id: "call_1",
+					name: "computer_tool",
+					arguments: '{"action":"screenshot"}',
+				},
+			})}`,
+			`data: ${JSON.stringify({ type: "response.completed", response: { status: "completed" } })}`,
+		].join("\n\n")}\n\n`;
+		global.fetch = vi.fn(
+			async () => new Response(sse, { status: 200, headers: { "content-type": "text/event-stream" } }),
+		) as unknown as typeof fetch;
+
+		const model = { ...createCodexTestModel("https://chatgpt.com/backend-api"), preferWebsockets: false };
+		const result = await streamOpenAICodexResponses(model, createCodexTestContext(), { apiKey: token }).result();
+
+		const toolCalls = result.content.filter(block => block.type === "toolCall");
+		expect(toolCalls).toHaveLength(1);
+		expect(toolCalls[0]).toMatchObject({ name: "computer", arguments: { action: "screenshot" } });
+	});
+
 	it.each([
 		[false, 2],
 		[true, 1],

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { type RequestBody, transformRequestBody } from "@gajae-code/ai/providers/openai-codex/request-transformer";
 import { parseCodexError } from "@gajae-code/ai/providers/openai-codex/response-handler";
-import { convertOpenAICodexResponsesTools } from "@gajae-code/ai/providers/openai-codex-responses";
+import {
+	codexToolCanonicalName,
+	codexToolWireName,
+	convertOpenAICodexResponsesTools,
+	normalizeCodexToolChoice,
+} from "@gajae-code/ai/providers/openai-codex-responses";
 import type { Tool } from "@gajae-code/ai/types";
 import { createCodexModel } from "./helpers";
 
@@ -26,6 +31,41 @@ describe("openai-codex tool schemas", () => {
 			description: "List outgoing messages",
 			parameters: { type: "object", properties: {} },
 		});
+	});
+});
+
+describe("openai-codex reserved tool namespaces", () => {
+	const reservedTools: Tool[] = [
+		{ name: "browser", description: "Control a browser", parameters: { type: "object", properties: {} } },
+		{ name: "computer", description: "Control the desktop", parameters: { type: "object", properties: {} } },
+		{ name: "read_file", description: "Read a file", parameters: { type: "object", properties: {} } },
+	];
+
+	it("renames reserved tool names on the wire and leaves others untouched", () => {
+		const converted = convertOpenAICodexResponsesTools(reservedTools, createCodexModel("gpt-5.1-codex"));
+
+		expect(converted.map(tool => tool.name)).toEqual(["browser_tool", "computer_tool", "read_file"]);
+		expect(converted.every(tool => tool.type === "function")).toBe(true);
+	});
+
+	it("renames reserved names in pinned tool choices", () => {
+		const model = createCodexModel("gpt-5.1-codex");
+
+		expect(normalizeCodexToolChoice({ type: "tool", name: "computer" }, reservedTools, model)).toEqual({
+			type: "function",
+			name: "computer_tool",
+		});
+		expect(normalizeCodexToolChoice({ type: "tool", name: "read_file" }, reservedTools, model)).toEqual({
+			type: "function",
+			name: "read_file",
+		});
+	});
+
+	it("maps wire names back to canonical names", () => {
+		expect(codexToolCanonicalName("browser_tool")).toBe("browser");
+		expect(codexToolCanonicalName("computer_tool")).toBe("computer");
+		expect(codexToolCanonicalName("read_file")).toBe("read_file");
+		expect(codexToolWireName("read_file")).toBe("read_file");
 	});
 });
 

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -1221,3 +1221,90 @@ describe("OpenAI responses history payload", () => {
 		expect(note?.content).toContain(orphanOutput);
 	});
 });
+
+describe("codex reserved tool namespace history replay", () => {
+	const model = getBundledModel("openai-codex", "gpt-5.2-codex") as Model<"openai-codex-responses">;
+
+	it("keeps raw provider payload tool names untouched", async () => {
+		const payload = (await captureCodexPayload(model, {
+			messages: [
+				{ role: "user", content: "prior question", timestamp: Date.now() },
+				makeAssistantMessage(
+					[
+						{
+							type: "function_call",
+							id: "fc_replay",
+							call_id: "call_replay",
+							name: "computer_tool",
+							arguments: '{"action":"screenshot"}',
+						},
+					],
+					false,
+					"openai-codex",
+					"gpt-5.2-codex",
+				),
+				{
+					role: "toolResult",
+					toolCallId: "call_replay",
+					toolName: "computer",
+					content: [{ type: "text", text: "ok" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+				{ role: "user", content: "follow-up user", timestamp: Date.now() },
+			],
+		})) as { input?: Array<Record<string, unknown>> };
+
+		const call = payload.input?.find(item => item.type === "function_call");
+		expect(call?.name).toBe("computer_tool");
+	});
+
+	it("renames canonical tool names when rebuilding assistant history", async () => {
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			model: "gpt-5.2-codex",
+			stopReason: "toolUse",
+			content: [
+				{ type: "toolCall", id: "call_live", name: "computer", arguments: { action: "screenshot" } },
+				{ type: "toolCall", id: "call_read", name: "read_file", arguments: { path: "a.ts" } },
+			],
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+		const payload = (await captureCodexPayload(model, {
+			messages: [
+				{ role: "user", content: "question", timestamp: Date.now() },
+				assistant,
+				{
+					role: "toolResult",
+					toolCallId: "call_live",
+					toolName: "computer",
+					content: [{ type: "text", text: "ok" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+				{
+					role: "toolResult",
+					toolCallId: "call_read",
+					toolName: "read_file",
+					content: [{ type: "text", text: "ok" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+				{ role: "user", content: "follow-up user", timestamp: Date.now() },
+			],
+		})) as { input?: Array<Record<string, unknown>> };
+
+		const callNames = (payload.input ?? []).filter(item => item.type === "function_call").map(item => item.name);
+		expect(callNames).toEqual(["computer_tool", "read_file"]);
+	});
+});

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -21,6 +21,7 @@ import {
 	type ToolResultMessage,
 } from "@gajae-code/ai";
 import {
+	codexToolWireName,
 	getOpenAICodexTransportDetails,
 	prewarmOpenAICodexResponses,
 } from "@gajae-code/ai/providers/openai-codex-responses";
@@ -2188,7 +2189,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				const previousPromptMetadataModel = promptMetadataModel;
 				promptMetadataModel = candidateModel;
 				try {
-					return buildSystemPromptToolMetadata(tools);
+					const activeModel = candidateModel ?? agent?.state.model ?? model;
+					// Codex renames reserved tool names on the wire; the prompt must
+					// refer to the tools by the names the model actually receives.
+					const overrides =
+						activeModel?.api === "openai-codex-responses"
+							? Object.fromEntries(
+									Array.from(tools.keys())
+										.filter(name => codexToolWireName(name) !== name)
+										.map(name => [name, { wireName: codexToolWireName(name) }]),
+								)
+							: {};
+					return buildSystemPromptToolMetadata(tools, overrides);
 				} finally {
 					promptMetadataModel = previousPromptMetadataModel;
 				}


### PR DESCRIPTION
## Problem

Codex sessions with the `browser` or `computer` tool active fail the request outright:

```
Error: Codex error event: Invalid Value: 'tools'. Function 'computer.computer' not allowed in namespace 'computer'. (code=invalid_request_error)
```

The Codex backend reserves `browser` and `computer` as tool *namespaces* (`computer` is protocol-level — the Responses API defines a separate `computer_call` output-item type, see `sanitizeComputerCallForResponsesInput` in `packages/ai/src/utils.ts`). A plain function tool named `computer` collides with that namespace and the whole turn is rejected.

`Tool.customWireName` can't fix this: `convertOpenAICodexResponsesTools` only reads it on the `tool.customFormat` (freeform grammar) branch. `browser`/`computer` are ordinary zod-schema function tools, so setting `customWireName` has no effect — and forcing them onto the custom-tool path would swap JSON schema validation for freeform `{input: string}`.

## Fix

Rename at the codex provider boundary only, with a reverse mapping on receive so the internal name never changes.

Send (canonical → wire):
- `convertOpenAICodexResponsesTools` — the `tools` array
- `normalizeCodexToolChoice` — pinned `tool_choice` (missing this would leave a partial bug where only forced calls fail)
- `convertMessages` — history rebuilt from canonical `AssistantMessage.content`

Receive (wire → canonical):
- `createOutputBlockForItem` and `handleOutputItemDone` `function_call` branches

`ToolCall.name` therefore stays `browser`/`computer` everywhere else — the agent-loop dispatcher (`tools?.find(t => t.name === toolCall.name)`), tool results, and history reuse after a provider switch all work unchanged.

Raw `providerPayload` replay is deliberately untouched: it already carries whatever Codex actually returned, and `sanitizeOpenAIResponsesHistoryItemForReplay` normalizes only `id`/`call_id`. No migration needed.

The shared `openai-responses-shared.ts` converter is left alone so the plain `openai-responses` path keeps sending unrenamed names.

The system prompt renders the same wire names for codex sessions via existing `buildSystemPromptToolMetadata` overrides, so prompt text matches what the model receives.

## Tests

- `packages/ai/test/openai-codex.test.ts` — reserved names renamed, non-reserved (`read_file`) untouched, in both `tools` and `tool_choice`; canonical round-trip
- `packages/ai/test/openai-codex-stream.test.ts` — SSE `function_call` with wire name `computer_tool` surfaces as `ToolCall.name === "computer"`
- `packages/ai/test/openai-responses-history-payload.test.ts` — raw `providerPayload` replay preserves the name verbatim; canonical rebuild renames `computer` but not `read_file`

Both new history tests were mutation-verified (the rename assertion fails when the send-side mapping is removed).

`bun test packages/ai/test/` shows no new failures; the 16 pre-existing `strict`-related failures reproduce identically on the base commit.