### PR TITLE
fix(coding-agent): fence notification WebSocket fixture startup

### DIFF
--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -12,6 +12,7 @@ import { TelegramDaemonController } from "../src/sdk/bus/telegram-daemon-control
 import { readEndpoint } from "../src/sdk/bus/telegram-reference";
 import { renderThreadedFrame } from "../src/sdk/bus/threaded-render";
 import {
+	cleanupFixtureRoot,
 	cleanupFixtureRoots,
 	createNotificationFixtureRoot,
 	type FixtureRootCleanup,
@@ -69,7 +70,7 @@ async function waitFor(pred: () => boolean, ms = 4000, label = "condition"): Pro
 }
 
 type Handler = (event: unknown, ctx: unknown) => unknown;
-type Frame = { type: string; phase?: string; text?: string; messageRef?: string };
+type Frame = { type: string; connectionId?: string; phase?: string; text?: string; messageRef?: string };
 
 const cleanupRoots: FixtureRootCleanup[] = [];
 const openSockets: WebSocket[] = [];
@@ -100,6 +101,49 @@ function setEnv(over: Partial<Record<(typeof envKeys)[number], string>>): void {
 	for (const k of envKeys) delete process.env[k];
 	for (const [k, v] of Object.entries(over)) process.env[k] = v;
 }
+class FixtureEndpointNotReadyError extends Error {
+	constructor() {
+		super("fixture endpoint closed before SDK hello");
+		this.name = "FixtureEndpointNotReadyError";
+	}
+}
+
+async function abandonEndpointGeneration(abandon: () => Promise<void>, failure: unknown): Promise<void> {
+	try {
+		await abandon();
+	} catch (cleanupError) {
+		throw new AggregateError(
+			[failure, cleanupError],
+			"Fixture endpoint generation failed before readiness and cleanup also failed.",
+		);
+	}
+}
+
+async function replaceAbandonedEndpoint<T>(
+	abandon: () => Promise<void>,
+	startReplacement: () => Promise<T>,
+	failure: unknown,
+): Promise<T> {
+	await abandonEndpointGeneration(abandon, failure);
+	return startReplacement();
+}
+
+test("abandons a premature endpoint generation before handing out its replacement", async () => {
+	const events = ["start:1"];
+	const generation = await replaceAbandonedEndpoint(
+		async () => {
+			events.push("abandon:1");
+		},
+		async () => {
+			events.push("start:2");
+			return 2;
+		},
+		new FixtureEndpointNotReadyError(),
+	);
+
+	expect(generation).toBe(2);
+	expect(events).toEqual(["start:1", "abandon:1", "start:2"]);
+});
 
 async function bootSession(
 	settingsOverrides: Record<string, unknown> = {},
@@ -110,6 +154,7 @@ async function bootSession(
 			sessionId: string;
 		}) => Promise<EnsureDaemonResult>;
 	} = {},
+	replacePrematureEndpoint = true,
 ): Promise<{
 	handlers: Map<string, Handler>;
 	ctx: NotificationSessionContext;
@@ -178,12 +223,41 @@ async function bootSession(
 	const frames: Frame[] = [];
 	const ws = new WebSocket(`${url}/?token=${encodeURIComponent(token)}`);
 	openSockets.push(ws);
-	ws.addEventListener("message", ev => frames.push(JSON.parse(String((ev as MessageEvent).data))));
-	await new Promise<void>((resolve, reject) => {
-		ws.addEventListener("open", () => resolve());
-		ws.addEventListener("error", () => reject(new Error("ws error")));
+	const ready = Promise.withResolvers<void>();
+	let readySettled = false;
+	const rejectBeforeHello = (): void => {
+		if (readySettled) return;
+		readySettled = true;
+		ready.reject(new FixtureEndpointNotReadyError());
+	};
+	ws.addEventListener("message", event => {
+		const frame = JSON.parse(String((event as MessageEvent).data)) as Frame;
+		frames.push(frame);
+		if (readySettled || frame.type !== "hello" || !frame.connectionId) return;
+		readySettled = true;
+		ready.resolve();
 	});
-	await sleep(250);
+	ws.addEventListener("error", rejectBeforeHello);
+	ws.addEventListener("close", rejectBeforeHello);
+	try {
+		await ready.promise;
+	} catch (error) {
+		const socketIndex = openSockets.indexOf(ws);
+		if (socketIndex >= 0) openSockets.splice(socketIndex, 1);
+		try {
+			ws.close();
+		} catch {}
+		const abandon = async (): Promise<void> => {
+			await cleanupFixtureRoot(cleanup);
+			const cleanupIndex = cleanupRoots.indexOf(cleanup);
+			if (cleanupIndex >= 0) cleanupRoots.splice(cleanupIndex, 1);
+		};
+		if (!(error instanceof FixtureEndpointNotReadyError) || !replacePrematureEndpoint) {
+			await abandonEndpointGeneration(abandon, error);
+			throw error;
+		}
+		return replaceAbandonedEndpoint(abandon, () => bootSession(settingsOverrides, options, false), error);
+	}
 	return { handlers, ctx, frames, settings, controller };
 }
 


### PR DESCRIPTION
## Summary

- Repair the notification live-stream fixture implicated by Dev CI run 30309767471.
- Treat the authenticated SDK `hello` frame, not endpoint-file existence or WebSocket `open`, as connect readiness.
- On a pre-hello `error`/`close`, close the client and deterministically release the exact fixture runtime, broker lease, and root before starting one replacement generation.
- Add a structural, clock-free regression proving abandonment completes before replacement startup.
- Production notification runtime semantics are unchanged; this is a hermetic TypeScript fixture ownership repair with no generic retry loop or timeout increase.

Run: https://github.com/Yeachan-Heo/gajae-code/actions/runs/30309767471

## Evidence

### Before

`bun test packages/coding-agent/test/notifications-live-stream.test.ts --test-name-pattern "abandons a premature endpoint generation"`

- 0 pass, 1 fail
- `FixtureEndpointNotReadyError: fixture endpoint closed before SDK hello`

### After

- Focused file: 3 consecutive final runs, each `20 pass / 0 fail` (`60/60` total).
- `bun --cwd=packages/coding-agent run check:types` — pass.
- `bun --cwd=packages/coding-agent run check` — pass (`biome check` + TypeScript).
- `bun --cwd=packages/coding-agent run build` — pass.
- `bun --cwd=packages/coding-agent test --shard=4/8` — notification live-stream coverage passed inside the shard; the shard remained red on 9 pre-existing `agent-session-openai-responses-replay.test.ts` timeout/state assertions plus an unrelated `/tmp` EACCES cleanup error. No notification WebSocket failure occurred.

Evidence attested by GJC, sole repair owner, for commit `c99728c1f`.