### PR TITLE
fix(coding-agent): clone sticky-viewport fixture instead of recapturing

### DIFF
--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -150,19 +150,29 @@ describe("sticky viewport production evidence verifier", () => {
 		await verifyStickyViewportShowcase(await capture());
 	});
 	it("fails closed for semantic evidence and provenance corruption", async () => {
-		const root = await capture();
+		// `capture()` spawns a ~2.2s subprocess. Capture once and clone the
+		// deterministic output so each corruption case stays isolated without
+		// paying that cost seven times, which overruns the timeout budget.
+		const base = await capture();
+		const cloneBase = async () => {
+			const clone = await fs.mkdtemp(path.join(os.tmpdir(), "sticky-viewport-showcase-semantic-"));
+			roots.push(clone);
+			await fs.cp(base, clone, { recursive: true });
+			return clone;
+		};
+		const root = await cloneBase();
 		const key = "manual-new-output/80x24/unicode-color";
 		await fs.writeFile(path.join(root, key, "terminal.txt"), "forged\n");
 		await rehash(root, key, "terminal.txt");
 		await expect(verifyStickyViewportShowcase(root)).rejects.toThrow("semantic evidence");
-		const provenanceRoot = await capture();
+		const provenanceRoot = await cloneBase();
 		const metadataPath = path.join(provenanceRoot, key, "metadata.json");
 		const metadata = JSON.parse(await fs.readFile(metadataPath, "utf8"));
 		metadata.provenance.capture_mode = "fixture";
 		await Bun.write(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
 		await rehash(provenanceRoot, key, "metadata.json");
 		await expect(verifyStickyViewportShowcase(provenanceRoot)).rejects.toThrow("metadata schema");
-		const noticeRoot = await capture();
+		const noticeRoot = await cloneBase();
 		const noticeMetadataPath = path.join(noticeRoot, key, "metadata.json");
 		const noticeMetadata = JSON.parse(await fs.readFile(noticeMetadataPath, "utf8"));
 		noticeMetadata.output_revision = "0";
@@ -170,7 +180,7 @@ describe("sticky viewport production evidence verifier", () => {
 		await rehash(noticeRoot, key, "metadata.json");
 		await expect(verifyStickyViewportShowcase(noticeRoot)).rejects.toThrow("manual notice invariant");
 
-		const capacityRoot = await capture();
+		const capacityRoot = await cloneBase();
 		const capacityKey = "capacity-one/80x24/unicode-color";
 		const capacityMetadataPath = path.join(capacityRoot, capacityKey, "metadata.json");
 		const capacityMetadata = JSON.parse(await fs.readFile(capacityMetadataPath, "utf8"));
@@ -179,7 +189,7 @@ describe("sticky viewport production evidence verifier", () => {
 		await rehash(capacityRoot, capacityKey, "metadata.json");
 		await expect(verifyStickyViewportShowcase(capacityRoot)).rejects.toThrow("capacity metadata/frame mismatch");
 
-		const cjkRoot = await capture();
+		const cjkRoot = await cloneBase();
 		const cjkKey = "narrow-cjk/48x10/unicode-color";
 		for (const name of ["terminal.txt", "terminal-ansi.txt", "terminal.html"] as const) {
 			const artifactPath = path.join(cjkRoot, cjkKey, name);
@@ -193,7 +203,7 @@ describe("sticky viewport production evidence verifier", () => {
 			"narrow CJK visible terminal evidence missing",
 		);
 
-		const evidenceRoot = await capture();
+		const evidenceRoot = await cloneBase();
 		const evidencePath = path.join(evidenceRoot, key, "metadata.json");
 		const evidence = JSON.parse(await fs.readFile(evidencePath, "utf8"));
 		evidence.state.manual_historical_rows = [];
@@ -201,7 +211,7 @@ describe("sticky viewport production evidence verifier", () => {
 		await rehash(evidenceRoot, key, "metadata.json");
 		await expect(verifyStickyViewportShowcase(evidenceRoot)).rejects.toThrow("manual historical transcript evidence");
 
-		const nonNarrowCjkRoot = await capture();
+		const nonNarrowCjkRoot = await cloneBase();
 		const nonNarrowMetadataPath = path.join(nonNarrowCjkRoot, key, "metadata.json");
 		const nonNarrowMetadata = JSON.parse(await fs.readFile(nonNarrowMetadataPath, "utf8"));
 		nonNarrowMetadata.cjk_phrase_boundaries = ["意味のある文の境界"];


### PR DESCRIPTION
## Dev CI shard-2 repair

Fixes the red post-merge `dev` at `a551d8ee`: `sticky viewport production evidence verifier > fails closed for semantic evidence and provenance corruption` timed out at 15000ms in [run 30319457639 / job 90152948696](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30319457639/job/90152948696).

### Root cause — deterministic, not flaky

The test called `capture()` **seven times**. Each call spawns a `capture-sticky-viewport-showcase.ts` subprocess measured at **~2.2s** locally (2.17 / 2.21 / 2.19s), so the body required **~15.4s of fixture setup alone** against a **15s** budget. It fails every run, not intermittently.

The `ENOENT: no such file or directory, open '/tmp/sticky-viewport-showcase-.../manifest.json'` in the CI log is a **symptom, not the cause**: when the test times out, the shared `afterEach` `rm -rf`s the temp roots while the body is still awaiting, so a later assertion reports a vanished fixture. Chasing that ENOENT leads away from the real problem.

### Fix

Capture once, then clone per corruption case with `fs.cp` — the exact idiom the neighbouring table-driven test (`rejects table-driven manifest, metadata, and review-input corruption`) already uses.

Capture output is **byte-identical across runs** (verified with `diff -r` on two independent captures), so cloning preserves per-case isolation exactly. Each case still gets its own mutable root registered in `roots` for cleanup.

**No timeout inflation, no retry masking, no rerun-only response, no assertion weakened.** All seven corruption assertions are unchanged; the 15000ms budget is untouched. One test file changed, +17/-7.

### Verification

| Check | Result |
|---|---|
| Focused test, 5 consecutive runs | **5/5 pass**, 2.79–2.87s (was 15008ms timeout) |
| Full `sticky-viewport-showcase.test.ts` | **9/9 pass**, 14.35s |
| Causality — revert the change, rerun | **reproduces the 15009ms timeout** |
| Adjacent shard-2 files (`gjc-ui-redesign`, `light-theme-compliance`) | **19/19 pass** |
| `bun --cwd=packages/coding-agent run check:types` | clean |
| `biome check` on the changed file | clean |

Causality is demonstrated in both directions: reverting reproduces the failure, applying fixes it.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*