### PR TITLE
fix(ralplan): stop infinite consensus loops with reviewer ratchet + per-lane review budget

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Deterministic tests for session_switch await policy (selector defer vs default/branch await), control-drain ordering, host pre-response readiness gating, and resume progress lease-before-switch behavior (#2914).
 - Telegram per-tool activity is now opt-in and remains durably controllable with `/toolactivity on|off` or the Notifications preferences UI; disabling it suppresses tool start/completion success and error bubbles without hiding assistant, ask, or session notifications.
 - `/model`, `/login`, and `/provider` now order providers through one shared ranking: providers you already have (valid auth, in-flight validation, or a configured non-OAuth provider) come first, then providers whose stored credentials failed validation, then a curated list of well-known providers with regional and device variants grouped behind their primary, then everything else by display name. In `/model` rows, role/default rank and recent usage still take precedence over provider order (#3243).
+- Ralplan now bounds architect and critic re-review lanes independently through `gjc.ralplan.maxReviewPassesPerLane` (integer 1–10; default 1). Per-lane budget exhaustion emits a lane-specific `PLANNING-STUCK` exit 3, fails closed against on-disk artifact floors, and repairs crash-gap retries. Architect and critic `gjc ralplan --write` calls can optionally pass `--lane-verdict`, which drives HUD lane pass counts and the latest verdict; critic/architect prompts and the ralplan SKILL workflow now ratchet re-reviews through persisted receipts.
 
 ## [0.11.11] - 2026-07-26
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -506,6 +506,11 @@ export const SETTINGS_SCHEMA = {
 		default: 5,
 		validate: (value: number) => Number.isInteger(value) && value >= 1 && value <= 20,
 	},
+	"gjc.ralplan.maxReviewPassesPerLane": {
+		type: "number",
+		default: 1,
+		validate: (value: number) => Number.isInteger(value) && value >= 1 && value <= 10,
+	},
 
 	// ────────────────────────────────────────────────────────────────────────
 	// Appearance

--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -63,14 +63,25 @@ The consensus workflow:
    - Deliberate mode only: pre-mortem (3 scenarios) + expanded test plan (unit/integration/e2e/observability)
 2. **User feedback** *(--interactive only)*: If `--interactive` is set, use the `ask` tool to present the draft plan **plus the Principles / Drivers / Options summary** before review (Proceed to review / Request changes / Skip review). Otherwise, automatically proceed to review.
 3. **Review fan-out after Planner persistence**: launch fresh Architect and Critic review lanes against the same immutable Planner receipt/path/sha/stage_n when Critic is **plan-only** and does not consume Architect output.
-   - **Architect lane**: challenge architecture, surface tradeoff tensions, and enrich thin plans with synthesis or missed sub-scope. Persist with `gjc ralplan --write --stage architect --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --json`, then return receipt/path plus `CLEAR`/`WATCH`/`BLOCK` and `APPROVE`/`COMMENT`/`REQUEST CHANGES`.
-   - **Plan-only Critic lane**: independently check quality, principle-option consistency, alternatives, risks, acceptance criteria, and verification; when the plan is thin, request concrete expansion rather than only defects. Persist with `gjc ralplan --write --stage critic --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --json`, then return receipt/path plus `OKAY`/`ITERATE`/`REJECT`.
+   - **Architect lane**: challenge architecture, surface tradeoff tensions, and enrich thin plans with synthesis or missed sub-scope. Persist with `gjc ralplan --write --stage architect --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --lane-verdict <token> --json`, then return receipt/path plus `CLEAR`/`WATCH`/`BLOCK` and `APPROVE`/`COMMENT`/`REQUEST CHANGES`.
+   - **Plan-only Critic lane**: independently check quality, principle-option consistency, alternatives, risks, acceptance criteria, and verification; when the plan is thin, request concrete expansion rather than only defects. Persist with `gjc ralplan --write --stage critic --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --lane-verdict <token> --json`, then return receipt/path plus `OKAY`/`ITERATE`/`REJECT`.
    - **Sequential fallback**: if Critic must evaluate Architect findings, verdict, antithesis, tradeoffs, synthesis, status, or any Architect-produced artifact, await the Architect result before issuing that Architect-dependent Critic pass.
+   - Every Architect/Critic assignment, including each pass-2+ re-review assignment in step 5, MUST instruct the reviewer to include `--lane-verdict <token>` on its existing `gjc ralplan --write`: Architect passes its Architectural Status token (`CLEAR`/`WATCH`/`BLOCK`), and Critic passes its verdict token (`OKAY`/`ITERATE`/`REJECT`). The flag is optional so legacy invocations stay valid.
 4. **Review join gate**: before consensus, revision, reconciliation, finalization, or approval, verify both Architect and Critic receipts/verdicts exist for the same Planner artifact/pass (`path`, `sha256`, `stage_n`). A non-`CLEAR` Architect verdict, non-`APPROVE` Architect decision, or any non-`OKAY` Critic verdict routes back to Planner revision; do not finalize from only one review lane.
-5. **Re-review loop** (max 5 iterations; **runtime-enforced**): Any non-`OKAY` Critic verdict (`ITERATE` or `REJECT`) or Architect result that is not `CLEAR`/`APPROVE` MUST run the same full closed loop:
+5. **Re-review loop** (max 5 iterations; **runtime-enforced**): Any non-`OKAY` Critic verdict (`ITERATE` or `REJECT`) or Architect result that is not `CLEAR`/`APPROVE` MUST run the same full closed loop. Pass 2+ runs sequentially Architect -> Critic: await the Architect result and its receipt/path before assigning Critic; Critic receives the current-pass Architect receipt/path and performs the rule-5 counter-review before consolidated feedback routes to Planner revision. From pass 2, both reviewers are bound by the five-rule ratchet: delta-only review, novelty justification, verdict monotonicity, severity scoping, and Critic counter-review of Architect scope inflation; unjustified inflation does not force a revision.
    a. Collect Architect + Critic feedback
    b. Revise the plan by resuming the SAME persisted Planner subagent with consolidated Architect + Critic feedback (see **Persisted Planner** below); fall back to a fresh Planner spawn only per the fallback routing table
-   c. Return to the review fan-out or sequential fallback path above
+
+   **Re-review context bundle (pass 2+; mandatory):** Every pass-2+ Architect or Critic assignment MUST include:
+   1. the explicit review pass number `N` for that lane, stated literally as `review pass N` in the assignment text, where **N is the ordinal review pass for that lane across the entire ralplan run/re-review loop** (equivalently the opener-iteration ordinal): the review of the initial Planner artifact is `review pass 1`, the review of the first revised Planner artifact is `review pass 2`, and so on; **N never resets within an opener iteration and never resets when a new `revision` opener begins in the same run** — it increments monotonically with every review the lane performs in the run. This ordinal is a workflow counter distinct from the runtime lane budget (which counts lane writes per opener iteration, WI-5): at the default budget the two coincide numerically, but the ratchet ("from pass 2") always keys off the run-level N so normal post-revision re-reviews activate delta-only review, monotonicity, and the sequential cadence;
+   2. the current revision receipt under review (`path`, `sha256`, `stage_n`);
+   3. the prior Planner/revision artifact path that the previous pass reviewed;
+   4. the prior same-lane review artifact path (`stage-NN-architect.md` / `stage-NN-critic.md`) with its receipt fields;
+   5. the consolidated prior blockers and the revision's claimed resolutions, as orchestrator-collected pointers into those artifacts (never pasted bodies);
+   6. Critic pass-2+ only: the current-pass Architect receipt/path, awaited first per the sequential cadence, so the rule-5 counter-review is evaluable.
+
+   Fresh spawns always receive everything required to apply delta-only review (rule 1), novelty justification (rule 2), monotonicity (rule 3), severity scoping (rule 4), and counter-review (rule 5).
+   c. For pass 2+, run Architect -> Critic sequentially: await the Architect result and receipt/path, then issue Critic with the mandatory context bundle, including the current-pass Architect receipt/path. Critic performs the rule-5 counter-review before consolidated feedback routes to Planner revision.
       - Persist each Planner revision with `gjc ralplan --write --stage revision --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --json` before re-review, then pass the receipt/path forward instead of duplicating the full revision markdown in the parent conversation.
    d. Re-join Architect and Critic verdicts for the same revised Planner artifact/pass
    e. Repeat this loop until Critic returns `OKAY` **and** Architect is `CLEAR`/`APPROVE` for the same Planner artifact/pass, or 5 iterations are reached
@@ -102,7 +113,7 @@ The consensus workflow:
 
    The skill tool then dispatches the execution skill same-turn and runs `gjc state ralplan handoff --to <team|ultragoal> --json` in-process to atomically demote ralplan, promote the callee, and sync `.gjc/_session-{sessionid}/state/skill-active-state.json`. You do not need to run the handoff verb yourself.
 
-> **Important:** Architect and Critic MAY run in the same parallel batch only for the plan-only Critic lane after Planner persistence. Any Architect-dependent Critic pass MUST remain sequential: await Architect before issuing Critic, then apply the same review join gate before consensus.
+> **Important:** Architect and Critic MAY run in the same parallel batch only for the plan-only Critic lane after Planner persistence (review pass 1). Pass 2+ re-reviews MUST run sequentially Architect -> Critic: await Architect before issuing Critic, pass the current-pass Architect receipt/path to Critic for the rule-5 counter-review, then apply the same review join gate before consensus.
 
 ## Consensus iteration cap (operator contract)
 
@@ -117,6 +128,28 @@ The consensus workflow:
   "gjc": {
     "ralplan": {
       "maxIterations": 3
+    }
+  }
+}
+```
+
+## Per-lane review budget (operator contract)
+
+- Default: **1** Architect pass and **1** Critic pass per opener iteration.
+- Override via `gjc.ralplan.maxReviewPassesPerLane`: project `.gjc/settings.json` overrides user settings; the value is an integer **1..10** registered in the public settings schema.
+- On overflow: exit code **3** with the **`PLANNING-STUCK`** marker and lane-specific JSON/stderr detail.
+- `post-interview`, `adr`, and `final` are always allowed.
+- Identical re-writes dedupe without stuck-signaling — including after a crash between artifact write and ledger append: the identical retry repairs the missing ledger row and returns the dedupe receipt.
+- A new `--run-id` starts a fresh budget.
+- A rule-2-justified blocker routes through a Planner `revision` opener (new iteration, fresh lane budget), never a second same-iteration review pass.
+- Override example (project `.gjc/settings.json`):
+
+```json
+{
+  "gjc": {
+    "ralplan": {
+      "maxIterations": 3,
+      "maxReviewPassesPerLane": 2
     }
   }
 }

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -50,7 +50,7 @@ import { getSkillManifest } from "./workflow-manifest";
  *
  * 2. **Artifact write**: `gjc ralplan --write --stage <type> --stage_n <N>
  *    (--artifact <path-or-string> | --artifact-env GJC_RALPLAN_ARTIFACT)
- *    [--run-id <id>] [--session-id <id>] [--json]` persists Planner / Architect
+ *    [--run-id <id>] [--session-id <id>] [--lane-verdict <token>] [--json]` persists Planner / Architect
  *    / Critic / revision / post-interview / ADR / final markdown under `.gjc/plans/ralplan/<run-id>/`, maintains
  *    an `index.jsonl` audit log, copies `final` stages to `pending-approval.md`, and advances
  *    the HUD chip to reflect the latest persisted stage.
@@ -70,8 +70,25 @@ export const RALPLAN_DEFAULT_MAX_ITERATIONS = 5;
 export const RALPLAN_MAX_ITERATIONS_LIMIT = 20;
 /** Operator-visible stuck signal for headless/CI orchestration (#3165). */
 export const PLANNING_STUCK_MARKER = "PLANNING-STUCK";
+/** Default architect/critic review passes per consensus iteration. */
+export const RALPLAN_DEFAULT_MAX_REVIEW_PASSES_PER_LANE = 1;
+/** Inclusive upper bound for `gjc.ralplan.maxReviewPassesPerLane` settings overrides. */
+export const RALPLAN_MAX_REVIEW_PASSES_PER_LANE_LIMIT = 10;
 
 const RALPLAN_ITERATION_OPENER_STAGES = new Set<RalplanStage>(["planner", "revision"]);
+
+/** Collapse duplicate ledger rows for the same deterministic stage artifact before review-lane budget accounting. */
+function deduplicateRalplanIndexRowsByStageIdentity(rows: readonly RalplanIndexRow[]): RalplanIndexRow[] {
+	const seen = new Set<string>();
+	return rows.filter(row => {
+		if (typeof row.stageN !== "number") return true;
+		const identity = `${row.stage}\u0000${row.stageN}`;
+		if (seen.has(identity)) return false;
+		seen.add(identity);
+		return true;
+	});
+}
+
 
 export type RalplanIterationCapDecision =
 	| {
@@ -147,8 +164,108 @@ export function evaluateRalplanIterationCap(input: {
 	};
 }
 
+export type RalplanReviewLane = "architect" | "critic";
+
+export type RalplanReviewLaneBudgetDecision =
+	| {
+			allowed: true;
+			lane?: RalplanReviewLane;
+			currentPasses: number;
+			projectedPasses: number;
+			maxReviewPassesPerLane: number;
+			finalSlot: boolean;
+			ledgerNote?: string;
+	  }
+	| {
+			allowed: false;
+			lane: RalplanReviewLane;
+			currentPasses: number;
+			projectedPasses: number;
+			maxReviewPassesPerLane: number;
+			finalSlot: false;
+			ledgerNote?: string;
+			reason: string;
+	  };
+
+/**
+ * Pure per-lane review-pass budget gate. Architect and critic passes are limited
+ * within the current consensus iteration; all other stages remain unconditionally
+ * available as escalation paths.
+ */
+export function evaluateRalplanReviewLaneBudget(input: {
+	rows: readonly RalplanIndexRow[];
+	stage: string;
+	maxReviewPassesPerLane?: unknown;
+	onDiskLaneCounts?: { architect: number; critic: number };
+}): RalplanReviewLaneBudgetDecision {
+	const maxReviewPassesPerLane =
+		typeof input.maxReviewPassesPerLane === "number" &&
+		Number.isInteger(input.maxReviewPassesPerLane) &&
+		input.maxReviewPassesPerLane >= 1 &&
+		input.maxReviewPassesPerLane <= RALPLAN_MAX_REVIEW_PASSES_PER_LANE_LIMIT
+			? input.maxReviewPassesPerLane
+			: RALPLAN_DEFAULT_MAX_REVIEW_PASSES_PER_LANE;
+	if (input.stage !== "architect" && input.stage !== "critic") {
+		return {
+			allowed: true,
+			currentPasses: 0,
+			projectedPasses: 0,
+			maxReviewPassesPerLane,
+			finalSlot: false,
+		};
+	}
+
+	const lane = input.stage as RalplanReviewLane;
+	const rows = deduplicateRalplanIndexRowsByStageIdentity(input.rows);
+	const summary = summarizeRalplanIndex(rows);
+	const indexCurrent = summary.currentStages.filter(stage => stage === lane).length;
+	const parsedTotal = rows.filter(row => row.stage === lane).length;
+	const onDiskRaw = input.onDiskLaneCounts?.[lane];
+	const onDiskTotal =
+		typeof onDiskRaw === "number" && Number.isInteger(onDiskRaw) && onDiskRaw > 0 ? onDiskRaw : 0;
+	const diskExcess = Math.max(0, onDiskTotal - parsedTotal);
+	const currentPasses = indexCurrent + diskExcess;
+	const projectedPasses = currentPasses + 1;
+	const ledgerNote =
+		diskExcess > 0
+			? ` (ledger under-count: parsed ${lane} rows=${parsedTotal}, on-disk ${lane} artifacts=${onDiskTotal})`
+			: undefined;
+	const finalSlot = projectedPasses === maxReviewPassesPerLane;
+	if (projectedPasses > maxReviewPassesPerLane) {
+		return {
+			allowed: false,
+			lane,
+			currentPasses,
+			projectedPasses,
+			maxReviewPassesPerLane,
+			finalSlot: false,
+			ledgerNote,
+			reason:
+				`ralplan review lane budget exceeded: ${lane} pass ${projectedPasses} of max ${maxReviewPassesPerLane} ` +
+				`in consensus iteration ${Math.max(1, summary.iteration)}${ledgerNote ?? ""}`,
+		};
+	}
+	return {
+		allowed: true,
+		lane,
+		currentPasses,
+		projectedPasses,
+		maxReviewPassesPerLane,
+		finalSlot,
+		ledgerNote,
+	};
+}
+
+function getErrorCode(error: unknown): string | undefined {
+	if (!error || typeof error !== "object" || !("code" in error)) return undefined;
+	const code = (error as { code?: unknown }).code;
+	return typeof code === "string" ? code : undefined;
+}
+
 /** Filename pattern for persisted planner/revision stage artifacts. */
 const OPENER_ARTIFACT_RE = /^stage-\d{2,}-(planner|revision)\.md$/;
+const LANE_ARTIFACT_RE = /^stage-\d{2,}-(architect|critic)\.md$/;
+
 
 /**
  * Count on-disk planner/revision stage artifacts for a run. Used as a floor when
@@ -169,6 +286,30 @@ export async function countRalplanOnDiskOpeners(cwd: string, sessionId: string, 
 }
 
 /**
+ * Count on-disk Architect/Critic stage artifacts for a run. This is the
+ * fail-closed floor for a missing, truncated, or malformed `index.jsonl`.
+ */
+export async function countRalplanOnDiskLaneArtifacts(
+	cwd: string,
+	sessionId: string,
+	runId: string,
+): Promise<{ architect: number; critic: number }> {
+	const runDir = path.join(sessionPlansDir(cwd, sessionId), "ralplan", runId);
+	try {
+		const entries = await fs.readdir(runDir);
+		const counts = { architect: 0, critic: 0 };
+		for (const name of entries) {
+			const match = LANE_ARTIFACT_RE.exec(name);
+			if (match) counts[match[1] as RalplanReviewLane] += 1;
+		}
+		return counts;
+	} catch (error) {
+		if (getErrorCode(error) === "ENOENT") return { architect: 0, critic: 0 };
+		throw error;
+	}
+}
+
+/**
  * Load index rows for cap enforcement. Unlike HUD reads, returns structural
  * signals so callers can fail closed when the ledger is empty/malformed while
  * opener artifacts already exist on disk.
@@ -177,7 +318,13 @@ export async function loadRalplanIndexForCap(
 	cwd: string,
 	sessionId: string,
 	runId: string,
-): Promise<{ rows: RalplanIndexRow[]; indexPresent: boolean; parseableLines: number; rawLineCount: number }> {
+): Promise<{
+	rows: RalplanIndexRow[];
+	indexPresent: boolean;
+	parseableLines: number;
+	rawLineCount: number;
+	rawText?: string;
+}> {
 	const indexPath = path.join(sessionPlansDir(cwd, sessionId), "ralplan", runId, "index.jsonl");
 	try {
 		const text = await fs.readFile(indexPath, "utf8");
@@ -192,6 +339,7 @@ export async function loadRalplanIndexForCap(
 			indexPresent: true,
 			parseableLines: rows.length,
 			rawLineCount: lines.length,
+			rawText: text,
 		};
 	} catch (error) {
 		const code =
@@ -204,14 +352,18 @@ export async function loadRalplanIndexForCap(
 	}
 }
 
-function parseMaxIterationsValue(value: unknown): number | null {
+function parseBoundedPositiveInteger(value: unknown, limit: number): number | null {
 	return typeof value === "number" &&
 		Number.isFinite(value) &&
 		Number.isInteger(value) &&
 		value >= 1 &&
-		value <= RALPLAN_MAX_ITERATIONS_LIMIT
+		value <= limit
 		? value
 		: null;
+}
+
+function parseMaxIterationsValue(value: unknown): number | null {
+	return parseBoundedPositiveInteger(value, RALPLAN_MAX_ITERATIONS_LIMIT);
 }
 
 async function readSettingsMaxIterations(settingsPath: string): Promise<number | null> {
@@ -248,6 +400,87 @@ export async function resolveRalplanMaxIterations(cwd: string): Promise<{ maxIte
 	return { maxIterations: RALPLAN_DEFAULT_MAX_ITERATIONS, source: "default" };
 }
 
+function parseMaxReviewPassesPerLaneValue(value: unknown): number | null {
+	return parseBoundedPositiveInteger(value, RALPLAN_MAX_REVIEW_PASSES_PER_LANE_LIMIT);
+}
+
+type RalplanReviewPassesPerLaneSetting =
+	| { kind: "absent" }
+	| { kind: "valid"; value: number }
+	| { kind: "invalid"; reason: string };
+
+function parsePresentMaxReviewPassesPerLane(value: unknown): RalplanReviewPassesPerLaneSetting {
+	const parsed = parseMaxReviewPassesPerLaneValue(value);
+	return parsed === null
+		? {
+				kind: "invalid",
+				reason:
+					"expected gjc.ralplan.maxReviewPassesPerLane to be an integer between 1 and " +
+					RALPLAN_MAX_REVIEW_PASSES_PER_LANE_LIMIT,
+			}
+		: { kind: "valid", value: parsed };
+}
+
+function parseMaxReviewPassesPerLaneSettings(parsed: unknown): RalplanReviewPassesPerLaneSetting {
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return { kind: "absent" };
+	const settings = parsed as Record<string, unknown>;
+	if (Object.hasOwn(settings, "gjc.ralplan.maxReviewPassesPerLane")) {
+		return parsePresentMaxReviewPassesPerLane(settings["gjc.ralplan.maxReviewPassesPerLane"]);
+	}
+	const gjc = settings.gjc;
+	if (!gjc || typeof gjc !== "object" || Array.isArray(gjc)) return { kind: "absent" };
+	const ralplan = (gjc as Record<string, unknown>).ralplan;
+	if (!ralplan || typeof ralplan !== "object" || Array.isArray(ralplan)) return { kind: "absent" };
+	const ralplanSettings = ralplan as Record<string, unknown>;
+	if (!Object.hasOwn(ralplanSettings, "maxReviewPassesPerLane")) return { kind: "absent" };
+	return parsePresentMaxReviewPassesPerLane(ralplanSettings.maxReviewPassesPerLane);
+}
+
+async function readSettingsMaxReviewPassesPerLane(
+	settingsPath: string,
+): Promise<RalplanReviewPassesPerLaneSetting> {
+	let raw: string;
+	try {
+		raw = await Bun.file(settingsPath).text();
+	} catch (error) {
+		if (getErrorCode(error) === "ENOENT") return { kind: "absent" };
+		return {
+			kind: "invalid",
+			reason: `unable to read settings: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		return {
+			kind: "invalid",
+			reason: `malformed JSON: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+	return parseMaxReviewPassesPerLaneSettings(parsed);
+}
+
+/** Resolve the per-lane review-pass budget with project-over-user precedence. */
+export async function resolveRalplanMaxReviewPassesPerLane(
+	cwd: string,
+): Promise<{ maxReviewPassesPerLane: number; source: string }> {
+	const projectPath = path.join(gjcRoot(cwd), "settings.json");
+	const project = await readSettingsMaxReviewPassesPerLane(projectPath);
+	if (project.kind === "invalid") {
+		throw new RalplanCommandError(2, `invalid ralplan settings at ${projectPath}: ${project.reason}`);
+	}
+	if (project.kind === "valid") return { maxReviewPassesPerLane: project.value, source: projectPath };
+	const userDir = process.env.GJC_CONFIG_DIR?.trim() || path.join(os.homedir(), ".gjc");
+	const userPath = path.join(userDir, "settings.json");
+	const user = await readSettingsMaxReviewPassesPerLane(userPath);
+	if (user.kind === "invalid") {
+		throw new RalplanCommandError(2, `invalid ralplan settings at ${userPath}: ${user.reason}`);
+	}
+	if (user.kind === "valid") return { maxReviewPassesPerLane: user.value, source: userPath };
+	return { maxReviewPassesPerLane: RALPLAN_DEFAULT_MAX_REVIEW_PASSES_PER_LANE, source: "default" };
+}
+
 function buildPlanningStuckResult(input: {
 	json: boolean;
 	stage: RalplanStage;
@@ -275,6 +508,51 @@ function buildPlanningStuckResult(input: {
 					projected_iteration: input.decision.projectedIterations,
 					max_iterations: input.decision.maxIterations,
 					max_iterations_source: input.source,
+					reason: input.decision.reason,
+				},
+				null,
+				2,
+			)}\n`,
+			stderr: `${detail}\n`,
+		};
+	}
+	return {
+		status: 3,
+		stdout: `${PLANNING_STUCK_MARKER}\n`,
+		stderr: `${detail}\n`,
+	};
+}
+
+function buildLaneBudgetStuckResult(input: {
+	json: boolean;
+	stage: RalplanStage;
+	stageN: number;
+	runId: string;
+	decision: Extract<RalplanReviewLaneBudgetDecision, { allowed: false }>;
+	source: string;
+}): RalplanCommandResult {
+	const detail =
+		`${PLANNING_STUCK_MARKER}: ${input.decision.reason} ` +
+		`(run_id=${input.runId}, stage=${input.stage}, stage_n=${input.stageN}, source=${input.source}). ` +
+		`Stop re-invoking the ${input.decision.lane} review lane in this consensus iteration; ` +
+		"route a rule-2-justified blocker through a Planner revision opener (fresh lane budget) while opener budget remains, " +
+		"or escalate the best existing plan via post-interview/adr/final without auto-implementation.";
+	if (input.json) {
+		return {
+			status: 3,
+			stdout: `${JSON.stringify(
+				{
+					ok: false,
+					planning_stuck: true,
+					marker: PLANNING_STUCK_MARKER,
+					run_id: input.runId,
+					stage: input.stage,
+					stage_n: input.stageN,
+					lane: input.decision.lane,
+					passes: input.decision.currentPasses,
+					projected_passes: input.decision.projectedPasses,
+					max_review_passes_per_lane: input.decision.maxReviewPassesPerLane,
+					max_review_passes_source: input.source,
 					reason: input.decision.reason,
 				},
 				null,
@@ -326,6 +604,7 @@ const VALUE_FLAGS = new Set([
 	"--fallback-attempted-id",
 	"--fallback-stage-n",
 	"--fallback-receipt-path",
+	"--lane-verdict",
 ]);
 
 export function isRalplanArtifactWriteInvocation(args: readonly string[]): boolean {
@@ -485,6 +764,13 @@ async function persistActiveRunId(cwd: string, sessionId: string, runId: string,
 			// "complete"/"handoff" and disarm the Stop hook). PHASE_LOCK only guards same-run writes.
 			const isNewRun = existing.run_id !== runId;
 			const nextPhase = isNewRun ? stage : advanceCurrentPhase(existing.current_phase, stage);
+			if (isNewRun) {
+				// State writes shallow-merge, so clear both HUD verdict sources at the run boundary.
+				delete existing.verdict;
+				for (const key of Object.keys(existing)) {
+					if (key.startsWith("last_review_verdict")) delete existing[key];
+				}
+			}
 			if (
 				existing.run_id === runId &&
 				existing.version === WORKFLOW_STATE_VERSION &&
@@ -521,6 +807,17 @@ interface PlannerStateUpdate {
 	fallbackStageN?: number;
 	fallbackReceiptPath?: string;
 }
+
+interface LaneVerdictUpdate {
+	lane: RalplanReviewLane;
+	verdict: string;
+	stageN: number;
+}
+
+const LANE_VERDICTS: Record<RalplanReviewLane, ReadonlySet<string>> = {
+	architect: new Set(["CLEAR", "WATCH", "BLOCK"]),
+	critic: new Set(["OKAY", "ITERATE", "REJECT"]),
+};
 
 function parseBooleanFlag(raw: string, flag: string): boolean {
 	if (raw === "true") return true;
@@ -613,6 +910,27 @@ function parsePlannerStateArgs(args: readonly string[]): PlannerStateUpdate | un
 	return update;
 }
 
+/** Parse the self-reported review verdict carried by a lane artifact write. */
+function parseLaneVerdictArgs(
+	args: readonly string[],
+	stage: RalplanStage,
+	stageN: number,
+): LaneVerdictUpdate | undefined {
+	const rawVerdict = plannerFlagValue(args, "--lane-verdict");
+	if (rawVerdict === undefined) return undefined;
+	if (stage !== "architect" && stage !== "critic") {
+		throw new RalplanCommandError(2, `--lane-verdict is only valid with --stage architect or critic (received ${stage}).`);
+	}
+	const verdict = rawVerdict.trim().toUpperCase();
+	if (!LANE_VERDICTS[stage].has(verdict)) {
+		throw new RalplanCommandError(
+			2,
+			`invalid --lane-verdict for ${stage}: ${rawVerdict}. Expected one of: ${[...LANE_VERDICTS[stage]].join(", ")}.`,
+		);
+	}
+	return { lane: stage, verdict, stageN };
+}
+
 /** Snake-case projection of a PlannerStateUpdate for state JSON + receipts. Omitted fields stay absent — an unknown `planner_resumable` is encoded by omission, never literal null. */
 function plannerStatePayload(update: PlannerStateUpdate): Record<string, unknown> {
 	const payload: Record<string, unknown> = {};
@@ -654,6 +972,47 @@ async function applyPlannerStateUpdate(cwd: string, sessionId: string, update: P
 				receipt: { cwd, skill: "ralplan", owner: "gjc-runtime", command: "gjc ralplan planner-state", sessionId },
 				audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "ralplan", sessionId },
 			});
+		},
+		{ cwd },
+	);
+}
+
+/** Merge a lane's self-reported verdict into the same-session ralplan run state, optionally only for its active run. */
+async function applyLaneVerdictUpdate(
+	cwd: string,
+	sessionId: string,
+	update: LaneVerdictUpdate,
+	expectedActiveRunId?: string,
+): Promise<boolean> {
+	const statePath = ralplanStatePath(cwd, sessionId);
+	return await withWorkflowStateLock(
+		statePath,
+		async () => {
+			const existingRead = await readExistingStateForMutation(statePath);
+			if (existingRead.kind === "corrupt") {
+				throw new RalplanCommandError(
+					2,
+					`existing ralplan state is corrupt or tampered (${existingRead.error}); refusing to overwrite ${statePath}`,
+				);
+			}
+			let existing: Record<string, unknown> = existingRead.kind === "valid" ? existingRead.value : {};
+			if (expectedActiveRunId !== undefined && existing.run_id !== expectedActiveRunId) return false;
+			Object.assign(existing, {
+				last_review_verdict: update.verdict,
+				last_review_verdict_lane: update.lane,
+				last_review_verdict_stage_n: update.stageN,
+			});
+			if (typeof existing.skill !== "string") existing.skill = "ralplan";
+			if (typeof existing.active !== "boolean") existing.active = true;
+			if (typeof existing.current_phase !== "string") existing.current_phase = "planner";
+			existing = migrateWorkflowState(existing, "ralplan").state;
+			existing.updated_at = new Date().toISOString();
+			await writeWorkflowEnvelopeAtomic(statePath, existing, {
+				cwd,
+				receipt: { cwd, skill: "ralplan", owner: "gjc-runtime", command: "gjc ralplan lane-verdict", sessionId },
+				audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "ralplan", sessionId },
+			});
+			return true;
 		},
 		{ cwd },
 	);
@@ -804,28 +1163,19 @@ interface ExistingStageArtifact {
 }
 
 /**
- * Find the most recent `index.jsonl` row for a `(stage, stage_n)` pair so a
- * repeated `--write` can dedupe instead of silently clobbering the artifact and
- * appending a duplicate ledger row. Best-effort: a missing or unreadable index
- * yields `undefined`, treated as "no prior artifact". The ledger is the source of
- * truth for dedup because it is exactly what a duplicate write would corrupt.
+ * Find the most recent complete `index.jsonl` row for a `(stage, stage_n)` pair
+ * in the single ledger snapshot used by the dedupe guard and both budget gates.
+ * A parseable row missing `path` or `sha256` is intentionally treated as missing
+ * so the deterministic on-disk probe can repair the crash gap.
  */
-async function findExistingStageArtifact(
-	cwd: string,
-	sessionId: string,
-	runId: string,
+function findExistingStageArtifact(
+	indexText: string | undefined,
 	stage: RalplanStage,
 	stageN: number,
-): Promise<ExistingStageArtifact | undefined> {
-	const indexPath = path.join(sessionPlansDir(cwd, sessionId), "ralplan", runId, "index.jsonl");
-	let text: string;
-	try {
-		text = await fs.readFile(indexPath, "utf8");
-	} catch {
-		return undefined;
-	}
+): ExistingStageArtifact | undefined {
+	if (indexText === undefined) return undefined;
 	let match: ExistingStageArtifact | undefined;
-	for (const line of text.split(/\r?\n/)) {
+	for (const line of indexText.split(/\r?\n/)) {
 		const trimmed = line.trim();
 		if (!trimmed) continue;
 		let row: unknown;
@@ -847,6 +1197,125 @@ async function findExistingStageArtifact(
 	return match;
 }
 
+interface OnDiskStageArtifact {
+	path: string;
+	sha256: string;
+}
+
+/** Probe the deterministic artifact path left by a crash before ledger append. */
+async function findOnDiskStageArtifact(
+	cwd: string,
+	resolved: Pick<ResolvedArtifactArgs, "sessionId" | "runId" | "stage" | "stageN">,
+): Promise<OnDiskStageArtifact | undefined> {
+	const filePath = path.join(
+		sessionPlansDir(cwd, resolved.sessionId),
+		"ralplan",
+		resolved.runId,
+		`stage-${pad2(resolved.stageN)}-${resolved.stage}.md`,
+	);
+	try {
+		const content = await fs.readFile(filePath, "utf8");
+		return { path: filePath, sha256: createHash("sha256").update(content).digest("hex") };
+	} catch (error) {
+		const code = getErrorCode(error);
+		if (code === "ENOENT" || code === "ENOTDIR") return undefined;
+		throw error;
+	}
+}
+
+/** Ensure a deduplicated final stage still has its byte-identical pending-approval copy. */
+async function ensureFinalPendingApproval(
+	cwd: string,
+	resolved: Pick<ResolvedArtifactArgs, "sessionId" | "runId" | "stageN">,
+	stageArtifact: Pick<OnDiskStageArtifact, "path" | "sha256">,
+): Promise<string> {
+	const pendingApprovalPath = path.join(
+		sessionPlansDir(cwd, resolved.sessionId),
+		"ralplan",
+		resolved.runId,
+		"pending-approval.md",
+	);
+	const stageContent = await fs.readFile(stageArtifact.path);
+	const stageSha256 = createHash("sha256").update(stageContent).digest("hex");
+	if (stageSha256 !== stageArtifact.sha256) {
+		throw new RalplanCommandError(
+			2,
+			`refusing to deduplicate ralplan final stage ${resolved.stageN}: stage artifact sha256 mismatch at ${stageArtifact.path} (ledger sha256=${stageArtifact.sha256}, artifact sha256=${stageSha256}).`,
+		);
+	}
+
+	let pendingContent: Buffer;
+	try {
+		pendingContent = await fs.readFile(pendingApprovalPath);
+	} catch (error) {
+		if (getErrorCode(error) !== "ENOENT") throw error;
+		await writeArtifact(pendingApprovalPath, stageContent.toString("utf8"), {
+			cwd,
+			audit: {
+				category: "artifact",
+				verb: "write",
+				owner: "gjc-runtime",
+				skill: "ralplan",
+				sessionId: resolved.sessionId,
+			},
+		});
+		return pendingApprovalPath;
+	}
+
+	const pendingSha256 = createHash("sha256").update(pendingContent).digest("hex");
+	if (!pendingContent.equals(stageContent) || pendingSha256 !== stageSha256) {
+		throw new RalplanCommandError(
+			2,
+			`refusing to deduplicate ralplan final stage ${resolved.stageN}: pending approval content mismatch at ${pendingApprovalPath} (stage sha256=${stageSha256}, pending sha256=${pendingSha256}).`,
+		);
+	}
+	return pendingApprovalPath;
+}
+
+
+/** Append the missing row for a deterministic artifact that survived a crash gap. */
+async function repairMissingStageArtifactLedger(
+	cwd: string,
+	resolved: Pick<ResolvedArtifactArgs, "sessionId" | "runId" | "stage" | "stageN">,
+	onDisk: OnDiskStageArtifact,
+): Promise<ExistingStageArtifact> {
+	const createdAt = new Date().toISOString();
+	const indexEntry = {
+		stage: resolved.stage,
+		stage_n: resolved.stageN,
+		path: onDisk.path,
+		created_at: createdAt,
+		sha256: onDisk.sha256,
+	};
+	const result = await appendJsonlIdempotent(
+		path.join(sessionPlansDir(cwd, resolved.sessionId), "ralplan", resolved.runId, "index.jsonl"),
+		indexEntry,
+		{
+			cwd,
+			audit: {
+				category: "ledger",
+				verb: "append",
+				owner: "gjc-runtime",
+				skill: "ralplan",
+				sessionId: resolved.sessionId,
+			},
+			key: ralplanIndexKey,
+		},
+	);
+	const duplicate = result.duplicate;
+	if (duplicate && typeof duplicate === "object" && !Array.isArray(duplicate)) {
+		const record = duplicate as Record<string, unknown>;
+		if (typeof record.path === "string" && typeof record.sha256 === "string") {
+			return {
+				path: record.path,
+				sha256: record.sha256,
+				createdAt: typeof record.created_at === "string" ? record.created_at : createdAt,
+			};
+		}
+	}
+	return { path: onDisk.path, sha256: onDisk.sha256, createdAt };
+}
+
 /**
  * Read and parse the run's `index.jsonl` rows. Best-effort: returns [] when the
  * file is absent or unreadable so HUD sync never fails on a missing index.
@@ -866,6 +1335,18 @@ async function readRalplanIndexRows(cwd: string, sessionId: string, runId: strin
 	}
 }
 
+/** Read the lane verdict from ralplan run state without making HUD sync fail on state read errors. */
+async function readRalplanLastReviewVerdict(cwd: string, sessionId: string): Promise<string | undefined> {
+	try {
+		const existingRead = await readExistingStateForMutation(ralplanStatePath(cwd, sessionId));
+		return existingRead.kind === "valid" && typeof existingRead.value.last_review_verdict === "string"
+			? existingRead.value.last_review_verdict
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 async function syncRalplanHud(options: {
 	cwd: string;
 	sessionId: string;
@@ -873,6 +1354,7 @@ async function syncRalplanHud(options: {
 	pendingApproval: boolean;
 	iteration?: number;
 	runId?: string;
+	reviewPassBudget?: number;
 	latestSummary?: string;
 }): Promise<void> {
 	try {
@@ -898,15 +1380,25 @@ async function buildRalplanHud(options: {
 	latestSummary?: string;
 	runId?: string;
 	sessionId?: string;
+	reviewPassBudget?: number;
 }) {
 	let iterationFromIndex: number | undefined;
 	let stages: string | undefined;
+	let architectPasses: number | undefined;
+	let criticPasses: number | undefined;
+	let verdict: string | undefined;
 	if (options.runId && options.sessionId) {
-		const rows = await readRalplanIndexRows(options.cwd, options.sessionId, options.runId);
+		const [rows, lastReviewVerdict] = await Promise.all([
+			readRalplanIndexRows(options.cwd, options.sessionId, options.runId),
+			readRalplanLastReviewVerdict(options.cwd, options.sessionId),
+		]);
+		verdict = lastReviewVerdict;
 		if (rows.length > 0) {
 			const summary = summarizeRalplanIndex(rows);
 			iterationFromIndex = summary.iteration;
 			stages = formatRalplanStagePresence(summary.currentStages);
+			architectPasses = summary.currentStages.filter(stage => stage === "architect").length;
+			criticPasses = summary.currentStages.filter(stage => stage === "critic").length;
 		}
 	}
 	return buildRalplanHudSummary({
@@ -914,6 +1406,10 @@ async function buildRalplanHud(options: {
 		iteration: options.iteration,
 		iterationFromIndex,
 		stages,
+		architectPasses,
+		criticPasses,
+		reviewPassBudget: options.reviewPassBudget,
+		verdict,
 		pendingApproval: options.pendingApproval,
 		latestSummary: options.latestSummary,
 		updatedAt: new Date().toISOString(),
@@ -923,6 +1419,7 @@ async function buildRalplanHud(options: {
 async function handleArtifactWrite(args: readonly string[], cwd: string): Promise<RalplanCommandResult> {
 	const plannerState = parsePlannerStateArgs(args);
 	const resolved = await resolveArtifactArgs(args, cwd);
+	const laneVerdict = parseLaneVerdictArgs(args, resolved.stage, resolved.stageN);
 	// Fail closed before stage persistence / path writes when cwd drifted to a sibling repo.
 	const repositoryBinding = await enforceRalplanRepositoryBinding(cwd, resolved.sessionId);
 	// Artifact file paths (when --artifact points at a file) must stay under the bound root.
@@ -944,16 +1441,15 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 	const content = resolved.artifact.endsWith("\n") ? resolved.artifact : `${resolved.artifact}\n`;
 	const sha256 = createHash("sha256").update(content).digest("hex");
 
+	// Read the ledger once before persistence. The dedupe guard and both gates
+	// consume this same snapshot so no additional ledger read can slip between gate
+	// evaluation and persistence.
+	const indexLoad = await loadRalplanIndexForCap(cwd, resolved.sessionId, resolved.runId);
+
 	// Duplicate-write guard: a second `--write` for the same (stage, stage_n) must not
 	// silently clobber the artifact or append a duplicate ledger row. Classify before any
 	// state mutation so a conflict never regresses run-state phase.
-	const existingArtifact = await findExistingStageArtifact(
-		cwd,
-		resolved.sessionId,
-		resolved.runId,
-		resolved.stage,
-		resolved.stageN,
-	);
+	const existingArtifact = findExistingStageArtifact(indexLoad.rawText, resolved.stage, resolved.stageN);
 	if (existingArtifact) {
 		if (existingArtifact.sha256 !== sha256) {
 			throw new RalplanCommandError(
@@ -961,7 +1457,29 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 				`refusing to overwrite ralplan ${resolved.stage} stage ${resolved.stageN} at ${existingArtifact.path}: an artifact with different content already exists (existing sha256=${existingArtifact.sha256}, new sha256=${sha256}). Use a new --stage_n to record another pass.`,
 			);
 		}
+		if (resolved.stage === "final") await ensureFinalPendingApproval(cwd, resolved, existingArtifact);
 		return buildDeduplicatedResult(resolved, existingArtifact, sha256, cwd, repositoryBinding);
+	}
+
+	// `persistArtifact` writes the artifact before its ledger row. If a process crashed
+	// in that gap, an identical retry repairs the row and remains a normal deduplicated
+	// receipt; a differing retry retains the ordinary no-overwrite refusal.
+	const onDiskArtifact = await findOnDiskStageArtifact(cwd, resolved);
+	if (onDiskArtifact) {
+		if (onDiskArtifact.sha256 !== sha256) {
+			throw new RalplanCommandError(
+				2,
+				`refusing to overwrite ralplan ${resolved.stage} stage ${resolved.stageN} at ${onDiskArtifact.path}: an artifact with different content already exists (existing sha256=${onDiskArtifact.sha256}, new sha256=${sha256}). Use a new --stage_n to record another pass.`,
+			);
+		}
+		if (resolved.stage === "final") await ensureFinalPendingApproval(cwd, resolved, onDiskArtifact);
+		const repairedArtifact = await repairMissingStageArtifactLedger(cwd, resolved, onDiskArtifact);
+		if (plannerState) await applyPlannerStateUpdate(cwd, resolved.sessionId, plannerState);
+		let appliedLaneVerdict: LaneVerdictUpdate | undefined;
+		if (laneVerdict && (await applyLaneVerdictUpdate(cwd, resolved.sessionId, laneVerdict, resolved.runId))) {
+			appliedLaneVerdict = laneVerdict;
+		}
+		return buildDeduplicatedResult(resolved, repairedArtifact, sha256, cwd, repositoryBinding, appliedLaneVerdict);
 	}
 
 	// Consensus iteration budget (#3165): refuse new planner/revision openers past the cap.
@@ -969,13 +1487,21 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 	// critic, final, …) remain allowed so operators can escalate without auto-implementation.
 	// On-disk opener artifacts floor the count so a wiped/truncated/malformed index.jsonl cannot
 	// under-count and fail open after prior planner/revision writes.
-	const indexLoad = await loadRalplanIndexForCap(cwd, resolved.sessionId, resolved.runId);
-	const onDiskOpeners = await countRalplanOnDiskOpeners(cwd, resolved.sessionId, resolved.runId);
-	const { maxIterations, source: maxIterationsSource } = await resolveRalplanMaxIterations(cwd);
+	//
+	// Gate evaluation, artifact write, and ledger append are sequential within one
+	// `gjc ralplan --write` invocation. This is NOT exclusive across processes: no
+	// run-scoped lock or CAS admission exists, intentionally matching #3165's
+	// check-then-persist exposure.
+	const [onDiskOpeners, onDiskLaneArtifacts, iterationLimit, laneLimit] = await Promise.all([
+		countRalplanOnDiskOpeners(cwd, resolved.sessionId, resolved.runId),
+		countRalplanOnDiskLaneArtifacts(cwd, resolved.sessionId, resolved.runId),
+		resolveRalplanMaxIterations(cwd),
+		resolveRalplanMaxReviewPassesPerLane(cwd),
+	]);
 	const capDecision = evaluateRalplanIterationCap({
 		rows: indexLoad.rows,
 		stage: resolved.stage,
-		maxIterations,
+		maxIterations: iterationLimit.maxIterations,
 		iterationFloor: onDiskOpeners,
 	});
 	if (!capDecision.allowed) {
@@ -985,7 +1511,23 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 			stageN: resolved.stageN,
 			runId: resolved.runId,
 			decision: capDecision,
-			source: maxIterationsSource,
+			source: iterationLimit.source,
+		});
+	}
+	const laneBudgetDecision = evaluateRalplanReviewLaneBudget({
+		rows: indexLoad.rows,
+		stage: resolved.stage,
+		maxReviewPassesPerLane: laneLimit.maxReviewPassesPerLane,
+		onDiskLaneCounts: onDiskLaneArtifacts,
+	});
+	if (!laneBudgetDecision.allowed) {
+		return buildLaneBudgetStuckResult({
+			json: resolved.json,
+			stage: resolved.stage,
+			stageN: resolved.stageN,
+			runId: resolved.runId,
+			decision: laneBudgetDecision,
+			source: laneLimit.source,
 		});
 	}
 
@@ -995,6 +1537,9 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 	if (plannerState) {
 		await applyPlannerStateUpdate(cwd, resolved.sessionId, plannerState);
 	}
+	if (laneVerdict) {
+		await applyLaneVerdictUpdate(cwd, resolved.sessionId, laneVerdict);
+	}
 	await writeSessionActivityMarker(cwd, resolved.sessionId, { writer: "ralplan-runtime", path: persisted.path });
 	await syncRalplanHud({
 		cwd,
@@ -1003,8 +1548,18 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 		runId: persisted.runId,
 		pendingApproval: persisted.stage === "final",
 		iteration: persisted.stageN,
+		reviewPassBudget: laneLimit.maxReviewPassesPerLane,
 		latestSummary: `persisted ${persisted.stage} stage ${persisted.stageN}`,
 	});
+	const reviewBudgetWarning =
+		laneBudgetDecision.lane && laneBudgetDecision.finalSlot && laneBudgetDecision.maxReviewPassesPerLane > 1
+			? {
+				lane: laneBudgetDecision.lane,
+				passes: laneBudgetDecision.projectedPasses,
+				max: laneBudgetDecision.maxReviewPassesPerLane,
+			}
+			: undefined;
+
 	const payload: Record<string, unknown> = {
 		run_id: persisted.runId,
 		path: persisted.path,
@@ -1016,16 +1571,19 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 	};
 	if (persisted.pendingApprovalPath) payload.pending_approval_path = persisted.pendingApprovalPath;
 	if (plannerState) payload.planner_state = plannerStatePayload(plannerState);
+	if (reviewBudgetWarning) payload.review_budget_warning = reviewBudgetWarning;
+	if (laneVerdict) payload.lane_verdict = { lane: laneVerdict.lane, verdict: laneVerdict.verdict };
+
 	const stdout = resolved.json
 		? `${JSON.stringify(payload, null, 2)}\n`
-		: `Persisted ralplan ${persisted.stage} stage ${persisted.stageN} at ${persisted.path}.\n`;
+		: `${reviewBudgetWarning ? `Warning: ralplan ${reviewBudgetWarning.lane} review budget final slot used (${reviewBudgetWarning.passes}/${reviewBudgetWarning.max}).\n` : ""}Persisted ralplan ${persisted.stage} stage ${persisted.stageN} at ${persisted.path}.\n`;
 	return { status: 0, stdout };
 }
 
 /**
- * Deterministic no-op receipt for an identical repeated `--write`: report the
- * already-persisted artifact without rewriting the file, appending a ledger row, or
- * churning run-state. `deduplicated: true` lets callers distinguish it from a fresh write.
+ * Deterministic receipt for an identical repeated `--write`. Ledger-backed duplicates
+ * do not rewrite artifacts, append rows, or churn run state; a crash-gap repair may
+ * complete riding planner/lane metadata before returning this receipt.
  */
 function buildDeduplicatedResult(
 	resolved: ResolvedArtifactArgs,
@@ -1033,6 +1591,7 @@ function buildDeduplicatedResult(
 	sha256: string,
 	cwd: string,
 	repositoryBinding: RepositoryBinding,
+	laneVerdict?: LaneVerdictUpdate,
 ): RalplanCommandResult {
 	const payload: Record<string, unknown> = {
 		run_id: resolved.runId,
@@ -1044,6 +1603,7 @@ function buildDeduplicatedResult(
 		created_at: existing.createdAt,
 		deduplicated: true,
 	};
+	if (laneVerdict) payload.lane_verdict = { lane: laneVerdict.lane, verdict: laneVerdict.verdict };
 	if (resolved.stage === "final") {
 		payload.pending_approval_path = path.join(
 			sessionPlansDir(cwd, resolved.sessionId),
@@ -1092,6 +1652,9 @@ function extractPositionalTask(args: readonly string[]): string {
 }
 
 function resolveConsensusArgs(args: readonly string[], cwd: string): ConsensusHandoffArgs {
+	if (hasFlag(args, "--lane-verdict")) {
+		throw new RalplanCommandError(2, "--lane-verdict is only supported with gjc ralplan --write.");
+	}
 	const architectKind = flagValue(args, "--architect")?.trim() || undefined;
 	if (architectKind && !KNOWN_ARCHITECT_KINDS.has(architectKind)) {
 		throw new RalplanCommandError(

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -89,7 +89,6 @@ function deduplicateRalplanIndexRowsByStageIdentity(rows: readonly RalplanIndexR
 	});
 }
 
-
 export type RalplanIterationCapDecision =
 	| {
 			allowed: true;
@@ -221,8 +220,7 @@ export function evaluateRalplanReviewLaneBudget(input: {
 	const indexCurrent = summary.currentStages.filter(stage => stage === lane).length;
 	const parsedTotal = rows.filter(row => row.stage === lane).length;
 	const onDiskRaw = input.onDiskLaneCounts?.[lane];
-	const onDiskTotal =
-		typeof onDiskRaw === "number" && Number.isInteger(onDiskRaw) && onDiskRaw > 0 ? onDiskRaw : 0;
+	const onDiskTotal = typeof onDiskRaw === "number" && Number.isInteger(onDiskRaw) && onDiskRaw > 0 ? onDiskRaw : 0;
 	const diskExcess = Math.max(0, onDiskTotal - parsedTotal);
 	const currentPasses = indexCurrent + diskExcess;
 	const projectedPasses = currentPasses + 1;
@@ -265,7 +263,6 @@ function getErrorCode(error: unknown): string | undefined {
 /** Filename pattern for persisted planner/revision stage artifacts. */
 const OPENER_ARTIFACT_RE = /^stage-\d{2,}-(planner|revision)\.md$/;
 const LANE_ARTIFACT_RE = /^stage-\d{2,}-(architect|critic)\.md$/;
-
 
 /**
  * Count on-disk planner/revision stage artifacts for a run. Used as a floor when
@@ -353,11 +350,7 @@ export async function loadRalplanIndexForCap(
 }
 
 function parseBoundedPositiveInteger(value: unknown, limit: number): number | null {
-	return typeof value === "number" &&
-		Number.isFinite(value) &&
-		Number.isInteger(value) &&
-		value >= 1 &&
-		value <= limit
+	return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value >= 1 && value <= limit
 		? value
 		: null;
 }
@@ -436,9 +429,7 @@ function parseMaxReviewPassesPerLaneSettings(parsed: unknown): RalplanReviewPass
 	return parsePresentMaxReviewPassesPerLane(ralplanSettings.maxReviewPassesPerLane);
 }
 
-async function readSettingsMaxReviewPassesPerLane(
-	settingsPath: string,
-): Promise<RalplanReviewPassesPerLaneSetting> {
+async function readSettingsMaxReviewPassesPerLane(settingsPath: string): Promise<RalplanReviewPassesPerLaneSetting> {
 	let raw: string;
 	try {
 		raw = await Bun.file(settingsPath).text();
@@ -919,7 +910,10 @@ function parseLaneVerdictArgs(
 	const rawVerdict = plannerFlagValue(args, "--lane-verdict");
 	if (rawVerdict === undefined) return undefined;
 	if (stage !== "architect" && stage !== "critic") {
-		throw new RalplanCommandError(2, `--lane-verdict is only valid with --stage architect or critic (received ${stage}).`);
+		throw new RalplanCommandError(
+			2,
+			`--lane-verdict is only valid with --stage architect or critic (received ${stage}).`,
+		);
 	}
 	const verdict = rawVerdict.trim().toUpperCase();
 	if (!LANE_VERDICTS[stage].has(verdict)) {
@@ -1272,7 +1266,6 @@ async function ensureFinalPendingApproval(
 	return pendingApprovalPath;
 }
 
-
 /** Append the missing row for a deterministic artifact that survived a crash gap. */
 async function repairMissingStageArtifactLedger(
 	cwd: string,
@@ -1554,10 +1547,10 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 	const reviewBudgetWarning =
 		laneBudgetDecision.lane && laneBudgetDecision.finalSlot && laneBudgetDecision.maxReviewPassesPerLane > 1
 			? {
-				lane: laneBudgetDecision.lane,
-				passes: laneBudgetDecision.projectedPasses,
-				max: laneBudgetDecision.maxReviewPassesPerLane,
-			}
+					lane: laneBudgetDecision.lane,
+					passes: laneBudgetDecision.projectedPasses,
+					max: laneBudgetDecision.maxReviewPassesPerLane,
+				}
 			: undefined;
 
 	const payload: Record<string, unknown> = {

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -857,7 +857,8 @@ function buildHudForMode(
 					: typeof payload.mode === "string"
 						? (payload.mode as string)
 						: undefined;
-			const verdict = typeof payload.verdict === "string" ? (payload.verdict as string) : undefined;
+			const rawVerdict = payload.last_review_verdict ?? payload.verdict;
+			const verdict = typeof rawVerdict === "string" ? rawVerdict : undefined;
 			const iteration = typeof payload.iteration === "number" ? (payload.iteration as number) : undefined;
 			const pendingApproval = payload.pending_approval === true || stage === "final";
 			return buildRalplanHudSummary({

--- a/packages/coding-agent/src/prompts/agents/architect.md
+++ b/packages/coding-agent/src/prompts/agents/architect.md
@@ -37,10 +37,18 @@ You may receive a forked parent-conversation snapshot as background. Your read-o
 {{restrictedBash}}
 - Never approve code or plans you have not grounded in inspected files.
 - Never give generic advice detached from this codebase.
-- Never approve CRITICAL or HIGH severity issues.
+- Never approve carryover CRITICAL or HIGH severity issues (raised in a prior pass and still unresolved). A fresh CRITICAL/HIGH minted from pass 2 on previously-approved ground blocks only with an explicit why-not-visible-earlier justification (rule 2); without that justification, record it as a non-blocking caveat with its severity noted. On pass 1 every CRITICAL/HIGH blocks.
 - Do not skip spec compliance to jump to style nitpicks.
 - Be constructive: explain why an issue matters and how to fix it or strengthen the design.
 </constraints>
+
+<re_review_ratchet>
+- Rule 1 (delta-only): from pass 2, review only the delta against the prior pass plus the resolution of previously raised findings; do not re-litigate previously-approved ground. The prior pass is identified by the re-review context bundle: prior reviewed-plan path, prior same-lane review path, and the explicit run-level pass number supplied in the assignment.
+- Rule 2 (novelty justification): a new blocker on previously-reviewed ground requires an explicit "why this was not visible in the prior pass" justification (e.g. revealed by a fix, new file evidence); without it, demote to a non-blocking caveat.
+- Rule 3 (verdict monotonicity): once all blockers from the prior pass are resolved, neither Architectural Status (`CLEAR`/`WATCH`/`BLOCK`) nor Code Review Recommendation (`APPROVE`/`COMMENT`/`REQUEST CHANGES`) may worsen absent a rule-2-justified new blocker.
+- Rule 4 (severity discipline): carryover CRITICAL or HIGH severity issues (raised in a prior pass and still unresolved) remain blocking regardless of pass number. A fresh CRITICAL/HIGH minted from pass 2 on previously-approved ground blocks only with an explicit why-not-visible-earlier justification (rule 2); without that justification, record it as a non-blocking caveat with its severity noted. On pass 1 every CRITICAL/HIGH blocks.
+- Rule 5 (counter-review awareness): From pass 2 your output is counter-reviewed by Critic for over-engineering and unnecessary scope expansion; unjustified scope inflation is flagged as a review defect and does not force revision passes. On pass 2+, do not broaden scope, add options, or demand synthesis beyond what resolves prior findings; constructive synthesis (Stage 3) stays full-strength on pass 1 only.
+</re_review_ratchet>
 
 <review_stages>
 1. Understand the request, spec, plan, or diff.

--- a/packages/coding-agent/src/prompts/agents/critic.md
+++ b/packages/coding-agent/src/prompts/agents/critic.md
@@ -32,6 +32,15 @@ Review plan clarity, completeness, verification, big-picture fit, referenced fil
 - For consensus planning, reject shallow alternatives, driver contradictions, vague risks, weak verification, missing acceptance criteria, or under-specified areas needing expansion before execution.
 </constraints>
 
+<re_review_ratchet>
+- Rule 1 (delta-only): from pass 2, review only the delta against the prior pass plus the resolution of previously raised findings; do not re-litigate previously-approved ground. The prior pass is identified by the re-review context bundle (WI-3): prior reviewed-plan path, prior same-lane review path, and the explicit run-level pass number supplied in the assignment.
+- Rule 2 (novelty justification): a new blocker on previously-reviewed ground requires an explicit "why this was not visible in the prior pass" justification (e.g. revealed by a fix, new file evidence); without it, demote to a non-blocking caveat.
+- Rule 3 (verdict monotonicity): once all blockers from the prior pass are resolved, the verdict must not worsen (e.g. ITERATE -> REJECT) absent a rule-2-justified new blocker.
+- Rule 4 (severity discipline): carryover blockers (raised in a prior pass, still unresolved) remain blocking regardless of pass number. A fresh high-severity concern minted from pass 2 on previously-approved ground follows rule 2: it blocks only with the why-not-visible-earlier justification, else it is recorded as a non-blocking caveat with severity noted.
+- Rule 5 (counter-review duty): from pass 2, Critic also reviews the Architect output (routed via the context bundle) for over-engineering and unnecessary scope expansion; flag inflation as a review defect and do NOT convert unjustified Architect demands into ITERATE — inflating demands must not force revision passes.
+- Enrichment lane ("spec too thin — expand") preserved verbatim but justification-gated from pass 2: expansion requests on already-reviewed ground need the rule-2 justification.
+</re_review_ratchet>
+
 <execution_loop>
 1. Read the plan and referenced artifacts.
 2. Extract and verify file references.

--- a/packages/coding-agent/src/skill-state/workflow-hud.ts
+++ b/packages/coding-agent/src/skill-state/workflow-hud.ts
@@ -23,6 +23,9 @@ interface RalplanHudState extends WorkflowGateHudState {
 	iteration?: number;
 	iterationFromIndex?: number;
 	stages?: string;
+	architectPasses?: number;
+	criticPasses?: number;
+	reviewPassBudget?: number;
 	verdict?: string;
 	latestSummary?: string;
 	pendingApproval?: boolean;
@@ -194,13 +197,27 @@ export function deriveDeepInterviewHud(
 export function buildRalplanHudSummary(state: RalplanHudState): WorkflowHudSummary {
 	const verdict = state.verdict?.toUpperCase();
 	const verdictSeverity =
-		verdict === "BLOCK"
+		verdict === "BLOCK" || verdict === "REJECT"
 			? "blocked"
 			: verdict === "ITERATE" || verdict === "WATCH"
 				? "warning"
-				: verdict === "APPROVE" || verdict === "CLEAR"
+				: verdict === "APPROVE" || verdict === "CLEAR" || verdict === "OKAY"
 					? "success"
 					: undefined;
+	const reviewPassChip = (label: "arch" | "crit", passes: number | undefined, priority: number): WorkflowHudChip | null => {
+		if (
+			state.pendingApproval ||
+			typeof passes !== "number" ||
+			!Number.isFinite(passes) ||
+			passes <= 0 ||
+			typeof state.reviewPassBudget !== "number" ||
+			!Number.isFinite(state.reviewPassBudget) ||
+			state.reviewPassBudget <= 0
+		) {
+			return null;
+		}
+		return chip(label, `${passes}/${state.reviewPassBudget}`, priority);
+	};
 	return {
 		version: 1,
 		summary: state.latestSummary,
@@ -217,6 +234,8 @@ export function buildRalplanHudSummary(state: RalplanHudState): WorkflowHudSumma
 				30,
 			),
 			chip("stages", state.stages, 35),
+			reviewPassChip("arch", state.architectPasses, 36),
+			reviewPassChip("crit", state.criticPasses, 38),
 			chip("verdict", verdict, 40, verdictSeverity),
 		]),
 		...(state.updatedAt ? { updated_at: state.updatedAt } : {}),

--- a/packages/coding-agent/src/skill-state/workflow-hud.ts
+++ b/packages/coding-agent/src/skill-state/workflow-hud.ts
@@ -204,7 +204,11 @@ export function buildRalplanHudSummary(state: RalplanHudState): WorkflowHudSumma
 				: verdict === "APPROVE" || verdict === "CLEAR" || verdict === "OKAY"
 					? "success"
 					: undefined;
-	const reviewPassChip = (label: "arch" | "crit", passes: number | undefined, priority: number): WorkflowHudChip | null => {
+	const reviewPassChip = (
+		label: "arch" | "crit",
+		passes: number | undefined,
+		priority: number,
+	): WorkflowHudChip | null => {
 		if (
 			state.pendingApproval ||
 			typeof passes !== "number" ||

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -2147,6 +2147,50 @@ describe("ralplan HUD lane verdict carriage", () => {
 		expect(state).toMatchObject({ last_review_verdict: "BLOCK", verdict: "ITERATE" });
 		expect((await readRalplanHudChips(root)).find(chip => chip.label === "verdict")?.value).toBe("BLOCK");
 	});
+	it("keeps a lane verdict visible after artifact-then-state write order", async () => {
+		const root = await tempDir();
+		const runId = "state-after-artifact";
+		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
+		expect((await writeRalplanLaneVerdictArtifact(root, runId, "critic", 2, "# critique", "ITERATE")).status).toBe(0);
+		expect(
+			(
+				await runNativeStateCommand(
+					["write", "--mode", "ralplan", "--input", JSON.stringify({ marker: "after-artifact" })],
+					root,
+				)
+			).status,
+		).toBe(0);
+		expect((await readRalplanHudChips(root)).find(chip => chip.label === "verdict")?.value).toBe("ITERATE");
+	});
+
+	it("prefers a run-scoped lane verdict over a stale legacy ralplan verdict", async () => {
+		const root = await tempDir();
+		const runId = "state-lane-precedence";
+		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
+		expect(
+			(
+				await runNativeStateCommand(
+					["write", "--mode", "ralplan", "--input", JSON.stringify({ verdict: "ITERATE" })],
+					root,
+				)
+			).status,
+		).toBe(0);
+		expect((await writeRalplanLaneVerdictArtifact(root, runId, "critic", 2, "# critique", "OKAY")).status).toBe(0);
+		expect(
+			(
+				await runNativeStateCommand(
+					["write", "--mode", "ralplan", "--input", JSON.stringify({ marker: "verdict-less" })],
+					root,
+				)
+			).status,
+		).toBe(0);
+
+		const state = JSON.parse(await fs.readFile(ralplanStatePath(root), "utf-8"));
+		expect(state).toMatchObject({ verdict: "ITERATE", last_review_verdict: "OKAY" });
+		const verdict = (await readRalplanHudChips(root)).find(chip => chip.label === "verdict");
+		expect(verdict?.value).toBe("OKAY");
+		expect(verdict?.severity).toBe("success");
+	});
 
 	it("uses the resolved per-lane budget as the review-pass denominator", async () => {
 		const root = await tempDir();

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -1,10 +1,14 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { existsSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
 	evaluateRalplanIterationCap,
+	evaluateRalplanReviewLaneBudget,
 	PLANNING_STUCK_MARKER,
 	RALPLAN_DEFAULT_MAX_ITERATIONS,
+	RALPLAN_DEFAULT_MAX_REVIEW_PASSES_PER_LANE,
+	resolveRalplanMaxReviewPassesPerLane,
 	runNativeRalplanCommand,
 } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
 import {
@@ -18,6 +22,7 @@ import {
 	sessionPlansDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { readVisibleSkillActiveState } from "@gajae-code/coding-agent/skill-state/active-state";
+import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
 
 const TEST_SESSION_ID = "test-session";
 const tempRoots: string[] = [];
@@ -51,6 +56,68 @@ async function tempDir(): Promise<string> {
 afterEach(async () => {
 	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
+
+async function writeRalplanArtifact(
+	root: string,
+	runId: string,
+	stage: string,
+	stageN: number,
+	artifact: string,
+	json = true,
+) {
+	return await runNativeRalplanCommand(
+		[
+			"--write",
+			"--stage",
+			stage,
+			"--stage_n",
+			String(stageN),
+			"--artifact",
+			artifact,
+			"--run-id",
+			runId,
+			...(json ? ["--json"] : []),
+		],
+		root,
+	);
+}
+
+async function writeRalplanLaneVerdictArtifact(
+	root: string,
+	runId: string,
+	stage: "architect" | "critic",
+	stageN: number,
+	artifact: string,
+	verdict: string,
+) {
+	return await runNativeRalplanCommand(
+		[
+			"--write",
+			"--stage",
+			stage,
+			"--stage_n",
+			String(stageN),
+			"--artifact",
+			artifact,
+			"--run-id",
+			runId,
+			"--lane-verdict",
+			verdict,
+			"--json",
+		],
+		root,
+	);
+}
+
+async function readRalplanHudChips(root: string): Promise<Array<{ label: string; value?: string; severity?: string }>> {
+	const active = JSON.parse(await fs.readFile(activeSnapshotPath(root, TEST_SESSION_ID), "utf-8")) as {
+		active_skills?: Array<{
+			skill: string;
+			hud?: { chips?: Array<{ label: string; value?: string; severity?: string }> };
+		}>;
+	};
+	return active.active_skills?.find(entry => entry.skill === "ralplan")?.hud?.chips ?? [];
+}
 
 describe("native gjc ralplan runtime — consensus handoff", () => {
 	it("accepts the documented flag surface without rejecting --interactive/--deliberate", async () => {
@@ -729,6 +796,28 @@ describe("native gjc ralplan runtime — duplicate --write guard", () => {
 			.filter(Boolean);
 		expect(indexLines.length).toBe(1);
 		expect(JSON.parse(indexLines[0]).stage).toBe("planner");
+	});
+	it("uses one pre-persist ledger snapshot without claiming cross-process exclusivity", async () => {
+		const root = await tempDir();
+		const runId = "sequential-snapshot";
+		const indexPath = path.join(ralplanRunDir(root, runId), "index.jsonl");
+		const artifactPath = path.join(ralplanRunDir(root, runId), "stage-01-planner.md");
+		const originalReadFile = fs.readFile;
+		let prePersistLedgerReads = 0;
+		const readSpy = spyOn(fs, "readFile").mockImplementation(async (...args: any[]) => {
+			const target = typeof args[0] === "string" ? args[0] : String(args[0]);
+			if (path.resolve(target) === indexPath && !existsSync(artifactPath)) prePersistLedgerReads += 1;
+			return await (originalReadFile as (...readArgs: any[]) => Promise<any>)(...args);
+		});
+		try {
+			// One invocation only: the documented sequence is intentionally not a
+			// cross-process admission claim, lock, or CAS test.
+			const result = await writeRalplanArtifact(root, runId, "planner", 1, "# plan");
+			expect(result.status).toBe(0);
+		} finally {
+			readSpy.mockRestore();
+		}
+		expect(prePersistLedgerReads).toBe(1);
 	});
 });
 
@@ -1413,5 +1502,743 @@ describe("ralplan consensus iteration cap (#3165)", () => {
 		// Fresh run is independent even while the old run remains at cap under wipe.
 		expect((await write("run-new", "planner", 1, "# p-new")).status).toBe(0);
 		expect((await write("run-new", "revision", 2, "# r2-new")).status).toBe(0);
+	});
+});
+
+describe("ralplan review lane budget", () => {
+	it("enforces independent per-lane passes, resets on a revision, and defaults invalid overrides", () => {
+		const initialArchitect = evaluateRalplanReviewLaneBudget({ rows: [], stage: "architect" });
+		const initialCritic = evaluateRalplanReviewLaneBudget({ rows: [], stage: "critic" });
+		expect(initialArchitect).toMatchObject({
+			allowed: true,
+			lane: "architect",
+			currentPasses: 0,
+			projectedPasses: 1,
+			maxReviewPassesPerLane: RALPLAN_DEFAULT_MAX_REVIEW_PASSES_PER_LANE,
+		});
+		expect(initialCritic.allowed).toBe(true);
+
+		const firstIteration = [
+			{ stage: "planner", stageN: 1 },
+			{ stage: "architect", stageN: 2 },
+		];
+		expect(evaluateRalplanReviewLaneBudget({ rows: firstIteration, stage: "architect" })).toMatchObject({
+			allowed: false,
+			lane: "architect",
+			currentPasses: 1,
+			projectedPasses: 2,
+		});
+		expect(evaluateRalplanReviewLaneBudget({ rows: firstIteration, stage: "critic" })).toMatchObject({
+			allowed: true,
+			lane: "critic",
+			currentPasses: 0,
+		});
+
+		const afterRevision = [...firstIteration, { stage: "revision", stageN: 3 }];
+		expect(evaluateRalplanReviewLaneBudget({ rows: afterRevision, stage: "architect" })).toMatchObject({
+			allowed: true,
+			currentPasses: 0,
+			projectedPasses: 1,
+		});
+		for (const stage of ["planner", "revision", "post-interview", "adr", "final"]) {
+			expect(evaluateRalplanReviewLaneBudget({ rows: firstIteration, stage })).toMatchObject({
+				allowed: true,
+				finalSlot: false,
+			});
+		}
+
+		const overrideRows = [...firstIteration, { stage: "architect", stageN: 3 }];
+		expect(
+			evaluateRalplanReviewLaneBudget({ rows: firstIteration, stage: "architect", maxReviewPassesPerLane: 2 }),
+		).toMatchObject({ allowed: true, projectedPasses: 2, finalSlot: true });
+		expect(
+			evaluateRalplanReviewLaneBudget({ rows: overrideRows, stage: "architect", maxReviewPassesPerLane: 2 }),
+		).toMatchObject({ allowed: false, projectedPasses: 3, finalSlot: false });
+		for (const maxReviewPassesPerLane of [0, 11, 2.5, "3"]) {
+			expect(
+				evaluateRalplanReviewLaneBudget({ rows: firstIteration, stage: "architect", maxReviewPassesPerLane }),
+			).toMatchObject({ allowed: false, maxReviewPassesPerLane: 1 });
+		}
+	});
+
+	it("fails closed from missing, malformed, and truncated lane ledgers while intact rows do not over-refuse", async () => {
+		const root = await tempDir();
+		const writeRunArtifact = async (runId: string, fileName: string, content = "# architect\n") => {
+			const runDir = ralplanRunDir(root, runId);
+			await fs.mkdir(runDir, { recursive: true });
+			await fs.writeFile(path.join(runDir, fileName), content, "utf-8");
+			return runDir;
+		};
+
+		await writeRunArtifact("absent", "stage-01-architect.md");
+		const absent = await writeRalplanArtifact(root, "absent", "architect", 2, "# new architect");
+		expect(absent.status).toBe(3);
+		expect(JSON.parse(absent.stdout ?? "{}")).toMatchObject({ lane: "architect", passes: 1, projected_passes: 2 });
+
+		for (const [runId, index] of [
+			["empty", ""],
+			["malformed", "{not-json\nnot a row\n"],
+		] as const) {
+			const runDir = await writeRunArtifact(runId, "stage-01-architect.md");
+			await fs.writeFile(path.join(runDir, "index.jsonl"), index, "utf-8");
+			const result = await writeRalplanArtifact(root, runId, "architect", 2, `# ${runId} retry`);
+			expect(result.status).toBe(3);
+			expect(JSON.parse(result.stdout ?? "{}").reason).toContain("ledger under-count");
+		}
+
+		const truncatedDir = await writeRunArtifact("truncated", "stage-02-architect.md");
+		await fs.writeFile(truncatedDir + "/index.jsonl", '{"stage":"planner","stage_n":1}\n', "utf-8");
+		const truncated = await writeRalplanArtifact(root, "truncated", "architect", 3, "# truncated retry");
+		expect(truncated.status).toBe(3);
+		expect(JSON.parse(truncated.stdout ?? "{}")).toMatchObject({ passes: 1, projected_passes: 2 });
+
+		const mixedDir = await writeRunArtifact("mixed", "stage-02-architect.md");
+		await fs.writeFile(path.join(mixedDir, "stage-03-architect.md"), "# another architect\n", "utf-8");
+		await fs.writeFile(
+			path.join(mixedDir, "index.jsonl"),
+			'{"stage":"planner","stage_n":1}\nnot-json\n{"stage":"architect","stage_n":2}\n',
+			"utf-8",
+		);
+		const mixed = await writeRalplanArtifact(root, "mixed", "architect", 4, "# mixed retry");
+		expect(mixed.status).toBe(3);
+		expect(JSON.parse(mixed.stdout ?? "{}").reason).toContain("ledger under-count");
+
+		const intactRows = [
+			{ stage: "planner", stageN: 1 },
+			{ stage: "architect", stageN: 2 },
+			{ stage: "revision", stageN: 3 },
+			{ stage: "architect", stageN: 4 },
+		];
+		expect(
+			evaluateRalplanReviewLaneBudget({
+				rows: intactRows,
+				stage: "architect",
+				onDiskLaneCounts: { architect: 2, critic: 0 },
+			}),
+		).toMatchObject({ allowed: false, currentPasses: 1, projectedPasses: 2 });
+	});
+
+	it("fails visibly instead of admitting a lane pass when the on-disk floor cannot be read", async () => {
+		const root = await tempDir();
+		const runId = "lane-floor-readdir-failure";
+		const runDir = ralplanRunDir(root, runId);
+		const indexPath = path.join(runDir, "index.jsonl");
+		const nextArtifactPath = path.join(runDir, "stage-02-architect.md");
+		const indexBefore = '{"stage":"planner","stage_n":1}\n';
+		await fs.mkdir(runDir, { recursive: true });
+		await fs.writeFile(path.join(runDir, "stage-01-architect.md"), "# existing architect pass\n", "utf-8");
+		await fs.writeFile(indexPath, indexBefore, "utf-8");
+
+		const injectedError = Object.assign(new Error("EIO: injected lane-floor readdir failure"), { code: "EIO" });
+		const readdirSpy = spyOn(fs, "readdir").mockRejectedValue(injectedError);
+		try {
+			const result = await writeRalplanArtifact(root, runId, "architect", 2, "# extra architect pass");
+			expect(result.status).toBe(1);
+			expect(result.stderr).toContain(injectedError.message);
+		} finally {
+			readdirSpy.mockRestore();
+		}
+
+		expect(existsSync(nextArtifactPath)).toBe(false);
+		expect(await fs.readFile(indexPath, "utf-8")).toBe(indexBefore);
+	});
+
+});
+
+describe("ralplan crash-gap dedupe repair", () => {
+	it("repairs an identical on-disk retry without consuming a second lane pass", async () => {
+		const root = await tempDir();
+		const runId = "repair-identical";
+		const runDir = ralplanRunDir(root, runId);
+		await fs.mkdir(runDir, { recursive: true });
+		await fs.writeFile(path.join(runDir, "stage-02-architect.md"), "# artifact C\n", "utf-8");
+
+		const result = await writeRalplanArtifact(root, runId, "architect", 2, "# artifact C");
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.deduplicated).toBe(true);
+		expect(payload.review_budget_warning).toBeUndefined();
+		expect(result.stdout).not.toContain(PLANNING_STUCK_MARKER);
+		const indexLines = (await fs.readFile(path.join(runDir, "index.jsonl"), "utf-8"))
+			.trim()
+			.split("\n")
+			.filter(Boolean);
+		expect(indexLines).toHaveLength(1);
+		const repairedRow = JSON.parse(indexLines[0]);
+		expect(repairedRow).toMatchObject({ stage: "architect", stage_n: 2, path: path.join(runDir, "stage-02-architect.md") });
+		const repairedDecision = evaluateRalplanReviewLaneBudget({
+			rows: [{ stage: repairedRow.stage, stageN: repairedRow.stage_n }],
+			stage: "architect",
+			onDiskLaneCounts: { architect: 1, critic: 0 },
+		});
+		expect(repairedDecision).toMatchObject({ currentPasses: 1, projectedPasses: 2 });
+		expect(repairedDecision.ledgerNote).toBeUndefined();
+	});
+
+	it("refuses a different-content crash-gap retry without touching the artifact or ledger", async () => {
+		const root = await tempDir();
+		const runId = "repair-conflict";
+		const runDir = ralplanRunDir(root, runId);
+		const artifactPath = path.join(runDir, "stage-02-architect.md");
+		await fs.mkdir(runDir, { recursive: true });
+		await fs.writeFile(artifactPath, "# original\n", "utf-8");
+
+		const result = await writeRalplanArtifact(root, runId, "architect", 2, "# different");
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("refusing to overwrite ralplan architect stage 2");
+		expect(await fs.readFile(artifactPath, "utf-8")).toBe("# original\n");
+		await expect(fs.readFile(path.join(runDir, "index.jsonl"), "utf-8")).rejects.toThrow();
+	});
+
+	it("fails a crash-gap probe read without replacing the artifact or ledger", async () => {
+		const root = await tempDir();
+		const runId = "repair-read-failure";
+		const runDir = ralplanRunDir(root, runId);
+		const artifactPath = path.join(runDir, "stage-02-final.md");
+		const indexPath = path.join(runDir, "index.jsonl");
+		const artifactBefore = "# existing final\n";
+		const indexBefore = '{"stage":"planner","stage_n":1}\n';
+		await fs.mkdir(runDir, { recursive: true });
+		await fs.writeFile(artifactPath, artifactBefore, "utf-8");
+		await fs.writeFile(indexPath, indexBefore, "utf-8");
+
+		const originalReadFile = fs.readFile;
+		const injectedError = Object.assign(new Error("EIO: injected crash-gap artifact read failure"), { code: "EIO" });
+		const readSpy = spyOn(fs, "readFile").mockImplementation(async (...args: any[]) => {
+			const target = typeof args[0] === "string" ? args[0] : String(args[0]);
+			if (path.resolve(target) === artifactPath) throw injectedError;
+			return await (originalReadFile as (...readArgs: any[]) => Promise<any>)(...args);
+		});
+		try {
+			const result = await writeRalplanArtifact(root, runId, "final", 2, "# replacement final");
+			expect(result.status).toBe(1);
+			expect(result.stderr).toContain(injectedError.message);
+		} finally {
+			readSpy.mockRestore();
+		}
+
+		expect(await fs.readFile(artifactPath, "utf-8")).toBe(artifactBefore);
+		expect(await fs.readFile(indexPath, "utf-8")).toBe(indexBefore);
+	});
+
+	it("repairs a final-stage crash gap and recreates pending-approval.md", async () => {
+		const root = await tempDir();
+		const runId = "repair-final-no-ledger";
+		const runDir = ralplanRunDir(root, runId);
+		const artifactPath = path.join(runDir, "stage-02-final.md");
+		const pendingApprovalPath = path.join(runDir, "pending-approval.md");
+		await fs.mkdir(runDir, { recursive: true });
+		await fs.writeFile(artifactPath, "# recovered final\n", "utf-8");
+
+		const repaired = await writeRalplanArtifact(root, runId, "final", 2, "# recovered final");
+		expect(repaired.status).toBe(0);
+		expect(JSON.parse(repaired.stdout ?? "{}")).toMatchObject({
+			deduplicated: true,
+			pending_approval_path: pendingApprovalPath,
+		});
+		expect(await fs.readFile(pendingApprovalPath, "utf-8")).toBe("# recovered final\n");
+		const repairedRows = (await fs.readFile(path.join(runDir, "index.jsonl"), "utf-8"))
+			.trim()
+			.split("\n")
+			.map(line => JSON.parse(line));
+		expect(repairedRows).toEqual([
+			expect.objectContaining({ stage: "final", stage_n: 2, path: artifactPath }),
+		]);
+	});
+
+	it("recreates a missing pending approval for ledger-backed final dedupe and refuses a mismatch", async () => {
+		const root = await tempDir();
+		const runId = "repair-final-ledger";
+		const pendingApprovalPath = ralplanPlanPath(root, runId, "pending-approval.md");
+		expect((await writeRalplanArtifact(root, runId, "final", 2, "# ledger final")).status).toBe(0);
+		await fs.rm(pendingApprovalPath);
+
+		const recreated = await writeRalplanArtifact(root, runId, "final", 2, "# ledger final");
+		expect(recreated.status).toBe(0);
+		expect(JSON.parse(recreated.stdout ?? "{}")).toMatchObject({
+			deduplicated: true,
+			pending_approval_path: pendingApprovalPath,
+		});
+		expect(await fs.readFile(pendingApprovalPath, "utf-8")).toBe("# ledger final\n");
+
+		await fs.writeFile(pendingApprovalPath, "# stale pending\n", "utf-8");
+		const mismatch = await writeRalplanArtifact(root, runId, "final", 2, "# ledger final");
+		expect(mismatch.status).toBe(2);
+		expect(mismatch.stderr).toContain("pending approval content mismatch");
+		expect(await fs.readFile(pendingApprovalPath, "utf-8")).toBe("# stale pending\n");
+	});
+
+	it("does not consume a raised-budget second slot while repairing a crash gap", async () => {
+		const root = await tempDir();
+		const runId = "repair-raised-budget";
+		const runDir = ralplanRunDir(root, runId);
+		await fs.mkdir(path.join(root, ".gjc"), { recursive: true });
+		await fs.writeFile(
+			path.join(root, ".gjc", "settings.json"),
+			JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 2 } } }),
+			"utf-8",
+		);
+		await fs.mkdir(runDir, { recursive: true });
+		await fs.writeFile(path.join(runDir, "stage-02-architect.md"), "# repaired\n", "utf-8");
+
+		expect((await writeRalplanArtifact(root, runId, "architect", 2, "# repaired")).status).toBe(0);
+		const newPass = await writeRalplanArtifact(root, runId, "architect", 3, "# genuinely new");
+		expect(newPass.status).toBe(0);
+		expect(JSON.parse(newPass.stdout ?? "{}").review_budget_warning).toEqual({ lane: "architect", passes: 2, max: 2 });
+	});
+
+	it("deduplicates a repaired short row before consuming a raised-budget slot", async () => {
+		const root = await tempDir();
+		const runId = "repair-short-row";
+		const runDir = ralplanRunDir(root, runId);
+		await fs.mkdir(path.join(root, ".gjc"), { recursive: true });
+		await fs.writeFile(
+			path.join(root, ".gjc", "settings.json"),
+			JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 2 } } }),
+			"utf-8",
+		);
+		await fs.mkdir(runDir, { recursive: true });
+		await fs.writeFile(path.join(runDir, "stage-02-architect.md"), "# short row\n", "utf-8");
+		await fs.writeFile(path.join(runDir, "index.jsonl"), '{"stage":"architect","stage_n":2}\n', "utf-8");
+
+		const repaired = await writeRalplanArtifact(root, runId, "architect", 2, "# short row");
+		expect(repaired.status).toBe(0);
+		expect(JSON.parse(repaired.stdout ?? "{}").deduplicated).toBe(true);
+		const repairedRows = (await fs.readFile(path.join(runDir, "index.jsonl"), "utf-8"))
+			.trim()
+			.split("\n")
+			.map(line => JSON.parse(line));
+		expect(repairedRows).toHaveLength(2);
+		expect(repairedRows.filter(row => typeof row.path === "string" && typeof row.sha256 === "string")).toHaveLength(1);
+		expect(
+			evaluateRalplanReviewLaneBudget({
+				rows: repairedRows.map(row => ({ stage: row.stage, stageN: row.stage_n })),
+				stage: "architect",
+				maxReviewPassesPerLane: 2,
+				onDiskLaneCounts: { architect: 1, critic: 0 },
+			}),
+		).toMatchObject({ allowed: true, currentPasses: 1, projectedPasses: 2, finalSlot: true });
+
+		const newPass = await writeRalplanArtifact(root, runId, "architect", 3, "# genuinely new");
+		expect(newPass.status).toBe(0);
+		expect(JSON.parse(newPass.stdout ?? "{}").review_budget_warning).toEqual({ lane: "architect", passes: 2, max: 2 });
+		const persistedRows = (await fs.readFile(path.join(runDir, "index.jsonl"), "utf-8"))
+			.trim()
+			.split("\n")
+			.map(line => JSON.parse(line));
+		expect(persistedRows.filter(row => row.stage === "architect" && row.stage_n === 3)).toHaveLength(1);
+	});
+});
+
+describe("ralplan review lane budget settings", () => {
+	it("resolves nested and flat settings with project-over-user precedence", async () => {
+		const root = await tempDir();
+		const userDir = await tempDir();
+		const previousConfigDir = process.env.GJC_CONFIG_DIR;
+		try {
+			process.env.GJC_CONFIG_DIR = userDir;
+			await fs.writeFile(
+				path.join(userDir, "settings.json"),
+				JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 2 } } }),
+				"utf-8",
+			);
+			await fs.mkdir(path.join(root, ".gjc"), { recursive: true });
+			const projectPath = path.join(root, ".gjc", "settings.json");
+			await fs.writeFile(
+				projectPath,
+				JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 3 } } }),
+				"utf-8",
+			);
+			expect(await resolveRalplanMaxReviewPassesPerLane(root)).toEqual({
+				maxReviewPassesPerLane: 3,
+				source: projectPath,
+			});
+
+			await fs.writeFile(projectPath, JSON.stringify({ "gjc.ralplan.maxReviewPassesPerLane": 4 }), "utf-8");
+			expect(await resolveRalplanMaxReviewPassesPerLane(root)).toEqual({
+				maxReviewPassesPerLane: 4,
+				source: projectPath,
+			});
+		} finally {
+			if (previousConfigDir === undefined) delete process.env.GJC_CONFIG_DIR;
+			else process.env.GJC_CONFIG_DIR = previousConfigDir;
+		}
+	});
+
+	it("rejects malformed project settings instead of falling through to a user override", async () => {
+		const root = await tempDir();
+		const userDir = await tempDir();
+		const previousConfigDir = process.env.GJC_CONFIG_DIR;
+		try {
+			process.env.GJC_CONFIG_DIR = userDir;
+			await fs.writeFile(
+				path.join(userDir, "settings.json"),
+				JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 2 } } }),
+				"utf-8",
+			);
+			await fs.mkdir(path.join(root, ".gjc"), { recursive: true });
+			const projectPath = path.join(root, ".gjc", "settings.json");
+			await fs.writeFile(projectPath, "{invalid JSON", "utf-8");
+
+			await expect(resolveRalplanMaxReviewPassesPerLane(root)).rejects.toThrow(projectPath);
+		} finally {
+			if (previousConfigDir === undefined) delete process.env.GJC_CONFIG_DIR;
+			else process.env.GJC_CONFIG_DIR = previousConfigDir;
+		}
+	});
+
+	it("rejects an invalid present project value rather than defaulting", async () => {
+		const root = await tempDir();
+		const projectPath = path.join(root, ".gjc", "settings.json");
+		await fs.mkdir(path.dirname(projectPath), { recursive: true });
+		await fs.writeFile(
+			projectPath,
+			JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 99 } } }),
+			"utf-8",
+		);
+
+		await expect(resolveRalplanMaxReviewPassesPerLane(root)).rejects.toThrow(projectPath);
+	});
+});
+
+describe("ralplan review lane budget replays", () => {
+	it("refuses only the pathological same-iteration lane retries and preserves final escalation", async () => {
+		const root = await tempDir();
+		const runId = "pathological-replay";
+		const sequence = [
+			["planner", "planner"],
+			["a1", "architect"],
+			["c1", "critic"],
+			["a2", "architect"],
+			["rev2", "revision"],
+			["c2", "critic"],
+			["a3", "architect"],
+			["rev3", "revision"],
+			["c3", "critic"],
+			["a4", "architect"],
+			["rev4", "revision"],
+			["c4", "critic"],
+			["a5", "architect"],
+			["a6", "architect"],
+			["rev5", "revision"],
+			["c5", "critic"],
+			["a7", "architect"],
+			["rev6", "revision"],
+			["c6", "critic"],
+			["a8", "architect"],
+		] as const;
+		const results = new Map<string, Awaited<ReturnType<typeof writeRalplanArtifact>>>();
+		for (const [index, [label, stage]] of sequence.entries()) {
+			results.set(label, await writeRalplanArtifact(root, runId, stage, index + 1, `# ${label}`));
+		}
+		const refusals = [...results.entries()]
+			.filter(([, result]) => result.status === 3)
+			.map(([label]) => label);
+		expect(refusals).toEqual(["a2", "a6", "rev6", "c6", "a8"]);
+		for (const [label, result] of results) {
+			expect(result.status).toBe(refusals.includes(label) ? 3 : 0);
+		}
+		for (const label of ["a2", "a6", "c6", "a8"]) {
+			const payload = JSON.parse(results.get(label)?.stdout ?? "{}");
+			expect(payload).toMatchObject({ planning_stuck: true, marker: PLANNING_STUCK_MARKER });
+			expect(["architect", "critic"]).toContain(payload.lane);
+			expect(typeof payload.passes).toBe("number");
+			expect(typeof payload.max_review_passes_per_lane).toBe("number");
+		}
+		const openerPayload = JSON.parse(results.get("rev6")?.stdout ?? "{}");
+		expect(openerPayload).toMatchObject({ planning_stuck: true, max_iterations: 5, projected_iteration: 6 });
+
+		const final = await writeRalplanArtifact(root, runId, "final", sequence.length + 1, "# best effort final");
+		expect(final.status).toBe(0);
+		expect(JSON.parse(final.stdout ?? "{}").pending_approval_path).toBeDefined();
+	});
+
+	it("keeps healthy t3code and browser-use shaped replays free of warnings and stuck signals", async () => {
+		const root = await tempDir();
+		const replay = async (runId: string, stages: readonly string[]) => {
+			const results = [];
+			for (const [index, stage] of stages.entries()) {
+				results.push(await writeRalplanArtifact(root, runId, stage, index + 1, `# ${stage} ${index + 1}`));
+			}
+			return results;
+		};
+		const t3code = await replay("healthy-t3code", ["planner", "architect", "critic", "revision", "architect", "critic", "final"]);
+		const browserUse = await replay("healthy-browser-use", ["planner", "architect", "critic", "final"]);
+		for (const result of [...t3code, ...browserUse]) {
+			expect(result.status).toBe(0);
+			expect(result.stdout).not.toContain(PLANNING_STUCK_MARKER);
+			expect(JSON.parse(result.stdout ?? "{}").review_budget_warning).toBeUndefined();
+		}
+	});
+});
+
+describe("ralplan review lane budget rigor and receipts", () => {
+	it("does not parse or demote a justified critic blocker, while exhausted openers remain visibly stuck", async () => {
+		const root = await tempDir();
+		const runId = "rigor-preserved";
+		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# initial plan")).status).toBe(0);
+		const critic = await writeRalplanArtifact(
+			root,
+			runId,
+			"critic",
+			2,
+			"Verdict: ITERATE\n\nNew blocker: a newly discovered integration boundary requires a revision.\n",
+		);
+		expect(critic.status).toBe(0);
+		expect((await writeRalplanArtifact(root, runId, "revision", 3, "# justified revision")).status).toBe(0);
+		for (let stageN = 4; stageN <= 6; stageN++) {
+			expect((await writeRalplanArtifact(root, runId, "revision", stageN, `# revision ${stageN}`)).status).toBe(0);
+		}
+		const stuck = await writeRalplanArtifact(root, runId, "revision", 7, "# unresolved issue remains");
+		expect(stuck.status).toBe(3);
+		expect(stuck.stdout).toContain(PLANNING_STUCK_MARKER);
+		expect(stuck.stderr).toContain(PLANNING_STUCK_MARKER);
+		expect((await writeRalplanArtifact(root, runId, "final", 8, "# escalated final")).status).toBe(0);
+	});
+
+	it("warns only on a raised-budget final slot and returns lane-specific stuck receipts", async () => {
+		const root = await tempDir();
+		const runId = "warning-json";
+		await fs.mkdir(path.join(root, ".gjc"), { recursive: true });
+		await fs.writeFile(
+			path.join(root, ".gjc", "settings.json"),
+			JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 2 } } }),
+			"utf-8",
+		);
+		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
+		expect((await writeRalplanArtifact(root, runId, "architect", 2, "# architect one")).status).toBe(0);
+		const second = await writeRalplanArtifact(root, runId, "architect", 3, "# architect two");
+		expect(second.status).toBe(0);
+		expect(JSON.parse(second.stdout ?? "{}").review_budget_warning).toEqual({ lane: "architect", passes: 2, max: 2 });
+		const third = await writeRalplanArtifact(root, runId, "architect", 4, "# architect three");
+		expect(third.status).toBe(3);
+		const stuckPayload = JSON.parse(third.stdout ?? "{}");
+		expect(stuckPayload).toMatchObject({
+			ok: false,
+			planning_stuck: true,
+			marker: PLANNING_STUCK_MARKER,
+			lane: "architect",
+			passes: 2,
+			projected_passes: 3,
+			max_review_passes_per_lane: 2,
+		});
+		expect(stuckPayload.iteration).toBeUndefined();
+		expect(stuckPayload.max_iterations).toBeUndefined();
+
+		const textRoot = await tempDir();
+		const textRunId = "warning-text";
+		await fs.mkdir(path.join(textRoot, ".gjc"), { recursive: true });
+		await fs.writeFile(
+			path.join(textRoot, ".gjc", "settings.json"),
+			JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 2 } } }),
+			"utf-8",
+		);
+		expect((await writeRalplanArtifact(textRoot, textRunId, "planner", 1, "# plan")).status).toBe(0);
+		expect((await writeRalplanArtifact(textRoot, textRunId, "architect", 2, "# architect one")).status).toBe(0);
+		const textSecond = await writeRalplanArtifact(textRoot, textRunId, "architect", 3, "# architect two", false);
+		expect(textSecond.status).toBe(0);
+		expect(textSecond.stdout).toContain("Warning: ralplan architect review budget final slot used (2/2).");
+		const textThird = await writeRalplanArtifact(textRoot, textRunId, "architect", 4, "# architect three", false);
+		expect(textThird.status).toBe(3);
+		expect(textThird.stdout).toBe(`${PLANNING_STUCK_MARKER}\n`);
+		expect(textThird.stderr).toContain("Stop re-invoking the architect review lane");
+
+		const defaultRoot = await tempDir();
+		const defaultResult = await writeRalplanArtifact(defaultRoot, "default-no-warning", "architect", 1, "# default pass");
+		expect(defaultResult.status).toBe(0);
+		expect(JSON.parse(defaultResult.stdout ?? "{}").review_budget_warning).toBeUndefined();
+	});
+});
+
+describe("ralplan HUD lane verdict carriage", () => {
+	it("composes current-lane pass counts and the latest lane verdict", async () => {
+		const root = await tempDir();
+		const runId = "hud-composition";
+		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
+
+		const architect = await writeRalplanLaneVerdictArtifact(root, runId, "architect", 2, "# architecture", "BLOCK");
+		expect(architect.status).toBe(0);
+		expect(JSON.parse(architect.stdout ?? "{}").lane_verdict).toEqual({ lane: "architect", verdict: "BLOCK" });
+
+		const critic = await writeRalplanLaneVerdictArtifact(root, runId, "critic", 3, "# critique", "iterate");
+		expect(critic.status).toBe(0);
+		expect(JSON.parse(critic.stdout ?? "{}").lane_verdict).toEqual({ lane: "critic", verdict: "ITERATE" });
+		expect(JSON.parse(await fs.readFile(ralplanStatePath(root), "utf-8"))).toMatchObject({
+			last_review_verdict: "ITERATE",
+			last_review_verdict_lane: "critic",
+			last_review_verdict_stage_n: 3,
+		});
+
+		const chips = await readRalplanHudChips(root);
+		expect(chips.find(chip => chip.label === "arch")?.value).toBe("1/1");
+		expect(chips.find(chip => chip.label === "crit")?.value).toBe("1/1");
+		expect(chips.find(chip => chip.label === "verdict")?.value).toBe("ITERATE");
+	});
+
+	it("applies a riding lane verdict while repairing an identical crash-gap artifact", async () => {
+		const root = await tempDir();
+		const runId = "hud-crash-gap-verdict";
+		const runDir = ralplanRunDir(root, runId);
+		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
+		await fs.mkdir(runDir, { recursive: true });
+		await fs.writeFile(path.join(runDir, "stage-02-architect.md"), "# architecture\n", "utf-8");
+
+		const repaired = await writeRalplanLaneVerdictArtifact(root, runId, "architect", 2, "# architecture", "WATCH");
+		expect(repaired.status).toBe(0);
+		expect(JSON.parse(repaired.stdout ?? "{}")).toMatchObject({
+			deduplicated: true,
+			lane_verdict: { lane: "architect", verdict: "WATCH" },
+		});
+		expect(JSON.parse(await fs.readFile(ralplanStatePath(root), "utf-8"))).toMatchObject({
+			last_review_verdict: "WATCH",
+			last_review_verdict_lane: "architect",
+			last_review_verdict_stage_n: 2,
+		});
+	});
+
+	it("does not carry a stale crash-gap lane verdict into another active run", async () => {
+		const root = await tempDir();
+		const staleRunId = "hud-stale-repair";
+		const activeRunId = "hud-active-run";
+		const staleRunDir = ralplanRunDir(root, staleRunId);
+		expect((await writeRalplanArtifact(root, staleRunId, "planner", 1, "# stale plan")).status).toBe(0);
+		await fs.writeFile(path.join(staleRunDir, "stage-02-architect.md"), "# stale architecture\n", "utf-8");
+		expect((await writeRalplanArtifact(root, activeRunId, "planner", 1, "# active plan")).status).toBe(0);
+
+		const repaired = await writeRalplanLaneVerdictArtifact(
+			root,
+			staleRunId,
+			"architect",
+			2,
+			"# stale architecture",
+			"BLOCK",
+		);
+		expect(repaired.status).toBe(0);
+		expect(JSON.parse(repaired.stdout ?? "{}").lane_verdict).toBeUndefined();
+		const state = JSON.parse(await fs.readFile(ralplanStatePath(root), "utf-8"));
+		expect(state.run_id).toBe(activeRunId);
+		for (const key of ["last_review_verdict", "last_review_verdict_lane", "last_review_verdict_stage_n"]) {
+			expect(Object.hasOwn(state, key)).toBe(false);
+		}
+
+		const verdictlessActiveWrite = await writeRalplanArtifact(root, activeRunId, "architect", 2, "# active architecture");
+		expect(verdictlessActiveWrite.status).toBe(0);
+		const chips = await readRalplanHudChips(root);
+		expect(chips.some(chip => chip.value === "BLOCK")).toBe(false);
+		expect(chips.find(chip => chip.label === "verdict")).toBeUndefined();
+	});
+
+	it("preserves the run-state lane verdict through a state write followed by a verdict-less artifact write", async () => {
+		const root = await tempDir();
+		const runId = "hud-state-then-artifact";
+		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
+		expect((await writeRalplanLaneVerdictArtifact(root, runId, "architect", 2, "# architecture", "BLOCK")).status).toBe(0);
+		expect(
+			(
+				await runNativeStateCommand(
+					["write", "--mode", "ralplan", "--input", JSON.stringify({ verdict: "ITERATE" })],
+					root,
+				)
+			).status,
+		).toBe(0);
+		expect((await writeRalplanArtifact(root, runId, "critic", 3, "# critique")).status).toBe(0);
+
+		const state = JSON.parse(await fs.readFile(ralplanStatePath(root), "utf-8"));
+		expect(state).toMatchObject({ last_review_verdict: "BLOCK", verdict: "ITERATE" });
+		expect((await readRalplanHudChips(root)).find(chip => chip.label === "verdict")?.value).toBe("BLOCK");
+	});
+
+	it("uses the resolved per-lane budget as the review-pass denominator", async () => {
+		const root = await tempDir();
+		const runId = "hud-budget-denominator";
+		await fs.mkdir(path.join(root, ".gjc"), { recursive: true });
+		await fs.writeFile(
+			path.join(root, ".gjc", "settings.json"),
+			JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 3 } } }),
+			"utf-8",
+		);
+		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
+		expect((await writeRalplanLaneVerdictArtifact(root, runId, "architect", 2, "# architecture", "CLEAR")).status).toBe(0);
+		expect((await readRalplanHudChips(root)).find(chip => chip.label === "arch")?.value).toBe("1/3");
+	});
+
+	it("keeps artifact HUDs within six chips and omits lane counts on the final path", async () => {
+		const root = await tempDir();
+		const runId = "hud-chip-cap";
+		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
+		expect((await writeRalplanLaneVerdictArtifact(root, runId, "architect", 2, "# architecture", "CLEAR")).status).toBe(0);
+		expect((await writeRalplanLaneVerdictArtifact(root, runId, "critic", 3, "# critique", "OKAY")).status).toBe(0);
+		const reviewChips = await readRalplanHudChips(root);
+		expect(reviewChips).toHaveLength(6);
+		expect(reviewChips.map(chip => chip.label)).toEqual(["stage", "iter", "stages", "arch", "crit", "verdict"]);
+
+		expect((await writeRalplanArtifact(root, runId, "final", 4, "# final")).status).toBe(0);
+		const finalChips = await readRalplanHudChips(root);
+		expect(finalChips.length).toBeLessThanOrEqual(6);
+		expect(finalChips.map(chip => chip.label)).toEqual(["pending", "stage", "iter", "stages", "verdict"]);
+	});
+
+	it("rejects invalid, wrong-lane, and non-lane --lane-verdict values", async () => {
+		const root = await tempDir();
+		const write = async (stage: string, verdict: string) =>
+			await runNativeRalplanCommand(
+				[
+					"--write",
+					"--stage",
+					stage,
+					"--stage_n",
+					"1",
+					"--artifact",
+					"# artifact",
+					"--run-id",
+					"hud-invalid-verdict",
+					"--lane-verdict",
+					verdict,
+					"--json",
+				],
+				root,
+			);
+		for (const [stage, verdict] of [
+			["architect", "NOPE"],
+			["architect", "OKAY"],
+			["planner", "CLEAR"],
+		] as const) {
+			const result = await write(stage, verdict);
+			expect(result.status).toBe(2);
+			expect(result.stderr).toContain("--lane-verdict");
+		}
+	});
+
+	it("clears both verdict sources when a new run starts and rebuilds HUD state", async () => {
+		const root = await tempDir();
+		const runOne = "hud-reset-one";
+		const runTwo = "hud-reset-two";
+		expect((await writeRalplanArtifact(root, runOne, "planner", 1, "# plan one")).status).toBe(0);
+		expect((await writeRalplanLaneVerdictArtifact(root, runOne, "critic", 2, "# critique one", "ITERATE")).status).toBe(0);
+		expect(
+			(
+				await runNativeStateCommand(
+					["write", "--mode", "ralplan", "--input", JSON.stringify({ verdict: "BLOCK" })],
+					root,
+				)
+			).status,
+		).toBe(0);
+
+		expect((await writeRalplanArtifact(root, runTwo, "planner", 1, "# plan two")).status).toBe(0);
+		expect((await readRalplanHudChips(root)).some(chip => chip.label === "verdict")).toBe(false);
+		const switchedState = JSON.parse(await fs.readFile(ralplanStatePath(root), "utf-8"));
+		for (const key of ["verdict", "last_review_verdict", "last_review_verdict_lane", "last_review_verdict_stage_n"]) {
+			expect(Object.hasOwn(switchedState, key)).toBe(false);
+		}
+
+		expect(
+			(
+				await runNativeStateCommand(
+					["write", "--mode", "ralplan", "--input", JSON.stringify({ marker: "verdict-less-rebuild" })],
+					root,
+				)
+			).status,
+		).toBe(0);
+		expect((await readRalplanHudChips(root)).some(chip => chip.label === "verdict")).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -21,8 +21,8 @@ import {
 	modeStatePath,
 	sessionPlansDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
-import { readVisibleSkillActiveState } from "@gajae-code/coding-agent/skill-state/active-state";
 import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+import { readVisibleSkillActiveState } from "@gajae-code/coding-agent/skill-state/active-state";
 
 const TEST_SESSION_ID = "test-session";
 const tempRoots: string[] = [];
@@ -1587,7 +1587,7 @@ describe("ralplan review lane budget", () => {
 		}
 
 		const truncatedDir = await writeRunArtifact("truncated", "stage-02-architect.md");
-		await fs.writeFile(truncatedDir + "/index.jsonl", '{"stage":"planner","stage_n":1}\n', "utf-8");
+		await fs.writeFile(path.join(truncatedDir, "index.jsonl"), '{"stage":"planner","stage_n":1}\n', "utf-8");
 		const truncated = await writeRalplanArtifact(root, "truncated", "architect", 3, "# truncated retry");
 		expect(truncated.status).toBe(3);
 		expect(JSON.parse(truncated.stdout ?? "{}")).toMatchObject({ passes: 1, projected_passes: 2 });
@@ -1642,7 +1642,6 @@ describe("ralplan review lane budget", () => {
 		expect(existsSync(nextArtifactPath)).toBe(false);
 		expect(await fs.readFile(indexPath, "utf-8")).toBe(indexBefore);
 	});
-
 });
 
 describe("ralplan crash-gap dedupe repair", () => {
@@ -1665,7 +1664,11 @@ describe("ralplan crash-gap dedupe repair", () => {
 			.filter(Boolean);
 		expect(indexLines).toHaveLength(1);
 		const repairedRow = JSON.parse(indexLines[0]);
-		expect(repairedRow).toMatchObject({ stage: "architect", stage_n: 2, path: path.join(runDir, "stage-02-architect.md") });
+		expect(repairedRow).toMatchObject({
+			stage: "architect",
+			stage_n: 2,
+			path: path.join(runDir, "stage-02-architect.md"),
+		});
 		const repairedDecision = evaluateRalplanReviewLaneBudget({
 			rows: [{ stage: repairedRow.stage, stageN: repairedRow.stage_n }],
 			stage: "architect",
@@ -1741,9 +1744,7 @@ describe("ralplan crash-gap dedupe repair", () => {
 			.trim()
 			.split("\n")
 			.map(line => JSON.parse(line));
-		expect(repairedRows).toEqual([
-			expect.objectContaining({ stage: "final", stage_n: 2, path: artifactPath }),
-		]);
+		expect(repairedRows).toEqual([expect.objectContaining({ stage: "final", stage_n: 2, path: artifactPath })]);
 	});
 
 	it("recreates a missing pending approval for ledger-backed final dedupe and refuses a mismatch", async () => {
@@ -1784,7 +1785,11 @@ describe("ralplan crash-gap dedupe repair", () => {
 		expect((await writeRalplanArtifact(root, runId, "architect", 2, "# repaired")).status).toBe(0);
 		const newPass = await writeRalplanArtifact(root, runId, "architect", 3, "# genuinely new");
 		expect(newPass.status).toBe(0);
-		expect(JSON.parse(newPass.stdout ?? "{}").review_budget_warning).toEqual({ lane: "architect", passes: 2, max: 2 });
+		expect(JSON.parse(newPass.stdout ?? "{}").review_budget_warning).toEqual({
+			lane: "architect",
+			passes: 2,
+			max: 2,
+		});
 	});
 
 	it("deduplicates a repaired short row before consuming a raised-budget slot", async () => {
@@ -1809,7 +1814,9 @@ describe("ralplan crash-gap dedupe repair", () => {
 			.split("\n")
 			.map(line => JSON.parse(line));
 		expect(repairedRows).toHaveLength(2);
-		expect(repairedRows.filter(row => typeof row.path === "string" && typeof row.sha256 === "string")).toHaveLength(1);
+		expect(repairedRows.filter(row => typeof row.path === "string" && typeof row.sha256 === "string")).toHaveLength(
+			1,
+		);
 		expect(
 			evaluateRalplanReviewLaneBudget({
 				rows: repairedRows.map(row => ({ stage: row.stage, stageN: row.stage_n })),
@@ -1821,7 +1828,11 @@ describe("ralplan crash-gap dedupe repair", () => {
 
 		const newPass = await writeRalplanArtifact(root, runId, "architect", 3, "# genuinely new");
 		expect(newPass.status).toBe(0);
-		expect(JSON.parse(newPass.stdout ?? "{}").review_budget_warning).toEqual({ lane: "architect", passes: 2, max: 2 });
+		expect(JSON.parse(newPass.stdout ?? "{}").review_budget_warning).toEqual({
+			lane: "architect",
+			passes: 2,
+			max: 2,
+		});
 		const persistedRows = (await fs.readFile(path.join(runDir, "index.jsonl"), "utf-8"))
 			.trim()
 			.split("\n")
@@ -1844,11 +1855,7 @@ describe("ralplan review lane budget settings", () => {
 			);
 			await fs.mkdir(path.join(root, ".gjc"), { recursive: true });
 			const projectPath = path.join(root, ".gjc", "settings.json");
-			await fs.writeFile(
-				projectPath,
-				JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 3 } } }),
-				"utf-8",
-			);
+			await fs.writeFile(projectPath, JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 3 } } }), "utf-8");
 			expect(await resolveRalplanMaxReviewPassesPerLane(root)).toEqual({
 				maxReviewPassesPerLane: 3,
 				source: projectPath,
@@ -1891,11 +1898,7 @@ describe("ralplan review lane budget settings", () => {
 		const root = await tempDir();
 		const projectPath = path.join(root, ".gjc", "settings.json");
 		await fs.mkdir(path.dirname(projectPath), { recursive: true });
-		await fs.writeFile(
-			projectPath,
-			JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 99 } } }),
-			"utf-8",
-		);
+		await fs.writeFile(projectPath, JSON.stringify({ gjc: { ralplan: { maxReviewPassesPerLane: 99 } } }), "utf-8");
 
 		await expect(resolveRalplanMaxReviewPassesPerLane(root)).rejects.toThrow(projectPath);
 	});
@@ -1931,9 +1934,7 @@ describe("ralplan review lane budget replays", () => {
 		for (const [index, [label, stage]] of sequence.entries()) {
 			results.set(label, await writeRalplanArtifact(root, runId, stage, index + 1, `# ${label}`));
 		}
-		const refusals = [...results.entries()]
-			.filter(([, result]) => result.status === 3)
-			.map(([label]) => label);
+		const refusals = [...results.entries()].filter(([, result]) => result.status === 3).map(([label]) => label);
 		expect(refusals).toEqual(["a2", "a6", "rev6", "c6", "a8"]);
 		for (const [label, result] of results) {
 			expect(result.status).toBe(refusals.includes(label) ? 3 : 0);
@@ -1962,7 +1963,15 @@ describe("ralplan review lane budget replays", () => {
 			}
 			return results;
 		};
-		const t3code = await replay("healthy-t3code", ["planner", "architect", "critic", "revision", "architect", "critic", "final"]);
+		const t3code = await replay("healthy-t3code", [
+			"planner",
+			"architect",
+			"critic",
+			"revision",
+			"architect",
+			"critic",
+			"final",
+		]);
 		const browserUse = await replay("healthy-browser-use", ["planner", "architect", "critic", "final"]);
 		for (const result of [...t3code, ...browserUse]) {
 			expect(result.status).toBe(0);
@@ -2044,7 +2053,13 @@ describe("ralplan review lane budget rigor and receipts", () => {
 		expect(textThird.stderr).toContain("Stop re-invoking the architect review lane");
 
 		const defaultRoot = await tempDir();
-		const defaultResult = await writeRalplanArtifact(defaultRoot, "default-no-warning", "architect", 1, "# default pass");
+		const defaultResult = await writeRalplanArtifact(
+			defaultRoot,
+			"default-no-warning",
+			"architect",
+			1,
+			"# default pass",
+		);
 		expect(defaultResult.status).toBe(0);
 		expect(JSON.parse(defaultResult.stdout ?? "{}").review_budget_warning).toBeUndefined();
 	});
@@ -2121,7 +2136,13 @@ describe("ralplan HUD lane verdict carriage", () => {
 			expect(Object.hasOwn(state, key)).toBe(false);
 		}
 
-		const verdictlessActiveWrite = await writeRalplanArtifact(root, activeRunId, "architect", 2, "# active architecture");
+		const verdictlessActiveWrite = await writeRalplanArtifact(
+			root,
+			activeRunId,
+			"architect",
+			2,
+			"# active architecture",
+		);
 		expect(verdictlessActiveWrite.status).toBe(0);
 		const chips = await readRalplanHudChips(root);
 		expect(chips.some(chip => chip.value === "BLOCK")).toBe(false);
@@ -2132,7 +2153,9 @@ describe("ralplan HUD lane verdict carriage", () => {
 		const root = await tempDir();
 		const runId = "hud-state-then-artifact";
 		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
-		expect((await writeRalplanLaneVerdictArtifact(root, runId, "architect", 2, "# architecture", "BLOCK")).status).toBe(0);
+		expect(
+			(await writeRalplanLaneVerdictArtifact(root, runId, "architect", 2, "# architecture", "BLOCK")).status,
+		).toBe(0);
 		expect(
 			(
 				await runNativeStateCommand(
@@ -2202,7 +2225,9 @@ describe("ralplan HUD lane verdict carriage", () => {
 			"utf-8",
 		);
 		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
-		expect((await writeRalplanLaneVerdictArtifact(root, runId, "architect", 2, "# architecture", "CLEAR")).status).toBe(0);
+		expect(
+			(await writeRalplanLaneVerdictArtifact(root, runId, "architect", 2, "# architecture", "CLEAR")).status,
+		).toBe(0);
 		expect((await readRalplanHudChips(root)).find(chip => chip.label === "arch")?.value).toBe("1/3");
 	});
 
@@ -2210,7 +2235,9 @@ describe("ralplan HUD lane verdict carriage", () => {
 		const root = await tempDir();
 		const runId = "hud-chip-cap";
 		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
-		expect((await writeRalplanLaneVerdictArtifact(root, runId, "architect", 2, "# architecture", "CLEAR")).status).toBe(0);
+		expect(
+			(await writeRalplanLaneVerdictArtifact(root, runId, "architect", 2, "# architecture", "CLEAR")).status,
+		).toBe(0);
 		expect((await writeRalplanLaneVerdictArtifact(root, runId, "critic", 3, "# critique", "OKAY")).status).toBe(0);
 		const reviewChips = await readRalplanHudChips(root);
 		expect(reviewChips).toHaveLength(6);
@@ -2258,7 +2285,9 @@ describe("ralplan HUD lane verdict carriage", () => {
 		const runOne = "hud-reset-one";
 		const runTwo = "hud-reset-two";
 		expect((await writeRalplanArtifact(root, runOne, "planner", 1, "# plan one")).status).toBe(0);
-		expect((await writeRalplanLaneVerdictArtifact(root, runOne, "critic", 2, "# critique one", "ITERATE")).status).toBe(0);
+		expect(
+			(await writeRalplanLaneVerdictArtifact(root, runOne, "critic", 2, "# critique one", "ITERATE")).status,
+		).toBe(0);
 		expect(
 			(
 				await runNativeStateCommand(

--- a/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
@@ -8,6 +8,7 @@ import {
 	sessionStateDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
 
 const TEST_SESSION_ID = "test-session";
 
@@ -44,6 +45,42 @@ function envelopeState(stdout: string | undefined): Record<string, unknown> {
 	const inner = parsed.state;
 	if (inner && typeof inner === "object" && !Array.isArray(inner)) return inner as Record<string, unknown>;
 	return parsed;
+}
+
+async function writeRalplanArtifact(
+	root: string,
+	runId: string,
+	stage: string,
+	stageN: number,
+	artifact: string,
+	laneVerdict?: string,
+) {
+	return await runNativeRalplanCommand(
+		[
+			"--write",
+			"--stage",
+			stage,
+			"--stage_n",
+			String(stageN),
+			"--artifact",
+			artifact,
+			"--run-id",
+			runId,
+			...(laneVerdict ? ["--lane-verdict", laneVerdict] : []),
+			"--json",
+		],
+		root,
+	);
+}
+
+async function readRalplanHudChips(root: string): Promise<Array<{ label: string; value?: string; severity?: string }>> {
+	const active = JSON.parse(await fs.readFile(activeSnapshotPath(root, TEST_SESSION_ID), "utf-8")) as {
+		active_skills?: Array<{
+			skill: string;
+			hud?: { chips?: Array<{ label: string; value?: string; severity?: string }> };
+		}>;
+	};
+	return active.active_skills?.find(entry => entry.skill === "ralplan")?.hud?.chips ?? [];
 }
 
 describe("native gjc state runtime", () => {
@@ -645,6 +682,51 @@ describe("native gjc state runtime", () => {
 		expect(stage?.value).toBe("architect");
 		expect(verdict?.value).toBe("ITERATE");
 		expect(verdict?.severity).toBe("warning");
+	});
+
+	it("keeps a lane verdict visible after artifact-then-state write order", async () => {
+		const root = await tempDir();
+		const runId = "state-after-artifact";
+		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
+		expect((await writeRalplanArtifact(root, runId, "critic", 2, "# critique", "ITERATE")).status).toBe(0);
+		expect(
+			(
+				await runNativeStateCommand(
+					["write", "--mode", "ralplan", "--input", JSON.stringify({ marker: "after-artifact" })],
+					root,
+				)
+			).status,
+		).toBe(0);
+		expect((await readRalplanHudChips(root)).find(chip => chip.label === "verdict")?.value).toBe("ITERATE");
+	});
+
+	it("prefers a run-scoped lane verdict over a stale legacy ralplan verdict", async () => {
+		const root = await tempDir();
+		const runId = "state-lane-precedence";
+		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
+		expect(
+			(
+				await runNativeStateCommand(
+					["write", "--mode", "ralplan", "--input", JSON.stringify({ verdict: "ITERATE" })],
+					root,
+				)
+			).status,
+		).toBe(0);
+		expect((await writeRalplanArtifact(root, runId, "critic", 2, "# critique", "OKAY")).status).toBe(0);
+		expect(
+			(
+				await runNativeStateCommand(
+					["write", "--mode", "ralplan", "--input", JSON.stringify({ marker: "verdict-less" })],
+					root,
+				)
+			).status,
+		).toBe(0);
+
+		const state = JSON.parse(await fs.readFile(modeStatePath(root, TEST_SESSION_ID, "ralplan"), "utf-8"));
+		expect(state).toMatchObject({ verdict: "ITERATE", last_review_verdict: "OKAY" });
+		const verdict = (await readRalplanHudChips(root)).find(chip => chip.label === "verdict");
+		expect(verdict?.value).toBe("OKAY");
+		expect(verdict?.severity).toBe("success");
 	});
 
 	it("clears the active entry when clearing a workflow receipt", async () => {

--- a/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
@@ -46,7 +46,6 @@ function envelopeState(stdout: string | undefined): Record<string, unknown> {
 	return parsed;
 }
 
-
 describe("native gjc state runtime", () => {
 	it("reads an empty receipt as {}", async () => {
 		const root = await tempDir();
@@ -647,7 +646,6 @@ describe("native gjc state runtime", () => {
 		expect(verdict?.value).toBe("ITERATE");
 		expect(verdict?.severity).toBe("warning");
 	});
-
 
 	it("clears the active entry when clearing a workflow receipt", async () => {
 		const root = await tempDir();

--- a/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
@@ -8,7 +8,6 @@ import {
 	sessionStateDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
-import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
 
 const TEST_SESSION_ID = "test-session";
 
@@ -47,41 +46,6 @@ function envelopeState(stdout: string | undefined): Record<string, unknown> {
 	return parsed;
 }
 
-async function writeRalplanArtifact(
-	root: string,
-	runId: string,
-	stage: string,
-	stageN: number,
-	artifact: string,
-	laneVerdict?: string,
-) {
-	return await runNativeRalplanCommand(
-		[
-			"--write",
-			"--stage",
-			stage,
-			"--stage_n",
-			String(stageN),
-			"--artifact",
-			artifact,
-			"--run-id",
-			runId,
-			...(laneVerdict ? ["--lane-verdict", laneVerdict] : []),
-			"--json",
-		],
-		root,
-	);
-}
-
-async function readRalplanHudChips(root: string): Promise<Array<{ label: string; value?: string; severity?: string }>> {
-	const active = JSON.parse(await fs.readFile(activeSnapshotPath(root, TEST_SESSION_ID), "utf-8")) as {
-		active_skills?: Array<{
-			skill: string;
-			hud?: { chips?: Array<{ label: string; value?: string; severity?: string }> };
-		}>;
-	};
-	return active.active_skills?.find(entry => entry.skill === "ralplan")?.hud?.chips ?? [];
-}
 
 describe("native gjc state runtime", () => {
 	it("reads an empty receipt as {}", async () => {
@@ -684,50 +648,6 @@ describe("native gjc state runtime", () => {
 		expect(verdict?.severity).toBe("warning");
 	});
 
-	it("keeps a lane verdict visible after artifact-then-state write order", async () => {
-		const root = await tempDir();
-		const runId = "state-after-artifact";
-		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
-		expect((await writeRalplanArtifact(root, runId, "critic", 2, "# critique", "ITERATE")).status).toBe(0);
-		expect(
-			(
-				await runNativeStateCommand(
-					["write", "--mode", "ralplan", "--input", JSON.stringify({ marker: "after-artifact" })],
-					root,
-				)
-			).status,
-		).toBe(0);
-		expect((await readRalplanHudChips(root)).find(chip => chip.label === "verdict")?.value).toBe("ITERATE");
-	});
-
-	it("prefers a run-scoped lane verdict over a stale legacy ralplan verdict", async () => {
-		const root = await tempDir();
-		const runId = "state-lane-precedence";
-		expect((await writeRalplanArtifact(root, runId, "planner", 1, "# plan")).status).toBe(0);
-		expect(
-			(
-				await runNativeStateCommand(
-					["write", "--mode", "ralplan", "--input", JSON.stringify({ verdict: "ITERATE" })],
-					root,
-				)
-			).status,
-		).toBe(0);
-		expect((await writeRalplanArtifact(root, runId, "critic", 2, "# critique", "OKAY")).status).toBe(0);
-		expect(
-			(
-				await runNativeStateCommand(
-					["write", "--mode", "ralplan", "--input", JSON.stringify({ marker: "verdict-less" })],
-					root,
-				)
-			).status,
-		).toBe(0);
-
-		const state = JSON.parse(await fs.readFile(modeStatePath(root, TEST_SESSION_ID, "ralplan"), "utf-8"));
-		expect(state).toMatchObject({ verdict: "ITERATE", last_review_verdict: "OKAY" });
-		const verdict = (await readRalplanHudChips(root)).find(chip => chip.label === "verdict");
-		expect(verdict?.value).toBe("OKAY");
-		expect(verdict?.severity).toBe("success");
-	});
 
 	it("clears the active entry when clearing a workflow receipt", async () => {
 		const root = await tempDir();

--- a/packages/coding-agent/test/ralplan-decision-artifacts.test.ts
+++ b/packages/coding-agent/test/ralplan-decision-artifacts.test.ts
@@ -57,6 +57,62 @@ const staleCriticApprovalPatterns = [
 	/without `APPROVE`/u,
 ] as const;
 
+const criticReReviewRatchetPatterns = [
+	/<re_review_ratchet>/u,
+	/Rule 1 \(delta-only\): from pass 2, review only the delta against the prior pass/u,
+	/The prior pass is identified by the re-review context bundle \(WI-3\): prior reviewed-plan path, prior same-lane review path, and the explicit run-level pass number supplied in the assignment\./u,
+	/Rule 2 \(novelty justification\): a new blocker on previously-reviewed ground requires an explicit "why this was not visible in the prior pass" justification/u,
+	/Rule 3 \(verdict monotonicity\): once all blockers from the prior pass are resolved, the verdict must not worsen/u,
+	/Rule 4 \(severity discipline\): carryover blockers \(raised in a prior pass, still unresolved\) remain blocking regardless of pass number/u,
+	/Rule 5 \(counter-review duty\): from pass 2, Critic also reviews the Architect output \(routed via the context bundle\) for over-engineering and unnecessary scope expansion/u,
+	/do NOT convert unjustified Architect demands into ITERATE/u,
+	/Enrichment lane \("spec too thin — expand"\) preserved verbatim but justification-gated from pass 2: expansion requests on already-reviewed ground need the rule-2 justification\./u,
+] as const;
+
+const architectReReviewRatchetPatterns = [
+	/<re_review_ratchet>/u,
+	/Rule 1 \(delta-only\): from pass 2, review only the delta against the prior pass/u,
+	/Rule 2 \(novelty justification\): a new blocker on previously-reviewed ground requires an explicit "why this was not visible in the prior pass" justification/u,
+	/Rule 3 \(verdict monotonicity\): once all blockers from the prior pass are resolved, neither Architectural Status/u,
+	/Architectural Status \(`CLEAR`\/`WATCH`\/`BLOCK`\) nor Code Review Recommendation \(`APPROVE`\/`COMMENT`\/`REQUEST CHANGES`\) may worsen/u,
+	/Rule 4 \(severity discipline\): carryover CRITICAL or HIGH severity issues \(raised in a prior pass and still unresolved\) remain blocking regardless of pass number/u,
+	/Rule 5 \(counter-review awareness\): From pass 2 your output is counter-reviewed by Critic for over-engineering and unnecessary scope expansion/u,
+	/On pass 2\+, do not broaden scope, add options, or demand synthesis beyond what resolves prior findings; constructive synthesis \(Stage 3\) stays full-strength on pass 1 only\./u,
+	/Never approve carryover CRITICAL or HIGH severity issues \(raised in a prior pass and still unresolved\)\. A fresh CRITICAL\/HIGH minted from pass 2 on previously-approved ground blocks only with an explicit why-not-visible-earlier justification \(rule 2\); without that justification, record it as a non-blocking caveat with its severity noted\. On pass 1 every CRITICAL\/HIGH blocks\./u,
+] as const;
+
+const staleArchitectReReviewRatchetPatterns = [/^- Never approve CRITICAL or HIGH severity issues\.$/mu] as const;
+
+const ralplanReReviewContractPatterns = [
+	/Pass 2\+ runs sequentially Architect -> Critic/u,
+	/Pass 2\+ re-reviews MUST run sequentially Architect -> Critic/u,
+	/Critic receives the current-pass Architect receipt\/path and performs the rule-5 counter-review before consolidated feedback routes to Planner revision\./u,
+	/\*\*Re-review context bundle \(pass 2\+; mandatory\):\*\*/u,
+	/Every pass-2\+ Architect or Critic assignment MUST include:/u,
+	/stated literally as `review pass N` in the assignment text/u,
+	/ordinal review pass for that lane across the entire ralplan run\/re-review loop/u,
+	/the review of the initial Planner artifact is `review pass 1`, the review of the first revised Planner artifact is `review pass 2`/u,
+	/N never resets within an opener iteration and never resets when a new `revision` opener begins in the same run/u,
+	/the current revision receipt under review \(`path`, `sha256`, `stage_n`\)/u,
+	/the prior Planner\/revision artifact path that the previous pass reviewed/u,
+	/the prior same-lane review artifact path \(`stage-NN-architect\.md` \/ `stage-NN-critic\.md`\) with its receipt fields/u,
+	/the consolidated prior blockers and the revision's claimed resolutions, as orchestrator-collected pointers into those artifacts \(never pasted bodies\)/u,
+	/Critic pass-2\+ only: the current-pass Architect receipt\/path, awaited first per the sequential cadence, so the rule-5 counter-review is evaluable\./u,
+	/gjc\.ralplan\.maxReviewPassesPerLane/u,
+	/Default: \*\*1\*\* Architect pass and \*\*1\*\* Critic pass per opener iteration\./u,
+	/project `\.gjc\/settings\.json` overrides user settings; the value is an integer \*\*1\.\.10\*\* registered in the public settings schema\./u,
+	/On overflow: exit code \*\*3\*\* with the \*\*`PLANNING-STUCK`\*\* marker and lane-specific JSON\/stderr detail\./u,
+	/`post-interview`, `adr`, and `final` are always allowed\./u,
+	/including after a crash between artifact write and ledger append: the identical retry repairs the missing ledger row and returns the dedupe receipt\./u,
+	/A new `--run-id` starts a fresh budget\./u,
+	/A rule-2-justified blocker routes through a Planner `revision` opener \(new iteration, fresh lane budget\), never a second same-iteration review pass\./u,
+	/"maxIterations": 3,\n\s+"maxReviewPassesPerLane": 2/u,
+	/--lane-verdict <token>/u,
+	/Architect passes its Architectural Status token \(`CLEAR`\/`WATCH`\/`BLOCK`\), and Critic passes its verdict token \(`OKAY`\/`ITERATE`\/`REJECT`\)/u,
+] as const;
+
+const staleRalplanReReviewContractPatterns = [/within the current consensus iteration/u] as const;
+
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -96,6 +152,35 @@ describe("ralplan decision artifacts", () => {
 			expect(content).not.toMatch(pattern);
 		}
 		for (const pattern of staleCriticApprovalPatterns) {
+			expect(content).not.toMatch(pattern);
+		}
+	});
+
+	it("enforces re-review ratchet and lane-budget contracts", () => {
+		const critic = getBundledAgent("critic");
+		if (!critic) throw new Error("missing bundled critic agent");
+		for (const pattern of criticReReviewRatchetPatterns) {
+			expect(critic.systemPrompt).toMatch(pattern);
+		}
+
+		const architect = getBundledAgent("architect");
+		if (!architect) throw new Error("missing bundled architect agent");
+		for (const pattern of architectReReviewRatchetPatterns) {
+			expect(architect.systemPrompt).toMatch(pattern);
+		}
+		for (const pattern of staleArchitectReReviewRatchetPatterns) {
+			expect(architect.systemPrompt).not.toMatch(pattern);
+		}
+
+		const ralplan = getDefaultGjcDefinitions().find(
+			definition => definition.kind === "skill" && definition.name === "ralplan",
+		);
+		expect(ralplan).toBeDefined();
+		const content = ralplan?.content ?? "";
+		for (const pattern of ralplanReReviewContractPatterns) {
+			expect(content).toMatch(pattern);
+		}
+		for (const pattern of staleRalplanReReviewContractPatterns) {
 			expect(content).not.toMatch(pattern);
 		}
 	});

--- a/packages/coding-agent/test/workflow-hud-summary.test.ts
+++ b/packages/coding-agent/test/workflow-hud-summary.test.ts
@@ -51,6 +51,66 @@ describe("workflow HUD summary builders", () => {
 		expect(hud.chips?.find(chip => chip.label === "stages")?.value).toBe("P·A·C");
 	});
 
+	it("renders ralplan review-pass chips between stages and verdict without exceeding the final HUD shape", () => {
+		const hud = buildRalplanHudSummary({
+			stage: "critic",
+			iterationFromIndex: 1,
+			stages: "P·A·C",
+			architectPasses: 1,
+			criticPasses: 2,
+			reviewPassBudget: 3,
+			verdict: "ITERATE",
+		});
+		expect(hud.chips?.map(chip => `${chip.label}:${chip.value}:${chip.priority}`)).toEqual([
+			"stage:critic:10",
+			"iter:1:30",
+			"stages:P·A·C:35",
+			"arch:1/3:36",
+			"crit:2/3:38",
+			"verdict:ITERATE:40",
+		]);
+
+		const finalHud = buildRalplanHudSummary({
+			stage: "final",
+			iterationFromIndex: 1,
+			stages: "P·A·C·F",
+			architectPasses: 1,
+			criticPasses: 1,
+			reviewPassBudget: 1,
+			verdict: "OKAY",
+			pendingApproval: true,
+		});
+		expect(finalHud.chips?.map(chip => chip.label)).toEqual(["pending", "stage", "iter", "stages", "verdict"]);
+	});
+
+	it("keeps a zero-pass ralplan HUD byte-identical to the pre-counter shape", () => {
+		const baseline = {
+			stage: "planner",
+			iterationFromIndex: 1,
+			stages: "P",
+			updatedAt: "2026-07-28T00:00:00.000Z",
+		};
+		expect(
+			buildRalplanHudSummary({
+				...baseline,
+				architectPasses: 0,
+				criticPasses: 0,
+				reviewPassBudget: 1,
+			}),
+		).toEqual(buildRalplanHudSummary(baseline));
+	});
+
+	it("renders OKAY and REJECT with their closed-vocabulary severities", () => {
+		const okay = buildRalplanHudSummary({ stage: "critic", verdict: "OKAY" });
+		const reject = buildRalplanHudSummary({ stage: "critic", verdict: "REJECT" });
+		const clear = buildRalplanHudSummary({ stage: "architect", verdict: "CLEAR" });
+		const block = buildRalplanHudSummary({ stage: "architect", verdict: "BLOCK" });
+		expect(okay.chips?.find(chip => chip.label === "verdict")?.severity).toBe("success");
+		expect(reject.chips?.find(chip => chip.label === "verdict")?.severity).toBe("blocked");
+		expect(clear.chips?.find(chip => chip.label === "verdict")?.severity).toBe("success");
+		expect(block.chips?.find(chip => chip.label === "verdict")?.severity).toBe("blocked");
+	});
+
 	it("renders ultragoal latest ledger event as a main chip", () => {
 		const hud = buildUltragoalHudSummary({
 			status: "blocked",

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -354,6 +354,10 @@
 						"maxIterations": {
 							"type": "number",
 							"default": 5
+						},
+						"maxReviewPassesPerLane": {
+							"type": "number",
+							"default": 1
 						}
 					},
 					"additionalProperties": false

--- a/scripts/generate-json-schemas.test.ts
+++ b/scripts/generate-json-schemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { JSON_SCHEMA_OUTPUTS, stableJson } from "./generate-json-schemas";
+import { SETTINGS_SCHEMA } from "../packages/coding-agent/src/config/settings-schema";
 
 function acceptsJsonSchemaFixture(schema: unknown, value: unknown): boolean {
 	if (schema === true) return true;
@@ -35,6 +36,19 @@ describe("generated JSON Schemas", () => {
 			const existing = await Bun.file(target).text();
 			expect(existing).toBe(stableJson(output.schema));
 		}
+	});
+
+	it("registers the ralplan per-lane review budget without loosening the object", () => {
+		const setting = SETTINGS_SCHEMA["gjc.ralplan.maxReviewPassesPerLane"];
+		expect(setting.default).toBe(1);
+		expect(setting.validate?.(0)).toBe(false);
+		expect(setting.validate?.(11)).toBe(false);
+		expect(setting.validate?.(1.5)).toBe(false);
+
+		const schema = configSchema() as any;
+		const ralplan = schema.properties.gjc.properties.ralplan;
+		expect(ralplan.properties.maxReviewPassesPerLane).toMatchObject({ type: "number", default: 1 });
+		expect(ralplan.additionalProperties).toBe(false);
 	});
 
 	it("accepts documented Discord and Slack config while rejecting unknown chat properties", () => {


### PR DESCRIPTION
## Summary

Fixes infinite-ralplan symptoms observed after enabling heavy models for the Critic/Architect roles: endless ITERATE/REJECT loops driven by review goalpost-moving (one fresh HIGH per pass on previously-approved ground), escalating revision sizes (20KB → 99KB), and lane passes escaping the #3165 opener-only cap (8 architect passes in one run).

**Approach — behavior-first, per approved spec and consensus plan:**

### Reviewer behavior contracts (primary surface)
- **critic.md** — 5-rule re-review ratchet from pass 2: delta-only review, novelty justification for new blockers on reviewed ground, verdict monotonicity, carryover-vs-fresh severity discipline, and a counter-review duty that flags Architect over-engineering/scope expansion as a review defect. Enrichment lane preserved, justification-gated from pass 2.
- **architect.md** — ratchet rules 1–4 + rule-5 awareness; the unconditional "Never approve CRITICAL or HIGH" line is scoped: carryover CRITICAL/HIGH stay unapprovable; fresh HIGHs minted on approved ground need a why-not-visible-earlier justification, else demote to non-blocking caveats.
- **ralplan SKILL.md** — mandatory pass-2+ re-review context bundle (receipts/paths + run-level pass ordinal that never resets per opener), sequential Architect→Critic cadence from pass 2 (pass-1 parallel fan-out unchanged), per-lane budget operator contract, `--lane-verdict` assignment instruction.

### Runtime backstop (minimal, reuses #3165 cap machinery)
- Per-lane review budget: default **1 pass/lane/opener iteration**, `gjc.ralplan.maxReviewPassesPerLane` (integer 1..10, registered in settings schema + regenerated `config.schema.json`).
- Lane-specific PLANNING-STUCK (exit 3, marker); `post-interview`/`adr`/`final` always allowed so stuck plans escalate visibly, never silently approve.
- Fail-closed on-disk lane-artifact floor (only ENOENT masks as empty); crash-gap dedupe repair (identical retry repairs missing/short ledger rows exactly once; final-stage retries verify/recreate `pending-approval.md`).
- HUD: `arch`/`crit` pass-count chips + last verdict via optional `--lane-verdict` token (closed vocabularies, run-scoped, zero artifact parsing; legacy verdict cleared on run-id change; stale-run repairs cannot leak verdicts into the active run).

### No-regression boundaries (held)
Verdict vocabularies, receipt-only role contracts, full-depth pass-1 review, Critic enrichment lane, and all #3165 semantics unchanged — the existing opener-cap test block is byte-identical.

### Accepted risks (documented per consensus, intentionally not implemented)
1. No cross-process admission lock/CAS (parity with existing #3165 check-then-persist posture)
2. Lane-count HUD chips may be replaced by later generic state writes
3. No transactional replay of display-only verdict metadata on crash-gap dedupe

## Provenance

The approved planning artifacts are session-local files under `.gjc/` (gitignored by design) and are therefore **not linkable from this PR**; exact untruncated paths in the authoring worktree (`research-enhance-infinite-ralplan-4ad850b0`):
- **Deep-interview spec** (10 rounds, final ambiguity 5%, threshold 5%): `.gjc/_session-019fa2eb-abd6-7000-9ad3-d563f3cc5787/specs/deep-interview-ralplan-infinite-loop-convergence.md`
- **Ralplan consensus plan rev 5** (Architect CLEAR/APPROVE, Critic OKAY, reconciled-clean post-interview): `.gjc/_session-019fa2eb-abd6-7000-9ad3-d563f3cc5787/plans/ralplan/019fa2eb-abd6-7000-9ad3-d563f3cc5787/pending-approval.md`

The plan's full ADR and Intent Reconciliation sections are embedded in that artifact and summarized in the first commit message on this branch.


## Verification (focused, per plan)
```
bun test packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts \
  packages/coding-agent/test/ralplan-decision-artifacts.test.ts \
  packages/coding-agent/test/gjc-runtime/state-runtime.test.ts \
  packages/coding-agent/test/workflow-hud-summary.test.ts \
  scripts/generate-json-schemas.test.ts
# 135 pass, 0 fail, 741 expect() calls
bun scripts/generate-json-schemas.ts --check   # green
```
Red-team highlights: pathological 20-stage replay refuses exactly at the degenerate passes (a2/a6/rev6/c6/a8) while `final` still succeeds; healthy replays produce zero warnings/refusals; justified blockers still block; injected EIO fails closed; cross-run verdict-leak, short-row double-count, and final pending-approval crash-gap attacks all fixed and retested.

