### PR TITLE
fix(test): wrap an over-long assertion to satisfy the formatter

### DIFF
--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -662,7 +662,9 @@ Project executor override body.
 		expect(ultragoal).toContain("not rubber-stamp its earlier verdict");
 
 		// Fallback routing mirrors the existing subagent resume outcomes.
-		expect(ultragoal).toContain("`context_unavailable`, `not_found`, `no_runner`, or `resume_failed` → fresh spawn fallback");
+		expect(ultragoal).toContain(
+			"`context_unavailable`, `not_found`, `no_runner`, or `resume_failed` → fresh spawn fallback",
+		);
 
 		// Terminal critic resumption on iteration.
 		expect(ultragoal).toContain("resume the prior terminal-critic subagent when resumable");


### PR DESCRIPTION
PR #3359 landed an assertion line in `packages/coding-agent/test/default-gjc-definitions.test.ts` that exceeds the formatter's line width.

This breaks `Affected path validation / check:@gajae-code/coding-agent` on `dev` HEAD and, by inheritance, on every PR rebased onto it — currently blocking #3351 and #3352 among others.

Reproduced locally with `biome check`; this is the exact `--write` output (a single line wrapped, no semantic change).