### PR TITLE
fix(tui): redraw once the terminal width settles

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -669,7 +669,7 @@ export class TUI extends Container {
 	#lastRenderWriteSucceeded = false;
 	#renderTimer: NodeJS.Timeout | undefined;
 	#widthSettleTimer: NodeJS.Timeout | undefined;
-	#widthSettleBaseline = 0;
+	#lastObservedWidth = 0;
 	static readonly #WIDTH_SETTLE_MS = 1000;
 	#lastRenderAt = 0;
 	static readonly #MIN_RENDER_INTERVAL_MS = 16;
@@ -1247,6 +1247,9 @@ export class TUI extends Container {
 	start(): void {
 		this.#stopped = false;
 		this.#terminalUnavailable = false;
+		// Seed the observed width so a spurious post-start resize event (iTerm2 tab
+		// activation, the self-sent SIGWINCH after resume) is not read as a reflow.
+		this.#lastObservedWidth = this.terminal.columns;
 		this.terminal.setMouseEnabled?.(this.options.enableMouse === true);
 		this.terminal.start(
 			data => this.#handleInput(data),
@@ -1590,31 +1593,49 @@ export class TUI extends Container {
 	 * is a no-op otherwise.
 	 */
 	requestResizeRender(): void {
-		const widthChanged = this.#previousWidth !== this.terminal.columns;
+		// Width is tracked against the last OBSERVED terminal width, not against
+		// #previousWidth (the last committed frame). Those diverge whenever resize
+		// events coalesce inside one frame budget: a 100->90->100 burst would leave
+		// #previousWidth at 100 the whole time, so a commit-keyed debounce would
+		// never see the second transition and could skip the only repair frame.
+		const observedWidth = this.terminal.columns;
+		const widthChanged = observedWidth !== this.#lastObservedWidth;
+		this.#lastObservedWidth = observedWidth;
 		const heightChanged = this.#previousHeight !== this.terminal.rows;
 		if (widthChanged) this.#scheduleWidthSettleRedraw();
 		this.requestRender(heightChanged && !useViewportRepaintPath(this.terminal), "resize");
 	}
 
 	/**
-	 * Width reflow leaves artifacts that a differential render cannot repair: lines
-	 * wrapped at the old column count stay on screen as stale bands. Only a full
-	 * redraw fixes them, but forcing one per SIGWINCH during a drag-resize is a
-	 * replay storm. So width changes arm a trailing timer instead: interim frames
-	 * keep the normal (cheap) render path, and one forced full redraw commits
-	 * #WIDTH_SETTLE_MS after the last width change. Height-only changes are
-	 * unaffected — they reflow nothing and keep their existing behavior.
+	 * Width reflow leaves artifacts that the immediate resize frame does not always
+	 * repair: lines wrapped at the old column count can survive as stale bands. The
+	 * immediate frame is unchanged by this timer — `#doRender` still promotes a real
+	 * width change to `fullRender`/`viewportRepaint` on the spot. What this adds is a
+	 * single trailing repair: one forced redraw #WIDTH_SETTLE_MS after the last
+	 * observed width change, so a drag-resize converges on a correct frame without
+	 * forcing an extra full redraw per SIGWINCH.
+	 *
+	 * Every observed width sequence gets exactly one repair, including one that
+	 * ends back at its starting width. Skipping the drag-and-return case would
+	 * require proving that a frame committed at the final geometry *after* the
+	 * final resize event, which the render pipeline does not guarantee; one extra
+	 * repaint is cheaper than a missed repair.
+	 *
+	 * Scope: the repair is dispatched through `requestRender(true)`, so on
+	 * viewport-repaint hosts (tmux/screen/zellij, Windows Terminal, process
+	 * terminals) it repaints the live viewport rather than replaying the whole
+	 * transcript. Rows that already scrolled off keep their old-width wrapping —
+	 * reconstructing them is what caused the replay storm that
+	 * `resize-replay-storm.test.ts` pins against.
+	 *
+	 * Height-only changes are unaffected: they reflow nothing and keep their
+	 * existing behavior.
 	 */
 	#scheduleWidthSettleRedraw(): void {
-		if (this.#widthSettleTimer) {
-			clearTimeout(this.#widthSettleTimer);
-		} else {
-			this.#widthSettleBaseline = this.#previousWidth;
-		}
+		if (this.#widthSettleTimer) clearTimeout(this.#widthSettleTimer);
 		this.#widthSettleTimer = setTimeout(() => {
 			this.#widthSettleTimer = undefined;
 			if (this.#stopped) return;
-			if (this.terminal.columns === this.#widthSettleBaseline) return;
 			this.requestRender(true, "resize.width-settled");
 		}, TUI.#WIDTH_SETTLE_MS);
 		this.#widthSettleTimer.unref?.();

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -668,6 +668,9 @@ export class TUI extends Container {
 	#renderCommitWaiters = new Map<number, Set<RenderCommitWaiter>>();
 	#lastRenderWriteSucceeded = false;
 	#renderTimer: NodeJS.Timeout | undefined;
+	#widthSettleTimer: NodeJS.Timeout | undefined;
+	#widthSettleBaseline = 0;
+	static readonly #WIDTH_SETTLE_MS = 1000;
 	#lastRenderAt = 0;
 	static readonly #MIN_RENDER_INTERVAL_MS = 16;
 	// Input-priority scheduling: an input keystroke must never be starved behind a
@@ -1523,6 +1526,10 @@ export class TUI extends Container {
 			this.#renderTimer = undefined;
 			if (renderMetrics.enabled) renderMetrics.setTimerGauge("tui.renderTimer", 0);
 		}
+		if (this.#widthSettleTimer) {
+			clearTimeout(this.#widthSettleTimer);
+			this.#widthSettleTimer = undefined;
+		}
 		// Move cursor to the end of the content to prevent overwriting/artifacts on exit
 		if (this.#previousLines.length > 0) {
 			const targetRow = this.#previousLines.length; // Line after the last content
@@ -1583,9 +1590,34 @@ export class TUI extends Container {
 	 * is a no-op otherwise.
 	 */
 	requestResizeRender(): void {
-		const dimensionsChanged =
-			this.#previousWidth !== this.terminal.columns || this.#previousHeight !== this.terminal.rows;
-		this.requestRender(dimensionsChanged && !useViewportRepaintPath(this.terminal), "resize");
+		const widthChanged = this.#previousWidth !== this.terminal.columns;
+		const heightChanged = this.#previousHeight !== this.terminal.rows;
+		if (widthChanged) this.#scheduleWidthSettleRedraw();
+		this.requestRender(heightChanged && !useViewportRepaintPath(this.terminal), "resize");
+	}
+
+	/**
+	 * Width reflow leaves artifacts that a differential render cannot repair: lines
+	 * wrapped at the old column count stay on screen as stale bands. Only a full
+	 * redraw fixes them, but forcing one per SIGWINCH during a drag-resize is a
+	 * replay storm. So width changes arm a trailing timer instead: interim frames
+	 * keep the normal (cheap) render path, and one forced full redraw commits
+	 * #WIDTH_SETTLE_MS after the last width change. Height-only changes are
+	 * unaffected — they reflow nothing and keep their existing behavior.
+	 */
+	#scheduleWidthSettleRedraw(): void {
+		if (this.#widthSettleTimer) {
+			clearTimeout(this.#widthSettleTimer);
+		} else {
+			this.#widthSettleBaseline = this.#previousWidth;
+		}
+		this.#widthSettleTimer = setTimeout(() => {
+			this.#widthSettleTimer = undefined;
+			if (this.#stopped) return;
+			if (this.terminal.columns === this.#widthSettleBaseline) return;
+			this.requestRender(true, "resize.width-settled");
+		}, TUI.#WIDTH_SETTLE_MS);
+		this.#widthSettleTimer.unref?.();
 	}
 
 	requestRender(force = false, source = "unknown"): void {

--- a/packages/tui/test/resize-width-settle-redteam.test.ts
+++ b/packages/tui/test/resize-width-settle-redteam.test.ts
@@ -1,0 +1,560 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Text } from "../src/components/text";
+import { TUI } from "../src/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+const START_WIDTH = 44;
+const SETTLED_WIDTH = 22;
+const ROWS = 12;
+const SETTLE_MS = 1000;
+const FAKE_TMUX = "/tmp/fake-tmux,4242,0";
+
+type Capture = {
+	viewport: string[];
+	scrollback: string[];
+	writeLog: string;
+};
+
+let originalTmux: string | undefined;
+let originalTmuxPane: string | undefined;
+let originalSty: string | undefined;
+let originalZellij: string | undefined;
+let originalTmuxLaunched: string | undefined;
+let originalVirtualViewport: string | undefined;
+let originalLegacyMultiplexer: string | undefined;
+
+function transcriptTexts(count = 32): string[] {
+	return Array.from(
+		{ length: count },
+		(_value, index) => `R${index}-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-TAIL${index}`,
+	);
+}
+
+function trimTerminalLines(lines: string[]): string[] {
+	return lines.map(line => line.replace(/[ ]+$/u, ""));
+}
+
+function capture(term: VirtualTerminal): Capture {
+	return {
+		viewport: trimTerminalLines(term.getViewport()),
+		scrollback: trimTerminalLines(term.getScrollBuffer()),
+		writeLog: term.getWriteLog().join(""),
+	};
+}
+
+function nonEmpty(lines: string[]): string[] {
+	return lines.filter(line => line.length > 0);
+}
+
+function countSequence(haystack: string, needle: string): number {
+	let count = 0;
+	let offset = 0;
+	while (true) {
+		const index = haystack.indexOf(needle, offset);
+		if (index < 0) return count;
+		count += 1;
+		offset = index + needle.length;
+	}
+}
+
+function writeExcerpt(writeLog: string, maxLength = 5000): string {
+	return writeLog.length <= maxLength ? writeLog : writeLog.slice(-maxLength);
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await term.waitForRender();
+}
+
+async function addTranscript(tui: TUI, term: VirtualTerminal, texts = transcriptTexts()): Promise<void> {
+	for (const text of texts) tui.addChild(new Text(text, 0, 0));
+	tui.requestRender(false, "redteam.setup");
+	await settle(term);
+}
+
+async function renderReference(
+	width: number,
+	rows: number,
+	texts: string[],
+	isProcessTerminal: boolean,
+	underTmux: boolean,
+): Promise<Capture> {
+	if (underTmux) process.env.TMUX = FAKE_TMUX;
+	else delete process.env.TMUX;
+	const term = new VirtualTerminal(width, rows, { isProcessTerminal });
+	const tui = new TUI(term);
+	try {
+		tui.start();
+		await settle(term);
+		for (const text of texts) tui.addChild(new Text(text, 0, 0));
+		tui.requestRender(false, "redteam.reference");
+		await settle(term);
+		return capture(term);
+	} finally {
+		tui.stop();
+	}
+}
+
+// Each case asserts a named set of checks. `expected` documents the contract the
+// case pins; `evidence` is attached to the failure message so a red-team failure
+// reports the captured terminal state instead of a bare boolean.
+function finishCase(
+	id: string,
+	expected: string,
+	checks: Record<string, boolean>,
+	evidence: Record<string, unknown>,
+): void {
+	const failedChecks = Object.entries(checks)
+		.filter(([, passed]) => !passed)
+		.map(([name]) => name);
+	const detail = `${id} failed [${failedChecks.join(", ")}]\nexpected: ${expected}\nevidence: ${JSON.stringify(evidence, null, 2)}`;
+	expect(failedChecks, detail).toEqual([]);
+}
+
+class LegacyHeightResizeTUI extends TUI {
+	override requestResizeRender(): void {
+		this.requestRender(true, "resize");
+	}
+}
+
+async function runHeightScenario(legacy: boolean): Promise<{
+	immediate: Capture;
+	delayedWriteLog: string;
+	redrawsBefore: number;
+	redrawsAfterImmediate: number;
+	redrawsAfterDelay: number;
+}> {
+	delete process.env.TMUX;
+	const term = new VirtualTerminal(START_WIDTH, ROWS, { isProcessTerminal: false });
+	const tui = legacy ? new LegacyHeightResizeTUI(term) : new TUI(term);
+	try {
+		tui.start();
+		await settle(term);
+		await addTranscript(tui, term, transcriptTexts(18));
+		term.clearWriteLog();
+		const redrawsBefore = tui.fullRedraws;
+		for (const height of [8, 10, 6, 9, 7]) {
+			term.resize(START_WIDTH, height);
+			await settle(term);
+		}
+		const immediate = capture(term);
+		const redrawsAfterImmediate = tui.fullRedraws;
+		term.clearWriteLog();
+		await Bun.sleep(SETTLE_MS + 150);
+		await term.flush();
+		const delayedWriteLog = term.getWriteLog().join("");
+		const redrawsAfterDelay = tui.fullRedraws;
+		return { immediate, delayedWriteLog, redrawsBefore, redrawsAfterImmediate, redrawsAfterDelay };
+	} finally {
+		tui.stop();
+	}
+}
+
+beforeEach(() => {
+	originalTmux = process.env.TMUX;
+	originalTmuxPane = process.env.TMUX_PANE;
+	originalSty = process.env.STY;
+	originalZellij = process.env.ZELLIJ;
+	originalTmuxLaunched = process.env.GJC_TMUX_LAUNCHED;
+	originalVirtualViewport = process.env.PI_TUI_VIRTUAL_VIEWPORT;
+	originalLegacyMultiplexer = process.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
+	delete process.env.TMUX;
+	delete process.env.TMUX_PANE;
+	delete process.env.STY;
+	delete process.env.ZELLIJ;
+	delete process.env.GJC_TMUX_LAUNCHED;
+	delete process.env.PI_TUI_VIRTUAL_VIEWPORT;
+	delete process.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
+});
+
+afterEach(() => {
+	const restore = (name: string, value: string | undefined): void => {
+		if (value === undefined) delete process.env[name];
+		else process.env[name] = value;
+	};
+	restore("TMUX", originalTmux);
+	restore("TMUX_PANE", originalTmuxPane);
+	restore("STY", originalSty);
+	restore("ZELLIJ", originalZellij);
+	restore("GJC_TMUX_LAUNCHED", originalTmuxLaunched);
+	restore("PI_TUI_VIRTUAL_VIEWPORT", originalVirtualViewport);
+	restore("PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER", originalLegacyMultiplexer);
+});
+
+async function runWidthRepair(underTmux: boolean): Promise<{
+	before: Capture;
+	interim: Capture;
+	post: Capture;
+	reference: Capture;
+	redrawsBeforeSettle: number;
+	redrawsAfterSettle: number;
+	texts: string[];
+}> {
+	if (underTmux) process.env.TMUX = FAKE_TMUX;
+	else delete process.env.TMUX;
+	const texts = transcriptTexts();
+	const term = new VirtualTerminal(START_WIDTH, ROWS, { isProcessTerminal: underTmux });
+	const tui = new TUI(term);
+	try {
+		tui.start();
+		await settle(term);
+		await addTranscript(tui, term, texts);
+		term.clearWriteLog();
+		const before = capture(term);
+		term.resize(SETTLED_WIDTH, ROWS);
+		await settle(term);
+		const interim = capture(term);
+		const redrawsBeforeSettle = tui.fullRedraws;
+		await Bun.sleep(SETTLE_MS + 150);
+		await term.flush();
+		const post = capture(term);
+		const redrawsAfterSettle = tui.fullRedraws;
+		const reference = await renderReference(SETTLED_WIDTH, ROWS, texts, underTmux, underTmux);
+		return { before, interim, post, reference, redrawsBeforeSettle, redrawsAfterSettle, texts };
+	} finally {
+		tui.stop();
+	}
+}
+
+describe("width-settle debounce red-team", () => {
+	it("DEFAULT-HOST-STALE-BAND repairs wrapped transcript after settling", async () => {
+		const result = await runWidthRepair(false);
+		const postRows = nonEmpty(result.post.scrollback);
+		const referenceRows = nonEmpty(result.reference.scrollback);
+		finishCase(
+			"DEFAULT-HOST-STALE-BAND",
+			"After a shrink from 44 to 22 columns, the settled terminal state matches a clean 22-column render and the settled write is a real full redraw.",
+			{
+				postStateMatchesFreshTarget: postRows.join("\n") === referenceRows.join("\n"),
+				settledRedrawExactlyOne: result.redrawsAfterSettle - result.redrawsBeforeSettle === 1,
+				settledWriteClearsAndReplays: result.post.writeLog.includes("\x1b[2J\x1b[H\x1b[3J"),
+				widthChangedContentVisible: result.post.viewport.some(line => line.startsWith("R31-")),
+			},
+			{
+				startingWidth: START_WIDTH,
+				settledWidth: SETTLED_WIDTH,
+				beforeViewport: result.before.viewport,
+				interimViewport: result.interim.viewport,
+				postViewport: result.post.viewport,
+				postScrollbackRows: postRows.length,
+				referenceScrollbackRows: referenceRows.length,
+				interimWriteLength: result.interim.writeLog.length,
+				settledWriteLength: result.post.writeLog.length,
+				settledFullRedrawDelta: result.redrawsAfterSettle - result.redrawsBeforeSettle,
+			},
+		);
+	});
+
+	it("TMUX-STALE-BAND measures whether viewport-only settle repairs scrollback", async () => {
+		const result = await runWidthRepair(true);
+		const postRows = nonEmpty(result.post.scrollback);
+		const referenceRows = nonEmpty(result.reference.scrollback);
+		finishCase(
+			"TMUX-STALE-BAND",
+			"With TMUX set, the settled request routes through viewportRepaint: the LIVE viewport must match a clean 22-column render, while already-scrolled-off history keeps its old-width wrapping (reconstructing it is the replay storm resize-replay-storm.test.ts pins against).",
+			{
+				postViewportMatchesFreshTarget: result.post.viewport.join("\n") === result.reference.viewport.join("\n"),
+				settledRedrawExactlyOne: result.redrawsAfterSettle - result.redrawsBeforeSettle === 1,
+				settledWriteUsesViewportRepaint:
+					result.post.writeLog.includes("\x1b[2K") && !result.post.writeLog.includes("\x1b[3J"),
+				widthChangedContentVisible: result.post.viewport.some(line => line.startsWith("R31-")),
+			},
+			{
+				host: "TMUX",
+				startingWidth: START_WIDTH,
+				settledWidth: SETTLED_WIDTH,
+				postViewport: result.post.viewport,
+				postScrollbackRows: postRows.length,
+				referenceScrollbackRows: referenceRows.length,
+				missingOrStaleRows: referenceRows.filter((line, index) => postRows[index] !== line).slice(0, 8),
+				interimWriteLength: result.interim.writeLog.length,
+				settledWriteLength: result.post.writeLog.length,
+				settledFullRedrawDelta: result.redrawsAfterSettle - result.redrawsBeforeSettle,
+			},
+		);
+	});
+
+	it("STOP-START cancels the old timer and does not double-render after restart", async () => {
+		delete process.env.TMUX;
+		const term = new VirtualTerminal(START_WIDTH, ROWS, { isProcessTerminal: false });
+		const tui = new TUI(term);
+		try {
+			tui.start();
+			await settle(term);
+			await addTranscript(tui, term);
+			term.clearWriteLog();
+			term.resize(SETTLED_WIDTH, ROWS);
+			await settle(term);
+			const redrawsBeforeStop = tui.fullRedraws;
+			tui.stop();
+			term.clearWriteLog();
+			await Bun.sleep(SETTLE_MS + 150);
+			await term.flush();
+			const stoppedWriteLog = term.getWriteLog().join("");
+			const redrawsWhileStopped = tui.fullRedraws;
+
+			term.clearWriteLog();
+			const redrawsBeforeRestart = tui.fullRedraws;
+			tui.start();
+			await settle(term);
+			const restartWriteLog = term.getWriteLog().join("");
+			const redrawsAfterRestart = tui.fullRedraws;
+			term.clearWriteLog();
+			await Bun.sleep(SETTLE_MS + 150);
+			await term.flush();
+			const postRestartWriteLog = term.getWriteLog().join("");
+			const redrawsAfterRestartWindow = tui.fullRedraws;
+			finishCase(
+				"STOP-START",
+				"Stopping during the debounce window cancels it; restarting performs one normal forced frame and never receives a delayed orphaned write.",
+				{
+					noWriteWhileStopped: stoppedWriteLog === "",
+					noRedrawWhileStopped: redrawsWhileStopped === redrawsBeforeStop,
+					exactlyOneRestartRedraw: redrawsAfterRestart - redrawsBeforeRestart === 1,
+					restartWritesAFrame: restartWriteLog.length > 0,
+					noDoubleRedrawAfterRestart: redrawsAfterRestartWindow === redrawsAfterRestart,
+					noDelayedWriteAfterRestart: postRestartWriteLog === "",
+				},
+				{
+					redrawsBeforeStop,
+					redrawsWhileStopped,
+					redrawsBeforeRestart,
+					redrawsAfterRestart,
+					redrawsAfterRestartWindow,
+					stoppedWriteLength: stoppedWriteLog.length,
+					restartWriteLength: restartWriteLog.length,
+					postRestartWriteLength: postRestartWriteLog.length,
+				},
+			);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("UNRELATED-FORCE keeps the settle timer sane after a forced render", async () => {
+		delete process.env.TMUX;
+		const texts = transcriptTexts();
+		const term = new VirtualTerminal(START_WIDTH, ROWS, { isProcessTerminal: false });
+		const tui = new TUI(term);
+		try {
+			tui.start();
+			await settle(term);
+			await addTranscript(tui, term, texts);
+			term.clearWriteLog();
+			term.resize(SETTLED_WIDTH, ROWS);
+			await settle(term);
+			const redrawsAfterResize = tui.fullRedraws;
+			await Bun.sleep(400);
+			term.clearWriteLog();
+			const redrawsBeforeUnrelated = tui.fullRedraws;
+			tui.requestRender(true, "test.unrelated");
+			await settle(term);
+			const unrelatedWriteLog = term.getWriteLog().join("");
+			const redrawsAfterUnrelated = tui.fullRedraws;
+			term.clearWriteLog();
+			await Bun.sleep(SETTLE_MS - 400 + 150);
+			await term.flush();
+			const settleWriteLog = term.getWriteLog().join("");
+			const redrawsAfterSettle = tui.fullRedraws;
+			const reference = await renderReference(SETTLED_WIDTH, ROWS, texts, false, false);
+			const post = capture(term);
+			finishCase(
+				"UNRELATED-FORCE",
+				"An unrelated forced render may commit first, but the armed width timer must still produce at most one trailing settle frame and leave the target-width transcript correct.",
+				{
+					unrelatedForcedOneFrame: redrawsAfterUnrelated - redrawsBeforeUnrelated === 1,
+					settleAddsExactlyOneFrame: redrawsAfterSettle - redrawsAfterUnrelated === 1,
+					settleWriteIsFullRepair: settleWriteLog.includes("\x1b[2J\x1b[H\x1b[3J"),
+					finalStateMatchesFreshTarget:
+						nonEmpty(post.scrollback).join("\n") === nonEmpty(reference.scrollback).join("\n"),
+					noExtraSettleFrames: countSequence(settleWriteLog, "\x1b[2J\x1b[H\x1b[3J") === 1,
+				},
+				{
+					redrawsAfterResize,
+					redrawsBeforeUnrelated,
+					redrawsAfterUnrelated,
+					redrawsAfterSettle,
+					unrelatedWriteLength: unrelatedWriteLog.length,
+					settleWriteLength: settleWriteLog.length,
+					settleWriteExcerpt: writeExcerpt(settleWriteLog, 2400),
+				},
+			);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	async function runOscillation(widths: number[]): Promise<{
+		beforeSettle: number;
+		afterSettle: number;
+		post: Capture;
+		reference: Capture;
+		interimWriteLength: number;
+	}> {
+		delete process.env.TMUX;
+		const texts = transcriptTexts();
+		const term = new VirtualTerminal(START_WIDTH, ROWS, { isProcessTerminal: false });
+		const tui = new TUI(term);
+		try {
+			tui.start();
+			await settle(term);
+			await addTranscript(tui, term, texts);
+			term.clearWriteLog();
+			for (const width of widths) {
+				term.resize(width, ROWS);
+				await settle(term);
+			}
+			const interimWriteLength = term.getWriteLog().join("").length;
+			const beforeSettle = tui.fullRedraws;
+			await Bun.sleep(SETTLE_MS + 150);
+			await term.flush();
+			const post = capture(term);
+			const afterSettle = tui.fullRedraws;
+			const finalWidth = widths.at(-1) ?? START_WIDTH;
+			const reference = await renderReference(finalWidth, ROWS, texts, false, false);
+			return { beforeSettle, afterSettle, post, reference, interimWriteLength };
+		} finally {
+			tui.stop();
+		}
+	}
+
+	it("RAPID-OSCILLATION emits one settle repair when the final width differs", async () => {
+		const widths = [36, 28, 36, 28, 36, 30, 34, 30];
+		const result = await runOscillation(widths);
+		finishCase(
+			"RAPID-OSCILLATION-ENDS-DIFFERENT",
+			"Many width changes inside one debounce window produce exactly one settled redraw, and the final target-width frame is correct.",
+			{
+				exactlyOneSettledRedraw: result.afterSettle - result.beforeSettle === 1,
+				finalStateMatchesFreshTarget:
+					nonEmpty(result.post.scrollback).join("\n") === nonEmpty(result.reference.scrollback).join("\n"),
+				interimFramesWereWritten: result.interimWriteLength > 0,
+			},
+			{
+				widths,
+				finalWidth: widths.at(-1),
+				interimWriteLength: result.interimWriteLength,
+				settledRedrawDelta: result.afterSettle - result.beforeSettle,
+				postViewport: result.post.viewport,
+			},
+		);
+	});
+
+	it("RAPID-OSCILLATION still emits one settle repair when the drag returns to its starting width", async () => {
+		const widths = [36, 28, 36, 28, 36, 30, 34, START_WIDTH];
+		const result = await runOscillation(widths);
+		finishCase(
+			"RAPID-OSCILLATION-ENDS-SAME",
+			"A drag that ends back at its starting width still gets exactly one repair: the render pipeline does not guarantee a frame committed at the final geometry after the final resize event, so skipping could drop the only repair.",
+			{
+				exactlyOneSettledRedraw: result.afterSettle - result.beforeSettle === 1,
+				finalStateMatchesFreshTarget:
+					nonEmpty(result.post.scrollback).join("\n") === nonEmpty(result.reference.scrollback).join("\n"),
+				interimFramesWereWritten: result.interimWriteLength > 0,
+			},
+			{
+				widths,
+				baselineWidth: START_WIDTH,
+				finalWidth: widths.at(-1),
+				interimWriteLength: result.interimWriteLength,
+				settledRedrawDelta: result.afterSettle - result.beforeSettle,
+				postViewport: result.post.viewport,
+			},
+		);
+	});
+
+	it("HEIGHT-ONLY-REGRESSION remains byte-identical and never arms a settle timer", async () => {
+		const legacy = await runHeightScenario(true);
+		const current = await runHeightScenario(false);
+		finishCase(
+			"HEIGHT-ONLY-REGRESSION",
+			"A height-only resize storm follows the pre-change forced height path byte-for-byte and emits no later width-settle write.",
+			{
+				viewportByteIdentical: current.immediate.viewport.join("\n") === legacy.immediate.viewport.join("\n"),
+				scrollbackByteIdentical: current.immediate.scrollback.join("\n") === legacy.immediate.scrollback.join("\n"),
+				writeLogByteIdentical: current.immediate.writeLog === legacy.immediate.writeLog,
+				redrawCountByteIdentical:
+					current.redrawsAfterImmediate - current.redrawsBefore ===
+					legacy.redrawsAfterImmediate - legacy.redrawsBefore,
+				noDelayedCurrentWrite: current.delayedWriteLog === "",
+				noDelayedLegacyWrite: legacy.delayedWriteLog === "",
+			},
+			{
+				heights: [8, 10, 6, 9, 7],
+				currentImmediateWriteLength: current.immediate.writeLog.length,
+				legacyImmediateWriteLength: legacy.immediate.writeLog.length,
+				currentImmediateRedrawDelta: current.redrawsAfterImmediate - current.redrawsBefore,
+				legacyImmediateRedrawDelta: legacy.redrawsAfterImmediate - legacy.redrawsBefore,
+				currentDelayedWriteLength: current.delayedWriteLog.length,
+				legacyDelayedWriteLength: legacy.delayedWriteLog.length,
+			},
+		);
+	});
+
+	it("TIMING-BOUNDARY waits for 1000ms and extends the window at t=900ms", async () => {
+		delete process.env.TMUX;
+		const term = new VirtualTerminal(START_WIDTH, ROWS, { isProcessTerminal: false });
+		const tui = new TUI(term);
+		try {
+			tui.start();
+			await settle(term);
+			await addTranscript(tui, term);
+			term.clearWriteLog();
+			term.resize(36, ROWS);
+			await settle(term);
+			const firstResizeAt = performance.now();
+			const redrawsAfterFirstResize = tui.fullRedraws;
+			await Bun.sleep(850);
+			term.resize(28, ROWS);
+			await settle(term);
+			const secondResizeAt = performance.now();
+			const redrawsAfterSecondResize = tui.fullRedraws;
+			term.clearWriteLog();
+
+			// The first deadline is now past, but the t=850-900ms change must have
+			// re-armed the timer. No settle write may occur at the first deadline.
+			const firstDeadlineProbeDelay = Math.max(0, SETTLE_MS - (performance.now() - firstResizeAt) + 150);
+			await Bun.sleep(firstDeadlineProbeDelay);
+			await term.flush();
+			const beforeExtendedDeadlineWrite = term.getWriteLog().join("");
+			const redrawsBeforeExtendedDeadline = tui.fullRedraws;
+			const elapsedFromFirstResize = performance.now() - firstResizeAt;
+			const elapsedBetweenResizes = secondResizeAt - firstResizeAt;
+
+			const secondDeadlineWait = Math.max(0, SETTLE_MS - (performance.now() - secondResizeAt) + 150);
+			await Bun.sleep(secondDeadlineWait);
+			await term.flush();
+			const afterExtendedDeadlineWrite = term.getWriteLog().join("");
+			const redrawsAfterExtendedDeadline = tui.fullRedraws;
+			finishCase(
+				"TIMING-BOUNDARY",
+				"No settled redraw occurs before about 1000ms, and a width change near t=900ms pushes the single settle deadline out by another 1000ms.",
+				{
+					noEarlySettleAtFirstDeadline: beforeExtendedDeadlineWrite === "",
+					noEarlyRedrawAtFirstDeadline: redrawsBeforeExtendedDeadline === redrawsAfterSecondResize,
+					// The only real precondition: the second change landed inside the
+					// first window. Asserting a tight upper bound here would fail correct
+					// code whenever the CI scheduler pauses between the two resizes.
+					secondChangeInsideFirstWindow: elapsedBetweenResizes < SETTLE_MS,
+					exactlyOneExtendedSettle: redrawsAfterExtendedDeadline - redrawsAfterSecondResize === 1,
+					extendedSettleWritesRepair: afterExtendedDeadlineWrite.includes("\x1b[2J\x1b[H\x1b[3J"),
+				},
+				{
+					firstResizeAt: firstResizeAt.toFixed(1),
+					secondResizeAt: secondResizeAt.toFixed(1),
+					elapsedBetweenResizes: elapsedBetweenResizes.toFixed(1),
+					elapsedFromFirstResizeAtProbe: elapsedFromFirstResize.toFixed(1),
+					redrawsAfterFirstResize,
+					redrawsAfterSecondResize,
+					redrawsBeforeExtendedDeadline,
+					redrawsAfterExtendedDeadline,
+					beforeExtendedDeadlineWriteLength: beforeExtendedDeadlineWrite.length,
+					afterExtendedDeadlineWriteLength: afterExtendedDeadlineWrite.length,
+					beforeExtendedDeadlineWriteExcerpt: writeExcerpt(beforeExtendedDeadlineWrite, 1400),
+					afterExtendedDeadlineWriteExcerpt: writeExcerpt(afterExtendedDeadlineWrite, 1400),
+				},
+			);
+		} finally {
+			tui.stop();
+		}
+	});
+});

--- a/packages/tui/test/resize-width-settle.test.ts
+++ b/packages/tui/test/resize-width-settle.test.ts
@@ -3,10 +3,11 @@ import { Text } from "../src/components/text";
 import { TUI } from "../src/tui";
 import { VirtualTerminal } from "./virtual-terminal";
 
-// Width reflow leaves stale wrapped bands that a differential render cannot
-// repair, so a width change must end in a full redraw. Forcing one per SIGWINCH
-// during a drag-resize is a replay storm, so the redraw is deferred until the
-// width has been stable for 1000ms. Height-only changes keep their behavior.
+// Width reflow can leave stale wrapped bands that the immediate resize frame
+// does not repair. The immediate frame is unchanged; what these tests pin is the
+// trailing repair: exactly one extra forced redraw 1000ms after the last observed
+// width change, no matter how many SIGWINCHes arrived. Height-only changes keep
+// their existing behavior and never arm the timer.
 
 const COLS = 100;
 const SETTLE_MS = 1000;
@@ -66,7 +67,7 @@ describe("debounced full redraw on terminal width change", () => {
 		tui.stop();
 	});
 
-	it("skips the settled redraw when the width returns to its original value", async () => {
+	it("still repairs once when the width returns to its original value", async () => {
 		const term = new VirtualTerminal(COLS, 30);
 		const tui = new TUI(term);
 		tui.start();
@@ -79,12 +80,12 @@ describe("debounced full redraw on terminal width change", () => {
 		const beforeSettle = tui.fullRedraws;
 
 		await Bun.sleep(SETTLE_MS + 200);
-		expect(tui.fullRedraws).toBe(beforeSettle);
+		expect(tui.fullRedraws).toBe(beforeSettle + 1);
 
 		tui.stop();
 	});
 
-	it("cancels a pending settled redraw when the TUI stops", async () => {
+	it("cancels a pending settled redraw when the TUI stops, even if it restarts before the deadline", async () => {
 		const term = new VirtualTerminal(COLS, 30);
 		const tui = new TUI(term);
 		tui.start();
@@ -94,9 +95,58 @@ describe("debounced full redraw on terminal width change", () => {
 		term.resize(COLS - 10, 30);
 		await term.waitForRender();
 		tui.stop();
-		term.clearWriteLog();
+
+		// Restart WELL BEFORE the original deadline. A stopped-guard alone would not
+		// catch a leaked timer here: the TUI is running again when it would fire, so
+		// only real cancellation in stop() keeps the count flat.
+		await Bun.sleep(SETTLE_MS / 4);
+		tui.start();
+		await term.waitForRender();
+		const afterRestart = tui.fullRedraws;
 
 		await Bun.sleep(SETTLE_MS + 200);
-		expect(term.getWriteLog().join("")).toBe("");
+		expect(tui.fullRedraws).toBe(afterRestart);
+
+		tui.stop();
+	});
+
+	it("repairs a coalesced width burst that never commits an intermediate frame", async () => {
+		const term = new VirtualTerminal(COLS, 30);
+		const tui = new TUI(term);
+		tui.start();
+		await term.waitForRender();
+		await buildTranscript(tui, term, 60);
+		const beforeBurst = tui.fullRedraws;
+
+		// No waitForRender between these: #previousWidth stays at COLS for the whole
+		// burst, so a debounce keyed to the committed frame width would never see the
+		// second transition and would skip the only repair.
+		term.resize(COLS - 10, 30);
+		term.resize(COLS, 30);
+		await term.waitForRender();
+
+		await Bun.sleep(SETTLE_MS + 200);
+		expect(tui.fullRedraws).toBeGreaterThan(beforeBurst);
+
+		tui.stop();
+	});
+
+	it("does not arm the timer for a same-width resize event right after start", async () => {
+		const term = new VirtualTerminal(COLS, 30);
+		const tui = new TUI(term);
+		tui.start();
+		await term.waitForRender();
+		await buildTranscript(tui, term, 60);
+		const beforeSpurious = tui.fullRedraws;
+
+		// iTerm2 tab activation and the self-sent SIGWINCH after resume deliver a
+		// resize event with unchanged dimensions.
+		term.resize(COLS, 30);
+		await term.waitForRender();
+
+		await Bun.sleep(SETTLE_MS + 200);
+		expect(tui.fullRedraws).toBe(beforeSpurious);
+
+		tui.stop();
 	});
 });

--- a/packages/tui/test/resize-width-settle.test.ts
+++ b/packages/tui/test/resize-width-settle.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import { Text } from "../src/components/text";
+import { TUI } from "../src/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// Width reflow leaves stale wrapped bands that a differential render cannot
+// repair, so a width change must end in a full redraw. Forcing one per SIGWINCH
+// during a drag-resize is a replay storm, so the redraw is deferred until the
+// width has been stable for 1000ms. Height-only changes keep their behavior.
+
+const COLS = 100;
+const SETTLE_MS = 1000;
+
+async function buildTranscript(tui: TUI, term: VirtualTerminal, count: number): Promise<void> {
+	for (let i = 0; i < count; i++) {
+		tui.addChild(new Text(`L${i}:${"x".repeat(20)}`, 1, 0));
+	}
+	tui.requestRender(false, "setup");
+	await term.waitForRender();
+}
+
+function distinctReplayedLineMarkers(out: string): number {
+	return new Set(out.match(/L\d+:/g) ?? []).size;
+}
+
+describe("debounced full redraw on terminal width change", () => {
+	it("emits exactly one extra full redraw after the width settles", async () => {
+		const term = new VirtualTerminal(COLS, 30);
+		const tui = new TUI(term);
+		tui.start();
+		await term.waitForRender();
+		await buildTranscript(tui, term, 60);
+		term.clearWriteLog();
+
+		// Drag-resize storm: several width changes in quick succession.
+		for (let i = 1; i <= 5; i++) {
+			term.resize(COLS - i, 30);
+			await term.waitForRender();
+		}
+		const beforeSettle = tui.fullRedraws;
+
+		await Bun.sleep(SETTLE_MS + 200);
+		// One deferred forced redraw, not one per SIGWINCH.
+		expect(tui.fullRedraws).toBe(beforeSettle + 1);
+		const out = term.getWriteLog().join("");
+		expect(distinctReplayedLineMarkers(out)).toBeGreaterThanOrEqual(55);
+
+		tui.stop();
+	});
+
+	it("does not schedule a settled redraw for a height-only change", async () => {
+		const term = new VirtualTerminal(COLS, 30);
+		const tui = new TUI(term);
+		tui.start();
+		await term.waitForRender();
+		await buildTranscript(tui, term, 60);
+
+		term.resize(COLS, 24);
+		await term.waitForRender();
+		// The height change itself still renders through the existing path.
+		term.clearWriteLog();
+
+		await Bun.sleep(SETTLE_MS + 200);
+		expect(term.getWriteLog().join("")).toBe("");
+
+		tui.stop();
+	});
+
+	it("skips the settled redraw when the width returns to its original value", async () => {
+		const term = new VirtualTerminal(COLS, 30);
+		const tui = new TUI(term);
+		tui.start();
+		await term.waitForRender();
+		await buildTranscript(tui, term, 60);
+		term.resize(COLS - 10, 30);
+		await term.waitForRender();
+		term.resize(COLS, 30);
+		await term.waitForRender();
+		const beforeSettle = tui.fullRedraws;
+
+		await Bun.sleep(SETTLE_MS + 200);
+		expect(tui.fullRedraws).toBe(beforeSettle);
+
+		tui.stop();
+	});
+
+	it("cancels a pending settled redraw when the TUI stops", async () => {
+		const term = new VirtualTerminal(COLS, 30);
+		const tui = new TUI(term);
+		tui.start();
+		await term.waitForRender();
+		await buildTranscript(tui, term, 60);
+
+		term.resize(COLS - 10, 30);
+		await term.waitForRender();
+		tui.stop();
+		term.clearWriteLog();
+
+		await Bun.sleep(SETTLE_MS + 200);
+		expect(term.getWriteLog().join("")).toBe("");
+	});
+});


### PR DESCRIPTION
## Motivation

Width reflow leaves stale wrapped bands on screen. Lines wrapped at the old column count survive differential rendering because their *content* is unchanged — only their wrapping is wrong — so the diff has nothing to write and the artifact persists until something forces a repaint.

Only a forced redraw repairs it. But forcing one per `SIGWINCH` during a drag-resize is exactly the replay storm that `test/resize-replay-storm.test.ts` exists to prevent.

## Design

Width changes arm a **1000ms trailing debounce**; one forced redraw commits after the width stops changing.

- `requestResizeRender()` splits width from height. Height-only changes keep their previous behavior byte-for-byte — they reflow nothing.
- The debounce is keyed to `#lastObservedWidth`, the last **observed** resize event, deliberately *not* the committed frame width `#previousWidth`. Those diverge whenever resize events coalesce inside one frame budget: a `100→90→100` burst leaves `#previousWidth` at 100 throughout, so a commit-keyed debounce would never see the second transition and would skip the only repair.
- Every observed width sequence gets exactly one repair, **including one that ends back at its starting width**. Skipping the drag-and-return case would require proving a frame committed at the final geometry *after* the final resize event, which the render pipeline does not guarantee. One extra repaint beats a missed repair.
- `start()` seeds `#lastObservedWidth` so a spurious same-size resize event (iTerm2 tab activation, the self-sent `SIGWINCH` after resume) is not read as a reflow. `stop()` cancels a pending timer.

### Scope of the repair

The interim frame is **unchanged** — `#doRender` still promotes a real width change to `fullRender`/`viewportRepaint` immediately. What this adds is only the extra trailing forced redraw.

On viewport-repaint hosts (tmux/screen/zellij, Windows Terminal, process terminals) that repair covers the **live viewport**. Rows that already scrolled off keep their old-width wrapping — reconstructing them is precisely the replay storm the regression suite pins against. This is a deliberate tradeoff, asserted explicitly in the red-team suite.

## Rejected alternative

Routing interim width frames through `viewportRepaint()` on *all* hosts (adding `|| this.#widthSettleTimer !== undefined` to the `widthChanged` branch guard) was implemented and reverted. It broke:

- `test/render-goldens.test.ts` — the `layout-resize-rich-text` golden gained 32 spurious lines
- `test/render-regressions.test.ts` — the mixed width/height resize storm scrollback bound blew out to 972 lines against a `<120` budget

## Tests

`test/resize-width-settle.test.ts` pins the contract:

| case | asserts |
|---|---|
| settle-once | a 5-event storm produces exactly **one** extra redraw, not one per SIGWINCH |
| height-only | a height storm arms nothing and writes nothing after the window |
| width-return | a drag that ends where it started still gets its one repair |
| restart-before-deadline | `stop()` truly cancels — the TUI is restarted *before* the original deadline, so a leaked timer cannot hide behind the stopped-guard |
| coalesced burst | `100→90→100` with no render between still repairs (pins `#lastObservedWidth` against `#previousWidth`) |
| start seed | a same-width event right after `start()` arms nothing |

`test/resize-width-settle-redteam.test.ts` adds an adversarial suite: default-host stale-band repair verified against a clean target-width render, the tmux/viewport-repaint scope boundary, stop/start, an interleaved unrelated forced render, rapid oscillation (ends-same and ends-different), height-only byte-identical parity against a subclass modelling the pre-change path, and the debounce boundary.

```
bun test  →  895 pass, 6 skip, 0 fail  (75 files)
biome check  →  OK
tsc --noEmit  →  exit 0
```

## Review trail

Two independent review rounds gated this. Round 1 returned `REQUEST CHANGES` on a real defect — the debounce was keyed to the committed frame width, which could skip the only repair under coalesced events or fire early near expiry. A cleanup sweep separately caught doc comments that misdescribed the interim path, a test-authored evidence artifact with fabricated pass counts, a `stop()` test that passed even with a leaked timer, and unrestored env vars. All are fixed in `679ad05de`.
