### PR TITLE
fix(read): scan directional windows for merge conflicts

### DIFF
--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -3063,6 +3063,41 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 								}
 							}
 						}
+						if (!partialTailWarning) {
+							const conflictBlocks = windowSegments(window).flatMap(segment =>
+								segment.kind === "lines"
+									? scanConflictLines(linesOfSegment(segment), segment.origin.startLine)
+									: [],
+							);
+							if (conflictBlocks.length > 0) {
+								const history = getConflictHistory(this.session);
+								const displayPathForWarning = formatPathRelativeToCwd(absolutePath, this.session.cwd);
+								const entries = conflictBlocks.map(block =>
+									history.register({
+										absolutePath,
+										displayPath: displayPathForWarning,
+										...block,
+									}),
+								);
+								// Cheap full-file scan only when the window already showed
+								// at least one conflict — otherwise pay nothing on clean files.
+								let totalInFile = entries.length;
+								let scanTruncated = false;
+								try {
+									const fileScan = await scanFileForConflicts(absolutePath);
+									totalInFile = Math.max(entries.length, fileScan.blocks.length);
+									scanTruncated = fileScan.scanTruncated;
+								} catch {
+									// Best-effort enrichment; fall back to window-only count.
+								}
+								outputText += formatConflictWarning(entries, {
+									totalInFile,
+									displayPath: displayPathForWarning,
+									scanTruncated,
+								});
+								details.conflictCount = entries.length;
+							}
+						}
 						sourcePath = absolutePath;
 						content = [{ type: "text", text: outputText }];
 					} else {


### PR DESCRIPTION
## Problem
Dev CI shards 1-2 fail on `conflict-integration.test.ts` (18 tests): reads of conflicted files no longer append the conflict warning footer or register `conflict://` ids.

## Cause
#3348 made bare reads default to tail truncation, routing them through the directional-window branch in `read.ts`, which returns before the conflict-scan block that only exists on the legacy head path.

## Fix
Run `scanConflictLines` over each `lines` segment of the rendered window (head+tail), preserving original file line numbers, with the same best-effort full-file enrichment. Partial-tail (oversized line) windows are skipped as before.

## Verification
- `bun test conflict-integration conflict-detect write-acp-fs read-acp-fs` → 84 pass, 0 fail (was 18 fail on dev)
- biome + tsc clean